### PR TITLE
Abandon mutexes held by terminated fibers (#642)

### DIFF
--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -127,6 +127,25 @@ fn raiseError(error_type: types.ErrorObject.ErrorType, msg: []const u8, reason: 
     return PrimitiveError.ExceptionRaised;
 }
 
+pub fn abandonFiberMutexes(gc: *memory.GC, fiber: *fiber_mod.Fiber, sched: ?*fiber_mod.FiberScheduler) void {
+    const fiber_val = types.makePointer(@ptrCast(fiber));
+    var lists = [_]?*types.Object{ gc.objects, gc.old_objects };
+    for (&lists) |*head| {
+        var obj = head.*;
+        while (obj) |o| : (obj = o.next) {
+            if (o.tag == .mutex) {
+                const m = o.as(types.Mutex);
+                if (m.locked and m.owner == fiber_val) {
+                    m.abandoned = true;
+                    m.locked = false;
+                    m.owner = types.VOID;
+                    if (sched) |s| s.wakeMutexWaiters(types.makePointer(@ptrCast(o)));
+                }
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Thread primitives
 // ---------------------------------------------------------------------------
@@ -269,10 +288,13 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_g
     };
 
     const result = child_vm.callWithArgs(child_thunk, &.{}) catch {
+        if (child_vm.current_fiber) |cf| abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
         fiber.status = .errored;
         storeChildResult(@intFromPtr(fiber), types.VOID, child_vm.current_exception);
         return;
     };
+
+    if (child_vm.current_fiber) |cf| abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
 
     // Store result in child_resources (not on the fiber) so the parent
     // GC never traverses a child-heap pointer (Race C).
@@ -322,6 +344,9 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
 
     fiber.terminated = true;
+
+    if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, ctx.sched);
+
     if (fiber.status != .completed and fiber.status != .errored) {
         fiber.status = .errored;
         ctx.sched.wakeWaiters(fiber);
@@ -478,13 +503,17 @@ fn runSchedulerUntilDone(target: *fiber_mod.Fiber) PrimitiveError!void {
                 continue;
             }
             fiber.status = .errored;
+            if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
             sched.saveCurrentFiber();
             sched.wakeWaiters(fiber);
             continue;
         };
         fiber.status = .completed;
         fiber.result = result;
-        if (primitives.gc_instance) |gc| gc.writeBarrier(&fiber.header, result);
+        if (primitives.gc_instance) |gc| {
+            gc.writeBarrier(&fiber.header, result);
+            abandonFiberMutexes(gc, fiber, sched);
+        }
         sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }
@@ -635,13 +664,17 @@ fn runSchedulerUntilMutex(m: *types.Mutex, me: *fiber_mod.Fiber) PrimitiveError!
                 continue;
             }
             fiber.status = .errored;
+            if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
             sched.saveCurrentFiber();
             sched.wakeWaiters(fiber);
             continue;
         };
         fiber.status = .completed;
         fiber.result = result;
-        if (primitives.gc_instance) |gc| gc.writeBarrier(&fiber.header, result);
+        if (primitives.gc_instance) |gc| {
+            gc.writeBarrier(&fiber.header, result);
+            abandonFiberMutexes(gc, fiber, sched);
+        }
         sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }
@@ -710,13 +743,17 @@ fn runSchedulerUntilCondVar(me: *fiber_mod.Fiber) PrimitiveError!void {
                 continue;
             }
             fiber.status = .errored;
+            if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
             sched.saveCurrentFiber();
             sched.wakeWaiters(fiber);
             continue;
         };
         fiber.status = .completed;
         fiber.result = result;
