### PR TITLE
Reject non-integer flonums in even? and odd?

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -998,6 +998,8 @@ fn evenP(args: []const Value) PrimitiveError!Value {
     }
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
+        if (f != @trunc(f) or !std.math.isFinite(f))
+            return PrimitiveError.TypeError;
         return if (@rem(f, 2.0) == 0.0) types.TRUE else types.FALSE;
     }
     return PrimitiveError.TypeError;
@@ -1012,6 +1014,8 @@ fn oddP(args: []const Value) PrimitiveError!Value {
     }
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
+        if (f != @trunc(f) or !std.math.isFinite(f))
+            return PrimitiveError.TypeError;
         return if (@rem(f, 2.0) != 0.0) types.TRUE else types.FALSE;
     }
     return PrimitiveError.TypeError;

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -999,7 +999,7 @@ fn evenP(args: []const Value) PrimitiveError!Value {
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
         if (f != @trunc(f) or !std.math.isFinite(f))
-            return PrimitiveError.TypeError;
+            return primitives.typeError("even?", "integer", args[0]);
         return if (@rem(f, 2.0) == 0.0) types.TRUE else types.FALSE;
     }
     return PrimitiveError.TypeError;
@@ -1015,7 +1015,7 @@ fn oddP(args: []const Value) PrimitiveError!Value {
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
         if (f != @trunc(f) or !std.math.isFinite(f))
-            return PrimitiveError.TypeError;
+            return primitives.typeError("odd?", "integer", args[0]);
         return if (@rem(f, 2.0) != 0.0) types.TRUE else types.FALSE;
     }
     return PrimitiveError.TypeError;

--- a/tests/scheme/smoke/even-odd-non-integer.scm
+++ b/tests/scheme/smoke/even-odd-non-integer.scm
@@ -1,0 +1,50 @@
+;; Regression test for #441:
+;; even? and odd? must reject non-integer flonums.
+
+(import (scheme base) (scheme write))
+
+;; Non-integer flonum should error
+(define caught-1 #f)
+(guard (exn (#t (set! caught-1 #t)))
+  (odd? 2.5))
+(if caught-1
+    (display "PASS: (odd? 2.5) raises error")
+    (display "FAIL: (odd? 2.5) did not raise error"))
+(newline)
+
+(define caught-2 #f)
+(guard (exn (#t (set! caught-2 #t)))
+  (even? 2.5))
+(if caught-2
+    (display "PASS: (even? 2.5) raises error")
+    (display "FAIL: (even? 2.5) did not raise error"))
+(newline)
+
+;; Infinity should error
+(define caught-3 #f)
+(guard (exn (#t (set! caught-3 #t)))
+  (odd? +inf.0))
+(if caught-3
+    (display "PASS: (odd? +inf.0) raises error")
+    (display "FAIL: (odd? +inf.0) did not raise error"))
+(newline)
+
+;; NaN should error
+(define caught-4 #f)
+(guard (exn (#t (set! caught-4 #t)))
+  (even? +nan.0))
+(if caught-4
+    (display "PASS: (even? +nan.0) raises error")
+    (display "FAIL: (even? +nan.0) did not raise error"))
+(newline)
+
+;; Integer-valued flonums should work
+(if (even? 4.0)
+    (display "PASS: (even? 4.0) is #t")
+    (display "FAIL: (even? 4.0) should be #t"))
+(newline)
+
+(if (odd? 3.0)
+    (display "PASS: (odd? 3.0) is #t")
+    (display "FAIL: (odd? 3.0) should be #t"))
+(newline)


### PR DESCRIPTION
## Summary

- `even?` and `odd?` accepted non-integer flonum arguments (2.5, +inf.0, +nan.0) and returned wrong results — e.g. `(odd? 2.5)` returned `#t`
- Added a finite + integer-valued check to both functions so non-integer flonums raise a type error per R7RS

## Test plan

- [x] New regression test `tests/scheme/smoke/even-odd-non-integer.scm` covering 2.5, +inf.0, +nan.0, and valid integer flonums
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme integration tests pass (1528 pass, 0 fail)

Fixes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)