### PR TITLE
Fix macro import leaking entire def_env into importer

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -6,6 +6,7 @@ const library_mod = @import("library.zig");
 const bytecode_file = @import("bytecode_file.zig");
 const Value = types.Value;
 
+const passthrough = @import("compiler_passthrough.zig");
 const vm_mod = @import("vm.zig");
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
@@ -19,11 +20,22 @@ fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, v
         }
         const tx = types.toObject(val).as(types.Transformer);
         if (tx.def_env) |env| {
-            var it = env.iterator();
-            while (it.next()) |entry| {
-                if (!target.contains(entry.key_ptr.*)) {
-                    target.put(entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
-                    if (target == &vm.globals) vm.global_version +%= 1;
+            var pv_names: [64][]const u8 = undefined;
+            var pv_count: usize = 0;
+            for (tx.patterns[0..tx.num_rules]) |pat| {
+                if (!passthrough.collectSymbols(pat, &pv_names, &pv_count)) break;
+            }
+            var free_names: [64][]const u8 = undefined;
+            var free_count: usize = 0;
+            for (tx.templates[0..tx.num_rules]) |tmpl| {
+                if (!passthrough.collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &free_names, &free_count)) break;
+            }
+            for (free_names[0..free_count]) |fname| {
+                if (env.get(fname)) |fval| {
+                    if (!target.contains(fname)) {
+                        target.put(fname, fval) catch return error.OutOfMemory;
+                        if (target == &vm.globals) vm.global_version +%= 1;
+                    }
                 }
             }
         }

--- a/tests/scheme/smoke/macro-import-leak.scm
+++ b/tests/scheme/smoke/macro-import-leak.scm
@@ -1,0 +1,36 @@
+;; Regression test for #608: importing a macro must not leak the entire
+;; def_env — only template-referenced names should be injected.
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define-library (leak-test-lib)
+  (export the-macro)
+  (import (scheme base))
+  (begin
+    (define totally-unrelated 777)
+    (define used-helper 999)
+    (define-syntax the-macro
+      (syntax-rules ()
+        ((_ x) (+ x used-helper))))))
+
+(import (only (leak-test-lib) the-macro))
+
+(define failures 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      #t
+      (begin (set! failures (+ failures 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write actual) (newline))))
+
+;; The macro itself must still work (used-helper is a template free ref)
+(check "macro works" 1000 (the-macro 1))
+
+;; totally-unrelated must NOT leak (never referenced by any template)
+(check "unreferenced binding not leaked" #f
+       (guard (exn (#t #f))
+         (eval 'totally-unrelated (interaction-environment))))
+
+(if (= failures 0)
+    (begin (display "all passed") (newline))
+    (begin (display failures) (display " failures") (newline) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #608.

`importBinding` copied the macro's entire definition-site environment (`def_env`) into the importing namespace, leaking all private library bindings — even those never referenced by any template. This violated R7RS §5.5/§5.6 (unexported identifiers should not be visible) and bypassed import modifiers (`only`/`except`/`rename`/`prefix`).

The fix uses `collectFreeRefs`/`collectSymbols` to compute which names the templates actually reference, and only copies those from `def_env`. Unreferenced private helpers are no longer visible in the importer.

**Before:** `(import (only (lib) the-macro))` → `totally-unrelated` (never exported, never template-referenced) visible
**After:** `(import (only (lib) the-macro))` → `totally-unrelated` correctly undefined

Note: template-referenced helpers (like `used-helper` in the example) are still injected into the importer's globals since the macro expansion needs them to resolve. Full isolation of these would require hygienic scoping changes beyond the scope of this fix.

## Test plan

- [x] New regression test `tests/scheme/smoke/macro-import-leak.scm`
- [x] All 1564 tests pass (unit + Scheme integration + R7RS suite)
- [x] Import modifier tests (`import-modifier-macros.scm`, `import-composed.scm`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)