### PR TITLE
Growable frame stack and register array

### DIFF
--- a/.claude/hooks/test-on-stop.sh
+++ b/.claude/hooks/test-on-stop.sh
@@ -10,7 +10,15 @@ if [[ -z "$modified" && -z "$staged" ]]; then
   exit 0
 fi
 
-if output=$(timeout 120 zig build test 2>&1); then
+if command -v timeout &>/dev/null; then
+  test_cmd="timeout 120 zig build test"
+elif command -v gtimeout &>/dev/null; then
+  test_cmd="gtimeout 120 zig build test"
+else
+  test_cmd="zig build test"
+fi
+
+if output=$($test_cmd 2>&1); then
   exit 0
 else
   tail_output=$(printf '%s' "$output" | tail -30)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ zig build coverage                 # unit test code coverage (requires kcov)
 zig build coverage-scheme -- f.scm # Scheme file code coverage (requires kcov)
 zig build -Dbundle-src=program.scm # standalone binary (compile + embed in one step)
 zig build -Dbundle=program.sbc     # standalone binary from pre-compiled .sbc
-zig build -Dmax-frames=1024        # custom max call depth (default: 480)
-zig build -Dmax-registers=4096     # custom register count (default: 2048)
+zig build -Dmax-frames=1024        # initial frame capacity (default: 480, grows to 32768)
+zig build -Dmax-registers=4096     # initial register count (default: 2048, grows to 65536)
 zig build -Dgc-threshold=16384     # custom initial GC threshold (default: 8192)
 ```
 
@@ -28,8 +28,8 @@ Subcommand: `kaappi compile <file> [-o output]`
 compiles to native binary via LLVM. Version is defined as `pub const version`
 in `main.zig`. Environment: `KAAPPI_LIB_DIR` overrides `libkaappi_rt.a` lookup.
 
-Build-time options: `-Dmax-frames=N` (call frame depth, default 512),
-`-Dmax-registers=N` (register count, default 2048),
+Build-time options: `-Dmax-frames=N` (initial frame capacity, default 480, grows to 32768),
+`-Dmax-registers=N` (initial register count, default 2048, grows to 65536),
 `-Dgc-threshold=N` (initial GC object threshold, default 8192).
 
 Requires Zig 0.16+ and libc (for linenoise terminal handling).
@@ -110,7 +110,7 @@ Source → Reader → Expander → IR → Analysis → Optimization → Bytecode
 | Expander | `expander.zig` | `syntax-rules` pattern matching and template instantiation. Called by the compiler when a macro keyword is encountered. |
 | IR | `ir.zig` | Lowers S-expressions to tree-structured IR (33 node types). Runs 3 analysis passes (tail positions, primitive identification, constant detection) and 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification). See `docs/dev/ir.md`. |
 | Compiler | `compiler.zig` | IR nodes → register-based bytecode via `compileFromNode()`. Retains `compileExpr()` for forms delegated via `passthrough`. Dispatches derived forms to sub-modules. |
-| VM | `vm.zig` | Executes bytecode. Register file + call frame stack. Handles continuations (stack-copying), exception handler stack, dynamic-wind stack, stepping debugger. |
+| VM | `vm.zig` | Executes bytecode. Growable register file + call frame stack (heap-allocated, double-on-overflow). Handles continuations (stack-copying), exception handler stack, dynamic-wind stack, stepping debugger. |
 | GC | `memory.zig` | Generational collector (young/old) with minor and full collections, write barrier for old→young references. Roots tracked via `gc.pushRoot`/`gc.popRoot`. Triggered after N allocations. |
 
 ### Value representation

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Source code
 | **Reader** | `reader.zig` | Tokenizer + recursive descent parser. Handles full R7RS lexical syntax including Unicode identifiers, `#\λ` character literals, `#(...)` vectors, `#u8(...)` bytevectors. |
 | **Expander** | `expander.zig` | `syntax-rules` pattern matching with ellipsis, literal identifiers, underscore wildcards. Template instantiation with hygienic renaming. |
 | **Compiler** | `compiler.zig` + 5 sub-modules | Compiles S-expressions to register-based bytecode. Detects tail positions for proper tail call optimization. Handles 32 syntax forms across 6 files. |
-| **VM** | `vm.zig` + 5 sub-modules | Executes bytecode with a register file, call frame stack, exception handler stack, and dynamic-wind stack. Supports first-class continuations via stack copying, plus a stepping debugger. |
+| **VM** | `vm.zig` + 5 sub-modules | Executes bytecode with a growable register file and call frame stack, exception handler stack, and dynamic-wind stack. Supports first-class continuations via stack copying, plus a stepping debugger. |
 | **GC** | `memory.zig` | Generational collector (young/old) with minor and full collections. Write barrier tracks old→young references. Root tracking via `pushRoot`/`popRoot`. Triggered after N allocations. |
 | **Primitives** | 21 `primitives_*.zig` files | 554 built-in procedures organized by domain: arithmetic, strings, vectors, I/O, control flow, etc. |
 

--- a/build.zig
+++ b/build.zig
@@ -21,8 +21,8 @@ pub fn build(b: *std.Build) void {
     const do_strip = b.option(bool, "strip", "Strip debug info from binaries (for release builds)") orelse false;
     const strip: ?bool = if (do_strip) true else null;
 
-    const max_frames = b.option(u32, "max-frames", "Maximum call frame depth (default: 480)") orelse 480;
-    const max_registers = b.option(u32, "max-registers", "Maximum register count (default: 2048)") orelse 2048;
+    const max_frames = b.option(u32, "max-frames", "Initial call frame capacity (default: 480, grows to 32768)") orelse 480;
+    const max_registers = b.option(u32, "max-registers", "Initial register count (default: 2048, grows to 65536)") orelse 2048;
 
     const gc_threshold = b.option(u32, "gc-threshold", "Initial GC object threshold (default: 8192)") orelse 8192;
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -30,7 +30,7 @@ Source code
 | **Expander** | `expander.zig` | `syntax-rules` pattern matching with ellipsis, literal identifiers, and underscore wildcards. Template instantiation with hygienic renaming (gensym-based). |
 | **IR** | `ir.zig` | Lowers S-expressions to a tree-structured IR (33 node types). Runs 3 analysis passes (tail positions, primitive identification, constant detection) and 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification). See [ir.md](ir.md) for details. |
 | **Compiler** | `compiler.zig` + 5 sub-modules | Emits register-based bytecode from IR nodes via `compileFromNode()`. Retains `compileExpr()` for forms delegated via `passthrough`. Dispatches 32 syntax forms across 6 files. |
-| **VM** | `vm.zig` + 7 sub-modules | Executes bytecode with a register file, call frame stack, exception handler stack, and dynamic-wind stack. First-class continuations via stack copying, plus a stepping debugger. |
+| **VM** | `vm.zig` + 7 sub-modules | Executes bytecode with a growable register file and call frame stack (heap-allocated, double-on-overflow), exception handler stack, and dynamic-wind stack. First-class continuations via stack copying, plus a stepping debugger. |
 | **GC** | `memory.zig` | Mark-and-sweep collector with intrusive linked list. Root tracking via `pushRoot`/`popRoot`. Triggered after N allocations. |
 | **Primitives** | 21 `primitives_*.zig` files | 554 built-in procedures organized by domain. |
 

