### PR TITLE
Fix bytecode_file f64 read/write to use little-endian byte order

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -86,7 +86,8 @@ const Writer = struct {
     }
 
     fn writeF64(self: *Writer, allocator: std.mem.Allocator, v: f64) !void {
-        const bytes: [8]u8 = @bitCast(v);
+        const bits: u64 = @bitCast(v);
+        const bytes: [8]u8 = @bitCast(std.mem.nativeToLittle(u64, bits));
         self.buf.appendSlice(allocator, &bytes) catch return BytecodeError.OutOfMemory;
     }
 
@@ -146,7 +147,8 @@ const Reader = struct {
         if (self.pos + 8 > self.data.len) return BytecodeError.CorruptedFile;
         const bytes = self.data[self.pos..][0..8];
         self.pos += 8;
-        return @bitCast(bytes.*);
+        const bits = std.mem.littleToNative(u64, @bitCast(bytes.*));
+        return @bitCast(bits);
     }
 
     fn readBytes(self: *Reader, len: usize) ![]const u8 {


### PR DESCRIPTION
## Summary
- Fix `writeF64` and `readF64` in `bytecode_file.zig` to apply little-endian byte order conversion via u64 reinterpretation
- All integer methods already used `nativeToLittle`/`littleToNative`; floats were the only inconsistency
- Affects flonum constants and complex number real/imag parts in `.sbc` files

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1541 pass, 0 fail
- No behavioral change on little-endian platforms (all current targets)

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)