### PR TITLE
Fix peek-char corrupting multi-byte UTF-8 on file ports

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -388,6 +388,14 @@ fn readOneByte(port: *types.Port) ?u8 {
         port.peek_byte = null;
         return b;
     }
+    // Check peek continuation bytes (from multi-byte peek-char)
+    if (port.peek_extra_len > 0) {
+        const b = port.peek_extra[0];
+        port.peek_extra[0] = port.peek_extra[1];
+        port.peek_extra[1] = port.peek_extra[2];
+        port.peek_extra_len -= 1;
+        return b;
+    }
     // Check read buffer (from prior (read) that buffered excess)
     if (port.read_buf) |rb| {
         if (port.read_buf_len > 0) {
@@ -453,6 +461,15 @@ fn peekCharFn(args: []const Value) PrimitiveError!Value {
                     return types.makeChar(cp);
                 }
             }
+        } else if (port.peek_extra_len > 0) {
+            var utf8_buf: [4]u8 = undefined;
+            utf8_buf[0] = b;
+            const avail: usize = @intCast(port.peek_extra_len);
+            for (0..avail) |i| utf8_buf[i + 1] = port.peek_extra[i];
+            if (avail >= seq_len - 1) {
+                const cp = std.unicode.utf8Decode(utf8_buf[0..seq_len]) catch return types.makeChar(@intCast(b));
+                return types.makeChar(cp);
+            }
         }
         return types.makeChar(@intCast(b));
     }
@@ -467,10 +484,10 @@ fn peekCharFn(args: []const Value) PrimitiveError!Value {
     } else {
         var buf: [4]u8 = undefined;
         const len = std.unicode.utf8Encode(cp, &buf) catch 1;
-        if (len == 1) {
-            port2.peek_byte = buf[0];
-        } else {
-            port2.peek_byte = buf[0];
+        port2.peek_byte = buf[0];
+        if (len > 1) {
+            for (1..len) |i| port2.peek_extra[i - 1] = buf[i];
+            port2.peek_extra_len = @intCast(len - 1);
         }
     }
     return types.makeChar(cp);
@@ -508,7 +525,7 @@ fn readLineFn(args: []const Value) PrimitiveError!Value {
 
 fn charReadyP(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 0, "char-ready?");
-    if (port.peek_byte != null) return types.TRUE;
+    if (port.peek_byte != null or port.peek_extra_len > 0) return types.TRUE;
     // For simplicity, always return #t (non-blocking check not worth the complexity)
     return types.TRUE;
 }
@@ -603,10 +620,16 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
         port.read_buf_len = 0;
     }
 
-    // Consume any peeked byte
+    // Consume any peeked bytes
     if (port.peek_byte) |b| {
         buf.append(gc.allocator, b) catch return PrimitiveError.OutOfMemory;
         port.peek_byte = null;
+    }
+    while (port.peek_extra_len > 0) {
+        buf.append(gc.allocator, port.peek_extra[0]) catch return PrimitiveError.OutOfMemory;
+        port.peek_extra[0] = port.peek_extra[1];
+        port.peek_extra[1] = port.peek_extra[2];
+        port.peek_extra_len -= 1;
     }
 
     // Read from fd (appends after any buffered data)

--- a/src/types.zig
+++ b/src/types.zig
@@ -315,7 +315,9 @@ pub const Port = struct {
     is_open: bool,
     name: []const u8,
     owns_name: bool, // if true, name is heap-allocated and must be freed
-    peek_byte: ?u8, // 1-byte lookahead buffer for peek-char
+    peek_byte: ?u8, // lead byte lookahead for peek-char
+    peek_extra: [3]u8 = .{ 0, 0, 0 }, // UTF-8 continuation bytes from peek-char
+    peek_extra_len: u2 = 0,
     // String port fields:
     is_string_port: bool = false,
     string_data: ?[]const u8 = null, // for input string ports (owned copy)

--- a/tests/scheme/smoke/peek-char-utf8.scm
+++ b/tests/scheme/smoke/peek-char-utf8.scm
@@ -1,0 +1,54 @@
+(import (scheme base) (scheme write) (scheme file))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; Write a file with multi-byte UTF-8 characters, then peek/read them
+(define test-file "/tmp/kaappi-peek-utf8-test.txt")
+
+(let ((p (open-output-file test-file)))
+  (display "λx" p)  ; λ = U+03BB (2 bytes: 0xCE 0xBB), then ASCII x
+  (close-port p))
+
+(let ((p (open-input-file test-file)))
+  (check "peek-char lambda" (peek-char p) #\λ)
+  (check "read-char lambda" (read-char p) #\λ)
+  (check "read-char x" (read-char p) #\x)
+  (check "read-char eof" (read-char p) (eof-object))
+  (close-port p))
+
+;; Test with 3-byte UTF-8 char: ✓ = U+2713 (3 bytes: 0xE2 0x9C 0x93)
+(let ((p (open-output-file test-file)))
+  (display "✓y" p)
+  (close-port p))
+
+(let ((p (open-input-file test-file)))
+  (check "peek-char checkmark" (peek-char p) #\✓)
+  (check "peek-char checkmark again" (peek-char p) #\✓)
+  (check "read-char checkmark" (read-char p) #\✓)
+  (check "read-char y" (read-char p) #\y)
+  (close-port p))
+
+;; Test with 4-byte UTF-8 char: 𝕜 = U+1D55C (4 bytes)
+(let ((p (open-output-file test-file)))
+  (display "𝕜z" p)
+  (close-port p))
+
+(let ((p (open-input-file test-file)))
+  (check "peek-char 4byte" (peek-char p) #\𝕜)
+  (check "read-char 4byte" (read-char p) #\𝕜)
+  (check "read-char z" (read-char p) #\z)
+  (close-port p))
+
+;; Clean up
+(delete-file test-file)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "peek-char UTF-8 tests failed" fail))


### PR DESCRIPTION
## Summary

- Add a 3-byte `peek_extra` buffer to the Port struct for UTF-8 continuation bytes
- `peek-char` on fd-backed ports was consuming the full UTF-8 sequence but only storing the lead byte, discarding continuation bytes and desynchronizing the stream

Fixes #29

## Details

`readUtf8Char` consumed all bytes of a multi-byte character (e.g. 0xCE 0xBB for λ) from the fd, but `peekCharFn` stored only `buf[0]` in the single-byte `peek_byte` field. The next `read-char` re-read the lead byte from `peek_byte`, then read continuation bytes from the *next* character in the fd, producing garbage.

The fix adds `peek_extra: [3]u8` and `peek_extra_len: u2` to the Port struct. `readOneByte` drains `peek_extra` after `peek_byte` (maintaining byte order). `peekCharFn` stores continuation bytes in `peek_extra` for fd ports, and the already-peeked path reconstructs the full codepoint from both buffers.

## Test plan

- [x] New `tests/scheme/smoke/peek-char-utf8.scm` — 11 assertions testing peek/read on file ports with 2-byte (λ), 3-byte (✓), and 4-byte (𝕜) UTF-8 characters, including repeated peek-char
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 68 Scheme test files pass (1461 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)