### PR TITLE
Restore internal define in nqueens benchmark

### DIFF
--- a/benchmarks/nqueens.scm
+++ b/benchmarks/nqueens.scm
@@ -1,19 +1,18 @@
 (include "benchmarks/common.scm")
 
 (define (nqueens n)
-  (letrec ((queen-cols
-            (lambda (k)
-              (if (= k 0)
-                  (list '())
-                  (filter
-                   (lambda (positions) (safe? k positions))
-                   (flatmap
-                    (lambda (rest-of-queens)
-                      (map-interval
-                       (lambda (new-row) (cons new-row rest-of-queens))
-                       1 n))
-                    (queen-cols (- k 1))))))))
-    (length (queen-cols n))))
+  (define (queen-cols k)
+    (if (= k 0)
+        (list '())
+        (filter
+         (lambda (positions) (safe? k positions))
+         (flatmap
+          (lambda (rest-of-queens)
+            (map-interval
+             (lambda (new-row) (cons new-row rest-of-queens))
+             1 n))
+          (queen-cols (- k 1))))))
+  (length (queen-cols n)))
 
 (define (safe? k positions)
   (let ((new-row (car positions))


### PR DESCRIPTION
## Summary

- Reverts the `letrec` workaround for `queen-cols` back to idiomatic `define`, now that #592 fixed internal define scoping

The `letrec` wrapper was added in #590 because internal `define` couldn't handle self-recursion. With the R7RS 5.3.2 fix in #592, the workaround is no longer needed.

## Test plan

- [x] `bash benchmarks/run-benchmarks.sh` — nqueens(11) passes with `ok` status
- [x] `bash tests/scheme/run-all.sh` — 1559 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)