### PR TITLE
Fix expander: flonum datum patterns and ellipsis escape hygiene

### DIFF
--- a/src/expander.zig
+++ b/src/expander.zig
@@ -231,6 +231,9 @@ fn matchPattern(pattern: Value, input: Value, literals: []const Value, bindings:
     if (types.isFixnum(pattern)) {
         return types.isFixnum(input) and pattern == input;
     }
+    if (types.isFlonum(pattern)) {
+        return types.isFlonum(input) and pattern == input;
+    }
     if (types.isBool(pattern)) {
         return pattern == input;
     }
@@ -482,7 +485,7 @@ fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_scop
     if (!in_escape and types.isSymbol(elem) and isEllipsis(types.symbolName(elem))) {
         if (rest != types.NIL and types.isPair(rest) and types.cdr(rest) == types.NIL) {
             const inner = types.car(rest);
-            return instantiateTemplate(gc, inner, bindings, intro_scope | ESCAPE_FLAG | QUOTE_FLAG, literals, macro_keyword, globals, macros);
+            return instantiateTemplate(gc, inner, bindings, intro_scope | ESCAPE_FLAG, literals, macro_keyword, globals, macros);
         }
         return template;
     }
@@ -661,8 +664,9 @@ fn substitutePatternVarsOnly(gc: *GC, template: Value, bindings: []Binding) !Val
 }
 
 fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.StringHashMap(Value)) !Value {
-    // Skip renaming inside quote or ellipsis escape contexts
-    if ((scope & 0xC0000000) != 0) return gc.allocSymbol(name);
+    // Skip renaming inside quote contexts (not ellipsis escape — hygiene still applies there)
+    const QUOTE_FLAG: u32 = 0x40000000;
+    if ((scope & QUOTE_FLAG) != 0) return gc.allocSymbol(name);
     // If the name exists as a global binding, keep it as-is.
     // This preserves referential transparency AND allows set! to
     // mutate the original global (aliasing would create a separate binding).

--- a/tests/scheme/smoke/expander-fixes.scm
+++ b/tests/scheme/smoke/expander-fixes.scm
@@ -1,0 +1,51 @@
+;; Regression tests for expander fixes
+;; #309: flonum datum patterns in syntax-rules
+;; #308: ellipsis escape hygiene
+
+(import (scheme base) (scheme write))
+
+;; ---- #309: Flonum datum patterns ----
+
+(define-syntax check-pi
+  (syntax-rules ()
+    ((check-pi 3.14) 'pi)
+    ((check-pi _) 'other)))
+
+(display (check-pi 3.14))    ; pi
+(newline)
+(display (check-pi 2.71))    ; other
+(newline)
+(display (check-pi 42))      ; other
+(newline)
+
+;; Integer datum patterns still work
+(define-syntax check-zero
+  (syntax-rules ()
+    ((check-zero 0) 'zero)
+    ((check-zero _) 'nonzero)))
+
+(display (check-zero 0))     ; zero
+(newline)
+(display (check-zero 1))     ; nonzero
+(newline)
+
+;; ---- #308: Ellipsis escape hygiene ----
+
+;; The template-introduced variable 't' inside (... ...) should be
+;; renamed for hygiene and not conflict with outer 't'.
+(define-syntax my-or
+  (syntax-rules ()
+    ((my-or a b)
+     (... (let ((t a)) (if t t b))))))
+
+(let ((t 42))
+  (display (my-or #f t))      ; 42 (not shadowed by hygienic 't')
+  (newline))
+
+(display (my-or 1 2))         ; 1
+(newline)
+(display (my-or #f 99))       ; 99
+(newline)
+
+(display "all passed")
+(newline)


### PR DESCRIPTION
## Summary
- Add flonum check in `matchPattern` so `syntax-rules` datum patterns like `3.14` match correctly (#309)
- Remove `QUOTE_FLAG` from ellipsis escape `(... <template>)` so template-introduced identifiers are still renamed for hygiene (#308)
- Fix `renameForHygiene` mask to only skip renaming for `QUOTE_FLAG`, not `ESCAPE_FLAG`

Closes #309, closes #308

## Test plan
- [x] New smoke test (`tests/scheme/smoke/expander-fixes.scm`) covers both flonum patterns and ellipsis escape hygiene
- [x] Full unit tests pass (`zig build test`)
- [x] Full Scheme suite passes (1505 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)