### PR TITLE
Raise read error on file port syntax errors instead of returning EOF

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -651,7 +651,17 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
     // Parse one datum
     var reader = reader_mod.Reader.init(gc, buf.items);
     defer reader.deinit();
-    const datum = reader.readDatum() catch return types.EOF;
+    const datum = reader.readDatum() catch |err| {
+        if (err == reader_mod.ReadError.UnexpectedEof or err == reader_mod.ReadError.OutOfMemory) return types.EOF;
+        var msg = gc.allocString("read error") catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
+        defer gc.popRoot();
+        const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.OutOfMemory;
+        const errObj = types.toObject(err_obj).as(types.ErrorObject);
+        errObj.error_type = .read;
+        const raise_args = [1]Value{err_obj};
+        return primitives_control.raiseFn(&raise_args);
+    };
 
     // Save unconsumed bytes back to port buffer
     const remaining = buf.items[reader.pos..];


### PR DESCRIPTION
## Summary
- File port path in `readDatumFn` caught ALL reader errors as EOF, silently swallowing parse errors
- Apply the same error handling as the string port path: only EOF and OOM return `#<eof>`, everything else raises a read error
- Per R7RS 6.13.2, `read` should signal an error for invalid external representations

## Test plan
- [x] File port `(read)` on `)` now raises read error instead of returning EOF
- [x] String port behavior unchanged
- [x] All tests pass

Fixes #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)