### PR TITLE
Fix angle to return pi for -0.0

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1165,7 +1165,7 @@ fn angleFn(args: []const Value) PrimitiveError!Value {
     }
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
-        return makeFlonumVal(if (f >= 0.0) 0.0 else std.math.pi);
+        return makeFlonumVal(std.math.atan2(@as(f64, 0.0), f));
     }
     if (types.isBignum(args[0])) {
         return makeFlonumVal(if (bignum_mod.isNegative(args[0])) std.math.pi else 0.0);


### PR DESCRIPTION
## Summary
- Use `atan2(0.0, f)` instead of `f >= 0.0` comparison for flonum angle, correctly handling -0.0
- `(angle -0.0)` now returns pi per R7RS

## Test plan
- [x] All tests pass (1600 pass, 0 fail)
- [ ] CI

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)