### PR TITLE
Root vector-partition yes/no accumulators (#810)

### DIFF
--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -899,6 +899,13 @@ fn vectorPartitionFn(args: []const Value) PrimitiveError!Value {
     var no: std.ArrayList(Value) = .empty;
     defer no.deinit(gc.allocator);
 
+    // The predicate runs arbitrary Scheme and may mutate `vec`, displacing an
+    // element whose only remaining reference is the yes/no accumulator. Those
+    // lists are invisible to the GC, so root every classified element to keep
+    // it alive across later predicate calls (which can trigger collection).
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+
     for (vec.data) |elem| {
         const call_args_buf = [1]Value{elem};
         const result = try callVM(pred, &call_args_buf);
@@ -907,6 +914,7 @@ fn vectorPartitionFn(args: []const Value) PrimitiveError!Value {
         } else {
             no.append(gc.allocator, elem) catch return PrimitiveError.OutOfMemory;
         }
+        gc.extra_roots.append(gc.allocator, elem) catch return PrimitiveError.OutOfMemory;
     }
 
     const combined = gc.allocator.alloc(Value, yes.items.len + no.items.len) catch return PrimitiveError.OutOfMemory;

--- a/tests/scheme/smoke/vector-map-gc.scm
+++ b/tests/scheme/smoke/vector-map-gc.scm
@@ -64,6 +64,31 @@
   (check "vector-unfold-right elem 0" (vector-ref out 0) '(0 8))
   (check "vector-unfold-right elem 3" (vector-ref out 3) '(3 1)))
 
+;; Test 6: vector-partition — the predicate mutates the source vector,
+;; displacing each element so its only remaining reference is the invisible
+;; yes/no accumulator, then allocates heavily to force a collection.
+;; Regression for #810 (residual of #335): the classified elements must be
+;; rooted or the first partition element comes back recycled.
+(let ((v (vector (string-copy "keepme000001")
+                 (string-copy "keepme000002")
+                 (string-copy "keepme000003")
+                 (string-copy "keepme000004")
+                 (string-copy "keepme000005")
+                 (string-copy "keepme000006"))))
+  (call-with-values
+    (lambda ()
+      (vector-partition
+       (lambda (x)
+         (vector-fill! v #f)              ; displace all elements from the source
+         (do ((i 0 (+ i 1))) ((= i 20000)) ; churn the heap to force collection
+           (string-copy "REUSEDREUSED"))
+         (string? x))
+       v))
+    (lambda (part n)
+      (check "vector-partition survives predicate mutation"
+             (vector-ref part 0) "keepme000001")
+      (check "vector-partition count" n 1))))
+
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "vector-map GC tests failed" fail))


### PR DESCRIPTION
## Summary

Fixes #810 — a use-after-free in `vector-partition` when the predicate mutates the source vector.

The #335 fix (commit e726b7c) rooted intermediate results in `vectorMapFn`, `vectorUnfoldFn`, `vectorUnfoldRightFn`, and `vectorCumulateFn` via `gc.extra_roots`, but never touched `vectorPartitionFn` — even though #335 explicitly named its un-rooted `yes`/`no` accumulators as the same root cause.

The predicate runs arbitrary Scheme and can mutate the source vector. Once an element is displaced from `vec`, its only remaining reference is the allocator-backed `yes`/`no` list, which the GC cannot see. The next collection (a later predicate call, or the `allocVector` before the buffer copy) frees it and hands back a recycled heap slot.

## Fix

Apply the same `gc.extra_roots` save/restore pattern `vectorMapFn` uses: root each element as it is classified so it survives later predicate calls. The `defer shrinkRetainingCapacity` keeps the roots in place through both `allocVector(combined)` and `allocMultipleValues`, then restores the root stack on return.

## Testing

- Added Test 6 to `tests/scheme/smoke/vector-map-gc.scm`: the predicate calls `vector-fill! v #f` to displace all elements, then churns the heap to force a collection.
- **Confirmed the test fails without the fix** (`expected "keepme000001" got "REUSEDREUSED"` — the recycled slot) and passes with it.
- The exact reproduction from the issue now prints `keepme000001` on a default build.
- `zig build test` passes; `srfi133-ext.scm` (45/45) and `srfi1-gc-stress.scm` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)