### PR TITLE
Fix compiler correctness bugs in do, define, cond/case =>, delay, named-let

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -137,15 +137,15 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
                     try self.emitU16(arg_reg);
                     try self.emitU16(key_reg);
                     try self.compileExpr(proc_expr, proc_reg, false);
-                    try self.emitOp(.move);
-                    try self.emitU16(dst);
-                    try self.emitU16(proc_reg);
-                    try self.emitOp(.move);
-                    try self.emitU16(dst + 1);
-                    try self.emitU16(arg_reg);
+                    // Call at proc_reg (arg already at proc_reg + 1)
                     if (is_tail) try self.emitOp(.tail_call) else try self.emitOp(.call);
-                    try self.emitU16(dst);
+                    try self.emitU16(proc_reg);
                     try self.emit(1);
+                    if (!is_tail) {
+                        try self.emitOp(.move);
+                        try self.emitU16(dst);
+                        try self.emitU16(proc_reg);
+                    }
                     self.freeReg(); // arg_reg
                     self.freeReg(); // proc_reg
                     had_else = true;

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -25,14 +25,39 @@ fn renameInBody(gc: *memory.GC, expr: Value, old_name: []const u8, new_sym: Valu
     }
     if (types.isPair(expr)) {
         const head = types.car(expr);
-        if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "quote"))
-            return expr;
+        if (types.isSymbol(head)) {
+            const hname = types.symbolName(head);
+            if (std.mem.eql(u8, hname, "quote"))
+                return expr;
+            if (std.mem.eql(u8, hname, "quasiquote")) {
+                const new_tmpl = try renameInQuasiquote(gc, types.cdr(expr), old_name, new_sym);
+                if (new_tmpl == types.cdr(expr)) return expr;
+                return gc.allocPair(head, new_tmpl) catch return CompileError.OutOfMemory;
+            }
+        }
         const new_car = try renameInBody(gc, types.car(expr), old_name, new_sym);
         const new_cdr = try renameInBody(gc, types.cdr(expr), old_name, new_sym);
         if (new_car == types.car(expr) and new_cdr == types.cdr(expr)) return expr;
         return gc.allocPair(new_car, new_cdr) catch return CompileError.OutOfMemory;
     }
     return expr;
+}
+
+fn renameInQuasiquote(gc: *memory.GC, template: Value, old_name: []const u8, new_sym: Value) CompileError!Value {
+    if (!types.isPair(template)) return template;
+    const head = types.car(template);
+    if (types.isSymbol(head)) {
+        const hname = types.symbolName(head);
+        if (std.mem.eql(u8, hname, "unquote") or std.mem.eql(u8, hname, "unquote-splicing")) {
+            const new_cdr = try renameInBody(gc, types.cdr(template), old_name, new_sym);
+            if (new_cdr == types.cdr(template)) return template;
+            return gc.allocPair(head, new_cdr) catch return CompileError.OutOfMemory;
+        }
+    }
+    const new_car = try renameInQuasiquote(gc, head, old_name, new_sym);
+    const new_cdr = try renameInQuasiquote(gc, types.cdr(template), old_name, new_sym);
+    if (new_car == head and new_cdr == types.cdr(template)) return template;
+    return gc.allocPair(new_car, new_cdr) catch return CompileError.OutOfMemory;
 }
 
 // -- Binding and iteration forms --
@@ -309,8 +334,9 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
 
     self.beginScope();
 
-    // Parse var specs and evaluate inits
+    // Parse var specs and evaluate inits (two-phase: all inits first, then locals)
     var var_slots: [MAX_LET_BINDINGS]u16 = undefined;
+    var var_names: [MAX_LET_BINDINGS][]const u8 = undefined;
     var step_exprs: [MAX_LET_BINDINGS]Value = undefined;
     var has_step: [MAX_LET_BINDINGS]bool = undefined;
     var var_count: usize = 0;
@@ -329,8 +355,8 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
         if (var_count >= MAX_LET_BINDINGS) return CompileError.TooManyLocals;
         const slot = try self.allocReg();
         try self.compileExpr(init_expr, slot, false);
-        try self.addLocal(types.symbolName(var_name), slot);
         var_slots[var_count] = slot;
+        var_names[var_count] = types.symbolName(var_name);
 
         const step_rest = types.cdr(types.cdr(spec));
         if (step_rest != types.NIL) {
@@ -343,6 +369,11 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
 
         var_count += 1;
         spec_list = types.cdr(spec_list);
+    }
+
+    // Phase 2: add all locals at once (let semantics, not let*)
+    for (0..var_count) |vi| {
+        try self.addLocal(var_names[vi], var_slots[vi]);
     }
 
     // Loop start
@@ -364,7 +395,7 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     }
 
     // Step: evaluate all steps to temp registers, then assign back
