### PR TITLE
Raise syntax-rules pattern variable limit from 16 to 128 per ellipsis

### DIFF
--- a/src/expander.zig
+++ b/src/expander.zig
@@ -322,8 +322,7 @@ fn matchEllipsis(elem_pattern: Value, rest_pattern: Value, input: Value, literal
     if (input_len < rest_len) return false;
     const repeat_count = input_len - rest_len;
 
-    // Collect pattern variable names from elem_pattern
-    var elem_var_names: [16][]const u8 = undefined;
+    var elem_var_names: [128][]const u8 = undefined;
     var elem_var_count: usize = 0;
     var var_overflow = false;
     collectPatternVars(elem_pattern, literals, &elem_var_names, &elem_var_count, &var_overflow);
@@ -386,20 +385,16 @@ fn matchEllipsis(elem_pattern: Value, rest_pattern: Value, input: Value, literal
     return matchListPattern(rest_pattern, inp, literals, bindings, count, gc);
 }
 
-fn collectPatternVars(pattern: Value, literals: []const Value, names: *[16][]const u8, count: *usize, overflowed: *bool) void {
+fn collectPatternVars(pattern: Value, literals: []const Value, names: *[128][]const u8, count: *usize, overflowed: *bool) void {
     if (types.isSymbol(pattern)) {
         const name = types.symbolName(pattern);
-        // Skip underscore
         if (std.mem.eql(u8, name, "_")) return;
-        // Skip literals
         for (literals) |lit| {
             if (types.isSymbol(lit) and std.mem.eql(u8, types.symbolName(lit), name))
                 return;
         }
-        // Skip ellipsis
         if (isEllipsis(name)) return;
-        // Add pattern variable
-        if (count.* >= 16) {
+        if (count.* >= 128) {
             overflowed.* = true;
             return;
         }
@@ -517,7 +512,7 @@ fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_scop
 fn instantiateNestedSyntaxRules(gc: *GC, template: Value, bindings: []Binding, intro_scope: u32, literals: []const Value, macro_keyword: ?[]const u8, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value)) (std.mem.Allocator.Error || ExpandError)!Value {
     // template = (syntax-rules (lits...) (pat tmpl) ...)
     // Collect inner pattern variable names to exclude from outer bindings
-    var inner_pvs: [16][]const u8 = undefined;
+    var inner_pvs: [128][]const u8 = undefined;
     var inner_pv_count: usize = 0;
     const sr_rest = types.cdr(template); // skip 'syntax-rules'
     if (sr_rest != types.NIL and types.isPair(sr_rest)) {

--- a/tests/scheme/smoke/expander-many-patvars.scm
+++ b/tests/scheme/smoke/expander-many-patvars.scm
@@ -1,0 +1,18 @@
+;; Regression test for #683: syntax-rules with >16 pattern variables
+;; per ellipsis sub-pattern must work.
+
+;; 17 pattern variables — previously failed with InvalidSyntax
+(define-syntax many-vars
+  (syntax-rules ()
+    ((_ (a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16) ...)
+     (quote ((a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16) ...)))))
+
+(let ((result (many-vars (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16))))
+  (if (equal? result '((0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)))
+    (display "PASS")
+    (begin
+      (display "FAIL: got ")
+      (display result)
+      (newline)
+      (exit 1))))
+(newline)


### PR DESCRIPTION
## Summary
- Increase pattern variable buffer in `matchEllipsis`, `collectPatternVars`, and `instantiateNestedSyntaxRules` from `[16]` to `[128]` to match `MAX_BINDINGS`

## Test plan
- [x] New regression test with 17 pattern variables (previously failed)
- [x] All unit tests pass

Fixes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)