### PR TITLE
Fix nested-ellipsis expansion rejecting depth-2 pattern variables

### DIFF
--- a/src/expander.zig
+++ b/src/expander.zig
@@ -646,12 +646,14 @@ fn templateReferencesVar(template: Value, name: []const u8) bool {
 
 fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bindings: []Binding, intro_scope: u32, literals: []const Value, macro_keyword: ?[]const u8, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value)) (std.mem.Allocator.Error || ExpandError)!Value {
     // Find the repeat count from ellipsis bindings referenced in elem_template.
-    // All referenced list bindings must have equal counts (R7RS).
+    // All referenced list bindings must have equal counts (R7RS). Bindings
+    // with depth > 1 (nested ellipses) participate too: their ellipsis_count
+    // at this level is the outer repetition count, and each iteration below
+    // unpacks them one level for the inner ellipsis to consume.
     var repeat_count: usize = 0;
     var count_set = false;
     for (bindings) |b| {
         if (b.is_list and templateReferencesVar(elem_template, b.name)) {
-            if (b.depth != 1) return ExpandError.EllipsisDepthMismatch;
             if (!count_set) {
                 repeat_count = b.ellipsis_count;
                 count_set = true;

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -455,3 +455,18 @@ test "top-level begin: define-syntax persists for later forms" {
     const result = try vm.eval("(k)");
     try std.testing.expectEqual(@as(i64, 7), types.toFixnum(result));
 }
+
+test "syntax-rules nested ellipsis: depth-2 pattern variables" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Regression: variables at ellipsis depth 2 (e.g. b, c in
+    // ((a (b c) ...) ...)) were rejected with EllipsisDepthMismatch at the
+    // outer ellipsis instead of being unpacked one level per ellipsis.
+    // Surfaced by SRFI-35's `condition` construction macro.
+    _ = try vm.eval("(define-syntax nest (syntax-rules () ((nest (a (b c) ...) ...) (+ (+ a (* b c) ...) ...))))");
+    const result = try vm.eval("(nest (1 (2 3) (4 5)) (10 (6 7)))");
+    try std.testing.expectEqual(@as(i64, 79), types.toFixnum(result));
+}

--- a/tests/scheme/smoke/nested-ellipsis-depth2.scm
+++ b/tests/scheme/smoke/nested-ellipsis-depth2.scm
@@ -1,0 +1,52 @@
+;; Regression test: syntax-rules templates using pattern variables at
+;; ellipsis depth 2 — e.g. ((a (b c) ...) ...) — failed to expand with
+;; "compile error: error.InvalidSyntax" (EllipsisDepthMismatch in the
+;; expander). Surfaced by SRFI-35's `condition` construction macro:
+;; (condition (&message (message "test msg"))).
+;;
+;; Uses manual checks (not SRFI-64) and define+set! so that a compile
+;; error in a macro-using form is still caught: the set! form is skipped,
+;; the sentinel value survives, and the check fails.
+
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define failures 0)
+(define (check name got expected)
+  (if (equal? got expected)
+      (begin (display "  PASS ") (display name) (newline))
+      (begin (display "  FAIL ") (display name)
+             (display " got: ") (write got)
+             (display " expected: ") (write expected)
+             (newline)
+             (set! failures (+ failures 1)))))
+
+;; Same shape as SRFI-35's `condition` macro: depth-1 var (key) alongside
+;; depth-2 vars (f, v), with quoted depth-2 vars in the template.
+(define-syntax alist
+  (syntax-rules ()
+    ((alist (key (f v) ...) ...)
+     (list (cons 'key (list (cons 'f v) ...)) ...))))
+
+(define r1 'compile-error)
+(set! r1 (alist (k1 (a 1) (b 2)) (k2 (c 3))))
+(check "depth-2 vars with quote" r1 '((k1 (a . 1) (b . 2)) (k2 (c . 3))))
+
+(define r2 'compile-error)
+(set! r2 (alist))
+(check "zero outer repetitions" r2 '())
+
+(define r3 'compile-error)
+(set! r3 (alist (k)))
+(check "zero inner repetitions" r3 '((k)))
+
+;; Depth-2 vars in an evaluated (non-quoted) position.
+(define-syntax nest+
+  (syntax-rules ()
+    ((_ (a (b c) ...) ...)
+     (+ (+ a (* b c) ...) ...))))
+
+(define r4 'compile-error)
+(set! r4 (nest+ (1 (2 3) (4 5)) (10 (6 7))))
+(check "depth-2 arithmetic" r4 79)
+
+(if (> failures 0) (exit 1))


### PR DESCRIPTION
## Summary

`syntax-rules` templates using pattern variables bound under two ellipses — e.g. `((?type1 (?field1 ?value1) ...) ...)` — failed to expand with `compile error: error.InvalidSyntax`. Surfaced by SRFI-35's `condition` construction macro: `(condition (&message (message "test msg")))` at `tests/scheme/srfi/srfi35.scm:63` (previously masked because uncaught script errors exited 0).

The fault is in the expander, not `lib/srfi/35.sld` (which is the standard SRFI-35 reference implementation).

## Root cause

`instantiateEllipsis` in `src/expander.zig` required every ellipsis binding referenced by the template element to have depth exactly 1, returning `EllipsisDepthMismatch` otherwise. But with nested ellipses, inner variables legitimately carry depth 2 at the outer ellipsis level — they are unpacked one level per ellipsis. The unpacking logic for `depth > 1` already existed a few lines below; the check made it unreachable, so *any* macro with depth-2 pattern variables failed.

The fix removes the depth restriction. The R7RS count-consistency check (all referenced bindings must repeat the same number of times) is unchanged: a deeper binding's `ellipsis_count` at the outer level is the outer repetition count, same as depth-1 bindings.

## Tests

Both regression tests verified to **fail without the fix** and pass with it:

- Zig unit test in `src/tests_macros.zig` (without the fix: the only failure, 448/449)
- `tests/scheme/smoke/nested-ellipsis-depth2.scm` — covers the SRFI-35 shape (depth-1 var alongside quoted depth-2 vars), zero inner/outer repetitions, and evaluated positions. Uses manual checks with a `define`+`set!` sentinel rather than SRFI-64, both because SRFI-64 is currently broken on main (`%test-on-test-begin` undefined — assertions never execute) and so a compile error in the macro-using form is still detected while uncaught errors exit 0.

## Validation

- `tests/scheme/srfi/srfi35.scm`: all 26 tests pass, including the previously failing `condition syntax`
- `zig build test`: 449/449
- `bash tests/scheme/run-all.sh`: 1636 pass, 0 fail (1 skip = known SRFI-18 timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)