### PR TITLE
Fix makeRationalFromReader using unchecked makeFixnum

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -216,8 +216,10 @@ pub fn makeRationalFromReader(gc: *@import("memory.zig").GC, num: i64, den: i64)
     const g = gcdTwo(abs_n, d);
     n = @divExact(n, g);
     d = @divExact(d, g);
-    if (d == 1) return types.makeFixnum(n);
-    return gc.allocRational(types.makeFixnum(n), types.makeFixnum(d));
+    if (d == 1) return try makeFixnumChecked(n);
+    const num_val = try makeFixnumChecked(n);
+    const den_val = try makeFixnumChecked(d);
+    return gc.allocRational(num_val, den_val);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/scheme/smoke/numeric-overflow.scm
+++ b/tests/scheme/smoke/numeric-overflow.scm
@@ -38,6 +38,11 @@
 (check "truncate-quotient minInt÷-1 positive" (positive? (truncate-quotient -140737488355328 -1)) #t)
 (check "floor-quotient minInt÷-1 positive" (positive? (floor-quotient -140737488355328 -1)) #t)
 
+;; Regression for #610: rational literals with large num/den must not truncate
+(check "rational literal large num" 200000000000000/3 200000000000000/3)
+(check "rational literal large den" 1/140737488355328 1/140737488355328)
+(check "rational large den positive" #t (positive? (denominator 1/140737488355328)))
+
 ;; Regression for #611: rationals with bignum fields must not produce garbage
 (check "add bignum-field rational" #t (number? (+ (exact 0.1) 0)))
 (check "mul bignum-field rational" #t (number? (* (exact 0.1) 1)))


### PR DESCRIPTION
## Summary

Fixes #610.

`makeRationalFromReader` used unchecked `types.makeFixnum` for numerator and denominator, silently truncating values outside i48 range. Rational literals like `200000000000000/3` would parse to a completely wrong value.

Replaced with `makeFixnumChecked` which auto-promotes to bignum when the value exceeds i48 range.

**Before:** `200000000000000/3` → `-81474976710656/3` (wrong, truncated)
**After:** `200000000000000/3` → `200000000000000/3` (correct)

## Test plan

- [x] 3 new regression tests in `tests/scheme/smoke/numeric-overflow.scm`
- [x] All 1564 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)