### PR TITLE
Fix printer freeing string literal on bignum toString failure

### DIFF
--- a/src/printer.zig
+++ b/src/printer.zig
@@ -656,7 +656,10 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
             .bignum => {
                 const bignum_mod = @import("bignum.zig");
                 const allocator = std.heap.page_allocator;
-                const s = bignum_mod.toString(allocator, value) catch "?bignum?";
+                const s = bignum_mod.toString(allocator, value) catch {
+                    try writer.writeAll("?bignum?");
+                    return;
+                };
                 defer allocator.free(s);
                 try writer.writeAll(s);
             },


### PR DESCRIPTION
## Summary
- When `bignum.toString` fails (OOM), the catch fallback assigned a string literal to `s`, and `defer allocator.free(s)` would free read-only static memory (UB)
- Handle the error explicitly: write fallback string directly and return

## Test plan
- [x] Unit tests pass
- [x] All Scheme tests pass

Fixes #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)