### PR TITLE
Require delimiter after numeric tokens in the reader

### DIFF
--- a/src/reader.zig
+++ b/src/reader.zig
@@ -302,7 +302,10 @@ pub const Reader = struct {
     const reader_datum = @import("reader_datum.zig");
 
     fn readNumber(self: *Reader) ReadError!Token {
-        return reader_tokens.readNumber(self);
+        const tok = try reader_tokens.readNumber(self);
+        if (self.pos < self.source.len and !isDelimiter(self.source[self.pos]))
+            return ReadError.UnexpectedChar;
+        return tok;
     }
 
     fn foldAndReturnSymbol(self: *Reader, sym_text: []const u8) ReadError!Token {
@@ -528,7 +531,10 @@ pub const Reader = struct {
     }
 
     fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
-        return reader_tokens.readIntegerWithRadix(self, radix);
+        const tok = try reader_tokens.readIntegerWithRadix(self, radix);
+        if (self.pos < self.source.len and !isDelimiter(self.source[self.pos]))
+            return ReadError.UnexpectedChar;
+        return tok;
     }
 
     fn readCharacter(self: *Reader) ReadError!Token {


### PR DESCRIPTION
## Summary
- Add trailing delimiter check in `Reader.readNumber()` and `Reader.readIntegerWithRadix()` wrappers
- Malformed input like `12abc` now raises `ReadError.UnexpectedChar` instead of silently splitting into separate tokens

## Test plan
- [x] Verified `12abc` and `1+` now error; `42 ` and `(123)` still parse correctly
- [x] All unit tests pass
- [x] All Scheme tests pass (1593 pass, 0 fail)

Fixes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)