### PR TITLE
Fix SRFI-27 make-random-source seeding and unit validation

### DIFF
--- a/lib/srfi/27.sld
+++ b/lib/srfi/27.sld
@@ -12,6 +12,11 @@
       (lambda (n) (%rs-next-int rs n)))
 
     (define (random-source-make-reals rs . rest)
+      (when (and (pair? rest)
+                 (not (and (real? (car rest))
+                           (> (car rest) 0)
+                           (< (car rest) 1))))
+        (error "random-source-make-reals: unit must satisfy 0 < unit < 1" (car rest)))
       (lambda () (%rs-next-real rs)))
 
     ))

--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -90,7 +90,7 @@ fn randomSourcePFn(args: []const Value) PrimitiveError!Value {
 fn makeRandomSourceFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
-    return gc.allocRandomSource(freshSeed()) catch return PrimitiveError.OutOfMemory;
+    return gc.allocRandomSource(0) catch return PrimitiveError.OutOfMemory;
 }
 
 fn randomSourceRandomizeFn(args: []const Value) PrimitiveError!Value {


### PR DESCRIPTION
## Summary
- **make-random-source (#555)**: Uses deterministic seed (0) per SRFI-27 spec instead of fresh entropy
- **random-source-make-reals (#557)**: Validates optional unit argument is in (0, 1)

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1553 pass, 0 fail

Fixes #555
Fixes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)