### PR TITLE
Fix FFI bignum arguments: extract numeric value instead of pointer bits

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -4,6 +4,16 @@ const memory = @import("memory.zig");
 const Value = types.Value;
 const FfiType = types.FfiType;
 
+fn toIntArg(v: Value) i64 {
+    if (types.isBignum(v)) {
+        const bn = types.toBignum(v);
+        if (bn.len == 0) return 0;
+        const mag: i64 = @bitCast(bn.limbs[0]);
+        return if (bn.positive) mag else -mag;
+    }
+    return types.toFixnum(v);
+}
+
 /// Convert a Scheme string Value to a null-terminated C string using a stack buffer.
 /// Returns null if the value is not a string or the string is too long.
 fn toCString(v: Value, buf: *[4096]u8) ?[*:0]const u8 {
@@ -202,21 +212,21 @@ fn callFfi1(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // int -> int (abs, etc.)
     if (p0 == .int and rt == .int) {
         const f: *const fn (c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])));
+        const result = f(@intCast(toIntArg(args[0])));
         return types.makeFixnum(@intCast(result));
     }
 
     // int -> long
     if (p0 == .int and rt == .long) {
         const f: *const fn (c_int) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])));
+        const result = f(@intCast(toIntArg(args[0])));
         return marshalLongReturn(result, gc);
     }
 
     // long -> long
     if (p0 == .long and rt == .long) {
         const f: *const fn (c_long) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])));
+        const result = f(@intCast(toIntArg(args[0])));
         return marshalLongReturn(result, gc);
     }
 
@@ -259,7 +269,7 @@ fn callFfi1(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // int -> void
     if (p0 == .int and rt == .void_type) {
         const f: *const fn (c_int) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(types.toFixnum(args[0])));
+        f(@intCast(toIntArg(args[0])));
         return types.VOID;
     }
 
@@ -315,21 +325,21 @@ fn callFfi1(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // int -> pointer (malloc, etc.)
     if (p0 == .int and rt == .pointer) {
         const f: *const fn (c_int) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])));
+        const result = f(@intCast(toIntArg(args[0])));
         return marshalPointerReturn(result, gc);
     }
 
     // long -> pointer
     if (p0 == .long and rt == .pointer) {
         const f: *const fn (c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])));
+        const result = f(@intCast(toIntArg(args[0])));
         return marshalPointerReturn(result, gc);
     }
 
     // long -> void
     if (p0 == .long and rt == .void_type) {
         const f: *const fn (c_long) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(types.toFixnum(args[0])));
+        f(@intCast(toIntArg(args[0])));
         return types.VOID;
     }
 
@@ -387,21 +397,21 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (int, int) -> int
     if (p0 == .int and p1 == .int and rt == .int) {
         const f: *const fn (c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])));
+        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (int, int) -> long
     if (p0 == .int and p1 == .int and rt == .long) {
         const f: *const fn (c_int, c_int) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])));
+        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
         return marshalLongReturn(result, gc);
     }
 
     // (long, long) -> long
     if (p0 == .long and p1 == .long and rt == .long) {
         const f: *const fn (c_long, c_long) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])));
+        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
         return marshalLongReturn(result, gc);
     }
 
@@ -441,7 +451,7 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (int, int) -> void
     if (p0 == .int and p1 == .int and rt == .void_type) {
         const f: *const fn (c_int, c_int) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])));
+        f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
         return types.VOID;
     }
 
@@ -476,63 +486,63 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (pointer, int) -> int
     if (p0 == .pointer and p1 == .int and rt == .int) {
         const f: *const fn (?*anyopaque, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, int) -> void
     if (p0 == .pointer and p1 == .int and rt == .void_type) {
         const f: *const fn (?*anyopaque, c_int) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])));
+        f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
         return types.VOID;
     }
 
     // (pointer, int) -> pointer
     if (p0 == .pointer and p1 == .int and rt == .pointer) {
         const f: *const fn (?*anyopaque, c_int) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
         return marshalPointerReturn(result, gc);
     }
 
     // (pointer, long) -> pointer (realloc, etc.)
     if (p0 == .pointer and p1 == .long and rt == .pointer) {
         const f: *const fn (?*anyopaque, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
         return marshalPointerReturn(result, gc);
     }
 
     // (pointer, long) -> int
     if (p0 == .pointer and p1 == .long and rt == .int) {
         const f: *const fn (?*anyopaque, c_long) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, long) -> void
     if (p0 == .pointer and p1 == .long and rt == .void_type) {
         const f: *const fn (?*anyopaque, c_long) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])));
+        f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
         return types.VOID;
     }
 
     // (pointer, long) -> long
     if (p0 == .pointer and p1 == .long and rt == .long) {
         const f: *const fn (?*anyopaque, c_long) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
         return marshalLongReturn(result, gc);
     }
 
     // (int, pointer) -> int
     if (p0 == .int and p1 == .pointer and rt == .int) {
         const f: *const fn (c_int, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), marshalToPointer(args[1]));
