### PR TITLE
Fix compileFile preamble skip and GC safety

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1057,9 +1057,10 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
             return;
         };
 
+        vm.gc.pushRoot(&expr) catch continue;
+        defer vm.gc.popRoot();
+
         if (vm.handleTopLevelForm(expr)) |top_result| {
-            vm.gc.pushRoot(&expr) catch continue;
-            defer vm.gc.popRoot();
             const form_src = printer.valueToString(allocator, expr, .write) catch continue;
             _ = top_result catch |err| {
                 const detail = vm.getErrorDetail();

--- a/src/main.zig
+++ b/src/main.zig
@@ -1049,7 +1049,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         return;
     }) {
         const datum_lc = r.getLineCol();
-        const expr = r.readDatum() catch |err| {
+        var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
@@ -1058,6 +1058,9 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         };
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
+            vm.gc.pushRoot(&expr) catch continue;
+            defer vm.gc.popRoot();
+            const form_src = printer.valueToString(allocator, expr, .write) catch continue;
             _ = top_result catch |err| {
                 const detail = vm.getErrorDetail();
                 if (detail.len > 0) {
@@ -1070,9 +1073,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
                     writeStderr(s);
                 }
                 vm.last_error_detail_len = 0;
-                continue;
             };
-            const form_src = printer.valueToString(allocator, expr, .write) catch continue;
             preamble.append(allocator, form_src) catch {
                 allocator.free(form_src);
             };

--- a/tests/scheme/compile/compile-preamble-699.sh
+++ b/tests/scheme/compile/compile-preamble-699.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Regression test for #699: compileFile GC safety and preamble recording.
+# Exercises the --compile path (compileFile), which roots expr before
+# handleTopLevelForm and always appends to preamble. Compiles to .sbc,
+# then re-runs the .scm (which loads the cached .sbc) to verify imports replay.
+#
+# Usage: bash tests/scheme/compile/compile-preamble-699.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+
+COMPILE_DIR=$(mktemp -d)
+trap 'rm -rf "$COMPILE_DIR"' EXIT
+
+cat > "$COMPILE_DIR/test.scm" << 'SCHEME'
+(import (scheme base) (scheme write) (scheme char) (scheme cxr))
+(display (string-upcase "hello"))
+(display " ")
+(display (car (cons 42 '())))
+(newline)
+SCHEME
+
+"$KAAPPI" --compile -o "$COMPILE_DIR/test.sbc" "$COMPILE_DIR/test.scm" > /dev/null 2>&1
+
+REPLAY_OUTPUT=$("$KAAPPI" "$COMPILE_DIR/test.scm" 2>&1)
+if [[ "$REPLAY_OUTPUT" != "HELLO 42" ]]; then
+    echo "FAIL: expected 'HELLO 42', got '$REPLAY_OUTPUT'" >&2
+    exit 1
+fi

--- a/tests/scheme/compile/compile-preamble-699.sh
+++ b/tests/scheme/compile/compile-preamble-699.sh
@@ -23,7 +23,7 @@ SCHEME
 
 "$KAAPPI" --compile -o "$COMPILE_DIR/test.sbc" "$COMPILE_DIR/test.scm" > /dev/null 2>&1
 
-REPLAY_OUTPUT=$("$KAAPPI" "$COMPILE_DIR/test.scm" 2>&1)
+REPLAY_OUTPUT=$("$KAAPPI" "$COMPILE_DIR/test.scm" 2>/dev/null)
 if [[ "$REPLAY_OUTPUT" != "HELLO 42" ]]; then
     echo "FAIL: expected 'HELLO 42', got '$REPLAY_OUTPUT'" >&2
     exit 1

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -80,6 +80,40 @@ run_suite "SRFI tests" tests/scheme/srfi/*.scm
 run_suite "FFI tests" tests/scheme/ffi/*.scm
 run_suite "Audit tests" tests/scheme/audit/*.scm
 
+# Regression test for #699: compileFile GC safety and preamble recording.
+# Exercises the --compile path (compileFile), which roots expr before
+# handleTopLevelForm and always appends to preamble. Compiles to .sbc,
+# then re-runs the .scm (which loads the cached .sbc) to verify imports replay.
+echo "=== Compile tests ==="
+COMPILE_DIR=$(mktemp -d)
+trap 'rm -rf "$COMPILE_DIR"' EXIT
+cat > "$COMPILE_DIR/test.scm" << 'SCHEME'
+(import (scheme base) (scheme write) (scheme char) (scheme cxr))
+(display (string-upcase "hello"))
+(display " ")
+(display (car (cons 42 '())))
+(newline)
+SCHEME
+set +e
+"$KAAPPI" --compile -o "$COMPILE_DIR/test.sbc" "$COMPILE_DIR/test.scm" > /tmp/kaappi-test-out 2>&1
+COMPILE_STATUS=$?
+set -e
+if [[ $COMPILE_STATUS -eq 0 ]]; then
+    REPLAY_OUTPUT=$("$KAAPPI" "$COMPILE_DIR/test.scm" 2>&1)
+    if [[ "$REPLAY_OUTPUT" == "HELLO 42" ]]; then
+        echo "  PASS  compile-preamble-replay (#699)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  compile-preamble-replay (#699): got '$REPLAY_OUTPUT'"
+        FAIL=$((FAIL + 1))
+    fi
+else
+    echo "  FAIL  compile-preamble-replay (#699): --compile exited $COMPILE_STATUS"
+    cat /tmp/kaappi-test-out
+    FAIL=$((FAIL + 1))
+fi
+echo ""
+
 echo "=== R7RS test suite ==="
 set +e
 # Capture stdout and stderr separately to preserve panic messages

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -80,38 +80,23 @@ run_suite "SRFI tests" tests/scheme/srfi/*.scm
 run_suite "FFI tests" tests/scheme/ffi/*.scm
 run_suite "Audit tests" tests/scheme/audit/*.scm
 
-# Regression test for #699: compileFile GC safety and preamble recording.
-# Exercises the --compile path (compileFile), which roots expr before
-# handleTopLevelForm and always appends to preamble. Compiles to .sbc,
-# then re-runs the .scm (which loads the cached .sbc) to verify imports replay.
 echo "=== Compile tests ==="
-COMPILE_DIR=$(mktemp -d)
-trap 'rm -rf "$COMPILE_DIR"' EXIT
-cat > "$COMPILE_DIR/test.scm" << 'SCHEME'
-(import (scheme base) (scheme write) (scheme char) (scheme cxr))
-(display (string-upcase "hello"))
-(display " ")
-(display (car (cons 42 '())))
-(newline)
-SCHEME
-set +e
-"$KAAPPI" --compile -o "$COMPILE_DIR/test.sbc" "$COMPILE_DIR/test.scm" > /tmp/kaappi-test-out 2>&1
-COMPILE_STATUS=$?
-set -e
-if [[ $COMPILE_STATUS -eq 0 ]]; then
-    REPLAY_OUTPUT=$("$KAAPPI" "$COMPILE_DIR/test.scm" 2>&1)
-    if [[ "$REPLAY_OUTPUT" == "HELLO 42" ]]; then
-        echo "  PASS  compile-preamble-replay (#699)"
-        PASS=$((PASS + 1))
-    else
-        echo "  FAIL  compile-preamble-replay (#699): got '$REPLAY_OUTPUT'"
-        FAIL=$((FAIL + 1))
+for test_script in tests/scheme/compile/*.sh; do
+    if [[ -x "$test_script" ]]; then
+        set +e
+        bash "$test_script" "$KAAPPI" > /tmp/kaappi-test-out 2>&1
+        status=$?
+        set -e
+        if [[ $status -eq 0 ]]; then
+            echo "  PASS  $test_script"
+            PASS=$((PASS + 1))
+        else
+            echo "  FAIL  $test_script"
+            cat /tmp/kaappi-test-out
+            FAIL=$((FAIL + 1))
+        fi
     fi
-else
-    echo "  FAIL  compile-preamble-replay (#699): --compile exited $COMPILE_STATUS"
-    cat /tmp/kaappi-test-out
-    FAIL=$((FAIL + 1))
-fi
+done
 echo ""
 
 echo "=== R7RS test suite ==="


### PR DESCRIPTION
## Summary
- **GC root expr** before `handleTopLevelForm` — `expr` is now `var` and rooted with `pushRoot`/`popRoot` so GC during library loading can't free the cons cells before stringification
- **Always append to preamble** — `valueToString` runs before the error catch block (while `expr` is still valid), and the `continue` is removed so `preamble.append` always executes regardless of whether `top_result` errored

Fixes #699

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1583 pass, 0 fail
- [x] `zig build -Dbundle-src=...` — bundled binary correctly replays imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)