### PR TITLE
Fix isConstraintSpec panic on empty-after-trim version

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -266,6 +266,7 @@ fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constrain
 fn isConstraintSpec(ver: []const u8) bool {
     if (ver.len == 0) return false;
     const clean = std.mem.trim(u8, ver, "\"");
+    if (clean.len == 0) return false;
     return clean[0] == '>' or clean[0] == '<' or clean[0] == '^' or clean[0] == '~';
 }
 


### PR DESCRIPTION
## Summary

Fixes #613.

`isConstraintSpec` checked `ver.len == 0` but then trimmed quotes and indexed `clean[0]` without rechecking length. A version like `@""` produced an empty slice after trim, panicking on the out-of-bounds index in ReleaseSafe.

Added `clean.len == 0` check after trimming.

## Test plan

- [x] All 1564 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)