### PR TITLE
Fix EINTR handling in all read/write syscall loops

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -636,7 +636,11 @@ fn writeBufferToFile(w: *Writer, path: []const u8) !void {
     var total: usize = 0;
     while (total < w.buf.items.len) {
         const result = std.posix.system.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
-        if (result <= 0) return BytecodeError.WriteError;
+        if (result < 0) {
+            if (std.posix.errno(result) == .INTR) continue;
+            return BytecodeError.WriteError;
+        }
+        if (result == 0) return BytecodeError.WriteError;
         total += @as(usize, @intCast(result));
     }
 }
@@ -1157,7 +1161,11 @@ test "bytecode validation rejects oversized function count header" {
     var total: usize = 0;
     while (total < w.buf.items.len) {
         const wrote = std.posix.system.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
-        if (wrote <= 0) break;
+        if (wrote < 0) {
+            if (std.posix.errno(wrote) == .INTR) continue;
+            break;
+        }
+        if (wrote == 0) break;
         total += @as(usize, @intCast(wrote));
     }
 
@@ -1276,7 +1284,11 @@ test "bytecode validation rejects invalid opcode" {
     var total: usize = 0;
     while (total < w.buf.items.len) {
         const wrote = std.posix.system.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
-        if (wrote <= 0) break;
+        if (wrote < 0) {
+            if (std.posix.errno(wrote) == .INTR) continue;
+            break;
+        }
+        if (wrote == 0) break;
         total += @as(usize, @intCast(wrote));
     }
 

--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -519,8 +519,11 @@ fn writeStderr(bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
         const result: isize = std.posix.system.write(2, bytes.ptr + total, bytes.len - total);
-        if (result > 0) {
-            total += @intCast(result);
-        } else break;
+        if (result < 0) {
+            if (std.posix.errno(result) == .INTR) continue;
+            break;
+        }
+        if (result == 0) break;
+        total += @intCast(result);
     }
 }

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -282,9 +282,15 @@ fn portReadOneByte(port: *types.Port) ?u8 {
         return b;
     }
     var buf: [1]u8 = undefined;
-    const raw = std.posix.system.read(port.fd, &buf, buf.len);
-    if (raw <= 0) return null;
-    return buf[0];
+    while (true) {
+        const raw = std.posix.system.read(port.fd, &buf, buf.len);
+        if (raw < 0) {
+            if (std.posix.errno(raw) == .INTR) continue;
+            return null;
+        }
+        if (raw == 0) return null;
+        return buf[0];
+    }
 }
 
 fn readU8Fn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -125,7 +125,11 @@ pub fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
         const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) break;
+        if (result < 0) {
+            if (std.posix.errno(result) == .INTR) continue;
+            break;
+        }
+        if (result == 0) break;
         total += @as(usize, @intCast(result));
     }
 }
@@ -420,9 +424,15 @@ fn readOneByte(port: *types.Port) ?u8 {
         return byte;
     }
     var buf: [1]u8 = undefined;
-    const raw = std.posix.system.read(port.fd, &buf, buf.len);
-    if (raw <= 0) return null;
-    return buf[0];
+    while (true) {
+        const raw = std.posix.system.read(port.fd, &buf, buf.len);
+        if (raw < 0) {
+            if (std.posix.errno(raw) == .INTR) continue;
+            return null;
+        }
+        if (raw == 0) return null;
+        return buf[0];
+    }
 }
 
 fn readUtf8Char(port: *types.Port) ?u21 {
@@ -640,9 +650,12 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
     var tmp: [4096]u8 = undefined;
     while (true) {
         const raw_n = std.posix.system.read(port.fd, &tmp, tmp.len);
-        if (raw_n <= 0) break;
+        if (raw_n < 0) {
+            if (std.posix.errno(raw_n) == .INTR) continue;
+            break;
+        }
+        if (raw_n == 0) break;
         const n: usize = @intCast(raw_n);
-        if (n == 0) break;
         buf.appendSlice(gc.allocator, tmp[0..n]) catch return PrimitiveError.OutOfMemory;
     }
 

--- a/src/reporting.zig
+++ b/src/reporting.zig
@@ -8,7 +8,11 @@ fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
         const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) break;
+        if (result < 0) {
+            if (std.posix.errno(result) == .INTR) continue;
+            break;
+        }
+        if (result == 0) break;
         total += @as(usize, @intCast(result));
     }
 }
@@ -496,7 +500,11 @@ pub fn writeCoverageXml(vm: *vm_mod.VM, path: []const u8) void {
     var written: usize = 0;
     while (written < xml.items.len) {
         const result = std.posix.system.write(fd, xml.items.ptr + written, xml.items.len - written);
-        if (result <= 0) break;
+        if (result < 0) {
+            if (std.posix.errno(result) == .INTR) continue;
+            break;
+        }
+        if (result == 0) break;
         written += @as(usize, @intCast(result));
     }
 }

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -125,7 +125,11 @@ fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
         const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) break;
+        if (result < 0) {
+            if (std.posix.errno(result) == .INTR) continue;
+            break;
+        }
+        if (result == 0) break;
         total += @as(usize, @intCast(result));
     }
 }

--- a/src/vm_debug.zig
+++ b/src/vm_debug.zig
@@ -91,7 +91,13 @@ pub fn debugPause(vm: *VM, frame: *CallFrame) !void {
         var i: usize = 0;
         while (i < cmd_buf.len) {
             const result = std.posix.system.read(0, cmd_buf[i .. i + 1].ptr, 1);
-            if (result <= 0) {
+            if (result < 0) {
+                if (std.posix.errno(result) == .INTR) continue;
+                vm.debug_mode = false;
+                vm.step_mode = .none;
+                return;
+            }
+            if (result == 0) {
                 vm.debug_mode = false;
                 vm.step_mode = .none;
                 return;


### PR DESCRIPTION
## Summary
- All `read`/`write` syscall loops now retry on `EINTR` instead of silently treating the interrupted return (-1) as EOF/done
- Fixed 7 files: `primitives_io.zig`, `primitives_bytevector.zig`, `vm.zig`, `reporting.zig`, `disassembler.zig`, `bytecode_file.zig`, `vm_debug.zig`
- Matches existing EINTR-retry pattern already used in `main.zig` and `repl.zig`

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1546 pass, 0 fail
- [x] Structural fix: the bug is intermittent (requires signal during syscall) but the pattern is well-established POSIX practice

Fixes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)