### PR TITLE
Free child VM/GC/heap on thread-join and protect symbol table during GC

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1253,11 +1253,14 @@ pub const GC = struct {
         // Mark active FFI callback closures
         const ffi_cb = @import("ffi_callback.zig");
         ffi_cb.markCallbackRoots(self);
-        // Mark interned symbols
+        // Mark interned symbols (take mutex when the table may be shared
+        // with a child thread that concurrently interns symbols)
+        spinLock(&symbol_mutex);
         var it = self.symbols.valueIterator();
         while (it.next()) |v| {
             self.markValue(v.*);
         }
+        spinUnlock(&symbol_mutex);
         // Mark VM-owned roots (live registers, call frames, handlers, winds).
         if (self.root_marker) |mark| mark(self);
     }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -374,8 +374,16 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
 
 fn freeChildResources(fiber_key: usize) void {
     while (!child_resources_mutex.tryLock()) {}
-    _ = child_resources.fetchRemove(fiber_key);
+    const entry = child_resources.fetchRemove(fiber_key);
     child_resources_mutex.unlock();
+
+    if (entry) |kv| {
+        const allocator = kv.value.child_gc.allocator;
+        kv.value.child_vm.deinit();
+        allocator.destroy(kv.value.child_vm);
+        kv.value.child_gc.deinit();
+        allocator.destroy(kv.value.child_gc);
+    }
 }
 
 fn threadJoinResult(target: *fiber_mod.Fiber) PrimitiveError!Value {


### PR DESCRIPTION
## Summary
- **#76 fix:** `freeChildResources` now properly calls `deinit()` and `destroy()` on the child VM and GC after `thread-join!`, fixing an unbounded memory leak (VM+GC+heap leaked per thread)
- **#77 partial fix:** `markRoots` now takes `symbol_mutex` during symbol table iteration, preventing a data race where concurrent symbol interning could rehash the table mid-traversal

The globals/macros sharing race (Race A in #77) needs deeper architectural changes and is documented as remaining work.

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1478 pass, 0 fail
- [x] SRFI-18 basic thread test works correctly

Fixes #76
Partially addresses #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)