### PR TITLE
Fix GC markObjectContents missing types causing use-after-free

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -109,7 +109,127 @@ fn referencesYoung(obj: *Object) bool {
                 }
             }
         },
-        else => return true,
+        .closure => {
+            const cls = obj.as(Closure);
+            for (cls.upvalues) |uv| {
+                if (isYoungPointer(uv)) return true;
+            }
+        },
+        .promise => {
+            if (isYoungPointer(obj.as(Promise).value)) return true;
+        },
+        .parameter => {
+            const param = obj.as(types.ParameterObject);
+            if (isYoungPointer(param.value) or isYoungPointer(param.converter)) return true;
+        },
+        .transformer => {
+            const tx = obj.as(Transformer);
+            for (tx.literals) |lit| {
+                if (isYoungPointer(lit)) return true;
+            }
+            for (tx.patterns) |pat| {
+                if (isYoungPointer(pat)) return true;
+            }
+            for (tx.templates) |tmpl| {
+                if (isYoungPointer(tmpl)) return true;
+            }
+        },
+        .error_object => {
+            const err = obj.as(types.ErrorObject);
+            if (isYoungPointer(err.message) or isYoungPointer(err.irritants) or isYoungPointer(err.uncaught_reason)) return true;
+        },
+        .continuation => {
+            const cont = obj.as(Continuation);
+            for (cont.registers) |reg| {
+                if (isYoungPointer(reg)) return true;
+            }
+            for (cont.frames[0..cont.frame_count]) |frame| {
+                if (frame.closure) |cls| {
+                    if (isYoungPointer(types.makePointer(@ptrCast(cls)))) return true;
+                }
+                if (frame.native) |nf| {
+                    if (isYoungPointer(types.makePointer(@ptrCast(nf)))) return true;
+                }
+            }
+            for (cont.handlers[0..cont.handler_count]) |handler| {
+                if (isYoungPointer(handler.handler)) return true;
+            }
+            for (cont.wind_records[0..cont.wind_count]) |wr| {
+                if (isYoungPointer(wr.before) or isYoungPointer(wr.after)) return true;
+            }
+        },
+        .multiple_values => {
+            const mv = obj.as(MultipleValues);
+            for (mv.values) |val| {
+                if (isYoungPointer(val)) return true;
+            }
+        },
+        .rational => {
+            const rat = obj.as(Rational);
+            if (isYoungPointer(rat.numerator) or isYoungPointer(rat.denominator)) return true;
+        },
+        .ffi_function => {
+            if (isYoungPointer(obj.as(FfiFunction).library)) return true;
+        },
+        .ffi_callback => {
+            if (isYoungPointer(obj.as(FfiCallback).closure)) return true;
+        },
+        .fiber => {
+            const fiber_mod = @import("fiber.zig");
+            const fiber = obj.as(fiber_mod.Fiber);
+            if (isYoungPointer(fiber.thunk) or isYoungPointer(fiber.result) or
+                isYoungPointer(fiber.waiting_on) or isYoungPointer(fiber.name) or
+                isYoungPointer(fiber.specific)) return true;
+            if (fiber.current_exception) |exc| {
+                if (isYoungPointer(exc)) return true;
+            }
+            if (isYoungPointer(fiber.continuation_value)) return true;
+            for (fiber.frames[0..fiber.frame_count]) |f| {
+                if (f.closure) |cls| {
+                    if (isYoungPointer(types.makePointer(@ptrCast(cls)))) return true;
+                }
+                const window: usize = if (f.closure) |cls| blk: {
+                    const lc = cls.func.locals_count;
+                    break :blk if (lc == 0) 256 else @as(usize, lc);
+                } else 256;
+                const vm_mod = @import("vm.zig");
+                const end: usize = @min(@as(usize, f.base) + window, vm_mod.MAX_REGISTERS);
+                var r: usize = f.base;
+                while (r < end) : (r += 1) {
+                    if (isYoungPointer(fiber.registers[r])) return true;
+                }
+            }
+        },
+        .channel => {
+            const ch = obj.as(types.Channel);
+            if (isYoungPointer(ch.head) or isYoungPointer(ch.tail)) return true;
+        },
+        .mutex => {
+            const m = obj.as(types.Mutex);
+            if (isYoungPointer(m.name) or isYoungPointer(m.owner) or isYoungPointer(m.specific)) return true;
+        },
+        .condition_variable => {
+            const cv = obj.as(types.ConditionVariable);
+            if (isYoungPointer(cv.name) or isYoungPointer(cv.specific)) return true;
+        },
+        .function => {
+            const func = obj.as(Function);
+            for (func.constants.items) |c| {
+                if (isYoungPointer(c)) return true;
+            }
+            if (func.global_cache) |cache| {
+                for (cache) |c| {
+                    if (isYoungPointer(c)) return true;
+                }
+            }
+        },
+        .native_closure => {
+            const nc = obj.as(types.NativeClosure);
+            for (nc.upvalues) |uv| {
+                if (isYoungPointer(uv)) return true;
+            }
+        },
+        .symbol, .string, .native_fn, .flonum, .port, .complex, .bytevector, .bignum, .record_type, .ffi_library, .file_info, .user_info, .group_info, .directory_object, .random_source, .srfi18_time => {},
     }
     return false;
 }
