### PR TITLE
Fix reader token validation: codepoints, delimiters, booleans

### DIFF
--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -399,9 +399,10 @@ pub fn readHash(self: *Reader) ReadError!Token {
                     self.pos += 1;
                 }
                 const word = self.source[start..self.pos];
-                if (std.mem.eql(u8, word, "true")) return .{ .boolean = true };
-                return ReadError.UnexpectedChar;
+                if (!std.mem.eql(u8, word, "true")) return ReadError.UnexpectedChar;
             }
+            if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+                return ReadError.UnexpectedChar;
             return .{ .boolean = true };
         },
         'f' => {
@@ -412,9 +413,10 @@ pub fn readHash(self: *Reader) ReadError!Token {
                     self.pos += 1;
                 }
                 const word = self.source[start..self.pos];
-                if (std.mem.eql(u8, word, "false")) return .{ .boolean = false };
-                return ReadError.UnexpectedChar;
+                if (!std.mem.eql(u8, word, "false")) return ReadError.UnexpectedChar;
             }
+            if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+                return ReadError.UnexpectedChar;
             return .{ .boolean = false };
         },
         '\\' => return readCharacter(self),
@@ -570,11 +572,15 @@ pub fn readCharacter(self: *Reader) ReadError!Token {
                 }
                 const hex_str = self.source[start + 1 .. self.pos];
                 const cp = std.fmt.parseInt(u21, hex_str, 16) catch return ReadError.InvalidNumber;
-                if (cp >= 0xD800 and cp <= 0xDFFF) return ReadError.InvalidCharacterName;
+                if (cp > 0x10FFFF or (cp >= 0xD800 and cp <= 0xDFFF)) return ReadError.InvalidCharacterName;
+                if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+                    return ReadError.UnexpectedChar;
                 return .{ .character = cp };
             }
             // Just #\x alone — return 'x'
             if (self.pos >= self.source.len or !std.ascii.isAlphabetic(self.source[self.pos])) {
+                if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+                    return ReadError.UnexpectedChar;
                 return .{ .character = first_byte };
             }
         }
@@ -583,18 +589,14 @@ pub fn readCharacter(self: *Reader) ReadError!Token {
         }
         const name = self.source[start..self.pos];
         if (name.len == 1) {
+            if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+                return ReadError.UnexpectedChar;
             return .{ .character = name[0] };
         }
-        if (std.ascii.eqlIgnoreCase(name, "space")) return .{ .character = ' ' };
-        if (std.ascii.eqlIgnoreCase(name, "newline")) return .{ .character = '\n' };
-        if (std.ascii.eqlIgnoreCase(name, "tab")) return .{ .character = '\t' };
-        if (std.ascii.eqlIgnoreCase(name, "return")) return .{ .character = '\r' };
-        if (std.ascii.eqlIgnoreCase(name, "null")) return .{ .character = 0 };
-        if (std.ascii.eqlIgnoreCase(name, "alarm")) return .{ .character = 7 };
-        if (std.ascii.eqlIgnoreCase(name, "backspace")) return .{ .character = 8 };
-        if (std.ascii.eqlIgnoreCase(name, "delete")) return .{ .character = 0x7F };
-        if (std.ascii.eqlIgnoreCase(name, "escape")) return .{ .character = 0x1B };
-        return ReadError.InvalidCharacterName;
+        const char_val: u21 = if (std.ascii.eqlIgnoreCase(name, "space")) ' ' else if (std.ascii.eqlIgnoreCase(name, "newline")) '\n' else if (std.ascii.eqlIgnoreCase(name, "tab")) '\t' else if (std.ascii.eqlIgnoreCase(name, "return")) '\r' else if (std.ascii.eqlIgnoreCase(name, "null")) 0 else if (std.ascii.eqlIgnoreCase(name, "alarm")) 7 else if (std.ascii.eqlIgnoreCase(name, "backspace")) 8 else if (std.ascii.eqlIgnoreCase(name, "delete")) 0x7F else if (std.ascii.eqlIgnoreCase(name, "escape")) 0x1B else return ReadError.InvalidCharacterName;
+        if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+            return ReadError.UnexpectedChar;
+        return .{ .character = char_val };
     }
 
     // Multi-byte UTF-8 character (e.g., #\λ)
@@ -607,6 +609,8 @@ pub fn readCharacter(self: *Reader) ReadError!Token {
             return ReadError.InvalidCharacterName;
         };
         self.pos += seq_len;
