### PR TITLE
Clear global cache on set_global/define_global rebind (#812)

### DIFF
--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -198,3 +198,75 @@ test "vm deinit clears threadlocal vm_instance" {
     vm.deinit();
     try std.testing.expect(vm_mod.vm_instance == null);
 }
+
+// Regression tests for issue #812: set_global/define_global must clear the
+// whole global cache when they bump global_version, not just refresh their own
+// slot and re-stamp cache_version. Otherwise an entry cached before an
+// unrelated rebinding (which already bumped global_version) gets re-blessed and
+// served stale. Each scenario lives inside one procedure body so the caching,
+// the rebinding, and the re-stamping all share a single Function's cache.
+
+test "set! of unrelated global does not re-bless stale cache (issue 812)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define (g) 1)");
+    _ = try vm.eval("(define counter 0)");
+    _ = try vm.eval("(define (redefine!) (set! g (lambda () 2)))");
+    // f call-caches g, rebinds g (bumps global_version), then set!s an
+    // unrelated global. Pre-fix that set! re-stamped f's whole cache, so the
+    // tail call to g served the stale old closure and returned 1.
+    _ = try vm.eval(
+        \\(define (f)
+        \\  (g)
+        \\  (redefine!)
+        \\  (set! counter 1)
+        \\  (g))
+    );
+    const result = try vm.eval("(f)");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
+}
+
+test "reference to rebound global not served stale after set! (issue 812)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define (g) 1)");
+    _ = try vm.eval("(define counter 0)");
+    _ = try vm.eval("(define (redefine!) (set! g (lambda () 2)))");
+    // Same staleness observed via plain get_global (reference position).
+    _ = try vm.eval(
+        \\(define (f)
+        \\  (let ((h1 g)) (h1))
+        \\  (redefine!)
+        \\  (set! counter 1)
+        \\  (let ((h2 g)) (h2)))
+    );
+    const result = try vm.eval("(f)");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
+}
+
+test "define_global (named let) does not re-bless stale cache (issue 812)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define (g) 1)");
+    _ = try vm.eval("(define (redefine!) (set! g (lambda () 2)))");
+    // A named let emits define_global for its loop procedure inside f's body,
+    // bumping global_version. Pre-fix that re-stamped f's cache, serving g stale.
+    _ = try vm.eval(
+        \\(define (f)
+        \\  (g)
+        \\  (redefine!)
+        \\  (let loop ((n 0)) (if (> n 0) (loop (- n 1))))
+        \\  (g))
+    );
+    const result = try vm.eval("(f)");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
+}

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -244,6 +244,13 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 if (func.env == null) {
                     self.global_version +%= 1;
                     if (func.global_cache) |cache| {
+                        // Bumping global_version invalidates every function's
+                        // cache, including this one's other entries. Clear the
+                        // whole cache before revalidating the written slot —
+                        // stamping cache_version without the memset would
+                        // re-bless entries cached before an unrelated rebinding,
+                        // serving them stale (issue #812). Mirrors get_global.
+                        @memset(cache, types.VOID);
                         if (sym_idx < cache.len) cache[sym_idx] = val;
                         func.cache_version = self.global_version;
                     }
@@ -264,6 +271,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 if (func.env == null) {
                     self.global_version +%= 1;
                     if (func.global_cache) |cache| {
+                        // See set_global: clear the whole cache before
+                        // revalidating so unrelated stale entries aren't
+                        // re-blessed by the version stamp (issue #812).
+                        @memset(cache, types.VOID);
                         if (sym_idx < cache.len) cache[sym_idx] = val;
                         func.cache_version = self.global_version;
                     }


### PR DESCRIPTION
## Summary

Fixes #812.

Each `Function` carries a `global_cache` (one slot per constant) gated by a whole-cache validity stamp `func.cache_version == vm.global_version`. Any `set!`/`define` of a global bumps `vm.global_version` to invalidate every function's cache.

But the `set_global` and `define_global` opcode handlers in `src/vm_dispatch.zig` bumped `global_version`, refreshed only their **own** symbol's cache slot, then re-stamped `cache_version = global_version` — re-blessing the *entire* cache. Any entry cached before an unrelated rebinding (which had already bumped `global_version`) was instantly revalidated and served stale by the cache-hit fast paths in `get_global`, `call_global`, and `tail_call_global`.

```scheme
(define (g) 'old)
(define counter 0)
(define (redefine!) (set! g (lambda () 'new)))
(define (f)
  (display (g)) (newline)   ; f caches g -> old closure
  (redefine!)               ; g rebound; global_version bumped
  (set! counter 1)          ; BUG: re-stamps f's whole cache as current
  (display (g)) (newline))  ; served the STALE cached closure
(f)
;; before: old / old   after: old / new
```

## Fix

Mirror `get_global`'s version-mismatch path (`src/vm_dispatch.zig:174`): `@memset(cache, types.VOID)` before revalidating the written slot, in both `set_global` and `define_global`. Stale entries are then re-checked against the environment on next access, while the just-written slot stays warm.

## Tests

Added 3 regression tests to `src/tests_core_eval.zig`, each failing before the fix and passing after, covering all three affected opcode fast paths:

- `set_global` (call + tail position)
- `get_global` (reference position)
- `define_global` — via a named `let`, which emits `define_global` for its loop procedure inline in a function body (the reachable path; top-level `begin` splices into separate per-form Functions)

Each fix was independently verified load-bearing by temporarily reverting its `@memset` and watching the matching reproduction regress.

- `zig build test` → pass
- `bash tests/scheme/run-all.sh` → 1644 pass, 0 fail (249 Scheme files + 1395 R7RS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)