### PR TITLE
Fix minInt negation overflow in abs, unary minus, and magnitude

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -430,8 +430,8 @@ fn sub(args: []const Value) PrimitiveError!Value {
         var d = first_parts.den;
         if (args.len == 1) {
             // Negate
-            if (d == 1) return types.makeFixnum(-n);
-            return gc.allocRational(types.makeFixnum(-n), types.makeFixnum(d)) catch return PrimitiveError.OutOfMemory;
+            if (d == 1) return makeFixnumChecked(-n);
+            return allocRationalRooted(gc, -n, d);
         }
         for (args[1..]) |a| {
             if (types.isFlonum(a)) {
@@ -1046,7 +1046,8 @@ fn absVal(args: []const Value) PrimitiveError!Value {
         if (types.isFixnum(r.numerator)) {
             const n = types.toFixnum(r.numerator);
             if (n >= 0) return args[0];
-            return gc.allocRational(types.makeFixnum(-n), r.denominator) catch return PrimitiveError.OutOfMemory;
+            const abs_num = try makeFixnumChecked(-n);
+            return gc.allocRational(abs_num, r.denominator) catch return PrimitiveError.OutOfMemory;
         }
         if (types.isBignum(r.numerator)) {
             if (bignum_mod.isNegative(r.numerator)) {

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1139,7 +1139,7 @@ fn magnitudeFn(args: []const Value) PrimitiveError!Value {
     }
     if (types.isFixnum(args[0])) {
         const n = types.toFixnum(args[0]);
-        return if (n < 0) types.makeFixnum(-n) else args[0];
+        return if (n < 0) try arith.makeFixnumChecked(-n) else args[0];
     }
     if (types.isFlonum(args[0])) {
         return makeFlonumVal(@abs(types.toFlonum(args[0])));


### PR DESCRIPTION
## Summary
- Use `makeFixnumChecked` for negation of fixnum values that could be `minInt(i48)`, auto-promoting to bignum when the result overflows
- Fixes `(abs -140737488355328/3)` returning negative, `(- -140737488355328/3)` wrapping, and `(magnitude -140737488355328)` returning negative

## Test plan
- [x] All tests pass (1600 pass, 0 fail)
- [ ] CI

Closes #744, closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)