### PR TITLE
Fix constant folding ignoring redefined primitives

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -268,6 +268,7 @@ pub const Compiler = struct {
 
         // Lower AST to IR, run analysis and optimizations, then emit bytecode.
         var ir = ir_mod.IR.init(self.gc.allocator);
+        ir.globals = self.globals;
         defer ir.deinit();
         var root = try ir_mod.lowerWithMacros(&ir, expr_root, &self.macros);
 
@@ -543,6 +544,7 @@ pub const Compiler = struct {
 
             // Lower each body expression through IR
             var ir = ir_mod.IR.init(child.gc.allocator);
+            ir.globals = child.globals;
             defer ir.deinit();
             var root = try ir_mod.lowerWithMacros(&ir, expr, &child.macros);
             ir_mod.markTailPositions(root, rest == types.NIL);
@@ -601,6 +603,7 @@ pub const Compiler = struct {
     fn compileDefineFromIR(self: *Compiler, data: ir_mod.DefineData, dst: u16) CompileError!void {
         // Lower the value expression through IR for optimization
         var ir = ir_mod.IR.init(self.gc.allocator);
+        ir.globals = self.globals;
         defer ir.deinit();
         var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
         ir_mod.identifyPrimitives(val_root);
@@ -649,6 +652,7 @@ pub const Compiler = struct {
 
         // Lower the value expression through IR for optimization
         var ir = ir_mod.IR.init(self.gc.allocator);
+        ir.globals = self.globals;
         defer ir.deinit();
         var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
         ir_mod.identifyPrimitives(val_root);
@@ -793,6 +797,7 @@ pub const Compiler = struct {
         for (exprs, 0..) |expr, i| {
             // Lower each expression through the IR pipeline.
             var ir = ir_mod.IR.init(self.gc.allocator);
+            ir.globals = self.globals;
             defer ir.deinit();
             var root = try ir_mod.lowerWithMacros(&ir, expr, &self.macros);
             ir_mod.markTailPositions(root, false);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -136,12 +136,23 @@ pub const IfData = struct {
 pub const IR = struct {
     allocator: std.mem.Allocator,
     nodes: std.ArrayList(*Node),
+    globals: ?*const std.StringHashMap(Value) = null,
 
     pub fn init(allocator: std.mem.Allocator) IR {
         return .{
             .allocator = allocator,
             .nodes = .empty,
         };
+    }
+
+    fn isRedefined(self: *const IR, name: []const u8) bool {
+        const g = self.globals orelse return false;
+        const val = g.get(name) orelse return false;
+        if (!types.isPointer(val)) return true;
+        const obj = types.toObject(val);
+        if (obj.tag != .native_fn) return true;
+        const nfn = obj.as(types.NativeFn);
+        return !std.mem.eql(u8, nfn.name, name);
     }
 
     pub fn deinit(self: *IR) void {
@@ -557,6 +568,7 @@ fn tryFoldFromAST(ir: *IR, expr: Value) ?*Node {
     const operator = types.car(expr);
     if (!types.isSymbol(operator)) return null;
     const name = types.symbolName(operator);
+    if (ir.isRedefined(name)) return null;
 
     const args_pair = types.cdr(expr);
     if (!types.isPair(args_pair)) return null;
@@ -876,6 +888,7 @@ pub fn foldConstants(ir: *IR, node: *Node) *Node {
             const sym = call.operator.data.global_ref;
             if (!types.isSymbol(sym)) return node;
             const name = types.symbolName(sym);
+            if (ir.isRedefined(name)) return node;
 
             if (call.args.len == 1) {
                 const a = call.args[0];
@@ -1021,7 +1034,7 @@ pub fn simplifyBooleans(ir: *IR, node: *Node) *Node {
                 new_test.data.call.operator.tag == .global_ref)
             {
                 const sym = new_test.data.call.operator.data.global_ref;
-                if (types.isSymbol(sym) and std.mem.eql(u8, types.symbolName(sym), "not")) {
+                if (types.isSymbol(sym) and std.mem.eql(u8, types.symbolName(sym), "not") and !ir.isRedefined("not")) {
                     new_test = new_test.data.call.args[0];
                     return ir.makeIf(new_test, new_alt orelse (ir.makeConst(types.VOID) catch return node), new_cons) catch return node;
                 }

--- a/tests/scheme/smoke/global-redefine-fold.scm
+++ b/tests/scheme/smoke/global-redefine-fold.scm
@@ -1,0 +1,49 @@
+;; Regression test for #600: constant folding must not fold redefined primitives
+;; Uses manual pass/fail since SRFI-64 depends on standard + which we redefine.
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define failures 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      #t
+      (begin (set! failures (+ failures 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write actual) (newline))))
+
+;; Save originals before redefining
+(define orig+ +)
+(define orig- -)
+
+;; Top-level redefine + to -
+(define + -)
+(check "redefined + folds as -" -1 (+ 3 4))
+
+;; Restore and redefine *
+(define + orig+)
+(define * orig-)
+(check "redefined * folds as -" -1 (* 3 4))
+(define * (lambda (a b) (orig+ a b)))
+
+;; Redefine = to >
+(define = >)
+(check "redefined = folds as >" #f (= 1 2))
+(define = equal?)
+
+;; Redefine not
+(define not (lambda (x) 'shadowed))
+(check "redefined not" 'shadowed (not #f))
+
+;; simplifyBooleans: (if (not X) A B) must not rewrite when not is redefined
+(define not (lambda (x) x))
+(check "redefined not in if" 'then (if (not #t) 'then 'else))
+
+;; Redefine zero?
+(define zero? (lambda (x) 'custom))
+(check "redefined zero?" 'custom (zero? 0))
+
+(if (= failures 0)
+    (display "all passed")
+    (begin (display failures) (display " failures")))
+(newline)
+(if (> failures 0) (exit 1))


### PR DESCRIPTION
## Summary

Fixes #600.

The IR constant folding (`foldConstants`, `tryFoldFromAST`) and boolean simplification (`simplifyBooleans`) passes folded calls to `+`, `-`, `*`, `=`, `<`, `>`, `<=`, `>=`, `zero?`, `not` by symbol name without checking if the user had redefined those bindings.

Added a `globals` field to the `IR` struct with an `isRedefined` check that verifies the global binding is still the original `NativeFn`. All five IR construction sites in the compiler now thread the globals map through.

**Before:** `(define + -) (+ 3 4)` → `7` (folded at compile time, ignoring redefinition)
**After:** `(define + -) (+ 3 4)` → `-1` (correct, calls the redefined `-`)

## Test plan

- [x] 6 new regression tests in `tests/scheme/smoke/global-redefine-fold.scm`
- [x] All 1561 tests pass (unit + Scheme integration + R7RS suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)