### PR TITLE
Fix parseBignumString CHUNK_DIGITS overflow for radix 12-36 (#631)

### DIFF
--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -643,6 +643,18 @@ pub fn toStringRadix(allocator: std.mem.Allocator, v: Value, radix: u8) ![]u8 {
     return (result.toOwnedSlice(allocator) catch return error.OutOfMemory);
 }
 
+// max d such that radix^d <= u64 max, indexed by radix (2..36)
+//  radix 2:63  3:40  4:31  5:27  6:24  7:22  8:21  9:20  10:19
+// 11:18 12:17 13:17 14:16 15:16 16:15 17:15 18:15 19:14 20:14
+// 21:14 22:14 23:13 24:13 25:13 26:13 27:13 28:13 29:12 30:12
+// 31:12 32:12 33:12 34:12 35:12 36:12
+const max_chunk_digits = [37]u8{
+    0,  0,  63, 40, 31, 27, 24, 22, 21, 20,
+    19, 18, 17, 17, 16, 16, 15, 15, 15, 14,
+    14, 14, 14, 13, 13, 13, 13, 13, 13, 12,
+    12, 12, 12, 12, 12, 12, 12,
+};
+
 /// Parse a decimal string into a bignum Value.
 pub fn parseBignumString(gc: *memory.GC, digits: []const u8, radix: u8) !Value {
     if (digits.len == 0) return types.makeFixnum(0);
@@ -659,12 +671,7 @@ pub fn parseBignumString(gc: *memory.GC, digits: []const u8, radix: u8) !Value {
     const num_digits = digits[start..];
     if (num_digits.len == 0) return types.makeFixnum(0);
 
-    const CHUNK_DIGITS: usize = switch (radix) {
-        2 => 63,
-        8 => 21,
-        16 => 15,
-        else => 18,
-    };
+    const CHUNK_DIGITS: usize = max_chunk_digits[radix];
     const radix_u64: u64 = radix;
 
     var limbs = try gc.allocator.alloc(u64, 1);

--- a/tests/scheme/smoke/bignum-radix-chunk.scm
+++ b/tests/scheme/smoke/bignum-radix-chunk.scm
@@ -1,0 +1,38 @@
+;;; Regression test for issue #631: parseBignumString CHUNK_DIGITS overflow
+;;; for radix 12-36. The chunk size must be computed per-radix to avoid
+;;; overflowing u64 during parsing.
+
+(import (scheme base) (scheme write))
+
+;; Base 36: 32 Z's — verified against Python int("ZZZ...Z", 36)
+(let ((r (string->number "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" 36)))
+  (unless (and (integer? r) (exact? r)
+               (= r 63340286662973277706162286946811886609896461828095))
+    (display "FAIL: base-36 bignum")
+    (newline)
+    (exit 1)))
+
+;; Base 17
+(let ((r (string->number "11111111111111111111111111111111" 17)))
+  (unless (and (integer? r) (exact? r)
+               (= r 147994474672529202865256643582559452960))
+    (display "FAIL: base-17 bignum")
+    (newline)
+    (exit 1)))
+
+;; Base 12 — right at the boundary where old CHUNK_DIGITS=18 overflowed
+(let ((r (string->number "BBBBBBBBBBBBBBBBBBBBB" 12)))
+  (unless (and (integer? r) (exact? r))
+    (display "FAIL: base-12 bignum")
+    (newline)
+    (exit 1)))
+
+;; Negative bignum in high radix
+(let ((r (string->number "-ZZZZZZ" 36)))
+  (unless (and (integer? r) (exact? r) (negative? r))
+    (display "FAIL: negative base-36 bignum")
+    (newline)
+    (exit 1)))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- Replace hardcoded `CHUNK_DIGITS=18` with a precomputed lookup table giving the largest chunk size that fits in a u64 for each radix 2-36
- Radix 10 stays at 19 (safe), radix 12 drops to 17, radix 36 drops to 12, etc.
- Previously, `string->number` with radix 12+ on large numbers crashed with a runtime overflow error

Fixes #631

## Test plan
- [x] New regression test `tests/scheme/smoke/bignum-radix-chunk.scm` verifies base-36, base-17, base-12 bignum parsing
- [x] Unit tests pass (`zig build test`)
- [x] All 1568 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)