### PR TITLE
Detect thread-join! on current thread and raise error

### DIFF
--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -339,6 +339,14 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
 
     const target = types.toObject(args[0]).as(fiber_mod.Fiber);
 
+    // Self-join detection: a thread cannot join itself (SRFI-18)
+    if (vm_mod.vm_instance) |vm| {
+        if (vm.current_fiber) |me| {
+            if (me == target)
+                return raiseError(.general, "thread-join!: thread cannot join itself", args[0]);
+        }
+    }
+
     // OS thread path: join, deep-copy result from child heap, free child resources
     if (target.os_thread) |thread| {
         thread.join();

--- a/tests/scheme/smoke/thread-self-join.scm
+++ b/tests/scheme/smoke/thread-self-join.scm
@@ -1,0 +1,13 @@
+;; Regression test for #643: thread-join! on (current-thread) must
+;; signal an error, not silently return void.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18))
+
+(guard (exn
+        ((error-object? exn)
+         (display "PASS")
+         (newline)))
+  (thread-join! (current-thread))
+  (display "FAIL: no error raised")
+  (newline)
+  (exit 1))


### PR DESCRIPTION
## Summary
- Add self-join detection at the top of `threadJoinFn`: if the target fiber is the current fiber, raise a general error per SRFI-18
- Previously, `thread-join!` on `(current-thread)` silently returned void because the scheduler loop broke immediately when target == current fiber

## Test plan
- [x] Added `tests/scheme/smoke/thread-self-join.scm` verifying error is raised
- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1582 pass, 0 fail)

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)