### PR TITLE
Fix lost set! writes and builtin-name capture in macro templates

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -26,6 +26,10 @@ const Local = struct {
     depth: u16,
     slot: u16,
     is_boxed: bool = false,
+    // Register alias for a global, injected during macro expansion so a
+    // template's free reference pierces use-site shadowing. set! through
+    // the alias must write back to the global (see compileSet).
+    is_global_alias: bool = false,
 };
 
 const Upvalue = struct {
@@ -240,6 +244,17 @@ pub const Compiler = struct {
             i -= 1;
             if (std.mem.eql(u8, self.locals.items[i].name, name)) {
                 return self.locals.items[i].is_boxed;
+            }
+        }
+        return false;
+    }
+
+    pub fn isLocalGlobalAlias(self: *Compiler, name: []const u8) bool {
+        var i: usize = self.locals.items.len;
+        while (i > 0) {
+            i -= 1;
+            if (std.mem.eql(u8, self.locals.items[i].name, name)) {
+                return self.locals.items[i].is_global_alias;
             }
         }
         return false;
@@ -1248,6 +1263,7 @@ pub const Compiler = struct {
                         .name = gname,
                         .depth = self.scope_depth,
                         .slot = gslot,
+                        .is_global_alias = true,
                     }) catch {};
                 }
                 const result_err = self.compileExpr(expanded_root, dst, is_tail);

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -535,7 +535,19 @@ pub fn compileSet(self: *Compiler, args: Value, dst: u16) CompileError!void {
 
     const name = types.symbolName(target);
     if (self.resolveLocal(name)) |slot| {
-        if (self.isLocalBoxed(name)) {
+        if (self.isLocalGlobalAlias(name)) {
+            // The target is a register alias injected for a macro template's
+            // free reference to a global: the variable itself lives in the
+            // globals map, so write through to it, then refresh the alias
+            // register for subsequent reads within the same expansion.
+            const sym_idx = try self.addConstant(target);
+            try self.emitOp(.set_global);
+            try self.emitU16(sym_idx);
+            try self.emitU16(dst);
+            try self.emitOp(.move);
+            try self.emitU16(slot);
+            try self.emitU16(dst);
+        } else if (self.isLocalBoxed(name)) {
             try self.emitOp(.set_box_local);
             try self.emitU16(slot);
             try self.emitU16(dst);

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -765,7 +765,13 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
     if (globals) |g| {
         if (g.get(name)) |val| {
             if (types.isProcedure(val) or types.isTransformer(val)) {
-                if (!in_binding) return gc.allocSymbol(name);
+                // A template binding of the same name in this expansion
+                // shadows the global procedure (e.g. a template let variable
+                // named exp must not resolve to the builtin exp), so the
+                // reference must follow the rename recorded for the binding.
+                if (!in_binding and !scopeTableContains(clean_scope, name)) {
+                    return gc.allocSymbol(name);
+                }
             } else if (val == types.VOID) {
                 // VOID entries are sentinels planted by the compiler's body
                 // prescan (compileBody/compileLetBody) for internal defines

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -470,3 +470,80 @@ test "syntax-rules nested ellipsis: depth-2 pattern variables" {
     const result = try vm.eval("(nest (1 (2 3) (4 5)) (10 (6 7)))");
     try std.testing.expectEqual(@as(i64, 79), types.toFixnum(result));
 }
+
+test "hygiene: template set! of a free global writes through to the global" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The compiler injects a register alias for a template's free
+    // reference to a non-procedure global so the reference pierces
+    // use-site shadowing (R7RS 4.3.1). set! through the alias used to
+    // update only the register, silently losing the assignment.
+    _ = try vm.eval("(define count 0)");
+    _ = try vm.eval(
+        \\(define-syntax inc!
+        \\  (syntax-rules ()
+        \\    ((inc!) (set! count (+ count 1)))))
+    );
+    _ = try vm.eval("(inc!)");
+    _ = try vm.eval("(inc!)");
+    const result = try vm.eval("count");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
+
+    // Same expansion inside a lambda body
+    _ = try vm.eval("(define (bump) (inc!))");
+    _ = try vm.eval("(bump)");
+    const result2 = try vm.eval("count");
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result2));
+}
+
+test "hygiene: template set! reaches the global past a use-site shadow" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define counter 0)");
+    _ = try vm.eval(
+        \\(define-syntax bump!
+        \\  (syntax-rules ()
+        \\    ((bump!) (set! counter (+ counter 1)))))
+    );
+    // The use-site local counter must stay untouched; the template's
+    // set! must mutate the definition-site global.
+    const local = try vm.eval("(let ((counter 100)) (bump!) counter)");
+    try std.testing.expectEqual(@as(i64, 100), types.toFixnum(local));
+    const global = try vm.eval("counter");
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(global));
+}
+
+test "hygiene: template binding shadows a builtin procedure of the same name" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The template binds a variable named exp; references in the
+    // template body must follow the hygienic rename of that binding,
+    // not resolve to the builtin exp procedure. (This broke the SRFI-19
+    // test harness: every `expected` value became #<builtin exp>.)
+    _ = try vm.eval(
+        \\(define-syntax capture-exp
+        \\  (syntax-rules ()
+        \\    ((_ v) (let ((exp v)) exp))))
+    );
+    const result = try vm.eval("(capture-exp 42)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+
+    // A template reference without a template binding must still reach
+    // the builtin.
+    _ = try vm.eval(
+        \\(define-syntax call-exp
+        \\  (syntax-rules ()
+        \\    ((_ v) (exp v))))
+    );
+    const builtin = try vm.eval("(exact (round (call-exp 0)))");
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(builtin));
+}

