### PR TITLE
Add FFI function and parameter object support to tail_apply

### DIFF
--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -598,6 +598,33 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     }
                     if (target_frame_count == 0) continue;
                     return VMError.ContinuationInvoked;
+                } else if (types.isFfiFunction(proc)) {
+                    const ffi_fn = types.toObject(proc).as(types.FfiFunction);
+                    if (count != ffi_fn.param_count) return VMError.ArityMismatch;
+                    const ffi_mod = @import("ffi.zig");
+                    const result = ffi_mod.callFfi(ffi_fn, flat_args[0..count], self.gc) catch return VMError.TypeError;
+                    const return_dst = frame.dst;
+                    self.frame_count -= 1;
+                    if (self.frame_count <= target_frame_count) return result;
+                    const caller = &self.frames[self.frame_count - 1];
+                    const ret_idx = try registerIndex(self, caller.base, return_dst);
+                    self.registers[ret_idx] = result;
+                } else if (types.isParameter(proc)) {
+                    const param = types.toObject(proc).as(types.ParameterObject);
+                    const result = if (count == 0) self.getParameterValue(param) else blk: {
+                        var new_val = flat_args[0];
+                        if (param.converter != types.NIL) {
+                            new_val = self.callWithArgs(param.converter, &[_]Value{new_val}) catch |err| return err;
+                        }
+                        try self.setParameterValue(param, new_val);
+                        break :blk types.VOID;
+                    };
+                    const return_dst = frame.dst;
+                    self.frame_count -= 1;
+                    if (self.frame_count <= target_frame_count) return result;
+                    const caller = &self.frames[self.frame_count - 1];
+                    const ret_idx = try registerIndex(self, caller.base, return_dst);
+                    self.registers[ret_idx] = result;
                 } else {
                     self.setErrorDetail("apply: not a procedure", .{});
                     return VMError.NotAProcedure;

--- a/tests/scheme/smoke/tail-calls.scm
+++ b/tests/scheme/smoke/tail-calls.scm
@@ -81,6 +81,16 @@
       (let ((adder (make-adder i)))
         (loop (+ i 1) (+ sum (adder 1))))))
 
+;; tail_apply with parameter objects (issue #446)
+(define p446 (make-parameter 42))
+(define (test-param-apply) (apply p446 (list)))
+(test-eqv "tail_apply parameter get" 42 (test-param-apply))
+
+(define p446-set (make-parameter 0))
+(define (test-param-apply-set v) (apply p446-set (list v)))
+(test-param-apply-set 99)
+(test-eqv "tail_apply parameter set" 99 (p446-set))
+
 (set! %test-fail-count (test-runner-fail-count (test-runner-current)))
 (test-end "tail-calls")
 (if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
## Summary

- The `tail_apply` opcode handler only handled closures, native functions, and continuations — FFI functions and parameter objects fell through to the else branch, returning "apply: not a procedure"
- Added `isFfiFunction` and `isParameter` branches matching the existing `tail_call` handler logic
- Added regression tests for parameter objects in tail-position apply

Fixes #446

## Test plan

- [x] Unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1523 pass, 0 fail)
- [x] Regression tests verify `(apply parameter-obj (list))` works in tail position

🤖 Generated with [Claude Code](https://claude.com/claude-code)