### PR TITLE
Remove 256-argument cap from apply by using heap-allocated ArrayList

### DIFF
--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -600,31 +600,28 @@ fn symbolToString(args: []const Value) PrimitiveError!Value {
 
 fn applyFn(args: []const Value) PrimitiveError!Value {
     const vm = @import("vm.zig").vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return PrimitiveError.TypeError;
 
     // Collect all arguments: args[1..n-1] are individual, args[n-1] is a list
-    var call_args: [256]Value = undefined;
-    var count: usize = 0;
+    var call_args: std.ArrayList(Value) = .empty;
+    defer call_args.deinit(gc.allocator);
 
     // Individual args (everything between proc and the final list)
     for (args[1 .. args.len - 1]) |a| {
-        if (count >= 256) return PrimitiveError.OutOfMemory;
-        call_args[count] = a;
-        count += 1;
+        call_args.append(gc.allocator, a) catch return PrimitiveError.OutOfMemory;
     }
 
     // Flatten the last arg (must be a proper list)
     var rest = args[args.len - 1];
     while (rest != types.NIL) {
         if (!types.isPair(rest)) return PrimitiveError.TypeError;
-        if (count >= 256) return PrimitiveError.OutOfMemory;
-        call_args[count] = types.car(rest);
-        count += 1;
+        call_args.append(gc.allocator, types.car(rest)) catch return PrimitiveError.OutOfMemory;
         rest = types.cdr(rest);
     }
 
-    return vm.callWithArgs(proc, call_args[0..count]) catch |err| {
+    return vm.callWithArgs(proc, call_args.items) catch |err| {
         return switch (err) {
             @import("vm.zig").VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
             @import("vm.zig").VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,

--- a/tests/scheme/smoke/apply-large-arglist.scm
+++ b/tests/scheme/smoke/apply-large-arglist.scm
@@ -1,0 +1,37 @@
+;; Regression test for #649: apply with >256 arguments fails with
+;; misleading OutOfMemory error instead of succeeding.
+
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define (mk n) (if (= n 0) '() (cons n (mk (- n 1)))))
+
+;; 256 args — worked before
+(let ((result (apply + (mk 256))))
+  (when (not (= result 32896))
+    (display "FAIL: apply with 256 args")
+    (newline)
+    (exit 1)))
+
+;; 257 args — previously failed with OutOfMemory
+(let ((result (apply + (mk 257))))
+  (when (not (= result 33153))
+    (display "FAIL: apply with 257 args")
+    (newline)
+    (exit 1)))
+
+;; 500 args — well beyond old limit
+(let ((result (apply + (mk 500))))
+  (when (not (= result 125250))
+    (display "FAIL: apply with 500 args")
+    (newline)
+    (exit 1)))
+
+;; apply with individual args + trailing list > 256 total
+(let ((result (apply + 1 2 3 (mk 260))))
+  (when (not (= result 33936))
+    (display "FAIL: apply with mixed args > 256")
+    (newline)
+    (exit 1)))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- Replace fixed `[256]Value` stack buffer in `applyFn` with `std.ArrayList(Value)` using `gc.allocator`
- Removes the artificial 256-argument cap that caused a misleading `OutOfMemory` error
- `apply` now handles arbitrary argument counts, matching `callWithArgs` which has no such limit

## Test plan
- [x] Added `tests/scheme/smoke/apply-large-arglist.scm` testing 256, 257, 500, and mixed args > 256
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1580 pass, 0 fail)

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)