### PR TITLE
Add if, define, and string support to LLVM backend

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -7,14 +7,20 @@ const Value = types.Value;
 pub const LLVMEmitter = struct {
     buf: std.ArrayList(u8),
     symbols: std.StringHashMap(void),
+    string_decls: std.ArrayList([]const u8),
     tmp_counter: u32,
+    label_counter: u32,
+    string_counter: u32,
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) LLVMEmitter {
         return .{
             .buf = .empty,
             .symbols = std.StringHashMap(void).init(allocator),
+            .string_decls = .empty,
             .tmp_counter = 0,
+            .label_counter = 0,
+            .string_counter = 0,
             .allocator = allocator,
         };
     }
@@ -22,22 +28,40 @@ pub const LLVMEmitter = struct {
     pub fn deinit(self: *LLVMEmitter) void {
         self.buf.deinit(self.allocator);
         self.symbols.deinit();
+        self.string_decls.deinit(self.allocator);
     }
 
     pub fn emitProgram(self: *LLVMEmitter, nodes: []const *ir.Node) EmitError!void {
+        // Emit body into a separate buffer to collect string decls
+        var body: std.ArrayList(u8) = .empty;
+        defer body.deinit(self.allocator);
+        const saved_buf = self.buf;
+        self.buf = body;
+
+        self.write("  %vm = call ptr @kaappi_runtime_init()\n") catch return error.OutOfMemory;
+        for (nodes) |node| {
+            _ = self.emitNode(node) catch return error.OutOfMemory;
+        }
+
+        body = self.buf;
+        self.buf = saved_buf;
+
+        // Now emit preamble + symbols + string decls + body
         try self.emitPreamble();
 
-        var sym_buf: [64][]const u8 = undefined;
-        var sym_count: usize = 0;
-        self.collectSymbols(nodes, &sym_buf, &sym_count);
-        try self.emitSymbolConstants(sym_buf[0..sym_count]);
+        // Emit all symbol constants collected during body emission
+        var sym_iter = self.symbols.keyIterator();
+        try self.write("\n");
+        while (sym_iter.next()) |key| {
+            try self.print("@.sym.{s} = private unnamed_addr constant [{d} x i8] c\"{s}\"\n", .{ key.*, key.len, key.* });
+        }
+
+        for (self.string_decls.items) |decl| {
+            try self.write(decl);
+        }
 
         try self.write("\ndefine i32 @main() {\nentry:\n");
-        try self.write("  %vm = call ptr @kaappi_runtime_init()\n");
-
-        for (nodes) |node| {
-            _ = try self.emitNode(node);
-        }
+        try self.write(body.items);
 
         try self.write("\n  call void @kaappi_runtime_deinit(ptr %vm)\n");
         try self.write("  ret i32 0\n}\n");
@@ -49,11 +73,21 @@ pub const LLVMEmitter = struct {
             .global_ref => try self.emitGlobalRef(node.data.global_ref),
             .call => try self.emitCall(node.data.call),
             .begin => try self.emitBegin(node.data.begin),
+            .@"if" => try self.emitIf(node.data.@"if"),
+            .define => try self.emitDefine(node.data.define),
+            .passthrough => return error.UnsupportedNodeType,
             else => error.UnsupportedNodeType,
         };
     }
 
     fn emitConstant(self: *LLVMEmitter, value: Value) EmitError![]const u8 {
+        if (types.isString(value)) {
+            const str_data = types.toObject(value).as(types.SchemeString).data;
+            const str_name = try self.internString(str_data);
+            const tmp = try self.freshTemp();
+            try self.print("  {s} = call i64 @kaappi_make_string(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, str_data.len });
+            return tmp;
+        }
         const tmp = try self.freshTemp();
         const signed: i64 = @bitCast(value);
         try self.print("  {s} = add i64 0, {d}\n", .{ tmp, signed });
@@ -63,8 +97,9 @@ pub const LLVMEmitter = struct {
     fn emitGlobalRef(self: *LLVMEmitter, sym: Value) EmitError![]const u8 {
         if (!types.isSymbol(sym)) return error.UnsupportedNodeType;
         const name = types.symbolName(sym);
+        const sym_name = try self.internSymbol(name);
         const tmp = try self.freshTemp();
-        try self.print("  {s} = call i64 @kaappi_global_lookup(ptr %vm, ptr @.sym.{s}, i64 {d})\n", .{ tmp, name, name.len });
+        try self.print("  {s} = call i64 @kaappi_global_lookup(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, sym_name, name.len });
         return tmp;
     }
 
@@ -105,6 +140,99 @@ pub const LLVMEmitter = struct {
         return last;
     }
 
+    fn emitIf(self: *LLVMEmitter, data: ir.IfData) EmitError![]const u8 {
+        const test_val = try self.emitNode(data.test_expr);
+
+        const false_val: i64 = @bitCast(types.FALSE);
+        const cmp = try self.freshTemp();
+        try self.print("  {s} = icmp ne i64 {s}, {d}\n", .{ cmp, test_val, false_val });
+
+        const label_id = self.label_counter;
+        self.label_counter += 1;
+
+        const then_label = try std.fmt.allocPrint(self.allocator, "then{d}", .{label_id});
+        const else_label = try std.fmt.allocPrint(self.allocator, "else{d}", .{label_id});
+        const merge_label = try std.fmt.allocPrint(self.allocator, "merge{d}", .{label_id});
+        const pre_label = try std.fmt.allocPrint(self.allocator, "pre{d}", .{label_id});
+
+        // Name the current block so phi can reference it
+        try self.print("  br label %{s}\n{s}:\n", .{ pre_label, pre_label });
+
+        if (data.alternate != null) {
+            try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ cmp, then_label, else_label });
+        } else {
+            try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ cmp, then_label, merge_label });
+        }
+
+        try self.print("{s}:\n", .{then_label});
+        const then_val = try self.emitNode(data.consequent);
+        try self.print("  br label %{s}\n", .{merge_label});
+
+        if (data.alternate) |alt| {
+            try self.print("{s}:\n", .{else_label});
+            const else_val = try self.emitNode(alt);
+            try self.print("  br label %{s}\n", .{merge_label});
+
+            try self.print("{s}:\n", .{merge_label});
+            const result = try self.freshTemp();
+            try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {s}, %{s} ]\n", .{ result, then_val, then_label, else_val, else_label });
+            return result;
+        } else {
+            const void_val: i64 = @bitCast(types.VOID);
+            try self.print("{s}:\n", .{merge_label});
+            const result = try self.freshTemp();
+            try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {d}, %{s} ]\n", .{ result, then_val, then_label, void_val, pre_label });
+            return result;
+        }
+    }
+
+    fn emitDefine(self: *LLVMEmitter, data: ir.DefineData) EmitError![]const u8 {
+        if (!types.isSymbol(data.name)) return error.UnsupportedNodeType;
+        const name = types.symbolName(data.name);
+        const sym_name = try self.internSymbol(name);
+
+        // DefineData.value is a raw S-expression Value, not an IR node.
+        // Handle literal constants directly.
+        const val = try self.emitConstant(data.value);
+
+        try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym_name, name.len, val });
+
+        const result = try self.freshTemp();
+        const void_val: i64 = @bitCast(types.VOID);
+        try self.print("  {s} = add i64 0, {d}\n", .{ result, void_val });
+        return result;
+    }
+
+    fn internSymbol(self: *LLVMEmitter, name: []const u8) EmitError![]const u8 {
+        if (!self.symbols.contains(name)) {
+            self.symbols.put(name, {}) catch return error.OutOfMemory;
+        }
+        return std.fmt.allocPrint(self.allocator, "@.sym.{s}", .{name}) catch return error.OutOfMemory;
+    }
+
+    fn internString(self: *LLVMEmitter, data: []const u8) EmitError![]const u8 {
+        const id = self.string_counter;
+        self.string_counter += 1;
+        const global_name = std.fmt.allocPrint(self.allocator, "@.str.{d}", .{id}) catch return error.OutOfMemory;
+
+        var escaped: std.ArrayList(u8) = .empty;
+        defer escaped.deinit(self.allocator);
+        for (data) |byte| {
+            if (byte >= 0x20 and byte < 0x7F and byte != '"' and byte != '\\') {
+                escaped.append(self.allocator, byte) catch return error.OutOfMemory;
+            } else {
+                const hex = std.fmt.allocPrint(self.allocator, "\\{X:0>2}", .{byte}) catch return error.OutOfMemory;
+                defer self.allocator.free(hex);
+                escaped.appendSlice(self.allocator, hex) catch return error.OutOfMemory;
+            }
+        }
+
+        const decl = std.fmt.allocPrint(self.allocator, "{s} = private unnamed_addr constant [{d} x i8] c\"{s}\"\n", .{ global_name, data.len, escaped.items }) catch return error.OutOfMemory;
+        self.string_decls.append(self.allocator, decl) catch return error.OutOfMemory;
+
+        return global_name;
+    }
+
     fn emitPreamble(self: *LLVMEmitter) EmitError!void {
         const arch = @import("builtin").cpu.arch;
         const os = @import("builtin").os.tag;
@@ -127,47 +255,8 @@ pub const LLVMEmitter = struct {
         try self.write("declare void @kaappi_runtime_deinit(ptr)\n");
         try self.write("declare i64 @kaappi_global_lookup(ptr, ptr, i64)\n");
         try self.write("declare i64 @kaappi_call_scheme(ptr, i64, ptr, i64)\n");
-    }
-
-    fn collectSymbols(self: *LLVMEmitter, nodes: []const *ir.Node, buf: [][]const u8, count: *usize) void {
-        for (nodes) |node| {
-            self.collectNodeSymbols(node, buf, count);
-        }
-    }
-
-    fn collectNodeSymbols(self: *LLVMEmitter, node: *const ir.Node, buf: [][]const u8, count: *usize) void {
-        switch (node.tag) {
-            .global_ref => {
-                if (types.isSymbol(node.data.global_ref)) {
-                    const name = types.symbolName(node.data.global_ref);
-                    if (!self.symbols.contains(name) and count.* < buf.len) {
-                        self.symbols.put(name, {}) catch return;
-                        buf[count.*] = name;
-                        count.* += 1;
-                    }
-                }
-            },
-            .call => {
-                self.collectNodeSymbols(node.data.call.operator, buf, count);
-                for (node.data.call.args) |arg| {
-                    self.collectNodeSymbols(arg, buf, count);
-                }
-            },
-            .begin => {
-                for (node.data.begin) |expr| {
-                    self.collectNodeSymbols(expr, buf, count);
-                }
-            },
-            else => {},
-        }
-    }
-
-    fn emitSymbolConstants(self: *LLVMEmitter, names: []const []const u8) EmitError!void {
-        if (names.len == 0) return;
-        try self.write("\n");
-        for (names) |name| {
-            try self.print("@.sym.{s} = private unnamed_addr constant [{d} x i8] c\"{s}\"\n", .{ name, name.len, name });
-        }
+        try self.write("declare void @kaappi_define_global(ptr, ptr, i64, i64)\n");
+        try self.write("declare i64 @kaappi_make_string(ptr, ptr, i64)\n");
     }
 
     fn freshTemp(self: *LLVMEmitter) EmitError![]const u8 {

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -56,6 +56,27 @@ export fn kaappi_global_lookup(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len:
     };
 }
 
+export fn kaappi_define_global(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len: u64, val: u64) callconv(.c) void {
+    const v = vm orelse return;
+    const len: usize = @intCast(name_len);
+    const name = name_ptr[0..len];
+    v.defineGlobal(name, val) catch {
+        _ = std.posix.system.write(2, "failed to define global\n", 24);
+        std.process.exit(1);
+    };
+}
+
+export fn kaappi_make_string(vm: ?*vm_mod.VM, str_ptr: [*]const u8, str_len: u64) callconv(.c) u64 {
+    const v = vm orelse return 0;
+    const len: usize = @intCast(str_len);
+    const data = str_ptr[0..len];
+    const result = v.gc.allocString(data) catch {
+        _ = std.posix.system.write(2, "failed to allocate string\n", 26);
+        std.process.exit(1);
+    };
+    return result;
+}
+
 export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]const u64, nargs: u64) callconv(.c) u64 {
     _ = vm;
     const n: usize = @intCast(nargs);

--- a/tests/e2e/programs/define-string.scm
+++ b/tests/e2e/programs/define-string.scm
@@ -1,0 +1,3 @@
+(define greeting "world")
+(display greeting)
+(newline)

--- a/tests/e2e/programs/define.scm
+++ b/tests/e2e/programs/define.scm
@@ -1,0 +1,3 @@
+(define x 42)
+(display x)
+(newline)

--- a/tests/e2e/programs/if-expr.scm
+++ b/tests/e2e/programs/if-expr.scm
@@ -1,0 +1,2 @@
+(display (if (< 1 2) 10 20))
+(newline)

--- a/tests/e2e/programs/string.scm
+++ b/tests/e2e/programs/string.scm
@@ -1,0 +1,2 @@
+(display "hello")
+(newline)

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -67,7 +67,7 @@ assert_native_parity() {
     fi
 
     local clang_output
-    local cc="${CC:-zig cc}"
+    local cc="${KAAPPI_CC:-zig cc}"
     if ! clang_output=$($cc -w "$ll_file" -o "$native_bin" -L"$LIBDIR" -lkaappi_rt -lc -lm -lpthread 2>&1); then
         echo "  cc: $clang_output"
         echo "FAIL: $label — clang linking failed"

--- a/tests/e2e/test-llvm-backend.scm
+++ b/tests/e2e/test-llvm-backend.scm
@@ -32,6 +32,23 @@
       (expect #f to-be-falsy))
 
     (it "evaluates not"
-      (expect (not #f) to-be-truthy))))
+      (expect (not #f) to-be-truthy)))
+
+  (describe "if expressions"
+    (it "selects consequent when true"
+      (expect (if #t 1 2) to-equal 1))
+
+    (it "selects alternate when false"
+      (expect (if #f 1 2) to-equal 2))
+
+    (it "folds comparison in test"
+      (expect (if (< 1 2) 10 20) to-equal 10)))
+
+  (describe "string constants"
+    (it "creates strings"
+      (expect "hello" to-equal "hello"))
+
+    (it "measures string length"
+      (expect (string-length "world") to-equal 5))))
 
 (run-specs)


### PR DESCRIPTION
## Summary

- Extends LLVM IR emitter with `if` (branching via LLVM basic blocks + phi), `define` (global variable binding), and string constants (runtime allocation)
- Adds two runtime exports: `kaappi_define_global`, `kaappi_make_string`
- Fixes `KAAPPI_CC` env var in e2e script (was `CC`, conflicting with system CC)
- 4 new test programs: define, define-string, if-expr, string
- BDD specs expanded from 10 to 15

## Test plan

- [x] `bash tests/e2e/run-e2e.sh` — 8/8 passed (15 BDD specs + 7 native parity)
- [x] `zig build` compiles without errors
- [x] `zig build lib` produces updated libkaappi_rt.a
- [x] Native binaries produce correct output for all test programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)