### PR TITLE
Implement eval environment-specifier and environment procedures

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -46,6 +46,7 @@ pub const Compiler = struct {
     macros: std.StringHashMap(Value),
     globals: ?*std.StringHashMap(Value) = null,
     lib_env: ?*std.StringHashMap(Value) = null,
+    restricted_env: bool = false, // true for restricted environments (null-environment, environment)
     scope_depth: u16 = 0,
     next_register: u16 = 0,
     parent: ?*Compiler = null,
@@ -96,6 +97,7 @@ pub const Compiler = struct {
             .macros = std.StringHashMap(Value).init(parent.gc.allocator),
             .globals = parent.globals,
             .lib_env = parent.lib_env,
+            .restricted_env = parent.restricted_env,
             .parent = parent,
         };
     }
@@ -269,6 +271,7 @@ pub const Compiler = struct {
         // Lower AST to IR, run analysis and optimizations, then emit bytecode.
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
+        ir.restricted_env = self.restricted_env;
         defer ir.deinit();
         var root = try ir_mod.lowerWithMacros(&ir, expr_root, &self.macros);
 
@@ -545,6 +548,7 @@ pub const Compiler = struct {
             // Lower each body expression through IR
             var ir = ir_mod.IR.init(child.gc.allocator);
             ir.globals = child.globals;
+            ir.restricted_env = child.restricted_env;
             defer ir.deinit();
             var root = try ir_mod.lowerWithMacros(&ir, expr, &child.macros);
             ir_mod.markTailPositions(root, rest == types.NIL);
@@ -604,6 +608,7 @@ pub const Compiler = struct {
         // Lower the value expression through IR for optimization
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
+        ir.restricted_env = self.restricted_env;
         defer ir.deinit();
         var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
         ir_mod.identifyPrimitives(val_root);
@@ -653,6 +658,7 @@ pub const Compiler = struct {
         // Lower the value expression through IR for optimization
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
+        ir.restricted_env = self.restricted_env;
         defer ir.deinit();
         var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
         ir_mod.identifyPrimitives(val_root);
@@ -798,6 +804,7 @@ pub const Compiler = struct {
             // Lower each expression through the IR pipeline.
             var ir = ir_mod.IR.init(self.gc.allocator);
             ir.globals = self.globals;
+            ir.restricted_env = self.restricted_env;
             defer ir.deinit();
             var root = try ir_mod.lowerWithMacros(&ir, expr, &self.macros);
             ir_mod.markTailPositions(root, false);
@@ -1456,6 +1463,7 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
     var c = try Compiler.init(gc);
     c.globals = env;
     c.lib_env = env;
+    c.restricted_env = true;
     var ok = false;
     defer {
         if (!ok) Compiler.unrootFunction(gc, c.func);

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -243,6 +243,13 @@ fn referencesYoung(obj: *Object) bool {
                 if (isYoungPointer(uv)) return true;
             }
         },
+        .scheme_environment => {
+            const se = obj.as(types.SchemeEnvironment);
+            var vit = se.env.valueIterator();
+            while (vit.next()) |val| {
+                if (isYoungPointer(val.*)) return true;
+            }
+        },
         .symbol, .string, .native_fn, .flonum, .port, .complex, .bytevector, .bignum, .record_type, .ffi_library, .file_info, .user_info, .group_info, .directory_object, .random_source, .srfi18_time => {},
     }
     return false;
@@ -443,6 +450,11 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
             const nc = obj.as(types.NativeClosure);
             for (nc.upvalues) |uv| markValue(gc, uv);
         },
+        .scheme_environment => {
+            const se = obj.as(types.SchemeEnvironment);
+            var vit = se.env.valueIterator();
+            while (vit.next()) |val| markValue(gc, val.*);
+        },
         .symbol, .string, .native_fn, .flonum, .port, .complex, .bytevector, .bignum, .record_type, .ffi_library, .file_info, .user_info, .group_info, .directory_object, .random_source, .srfi18_time => {},
     }
 }
@@ -640,6 +652,11 @@ pub fn markValue(gc: *GC, v: Value) void {
             const nc = obj.as(types.NativeClosure);
             for (nc.upvalues) |uv| markValue(gc, uv);
         },
+        .scheme_environment => {
+            const se = obj.as(types.SchemeEnvironment);
+            var vit = se.env.valueIterator();
+            while (vit.next()) |val| markValue(gc, val.*);
+        },
         .symbol, .string, .native_fn, .flonum, .port, .complex, .bytevector, .bignum, .file_info, .user_info, .group_info, .directory_object, .random_source, .srfi18_time => {},
     }
 }
