### PR TITLE
Use PID-unique temp path for native compilation LLVM IR

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1225,8 +1225,12 @@ fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !voi
 fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;
 
-    const ll_path = "/tmp/kaappi_native.ll";
+    const pid = std.c.getpid();
+    const ll_path_owned = std.fmt.allocPrintZ(allocator, "/tmp/kaappi_native_{d}.ll", .{pid}) catch return;
+    defer allocator.free(ll_path_owned);
+    const ll_path: []const u8 = ll_path_owned;
     emitLlvmFile(vm, path, ll_path) catch return;
+    defer _ = std.posix.system.unlink(ll_path_owned.ptr);
 
     const out_path = output_path orelse blk: {
         if (std.mem.endsWith(u8, path, ".scm")) {
@@ -1248,13 +1252,11 @@ fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !vo
         const cc_path = findInPath(allocator, cc) orelse continue;
         defer allocator.free(cc_path);
         if (tryLink(allocator, cc_path, ll_path, out_path, lib_flag, std.mem.eql(u8, cc, "zig"))) {
-            _ = std.posix.system.unlink(ll_path.ptr);
             return;
         }
     }
 
     writeStderr("No C compiler found. Install zig, clang, or gcc.\n");
-    _ = std.posix.system.unlink(ll_path.ptr);
 }
 
 fn findInPath(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1226,11 +1226,13 @@ fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !vo
     const allocator = vm.gc.allocator;
 
     const pid = std.c.getpid();
-    const ll_path_owned = std.fmt.allocPrintZ(allocator, "/tmp/kaappi_native_{d}.ll", .{pid}) catch return;
-    defer allocator.free(ll_path_owned);
-    const ll_path: []const u8 = ll_path_owned;
+    var ll_buf: [64]u8 = undefined;
+    var ll_w: std.Io.Writer = .fixed(&ll_buf);
+    ll_w.print("/tmp/kaappi_native_{d}.ll", .{pid}) catch return;
+    const ll_path = ll_w.buffered();
+    ll_buf[ll_path.len] = 0;
     emitLlvmFile(vm, path, ll_path) catch return;
-    defer _ = std.posix.system.unlink(ll_path_owned.ptr);
+    defer _ = std.posix.system.unlink(@ptrCast(ll_path.ptr));
 
     const out_path = output_path orelse blk: {
         if (std.mem.endsWith(u8, path, ".scm")) {


### PR DESCRIPTION
## Summary
- `compileNative` now generates `/tmp/kaappi_native_<pid>.ll` instead of the fixed `/tmp/kaappi_native.ll`
- Temp file cleaned up via `defer` on all exit paths
- Prevents concurrent compile races and stale file failures

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1551 pass, 0 fail

Fixes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)