### PR TITLE
Fix data race in symbol table marking during SRFI-18 threading

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -469,16 +469,17 @@ fn markRoots(gc: *GC) void {
     // Mark active FFI callback closures
     const ffi_cb = @import("ffi_callback.zig");
     ffi_cb.markCallbackRoots(gc);
-    // Mark interned symbols. Use tryLock to avoid deadlock when GC is
-    // triggered from within allocSymbol (which already holds the mutex).
-    // If we can't get the lock, symbol values are already reachable via
-    // the globals map -- they won't be collected.
-    const got_sym_lock = memory_mod.symbol_mutex.tryLock();
+    // Mark interned symbols. Use a blocking lock to prevent iterating
+    // while a child thread's put() rehashes the HashMap. Deadlock is not
+    // possible: the parent thread never holds symbol_mutex (only child
+    // threads acquire it in allocSymbol when shared_symbols != null),
+    // and allocSymbol does not call maybeCollect.
+    memory_mod.spinLock(&memory_mod.symbol_mutex);
+    defer memory_mod.spinUnlock(&memory_mod.symbol_mutex);
     var it = gc.symbols.valueIterator();
     while (it.next()) |v| {
         markValue(gc, v.*);
     }
-    if (got_sym_lock) memory_mod.symbol_mutex.unlock();
     // Mark VM-owned roots (live registers, call frames, handlers, winds).
     if (gc.root_marker) |mark| mark(gc);
 }

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -52,10 +52,10 @@ pub const GcStats = struct {
 
 pub var symbol_mutex: std.atomic.Mutex = .unlocked;
 
-fn spinLock(m: *std.atomic.Mutex) void {
+pub fn spinLock(m: *std.atomic.Mutex) void {
     while (!m.tryLock()) std.atomic.spinLoopHint();
 }
-fn spinUnlock(m: *std.atomic.Mutex) void {
+pub fn spinUnlock(m: *std.atomic.Mutex) void {
     m.unlock();
 }
 


### PR DESCRIPTION
## Summary
- Replace `tryLock` with blocking `spinLock` in `markRoots` to prevent iterating the symbol HashMap while a child thread's `put()` rehashes it
- Make `spinLock`/`spinUnlock` public in `memory.zig` so `gc_collect.zig` can use them
- Deadlock is not possible: the parent thread never holds `symbol_mutex` (only child threads acquire it in `allocSymbol` when `shared_symbols != null`), and `allocSymbol` does not call `maybeCollect`

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1599 pass, 0 fail)
- [ ] CI passes on all platforms

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)