+        const result = f(@intCast(toIntArg(args[0])), marshalToPointer(args[1]));
         return types.makeFixnum(@intCast(result));
     }
 
     // (int, pointer) -> void
     if (p0 == .int and p1 == .pointer and rt == .void_type) {
         const f: *const fn (c_int, ?*anyopaque) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(types.toFixnum(args[0])), marshalToPointer(args[1]));
+        f(@intCast(toIntArg(args[0])), marshalToPointer(args[1]));
         return types.VOID;
     }
 
@@ -541,7 +551,7 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         const f: *const fn ([*:0]const u8, c_int) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
         var buf0: [4096]u8 = undefined;
         const cs0 = toCString(args[0], &buf0) orelse return error.TypeError;
-        const result = f(cs0, @intCast(types.toFixnum(args[1])));
+        const result = f(cs0, @intCast(toIntArg(args[1])));
         return marshalPointerReturn(result, gc);
     }
 
@@ -570,7 +580,7 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (long, long) -> pointer
     if (p0 == .long and p1 == .long and rt == .pointer) {
         const f: *const fn (c_long, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])));
+        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
         return marshalPointerReturn(result, gc);
     }
 
@@ -592,7 +602,7 @@ fn callFfi3(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         const f: *const fn ([*:0]const u8, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
         var buf: [4096]u8 = undefined;
         const cstr = toCString(args[0], &buf) orelse return error.TypeError;
-        const result = f(cstr, @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])));
+        const result = f(cstr, @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -606,7 +616,7 @@ fn callFfi3(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (int, int, int) -> int
     if (p0 == .int and p1 == .int and p2 == .int and rt == .int) {
         const f: *const fn (c_int, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])));
+        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -617,28 +627,28 @@ fn callFfi3(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         var buf1: [4096]u8 = undefined;
         const cs0 = toCString(args[0], &buf0) orelse return error.TypeError;
         const cs1 = toCString(args[1], &buf1) orelse return error.TypeError;
-        const result = f(cs0, cs1, @intCast(types.toFixnum(args[2])));
+        const result = f(cs0, cs1, @intCast(toIntArg(args[2])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, pointer, long) -> pointer (memcpy, memmove, etc.)
     if (p0 == .pointer and p1 == .pointer and p2 == .long and rt == .pointer) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(types.toFixnum(args[2])));
+        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])));
         return marshalPointerReturn(result, gc);
     }
 
     // (pointer, int, long) -> pointer (memset, etc.)
     if (p0 == .pointer and p1 == .int and p2 == .long and rt == .pointer) {
         const f: *const fn (?*anyopaque, c_int, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])));
         return marshalPointerReturn(result, gc);
     }
 
     // (pointer, long, pointer) -> long (fread/fwrite patterns)
     if (p0 == .pointer and p1 == .long and p2 == .pointer and rt == .long) {
         const f: *const fn (?*anyopaque, c_long, ?*anyopaque) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])), marshalToPointer(args[2]));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])), marshalToPointer(args[2]));
         return marshalLongReturn(result, gc);
     }
 
@@ -666,21 +676,21 @@ fn callFfi3(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (pointer, pointer, long) -> int
     if (p0 == .pointer and p1 == .pointer and p2 == .long and rt == .int) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(types.toFixnum(args[2])));
+        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, pointer, long) -> void
     if (p0 == .pointer and p1 == .pointer and p2 == .long and rt == .void_type) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(types.toFixnum(args[2])));
+        f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])));
         return types.VOID;
     }
 
     // (int, pointer, pointer) -> int
     if (p0 == .int and p1 == .pointer and p2 == .pointer and rt == .int) {
         const f: *const fn (c_int, ?*anyopaque, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), marshalToPointer(args[1]), marshalToPointer(args[2]));
+        const result = f(@intCast(toIntArg(args[0])), marshalToPointer(args[1]), marshalToPointer(args[2]));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -716,8 +726,8 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         const f: *const fn (?*anyopaque, usize, usize, *const fn (?*anyopaque, ?*anyopaque) callconv(.c) c_int) callconv(.c) void =
             @ptrCast(@alignCast(ffi_fn.symbol));
         const ptr0 = marshalToPointer(args[0]) orelse return error.TypeError;
-        const n_signed = types.toFixnum(args[1]);
-        const sz_signed = types.toFixnum(args[2]);
+        const n_signed = toIntArg(args[1]);
+        const sz_signed = toIntArg(args[2]);
         if (n_signed < 0 or sz_signed < 0) return error.TypeError;
         const n: usize = @intCast(n_signed);
         const sz: usize = @intCast(sz_signed);
@@ -733,7 +743,7 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
             @ptrCast(@alignCast(ffi_fn.symbol));
         const ptr0 = marshalToPointer(args[0]) orelse return error.TypeError;
         const ptr3 = marshalToPointer(args[3]) orelse return error.TypeError;
-        const result = f(ptr0, @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])), ptr3);
+        const result = f(ptr0, @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), ptr3);
         return types.makeFixnum(@intCast(result));
     }
 
@@ -754,7 +764,7 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     if (p0 == .pointer and p1 == .pointer and p2 == .long and p3 == .long and rt == .pointer) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long, c_long) callconv(.c) ?*anyopaque =
             @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(types.toFixnum(args[2])), @intCast(types.toFixnum(args[3])));
