### PR TITLE
Fix case => proc clause to not clobber live local registers

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -249,28 +249,19 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
                 if (arrow_rest == types.NIL or !types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
                 const proc_expr = types.car(arrow_rest);
                 const proc_reg = try self.allocReg();
-                // Move key value to arg position
                 const arg_reg = try self.allocReg();
                 try self.emitOp(.move);
                 try self.emitU16(arg_reg);
                 try self.emitU16(key_reg);
-                // Compile proc
                 try self.compileExpr(proc_expr, proc_reg, false);
-                // Move proc to dst (for call base)
-                try self.emitOp(.move);
-                try self.emitU16(dst);
+                if (is_tail) try self.emitOp(.tail_call) else try self.emitOp(.call);
                 try self.emitU16(proc_reg);
-                // Move arg after dst
-                try self.emitOp(.move);
-                try self.emitU16(dst + 1);
-                try self.emitU16(arg_reg);
-                if (is_tail) {
-                    try self.emitOp(.tail_call);
-                } else {
-                    try self.emitOp(.call);
-                }
-                try self.emitU16(dst);
                 try self.emit(1);
+                if (!is_tail) {
+                    try self.emitOp(.move);
+                    try self.emitU16(dst);
+                    try self.emitU16(proc_reg);
+                }
                 self.freeReg(); // arg_reg
                 self.freeReg(); // proc_reg
 

--- a/tests/scheme/smoke/case-arrow-register.scm
+++ b/tests/scheme/smoke/case-arrow-register.scm
@@ -1,0 +1,17 @@
+;; Regression test for #541: case ((datum ...) => proc) must not clobber
+;; live local variables at dst+1.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "case-arrow-register")
+
+(define (f k)
+  (let ((r 0) (a 111) (b 222))
+    (set! r (case k ((1 2 3) => (lambda (v) (* v 10))) (else 0)))
+    (list r a b)))
+
+(test-equal "case => does not clobber locals" '(20 111 222) (f 2))
+(test-equal "case => else branch" '(0 111 222) (f 9))
+
+(let ((runner (test-runner-current)))
+  (test-end "case-arrow-register")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- Non-else `case =>` branch now calls at `proc_reg` base (arg at `proc_reg+1`), then moves result to `dst`
- Previously called at `dst` base, clobbering live locals at `dst+1`
- Mirrors the existing correct pattern in `else =>` (fixed for `cond =>` in #271)

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] New test `tests/scheme/smoke/case-arrow-register.scm` — 2 assertions pass
- [x] `bash tests/scheme/run-all.sh` — 1553 pass, 0 fail
- [x] Reproduction case `(f 2)` now returns `(20 111 222)` instead of `(20 #<builtin *> 2)`

Fixes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)