-    var temp_slots: [32]u16 = undefined;
+    var temp_slots: [MAX_LET_BINDINGS]u16 = undefined;
     var step_count: usize = 0;
     for (0..var_count) |j| {
         if (has_step[j]) {

--- a/src/compiler_conditionals.zig
+++ b/src/compiler_conditionals.zig
@@ -184,28 +184,26 @@ pub fn compileCond(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
                 if (!types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
                 const proc_expr = types.car(arrow_rest);
                 const proc_reg = try self.allocReg();
-                // Move test value to arg position
                 const arg_reg = try self.allocReg();
+                // Save test value to arg position (proc_reg + 1)
                 try self.emitOp(.move);
                 try self.emitU16(arg_reg);
                 try self.emitU16(dst);
-                // Compile proc
+                // Compile proc into proc_reg
                 try self.compileExpr(proc_expr, proc_reg, false);
-                // Move proc to dst (for call base)
-                try self.emitOp(.move);
-                try self.emitU16(dst);
-                try self.emitU16(proc_reg);
-                // Move arg after dst
-                try self.emitOp(.move);
-                try self.emitU16(dst + 1);
-                try self.emitU16(arg_reg);
+                // Call at proc_reg (arg already at proc_reg + 1)
                 if (is_tail) {
                     try self.emitOp(.tail_call);
                 } else {
                     try self.emitOp(.call);
                 }
-                try self.emitU16(dst);
+                try self.emitU16(proc_reg);
                 try self.emit(1);
+                if (!is_tail) {
+                    try self.emitOp(.move);
+                    try self.emitU16(dst);
+                    try self.emitU16(proc_reg);
+                }
                 self.freeReg(); // arg_reg
                 self.freeReg(); // proc_reg
 

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -226,11 +226,23 @@ pub fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
         if (!types.isSymbol(name)) return CompileError.InvalidSyntax;
         const param_formals = types.cdr(target);
 
-        // Build lambda body list. compileLambda sets the function's name (used
-        // for debugging and for self-tail-call detection in the body).
         const lambda_args = self.gc.allocPair(param_formals, rest) catch return CompileError.OutOfMemory;
         try compileLambda(self, lambda_args, dst, types.symbolName(name));
 
+        if (self.in_body_scope) {
+            const slot = try self.allocReg();
+            try self.emitOp(.move);
+            try self.emitU16(slot);
+            try self.emitU16(dst);
+            self.locals.append(self.gc.allocator, .{
+                .name = types.symbolName(name),
+                .depth = self.scope_depth,
+                .slot = slot,
+            }) catch return CompileError.OutOfMemory;
+            try self.emitOp(.load_void);
+            try self.emitU16(dst);
+            return;
+        }
         const sym_idx = try self.addConstant(name);
         try self.emitOp(.define_global);
         try self.emitU16(sym_idx);
@@ -464,6 +476,11 @@ pub fn compileDelay(self: *Compiler, args: Value, dst: u16) CompileError!void {
     try child.emitOp(.@"return");
     try child.emitU16(body_dst);
 
+    // Box parent locals that are captured as upvalues (enables shared mutation)
+    for (child.upvalues.items) |uv| {
+        if (uv.is_local) try self.markLocalBoxedBySlot(uv.index);
+    }
+
     // Store the lambda as a closure constant and emit closure + upvalue descriptors
     const func_val = types.makePointer(@ptrCast(child.func));
     const closure_idx = try self.addConstant(func_val);
@@ -472,28 +489,31 @@ pub fn compileDelay(self: *Compiler, args: Value, dst: u16) CompileError!void {
     try self.emitU16(thunk_reg);
     try self.emitU16(closure_idx);
 
-    // Emit upvalue descriptors (critical for capturing variables)
     for (child.upvalues.items) |uv| {
         try self.emit(if (uv.is_local) 1 else 0);
         try self.emitU16(uv.index);
     }
 
-    // Call %make-promise-lazy(thunk) to create an unforced promise
+    // Call %make-promise-lazy(thunk) — use fresh registers to avoid clobbering
     const sym = self.gc.allocSymbol("%make-promise-lazy") catch return CompileError.OutOfMemory;
     const sym_idx = try self.addConstant(sym);
+    const call_base = try self.allocReg();
     try self.emitOp(.get_global);
-    try self.emitU16(dst);
+    try self.emitU16(call_base);
     try self.emitU16(sym_idx);
 
-    // Set up the call: dst=func, dst+1=arg
     try self.emitOp(.move);
-    try self.emitU16(dst + 1);
+    try self.emitU16(call_base + 1);
     try self.emitU16(thunk_reg);
 
     try self.emitOp(.call);
-    try self.emitU16(dst);
+    try self.emitU16(call_base);
     try self.emit(1);
+    try self.emitOp(.move);
+    try self.emitU16(dst);
+    try self.emitU16(call_base);
 
+    self.freeReg(); // free call_base
     self.freeReg(); // free thunk_reg
 }
 


### PR DESCRIPTION
## Summary
- **do init scoping** (#293): Two-phase init evaluation (all inits, then all locals) for R7RS let semantics
- **do temp_slots** (#294): Expand buffer from [32] to [256] to handle 33+ stepped variables  
- **define function shorthand** (#283): Respect `in_body_scope` for local bindings
- **cond/case =>** (#271): Call at proc_reg to avoid clobbering adjacent registers
- **delay boxing** (#285): Call `markLocalBoxedBySlot` for captured upvalues
- **delay register** (#284): Use fresh call_base register for `%make-promise-lazy`
- **named-let quasiquote** (#295): Skip quasiquote templates, walk into unquote subforms

## Test plan
- [x] All unit tests pass
- [x] Full Scheme test suite passes (1503 pass, 0 fail)
- [x] Verified: `(do ((x 1 ...) (y x ...)) ...)` → y sees outer x
- [x] Verified: `(define (f x) ...)` inside body creates local binding
- [x] Verified: `(cond (#t => ...))` doesn't clobber let bindings
- [x] Verified: `(delay x)` sees `set!` mutations
- [x] Verified: `(let loop ... (quasiquote loop))` → symbol `loop`, not gensym

Fixes #293, #294, #283, #271, #284, #285, #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)