### PR TITLE
Inline primitive operations in LLVM backend

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -164,6 +164,12 @@ pub const LLVMEmitter = struct {
             if (self.native_fns.get(op_name)) |native| {
                 return self.emitDirectCall(native.llvm_name, call.args);
             }
+            if (call.args.len == 2) {
+                if (self.tryEmitInlineBinary(op_name, call.args)) |result| return result;
+            }
+            if (call.args.len == 1) {
+                if (self.tryEmitInlineUnary(op_name, call.args[0])) |result| return result;
+            }
         }
 
         const callee = try self.emitNode(call.operator);
@@ -722,6 +728,47 @@ pub const LLVMEmitter = struct {
         return fn_name;
     }
 
+    fn tryEmitInlineBinary(self: *LLVMEmitter, name: []const u8, args: []const *ir.Node) ?[]const u8 {
+        const fn_name: ?[]const u8 = if (std.mem.eql(u8, name, "+"))
+            "@kaappi_fixnum_add"
+        else if (std.mem.eql(u8, name, "-"))
+            "@kaappi_fixnum_sub"
+        else if (std.mem.eql(u8, name, "*"))
+            "@kaappi_fixnum_mul"
+        else if (std.mem.eql(u8, name, "<"))
+            "@kaappi_fixnum_lt"
+        else if (std.mem.eql(u8, name, "="))
+            "@kaappi_fixnum_eq"
+        else if (std.mem.eql(u8, name, "cons"))
+            "@kaappi_cons"
+        else
+            null;
+
+        const target = fn_name orelse return null;
+        const a = self.emitNode(args[0]) catch return null;
+        const b = self.emitNode(args[1]) catch return null;
+        const result = self.freshTemp() catch return null;
+        self.print("  {s} = call i64 {s}(i64 {s}, i64 {s})\n", .{ result, target, a, b }) catch return null;
+        return result;
+    }
+
+    fn tryEmitInlineUnary(self: *LLVMEmitter, name: []const u8, arg: *const ir.Node) ?[]const u8 {
+        const fn_name: ?[]const u8 = if (std.mem.eql(u8, name, "car"))
+            "@kaappi_car"
+        else if (std.mem.eql(u8, name, "cdr"))
+            "@kaappi_cdr"
+        else if (std.mem.eql(u8, name, "null?"))
+            "@kaappi_is_null"
+        else
+            null;
+
+        const target = fn_name orelse return null;
+        const v = self.emitNode(arg) catch return null;
+        const result = self.freshTemp() catch return null;
+        self.print("  {s} = call i64 {s}(i64 {s})\n", .{ result, target, v }) catch return null;
+        return result;
+    }
+
     fn emitDirectCall(self: *LLVMEmitter, fn_name: []const u8, args: []const *ir.Node) EmitError![]const u8 {
         const nargs = args.len;
         var arg_tmps: [256][]const u8 = undefined;
@@ -827,6 +874,15 @@ pub const LLVMEmitter = struct {
         try self.write("declare void @kaappi_define_global(ptr, ptr, i64, i64)\n");
         try self.write("declare i64 @kaappi_make_string(ptr, ptr, i64)\n");
         try self.write("declare i64 @kaappi_intern_symbol(ptr, ptr, i64)\n");
+        try self.write("declare i64 @kaappi_fixnum_add(i64, i64)\n");
+        try self.write("declare i64 @kaappi_fixnum_sub(i64, i64)\n");
+        try self.write("declare i64 @kaappi_fixnum_mul(i64, i64)\n");
+        try self.write("declare i64 @kaappi_fixnum_lt(i64, i64)\n");
+        try self.write("declare i64 @kaappi_fixnum_eq(i64, i64)\n");
+        try self.write("declare i64 @kaappi_car(i64)\n");
+        try self.write("declare i64 @kaappi_cdr(i64)\n");
+        try self.write("declare i64 @kaappi_cons(i64, i64)\n");
+        try self.write("declare i64 @kaappi_is_null(i64)\n");
         try self.write("declare i64 @kaappi_eval(ptr, ptr, i64)\n");
     }
 

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -99,6 +99,73 @@ export fn kaappi_eval(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len: u64) callc
     return result;
 }
 
