### PR TITLE
Add missing Reader.deinit() in fuzz tests

### DIFF
--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -19,6 +19,7 @@ test "fuzz reader" {
             var gc = memory.GC.init(std.testing.allocator);
             defer gc.deinit();
             var r = reader_mod.Reader.init(&gc, input);
+            defer r.deinit();
             while (true) {
                 _ = r.readDatum() catch break;
             }
@@ -48,6 +49,7 @@ test "fuzz compiler" {
             var gc = memory.GC.init(std.testing.allocator);
             defer gc.deinit();
             var r = reader_mod.Reader.init(&gc, input);
+            defer r.deinit();
             const expr = r.readDatum() catch return;
             var macros = std.StringHashMap(types.Value).init(std.testing.allocator);
             defer macros.deinit();


### PR DESCRIPTION
## Summary
- Both the fuzz reader and fuzz compiler tests created a `Reader` without calling `deinit()`, leaking the internal `token_buf` ArrayList backing memory
- Under real fuzzing with `std.testing.allocator`, inputs containing symbols or strings cause `token_buf` to allocate, and the leaked memory triggers test failures from leak detection

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — all 1500 tests pass

Fixes #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)