### PR TITLE
Fix continuation restore escape misdetection and dynamic-wind double-run

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -185,6 +185,7 @@ pub const VM = struct {
     wind_count: usize = 0,
     continuation_invoked: bool = false,
     continuation_value: Value = types.VOID,
+    continuation_generation: u32 = 0,
     stdin_port: Value = types.VOID,
     stdout_port: Value = types.VOID,
     stderr_port: Value = types.VOID,
@@ -556,6 +557,7 @@ pub const VM = struct {
             const saved_frame_count = self.frame_count;
             const saved_handler_count = self.handler_count;
             const saved_wind_count = self.wind_count;
+            const saved_cgen = self.continuation_generation;
             self.frames[self.frame_count] = .{
                 .closure = closure,
                 .code = func.code.items,
@@ -568,12 +570,14 @@ pub const VM = struct {
 
             const result = self.runUntil(saved_frame_count, saved_wind_count) catch |err| {
                 if (err == VMError.ContinuationInvoked) {
-                    if (self.frame_count >= saved_frame_count) return self.continuation_value;
+                    if (self.continuation_generation == saved_cgen and self.frame_count >= saved_frame_count) return self.continuation_value;
                     return err;
                 }
-                self.frame_count = saved_frame_count;
-                self.handler_count = saved_handler_count;
-                self.wind_count = saved_wind_count;
+                if (self.continuation_generation == saved_cgen) {
+                    self.frame_count = saved_frame_count;
+                    self.handler_count = saved_handler_count;
+                    self.wind_count = saved_wind_count;
+                }
                 return err;
             };
             return result;
@@ -644,6 +648,7 @@ pub const VM = struct {
             const saved_frame_count = self.frame_count;
             const saved_handler_count = self.handler_count;
             const saved_wind_count = self.wind_count;
+            const saved_cgen = self.continuation_generation;
             self.frames[self.frame_count] = .{
                 .closure = closure,
                 .code = func.code.items,
@@ -658,15 +663,17 @@ pub const VM = struct {
                 if (err == VMError.ContinuationInvoked) {
                     // If the escape continuation targeted a frame within our
                     // scope, the value has been delivered — return it.
-                    if (self.frame_count >= saved_frame_count) {
+                    if (self.continuation_generation == saved_cgen and self.frame_count >= saved_frame_count) {
                         return self.continuation_value;
                     }
                     return err;
                 }
                 // On error, unwind any frames that were pushed during the thunk
-                self.frame_count = saved_frame_count;
-                self.handler_count = saved_handler_count;
-                self.wind_count = saved_wind_count;
+                if (self.continuation_generation == saved_cgen) {
+                    self.frame_count = saved_frame_count;
+                    self.handler_count = saved_handler_count;
+                    self.wind_count = saved_wind_count;
+                }
                 return err;
             };
             return result;
@@ -780,6 +787,7 @@ pub const VM = struct {
             const saved_frame_count = self.frame_count;
             const saved_handler_count = self.handler_count;
             const saved_wind_count = self.wind_count;
+            const saved_cgen = self.continuation_generation;
             self.frames[self.frame_count] = .{
                 .closure = closure,
                 .code = func.code.items,
@@ -792,12 +800,14 @@ pub const VM = struct {
 
             const result = self.runUntil(saved_frame_count, saved_wind_count) catch |err| {
                 if (err == VMError.ContinuationInvoked) {
-                    if (self.frame_count >= saved_frame_count) return self.continuation_value;
+                    if (self.continuation_generation == saved_cgen and self.frame_count >= saved_frame_count) return self.continuation_value;
                     return err;
                 }
-                self.frame_count = saved_frame_count;
-                self.handler_count = saved_handler_count;
-                self.wind_count = saved_wind_count;
+                if (self.continuation_generation == saved_cgen) {
+                    self.frame_count = saved_frame_count;
+                    self.handler_count = saved_handler_count;
+                    self.wind_count = saved_wind_count;
+                }
                 return err;
             };
             return result;

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -164,14 +164,14 @@ pub fn performWindTransition(vm: *VM, target_winds: []const types.WindRecord, ta
         common += 1;
     }
 
-    // Unwind: call after thunks from current top down to common
-    var i = vm.wind_count;
-    while (i > common) {
-        i -= 1;
-        const after = vm.wind_stack[i].after;
+    // Unwind: call after thunks from current top down to common.
+    // Decrement wind_count before each call so re-entrant wind
+    // transitions (from exceptions in after-thunks) don't re-run it.
+    while (vm.wind_count > common) {
+        vm.wind_count -= 1;
+        const after = vm.wind_stack[vm.wind_count].after;
         _ = try vm.callThunk(after);
     }
-    vm.wind_count = common;
 
     // Rewind: call before thunks from common up to target
     var j = common;
@@ -238,4 +238,5 @@ pub fn restoreContinuation(vm: *VM, cont: *types.Continuation, value: Value) VME
     vm.registers[dst_idx] = value;
     vm.continuation_value = value;
     vm.continuation_invoked = true;
+    vm.continuation_generation +%= 1;
 }

--- a/tests/scheme/smoke/continuation-wind-870.scm
+++ b/tests/scheme/smoke/continuation-wind-870.scm
@@ -1,0 +1,20 @@
+;; Regression test for #870: full continuation restore misread as escape
+;; by callThunk — wind_count underflow panic when invoked inside dynamic-wind.
+
+(define (main)
+  (let ((k #f) (done (vector #f)))
+    (define (deep n)
+      (if (= n 0)
+          (call/cc (lambda (c) (set! k c) 0))
+          (+ 1 (deep (- n 1)))))
+    (deep 5)
+    (if (not (vector-ref done 0))
+        (begin
+          (vector-set! done 0 #t)
+          (dynamic-wind
+            (lambda () #f)
+            (lambda () (k 0))
+            (lambda () #f))))
+    'ok))
+(display (main))
+(newline)

--- a/tests/scheme/smoke/dynamic-wind-double-875.scm
+++ b/tests/scheme/smoke/dynamic-wind-double-875.scm
@@ -1,0 +1,14 @@
+;; Regression test for #875: dynamic-wind after-thunk must run exactly once
+;; even when the exit is via a continuation (call/ec or call/cc).
+
+(define count 0)
+
+(call-with-current-continuation
+  (lambda (exit)
+    (dynamic-wind
+      (lambda () #f)
+      (lambda () (exit 'done))
+      (lambda () (set! count (+ count 1))))))
+
+(display (= count 1))
+(newline)


### PR DESCRIPTION
## Summary
- Add `continuation_generation` counter to VM, bumped on full continuation restore
- Guard all `frame_count >= saved_frame_count` escape-detection checks with generation comparison
- Fix `performWindTransition` to decrement `wind_count` before calling after-thunks

## Test plan
- [x] Regression test for #870 (full continuation inside dynamic-wind)
- [x] Regression test for #875 (after-thunk count check)
- [x] Unit tests pass
- [x] Scheme integration tests running

Fixes #870, #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)