### PR TITLE
Fix exact/numerator/denominator abort on 2^63 and bignum rational parsing

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -22,7 +22,7 @@ const gcdTwo = arith.gcdTwo;
 fn safeFloatToExactInt(f: f64) PrimitiveError!Value {
     const min_i64: f64 = @floatFromInt(std.math.minInt(i64));
     const max_i64_f: f64 = @floatFromInt(std.math.maxInt(i64));
-    if (f >= min_i64 and f <= max_i64_f) {
+    if (f >= min_i64 and f < max_i64_f) {
         return try arith.makeFixnumChecked(@intFromFloat(f));
     }
     return floatToBignum(f);
@@ -235,7 +235,7 @@ fn bankersRound(f: f64) f64 {
     if (frac == 0.5) {
         const min_i64: f64 = @floatFromInt(std.math.minInt(i64));
         const max_i64_f: f64 = @floatFromInt(std.math.maxInt(i64));
-        if (floored >= min_i64 and floored <= max_i64_f) {
+        if (floored >= min_i64 and floored < max_i64_f) {
             const i: i64 = @intFromFloat(floored);
             return if (@mod(i, @as(i64, 2)) != 0) @ceil(f) else floored;
         }
@@ -965,7 +965,7 @@ fn applyExactness(gc: *@import("memory.zig").GC, val: Value, exactness: Exactnes
                 }
                 const min_i64: f64 = @floatFromInt(std.math.minInt(i64));
                 const max_i64_f: f64 = @floatFromInt(std.math.maxInt(i64));
-                if (num < min_i64 or num > max_i64_f or den < min_i64 or den > max_i64_f) {
+                if (num < min_i64 or num >= max_i64_f or den < min_i64 or den >= max_i64_f) {
                     return try safeFloatToExactInt(f);
                 }
                 const n: i64 = @intFromFloat(num);
@@ -1041,13 +1041,30 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
         if (slash_pos > 0 and slash_pos + 1 < s.len) {
             const num_str = s[0..slash_pos];
             const den_str = s[slash_pos + 1 ..];
-            if (std.fmt.parseInt(i64, num_str, radix)) |num| {
-                if (std.fmt.parseInt(i64, den_str, radix)) |den| {
-                    if (den == 0) return types.FALSE;
-                    const result = arith.makeRationalFromReader(gc, num, den) catch return PrimitiveError.OutOfMemory;
-                    return applyExactness(gc, result, exactness);
-                } else |_| {}
-            } else |_| {}
+            const num_val: Value = if (std.fmt.parseInt(i64, num_str, radix)) |num|
+                try arith.makeFixnumChecked(num)
+            else |err| blk: {
+                if (err != error.Overflow) break :blk types.FALSE;
+                break :blk bignum_mod.parseBignumString(gc, num_str, radix) catch |e| switch (e) {
+                    error.InvalidCharacter => types.FALSE,
+                    else => return PrimitiveError.OutOfMemory,
+                };
+            };
+            if (num_val == types.FALSE) return types.FALSE;
+            const den_val: Value = if (std.fmt.parseInt(i64, den_str, radix)) |den| blk: {
+                if (den == 0) return types.FALSE;
+                break :blk try arith.makeFixnumChecked(den);
+            } else |err| blk: {
+                if (err != error.Overflow) break :blk types.FALSE;
+                break :blk bignum_mod.parseBignumString(gc, den_str, radix) catch |e| switch (e) {
+                    error.InvalidCharacter => types.FALSE,
+                    else => return PrimitiveError.OutOfMemory,
+                };
+            };
+            if (den_val == types.FALSE) return types.FALSE;
+            if (bignum_mod.isZero(den_val)) return types.FALSE;
+            const result = arith.makeRationalReduced(gc, num_val, den_val) catch return PrimitiveError.OutOfMemory;
+            return applyExactness(gc, result, exactness);
         }
     }
 
@@ -1345,7 +1362,7 @@ pub fn floatToRational(f: f64) struct { num: i64, den: i64 } {
     const min_i64: f64 = @floatFromInt(std.math.minInt(i64));
     const max_i64_f: f64 = @floatFromInt(std.math.maxInt(i64));
     if (f == @trunc(f)) {
-        if (f >= min_i64 and f <= max_i64_f) return .{ .num = @intFromFloat(f), .den = 1 };
+        if (f >= min_i64 and f < max_i64_f) return .{ .num = @intFromFloat(f), .den = 1 };
         return .{ .num = 0, .den = 0 };
     }
     const sign: i64 = if (f < 0) -1 else 1;

--- a/tests/scheme/smoke/numeric-edge-846-853.scm
+++ b/tests/scheme/smoke/numeric-edge-846-853.scm
@@ -1,0 +1,15 @@
+;; Regression tests for #846 (exact/numerator/denominator abort on 2^63)
+;; and #853 (string->number raises OutOfMemory for bignum rationals)
+
+;; #846: exact of 2^63 must not panic
+(display (= (exact (expt 2.0 63)) (expt 2 63)))
+(newline)
+
+;; #853: string->number with bignum rational components
+(display (= (string->number "123456789012345678901234567890/3")
+             41152263004115226300411522630))
+(newline)
+(display (rational? (string->number "3/123456789012345678901234567890")))
+(newline)
+(display (eq? (string->number "bad/input") #f))
+(newline)


### PR DESCRIPTION
## Summary
- Use `<` instead of `<=` for i64 max comparison to avoid panic on 2^63 (#846)
- Parse rational components with `parseBignumString` on i64 overflow (#853)

## Test plan
- [x] Regression test
- [x] Unit tests pass

Fixes #846, #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)