### PR TITLE
Process vector unquotes in quasiquote splicing context

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -616,6 +616,12 @@ fn buildQQListExpr(gc: *@import("memory.zig").GC, quote_sym: Value, list_sym: Va
             args = gc.allocPair(wrapped, args) catch return CompileError.OutOfMemory;
             continue;
         }
+        // Vector: wrap in (quasiquote elem) so nested unquotes are processed
+        if (types.isVector(elem)) {
+            const wrapped = gc.allocPair(qq_sym, gc.allocPair(elem, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            args = gc.allocPair(wrapped, args) catch return CompileError.OutOfMemory;
+            continue;
+        }
         // Atom: wrap in (quote elem)
         const quoted = gc.allocPair(quote_sym, gc.allocPair(elem, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
         args = gc.allocPair(quoted, args) catch return CompileError.OutOfMemory;


### PR DESCRIPTION
## Summary
- When a vector with unquotes appeared in a quasiquote list alongside `unquote-splicing`, the vector was wrapped in `(quote ...)` which suppressed unquote evaluation
- Vectors now wrapped in `(quasiquote ...)` so the recursive `compileQQ` vector path processes nested unquotes
- Example: `` `(,@ys #(c ,x)) `` now correctly evaluates to `(1 2 #(c 42))`

## Test plan
- [x] `` `(,@ys #(c ,x)) `` → `(1 2 #(c 42))`
- [x] All tests pass

Fixes #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)