### PR TITLE
Fix readFile to propagate read errors instead of partial data

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -265,7 +265,10 @@ fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     var tmp: [4096]u8 = undefined;
     while (true) {
-        const n = std.posix.read(fd, &tmp) catch return buf.toOwnedSlice(allocator);
+        const n = std.posix.read(fd, &tmp) catch {
+            buf.deinit(allocator);
+            return error.ReadFailed;
+        };
         if (n == 0) break;
         buf.appendSlice(allocator, tmp[0..n]) catch return error.OutOfMemory;
     }


### PR DESCRIPTION
## Summary

- `readFile` returned partial content on mid-file read error, which could corrupt lockfile/installed list when callers rewrite the file
- Now calls `buf.deinit()` and returns `error.ReadFailed` so callers can handle the error properly

Fixes #402

## Test plan

- [x] All unit tests pass (`zig build test`)
- [x] All 1542 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)