### PR TITLE
Fix missing write barriers in fiber/channel/SRFI-18 mutations

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -193,6 +193,7 @@ pub const FiberScheduler = struct {
                 if (fiber.status == .waiting and fiber.waiting_on == completed_val) {
                     fiber.status = .suspended;
                     fiber.result = completed_fiber.result;
+                    self.vm.gc.writeBarrier(&fiber.header, completed_fiber.result);
                 }
             }
         }

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -67,7 +67,7 @@ fn fiberJoinFn(args: []const Value) PrimitiveError!Value {
 
     if (target.status == .completed or target.status == .errored) return target.result;
 
-    return runSchedulerUntil(target, null);
+    return runSchedulerUntil(target, null, types.VOID);
 }
 
 fn fiberPredFn(args: []const Value) PrimitiveError!Value {
@@ -88,10 +88,17 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
     const new_pair = gc.allocPair(args[1], types.NIL) catch return PrimitiveError.OutOfMemory;
 
     if (ch.tail != types.NIL and types.isPair(ch.tail)) {
-        types.toObject(ch.tail).as(types.Pair).cdr = new_pair;
+        const tail_obj = types.toObject(ch.tail);
+        tail_obj.as(types.Pair).cdr = new_pair;
+        gc.writeBarrier(tail_obj, new_pair);
     }
+    const ch_obj = types.toObject(args[0]);
     ch.tail = new_pair;
-    if (ch.head == types.NIL) ch.head = new_pair;
+    gc.writeBarrier(ch_obj, new_pair);
+    if (ch.head == types.NIL) {
+        ch.head = new_pair;
+        gc.writeBarrier(ch_obj, new_pair);
+    }
     return types.VOID;
 }
 
@@ -102,22 +109,24 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     const ch = types.toObject(args[0]).as(types.Channel);
 
     if (ch.head != types.NIL and types.isPair(ch.head)) {
-        return dequeueChannel(ch);
+        return dequeueChannel(ch, args[0]);
     }
 
-    return runSchedulerUntil(null, ch);
+    return runSchedulerUntil(null, ch, args[0]);
 }
 
-fn dequeueChannel(ch: *types.Channel) Value {
+fn dequeueChannel(ch: *types.Channel, ch_val: Value) Value {
     const pair = types.toObject(ch.head).as(types.Pair);
     const val = pair.car;
     ch.head = pair.cdr;
+    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(ch_val), pair.cdr);
     if (ch.head == types.NIL) ch.tail = types.NIL;
     return val;
 }
 
-fn runSchedulerUntil(target: ?*fiber_mod.Fiber, ch: ?*types.Channel) PrimitiveError!Value {
+fn runSchedulerUntil(target: ?*fiber_mod.Fiber, ch: ?*types.Channel, ch_val: Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const sched = vm.scheduler orelse return PrimitiveError.OutOfMemory;
     const my_idx = sched.current_idx;
     sched.saveCurrentFiber();
@@ -161,6 +170,7 @@ fn runSchedulerUntil(target: ?*fiber_mod.Fiber, ch: ?*types.Channel) PrimitiveEr
         };
         fiber.status = .completed;
         fiber.result = result;
+        gc.writeBarrier(&fiber.header, result);
         sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }
@@ -173,7 +183,7 @@ fn runSchedulerUntil(target: ?*fiber_mod.Fiber, ch: ?*types.Channel) PrimitiveEr
 
     if (target) |f| return f.result;
     if (ch) |channel| {
-        if (channel.head != types.NIL) return dequeueChannel(channel);
+        if (channel.head != types.NIL) return dequeueChannel(channel, ch_val);
     }
     return types.VOID;
 }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -190,6 +190,7 @@ fn threadSpecificSetFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("thread-specific-set!", "thread", args[0]);
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
     fiber.specific = args[1];
+    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     return types.VOID;
 }
 
@@ -451,6 +452,7 @@ fn runSchedulerUntilDone(target: *fiber_mod.Fiber) PrimitiveError!void {
         };
         fiber.status = .completed;
         fiber.result = result;
