### PR TITLE
Fix GC corruption: clear old marks before full collection

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -120,6 +120,7 @@ fn isYoungPointer(val: Value) bool {
 }
 
 fn fullCollect(gc: *GC) void {
+    clearOldMarks(gc);
     markRoots(gc);
     sweep(gc);
     sweepOld(gc);
@@ -218,6 +219,10 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
                     markValue(gc, entry.value);
                 }
             }
+        },
+        .record_instance => {
+            const ri = obj.as(RecordInstance);
+            for (ri.fields) |field| markValue(gc, field);
         },
         else => {},
     }

--- a/src/tests_records.zig
+++ b/src/tests_records.zig
@@ -168,3 +168,34 @@ test "record in define-library" {
     try std.testing.expectEqual(@as(i64, 10), types.toFixnum(try vm.eval("(rect-width r)")));
     try std.testing.expectEqual(@as(i64, 20), types.toFixnum(try vm.eval("(rect-height r)")));
 }
+
+test "record-set! field survives full GC" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-record-type <point>
+        \\  (make-point x y)
+        \\  point?
+        \\  (x point-x set-point-x!)
+        \\  (y point-y set-point-y!))
+    );
+
+    const result = try vm.eval(
+        \\(let ()
+        \\  (define p (make-point 1 2))
+        \\  ;; Promote p to old generation
+        \\  (let loop ((i 0))
+        \\    (when (< i 3000) (make-list 10 i) (loop (+ i 1))))
+        \\  ;; Mutate with young-gen value
+        \\  (set-point-y! p (list 'a 'b 'c))
+        \\  ;; Force enough GC cycles to trigger full collection
+        \\  (let loop ((i 0))
+        \\    (when (< i 3000) (make-list 10 i) (loop (+ i 1))))
+        \\  (point-y p))
+    );
+    try std.testing.expect(types.isPair(result));
+    try std.testing.expect(types.isSymbol(types.car(result)));
+}


### PR DESCRIPTION
## Summary

- `fullCollect()` did not call `clearOldMarks()` before `markRoots()`, so old objects retained stale `marked=true` from the previous minor collection. On the 8th GC cycle (full collection), `markValue` saw these stale marks and skipped tracing children — young values referenced only through old objects were freed, corrupting record fields.
- Added `record_instance` handling to `markObjectContents` so the remembered set properly traces record fields during minor collection (defense-in-depth).
- Added regression test in `tests_records.zig` that promotes a record to old gen, mutates a field with a young-gen list, triggers GC pressure, and verifies the field survives.

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1496 pass, 0 fail (ReleaseSafe)
- [x] `bash tests/scheme/run-all.sh` — 1496 pass, 0 fail (ReleaseFast)
- [x] `tests/scheme/smoke/record-set-gc.scm` passes 5/5 runs on ReleaseFast (previously failed every run)

Fixes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)