### PR TITLE
Make GC markValue iterative for pair cdr chains

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1263,17 +1263,39 @@ pub const GC = struct {
     }
 
     pub fn markValue(self: *GC, v: Value) void {
-        if (!types.isPointer(v)) return;
-        const obj = types.toObject(v);
-        if (obj.marked) return;
-        obj.marked = true;
+        var cur = v;
+        while (true) {
+            if (!types.isPointer(cur)) return;
+            const obj = types.toObject(cur);
+            if (obj.marked) return;
+            obj.marked = true;
 
-        switch (obj.tag) {
-            .pair => {
+            if (obj.tag == .pair) {
                 const pair = obj.as(Pair);
-                self.markValue(pair.car);
-                self.markValue(pair.cdr);
-            },
+                const car = pair.car;
+                const cdr = pair.cdr;
+                // Iterate into whichever child is a pair; recurse on the other.
+                // For proper lists (cdr is pair, car is atom): iterate cdr.
+                // For nested lists like (((...))): iterate car (the deep branch).
+                const car_is_ptr = types.isPointer(car);
+                const cdr_is_ptr = types.isPointer(cdr);
+                if (car_is_ptr and cdr_is_ptr) {
+                    self.markValue(car);
+                    cur = cdr;
+                } else if (cdr_is_ptr) {
+                    cur = cdr;
+                } else {
+                    cur = car;
+                }
+                continue;
+            }
+            break;
+        }
+
+        // Non-pair heap object — already marked above, now trace its fields.
+        const obj = types.toObject(cur);
+        switch (obj.tag) {
+            .pair => unreachable,
             .closure => {
                 const cls = obj.as(Closure);
                 self.markValue(types.makePointer(@ptrCast(cls.func)));

--- a/tests/scheme/smoke/deep-nesting-print.scm
+++ b/tests/scheme/smoke/deep-nesting-print.scm
@@ -3,9 +3,9 @@
 
 (define (nest n acc) (if (= n 0) acc (nest (- n 1) (list acc))))
 
-;; 10k deep nesting — tests the depth guard without overflowing the native
-;; stack in GC's recursive markValue (200k overflows in Debug builds).
-(let ((deep (nest 10000 '())))
+;; 200k deep nesting — previously overflowed the native stack in markCyclesRec
+;; and in GC's markValue. Both now use iterative cdr-spine traversal.
+(let ((deep (nest 200000 '())))
   (let ((port (open-output-string)))
     (write deep port)
     (let ((s (get-output-string port)))


### PR DESCRIPTION
## Problem

`markValue` recursed on both car and cdr of pairs. A 200k-deep nested list created 200k stack frames, overflowing the native stack in Debug mode (where stack frames are larger due to no inlining).

## Fix

Walk the cdr spine in a loop, only recursing on car. Car depth is bounded by tree structure (typically shallow), while cdr length is bounded by list length (can be arbitrarily long).

Restores the 200k nesting test from 10k.

## Test plan

- [x] 200k deep nesting test passes locally
- [x] All 1473 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)