### PR TITLE
Add arity check for native functions in tail_apply

### DIFF
--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -551,6 +551,20 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     frame.ip = 0;
                 } else if (types.isNativeFn(proc)) {
                     const native = types.toObject(proc).as(types.NativeFn);
+                    switch (native.arity) {
+                        .exact => |expected| {
+                            if (count != expected) {
+                                self.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ native.name, expected, count });
+                                return VMError.ArityMismatch;
+                            }
+                        },
+                        .variadic => |min| {
+                            if (count < min) {
+                                self.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, min, count });
+                                return VMError.ArityMismatch;
+                            }
+                        },
+                    }
                     const result = native.func(flat_args[0..count]) catch |err| {
                         if (err == error.ContinuationInvoked) {
                             if (target_frame_count == 0) continue;

--- a/tests/scheme/smoke/tail-apply-arity.scm
+++ b/tests/scheme/smoke/tail-apply-arity.scm
@@ -1,0 +1,67 @@
+;; Regression test for #445: tail_apply missing arity check for
+;; native functions. Previously crashed (panic) on too few args
+;; and silently ignored extra args.
+
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+;; Test 1: too few args to car via tail apply (was: PANIC)
+(define (test-car-no-args)
+  (apply car (list)))
+
+(check "car-no-args"
+       (guard (e (#t (error-object? e)))
+         (test-car-no-args)
+         #f)
+       #t)
+
+;; Test 2: too many args to cons via tail apply (was: silently dropped)
+(define (test-cons-too-many)
+  (apply cons (list 1 2 3)))
+
+(check "cons-too-many"
+       (guard (e (#t (error-object? e)))
+         (test-cons-too-many)
+         #f)
+       #t)
+
+;; Test 3: correct arity still works
+(define (test-car-ok) (apply car (list '(a b c))))
+(check "car-ok" (test-car-ok) 'a)
+
+(define (test-cons-ok) (apply cons (list 1 2)))
+(check "cons-ok" (test-cons-ok) '(1 . 2))
+
+;; Test 4: variadic native function with too few args
+(define (test-plus-no-args) (apply + (list)))
+(check "plus-no-args" (test-plus-no-args) 0)
+
+(define (test-list-variadic) (apply list (list 1 2 3)))
+(check "list-variadic" (test-list-variadic) '(1 2 3))
+
+;; Test 5: mixed fixed + list args
+(define (test-apply-mixed) (apply cons 1 (list 2)))
+(check "apply-mixed" (test-apply-mixed) '(1 . 2))
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary
- Add arity validation for native functions in the `tail_apply` opcode handler before calling the function
- Too few args: was PANIC (index out of bounds), now proper ArityMismatch error
- Too many args: was silently ignored, now proper ArityMismatch error
- Add regression test with both error cases and correct-arity verification

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1521 pass, 0 fail
- [x] New test `tests/scheme/smoke/tail-apply-arity.scm` — 7 assertions covering exact reproducers from the issue

Fixes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)