### PR TITLE
Fix non-decimal bignum overflow and reject surrogate codepoints

### DIFF
--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -573,7 +573,7 @@ pub fn toString(allocator: std.mem.Allocator, v: Value) ![]u8 {
 }
 
 /// Parse a decimal string into a bignum Value.
-pub fn parseBignumString(gc: *memory.GC, digits: []const u8) !Value {
+pub fn parseBignumString(gc: *memory.GC, digits: []const u8, radix: u8) !Value {
     if (digits.len == 0) return types.makeFixnum(0);
 
     var start: usize = 0;
@@ -588,9 +588,13 @@ pub fn parseBignumString(gc: *memory.GC, digits: []const u8) !Value {
     const num_digits = digits[start..];
     if (num_digits.len == 0) return types.makeFixnum(0);
 
-    // Start with zero and multiply-add each digit
-    // Use chunks of 18 digits for efficiency
-    const CHUNK_DIGITS: usize = 18;
+    const CHUNK_DIGITS: usize = switch (radix) {
+        2 => 63,
+        8 => 21,
+        16 => 15,
+        else => 18,
+    };
+    const radix_u64: u64 = radix;
 
     var limbs = try gc.allocator.alloc(u64, 1);
     limbs[0] = 0;
@@ -604,11 +608,11 @@ pub fn parseBignumString(gc: *memory.GC, digits: []const u8) !Value {
         const chunk_str = num_digits[pos .. pos + chunk_size];
 
         // Parse the chunk
-        const chunk_val = std.fmt.parseInt(u64, chunk_str, 10) catch return error.OutOfMemory;
+        const chunk_val = std.fmt.parseInt(u64, chunk_str, radix) catch return error.OutOfMemory;
 
-        // Compute the multiplier (10^chunk_size)
+        // Compute the multiplier (radix^chunk_size)
         var multiplier: u64 = 1;
-        for (0..chunk_size) |_| multiplier *= 10;
+        for (0..chunk_size) |_| multiplier *= radix_u64;
 
         // Multiply existing number by multiplier and add chunk_val
         // Multiply
@@ -812,7 +816,7 @@ test "bignum parseBignumString small" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
-    const val = try parseBignumString(&gc, "42");
+    const val = try parseBignumString(&gc, "42", 10);
     try std.testing.expect(types.isFixnum(val));
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(val));
 }
@@ -821,7 +825,7 @@ test "bignum parseBignumString large" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
-    const val = try parseBignumString(&gc, "99999999999999999999999999999999");
+    const val = try parseBignumString(&gc, "99999999999999999999999999999999", 10);
     try std.testing.expect(types.isBignum(val));
     const s = try toString(std.testing.allocator, val);
     defer std.testing.allocator.free(s);
@@ -832,8 +836,8 @@ test "bignum compare" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
-    const a = try parseBignumString(&gc, "99999999999999999999999999999999");
-    const b = try parseBignumString(&gc, "99999999999999999999999999999998");
+    const a = try parseBignumString(&gc, "99999999999999999999999999999999", 10);
+    const b = try parseBignumString(&gc, "99999999999999999999999999999998", 10);
     try std.testing.expectEqual(@as(i8, 1), compare(a, b));
     try std.testing.expectEqual(@as(i8, -1), compare(b, a));
     try std.testing.expectEqual(@as(i8, 0), compare(a, a));
@@ -843,7 +847,7 @@ test "bignum negate" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
-    const pos = try parseBignumString(&gc, "99999999999999999999999999999999");
+    const pos = try parseBignumString(&gc, "99999999999999999999999999999999", 10);
     const neg = try negate(&gc, pos);
     try std.testing.expect(types.isBignum(neg));
     const s = try toString(std.testing.allocator, neg);

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -689,8 +689,8 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
     if (std.fmt.parseInt(i64, s, radix)) |n| {
         return try arith.makeFixnumChecked(n);
     } else |err| {
-        if (err == error.Overflow and radix == 10) {
-            return bignum_mod.parseBignumString(gc, s) catch return PrimitiveError.OutOfMemory;
+        if (err == error.Overflow) {
+            return bignum_mod.parseBignumString(gc, s, radix) catch return PrimitiveError.OutOfMemory;
         }
     }
 

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -35,7 +35,7 @@ pub const Token = union(enum) {
     character: u21,
     datum_label_def: u32,
     datum_label_ref: u32,
-    bignum_str: []const u8,
+    bignum_str: struct { str: []const u8, radix: u8 },
     rational: struct { num: i64, den: i64 },
     complex: struct { real: f64, imag: f64, exact_real: bool = false, exact_imag: bool = false },
     eof,

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -23,9 +23,9 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
             return types.makeFixnum(n);
         },
         .flonum => |f| return types.makeFlonum(f),
-        .bignum_str => |digits| {
+        .bignum_str => |b| {
             const bignum_mod = @import("bignum.zig");
-            return bignum_mod.parseBignumString(self.gc, digits) catch return ReadError.OutOfMemory;
+            return bignum_mod.parseBignumString(self.gc, b.str, b.radix) catch return ReadError.OutOfMemory;
         },
         .rational => |r| {
             if (r.den == 0) return ReadError.InvalidNumber;

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -164,7 +164,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
     } else {
         const n = std.fmt.parseInt(i64, num_str, 10) catch |err| {
             if (err == error.Overflow) {
-                return .{ .bignum_str = num_str };
+                return .{ .bignum_str = .{ .str = num_str, .radix = 10 } };
             }
             return ReadError.InvalidNumber;
         };
@@ -520,8 +520,8 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
     if (num_str.len > Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
     if (num_str.len == 0 or (num_str.len == 1 and (num_str[0] == '+' or num_str[0] == '-'))) return ReadError.InvalidNumber;
     const n = std.fmt.parseInt(i64, num_str, radix) catch |err| {
-        if (err == error.Overflow and radix == 10) {
-            return .{ .bignum_str = num_str };
+        if (err == error.Overflow) {
+            return .{ .bignum_str = .{ .str = num_str, .radix = radix } };
         }
         return ReadError.InvalidNumber;
     };
@@ -570,6 +570,7 @@ pub fn readCharacter(self: *Reader) ReadError!Token {
                 }
                 const hex_str = self.source[start + 1 .. self.pos];
                 const cp = std.fmt.parseInt(u21, hex_str, 16) catch return ReadError.InvalidNumber;
+                if (cp >= 0xD800 and cp <= 0xDFFF) return ReadError.InvalidCharacterName;
                 return .{ .character = cp };
             }
             // Just #\x alone — return 'x'

--- a/tests/scheme/compliance/reader-numerics.scm
+++ b/tests/scheme/compliance/reader-numerics.scm
@@ -1,0 +1,52 @@
+;;; Reader numeric literal tests — non-decimal bignums and surrogate rejection
+
+(import (scheme base) (scheme process-context) (srfi 64))
+
+(test-begin "reader-numerics")
+
+;; #230: Non-decimal integers that overflow i64 must promote to bignum
+(test-group "non-decimal bignum promotion"
+  (test-eqv "hex bignum value"
+    18446744073709551615
+    #xFFFFFFFFFFFFFFFF)
+
+  (test-eqv "hex bignum negative"
+    -18446744073709551615
+    #x-FFFFFFFFFFFFFFFF)
+
+  (test-eqv "binary bignum value"
+    73786976294838206463
+    #b111111111111111111111111111111111111111111111111111111111111111111)
+
+  (test-eqv "octal bignum value"
+    1152921504606846975
+    #o77777777777777777777)
+
+  (test-assert "hex bignum is exact integer"
+    (exact? #xFFFFFFFFFFFFFFFF))
+
+  (test-assert "hex bignum arithmetic"
+    (= (+ #xFFFFFFFFFFFFFFFF 1) #x10000000000000000))
+
+  ;; Non-overflow non-decimal should still work
+  (test-eqv "hex fixnum" 255 #xFF)
+  (test-eqv "binary fixnum" 7 #b111)
+  (test-eqv "octal fixnum" 63 #o77))
+
+;; #230: string->number with non-decimal radix and overflow
+(test-group "string->number non-decimal bignum"
+  (test-eqv "string->number hex bignum"
+    18446744073709551615
+    (string->number "FFFFFFFFFFFFFFFF" 16))
+
+  (test-eqv "string->number binary bignum"
+    73786976294838206463
+    (string->number "111111111111111111111111111111111111111111111111111111111111111111" 2))
+
+  (test-eqv "string->number octal bignum"
+    1152921504606846975
+    (string->number "77777777777777777777" 8)))
+
+(define %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "reader-numerics")
+(if (> %test-fail-count 0) (exit 1))

--- a/tests/scheme/compliance/reader-surrogates.scm
+++ b/tests/scheme/compliance/reader-surrogates.scm
@@ -1,0 +1,33 @@
+;;; #231: Reader must reject Unicode surrogate codepoints in character literals
+
+(import (scheme base) (scheme read) (scheme process-context) (srfi 64))
+
+(test-begin "reader-surrogates")
+
+;; Surrogate codepoints (U+D800..U+DFFF) are not valid Unicode scalar values.
+;; R7RS Section 6.6 requires characters to represent Unicode scalar values.
+;; Reading #\xD800 etc. must raise a read error.
+
+(test-group "surrogate codepoint rejection"
+  (test-error "low surrogate #\\xD800 is rejected"
+    (read (open-input-string "#\\xD800")))
+
+  (test-error "high surrogate #\\xDFFF is rejected"
+    (read (open-input-string "#\\xDFFF")))
+
+  (test-error "mid surrogate #\\xDB00 is rejected"
+    (read (open-input-string "#\\xDB00"))))
+
+;; Boundary values just outside the surrogate range must still work
+(test-group "surrogate boundary values"
+  (test-eqv "U+D7FF is valid"
+    #xD7FF
+    (char->integer (read (open-input-string "#\\xD7FF"))))
+
+  (test-eqv "U+E000 is valid"
+    #xE000
+    (char->integer (read (open-input-string "#\\xE000")))))
+
+(define %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "reader-surrogates")
+(if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
## Summary
- **Non-decimal bignum (#230):** Hex, binary, and octal integers that overflow i64 were rejected with `InvalidNumber` instead of promoted to bignum. The bignum fallback was gated on `radix == 10`. Fix: thread the radix through the Token type and bignum parser so all radixes promote correctly. Also fixed the same bug in `string->number`.
- **Surrogate codepoints (#231):** Character literals like `#\xD800` (surrogate range U+D800..U+DFFF) were silently accepted, producing corrupted output when printed. Fix: reject surrogates in `readCharacter` per R7RS Section 6.6.

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — all 1500 tests pass (1393 R7RS + 107 Scheme)
- [x] New regression tests: `reader-numerics.scm` (12 tests) and `reader-surrogates.scm` (5 tests)

Fixes #230, fixes #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)