### PR TITLE
Root squared base in bignum expt to prevent use-after-free

### DIFF
--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -461,21 +461,21 @@ pub fn expt(gc: *memory.GC, base_val: Value, exp_val: Value) !Value {
     var b = base_val;
     var e: u64 = @intCast(exp);
 
-    // Root the intermediate values
+    // Root both intermediates — result and the squared base
+    const roots_base = gc.extra_roots.items.len;
     gc.extra_roots.append(gc.allocator, result) catch return error.OutOfMemory;
-    defer {
-        if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-    }
+    gc.extra_roots.append(gc.allocator, b) catch return error.OutOfMemory;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
 
     while (e > 0) {
         if (e & 1 == 1) {
             result = try mul(gc, result, b);
-            // Update the root
-            gc.extra_roots.items[gc.extra_roots.items.len - 1] = result;
+            gc.extra_roots.items[roots_base] = result;
         }
         e >>= 1;
         if (e > 0) {
             b = try mul(gc, b, b);
+            gc.extra_roots.items[roots_base + 1] = b;
         }
     }
     return result;

--- a/tests/scheme/smoke/bignum-expt-gc.scm
+++ b/tests/scheme/smoke/bignum-expt-gc.scm
@@ -1,0 +1,35 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; expt with large bignums — squared base must survive GC
+(check "7^20" (expt 7 20) 79792266297612001)
+(check "10^30" (expt 10 30) 1000000000000000000000000000000)
+(check "2^100" (expt 2 100) 1267650600228229401496703205376)
+(check "3^50" (expt 3 50) 717897987691852588770249)
+(check "(-2)^31" (expt -2 31) -2147483648)
+(check "(-3)^19" (expt -3 19) -1162261467)
+
+;; Allocate many objects to push GC threshold, then compute large expt
+(define keep (make-vector 4000 #f))
+(do ((i 0 (+ i 1))) ((= i 4000))
+  (vector-set! keep i (list i)))
+
+(check "7^100 after heap pressure"
+  (expt 7 100)
+  3234476509624757991344647769100216810857203198904625400933895331391691459636928060001)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "bignum expt GC tests failed" fail))


### PR DESCRIPTION
## Summary

- Root both `result` and squared base `b` in `bignum.expt` via `gc.extra_roots`
- Previously only `result` was rooted; `b` could be collected after `b = mul(gc, b, b)` when the next `mul(gc, result, b)` triggers GC
- Uses save/restore pattern with indexed updates for both slots

## Test plan

- [x] New test `tests/scheme/smoke/bignum-expt-gc.scm` — 7 checks including large exponents (7^100) under heap pressure
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite: 1513 pass, 0 fail

Fixes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)