### PR TITLE
Fix floor/ceiling/truncate/round on exact rationals to use exact arithmetic

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -145,13 +145,65 @@ pub fn registerNumeric(vm: *vm_mod.VM) !void {
 // Rounding
 // ---------------------------------------------------------------------------
 
+fn rationalFloor(r: *types.Rational) PrimitiveError!Value {
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
+    const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
+    if (bignum_mod.isZero(rem)) return bignum_mod.demote(q);
+    if (bignum_mod.isNegative(r.numerator)) {
+        return bignum_mod.demote(bignum_mod.sub(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory);
+    }
+    return bignum_mod.demote(q);
+}
+
+fn rationalCeiling(r: *types.Rational) PrimitiveError!Value {
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
+    const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
+    if (bignum_mod.isZero(rem)) return bignum_mod.demote(q);
+    if (bignum_mod.isPositive(r.numerator) or bignum_mod.isZero(r.numerator)) {
+        return bignum_mod.demote(bignum_mod.add(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory);
+    }
+    return bignum_mod.demote(q);
+}
+
+fn rationalTruncate(r: *types.Rational) PrimitiveError!Value {
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    return bignum_mod.demote(bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory);
+}
+
+fn rationalRound(r: *types.Rational) PrimitiveError!Value {
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
+    const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
+    if (bignum_mod.isZero(rem)) return bignum_mod.demote(q);
+    const abs_rem = bignum_mod.absVal(gc, rem) catch return PrimitiveError.OutOfMemory;
+    const double_rem = bignum_mod.mul(gc, abs_rem, types.makeFixnum(2)) catch return PrimitiveError.OutOfMemory;
+    const cmp = bignum_mod.compare(double_rem, r.denominator);
+    if (cmp < 0) {
+        return bignum_mod.demote(if (bignum_mod.isNegative(rem))
+            bignum_mod.sub(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory
+        else
+            q);
+    }
+    if (cmp > 0) {
+        return bignum_mod.demote(if (bignum_mod.isNegative(rem))
+            bignum_mod.sub(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory
+        else
+            bignum_mod.add(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory);
+    }
+    // Exact half — ties to even
+    if (bignum_mod.isEven(q)) return bignum_mod.demote(q);
+    return bignum_mod.demote(if (bignum_mod.isNegative(rem))
+        bignum_mod.sub(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory
+    else
+        bignum_mod.add(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory);
+}
+
 fn floorFn(args: []const Value) PrimitiveError!Value {
     if (types.isFixnum(args[0])) return args[0];
     if (types.isBignum(args[0])) return args[0];
-    if (types.isRationalObj(args[0])) {
-        const f = try toF64Ext(args[0]);
-        return try safeFloatToExactInt(@floor(f));
-    }
+    if (types.isRationalObj(args[0])) return rationalFloor(types.toRational(args[0]));
     if (types.isFlonum(args[0])) return makeFlonumVal(@floor(types.toFlonum(args[0])));
     return primitives.typeError("floor", "number", args[0]);
 }
@@ -159,10 +211,7 @@ fn floorFn(args: []const Value) PrimitiveError!Value {
 fn ceilingFn(args: []const Value) PrimitiveError!Value {
     if (types.isFixnum(args[0])) return args[0];
     if (types.isBignum(args[0])) return args[0];
-    if (types.isRationalObj(args[0])) {
-        const f = try toF64Ext(args[0]);
-        return try safeFloatToExactInt(@ceil(f));
-    }
+    if (types.isRationalObj(args[0])) return rationalCeiling(types.toRational(args[0]));
     if (types.isFlonum(args[0])) return makeFlonumVal(@ceil(types.toFlonum(args[0])));
     return primitives.typeError("ceiling", "number", args[0]);
 }
@@ -170,10 +219,7 @@ fn ceilingFn(args: []const Value) PrimitiveError!Value {
 fn truncateFn(args: []const Value) PrimitiveError!Value {
     if (types.isFixnum(args[0])) return args[0];
     if (types.isBignum(args[0])) return args[0];
-    if (types.isRationalObj(args[0])) {
-        const f = try toF64Ext(args[0]);
-        return try safeFloatToExactInt(@trunc(f));
-    }
+    if (types.isRationalObj(args[0])) return rationalTruncate(types.toRational(args[0]));
     if (types.isFlonum(args[0])) return makeFlonumVal(@trunc(types.toFlonum(args[0])));
     return primitives.typeError("truncate", "number", args[0]);
 }
@@ -196,10 +242,7 @@ fn bankersRound(f: f64) f64 {
 fn roundFn(args: []const Value) PrimitiveError!Value {
     if (types.isFixnum(args[0])) return args[0];
     if (types.isBignum(args[0])) return args[0];
-    if (types.isRationalObj(args[0])) {
-        const f = try toF64Ext(args[0]);
-        return try safeFloatToExactInt(bankersRound(f));
-    }
+    if (types.isRationalObj(args[0])) return rationalRound(types.toRational(args[0]));
     if (types.isFlonum(args[0])) return makeFlonumVal(bankersRound(types.toFlonum(args[0])));
     return primitives.typeError("round", "number", args[0]);
 }

--- a/tests/scheme/smoke/rational-rounding.scm
+++ b/tests/scheme/smoke/rational-rounding.scm
@@ -1,0 +1,41 @@
+;; Regression test for #499: floor/ceiling/truncate/round on exact rationals
+;; must use exact arithmetic, not route through f64.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "rational-rounding")
+
+;; Basic floor
+(test-equal "floor 7/3" 2 (floor 7/3))
+(test-equal "floor -7/3" -3 (floor -7/3))
+(test-equal "floor 1/2" 0 (floor 1/2))
+(test-equal "floor -1/2" -1 (floor -1/2))
+(test-equal "floor 4/2" 2 (floor 4/2))
+
+;; Basic ceiling
+(test-equal "ceiling 7/3" 3 (ceiling 7/3))
+(test-equal "ceiling -7/3" -2 (ceiling -7/3))
+(test-equal "ceiling 1/2" 1 (ceiling 1/2))
+(test-equal "ceiling -1/2" 0 (ceiling -1/2))
+
+;; Basic truncate
+(test-equal "truncate 7/3" 2 (truncate 7/3))
+(test-equal "truncate -7/3" -2 (truncate -7/3))
+
+;; Basic round (ties to even)
+(test-equal "round 7/3" 2 (round 7/3))
+(test-equal "round 1/2" 0 (round 1/2))    ; ties to even (0)
+(test-equal "round 3/2" 2 (round 3/2))    ; ties to even (2)
+(test-equal "round -1/2" 0 (round -1/2))  ; ties to even (0)
+(test-equal "round -3/2" -2 (round -3/2)) ; ties to even (-2)
+(test-equal "round 5/2" 2 (round 5/2))    ; ties to even (2)
+(test-equal "round 7/2" 4 (round 7/2))    ; ties to even (4)
+
+;; Results must be exact integers
+(test-assert "floor of rational is exact" (exact? (floor 7/3)))
+(test-assert "ceiling of rational is exact" (exact? (ceiling 7/3)))
+(test-assert "truncate of rational is exact" (exact? (truncate 7/3)))
+(test-assert "round of rational is exact" (exact? (round 7/3)))
+
+(let ((runner (test-runner-current)))
+  (test-end "rational-rounding")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- Replaced f64 conversion with exact bignum quotient/remainder for floor/ceiling/truncate/round on exact rationals
- `round` uses exact `2*|remainder|` vs denominator comparison for ties-to-even
- Preserves full precision regardless of magnitude (no 2^53 limit)

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] New test `tests/scheme/smoke/rational-rounding.scm` — 22 assertions pass
- [x] `bash tests/scheme/run-all.sh` — 1550 pass, 0 fail

Fixes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)