### PR TITLE
Remove incorrect (not (not X)) → X optimization

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -1039,25 +1039,7 @@ pub fn simplifyBooleans(ir: *IR, node: *Node) *Node {
             if (changed) return ir.makeBegin(buf[0..node.data.begin.len]) catch return node;
             return node;
         },
-        .call => {
-            const call = node.data.call;
-            // (not (not X)) → X
-            if (call.args.len == 1 and call.operator.tag == .global_ref) {
-                const sym = call.operator.data.global_ref;
-                if (types.isSymbol(sym) and std.mem.eql(u8, types.symbolName(sym), "not")) {
-                    const inner = call.args[0];
-                    if (inner.tag == .call and inner.data.call.args.len == 1 and
-                        inner.data.call.operator.tag == .global_ref)
-                    {
-                        const inner_sym = inner.data.call.operator.data.global_ref;
-                        if (types.isSymbol(inner_sym) and std.mem.eql(u8, types.symbolName(inner_sym), "not")) {
-                            return inner.data.call.args[0];
-                        }
-                    }
-                }
-            }
-            return node;
-        },
+        .call => return node,
         else => return node,
     }
 }

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -437,7 +437,7 @@ test "IR analysis: constant detection — variable ref is not constant" {
     try std.testing.expect(!node.ann.is_constant);
 }
 
-test "IR optimization: boolean simplification — not not" {
+test "IR optimization: boolean simplification — not not preserved for correctness" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var ir = ir_mod.IR.init(std.testing.allocator);
@@ -452,7 +452,8 @@ test "IR optimization: boolean simplification — not not" {
     const outer = try ir.makeCall(not_op2, &.{inner});
 
     const result = ir_mod.simplifyBooleans(&ir, outer);
-    try std.testing.expect(result.tag == .global_ref);
+    // (not (not X)) must NOT fold to X — X may not be boolean
+    try std.testing.expect(result.tag == .call);
 }
 
 test "IR optimization: boolean simplification — if not test swaps branches" {

--- a/tests/scheme/smoke/not-not-non-boolean.scm
+++ b/tests/scheme/smoke/not-not-non-boolean.scm
@@ -1,0 +1,36 @@
+;; Regression test for #440:
+;; (not (not X)) must return a boolean, not X itself.
+
+(import (scheme base) (scheme write))
+
+(define y (not (not "hello")))
+(if (eq? y #t)
+    (display "PASS: (not (not \"hello\")) is #t")
+    (begin
+      (display "FAIL: (not (not \"hello\")) returned ")
+      (write y)))
+(newline)
+
+(define z (not (not (+ 1 2))))
+(if (eq? z #t)
+    (display "PASS: (not (not 3)) is #t")
+    (begin
+      (display "FAIL: (not (not 3)) returned ")
+      (write z)))
+(newline)
+
+(define w (not (not #f)))
+(if (eq? w #f)
+    (display "PASS: (not (not #f)) is #f")
+    (begin
+      (display "FAIL: (not (not #f)) returned ")
+      (write w)))
+(newline)
+
+(define v (not (not '())))
+(if (eq? v #t)
+    (display "PASS: (not (not '())) is #t")
+    (begin
+      (display "FAIL: (not (not '())) returned ")
+      (write v)))
+(newline)


### PR DESCRIPTION
## Summary

- The `simplifyBooleans` IR pass folded `(not (not X))` to `X`, which is incorrect when `X` is not a boolean — R7RS requires `(not (not X))` to always return `#t` or `#f`
- Removed the optimization entirely since it cannot be applied safely without compile-time type information

## Test plan

- [x] New regression test `tests/scheme/smoke/not-not-non-boolean.scm` verifying boolean return for strings, numbers, #f, and '()
- [x] Updated IR unit test to verify `(not (not X))` is no longer simplified away
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme integration tests pass (1526 pass, 0 fail)

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)