### PR TITLE
Retire replaced library envs instead of freeing them

### DIFF
--- a/src/library.zig
+++ b/src/library.zig
@@ -51,6 +51,11 @@ pub const Library = struct {
 pub const LibraryRegistry = struct {
     allocator: std.mem.Allocator,
     libraries: std.StringHashMap(Library),
+    /// Environments of replaced libraries. Closures compiled in a library's
+    /// begin block hold `Function.env` pointers to its lib_env and can
+    /// outlive the library (escaping via import into vm.globals), so a
+    /// replaced env must stay alive until the registry is torn down (#820).
+    retired_envs: std.ArrayList(*std.StringHashMap(Value)) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) LibraryRegistry {
         return .{
@@ -65,12 +70,21 @@ pub const LibraryRegistry = struct {
             lib.deinit();
         }
         self.libraries.deinit();
+        for (self.retired_envs.items) |env| {
+            env.deinit();
+            self.allocator.destroy(env);
+        }
+        self.retired_envs.deinit(self.allocator);
     }
 
     /// Register a new library (or replace an existing one).
     pub fn register(self: *LibraryRegistry, lib: Library) !void {
         const gop = try self.libraries.getOrPut(lib.name);
         if (gop.found_existing) {
+            if (gop.value_ptr.lib_env) |env| {
+                try self.retired_envs.append(self.allocator, env);
+                gop.value_ptr.lib_env = null;
+            }
             gop.value_ptr.deinit();
             gop.key_ptr.* = lib.name;
         }

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -345,3 +345,70 @@ test "imported macro chain resolves library-internal bindings" {
     const result = try vm.eval("(outer 41)");
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
 }
+
+test "re-registering a library keeps old closures' lib_env alive (#820)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // f closes over the library env to look up the non-exported `secret`.
+    _ = try vm.eval(
+        \\(define-library (foo bar)
+        \\  (import (scheme base))
+        \\  (export f)
+        \\  (begin
+        \\    (define secret 42)
+        \\    (define (f) secret)))
+    );
+    _ = try vm.eval("(import (foo bar))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try vm.eval("(f)")));
+
+    // Re-register the same library name; the old lib_env must be retired,
+    // not freed, because f still references it via Function.env.
+    _ = try vm.eval(
+        \\(define-library (foo bar)
+        \\  (import (scheme base))
+        \\  (export g)
+        \\  (begin (define (g) 99)))
+    );
+
+    // Calling the stale closure must still resolve `secret` in the old env.
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try vm.eval("(f)")));
+
+    // And the replacement library works normally.
+    _ = try vm.eval("(import (foo bar))");
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(try vm.eval("(g)")));
+}
+
+test "retired lib_env values survive GC (#820)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-library (gc lib)
+        \\  (import (scheme base))
+        \\  (export get)
+        \\  (begin
+        \\    (define stash (list 1 2 3))
+        \\    (define (get) stash)))
+    );
+    _ = try vm.eval("(import (gc lib))");
+    _ = try vm.eval(
+        \\(define-library (gc lib)
+        \\  (import (scheme base))
+        \\  (export other)
+        \\  (begin (define (other) 0)))
+    );
+
+    // Allocation churn to force collections; `stash` is only reachable
+    // through the retired env, which markVMRoots must trace.
+    _ = try vm.eval(
+        \\(let churn ((n 50000) (acc '()))
+        \\  (if (= n 0) acc (churn (- n 1) (cons n acc))))
+    );
+    const result = try vm.eval("(length (get))");
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -105,6 +105,12 @@ fn markVMRoots(gc: *memory.GC) void {
                 while (eit2.next()) |v| gc.markValue(v.*);
             }
         }
+        // Envs of replaced libraries stay reachable through closures that
+        // were compiled against them (#820).
+        for (vm.libraries.retired_envs.items) |env| {
+            var eit = env.valueIterator();
+            while (eit.next()) |v| gc.markValue(v.*);
+        }
     }
 
     // Mark library environments being built by handleDefineLibrary

--- a/tests/scheme/smoke/library-redefine-closure-820.scm
+++ b/tests/scheme/smoke/library-redefine-closure-820.scm
@@ -1,0 +1,52 @@
+;; Regression test for #820: re-registering a library freed its lib_env
+;; while closures compiled against it were still live (via Function.env),
+;; so calling such a closure afterwards dereferenced freed memory.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "library-redefine-closure-820")
+
+(define-library (foo bar)
+  (import (scheme base))
+  (export f)
+  (begin
+    (define secret 42)
+    (define (f) secret)))
+(import (foo bar))
+
+(test-equal "closure works before redefinition" 42 (f))
+
+;; Re-register the same library name — the old lib_env must survive
+;; because f still resolves `secret` through it.
+(define-library (foo bar)
+  (import (scheme base))
+  (export g)
+  (begin (define (g) 99)))
+
+(test-equal "stale closure still resolves old lib_env" 42 (f))
+
+(import (foo bar))
+(test-equal "replacement library works" 99 (g))
+
+;; Churn allocations to force collections — values in the retired env
+;; (like `secret` and f's stash below) must be traced by the GC.
+(define-library (gc lib)
+  (import (scheme base))
+  (export get)
+  (begin
+    (define stash (list 1 2 3))
+    (define (get) stash)))
+(import (gc lib))
+(define-library (gc lib)
+  (import (scheme base))
+  (export other)
+  (begin (define (other) 0)))
+
+(define junk
+  (let churn ((n 100000) (acc '()))
+    (if (= n 0) acc (churn (- n 1) (cons n acc)))))
+
+(test-equal "retired env values survive GC" '(1 2 3) (get))
+
+(let ((runner (test-runner-current)))
+  (test-end "library-redefine-closure-820")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #820.

## Problem

Re-registering a library (a second `define-library` with the same name — e.g. reloading a library definition in a program or REPL session) freed the old library's per-library environment (`lib_env`) via `Library.deinit` in `LibraryRegistry.register`. But closures compiled in the old library's `begin` block hold `Function.env` pointers to that env for runtime global lookup, and they outlive the library by escaping into `vm.globals` through `(import ...)`. Calling such a closure afterwards dereferenced the freed `StringHashMap` — a use-after-free that panics (`integer overflow` in `hash_map.zig` getIndex) or silently reads garbage.

## Fix

- `LibraryRegistry` gains a `retired_envs` graveyard. On replacement, the old library's `lib_env` is detached into it instead of being freed; retired envs are freed only when the registry itself is torn down.
- `markVMRoots` traces retired envs so values reachable only through them (non-exported library internals like `secret` in the repro) survive GC.

The leak is bounded by the number of re-registrations, which only happen when a program redefines a library. All registration paths funnel through `register()` (the `.sbc` cache-read path for `.sld` files was already removed in d1e9616), so this covers every case.

## Tests

- Two Zig unit tests in `src/tests_libraries.zig`: stale closure still resolves its old env after re-registration, and retired-env values survive allocation churn/GC.
- Scheme smoke test `tests/scheme/smoke/library-redefine-closure-820.scm` covering both, SRFI-64 style.
- Verified the issue's 6-line repro now prints `42` twice (was: undefined-variable error / panic).
- GC stress: repro variant passes under `-Dgc-threshold=1` (collection on every allocation).
- `zig build test`: 468/468 pass. Full Scheme suite: 1,643 pass, 0 fail (248 files + 1,395 R7RS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)