### PR TITLE
Add import/define-library support to LLVM backend

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -90,7 +90,7 @@ pub const LLVMEmitter = struct {
             .do_form, .delay, .delay_force, .cond, .case_form, .case_lambda, .guard => try self.emitSexprEval(node),
             .quasiquote, .parameterize, .define_values, .let_values, .let_star_values => try self.emitSexprEval(node),
             .define_syntax, .let_syntax, .letrec_syntax, .cond_expand => try self.emitSexprEval(node),
-            .passthrough => return error.UnsupportedNodeType,
+            .passthrough => try self.emitEvalExpr(node.data.passthrough),
         };
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1672,6 +1672,26 @@ fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !voi
             return;
         };
 
+        // Handle top-level forms (import, define-library) at compile time
+        // so subsequent expressions can reference imported bindings.
+        // Also emit them as kaappi_eval calls for runtime execution.
+        if (types.isPair(expr)) {
+            const head = types.car(expr);
+            if (types.isSymbol(head)) {
+                const form_name = types.symbolName(head);
+                if (std.mem.eql(u8, form_name, "import") or
+                    std.mem.eql(u8, form_name, "define-library"))
+                {
+                    if (vm.handleTopLevelForm(expr)) |result| {
+                        _ = result catch {};
+                    }
+                    const passthrough_node = ir_instance.makePassthrough(expr) catch continue;
+                    ir_nodes.append(allocator, passthrough_node) catch continue;
+                    continue;
+                }
+            }
+        }
+
         var root = ir_mod.lowerWithMacros(&ir_instance, expr, &vm.macros) catch |err| {
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "IR lowering error: {}\n", .{err}) catch "IR error\n";

--- a/tests/e2e/programs/import.scm
+++ b/tests/e2e/programs/import.scm
@@ -1,0 +1,3 @@
+(import (scheme base) (scheme write) (scheme char))
+(display (char-upcase #\a))
+(newline)


### PR DESCRIPTION
## Summary

- Import and define-library forms processed at compile time AND emitted for runtime execution
- Passthrough nodes now handled via kaappi_eval instead of erroring
- Native binaries can import standard libraries and ecosystem packages

Closes #143

## Test plan

- [x] `(import (scheme char)) (display (char-upcase #\a))` → native binary prints `A`
- [x] `bash tests/e2e/run-e2e.sh` — 12/12 native parity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)