### PR TITLE
Compare rationals exactly instead of falling back to f64 (#844)

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -792,27 +792,92 @@ fn modulo(args: []const Value) PrimitiveError!Value {
     return types.makeFixnum(@mod(types.toFixnum(args[0]), b));
 }
 
+/// True for any exact real: fixnum, bignum, or rational.
+fn isExactReal(v: Value) bool {
+    return types.isFixnum(v) or types.isBignum(v) or types.isRationalObj(v);
+}
+
+/// Numerator of an exact real as a fixnum/bignum Value.
+fn exactNumerator(v: Value) Value {
+    if (types.isRationalObj(v)) return types.toRational(v).numerator;
+    return v; // fixnum or bignum
+}
+
+/// Denominator of an exact real as a fixnum/bignum Value (always positive).
+fn exactDenominator(v: Value) Value {
+    if (types.isRationalObj(v)) return types.toRational(v).denominator;
+    return types.makeFixnum(1); // fixnum or bignum: denominator 1
+}
+
+/// Compare two exact reals (fixnum, bignum, or rational) exactly.
+/// Returns -1, 0, or 1. Never loses precision: denominators are positive, so
+/// the sign of (na*db - nb*da) gives the ordering. Uses an i64 fast path when
+/// both sides fit, falling back to bignum cross-multiplication otherwise.
+fn compareExactReals(a: Value, b: Value) PrimitiveError!i8 {
+    // Both exact integers: direct comparison, no cross-multiplication.
+    if (!types.isRationalObj(a) and !types.isRationalObj(b)) {
+        return bignum_mod.compare(a, b);
+    }
+    // Fast path: both fit RatParts and the i64 cross-products don't overflow.
+    if (toRationalParts(a)) |pa| {
+        if (toRationalParts(b)) |pb| {
+            const r1 = @mulWithOverflow(pa.num, pb.den);
+            const r2 = @mulWithOverflow(pb.num, pa.den);
+            if (r1[1] == 0 and r2[1] == 0) {
+                if (r1[0] < r2[0]) return -1;
+                if (r1[0] > r2[0]) return 1;
+                return 0;
+            }
+        }
+    }
+    // General path: bignum cross-multiplication (handles bignum parts/overflow).
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const na = exactNumerator(a);
+    const da = exactDenominator(a);
+    const nb = exactNumerator(b);
+    const db = exactDenominator(b);
+    var p1 = bignum_mod.mul(gc, na, db) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&p1) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
+    const p2 = bignum_mod.mul(gc, nb, da) catch return PrimitiveError.OutOfMemory;
+    return bignum_mod.compare(p1, p2);
+}
+
+/// Compare an exact real against an inexact flonum by comparing against the
+/// flonum's exact value. A finite double is exactly mantissa*2^exp, so this
+/// keeps `=`, `<`, etc. transitive across the exact/inexact boundary as
+/// R7RS 6.2.6 requires (converting the exact side to double would not be).
+fn compareExactVsFlonum(a: Value, f: f64) PrimitiveError!i8 {
+    if (!std.math.isFinite(f)) {
+        if (std.math.isNan(f)) return 1; // callers short-circuit NaN; be safe
+        return if (f > 0) @as(i8, -1) else @as(i8, 1); // a < +inf ; a > -inf
+    }
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    var f_exact = try numeric.exactFn(&[1]Value{types.makeFlonum(f)});
+    gc.pushRoot(&f_exact) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
+    return try compareExactReals(a, f_exact);
+}
+
 fn cmpPair(a: Value, b: Value) PrimitiveError!i8 {
     // Both exact integers (fixnum or bignum): use exact comparison
     if ((types.isFixnum(a) or types.isBignum(a)) and (types.isFixnum(b) or types.isBignum(b))) {
         return bignum_mod.compare(a, b);
     }
-    // Rational comparison: cross-multiply to avoid floating point
-    if ((types.isRationalObj(a) or types.isFixnum(a)) and (types.isRationalObj(b) or types.isFixnum(b))) {
-        if (types.isRationalObj(a) or types.isRationalObj(b)) {
-            const pa = toRationalParts(a);
-            const pb = toRationalParts(b);
-            if (pa != null and pb != null) {
-                const r1 = @mulWithOverflow(pa.?.num, pb.?.den);
-                const r2 = @mulWithOverflow(pb.?.num, pa.?.den);
-                if (r1[1] == 0 and r2[1] == 0) {
-                    if (r1[0] < r2[0]) return -1;
-                    if (r1[0] > r2[0]) return 1;
-                    return 0;
-                }
-            }
-            // Overflow or bignum fields: fall back to float
-        }
+    // Both exact with at least one rational: exact cross-multiplication.
+    // Covers rational-vs-rational, rational-vs-fixnum, and rational-vs-bignum
+    // without ever falling back to lossy f64 (issue #844).
+    if (isExactReal(a) and isExactReal(b)) {
+        return try compareExactReals(a, b);
+    }
+    // Exact rational vs inexact flonum: compare against the flonum's exact
+    // value. The integer-vs-flonum cases below are already exact; only
+    // rationals were missing this (issue #844).
+    if (types.isRationalObj(a) and types.isFlonum(b)) {
+        return try compareExactVsFlonum(a, types.toFlonum(b));
+    }
+    if (types.isFlonum(a) and types.isRationalObj(b)) {
+        return -(try compareExactVsFlonum(b, types.toFlonum(a)));
     }
     // Exact bignum vs inexact flonum: check if bignum is exactly representable
     if (types.isBignum(a) and types.isFlonum(b)) {

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -278,7 +278,7 @@ fn exactIntegerP(args: []const Value) PrimitiveError!Value {
     return if (types.isFixnum(args[0]) or types.isBignum(args[0])) types.TRUE else types.FALSE;
 }
 
-fn exactFn(args: []const Value) PrimitiveError!Value {
+pub fn exactFn(args: []const Value) PrimitiveError!Value {
     if (types.isFixnum(args[0])) return args[0];
     if (types.isBignum(args[0])) return args[0];
     if (types.isRationalObj(args[0])) return args[0]; // already exact

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -219,6 +219,50 @@ test "eval comparisons with mixed types" {
     try std.testing.expectEqual(types.TRUE, try vm.eval("(>= 2.0 2)"));
 }
 
+test "exact rational comparisons never fall back to f64 (issue 844)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // (2^100+1)/2^101 and 1/2 are distinct exact numbers within one double ULP.
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(= (/ (+ (expt 2 100) 1) (expt 2 101)) 1/2)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(< 1/2 (/ (+ (expt 2 100) 1) (expt 2 101)))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(> (/ (+ (expt 2 100) 1) (expt 2 101)) 1/2)"));
+
+    // i64 cross-product overflows but parts still fit fixnums.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(< 1/1000000000 1/999999999)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= 3000000000/6000000000 1/2)"));
+
+    // Rational vs bignum near equality (differ by 1/3).
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(= (/ (+ (* 3 (expt 2 100)) 1) 3) (expt 2 100))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(> (/ (+ (* 3 (expt 2 100)) 1) 3) (expt 2 100))"));
+}
+
+test "exact-vs-inexact comparisons stay transitive (issue 844)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // (exact 0.3333333333333333) is 6004799503160661/18014398509481984, not 1/3.
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(= (exact 0.3333333333333333) 1/3)"));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(= 1/3 0.3333333333333333)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(< 0.3333333333333333 1/3)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(> 1/3 0.3333333333333333)"));
+
+    // Transitivity: e = double(1/3) < 1/3, and e = 0.333..., so e /= 1/3.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(let ((e (exact 0.3333333333333333))) (and (= e 0.3333333333333333) (< e 1/3) (not (= e 1/3))))"));
+
+    // Controls that must keep working.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= 1/2 0.5)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(< 1/3 +inf.0)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(> 1/3 -inf.0)"));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(= 1/3 +nan.0)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= -1/2 -0.5)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(< -1/3 -0.3333333333333333)"));
+}
+
 test "eval number predicates with flonums" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();


### PR DESCRIPTION
Fixes #844.

## Problem

`cmpPair` in `src/primitives_arithmetic.zig` (backing `=`, `<`, `>`, `<=`, `>=`) fell back to lossy f64 conversion whenever a rational was involved:

- The rational-vs-rational branch only worked when both sides fit i48 fixnum parts **and** the i64 cross-products didn't overflow; otherwise it fell through to an f64 comparison. Rational-vs-bignum wasn't handled at all.
- There was no exact rational-vs-flonum branch, so those pairs always converted the exact side to a double.

Two user-visible consequences:

1. **Distinct exact numbers compared equal** — any two exact rationals within one double ULP, e.g. `(= (/ (+ (expt 2 100) 1) (expt 2 101)) 1/2)` returned `#t`.
2. **Exact-vs-inexact was non-transitive** — `(= 1/3 0.3333333333333333)` returned `#t`, violating R7RS §6.2.6 (which explicitly notes that converting to inexact before comparison is not transitive).

## Fix

- `compareExactReals` — compares any two exact reals (fixnum/bignum/rational) exactly. Keeps the fast i64 cross-multiply path, then falls back to **bignum cross-multiplication** (`na·db` vs `nb·da`, denominators positive) instead of f64. Now covers rational-vs-rational, rational-vs-fixnum, and rational-vs-bignum.
- `compareExactVsFlonum` — compares an exact value against the flonum's **exact** value (a finite double is exactly mantissa·2^exp), reusing `exactFn`, so the predicates stay transitive across the exact/inexact boundary. Handles ±inf/NaN.
- Integer-vs-flonum fast paths (already exact) are untouched, so common comparisons like `(< i 3.0)` keep their non-allocating path.

GC-safe: intermediate bignum products and the converted flonum are rooted with `pushRoot`/`popRoot` before subsequent allocations.

## Verification

All reproduction cases from the issue now match Chez/Racket/Guile/Gauche, plus edge cases (negatives, both operand orders, ±inf, NaN, reduced forms, i64 overflow, rational-near-bignum, and the full transitivity chain).

- New Zig regression tests in `src/tests_numeric.zig` (two tests covering both bug classes).
- `zig build test` — pass.
- `bash tests/scheme/run-all.sh` — **1643 pass, 0 fail** (R7RS suite: 1395 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)