### PR TITLE
Fix symbol identity in native binaries

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -102,6 +102,16 @@ pub const LLVMEmitter = struct {
             try self.print("  {s} = call i64 @kaappi_make_string(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, str_data.len });
             return tmp;
         }
+        if (types.isSymbol(value)) {
+            const sym_data = types.symbolName(value);
+            const str_name = try self.internString(sym_data);
+            const tmp = try self.freshTemp();
+            try self.print("  {s} = call i64 @kaappi_intern_symbol(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, sym_data.len });
+            return tmp;
+        }
+        if (types.isPointer(value)) {
+            return self.emitEvalExpr(value);
+        }
         const tmp = try self.freshTemp();
         const signed: i64 = @bitCast(value);
         try self.print("  {s} = add i64 0, {d}\n", .{ tmp, signed });
@@ -545,6 +555,7 @@ pub const LLVMEmitter = struct {
         try self.write("declare i64 @kaappi_call_scheme(ptr, i64, ptr, i64)\n");
         try self.write("declare void @kaappi_define_global(ptr, ptr, i64, i64)\n");
         try self.write("declare i64 @kaappi_make_string(ptr, ptr, i64)\n");
+        try self.write("declare i64 @kaappi_intern_symbol(ptr, ptr, i64)\n");
         try self.write("declare i64 @kaappi_eval(ptr, ptr, i64)\n");
     }
 

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -77,6 +77,17 @@ export fn kaappi_make_string(vm: ?*vm_mod.VM, str_ptr: [*]const u8, str_len: u64
     return result;
 }
 
+export fn kaappi_intern_symbol(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len: u64) callconv(.c) u64 {
+    const v = vm orelse return 0;
+    const len: usize = @intCast(name_len);
+    const name = name_ptr[0..len];
+    const result = v.gc.allocSymbol(name) catch {
+        _ = std.posix.system.write(2, "failed to intern symbol\n", 24);
+        std.process.exit(1);
+    };
+    return result;
+}
+
 export fn kaappi_eval(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len: u64) callconv(.c) u64 {
     const v = vm orelse return 0;
     const len: usize = @intCast(src_len);

--- a/tests/e2e/programs/symbol-eq.scm
+++ b/tests/e2e/programs/symbol-eq.scm
@@ -1,0 +1,12 @@
+(define (make-counter start)
+  (let ((n start))
+    (lambda (msg)
+      (cond ((eq? msg 'get) n)
+            ((eq? msg 'inc) (set! n (+ n 1)) n)
+            (else 0)))))
+
+(define c (make-counter 0))
+(display (c 'get))
+(display (c 'inc))
+(display (c 'inc))
+(newline)


### PR DESCRIPTION
## Summary

Symbol constants in LLVM IR were emitted as raw NaN-boxed pointers to compile-time GC objects — dangling at runtime. This broke `eq?` on quoted symbols in closures compiled via `kaappi_eval`.

**Before:** `(eq? msg 'get)` in a closure always returned `#f` in native binaries
**After:** Symbols are interned at runtime via `kaappi_intern_symbol`, ensuring identity matches

Also handles other heap-allocated constants (pairs, vectors) by falling back to `kaappi_eval`.

Found by testing a real closure-based message-dispatch program against the LLVM backend.

## Test plan

- [x] Counter program with `eq?` symbol dispatch works: `0 1 2 3 2`
- [x] `bash tests/e2e/run-e2e.sh` — 17/17 pass (new `symbol-eq` test added)
- [x] FizzBuzz still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)