### PR TITLE
Root return value across dynamic-wind after-thunks

### DIFF
--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -573,7 +573,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
             .@"return" => {
                 const src = readU8(self, frame);
                 const src_idx = try registerIndex(self, frame.base, src);
-                const result = self.registers[src_idx];
+                var result = self.registers[src_idx];
+                self.gc.pushRoot(&result) catch return VMError.OutOfMemory;
+                defer self.gc.popRoot();
                 const return_dst = frame.dst;
                 const frame_wind = frame.saved_wind_count;
                 self.frame_count -= 1;

--- a/tests/scheme/smoke/return-wind-gc.scm
+++ b/tests/scheme/smoke/return-wind-gc.scm
@@ -1,0 +1,62 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; Return a heap-allocated value through a dynamic-wind that allocates
+;; heavily in its after-thunk, pressuring the GC while the return value
+;; is in flight.
+(define (return-through-wind)
+  (call-with-current-continuation
+    (lambda (escape)
+      (dynamic-wind
+        (lambda () #f)
+        (lambda () (escape (list 'a 'b 'c)))
+        (lambda ()
+          ;; Allocate enough to cross the GC threshold
+          (let loop ((i 0))
+            (when (< i 500)
+              (cons i (make-string 10 #\x))
+              (loop (+ i 1)))))))))
+
+(check "return through wind" (return-through-wind) '(a b c))
+
+;; Multiple nested dynamic-winds
+(define (nested-wind-return)
+  (call-with-current-continuation
+    (lambda (escape)
+      (dynamic-wind
+        (lambda () #f)
+        (lambda ()
+          (dynamic-wind
+            (lambda () #f)
+            (lambda () (escape (cons 1 (cons 2 '()))))
+            (lambda ()
+              (let loop ((i 0))
+                (when (< i 200) (cons i '()) (loop (+ i 1)))))))
+        (lambda ()
+          (let loop ((i 0))
+            (when (< i 200) (cons i '()) (loop (+ i 1)))))))))
+
+(check "nested wind return" (nested-wind-return) '(1 2))
+
+;; Simple dynamic-wind with return value (no continuation escape)
+(define (simple-wind-return)
+  (dynamic-wind
+    (lambda () #f)
+    (lambda () (list 1 2 3))
+    (lambda ()
+      (let loop ((i 0))
+        (when (< i 300) (cons i '()) (loop (+ i 1)))))))
+
+(check "simple wind return" (simple-wind-return) '(1 2 3))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "return-wind-gc tests failed" fail))


### PR DESCRIPTION
## Summary

- Root the return value in the `.return` opcode handler (`src/vm_dispatch.zig`) before popping the frame and running dynamic-wind after-thunks
- After `frame_count -= 1`, the callee's register window is no longer scanned by the GC, so the return value (held only in a Zig local) could be swept by a GC triggered from an after-thunk

Fixes #26

## Details

The return value was captured into a plain `const` Zig local, the frame was popped, and then `callThunk` ran after-thunks that could execute arbitrary Scheme (including allocation that triggers GC). Since the GC only marks register windows of live frames (`frames[0..frame_count]`), the return value was unreachable from any root.

Fix: `pushRoot(&result)` immediately after capture, `defer popRoot()` for cleanup.

## Test plan

- [x] New `tests/scheme/smoke/return-wind-gc.scm` — 3 assertions: return through continuation escape with allocating after-thunk, nested dynamic-winds, simple dynamic-wind return
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 67 Scheme test files pass (1460 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)