### PR TITLE
Fix gcd crash on inexact args outside i64 range

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -1057,12 +1057,12 @@ fn gcdFn(args: []const Value) PrimitiveError!Value {
         return result;
     }
     if (anyFlonum(args)) {
-        var result: i64 = @intFromFloat(@abs(try toF64Ext(args[0])));
+        var result: f64 = @abs(try toF64Ext(args[0]));
         for (args[1..]) |a| {
-            const n: i64 = @intFromFloat(@abs(try toF64Ext(a)));
-            result = gcdTwo(result, n);
+            const b = @abs(try toF64Ext(a));
+            result = gcdF64(result, b);
         }
-        return makeFlonumVal(@floatFromInt(result));
+        return makeFlonumVal(result);
     }
     if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
     var result = types.toFixnum(args[0]);

--- a/tests/scheme/audit/primitives_arithmetic-audit.scm
+++ b/tests/scheme/audit/primitives_arithmetic-audit.scm
@@ -37,6 +37,14 @@
 (test #t (= 2.0 (gcd 4 6.0)))
 
 ;;; ================================================================
+;;; Bug 439: gcd must not crash on inexact args outside i64 range
+;;; ================================================================
+(test #t (number? (gcd +nan.0 1.0)))
+(test #t (number? (gcd +inf.0 6.0)))
+(test #t (= 1e100 (gcd 1e100 0.0)))
+(test #t (= 2.0 (gcd 1e100 2.0)))
+
+;;; ================================================================
 ;;; Bug 5: lcm should not overflow — large values
 ;;; (lcm on large values should promote to bignum, not panic)
 ;;; ================================================================


### PR DESCRIPTION
## Summary

- The flonum path in `gcdFn` used `@intFromFloat` to convert float args to i64, which panics on `+inf.0`, `+nan.0`, and values > 2^63 (like `1e100`)
- Replaced with `gcdF64` (float-based Euclidean algorithm that already existed), matching the approach `lcmFn` already uses
- Added regression tests for all crash cases

Fixes #439

## Test plan

- [x] Unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1522 pass, 0 fail)
- [x] Regression tests verify `(gcd +inf.0 6.0)`, `(gcd +nan.0 1.0)`, `(gcd 1e100 0.0)`, `(gcd 1e100 2.0)` no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)