### PR TITLE
Fix record field spec validation and REPL datum comment handling

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -260,6 +260,60 @@ fn parenDepth(src: []const u8) i32 {
             i += 1;
             continue;
         }
+        // Datum comment: #; — skip the next datum for paren counting
+        if (ch == '#' and i + 1 < src.len and src[i + 1] == ';') {
+            i += 2;
+            // Skip whitespace
+            while (i < src.len and (src[i] == ' ' or src[i] == '\t' or src[i] == '\n' or src[i] == '\r')) : (i += 1) {}
+            if (i >= src.len) {
+                depth += 1;
+                continue;
+            }
+            if (src[i] == '(' or src[i] == '[') {
+                var datum_depth: i32 = 1;
+                i += 1;
+                var dc_in_string = false;
+                var dc_escape = false;
+                while (i < src.len and datum_depth > 0) {
+                    if (dc_escape) {
+                        dc_escape = false;
+                        i += 1;
+                        continue;
+                    }
+                    if (dc_in_string) {
+                        if (src[i] == '\\') dc_escape = true else if (src[i] == '"') dc_in_string = false;
+                        i += 1;
+                        continue;
+                    }
+                    if (src[i] == '"') {
+                        dc_in_string = true;
+                    } else if (src[i] == '(' or src[i] == '[') {
+                        datum_depth += 1;
+                    } else if (src[i] == ')' or src[i] == ']') {
+                        datum_depth -= 1;
+                    }
+                    i += 1;
+                }
+                if (datum_depth > 0) depth += 1;
+                i -= 1;
+            } else if (src[i] == '"') {
+                i += 1;
+                while (i < src.len) {
+                    if (src[i] == '\\' and i + 1 < src.len) {
+                        i += 2;
+                        continue;
+                    }
+                    if (src[i] == '"') break;
+                    i += 1;
+                }
+            } else {
+                while (i < src.len and src[i] != ' ' and src[i] != '\t' and src[i] != '\n' and
+                    src[i] != ')' and src[i] != '(' and src[i] != ';') : (i += 1)
+                {}
+                i -= 1;
+            }
+            continue;
+        }
         // Character literals: #\x or #\space etc.
         if (ch == '#' and i + 1 < src.len and src[i + 1] == '\\') {
             i += 2; // skip #\ — now i points at the character after backslash

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -81,6 +81,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const mut_sym = types.car(spec_rest2);
             if (!types.isSymbol(mut_sym)) return VMError.CompileError;
             mutator_names[all_field_count] = types.symbolName(mut_sym);
+            if (types.cdr(spec_rest2) != types.NIL) return VMError.CompileError;
         } else {
             mutator_names[all_field_count] = null;
         }


### PR DESCRIPTION
## Summary
- **vm_records (#562)**: Reject field specs with extra tokens after the optional mutator
- **repl (#542)**: `parenDepth` now skips `#;` datum comments correctly instead of treating `;` as line comment

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1553 pass, 0 fail

Fixes #562
Fixes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)