### PR TITLE
Validate non-negative index before @intCast in vector procedures

### DIFF
--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -649,11 +649,15 @@ fn vectorReverseBangFn(args: []const Value) PrimitiveError!Value {
     var end: usize = vec.data.len;
     if (args.len > 1) {
         if (!types.isFixnum(args[1])) return primitives.typeError("vector-reverse!", "exact non-negative integer", args[1]);
-        start = @intCast(types.toFixnum(args[1]));
+        const s = types.toFixnum(args[1]);
+        if (s < 0) return primitives.typeError("vector-reverse!", "exact non-negative integer", args[1]);
+        start = @intCast(s);
     }
     if (args.len > 2) {
         if (!types.isFixnum(args[2])) return primitives.typeError("vector-reverse!", "exact non-negative integer", args[2]);
-        end = @intCast(types.toFixnum(args[2]));
+        const e = types.toFixnum(args[2]);
+        if (e < 0) return primitives.typeError("vector-reverse!", "exact non-negative integer", args[2]);
+        end = @intCast(e);
     }
     if (start > end or end > vec.data.len) return primitives.typeError("vector-reverse!", "valid index range", args[0]);
     var lo = start;
@@ -677,11 +681,15 @@ fn vectorReverseCopyFn(args: []const Value) PrimitiveError!Value {
     var end: usize = vec.data.len;
     if (args.len > 1) {
         if (!types.isFixnum(args[1])) return primitives.typeError("vector-reverse-copy", "exact non-negative integer", args[1]);
-        start = @intCast(types.toFixnum(args[1]));
+        const s = types.toFixnum(args[1]);
+        if (s < 0) return primitives.typeError("vector-reverse-copy", "exact non-negative integer", args[1]);
+        start = @intCast(s);
     }
     if (args.len > 2) {
         if (!types.isFixnum(args[2])) return primitives.typeError("vector-reverse-copy", "exact non-negative integer", args[2]);
-        end = @intCast(types.toFixnum(args[2]));
+        const e = types.toFixnum(args[2]);
+        if (e < 0) return primitives.typeError("vector-reverse-copy", "exact non-negative integer", args[2]);
+        end = @intCast(e);
     }
     if (start > end or end > vec.data.len) return primitives.typeError("vector-reverse-copy", "valid index range", args[0]);
     const len = end - start;
@@ -698,7 +706,9 @@ fn vectorUnfoldFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const f = args[0];
     if (!types.isFixnum(args[1])) return primitives.typeError("vector-unfold", "exact non-negative integer", args[1]);
-    const length: usize = @intCast(types.toFixnum(args[1]));
+    const len_val = types.toFixnum(args[1]);
+    if (len_val < 0) return primitives.typeError("vector-unfold", "exact non-negative integer", args[1]);
+    const length: usize = @intCast(len_val);
 
     var seeds: std.ArrayList(Value) = .empty;
     defer seeds.deinit(gc.allocator);

--- a/tests/scheme/smoke/vector-negative-index.scm
+++ b/tests/scheme/smoke/vector-negative-index.scm
@@ -1,0 +1,19 @@
+;; Regression test for #50: negative index args must error, not panic
+
+(import (scheme base) (scheme write))
+
+(define (expect-error thunk name)
+  (guard (exn (#t (begin (display "PASS: ") (display name) (newline))))
+    (thunk)
+    (display "FAIL: ") (display name) (display " did not error") (newline)))
+
+(expect-error (lambda () (vector-reverse! (vector 1 2 3) -1))
+              "vector-reverse! negative start")
+(expect-error (lambda () (vector-reverse! (vector 1 2 3) 0 -1))
+              "vector-reverse! negative end")
+(expect-error (lambda () (vector-reverse-copy (vector 1 2 3) -1))
+              "vector-reverse-copy negative start")
+(expect-error (lambda () (vector-reverse-copy (vector 1 2 3) 0 -1))
+              "vector-reverse-copy negative end")
+(expect-error (lambda () (vector-unfold (lambda (i) i) -5))
+              "vector-unfold negative length")


### PR DESCRIPTION
## Summary

- `vector-reverse!`, `vector-reverse-copy`, and `vector-unfold` cast fixnum args to `usize` with `@intCast` before checking sign, causing ReleaseSafe panic/abort on negative values
- Now validate `>= 0` before casting, returning a type error for negative args
- Matches the existing pattern used by `vector-ref`, `make-vector`, `vector-unfold-right` in the same file

Closes #50

## Test plan

- [x] New Scheme regression test: `tests/scheme/smoke/vector-negative-index.scm` — all 5 negative-arg cases produce errors instead of panics
- [x] All 74 Scheme test files pass, R7RS: 1393/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)