### PR TITLE
Add missing ArityMismatch in call-with-values multi-value branch

### DIFF
--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -389,6 +389,7 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
                 vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
                 vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
                 vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
+                vm_mod.VMError.ArityMismatch => PrimitiveError.ArityMismatch,
                 else => PrimitiveError.TypeError, // bare-ok: catch fallback
             };
         };

--- a/tests/scheme/smoke/call-with-values-arity.scm
+++ b/tests/scheme/smoke/call-with-values-arity.scm
@@ -1,0 +1,26 @@
+;; Regression test for call-with-values ArityMismatch in multi-value branch
+;; Issue #268
+
+(import (scheme base) (scheme write))
+
+;; Multi-value arity mismatch should raise an error, not a type error
+(display
+  (guard (exn (#t 'error-caught))
+    (call-with-values (lambda () (values 1 2 3)) (lambda (x) x))))
+(newline)
+;; Expected: error-caught
+
+;; Normal multi-value case still works
+(display
+  (call-with-values (lambda () (values 1 2 3)) (lambda (a b c) (+ a b c))))
+(newline)
+;; Expected: 6
+
+;; Single-value case still works
+(display
+  (call-with-values (lambda () 42) (lambda (x) (* x 2))))
+(newline)
+;; Expected: 84
+
+(display "all passed")
+(newline)


### PR DESCRIPTION
## Summary
- Add `ArityMismatch` case to the error switch in the multi-value branch of `callWithValuesFn`, matching the single-value branch (#268)
- Previously, arity errors from `(call-with-values (lambda () (values 1 2 3)) (lambda (x) x))` were misreported as TypeErrors

Closes #268

## Test plan
- [x] New smoke test verifies arity mismatch is caught by `guard`
- [x] Full test suite passes (1509 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)