### PR TITLE
Fix two-argument log to return complex for negative first argument

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -731,6 +731,14 @@ fn logFn(args: []const Value) PrimitiveError!Value {
     // (log z base)
     const z = try toF64(args[0]);
     const base = try toF64(args[1]);
+    if (z < 0.0) {
+        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const mag = @sqrt(z * z);
+        const log_re = @log(mag) / @log(base);
+        const log_im = std.math.pi / @log(base);
+        if (@abs(log_im) < 1e-15) return makeFlonumVal(log_re);
+        return gc.allocComplex(log_re, log_im) catch return PrimitiveError.OutOfMemory;
+    }
     return makeFlonumVal(@log(z) / @log(base));
 }
 


### PR DESCRIPTION
## Summary
- When `z < 0` in `(log z base)`, compute complex log properly instead of returning NaN
- `(log -1 10)` now returns `0.0+1.364...i` instead of `+nan.0`

## Test plan
- [x] All tests pass (1600 pass, 0 fail)
- [ ] CI

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)