### PR TITLE
Use case-folding instead of downcase in string-ci comparisons

### DIFF
--- a/src/primitives_char.zig
+++ b/src/primitives_char.zig
@@ -333,8 +333,8 @@ fn foldCompareStrings(a: []const u8, b: []const u8) std.math.Order {
             (std.unicode.utf8Decode(b[bi .. bi + b_len]) catch @as(u21, b[bi]))
         else
             @as(u21, b[bi]);
-        const fa = unicodeDowncase(a_cp);
-        const fb = unicodeDowncase(b_cp);
+        const fa = foldChar(a_cp);
+        const fb = foldChar(b_cp);
         if (fa < fb) return .lt;
         if (fa > fb) return .gt;
         ai += a_len;

--- a/tests/scheme/smoke/string-ci-folding.scm
+++ b/tests/scheme/smoke/string-ci-folding.scm
@@ -1,0 +1,27 @@
+;; Regression test for issue #80:
+;; string-ci comparisons must use case-folding, not bare downcase.
+
+(import (scheme base) (scheme char) (scheme write))
+
+;; Long-s (U+017F) must fold to s
+(unless (string-ci=? "ſ" "s")
+  (display "FAIL: long-s vs s") (newline) (exit 1))
+
+;; Micro sign (U+00B5) must fold to Greek mu (U+03BC)
+(unless (string-ci=? "µ" "μ")
+  (display "FAIL: micro sign vs mu") (newline) (exit 1))
+
+;; Consistency: string-ci=? should agree with char-ci=?
+(unless (eq? (char-ci=? #\ſ #\s) (string-ci=? "ſ" "s"))
+  (display "FAIL: char-ci vs string-ci consistency for long-s") (newline) (exit 1))
+
+;; Basic ASCII case insensitive
+(unless (string-ci=? "Hello" "hello")
+  (display "FAIL: basic ASCII") (newline) (exit 1))
+
+;; Ordering with case folding
+(unless (string-ci<? "abc" "abd")
+  (display "FAIL: ci ordering") (newline) (exit 1))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- `foldCompareStrings` used `unicodeDowncase` instead of `foldChar` for string-ci comparisons, giving wrong results for characters that only match under case-folding (long-s → s, micro sign → Greek mu)
- One-line fix: `unicodeDowncase` → `foldChar` in `foldCompareStrings` (lines 336-337)

## Test plan
- [x] `(string-ci=? "ſ" "s")` → `#t` (was `#f`)
- [x] `(string-ci=? "µ" "μ")` → `#t` (was `#f`)
- [x] ASCII case-insensitive comparison still works
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1479 pass, 0 fail

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)