### PR TITLE
Fix use-after-free of frame pointer after re-entrant natives grow the frames array

### DIFF
--- a/src/tests_tail_calls.zig
+++ b/src/tests_tail_calls.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const vm_mod = @import("vm.zig");
 
 test "tail-recursive loop does not overflow" {
     var gc = memory.GC.init(std.testing.allocator);
@@ -110,4 +111,83 @@ test "parameterize body with tail position calls" {
     _ = try vm.eval("(define (f) (radix))");
     const result = try vm.eval("(parameterize ((radix 2)) (f))");
     try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
+}
+
+// Regression for #817: the dispatch loop captured `frame` as a pointer into
+// self.frames; a tail call to a native that re-enters the VM (map calling its
+// lambda) can grow the frames array, freeing the block `frame` points into,
+// and the handler then read frame.dst from freed memory. Shrinking the frames
+// array makes growth happen at shallow depth; scanning a contiguous depth
+// range guarantees the re-entrant push lands exactly on a capacity boundary.
+fn shrinkFrames(vm: *th.VM) !void {
+    std.testing.allocator.free(vm.frames);
+    vm.frames = try std.testing.allocator.alloc(vm_mod.CallFrame, 8);
+}
+
+test "tail call to re-entrant native across frames array growth" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    try shrinkFrames(&vm);
+
+    _ = try vm.eval(
+        \\(define (nest d)
+        \\  (if (= d 0)
+        \\      (map (lambda (x) (* 2 x)) '(1 2 3))
+        \\      (car (list (nest (- d 1))))))
+    );
+    const result = try vm.eval(
+        \\(let loop ((d 0) (ok #t))
+        \\  (if (= d 40)
+        \\      ok
+        \\      (loop (+ d 1) (and ok (equal? (nest d) '(2 4 6))))))
+    );
+    try std.testing.expectEqual(types.TRUE, result);
+}
+
+test "tail apply of re-entrant native across frames array growth" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    try shrinkFrames(&vm);
+
+    _ = try vm.eval(
+        \\(define (nest d)
+        \\  (if (= d 0)
+        \\      (apply map (lambda (x) (* 2 x)) '((1 2 3)))
+        \\      (car (list (nest (- d 1))))))
+    );
+    const result = try vm.eval(
+        \\(let loop ((d 0) (ok #t))
+        \\  (if (= d 40)
+        \\      ok
+        \\      (loop (+ d 1) (and ok (equal? (nest d) '(2 4 6))))))
+    );
+    try std.testing.expectEqual(types.TRUE, result);
+}
+
+test "tail call to parameter with converter across frames array growth" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    try shrinkFrames(&vm);
+
+    _ = try vm.eval("(define p (make-parameter 1 (lambda (v) (* v 10))))");
+    _ = try vm.eval(
+        \\(define (nest d)
+        \\  (if (= d 0)
+        \\      (p 5)
+        \\      (car (list (nest (- d 1))))))
+    );
+    _ = try vm.eval(
+        \\(let loop ((d 0))
+        \\  (unless (= d 40)
+        \\    (nest d)
+        \\    (loop (+ d 1))))
+    );
+    const result = try vm.eval("(p)");
+    try std.testing.expectEqual(@as(i64, 50), types.toFixnum(result));
 }

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -392,6 +392,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const native_start = if (self.profile_mode) vm_calls.clockNs() else 0;
                     const nargs_slice = self.registers[abs_base + 1 .. abs_base + 1 + nargs];
                     self.last_error_detail_len = 0;
+                    // native.func may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
+                    const return_dst = frame.dst;
                     const result = native.func(nargs_slice) catch |err| {
                         if (self.profile_mode) {
                             native.profile_time_ns +%= vm_calls.clockNs() -% native_start;
@@ -433,7 +436,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         self.profile_last_ns = vm_calls.clockNs();
                         self.gc.profile_alloc_target = saved_alloc_target;
                     }
-                    const return_dst = frame.dst;
                     self.frame_count -= 1;
                     if (self.profile_mode) vm_calls.profilePopReturn(self);
                     if (self.frame_count <= target_frame_count) {
@@ -459,8 +461,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const ffi_fn = types.toObject(callee).as(types.FfiFunction);
                     if (nargs != ffi_fn.param_count) return VMError.ArityMismatch;
                     const ffi_mod = @import("ffi.zig");
-                    const result = ffi_mod.callFfi(ffi_fn, self.registers[abs_base + 1 .. abs_base + 1 + nargs], self.gc) catch return VMError.TypeError;
+                    // FFI callbacks may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
+                    const result = ffi_mod.callFfi(ffi_fn, self.registers[abs_base + 1 .. abs_base + 1 + nargs], self.gc) catch return VMError.TypeError;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) {
                         return result;
@@ -470,6 +474,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isParameter(callee)) {
                     const param = types.toObject(callee).as(types.ParameterObject);
+                    // callWithArgs on the converter re-enters the VM and may
+                    // grow self.frames, invalidating `frame` — read dst first.
+                    const return_dst = frame.dst;
                     const result = if (nargs == 0) self.getParameterValue(param) else blk: {
                         var new_val = self.registers[abs_base + 1];
                         if (param.converter != types.NIL) {
@@ -478,7 +485,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         try self.setParameterValue(param, new_val);
                         break :blk types.VOID;
                     };
-                    const return_dst = frame.dst;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) {
                         return result;
@@ -583,6 +589,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             }
                         },
                     }
+                    // native.func may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
+                    const return_dst = frame.dst;
                     const result = native.func(flat_args[0..count]) catch |err| {
                         if (err == error.ContinuationInvoked) {
                             if (target_frame_count == 0) continue;
@@ -599,7 +608,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             else => VMError.InvalidBytecode,
                         };
                     };
-                    const return_dst = frame.dst;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     const caller = &self.frames[self.frame_count - 1];
@@ -620,8 +628,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const ffi_fn = types.toObject(proc).as(types.FfiFunction);
                     if (count != ffi_fn.param_count) return VMError.ArityMismatch;
                     const ffi_mod = @import("ffi.zig");
-                    const result = ffi_mod.callFfi(ffi_fn, flat_args[0..count], self.gc) catch return VMError.TypeError;
+                    // FFI callbacks may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
+                    const result = ffi_mod.callFfi(ffi_fn, flat_args[0..count], self.gc) catch return VMError.TypeError;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     const caller = &self.frames[self.frame_count - 1];
@@ -629,6 +639,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isParameter(proc)) {
                     const param = types.toObject(proc).as(types.ParameterObject);
+                    // callWithArgs on the converter re-enters the VM and may
+                    // grow self.frames, invalidating `frame` — read dst first.
+                    const return_dst = frame.dst;
                     const result = if (count == 0) self.getParameterValue(param) else blk: {
                         var new_val = flat_args[0];
                         if (param.converter != types.NIL) {
@@ -637,7 +650,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         try self.setParameterValue(param, new_val);
                         break :blk types.VOID;
                     };
-                    const return_dst = frame.dst;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     const caller = &self.frames[self.frame_count - 1];
@@ -676,12 +688,15 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 // native function isn't on the Zig stack, so its
                 // cleanup won't run. The caller's saved_wind_count
                 // tells us the correct wind level to unwind to.
-                const caller = &self.frames[self.frame_count - 1];
-                while (self.wind_count > caller.saved_wind_count) {
+                // callThunk may re-enter the VM and grow self.frames — copy
+                // the caller's fields instead of holding a pointer across it.
+                const caller_wind_count = self.frames[self.frame_count - 1].saved_wind_count;
+                const caller_base = self.frames[self.frame_count - 1].base;
+                while (self.wind_count > caller_wind_count) {
                     self.wind_count -= 1;
                     _ = self.callThunk(self.wind_stack[self.wind_count].after) catch {};
                 }
-                const ret_idx = try registerIndex(self, caller.base, return_dst);
+                const ret_idx = try registerIndex(self, caller_base, return_dst);
                 self.registers[ret_idx] = result;
             },
             .closure => {
@@ -978,6 +993,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 } else if (types.isNativeFn(callee)) {
                     const native = types.toObject(callee).as(types.NativeFn);
                     const args = self.registers[abs_base + 1 .. abs_base + 1 + nargs];
+                    // native.func may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
+                    const return_dst = frame.dst;
                     const result = if (!self.profile_mode)
                         native.func(args) catch |err| {
                             if (err == error.ContinuationInvoked) {
@@ -1030,7 +1048,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         self.gc.profile_alloc_target = saved_alloc_target;
                         break :blk r;
                     };
-                    const return_dst = frame.dst;
                     self.frame_count -= 1;
                     if (self.profile_mode) vm_calls.profilePopReturn(self);
                     if (self.frame_count <= target_frame_count) return result;


### PR DESCRIPTION
Fixes #817

## Problem

`runUntil` captures `const frame = &self.frames[self.frame_count - 1]` at the top of each dispatch iteration. The `tail_call`, `tail_apply`, and `tail_call_global` handlers invoke code that can re-enter the VM — natives that call Scheme callbacks (`map`, `sort`, `apply`, ...), parameter converters via `callWithArgs`, FFI callbacks — and afterwards read `frame.dst`. Re-entry pushes a frame via `ensureFrameCapacity`, which on growth allocates a new frames array and frees the old one, leaving `frame` dangling. Depending on heap reuse the stale read yielded a spurious `InvalidBytecode` error or silently wrote the native's return value into the wrong caller register.

The `.return` handler had the same pattern: `caller = &self.frames[...]` held across `callThunk` invocations of dynamic-wind after-thunks.

## Fix

- Read `frame.dst` into a local **before** any potentially re-entrant call, at all 7 affected sites (`tail_call` native/FFI/parameter, `tail_apply` native/FFI/parameter, `tail_call_global` native).
- In `.return`, copy the caller's `saved_wind_count`/`base` into locals instead of holding a pointer across the after-thunk calls.

The `.call`/`.call_global` paths were already safe — they never touch `frame` after re-entrant calls.

## Tests

Three regression tests in `src/tests_tail_calls.zig`, one per re-entry mechanism (native callback via `map`, `apply` of a native, parameter converter). Each shrinks the frames array to 8 entries and scans a contiguous nesting-depth range, which guarantees the re-entrant push lands exactly on a capacity boundary and forces the reallocation at the vulnerable moment. All three fail with `InvalidBytecode` without the fix and pass with it.

Verified:
- `zig build test` — 445/445 pass (442/445 pre-fix)
- `bash tests/scheme/run-all.sh` — 1634 pass, 0 fail
- The issue's original repro (depth scan 380–620 against the stock ReleaseSafe build) completes silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)