### PR TITLE
Escape control characters in write mode for strings and symbols

### DIFF
--- a/src/printer.zig
+++ b/src/printer.zig
@@ -439,8 +439,18 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                 if (mode != .display and symbolNeedsBars(sym.name)) {
                     try writer.writeByte('|');
                     for (sym.name) |c| {
-                        if (c == '|' or c == '\\') try writer.writeByte('\\');
-                        try writer.writeByte(c);
+                        if (c == '|' or c == '\\') {
+                            try writer.writeByte('\\');
+                            try writer.writeByte(c);
+                        } else if (c < 0x20 or c == 0x7F) {
+                            try writer.writeAll("\\x");
+                            const hex = "0123456789abcdef";
+                            try writer.writeByte(hex[c >> 4]);
+                            try writer.writeByte(hex[c & 0x0F]);
+                            try writer.writeByte(';');
+                        } else {
+                            try writer.writeByte(c);
+                        }
                     }
                     try writer.writeByte('|');
                 } else {
@@ -460,7 +470,17 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                             '\t' => try writer.writeAll("\\t"),
                             0x07 => try writer.writeAll("\\a"),
                             0x08 => try writer.writeAll("\\b"),
-                            else => try writer.writeByte(c),
+                            else => {
+                                if (c < 0x20 or c == 0x7F) {
+                                    try writer.writeAll("\\x");
+                                    const hex = "0123456789abcdef";
+                                    try writer.writeByte(hex[c >> 4]);
+                                    try writer.writeByte(hex[c & 0x0F]);
+                                    try writer.writeByte(';');
+                                } else {
+                                    try writer.writeByte(c);
+                                }
+                            },
                         }
                     }
                     try writer.writeByte('"');


### PR DESCRIPTION
## Summary
- `write` output raw control bytes inside string literals and pipe-quoted symbols
- This broke the `write`/`read` round-trip invariant (R7RS 6.13.3)
- Escape bytes where `c < 0x20` or `c == 0x7F` (excluding already-handled \a, \b, \t, \n, \r) using `\xNN;` hex notation per R7RS 7.1.1

## Test plan
- [x] `(write (string (integer->char 0)))` → `"\x00;"`
- [x] `(write (string (integer->char 27)))` → `"\x1b;"`
- [x] All tests pass

Fixes #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)