### PR TITLE
Fix SRFI-27: lossless state roundtrip, negative arg guard, zero-state rejection

### DIFF
--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -26,7 +26,7 @@ fn freshSeed() u64 {
     return @as(u64, @bitCast(ts.sec)) ^ @as(u64, @bitCast(ts.nsec));
 }
 
-var default_rs_val: Value = types.VOID;
+threadlocal var default_rs_val: Value = types.VOID;
 
 pub fn registerRandom(vm: *vm_mod.VM) !void {
     default_rs_val = vm.gc.allocRandomSource(freshSeed()) catch return error.OutOfMemory;
@@ -45,6 +45,15 @@ pub fn registerRandom(vm: *vm_mod.VM) !void {
     try reg(vm, "%rs-next-real", &rsNextRealFn, .{ .exact = 1 });
 }
 
+pub fn ensureDefaultRS() void {
+    if (default_rs_val == types.VOID) {
+        if (primitives.gc_instance) |gc| {
+            default_rs_val = gc.allocRandomSource(freshSeed()) catch return;
+            gc.extra_roots.append(gc.allocator, default_rs_val) catch {};
+        }
+    }
+}
+
 fn getRS(proc: []const u8, v: Value) PrimitiveError!*types.RandomSource {
     if (!types.isRandomSource(v)) return primitives.typeError(proc, "random-source", v);
     return types.toObject(v).as(types.RandomSource);
@@ -54,6 +63,7 @@ fn randomIntegerFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("random-integer", "integer", args[0]);
     const n = types.toFixnum(args[0]);
     if (n <= 0) return primitives.typeError("random-integer", "positive integer", args[0]);
+    ensureDefaultRS();
     const rs = try getRS("random-integer", default_rs_val);
     const r = rs.prng.random();
     return types.makeFixnum(r.intRangeLessThan(i64, 0, n));
@@ -61,6 +71,7 @@ fn randomIntegerFn(args: []const Value) PrimitiveError!Value {
 
 fn randomRealFn(args: []const Value) PrimitiveError!Value {
     _ = args;
+    ensureDefaultRS();
     const rs = try getRS("random-real", default_rs_val);
     const r = rs.prng.random();
     return types.makeFlonum(r.float(f64));
@@ -68,6 +79,7 @@ fn randomRealFn(args: []const Value) PrimitiveError!Value {
 
 fn defaultRandomSourceFn(args: []const Value) PrimitiveError!Value {
     _ = args;
+    ensureDefaultRS();
     return default_rs_val;
 }
 
@@ -91,8 +103,12 @@ fn randomSourcePseudoRandomizeFn(args: []const Value) PrimitiveError!Value {
     const rs = try getRS("random-source-pseudo-randomize!", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("random-source-pseudo-randomize!", "integer", args[1]);
     if (!types.isFixnum(args[2])) return primitives.typeError("random-source-pseudo-randomize!", "integer", args[2]);
-    const i: u64 = @intCast(types.toFixnum(args[1]));
-    const j: u64 = @intCast(types.toFixnum(args[2]));
+    const i_val = types.toFixnum(args[1]);
+    const j_val = types.toFixnum(args[2]);
+    if (i_val < 0) return PrimitiveError.TypeError;
+    if (j_val < 0) return PrimitiveError.TypeError;
+    const i: u64 = @intCast(i_val);
+    const j: u64 = @intCast(j_val);
     rs.prng = std.Random.DefaultPrng.init(i *% 2654435761 +% j *% 2246822519);
     return types.VOID;
 }
@@ -106,23 +122,42 @@ fn randomSourceStateRefFn(args: []const Value) PrimitiveError!Value {
     var i: usize = 4;
     while (i > 0) {
         i -= 1;
-        const word: i64 = @bitCast(rs.prng.s[i]);
-        result = gc.allocPair(types.makeFixnum(word), result) catch return PrimitiveError.OutOfMemory;
+        const limb = [1]u64{rs.prng.s[i]};
+        const word = gc.allocBignumFromLimbs(&limb, 1, true) catch return PrimitiveError.OutOfMemory;
+        result = gc.allocPair(word, result) catch return PrimitiveError.OutOfMemory;
     }
     return result;
+}
+
+fn stateWordToU64(v: Value) ?u64 {
+    if (types.isFixnum(v)) {
+        const n = types.toFixnum(v);
+        return @bitCast(n);
+    }
+    if (types.isBignum(v)) {
+        const bn = types.toBignum(v);
+        if (bn.len == 0) return 0;
+        if (bn.len > 1) return null;
+        return bn.limbs[0];
+    }
+    return null;
 }
 
 fn randomSourceStateSetFn(args: []const Value) PrimitiveError!Value {
     const rs = try getRS("random-source-state-set!", args[0]);
     var state_list = args[1];
+    var new_state: [4]u64 = undefined;
     var i: usize = 0;
     while (i < 4) : (i += 1) {
         if (!types.isPair(state_list)) return primitives.typeError("random-source-state-set!", "list of 4 integers", state_list);
         const word = types.car(state_list);
-        if (!types.isFixnum(word)) return primitives.typeError("random-source-state-set!", "integer", word);
-        rs.prng.s[i] = @bitCast(types.toFixnum(word));
+        new_state[i] = stateWordToU64(word) orelse return primitives.typeError("random-source-state-set!", "integer", word);
         state_list = types.cdr(state_list);
     }
+    if (new_state[0] == 0 and new_state[1] == 0 and new_state[2] == 0 and new_state[3] == 0) {
+        return PrimitiveError.TypeError;
+    }
+    rs.prng.s = new_state;
     return types.VOID;
 }
 

--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -105,8 +105,8 @@ fn randomSourcePseudoRandomizeFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[2])) return primitives.typeError("random-source-pseudo-randomize!", "integer", args[2]);
     const i_val = types.toFixnum(args[1]);
     const j_val = types.toFixnum(args[2]);
-    if (i_val < 0) return PrimitiveError.TypeError;
-    if (j_val < 0) return PrimitiveError.TypeError;
+    if (i_val < 0) return primitives.typeError("random-source-pseudo-randomize!", "non-negative integer", args[1]);
+    if (j_val < 0) return primitives.typeError("random-source-pseudo-randomize!", "non-negative integer", args[2]);
     const i: u64 = @intCast(i_val);
     const j: u64 = @intCast(j_val);
     rs.prng = std.Random.DefaultPrng.init(i *% 2654435761 +% j *% 2246822519);
@@ -155,7 +155,7 @@ fn randomSourceStateSetFn(args: []const Value) PrimitiveError!Value {
         state_list = types.cdr(state_list);
     }
     if (new_state[0] == 0 and new_state[1] == 0 and new_state[2] == 0 and new_state[3] == 0) {
-        return PrimitiveError.TypeError;
+        return primitives.typeError("random-source-state-set!", "non-all-zero state", args[1]);
     }
     rs.prng.s = new_state;
     return types.VOID;

--- a/tests/scheme/srfi/srfi27-state.scm
+++ b/tests/scheme/srfi/srfi27-state.scm
@@ -1,0 +1,81 @@
+(import (scheme base) (scheme write) (srfi 27))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (check-true name val)
+  (if val
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " — expected true")
+        (newline))))
+
+;; Bug 1: State truncation — state-ref/state-set! must be a lossless roundtrip.
+;; Previously, state words were stored as fixnums (48-bit), truncating u64 values.
+
+(define rs (make-random-source))
+(define rand-int (random-source-make-integers rs))
+
+;; Advance the PRNG to produce state with high bits set
+(let loop ((i 0))
+  (when (< i 1000)
+    (rand-int 100)
+    (loop (+ i 1))))
+
+(define saved-state (random-source-state-ref rs))
+
+;; Generate some numbers from the saved state
+(random-source-state-set! rs saved-state)
+(define n1 (rand-int 1000000))
+(define n2 (rand-int 1000000))
+(define n3 (rand-int 1000000))
+
+;; Restore state and verify same sequence
+(random-source-state-set! rs saved-state)
+(check "state roundtrip n1" (rand-int 1000000) n1)
+(check "state roundtrip n2" (rand-int 1000000) n2)
+(check "state roundtrip n3" (rand-int 1000000) n3)
+
+;; Bug 2: pseudo-randomize! must reject negative arguments (was panicking)
+(define rs2 (make-random-source))
+(define pseudo-err-i #f)
+(guard (e (#t (set! pseudo-err-i #t)))
+  (random-source-pseudo-randomize! rs2 -1 0))
+(check-true "pseudo-randomize! rejects negative i" pseudo-err-i)
+
+(define pseudo-err-j #f)
+(guard (e (#t (set! pseudo-err-j #t)))
+  (random-source-pseudo-randomize! rs2 0 -1))
+(check-true "pseudo-randomize! rejects negative j" pseudo-err-j)
+
+;; Bug 3: state-set! must reject all-zero state (Xoshiro256 invariant)
+(define rs3 (make-random-source))
+(define zero-err #f)
+(guard (e (#t (set! zero-err #t)))
+  (random-source-state-set! rs3 '(0 0 0 0)))
+(check-true "state-set! rejects all-zero state" zero-err)
+
+;; Verify state words are integers (now bignums for full 64-bit)
+(define state-words (random-source-state-ref (default-random-source)))
+(check-true "state is a list of 4" (= 4 (length state-words)))
+(check-true "state words are integers"
+  (and (integer? (car state-words))
+       (integer? (cadr state-words))
+       (integer? (caddr state-words))
+       (integer? (cadddr state-words))))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "SRFI-27 state tests failed" fail))


### PR DESCRIPTION
## Summary

Four bugs fixed in `primitives_random.zig`:

- **State truncation**: `random-source-state-ref` now stores u64 PRNG words as bignums (full 64-bit) instead of fixnums (48-bit truncation)
- **Negative arg panic**: `random-source-pseudo-randomize!` validates non-negative arguments before `@intCast` (was panicking in ReleaseSafe)
- **All-zero state**: `random-source-state-set!` rejects `(0 0 0 0)` which violates Xoshiro256's invariant
- **Thread safety**: `default_rs_val` is now `threadlocal` with lazy init via `ensureDefaultRS()`

## Test plan

- [x] New test `tests/scheme/srfi/srfi27-state.scm` — state roundtrip, negative arg rejection, zero-state rejection
- [x] Full test suite: 1492 pass, 0 fail

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)