### PR TITLE
Fix SRFI-18 thread data races: globals marking, symbol mutex, fiber result

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1253,14 +1253,16 @@ pub const GC = struct {
         // Mark active FFI callback closures
         const ffi_cb = @import("ffi_callback.zig");
         ffi_cb.markCallbackRoots(self);
-        // Mark interned symbols (take mutex when the table may be shared
-        // with a child thread that concurrently interns symbols)
-        spinLock(&symbol_mutex);
+        // Mark interned symbols. Use tryLock to avoid deadlock when GC is
+        // triggered from within allocSymbol (which already holds the mutex).
+        // If we can't get the lock, symbol values are already reachable via
+        // the globals map — they won't be collected.
+        const got_sym_lock = symbol_mutex.tryLock();
         var it = self.symbols.valueIterator();
         while (it.next()) |v| {
             self.markValue(v.*);
         }
-        spinUnlock(&symbol_mutex);
+        if (got_sym_lock) symbol_mutex.unlock();
         // Mark VM-owned roots (live registers, call frames, handlers, winds).
         if (self.root_marker) |mark| mark(self);
     }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -11,6 +11,8 @@ const PrimitiveError = primitives.PrimitiveError;
 const ChildThreadResources = struct {
     child_gc: *memory.GC,
     child_vm: *vm_mod.VM,
+    result: Value = types.VOID,
+    exception: ?Value = null,
 };
 
 var child_resources: std.AutoHashMap(usize, ChildThreadResources) = std.AutoHashMap(usize, ChildThreadResources).init(std.heap.page_allocator);
