### PR TITLE
Fix dangling registry key on library redefinition

### DIFF
--- a/src/library.zig
+++ b/src/library.zig
@@ -69,11 +69,12 @@ pub const LibraryRegistry = struct {
 
     /// Register a new library (or replace an existing one).
     pub fn register(self: *LibraryRegistry, lib: Library) !void {
-        // If a library with this name already exists, deinit it first
-        if (self.libraries.getPtr(lib.name)) |existing| {
-            existing.deinit();
+        const gop = try self.libraries.getOrPut(lib.name);
+        if (gop.found_existing) {
+            gop.value_ptr.deinit();
+            gop.key_ptr.* = lib.name;
         }
-        try self.libraries.put(lib.name, lib);
+        gop.value_ptr.* = lib;
     }
 
     /// Look up a library by canonical name.

--- a/tests/scheme/smoke/library-redefine.scm
+++ b/tests/scheme/smoke/library-redefine.scm
@@ -1,0 +1,27 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; Redefine a library with the same name — must not crash
+(define-library (my test) (export foo) (begin (define (foo) 1)))
+(define-library (my test) (export bar) (begin (define (bar) 2)))
+(import (my test))
+
+(check "redefined library" (bar) 2)
+
+;; Redefine again to exercise the path multiple times
+(define-library (my test) (export baz) (begin (define (baz) 3)))
+(import (my test))
+
+(check "redefined library again" (baz) 3)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "library redefine tests failed" fail))


### PR DESCRIPTION
## Summary

- Fix use-after-free in `LibraryRegistry.register` when a library is redefined with the same name
- The old library's `owned_name` (which was the hashmap key) was freed via `deinit()`, but the map retained the dangling slice as its key

Fixes #17

## Details

`StringHashMap.put` only writes the key for new entries. For existing entries, it updates the value but retains the old key pointer. When `existing.deinit()` freed the old name, the map key became a dangling pointer — causing crashes on later lookups or during `vm.deinit()`.

Fix: use `getOrPut` and, when `found_existing`, deinit the old value and overwrite `gop.key_ptr.*` with the new library's name before setting the value.

## Test plan

- [x] New `tests/scheme/smoke/library-redefine.scm` — 2 assertions: redefine library twice, verify latest exports are accessible
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 71 Scheme test files pass (1464 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)