### PR TITLE
Fix char literal semicolon and string-prefix?/suffix? argument order

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -74,20 +74,22 @@ fn stringContainsFn(args: []const Value) PrimitiveError!Value {
     return types.FALSE;
 }
 
-// (string-prefix? prefix s [start end])
+// (string-prefix? s1 s2 [start1 end1 start2 end2])
 fn stringPrefixPFn(args: []const Value) PrimitiveError!Value {
-    const prefix = try getStringSlice(args[0]);
-    const full_s = try getStringSlice(args[1]);
-    const range = try parseStartEnd(full_s, args, 2);
-    return if (std.mem.startsWith(u8, range.data, prefix)) types.TRUE else types.FALSE;
+    const full_s1 = try getStringSlice(args[0]);
+    const full_s2 = try getStringSlice(args[1]);
+    const s1_range = try parseStartEnd(full_s1, args, 2);
+    const s2_range = try parseStartEnd(full_s2, args, 4);
+    return if (std.mem.startsWith(u8, s2_range.data, s1_range.data)) types.TRUE else types.FALSE;
 }
 
-// (string-suffix? suffix s [start end])
+// (string-suffix? s1 s2 [start1 end1 start2 end2])
 fn stringSuffixPFn(args: []const Value) PrimitiveError!Value {
-    const suffix = try getStringSlice(args[0]);
-    const full_s = try getStringSlice(args[1]);
-    const range = try parseStartEnd(full_s, args, 2);
-    return if (std.mem.endsWith(u8, range.data, suffix)) types.TRUE else types.FALSE;
+    const full_s1 = try getStringSlice(args[0]);
+    const full_s2 = try getStringSlice(args[1]);
+    const s1_range = try parseStartEnd(full_s1, args, 2);
+    const s2_range = try parseStartEnd(full_s2, args, 4);
+    return if (std.mem.endsWith(u8, s2_range.data, s1_range.data)) types.TRUE else types.FALSE;
 }
 
 fn isWhitespace(c: u8) bool {

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -420,7 +420,7 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                     if (cp < 0x20 or (cp >= 0x7F and cp <= 0x9F)) {
                         var hex_buf: [8]u8 = undefined;
                         var hw: std.Io.Writer = .fixed(&hex_buf);
-                        hw.print("x{x};", .{cp}) catch {};
+                        hw.print("x{x}", .{cp}) catch {};
                         try writer.writeAll(hw.buffered());
                     } else {
                         var buf: [4]u8 = undefined;

--- a/tests/scheme/smoke/printer-string-fixes.scm
+++ b/tests/scheme/smoke/printer-string-fixes.scm
@@ -1,0 +1,19 @@
+;; Regression tests for #855 (char literal semicolon) and #829 (string-prefix?/suffix?)
+
+;; #855: write of control chars should not emit trailing semicolon
+(let* ((p (open-output-string))
+       (_ (write (list #\x05 1 2) p))
+       (s (get-output-string p)))
+  (display (equal? (read (open-input-string s)) (list #\x05 1 2)))
+  (newline))
+
+;; #829: string-prefix? optional args apply to s1, not s2
+(import (srfi 13))
+(display (string-prefix? "hello" "hell" 0 2))  ; s1[0:2]="he" is prefix of "hell" => #t
+(newline)
+(display (string-suffix? "hello" "llo" 2))      ; s1[2:]="llo" is suffix of "llo" => #t
+(newline)
+(display (string-prefix? "abc" "abcdef"))        ; basic: "abc" is prefix of "abcdef" => #t
+(newline)
+(display (string-prefix? "xyz" "abcdef"))        ; basic: "xyz" is NOT prefix => #f
+(newline)

--- a/tests/scheme/srfi/srfi13-startend.scm
+++ b/tests/scheme/srfi/srfi13-startend.scm
@@ -52,15 +52,15 @@
 (check "string-contains start" 4 (string-contains "xxabcd" "cd" 2))
 (check "string-contains start end miss" #f (string-contains "abcdef" "ef" 0 4))
 
-;; --- string-prefix? with start/end ---
+;; --- string-prefix? with start/end (SRFI-13: start1/end1 apply to s1) ---
 (check "string-prefix? basic" #t (string-prefix? "ab" "abcdef"))
-(check "string-prefix? start" #t (string-prefix? "cd" "abcdef" 2))
-(check "string-prefix? start miss" #f (string-prefix? "ab" "abcdef" 2))
+(check "string-prefix? s1 range" #t (string-prefix? "hello" "hell" 0 2))
+(check "string-prefix? s1 skip" #t (string-prefix? "xxab" "abcdef" 2))
 
-;; --- string-suffix? with start/end ---
+;; --- string-suffix? with start/end (SRFI-13: start1/end1 apply to s1) ---
 (check "string-suffix? basic" #t (string-suffix? "ef" "abcdef"))
-(check "string-suffix? end" #t (string-suffix? "cd" "abcdef" 0 4))
-(check "string-suffix? end miss" #f (string-suffix? "ef" "abcdef" 0 4))
+(check "string-suffix? s1 range" #t (string-suffix? "hello" "llo" 2))
+(check "string-suffix? s1 end miss" #f (string-suffix? "xy" "abcdef" 0 1))
 
 ;; --- string-every with start/end ---
 (check "string-every full" #t (string-every char-lower-case? "abc"))


### PR DESCRIPTION
## Summary
- Remove trailing semicolon from control char hex output in write mode — `#\x5` not `#\x5;` (#855)
- Apply optional start/end to s1 (prefix/suffix) per SRFI-13, not s2; accept start2/end2 (#829)

## Test plan
- [x] New regression test with write round-trip and string-prefix?/suffix? edge cases
- [x] Unit tests pass

Fixes #855, #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)