### PR TITLE
Fix string-join default delimiter from empty to single space

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -359,7 +359,7 @@ fn stringJoinFn(args: []const Value) PrimitiveError!Value {
     const delim: []const u8 = if (args.len > 1)
         (try getStringSlice(args[1]))
     else
-        "";
+        " ";
 
     // Calculate total length
     var total: usize = 0;


### PR DESCRIPTION
Fixes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)