### PR TITLE
Desugar internal define to letrec* (R7RS 5.3.2)

### DIFF
--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -498,13 +498,81 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
         }
     }
 
+    // Collect leading internal defines and desugar to letrec* (R7RS 5.3.2)
+    const MAX_BODY_DEFS = 256;
+    var def_names: [MAX_BODY_DEFS][]const u8 = undefined;
+    var def_inits: [MAX_BODY_DEFS]Value = undefined;
+    var def_slots: [MAX_BODY_DEFS]u16 = undefined;
+    var def_count: usize = 0;
+
     var current = body;
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
+    while (current != types.NIL and types.isPair(current)) {
         const expr = types.car(current);
+        if (!types.isPair(expr)) break;
+        const head = types.car(expr);
+        if (!types.isSymbol(head)) break;
+        const head_name = types.symbolName(head);
+        if (!std.mem.eql(u8, head_name, "define")) break;
+
+        const def_args = types.cdr(expr);
+        if (def_args == types.NIL or !types.isPair(def_args)) break;
+        const target = types.car(def_args);
+        const def_rest = types.cdr(def_args);
+
+        if (types.isSymbol(target)) {
+            if (def_rest == types.NIL or !types.isPair(def_rest)) break;
+            if (def_count >= MAX_BODY_DEFS) return CompileError.TooManyLocals;
+            def_names[def_count] = types.symbolName(target);
+            def_inits[def_count] = types.car(def_rest);
+            def_count += 1;
+        } else if (types.isPair(target)) {
+            const fn_name = types.car(target);
+            if (!types.isSymbol(fn_name)) break;
+            if (def_count >= MAX_BODY_DEFS) return CompileError.TooManyLocals;
+            def_names[def_count] = types.symbolName(fn_name);
+            const param_formals = types.cdr(target);
+            const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+            const lambda_args = self.gc.allocPair(param_formals, def_rest) catch return CompileError.OutOfMemory;
+            def_inits[def_count] = self.gc.allocPair(lambda_sym, lambda_args) catch return CompileError.OutOfMemory;
+            def_count += 1;
+        } else {
+            break;
+        }
         current = types.cdr(current);
-        const tail = is_tail and current == types.NIL;
-        try self.compileExpr(expr, dst, tail);
+    }
+
+    if (def_count > 0) {
+        self.beginScope();
+        for (0..def_count) |i| {
+            const slot = try self.allocReg();
+            def_slots[i] = slot;
+            try self.emitOp(.load_void);
+            try self.emitU16(slot);
+            try self.addLocal(def_names[i], slot);
+            try self.markLocalBoxedBySlot(slot);
+        }
+        for (0..def_count) |i| {
+            try self.compileExpr(def_inits[i], dst, false);
+            try self.emitOp(.set_box_local);
+            try self.emitU16(def_slots[i]);
+            try self.emitU16(dst);
+        }
+        while (current != types.NIL) {
+            if (!types.isPair(current)) return CompileError.InvalidSyntax;
+            const expr = types.car(current);
+            current = types.cdr(current);
+            const tail = is_tail and current == types.NIL;
+            try self.compileExpr(expr, dst, tail);
+        }
+        self.endScope();
+    } else {
+        while (current != types.NIL) {
+            if (!types.isPair(current)) return CompileError.InvalidSyntax;
+            const expr = types.car(current);
+            current = types.cdr(current);
+            const tail = is_tail and current == types.NIL;
+            try self.compileExpr(expr, dst, tail);
+        }
     }
 }
 

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -150,24 +150,121 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
         }
     }
 
+    // Collect leading internal defines and desugar to letrec* (R7RS 5.3.2).
+    // Internal definitions must be equivalent to letrec* — all defined names
+    // are visible to their own initializers (self-recursion) and to each
+    // other (mutual recursion).
+    const MAX_BODY_DEFS = 256;
+    var def_names: [MAX_BODY_DEFS][]const u8 = undefined;
+    var def_inits: [MAX_BODY_DEFS]Value = undefined;
+    var def_slots: [MAX_BODY_DEFS]u16 = undefined;
+    var def_count: usize = 0;
+
     var current = body;
