### PR TITLE
thottam: fix use-after-free in doInstall visited set on transitive deps

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -722,6 +722,33 @@ fn printErrColor(comptime color: []const u8, text: []const u8) void {
     if (use_color) writeStderr(Color.reset);
 }
 
+/// Record `pkg` in the install cycle/dedup guard. Returns true if it was newly
+/// inserted, false if already present.
+///
+/// The key is stored as a private copy because `pkg` often aliases memory the
+/// map must outlive: for a transitive dependency it is a sub-slice of the
+/// caller's `manifest.depends`, which `manifest.deinit` frees when that
+/// caller's install frame unwinds — while this map is still live and probed by
+/// later `doInstall` calls. Storing the slice directly leaves dangling keys
+/// (use-after-free on every later bucket probe). Keys are freed by
+/// `freeVisited` when the map is torn down.
+fn markVisited(allocator: std.mem.Allocator, visited: *std.StringHashMap(void), pkg: []const u8) !bool {
+    if (visited.get(pkg) != null) return false;
+    const key = try allocator.dupe(u8, pkg);
+    visited.put(key, {}) catch |err| {
+        allocator.free(key);
+        return err;
+    };
+    return true;
+}
+
+/// Free the owned keys inserted by `markVisited`, then deinit the map.
+fn freeVisited(allocator: std.mem.Allocator, visited: *std.StringHashMap(void)) void {
+    var it = visited.keyIterator();
+    while (it.next()) |k| allocator.free(k.*);
+    visited.deinit();
+}
+
 fn doInstall(
     allocator: std.mem.Allocator,
     config: Config,
@@ -741,8 +768,7 @@ fn doInstall(
         return error.InvalidPackageName;
     }
 
-    if (visited.get(pkg) != null) return;
-    try visited.put(pkg, {});
+    if (!try markVisited(allocator, visited, pkg)) return;
 
     if (isInstalled(allocator, config.installed, pkg)) {
         writeStdout("  ");
@@ -1242,7 +1268,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
             std.process.exit(1);
         };
         var visited = std.StringHashMap(void).init(allocator);
-        defer visited.deinit();
+        defer freeVisited(allocator, &visited);
         doInstall(allocator, config, spec, locked_mode, &visited) catch |err| {
             if (err == error.GitFailed or err == error.BuildFailed) std.process.exit(1);
             return err;
@@ -1339,6 +1365,30 @@ test "parseField" {
     try std.testing.expectEqualStrings("value", parseField("key:  value  ", "key:").?);
     try std.testing.expect(parseField("other: value", "key:") == null);
     try std.testing.expect(parseField("", "key:") == null);
+}
+
+test "markVisited copies keys so freed dependency names stay valid (issue #784)" {
+    // Regression for #784: doInstall's visited guard stored package-name keys
+    // by reference. For a transitive dependency the name is a sub-slice of the
+    // caller's manifest.depends buffer, which is freed when that caller's
+    // install frame unwinds — leaving a dangling key that later probes read
+    // (use-after-free) and that silently breaks the dedup guard.
+    const allocator = std.testing.allocator;
+    var visited = std.StringHashMap(void).init(allocator);
+    defer freeVisited(allocator, &visited);
+
+    // A dependency name living in a manifest.depends buffer: record it, then
+    // overwrite and free the buffer to mimic manifest.deinit reclaiming it.
+    const dep = try allocator.dupe(u8, "rd");
+    try std.testing.expect(try markVisited(allocator, &visited, dep));
+    @memset(dep, 0xaa);
+    allocator.free(dep);
+
+    // A second parent depending on the same package must still be recognized
+    // as visited without relying on the freed buffer's bytes.
+    try std.testing.expect(!try markVisited(allocator, &visited, "rd"));
+    // And a genuinely new package is still inserted.
+    try std.testing.expect(try markVisited(allocator, &visited, "re"));
 }
 
 test "caret constraint: major > 0 locks major" {


### PR DESCRIPTION
## Problem

`doInstall`'s cycle/duplicate guard (`visited: *std.StringHashMap(void)`) stored package-name keys **by reference**. For a transitive dependency, that name is a sub-slice of the caller's `manifest.depends` buffer, which `manifest.deinit` frees when the caller's install frame unwinds — while the map is still live. Every later `visited.get`/`put` bucket probe then read freed memory (use-after-free), and the dedup guard silently degraded.

Observable in a diamond dependency (`ra → rb rc`, both `rb`/`rc` → `rd`): the second visit to `rd` printed `rd already installed` (a `visited` miss that fell through to `installed.txt`) instead of a silent visited-hit early return. In ReleaseSafe/ReleaseFast with the C allocator this is a latent UAF read that, if the freed chunk is reused, can produce a false positive and silently skip a never-installed dependency.

## Fix

Extract the guard into two helpers so the map owns its keys for its whole lifetime:

- **`markVisited`** — membership check + inserts an owned `dupe` of the key (frees it on `put` failure); returns whether the package was newly inserted.
- **`freeVisited`** — frees every owned key before `deinit` (keeps the Debug allocator leak-free; thottam otherwise relies on process exit).

`doInstall` now calls `if (!try markVisited(...)) return;` and `main` uses `defer freeVisited(...)`.

## Testing

- **Regression unit test** `markVisited copies keys so freed dependency names stay valid (issue #784)` — records a name, overwrites + frees the backing buffer, then re-probes. Passes with the fix; reverting `markVisited` to store-by-reference makes it fault in `eqlBytes` on the dangling key.
- **Integration** — reproduced the diamond scenario with local git repos in an isolated `KAAPPI_HOME` (Debug build, poisoned free): `rd already installed` before the fix, silent visited-hit after.
- `zig fmt --check` clean; `zig build` and full `zig build test` (469 tests) pass.

Fixes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)