### PR TITLE
Use raise-continuable for unmatched guard clauses

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -46,7 +46,7 @@ pub fn compileGuard(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compi
 
     var cond_clauses = clauses;
     if (!has_else) {
-        const raise_sym = gc.allocSymbol("raise") catch return CompileError.OutOfMemory;
+        const raise_sym = gc.allocSymbol("raise-continuable") catch return CompileError.OutOfMemory;
         const raise_call = gc.allocPair(raise_sym, gc.allocPair(var_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
         const else_sym = gc.allocSymbol("else") catch return CompileError.OutOfMemory;
         const else_clause = gc.allocPair(else_sym, gc.allocPair(raise_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;

--- a/tests/scheme/smoke/guard-continuable-845.scm
+++ b/tests/scheme/smoke/guard-continuable-845.scm
@@ -1,0 +1,18 @@
+;; Regression test for #845: guard re-raises unmatched conditions with
+;; raise instead of raise-continuable
+
+;; Non-continuable raise through non-matching guard should work
+(display
+ (guard (outer-c (#t 'caught))
+   (guard (c (#f #f))
+     (raise 'boom))))
+(newline)
+
+;; raise-continuable through non-matching guard should not crash
+(display
+ (with-exception-handler
+   (lambda (e) 100)
+   (lambda ()
+     (guard (c (#f #f))
+       (raise-continuable 'x)))))
+(newline)


### PR DESCRIPTION
## Summary
- Change `raise` to `raise-continuable` in the else clause appended by `compileGuard` for unmatched conditions, per R7RS 4.2.7

## Test plan
- [x] Regression test
- [x] Unit tests pass

Fixes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)