### PR TITLE
Add boolean simplification optimization pass

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -278,6 +278,7 @@ pub const Compiler = struct {
         // Optimization passes
         root = ir_mod.foldConstants(&ir, root);
         root = ir_mod.eliminateDeadBranches(&ir, root);
+        root = ir_mod.simplifyBooleans(&ir, root);
 
         const dst = try self.allocReg();
         try self.compileFromNode(root, dst, false);
@@ -644,6 +645,7 @@ pub const Compiler = struct {
             ir_mod.markConstants(root);
             root = ir_mod.foldConstants(&ir, root);
             root = ir_mod.eliminateDeadBranches(&ir, root);
+            root = ir_mod.simplifyBooleans(&ir, root);
 
             dst = try self.allocReg();
             try self.compileFromNode(root, dst, false);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -1055,6 +1055,69 @@ pub fn eliminateDeadBranches(ir: *IR, node: *Node) *Node {
 }
 
 // ---------------------------------------------------------------------------
+// Optimization: boolean simplification
+// ---------------------------------------------------------------------------
+
+pub fn simplifyBooleans(ir: *IR, node: *Node) *Node {
+    switch (node.tag) {
+        .@"if" => {
+            const data = node.data.@"if";
+            var new_test = simplifyBooleans(ir, data.test_expr);
+            const new_cons = simplifyBooleans(ir, data.consequent);
+            const new_alt = if (data.alternate) |alt| simplifyBooleans(ir, alt) else null;
+
+            // (if (not X) A B) → (if X B A)
+            if (new_test.tag == .call and new_test.data.call.args.len == 1 and
+                new_test.data.call.operator.tag == .global_ref)
+            {
+                const sym = new_test.data.call.operator.data.global_ref;
+                if (types.isSymbol(sym) and std.mem.eql(u8, types.symbolName(sym), "not")) {
+                    new_test = new_test.data.call.args[0];
+                    return ir.makeIf(new_test, new_alt orelse (ir.makeConst(types.VOID) catch return node), new_cons) catch return node;
+                }
+            }
+
+            if (new_test != data.test_expr or new_cons != data.consequent or
+                (data.alternate != null and new_alt != data.alternate.?))
+            {
+                return ir.makeIf(new_test, new_cons, new_alt) catch return node;
+            }
+            return node;
+        },
+        .begin => {
+            var changed = false;
+            var buf: [256]*Node = undefined;
+            for (node.data.begin, 0..) |expr, i| {
+                buf[i] = simplifyBooleans(ir, expr);
+                if (buf[i] != expr) changed = true;
+            }
+            if (changed) return ir.makeBegin(buf[0..node.data.begin.len]) catch return node;
+            return node;
+        },
+        .call => {
+            const call = node.data.call;
+            // (not (not X)) → X
+            if (call.args.len == 1 and call.operator.tag == .global_ref) {
+                const sym = call.operator.data.global_ref;
+                if (types.isSymbol(sym) and std.mem.eql(u8, types.symbolName(sym), "not")) {
+                    const inner = call.args[0];
+                    if (inner.tag == .call and inner.data.call.args.len == 1 and
+                        inner.data.call.operator.tag == .global_ref)
+                    {
+                        const inner_sym = inner.data.call.operator.data.global_ref;
+                        if (types.isSymbol(inner_sym) and std.mem.eql(u8, types.symbolName(inner_sym), "not")) {
+                            return inner.data.call.args[0];
+                        }
+                    }
+                }
+            }
+            return node;
+        },
+        else => return node,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // IR → bytecode emission (standalone, used by Stage 1 parity tests)
 // ---------------------------------------------------------------------------
 

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -437,6 +437,46 @@ test "IR analysis: constant detection — variable ref is not constant" {
     try std.testing.expect(!node.ann.is_constant);
 }
 
+test "IR optimization: boolean simplification — not not" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const not_sym = try gc.allocSymbol("not");
+    const x_sym = try gc.allocSymbol("x");
+    const x = try ir.makeGlobalRef(x_sym);
+    const not_op = try ir.makeGlobalRef(not_sym);
+    const inner = try ir.makeCall(not_op, &.{x});
+    const not_op2 = try ir.makeGlobalRef(not_sym);
+    const outer = try ir.makeCall(not_op2, &.{inner});
+
+    const result = ir_mod.simplifyBooleans(&ir, outer);
+    try std.testing.expect(result.tag == .global_ref);
+}
+
+test "IR optimization: boolean simplification — if not test swaps branches" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const not_sym = try gc.allocSymbol("not");
+    const x_sym = try gc.allocSymbol("x");
+    const x = try ir.makeGlobalRef(x_sym);
+    const not_op = try ir.makeGlobalRef(not_sym);
+    const test_node = try ir.makeCall(not_op, &.{x});
+    const cons = try ir.makeConst(types.makeFixnum(1));
+    const alt = try ir.makeConst(types.makeFixnum(2));
+    const if_node = try ir.makeIf(test_node, cons, alt);
+
+    const result = ir_mod.simplifyBooleans(&ir, if_node);
+    try std.testing.expect(result.tag == .@"if");
+    try std.testing.expect(result.data.@"if".test_expr.tag == .global_ref);
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result.data.@"if".consequent.data.constant));
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(result.data.@"if".alternate.?.data.constant));
+}
+
 fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
     var reader = reader_mod.Reader.init(gc, source);
     defer reader.deinit();


### PR DESCRIPTION
## Summary

- Adds \`simplifyBooleans()\` optimization pass
- \`(not (not X))\` → \`X\` (double-negation elimination)
- \`(if (not X) A B)\` → \`(if X B A)\` (branch swap, saves a function call)
- Integrated into both compilation entry points
- 2 unit tests

Part of #93, toward #97.

## Test plan

- [x] \`zig build test\` passes
- [x] \`bash tests/scheme/run-all.sh\` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)