### PR TITLE
Compile let and let* binding forms in LLVM native backend

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -407,8 +407,21 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
     return lowerCall(ir, expr, macros);
 }
 
-pub fn lower(ir: *IR, expr: Value) CompileError!*Node {
-    return lowerWithMacros(ir, expr, null);
+pub fn lower(irn: *IR, expr: Value) CompileError!*Node {
+    return lowerWithMacros(irn, expr, null);
+}
+
+pub fn lowerSingleExpr(allocator: std.mem.Allocator, expr: Value) CompileError!*Node {
+    var scratch = IR.init(allocator);
+    const node = try lowerWithMacros(&scratch, expr, null);
+    identifyPrimitives(node);
+    markConstants(node);
+    var opt = foldConstants(&scratch, node);
+    opt = eliminateDeadBranches(&scratch, opt);
+    opt = simplifyBooleans(&scratch, opt);
+    opt = eliminateIdentity(&scratch, opt);
+    opt = simplifyBegin(&scratch, opt);
+    return opt;
 }
 
 fn lowerIf(ir: *IR, args: Value, macros: ?*std.StringHashMap(Value)) CompileError!*Node {

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -29,6 +29,7 @@ pub const LLVMEmitter = struct {
     current_block: []const u8 = "entry",
     rest_param_alloca: ?[]const u8 = null,
     rest_param_name: ?[]const u8 = null,
+    locals: ?std.StringHashMap([]const u8) = null,
 
     pub fn init(allocator: std.mem.Allocator) LLVMEmitter {
         return .{
@@ -113,7 +114,9 @@ pub const LLVMEmitter = struct {
             .define => try self.emitDefine(node.data.define),
             .set_form => try self.emitSet(node.data.set_form),
             .lambda => try self.emitLambda(node.data.lambda),
-            .let_form, .let_star, .letrec, .letrec_star, .named_let => try self.emitSexprEval(node),
+            .let_form => try self.emitLet(node.data.let_form.args, false),
+            .let_star => try self.emitLet(node.data.let_star.args, true),
+            .letrec, .letrec_star, .named_let => try self.emitSexprEval(node),
             .do_form, .delay, .delay_force, .cond, .case_form, .case_lambda, .guard => try self.emitSexprEval(node),
             .quasiquote, .parameterize, .define_values, .let_values, .let_star_values => try self.emitSexprEval(node),
             .define_syntax, .let_syntax, .letrec_syntax, .cond_expand => try self.emitSexprEval(node),
@@ -148,6 +151,14 @@ pub const LLVMEmitter = struct {
     fn emitGlobalRef(self: *LLVMEmitter, sym: Value) EmitError![]const u8 {
         if (!types.isSymbol(sym)) return error.UnsupportedNodeType;
         const name = types.symbolName(sym);
+
+        if (self.locals) |loc| {
+            if (loc.get(name)) |alloca_name| {
+                const tmp = try self.freshTemp();
+                try self.print("  {s} = load i64, ptr {s}\n", .{ tmp, alloca_name });
+                return tmp;
+            }
+        }
 
         if (self.rest_param_name) |rp_name| {
             if (std.mem.eql(u8, name, rp_name)) {
@@ -279,6 +290,100 @@ pub const LLVMEmitter = struct {
             last = try self.emitNode(expr);
         }
         return last;
+    }
+
+    fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool) EmitError![]const u8 {
+        const bindings = types.car(args);
+        const body_list = types.cdr(args);
+
+        const saved_locals = self.locals;
+        self.locals = if (saved_locals) |existing|
+            existing.clone() catch return error.OutOfMemory
+        else
+            std.StringHashMap([]const u8).init(self.allocator);
+
+        if (!sequential) {
+            var init_vals: [32][]const u8 = undefined;
+            var var_names: [32][]const u8 = undefined;
+            var count: usize = 0;
+            var blist = bindings;
+            while (blist != types.NIL and types.isPair(blist)) {
+                if (count >= 32) {
+                    self.locals.?.deinit();
+                    self.locals = saved_locals;
+                    return self.emitSexprEvalValue(args);
+                }
+                const binding = types.car(blist);
+                const var_sym = types.car(binding);
+                const init_expr = types.car(types.cdr(binding));
+                if (!types.isSymbol(var_sym)) {
+                    self.locals.?.deinit();
+                    self.locals = saved_locals;
+                    return self.emitSexprEvalValue(args);
+                }
+
+                const node = ir.lowerSingleExpr(self.allocator, init_expr) catch {
+                    self.locals.?.deinit();
+                    self.locals = saved_locals;
+                    return self.emitSexprEvalValue(args);
+                };
+                init_vals[count] = try self.emitNode(node);
+                var_names[count] = types.symbolName(var_sym);
+                count += 1;
+                blist = types.cdr(blist);
+            }
+
+            for (0..count) |i| {
+                const alloca = try self.freshTemp();
+                try self.print("  {s} = alloca i64, align 8\n", .{alloca});
+                try self.print("  store i64 {s}, ptr {s}\n", .{ init_vals[i], alloca });
+                self.locals.?.put(var_names[i], alloca) catch return error.OutOfMemory;
+            }
+        } else {
+            var blist = bindings;
+            while (blist != types.NIL and types.isPair(blist)) {
+                const binding = types.car(blist);
+                const var_sym = types.car(binding);
+                const init_expr = types.car(types.cdr(binding));
+                if (!types.isSymbol(var_sym)) {
+                    self.locals.?.deinit();
+                    self.locals = saved_locals;
+                    return self.emitSexprEvalValue(args);
+                }
+
+                const node = ir.lowerSingleExpr(self.allocator, init_expr) catch {
+                    self.locals.?.deinit();
+                    self.locals = saved_locals;
+                    return self.emitSexprEvalValue(args);
+                };
+                const val = try self.emitNode(node);
+                const alloca = try self.freshTemp();
+                try self.print("  {s} = alloca i64, align 8\n", .{alloca});
+                try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
+                self.locals.?.put(types.symbolName(var_sym), alloca) catch return error.OutOfMemory;
+                blist = types.cdr(blist);
+            }
+        }
+
+        var last: []const u8 = "";
+        var body_expr = body_list;
+        while (body_expr != types.NIL and types.isPair(body_expr)) {
+            const node = ir.lowerSingleExpr(self.allocator, types.car(body_expr)) catch {
+                self.locals.?.deinit();
+                self.locals = saved_locals;
+                return error.UnsupportedNodeType;
+            };
+            last = try self.emitNode(node);
+            body_expr = types.cdr(body_expr);
+        }
+
+        self.locals.?.deinit();
+        self.locals = saved_locals;
+        return last;
+    }
+
+    fn emitSexprEvalValue(self: *LLVMEmitter, args: Value) EmitError![]const u8 {
+        return self.emitEvalExpr(args);
     }
 
     fn emitIf(self: *LLVMEmitter, data: ir.IfData) EmitError![]const u8 {

--- a/tests/e2e/test-llvm-backend.scm
+++ b/tests/e2e/test-llvm-backend.scm
@@ -83,7 +83,23 @@
 
   (describe "let"
     (it "binds local variables"
-      (expect (let ((x 5) (y 3)) (+ x y)) to-equal 8)))
+      (expect (let ((x 5) (y 3)) (+ x y)) to-equal 8))
+
+    (it "let* uses sequential bindings"
+      (expect (let* ((x 10) (y (+ x 5))) y) to-equal 15))
+
+    (it "nested let scopes correctly"
+      (expect (let ((x 1))
+                (let ((y (+ x 10)))
+                  (+ x y)))
+              to-equal 12))
+
+    (it "let in function body"
+      (define (compute a b)
+        (let ((sum (+ a b))
+              (diff (- a b)))
+          (* sum diff)))
+      (expect (compute 7 3) to-equal 40)))
 
   (describe "tail calls"
     (it "optimizes self-tail-call as loop"


### PR DESCRIPTION
## Summary

Closes #179 (partial — let and let* forms)

- `let` and `let*` binding forms are now compiled natively as LLVM `alloca` + `store` instead of falling back to `kaappi_eval`
- `let` evaluates all init expressions before binding (parallel semantics)
- `let*` binds each variable immediately so later inits can reference earlier ones
- Nested let scopes handled correctly via cloned locals map
- `letrec`, `letrec*`, and `named-let` still fall back to eval (their init expressions typically contain lambdas needing cross-function variable capture)
- Added `lowerSingleExpr` helper to `ir.zig` for lowering individual S-expressions with full optimization passes

## Test plan

- [x] Basic let bindings: `(let ((x 5) (y 3)) (+ x y))` → 8
- [x] let* sequential: `(let* ((x 10) (y (+ x 5))) y)` → 15
- [x] Nested let scoping
- [x] let in function bodies
- [x] letrec with lambdas still works (falls back to eval)
- [x] All 36 LLVM backend E2E tests pass
- [x] All unit tests pass
- [x] All 1485 Scheme tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)