### PR TITLE
Fix FFI toIntArg wrong sign and silent truncation for bignums

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -4,14 +4,30 @@ const memory = @import("memory.zig");
 const Value = types.Value;
 const FfiType = types.FfiType;
 
-fn toIntArg(v: Value) i64 {
+fn toIntArgOpt(v: Value) ?i64 {
     if (types.isBignum(v)) {
         const bn = types.toBignum(v);
         if (bn.len == 0) return 0;
-        const mag: i64 = @bitCast(bn.limbs[0]);
-        return if (bn.positive) mag else -mag;
+        if (bn.len > 1) return null;
+        const limb = bn.limbs[0];
+        if (bn.positive) {
+            if (limb > @as(u64, @intCast(std.math.maxInt(i64))))
+                return null;
+            return @intCast(limb);
+        } else {
+            if (limb > @as(u64, @intCast(std.math.maxInt(i64))) + 1)
+                return null;
+            if (limb == @as(u64, @intCast(std.math.maxInt(i64))) + 1)
+                return std.math.minInt(i64);
+            const mag: i64 = @intCast(limb);
+            return -mag;
+        }
     }
     return types.toFixnum(v);
+}
+
+fn toIntArg(v: Value) error{TypeError}!i64 {
+    return toIntArgOpt(v) orelse return error.TypeError;
 }
 
 /// Convert a Scheme string Value to a null-terminated C string using a stack buffer.
@@ -78,6 +94,7 @@ fn marshalToPointer(v: Value) ?*anyopaque {
     if (types.isBignum(v)) {
         const bn = types.toBignum(v);
         if (bn.len == 0) return null;
+        if (bn.len > 1) return null;
         if (!bn.positive) return null;
         const limb = bn.limbs[0];
         if (limb > std.math.maxInt(usize)) return null;
@@ -216,21 +233,21 @@ fn callFfi1(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // int -> int (abs, etc.)
     if (p0 == .int and rt == .int) {
         const f: *const fn (c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])));
+        const result = f(@intCast(try toIntArg(args[0])));
         return types.makeFixnum(@intCast(result));
     }
 
     // int -> long
     if (p0 == .int and rt == .long) {
         const f: *const fn (c_int) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])));
+        const result = f(@intCast(try toIntArg(args[0])));
         return marshalLongReturn(result, gc);
     }
 
     // long -> long
     if (p0 == .long and rt == .long) {
         const f: *const fn (c_long) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])));
+        const result = f(@intCast(try toIntArg(args[0])));
         return marshalLongReturn(result, gc);
     }
 
@@ -273,7 +290,7 @@ fn callFfi1(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // int -> void
     if (p0 == .int and rt == .void_type) {
         const f: *const fn (c_int) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(toIntArg(args[0])));
+        f(@intCast(try toIntArg(args[0])));
         return types.VOID;
     }
 
@@ -329,21 +346,21 @@ fn callFfi1(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // int -> pointer (malloc, etc.)
     if (p0 == .int and rt == .pointer) {
         const f: *const fn (c_int) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])));
+        const result = f(@intCast(try toIntArg(args[0])));
         return marshalPointerReturn(result, gc);
     }
 
     // long -> pointer
     if (p0 == .long and rt == .pointer) {
         const f: *const fn (c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])));
+        const result = f(@intCast(try toIntArg(args[0])));
         return marshalPointerReturn(result, gc);
     }
 
     // long -> void
     if (p0 == .long and rt == .void_type) {
         const f: *const fn (c_long) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(toIntArg(args[0])));
+        f(@intCast(try toIntArg(args[0])));
         return types.VOID;
     }
 
@@ -401,21 +418,21 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (int, int) -> int
     if (p0 == .int and p1 == .int and rt == .int) {
         const f: *const fn (c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
+        const result = f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (int, int) -> long
     if (p0 == .int and p1 == .int and rt == .long) {
         const f: *const fn (c_int, c_int) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
+        const result = f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])));
         return marshalLongReturn(result, gc);
     }
 
     // (long, long) -> long
     if (p0 == .long and p1 == .long and rt == .long) {
         const f: *const fn (c_long, c_long) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
+        const result = f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])));
         return marshalLongReturn(result, gc);
     }
 
@@ -455,7 +472,7 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (int, int) -> void
     if (p0 == .int and p1 == .int and rt == .void_type) {
         const f: *const fn (c_int, c_int) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
+        f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])));
         return types.VOID;
     }
 
