### PR TITLE
Fix bare lambda internal define register clobbering

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -557,8 +557,11 @@ pub const Compiler = struct {
             if (rest == types.NIL) {
                 try child.compileFromNode(root, last_dst, true);
             } else {
+                const saved_next = child.next_register;
                 try child.compileFromNode(root, last_dst, false);
-                child.freeReg();
+                if (child.next_register == saved_next) {
+                    child.freeReg();
+                }
             }
             current = rest;
         }

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -569,6 +569,42 @@ test "IR analysis: emission uses tail annotation" {
     try std.testing.expectEqual(@as(i64, 6), types.toFixnum(result));
 }
 
+test "bare lambda with single internal define" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    const result = try vm.eval("(define b (lambda () (define q 7) (- q))) (b)");
+    try std.testing.expectEqual(@as(i64, -7), types.toFixnum(result));
+}
+
+test "bare lambda with internal define and complex expression" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    const result = try vm.eval("(define h (lambda () (define z 5) (+ (* z z) z))) (h)");
+    try std.testing.expectEqual(@as(i64, 30), types.toFixnum(result));
+}
+
+test "bare lambda with multiple internal defines" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    const result = try vm.eval("(define m (lambda () (define a 3) (define b 4) (+ a b))) (m)");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(result));
+}
+
+test "bare lambda internal define with lambda application" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    const result = try vm.eval("(define g (lambda () (define x 10) ((lambda (a) a) x))) (g)");
+    try std.testing.expectEqual(@as(i64, 10), types.toFixnum(result));
+}
+
 fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
     var reader = reader_mod.Reader.init(gc, source);
     defer reader.deinit();

--- a/tests/scheme/smoke/internal-define.scm
+++ b/tests/scheme/smoke/internal-define.scm
@@ -58,6 +58,32 @@
     (define (double x) (* x 2))
     (+ a (double a))))
 
+;; Regression tests for #601: bare lambda with internal defines
+;; (compileLambdaWithIR register clobbering)
+(test-equal "bare lambda with single internal define"
+  -7
+  (let ()
+    (define b (lambda () (define q 7) (- q)))
+    (b)))
+
+(test-equal "bare lambda with define and complex expression"
+  30
+  (let ()
+    (define h (lambda () (define z 5) (+ (* z z) z)))
+    (h)))
+
+(test-equal "bare lambda with multiple internal defines"
+  7
+  (let ()
+    (define m (lambda () (define a 3) (define b 4) (+ a b)))
+    (m)))
+
+(test-equal "bare lambda define with lambda application"
+  10
+  (let ()
+    (define g (lambda () (define x 10) ((lambda (a) a) x)))
+    (g)))
+
 (define %test-fail-count (test-runner-fail-count (test-runner-current)))
 (test-end "internal-define")
 (if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
## Summary

Fixes #601.

In `compileLambdaWithIR`, the body loop freed exactly one register after each non-final expression. When `compileDefineFromIR` allocated an extra register for a local variable, that local's slot was reused by the next expression, causing wrong values or runtime type errors (e.g. `expected number, got #<builtin ->`).

The fix tracks whether `compileFromNode` allocated extra registers (for local slots) and skips `freeReg` when it did, preserving the local's slot for subsequent expressions.

**Before:** `(define b (lambda () (define q 7) (- q)))` → runtime error
**After:** `(define b (lambda () (define q 7) (- q)))` → `-7` (correct)

## Test plan

- [x] 4 new Zig unit tests in `tests_ir.zig` covering bare lambda with single/multiple internal defines
- [x] 4 new Scheme regression tests in `tests/scheme/smoke/internal-define.scm`
- [x] All 1560 tests pass (unit + Scheme integration + R7RS suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)