### PR TITLE
Fix Complex number printing dropping -0.0 components (#637)

### DIFF
--- a/src/printer.zig
+++ b/src/printer.zig
@@ -568,10 +568,10 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
             .complex => {
                 const c = obj.as(types.Complex);
                 var buf: [64]u8 = undefined;
-                if (c.imag == 0.0) {
+                if (c.imag == 0.0 and !std.math.signbit(c.imag)) {
                     try writer.writeAll(formatFlonum(&buf, c.real));
                 } else {
-                    const has_real = c.real != 0.0;
+                    const has_real = c.real != 0.0 or std.math.signbit(c.real);
                     if (has_real) try writer.writeAll(formatComplexPart(&buf, c.real, c.exact_real));
                     const im = c.imag;
                     if (std.math.isNan(im)) {
@@ -579,7 +579,7 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                     } else if (std.math.isInf(im)) {
                         try writer.writeAll(if (im > 0) "+inf.0i" else "-inf.0i");
                     } else {
-                        try writer.writeByte(if (im < 0) '-' else '+');
+                        try writer.writeByte(if (im < 0 or std.math.signbit(im)) '-' else '+');
                         const mag = @abs(im);
                         if (mag != 1.0 or has_real) try writer.writeAll(formatComplexPart(&buf, mag, c.exact_imag));
                         try writer.writeByte('i');

--- a/tests/scheme/smoke/complex-neg-zero.scm
+++ b/tests/scheme/smoke/complex-neg-zero.scm
@@ -1,0 +1,43 @@
+;;; Regression test for issue #637: Complex number printing must not drop
+;;; real/imaginary part when it equals negative zero.
+
+(import (scheme base) (scheme write) (scheme inexact))
+
+;; 1.0-0.0i: imaginary part is -0.0, must not be dropped
+(let* ((x (read (open-input-string "1.0-0.0i")))
+       (s (let ((p (open-output-string)))
+            (write x p)
+            (get-output-string p))))
+  (unless (string=? s "1.0-0.0i")
+    (display "FAIL: expected 1.0-0.0i, got ") (display s) (newline)
+    (exit 1)))
+
+;; -0.0+2.0i: real part is -0.0, must not be dropped
+(let* ((y (read (open-input-string "-0.0+2.0i")))
+       (s (let ((p (open-output-string)))
+            (write y p)
+            (get-output-string p))))
+  (unless (string=? s "-0.0+2.0i")
+    (display "FAIL: expected -0.0+2.0i, got ") (display s) (newline)
+    (exit 1)))
+
+;; Normal complex should still work
+(let* ((z (read (open-input-string "3.0+4.0i")))
+       (s (let ((p (open-output-string)))
+            (write z p)
+            (get-output-string p))))
+  (unless (string=? s "3.0+4.0i")
+    (display "FAIL: expected 3.0+4.0i, got ") (display s) (newline)
+    (exit 1)))
+
+;; Positive zero imaginary should collapse to real
+(let* ((w (read (open-input-string "5.0+0.0i")))
+       (s (let ((p (open-output-string)))
+            (write w p)
+            (get-output-string p))))
+  (unless (string=? s "5.0")
+    (display "FAIL: expected 5.0, got ") (display s) (newline)
+    (exit 1)))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- Use `std.math.signbit` alongside `== 0.0` / `!= 0.0` checks in the Complex printer to correctly handle -0.0
- Imaginary part -0.0 is no longer silently dropped (was printing as bare real)
- Real part -0.0 is no longer omitted (was printing as just imaginary with sign)
- Sign byte now correctly emits `-` for -0.0 imaginary part

Fixes #637

## Test plan
- [x] New regression test `tests/scheme/smoke/complex-neg-zero.scm` verifies -0.0 round-tripping
- [x] Unit tests pass (`zig build test`)
- [x] All 1570 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)