### PR TITLE
Fix mismatched-length ellipsis template variables reading uninitialized memory

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -624,7 +624,7 @@ pub const Compiler = struct {
                     return switch (err) {
                         error.OutOfMemory => CompileError.OutOfMemory,
                         error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
-                        error.NoMatchingPattern => CompileError.InvalidSyntax,
+                        error.NoMatchingPattern, error.EllipsisCountMismatch => CompileError.InvalidSyntax,
                     };
                 };
                 var expanded_root = expanded;

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -192,6 +192,7 @@ pub const ExpandError = error{
     NoMatchingPattern,
     ScopeTableFull,
     PatternTooComplex,
+    EllipsisCountMismatch,
     OutOfMemory,
 };
 
@@ -565,12 +566,18 @@ fn templateReferencesVar(template: Value, name: []const u8) bool {
 }
 
 fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bindings: []Binding, intro_scope: u32, literals: []const Value, macro_keyword: ?[]const u8, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value)) (std.mem.Allocator.Error || ExpandError)!Value {
-    // Find the repeat count from ellipsis bindings referenced in elem_template
+    // Find the repeat count from ellipsis bindings referenced in elem_template.
+    // All referenced list bindings must have equal counts (R7RS).
     var repeat_count: usize = 0;
+    var count_set = false;
     for (bindings) |b| {
         if (b.is_list and templateReferencesVar(elem_template, b.name)) {
-            repeat_count = b.ellipsis_count;
-            break;
+            if (!count_set) {
+                repeat_count = b.ellipsis_count;
+                count_set = true;
+            } else if (b.ellipsis_count != repeat_count) {
+                return ExpandError.EllipsisCountMismatch;
+            }
         }
     }
 

--- a/tests/scheme/smoke/ellipsis-mismatch.scm
+++ b/tests/scheme/smoke/ellipsis-mismatch.scm
@@ -1,0 +1,30 @@
+;; Regression test for issue #78:
+;; Mismatched-length ellipsis template variables must produce a clean error,
+;; not read uninitialized memory.
+
+(import (scheme base) (scheme write))
+
+;; Equal-length ellipsis — must work correctly
+(define-syntax zip-equal
+  (syntax-rules ()
+    ((zip-equal (a ...) (b ...)) (quote ((a b) ...)))))
+
+(let ((result (zip-equal (1 2 3) (4 5 6))))
+  (unless (equal? result '((1 4) (2 5) (3 6)))
+    (display "FAIL: equal-length ellipsis zip")
+    (newline)
+    (exit 1)))
+
+;; Mismatched-length ellipsis — must raise an error, not produce garbage
+(define-syntax zip-mismatched
+  (syntax-rules ()
+    ((zip-mismatched (a ...) (b ...)) (quote ((a b) ...)))))
+
+(guard (exn (#t 'caught))
+  (zip-mismatched (1 2 3) (4 5))
+  (display "FAIL: mismatched ellipsis should have raised an error")
+  (newline)
+  (exit 1))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- When a `syntax-rules` template referenced two pattern variables matched with different counts, the expander indexed past the shorter variable's valid `ellipsis_values` array, reading uninitialized memory (potential crash/corruption)
- All referenced list bindings are now checked for equal counts; mismatches return a clean `EllipsisCountMismatch` error
- Added regression test in `tests/scheme/smoke/ellipsis-mismatch.scm`

## Test plan
- [x] Regression test verifies mismatched counts produce clean error
- [x] Equal-length ellipsis continues to work correctly
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1474 pass, 0 fail

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)