+export fn kaappi_fixnum_add(a: u64, b: u64) callconv(.c) u64 {
+    if (types.isFixnum(a) and types.isFixnum(b)) {
+        const va = types.toFixnum(a);
+        const vb = types.toFixnum(b);
+        const result = @addWithOverflow(va, vb);
+        if (result[1] == 0 and result[0] >= std.math.minInt(i48) and result[0] <= std.math.maxInt(i48)) {
+            return types.makeFixnum(result[0]);
+        }
+    }
+    return 0;
+}
+
+export fn kaappi_fixnum_sub(a: u64, b: u64) callconv(.c) u64 {
+    if (types.isFixnum(a) and types.isFixnum(b)) {
+        const va = types.toFixnum(a);
+        const vb = types.toFixnum(b);
+        const result = @subWithOverflow(va, vb);
+        if (result[1] == 0 and result[0] >= std.math.minInt(i48) and result[0] <= std.math.maxInt(i48)) {
+            return types.makeFixnum(result[0]);
+        }
+    }
+    return 0;
+}
+
+export fn kaappi_fixnum_mul(a: u64, b: u64) callconv(.c) u64 {
+    if (types.isFixnum(a) and types.isFixnum(b)) {
+        const va = types.toFixnum(a);
+        const vb = types.toFixnum(b);
+        const result = @mulWithOverflow(va, vb);
+        if (result[1] == 0 and result[0] >= std.math.minInt(i48) and result[0] <= std.math.maxInt(i48)) {
+            return types.makeFixnum(result[0]);
+        }
+    }
+    return 0;
+}
+
+export fn kaappi_fixnum_lt(a: u64, b: u64) callconv(.c) u64 {
+    if (types.isFixnum(a) and types.isFixnum(b))
+        return if (types.toFixnum(a) < types.toFixnum(b)) types.TRUE else types.FALSE;
+    return types.FALSE;
+}
+
+export fn kaappi_fixnum_eq(a: u64, b: u64) callconv(.c) u64 {
+    if (types.isFixnum(a) and types.isFixnum(b))
+        return if (a == b) types.TRUE else types.FALSE;
+    return types.FALSE;
+}
+
+export fn kaappi_car(v: u64) callconv(.c) u64 {
+    if (types.isPair(v)) return types.car(v);
+    return 0;
+}
+
+export fn kaappi_cdr(v: u64) callconv(.c) u64 {
+    if (types.isPair(v)) return types.cdr(v);
+    return 0;
+}
+
+export fn kaappi_cons(a: u64, b: u64) callconv(.c) u64 {
+    const gc = primitives.gc_instance orelse return 0;
+    return gc.allocPair(a, b) catch return 0;
+}
+
+export fn kaappi_is_null(v: u64) callconv(.c) u64 {
+    return if (v == types.NIL) types.TRUE else types.FALSE;
+}
+
 export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]const u64, nargs: u64) callconv(.c) u64 {
     const v = vm orelse {
         _ = std.posix.system.write(2, "null vm\n", 8);


### PR DESCRIPTION
## Summary

Binary primitives (`+`, `-`, `*`, `<`, `=`, `cons`) and unary primitives (`car`, `cdr`, `null?`) now emit direct C-ABI calls to fast-path runtime functions, bypassing the full `kaappi_global_lookup` + `kaappi_call_scheme` dispatch.

```
Before: global_lookup("+") → alloc args → call_scheme(callee, args, 2)
After:  call @kaappi_fixnum_add(x, 1)
```

Partially addresses #176

## Test plan

- [x] `bash tests/e2e/run-e2e.sh` — 23/23 pass
- [x] `(+ x 1)` emits `call @kaappi_fixnum_add` in native lambda
- [x] `(car lst)` emits `call @kaappi_car`

🤖 Generated with [Claude Code](https://claude.com/claude-code)