@@ -224,7 +344,90 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
             const ri = obj.as(RecordInstance);
             for (ri.fields) |field| markValue(gc, field);
         },
-        else => {},
+        .promise => {
+            const p = obj.as(Promise);
+            markValue(gc, p.value);
+        },
+        .parameter => {
+            const param = obj.as(types.ParameterObject);
+            markValue(gc, param.value);
+            markValue(gc, param.converter);
+        },
+        .transformer => {
+            const tx = obj.as(Transformer);
+            for (tx.literals) |lit| markValue(gc, lit);
+            for (tx.patterns) |pat| markValue(gc, pat);
+            for (tx.templates) |tmpl| markValue(gc, tmpl);
+        },
+        .error_object => {
+            const err = obj.as(types.ErrorObject);
+            markValue(gc, err.message);
+            markValue(gc, err.irritants);
+            markValue(gc, err.uncaught_reason);
+        },
+        .continuation => {
+            const cont = obj.as(Continuation);
+            for (cont.registers) |reg| markValue(gc, reg);
+            for (cont.frames[0..cont.frame_count]) |frame| {
+                if (frame.closure) |cls| markValue(gc, types.makePointer(@ptrCast(cls)));
+                if (frame.native) |nf| markValue(gc, types.makePointer(@ptrCast(nf)));
+            }
+            for (cont.handlers[0..cont.handler_count]) |handler| markValue(gc, handler.handler);
+            for (cont.wind_records[0..cont.wind_count]) |wr| {
+                markValue(gc, wr.before);
+                markValue(gc, wr.after);
+            }
+        },
+        .multiple_values => {
+            const mv = obj.as(MultipleValues);
+            for (mv.values) |val| markValue(gc, val);
+        },
+        .rational => {
+            const rat = obj.as(Rational);
+            markValue(gc, rat.numerator);
+            markValue(gc, rat.denominator);
+        },
+        .ffi_function => {
+            const ffi_fn = obj.as(FfiFunction);
+            markValue(gc, ffi_fn.library);
+        },
+        .ffi_callback => {
+            const cb = obj.as(FfiCallback);
+            markValue(gc, cb.closure);
+        },
+        .fiber => {
+            const fiber_mod = @import("fiber.zig");
+            const fiber = obj.as(fiber_mod.Fiber);
+            fiber_mod.markFiberState(gc, fiber);
+        },
+        .channel => {
+            const ch = obj.as(types.Channel);
+            markValue(gc, ch.head);
+            markValue(gc, ch.tail);
+        },
+        .mutex => {
+            const m = obj.as(types.Mutex);
+            markValue(gc, m.name);
+            markValue(gc, m.owner);
+            markValue(gc, m.specific);
+        },
+        .condition_variable => {
+            const cv = obj.as(types.ConditionVariable);
+            markValue(gc, cv.name);
+            markValue(gc, cv.specific);
+        },
+        .function => {
+            const func = obj.as(Function);
+            for (func.constants.items) |c| markValue(gc, c);
+            if (func.global_cache) |cache| {
+                for (cache) |c| markValue(gc, c);
+            }
+        },
+        .native_closure => {
+            const nc = obj.as(types.NativeClosure);
+            for (nc.upvalues) |uv| markValue(gc, uv);
+        },
+        .symbol, .string, .native_fn, .flonum, .port, .complex, .bytevector, .bignum, .record_type, .ffi_library, .file_info, .user_info, .group_info, .directory_object, .random_source, .srfi18_time => {},
     }
 }
 

