### PR TITLE
Fix export (rename) to use R7RS flat syntax

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -287,22 +287,18 @@ fn extractExportsAndImports(vm: *VM, source: []const u8) !LibraryMeta {
                     } else if (types.isPair(id)) {
                         const eh = types.car(id);
                         if (types.isSymbol(eh) and std.mem.eql(u8, types.symbolName(eh), "rename")) {
-                            var rl = types.cdr(id);
-                            while (rl != types.NIL and types.isPair(rl)) {
-                                const p = types.car(rl);
-                                if (types.isPair(p)) {
-                                    const os = types.car(p);
-                                    const nr = types.cdr(p);
-                                    if (types.isPair(nr)) {
-                                        const ns = types.car(nr);
-                                        if (types.isSymbol(os) and types.isSymbol(ns) and result.export_count < 128) {
-                                            result.export_names[result.export_count] = types.symbolName(os);
-                                            result.export_renames[result.export_count] = types.symbolName(ns);
-                                            result.export_count += 1;
-                                        }
+                            const rename_args = types.cdr(id);
+                            if (types.isPair(rename_args)) {
+                                const os = types.car(rename_args);
+                                const nr = types.cdr(rename_args);
+                                if (types.isPair(nr) and types.isSymbol(os)) {
+                                    const ns = types.car(nr);
+                                    if (types.isSymbol(ns) and result.export_count < 128) {
+                                        result.export_names[result.export_count] = types.symbolName(os);
+                                        result.export_renames[result.export_count] = types.symbolName(ns);
+                                        result.export_count += 1;
                                     }
                                 }
-                                rl = types.cdr(rl);
                             }
                         }
                     }
@@ -905,22 +901,18 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
                 } else if (types.isPair(id)) {
                     const head = types.car(id);
                     if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "rename")) {
-                        var rename_list = types.cdr(id);
-                        while (rename_list != types.NIL and types.isPair(rename_list)) {
-                            const pair = types.car(rename_list);
-                            if (types.isPair(pair)) {
-                                const old_sym = types.car(pair);
-                                const new_rest = types.cdr(pair);
-                                if (types.isPair(new_rest)) {
-                                    const new_sym = types.car(new_rest);
-                                    if (types.isSymbol(old_sym) and types.isSymbol(new_sym) and export_count < 128) {
-                                        export_names[export_count] = types.symbolName(old_sym);
-                                        export_renames[export_count] = types.symbolName(new_sym);
-                                        export_count += 1;
-                                    }
+                        const rename_args = types.cdr(id);
+                        if (types.isPair(rename_args)) {
+                            const old_sym = types.car(rename_args);
+                            const rest = types.cdr(rename_args);
+                            if (types.isPair(rest) and types.isSymbol(old_sym)) {
+                                const new_sym = types.car(rest);
+                                if (types.isSymbol(new_sym) and export_count < 128) {
+                                    export_names[export_count] = types.symbolName(old_sym);
+                                    export_renames[export_count] = types.symbolName(new_sym);
+                                    export_count += 1;
                                 }
                             }
-                            rename_list = types.cdr(rename_list);
                         }
                     }
                 }

--- a/tests/scheme/smoke/export-rename.scm
+++ b/tests/scheme/smoke/export-rename.scm
@@ -1,0 +1,29 @@
+;; Regression test for #429: export (rename old new) uses wrong syntax
+;; R7RS specifies flat syntax: (export (rename internal external))
+
+(import (scheme base) (scheme write))
+
+;; Test with a library defined via define-library using rename exports
+(define-library (test rename-lib)
+  (export (rename internal-val external-val)
+          (rename helper-fn public-fn)
+          plain-val)
+  (import (scheme base))
+  (begin
+    (define internal-val 42)
+    (define helper-fn (lambda (x) (* x 2)))
+    (define plain-val 99)))
+
+(import (test rename-lib))
+
+(unless (= external-val 42)
+  (error "renamed export external-val should be 42" external-val))
+
+(unless (= (public-fn 5) 10)
+  (error "renamed export public-fn should work"))
+
+(unless (= plain-val 99)
+  (error "plain export should still work"))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary

- Fix `handleDefineLibrary` and `extractExportsAndImports` to parse R7RS flat syntax `(rename old new)` instead of non-standard nested `(rename (old new) ...)`
- Aligns both paths with the correct parsing already used by `includeLibraryDeclarations`
- Libraries using standard `(export (rename internal external))` now work correctly

## Test plan

- [x] Added `tests/scheme/smoke/export-rename.scm` testing renamed exports via `define-library`
- [x] Verified external `.sld` file loading also works with renamed exports
- [x] Unit tests pass (`zig build test`)
- [x] Scheme integration tests pass (1533 pass, 0 fail)

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)