### PR TITLE
Make FFI (pointer,long,long,pointer)->void handler generic

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -742,19 +742,11 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     const p3 = normalizeType(ffi_fn.param_types[3]);
     const rt = normalizeType(ffi_fn.return_type);
 
-    // (pointer, long, long, pointer) -> void  — qsort
+    // (pointer, long, long, pointer) -> void
     if (p0 == .pointer and p1 == .long and p2 == .long and p3 == .pointer and rt == .void_type) {
-        const f: *const fn (?*anyopaque, usize, usize, *const fn (?*anyopaque, ?*anyopaque) callconv(.c) c_int) callconv(.c) void =
+        const f: *const fn (?*anyopaque, c_long, c_long, ?*anyopaque) callconv(.c) void =
             @ptrCast(@alignCast(ffi_fn.symbol));
-        const ptr0 = marshalToPointer(args[0]) orelse return error.TypeError;
-        const n_signed = try toIntArg(args[1]);
-        const sz_signed = try toIntArg(args[2]);
-        if (n_signed < 0 or sz_signed < 0) return error.TypeError;
-        const n: usize = @intCast(n_signed);
-        const sz: usize = @intCast(sz_signed);
-        const cmp_ptr = marshalToPointer(args[3]) orelse return error.TypeError;
-        const cmp: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(cmp_ptr));
-        f(ptr0, n, sz, cmp);
+        f(marshalToPointer(args[0]), @intCast(try toIntArg(args[1])), @intCast(try toIntArg(args[2])), marshalToPointer(args[3]));
         return types.VOID;
     }
 


### PR DESCRIPTION
## Summary
- Replace qsort-specific FFI handler with a generic one for `(pointer, long, long, pointer) -> void`
- The old handler rejected null pointers, negative longs, and force-cast arg3 as a function pointer
- Now uses `c_long` for args 1/2 and `?*anyopaque` for all pointer args, matching declared types

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1542 pass, 0 fail
- [x] FFI tests in `tests/scheme/ffi/` pass

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)