### PR TITLE
Fix multi-arg bignum division to process all divisors

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -725,7 +725,12 @@ fn divFn(args: []const Value) PrimitiveError!Value {
     if (anyBignum(args) and !anyFlonum(args) and !anyRational(args)) {
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
         var num_val = args[0];
+        var den_val: Value = types.makeFixnum(1);
         gc.extra_roots.append(gc.allocator, num_val) catch return PrimitiveError.OutOfMemory;
+        defer {
+            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
+        }
+        gc.extra_roots.append(gc.allocator, den_val) catch return PrimitiveError.OutOfMemory;
         defer {
             if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
         }
@@ -735,12 +740,14 @@ fn divFn(args: []const Value) PrimitiveError!Value {
             if (bignum_mod.isZero(rem)) {
                 num_val = bignum_mod.quotient(gc, num_val, a) catch return PrimitiveError.OutOfMemory;
                 num_val = bignum_mod.demote(num_val);
-                gc.extra_roots.items[gc.extra_roots.items.len - 1] = num_val;
+                gc.extra_roots.items[gc.extra_roots.items.len - 2] = num_val;
             } else {
-                return makeRationalReduced(gc, num_val, a);
+                den_val = bignum_mod.mul(gc, den_val, a) catch return PrimitiveError.OutOfMemory;
+                gc.extra_roots.items[gc.extra_roots.items.len - 1] = den_val;
             }
         }
-        return num_val;
+        if (types.isFixnum(den_val) and types.toFixnum(den_val) == 1) return num_val;
+        return makeRationalReduced(gc, num_val, den_val);
     }
     // At least one flonum or bignum — convert to float
     var result = try toF64Ext(args[0]);

--- a/tests/scheme/smoke/bignum-division-multi-arg.scm
+++ b/tests/scheme/smoke/bignum-division-multi-arg.scm
@@ -1,0 +1,24 @@
+;; Regression test for #739: (/ bignum bignum bignum) stops after first
+;; non-exact division, ignoring remaining arguments.
+
+(import (scheme base) (scheme write))
+
+;; (/ 2^100 3 7) should be 2^100/21, not 2^100/3
+(let ((result (/ (expt 2 100) 3 7)))
+  (unless (and (exact? result)
+               (= (denominator result) 21))
+    (display "FAIL: (/ (expt 2 100) 3 7) denominator should be 21, got ")
+    (display (denominator result))
+    (newline)
+    (exit 1)))
+
+;; (/ 60 3 4) = 5 (exact division through all args)
+(let ((result (/ (expt 2 60) (expt 2 20) (expt 2 10))))
+  (unless (= result (expt 2 30))
+    (display "FAIL: (/ 2^60 2^20 2^10) should be 2^30, got ")
+    (display result)
+    (newline)
+    (exit 1)))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary
- Track accumulated denominator across all args instead of returning a rational immediately on the first non-exact division
- `(/ (expt 2 100) 3 7)` now correctly produces `2^100/21` instead of `2^100/3`
- Add regression test

## Test plan
- [x] All unit tests pass
- [x] Full Scheme test suite passes (1600 pass, 0 fail)
- [x] New test: `bignum-division-multi-arg.scm`
- [ ] CI passes

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)