### PR TITLE
Distinguish char-special and block-special in file-info-type

### DIFF
--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -274,7 +274,8 @@ fn fileInfoFn(args: []const Value) PrimitiveError!Value {
         if (masked == S.IFLNK) break :blk .symlink;
         if (masked == S.IFIFO) break :blk .fifo;
         if (masked == S.IFSOCK) break :blk .socket;
-        if (masked == S.IFCHR or masked == S.IFBLK) break :blk .device;
+        if (masked == S.IFCHR) break :blk .char_device;
+        if (masked == S.IFBLK) break :blk .block_device;
         break :blk .other;
     };
 
@@ -400,7 +401,8 @@ fn fileInfoSocketP(args: []const Value) PrimitiveError!Value {
 
 fn fileInfoDeviceP(args: []const Value) PrimitiveError!Value {
     if (!types.isFileInfo(args[0])) return primitives.typeError("file-info-device?", "file-info", args[0]);
-    return if (types.toFileInfo(args[0]).file_type == .device) types.TRUE else types.FALSE;
+    const ft = types.toFileInfo(args[0]).file_type;
+    return if (ft == .char_device or ft == .block_device) types.TRUE else types.FALSE;
 }
 
 // -------------------------------------------------------------------------
@@ -953,7 +955,8 @@ fn fileInfoTypeFn(args: []const Value) PrimitiveError!Value {
         .symlink => "symlink",
         .fifo => "fifo",
         .socket => "socket",
-        .device => "block-special",
+        .char_device => "char-special",
+        .block_device => "block-special",
         .other => "unknown",
     };
     return gc.allocSymbol(name) catch return PrimitiveError.OutOfMemory;

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -697,7 +697,8 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                     .symlink => "symlink",
                     .fifo => "fifo",
                     .socket => "socket",
-                    .device => "device",
+                    .char_device => "char-device",
+                    .block_device => "block-device",
                     .other => "other",
                 };
                 try writer.print("#<file-info {s} size={d} mode={o}>", .{ kind, fi.size, fi.mode });

--- a/src/types.zig
+++ b/src/types.zig
@@ -557,7 +557,7 @@ pub const FileInfo = struct {
     gid: u32,
     file_type: FileType,
 
-    pub const FileType = enum(u8) { regular, directory, symlink, fifo, socket, device, other };
+    pub const FileType = enum(u8) { regular, directory, symlink, fifo, socket, char_device, block_device, other };
 };
 
 pub const UserInfo = struct {


### PR DESCRIPTION
## Summary
- `file-info-type` returned `block-special` for character devices like `/dev/null`
- Split `FileType.device` into `.char_device` and `.block_device`
- `file-info-type` now returns `char-special` for `S_IFCHR` and `block-special` for `S_IFBLK`
- `file-info-device?` updated to check both variants

## Test plan
- [x] `(file-info-type (file-info "/dev/null"))` → `char-special`
- [x] `(file-info-device? (file-info "/dev/null"))` → `#t`
- [x] All tests pass

Fixes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)