@@ -241,25 +243,34 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_g
 
     const child_thunk = child_gc.deepCopy(fiber.thunk) catch |err| {
         fiber.status = .errored;
-        fiber.result = types.VOID;
         if (err == error.UncopyableType) {
-            fiber.current_exception = child_gc.allocErrorObject(
+            const exc = child_gc.allocErrorObject(
                 child_gc.allocString("thread thunk contains uncopyable type (port, continuation, etc.)") catch types.VOID,
                 types.NIL,
             ) catch null;
+            storeChildResult(@intFromPtr(fiber), types.VOID, exc);
         }
         return;
     };
 
     const result = child_vm.callWithArgs(child_thunk, &.{}) catch {
         fiber.status = .errored;
-        fiber.result = types.VOID;
-
         return;
     };
 
+    // Store result in child_resources (not on the fiber) so the parent
+    // GC never traverses a child-heap pointer (Race C).
+    storeChildResult(@intFromPtr(fiber), result, null);
     fiber.status = .completed;
-    fiber.result = result;
+}
+
+fn storeChildResult(fiber_key: usize, result: Value, exception: ?Value) void {
+    while (!child_resources_mutex.tryLock()) {}
+    defer child_resources_mutex.unlock();
+    if (child_resources.getPtr(fiber_key)) |entry| {
+        entry.result = result;
+        entry.exception = exception;
+    }
 }
 
 fn threadYieldFn(_: []const Value) PrimitiveError!Value {
@@ -312,7 +323,7 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
 
     const target = types.toObject(args[0]).as(fiber_mod.Fiber);
 
-    // OS thread path: join, deep-copy result, free child GC/VM
+    // OS thread path: join, deep-copy result from child heap, free child resources
     if (target.os_thread) |thread| {
         thread.join();
         target.os_thread = null;
@@ -320,19 +331,29 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
         const fiber_key = @intFromPtr(target);
 
-        if (target.status == .completed and target.result != types.VOID) {
-            target.result = gc.deepCopy(target.result) catch |err| {
-                target.result = types.VOID;
-                freeChildResources(fiber_key);
-                if (err == error.UncopyableType) {
-                    return raiseError(.general, "thread-join!: result contains uncopyable type (port, continuation, etc.)", types.VOID);
+        // Retrieve result/exception from child_resources (stored there to
+        // avoid the parent GC traversing child-heap pointers via the fiber).
+        {
+            while (!child_resources_mutex.tryLock()) {}
+            const entry = child_resources.get(fiber_key);
+            child_resources_mutex.unlock();
+
+            if (entry) |res| {
+                if (target.status == .completed and res.result != types.VOID) {
+                    target.result = gc.deepCopy(res.result) catch |err| {
+                        target.result = types.VOID;
+                        freeChildResources(fiber_key);
+                        if (err == error.UncopyableType) {
+                            return raiseError(.general, "thread-join!: result contains uncopyable type (port, continuation, etc.)", types.VOID);
+                        }
+                        return PrimitiveError.OutOfMemory;
+                    };
                 }
-                return PrimitiveError.OutOfMemory;
-            };
-        }
-        if (target.status == .errored) {
-            if (target.current_exception) |exc| {
-                target.current_exception = gc.deepCopy(exc) catch null;
+                if (target.status == .errored) {
+                    if (res.exception) |exc| {
+                        target.current_exception = gc.deepCopy(exc) catch null;
+                    }
+                }
             }
         }
         freeChildResources(fiber_key);

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -78,10 +78,16 @@ fn markVMRoots(gc: *memory.GC) void {
     if (vm.current_exception) |exc| gc.markValue(exc);
     gc.markValue(vm.continuation_value);
 
-    var git = vm.globals.valueIterator();
-    while (git.next()) |v| gc.markValue(v.*);
-    var mit = vm.macros.valueIterator();
-    while (mit.next()) |v| gc.markValue(v.*);
+    // Only mark globals/macros when this VM owns them. Child threads
+    // share the parent's maps — the parent GC keeps those values alive.
+    // Marking them here would write mark bits on parent-heap objects
+    // without synchronization (data race).
+    if (vm.owns_globals) {
+        var git = vm.globals.valueIterator();
+        while (git.next()) |v| gc.markValue(v.*);
+        var mit = vm.macros.valueIterator();
+        while (mit.next()) |v| gc.markValue(v.*);
+    }
 
     var pit = vm.param_overrides.valueIterator();
     while (pit.next()) |v| gc.markValue(v.*);

--- a/tests/scheme/srfi/srfi18-globals-race.scm
+++ b/tests/scheme/srfi/srfi18-globals-race.scm
@@ -1,0 +1,42 @@
+;; Regression test for issue #77:
+;; Child threads must not crash when the parent defines globals concurrently.
+;; Before the fix, the parent's globals.put could rehash the map while
+;; the child was mid-get, causing a torn read / use-after-free.
+
+(import (scheme base) (scheme write) (srfi 18))
+
+;; Spawn a worker that reads a global in a loop
+(define counter 0)
+(define (worker-thunk)
+  (let loop ((i 0))
+    (when (< i 1000)
+      (+ counter 1)
+      (loop (+ i 1))))
+  'done)
+
+;; Spawn 3 workers
+(define threads
+  (map (lambda (_)
+         (thread-start! (make-thread worker-thunk)))
+       '(1 2 3)))
+
+;; Meanwhile, define new globals from the main thread
+(let loop ((i 0))
+  (when (< i 100)
+    (eval `(define ,(string->symbol
+                     (string-append "temp-var-" (number->string i)))
+             ,i))
+    (loop (+ i 1))))
+
+;; Join all workers
+(for-each (lambda (t)
+            (let ((r (thread-join! t)))
+              (unless (eq? r 'done)
+                (display "FAIL: unexpected result ")
+                (display r)
+                (newline)
+                (exit 1))))
+          threads)
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary

Three fixes for the remaining SRFI-18 thread data races:

- **Race A (globals/macros):** Child thread's GC no longer marks parent-owned globals/macros values via `markVMRoots`. When `owns_globals == false`, globals iteration is skipped — the parent GC keeps those values alive. This eliminates unsynchronized cross-heap mark-bit writes.

- **Race B (symbol table):** Changed `markRoots` from `spinLock` to `tryLock` for `symbol_mutex`, fixing a deadlock where GC triggered from within `allocSymbol` (which holds the mutex) would re-lock → deadlock.

- **Race C (fiber result):** Child thread now stores its result in the `child_resources` map (protected by mutex) instead of directly on the parent-heap `Fiber` object. The join path retrieves and deep-copies it. This prevents the parent GC from traversing a child-heap pointer between child completion and join.

## Test plan
- [x] `srfi18-gc-stress.scm` — concurrent thread returns with GC pressure pass
- [x] `srfi18-deepcopy-reject.scm` — uncopyable type handling passes
- [x] `srfi18-globals-race.scm` — new test: workers read globals while parent defines new ones concurrently
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1481 pass, 0 fail

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)