### PR TITLE
Add define and set! IR nodes with scope-aware emission

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -298,6 +298,8 @@ pub const Compiler = struct {
             .or_form => try self.compileOrFromIR(node.data.or_form, dst, is_tail),
             .when_form => try self.compileWhenFromIR(node.data.when_form, dst, is_tail),
             .unless_form => try self.compileUnlessFromIR(node.data.unless_form, dst, is_tail),
+            .define => try self.compileDefineFromIR(node.data.define, dst),
+            .set_form => try self.compileSetFromIR(node.data.set_form, dst),
             .passthrough => try self.compileExpr(node.data.passthrough, dst, is_tail),
         }
     }
@@ -430,6 +432,69 @@ pub const Compiler = struct {
             try self.emitU16(base);
             self.freeReg();
         }
+    }
+
+    fn compileDefineFromIR(self: *Compiler, data: ir_mod.DefineData, dst: u16) CompileError!void {
+        try self.compileExpr(data.value, dst, false);
+
+        if (self.func.constants.items.len > 0) {
+            const last_const = self.func.constants.items[self.func.constants.items.len - 1];
+            if (types.isFunction(last_const)) {
+                const child_func = types.toObject(last_const).as(types.Function);
+                if (child_func.name == null) {
+                    child_func.name = types.symbolName(data.name);
+                }
+            }
+        }
+
+        if (self.in_body_scope) {
+            const slot = try self.allocReg();
+            try self.emitOp(.move);
+            try self.emitU16(slot);
+            try self.emitU16(dst);
+            self.locals.append(self.gc.allocator, .{
+                .name = types.symbolName(data.name),
+                .depth = self.scope_depth,
+                .slot = slot,
+            }) catch return CompileError.OutOfMemory;
+            try self.emitOp(.load_void);
+            try self.emitU16(dst);
+            return;
+        }
+        const sym_idx = try self.addConstant(data.name);
+        try self.emitOp(.define_global);
+        try self.emitU16(sym_idx);
+        try self.emitU16(dst);
+        try self.emitOp(.load_void);
+        try self.emitU16(dst);
+    }
+
+    fn compileSetFromIR(self: *Compiler, data: ir_mod.SetData, dst: u16) CompileError!void {
+        const name = types.symbolName(data.name);
+        try self.compileExpr(data.value, dst, false);
+
+        if (self.resolveLocal(name)) |slot| {
+            if (self.isLocalBoxed(name)) {
+                try self.emitOp(.set_box_local);
+                try self.emitU16(slot);
+                try self.emitU16(dst);
+            } else {
+                try self.emitOp(.move);
+                try self.emitU16(slot);
+                try self.emitU16(dst);
+            }
+        } else if (try self.resolveUpvalue(name)) |idx| {
+            try self.emitOp(.set_upvalue);
+            try self.emitU16(idx);
+            try self.emitU16(dst);
+        } else {
+            const sym_idx = try self.addConstant(data.name);
+            try self.emitOp(.set_global);
+            try self.emitU16(sym_idx);
+            try self.emitU16(dst);
+        }
+        try self.emitOp(.load_void);
+        try self.emitU16(dst);
     }
 
     fn compileAndFromIR(self: *Compiler, exprs: []const *ir_mod.Node, dst: u16, is_tail: bool) CompileError!void {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -17,6 +17,8 @@ pub const NodeTag = enum {
     or_form,
     when_form,
     unless_form,
+    define,
+    set_form,
     passthrough,
 };
 
@@ -34,8 +36,20 @@ pub const Node = struct {
         or_form: []const *Node,
         when_form: CondBodyData,
         unless_form: CondBodyData,
+        define: DefineData,
+        set_form: SetData,
         passthrough: Value,
     };
+};
+
+pub const DefineData = struct {
+    name: Value,
+    value: Value,
+};
+
+pub const SetData = struct {
+    name: Value,
+    value: Value,
 };
 
 pub const CondBodyData = struct {
@@ -80,7 +94,7 @@ pub const IR = struct {
             .or_form => self.allocator.free(node.data.or_form),
             .when_form => self.allocator.free(node.data.when_form.body),
             .unless_form => self.allocator.free(node.data.unless_form.body),
-            .constant, .global_ref, .@"if", .passthrough => {},
+            .constant, .global_ref, .@"if", .define, .set_form, .passthrough => {},
         }
         self.allocator.destroy(node);
     }
