### PR TITLE
Update developer docs for LLVM backend and IR changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,13 @@ and continuation-heavy workloads — only use it when debugging:
 ### LLVM native backend
 
 ```bash
+zig build native -Dnative-src=program.scm        # single-step native compilation
+./zig-out/bin/program                            # run native binary
+
+# Or manual three-step:
 zig build lib                                    # build libkaappi_rt.a
-zig build run -- --emit-llvm program.scm -o out.ll  # emit LLVM IR
+zig build run -- --emit-llvm -o out.ll program.scm  # emit LLVM IR
 zig cc -w out.ll -o program -Lzig-out/lib -lkaappi_rt -lc -lm -lpthread  # link
-./program                                        # run native binary
 ```
 
 **Always use `zig cc` (not `clang`) for linking native binaries against
@@ -203,6 +206,8 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 | `linenoise.zig` | Zig FFI wrapper for vendored linenoise C library |
 | `main.zig` | Entry point, REPL loop with linenoise, file execution, CLI flags, `pub const version` |
 | `thottam.zig` | Package manager binary (thottam): install, remove, list, update, verify |
+| `llvm_emit.zig` | LLVM IR text emitter (walks IR nodes, produces `.ll` files) |
+| `runtime_exports.zig` | C-ABI bridge for LLVM native backend (8 exported functions) |
 | `testing_helpers.zig` | Shared `makeTestVM` helper for unit tests |
 | `tests_ir.zig` | IR tests: bytecode parity, behavioral correctness, analysis, optimizations |
 | `tests_*.zig` | Unit tests by feature (core_eval, tail_calls, macros, io, etc.) |

--- a/README.md
+++ b/README.md
@@ -223,6 +223,25 @@ zig build run -- examples/hello.scm
 echo '(+ 1 2)' | zig build run
 ```
 
+### Native compilation (LLVM backend)
+
+Compile Scheme programs to native executables via LLVM IR:
+
+```bash
+# Single-step
+zig build native -Dnative-src=program.scm
+./zig-out/bin/program
+
+# Manual three-step
+zig build lib                                        # build runtime library
+kaappi --emit-llvm -o program.ll program.scm         # emit LLVM IR
+zig cc -w program.ll -o program \
+    -Lzig-out/lib -lkaappi_rt -lc -lm -lpthread      # link
+```
+
+The native binary links against `libkaappi_rt.a` (the Kaappi runtime).
+Always use `zig cc` (not `clang`) for linking.
+
 ---
 
 ## Project structure
@@ -250,12 +269,15 @@ kaappi/
 │   ├── bytecode_file.zig          Bytecode serialization (.sbc format)
 │   ├── library.zig                Library registry + standard libs
 │   │
-│   ├── compiler.zig               Bytecode compiler (core)
+│   ├── ir.zig                     Intermediate representation (33 node types, analysis, optimization)
+│   ├── compiler.zig               Bytecode compiler (IR → bytecode via compileFromNode)
 │   ├── compiler_forms.zig         Re-export hub for derived forms
 │   ├── compiler_conditionals.zig  and, or, cond, when, unless, cond-expand
 │   ├── compiler_bindings.zig      let, letrec, do, let-values
 │   ├── compiler_advanced.zig      case, case-lambda, guard, quasiquote
 │   ├── compiler_lambda.zig        lambda, define, set!, begin, delay
+│   ├── llvm_emit.zig              LLVM IR text emitter (IR → .ll files)
+│   ├── runtime_exports.zig        C-ABI bridge for LLVM native backend
 │   │
 │   ├── vm.zig                     Register VM (core)
 │   ├── vm_eval.zig                eval, top-level form handling

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -116,6 +116,8 @@ Source code
 | `jit_aarch64.zig` | AArch64 assembler (fixed 4-byte instruction encoding) |
 | `jit_x86_64.zig` | x86_64 assembler (variable-length encoding, REX prefixes) |
 | `jit_mem.zig` | Executable memory allocation (mmap RWX, macOS JIT protection + entitlements) |
+| `runtime_exports.zig` | C-ABI bridge for LLVM native backend (8 exported functions) |
+| `llvm_emit.zig` | LLVM IR text emitter (walks IR nodes, produces `.ll` files) |
 | `bignum.zig` | Arbitrary-precision integer arithmetic |
 | `bytecode_file.zig` | Bytecode serialization/deserialization (.sbc format) |
 | `disassembler.zig` | Bytecode disassembler for `(disassemble proc)` |

--- a/docs/dev/ir.md
+++ b/docs/dev/ir.md
@@ -129,9 +129,14 @@ Every node carries an `Annotations` struct set by the analysis passes:
 
 Two entry points convert S-expressions to IR:
 
-- **`lower(ir, expr)`** — basic lowering (no macro awareness)
-- **`lowerWithMacros(ir, expr, macros)`** — macro-aware; checks the macro
-  table and falls back to `passthrough` for macro invocations
+- **`lowerWithMacros(ir, expr, macros)`** — primary entry point; checks the
+  macro table and falls back to `passthrough` for macro invocations
+- **`lower(ir, expr)`** — convenience wrapper that calls
+  `lowerWithMacros(ir, expr, null)`
+
+All recursive lowering uses `lowerWithMacros` internally, threading the
+macros parameter through helper functions. This ensures nested calls
+produce proper `call` nodes instead of `passthrough` nodes.
 
 Lowering dispatches on the head symbol of a pair. Per-form helpers:
 `lowerIf`, `lowerQuote`, `lowerBegin`, `lowerLet`, `lowerDefine`,

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -39,7 +39,7 @@ Source → Reader → Expander → IR → Analysis → Optimization
                               |                                           |
                         Bytecode Emission                          LLVM IR Emission
                               |                                           |
-                         VM + JIT                                   clang / zig cc
+                         VM + JIT                                    zig cc
                               |                                           |
                         Interpreter                               Native Binary
                     (REPL, debugging)                        (links libkaappi_rt.a)
@@ -59,9 +59,10 @@ functions that native code calls:
 | `kaappi_runtime_init` | Create GC, VM, register primitives, return VM pointer |
 | `kaappi_runtime_deinit` | Clean up VM and GC |
 | `kaappi_global_lookup` | Look up a global variable by name |
-| `kaappi_call_scheme` | Call a Scheme procedure (closure, native, etc.) |
+| `kaappi_call_scheme` | Call a Scheme procedure (closure, native, etc.) via `VM.callWithArgs` |
 | `kaappi_define_global` | Define a global variable |
 | `kaappi_make_string` | Allocate a string on the GC heap |
+| `kaappi_intern_symbol` | Intern a symbol via the GC symbol table (ensures `eq?` identity) |
 | `kaappi_eval` | Parse, compile, and evaluate a Scheme expression |
 
 All functions use `callconv(.c)` and pass Values as plain `u64` (the
@@ -69,12 +70,21 @@ NaN-boxed representation crosses C ABI trivially).
 
 ## Build and Usage
 
+### Manual three-step flow
+
 ```bash
 zig build lib                                        # build libkaappi_rt.a
