### PR TITLE
Fix kaappi compile: find libkaappi_rt.a relative to binary, include in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
         with:
           version: 0.16.0
 
-      - name: Build release binaries
-        run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=true
+      - name: Build release binaries and runtime library
+        run: |
+          zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=true
+          zig build lib -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }}
 
       - name: Sign and notarize macOS binaries
         if: matrix.target == 'aarch64-macos'
@@ -78,6 +80,7 @@ jobs:
         run: |
           cp zig-out/bin/kaappi ${{ matrix.artifact }}
           cp zig-out/bin/thottam thottam-${{ matrix.target }}
+          cp zig-out/lib/libkaappi_rt.a libkaappi_rt-${{ matrix.target }}.a
 
       - name: Upload kaappi artifact
         uses: actions/upload-artifact@v7
@@ -91,6 +94,13 @@ jobs:
         with:
           name: thottam-${{ matrix.target }}
           path: thottam-${{ matrix.target }}
+          retention-days: 1
+
+      - name: Upload libkaappi_rt artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: libkaappi_rt-${{ matrix.target }}
+          path: libkaappi_rt-${{ matrix.target }}.a
           retention-days: 1
 
   build-wasm:
@@ -139,10 +149,10 @@ jobs:
       - name: Collect binaries, generate checksums, and sign
         run: |
           mkdir -p release
-          find artifacts -type f \( -name 'kaappi-*' -o -name 'kaappi.wasm' -o -name 'thottam-*' \) -exec cp {} release/ \;
+          find artifacts -type f \( -name 'kaappi-*' -o -name 'kaappi.wasm' -o -name 'thottam-*' -o -name 'libkaappi_rt-*' \) -exec cp {} release/ \;
           cp kaappi-lib.tar.gz release/
           cd release
-          sha256sum kaappi-* kaappi.wasm thottam-* kaappi-lib.tar.gz > SHA256SUMS
+          sha256sum kaappi-* kaappi.wasm thottam-* libkaappi_rt-* kaappi-lib.tar.gz > SHA256SUMS
           echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --detach-sign --armor SHA256SUMS
 
       - name: Extract changelog for this version

--- a/src/main.zig
+++ b/src/main.zig
@@ -84,6 +84,9 @@ fn printUsage() void {
             "  --timeout <ms>     Execution timeout in milliseconds\n" ++
             "  --max-memory <n>   Maximum heap memory in bytes\n" ++
             "\n" ++
+            "Environment variables:\n" ++
+            "  KAAPPI_LIB_DIR     Directory containing libkaappi_rt.a (for compile)\n" ++
+            "\n" ++
             "With no file argument, starts an interactive REPL.\n",
     );
 }
@@ -2050,6 +2053,11 @@ fn findInPath(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {
 }
 
 fn findLibDir(allocator: std.mem.Allocator) ?[]const u8 {
+    if (std.c.getenv("KAAPPI_LIB_DIR")) |env| {
+        const dir = std.mem.span(env);
+        if (checkLibDir(allocator, dir)) return dir;
+    }
+
     if (getExeRelativeLibDir(allocator)) |dir| return dir;
 
     const candidates = [_][]const u8{

--- a/src/main.zig
+++ b/src/main.zig
@@ -2050,19 +2050,62 @@ fn findInPath(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {
 }
 
 fn findLibDir(allocator: std.mem.Allocator) ?[]const u8 {
+    if (getExeRelativeLibDir(allocator)) |dir| return dir;
+
     const candidates = [_][]const u8{
         "zig-out/lib",
         "/usr/local/lib",
     };
 
     for (candidates) |dir| {
-        const path = std.fmt.allocPrint(allocator, "{s}/libkaappi_rt.a", .{dir}) catch continue;
-        defer allocator.free(path);
-        const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{ .ACCMODE = .RDONLY }, 0) catch continue;
-        _ = std.posix.system.close(fd);
-        return dir;
+        if (checkLibDir(allocator, dir)) return dir;
     }
     return null;
+}
+
+fn getExeRelativeLibDir(allocator: std.mem.Allocator) ?[]const u8 {
+    var path_buf: [1024]u8 = undefined;
+    const exe_path: []const u8 = blk: {
+        if (comptime @import("builtin").os.tag == .linux) {
+            const n: isize = std.posix.system.readlink(
+                "/proc/self/exe",
+                &path_buf,
+                path_buf.len,
+            );
+            if (n > 0) break :blk path_buf[0..@intCast(n)];
+        }
+
+        if (comptime @import("builtin").os.tag == .macos) {
+            var size: u32 = path_buf.len;
+            const rc = std.c._NSGetExecutablePath(&path_buf, &size);
+            if (rc == 0) {
+                const len = std.mem.indexOfScalar(u8, &path_buf, 0) orelse path_buf.len;
+                break :blk path_buf[0..len];
+            }
+        }
+
+        break :blk "";
+    };
+    if (exe_path.len == 0) return null;
+
+    const last_slash = std.mem.lastIndexOfScalar(u8, exe_path, '/') orelse return null;
+    if (last_slash == 0) return null;
+    const bin_dir = exe_path[0..last_slash];
+    const parent_slash = std.mem.lastIndexOfScalar(u8, bin_dir, '/') orelse return null;
+    const parent = exe_path[0..parent_slash];
+
+    const lib_dir = std.fmt.allocPrint(allocator, "{s}/lib", .{parent}) catch return null;
+    if (checkLibDir(allocator, lib_dir)) return lib_dir;
+    allocator.free(lib_dir);
+    return null;
+}
+
+fn checkLibDir(allocator: std.mem.Allocator, dir: []const u8) bool {
+    const path = std.fmt.allocPrint(allocator, "{s}/libkaappi_rt.a", .{dir}) catch return false;
+    defer allocator.free(path);
+    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{ .ACCMODE = .RDONLY }, 0) catch return false;
+    _ = std.posix.system.close(fd);
+    return true;
 }
 
 fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, out_path: []const u8, lib_flag: []const u8, is_zig: bool) bool {


### PR DESCRIPTION
## Summary

Fixes `kaappi compile` for end users who install via GitHub releases.

**Problem:** `findLibDir` only checked `zig-out/lib` and `/usr/local/lib`, so `kaappi compile` couldn't find `libkaappi_rt.a` when installed to a custom prefix.

**Fixes:**

1. **Exe-relative lib discovery**: `findLibDir` now resolves the kaappi binary's own path via `_NSGetExecutablePath` (macOS) or `/proc/self/exe` (Linux) and checks `<exe_dir>/../lib/` first. This works for any install prefix (e.g., `/opt/kaappi/bin/kaappi` finds `/opt/kaappi/lib/libkaappi_rt.a`).

2. **Release artifacts**: The release workflow now builds `libkaappi_rt.a` for each platform target and includes it in the GitHub Release alongside the binaries. Users download `libkaappi_rt-<target>.a` and place it in `<prefix>/lib/`.

## Test plan

- [x] Verified exe-relative discovery: installed binary at `/tmp/kaappi-install/bin/kaappi` finds lib at `/tmp/kaappi-install/lib/libkaappi_rt.a`
- [x] Fallback to `zig-out/lib` still works for development
- [x] Cross-compiles for Linux x86_64
- [x] All unit tests pass
- [x] All 1485 Scheme tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)