### PR TITLE
Add and/or/when/unless IR nodes with emission and behavioral tests

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -294,6 +294,10 @@ pub const Compiler = struct {
             .call => try self.compileCallFromIR(node.data.call, dst, is_tail),
             .@"if" => try self.compileIfFromIR(node.data.@"if", dst, is_tail),
             .begin => try self.compileBeginFromIR(node.data.begin, dst, is_tail),
+            .and_form => try self.compileAndFromIR(node.data.and_form, dst, is_tail),
+            .or_form => try self.compileOrFromIR(node.data.or_form, dst, is_tail),
+            .when_form => try self.compileWhenFromIR(node.data.when_form, dst, is_tail),
+            .unless_form => try self.compileUnlessFromIR(node.data.unless_form, dst, is_tail),
             .passthrough => try self.compileExpr(node.data.passthrough, dst, is_tail),
         }
     }
@@ -426,6 +430,96 @@ pub const Compiler = struct {
             try self.emitU16(base);
             self.freeReg();
         }
+    }
+
+    fn compileAndFromIR(self: *Compiler, exprs: []const *ir_mod.Node, dst: u16, is_tail: bool) CompileError!void {
+        if (exprs.len == 0) {
+            try self.emitOp(.load_true);
+            try self.emitU16(dst);
+            return;
+        }
+        var end_jumps: std.ArrayList(usize) = .empty;
+        defer end_jumps.deinit(self.gc.allocator);
+        for (exprs, 0..) |expr, i| {
+            if (i == exprs.len - 1) {
+                try self.compileFromNode(expr, dst, is_tail);
+            } else {
+                try self.compileFromNode(expr, dst, false);
+                try self.emitOp(.jump_false);
+                try self.emitU16(dst);
+                end_jumps.append(self.gc.allocator, self.currentOffset()) catch return CompileError.TooManyLocals;
+                try self.emitI16(0);
+            }
+        }
+        for (end_jumps.items) |j| {
+            try self.patchJump(j);
+        }
+    }
+
+    fn compileOrFromIR(self: *Compiler, exprs: []const *ir_mod.Node, dst: u16, is_tail: bool) CompileError!void {
+        if (exprs.len == 0) {
+            try self.emitOp(.load_false);
+            try self.emitU16(dst);
+            return;
+        }
+        var end_jumps: std.ArrayList(usize) = .empty;
+        defer end_jumps.deinit(self.gc.allocator);
+        for (exprs, 0..) |expr, i| {
+            if (i == exprs.len - 1) {
+                try self.compileFromNode(expr, dst, is_tail);
+            } else {
+                try self.compileFromNode(expr, dst, false);
+                try self.emitOp(.jump_true);
+                try self.emitU16(dst);
+                end_jumps.append(self.gc.allocator, self.currentOffset()) catch return CompileError.TooManyLocals;
+                try self.emitI16(0);
+            }
+        }
+        for (end_jumps.items) |j| {
+            try self.patchJump(j);
+        }
+    }
+
+    fn compileWhenFromIR(self: *Compiler, data: ir_mod.CondBodyData, dst: u16, is_tail: bool) CompileError!void {
+        try self.compileFromNode(data.test_expr, dst, false);
+        try self.emitOp(.jump_false);
+        try self.emitU16(dst);
+        const false_jump = self.currentOffset();
+        try self.emitI16(0);
+
+        for (data.body, 0..) |expr, i| {
+            const tail = is_tail and i == data.body.len - 1;
+            try self.compileFromNode(expr, dst, tail);
+        }
+
+        try self.emitOp(.jump);
+        const end_jump = self.currentOffset();
+        try self.emitI16(0);
+        try self.patchJump(false_jump);
+        try self.emitOp(.load_void);
+        try self.emitU16(dst);
+        try self.patchJump(end_jump);
+    }
+
+    fn compileUnlessFromIR(self: *Compiler, data: ir_mod.CondBodyData, dst: u16, is_tail: bool) CompileError!void {
+        try self.compileFromNode(data.test_expr, dst, false);
+        try self.emitOp(.jump_true);
+        try self.emitU16(dst);
+        const true_jump = self.currentOffset();
+        try self.emitI16(0);
+
+        for (data.body, 0..) |expr, i| {
+            const tail = is_tail and i == data.body.len - 1;
+            try self.compileFromNode(expr, dst, tail);
+        }
+
+        try self.emitOp(.jump);
+        const end_jump = self.currentOffset();
+        try self.emitI16(0);
+        try self.patchJump(true_jump);
+        try self.emitOp(.load_void);
+        try self.emitU16(dst);
+        try self.patchJump(end_jump);
     }
 
     pub fn compileMultiple(self: *Compiler, exprs: []const Value) CompileError!void {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -13,6 +13,10 @@ pub const NodeTag = enum {
     call,
     @"if",
     begin,
+    and_form,
+    or_form,
+    when_form,
+    unless_form,
     passthrough,
 };
 
@@ -26,8 +30,17 @@ pub const Node = struct {
         call: CallData,
         @"if": IfData,
         begin: []const *Node,
+        and_form: []const *Node,
+        or_form: []const *Node,
+        when_form: CondBodyData,
+        unless_form: CondBodyData,
         passthrough: Value,
     };
+};
+
+pub const CondBodyData = struct {
+    test_expr: *Node,
+    body: []const *Node,
 };
 
 pub const CallData = struct {
@@ -63,6 +76,10 @@ pub const IR = struct {
         switch (node.tag) {
             .call => self.allocator.free(node.data.call.args),
             .begin => self.allocator.free(node.data.begin),
+            .and_form => self.allocator.free(node.data.and_form),
+            .or_form => self.allocator.free(node.data.or_form),
+            .when_form => self.allocator.free(node.data.when_form.body),
+            .unless_form => self.allocator.free(node.data.unless_form.body),
             .constant, .global_ref, .@"if", .passthrough => {},
         }
         self.allocator.destroy(node);
@@ -97,6 +114,30 @@ pub const IR = struct {
         const copy = self.allocator.alloc(*Node, exprs.len) catch return CompileError.OutOfMemory;
         @memcpy(copy, exprs);
         return self.allocNode(.begin, .{ .begin = copy });
+    }
+
+    pub fn makeAnd(self: *IR, exprs: []const *Node) CompileError!*Node {
+        const copy = self.allocator.alloc(*Node, exprs.len) catch return CompileError.OutOfMemory;
+        @memcpy(copy, exprs);
+        return self.allocNode(.and_form, .{ .and_form = copy });
+    }
+
+    pub fn makeOr(self: *IR, exprs: []const *Node) CompileError!*Node {
+        const copy = self.allocator.alloc(*Node, exprs.len) catch return CompileError.OutOfMemory;
+        @memcpy(copy, exprs);
+        return self.allocNode(.or_form, .{ .or_form = copy });
+    }
+
+    pub fn makeWhen(self: *IR, test_expr: *Node, body: []const *Node) CompileError!*Node {
+        const copy = self.allocator.alloc(*Node, body.len) catch return CompileError.OutOfMemory;
+        @memcpy(copy, body);
+        return self.allocNode(.when_form, .{ .when_form = .{ .test_expr = test_expr, .body = copy } });
+    }
+
+    pub fn makeUnless(self: *IR, test_expr: *Node, body: []const *Node) CompileError!*Node {
+        const copy = self.allocator.alloc(*Node, body.len) catch return CompileError.OutOfMemory;
+        @memcpy(copy, body);
+        return self.allocNode(.unless_form, .{ .unless_form = .{ .test_expr = test_expr, .body = copy } });
     }
 
     pub fn makePassthrough(self: *IR, expr: Value) CompileError!*Node {
@@ -166,6 +207,10 @@ fn lowerForm(ir: *IR, expr: Value) CompileError!*Node {
         if (std.mem.eql(u8, effective_name, "if")) return lowerIf(ir, types.cdr(expr));
         if (std.mem.eql(u8, effective_name, "quote")) return lowerQuote(ir, types.cdr(expr));
         if (std.mem.eql(u8, effective_name, "begin")) return lowerBegin(ir, types.cdr(expr));
+        if (std.mem.eql(u8, effective_name, "and")) return lowerList(ir, types.cdr(expr), .and_form);
+        if (std.mem.eql(u8, effective_name, "or")) return lowerList(ir, types.cdr(expr), .or_form);
+        if (std.mem.eql(u8, effective_name, "when")) return lowerCondBody(ir, types.cdr(expr), .when_form);
+        if (std.mem.eql(u8, effective_name, "unless")) return lowerCondBody(ir, types.cdr(expr), .unless_form);
 
         // All other named forms (special forms, macros, user-defined) use
         // passthrough — the compiler handles macro expansion, local-variable
@@ -218,6 +263,45 @@ fn lowerBegin(ir: *IR, args: Value) CompileError!*Node {
         current = types.cdr(current);
     }
     return ir.makeBegin(buf[0..count]);
+}
+
+fn lowerList(ir: *IR, args: Value, tag: NodeTag) CompileError!*Node {
+    var buf: [256]*Node = undefined;
+    var count: usize = 0;
+    var current = args;
+    while (current != types.NIL) {
+        if (!types.isPair(current)) return CompileError.InvalidSyntax;
+        if (count >= 256) return CompileError.InternalLimit;
+        buf[count] = try lower(ir, types.car(current));
+        count += 1;
+        current = types.cdr(current);
+    }
+    return switch (tag) {
+        .and_form => ir.makeAnd(buf[0..count]),
+        .or_form => ir.makeOr(buf[0..count]),
+        else => ir.makeBegin(buf[0..count]),
+    };
+}
+
+fn lowerCondBody(ir: *IR, args: Value, tag: NodeTag) CompileError!*Node {
+    if (args == types.NIL) return CompileError.InvalidSyntax;
+    const test_expr = try lower(ir, types.car(args));
+
+    var buf: [256]*Node = undefined;
+    var count: usize = 0;
+    var current = types.cdr(args);
+    while (current != types.NIL) {
+        if (!types.isPair(current)) return CompileError.InvalidSyntax;
+        if (count >= 256) return CompileError.InternalLimit;
+        buf[count] = try lower(ir, types.car(current));
+        count += 1;
+        current = types.cdr(current);
+    }
+    return switch (tag) {
+        .when_form => ir.makeWhen(test_expr, buf[0..count]),
+        .unless_form => ir.makeUnless(test_expr, buf[0..count]),
+        else => unreachable,
+    };
 }
 
 fn lowerCall(ir: *IR, expr: Value) CompileError!*Node {
@@ -337,6 +421,7 @@ pub const Emitter = struct {
             .call => try self.emitCall(node.data.call, dst, is_tail),
             .@"if" => try self.emitIf(node.data.@"if", dst, is_tail),
             .begin => try self.emitBegin(node.data.begin, dst, is_tail),
+            .and_form, .or_form, .when_form, .unless_form => return CompileError.NotImplemented,
             .passthrough => return CompileError.NotImplemented,
         }
     }

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -125,3 +125,87 @@ test "IR parity: unary constant fold (zero?)" {
 test "IR parity: constant fold multiplication" {
     try expectBytecodeParity("(* 6 7)");
 }
+
+test "IR behavioral: and with true" {
+    try expectBehavioralParity("(and 1 2 3)");
+}
+
+test "IR behavioral: and short-circuit" {
+    try expectBehavioralParity("(and 1 #f 3)");
+}
+
+test "IR behavioral: and empty" {
+    try expectBehavioralParity("(and)");
+}
+
+test "IR behavioral: or with false" {
+    try expectBehavioralParity("(or #f #f 3)");
+}
+
+test "IR behavioral: or short-circuit" {
+    try expectBehavioralParity("(or 1 2 3)");
+}
+
+test "IR behavioral: or empty" {
+    try expectBehavioralParity("(or)");
+}
+
+test "IR behavioral: when true" {
+    try expectBehavioralParity("(when #t 42)");
+}
+
+test "IR behavioral: when false" {
+    try expectBehavioralParity("(when #f 42)");
+}
+
+test "IR behavioral: unless true" {
+    try expectBehavioralParity("(unless #t 42)");
+}
+
+test "IR behavioral: unless false" {
+    try expectBehavioralParity("(unless #f 42)");
+}
+
+test "IR behavioral: begin with define" {
+    try expectBehavioralParity("(begin (define x 1) (define y 2) (+ x y))");
+}
+
+test "IR behavioral: lambda and call" {
+    try expectBehavioralParity("((lambda (x) (+ x 1)) 41)");
+}
+
+test "IR behavioral: let binding" {
+    try expectBehavioralParity("(let ((x 10) (y 20)) (+ x y))");
+}
+
+test "IR behavioral: define and call" {
+    try expectBehavioralParity("(define (f x) (* x x)) (f 7)");
+}
+
+test "IR behavioral: set!" {
+    try expectBehavioralParity("(define x 1) (set! x 42) x");
+}
+
+test "IR behavioral: cond" {
+    try expectBehavioralParity("(cond (#f 1) (#t 2) (else 3))");
+}
+
+test "IR behavioral: case" {
+    try expectBehavioralParity("(case (+ 1 1) ((1) 10) ((2) 20) (else 30))");
+}
+
+test "IR behavioral: do loop" {
+    try expectBehavioralParity("(do ((i 0 (+ i 1))) ((= i 5) i))");
+}
+
+test "IR behavioral: guard" {
+    try expectBehavioralParity("(guard (e (#t 42)) (error \"test\"))");
+}
+
+test "IR behavioral: quasiquote" {
+    try expectBehavioralParity("(let ((x 5)) `(a ,x b))");
+}
+
+test "IR behavioral: macros" {
+    try expectBehavioralParity("(define-syntax my-add (syntax-rules () ((my-add a b) (+ a b)))) (my-add 3 4)");
+}


### PR DESCRIPTION
## Summary

- Adds 4 new IR node types: `and`, `or`, `when`, `unless` with proper lowering and emission
- and/or use short-circuit jump patterns matching the existing compiler
- when/unless use conditional jump patterns (jump_false/jump_true respectively)
- 18 new behavioral parity tests covering the new forms plus lambda, let, define, set!, cond, case, do, guard, quasiquote, and macros

Forms now handled as proper IR nodes: constants, global refs, if, begin, and, or, when, unless, quote, constant-folded arithmetic. All other forms use passthrough.

Part of #93, toward #95.

## Test plan

- [x] `zig build test` passes (all unit tests including 37 IR tests)
- [x] `bash tests/scheme/run-all.sh` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)