### PR TITLE
Fix preamble replay GC root and resilient library imports

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -356,7 +356,9 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 var pr = reader_mod.Reader.init(&gc, src);
                 defer pr.deinit();
                 while (pr.hasMore() catch break) {
-                    const expr = pr.readDatum() catch break;
+                    var expr = pr.readDatum() catch break;
+                    gc.pushRoot(&expr) catch break;
+                    defer gc.popRoot();
                     if (vm.handleTopLevelForm(expr)) |top_result| {
                         _ = top_result catch |err| {
                             const detail = vm.getErrorDetail();

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -931,9 +931,7 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
                 id_list = types.cdr(id_list);
             }
         } else if (std.mem.eql(u8, decl_name, "import")) {
-            _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch |err| {
-                if (err != VMError.CompileError) return err;
-            };
+            _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch return VMError.CompileError;
         } else if (std.mem.eql(u8, decl_name, "begin")) {
             try compileLibBeginBlock(vm, lib_env, types.cdr(declaration));
         } else if (std.mem.eql(u8, decl_name, "include") or std.mem.eql(u8, decl_name, "include-ci")) {
@@ -1167,9 +1165,7 @@ fn includeLibraryDeclarations(
                     id_list = types.cdr(id_list);
                 }
             } else if (std.mem.eql(u8, decl_name, "import")) {
-                _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch |err| {
-                    if (err != VMError.CompileError) return err;
-                };
+                _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch return VMError.CompileError;
             } else if (std.mem.eql(u8, decl_name, "begin")) {
                 try compileLibBeginBlock(vm, lib_env, types.cdr(declaration));
             } else if (std.mem.eql(u8, decl_name, "include") or std.mem.eql(u8, decl_name, "include-ci")) {

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -49,12 +49,16 @@ fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, v
 /// Handle (import import-set ...) into a specific target environment.
 pub fn handleImportInto(vm: *VM, target: *std.StringHashMap(Value), args: Value) VMError!Value {
     var current = args;
+    var had_error = false;
     while (current != types.NIL) {
         if (!types.isPair(current)) return VMError.CompileError;
         const import_set = types.car(current);
-        processImportSet(vm, target, import_set) catch return VMError.CompileError;
+        processImportSet(vm, target, import_set) catch {
+            had_error = true;
+        };
         current = types.cdr(current);
     }
+    if (had_error) return VMError.CompileError;
     return types.VOID;
 }
 
@@ -927,7 +931,9 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
                 id_list = types.cdr(id_list);
             }
         } else if (std.mem.eql(u8, decl_name, "import")) {
-            _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch return VMError.CompileError;
+            _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch |err| {
+                if (err != VMError.CompileError) return err;
+            };
         } else if (std.mem.eql(u8, decl_name, "begin")) {
             try compileLibBeginBlock(vm, lib_env, types.cdr(declaration));
         } else if (std.mem.eql(u8, decl_name, "include") or std.mem.eql(u8, decl_name, "include-ci")) {
@@ -1161,7 +1167,9 @@ fn includeLibraryDeclarations(
                     id_list = types.cdr(id_list);
                 }
             } else if (std.mem.eql(u8, decl_name, "import")) {
-                _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch return VMError.CompileError;
+                _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch |err| {
+                    if (err != VMError.CompileError) return err;
+                };
             } else if (std.mem.eql(u8, decl_name, "begin")) {
                 try compileLibBeginBlock(vm, lib_env, types.cdr(declaration));
             } else if (std.mem.eql(u8, decl_name, "include") or std.mem.eql(u8, decl_name, "include-ci")) {

--- a/tests/scheme/compile/compile-preamble-gc-700.sh
+++ b/tests/scheme/compile/compile-preamble-gc-700.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Regression test for #700: preamble replay GC root and resilient imports.
+# Creates a multi-library project where a bundled binary must replay preamble
+# imports that trigger nested library loading (stressing GC). Without the
+# expr root in the preamble replay loop, GC corrupts the import-set list.
+#
+# Usage: bash tests/scheme/compile/compile-preamble-gc-700.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+mkdir -p "$DIR/lib/myapp"
+
+# Leaf library with no dependencies
+cat > "$DIR/lib/myapp/util.sld" << 'SCHEME'
+(define-library (myapp util)
+  (import (scheme base))
+  (export double square)
+  (begin
+    (define (double x) (* x 2))
+    (define (square x) (* x x))))
+SCHEME
+
+# Middle library depending on util
+cat > "$DIR/lib/myapp/math.sld" << 'SCHEME'
+(define-library (myapp math)
+  (import (scheme base) (myapp util))
+  (export quad)
+  (begin
+    (define (quad x) (double (double x)))))
+SCHEME
+
+# Top library depending on both
+cat > "$DIR/lib/myapp/app.sld" << 'SCHEME'
+(define-library (myapp app)
+  (import (scheme base) (myapp util) (myapp math))
+  (export run-app)
+  (begin
+    (define (run-app n) (+ (quad n) (square n)))))
+SCHEME
+
+# Main program importing all libraries in one form
+cat > "$DIR/main.scm" << 'SCHEME'
+(import (scheme base) (scheme write) (myapp app) (myapp util))
+(display (run-app 3))
+(display " ")
+(display (double 5))
+(newline)
+SCHEME
+
+# Compile to .sbc (from within temp dir so lib paths are relative)
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+(cd "$DIR" && "$KAAPPI_ABS" --lib-path lib --compile -o main.sbc main.scm > /dev/null 2>&1)
+
+# Verify .sbc was created
+if [[ ! -f "$DIR/main.sbc" ]]; then
+    echo "FAIL: .sbc file not created" >&2
+    exit 1
+fi
+
+# Build bundled binary
+BUNDLE_BIN="$DIR/main-standalone"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+(cd "$REPO_DIR" && zig build -Dbundle="$DIR/main.sbc" -Doptimize=ReleaseSafe 2>/dev/null)
+cp "$REPO_DIR/zig-out/bin/kaappi" "$BUNDLE_BIN"
+
+# Rebuild regular binary
+(cd "$REPO_DIR" && zig build 2>/dev/null)
+
+# Run the bundled binary — must not crash or show preamble errors
+OUTPUT=$("$BUNDLE_BIN" 2>&1)
+if echo "$OUTPUT" | grep -q "preamble error"; then
+    echo "FAIL: preamble error in bundled binary: $OUTPUT" >&2
+    exit 1
+fi
+if [[ "$OUTPUT" != "21 10" ]]; then
+    echo "FAIL: expected '21 10', got '$OUTPUT'" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #700 — bundled binaries (`-Dbundle`) fail when the preamble replays imports that trigger nested library loading.

## Root cause

During preamble replay in `main.zig`, the parsed expression (`expr`) was **not GC-rooted** before being passed to `handleTopLevelForm`. When an `(import ...)` form triggers recursive library loading (e.g., `(c0c driver)` → `(c0c lexer)` → `(c0c parser)` → ...), the nested `handleDefineLibrary` calls allocate heavily, triggering GC. Without a root, the pairs in the import-set list get collected and reused, so when the import loop advances to the next import-set, it follows a stale `cdr` pointer into unrelated heap data.

**Concrete symptom:** `(cadr field)` (a random expression from recycled heap memory) was being treated as a library name, producing `library not found: (cadr.field)`.

This is the same class of bug as #699 (fixed in #701 for `compileFile`), but in the preamble replay path which was missed.

## Changes

### 1. GC root for preamble replay (`src/main.zig`)

Root `expr` before `handleTopLevelForm` in the preamble replay loop, matching what `compileFile` already does.

```zig
// Before (line 359)
const expr = pr.readDatum() catch break;

// After
var expr = pr.readDatum() catch break;
gc.pushRoot(&expr) catch break;
defer gc.popRoot();
```

### 2. `handleImportInto` continues past failures (`src/vm_library.zig`)

Previously, `(import (lib-a) (lib-b) (lib-c))` would abort on the first failure, preventing `(lib-c)` from loading even if it would succeed independently. Now all import-sets are attempted before reporting the error:

```zig
// Before
processImportSet(vm, target, import_set) catch return VMError.CompileError;

// After
var had_error = false;
// ... in loop:
processImportSet(vm, target, import_set) catch { had_error = true; };
// ... after loop:
if (had_error) return VMError.CompileError;
```

### Change 3 (dropped)

The original issue requested that `handleDefineLibrary` swallow `CompileError` from its import clause so the begin block and library registration still run. This was implemented but **reverted** because it suppressed missing-dependency error diagnostics — the error format test "missing dependency names the dependency" failed in CI. The GC root fix and `handleImportInto` resilience are sufficient for the bundled binary use case.

## Investigation trace

The debugging process traced the failure through multiple layers:

1. **Initial hypothesis** (from the issue): `handleImportInto` aborting on first failure → applied fix, but compile step segfaulted
2. **Segfault analysis**: `printer.zig:505` accessing `cls.func.name` on corrupt closure → reverted change 2 in isolation, compile step succeeded
3. **Preamble replay test**: built bundled binary, ran c0c-standalone → `preamble error: error.CompileError`
4. **Agent analysis**: fanned out 3 agents to analyze preamble replay path, c0c dependency DAG, and `handleDefineLibrary` error flow — confirmed clean DAG, no circular deps
5. **Debug instrumentation**: added `std.posix.system.write(2, ...)` traces at every error path in `handleDefineLibrary` — none fired for any known error path
6. **Declaration loop tracing**: printed `decl_name` at each iteration → all libraries processed import/export/begin correctly
7. **Import-set tracing**: printed each `processImportSet` call → discovered `processImportSet: (cadr.field)` — a Scheme expression being treated as a library name
8. **Root cause identified**: `expr` in preamble replay loop was not GC-rooted; during nested library loading, GC collected pairs in the import-set list, and `cdr` followed stale pointers into recycled heap memory
9. **Pre-existing c0c issue**: confirmed the c0c runtime errors (`type error in 'cdr': expected pair`) happen even with the unmodified kaappi binary — separate from this fix

## Regression test

`tests/scheme/compile/compile-preamble-gc-700.sh` — creates a 3-library project (util → math → app), compiles to `.sbc`, builds a bundled binary, and verifies it runs without preamble errors. Exercises the nested library loading path that stresses GC during preamble replay.

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1585 pass, 0 fail, 1 skip (191 scheme + 1394 R7RS)
- [x] `bash tests/scheme/errors/error-format.sh` — 21 pass, 0 fail
- [x] New regression test `compile-preamble-gc-700.sh` passes
- [x] Existing regression test `compile-preamble-699.sh` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)