### PR TITLE
Fix tail call passing pointer to caller's stack alloca (#639)

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -250,9 +250,9 @@ pub const LLVMEmitter = struct {
         }
 
         const result = try self.freshTemp();
-        const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
 
         if (nargs == 0) {
+            const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
             try self.print("  {s} = {s} i64 @kaappi_call_scheme(ptr %vm, i64 {s}, ptr null, i64 0)\n", .{ result, call_prefix, callee });
         } else {
             const args_alloca = try self.freshTemp();
@@ -264,7 +264,7 @@ pub const LLVMEmitter = struct {
                 try self.print("  store i64 {s}, ptr {s}\n", .{ arg_tmps[i], gep });
             }
 
-            try self.print("  {s} = {s} i64 @kaappi_call_scheme(ptr %vm, i64 {s}, ptr {s}, i64 {d})\n", .{ result, call_prefix, callee, args_alloca, nargs });
+            try self.print("  {s} = call i64 @kaappi_call_scheme(ptr %vm, i64 {s}, ptr {s}, i64 {d})\n", .{ result, callee, args_alloca, nargs });
         }
 
         if (is_tail) {
@@ -819,9 +819,9 @@ pub const LLVMEmitter = struct {
         }
 
         const result = try self.freshTemp();
-        const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
 
         if (nargs == 0) {
+            const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
             try self.print("  {s} = {s} i64 {s}(ptr %vm, ptr null, i64 0, ptr null)\n", .{ result, call_prefix, fn_name });
         } else {
             const args_alloca = try self.freshTemp();
@@ -833,7 +833,7 @@ pub const LLVMEmitter = struct {
                 try self.print("  store i64 {s}, ptr {s}\n", .{ arg_tmps[i], gep });
             }
 
-            try self.print("  {s} = {s} i64 {s}(ptr %vm, ptr {s}, i64 {d}, ptr null)\n", .{ result, call_prefix, fn_name, args_alloca, nargs });
+            try self.print("  {s} = call i64 {s}(ptr %vm, ptr {s}, i64 {d}, ptr null)\n", .{ result, fn_name, args_alloca, nargs });
         }
 
         if (is_tail) {

--- a/tests/scheme/smoke/llvm-tail-call-args.scm
+++ b/tests/scheme/smoke/llvm-tail-call-args.scm
@@ -1,0 +1,16 @@
+;; Regression test for issue #639: tail call with args passing pointer
+;; to caller's stack alloca, corrupting arguments in native backend.
+;;
+;; Must produce the same output when run via interpreter and native backend.
+
+(define (add3 a b c) (+ a b c))
+(display (= (add3 10 20 30) 60))
+(newline)
+
+(define (sum5 a b c d e) (+ a b c d e))
+(display (= (sum5 1 2 3 4 5) 15))
+(newline)
+
+(define (forward a b c) (add3 a b c))
+(display (= (forward 100 200 300) 600))
+(newline)


### PR DESCRIPTION
## Summary
- Fix LLVM native backend emitting `tail call` with a pointer to the caller's own stack `alloca`, which is UB and corrupts arguments
- Only use `tail call` for zero-argument calls (no alloca needed); calls with args use regular `call` + `ret`
- Affects both `emitCallNode` (indirect calls via `kaappi_call_scheme`) and `emitDirectCall` (direct calls to other native functions)

Closes #639

## Test plan
- [x] Added regression test `tests/scheme/smoke/llvm-tail-call-args.scm` verifying 3+ arg calls
- [x] Verified native binary produces `60` / `15` / `600` (was garbage before fix)
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1572 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)