### PR TITLE
Add SRFI-69 hash-table-equivalence-function, hash-table-hash-function

### DIFF
--- a/src/library.zig
+++ b/src/library.zig
@@ -542,17 +542,18 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
 
     // SRFI-69: Hash Tables
     const srfi69_names = [_][]const u8{
-        "make-hash-table",        "hash-table?",
-        "hash-table-ref",         "hash-table-set!",
-        "hash-table-delete!",     "hash-table-exists?",
-        "hash-table-size",        "hash-table-keys",
-        "hash-table-values",      "hash-table-walk",
-        "hash-table->alist",      "alist->hash-table",
-        "hash-table-copy",        "hash-table-update!/default",
-        "hash",                   "string-hash",
-        "string-ci-hash",         "hash-by-identity",
-        "hash-table-ref/default", "hash-table-fold",
-        "hash-table-merge!",
+        "make-hash-table",          "hash-table?",
+        "hash-table-ref",           "hash-table-set!",
+        "hash-table-delete!",       "hash-table-exists?",
+        "hash-table-size",          "hash-table-keys",
+        "hash-table-values",        "hash-table-walk",
+        "hash-table->alist",        "alist->hash-table",
+        "hash-table-copy",          "hash-table-update!/default",
+        "hash",                     "string-hash",
+        "string-ci-hash",           "hash-by-identity",
+        "hash-table-ref/default",   "hash-table-fold",
+        "hash-table-merge!",        "hash-table-equivalence-function",
+        "hash-table-hash-function",
     };
     var srfi69_lib = Library.init(allocator, "srfi.69");
     for (srfi69_names) |name| {
@@ -893,17 +894,18 @@ pub fn registerSandboxedLibraries(registry: *LibraryRegistry, globals: *std.Stri
 
     // SRFI-69
     const srfi69_names = [_][]const u8{
-        "make-hash-table",        "hash-table?",
-        "hash-table-ref",         "hash-table-set!",
-        "hash-table-delete!",     "hash-table-exists?",
-        "hash-table-size",        "hash-table-keys",
-        "hash-table-values",      "hash-table-walk",
-        "hash-table->alist",      "alist->hash-table",
-        "hash-table-copy",        "hash-table-update!/default",
-        "hash",                   "string-hash",
-        "string-ci-hash",         "hash-by-identity",
-        "hash-table-ref/default", "hash-table-fold",
-        "hash-table-merge!",
+        "make-hash-table",          "hash-table?",
+        "hash-table-ref",           "hash-table-set!",
+        "hash-table-delete!",       "hash-table-exists?",
+        "hash-table-size",          "hash-table-keys",
+        "hash-table-values",        "hash-table-walk",
+        "hash-table->alist",        "alist->hash-table",
+        "hash-table-copy",          "hash-table-update!/default",
+        "hash",                     "string-hash",
+        "string-ci-hash",           "hash-by-identity",
+        "hash-table-ref/default",   "hash-table-fold",
+        "hash-table-merge!",        "hash-table-equivalence-function",
+        "hash-table-hash-function",
     };
     var srfi69_lib = Library.init(allocator, "srfi.69");
     for (srfi69_names) |name| {

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -34,6 +34,8 @@ pub fn registerHashTable(vm: *vm_mod.VM) !void {
     try reg(vm, "hash-table-ref/default", &hashTableRefDefaultFn, .{ .exact = 3 });
     try reg(vm, "hash-table-fold", &hashTableFoldFn, .{ .exact = 3 });
     try reg(vm, "hash-table-merge!", &hashTableMergeFn, .{ .exact = 2 });
+    try reg(vm, "hash-table-equivalence-function", &hashTableEquivFn, .{ .exact = 1 });
+    try reg(vm, "hash-table-hash-function", &hashTableHashFn, .{ .exact = 1 });
 }
 
 // ---------------------------------------------------------------------------
@@ -498,4 +500,16 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
         }
     }
     return args[0];
+}
+
+fn hashTableEquivFn(args: []const Value) PrimitiveError!Value {
+    _ = getHashTable("hash-table-equivalence-function", args[0]) catch return PrimitiveError.TypeError;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
+    return vm.globals.get("equal?") orelse return PrimitiveError.TypeError;
+}
+
+fn hashTableHashFn(args: []const Value) PrimitiveError!Value {
+    _ = getHashTable("hash-table-hash-function", args[0]) catch return PrimitiveError.TypeError;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
+    return vm.globals.get("hash") orelse return PrimitiveError.TypeError;
 }

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -503,13 +503,13 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn hashTableEquivFn(args: []const Value) PrimitiveError!Value {
-    _ = getHashTable("hash-table-equivalence-function", args[0]) catch return PrimitiveError.TypeError;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
-    return vm.globals.get("equal?") orelse return PrimitiveError.TypeError;
+    _ = try getHashTable("hash-table-equivalence-function", args[0]);
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
+    return vm.globals.get("equal?") orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
 }
 
 fn hashTableHashFn(args: []const Value) PrimitiveError!Value {
-    _ = getHashTable("hash-table-hash-function", args[0]) catch return PrimitiveError.TypeError;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
-    return vm.globals.get("hash") orelse return PrimitiveError.TypeError;
+    _ = try getHashTable("hash-table-hash-function", args[0]);
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
+    return vm.globals.get("hash") orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
 }

--- a/tests/scheme/srfi/test-srfi69-extras.scm
+++ b/tests/scheme/srfi/test-srfi69-extras.scm
@@ -1,0 +1,31 @@
+;; Test SRFI-69 extra procedures
+
+(import (scheme base) (scheme write) (srfi 69))
+
+(define ht (make-hash-table))
+(hash-table-set! ht "key" 42)
+
+;; hash-table-equivalence-function returns a procedure
+(display (procedure? (hash-table-equivalence-function ht)))
+(newline)
+;; Expected: #t
+
+;; hash-table-hash-function returns a procedure
+(display (procedure? (hash-table-hash-function ht)))
+(newline)
+;; Expected: #t
+
+;; The equivalence function should be equal?
+(let ((equiv (hash-table-equivalence-function ht)))
+  (display (equiv "hello" "hello")))
+(newline)
+;; Expected: #t
+
+;; The hash function should work
+(let ((h (hash-table-hash-function ht)))
+  (display (number? (h "test"))))
+(newline)
+;; Expected: #t
+
+(display "srfi69-extras-ok")
+(newline)


### PR DESCRIPTION
## Summary

Adds the two missing SRFI-69 introspection procedures:
- `hash-table-equivalence-function` — returns `equal?`
- `hash-table-hash-function` — returns `hash`

Partially addresses #148

## Test plan

- [x] `zig build` compiles
- [x] Both procedures return working procedures
- [x] Test: `tests/scheme/srfi/test-srfi69-extras.scm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)