### PR TITLE
Remove non-R7RS exports from (scheme write)

### DIFF
--- a/src/library.zig
+++ b/src/library.zig
@@ -219,7 +219,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
 
     // (scheme write) — write/display procedures
     const scheme_write_names = [_][]const u8{
-        "display",      "write",        "newline", "write-char", "write-string",
+        "display",      "write",
         "write-shared", "write-simple",
     };
     var write_lib = Library.init(allocator, "scheme.write");

--- a/tests/scheme/smoke/scheme-write-exports.scm
+++ b/tests/scheme/smoke/scheme-write-exports.scm
@@ -1,0 +1,13 @@
+;; Regression test for #425: (scheme write) should only export
+;; display, write, write-shared, write-simple per R7RS
+
+(import (scheme base))
+
+;; Verify newline, write-char, write-string come from (scheme base)
+(import (only (scheme base) newline write-char write-string))
+
+;; Verify (scheme write) has exactly the R7RS set
+(import (only (scheme write) display write write-shared write-simple))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary

- Remove `newline`, `write-char`, `write-string` from `(scheme write)` export list
- These belong in `(scheme base)` per R7RS Appendix A, where they are already exported
- Sandboxed version was already correct

## Test plan

- [x] Added `tests/scheme/smoke/scheme-write-exports.scm` verifying correct exports
- [x] Unit tests pass (`zig build test`)
- [x] Scheme integration tests pass (1537 pass, 0 fail)

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)