### PR TITLE
Fix macro hygiene for template-introduced bindings named after built-ins

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1066,6 +1066,10 @@ pub const Compiler = struct {
                 const TempGlobal = struct { name: []const u8, old_val: ?Value, was_present: bool };
                 var temp_globals: [128]TempGlobal = undefined;
                 var temp_global_count: usize = 0;
+                // Track non-procedure global free vars that need local injection
+                // to prevent shadowing by use-site locals (R7RS 4.3.1).
+                var global_free_names: [64][]const u8 = undefined;
+                var global_free_count: usize = 0;
                 if (self.globals) |g| {
                     for (tx.captured_locals) |cap| {
                         if (!g.contains(cap.name) and temp_global_count < 128) {
@@ -1111,6 +1115,11 @@ pub const Compiler = struct {
                                         temp_global_count += 1;
                                         g.put(cname, types.VOID) catch {};
                                     }
+                                    // Track for local injection after expansion
+                                    if (global_free_count < 64) {
+                                        global_free_names[global_free_count] = cname;
+                                        global_free_count += 1;
+                                    }
                                 }
                             }
                         }
@@ -1142,13 +1151,39 @@ pub const Compiler = struct {
                 try self.gc.pushRoot(&expanded_root);
                 defer self.gc.popRoot();
                 self.gc.no_collect -= 1;
-                // Inject captured locals from the macro definition site
                 const saved_locals_len = self.locals.items.len;
                 for (tx.captured_locals) |cap| {
                     self.locals.append(self.gc.allocator, .{
                         .name = cap.name,
                         .depth = self.scope_depth,
                         .slot = cap.slot,
+                    }) catch {};
+                }
+                injectHygienicCapturedLocals(self, expanded_root, tx.captured_locals);
+                // Inject non-procedure global free vars as locals so
+                // use-site locals don't shadow the definition-site
+                // global binding (R7RS 4.3.1 referential transparency).
+                for (global_free_names[0..global_free_count]) |gname| {
+                    // Skip if already covered by captured_locals
+                    var already_captured = false;
+                    for (tx.captured_locals) |cap| {
+                        if (std.mem.eql(u8, cap.name, gname)) {
+                            already_captured = true;
+                            break;
+                        }
+                    }
+                    if (already_captured) continue;
+                    // Load the global value into a fresh register
+                    const gslot = self.allocReg() catch continue;
+                    const gsym = self.gc.allocSymbol(gname) catch continue;
+                    const gsym_idx = self.addConstant(gsym) catch continue;
+                    self.emitOp(.get_global) catch continue;
+                    self.emitU16(gslot) catch continue;
+                    self.emitU16(gsym_idx) catch continue;
+                    self.locals.append(self.gc.allocator, .{
+                        .name = gname,
+                        .depth = self.scope_depth,
+                        .slot = gslot,
                     }) catch {};
                 }
                 const result_err = self.compileExpr(expanded_root, dst, is_tail);
@@ -1227,6 +1262,54 @@ pub const Compiler = struct {
         // define-syntax returns void
         try self.emitOp(.load_void);
         try self.emitU16(dst);
+    }
+
+    fn stripHygPrefix(name: []const u8) []const u8 {
+        var n = name;
+        while (std.mem.startsWith(u8, n, "__hyg_")) {
+            if (std.mem.indexOfScalar(u8, n[6..], '_')) |sep| {
+                n = n[6 + sep + 1 ..];
+            } else break;
+        }
+        return n;
+    }
+
+    fn injectHygienicCapturedLocals(self: *Compiler, expr: Value, captured: []const types.CapturedLocal) void {
+        if (captured.len == 0) return;
+        injectHygCapturedWalk(self, expr, captured);
+    }
+
+    fn injectHygCapturedWalk(self: *Compiler, expr: Value, captured: []const types.CapturedLocal) void {
+        if (types.isSymbol(expr)) {
+            const name = types.symbolName(expr);
+            if (!std.mem.startsWith(u8, name, "__hyg_")) return;
+            const base = stripHygPrefix(name);
+            if (base.len == name.len) return;
+            for (captured) |cap| {
+                if (std.mem.eql(u8, cap.name, base)) {
+                    var already = false;
+                    for (self.locals.items) |loc| {
+                        if (std.mem.eql(u8, loc.name, name)) {
+                            already = true;
+                            break;
+                        }
+                    }
+                    if (!already) {
+                        self.locals.append(self.gc.allocator, .{
+                            .name = name,
+                            .depth = self.scope_depth,
+                            .slot = cap.slot,
+                        }) catch {};
+                    }
+                    return;
+                }
+            }
+            return;
+        }
+        if (types.isPair(expr)) {
+            injectHygCapturedWalk(self, types.car(expr), captured);
+            injectHygCapturedWalk(self, types.cdr(expr), captured);
+        }
     }
 
     fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -35,49 +35,17 @@ fn isEllipsis(name: []const u8) bool {
 /// variables. The compiler recognizes hygienic renames via
 /// effective_name stripping.
 const well_known_forms = [_][]const u8{
-    // Special forms
-    "begin",                          "define",              "set!",               "lambda",
-    "let*",                           "letrec",              "letrec*",            "quote",
-    "quasiquote",                     "unquote",             "unquote-splicing",   "define-syntax",
-    "let-syntax",                     "letrec-syntax",       "syntax-rules",       "define-record-type",
-    "define-values",                  "let-values",          "let*-values",        "case-lambda",
-    "cond-expand",                    "cond",                "case",               "and",
-    "or",                             "when",                "unless",             "do",
-    "guard",                          "delay",               "delay-force",        "parameterize",
-    "syntax-error",                   "include",             "include-ci",         "define-library",
-    "import",                         "export",
-    // Tail-form keywords
-                 "else",               "=>",
-    // Built-in procedures commonly used in macro templates
-    "cons",                           "car",                 "cdr",                "list",
-    "append",                         "map",                 "for-each",           "+",
-    "-",                              "*",                   "/",                  "=",
-    "<",                              ">",                   "<=",                 ">=",
-    "not",                            "null?",               "pair?",              "boolean?",
-    "number?",                        "symbol?",             "string?",            "char?",
-    "vector?",                        "procedure?",          "port?",              "eof-object?",
-    "eq?",                            "eqv?",                "equal?",             "zero?",
-    "positive?",                      "negative?",           "even?",              "odd?",
-    "abs",                            "min",                 "max",                "length",
-    "reverse",                        "memq",                "memv",               "assq",
-    "assv",                           "values",              "call-with-values",   "apply",
-    "call-with-current-continuation", "call/cc",             "dynamic-wind",       "with-exception-handler",
-    "raise",                          "raise-continuable",   "error",              "error-object?",
-    "display",                        "newline",             "write",              "read",
-    "open-input-file",                "open-output-file",    "close-input-port",   "close-output-port",
-    "current-input-port",             "current-output-port", "current-error-port", "string-ref",
-    "string-set!",                    "string-length",       "substring",          "string-append",
-    "string->number",                 "number->string",      "string->symbol",     "symbol->string",
-    "string-copy",                    "string-copy!",        "vector-ref",         "vector-set!",
-    "vector-length",                  "make-vector",         "vector->list",       "list->vector",
-    "make-string",                    "string->list",        "list->string",       "char->integer",
-    "integer->char",                  "exact",               "inexact",            "floor",
-    "ceiling",                        "truncate",            "round",              "modulo",
-    "remainder",                      "quotient",            "gcd",                "lcm",
-    "expt",                           "sqrt",                "make-parameter",     "make-promise",
-    "force",                          "boolean=?",           "char=?",             "char<?",
-    "char>?",                         "string=?",            "string<?",           "...",
-    "_",
+    "begin",         "define",        "set!",             "lambda",
+    "let*",          "letrec",        "letrec*",          "quote",
+    "quasiquote",    "unquote",       "unquote-splicing", "define-syntax",
+    "let-syntax",    "letrec-syntax", "syntax-rules",     "define-record-type",
+    "define-values", "let-values",    "let*-values",      "case-lambda",
+    "cond-expand",   "cond",          "case",             "and",
+    "or",            "when",          "unless",           "do",
+    "guard",         "delay",         "delay-force",      "parameterize",
+    "syntax-error",  "include",       "include-ci",       "define-library",
+    "import",        "export",        "else",             "=>",
+    "...",           "_",
 };
 
 pub fn isWellKnown(name: []const u8) bool {
@@ -551,13 +519,74 @@ fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_scop
         return instantiateNestedSyntaxRules(gc, template, bindings, intro_scope, literals, macro_keyword, globals, macros);
     }
 
+    // Detect binding forms and set binding-position flag for variable names
+    const BINDING_FLAG: u32 = 0x20000000;
+    if (types.isSymbol(elem)) {
+        const form_name = types.symbolName(elem);
+        const is_let_form = std.mem.eql(u8, form_name, "let") or
+            std.mem.eql(u8, form_name, "let*") or
+            std.mem.eql(u8, form_name, "letrec") or
+            std.mem.eql(u8, form_name, "letrec*");
+        if (is_let_form) {
+            const new_car = try instantiateTemplate(gc, elem, bindings, intro_scope, literals, macro_keyword, globals, macros);
+            var car_root = new_car;
+            try gc.pushRoot(&car_root);
+            defer gc.popRoot();
+            const let_rest = types.cdr(template);
+            if (let_rest != types.NIL and types.isPair(let_rest)) {
+                const binding_list = types.car(let_rest);
+                const body = types.cdr(let_rest);
+                const new_bindings = try instantiateLetBindings(gc, binding_list, bindings, intro_scope | BINDING_FLAG, literals, macro_keyword, globals, macros);
+                var bindings_root = new_bindings;
+                try gc.pushRoot(&bindings_root);
+                defer gc.popRoot();
+                const new_body = try instantiateTemplate(gc, body, bindings, intro_scope & ~BINDING_FLAG, literals, macro_keyword, globals, macros);
+                var body_root = new_body;
+                try gc.pushRoot(&body_root);
+                defer gc.popRoot();
+                const inner = try gc.allocPair(bindings_root, body_root);
+                return gc.allocPair(car_root, inner);
+            }
+        }
+    }
+
     // Regular pair: recurse
-    const new_car = try instantiateTemplate(gc, types.car(template), bindings, intro_scope, literals, macro_keyword, globals, macros);
+    const new_car = try instantiateTemplate(gc, types.car(template), bindings, intro_scope & ~BINDING_FLAG, literals, macro_keyword, globals, macros);
     var car_root = new_car;
     try gc.pushRoot(&car_root);
     defer gc.popRoot();
-    const new_cdr = try instantiateTemplate(gc, types.cdr(template), bindings, intro_scope, literals, macro_keyword, globals, macros);
+    const new_cdr = try instantiateTemplate(gc, types.cdr(template), bindings, intro_scope & ~BINDING_FLAG, literals, macro_keyword, globals, macros);
     return gc.allocPair(car_root, new_cdr);
+}
+
+fn instantiateLetBindings(gc: *GC, binding_list: Value, bindings: []Binding, scope: u32, literals: []const Value, macro_keyword: ?[]const u8, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value)) !Value {
+    if (binding_list == types.NIL) return types.NIL;
+    if (!types.isPair(binding_list)) return instantiateTemplate(gc, binding_list, bindings, scope, literals, macro_keyword, globals, macros);
+    const pair = types.car(binding_list);
+    if (!types.isPair(pair)) {
+        const new_pair = try instantiateTemplate(gc, pair, bindings, scope, literals, macro_keyword, globals, macros);
+        var pair_root = new_pair;
+        try gc.pushRoot(&pair_root);
+        defer gc.popRoot();
+        const new_rest = try instantiateLetBindings(gc, types.cdr(binding_list), bindings, scope, literals, macro_keyword, globals, macros);
+        return gc.allocPair(pair_root, new_rest);
+    }
+    const var_name = types.car(pair);
+    const init_and_rest = types.cdr(pair);
+    const new_var = try instantiateTemplate(gc, var_name, bindings, scope, literals, macro_keyword, globals, macros);
+    var var_root = new_var;
+    try gc.pushRoot(&var_root);
+    defer gc.popRoot();
+    const new_init = try instantiateTemplate(gc, init_and_rest, bindings, scope & ~@as(u32, 0x20000000), literals, macro_keyword, globals, macros);
+    var init_root = new_init;
+    try gc.pushRoot(&init_root);
+    defer gc.popRoot();
+    const new_pair = try gc.allocPair(var_root, init_root);
+    var np_root = new_pair;
+    try gc.pushRoot(&np_root);
+    defer gc.popRoot();
+    const new_rest = try instantiateLetBindings(gc, types.cdr(binding_list), bindings, scope, literals, macro_keyword, globals, macros);
+    return gc.allocPair(np_root, new_rest);
 }
 
 fn instantiateNestedSyntaxRules(gc: *GC, template: Value, bindings: []Binding, intro_scope: u32, literals: []const Value, macro_keyword: ?[]const u8, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value)) (std.mem.Allocator.Error || ExpandError)!Value {
@@ -710,28 +739,27 @@ fn substitutePatternVarsOnly(gc: *GC, template: Value, bindings: []Binding) !Val
 }
 
 fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.StringHashMap(Value)) !Value {
-    // Skip renaming inside quote contexts (not ellipsis escape — hygiene still applies there)
     const QUOTE_FLAG: u32 = 0x40000000;
+    const BINDING_FLAG: u32 = 0x20000000;
     if ((scope & QUOTE_FLAG) != 0) return gc.allocSymbol(name);
-    // If the name exists as a global binding, keep it as-is.
-    // This preserves referential transparency AND allows set! to
-    // mutate the original global (aliasing would create a separate binding).
+    const in_binding = (scope & BINDING_FLAG) != 0;
+    const clean_scope = scope & ~BINDING_FLAG;
     if (globals) |g| {
         if (g.get(name)) |val| {
-            if (types.isProcedure(val) or types.isTransformer(val) or val == types.VOID) return gc.allocSymbol(name);
+            if (types.isProcedure(val) or types.isTransformer(val)) {
+                if (!in_binding) return gc.allocSymbol(name);
+            }
         }
     }
-    // Also check the VM's global environment for procedures and macros
     const vm_mod = @import("vm.zig");
     if (vm_mod.vm_instance) |vm| {
         if (vm.globals.get(name)) |val| {
-            if (types.isProcedure(val) or types.isTransformer(val)) return gc.allocSymbol(name);
+            if (types.isTransformer(val)) return gc.allocSymbol(name);
         }
     }
 
-    // Check if we already renamed this (name, scope) pair
     for (scope_table[0..scope_table_count]) |entry| {
-        if (entry.scope == scope and std.mem.eql(u8, entry.original_name, name)) {
+        if (entry.scope == clean_scope and std.mem.eql(u8, entry.original_name, name)) {
             return gc.allocSymbol(entry.renamed_to);
         }
     }
@@ -748,7 +776,7 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
     if (scope_table_count >= MAX_SCOPE_ENTRIES) return ExpandError.ScopeTableFull;
     scope_table[scope_table_count] = .{
         .original_name = name,
-        .scope = scope,
+        .scope = clean_scope,
         .renamed_to = renamed_persistent,
     };
     scope_table_count += 1;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -14,6 +14,16 @@ const vm_debug = @import("vm_debug.zig");
 const vm_library = @import("vm_library.zig");
 const vm_records = @import("vm_records.zig");
 
+fn stripHygienicPrefix(name: []const u8) []const u8 {
+    var n = name;
+    while (std.mem.startsWith(u8, n, "__hyg_")) {
+        if (std.mem.indexOfScalar(u8, n[6..], '_')) |sep| {
+            n = n[6 + sep + 1 ..];
+        } else break;
+    }
+    return n;
+}
+
 pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) VMError!Value {
     while (self.frame_count > target_frame_count) {
         if (self.yielded) {
@@ -140,6 +150,13 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const val = env.get(name) orelse blk: {
                     if (func.env != null) {
                         if (self.globals.get(name)) |gval| break :blk gval;
+                    }
+                    const base = stripHygienicPrefix(name);
+                    if (base.len != name.len) {
+                        if (env.get(base)) |bval| break :blk bval;
+                        if (env != &self.globals) {
+                            if (self.globals.get(base)) |gval| break :blk gval;
+                        }
                     }
                     if (self.findSimilarName(name)) |suggestion| {
                         self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, suggestion });
@@ -755,7 +772,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             const sym = try constantAt(self, the_func, sym_idx);
                             if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                             const name = types.symbolName(sym);
-                            const val = env.get(name) orelse {
+                            const val = env.get(name) orelse val_blk: {
+                                const b = stripHygienicPrefix(name);
+                                if (b.len != name.len) {
+                                    if (env.get(b)) |bval| break :val_blk bval;
+                                }
                                 if (self.findSimilarName(name)) |sug| {
                                     self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
                                 } else {
@@ -772,7 +793,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         const sym = try constantAt(self, the_func, sym_idx);
                         if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                         const name = types.symbolName(sym);
-                        const val = env.get(name) orelse {
+                        const val = env.get(name) orelse val_blk2: {
+                            const b = stripHygienicPrefix(name);
+                            if (b.len != name.len) {
+                                if (env.get(b)) |bval| break :val_blk2 bval;
+                            }
                             if (self.findSimilarName(name)) |sug| {
                                 self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
                             } else {
@@ -875,7 +900,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const sym = try constantAt(self, func, sym_idx);
                     if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                     const name = types.symbolName(sym);
-                    callee = env.get(name) orelse {
+                    callee = env.get(name) orelse callee_blk: {
+                        const b = stripHygienicPrefix(name);
+                        if (b.len != name.len) {
+                            if (env.get(b)) |bval| break :callee_blk bval;
+                        }
                         if (self.findSimilarName(name)) |sug| {
                             self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
                         } else {

--- a/tests/scheme/hygiene/well-known-binding-capture.scm
+++ b/tests/scheme/hygiene/well-known-binding-capture.scm
@@ -1,0 +1,18 @@
+;; Regression test for #681: macro hygiene for template-introduced bindings
+;; named after built-in procedures (list, map, cons, etc.)
+
+(define-syntax capture-test
+  (syntax-rules ()
+    ((_ expr)
+     (let ((list (lambda (x y) (cons 'captured (cons x (cons y '()))))))
+       expr))))
+
+;; The user's (list 1 2) should call the global list, not the macro's binding
+(let ((result (capture-test (list 1 2))))
+  (if (equal? result '(1 2))
+    (display "PASS")
+    (begin
+      (display "FAIL: expected (1 2), got ")
+      (display result)
+      (exit 1))))
+(newline)


### PR DESCRIPTION
## Summary
Two related macro hygiene fixes:

**#681**: Template-introduced bindings named after built-in procedures (`list`, `cons`, `map`, etc.) no longer capture user references:
- Remove procedure names from `well_known_forms`, keeping only syntax keywords
- Add binding-position detection for `let`/`let*`/`letrec`/`letrec*` forms in templates
- Add `stripHygienicPrefix` fallback in VM's `get_global`/`call_global`/`tail_call_global`

**#729**: `let-syntax` macro template free variables now correctly capture definition-site bindings (R7RS 4.3.1 referential transparency):
- After expansion, scan for hygienic names matching captured locals and inject aliases so `resolveLocal` finds the definition-site binding

## Test plan
- [x] New regression test `tests/scheme/hygiene/well-known-binding-capture.scm`
- [x] All unit tests pass (423/423)
- [x] All Scheme tests pass (205/205, 0 fail)
- [x] R7RS suite: **1392 pass, 0 fail** (previously 1391 pass, 1 fail — the pre-existing 4.3 Macros failure is now fixed)

Fixes #681
Fixes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)