### PR TITLE
Fix LLVM backend: bail out of native closure for variadic lambdas

### DIFF
--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -40,6 +40,8 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
         plist = types.cdr(plist);
     }
 
+    if (rest_name != null) return null;
+
     var body_ir = ir.IR.init(self.allocator);
     defer body_ir.deinit();
     var body_nodes: [64]*ir.Node = undefined;

--- a/tests/scheme/smoke/llvm-variadic-closure.scm
+++ b/tests/scheme/smoke/llvm-variadic-closure.scm
@@ -1,0 +1,30 @@
+;; Regression test for #685: variadic (rest-arg) native closures must
+;; not crash with arity mismatch when called with extra arguments.
+
+(define (make-variadic)
+  (lambda (a b . rest)
+    (list a b rest)))
+
+(define (caller)
+  (let ((f (make-variadic)))
+    (f 1 2 3 4 5)))
+
+(define result (caller))
+(unless (equal? result '(1 2 (3 4 5)))
+  (display "FAIL: expected (1 2 (3 4 5)), got ")
+  (display result)
+  (newline)
+  (exit 1))
+
+;; Also test direct variadic call
+(define variadic-add
+  (lambda (a . rest)
+    (apply + a rest)))
+
+(unless (= (variadic-add 1 2 3 4) 10)
+  (display "FAIL: variadic-add should return 10")
+  (newline)
+  (exit 1))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- Bail out of `tryCompilePureLambdaAsNativeClosure` when the lambda has a rest parameter (`rest_name != null`), falling back to `kaappi_eval` which handles variadic calls correctly

## Test plan
- [x] New regression test `tests/scheme/smoke/llvm-variadic-closure.scm`
- [x] All unit tests pass
- [x] All Scheme tests pass (1589 pass, 0 fail)

Fixes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)