### PR TITLE
Fix malformed #-prefixed numeric literals panicking instead of clean error

### DIFF
--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -45,6 +45,7 @@ fn parseDecimalReal(s: []const u8) ?f64 {
 }
 
 pub fn readNumber(self: *Reader) ReadError!Token {
+    if (self.pos >= self.source.len) return ReadError.InvalidNumber;
     const start = self.pos;
     if (self.source[self.pos] == '+' or self.source[self.pos] == '-') {
         self.pos += 1;
@@ -310,6 +311,9 @@ fn applyExactness(tok: Token, exact: ?bool) ReadError!Token {
             .fixnum, .rational, .bignum_str => tok,
             .flonum => |f| blk: {
                 if (!std.math.isFinite(f)) break :blk Token{ .flonum = f };
+                const max_i64_f: f64 = @floatFromInt(@as(i64, std.math.maxInt(i64)));
+                const min_i64_f: f64 = @floatFromInt(@as(i64, std.math.minInt(i64)));
+                if (f > max_i64_f or f < min_i64_f) break :blk Token{ .flonum = f };
                 const trunc: i64 = @intFromFloat(f);
                 if (@as(f64, @floatFromInt(trunc)) == f) break :blk Token{ .fixnum = trunc };
                 // Non-integer float: convert to rational via continued fraction
@@ -320,13 +324,20 @@ fn applyExactness(tok: Token, exact: ?bool) ReadError!Token {
                 var x = @abs(f);
                 var iters: u32 = 0;
                 while (iters < 64) : (iters += 1) {
+                    if (x > max_i64_f) break;
                     const a: i64 = @intFromFloat(x);
-                    const new_num = a * num + prev_num;
-                    const new_den = a * den + prev_den;
+                    const new_num = @mulWithOverflow(a, num);
+                    if (new_num[1] != 0) break;
+                    const final_num = @addWithOverflow(new_num[0], prev_num);
+                    if (final_num[1] != 0) break;
+                    const new_den = @mulWithOverflow(a, den);
+                    if (new_den[1] != 0) break;
+                    const final_den = @addWithOverflow(new_den[0], prev_den);
+                    if (final_den[1] != 0) break;
                     prev_num = num;
                     prev_den = den;
-                    num = new_num;
-                    den = new_den;
+                    num = final_num[0];
+                    den = final_den[0];
                     const approx = @as(f64, @floatFromInt(num)) / @as(f64, @floatFromInt(den));
                     if (@abs(approx - @abs(f)) < 1e-15) break;
                     const frac = x - @as(f64, @floatFromInt(a));

--- a/tests/scheme/smoke/reader-numeric-prefix.scm
+++ b/tests/scheme/smoke/reader-numeric-prefix.scm
@@ -1,0 +1,41 @@
+;; Regression test for issue #79:
+;; Malformed #-prefixed numeric literals must produce clean read errors,
+;; not abort the interpreter.
+
+(import (scheme base) (scheme read) (scheme write))
+
+(define (read-from-string s)
+  (read (open-input-string s)))
+
+(define (read-errors? s)
+  (guard (exn (#t #t))
+    (read-from-string s)
+    #f))
+
+;; Bug A: #d / #e / #i at EOF must error, not OOB panic
+(unless (read-errors? "#d")
+  (display "FAIL: #d at EOF should error") (newline) (exit 1))
+(unless (read-errors? "#i")
+  (display "FAIL: #i at EOF should error") (newline) (exit 1))
+(unless (read-errors? "#e#d")
+  (display "FAIL: #e#d at EOF should error") (newline) (exit 1))
+
+;; Bug B: #e of large flonum must not panic from intFromFloat overflow
+(let ((v (read-from-string "#e1e19")))
+  (unless (number? v)
+    (display "FAIL: #e1e19 should produce a number") (newline) (exit 1)))
+(let ((v (read-from-string "#e1e308")))
+  (unless (number? v)
+    (display "FAIL: #e1e308 should produce a number") (newline) (exit 1)))
+(let ((v (read-from-string "#e9.5e18")))
+  (unless (number? v)
+    (display "FAIL: #e9.5e18 should produce a number") (newline) (exit 1)))
+
+;; Valid #e cases still work
+(unless (= (read-from-string "#e1.5") 3/2)
+  (display "FAIL: #e1.5 should be 3/2") (newline) (exit 1))
+(unless (= (read-from-string "#e42") 42)
+  (display "FAIL: #e42 should be 42") (newline) (exit 1))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- **Bug A:** `readNumber` had no EOF bounds check — `#d`/`#e`/`#i` at EOF caused OOB read panic. Added `pos >= len` guard
- **Bug B:** `applyExactness` used unchecked `@intFromFloat` for floats exceeding i64 range (`#e1e19`, `#e1e308`) — overflow panic. Added range checks and overflow-safe arithmetic in the continued-fraction loop
- Both are reachable via the runtime `(read)` procedure on untrusted input (DoS vector)

## Test plan
- [x] All previously-crashing inputs now produce clean errors or valid results
- [x] Valid `#e` cases still work correctly
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1475 pass, 0 fail

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)