### PR TITLE
Prevent (* expr 0) optimization from dropping side effects

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -1092,10 +1092,10 @@ pub fn eliminateIdentity(ir: *IR, node: *Node) *Node {
                         return eliminateIdentity(ir, a);
                     if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 1)
                         return eliminateIdentity(ir, b);
-                    // (* x 0) → 0, (* 0 x) → 0
-                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0)
+                    // (* x 0) → 0, (* 0 x) → 0 (only when the other operand is pure)
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0 and a.tag == .constant)
                         return ir.makeConst(types.makeFixnum(0)) catch return node;
-                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 0)
+                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 0 and b.tag == .constant)
                         return ir.makeConst(types.makeFixnum(0)) catch return node;
                 }
                 // (- x 0) → x

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -494,7 +494,24 @@ test "IR optimization: identity elimination — add zero" {
     try std.testing.expect(result.tag == .global_ref);
 }
 
-test "IR optimization: identity elimination — multiply by zero" {
+test "IR optimization: identity elimination — multiply by zero (pure)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const mul_sym = try gc.allocSymbol("*");
+    const op = try ir.makeGlobalRef(mul_sym);
+    const five = try ir.makeConst(types.makeFixnum(5));
+    const zero = try ir.makeConst(types.makeFixnum(0));
+    const call = try ir.makeCall(op, &.{ five, zero });
+
+    const result = ir_mod.eliminateIdentity(&ir, call);
+    try std.testing.expect(result.tag == .constant);
+    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(result.data.constant));
+}
+
+test "IR optimization: identity elimination — multiply by zero (impure preserved)" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var ir = ir_mod.IR.init(std.testing.allocator);
@@ -508,8 +525,8 @@ test "IR optimization: identity elimination — multiply by zero" {
     const call = try ir.makeCall(op, &.{ x, zero });
 
     const result = ir_mod.eliminateIdentity(&ir, call);
-    try std.testing.expect(result.tag == .constant);
-    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(result.data.constant));
+    // Non-constant operand must NOT be optimized away (may have side effects)
+    try std.testing.expect(result.tag == .call);
 }
 
 test "IR optimization: begin simplification — single expr" {

--- a/tests/scheme/smoke/mul-zero-side-effects.scm
+++ b/tests/scheme/smoke/mul-zero-side-effects.scm
@@ -1,0 +1,36 @@
+;; Regression test for #443:
+;; (* expr 0) optimization must not drop side effects from expr.
+
+(import (scheme base) (scheme write))
+
+;; (* side-effecting-expr 0) must still execute the side effect
+(define output '())
+
+(define (track! x)
+  (set! output (cons x output))
+  x)
+
+(define r1 (* (track! 5) 0))
+(if (and (= r1 0) (equal? output '(5)))
+    (display "PASS: (* (track! 5) 0) preserves side effect")
+    (begin
+      (display "FAIL: r1=") (display r1)
+      (display " output=") (display output)))
+(newline)
+
+;; (* 0 side-effecting-expr) must also preserve side effects
+(set! output '())
+(define r2 (* 0 (track! 7)))
+(if (and (= r2 0) (equal? output '(7)))
+    (display "PASS: (* 0 (track! 7)) preserves side effect")
+    (begin
+      (display "FAIL: r2=") (display r2)
+      (display " output=") (display output)))
+(newline)
+
+;; Pure (* const 0) should still fold to 0
+(define r3 (* 42 0))
+(if (= r3 0)
+    (display "PASS: (* 42 0) folds to 0")
+    (begin (display "FAIL: r3=") (display r3)))
+(newline)


### PR DESCRIPTION
## Summary

- The `eliminateIdentity` IR pass folded `(* expr 0)` and `(* 0 expr)` to `0` unconditionally, silently discarding side effects in `expr`
- Restricted the optimization to only apply when the non-zero operand is a constant (guaranteed pure)

## Test plan

- [x] New regression test `tests/scheme/smoke/mul-zero-side-effects.scm` verifying side effects are preserved
- [x] Updated IR unit test to cover both pure (folds) and impure (preserved) cases
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme integration tests pass (1525 pass, 0 fail)

Fixes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)