### PR TITLE
Fix caret semver constraint for major version 0

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -148,7 +148,12 @@ const Constraint = struct {
             .lte => Semver.order(v, self.ver) != .gt,
             .lt => Semver.order(v, self.ver) == .lt,
             .eq => Semver.order(v, self.ver) == .eq,
-            .caret => v.major == self.ver.major and Semver.order(v, self.ver) != .lt,
+            .caret => blk: {
+                if (Semver.order(v, self.ver) == .lt) break :blk false;
+                if (self.ver.major != 0) break :blk v.major == self.ver.major;
+                if (self.ver.minor != 0) break :blk v.major == 0 and v.minor == self.ver.minor;
+                break :blk v.major == 0 and v.minor == 0 and v.patch == self.ver.patch;
+            },
             .tilde => v.major == self.ver.major and v.minor == self.ver.minor and Semver.order(v, self.ver) != .lt,
         };
     }
@@ -1282,6 +1287,31 @@ test "parseField" {
     try std.testing.expectEqualStrings("value", parseField("key:  value  ", "key:").?);
     try std.testing.expect(parseField("other: value", "key:") == null);
     try std.testing.expect(parseField("", "key:") == null);
+}
+
+test "caret constraint: major > 0 locks major" {
+    const c = Constraint{ .op = .caret, .ver = .{ .major = 1, .minor = 2, .patch = 3 } };
+    try std.testing.expect(c.matches(.{ .major = 1, .minor = 2, .patch = 3 }));
+    try std.testing.expect(c.matches(.{ .major = 1, .minor = 9, .patch = 0 }));
+    try std.testing.expect(!c.matches(.{ .major = 2, .minor = 0, .patch = 0 }));
+    try std.testing.expect(!c.matches(.{ .major = 1, .minor = 2, .patch = 2 }));
+}
+
+test "caret constraint: major=0 minor>0 locks minor" {
+    const c = Constraint{ .op = .caret, .ver = .{ .major = 0, .minor = 2, .patch = 3 } };
+    try std.testing.expect(c.matches(.{ .major = 0, .minor = 2, .patch = 3 }));
+    try std.testing.expect(c.matches(.{ .major = 0, .minor = 2, .patch = 9 }));
+    try std.testing.expect(!c.matches(.{ .major = 0, .minor = 3, .patch = 0 }));
+    try std.testing.expect(!c.matches(.{ .major = 0, .minor = 2, .patch = 2 }));
+    try std.testing.expect(!c.matches(.{ .major = 1, .minor = 0, .patch = 0 }));
+}
+
+test "caret constraint: major=0 minor=0 locks patch" {
+    const c = Constraint{ .op = .caret, .ver = .{ .major = 0, .minor = 0, .patch = 3 } };
+    try std.testing.expect(c.matches(.{ .major = 0, .minor = 0, .patch = 3 }));
+    try std.testing.expect(!c.matches(.{ .major = 0, .minor = 0, .patch = 4 }));
+    try std.testing.expect(!c.matches(.{ .major = 0, .minor = 0, .patch = 2 }));
+    try std.testing.expect(!c.matches(.{ .major = 0, .minor = 1, .patch = 0 }));
 }
 
 test "dylib_ext is correct for platform" {


### PR DESCRIPTION
## Summary

- `^0.2.3` now correctly means `>=0.2.3, <0.3.0` (locks minor when major=0)
- `^0.0.3` now correctly means `>=0.0.3, <0.0.4` (locks patch when major=0, minor=0)
- `^1.2.3` behavior unchanged (`>=1.2.3, <2.0.0`)

Fixes #399

## Test plan

- [x] Unit tests for all three caret cases (major>0, major=0/minor>0, major=0/minor=0)
- [x] All unit tests pass (`zig build test`)
- [x] All 1542 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)