### PR TITLE
Fix character write format and string-every/string-any char criterion

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -669,7 +669,9 @@ fn stringEveryFn(args: []const Value) PrimitiveError!Value {
             i += len;
             continue;
         };
-        if (types.isRecordInstance(pred)) {
+        if (types.isChar(pred)) {
+            if (types.toChar(pred) != cp) return types.FALSE;
+        } else if (types.isRecordInstance(pred)) {
             if (!try callPredOrCharset(pred, cp)) return types.FALSE;
         } else {
             const r = try callVM(pred, &[1]Value{types.makeChar(cp)});
@@ -693,7 +695,9 @@ fn stringAnyFn(args: []const Value) PrimitiveError!Value {
             i += len;
             continue;
         };
-        if (types.isRecordInstance(pred)) {
+        if (types.isChar(pred)) {
+            if (types.toChar(pred) == cp) return types.TRUE;
+        } else if (types.isRecordInstance(pred)) {
             if (try callPredOrCharset(pred, cp)) return types.TRUE;
         } else {
             const r = try callVM(pred, &[1]Value{types.makeChar(cp)});

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -417,9 +417,16 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                 0x20 => try writer.writeAll("space"),
                 0x7F => try writer.writeAll("delete"),
                 else => {
-                    var buf: [4]u8 = undefined;
-                    const len = std.unicode.utf8Encode(cp, &buf) catch 0;
-                    try writer.writeAll(buf[0..len]);
+                    if (cp < 0x20 or (cp >= 0x7F and cp <= 0x9F)) {
+                        var hex_buf: [8]u8 = undefined;
+                        var hw: std.Io.Writer = .fixed(&hex_buf);
+                        hw.print("x{x};", .{cp}) catch {};
+                        try writer.writeAll(hw.buffered());
+                    } else {
+                        var buf: [4]u8 = undefined;
+                        const len = std.unicode.utf8Encode(cp, &buf) catch 0;
+                        try writer.writeAll(buf[0..len]);
+                    }
                 },
             }
         } else {


### PR DESCRIPTION
## Summary
- **printer (#547)**: Control characters (< 0x20, 0x7F-0x9F) in write mode now emit `#\xNN;` hex notation instead of raw bytes
- **string-ext (#539)**: `string-every` and `string-any` now accept a character as the criterion argument

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1553 pass, 0 fail

Fixes #547
Fixes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)