### PR TITLE
Track child-interned symbols on parent GC to fix leak

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -67,6 +67,19 @@ pub const GC = struct {
     gc_threshold: usize = GC_THRESHOLD,
     symbols: std.StringHashMap(Value),
     shared_symbols: ?*std.StringHashMap(Value) = null,
+    // Symbols interned into THIS gc's `symbols` table by *other* (child)
+    // threads. A child thread aliases this table via `shared_symbols` but must
+    // not track such a Symbol on its own object list — the child frees that
+    // list at thread teardown while this table (and this gc) still reference
+    // the symbol (use-after-free). Nor can it push onto this gc's `objects`
+    // list, which this thread mutates without a lock. Instead the child
+    // appends here under `symbol_mutex`, and this gc frees them at deinit.
+    // Interned symbols are permanent (marked as roots every GC, never swept),
+    // so this list needs no sweep interaction — only teardown ownership.
+    foreign_symbols: std.ArrayList(*Object) = .empty,
+    // For a child gc, points at the owning (parent) gc's `foreign_symbols`;
+    // set alongside `shared_symbols` in `initForThread`.
+    shared_foreign_symbols: ?*std.ArrayList(*Object) = null,
     roots: std.ArrayList(*Value),
     extra_roots: std.ArrayList(Value),
     remembered_set: std.ArrayList(*Object),
@@ -96,6 +109,7 @@ pub const GC = struct {
             .allocator = allocator,
             .symbols = std.StringHashMap(Value).init(allocator),
             .shared_symbols = &parent.symbols,
+            .shared_foreign_symbols = &parent.foreign_symbols,
             .roots = .empty,
             .extra_roots = .empty,
             .remembered_set = .empty,
@@ -117,6 +131,11 @@ pub const GC = struct {
             gc_collect.freeObject(self, o);
             obj = next;
         }
+        // Free symbols that child threads interned into our shared table but
+        // could not track themselves (see `foreign_symbols`). No other thread
+        // runs at deinit — every child has joined — so this needs no lock.
+        for (self.foreign_symbols.items) |o| gc_collect.freeObject(self, o);
+        self.foreign_symbols.deinit(self.allocator);
         self.symbols.deinit();
         self.roots.deinit(self.allocator);
         self.extra_roots.deinit(self.allocator);
@@ -194,7 +213,19 @@ pub const GC = struct {
         self.bytes_allocated += @sizeOf(Symbol) + name.len;
         self.profileAlloc(@sizeOf(Symbol) + name.len);
 
-        if (!is_child) self.trackObject(&sym.header);
+        if (is_child) {
+            // The symbol lives in the parent's shared table and must outlive
+            // this child thread, so hand ownership to the parent (freed at the
+            // parent's deinit). Appended under `symbol_mutex`, held here.
+            // `shared_foreign_symbols` is set whenever `shared_symbols` is.
+            self.shared_foreign_symbols.?.append(self.allocator, &sym.header) catch {
+                self.allocator.destroy(sym);
+                self.allocator.free(owned_name);
+                return error.OutOfMemory;
+            };
+        } else {
+            self.trackObject(&sym.header);
+        }
 
         const val = types.makePointer(@ptrCast(sym));
         try sym_table.put(owned_name, val);

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -29,6 +29,38 @@ test "thread-terminate! stops busy OS thread and join raises terminated" {
     try std.testing.expectEqualStrings("terminated", types.symbolName(result));
 }
 
+// Regression: symbols first interned by an SRFI-18 child thread go into the
+// parent's shared symbol table, but allocSymbol used to skip trackObject for a
+// child GC — so those Symbols landed on no GC's object list. The child's
+// sweep/deinit never freed them (not on its list) and the parent never knew
+// about them, leaking each distinct child-interned symbol's Symbol struct and
+// its name dupe. The fix hands such symbols to the parent GC's foreign_symbols
+// list, freed at the parent's deinit. std.testing.allocator fails this test if
+// any allocation is leaked, so the many distinct child-only symbols below must
+// all be reclaimed.
+test "child thread interning distinct new symbols does not leak" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(let ((t (make-thread
+        \\           (lambda ()
+        \\             (let loop ((i 0))
+        \\               (if (< i 200)
+        \\                   (begin
+        \\                     (string->symbol
+        \\                      (string-append "child-only-" (number->string i)))
+        \\                     (loop (+ i 1)))
+        \\                   'child-done))))))
+        \\  (thread-start! t)
+        \\  (thread-join! t))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("child-done", types.symbolName(result));
+}
+
 test "abandonFiberMutexes marks owned mutex abandoned" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/tests/scheme/srfi/srfi18-child-symbol-leak.scm
+++ b/tests/scheme/srfi/srfi18-child-symbol-leak.scm
@@ -1,0 +1,49 @@
+;; Regression test: symbols first interned by an SRFI-18 child thread must be
+;; freed at parent teardown, not leaked.
+;;
+;; A child thread's GC aliases the parent's symbol table via `shared_symbols`.
+;; allocSymbol used to skip `trackObject` for a child GC, so a symbol the child
+;; interned landed on NO GC's object list: the child's sweep/deinit never freed
+;; it (not on its list) and the parent never knew about it. Every distinct
+;; symbol first interned by a child thread therefore leaked its Symbol struct
+;; plus its name dupe (~2 allocations each). This is orthogonal to issue #797
+;; (the allocSymbol data race) — that only changed the locking, not the
+;; trackObject decision. The fix hands child-interned symbols to the parent
+;; GC's `foreign_symbols` list, which the parent frees at deinit.
+;;
+;; The child below interns 500 DISTINCT new symbols that the parent never
+;; touches, so every one exercises the child-only intern path. The leak is
+;; observable only under the Debug leak-checking allocator, by leak count:
+;;
+;;   zig build run -Doptimize=Debug -- tests/scheme/srfi/srfi18-child-symbol-leak.scm \
+;;     2>&1 | grep -c 'leaked:'
+;;
+;; Before the fix that reports 1002 leaks (1000 from the child symbols — a
+;; Symbol struct + name dupe each — plus 2 unrelated pre-existing teardown
+;; leaks the interpreter reports for any script). After the fix it reports 2:
+;; the child symbols are all reclaimed. Under the default ReleaseSafe build
+;; (what run-all.sh uses) there is no leak checker, so the script just runs to
+;; completion and prints OK. The mechanical assertion that fails without the
+;; fix lives in src/tests_srfi18.zig, which runs the same scenario against a
+;; dedicated GC under std.testing.allocator (0 tolerated leaks).
+
+(import (scheme base) (scheme write) (srfi 18))
+
+(define (intern-distinct n prefix)
+  (let loop ((i 0))
+    (if (< i n)
+        (begin
+          (string->symbol (string-append prefix (number->string i)))
+          (loop (+ i 1)))
+        'done)))
+
+(define t (make-thread (lambda () (intern-distinct 500 "child-only-"))))
+(define started (thread-start! t))
+
+(unless (eq? (thread-join! t) 'done)
+  (display "FAIL: child thread did not complete")
+  (newline)
+  (exit 1))
+
+(display "OK")
+(newline)

--- a/tests/scheme/srfi/srfi18-symbol-race.scm
+++ b/tests/scheme/srfi/srfi18-symbol-race.scm
@@ -14,11 +14,11 @@
 ;; alike). With the fix both threads serialize on symbol_mutex and the script
 ;; prints OK.
 ;;
-;; Note: symbols a *child* interns are not freed (child GCs skip trackObject) —
-;; a separate, pre-existing leak, not what #797 is about. It is only observable
-;; under the Debug leak-checking allocator on a *clean* exit, so it never shows
-;; in CI: the unfixed run panics before teardown (no leak report), and the
-;; fixed run passes (run-all.sh prints test output only on failure).
+;; Note: symbols a *child* interns are a separate concern from #797 — they go
+;; into the parent's shared table and used to leak because child GCs skipped
+;; trackObject for them. That leak is now fixed (child-interned symbols are
+;; handed to the parent GC's foreign_symbols list, freed at parent deinit); see
+;; srfi18-child-symbol-leak.scm and src/tests_srfi18.zig for its regression.
 
 (import (scheme base) (scheme write) (srfi 18))
 


### PR DESCRIPTION
## Problem

`GC.allocSymbol` interns symbols into a shared `StringHashMap`. When called from a child SRFI-18 thread's GC (`shared_symbols != null`), it deliberately skips `trackObject`, so a symbol newly interned by a child thread was never placed on any GC's object list:

- The child GC's sweep/deinit never freed it (not on its list).
- The parent GC never knew about it (it lived only as a value in the shared table).

On parent teardown, `symbols.deinit()` frees the map's bucket array but not the `Symbol` structs or their `owned_name` dupes. Result: **every distinct symbol first interned by a child thread leaked** — the `Symbol` object plus its name dupe (~2 allocations each).

This is pre-existing and orthogonal to #797 (the `allocSymbol` data race, fixed in #945). #945 only changed the locking, not the `trackObject` decision.

## Fix

Child-interned symbols must outlive the child, since the parent's shared table keeps referencing them — so ownership belongs to the parent, not the child. Pushing onto the parent's lock-free `objects` list from a child thread is unsafe, so this adds a dedicated `foreign_symbols` list on the owner GC:

- Appended by the child under the `symbol_mutex` that `allocSymbol` already holds after #945.
- Freed at the parent's `deinit` (all children have joined by then, so no lock is needed there).
- Interned symbols are permanent (marked as roots every GC, never swept), so the list needs no sweep interaction — only teardown ownership.

## Tests

- **`src/tests_srfi18.zig`** — mechanical regression: a child interns 200 distinct new symbols, joins, and `std.testing.allocator` (0 tolerated leaks) fails the test without the fix. Verified: reverting the fix produces exactly **400 leaks** traced to `stringToSymbol`→`allocSymbol` in `threadEntryFn`; clean with the fix.
- **`tests/scheme/srfi/srfi18-child-symbol-leak.scm`** — end-to-end reproduction (500 child-only symbols). Under a Debug build the leak count goes **1002 → 2** (the residual 2 are unrelated pre-existing `main.zig` teardown leaks any script reports).
- **`tests/scheme/srfi/srfi18-symbol-race.scm`** — updated the now-stale note that described this leak as unfixed.

## Verification

`zig fmt` clean · full unit suite passes · all SRFI-18 Scheme tests pass · no crash/UAF under `-Dgc-threshold=1` (GC on every allocation) for both the new test and the #797 race test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)