### PR TITLE
Fix string->number to return #f for #e+inf.0 and #e+nan.0

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -926,10 +926,14 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
     }
     if (s.len == 0) return types.FALSE;
 
-    if (std.mem.eql(u8, s, "+inf.0")) return types.makeFlonum(std.math.inf(f64));
-    if (std.mem.eql(u8, s, "-inf.0")) return types.makeFlonum(-std.math.inf(f64));
-    if (std.mem.eql(u8, s, "+nan.0")) return types.makeFlonum(std.math.nan(f64));
-    if (std.mem.eql(u8, s, "-nan.0")) return types.makeFlonum(std.math.nan(f64));
+    if (std.mem.eql(u8, s, "+inf.0") or std.mem.eql(u8, s, "-inf.0") or
+        std.mem.eql(u8, s, "+nan.0") or std.mem.eql(u8, s, "-nan.0"))
+    {
+        if (exactness == .exact) return types.FALSE;
+        if (std.mem.eql(u8, s, "+inf.0")) return types.makeFlonum(std.math.inf(f64));
+        if (std.mem.eql(u8, s, "-inf.0")) return types.makeFlonum(-std.math.inf(f64));
+        return types.makeFlonum(std.math.nan(f64));
+    }
 
     // Rational: num/den
     if (std.mem.indexOfScalar(u8, s, '/')) |slash_pos| {

--- a/tests/scheme/smoke/exact-inf-nan.scm
+++ b/tests/scheme/smoke/exact-inf-nan.scm
@@ -1,0 +1,34 @@
+;; Regression test for #419: string->number with #e prefix must return #f
+;; for +inf.0, -inf.0, +nan.0, -nan.0 (no exact representation exists).
+
+(import (scheme base) (scheme write))
+
+(define (test name expr expected)
+  (unless (equal? expr expected)
+    (display "FAIL: ")
+    (display name)
+    (display " => ")
+    (write expr)
+    (display " expected ")
+    (write expected)
+    (newline)
+    (error "test failed" name)))
+
+(test "#e+inf.0" (string->number "#e+inf.0") #f)
+(test "#e-inf.0" (string->number "#e-inf.0") #f)
+(test "#e+nan.0" (string->number "#e+nan.0") #f)
+(test "#e-nan.0" (string->number "#e-nan.0") #f)
+
+;; #i prefix should still work
+(test "#i+inf.0" (infinite? (string->number "#i+inf.0")) #t)
+(test "#i-inf.0" (infinite? (string->number "#i-inf.0")) #t)
+(test "#i+nan.0" (nan? (string->number "#i+nan.0")) #t)
+
+;; No prefix should still work
+(test "+inf.0" (infinite? (string->number "+inf.0")) #t)
+(test "-inf.0" (infinite? (string->number "-inf.0")) #t)
+(test "+nan.0" (nan? (string->number "+nan.0")) #t)
+(test "-nan.0" (nan? (string->number "-nan.0")) #t)
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- Fix `string->number` to return `#f` when `#e` (exact) prefix is used with `+inf.0`, `-inf.0`, `+nan.0`, `-nan.0`
- These values have no exact representation per R7RS section 6.2.7
- Previously the inf/NaN checks returned before `applyExactness` was called
- Add regression test covering `#e`, `#i`, and unprefixed variants

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1542 pass, 0 fail
- [x] New test `tests/scheme/smoke/exact-inf-nan.scm` passes

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)