### PR TITLE
Support radix in number->string for rationals

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -755,6 +755,20 @@ fn numberToString(args: []const Value) PrimitiveError!Value {
         return gc.allocString(s) catch return PrimitiveError.OutOfMemory;
     }
     if (types.isRationalObj(args[0])) {
+        if (radix != 10) {
+            const r = types.toRational(args[0]);
+            const num_s = bignum_mod.toStringRadix(gc.allocator, r.numerator, radix) catch return PrimitiveError.OutOfMemory;
+            defer gc.allocator.free(num_s);
+            const den_s = bignum_mod.toStringRadix(gc.allocator, r.denominator, radix) catch return PrimitiveError.OutOfMemory;
+            defer gc.allocator.free(den_s);
+            var result: std.ArrayList(u8) = .empty;
+            defer result.deinit(gc.allocator);
+            result.appendSlice(gc.allocator, num_s) catch return PrimitiveError.OutOfMemory;
+            result.append(gc.allocator, '/') catch return PrimitiveError.OutOfMemory;
+            result.appendSlice(gc.allocator, den_s) catch return PrimitiveError.OutOfMemory;
+            const s = result.items;
+            return gc.allocString(s) catch return PrimitiveError.OutOfMemory;
+        }
         const printer = @import("printer.zig");
         const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.OutOfMemory;
         defer gc.allocator.free(s);

--- a/tests/scheme/smoke/number-string-rational-radix.scm
+++ b/tests/scheme/smoke/number-string-rational-radix.scm
@@ -1,0 +1,22 @@
+;; Regression test for #430: number->string ignores radix for rationals
+
+(import (scheme base) (scheme write))
+
+(unless (string=? (number->string 255/256 16) "ff/100")
+  (error "rational hex failed" (number->string 255/256 16)))
+
+(unless (string=? (number->string 10/3 2) "1010/11")
+  (error "rational binary failed" (number->string 10/3 2)))
+
+(unless (string=? (number->string 1/2 16) "1/2")
+  (error "rational hex simple failed"))
+
+;; Decimal (default) still works
+(unless (string=? (number->string 1/2) "1/2")
+  (error "rational decimal failed"))
+
+(unless (string=? (number->string 7/8 8) "7/10")
+  (error "rational octal failed"))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary

- Format rational numerator and denominator individually using the specified radix
- `(number->string 255/256 16)` now correctly returns `"ff/100"` instead of `"255/256"`

## Test plan

- [x] Added `tests/scheme/smoke/number-string-rational-radix.scm` testing hex, binary, octal, and decimal
- [x] Unit tests pass (`zig build test`)
- [x] Scheme integration tests pass (1537 pass, 0 fail)

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)