### PR TITLE
Respect lexical shadowing of primitives in IR constant folding (#790)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -238,6 +238,24 @@ pub const Compiler = struct {
         return null;
     }
 
+    /// Pure predicate: is `name` bound as a lexical variable — a local in this
+    /// compiler or any enclosing compiler? Unlike `resolveUpvalue`, this has no
+    /// side effects (it does not register upvalues), so the IR optimizer can
+    /// call it while deciding whether a call to a primitive name is safe to
+    /// constant-fold. A lambda parameter (or enclosing local) that shadows a
+    /// built-in must suppress folding: the reference is to the binding, not the
+    /// primitive. See issue #790.
+    pub fn isLexicallyBound(self: *const Compiler, name: []const u8) bool {
+        var comp: ?*const Compiler = self;
+        while (comp) |c| {
+            for (c.locals.items) |local| {
+                if (std.mem.eql(u8, local.name, name)) return true;
+            }
+            comp = c.parent;
+        }
+        return false;
+    }
+
     pub fn isLocalBoxed(self: *Compiler, name: []const u8) bool {
         var i: usize = self.locals.items.len;
         while (i > 0) {
@@ -344,6 +362,7 @@ pub const Compiler = struct {
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
         ir.restricted_env = self.restricted_env;
+        ir.compiler = self;
         defer ir.deinit();
         var root = try ir_mod.lowerWithMacros(&ir, expr_root, &self.macros);
 
@@ -621,6 +640,7 @@ pub const Compiler = struct {
             var ir = ir_mod.IR.init(child.gc.allocator);
             ir.globals = child.globals;
             ir.restricted_env = child.restricted_env;
+            ir.compiler = &child;
             defer ir.deinit();
             var root = try ir_mod.lowerWithMacros(&ir, expr, &child.macros);
             ir_mod.markTailPositions(root, rest == types.NIL);
@@ -681,6 +701,7 @@ pub const Compiler = struct {
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
         ir.restricted_env = self.restricted_env;
+        ir.compiler = self;
         defer ir.deinit();
         var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
         ir_mod.identifyPrimitives(val_root);
@@ -731,6 +752,7 @@ pub const Compiler = struct {
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
         ir.restricted_env = self.restricted_env;
+        ir.compiler = self;
         defer ir.deinit();
         var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
         ir_mod.identifyPrimitives(val_root);
@@ -877,6 +899,7 @@ pub const Compiler = struct {
             var ir = ir_mod.IR.init(self.gc.allocator);
             ir.globals = self.globals;
             ir.restricted_env = self.restricted_env;
+            ir.compiler = self;
             defer ir.deinit();
             var root = try ir_mod.lowerWithMacros(&ir, expr, &self.macros);
             ir_mod.markTailPositions(root, false);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -138,6 +138,15 @@ pub const IR = struct {
     nodes: std.ArrayList(*Node),
     globals: ?*const std.StringHashMap(Value) = null,
     restricted_env: bool = false, // true when compiling in a restricted environment (environment procedure)
+    // Enclosing compiler, when lowering happens inside one. Supplies lexical
+    // scope so isRedefined can see lambda parameters / enclosing locals that
+    // shadow a primitive (issue #790). Null for standalone lowering (Stage 1
+    // parity tests, ir_emitter), where only the globals check applies.
+    compiler: ?*const compiler_mod.Compiler = null,
+    // Extra lexically-bound names that shadow primitives, for lowering paths
+    // that have no Compiler (the LLVM native backend passes a lambda's own
+    // parameter names here). Also consulted by isRedefined (issue #790).
+    bound_names: ?[]const []const u8 = null,
 
     pub fn init(allocator: std.mem.Allocator) IR {
         return .{
@@ -147,6 +156,17 @@ pub const IR = struct {
     }
 
     fn isRedefined(self: *const IR, name: []const u8) bool {
+        // A lexical binding (lambda parameter or enclosing local) shadowing the
+        // primitive makes any fold that assumes the built-in's semantics wrong.
+        // The globals map never sees these, so consult the compiler's scope.
+        if (self.compiler) |c| {
+            if (c.isLexicallyBound(name)) return true;
+        }
+        if (self.bound_names) |names| {
+            for (names) |n| {
+                if (std.mem.eql(u8, n, name)) return true;
+            }
+        }
         const g = self.globals orelse return false;
         const val = g.get(name) orelse {
             // In a restricted environment, missing names mean "not available".

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -44,6 +44,9 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
 
     var body_ir = ir.IR.init(self.allocator);
     defer body_ir.deinit();
+    // Parameters shadow primitives of the same name; don't fold calls to them
+    // using the built-in's semantics (issue #790).
+    body_ir.bound_names = param_names[0..arity];
     var body_nodes: [64]*ir.Node = undefined;
     var body_count: usize = 0;
     var body_expr = body_list;
@@ -103,6 +106,9 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
 
     var body_ir = ir.IR.init(self.allocator);
     defer body_ir.deinit();
+    // Parameters shadow primitives of the same name; don't fold calls to them
+    // using the built-in's semantics (issue #790).
+    body_ir.bound_names = param_names[0..arity];
     var body_nodes: [64]*ir.Node = undefined;
     var body_count: usize = 0;
     var body_expr = body_list;
@@ -354,6 +360,18 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
 
     var body_ir = ir.IR.init(self.allocator);
     defer body_ir.deinit();
+    // Parameters (including a rest parameter) shadow primitives of the same
+    // name; don't fold calls to them using the built-in's semantics (#790).
+    if (rest_name) |rn| {
+        if (arity < param_names.len) {
+            param_names[arity] = rn;
+            body_ir.bound_names = param_names[0 .. arity + 1];
+        } else {
+            body_ir.bound_names = param_names[0..arity];
+        }
+    } else {
+        body_ir.bound_names = param_names[0..arity];
+    }
 
     var body_nodes: [64]*ir.Node = undefined;
     var body_count: usize = 0;

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -605,6 +605,86 @@ test "bare lambda internal define with lambda application" {
     try std.testing.expectEqual(@as(i64, 10), types.toFixnum(result));
 }
 
+// Issue #790: IR constant folding / simplifyBooleans must not fold a call to a
+// primitive name that is shadowed by a lambda parameter (or an enclosing
+// local). The lambda body is lowered through the IR by compileLambdaWithIR;
+// the IR now consults the enclosing compiler's lexical scope in isRedefined.
+// These forms are evaluated bare (not wrapped in a macro), so the operator
+// lambda is compiled via the IR path, not the legacy passthrough compiler.
+
+test "issue #790: lambda param shadows + (binary fold suppressed)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    // + is bound to -, so (+ 1 2) evaluates as (- 1 2) = -1, not the folded 3.
+    const result = try vm.eval("((lambda (+) (+ 1 2)) -)");
+    try std.testing.expectEqual(@as(i64, -1), types.toFixnum(result));
+}
+
+test "issue #790: lambda param shadows < (comparison fold suppressed)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    // < is bound to +, so (< 1 2) evaluates as (+ 1 2) = 3, not #t.
+    const result = try vm.eval("((lambda (<) (< 1 2)) +)");
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+}
+
+test "issue #790: lambda param shadows zero? (unary fold suppressed)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    // zero? is bound to (lambda (x) #f), so (if (zero? 0) 10 20) = 20, not 10.
+    const result = try vm.eval("((lambda (zero?) (if (zero? 0) 10 20)) (lambda (x) #f))");
+    try std.testing.expectEqual(@as(i64, 20), types.toFixnum(result));
+}
+
+test "issue #790: lambda param shadows not (simplifyBooleans suppressed)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    // not is bound to odd?; (odd? 5) is #t, so (if (not 5) 100 200) = 100. The
+    // buggy (if (not X) A B) -> (if X B A) rewrite would yield 200.
+    const result = try vm.eval("((lambda (not) (if (not 5) 100 200)) odd?)");
+    try std.testing.expectEqual(@as(i64, 100), types.toFixnum(result));
+}
+
+test "issue #790: shadowed operator with pre-folded args (foldConstants pass)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    // (- 5 4) folds to 1 (- is not shadowed); the outer + is shadowed by *, so
+    // the IR foldConstants pass must not fold (+ 1 2). Result: (* 1 2) = 2.
+    const result = try vm.eval("((lambda (+) (+ (- 5 4) 2)) *)");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
+}
+
+test "issue #790: enclosing lambda param shadows via upvalue chain" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    // The inner lambda's (+ 3 4) sees + as an upvalue bound to -, so isRedefined
+    // must walk the enclosing compiler chain. Result: (- 3 4) = -1, not 7.
+    const result = try vm.eval("((lambda (+) ((lambda (y) (+ 3 4)) 10)) -)");
+    try std.testing.expectEqual(@as(i64, -1), types.toFixnum(result));
+}
+
+test "issue #790: unshadowed operator still folds in a lambda body" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    // + is not shadowed here, so folding must still happen normally.
+    const result = try vm.eval("((lambda (y) (+ 1 2)) 99)");
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+}
+
 fn readExpr(gc: *memory.GC, source: []const u8) !types.Value {
     var reader = reader_mod.Reader.init(gc, source);
     defer reader.deinit();

--- a/tests/scheme/compile/native-param-shadow-fold-790.sh
+++ b/tests/scheme/compile/native-param-shadow-fold-790.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Regression test for #790 (LLVM native backend): constant folding in
+# llvm_emit_lambda.zig must not fold a call to a primitive name that is
+# shadowed by a lambda / define-function parameter. The native emitter now
+# passes the parameter names to the IR via IR.bound_names so isRedefined
+# suppresses the fold.
+#
+# Without the fix, ((lambda (+) (+ 1 2)) -) compiles to a binary that prints 3.
+#
+# Usage: bash tests/scheme/compile/native-param-shadow-fold-790.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# The native backend needs libkaappi_rt.a; build it once.
+(cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+# lambda parameter shadows +, bound to - : (+ 1 2) must evaluate as (- 1 2).
+cat > "$DIR/lambda.scm" << 'SCHEME'
+(display ((lambda (+) (+ 1 2)) -))
+(newline)
+SCHEME
+
+# define-function parameter shadows *, bound to - : (* 3 4) must be (- 3 4).
+cat > "$DIR/define.scm" << 'SCHEME'
+(define (f *) (* 3 4))
+(display (f -))
+(newline)
+SCHEME
+
+check_native() {
+    local src="$1" expected="$2" label="$3"
+    local bin="$DIR/${label}.bin"
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — native compile did not produce a binary" >&2
+        exit 1
+    fi
+    local out
+    out="$("$bin")"
+    if [[ "$out" != "$expected" ]]; then
+        echo "FAIL: $label — expected '$expected', got '$out'" >&2
+        exit 1
+    fi
+}
+
+check_native "$DIR/lambda.scm" "-1" "lambda-param-shadow"
+check_native "$DIR/define.scm" "-1" "define-param-shadow"
+
+echo "PASS"

--- a/tests/scheme/smoke/lambda-param-shadow-fold-790.scm
+++ b/tests/scheme/smoke/lambda-param-shadow-fold-790.scm
@@ -1,0 +1,51 @@
+;; Regression test for #790: IR constant folding and simplifyBooleans must not
+;; fold a call to a primitive name that is shadowed by a lambda parameter (or an
+;; enclosing local). Lambda bodies are lowered through the IR by
+;; compileLambdaWithIR, where the folds previously fired with no scope check.
+;;
+;; The shadowing expressions are passed as arguments to the plain procedure
+;; `check` (NOT wrapped in a macro like SRFI-64's test-eqv), so the operator
+;; lambda is compiled via the IR path rather than the legacy passthrough
+;; compiler. Wrapping in test-eqv would exercise the already-correct legacy
+;; path and pass even against the bug.
+(import (scheme base) (scheme write))
+
+(define failures 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      #t
+      (begin (set! failures (+ failures 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write actual) (newline))))
+
+;; tryFoldFromAST / foldConstants: binary arithmetic
+(check "param-shadowed + folds as -" -1 ((lambda (+) (+ 1 2)) -))
+(check "param-shadowed * folds as -" -1 ((lambda (*) (* 3 4)) -))
+
+;; comparison operators
+(check "param-shadowed < returns +" 3 ((lambda (<) (< 1 2)) +))
+(check "param-shadowed = returns +" 3 ((lambda (=) (= 1 2)) +))
+
+;; unary predicates
+(check "param-shadowed zero? returns list" '(0) ((lambda (zero?) (zero? 0)) list))
+(check "param-shadowed not returns odd?" #t ((lambda (not) (not 5)) odd?))
+
+;; simplifyBooleans: (if (not X) A B) must not rewrite when not is a parameter
+(check "param-shadowed not in if" 'a ((lambda (not) (if (not 5) 'a 'b)) odd?))
+
+;; foldConstants pass: inner (- 5 4) folds (- not shadowed), outer + is shadowed
+;; by *, so the IR fold pass must leave (+ 1 2) alone -> (* 1 2) = 2.
+(check "shadowed op with pre-folded args" 2 ((lambda (+) (+ (- 5 4) 2)) *))
+
+;; enclosing lambda parameter shadows via the upvalue chain
+(check "upvalue-shadowed + in nested lambda"
+  -1 ((lambda (+) ((lambda (y) (+ 3 4)) 10)) -))
+
+;; unshadowed operators must still fold normally inside a lambda body
+(check "unshadowed + still folds" 3 ((lambda (y) (+ 1 2)) 99))
+(check "unshadowed not still folds in if" 'then ((lambda (y) (if (not #f) 'then 'else)) 99))
+
+(if (= failures 0)
+    (begin (display "PASS") (newline))
+    (begin (display failures) (display " failures") (newline) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #790. The IR constant-folding (`tryFoldFromAST`, `foldConstants`) and boolean-simplification (`simplifyBooleans`) passes guarded only against **global** redefinition of primitives via `isRedefined()`, which consults the globals map. Lambda parameters that shadow `+`, `-`, `*`, `<`, `=`, `zero?`, `not`, etc. are lexical bindings the globals map never sees, so the folds fired using the built-in's semantics and produced silently wrong results:

```scheme
(display ((lambda (+) (+ 1 2)) -))                 ; was 3,  now -1
(display ((lambda (<) (< 1 2)) +))                 ; was #t, now 3
(display ((lambda (zero?) (zero? 0)) list))        ; was #t, now (0)
(display ((lambda (not) (if (not 5) 'a 'b)) odd?)) ; was b,  now a   (simplifyBooleans)
```

Lambda bodies are lowered through the IR by `compileLambdaWithIR`, which registers parameters as compiler locals but never told the IR about them. This is the IR-path remnant of #5 (the legacy `tryConstantFold` path already consulted `resolveLocal`/`resolveUpvalue`).

## Fix

- **`compiler.zig`** — add `Compiler.isLexicallyBound`, a side-effect-free predicate that walks the compiler's locals and parent chain (unlike `resolveUpvalue`, which registers upvalues). Point `IR.compiler` at the enclosing compiler at every `IR.init` site so `isRedefined` can consult lexical scope.
- **`ir.zig`** — `isRedefined` now returns `true` when the name is lexically bound. This only makes folding *more* conservative, so it can never introduce an incorrect fold.
- **`llvm_emit_lambda.zig`** — the LLVM native backend exhibited the same bug (no `Compiler` there); add `IR.bound_names` and pass each lambda's own parameter names.

## Tests

All three new tests were verified to **fail on the pre-fix build** and **pass after**:

- `src/tests_ir.zig` — 7 Zig unit tests (binary/unary/comparison folds, the `simplifyBooleans` rewrite, the IR `foldConstants` pass, the upvalue-chain case, and an unshadowed-still-folds guard).
- `tests/scheme/smoke/lambda-param-shadow-fold-790.scm` — uses the manual-`check` procedure-argument style because SRFI-64's `test-eqv` forces the already-correct legacy path and would mask the bug.
- `tests/scheme/compile/native-param-shadow-fold-790.sh` — native-compile regression for the LLVM path.

Full suite after rebase onto `main`: **254 Scheme files pass, 0 fail, 0 timeout; R7RS 1395 pass, 0 fail**. `zig build test` green; `zig fmt` clean.

## Out of scope

The issue's "related manifestation" — `(lambda () (set! + -) (+ 5 2))` printing `7` — is a **temporal** staleness that affects *both* the legacy and IR fold paths equally (not lexical shadowing). It needs whole-body `set!`-target analysis and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)