--- a/docs/dev/deep-recursion-register-overflow.md
+++ b/docs/dev/deep-recursion-register-overflow.md
@@ -54,7 +54,7 @@ are two ways a frame's `base` is chosen, and they behave very differently:
    frame's base is a **flat `prev.base + 200`**:
 
    ```zig
-   const base: u16 = if (self.frame_count > 0)
+   const base: u32 = if (self.frame_count > 0)
        self.frames[self.frame_count - 1].base + 200
    else
        0;
@@ -113,6 +113,10 @@ offset, so it tolerates much greater depth before (also unbounded) overflow.
    heap-allocated slices that double on overflow (initial 480/2048, caps at
    32768/65536). `ensureFrameCapacity` and `ensureRegisterCapacity` on the VM
    handle growth at all frame push sites.
+4. **Widened `CallFrame.base` from u16 to u32 (#593).** The u16 field overflowed
+   at ~20,000 non-tail frames, causing a Zig panic instead of a clean
+   `StackOverflow`. The u32 field supports up to 4 billion register indices.
+   `dst` stays u16 (per-frame offset, bounded by `locals_count`).
 
 ## Cross-references
 

--- a/docs/dev/deep-recursion-register-overflow.md
+++ b/docs/dev/deep-recursion-register-overflow.md
@@ -2,9 +2,13 @@
 
 ## Status
 
-**Fixed.** Bounds checks added at all three re-entrant call sites. Adaptive stride (locals_count+2, min 16) replaces flat +200, allowing ~60 re-entrant levels. Found while sweeping the test suite during the GC
-reachability investigation (2026-06-17); confirmed identical on the pre-fix
-commit, so not introduced by that work.
+**Fixed** (two phases). Phase 1 (2026-06-17): bounds checks added at all three
+re-entrant call sites; adaptive stride (locals_count+2, min 16) replaces flat
++200, allowing ~60 re-entrant levels. Phase 2 (#593, 2026-06-30): frame and
+register arrays made growable (heap-allocated slices, double-on-overflow), fully
+eliminating the fixed-capacity limit. The VM now supports thousands of nested
+non-tail-recursive frames, bounded only by available memory (hard caps: 32768
+frames, 65536 registers).
 
 ## Symptom
 
@@ -26,12 +30,13 @@ deeply recursive chain of `force` / promise streams.
 
 ## Root cause
 
-The VM uses a single **flat, fixed register file** shared by all call frames:
+The VM uses a single **flat register file** shared by all call frames (now
+heap-allocated and growable; originally fixed-size):
 
 ```zig
