### PR TITLE
Fix closure capture inside do loops corrupting the captured variable (#803)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -260,6 +260,13 @@ pub const Compiler = struct {
         return false;
     }
 
+    pub fn isSlotBoxed(self: *Compiler, slot: u16) bool {
+        for (self.locals.items) |local| {
+            if (local.slot == slot) return local.is_boxed;
+        }
+        return false;
+    }
+
     pub fn markLocalBoxedBySlot(self: *Compiler, slot: u16) CompileError!void {
         for (self.locals.items) |*local| {
             if (local.slot == slot and !local.is_boxed) {

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -321,6 +321,60 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
     self.freeReg(); // free loop_reg
 }
 
+// Collect the names of variables that are referenced free inside a nested
+// closure form (lambda/case-lambda/delay/delay-force) somewhere within `expr`.
+// Such variables, if they resolve to locals in the current scope, must be
+// boxed *before* any loop back-edge so that (a) the box is created once, and
+// (b) every access to them compiles as box-aware. This is an over-approximation
+// (it ignores shadowing and can't see through macros), which is safe: boxing a
+// variable that is never actually captured is transparent, just an extra
+// indirection. Missing a macro-hidden capture falls back to the idempotent
+// box_local guard. See issue #803.
+const CaptureScan = struct {
+    names: *std.ArrayList([]const u8),
+    alloc: std.mem.Allocator,
+
+    fn addName(self: *@This(), name: []const u8) void {
+        for (self.names.items) |n| {
+            if (std.mem.eql(u8, n, name)) return;
+        }
+        self.names.append(self.alloc, name) catch {};
+    }
+
+    fn walk(self: *@This(), expr: Value, in_closure: bool) void {
+        if (types.isSymbol(expr)) {
+            if (in_closure) self.addName(types.symbolName(expr));
+            return;
+        }
+        if (!types.isPair(expr)) return;
+
+        const head = types.car(expr);
+        if (types.isSymbol(head)) {
+            const h = types.symbolName(head);
+            // Quoted data holds no variable references.
+            if (std.mem.eql(u8, h, "quote")) return;
+            if (std.mem.eql(u8, h, "lambda") or
+                std.mem.eql(u8, h, "case-lambda") or
+                std.mem.eql(u8, h, "delay") or
+                std.mem.eql(u8, h, "delay-force"))
+            {
+                var p = types.cdr(expr);
+                while (types.isPair(p)) : (p = types.cdr(p)) {
+                    self.walk(types.car(p), true);
+                }
+                return;
+            }
+        }
+
+        var p = expr;
+        while (types.isPair(p)) : (p = types.cdr(p)) {
+            self.walk(types.car(p), in_closure);
+        }
+        // Improper (dotted) tail: a bare symbol in a closure is a reference.
+        if (in_closure and types.isSymbol(p)) self.addName(types.symbolName(p));
+    }
+};
+
 pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
     if (args == types.NIL) return CompileError.InvalidSyntax;
     const var_specs = types.car(args);
@@ -377,6 +431,40 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
         try self.addLocal(var_names[vi], var_slots[vi]);
     }
 
+    // Box any local captured by a closure in the loop body *before* the loop
+    // starts. `do` compiles to a same-frame backward jump, so a box_local
+    // emitted at the (in-loop) point where the capturing lambda is compiled
+    // would re-run every iteration and every access compiled before it would
+    // bypass the box. Boxing here (once, ahead of loop_start) makes all in-loop
+    // accesses box-aware and keeps the box creation off the back-edge. Applies
+    // to captured `do` variables and to captured enclosing locals alike.
+    // See issue #803.
+    {
+        var captured: std.ArrayList([]const u8) = .empty;
+        defer captured.deinit(self.gc.allocator);
+        var scan = CaptureScan{ .names = &captured, .alloc = self.gc.allocator };
+        scan.walk(test_expr, false);
+        scan.walk(commands, false);
+        for (0..var_count) |j| {
+            if (has_step[j]) scan.walk(step_exprs[j], false);
+        }
+        scan.walk(result_exprs, false);
+        for (captured.items) |name| {
+            if (self.resolveLocal(name)) |slot| {
+                try self.markLocalBoxedBySlot(slot);
+            }
+        }
+    }
+
+    // Record which `do` variables ended up boxed (captured). Their step
+    // assignment must install a *fresh* box each iteration so that a closure
+    // made in one iteration keeps seeing that iteration's value — R7RS binds
+    // the variables to fresh locations on every pass.
+    var var_boxed: [MAX_LET_BINDINGS]bool = undefined;
+    for (0..var_count) |j| {
+        var_boxed[j] = self.isSlotBoxed(var_slots[j]);
+    }
+
     // Loop start
     const loop_start = self.currentOffset();
 
@@ -413,6 +501,14 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
             try self.emitOp(.move);
             try self.emitU16(var_slots[j]);
             try self.emitU16(temp_slots[step_idx]);
+            if (var_boxed[j]) {
+                // Rebind the captured variable to a fresh box holding the new
+                // value. The slot now holds the raw stepped value, so box_local
+                // (idempotent) wraps it in a new box, leaving the previous
+                // iteration's box — and any closure that captured it — intact.
+                try self.emitOp(.box_local);
+                try self.emitU16(var_slots[j]);
+            }
             step_idx += 1;
         }
     }

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -1105,8 +1105,15 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const reg = readU16(self, frame);
                 const reg_idx = try registerIndex(self, frame.base, reg);
                 const val = self.registers[reg_idx];
