### PR TITLE
Fix infinite loop when cond-expand clause has empty body

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -963,6 +963,9 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
                         types.setCdr(last_pair, remaining);
                         decl = spliced;
                         continue;
+                    } else {
+                        decl = types.cdr(decl);
+                        continue;
                     }
                 }
             }

--- a/tests/scheme/smoke/cond-expand-empty.scm
+++ b/tests/scheme/smoke/cond-expand-empty.scm
@@ -1,0 +1,65 @@
+;; Regression test for #432: cond-expand with empty matching clause
+;; in define-library caused an infinite loop.
+
+(import (scheme base) (scheme write))
+
+;; Inline library with empty cond-expand clause.
+;; The r7rs clause matches but has an empty body — previously hung.
+(define-library (cond-expand-empty-test)
+  (export greet)
+  (cond-expand
+    (r7rs)
+    (else (begin)))
+  (begin
+    (define (greet) "hello")))
+
+(import (cond-expand-empty-test))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+(check "cond-expand-empty-clause" (greet) "hello")
+
+;; Also test: cond-expand where else clause is empty
+(define-library (cond-expand-else-empty-test)
+  (export farewell)
+  (cond-expand
+    (nonexistent-feature (begin (define unused 1)))
+    (else))
+  (begin
+    (define (farewell) "bye")))
+
+(import (cond-expand-else-empty-test))
+(check "cond-expand-else-empty" (farewell) "bye")
+
+;; Test: cond-expand with multiple empty clauses before match
+(define-library (cond-expand-multi-empty-test)
+  (export value)
+  (cond-expand
+    (no-such-feature)
+    (r7rs))
+  (begin
+    (define (value) 42)))
+
+(import (cond-expand-multi-empty-test))
+(check "cond-expand-multi-empty" (value) 42)
+
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary
- When a `cond-expand` clause in `define-library` matched but had an empty body, the declaration pointer was never advanced, causing an infinite loop
- Advance `decl` past the cond-expand declaration when the matched clause body is empty
- Add regression test with three cases: empty matching clause, empty else clause, and multiple empty clauses

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1522 pass, 0 fail
- [x] New test `tests/scheme/smoke/cond-expand-empty.scm` — 3 assertions (previously would hang forever)

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)