### PR TITLE
Validate start <= end in string-replace to prevent silent corruption

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -607,6 +607,7 @@ fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
     if (ev < 0) return primitives.typeError("string-replace", "non-negative integer", args[3]);
     const start: usize = @intCast(sv);
     const end: usize = @intCast(ev);
+    if (start > end) return primitives.typeError("string-replace", "valid index range (start <= end)", args[2]);
     const byte_start = pstr.utf8IndexToByteOffset(data1, start) orelse data1.len;
     const byte_end = pstr.utf8IndexToByteOffset(data1, end) orelse data1.len;
     const new_len = byte_start + data2.len + (data1.len - byte_end);

--- a/tests/scheme/smoke/string-replace-range.scm
+++ b/tests/scheme/smoke/string-replace-range.scm
@@ -1,0 +1,32 @@
+;; Regression test for #55: string-replace start > end must error
+
+(import (scheme base) (scheme write))
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+    (begin (display "PASS: ") (display name) (newline))
+    (begin (display "FAIL: ") (display name)
+           (display " expected=") (write expected)
+           (display " actual=") (write actual) (newline))))
+
+(define (expect-error thunk name)
+  (guard (exn (#t (begin (display "PASS: ") (display name) (newline))))
+    (thunk)
+    (display "FAIL: ") (display name) (display " did not error") (newline)))
+
+;; start > end must error, not silently corrupt
+(expect-error (lambda () (string-replace "abcdef" "XY" 4 2))
+              "string-replace start > end")
+
+;; Normal replacements still work
+(test "string-replace normal"
+  "abXYef"
+  (string-replace "abcdef" "XY" 2 4))
+
+(test "string-replace at start"
+  "XYcdef"
+  (string-replace "abcdef" "XY" 0 2))
+
+(test "string-replace equal start/end (insert)"
+  "abXYcdef"
+  (string-replace "abcdef" "XY" 2 2))


### PR DESCRIPTION
## Summary

- `string-replace` with `start > end` silently built a corrupted string instead of erroring
- Now validates `start <= end` before computing byte offsets, returning a type error for invalid ranges

Closes #55

## Test plan

- [x] New test: `tests/scheme/smoke/string-replace-range.scm` — start > end errors, normal/start/insert replacements work
- [x] All 79 Scheme files pass, R7RS: 1393/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)