### PR TITLE
Fix thottam verify SHA parsing to exclude source URL

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -1060,7 +1060,8 @@ fn doVerify(allocator: std.mem.Allocator, config: Config) !void {
         if (line.len == 0) continue;
         const space = std.mem.indexOfScalar(u8, line, ' ') orelse continue;
         const pkg = line[0..space];
-        const locked_sha = line[space + 1 ..];
+        const rest = line[space + 1 ..];
+        const locked_sha = if (std.mem.indexOfScalar(u8, rest, ' ')) |sp2| rest[0..sp2] else rest;
 
         const current_sha = getPkgSha(allocator, config.src_dir, pkg);
         if (current_sha == null) {


### PR DESCRIPTION
## Summary

- `doVerify` split lockfile lines on only the first space, so when a source URL was present (format: `"pkg sha url"`), `locked_sha` included the URL
- Every package with a custom source URL reported a false MISMATCH
- Now extracts just the SHA by finding the second space delimiter

Fixes #398

## Test plan

- [x] All unit tests pass (`zig build test`)
- [x] All 1542 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)