### PR TITLE
Fix SRFI-13 parseStartEnd and string-take/-drop silently clamping out-of-range indices (#640)

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -151,7 +151,7 @@ fn parseStartEnd(data: []const u8, args: []const Value, start_arg_idx: usize) Pr
         const sv = types.toFixnum(args[start_arg_idx]);
         if (sv < 0) return PrimitiveError.TypeError; // bare-ok: generic helper, no proc name
         const start_cp: usize = @intCast(sv);
-        byte_start = pstr.utf8IndexToByteOffset(data, start_cp) orelse data.len;
+        byte_start = pstr.utf8IndexToByteOffset(data, start_cp) orelse return PrimitiveError.IndexOutOfBounds;
         cp_offset = start_cp;
     }
     if (args.len > start_arg_idx + 1) {
@@ -159,7 +159,7 @@ fn parseStartEnd(data: []const u8, args: []const Value, start_arg_idx: usize) Pr
         const ev = types.toFixnum(args[start_arg_idx + 1]);
         if (ev < 0) return PrimitiveError.TypeError; // bare-ok: generic helper, no proc name
         const end_cp: usize = @intCast(ev);
-        byte_end = pstr.utf8IndexToByteOffset(data, end_cp) orelse data.len;
+        byte_end = pstr.utf8IndexToByteOffset(data, end_cp) orelse return PrimitiveError.IndexOutOfBounds;
     }
     if (byte_start > byte_end) return PrimitiveError.TypeError;
     return .{ .data = data[byte_start..byte_end], .byte_start = byte_start, .byte_end = byte_end, .cp_offset = cp_offset };
