### PR TITLE
Fix case-lambda capturing user variables and dropping clauses past the 32nd

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -848,8 +848,10 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
     var cond_clauses: Value = types.NIL;
     var clause_list = args;
 
-    var clause_buf: [32]Value = undefined;
-    var clause_count: usize = 0;
+    // Values collected here stay reachable because no_collect is held until
+    // after the desugared form is fully built.
+    var clause_buf: std.ArrayList(Value) = .empty;
+    defer clause_buf.deinit(gc.allocator);
 
     while (clause_list != types.NIL) {
         if (!types.isPair(clause_list)) return CompileError.InvalidSyntax;
@@ -881,10 +883,7 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
         // ((= n arity) (apply ...))
         const cond_clause = try gc.allocPair(test_expr, try gc.allocPair(apply_call, types.NIL));
 
-        if (clause_count < 32) {
-            clause_buf[clause_count] = cond_clause;
-            clause_count += 1;
-        }
+        clause_buf.append(gc.allocator, cond_clause) catch return CompileError.OutOfMemory;
     }
 
     // Build else clause: (else (error "wrong number of arguments"))
@@ -894,10 +893,10 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
 
     // Build cond clauses list (in order) ending with else
     cond_clauses = try gc.allocPair(else_clause, types.NIL);
-    var ci = clause_count;
+    var ci = clause_buf.items.len;
     while (ci > 0) {
         ci -= 1;
-        cond_clauses = try gc.allocPair(clause_buf[ci], cond_clauses);
+        cond_clauses = try gc.allocPair(clause_buf.items[ci], cond_clauses);
     }
 
     // Build: (cond clauses...)

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -820,12 +820,13 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
 
 /// Compile (case-lambda (formals body ...) ...)
 ///
-/// Desugars to:
-/// (lambda args
-///   (let ((n (length args)))
+/// Desugars to (internal names %-prefixed so clause bodies referencing
+/// user variables named `args` or `n` are not captured):
+/// (lambda %cl-args
+///   (let ((%cl-n (length %cl-args)))
 ///     (cond
-///       ((= n arity1) (apply (lambda formals1 body1...) args))
-///       ((= n arity2) (apply (lambda formals2 body2...) args))
+///       ((= %cl-n arity1) (apply (lambda formals1 body1...) %cl-args))
+///       ((= %cl-n arity2) (apply (lambda formals2 body2...) %cl-args))
 ///       ...
 ///       (else (error "wrong number of arguments")))))
 pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!void {
@@ -841,8 +842,8 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
     const apply_sym = try gc.allocSymbol("apply");
     const else_sym = try gc.allocSymbol("else");
     const error_sym = try gc.allocSymbol("error");
-    const args_sym = try gc.allocSymbol("args");
-    const n_sym = try gc.allocSymbol("n");
+    const args_sym = try gc.allocSymbol("%cl-args");
+    const n_sym = try gc.allocSymbol("%cl-n");
 
     var cond_clauses: Value = types.NIL;
     var clause_list = args;

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -224,6 +224,31 @@ test "case-lambda dispatch by arity" {
     try std.testing.expectEqual(@as(i64, 7), types.toFixnum(r2));
 }
 
+test "case-lambda does not capture user variables named n or args" {
+    // Regression: the desugaring bound its internal rest-args list to `args`
+    // and the argument count to `n`, shadowing user variables of those names
+    // inside clause bodies (#836).
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define n 42)");
+    _ = try vm.eval("(define f (case-lambda ((x) (+ x n))))");
+    const r1 = try vm.eval("(f 1)");
+    try std.testing.expectEqual(@as(i64, 43), types.toFixnum(r1));
+
+    _ = try vm.eval("(define args 100)");
+    _ = try vm.eval("(define g (case-lambda ((x) (+ x args))))");
+    const r2 = try vm.eval("(g 1)");
+    try std.testing.expectEqual(@as(i64, 101), types.toFixnum(r2));
+
+    // Rest-arg clauses go through the same desugaring
+    _ = try vm.eval("(define h (case-lambda ((x . rest) (+ x n args))))");
+    const r3 = try vm.eval("(h 1 2 3)");
+    try std.testing.expectEqual(@as(i64, 143), types.toFixnum(r3));
+}
+
 // ---------------------------------------------------------------------------
 // Complex number tests
 // ---------------------------------------------------------------------------

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -249,6 +249,46 @@ test "case-lambda does not capture user variables named n or args" {
     try std.testing.expectEqual(@as(i64, 143), types.toFixnum(r3));
 }
 
