### PR TITLE
Add write barrier to %record-set! and fix generational GC remembered set

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -55,12 +55,68 @@ pub fn collect(gc: *GC) void {
 }
 
 fn minorCollect(gc: *GC) void {
+    clearOldMarks(gc);
     markRoots(gc);
     for (gc.remembered_set.items) |obj| {
         markObjectContents(gc, obj);
     }
     sweepYoung(gc);
-    gc.remembered_set.clearRetainingCapacity();
+    pruneRememberedSet(gc);
+}
+
+fn clearOldMarks(gc: *GC) void {
+    var obj = gc.old_objects;
+    while (obj) |o| {
+        o.marked = false;
+        obj = o.next;
+    }
+}
+
+fn pruneRememberedSet(gc: *GC) void {
+    var write_idx: usize = 0;
+    for (gc.remembered_set.items) |obj| {
+        if (referencesYoung(obj)) {
+            gc.remembered_set.items[write_idx] = obj;
+            write_idx += 1;
+        }
+    }
+    gc.remembered_set.shrinkRetainingCapacity(write_idx);
+}
+
+fn referencesYoung(obj: *Object) bool {
+    switch (obj.tag) {
+        .pair => {
+            const pair = obj.as(Pair);
+            if (isYoungPointer(pair.car) or isYoungPointer(pair.cdr)) return true;
+        },
+        .vector => {
+            const vec = obj.as(types.Vector);
+            for (vec.data) |item| {
+                if (isYoungPointer(item)) return true;
+            }
+        },
+        .record_instance => {
+            const ri = obj.as(RecordInstance);
+            for (ri.fields) |field| {
+                if (isYoungPointer(field)) return true;
+            }
+        },
+        .hash_table => {
+            const ht = obj.as(HashTable);
+            for (ht.entries[0..ht.capacity]) |entry| {
+                if (entry.key != types.VOID and entry.key != types.NIL) {
+                    if (isYoungPointer(entry.key) or isYoungPointer(entry.value)) return true;
+                }
+            }
+        },
+        else => return true,
+    }
+    return false;
+}
+
+fn isYoungPointer(val: Value) bool {
+    if (!types.isPointer(val)) return false;
+    return types.toObject(val).generation == 0;
 }
 
 fn fullCollect(gc: *GC) void {

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -694,6 +694,7 @@ fn recordSetFn(args: []const Value) PrimitiveError!Value {
     const ri = types.toObject(args[0]).as(types.RecordInstance);
     const idx: usize = @intCast(types.toFixnum(args[1]));
     if (idx >= ri.fields.len) return PrimitiveError.TypeError;
+    if (gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     ri.fields[idx] = args[2];
     return types.VOID;
 }

--- a/tests/scheme/smoke/record-set-gc.scm
+++ b/tests/scheme/smoke/record-set-gc.scm
@@ -1,0 +1,62 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; Record mutation must preserve young-gen values when the record is old-gen.
+;; Without the write barrier in %record-set!, minor GC can collect the new value.
+
+(define-record-type <point>
+  (make-point x y)
+  point?
+  (x point-x set-point-x!)
+  (y point-y set-point-y!))
+
+;; Create a record and force it into old generation via GC pressure
+(define p (make-point 1 2))
+
+;; Allocate enough to trigger several GC cycles, promoting p to old gen
+(let loop ((i 0))
+  (when (< i 3000)
+    (make-list 10 i)
+    (loop (+ i 1))))
+
+;; Now mutate the old-gen record with a new young-gen value (a freshly allocated string)
+(set-point-x! p (string-copy "new-value"))
+
+;; More allocation to trigger minor GC
+(let loop ((i 0))
+  (when (< i 3000)
+    (make-list 10 i)
+    (loop (+ i 1))))
+
+;; The string must survive — the write barrier should have protected it
+(check "record mutation survives GC"
+  (point-x p)
+  "new-value")
+
+;; Test mutating multiple fields
+(set-point-y! p (list 'a 'b 'c))
+
+(let loop ((i 0))
+  (when (< i 3000)
+    (make-list 10 i)
+    (loop (+ i 1))))
+
+(check "record second field survives GC"
+  (point-y p)
+  '(a b c))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "record-set GC tests failed" fail))


### PR DESCRIPTION
## Summary

- Add missing `gc.writeBarrier()` call in `recordSetFn` before record field mutation
- Fix generational GC bug: old-generation marks were never cleared between minor collections, causing `markValue()` to skip re-traversing old objects and miss young values
- Prune remembered set after minor collection instead of clearing it unconditionally

## Details

The `%record-set!` primitive mutated record fields without a write barrier, but fixing that alone wasn't enough — a deeper GC issue prevented the barrier from working:

**Root cause:** `sweepYoung()` only clears marks on young objects. Old-gen objects stayed marked across minor cycles. On the next minor GC, `markValue()` saw them as already-marked and didn't trace their fields, so young values referenced only through old-gen parents were collected.

**Fix:** `clearOldMarks()` resets old-gen marks at the start of each minor collection. `pruneRememberedSet()` retains entries that still reference young values instead of clearing all entries.

## Test plan

- [x] New regression test `tests/scheme/smoke/record-set-gc.scm` — creates old-gen record, mutates field to young value, triggers GC, verifies value survives
- [x] Zig unit tests pass
- [x] Full Scheme test suite: 1489 pass, 0 fail

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)