### PR TITLE
Fix file-info:device/rdev dropping device minor number on Linux

### DIFF
--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -33,6 +33,11 @@ const StatResult = struct {
     gid: u32,
 };
 
+fn makedev(major: u64, minor: u64) u64 {
+    return ((major & 0xfff) << 8) | (minor & 0xff) |
+        ((minor & ~@as(u64, 0xff)) << 12) | ((major & ~@as(u64, 0xfff)) << 32);
+}
+
 fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
     if (is_linux) {
         const linux = std.os.linux;
@@ -47,10 +52,10 @@ fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
             .mtime_sec = sx.mtime.sec,
             .atime_sec = sx.atime.sec,
             .ctime_sec = sx.ctime.sec,
-            .dev = @intCast(sx.dev_major),
+            .dev = makedev(sx.dev_major, sx.dev_minor),
             .ino = sx.ino,
             .nlinks = sx.nlink,
-            .rdev = @intCast(sx.rdev_major),
+            .rdev = makedev(sx.rdev_major, sx.rdev_minor),
             .blksize = @intCast(sx.blksize),
             .uid = sx.uid,
             .gid = sx.gid,


### PR DESCRIPTION
## Summary

- Combine `dev_major`/`dev_minor` and `rdev_major`/`rdev_minor` using the glibc `makedev` encoding on the Linux statx path
- Previously only the major number was stored, dropping the minor entirely

Fixes #30

## Test plan

- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 71 Scheme test files pass (1464 total, 0 fail)
- [x] CI validates on native Linux (Ubuntu x86_64, ARM, RISC-V)

🤖 Generated with [Claude Code](https://claude.com/claude-code)