### PR TITLE
Probe upvalues when checking if a keyword is shadowed (#814)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1054,10 +1054,17 @@ pub const Compiler = struct {
                 } else break;
             }
 
-            // If the effective name is a local variable but NOT a hygienic
-            // rename, it's a function call, not a special form.
-            const is_shadowed = self.resolveLocal(name) != null and
-                std.mem.eql(u8, effective_name, name);
+            // If the effective name is a variable binding in scope but NOT a
+            // hygienic rename, it's a function call, not a special form. The
+            // binding may be a same-scope local or an upvalue captured from an
+            // enclosing function, so probe both (mirrors the `apply` and macro
+            // checks below). Probing an upvalue registers it in this function,
+            // but a shadowing name compiles to a call referencing that same
+            // upvalue anyway, so the side effect is harmless. The cheap name
+            // comparison is checked first so hygienic renames short-circuit
+            // without touching the scope-resolution machinery.
+            const is_shadowed = std.mem.eql(u8, effective_name, name) and
+                (self.resolveLocal(name) != null or (try self.resolveUpvalue(name)) != null);
 
             // Primitive forms — only if not shadowed by local binding
             if (!is_shadowed) {

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -547,3 +547,34 @@ test "hygiene: template binding shadows a builtin procedure of the same name" {
     const builtin = try vm.eval("(exact (round (call-exp 0)))");
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(builtin));
 }
+
+test "keyword shadowed by an enclosing-scope binding compiles as a call inside a lambda (#814)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // R7RS has no reserved words: a lexical binding shadows a syntactic
+    // keyword throughout its scope, including inner lambdas. When the
+    // binding lives in an enclosing function scope the reference resolves
+    // as an upvalue, so the shadowing guard in compileForm must probe
+    // resolveUpvalue in addition to resolveLocal. Previously these forms
+    // were still compiled as the special form and returned the wrong value.
+
+    // Control: same-scope shadowing already worked.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? (let ((if list)) (if 1 2 3)) '(1 2 3))"));
+
+    // Captured (upvalue) shadowing across a lambda boundary.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((let ((if list))    (lambda () (if 1 2 3)))) '(1 2 3))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((let ((and list))   (lambda () (and 1 2))))  '(1 2))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((let ((begin list)) (lambda () (begin 1 2)))) '(1 2))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((let ((when list))  (lambda () (when 1 2))))  '(1 2))"));
+
+    // Two levels deep: the binding resolves as an upvalue-of-an-upvalue.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? (((let ((if list)) (lambda () (lambda () (if 1 2 3)))))) '(1 2 3))"));
+
+    // A macro that expands to a genuine `if` must still compile it as the
+    // special form; the shadow probe must not disturb hygienic renames.
+    _ = try vm.eval("(define-syntax my-if (syntax-rules () ((_ a b c) (if a b c))))");
+    try std.testing.expectEqualStrings("yes", types.symbolName(try vm.eval("(my-if #t 'yes 'no)")));
+}


### PR DESCRIPTION
## Summary

Fixes #814. `compileForm`'s shadowing guard consulted only `resolveLocal`, so a syntactic keyword (`if`, `and`, `begin`, `when`, ...) shadowed by a variable bound in an *enclosing* function scope — where the reference resolves as an **upvalue** — was still compiled as the special form instead of a procedure call. R7RS has no reserved words: a lexical binding shadows the syntactic keyword throughout its scope, including inner lambdas. The direct same-scope case already worked, so this was an inconsistency in the implementation's own supported feature.

## Fix

`src/compiler.zig` — the `is_shadowed` check now probes both `resolveLocal` and `resolveUpvalue`, mirroring the dual check already used for `apply` (#760) and macro keywords a few lines below. The cheap `effective_name == name` comparison is evaluated first so hygienic renames short-circuit before `resolveUpvalue` runs; its upvalue-registration side effect is harmless for genuinely shadowed names, which compile to a call referencing that same upvalue anyway.

## Before / after

```scheme
(display ((let ((if list))    (lambda () (if 1 2 3)))))  (newline) ; was 2, now (1 2 3)
(display ((let ((and list))   (lambda () (and 1 2)))))   (newline) ; was 2, now (1 2)
(display ((let ((begin list)) (lambda () (begin 1 2))))) (newline) ; was 2, now (1 2)
(display ((let ((when list))  (lambda () (when 1 2)))))  (newline) ; was 2, now (1 2)
```

## Tests

Added a regression test in `src/tests_macros.zig` covering same-scope control, captured (upvalue) shadowing of `if`/`and`/`begin`/`when`, two-level nesting (upvalue-of-an-upvalue), and a hygienic `my-if` macro that must still compile `if` as the special form.

- `zig build test` — pass
- `bash tests/scheme/run-all.sh` — 249 Scheme files + 1395 R7RS, 0 fail

Note: #788 (open) is a related symptom on the IR-lowering path with lambda *parameters*; it is a separate defect and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)