### PR TITLE
Fix generational GC: mark Closure.func in minor collections

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -111,6 +111,7 @@ fn referencesYoung(obj: *Object) bool {
         },
         .closure => {
             const cls = obj.as(Closure);
+            if (isYoungPointer(types.makePointer(@ptrCast(cls.func)))) return true;
             for (cls.upvalues) |uv| {
                 if (isYoungPointer(uv)) return true;
             }
@@ -341,6 +342,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
         },
         .closure => {
             const cls = obj.as(Closure);
+            markValue(gc, types.makePointer(@ptrCast(cls.func)));
             for (cls.upvalues) |uv| markValue(gc, uv);
         },
         .hash_table => {


### PR DESCRIPTION
## Summary

`markObjectContents` (used by `minorCollect` for remembered-set objects) was missing the `Closure.func` mark. `hasYoungReferences` also missed the `func` pointer. This caused Functions to be freed during minor collections while their parent Closures still referenced them.

The full `markValue` path (line 504) correctly marks `cls.func` — this inconsistency only triggered during generational minor collections when a promoted Closure referenced a young-generation Function.

## Root cause

`Closure.func` is a `*Function` (Zig pointer, not a Scheme Value), so the write barrier doesn't track it. Two locations in `gc_collect.zig` handle Closures but only marked upvalues:

```zig
// hasYoungReferences (line 112) — MISSING func check
.closure => {
    const cls = obj.as(Closure);
    for (cls.upvalues) |uv| { if (isYoungPointer(uv)) return true; }
},

// markObjectContents (line 342) — MISSING func mark
.closure => {
    const cls = obj.as(Closure);
    for (cls.upvalues) |uv| markValue(gc, uv);
},
```

## Fix

Added `cls.func` marking to both locations, matching the existing pattern in `markValue` (line 506).

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1586 pass, 0 fail, 1 skip
- [x] Existing compile regression tests pass (compile-preamble-699.sh, compile-preamble-gc-700.sh, compile-import-error-703.sh)

Fixes part of #705.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>