### PR TITLE
Fix identity elimination dropping type checks and breaking signed-zero

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -1048,6 +1048,10 @@ pub fn simplifyBooleans(ir: *IR, node: *Node) *Node {
 // Optimization: identity elimination
 // ---------------------------------------------------------------------------
 
+fn isExactInteger(val: Value) bool {
+    return types.isFixnum(val) or types.isBignum(val);
+}
+
 pub fn eliminateIdentity(ir: *IR, node: *Node) *Node {
     switch (node.tag) {
         .call => {
@@ -1061,28 +1065,28 @@ pub fn eliminateIdentity(ir: *IR, node: *Node) *Node {
                 const a = call.args[0];
                 const b = call.args[1];
 
-                // (+ x 0) → x, (+ 0 x) → x
+                // (+ x 0) → x, (+ 0 x) → x  (only for exact integer constants)
                 if (std.mem.eql(u8, name, "+")) {
-                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0)
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0 and a.tag == .constant and isExactInteger(a.data.constant))
                         return eliminateIdentity(ir, a);
-                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 0)
+                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 0 and b.tag == .constant and isExactInteger(b.data.constant))
                         return eliminateIdentity(ir, b);
                 }
-                // (* x 1) → x, (* 1 x) → x
+                // (* x 1) → x, (* 1 x) → x  (only for exact integer constants)
                 if (std.mem.eql(u8, name, "*")) {
-                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 1)
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 1 and a.tag == .constant and isExactInteger(a.data.constant))
                         return eliminateIdentity(ir, a);
-                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 1)
+                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 1 and b.tag == .constant and isExactInteger(b.data.constant))
                         return eliminateIdentity(ir, b);
-                    // (* x 0) → 0, (* 0 x) → 0 (only when the other operand is pure)
-                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0 and a.tag == .constant)
+                    // (* x 0) → 0, (* 0 x) → 0 (only when both operands are exact integer constants)
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0 and a.tag == .constant and isExactInteger(a.data.constant))
                         return ir.makeConst(types.makeFixnum(0)) catch return node;
-                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 0 and b.tag == .constant)
+                    if (a.tag == .constant and types.isFixnum(a.data.constant) and types.toFixnum(a.data.constant) == 0 and b.tag == .constant and isExactInteger(b.data.constant))
                         return ir.makeConst(types.makeFixnum(0)) catch return node;
                 }
-                // (- x 0) → x
+                // (- x 0) → x  (only for exact integer constants)
                 if (std.mem.eql(u8, name, "-")) {
-                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0)
+                    if (b.tag == .constant and types.isFixnum(b.data.constant) and types.toFixnum(b.data.constant) == 0 and a.tag == .constant and isExactInteger(a.data.constant))
                         return eliminateIdentity(ir, a);
                 }
             }

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -485,6 +485,23 @@ test "IR optimization: identity elimination — add zero" {
     defer ir.deinit();
 
     const plus_sym = try gc.allocSymbol("+");
+    const op = try ir.makeGlobalRef(plus_sym);
+    const five = try ir.makeConst(types.makeFixnum(5));
+    const zero = try ir.makeConst(types.makeFixnum(0));
+    const call = try ir.makeCall(op, &.{ five, zero });
+
+    const result = ir_mod.eliminateIdentity(&ir, call);
+    try std.testing.expect(result.tag == .constant);
+    try std.testing.expect(types.toFixnum(result.data.constant) == 5);
+}
+
+test "IR optimization: identity elimination — add zero skipped for non-constant" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    const plus_sym = try gc.allocSymbol("+");
     const x_sym = try gc.allocSymbol("x");
     const op = try ir.makeGlobalRef(plus_sym);
     const x = try ir.makeGlobalRef(x_sym);
@@ -492,7 +509,7 @@ test "IR optimization: identity elimination — add zero" {
     const call = try ir.makeCall(op, &.{ x, zero });
 
     const result = ir_mod.eliminateIdentity(&ir, call);
-    try std.testing.expect(result.tag == .global_ref);
+    try std.testing.expect(result.tag == .call);
 }
 
 test "IR optimization: identity elimination — multiply by zero (pure)" {

--- a/tests/scheme/smoke/identity-elim-typecheck.scm
+++ b/tests/scheme/smoke/identity-elim-typecheck.scm
@@ -1,0 +1,53 @@
+;; Regression test for issue #498: identity elimination must preserve
+;; type checks and IEEE signed-zero semantics.
+
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (check-error name thunk)
+  (guard (exn (#t (set! pass (+ pass 1))))
+    (thunk)
+    (set! fail (+ fail 1))
+    (display "FAIL: ") (display name) (display " should have raised error")
+    (newline)))
+
+;; (+ non-number 0) must raise error, not return the non-number
+(define g "hello")
+(check-error "(+ string 0) must error"
+  (lambda () (+ g 0)))
+
+(check-error "(+ 0 string) must error"
+  (lambda () (+ 0 g)))
+
+(check-error "(* string 1) must error"
+  (lambda () (* g 1)))
+
+(check-error "(- string 0) must error"
+  (lambda () (- g 0)))
+
+;; Signed zero: (+ -0.0 0) must be +0.0
+(define nz -0.0)
+(check "(+ -0.0 0) = +0.0" (eqv? (+ nz 0) 0.0) #t)
+(check "(+ -0.0 0) != -0.0" (eqv? (+ nz 0) -0.0) #f)
+
+;; Valid identity cases still work
+(check "(+ 5 0)" (+ 5 0) 5)
+(check "(+ 0 5)" (+ 0 5) 5)
+(check "(* 7 1)" (* 7 1) 7)
+(check "(- 3 0)" (- 3 0) 3)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary
- Added `isExactInteger` check so identity elimination only fires when the surviving operand is a constant fixnum/bignum
- Prevents type-error swallowing for non-numeric operands and preserves IEEE signed-zero semantics
- Updated IR unit test and added new test verifying non-constant operands are not eliminated

## Test plan
- [x] Added `tests/scheme/smoke/identity-elim-typecheck.scm` — tests type errors for non-numbers and signed-zero
- [x] Updated `tests_ir.zig` identity elimination test + added new non-constant test
- [x] All 1546 tests pass

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)