@@ -490,63 +507,63 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (pointer, int) -> int
     if (p0 == .pointer and p1 == .int and rt == .int) {
         const f: *const fn (?*anyopaque, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, int) -> void
     if (p0 == .pointer and p1 == .int and rt == .void_type) {
         const f: *const fn (?*anyopaque, c_int) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
+        f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])));
         return types.VOID;
     }
 
     // (pointer, int) -> pointer
     if (p0 == .pointer and p1 == .int and rt == .pointer) {
         const f: *const fn (?*anyopaque, c_int) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])));
         return marshalPointerReturn(result, gc);
     }
 
     // (pointer, long) -> pointer (realloc, etc.)
     if (p0 == .pointer and p1 == .long and rt == .pointer) {
         const f: *const fn (?*anyopaque, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])));
         return marshalPointerReturn(result, gc);
     }
 
     // (pointer, long) -> int
     if (p0 == .pointer and p1 == .long and rt == .int) {
         const f: *const fn (?*anyopaque, c_long) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, long) -> void
     if (p0 == .pointer and p1 == .long and rt == .void_type) {
         const f: *const fn (?*anyopaque, c_long) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
+        f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])));
         return types.VOID;
     }
 
     // (pointer, long) -> long
     if (p0 == .pointer and p1 == .long and rt == .long) {
         const f: *const fn (?*anyopaque, c_long) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])));
         return marshalLongReturn(result, gc);
     }
 
     // (int, pointer) -> int
     if (p0 == .int and p1 == .pointer and rt == .int) {
         const f: *const fn (c_int, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), marshalToPointer(args[1]));
+        const result = f(@intCast(try toIntArg(args[0])), marshalToPointer(args[1]));
         return types.makeFixnum(@intCast(result));
     }
 
     // (int, pointer) -> void
     if (p0 == .int and p1 == .pointer and rt == .void_type) {
         const f: *const fn (c_int, ?*anyopaque) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(toIntArg(args[0])), marshalToPointer(args[1]));
+        f(@intCast(try toIntArg(args[0])), marshalToPointer(args[1]));
         return types.VOID;
     }
 
@@ -555,7 +572,7 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         const f: *const fn ([*:0]const u8, c_int) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
         var buf0: [4096]u8 = undefined;
         const cs0 = toCString(args[0], &buf0) orelse return error.TypeError;
-        const result = f(cs0, @intCast(toIntArg(args[1])));
+        const result = f(cs0, @intCast(try toIntArg(args[1])));
         return marshalPointerReturn(result, gc);
     }
 
@@ -584,7 +601,7 @@ fn callFfi2(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (long, long) -> pointer
     if (p0 == .long and p1 == .long and rt == .pointer) {
         const f: *const fn (c_long, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])));
+        const result = f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])));
         return marshalPointerReturn(result, gc);
     }
 
@@ -606,7 +623,7 @@ fn callFfi3(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         const f: *const fn ([*:0]const u8, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
         var buf: [4096]u8 = undefined;
         const cstr = toCString(args[0], &buf) orelse return error.TypeError;
-        const result = f(cstr, @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])));
+        const result = f(cstr, @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -620,7 +637,7 @@ fn callFfi3(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (int, int, int) -> int
     if (p0 == .int and p1 == .int and p2 == .int and rt == .int) {
         const f: *const fn (c_int, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])));
+        const result = f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -631,28 +648,28 @@ fn callFfi3(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         var buf1: [4096]u8 = undefined;
         const cs0 = toCString(args[0], &buf0) orelse return error.TypeError;
         const cs1 = toCString(args[1], &buf1) orelse return error.TypeError;
-        const result = f(cs0, cs1, @intCast(toIntArg(args[2])));
+        const result = f(cs0, cs1, @intCast(try toIntArg(args[2])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, pointer, long) -> pointer (memcpy, memmove, etc.)
     if (p0 == .pointer and p1 == .pointer and p2 == .long and rt == .pointer) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])));
