### PR TITLE
Add begin simplification optimization pass

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -280,6 +280,7 @@ pub const Compiler = struct {
         root = ir_mod.eliminateDeadBranches(&ir, root);
         root = ir_mod.simplifyBooleans(&ir, root);
         root = ir_mod.eliminateIdentity(&ir, root);
+        root = ir_mod.simplifyBegin(&ir, root);
 
         const dst = try self.allocReg();
         try self.compileFromNode(root, dst, false);
@@ -648,6 +649,7 @@ pub const Compiler = struct {
             root = ir_mod.eliminateDeadBranches(&ir, root);
             root = ir_mod.simplifyBooleans(&ir, root);
             root = ir_mod.eliminateIdentity(&ir, root);
+            root = ir_mod.simplifyBegin(&ir, root);
 
             dst = try self.allocReg();
             try self.compileFromNode(root, dst, false);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -1188,6 +1188,39 @@ pub fn eliminateIdentity(ir: *IR, node: *Node) *Node {
 }
 
 // ---------------------------------------------------------------------------
+// Optimization: begin simplification
+// ---------------------------------------------------------------------------
+
+pub fn simplifyBegin(ir: *IR, node: *Node) *Node {
+    switch (node.tag) {
+        .begin => {
+            if (node.data.begin.len == 1) return simplifyBegin(ir, @constCast(node.data.begin[0]));
+            var changed = false;
+            var buf: [256]*Node = undefined;
+            for (node.data.begin, 0..) |expr, i| {
+                buf[i] = simplifyBegin(ir, @constCast(expr));
+                if (buf[i] != expr) changed = true;
+            }
+            if (changed) return ir.makeBegin(buf[0..node.data.begin.len]) catch return node;
+            return node;
+        },
+        .@"if" => {
+            const data = node.data.@"if";
+            const new_test = simplifyBegin(ir, data.test_expr);
+            const new_cons = simplifyBegin(ir, data.consequent);
+            const new_alt = if (data.alternate) |alt| simplifyBegin(ir, alt) else null;
+            if (new_test != data.test_expr or new_cons != data.consequent or
+                (data.alternate != null and new_alt != data.alternate.?))
+            {
+                return ir.makeIf(new_test, new_cons, new_alt) catch return node;
+            }
+            return node;
+        },
+        else => return node,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // IR → bytecode emission (standalone, used by Stage 1 parity tests)
 // ---------------------------------------------------------------------------
 

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -512,6 +512,19 @@ test "IR optimization: identity elimination — multiply by zero" {
     try std.testing.expectEqual(@as(i64, 0), types.toFixnum(result.data.constant));
 }
 
+test "IR optimization: begin simplification — single expr" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const val = try ir.makeConst(types.makeFixnum(42));
+    const begin = try ir.makeBegin(&.{val});
+    const result = ir_mod.simplifyBegin(&ir, begin);
+    try std.testing.expect(result.tag == .constant);
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result.data.constant));
+}
+
 fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
     var reader = reader_mod.Reader.init(gc, source);
     defer reader.deinit();


### PR DESCRIPTION
## Summary

- Adds \`simplifyBegin()\` pass: \`(begin X)\` → \`X\`
- Propagates through if nodes
- 5th optimization pass in the pipeline
- 1 unit test

Part of #93, toward #97.

## Test plan

- [x] \`zig build test\` passes
- [x] \`bash tests/scheme/run-all.sh\` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)