### PR TITLE
Root allocated string in string-split empty-delimiter path

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -306,8 +306,13 @@ fn stringSplitFn(args: []const Value) PrimitiveError!Value {
             while (start > 0 and (data[start] & 0xC0) == 0x80) {
                 start -= 1;
             }
-            const s = gc.allocString(data[start..byte_i]) catch return PrimitiveError.OutOfMemory;
-            result = gc.allocPair(s, result) catch return PrimitiveError.OutOfMemory;
+            var str_val = gc.allocString(data[start..byte_i]) catch return PrimitiveError.OutOfMemory;
+            gc.pushRoot(&str_val) catch return PrimitiveError.OutOfMemory;
+            result = gc.allocPair(str_val, result) catch {
+                gc.popRoot();
+                return PrimitiveError.OutOfMemory;
+            };
+            gc.popRoot();
             byte_i = start;
         }
         return result;


### PR DESCRIPTION
## Summary
- Empty-delimiter path in `string-split` allocated a string then passed it to `allocPair` without GC-rooting
- If `allocPair` triggers collection, the string could be swept (use-after-free)
- Root the string value before `allocPair`, matching the non-empty delimiter path

## Test plan
- [x] All tests pass

Fixes #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)