### PR TITLE
Fix extra_roots leak from successful bytecode deserialization

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -723,8 +723,7 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
     defer allocator.free(all_funcs);
 
     const roots_base = gc.extra_roots.items.len;
-    var deser_ok = false;
-    defer if (!deser_ok) gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
     for (0..func_count) |i| {
         all_funcs[i] = gc.allocFunction() catch return BytecodeError.OutOfMemory;
         gc.extra_roots.append(allocator, types.makePointer(@ptrCast(all_funcs[i]))) catch return BytecodeError.OutOfMemory;
@@ -865,7 +864,6 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
 
     const result = allocator.alloc(*Function, func_count) catch return BytecodeError.OutOfMemory;
     @memcpy(result, all_funcs);
-    deser_ok = true;
     return .{ .funcs = result, .top_level_count = top_level_count, .bundled_files = bundled_files, .preamble = preamble };
 }
 


### PR DESCRIPTION
## Summary
- Made the `defer gc.extra_roots.shrinkRetainingCapacity(roots_base)` unconditional instead of only running on the failure path
- Removed the now-unnecessary `deser_ok` flag

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] All 1545 Scheme integration tests pass (`run-all.sh`)

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)