### PR TITLE
Mark hash-table entries occupied on insert via update!/default and alist->hash-table

### DIFF
--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -362,7 +362,7 @@ fn alistToHashTableFn(args: []const Value) PrimitiveError!Value {
         // Only add if key not already present (first occurrence wins)
         const slot = findSlot(ht, key);
         if (!slot.found) {
-            ht.entries[slot.idx] = .{ .key = key, .value = value };
+            ht.entries[slot.idx] = .{ .key = key, .value = value, .state = .occupied };
             ht.count += 1;
         }
         current = types.cdr(current);
@@ -413,7 +413,7 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
     if (slot.found) {
         ht.entries[slot.idx].value = new_val;
     } else {
-        ht.entries[slot.idx] = .{ .key = key, .value = new_val };
+        ht.entries[slot.idx] = .{ .key = key, .value = new_val, .state = .occupied };
         ht.count += 1;
     }
     return types.VOID;

--- a/tests/scheme/smoke/hashtable-insert-occupied.scm
+++ b/tests/scheme/smoke/hashtable-insert-occupied.scm
@@ -1,0 +1,61 @@
+;; Regression test: hash-table-update!/default and alist->hash-table wrote
+;; new entries without setting the entry state to occupied, so inserted keys
+;; were invisible to lookup (hash-table-ref raised "expected key to be
+;; present or default") and were dropped on the next rehash.
+;;
+;; Manual counters + guard instead of SRFI-64: a raised error must count as
+;; a failure rather than abort the enclosing form, and failure must reach
+;; the explicit (exit 1) that run-all.sh keys on.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 69))
+
+(define pass 0)
+(define fail 0)
+(define (check name thunk expected)
+  (let ((got (guard (e (#t 'check-raised-error)) (thunk))))
+    (if (equal? got expected)
+        (set! pass (+ pass 1))
+        (begin
+          (set! fail (+ fail 1))
+          (display "FAIL: ") (display name)
+          (display " expected ") (write expected)
+          (display " got ") (write got) (newline)))))
+
+;; hash-table-update!/default inserting a missing key
+(define ht (make-hash-table))
+(hash-table-update!/default ht 'counter (lambda (x) (+ x 1)) 0)
+(check "update!/default inserts missing key"
+       (lambda () (hash-table-ref ht 'counter)) 1)
+(check "inserted key exists"
+       (lambda () (hash-table-exists? ht 'counter)) #t)
+(check "size counts inserted key"
+       (lambda () (hash-table-size ht)) 1)
+(check "keys include inserted key"
+       (lambda () (hash-table-keys ht)) '(counter))
+
+;; updating the freshly inserted key must hit the same entry
+(hash-table-update!/default ht 'counter (lambda (x) (+ x 1)) 0)
+(check "second update sees first"
+       (lambda () (hash-table-ref ht 'counter)) 2)
+(check "no duplicate entry"
+       (lambda () (hash-table-size ht)) 1)
+
+;; inserted entry must survive a rehash (growth used to drop phantom entries)
+(define ht2 (make-hash-table))
+(hash-table-update!/default ht2 'seed (lambda (x) x) 42)
+(do ((i 0 (+ i 1)))
+    ((= i 20))
+  (hash-table-set! ht2 i i))
+(check "inserted key survives rehash"
+       (lambda () (hash-table-ref ht2 'seed)) 42)
+(check "size after rehash"
+       (lambda () (hash-table-size ht2)) 21)
+
+;; alist->hash-table entries must be visible to lookup
+(define ht3 (alist->hash-table '((a . 1) (b . 2) (a . 99))))
+(check "alist key a" (lambda () (hash-table-ref ht3 'a)) 1)
+(check "alist key b" (lambda () (hash-table-ref ht3 'b)) 2)
+(check "alist size" (lambda () (hash-table-size ht3)) 2)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

`HashEntry.state` defaults to `.empty` (`src/types.zig`), and two insert paths in `src/primitives_hashtable.zig` wrote new entries without setting `.state = .occupied`:

- the insert-missing-key path of `hash-table-update!/default`
- `alist->hash-table`

The key and value were stored and `count` incremented, but lookups treat `.empty` slots as probe-chain terminators, so the inserted key was invisible: `hash-table-ref` raised "expected key to be present or default", `hash-table-exists?` returned `#f`, `alist->hash-table`'s first-occurrence-wins dedup never fired (duplicates got inserted twice), and the phantom entry was silently dropped on the next rehash (which only migrates `.occupied` entries). `hash-table-set!` already set the state explicitly, which is why only these two paths were affected.

The failures were masked because uncaught script errors currently exit 0, so `tests/scheme/smoke/mutation-write-barrier.scm` and `tests/scheme/srfi/srfi69-ext.scm` reported PASS despite aborting mid-file. Once exit-code enforcement (#929) lands, both files become hard failures without this fix.

## Testing

- New regression test `tests/scheme/smoke/hashtable-insert-occupied.scm`: fails 10/11 checks without the fix, passes 11/11 with it. Covers insert-via-default, re-update of the inserted key, survival across a rehash, and alist dedup. It uses manual counters + `guard` + explicit `(exit 1)` (not SRFI-64) so it gates correctly on current main where SRFI-64 asserts are still broken and uncaught errors exit 0.
- `zig build test` clean; full `run-all.sh`: 245 files + 1395 R7RS tests, 0 fail.

## Note on #929

This commit is also cherry-picked into #929 (exit-code enforcement needs it to stay green). Merging this PR first is fine — the identical patch will drop out of #929 on its next rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)