### PR TITLE
Validate let-syntax bindings have transformer spec

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1340,7 +1340,9 @@ pub const Compiler = struct {
 
             const keyword = types.car(binding);
             if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
-            const transformer_spec = types.car(types.cdr(binding));
+            const binding_rest = types.cdr(binding);
+            if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
+            const transformer_spec = types.car(binding_rest);
             const transformer = passthrough.parseSyntaxRules(self, transformer_spec) catch return CompileError.InvalidSyntax;
 
             const name = types.symbolName(keyword);

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -289,3 +289,13 @@ test "hygiene: multiple macro invocations are independent" {
     try std.testing.expectEqual(@as(i64, 10), types.toFixnum(types.car(result)));
     try std.testing.expectEqual(@as(i64, 10), types.toFixnum(types.car(types.cdr(result))));
 }
+
+test "let-syntax rejects malformed binding without transformer" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = vm.eval("(let-syntax ((my-macro)) 1)");
+    try std.testing.expectError(error.CompileError, result);
+}


### PR DESCRIPTION
## Summary
- Add pair check before extracting transformer spec from let-syntax bindings, matching the existing pattern in `compileDefineSyntax`
- Without this, `(let-syntax ((keyword)) body)` dereferences NIL as a pointer (UB/crash)
- Add regression test that malformed bindings return `CompileError`

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] New regression test: `let-syntax rejects malformed binding without transformer`
- [ ] CI passes on all platforms

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)