### PR TITLE
Add PR-level benchmark comparison for pre-merge regression detection

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -1,0 +1,51 @@
+name: PR Benchmark Comparison
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - 'lib/**'
+      - 'build.zig'
+      - 'build.zig.zon'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@v1
+        with:
+          version: 0.16.0
+
+      - name: Build and benchmark PR branch
+        run: |
+          zig build
+          bash benchmarks/run-benchmarks.sh --json > pr-results.json
+
+      - name: Build and benchmark base branch
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          zig build
+          bash benchmarks/run-benchmarks.sh --json > base-results.json
+          git checkout ${{ github.event.pull_request.head.sha }}
+
+      - name: Compare and comment
+        uses: openpgpjs/github-action-pull-request-benchmark@v1
+        with:
+          tool: 'customSmallerIsBetter'
+          pr-benchmark-file-path: pr-results.json
+          base-benchmark-file-path: base-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '120%'
+          comment-always: true


### PR DESCRIPTION
## Summary
- Add a new `benchmark-pr.yml` workflow that benchmarks PR branches and compares against the base branch
- Posts a comparison table as a PR comment showing per-benchmark time deltas
- Path-filtered: only runs when `src/`, `benchmarks/`, `lib/`, or build files change
- Uses `pull_request` event (not `pull_request_target`) for fork safety — fork PRs cannot write to `gh-pages` or access secrets

## Configuration
- **Alert threshold**: 120% (flags >20% regression)
- **`comment-always`**: true (posts comparison table on every PR run, not just regressions)
- **Timeout**: 30 minutes (builds and benchmarks both PR and base branches)
- **Path filter**: `src/**`, `benchmarks/**`, `lib/**`, `build.zig`, `build.zig.zon`

## Test plan
- [ ] Workflow triggers on PRs that change source files
- [ ] Workflow does NOT trigger on documentation-only PRs
- [ ] Both PR and base branches are benchmarked and compared
- [ ] Comparison table posted as a PR comment

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)