### PR TITLE
Fix toCString silently truncating strings with embedded NUL bytes (#630)

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -43,6 +43,7 @@ fn toCString(v: Value, buf: *[4096]u8) ?[*:0]const u8 {
     if (!types.isString(v)) return null;
     const str = types.toObject(v).as(types.SchemeString);
     if (str.len >= buf.len) return null;
+    if (std.mem.indexOfScalar(u8, str.data[0..str.len], 0) != null) return null;
     @memcpy(buf[0..str.len], str.data[0..str.len]);
     buf[str.len] = 0;
     return @ptrCast(buf[0..str.len :0]);

--- a/tests/scheme/smoke/ffi-nul-string.scm
+++ b/tests/scheme/smoke/ffi-nul-string.scm
@@ -1,0 +1,35 @@
+;;; Regression test for issue #630: toCString must reject strings with
+;;; embedded NUL bytes instead of silently truncating them.
+
+(import (scheme base) (scheme write))
+
+(define libc (ffi-open #f))
+(define c-strlen (ffi-fn libc "strlen" '(string) 'long))
+
+;; String with embedded NUL should raise error
+(guard (exn
+  (#t
+   (unless (error-object? exn)
+     (display "FAIL: expected error object")
+     (newline)
+     (exit 1))))
+  (c-strlen (string #\a #\b #\c #\null #\d #\e #\f))
+  (display "FAIL: should have raised error for embedded NUL")
+  (newline)
+  (exit 1))
+
+;; Normal strings should still work
+(unless (= (c-strlen "hello") 5)
+  (display "FAIL: strlen of normal string")
+  (newline)
+  (exit 1))
+
+;; Empty string should work
+(unless (= (c-strlen "") 0)
+  (display "FAIL: strlen of empty string")
+  (newline)
+  (exit 1))
+
+(ffi-close libc)
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- Add interior NUL byte scan in `toCString` before copying to the C string buffer
- Strings with embedded NUL now raise TypeError instead of silently truncating at the first NUL

Fixes #630

## Test plan
- [x] New regression test `tests/scheme/smoke/ffi-nul-string.scm` verifies NUL rejection and normal string passthrough
- [x] Unit tests pass (`zig build test`)
- [x] All 1569 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)