### PR TITLE
Stop define-record-type from polluting user namespace

### DIFF
--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -97,8 +97,8 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
     vm.gc.pushRoot(&rt_val) catch return VMError.OutOfMemory;
     defer vm.gc.popRoot();
 
-    // Store in a global with an internal name
-    const internal_name_buf = std.fmt.allocPrint(vm.gc.allocator, "__record_type_{s}", .{type_name}) catch return VMError.OutOfMemory;
+    // Store in a global with an internal name (space prefix prevents user access)
+    const internal_name_buf = std.fmt.allocPrint(vm.gc.allocator, " __record_type_{s}", .{type_name}) catch return VMError.OutOfMemory;
     defer vm.gc.allocator.free(internal_name_buf);
     // Intern the name via allocSymbol so it persists
     const internal_sym = vm.gc.allocSymbol(internal_name_buf) catch return VMError.OutOfMemory;
@@ -153,11 +153,9 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
                 }
             }
             if (!found_in_ctor) {
-                if (!target_env.contains("__undefined__")) {
-                    target_env.put("__undefined__", types.UNDEFINED) catch return VMError.OutOfMemory;
-                    if (vm.current_lib_env == null) vm.global_version +%= 1;
-                }
-                body_args[2 + fi] = vm.gc.allocSymbol("__undefined__") catch return VMError.OutOfMemory;
+                // (if #f #f) evaluates to void/undefined without polluting the namespace
+                const if_sym = vm.gc.allocSymbol("if") catch return VMError.OutOfMemory;
+                body_args[2 + fi] = vm.gc.makeList(&[_]Value{ if_sym, types.FALSE, types.FALSE }) catch return VMError.OutOfMemory;
             }
         }
 

--- a/tests/scheme/smoke/record-namespace-clean.scm
+++ b/tests/scheme/smoke/record-namespace-clean.scm
@@ -1,0 +1,49 @@
+;; Regression test for #563: define-record-type should not pollute namespace
+;; Internal bindings (__undefined__, __record_type_*) must not be user-visible.
+
+(import (scheme base) (scheme write) (scheme eval))
+
+(define pass 0)
+(define fail 0)
+
+(define-syntax check
+  (syntax-rules ()
+    ((_ name expr)
+     (begin
+       (display name)
+       (display ": ")
+       (if expr
+         (begin (set! pass (+ pass 1)) (display "ok"))
+         (begin (set! fail (+ fail 1)) (display "FAIL")))
+       (newline)))))
+
+;; Partial constructor — omitted field y
+(define-record-type pt (make-pt x) pt? (x get-x) (y get-y set-y!))
+(define p (make-pt 99))
+(check "partial-ctor-field" (= (get-x p) 99))
+(check "predicate" (pt? p))
+
+;; __undefined__ must not be visible
+(check "no-__undefined__"
+  (guard (exn (#t #t))
+    (eval '__undefined__ (interaction-environment))
+    #f))
+
+;; __record_type_pt must not be visible
+(check "no-__record_type_pt"
+  (guard (exn (#t #t))
+    (eval '__record_type_pt (interaction-environment))
+    #f))
+
+;; Full constructor still works
+(define-record-type point (make-point x y) point? (x point-x) (y point-y))
+(define q (make-point 1 2))
+(check "full-ctor" (and (= (point-x q) 1) (= (point-y q) 2)))
+
+;; Mutator on partial ctor record
+(set-y! p 42)
+(check "set-omitted-field" (= (get-y p) 42))
+
+(display pass) (display " pass, ") (display fail) (display " fail")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

- Space-prefix internal `__record_type_<name>` bindings so they can't be accessed from user code (the Scheme reader can't produce symbols with leading spaces)
- Replace `__undefined__` global with inline `(if #f #f)` expression for omitted constructor fields — no binding injected at all

## Test plan

- [x] `tests/scheme/smoke/record-namespace-clean.scm` — verifies neither `__undefined__` nor `__record_type_*` are visible via `eval`
- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1555 pass, 0 fail

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)