### PR TITLE
Fix import modifiers to apply to exported macros

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -12,10 +12,11 @@ const VMError = vm_mod.VMError;
 
 /// Import a binding into the target environment, routing macros to vm.macros.
 fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, val: Value) !void {
+    target.put(name, val) catch return error.OutOfMemory;
     if (types.isTransformer(val)) {
-        vm.macros.put(name, val) catch return error.OutOfMemory;
-        // Also import the macro's definition-site bindings so free
-        // references in the template resolve at runtime (R7RS §4.3.2).
+        if (target == &vm.globals) {
+            vm.macros.put(name, val) catch return error.OutOfMemory;
+        }
         const tx = types.toObject(val).as(types.Transformer);
         if (tx.def_env) |env| {
             var it = env.iterator();
@@ -28,7 +29,6 @@ fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, v
         }
         return;
     }
-    target.put(name, val) catch return error.OutOfMemory;
     if (target == &vm.globals) {
         vm.global_version +%= 1;
     }

--- a/tests/scheme/smoke/import-modifier-macros.scm
+++ b/tests/scheme/smoke/import-modifier-macros.scm
@@ -1,0 +1,24 @@
+;; Regression test for #495: import modifiers (only/except/rename/prefix)
+;; must apply to exported macros, not just procedures.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "import-modifier-macros")
+
+;; (only ...) should only import cut, not cute
+(import (only (srfi 26) cut))
+(test-assert "cut available after (only ... cut)"
+  (procedure? (cut + 1 <>)))
+
+;; (except ...) should exclude cute
+(import (except (srfi 26) cute))
+(test-assert "cut available after (except ... cute)"
+  (procedure? (cut + 1 <>)))
+
+;; (prefix ...) should prefix macros
+(import (prefix (srfi 26) s:))
+(test-assert "s:cut available after (prefix ... s:)"
+  (procedure? (s:cut + 1 <>)))
+
+(let ((runner (test-runner-current)))
+  (test-end "import-modifier-macros")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- `importBinding` now always adds macros to the target bindings map so they're visible to only/except/rename/prefix modifiers
- Macros are only installed into `vm.macros` when the target is `vm.globals` (the final import destination)
- Previously macros bypassed the modifier processing entirely

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] New test `tests/scheme/smoke/import-modifier-macros.scm` — 3 assertions pass (only, except, prefix)
- [x] `bash tests/scheme/run-all.sh` — 1550 pass, 0 fail

Fixes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)