### PR TITLE
Fix toRationalParts to return null for non-numeric types

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -70,7 +70,7 @@ fn toRationalParts(v: Value) ?RatParts {
         if (!types.isFixnum(r.numerator) or !types.isFixnum(r.denominator)) return null;
         return .{ .num = types.toFixnum(r.numerator), .den = types.toFixnum(r.denominator) };
     }
-    return .{ .num = 0, .den = 1 };
+    return null;
 }
 
 fn allocRationalRooted(gc: *@import("memory.zig").GC, n: i64, d: i64) PrimitiveError!Value {


### PR DESCRIPTION
## Summary
- Change `toRationalParts` fallthrough from `{0, 1}` to `null` so non-numeric values signal type errors instead of being silently treated as zero
- All callers already handle `null` via `orelse` or explicit null checks

## Test plan
- [x] All tests pass (1600 pass, 0 fail)
- [ ] CI

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)