### PR TITLE
Handle EINTR in readFileContents and readAllStdin

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -151,7 +151,11 @@ fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     var tmp: [4096]u8 = undefined;
     while (true) {
         const raw = std.c.read(fd, &tmp, tmp.len);
-        if (raw <= 0) break;
+        if (raw == 0) break;
+        if (raw < 0) {
+            if (std.posix.errno(raw) == .INTR) continue;
+            break;
+        }
         const bytes_read: usize = @intCast(raw);
         if (result.items.len + bytes_read > max_size) {
             std.debug.print("File too large\n", .{});
@@ -171,7 +175,11 @@ fn readAllStdin(allocator: std.mem.Allocator) ![]u8 {
     var tmp: [4096]u8 = undefined;
     while (true) {
         const raw = std.c.read(0, &tmp, tmp.len);
-        if (raw <= 0) break;
+        if (raw == 0) break;
+        if (raw < 0) {
+            if (std.posix.errno(raw) == .INTR) continue;
+            break;
+        }
         const bytes_read: usize = @intCast(raw);
         if (result.items.len + bytes_read > max_size) return error.StreamTooLong;
         result.appendSlice(allocator, tmp[0..bytes_read]) catch |err| return err;


### PR DESCRIPTION
## Summary
- Fix `readFileContents` and `readAllStdin` to retry `read()` on EINTR instead of treating it as EOF
- Without this, a signal during file reading could silently truncate source code
- Consistent with `writeToFd` which already handles EINTR correctly

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1541 pass, 0 fail

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)