### PR TITLE
Add fixnum range validation during .sbc deserialization

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -342,6 +342,7 @@ fn readConstant(r: *Reader, gc: *GC, all_funcs: []*Function, depth: u32) !Value 
     switch (tag) {
         TAG_FIXNUM => {
             const n = try r.readI64();
+            if (n < -(1 << 47) or n >= (1 << 47)) return BytecodeError.CorruptedFile;
             return types.makeFixnum(n);
         },
         TAG_FLONUM => {


### PR DESCRIPTION
## Summary
- Add range check for TAG_FIXNUM in `readConstant`: reject i64 values outside [-2^47, 2^47-1] as `CorruptedFile`
- Without this, `makeFixnum` silently truncates out-of-range values from corrupted/malicious .sbc files
- Consistent with existing validation for TAG_CHAR, TAG_BOOLEAN, TAG_VECTOR

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1541 pass, 0 fail

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)