### PR TITLE
Show source code snippets in runtime error messages

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -89,6 +89,34 @@ fn writeStderr(bytes: []const u8) void {
     writeToFd(2, bytes);
 }
 
+fn printSourceSnippet(source: []const u8, line: u32) void {
+    if (line == 0 or source.len == 0) return;
+    var current_line: u32 = 1;
+    var line_start: usize = 0;
+    for (source, 0..) |c, i| {
+        if (current_line == line) {
+            var line_end = i;
+            while (line_end < source.len and source[line_end] != '\n') : (line_end += 1) {}
+            const snippet = source[line_start..line_end];
+            if (snippet.len > 0) {
+                writeStderr("    ");
+                writeStderr(snippet);
+                writeStderr("\n");
+            }
+            return;
+        }
+        if (c == '\n') {
+            current_line += 1;
+            line_start = i + 1;
+        }
+    }
+    if (current_line == line and line_start < source.len) {
+        writeStderr("    ");
+        writeStderr(source[line_start..]);
+        writeStderr("\n");
+    }
+}
+
 fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     const path_z = allocator.dupeZ(u8, path) catch return error.OutOfMemory;
     defer allocator.free(path_z);
@@ -672,6 +700,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                 const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: runtime error: {}\n", .{ err_source, err_line, err }) catch "runtime error\n";
                 writeStderr(s);
             }
+            printSourceSnippet(source, err_line);
             // Print stack trace for file execution
             const trace = vm.getLastStackTrace();
             if (trace.len > 1) {

--- a/tests/scheme/errors/test-source-snippet.sh
+++ b/tests/scheme/errors/test-source-snippet.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Test that error messages include source code snippets
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+
+assert_contains() {
+    local label="$1"
+    local input="$2"
+    local expected="$3"
+    local output
+    output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
+    if echo "$output" | grep -qF "$expected"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected '$expected' in output"
+        echo "  got: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Test: runtime error shows source snippet
+TMPFILE=$(mktemp /tmp/kaappi_err_XXXXXX.scm)
+echo '(define (foo x) (+ x 1))
+(foo "hello")' > "$TMPFILE"
+output=$("$KAAPPI" "$TMPFILE" 2>&1 || true)
+if echo "$output" | grep -qF '(define (foo x) (+ x 1))'; then
+    echo "PASS: runtime error includes source snippet"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: runtime error should include source snippet"
+    echo "  got: $output"
+    FAIL=$((FAIL + 1))
+fi
+rm -f "$TMPFILE"
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Runtime errors during file execution now show the offending source line:

```
program.scm:3: error: undefined variable 'foo'
    (display foo)
  called from program.scm:5
```

Closes #152

## Test plan

- [x] `zig build` compiles
- [x] Errors show source line indented below the message
- [x] Regression test: `tests/scheme/errors/test-source-snippet.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)