### PR TITLE
Add constant folding optimization pass on the IR

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -761,6 +761,107 @@ pub fn identifyPrimitives(node: *Node) void {
 }
 
 // ---------------------------------------------------------------------------
+// Optimization: constant folding on the IR
+// ---------------------------------------------------------------------------
+
+pub fn foldConstants(ir: *IR, node: *Node) *Node {
+    switch (node.tag) {
+        .call => {
+            const call = node.data.call;
+            if (call.operator.tag != .global_ref) return node;
+            const sym = call.operator.data.global_ref;
+            if (!types.isSymbol(sym)) return node;
+            const name = types.symbolName(sym);
+
+            if (call.args.len == 1) {
+                const a = call.args[0];
+                if (a.tag != .constant) return node;
+                const av = a.data.constant;
+                if (!types.isFixnum(av) and av != types.TRUE and av != types.FALSE) return node;
+
+                const result: ?Value = if (std.mem.eql(u8, name, "not"))
+                    (if (av == types.FALSE) types.TRUE else types.FALSE)
+                else if (std.mem.eql(u8, name, "zero?"))
+                    (if (types.isFixnum(av) and types.toFixnum(av) == 0) types.TRUE else types.FALSE)
+                else if (std.mem.eql(u8, name, "-") and types.isFixnum(av)) blk: {
+                    const neg = @subWithOverflow(@as(i64, 0), types.toFixnum(av));
+                    if (neg[1] != 0) break :blk null;
+                    if (neg[0] < std.math.minInt(i48) or neg[0] > std.math.maxInt(i48)) break :blk null;
+                    break :blk types.makeFixnum(neg[0]);
+                } else null;
+
+                if (result) |val| return ir.makeConst(val) catch return node;
+            }
+
+            if (call.args.len == 2) {
+                const a = call.args[0];
+                const b = call.args[1];
+                if (a.tag != .constant or b.tag != .constant) return node;
+                const av = a.data.constant;
+                const bv = b.data.constant;
+                if (!types.isFixnum(av) or !types.isFixnum(bv)) return node;
+                const va = types.toFixnum(av);
+                const vb = types.toFixnum(bv);
+
+                const result: ?Value = if (std.mem.eql(u8, name, "+")) blk: {
+                    const r = @addWithOverflow(va, vb);
+                    if (r[1] != 0) break :blk null;
+                    if (r[0] < std.math.minInt(i48) or r[0] > std.math.maxInt(i48)) break :blk null;
+                    break :blk types.makeFixnum(r[0]);
+                } else if (std.mem.eql(u8, name, "-")) blk: {
+                    const r = @subWithOverflow(va, vb);
+                    if (r[1] != 0) break :blk null;
+                    if (r[0] < std.math.minInt(i48) or r[0] > std.math.maxInt(i48)) break :blk null;
+                    break :blk types.makeFixnum(r[0]);
+                } else if (std.mem.eql(u8, name, "*")) blk: {
+                    const r = @mulWithOverflow(va, vb);
+                    if (r[1] != 0) break :blk null;
+                    if (r[0] < std.math.minInt(i48) or r[0] > std.math.maxInt(i48)) break :blk null;
+                    break :blk types.makeFixnum(r[0]);
+                } else if (std.mem.eql(u8, name, "<"))
+                    (if (va < vb) types.TRUE else types.FALSE)
+                else if (std.mem.eql(u8, name, ">"))
+                    (if (va > vb) types.TRUE else types.FALSE)
+                else if (std.mem.eql(u8, name, "<="))
+                    (if (va <= vb) types.TRUE else types.FALSE)
+                else if (std.mem.eql(u8, name, ">="))
+                    (if (va >= vb) types.TRUE else types.FALSE)
+                else if (std.mem.eql(u8, name, "="))
+                    (if (va == vb) types.TRUE else types.FALSE)
+                else
+                    null;
+
+                if (result) |val| return ir.makeConst(val) catch return node;
+            }
+            return node;
+        },
+        .@"if" => {
+            const data = node.data.@"if";
+            const new_test = foldConstants(ir, data.test_expr);
+            const new_cons = foldConstants(ir, data.consequent);
+            const new_alt = if (data.alternate) |alt| foldConstants(ir, alt) else null;
+            if (new_test != data.test_expr or new_cons != data.consequent or
+                (data.alternate != null and new_alt != data.alternate.?))
+            {
+                return ir.makeIf(new_test, new_cons, new_alt) catch return node;
+            }
+            return node;
+        },
+        .begin => {
+            var changed = false;
+            var buf: [256]*Node = undefined;
+            for (node.data.begin, 0..) |expr, i| {
+                buf[i] = foldConstants(ir, expr);
+                if (buf[i] != expr) changed = true;
+            }
+            if (changed) return ir.makeBegin(buf[0..node.data.begin.len]) catch return node;
+            return node;
+        },
+        else => return node,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // IR → bytecode emission (standalone, used by Stage 1 parity tests)
 // ---------------------------------------------------------------------------
 

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -297,6 +297,62 @@ test "IR analysis: non-primitive not marked" {
     try std.testing.expect(call.ann.primitive_name == null);
 }
 
+test "IR optimization: constant folding on Call" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const plus_sym = try gc.allocSymbol("+");
+    const op = try ir.makeGlobalRef(plus_sym);
+    const a = try ir.makeConst(types.makeFixnum(3));
+    const b = try ir.makeConst(types.makeFixnum(4));
+    const call = try ir.makeCall(op, &.{ a, b });
+
+    const folded = ir_mod.foldConstants(&ir, call);
+    try std.testing.expect(folded.tag == .constant);
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(folded.data.constant));
+}
+
+test "IR optimization: constant folding not applied to non-constant args" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const plus_sym = try gc.allocSymbol("+");
+    const x_sym = try gc.allocSymbol("x");
+    const op = try ir.makeGlobalRef(plus_sym);
+    const a = try ir.makeGlobalRef(x_sym);
+    const b = try ir.makeConst(types.makeFixnum(1));
+    const call = try ir.makeCall(op, &.{ a, b });
+
+    const folded = ir_mod.foldConstants(&ir, call);
+    try std.testing.expect(folded.tag == .call);
+}
+
+test "IR optimization: constant folding through if" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const plus_sym = try gc.allocSymbol("+");
+    const op = try ir.makeGlobalRef(plus_sym);
+    const a = try ir.makeConst(types.makeFixnum(1));
+    const b = try ir.makeConst(types.makeFixnum(2));
+    const call = try ir.makeCall(op, &.{ a, b });
+
+    const test_node = try ir.makeConst(types.TRUE);
+    const alt = try ir.makeConst(types.makeFixnum(0));
+    const if_node = try ir.makeIf(test_node, call, alt);
+
+    const folded = ir_mod.foldConstants(&ir, if_node);
+    try std.testing.expect(folded.tag == .@"if");
+    try std.testing.expect(folded.data.@"if".consequent.tag == .constant);
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(folded.data.@"if".consequent.data.constant));
+}
+
 fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
     var reader = reader_mod.Reader.init(gc, source);
     defer reader.deinit();


### PR DESCRIPTION
## Summary

- Implements `foldConstants()` IR optimization pass
- Folds `Call(+, [Const(3), Const(4)])` → `Const(7)` for all arithmetic/comparison ops
- Propagates recursively through if and begin nodes
- 3 unit tests covering folding, non-folding, and recursive folding

This is the first shared optimization pass (Stage 4), demonstrating the value of the IR as a substrate for optimizations that benefit both the bytecode VM and future native backend.

Part of #93, toward #97.

## Test plan

- [x] `zig build test` passes
- [x] `bash tests/scheme/run-all.sh` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)