### PR TITLE
Fix FFI pointer truncation: promote large addresses to bignum

### DIFF
--- a/src/ffi_callback.zig
+++ b/src/ffi_callback.zig
@@ -23,6 +23,17 @@ pub const CallbackSig = enum {
     pp_void, // (pointer, pointer) -> void
 };
 
+const MAX_FIXNUM: i64 = 0x7FFF_FFFF_FFFF;
+
+fn marshalPtrArg(ptr: ?*anyopaque, gc: *memory.GC) ?Value {
+    const addr: usize = if (ptr) |p| @intFromPtr(p) else return types.makeFixnum(0);
+    const signed: i64 = @bitCast(@as(u64, addr));
+    if (signed >= 0 and signed <= MAX_FIXNUM)
+        return types.makeFixnum(signed);
+    const limbs_buf = [1]u64{addr};
+    return gc.allocBignumFromLimbs(&limbs_buf, 1, true) catch return null;
+}
+
 // ---------------------------------------------------------------------------
 // Trampoline generators — one per supported C callback signature
 // ---------------------------------------------------------------------------
@@ -33,8 +44,8 @@ fn makeTrampolinePPI(comptime idx: usize) *const fn (?*anyopaque, ?*anyopaque) c
             const slot = &callback_slots[idx];
             if (!slot.active) return 0;
             const vm = vm_mod.vm_instance orelse return 0;
-            const arg0 = types.makeFixnum(@intCast(@intFromPtr(a orelse return 0)));
-            const arg1 = types.makeFixnum(@intCast(@intFromPtr(b orelse return 0)));
+            const arg0 = marshalPtrArg(a, vm.gc) orelse return 0;
+            const arg1 = marshalPtrArg(b, vm.gc) orelse return 0;
             const args = [2]Value{ arg0, arg1 };
             const result = vm.callWithArgs(slot.closure, &args) catch {
                 vm.last_callback_error = true;
@@ -71,7 +82,7 @@ fn makeTrampolinePV(comptime idx: usize) *const fn (?*anyopaque) callconv(.c) vo
             const slot = &callback_slots[idx];
             if (!slot.active) return;
             const vm = vm_mod.vm_instance orelse return;
-            const arg0 = types.makeFixnum(@intCast(@intFromPtr(a orelse return)));
+            const arg0 = marshalPtrArg(a, vm.gc) orelse return;
             const args = [1]Value{arg0};
             _ = vm.callWithArgs(slot.closure, &args) catch {
                 vm.last_callback_error = true;
@@ -87,7 +98,7 @@ fn makeTrampolinePI(comptime idx: usize) *const fn (?*anyopaque) callconv(.c) c_
             const slot = &callback_slots[idx];
             if (!slot.active) return 0;
             const vm = vm_mod.vm_instance orelse return 0;
-            const arg0 = types.makeFixnum(@intCast(@intFromPtr(a orelse return 0)));
+            const arg0 = marshalPtrArg(a, vm.gc) orelse return 0;
             const args = [1]Value{arg0};
             const result = vm.callWithArgs(slot.closure, &args) catch {
                 vm.last_callback_error = true;
@@ -111,8 +122,7 @@ fn makeTrampolineIPI(comptime idx: usize) *const fn (c_int, ?*anyopaque) callcon
             if (!slot.active) return 0;
             const vm = vm_mod.vm_instance orelse return 0;
             const arg0 = types.makeFixnum(@intCast(a));
-            const b_addr: usize = if (b) |p| @intFromPtr(p) else 0;
-            const arg1 = types.makeFixnum(@intCast(b_addr));
+            const arg1 = marshalPtrArg(b, vm.gc) orelse return 0;
             const args = [2]Value{ arg0, arg1 };
             const result = vm.callWithArgs(slot.closure, &args) catch {
                 vm.last_callback_error = true;
@@ -151,10 +161,8 @@ fn makeTrampolinePPV(comptime idx: usize) *const fn (?*anyopaque, ?*anyopaque) c
             const slot = &callback_slots[idx];
             if (!slot.active) return;
             const vm = vm_mod.vm_instance orelse return;
-            const a_addr: usize = if (a) |p| @intFromPtr(p) else 0;
-            const b_addr: usize = if (b) |p| @intFromPtr(p) else 0;
-            const arg0 = types.makeFixnum(@intCast(a_addr));
-            const arg1 = types.makeFixnum(@intCast(b_addr));
+            const arg0 = marshalPtrArg(a, vm.gc) orelse return;
+            const arg1 = marshalPtrArg(b, vm.gc) orelse return;
             const args = [2]Value{ arg0, arg1 };
             _ = vm.callWithArgs(slot.closure, &args) catch {
                 vm.last_callback_error = true;
@@ -246,4 +254,30 @@ pub fn markCallbackRoots(gc: *memory.GC) void {
             gc.markValue(slot.closure);
         }
     }
+}
+
+test "marshalPtrArg: null returns fixnum zero" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    const val = marshalPtrArg(null, &gc).?;
+    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(val));
+}
+
+test "marshalPtrArg: small address returns fixnum" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    const addr: usize = 0x1000;
+    const ptr: *anyopaque = @ptrFromInt(addr);
+    const val = marshalPtrArg(ptr, &gc).?;
+    try std.testing.expect(types.isFixnum(val));
+    try std.testing.expectEqual(@as(i64, @intCast(addr)), types.toFixnum(val));
+}
+
+test "marshalPtrArg: large address returns bignum" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    const addr: usize = 0x0001_0000_0000_0000;
+    const ptr: *anyopaque = @ptrFromInt(addr);
+    const val = marshalPtrArg(ptr, &gc).?;
+    try std.testing.expect(types.isBignum(val));
 }

