### PR TITLE
Fix aarch64 JIT pair? branch offset with patch-based approach

### DIFF
--- a/src/jit_compile_aarch64.zig
+++ b/src/jit_compile_aarch64.zig
@@ -798,8 +798,9 @@ fn emitSpecializedPredicate(asm_ctx: *a64.Assembler, base_reg: u8, spec: Special
             try asm_ctx.emitMovz(.x2, 0xFFFC, 0);
             try asm_ctx.emitLoadImm64(.x4, types.FALSE);
             try asm_ctx.emitCmpReg(.x1, .x2);
-            // Not a pointer → store #f
-            try asm_ctx.emit(a64.Assembler.bCond(.ne, 7)); // skip to store #f
+            // Not a pointer → skip to store result
+            const not_ptr_br = asm_ctx.pos();
+            try asm_ctx.emit(0); // placeholder, patched below
             // Extract raw pointer and check object tag
             try asm_ctx.emit(ubfx48(.x1, .x0));
             try asm_ctx.emitLdrbImm(.x1, .x1, @intCast(OFF_OBJECT_TAG));
@@ -808,6 +809,9 @@ fn emitSpecializedPredicate(asm_ctx: *a64.Assembler, base_reg: u8, spec: Special
             try asm_ctx.emitCmpImm(.x1, @intFromEnum(types.ObjectTag.pair));
             try asm_ctx.emitLoadImm64(.x5, types.TRUE);
             try asm_ctx.emitCsel(.x4, .x5, .x4, .eq);
+            const store_pos = asm_ctx.pos();
+            const br_off: i32 = @as(i32, @intCast(store_pos)) - @as(i32, @intCast(not_ptr_br));
+            asm_ctx.patchAt(not_ptr_br, a64.Assembler.bCond(.ne, @intCast(br_off)));
             try asm_ctx.emitStrImm(.x4, FRAME_PTR, dst_off);
         },
         .not_op => {

--- a/tests/scheme/smoke/jit-pair-predicate.scm
+++ b/tests/scheme/smoke/jit-pair-predicate.scm
@@ -1,0 +1,45 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+(define (is-pair? x) (pair? x))
+
+;; Warm up to trigger JIT compilation (threshold = 100)
+(let loop ((i 0))
+  (when (< i 200)
+    (is-pair? (cons 1 2))
+    (is-pair? 42)
+    (is-pair? '())
+    (is-pair? #t)
+    (is-pair? #\a)
+    (loop (+ i 1))))
+
+;; Test all value types through JIT-compiled pair?
+(check "pair? cons" #t (is-pair? (cons 1 2)))
+(check "pair? list" #t (is-pair? '(1 2 3)))
+(check "pair? nested" #t (is-pair? '((a) b)))
+
+;; Non-pointer immediates (exercise the branch path)
+(check "pair? fixnum" #f (is-pair? 42))
+(check "pair? zero" #f (is-pair? 0))
+(check "pair? negative" #f (is-pair? -1))
+(check "pair? nil" #f (is-pair? '()))
+(check "pair? true" #f (is-pair? #t))
+(check "pair? false" #f (is-pair? #f))
+(check "pair? char" #f (is-pair? #\x))
+
+;; Pointer types that are not pairs
+(check "pair? string" #f (is-pair? "hello"))
+(check "pair? vector" #f (is-pair? #(1 2 3)))
+(check "pair? symbol" #f (is-pair? 'foo))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "JIT pair? predicate tests failed" fail))


### PR DESCRIPTION
## Summary

- Replace hardcoded `bCond(.ne, 7)` with placeholder+patch in the aarch64 JIT's `pair?` predicate (`src/jit_compile_aarch64.zig`)
- The offset was 7 but should have been 9 — `emitLoadImm64` for `types.TRUE` expands to 2 instructions (MOVZ+MOVK), not 1
- Currently masked (result accidentally correct due to stale condition flags), but incorrect by construction
- The x86_64 JIT already uses the patch-based approach for the same code path

Fixes #11

## Details

The branch was landing on the MOVK instruction (word 7) instead of the target `emitStrImm` (word 9). The stray MOVK corrupted x5, but `csel` selected x4 (FALSE) anyway because the `.eq` flag was false on the not-a-pointer path. Any change to constant encodings or register choices would have turned this into a real miscompile.

Replaced with `pos()`/`patchAt()` pattern which computes the offset dynamically, matching both the x86_64 pair? implementation and the canonical forward-branch pattern used throughout the aarch64 JIT.

## Test plan

- [x] New `tests/scheme/smoke/jit-pair-predicate.scm` — 13 assertions testing `pair?` through JIT on all value types (pairs, fixnums, nil, booleans, characters, strings, vectors, symbols)
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 65 Scheme test files pass (1458 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)