### PR TITLE
Validate vector-append-subvectors indices are non-negative and in bounds

### DIFF
--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -920,8 +920,15 @@ fn vectorAppendSubvectorsFn(args: []const Value) PrimitiveError!Value {
         if (!types.isVector(args[i])) return primitives.typeError("vector-append-subvectors", "vector", args[i]);
         if (!types.isFixnum(args[i + 1])) return primitives.typeError("vector-append-subvectors", "integer", args[i + 1]);
         if (!types.isFixnum(args[i + 2])) return primitives.typeError("vector-append-subvectors", "integer", args[i + 2]);
-        const start: usize = @intCast(types.toFixnum(args[i + 1]));
-        const end: usize = @intCast(types.toFixnum(args[i + 2]));
+        const s = types.toFixnum(args[i + 1]);
+        const e = types.toFixnum(args[i + 2]);
+        if (s < 0) return primitives.typeError("vector-append-subvectors", "non-negative integer", args[i + 1]);
+        if (e < 0) return primitives.typeError("vector-append-subvectors", "non-negative integer", args[i + 2]);
+        const start: usize = @intCast(s);
+        const end: usize = @intCast(e);
+        const vec_len = types.toVector(args[i]).data.len;
+        if (start > vec_len) return PrimitiveError.IndexOutOfBounds;
+        if (end > vec_len) return PrimitiveError.IndexOutOfBounds;
         if (end < start) return primitives.typeError("vector-append-subvectors", "valid range (end >= start)", args[i + 2]);
         total += end - start;
     }


### PR DESCRIPTION
## Summary
- Negative start/end indices caused `@intCast` panic (integer doesn't fit in usize)
- Out-of-bounds end indices caused slice panic (`index 100, len 3`)
- Add explicit negative and bounds checks before the casts

## Test plan
- [x] `(vector-append-subvectors #(1 2 3) -1 2)` raises error instead of crashing
- [x] `(vector-append-subvectors #(1 2 3) 0 100)` raises error instead of crashing
- [x] All tests pass

Fixes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)