### PR TITLE
Fix deepCopy hash table using wrong hash function

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const types = @import("types.zig");
+const hashtable = @import("primitives_hashtable.zig");
 const Value = types.Value;
 const Object = types.Object;
 const ObjectTag = types.ObjectTag;
@@ -1167,8 +1168,7 @@ pub const GC = struct {
                     if (entry.key != types.VOID and entry.key != types.EOF) {
                         const nk = try self.deepCopyValue(entry.key, visited);
                         const nv = try self.deepCopyValue(entry.value, visited);
-                        const hash = std.hash.Wyhash.hash(0, std.mem.asBytes(&nk));
-                        var idx = hash & (new_ht.capacity - 1);
+                        var idx = hashtable.valueHash(nk) & (new_ht.capacity - 1);
                         while (new_ht.entries[idx].key != types.VOID) {
                             idx = (idx + 1) & (new_ht.capacity - 1);
                         }

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -51,7 +51,7 @@ fn getHashTable(proc: []const u8, v: Value) PrimitiveError!*HashTable {
 const EMPTY: Value = types.VOID;
 const TOMBSTONE: Value = types.EOF;
 
-fn valueHash(key: Value) usize {
+pub fn valueHash(key: Value) usize {
     if (types.isFixnum(key)) {
         return @truncate(@as(u64, @bitCast(types.toFixnum(key))) *% 2654435761);
     }


### PR DESCRIPTION
## Summary
- Made `valueHash` pub in `primitives_hashtable.zig` so it's accessible from `memory.zig`
- Replaced `std.hash.Wyhash.hash(0, asBytes(&nk))` with `hashtable.valueHash(nk)` in the hash_table arm of `deepCopyValue` so deep-copied hash tables use the same bucket placement as all accessors

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] All 1545 Scheme integration tests pass (`run-all.sh`)

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)