### PR TITLE
Add dead branch elimination optimization pass

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -862,6 +862,45 @@ pub fn foldConstants(ir: *IR, node: *Node) *Node {
 }
 
 // ---------------------------------------------------------------------------
+// Optimization: dead branch elimination
+// ---------------------------------------------------------------------------
+
+pub fn eliminateDeadBranches(ir: *IR, node: *Node) *Node {
+    switch (node.tag) {
+        .@"if" => {
+            const data = node.data.@"if";
+            const new_test = eliminateDeadBranches(ir, data.test_expr);
+            const new_cons = eliminateDeadBranches(ir, data.consequent);
+            const new_alt = if (data.alternate) |alt| eliminateDeadBranches(ir, alt) else null;
+
+            if (new_test.tag == .constant) {
+                const test_val = new_test.data.constant;
+                if (test_val != types.FALSE) return new_cons;
+                if (new_alt) |alt| return alt;
+                return ir.makeConst(types.VOID) catch return node;
+            }
+            if (new_test != data.test_expr or new_cons != data.consequent or
+                (data.alternate != null and new_alt != data.alternate.?))
+            {
+                return ir.makeIf(new_test, new_cons, new_alt) catch return node;
+            }
+            return node;
+        },
+        .begin => {
+            var changed = false;
+            var buf: [256]*Node = undefined;
+            for (node.data.begin, 0..) |expr, i| {
+                buf[i] = eliminateDeadBranches(ir, expr);
+                if (buf[i] != expr) changed = true;
+            }
+            if (changed) return ir.makeBegin(buf[0..node.data.begin.len]) catch return node;
+            return node;
+        },
+        else => return node,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // IR → bytecode emission (standalone, used by Stage 1 parity tests)
 // ---------------------------------------------------------------------------
 

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -353,6 +353,54 @@ test "IR optimization: constant folding through if" {
     try std.testing.expectEqual(@as(i64, 3), types.toFixnum(folded.data.@"if".consequent.data.constant));
 }
 
+test "IR optimization: dead branch elimination — true test" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const test_node = try ir.makeConst(types.TRUE);
+    const cons = try ir.makeConst(types.makeFixnum(42));
+    const alt = try ir.makeConst(types.makeFixnum(0));
+    const if_node = try ir.makeIf(test_node, cons, alt);
+
+    const result = ir_mod.eliminateDeadBranches(&ir, if_node);
+    try std.testing.expect(result.tag == .constant);
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result.data.constant));
+}
+
+test "IR optimization: dead branch elimination — false test" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const test_node = try ir.makeConst(types.FALSE);
+    const cons = try ir.makeConst(types.makeFixnum(42));
+    const alt = try ir.makeConst(types.makeFixnum(0));
+    const if_node = try ir.makeIf(test_node, cons, alt);
+
+    const result = ir_mod.eliminateDeadBranches(&ir, if_node);
+    try std.testing.expect(result.tag == .constant);
+    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(result.data.constant));
+}
+
+test "IR optimization: dead branch elimination — non-constant test unchanged" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const x_sym = try gc.allocSymbol("x");
+    const test_node = try ir.makeGlobalRef(x_sym);
+    const cons = try ir.makeConst(types.makeFixnum(42));
+    const alt = try ir.makeConst(types.makeFixnum(0));
+    const if_node = try ir.makeIf(test_node, cons, alt);
+
+    const result = ir_mod.eliminateDeadBranches(&ir, if_node);
+    try std.testing.expect(result.tag == .@"if");
+}
+
 fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
     var reader = reader_mod.Reader.init(gc, source);
     defer reader.deinit();


### PR DESCRIPTION
## Summary

- Implements `eliminateDeadBranches()` IR optimization pass
- Removes unreachable branches when if-test is a known constant
- Propagates recursively through if and begin
- 3 unit tests covering true, false, and non-constant test cases

Combines with constant folding: `(if (< 1 2) A B)` → fold `(< 1 2)` → `#t` → eliminate → `A`.

Part of #93, toward #97.

## Test plan

- [x] `zig build test` passes
- [x] `bash tests/scheme/run-all.sh` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)