### PR TITLE
Remove open-binary-* from (scheme base)

### DIFF
--- a/src/library.zig
+++ b/src/library.zig
@@ -200,13 +200,12 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
         "call-with-port",
         // Binary I/O
                         "read-u8",               "peek-u8",                       "u8-ready?",
-        "write-u8",                       "read-bytevector",       "write-bytevector",              "open-binary-input-file",
-        "open-binary-output-file",
+        "write-u8",                       "read-bytevector",       "write-bytevector",
         // Bytevector ports
-               "open-input-bytevector", "open-output-bytevector",        "get-output-bytevector",
-        "read-bytevector!",
+                     "open-input-bytevector",
+        "open-output-bytevector",         "get-output-bytevector", "read-bytevector!",
         // String/vector conversion
-                      "string->vector",
+                     "string->vector",
     };
 
     var base = Library.init(allocator, "scheme.base");

--- a/tests/scheme/smoke/scheme-base-file-exports.scm
+++ b/tests/scheme/smoke/scheme-base-file-exports.scm
@@ -1,0 +1,9 @@
+;; Regression test for #422: open-binary-* should be in (scheme file), not (scheme base)
+
+(import (scheme base) (scheme write))
+
+;; These should come from (scheme file), not (scheme base)
+(import (only (scheme file) open-binary-input-file open-binary-output-file))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary

- Remove `open-binary-input-file` and `open-binary-output-file` from `(scheme base)` exports
- Per R7RS Appendix A, these belong exclusively in `(scheme file)` where they remain

## Test plan

- [x] Added `tests/scheme/smoke/scheme-base-file-exports.scm` verifying imports from (scheme file)
- [x] Unit tests pass (`zig build test`)
- [x] Scheme integration tests pass (1538 pass, 0 fail)

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)