+        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(try toIntArg(args[2])));
         return marshalPointerReturn(result, gc);
     }
 
     // (pointer, int, long) -> pointer (memset, etc.)
     if (p0 == .pointer and p1 == .int and p2 == .long and rt == .pointer) {
         const f: *const fn (?*anyopaque, c_int, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])));
         return marshalPointerReturn(result, gc);
     }
 
     // (pointer, long, pointer) -> long (fread/fwrite patterns)
     if (p0 == .pointer and p1 == .long and p2 == .pointer and rt == .long) {
         const f: *const fn (?*anyopaque, c_long, ?*anyopaque) callconv(.c) c_long = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])), marshalToPointer(args[2]));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])), marshalToPointer(args[2]));
         return marshalLongReturn(result, gc);
     }
 
@@ -680,21 +697,21 @@ fn callFfi3(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (pointer, pointer, long) -> int
     if (p0 == .pointer and p1 == .pointer and p2 == .long and rt == .int) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])));
+        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(try toIntArg(args[2])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, pointer, long) -> void
     if (p0 == .pointer and p1 == .pointer and p2 == .long and rt == .void_type) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])));
+        f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(try toIntArg(args[2])));
         return types.VOID;
     }
 
     // (int, pointer, pointer) -> int
     if (p0 == .int and p1 == .pointer and p2 == .pointer and rt == .int) {
         const f: *const fn (c_int, ?*anyopaque, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), marshalToPointer(args[1]), marshalToPointer(args[2]));
+        const result = f(@intCast(try toIntArg(args[0])), marshalToPointer(args[1]), marshalToPointer(args[2]));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -730,8 +747,8 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         const f: *const fn (?*anyopaque, usize, usize, *const fn (?*anyopaque, ?*anyopaque) callconv(.c) c_int) callconv(.c) void =
             @ptrCast(@alignCast(ffi_fn.symbol));
         const ptr0 = marshalToPointer(args[0]) orelse return error.TypeError;
-        const n_signed = toIntArg(args[1]);
-        const sz_signed = toIntArg(args[2]);
+        const n_signed = try toIntArg(args[1]);
+        const sz_signed = try toIntArg(args[2]);
         if (n_signed < 0 or sz_signed < 0) return error.TypeError;
         const n: usize = @intCast(n_signed);
         const sz: usize = @intCast(sz_signed);
@@ -747,7 +764,7 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
             @ptrCast(@alignCast(ffi_fn.symbol));
         const ptr0 = marshalToPointer(args[0]) orelse return error.TypeError;
         const ptr3 = marshalToPointer(args[3]) orelse return error.TypeError;
-        const result = f(ptr0, @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), ptr3);
+        const result = f(ptr0, @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])), ptr3);
         return types.makeFixnum(@intCast(result));
     }
 
@@ -768,7 +785,7 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     if (p0 == .pointer and p1 == .pointer and p2 == .long and p3 == .long and rt == .pointer) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long, c_long) callconv(.c) ?*anyopaque =
             @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])));
+        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(try toIntArg(args[2])), @intCast(try toIntArg(args[3])));
         return marshalPointerReturn(result, gc);
     }
 
@@ -776,7 +793,7 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     if (p0 == .pointer and p1 == .long and p2 == .long and p3 == .long and rt == .int) {
         const f: *const fn (?*anyopaque, c_long, c_long, c_long) callconv(.c) c_int =
             @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])), @intCast(try toIntArg(args[3])));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -828,35 +845,35 @@ fn callFfi5(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     // (int, int, int, int, int) -> int
     if (p0 == .int and p1 == .int and p2 == .int and p3 == .int and p4 == .int and rt == .int) {
         const f: *const fn (c_int, c_int, c_int, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), @intCast(toIntArg(args[4])));
+        const result = f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])), @intCast(try toIntArg(args[3])), @intCast(try toIntArg(args[4])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (int, int, int, int, int) -> void
     if (p0 == .int and p1 == .int and p2 == .int and p3 == .int and p4 == .int and rt == .void_type) {
         const f: *const fn (c_int, c_int, c_int, c_int, c_int) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
-        f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), @intCast(toIntArg(args[4])));
+        f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])), @intCast(try toIntArg(args[3])), @intCast(try toIntArg(args[4])));
         return types.VOID;
     }
 
     // (int, int, int, pointer, int) -> int — setsockopt
     if (p0 == .int and p1 == .int and p2 == .int and p3 == .pointer and p4 == .int and rt == .int) {
         const f: *const fn (c_int, c_int, c_int, ?*anyopaque, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(@intCast(toIntArg(args[0])), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), marshalToPointer(args[3]), @intCast(toIntArg(args[4])));
+        const result = f(@intCast(try toIntArg(args[0])), @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])), marshalToPointer(args[3]), @intCast(try toIntArg(args[4])));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, pointer, long, int, pointer) -> int — sendto
     if (p0 == .pointer and p1 == .pointer and p2 == .long and p3 == .int and p4 == .pointer and rt == .int) {
         const f: *const fn (?*anyopaque, ?*anyopaque, c_long, c_int, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), marshalToPointer(args[4]));
