### PR TITLE
Fix LLVM backend: respect local parameter shadowing in call position

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -157,6 +157,22 @@ pub const LLVMEmitter = struct {
         return tmp;
     }
 
+    fn isNameShadowed(self: *LLVMEmitter, name: []const u8) bool {
+        if (self.locals) |loc| {
+            if (loc.get(name) != null) return true;
+        }
+        if (self.rest_param_name) |rp_name| {
+            if (std.mem.eql(u8, name, rp_name)) return true;
+        }
+        if (self.params) |p| {
+            if (p.get(name) != null) return true;
+        }
+        if (self.upvalues) |uv| {
+            if (uv.get(name) != null) return true;
+        }
+        return false;
+    }
+
     fn emitGlobalRef(self: *LLVMEmitter, sym: Value) EmitError![]const u8 {
         if (!types.isSymbol(sym)) return error.UnsupportedNodeType;
         const name = types.symbolName(sym);
@@ -210,7 +226,9 @@ pub const LLVMEmitter = struct {
         if (call.operator.tag == .global_ref and types.isSymbol(call.operator.data.global_ref)) {
             const op_name = types.symbolName(call.operator.data.global_ref);
 
-            if (is_tail) {
+            const is_shadowed = self.isNameShadowed(op_name);
+
+            if (!is_shadowed and is_tail) {
                 if (self.current_fn_name) |fn_name| {
                     if (self.body_label) |body_lbl| {
                         if (std.mem.eql(u8, op_name, fn_name)) {
@@ -224,20 +242,24 @@ pub const LLVMEmitter = struct {
                 }
             }
 
-            if (self.native_fns.get(op_name)) |native| {
-                const arity_ok = if (native.is_variadic)
-                    call.args.len >= native.arity
-                else
-                    call.args.len == native.arity;
-                if (arity_ok) {
-                    return self.emitDirectCall(native.llvm_name, call.args, is_tail);
+            if (!is_shadowed) {
+                if (self.native_fns.get(op_name)) |native| {
+                    const arity_ok = if (native.is_variadic)
+                        call.args.len >= native.arity
+                    else
+                        call.args.len == native.arity;
+                    if (arity_ok) {
+                        return self.emitDirectCall(native.llvm_name, call.args, is_tail);
+                    }
                 }
             }
-            if (call.args.len == 2) {
-                if (self.tryEmitInlineBinary(op_name, call.args)) |result| return result;
-            }
-            if (call.args.len == 1) {
-                if (self.tryEmitInlineUnary(op_name, call.args[0])) |result| return result;
+            if (!is_shadowed) {
+                if (call.args.len == 2) {
+                    if (self.tryEmitInlineBinary(op_name, call.args)) |result| return result;
+                }
+                if (call.args.len == 1) {
+                    if (self.tryEmitInlineUnary(op_name, call.args[0])) |result| return result;
+                }
             }
         }
 

--- a/tests/scheme/smoke/llvm-call-shadowing.scm
+++ b/tests/scheme/smoke/llvm-call-shadowing.scm
@@ -1,0 +1,32 @@
+;; Regression test for #684: LLVM backend must respect parameter shadowing
+;; in call position.
+
+;; A global function 'f' that the LLVM backend will try to call directly
+(define (f x)
+  (if (< x 1) 99 (f (- x 1))))
+
+;; 'apply-twice' takes a parameter named 'f' that shadows the global 'f'
+(define (apply-twice f x)
+  (f (f x)))
+
+;; Should call the lambda, not the global f
+(define result (apply-twice (lambda (y) (+ y 1)) 5))
+(unless (= result 7)
+  (display "FAIL: expected 7, got ")
+  (display result)
+  (newline)
+  (exit 1))
+
+;; Another case: higher-order with shadowed name
+(define (add a b) (+ a b))
+(define (apply-op add x y)
+  (add x y))
+(define result2 (apply-op * 3 4))
+(unless (= result2 12)
+  (display "FAIL: expected 12, got ")
+  (display result2)
+  (newline)
+  (exit 1))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- Add `isNameShadowed()` helper to check locals, params, upvalues, and rest_param_name before native-function fast paths in `emitCallNode`
- Skip self-tail-call optimization, direct native call, and inline binary/unary paths when the called name is locally shadowed

## Test plan
- [x] New regression test `tests/scheme/smoke/llvm-call-shadowing.scm` — verifies parameter shadowing of global function names produces correct results
- [x] All unit tests pass (`zig build test`)
- [x] All Scheme tests pass (1589 pass, 0 fail)

Fixes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)