### PR TITLE
Fix floor-quotient/truncate-quotient fixnum overflow

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1202,7 +1202,7 @@ fn floorQuotient(args: []const Value) PrimitiveError!Value {
     const a = types.toFixnum(args[0]);
     const b = types.toFixnum(args[1]);
     if (b == 0) return raiseDivByZero();
-    return types.makeFixnum(@divFloor(a, b));
+    return try arith.makeFixnumChecked(@divFloor(a, b));
 }
 
 fn floorRemainder(args: []const Value) PrimitiveError!Value {
@@ -1253,7 +1253,7 @@ fn truncateQuotient(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0]) or !types.isFixnum(args[1])) return primitives.typeError("truncate-quotient", "integer", if (!types.isFixnum(args[0])) args[0] else args[1]);
     const b = types.toFixnum(args[1]);
     if (b == 0) return raiseDivByZero();
-    return types.makeFixnum(@divTrunc(types.toFixnum(args[0]), b));
+    return try arith.makeFixnumChecked(@divTrunc(types.toFixnum(args[0]), b));
 }
 
 fn truncateRemainder(args: []const Value) PrimitiveError!Value {

--- a/tests/scheme/smoke/numeric-overflow.scm
+++ b/tests/scheme/smoke/numeric-overflow.scm
@@ -32,6 +32,12 @@
 (check "floor large flonum" (floor 2.5e15) 2.5e15)
 (check "round large flonum" (round 2.5e15) 2.5e15)
 
+;; Regression for #603: floor-quotient/truncate-quotient must promote to bignum
+(check "truncate-quotient minInt÷-1" (truncate-quotient -140737488355328 -1) 140737488355328)
+(check "floor-quotient minInt÷-1" (floor-quotient -140737488355328 -1) 140737488355328)
+(check "truncate-quotient minInt÷-1 positive" (positive? (truncate-quotient -140737488355328 -1)) #t)
+(check "floor-quotient minInt÷-1 positive" (positive? (floor-quotient -140737488355328 -1)) #t)
+
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "numeric overflow tests failed" fail))


### PR DESCRIPTION
## Summary

Fixes #603.

`floor-quotient` and `truncate-quotient` used `types.makeFixnum` for the quotient result, which silently truncates values outside i48 range. The only triggering case is `minInt(i48) ÷ -1 = 2^47`, which wrapped to the most-negative fixnum (sign flip).

Replaced with `arith.makeFixnumChecked` which promotes to bignum on overflow.

**Before:** `(truncate-quotient -140737488355328 -1)` → `-140737488355328` (wrong sign)
**After:** `(truncate-quotient -140737488355328 -1)` → `140737488355328` (correct)

## Test plan

- [x] 4 new regression tests in `tests/scheme/smoke/numeric-overflow.scm`
- [x] All 1560 tests pass (unit + Scheme integration + R7RS suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)