### PR TITLE
Add tail-position analysis pass and annotations infrastructure

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -265,10 +265,11 @@ pub const Compiler = struct {
         try self.gc.pushRoot(&expr_root);
         defer self.gc.popRoot();
 
-        // Lower AST to IR, then emit bytecode from the IR tree.
+        // Lower AST to IR, run analysis, then emit bytecode.
         var ir = ir_mod.IR.init(self.gc.allocator);
         defer ir.deinit();
         const root = try ir_mod.lower(&ir, expr_root);
+        ir_mod.markTailPositions(root, false);
 
         const dst = try self.allocReg();
         try self.compileFromNode(root, dst, false);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -44,9 +44,14 @@ pub const NodeTag = enum {
     passthrough,
 };
 
+pub const Annotations = struct {
+    is_tail: bool = false,
+};
+
 pub const Node = struct {
     tag: NodeTag,
     data: Data,
+    ann: Annotations = .{},
 
     const Data = union {
         constant: Value,
@@ -590,6 +595,78 @@ fn tryFoldFromAST(ir: *IR, expr: Value) ?*Node {
 
     if (result) |val| return ir.makeConst(val) catch null;
     return null;
+}
+
+// ---------------------------------------------------------------------------
+// Semantic analysis: tail-position marking
+// ---------------------------------------------------------------------------
+
+pub fn markTailPositions(node: *Node, is_tail: bool) void {
+    node.ann.is_tail = is_tail;
+    switch (node.tag) {
+        .@"if" => {
+            markTailPositions(node.data.@"if".test_expr, false);
+            markTailPositions(node.data.@"if".consequent, is_tail);
+            if (node.data.@"if".alternate) |alt| markTailPositions(alt, is_tail);
+        },
+        .begin => {
+            for (node.data.begin, 0..) |expr, i| {
+                markTailPositions(expr, is_tail and i == node.data.begin.len - 1);
+            }
+        },
+        .and_form => {
+            for (node.data.and_form, 0..) |expr, i| {
+                markTailPositions(expr, is_tail and i == node.data.and_form.len - 1);
+            }
+        },
+        .or_form => {
+            for (node.data.or_form, 0..) |expr, i| {
+                markTailPositions(expr, is_tail and i == node.data.or_form.len - 1);
+            }
+        },
+        .when_form => {
+            markTailPositions(node.data.when_form.test_expr, false);
+            for (node.data.when_form.body, 0..) |expr, i| {
+                markTailPositions(expr, is_tail and i == node.data.when_form.body.len - 1);
+            }
+        },
+        .unless_form => {
+            markTailPositions(node.data.unless_form.test_expr, false);
+            for (node.data.unless_form.body, 0..) |expr, i| {
+                markTailPositions(expr, is_tail and i == node.data.unless_form.body.len - 1);
+            }
+        },
+        .call => {
+            markTailPositions(node.data.call.operator, false);
+            for (node.data.call.args) |arg| markTailPositions(arg, false);
+        },
+        .constant, .global_ref, .passthrough => {},
+        .define,
+        .set_form,
+        .lambda,
+        .let_form,
+        .let_star,
+        .letrec,
+        .letrec_star,
+        .do_form,
+        .delay,
+        .delay_force,
+        .cond,
+        .case_form,
+        .case_lambda,
+        .guard,
+        .quasiquote,
+        .parameterize,
+        .define_values,
+        .let_values,
+        .let_star_values,
+        .define_syntax,
+        .named_let,
+        .let_syntax,
+        .letrec_syntax,
+        .cond_expand,
+        => {},
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -209,3 +209,63 @@ test "IR behavioral: quasiquote" {
 test "IR behavioral: macros" {
     try expectBehavioralParity("(define-syntax my-add (syntax-rules () ((my-add a b) (+ a b)))) (my-add 3 4)");
 }
+
+// --- Semantic analysis tests ---
+
+test "IR analysis: tail position in if" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+    const root = try ir_mod.lower(&ir, try readExpr(&gc, "(if #t 1 2)"));
+    ir_mod.markTailPositions(root, false);
+    try std.testing.expect(!root.ann.is_tail);
+    try std.testing.expect(root.tag == .@"if");
+    try std.testing.expect(!root.data.@"if".test_expr.ann.is_tail);
+    try std.testing.expect(!root.data.@"if".consequent.ann.is_tail);
+    try std.testing.expect(!root.data.@"if".alternate.?.ann.is_tail);
+}
+
+test "IR analysis: tail position propagates through if" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+    const root = try ir_mod.lower(&ir, try readExpr(&gc, "(if #t 1 2)"));
+    ir_mod.markTailPositions(root, true);
+    try std.testing.expect(root.ann.is_tail);
+    try std.testing.expect(!root.data.@"if".test_expr.ann.is_tail);
+    try std.testing.expect(root.data.@"if".consequent.ann.is_tail);
+    try std.testing.expect(root.data.@"if".alternate.?.ann.is_tail);
+}
+
+test "IR analysis: tail position in begin" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+    const root = try ir_mod.lower(&ir, try readExpr(&gc, "(begin 1 2 3)"));
+    ir_mod.markTailPositions(root, true);
+    try std.testing.expect(root.ann.is_tail);
+    try std.testing.expect(!root.data.begin[0].ann.is_tail);
+    try std.testing.expect(!root.data.begin[1].ann.is_tail);
+    try std.testing.expect(root.data.begin[2].ann.is_tail);
+}
+
+test "IR analysis: tail position in and/or" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+    const root = try ir_mod.lower(&ir, try readExpr(&gc, "(and 1 2 3)"));
+    ir_mod.markTailPositions(root, true);
+    try std.testing.expect(!root.data.and_form[0].ann.is_tail);
+    try std.testing.expect(!root.data.and_form[1].ann.is_tail);
+    try std.testing.expect(root.data.and_form[2].ann.is_tail);
+}
+
+fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
+    var reader = reader_mod.Reader.init(gc, source);
+    defer reader.deinit();
+    return reader.readDatum();
+}


### PR DESCRIPTION
## Summary

- Introduces `Annotations` struct on IR nodes with `is_tail` field
- Implements `markTailPositions()` analysis pass that traverses the IR tree
- Integrated into `compile()` — analysis runs after lowering, before emission
- 4 unit tests asserting tail-position analysis independently of emission

Tail position propagation rules:
- `if`: test is never tail; consequent/alternate inherit parent's tail status
- `begin`: only last expression inherits tail
- `and`/`or`: only last expression inherits tail  
- `when`/`unless`: test never tail; only last body expression inherits tail
- `call`: operator and args are never in tail position

This establishes the annotations infrastructure for Stage 3. Future analysis passes (variable resolution, primitive identification, boxing analysis) will add more fields to `Annotations`.

Part of #93, toward #96.

## Test plan

- [x] `zig build test` passes (all unit tests including 4 new analysis tests)
- [x] `bash tests/scheme/run-all.sh` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)