@@ -439,7 +439,7 @@ fn stringTakeFn(args: []const Value) PrimitiveError!Value {
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-take", "non-negative integer", args[1]);
     const n: usize = @intCast(nv);
-    const byte_end = pstr.utf8IndexToByteOffset(data, n) orelse data.len;
+    const byte_end = pstr.utf8IndexToByteOffset(data, n) orelse return PrimitiveError.IndexOutOfBounds;
     return gc.allocString(data[0..byte_end]) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -450,7 +450,7 @@ fn stringDropFn(args: []const Value) PrimitiveError!Value {
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-drop", "non-negative integer", args[1]);
     const n: usize = @intCast(nv);
-    const byte_start = pstr.utf8IndexToByteOffset(data, n) orelse data.len;
+    const byte_start = pstr.utf8IndexToByteOffset(data, n) orelse return PrimitiveError.IndexOutOfBounds;
     return gc.allocString(data[byte_start..]) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -462,8 +462,9 @@ fn stringTakeRightFn(args: []const Value) PrimitiveError!Value {
     if (nv < 0) return primitives.typeError("string-take-right", "non-negative integer", args[1]);
     const n: usize = @intCast(nv);
     const total_cp = utf8CodepointCount(data);
-    if (n >= total_cp) return gc.allocString(data) catch return PrimitiveError.OutOfMemory;
-    const byte_start = pstr.utf8IndexToByteOffset(data, total_cp - n) orelse data.len;
+    if (n > total_cp) return PrimitiveError.IndexOutOfBounds;
+    if (n == total_cp) return gc.allocString(data) catch return PrimitiveError.OutOfMemory;
+    const byte_start = pstr.utf8IndexToByteOffset(data, total_cp - n) orelse return PrimitiveError.IndexOutOfBounds;
     return gc.allocString(data[byte_start..]) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -475,8 +476,9 @@ fn stringDropRightFn(args: []const Value) PrimitiveError!Value {
     if (nv < 0) return primitives.typeError("string-drop-right", "non-negative integer", args[1]);
     const n: usize = @intCast(nv);
     const total_cp = utf8CodepointCount(data);
-    if (n >= total_cp) return gc.allocString("") catch return PrimitiveError.OutOfMemory;
-    const byte_end = pstr.utf8IndexToByteOffset(data, total_cp - n) orelse data.len;
+    if (n > total_cp) return PrimitiveError.IndexOutOfBounds;
+    if (n == total_cp) return gc.allocString("") catch return PrimitiveError.OutOfMemory;
+    const byte_end = pstr.utf8IndexToByteOffset(data, total_cp - n) orelse return PrimitiveError.IndexOutOfBounds;
     return gc.allocString(data[0..byte_end]) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -495,7 +497,7 @@ fn stringPadFn(args: []const Value) PrimitiveError!Value {
     const data = range.data;
     const current_len = utf8CodepointCount(data);
     if (current_len >= target_len) {
-        const byte_start = pstr.utf8IndexToByteOffset(data, current_len - target_len) orelse data.len;
+        const byte_start = pstr.utf8IndexToByteOffset(data, current_len - target_len) orelse return PrimitiveError.IndexOutOfBounds;
         return gc.allocString(data[byte_start..]) catch return PrimitiveError.OutOfMemory;
     }
     const pad_count = target_len - current_len;
@@ -523,7 +525,7 @@ fn stringPadRightFn(args: []const Value) PrimitiveError!Value {
     const data = range.data;
     const current_len = utf8CodepointCount(data);
     if (current_len >= target_len) {
-        const byte_end = pstr.utf8IndexToByteOffset(data, target_len) orelse data.len;
+        const byte_end = pstr.utf8IndexToByteOffset(data, target_len) orelse return PrimitiveError.IndexOutOfBounds;
         return gc.allocString(data[0..byte_end]) catch return PrimitiveError.OutOfMemory;
     }
     const pad_count = target_len - current_len;

--- a/tests/scheme/smoke/string-ext-bounds.scm
+++ b/tests/scheme/smoke/string-ext-bounds.scm
@@ -1,0 +1,46 @@
+;;; Regression test for #640: SRFI-13 parseStartEnd and string-take/-drop
+;;; silently clamp out-of-range start/end instead of erroring.
+
+(import (scheme base) (scheme write) (srfi 13))
+
+(define pass 0)
+(define fail 0)
+
+(define (check-error name thunk)
+  (guard (exn
+    (#t (set! pass (+ pass 1))))
+    (thunk)
+    (set! fail (+ fail 1))
+    (display "FAIL: ") (display name)
+    (display " — no error raised") (newline)))
+
+(define (check name expected actual)
+  (if (equal? expected actual)
+    (set! pass (+ pass 1))
+    (begin
+      (set! fail (+ fail 1))
+      (display "FAIL: ") (display name) (newline)
+      (display "  expected: ") (display expected) (newline)
+      (display "  actual:   ") (display actual) (newline))))
+
+;; Out-of-range must error
+(check-error "string-take out of range" (lambda () (string-take "abc" 100)))
+(check-error "string-drop out of range" (lambda () (string-drop "abc" 100)))
+(check-error "string-take-right out of range" (lambda () (string-take-right "abc" 100)))
+(check-error "string-drop-right out of range" (lambda () (string-drop-right "abc" 100)))
+(check-error "string-contains start out of range" (lambda () (string-contains "abc" "x" 100)))
+(check-error "string-index start out of range" (lambda () (string-index "abc" char-alphabetic? 100)))
+
+;; Valid boundary cases still work
+(check "string-take at length" "abc" (string-take "abc" 3))
+(check "string-take 0" "" (string-take "abc" 0))
+(check "string-drop at length" "" (string-drop "abc" 3))
+(check "string-drop 0" "abc" (string-drop "abc" 0))
+(check "string-take-right at length" "abc" (string-take-right "abc" 3))
+(check "string-drop-right at length" "" (string-drop-right "abc" 3))
+
+;; substring errors (pre-existing correct behavior, verify it's preserved)
+(check-error "substring out of range" (lambda () (substring "abc" 10 12)))
+
+(display pass) (display " pass, ") (display fail) (display " fail") (newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary
- Replace `orelse data.len` with `orelse return PrimitiveError.IndexOutOfBounds` in `parseStartEnd`, `string-take`, `string-drop`, `string-take-right`, `string-drop-right`, `string-pad`, and `string-pad-right`
- Out-of-range indices now raise errors, matching `substring`/`string-copy`/`string-ref` behavior and SRFI-13 preconditions
- Boundary cases (index == string-length) still work correctly

Closes #640

## Test plan
- [x] Added `tests/scheme/smoke/string-ext-bounds.scm` with 6 error cases + 6 boundary cases + 1 existing behavior check
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1575 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)