### PR TITLE
Fix GC hash table marking using wrong sentinel in minor collection

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -104,7 +104,7 @@ fn referencesYoung(obj: *Object) bool {
         .hash_table => {
             const ht = obj.as(HashTable);
             for (ht.entries[0..ht.capacity]) |entry| {
-                if (entry.key != types.VOID and entry.key != types.NIL) {
+                if (entry.key != types.VOID and entry.key != types.EOF) {
                     if (isYoungPointer(entry.key) or isYoungPointer(entry.value)) return true;
                 }
             }
@@ -214,7 +214,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
         .hash_table => {
             const ht = obj.as(HashTable);
             for (ht.entries[0..ht.capacity]) |entry| {
-                if (entry.key != types.VOID and entry.key != types.NIL) {
+                if (entry.key != types.VOID and entry.key != types.EOF) {
                     markValue(gc, entry.key);
                     markValue(gc, entry.value);
                 }

--- a/tests/scheme/smoke/gc-hashtable-nil-key.scm
+++ b/tests/scheme/smoke/gc-hashtable-nil-key.scm
@@ -1,0 +1,24 @@
+;; Regression test for #298/#277: GC hash table marking used types.NIL
+;; instead of types.EOF as tombstone sentinel, causing entries with '()
+;; as key to be skipped during minor GC marking.
+
+(import (srfi 69))
+
+(define ht (make-hash-table))
+(hash-table-set! ht '() "value-for-nil-key")
+(hash-table-set! ht 'a "aaa")
+(hash-table-set! ht 'b "bbb")
+
+;; Force some GC pressure
+(let loop ((i 0))
+  (when (< i 5000)
+    (make-vector 100 i)
+    (loop (+ i 1))))
+
+;; The value stored under '() key must survive GC
+(display (hash-table-ref ht '()))
+(newline)
+(display (hash-table-ref ht 'a))
+(newline)
+(display (hash-table-ref ht 'b))
+(newline)


### PR DESCRIPTION
## Summary
- Fixed `referencesYoung` and `markObjectContents` in `gc_collect.zig` to check `types.EOF` (tombstone) instead of `types.NIL` when iterating hash table entries during minor GC
- `NIL` (`'()`) is a valid hash table key — using it as the sentinel skip value caused entries with `'()` as key to be silently skipped during marking, potentially leading to premature collection of their values
- The full collection path (`markValue`) already correctly used `types.EOF`

## Test plan
- [x] Added `tests/scheme/smoke/gc-hashtable-nil-key.scm` regression test
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1502 pass, 0 fail)

Fixes #298
Fixes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)