### PR TITLE
Fix passthrough constant folding: check globals for redefined primitives

### DIFF
--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -211,6 +211,14 @@ fn tryConstantFold(self: *Compiler, expr: Value, dst: u16) bool {
 
     if (self.resolveLocal(name) != null) return false;
     if ((self.resolveUpvalue(name) catch null) != null) return false;
+    if (self.globals) |globals| {
+        if (globals.get(name)) |val| {
+            if (!types.isPointer(val)) return false;
+            const obj = types.toObject(val);
+            if (obj.tag != .native_fn) return false;
+            if (!std.mem.eql(u8, obj.as(types.NativeFn).name, name)) return false;
+        }
+    }
 
     const args_pair = types.cdr(expr);
     if (!types.isPair(args_pair)) return false;

--- a/tests/scheme/smoke/passthrough-redefine-constfold.scm
+++ b/tests/scheme/smoke/passthrough-redefine-constfold.scm
@@ -1,0 +1,18 @@
+;; Regression test for #698: constant folding in compiler_passthrough
+;; must respect redefined primitives.
+
+(define (+ a b) (list 'custom a b))
+
+(define-syntax my-add
+  (syntax-rules ()
+    ((_ x y) (+ x y))))
+
+(define result (my-add 1 2))
+(unless (equal? result '(custom 1 2))
+  (display "FAIL: expected (custom 1 2), got ")
+  (display result)
+  (newline)
+  (exit 1))
+
+(display "PASS")
+(newline)


### PR DESCRIPTION
## Summary
- Add globals redefinition check to `tryConstantFold` in `compiler_passthrough.zig`, matching the fix already applied to `ir.zig` in PR #618
- Prevents silent bypassing of user-redefined `+`, `-`, `*`, `=`, etc. when called with literal arguments inside macro-expanded code

## Test plan
- [x] New regression test `tests/scheme/smoke/passthrough-redefine-constfold.scm`
- [x] All unit tests pass

Fixes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)