### PR TITLE
Bundle portable SRFIs in release and install script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,12 +133,16 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Bundle portable libraries
+        run: tar czf kaappi-lib.tar.gz lib/srfi/ lib/chibi/ lib/scheme/ LICENSE
+
       - name: Collect binaries, generate checksums, and sign
         run: |
           mkdir -p release
           find artifacts -type f \( -name 'kaappi-*' -o -name 'kaappi.wasm' -o -name 'thottam-*' \) -exec cp {} release/ \;
+          cp kaappi-lib.tar.gz release/
           cd release
-          sha256sum kaappi-* kaappi.wasm thottam-* > SHA256SUMS
+          sha256sum kaappi-* kaappi.wasm thottam-* kaappi-lib.tar.gz > SHA256SUMS
           echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --detach-sign --armor SHA256SUMS
 
       - name: Extract changelog for this version

--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,7 @@ main() {
 
     curl -fsSL -o "$tmpdir/kaappi" "$base_url/$kaappi_artifact"
     curl -fsSL -o "$tmpdir/thottam" "$base_url/$thottam_artifact"
+    curl -fsSL -o "$tmpdir/kaappi-lib.tar.gz" "$base_url/kaappi-lib.tar.gz"
     curl -fsSL -o "$tmpdir/SHA256SUMS" "$base_url/SHA256SUMS"
 
     echo "Verifying checksums..."
@@ -80,6 +81,7 @@ main() {
     # SHA256SUMS references artifact names; remap to local filenames for verification
     grep "$kaappi_artifact" SHA256SUMS | sed "s|$kaappi_artifact|kaappi|" > check.txt
     grep "$thottam_artifact" SHA256SUMS | sed "s|$thottam_artifact|thottam|" >> check.txt
+    grep "kaappi-lib.tar.gz" SHA256SUMS >> check.txt
     if command -v sha256sum >/dev/null 2>&1; then
         sha256sum -c --quiet check.txt
     elif command -v shasum >/dev/null 2>&1; then
@@ -94,8 +96,15 @@ main() {
     mv "$tmpdir/thottam" "$INSTALL_DIR/thottam"
     chmod +x "$INSTALL_DIR/kaappi" "$INSTALL_DIR/thottam"
 
+    echo "Installing standard libraries to ~/.kaappi/lib/..."
+    mkdir -p "$HOME/.kaappi/lib" "$tmpdir/libextract"
+    tar xzf "$tmpdir/kaappi-lib.tar.gz" -C "$tmpdir/libextract"
+    cp -r "$tmpdir/libextract/lib/"* "$HOME/.kaappi/lib/"
+    cp "$tmpdir/libextract/LICENSE" "$HOME/.kaappi/lib/"
+
     echo
-    echo "Installed kaappi $tag and thottam to $INSTALL_DIR/"
+    echo "Installed kaappi $tag to $INSTALL_DIR/"
+    echo "Standard libraries installed to ~/.kaappi/lib/"
 
     if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
         echo

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -97,13 +97,17 @@ fn processImportSet(vm: *VM, target: *std.StringHashMap(Value), import_set: Valu
 
     // Not found in registry — try loading from .sld file
     tryLoadLibraryFromFile(vm, import_set) catch {
-        vm.setErrorDetail("library not found: ({s})", .{lib_name});
+        if (vm.last_error_detail_len == 0) {
+            vm.setErrorDetail("library not found: ({s})", .{lib_name});
+        }
         return error.UndefinedVariable;
     };
 
     // Now try again
     const lib = vm.libraries.get(lib_name) orelse {
-        vm.setErrorDetail("library not found: ({s})", .{lib_name});
+        if (vm.last_error_detail_len == 0) {
+            vm.setErrorDetail("library not found: ({s})", .{lib_name});
+        }
         return error.UndefinedVariable;
     };
     var it = lib.exports.iterator();
@@ -166,7 +170,7 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
         const expr = rdr.readDatum() catch return error.InvalidSyntax;
 
         if (vm.handleTopLevelForm(expr)) |result| {
-            _ = result catch return error.OutOfMemory;
+            _ = result catch |err| return err;
         } else {
             const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, &vm.globals) catch return error.InvalidSyntax;
             var func_val = types.makePointer(@ptrCast(func));

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -121,6 +121,17 @@ assert_output_contains "library not found names the library" \
 assert_output_contains "library not found includes library name" \
     '(import (nonexistent library))' "nonexistent.library"
 
+# Missing dependency reports the actual missing library, not the top-level one
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+dep_output=$("$KAAPPI" --lib-path "$SCRIPT_DIR/fixtures" "$SCRIPT_DIR/fixtures/missing-dep.scm" 2>&1 || true)
+if echo "$dep_output" | grep -qF "srfi.999"; then
+    echo "PASS: missing dependency names the dependency"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: missing dependency names the dependency — expected 'srfi.999' in output"
+    FAIL=$((FAIL + 1))
+fi
+
 # --- Closure arity errors ---
 echo
 echo "-- Closure arity errors --"

--- a/tests/scheme/errors/fixtures/badlib/dep.sld
+++ b/tests/scheme/errors/fixtures/badlib/dep.sld
@@ -1,0 +1,4 @@
+(define-library (badlib dep)
+  (import (scheme base) (srfi 999))
+  (export dummy)
+  (begin (define (dummy) #t)))

--- a/tests/scheme/errors/fixtures/missing-dep.scm
+++ b/tests/scheme/errors/fixtures/missing-dep.scm
@@ -1,0 +1,1 @@
+(import (badlib dep))


### PR DESCRIPTION
## Summary

Fixes #1

- **Release workflow**: bundle `lib/srfi/`, `lib/chibi/`, `lib/scheme/`, and `LICENSE` into `kaappi-lib.tar.gz` as a release asset, included in SHA256SUMS
- **Install script**: download, verify, and extract the library archive to `~/.kaappi/lib/`
- **Error reporting**: preserve inner error detail when a library's dependency import fails — e.g. report "library not found: (srfi.999)" instead of blaming the top-level library
- **Regression test**: verify missing dependency errors name the actual missing library

## Test plan

- [x] `zig build` succeeds
- [x] `zig build test` passes (exit 0)
- [x] `bash tests/scheme/errors/error-format.sh` — 21/21 pass including new regression test
- [x] Local `tar czf` produces correct archive structure (lib/srfi/*.sld + LICENSE)
- [ ] After merge + release: verify `kaappi-lib.tar.gz` appears in release assets
- [ ] After merge: update `install.sh` copies in `kaappi.github.io/` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)