### PR TITLE
Fix fixnum overflow in gcd, lcm, and rational arithmetic

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -94,8 +94,10 @@ pub fn makeRationalReduced(gc: *@import("memory.zig").GC, num_val: Value, den_va
         const g = gcdTwo(if (n < 0) -n else n, d);
         n = @divExact(n, g);
         d = @divExact(d, g);
-        if (d == 1) return types.makeFixnum(n);
-        return gc.allocRational(types.makeFixnum(n), types.makeFixnum(d)) catch return PrimitiveError.OutOfMemory;
+        if (d == 1) return try makeFixnumChecked(n);
+        const num = try makeFixnumChecked(n);
+        const den = try makeFixnumChecked(d);
+        return gc.allocRational(num, den) catch return PrimitiveError.OutOfMemory;
     }
     // Bignum-containing case: check for zero denominator
     if (bignum_mod.isZero(den_val)) return raiseDivByZero();
@@ -301,12 +303,14 @@ fn add(args: []const Value) PrimitiveError!Value {
                 d = @divExact(d, g);
             }
         }
-        if (d == 1) return types.makeFixnum(n);
+        if (d == 1) return try makeFixnumChecked(n);
         if (d < 0) {
             n = -n;
             d = -d;
         }
-        return gc.allocRational(types.makeFixnum(n), types.makeFixnum(d)) catch return PrimitiveError.OutOfMemory;
+        const num = try makeFixnumChecked(n);
+        const den = try makeFixnumChecked(d);
+        return gc.allocRational(num, den) catch return PrimitiveError.OutOfMemory;
     }
     if (anyBignum(args)) return bignumAddAll(args);
     // Fixnum path with overflow detection
@@ -388,12 +392,14 @@ fn sub(args: []const Value) PrimitiveError!Value {
             }
         }
         if (n == 0) return types.makeFixnum(0);
-        if (d == 1) return types.makeFixnum(n);
+        if (d == 1) return try makeFixnumChecked(n);
         if (d < 0) {
             n = -n;
             d = -d;
         }
-        return gc.allocRational(types.makeFixnum(n), types.makeFixnum(d)) catch return PrimitiveError.OutOfMemory;
+        const num = try makeFixnumChecked(n);
+        const den = try makeFixnumChecked(d);
+        return gc.allocRational(num, den) catch return PrimitiveError.OutOfMemory;
     }
     if (anyBignum(args)) return bignumSubAll(args);
     if (!types.isFixnum(args[0]) and !types.isRationalObj(args[0])) return numberTypeError(args[0]);
@@ -475,8 +481,10 @@ fn mul(args: []const Value) PrimitiveError!Value {
             n = -n;
             d = -d;
         }
-        if (d == 1) return types.makeFixnum(n);
-        return gc.allocRational(types.makeFixnum(n), types.makeFixnum(d)) catch return PrimitiveError.OutOfMemory;
+        if (d == 1) return try makeFixnumChecked(n);
+        const num = try makeFixnumChecked(n);
+        const den = try makeFixnumChecked(d);
+        return gc.allocRational(num, den) catch return PrimitiveError.OutOfMemory;
     }
     if (anyBignum(args)) return bignumMulAll(args);
     var product: i64 = 1;
@@ -565,8 +573,10 @@ fn divFn(args: []const Value) PrimitiveError!Value {
             }
         }
         if (n == 0) return types.makeFixnum(0);
