### PR TITLE
Shrink x86_64 JIT register cache to avoid r10/r11 scratch conflict

### DIFF
--- a/src/jit.zig
+++ b/src/jit.zig
@@ -77,13 +77,13 @@ pub const PendingBranch = struct {
 
 const CacheEntry = struct { slot: u8, dirty: bool };
 const CacheSnapshot = struct {
-    entries: [4]?CacheEntry = .{null} ** 4,
+    entries: [2]?CacheEntry = .{null} ** 2,
 };
-pub const CACHE_REGS: [4]x64.Reg = .{ .r8, .r9, .r10, .r11 };
+pub const CACHE_REGS: [2]x64.Reg = .{ .r8, .r9 };
 
 pub const RegCache = struct {
-    entries: [4]?CacheEntry = .{null} ** 4,
-    next_evict: u2 = 0,
+    entries: [2]?CacheEntry = .{null} ** 2,
+    next_evict: u1 = 0,
 
     pub fn find(self: *const RegCache, slot: u8) ?usize {
         for (self.entries, 0..) |entry_opt, i| {
@@ -126,7 +126,7 @@ pub const RegCache = struct {
 
     pub fn invalidateAll(self: *RegCache, asm_ctx: *x64.Assembler) !void {
         try self.flushAll(asm_ctx);
-        self.entries = .{null} ** 4;
+        self.entries = .{null} ** 2;
     }
 
     pub fn invalidateSlot(self: *RegCache, slot: u8) void {


### PR DESCRIPTION
## Summary

- Shrink `CACHE_REGS` from `{r8, r9, r10, r11}` to `{r8, r9}` in `src/jit.zig`
- The specialized arithmetic/predicate helpers (`x64EmitFixnumGuard`, `x64EmitTagFixnum`, `x64EmitI48OverflowCheck`, `x64EmitPointerGuard`, `x64EmitPairGuard`) use r10/r11 as scratch without spilling the cache
- With 4 cache slots, live VM values in r10/r11 get corrupted, then the stale cache metadata spills garbage back into `vm.registers[]` on side-exit or flush

Fixes #14

## Details

When >=3 VM registers were simultaneously cached, slots 2 (r10) and 3 (r11) could hold live values. The guard helpers then overwrote these registers as scratch, and:
1. Side-exit code spilled the corrupted values back to the VM register file
2. Fall-through code continued with garbage in cache-tracked registers

Shrinking to 2 cache slots is the minimal safe fix — the cache still accelerates the most common patterns (2-operand operations), and there's no overlap with scratch registers. A fuller fix could use dedicated non-conflicting scratch registers, but that's a larger refactor.

## Test plan

- [x] All 374 Zig unit tests pass locally (aarch64, 373 pass, 1 skip)
- [x] All 66 Scheme test files pass (1459 assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail
- [x] x86_64 unit tests pass via podman (Rosetta blocks full binary build, CI will validate)
- [ ] CI: native x86_64 validation (Ubuntu ReleaseSafe/ReleaseFast/Debug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)