### PR TITLE
Fix call/cc escapes lost inside re-entrant native calls

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -106,6 +106,7 @@ pub const FiberScheduler = struct {
             .base = 0,
             .dst = 0,
             .saved_wind_count = 0,
+            .seq = self.vm.nextFrameSeq(),
         };
         fiber.frame_count = 1;
         fiber.status = .created;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -174,6 +174,7 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
     const closure = types.toObject(thunk).as(types.Closure);
     @memset(fiber.registers, types.UNDEFINED);
     fiber.registers[0] = thunk;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     fiber.frames[0] = .{
         .closure = closure,
         .code = closure.func.code.items,
@@ -181,6 +182,7 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
         .base = 0,
         .dst = 0,
         .saved_wind_count = 0,
+        .seq = vm.nextFrameSeq(),
     };
     fiber.frame_count = 1;
     fiber.status = .created;

--- a/src/tests_continuations.zig
+++ b/src/tests_continuations.zig
@@ -233,3 +233,124 @@ test "nested call/ec — inner escapes inside outer" {
     const r = try vm.eval("(call/ec (lambda (o) (+ 1 (call/ec (lambda (i) (i 5))))))");
     try std.testing.expectEqual(@as(i64, 6), types.toFixnum(r));
 }
+
+test "call/cc escape inside with-exception-handler thunk" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Regression: a continuation restored inside a re-entrant native call
+    // (with-exception-handler runs its thunk via callThunk) used to unwind
+    // to the outermost dispatch loop, abandoning the native's pending
+    // result-register write — the expression returned the
+    // with-exception-handler builtin instead of the escaped value.
+
+    // call/cc in tail position of the thunk, k in tail position
+    const r1 = try vm.eval(
+        \\(with-exception-handler (lambda (e) 'err)
+        \\  (lambda () (call/cc (lambda (k) (k 42)))))
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(r1));
+
+    // call/cc in tail position, k in non-tail position
+    const r2 = try vm.eval(
+        \\(with-exception-handler (lambda (e) 'err)
+        \\  (lambda () (call/cc (lambda (k) (+ 0 (k 42))))))
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(r2));
+
+    // call/cc in non-tail position
+    const r3 = try vm.eval(
+        \\(with-exception-handler (lambda (e) 'err)
+        \\  (lambda () (+ 1 (call/cc (lambda (k) (k 41))))))
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(r3));
+}
+
+test "call/cc deep non-tail escape inside guard" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define (sum-to n k)
+        \\  (if (= n 0) (k 'done) (+ n (sum-to (- n 1) k))))
+    );
+    const r = try vm.eval(
+        \\(guard (e (#t 'caught))
+        \\  (call/cc (lambda (k) (sum-to 20 k))))
+    );
+    try std.testing.expect(types.isSymbol(r));
+    try std.testing.expectEqualStrings("done", types.symbolName(r));
+}
+
+test "nested call/cc escapes inside guard" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const r1 = try vm.eval(
+        \\(guard (e (#t 'caught))
+        \\  (call/cc (lambda (o) (call/cc (lambda (i) (i 5))))))
+    );
+    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(r1));
+
+    const r2 = try vm.eval(
+        \\(guard (e (#t 'caught))
+        \\  (call/cc (lambda (o) (+ 1 (call/cc (lambda (i) (o 7)))))))
+    );
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(r2));
+}
+
+test "out-of-lineage restore inside dynamic-wind thunk" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The continuation captured in (deep 5) predates the dynamic-wind, so
+    // invoking it inside the wind thunk must NOT be treated as the thunk
+    // returning normally — the resumesHere birth-id check propagates it out
+    // of dynamicWindFn instead (previously: wind_count underflow panic).
+    const r = try vm.eval(
+        \\(let ((k #f) (done (vector #f)))
+        \\  (define (deep n)
+        \\    (if (= n 0)
+        \\        (call/cc (lambda (c) (set! k c) 0))
+        \\        (+ 1 (deep (- n 1)))))
+        \\  (deep 5)
+        \\  (if (not (vector-ref done 0))
+        \\      (begin
+        \\        (vector-set! done 0 #t)
+        \\        (dynamic-wind (lambda () #f) (lambda () (k 0)) (lambda () #f))))
+        \\  'ok)
+    );
+    try std.testing.expect(types.isSymbol(r));
+    try std.testing.expectEqualStrings("ok", types.symbolName(r));
+}
+
+test "dynamic-wind after-thunk runs on nested escape under guard" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define trace '())");
+    const r = try vm.eval(
+        \\(guard (e (#t 'caught))
+        \\  (call/cc
+        \\   (lambda (k)
+        \\     (dynamic-wind
+        \\       (lambda () (set! trace (cons 'before trace)))
+        \\       (lambda () (set! trace (cons 'during trace)) (k 'out) (set! trace (cons 'never trace)))
+        \\       (lambda () (set! trace (cons 'after trace)))))))
+    );
+    try std.testing.expectEqualStrings("out", types.symbolName(r));
+    const log = try vm.eval("(reverse trace)");
+    try std.testing.expectEqualStrings("before", types.symbolName(types.car(log)));
+    try std.testing.expectEqualStrings("during", types.symbolName(types.car(types.cdr(log))));
+    try std.testing.expectEqualStrings("after", types.symbolName(types.car(types.cdr(types.cdr(log)))));
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -357,9 +357,10 @@ pub const SavedFrame = struct {
     base: u32,
     dst: u16,
     saved_wind_count: u16,
-    // On wasm32, pointer-sized fields shrink from 8 to 4 bytes, making the
-    // struct 28 bytes — not a multiple of @sizeOf(Value) (8). Pad to 32.
-    _pad: if (@sizeOf(usize) < 8) [4]u8 else [0]u8 = undefined,
+    // Frame birth id (see CallFrame.seq in vm.zig). The u64 also forces
+    // 8-byte alignment on wasm32, keeping the struct size a multiple of
+    // @sizeOf(Value) without manual padding.
+    seq: u64,
 };
 
 /// Saved exception handler for continuation capture.

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -150,6 +150,12 @@ pub const CallFrame = struct {
     base: u32,
     dst: u16,
     saved_wind_count: u16 = 0,
+    // Birth id, unique per pushed frame (VM.nextFrameSeq). Tail calls reuse
+    // the frame and keep its seq; continuation capture/restore preserves it.
+    // Dispatch loops use it to tell whether a restored frame stack still
+    // contains the loop's own scope-root frame (resume here) or jumps to a
+    // different program point (propagate ContinuationInvoked outward).
+    seq: u64 = 0,
 };
 
 pub const StepMode = enum { none, step, next, step_out, continue_to_break };
@@ -186,6 +192,8 @@ pub const VM = struct {
     continuation_invoked: bool = false,
     continuation_value: Value = types.VOID,
     continuation_generation: u32 = 0,
+    /// Monotonic counter backing CallFrame.seq (0 is never a valid seq).
+    frame_seq: u64 = 0,
     stdin_port: Value = types.VOID,
     stdout_port: Value = types.VOID,
     stderr_port: Value = types.VOID,
@@ -497,6 +505,12 @@ pub const VM = struct {
 
     // -- Exception handling --
 
+    /// Allocate a fresh frame birth id (see CallFrame.seq).
+    pub fn nextFrameSeq(self: *VM) u64 {
+        self.frame_seq +%= 1;
+        return self.frame_seq;
+    }
+
     pub fn pushHandler(self: *VM, handler: Value) VMError!void {
         if (self.handler_count >= MAX_HANDLERS) return VMError.StackOverflow;
         self.handler_stack[self.handler_count] = .{
@@ -570,6 +584,7 @@ pub const VM = struct {
                 .base = base,
                 .dst = return_dst,
                 .saved_wind_count = @intCast(self.wind_count),
+                .seq = self.nextFrameSeq(),
             };
             self.frame_count += 1;
 
@@ -661,6 +676,7 @@ pub const VM = struct {
                 .base = base,
                 .dst = 0,
                 .saved_wind_count = @intCast(self.wind_count),
+                .seq = self.nextFrameSeq(),
             };
             self.frame_count += 1;
 
@@ -800,6 +816,7 @@ pub const VM = struct {
                 .base = base,
                 .dst = 0,
                 .saved_wind_count = @intCast(self.wind_count),
+                .seq = self.nextFrameSeq(),
             };
             self.frame_count += 1;
 

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -101,6 +101,7 @@ pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
         .base = 0,
         .dst = 0,
         .saved_wind_count = 0,
+        .seq = vm.nextFrameSeq(),
     };
     vm.frame_count = 1;
 
@@ -321,6 +322,7 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u32, nargs: u8) VMErr
         .base = new_base,
         .dst = @intCast(base - vm.frames[vm.frame_count - 1].base),
         .saved_wind_count = @intCast(vm.wind_count),
+        .seq = vm.nextFrameSeq(),
     };
     vm.frame_count += 1;
 

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -44,6 +44,7 @@ pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u32) VMError!Value {
             .base = f.base,
             .dst = f.dst,
             .saved_wind_count = f.saved_wind_count,
+            .seq = f.seq,
         };
     }
 
@@ -210,6 +211,7 @@ pub fn restoreContinuation(vm: *VM, cont: *types.Continuation, value: Value) VME
             .base = saved_frame.base,
             .dst = saved_frame.dst,
             .saved_wind_count = saved_frame.saved_wind_count,
+            .seq = saved_frame.seq,
         };
     }
     vm.frame_count = cont.frame_count;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -24,7 +24,33 @@ fn stripHygienicPrefix(name: []const u8) []const u8 {
     return n;
 }
 
+/// True when a just-restored (or escape-unwound) frame stack should resume in
+/// THIS dispatch loop: the new stack must still contain the loop's scope-root
+/// frame, identified by birth id — frame depth alone can't distinguish "these
+/// frames extend this loop's scope" from "these frames jump to an unrelated
+/// program point that happens to be deeper". The outermost loop (target 0)
+/// has no re-entrant Zig callers left to corrupt, so it accepts any stack.
+fn resumesHere(self: *VM, target_frame_count: usize, scope_root_seq: u64) bool {
+    if (self.frame_count <= target_frame_count) return false;
+    if (target_frame_count == 0) return true;
+    return self.frames[target_frame_count].seq == scope_root_seq;
+}
+
+/// Continuation-invoked handling: after a restore/escape delivers its value,
+/// execution must resume in the innermost dispatch loop whose scope-root
+/// frame is still live (checked by frame birth id, see resumesHere). Loops
+/// whose scope frames were discarded propagate ContinuationInvoked instead,
+/// so the re-entrant Zig callers (callThunk/callHandler in natives like
+/// with-exception-handler or dynamic-wind) between that loop and the resume
+/// point unwind and keep their pending result-register writes consistent.
 pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) VMError!Value {
+    // Birth id of this loop's scope-root frame (the frame whose return ends
+    // the loop). Tail calls reuse the frame and keep the id, so it is stable
+    // for the loop's lifetime.
+    const scope_root_seq: u64 = if (target_frame_count < self.frame_count)
+        self.frames[target_frame_count].seq
+    else
+        0;
     while (self.frame_count > target_frame_count) {
         if (self.yielded) {
             self.yielded = false;
@@ -298,7 +324,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 } else {
                     vm_calls.callValue(self, callee, base, nargs) catch |err| {
                         if (err == VMError.ContinuationInvoked) {
-                            if (self.frame_count > target_frame_count) {
+                            if (resumesHere(self, target_frame_count, scope_root_seq)) {
                                 continue;
                             }
                             return VMError.ContinuationInvoked;
@@ -402,7 +428,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             self.gc.profile_alloc_target = saved_alloc_target;
                         }
                         if (err == error.ContinuationInvoked) {
-                            if (target_frame_count == 0) {
+                            if (resumesHere(self, target_frame_count, scope_root_seq)) {
                                 continue;
                             }
                             return VMError.ContinuationInvoked;
@@ -453,7 +479,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         try self.performWindTransition(cont.wind_records[0..cont.wind_count], cont.wind_count);
                         try self.restoreContinuation(cont, value);
                     }
-                    if (target_frame_count == 0) {
+                    if (resumesHere(self, target_frame_count, scope_root_seq)) {
                         continue;
                     }
                     return VMError.ContinuationInvoked;
@@ -594,7 +620,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const return_dst = frame.dst;
                     const result = native.func(flat_args[0..count]) catch |err| {
                         if (err == error.ContinuationInvoked) {
-                            if (target_frame_count == 0) continue;
+                            if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                             return VMError.ContinuationInvoked;
                         }
                         return switch (err) {
@@ -622,7 +648,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         try self.performWindTransition(cont.wind_records[0..cont.wind_count], cont.wind_count);
                         try self.restoreContinuation(cont, value);
                     }
-                    if (target_frame_count == 0) continue;
+                    if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                     return VMError.ContinuationInvoked;
                 } else if (types.isFfiFunction(proc)) {
                     const ffi_fn = types.toObject(proc).as(types.FfiFunction);
@@ -825,7 +851,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             const cache = self.gc.allocator.alloc(Value, the_func.constants.items.len) catch {
                                 vm_calls.callValue(self, val, base, nargs) catch |err| {
                                     if (err == VMError.ContinuationInvoked) {
-                                        if (target_frame_count == 0) continue;
+                                        if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                         return VMError.ContinuationInvoked;
                                     }
                                     return err;
@@ -863,7 +889,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         const args = self.registers[base + 1 .. base + 1 + nargs];
                         const result = native.func(args) catch |err| {
                             if (err == error.ContinuationInvoked) {
-                                if (target_frame_count == 0) continue;
+                                if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                 return VMError.ContinuationInvoked;
                             }
                             return vm_calls.handleNativeError(self, err, base, nargs);
@@ -872,7 +898,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     } else {
                         vm_calls.callNative(self, native, base, nargs) catch |err| {
                             if (err == VMError.ContinuationInvoked) {
-                                if (target_frame_count == 0) continue;
+                                if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                 return VMError.ContinuationInvoked;
                             }
                             return err;
@@ -883,7 +909,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 } else {
                     vm_calls.callValue(self, callee, base, nargs) catch |err| {
                         if (err == VMError.ContinuationInvoked) {
-                            if (target_frame_count == 0) continue;
+                            if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                             return VMError.ContinuationInvoked;
                         }
                         return err;
@@ -999,7 +1025,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const result = if (!self.profile_mode)
                         native.func(args) catch |err| {
                             if (err == error.ContinuationInvoked) {
-                                if (target_frame_count == 0) continue;
+                                if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                 return VMError.ContinuationInvoked;
                             }
                             return vm_calls.handleNativeError(self, err, abs_base, nargs);
@@ -1016,7 +1042,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             self.profile_last_ns = vm_calls.clockNs();
                             self.gc.profile_alloc_target = saved_alloc_target;
                             if (err == error.ContinuationInvoked) {
-                                if (target_frame_count == 0) continue;
+                                if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                 return VMError.ContinuationInvoked;
                             }
                             return switch (err) {

--- a/tests/scheme/continuations/callcc-reentrant-escape.scm
+++ b/tests/scheme/continuations/callcc-reentrant-escape.scm
@@ -1,0 +1,94 @@
+;; Regression test: call/cc escape inside a re-entrant native call.
+;;
+;; Natives like with-exception-handler, guard, and dynamic-wind run Scheme
+;; code through a nested dispatch loop (callThunk/callHandler). Restoring a
+;; continuation captured inside that extent used to unwind all the way to the
+;; outermost loop, abandoning the native's pending result-register write: the
+;; whole expression evaluated to the with-exception-handler builtin instead of
+;; the escaped value. Fixed by resuming in the innermost dispatch loop whose
+;; scope-root frame (identified by birth id) survived the restore.
+;;
+;; Manual assertions (not SRFI-64) so this file stands alone even if the
+;; test framework itself regresses.
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define failures 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "ok: ") (display name) (newline))
+      (begin
+        (set! failures (+ failures 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write actual) (newline))))
+
+;; --- with-exception-handler extent ---
+
+(check "weh: tail call/cc, tail k" 42
+  (with-exception-handler (lambda (e) 'err)
+    (lambda () (call/cc (lambda (k) (k 42))))))
+
+(check "weh: tail call/cc, non-tail k" 42
+  (with-exception-handler (lambda (e) 'err)
+    (lambda () (call/cc (lambda (k) (+ 0 (k 42)))))))
+
+(check "weh: non-tail call/cc" 42
+  (with-exception-handler (lambda (e) 'err)
+    (lambda () (+ 1 (call/cc (lambda (k) (k 41)))))))
+
+;; --- guard extent ---
+
+(define (sum-to n k)
+  (if (= n 0)
+      (k 'done)
+      (+ n (sum-to (- n 1) k))))
+
+(check "guard: deep non-tail escape" 'done
+  (guard (e (#t 'caught))
+    (call/cc (lambda (k) (sum-to 20 k)))))
+
+(check "guard: inner escape, no arithmetic" 5
+  (guard (e (#t 'caught))
+    (call/cc (lambda (o) (call/cc (lambda (i) (i 5)))))))
+
+(check "guard: outer escape from inner extent" 7
+  (guard (e (#t 'caught))
+    (call/cc (lambda (o) (+ 1 (call/cc (lambda (i) (o 7))))))))
+
+;; --- dynamic-wind interaction ---
+
+(define trace '())
+(define (note x) (set! trace (cons x trace)))
+
+(check "guard: dynamic-wind ordering with escape" 'out
+  (guard (e (#t 'caught))
+    (call/cc
+     (lambda (k)
+       (dynamic-wind
+         (lambda () (note 'before))
+         (lambda () (note 'during) (k 'out) (note 'never))
+         (lambda () (note 'after)))))))
+
+(check "guard: dynamic-wind trace" '(before during after) (reverse trace))
+
+;; Out-of-lineage restore: the continuation predates the dynamic-wind, so
+;; invoking it inside the wind thunk must escape past dynamic-wind's native
+;; frame rather than pose as the thunk's normal return (used to corrupt the
+;; wind stack).
+(check "dynamic-wind: out-of-lineage restore" 'ok
+  (let ((k #f) (done (vector #f)))
+    (define (deep n)
+      (if (= n 0)
+          (call/cc (lambda (c) (set! k c) 0))
+          (+ 1 (deep (- n 1)))))
+    (deep 5)
+    (if (not (vector-ref done 0))
+        (begin
+          (vector-set! done 0 #t)
+          (dynamic-wind (lambda () #f) (lambda () (k 0)) (lambda () #f))))
+    'ok))
+
+(if (> failures 0)
+    (begin
+      (display failures) (display " failure(s)") (newline)
+      (exit 1)))


### PR DESCRIPTION
## Summary

Restoring a continuation captured inside the dynamic extent of a native that re-enters the dispatch loop (`with-exception-handler`, `guard`, `dynamic-wind`, `map`, …) unwound execution to the **outermost** loop: of the eleven `ContinuationInvoked` catch sites in `runUntil`, only the plain `.call` path resumed in the innermost loop containing the restored frame, while the `tail_call` / `call_global` / `tail_call_global` / `tail_apply` paths bailed unless `target_frame_count == 0`.

Since `(call/cc ...)` in tail position of a thunk compiles to `tail_call`, escaping from a `guard` or `with-exception-handler` body abandoned the native's pending result-register write, and the surrounding expression evaluated to a stale register — typically the `with-exception-handler` builtin itself:

```scheme
(guard (e (#t 'caught))
  (call/cc (lambda (k) (k 42))))   ; ⇒ #<builtin with-exception-handler>
```

Every SRFI-64 assertion wraps its expression this way, which is what broke `"deep non-tail escape"` (callcc-correctness.scm), `"inner escape, no arithmetic"` and `"outer escape from inner extent"` (callcc-nested.scm) — previously masked by the suite-wide SRFI-64 breakage being fixed separately.

## Fix

1. **Resume in the innermost dispatch loop** whose scope still contains the restored frames, so the Zig-side re-entrant callers (`callThunk`/`callHandler`) between the restore point and that loop keep delivering results correctly.
2. **Frame depth alone can't identify that loop** — a restore targeting older-but-deeper frames inside a `dynamic-wind` thunk would masquerade as the thunk's normal return and underflow the wind stack (caught by `continuation-wind-870.scm`). Each frame now carries a birth id (`CallFrame.seq`), preserved across tail-call reuse and capture/restore; `resumesHere()` resumes only where the loop's scope-root frame survived the restore, and out-of-lineage restores propagate outward exactly as before.

The `u64 seq` also gives `SavedFrame` 8-byte alignment on wasm32, replacing the manual padding (comptime asserts in `memory.zig` verify the layout).

## Tests

- Five unit tests in `src/tests_continuations.zig`: escapes under `with-exception-handler` (tail/non-tail `call/cc`, tail/non-tail `k`), deep non-tail and nested escapes under `guard`, the out-of-lineage `dynamic-wind` restore, and wind-ordering under `guard`.
- `tests/scheme/continuations/callcc-reentrant-escape.scm` — written with manual assertions so it stands alone while the SRFI-64 fix lands separately. On the pre-fix binary it reports exactly the 6 expected failures; all pass with the fix.

## Verification

- `zig build test` — pass
- `bash tests/scheme/run-all.sh` — 240 Scheme files pass, R7RS 1395/1395, 0 fail (1 pre-existing skip: srfi18 timeout, confirmed present on a baseline build without this change)
- `zig build wasm` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)