### PR TITLE
Splice top-level begin for define-record-type and other special forms

### DIFF
--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -44,7 +44,31 @@ pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
     if (std.mem.eql(u8, name, "define-values")) return handleDefineValues(vm, types.cdr(expr));
     if (std.mem.eql(u8, name, "include")) return vm_library.handleTopLevelInclude(vm, types.cdr(expr), false);
     if (std.mem.eql(u8, name, "include-ci")) return vm_library.handleTopLevelInclude(vm, types.cdr(expr), true);
+
+    // R7RS 5.1: top-level begin splices its body as top-level forms
+    if (std.mem.eql(u8, name, "begin")) return handleTopLevelBegin(vm, types.cdr(expr));
+
     return null;
+}
+
+fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
+    var last: Value = types.VOID;
+    var rest = body;
+    while (types.isPair(rest)) {
+        const form = types.car(rest);
+        if (handleTopLevelForm(vm, form)) |result| {
+            last = result catch |err| return err;
+        } else {
+            const func = compiler_mod.compileExpressionWithMacros(vm.gc, form, &vm.macros, &vm.globals) catch return VMError.CompileError;
+            var func_val = types.makePointer(@ptrCast(func));
+            vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
+            defer vm.gc.popRoot();
+            compiler_mod.Compiler.unrootFunction(vm.gc, func);
+            last = vm.execute(func) catch |err| return err;
+        }
+        rest = types.cdr(rest);
+    }
+    return last;
 }
 
 fn handleDefineValues(vm: *VM, args: Value) VMError!Value {

--- a/tests/scheme/smoke/record-type-begin.scm
+++ b/tests/scheme/smoke/record-type-begin.scm
@@ -1,0 +1,42 @@
+;; Regression test for #560: define-record-type inside begin at top level
+
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define-syntax check
+  (syntax-rules ()
+    ((_ name expr)
+     (begin
+       (display name)
+       (display ": ")
+       (if expr
+         (begin (set! pass (+ pass 1)) (display "ok"))
+         (begin (set! fail (+ fail 1)) (display "FAIL")))
+       (newline)))))
+
+;; define-record-type inside begin at top level
+(begin
+  (define-record-type pt (make-pt x y) pt? (x get-x) (y get-y)))
+
+(check "begin-record-ctor" (pt? (make-pt 1 2)))
+(check "begin-record-accessor" (= (get-x (make-pt 3 4)) 3))
+
+;; nested begin
+(begin
+  (begin
+    (define-record-type line (make-line a b) line? (a line-a) (b line-b))))
+
+(check "nested-begin" (= (line-b (make-line 10 20)) 20))
+
+;; begin with mixed definitions and expressions
+(begin
+  (define-record-type color (make-color r g b) color? (r red) (g green) (b blue))
+  (define c (make-color 255 128 0)))
+
+(check "begin-mixed" (and (= (red c) 255) (= (green c) 128) (= (blue c) 0)))
+
+(display pass) (display " pass, ") (display fail) (display " fail")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

- `handleTopLevelForm` now handles `begin` by recursively processing each sub-form as a top-level form (R7RS 5.1 splicing)
- Fixes `define-record-type`, `import`, `define-values`, and `include` inside top-level `begin` blocks
- Also gains +1 R7RS test pass (1394 from 1393)

## Test plan

- [x] `tests/scheme/smoke/record-type-begin.scm` — regression tests for begin-wrapped record types
- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1556 pass, 0 fail

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)