### PR TITLE
Fix define-values register corruption with 2+ names in lambda body

### DIFF
--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -242,8 +242,11 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
                 if (rest == types.NIL) {
                     try self.compileExpr(expr, last_dst, true);
                 } else {
+                    const saved_next = self.next_register;
                     try self.compileExpr(expr, last_dst, false);
-                    self.freeReg();
+                    if (self.next_register == saved_next) {
+                        self.freeReg();
+                    }
                 }
                 current = rest;
             }
@@ -260,8 +263,11 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
             if (rest == types.NIL) {
                 try self.compileExpr(expr, last_dst, true);
             } else {
+                const saved_next = self.next_register;
                 try self.compileExpr(expr, last_dst, false);
-                self.freeReg();
+                if (self.next_register == saved_next) {
+                    self.freeReg();
+                }
             }
             current = rest;
         }

--- a/tests/scheme/smoke/define-values-lambda-body.scm
+++ b/tests/scheme/smoke/define-values-lambda-body.scm
@@ -1,0 +1,50 @@
+;; Regression test for #687: define-values with 2+ names inside a lambda
+;; body must not corrupt registers.
+
+;; Two names inside lambda body — the primary failure case
+(define (f)
+  (define-values (p q) (values 100 200))
+  (+ p q))
+(unless (= (f) 300)
+  (display "FAIL: (f) should be 300, got ")
+  (display (f))
+  (newline)
+  (exit 1))
+
+;; Three names
+(define (g)
+  (define-values (a b c) (values 1 2 3))
+  (list a b c))
+(unless (equal? (g) '(1 2 3))
+  (display "FAIL: (g) should be (1 2 3), got ")
+  (display (g))
+  (newline)
+  (exit 1))
+
+;; Single name (should still work, was not broken)
+(define (h)
+  (define-values (x) (values 42))
+  x)
+(unless (= (h) 42)
+  (display "FAIL: (h) should be 42, got ")
+  (display (h))
+  (newline)
+  (exit 1))
+
+;; Top-level define-values (was not broken, sanity check)
+(define-values (a b) (values 10 20))
+(unless (= (+ a b) 30)
+  (display "FAIL: top-level define-values")
+  (newline)
+  (exit 1))
+
+;; define-values inside let body (was not broken, sanity check)
+(let ()
+  (define-values (x y) (values 5 6))
+  (unless (= (+ x y) 11)
+    (display "FAIL: let body define-values")
+    (newline)
+    (exit 1)))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- `compileBody()` unconditionally called `freeReg()` after non-tail body expressions, but `define-values` allocates persistent locals (boxed registers) that must not be freed
- Apply the same `saved_next` guard used in `compileLambdaWithIR`: only free when `next_register` is unchanged after compilation

## Test plan
- [x] New regression test `tests/scheme/smoke/define-values-lambda-body.scm` — covers 2-name, 3-name, 1-name, top-level, and let-body cases
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1588 pass, 0 fail)

Fixes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)