### PR TITLE
Fix unit test false failure from disassembler stderr writes

### DIFF
--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -503,11 +503,19 @@ test "disassemble all opcodes" {
 
     // Verify all opcodes are present in the bytecode
     try std.testing.expect(func.code.items.len > 120);
-    // Exercise all formatting branches by calling disassemble
+    // Exercise all formatting branches without writing to stderr
+    // (raw stderr writes corrupt zig build test IPC protocol)
+    suppress_output = true;
+    defer {
+        suppress_output = false;
+    }
     disassemble(func, allocator);
 }
 
+threadlocal var suppress_output: bool = false;
+
 fn writeStderr(bytes: []const u8) void {
+    if (suppress_output) return;
     var total: usize = 0;
     while (total < bytes.len) {
         const result: isize = std.posix.system.write(2, bytes.ptr + total, bytes.len - total);


### PR DESCRIPTION
## Summary

Closes #194

The `disassemble all opcodes` test wrote raw bytes to stderr via `writeStderr()`, which corrupted Zig's test runner IPC protocol (`--listen=-`). This caused `zig build test` to report failure despite all 400 tests actually passing when the binary was run directly.

Fix: suppress stderr output during the test with a threadlocal flag.

## Test plan

- [x] `zig build test` exits 0 with no spurious failure output
- [x] All 1485 Scheme tests pass
- [x] Disassembler still works at runtime (flag is threadlocal, only set during tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)