### PR TITLE
Fix toRationalParts calling toFixnum on bignum fields

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -62,10 +62,12 @@ fn anyRational(args: []const Value) bool {
 const RatParts = struct { num: i64, den: i64 };
 
 /// Extract numerator/denominator from any exact number.
-fn toRationalParts(v: Value) RatParts {
+/// Returns null when a rational has bignum fields that cannot fit in i64.
+fn toRationalParts(v: Value) ?RatParts {
     if (types.isFixnum(v)) return .{ .num = types.toFixnum(v), .den = 1 };
     if (types.isRationalObj(v)) {
         const r = types.toRational(v);
+        if (!types.isFixnum(r.numerator) or !types.isFixnum(r.denominator)) return null;
         return .{ .num = types.toFixnum(r.numerator), .den = types.toFixnum(r.denominator) };
     }
     return .{ .num = 0, .den = 1 };
@@ -315,7 +317,11 @@ fn add(args: []const Value) PrimitiveError!Value {
                 f += bignum_mod.toF64(a);
                 return makeFlonumVal(f);
             }
-            const parts = toRationalParts(a);
+            const parts = toRationalParts(a) orelse {
+                var f: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+                f += try toF64(a);
+                return makeFlonumVal(f);
+            };
             // n/d + parts.num/parts.den = (n*parts.den + parts.num*d) / (d*parts.den)
             const r1 = @mulWithOverflow(n, parts.den);
             const r2 = @mulWithOverflow(parts.num, d);
@@ -394,7 +400,14 @@ fn sub(args: []const Value) PrimitiveError!Value {
             }
             return makeFlonumVal(f);
         }
-        const first_parts = toRationalParts(args[0]);
+        const first_parts = toRationalParts(args[0]) orelse {
+            var f: f64 = toF64(args[0]) catch return PrimitiveError.TypeError;
+            if (args.len == 1) return makeFlonumVal(-f);
+            for (args[1..]) |a2| {
+                f -= toF64(a2) catch return PrimitiveError.TypeError;
+            }
+            return makeFlonumVal(f);
+        };
         var n = first_parts.num;
         var d = first_parts.den;
         if (args.len == 1) {
@@ -413,7 +426,11 @@ fn sub(args: []const Value) PrimitiveError!Value {
                 f -= bignum_mod.toF64(a);
                 return makeFlonumVal(f);
             }
-            const parts = toRationalParts(a);
+            const parts = toRationalParts(a) orelse {
+                var f: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+                f -= toF64(a) catch return PrimitiveError.TypeError;
+                return makeFlonumVal(f);
+            };
             // n/d - parts.num/parts.den = (n*parts.den - parts.num*d) / (d*parts.den)
             const r1 = @mulWithOverflow(n, parts.den);
             const r2 = @mulWithOverflow(parts.num, d);
@@ -503,7 +520,11 @@ fn mul(args: []const Value) PrimitiveError!Value {
                 f *= bignum_mod.toF64(a);
                 return makeFlonumVal(f);
             }
-            const parts = toRationalParts(a);
+            const parts = toRationalParts(a) orelse {
+                var f: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+                f *= toF64(a) catch return PrimitiveError.TypeError;
+                return makeFlonumVal(f);
+            };
             // n/d * parts.num/parts.den = (n*parts.num) / (d*parts.den)
             const r1 = @mulWithOverflow(n, parts.num);
             const r2 = @mulWithOverflow(d, parts.den);
@@ -596,7 +617,15 @@ fn divFn(args: []const Value) PrimitiveError!Value {
             }
             return makeFlonumVal(f);
         }
-        const first_parts = toRationalParts(args[0]);
+        const first_parts = toRationalParts(args[0]) orelse {
+            var f: f64 = toF64(args[0]) catch return PrimitiveError.TypeError;
+            for (args[1..]) |a2| {
+                const dv = toF64(a2) catch return PrimitiveError.TypeError;
+                if (dv == 0.0) return raiseDivByZero();
+                f /= dv;
+            }
+            return makeFlonumVal(f);
+        };
         var n = first_parts.num;
         var d = first_parts.den;
         for (args[1..]) |a| {
@@ -605,7 +634,13 @@ fn divFn(args: []const Value) PrimitiveError!Value {
                 f /= bignum_mod.toF64(a);
                 return makeFlonumVal(f);
             }
-            const parts = toRationalParts(a);
+            const parts = toRationalParts(a) orelse {
+                var f: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+                const dv = toF64(a) catch return PrimitiveError.TypeError;
+                if (dv == 0.0) return raiseDivByZero();
+                f /= dv;
+                return makeFlonumVal(f);
+            };
             if (parts.num == 0) return raiseDivByZero();
             // (n/d) / (parts.num/parts.den) = (n*parts.den) / (d*parts.num)
             const r1 = @mulWithOverflow(n, parts.den);
@@ -760,16 +795,16 @@ fn cmpPair(a: Value, b: Value) PrimitiveError!i8 {
         if (types.isRationalObj(a) or types.isRationalObj(b)) {
             const pa = toRationalParts(a);
             const pb = toRationalParts(b);
-            // Compare a_num/a_den vs b_num/b_den
-            // a_num * b_den vs b_num * a_den (both denominators positive)
-            const r1 = @mulWithOverflow(pa.num, pb.den);
-            const r2 = @mulWithOverflow(pb.num, pa.den);
-            if (r1[1] == 0 and r2[1] == 0) {
-                if (r1[0] < r2[0]) return -1;
-                if (r1[0] > r2[0]) return 1;
-                return 0;
+            if (pa != null and pb != null) {
+                const r1 = @mulWithOverflow(pa.?.num, pb.?.den);
+                const r2 = @mulWithOverflow(pb.?.num, pa.?.den);
+                if (r1[1] == 0 and r2[1] == 0) {
+                    if (r1[0] < r2[0]) return -1;
+                    if (r1[0] > r2[0]) return 1;
+                    return 0;
+                }
             }
-            // Overflow: fall back to float
+            // Overflow or bignum fields: fall back to float
         }
     }
     // Exact bignum vs inexact flonum: check if bignum is exactly representable

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -401,10 +401,10 @@ fn sub(args: []const Value) PrimitiveError!Value {
             return makeFlonumVal(f);
         }
         const first_parts = toRationalParts(args[0]) orelse {
-            var f: f64 = toF64(args[0]) catch return PrimitiveError.TypeError;
+            var f: f64 = toF64(args[0]) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
             if (args.len == 1) return makeFlonumVal(-f);
             for (args[1..]) |a2| {
-                f -= toF64(a2) catch return PrimitiveError.TypeError;
+                f -= toF64(a2) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
             }
             return makeFlonumVal(f);
         };
@@ -428,7 +428,7 @@ fn sub(args: []const Value) PrimitiveError!Value {
             }
             const parts = toRationalParts(a) orelse {
                 var f: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
-                f -= toF64(a) catch return PrimitiveError.TypeError;
+                f -= toF64(a) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
                 return makeFlonumVal(f);
             };
             // n/d - parts.num/parts.den = (n*parts.den - parts.num*d) / (d*parts.den)
@@ -522,7 +522,7 @@ fn mul(args: []const Value) PrimitiveError!Value {
             }
             const parts = toRationalParts(a) orelse {
                 var f: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
-                f *= toF64(a) catch return PrimitiveError.TypeError;
+                f *= toF64(a) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
                 return makeFlonumVal(f);
             };
             // n/d * parts.num/parts.den = (n*parts.num) / (d*parts.den)
@@ -618,9 +618,9 @@ fn divFn(args: []const Value) PrimitiveError!Value {
             return makeFlonumVal(f);
         }
         const first_parts = toRationalParts(args[0]) orelse {
-            var f: f64 = toF64(args[0]) catch return PrimitiveError.TypeError;
+            var f: f64 = toF64(args[0]) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
             for (args[1..]) |a2| {
-                const dv = toF64(a2) catch return PrimitiveError.TypeError;
+                const dv = toF64(a2) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
                 if (dv == 0.0) return raiseDivByZero();
                 f /= dv;
             }
@@ -636,7 +636,7 @@ fn divFn(args: []const Value) PrimitiveError!Value {
             }
             const parts = toRationalParts(a) orelse {
                 var f: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
-                const dv = toF64(a) catch return PrimitiveError.TypeError;
+                const dv = toF64(a) catch return PrimitiveError.TypeError; // bare-ok: bignum fallback
                 if (dv == 0.0) return raiseDivByZero();
                 f /= dv;
                 return makeFlonumVal(f);

--- a/tests/scheme/smoke/numeric-overflow.scm
+++ b/tests/scheme/smoke/numeric-overflow.scm
@@ -38,6 +38,13 @@
 (check "truncate-quotient minInt÷-1 positive" (positive? (truncate-quotient -140737488355328 -1)) #t)
 (check "floor-quotient minInt÷-1 positive" (positive? (floor-quotient -140737488355328 -1)) #t)
 
+;; Regression for #611: rationals with bignum fields must not produce garbage
+(check "add bignum-field rational" #t (number? (+ (exact 0.1) 0)))
+(check "mul bignum-field rational" #t (number? (* (exact 0.1) 1)))
+(check "negate bignum-field rational" #t (negative? (- (exact 0.1))))
+(check "compare bignum-field rational" #t (< (exact 0.1) 1))
+(check "equality bignum-field rational" #t (= (exact 0.1) (exact 0.1)))
+
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "numeric overflow tests failed" fail))


### PR DESCRIPTION
## Summary

Fixes #611.

`toRationalParts` called `types.toFixnum` on rational numerator/denominator without checking if they were bignums. Since bignums are heap objects, `toFixnum` truncated the pointer payload to i48, producing garbage `i64` values. This caused silent data corruption in all arithmetic (`+`, `-`, `*`, `/`) and comparison (`<`, `>`, `=`, `<=`, `>=`) operations on rationals like `(exact 0.1)` whose reduced fields exceed i48 range.

The fix makes `toRationalParts` return `null` when either field is a bignum, and all 8 call sites now fall back to float arithmetic (matching the existing bignum argument fallback pattern).

**Before:** `(+ (exact 0.1) 0)` → `273420427/273420213` (garbage)
**After:** `(+ (exact 0.1) 0)` → `0.1` (correct float fallback)

## Test plan

- [x] 5 new regression tests in `tests/scheme/smoke/numeric-overflow.scm`
- [x] All 1564 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)