### PR TITLE
Fix wrong vector-partition expectation in SRFI-133 extended tests

### DIFF
--- a/tests/scheme/srfi/srfi133-ext.scm
+++ b/tests/scheme/srfi/srfi133-ext.scm
@@ -73,9 +73,21 @@
 (check "cumulate *" (vector-cumulate * 1 (vector 1 2 3 4)) (vector 1 2 6 24))
 
 ;;; vector-partition
-(let-values (((yes count) (vector-partition even? (vector 1 2 3 4 5))))
+;; Per SRFI 133, the first value is a vector the SAME SIZE as the input —
+;; satisfying elements first (in order), then the rest (in order). The
+;; second value is the count of satisfying elements.
+(let-values (((part count) (vector-partition even? (vector 1 2 3 4 5))))
   (check "partition count" count 2)
-  (check "partition vec" (vector-length yes) 2))
+  (check "partition vec" part (vector 2 4 1 3 5)))
+(let-values (((part count) (vector-partition even? (vector 2 4 6))))
+  (check "partition all count" count 3)
+  (check "partition all vec" part (vector 2 4 6)))
+(let-values (((part count) (vector-partition even? (vector 1 3 5))))
+  (check "partition none count" count 0)
+  (check "partition none vec" part (vector 1 3 5)))
+(let-values (((part count) (vector-partition even? (vector))))
+  (check "partition empty count" count 0)
+  (check "partition empty vec" part (vector)))
 
 ;;; Standard ops (re-exported)
 (check "vector" (vector 1 2 3) #(1 2 3))


### PR DESCRIPTION
## Summary

`tests/scheme/srfi/srfi133-ext.scm` failed with `FAIL: partition vec expected 2 got 5`. The reported suspicion was a bug in the built-in `vector-partition`, but the implementation is correct — the **test expectation was wrong**.

Per the [SRFI 133 spec](https://srfi.schemers.org/srfi-133/srfi-133.html), `vector-partition` returns:

1. a newly allocated vector **the same size as the input**, with satisfying elements first (in original order) followed by non-satisfying elements (in original order), and
2. the count of satisfying elements.

Kaappi returns `#(2 4 1 3 5)` and `2` for `(vector-partition even? #(1 2 3 4 5))` — exactly per spec, and consistent with the existing assertions in `tests/scheme/coverage/vector-coverage.scm`. The old test instead expected the first value to be a 2-element vector of only the matching elements. The failure had been masked because script errors previously exited 0.

## Changes

- Correct the expectation and strengthen it to compare **full vector contents** (`#(2 4 1 3 5)`), so a future regression that truncates the result to only satisfying elements is caught — the previous length-only check couldn't distinguish that.
- Add edge cases: all-satisfying, none-satisfying, and empty input vectors (checking both values each).

No Zig changes.

## Test plan

- `zig build && ./zig-out/bin/kaappi tests/scheme/srfi/srfi133-ext.scm` → `45 passed, 0 failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)