### PR TITLE
Suggest similar names for undefined variable errors

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -310,6 +310,38 @@ pub const VM = struct {
         self.captureErrorLocation();
     }
 
+    pub fn findSimilarName(self: *VM, name: []const u8) ?[]const u8 {
+        var best: ?[]const u8 = null;
+        var best_dist: usize = 4;
+        var iter = self.globals.keyIterator();
+        while (iter.next()) |key| {
+            const candidate = key.*;
+            if (candidate.len == 0 or candidate[0] == '%') continue;
+            const dist = editDistance(name, candidate);
+            if (dist > 0 and dist < best_dist) {
+                best_dist = dist;
+                best = candidate;
+            }
+        }
+        return best;
+    }
+
+    fn editDistance(a: []const u8, b: []const u8) usize {
+        if (a.len > 32 or b.len > 32) return 99;
+        var prev: [33]usize = undefined;
+        var curr: [33]usize = undefined;
+        for (0..b.len + 1) |j| prev[j] = j;
+        for (a, 0..) |ca, i| {
+            curr[0] = i + 1;
+            for (b, 0..) |cb, j| {
+                const cost: usize = if (ca == cb) 0 else 1;
+                curr[j + 1] = @min(@min(curr[j] + 1, prev[j + 1] + 1), prev[j] + cost);
+            }
+            @memcpy(prev[0 .. b.len + 1], curr[0 .. b.len + 1]);
+        }
+        return prev[b.len];
+    }
+
     fn captureErrorLocation(self: *VM) void {
         self.last_error_line = 0;
         self.last_error_source = null;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -143,7 +143,15 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (func.env != null) {
                         if (self.globals.get(name)) |gval| break :blk gval;
                     }
-                    self.setErrorDetail("undefined variable '{s}'", .{name});
+                    if (self.findSimilarName(name)) |suggestion| {
+                        self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, suggestion });
+                    } else {
+                        if (self.findSimilarName(name)) |sug| {
+                            self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
+                        } else {
+                            self.setErrorDetail("undefined variable '{s}'", .{name});
+                        }
+                    }
                     return VMError.UndefinedVariable;
                 };
                 self.registers[dst_idx] = val;
@@ -690,7 +698,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                             const name = types.symbolName(sym);
                             const val = env.get(name) orelse {
-                                self.setErrorDetail("undefined variable '{s}'", .{name});
+                                if (self.findSimilarName(name)) |sug| {
+                                    self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
+                                } else {
+                                    self.setErrorDetail("undefined variable '{s}'", .{name});
+                                }
                                 return VMError.UndefinedVariable;
                             };
                             self.registers[base] = val;
@@ -703,7 +715,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                         const name = types.symbolName(sym);
                         const val = env.get(name) orelse {
-                            self.setErrorDetail("undefined variable '{s}'", .{name});
+                            if (self.findSimilarName(name)) |sug| {
+                                self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
+                            } else {
+                                self.setErrorDetail("undefined variable '{s}'", .{name});
+                            }
                             return VMError.UndefinedVariable;
                         };
                         self.registers[base] = val;
@@ -728,7 +744,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                     const name = types.symbolName(sym);
                     const val = env.get(name) orelse {
-                        self.setErrorDetail("undefined variable '{s}'", .{name});
+                        if (self.findSimilarName(name)) |sug| {
+                            self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
+                        } else {
+                            self.setErrorDetail("undefined variable '{s}'", .{name});
+                        }
                         return VMError.UndefinedVariable;
                     };
                     self.registers[base] = val;
@@ -793,7 +813,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                     const name = types.symbolName(sym);
                     callee = env.get(name) orelse {
-                        self.setErrorDetail("undefined variable '{s}'", .{name});
+                        if (self.findSimilarName(name)) |sug| {
+                            self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
+                        } else {
+                            self.setErrorDetail("undefined variable '{s}'", .{name});
+                        }
                         return VMError.UndefinedVariable;
                     };
                     if (func.env == null and (types.isClosure(callee) or types.isNativeFn(callee))) {


### PR DESCRIPTION
## Summary

Undefined variable errors now suggest the closest match using Levenshtein edit distance:

```
error: undefined variable 'dsiplay'. Did you mean 'display'?
```

Covers all error paths: `get_global`, `call_global`, `tail_call_global`.

Closes #184

## Test plan

- [x] `(dsiplay 42)` → suggests `display`
- [x] 23/23 e2e tests pass
- [x] 1485/1485 scheme tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)