### PR TITLE
io: return "" for (read-string 0 port), not eof

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -760,6 +760,10 @@ fn readStringFn(args: []const Value) PrimitiveError!Value {
     const count: usize = @intCast(@as(u64, @bitCast(k)));
     const port = try getInputPort(args, 1, "read-string");
 
+    // (read-string 0 port) yields "" -- characters are "available" only when
+    // k > 0, so k = 0 never signals EOF (mirrors read-bytevector, issue #281).
+    if (count == 0) return gc.allocString("") catch return PrimitiveError.OutOfMemory;
+
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(gc.allocator);
 

--- a/src/tests_io.zig
+++ b/src/tests_io.zig
@@ -385,3 +385,29 @@ test "import scheme file" {
     try std.testing.expectEqual(types.TRUE, try vm.eval("(procedure? open-output-file)"));
     try std.testing.expectEqual(types.TRUE, try vm.eval("(procedure? file-exists?)"));
 }
+
+test "read-string 0 on non-exhausted port returns empty string, not eof (issue #815)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define p (open-input-string \"abc\"))");
+
+    // k = 0 with input available: empty string, NOT eof
+    const zero = try vm.eval("(read-string 0 p)");
+    try std.testing.expect(types.isString(zero));
+    const zstr = types.toObject(zero).as(types.SchemeString);
+    try std.testing.expectEqualStrings("", zstr.data[0..zstr.len]);
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(eof-object? (read-string 0 p))"));
+
+    // Reading remaining characters still works normally afterwards.
+    const all = try vm.eval("(read-string 3 p)");
+    const astr = types.toObject(all).as(types.SchemeString);
+    try std.testing.expectEqualStrings("abc", astr.data[0..astr.len]);
+
+    // k > 0 at EOF still returns eof.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(eof-object? (read-string 3 p))"));
+    // k = 0 at EOF returns empty string (port exhausted, but zero requested).
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(eof-object? (read-string 0 p))"));
+}


### PR DESCRIPTION
## Summary

`(read-string 0 port)` returned an eof-object even when the port had input available. Per R7RS 6.13.2, an eof-object is returned only *"if no characters are available before the end of file"* — with `k = 0` no characters are requested, so the correct result is the empty string `""`, not eof.

This makes `read-string` consistent with `read-bytevector`, which was already fixed the same way in #281:

```scheme
(read-bytevector 0 (open-input-string "abc"))  ; => #u8()   (correct)
(read-string    0 (open-input-string "abc"))   ; => ""      (now correct; was #<eof>)
```

## Root cause

In `readStringFn` (`src/primitives_io.zig`), the read loop never executes when `k = 0`, and the empty-result check conflated "asked for zero characters" with "at EOF":

```zig
if (result.items.len == 0) return types.EOF;
```

## Fix

Early-return `""` when `count == 0`, before the loop — mirroring the #281 `read-bytevector` fix. The `len == 0 → EOF` return still correctly handles `k > 0` at EOF.

## Testing

- Added a regression test in `src/tests_io.zig` covering: `k = 0` on a non-exhausted port (→ `""`, not eof), normal reads afterward, `k > 0` at EOF (→ eof), and `k = 0` at EOF (→ `""`).
- Confirmed the test **fails without the fix** and passes with it.
- Full `zig build test` passes.

Fixes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)