### PR TITLE
Add missing GC write barriers in mutation primitives

### DIFF
--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -190,6 +190,10 @@ fn hashTableSetFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-set!", args[0]);
     try growIfNeeded(ht);
     const slot = findSlot(ht, args[1]);
+    if (primitives.gc_instance) |gc| {
+        gc.writeBarrier(types.toObject(args[0]), args[1]);
+        gc.writeBarrier(types.toObject(args[0]), args[2]);
+    }
     if (slot.found) {
         ht.entries[slot.idx].value = args[2];
     } else {
@@ -366,6 +370,10 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
 
     try growIfNeeded(ht);
     const slot = findSlot(ht, key);
+    if (primitives.gc_instance) |gc| {
+        gc.writeBarrier(types.toObject(args[0]), key);
+        gc.writeBarrier(types.toObject(args[0]), new_val);
+    }
     if (slot.found) {
         ht.entries[slot.idx].value = new_val;
     } else {

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -74,6 +74,7 @@ fn listSetFn(args: []const Value) PrimitiveError!Value {
     while (current != types.NIL) {
         if (!types.isPair(current)) return primitives.typeError("list-set!", "pair", current);
         if (idx == k) {
+            if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(current), args[2]);
             types.setCar(current, args[2]);
             return types.VOID;
         }

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -111,6 +111,7 @@ fn vectorSetFn(args: []const Value) PrimitiveError!Value {
     const vec = types.toVector(args[0]);
     const k = types.toFixnum(args[1]);
     if (k < 0 or @as(usize, @intCast(k)) >= vec.data.len) return PrimitiveError.IndexOutOfBounds;
+    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     vec.data[@intCast(k)] = args[2];
     return types.VOID;
 }
@@ -205,6 +206,7 @@ fn vectorFillFn(args: []const Value) PrimitiveError!Value {
         end = @intCast(e);
     }
     if (start > end) return primitives.typeError("vector-fill!", "start <= end", args[2]);
+    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     @memset(vec.data[start..end], args[1]);
     return types.VOID;
 }
@@ -276,6 +278,11 @@ fn vectorCopyBangFn(args: []const Value) PrimitiveError!Value {
     const count = end - start;
     if (at + count > to_vec.data.len) return primitives.typeError("vector-copy!", "valid index range", args[1]);
 
+    if (primitives.gc_instance) |gc| {
+        for (from_vec.data[start..end]) |val| {
+            gc.writeBarrier(types.toObject(args[0]), val);
+        }
+    }
     // Use a loop that handles overlapping regions correctly
     if (at <= start) {
         for (0..count) |i| {

--- a/tests/scheme/smoke/mutation-write-barrier.scm
+++ b/tests/scheme/smoke/mutation-write-barrier.scm
@@ -1,0 +1,83 @@
+(import (scheme base) (scheme write) (srfi 69))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (gc-pressure)
+  (let loop ((i 0))
+    (when (< i 3000)
+      (make-list 10 i)
+      (loop (+ i 1)))))
+
+;; --- vector-set! ---
+
+(define v (vector 0 0 0))
+(gc-pressure)
+(vector-set! v 1 (string-copy "vec-val"))
+(gc-pressure)
+(check "vector-set! survives GC" (vector-ref v 1) "vec-val")
+
+;; --- vector-fill! ---
+
+(define v2 (make-vector 5 #f))
+(gc-pressure)
+(vector-fill! v2 (list 'x 'y))
+(gc-pressure)
+(check "vector-fill! survives GC" (vector-ref v2 0) '(x y))
+(check "vector-fill! all slots" (vector-ref v2 4) '(x y))
+
+;; --- vector-copy! ---
+
+(define src (vector (string-copy "a") (string-copy "b") (string-copy "c")))
+(define dst (make-vector 3 #f))
+(gc-pressure)
+(vector-copy! dst 0 src)
+(gc-pressure)
+(check "vector-copy! survives GC (0)" (vector-ref dst 0) "a")
+(check "vector-copy! survives GC (1)" (vector-ref dst 1) "b")
+(check "vector-copy! survives GC (2)" (vector-ref dst 2) "c")
+
+;; --- hash-table-set! ---
+
+(define ht (make-hash-table))
+(gc-pressure)
+(hash-table-set! ht 'key1 (string-copy "ht-val"))
+(gc-pressure)
+(check "hash-table-set! value survives GC"
+  (hash-table-ref ht 'key1) "ht-val")
+
+(hash-table-set! ht (string-copy "str-key") 42)
+(gc-pressure)
+(check "hash-table-set! string key survives GC"
+  (hash-table-ref ht "str-key") 42)
+
+;; --- hash-table-update!/default ---
+
+(define ht2 (make-hash-table))
+(gc-pressure)
+(hash-table-update!/default ht2 'counter (lambda (x) (+ x 1)) 0)
+(gc-pressure)
+(check "hash-table-update!/default survives GC"
+  (hash-table-ref ht2 'counter) 1)
+
+;; --- list-set! ---
+
+(define ls (list 'a 'b 'c))
+(gc-pressure)
+(list-set! ls 1 (string-copy "list-val"))
+(gc-pressure)
+(check "list-set! survives GC" (list-ref ls 1) "list-val")
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "mutation write barrier tests failed" fail))


### PR DESCRIPTION
## Summary

- Add `writeBarrier()` calls to `vector-set!`, `vector-fill!`, `vector-copy!` in `primitives_vector.zig`
- Add `writeBarrier()` calls to `hash-table-set!`, `hash-table-update!/default` in `primitives_hashtable.zig`
- Add `writeBarrier()` call to `list-set!` in `primitives_list.zig`
- Add regression test `tests/scheme/smoke/mutation-write-barrier.scm` covering all six primitives

These mutation primitives stored values into heap objects without calling the GC write barrier, which meant young-generation values placed into old-generation containers could be prematurely collected during minor GC.

Fixes #300, fixes #302, fixes #307.

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1501 pass, 0 fail
- [x] New regression test exercises all six affected primitives with GC pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)