### PR TITLE
Fix hash-table-walk/fold use-after-free when callback triggers rehash

### DIFF
--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -51,6 +51,22 @@ fn getHashTable(proc: []const u8, v: Value) PrimitiveError!*HashTable {
 const EMPTY: Value = types.VOID;
 const TOMBSTONE: Value = types.EOF;
 
+const GC = @import("memory.zig").GC;
+
+fn snapshotLiveEntries(gc: *GC, ht: *HashTable) ?[]HashEntry {
+    if (ht.count == 0) return gc.allocator.alloc(HashEntry, 0) catch return null;
+    const buf = gc.allocator.alloc(HashEntry, ht.count) catch return null;
+    var idx: usize = 0;
+    for (ht.entries[0..ht.capacity]) |entry| {
+        if (entry.key != EMPTY and entry.key != TOMBSTONE) {
+            buf[idx] = entry;
+            idx += 1;
+            if (idx >= ht.count) break;
+        }
+    }
+    return buf[0..idx];
+}
+
 pub fn valueHash(key: Value) usize {
     if (types.isFixnum(key)) {
         return @truncate(@as(u64, @bitCast(types.toFixnum(key))) *% 2654435761);
@@ -259,21 +275,23 @@ fn hashTableValuesFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-walk ht proc) — call (proc key value) for each entry
 fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-walk", args[0]);
     const proc = args[1];
 
-    for (ht.entries[0..ht.capacity]) |entry| {
-        if (entry.key != EMPTY and entry.key != TOMBSTONE) {
-            const call_args = [2]Value{ entry.key, entry.value };
-            _ = vm.callWithArgs(proc, &call_args) catch |err| {
-                return switch (err) {
-                    vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                    vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                    vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                    else => PrimitiveError.TypeError, // bare-ok: catch fallback
-                };
+    const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;
+    defer gc.allocator.free(snapshot);
+
+    for (snapshot) |entry| {
+        const call_args = [2]Value{ entry.key, entry.value };
+        _ = vm.callWithArgs(proc, &call_args) catch |err| {
+            return switch (err) {
+                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
+                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
+                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
+                else => PrimitiveError.TypeError, // bare-ok: catch fallback
             };
-        }
+        };
     }
     return types.VOID;
 }
@@ -470,22 +488,24 @@ fn hashTableRefDefaultFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-fold ht f init) — fold over hash table entries
 fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-fold", args[0]);
     const proc = args[1];
     var acc = args[2];
 
-    for (ht.entries[0..ht.capacity]) |entry| {
-        if (entry.key != EMPTY and entry.key != TOMBSTONE) {
-            const call_args = [3]Value{ entry.key, entry.value, acc };
-            acc = vm.callWithArgs(proc, &call_args) catch |err| {
-                return switch (err) {
-                    vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                    vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                    vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                    else => PrimitiveError.TypeError, // bare-ok: catch fallback
-                };
+    const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;
+    defer gc.allocator.free(snapshot);
+
+    for (snapshot) |entry| {
+        const call_args = [3]Value{ entry.key, entry.value, acc };
+        acc = vm.callWithArgs(proc, &call_args) catch |err| {
+            return switch (err) {
+                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
+                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
+                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
+                else => PrimitiveError.TypeError, // bare-ok: catch fallback
             };
-        }
+        };
     }
     return acc;
 }

--- a/tests/scheme/smoke/hash-table-walk-rehash.scm
+++ b/tests/scheme/smoke/hash-table-walk-rehash.scm
@@ -1,0 +1,57 @@
+;; Regression test for #690: hash-table-walk/fold must not use-after-free
+;; when the callback triggers a rehash on the same table.
+
+;; --- hash-table-walk with rehash ---
+(define ht (make-hash-table))
+(let loop ((i 0))
+  (when (< i 6)
+    (hash-table-set! ht i i)
+    (loop (+ i 1))))
+
+(define walk-count 0)
+(hash-table-walk ht
+  (lambda (k v)
+    (set! walk-count (+ walk-count 1))
+    (hash-table-set! ht (+ 1000 k) 'new)))
+
+;; Should visit exactly 6 original entries (not stale/garbage entries)
+(unless (= walk-count 6)
+  (display "FAIL: hash-table-walk visited ")
+  (display walk-count)
+  (display " entries, expected 6")
+  (newline)
+  (exit 1))
+
+;; --- hash-table-fold with rehash ---
+(define ht2 (make-hash-table))
+(let loop ((i 0))
+  (when (< i 6)
+    (hash-table-set! ht2 i i)
+    (loop (+ i 1))))
+
+(define result
+  (hash-table-fold ht2
+    (lambda (k v acc)
+      (hash-table-set! ht2 (+ 2000 k) 'grown)
+      (cons (cons k v) acc))
+    '()))
+
+;; Should have exactly 6 pairs, all with valid fixnum keys 0-5
+(unless (= (length result) 6)
+  (display "FAIL: hash-table-fold returned ")
+  (display (length result))
+  (display " pairs, expected 6")
+  (newline)
+  (exit 1))
+
+(for-each
+  (lambda (pair)
+    (unless (and (number? (car pair)) (number? (cdr pair)))
+      (display "FAIL: corrupted pair in fold result: ")
+      (display pair)
+      (newline)
+      (exit 1)))
+  result)
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- Snapshot live hash-table entries into a temporary array before iterating in `hash-table-walk` and `hash-table-fold`, preventing use-after-free when the user callback triggers a rehash on the same table
- Add `snapshotLiveEntries` helper that copies only occupied entries (not empty/tombstone slots)

## Test plan
- [x] New regression test `tests/scheme/smoke/hash-table-walk-rehash.scm` — verifies walk visits exactly 6 entries and fold returns 6 valid pairs when callback grows the table mid-iteration
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1588 pass, 0 fail)

Fixes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)