### PR TITLE
Guard apply tail-call optimization against local variable shadowing

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1152,7 +1152,9 @@ pub const Compiler = struct {
         }
 
         if (is_tail and types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "apply")) {
-            return passthrough.compileApplyTail(self, expr, dst);
+            if (self.resolveLocal(types.symbolName(head)) == null) {
+                return passthrough.compileApplyTail(self, expr, dst);
+            }
         }
 
         return passthrough.compileCall(self, expr, dst, is_tail);

--- a/tests/scheme/smoke/apply-shadowing.scm
+++ b/tests/scheme/smoke/apply-shadowing.scm
@@ -1,0 +1,45 @@
+;; Regression test for #444:
+;; apply tail-call optimization must respect local variable shadowing.
+
+;; When 'apply' is shadowed by a local binding, calls to that binding
+;; should treat it as a regular function call, not as the built-in apply.
+
+(import (scheme base) (scheme write))
+
+(define (test-apply-shadowed)
+  (let ((apply +))
+    (apply 1 2)))
+
+(let ((result (test-apply-shadowed)))
+  (if (= result 3)
+      (display "PASS: shadowed apply uses local binding")
+      (begin
+        (display "FAIL: expected 3, got ")
+        (display result)))
+  (newline))
+
+;; Non-tail position should also work
+(define (test-apply-shadowed-non-tail)
+  (let ((apply +))
+    (let ((r (apply 10 20)))
+      r)))
+
+(let ((result (test-apply-shadowed-non-tail)))
+  (if (= result 30)
+      (display "PASS: shadowed apply in non-tail position")
+      (begin
+        (display "FAIL: expected 30, got ")
+        (display result)))
+  (newline))
+
+;; Unshadowed apply should still work normally
+(define (test-normal-apply)
+  (apply + '(1 2 3)))
+
+(let ((result (test-normal-apply)))
+  (if (= result 6)
+      (display "PASS: unshadowed apply works normally")
+      (begin
+        (display "FAIL: expected 6, got ")
+        (display result)))
+  (newline))


### PR DESCRIPTION
## Summary

- When `apply` is shadowed by a local variable binding (e.g. `(let ((apply +)) (apply 1 2))`), the tail-call optimization path bypassed the local variable lookup and compiled it as a `tail_apply` opcode
- Added a `resolveLocal` check so shadowed `apply` falls through to regular function call compilation, consistent with how all other special forms are guarded

## Test plan

- [x] New regression test `tests/scheme/smoke/apply-shadowing.scm` covering shadowed apply in tail position, non-tail position, and unshadowed apply
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme integration tests pass (1524 pass, 0 fail)

Fixes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)