### PR TITLE
Fix quasiquote dropping nested unquotes when sibling splice is present

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -590,13 +590,12 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u8, depth: u8) CompileEr
 /// Build an S-expression (list expr1 expr2 ...) where each expr is either
 /// (quote elem) for plain data, or the unquote expression for ,expr.
 fn buildQQListExpr(gc: *@import("memory.zig").GC, quote_sym: Value, list_sym: Value, elems: []const Value) CompileError!Value {
-    // Build args list backwards
+    const qq_sym = gc.allocSymbol("quasiquote") catch return CompileError.OutOfMemory;
     var args: Value = types.NIL;
     var i = elems.len;
     while (i > 0) {
         i -= 1;
         const elem = elems[i];
-        // Check if this is an (unquote expr) form -- if so, use expr directly
         if (types.isPair(elem)) {
             const elem_head = types.car(elem);
             if (types.isSymbol(elem_head) and std.mem.eql(u8, types.symbolName(elem_head), "unquote")) {
@@ -606,8 +605,12 @@ fn buildQQListExpr(gc: *@import("memory.zig").GC, quote_sym: Value, list_sym: Va
                     continue;
                 }
             }
+            // Compound element: wrap in (quasiquote elem) so nested unquotes are processed
+            const wrapped = gc.allocPair(qq_sym, gc.allocPair(elem, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            args = gc.allocPair(wrapped, args) catch return CompileError.OutOfMemory;
+            continue;
         }
-        // Wrap in (quote elem)
+        // Atom: wrap in (quote elem)
         const quoted = gc.allocPair(quote_sym, gc.allocPair(elem, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
         args = gc.allocPair(quoted, args) catch return CompileError.OutOfMemory;
     }

--- a/tests/scheme/smoke/quasiquote-splice-nested.scm
+++ b/tests/scheme/smoke/quasiquote-splice-nested.scm
@@ -1,0 +1,33 @@
+;; Regression test for #51: quasiquote + unquote-splicing must process nested unquotes
+
+(import (scheme base) (scheme write))
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+    (begin (display "PASS: ") (display name) (newline))
+    (begin (display "FAIL: ") (display name)
+           (display " expected=") (write expected)
+           (display " actual=") (write actual) (newline))))
+
+(define c 99)
+(define d (list 7 8))
+
+(test "nested unquote with splice"
+  '(a (b 99) 7 8)
+  `(a (b ,c) ,@d))
+
+(test "deeply nested unquote with splice"
+  '(x (y (z 99)) 7 8)
+  `(x (y (z ,c)) ,@d))
+
+(test "multiple nested unquotes with splice"
+  '((1 99) (2 99) 7 8)
+  `((1 ,c) (2 ,c) ,@d))
+
+(test "no splice still works"
+  '(a (b 99))
+  `(a (b ,c)))
+
+(test "splice only"
+  '(7 8)
+  `(,@d))


### PR DESCRIPTION
## Summary

- In the quasiquote splicing path, non-unquote compound elements were wrapped in `(quote elem)` instead of `(quasiquote elem)`, causing inner unquotes like `,c` in `` `(a (b ,c) ,@d) `` to be emitted literally instead of evaluated
- Now wraps compound elements in `(quasiquote elem)` so nested structures are recursively processed, while atoms still use `(quote elem)`

Closes #51

## Test plan

- [x] New Scheme test: `tests/scheme/smoke/quasiquote-splice-nested.scm` — verifies nested unquote + splice, deeply nested, multiple, and simple cases
- [x] All 75 Scheme files pass, R7RS: 1393/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)