### PR TITLE
Fix native backend arithmetic for non-fixnum operands and overflow

### DIFF
--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -110,6 +110,13 @@ export fn kaappi_eval(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len: u64) callc
     return result;
 }
 
+fn callPrimitive(name: []const u8, a: u64, b: u64) u64 {
+    const vm = vm_mod.vm_instance orelse return 0;
+    const proc = vm.globals.get(name) orelse return 0;
+    const args = [_]u64{ a, b };
+    return vm.callWithArgs(proc, &args) catch return 0;
+}
+
 export fn kaappi_fixnum_add(a: u64, b: u64) callconv(.c) u64 {
     if (types.isFixnum(a) and types.isFixnum(b)) {
         const va = types.toFixnum(a);
@@ -119,7 +126,7 @@ export fn kaappi_fixnum_add(a: u64, b: u64) callconv(.c) u64 {
             return types.makeFixnum(result[0]);
         }
     }
-    return 0;
+    return callPrimitive("+", a, b);
 }
 
 export fn kaappi_fixnum_sub(a: u64, b: u64) callconv(.c) u64 {
@@ -131,7 +138,7 @@ export fn kaappi_fixnum_sub(a: u64, b: u64) callconv(.c) u64 {
             return types.makeFixnum(result[0]);
         }
     }
-    return 0;
+    return callPrimitive("-", a, b);
 }
 
 export fn kaappi_fixnum_mul(a: u64, b: u64) callconv(.c) u64 {
@@ -143,19 +150,19 @@ export fn kaappi_fixnum_mul(a: u64, b: u64) callconv(.c) u64 {
             return types.makeFixnum(result[0]);
         }
     }
-    return 0;
+    return callPrimitive("*", a, b);
 }
 
 export fn kaappi_fixnum_lt(a: u64, b: u64) callconv(.c) u64 {
     if (types.isFixnum(a) and types.isFixnum(b))
         return if (types.toFixnum(a) < types.toFixnum(b)) types.TRUE else types.FALSE;
-    return types.FALSE;
+    return callPrimitive("<", a, b);
 }
 
 export fn kaappi_fixnum_eq(a: u64, b: u64) callconv(.c) u64 {
     if (types.isFixnum(a) and types.isFixnum(b))
         return if (a == b) types.TRUE else types.FALSE;
-    return types.FALSE;
+    return callPrimitive("=", a, b);
 }
 
 export fn kaappi_car(v: u64) callconv(.c) u64 {

--- a/tests/e2e/programs/native-mixed-arith.scm
+++ b/tests/e2e/programs/native-mixed-arith.scm
@@ -1,0 +1,24 @@
+;; Regression test for #211: native arithmetic must handle
+;; non-fixnum operands and fixnum overflow correctly.
+
+;; Flonum operands
+(display (+ 1 2.5))
+(newline)
+(display (+ 1.0 2.0))
+(newline)
+(display (- 5.5 2.5))
+(newline)
+(display (* 3 2.5))
+(newline)
+
+;; Flonum comparisons
+(display (< 1 2.5))
+(newline)
+(display (= 2.0 2))
+(newline)
+
+;; Fixnum overflow (i48 max is 140737488355327)
+(display (+ 140737488355327 1))
+(newline)
+(display (* 140737488355327 2))
+(newline)


### PR DESCRIPTION
## Summary

- Fall back to full VM arithmetic primitives when the fast fixnum path fails in `kaappi_fixnum_add/sub/mul`
- Also fix `kaappi_fixnum_lt/eq` which returned `#f` for non-fixnum comparisons
- Extract shared `callPrimitive` helper that looks up the operator in VM globals and calls via `callWithArgs`

## Root cause

The runtime export functions returned raw `0` (which is flonum `+0.0` in the NaN-boxing scheme) when operands were not fixnums or when fixnum arithmetic overflowed. This caused silently wrong results — e.g. `(+ 1 2.5)` returned `0.0` instead of `3.5` in natively compiled programs.

## Test plan

- [x] New e2e parity test (`native-mixed-arith.scm`): flonum operands, flonum comparisons, fixnum overflow
- [x] Native output matches interpreter output for all test cases
- [x] All 1485 existing tests pass (unit + Scheme + R7RS)

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)