### PR TITLE
Fix SRFI-64 test-end template in tests/scheme/CLAUDE.md

### DIFF
--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -31,10 +31,15 @@
    (test-equal "what it tests" expected-value actual-expr)
    (test-assert "condition holds" bool-expr)
 
-   (test-end "descriptive-name")
-   (when (> (test-runner-fail-count (test-runner-current)) 0) (exit 1))
+   (let ((runner (test-runner-current)))
+     (test-end "descriptive-name")
+     (when (> (test-runner-fail-count runner) 0) (exit 1)))
    ```
 3. The `(exit 1)` on failure is required — `run-all.sh` uses exit codes.
+   Grab the runner **before** `(test-end ...)`: the outermost `test-end`
+   resets the current runner, so `(test-runner-current)` afterwards no
+   longer returns the runner and `test-runner-fail-count` raises a type
+   error.
 4. No registration needed — `run-all.sh` picks up `*.scm` files automatically.
 5. For bug regressions, name the file after the bug and add a comment:
    ```scheme


### PR DESCRIPTION
## Summary

The "Adding a test" section of `tests/scheme/CLAUDE.md` documented a SRFI-64 test-ending template that errors at runtime:

```scheme
(test-end "descriptive-name")
(when (> (test-runner-fail-count (test-runner-current)) 0) (exit 1))
```

The outermost `(test-end ...)` resets the current runner, so the subsequent `(test-runner-current)` no longer returns the runner and `test-runner-fail-count` raises `type error in '%record-ref'`.

This replaces it with the working pattern already used by existing smoke tests (e.g. `case-arrow-register.scm`, `bignum-rational-normalization.scm`), which captures the runner before `test-end`:

```scheme
(let ((runner (test-runner-current)))
  (test-end "descriptive-name")
  (when (> (test-runner-fail-count runner) 0) (exit 1)))
```

A short note explaining *why* was added below the template.

## Verification

- Wrote a trivial test file from the updated template: exits **0** when assertions pass.
- Same file with a deliberately failing `test-equal`: prints `FAIL` and exits **1**.
- Grepped all of `tests/scheme/` for the broken after-`test-end` pattern — no committed test uses it, so no test fixes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)