### PR TITLE
Fix missing write barriers in promise forcing

### DIFF
--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -34,6 +34,7 @@ fn makePromiseLazy(args: []const Value) PrimitiveError!Value {
 
 fn forceFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     var current = args[0];
 
@@ -70,17 +71,21 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
             if (inner.forced) {
                 promise.forced = true;
                 promise.value = inner.value;
+                gc.writeBarrier(&promise.header, inner.value);
                 return inner.value;
             }
             promise.value = inner.value;
+            gc.writeBarrier(&promise.header, inner.value);
             inner.forced = true;
             inner.value = types.makePointer(@ptrCast(promise));
+            gc.writeBarrier(&inner.header, types.makePointer(@ptrCast(promise)));
             current = types.makePointer(@ptrCast(promise));
             continue;
         }
 
         promise.forced = true;
         promise.value = result;
+        gc.writeBarrier(&promise.header, result);
         return result;
     }
 

--- a/tests/scheme/smoke/promise-gc.scm
+++ b/tests/scheme/smoke/promise-gc.scm
@@ -1,0 +1,73 @@
+;; Regression test for #208: write barriers in promise forcing.
+;; Forces promises under GC pressure to verify old→young references
+;; in promise.value are tracked by the generational GC.
+
+(import (scheme base)
+        (scheme write)
+        (scheme lazy))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+(define (gc-pressure)
+  (let loop ((i 0))
+    (when (< i 500)
+      (make-vector 50 (list i i i))
+      (loop (+ i 1)))))
+
+;; Test 1: basic delay/force with GC pressure
+(define p1 (delay (begin (gc-pressure) (list 'a 'b 'c))))
+(gc-pressure)
+(check "force-basic" (force p1) '(a b c))
+(gc-pressure)
+(check "force-cached" (force p1) '(a b c))
+
+;; Test 2: chained promises (SRFI-45 forwarding)
+(define p2 (delay (delay (begin (gc-pressure) (vector 1 2 3)))))
+(gc-pressure)
+(check "force-chained" (force p2) #(1 2 3))
+(gc-pressure)
+(check "force-chained-cached" (force p2) #(1 2 3))
+
+;; Test 3: make-promise with non-promise value
+(define p3 (make-promise 42))
+(gc-pressure)
+(check "make-promise-val" (force p3) 42)
+
+;; Test 4: deeply nested delay chain
+(define p4 (delay (delay (delay (begin (gc-pressure) "deep")))))
+(gc-pressure)
+(check "force-deep" (force p4) "deep")
+
+;; Test 5: promise producing large heap object
+(define p5 (delay (begin
+                    (gc-pressure)
+                    (let ((v (make-vector 100 #f)))
+                      (vector-set! v 0 'first)
+                      (vector-set! v 99 'last)
+                      v))))
+(gc-pressure)
+(let ((r (force p5)))
+  (check "large-result-first" (vector-ref r 0) 'first)
+  (check "large-result-last" (vector-ref r 99) 'last))
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary
- Add `gc.writeBarrier()` calls at 4 locations in `primitives_lazy.zig` where `promise.value` is mutated without barriers
- Promises are long-lived objects likely promoted to old generation; values stored into them are often fresh young-gen allocations
- Without barriers, minor GC collections miss old→young references, causing premature collection

## Locations fixed
- Line 72: `promise.value = inner.value` (inner already forced)
- Line 75: `promise.value = inner.value` (SRFI-45 forwarding)
- Line 77: `inner.value = makePointer(promise)` (forwarding pointer)
- Line 83: `promise.value = result` (storing thunk result)

## Test plan
- [x] New regression test: `tests/scheme/smoke/promise-gc.scm` (delay/force under GC pressure)
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme suite: 1487 pass, 0 fail, 1 skip

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)