+        if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+            return ReadError.UnexpectedChar;
         return .{ .character = cp };
     }
 

--- a/tests/scheme/errors/reader-token-errors.sh
+++ b/tests/scheme/errors/reader-token-errors.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Regression tests for reader token validation error cases
+# Issues: #313, #312, #311
+set -e
+
+KAAPPI="${KAAPPI:-./zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+
+check_error() {
+    local desc="$1"
+    local input="$2"
+    if printf '%s\n' "$input" | $KAAPPI 2>&1 | grep -qi "error"; then
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $desc — expected error for: $input"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# #313: Codepoints above U+10FFFF
+check_error "#\\x110000 (above max Unicode)" '#\x110000'
+check_error "#\\x1FFFFF (above max Unicode)" '#\x1FFFFF'
+check_error "#\\xD800 (surrogate)" '#\xD800'
+check_error "#\\xDFFF (surrogate)" '#\xDFFF'
+
+# #312: Missing delimiter after character literals
+check_error "#\\x41z (no delimiter after hex char)" '#\x41z'
+check_error "#\\a1 (no delimiter after single char)" '#\a1'
+check_error "#\\space. (no delimiter after named char)" '#\space.'
+
+# #311: Missing delimiter after boolean literals
+check_error "#t1 (no delimiter after #t)" '#t1'
+check_error "#f. (no delimiter after #f)" '#f.'
+check_error "#true1 (no delimiter after #true)" '#true1'
+check_error "#false+ (no delimiter after #false)" '#false+'
+
+echo ""
+echo "Reader token errors: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scheme/smoke/reader-token-validation.scm
+++ b/tests/scheme/smoke/reader-token-validation.scm
@@ -1,0 +1,30 @@
+;; Regression tests for reader token validation
+;; Issues: #313 (codepoints above U+10FFFF), #312 (char literal delimiters),
+;;         #311 (boolean literal delimiters)
+
+(import (scheme base) (scheme write))
+
+;; ---- #313: Valid Unicode codepoints should still work ----
+(display (eqv? #\x41 #\A)) (newline)            ; #t
+(display (eqv? #\x0 #\null)) (newline)           ; #t
+(display (eqv? #\x10FFFF #\x10FFFF)) (newline)   ; #t (max valid codepoint)
+(display (char->integer #\xD7FF)) (newline)       ; 55295 (just below surrogates)
+(display (char->integer #\xE000)) (newline)       ; 57344 (just above surrogates)
+(display (char->integer #\x10FFFF)) (newline)     ; 1114111 (max valid)
+
+;; ---- #311: Boolean literals followed by delimiters should work ----
+(display #t) (newline)                            ; #t
+(display #f) (newline)                            ; #f
+(display #true) (newline)                         ; #t
+(display #false) (newline)                        ; #f
+(display (list #t #f)) (newline)                  ; (#t #f)
+(display (if #t "yes" "no")) (newline)            ; yes
+
+;; ---- #312: Character literals followed by delimiters should work ----
+(display #\a) (newline)                           ; a
+(display #\space) (newline)                       ; (space char)
+(display (list #\x41 #\newline)) (newline)        ; (A newline)
+(display (char->integer #\x)) (newline)           ; 120
+
+(display "all passed")
+(newline)


### PR DESCRIPTION
## Summary
- Reject character hex literals with codepoints above U+10FFFF (`#\x110000` etc.) — previously accepted, producing garbled output (#313)
- Enforce delimiter after all character literal forms (`#\a`, `#\space`, `#\x41`, `#\λ`) — previously `#\a1` silently split into `#\a` and `1` (#312)
- Enforce delimiter after `#t`/`#f`/`#true`/`#false` — previously `#t1` silently split into `#t` and `1` (#311)

Per R7RS 7.1.1, tokens must be followed by a delimiter (whitespace, parentheses, quotes, semicolons, or vertical bar).

Closes #313, closes #312, closes #311

## Test plan
- [x] New smoke test (`tests/scheme/smoke/reader-token-validation.scm`) validates correct character/boolean parsing
- [x] New error test (`tests/scheme/errors/reader-token-errors.sh`) — 11 invalid-input cases all produce read errors
- [x] Full unit tests pass (`zig build test`)
- [x] Full Scheme suite passes (1504 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)