### PR TITLE
Route function-define bodies through IR pipeline

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -474,7 +474,7 @@ pub const Compiler = struct {
         }
     }
 
-    fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]const u8) CompileError!void {
+    pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]const u8) CompileError!void {
         if (args == types.NIL) return CompileError.InvalidSyntax;
         const formals = types.car(args);
         const body = types.cdr(args);

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -229,7 +229,7 @@ pub fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
         // Build lambda body list. compileLambda sets the function's name (used
         // for debugging and for self-tail-call detection in the body).
         const lambda_args = self.gc.allocPair(param_formals, rest) catch return CompileError.OutOfMemory;
-        try compileLambda(self, lambda_args, dst, types.symbolName(name));
+        try self.compileLambdaWithIR(lambda_args, dst, types.symbolName(name));
 
         const sym_idx = try self.addConstant(name);
         try self.emitOp(.define_global);

--- a/tests/scheme/bench/const-prop.scm
+++ b/tests/scheme/bench/const-prop.scm
@@ -1,0 +1,14 @@
+;; Benchmark for IR constant folding + dead branch elimination
+;; With optimization: inner expressions fold to constants, branches eliminated
+;; Without optimization: evaluates arithmetic + conditionals at runtime
+(define (bench n)
+  (define (go i acc)
+    (if (= i 0) acc
+        (go (- i 1)
+            (+ acc
+               (if (not (< 2 1)) (+ 10 20) (- 100 200))
+               (if (< 1 2) (* 3 7) (* 0 1))
+               (+ 0 (+ 5 10))
+               (* 1 (- 50 20))))))
+  (go n 0))
+(bench 5000000)


### PR DESCRIPTION
## Summary

- \`(define (f x) body)\` now compiles body through full IR pipeline
- Made \`compileLambdaWithIR\` public for cross-file access
- Added \`tests/scheme/bench/const-prop.scm\` benchmark
- All 1482 tests pass

Part of #93, toward #97.

## Test plan

- [x] \`zig build test\` passes
- [x] \`bash tests/scheme/run-all.sh\` passes (1482 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)