### PR TITLE
Fix FFI uint32 params panic for values > 2^31-1

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -93,8 +93,8 @@ fn marshalToPointer(v: Value) ?*anyopaque {
 
 fn normalizeType(t: FfiType) FfiType {
     return switch (t) {
-        .int8, .int16, .int32, .char_type, .bool_type, .uint8, .uint16, .uint32 => .int,
-        .int64, .uint64, .size_type => .long,
+        .int8, .int16, .int32, .char_type, .bool_type, .uint8, .uint16 => .int,
+        .int64, .uint32, .uint64, .size_type => .long,
         else => t,
     };
 }

--- a/tests/scheme/ffi/uint32-range.scm
+++ b/tests/scheme/ffi/uint32-range.scm
@@ -1,0 +1,35 @@
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; Test that uint32 FFI parameters accept the full [0, 2^32-1] range.
+;; Previously, uint32 was normalized to c_int (i32), causing @intCast
+;; to panic for values > 2^31-1.
+
+(define libc (ffi-open #f))
+(define c-htonl (ffi-fn libc "htonl" '(uint32) 'uint32))
+
+;; Values within i32 range should still work
+(check "htonl(0)" (c-htonl 0) 0)
+(check "htonl(1)" (c-htonl 1) 16777216)
+
+;; Values > 2^31-1 that previously caused panic
+(check "htonl(2^31) no panic" (number? (c-htonl 2147483648)) #t)
+(check "htonl(3e9) no panic" (number? (c-htonl 3000000000)) #t)
+(check "htonl(2^32-1) no panic" (number? (c-htonl 4294967295)) #t)
+
+(ffi-close libc)
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "FFI uint32 range tests failed" fail))


### PR DESCRIPTION
## Summary

- `normalizeType` mapped `uint32` to `.int` (c_int/i32), causing `@intCast` to panic for valid uint32 values in [2^31, 2^32-1]
- Moved `uint32` to the `.long` normalization group so values pass as 64-bit integers, matching how `uint64` is already handled
- Added regression test using `htonl` with values across the full uint32 range

Fixes #412

## Test plan

- [x] Unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1523 pass, 0 fail)
- [x] New `uint32-range.scm` test verifies values 0, 1, 2^31, 3e9, and 2^32-1 work without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)