### PR TITLE
Handle ContinuationInvoked in call_global and tail_call_global fast paths

### DIFF
--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -779,6 +779,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (arity_ok and base + @as(u16, nargs) + 1 < MAX_REGISTERS) {
                         const args = self.registers[base + 1 .. base + 1 + nargs];
                         const result = native.func(args) catch |err| {
+                            if (err == error.ContinuationInvoked) {
+                                if (target_frame_count == 0) continue;
+                                return VMError.ContinuationInvoked;
+                            }
                             return vm_calls.handleNativeError(self, err, base, nargs);
                         };
                         self.registers[base] = result;
@@ -903,6 +907,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const args = self.registers[abs_base + 1 .. abs_base + 1 + nargs];
                     const result = if (!self.profile_mode)
                         native.func(args) catch |err| {
+                            if (err == error.ContinuationInvoked) {
+                                if (target_frame_count == 0) continue;
+                                return VMError.ContinuationInvoked;
+                            }
                             return vm_calls.handleNativeError(self, err, abs_base, nargs);
                         }
                     else blk: {
@@ -916,6 +924,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             native.profile_time_ns +%= vm_calls.clockNs() -% native_start;
                             self.profile_last_ns = vm_calls.clockNs();
                             self.gc.profile_alloc_target = saved_alloc_target;
+                            if (err == error.ContinuationInvoked) {
+                                if (target_frame_count == 0) continue;
+                                return VMError.ContinuationInvoked;
+                            }
                             return switch (err) {
                                 error.TypeError => b2: {
                                     if (self.last_error_detail_len == 0)

--- a/tests/scheme/smoke/call-global-continuation.scm
+++ b/tests/scheme/smoke/call-global-continuation.scm
@@ -1,0 +1,85 @@
+;; Regression test for #449: ContinuationInvoked not handled in
+;; call_global fast path. Continuations invoked inside native
+;; higher-order functions (for-each, map) called via call_global
+;; should work correctly.
+
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+;; Test 1: continuation invoked through for-each (call_global)
+(define k1 #f)
+(define result1
+  (+ 100
+     (call-with-current-continuation
+       (lambda (cont)
+         (set! k1 cont)
+         0))))
+
+(check "initial" result1 100)
+
+(define (invoke-through-for-each)
+  (for-each (lambda (x) (when (= x 2) (k1 42))) (list 1 2 3))
+  (display "should not reach here"))
+
+(invoke-through-for-each)
+(check "for-each-continuation" result1 142)
+
+;; Test 2: continuation invoked through map (call_global)
+(define k2 #f)
+(define result2
+  (+ 200
+     (call-with-current-continuation
+       (lambda (cont)
+         (set! k2 cont)
+         0))))
+
+(check "map-initial" result2 200)
+
+(define (invoke-through-map)
+  (map (lambda (x) (when (= x 3) (k2 50))) (list 1 2 3))
+  (display "should not reach here"))
+
+(invoke-through-map)
+(check "map-continuation" result2 250)
+
+;; Test 3: continuation with dynamic-wind through call_global
+(define wind-log '())
+(define k3 #f)
+
+(define result3
+  (call-with-current-continuation
+    (lambda (c)
+      (dynamic-wind
+        (lambda () (set! wind-log (cons 'in wind-log)))
+        (lambda ()
+          (for-each
+            (lambda (x)
+              (when (= x 1) (set! k3 c))
+              (when (= x 2) (c 'done)))
+            (list 1 2 3)))
+        (lambda () (set! wind-log (cons 'out wind-log)))))))
+
+(check "dynamic-wind-result" result3 'done)
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary
- Add `ContinuationInvoked` handling to the native function fast path in `call_global` (line 781) — was returning the error instead of continuing the dispatch loop
- Fix the same issue in `tail_call_global` for both the normal path (line 909) and the profiling path (line 942)
- Add regression test with continuations invoked through `for-each`, `map`, and `dynamic-wind`

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1520 pass, 0 fail
- [x] New test `tests/scheme/smoke/call-global-continuation.scm` — 5 assertions including the exact reproducer from the issue

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)