### PR TITLE
Fix handleDefineLibrary import abort and bundled file paths

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -429,8 +429,9 @@ fn tryLoadLibraryFromFile(vm: *VM, name_list: Value) !void {
     const source = readFileContents(allocator, sld_path) catch return error.UndefinedVariable;
     defer allocator.free(source);
 
-    // Record for bundling
-    recordFileForBundle(vm, sld_path, source);
+    // Record for bundling (use rel_path so findBundledSource can locate it
+    // without the compile-time --lib-path prefix)
+    recordFileForBundle(vm, rel_path, source);
 
     const source_hash = bytecode_file.sourceHash(source);
 
@@ -931,7 +932,15 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
                 id_list = types.cdr(id_list);
             }
         } else if (std.mem.eql(u8, decl_name, "import")) {
-            _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch return VMError.CompileError;
+            _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch |err| {
+                if (err != VMError.CompileError) return err;
+                const detail = vm.getErrorDetail();
+                if (detail.len > 0) {
+                    vm_mod.writeStderr(detail);
+                    vm_mod.writeStderr("\n");
+                    vm.last_error_detail_len = 0;
+                }
+            };
         } else if (std.mem.eql(u8, decl_name, "begin")) {
             try compileLibBeginBlock(vm, lib_env, types.cdr(declaration));
         } else if (std.mem.eql(u8, decl_name, "include") or std.mem.eql(u8, decl_name, "include-ci")) {

--- a/tests/scheme/compile/compile-import-error-703.sh
+++ b/tests/scheme/compile/compile-import-error-703.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Regression test for #703: handleDefineLibrary continues past import CompileError.
+# A library whose import clause produces a CompileError (from a partially failing
+# multi-import) should still execute its begin block and register exports.
+#
+# Without the fix, handleDefineLibrary returns immediately on CompileError,
+# skipping the begin block (so module state is UNDEFINED) and library registration.
+#
+# Usage: bash tests/scheme/compile/compile-import-error-703.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+mkdir -p "$DIR/lib/myapp"
+
+# Library A: simple leaf
+cat > "$DIR/lib/myapp/util.sld" << 'SCHEME'
+(define-library (myapp util)
+  (import (scheme base))
+  (export greet)
+  (begin
+    (define (greet name) (string-append "Hello, " name "!"))))
+SCHEME
+
+# Library B: depends on A, defines module-level state in begin block
+cat > "$DIR/lib/myapp/app.sld" << 'SCHEME'
+(define-library (myapp app)
+  (import (scheme base) (srfi 69) (myapp util))
+  (export app-greet lookup register!)
+  (begin
+    (define registry (make-hash-table string=? string-hash))
+    (define (register! key val) (hash-table-set! registry key val))
+    (define (lookup key) (hash-table-ref/default registry key #f))
+    (define (app-greet name)
+      (register! name #t)
+      (greet name))))
+SCHEME
+
+# Main program
+cat > "$DIR/main.scm" << 'SCHEME'
+(import (scheme base) (scheme write) (myapp app))
+(display (app-greet "world"))
+(newline)
+(display (lookup "world"))
+(newline)
+SCHEME
+
+# Run in interpreter mode — must succeed
+OUTPUT=$("$KAAPPI" --lib-path "$DIR/lib" "$DIR/main.scm" 2>/dev/null)
+if [[ "$OUTPUT" != "Hello, world!"$'\n'"#t" ]]; then
+    echo "FAIL: interpreter mode — expected 'Hello, world!' + '#t', got '$OUTPUT'" >&2
+    exit 1
+fi
+
+# Compile to .sbc
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+(cd "$DIR" && "$KAAPPI_ABS" --lib-path lib --compile -o main.sbc main.scm > /dev/null 2>&1)
+
+if [[ ! -f "$DIR/main.sbc" ]]; then
+    echo "FAIL: .sbc file not created" >&2
+    exit 1
+fi
+
+# Build bundled binary
+BUNDLE_BIN="$DIR/main-standalone"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+(cd "$REPO_DIR" && zig build -Dbundle="$DIR/main.sbc" -Doptimize=ReleaseSafe 2>/dev/null)
+cp "$REPO_DIR/zig-out/bin/kaappi" "$BUNDLE_BIN"
+
+# Rebuild regular binary
+(cd "$REPO_DIR" && zig build 2>/dev/null)
+
+# Run bundled binary — the begin block must have executed (hash table initialized)
+OUTPUT=$("$BUNDLE_BIN" 2>/dev/null)
+if [[ "$OUTPUT" != "Hello, world!"$'\n'"#t" ]]; then
+    echo "FAIL: standalone mode — expected 'Hello, world!' + '#t', got '$OUTPUT'" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #703.

- **handleDefineLibrary** no longer aborts when the import clause produces a `CompileError`. It prints the diagnostic to stderr (preserving missing-dependency messages) and continues to the begin block and library registration.
- **Bundled file paths** are now recorded with the canonical relative path (`c0c/driver.sld`) instead of the resolved path including `--lib-path` prefix (`../c0c/lib/c0c/driver.sld`), so `findBundledSource` can locate them at runtime in standalone binaries.

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1586 pass, 0 fail
- [x] `bash tests/scheme/errors/error-format.sh` — all 21 tests pass (including "missing dependency names the dependency" which broke PR #702)
- [x] New regression test `tests/scheme/compile/compile-import-error-703.sh` — verifies library with hash-table state works in both interpreter and standalone binary modes
- [x] Standalone binary no longer produces "library not found" errors — output matches interpreter mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)