### PR TITLE
Fix Function leak into extra_roots on bytecode deserialize error paths

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -696,6 +696,9 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
     const all_funcs = allocator.alloc(*Function, func_count) catch return BytecodeError.OutOfMemory;
     defer allocator.free(all_funcs);
 
+    const roots_base = gc.extra_roots.items.len;
+    var deser_ok = false;
+    defer if (!deser_ok) gc.extra_roots.shrinkRetainingCapacity(roots_base);
     for (0..func_count) |i| {
         all_funcs[i] = gc.allocFunction() catch return BytecodeError.OutOfMemory;
         gc.extra_roots.append(allocator, types.makePointer(@ptrCast(all_funcs[i]))) catch return BytecodeError.OutOfMemory;
@@ -837,6 +840,7 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
 
     const result = allocator.alloc(*Function, func_count) catch return BytecodeError.OutOfMemory;
     @memcpy(result, all_funcs);
+    deser_ok = true;
     return .{ .funcs = result, .top_level_count = top_level_count, .bundled_files = bundled_files, .preamble = preamble };
 }
 


### PR DESCRIPTION
## Summary

- Clean up `gc.extra_roots` on error/null returns from `deserializeFromBuffer`
- Partially-built Functions were permanently pinned in extra_roots on every failed .sbc load

Fixes #13

## Details

Uses a `defer` with a success flag — `deser_ok` is set true only before the successful return. On any null/error path, the defer shrinks extra_roots back to its pre-allocation baseline, freeing the leaked Function references.

## Test plan

- [x] All 374 Zig unit tests pass (373 pass, 1 skip) — includes bytecode round-trip and validation tests
- [x] All 71 Scheme test files pass (1464 total, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)