### PR TITLE
Fix bytecode symbol name length write/read mismatch

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -279,6 +279,7 @@ fn writeConstant(w: *Writer, allocator: std.mem.Allocator, val: Value, all_funcs
         switch (obj.tag) {
             .symbol => {
                 const sym = obj.as(types.Symbol);
+                if (sym.name.len > MAX_SYMBOL_BYTES) return BytecodeError.CorruptedFile;
                 try w.writeU8(allocator, TAG_SYMBOL);
                 try w.writeU16(allocator, @intCast(sym.name.len));
                 try w.writeBytes(allocator, sym.name);
@@ -607,6 +608,7 @@ fn writeFunctionsToBuffer(w: *Writer, allocator: std.mem.Allocator, top_level_fu
         try w.writeU8(allocator, if (func.is_variadic) @as(u8, 1) else @as(u8, 0));
 
         if (func.name) |name| {
+            if (name.len > MAX_SYMBOL_BYTES) return BytecodeError.CorruptedFile;
             try w.writeU16(allocator, @intCast(name.len));
             try w.writeBytes(allocator, name);
         } else {


### PR DESCRIPTION
## Summary

Fixes #609.

The bytecode writer used unchecked `@intCast(sym.name.len)` to `u16` for symbol and function name lengths:
1. **Panic** on names > 65535 bytes (ReleaseSafe `@intCast` overflow)
2. **Silent round-trip failure** for names 4097-65535 bytes (writer produces valid u16, reader rejects with `> MAX_SYMBOL_BYTES`)

Added `MAX_SYMBOL_BYTES` validation on the write side for both symbol constants and function names, matching the reader's limit. The bytecode file is now gracefully rejected instead of the process aborting.

## Test plan

- [x] All 1563 tests pass
- [x] Normal symbol serialization unaffected (names under 4096 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)