### PR TITLE
Add e2e tests for LLVM native backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
       - name: Error format tests
         run: bash tests/scheme/errors/error-format.sh
 
+      - name: E2E tests (LLVM native backend)
+        if: matrix.optimize == 'ReleaseSafe' && matrix.os != 'macos-latest'
+        run: |
+          git clone --depth 1 https://github.com/kaappi/kaappi-bdd.git ../kaappi-bdd
+          bash tests/e2e/run-e2e.sh
+
       - name: thottam integration test
         if: matrix.optimize == 'ReleaseSafe'
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,20 @@ fixnum overflow auto-promotes to bignum). Debug is ~500x slower for allocation-
 and continuation-heavy workloads — only use it when debugging:
 `zig build -Doptimize=Debug`. For maximum throughput: `-Doptimize=ReleaseFast`.
 
+### LLVM native backend
+
+```bash
+zig build lib                                    # build libkaappi_rt.a
+zig build run -- --emit-llvm program.scm -o out.ll  # emit LLVM IR
+zig cc -w out.ll -o program -Lzig-out/lib -lkaappi_rt -lc -lm -lpthread  # link
+./program                                        # run native binary
+```
+
+**Always use `zig cc` (not `clang`) for linking native binaries against
+`libkaappi_rt.a`.** The Zig-compiled static library references
+`__zig_probe_stack` and other Zig compiler-rt intrinsics that `clang`
+cannot resolve. `zig cc` includes these automatically.
+
 ## Architecture
 
 ```

--- a/tests/e2e/programs/arithmetic.scm
+++ b/tests/e2e/programs/arithmetic.scm
@@ -1,0 +1,2 @@
+(display (+ 1 2))
+(newline)

--- a/tests/e2e/programs/hello.scm
+++ b/tests/e2e/programs/hello.scm
@@ -1,0 +1,2 @@
+(display 42)
+(newline)

--- a/tests/e2e/programs/multiple-exprs.scm
+++ b/tests/e2e/programs/multiple-exprs.scm
@@ -1,0 +1,4 @@
+(display 1)
+(display 2)
+(display 3)
+(newline)

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# End-to-end tests for the LLVM native backend.
+# Verifies: Scheme source → --emit-llvm → .ll → clang → native binary → correct output.
+#
+# Usage: bash tests/e2e/run-e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BDD_LIB="$REPO_DIR/../kaappi-bdd/lib"
+TMPDIR="${TMPDIR:-/tmp}/kaappi-e2e-$$"
+PASS=0
+FAIL=0
+
+cleanup() {
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+mkdir -p "$TMPDIR"
+
+cd "$REPO_DIR"
+
+# Build kaappi and runtime library
+echo "=== Building kaappi and libkaappi_rt.a ==="
+zig build
+zig build lib
+
+KAAPPI="$REPO_DIR/zig-out/bin/kaappi"
+LIBDIR="$REPO_DIR/zig-out/lib"
+
+# --- Phase 1: BDD tests via interpreter ---
+
+echo ""
+echo "=== Phase 1: BDD tests (interpreter) ==="
+if [[ -d "$BDD_LIB" ]]; then
+    if "$KAAPPI" --lib-path "$BDD_LIB" "$SCRIPT_DIR/test-llvm-backend.scm"; then
+        echo "BDD tests: PASS"
+        PASS=$((PASS + 1))
+    else
+        echo "BDD tests: FAIL"
+        FAIL=$((FAIL + 1))
+    fi
+else
+    echo "SKIP: kaappi-bdd not found at $BDD_LIB"
+fi
+
+# --- Phase 2: Native compilation parity tests ---
+
+echo ""
+echo "=== Phase 2: Native compilation parity tests ==="
+
+assert_native_parity() {
+    local label="$1"
+    local program="$2"
+
+    local expected
+    expected=$("$KAAPPI" "$program" 2>&1) || true
+
+    local ll_file="$TMPDIR/$(basename "$program" .scm).ll"
+    local native_bin="$TMPDIR/$(basename "$program" .scm)"
+
+    if ! "$KAAPPI" --emit-llvm -o "$ll_file" "$program" 2>/dev/null; then
+        echo "FAIL: $label — emit-llvm failed"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    local clang_output
+    local cc="${CC:-zig cc}"
+    if ! clang_output=$($cc -w "$ll_file" -o "$native_bin" -L"$LIBDIR" -lkaappi_rt -lc -lm -lpthread 2>&1); then
+        echo "  cc: $clang_output"
+        echo "FAIL: $label — clang linking failed"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    local actual
+    actual=$("$native_bin" 2>&1) || true
+
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+for program in "$SCRIPT_DIR"/programs/*.scm; do
+    name=$(basename "$program" .scm)
+    assert_native_parity "$name" "$program"
+done
+
+# --- Summary ---
+
+echo ""
+TOTAL=$((PASS + FAIL))
+echo "=== E2E Summary: $PASS/$TOTAL passed ==="
+if [[ $FAIL -gt 0 ]]; then
+    echo "$FAIL FAILED"
+    exit 1
+fi

--- a/tests/e2e/test-llvm-backend.scm
+++ b/tests/e2e/test-llvm-backend.scm
@@ -1,0 +1,37 @@
+(import (scheme base) (scheme write) (kaappi bdd))
+
+(describe "LLVM backend target expressions"
+  (describe "arithmetic"
+    (it "folds constant addition"
+      (expect (+ 1 2) to-equal 3))
+
+    (it "handles subtraction"
+      (expect (- 10 3) to-equal 7))
+
+    (it "handles multiplication"
+      (expect (* 4 5) to-equal 20))
+
+    (it "handles nested arithmetic"
+      (expect (+ (* 2 3) (- 10 4)) to-equal 12)))
+
+  (describe "display values"
+    (it "converts fixnums to strings"
+      (expect (number->string 42) to-equal "42"))
+
+    (it "converts negative fixnums"
+      (expect (number->string -7) to-equal "-7"))
+
+    (it "concatenates strings"
+      (expect (string-append "hello" " world") to-equal "hello world")))
+
+  (describe "boolean logic"
+    (it "evaluates true"
+      (expect #t to-be-truthy))
+
+    (it "evaluates false"
+      (expect #f to-be-falsy))
+
+    (it "evaluates not"
+      (expect (not #f) to-be-truthy))))
+
+(run-specs)


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/` directory with end-to-end tests for the LLVM native backend
- Uses kaappi-bdd framework for interpreter-side BDD specs (10 examples)
- Compares interpreter vs native binary output for each test program (3 parity tests)

## Structure

```
tests/e2e/
  run-e2e.sh              — Shell runner (builds, runs BDD + parity tests)
  test-llvm-backend.scm   — BDD specs using kaappi-bdd
  programs/               — Scheme programs compiled to native binaries
    hello.scm
    arithmetic.scm
    multiple-exprs.scm
```

## Test plan

- [x] `bash tests/e2e/run-e2e.sh` passes all 4 tests (10 BDD specs + 3 native parity)
- [x] BDD tests verify arithmetic, display values, boolean logic
- [x] Native parity tests verify interpreter and native binary produce identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)