### PR TITLE
Fix FFI callback slot leak on allocation failure

### DIFF
--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -202,7 +202,10 @@ fn ffiCallbackFn(args: []const Value) PrimitiveError!Value {
         return PrimitiveError.OutOfMemory;
     };
 
-    return gc.allocFfiCallback(proc, slot.index, slot.fn_ptr) catch return PrimitiveError.OutOfMemory;
+    return gc.allocFfiCallback(proc, slot.index, slot.fn_ptr) catch {
+        ffi_callback.releaseSlot(slot.index);
+        return PrimitiveError.OutOfMemory;
+    };
 }
 
 /// (ffi-callback-release cb)


### PR DESCRIPTION
## Summary

In `primitives_ffi.zig`, `ffiCallbackFn` called `ffi_callback.allocSlot()` which marked a global callback slot as active, then called `gc.allocFfiCallback()` which could fail with `OutOfMemory`. On failure, the function returned without calling `ffi_callback.releaseSlot()`, permanently leaking the slot.

With only 32 callback slots total, each leaked slot was a permanent resource loss that also kept the closure GC-rooted via `markCallbackRoots`.

## Test plan

- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1496 pass, 0 fail, 1 skip)
- [x] Existing FFI callback tests still pass

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)