### PR TITLE
Fix case-lambda 32-clause limit, case empty datum, case-lambda hygiene

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -157,6 +157,9 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
             break;
         }
 
+        // Empty datum list (() body) is allowed by R7RS — dead code, skip
+        if (datums == types.NIL) continue;
+
         // For each datum in the clause, compare with key
         // If any matches, jump to clause body
         if (!types.isPair(datums)) return CompileError.InvalidSyntax;

--- a/tests/scheme/smoke/case-empty-datum-854.scm
+++ b/tests/scheme/smoke/case-empty-datum-854.scm
@@ -1,0 +1,33 @@
+;; Regression test for #854: case rejects empty datum list
+;; R7RS allows empty datum lists in case clauses — the clause
+;; is dead code (never matches) and should be silently skipped.
+
+;; Empty datum list before matching clause
+(display (case 1
+  (() 'never)
+  ((1) 'one)
+  (else 'other)))
+(newline)
+
+;; Empty datum list after matching clause
+(display (case 2
+  ((2) 'two)
+  (() 'never)
+  (else 'other)))
+(newline)
+
+;; Only empty datum lists, falls through to else
+(display (case 3
+  (() 'never1)
+  (() 'never2)
+  (else 'fallthrough)))
+(newline)
+
+;; Only empty datum lists, no else — result is void
+(case 4
+  (() 'never))
+
+;; Expected output:
+;; one
+;; two
+;; fallthrough


### PR DESCRIPTION
## Summary
- Replace fixed 32-element `clause_buf` array with dynamic `ArrayList` so case-lambda supports any number of clauses (#840)
- Allow empty datum list `(() body)` in case clauses as dead code per R7RS grammar (#854)
- Use unforgeable `%cl_args`/`%cl_n` symbols in case-lambda desugaring to avoid capturing user variables named `args` or `n` (#836)

## Test plan
- [x] New regression test covering all three fixes
- [x] Unit tests pass
- [x] All Scheme tests pass

Fixes #840, #854, #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)