### PR TITLE
Trace environment Value in Function/Transformer to prevent use-after-free

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -46,6 +46,7 @@ pub const Compiler = struct {
     macros: std.StringHashMap(Value),
     globals: ?*std.StringHashMap(Value) = null,
     lib_env: ?*std.StringHashMap(Value) = null,
+    lib_env_val: Value = types.NIL,
     restricted_env: bool = false, // true for restricted environments (null-environment, environment)
     scope_depth: u16 = 0,
     next_register: u16 = 0,
@@ -86,6 +87,7 @@ pub const Compiler = struct {
     pub fn initChild(parent: *Compiler) CompileError!Compiler {
         const func = parent.gc.allocFunction() catch return CompileError.OutOfMemory;
         func.env = parent.lib_env;
+        func.env_val = parent.lib_env_val;
         func.source_line = parent.func.source_line;
         func.source_name = parent.func.source_name;
         parent.gc.extra_roots.append(parent.gc.allocator, types.makePointer(@ptrCast(func))) catch return CompileError.OutOfMemory;
@@ -97,6 +99,7 @@ pub const Compiler = struct {
             .macros = std.StringHashMap(Value).init(parent.gc.allocator),
             .globals = parent.globals,
             .lib_env = parent.lib_env,
+            .lib_env_val = parent.lib_env_val,
             .restricted_env = parent.restricted_env,
             .parent = parent,
         };
@@ -1266,6 +1269,7 @@ pub const Compiler = struct {
         const tx = types.toObject(transformer).as(types.Transformer);
         if (self.lib_env) |env| {
             tx.def_env = env;
+            tx.def_env_val = self.lib_env_val;
         }
 
         // Store in macro table
@@ -1466,10 +1470,11 @@ pub fn compileExpressionWithMacrosAt(gc: *memory.GC, expr: Value, vm_macros: *st
     return c.func;
 }
 
-pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.StringHashMap(Value), env: *std.StringHashMap(Value)) CompileError!*types.Function {
+pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.StringHashMap(Value), env: *std.StringHashMap(Value), env_val: Value) CompileError!*types.Function {
     var c = try Compiler.init(gc);
     c.globals = env;
     c.lib_env = env;
+    c.lib_env_val = env_val;
     c.restricted_env = true;
     var ok = false;
     defer {
@@ -1482,6 +1487,7 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
     }
     try c.compile(expr);
     c.func.env = env;
+    c.func.env_val = env_val;
     var out_it = c.macros.iterator();
     while (out_it.next()) |entry| {
         vm_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return CompileError.OutOfMemory;

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -563,6 +563,7 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
             const tx = types.toObject(transformer).as(types.Transformer);
             if (self.lib_env) |env| {
                 tx.def_env = env;
+                tx.def_env_val = self.lib_env_val;
             }
             self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
         } else {

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -135,6 +135,7 @@ fn referencesYoung(obj: *Object) bool {
             for (tx.templates) |tmpl| {
                 if (isYoungPointer(tmpl)) return true;
             }
+            if (isYoungPointer(tx.def_env_val)) return true;
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);
@@ -236,6 +237,7 @@ fn referencesYoung(obj: *Object) bool {
                     if (isYoungPointer(c)) return true;
                 }
             }
+            if (isYoungPointer(func.env_val)) return true;
         },
         .native_closure => {
             const nc = obj.as(types.NativeClosure);
@@ -381,6 +383,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
             for (tx.literals) |lit| markValue(gc, lit);
             for (tx.patterns) |pat| markValue(gc, pat);
             for (tx.templates) |tmpl| markValue(gc, tmpl);
+            markValue(gc, tx.def_env_val);
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);
@@ -445,6 +448,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
             if (func.global_cache) |cache| {
                 for (cache) |c| markValue(gc, c);
             }
+            markValue(gc, func.env_val);
         },
         .native_closure => {
             const nc = obj.as(types.NativeClosure);
@@ -533,6 +537,7 @@ pub fn markValue(gc: *GC, v: Value) void {
             if (func.global_cache) |cache| {
                 for (cache) |c| markValue(gc, c);
             }
+            markValue(gc, func.env_val);
         },
         .transformer => {
             const tx = obj.as(Transformer);
@@ -545,6 +550,7 @@ pub fn markValue(gc: *GC, v: Value) void {
             for (tx.templates) |tmpl| {
                 markValue(gc, tmpl);
             }
+            markValue(gc, tx.def_env_val);
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -90,6 +90,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
             new_func.source_name = func.source_name;
             new_func.global_cache = null;
             new_func.env = null;
+            new_func.env_val = types.NIL;
             if (func.name) |name| {
                 if (func.owns_name) {
                     const dup = try gc.allocator.alloc(u8, name.len);
@@ -212,6 +213,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
                 new_tx.captured_locals = gc.allocator.dupe(types.CapturedLocal, t.captured_locals) catch &.{};
             }
             new_tx.def_env = t.def_env;
+            new_tx.def_env_val = t.def_env_val;
             return new_val;
         },
         .native_fn, .native_closure, .ffi_library, .ffi_function => src,

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -198,7 +198,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     // If an environment specifier is provided, compile in that environment
     if (args.len > 1 and types.isEnvironment(args[1])) {
         const se = types.toEnvironment(args[1]);
-        const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env) catch return PrimitiveError.TypeError; // bare-ok: compile error
+        const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env, args[1]) catch return PrimitiveError.TypeError; // bare-ok: compile error
         var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
         compiler_mod.Compiler.unrootFunction(gc, func);
         gc.pushRoot(&closure_val) catch return PrimitiveError.OutOfMemory;

--- a/src/types.zig
+++ b/src/types.zig
@@ -230,6 +230,7 @@ pub const Function = struct {
     global_cache: ?[]Value = null,
     cache_version: u32 = 0,
     env: ?*std.StringHashMap(Value) = null,
+    env_val: Value = NIL,
     profile_instrs: u64 = 0,
     profile_calls: u64 = 0,
     profile_time_ns: u64 = 0,
@@ -269,6 +270,7 @@ pub const Transformer = struct {
     num_rules: u16,
     captured_locals: []CapturedLocal = &.{},
     def_env: ?*std.StringHashMap(Value) = null,
+    def_env_val: Value = NIL,
     custom_ellipsis: ?[]const u8 = null,
 };
 

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -1051,7 +1051,7 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
         return;
     }
 
-    const func = compiler_mod.compileExpressionInEnv(vm.gc, expr, &vm.macros, lib_env) catch return VMError.CompileError;
+    const func = compiler_mod.compileExpressionInEnv(vm.gc, expr, &vm.macros, lib_env, types.NIL) catch return VMError.CompileError;
     if (vm.lib_compile_collect) |collect| {
         collect.append(vm.gc.allocator, func) catch return VMError.OutOfMemory;
     }

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -182,7 +182,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         body_list = define_expr;
 
         const func = if (vm.current_lib_env) |env|
-            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env) catch return VMError.CompileError
+            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL) catch return VMError.CompileError
         else
             compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
         const func_val = types.makePointer(@ptrCast(func));
@@ -209,7 +209,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         defer vm.gc.popRoot();
 
         const func = if (vm.current_lib_env) |env|
-            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env) catch return VMError.CompileError
+            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL) catch return VMError.CompileError
         else
             compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
         define_expr = types.makePointer(@ptrCast(func));
