### PR TITLE
Fix cond-expand (library ...) and include in library bodies

### DIFF
--- a/src/compiler_conditionals.zig
+++ b/src/compiler_conditionals.zig
@@ -368,9 +368,24 @@ pub fn evalFeatureReq(self: *Compiler, req: Value) bool {
             for (known_libs) |l| {
                 if (std.mem.eql(u8, lib_name, l)) return true;
             }
-            // Also check the VM's live library registry via globals
-            // The compiler doesn't have direct VM access, so check if
-            // the library exists on disk as a .sld file
+            // Check the VM's live library registry and .sld files on disk
+            const vm_mod = @import("vm.zig");
+            if (vm_mod.vm_instance) |vm| {
+                if (vm.libraries.get(lib_name) != null) return true;
+                const vm_library_mod = @import("vm_library.zig");
+                var path_buf: [512]u8 = undefined;
+                const rel_path = vm_library_mod.buildLibRelPath(lib_name_list, &path_buf) catch return false;
+                for (vm.lib_paths) |dir| {
+                    var full_buf: [1024:0]u8 = undefined;
+                    const full_len = std.fmt.bufPrint(&full_buf, "{s}/{s}", .{ dir, rel_path }) catch continue;
+                    full_buf[full_len.len] = 0;
+                    const fd = std.posix.system.open(@ptrCast(&full_buf), .{}, @as(u32, 0));
+                    if (fd >= 0) {
+                        _ = std.posix.system.close(fd);
+                        return true;
+                    }
+                }
+            }
             return false;
         }
     }

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -141,7 +141,7 @@ fn processImportSet(vm: *VM, target: *std.StringHashMap(Value), import_set: Valu
 
 /// Build the relative .sld path from a library name list.
 /// (mylib util) -> "mylib/util.sld"
-fn buildLibRelPath(name_list: Value, buf: *[512]u8) ![]const u8 {
+pub fn buildLibRelPath(name_list: Value, buf: *[512]u8) ![]const u8 {
     var pos: usize = 0;
     var current = name_list;
     var first = true;
@@ -1216,5 +1216,6 @@ fn isLibTopLevelForm(expr: Value) bool {
     const name = types.symbolName(head);
     if (std.mem.eql(u8, name, "define-record-type")) return true;
     if (std.mem.eql(u8, name, "define-values")) return true;
+    if (std.mem.eql(u8, name, "include")) return true;
     return false;
 }

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -565,7 +565,21 @@ fn evalLibFeatureReq(vm: *VM, req: Value) bool {
             const lib_name_list = types.car(rest);
             const lib_name = library_mod.libraryNameToString(vm.gc.allocator, lib_name_list) catch return false;
             defer vm.gc.allocator.free(lib_name);
-            return vm.libraries.get(lib_name) != null;
+            if (vm.libraries.get(lib_name) != null) return true;
+            // Check if a .sld file exists on the library path
+            var path_buf: [512]u8 = undefined;
+            const rel_path = buildLibRelPath(lib_name_list, &path_buf) catch return false;
+            for (vm.lib_paths) |dir| {
+                var full_buf: [1024:0]u8 = undefined;
+                const full_len = std.fmt.bufPrint(&full_buf, "{s}/{s}", .{ dir, rel_path }) catch continue;
+                full_buf[full_len.len] = 0;
+                const fd = std.posix.system.open(@ptrCast(&full_buf), .{}, @as(u32, 0));
+                if (fd >= 0) {
+                    _ = std.posix.system.close(fd);
+                    return true;
+                }
+            }
+            return false;
         }
     }
     return false;

--- a/tests/scheme/smoke/condexpand-include-lib-868-879.scm
+++ b/tests/scheme/smoke/condexpand-include-lib-868-879.scm
@@ -1,0 +1,29 @@
+;;; Regression tests for #868 and #879
+;;;
+;;; #868: cond-expand (library ...) should detect importable .sld
+;;;       libraries that haven't been loaded yet
+;;; #879: (include ...) inside a library begin block should work
+
+(import (scheme base) (scheme write))
+
+;; --- Test #868: cond-expand (library ...) for unloaded .sld library ---
+;; (test helpers) is a .sld file on the lib path but not yet imported.
+;; cond-expand should detect it via file existence check.
+(display
+  (cond-expand
+    ((library (test helpers)) "found")
+    (else "not-found")))
+(newline)
+
+;; Also verify that non-existent libraries correctly return false
+(display
+  (cond-expand
+    ((library (test nonexistent-library-xyz)) "found")
+    (else "not-found")))
+(newline)
+
+;; --- Test #879: include inside library begin block ---
+;; (test with-include) uses (include "incbody.scm") in its begin block
+(import (test with-include))
+(display included-value)
+(newline)

--- a/tests/scheme/smoke/lib868/test/helpers.sld
+++ b/tests/scheme/smoke/lib868/test/helpers.sld
@@ -1,0 +1,4 @@
+(define-library (test helpers)
+  (export helper-value)
+  (begin
+    (define helper-value 42)))

--- a/tests/scheme/smoke/lib868/test/incbody.scm
+++ b/tests/scheme/smoke/lib868/test/incbody.scm
@@ -1,0 +1,1 @@
+(define included-value 99)

--- a/tests/scheme/smoke/lib868/test/with-include.sld
+++ b/tests/scheme/smoke/lib868/test/with-include.sld
@@ -1,0 +1,4 @@
+(define-library (test with-include)
+  (export included-value)
+  (begin
+    (include "incbody.scm")))


### PR DESCRIPTION
## Summary
- cond-expand (library ...) checks .sld file existence on library path (#868)
- include in library begin blocks routed through handleTopLevelForm (#879)

Fixes #868, #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)