### PR TITLE
Fix REPL completion OOB read and highlight allocator mismatch

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -60,7 +60,12 @@ fn completionCallback(buf: [*c]const u8, lc: [*c]ln.c.linenoiseCompletions) call
     var it = vm.globals.keyIterator();
     while (it.next()) |key| {
         if (std.mem.startsWith(u8, key.*, prefix)) {
-            ln.addCompletion(lc, @ptrCast(key.*.ptr));
+            var name_buf: [512:0]u8 = undefined;
+            const name = key.*;
+            if (name.len >= name_buf.len) continue;
+            @memcpy(name_buf[0..name.len], name);
+            name_buf[name.len] = 0;
+            ln.addCompletion(lc, &name_buf);
         }
     }
 }
@@ -102,7 +107,7 @@ fn highlightCallback(buf: [*c]const u8, len: usize, out_len: [*c]usize) callconv
     const input = buf[0..len];
 
     var result: std.ArrayList(u8) = .empty;
-    const allocator = if (repl_vm) |vm| vm.gc.allocator else return null;
+    const allocator = std.heap.c_allocator;
 
     var i: usize = 0;
     while (i < input.len) {


### PR DESCRIPTION
## Summary
- **Completion callback (#233):** Symbol names from GC allocator are not null-terminated, but were @ptrCast to `[*:0]const u8` and passed to linenoise C code that calls `strlen`. This is an out-of-bounds read. Fix: copy into a stack buffer with explicit null terminator.
- **Highlight callback (#234):** Result buffer was allocated with `vm.gc.allocator` (DebugAllocator in debug builds) but freed by linenoise with libc `free()`. Fix: use `c_allocator` unconditionally since linenoise owns the buffer lifetime.

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — all 1498 tests pass (1393 R7RS + 105 Scheme files)

Fixes #233, fixes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)