### PR TITLE
Add benchmark trend visualization and regression detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.event_name == 'push'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
 
@@ -211,3 +213,16 @@ jobs:
           name: benchmark-results
           path: benchmark-results.json
           retention-days: 30
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'customSmallerIsBetter'
+          output-file-path: benchmark-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '130%'
+          comment-on-alert: true
+          fail-on-alert: false
+          benchmark-data-dir-path: 'dev/bench'
+          max-items-in-chart: 100


### PR DESCRIPTION
## Summary
- Integrate `github-action-benchmark` into the CI benchmark job to store historical results on the `gh-pages` branch
- Auto-generates trend charts accessible via GitHub Pages
- Posts commit comments when any benchmark regresses >30% vs. the previous run
- Retains the existing artifact upload for backward compatibility

## Details
The existing JSON output format (`name`, `unit`, `value`) is already compatible with `customSmallerIsBetter`, so no transform is needed. The action pushes results to `dev/bench/` on `gh-pages` with up to 100 data points per chart.

Configuration:
- **Alert threshold**: 130% (flags >30% regression)
- **`comment-on-alert`**: posts a commit comment on regression
- **`fail-on-alert`**: false (warns, doesn't block)
- **`auto-push`**: true (stores data to `gh-pages`)

## Test plan
- [ ] CI benchmark job runs successfully on push to `main`
- [ ] Benchmark data appears on `gh-pages` branch under `dev/bench/`
- [ ] Trend charts accessible via GitHub Pages URL
- [ ] Existing artifact upload still works

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)