### PR TITLE
Fix quoted list constants and macro support in native binaries

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -110,7 +110,7 @@ pub const LLVMEmitter = struct {
             return tmp;
         }
         if (types.isPointer(value)) {
-            return self.emitEvalExpr(value);
+            return self.emitQuotedEvalExpr(value);
         }
         const tmp = try self.freshTemp();
         const signed: i64 = @bitCast(value);
@@ -491,6 +491,17 @@ pub const LLVMEmitter = struct {
 
     fn emitEvalExpr(self: *LLVMEmitter, value: Value) EmitError![]const u8 {
         const source = printer.valueToString(self.allocator, value, .write) catch return error.OutOfMemory;
+        defer self.allocator.free(source);
+        const str_name = try self.internString(source);
+        const tmp = try self.freshTemp();
+        try self.print("  {s} = call i64 @kaappi_eval(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, source.len });
+        return tmp;
+    }
+
+    fn emitQuotedEvalExpr(self: *LLVMEmitter, value: Value) EmitError![]const u8 {
+        const printed = printer.valueToString(self.allocator, value, .write) catch return error.OutOfMemory;
+        defer self.allocator.free(printed);
+        const source = std.fmt.allocPrint(self.allocator, "(quote {s})", .{printed}) catch return error.OutOfMemory;
         defer self.allocator.free(source);
         const str_name = try self.internString(source);
         const tmp = try self.freshTemp();

--- a/src/main.zig
+++ b/src/main.zig
@@ -1727,6 +1727,15 @@ fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !voi
                     ir_nodes.append(allocator, passthrough_node) catch continue;
                     continue;
                 }
+                if (std.mem.eql(u8, form_name, "define-syntax") or
+                    std.mem.eql(u8, form_name, "define-record-type"))
+                {
+                    const func = compiler.compileExpressionWithMacros(vm.gc, expr, &vm.macros, &vm.globals) catch continue;
+                    _ = vm.execute(func) catch {};
+                    const passthrough_node = ir_instance.makePassthrough(expr) catch continue;
+                    ir_nodes.append(allocator, passthrough_node) catch continue;
+                    continue;
+                }
             }
         }
 

--- a/tests/e2e/programs/macro.scm
+++ b/tests/e2e/programs/macro.scm
@@ -1,0 +1,7 @@
+(import (scheme base) (scheme write))
+(define-syntax my-when
+  (syntax-rules ()
+    ((_ test body ...)
+     (if test (begin body ...)))))
+(my-when #t (display 42))
+(newline)

--- a/tests/e2e/programs/quoted-list.scm
+++ b/tests/e2e/programs/quoted-list.scm
@@ -1,0 +1,6 @@
+(import (scheme base) (scheme write))
+(define (my-len lst)
+  (if (null? lst) 0
+      (+ 1 (my-len (cdr lst)))))
+(display (my-len '(1 2 3 4 5)))
+(newline)


### PR DESCRIPTION
## Summary

Two bugs found by stress-testing real programs against the LLVM backend:

1. **Quoted list constants** like `'(1 2 3)` were emitted as raw pointers to compile-time GC objects — dangling at runtime. Fix: wrap pointer constants in `(quote ...)` before eval.

2. **define-syntax** forms weren't processed at compile time, so macros weren't available for subsequent expressions. Fix: compile and execute `define-syntax` at compile time (like `import`).

## Test plan

- [x] `(my-len '(1 2 3 4 5))` → `5` in native binary
- [x] `define-syntax` macros work in native binary
- [x] `bash tests/e2e/run-e2e.sh` — 19/19 pass
- [x] Guard/error handling works
- [x] Recursive data structures (flatten, assq) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)