### PR TITLE
Strip debug info from release binaries via -Dstrip build option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           version: 0.16.0
 
       - name: Build release binaries
-        run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }}
+        run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=true
 
       - name: Sign and notarize macOS binaries
         if: matrix.target == 'aarch64-macos'

--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,9 @@ pub fn build(b: *std.Build) void {
     // Single-step: compile and embed in one build
     const bundle_src = b.option([]const u8, "bundle-src", "Path to .scm source file to compile and embed for standalone binary");
 
+    const do_strip = b.option(bool, "strip", "Strip debug info from binaries (for release builds)") orelse false;
+    const strip: ?bool = if (do_strip) true else null;
+
     const max_frames = b.option(u32, "max-frames", "Maximum call frame depth (default: 480)") orelse 480;
     const max_registers = b.option(u32, "max-registers", "Maximum register count (default: 2048)") orelse 2048;
 
@@ -39,6 +42,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+        .strip = strip,
         .single_threaded = if (is_wasm_target) true else null,
     });
     main_mod.addImport("build_options", options.createModule());
@@ -178,6 +182,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+        .strip = strip,
     });
     const thottam_exe = b.addExecutable(.{
         .name = "thottam",
@@ -192,6 +197,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+        .strip = strip,
     });
     lsp_mod.addImport("build_options", options.createModule());
     lsp_mod.addAnonymousImport("embedded_bytecode", .{


### PR DESCRIPTION
## Summary
- Added `-Dstrip` build option that strips DWARF debug info from shipped binaries (kaappi, thottam, kaappi-lsp)
- Release workflow now passes `-Dstrip=true`
- Test/bench/coverage modules are **not** stripped (they need debug info)

## Size reduction

| Binary | Before | After | Reduction |
|--------|--------|-------|-----------|
| kaappi (x86_64-linux) | 9.57 MB | 1.71 MB | **82%** |
| thottam (x86_64-linux) | 4.34 MB | 440 KB | **90%** |
| kaappi (aarch64-macos) | 1.85 MB | 1.40 MB | **24%** |
| thottam (aarch64-macos) | 497 KB | 239 KB | **52%** |

The macOS reduction is smaller because Zig's Mach-O linker already uses the debug-map model (DWARF stays in `.o` files, not the binary).

## Test plan
- [x] Stripped binary runs and passes all Scheme tests (1481 pass, 0 fail)
- [x] Unit tests still pass (unstripped, as intended)
- [x] Cross-compiled x86_64-linux stripped binary verified
- [x] Default build (no `-Dstrip`) unchanged

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)