### PR TITLE
Fix two R7RS suite forms aborted by hygiene and macro-shadowing bugs

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1046,8 +1046,15 @@ pub const Compiler = struct {
                 if (std.mem.eql(u8, effective_name, "syntax-rules")) return CompileError.InvalidSyntax;
             } // end if (!is_local)
 
-            // Check if head is a macro keyword
-            if (self.lookupMacro(name)) |transformer| {
+            // Check if head is a macro keyword. A variable binding in scope
+            // shadows the macro (R7RS 5.3: a body's definitions shadow outer
+            // syntactic bindings), so a local or captured binding with the
+            // same name makes this a procedure call instead.
+            const macro_hit: ?Value = if (self.lookupMacro(name)) |t|
+                if (self.resolveLocal(name) != null or (try self.resolveUpvalue(name)) != null) null else t
+            else
+                null;
+            if (macro_hit) |transformer| {
                 if (self.macro_expansion_depth >= MAX_MACRO_EXPANSION_DEPTH or
                     self.macro_expansion_steps >= MAX_MACRO_EXPANSION_STEPS)
                 {

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -740,6 +740,13 @@ fn substitutePatternVarsOnly(gc: *GC, template: Value, bindings: []Binding) !Val
     return gc.allocPair(car_root, new_cdr);
 }
 
+fn scopeTableContains(scope: u32, name: []const u8) bool {
+    for (scope_table[0..scope_table_count]) |entry| {
+        if (entry.scope == scope and std.mem.eql(u8, entry.original_name, name)) return true;
+    }
+    return false;
+}
+
 fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.StringHashMap(Value)) !Value {
     const QUOTE_FLAG: u32 = 0x40000000;
     const BINDING_FLAG: u32 = 0x20000000;
@@ -757,6 +764,17 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
         if (g.get(name)) |val| {
             if (types.isProcedure(val) or types.isTransformer(val)) {
                 if (!in_binding) return gc.allocSymbol(name);
+            } else if (val == types.VOID) {
+                // VOID entries are sentinels planted by the compiler's body
+                // prescan (compileBody/compileLetBody) for internal defines
+                // that appear later in the same body — the template reference
+                // must keep its name so it resolves to that binding (R7RS
+                // 5.3.2 letrec* body semantics). But if this expansion already
+                // renamed the name as a template-introduced binding, the
+                // reference must follow the rename instead.
+                if (!in_binding and !scopeTableContains(clean_scope, name)) {
+                    return gc.allocSymbol(name);
+                }
             }
         }
     }

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -325,6 +325,56 @@ test "hygiene: macro-generating macro shares binding with inner macro" {
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
 }
 
+test "hygiene: template references sibling define that appears later in body" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // R7RS 5.3.2: body defines have letrec* scope, so the macro-definition
+    // environment includes bar399 even though it is defined after the macro.
+    // The expander must not hygiene-rename the template's free reference.
+    const result = try vm.eval(
+        \\(let ()
+        \\  (define-syntax foo399
+        \\    (syntax-rules () ((foo399) (bar399))))
+        \\  (define (quux399) (foo399))
+        \\  (define (bar399) 42)
+        \\  (quux399))
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "internal define shadows a macro keyword bound outside the body" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The first form's (foo bar x) expands to a define-syntax for bar that
+    // escapes the let body. The second form's internal (define bar ...) is a
+    // variable binding for the whole body (R7RS 5.3), so (bar x y) must
+    // compile as a procedure call, not as a use of the leaked macro.
+    _ = try vm.eval(
+        \\(let ()
+        \\  (define-syntax foo
+        \\    (syntax-rules ()
+        \\      ((foo bar y)
+        \\       (define-syntax bar
+        \\         (syntax-rules ()
+        \\           ((bar x) 'y))))))
+        \\  (foo bar x)
+        \\  (bar 1))
+    );
+    const result = try vm.eval(
+        \\(let ((x 5))
+        \\  (define foo (lambda (y) (bar x y)))
+        \\  (define bar (lambda (a b) (+ (* a b) a)))
+        \\  (foo (+ x 3)))
+    );
+    try std.testing.expectEqual(@as(i64, 45), types.toFixnum(result));
+}
+
 test "hygiene: inner syntax-rules pattern variables shadow outer bindings" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/tests/scheme/hygiene/define-shadows-macro-keyword.scm
+++ b/tests/scheme/hygiene/define-shadows-macro-keyword.scm
@@ -1,0 +1,41 @@
+;; Regression test: an internal define must shadow a macro keyword bound
+;; outside the body (R7RS 5.3). The first form's (foo bar x) expands to a
+;; define-syntax for bar whose registration escapes the let body; the
+;; second form's (define bar (lambda (a b) ...)) is a variable binding
+;; for the whole body, so (bar x y) must compile as a procedure call.
+;; Previously it was expanded as a use of the leaked one-argument macro,
+;; aborting the form with error.InvalidSyntax (R7RS suite line 633).
+;;
+;; Note: compile errors abort a top-level form without setting a non-zero
+;; exit code, so the result is checked via a flag in a separate form.
+
+(define ok #f)
+
+;; Leak a generated macro named gen-bar out of a let body
+;; (mirrors R7RS suite lines 547-555).
+(let ()
+  (define-syntax gen-foo
+    (syntax-rules ()
+      ((gen-foo gen-bar y)
+       (define-syntax gen-bar
+         (syntax-rules ()
+           ((gen-bar x) 'y))))))
+  (gen-foo gen-bar marker)
+  (if (not (eq? (gen-bar 1) 'marker))
+      (begin (display "FAIL: generated macro broken") (newline) (exit 1))))
+
+;; Now an internal define of the same name must shadow the macro keyword.
+(let ((r (let ((x 5))
+           (define use-it (lambda (y) (gen-bar x y)))
+           (define gen-bar (lambda (a b) (+ (* a b) a)))
+           (use-it (+ x 3)))))
+  (if (equal? r 45)
+      (set! ok #t)
+      (begin
+        (display "FAIL: expected 45, got ")
+        (display r)
+        (newline))))
+
+(if ok
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL: internal define did not shadow macro keyword") (newline) (exit 1)))

--- a/tests/scheme/hygiene/forward-sibling-define-ref.scm
+++ b/tests/scheme/hygiene/forward-sibling-define-ref.scm
@@ -1,0 +1,30 @@
+;; Regression test: a macro template may reference a sibling internal
+;; define that appears later in the same body. R7RS 5.3.2 gives body
+;; defines letrec* scope, so the macro-definition environment includes
+;; bar399 even though it is defined after the macro. The expander used
+;; to hygiene-rename the free reference to a gensym, producing
+;; "undefined variable '__hyg_N_bar399'" (R7RS suite line 580).
+;;
+;; Note: compile/runtime errors abort a top-level form without setting
+;; a non-zero exit code, so the result is checked via a flag in a
+;; separate top-level form.
+
+(define ok #f)
+
+(let ()
+  (define-syntax foo399
+    (syntax-rules () ((foo399) (bar399))))
+  (define (quux399)
+    (foo399))
+  (define (bar399)
+    42)
+  (if (equal? (quux399) 42)
+      (set! ok #t)
+      (begin
+        (display "FAIL: expected 42, got ")
+        (display (quux399))
+        (newline))))
+
+(if ok
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL: forward sibling define reference") (newline) (exit 1)))


### PR DESCRIPTION
## Summary

Two top-level forms in `tests/scheme/r7rs/r7rs-tests.scm` aborted with errors after the #919 fix and were counted neither pass nor fail. Both are now fixed; the suite runs **1395 pass, 0 fail** with zero aborted forms.

### Line 580 — `undefined variable '__hyg_N_bar399'` (forward hygienic refs)

The compiler's body prescan (`compileBody`/`compileLetBody`) plants `VOID` sentinels in the globals map for internal defines that appear later in the same body, so the expander keeps template references to them intact (R7RS 5.3.2 letrec* body scope). Commit d32f475 dropped the `VOID` case from `renameForHygiene`'s preservation check, so the sibling-define reference `bar399` was renamed to a gensym and severed from its binding.

Restored the `VOID` case with two guards:
- not in binding position — preserves d32f475's fix for template bindings named after built-ins
- not already renamed by this expansion as a template-introduced binding (new `scopeTableContains` check) — without this, a template that both binds and references a name colliding with a non-procedure global (e.g. the suite's `test-numeric-syntax` macro binding `z` while a global `z = (3 4)` exists) renames the binding but not the references

### Line 633 — `compile error: error.InvalidSyntax`

The suite's earlier macro-generating macro test (lines 547–555) leaks the generated one-argument macro `bar` past its `let` body. At line 633, the body's `(define bar (lambda (a b) ...))` did not shadow the leaked keyword, so `(bar x y)` was expanded as a macro use and failed pattern matching. Per R7RS 5.3 a variable binding shadows a syntactic keyword: a local or captured (upvalue) binding at the expansion site now makes the form compile as a procedure call.

The underlying macro leak (body-local macros escaping via mid-body expansions) is a separate pre-existing issue, tracked for follow-up.

## Regression tests

All four verified to fail without the fixes and pass with them:
- `src/tests_macros.zig` — two Zig unit tests, one per bug
- `tests/scheme/hygiene/forward-sibling-define-ref.scm`
- `tests/scheme/hygiene/define-shadows-macro-keyword.scm` — both use a flag-check pattern since aborted top-level forms don't set a non-zero exit code

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 239 Scheme files + 1395 R7RS tests, 0 fail
- [x] New regression tests fail on `main`, pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)