### PR TITLE
Validate mode/uid/gid range in filesystem primitives

### DIFF
--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -18,6 +18,26 @@ extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int
 extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 const is_linux = @import("builtin").os.tag == .linux;
 
+fn validateMode(gc: *GC, val: Value) PrimitiveError!std.c.mode_t {
+    if (!types.isFixnum(val)) return primitives.typeError("set-file-mode", "integer", val);
+    const n = types.toFixnum(val);
+    if (n < 0 or n > std.math.maxInt(std.c.mode_t)) {
+        _ = try raiseFileError(gc, "mode value out of range", val);
+        unreachable;
+    }
+    return @truncate(@as(u64, @intCast(n)));
+}
+
+fn validateUid(gc: *GC, val: Value) PrimitiveError!std.c.uid_t {
+    const n = types.toFixnum(val);
+    if (n == -1) return @bitCast(@as(u32, 0xFFFFFFFF));
+    if (n < 0 or n > std.math.maxInt(std.c.uid_t)) {
+        _ = try raiseFileError(gc, "uid/gid value out of range", val);
+        unreachable;
+    }
+    return @truncate(@as(u64, @intCast(n)));
+}
+
 const StatResult = struct {
     mode: u32,
     size: i64,
@@ -260,10 +280,10 @@ fn fileInfoFn(args: []const Value) PrimitiveError!Value {
         .mtime = sr.mtime_sec,
         .atime = sr.atime_sec,
         .ctime = sr.ctime_sec,
-        .dev = @intCast(sr.dev),
-        .ino = @intCast(sr.ino),
-        .nlinks = @intCast(sr.nlinks),
-        .rdev = @intCast(sr.rdev),
+        .dev = @bitCast(sr.dev),
+        .ino = @bitCast(sr.ino),
+        .nlinks = @bitCast(sr.nlinks),
+        .rdev = @bitCast(sr.rdev),
         .blksize = @intCast(sr.blksize),
         .blocks = 0,
         .mode = sr.mode,
@@ -390,7 +410,7 @@ fn createDirectoryFn(args: []const Value) PrimitiveError!Value {
     const path = extractPath(args[0]) orelse return primitives.typeError("create-directory", "string", args[0]);
 
     const mode: std.c.mode_t = if (args.len > 1 and types.isFixnum(args[1]))
-        @intCast(@as(u64, @bitCast(types.toFixnum(args[1]))))
+        try validateMode(gc, args[1])
     else
         0o755;
 
@@ -506,7 +526,7 @@ fn setFileModeFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const mode: std.c.mode_t = @intCast(@as(u64, @bitCast(types.toFixnum(args[1]))));
+    const mode = try validateMode(gc, args[1]);
     if (std.c.chmod(path_z, mode) != 0) {
         return raiseFileError(gc, "cannot set file mode", args[0]);
     }
@@ -533,7 +553,7 @@ fn createFifoFn(args: []const Value) PrimitiveError!Value {
     const path = extractPath(args[0]) orelse return primitives.typeError("create-fifo", "string", args[0]);
 
     const mode: std.c.mode_t = if (args.len > 1 and types.isFixnum(args[1]))
-        @intCast(@as(u64, @bitCast(types.toFixnum(args[1]))))
+        try validateMode(gc, args[1])
     else
         0o664;
 
@@ -555,10 +575,8 @@ fn setFileOwnerFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const uid_val = types.toFixnum(args[1]);
-    const gid_val = types.toFixnum(args[2]);
-    const owner: std.c.uid_t = if (uid_val < 0) @bitCast(@as(u32, 0xFFFFFFFF)) else @intCast(@as(u64, @bitCast(uid_val)));
-    const group: std.c.gid_t = if (gid_val < 0) @bitCast(@as(u32, 0xFFFFFFFF)) else @intCast(@as(u64, @bitCast(gid_val)));
+    const owner: std.c.uid_t = try validateUid(gc, args[1]);
+    const group: std.c.gid_t = try validateUid(gc, args[2]);
 
     if (chown(path_z, owner, group) != 0) {
         return raiseFileError(gc, "cannot set file owner", args[0]);
@@ -627,8 +645,9 @@ fn umaskFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn setUmaskFn(args: []const Value) PrimitiveError!Value {
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[0])) return primitives.typeError("set-umask!", "integer", args[0]);
-    const mask: std.c.mode_t = @intCast(@as(u64, @bitCast(types.toFixnum(args[0]))));
+    const mask = try validateMode(gc, args[0]);
     _ = std.c.umask(mask);
     return types.VOID;
 }

--- a/tests/scheme/smoke/filesystem-intcast.scm
+++ b/tests/scheme/smoke/filesystem-intcast.scm
@@ -1,0 +1,61 @@
+(import (scheme base) (scheme write) (srfi 170))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (check-error name thunk)
+  (guard (exn (#t (set! pass (+ pass 1))))
+    (thunk)
+    (set! fail (+ fail 1))
+    (display "FAIL: ") (display name) (display " did not raise error") (newline)))
+
+(define test-file "/tmp/kaappi-intcast-test.txt")
+(call-with-output-file test-file (lambda (p) (write-char #\x p)))
+
+;; set-file-mode with negative value should raise error, not crash
+(check-error "set-file-mode negative"
+  (lambda () (set-file-mode test-file -1)))
+
+;; set-file-mode with value larger than u16 max should raise error
+(check-error "set-file-mode too large"
+  (lambda () (set-file-mode test-file 100000)))
+
+;; set-file-mode with valid value should work
+(set-file-mode test-file #o644)
+(check "set-file-mode valid" #t #t)
+
+;; set-umask! with negative value should raise error
+(check-error "set-umask! negative"
+  (lambda () (set-umask! -1)))
+
+;; set-umask! with value too large should raise error
+(check-error "set-umask! too large"
+  (lambda () (set-umask! 100000)))
+
+;; set-umask! with valid value should work
+(let ((old (umask)))
+  (set-umask! #o022)
+  (let ((cur (umask)))
+    (set-umask! old)
+    (check "set-umask! valid" cur #o022)))
+
+;; create-directory with negative mode should raise error
+(check-error "create-directory negative mode"
+  (lambda () (create-directory "/tmp/kaappi-intcast-dir" -1)))
+
+;; Clean up
+(delete-file test-file)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "filesystem intcast tests failed" fail))


### PR DESCRIPTION
## Summary

- Add `validateMode` and `validateUid` helpers that range-check fixnum values before narrowing to `mode_t`/`uid_t`/`gid_t`, raising a recoverable Scheme-level file error instead of crashing
- Fixes 5 primitives: `set-file-mode`, `create-directory`, `create-fifo`, `set-umask!`, `set-file-owner`
- Use `@bitCast` instead of `@intCast` for `u64→i64` fields (dev, ino, nlinks, rdev) in file-info construction

## Test plan

- [x] New test `tests/scheme/smoke/filesystem-intcast.scm` — 7 checks: negative mode, too-large mode, valid mode, negative umask, too-large umask, valid umask, negative create-directory mode
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite: 1514 pass, 0 fail

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)