### PR TITLE
Fix GC rooting in concatenate, cons*, and unfold list builders

### DIFF
--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -687,6 +687,8 @@ fn concatenateFn(args: []const Value) PrimitiveError!Value {
 
     // Append them all: result starts as last sublist, then prepend in reverse
     var result = sublists.items[sublists.items.len - 1];
+    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     var idx = sublists.items.len - 1;
     while (idx > 0) {
         idx -= 1;
@@ -1170,6 +1172,8 @@ fn consStarFn(args: []const Value) PrimitiveError!Value {
     if (args.len == 0) return PrimitiveError.ArityMismatch;
     if (args.len == 1) return args[0];
     var result = args[args.len - 1];
+    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     var i = args.len - 1;
     while (i > 0) {
         i -= 1;
@@ -1848,6 +1852,8 @@ fn unfoldFn(args: []const Value) PrimitiveError!Value {
     } else {
         result = types.NIL;
     }
+    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     var i = elems.items.len;
     while (i > 0) {

--- a/tests/scheme/srfi/srfi1-gc-stress.scm
+++ b/tests/scheme/srfi/srfi1-gc-stress.scm
@@ -53,6 +53,29 @@
     ;; xor = {0..49} union {100..149} = 100 elements
     (check "lset-xor size" (length result) 100)))
 
+;; concatenate: flatten 50 ten-element sublists
+(let ((sublists (list-tabulate 50 (lambda (i)
+                  (list-tabulate 10 (lambda (j) (+ (* i 10) j)))))))
+  (let ((result (concatenate sublists)))
+    (check "concatenate length" (length result) 500)
+    (check "concatenate first" (car result) 0)
+    (check "concatenate last" (list-ref result 499) 499)))
+
+;; cons*: build a long dotted spine
+(let ((result (apply cons* (list-tabulate 300 values))))
+  (check "cons* first" (car result) 0)
+  (check "cons* second" (cadr result) 1)
+  (check "cons* tail" (list-ref result 298) 298))
+
+;; unfold: generate a 500-element list
+(let ((result (unfold (lambda (i) (= i 500))
+                      values
+                      (lambda (i) (+ i 1))
+                      0)))
+  (check "unfold length" (length result) 500)
+  (check "unfold first" (car result) 0)
+  (check "unfold last" (list-ref result 499) 499))
+
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "SRFI-1 GC stress tests failed" fail))


### PR DESCRIPTION
## Summary

- Root result accumulators in `concatenateFn`, `consStarFn`, and `unfoldFn` in `src/primitives_srfi1.zig`
- Same class of bug as #8 / PR #22 — unrooted accumulator across `allocPair` loop allows GC to sweep the partially-built list spine
- `appendReverseFn` was already fixed in PR #22

Fixes #10

## Test plan

- [x] Extended `tests/scheme/srfi/srfi1-gc-stress.scm` with 6 new assertions covering `concatenate` (500 elements from 50 sublists), `cons*` (300 elements), and `unfold` (500 elements)
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 64 Scheme test files pass (1457 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)