### PR TITLE
Fix #e on complex numbers and #i on bignums in reader

### DIFF
--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -348,6 +348,9 @@ fn applyExactness(tok: Token, exact: ?bool) ReadError!Token {
                 if (den == 1) break :blk Token{ .fixnum = num };
                 break :blk Token{ .rational = .{ .num = num, .den = den } };
             },
+            .complex => |c| blk: {
+                break :blk Token{ .complex = .{ .real = c.real, .imag = c.imag, .exact_real = true, .exact_imag = true } };
+            },
             else => ReadError.InvalidNumber,
         };
     }
@@ -355,6 +358,7 @@ fn applyExactness(tok: Token, exact: ?bool) ReadError!Token {
         .flonum, .complex => tok,
         .fixnum => |n| .{ .flonum = @floatFromInt(n) },
         .rational => |r| .{ .flonum = @as(f64, @floatFromInt(r.num)) / @as(f64, @floatFromInt(r.den)) },
+        .bignum_str => |bs| .{ .flonum = std.fmt.parseFloat(f64, bs.str) catch return ReadError.InvalidNumber },
         else => ReadError.InvalidNumber,
     };
 }

--- a/tests/scheme/smoke/exactness-prefix.scm
+++ b/tests/scheme/smoke/exactness-prefix.scm
@@ -1,0 +1,31 @@
+;; Regression tests for #e/#i exactness prefix handling
+;; Issue #296
+
+(import (scheme base) (scheme write))
+
+;; #e on complex numbers
+(display (exact? (make-rectangular (real-part #e1+2i) (imag-part #e1+2i)))) ; #t
+(newline)
+(display (= (real-part #e1+2i) 1)) ; #t
+(newline)
+(display (= (imag-part #e1+2i) 2)) ; #t
+(newline)
+
+;; #i on large integers (bignums)
+(display (inexact? #i99999999999999999999999999999)) ; #t
+(newline)
+(display (number? #i99999999999999999999999999999)) ; #t
+(newline)
+
+;; #e on flonum still works
+(display (exact? #e1.5))   ; #t
+(newline)
+(display (= #e1.5 3/2))   ; #t
+(newline)
+
+;; #i on fixnum still works
+(display (inexact? #i42))  ; #t
+(newline)
+
+(display "all passed")
+(newline)


### PR DESCRIPTION
## Summary
- `#e` prefix on complex numbers now marks both components as exact instead of rejecting with `InvalidNumber`
- `#i` prefix on bignums now converts the bignum string to a flonum instead of rejecting with `InvalidNumber`

Closes #296

## Test plan
- [x] New smoke test covers `#e1+2i`, `#i<bignum>`, `#e1.5`, `#i42`
- [x] Full test suite passes (1510 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)