### PR TITLE
Fix markVMRoots iterating shared libraries map in child threads (#634)

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -94,14 +94,15 @@ fn markVMRoots(gc: *memory.GC) void {
     var pit = vm.param_overrides.valueIterator();
     while (pit.next()) |v| gc.markValue(v.*);
 
-    // Mark library export values and per-library environments
-    var lit = vm.libraries.libraries.valueIterator();
-    while (lit.next()) |lib| {
-        var eit = lib.exports.valueIterator();
-        while (eit.next()) |v| gc.markValue(v.*);
-        if (lib.lib_env) |env| {
-            var eit2 = env.valueIterator();
-            while (eit2.next()) |v| gc.markValue(v.*);
+    if (vm.owns_globals) {
+        var lit = vm.libraries.libraries.valueIterator();
+        while (lit.next()) |lib| {
+            var eit = lib.exports.valueIterator();
+            while (eit.next()) |v| gc.markValue(v.*);
+            if (lib.lib_env) |env| {
+                var eit2 = env.valueIterator();
+                while (eit2.next()) |v| gc.markValue(v.*);
+            }
         }
     }
 

--- a/tests/scheme/smoke/thread-library-gc.scm
+++ b/tests/scheme/smoke/thread-library-gc.scm
@@ -1,0 +1,24 @@
+;;; Regression test for issue #634: markVMRoots must not iterate shared
+;;; vm.libraries map in child threads (data race with parent's import).
+;;; The fix gates library marking on owns_globals, matching globals/macros.
+
+(import (scheme base) (scheme write) (srfi 18))
+
+(define (allocator)
+  (lambda ()
+    (let loop ((i 0) (acc '()))
+      (if (< i 50000)
+          (loop (+ i 1) (cons i acc))
+          (length acc)))))
+
+(define t1 (thread-start! (make-thread (allocator))))
+
+(define result (thread-join! t1))
+(unless (= result 50000)
+  (display "FAIL: expected 50000, got ")
+  (display result)
+  (newline)
+  (exit 1))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- Gate `vm.libraries.libraries` marking on `owns_globals` in `markVMRoots`, matching the existing treatment of `globals`/`macros`
- Child threads spawned via `thread-start!` share the parent's library registry by reference; iterating it during child GC without synchronization is a data race

Fixes #634

## Test plan
- [x] New regression test `tests/scheme/smoke/thread-library-gc.scm` exercises child thread GC with shared libraries
- [x] Unit tests pass (`zig build test`)
- [x] All 1566 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)