### PR TITLE
Fix stack overflow deep-copying long lists across thread boundaries (#801)

### DIFF
--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -25,13 +25,47 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
     const obj = types.toObject(src);
     return switch (obj.tag) {
         .pair => {
-            const pair = obj.as(types.Pair);
-            const new_val = try gc.allocPair(types.NIL, types.NIL);
-            try visited.put(src_ptr, new_val);
-            const new_pair = types.toObject(new_val).as(types.Pair);
-            new_pair.car = try deepCopyValue(gc, pair.car, visited);
-            new_pair.cdr = try deepCopyValue(gc, pair.cdr, visited);
-            return new_val;
+            // Iterate the cdr spine in a loop rather than recursing on it, so
+            // copying a flat list of N elements uses O(1) native stack frames
+            // instead of N (issue #801). Only the car branch recurses, bounding
+            // native recursion by structural nesting depth, not list length.
+            // The GC marker was fixed the same way for issue #864.
+            const head_new = try gc.allocPair(types.NIL, types.NIL);
+            try visited.put(src_ptr, head_new);
+
+            var src_pair = obj.as(types.Pair);
+            var dst_pair = types.toObject(head_new).as(types.Pair);
+            while (true) {
+                dst_pair.car = try deepCopyValue(gc, src_pair.car, visited);
+
+                const cdr = src_pair.cdr;
+                if (!types.isPointer(cdr)) {
+                    // Immediate tail (nil for a proper list, or a non-pointer
+                    // improper tail) -- copy directly, no allocation.
+                    dst_pair.cdr = cdr;
+                    break;
+                }
+                const cdr_obj = types.toObject(cdr);
+                if (cdr_obj.tag != .pair) {
+                    // Improper list ending in a heap object -- recurse once.
+                    dst_pair.cdr = try deepCopyValue(gc, cdr, visited);
+                    break;
+                }
+                const cdr_ptr = @intFromPtr(cdr_obj);
+                if (visited.get(cdr_ptr)) |already| {
+                    // Shared or cyclic cdr already copied -- reuse it.
+                    dst_pair.cdr = already;
+                    break;
+                }
+                // Extend the spine: allocate the next pair, register it in
+                // `visited` before copying its car so cycles resolve correctly.
+                const next_new = try gc.allocPair(types.NIL, types.NIL);
+                dst_pair.cdr = next_new;
+                try visited.put(cdr_ptr, next_new);
+                src_pair = cdr_obj.as(types.Pair);
+                dst_pair = types.toObject(next_new).as(types.Pair);
+            }
+            return head_new;
         },
         .symbol => try gc.allocSymbol(obj.as(types.Symbol).name),
         .string => {

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -61,6 +61,71 @@ test "deepCopy nested list" {
     try std.testing.expectEqual(types.NIL, p3.cdr);
 }
 
+test "deepCopy long flat list does not overflow the stack (issue #801)" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    // Build a proper list (0 1 2 ... n-1) with n well past the ~15k element
+    // native-stack-overflow threshold reported in #801. Before the fix, the
+    // cdr-spine recursion in deepCopyValue crashed the process here.
+    const n: i64 = 200_000;
+    var lst = types.NIL;
+    try gc1.pushRoot(&lst); // keep the partial list alive across collections
+    defer gc1.popRoot();
+    var i: i64 = n - 1;
+    while (i >= 0) : (i -= 1) {
+        lst = try gc1.allocPair(types.makeFixnum(i), lst);
+    }
+
+    const copied = try gc2.deepCopy(lst);
+    try std.testing.expect(lst != copied);
+
+    // Walk the copy: verify every element and the length, and confirm it is a
+    // fresh structure (independent heap objects).
+    var count: i64 = 0;
+    var cur = copied;
+    while (types.isPointer(cur) and types.toObject(cur).tag == .pair) {
+        const p = types.toObject(cur).as(types.Pair);
+        try std.testing.expectEqual(types.makeFixnum(count), p.car);
+        count += 1;
+        cur = p.cdr;
+    }
+    try std.testing.expectEqual(n, count);
+    try std.testing.expectEqual(types.NIL, cur);
+}
+
+test "deepCopy long improper list preserves the tail (issue #801)" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    // Long list ending in a non-nil immediate tail exercises the loop's
+    // "immediate cdr" break path at depth.
+    const n: i64 = 100_000;
+    var lst = types.makeFixnum(-1);
+    try gc1.pushRoot(&lst);
+    defer gc1.popRoot();
+    var i: i64 = n - 1;
+    while (i >= 0) : (i -= 1) {
+        lst = try gc1.allocPair(types.makeFixnum(i), lst);
+    }
+
+    const copied = try gc2.deepCopy(lst);
+    var count: i64 = 0;
+    var cur = copied;
+    while (types.isPointer(cur) and types.toObject(cur).tag == .pair) {
+        const p = types.toObject(cur).as(types.Pair);
+        try std.testing.expectEqual(types.makeFixnum(count), p.car);
+        count += 1;
+        cur = p.cdr;
+    }
+    try std.testing.expectEqual(n, count);
+    try std.testing.expectEqual(types.makeFixnum(-1), cur);
+}
+
 test "deepCopy vector" {
     var gc1 = memory.GC.init(std.testing.allocator);
     defer gc1.deinit();

--- a/tests/scheme/smoke/deep-copy-list-801.scm
+++ b/tests/scheme/smoke/deep-copy-list-801.scm
@@ -1,0 +1,26 @@
+;; Regression test for issue #801: gc_deep_copy deepCopyValue recursed on the
+;; cdr spine, so deep-copying a flat list of ~15k+ elements across an SRFI-18
+;; thread boundary overflowed the native stack and killed the whole process.
+;; Deep copy runs at thread-start! (thunk closure upvalues) and at thread-join!
+;; (result), so both directions are exercised. Without the fix this crashes
+;; with a Bus error (non-zero exit); with it, both joins return 100000.
+(import (scheme base) (scheme write) (srfi 18))
+
+(define (make-long-list n)
+  (let loop ((i 0) (acc '()))
+    (if (= i n) acc (loop (+ i 1) (cons i acc)))))
+
+;; Direction 1: closure upvalue deep-copied into the child at thread-start!.
+(define t1
+  (let ((lst (make-long-list 100000)))
+    (make-thread (lambda () (length lst)))))
+(define r1 (begin (thread-start! t1) (thread-join! t1)))
+
+;; Direction 2: result deep-copied back to the parent at thread-join!.
+(define t2 (make-thread (lambda () (make-long-list 100000))))
+(define r2 (begin (thread-start! t2) (length (thread-join! t2))))
+
+(if (and (= r1 100000) (= r2 100000))
+    (begin (display "ok") (newline))
+    (begin (display "FAIL: ") (display r1) (display " ") (display r2) (newline)
+           (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #801. `deepCopyValue` (`src/gc_deep_copy.zig`) copied pairs by recursing on **both** `car` and `cdr`, so the `cdr` recursion went N frames deep for a proper list of N elements. Deep copy runs at every SRFI-18 thread boundary (thunk closure copy at `thread-start!`, result copy at `thread-join!`), so passing a flat list of a few tens of thousands of elements to or from a thread overflowed the native stack and killed the **whole process** with a Bus error. Measured threshold: 10k elements copied fine, ≥~15k crashed.

## Fix

Walk the `cdr` spine in a loop, allocating and linking each successor pair, and recurse only on `car`. Native recursion is now bounded by structural nesting depth rather than list length. Each spine pair is registered in `visited` before its `car` is copied, so shared and cyclic structure resolves exactly as before (verified by the existing `deepCopy circular pair` / `deepCopy shared structure` tests). This mirrors the worklist fix applied to the GC marker for #864.

No new rooting or write barriers are needed: `deepCopyValue` runs with `gc.no_collect` set for the whole operation, and the collector is non-moving mark-and-sweep, so the partially built structure is neither freed nor relocated during the copy — the same invariant the previous recursive code relied on.

## Tests

- `src/tests_deepcopy.zig`: two new unit tests that deep-copy 200k-element proper and 100k-element improper lists. Both crash the process without the fix; both pass with it.
- `tests/scheme/smoke/deep-copy-list-801.scm`: end-to-end SRFI-18 test exercising both thread directions from the issue's reproduction.

Verified the fix by reverting it and confirming the exact `gc_deep_copy.zig:33` stack-overflow crash returns, then confirming it's gone with the fix. Full `zig build test`, the SRFI-18 suites, and all smoke tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)