### PR TITLE
Add write barrier to set_upvalue and set_box_local opcodes

### DIFF
--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -232,8 +232,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const src_idx = try registerIndex(self, frame.base, src);
                 const uv = closure.upvalues[idx];
                 if (types.isPair(uv) and types.cdr(uv) == types.VOID) {
+                    self.gc.writeBarrier(types.toObject(uv), self.registers[src_idx]);
                     types.setCar(uv, self.registers[src_idx]);
                 } else {
+                    self.gc.writeBarrier(&closure.header, self.registers[src_idx]);
                     closure.upvalues[idx] = self.registers[src_idx];
                 }
             },
@@ -980,6 +982,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const src_idx = try registerIndex(self, frame.base, src);
                 const val = self.registers[reg_idx];
                 if (types.isPair(val) and types.cdr(val) == types.VOID) {
+                    self.gc.writeBarrier(types.toObject(val), self.registers[src_idx]);
                     types.setCar(val, self.registers[src_idx]);
                 } else {
                     const box = self.gc.allocPair(self.registers[src_idx], types.VOID) catch return VMError.OutOfMemory;

--- a/tests/scheme/smoke/upvalue-write-barrier.scm
+++ b/tests/scheme/smoke/upvalue-write-barrier.scm
@@ -1,0 +1,84 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (gc-pressure)
+  (let loop ((i 0))
+    (when (< i 5000)
+      (cons i (make-list 5 i))
+      (loop (+ i 1)))))
+
+;; Test 1: set! on a captured mutable variable (set_upvalue opcode, boxed case)
+(define (make-box init)
+  (let ((slot init))
+    (lambda (op . args)
+      (cond ((eq? op 'get) slot)
+            ((eq? op 'set!) (set! slot (car args)))))))
+
+(define b (make-box '()))
+(gc-pressure)
+(b 'set! (cons 'live 'value))
+(gc-pressure)
+(check "set_upvalue box survives GC" (b 'get) '(live . value))
+
+;; Test 2: multiple set! cycles on captured variable
+(define (make-counter)
+  (let ((n 0))
+    (lambda ()
+      (set! n (+ n 1))
+      n)))
+
+(define c (make-counter))
+(gc-pressure)
+(c)
+(gc-pressure)
+(c)
+(gc-pressure)
+(check "set_upvalue counter after GC" (c) 3)
+
+;; Test 3: set! storing a fresh heap object into a long-lived closure
+(define (make-accumulator)
+  (let ((acc '()))
+    (lambda (x)
+      (set! acc (cons x acc))
+      acc)))
+
+(define a (make-accumulator))
+(gc-pressure)
+(a (string-copy "one"))
+(gc-pressure)
+(a (string-copy "two"))
+(gc-pressure)
+(a (string-copy "three"))
+(gc-pressure)
+(let ((result (a (string-copy "four"))))
+  (check "set_upvalue accumulator length" (length result) 4)
+  (check "set_upvalue accumulator first" (car result) "four")
+  (check "set_upvalue accumulator last" (list-ref result 3) "one"))
+
+;; Test 4: set_box_local — local mutable variable re-bound in a loop
+(define (sum-with-mutation n)
+  (let ((total 0))
+    (let loop ((i 0))
+      (when (< i n)
+        (set! total (+ total i))
+        (gc-pressure)
+        (loop (+ i 1))))
+    total))
+
+(check "set_box_local loop mutation" (sum-with-mutation 10) 45)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "upvalue write barrier tests failed" fail))


### PR DESCRIPTION
## Summary

- Add `gc.writeBarrier()` calls before mutating upvalue boxes and closure upvalue slots in `set_upvalue` and `set_box_local` VM opcodes
- Without the barrier, old-generation boxes/closures holding young-generation values are not added to the remembered set, allowing minor GC to sweep the values (use-after-free)
- Add regression test exercising captured-variable mutation under GC pressure

## Test plan

- [x] New test `tests/scheme/smoke/upvalue-write-barrier.scm` — 6 checks covering boxed upvalue set!, counter mutation, accumulator pattern, and local box mutation under GC pressure
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite: 1511 pass, 0 fail

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)