+        if (primitives.gc_instance) |gc| gc.writeBarrier(&fiber.header, result);
         sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }
@@ -492,6 +494,7 @@ fn mutexSpecificSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isMutex(args[0]))
         return primitives.typeError("mutex-specific-set!", "mutex", args[0]);
     types.toMutex(args[0]).specific = args[1];
+    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     return types.VOID;
 }
 
@@ -606,6 +609,7 @@ fn runSchedulerUntilMutex(m: *types.Mutex, me: *fiber_mod.Fiber) PrimitiveError!
         };
         fiber.status = .completed;
         fiber.result = result;
+        if (primitives.gc_instance) |gc| gc.writeBarrier(&fiber.header, result);
         sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }
@@ -680,6 +684,7 @@ fn runSchedulerUntilCondVar(me: *fiber_mod.Fiber) PrimitiveError!void {
         };
         fiber.status = .completed;
         fiber.result = result;
+        if (primitives.gc_instance) |gc| gc.writeBarrier(&fiber.header, result);
         sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }
@@ -720,6 +725,7 @@ fn condvarSpecificSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isConditionVariable(args[0]))
         return primitives.typeError("condition-variable-specific-set!", "condition-variable", args[0]);
     types.toConditionVariable(args[0]).specific = args[1];
+    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     return types.VOID;
 }
 

--- a/tests/scheme/smoke/fiber-channel-gc.scm
+++ b/tests/scheme/smoke/fiber-channel-gc.scm
@@ -1,0 +1,70 @@
+;; Regression test for #205: write barriers in fiber/channel mutations.
+;; Exercises channel send/receive and fiber join under GC pressure to
+;; verify that old→young references are tracked correctly.
+
+(import (scheme base)
+        (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+;; Allocate garbage to pressure GC between operations
+(define (gc-pressure)
+  (let loop ((i 0))
+    (when (< i 500)
+      (make-vector 50 (list i i i))
+      (loop (+ i 1)))))
+
+;; Test 1: channel send/receive with GC pressure
+(define ch (make-channel))
+(channel-send ch (list 1 2 3))
+(gc-pressure)
+(channel-send ch (vector 4 5 6))
+(gc-pressure)
+(let ((v1 (channel-receive ch)))
+  (check "channel-recv-1" v1 '(1 2 3)))
+(let ((v2 (channel-receive ch)))
+  (check "channel-recv-2" v2 #(4 5 6)))
+
+;; Test 2: fiber join retrieves result after GC pressure
+(define f1 (spawn (lambda ()
+                    (gc-pressure)
+                    (list 'fiber-result 42))))
+(gc-pressure)
+(check "fiber-join" (fiber-join f1) '(fiber-result 42))
+
+;; Test 3: multiple fibers communicating through channel
+(define ch2 (make-channel))
+(spawn (lambda ()
+         (gc-pressure)
+         (channel-send ch2 "hello")))
+(spawn (lambda ()
+         (gc-pressure)
+         (channel-send ch2 "world")))
+(gc-pressure)
+(let* ((a (channel-receive ch2))
+       (b (channel-receive ch2)))
+  (check "multi-fiber-channel"
+         (list (string? a) (string? b))
+         '(#t #t)))
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary
- Add `gc.writeBarrier()` calls at 10 locations where heap object Value fields are mutated without barriers in fiber, channel, and SRFI-18 code
- Without barriers, old→young references go untracked during minor GC collections, causing premature collection and use-after-free
- Add regression test exercising channel send/receive and fiber join under GC pressure

## Locations fixed
- `primitives_fiber.zig`: channelSendFn (tail pair cdr, channel head/tail), dequeueChannel, runSchedulerUntil (fiber.result)
- `fiber.zig`: wakeWaiters (fiber.result copy)
- `primitives_srfi18.zig`: runSchedulerUntilDone/Mutex/CondVar (fiber.result), thread-specific-set!, mutex-specific-set!, condition-variable-specific-set!

## Test plan
- [x] New regression test: `tests/scheme/smoke/fiber-channel-gc.scm` (fibers + channels under GC pressure)
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme suite: 1486 pass, 0 fail, 1 skip

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)