### PR TITLE
Fix highlightCallback misparses character literals (#633)

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -173,6 +173,27 @@ fn highlightCallback(buf: [*c]const u8, len: usize, out_len: [*c]usize) callconv
             continue;
         }
 
+        if (ch == '#' and i + 1 < input.len and input[i + 1] == '\\') {
+            result.appendSlice(allocator, ANSI_NUMBER) catch return null;
+            result.append(allocator, '#') catch return null;
+            result.append(allocator, '\\') catch return null;
+            i += 2;
+            if (i < input.len) {
+                const first = input[i];
+                if ((first >= 'a' and first <= 'z') or (first >= 'A' and first <= 'Z')) {
+                    while (i < input.len and ((input[i] >= 'a' and input[i] <= 'z') or (input[i] >= 'A' and input[i] <= 'Z'))) {
+                        result.append(allocator, input[i]) catch return null;
+                        i += 1;
+                    }
+                } else {
+                    result.append(allocator, first) catch return null;
+                    i += 1;
+                }
+            }
+            result.appendSlice(allocator, ANSI_RESET) catch return null;
+            continue;
+        }
+
         if (ch == '#' and i + 1 < input.len and (input[i + 1] == 't' or input[i + 1] == 'f')) {
             const is_bool = (i + 2 >= input.len or isDelimiter(input[i + 2]));
             if (is_bool) {


### PR DESCRIPTION
## Summary
- Add `#\` character literal handling to `highlightCallback` in `repl.zig`
- `#\;` no longer triggers the line-comment branch (was painting rest of line as comment)
- `#\(` / `#\)` no longer triggers the paren branch (was producing extra paren-colored spans)
- Named characters like `#\space` are consumed as a single token
- Mirrors the existing handling in `parenDepth` (lines 318-331)

Fixes #633

## Test plan
- [x] Unit tests pass (`zig build test`)
- [x] All 1570 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)