### PR TITLE
Read st_blocks from stat into file-info:blocks

### DIFF
--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -49,6 +49,7 @@ const StatResult = struct {
     nlinks: u64,
     rdev: u64,
     blksize: i64,
+    blocks: i64,
     uid: u32,
     gid: u32,
 };
@@ -77,6 +78,7 @@ fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
             .nlinks = sx.nlink,
             .rdev = makedev(sx.rdev_major, sx.rdev_minor),
             .blksize = @intCast(sx.blksize),
+            .blocks = @intCast(sx.blocks),
             .uid = sx.uid,
             .gid = sx.gid,
         };
@@ -96,6 +98,7 @@ fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
             .nlinks = @intCast(stat_buf.nlink),
             .rdev = @intCast(stat_buf.rdev),
             .blksize = @intCast(stat_buf.blksize),
+            .blocks = @intCast(stat_buf.blocks),
             .uid = stat_buf.uid,
             .gid = stat_buf.gid,
         };
@@ -285,7 +288,7 @@ fn fileInfoFn(args: []const Value) PrimitiveError!Value {
         .nlinks = @bitCast(sr.nlinks),
         .rdev = @bitCast(sr.rdev),
         .blksize = @intCast(sr.blksize),
-        .blocks = 0,
+        .blocks = sr.blocks,
         .mode = sr.mode,
         .uid = sr.uid,
         .gid = sr.gid,

--- a/tests/scheme/smoke/file-info-blocks.scm
+++ b/tests/scheme/smoke/file-info-blocks.scm
@@ -1,0 +1,42 @@
+(import (scheme base) (scheme write) (srfi 170))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define test-file "/tmp/kaappi-blocks-test.txt")
+
+;; Write enough data to occupy multiple disk blocks
+(call-with-output-file test-file
+  (lambda (p) (write-string (make-string 100000 #\a) p)))
+
+(define fi (file-info test-file))
+
+(check "file-info:size" (file-info:size fi) 100000)
+
+;; blocks should be a positive integer for a 100KB file
+(check "file-info:blocks is number" (number? (file-info:blocks fi)) #t)
+(check "file-info:blocks > 0" (> (file-info:blocks fi) 0) #t)
+
+;; An empty file should have 0 blocks (or very few)
+(define empty-file "/tmp/kaappi-blocks-empty.txt")
+(call-with-output-file empty-file (lambda (p) (values)))
+(define fi2 (file-info empty-file))
+(check "empty file blocks >= 0" (>= (file-info:blocks fi2) 0) #t)
+
+;; Clean up
+(delete-file test-file)
+(delete-file empty-file)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "file-info:blocks tests failed" fail))


### PR DESCRIPTION
## Summary

- Add `blocks` field to `StatResult` struct
- Read `blocks` from `statx` (Linux) and `stat` (macOS) in `doStat`
- Pass `sr.blocks` to `allocFileInfo` instead of hard-coding `0`
- `file-info:blocks` now returns the actual allocated block count per SRFI-170

## Test plan

- [x] New test `tests/scheme/smoke/file-info-blocks.scm` — 4 checks: size correctness, blocks is a number, blocks > 0 for 100KB file, blocks >= 0 for empty file
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite: 1515 pass, 0 fail

Fixes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)