### PR TITLE
Fix GC-unsafe vector deserialization in bytecode cache loader

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -388,13 +388,14 @@ fn readConstant(r: *Reader, gc: *GC, all_funcs: []*Function, depth: u32) !Value 
         TAG_VECTOR => {
             const len = try r.readU32();
             if (len > MAX_VECTOR_LEN) return BytecodeError.CorruptedFile;
-            const allocator = gc.allocator;
-            const elems = allocator.alloc(Value, len) catch return BytecodeError.OutOfMemory;
-            defer allocator.free(elems);
+            var vec_val = gc.allocVectorFill(len, types.NIL) catch return BytecodeError.OutOfMemory;
+            try gc.pushRoot(&vec_val);
+            defer gc.popRoot();
+            const vec = types.toVector(vec_val);
             for (0..len) |i| {
-                elems[i] = try readConstant(r, gc, all_funcs, depth + 1);
+                vec.data[i] = try readConstant(r, gc, all_funcs, depth + 1);
             }
-            return gc.allocVector(elems) catch return BytecodeError.OutOfMemory;
+            return vec_val;
         },
         TAG_BYTEVECTOR => {
             const len = try r.readU32();


### PR DESCRIPTION
## Summary

- Allocate the vector up front with `allocVectorFill`, root it, then fill elements in place during deserialization
- Previously, elements were read into an unrooted allocator slice — each element's `readConstant` could trigger GC, sweeping already-read elements

Fixes #12

## Details

The sibling cases (TAG_PAIR, TAG_RATIONAL) correctly root the first sub-value across the second read. The vector path had no equivalent protection for its accumulated elements.

The fix uses `allocVectorFill(len, NIL)` to create a GC-tracked vector, roots it with `pushRoot`, then fills `vec.data[i]` in place. Every committed element is reachable from the root at every allocation point.

## Test plan

- [x] All 374 Zig unit tests pass (373 pass, 1 skip) — includes bytecode round-trip tests with vector constants
- [x] All 70 Scheme test files pass (1463 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)