### PR TITLE
Fix FFI use-after-free: validate library before calling functions

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -121,6 +121,10 @@ fn validateArgs(ffi_fn: *types.FfiFunction, args: []const Value) !void {
 
 /// Main FFI call dispatcher. Routes to arity-specific handlers.
 pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Value {
+    if (types.isFfiLibrary(ffi_fn.library)) {
+        const lib = types.toObject(ffi_fn.library).as(types.FfiLibrary);
+        if (lib.handle == null) return error.TypeError;
+    }
     try validateArgs(ffi_fn, args);
     return switch (ffi_fn.param_count) {
         0 => callFfi0(ffi_fn, gc),

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -387,7 +387,11 @@ pub fn markValue(gc: *GC, v: Value) void {
             markValue(gc, rat.numerator);
             markValue(gc, rat.denominator);
         },
-        .ffi_library, .ffi_function => {},
+        .ffi_library => {},
+        .ffi_function => {
+            const ffi_fn = obj.as(FfiFunction);
+            markValue(gc, ffi_fn.library);
+        },
         .ffi_callback => {
             const cb = obj.as(FfiCallback);
             markValue(gc, cb.closure);

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -669,7 +669,7 @@ pub const GC = struct {
         return types.makePointer(@ptrCast(lib));
     }
 
-    pub fn allocFfiFunction(self: *GC, symbol: *anyopaque, name: []const u8, param_types: []const FfiType, return_type: FfiType) !Value {
+    pub fn allocFfiFunction(self: *GC, symbol: *anyopaque, library: Value, name: []const u8, param_types: []const FfiType, return_type: FfiType) !Value {
         try self.maybeCollect();
         const owned_name = try self.allocator.dupe(u8, name);
         const owned_params = try self.allocator.dupe(FfiType, param_types);
@@ -677,6 +677,7 @@ pub const GC = struct {
         ffi_fn.* = .{
             .header = .{ .tag = .ffi_function },
             .symbol = symbol,
+            .library = library,
             .name = owned_name,
             .param_types = owned_params,
             .return_type = return_type,

--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -150,6 +150,7 @@ fn ffiFn(args: []const Value) PrimitiveError!Value {
 
     return gc.allocFfiFunction(
         symbol,
+        args[0],
         name_str.data[0..name_str.len],
         param_types_buf[0..param_count],
         return_type,

--- a/src/types.zig
+++ b/src/types.zig
@@ -458,6 +458,7 @@ pub const FfiLibrary = struct {
 pub const FfiFunction = struct {
     header: Object,
     symbol: *anyopaque,
+    library: Value,
     name: []const u8,
     param_types: []FfiType,
     return_type: FfiType,

--- a/tests/scheme/ffi/use-after-close.scm
+++ b/tests/scheme/ffi/use-after-close.scm
@@ -1,0 +1,42 @@
+(import (scheme base) (scheme write))
+
+;; Regression test for #222: ffi-close leaves dangling symbol pointers.
+;; Calling an FFI function after its library is closed must raise an error,
+;; not crash via dangling pointer.
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define libm (ffi-open "libm"))
+(define c-sqrt (ffi-fn libm "sqrt" '(double) 'double))
+
+;; Verify the function works before close
+(check "sqrt before close" (< (abs (- (c-sqrt 4.0) 2.0)) 1e-12) #t)
+
+;; Close the library
+(ffi-close libm)
+
+;; Calling c-sqrt after close must raise an error
+(check "use-after-close raises error"
+  (guard (exn (#t 'caught))
+    (c-sqrt 4.0)
+    'no-error)
+  'caught)
+
+;; Double close should be safe (no-op)
+(ffi-close libm)
+(check "double close is safe" #t #t)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "FFI use-after-close tests failed" fail))


### PR DESCRIPTION
## Summary
- FfiFunction now stores a back-reference to its parent FfiLibrary
- `callFfi` checks `lib.handle != null` before dereferencing the symbol pointer
- GC marking traces the new library reference to prevent premature collection
- Calling an FFI function after `ffi-close` now raises a type error instead of segfaulting

## Test plan
- [x] New regression test `tests/scheme/ffi/use-after-close.scm` (use-after-close raises error, double-close is safe)
- [x] All existing FFI tests pass
- [x] Full R7RS suite: 1393 pass, 0 fail
- [x] All Scheme tests: 104 pass, 0 fail

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)