### PR TITLE
Fix run-all.sh masking non-zero exit status from test processes

### DIFF
--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -24,8 +24,8 @@ run_file() {
     "$KAAPPI" "$file" > /tmp/kaappi-test-out 2>&1 &
     pid=$!
     if wait_with_timeout "$pid" "$TIMEOUT"; then
-        wait "$pid" || true
-        status=$?
+        status=0
+        wait "$pid" || status=$?
     else
         kill "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true


### PR DESCRIPTION
## Bug

`wait "$pid" || true` on line 27 always set `$?` to 0 (from `true`), so any test process that crashed (SIGABRT, SIGSEGV) was incorrectly marked PASS.

## Fix

Change to `wait "$pid" || status=$?` — captures the real exit code while preventing `set -e` from killing the script.

## Impact

This surfaces a pre-existing crash in `tests/scheme/compliance/strings.scm` (`toObject` called on nil — "cast causes pointer to be null") that was previously hidden. That crash is a separate bug to fix.

## Test plan

- [x] Verified locally: the strings.scm crash is now correctly reported as FAIL
- [x] All other 78 Scheme tests pass, R7RS 1393/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)