-// src/vm.zig
-pub const MAX_FRAMES    = 256;
-pub const MAX_REGISTERS = 1024;   // registers: [MAX_REGISTERS]Value
+// src/vm.zig (original constants, now replaced by growable slices)
+pub const INITIAL_FRAME_CAPACITY    = 480;   // grows to MAX_FRAME_LIMIT (32768)
+pub const INITIAL_REGISTER_CAPACITY = 2048;  // grows to MAX_REGISTER_LIMIT (65536)
 ```
 
 Each call frame occupies a slice of that one array starting at its `base`. There
@@ -96,21 +101,18 @@ offset, so it tolerates much greater depth before (also unbounded) overflow.
   adjacent to the `registers` array inside the `VM` struct (`frames`,
   `handler_stack`, counters, …), i.e. silent memory corruption / UB.
 
-## Possible fixes (not yet chosen)
+## Fixes applied
 
-1. **Bounds-check the register window (minimal, highest value).** Before writing
-   args / pushing a frame in `callWithArgs`, `callClosure`, and `callValue`,
-   verify `base + window <= MAX_REGISTERS` and return `VMError.StackOverflow`
-   otherwise. This converts the crash into a clean, catchable Scheme error and
-   closes the ReleaseFast corruption hole. `window` can be `func.locals_count`
-   (or a safe bound when unknown).
-2. **Shrink / make the stride adaptive.** Replace the flat `+200` with the
-   caller's actual high-water register use (`locals_count`) so re-entrant frames
-   pack tighter and tolerate deeper recursion. Combine with (1).
-3. **Grow the budget.** Increase `MAX_REGISTERS`, and/or make the register file a
-   growable allocation. Larger ceiling, but still needs (1) to fail gracefully.
-
-Recommended: (1) now for safety, then (2) to raise the practical depth limit.
+1. **Bounds-check the register window.** Before writing args / pushing a frame in
+   `callWithArgs`, `callClosure`, and `callValue`, the register window is
+   validated. This converts overflows into clean, catchable `StackOverflow` errors.
+2. **Adaptive stride.** The flat `+200` was replaced with the caller's actual
+   high-water register use (`locals_count + 2`, min 16) so re-entrant frames pack
+   tighter.
+3. **Growable register file (#593).** Both `frames` and `registers` are now
+   heap-allocated slices that double on overflow (initial 480/2048, caps at
+   32768/65536). `ensureFrameCapacity` and `ensureRegisterCapacity` on the VM
+   handle growth at all frame push sites.
 
 ## Cross-references
 

--- a/docs/dev/gc-reachability-bug.md
+++ b/docs/dev/gc-reachability-bug.md
@@ -107,4 +107,5 @@ commit, so not introduced here:
   (`tests/scheme/r7rs-tests.scm`).
 - Deep `force`/promise recursion overflows the fixed 1024-entry frame/register
   arrays (`index out of bounds: index 1201, len 1024`) in
-  `tests/scheme/r7rs/{combined-tests,r7rs-tests}.scm`.
+  `tests/scheme/r7rs/{combined-tests,r7rs-tests}.scm`. **Resolved:** bounds
+  checks added (adaptive stride), then frame/register arrays made growable (#593).

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -34,7 +34,7 @@ const Upvalue = struct {
 };
 
 const build_options = @import("build_options");
-const MAX_COMPILER_REGISTERS: u16 = @min(std.math.maxInt(u16), build_options.max_registers);
+const MAX_COMPILER_REGISTERS: u16 = std.math.maxInt(u16);
 const MAX_MACRO_EXPANSION_DEPTH: u16 = 256;
 const MAX_MACRO_EXPANSION_STEPS: u32 = 10_000;
 

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -26,8 +26,8 @@ pub const FiberStatus = enum(u8) {
 
 pub const Fiber = struct {
     header: types.Object,
-    registers: [vm_mod.MAX_REGISTERS]Value,
-    frames: [vm_mod.MAX_FRAMES]CallFrame,
+    registers: []Value,
+    frames: []CallFrame,
     frame_count: usize,
     handler_stack: [vm_mod.MAX_HANDLERS]vm_mod.ExceptionHandler,
     handler_count: usize,
@@ -97,7 +97,7 @@ pub const FiberScheduler = struct {
         if (!types.isClosure(thunk_val)) return VMError.NotAProcedure;
         const closure = types.toObject(thunk_val).as(types.Closure);
 
-        @memset(&fiber.registers, types.UNDEFINED);
+        @memset(fiber.registers, types.UNDEFINED);
         fiber.registers[0] = thunk_val;
         fiber.frames[0] = .{
             .closure = closure,
@@ -124,9 +124,20 @@ pub const FiberScheduler = struct {
     pub fn saveCurrentFiber(self: *FiberScheduler) void {
         const fiber = self.fibers[self.current_idx] orelse return;
         const vm = self.vm;
-        @memcpy(&fiber.registers, &vm.registers);
-        @memcpy(fiber.frames[0..vm.frame_count], vm.frames[0..vm.frame_count]);
+        // Grow fiber's backing arrays if the VM grew beyond them
+        if (vm.registers.len > fiber.registers.len) {
+            const new_regs = vm.gc.allocator.alloc(Value, vm.registers.len) catch return;
+            vm.gc.allocator.free(fiber.registers);
+            fiber.registers = new_regs;
+        }
+        if (vm.frames.len > fiber.frames.len) {
+            const new_frames = vm.gc.allocator.alloc(CallFrame, vm.frames.len) catch return;
+            vm.gc.allocator.free(fiber.frames);
+            fiber.frames = new_frames;
+        }
+        @memcpy(fiber.registers[0..vm.registers.len], vm.registers);
         fiber.frame_count = vm.frame_count;
+        @memcpy(fiber.frames[0..vm.frame_count], vm.frames[0..vm.frame_count]);
         @memcpy(fiber.handler_stack[0..vm.handler_count], vm.handler_stack[0..vm.handler_count]);
         fiber.handler_count = vm.handler_count;
         @memcpy(fiber.wind_stack[0..vm.wind_count], vm.wind_stack[0..vm.wind_count]);
@@ -139,7 +150,18 @@ pub const FiberScheduler = struct {
     pub fn restoreFiber(self: *FiberScheduler, idx: usize) void {
         const fiber = self.fibers[idx] orelse return;
         const vm = self.vm;
-        @memcpy(&vm.registers, &fiber.registers);
+        // Grow VM's backing arrays if the fiber grew beyond them
+        if (fiber.registers.len > vm.registers.len) {
+            const new_regs = vm.gc.allocator.alloc(Value, fiber.registers.len) catch return;
+            vm.gc.allocator.free(vm.registers);
+            vm.registers = new_regs;
+        }
+        if (fiber.frames.len > vm.frames.len) {
+            const new_frames = vm.gc.allocator.alloc(CallFrame, fiber.frames.len) catch return;
+            vm.gc.allocator.free(vm.frames);
+            vm.frames = new_frames;
+        }
+        @memcpy(vm.registers[0..fiber.registers.len], fiber.registers[0..fiber.registers.len]);
         @memcpy(vm.frames[0..fiber.frame_count], fiber.frames[0..fiber.frame_count]);
         vm.frame_count = fiber.frame_count;
         @memcpy(vm.handler_stack[0..fiber.handler_count], fiber.handler_stack[0..fiber.handler_count]);
@@ -273,7 +295,7 @@ pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {
             const lc = cls.func.locals_count;
             break :blk if (lc == 0) 256 else @as(usize, lc);
         } else 256;
-        const end: usize = @min(@as(usize, f.base) + window, vm_mod.MAX_REGISTERS);
+        const end: usize = @min(@as(usize, f.base) + window, fiber.registers.len);
         var r: usize = f.base;
         while (r < end) : (r += 1) gc.markValue(fiber.registers[r]);
     }

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -192,8 +192,7 @@ fn referencesYoung(obj: *Object) bool {
                     const lc = cls.func.locals_count;
                     break :blk if (lc == 0) 256 else @as(usize, lc);
                 } else 256;
-                const vm_mod = @import("vm.zig");
-                const end: usize = @min(@as(usize, f.base) + window, vm_mod.MAX_REGISTERS);
+                const end: usize = @min(@as(usize, f.base) + window, fiber.registers.len);
                 var r: usize = f.base;
                 while (r < end) : (r += 1) {
                     if (isYoungPointer(fiber.registers[r])) return true;
@@ -713,7 +712,12 @@ fn objectSize(obj: *Object) usize {
         .group_info => @sizeOf(types.GroupInfo) + obj.as(types.GroupInfo).name.len,
         .directory_object => @sizeOf(types.DirectoryObject),
         .random_source => @sizeOf(RandomSource),
-        .fiber => @sizeOf(@import("fiber.zig").Fiber),
+        .fiber => blk: {
+            const fiber = obj.as(@import("fiber.zig").Fiber);
+            break :blk @sizeOf(@import("fiber.zig").Fiber) +
+                fiber.registers.len * @sizeOf(Value) +
+                fiber.frames.len * @sizeOf(@import("vm.zig").CallFrame);
+        },
         .channel => @sizeOf(types.Channel),
         .mutex => @sizeOf(types.Mutex),
         .condition_variable => @sizeOf(types.ConditionVariable),
@@ -914,6 +918,8 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
         .fiber => {
             const fiber = obj.as(@import("fiber.zig").Fiber);
             fiber.param_overrides.deinit();
+            gc.allocator.free(fiber.frames);
+            gc.allocator.free(fiber.registers);
             gc.allocator.destroy(fiber);
         },
         .channel => {

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -742,11 +742,16 @@ pub const GC = struct {
     pub fn allocFiber(self: *GC, thunk: Value, id: u32) !*@import("fiber.zig").Fiber {
         try self.maybeCollect();
         const fiber_mod = @import("fiber.zig");
+        const vm_m = @import("vm.zig");
+        const registers = try self.allocator.alloc(Value, vm_m.INITIAL_REGISTER_CAPACITY);
+        errdefer self.allocator.free(registers);
+        const frames = try self.allocator.alloc(vm_m.CallFrame, vm_m.INITIAL_FRAME_CAPACITY);
+        errdefer self.allocator.free(frames);
         const fiber = try self.allocator.create(fiber_mod.Fiber);
         fiber.* = .{
             .header = .{ .tag = .fiber },
-            .registers = undefined,
-            .frames = undefined,
+            .registers = registers,
+            .frames = frames,
             .frame_count = 0,
             .handler_stack = undefined,
             .handler_count = 0,
@@ -767,10 +772,13 @@ pub const GC = struct {
             .terminated = false,
             .param_overrides = std.AutoHashMap(usize, Value).init(self.allocator),
         };
-        @memset(&fiber.registers, types.UNDEFINED);
-        self.bytes_allocated += @sizeOf(fiber_mod.Fiber);
+        @memset(fiber.registers, types.UNDEFINED);
+        const total_size = @sizeOf(fiber_mod.Fiber) +
+            registers.len * @sizeOf(Value) +
+            frames.len * @sizeOf(vm_m.CallFrame);
+        self.bytes_allocated += total_size;
 
-        self.profileAlloc(@sizeOf(fiber_mod.Fiber));
+        self.profileAlloc(total_size);
         self.trackObject(&fiber.header);
         return fiber;
     }

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -529,7 +529,7 @@ pub const GC = struct {
         wind_records: []const WindRecord,
         wind_count: usize,
         dst_reg: u16,
-        dst_base: u16,
+        dst_base: u32,
     ) !Value {
         try self.maybeCollect();
 
@@ -602,7 +602,7 @@ pub const GC = struct {
         target_wind_count: usize,
         target_handler_count: usize,
         dst_reg: u16,
-        dst_base: u16,
+        dst_base: u32,
     ) !Value {
         try self.maybeCollect();
         const cont = try self.allocator.create(Continuation);

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -153,7 +153,7 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
     ctx.sched.next_id += 1;
 
     const closure = types.toObject(thunk).as(types.Closure);
-    @memset(&fiber.registers, types.UNDEFINED);
+    @memset(fiber.registers, types.UNDEFINED);
     fiber.registers[0] = thunk;
     fiber.frames[0] = .{
         .closure = closure,
@@ -231,7 +231,13 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_g
         return;
     };
     @memset(std.mem.asBytes(child_vm), 0);
-    child_vm.* = vm_mod.VM.initForThread(child_gc, parent_vm);
+    child_vm.* = vm_mod.VM.initForThread(child_gc, parent_vm) catch {
+        allocator.destroy(child_vm);
+        child_gc.deinit();
+        allocator.destroy(child_gc);
+        fiber.status = .errored;
+        return;
+    };
 
     vm_mod.vm_instance = child_vm;
     primitives.gc_instance = child_gc;

--- a/src/types.zig
+++ b/src/types.zig
@@ -351,7 +351,7 @@ pub const SavedFrame = struct {
     native: ?*NativeFn,
     code: []const u8,
     ip: usize,
-    base: u16,
+    base: u32,
     dst: u16,
     saved_wind_count: u16,
     // On wasm32, pointer-sized fields shrink from 8 to 4 bytes, making the
@@ -383,7 +383,7 @@ pub const Continuation = struct {
     wind_records: []WindRecord,
     wind_count: usize,
     dst_reg: u16, // register offset within frame where result goes
-    dst_base: u16, // base register of the return frame
+    dst_base: u32, // base register of the return frame
     // Single backing allocation holding registers, frames, handlers and winds
     // contiguously. The four slices above are views into this buffer; it is
     // freed as one block on sweep. Empty for escape continuations.

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -29,8 +29,10 @@ pub const VMError = error{
 };
 
 const build_options = @import("build_options");
-pub const MAX_FRAMES: usize = build_options.max_frames;
-pub const MAX_REGISTERS: usize = build_options.max_registers;
+pub const INITIAL_FRAME_CAPACITY: usize = build_options.max_frames;
+pub const INITIAL_REGISTER_CAPACITY: usize = build_options.max_registers;
+pub const MAX_FRAME_LIMIT: usize = 32768;
+pub const MAX_REGISTER_LIMIT: usize = 65536;
 pub const MAX_HANDLERS = 64;
 pub const MAX_WINDS = 64;
 
@@ -62,7 +64,7 @@ fn markVMRoots(gc: *memory.GC) void {
             const lc = cls.func.locals_count;
             break :blk if (lc == 0) 256 else @as(usize, lc);
         } else 256;
-        const end: usize = @min(@as(usize, f.base) + window, MAX_REGISTERS);
+        const end: usize = @min(@as(usize, f.base) + window, vm.registers.len);
         var r: usize = f.base;
         while (r < end) : (r += 1) gc.markValue(vm.registers[r]);
     }
@@ -168,8 +170,8 @@ pub const ProfileTimeEntry = struct {
 
 pub const VM = struct {
     gc: *memory.GC,
-    registers: [MAX_REGISTERS]Value = undefined,
-    frames: [MAX_FRAMES]CallFrame = undefined,
+    registers: []Value,
+    frames: []CallFrame,
     frame_count: usize = 0,
     globals: std.StringHashMap(Value),
     macros: std.StringHashMap(Value),
@@ -239,8 +241,14 @@ pub const VM = struct {
     yielded: bool = false,
 
     pub fn init(gc: *memory.GC) !VM {
+        const frames = try gc.allocator.alloc(CallFrame, INITIAL_FRAME_CAPACITY);
+        errdefer gc.allocator.free(frames);
+        const registers = try gc.allocator.alloc(Value, INITIAL_REGISTER_CAPACITY);
+        errdefer gc.allocator.free(registers);
         var vm = VM{
             .gc = gc,
+            .frames = frames,
+            .registers = registers,
             .globals = std.StringHashMap(Value).init(gc.allocator),
             .macros = std.StringHashMap(Value).init(gc.allocator),
             .output = .empty,
@@ -248,10 +256,7 @@ pub const VM = struct {
             .loading_libs = std.StringHashMap(void).init(gc.allocator),
             .param_overrides = std.AutoHashMap(usize, Value).init(gc.allocator),
         };
-        @memset(&vm.registers, types.UNDEFINED);
-        // Teach the GC how to find roots held in the VM (registers, frames,
-        // handlers, winds, globals, macros) so collections during execution
-        // don't free in-flight objects.
+        @memset(vm.registers, types.UNDEFINED);
         gc.root_marker = &markVMRoots;
         // Pre-allocate standard ports
         vm.stdin_port = gc.allocPort(0, true, false, "stdin", false) catch types.VOID;
@@ -264,9 +269,15 @@ pub const VM = struct {
         return vm;
     }
 
-    pub fn initForThread(gc: *memory.GC, parent: *VM) VM {
-        var vm = VM{
+    pub fn initForThread(gc: *memory.GC, parent: *VM) !VM {
+        const frames = try gc.allocator.alloc(CallFrame, INITIAL_FRAME_CAPACITY);
+        errdefer gc.allocator.free(frames);
+        const registers = try gc.allocator.alloc(Value, INITIAL_REGISTER_CAPACITY);
+        errdefer gc.allocator.free(registers);
+        const vm = VM{
             .gc = gc,
+            .frames = frames,
+            .registers = registers,
             .globals = parent.globals,
             .macros = parent.macros,
             .output = .empty,
@@ -279,7 +290,7 @@ pub const VM = struct {
             .stderr_port = parent.stderr_port,
             .owns_globals = false,
         };
-        @memset(&vm.registers, types.UNDEFINED);
+        @memset(vm.registers, types.UNDEFINED);
         gc.root_marker = &markVMRoots;
         return vm;
     }
@@ -303,6 +314,33 @@ pub const VM = struct {
             if (bp.condition) |cond| self.gc.allocator.free(cond);
         }
         self.breakpoint_count = 0;
+        self.gc.allocator.free(self.frames);
+        self.gc.allocator.free(self.registers);
+    }
+
+    pub fn ensureFrameCapacity(self: *VM, needed: usize) VMError!void {
+        if (needed <= self.frames.len) return;
+        if (needed > MAX_FRAME_LIMIT) return VMError.StackOverflow;
+        var new_cap = self.frames.len;
+        while (new_cap < needed) new_cap *= 2;
+        if (new_cap > MAX_FRAME_LIMIT) new_cap = MAX_FRAME_LIMIT;
+        const new_frames = self.gc.allocator.alloc(CallFrame, new_cap) catch return VMError.OutOfMemory;
+        @memcpy(new_frames[0..self.frame_count], self.frames[0..self.frame_count]);
+        self.gc.allocator.free(self.frames);
+        self.frames = new_frames;
+    }
+
+    pub fn ensureRegisterCapacity(self: *VM, needed: usize) VMError!void {
+        if (needed <= self.registers.len) return;
+        if (needed > MAX_REGISTER_LIMIT) return VMError.StackOverflow;
+        var new_cap = self.registers.len;
+        while (new_cap < needed) new_cap *= 2;
+        if (new_cap > MAX_REGISTER_LIMIT) new_cap = MAX_REGISTER_LIMIT;
+        const new_regs = self.gc.allocator.alloc(Value, new_cap) catch return VMError.OutOfMemory;
+        @memcpy(new_regs[0..self.registers.len], self.registers);
+        @memset(new_regs[self.registers.len..], types.UNDEFINED);
+        self.gc.allocator.free(self.registers);
+        self.registers = new_regs;
     }
 
     pub fn getParameterValue(self: *VM, param: *types.ParameterObject) Value {
@@ -496,7 +534,7 @@ pub const VM = struct {
                     32;
                 break :blk prev.base + stride;
             } else 0;
-            if (base + func.locals_count >= MAX_REGISTERS) return VMError.StackOverflow;
+            try self.ensureRegisterCapacity(@as(usize, base) + @as(usize, func.locals_count) + 1);
 
             if (func.is_variadic and func.arity == 0) {
                 // (lambda args ...) — wrap arg in a list
@@ -509,7 +547,7 @@ pub const VM = struct {
                 self.registers[base] = arg;
             }
 
-            if (self.frame_count >= MAX_FRAMES) return VMError.StackOverflow;
+            try self.ensureFrameCapacity(self.frame_count + 1);
 
             const saved_frame_count = self.frame_count;
             const saved_handler_count = self.handler_count;
@@ -591,13 +629,13 @@ pub const VM = struct {
                     32;
                 break :blk prev.base + stride;
             } else 0;
-            if (base + @as(u16, func.locals_count) >= MAX_REGISTERS) return VMError.StackOverflow;
+            try self.ensureRegisterCapacity(@as(usize, base) + @as(usize, func.locals_count) + 1);
 
             if (func.is_variadic and func.arity == 0) {
                 self.registers[base] = types.NIL;
             }
 
-            if (self.frame_count >= MAX_FRAMES) return VMError.StackOverflow;
+            try self.ensureFrameCapacity(self.frame_count + 1);
 
             const saved_frame_count = self.frame_count;
             const saved_handler_count = self.handler_count;
@@ -699,7 +737,7 @@ pub const VM = struct {
                     32;
                 break :blk prev.base + stride;
             } else 0;
-            if (base + @as(usize, func.locals_count) >= MAX_REGISTERS) return VMError.StackOverflow;
+            try self.ensureRegisterCapacity(@as(usize, base) + @as(usize, func.locals_count) + 1);
 
             if (args.len > std.math.maxInt(u8)) return VMError.ArityMismatch;
             const nargs: u8 = @intCast(args.len);
@@ -733,7 +771,7 @@ pub const VM = struct {
                 }
             }
 
-            if (self.frame_count >= MAX_FRAMES) return VMError.StackOverflow;
+            try self.ensureFrameCapacity(self.frame_count + 1);
 
             const saved_frame_count = self.frame_count;
             const saved_handler_count = self.handler_count;

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -146,7 +146,7 @@ pub const CallFrame = struct {
     native: ?*types.NativeFn = null,
     code: []const u8,
     ip: usize,
-    base: u16,
+    base: u32,
     dst: u16,
     saved_wind_count: u16 = 0,
 };
@@ -526,9 +526,9 @@ pub const VM = struct {
             const closure = types.toObject(handler_val).as(types.Closure);
             const func = closure.func;
 
-            const base: u16 = if (self.frame_count > 0) blk: {
+            const base: u32 = if (self.frame_count > 0) blk: {
                 const prev = self.frames[self.frame_count - 1];
-                const stride: u16 = if (prev.closure) |c|
+                const stride: u32 = if (prev.closure) |c|
                     @max(16, @as(u16, c.func.locals_count) + 2)
                 else
                     32;
@@ -621,9 +621,9 @@ pub const VM = struct {
             const closure = types.toObject(thunk_val).as(types.Closure);
             const func = closure.func;
 
-            const base: u16 = if (self.frame_count > 0) blk: {
+            const base: u32 = if (self.frame_count > 0) blk: {
                 const prev = self.frames[self.frame_count - 1];
-                const stride: u16 = if (prev.closure) |c|
+                const stride: u32 = if (prev.closure) |c|
                     @max(16, @as(u16, c.func.locals_count) + 2)
                 else
                     32;
@@ -729,9 +729,9 @@ pub const VM = struct {
             const closure = types.toObject(proc).as(types.Closure);
             const func = closure.func;
 
-            const base: u16 = if (self.frame_count > 0) blk: {
+            const base: u32 = if (self.frame_count > 0) blk: {
                 const prev = self.frames[self.frame_count - 1];
-                const stride: u16 = if (prev.closure) |c|
+                const stride: u32 = if (prev.closure) |c|
                     @max(16, @as(u16, c.func.locals_count) + 2)
                 else
                     32;
@@ -861,7 +861,7 @@ pub const VM = struct {
     }
 
     /// Capture the current continuation state (delegates to vm_continuations).
-    pub fn captureContinuation(self: *VM, dst_reg: u8, dst_base: u16) VMError!Value {
+    pub fn captureContinuation(self: *VM, dst_reg: u8, dst_base: u32) VMError!Value {
         return vm_continuations.captureContinuation(self, dst_reg, dst_base);
     }
 
@@ -871,7 +871,7 @@ pub const VM = struct {
     }
 
     /// Capture an escape continuation (delegates to vm_continuations).
-    pub fn captureEscape(self: *VM, dst_reg: u8, dst_base: u16) VMError!Value {
+    pub fn captureEscape(self: *VM, dst_reg: u8, dst_base: u32) VMError!Value {
         return vm_continuations.captureEscape(self, dst_reg, dst_base);
     }
 

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -6,8 +6,6 @@ const vm_mod = @import("vm.zig");
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
 const CallFrame = vm_mod.CallFrame;
-const MAX_REGISTERS = vm_mod.MAX_REGISTERS;
-const MAX_FRAMES = vm_mod.MAX_FRAMES;
 
 const memory = @import("memory.zig");
 const vm_continuations = @import("vm_continuations.zig");
@@ -272,8 +270,7 @@ pub fn callValue(vm: *VM, callee: Value, base: u16, nargs: u8) VMError!void {
 pub fn callClosure(vm: *VM, closure: *types.Closure, base: u16, nargs: u8) VMError!void {
     const func = closure.func;
 
-    if (base + @as(u16, @max(nargs + 1, func.locals_count)) >= MAX_REGISTERS)
-        return VMError.StackOverflow;
+    try vm.ensureRegisterCapacity(@as(usize, base) + @as(usize, @max(nargs + 1, func.locals_count)) + 1);
 
     if (!func.is_variadic) {
         if (nargs != func.arity) {
@@ -312,7 +309,7 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u16, nargs: u8) VMErr
         vm.registers[base + 1 + rest_start] = rest_list;
     }
 
-    if (vm.frame_count >= MAX_FRAMES) return VMError.StackOverflow;
+    try vm.ensureFrameCapacity(vm.frame_count + 1);
 
     // The callee is in base, args are in base+1..base+nargs
     // New frame's registers start at base (callee reg becomes r0 for the function)
@@ -381,7 +378,7 @@ pub fn callNative(vm: *VM, native: *types.NativeFn, base: u16, nargs: u8) VMErro
         native.profile_calls += 1;
     }
 
-    if (base + @as(u16, nargs) + 1 >= MAX_REGISTERS)
+    if (@as(usize, base) + @as(usize, nargs) + 1 > vm.registers.len)
         return VMError.StackOverflow;
 
     switch (native.arity) {

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -198,7 +198,7 @@ pub fn restoreContinuation(self: *VM, cont: *types.Continuation, value: Value) V
     try vm_continuations.restoreContinuation(self, cont, value);
 }
 
-pub fn handleNativeError(_: *VM, err: anyerror, _: u16, _: u8) VMError {
+pub fn handleNativeError(_: *VM, err: anyerror, _: u32, _: u8) VMError {
     return switch (err) {
         error.TypeError => VMError.TypeError,
         error.DivisionByZero => VMError.DivisionByZero,
@@ -212,7 +212,7 @@ pub fn handleNativeError(_: *VM, err: anyerror, _: u16, _: u8) VMError {
     };
 }
 
-pub fn callValue(vm: *VM, callee: Value, base: u16, nargs: u8) VMError!void {
+pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
     // Check closure first — by far the most common case in Scheme programs
     if (types.isClosure(callee)) {
         return callClosure(vm, types.toObject(callee).as(types.Closure), base, nargs);
@@ -267,7 +267,7 @@ pub fn callValue(vm: *VM, callee: Value, base: u16, nargs: u8) VMError!void {
     return VMError.NotAProcedure;
 }
 
-pub fn callClosure(vm: *VM, closure: *types.Closure, base: u16, nargs: u8) VMError!void {
+pub fn callClosure(vm: *VM, closure: *types.Closure, base: u32, nargs: u8) VMError!void {
     const func = closure.func;
 
     try vm.ensureRegisterCapacity(@as(usize, base) + @as(usize, @max(nargs + 1, func.locals_count)) + 1);
@@ -313,7 +313,7 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u16, nargs: u8) VMErr
 
     // The callee is in base, args are in base+1..base+nargs
     // New frame's registers start at base (callee reg becomes r0 for the function)
-    const new_base = base + 1; // skip the callee register
+    const new_base = if (base < std.math.maxInt(u32)) base + 1 else return VMError.StackOverflow;
     vm.frames[vm.frame_count] = .{
         .closure = closure,
         .code = func.code.items,
@@ -373,7 +373,7 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u16, nargs: u8) VMErr
     }
 }
 
-pub fn callNative(vm: *VM, native: *types.NativeFn, base: u16, nargs: u8) VMError!void {
+pub fn callNative(vm: *VM, native: *types.NativeFn, base: u32, nargs: u8) VMError!void {
     if (vm.profile_mode) {
         native.profile_calls += 1;
     }

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -5,9 +5,7 @@ const Value = types.Value;
 const vm_mod = @import("vm.zig");
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
-const MAX_FRAMES = vm_mod.MAX_FRAMES;
 const MAX_HANDLERS = vm_mod.MAX_HANDLERS;
-const MAX_REGISTERS = vm_mod.MAX_REGISTERS;
 const MAX_WINDS = vm_mod.MAX_WINDS;
 
 /// Capture the current continuation state.
@@ -28,13 +26,15 @@ pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u16) VMError!Value {
         const frame_end = @as(usize, f.base) + window;
         if (frame_end > max_reg) max_reg = frame_end;
     }
-    if (max_reg > MAX_REGISTERS) max_reg = MAX_REGISTERS;
+    if (max_reg > vm.registers.len) max_reg = vm.registers.len;
     // At minimum, save up to dst_base + dst_reg + 1
     const min_needed = @as(usize, dst_base) + @as(usize, dst_reg) + 1;
     if (min_needed > max_reg) max_reg = min_needed;
 
-    // Convert frames to SavedFrames
-    var saved_frames: [MAX_FRAMES]types.SavedFrame = undefined;
+    // Convert frames to SavedFrames (heap-allocated for growable stacks)
+    const saved_frames = vm.gc.allocator.alloc(types.SavedFrame, vm.frame_count) catch
+        return VMError.OutOfMemory;
+    defer vm.gc.allocator.free(saved_frames);
     for (vm.frames[0..vm.frame_count], 0..) |f, i| {
         saved_frames[i] = .{
             .closure = f.closure,
@@ -142,7 +142,7 @@ pub fn invokeEscape(vm: *VM, cont: *types.Continuation, value: Value) VMError!vo
     // Truncate the live stack back to the call/ec point and deliver the value.
     vm.frame_count = cont.target_frame_count;
     const dst_idx = @as(usize, cont.dst_base) + @as(usize, cont.dst_reg);
-    if (dst_idx < MAX_REGISTERS) {
+    if (dst_idx < vm.registers.len) {
         vm.registers[dst_idx] = value;
     }
     vm.continuation_value = value;
@@ -188,16 +188,16 @@ pub fn performWindTransition(vm: *VM, target_winds: []const types.WindRecord, ta
 /// Restore a captured continuation, replacing the VM state and placing
 /// the given value at the continuation's destination register.
 pub fn restoreContinuation(vm: *VM, cont: *types.Continuation, value: Value) VMError!void {
-    // Validate captured counts fit within VM limits; fail closed instead of
-    // truncating continuation state silently.
-    if (cont.registers.len > MAX_REGISTERS) return VMError.StackOverflow;
-    if (cont.frame_count > MAX_FRAMES) return VMError.StackOverflow;
     if (cont.handler_count > MAX_HANDLERS) return VMError.StackOverflow;
     if (cont.wind_count > MAX_WINDS) return VMError.StackOverflow;
     if (cont.frames.len < cont.frame_count) return VMError.InvalidBytecode;
     if (cont.handlers.len < cont.handler_count) return VMError.InvalidBytecode;
     if (cont.wind_records.len < cont.wind_count) return VMError.InvalidBytecode;
     if (cont.is_escape) return VMError.InvalidArgument;
+
+    // Grow VM capacity to fit the captured state
+    try vm.ensureRegisterCapacity(cont.registers.len);
+    try vm.ensureFrameCapacity(cont.frame_count);
 
     // Restore saved VM state
     @memcpy(vm.registers[0..cont.registers.len], cont.registers[0..cont.registers.len]);
@@ -234,7 +234,7 @@ pub fn restoreContinuation(vm: *VM, cont: *types.Continuation, value: Value) VME
 
     // Place the result value where call/cc was waiting for it
     const dst_idx = @as(usize, cont.dst_base) + @as(usize, cont.dst_reg);
-    if (dst_idx >= MAX_REGISTERS) return VMError.StackOverflow;
+    if (dst_idx >= vm.registers.len) return VMError.StackOverflow;
     vm.registers[dst_idx] = value;
     vm.continuation_value = value;
     vm.continuation_invoked = true;

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -11,7 +11,7 @@ const MAX_WINDS = vm_mod.MAX_WINDS;
 /// Capture the current continuation state.
 /// dst_reg is the register offset within the caller's frame where the result of call/cc will go.
 /// dst_base is the base register of the caller's frame.
-pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u16) VMError!Value {
+pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u32) VMError!Value {
     // Determine how many registers are actually in use. Each frame's live
     // register window is [base, base + locals_count): locals_count is the
     // compiler-recorded high-water mark of registers the function can touch.
@@ -75,11 +75,11 @@ pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u16) VMError!Value {
 /// proc is the one-argument procedure to call with the continuation.
 /// base is the register containing the callee (call/cc itself),
 /// and the result of call/cc will be stored at base.
-pub fn callWithCC(vm: *VM, proc: Value, base: u16) VMError!void {
+pub fn callWithCC(vm: *VM, proc: Value, base: u32) VMError!void {
     // The caller's frame is at vm.frame_count - 1.
     // After call/cc returns, the result goes into base (relative to caller's frame).
     const caller_frame = &vm.frames[vm.frame_count - 1];
-    const dst_reg: u16 = @intCast(base - caller_frame.base);
+    const dst_reg: u16 = @intCast(@as(u32, base) - caller_frame.base);
 
     // Capture the continuation. The continuation, when invoked,
     // will restore state and place the value at base (which is
@@ -96,7 +96,7 @@ pub fn callWithCC(vm: *VM, proc: Value, base: u16) VMError!void {
 
 /// Capture an escape continuation (call/ec). Records only the stack depths to
 /// unwind back to — no register/frame snapshot — so capture is O(1).
-pub fn captureEscape(vm: *VM, dst_reg: u16, dst_base: u16) VMError!Value {
+pub fn captureEscape(vm: *VM, dst_reg: u16, dst_base: u32) VMError!Value {
     return vm.gc.allocEscapeContinuation(
         vm.frame_count,
         vm.wind_count,

--- a/src/vm_debug.zig
+++ b/src/vm_debug.zig
@@ -40,7 +40,7 @@ fn checkWatches(vm: *VM) bool {
         for (func.debug_locals) |local| {
             if (std.mem.eql(u8, local.name, w.name)) {
                 const idx = @as(usize, frame.base) + @as(usize, local.slot);
-                if (idx >= vm_mod.MAX_REGISTERS) continue;
+                if (idx >= vm.registers.len) continue;
                 const val = vm.registers[idx];
                 if (val != w.last_value) {
                     w.last_value = val;
@@ -211,7 +211,7 @@ fn printLocals(vm: *VM, frame_idx: usize, allocator: std.mem.Allocator) void {
         const printer = @import("printer.zig");
         for (func.debug_locals) |local| {
             const idx = @as(usize, f.base) + @as(usize, local.slot);
-            if (idx >= vm_mod.MAX_REGISTERS) continue;
+            if (idx >= vm.registers.len) continue;
             writeStderr("  ");
             writeStderr(local.name);
             writeStderr(" = ");

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -7,8 +7,6 @@ const vm_mod = @import("vm.zig");
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
 const CallFrame = vm_mod.CallFrame;
-const MAX_REGISTERS = vm_mod.MAX_REGISTERS;
-const MAX_FRAMES = vm_mod.MAX_FRAMES;
 
 const vm_calls = @import("vm_calls.zig");
 const vm_continuations = @import("vm_continuations.zig");
@@ -315,7 +313,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             return VMError.ArityMismatch;
                         }
                         const rest_start = func.arity;
-                        if (@as(usize, abs_base) + @as(usize, rest_start) + 1 >= MAX_REGISTERS) {
+                        if (@as(usize, abs_base) + @as(usize, rest_start) + 1 >= self.registers.len) {
                             return VMError.InvalidBytecode;
                         }
                         var rest_list: Value = types.NIL;
@@ -339,7 +337,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     for (0..arg_count) |i| {
                         const dst_idx = @as(usize, frame.base) + i;
                         const src_idx = @as(usize, abs_base) + 1 + i;
-                        if (dst_idx >= MAX_REGISTERS or src_idx >= MAX_REGISTERS) {
+                        if (dst_idx >= self.registers.len or src_idx >= self.registers.len) {
                             return VMError.InvalidBytecode;
                         }
                         self.registers[dst_idx] = self.registers[src_idx];
@@ -545,7 +543,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const arg_count: u8 = if (func.is_variadic) func.arity + 1 else total_nargs;
                     for (0..arg_count) |i| {
                         const dst_idx = @as(usize, frame.base) + i;
-                        if (dst_idx >= MAX_REGISTERS) return VMError.InvalidBytecode;
+                        if (dst_idx >= self.registers.len) return VMError.InvalidBytecode;
                         self.registers[dst_idx] = flat_args[i];
                     }
 
@@ -821,7 +819,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         .exact => |expected| nargs == expected,
                         .variadic => |min| nargs >= min,
                     };
-                    if (arity_ok and base + @as(u16, nargs) + 1 < MAX_REGISTERS) {
+                    if (arity_ok and base + @as(u16, nargs) + 1 < self.registers.len) {
                         const args = self.registers[base + 1 .. base + 1 + nargs];
                         const result = native.func(args) catch |err| {
                             if (err == error.ContinuationInvoked) {
@@ -913,7 +911,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     } else {
                         if (nargs < tfunc.arity) return VMError.ArityMismatch;
                         const rest_start = tfunc.arity;
-                        if (@as(usize, abs_base) + @as(usize, rest_start) + 1 >= MAX_REGISTERS) {
+                        if (@as(usize, abs_base) + @as(usize, rest_start) + 1 >= self.registers.len) {
                             return VMError.InvalidBytecode;
                         }
                         var rest_list: Value = types.NIL;
@@ -936,7 +934,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     for (0..arg_count) |ai| {
                         const dst_idx = @as(usize, frame.base) + ai;
                         const src_idx = @as(usize, abs_base) + 1 + ai;
-                        if (dst_idx >= MAX_REGISTERS or src_idx >= MAX_REGISTERS) {
+                        if (dst_idx >= self.registers.len or src_idx >= self.registers.len) {
                             return VMError.InvalidBytecode;
                         }
                         self.registers[dst_idx] = self.registers[src_idx];
@@ -1059,7 +1057,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 for (0..nargs) |i| {
                     const dst_idx = @as(usize, frame.base) + i;
                     const src_idx = @as(usize, abs_base) + 1 + i;
-                    if (dst_idx >= MAX_REGISTERS or src_idx >= MAX_REGISTERS) {
+                    if (dst_idx >= self.registers.len or src_idx >= self.registers.len) {
                         return VMError.InvalidBytecode;
                     }
                     self.registers[dst_idx] = self.registers[src_idx];
@@ -1092,16 +1090,14 @@ pub fn ensureOperands(vm: *VM, frame: *CallFrame, operand_bytes: usize) VMError!
 }
 
 pub fn registerIndex(vm: *VM, base: u16, reg: u16) VMError!usize {
-    _ = vm;
     const idx = @as(usize, base) + @as(usize, reg);
-    if (idx >= MAX_REGISTERS) return VMError.InvalidBytecode;
+    if (idx >= vm.registers.len) return VMError.InvalidBytecode;
     return idx;
 }
 
 pub fn ensureCallWindow(vm: *VM, base: usize, nargs: u8) VMError!void {
-    _ = vm;
     const hi = base + @as(usize, nargs) + 1;
-    if (hi > MAX_REGISTERS) return VMError.InvalidBytecode;
+    if (hi > vm.registers.len) try vm.ensureRegisterCapacity(hi);
 }
 
 pub fn constantAt(vm: *VM, func: *types.Function, idx: u16) VMError!Value {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -274,7 +274,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const nargs = readU8(self, frame);
                 const base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, base_wide, nargs);
-                const base: u16 = @intCast(base_wide);
+                const base: u32 = try toBase(base_wide);
                 const callee = self.registers[base];
                 if (types.isClosure(callee)) {
                     vm_calls.callClosure(self, types.toObject(callee).as(types.Closure), base, nargs) catch |err| return err;
@@ -295,7 +295,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const nargs = readU8(self, frame);
                 const abs_base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, abs_base_wide, nargs);
-                const abs_base: u16 = @intCast(abs_base_wide);
+                const abs_base: u32 = try toBase(abs_base_wide);
                 const callee = self.registers[abs_base];
 
                 if (types.isClosure(callee)) {
@@ -480,7 +480,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 if (nargs == 0) return VMError.InvalidBytecode;
                 const abs_base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, abs_base_wide, nargs);
-                const abs_base: u16 = @intCast(abs_base_wide);
+                const abs_base: u32 = try toBase(abs_base_wide);
                 const proc = self.registers[abs_base];
 
                 var flat_args: [256]Value = undefined;
@@ -743,7 +743,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const env: *std.StringHashMap(Value) = the_func.env orelse &self.globals;
                 const base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, base_wide, nargs);
-                const base: u16 = @intCast(base_wide);
+                const base: u32 = try toBase(base_wide);
 
                 if (the_func.env == null) {
                     if (the_func.global_cache) |cache| {
@@ -859,7 +859,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const env: *std.StringHashMap(Value) = func.env orelse &self.globals;
                 const abs_base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, abs_base_wide, nargs);
-                const abs_base: u16 = @intCast(abs_base_wide);
+                const abs_base: u32 = try toBase(abs_base_wide);
 
                 var callee: Value = types.VOID;
                 if (func.env == null) {
@@ -1053,7 +1053,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const nargs = readU8(self, frame);
                 const abs_base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, abs_base_wide, nargs);
-                const abs_base: u16 = @intCast(abs_base_wide);
+                const abs_base: u32 = try toBase(abs_base_wide);
                 for (0..nargs) |i| {
                     const dst_idx = @as(usize, frame.base) + i;
                     const src_idx = @as(usize, abs_base) + 1 + i;
@@ -1089,7 +1089,7 @@ pub fn ensureOperands(vm: *VM, frame: *CallFrame, operand_bytes: usize) VMError!
     if (frame.ip + operand_bytes > frame.code.len) return VMError.InvalidBytecode;
 }
 
-pub fn registerIndex(vm: *VM, base: u16, reg: u16) VMError!usize {
+pub fn registerIndex(vm: *VM, base: u32, reg: u16) VMError!usize {
     const idx = @as(usize, base) + @as(usize, reg);
     if (idx >= vm.registers.len) return VMError.InvalidBytecode;
     return idx;
@@ -1098,6 +1098,11 @@ pub fn registerIndex(vm: *VM, base: u16, reg: u16) VMError!usize {
 pub fn ensureCallWindow(vm: *VM, base: usize, nargs: u8) VMError!void {
     const hi = base + @as(usize, nargs) + 1;
     if (hi > vm.registers.len) try vm.ensureRegisterCapacity(hi);
+}
+
+fn toBase(base_wide: usize) VMError!u32 {
+    if (base_wide > std.math.maxInt(u32)) return VMError.StackOverflow;
+    return @intCast(base_wide);
 }
 
 pub fn constantAt(vm: *VM, func: *types.Function, idx: u16) VMError!Value {

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -109,7 +109,7 @@ echo
 echo "-- Stack overflow --"
 
 assert_output_contains "stack overflow is reported" \
-    '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 10000)' "StackOverflow"
+    '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 50000)' "StackOverflow"
 
 # --- Library import errors ---
 echo

--- a/tests/scheme/robustness/robustness.sh
+++ b/tests/scheme/robustness/robustness.sh
@@ -48,11 +48,14 @@ echo
 
 # --- Deep recursion ---
 echo "-- Deep recursion --"
-assert_error "deep non-tail recursion" \
+assert_no_crash "deep non-tail recursion (growable stack)" \
     '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 10000)'
 
+assert_error "non-tail recursion past hard limit" \
+    '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 50000)'
+
 assert_no_crash "catchable stack overflow" \
-    '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (guard (e (#t "caught")) (deep 10000))'
+    '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (guard (e (#t "caught")) (deep 50000))'
 
 assert_no_crash "deep tail recursion (should not overflow)" \
     '(define (loop n) (if (= n 0) (display "ok") (loop (- n 1)))) (loop 1000000)'

--- a/tests/scheme/smoke/deep-recursion.scm
+++ b/tests/scheme/smoke/deep-recursion.scm
@@ -1,0 +1,35 @@
+;; Test growable frame stack — non-tail-recursive patterns that previously
+;; overflowed at ~475 elements with the 480-frame fixed limit.
+
+(import (scheme base) (scheme write))
+
+;; Non-tail-recursive filter
+(define (my-filter pred lst)
+  (cond ((null? lst) '())
+        ((pred (car lst)) (cons (car lst) (my-filter pred (cdr lst))))
+        (else (my-filter pred (cdr lst)))))
+
+(let ((result (my-filter (lambda (x) #t) (make-list 5000 1))))
+  (unless (= 5000 (length result))
+    (error "my-filter failed" (length result))))
+
+;; Non-tail-recursive enumerate-interval
+(define (enumerate-interval low high)
+  (if (> low high) '()
+      (cons low (enumerate-interval (+ low 1) high))))
+
+(let ((result (enumerate-interval 1 5000)))
+  (unless (= 5000 (length result))
+    (error "enumerate-interval failed" (length result))))
+
+;; Non-tail-recursive map
+(define (my-map f lst)
+  (if (null? lst) '()
+      (cons (f (car lst)) (my-map f (cdr lst)))))
+
+(let ((result (my-map (lambda (x) (* x 2)) (make-list 3000 1))))
+  (unless (= 3000 (length result))
+    (error "my-map failed" (length result))))
+
+(display "deep-recursion: all tests passed")
+(newline)


### PR DESCRIPTION
## Summary

Fixes #593. Replace fixed-size frame and register arrays with heap-allocated slices that grow on demand, and widen `CallFrame.base` from u16 to u32.

- Non-tail-recursive `filter`, `enumerate-interval`, and similar now handle **5000+ elements** (was ~475)
- Initial capacity unchanged (480 frames / 2048 registers) — zero overhead for shallow programs
- Growth by doubling up to hard caps (32768 frames / 65536 registers)
- GC-safe: growth uses the system allocator, never triggers collection
- `CallFrame.base` widened from u16 to u32 — eliminates integer overflow panics at deep recursion (the u16 field overflowed at ~20,000 frames)

## Changes (20 files, +264 −133)

| Area | Files | Change |
|------|-------|--------|
| VM core | `vm.zig` | Slices, init/deinit allocation, `ensureFrameCapacity`/`ensureRegisterCapacity` growth functions, frame push sites, `CallFrame.base` u16→u32 |
| Call machinery | `vm_calls.zig`, `vm_dispatch.zig` | Growth calls at frame push, dynamic bounds in `registerIndex`/`ensureCallWindow`, u32 base signatures |
| Continuations | `vm_continuations.zig` | Heap-allocated saved_frames temp, grow-on-restore, u32 dst_base |
| Type defs | `types.zig` | `SavedFrame.base` u16→u32, `Continuation.dst_base` u16→u32 |
| Fibers | `fiber.zig`, `memory.zig`, `gc_collect.zig` | Dynamic backing arrays, save/restore handles size mismatches |
| Peripheral | `compiler.zig`, `primitives_srfi18.zig`, `vm_debug.zig`, `build.zig` | Compiler register cap, fallible `initForThread`, dynamic debug bounds |
| Docs | `CLAUDE.md`, `README.md`, `docs/dev/` (3 files) | Updated build options, architecture notes, deep-recursion postmortem |
| Tests | `tests/scheme/smoke/deep-recursion.scm`, `tests/scheme/robustness/robustness.sh` | 5000-element deep recursion test, robustness tests for growable stack and hard-limit overflow |
| Hooks | `.claude/hooks/test-on-stop.sh` | macOS compatibility (fallback when `timeout` missing) |

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1560 pass, 0 fail
- [x] `deep-recursion.scm` — 5000-element non-tail-recursive filter/enumerate/map
- [x] `robustness.sh` — 29 pass, 0 fail (growable stack at 10k, clean StackOverflow at 50k)
- [x] GC stress: `zig build -Dgc-threshold=1 run -- tests/scheme/r7rs/r7rs-tests.scm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)