### PR TITLE
Add type and range validation to string-fill! start/end arguments

### DIFF
--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -350,14 +350,26 @@ fn stringFillFn(args: []const Value) PrimitiveError!Value {
     const data = str.data[0..str.len];
     const cp = types.toChar(args[1]);
     const char_count = utf8CodepointCount(data);
-    const start: usize = if (args.len > 2) @intCast(@as(u64, @bitCast(types.toFixnum(args[2])))) else 0;
-    const end: usize = if (args.len > 3) @intCast(@as(u64, @bitCast(types.toFixnum(args[3])))) else char_count;
+    var start_cp: usize = 0;
+    if (args.len > 2) {
+        if (!types.isFixnum(args[2])) return primitives.typeError("string-fill!", "exact integer", args[2]);
+        const k = types.toFixnum(args[2]);
+        if (k < 0) return primitives.typeError("string-fill!", "non-negative integer", args[2]);
+        start_cp = @intCast(@as(u64, @bitCast(k)));
+    }
+    var end_cp: usize = char_count;
+    if (args.len > 3) {
+        if (!types.isFixnum(args[3])) return primitives.typeError("string-fill!", "exact integer", args[3]);
+        const k = types.toFixnum(args[3]);
+        if (k < 0) return primitives.typeError("string-fill!", "non-negative integer", args[3]);
+        end_cp = @intCast(@as(u64, @bitCast(k)));
+    }
+    if (start_cp > end_cp) return primitives.typeError("string-fill!", "start <= end", args[2]);
+    if (end_cp > char_count) return PrimitiveError.IndexOutOfBounds;
+    const start = start_cp;
+    const end = end_cp;
     var fill_buf: [4]u8 = undefined;
     const fill_len = std.unicode.utf8Encode(cp, &fill_buf) catch return primitives.typeError("string-fill!", "valid character", args[1]);
-    const fill_count = end - start;
-    const unfilled = char_count - fill_count;
-    const new_total = unfilled * 1 + fill_count * fill_len;
-    _ = new_total;
     // Build new string: [0..start] unchanged, [start..end] filled, [end..] unchanged
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(gc.allocator);

--- a/tests/scheme/smoke/string-fill-validation.scm
+++ b/tests/scheme/smoke/string-fill-validation.scm
@@ -1,0 +1,39 @@
+;; Regression test for issue #74:
+;; string-fill! must validate start/end arguments instead of panicking.
+
+(import (scheme base) (scheme write))
+
+(define (errors? thunk)
+  (guard (exn (#t #t))
+    (thunk)
+    #f))
+
+;; Valid uses
+(let ((s (make-string 5 #\a)))
+  (string-fill! s #\z)
+  (unless (equal? s "zzzzz")
+    (display "FAIL: basic fill") (newline) (exit 1)))
+
+(let ((s (make-string 5 #\a)))
+  (string-fill! s #\z 1 3)
+  (unless (equal? s "azzaa")
+    (display "FAIL: fill with start/end") (newline) (exit 1)))
+
+;; start > end must error
+(unless (errors? (lambda () (string-fill! (make-string 3 #\x) #\z 3 1)))
+  (display "FAIL: start > end should error") (newline) (exit 1))
+
+;; start/end > len must error
+(unless (errors? (lambda () (string-fill! (make-string 3 #\x) #\z 5 10)))
+  (display "FAIL: start > len should error") (newline) (exit 1))
+
+;; Negative start must error
+(unless (errors? (lambda () (string-fill! (make-string 3 #\x) #\z -1)))
+  (display "FAIL: negative start should error") (newline) (exit 1))
+
+;; Non-fixnum start must error
+(unless (errors? (lambda () (string-fill! (make-string 3 #\x) #\z "no")))
+  (display "FAIL: non-fixnum start should error") (newline) (exit 1))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- `string-fill!` performed no validation on optional `start`/`end` args — non-fixnum, negative, or out-of-range values caused unsigned arithmetic underflow panics (DoS)
- Added `isFixnum`, non-negative, `start <= end`, and `end <= string-length` checks, matching the validation pattern used by all sibling string procedures

## Test plan
- [x] All previously-crashing inputs now produce clean Scheme errors
- [x] Valid `string-fill!` with and without start/end still works
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1476 pass, 0 fail

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)