### PR TITLE
Fix thottam version-pinned install: use --end-of-options not -- (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+#### Package manager (thottam)
+- Fix version-pinned installs always failing with "Failed to checkout version": `git checkout -- <ref>` treats the ref as a pathspec, so use `--end-of-options` to keep the option-injection guard while resolving `<ref>` as a revision. Affected `install pkg@v1.0.0`, semver constraints, and `--locked` installs (#780)
+
 ## [0.11.1] - 2026-07-02
 
 ### Fixed

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -500,6 +500,18 @@ fn runGitCapture(allocator: std.mem.Allocator, args: []const []const u8) ![]u8 {
     return runCapture(allocator, argv.items, null);
 }
 
+/// Check out a pinned version (tag or SHA) in an already-cloned package repo.
+///
+/// Uses `--end-of-options` (git 2.24+), NOT `--`: everything after `--` is a
+/// pathspec, so `git checkout -- v1.0.0` restores a file named "v1.0.0" instead
+/// of switching to that ref — which fails for any repo lacking such a file, and
+/// silently checks out the file (never the ref) for any repo that has one
+/// (issue #780). `--end-of-options` stops flag parsing while still treating the
+/// argument as a revision, keeping the option-injection guard from #736.
+fn checkoutVersion(allocator: std.mem.Allocator, pkg_dir: []const u8, v: []const u8) !void {
+    return runGit(allocator, &.{ "-C", pkg_dir, "checkout", "--quiet", "--end-of-options", v });
+}
+
 fn isInstalled(allocator: std.mem.Allocator, installed_path: []const u8, pkg: []const u8) bool {
     const content = readFile(allocator, installed_path) catch return false;
     defer allocator.free(content);
@@ -842,7 +854,7 @@ fn doInstall(
     if (install_version) |v| {
         printBuf(&buf, "  Checking out {s}...\n", .{v});
         runGit(allocator, &.{ "-C", pkg_dir, "fetch", "--quiet", "--tags" }) catch {};
-        runGit(allocator, &.{ "-C", pkg_dir, "checkout", "--quiet", "--", v }) catch {
+        checkoutVersion(allocator, pkg_dir, v) catch {
             printErrColor(Color.red, "  Failed to checkout version\n");
             return error.GitFailed;
         };
@@ -1422,4 +1434,46 @@ test "dylib_ext is correct for platform" {
     } else {
         try std.testing.expectEqualStrings(".so", dylib_ext);
     }
+}
+
+test "checkoutVersion resolves a pinned tag as a ref, not a pathspec (issue #780)" {
+    // Regression for #780: the pinned-install checkout used
+    // `git checkout -- <v>`, but arguments after `--` are pathspecs, so the
+    // tag/SHA was treated as a filename and every version-pinned install failed
+    // with "pathspec '<v>' did not match any file(s)". The fix uses
+    // `--end-of-options`, which still resolves <v> as a revision.
+    const allocator = std.testing.allocator;
+
+    // runGit shells out to /usr/bin/git; skip if it isn't present.
+    if (!fileExists(allocator, "/usr/bin/git")) return error.SkipZigTest;
+
+    // Unique temp repo path; `git init` creates the directory for us.
+    const base = getenv("TMPDIR") orelse "/tmp";
+    const repo = try std.fmt.allocPrint(allocator, "{s}/kaappi-thottam-780-{d}", .{ base, std.c.getpid() });
+    defer allocator.free(repo);
+    defer removeDir(allocator, repo) catch {};
+    // Start clean in case a prior aborted run left this path behind.
+    removeDir(allocator, repo) catch {};
+
+    // Two tagged commits; HEAD starts on v1.1.0. Pass identity and gpgsign via
+    // -c so the test doesn't depend on the ambient git config.
+    runGit(allocator, &.{ "init", "-q", repo }) catch return error.SkipZigTest;
+    try runGit(allocator, &.{ "-C", repo, "-c", "user.email=t@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", "one" });
+    try runGit(allocator, &.{ "-C", repo, "tag", "v1.0.0" });
+    try runGit(allocator, &.{ "-C", repo, "-c", "user.email=t@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", "two" });
+    try runGit(allocator, &.{ "-C", repo, "tag", "v1.1.0" });
+
+    // Checking out the older tag must switch HEAD to that tag's commit.
+    try checkoutVersion(allocator, repo, "v1.0.0");
+
+    const head = try runGitCapture(allocator, &.{ "-C", repo, "rev-parse", "HEAD" });
+    defer allocator.free(head);
+    const want = try runGitCapture(allocator, &.{ "-C", repo, "rev-parse", "v1.0.0^{commit}" });
+    defer allocator.free(want);
+    try std.testing.expectEqualStrings(want, head);
+
+    // And it genuinely moved off v1.1.0 (guards against a no-op "pass").
+    const v11 = try runGitCapture(allocator, &.{ "-C", repo, "rev-parse", "v1.1.0^{commit}" });
+    defer allocator.free(v11);
+    try std.testing.expect(!std.mem.eql(u8, head, v11));
 }


### PR DESCRIPTION
## Summary

Fixes #780. Every version-pinned `thottam` install was broken in v0.11.1 — `install pkg@v1.0.0`, semver constraints, and `--locked` installs all failed with `Failed to checkout version`.

**Root cause:** the #736 option-injection fix changed the checkout to `git checkout --quiet -- <ref>`, but arguments **after `--` are pathspecs**, not refnames. So git tried to restore a *file* named after the tag/SHA and failed with `pathspec '<ref>' did not match any file(s)`. (Worse, a repo that happened to contain such a file would silently restore it and never switch refs.)

**Fix:** use `--end-of-options` (git 2.24+) instead of `--`. It stops flag parsing — preserving the #736 injection guard — while still resolving the argument as a revision. The checkout is extracted into a documented `checkoutVersion` helper so the exact argument list is unit-testable.

## Testing

- New regression test `checkoutVersion resolves a pinned tag as a ref, not a pathspec (issue #780)` builds a throwaway repo with two tags, checks out the older one, and asserts HEAD moved to that tag's commit (and off the newer one). Verified it **fails** with `--` (`pathspec 'v1.0.0' did not match`) and **passes** with `--end-of-options`.
- `zig build test` passes; `zig fmt --check` clean.
- Ran the issue's end-to-end reproduction: `install pkga@v1.0.0::<repo>` and `install pkgb@>=1.0.0::<repo>` both succeed, with checked-out HEAD matching the expected tag commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)