### PR TITLE
Fix hash-table sentinel collision with eof-object and void keys

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -105,7 +105,7 @@ fn referencesYoung(obj: *Object) bool {
         .hash_table => {
             const ht = obj.as(HashTable);
             for (ht.entries[0..ht.capacity]) |entry| {
-                if (entry.key != types.VOID and entry.key != types.EOF) {
+                if (entry.state == .occupied) {
                     if (isYoungPointer(entry.key) or isYoungPointer(entry.value)) return true;
                 }
             }
@@ -349,7 +349,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
         .hash_table => {
             const ht = obj.as(HashTable);
             for (ht.entries[0..ht.capacity]) |entry| {
-                if (entry.key != types.VOID and entry.key != types.EOF) {
+                if (entry.state == .occupied) {
                     markValue(gc, entry.key);
                     markValue(gc, entry.value);
                 }
@@ -595,7 +595,7 @@ pub fn markValue(gc: *GC, v: Value) void {
         .hash_table => {
             const ht = obj.as(HashTable);
             for (ht.entries[0..ht.capacity]) |entry| {
-                if (entry.key != types.VOID and entry.key != types.EOF) {
+                if (entry.state == .occupied) {
                     markValue(gc, entry.key);
                     markValue(gc, entry.value);
                 }

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -854,10 +854,8 @@ pub const GC = struct {
         }
         const entries = try self.allocator.alloc(HashEntry, cap);
         errdefer self.allocator.free(entries);
-        // Initialize all entries as empty (key=VOID sentinel)
         for (entries) |*e| {
-            e.key = types.VOID;
-            e.value = types.VOID;
+            e.* = .{ .key = 0, .value = 0, .state = .empty };
         }
         const ht = try self.allocator.create(HashTable);
         ht.* = .{
@@ -1173,14 +1171,14 @@ pub const GC = struct {
                 try visited.put(src_ptr, new_val);
                 const new_ht = types.toObject(new_val).as(types.HashTable);
                 for (ht.entries[0..ht.capacity]) |entry| {
-                    if (entry.key != types.VOID and entry.key != types.EOF) {
+                    if (entry.state == .occupied) {
                         const nk = try self.deepCopyValue(entry.key, visited);
                         const nv = try self.deepCopyValue(entry.value, visited);
                         var idx = hashtable.valueHash(nk) & (new_ht.capacity - 1);
-                        while (new_ht.entries[idx].key != types.VOID) {
+                        while (new_ht.entries[idx].state == .occupied) {
                             idx = (idx + 1) & (new_ht.capacity - 1);
                         }
-                        new_ht.entries[idx] = .{ .key = nk, .value = nv };
+                        new_ht.entries[idx] = .{ .key = nk, .value = nv, .state = .occupied };
                         new_ht.count += 1;
                     }
                 }

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -47,10 +47,6 @@ fn getHashTable(proc: []const u8, v: Value) PrimitiveError!*HashTable {
     return types.toHashTable(v);
 }
 
-// Sentinels: VOID = empty slot, EOF = tombstone (deleted)
-const EMPTY: Value = types.VOID;
-const TOMBSTONE: Value = types.EOF;
-
 const GC = @import("memory.zig").GC;
 
 fn snapshotLiveEntries(gc: *GC, ht: *HashTable) ?[]HashEntry {
@@ -58,7 +54,7 @@ fn snapshotLiveEntries(gc: *GC, ht: *HashTable) ?[]HashEntry {
     const buf = gc.allocator.alloc(HashEntry, ht.count) catch return null;
     var idx: usize = 0;
     for (ht.entries[0..ht.capacity]) |entry| {
-        if (entry.key != EMPTY and entry.key != TOMBSTONE) {
+        if (entry.state == .occupied) {
             buf[idx] = entry;
             idx += 1;
             if (idx >= ht.count) break;
@@ -92,36 +88,34 @@ pub fn valueHash(key: Value) usize {
     return @truncate(key *% 2654435761);
 }
 
-/// Find bucket index of key, or null if not found.
 fn findKey(ht: *HashTable, key: Value) ?usize {
     if (ht.capacity == 0) return null;
     const mask = ht.capacity - 1;
     var idx = valueHash(key) & mask;
     var probes: usize = 0;
     while (probes < ht.capacity) {
-        const k = ht.entries[idx].key;
-        if (k == EMPTY) return null; // empty slot = key not present
-        if (k != TOMBSTONE and primitives.deepEqual(k, key)) return idx;
+        const entry = &ht.entries[idx];
+        if (entry.state == .empty) return null;
+        if (entry.state == .occupied and primitives.deepEqual(entry.key, key)) return idx;
         idx = (idx + 1) & mask;
         probes += 1;
     }
     return null;
 }
 
-/// Find slot for insertion: returns index of matching key, first tombstone, or empty slot.
 fn findSlot(ht: *HashTable, key: Value) struct { idx: usize, found: bool } {
     const mask = ht.capacity - 1;
     var idx = valueHash(key) & mask;
     var first_tombstone: ?usize = null;
     var probes: usize = 0;
     while (probes < ht.capacity) {
-        const k = ht.entries[idx].key;
-        if (k == EMPTY) {
+        const entry = &ht.entries[idx];
+        if (entry.state == .empty) {
             return .{ .idx = first_tombstone orelse idx, .found = false };
         }
-        if (k == TOMBSTONE) {
+        if (entry.state == .tombstone) {
             if (first_tombstone == null) first_tombstone = idx;
-        } else if (primitives.deepEqual(k, key)) {
+        } else if (primitives.deepEqual(entry.key, key)) {
             return .{ .idx = idx, .found = true };
         }
         idx = (idx + 1) & mask;
@@ -135,17 +129,15 @@ fn rehash(ht: *HashTable) PrimitiveError!void {
     const new_cap = if (ht.capacity == 0) 8 else ht.capacity * 2;
     const new_entries = gc.allocator.alloc(HashEntry, new_cap) catch return PrimitiveError.OutOfMemory;
     for (new_entries) |*e| {
-        e.key = EMPTY;
-        e.value = EMPTY;
+        e.* = .{ .key = 0, .value = 0, .state = .empty };
     }
     const old_entries = ht.entries;
     const old_cap = ht.capacity;
     ht.entries = new_entries;
     ht.capacity = new_cap;
     ht.count = 0;
-    // Re-insert all live entries
     for (old_entries[0..old_cap]) |entry| {
-        if (entry.key != EMPTY and entry.key != TOMBSTONE) {
+        if (entry.state == .occupied) {
             const slot = findSlot(ht, entry.key);
             ht.entries[slot.idx] = entry;
             ht.count += 1;
@@ -213,7 +205,7 @@ fn hashTableSetFn(args: []const Value) PrimitiveError!Value {
     if (slot.found) {
         ht.entries[slot.idx].value = args[2];
     } else {
-        ht.entries[slot.idx] = .{ .key = args[1], .value = args[2] };
+        ht.entries[slot.idx] = .{ .key = args[1], .value = args[2], .state = .occupied };
         ht.count += 1;
     }
     return types.VOID;
@@ -223,8 +215,9 @@ fn hashTableSetFn(args: []const Value) PrimitiveError!Value {
 fn hashTableDeleteFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-delete!", args[0]);
     if (findKey(ht, args[1])) |idx| {
-        ht.entries[idx].key = TOMBSTONE;
-        ht.entries[idx].value = EMPTY;
+        ht.entries[idx].state = .tombstone;
+        ht.entries[idx].key = 0;
+        ht.entries[idx].value = 0;
         ht.count -= 1;
     }
     return types.VOID;
@@ -250,7 +243,7 @@ fn hashTableKeysFn(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
     for (ht.entries[0..ht.capacity]) |entry| {
-        if (entry.key != EMPTY and entry.key != TOMBSTONE) {
+        if (entry.state == .occupied) {
             result = gc.allocPair(entry.key, result) catch return PrimitiveError.OutOfMemory;
         }
     }
@@ -265,7 +258,7 @@ fn hashTableValuesFn(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
     for (ht.entries[0..ht.capacity]) |entry| {
-        if (entry.key != EMPTY and entry.key != TOMBSTONE) {
+        if (entry.state == .occupied) {
             result = gc.allocPair(entry.value, result) catch return PrimitiveError.OutOfMemory;
         }
     }
@@ -304,7 +297,7 @@ fn hashTableToAlistFn(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
     for (ht.entries[0..ht.capacity]) |entry| {
-        if (entry.key != EMPTY and entry.key != TOMBSTONE) {
+        if (entry.state == .occupied) {
             var pair = gc.allocPair(entry.key, entry.value) catch return PrimitiveError.OutOfMemory;
             gc.pushRoot(&pair) catch return PrimitiveError.OutOfMemory;
             result = gc.allocPair(pair, result) catch {
@@ -518,7 +511,7 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
 
     const gc = primitives.gc_instance;
     for (ht2.entries[0..ht2.capacity]) |entry| {
-        if (entry.key == EMPTY or entry.key == TOMBSTONE) continue;
+        if (entry.state != .occupied) continue;
         const slot = findSlot(ht1, entry.key);
         if (gc) |g| {
             g.writeBarrier(types.toObject(args[0]), entry.key);

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -94,7 +94,7 @@ test "deepCopy hash_table" {
     const value = types.makeFixnum(99);
     const hash = std.hash.Wyhash.hash(0, std.mem.asBytes(&key));
     const idx = hash & (ht.capacity - 1);
-    ht.entries[idx] = .{ .key = key, .value = value };
+    ht.entries[idx] = .{ .key = key, .value = value, .state = .occupied };
     ht.count = 1;
 
     const copied = try gc2.deepCopy(ht_val);
@@ -103,7 +103,7 @@ test "deepCopy hash_table" {
     try std.testing.expectEqual(@as(usize, 1), cht.count);
     var found = false;
     for (cht.entries[0..cht.capacity]) |entry| {
-        if (entry.key == key) {
+        if (entry.state == .occupied and entry.key == key) {
             try std.testing.expectEqual(value, entry.value);
             found = true;
         }

--- a/src/types.zig
+++ b/src/types.zig
@@ -507,9 +507,16 @@ pub const Srfi18Time = struct {
 // Hash table (SRFI-69)
 // ---------------------------------------------------------------------------
 
+pub const HashEntryState = enum(u8) {
+    empty,
+    occupied,
+    tombstone,
+};
+
 pub const HashEntry = struct {
     key: Value,
     value: Value,
+    state: HashEntryState = .empty,
 };
 
 pub const HashTable = struct {

--- a/tests/scheme/smoke/hash-table-eof-void-key.scm
+++ b/tests/scheme/smoke/hash-table-eof-void-key.scm
@@ -1,0 +1,61 @@
+;; Regression test for #694: eof-object and void as hash-table keys
+;; must work correctly instead of colliding with internal sentinels.
+
+;; Test eof-object as key
+(define ht (make-hash-table))
+(hash-table-set! ht (eof-object) "eof-key-value")
+(unless (= (hash-table-size ht) 1)
+  (display "FAIL: size should be 1 after eof key insert, got ")
+  (display (hash-table-size ht))
+  (newline)
+  (exit 1))
+
+(define ref-result (hash-table-ref ht (eof-object) (lambda () 'MISSING)))
+(unless (equal? ref-result "eof-key-value")
+  (display "FAIL: eof key ref should be \"eof-key-value\", got ")
+  (display ref-result)
+  (newline)
+  (exit 1))
+
+(unless (hash-table-exists? ht (eof-object))
+  (display "FAIL: eof key should exist")
+  (newline)
+  (exit 1))
+
+;; Check it shows up in alist
+(define alist (hash-table->alist ht))
+(unless (= (length alist) 1)
+  (display "FAIL: alist should have 1 entry, got ")
+  (display (length alist))
+  (newline)
+  (exit 1))
+
+;; Test void (unspecified) as key
+(define ht2 (make-hash-table))
+(define unspecified (if #f #f))
+(hash-table-set! ht2 unspecified "void-key-value")
+(unless (= (hash-table-size ht2) 1)
+  (display "FAIL: size should be 1 after void key insert")
+  (newline)
+  (exit 1))
+
+(define ref2 (hash-table-ref ht2 unspecified (lambda () 'MISSING)))
+(unless (equal? ref2 "void-key-value")
+  (display "FAIL: void key ref should be \"void-key-value\", got ")
+  (display ref2)
+  (newline)
+  (exit 1))
+
+;; Test delete of eof key
+(hash-table-delete! ht (eof-object))
+(unless (= (hash-table-size ht) 0)
+  (display "FAIL: size should be 0 after eof key delete")
+  (newline)
+  (exit 1))
+(when (hash-table-exists? ht (eof-object))
+  (display "FAIL: eof key should not exist after delete")
+  (newline)
+  (exit 1))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- Add `HashEntryState` enum (`empty`/`occupied`/`tombstone`) to `HashEntry` struct to track slot state independently of key value
- Remove `EMPTY`/`TOMBSTONE` sentinel constants that collided with user-constructible `(eof-object)` and `(if #f #f)` values
- Update all hash table operations (lookup, insert, delete, iteration, GC marking, deep-copy) to use the state field

## Test plan
- [x] New regression test `tests/scheme/smoke/hash-table-eof-void-key.scm` — verifies eof-object and void as keys can be stored, retrieved, and deleted
- [x] All unit tests pass (`zig build test`) including updated `tests_deepcopy.test.deepCopy hash_table`
- [x] All Scheme tests pass (1589 pass, 0 fail)

Fixes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)