### PR TITLE
Add identity elimination optimization pass

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -279,6 +279,7 @@ pub const Compiler = struct {
         root = ir_mod.foldConstants(&ir, root);
         root = ir_mod.eliminateDeadBranches(&ir, root);
         root = ir_mod.simplifyBooleans(&ir, root);
+        root = ir_mod.eliminateIdentity(&ir, root);
 
         const dst = try self.allocReg();
         try self.compileFromNode(root, dst, false);
@@ -646,6 +647,7 @@ pub const Compiler = struct {
             root = ir_mod.foldConstants(&ir, root);
             root = ir_mod.eliminateDeadBranches(&ir, root);
             root = ir_mod.simplifyBooleans(&ir, root);
+            root = ir_mod.eliminateIdentity(&ir, root);
 
             dst = try self.allocReg();
             try self.compileFromNode(root, dst, false);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -1118,6 +1118,76 @@ pub fn simplifyBooleans(ir: *IR, node: *Node) *Node {
 }
 
 // ---------------------------------------------------------------------------
+// Optimization: identity elimination
+// ---------------------------------------------------------------------------
+
+pub fn eliminateIdentity(ir: *IR, node: *Node) *Node {
+    switch (node.tag) {
+        .call => {
+            const call = node.data.call;
+            if (call.operator.tag != .global_ref) return node;
+            const sym = call.operator.data.global_ref;
+            if (!types.isSymbol(sym)) return node;
+            const name = types.symbolName(sym);
+
+            if (call.args.len == 2) {
+                const a = call.args[0];
+                const b = call.args[1];
+
+                // (+ x 0) → x, (+ 0 x) → x
+                if (std.mem.eql(u8, name, "+")) {
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0)
+                        return eliminateIdentity(ir, a);
+                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 0)
+                        return eliminateIdentity(ir, b);
+                }
+                // (* x 1) → x, (* 1 x) → x
+                if (std.mem.eql(u8, name, "*")) {
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 1)
+                        return eliminateIdentity(ir, a);
+                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 1)
+                        return eliminateIdentity(ir, b);
+                    // (* x 0) → 0, (* 0 x) → 0
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0)
+                        return ir.makeConst(types.makeFixnum(0)) catch return node;
+                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 0)
+                        return ir.makeConst(types.makeFixnum(0)) catch return node;
+                }
+                // (- x 0) → x
+                if (std.mem.eql(u8, name, "-")) {
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0)
+                        return eliminateIdentity(ir, a);
+                }
+            }
+            return node;
+        },
+        .@"if" => {
+            const data = node.data.@"if";
+            const new_test = eliminateIdentity(ir, data.test_expr);
+            const new_cons = eliminateIdentity(ir, data.consequent);
+            const new_alt = if (data.alternate) |alt| eliminateIdentity(ir, alt) else null;
+            if (new_test != data.test_expr or new_cons != data.consequent or
+                (data.alternate != null and new_alt != data.alternate.?))
+            {
+                return ir.makeIf(new_test, new_cons, new_alt) catch return node;
+            }
+            return node;
+        },
+        .begin => {
+            var changed = false;
+            var buf: [256]*Node = undefined;
+            for (node.data.begin, 0..) |expr, i| {
+                buf[i] = eliminateIdentity(ir, expr);
+                if (buf[i] != expr) changed = true;
+            }
+            if (changed) return ir.makeBegin(buf[0..node.data.begin.len]) catch return node;
+            return node;
+        },
+        else => return node,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // IR → bytecode emission (standalone, used by Stage 1 parity tests)
 // ---------------------------------------------------------------------------
 

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -477,6 +477,41 @@ test "IR optimization: boolean simplification — if not test swaps branches" {
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(result.data.@"if".alternate.?.data.constant));
 }
 
+test "IR optimization: identity elimination — add zero" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const plus_sym = try gc.allocSymbol("+");
+    const x_sym = try gc.allocSymbol("x");
+    const op = try ir.makeGlobalRef(plus_sym);
+    const x = try ir.makeGlobalRef(x_sym);
+    const zero = try ir.makeConst(types.makeFixnum(0));
+    const call = try ir.makeCall(op, &.{ x, zero });
+
+    const result = ir_mod.eliminateIdentity(&ir, call);
+    try std.testing.expect(result.tag == .global_ref);
+}
+
+test "IR optimization: identity elimination — multiply by zero" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const mul_sym = try gc.allocSymbol("*");
+    const x_sym = try gc.allocSymbol("x");
+    const op = try ir.makeGlobalRef(mul_sym);
+    const x = try ir.makeGlobalRef(x_sym);
+    const zero = try ir.makeConst(types.makeFixnum(0));
+    const call = try ir.makeCall(op, &.{ x, zero });
+
+    const result = ir_mod.eliminateIdentity(&ir, call);
+    try std.testing.expect(result.tag == .constant);
+    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(result.data.constant));
+}
+
 fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
     var reader = reader_mod.Reader.init(gc, source);
     defer reader.deinit();


### PR DESCRIPTION
## Summary

- Adds \`eliminateIdentity()\` optimization pass
- Removes identity operations: \`(+ x 0)\` → \`x\`, \`(* x 1)\` → \`x\`, \`(* x 0)\` → \`0\`, \`(- x 0)\` → \`x\`
- Integrated into both compilation entry points
- 2 unit tests

The compilation pipeline now has 4 optimization passes: constant folding, dead branch elimination, boolean simplification, identity elimination.

Part of #93, toward #97.

## Test plan

- [x] \`zig build test\` passes
- [x] \`bash tests/scheme/run-all.sh\` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)