### PR TITLE
Fix double hygiene renaming in macro-generating macros

### DIFF
--- a/src/expander.zig
+++ b/src/expander.zig
@@ -744,6 +744,13 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
     const QUOTE_FLAG: u32 = 0x40000000;
     const BINDING_FLAG: u32 = 0x20000000;
     if ((scope & QUOTE_FLAG) != 0) return gc.allocSymbol(name);
+
+    // Already renamed by an enclosing expansion: macro-generating macros
+    // bake __hyg_ names into the inner macro's stored template. Gensyms are
+    // globally unique, so renaming again cannot prevent any capture — it
+    // only severs the reference from the binding created by the generating
+    // expansion (issue #919: __hyg_N___hyg_M_march-hare undefined).
+    if (std.mem.startsWith(u8, name, "__hyg_")) return gc.allocSymbol(name);
     const in_binding = (scope & BINDING_FLAG) != 0;
     const clean_scope = scope & ~BINDING_FLAG;
     if (globals) |g| {

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -180,3 +180,21 @@ test "default-random-source is per-VM" {
     const rs1_again = try vm1.eval("(default-random-source)");
     try std.testing.expectEqual(rs1, rs1_again);
 }
+
+test "vm deinit clears threadlocal vm_instance" {
+    const vm_mod = @import("vm.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+
+    // execute() registers the VM in the threadlocal
+    _ = try vm.eval("(+ 1 2)");
+    try std.testing.expect(vm_mod.vm_instance == &vm);
+
+    // deinit must unregister it: a stale pointer here is read by the macro
+    // expander (renameForHygiene) during the next VM's first compile, before
+    // that VM's own execute() re-registers the threadlocal — a use-after-free
+    // that crashed the Linux unit-test runs.
+    vm.deinit();
+    try std.testing.expect(vm_mod.vm_instance == null);
+}

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -299,3 +299,52 @@ test "let-syntax rejects malformed binding without transformer" {
     const result = vm.eval("(let-syntax ((my-macro)) 1)");
     try std.testing.expectError(error.CompileError, result);
 }
+
+test "hygiene: macro-generating macro shares binding with inner macro" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Issue #919: the inner macro's stored template references march-hare,
+    // already hygiene-renamed by the outer expansion. Expanding (mad-hatter)
+    // must not rename it a second time, or the reference is severed from
+    // the binding the outer expansion created.
+    _ = try vm.eval(
+        \\(define-syntax jabberwocky
+        \\  (syntax-rules ()
+        \\    ((_ hatter)
+        \\     (begin
+        \\       (define march-hare 42)
+        \\       (define-syntax hatter
+        \\         (syntax-rules ()
+        \\           ((_) march-hare)))))))
+    );
+    _ = try vm.eval("(jabberwocky mad-hatter)");
+    const result = try vm.eval("(mad-hatter)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "hygiene: inner syntax-rules pattern variables shadow outer bindings" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Issue #919 (pattern-variable scoping variant): the inner macro's
+    // pattern variable x must not be confused with the use-site symbol x
+    // substituted for the outer pattern variable y.
+    const result = try vm.eval(
+        \\(let ()
+        \\  (define-syntax foo
+        \\    (syntax-rules ()
+        \\      ((foo bar y)
+        \\       (define-syntax bar
+        \\         (syntax-rules ()
+        \\           ((bar x) 'y))))))
+        \\  (foo bar x)
+        \\  (bar 1))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("x", types.symbolName(result));
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -301,6 +301,11 @@ pub const VM = struct {
     }
 
     pub fn deinit(self: *VM) void {
+        // execute() registers the VM in the threadlocal; without this reset a
+        // later VM on the same thread (e.g. the next unit test) would reach a
+        // freed globals map through vm_instance during compile-time macro
+        // expansion, before its own first execute() re-registers it.
+        if (vm_instance == self) vm_instance = null;
         if (self.scheduler) |sched| {
             self.gc.allocator.destroy(sched);
             self.scheduler = null;

--- a/tests/scheme/hygiene/hygiene.scm
+++ b/tests/scheme/hygiene/hygiene.scm
@@ -131,6 +131,36 @@
   (test-equal "my-list" '(1 2 3) (my-list 1 2 3))
   (test-eqv "my-begin" 3 (my-begin 1 2 3)))
 
+;; -------------------------------------------------------------------------
+;; 8. Macro-generating macros (issue #919): identifiers renamed by the outer
+;;    expansion and baked into the inner macro's template must not be renamed
+;;    again when the inner macro expands, and inner pattern variables must
+;;    shadow outer substitutions.
+;; -------------------------------------------------------------------------
+
+(define-syntax jabberwocky
+  (syntax-rules ()
+    ((_ hatter)
+     (begin
+       (define march-hare 42)
+       (define-syntax hatter
+         (syntax-rules ()
+           ((_) march-hare)))))))
+(jabberwocky mad-hatter)
+
+(test-group "macro-generating macros"
+  (test-eqv "inner macro sees outer expansion's binding" 42 (mad-hatter))
+  (test-eqv "inner pattern variable shadows outer substitution" 'x
+    (let ()
+      (define-syntax foo
+        (syntax-rules ()
+          ((foo bar y)
+           (define-syntax bar
+             (syntax-rules ()
+               ((bar x) 'y))))))
+      (foo bar x)
+      (bar 1))))
+
 (set! %test-fail-count (test-runner-fail-count (test-runner-current)))
 (test-end "hygiene")
 (if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
Fixes #919.

## Problem

When a macro's template defines another macro, identifiers in the inner template that were already hygiene-renamed by the outer expansion (e.g. `__hyg_369_march-hare`) got renamed a **second time** when the inner macro expanded, producing `__hyg_373___hyg_369_march-hare` — a name that no longer matches the binding the outer expansion created:

```scheme
(define-syntax jabberwocky
  (syntax-rules ()
    ((_ hatter)
     (begin
       (define march-hare 42)
       (define-syntax hatter
         (syntax-rules ()
           ((_) march-hare)))))))
(jabberwocky mad-hatter)
(mad-hatter)   ; error: undefined variable '__hyg_373___hyg_369_march-hare'
```

## Fix

`renameForHygiene` in `src/expander.zig` now returns identifiers that already carry the `__hyg_` prefix unchanged. Renaming an already-renamed identifier cannot prevent any capture — gensyms are globally unique, so they can never collide with user identifiers. Renaming again only severs the reference from the binding created by the generating expansion. This approximates proper sets-of-scopes behavior: adding a scope to an identifier never stops it from resolving to a binding carrying a subset of its scopes.

The pattern-variable scoping variant from the issue (`instantiateNestedSyntaxRules` excluding inner pattern variables from outer substitution) already worked; it now has a guard test.

## Tests

- New Zig unit tests in `src/tests_macros.zig`: the jabberwocky case (fails without the fix, passes with it) and the inner-pattern-variable shadowing case.
- New "macro-generating macros" section in `tests/scheme/hygiene/hygiene.scm`.
- The jabberwocky test at `tests/scheme/r7rs/r7rs-tests.scm:536` now passes; the R7RS suite reports 1393 pass, 0 fail.
- `zig build test` (439 tests) and `bash tests/scheme/run-all.sh` fully green.

## Out of scope (found while verifying, flagged separately)

- `r7rs-tests.scm:580` (forward hygienic refs — template referencing a local defined later in the same body) and `r7rs-tests.scm:633` (section 5 compile error) still error; different root causes.
- SRFI-64 assertions in `tests/scheme/` are currently silent no-ops on main (`%test-on-test-begin` undefined, exit 0), so the hygiene.scm addition only becomes an active guard once that is fixed. The Zig unit tests carry the regression coverage meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)