### PR TITLE
Fix GC root leak: unroot accessor/mutator functions in vm_records

### DIFF
--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -248,6 +248,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             vm.gc.popRoot();
             var func_val = types.makePointer(@ptrCast(func));
             vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
+            compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = vm.execute(func) catch |err| {
                 vm.gc.popRoot();
                 return err;
@@ -279,6 +280,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             vm.gc.popRoot();
             var func_val = types.makePointer(@ptrCast(func));
             vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
+            compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = vm.execute(func) catch |err| {
                 vm.gc.popRoot();
                 return err;

--- a/tests/scheme/smoke/record-gc-roots.scm
+++ b/tests/scheme/smoke/record-gc-roots.scm
@@ -1,0 +1,74 @@
+;; Regression test for #220: accessor/mutator functions not unrooted
+;; from extra_roots after compilation in define-record-type.
+;;
+;; Creates multiple record types and exercises their accessors and
+;; mutators under GC pressure to verify no root leak.
+
+(import (scheme base)
+        (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+(define (gc-pressure)
+  (let loop ((i 0))
+    (when (< i 500)
+      (make-vector 50 i)
+      (loop (+ i 1)))))
+
+(define-record-type <point>
+  (make-point x y)
+  point?
+  (x point-x set-point-x!)
+  (y point-y set-point-y!))
+
+(define-record-type <rect>
+  (make-rect left top right bottom)
+  rect?
+  (left rect-left)
+  (top rect-top)
+  (right rect-right)
+  (bottom rect-bottom))
+
+;; Exercise accessors
+(let ((p (make-point 10 20)))
+  (gc-pressure)
+  (check "point-x" (point-x p) 10)
+  (check "point-y" (point-y p) 20))
+
+;; Exercise mutators
+(let ((p (make-point 1 2)))
+  (set-point-x! p 100)
+  (gc-pressure)
+  (set-point-y! p 200)
+  (gc-pressure)
+  (check "mutated-x" (point-x p) 100)
+  (check "mutated-y" (point-y p) 200))
+
+;; Exercise multiple record types
+(let ((r (make-rect 0 0 640 480)))
+  (gc-pressure)
+  (check "rect-left" (rect-left r) 0)
+  (check "rect-right" (rect-right r) 640)
+  (check "rect-bottom" (rect-bottom r) 480))
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary

In `vm_records.zig`, the constructor and predicate blocks correctly called `Compiler.unrootFunction()` after compiling, but the accessor and mutator blocks omitted this call. Every accessor/mutator defined for every record type permanently added a `Function` to `extra_roots`, causing:

- A memory leak proportional to the number of record fields defined
- Increasing GC mark phase overhead from scanning extra roots each cycle

## Test plan

- [x] New regression test `tests/scheme/smoke/record-gc-roots.scm` exercises record accessors/mutators under GC pressure
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1494 pass, 0 fail, 1 skip)

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)