### PR TITLE
Strengthen eval quote, begin, and exception handler tests

### DIFF
--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -95,6 +95,13 @@ test "eval quote" {
     const result = try vm.eval("'(1 2 3)");
     try std.testing.expect(types.isPair(result));
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(types.car(result)));
+    const tail1 = types.cdr(result);
+    try std.testing.expect(types.isPair(tail1));
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(types.car(tail1)));
+    const tail2 = types.cdr(tail1);
+    try std.testing.expect(types.isPair(tail2));
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(types.car(tail2)));
+    try std.testing.expectEqual(types.NIL, types.cdr(tail2));
 }
 
 test "eval set!" {
@@ -117,8 +124,7 @@ test "eval begin" {
 
     _ = try vm.eval("(define a 0)");
     _ = try vm.eval("(define b 0)");
-    _ = try vm.eval("(begin (set! a 1) (set! b 2))");
-    const result = try vm.eval("(+ a b)");
+    const result = try vm.eval("(begin (set! a 1) (set! b 2) (+ a b))");
     try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
 }
 

--- a/src/tests_exceptions.zig
+++ b/src/tests_exceptions.zig
@@ -59,11 +59,13 @@ test "with-exception-handler basic" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    // R7RS: handler returning from non-continuable raise triggers re-raise.
-    // Use guard instead, which properly escapes via continuation.
+    // Exercise with-exception-handler directly via call/cc to escape
     const result = try vm.eval(
-        \\(guard (e (#t 42))
-        \\  (raise "boom"))
+        \\(call-with-current-continuation
+        \\  (lambda (k)
+        \\    (with-exception-handler
+        \\      (lambda (e) (k 42))
+        \\      (lambda () (raise "boom")))))
     );
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
 }


### PR DESCRIPTION
## Summary

- **#553**: Quote test now verifies full list structure (all three elements + nil terminator, not just car). Begin test now asserts the returned value directly instead of only checking side effects.
- **#548**: `with-exception-handler basic` test now actually exercises `with-exception-handler`'s handler path via `call/cc` escape, instead of using `guard`.

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] Tests exercise the correct code paths now

Closes #553, closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)