### PR TITLE
Root cdr value in reader dotted-pair path before datum comments

### DIFF
--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -100,14 +100,14 @@ fn readList(self: *Reader) ReadError!Value {
         if (self.pos + 1 < self.source.len and Reader.isDelimiter(self.source[self.pos + 1])) {
             self.pos += 1;
             const rest = try readDatum(self);
+            var rest_root = rest;
+            try self.gc.pushRoot(&rest_root);
+            defer self.gc.popRoot();
             try self.skipWhitespaceAndCommentsChecked();
             if (self.pos >= self.source.len or self.source[self.pos] != ')') {
                 return ReadError.UnexpectedChar;
             }
             self.pos += 1;
-            var rest_root = rest;
-            try self.gc.pushRoot(&rest_root);
-            defer self.gc.popRoot();
             const pair = self.gc.allocPair(first_root, rest_root) catch return ReadError.OutOfMemory;
             self.gc.source_lines.put(pair, list_line) catch {};
             return pair;

--- a/tests/scheme/smoke/dotted-pair-datum-comment.scm
+++ b/tests/scheme/smoke/dotted-pair-datum-comment.scm
@@ -1,0 +1,40 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; Dotted pair with datum comment after the cdr value.
+;; The reader must root the cdr value before processing the datum comment,
+;; which can trigger GC.
+
+;; Allocate to create GC pressure
+(let loop ((i 0))
+  (when (< i 2000)
+    (make-list 10 i)
+    (loop (+ i 1))))
+
+(check "dotted pair with datum comment"
+  '(a . b #; discarded)
+  '(a . b))
+
+(check "dotted pair with complex datum comment"
+  '(x . y #; (a long list that allocates))
+  '(x . y))
+
+(check "dotted pair with nested datum comments"
+  '(1 . 2 #; #; nested also-nested)
+  '(1 . 2))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "dotted-pair datum comment tests failed" fail))


### PR DESCRIPTION
## Summary

- Root the cdr value immediately after `readDatum()` in the dotted-pair branch of `readList`, before calling `skipWhitespaceAndCommentsChecked()`
- The skip function can process `#;` datum comments, which call `readDatum()` internally and can trigger GC

## Test plan

- [x] New test `tests/scheme/smoke/dotted-pair-datum-comment.scm` — exercises dotted pairs with datum comments
- [x] Zig unit tests pass
- [x] Full Scheme test suite: 1490 pass, 0 fail

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)