### PR TITLE
Fix string->number "#e<large>" process abort

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -918,13 +918,10 @@ fn applyExactness(gc: *@import("memory.zig").GC, val: Value, exactness: Exactnes
             if (types.isFlonum(val)) {
                 const f = types.toFlonum(val);
                 if (std.math.isNan(f) or std.math.isInf(f)) return types.FALSE;
-                const trunc = @trunc(f);
-                if (f == trunc) {
-                    const n: i64 = @intFromFloat(trunc);
-                    return arith.makeFixnumChecked(n);
+                const trunc_val = @trunc(f);
+                if (f == trunc_val) {
+                    return try safeFloatToExactInt(trunc_val);
                 }
-                // Non-integer exact: convert to rational
-                // Use a simple approach: multiply by power of 10 to get integers
                 var num = f;
                 var den: f64 = 1.0;
                 var i: u32 = 0;
@@ -932,6 +929,11 @@ fn applyExactness(gc: *@import("memory.zig").GC, val: Value, exactness: Exactnes
                     if (num == @trunc(num)) break;
                     num *= 10.0;
                     den *= 10.0;
+                }
+                const min_i64: f64 = @floatFromInt(std.math.minInt(i64));
+                const max_i64_f: f64 = @floatFromInt(std.math.maxInt(i64));
+                if (num < min_i64 or num > max_i64_f or den < min_i64 or den > max_i64_f) {
+                    return try safeFloatToExactInt(f);
                 }
                 const n: i64 = @intFromFloat(num);
                 const d: i64 = @intFromFloat(den);

--- a/tests/scheme/smoke/string-to-number-prefix.scm
+++ b/tests/scheme/smoke/string-to-number-prefix.scm
@@ -36,6 +36,12 @@
 ;; Rational with non-decimal radix
 (test "a/b base 16" 10/11 (string->number "a/b" 16))
 
+;; Regression for #604: #e with large floats must not abort
+(test "#e1e20" 100000000000000000000 (string->number "#e1e20"))
+(test "#e9.5e18" 9500000000000000000 (string->number "#e9.5e18"))
+(test "#e1e19" 10000000000000000000 (string->number "#e1e19"))
+(test "#e1e20 = exact" #t (= (string->number "#e1e20") (exact 1e20)))
+
 ;; Existing functionality preserved
 (test "42" 42 (string->number "42"))
 (test "3.14" 3.14 (string->number "3.14"))


### PR DESCRIPTION
## Summary

Fixes #604.

`applyExactness` in `primitives_numeric.zig` used unchecked `@intFromFloat(trunc)` to `i64` for the exact integer path. When the float exceeded i64 range (e.g. `(string->number "#e1e20")`), this caused a process abort in ReleaseSafe.

The fix uses `safeFloatToExactInt` which handles bignum promotion for values outside i64 range. Also guards the non-integer rational conversion path against i64 overflow on the scaled numerator.

**Before:** `(string->number "#e1e20")` → process abort
**After:** `(string->number "#e1e20")` → `100000000000000000000` (correct bignum)

## Test plan

- [x] 4 new regression tests in `tests/scheme/smoke/string-to-number-prefix.scm`
- [x] All 1560 tests pass (unit + Scheme integration + R7RS suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)