### PR TITLE
Handle bignum first argument in sub and div rational paths

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -352,7 +352,7 @@ fn sub(args: []const Value) PrimitiveError!Value {
             var f: f64 = bignum_mod.toF64(args[0]);
             if (args.len == 1) return makeFlonumVal(-f);
             for (args[1..]) |a| {
-                f -= toF64(a) catch return PrimitiveError.TypeError;
+                f -= toF64(a) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
             }
             return makeFlonumVal(f);
         }
@@ -552,7 +552,7 @@ fn divFn(args: []const Value) PrimitiveError!Value {
         if (types.isBignum(args[0])) {
             var f: f64 = bignum_mod.toF64(args[0]);
             for (args[1..]) |a| {
-                const dv = toF64(a) catch return PrimitiveError.TypeError;
+                const dv = toF64(a) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
                 if (dv == 0.0) return raiseDivByZero();
                 f /= dv;
             }

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -348,6 +348,14 @@ fn sub(args: []const Value) PrimitiveError!Value {
     }
     if (anyRational(args)) {
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        if (types.isBignum(args[0])) {
+            var f: f64 = bignum_mod.toF64(args[0]);
+            if (args.len == 1) return makeFlonumVal(-f);
+            for (args[1..]) |a| {
+                f -= toF64(a) catch return PrimitiveError.TypeError;
+            }
+            return makeFlonumVal(f);
+        }
         const first_parts = toRationalParts(args[0]);
         var n = first_parts.num;
         var d = first_parts.den;
@@ -541,6 +549,15 @@ fn divFn(args: []const Value) PrimitiveError!Value {
     // Handle rational division: any rational arg means rational result
     if (anyRational(args) and !anyFlonum(args)) {
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        if (types.isBignum(args[0])) {
+            var f: f64 = bignum_mod.toF64(args[0]);
+            for (args[1..]) |a| {
+                const dv = toF64(a) catch return PrimitiveError.TypeError;
+                if (dv == 0.0) return raiseDivByZero();
+                f /= dv;
+            }
+            return makeFlonumVal(f);
+        }
         const first_parts = toRationalParts(args[0]);
         var n = first_parts.num;
         var d = first_parts.den;

--- a/tests/scheme/smoke/bignum-rational-arith.scm
+++ b/tests/scheme/smoke/bignum-rational-arith.scm
@@ -1,0 +1,40 @@
+;; Regression test for #437:
+;; toRationalParts must not treat bignums as zero.
+
+(import (scheme base) (scheme write))
+
+;; (- bignum rational) should not return (- 0 rational)
+(let ((result (- (expt 2 60) 1/3)))
+  (if (> result (expt 2 59))
+      (display "PASS: (- 2^60 1/3) is large")
+      (begin
+        (display "FAIL: (- 2^60 1/3) returned ")
+        (display result))))
+(newline)
+
+;; (/ bignum rational) should not return 0
+(let ((result (/ (expt 2 60) 1/3)))
+  (if (> result (expt 2 59))
+      (display "PASS: (/ 2^60 1/3) is large")
+      (begin
+        (display "FAIL: (/ 2^60 1/3) returned ")
+        (display result))))
+(newline)
+
+;; Sanity: (+ bignum rational) should still work
+(let ((result (+ (expt 2 60) 1/3)))
+  (if (> result (expt 2 59))
+      (display "PASS: (+ 2^60 1/3) is large")
+      (begin
+        (display "FAIL: (+ 2^60 1/3) returned ")
+        (display result))))
+(newline)
+
+;; Sanity: (* bignum rational) should still work
+(let ((result (* (expt 2 60) 1/3)))
+  (if (> result (expt 2 58))
+      (display "PASS: (* 2^60 1/3) is large")
+      (begin
+        (display "FAIL: (* 2^60 1/3) returned ")
+        (display result))))
+(newline)


### PR DESCRIPTION
## Summary

- `toRationalParts` silently returned `{0, 1}` for bignum values, causing `(- bignum rational)` to treat the bignum as zero and `(/ bignum rational)` to return 0
- Added bignum checks before calling `toRationalParts` on `args[0]` in both `sub` and `divFn`, falling back to float arithmetic (matching the approach used by `add` and `mul`)

## Test plan

- [x] New regression test `tests/scheme/smoke/bignum-rational-arith.scm` covering `(- 2^60 1/3)`, `(/ 2^60 1/3)`, and sanity checks for `+` and `*`
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme integration tests pass (1529 pass, 0 fail)

Fixes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)