### PR TITLE
Fix buffer overflow in syntax-rules free-reference collection

### DIFF
--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -500,10 +500,10 @@ fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, lite
         }
         if (std.mem.eql(u8, hname, "syntax-rules")) {
             if (rest != types.NIL and types.isPair(rest)) {
-                var sr_names: [16][]const u8 = undefined;
+                var sr_names: [64][]const u8 = undefined;
                 var sr_count: usize = 0;
                 for (local_binds) |lb| {
-                    if (sr_count < 16) {
+                    if (sr_count < 64) {
                         sr_names[sr_count] = lb;
                         sr_count += 1;
                     }

--- a/tests/scheme/smoke/syntax-rules-many-vars.scm
+++ b/tests/scheme/smoke/syntax-rules-many-vars.scm
@@ -1,0 +1,10 @@
+;; Regression test for #279: syntax-rules with 17+ pattern variables
+;; caused stack buffer overflow via @ptrCast mismatch (16 vs 64 elements).
+
+(define-syntax many-vars
+  (syntax-rules ()
+    ((many-vars a b c d e f g h i j k l m n o p q)
+     (+ a b c d e f g h i j k l m n o p q))))
+
+(display (many-vars 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17))
+(newline)


### PR DESCRIPTION
## Summary
- Fixed `sr_names` buffer in `collectFreeRefsWithLocals` from `[16]` to `[64]` elements to match what `collectSymbols` expects
- A syntax-rules macro with 17+ unique pattern variable names would write past the buffer end, corrupting stack memory

## Test plan
- [x] Added `tests/scheme/smoke/syntax-rules-many-vars.scm` with 17-variable macro
- [x] All unit tests pass
- [x] Full Scheme test suite passes (1503 pass, 0 fail)

Fixes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)