-        if (d == 1) return types.makeFixnum(n);
-        return gc.allocRational(types.makeFixnum(n), types.makeFixnum(d)) catch return PrimitiveError.OutOfMemory;
+        if (d == 1) return try makeFixnumChecked(n);
+        const num = try makeFixnumChecked(n);
+        const den = try makeFixnumChecked(d);
+        return gc.allocRational(num, den) catch return PrimitiveError.OutOfMemory;
     }
     // All exact integers (fixnum or bignum) — try exact division, produce rational if needed
     if (!anyFlonum(args) and !anyBignum(args) and !anyRational(args)) {
@@ -1061,7 +1071,7 @@ fn gcdFn(args: []const Value) PrimitiveError!Value {
         if (!types.isFixnum(a)) return PrimitiveError.TypeError;
         result = gcdTwo(result, types.toFixnum(a));
     }
-    return types.makeFixnum(result);
+    return try makeFixnumChecked(result);
 }
 
 fn lcmFn(args: []const Value) PrimitiveError!Value {
@@ -1099,15 +1109,36 @@ fn lcmFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
     var result = types.toFixnum(args[0]);
     if (result < 0) result = -result;
-    for (args[1..]) |a| {
-        if (!types.isFixnum(a)) return PrimitiveError.TypeError;
-        const b = types.toFixnum(a);
+    var idx: usize = 1;
+    while (idx < args.len) : (idx += 1) {
+        if (!types.isFixnum(args[idx])) return PrimitiveError.TypeError;
+        const b = types.toFixnum(args[idx]);
         const g = gcdTwo(result, b);
         if (g == 0) {
             result = 0;
         } else {
-            result = @divExact(result, g) * (if (b < 0) -b else b);
+            const partial = @divExact(result, g);
+            const abs_b: i64 = if (b < 0) -b else b;
+            const ov = @mulWithOverflow(partial, abs_b);
+            if (ov[1] != 0) {
+                const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+                var big_result = bignum_mod.mul(gc, try makeFixnumChecked(partial), try makeFixnumChecked(abs_b)) catch return PrimitiveError.OutOfMemory;
+                idx += 1;
+                while (idx < args.len) : (idx += 1) {
+                    const b_abs = bignum_mod.absVal(gc, args[idx]) catch return PrimitiveError.OutOfMemory;
+                    const gcd_pair = [_]Value{ big_result, b_abs };
+                    const g2 = try gcdFn(&gcd_pair);
+                    if (bignum_mod.isZero(g2)) {
+                        big_result = types.makeFixnum(0);
+                    } else {
+                        const q = bignum_mod.quotient(gc, big_result, g2) catch return PrimitiveError.OutOfMemory;
+                        big_result = bignum_mod.mul(gc, q, b_abs) catch return PrimitiveError.OutOfMemory;
+                    }
+                }
+                return big_result;
+            }
+            result = ov[0];
         }
     }
-    return types.makeFixnum(result);
+    return try makeFixnumChecked(result);
 }

--- a/tests/scheme/smoke/arith-overflow.scm
+++ b/tests/scheme/smoke/arith-overflow.scm
@@ -1,0 +1,37 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; gcd: result must be non-negative, even at fixnum boundary
+(check "gcd minInt48 0" (gcd -140737488355328 0) 140737488355328)
+(check "gcd minInt48" (gcd -140737488355328) 140737488355328)
+(check "gcd large" (gcd 140737488355328 2) 2)
+
+;; lcm: must not truncate large results
+(check "lcm large" (lcm 16777216 16777259) 281475698130944)
+(check "lcm overflow" (lcm 100000000000 99999999999) 9999999999900000000000)
+(check "lcm basic" (lcm 6 10) 30)
+(check "lcm zero" (lcm 0 5) 0)
+
+;; rational add: integer result past fixnum range
+(check "rational+ overflow" (+ 1/3 2/3 140737488355327) 140737488355328)
+
+;; rational mul: result past fixnum range
+(check "rational* overflow" (* 3/2 2 70368744177665) 211106232532995)
+
+;; rational sub: integer result past fixnum range
+(check "rational- overflow" (- 2/3 -1/3 -140737488355327) 140737488355328)
+
+;; rational div: integer result past fixnum range
+(check "rational/ overflow" (/ 281474976710656 2) 140737488355328)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "arithmetic overflow tests failed" fail))


### PR DESCRIPTION
## Summary

- Replace `makeFixnum` with `makeFixnumChecked` at all integer-return sites in `gcd`, `lcm`, `makeRationalReduced`, and rational `+`/`-`/`*`/`/`
- Guard lcm's i64 multiply with `@mulWithOverflow` and promote to bignum on overflow
- Also fix rational numerator/denominator values in `allocRational` calls that could exceed i48

Fixes #16

## Details

`makeFixnum` masks to 48 bits with no range check. When exact integer results fit in i64 but exceed the i48 fixnum range (±2^47), values were silently truncated. `lcm` additionally had an unguarded i64 multiply that panicked in ReleaseSafe.

All affected sites now use `makeFixnumChecked`, which promotes to bignum when the value exceeds i48 range. The lcm multiply uses `@mulWithOverflow` and falls through to bignum arithmetic for remaining arguments on overflow.

## Test plan

- [x] New `tests/scheme/smoke/arith-overflow.scm` — 11 assertions covering gcd at minInt(i48), lcm truncation, lcm i64 overflow, and rational +/-/*/÷ producing integers past fixnum range
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 69 Scheme test files pass (1462 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)