--- a/tests/scheme/smoke/gc-mark-contents-types.scm
+++ b/tests/scheme/smoke/gc-mark-contents-types.scm
@@ -1,0 +1,131 @@
+;; Regression test for #407: markObjectContents missing types.
+;; Exercises old-gen objects of various types (promise, parameter,
+;; error-object, continuation, rational) referencing young-gen values
+;; under GC pressure that triggers minor collections.
+
+(import (scheme base)
+        (scheme write)
+        (scheme lazy)
+        (scheme case-lambda))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+(define (gc-pressure)
+  (let loop ((i 0))
+    (when (< i 500)
+      (make-vector 50 (list i i i))
+      (loop (+ i 1)))))
+
+;; Promote objects to old generation
+(define (promote)
+  (let loop ((i 0))
+    (when (< i 20)
+      (gc-pressure)
+      (loop (+ i 1)))))
+
+;; Test 1: Promise with young-gen result after promotion
+(define p (delay (make-string 50 #\x)))
+(promote)
+(gc-pressure)
+(check "promise-force" (string-length (force p)) 50)
+(gc-pressure)
+(check "promise-reforce" (string-length (force p)) 50)
+
+;; Test 2: Parameter with mutated value
+(define param (make-parameter '()))
+(promote)
+(param (list 'a 'b 'c))
+(gc-pressure)
+(check "parameter-value" (param) '(a b c))
+(gc-pressure)
+(check "parameter-value-2" (param) '(a b c))
+
+;; Test 3: Parameter with converter
+(define param2 (make-parameter 0 (lambda (x) (+ x 1))))
+(promote)
+(check "parameter-converter" (param2) 1)
+(gc-pressure)
+(check "parameter-converter-stable" (param2) 1)
+
+;; Test 4: Error object survives GC
+(define saved-err #f)
+(guard (e (#t (set! saved-err e)))
+  (error "test error" (make-string 30 #\z)))
+(promote)
+(gc-pressure)
+(check "error-message" (error-object-message saved-err) "test error")
+(check "error-irritants"
+       (string-length (car (error-object-irritants saved-err)))
+       30)
+
+;; Test 5: Continuation with captured state
+(define k #f)
+(define cont-result
+  (call-with-current-continuation
+    (lambda (c)
+      (set! k c)
+      'first)))
+(promote)
+(gc-pressure)
+(check "continuation-result" cont-result 'first)
+
+;; Test 6: Rationals (numerator/denominator are heap bignums for large values)
+(define r (/ 1 3))
+(promote)
+(gc-pressure)
+(check "rational-value" (* r 3) 1)
+(check "rational-exact" (exact? r) #t)
+
+;; Test 7: Multiple values (values object survives GC)
+(define mv-result #f)
+(call-with-values
+  (lambda () (values (make-string 20 #\a) (make-string 20 #\b)))
+  (lambda (a b)
+    (set! mv-result (list a b))))
+(promote)
+(gc-pressure)
+(check "multiple-values-a" (string-length (car mv-result)) 20)
+(check "multiple-values-b" (string-length (cadr mv-result)) 20)
+
+;; Test 8: Record instance
+(define-record-type <point>
+  (make-point x y)
+  point?
+  (x point-x)
+  (y point-y))
+
+(define pt (make-point (make-string 10 #\x) (make-string 10 #\y)))
+(promote)
+(gc-pressure)
+(check "record-x" (string-length (point-x pt)) 10)
+(check "record-y" (string-length (point-y pt)) 10)
+
+;; Test 9: Hash table
+(import (srfi 69))
+(define ht (make-hash-table))
+(hash-table-set! ht 'key (make-string 25 #\h))
+(promote)
+(gc-pressure)
+(check "hash-table-value" (string-length (hash-table-ref ht 'key)) 25)
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary
- Add 13 missing type cases to `markObjectContents` in `gc_collect.zig` (promise, parameter, transformer, error_object, continuation, multiple_values, rational, ffi_function, ffi_callback, fiber, channel, mutex, condition_variable, function, native_closure)
- Fix `referencesYoung` to enumerate all types instead of conservatively returning `true` for unknown types (which leaked remembered-set entries)
- Add regression test exercising old-gen objects of various types under GC pressure

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1518 pass, 0 fail
- [x] New test `tests/scheme/smoke/gc-mark-contents-types.scm` — 16 assertions covering promise, parameter, error-object, continuation, rational, multiple-values, record, hash-table

Fixes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)