### PR TITLE
Fix round on negative exact rationals with fraction < 1/2

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -189,10 +189,7 @@ fn rationalRound(r: *types.Rational) PrimitiveError!Value {
     const double_rem = bignum_mod.mul(gc, abs_rem, types.makeFixnum(2)) catch return PrimitiveError.OutOfMemory;
     const cmp = bignum_mod.compare(double_rem, r.denominator);
     if (cmp < 0) {
-        return bignum_mod.demote(if (bignum_mod.isNegative(rem))
-            bignum_mod.sub(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory
-        else
-            q);
+        return bignum_mod.demote(q);
     }
     if (cmp > 0) {
         return bignum_mod.demote(if (bignum_mod.isNegative(rem))

--- a/tests/scheme/smoke/round-neg-rational-837.scm
+++ b/tests/scheme/smoke/round-neg-rational-837.scm
@@ -1,0 +1,21 @@
+;; Regression test for #837: round on negative exact rationals with
+;; fraction < 1/2 rounds away from zero instead of toward it.
+
+;; Fraction < 1/2 — should round toward zero
+(display (= (round -1/3) 0))   (newline)
+(display (= (round -1/4) 0))   (newline)
+(display (= (round -4/3) -1))  (newline)
+
+;; Fraction > 1/2 — should round away from zero
+(display (= (round -2/3) -1))  (newline)
+(display (= (round -5/3) -2))  (newline)
+
+;; Ties to even
+(display (= (round -5/2) -2))  (newline)
+(display (= (round -7/2) -4))  (newline)
+(display (= (round -3/2) -2))  (newline)
+
+;; Positive rationals (sanity check)
+(display (= (round 1/3) 0))    (newline)
+(display (= (round 2/3) 1))    (newline)
+(display (= (round 5/2) 2))    (newline)


### PR DESCRIPTION
## Summary
- The `cmp < 0` branch in `rationalRound` incorrectly subtracted 1 for negative remainders
- When the fractional part's magnitude is below 1/2, the closest integer is always the truncated quotient `q` regardless of sign
- Changed to return `q` unconditionally in the `cmp < 0` case

## Test plan
- [x] New regression test with negative and positive rational rounding
- [x] Unit tests pass
- [x] All Scheme tests pass

Fixes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)