### PR TITLE
Fix create-temp-file raising uninformative bare TypeError (#632)

### DIFF
--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -994,7 +994,7 @@ fn createTempFileFn(args: []const Value) PrimitiveError!Value {
 
     // Build template: prefix + XXXXXX + null
     var template_buf: [256]u8 = undefined;
-    if (prefix.len + 7 > template_buf.len) return PrimitiveError.TypeError;
+    if (prefix.len + 7 > template_buf.len) return raiseFileError(gc, "temp file prefix too long", args[0]);
     @memcpy(template_buf[0..prefix.len], prefix);
     @memcpy(template_buf[prefix.len..][0..6], "XXXXXX");
     template_buf[prefix.len + 6] = 0;

--- a/tests/scheme/smoke/create-temp-file-error.scm
+++ b/tests/scheme/smoke/create-temp-file-error.scm
@@ -1,0 +1,32 @@
+;;; Regression test for issue #632: create-temp-file must give a descriptive
+;;; error message when the prefix is too long, not a bare TypeError.
+
+(import (scheme base) (scheme write) (srfi 170))
+
+;; Over-long prefix should give descriptive error with irritants
+(guard (exn
+  (#t
+   (unless (string-contains (error-object-message exn) "prefix too long")
+     (display "FAIL: expected 'prefix too long' in message, got: ")
+     (display (error-object-message exn))
+     (newline)
+     (exit 1))
+   (when (null? (error-object-irritants exn))
+     (display "FAIL: expected non-empty irritants")
+     (newline)
+     (exit 1))))
+  (create-temp-file (make-string 250 #\a))
+  (display "FAIL: should have raised error")
+  (newline)
+  (exit 1))
+
+;; Normal prefix should work
+(let ((path (create-temp-file "/tmp/kaappi-test-")))
+  (unless (string? path)
+    (display "FAIL: expected string path")
+    (newline)
+    (exit 1))
+  (delete-file path))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- Replace bare `PrimitiveError.TypeError` with `raiseFileError("temp file prefix too long", args[0])` for over-long prefix
- Error now has descriptive message and the prefix string as irritant, consistent with other error paths in `primitives_filesystem.zig`

Fixes #632

## Test plan
- [x] New regression test `tests/scheme/smoke/create-temp-file-error.scm` verifies error message and irritants
- [x] Unit tests pass (`zig build test`)
- [x] All 1571 Scheme tests pass (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)