### PR TITLE
Support nested/composed import sets (prefix/only/except/rename)

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -703,16 +703,21 @@ fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     return result.toOwnedSlice(allocator);
 }
 
+fn resolveImportBindings(vm: *VM, import_set: Value) anyerror!std.StringHashMap(Value) {
+    var bindings = std.StringHashMap(Value).init(vm.gc.allocator);
+    errdefer bindings.deinit();
+    try processImportSet(vm, &bindings, import_set);
+    return bindings;
+}
+
 fn processImportOnly(vm: *VM, target: *std.StringHashMap(Value), args: Value) !void {
-    // (only (lib-name) id ...)
+    // (only <import-set> id ...)
     if (!types.isPair(args)) return error.InvalidSyntax;
-    const lib_spec = types.car(args);
+    const inner_set = types.car(args);
     const ids = types.cdr(args);
 
-    const lib_name = library_mod.libraryNameToString(vm.gc.allocator, lib_spec) catch return error.InvalidSyntax;
-    defer vm.gc.allocator.free(lib_name);
-
-    const lib = vm.libraries.get(lib_name) orelse return error.UndefinedVariable;
+    var source = try resolveImportBindings(vm, inner_set);
+    defer source.deinit();
 
     var id_list = ids;
     while (id_list != types.NIL) {
@@ -720,7 +725,7 @@ fn processImportOnly(vm: *VM, target: *std.StringHashMap(Value), args: Value) !v
         const id = types.car(id_list);
         if (!types.isSymbol(id)) return error.InvalidSyntax;
         const id_name = types.symbolName(id);
-        if (lib.exports.get(id_name)) |val| {
+        if (source.get(id_name)) |val| {
             importBinding(vm, target, id_name, val) catch return error.OutOfMemory;
         }
         id_list = types.cdr(id_list);
@@ -728,17 +733,14 @@ fn processImportOnly(vm: *VM, target: *std.StringHashMap(Value), args: Value) !v
 }
 
 fn processImportExcept(vm: *VM, target: *std.StringHashMap(Value), args: Value) !void {
-    // (except (lib-name) id ...)
+    // (except <import-set> id ...)
     if (!types.isPair(args)) return error.InvalidSyntax;
-    const lib_spec = types.car(args);
+    const inner_set = types.car(args);
     const ids = types.cdr(args);
 
-    const lib_name = library_mod.libraryNameToString(vm.gc.allocator, lib_spec) catch return error.InvalidSyntax;
-    defer vm.gc.allocator.free(lib_name);
+    var source = try resolveImportBindings(vm, inner_set);
+    defer source.deinit();
 
-    const lib = vm.libraries.get(lib_name) orelse return error.UndefinedVariable;
-
-    // Collect excluded names
     var excluded: [64][]const u8 = undefined;
     var excluded_count: usize = 0;
     var id_list = ids;
@@ -753,8 +755,7 @@ fn processImportExcept(vm: *VM, target: *std.StringHashMap(Value), args: Value) 
         id_list = types.cdr(id_list);
     }
 
-    // Import all except excluded
-    var it = lib.exports.iterator();
+    var it = source.iterator();
     while (it.next()) |entry| {
         var is_excluded = false;
         for (excluded[0..excluded_count]) |exc| {
@@ -770,21 +771,19 @@ fn processImportExcept(vm: *VM, target: *std.StringHashMap(Value), args: Value) 
 }
 
 fn processImportPrefix(vm: *VM, target: *std.StringHashMap(Value), args: Value) !void {
-    // (prefix (lib-name) prefix-id)
+    // (prefix <import-set> prefix-id)
     if (!types.isPair(args)) return error.InvalidSyntax;
-    const lib_spec = types.car(args);
+    const inner_set = types.car(args);
     const rest = types.cdr(args);
     if (!types.isPair(rest)) return error.InvalidSyntax;
     const prefix_sym = types.car(rest);
     if (!types.isSymbol(prefix_sym)) return error.InvalidSyntax;
     const prefix = types.symbolName(prefix_sym);
 
-    const lib_name = library_mod.libraryNameToString(vm.gc.allocator, lib_spec) catch return error.InvalidSyntax;
-    defer vm.gc.allocator.free(lib_name);
+    var source = try resolveImportBindings(vm, inner_set);
+    defer source.deinit();
 
-    const lib = vm.libraries.get(lib_name) orelse return error.UndefinedVariable;
-
-    var it = lib.exports.iterator();
+    var it = source.iterator();
     while (it.next()) |entry| {
         const prefixed_buf = std.fmt.allocPrint(vm.gc.allocator, "{s}{s}", .{ prefix, entry.key_ptr.* }) catch return error.OutOfMemory;
         defer vm.gc.allocator.free(prefixed_buf);
@@ -795,17 +794,14 @@ fn processImportPrefix(vm: *VM, target: *std.StringHashMap(Value), args: Value) 
 }
 
 fn processImportRename(vm: *VM, target: *std.StringHashMap(Value), args: Value) !void {
-    // (rename (lib-name) (old new) ...)
+    // (rename <import-set> (old new) ...)
     if (!types.isPair(args)) return error.InvalidSyntax;
-    const lib_spec = types.car(args);
+    const inner_set = types.car(args);
     const renames = types.cdr(args);
 
-    const lib_name = library_mod.libraryNameToString(vm.gc.allocator, lib_spec) catch return error.InvalidSyntax;
-    defer vm.gc.allocator.free(lib_name);
+    var source = try resolveImportBindings(vm, inner_set);
+    defer source.deinit();
 
-    const lib = vm.libraries.get(lib_name) orelse return error.UndefinedVariable;
-
-    // Collect rename mappings
     var rename_old: [32][]const u8 = undefined;
     var rename_new: [32][]const u8 = undefined;
     var rename_count: usize = 0;
@@ -827,8 +823,7 @@ fn processImportRename(vm: *VM, target: *std.StringHashMap(Value), args: Value) 
         rename_list = types.cdr(rename_list);
     }
 
-    // Import all exports, applying renames
-    var it = lib.exports.iterator();
+    var it = source.iterator();
     while (it.next()) |entry| {
         var imported_name = entry.key_ptr.*;
         for (0..rename_count) |i| {

--- a/tests/scheme/smoke/import-composed.scm
+++ b/tests/scheme/smoke/import-composed.scm
@@ -1,0 +1,28 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; prefix + only (composed import): imported as s:car, s:cdr
+(import (prefix (only (scheme base) car cdr) s:))
+(check "prefix+only car" (s:car (cons 1 2)) 1)
+(check "prefix+only cdr" (s:cdr (cons 1 2)) 2)
+
+;; except: import everything except car/cdr
+(import (except (scheme base) car cdr))
+(check "except cons" (cons 'a 'b) '(a . b))
+
+;; rename
+(import (rename (scheme base) (car first) (cdr rest)))
+(check "rename first" (first '(10 20 30)) 10)
+(check "rename rest" (rest '(10 20 30)) '(20 30))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "composed import tests failed" fail))


### PR DESCRIPTION
## Summary

- Refactor import set handlers to recursively resolve their operand via `resolveImportBindings`
- Enables composed imports like `(prefix (only (scheme base) car cdr) s:)` per R7RS §5.6
- Also fixes the related issue of modifiers not loading libraries from disk (they now go through `processImportSet` which handles file loading)

Fixes #18

## Test plan

- [x] New `tests/scheme/smoke/import-composed.scm` — 5 assertions: prefix+only composition, except, rename
- [x] All 374 Zig unit tests pass (373 pass, 1 skip)
- [x] All 72 Scheme test files pass (1465 total, 0 fail)
- [x] R7RS suite: 1393 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)