### PR TITLE
Fix numerator/denominator on flonums to use exact dyadic fraction

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1383,9 +1383,13 @@ fn numeratorFn(args: []const Value) PrimitiveError!Value {
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
         if (!std.math.isFinite(f)) return args[0];
-        const rat = floatToRational(f);
-        if (rat.den == 0) return args[0];
-        return makeFlonumVal(@floatFromInt(rat.num));
+        if (f == @trunc(f)) return args[0];
+        const exact_val = try exactFn(args);
+        if (types.isRationalObj(exact_val)) {
+            const r = types.toRational(exact_val);
+            return makeFlonumVal(try toF64Ext(r.numerator));
+        }
+        return makeFlonumVal(try toF64Ext(exact_val));
     }
     return primitives.typeError("numerator", "number", args[0]);
 }
@@ -1400,9 +1404,13 @@ fn denominatorFn(args: []const Value) PrimitiveError!Value {
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
         if (!std.math.isFinite(f)) return makeFlonumVal(1.0);
-        const rat = floatToRational(f);
-        if (rat.den == 0) return makeFlonumVal(1.0);
-        return makeFlonumVal(@floatFromInt(rat.den));
+        if (f == @trunc(f)) return makeFlonumVal(1.0);
+        const exact_val = try exactFn(args);
+        if (types.isRationalObj(exact_val)) {
+            const r = types.toRational(exact_val);
+            return makeFlonumVal(try toF64Ext(r.denominator));
+        }
+        return makeFlonumVal(1.0);
     }
     return primitives.typeError("denominator", "number", args[0]);
 }

--- a/tests/scheme/smoke/numden-flonum-858.scm
+++ b/tests/scheme/smoke/numden-flonum-858.scm
@@ -1,0 +1,9 @@
+;; Regression test for #858: numerator/denominator on flonums must return
+;; the exact dyadic fraction, not a decimal approximation.
+
+(let ((x 3.141592653589793))
+  (display (= x (/ (numerator x) (denominator x)))))
+(newline)
+
+(display (= (denominator 0.3) (denominator (exact 0.3))))
+(newline)


### PR DESCRIPTION
## Summary
- Use `exactFn` to convert flonum to its exact rational, then extract numerator/denominator
- Preserves the invariant `(= x (/ (numerator x) (denominator x)))`

Fixes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)