@@ -739,6 +756,7 @@ fn objectSize(obj: *Object) usize {
         .mutex => @sizeOf(types.Mutex),
         .condition_variable => @sizeOf(types.ConditionVariable),
         .srfi18_time => @sizeOf(types.Srfi18Time),
+        .scheme_environment => @sizeOf(types.SchemeEnvironment),
     };
 }
 
@@ -950,6 +968,14 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
         },
         .srfi18_time => {
             gc.allocator.destroy(obj.as(types.Srfi18Time));
+        },
+        .scheme_environment => {
+            const se = obj.as(types.SchemeEnvironment);
+            if (se.owned) {
+                se.env.deinit();
+                gc.allocator.destroy(se.env);
+            }
+            gc.allocator.destroy(se);
         },
     }
 }

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -137,6 +137,7 @@ pub const IR = struct {
     allocator: std.mem.Allocator,
     nodes: std.ArrayList(*Node),
     globals: ?*const std.StringHashMap(Value) = null,
+    restricted_env: bool = false, // true when compiling in a restricted environment (environment procedure)
 
     pub fn init(allocator: std.mem.Allocator) IR {
         return .{
@@ -147,7 +148,12 @@ pub const IR = struct {
 
     fn isRedefined(self: *const IR, name: []const u8) bool {
         const g = self.globals orelse return false;
-        const val = g.get(name) orelse return false;
+        const val = g.get(name) orelse {
+            // In a restricted environment, missing names mean "not available".
+            // Return true so the IR does not inline the primitive; the VM
+            // will raise "undefined variable" at runtime.
+            return self.restricted_env;
+        };
         if (!types.isPointer(val)) return true;
         const obj = types.toObject(val);
         if (obj.tag != .native_fn) return true;

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1011,6 +1011,21 @@ pub const GC = struct {
         return types.makePointer(@ptrCast(gi));
     }
 
+    pub fn allocEnvironment(self: *GC, env_map: *std.StringHashMap(Value), owned: bool) !Value {
+        try self.maybeCollect();
+        const se = try self.allocator.create(types.SchemeEnvironment);
+        se.* = .{
+            .header = .{ .tag = .scheme_environment },
+            .env = env_map,
+            .owned = owned,
+        };
+        self.bytes_allocated += @sizeOf(types.SchemeEnvironment);
+
+        self.profileAlloc(@sizeOf(types.SchemeEnvironment));
+        self.trackObject(&se.header);
+        return types.makePointer(@ptrCast(se));
+    }
+
     pub fn allocDirectoryObject(self: *GC, dir: *anyopaque, include_dotfiles: bool) !Value {
         try self.maybeCollect();
         const d = try self.allocator.create(types.DirectoryObject);
@@ -1278,6 +1293,7 @@ pub const GC = struct {
             .user_info,
             .group_info,
             .directory_object,
+            .scheme_environment,
             => return error.UncopyableType,
         };
     }

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -198,7 +198,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     // If an environment specifier is provided, compile in that environment
     if (args.len > 1 and types.isEnvironment(args[1])) {
         const se = types.toEnvironment(args[1]);
-        const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env) catch return PrimitiveError.TypeError;
+        const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env) catch return PrimitiveError.TypeError; // bare-ok: compile error
         var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
         compiler_mod.Compiler.unrootFunction(gc, func);
         gc.pushRoot(&closure_val) catch return PrimitiveError.OutOfMemory;
@@ -243,14 +243,12 @@ fn environmentFn(args: []const Value) PrimitiveError!Value {
     env_map.* = std.StringHashMap(Value).init(gc.allocator);
 
     for (args) |import_set| {
-        const lib_name = library_mod.libraryNameToString(gc.allocator, import_set) catch return PrimitiveError.TypeError;
+        const lib_name = library_mod.libraryNameToString(gc.allocator, import_set) catch return PrimitiveError.TypeError; // bare-ok: invalid import set
         defer gc.allocator.free(lib_name);
 
-        // Try loading the library if not already registered
         const vm_library = @import("vm_library.zig");
-        vm_library.ensureLibraryLoaded(vm, import_set, lib_name) catch return PrimitiveError.TypeError;
-
-        const lib = vm.libraries.get(lib_name) orelse return PrimitiveError.TypeError;
+        vm_library.ensureLibraryLoaded(vm, import_set, lib_name) catch return PrimitiveError.TypeError; // bare-ok: library load failure
+        const lib = vm.libraries.get(lib_name) orelse return PrimitiveError.TypeError; // bare-ok: library not found
         var it = lib.exports.iterator();
         while (it.next()) |entry| {
             env_map.put(entry.key_ptr.*, entry.value_ptr.*) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -193,8 +193,27 @@ fn getEnvVars(args: []const Value) PrimitiveError!Value {
 fn evalFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
-    // args[0] = expression, args[1] = environment (optional, ignored)
     const expr = args[0];
+
+    // If an environment specifier is provided, compile in that environment
+    if (args.len > 1 and types.isEnvironment(args[1])) {
+        const se = types.toEnvironment(args[1]);
+        const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env) catch return PrimitiveError.TypeError;
+        var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
+        compiler_mod.Compiler.unrootFunction(gc, func);
+        gc.pushRoot(&closure_val) catch return PrimitiveError.OutOfMemory;
+        defer gc.popRoot();
+
+        const result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
+            return switch (err) {
+                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
+                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
+                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
+                else => PrimitiveError.TypeError, // bare-ok: catch fallback
+            };
+        };
+        return result;
+    }
 
     const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, &vm.globals) catch return PrimitiveError.TypeError;
     var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
@@ -202,7 +221,6 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&closure_val) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
 
-    // Use callWithArgs to properly nest within the current execution
     const result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
         return switch (err) {
             vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
@@ -215,10 +233,31 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn environmentFn(args: []const Value) PrimitiveError!Value {
-    // (environment import-set ...) — return a value representing an environment
-    // Simplified: return a dummy value, eval ignores the environment arg
-    _ = args;
-    return types.VOID;
+    // (environment import-set ...) — R7RS 6.12
+    // Create a new environment containing bindings from the given import sets.
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const library_mod = @import("library.zig");
+
+    const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;
+    env_map.* = std.StringHashMap(Value).init(gc.allocator);
+
+    for (args) |import_set| {
+        const lib_name = library_mod.libraryNameToString(gc.allocator, import_set) catch return PrimitiveError.TypeError;
+        defer gc.allocator.free(lib_name);
+
+        // Try loading the library if not already registered
+        const vm_library = @import("vm_library.zig");
+        vm_library.ensureLibraryLoaded(vm, import_set, lib_name) catch return PrimitiveError.TypeError;
+
+        const lib = vm.libraries.get(lib_name) orelse return PrimitiveError.TypeError;
+        var it = lib.exports.iterator();
+        while (it.next()) |entry| {
+            env_map.put(entry.key_ptr.*, entry.value_ptr.*) catch return PrimitiveError.OutOfMemory;
+        }
+    }
+
+    return gc.allocEnvironment(env_map, true) catch return PrimitiveError.OutOfMemory;
 }
 
 // ---------------------------------------------------------------------------
@@ -337,19 +376,38 @@ fn parameterSetDirectFn(args: []const Value) PrimitiveError!Value {
 
 fn interactionEnvironmentFn(args: []const Value) PrimitiveError!Value {
     _ = args;
-    return types.VOID;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    return gc.allocEnvironment(&vm.globals, false) catch return PrimitiveError.OutOfMemory;
 }
 
 fn nullEnvironmentFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("null-environment", "integer", args[0]);
     const version = types.toFixnum(args[0]);
     if (version != 5 and version != 7) return primitives.typeError("null-environment", "5 or 7", args[0]);
-    return types.VOID;
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+
+    const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;
+    env_map.* = std.StringHashMap(Value).init(gc.allocator);
+    return gc.allocEnvironment(env_map, true) catch return PrimitiveError.OutOfMemory;
 }
 
 fn schemeReportEnvironmentFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("scheme-report-environment", "integer", args[0]);
     const version = types.toFixnum(args[0]);
     if (version != 5 and version != 7) return primitives.typeError("scheme-report-environment", "5 or 7", args[0]);
-    return types.VOID;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+
+    const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;
+    env_map.* = std.StringHashMap(Value).init(gc.allocator);
+
+    // Import (scheme base) bindings
+    if (vm.libraries.get("scheme.base")) |lib| {
+        var it = lib.exports.iterator();
+        while (it.next()) |entry| {
+            env_map.put(entry.key_ptr.*, entry.value_ptr.*) catch return PrimitiveError.OutOfMemory;
+        }
+    }
+    return gc.allocEnvironment(env_map, true) catch return PrimitiveError.OutOfMemory;
 }

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -724,6 +724,9 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
             .random_source => {
                 try writer.writeAll("#<random-source>");
             },
+            .scheme_environment => {
+                try writer.writeAll("#<environment>");
+            },
         }
     } else {
         try writer.writeAll("#<unknown>");

--- a/src/types.zig
+++ b/src/types.zig
@@ -137,6 +137,7 @@ pub const ObjectTag = enum(u6) {
     condition_variable = 33,
     srfi18_time = 34,
     native_closure = 35,
+    scheme_environment = 36,
 };
 
 pub const Object = struct {
@@ -594,6 +595,12 @@ pub const RandomSource = struct {
     prng: std.Random.DefaultPrng,
 };
 
+pub const SchemeEnvironment = struct {
+    header: Object,
+    env: *std.StringHashMap(Value),
+    owned: bool = true, // false for interaction-environment (don't free the map)
+};
+
 // ---------------------------------------------------------------------------
 // Type predicates on Value
 // ---------------------------------------------------------------------------
@@ -814,6 +821,14 @@ pub fn toDirectoryObject(v: Value) *DirectoryObject {
 
 pub fn isRandomSource(v: Value) bool {
     return isPointer(v) and toObject(v).tag == .random_source;
+}
+
+pub fn isEnvironment(v: Value) bool {
+    return isPointer(v) and toObject(v).tag == .scheme_environment;
+}
+
+pub fn toEnvironment(v: Value) *SchemeEnvironment {
+    return toObject(v).as(SchemeEnvironment);
 }
 
 pub fn isNumber(v: Value) bool {

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -67,6 +67,13 @@ pub fn handleImport(vm: *VM, args: Value) VMError!Value {
     return handleImportInto(vm, &vm.globals, args);
 }
 
+/// Ensure a library is loaded and registered. If already in vm.libraries, no-op.
+/// Otherwise tries to load from an .sld file. Used by `environment` procedure.
+pub fn ensureLibraryLoaded(vm: *VM, import_set: Value, lib_name: []const u8) !void {
+    if (vm.libraries.get(lib_name) != null) return;
+    tryLoadLibraryFromFile(vm, import_set) catch return error.CompileError;
+}
+
 fn processImportSet(vm: *VM, target: *std.StringHashMap(Value), import_set: Value) !void {
     if (!types.isPair(import_set)) return error.InvalidSyntax;
 

--- a/tests/scheme/smoke/eval-environment.scm
+++ b/tests/scheme/smoke/eval-environment.scm
@@ -1,0 +1,31 @@
+;; Regression test for #691: eval must honor its environment-specifier argument
+
+(import (scheme base) (scheme write) (scheme eval))
+
+;; null-environment should not have procedure bindings
+(guard (exn (#t 'ok))
+  (eval '(+ 1 2) (null-environment 5))
+  (display "FAIL: null-environment should not have +") (newline) (exit 1))
+
+;; environment with (scheme base) should work
+(let ((result (eval '(+ 1 2) (environment '(scheme base)))))
+  (unless (= result 3)
+    (display "FAIL: environment (scheme base) gave wrong result") (newline) (exit 1)))
+
+;; scheme-report-environment should work like (scheme base)
+(let ((result (eval '(* 6 7) (scheme-report-environment 5))))
+  (unless (= result 42)
+    (display "FAIL: scheme-report-environment gave wrong result") (newline) (exit 1)))
+
+;; interaction-environment should see user defines
+(define x 42)
+(let ((result (eval 'x (interaction-environment))))
+  (unless (= result 42)
+    (display "FAIL: interaction-environment did not see define") (newline) (exit 1)))
+
+;; environment? predicate via type check
+(let ((e (environment '(scheme base))))
+  (unless (eval '(+ 10 20) e)
+    (display "FAIL: eval in environment returned false") (newline) (exit 1)))
+
+(display "PASS") (newline)


### PR DESCRIPTION
## Summary
- Add `SchemeEnvironment` heap type wrapping a `StringHashMap(Value)` for restricted evaluation environments
- `eval` now checks its second argument and compiles against the restricted environment when provided
- Implement `environment`, `null-environment`, `scheme-report-environment`, and `interaction-environment` per R7RS
- Add `restricted_env` flag to compiler/IR to prevent primitive inlining in restricted environments

## Test plan
- [x] New regression test `tests/scheme/smoke/eval-environment.scm` — tests null-environment (errors on `+`), environment with imports (works), and interaction-environment (sees user defines)
- [x] All unit tests pass
- [x] R7RS eval tests at lines 1942-1955 pass (environment with scheme base, inexact, multiple imports)

Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)