### PR TITLE
Reject denormalized bignum in bytecode reader

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -432,6 +432,7 @@ fn readConstant(r: *Reader, gc: *GC, all_funcs: []*Function, depth: u32) !Value 
             for (0..len) |i| {
                 limbs[i] = try r.readU64();
             }
+            if (limbs[len - 1] == 0) return BytecodeError.CorruptedFile;
             return gc.allocBignumFromLimbs(limbs, len, positive) catch return BytecodeError.OutOfMemory;
         },
         TAG_RATIONAL => {


### PR DESCRIPTION
## Summary

Fixes #607.

`readConstant`'s `TAG_BIGNUM` branch accepted bignums with a zero most-significant limb, violating the normalization invariant that Kaappi's bignum routines (comparison, arithmetic) rely on. A corrupt `.sbc` file could produce a numerically-valid-looking bignum that silently returns wrong results from `=`, `<`, and arithmetic operations.

Added a check that the top limb is non-zero, rejecting such files as corrupted.

## Test plan

- [x] All 1563 tests pass (unit + Scheme integration + R7RS suite)
- [x] Normal bignum serialization/deserialization unaffected (top limb is always non-zero for valid bignums)

🤖 Generated with [Claude Code](https://claude.com/claude-code)