### PR TITLE
Fix JIT miscompilation of box_local/get_box_local/set_box_local

### DIFF
--- a/src/jit_compile_aarch64.zig
+++ b/src/jit_compile_aarch64.zig
@@ -323,25 +323,8 @@ pub fn compile(func: *types.Function, vm: *VM, allocator: std.mem.Allocator) !*J
                 ip += 3;
                 try emitSetGlobal(&asm_ctx, src, sym_idx, &pending_exits, allocator, ip - 4);
             },
-            .box_local => {
-                const reg = code[ip];
-                ip += 1;
-                // box_local is a no-op in our register VM — values are already in registers
-                // The box concept exists for closure capture; here just skip
-                _ = reg;
-            },
-            .get_box_local => {
-                const dst = code[ip];
-                const src = code[ip + 1];
-                ip += 2;
-                try emitRegCopy(&asm_ctx, dst, src);
-            },
-            .set_box_local => {
-                const dst = code[ip];
-                const src = code[ip + 1];
-                ip += 2;
-                try emitRegCopy(&asm_ctx, dst, src);
-            },
+            // box_local, get_box_local, set_box_local: side-exit to interpreter
+            // (handled by the else case below)
             .self_tail_call => {
                 const base_reg = code[ip];
                 const stc_nargs = code[ip + 1];

--- a/src/jit_compile_x86_64.zig
+++ b/src/jit_compile_x86_64.zig
@@ -211,18 +211,15 @@ pub fn compile(func: *types.Function, vm: *VM, allocator: std.mem.Allocator) !*J
                 }
                 try cachedStore(&asm_ctx, &cache, dst, .rax);
             },
-            .move, .get_local, .set_local, .get_box_local, .set_box_local => {
+            .move, .get_local, .set_local => {
                 const dst = code[ip];
                 const src = code[ip + 1];
                 ip += 2;
                 try cachedLoad(&asm_ctx, &cache, .rax, src);
                 try cachedStore(&asm_ctx, &cache, dst, .rax);
             },
-            .box_local => {
-                const reg = code[ip];
-                ip += 1;
-                cache.invalidateSlot(reg);
-            },
+            // box_local, get_box_local, set_box_local: side-exit to interpreter
+            // (handled by the else case below)
             .@"return" => {
                 const src = code[ip];
                 ip += 1;
@@ -433,6 +430,8 @@ pub fn compile(func: *types.Function, vm: *VM, allocator: std.mem.Allocator) !*J
             else => {
                 // Side-exit for unhandled opcodes
                 const operand_bytes: usize = switch (op) {
+                    .box_local => 1,
+                    .get_box_local, .set_box_local => 2,
                     else => 0,
                 };
                 const side_exit_ip = ip - 1;

--- a/tests/scheme/smoke/jit-box-local.scm
+++ b/tests/scheme/smoke/jit-box-local.scm
@@ -1,0 +1,43 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; Mutable captured local: set! forces boxing of n
+(define (run)
+  (let ((n 0))
+    (let ((getter (lambda () n)))
+      (set! n (+ n 1))
+      (+ n (getter)))))
+
+;; Call 200+ times to trigger JIT compilation (threshold = 100)
+(let loop ((i 0) (acc 0))
+  (if (< i 200)
+      (loop (+ i 1) (+ acc (run)))
+      (check "box_local accumulator" acc 400)))
+
+;; Verify individual call after JIT compilation
+(check "box_local single call" (run) 2)
+
+;; Mutable captured local with multiple set!
+(define (run2)
+  (let ((x 10))
+    (let ((get (lambda () x))
+          (set (lambda (v) (set! x v))))
+      (set 42)
+      (+ x (get)))))
+
+(let loop ((i 0))
+  (when (< i 200) (run2) (loop (+ i 1))))
+
+(check "box_local multi-set!" (run2) 84)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "JIT box_local tests failed" fail))


### PR DESCRIPTION
## Summary

- Make `box_local`, `get_box_local`, and `set_box_local` side-exit to the interpreter in both JIT backends
- Previously compiled as plain register copies/no-ops, causing boxed pairs to leak into arithmetic and other operations
- Functions with mutable captured locals (`set!` on a closure-shared variable) produced wrong results or type errors when JIT-compiled

Fixes #15

## Details

The VM implements real boxing: `box_local` heap-allocates a pair, `get_box_local` reads its car, `set_box_local` mutates its car. Both JIT backends instead treated these as plain copies, so the raw box pair leaked into subsequent operations.

The fix removes the incorrect compilation and lets these opcodes fall through to the side-exit path. The aarch64 `else` case already had the correct operand sizes; the x86_64 `else` case is extended with them.

## Test plan

- [x] New `tests/scheme/smoke/jit-box-local.scm` — 3 assertions testing mutable captured locals through JIT (the exact repro from the issue, plus multi-set! variant)
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 66 Scheme test files pass (1459 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)