### PR TITLE
Fix unbounded extra_roots growth from compiler macro re-rooting

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1356,7 +1356,6 @@ pub fn compileExpressionWithMacrosAt(gc: *memory.GC, expr: Value, vm_macros: *st
     var out_it = c.macros.iterator();
     while (out_it.next()) |entry| {
         vm_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return CompileError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, entry.value_ptr.*) catch return CompileError.OutOfMemory;
     }
     ok = true;
     return c.func;
@@ -1380,7 +1379,6 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
     var out_it = c.macros.iterator();
     while (out_it.next()) |entry| {
         vm_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return CompileError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, entry.value_ptr.*) catch return CompileError.OutOfMemory;
     }
     ok = true;
     return c.func;


### PR DESCRIPTION
## Summary
- Removed redundant `gc.extra_roots.append` for macro transformers in `compileExpressionWithMacrosAt` and `compileExpressionInEnv`
- Macros are already rooted via `vm.macros` marking in `markVMRoots` (vm.zig:84-89), so the extra_roots append was causing O(forms × macros) unbounded growth

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] All 1545 Scheme integration tests pass (`run-all.sh`)

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)