### PR TITLE
Fix thottam resolveVersion using bare 'git' path

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -210,7 +210,7 @@ fn matchesAllConstraints(v: Semver, constraints: [4]?Constraint) bool {
 fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constraint_str: []const u8) ?[]const u8 {
     const constraints = parseConstraints(constraint_str) orelse return null;
 
-    const output = runCapture(allocator, &.{ "git", "ls-remote", "--tags", clone_url }, null) catch return null;
+    const output = runGitCapture(allocator, &.{ "ls-remote", "--tags", clone_url }) catch return null;
     defer allocator.free(output);
 
     var best: ?Semver = null;


### PR DESCRIPTION
## Summary

- `resolveVersion` passed bare `"git"` to `runCapture` which uses `execve`. Since `execve` doesn't search PATH, the git command always failed with ENOENT, making semver constraint resolution completely broken.
- Switch to `runGitCapture` which prepends `/usr/bin/git`, consistent with all other git invocations in the file.

Fixes #415

## Test plan

- [x] All unit tests pass (`zig build test`)
- [x] All 1542 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)