+        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])));
         return marshalPointerReturn(result, gc);
     }
 
@@ -762,7 +772,7 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     if (p0 == .pointer and p1 == .long and p2 == .long and p3 == .long and rt == .int) {
         const f: *const fn (?*anyopaque, c_long, c_long, c_long) callconv(.c) c_int =
             @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])), @intCast(types.toFixnum(args[3])));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -814,35 +824,35 @@ fn callFfi5(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (int, int, int, int, int) -> int
     if (p0 == .int and p1 == .int and p2 == .int and p3 == .int and p4 == .int and rt == .int) {
         const f: *const fn (c_int, c_int, c_int, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])), @intCast(types.toFixnum(args[3])), @intCast(types.toFixnum(args[4])));
+        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), @intCast(toIntArg(args[4])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (int, int, int, int, int) -> void
     if (p0 == .int and p1 == .int and p2 == .int and p3 == .int and p4 == .int and rt == .void_type) {
         const f: *const fn (c_int, c_int, c_int, c_int, c_int) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])), @intCast(types.toFixnum(args[3])), @intCast(types.toFixnum(args[4])));
+        f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), @intCast(toIntArg(args[4])));
         return types.VOID;
     }
 
     // (int, int, int, pointer, int) -> int — setsockopt
     if (p0 == .int and p1 == .int and p2 == .int and p3 == .pointer and p4 == .int and rt == .int) {
         const f: *const fn (c_int, c_int, c_int, ?*anyopaque, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(types.toFixnum(args[0])), @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])), marshalToPointer(args[3]), @intCast(types.toFixnum(args[4])));
+        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), marshalToPointer(args[3]), @intCast(toIntArg(args[4])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, pointer, long, int, pointer) -> int — sendto
     if (p0 == .pointer and p1 == .pointer and p2 == .long and p3 == .int and p4 == .pointer and rt == .int) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long, c_int, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(types.toFixnum(args[2])), @intCast(types.toFixnum(args[3])), marshalToPointer(args[4]));
+        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), marshalToPointer(args[4]));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, int, int, int, int) -> int — socket/IO ops
     if (p0 == .pointer and p1 == .int and p2 == .int and p3 == .int and p4 == .int and rt == .int) {
         const f: *const fn (?*anyopaque, c_int, c_int, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])), @intCast(types.toFixnum(args[3])), @intCast(types.toFixnum(args[4])));
+        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), @intCast(toIntArg(args[4])));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -874,7 +884,7 @@ fn callFfi5(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     if (p0 == .string and p1 == .int and p2 == .int and p3 == .int and p4 == .int and rt == .int) {
         const f: *const fn ([*:0]const u8, c_int, c_int, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
         var buf0: [4096]u8 = undefined;
-        const result = f(toCString(args[0], &buf0) orelse return error.TypeError, @intCast(types.toFixnum(args[1])), @intCast(types.toFixnum(args[2])), @intCast(types.toFixnum(args[3])), @intCast(types.toFixnum(args[4])));
+        const result = f(toCString(args[0], &buf0) orelse return error.TypeError, @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), @intCast(toIntArg(args[4])));
         return types.makeFixnum(@intCast(result));
     }
 

--- a/tests/scheme/ffi/bignum-args.scm
+++ b/tests/scheme/ffi/bignum-args.scm
@@ -1,0 +1,36 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; Test that bignum integer arguments are correctly passed to C functions.
+;; Previously, toFixnum extracted pointer bits from bignums instead of
+;; the numeric value.
+
+(define libc (ffi-open #f))
+(define c-abs (ffi-fn libc "abs" '(int) 'int))
+(define c-labs (ffi-fn libc "labs" '(long) 'long))
+
+;; Fixnum args should still work
+(check "abs fixnum positive" (c-abs 42) 42)
+(check "abs fixnum negative" (c-abs -42) 42)
+(check "abs fixnum zero" (c-abs 0) 0)
+
+;; Bignum that fits in an int (> 2^47 but < 2^31 is impossible, so test
+;; with large fixnum boundary values)
+(check "labs large positive" (c-labs (expt 2 50)) (expt 2 50))
+(check "labs large negative" (c-labs (- (expt 2 50))) (expt 2 50))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "FFI bignum argument tests failed" fail))


### PR DESCRIPTION
## Summary

- Add `toIntArg()` helper in `ffi.zig` that checks for bignum and extracts the numeric value from limbs, falling back to `toFixnum()` for fixnums
- Replace all 42 `types.toFixnum(args[...])` calls in FFI dispatcher functions with `toIntArg(args[...])`

## Details

`validateArg()` correctly accepts both fixnums and bignums for integer parameter types, but all dispatcher functions (`callFfi1` through `callFfi5`) unconditionally called `types.toFixnum()`. For bignums, this extracts the 48-bit pointer payload instead of the numeric value, silently passing garbage to C functions.

## Test plan

- [x] New test `tests/scheme/ffi/bignum-args.scm` — tests `abs` and `labs` with fixnum and bignum arguments
- [x] Existing FFI tests pass
- [x] Full test suite: 1490 pass, 0 fail

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)