### PR TITLE
Route compileMultiple through IR pipeline

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -635,8 +635,18 @@ pub const Compiler = struct {
 
         var dst: u16 = 0;
         for (exprs, 0..) |expr, i| {
+            // Lower each expression through the IR pipeline.
+            var ir = ir_mod.IR.init(self.gc.allocator);
+            defer ir.deinit();
+            var root = try ir_mod.lower(&ir, expr);
+            ir_mod.markTailPositions(root, false);
+            ir_mod.identifyPrimitives(root);
+            ir_mod.markConstants(root);
+            root = ir_mod.foldConstants(&ir, root);
+            root = ir_mod.eliminateDeadBranches(&ir, root);
+
             dst = try self.allocReg();
-            try self.compileExpr(expr, dst, false);
+            try self.compileFromNode(root, dst, false);
             if (i < exprs.len - 1) {
                 self.freeReg();
             }


### PR DESCRIPTION
## Summary

- Routes \`compileMultiple()\` through the full IR pipeline (lower → analysis → optimization → emit)
- Both \`compile()\` and \`compileMultiple()\` now go through IR
- All compilation entry points consistently use the IR infrastructure

Part of #93, toward #95.

## Test plan

- [x] \`zig build test\` passes
- [x] \`bash tests/scheme/run-all.sh\` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)