@@ -237,7 +237,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             defer vm.gc.popRoot();
 
             const func = if (vm.current_lib_env) |env|
-                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env) catch return VMError.CompileError
+                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL) catch return VMError.CompileError
             else
                 compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(@ptrCast(func));
@@ -264,7 +264,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             defer vm.gc.popRoot();
 
             const func = if (vm.current_lib_env) |env|
-                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env) catch return VMError.CompileError
+                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL) catch return VMError.CompileError
             else
                 compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(@ptrCast(func));

--- a/tests/scheme/smoke/env-uaf.scm
+++ b/tests/scheme/smoke/env-uaf.scm
@@ -1,0 +1,18 @@
+;; Regression test for #867: GC frees (environment ...) map still referenced
+;; by eval'd closures via Function.env — use-after-free.
+;;
+;; A closure produced by (eval expr (environment ...)) must keep the
+;; environment's binding map alive even after the environment object
+;; becomes otherwise unreachable.
+
+(define f (eval '(begin (define secret 42) (lambda () secret))
+                (environment '(scheme base))))
+
+;; Environment object is now unreachable; churn to force collections
+;; and reuse of the freed map memory.
+(define junk
+  (let churn ((n 200000) (acc '()))
+    (if (= n 0) acc (churn (- n 1) (cons n acc)))))
+
+(display (= (f) 42))
+(newline)


### PR DESCRIPTION
## Summary
- Add `env_val` field to `Function` and `def_env_val` to `Transformer` to store the GC-managed `SchemeEnvironment` Value alongside the raw hashmap pointer
- Trace these fields in all three marking functions (hasYoungRefs, minor-GC markValue, full-GC markValue) so the environment stays alive while closures reference it
- Propagate env_val through `Compiler.initChild` and `compileExpressionInEnv`

## Test plan
- [x] New regression test `tests/scheme/smoke/env-uaf.scm` — eval'd closure outlives its environment, GC churn forces collection
- [x] Unit tests pass (`zig build test`)
- [x] All 1604 Scheme tests pass (212 files + 1392 R7RS)

Fixes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)