### PR TITLE
Fix LLVM symbol escaping and LSP document text memory leak

### DIFF
--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -687,6 +687,7 @@ fn handleDidOpenOrChange(allocator: std.mem.Allocator, vm: *vm_mod.VM, params: [
 
     if (text) |raw_t| {
         const t = jsonUnescape(allocator, raw_t) orelse raw_t;
+        defer if (t.ptr != raw_t.ptr) allocator.free(t);
         storeDocument(uri, t);
         runDiagnostics(allocator, vm, uri, t);
     }

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -81,7 +81,15 @@ pub const LLVMEmitter = struct {
         while (sym_iter.next()) |entry| {
             const name = entry.key_ptr.*;
             const id = entry.value_ptr.*;
-            try self.print("@.sym.{d} = private unnamed_addr constant [{d} x i8] c\"{s}\"\n", .{ id, name.len, name });
+            try self.print("@.sym.{d} = private unnamed_addr constant [{d} x i8] c\"", .{ id, name.len });
+            for (name) |byte| {
+                if (byte >= 0x20 and byte < 0x7F and byte != '"' and byte != '\\') {
+                    try self.print("{c}", .{byte});
+                } else {
+                    try self.print("\\{X:0>2}", .{byte});
+                }
+            }
+            try self.write("\"\n");
         }
 
         for (self.string_decls.items) |decl| {


### PR DESCRIPTION
## Summary
- **llvm_emit (#544)**: Symbol name constants now escape quotes, backslashes, and control bytes in LLVM `c"..."` literals
- **kaappi_lsp (#538)**: Free `jsonUnescape` buffer after `storeDocument` copies it

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1553 pass, 0 fail

Fixes #544
Fixes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)