### PR TITLE
Free breakpoint name/condition strings on delete and teardown

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -417,13 +417,16 @@ pub fn repl(vm: *vm_mod.VM) !void {
         // Debug commands (comma-prefixed)
         if (std.mem.startsWith(u8, debug_trimmed, ",break ")) {
             const bp_name_src = std.mem.trim(u8, debug_trimmed[7..], " ");
-            const bp_name = allocator.dupe(u8, bp_name_src) catch continue;
-            if (vm.breakpoint_count < 16) {
-                vm.breakpoints[vm.breakpoint_count] = .{ .name = bp_name };
-                vm.breakpoint_count += 1;
-                vm.debug_mode = true;
-                vm.step_mode = .continue_to_break;
+            if (vm.breakpoint_count >= 16) {
+                writeStdout("Too many breakpoints (max 16)\n");
+                input_buf.clearRetainingCapacity();
+                continue;
             }
+            const bp_name = allocator.dupe(u8, bp_name_src) catch continue;
+            vm.breakpoints[vm.breakpoint_count] = .{ .name = bp_name };
+            vm.breakpoint_count += 1;
+            vm.debug_mode = true;
+            vm.step_mode = .continue_to_break;
             writeStdout("Breakpoint set on ");
             writeStdout(bp_name);
             writeStdout("\n");
@@ -472,6 +475,10 @@ pub fn repl(vm: *vm_mod.VM) !void {
             continue;
         }
         if (std.mem.eql(u8, debug_trimmed, ",delete all")) {
+            for (vm.breakpoints[0..vm.breakpoint_count]) |bp| {
+                allocator.free(bp.name);
+                if (bp.condition) |cond| allocator.free(cond);
+            }
             vm.breakpoint_count = 0;
             vm.debug_mode = false;
             vm.step_mode = .none;

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -137,3 +137,21 @@ test "eval nested arithmetic" {
     const result = try vm.eval("(+ (* 2 3) (- 10 4))");
     try std.testing.expectEqual(@as(i64, 12), types.toFixnum(result));
 }
+
+test "breakpoint strings freed on deinit" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+
+    // Simulate ,break: allocate duped name strings and store as breakpoints
+    const name1 = try std.testing.allocator.dupe(u8, "foo");
+    const name2 = try std.testing.allocator.dupe(u8, "bar");
+    const cond = try std.testing.allocator.dupe(u8, "(> x 0)");
+    vm.breakpoints[0] = .{ .name = name1, .condition = cond };
+    vm.breakpoints[1] = .{ .name = name2 };
+    vm.breakpoint_count = 2;
+
+    // deinit must free the duped strings — std.testing.allocator will
+    // report a leak (test failure) if any are missed
+    vm.deinit();
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -296,6 +296,11 @@ pub const VM = struct {
         self.loading_libs.deinit();
         self.param_overrides.deinit();
         vm_debug.freeWatches(self);
+        for (self.breakpoints[0..self.breakpoint_count]) |bp| {
+            self.gc.allocator.free(bp.name);
+            if (bp.condition) |cond| self.gc.allocator.free(cond);
+        }
+        self.breakpoint_count = 0;
     }
 
     pub fn getParameterValue(self: *VM, param: *types.ParameterObject) Value {


### PR DESCRIPTION
## Summary

- `,delete all` frees all breakpoint name and condition strings before resetting the count
- `,break` checks the 16-breakpoint cap before allocating the name string, avoiding a leak when the cap is hit; reports "Too many breakpoints" instead of silently claiming success
- `VM.deinit` frees remaining breakpoint strings at shutdown

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1557 pass, 0 fail
- [x] Code review confirms all alloc/free paths are balanced

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)