+    // Scan leading defines
+    while (current != types.NIL and types.isPair(current)) {
+        const expr = types.car(current);
+        if (!types.isPair(expr)) break;
+        const head = types.car(expr);
+        if (!types.isSymbol(head)) break;
+        const head_name = types.symbolName(head);
+        if (!std.mem.eql(u8, head_name, "define")) break;
+
+        const def_args = types.cdr(expr);
+        if (def_args == types.NIL or !types.isPair(def_args)) break;
+        const target = types.car(def_args);
+        const def_rest = types.cdr(def_args);
+
+        if (types.isSymbol(target)) {
+            // (define x expr)
+            if (def_rest == types.NIL or !types.isPair(def_rest)) break;
+            if (def_count >= MAX_BODY_DEFS) return CompileError.TooManyLocals;
+            def_names[def_count] = types.symbolName(target);
+            def_inits[def_count] = types.car(def_rest);
+            def_count += 1;
+        } else if (types.isPair(target)) {
+            // (define (name args...) body) => lambda
+            const fn_name = types.car(target);
+            if (!types.isSymbol(fn_name)) break;
+            if (def_count >= MAX_BODY_DEFS) return CompileError.TooManyLocals;
+            def_names[def_count] = types.symbolName(fn_name);
+            // Build (lambda (args...) body...) as init expression
+            const param_formals = types.cdr(target);
+            const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+            const lambda_args = self.gc.allocPair(param_formals, def_rest) catch return CompileError.OutOfMemory;
+            def_inits[def_count] = self.gc.allocPair(lambda_sym, lambda_args) catch return CompileError.OutOfMemory;
+            def_count += 1;
+        } else {
+            break;
+        }
+        current = types.cdr(current);
+    }
+    // `current` now points to the remaining non-define body expressions.
+
     var last_dst: u16 = 0;
 
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const expr = types.car(current);
-        const rest = types.cdr(current);
+    if (def_count > 0) {
+        // Compile as letrec*: pre-allocate all slots, then evaluate inits.
+        self.beginScope();
 
-        last_dst = try self.allocReg();
+        // Phase 1: allocate locals initialized to void, box for closure capture
+        for (0..def_count) |i| {
+            const slot = try self.allocReg();
+            def_slots[i] = slot;
+            try self.emitOp(.load_void);
+            try self.emitU16(slot);
+            try self.addLocal(def_names[i], slot);
+            try self.markLocalBoxedBySlot(slot);
+        }
 
-        if (rest == types.NIL) {
-            try self.compileExpr(expr, last_dst, true);
-        } else {
-            try self.compileExpr(expr, last_dst, false);
+        // Phase 2: evaluate initializers (all names are now visible)
+        for (0..def_count) |i| {
+            last_dst = try self.allocReg();
+            try self.compileExpr(def_inits[i], last_dst, false);
+            try self.emitOp(.set_box_local);
+            try self.emitU16(def_slots[i]);
+            try self.emitU16(last_dst);
             self.freeReg();
         }
 
-        current = rest;
+        // Phase 3: compile remaining body expressions
+        if (current == types.NIL) {
+            // Body was all defines — return void
+            last_dst = try self.allocReg();
+            try self.emitOp(.load_void);
+            try self.emitU16(last_dst);
+        } else {
+            while (current != types.NIL) {
+                if (!types.isPair(current)) return CompileError.InvalidSyntax;
+                const expr = types.car(current);
+                const rest = types.cdr(current);
+                last_dst = try self.allocReg();
+                if (rest == types.NIL) {
+                    try self.compileExpr(expr, last_dst, true);
+                } else {
+                    try self.compileExpr(expr, last_dst, false);
+                    self.freeReg();
+                }
+                current = rest;
+            }
+        }
+
+        self.endScope();
+    } else {
+        // No internal defines — compile body expressions directly
+        while (current != types.NIL) {
+            if (!types.isPair(current)) return CompileError.InvalidSyntax;
+            const expr = types.car(current);
+            const rest = types.cdr(current);
+            last_dst = try self.allocReg();
+            if (rest == types.NIL) {
+                try self.compileExpr(expr, last_dst, true);
+            } else {
+                try self.compileExpr(expr, last_dst, false);
+                self.freeReg();
+            }
+            current = rest;
+        }
     }
 
     self.in_body_scope = saved_body_scope;

--- a/tests/scheme/smoke/internal-define.scm
+++ b/tests/scheme/smoke/internal-define.scm
@@ -1,0 +1,63 @@
+;; Regression test for #591: internal define must support recursion (R7RS 5.3.2)
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "internal-define")
+
+;; Self-recursive internal define
+(test-equal "self-recursive factorial"
+  120
+  (let ()
+    (define (f n) (if (= n 0) 1 (* n (f (- n 1)))))
+    (f 5)))
+
+;; Mutual recursion via internal defines
+(test-equal "mutually recursive even?/odd?"
+  #t
+  (let ()
+    (define (even? n) (if (= n 0) #t (odd? (- n 1))))
+    (define (odd? n) (if (= n 0) #f (even? (- n 1))))
+    (even? 10)))
+
+(test-equal "mutually recursive odd? result"
+  #t
+  (let ()
+    (define (even? n) (if (= n 0) #t (odd? (- n 1))))
+    (define (odd? n) (if (= n 0) #f (even? (- n 1))))
+    (odd? 7)))
+
+;; Forward reference (foo calls bar, defined after foo)
+(test-equal "forward reference between internal defines"
+  45
+  (let ((x 5))
+    (define foo (lambda (y) (bar x y)))
+    (define bar (lambda (a b) (+ (* a b) a)))
+    (foo (+ x 3))))
+
+;; Non-recursive internal defines still work
+(test-equal "non-recursive sequential defines"
+  43
+  (let ()
+    (define x 42)
+    (define y (+ x 1))
+    y))
+
+;; Internal define in function body (not just let body)
+(test-equal "internal define in function body"
+  120
+  (begin
+    (define (test-fn)
+      (define (fact n) (if (= n 0) 1 (* n (fact (- n 1)))))
+      (fact 5))
+    (test-fn)))
+
+;; Mixed defines and body expressions
+(test-equal "defines followed by body expression"
+  30
+  (let ()
+    (define a 10)
+    (define (double x) (* x 2))
+    (+ a (double a))))
+
+(define %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "internal-define")
+(if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
## Summary

- Internal `define` forms at the beginning of a body now correctly desugar to `letrec*`, making all defined names visible to their own initializers and to each other
- Fixes self-recursive internal defines: `(define (f n) ... (f ...) ...)`
- Fixes mutually recursive internal defines: `(define (even? n) ...) (define (odd? n) ...)`
- Fixes forward references between internal defines
- Applied to both `compileBody` (lambda/function bodies) and `compileLetBody` (let/letrec bodies)

## Root cause

`compileDefine()` called `compileLambda()` first, then added the binding to `self.locals` after. The child compiler couldn't find the name via `resolveUpvalue()` because it didn't exist in the parent's locals yet. The fix pre-allocates boxed slots for all internal define names before compiling any initializer — the same pattern used by the existing `letrec*` compiler.

## Test plan

- [x] New regression test: `tests/scheme/smoke/internal-define.scm` (7 cases)
- [x] Unit tests: `zig build test` passes
- [x] R7RS suite: 1394 pass, 0 fail
- [x] Full Scheme suites: 1559 pass, 0 fail, 1 skip

Fixes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)