+test "case-lambda dispatches to clauses beyond the 32nd" {
+    // Regression: a fixed 32-entry buffer silently dropped later clauses, so
+    // calls matching them fell through to the wrong-number-of-arguments error.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const alloc = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(alloc);
+
+    // (define f (case-lambda (() 0) ((a0) 1) ((a0 a1) 2) ... arity 33))
+    try src.appendSlice(alloc, "(define f (case-lambda");
+    var arity: usize = 0;
+    while (arity < 34) : (arity += 1) {
+        try src.appendSlice(alloc, " ((");
+        var j: usize = 0;
+        while (j < arity) : (j += 1) {
+            var buf: [16]u8 = undefined;
+            try src.appendSlice(alloc, try std.fmt.bufPrint(&buf, " a{d}", .{j}));
+        }
+        var buf: [16]u8 = undefined;
+        try src.appendSlice(alloc, try std.fmt.bufPrint(&buf, ") {d})", .{arity}));
+    }
+    try src.appendSlice(alloc, "))");
+    _ = try vm.eval(src.items);
+
+    src.clearRetainingCapacity();
+    try src.appendSlice(alloc, "(f");
+    var k: usize = 0;
+    while (k < 33) : (k += 1) {
+        try src.appendSlice(alloc, " 1");
+    }
+    try src.appendSlice(alloc, ")");
+
+    const result = try vm.eval(src.items);
+    try std.testing.expectEqual(@as(i64, 33), types.toFixnum(result));
+}
+
 // ---------------------------------------------------------------------------
 // Complex number tests
 // ---------------------------------------------------------------------------

--- a/tests/scheme/smoke/case-lambda-fixes.scm
+++ b/tests/scheme/smoke/case-lambda-fixes.scm
@@ -1,23 +1,44 @@
 ;; Regression tests for case-lambda and case fixes:
-;; #840: case-lambda drops clauses beyond 32nd
 ;; #854: case rejects empty datum list (() body)
-;; #836: case-lambda hygiene — user variables named n or args
+;; #836: case-lambda desugaring captured user variables named n or args
+;;
+;; Checks are manual (not SRFI-64) and every risky expression runs inside
+;; guard: an uncaught top-level error does not fail the process exit code,
+;; so each check must reach (exit 1) itself for run-all.sh to see a failure.
+
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define (check name expected thunk)
+  (let ((actual (guard (e (#t (display "FAIL ")
+                              (display name)
+                              (display ": raised an error")
+                              (newline)
+                              (exit 1)))
+                  (thunk))))
+    (if (equal? actual expected)
+        (begin (display "ok ") (display name) (newline))
+        (begin (display "FAIL ") (display name)
+               (display ": expected ") (write expected)
+               (display ", got ") (write actual) (newline)
+               (exit 1)))))
 
 ;; #854: empty datum list in case
-(display (case 1
-  (() 'never)
-  ((1) 'one)
-  (else 'other)))
-(newline)
+(check "case with empty datum list" 'one
+  (lambda () (case 1 (() 'never) ((1) 'one) (else 'other))))
 
-;; #836: case-lambda hygiene — user variable n
+;; #836: case-lambda clause body referencing outer variable named n
 (define n 42)
 (define f (case-lambda ((x) (+ x n))))
-(display (f 1))
-(newline)
+(check "case-lambda body sees outer n" 43
+  (lambda () (f 1)))
 
-;; #836: case-lambda hygiene — user variable args
+;; #836: case-lambda clause body referencing outer variable named args
 (define args 100)
 (define g (case-lambda ((x) (+ x args))))
-(display (g 1))
-(newline)
+(check "case-lambda body sees outer args" 101
+  (lambda () (g 1)))
+
+;; #836: rest-arg clause goes through the same desugaring
+(define h (case-lambda ((x . rest) (+ x n args))))
+(check "case-lambda rest clause sees outer n and args" 143
+  (lambda () (h 1 2 3)))


### PR DESCRIPTION
## Summary

Two independent bugs in the `case-lambda` desugaring in `src/compiler_advanced.zig`:

- **Internal bindings captured user variables named `n` or `args`.** The desugaring expanded to `(lambda args (let ((n (length args))) (cond ...)))` using plain symbols, so a clause body referencing an outer `n` or `args` silently resolved to the internal argument count / argument list instead: with `(define n 42)`, `((x) (+ x n))` returned 2 for `(f 1)` instead of 43. The internals are renamed to `%cl-args` / `%cl-n`, following the `%`-prefix convention `parameterize` already uses — these are allocated directly by the compiler and can never collide with an identifier read from source.
- **Clauses beyond the 32nd were silently dropped.** Clauses were collected into a fixed `[32]Value` buffer guarded by `if (clause_count < 32)` with no error, so a `case-lambda` with more than 32 clauses raised "wrong number of arguments" for any call matching a later clause. The buffer is now a growable `std.ArrayList(Value)`; the clause values stay GC-reachable because `no_collect` is held until the desugared form is fully built.

Both bugs were previously masked because uncaught script errors exit 0 (fix pending in #929) and the old smoke test only `display`ed values.

## Tests

- Zig regression tests in `src/tests_advanced.zig`: outer `n`/`args`/rest-clause capture checks, and a generated 34-clause `case-lambda` called at arity 33. Each verified to fail without its fix and pass with it.
- `tests/scheme/smoke/case-lambda-fixes.scm` rewritten to assert via `guard` + `(exit 1)` so it can actually fail `run-all.sh` under the current exit-code behavior (SRFI-64 is still broken on main, so checks are manual).
- Full verification: `zig build test` passes (452 tests); `bash tests/scheme/run-all.sh` reports 240 files + 1,395 R7RS tests, 0 failures (single pre-existing `srfi18.scm` timeout skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)