+        const result = f(marshalToPointer(args[0]), marshalToPointer(args[1]), @intCast(try toIntArg(args[2])), @intCast(try toIntArg(args[3])), marshalToPointer(args[4]));
         return types.makeFixnum(@intCast(result));
     }
 
     // (pointer, int, int, int, int) -> int — socket/IO ops
     if (p0 == .pointer and p1 == .int and p2 == .int and p3 == .int and p4 == .int and rt == .int) {
         const f: *const fn (?*anyopaque, c_int, c_int, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
-        const result = f(marshalToPointer(args[0]), @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), @intCast(toIntArg(args[4])));
+        const result = f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])), @intCast(try toIntArg(args[3])), @intCast(try toIntArg(args[4])));
         return types.makeFixnum(@intCast(result));
     }
 
@@ -888,7 +905,7 @@ fn callFfi5(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     if (p0 == .string and p1 == .int and p2 == .int and p3 == .int and p4 == .int and rt == .int) {
         const f: *const fn ([*:0]const u8, c_int, c_int, c_int, c_int) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
         var buf0: [4096]u8 = undefined;
-        const result = f(toCString(args[0], &buf0) orelse return error.TypeError, @intCast(toIntArg(args[1])), @intCast(toIntArg(args[2])), @intCast(toIntArg(args[3])), @intCast(toIntArg(args[4])));
+        const result = f(toCString(args[0], &buf0) orelse return error.TypeError, @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])), @intCast(try toIntArg(args[3])), @intCast(try toIntArg(args[4])));
         return types.makeFixnum(@intCast(result));
     }
 

--- a/tests/scheme/ffi/bignum-args.scm
+++ b/tests/scheme/ffi/bignum-args.scm
@@ -31,6 +31,33 @@
 (check "labs large positive" (c-labs (expt 2 50)) (expt 2 50))
 (check "labs large negative" (c-labs (- (expt 2 50))) (expt 2 50))
 
+;; Regression test for #409: bignums >= 2^63 must not produce wrong sign
+;; Negative bignums with magnitude < 2^63 should give correct negative value
+(check "labs negative bignum" (c-labs (- (expt 2 62))) (expt 2 62))
+
+;; Regression test for #409: positive bignum 2^63 exceeds i64 range
+;; Should error, not silently produce a wrong (negative) value
+(define caught-overflow #f)
+(guard (exn (#t (set! caught-overflow #t)))
+  (c-labs (expt 2 63)))
+(if caught-overflow
+    (set! pass (+ pass 1))
+    (begin
+      (set! fail (+ fail 1))
+      (display "FAIL: (c-labs 2^63) should error (exceeds i64)")
+      (newline)))
+
+;; Regression test for #406: multi-limb bignums must not be silently truncated
+(define caught-multi-limb #f)
+(guard (exn (#t (set! caught-multi-limb #t)))
+  (c-labs (expt 2 65)))
+(if caught-multi-limb
+    (set! pass (+ pass 1))
+    (begin
+      (set! fail (+ fail 1))
+      (display "FAIL: (c-labs 2^65) should error (multi-limb bignum)")
+      (newline)))
+
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "FFI bignum argument tests failed" fail))


### PR DESCRIPTION
## Summary

- `toIntArg` used `@bitCast` to convert unsigned bignum limbs to signed `i64`, producing wrong signs for magnitudes >= 2^63 (e.g., a positive bignum 2^63 was interpreted as -2^63)
- `toIntArg` silently truncated multi-limb bignums to their first limb, discarding higher bits
- Replaced `@bitCast` with proper `@intCast` and range checking, returning `TypeError` when the value exceeds `i64` range or has multiple limbs
- Added multi-limb guard to `marshalToPointer` as well

## Test plan

- [x] Extended `tests/scheme/ffi/bignum-args.scm` with tests for negative bignum sign, 2^63 overflow error, and multi-limb error
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme integration tests pass (1529 pass, 0 fail)

Fixes #409
Fixes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)