### PR TITLE
Set current_lib_dir in disassembleFile and emitLlvmFile

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -911,6 +911,10 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
     const source = readFileContents(allocator, path) catch return;
     defer allocator.free(source);
 
+    const saved_lib_dir = vm.current_lib_dir;
+    vm.current_lib_dir = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[0 .. pos + 1] else "";
+    defer vm.current_lib_dir = saved_lib_dir;
+
     var r = reader.Reader.initWithName(vm.gc, source, path);
     defer r.deinit();
 
@@ -1092,6 +1096,10 @@ fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !voi
     const allocator = vm.gc.allocator;
     const source = readFileContents(allocator, path) catch return;
     defer allocator.free(source);
+
+    const saved_lib_dir = vm.current_lib_dir;
+    vm.current_lib_dir = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[0 .. pos + 1] else "";
+    defer vm.current_lib_dir = saved_lib_dir;
 
     var r = reader.Reader.initWithName(vm.gc, source, path);
     defer r.deinit();


### PR DESCRIPTION
## Summary
- Add `current_lib_dir` save/restore in `disassembleFile` and `emitLlvmFile`
- Without this, `(include "helper.scm")` resolves relative to CWD instead of the source file
- Matches the pattern already used by `runFile` and `compileFile`

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1542 pass, 0 fail

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)