### PR TITLE
Fix peek-char to restore exact consumed bytes on malformed UTF-8

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -435,16 +435,28 @@ fn readOneByte(port: *types.Port) ?u8 {
     }
 }
 
-fn readUtf8Char(port: *types.Port) ?u21 {
+const Utf8ReadResult = struct {
+    codepoint: u21,
+    bytes: [4]u8,
+    len: u3,
+};
+
+fn readUtf8CharWithBytes(port: *types.Port) ?Utf8ReadResult {
     const lead = readOneByte(port) orelse return null;
-    const seq_len = std.unicode.utf8ByteSequenceLength(lead) catch return @intCast(lead);
-    if (seq_len == 1) return @intCast(lead);
-    var buf: [4]u8 = undefined;
+    const seq_len = std.unicode.utf8ByteSequenceLength(lead) catch return .{ .codepoint = @intCast(lead), .bytes = .{ lead, 0, 0, 0 }, .len = 1 };
+    if (seq_len == 1) return .{ .codepoint = @intCast(lead), .bytes = .{ lead, 0, 0, 0 }, .len = 1 };
+    var buf: [4]u8 = .{ 0, 0, 0, 0 };
     buf[0] = lead;
     for (1..seq_len) |i| {
-        buf[i] = readOneByte(port) orelse return @intCast(lead);
+        buf[i] = readOneByte(port) orelse return .{ .codepoint = @intCast(lead), .bytes = buf, .len = @intCast(i) };
     }
-    return std.unicode.utf8Decode(buf[0..seq_len]) catch @intCast(lead);
+    const cp = std.unicode.utf8Decode(buf[0..seq_len]) catch return .{ .codepoint = @intCast(lead), .bytes = buf, .len = @intCast(seq_len) };
+    return .{ .codepoint = cp, .bytes = buf, .len = @intCast(seq_len) };
+}
+
+fn readUtf8Char(port: *types.Port) ?u21 {
+    const result = readUtf8CharWithBytes(port) orelse return null;
+    return result.codepoint;
 }
 
 fn readCharFn(args: []const Value) PrimitiveError!Value {
@@ -484,23 +496,18 @@ fn peekCharFn(args: []const Value) PrimitiveError!Value {
         return types.makeChar(@intCast(b));
     }
     const port2 = port;
-    const cp = readUtf8Char(port2) orelse return types.EOF;
-    // Put back the encoded bytes for peeking — only store lead byte
-    // and rewind string port position
-    if (port2.is_string_port and port2.string_pos > 0) {
-        var buf: [4]u8 = undefined;
-        const len = std.unicode.utf8Encode(cp, &buf) catch 1;
+    const result = readUtf8CharWithBytes(port2) orelse return types.EOF;
+    const len: usize = @intCast(result.len);
+    if (port2.is_string_port and port2.string_pos >= len) {
         port2.string_pos -= len;
     } else {
-        var buf: [4]u8 = undefined;
-        const len = std.unicode.utf8Encode(cp, &buf) catch 1;
-        port2.peek_byte = buf[0];
+        port2.peek_byte = result.bytes[0];
         if (len > 1) {
-            for (1..len) |i| port2.peek_extra[i - 1] = buf[i];
+            for (1..len) |i| port2.peek_extra[i - 1] = result.bytes[i];
             port2.peek_extra_len = @intCast(len - 1);
         }
     }
-    return types.makeChar(cp);
+    return types.makeChar(result.codepoint);
 }
 
 fn readLineFn(args: []const Value) PrimitiveError!Value {

--- a/tests/scheme/smoke/peek-char-malformed-utf8.scm
+++ b/tests/scheme/smoke/peek-char-malformed-utf8.scm
@@ -1,0 +1,36 @@
+;; Regression test for #518: peek-char must restore exact consumed bytes,
+;; not re-encode the codepoint, to avoid stream desync on malformed UTF-8.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "peek-char-malformed-utf8")
+
+;; Truncated 4-byte sequence: #xF0 #x90 #x80 (missing 4th byte)
+;; peek-char should return some character for the lead byte and
+;; a subsequent read-u8 must return #xF0 (the first byte), not skip it.
+(let ((p (open-input-bytevector (bytevector #xF0 #x90 #x80))))
+  (peek-char p)
+  (test-equal "read-u8 after peek on truncated 4-byte seq returns lead byte"
+    #xF0 (read-u8 p)))
+
+;; Truncated 2-byte sequence: #xCE (missing continuation)
+(let ((p (open-input-bytevector (bytevector #xCE #x41))))
+  (peek-char p)
+  (test-equal "read-u8 after peek on truncated 2-byte seq returns lead byte"
+    #xCE (read-u8 p)))
+
+;; Valid 2-byte char followed by ASCII — peek must not desync
+(let ((p (open-input-bytevector (bytevector #xCE #xBB #x78)))) ; λx
+  (test-equal "peek-char returns lambda" #\λ (peek-char p))
+  (test-equal "read-char returns lambda" #\λ (read-char p))
+  (test-equal "read-char returns x" #\x (read-char p)))
+
+;; Valid 3-byte char — peek/read roundtrip
+(let ((p (open-input-bytevector (bytevector #xE2 #x9C #x93 #x79)))) ; ✓y
+  (test-equal "peek-char returns checkmark" #\✓ (peek-char p))
+  (test-equal "peek-char idempotent" #\✓ (peek-char p))
+  (test-equal "read-char returns checkmark" #\✓ (read-char p))
+  (test-equal "read-char returns y" #\y (read-char p)))
+
+(let ((runner (test-runner-current)))
+  (test-end "peek-char-malformed-utf8")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- `readUtf8Char` now returns the raw bytes consumed alongside the codepoint via `readUtf8CharWithBytes`
- `peekCharFn` restores exact consumed bytes instead of re-encoding the codepoint, preventing stream desync on malformed/truncated UTF-8
- Added regression test with truncated 2-byte and 4-byte UTF-8 sequences

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] New test `tests/scheme/smoke/peek-char-malformed-utf8.scm` — 9 assertions pass
- [x] `bash tests/scheme/run-all.sh` — 1547 pass, 0 fail

Fixes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)