### PR TITLE
Fix pending_lib_envs unconditional pop causing UAF on deep nesting

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -865,13 +865,14 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
     // Root the library environment so GC can trace closures defined in
     // begin blocks before the library is registered. Push/pop for
     // nested library loading (e.g. SRFI 64 importing SRFI 35).
-    if (vm.pending_lib_env_count < vm.pending_lib_envs.len) {
+    const pushed_lib_env = vm.pending_lib_env_count < vm.pending_lib_envs.len;
+    if (pushed_lib_env) {
         vm.pending_lib_envs[vm.pending_lib_env_count] = lib_env;
         vm.pending_lib_env_count += 1;
     }
-    defer {
-        if (vm.pending_lib_env_count > 0) vm.pending_lib_env_count -= 1;
-    }
+    defer if (pushed_lib_env) {
+        vm.pending_lib_env_count -= 1;
+    };
 
     var export_names: [128][]const u8 = undefined;
     var export_renames: [128]?[]const u8 = undefined;

--- a/tests/scheme/smoke/nested-lib-env-root.scm
+++ b/tests/scheme/smoke/nested-lib-env-root.scm
@@ -1,0 +1,79 @@
+;; Regression test for issue #516: pending_lib_envs conditional push
+;; but unconditional pop over-decrements the counter, un-rooting
+;; in-flight library environments during deeply nested imports.
+;;
+;; Creates a chain of 12 nested libraries (beyond the 8-slot stack)
+;; to verify push/pop symmetry.
+
+(import (scheme base) (scheme process-context))
+
+(define-library (nest-1)
+  (import (scheme base))
+  (export nest-1-val)
+  (begin (define nest-1-val 1)))
+
+(define-library (nest-2)
+  (import (scheme base) (nest-1))
+  (export nest-2-val)
+  (begin (define nest-2-val (+ nest-1-val 1))))
+
+(define-library (nest-3)
+  (import (scheme base) (nest-2))
+  (export nest-3-val)
+  (begin (define nest-3-val (+ nest-2-val 1))))
+
+(define-library (nest-4)
+  (import (scheme base) (nest-3))
+  (export nest-4-val)
+  (begin (define nest-4-val (+ nest-3-val 1))))
+
+(define-library (nest-5)
+  (import (scheme base) (nest-4))
+  (export nest-5-val)
+  (begin (define nest-5-val (+ nest-4-val 1))))
+
+(define-library (nest-6)
+  (import (scheme base) (nest-5))
+  (export nest-6-val)
+  (begin (define nest-6-val (+ nest-5-val 1))))
+
+(define-library (nest-7)
+  (import (scheme base) (nest-6))
+  (export nest-7-val)
+  (begin (define nest-7-val (+ nest-6-val 1))))
+
+(define-library (nest-8)
+  (import (scheme base) (nest-7))
+  (export nest-8-val)
+  (begin (define nest-8-val (+ nest-7-val 1))))
+
+(define-library (nest-9)
+  (import (scheme base) (nest-8))
+  (export nest-9-val)
+  (begin (define nest-9-val (+ nest-8-val 1))))
+
+(define-library (nest-10)
+  (import (scheme base) (nest-9))
+  (export nest-10-val)
+  (begin (define nest-10-val (+ nest-9-val 1))))
+
+(define-library (nest-11)
+  (import (scheme base) (nest-10))
+  (export nest-11-val)
+  (begin (define nest-11-val (+ nest-10-val 1))))
+
+(define-library (nest-12)
+  (import (scheme base) (nest-11))
+  (export nest-12-val)
+  (begin (define nest-12-val (+ nest-11-val 1))))
+
+(import (nest-12))
+
+(unless (= nest-12-val 12)
+  (display "FAIL: expected 12, got ")
+  (display nest-12-val)
+  (newline)
+  (exit 1))
+
+(display "PASS: nested-lib-env-root")
+(newline)


### PR DESCRIPTION
## Summary
- Fixed `handleDefineLibrary` where the `defer` block unconditionally decremented `pending_lib_env_count` even when the capacity check prevented the push, causing counter desync that un-rooted still-active library environments during GC (use-after-free)
- Made push/pop symmetric by tracking whether the frame actually pushed via a `pushed_lib_env` flag

## Test plan
- [x] Added `tests/scheme/smoke/nested-lib-env-root.scm` — creates a chain of 12 nested libraries (beyond 8-slot cap) to verify push/pop symmetry
- [x] All unit tests pass (`zig build test`)
- [x] All 1543 Scheme integration tests pass (`run-all.sh`)

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)