### PR TITLE
Fix string-replace index clamping and bignum parse error propagation

### DIFF
--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -686,7 +686,10 @@ pub fn parseBignumString(gc: *memory.GC, digits: []const u8, radix: u8) !Value {
         const chunk_str = num_digits[pos .. pos + chunk_size];
 
         // Parse the chunk
-        const chunk_val = std.fmt.parseInt(u64, chunk_str, radix) catch return error.OutOfMemory;
+        const chunk_val = std.fmt.parseInt(u64, chunk_str, radix) catch |e| switch (e) {
+            error.InvalidCharacter => return error.InvalidCharacter,
+            else => return error.OutOfMemory,
+        };
 
         // Compute the multiplier (radix^chunk_size)
         var multiplier: u64 = 1;

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1059,7 +1059,10 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
         return applyExactness(gc, result, exactness);
     } else |err| {
         if (err == error.Overflow) {
-            const result = bignum_mod.parseBignumString(gc, s, radix) catch return PrimitiveError.OutOfMemory;
+            const result = bignum_mod.parseBignumString(gc, s, radix) catch |e| switch (e) {
+                error.InvalidCharacter => return types.FALSE,
+                else => return PrimitiveError.OutOfMemory,
+            };
             return applyExactness(gc, result, exactness);
         }
     }

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -623,8 +623,8 @@ fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
     const start: usize = @intCast(sv);
     const end: usize = @intCast(ev);
     if (start > end) return primitives.typeError("string-replace", "valid index range (start <= end)", args[2]);
-    const byte_start = pstr.utf8IndexToByteOffset(data1, start) orelse data1.len;
-    const byte_end = pstr.utf8IndexToByteOffset(data1, end) orelse data1.len;
+    const byte_start = pstr.utf8IndexToByteOffset(data1, start) orelse return PrimitiveError.IndexOutOfBounds;
+    const byte_end = pstr.utf8IndexToByteOffset(data1, end) orelse return PrimitiveError.IndexOutOfBounds;
     const new_len = byte_start + data2.len + (data1.len - byte_end);
     const alloc_buf = gc.allocator.alloc(u8, new_len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(alloc_buf);

--- a/tests/scheme/smoke/misc-830-835.scm
+++ b/tests/scheme/smoke/misc-830-835.scm
@@ -1,0 +1,14 @@
+;; Regression tests for #830 (string-replace clamping) and #835 (bignum parse error)
+
+;; #830: string-replace should error on out-of-range indices
+(guard (e (#t (display "caught") (newline)))
+  (string-replace "abc" "XY" 10 20))
+
+;; #835: string->number should return #f for invalid bignum strings
+(display (eq? (string->number "9999999999999999999999999999999999999x") #f))
+(newline)
+(display (eq? (string->number "99999999999999999999x") #f))
+(newline)
+;; Valid bignum strings should work
+(display (= (string->number "12345678901234567890") 12345678901234567890))
+(newline)


### PR DESCRIPTION
## Summary
- `string-replace` now raises IndexOutOfBounds for out-of-range indices instead of clamping (#830)
- `parseBignumString` propagates InvalidCharacter so `string->number` returns `#f` for invalid bignum strings (#835)

## Test plan
- [x] New regression tests
- [x] Unit tests pass

Fixes #830, #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)