### PR TITLE
Suppress constant folding of set!-reassigned globals in the same form

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -57,6 +57,12 @@ pub const Compiler = struct {
     lib_env: ?*std.StringHashMap(Value) = null,
     lib_env_val: Value = types.NIL,
     restricted_env: bool = false, // true for restricted environments (null-environment, environment)
+    // Names that are `set!` somewhere in the top-level form being compiled.
+    // Owned by the top-level compile() frame and inherited by child compilers
+    // so nested lambda bodies see the same suppression set. Consulted by the
+    // constant folders (IR and legacy) to avoid folding calls to a name that
+    // may be reassigned before the call executes.
+    set_targets: ?*const std.StringHashMap(void) = null,
     scope_depth: u16 = 0,
     next_register: u16 = 0,
     parent: ?*Compiler = null,
@@ -117,6 +123,7 @@ pub const Compiler = struct {
             .lib_env = parent.lib_env,
             .lib_env_val = parent.lib_env_val,
             .restricted_env = parent.restricted_env,
+            .set_targets = parent.set_targets,
             .parent = parent,
         };
     }
@@ -358,11 +365,21 @@ pub const Compiler = struct {
         try self.gc.pushRoot(&expr_root);
         defer self.gc.popRoot();
 
+        // Scan the whole top-level form for `set!` targets so the constant
+        // folders never fold a call to a name that is reassigned within it
+        // (including in nested lambda bodies, which inherit this set).
+        var set_targets = std.StringHashMap(void).init(self.gc.allocator);
+        defer set_targets.deinit();
+        try collectSetTargets(expr_root, &set_targets);
+        self.set_targets = &set_targets;
+        defer self.set_targets = null;
+
         // Lower AST to IR, run analysis and optimizations, then emit bytecode.
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
         ir.restricted_env = self.restricted_env;
         ir.compiler = self;
+        ir.set_targets = self.set_targets;
         defer ir.deinit();
         var root = try ir_mod.lowerWithMacros(&ir, expr_root, &self.macros);
 
@@ -641,6 +658,7 @@ pub const Compiler = struct {
             ir.globals = child.globals;
             ir.restricted_env = child.restricted_env;
             ir.compiler = &child;
+            ir.set_targets = child.set_targets;
             defer ir.deinit();
             var root = try ir_mod.lowerWithMacros(&ir, expr, &child.macros);
             ir_mod.markTailPositions(root, rest == types.NIL);
@@ -702,6 +720,7 @@ pub const Compiler = struct {
         ir.globals = self.globals;
         ir.restricted_env = self.restricted_env;
         ir.compiler = self;
+        ir.set_targets = self.set_targets;
         defer ir.deinit();
         var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
         ir_mod.identifyPrimitives(val_root);
@@ -753,6 +772,7 @@ pub const Compiler = struct {
         ir.globals = self.globals;
         ir.restricted_env = self.restricted_env;
         ir.compiler = self;
+        ir.set_targets = self.set_targets;
         defer ir.deinit();
         var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
         ir_mod.identifyPrimitives(val_root);
@@ -900,6 +920,7 @@ pub const Compiler = struct {
             ir.globals = self.globals;
             ir.restricted_env = self.restricted_env;
             ir.compiler = self;
+            ir.set_targets = self.set_targets;
             defer ir.deinit();
             var root = try ir_mod.lowerWithMacros(&ir, expr, &self.macros);
             ir_mod.markTailPositions(root, false);
@@ -1539,6 +1560,46 @@ pub const Compiler = struct {
         }
     }
 };
+
+/// Strip hygiene-rename prefixes (`__hyg_<n>_`) so macro-introduced `set!`
+/// forms are recognized. Mirrors the stripping in ir.lowerFormWithMacros.
+fn effectiveSymbolName(name: []const u8) []const u8 {
+    var n = name;
+    while (std.mem.startsWith(u8, n, "__hyg_")) {
+        if (std.mem.indexOfScalar(u8, n[6..], '_')) |sep| {
+            n = n[6 + sep + 1 ..];
+        } else break;
+    }
+    return n;
+}
+
+/// Recursively collect the symbol names that appear as the target of a
+/// `(set! <name> ...)` anywhere in `expr` into `out`. Used to suppress
+/// constant folding of those names within the enclosing form (see
+/// Compiler.set_targets). Conservative: it scans every sub-form except the
+/// interior of `quote`d data. Iterates the cdr spine to stay bounded on long
+/// lists and only recurses into car sub-forms.
+fn collectSetTargets(expr: Value, out: *std.StringHashMap(void)) CompileError!void {
+    var cur = expr;
+    while (types.isPair(cur)) {
+        const head = types.car(cur);
+        if (types.isSymbol(head)) {
+            const hname = effectiveSymbolName(types.symbolName(head));
+            if (std.mem.eql(u8, hname, "quote")) return; // literal data, not code
+            if (std.mem.eql(u8, hname, "set!")) {
+                const rest = types.cdr(cur);
+                if (types.isPair(rest)) {
+                    const target = types.car(rest);
+                    if (types.isSymbol(target)) {
+                        out.put(types.symbolName(target), {}) catch return CompileError.OutOfMemory;
+                    }
+                }
+            }
+        }
+        try collectSetTargets(head, out);
+        cur = types.cdr(cur);
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Convenience functions

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -209,6 +209,12 @@ fn tryConstantFold(self: *Compiler, expr: Value, dst: u16) bool {
     if (!types.isSymbol(operator)) return false;
     const name = types.symbolName(operator);
 
+    // A `set!` to this name in the enclosing form may run before this call,
+    // so folding would use a stale primitive value. Suppress it.
+    if (self.set_targets) |st| {
+        if (st.contains(name)) return false;
+    }
+
     if (self.resolveLocal(name) != null) return false;
     if ((self.resolveUpvalue(name) catch null) != null) return false;
     if (self.globals) |globals| {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -147,6 +147,12 @@ pub const IR = struct {
     // that have no Compiler (the LLVM native backend passes a lambda's own
     // parameter names here). Also consulted by isRedefined (issue #790).
     bound_names: ?[]const []const u8 = null,
+    // Names that are the target of a `set!` somewhere in the enclosing form
+    // being compiled. Folding a call to such a name is unsound: the `set!`
+    // may run before the call (e.g. `(lambda () (set! + -) (+ 5 2))`), so the
+    // primitive's value at compile time no longer reflects its value at the
+    // call site. Populated conservatively (whole-form scan) by the compiler.
+    set_targets: ?*const std.StringHashMap(void) = null,
 
     pub fn init(allocator: std.mem.Allocator) IR {
         return .{
@@ -166,6 +172,11 @@ pub const IR = struct {
             for (names) |n| {
                 if (std.mem.eql(u8, n, name)) return true;
             }
+        }
+        // A `set!` target in the enclosing form suppresses folding even when
+        // the global still holds the original primitive at compile time.
+        if (self.set_targets) |st| {
+            if (st.contains(name)) return true;
         }
         const g = self.globals orelse return false;
         const val = g.get(name) orelse {

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -331,6 +331,66 @@ test "IR optimization: constant folding not applied to non-constant args" {
     try std.testing.expect(folded.tag == .call);
 }
 
+test "IR optimization: set! target suppresses constant folding" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var ir = ir_mod.IR.init(std.testing.allocator);
+    defer ir.deinit();
+
+    var set_targets = std.StringHashMap(void).init(std.testing.allocator);
+    defer set_targets.deinit();
+    try set_targets.put("+", {});
+    ir.set_targets = &set_targets;
+
+    const plus_sym = try gc.allocSymbol("+");
+    const op = try ir.makeGlobalRef(plus_sym);
+    const a = try ir.makeConst(types.makeFixnum(3));
+    const b = try ir.makeConst(types.makeFixnum(4));
+    const call = try ir.makeCall(op, &.{ a, b });
+
+    const folded = ir_mod.foldConstants(&ir, call);
+    try std.testing.expect(folded.tag == .call); // must stay a call, not fold to 7
+}
+
+fn expectEvalFixnum(source: []const u8, expected: i64) !void {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    const result = try vm.eval(source);
+    try std.testing.expectEqual(expected, types.toFixnum(result));
+}
+
+test "IR fold: set! of + in lambda body is not folded (stale global rebind)" {
+    // (+ 5 2) must not fold to 7: + is set! to - before the call runs.
+    try expectEvalFixnum("(define f (lambda () (set! + -) (+ 5 2))) (f)", 3);
+}
+
+test "IR fold: set! of + inside let body is not folded (legacy passthrough path)" {
+    try expectEvalFixnum("(define g (lambda () (let ((x 1)) (set! + -) (+ 5 2)))) (g)", 3);
+}
+
+test "IR fold: set! in outer body suppresses fold in nested lambda" {
+    try expectEvalFixnum("(define k (lambda () (set! + -) (lambda () (+ 5 2)))) ((k))", 3);
+}
+
+test "IR fold: every + call in a set!-body is suppressed" {
+    try expectEvalFixnum("(define h (lambda () (+ 100 1) (set! + -) (+ 5 2))) (h)", 3);
+}
+
+test "IR fold: set! of * in lambda body is not folded" {
+    try expectEvalFixnum("(define f (lambda () (set! * -) (* 10 3))) (f)", 7);
+}
+
+test "IR fold: primitive still folds when no set! targets it" {
+    try expectEvalFixnum("((lambda () (+ 5 2)))", 7);
+}
+
+test "IR fold: set! inside quoted data does not suppress folding" {
+    // (quote (set! + -)) is data, not a rebind; (+ 5 2) still folds to 7.
+    try expectEvalFixnum("(define p (lambda () (quote (set! + -)) (+ 5 2))) (p)", 7);
+}
+
 test "IR optimization: constant folding through if" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/tests/scheme/smoke/set-redefine-fold.scm
+++ b/tests/scheme/smoke/set-redefine-fold.scm
@@ -1,0 +1,80 @@
+;; Regression test: constant folding must not fold a call to a primitive that
+;; is a `set!` target within the enclosing form. The `set!` runs before the
+;; call, so the value folded in at compile time is stale.
+;;
+;;   (define f (lambda () (set! + -) (+ 5 2)))
+;;   (f)  ; must be 3, not the folded 7
+;;
+;; Uses the manual-check / procedure-argument style (NOT SRFI-64 test-eqv) so
+;; the folded expressions travel the IR fold path (tryFoldFromAST /
+;; foldConstants). test-eqv would route through the legacy passthrough path
+;; and mask an IR-path regression. See also global-redefine-fold.scm.
+(import (scheme base) (scheme write) (scheme process-context))
+
+;; Adder captured from the original + so a test that clobbers the global +
+;; cannot corrupt failure counting.
+(define real+ +)
+(define failures 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      #t
+      (begin (set! failures (real+ failures 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write actual) (newline))))
+
+;; Originals, restored between tests so each starts from the primitive.
+(define orig+ +)
+(define orig- -)
+(define orig* *)
+(define orig= =)
+
+;; IR path: set! of + inside a lambda body.
+(define f (lambda () (set! + -) (+ 5 2)))
+(define r-f (f))              ; running f rebinds global + to -
+(set! + orig+)               ; restore before check (which uses +)
+(check "set! + -> - in lambda body folds as -" 3 r-f)
+
+;; Legacy passthrough path control: the let wrapper forces that path.
+(define g (lambda () (let ((x 1)) (set! + -) (+ 5 2))))
+(define r-g (g))
+(set! + orig+)
+(check "set! + -> - in let body folds as -" 3 r-g)
+
+;; A + call textually before the set! must also be suppressed (conservative
+;; whole-body scan); it evaluates before the rebind so it is still correct.
+(define h (lambda () (+ 100 1) (set! + -) (+ 5 2)))
+(define r-h (h))
+(set! + orig+)
+(check "set! + -> - suppresses every fold in the body" 3 r-h)
+
+;; The set! sits in the outer body; the folded call lives in a nested lambda
+;; that captures the same global +. Suppression must reach the nested scope.
+(define k (lambda () (set! + -) (lambda () (+ 5 2))))
+(define inner (k))           ; global + is now -
+(define r-k (inner))         ; (+ 5 2) with + = - -> 3, not folded 7
+(set! + orig+)
+(check "set! in outer body suppresses fold in nested lambda" 3 r-k)
+
+;; Other foldable primitives.
+(define fm (lambda () (set! * -) (* 10 3)))
+(define r-fm (fm))
+(set! * orig*)
+(check "set! * -> - folds as -" 7 r-fm)
+
+;; (= 2 1): folded as = would be #f; run as > it is #t.
+(define fe (lambda () (set! = >) (= 2 1)))
+(define r-fe (fe))
+(set! = orig=)
+(check "set! = -> > folds as >" #t r-fe)
+
+;; A primitive that is never a set! target must still fold correctly.
+(check "unshadowed + still folds" 3 ((lambda () (+ 1 2))))
+
+;; A set! that appears only inside quoted data must not suppress folding.
+(define p (lambda () (quote (set! + -)) (+ 5 2)))
+(check "quoted set! does not suppress folding" 7 (p))
+
+(if (= failures 0)
+    (begin (display "all passed") (newline))
+    (begin (display failures) (display " failures") (newline) (exit 1)))


### PR DESCRIPTION
## Problem

Constant folding evaluated a call to a primitive at closure-compile time, even when the same form reassigns that primitive with `set!` before the call runs:

```scheme
(define f (lambda () (set! + -) (+ 5 2)))
(f)   ; folded (+ 5 2) → 7 at compile time; correct result is 3
```

`(set! + -)` executes first, so `+` is `-` by the time `(+ 5 2)` runs — the answer must be 3. This hit **both** compile paths:

- **IR fold path** — `tryFoldFromAST` / `foldConstants`, gated by `isRedefined`, which only consulted the globals map (still the original primitive at compile time).
- **Legacy path** — `tryConstantFold` in `compiler_passthrough.zig`.

This is distinct from lexical shadowing (#790 / #956): `+` here is a global reassigned within the body, not a lambda/let binding.

## Fix

Scan the whole top-level form for `set!` targets and suppress folding of those names:

- **`compiler.zig`** — new `collectSetTargets()` walks the form (iterating the cdr spine to stay bounded on long lists, recursing into car sub-forms, skipping `quote`d data, stripping `__hyg_` prefixes so macro-introduced `set!` is recognized). `compile()` builds the name set once and stores it on the compiler; `initChild` inherits it so nested lambda bodies share the suppression. All five IR-creation sites set `ir.set_targets`.
- **`ir.zig`** — new `IR.set_targets` field; `isRedefined()` returns true for any name in it, covering `tryFoldFromAST`, `foldConstants`, and the `not`-in-`if` rewrite in `simplifyBooleans`.
- **`compiler_passthrough.zig`** — `tryConstantFold` bails when the operator is a `set!` target.

The scan is conservative by design (a `set!` anywhere in the form suppresses folding of that name everywhere in it), which also correctly covers the nested-lambda case and can only ever preserve correctness. Call emission already looks up the global at runtime, so folding was the only compile-time hazard.

## Tests

- `tests/scheme/smoke/set-redefine-fold.scm` — manual-`check` / procedure-argument style so the folded expressions travel the IR path (SRFI-64 `test-eqv` would route through the legacy path and mask an IR-path regression). Covers IR/legacy/nested/multi-use/`*`/`=`, plus quoted-`set!` and unshadowed controls.
- `src/tests_ir.zig` — one direct `foldConstants` suppression test plus `vm.eval` behavioral tests.
- Verified the new tests **fail without the fix** (6 assertions produced the buggy folded values 7/7/7/7/30/`#f`) and pass with it.
- `zig build test` ✅ · `zig fmt --check` ✅ · full Scheme suite **253 pass / 0 fail**, R7RS **1395 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)