### PR TITLE
Fix char folding: use fold table and handle multi-char expansions

### DIFF
--- a/src/primitives_char.zig
+++ b/src/primitives_char.zig
@@ -236,10 +236,7 @@ fn charFoldcaseFn(args: []const Value) PrimitiveError!Value {
 }
 
 pub fn charFoldcase(cp: u21) u21 {
-    return switch (cp) {
-        0x017F => 's',
-        else => unicodeDowncase(cp),
-    };
+    return foldChar(cp);
 }
 
 // ---------------------------------------------------------------------------
@@ -318,31 +315,72 @@ fn charCiGtFn(args: []const Value) PrimitiveError!Value {
 // Case-insensitive string comparison
 // ---------------------------------------------------------------------------
 
+const FoldResult = struct {
+    cps: [3]u21,
+    len: u2,
+};
+
+fn foldCharExpanding(cp: u21) FoldResult {
+    return switch (cp) {
+        0x00DF => .{ .cps = .{ 's', 's', 0 }, .len = 2 },
+        0x0130 => .{ .cps = .{ 0x0069, 0x0307, 0 }, .len = 2 },
+        0x01F0 => .{ .cps = .{ 'j', 0x030C, 0 }, .len = 2 },
+        0x0390 => .{ .cps = .{ 0x03B9, 0x0308, 0x0301 }, .len = 3 },
+        0x03B0 => .{ .cps = .{ 0x03C5, 0x0308, 0x0301 }, .len = 3 },
+        0xFB00 => .{ .cps = .{ 'f', 'f', 0 }, .len = 2 },
+        0xFB01 => .{ .cps = .{ 'f', 'i', 0 }, .len = 2 },
+        0xFB02 => .{ .cps = .{ 'f', 'l', 0 }, .len = 2 },
+        0xFB03 => .{ .cps = .{ 'f', 'f', 'i' }, .len = 3 },
+        0xFB04 => .{ .cps = .{ 'f', 'f', 'l' }, .len = 3 },
+        0xFB05, 0xFB06 => .{ .cps = .{ 's', 't', 0 }, .len = 2 },
+        else => {
+            const folded = foldChar(cp);
+            return .{ .cps = .{ folded, 0, 0 }, .len = 1 };
+        },
+    };
+}
+
 fn foldCompareStrings(a: []const u8, b: []const u8) std.math.Order {
-    // Compare codepoints after case-folding
     var ai: usize = 0;
     var bi: usize = 0;
-    while (ai < a.len and bi < b.len) {
-        const a_len = std.unicode.utf8ByteSequenceLength(a[ai]) catch 1;
-        const b_len = std.unicode.utf8ByteSequenceLength(b[bi]) catch 1;
-        const a_cp = if (ai + a_len <= a.len)
-            (std.unicode.utf8Decode(a[ai .. ai + a_len]) catch @as(u21, a[ai]))
-        else
-            @as(u21, a[ai]);
-        const b_cp = if (bi + b_len <= b.len)
-            (std.unicode.utf8Decode(b[bi .. bi + b_len]) catch @as(u21, b[bi]))
-        else
-            @as(u21, b[bi]);
-        const fa = foldChar(a_cp);
-        const fb = foldChar(b_cp);
+    var a_buf: FoldResult = .{ .cps = .{ 0, 0, 0 }, .len = 0 };
+    var b_buf: FoldResult = .{ .cps = .{ 0, 0, 0 }, .len = 0 };
+    var a_idx: u2 = 0;
+    var b_idx: u2 = 0;
+
+    while (true) {
+        if (a_idx >= a_buf.len) {
+            if (ai >= a.len) {
+                if (b_idx >= b_buf.len and bi >= b.len) return .eq;
+                return .lt;
+            }
+            const a_len = std.unicode.utf8ByteSequenceLength(a[ai]) catch 1;
+            const a_cp = if (ai + a_len <= a.len)
+                (std.unicode.utf8Decode(a[ai .. ai + a_len]) catch @as(u21, a[ai]))
+            else
+                @as(u21, a[ai]);
+            a_buf = foldCharExpanding(a_cp);
+            a_idx = 0;
+            ai += a_len;
+        }
+        if (b_idx >= b_buf.len) {
+            if (bi >= b.len) return .gt;
+            const b_len = std.unicode.utf8ByteSequenceLength(b[bi]) catch 1;
+            const b_cp = if (bi + b_len <= b.len)
+                (std.unicode.utf8Decode(b[bi .. bi + b_len]) catch @as(u21, b[bi]))
+            else
+                @as(u21, b[bi]);
+            b_buf = foldCharExpanding(b_cp);
+            b_idx = 0;
+            bi += b_len;
+        }
+        const fa = a_buf.cps[a_idx];
+        const fb = b_buf.cps[b_idx];
         if (fa < fb) return .lt;
         if (fa > fb) return .gt;
-        ai += a_len;
-        bi += b_len;
+        a_idx += 1;
+        b_idx += 1;
     }
-    if (ai < a.len) return .gt;
-    if (bi < b.len) return .lt;
-    return .eq;
 }
 
 fn compareCiStrings(proc: []const u8, args: []const Value, comptime cmp: enum { lt, le, eq, ge, gt }) PrimitiveError!Value {

--- a/tests/scheme/smoke/char-folding-fixes.scm
+++ b/tests/scheme/smoke/char-folding-fixes.scm
@@ -1,0 +1,44 @@
+;; Regression tests for char folding fixes
+;; #290: charFoldcase ignores Unicode fold table
+;; #291: string-ci comparisons fail on multi-character fold mappings
+
+(import (scheme base) (scheme char) (scheme write))
+
+;; ---- #290: charFoldcase uses fold table ----
+;; U+00B5 (MICRO SIGN) should fold to U+03BC (GREEK SMALL MU)
+(display (char-ci=? #\xB5 #\x3BC))   ; #t
+(newline)
+
+;; U+017F (LONG S) should fold to 's'
+(display (char-ci=? #\x17F #\s))      ; #t
+(newline)
+
+;; ---- #291: string-ci with multi-char fold ----
+;; Eszett (U+00DF) folds to "ss"
+(display (string-ci=? "\xDF;" "ss"))   ; #t
+(newline)
+(display (string-ci=? "\xDF;" "SS"))   ; #t
+(newline)
+
+;; ff ligature (U+FB00) folds to "ff"
+(display (string-ci=? "\xFB00;" "ff")) ; #t
+(newline)
+
+;; fi ligature (U+FB01) folds to "fi"
+(display (string-ci=? "\xFB01;" "fi")) ; #t
+(newline)
+
+;; string-ci<? with multi-char fold: "a"+eszett folds to "ass", equal to "ass"
+(display (string-ci=? "a\xDF;" "ass")) ; #t
+(newline)
+
+;; Ordering: "a" < "ass" since "a" is shorter
+(display (string-ci<? "a" "ass"))      ; #t
+(newline)
+
+;; Equal strings
+(display (string-ci=? "stra\xDF;e" "strasse")) ; #t (Straße = strasse)
+(newline)
+
+(display "all passed")
+(newline)


### PR DESCRIPTION
## Summary
- `charFoldcase` now delegates to `foldChar` which uses the Unicode fold table, fixing `string-ci-hash` for characters like U+00B5 (MICRO SIGN) (#290)
- `foldCompareStrings` now handles multi-character fold mappings (eszett -> "ss", ligatures -> expanded forms) by expanding each codepoint into up to 3 folded codepoints before comparison (#291)

Closes #290, closes #291

## Test plan
- [x] New smoke test (`tests/scheme/smoke/char-folding-fixes.scm`) covers both fold table usage and multi-char expansions
- [x] `(string-ci=? "\xDF;" "ss")` now returns `#t`
- [x] `(char-ci=? #\xB5 #\x3BC)` now returns `#t`
- [x] Full unit tests pass
- [x] Full Scheme suite passes (1507 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)