### PR TITLE
Add GC write barrier in vector constant deserialization

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -411,9 +411,11 @@ fn readConstant(r: *Reader, gc: *GC, all_funcs: []*Function, depth: u32) !Value 
             var vec_val = gc.allocVectorFill(len, types.NIL) catch return BytecodeError.OutOfMemory;
             try gc.pushRoot(&vec_val);
             defer gc.popRoot();
-            const vec = types.toVector(vec_val);
             for (0..len) |i| {
-                vec.data[i] = try readConstant(r, gc, all_funcs, depth + 1);
+                const elem = try readConstant(r, gc, all_funcs, depth + 1);
+                const vec = types.toVector(vec_val);
+                vec.data[i] = elem;
+                gc.writeBarrier(types.toObject(vec_val), elem);
             }
             return vec_val;
         },


### PR DESCRIPTION
## Summary
- Add `gc.writeBarrier()` call after each element store during vector deserialization in `bytecode_file.zig`
- Re-derive the vector pointer inside the loop since GC may relocate the rooted `vec_val`
- Prevents old-to-young references from being invisible to the minor collector

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1599 pass, 0 fail)
- [ ] CI passes on all platforms

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)