### PR TITLE
Validate operand types in quotient/remainder/modulo/gcd bignum paths

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -782,7 +782,11 @@ fn divFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn quotient(args: []const Value) PrimitiveError!Value {
-    if (types.isBignum(args[0]) or types.isBignum(args[1])) {
+    if ((types.isBignum(args[0]) or types.isBignum(args[1])) and
+        !types.isFlonum(args[0]) and !types.isFlonum(args[1]))
+    {
+        if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
+        if (!types.isFixnum(args[1]) and !types.isBignum(args[1])) return numberTypeError(args[1]);
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         return bignum_mod.quotient(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
@@ -800,7 +804,11 @@ fn quotient(args: []const Value) PrimitiveError!Value {
 }
 
 fn remainder(args: []const Value) PrimitiveError!Value {
-    if (types.isBignum(args[0]) or types.isBignum(args[1])) {
+    if ((types.isBignum(args[0]) or types.isBignum(args[1])) and
+        !types.isFlonum(args[0]) and !types.isFlonum(args[1]))
+    {
+        if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
+        if (!types.isFixnum(args[1]) and !types.isBignum(args[1])) return numberTypeError(args[1]);
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         return bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
@@ -818,7 +826,11 @@ fn remainder(args: []const Value) PrimitiveError!Value {
 }
 
 fn modulo(args: []const Value) PrimitiveError!Value {
-    if (types.isBignum(args[0]) or types.isBignum(args[1])) {
+    if ((types.isBignum(args[0]) or types.isBignum(args[1])) and
+        !types.isFlonum(args[0]) and !types.isFlonum(args[1]))
+    {
+        if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
+        if (!types.isFixnum(args[1]) and !types.isBignum(args[1])) return numberTypeError(args[1]);
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         const rem = bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
@@ -1213,15 +1225,25 @@ pub fn gcdTwo(a_in: i64, b_in: i64) i64 {
 
 fn gcdFn(args: []const Value) PrimitiveError!Value {
     if (args.len == 0) return types.makeFixnum(0);
+    if (anyFlonum(args)) {
+        var result: f64 = @abs(try toF64Ext(args[0]));
+        for (args[1..]) |a| {
+            const b = @abs(try toF64Ext(a));
+            result = gcdF64(result, b);
+        }
+        return makeFlonumVal(result);
+    }
     if (anyBignum(args)) {
         // Bignum GCD: use Euclidean algorithm with bignum ops
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
         var result = bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
         gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
         defer {
             if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
         }
         for (args[1..]) |a| {
+            if (!types.isFixnum(a) and !types.isBignum(a)) return numberTypeError(a);
             var b_val = bignum_mod.absVal(gc, a) catch return PrimitiveError.OutOfMemory;
             gc.extra_roots.append(gc.allocator, b_val) catch return PrimitiveError.OutOfMemory;
             while (!bignum_mod.isZero(b_val)) {
@@ -1235,14 +1257,6 @@ fn gcdFn(args: []const Value) PrimitiveError!Value {
             _ = gc.extra_roots.pop();
         }
         return result;
-    }
-    if (anyFlonum(args)) {
-        var result: f64 = @abs(try toF64Ext(args[0]));
-        for (args[1..]) |a| {
-            const b = @abs(try toF64Ext(a));
-            result = gcdF64(result, b);
-        }
-        return makeFlonumVal(result);
     }
     if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
     var result = types.toFixnum(args[0]);

--- a/tests/scheme/smoke/case-lambda-fixes.scm
+++ b/tests/scheme/smoke/case-lambda-fixes.scm
@@ -1,0 +1,23 @@
+;; Regression tests for case-lambda and case fixes:
+;; #840: case-lambda drops clauses beyond 32nd
+;; #854: case rejects empty datum list (() body)
+;; #836: case-lambda hygiene — user variables named n or args
+
+;; #854: empty datum list in case
+(display (case 1
+  (() 'never)
+  ((1) 'one)
+  (else 'other)))
+(newline)
+
+;; #836: case-lambda hygiene — user variable n
+(define n 42)
+(define f (case-lambda ((x) (+ x n))))
+(display (f 1))
+(newline)
+
+;; #836: case-lambda hygiene — user variable args
+(define args 100)
+(define g (case-lambda ((x) (+ x args))))
+(display (g 1))
+(newline)

--- a/tests/scheme/smoke/mixed-bignum-flonum-841.scm
+++ b/tests/scheme/smoke/mixed-bignum-flonum-841.scm
@@ -1,0 +1,74 @@
+;; Regression test for #841: quotient/remainder/modulo/gcd panic on
+;; mixed bignum + flonum arguments; non-numbers yield garbage.
+
+(import (scheme base) (scheme write))
+
+(define big (expt 2 100))
+(define pass #t)
+
+(define (fail . args)
+  (display "FAIL ")
+  (for-each display args)
+  (newline)
+  (set! pass #f))
+
+;; Mixed bignum + flonum must not panic and must return inexact values.
+;; Use (expt 2 48) = 281474976710656 which is a bignum (>2^47 fixnum range)
+;; but fits exactly in f64.
+(define b48 (expt 2 48))
+
+(let ((r (quotient b48 4.0)))
+  (unless (and (inexact? r) (= r 70368744177664.0))
+    (fail "quotient b48/4.0: " r)))
+
+(let ((r (quotient 1.0e15 b48)))
+  (unless (and (inexact? r) (= r 3.0))
+    (fail "quotient 1e15/b48: " r)))
+
+(let ((r (remainder b48 5.0)))
+  (unless (and (inexact? r) (= r 1.0))
+    (fail "remainder b48/5.0: " r)))
+
+(let ((r (modulo b48 5.0)))
+  (unless (and (inexact? r) (= r 1.0))
+    (fail "modulo b48/5.0: " r)))
+
+(let ((r (gcd b48 6.0)))
+  (unless (and (inexact? r) (= r 2.0))
+    (fail "gcd b48 6.0: " r)))
+
+;; Large bignum + flonum (tests the 2^100 case from the issue)
+(let ((r (quotient big 3.0)))
+  (unless (inexact? r)
+    (fail "quotient big/3.0 not inexact: " r)))
+
+(let ((r (remainder big 3.0)))
+  (unless (inexact? r)
+    (fail "remainder big/3.0 not inexact: " r)))
+
+(let ((r (modulo big 3.0)))
+  (unless (inexact? r)
+    (fail "modulo big/3.0 not inexact: " r)))
+
+(let ((r (gcd big 6.0)))
+  (unless (inexact? r)
+    (fail "gcd big 6.0 not inexact: " r)))
+
+;; Non-number arguments should raise an error, not produce garbage
+(define (expect-error name thunk)
+  (guard (e (#t #t))
+    (thunk)
+    (fail name " should have raised an error")))
+
+(expect-error "quotient string" (lambda () (quotient "a" 2)))
+(expect-error "remainder string" (lambda () (remainder 2 "b")))
+(expect-error "modulo string" (lambda () (modulo "a" "b")))
+(expect-error "gcd string" (lambda () (gcd "a" 2)))
+(expect-error "quotient bignum+string" (lambda () (quotient big "a")))
+(expect-error "remainder bignum+string" (lambda () (remainder "a" big)))
+(expect-error "modulo bignum+string" (lambda () (modulo big "a")))
+(expect-error "gcd bignum+string" (lambda () (gcd big "a")))
+
+(if pass
+    (display "All tests passed\n")
+    (begin (display "SOME TESTS FAILED\n") (exit 1)))


### PR DESCRIPTION
## Summary
- Guard bignum branches in quotient/remainder/modulo against mixed flonum operands — fall through to f64 path instead of panicking
- Move `anyFlonum` check before `anyBignum` in gcdFn to match lcmFn's correct order
- Add `numberTypeError` checks for non-number arguments in bignum branches

## Test plan
- [x] Regression test `tests/scheme/smoke/mixed-bignum-flonum-841.scm`
- [x] Unit tests pass
- [x] R7RS test suite passes

Fixes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)