### PR TITLE
Add vector-append-subvectors (SRFI-133)

### DIFF
--- a/src/library.zig
+++ b/src/library.zig
@@ -571,7 +571,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
         "vector-any",          "vector-every",      "vector-index",        "vector-index-right",
         "vector-skip",         "vector-skip-right", "vector-swap!",        "vector-reverse!",
         "vector-reverse-copy", "vector-unfold",     "vector-unfold-right", "vector-binary-search",
-        "vector-concatenate",  "vector-cumulate",   "vector-partition",
+        "vector-concatenate",  "vector-cumulate",   "vector-partition",    "vector-append-subvectors",
     };
     var srfi133_lib = Library.init(allocator, "srfi.133");
     for (srfi133_names) |name| {
@@ -922,7 +922,7 @@ pub fn registerSandboxedLibraries(registry: *LibraryRegistry, globals: *std.Stri
         "vector-any",          "vector-every",      "vector-index",        "vector-index-right",
         "vector-skip",         "vector-skip-right", "vector-swap!",        "vector-reverse!",
         "vector-reverse-copy", "vector-unfold",     "vector-unfold-right", "vector-binary-search",
-        "vector-concatenate",  "vector-cumulate",   "vector-partition",
+        "vector-concatenate",  "vector-cumulate",   "vector-partition",    "vector-append-subvectors",
     };
     var srfi133_lib = Library.init(allocator, "srfi.133");
     for (srfi133_names) |name| {

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -44,6 +44,7 @@ pub fn registerVector(vm: *vm_mod.VM) !void {
     try reg(vm, "vector-concatenate", &vectorConcatenateFn, .{ .exact = 1 });
     try reg(vm, "vector-cumulate", &vectorCumulateFn, .{ .exact = 3 });
     try reg(vm, "vector-partition", &vectorPartitionFn, .{ .exact = 2 });
+    try reg(vm, "vector-append-subvectors", &vectorAppendSubvectorsFn, .{ .variadic = 0 });
 }
 
 // ---------------------------------------------------------------------------
@@ -879,4 +880,34 @@ fn vectorPartitionFn(args: []const Value) PrimitiveError!Value {
 
     const vals = [2]Value{ yes_vec, count_val };
     return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
+}
+
+fn vectorAppendSubvectorsFn(args: []const Value) PrimitiveError!Value {
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (args.len % 3 != 0) return primitives.typeError("vector-append-subvectors", "multiple of 3 arguments", types.makeFixnum(@intCast(args.len)));
+
+    var total: usize = 0;
+    var i: usize = 0;
+    while (i < args.len) : (i += 3) {
+        if (!types.isVector(args[i])) return primitives.typeError("vector-append-subvectors", "vector", args[i]);
+        if (!types.isFixnum(args[i + 1])) return primitives.typeError("vector-append-subvectors", "integer", args[i + 1]);
+        if (!types.isFixnum(args[i + 2])) return primitives.typeError("vector-append-subvectors", "integer", args[i + 2]);
+        const start: usize = @intCast(types.toFixnum(args[i + 1]));
+        const end: usize = @intCast(types.toFixnum(args[i + 2]));
+        if (end < start) return PrimitiveError.TypeError;
+        total += end - start;
+    }
+
+    const result_data = gc.allocator.alloc(Value, total) catch return PrimitiveError.OutOfMemory;
+    var pos: usize = 0;
+    i = 0;
+    while (i < args.len) : (i += 3) {
+        const vec = types.toVector(args[i]);
+        const start: usize = @intCast(types.toFixnum(args[i + 1]));
+        const end: usize = @intCast(types.toFixnum(args[i + 2]));
+        @memcpy(result_data[pos .. pos + (end - start)], vec.data[start..end]);
+        pos += end - start;
+    }
+    defer gc.allocator.free(result_data);
+    return gc.allocVector(result_data) catch return PrimitiveError.OutOfMemory;
 }

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -894,7 +894,7 @@ fn vectorAppendSubvectorsFn(args: []const Value) PrimitiveError!Value {
         if (!types.isFixnum(args[i + 2])) return primitives.typeError("vector-append-subvectors", "integer", args[i + 2]);
         const start: usize = @intCast(types.toFixnum(args[i + 1]));
         const end: usize = @intCast(types.toFixnum(args[i + 2]));
-        if (end < start) return PrimitiveError.TypeError;
+        if (end < start) return primitives.typeError("vector-append-subvectors", "valid range (end >= start)", args[i + 2]);
         total += end - start;
     }
 


### PR DESCRIPTION
## Summary

Implements the last missing SRFI-133 procedure. Takes triples of (vector start end) and concatenates the specified subranges.

```scheme
(vector-append-subvectors #(1 2 3 4 5) 1 3 #(10 20 30) 0 2)
;; => #(2 3 10 20)
```

Partially addresses #148

## Test plan

- [x] `zig build` compiles
- [x] Procedure produces correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)