### PR TITLE
Fix thottam semver resolution to use KAAPPI_ORG

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -762,7 +762,7 @@ fn doInstall(
     if (install_version) |v| {
         if (isConstraintSpec(v)) {
             const clone_url = parsed.source orelse blk: {
-                break :blk std.fmt.allocPrint(allocator, "https://github.com/kaappi/{s}", .{pkg}) catch "";
+                break :blk std.fmt.allocPrint(allocator, "{s}/{s}", .{ config.org, pkg }) catch "";
             };
             if (resolveVersion(allocator, clone_url, v)) |resolved| {
                 writeStdout("  Resolved ");


### PR DESCRIPTION
## Summary
- Constraint-resolution URL now uses `config.org` (from `KAAPPI_ORG` env var) instead of hardcoded `github.com/kaappi`
- One-line fix: the resolution path now matches the clone path

## Test plan
- [x] `zig build test` — all unit tests pass

Fixes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)