### PR TITLE
Validate binding form shape and handle >32 bindings gracefully

### DIFF
--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -6,6 +6,8 @@ const Value = types.Value;
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 
+const MAX_LET_BINDINGS = 256;
+
 var named_let_counter: u32 = 0;
 
 fn makeUniqueLoopName(gc: *memory.GC, original: []const u8) CompileError!Value {
@@ -53,7 +55,7 @@ pub fn compileLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compile
     // is just a reference to that binding, the init IS the tail expression.
     if (is_tail and types.isPair(bindings) and types.cdr(bindings) == types.NIL) {
         const binding = types.car(bindings);
-        if (types.isPair(binding)) {
+        if (types.isPair(binding) and types.isPair(types.cdr(binding))) {
             const var_name = types.car(binding);
             if (types.isSymbol(var_name) and types.isPair(body) and types.cdr(body) == types.NIL) {
                 const body_expr = types.car(body);
@@ -69,8 +71,8 @@ pub fn compileLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compile
     }
 
     // Phase 1: evaluate all inits (no new locals visible yet)
-    var slots: [32]u16 = undefined;
-    var names: [32][]const u8 = undefined;
+    var slots: [MAX_LET_BINDINGS]u16 = undefined;
+    var names: [MAX_LET_BINDINGS][]const u8 = undefined;
     var count: usize = 0;
 
     var binding_list = bindings;
@@ -81,8 +83,10 @@ pub fn compileLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compile
 
         const var_name = types.car(binding);
         if (!types.isSymbol(var_name)) return CompileError.InvalidSyntax;
+        if (!types.isPair(types.cdr(binding))) return CompileError.InvalidSyntax;
         const init_expr = types.car(types.cdr(binding));
 
+        if (count >= MAX_LET_BINDINGS) return CompileError.TooManyLocals;
         const slot = try self.allocReg();
         try self.compileExpr(init_expr, slot, false);
         slots[count] = slot;
@@ -118,6 +122,7 @@ pub fn compileLetStar(self: *Compiler, args: Value, dst: u16, is_tail: bool) Com
 
         const var_name = types.car(binding);
         if (!types.isSymbol(var_name)) return CompileError.InvalidSyntax;
+        if (!types.isPair(types.cdr(binding))) return CompileError.InvalidSyntax;
         const init_expr = types.car(types.cdr(binding));
 
         const slot = try self.allocReg();
@@ -143,9 +148,9 @@ fn compileLetrecImpl(self: *Compiler, args: Value, dst: u16, is_tail: bool, is_s
 
     // letrec uses globals for mutually recursive closures. Use gensym'd
     // names to avoid overwriting user-visible globals like even?/odd?.
-    var syms: [32]Value = undefined;
-    var unique_syms: [32]Value = undefined;
-    var inits: [32]Value = undefined;
+    var syms: [MAX_LET_BINDINGS]Value = undefined;
+    var unique_syms: [MAX_LET_BINDINGS]Value = undefined;
+    var inits: [MAX_LET_BINDINGS]Value = undefined;
     var count: usize = 0;
 
     var binding_list = bindings;
@@ -156,7 +161,9 @@ fn compileLetrecImpl(self: *Compiler, args: Value, dst: u16, is_tail: bool, is_s
 
         const var_name = types.car(binding);
         if (!types.isSymbol(var_name)) return CompileError.InvalidSyntax;
+        if (!types.isPair(types.cdr(binding))) return CompileError.InvalidSyntax;
 
+        if (count >= MAX_LET_BINDINGS) return CompileError.TooManyLocals;
         syms[count] = var_name;
         unique_syms[count] = try makeUniqueLoopName(self.gc, types.symbolName(var_name));
         inits[count] = types.car(types.cdr(binding));
@@ -220,8 +227,8 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
     if (body == types.NIL) return CompileError.InvalidSyntax;
 
     // Collect var names and init expressions
-    var var_names: [32]Value = undefined;
-    var init_exprs: [32]Value = undefined;
+    var var_names: [MAX_LET_BINDINGS]Value = undefined;
+    var init_exprs: [MAX_LET_BINDINGS]Value = undefined;
     var param_count: usize = 0;
 
     var binding_list = bindings;
@@ -229,7 +236,9 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
         if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
         const binding = types.car(binding_list);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
+        if (!types.isPair(types.cdr(binding))) return CompileError.InvalidSyntax;
 
+        if (param_count >= MAX_LET_BINDINGS) return CompileError.TooManyLocals;
         var_names[param_count] = types.car(binding);
         init_exprs[param_count] = types.car(types.cdr(binding));
         param_count += 1;
@@ -322,9 +331,9 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     self.beginScope();
 
     // Parse var specs and evaluate inits
-    var var_slots: [32]u16 = undefined;
-    var step_exprs: [32]Value = undefined;
-    var has_step: [32]bool = undefined;
+    var var_slots: [MAX_LET_BINDINGS]u16 = undefined;
+    var step_exprs: [MAX_LET_BINDINGS]Value = undefined;
+    var has_step: [MAX_LET_BINDINGS]bool = undefined;
     var var_count: usize = 0;
 
     var spec_list = var_specs;
@@ -335,8 +344,10 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
 
         const var_name = types.car(spec);
         if (!types.isSymbol(var_name)) return CompileError.InvalidSyntax;
+        if (!types.isPair(types.cdr(spec))) return CompileError.InvalidSyntax;
         const init_expr = types.car(types.cdr(spec));
 
+        if (var_count >= MAX_LET_BINDINGS) return CompileError.TooManyLocals;
         const slot = try self.allocReg();
         try self.compileExpr(init_expr, slot, false);
         try self.addLocal(types.symbolName(var_name), slot);

--- a/tests/scheme/smoke/binding-form-validation.scm
+++ b/tests/scheme/smoke/binding-form-validation.scm
@@ -1,0 +1,42 @@
+;; Regression test for issue #72:
+;; Malformed binding forms must produce clean syntax errors, not abort.
+
+(import (scheme base) (scheme write))
+
+(define (compile-errors? thunk)
+  (guard (exn (#t #t))
+    (thunk)
+    #f))
+
+;; (let ((x)) x) — missing init
+(unless (compile-errors? (lambda () (eval '(let ((x)) x))))
+  (display "FAIL: let missing init") (newline) (exit 1))
+
+;; (let* ((x)) x) — missing init
+(unless (compile-errors? (lambda () (eval '(let* ((x)) x))))
+  (display "FAIL: let* missing init") (newline) (exit 1))
+
+;; (letrec ((x)) x) — missing init
+(unless (compile-errors? (lambda () (eval '(letrec ((x)) x))))
+  (display "FAIL: letrec missing init") (newline) (exit 1))
+
+;; (do ((x)) (#t 0)) — missing init
+(unless (compile-errors? (lambda () (eval '(do ((x)) (#t 0)))))
+  (display "FAIL: do missing init") (newline) (exit 1))
+
+;; (let ((x . 5)) x) — improper binding
+(unless (compile-errors? (lambda () (eval '(let ((x . 5)) x))))
+  (display "FAIL: let improper binding") (newline) (exit 1))
+
+;; Valid uses still work
+(unless (= (let ((x 1) (y 2)) (+ x y)) 3)
+  (display "FAIL: valid let") (newline) (exit 1))
+(unless (= (let* ((x 1) (y (+ x 1))) y) 2)
+  (display "FAIL: valid let*") (newline) (exit 1))
+(unless (= (letrec ((x 42)) x) 42)
+  (display "FAIL: valid letrec") (newline) (exit 1))
+(unless (= (do ((i 0 (+ i 1))) ((= i 5) i)) 5)
+  (display "FAIL: valid do") (newline) (exit 1))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- Binding forms (let, let*, letrec, letrec*, named let, do) crashed on malformed bindings missing init expressions — `car(cdr(binding))` was called without checking `cdr(binding)` is a pair
- Fixed [32] arrays caused OOB writes with >32 bindings — increased to 256 with explicit count checks
- Added `isPair(cdr(binding))` validation at all 6 call sites

## Test plan
- [x] All previously-crashing inputs produce clean syntax errors
- [x] Valid binding forms still work correctly
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1477 pass, 0 fail

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)