### PR TITLE
Add missing GC write barriers in hash-table-merge! and %parameter-set!

### DIFF
--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -495,9 +495,14 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
     const ht1 = try getHashTable("hash-table-merge!", args[0]);
     const ht2 = try getHashTable("hash-table-merge!", args[1]);
 
+    const gc = primitives.gc_instance;
     for (ht2.entries[0..ht2.capacity]) |entry| {
         if (entry.key == EMPTY or entry.key == TOMBSTONE) continue;
         const slot = findSlot(ht1, entry.key);
+        if (gc) |g| {
+            g.writeBarrier(types.toObject(args[0]), entry.key);
+            g.writeBarrier(types.toObject(args[0]), entry.value);
+        }
         if (slot.found) {
             ht1.entries[slot.idx].value = entry.value;
         } else {

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -286,6 +286,7 @@ fn parameterSetDirectFn(args: []const Value) PrimitiveError!Value {
         vm.setParameterValue(param, args[1]) catch return PrimitiveError.OutOfMemory;
     } else {
         param.value = args[1];
+        if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     }
     return types.VOID;
 }


### PR DESCRIPTION
## Summary
- Added write barriers in `hashTableMergeFn` when copying entries from source to destination hash table
- Added write barrier in `parameterSetDirectFn` fallback path (when `vm_instance` is null)

Note: `hashTableSetFn`, `hashTableUpdateDefaultFn`, and `listSetFn` already have write barriers in the current code (likely fixed in #314).

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1502 pass, 0 fail)

Fixes #276
Fixes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)