### PR TITLE
Fix flaky corrupted .sbc robustness test

### DIFF
--- a/tests/scheme/robustness/robustness.sh
+++ b/tests/scheme/robustness/robustness.sh
@@ -111,8 +111,8 @@ echo "-- Corrupted .sbc --"
 TMPFILE=$(mktemp /tmp/kaappi-corrupt-XXXXXX.sbc)
 echo "NOT_A_VALID_SBC_FILE" > "$TMPFILE"
 assert_error "corrupted .sbc (text)" "(load \"$TMPFILE\")"
-dd if=/dev/urandom bs=128 count=1 2>/dev/null > "$TMPFILE"
-assert_error "corrupted .sbc (random bytes)" "(load \"$TMPFILE\")"
+printf '\x00\x01\x02\x03\x80\x81\xff\xfe\x00\x00\x00\x00\x00\x00\x00\x00' > "$TMPFILE"
+assert_error "corrupted .sbc (binary)" "(load \"$TMPFILE\")"
 rm -f "$TMPFILE"
 
 echo


### PR DESCRIPTION
## Summary
The "corrupted .sbc (random bytes)" robustness test used `/dev/urandom` which is non-deterministic. Random bytes that happen to form valid Scheme comments (e.g. starting with `;` followed by no newline) cause `load` to succeed silently — the reader treats the entire file as a comment and returns VOID with no error.

Replace with deterministic binary bytes (null bytes + high bytes) that reliably trigger a read error.

## Test plan
- [x] `bash tests/scheme/robustness/robustness.sh` — 28/28 pass
- [x] `bash tests/scheme/run-all.sh` — all 1500 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)