### PR TITLE
Handle bignum and rational in real-part, imag-part, magnitude, angle

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -927,7 +927,7 @@ fn realPart(args: []const Value) PrimitiveError!Value {
         }
         return makeFlonumVal(c.real);
     }
-    if (types.isFixnum(args[0]) or types.isFlonum(args[0])) return args[0];
+    if (types.isFixnum(args[0]) or types.isFlonum(args[0]) or types.isBignum(args[0]) or types.isRationalObj(args[0])) return args[0];
     return primitives.typeError("real-part", "number", args[0]);
 }
 
@@ -939,7 +939,7 @@ fn imagPart(args: []const Value) PrimitiveError!Value {
         }
         return makeFlonumVal(c.imag);
     }
-    if (types.isFixnum(args[0])) return types.makeFixnum(0);
+    if (types.isFixnum(args[0]) or types.isBignum(args[0]) or types.isRationalObj(args[0])) return types.makeFixnum(0);
     if (types.isFlonum(args[0])) return makeFlonumVal(0.0);
     return primitives.typeError("imag-part", "number", args[0]);
 }
@@ -956,6 +956,13 @@ fn magnitudeFn(args: []const Value) PrimitiveError!Value {
     if (types.isFlonum(args[0])) {
         return makeFlonumVal(@abs(types.toFlonum(args[0])));
     }
+    if (types.isBignum(args[0])) {
+        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        return bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
+    }
+    if (types.isRationalObj(args[0])) {
+        return makeFlonumVal(@abs(try toF64Ext(args[0])));
+    }
     return primitives.typeError("magnitude", "number", args[0]);
 }
 
@@ -970,6 +977,13 @@ fn angleFn(args: []const Value) PrimitiveError!Value {
     }
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
+        return makeFlonumVal(if (f >= 0.0) 0.0 else std.math.pi);
+    }
+    if (types.isBignum(args[0])) {
+        return makeFlonumVal(if (bignum_mod.isNegative(args[0])) std.math.pi else 0.0);
+    }
+    if (types.isRationalObj(args[0])) {
+        const f = try toF64Ext(args[0]);
         return makeFlonumVal(if (f >= 0.0) 0.0 else std.math.pi);
     }
     return primitives.typeError("angle", "number", args[0]);

--- a/tests/scheme/smoke/complex-accessors-types.scm
+++ b/tests/scheme/smoke/complex-accessors-types.scm
@@ -1,0 +1,35 @@
+;; Regression test for #423: real-part, imag-part, magnitude, angle
+;; must accept bignum and rational arguments
+
+(import (scheme base) (scheme write) (scheme inexact))
+
+;; Rational arguments
+(unless (= (real-part 1/2) 1/2)
+  (error "(real-part 1/2) should be 1/2"))
+(unless (= (imag-part 1/2) 0)
+  (error "(imag-part 1/2) should be 0"))
+(unless (> (magnitude 1/2) 0)
+  (error "(magnitude 1/2) should be positive"))
+(unless (= (angle 1/2) 0)
+  (error "(angle 1/2) should be 0 for positive rational"))
+(unless (> (angle -1/2) 3)
+  (error "(angle -1/2) should be pi for negative rational"))
+
+;; Bignum arguments
+(let ((big (expt 2 100)))
+  (unless (= (real-part big) big)
+    (error "(real-part bignum) should return the bignum"))
+  (unless (= (imag-part big) 0)
+    (error "(imag-part bignum) should be 0"))
+  (unless (= (magnitude big) big)
+    (error "(magnitude bignum) should return abs value"))
+  (unless (= (angle big) 0)
+    (error "(angle bignum) should be 0 for positive bignum")))
+
+;; Negative bignum
+(let ((neg-big (- (expt 2 100))))
+  (unless (> (angle neg-big) 3)
+    (error "(angle neg-bignum) should be pi")))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary

- Add bignum and rational cases to `real-part`, `imag-part`, `magnitude`, and `angle`
- For real numbers: `real-part` returns itself, `imag-part` returns 0, `magnitude` returns `|x|`, `angle` returns 0 or pi
- Bignums and rationals are valid real numbers per R7RS

## Test plan

- [x] Added `tests/scheme/smoke/complex-accessors-types.scm` testing all four functions with rationals and bignums
- [x] Unit tests pass (`zig build test`)
- [x] Scheme integration tests pass (1534 pass, 0 fail)

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)