--- a/tests/scheme/hygiene/template-binds-builtin-name.scm
+++ b/tests/scheme/hygiene/template-binds-builtin-name.scm
@@ -1,0 +1,47 @@
+;; Regression test: a template-introduced binding whose name collides
+;; with a builtin procedure must shadow the builtin inside the template.
+;; renameForHygiene kept references to procedure-valued globals
+;; unrenamed, so the binding occurrence was renamed but the body
+;; references still resolved to the builtin. This broke the SRFI-19
+;; test harness, whose check macro binds (exp expected): every
+;; comparison used #<builtin exp> instead of the expected value,
+;; reporting 99 bogus failures.
+
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "  PASS  ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "  FAIL  ") (display name)
+             (display " expected=") (write expected)
+             (display " got=") (write actual) (newline))))
+
+;; 1. Template let binding named after a builtin procedure
+(define-syntax capture-exp
+  (syntax-rules ()
+    ((_ v) (let ((exp v)) exp))))
+(check "template let binding shadows builtin exp" 42 (capture-exp 42))
+
+;; 2. The SRFI-19 harness shape: two bindings, one collides with exp
+(define-syntax check-eq
+  (syntax-rules ()
+    ((_ a b)
+     (let ((result a) (exp b))
+       (equal? result exp)))))
+(check "srfi-19 harness shape compares values" #t (check-eq 7 7))
+(check "srfi-19 harness shape detects mismatch" #f (check-eq 7 8))
+
+;; 3. A template reference without a template binding still reaches
+;;    the builtin
+(define-syntax call-exp
+  (syntax-rules ()
+    ((_ v) (exp v))))
+(check "template reference still reaches builtin exp" 1 (exact (round (call-exp 0))))
+
+;; 4. Same collision with a different builtin (list)
+(define-syntax capture-list
+  (syntax-rules ()
+    ((_ v) (let ((list v)) list))))
+(check "template binding shadows builtin list" 5 (capture-list 5))
+
+(when (> fails 0) (exit 1))

--- a/tests/scheme/hygiene/template-set-global.scm
+++ b/tests/scheme/hygiene/template-set-global.scm
@@ -1,0 +1,85 @@
+;; Regression test: set! in a macro template targeting a free reference
+;; to a global variable must mutate the global (R7RS 4.3.1 referential
+;; transparency). The compiler injects a register alias for a template's
+;; free non-procedure globals so references pierce use-site shadowing;
+;; set! used to write only the alias register, silently losing the
+;; update — the global kept its old value and no error was raised.
+;; This also made counter-based test harness macros (e.g. the check
+;; macro in tests/scheme/smoke/) report "0 pass, 0 fail" and never
+;; flip the exit code on failure.
+;;
+;; check is deliberately a procedure, not a macro, so the harness
+;; itself does not depend on the behavior under test.
+
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "  PASS  ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "  FAIL  ") (display name)
+             (display " expected=") (write expected)
+             (display " got=") (write actual) (newline))))
+
+;; 1. set! of a template-free global from a top-level macro use
+(define count 0)
+(define-syntax inc!
+  (syntax-rules ()
+    ((inc!) (set! count (+ count 1)))))
+(inc!)
+(inc!)
+(check "top-level template set! of global" 2 count)
+
+;; 2. Same expansion inside a lambda body
+(define count2 0)
+(define-syntax inc2!
+  (syntax-rules ()
+    ((inc2!) (set! count2 (+ count2 1)))))
+(define (bump2) (inc2!))
+(bump2)
+(bump2)
+(bump2)
+(check "template set! of global inside lambda" 3 count2)
+
+;; 3. Use-site shadowing: the template's set! must reach the global,
+;;    and the use-site local of the same name must stay untouched
+(define counter 0)
+(define-syntax bump!
+  (syntax-rules ()
+    ((bump!) (set! counter (+ counter 1)))))
+(define shadow-result
+  (let ((counter 100))
+    (bump!)
+    counter))
+(check "use-site local untouched by template set!" 100 shadow-result)
+(check "global updated past use-site shadow" 1 counter)
+
+;; 4. Read-after-write within a single expansion
+(define acc 0)
+(define-syntax twice!
+  (syntax-rules ()
+    ((twice!) (begin (set! acc (+ acc 1)) (set! acc (+ acc 1))))))
+(twice!)
+(check "read-after-write within one expansion" 2 acc)
+
+;; 5. set! of a captured definition-site local keeps working
+(check "template set! of sibling internal define" 2
+  (let ()
+    (define n 0)
+    (define-syntax inc-n!
+      (syntax-rules ()
+        ((inc-n!) (set! n (+ n 1)))))
+    (inc-n!)
+    (inc-n!)
+    n))
+
+;; 6. Read of a sibling internal define from a template (the shape
+;;    from tests/scheme/smoke/internal-define-syntax-scope.scm case 5)
+(check "template reads sibling internal define" 15
+  (let ()
+    (define x 10)
+    (define-syntax add-x
+      (syntax-rules ()
+        ((add-x y) (+ x y))))
+    (add-x 5)))
+
+(when (> fails 0) (exit 1))


