### PR TITLE
Fix three compiler bugs: constant limit, apply upvalue, no_collect leak

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -137,7 +137,7 @@ pub const Compiler = struct {
         for (self.func.constants.items, 0..) |c, i| {
             if (c == value) return @intCast(i);
         }
-        if (self.func.constants.items.len >= 65535) return CompileError.TooManyConstants;
+        if (self.func.constants.items.len >= 65536) return CompileError.TooManyConstants;
         self.func.constants.append(self.gc.allocator, value) catch return CompileError.OutOfMemory;
         return @intCast(self.func.constants.items.len - 1);
     }
@@ -1155,7 +1155,10 @@ pub const Compiler = struct {
                     };
                 };
                 var expanded_root = expanded;
-                try self.gc.pushRoot(&expanded_root);
+                self.gc.pushRoot(&expanded_root) catch {
+                    self.gc.no_collect -= 1;
+                    return CompileError.OutOfMemory;
+                };
                 defer self.gc.popRoot();
                 self.gc.no_collect -= 1;
                 const saved_locals_len = self.locals.items.len;
@@ -1203,7 +1206,9 @@ pub const Compiler = struct {
         }
 
         if (is_tail and types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "apply")) {
-            if (self.resolveLocal(types.symbolName(head)) == null) {
+            if (self.resolveLocal(types.symbolName(head)) == null and
+                (try self.resolveUpvalue(types.symbolName(head))) == null)
+            {
                 return passthrough.compileApplyTail(self, expr, dst);
             }
         }


### PR DESCRIPTION
## Summary
- Fix off-by-one in `addConstant`: allow 65536 constants (u16 max index is 65535) (#756)
- Check `resolveUpvalue` before applying the `apply` tail-call optimization (#760)
- Decrement `no_collect` before propagating `pushRoot` OOM after macro expansion (#761)

## Test plan
- [x] All tests pass (1600 pass, 0 fail)
- [ ] CI

Closes #756, closes #760, closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)