### PR TITLE
Fix expt with exact rational base returning inexact result

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -311,6 +311,19 @@ fn exptFn(args: []const Value) PrimitiveError!Value {
         const denom = bignum_mod.expt(gc, args[0], pos_exp) catch return PrimitiveError.OutOfMemory;
         return arith.makeRationalReduced(gc, types.makeFixnum(1), denom);
     }
+    if (types.isRationalObj(args[0]) and types.isFixnum(args[1])) {
+        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const r = types.toRational(args[0]);
+        const exp = types.toFixnum(args[1]);
+        if (exp == 0) return types.makeFixnum(1);
+        const abs_exp = types.makeFixnum(if (exp < 0) -exp else exp);
+        const num_pow = bignum_mod.expt(gc, r.numerator, abs_exp) catch return PrimitiveError.OutOfMemory;
+        const den_pow = bignum_mod.expt(gc, r.denominator, abs_exp) catch return PrimitiveError.OutOfMemory;
+        if (exp > 0) {
+            return arith.makeRationalReduced(gc, num_pow, den_pow);
+        }
+        return arith.makeRationalReduced(gc, den_pow, num_pow);
+    }
     // Complex exponentiation: z^w = e^(w * ln(z))
     if (types.isComplex(args[0]) or types.isComplex(args[1])) {
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;

--- a/tests/scheme/smoke/expt-rational.scm
+++ b/tests/scheme/smoke/expt-rational.scm
@@ -1,0 +1,29 @@
+;; Regression test for #433: expt with exact rational base returns inexact
+
+(import (scheme base) (scheme write))
+
+;; Positive exponent
+(unless (and (exact? (expt 1/2 3)) (= (expt 1/2 3) 1/8))
+  (error "(expt 1/2 3) should be exact 1/8"))
+
+(unless (and (exact? (expt 2/3 2)) (= (expt 2/3 2) 4/9))
+  (error "(expt 2/3 2) should be exact 4/9"))
+
+;; Negative exponent: (expt 1/2 -2) = (2/1)^2 = 4
+(unless (and (exact? (expt 1/2 -2)) (= (expt 1/2 -2) 4))
+  (error "(expt 1/2 -2) should be exact 4"))
+
+;; (expt 2/3 -1) = 3/2
+(unless (and (exact? (expt 2/3 -1)) (= (expt 2/3 -1) 3/2))
+  (error "(expt 2/3 -1) should be exact 3/2"))
+
+;; Zero exponent
+(unless (= (expt 3/4 0) 1)
+  (error "(expt 3/4 0) should be 1"))
+
+;; Large exponent
+(unless (exact? (expt 1/3 10))
+  (error "(expt 1/3 10) should be exact"))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary

- Add rational base case in `exptFn` that computes `(num^exp)/(den^exp)` using exact bignum arithmetic
- For negative exponents, the fraction is inverted: `(den^|exp|)/(num^|exp|)`
- `(expt 1/2 3)` now returns exact `1/8` instead of inexact `0.125`

## Test plan

- [x] Added `tests/scheme/smoke/expt-rational.scm` testing positive, negative, zero exponents and large exponents
- [x] Unit tests pass (`zig build test`)
- [x] Scheme integration tests pass (1532 pass, 0 fail)

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)