### PR TITLE
Fix deepCopyValue record_instance missing cycle guard

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1218,12 +1218,13 @@ pub const GC = struct {
                 const rt_val = types.makePointer(@ptrCast(ri.record_type));
                 const new_rt_val = try self.deepCopyValue(rt_val, visited);
                 const new_rt = types.toObject(new_rt_val).as(types.RecordType);
-                const tmp_fields = try self.allocator.alloc(Value, ri.fields.len);
-                defer self.allocator.free(tmp_fields);
+                const new_val = try self.allocRecordInstance(new_rt, &.{});
+                try visited.put(src_ptr, new_val);
+                const new_ri = types.toObject(new_val).as(types.RecordInstance);
                 for (ri.fields, 0..) |f, i| {
-                    tmp_fields[i] = try self.deepCopyValue(f, visited);
+                    new_ri.fields[i] = try self.deepCopyValue(f, visited);
                 }
-                return try self.allocRecordInstance(new_rt, tmp_fields);
+                return new_val;
             },
             .multiple_values => {
                 const mv = obj.as(types.MultipleValues);

--- a/tests/scheme/smoke/record-cycle-deepcopy.scm
+++ b/tests/scheme/smoke/record-cycle-deepcopy.scm
@@ -1,0 +1,22 @@
+;; Regression test for #606: deepCopyValue record_instance cycle guard
+;; A cyclic record deep-copied across a thread boundary must not stack overflow.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18))
+
+(define-record-type node
+  (make-node val next)
+  node?
+  (val node-val)
+  (next node-next set-node-next!))
+
+;; Create a cyclic record
+(define n (make-node 42 #f))
+(set-node-next! n n)
+
+;; Deep-copy it via thread boundary
+(define t (make-thread (lambda () (node-val (node-next n)))))
+(thread-start! t)
+(define result (thread-join! t))
+
+(if (= result 42)
+    (begin (display "all passed") (newline))
+    (begin (display "FAIL: expected 42, got ") (display result) (newline) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #606.

The `.record_instance` arm in `deepCopyValue` was the only compound arm that never registered the new instance in the `visited` map. This caused:
1. **Infinite recursion → stack overflow** on cyclic records (e.g. a record whose field points to itself)
2. **Broken sharing/identity** on DAGs (same record reachable via multiple paths produces separate copies)

The fix allocates the new instance with empty fields first, registers it in `visited`, then deep-copies fields into the pre-allocated instance — matching the pattern used by `.pair`, `.vector`, `.closure`, and all other compound arms.

## Test plan

- [x] New regression test `tests/scheme/smoke/record-cycle-deepcopy.scm` (cyclic record via thread boundary)
- [x] All 1562 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)