### PR TITLE
Reject string-set! at index 0 on empty string

### DIFF
--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -197,6 +197,7 @@ fn stringSetFn(args: []const Value) PrimitiveError!Value {
     const char_idx: usize = @intCast(k);
     const byte_start = utf8IndexToByteOffset(data, char_idx) orelse return PrimitiveError.IndexOutOfBounds;
     const old_cp_len = utf8ByteLenAt(data, byte_start);
+    if (old_cp_len == 0) return PrimitiveError.IndexOutOfBounds;
     if (byte_start + old_cp_len > data.len) return primitives.typeError("string-set!", "valid UTF-8 string", args[0]);
 
     const new_cp = types.toChar(args[2]);


### PR DESCRIPTION
## Summary
- `string-set!` on an empty string at index 0 silently succeeded, growing the string from length 0 to 1
- Per R7RS, index 0 on an empty string is out of bounds (0 <= k < 0 is false)
- Fix: check that `old_cp_len > 0` (there is actually a character to replace)

## Test plan
- [x] `(string-set! (string-copy "") 0 #\x)` now raises IndexOutOfBounds
- [x] All tests pass

Fixes #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)