### PR TITLE
Coerce FFI bool args to 0/1 before the C _Bool trampoline (#796)

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -37,6 +37,17 @@ fn toCheckedInt(comptime T: type, v: Value) error{TypeError}!T {
     return std.math.cast(T, wide) orelse return error.TypeError;
 }
 
+/// C-truthiness of a value bound to a `bool` FFI parameter. `validateArg`
+/// guarantees such a value is #t, #f, a fixnum, or a bignum, so any nonzero
+/// integer is true and zero is false.
+fn boolArgIsTrue(v: Value) bool {
+    if (v == types.TRUE) return true;
+    if (v == types.FALSE) return false;
+    if (types.isFixnum(v)) return types.toFixnum(v) != 0;
+    if (types.isBignum(v)) return types.toBignum(v).len != 0;
+    return false;
+}
+
 /// Convert a Scheme string Value to a null-terminated C string using a stack buffer.
 /// Returns null if the value is not a string or the string is too long.
 fn toCString(v: Value, buf: *[4096]u8) ?[*:0]const u8 {
@@ -159,6 +170,29 @@ fn validateArgs(ffi_fn: *types.FfiFunction, args: []const Value) !void {
     }
 }
 
+/// Coerce every `bool` argument to exactly #t/#f before dispatch so that only
+/// 0 or 1 is loaded into the C `_Bool` trampoline parameter. Passing any other
+/// integer is undefined behavior at the C ABI level and traps under
+/// UBSan-instrumented libraries (e.g. those built with `zig cc`). This mirrors
+/// the return direction, which normalizes any nonzero result to #t. `args.len`
+/// equals `param_count` (arity is checked by every caller); over-arity calls
+/// pass through untouched because the dispatch `switch` rejects them.
+fn normalizeBoolArgs(ffi_fn: *types.FfiFunction, args: []const Value, buf: *[5]Value) []const Value {
+    if (args.len > buf.len) return args;
+    var has_bool = false;
+    for (ffi_fn.param_types[0..args.len]) |t| {
+        if (t == .bool_type) has_bool = true;
+    }
+    if (!has_bool) return args;
+    for (args, 0..) |v, i| {
+        buf[i] = if (ffi_fn.param_types[i] == .bool_type)
+            (if (boolArgIsTrue(v)) types.TRUE else types.FALSE)
+        else
+            v;
+    }
+    return buf[0..args.len];
+}
+
 /// Main FFI call dispatcher. Routes to arity-specific handlers.
 pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Value {
     if (types.isFfiLibrary(ffi_fn.library)) {
@@ -166,13 +200,15 @@ pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) 
         if (lib.handle == null) return error.TypeError;
     }
     try validateArgs(ffi_fn, args);
+    var bool_buf: [5]Value = undefined;
+    const call_args = normalizeBoolArgs(ffi_fn, args, &bool_buf);
     const result = switch (ffi_fn.param_count) {
         0 => try callFfi0(ffi_fn, gc),
-        1 => try callFfi1(ffi_fn, args, gc),
-        2 => try callFfi2(ffi_fn, args, gc),
-        3 => try callFfi3(ffi_fn, args, gc),
-        4 => try callFfi4(ffi_fn, args, gc),
-        5 => try callFfi5(ffi_fn, args, gc),
+        1 => try callFfi1(ffi_fn, call_args, gc),
+        2 => try callFfi2(ffi_fn, call_args, gc),
+        3 => try callFfi3(ffi_fn, call_args, gc),
+        4 => try callFfi4(ffi_fn, call_args, gc),
+        5 => try callFfi5(ffi_fn, call_args, gc),
         else => return error.TypeError,
     };
     if (ffi_fn.return_type == .bool_type) {

--- a/src/tests_ffi.zig
+++ b/src/tests_ffi.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const memory = @import("memory.zig");
+const types = @import("types.zig");
+const ffi = @import("ffi.zig");
+
+// A C-ABI function with a real `_Bool` parameter. In safe builds (the default)
+// the Zig compiler inserts a check that traps if the incoming byte is not 0 or
+// 1 — exactly like a `zig cc`-built library with UBSan trap mode. This lets the
+// test reproduce the process abort from #796 without an external shared library:
+// before the fix, a raw fixnum like 2 reached this `_Bool` parameter and aborted.
+fn recvBool(b: bool) callconv(.c) c_int {
+    return if (b) 1 else 0;
+}
+
+// Build a stack FfiFunction pointing at recvBool. `library` is #f (not an
+// FfiLibrary) so callFfi skips the shared-library handle check. The header is
+// never inspected because nothing calls toObject() on the FfiFunction itself.
+fn makeBoolFn(ptypes: []types.FfiType, ret: types.FfiType) types.FfiFunction {
+    return .{
+        .header = undefined,
+        .symbol = @ptrFromInt(@intFromPtr(&recvBool)),
+        .library = types.FALSE,
+        .name = "recv_bool",
+        .param_types = ptypes,
+        .return_type = ret,
+        .param_count = 1,
+    };
+}
+
+test "ffi bool arg: non-0/1 integers coerced to 0/1, never trap (#796)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var ptypes = [_]types.FfiType{.bool_type};
+    var fn_int = makeBoolFn(ptypes[0..], .int);
+
+    // 2 must be coerced to 1 before reaching the _Bool parameter — passing it
+    // through raw aborts the process under the safety check. Before the fix
+    // this returned 2 (or trapped); the raw integer must never reach _Bool.
+    const r2 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(2)}, &gc);
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(r2));
+
+    // Any nonzero value is true (C truthiness); zero is false.
+    const rneg = try ffi.callFfi(&fn_int, &.{types.makeFixnum(-5)}, &gc);
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rneg));
+
+    const r0 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(0)}, &gc);
+    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(r0));
+
+    // #t / #f keep working as before (#418).
+    const rt = try ffi.callFfi(&fn_int, &.{types.TRUE}, &gc);
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rt));
+
+    const rf = try ffi.callFfi(&fn_int, &.{types.FALSE}, &gc);
+    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(rf));
+}
+
+test "ffi bool arg: bignum coerced to 0/1 (#796)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var ptypes = [_]types.FfiType{.bool_type};
+    var fn_int = makeBoolFn(ptypes[0..], .int);
+
+    // A value too large for a fixnum arrives as a bignum; it is still just a
+    // truthy value for a bool parameter and must coerce to 1.
+    const big = try gc.allocBignumFromI64(0x1_0000_0000_0000);
+    const rbig = try ffi.callFfi(&fn_int, &.{big}, &gc);
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rbig));
+}
+
+test "ffi bool arg with bool return normalizes both directions (#796)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var ptypes = [_]types.FfiType{.bool_type};
+    var fn_bool = makeBoolFn(ptypes[0..], .bool_type);
+
+    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(2)}, &gc));
+    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(0)}, &gc));
+    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.TRUE}, &gc));
+    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.FALSE}, &gc));
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -17,4 +17,5 @@ test {
     _ = @import("tests_deepcopy.zig");
     _ = @import("tests_ir.zig");
     _ = @import("tests_srfi18.zig");
+    _ = @import("tests_ffi.zig");
 }