--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -222,14 +222,21 @@ fn ffiCallbackPred(args: []const Value) PrimitiveError!Value {
     return if (types.isFfiCallback(args[0])) types.TRUE else types.FALSE;
 }
 
-/// (ffi-bytevector-ptr bv) — returns data pointer as fixnum
+/// (ffi-bytevector-ptr bv) — returns data pointer as fixnum or bignum
 fn ffiBytevectorPtr(args: []const Value) PrimitiveError!Value {
     try checkSandbox("ffi-bytevector-ptr");
     if (!types.isBytevector(args[0]))
         return primitives.typeError("ffi-bytevector-ptr", "bytevector", args[0]);
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const bv = types.toObject(args[0]).as(types.Bytevector);
     if (bv.data.len == 0) return types.makeFixnum(0);
-    return types.makeFixnum(@intCast(@intFromPtr(bv.data.ptr)));
+    const addr: usize = @intFromPtr(bv.data.ptr);
+    const signed: i64 = @bitCast(@as(u64, addr));
+    const max_fixnum: i64 = 0x7FFF_FFFF_FFFF;
+    if (signed >= 0 and signed <= max_fixnum)
+        return types.makeFixnum(signed);
+    const limbs_buf = [1]u64{addr};
+    return gc.allocBignumFromLimbs(&limbs_buf, 1, true) catch return PrimitiveError.OutOfMemory;
 }
 
 fn matchCallbackSig(params: []const types.FfiType, ret: types.FfiType) ?ffi_callback.CallbackSig {

--- a/tests/scheme/ffi/bytevector-ptr.scm
+++ b/tests/scheme/ffi/bytevector-ptr.scm
@@ -1,0 +1,31 @@
+;; Regression test for #232: ffi-bytevector-ptr must return a non-negative
+;; integer (fixnum or bignum) for any data pointer address.
+
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; Empty bytevector returns 0
+(check "empty-bv" (ffi-bytevector-ptr (bytevector)) 0)
+
+;; Non-empty bytevector returns a positive integer
+(let ((ptr (ffi-bytevector-ptr (bytevector 1 2 3))))
+  (check "non-negative" (>= ptr 0) #t)
+  (check "is-integer" (integer? ptr) #t)
+  (check "is-exact" (exact? ptr) #t))
+
+;; Summary
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary

Two locations silently truncated pointer addresses above 2^47 by using `makeFixnum(@intCast(@intFromPtr(...)))`:

- **`ffi_callback.zig`**: All callback trampoline functions converted C pointer arguments to fixnums, producing negative values for large addresses. Negative fixnums return null when passed back through `marshalToPointer`. (#215)
- **`primitives_ffi.zig`**: `ffi-bytevector-ptr` converted bytevector data pointers the same way. (#232)

Both now use the same bounds-check-and-bignum-fallback approach as `marshalPointerReturn` in `ffi.zig`: addresses fitting in a fixnum (< 2^47) stay as fixnums; larger addresses are promoted to bignums.

## Test plan

- [x] 3 new unit tests for `marshalPtrArg` (null, small address, large address)
- [x] New Scheme test `tests/scheme/ffi/bytevector-ptr.scm`
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1495 pass, 0 fail, 1 skip)

Closes #215, closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)