### PR TITLE
Fix referencesYoung .fiber case missing handler_stack, wind_stack, param_overrides, and frame.native (#646)

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -188,6 +188,9 @@ fn referencesYoung(obj: *Object) bool {
                 if (f.closure) |cls| {
                     if (isYoungPointer(types.makePointer(@ptrCast(cls)))) return true;
                 }
+                if (f.native) |nf| {
+                    if (isYoungPointer(types.makePointer(@ptrCast(nf)))) return true;
+                }
                 const window: usize = if (f.closure) |cls| blk: {
                     const lc = cls.func.locals_count;
                     break :blk if (lc == 0) 256 else @as(usize, lc);
@@ -197,6 +200,16 @@ fn referencesYoung(obj: *Object) bool {
                 while (r < end) : (r += 1) {
                     if (isYoungPointer(fiber.registers[r])) return true;
                 }
+            }
+            for (fiber.handler_stack[0..fiber.handler_count]) |h| {
+                if (isYoungPointer(h.handler)) return true;
+            }
+            for (fiber.wind_stack[0..fiber.wind_count]) |wr| {
+                if (isYoungPointer(wr.before) or isYoungPointer(wr.after)) return true;
+            }
+            var pit = fiber.param_overrides.valueIterator();
+            while (pit.next()) |v| {
+                if (isYoungPointer(v.*)) return true;
             }
         },
         .channel => {

--- a/tests/scheme/smoke/fiber-gc-remembered-set.scm
+++ b/tests/scheme/smoke/fiber-gc-remembered-set.scm
@@ -1,0 +1,74 @@
+;; Regression test for #646: referencesYoung .fiber case omits
+;; handler_stack, wind_stack, param_overrides, and frame.native.
+;;
+;; Exercises fibers with closures and allocation across yield to stress
+;; the GC remembered-set pruning path.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (kaappi fibers))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name expected actual)
+  (display name)
+  (display ": ")
+  (if (equal? expected actual)
+    (begin (set! pass (+ pass 1)) (display "ok"))
+    (begin
+      (set! fail (+ fail 1))
+      (display "FAIL - expected ")
+      (write expected)
+      (display " got ")
+      (write actual)))
+  (newline))
+
+;; Test 1: Fiber closures survive GC across multiple yields
+;; The closure captures a freshly-allocated list, yields, allocates more,
+;; then yields again. If the remembered set incorrectly prunes the fiber,
+;; the captured list may be collected.
+(let ((f (spawn (lambda ()
+                  (let ((data (list 1 2 3 4 5)))
+                    (yield)
+                    (let ((more (list 6 7 8 9 10)))
+                      (yield)
+                      (append data more)))))))
+  (check "closure data survives yield+GC"
+         '(1 2 3 4 5 6 7 8 9 10)
+         (fiber-join f)))
+
+;; Test 2: Multiple fibers with captured closures and allocation pressure
+(let ((ch (make-channel)))
+  (let ((f1 (spawn (lambda ()
+                     (let ((v (make-vector 100 0)))
+                       (yield)
+                       (vector-set! v 0 42)
+                       (channel-send ch (vector-ref v 0))))))
+        (f2 (spawn (lambda ()
+                     (let ((s (make-string 50 #\x)))
+                       (yield)
+                       (channel-send ch (string-length s)))))))
+    (let ((r1 (channel-receive ch))
+          (r2 (channel-receive ch)))
+      (fiber-join f1)
+      (fiber-join f2)
+      (check "fiber vector survives GC" 42 r1)
+      (check "fiber string survives GC" 50 r2))))
+
+;; Test 3: Deeply nested closures in fiber survive remembered-set pruning
+(let ((f (spawn (lambda ()
+                  (let* ((a (list 'a))
+                         (b (cons 'b a))
+                         (c (cons 'c b)))
+                    (yield)
+                    (let* ((d (cons 'd c))
+                           (e (cons 'e d)))
+                      (yield)
+                      e))))))
+  (check "nested cons chain survives yield+GC"
+         '(e d c b a)
+         (fiber-join f)))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary
- Add missing field checks to `referencesYoung`'s `.fiber` case in `gc_collect.zig` to match `markFiberState`'s field coverage: `handler_stack`, `wind_stack`, `param_overrides`, and `frames[].native`
- Without this fix, `pruneRememberedSet` could evict fibers from the remembered set while they still hold young references through these unchecked fields

## Test plan
- [x] Added `tests/scheme/smoke/fiber-gc-remembered-set.scm` — fiber closures, vectors, and strings survive GC across yield
- [x] All 1576 tests pass (182 Scheme files + 1394 R7RS suite)
- [x] Zig unit tests pass

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)