### PR TITLE
Fail the Scheme suite when a test file times out

### DIFF
--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -13,7 +13,7 @@ KAAPPI=zig-out/bin/kaappi
 TIMEOUT=60
 PASS=0
 FAIL=0
-SKIP=0
+TIMEDOUT=0
 R7RS_PASS=0
 R7RS_FAIL=0
 R7RS_STATUS_FAIL=0
@@ -29,8 +29,9 @@ run_file() {
     else
         kill "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true
-        echo "  SKIP  $file  (timeout after ${TIMEOUT}s)"
-        SKIP=$((SKIP + 1))
+        echo "  TIMEOUT  $file  (killed after ${TIMEOUT}s)"
+        cat /tmp/kaappi-test-out
+        TIMEDOUT=$((TIMEDOUT + 1))
         return
     fi
     if [[ $status -eq 0 ]]; then
@@ -133,10 +134,10 @@ fi
 
 echo ""
 echo "=== Summary ==="
-echo "  Scheme files: $PASS pass, $FAIL fail, $SKIP skip"
+echo "  Scheme files: $PASS pass, $FAIL fail, $TIMEDOUT timeout"
 echo "  R7RS suite:   $R7RS_PASS pass, $R7RS_FAIL fail"
-echo "  Total:        $((PASS + R7RS_PASS)) pass, $((FAIL + R7RS_FAIL + R7RS_STATUS_FAIL)) fail, $SKIP skip"
+echo "  Total:        $((PASS + R7RS_PASS)) pass, $((FAIL + R7RS_FAIL + R7RS_STATUS_FAIL + TIMEDOUT)) fail ($TIMEDOUT from timeouts)"
 
-if [[ $FAIL -gt 0 || $R7RS_FAIL -gt 0 || $R7RS_STATUS_FAIL -gt 0 ]]; then
+if [[ $FAIL -gt 0 || $TIMEDOUT -gt 0 || $R7RS_FAIL -gt 0 || $R7RS_STATUS_FAIL -gt 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
## Summary

`tests/scheme/run-all.sh` labeled per-file 60s timeouts as `SKIP`, and the final exit check only counted `FAIL`s — so a hanging test file left the suite green. This is exactly how `tests/scheme/srfi/srfi18.scm` hung unnoticed for months (fixed in #933).

With this change:
- A timed-out file prints `TIMEOUT <file> (killed after 60s)` instead of `SKIP`, and dumps the test's partial output to help locate where it stalled.
- Timeouts count into the fail total; the summary line shows `N fail (M from timeouts)`.
- The suite exits 1 if any file timed out.

## Compatibility

- The awk parsing in run-all.sh only scrapes the R7RS chibi-test `N pass, N fail` output, never the per-file labels, so it is unaffected.
- CI (`.github/workflows/ci.yml`) runs the script and relies on its exit code only.
- No docs reference the old `SKIP` label.

## Verification

- Clean run on current main: `242 pass, 0 fail, 0 timeout` / R7RS `1395 pass, 0 fail` → exit 0.
- Injected an infinite-loop test file into `tests/scheme/smoke/`: printed `TIMEOUT` label, summary `1637 pass, 1 fail (1 from timeouts)` → exit 1.
- While verifying on a pre-#933 checkout, the new logic correctly flagged the real srfi18.scm hang as a failure — the exact scenario this change is meant to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)