### PR TITLE
Fix LLVM backend: when/unless emit correct phi predecessor blocks

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -543,17 +543,20 @@ pub const LLVMEmitter = struct {
         try self.print("  br label %{s}\n{s}:\n", .{ pre_label, pre_label });
         try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ cmp, body_label, merge_label });
         try self.print("{s}:\n", .{body_label});
+        self.current_block = body_label;
 
         var last: []const u8 = "";
         for (data.body) |expr| {
             last = try self.emitNode(expr);
         }
+        const body_end_block = self.current_block;
         try self.print("  br label %{s}\n", .{merge_label});
         try self.print("{s}:\n", .{merge_label});
+        self.current_block = merge_label;
 
         const void_val: i64 = @bitCast(types.VOID);
         const result = try self.freshTemp();
-        try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {d}, %{s} ]\n", .{ result, last, body_label, void_val, pre_label });
+        try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {d}, %{s} ]\n", .{ result, last, body_end_block, void_val, pre_label });
         return result;
     }
 
@@ -572,17 +575,20 @@ pub const LLVMEmitter = struct {
         try self.print("  br label %{s}\n{s}:\n", .{ pre_label, pre_label });
         try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ cmp, body_label, merge_label });
         try self.print("{s}:\n", .{body_label});
+        self.current_block = body_label;
 
         var last: []const u8 = "";
         for (data.body) |expr| {
             last = try self.emitNode(expr);
         }
+        const body_end_block = self.current_block;
         try self.print("  br label %{s}\n", .{merge_label});
         try self.print("{s}:\n", .{merge_label});
+        self.current_block = merge_label;
 
         const void_val: i64 = @bitCast(types.VOID);
         const result = try self.freshTemp();
-        try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {d}, %{s} ]\n", .{ result, last, body_label, void_val, pre_label });
+        try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {d}, %{s} ]\n", .{ result, last, body_end_block, void_val, pre_label });
         return result;
     }
 


### PR DESCRIPTION
## Summary
- Save `self.current_block` after body emission and use it as the phi predecessor instead of the static `body_label`
- When the body contains control flow (if, and, or), the actual predecessor block differs from the entry label, producing invalid LLVM IR

Closes #289

## Test plan
- [x] LLVM IR for `(when #t (if (> 1 0) ...))` now emits correct phi predecessor (`%merge1` instead of `%when_body0`)
- [x] Full test suite passes (1510 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)