### PR TITLE
Make REPL Ctrl-C show fresh prompt instead of exiting

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -419,6 +419,14 @@ pub fn repl(vm: *vm_mod.VM) !void {
     while (true) {
         const prompt: [*:0]const u8 = if (input_buf.items.len > 0) "  ... " else "kaappi> ";
         const line_ptr = ln.linenoise(prompt) orelse {
+            const err = std.c._errno().*;
+            if (err == @intFromEnum(std.posix.E.AGAIN)) {
+                if (input_buf.items.len > 0) {
+                    input_buf.clearRetainingCapacity();
+                }
+                writeStdout("\n");
+                continue;
+            }
             if (input_buf.items.len > 0) {
                 input_buf.clearRetainingCapacity();
                 writeStdout("\n");


### PR DESCRIPTION
## Summary
- Check `errno` after linenoise returns NULL to distinguish Ctrl-C (`EAGAIN`) from Ctrl-D (`ENOENT`)
- Ctrl-C now shows a fresh prompt (and clears partial input if any)
- Ctrl-D still exits the REPL as before
- Matches standard REPL behavior (Python, Node, etc.)

## Test plan
- [x] All tests pass (1600 pass, 0 fail)
- [ ] CI

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)