### PR TITLE
Fix panic on closures capturing 27+ variables (#809)

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -9,7 +9,7 @@ const GC = memory.GC;
 
 // File format constants
 const MAGIC = [4]u8{ 'K', 'P', 'B', 'C' };
-const VERSION: u16 = 4;
+const VERSION: u16 = 5;
 const MAX_FUNCTIONS: u32 = 16_384;
 const MAX_TOP_LEVEL_FUNCTIONS: u32 = 4_096;
 const MAX_CODE_BYTES: u32 = 4_194_304;
@@ -620,7 +620,7 @@ fn writeFunctionsToBuffer(w: *Writer, allocator: std.mem.Allocator, top_level_fu
     for (all_funcs) |func| {
         try w.writeU8(allocator, func.arity);
         try w.writeU16(allocator, func.locals_count);
-        try w.writeU8(allocator, func.upvalue_count);
+        try w.writeU16(allocator, func.upvalue_count);
         try w.writeU8(allocator, if (func.is_variadic) @as(u8, 1) else @as(u8, 0));
 
         if (func.name) |name| {
@@ -761,7 +761,7 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
 
         func.arity = r.readU8() catch return null;
         func.locals_count = r.readU16() catch return null;
-        func.upvalue_count = r.readU8() catch return null;
+        func.upvalue_count = r.readU16() catch return null;
         const variadic_byte = r.readU8() catch return null;
         func.is_variadic = variadic_byte != 0;
 
@@ -1282,7 +1282,7 @@ test "bytecode validation rejects invalid opcode" {
     // Function header
     try w.writeU8(allocator, 0); // arity
     try w.writeU16(allocator, 1); // locals_count
-    try w.writeU8(allocator, 0); // upvalue_count
+    try w.writeU16(allocator, 0); // upvalue_count
     try w.writeU8(allocator, 0); // is_variadic
     try w.writeU16(allocator, 0); // name_len
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -289,6 +289,9 @@ pub const Compiler = struct {
                 return @intCast(i);
             }
         }
+        // upvalue_count and upvalue indices are u16; refuse to overflow rather
+        // than panic on the @intCast below (mirrors the register cap in allocReg).
+        if (self.upvalues.items.len >= std.math.maxInt(u16)) return CompileError.TooManyLocals;
         self.upvalues.append(self.gc.allocator, .{ .index = index, .is_local = is_local }) catch return CompileError.OutOfMemory;
         self.func.upvalue_count = @intCast(self.upvalues.items.len);
         return @intCast(self.upvalues.items.len - 1);

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -277,9 +277,10 @@ pub const GC = struct {
             .func = func,
             .upvalues = upvalues,
         };
-        self.bytes_allocated += @sizeOf(Closure) + upvalue_count * @sizeOf(Value);
+        const closure_bytes = @sizeOf(Closure) + @as(usize, upvalue_count) * @sizeOf(Value);
+        self.bytes_allocated += closure_bytes;
 
-        self.profileAlloc(@sizeOf(Closure) + upvalue_count * @sizeOf(Value));
+        self.profileAlloc(closure_bytes);
         self.trackObject(&cls.header);
         return types.makePointer(@ptrCast(cls));
     }

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -610,3 +610,75 @@ test "nested quasiquote double unquote" {
     defer std.testing.allocator.free(s);
     try std.testing.expectEqualStrings("(a (quasiquote (b (unquote 1))))", s);
 }
+
+// ---------------------------------------------------------------------------
+// Closures with many captured variables (#809)
+// ---------------------------------------------------------------------------
+
+// Builds a program of the form
+//   (define f (lambda () (define v0 0) ... (define v{n-1} {n-1})
+//                        (lambda () (+ v0 (+ v1 ... (+ v{n-2} v{n-1}))))))
+//   ((f))
+// The inner lambda captures every v_i as an upvalue, so the returned closure
+// has exactly `n` upvalues. Evaluating it yields 0+1+...+(n-1) = n*(n-1)/2.
+// Pairwise `+` keeps every call under the 256-argument limit so the only thing
+// under test is the upvalue count. Requires n >= 2.
+fn buildManyCaptureProgram(src: *std.ArrayList(u8), n: usize) !void {
+    const a = std.testing.allocator;
+    try src.appendSlice(a, "(define f (lambda ()");
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        const line = try std.fmt.allocPrint(a, " (define v{d} {d})", .{ i, i });
+        defer a.free(line);
+        try src.appendSlice(a, line);
+    }
+    try src.appendSlice(a, " (lambda () ");
+    i = 0;
+    while (i + 1 < n) : (i += 1) {
+        const piece = try std.fmt.allocPrint(a, "(+ v{d} ", .{i});
+        defer a.free(piece);
+        try src.appendSlice(a, piece);
+    }
+    const last = try std.fmt.allocPrint(a, "v{d}", .{n - 1});
+    defer a.free(last);
+    try src.appendSlice(a, last);
+    i = 0;
+    while (i + 1 < n) : (i += 1) try src.append(a, ')');
+    try src.appendSlice(a, ")))"); // close inner lambda, outer lambda, define
+    try src.appendSlice(a, " ((f))");
+}
+
+test "closure capturing 27 variables does not overflow byte accounting (#809)" {
+    // Regression: allocClosure computed `@sizeOf(Closure) + upvalue_count *
+    // @sizeOf(Value)` in u8 arithmetic, overflowing (panic) at 27 captures.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const n = 27;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try buildManyCaptureProgram(&src, n);
+
+    const result = try vm.eval(src.items);
+    try std.testing.expectEqual(@as(i64, n * (n - 1) / 2), types.toFixnum(result));
+}
+
+test "closure capturing more than 255 variables compiles and runs (#809)" {
+    // Regression: addUpvalue did `@intCast` of the upvalue count into a u8
+    // upvalue_count field, panicking (compile-time) past 255 captures. The
+    // field is now u16, matching the u16 upvalue index in the bytecode.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const n = 300;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try buildManyCaptureProgram(&src, n);
+
+    const result = try vm.eval(src.items);
+    try std.testing.expectEqual(@as(i64, n * (n - 1) / 2), types.toFixnum(result));
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -219,7 +219,7 @@ pub const Function = struct {
     constants: std.ArrayList(Value),
     arity: u8,
     locals_count: u16 = 0,
-    upvalue_count: u8 = 0,
+    upvalue_count: u16 = 0,
     is_variadic: bool = false,
     name: ?[]const u8 = null,
     owns_name: bool = false,


### PR DESCRIPTION
## Summary

Fixes #809. A closure capturing 27+ variables from enclosing scopes crashed the interpreter with a Zig `integer overflow` panic at closure-creation time; capturing 256+ variables panicked at *compile* time. Both were safety-check aborts of the whole process on legal (if unusual) R7RS programs. There were two distinct `u8`-overflow bugs:

**1. `≥27` captures → runtime overflow panic.** `allocClosure` computed `@sizeOf(Closure) + upvalue_count * @sizeOf(Value)` where `upvalue_count` is `u8`, so the expression was evaluated in **u8 arithmetic** and overflowed at 27 captures (27×8 + 40 = 256 > 255) on every closure creation. Fixed by widening with `@as(usize, upvalue_count)`.

**2. `>255` captures → compile-time `@intCast` panic.** `addUpvalue` `@intCast`'d the upvalue count into a `u8` `upvalue_count` field. Widened `upvalue_count` from `u8` to **`u16`** (matching the u16 `locals_count` field and the u16 upvalue index the bytecode already uses in the `closure`/`get_upvalue`/`set_upvalue` opcodes), so 256–65535 captures now *work* instead of erroring. Added a guard that caps the count gracefully at the u16 limit with `CompileError.TooManyLocals` instead of panicking (mirrors the register cap in `allocReg`).

## Bytecode format

Serializing `upvalue_count` as u16 bumps the `.sbc` format `VERSION` 4 → 5. Stale v4 caches are rejected on version mismatch and recompiled automatically.

## Testing

- New regression tests in `src/tests_advanced.zig` for N=27 (byte-accounting overflow) and N=300 (>255 compile panic), each asserting the closure returns `0+1+…+(n-1)`.
- Ran the exact Python-generated repro from the issue: N=27→351, N=256→32640, N=300→44850, N=1000→499500 — all correct (previously all panicked).
- Verified `.sbc` cache round-trips with the new v5 format (300 upvalues written/read as u16).
- `zig build test` passes; `bash tests/scheme/run-all.sh` reports **1644 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)