### PR TITLE
Fix emitDirectCall skipping arity validation in native backend (#636)

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -8,6 +8,7 @@ const Value = types.Value;
 const NativeLambda = struct {
     llvm_name: []const u8,
     arity: u8,
+    is_variadic: bool,
 };
 
 pub const LLVMEmitter = struct {
@@ -213,14 +214,24 @@ pub const LLVMEmitter = struct {
                 if (self.current_fn_name) |fn_name| {
                     if (self.body_label) |body_lbl| {
                         if (std.mem.eql(u8, op_name, fn_name)) {
-                            return self.emitSelfTailCall(call.args, body_lbl);
+                            if (self.native_fns.get(fn_name)) |self_fn| {
+                                if (call.args.len == self_fn.arity) {
+                                    return self.emitSelfTailCall(call.args, body_lbl);
+                                }
+                            }
                         }
                     }
                 }
             }
 
             if (self.native_fns.get(op_name)) |native| {
-                return self.emitDirectCall(native.llvm_name, call.args, is_tail);
+                const arity_ok = if (native.is_variadic)
+                    call.args.len >= native.arity
+                else
+                    call.args.len == native.arity;
+                if (arity_ok) {
+                    return self.emitDirectCall(native.llvm_name, call.args, is_tail);
+                }
             }
             if (call.args.len == 2) {
                 if (self.tryEmitInlineBinary(op_name, call.args)) |result| return result;
@@ -709,9 +720,7 @@ pub const LLVMEmitter = struct {
                         const fn_name = types.symbolName(types.car(target));
                         const formals = types.cdr(target);
                         const body = types.cdr(rest);
-                        if (self.tryCompileDefineFunction(fn_name, formals, body)) |native_fn_name| {
-                            self.native_fns.put(fn_name, .{ .llvm_name = native_fn_name, .arity = 0 }) catch {};
-                        }
+                        _ = self.tryCompileDefineFunction(fn_name, formals, body);
                     }
                 }
             }
@@ -728,9 +737,7 @@ pub const LLVMEmitter = struct {
             const head = types.car(data.value);
             if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "lambda")) {
                 const lambda_data = ir.LambdaData{ .args = types.cdr(data.value), .name = name };
-                if (self.tryCompileLambdaNative(lambda_data)) |fn_name| {
-                    self.native_fns.put(name, .{ .llvm_name = fn_name, .arity = 0 }) catch {};
-                }
+                _ = self.tryCompileLambdaNative(lambda_data);
             }
         }
 

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -392,7 +392,7 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     const fn_name = std.fmt.allocPrint(self.allocator, "@lambda_{d}", .{id}) catch return null;
 
     if (name) |n| {
-        self.native_fns.put(n, .{ .llvm_name = fn_name, .arity = @intCast(param_names.len) }) catch {};
+        self.native_fns.put(n, .{ .llvm_name = fn_name, .arity = @intCast(param_names.len), .is_variadic = rest_name != null }) catch {};
     }
 
     var fn_buf: std.ArrayList(u8) = .empty;

--- a/tests/scheme/smoke/llvm-arity-check.scm
+++ b/tests/scheme/smoke/llvm-arity-check.scm
@@ -1,0 +1,41 @@
+;;; Regression test for issue #636: emitDirectCall must validate arity
+;;; Native-compiled direct calls should raise arity errors, not silently
+;;; compute wrong results or read out-of-bounds stack memory.
+
+(import (scheme base) (scheme write))
+
+(define (add2 a b) (+ a b))
+
+;; Correct arity — should work
+(let ((r (add2 10 20)))
+  (unless (= r 30)
+    (display "FAIL: add2 correct arity")
+    (newline)
+    (exit 1)))
+
+;; Over-application — should raise error
+(guard (exn
+  (#t
+   (unless (string-contains (error-object-message exn) "expected 2 arguments")
+     (display "FAIL: over-application error message")
+     (newline)
+     (exit 1))))
+  (add2 1 2 3)
+  (display "FAIL: over-application did not error")
+  (newline)
+  (exit 1))
+
+;; Under-application — should raise error
+(guard (exn
+  (#t
+   (unless (string-contains (error-object-message exn) "expected 2 arguments")
+     (display "FAIL: under-application error message")
+     (newline)
+     (exit 1))))
+  (add2 1)
+  (display "FAIL: under-application did not error")
+  (newline)
+  (exit 1))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- Add arity validation to `emitCallNode` before using the `emitDirectCall` and `emitSelfTailCall` fast paths in the LLVM native backend
- Fixed-arity functions require exact argument count match; variadic functions require at least the fixed parameter count
- Mismatched calls fall through to `kaappi_call_scheme` which raises proper arity errors
- Remove two redundant `native_fns.put` calls that overwrote correct arity with 0

Fixes #636

## Test plan
- [x] New regression test `tests/scheme/smoke/llvm-arity-check.scm` passes both interpreted and native
- [x] Unit tests pass (`zig build test`)
- [x] All 1565 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)