### PR TITLE
Fix allocator.free() called on string literal in debugger

### DIFF
--- a/src/vm_debug.zig
+++ b/src/vm_debug.zig
@@ -45,9 +45,12 @@ fn checkWatches(vm: *VM) bool {
                     writeStderr("Watch: ");
                     writeStderr(w.name);
                     writeStderr(" = ");
-                    const s = printer.valueToString(vm.gc.allocator, val, .write) catch "?";
-                    defer vm.gc.allocator.free(s);
-                    writeStderr(s);
+                    if (printer.valueToString(vm.gc.allocator, val, .write)) |s| {
+                        defer vm.gc.allocator.free(s);
+                        writeStderr(s);
+                    } else |_| {
+                        writeStderr("?");
+                    }
                     writeStderr("\n");
                     return true;
                 }


### PR DESCRIPTION
## Summary
- `checkWatches` in `vm_debug.zig` used `catch "?"` to handle `valueToString` OOM, then unconditionally called `allocator.free()` on the result
- String literals live in read-only static data — freeing them corrupts the allocator or crashes
- Use if/else on the error union so `free()` is only called on the heap-allocated success path

## Test plan
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme suite: 1488 pass, 0 fail, 1 skip
- Note: the bug path requires OOM during a debugger watch check, which is difficult to trigger in automated tests. The fix is mechanically correct — only freeing heap-allocated strings.

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)