### PR TITLE
Respect lexical shadowing of => in case and cond arrow checks

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -124,7 +124,10 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u8, is_tail: bool) Compile
             // (else => proc): apply proc to the key value.
             if (types.isPair(clause_body)) {
                 const maybe_arrow = types.car(clause_body);
-                if (types.isSymbol(maybe_arrow) and std.mem.eql(u8, types.symbolName(maybe_arrow), "=>")) {
+                if (types.isSymbol(maybe_arrow) and std.mem.eql(u8, types.symbolName(maybe_arrow), "=>") and
+                    self.resolveLocal("=>") == null and
+                    (try self.resolveUpvalue("=>")) == null)
+                {
                     const arrow_rest = types.cdr(clause_body);
                     if (!types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
                     const proc_expr = types.car(arrow_rest);
@@ -237,7 +240,10 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u8, is_tail: bool) Compile
         // Check for => form: ((datum ...) => proc)
         if (clause_body != types.NIL and types.isPair(clause_body)) {
             const maybe_arrow = types.car(clause_body);
-            if (types.isSymbol(maybe_arrow) and std.mem.eql(u8, types.symbolName(maybe_arrow), "=>")) {
+            if (types.isSymbol(maybe_arrow) and std.mem.eql(u8, types.symbolName(maybe_arrow), "=>") and
+                self.resolveLocal("=>") == null and
+                (try self.resolveUpvalue("=>")) == null)
+            {
                 // Arrow form: compile proc, call with key value
                 const arrow_rest = types.cdr(clause_body);
                 if (arrow_rest == types.NIL or !types.isPair(arrow_rest)) return CompileError.InvalidSyntax;

--- a/src/compiler_conditionals.zig
+++ b/src/compiler_conditionals.zig
@@ -170,7 +170,8 @@ pub fn compileCond(self: *Compiler, args: Value, dst: u8, is_tail: bool) Compile
         if (clause_body != types.NIL and types.isPair(clause_body)) {
             const maybe_arrow = types.car(clause_body);
             if (types.isSymbol(maybe_arrow) and std.mem.eql(u8, types.symbolName(maybe_arrow), "=>") and
-                self.resolveLocal("=>") == null)
+                self.resolveLocal("=>") == null and
+                (try self.resolveUpvalue("=>")) == null)
             {
                 // (test => proc) -- call proc with test value
                 try self.emitOp(.jump_false);

--- a/tests/scheme/smoke/case-arrow-shadowing.scm
+++ b/tests/scheme/smoke/case-arrow-shadowing.scm
@@ -1,0 +1,35 @@
+;; Regression test for #52: case must respect lexical shadowing of =>
+
+(import (scheme base) (scheme write))
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+    (begin (display "PASS: ") (display name) (newline))
+    (begin (display "FAIL: ") (display name)
+           (display " expected=") (write expected)
+           (display " actual=") (write actual) (newline))))
+
+;; When => is locally bound, case should NOT treat it as the arrow keyword.
+;; The clause body (=> foo) compiles as (begin => foo), returning foo.
+;; Without the fix, the arrow form is taken, which tries to call foo as
+;; a procedure and errors.
+(test "case datum clause with shadowed =>"
+  'F
+  (let ((=> (lambda (a b) (list 'app a b))) (foo 'F))
+    (case 1 ((1) => foo))))
+
+(test "case else clause with shadowed =>"
+  'F
+  (let ((=> (lambda (a b) (list 'app a b))) (foo 'F))
+    (case 1 (else => foo))))
+
+;; Normal arrow form still works when => is not shadowed
+(test "case arrow form unshadowed"
+  2
+  (case 1 ((1) => (lambda (x) (+ x 1)))))
+
+;; Verify => can be used as a regular procedure call when shadowed
+(test "shadowed => as procedure in case body"
+  '(called 1)
+  (let ((=> (lambda (x) (list 'called x))))
+    (case 1 ((1) (=> 1)))))


### PR DESCRIPTION
## Summary

- `case` treated `=>` as the arrow keyword even when it was lexically bound as a local or upvalue variable
- Added `resolveLocal("=>")` and `resolveUpvalue("=>")` guards to both `case` arrow checks (else clause and datum clause), matching the existing `cond` guard
- Also extended the `cond` guard to check upvalues (it previously only checked locals)

Closes #52

## Test plan

- [x] New Scheme test: `tests/scheme/smoke/case-arrow-shadowing.scm` — verifies shadowed `=>` is not treated as arrow in both datum and else clauses, unshadowed arrow still works, and `=>` works as a regular procedure call when shadowed
- [x] All 76 Scheme files pass, R7RS: 1393/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)