### PR TITLE
Fix SRFI-1 GC rooting bugs in list-building primitives

### DIFF
--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -1214,6 +1214,8 @@ fn circularListFn(args: []const Value) PrimitiveError!Value {
     var first: Value = undefined;
     var last_pair: Value = undefined;
     first = gc.allocPair(args[0], types.NIL) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&first) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     last_pair = first;
     for (args[1..]) |a| {
         const new_pair = gc.allocPair(a, types.NIL) catch return PrimitiveError.OutOfMemory;
@@ -1722,6 +1724,8 @@ fn lsetAdjoinFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var result = args[1];
+    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     for (args[2..]) |elt| {
         if (!try memberByPred(pred, elt, result)) {
@@ -1739,6 +1743,8 @@ fn lsetUnionFn(args: []const Value) PrimitiveError!Value {
     if (list_count == 0) return types.NIL;
 
     var result = args[1];
+    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     for (args[2..]) |lst| {
         var current = lst;
@@ -1763,6 +1769,8 @@ fn lsetXorFn(args: []const Value) PrimitiveError!Value {
     if (list_count == 1) return args[1];
 
     var result = args[1];
+    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     for (args[2..]) |lst| {
         // XOR of result and lst:
@@ -1884,6 +1892,8 @@ fn appendReverseFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
     var result = args[1];
+    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     while (current != types.NIL) {
         if (!types.isPair(current)) return primitives.typeError("append-reverse", "pair", current);
         result = gc.allocPair(types.car(current), result) catch return PrimitiveError.OutOfMemory;

--- a/tests/scheme/srfi/srfi1-gc-stress.scm
+++ b/tests/scheme/srfi/srfi1-gc-stress.scm
@@ -1,0 +1,58 @@
+(import (scheme base) (scheme write) (srfi 1))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; Build large argument lists for stress testing.
+;; With a low gc-threshold these force GC mid-construction.
+
+;; circular-list: build a 200-element circular list and verify wrapping
+(let ((cl (apply circular-list (list-tabulate 200 values))))
+  (check "circular-list wraps"
+    (list-ref cl 200)   ; element 200 == element 0
+    0)
+  (check "circular-list wraps+1"
+    (list-ref cl 201)
+    1)
+  (check "circular-list last before wrap"
+    (list-ref cl 199)
+    199))
+
+;; append-reverse: reverse a 500-element list onto a tail
+(let ((result (append-reverse (list-tabulate 500 values) '(done))))
+  (check "append-reverse length" (length result) 501)
+  (check "append-reverse first" (car result) 499)
+  (check "append-reverse last" (list-ref result 500) 'done))
+
+;; lset-adjoin: adjoin 200 elements into a base set
+(let ((base (list 0 1 2))
+      (elts (list-tabulate 200 values)))
+  (let ((result (apply lset-adjoin = base elts)))
+    (check "lset-adjoin covers all"
+      (length result) 200)))
+
+;; lset-union: union of several 100-element lists with overlaps
+(let ((a (list-tabulate 100 values))
+      (b (list-tabulate 100 (lambda (i) (+ i 50))))
+      (c (list-tabulate 100 (lambda (i) (+ i 100)))))
+  (let ((result (lset-union = a b c)))
+    (check "lset-union no duplicates"
+      (length result) 200)))
+
+;; lset-xor: symmetric difference of two 100-element lists
+(let ((a (list-tabulate 100 values))
+      (b (list-tabulate 100 (lambda (i) (+ i 50)))))
+  (let ((result (lset-xor = a b)))
+    ;; a has 0..99, b has 50..149
+    ;; xor = {0..49} union {100..149} = 100 elements
+    (check "lset-xor size" (length result) 100)))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "SRFI-1 GC stress tests failed" fail))


### PR DESCRIPTION
## Summary

- Root accumulators across allocation loops in `circular-list`, `lset-adjoin`, `lset-union`, `lset-xor`, and `append-reverse` in `src/primitives_srfi1.zig`
- Without rooting, GC triggered by `allocPair` mid-construction can sweep the partially-built spine, causing use-after-free / heap corruption
- Add GC stress regression tests exercising all 5 fixed functions with large inputs

Fixes #8

## Details

The reported issue was `circular-list` only (issue #8), but auditing the file revealed 4 additional functions with the same unrooted-accumulator pattern: `lsetAdjoinFn`, `lsetUnionFn`, `lsetXorFn`, and `appendReverseFn`. All 5 now use the standard `pushRoot`/`defer popRoot` pattern before their allocation loops.

## Test plan

- [x] New `tests/scheme/srfi/srfi1-gc-stress.scm` with 9 assertions covering all 5 functions
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 64 Scheme test files pass (1457 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)