### PR TITLE
Root expr in loadLibrarySource before handleTopLevelForm

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -183,7 +183,9 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
     defer rdr.deinit();
 
     while (rdr.hasMore() catch return error.InvalidSyntax) {
-        const expr = rdr.readDatum() catch return error.InvalidSyntax;
+        var expr = rdr.readDatum() catch return error.InvalidSyntax;
+        vm.gc.pushRoot(&expr) catch return error.OutOfMemory;
+        defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |result| {
             _ = result catch |err| return err;


### PR DESCRIPTION
## Summary

Same bug class as #699 (fixed in #701) and #700 (fixed in #702). `loadLibrarySource` reads `expr` via the Reader but doesn't GC-root it before passing to `handleTopLevelForm`, which triggers heavy allocation during nested library imports.

This is the third and final call site with this pattern — `compileFile` and preamble replay were fixed in #701 and #702.

## Change

```zig
// Before
const expr = rdr.readDatum() catch return error.InvalidSyntax;

// After
var expr = rdr.readDatum() catch return error.InvalidSyntax;
vm.gc.pushRoot(&expr) catch return error.OutOfMemory;
defer vm.gc.popRoot();
```

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1586 pass, 0 fail, 1 skip

Fixes part of #705.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>