### PR TITLE
Fix read-bytevector allocating full k-byte buffer upfront (#638)

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -953,16 +953,17 @@ fn readBytevectorFn(args: []const Value) PrimitiveError!Value {
     const count: usize = @intCast(@as(u64, @bitCast(k)));
     const port = try getInputPort(args, 1, "read-bytevector");
 
-    var result = gc.allocator.alloc(u8, count) catch return PrimitiveError.OutOfMemory;
-    defer gc.allocator.free(result);
+    var result: std.ArrayList(u8) = .empty;
+    defer result.deinit(gc.allocator);
+
     var bytes_read: usize = 0;
     while (bytes_read < count) {
         const byte = readOneByte(port) orelse break;
-        result[bytes_read] = byte;
+        result.append(gc.allocator, byte) catch return PrimitiveError.OutOfMemory;
         bytes_read += 1;
     }
-    if (bytes_read == 0) return types.EOF;
-    return gc.allocBytevector(result[0..bytes_read]) catch return PrimitiveError.OutOfMemory;
+    if (result.items.len == 0) return types.EOF;
+    return gc.allocBytevector(result.items) catch return PrimitiveError.OutOfMemory;
 }
 
 fn writeBytevectorFn(args: []const Value) PrimitiveError!Value {

--- a/tests/scheme/smoke/read-bytevector-large-k.scm
+++ b/tests/scheme/smoke/read-bytevector-large-k.scm
@@ -1,0 +1,39 @@
+;;; Regression test for #638: read-bytevector allocates full k-byte buffer
+;;; upfront, hanging on huge k even under --sandbox.
+;;; With the fix, read-bytevector grows incrementally and returns promptly.
+
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name expected actual)
+  (if (equal? expected actual)
+    (set! pass (+ pass 1))
+    (begin
+      (set! fail (+ fail 1))
+      (display "FAIL: ") (display name) (newline)
+      (display "  expected: ") (display expected) (newline)
+      (display "  actual:   ") (display actual) (newline))))
+
+;; A huge k on a small port should return only available bytes, not hang
+(check "large k reads only available bytes"
+  #u8(97 98 99)
+  (let ((p (open-input-bytevector #u8(97 98 99))))
+    (read-bytevector 999999999 p)))
+
+;; EOF on empty port
+(check "large k on empty port returns eof"
+  #t
+  (eof-object?
+    (let ((p (open-input-bytevector #u8())))
+      (read-bytevector 999999999 p))))
+
+;; Normal small reads still work
+(check "small read works"
+  #u8(104 101)
+  (let ((p (open-input-bytevector #u8(104 101 108 108 111))))
+    (read-bytevector 2 p)))
+
+(display pass) (display " pass, ") (display fail) (display " fail") (newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary
- Switch `read-bytevector` from upfront allocation of `k` bytes to incremental `ArrayList` growth
- Matches the existing `read-string` pattern — only buffers actually-read bytes
- Prevents DoS via huge `k` values, including under `--sandbox`

Closes #638

## Test plan
- [x] Added `tests/scheme/smoke/read-bytevector-large-k.scm` — verifies large k returns promptly with only available bytes
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1573 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)