### PR TITLE
Fix GC rooting for map, exception handler, call-with-values, make-parameter, command-line

### DIFF
--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -103,8 +103,10 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
             const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
             gc.pushRoot(&handler_root) catch return PrimitiveError.OutOfMemory;
             defer gc.popRoot();
-            const exc = vm.current_exception orelse types.FALSE;
+            var exc = vm.current_exception orelse types.FALSE;
             vm.current_exception = null;
+            gc.pushRoot(&exc) catch return PrimitiveError.OutOfMemory;
+            defer gc.popRoot();
             _ = vm.callHandler(handler_root, exc, 0) catch |herr| {
                 return switch (herr) {
                     vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
@@ -376,8 +378,12 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
     };
 
     // Call consumer with the produced values
-    if (types.isMultipleValues(produced)) {
-        const mv = types.toObject(produced).as(types.MultipleValues);
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    var produced_root = produced;
+    gc.pushRoot(&produced_root) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
+    if (types.isMultipleValues(produced_root)) {
+        const mv = types.toObject(produced_root).as(types.MultipleValues);
         const result = vm.callWithArgs(consumer, mv.values) catch |err| {
             return switch (err) {
                 vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -275,9 +275,13 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
     const list_count = args.len - 1;
     if (list_count == 0) return PrimitiveError.ArityMismatch;
 
-    // Collect results in an ArrayList, iterate lists in parallel
-    var results: std.ArrayList(Value) = .empty;
-    defer results.deinit(gc.allocator);
+    // Build result list incrementally (rooted head + tail)
+    var result_head: Value = types.NIL;
+    gc.pushRoot(&result_head) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
+    var result_tail: Value = types.NIL;
+    gc.pushRoot(&result_tail) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     // Current pointers for each list
     var currents: [256]Value = undefined;
@@ -314,7 +318,13 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
             };
         };
 
-        results.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
+        const new_pair = gc.allocPair(result, types.NIL) catch return PrimitiveError.OutOfMemory;
+        if (result_head == types.NIL) {
+            result_head = new_pair;
+        } else {
+            types.setCdr(result_tail, new_pair);
+        }
+        result_tail = new_pair;
 
         // Advance each list
         for (0..list_count) |i| {
@@ -322,16 +332,7 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
         }
     }
 
-    // Build result list from collected values
-    var result_list: Value = types.NIL;
-    gc.pushRoot(&result_list) catch return PrimitiveError.OutOfMemory;
-    defer gc.popRoot();
-    var i = results.items.len;
-    while (i > 0) {
-        i -= 1;
-        result_list = gc.allocPair(results.items[i], result_list) catch return PrimitiveError.OutOfMemory;
-    }
-    return result_list;
+    return result_head;
 }
 
 fn forEachFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -101,17 +101,21 @@ fn commandLine(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
 
+    var str_val: Value = types.NIL;
+    gc.pushRoot(&str_val) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
+
     // Build list in reverse: script args then program name at the front.
     var i = vm.command_line_args.len;
     while (i > 0) {
         i -= 1;
-        const s = gc.allocString(vm.command_line_args[i]) catch return PrimitiveError.OutOfMemory;
-        result = gc.allocPair(s, result) catch return PrimitiveError.OutOfMemory;
+        str_val = gc.allocString(vm.command_line_args[i]) catch return PrimitiveError.OutOfMemory;
+        result = gc.allocPair(str_val, result) catch return PrimitiveError.OutOfMemory;
     }
 
     // Prepend program name.
-    const name = gc.allocString("kaappi") catch return PrimitiveError.OutOfMemory;
-    result = gc.allocPair(name, result) catch return PrimitiveError.OutOfMemory;
+    str_val = gc.allocString("kaappi") catch return PrimitiveError.OutOfMemory;
+    result = gc.allocPair(str_val, result) catch return PrimitiveError.OutOfMemory;
     return result;
 }
 
@@ -265,6 +269,8 @@ fn makeParameterFn(args: []const Value) PrimitiveError!Value {
     const converter: Value = if (args.len > 1) args[1] else types.NIL;
     // If converter provided, apply it to initial value
     var val = init;
+    gc.pushRoot(&val) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     if (converter != types.NIL) {
         const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
         val = vm.callWithArgs(converter, &[_]Value{init}) catch |err| {


### PR DESCRIPTION
## Summary
- **map**: Replaced unrooted `ArrayList` accumulator with incrementally-built GC-rooted list using head/tail pointers
- **with-exception-handler**: Root exception value after clearing `current_exception` before `callHandler`
- **call-with-values**: Root `produced` value before calling consumer (it's the sole reference after `callThunk` returns)
- **make-parameter**: Root converted value before `allocParameter`
- **command-line**: Root intermediate string values before `allocPair`

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1503 pass, 0 fail)

Fixes #275
Fixes #270
Fixes #269
Fixes #266
Fixes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)