### PR TITLE
Fix command-line: remove hardcoded "kaappi" prefix

### DIFF
--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -105,17 +105,12 @@ fn commandLine(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&str_val) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
 
-    // Build list in reverse: script args then program name at the front.
     var i = vm.command_line_args.len;
     while (i > 0) {
         i -= 1;
         str_val = gc.allocString(vm.command_line_args[i]) catch return PrimitiveError.OutOfMemory;
         result = gc.allocPair(str_val, result) catch return PrimitiveError.OutOfMemory;
     }
-
-    // Prepend program name.
-    str_val = gc.allocString("kaappi") catch return PrimitiveError.OutOfMemory;
-    result = gc.allocPair(str_val, result) catch return PrimitiveError.OutOfMemory;
     return result;
 }
 

--- a/tests/scheme/smoke/command-line-o-flag.scm
+++ b/tests/scheme/smoke/command-line-o-flag.scm
@@ -1,13 +1,13 @@
 ;; Regression test for #602: -o must not be stripped from (command-line)
 ;; in normal script execution mode.
 ;; This test is invoked by run-all.sh as: kaappi this-file.scm
-;; So (command-line) should be ("kaappi" "this-file.scm") with no -o stripping.
+;; So (command-line) should be ("this-file.scm") — the script path as first element.
 (import (scheme base) (scheme write) (scheme process-context))
 
 (define args (command-line))
 
-;; Verify (command-line) returns a list with at least the program name and script
-(unless (and (list? args) (>= (length args) 2))
+;; Verify (command-line) returns a non-empty list with the script path
+(unless (and (list? args) (>= (length args) 1))
   (display "FAIL: (command-line) too short")
   (newline)
   (exit 1))


### PR DESCRIPTION
## Summary
- Remove hardcoded `"kaappi"` prepend from `commandLine()` so output matches documented format `("script.scm" "foo" "bar")`

## Test plan
- [x] Verified interactively: `echo '(display (command-line)) (newline)' | ./zig-out/bin/kaappi /dev/stdin foo bar` → `(/dev/stdin foo bar)`
- [x] All unit tests pass

Fixes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)