### PR TITLE
Fix exact denominator 2^47 wrapping and inexact NaN on huge rationals

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -319,7 +319,7 @@ fn exactFn(args: []const Value) PrimitiveError!Value {
         defer _ = gc.extra_roots.pop();
         // Build denominator 2^neg_exp
         const den_val = blk: {
-            if (neg_exp <= 47) {
+            if (neg_exp < 47) {
                 break :blk types.makeFixnum(@as(i64, 1) << @intCast(neg_exp));
             }
             const word_shift = neg_exp / 64;
@@ -360,7 +360,15 @@ fn inexactFn(args: []const Value) PrimitiveError!Value {
         const r = types.toRational(args[0]);
         const n = try toF64Ext(r.numerator);
         const d = try toF64Ext(r.denominator);
-        return makeFlonumVal(n / d);
+        const result = n / d;
+        if (!std.math.isNan(result)) return makeFlonumVal(result);
+        // Both overflow to inf — use bignum division for the integer part
+        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
+        const q_f = try toF64Ext(q);
+        const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
+        const rem_f = try toF64Ext(rem);
+        return makeFlonumVal(q_f + rem_f / d);
     }
     if (types.isComplex(args[0])) {
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;

--- a/tests/scheme/smoke/exact-inexact-842-848.scm
+++ b/tests/scheme/smoke/exact-inexact-842-848.scm
@@ -1,0 +1,14 @@
+;; Regression tests for #842 and #848
+
+;; #842: exact with dyadic denominator 2^47 must not produce negative denominator
+(let ((x (exact (/ 3.0 (expt 2.0 47)))))
+  (display (positive? x))
+  (newline)
+  (display (> (inexact x) 0))
+  (newline))
+
+;; #848: inexact on rationals with huge components must not return NaN
+(display (= (inexact (/ (+ (expt 10 400) 1) (expt 10 399))) 10.0))
+(newline)
+(display (= (inexact (/ (+ (expt 2 2000) 1) (expt 2 2000))) 1.0))
+(newline)


### PR DESCRIPTION
## Summary
- Fix off-by-one in exact denominator threshold: 2^47 overflows i48 (#842)
- Fall back to bignum division when inexact produces NaN from huge rationals (#848)

## Test plan
- [x] Regression test
- [x] Unit tests pass

Fixes #842, #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)