### PR TITLE
Fix debugger break line number and up/down navigation

### DIFF
--- a/src/vm_debug.zig
+++ b/src/vm_debug.zig
@@ -76,7 +76,9 @@ pub fn debugPause(vm: *VM, frame: *CallFrame) !void {
             writeStderr(" (");
             writeStderr(src);
             var buf: [32]u8 = undefined;
-            const s = std.fmt.bufPrint(&buf, ":{d}", .{func.source_line}) catch "";
+            const ip = if (frame.ip > 0) frame.ip - 1 else 0;
+            const line = func.lineForOffset(ip);
+            const s = std.fmt.bufPrint(&buf, ":{d}", .{line}) catch "";
             writeStderr(s);
             writeStderr(")");
         }
@@ -128,8 +130,8 @@ pub fn debugPause(vm: *VM, frame: *CallFrame) !void {
             continue;
         }
         if (std.mem.eql(u8, cmd, "up")) {
-            if (vm.inspect_frame + 1 < vm.frame_count) {
-                vm.inspect_frame += 1;
+            if (vm.inspect_frame > 0) {
+                vm.inspect_frame -= 1;
                 printFrameInfo(vm, vm.inspect_frame);
             } else {
                 writeStderr("Already at top of stack\n");
@@ -137,8 +139,8 @@ pub fn debugPause(vm: *VM, frame: *CallFrame) !void {
             continue;
         }
         if (std.mem.eql(u8, cmd, "down")) {
-            if (vm.inspect_frame > 0) {
-                vm.inspect_frame -= 1;
+            if (vm.inspect_frame + 1 < vm.frame_count) {
+                vm.inspect_frame += 1;
                 printFrameInfo(vm, vm.inspect_frame);
             } else {
                 writeStderr("Already at bottom of stack\n");


### PR DESCRIPTION
## Summary

Two debugger fixes in `src/vm_debug.zig`:

- **Break line number (#264):** The "Break at foo (file.scm:N)" message used `func.source_line` (the function definition line) instead of the current execution line. Now uses `func.lineForOffset(ip)` matching the pattern already used in `vm.zig` for error reporting.

- **Up/down navigation (#263):** The `up` command incremented `inspect_frame` (toward callees) and `down` decremented (toward callers) — the opposite of GDB/LLDB convention. Swapped the direction logic so `up` moves toward callers and `down` toward callees.

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1510 pass, 0 fail

Closes #264
Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)