-kaappi --emit-llvm program.scm -o program.ll         # emit LLVM IR
+kaappi --emit-llvm -o program.ll program.scm         # emit LLVM IR
 zig cc -w program.ll -o program \
     -Lzig-out/lib -lkaappi_rt -lc -lm -lpthread      # link native binary
 ./program                                            # run
+```
+
+### Single-step build
+
+```bash
+zig build native -Dnative-src=program.scm            # all-in-one
+./zig-out/bin/program                                # run
 ```
 
 **Always use `zig cc` (not `clang`) for linking.** The Zig-compiled static
@@ -84,28 +94,58 @@ that `clang` cannot resolve.
 ## LLVM IR Emission
 
 The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
-(`.ll` files). Supported IR node types:
+(`.ll` files). All 33 IR node types are handled:
 
 | Node | LLVM IR output |
 |------|---------------|
-| `constant` | Literal `i64` value (NaN-boxed) |
+| `constant` | Literal `i64` for immediates; `kaappi_make_string` for strings; `kaappi_intern_symbol` for symbols; `(quote ...)` via `kaappi_eval` for other heap values |
 | `global_ref` | `call @kaappi_global_lookup(...)` |
 | `call` | Stack-allocate args array, `call @kaappi_call_scheme(...)` |
 | `begin` | Emit each expression sequentially |
 | `if` | LLVM basic blocks with `br`/`phi` |
-| `define` | `call @kaappi_define_global(...)` |
+| `and`/`or` | Short-circuit with basic blocks and `phi` |
+| `when`/`unless` | Conditional body execution |
+| `define` | `call @kaappi_define_global(...)` (compound values via `kaappi_eval`) |
+| `set!` | `call @kaappi_define_global(...)` |
 | `lambda` | Serialize to source text, `call @kaappi_eval(...)` |
+| `let`, `letrec`, `cond`, `case`, `do`, `guard`, etc. | Serialize to source text, `call @kaappi_eval(...)` |
+| `passthrough` | Serialize to source text, `call @kaappi_eval(...)` |
 
-String constants are heap-allocated at runtime via `kaappi_make_string`.
-Lambda bodies are compiled at runtime via `kaappi_eval` (the interpreter
-handles the full compilation pipeline).
+## Compile-Time Processing
+
+The `--emit-llvm` path processes certain top-level forms at compile time
+so their effects are available to subsequent expressions during IR lowering:
+
+| Form | Compile-time action |
+|------|-------------------|
+| `import` | Loads the library, registers bindings in VM globals |
+| `define-library` | Registers the library in the VM |
+| `define-syntax` | Compiles and executes the macro definition |
+| `define-record-type` | Compiles and executes the record type definition |
+
+All four are also emitted as `kaappi_eval` calls for runtime execution
+in the native binary.
+
+## Heap-Allocated Constants
+
+Constants that are heap objects (pairs, vectors, symbols, strings) cannot
+be embedded as raw pointer values in LLVM IR — those pointers reference
+the compile-time GC heap which doesn't exist at runtime. Each type is
+handled differently:
+
+- **Strings**: `kaappi_make_string(vm, data_ptr, len)` — allocated at runtime
+- **Symbols**: `kaappi_intern_symbol(vm, name_ptr, len)` — interned at runtime,
+  ensuring `eq?` identity matches between native code and interpreter closures
+- **Pairs, vectors, other heap values**: Serialized via `(quote ...)` and
+  evaluated at runtime via `kaappi_eval`
+- **Fixnums, booleans, characters, nil, void**: Embedded directly as `i64`
+  literals (these are NaN-boxed immediates with no heap allocation)
 
 ## Lambda Strategy
 
 Lambda bodies are stored as raw S-expressions in the IR, not as
-pre-lowered IR nodes. The LLVM emitter cannot compile them directly.
-Instead, it serializes the lambda source text, embeds it as an LLVM IR
-string constant, and evaluates it at runtime:
+pre-lowered IR nodes. The LLVM emitter serializes the lambda source text,
+embeds it as an LLVM IR string constant, and evaluates it at runtime:
 
 ```llvm
 @.str.0 = private constant [23 x i8] c"(lambda (x) (* x x))"
