### PR TITLE
Add --profile-json for machine-readable profile export

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -398,6 +398,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     var disassemble_mode = false;
     var gc_stats_mode = false;
     var profile_mode = false;
+    var profile_json_path: ?[]const u8 = null;
     var coverage_mode = false;
     var sandbox_mode = false;
 
@@ -413,6 +414,9 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             }
         } else if (std.mem.eql(u8, arg, "--profile")) {
             profile_mode = true;
+        } else if (std.mem.eql(u8, arg, "--profile-json")) {
+            profile_mode = true;
+            profile_json_path = args.next();
         } else if (std.mem.eql(u8, arg, "--coverage")) {
             coverage_mode = true;
         } else if (std.mem.eql(u8, arg, "--coverage-xml")) {
@@ -513,7 +517,12 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
 
     defer if (gc_stats_mode) reporting.printGcStats(&gc);
     if (profile_mode) vm.profile_mode = true;
-    defer if (profile_mode) reporting.printProfileReport(&gc);
+    defer if (profile_mode) {
+        reporting.printProfileReport(&gc);
+        if (profile_json_path) |jp| {
+            reporting.writeProfileJson(&gc, jp);
+        }
+    };
     if (coverage_mode) {
         vm.profile_mode = true;
         vm.coverage_mode = true;

--- a/src/reporting.zig
+++ b/src/reporting.zig
@@ -622,3 +622,57 @@ pub fn printCoverageReport(vm: *vm_mod.VM) void {
         writeStderr(summary);
     }
 }
+
+pub fn writeProfileJson(gc: *memory.GC, path: []const u8) void {
+    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{
+        .ACCMODE = .WRONLY,
+        .CREAT = true,
+        .TRUNC = true,
+    }, 0o644) catch return;
+    defer _ = std.posix.system.close(fd);
+
+    writeToFd(fd, "[");
+    var first = true;
+    var obj = gc.objects;
+    while (obj) |o| {
+        if (o.tag == .function) {
+            const func = o.as(types.Function);
+            if (func.profile_calls > 0) {
+                if (!first) writeToFd(fd, ",");
+                first = false;
+                var buf: [512]u8 = undefined;
+                const s = std.fmt.bufPrint(&buf,
+                    \\{{"name":"{s}","source":"{s}","line":{d},"calls":{d},"self_ns":{d},"total_ns":{d},"alloc_bytes":{d}}}
+                , .{
+                    func.name orelse "(lambda)",
+                    func.source_name orelse "?",
+                    func.source_line,
+                    func.profile_calls,
+                    func.profile_time_ns,
+                    func.profile_inclusive_ns,
+                    func.profile_alloc_bytes,
+                }) catch continue;
+                writeToFd(fd, s);
+            }
+        } else if (o.tag == .native_fn) {
+            const native = o.as(types.NativeFn);
+            if (native.profile_calls > 0) {
+                if (!first) writeToFd(fd, ",");
+                first = false;
+                var buf: [512]u8 = undefined;
+                const s = std.fmt.bufPrint(&buf,
+                    \\{{"name":"{s}","source":"built-in","line":0,"calls":{d},"self_ns":{d},"total_ns":{d},"alloc_bytes":{d}}}
+                , .{
+                    native.name,
+                    native.profile_calls,
+                    native.profile_time_ns,
+                    native.profile_time_ns,
+                    native.profile_alloc_bytes,
+                }) catch continue;
+                writeToFd(fd, s);
+            }
+        }
+        obj = o.next;
+    }
+    writeToFd(fd, "]\n");
+}


### PR DESCRIPTION
## Summary

Adds `--profile-json <file>` flag that writes profiling data as a JSON array. Each entry contains function name, source location, call count, self/total time, and allocation bytes.

```bash
kaappi --profile --profile-json profile.json program.scm
```

Closes #153

## Test plan

- [x] `zig build` compiles
- [x] `--profile-json` writes valid JSON with function entries
- [x] Regular `--profile` output unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)