### PR TITLE
Apply exactness prefix to complex number parsing in string->number

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1047,10 +1047,12 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
 
             // Pure imaginary: +i, -i
             if (std.mem.eql(u8, body, "+")) {
-                return gc.allocComplex(0.0, 1.0) catch return PrimitiveError.OutOfMemory;
+                const c = gc.allocComplex(0.0, 1.0) catch return PrimitiveError.OutOfMemory;
+                return applyExactness(gc, c, exactness);
             }
             if (std.mem.eql(u8, body, "-")) {
-                return gc.allocComplex(0.0, -1.0) catch return PrimitiveError.OutOfMemory;
+                const c = gc.allocComplex(0.0, -1.0) catch return PrimitiveError.OutOfMemory;
+                return applyExactness(gc, c, exactness);
             }
 
             // Find the split point: last +/- that isn't at position 0 and isn't in an exponent
@@ -1081,13 +1083,15 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
                         return types.FALSE;
                     };
                 }
-                return gc.allocComplex(real_val, imag_val) catch return PrimitiveError.OutOfMemory;
+                const c = gc.allocComplex(real_val, imag_val) catch return PrimitiveError.OutOfMemory;
+                return applyExactness(gc, c, exactness);
             } else {
                 // No split found — pure imaginary like +3i or -2.5i
                 const imag_val = std.fmt.parseFloat(f64, body) catch {
                     return types.FALSE;
                 };
-                return gc.allocComplex(0.0, imag_val) catch return PrimitiveError.OutOfMemory;
+                const c = gc.allocComplex(0.0, imag_val) catch return PrimitiveError.OutOfMemory;
+                return applyExactness(gc, c, exactness);
             }
         }
     }


### PR DESCRIPTION
## Summary
- All four complex number return paths in `string->number` now pass through `applyExactness`
- `#e` and `#i` prefixes are now respected for complex literals like `#i1+2i`

## Test plan
- [x] All tests pass (1600 pass, 0 fail)
- [ ] CI

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)