### PR TITLE
Fix bytevector port primitives: u8-ready?, read-bytevector, get-output-bytevector

### DIFF
--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -343,7 +343,7 @@ fn u8ReadyP(args: []const Value) PrimitiveError!Value {
     if (port.peek_byte != null) return types.TRUE;
     if (port.is_string_port) {
         const data = port.string_data orelse return types.TRUE;
-        return if (port.string_pos < data.len) types.TRUE else types.TRUE;
+        return if (port.string_pos < data.len) types.TRUE else types.FALSE;
     }
     return types.TRUE; // simplified
 }
@@ -356,6 +356,8 @@ fn readBytevectorFn(args: []const Value) PrimitiveError!Value {
     if (k < 0) return primitives.typeError("read-bytevector", "non-negative integer", args[0]);
     const count: usize = @intCast(@as(u64, @bitCast(k)));
     const port = try getInputPort(args, 1);
+
+    if (count == 0) return gc.allocBytevector(&.{}) catch return PrimitiveError.OutOfMemory;
 
     const buf = gc.allocator.alloc(u8, count) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(buf);
@@ -427,7 +429,7 @@ fn getOutputBytevector(args: []const Value) PrimitiveError!Value {
     if (!types.isPort(args[0])) return primitives.typeError("get-output-bytevector", "output bytevector port", args[0]);
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = types.toObject(args[0]).as(types.Port);
-    if (!port.is_string_port or !port.is_output) return primitives.typeError("get-output-bytevector", "output bytevector port", args[0]);
+    if (!port.is_string_port or !port.is_output or !port.is_binary) return primitives.typeError("get-output-bytevector", "output bytevector port", args[0]);
     const data = if (port.string_out_buf) |buf| buf[0..port.string_out_len] else &[_]u8{};
     return gc.allocBytevector(data) catch return PrimitiveError.OutOfMemory;
 }

--- a/tests/scheme/smoke/bytevector-port-fixes.scm
+++ b/tests/scheme/smoke/bytevector-port-fixes.scm
@@ -1,0 +1,48 @@
+;; Regression tests for bytevector port fixes
+;; #280: u8-ready? always returns #t
+;; #281: read-bytevector returns EOF when k=0
+;; #282: get-output-bytevector accepts string ports
+
+(import (scheme base) (scheme write))
+
+;; ---- #280: u8-ready? returns #f at EOF ----
+(let ((p (open-input-bytevector #u8(1 2))))
+  (read-u8 p) (read-u8 p)
+  (display (u8-ready? p))          ; #f (port exhausted)
+  (newline))
+
+(let ((p (open-input-bytevector #u8(42))))
+  (display (u8-ready? p))          ; #t (data available)
+  (newline))
+
+;; ---- #281: read-bytevector with k=0 ----
+(let ((p (open-input-bytevector #u8(1 2 3))))
+  (let ((bv (read-bytevector 0 p)))
+    (display (bytevector? bv))     ; #t (not eof-object)
+    (newline)
+    (display (bytevector-length bv)) ; 0
+    (newline)))
+
+;; read-bytevector with k=0 should not consume any bytes
+(let ((p (open-input-bytevector #u8(1 2 3))))
+  (read-bytevector 0 p)
+  (display (read-u8 p))           ; 1 (first byte still there)
+  (newline))
+
+;; ---- #282: get-output-bytevector rejects string ports ----
+(let ((p (open-output-string)))
+  (write-string "hello" p)
+  (display
+    (guard (exn (#t 'error))
+      (get-output-bytevector p)))  ; error
+  (newline))
+
+;; get-output-bytevector still works on bytevector ports
+(let ((p (open-output-bytevector)))
+  (write-u8 65 p)
+  (write-u8 66 p)
+  (display (get-output-bytevector p))  ; #u8(65 66)
+  (newline))
+
+(display "all passed")
+(newline)


### PR DESCRIPTION
## Summary
- `u8-ready?` now returns `#f` when port is exhausted — was always `#t` due to copy-paste error (#280)
- `read-bytevector` returns empty bytevector `#u8()` instead of EOF when k=0 (#281)
- `get-output-bytevector` rejects string output ports by checking `is_binary` flag (#282)

Closes #280, closes #281, closes #282

## Test plan
- [x] New smoke test (`tests/scheme/smoke/bytevector-port-fixes.scm`) covers all three fixes
- [x] Full unit tests pass
- [x] Full Scheme suite passes (1506 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)