### PR TITLE
Fix GC collecting AST nodes during macro expansion

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -614,15 +614,23 @@ pub const Compiler = struct {
                         }
                     }
                 };
-                const expanded = expander.expandMacro(self.gc, expr, transformer, self.globals, &merged_macros) catch |err| switch (err) {
-                    error.OutOfMemory => return CompileError.OutOfMemory,
-                    error.ScopeTableFull => return CompileError.InternalLimit,
-                    error.PatternTooComplex => return CompileError.InternalLimit,
-                    error.NoMatchingPattern => return CompileError.InvalidSyntax,
+                // Suppress GC during expansion: the expanded form isn't
+                // rooted until pushRoot below, so a collection triggered
+                // by allocPair inside expandMacro could free AST nodes
+                // that the partially-built result references.
+                self.gc.no_collect += 1;
+                const expanded = expander.expandMacro(self.gc, expr, transformer, self.globals, &merged_macros) catch |err| {
+                    self.gc.no_collect -= 1;
+                    return switch (err) {
+                        error.OutOfMemory => CompileError.OutOfMemory,
+                        error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
+                        error.NoMatchingPattern => CompileError.InvalidSyntax,
+                    };
                 };
                 var expanded_root = expanded;
                 try self.gc.pushRoot(&expanded_root);
                 defer self.gc.popRoot();
+                self.gc.no_collect -= 1;
                 // Inject captured locals from the macro definition site
                 const saved_locals_len = self.locals.items.len;
                 for (tx.captured_locals) |cap| {


### PR DESCRIPTION
## Root cause

`expandMacro` allocates pairs via `gc.allocPair`, each of which can trigger `maybeCollect`. The expanded form is not rooted until `pushRoot` after `expandMacro` returns. If GC runs mid-expansion and collects sub-trees of the input AST that the partially-built result references, the expanded form contains dangling pointers.

This manifested as a crash in `tests/scheme/compliance/strings.scm` — the SRFI-64 test framework's `test-group` macro, combined with the `(scheme process-context)` import pushing GC object count past the threshold, triggered collection during expansion. The crash was previously masked by a `|| true` exit status bug in `run-all.sh` (fixed in PR #67).

## Fix

Suppress GC (`no_collect`) during macro expansion, allowing collection to resume once the result is rooted via `pushRoot`. This is a narrow window (just the expansion call), so GC runs normally during all subsequent compilation.

## Test plan

- [x] `strings.scm` now passes (was crashing with "cast causes pointer to be null")
- [x] All 1473 tests pass (79 files + 1394 R7RS), 0 failures
- [x] Reproduced and verified fix locally with debug instrumentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)