@@ -121,13 +161,6 @@ This approach is correct but not optimal — each lambda is parsed and
 compiled at startup. A future optimization would lower lambda bodies
 directly to LLVM IR functions.
 
-## Future: Replacing the JIT
-
-Once the LLVM backend matures, the hand-written JIT backends
-(`jit_compile_aarch64.zig`, `jit_compile_x86_64.zig`, and supporting
-files) will be removed. LLVM subsumes their role with better optimization
-and broader architecture support. See issue #99 for tracking.
-
 ## Testing
 
 End-to-end tests live in `tests/e2e/`:
@@ -138,6 +171,20 @@ End-to-end tests live in `tests/e2e/`:
 - `programs/*.scm` — test programs compiled to native binaries
 
 Run with: `bash tests/e2e/run-e2e.sh`
+
+The e2e tests run in CI on Ubuntu ReleaseSafe builds. The `KAAPPI_CC`
+environment variable controls the C compiler (defaults to `zig cc`).
+
+### What's been stress-tested
+
+- Closures with message dispatch (`eq?` on quoted symbols)
+- Recursive functions on quoted data (`flatten`, `my-len`)
+- Error handling with `guard`
+- User-defined macros (`define-syntax`)
+- SRFI libraries (SRFI-1, SRFI-13, SRFI-69)
+- Unicode strings, string ports, string mutation
+- Higher-order functions (`map`, `filter`, `fold`)
+- Tail-recursive loops (100k iterations)
 
 ## Related Documents
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -346,6 +346,50 @@ A pull request will not be merged if CI fails.
 
 ---
 
+## End-to-End Tests (LLVM Native Backend)
+
+E2e tests verify that the LLVM native backend produces binaries with
+identical output to the interpreter. They live in `tests/e2e/`:
+
+```
+tests/e2e/
+  run-e2e.sh              Shell runner (BDD specs + native parity tests)
+  test-llvm-backend.scm   BDD specs using kaappi-bdd
+  programs/               Scheme programs compiled to native binaries
+    arithmetic.scm         Constant-folded addition
+    string.scm             String display
+    define.scm             Global variable binding
+    if-expr.scm            Conditional branching
+    lambda-basic.scm       Lambda and application
+    lambda-closure.scm     Closures with upvalues
+    nested-calls.scm       Non-foldable nested calls
+    and-or.scm             Short-circuit boolean logic
+    when-unless.scm        Conditional body execution
+    set-bang.scm           Variable mutation
+    let-binding.scm        Local bindings via kaappi_eval
+    import.scm             Library imports
+    symbol-eq.scm          Symbol identity in closures
+    quoted-list.scm        Quoted list constants
+    macro.scm              User-defined macros
+```
+
+### Running
+
+```bash
+bash tests/e2e/run-e2e.sh
+```
+
+The script:
+1. Builds `kaappi` and `libkaappi_rt.a`
+2. Runs BDD specs via the interpreter
+3. For each program in `programs/`: runs via interpreter, compiles to
+   native via `--emit-llvm` + `zig cc`, diffs output
+
+Uses `KAAPPI_CC` env var for the C compiler (defaults to `zig cc`).
+Runs in CI on Ubuntu ReleaseSafe builds.
+
+---
+
 ## Testing Checklist
 
 When making changes, verify:


### PR DESCRIPTION
## Summary

Updates 6 documentation files to reflect all LLVM backend work:

- **llvm-backend.md**: symbol interning, quoted constants, compile-time processing, all 33 IR node types handled, single-step `zig build native`, stress test results
- **architecture.md**: add `runtime_exports.zig` and `llvm_emit.zig` to file table
- **ir.md**: update lowering section (`lower()` is now a wrapper around `lowerWithMacros`)
- **testing.md**: add e2e test documentation with full program list
- **README.md**: add native compilation section, add IR/LLVM files to project structure
- **CLAUDE.md**: add new files to table, add `zig build native` command

## Test plan

- [x] Docs-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)