### PR DESCRIPTION
## Summary

Two macro hygiene bugs, both of which silently corrupted test-harness macros that keep pass/fail counters in globals — tests printed PASS/FAIL lines but reported "0 pass, 0 fail" and could never flip the exit code.

**1. A template's `(set! g ...)` on a free global was silently lost.**
Before expanding a macro, the compiler injects a register alias local (preloaded via `get_global`) for each template-free non-procedure global so references pierce use-site shadowing (R7RS 4.3.1). Reads worked, but `compileSet` resolved the target to that alias and emitted a plain `move` into the register — the global was never written back and no error was raised. Alias locals now carry an `is_global_alias` flag (`src/compiler.zig`) and `set!` writes through with `set_global`, then refreshes the alias register for later reads in the same expansion (`src/compiler_lambda.zig`). Use-site shadowing semantics verified: a use-site local of the same name stays untouched while the definition-site global updates.

**2. A template binding named after a builtin procedure did not shadow the builtin.**
`renameForHygiene` renamed the binding occurrence but kept references unrenamed whenever the name resolved to a procedure-valued global, so the template body saw the builtin. The procedure-preservation shortcut now consults the expansion's scope table first (`src/expander.zig`), matching what the VOID-sentinel branch already did. This was the cause of all 99 `srfi-19-tests.scm` failures — its harness binds `(exp expected)`, so every comparison used `#<builtin exp>`. That file now reports 112 passed, 0 failed.

## Relationship to PR #929

Fix 2 is the same `renameForHygiene` reorder as in #929 — whichever lands second should drop the duplicate hunk. Fix 1 is complementary to #929's VM-level `set_global` fallback: alias locals never reach `set_global` at all, so the VM fallback alone does not cover this path (verified: `(define count 0)` + template `(set! count ...)` stays 0 without this fix, with no error raised).

## Regression tests

- `tests/scheme/hygiene/template-set-global.scm` — 7 checks; exits 1 without fix 1, 0 with it. Includes the sibling-internal-define shapes from `internal-define-syntax-scope.scm` case 5 to guard already-fixed behavior.
- `tests/scheme/hygiene/template-binds-builtin-name.scm` — 5 checks including the SRFI-19 harness shape; guards that unbound template references still reach builtins.
- Three unit tests in `src/tests_macros.zig` so `zig build test` catches regressions.

## Test plan

- [x] `zig build test` passes (after rebase onto main past #932)
- [x] `bash tests/scheme/run-all.sh`: 242 Scheme files pass, 0 fail, 1 skip (pre-existing `srfi18.scm` timeout, reproduced on unfixed binary); R7RS suite 1395/1395
- [x] Both new hygiene tests verified to fail (exit 1) without the fixes
- [x] `srfi-19-tests.scm` goes from 99 masked failures to 112 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)