### PR TITLE
Add compile subcommand to zsh completion script

### DIFF
--- a/src/completions.zig
+++ b/src/completions.zig
@@ -66,7 +66,7 @@ const kaappi_zsh =
     \\
     \\    _arguments -s \
     \\        $flags \
-    \\        '1:command or file:_files -g "*.scm"' \
+    \\        '1:command or file:_alternative "commands:command:(compile)" "files:file:_files -g \"*.scm\""' \
     \\        '*:script args:_files'
     \\}
     \\


### PR DESCRIPTION
## Summary
- Zsh completion now offers `compile` subcommand alongside `.scm` files, matching bash and fish scripts

## Test plan
- [x] `zig build test` — all unit tests pass

Fixes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)