### PR TITLE
Root intermediate results in vector-map/unfold/cumulate

### DIFF
--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -391,6 +391,9 @@ fn vectorMapFn(args: []const Value) PrimitiveError!Value {
     const results = gc.allocator.alloc(Value, min_len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(results);
 
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+
     var call_args: [256]Value = undefined;
     for (0..min_len) |i| {
         // Build argument list: one element from each vector
@@ -406,6 +409,7 @@ fn vectorMapFn(args: []const Value) PrimitiveError!Value {
                 else => PrimitiveError.TypeError, // bare-ok: catch fallback
             };
         };
+        gc.extra_roots.append(gc.allocator, results[i]) catch return PrimitiveError.OutOfMemory;
     }
 
     return gc.allocVector(results) catch return PrimitiveError.OutOfMemory;
@@ -727,6 +731,9 @@ fn vectorUnfoldFn(args: []const Value) PrimitiveError!Value {
     const new_data = gc.allocator.alloc(Value, length) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(new_data);
 
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+
     for (0..length) |i| {
         var call_args_buf: [257]Value = undefined;
         call_args_buf[0] = types.makeFixnum(@intCast(i));
@@ -745,6 +752,10 @@ fn vectorUnfoldFn(args: []const Value) PrimitiveError!Value {
             }
         } else {
             new_data[i] = result;
+        }
+        gc.extra_roots.append(gc.allocator, new_data[i]) catch return PrimitiveError.OutOfMemory;
+        for (seeds.items) |s| {
+            gc.extra_roots.append(gc.allocator, s) catch return PrimitiveError.OutOfMemory;
         }
     }
     return gc.allocVector(new_data) catch return PrimitiveError.OutOfMemory;
@@ -768,6 +779,9 @@ fn vectorUnfoldRightFn(args: []const Value) PrimitiveError!Value {
     const new_data = gc.allocator.alloc(Value, length) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(new_data);
 
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+
     // Fill from right to left (index length-1 down to 0)
     var i = length;
     while (i > 0) {
@@ -786,6 +800,10 @@ fn vectorUnfoldRightFn(args: []const Value) PrimitiveError!Value {
             }
         } else {
             new_data[i] = result;
+        }
+        gc.extra_roots.append(gc.allocator, new_data[i]) catch return PrimitiveError.OutOfMemory;
+        for (seeds.items) |s| {
+            gc.extra_roots.append(gc.allocator, s) catch return PrimitiveError.OutOfMemory;
         }
     }
     return gc.allocVector(new_data) catch return PrimitiveError.OutOfMemory;
@@ -851,10 +869,13 @@ fn vectorCumulateFn(args: []const Value) PrimitiveError!Value {
     const vec = types.toVector(args[2]);
     const new_data = gc.allocator.alloc(Value, vec.data.len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(new_data);
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
     for (0..vec.data.len) |i| {
         const call_args_buf = [2]Value{ acc, vec.data[i] };
         acc = try callVM(f, &call_args_buf);
         new_data[i] = acc;
+        gc.extra_roots.append(gc.allocator, acc) catch return PrimitiveError.OutOfMemory;
     }
     return gc.allocVector(new_data) catch return PrimitiveError.OutOfMemory;
 }

--- a/tests/scheme/smoke/vector-map-gc.scm
+++ b/tests/scheme/smoke/vector-map-gc.scm
@@ -1,0 +1,69 @@
+(import (scheme base) (scheme write) (srfi 133))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; Test 1: vector-map — mapping proc allocates heap objects
+(let ((v (make-vector 200 0)))
+  (do ((i 0 (+ i 1))) ((= i 200)) (vector-set! v i i))
+  (let ((out (vector-map
+              (lambda (x)
+                (make-list 5 x))
+              v)))
+    (check "vector-map length" (vector-length out) 200)
+    (check "vector-map first" (vector-ref out 0) '(0 0 0 0 0))
+    (check "vector-map last" (vector-ref out 199) '(199 199 199 199 199))
+    (check "vector-map mid" (car (vector-ref out 100)) 100)))
+
+;; Test 2: vector-map with string allocation
+(let* ((v (vector 1 2 3 4 5))
+       (out (vector-map
+             (lambda (x)
+               (make-string (* x 10) #\a))
+             v)))
+  (check "vector-map string lengths"
+         (vector->list (vector-map string-length out))
+         '(10 20 30 40 50)))
+
+;; Test 3: vector-cumulate — accumulator is a heap value
+(let* ((v (vector 1 2 3 4 5))
+       (out (vector-cumulate
+             (lambda (acc x) (cons x acc))
+             '()
+             v)))
+  (check "vector-cumulate last" (vector-ref out 4) '(5 4 3 2 1))
+  (check "vector-cumulate first" (vector-ref out 0) '(1)))
+
+;; Test 4: vector-unfold — results and seeds are heap values
+(let ((out (vector-unfold
+            (lambda (i seed)
+              (values (cons i seed) (+ seed 1)))
+            5
+            100)))
+  (check "vector-unfold length" (vector-length out) 5)
+  (check "vector-unfold first" (vector-ref out 0) '(0 . 100))
+  (check "vector-unfold last" (vector-ref out 4) '(4 . 104)))
+
+;; Test 5: vector-unfold-right
+(let ((out (vector-unfold-right
+            (lambda (i seed)
+              (values (list i seed) (* seed 2)))
+            4
+            1)))
+  (check "vector-unfold-right length" (vector-length out) 4)
+  (check "vector-unfold-right elem 0" (vector-ref out 0) '(0 8))
+  (check "vector-unfold-right elem 3" (vector-ref out 3) '(3 1)))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "vector-map GC tests failed" fail))


### PR DESCRIPTION
## Summary

- Root intermediate results via `gc.extra_roots` in `vectorMapFn`, `vectorUnfoldFn`, `vectorUnfoldRightFn`, and `vectorCumulateFn`
- These functions accumulate results in plain allocator buffers invisible to the GC; callbacks that trigger collection can sweep earlier results (use-after-free)
- Uses the save/restore `extra_roots` base pattern already used by `reader_datum.zig` and `compiler.zig`

## Test plan

- [x] New test `tests/scheme/smoke/vector-map-gc.scm` — 13 checks covering vector-map, vector-cumulate, vector-unfold, and vector-unfold-right with heap-allocating callbacks
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite: 1512 pass, 0 fail

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)