### PR TITLE
Scope library-body define-syntax macros to their library (#877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+#### Libraries
+- Fix `define-syntax` in a library body registering the macro in the process-global macro table at load time — unexported library-body macros no longer leak to all code, and a macro imported from one library is no longer silently clobbered by loading another library that defines the same name (#877)
+
 #### Package manager (thottam)
 - Fix version-pinned installs always failing with "Failed to checkout version": `git checkout -- <ref>` treats the ref as a pathspec, so use `--end-of-options` to keep the option-injection guard while resolving `<ref>` as a revision. Affected `install pkg@v1.0.0`, semver constraints, and `--locked` installs (#780)
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1385,6 +1385,18 @@ pub const Compiler = struct {
         try self.recordBodyMacro(name);
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
 
+        // A define-syntax at a library's top level (not nested in a lambda/let
+        // body scope) is also stored in the library environment. lib_env is
+        // per-library and GC-rooted, so the macro persists across the library's
+        // body forms and is found by lib_env export resolution — without
+        // leaking into the process-global macro table (issue #877). At the REPL
+        // top level lib_env is null, so ordinary define-syntax is unaffected.
+        if (self.body_macro_depth == 0) {
+            if (self.lib_env) |env| {
+                env.put(name, transformer) catch return CompileError.OutOfMemory;
+            }
+        }
+
         // define-syntax returns void
         try self.emitOp(.load_void);
         try self.emitU16(dst);

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -31,10 +31,11 @@ fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, v
 /// Copy the free references of a macro's templates from its definition
 /// environment into the import target, so use-site expansions can resolve
 /// library-internal bindings. Follows macro-to-macro references transitively:
-/// an exported macro may expand into internal helper macros (which live in
-/// vm.macros, not the library env) whose own free references must also be
-/// visible at the use site (e.g. SRFI 64 test-assert → %test-comp1body →
-/// %test-on-test-begin).
+/// an exported macro may expand into internal helper macros (which live in the
+/// source library's lib_env) whose own free references must also be visible at
+/// the use site (e.g. SRFI 64 test-assert → %test-comp1body →
+/// %test-on-test-begin). Helper macros are additionally registered in the
+/// importer's macro namespace so the compiler expands them there (issue #877).
 fn copyTransformerFreeRefs(
     vm: *VM,
     target: *std.StringHashMap(Value),
@@ -66,12 +67,22 @@ fn copyTransformerFreeRefs(
                     if (target == &vm.globals) vm.global_version +%= 1;
                 }
                 if (types.isTransformer(fval)) {
+                    // An exported macro may expand into a library-internal
+                    // helper macro (e.g. SRFI 64 test-assert → %test-comp1body).
+                    // The helper lives in the source library's lib_env, not the
+                    // importer's; register it in the importer's macro namespace
+                    // so the compiler expands it at the use site. This is the
+                    // only leg that reaches vm.macros, keeping importBinding the
+                    // sole path into it (issue #877).
+                    if (target == &vm.globals and !vm.macros.contains(fname)) {
+                        vm.macros.put(fname, fval) catch return error.OutOfMemory;
+                    }
                     try copyTransformerFreeRefs(vm, target, types.toObject(fval).as(types.Transformer), visited, depth + 1);
                 }
             } else if (vm.macros.get(fname)) |mval| {
-                // define-syntax in a library body registers the helper in
-                // vm.macros rather than the library env; recurse so the
-                // helper's free references resolve at the use site too.
+                // Fallback: a helper already present in the global macro table
+                // (e.g. imported at the REPL top level). Recurse so its own free
+                // references resolve at the use site too.
                 if (types.isTransformer(mval)) {
                     try copyTransformerFreeRefs(vm, target, types.toObject(mval).as(types.Transformer), visited, depth + 1);
                 }
@@ -905,12 +916,11 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
     for (0..export_names.items.len) |i| {
         const internal_name = export_names.items[i];
         const exported_name = export_renames.items[i] orelse internal_name;
+        // Both value definitions and library-body macros live in lib_env
+        // (issue #877), so a single lookup resolves every export. Macros are
+        // no longer sourced from the global vm.macros — that fallback only
+        // worked because define-syntax used to leak process-globally.
         if (lib_env.get(internal_name)) |val| {
-            lib.addExport(exported_name, val) catch {
-                lib.deinit();
-                return VMError.OutOfMemory;
-            };
-        } else if (vm.macros.get(internal_name)) |val| {
             lib.addExport(exported_name, val) catch {
                 lib.deinit();
                 return VMError.OutOfMemory;
@@ -950,7 +960,22 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
         return;
     }
 
-    const func = compiler_mod.compileExpressionInEnv(vm.gc, expr, &vm.macros, lib_env, types.NIL) catch return VMError.CompileError;
+    // Compile against a per-library macro table seeded from lib_env rather
+    // than the global vm.macros, so define-syntax in this library's body does
+    // not leak into (nor read from) the process-global macro namespace
+    // (issue #877). The library's own macros are stored in lib_env by
+    // compileDefineSyntax; imported macros already live there too. Seeding
+    // from lib_env's transformer entries makes both visible to the macro
+    // expander for this form without touching vm.macros.
+    var lib_macros = std.StringHashMap(Value).init(vm.gc.allocator);
+    defer lib_macros.deinit();
+    var env_it = lib_env.iterator();
+    while (env_it.next()) |entry| {
+        if (types.isTransformer(entry.value_ptr.*)) {
+            lib_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return VMError.OutOfMemory;
+        }
+    }
+    const func = compiler_mod.compileExpressionInEnv(vm.gc, expr, &lib_macros, lib_env, types.NIL) catch return VMError.CompileError;
     if (vm.lib_compile_collect) |collect| {
         collect.append(vm.gc.allocator, func) catch return VMError.OutOfMemory;
     }

--- a/tests/scheme/smoke/lib877/a.sld
+++ b/tests/scheme/smoke/lib877/a.sld
@@ -1,0 +1,6 @@
+;; Fixture for #877: exports macro `tag` expanding to 'from-a.
+(define-library (lib877 a)
+  (import (scheme base))
+  (export tag)
+  (begin
+    (define-syntax tag (syntax-rules () ((_) 'from-a)))))

--- a/tests/scheme/smoke/lib877/b.sld
+++ b/tests/scheme/smoke/lib877/b.sld
@@ -1,0 +1,9 @@
+;; Fixture for #877: also defines a macro named `tag` (expanding to 'from-b)
+;; but only exports the procedure `bfun`. Loading this library must not
+;; clobber a `tag` macro imported from (lib877 a).
+(define-library (lib877 b)
+  (import (scheme base))
+  (export tag bfun)
+  (begin
+    (define (bfun) 'bfun)
+    (define-syntax tag (syntax-rules () ((_) 'from-b)))))

--- a/tests/scheme/smoke/lib877/helper.sld
+++ b/tests/scheme/smoke/lib877/helper.sld
@@ -1,0 +1,13 @@
+;; Fixture for #877: an exported macro (`outer`) that expands into a private,
+;; unexported helper macro (`inner`) defined in the same library body. An
+;; importer of `outer` must still be able to expand it, which requires the
+;; transitively-referenced helper macro to be made available at the use site —
+;; without `inner` being independently importable.
+(define-library (lib877 helper)
+  (import (scheme base))
+  (export outer)
+  (begin
+    (define-syntax inner
+      (syntax-rules () ((_ x) (+ x 100))))
+    (define-syntax outer
+      (syntax-rules () ((_ x) (inner x))))))

--- a/tests/scheme/smoke/lib877/m.sld
+++ b/tests/scheme/smoke/lib877/m.sld
@@ -1,0 +1,9 @@
+;; Fixture for #877: a library with a PRIVATE (unexported) macro that is
+;; used by an exported procedure. The macro must not leak to importers.
+(define-library (lib877 m)
+  (import (scheme base))
+  (export public-f)
+  (begin
+    (define-syntax private-mac
+      (syntax-rules () ((_ x) (list 'private x))))
+    (define (public-f) (private-mac 1))))

--- a/tests/scheme/smoke/lib877/user.sld
+++ b/tests/scheme/smoke/lib877/user.sld
@@ -1,0 +1,8 @@
+;; Fixture for #877: imports a macro from another library and uses it in its
+;; own body. This must keep working after macros stop leaking process-globally
+;; (imported macros live in the importing library's environment).
+(define-library (lib877 user)
+  (import (scheme base) (lib877 a))
+  (export use-tag)
+  (begin
+    (define (use-tag) (tag))))

--- a/tests/scheme/smoke/library-macro-leak-877.scm
+++ b/tests/scheme/smoke/library-macro-leak-877.scm
@@ -1,0 +1,54 @@
+;; Regression test for #877: define-syntax inside a library body must not
+;; register the macro in the process-global macro table.
+;;
+;; Two observable bugs this guards against:
+;;   1. Unexported library-body macros leaking to all code once the library
+;;      loads (even when the importer filters them out).
+;;   2. Loading a library silently clobbering a same-named macro that the
+;;      program explicitly imported from a different library (wrong-answer bug).
+;;
+;; The fixture libraries live in lib877/ next to this script and are loaded
+;; lazily on first import, so the clobber case reproduces the real load order.
+(import (scheme base) (scheme write) (scheme eval) (srfi 64))
+
+(test-begin "library-macro-leak-877")
+
+;; --- 1. Unexported macro must not leak ---------------------------------------
+;; Only public-f is imported; the private-mac used inside the library must not
+;; become visible to the importer.
+(import (only (lib877 m) public-f))
+
+(test-equal "exported proc still uses its private macro" '(private 1) (public-f))
+
+(test-assert "unexported library macro does not leak"
+  (guard (exn (#t #t))
+    ;; If private-mac had leaked into the global macro table, this would
+    ;; expand to (list 'private 7); with the fix it is an unbound identifier.
+    (eval '(private-mac 7) (environment '(scheme base)))
+    #f))
+
+;; --- 2. Imported macro must not be clobbered by a later library --------------
+;; Import A's `tag` explicitly, then import only `bfun` from B. Loading B
+;; (which also defines a `tag` macro) must not overwrite A's `tag`.
+(import (only (lib877 a) tag))
+(import (only (lib877 b) bfun))
+
+(test-equal "macro imported from A is not clobbered by loading B" 'from-a (tag))
+(test-equal "the non-macro export from B is usable" 'bfun (bfun))
+
+;; --- 3. Importing and using a macro across libraries still works -------------
+(import (only (lib877 user) use-tag))
+(test-equal "library uses a macro imported from another library" 'from-a (use-tag))
+
+;; --- 4. Exported macro expanding into a private helper macro still works ------
+;; `outer` expands into the unexported helper `inner`; importing only `outer`
+;; must still expand correctly at the use site. (The helper is made available
+;; at the import target on demand so the expansion resolves — that is required
+;; for correctness and is distinct from the wholesale load-time leak in #877,
+;; where `private-mac` above is referenced by no export and stays hidden.)
+(import (only (lib877 helper) outer))
+(test-equal "exported macro expands via its private helper" 105 (outer 5))
+
+(let ((runner (test-runner-current)))
+  (test-end "library-macro-leak-877")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #877.

## Problem

`define-syntax` inside a library `begin` block registered the macro directly into the **process-global** `vm.macros` table while the library body compiled. Two observable bugs followed:

1. **Unexported macros leak** — any macro defined in a library body became usable by all code once the library loaded, even when the importer filtered it out with `only`.
2. **Silent clobbering (wrong answer)** — loading library B overwrote a same-named macro the program had explicitly imported from library A, so the program silently got B's expansion.

This is distinct from the earlier import-time issues #495/#608: here the macro never went through import at all — it landed in the global table while the library body was being compiled against `&vm.macros`.

## Fix

Library-body macros now live in the per-library `lib_env` (already GC-rooted and already home to imported transformers) instead of `vm.macros`:

- **`compiler.zig` `compileDefineSyntax`** — a library-top-level `define-syntax` (i.e. `body_macro_depth == 0` with `lib_env` set) also stores the transformer in `lib_env`. REPL-level `define-syntax` is unaffected (`lib_env` is null there).
- **`vm_library.zig` `compileLibExpr`** — seeds the compiler's macro table from `lib_env`'s transformer entries, so a library body compiles hermetically without reading or writing the global macro table.
- **Export resolution** reads `lib_env` only; the `vm.macros` fallback (which only worked *because* of the leak) is removed.
- **`copyTransformerFreeRefs`** — an exported macro's transitively-referenced private helper macros (they live in the source library's `lib_env`) are registered into the importer's macro namespace on demand, so use-site expansion still resolves them (e.g. SRFI-64 `test-assert` → `%test-comp1body`). `importBinding` remains the only path into `vm.macros`.

A subtlety worth flagging for reviewers: macro expansion happens during **IR lowering** (`lowerWithMacros(&self.macros)` in `compile()`), not the `lookupMacro`/`compileForm` passthrough path — so the seed goes into `self.macros`.

## Tests

New regression test `tests/scheme/smoke/library-macro-leak-877.scm` with `lib877/` `.sld` fixtures covering:
- unexported macro does not leak,
- a macro imported from A is not clobbered by loading B,
- a library importing and using another library's macro in its own body,
- an exported macro that expands through a private helper.

Also manually verified macro export-with-`rename`, macro re-export, and internal-name non-leak.

## Verification

- `zig build test` ✓
- Full Scheme suite ✓ (R7RS 1395/1395; SRFI-35 and SRFI-64 pass)
- GC stress `-Dgc-threshold=1` ✓ on the library-macro tests

Note: `tests/scheme/smoke/deep-copy-list-801.scm` is flaky (~40% `Abort trap: 6` in `_pthread_cond_broadcast`), but this reproduces identically on pristine `origin/main` without this change — it's a pre-existing SRFI-18 threading race, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)