### PR TITLE
Fix thread-terminate! never stopping OS threads, hanging thread-join!

### DIFF
--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -261,6 +261,10 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_g
     vm_mod.vm_instance = child_vm;
     primitives.gc_instance = child_gc;
 
+    // Let thread-terminate! from the parent stop this thread: the dispatch
+    // loop safepoint polls this flag and unwinds with VMError.Terminated.
+    child_vm.terminate_flag = &fiber.terminated;
+
     {
         while (!child_resources_mutex.tryLock()) {}
         defer child_resources_mutex.unlock();
@@ -361,7 +365,8 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
     const ctx = try ensureScheduler();
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
 
-    fiber.terminated = true;
+    // Atomic: for OS threads the child VM polls this flag concurrently.
+    @atomicStore(bool, &fiber.terminated, true, .monotonic);
 
     if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, ctx.sched);
 

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -7,6 +7,28 @@ const primitives = @import("primitives.zig");
 const srfi18 = @import("primitives_srfi18.zig");
 const vm_mod = @import("vm.zig");
 
+// Regression test: thread-terminate! on a busy-looping OS thread must stop
+// it so thread-join! returns (raising terminated-thread-exception) instead of
+// blocking forever in pthread_join. The child VM polls fiber.terminated at
+// the dispatch-loop safepoint.
+test "thread-terminate! stops busy OS thread and join raises terminated" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(let ((t (make-thread (lambda () (let loop () (loop))))))
+        \\  (thread-start! t)
+        \\  (thread-terminate! t)
+        \\  (guard (e (#t (if (terminated-thread-exception? e) 'terminated 'other)))
+        \\    (thread-join! t)
+        \\    'no-exception))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("terminated", types.symbolName(result));
+}
+
 test "abandonFiberMutexes marks owned mutex abandoned" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -26,6 +26,7 @@ pub const VMError = error{
     InvalidArgument,
     Yielded,
     ExecutionTimeout,
+    Terminated,
 };
 
 const build_options = @import("build_options");
@@ -241,6 +242,11 @@ pub const VM = struct {
     scheduler: ?*@import("fiber.zig").FiberScheduler = null,
     current_fiber: ?*@import("fiber.zig").Fiber = null,
     yielded: bool = false,
+    /// For child OS threads (SRFI-18): points at the parent-heap fiber's
+    /// `terminated` flag. Checked at the periodic dispatch-loop safepoint so
+    /// thread-terminate! from another thread can stop this VM. Written by the
+    /// parent thread, read here — access must be atomic.
+    terminate_flag: ?*bool = null,
 
     pub fn init(gc: *memory.GC) !VM {
         const frames = try gc.allocator.alloc(CallFrame, INITIAL_FRAME_CAPACITY);

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -33,6 +33,12 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
 
         self.instruction_counter +%= 1;
         if (self.instruction_counter & 0x3FF == 0) {
+            if (self.terminate_flag) |flag| {
+                if (@atomicLoad(bool, flag, .monotonic)) {
+                    self.setErrorDetail("thread terminated", .{});
+                    return VMError.Terminated;
+                }
+            }
             if (self.timeout_deadline_ns) |deadline| {
                 if (vm_calls.clockNs() >= deadline) {
                     self.setErrorDetail("execution timed out", .{});

--- a/tests/scheme/srfi/srfi18.scm
+++ b/tests/scheme/srfi/srfi18.scm
@@ -1,4 +1,5 @@
-(import (scheme base) (scheme write) (srfi 18))
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (kaappi fibers))
 
 (define pass 0)
 (define fail 0)
@@ -117,21 +118,34 @@
   (mutex-unlock! m)
   (check "mutex-state after unlock" (mutex-state m) 'not-abandoned))
 
-;; --- Mutex contention between threads ---
+;; --- Mutex contention between fibers ---
+;; OS threads (thread-start!) run on isolated heaps and cannot share mutexes
+;; or mutable state, so contention is exercised on the same-heap fiber path.
 (let ((m (make-mutex))
       (result '()))
-  (mutex-lock! m)
-  (let ((t (make-thread
-            (lambda ()
-              (mutex-lock! m)
-              (set! result (cons 'got-lock result))
-              (mutex-unlock! m)))))
-    (thread-start! t)
-    (set! result (cons 'main-holds result))
-    (mutex-unlock! m)
-    (thread-join! t)
-    (check-true "mutex contention: thread got lock"
-      (memq 'got-lock result))))
+  (let* ((holder (spawn (lambda ()
+                          (mutex-lock! m)
+                          (set! result (cons 'holder-locked result))
+                          (thread-yield!)  ; let waiter run and block on m
+                          (set! result (cons 'holder-unlocking result))
+                          (mutex-unlock! m))))
+         (waiter (spawn (lambda ()
+                          (mutex-lock! m)
+                          (set! result (cons 'waiter-locked result))
+                          (mutex-unlock! m)))))
+    (fiber-join holder)
+    (fiber-join waiter)
+    (check "mutex contention: waiter blocked until holder unlocked"
+      (reverse result) '(holder-locked holder-unlocking waiter-locked))))
+
+;; --- OS threads cannot capture sync primitives (isolated heaps) ---
+(let* ((m (make-mutex))
+       (t (make-thread (lambda () (mutex-lock! m)))))
+  (thread-start! t)
+  (check-true "thread thunk capturing mutex raises uncaught-exception"
+    (guard (e (#t (uncaught-exception? e)))
+      (thread-join! t)
+      #f)))
 
 ;; --- Condition variable basics ---
 (check-true "condition-variable?" (condition-variable? (make-condition-variable)))
@@ -144,19 +158,19 @@
   (condition-variable-specific-set! cv 'cv-data)
   (check "condition-variable-specific" (condition-variable-specific cv) 'cv-data))
 
-;; --- Condition variable signal ---
+;; --- Condition variable signal (fiber path; see mutex contention note) ---
 (let ((m (make-mutex))
       (cv (make-condition-variable))
       (ready #f))
-  (let ((t (make-thread
-            (lambda ()
-              (mutex-lock! m)
-              (set! ready #t)
-              (condition-variable-signal! cv)
-              (mutex-unlock! m)))))
+  (let ((f (spawn (lambda ()
+                    (mutex-lock! m)
+                    (set! ready #t)
+                    (condition-variable-signal! cv)
+                    (mutex-unlock! m)))))
     (mutex-lock! m)
-    (thread-start! t)
-    (mutex-unlock! m cv)
+    (check-true "mutex-unlock! with condvar waits and wakes"
+      (mutex-unlock! m cv))
+    (fiber-join f)
     (check-true "condition-variable-signal! wakes waiter" ready)))
 
 ;; --- Time objects ---
@@ -191,11 +205,11 @@
 (check-true "with-exception-handler is available" (procedure? with-exception-handler))
 
 ;; --- Interop: spawn creates thread? objects ---
-(import (kaappi fibers))
 (let ((f (spawn (lambda () 99))))
   (check-true "spawn result is thread?" (thread? f))
   (check "fiber-join on spawned fiber" (fiber-join f) 99))
 
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
-(if (> fail 0) (error "SRFI 18 tests failed" fail))
+;; run-all.sh keys off the exit code; a top-level (error ...) exits 0.
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Problem

`tests/scheme/srfi/srfi18.scm` has hung indefinitely with zero output since at least v0.10.0; `run-all.sh` masked it as a 60s-timeout SKIP, so the suite stayed green.

Sampling the hung process showed the main thread blocked in `pthread_join` (from `thread-join!`) while the child OS thread spun forever in the dispatch loop. Root cause: `thread-terminate!` only set cooperative-fiber-scheduler flags (`fiber.terminated`, `wakeWaiters`) that a child **OS thread** spawned by `thread-start!` never observes. The test's `(let loop () (thread-yield!) (loop))` thunk ran forever (`thread-yield!` is a no-op in a schedulerless child VM), and the parent's `thread-join!` blocked forever. The file hung at its `thread-terminate!` test and, since it only prints on failure or at the end, produced no output.

## Fix

- `vm.zig`: new `VMError.Terminated`; new `VM.terminate_flag: ?*bool` pointing at the shared parent-heap `fiber.terminated` flag for child OS threads.
- `vm_dispatch.zig`: poll the flag (atomic load) at the **existing** 1024-instruction safepoint next to the timeout check — no new cost in the hot dispatch path. On termination the child unwinds with `Terminated`, the OS thread exits, `pthread_join` returns, and `thread-join!` raises `terminated-thread-exception` per SRFI-18. Works even for pure busy loops with no yields.
- `primitives_srfi18.zig`: the thread entry wires up the flag; `thread-terminate!` stores it atomically.

## Test file repairs

Two tests in `srfi18.scm` could never work as written — they captured a mutex/condvar inside an OS-thread thunk, but OS threads run on isolated heaps and sync primitives are deliberately uncopyable (`gc_deep_copy.zig`):

- Mutex contention and condvar signal are now exercised on the cooperative fiber path (`spawn`), including a real holder/waiter blocking sequence.
- New test pins the OS-thread semantics: capturing a mutex in a thread thunk raises `uncaught-exception` at join.
- The file now fails via `(exit 1)`: a top-level `(error ...)` exits 0, so the old ending could never fail `run-all.sh` anyway.

## Regression test

`tests_srfi18.zig` terminates a pure busy-loop OS thread and joins it. Verified it catches the bug: with the safepoint check removed, `zig build test` hangs indefinitely; with it, the test passes in milliseconds.

## Verification

- `zig build test`: 451/451 pass (after rebase onto main)
- `bash tests/scheme/run-all.sh`: 240 Scheme files pass, 0 fail, **0 skip** (srfi18.scm was previously the only SKIP); R7RS suite 1395/1395
- `srfi18.scm` alone: 43 passed, 0 failed, exit 0, ~2s

## Follow-ups noticed (not in this PR)

- `run-all.sh` counts timeouts as SKIP and still exits 0 — this is what hid the hang for months.
- Top-level `(thread-yield!)` from the main fiber corrupts the top-level form's value (a spawned fiber's result leaks through `runWithScheduler`) and aborts top-level `define` with `error.Yielded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)