### PR TITLE
Raise MAX_CODE_BYTES to 4MB and add diagnostic on limit hit

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -12,7 +12,7 @@ const MAGIC = [4]u8{ 'K', 'P', 'B', 'C' };
 const VERSION: u16 = 3;
 const MAX_FUNCTIONS: u32 = 16_384;
 const MAX_TOP_LEVEL_FUNCTIONS: u32 = 4_096;
-const MAX_CODE_BYTES: u32 = 1_048_576;
+const MAX_CODE_BYTES: u32 = 4_194_304;
 const MAX_CONSTANTS_PER_FUNCTION: u32 = 65_535;
 const MAX_SYMBOL_BYTES: u16 = 4_096;
 const MAX_STRING_BYTES: u32 = 1_048_576;
@@ -719,7 +719,14 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
         }
 
         const code_len = r.readU32() catch return null;
-        if (code_len > MAX_CODE_BYTES) return null;
+        if (code_len > MAX_CODE_BYTES) {
+            var buf: [128]u8 = undefined;
+            var w: std.Io.Writer = .fixed(&buf);
+            w.print("error: bytecode too large ({d} bytes, max {d})\n", .{ code_len, MAX_CODE_BYTES }) catch {};
+            const msg = w.buffered();
+            _ = std.posix.system.write(2, msg.ptr, msg.len);
+            return null;
+        }
         const code_bytes = r.readBytes(code_len) catch return null;
         func.code.appendSlice(allocator, code_bytes) catch return BytecodeError.OutOfMemory;
 


### PR DESCRIPTION
## Summary

- Raise `MAX_CODE_BYTES` from 1MB to 4MB in `src/bytecode_file.zig`
- Add a clear diagnostic to stderr when the limit is exceeded

Fixes #33

## Details

The 1MB per-function bytecode limit caused large Scheme libraries (e.g. multi-module compilers like c0c) to fail with a misleading "library not found" error. The deserialization silently returned `null`, which propagated as `InvalidSyntax` → `UndefinedVariable` → "library not found".

Now: the limit is raised 4x, and if it's still exceeded, stderr shows `error: bytecode too large (N bytes, max M)` instead of a silent failure.

## Test plan

- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 67 Scheme test files pass (1460 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)