### PR TITLE
Add constant expression detection analysis pass

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -271,6 +271,7 @@ pub const Compiler = struct {
         const root = try ir_mod.lower(&ir, expr_root);
         ir_mod.markTailPositions(root, false);
         ir_mod.identifyPrimitives(root);
+        ir_mod.markConstants(root);
 
         const dst = try self.allocReg();
         try self.compileFromNode(root, dst, false);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -48,6 +48,7 @@ pub const Annotations = struct {
     is_tail: bool = false,
     is_primitive_call: bool = false,
     primitive_name: ?[]const u8 = null,
+    is_constant: bool = false,
 };
 
 pub const Node = struct {
@@ -732,6 +733,78 @@ pub fn identifyPrimitives(node: *Node) void {
             for (node.data.unless_form.body) |expr| identifyPrimitives(expr);
         },
         .constant, .global_ref, .passthrough => {},
+        .define,
+        .set_form,
+        .lambda,
+        .let_form,
+        .let_star,
+        .letrec,
+        .letrec_star,
+        .do_form,
+        .delay,
+        .delay_force,
+        .cond,
+        .case_form,
+        .case_lambda,
+        .guard,
+        .quasiquote,
+        .parameterize,
+        .define_values,
+        .let_values,
+        .let_star_values,
+        .define_syntax,
+        .named_let,
+        .let_syntax,
+        .letrec_syntax,
+        .cond_expand,
+        => {},
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Semantic analysis: constant expression detection
+// ---------------------------------------------------------------------------
+
+pub fn markConstants(node: *Node) void {
+    switch (node.tag) {
+        .constant => node.ann.is_constant = true,
+        .@"if" => {
+            markConstants(node.data.@"if".test_expr);
+            markConstants(node.data.@"if".consequent);
+            if (node.data.@"if".alternate) |alt| markConstants(alt);
+        },
+        .begin => {
+            for (node.data.begin) |expr| markConstants(expr);
+            if (node.data.begin.len > 0) {
+                node.ann.is_constant = node.data.begin[node.data.begin.len - 1].ann.is_constant;
+            }
+        },
+        .call => {
+            markConstants(node.data.call.operator);
+            var all_const = node.data.call.operator.tag == .global_ref;
+            for (node.data.call.args) |arg| {
+                markConstants(arg);
+                if (!arg.ann.is_constant) all_const = false;
+            }
+            if (all_const and node.ann.is_primitive_call) {
+                node.ann.is_constant = true;
+            }
+        },
+        .and_form => {
+            for (node.data.and_form) |expr| markConstants(expr);
+        },
+        .or_form => {
+            for (node.data.or_form) |expr| markConstants(expr);
+        },
+        .when_form => {
+            markConstants(node.data.when_form.test_expr);
+            for (node.data.when_form.body) |expr| markConstants(expr);
+        },
+        .unless_form => {
+            markConstants(node.data.unless_form.test_expr);
+            for (node.data.unless_form.body) |expr| markConstants(expr);
+        },
+        .global_ref, .passthrough => {},
         .define,
         .set_form,
         .lambda,

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -401,6 +401,42 @@ test "IR optimization: dead branch elimination — non-constant test unchanged" 
     try std.testing.expect(result.tag == .@"if");
 }
 
+test "IR analysis: constant detection — literal is constant" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+    const node = try ir.makeConst(types.makeFixnum(42));
+    ir_mod.markConstants(node);
+    try std.testing.expect(node.ann.is_constant);
+}
+
+test "IR analysis: constant detection — primitive call with const args" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+    const plus_sym = try gc.allocSymbol("+");
+    const op = try ir.makeGlobalRef(plus_sym);
+    const a = try ir.makeConst(types.makeFixnum(1));
+    const b = try ir.makeConst(types.makeFixnum(2));
+    const call = try ir.makeCall(op, &.{ a, b });
+    ir_mod.identifyPrimitives(call);
+    ir_mod.markConstants(call);
+    try std.testing.expect(call.ann.is_constant);
+}
+
+test "IR analysis: constant detection — variable ref is not constant" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+    const x_sym = try gc.allocSymbol("x");
+    const node = try ir.makeGlobalRef(x_sym);
+    ir_mod.markConstants(node);
+    try std.testing.expect(!node.ann.is_constant);
+}
+
 fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
     var reader = reader_mod.Reader.init(gc, source);
     defer reader.deinit();


### PR DESCRIPTION
## Summary

- Adds `is_constant` to IR annotations
- Implements `markConstants()` analysis pass
- Integrated into `compile()` after primitive identification
- 3 unit tests: literal is constant, primitive call with const args is constant, variable ref is not constant

Part of #93, toward #96.

## Test plan

- [x] `zig build test` passes
- [x] `bash tests/scheme/run-all.sh` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)