### PR TITLE
Store default-random-source on VM instead of thread-local

### DIFF
--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -26,11 +26,8 @@ fn freshSeed() u64 {
     return @as(u64, @bitCast(ts.sec)) ^ @as(u64, @bitCast(ts.nsec));
 }
 
-threadlocal var default_rs_val: Value = types.VOID;
-
 pub fn registerRandom(vm: *vm_mod.VM) !void {
-    default_rs_val = vm.gc.allocRandomSource(freshSeed()) catch return error.OutOfMemory;
-    vm.gc.extra_roots.append(vm.gc.allocator, default_rs_val) catch return error.OutOfMemory;
+    vm.default_random_source = vm.gc.allocRandomSource(freshSeed()) catch return error.OutOfMemory;
 
     try reg(vm, "random-integer", &randomIntegerFn, .{ .exact = 1 });
     try reg(vm, "random-real", &randomRealFn, .{ .exact = 0 });
@@ -46,11 +43,9 @@ pub fn registerRandom(vm: *vm_mod.VM) !void {
 }
 
 pub fn ensureDefaultRS() void {
-    if (default_rs_val == types.VOID) {
-        if (primitives.gc_instance) |gc| {
-            default_rs_val = gc.allocRandomSource(freshSeed()) catch return;
-            gc.extra_roots.append(gc.allocator, default_rs_val) catch {};
-        }
+    const vm = vm_mod.vm_instance orelse return;
+    if (vm.default_random_source == types.VOID) {
+        vm.default_random_source = vm.gc.allocRandomSource(freshSeed()) catch return;
     }
 }
 
@@ -64,7 +59,8 @@ fn randomIntegerFn(args: []const Value) PrimitiveError!Value {
     const n = types.toFixnum(args[0]);
     if (n <= 0) return primitives.typeError("random-integer", "positive integer", args[0]);
     ensureDefaultRS();
-    const rs = try getRS("random-integer", default_rs_val);
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const rs = try getRS("random-integer", vm.default_random_source);
     const r = rs.prng.random();
     return types.makeFixnum(r.intRangeLessThan(i64, 0, n));
 }
@@ -72,7 +68,8 @@ fn randomIntegerFn(args: []const Value) PrimitiveError!Value {
 fn randomRealFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     ensureDefaultRS();
-    const rs = try getRS("random-real", default_rs_val);
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const rs = try getRS("random-real", vm.default_random_source);
     const r = rs.prng.random();
     return types.makeFlonum(r.float(f64));
 }
@@ -80,7 +77,8 @@ fn randomRealFn(args: []const Value) PrimitiveError!Value {
 fn defaultRandomSourceFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     ensureDefaultRS();
-    return default_rs_val;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    return vm.default_random_source;
 }
 
 fn randomSourcePFn(args: []const Value) PrimitiveError!Value {

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -155,3 +155,28 @@ test "breakpoint strings freed on deinit" {
     // report a leak (test failure) if any are missed
     vm.deinit();
 }
+
+test "default-random-source is per-VM" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var vm1 = try th.makeTestVM(&gc1);
+    defer vm1.deinit();
+
+    const rs1 = try vm1.eval("(default-random-source)");
+    try std.testing.expect(types.isRandomSource(rs1));
+
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+    var vm2 = try th.makeTestVM(&gc2);
+    defer vm2.deinit();
+
+    const rs2 = try vm2.eval("(default-random-source)");
+    try std.testing.expect(types.isRandomSource(rs2));
+
+    // Each VM must have its own default random source
+    try std.testing.expect(rs1 != rs2);
+
+    // VM1's source must still be its own after VM2 was created
+    const rs1_again = try vm1.eval("(default-random-source)");
+    try std.testing.expectEqual(rs1, rs1_again);
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -76,6 +76,7 @@ fn markVMRoots(gc: *memory.GC) void {
 
     if (vm.current_exception) |exc| gc.markValue(exc);
     gc.markValue(vm.continuation_value);
+    gc.markValue(vm.default_random_source);
 
     // Only mark globals/macros when this VM owns them. Child threads
     // share the parent's maps — the parent GC keeps those values alive.
@@ -232,6 +233,7 @@ pub const VM = struct {
     /// When non-null, record files read during library loading for bundling.
     compile_collect_files: ?*std.StringHashMap([]const u8) = null,
     param_overrides: std.AutoHashMap(usize, Value) = undefined,
+    default_random_source: Value = types.VOID,
     scheduler: ?*@import("fiber.zig").FiberScheduler = null,
     current_fiber: ?*@import("fiber.zig").Fiber = null,
     yielded: bool = false,


### PR DESCRIPTION
## Summary

- Moved `default_random_source` from a file-level `threadlocal var` to a field on the `VM` struct
- GC root marking now traces the VM's default random source
- Removed the `extra_roots` registration (no longer needed since the VM root marker handles it)
- Each VM now has an independent default random source, preventing cross-GC pointers when multiple VMs are live in the same thread

## Test plan

- [x] Unit test `default-random-source is per-VM` — creates two VMs, verifies each has its own source and they don't interfere
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1558 pass, 0 fail

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)