### PR TITLE
Reclaim completed fiber slots in scheduler

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -68,9 +68,23 @@ pub const FiberScheduler = struct {
     }
 
     pub fn addFiber(self: *FiberScheduler, fiber: *Fiber) !void {
-        if (self.fiber_count >= MAX_FIBERS) return VMError.StackOverflow;
-        self.fibers[self.fiber_count] = fiber;
-        self.fiber_count += 1;
+        if (self.fiber_count < MAX_FIBERS) {
+            self.fibers[self.fiber_count] = fiber;
+            self.fiber_count += 1;
+            return;
+        }
+        for (self.fibers[0..self.fiber_count], 0..) |f, i| {
+            if (f) |existing| {
+                if (existing.status == .completed or existing.status == .errored) {
+                    self.fibers[i] = fiber;
+                    return;
+                }
+            } else {
+                self.fibers[i] = fiber;
+                return;
+            }
+        }
+        return VMError.StackOverflow;
     }
 
     pub fn spawnFiber(self: *FiberScheduler, thunk: Value) !*Fiber {

--- a/tests/scheme/smoke/fiber-slot-reuse.scm
+++ b/tests/scheme/smoke/fiber-slot-reuse.scm
@@ -1,0 +1,43 @@
+;; Regression test for #206: fiber scheduler slot exhaustion.
+;; Spawns more than MAX_FIBERS (64) total fibers over the program's
+;; lifetime. Without slot reclamation this crashes with StackOverflow.
+
+(import (scheme base)
+        (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+;; Spawn 100 fibers sequentially, each completing before the next.
+;; This requires slot reclamation since MAX_FIBERS = 64.
+(define results '())
+(let loop ((i 0))
+  (when (< i 100)
+    (let ((f (spawn (lambda () (* i 2)))))
+      (set! results (cons (fiber-join f) results)))
+    (loop (+ i 1))))
+
+(check "fiber-count" (length results) 100)
+(check "first-result" (car results) 198)
+(check "last-result" (list-ref results 99) 0)
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary
- `FiberScheduler.addFiber()` used a monotonically increasing index with no slot reclamation — completed fibers permanently consumed their slots
- After 64 total spawns over a program's lifetime, `StackOverflow` was returned even if only 1 fiber was active
- Now scans for completed/errored/null slots when the array is full, reusing the first available one

## Test plan
- [x] New regression test: `tests/scheme/smoke/fiber-slot-reuse.scm` (spawns 100 fibers sequentially)
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme suite: 1488 pass, 0 fail, 1 skip

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)