### PR TITLE
Fix zig build bench failing and call_cc/call_ec showing 0 (#666)

### DIFF
--- a/benchmarks/run-benchmarks.sh
+++ b/benchmarks/run-benchmarks.sh
@@ -71,12 +71,19 @@ run_bench() {
 run_callcc_bench() {
     local output
     output=$($TIMEOUT_CMD zig build bench 2>&1 || true)
-    # Extract timing from bench output
-    local callcc_time callec_time
-    callcc_time=$(echo "$output" | grep "call/cc" | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "0")
-    callec_time=$(echo "$output" | grep "call/ec" | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "0")
-    echo "call_cc ${callcc_time:-0} ok 0 0 1 0 0 0"
-    echo "call_ec ${callec_time:-0} ok 0 0 1 0 0 0"
+
+    local cc_line ec_line
+    cc_line=$(echo "$output" | grep "^name: call_cc," || true)
+    ec_line=$(echo "$output" | grep "^name: call_ec," || true)
+
+    local cc_time cc_status ec_time ec_status
+    cc_time=$(extract_field "$cc_line" "time")
+    cc_status=$(extract_field "$cc_line" "status")
+    ec_time=$(extract_field "$ec_line" "time")
+    ec_status=$(extract_field "$ec_line" "status")
+
+    echo "call_cc ${cc_time:-0} ${cc_status:-fail} 0 0 1 0 0 0"
+    echo "call_ec ${ec_time:-0} ${ec_status:-fail} 0 0 1 0 0 0"
 }
 
 # Collect results

--- a/build.zig
+++ b/build.zig
@@ -229,6 +229,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
+    bench_mod.addImport("build_options", options.createModule());
     const bench_exe = b.addExecutable(.{
         .name = "bench",
         .root_module = bench_mod,

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -77,12 +77,23 @@ pub fn main() !void {
     std.debug.print("capture benchmark: {d} immediately-escaping captures, GC off\n", .{iters});
     std.debug.print("{s:>6} | {s:>22} | {s:>22} | {s:>8}\n", .{ "depth", "call/cc (full)", "call/ec (escape)", "speedup" });
     std.debug.print("-------+------------------------+------------------------+---------\n", .{});
+    var cc_d0: Result = undefined;
+    var ec_d0: Result = undefined;
     for (depths) |d| {
         const cc = try measure(allocator, "call/cc", d, iters);
         const ec = try measure(allocator, "call/ec", d, iters);
+        if (d == 0) {
+            cc_d0 = cc;
+            ec_d0 = ec;
+        }
         std.debug.print(
             "{d:>6} | {d:>9.0} ns  {d:>4} MB | {d:>9.0} ns  {d:>4} MB | {d:>6.1}x\n",
             .{ d, cc.ns_per, cc.heap_mb, ec.ns_per, ec.heap_mb, cc.ns_per / ec.ns_per },
         );
     }
+
+    const cc_secs = cc_d0.ns_per * @as(f64, @floatFromInt(iters)) / 1e9;
+    const ec_secs = ec_d0.ns_per * @as(f64, @floatFromInt(iters)) / 1e9;
+    std.debug.print("name: call_cc, time: {d:.6}, status: ok, min: {d:.6}, max: {d:.6}, iterations: {d}\n", .{ cc_secs, cc_secs, cc_secs, iters });
+    std.debug.print("name: call_ec, time: {d:.6}, status: ok, min: {d:.6}, max: {d:.6}, iterations: {d}\n", .{ ec_secs, ec_secs, ec_secs, iters });
 }


### PR DESCRIPTION
## Summary

- Add missing `build_options` import to the bench module in `build.zig` — the only build target that was missing it, causing `zig build bench` to fail
- Add machine-readable summary lines to `bench.zig` output (depth=0 results in `common.scm` format) so the benchmark runner can parse them
- Rewrite `run_callcc_bench` in `run-benchmarks.sh` to use `extract_field` instead of broken grep patterns that matched the header line

## Test plan

- [x] `zig build bench` compiles and runs successfully
- [x] `bash benchmarks/run-benchmarks.sh` shows real times for call_cc (~0.27s) and call_ec (~0.015s)
- [x] `bash benchmarks/run-benchmarks.sh --json` produces non-zero values in JSON
- [x] `zig build test` passes

Fixes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)