-                const box = self.gc.allocPair(val, types.VOID) catch return VMError.OutOfMemory;
-                self.registers[reg_idx] = box;
+                // Idempotent: if the register already holds a box (a pair whose
+                // cdr is VOID, the box marker used throughout), leave it alone.
+                // Without this, a box_local that re-executes on a loop back-edge
+                // would wrap the previous box in a fresh one, and the inner box
+                // pair would leak out as a Scheme value (issue #803).
+                if (!types.isPair(val) or types.cdr(val) != types.VOID) {
+                    const box = self.gc.allocPair(val, types.VOID) catch return VMError.OutOfMemory;
+                    self.registers[reg_idx] = box;
+                }
             },
             .get_box_local => {
                 const dst_r = readU16(self, frame);

--- a/tests/scheme/smoke/do-closure-capture-803.scm
+++ b/tests/scheme/smoke/do-closure-capture-803.scm
@@ -1,0 +1,91 @@
+;; Regression test for #803: a closure created inside a `do` loop body corrupts
+;; the captured variable. `do` compiles to a same-frame backward jump, so the
+;; one-shot `box_local` emitted at the closure-creation point re-ran every
+;; iteration (wrapping the box in a fresh box, leaking the internal box pair
+;; `(v . #<void>)`), and accesses compiled before the capturing lambda used
+;; unboxed register moves that bypassed the box after the loop jumped back.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "do-closure-capture-803")
+
+;; Case A: the internal box pair must not leak as the closure's value.
+(test-equal "captured enclosing var reads correctly after loop"
+  1
+  (let ((x 1) (f #f))
+    (do ((i 0 (+ i 1)))
+        ((= i 2))
+      (set! f (lambda () x)))
+    (f)))
+
+;; Case B: an unboxed read compiled before the capturing lambda must still see
+;; the variable's value (not the raw box pair) on later iterations.
+(test-equal "read before capturing lambda stays unboxed-correct"
+  '(1 1)
+  (let ((x 1) (out '()) (f #f))
+    (do ((i 0 (+ i 1)))
+        ((= i 2))
+      (set! out (cons x out))
+      (set! f (lambda () x)))
+    out))
+
+;; Case C: a set! compiled before the capturing lambda must update the box, so
+;; the closure observes the latest value rather than a stale one.
+(test-equal "set! before capturing lambda updates the box"
+  11
+  (let ((x 1) (f #f))
+    (do ((i 0 (+ i 1)))
+        ((= i 2))
+      (set! x (+ i 10))
+      (unless f (set! f (lambda () x))))
+    (f)))
+
+;; The same shape without a loop was always correct — keep it covered.
+(test-equal "capture without a loop"
+  1
+  (let ((x 1) (f #f)) (set! f (lambda () x)) (f)))
+
+;; R7RS binds `do` variables to fresh locations each iteration, so a closure
+;; made in one pass keeps that pass's value. This behaviour must be preserved.
+(test-equal "do variable captured in body has fresh location per iteration"
+  '(2 1 0)
+  (let ((fs '()))
+    (do ((i 0 (+ i 1))) ((= i 3))
+      (set! fs (cons (lambda () i) fs)))
+    (map (lambda (p) (p)) fs)))
+
+;; Capturing a `do` variable from the step expression is also fresh per pass.
+(test-equal "do variable captured in step has fresh location per iteration"
+  '(0 1 4)
+  (let ((qs '()))
+    (do ((i 0 (+ i 1))) ((= i 3) (set! qs (reverse qs)))
+      (set! qs (cons (lambda () (* i i)) qs)))
+    (map (lambda (p) (p)) qs)))
+
+;; Nested `do` loops both capturing their own variable used to crash by leaking
+;; a box pair into arithmetic; each closure must see its own (i, j).
+(test-equal "nested do loops capture fresh locations"
+  '((1 1) (1 0) (0 1) (0 0))
+  (let ((rs '()))
+    (do ((i 0 (+ i 1))) ((= i 2))
+      (do ((j 0 (+ j 1))) ((= j 2))
+        (set! rs (cons (lambda () (list i j)) rs))))
+    (map (lambda (p) (p)) rs)))
+
+;; A plain accumulating `do` with no capture must be unaffected.
+(test-equal "do without capture is unchanged"
+  10
+  (do ((i 0 (+ i 1)) (acc 0 (+ acc i))) ((= i 5) acc)))
+
+;; An enclosing variable mutated in the loop and captured by many closures is a
+;; single shared location — all closures observe the final value.
+(test-equal "shared enclosing var mutated in loop"
+  '(3 3 3)
+  (let ((c 0) (fns '()))
+    (do ((i 0 (+ i 1))) ((= i 3))
+      (set! c (+ c 1))
+      (set! fns (cons (lambda () c) fns)))
+    (map (lambda (p) (p)) fns)))
+
+(let ((runner (test-runner-current)))
+  (test-end "do-closure-capture-803")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #803. A closure created inside a `do` loop body captured a garbled variable — the internal box pair `(v . #<void>)` leaked out as a Scheme value, and accesses compiled before the capturing lambda read/wrote past the box after the loop's backward jump.

Reproductions from the issue, all now correct:

```scheme
(let ((x 1) (f #f)) (do ((i 0 (+ i 1))) ((= i 2)) (set! f (lambda () x))) (f))          ; => 1   (was (1 . ))
(let ((x 1) (out '()) (f #f)) (do ((i 0 (+ i 1))) ((= i 2)) (set! out (cons x out)) (set! f (lambda () x))) out)  ; => (1 1)  (was ((1 . ) 1))
(let ((x 1) (f #f)) (do ((i 0 (+ i 1))) ((= i 2)) (set! x (+ i 10)) (unless f (set! f (lambda () x)))) (f))       ; => 11   (was 10)
```

## Root cause

`markLocalBoxedBySlot` emitted the one-shot `box_local` at the *closure-creation point*, which for a `do` loop sits **inside** the same-frame backward jump. So `box_local` re-executed every iteration (wrapping box-in-box), and any access to the variable compiled *before* the capturing lambda used raw register moves that bypassed the box once control jumped back to the top of the loop.

## Fix

- **`compileDo`** (`compiler_bindings.zig`): pre-scan the whole loop body (test, commands, steps, results) for variables referenced inside nested closures (`lambda`/`case-lambda`/`delay`/`delay-force`). Any that resolve to a local — a `do` variable *or* an enclosing local — is boxed **before `loop_start`**, so the box is created once and every in-loop access compiles box-aware. Captured `do` variables get a **fresh box each iteration** in the step assignment, preserving R7RS fresh-location semantics (a closure made in one pass keeps that pass's value, e.g. `(2 1 0)`); enclosing locals stay a single shared box.
- **`box_local`** (`vm_dispatch.zig`): made idempotent (skip if the register already holds a `(v . VOID)` box), matching the existing guard in the `.closure` handler. Defense-in-depth for captures the syntactic pre-scan can't see (e.g. macro-hidden lambdas).
- Added `isSlotBoxed` helper (`compiler.zig`).

The pre-scan is an over-approximation (ignores shadowing, can't see through macros), which is safe: boxing a variable that isn't actually captured is transparent.

## Testing

- New regression test `tests/scheme/smoke/do-closure-capture-803.scm` — 9 SRFI-64 assertions covering all three reported cases plus fresh-location (single and nested `do`), no-capture, and shared-mutation semantics.
- `zig build test` (Zig unit tests) passes.
- Full Scheme suite (`tests/scheme/run-all.sh`): 248 files + R7RS 1395, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)