### PR TITLE
Fix reader truncating peculiar identifiers like ->foo to just the sign

### DIFF
--- a/src/reader.zig
+++ b/src/reader.zig
@@ -320,7 +320,7 @@ pub const Reader = struct {
                 return self.foldAndReturnSymbol(self.source[start..self.pos]);
             }
             // +i, -i, peculiar identifiers with sign subsequent
-            if (isSpecialSubsequent(self.source[self.pos]) or std.ascii.isAlphabetic(self.source[self.pos])) {
+            if (isInitial(self.source[self.pos]) or isSpecialSubsequent(self.source[self.pos])) {
                 while (self.pos < self.source.len and isSubsequent(self.source[self.pos])) {
                     self.pos += 1;
                 }

--- a/tests/scheme/smoke/reader-peculiar-idents.scm
+++ b/tests/scheme/smoke/reader-peculiar-idents.scm
@@ -1,0 +1,51 @@
+;; Regression test for #647: peculiar identifiers like ->foo
+;; truncated to just the sign character.
+
+;; Arrow-style identifiers (most common real-world case)
+(define ->string (lambda (x) x))
+(display (eq? '->string '->string))
+(display " ")
+
+;; Peculiar identifiers with various special-initial chars after sign
+(display (symbol->string (read (open-input-string "->foo"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-<tag>"))))
+(display " ")
+(display (symbol->string (read (open-input-string "+>="))))
+(display " ")
+(display (symbol->string (read (open-input-string "-!default"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-$var"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-%pct"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-&ref"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-*glob"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-/path"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-:key"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-=eq"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-?pred"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-^up"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-_priv"))))
+(display " ")
+(display (symbol->string (read (open-input-string "-~approx"))))
+(display " ")
+
+;; + prefix too
+(display (symbol->string (read (open-input-string "+>cmp"))))
+(display " ")
+(display (symbol->string (read (open-input-string "+!bang"))))
+(display " ")
+
+;; These already worked (letter/dot/sign after sign) — sanity check
+(display (symbol->string (read (open-input-string "-foo"))))
+(display " ")
+(display (symbol->string (read (open-input-string "+.z"))))
+(newline)


### PR DESCRIPTION
## Summary
- Fix `readSymbol` in `reader.zig` to correctly handle R7RS peculiar identifiers where `+`/`-` is followed by special-initial characters (`! $ % & * / : < = > ? ^ _ ~`)
- Previously only `+ - . @` and alphabetic characters were accepted after a sign, causing identifiers like `->foo`, `-<tag>`, `+>=` to be truncated to just `+` or `-`
- Replace `isSpecialSubsequent(c) or isAlphabetic(c)` with `isInitial(c) or isSpecialSubsequent(c)` to match R7RS grammar

## Test plan
- [x] Added `tests/scheme/smoke/reader-peculiar-idents.scm` covering all 15 special-initial characters after `+`/`-`
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1578 pass, 0 fail)
- [x] R7RS suite now passes the previously-affected test at line 633

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)