@@ -138,6 +152,14 @@ pub const IR = struct {
         const copy = self.allocator.alloc(*Node, body.len) catch return CompileError.OutOfMemory;
         @memcpy(copy, body);
         return self.allocNode(.unless_form, .{ .unless_form = .{ .test_expr = test_expr, .body = copy } });
+    }
+
+    pub fn makeDefine(self: *IR, name: Value, value: Value) CompileError!*Node {
+        return self.allocNode(.define, .{ .define = .{ .name = name, .value = value } });
+    }
+
+    pub fn makeSet(self: *IR, name: Value, value: Value) CompileError!*Node {
+        return self.allocNode(.set_form, .{ .set_form = .{ .name = name, .value = value } });
     }
 
     pub fn makePassthrough(self: *IR, expr: Value) CompileError!*Node {
@@ -207,6 +229,8 @@ fn lowerForm(ir: *IR, expr: Value) CompileError!*Node {
         if (std.mem.eql(u8, effective_name, "if")) return lowerIf(ir, types.cdr(expr));
         if (std.mem.eql(u8, effective_name, "quote")) return lowerQuote(ir, types.cdr(expr));
         if (std.mem.eql(u8, effective_name, "begin")) return lowerBegin(ir, types.cdr(expr));
+        if (std.mem.eql(u8, effective_name, "define")) return lowerDefine(ir, expr);
+        if (std.mem.eql(u8, effective_name, "set!")) return lowerSet(ir, types.cdr(expr));
         if (std.mem.eql(u8, effective_name, "and")) return lowerList(ir, types.cdr(expr), .and_form);
         if (std.mem.eql(u8, effective_name, "or")) return lowerList(ir, types.cdr(expr), .or_form);
         if (std.mem.eql(u8, effective_name, "when")) return lowerCondBody(ir, types.cdr(expr), .when_form);
@@ -263,6 +287,26 @@ fn lowerBegin(ir: *IR, args: Value) CompileError!*Node {
         current = types.cdr(current);
     }
     return ir.makeBegin(buf[0..count]);
+}
+
+fn lowerDefine(ir: *IR, expr: Value) CompileError!*Node {
+    const args = types.cdr(expr);
+    if (args == types.NIL) return CompileError.InvalidSyntax;
+    const target = types.car(args);
+    if (types.isPair(target)) return ir.makePassthrough(expr);
+    if (!types.isSymbol(target)) return CompileError.InvalidSyntax;
+    const rest = types.cdr(args);
+    if (rest == types.NIL) return CompileError.InvalidSyntax;
+    return ir.makeDefine(target, types.car(rest));
+}
+
+fn lowerSet(ir: *IR, args: Value) CompileError!*Node {
+    if (args == types.NIL) return CompileError.InvalidSyntax;
+    const name = types.car(args);
+    if (!types.isSymbol(name)) return CompileError.InvalidSyntax;
+    const rest = types.cdr(args);
+    if (rest == types.NIL) return CompileError.InvalidSyntax;
+    return ir.makeSet(name, types.car(rest));
 }
 
 fn lowerList(ir: *IR, args: Value, tag: NodeTag) CompileError!*Node {
@@ -421,7 +465,7 @@ pub const Emitter = struct {
             .call => try self.emitCall(node.data.call, dst, is_tail),
             .@"if" => try self.emitIf(node.data.@"if", dst, is_tail),
             .begin => try self.emitBegin(node.data.begin, dst, is_tail),
-            .and_form, .or_form, .when_form, .unless_form => return CompileError.NotImplemented,
+            .and_form, .or_form, .when_form, .unless_form, .define, .set_form => return CompileError.NotImplemented,
             .passthrough => return CompileError.NotImplemented,
         }
     }


### PR DESCRIPTION
## Summary

- Adds `define` and `set!` as proper IR nodes (simple define form only; function shorthand stays passthrough)
- `define` emission handles both top-level (`define_global`) and body-scope (local variable) paths
- `set!` emission handles local/upvalue/global paths using the Compiler's scope state
- Function name setting on lambda constants preserved for debugging

IR nodes now covering: constants, global refs, if, begin, and, or, when, unless, define (simple), set!, quote, constant-folded arithmetic. Remaining forms use passthrough.

Part of #93, toward #95.

## Test plan

- [x] `zig build test` passes (all unit tests)
- [x] `bash tests/scheme/run-all.sh` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)