### PR TITLE
Fix exact division with bignums returning flonum instead of rational

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -603,6 +603,11 @@ fn divFn(args: []const Value) PrimitiveError!Value {
             const r = types.toRational(args[0]);
             return makeRationalReduced(gc, r.denominator, r.numerator);
         }
+        if (types.isBignum(args[0])) {
+            if (bignum_mod.isZero(args[0])) return raiseDivByZero();
+            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            return makeRationalReduced(gc, types.makeFixnum(1), args[0]);
+        }
         const a = try toF64Ext(args[0]);
         if (a == 0 and isExactZero(args[0])) return raiseDivByZero();
         return makeFlonumVal(1.0 / a);
@@ -706,15 +711,21 @@ fn divFn(args: []const Value) PrimitiveError!Value {
         if (d == 1) return makeFixnumChecked(n);
         return gc.allocRational(try makeFixnumChecked(n), try makeFixnumChecked(d)) catch return PrimitiveError.OutOfMemory;
     }
-    // Exact integer division with bignums: try quotient to preserve exactness
-    if (anyBignum(args) and !anyFlonum(args) and !anyRational(args) and args.len == 2) {
+    // Exact integer division with bignums: produce exact rational
+    if (anyBignum(args) and !anyFlonum(args) and !anyRational(args)) {
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
-        if (bignum_mod.isZero(args[1])) return raiseDivByZero();
-        const rem = bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
-        if (bignum_mod.isZero(rem)) {
-            const q = bignum_mod.quotient(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
-            return bignum_mod.demote(q);
+        var num_val = args[0];
+        for (args[1..]) |a| {
+            if (bignum_mod.isZero(a)) return raiseDivByZero();
+            const rem = bignum_mod.remainder(gc, num_val, a) catch return PrimitiveError.OutOfMemory;
+            if (bignum_mod.isZero(rem)) {
+                num_val = bignum_mod.quotient(gc, num_val, a) catch return PrimitiveError.OutOfMemory;
+                num_val = bignum_mod.demote(num_val);
+            } else {
+                return makeRationalReduced(gc, num_val, a);
+            }
         }
+        return num_val;
     }
     // At least one flonum or bignum — convert to float
     var result = try toF64Ext(args[0]);

--- a/tests/scheme/smoke/numeric-overflow.scm
+++ b/tests/scheme/smoke/numeric-overflow.scm
@@ -43,6 +43,12 @@
 (check "rational literal large den" 1/140737488355328 1/140737488355328)
 (check "rational large den positive" #t (positive? (denominator 1/140737488355328)))
 
+;; Regression for #612: exact division with bignums must produce exact rationals
+(check "/ bignum reciprocal exact" #t (exact? (/ 140737488355329)))
+(check "/ bignum rational" #t (exact? (/ 1 140737488355329)))
+(check "/ bignum non-even division" #t (exact? (/ 100000000000000000000000000 3)))
+(check "/ bignum even division" 2 (/ 6 3))
+
 ;; Regression for #611: rationals with bignum fields must not produce garbage
 (check "add bignum-field rational" #t (number? (+ (exact 0.1) 0)))
 (check "mul bignum-field rational" #t (number? (* (exact 0.1) 1)))


### PR DESCRIPTION
## Summary

Fixes #612.

Two paths in `divFn` silently degraded exact results to flonum when bignums were involved:

1. **Single-arg reciprocal** `(/ bignum)` fell through to the float path instead of producing `1/bignum`
2. **Multi-arg bignum division** only handled exact-divide (`remainder == 0`); non-even division fell through to float

Added bignum case to single-arg reciprocal using `makeRationalReduced`, and extended multi-arg bignum path to produce exact rationals.

**Before:** `(/ 1 140737488355329)` → `7.105427357600951e-15` (inexact)
**After:** `(/ 1 140737488355329)` → `1/140737488355329` (exact)

## Test plan

- [x] 4 new regression tests in `tests/scheme/smoke/numeric-overflow.scm`
- [x] All 1564 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)