### PR TITLE
Fix string-for-each/string-map byte cursor desync on mutation (#645)

### DIFF
--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -561,19 +561,13 @@ fn stringForEachFn(args: []const Value) PrimitiveError!Value {
         if (cp_len < min_cp_len) min_cp_len = cp_len;
     }
 
-    // Track byte offsets for each string
-    var byte_offsets: [256]usize = undefined;
-    for (0..str_count) |si| {
-        byte_offsets[si] = 0;
-    }
-
     var call_args: [256]Value = undefined;
-    for (0..min_cp_len) |_| {
+    for (0..min_cp_len) |cp_idx| {
         for (0..str_count) |si| {
             const data = try getStringSlice(args[1 + si]);
-            const cp = utf8DecodeAt(data, byte_offsets[si]) orelse return primitives.typeError("string-for-each", "valid UTF-8 string", args[1 + si]);
+            const byte_off = utf8IndexToByteOffset(data, cp_idx) orelse return primitives.typeError("string-for-each", "valid UTF-8 string", args[1 + si]);
+            const cp = utf8DecodeAt(data, byte_off) orelse return primitives.typeError("string-for-each", "valid UTF-8 string", args[1 + si]);
             call_args[si] = types.makeChar(cp);
-            byte_offsets[si] += utf8ByteLenAt(data, byte_offsets[si]);
         }
         _ = vm.callWithArgs(proc, call_args[0..str_count]) catch |err| {
             return switch (err) {
@@ -609,23 +603,17 @@ fn stringMapFn(args: []const Value) PrimitiveError!Value {
         if (cp_len < min_cp_len) min_cp_len = cp_len;
     }
 
-    // Track byte offsets for each string
-    var byte_offsets: [256]usize = undefined;
-    for (0..str_count) |si| {
-        byte_offsets[si] = 0;
-    }
-
     // Collect result chars
     var result_buf: std.ArrayList(u8) = .empty;
     defer result_buf.deinit(gc.allocator);
 
     var call_args: [256]Value = undefined;
-    for (0..min_cp_len) |_| {
+    for (0..min_cp_len) |cp_idx| {
         for (0..str_count) |si| {
             const data = try getStringSlice(args[1 + si]);
-            const cp = utf8DecodeAt(data, byte_offsets[si]) orelse return primitives.typeError("string-map", "valid UTF-8 string", args[1 + si]);
+            const byte_off = utf8IndexToByteOffset(data, cp_idx) orelse return primitives.typeError("string-map", "valid UTF-8 string", args[1 + si]);
+            const cp = utf8DecodeAt(data, byte_off) orelse return primitives.typeError("string-map", "valid UTF-8 string", args[1 + si]);
             call_args[si] = types.makeChar(cp);
-            byte_offsets[si] += utf8ByteLenAt(data, byte_offsets[si]);
         }
         const result = vm.callWithArgs(proc, call_args[0..str_count]) catch |err| {
             return switch (err) {

--- a/tests/scheme/smoke/string-foreach-mutation.scm
+++ b/tests/scheme/smoke/string-foreach-mutation.scm
@@ -1,0 +1,59 @@
+;;; Regression test for #645: string-for-each/string-map desync byte cursor
+;;; when callback mutates an iterated string, silently skipping characters.
+
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name expected actual)
+  (if (equal? expected actual)
+    (set! pass (+ pass 1))
+    (begin
+      (set! fail (+ fail 1))
+      (display "FAIL: ") (display name) (newline)
+      (display "  expected: ") (display expected) (newline)
+      (display "  actual:   ") (display actual) (newline))))
+
+;; Shrink mutation: multi-byte to ASCII behind the cursor
+(define s1 (string-copy "中bcde"))
+(define chars1 '())
+(string-for-each
+  (lambda (c)
+    (set! chars1 (cons c chars1))
+    (when (char=? c #\b)
+      (string-set! s1 0 #\x)))
+  s1)
+(check "string-for-each sees all 5 codepoints"
+  5
+  (length chars1))
+
+;; string-map with mutation behind cursor
+(define s2 (string-copy "中bcd"))
+(define mapped
+  (string-map
+    (lambda (c)
+      (when (char=? c #\b)
+        (string-set! s2 0 #\x))
+      (char-upcase c))
+    s2))
+(check "string-map produces correct length"
+  4
+  (string-length mapped))
+
+;; No mutation: normal case still works
+(define chars3 '())
+(string-for-each
+  (lambda (c) (set! chars3 (cons c chars3)))
+  "hello")
+(check "string-for-each normal case"
+  '(#\o #\l #\l #\e #\h)
+  chars3)
+
+;; string-map normal case
+(check "string-map normal case"
+  "HELLO"
+  (string-map char-upcase "hello"))
+
+(display pass) (display " pass, ") (display fail) (display " fail") (newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary
- Replace raw byte offset tracking with codepoint index tracking in `string-for-each` and `string-map`
- Recompute byte offset from codepoint index each iteration, correctly handling buffer layout changes from `string-set!` mutations
- Fixes silent character skipping and spurious "invalid UTF-8" errors when callback mutates iterated strings

Closes #645

## Test plan
- [x] Added `tests/scheme/smoke/string-foreach-mutation.scm` with shrink-mutation and normal-case tests
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1574 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)