### PR TITLE
Validate package names and use cwd to prevent shell injection

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -82,6 +82,14 @@ fn parsePkgSpec(spec: []const u8) PkgSpec {
     return .{ .name = name_ver, .ver = null, .source = source };
 }
 
+fn isValidPkgName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    for (name) |c| {
+        if (!std.ascii.isAlphanumeric(c) and c != '-' and c != '_') return false;
+    }
+    return true;
+}
+
 fn parseField(line: []const u8, prefix: []const u8) ?[]const u8 {
     if (std.mem.startsWith(u8, line, prefix)) {
         return std.mem.trim(u8, line[prefix.len..], " \t\r");
@@ -674,6 +682,14 @@ fn doInstall(
     const pkg = parsed.name;
     var install_version = parsed.ver;
 
+    if (!isValidPkgName(pkg)) {
+        printErrColor(Color.red, "error: ");
+        writeStderr("invalid package name '");
+        writeStderr(pkg);
+        writeStderr("' (only alphanumeric, '-', '_' allowed)\n");
+        return error.InvalidPackageName;
+    }
+
     if (visited.get(pkg) != null) return;
     try visited.put(pkg, {});
 
@@ -782,9 +798,7 @@ fn doInstall(
 
         if (manifest.build_cmd) |build_cmd| {
             printBuf(&buf, "  Building {s}...\n", .{pkg});
-            const full_cmd = try std.mem.concat(allocator, u8, &.{ "cd ", pkg_dir, " && ", build_cmd });
-            defer allocator.free(full_cmd);
-            const exit_code = runPassthrough(allocator, &.{ "/bin/sh", "-c", full_cmd }, null) catch 1;
+            const exit_code = runPassthrough(allocator, &.{ "/bin/sh", "-c", build_cmd }, pkg_dir) catch 1;
             if (exit_code != 0) {
                 printErrColor(Color.red, "  Build failed\n");
                 return error.BuildFailed;
@@ -932,9 +946,7 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
 
         if (getPkgManifest(allocator, config.src_dir, p)) |manifest| {
             if (manifest.build_cmd) |build_cmd| {
-                const full_cmd = std.mem.concat(allocator, u8, &.{ "cd ", pkg_dir, " && ", build_cmd }) catch return;
-                defer allocator.free(full_cmd);
-                _ = runPassthrough(allocator, &.{ "/bin/sh", "-c", full_cmd }, null) catch {};
+                _ = runPassthrough(allocator, &.{ "/bin/sh", "-c", build_cmd }, pkg_dir) catch {};
             }
         }
 


### PR DESCRIPTION
## Summary
- Add `isValidPkgName()` validation: only `[a-zA-Z0-9_-]` allowed in package names
- Call validation at the start of `doInstall` before any operations
- Replace `cd <pkg_dir> && <build_cmd>` shell concatenation with the existing `cwd` parameter on `runPassthrough` (uses `chdir` in child process, no shell interpolation)
- Applied to both `doInstall` (line 785) and `doUpdate` (line 935)

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1521 pass, 0 fail
- [x] Manual test: `thottam install 'foo;echo pwned'` now produces `error: invalid package name`
- [x] Manual test: `thottam install kaappi-json` still works correctly

Fixes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)