### PR TITLE
Fix invalid free of trimmed sub-slice in thottam runCapture

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -248,8 +248,9 @@ fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]co
     }
 
     const slice = output.toOwnedSlice(allocator) catch return error.OutOfMemory;
+    defer allocator.free(slice);
     const trimmed = std.mem.trim(u8, slice, "\n\r");
-    return @constCast(trimmed);
+    return allocator.dupe(u8, trimmed) catch return error.OutOfMemory;
 }
 
 fn runPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) !u8 {


### PR DESCRIPTION
## Summary

- Fix `runCapture` returning a `std.mem.trim` sub-slice that callers then `free()` — an invalid free (wrong length or interior pointer)
- Free the original owned slice and `dupe` the trimmed result so callers get a proper allocation

Fixes #19

## Details

`toOwnedSlice` returns an allocation whose `.ptr` is the base. `std.mem.trim` returns a sub-slice with potentially offset `.ptr` and shorter `.len`. Callers (`copyDylibsFromPkg`, `removeDylibsFromPkg`, `removeSldFiles`, `doUpdate`) freed this sub-slice, which is UB under the Zig allocator contract and a heap corruption vector with `c_allocator`.

## Test plan

- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 71 Scheme test files pass (1464 total assertions, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)