### PR TITLE
Add lambda and closure support to LLVM backend

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const ir = @import("ir.zig");
 const types = @import("types.zig");
+const printer = @import("printer.zig");
 
 const Value = types.Value;
 
@@ -79,6 +80,7 @@ pub const LLVMEmitter = struct {
             .begin => try self.emitBegin(node.data.begin),
             .@"if" => try self.emitIf(node.data.@"if"),
             .define => try self.emitDefine(node.data.define),
+            .lambda => try self.emitLambda(node.data.lambda),
             .passthrough => return error.UnsupportedNodeType,
             else => error.UnsupportedNodeType,
         };
@@ -195,9 +197,10 @@ pub const LLVMEmitter = struct {
         const name = types.symbolName(data.name);
         const sym_name = try self.internSymbol(name);
 
-        // DefineData.value is a raw S-expression Value, not an IR node.
-        // Handle literal constants directly.
-        const val = try self.emitConstant(data.value);
+        const val = if (types.isPair(data.value))
+            try self.emitEvalExpr(data.value)
+        else
+            try self.emitConstant(data.value);
 
         try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym_name, name.len, val });
 
@@ -205,6 +208,39 @@ pub const LLVMEmitter = struct {
         const void_val: i64 = @bitCast(types.VOID);
         try self.print("  {s} = add i64 0, {d}\n", .{ result, void_val });
         return result;
+    }
+
+    fn emitLambda(self: *LLVMEmitter, data: ir.LambdaData) EmitError![]const u8 {
+        var source_buf: std.ArrayList(u8) = .empty;
+        defer source_buf.deinit(self.allocator);
+        source_buf.appendSlice(self.allocator, "(lambda ") catch return error.OutOfMemory;
+
+        var current = data.args;
+        var first = true;
+        while (current != types.NIL and types.isPair(current)) {
+            if (!first) source_buf.append(self.allocator, ' ') catch return error.OutOfMemory;
+            first = false;
+            const elem = types.car(current);
+            const elem_str = printer.valueToString(self.allocator, elem, .write) catch return error.OutOfMemory;
+            defer self.allocator.free(elem_str);
+            source_buf.appendSlice(self.allocator, elem_str) catch return error.OutOfMemory;
+            current = types.cdr(current);
+        }
+        source_buf.append(self.allocator, ')') catch return error.OutOfMemory;
+
+        const str_name = try self.internString(source_buf.items);
+        const tmp = try self.freshTemp();
+        try self.print("  {s} = call i64 @kaappi_eval(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, source_buf.items.len });
+        return tmp;
+    }
+
+    fn emitEvalExpr(self: *LLVMEmitter, value: Value) EmitError![]const u8 {
+        const source = printer.valueToString(self.allocator, value, .write) catch return error.OutOfMemory;
+        defer self.allocator.free(source);
+        const str_name = try self.internString(source);
+        const tmp = try self.freshTemp();
+        try self.print("  {s} = call i64 @kaappi_eval(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, source.len });
+        return tmp;
     }
 
     fn internSymbol(self: *LLVMEmitter, name: []const u8) EmitError![]const u8 {
@@ -264,6 +300,7 @@ pub const LLVMEmitter = struct {
         try self.write("declare i64 @kaappi_call_scheme(ptr, i64, ptr, i64)\n");
         try self.write("declare void @kaappi_define_global(ptr, ptr, i64, i64)\n");
         try self.write("declare i64 @kaappi_make_string(ptr, ptr, i64)\n");
+        try self.write("declare i64 @kaappi_eval(ptr, ptr, i64)\n");
     }
 
     fn freshTemp(self: *LLVMEmitter) EmitError![]const u8 {

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -77,23 +77,26 @@ export fn kaappi_make_string(vm: ?*vm_mod.VM, str_ptr: [*]const u8, str_len: u64
     return result;
 }
 
+export fn kaappi_eval(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len: u64) callconv(.c) u64 {
+    const v = vm orelse return 0;
+    const len: usize = @intCast(src_len);
+    const source = src_ptr[0..len];
+    const result = v.eval(source) catch {
+        _ = std.posix.system.write(2, "eval error\n", 11);
+        std.process.exit(1);
+    };
+    return result;
+}
+
 export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]const u64, nargs: u64) callconv(.c) u64 {
-    _ = vm;
+    const v = vm orelse {
+        _ = std.posix.system.write(2, "null vm\n", 8);
+        std.process.exit(1);
+    };
     const n: usize = @intCast(nargs);
     const args: []const Value = if (n > 0 and args_ptr != null) args_ptr.?[0..n] else &.{};
-
-    if (!types.isPointer(callee)) {
-        _ = std.posix.system.write(2, "not a procedure\n", 16);
-        std.process.exit(1);
-    }
-    const obj = types.toObject(callee);
-    if (obj.tag != .native_fn) {
-        _ = std.posix.system.write(2, "not a procedure\n", 16);
-        std.process.exit(1);
-    }
-    const native = obj.as(types.NativeFn);
-    const result = native.func(args) catch {
-        _ = std.posix.system.write(2, "runtime error\n", 14);
+    const result = v.callWithArgs(callee, args) catch {
+        _ = std.posix.system.write(2, "runtime error in call\n", 22);
         std.process.exit(1);
     };
     return result;

--- a/tests/e2e/programs/lambda-basic.scm
+++ b/tests/e2e/programs/lambda-basic.scm
@@ -1,0 +1,3 @@
+(define square (lambda (x) (* x x)))
+(display (square 5))
+(newline)

--- a/tests/e2e/programs/lambda-closure.scm
+++ b/tests/e2e/programs/lambda-closure.scm
@@ -1,0 +1,4 @@
+(define make-adder (lambda (n) (lambda (x) (+ n x))))
+(define add-10 (make-adder 10))
+(display (add-10 5))
+(newline)

--- a/tests/e2e/test-llvm-backend.scm
+++ b/tests/e2e/test-llvm-backend.scm
@@ -49,6 +49,16 @@
       (expect "hello" to-equal "hello"))
 
     (it "measures string length"
-      (expect (string-length "world") to-equal 5))))
+      (expect (string-length "world") to-equal 5)))
+
+  (describe "lambda"
+    (it "applies inline lambda"
+      (expect ((lambda (x) (+ x 1)) 41) to-equal 42))
+
+    (it "applies lambda with multiple args"
+      (expect ((lambda (a b) (+ a b)) 3 7) to-equal 10))
+
+    (it "supports nested lambda (closure)"
+      (expect (((lambda (n) (lambda (x) (+ n x))) 10) 5) to-equal 15))))
 
 (run-specs)


### PR DESCRIPTION
## Summary

- Adds `lambda` support: serializes lambda S-expressions to source text, embeds as LLVM IR string constants, evaluates at runtime via `kaappi_eval`
- Fixes `kaappi_call_scheme` to use `VM.callWithArgs` — handles closures, not just NativeFns
- Handles `define` with compound values (lambda, list, etc.) via runtime eval
- New runtime export: `kaappi_eval(vm, src_ptr, src_len) -> value`

## Examples that now work

```scheme
(define square (lambda (x) (* x x)))
(display (square 5)) (newline)  ; → 25

(define make-adder (lambda (n) (lambda (x) (+ n x))))
(define add-10 (make-adder 10))
(display (add-10 5)) (newline)  ; → 15
```

## Test plan

- [x] `zig build` compiles
- [x] `bash tests/e2e/run-e2e.sh` — 11/11 native parity + 18 BDD specs
- [x] Lambda basic: native binary prints `25` for `(square 5)`
- [x] Closure: native binary prints `15` for `(add-10 5)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)