### PR TITLE
Scope macro-generated define-syntax to its body

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -33,6 +33,11 @@ const Upvalue = struct {
     is_local: bool,
 };
 
+const BodyMacro = struct {
+    name: []const u8,
+    saved: ?Value,
+};
+
 const build_options = @import("build_options");
 const MAX_COMPILER_REGISTERS: u16 = std.math.maxInt(u16);
 const MAX_MACRO_EXPANSION_DEPTH: u16 = 256;
@@ -52,6 +57,12 @@ pub const Compiler = struct {
     next_register: u16 = 0,
     parent: ?*Compiler = null,
     in_body_scope: bool = false,
+    // Body-scoped define-syntax tracking (R7RS 5.3): while depth > 0,
+    // compileDefineSyntax records each registration so the enclosing body
+    // restores the macro table on exit. At depth 0 (top level) definitions
+    // persist, which top-level (begin ...) splicing relies on.
+    body_macros: std.ArrayList(BodyMacro) = .empty,
+    body_macro_depth: u16 = 0,
     current_line: u32 = 0,
     macro_expansion_depth: u16 = 0,
     macro_expansion_steps: u32 = 0,
@@ -72,6 +83,7 @@ pub const Compiler = struct {
         self.locals.deinit(self.gc.allocator);
         self.upvalues.deinit(self.gc.allocator);
         self.macros.deinit();
+        self.body_macros.deinit(self.gc.allocator);
     }
 
     pub fn unrootFunction(gc: *memory.GC, func: *types.Function) void {
@@ -103,6 +115,38 @@ pub const Compiler = struct {
             .restricted_env = parent.restricted_env,
             .parent = parent,
         };
+    }
+
+    /// Enter a body scope for define-syntax tracking. Returns a mark for
+    /// the matching endBodyMacroScope.
+    pub fn beginBodyMacroScope(self: *Compiler) usize {
+        self.body_macro_depth += 1;
+        return self.body_macros.items.len;
+    }
+
+    /// Restore macro-table entries registered since the matching
+    /// beginBodyMacroScope, newest first so re-registrations of the same
+    /// name unwind correctly.
+    pub fn endBodyMacroScope(self: *Compiler, mark: usize) void {
+        self.body_macro_depth -= 1;
+        while (self.body_macros.items.len > mark) {
+            const entry = self.body_macros.pop().?;
+            if (entry.saved) |old_val| {
+                self.macros.put(entry.name, old_val) catch {};
+            } else {
+                _ = self.macros.remove(entry.name);
+            }
+        }
+    }
+
+    /// Record a macro registration for restoration at body-scope exit.
+    /// No-op at top level, where define-syntax must persist.
+    pub fn recordBodyMacro(self: *Compiler, name: []const u8) CompileError!void {
+        if (self.body_macro_depth == 0) return;
+        self.body_macros.append(self.gc.allocator, .{
+            .name = name,
+            .saved = self.macros.get(name),
+        }) catch return CompileError.OutOfMemory;
     }
 
     fn lookupMacro(self: *Compiler, name: []const u8) ?Value {
@@ -1279,8 +1323,11 @@ pub const Compiler = struct {
             tx.def_env_val = self.lib_env_val;
         }
 
-        // Store in macro table
-        self.macros.put(types.symbolName(keyword), transformer) catch return CompileError.OutOfMemory;
+        // Store in macro table; inside a body, track the registration so
+        // the enclosing body scope removes it on exit (R7RS 5.3).
+        const name = types.symbolName(keyword);
+        try self.recordBodyMacro(name);
+        self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
 
         // define-syntax returns void
         try self.emitOp(.load_void);
@@ -1387,6 +1434,8 @@ pub const Compiler = struct {
         self.beginScope();
         const saved_body_scope = self.in_body_scope;
         self.in_body_scope = true;
+        const macro_mark = self.beginBodyMacroScope();
+        errdefer self.endBodyMacroScope(macro_mark);
         var current = body;
         while (current != types.NIL) {
             if (!types.isPair(current)) return CompileError.InvalidSyntax;
@@ -1395,6 +1444,7 @@ pub const Compiler = struct {
             const tail = is_tail and current == types.NIL;
             try self.compileExpr(expr, dst, tail);
         }
+        self.endBodyMacroScope(macro_mark);
         self.in_body_scope = saved_body_scope;
         self.endScope();
 

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -506,10 +506,12 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
     var def_slots: [MAX_BODY_DEFS]u16 = undefined;
     var def_count: usize = 0;
 
-    const MAX_BODY_MACROS = 64;
-    var macro_names: [MAX_BODY_MACROS][]const u8 = undefined;
-    var macro_saved: [MAX_BODY_MACROS]?Value = undefined;
+    // Track define-syntax registrations (both the leading scan below and
+    // any produced mid-body by macro expansion, which reach the macro table
+    // via compileDefineSyntax) so they don't outlive the body (R7RS 5.3).
     var macro_count: usize = 0;
+    const macro_mark = self.beginBodyMacroScope();
+    defer self.endBodyMacroScope(macro_mark);
 
     var current = body;
     while (current != types.NIL and types.isPair(current)) {
@@ -555,9 +557,7 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
             const transformer = passthrough.parseSyntaxRules(self, transformer_spec) catch break;
             const name = types.symbolName(keyword);
 
-            if (macro_count >= MAX_BODY_MACROS) return CompileError.InternalLimit;
-            macro_names[macro_count] = name;
-            macro_saved[macro_count] = self.macros.get(name);
+            try self.recordBodyMacro(name);
             macro_count += 1;
 
             const tx = types.toObject(transformer).as(types.Transformer);
@@ -570,16 +570,6 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
             break;
         }
         current = types.cdr(current);
-    }
-
-    defer {
-        for (0..macro_count) |i| {
-            if (macro_saved[i]) |old_val| {
-                self.macros.put(macro_names[i], old_val) catch {};
-            } else {
-                _ = self.macros.remove(macro_names[i]);
-            }
-        }
     }
 
     if (def_count > 0) {

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -398,3 +398,60 @@ test "hygiene: inner syntax-rules pattern variables shadow outer bindings" {
     try std.testing.expect(types.isSymbol(result));
     try std.testing.expectEqualStrings("x", types.symbolName(result));
 }
+
+test "body scoping: leading define-syntax does not leak past let body" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const r1 = try vm.eval("(let () (define-syntax m (syntax-rules () ((m) 1))) (m))");
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(r1));
+
+    // After the body, m must be an ordinary identifier again.
+    _ = try vm.eval("(define (m) 2)");
+    const r2 = try vm.eval("(m)");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(r2));
+}
+
+test "body scoping: macro-generated define-syntax does not leak past body" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // (foo bar x) expands mid-body to (define-syntax bar ...); the generated
+    // macro must work for the remainder of the body (R7RS 5.3)...
+    const r1 = try vm.eval(
+        \\(let ()
+        \\  (define-syntax foo
+        \\    (syntax-rules ()
+        \\      ((foo bar y)
+        \\       (define-syntax bar
+        \\         (syntax-rules ()
+        \\           ((bar x) 'y))))))
+        \\  (foo bar x)
+        \\  (bar 1))
+    );
+    try std.testing.expect(types.isSymbol(r1));
+    try std.testing.expectEqualStrings("x", types.symbolName(r1));
+
+    // ...but must not survive the body: a later top-level (bar 1) must call
+    // the global procedure, not expand the leaked macro to 'x.
+    _ = try vm.eval("(define (bar x) 42)");
+    const r2 = try vm.eval("(bar 1)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(r2));
+}
+
+test "top-level begin: define-syntax persists for later forms" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // R7RS 5.1: top-level (begin ...) splices, so its define-syntax is a
+    // top-level definition and must remain visible afterwards.
+    _ = try vm.eval("(begin (define-syntax k (syntax-rules () ((k) 7))) #t)");
+    const result = try vm.eval("(k)");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(result));
+}

--- a/tests/scheme/hygiene/body-macro-scope.scm
+++ b/tests/scheme/hygiene/body-macro-scope.scm
@@ -1,0 +1,52 @@
+;;; Regression: define-syntax forms produced by macro expansion mid-body
+;;; must not escape their body scope (R7RS 5.3). The compiler previously
+;;; registered them untracked, leaking the generated macro into the VM
+;;; macro table for all subsequent top-level forms.
+;;;
+;;; Uses manual assertions instead of (srfi 64): a leaked macro keyword is
+;;; a compile-time effect, and the checks must not depend on macro-heavy
+;;; test machinery.
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define failures 0)
+(define (check label expected actual)
+  (if (equal? expected actual)
+      (begin (display "ok - ") (display label) (newline))
+      (begin (set! failures (+ failures 1))
+             (display "FAIL - ") (display label)
+             (display ": expected ") (write expected)
+             (display ", got ") (write actual) (newline))))
+
+;; Inside the body, the generated macro must be usable for the rest of
+;; the body.
+(check "generated macro visible in rest of body" 'inner
+  (let ()
+    (define-syntax gen
+      (syntax-rules ()
+        ((gen name)
+         (define-syntax name
+           (syntax-rules ()
+             ((name) 'inner))))))
+    (gen probe)
+    (probe)))
+
+;; After the body, the name must be an ordinary identifier again: this
+;; top-level definition and call must not expand the leaked macro.
+(define (probe) 'proc)
+(check "generated macro does not leak to top level" 'proc (probe))
+
+;; Leading define-syntax in a body must also stay body-local.
+(check "leading define-syntax visible in body" 1
+  (let ()
+    (define-syntax m (syntax-rules () ((m) 1)))
+    (m)))
+(define (m) 2)
+(check "leading define-syntax does not leak to top level" 2 (m))
+
+;; Top-level begin splices its body (R7RS 5.1), so a define-syntax inside
+;; it is a top-level definition and must persist.
+(begin
+  (define-syntax keep (syntax-rules () ((keep) 7))))
+(check "top-level begin define-syntax persists" 7 (keep))
+
+(when (> failures 0) (exit 1))


### PR DESCRIPTION
## Problem

A `define-syntax` produced by macro expansion mid-body escaped its body scope, violating R7RS 5.3 (body syntax definitions are local to the body). Given:

```scheme
(let ()
  (define-syntax foo
    (syntax-rules ()
      ((foo bar y)
       (define-syntax bar
         (syntax-rules ()
           ((bar x) 'y))))))
  (foo bar x)
  (bar 1))   ; => x  (correct)
(define (bar v) 42)
(bar 1)      ; => x  (wrong: leaked macro expands; should call the procedure)
```

`compileLetBody`'s leading scan saves/restores only the `define-syntax` forms it sees syntactically at the head of the body. The form generated by expanding `(foo bar x)` instead reaches `compileDefineSyntax`, which wrote to the compiler macro table untracked. Since `compileExpressionWithMacros` copies the whole table back into `vm.macros` after each top-level form, the generated macro persisted for all subsequent top-level code. The recent macro-shadowing fix (#926) masks the symptom when the name is rebound as a variable, but the leaked keyword still expanded at any later top-level use.

## Fix

Add a body-macro scope stack to the `Compiler`:

- `beginBodyMacroScope` / `endBodyMacroScope` bracket a body; entries unwind newest-first so re-registrations of the same name restore correctly.
- `recordBodyMacro` saves the prior table entry for any registration made while a body scope is active. At depth 0 it is a no-op, so top-level `define-syntax` persists — including top-level `(begin ...)` splicing (R7RS 5.1, exercised by r7rs-tests.scm).
- `compileDefineSyntax` records before registering, covering expansion-generated macros on both the legacy and IR compile paths.
- `compileLetBody` pushes a scope and routes its leading scan through the same mechanism, replacing the fixed 64-entry save/restore arrays (that limit is gone).
- `compileLetSyntax` bodies get the same treatment.

Lambda bodies need no change: they compile in a per-lambda child compiler whose macro table is discarded.

## Tests

- `src/tests_macros.zig`: mid-body macro-generated `define-syntax` must work for the rest of the body but not survive it (fails pre-fix: the leaked macro expanded `(bar 1)` to `'x` instead of calling the global procedure); plus pins for leading `define-syntax` body-locality and top-level `begin` persistence.
- `tests/scheme/hygiene/body-macro-scope.scm`: end-to-end regression, verified to exit 1 pre-fix. Uses manual assertions rather than SRFI-64 because SRFI-64 assertions are currently silent no-ops on main (#924).

Verified: `zig build test` passes; `tests/scheme/run-all.sh` reports 240 Scheme files + 1395 R7RS tests, 0 failures, on a fresh build rebased onto main (includes #926).

🤖 Generated with [Claude Code](https://claude.com/claude-code)