### PR TITLE
Accept char arguments as criterion in SRFI-13 string functions

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -97,6 +97,10 @@ fn isWhitespace(c: u8) bool {
 /// Call a predicate or char-set-contains? with a character.
 /// Handles both procedure arguments and SRFI-14 char-set record arguments.
 fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
+    if (types.isChar(pred)) {
+        return types.toChar(pred) == cp;
+    }
+
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const char_val = types.makeChar(cp);
 


### PR DESCRIPTION
## Summary
- SRFI-13 criterion parameter accepts char, char-set, or procedure
- `callPredOrCharset` only handled procedures and char-sets, rejecting plain characters with a type error
- Add char check: compare codepoints directly when the criterion is a character

## Test plan
- [x] `(string-trim "***hello" #\*)` → `"hello"`
- [x] `(string-index "hello" #\l)` → `2`
- [x] `(string-filter #\l "hello")` → `"ll"`
- [x] `(string-count "hello" #\l)` → `2`
- [x] All tests pass

Fixes #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)