### PR TITLE
Fix zero? constant folding to reject non-numeric arguments

### DIFF
--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -218,8 +218,8 @@ fn tryConstantFold(self: *Compiler, expr: Value, dst: u16) bool {
         if (!types.isFixnum(a) and a != types.TRUE and a != types.FALSE) return false;
         const result: ?Value = if (std.mem.eql(u8, name, "not"))
             (if (a == types.FALSE) types.TRUE else types.FALSE)
-        else if (std.mem.eql(u8, name, "zero?"))
-            (if (types.isFixnum(a) and types.toFixnum(a) == 0) types.TRUE else types.FALSE)
+        else if (std.mem.eql(u8, name, "zero?") and types.isFixnum(a))
+            (if (types.toFixnum(a) == 0) types.TRUE else types.FALSE)
         else if (std.mem.eql(u8, name, "-") and types.isFixnum(a)) blk: {
             const neg = @subWithOverflow(@as(i64, 0), types.toFixnum(a));
             if (neg[1] != 0) break :blk null;

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -563,8 +563,8 @@ fn tryFoldFromAST(ir: *IR, expr: Value) ?*Node {
 
         const result: ?Value = if (std.mem.eql(u8, name, "not"))
             (if (a == types.FALSE) types.TRUE else types.FALSE)
-        else if (std.mem.eql(u8, name, "zero?"))
-            (if (types.isFixnum(a) and types.toFixnum(a) == 0) types.TRUE else types.FALSE)
+        else if (std.mem.eql(u8, name, "zero?") and types.isFixnum(a))
+            (if (types.toFixnum(a) == 0) types.TRUE else types.FALSE)
         else if (std.mem.eql(u8, name, "-") and types.isFixnum(a)) blk: {
             const neg = @subWithOverflow(@as(i64, 0), types.toFixnum(a));
             if (neg[1] != 0) break :blk null;
@@ -880,8 +880,8 @@ pub fn foldConstants(ir: *IR, node: *Node) *Node {
 
                 const result: ?Value = if (std.mem.eql(u8, name, "not"))
                     (if (av == types.FALSE) types.TRUE else types.FALSE)
-                else if (std.mem.eql(u8, name, "zero?"))
-                    (if (types.isFixnum(av) and types.toFixnum(av) == 0) types.TRUE else types.FALSE)
+                else if (std.mem.eql(u8, name, "zero?") and types.isFixnum(av))
+                    (if (types.toFixnum(av) == 0) types.TRUE else types.FALSE)
                 else if (std.mem.eql(u8, name, "-") and types.isFixnum(av)) blk: {
                     const neg = @subWithOverflow(@as(i64, 0), types.toFixnum(av));
                     if (neg[1] != 0) break :blk null;

--- a/tests/scheme/smoke/zero-pred-type-error.scm
+++ b/tests/scheme/smoke/zero-pred-type-error.scm
@@ -1,0 +1,43 @@
+;; Regression test for #442:
+;; (zero? #t) and (zero? #f) must raise type errors, not fold to #f.
+
+(import (scheme base) (scheme write))
+
+;; zero? on #t should be a type error
+(define caught-1 #f)
+(guard (exn (#t (set! caught-1 #t)))
+  (zero? #t))
+(if caught-1
+    (display "PASS: (zero? #t) raises type error")
+    (display "FAIL: (zero? #t) did not raise error"))
+(newline)
+
+;; zero? on #f should be a type error
+(define caught-2 #f)
+(guard (exn (#t (set! caught-2 #t)))
+  (zero? #f))
+(if caught-2
+    (display "PASS: (zero? #f) raises type error")
+    (display "FAIL: (zero? #f) did not raise error"))
+(newline)
+
+;; zero? on a string should be a type error
+(define caught-3 #f)
+(guard (exn (#t (set! caught-3 #t)))
+  (zero? "hello"))
+(if caught-3
+    (display "PASS: (zero? \"hello\") raises type error")
+    (display "FAIL: (zero? \"hello\") did not raise error"))
+(newline)
+
+;; zero? on 0 should return #t (sanity check)
+(if (zero? 0)
+    (display "PASS: (zero? 0) is #t")
+    (display "FAIL: (zero? 0) should be #t"))
+(newline)
+
+;; zero? on 1 should return #f (sanity check)
+(if (not (zero? 1))
+    (display "PASS: (zero? 1) is #f")
+    (display "FAIL: (zero? 1) should be #f"))
+(newline)


### PR DESCRIPTION
## Summary

- Constant folding for `(zero? X)` accepted boolean arguments (`#t`, `#f`) and folded them to `#f` instead of letting the runtime raise a type error as R7RS requires
- Added `isFixnum` guard to all three `zero?` folding paths: `tryFoldFromAST` and `foldConstants` in `ir.zig`, and the passthrough folder in `compiler_passthrough.zig`

## Test plan

- [x] New regression test `tests/scheme/smoke/zero-pred-type-error.scm` verifying type errors for `#t`, `#f`, and strings
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme integration tests pass (1527 pass, 0 fail)

Fixes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)