### PR TITLE
Fix GC objectSize for continuations undercounting by 8x

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -683,7 +683,7 @@ fn objectSize(obj: *Object) usize {
         .record_type => @sizeOf(RecordType) + obj.as(RecordType).name.len,
         .record_instance => @sizeOf(RecordInstance) + obj.as(RecordInstance).fields.len * @sizeOf(Value),
         .port => @sizeOf(Port),
-        .continuation => @sizeOf(Continuation) + obj.as(Continuation).backing.len,
+        .continuation => @sizeOf(Continuation) + obj.as(Continuation).backing.len * @sizeOf(Value),
         .multiple_values => @sizeOf(MultipleValues) + obj.as(MultipleValues).values.len * @sizeOf(Value),
         .complex => @sizeOf(types.Complex),
         .promise => @sizeOf(Promise),

--- a/tests/scheme/smoke/continuation-gc-size.scm
+++ b/tests/scheme/smoke/continuation-gc-size.scm
@@ -1,0 +1,19 @@
+;; Regression test for #428: GC objectSize for continuations must count
+;; backing buffer in bytes (len * 8), not elements (len).
+;; If objectSize undercounts, bytes_allocated inflates over time.
+
+(import (scheme base) (scheme write))
+
+(define (make-continuation)
+  (call-with-current-continuation
+    (lambda (k) k)))
+
+;; Create and discard many continuations to exercise GC.
+;; If objectSize undercounts, bytes_allocated will grow unboundedly.
+(let loop ((i 0))
+  (when (< i 1000)
+    (make-continuation)
+    (loop (+ i 1))))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- Fix `objectSize` for continuations in `gc_collect.zig` to multiply `backing.len` by `@sizeOf(Value)` — the backing buffer is `[]Value` so `.len` is element count, not byte count
- Without this fix, `bytes_allocated` inflates monotonically in continuation-heavy code since sweep only subtracts 1/8th of what allocation adds
- Add regression test that creates and discards 1000 continuations

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1540 pass, 0 fail
- [x] New regression test `tests/scheme/smoke/continuation-gc-size.scm` passes

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)