-        if (primitives.gc_instance) |gc| gc.writeBarrier(&fiber.header, result);
+        if (primitives.gc_instance) |gc| {
+            gc.writeBarrier(&fiber.header, result);
+            abandonFiberMutexes(gc, fiber, sched);
+        }
         sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -1,0 +1,160 @@
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const fiber_mod = @import("fiber.zig");
+const primitives = @import("primitives.zig");
+const srfi18 = @import("primitives_srfi18.zig");
+const vm_mod = @import("vm.zig");
+
+test "abandonFiberMutexes marks owned mutex abandoned" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const fiber = try gc.allocFiber(types.VOID, 0);
+    const fiber_val = types.makePointer(@ptrCast(fiber));
+    const m_val = try gc.allocMutex(types.VOID);
+    const m = types.toMutex(m_val);
+
+    m.locked = true;
+    m.owner = fiber_val;
+
+    srfi18.abandonFiberMutexes(&gc, fiber, null);
+
+    try std.testing.expect(m.abandoned);
+    try std.testing.expect(!m.locked);
+    try std.testing.expectEqual(types.VOID, m.owner);
+}
+
+test "abandonFiberMutexes skips mutex owned by different fiber" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const fiber_a = try gc.allocFiber(types.VOID, 0);
+    const fiber_b = try gc.allocFiber(types.VOID, 1);
+    const fiber_a_val = types.makePointer(@ptrCast(fiber_a));
+    const m_val = try gc.allocMutex(types.VOID);
+    const m = types.toMutex(m_val);
+
+    m.locked = true;
+    m.owner = fiber_a_val;
+
+    srfi18.abandonFiberMutexes(&gc, fiber_b, null);
+
+    try std.testing.expect(!m.abandoned);
+    try std.testing.expect(m.locked);
+    try std.testing.expectEqual(fiber_a_val, m.owner);
+}
+
+test "abandonFiberMutexes skips unlocked mutex" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const fiber = try gc.allocFiber(types.VOID, 0);
+    const m_val = try gc.allocMutex(types.VOID);
+    const m = types.toMutex(m_val);
+
+    m.locked = false;
+    m.owner = types.VOID;
+
+    srfi18.abandonFiberMutexes(&gc, fiber, null);
+
+    try std.testing.expect(!m.abandoned);
+}
+
+test "abandonFiberMutexes handles multiple mutexes" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const fiber = try gc.allocFiber(types.VOID, 0);
+    const fiber_val = types.makePointer(@ptrCast(fiber));
+
+    const m1_val = try gc.allocMutex(types.VOID);
+    const m2_val = try gc.allocMutex(types.VOID);
+    const m3_val = try gc.allocMutex(types.VOID);
+    const m1 = types.toMutex(m1_val);
+    const m2 = types.toMutex(m2_val);
+    const m3 = types.toMutex(m3_val);
+
+    m1.locked = true;
+    m1.owner = fiber_val;
+    m2.locked = false;
+    m2.owner = types.VOID;
+    m3.locked = true;
+    m3.owner = fiber_val;
+
+    srfi18.abandonFiberMutexes(&gc, fiber, null);
+
+    try std.testing.expect(m1.abandoned);
+    try std.testing.expect(!m1.locked);
+    try std.testing.expect(!m2.abandoned);
+    try std.testing.expect(m3.abandoned);
+    try std.testing.expect(!m3.locked);
+}
+
+test "thread-terminate! on current thread abandons held mutex" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(import (srfi 18))
+    );
+    _ = try vm.eval(
+        \\(define m (make-mutex 'test))
+    );
+    _ = try vm.eval(
+        \\(mutex-lock! m)
+    );
+
+    _ = vm.eval(
+        \\(thread-terminate! (current-thread))
+    ) catch {};
+
+    vm.yielded = false;
+
+    const result = try vm.eval(
+        \\(eq? (mutex-state m) 'abandoned)
+    );
+    try std.testing.expectEqual(types.TRUE, result);
+}
+
+test "mutex-lock! on abandoned mutex raises abandoned-mutex-exception" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(import (srfi 18))
+    );
+    _ = try vm.eval(
+        \\(define m (make-mutex 'test))
+    );
+    _ = try vm.eval(
+        \\(mutex-lock! m)
+    );
+
+    const m_val = try vm.eval("m");
+    const m = types.toMutex(m_val);
+    const sched_fiber = vm.current_fiber.?;
+    srfi18.abandonFiberMutexes(&gc, sched_fiber, vm.scheduler);
+
+    try std.testing.expect(m.abandoned);
+
+    const result = try vm.eval(
+        \\(guard (e (#t (abandoned-mutex-exception? e)))
+        \\  (mutex-lock! m)
+        \\  #f)
+    );
+    try std.testing.expectEqual(types.TRUE, result);
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -16,4 +16,5 @@ test {
     _ = @import("tests_fuzz.zig");
     _ = @import("tests_deepcopy.zig");
     _ = @import("tests_ir.zig");
+    _ = @import("tests_srfi18.zig");
 }

--- a/tests/scheme/srfi/srfi18-abandoned-mutex.scm
+++ b/tests/scheme/srfi/srfi18-abandoned-mutex.scm
@@ -1,0 +1,46 @@
+;; Regression test for #642: Mutex.abandoned is never set to true
+(import (scheme base) (scheme write) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (check-true name val)
+  (if val
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name) (newline))))
+
+;; Test 1: properly unlocked mutex is NOT abandoned
+(let ((m (make-mutex 'no-abandon-test)))
+  (mutex-lock! m)
+  (mutex-unlock! m)
+  (check "mutex-state after proper unlock" (mutex-state m) 'not-abandoned))
+
+;; Test 2: never-locked mutex is not abandoned
+(let ((m (make-mutex 'never-locked)))
+  (check "mutex-state never locked" (mutex-state m) 'not-abandoned))
+
+;; Test 3: thread-terminate! on current thread abandons the held mutex
+;; Note: thread-terminate! on current thread sets vm.yielded which
+;; causes a runtime error on the next dispatch cycle, so we can only
+;; verify one check after the terminate call.
+(let ((m (make-mutex 'abandon-test)))
+  (mutex-lock! m)
+  (check-true "mutex locked before terminate" (thread? (mutex-state m)))
+  (thread-terminate! (current-thread))
+  (check "mutex abandoned after thread-terminate!" (mutex-state m) 'abandoned))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "abandoned mutex tests failed" fail))


### PR DESCRIPTION
## Summary

- Add `abandonFiberMutexes()` that walks GC young+old object lists to find mutexes owned by a terminating fiber and marks them `abandoned=true, locked=false`
- Call it from `threadTerminateFn` (explicit `thread-terminate!`), `threadEntryFn` (OS thread completion/error), and all three cooperative scheduler loops on fiber completion/error
- The read-side code in `mutexLockFn` and `mutexStateFn` already handled `m.abandoned == true` correctly — this fix wires up the write side

Closes #642

## Test plan

- [x] 6 new Zig unit tests in `tests_srfi18.zig` covering: single/multiple mutex abandonment, skip non-owned, skip unlocked, end-to-end via `thread-terminate!`, `abandoned-mutex-exception?` on re-lock
- [x] Scheme regression test `srfi18-abandoned-mutex.scm` verifying `mutex-state` returns `'abandoned` after `thread-terminate!`
- [x] All 423 Zig unit tests pass
- [x] All 1583 Scheme tests pass (189 files + 1394 R7RS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)