--- a/tests/scheme/ffi/bool-coercion.scm
+++ b/tests/scheme/ffi/bool-coercion.scm
@@ -1,0 +1,47 @@
+;; Regression test for #796: FFI `bool` parameters must coerce their argument
+;; to exactly 0/1 before it reaches the C _Bool parameter. Passing a raw integer
+;; like 2 into a _Bool is undefined behavior (and aborts UBSan-instrumented
+;; libraries built with `zig cc`).
+;;
+;; We declare libc `abs` (really `int abs(int)`) with a `bool` parameter. The
+;; marshaler coerces the Scheme argument to 0/1 and loads it into the trampoline;
+;; `abs` then simply returns that 0 or 1. Before the fix, the raw argument was
+;; passed through: (abs-bool 2) returned 2 and (abs-bool -5) returned 5.
+
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define libc (ffi-open #f))
+;; abs is int abs(int); we lie about the parameter type to exercise bool marshaling.
+(define abs-bool (ffi-fn libc "abs" '(bool) 'int))
+
+(check "bool arg 2 coerces to 1"   (abs-bool 2)  1)
+(check "bool arg -5 coerces to 1"  (abs-bool -5) 1)
+(check "bool arg 1 stays 1"        (abs-bool 1)  1)
+(check "bool arg 0 stays 0"        (abs-bool 0)  0)
+(check "bool arg #t is 1"          (abs-bool #t) 1)
+(check "bool arg #f is 0"          (abs-bool #f) 0)
+;; A bignum-range flag is still just truthy -> 1.
+(check "bool arg bignum coerces to 1" (abs-bool 4294967296) 1)
+
+;; bool return type still normalizes any nonzero to #t.
+(define abs-ret-bool (ffi-fn libc "abs" '(bool) 'bool))
+(check "bool return of true is #t"  (abs-ret-bool 2) #t)
+(check "bool return of false is #f" (abs-ret-bool 0) #f)
+
+(ffi-close libc)
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "FFI bool coercion tests failed" fail))


### PR DESCRIPTION
## Summary

Fixes #796. FFI parameters declared `bool` accepted **any** fixnum/bignum and passed the raw integer straight into the C `_Bool` argument. Only 0 and 1 are valid `_Bool` representations at the C ABI level, so a value like `2` is undefined behavior: it **aborts the whole interpreter** (uncatchable by `guard`) with libraries built by `zig cc` (UBSan trap mode, which the docs recommend), and is silent corruption otherwise. The bool-specific handling only ever covered `#t`/`#f` (added for #418); integer inputs fell through the generic `.int` marshaling path unclamped.

## Fix

Normalize every `bool` argument to exactly `#t`/`#f` at a single choke point in `callFfi`, **before** dispatch, so only 0/1 can reach the `_Bool` parameter. This mirrors the return direction, which already normalizes any nonzero result to `#t` (C-style truthiness).

- `boolArgIsTrue` — truthiness of a value bound to a `bool` param (`#t`/nonzero-int → true, `#f`/0 → false).
- `normalizeBoolArgs` — rewrites `bool`-typed args into a small stack buffer, leaving other args untouched; a no-op when the signature has no `bool` params.
- `callFfi` runs the normalization and dispatches with the coerced args.

Doing it in `callFfi` rather than at every `callFfi1`…`callFfi5` site keeps it in one place — the dispatch sites lose the `bool` type after `normalizeType`, so per-site clamping would be error-prone.

## Tests

Both new tests fail without the fix and pass with it (verified by temporarily bypassing the normalization):

- **`src/tests_ffi.zig`** — Zig unit tests that faithfully reproduce the issue with a real C-ABI `_Bool` function (`fn recvBool(b: bool) callconv(.c) c_int`). Covers fixnum coercion (`2`, `-5` → 1; `0` → 0), `#t`/`#f`, bignum-range flags, and `bool` return normalization. Registered in `src/vm_tests.zig`.
- **`tests/scheme/ffi/bool-coercion.scm`** — end-to-end test using libc `abs` declared with a `bool` parameter (no C compilation needed): `(abs-bool 2)` → 1, `(abs-bool -5)` → 1, etc.

`zig build test` and all Scheme FFI tests pass; formatting is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)