### PR TITLE
Fix exact returning flonum instead of bignum for large values

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -25,7 +25,49 @@ fn safeFloatToExactInt(f: f64) PrimitiveError!Value {
     if (f >= min_i64 and f <= max_i64_f) {
         return try arith.makeFixnumChecked(@intFromFloat(f));
     }
-    return makeFlonumVal(f);
+    return floatToBignum(f);
+}
+
+fn floatToBignum(f: f64) PrimitiveError!Value {
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const positive = f >= 0;
+    const abs_f = @abs(f);
+    const bits: u64 = @bitCast(abs_f);
+    const raw_exp = @as(u11, @intCast((bits >> 52) & 0x7FF));
+    if (raw_exp == 0 or raw_exp == 0x7FF) return PrimitiveError.TypeError;
+    const mantissa: u64 = (bits & 0x000FFFFFFFFFFFFF) | 0x0010000000000000;
+    const exp: i16 = @as(i16, @intCast(raw_exp)) - 1023 - 52;
+    if (exp < 0) {
+        const shift: u6 = @intCast(-exp);
+        const result = mantissa >> shift;
+        if (result <= @as(u64, @intCast(std.math.maxInt(i48)))) {
+            const signed: i64 = if (positive) @intCast(result) else -@as(i64, @intCast(result));
+            return types.makeFixnum(signed);
+        }
+        const limbs = [1]u64{result};
+        return gc.allocBignumFromLimbs(&limbs, 1, positive) catch return PrimitiveError.OutOfMemory;
+    }
+    const shift: u6 = @intCast(@min(exp, 63));
+    if (exp <= 10) {
+        const result = mantissa << shift;
+        const limbs = [1]u64{result};
+        return gc.allocBignumFromLimbs(&limbs, 1, positive) catch return PrimitiveError.OutOfMemory;
+    }
+    const uexp: u16 = @intCast(exp);
+    const word_shift = uexp / 64;
+    const bit_shift: u6 = @intCast(uexp % 64);
+    const total_limbs = word_shift + 1 + @as(u16, if (bit_shift > 10) 1 else 0);
+    var limbs = gc.allocator.alloc(u64, total_limbs) catch return PrimitiveError.OutOfMemory;
+    defer gc.allocator.free(limbs);
+    @memset(limbs, 0);
+    limbs[word_shift] = mantissa << bit_shift;
+    if (bit_shift > 10 and word_shift + 1 < total_limbs) {
+        const complement: u6 = @intCast(64 - @as(u7, bit_shift));
+        limbs[word_shift + 1] = mantissa >> complement;
+    }
+    var len = total_limbs;
+    while (len > 0 and limbs[len - 1] == 0) len -= 1;
+    return gc.allocBignumFromLimbs(limbs[0..total_limbs], len, positive) catch return PrimitiveError.OutOfMemory;
 }
 const raiseDivByZero = arith.raiseDivByZero;
 

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -34,7 +34,7 @@ fn floatToBignum(f: f64) PrimitiveError!Value {
     const abs_f = @abs(f);
     const bits: u64 = @bitCast(abs_f);
     const raw_exp = @as(u11, @intCast((bits >> 52) & 0x7FF));
-    if (raw_exp == 0 or raw_exp == 0x7FF) return PrimitiveError.TypeError;
+    if (raw_exp == 0 or raw_exp == 0x7FF) return PrimitiveError.TypeError; // bare-ok: subnormal/inf guard
     const mantissa: u64 = (bits & 0x000FFFFFFFFFFFFF) | 0x0010000000000000;
     const exp: i16 = @as(i16, @intCast(raw_exp)) - 1023 - 52;
     if (exp < 0) {

--- a/tests/scheme/smoke/exact-large-float.scm
+++ b/tests/scheme/smoke/exact-large-float.scm
@@ -1,0 +1,39 @@
+;; Regression test for #414: exact returns flonum instead of bignum for large values
+
+(import (scheme base) (scheme write))
+
+;; exact of integer-valued floats outside i64 range must return exact integers
+(unless (exact? (exact 1e19))
+  (error "(exact 1e19) should be exact"))
+
+(unless (= (exact 1e19) 10000000000000000000)
+  (error "(exact 1e19) should equal 10000000000000000000"))
+
+(unless (exact? (exact -1e19))
+  (error "(exact -1e19) should be exact"))
+
+(unless (= (exact -1e19) -10000000000000000000)
+  (error "(exact -1e19) should equal -10000000000000000000"))
+
+(unless (exact? (exact 1e20))
+  (error "(exact 1e20) should be exact"))
+
+(unless (exact? (exact 1e100))
+  (error "(exact 1e100) should be exact"))
+
+;; Small values should still produce fixnums
+(unless (exact? (exact 42.0))
+  (error "(exact 42.0) should be exact"))
+
+(unless (= (exact 42.0) 42)
+  (error "(exact 42.0) should equal 42"))
+
+;; Non-integer floats should produce exact rationals
+(unless (exact? (exact 0.5))
+  (error "(exact 0.5) should be exact"))
+
+(unless (= (exact 0.5) 1/2)
+  (error "(exact 0.5) should equal 1/2"))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary

- Add `floatToBignum` that decomposes IEEE 754 f64 into mantissa/exponent and constructs bignum limbs
- `safeFloatToExactInt` now produces a bignum instead of falling back to flonum when the value exceeds i64 range
- `(exact 1e19)`, `(exact 1e100)` etc. now correctly return exact integers

## Test plan

- [x] Added `tests/scheme/smoke/exact-large-float.scm` testing exact of 1e19, -1e19, 1e20, 1e100, plus small values and rationals
- [x] Unit tests pass (`zig build test`)
- [x] Scheme integration tests pass (1531 pass, 0 fail)

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)