### PR TITLE
Root rest-list accumulator during variadic call setup

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -698,11 +698,16 @@ pub const VM = struct {
                 // Collect rest args into a list
                 const rest_start = func.arity;
                 var rest_list: Value = types.NIL;
+                self.gc.pushRoot(&rest_list) catch return VMError.OutOfMemory;
                 var i: u8 = nargs;
                 while (i > rest_start) {
                     i -= 1;
-                    rest_list = self.gc.allocPair(args[i], rest_list) catch return VMError.OutOfMemory;
+                    rest_list = self.gc.allocPair(args[i], rest_list) catch {
+                        self.gc.popRoot();
+                        return VMError.OutOfMemory;
+                    };
                 }
+                self.gc.popRoot();
                 // Place fixed args and rest list
                 for (0..rest_start) |ri| {
                     self.registers[base + ri] = args[ri];

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -296,14 +296,19 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u16, nargs: u8) VMErr
         // Collect rest args into a list
         const rest_start = func.arity;
         var rest_list: Value = types.NIL;
+        vm.gc.pushRoot(&rest_list) catch return VMError.OutOfMemory;
         var i: u8 = nargs;
         while (i > rest_start) {
             i -= 1;
             rest_list = vm.gc.allocPair(
                 vm.registers[base + 1 + i],
                 rest_list,
-            ) catch return VMError.OutOfMemory;
+            ) catch {
+                vm.gc.popRoot();
+                return VMError.OutOfMemory;
+            };
         }
+        vm.gc.popRoot();
         vm.registers[base + 1 + rest_start] = rest_list;
     }
 

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -315,14 +315,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             return VMError.InvalidBytecode;
                         }
                         var rest_list: Value = types.NIL;
+                        self.gc.pushRoot(&rest_list) catch return VMError.OutOfMemory;
                         var ri: u8 = nargs;
                         while (ri > rest_start) {
                             ri -= 1;
                             rest_list = self.gc.allocPair(
                                 self.registers[abs_base + 1 + ri],
                                 rest_list,
-                            ) catch return VMError.OutOfMemory;
+                            ) catch {
+                                self.gc.popRoot();
+                                return VMError.OutOfMemory;
+                            };
                         }
+                        self.gc.popRoot();
                         self.registers[abs_base + 1 + rest_start] = rest_list;
                     }
 
@@ -519,11 +524,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         }
                         const rest_start = func.arity;
                         var rest_list: Value = types.NIL;
+                        self.gc.pushRoot(&rest_list) catch return VMError.OutOfMemory;
                         var ri: u8 = total_nargs;
                         while (ri > rest_start) {
                             ri -= 1;
-                            rest_list = self.gc.allocPair(flat_args[ri], rest_list) catch return VMError.OutOfMemory;
+                            rest_list = self.gc.allocPair(flat_args[ri], rest_list) catch {
+                                self.gc.popRoot();
+                                return VMError.OutOfMemory;
+                            };
                         }
+                        self.gc.popRoot();
                         flat_args[rest_start] = rest_list;
                     }
 
@@ -852,14 +862,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             return VMError.InvalidBytecode;
                         }
                         var rest_list: Value = types.NIL;
+                        self.gc.pushRoot(&rest_list) catch return VMError.OutOfMemory;
                         var ri: u8 = nargs;
                         while (ri > rest_start) {
                             ri -= 1;
                             rest_list = self.gc.allocPair(
                                 self.registers[abs_base + 1 + ri],
                                 rest_list,
-                            ) catch return VMError.OutOfMemory;
+                            ) catch {
+                                self.gc.popRoot();
+                                return VMError.OutOfMemory;
+                            };
                         }
+                        self.gc.popRoot();
                         self.registers[abs_base + 1 + rest_start] = rest_list;
                     }
                     const arg_count = if (tfunc.is_variadic) tfunc.arity + 1 else nargs;


### PR DESCRIPTION
## Summary
- Added GC rooting for the `rest_list` accumulator in all 5 variadic rest-argument construction loops
- Each `allocPair` can trigger GC; without rooting, previously allocated pairs in the chain could be swept
- Affected: `vm_calls.zig` (1), `vm_dispatch.zig` (3), `vm.zig` (1)

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1503 pass, 0 fail)

Fixes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)