### PR TITLE
Support radix in number->string for bignums

### DIFF
--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -572,6 +572,77 @@ pub fn toString(allocator: std.mem.Allocator, v: Value) ![]u8 {
     return (result.toOwnedSlice(allocator) catch return error.OutOfMemory);
 }
 
+pub fn toStringRadix(allocator: std.mem.Allocator, v: Value, radix: u8) ![]u8 {
+    if (radix == 10) return toString(allocator, v);
+    if (types.isFixnum(v)) {
+        var buf: [68]u8 = undefined;
+        var n = types.toFixnum(v);
+        const neg = n < 0;
+        if (neg) n = -n;
+        var pos: usize = buf.len;
+        if (n == 0) {
+            pos -= 1;
+            buf[pos] = '0';
+        } else {
+            const r: i64 = @intCast(radix);
+            while (n > 0) {
+                pos -= 1;
+                const digit: u8 = @intCast(@as(u64, @bitCast(@rem(n, r))));
+                buf[pos] = if (digit < 10) '0' + digit else 'a' + digit - 10;
+                n = @divTrunc(n, r);
+            }
+        }
+        if (neg) {
+            pos -= 1;
+            buf[pos] = '-';
+        }
+        return allocator.dupe(u8, buf[pos..]) catch return error.OutOfMemory;
+    }
+
+    const bn = types.toBignum(v);
+    if (bn.len == 0) {
+        return allocator.dupe(u8, "0") catch return error.OutOfMemory;
+    }
+
+    const r64: u64 = @intCast(radix);
+    var work = try allocator.alloc(u64, bn.len);
+    defer allocator.free(work);
+    @memcpy(work, bn.limbs[0..bn.len]);
+    var work_len = bn.len;
+
+    var digits_list: std.ArrayList(u8) = .empty;
+    defer digits_list.deinit(allocator);
+
+    while (work_len > 0) {
+        var rem: u128 = 0;
+        var i: usize = work_len;
+        while (i > 0) {
+            i -= 1;
+            rem = (rem << 64) | @as(u128, work[i]);
+            work[i] = @truncate(rem / @as(u128, r64));
+            rem = rem % @as(u128, r64);
+        }
+        const digit: u8 = @intCast(@as(u64, @truncate(rem)));
+        digits_list.append(allocator, if (digit < 10) '0' + digit else 'a' + digit - 10) catch return error.OutOfMemory;
+        while (work_len > 0 and work[work_len - 1] == 0) work_len -= 1;
+    }
+
+    var result: std.ArrayList(u8) = .empty;
+    defer result.deinit(allocator);
+
+    if (!bn.positive) {
+        result.append(allocator, '-') catch return error.OutOfMemory;
+    }
+
+    var i: usize = digits_list.items.len;
+    while (i > 0) {
+        i -= 1;
+        result.append(allocator, digits_list.items[i]) catch return error.OutOfMemory;
+    }
+
+    return (result.toOwnedSlice(allocator) catch return error.OutOfMemory);
+}
+
 /// Parse a decimal string into a bignum Value.
 pub fn parseBignumString(gc: *memory.GC, digits: []const u8, radix: u8) !Value {
     if (digits.len == 0) return types.makeFixnum(0);

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -750,7 +750,7 @@ fn numberToString(args: []const Value) PrimitiveError!Value {
         return gc.allocString(s) catch return PrimitiveError.OutOfMemory;
     }
     if (types.isBignum(args[0])) {
-        const s = bignum_mod.toString(gc.allocator, args[0]) catch return PrimitiveError.OutOfMemory;
+        const s = bignum_mod.toStringRadix(gc.allocator, args[0], radix) catch return PrimitiveError.OutOfMemory;
         defer gc.allocator.free(s);
         return gc.allocString(s) catch return PrimitiveError.OutOfMemory;
     }

--- a/tests/scheme/smoke/number-string-bignum-radix.scm
+++ b/tests/scheme/smoke/number-string-bignum-radix.scm
@@ -1,0 +1,27 @@
+;; Regression test for #417: number->string ignores radix for bignums
+
+(import (scheme base) (scheme write))
+
+;; 2^64 in hex should be "10000000000000000"
+(unless (string=? (number->string (expt 2 64) 16) "10000000000000000")
+  (error "bignum hex failed" (number->string (expt 2 64) 16)))
+
+;; 2^64 in binary should be 1 followed by 64 zeros
+(unless (string=? (number->string (expt 2 64) 2)
+                  "10000000000000000000000000000000000000000000000000000000000000000")
+  (error "bignum binary failed"))
+
+;; Negative bignum in hex
+(unless (string=? (number->string (- (expt 2 64)) 16) "-10000000000000000")
+  (error "negative bignum hex failed"))
+
+;; Octal
+(unless (string=? (number->string (expt 2 64) 8) "2000000000000000000000")
+  (error "bignum octal failed"))
+
+;; Decimal (default) still works
+(unless (string=? (number->string (expt 2 64)) "18446744073709551616")
+  (error "bignum decimal failed"))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary

- Add `toStringRadix` to `bignum.zig` that formats bignums in any base 2-36
- `number->string` now passes the radix to bignum formatting
- `(number->string (expt 2 64) 16)` now correctly returns `"10000000000000000"` instead of decimal

## Test plan

- [x] Added `tests/scheme/smoke/number-string-bignum-radix.scm` testing hex, binary, octal, and decimal
- [x] Unit tests pass (`zig build test`)
- [x] Scheme integration tests pass (1536 pass, 0 fail)

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)