### PR TITLE
Range-check nice argument to avoid @intCast panic (#800)

### DIFF
--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -734,10 +734,17 @@ fn userSupplementaryGidsFn(args: []const Value) PrimitiveError!Value {
 
 fn niceFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const delta: c_int = if (args.len > 0 and types.isFixnum(args[0]))
-        @intCast(types.toFixnum(args[0]))
-    else
-        1;
+    var delta: c_int = 1;
+    if (args.len > 0 and types.isFixnum(args[0])) {
+        // Fixnums range up to ±2^47, but nice() takes a C int. An unchecked
+        // @intCast panics (SIGABRT) on out-of-range values in ReleaseSafe;
+        // reject them as a recoverable Scheme error instead.
+        const n = types.toFixnum(args[0]);
+        if (n < std.math.minInt(c_int) or n > std.math.maxInt(c_int)) {
+            return raiseFileError(gc, "nice value out of range", args[0]);
+        }
+        delta = @intCast(n);
+    }
     const e = std.c._errno();
     e.* = 0;
     const result = nice(delta);

--- a/tests/scheme/smoke/filesystem-intcast.scm
+++ b/tests/scheme/smoke/filesystem-intcast.scm
@@ -53,6 +53,18 @@
 (check-error "create-directory negative mode"
   (lambda () (create-directory "/tmp/kaappi-intcast-dir" -1)))
 
+;; Regression test for #800: nice with an out-of-range integer must raise a
+;; recoverable Scheme error instead of panicking the interpreter (SIGABRT).
+;; The delta is cast to a C int, so values outside i32 range are rejected.
+(check-error "nice too large"
+  (lambda () (nice 4294967296)))
+
+(check-error "nice negative out of range"
+  (lambda () (nice -2147483649)))
+
+;; nice with a valid in-range delta must still return an integer.
+(check "nice valid" (integer? (nice 0)) #t)
+
 ;; Clean up
 (delete-file test-file)
 


### PR DESCRIPTION
## Summary

Fixes #800. `nice` (SRFI-170) cast its optional integer argument straight to a C `int` with an unchecked `@intCast`. A fixnum outside i32 range (e.g. `(nice 4294967296)` or `(nice -2147483649)`) tripped a Zig safety panic in the default ReleaseSafe build, aborting the whole interpreter with SIGABRT — an ordinary Scheme argument value could bring the VM down.

This is the same class of bug as #336, but `nice` was not among the call sites fixed there (and is distinct from #522, which fixed `nice`'s errno handling).

## Fix

`niceFn` now range-checks the fixnum against `c_int` bounds before the cast and raises a recoverable file error on overflow, mirroring the existing `validateMode`/`validateUid` pattern:

```zig
var delta: c_int = 1;
if (args.len > 0 and types.isFixnum(args[0])) {
    const n = types.toFixnum(args[0]);
    if (n < std.math.minInt(c_int) or n > std.math.maxInt(c_int)) {
        return raiseFileError(gc, "nice value out of range", args[0]);
    }
    delta = @intCast(n);
}
```

## Test

Added three checks to the existing `tests/scheme/smoke/filesystem-intcast.scm` (the file dedicated to this class of `@intCast` bug): `nice` too-large and negative-out-of-range both raise instead of crashing, and a valid `(nice 0)` still returns an integer.

## Verification

- `zig build` — clean
- `zig build test` — full unit suite passes
- Reproduction cases from the issue now raise catchable errors; VM stays alive (exit 0, previously exit 134)
- `filesystem-intcast.scm` (10/10) and `filesystem-coverage.scm` (61/61) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)