### PR TITLE
Fix string-pad/pad-right crash on multi-byte pad characters

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -466,7 +466,8 @@ fn stringPadFn(args: []const Value) PrimitiveError!Value {
     const target_len: usize = @intCast(types.toFixnum(args[1]));
     var pad_buf: [4]u8 = undefined;
     const pad_cp: u21 = if (args.len > 2 and types.isChar(args[2])) types.toChar(args[2]) else ' ';
-    const pad_len = std.unicode.utf8Encode(pad_cp, &pad_buf) catch return PrimitiveError.TypeError;
+    const pad_len = std.unicode.utf8Encode(pad_cp, &pad_buf) catch
+        return primitives.typeError("string-pad", "valid character", args[2]);
     const current_len = utf8CodepointCount(data);
     if (current_len >= target_len) {
         const byte_start = pstr.utf8IndexToByteOffset(data, current_len - target_len) orelse data.len;
@@ -489,7 +490,8 @@ fn stringPadRightFn(args: []const Value) PrimitiveError!Value {
     const target_len: usize = @intCast(types.toFixnum(args[1]));
     var pad_buf: [4]u8 = undefined;
     const pad_cp: u21 = if (args.len > 2 and types.isChar(args[2])) types.toChar(args[2]) else ' ';
-    const pad_len = std.unicode.utf8Encode(pad_cp, &pad_buf) catch return PrimitiveError.TypeError;
+    const pad_len = std.unicode.utf8Encode(pad_cp, &pad_buf) catch
+        return primitives.typeError("string-pad-right", "valid character", args[2]);
     const current_len = utf8CodepointCount(data);
     if (current_len >= target_len) {
         const byte_end = pstr.utf8IndexToByteOffset(data, target_len) orelse data.len;

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -464,17 +464,21 @@ fn stringPadFn(args: []const Value) PrimitiveError!Value {
     const data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-pad", "integer", args[1]);
     const target_len: usize = @intCast(types.toFixnum(args[1]));
-    const pad_char: u8 = if (args.len > 2 and types.isChar(args[2])) @intCast(types.toChar(args[2])) else ' ';
+    var pad_buf: [4]u8 = undefined;
+    const pad_cp: u21 = if (args.len > 2 and types.isChar(args[2])) types.toChar(args[2]) else ' ';
+    const pad_len = std.unicode.utf8Encode(pad_cp, &pad_buf) catch return PrimitiveError.TypeError;
     const current_len = utf8CodepointCount(data);
     if (current_len >= target_len) {
         const byte_start = pstr.utf8IndexToByteOffset(data, current_len - target_len) orelse data.len;
         return gc.allocString(data[byte_start..]) catch return PrimitiveError.OutOfMemory;
     }
     const pad_count = target_len - current_len;
-    const alloc_buf = gc.allocator.alloc(u8, pad_count + data.len) catch return PrimitiveError.OutOfMemory;
+    const alloc_buf = gc.allocator.alloc(u8, pad_count * pad_len + data.len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(alloc_buf);
-    @memset(alloc_buf[0..pad_count], pad_char);
-    @memcpy(alloc_buf[pad_count..], data);
+    for (0..pad_count) |i| {
+        @memcpy(alloc_buf[i * pad_len ..][0..pad_len], pad_buf[0..pad_len]);
+    }
+    @memcpy(alloc_buf[pad_count * pad_len ..], data);
     return gc.allocString(alloc_buf) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -483,17 +487,21 @@ fn stringPadRightFn(args: []const Value) PrimitiveError!Value {
     const data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-pad-right", "integer", args[1]);
     const target_len: usize = @intCast(types.toFixnum(args[1]));
-    const pad_char: u8 = if (args.len > 2 and types.isChar(args[2])) @intCast(types.toChar(args[2])) else ' ';
+    var pad_buf: [4]u8 = undefined;
+    const pad_cp: u21 = if (args.len > 2 and types.isChar(args[2])) types.toChar(args[2]) else ' ';
+    const pad_len = std.unicode.utf8Encode(pad_cp, &pad_buf) catch return PrimitiveError.TypeError;
     const current_len = utf8CodepointCount(data);
     if (current_len >= target_len) {
         const byte_end = pstr.utf8IndexToByteOffset(data, target_len) orelse data.len;
         return gc.allocString(data[0..byte_end]) catch return PrimitiveError.OutOfMemory;
     }
     const pad_count = target_len - current_len;
-    const alloc_buf = gc.allocator.alloc(u8, data.len + pad_count) catch return PrimitiveError.OutOfMemory;
+    const alloc_buf = gc.allocator.alloc(u8, data.len + pad_count * pad_len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(alloc_buf);
     @memcpy(alloc_buf[0..data.len], data);
-    @memset(alloc_buf[data.len..], pad_char);
+    for (0..pad_count) |i| {
+        @memcpy(alloc_buf[data.len + i * pad_len ..][0..pad_len], pad_buf[0..pad_len]);
+    }
     return gc.allocString(alloc_buf) catch return PrimitiveError.OutOfMemory;
 }
 

--- a/tests/scheme/smoke/string-pad-multibyte.scm
+++ b/tests/scheme/smoke/string-pad-multibyte.scm
@@ -1,0 +1,46 @@
+;; Regression test for #53: string-pad/pad-right with multi-byte pad chars
+
+(import (scheme base) (scheme write))
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+    (begin (display "PASS: ") (display name) (newline))
+    (begin (display "FAIL: ") (display name)
+           (display " expected=") (write expected)
+           (display " actual=") (write actual) (newline))))
+
+;; Multi-byte pad char (λ = U+03BB, 2 bytes in UTF-8)
+(test "string-pad with lambda char"
+  "λλλ42"
+  (string-pad "42" 5 #\λ))
+
+(test "string-pad-right with lambda char"
+  "42λλλ"
+  (string-pad-right "42" 5 #\λ))
+
+;; Codepoint 128-255 (é = U+00E9, 2 bytes in UTF-8)
+(test "string-pad with é"
+  "ééé42"
+  (string-pad "42" 5 #\é))
+
+(test "string-pad-right with é length"
+  5
+  (string-length (string-pad-right "42" 5 #\é)))
+
+;; ASCII pad char still works
+(test "string-pad with ASCII"
+  "***42"
+  (string-pad "42" 5 #\*))
+
+(test "string-pad-right with ASCII"
+  "42***"
+  (string-pad-right "42" 5 #\*))
+
+;; No padding needed (string already long enough)
+(test "string-pad no padding needed"
+  "hello"
+  (string-pad "hello" 5))
+
+(test "string-pad truncation"
+  "ello"
+  (string-pad "hello" 4))


### PR DESCRIPTION
## Summary

- `string-pad` and `string-pad-right` cast the pad char codepoint to `u8` via `@intCast`, panicking for codepoints > 255 and producing invalid UTF-8 for 128–255
- Now UTF-8 encodes the pad character via `utf8Encode` and sizes the buffer correctly by encoded byte length

Closes #53

## Test plan

- [x] New test: `tests/scheme/smoke/string-pad-multibyte.scm` — multi-byte chars (λ, é), ASCII, no-padding, and truncation cases
- [x] All 77 Scheme files pass, R7RS: 1393/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)