### PR TITLE
Extend debugger with step-out, watches, conditional breakpoints, up/down

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1298,7 +1298,7 @@ fn repl(vm: *vm_mod.VM) !void {
         if (std.mem.startsWith(u8, debug_trimmed, ",break ")) {
             const bp_name = std.mem.trim(u8, debug_trimmed[7..], " ");
             if (vm.breakpoint_count < 16) {
-                vm.breakpoints[vm.breakpoint_count] = bp_name;
+                vm.breakpoints[vm.breakpoint_count] = .{ .name = bp_name };
                 vm.breakpoint_count += 1;
                 vm.debug_mode = true;
                 vm.step_mode = .continue_to_break;
@@ -1309,12 +1309,37 @@ fn repl(vm: *vm_mod.VM) !void {
             input_buf.clearRetainingCapacity();
             continue;
         }
+        if (std.mem.startsWith(u8, debug_trimmed, ",condition ")) {
+            const rest = std.mem.trim(u8, debug_trimmed[11..], " ");
+            if (std.mem.indexOfScalar(u8, rest, ' ')) |space| {
+                const id_str = rest[0..space];
+                const expr = std.mem.trim(u8, rest[space + 1 ..], " ");
+                const id = std.fmt.parseInt(usize, id_str, 10) catch {
+                    writeStdout("Usage: ,condition <id> <expr>\n");
+                    input_buf.clearRetainingCapacity();
+                    continue;
+                };
+                if (id < vm.breakpoint_count) {
+                    vm.breakpoints[id].condition = expr;
+                    writeStdout("Condition set\n");
+                } else {
+                    writeStdout("Invalid breakpoint ID\n");
+                }
+            } else {
+                writeStdout("Usage: ,condition <id> <expr>\n");
+            }
+            input_buf.clearRetainingCapacity();
+            continue;
+        }
         if (std.mem.eql(u8, debug_trimmed, ",breakpoints")) {
             for (vm.breakpoints[0..vm.breakpoint_count], 0..) |bp, idx| {
-                var dbuf: [32]u8 = undefined;
-                const s = std.fmt.bufPrint(&dbuf, "  [{d}] ", .{idx}) catch "";
+                var dbuf: [64]u8 = undefined;
+                const s = std.fmt.bufPrint(&dbuf, "  [{d}] {s}", .{ idx, bp.name }) catch "";
                 writeStdout(s);
-                writeStdout(bp);
+                if (bp.condition) |cond| {
+                    writeStdout(" if ");
+                    writeStdout(cond);
+                }
                 writeStdout("\n");
             }
             if (vm.breakpoint_count == 0) {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -144,7 +144,17 @@ pub const CallFrame = struct {
     saved_wind_count: u16 = 0,
 };
 
-pub const StepMode = enum { none, step, next, continue_to_break };
+pub const StepMode = enum { none, step, next, step_out, continue_to_break };
+
+pub const Breakpoint = struct {
+    name: []const u8,
+    condition: ?[]const u8 = null,
+};
+
+pub const WatchEntry = struct {
+    name: []const u8,
+    last_value: Value = types.VOID,
+};
 
 pub const ProfileTimeEntry = struct {
     func: ?*types.Function,
@@ -194,10 +204,13 @@ pub const VM = struct {
     last_stack_trace_len: usize = 0,
     // Debugger state
     debug_mode: bool = false,
-    breakpoints: [16][]const u8 = undefined,
+    breakpoints: [16]Breakpoint = undefined,
     breakpoint_count: usize = 0,
     step_mode: StepMode = .none,
     step_frame: usize = 0,
+    watches: [16]WatchEntry = undefined,
+    watch_count: usize = 0,
+    inspect_frame: usize = 0,
     global_version: u32 = 0,
     profile_mode: bool = false,
     coverage_mode: bool = false,

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -331,8 +331,30 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u16, nargs: u8) VMErr
     if (vm.debug_mode and vm.breakpoint_count > 0) {
         if (func.name) |fname| {
             for (vm.breakpoints[0..vm.breakpoint_count]) |bp| {
-                if (std.mem.eql(u8, bp, fname)) {
-                    vm.step_mode = .step;
+                if (std.mem.eql(u8, bp.name, fname)) {
+                    if (bp.condition) |cond| {
+                        const reader_mod = @import("reader.zig");
+                        var r = reader_mod.Reader.init(vm.gc, cond);
+                        defer r.deinit();
+                        const expr = r.readDatum() catch {
+                            vm.step_mode = .step;
+                            break;
+                        };
+                        const compiler = @import("compiler.zig");
+                        const cond_func = compiler.compileExpression(vm.gc, expr) catch {
+                            vm.step_mode = .step;
+                            break;
+                        };
+                        const result = vm.execute(cond_func) catch {
+                            vm.step_mode = .step;
+                            break;
+                        };
+                        if (result != types.FALSE) {
+                            vm.step_mode = .step;
+                        }
+                    } else {
+                        vm.step_mode = .step;
+                    }
                     break;
                 }
             }

--- a/src/vm_debug.zig
+++ b/src/vm_debug.zig
@@ -10,15 +10,49 @@ fn writeStderr(bytes: []const u8) void {
 
 pub fn shouldDebugPause(vm: *VM, frame: *CallFrame) bool {
     _ = frame;
-    return switch (vm.step_mode) {
-        .step => true,
-        .next => vm.frame_count <= vm.step_frame,
-        .continue_to_break => false,
-        .none => false,
-    };
+    switch (vm.step_mode) {
+        .step => return true,
+        .next => return vm.frame_count <= vm.step_frame,
+        .step_out => return vm.frame_count < vm.step_frame,
+        .continue_to_break => {
+            if (vm.watch_count > 0) return checkWatches(vm);
+            return false;
+        },
+        .none => return false,
+    }
+}
+
+fn checkWatches(vm: *VM) bool {
+    if (vm.frame_count == 0) return false;
+    const frame = vm.frames[vm.frame_count - 1];
+    const cls = frame.closure orelse return false;
+    const func = cls.func;
+    const printer = @import("printer.zig");
+
+    for (vm.watches[0..vm.watch_count]) |*w| {
+        for (func.debug_locals) |local| {
+            if (std.mem.eql(u8, local.name, w.name)) {
+                const val = vm.registers[frame.base + local.slot];
+                if (val != w.last_value) {
+                    w.last_value = val;
+                    writeStderr("Watch: ");
+                    writeStderr(w.name);
+                    writeStderr(" = ");
+                    const s = printer.valueToString(vm.gc.allocator, val, .write) catch "?";
+                    defer vm.gc.allocator.free(s);
+                    writeStderr(s);
+                    writeStderr("\n");
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
 }
 
 pub fn debugPause(vm: *VM, frame: *CallFrame) !void {
+    vm.inspect_frame = if (vm.frame_count > 0) vm.frame_count - 1 else 0;
+
     if (frame.closure) |cls| {
         const func = cls.func;
         writeStderr("Break");
@@ -64,16 +98,76 @@ pub fn debugPause(vm: *VM, frame: *CallFrame) !void {
             vm.step_frame = vm.frame_count;
             return;
         }
+        if (std.mem.eql(u8, cmd, "finish") or std.mem.eql(u8, cmd, "out")) {
+            vm.step_mode = .step_out;
+            vm.step_frame = vm.frame_count;
+            return;
+        }
         if (std.mem.eql(u8, cmd, "continue") or std.mem.eql(u8, cmd, "c")) {
             vm.step_mode = .continue_to_break;
             return;
         }
         if (std.mem.eql(u8, cmd, "locals") or std.mem.eql(u8, cmd, "l")) {
-            printLocals(vm, frame, vm.gc.allocator);
+            printLocals(vm, vm.inspect_frame, vm.gc.allocator);
             continue;
         }
         if (std.mem.eql(u8, cmd, "backtrace") or std.mem.eql(u8, cmd, "bt")) {
             printBacktrace(vm);
+            continue;
+        }
+        if (std.mem.eql(u8, cmd, "up")) {
+            if (vm.inspect_frame + 1 < vm.frame_count) {
+                vm.inspect_frame += 1;
+                printFrameInfo(vm, vm.inspect_frame);
+            } else {
+                writeStderr("Already at top of stack\n");
+            }
+            continue;
+        }
+        if (std.mem.eql(u8, cmd, "down")) {
+            if (vm.inspect_frame > 0) {
+                vm.inspect_frame -= 1;
+                printFrameInfo(vm, vm.inspect_frame);
+            } else {
+                writeStderr("Already at bottom of stack\n");
+            }
+            continue;
+        }
+        if (std.mem.startsWith(u8, cmd, "watch ")) {
+            const var_name = std.mem.trim(u8, cmd[6..], " ");
+            if (var_name.len > 0 and vm.watch_count < 16) {
+                vm.watches[vm.watch_count] = .{ .name = var_name };
+                vm.watch_count += 1;
+                writeStderr("Watching ");
+                writeStderr(var_name);
+                writeStderr("\n");
+            }
+            continue;
+        }
+        if (std.mem.startsWith(u8, cmd, "unwatch ")) {
+            const var_name = std.mem.trim(u8, cmd[8..], " ");
+            var found = false;
+            var j: usize = 0;
+            while (j < vm.watch_count) {
+                if (std.mem.eql(u8, vm.watches[j].name, var_name)) {
+                    vm.watch_count -= 1;
+                    if (j < vm.watch_count) {
+                        vm.watches[j] = vm.watches[vm.watch_count];
+                    }
+                    found = true;
+                    break;
+                }
+                j += 1;
+            }
+            if (found) {
+                writeStderr("Unwatched ");
+                writeStderr(var_name);
+                writeStderr("\n");
+            } else {
+                writeStderr("No watch on ");
+                writeStderr(var_name);
+                writeStderr("\n");
+            }
             continue;
         }
         if (std.mem.eql(u8, cmd, "quit") or std.mem.eql(u8, cmd, "q")) {
@@ -81,19 +175,23 @@ pub fn debugPause(vm: *VM, frame: *CallFrame) !void {
             vm.step_mode = .none;
             return;
         }
-        writeStderr("Commands: step(s), next(n), continue(c), locals(l), backtrace(bt), quit(q)\n");
+        writeStderr("Commands: step(s), next(n), finish/out, continue(c),\n");
+        writeStderr("          locals(l), backtrace(bt), up, down,\n");
+        writeStderr("          watch <var>, unwatch <var>, quit(q)\n");
     }
 }
 
-fn printLocals(vm: *VM, frame: *CallFrame, allocator: std.mem.Allocator) void {
-    if (frame.closure) |cls| {
+fn printLocals(vm: *VM, frame_idx: usize, allocator: std.mem.Allocator) void {
+    if (frame_idx >= vm.frame_count) return;
+    const f = vm.frames[frame_idx];
+    if (f.closure) |cls| {
         const func = cls.func;
         const printer = @import("printer.zig");
         for (func.debug_locals) |local| {
             writeStderr("  ");
             writeStderr(local.name);
             writeStderr(" = ");
-            const val = vm.registers[frame.base + local.slot];
+            const val = vm.registers[f.base + local.slot];
             const s = printer.valueToString(allocator, val, .write) catch continue;
             defer allocator.free(s);
             writeStderr(s);
@@ -105,11 +203,31 @@ fn printLocals(vm: *VM, frame: *CallFrame, allocator: std.mem.Allocator) void {
     }
 }
 
+fn printFrameInfo(vm: *VM, frame_idx: usize) void {
+    if (frame_idx >= vm.frame_count) return;
+    const f = vm.frames[frame_idx];
+    var buf: [64]u8 = undefined;
+    const s = std.fmt.bufPrint(&buf, "[{d}] ", .{frame_idx}) catch "";
+    writeStderr(s);
+    if (f.closure) |cls| {
+        if (cls.func.name) |name| {
+            writeStderr(name);
+        } else {
+            writeStderr("<lambda>");
+        }
+    } else {
+        writeStderr("<native>");
+    }
+    writeStderr("\n");
+}
+
 fn printBacktrace(vm: *VM) void {
     var i: usize = vm.frame_count;
     while (i > 0) {
         i -= 1;
         const f = vm.frames[i];
+        const marker: []const u8 = if (i == vm.inspect_frame) "> " else "  ";
+        writeStderr(marker);
         var buf: [32]u8 = undefined;
         const idx = std.fmt.bufPrint(&buf, "[{d}] ", .{i}) catch "";
         writeStderr(idx);


### PR DESCRIPTION
## Summary

Closes #183

- **step-out** (`finish`/`out`): runs until the current call frame returns
- **conditional breakpoints** (`,condition <id> <expr>`): breakpoint only fires when the Scheme expression evaluates to truthy
- **watch expressions** (`watch <var>` / `unwatch <var>`): pauses execution when a watched local variable changes value
- **up/down frame navigation**: inspect locals at different stack levels; `backtrace` marks the inspected frame with `>`

## Test plan

- [x] All unit tests pass
- [x] All 1485 Scheme tests pass
- [x] Debugger features require interactive testing (terminal I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)