### PR TITLE
Update all docs for JIT removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ zig build -Dgc-threshold=16384     # custom initial GC threshold (default: 8192)
 ```
 
 CLI flags: `-h`/`--help`, `--version`, `--lib-path <path>`, `--compile`,
-`-o <file>`, `--disassemble`, `--no-jit`, `--sandbox`, `--gc-stats`,
+`-o <file>`, `--disassemble`, `--sandbox`, `--gc-stats`,
 `--profile`, `--coverage`. Version is defined as `pub const version` in `main.zig`.
 
 Build-time options: `-Dmax-frames=N` (call frame depth, default 512),
@@ -43,27 +43,17 @@ This runs `zig fmt --check` on staged `.zig` files before each commit.
 
 ### Supported platforms
 
-| OS | Architecture | Build | Unit Tests | JIT | Notes |
-|----|-------------|-------|------------|-----|-------|
-| macOS | aarch64 (Apple Silicon) | yes | 347/347 | AArch64 native | Primary dev platform |
-| Linux | x86_64 | yes | 312/320 (8 skip, 0 fail) | x86_64 native | CI tested (Ubuntu) |
-| Linux | aarch64 | yes | yes | AArch64 native | CI tested (Ubuntu ARM) |
-| Linux | riscv64 | yes | yes | No (interpreter only) | CI tested (QEMU) |
-| WebAssembly | wasm32-wasi | yes | — | No (interpreter only) | `zig build wasm`, browser/WASI |
-
-**JIT backends:** AArch64 and x86_64 are both fully implemented (all opcodes +
-specialized arithmetic + function calls + self-tail-call). Unhandled opcodes
-(`tail_call`, `closure`, `push_handler`, etc.) side-exit to the interpreter.
-RISC-V runs interpreter-only (no JIT backend). AArch64 and x86_64 backends
-are tested in CI; riscv64 tests via QEMU cross-compilation.
+| OS | Architecture | Build | Unit Tests | Notes |
+|----|-------------|-------|------------|-------|
+| macOS | aarch64 (Apple Silicon) | yes | yes | Primary dev platform |
+| Linux | x86_64 | yes | yes | CI tested (Ubuntu) |
+| Linux | aarch64 | yes | yes | CI tested (Ubuntu ARM) |
+| Linux | riscv64 | yes | yes | CI tested (QEMU) |
+| WebAssembly | wasm32-wasi | yes | — | `zig build wasm`, browser/WASI |
 
 **Cross-compilation:** `zig build -Dtarget=x86_64-linux` and
 `zig build -Dtarget=riscv64-linux` cross-compile from macOS ARM. Binaries
 run in Linux containers via podman (x86_64 via Rosetta, riscv64 via QEMU).
-
-**8 skipped tests on x86_64 Linux:** 4 aarch64-specific JIT tests (write ARM
-machine code directly), 2 library-loading tests (need source tree), 2
-filesystem tests (need `build.zig` on disk). All skip gracefully — 0 failures.
 
 Builds default to **ReleaseSafe** (fast, with bounds/safety checks retained;
 fixnum overflow auto-promotes to bignum). Debug is ~500x slower for allocation-
@@ -195,12 +185,6 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 | `library.zig` | Library registry, standard library registration ((scheme base), etc.) |
 | `bignum.zig` | Arbitrary-precision integer arithmetic |
 | `ffi.zig` | C FFI call dispatcher (type marshaling, arity routing, `normalizeType` for extended integer types) |
-| `jit.zig` | JIT orchestration: eligibility, compile dispatch, C-ABI helpers, shared utilities, tests |
-| `jit_compile_aarch64.zig` | AArch64 bytecode → native compiler: emit* functions, frame/call sequences |
-| `jit_compile_x86_64.zig` | x86_64 bytecode → native compiler: x64Emit* functions, register cache |
-| `jit_aarch64.zig` | AArch64 assembler: fixed 4-byte instruction encoding, register/branch/load-store emitters |
-| `jit_x86_64.zig` | x86_64 assembler: variable-length instruction encoding, REX prefixes, ModR/M addressing |
-| `jit_mem.zig` | Executable memory allocation (mmap RWX), code buffer write with JIT protection (macOS) |
 | `bytecode_file.zig` | Bytecode serialization/deserialization (.sbc cache format) |
 | `disassembler.zig` | Bytecode disassembler for `(disassemble proc)` |
 | `linenoise.zig` | Zig FFI wrapper for vendored linenoise C library |
@@ -313,7 +297,7 @@ Always root `Function*` pointers before calling `vm.execute()` — it allocates 
 
 **Every bug fix MUST include a regression test** that fails without the fix and
 passes with it. Place it in the appropriate location:
-- Zig unit test → `src/tests_*.zig` (for VM, compiler, GC, JIT internals)
+- Zig unit test → `src/tests_*.zig` (for VM, compiler, GC internals)
 - Scheme test → `tests/scheme/smoke/` or a dedicated file under `tests/scheme/`
   (for end-to-end behavior visible from Scheme)
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ zig build test                       # Run all tests
 
 ### Supported platforms
 
-| OS | Architecture | Build | Tests | JIT |
-|----|-------------|-------|-------|-----|
-| macOS | aarch64 (Apple Silicon) | yes | 347/347 | yes (native AArch64) |
-| Linux | x86_64 | yes | 312/320 (8 skip) | yes (native x86_64) |
-| Linux | aarch64 | yes | yes | yes (native AArch64) |
-| Linux | riscv64 | yes | yes | no (interpreter only) |
-| WebAssembly | wasm32-wasi | yes | — | no (interpreter only) |
+| OS | Architecture | Build | Tests | Native compilation |
+|----|-------------|-------|-------|--------------------|
+| macOS | aarch64 (Apple Silicon) | yes | yes | LLVM backend |
+| Linux | x86_64 | yes | yes | LLVM backend |
+| Linux | aarch64 | yes | yes | LLVM backend |
+| Linux | riscv64 | yes | yes | LLVM backend |
+| WebAssembly | wasm32-wasi | yes | — | interpreter only |
 
 The WASM build (`zig build wasm`) runs in browsers and WASI runtimes. See the
 [playground](https://kaappi-lang.org/playground/) for a live demo.
@@ -123,7 +123,7 @@ kaappi> (char-alphabetic? #\λ)
 ### Beyond R7RS
 
 - **C FFI** — call into shared libraries from Scheme via `(kaappi ffi)`: `ffi-open`, `ffi-fn`, `ffi-close`, plus `ffi-callback` for passing Scheme procedures to C (7 callback signatures, 18 types including explicit-width integers and `size_t`)
-- **JIT compiler** — hot functions (100+ calls) are compiled to native machine code (AArch64 and x86_64); inline fixnum arithmetic, comparisons, `car`/`cdr`, `cons`, predicates; JIT-to-JIT call chaining
+- **LLVM native backend** — compile Scheme programs to native executables via `zig build native -Dnative-src=program.scm`; native lambda compilation with direct calls; hybrid continuation strategy
 - **Green threads** — `(kaappi fibers)` with `spawn`, `yield`, `fiber-join`, channels; plus full SRFI-18 compatibility (`make-thread`, mutexes, condition variables)
 - **Profiler** — `kaappi --profile` or `,profile expr` in the REPL; per-function self/total time, call counts, allocation bytes
 - **Standalone binaries** — `zig build -Dbundle-src=program.scm` compiles and embeds bytecode + libraries into a single executable
@@ -308,10 +308,6 @@ kaappi/
 │   ├── primitives_ffi.zig         FFI procedures (ffi-open, ffi-fn, ffi-close)
 │   ├── primitives_r7rs.zig        time, process-context, eval, load
 │   ├── unicode_tables.zig         Unicode 15.1 case mapping tables (auto-generated)
-│   ├── jit.zig                    JIT compiler (arch dispatch + code gen)
-│   ├── jit_aarch64.zig            AArch64 instruction encoding
-│   ├── jit_x86_64.zig             x86_64 instruction encoding
-│   ├── jit_mem.zig                Executable memory allocation
 │   ├── disassembler.zig           Bytecode disassembler
 │   │
 │   ├── testing_helpers.zig        Shared test utilities
@@ -553,12 +549,6 @@ See **[CONFORMANCE.md](CONFORMANCE.md)** for design rationale and SRFI coverage 
 ### OS threads (SRFI-18)
 
 Each OS thread gets its own GC with an independent heap. Values are deep-copied when crossing thread boundaries (at `thread-start!` and `thread-join!`). This means threads cannot share mutable state directly — use channels or return values to communicate. Child threads can allocate and GC independently without affecting the parent.
-
-### JIT compiler
-
-AArch64 and x86_64 backends are both fully implemented: inline fixnum arithmetic with overflow detection, comparisons, predicates (`zero?`, `null?`, `pair?`, `not`, `car`, `cdr`), `cons` allocation, global variable access with inline caching, full call sequences with JIT-to-JIT chaining, and optimized self-recursive calls. RISC-V runs interpreter-only (no JIT backend). Use `--no-jit` to disable.
-
-Tail calls to known primitives (`+`, `-`, `*`, `<`, etc.) are specialized inline via peephole analysis, avoiding side-exits. The JIT currently shows no measurable speedup on standard benchmarks (fib, tak, ackermann) because the interpreter's NativeFn fast path already calls primitives directly via function pointer without frame construction, and the JIT does not yet perform inter-instruction register allocation. Future work: register allocation across instructions to reduce redundant frame memory loads/stores.
 
 ### Macros
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -110,12 +110,6 @@ Source code
 | `thottam.zig` | Package manager binary: install, remove, list, update, verify |
 | `kaappi_lsp.zig` | Language server (LSP) for IDE integration |
 | `ffi.zig` | FFI call dispatcher (type marshaling, arity routing, `normalizeType`) |
-| `jit.zig` | JIT orchestration: eligibility, compile dispatch, C-ABI helpers, shared utilities |
-| `jit_compile_aarch64.zig` | AArch64 bytecode → native compiler: NaN-boxed value encoding, frame/call sequences |
-| `jit_compile_x86_64.zig` | x86_64 bytecode → native compiler: register cache, NaN-boxed value encoding |
-| `jit_aarch64.zig` | AArch64 assembler (fixed 4-byte instruction encoding) |
-| `jit_x86_64.zig` | x86_64 assembler (variable-length encoding, REX prefixes) |
-| `jit_mem.zig` | Executable memory allocation (mmap RWX, macOS JIT protection + entitlements) |
 | `runtime_exports.zig` | C-ABI bridge for LLVM native backend (8 exported functions) |
 | `llvm_emit.zig` | LLVM IR text emitter (walks IR nodes, produces `.ll` files) |
 | `bignum.zig` | Arbitrary-precision integer arithmetic |

--- a/docs/dev/continuation-strategy.md
+++ b/docs/dev/continuation-strategy.md
@@ -45,7 +45,7 @@ swap.
 
 **Pros:** O(1) capture.
 **Cons:** Every call pays heap allocation cost. Destroys cache locality.
-Requires rewriting the entire call convention and frame layout. The JIT
+Requires rewriting the entire call convention and frame layout. The
 backends (aarch64, x86_64) would need complete redesign. Incompatible with
 C-ABI calls to the runtime.
 
@@ -66,7 +66,7 @@ back to the VM.
 
 **Pros:**
 - Zero overhead for continuation-free code (the common case)
-- No changes to the bytecode VM or JIT — they keep working as-is
+- No changes to the bytecode VM — it keeps working as-is
 - The direct-style IR serves both backends without conversion
 - `call/ec` (escape continuations) can be implemented natively as
   `setjmp`/`longjmp` — they're single-shot by definition
@@ -74,7 +74,7 @@ back to the VM.
 **Cons:**
 - Code that uses `call/cc` in hot loops does not benefit from native
   compilation. This is acceptable: such code is rare, and the bytecode
-  VM + JIT already handles it well.
+  the bytecode VM already handles it well.
 - The boundary between native and VM code requires a calling convention
   bridge (save/restore registers across the boundary).
 
@@ -96,9 +96,7 @@ Functions that may reach `call/cc` stay on the bytecode VM.
 
 At call boundaries, the native code calls into the VM's `execute()` function
 to run bytecode-compiled callees. The VM can call back into native code for
-functions it knows are native-compiled. This is analogous to how the JIT
-already works — JIT-compiled functions call back into the interpreter for
-opcodes they don't handle (`tail_call`, `closure`, `push_handler`).
+functions it knows are native-compiled.
 
 ### call/ec in native code
 

--- a/docs/dev/ir.md
+++ b/docs/dev/ir.md
@@ -2,7 +2,7 @@
 
 The compiler IR is a tree-structured intermediate representation that sits
 between the macro expander and bytecode emission. It enables shared analysis
-and optimization passes that benefit both the bytecode VM and JIT, and
+and optimization passes that benefit both the bytecode VM and LLVM backend, and
 provides a clean lowering target for a future native backend.
 
 **Source:** `src/ir.zig` (~1,500 lines)

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -3,7 +3,7 @@
 The LLVM backend compiles Scheme programs to native executables. It is
 the second of two execution backends:
 
-1. **Interpreter** (bytecode VM + JIT) — REPL, debugging, development
+1. **Interpreter** (bytecode VM) — REPL, debugging, development
 2. **LLVM backend** (this document) — native executables for deployment
 
 ## What LLVM provides vs what the runtime provides
@@ -39,7 +39,7 @@ Source → Reader → Expander → IR → Analysis → Optimization
                               |                                           |
                         Bytecode Emission                          LLVM IR Emission
                               |                                           |
-                         VM + JIT                                    zig cc
+                            VM                                       zig cc
                               |                                           |
                         Interpreter                               Native Binary
                     (REPL, debugging)                        (links libkaappi_rt.a)

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -221,8 +221,8 @@ Tests live in `tests/acceptance/`:
 
 | File | Purpose |
 |------|---------|
-| `acceptance.sh` | 34 tests: version, arithmetic/JIT, data structures, Unicode, library imports, file execution, tail calls, closures, continuations, error handling, sandbox, thottam |
-| `test-wasm.sh` | 14 WASM-specific tests via wasmtime (no JIT, no FFI) |
+| `acceptance.sh` | 34 tests: version, arithmetic, data structures, Unicode, library imports, file execution, tail calls, closures, continuations, error handling, sandbox, thottam |
+| `test-wasm.sh` | 14 WASM-specific tests via wasmtime (no FFI) |
 | `hello.scm` | Minimal test program for file execution |
 
 ### Running locally

--- a/docs/dev/vision.md
+++ b/docs/dev/vision.md
@@ -70,9 +70,9 @@ spec requirements — they're what makes a language usable.
 
 The codebase avoids abstraction layers that don't earn their keep. The GC is
 mark-and-sweep with an intrusive linked list — no generational promotion, no
-read barriers, no write barriers. The compiler is a single-pass tree walker,
-not an SSA-based optimizer. The JIT compiles hot loops to native code with a
-straightforward template approach — no IR, no register allocator.
+read barriers, no write barriers. The compiler lowers to an IR with analysis
+and optimization passes, then emits bytecode. The LLVM backend compiles
+Scheme programs to native executables via LLVM IR.
 
 When something is slow, we measure first. The answer is usually "use
 ReleaseSafe instead of Debug" or "the algorithm is O(n^2)", not "add a


### PR DESCRIPTION
## Summary

Removes all JIT references from documentation after PR #174 removed the JIT code:

- **README.md**: Replace JIT column with "Native compilation", remove JIT section, update feature list
- **CLAUDE.md**: Remove JIT file entries, --no-jit flag, platform JIT column
- **architecture.md**: Remove 6 JIT file entries
- **llvm-backend.md**: Update interpreter description (no JIT)
- **ir.md**: Replace "VM and JIT" with "VM and LLVM backend"
- **continuation-strategy.md**: Remove JIT analogies
- **vision.md**: Replace JIT description with IR/LLVM description
- **testing.md**: Remove JIT references from test descriptions

## Test plan

- [x] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)