### PR TITLE
Root datum-label placeholder pair to prevent use-after-free

### DIFF
--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -50,17 +50,22 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
         .hash_u8_lparen => return readBytevector(self),
         .datum_label_def => |n| {
             if (n >= self.labels.len) return ReadError.InvalidNumber;
-            // Pre-allocate a placeholder pair for circular references
-            const placeholder = self.gc.allocPair(types.VOID, types.NIL) catch return ReadError.OutOfMemory;
+            // Pre-allocate a placeholder pair for circular references.
+            // Root it so GC doesn't free it during the nested readDatum.
+            var placeholder = self.gc.allocPair(types.VOID, types.NIL) catch return ReadError.OutOfMemory;
+            self.gc.pushRoot(&placeholder) catch return ReadError.OutOfMemory;
             self.labels[n] = placeholder;
-            const datum = try readDatum(self);
+            const datum = readDatum(self) catch |err| {
+                self.gc.popRoot();
+                return err;
+            };
+            self.gc.popRoot();
+            self.labels[n] = placeholder;
             if (types.isPair(datum)) {
-                // Copy the read pair's contents into the placeholder
                 types.setCar(placeholder, types.car(datum));
                 types.setCdr(placeholder, types.cdr(datum));
                 return placeholder;
             } else {
-                // Non-pair datum: just store directly
                 self.labels[n] = datum;
                 return datum;
             }

--- a/tests/scheme/smoke/datum-label-gc.scm
+++ b/tests/scheme/smoke/datum-label-gc.scm
@@ -1,0 +1,33 @@
+;; Regression test for issue #75:
+;; Datum-label placeholder must survive GC during nested read.
+;; The placeholder pair is now GC-rooted across the readDatum call.
+
+(import (scheme base) (scheme read) (scheme write))
+
+;; Basic datum label round-trip
+(let ((x (read (open-input-string "#0=(1 2 3)"))))
+  (unless (equal? x '(1 2 3))
+    (display "FAIL: basic datum label")
+    (newline)
+    (exit 1)))
+
+;; Datum label with back-reference (cyclic structure)
+(let ((x (read (open-input-string "#0=(a . #0#)"))))
+  (unless (and (pair? x)
+               (eq? (car x) 'a)
+               (eq? (cdr x) x))
+    (display "FAIL: cyclic datum label")
+    (newline)
+    (exit 1)))
+
+;; Multiple datum labels
+(let ((x (read (open-input-string "#0=(1 #1=(2 3) #1#)"))))
+  (unless (and (equal? (car x) 1)
+               (equal? (cadr x) '(2 3))
+               (eq? (cadr x) (caddr x)))
+    (display "FAIL: multiple datum labels")
+    (newline)
+    (exit 1)))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- The reader's `#N=`/`#N#` datum-label table was not a GC root — a nested `readDatum` could trigger GC and free the placeholder pair, causing use-after-free on the subsequent `setCar`/`setCdr`
- The placeholder is now GC-rooted (`pushRoot`/`popRoot`) across the nested read
- Added regression test in `tests/scheme/smoke/datum-label-gc.scm`

## Test plan
- [x] Datum label basic, cyclic, and multi-label tests pass
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1474 pass, 0 fail

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)