### PR TITLE
Detect re-entrant promise forcing per SRFI-45

### DIFF
--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -55,7 +55,10 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
             return thunk;
         }
 
+        promise.forcing = true;
+
         const result = vm.callWithArgs(thunk, &[_]Value{}) catch |err| {
+            promise.forcing = false;
             return switch (err) {
                 vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
                 vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
@@ -66,11 +69,22 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
 
         // SRFI-45 §8: after the thunk returns, check if another force
         // has already completed this promise (re-entrant force).
-        if (promise.forced) return promise.value;
+        if (promise.forced) {
+            promise.forcing = false;
+            return promise.value;
+        }
 
         if (types.isPromise(result)) {
             const inner = types.toPromise(result);
+            // SRFI-45 §8: detect cyclic promise chains where a thunk
+            // returns a promise that is already being forced.
+            if (inner.forcing) {
+                promise.forcing = false;
+                vm.setErrorDetail("re-entrant forcing of promise", .{});
+                return PrimitiveError.TypeError;
+            }
             if (inner.forced) {
+                promise.forcing = false;
                 promise.forced = true;
                 promise.value = inner.value;
                 gc.writeBarrier(&promise.header, inner.value);
@@ -85,6 +99,7 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
             continue;
         }
 
+        promise.forcing = false;
         promise.forced = true;
         promise.value = result;
         gc.writeBarrier(&promise.header, result);

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -81,7 +81,7 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
             if (inner.forcing) {
                 promise.forcing = false;
                 vm.setErrorDetail("re-entrant forcing of promise", .{});
-                return PrimitiveError.TypeError;
+                return PrimitiveError.TypeError; // bare-ok: detail set above
             }
             if (inner.forced) {
                 promise.forcing = false;

--- a/tests/scheme/compliance/lazy.scm
+++ b/tests/scheme/compliance/lazy.scm
@@ -28,6 +28,24 @@
 (test-group "nested delay"
   (test-eqv "force nested delays" 99 (force (delay (force (delay 99))))))
 
+;; --- re-entrant forcing (SRFI-45 §8) ---
+
+;; Valid recursive forcing with termination (R7RS 4.2.5 example)
+(let ()
+  (define x 5)
+  (define count 0)
+  (define p
+    (delay (begin (set! count (+ count 1))
+                  (if (> count x) count (force p)))))
+  (test-eqv "recursive force with termination" 6 (force p)))
+
+;; Cyclic delay-force detected via forcing flag
+(let ()
+  (define p (delay-force (delay p)))
+  (test-assert "delay-force self-reference raises error"
+    (guard (exn (#t #t))
+      (force p) #f)))
+
 (set! %test-fail-count (test-runner-fail-count (test-runner-current)))
 (test-end "lazy")
 (if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
## Summary
- Wire up the previously unused `Promise.forcing` field to detect cyclic promise chains where a `delay-force` thunk returns a promise that is already being forced
- Produces a clear "re-entrant forcing of promise" error instead of spinning for 100k iterations before returning a confusing TypeError
- The check is placed in the iterative unwrapping path (when the thunk result is a promise), **not** at the top of the force loop, which preserves valid recursive forcing via `delay` as specified in R7RS 4.2.5

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — all 1500 tests pass (1393 R7RS + 107 Scheme)
- [x] New regression tests in `lazy.scm`: cyclic delay-force detection + valid recursive forcing

Fixes #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)