### PR TITLE
Exit non-zero on CLI usage and compile/standalone errors (#781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 #### Libraries
 - Fix `define-syntax` in a library body registering the macro in the process-global macro table at load time — unexported library-body macros no longer leak to all code, and a macro imported from one library is no longer silently clobbered by loading another library that defines the same name (#877)
 
+#### CLI
+- Exit non-zero on command-line usage errors so shell scripts and CI can detect them: missing flag arguments (`--lib-path`, `--timeout`, `--max-memory`, `-o`, `--coverage-xml`, `--profile-json`, `--completions`) and an unknown `--completions` shell now exit 2 instead of 0 (#781)
+- Reject unknown flags (e.g. `--typo-flag`) with a usage error instead of silently treating them as a script filename (#781)
+- Exit non-zero on `--compile`/`--disassemble` read and compile errors, and on standalone-binary runtime and corrupt-bytecode errors, so build and bundled-app failures are visible to CI (#781)
+
 #### Package manager (thottam)
 - Fix version-pinned installs always failing with "Failed to checkout version": `git checkout -- <ref>` treats the ref as a pathspec, so use `--end-of-options` to keep the option-injection guard while resolving `<ref>` as a revision. Affected `install pkg@v1.0.0`, semver constraints, and `--locked` installs (#780)
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -97,6 +97,21 @@ fn writeStderr(bytes: []const u8) void {
     writeToFd(2, bytes);
 }
 
+/// Exit code for command-line usage errors (missing flag argument, unknown
+/// option, unknown completions shell). Follows the common getopt convention
+/// of 2, distinct from the 1 used for script read/compile/runtime errors, so
+/// callers can tell "you invoked kaappi wrong" apart from "your program failed".
+const USAGE_ERROR_EXIT: u8 = 2;
+
+/// Report a command-line usage error and terminate the process with
+/// `USAGE_ERROR_EXIT`. Mirrors how `(exit n)` exits directly via
+/// `std.process.exit`; usage errors are detected before any real work begins,
+/// so there is nothing to unwind.
+fn usageError(msg: []const u8) noreturn {
+    writeStderr(msg);
+    std.process.exit(USAGE_ERROR_EXIT);
+}
+
 fn printSourceSnippet(source: []const u8, line: u32) void {
     if (line == 0 or source.len == 0) return;
     var current_line: u32 = 1;
@@ -293,15 +308,14 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 if (sa_iter.next()) |shell| {
                     if (@import("completions.zig").kaappi(shell)) |script| {
                         writeStdout(script);
-                    } else {
-                        writeStderr("unknown shell: ");
-                        writeStderr(shell);
-                        writeStderr("\nSupported: bash, zsh, fish\n");
+                        return;
                     }
-                } else {
-                    writeStderr("--completions requires a shell name (bash, zsh, fish)\n");
+                    writeStderr("unknown shell: ");
+                    writeStderr(shell);
+                    writeStderr("\nSupported: bash, zsh, fish\n");
+                    std.process.exit(USAGE_ERROR_EXIT);
                 }
-                return;
+                usageError("--completions requires a shell name (bash, zsh, fish)\n");
             } else if (std.mem.eql(u8, arg, "--gc-stats")) {
                 sa_gc_stats = true;
             } else if (std.mem.eql(u8, arg, "--profile")) {
@@ -310,7 +324,11 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 sa_coverage = true;
             } else if (std.mem.eql(u8, arg, "--coverage-xml")) {
                 sa_coverage = true;
-                if (sa_iter.next()) |p| vm.coverage_xml_path = p;
+                if (sa_iter.next()) |p| {
+                    vm.coverage_xml_path = p;
+                } else {
+                    usageError("--coverage-xml requires a file path argument\n");
+                }
             } else {
                 if (sa_count < 64) {
                     sa[sa_count] = arg;
@@ -334,9 +352,11 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
 
         const loaded = bytecode_file.readFromBuffer(&gc, bytecode_data) catch {
             writeStderr("fatal: corrupted embedded bytecode\n");
+            script_had_error = true;
             return;
         } orelse {
             writeStderr("fatal: invalid embedded bytecode (wrong version or format)\n");
+            script_had_error = true;
             return;
         };
         defer allocator.free(loaded.funcs);
@@ -372,6 +392,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                     defer gc.popRoot();
                     if (vm.handleTopLevelForm(expr)) |top_result| {
                         _ = top_result catch |err| {
+                            script_had_error = true;
                             const detail = vm.getErrorDetail();
                             if (detail.len > 0) {
                                 writeStderr("preamble error: ");
@@ -395,6 +416,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             vm.gc.pushRoot(&func_val) catch return error.OutOfMemory;
             const result = vm.execute(func) catch |err| {
                 vm.gc.popRoot();
+                script_had_error = true;
                 const detail = vm.getErrorDetail();
                 if (detail.len > 0) {
                     writeStderr(detail);
@@ -451,8 +473,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                     lib_path_count += 1;
                 }
             } else {
-                writeStderr("--lib-path requires a path argument\n");
-                return;
+                usageError("--lib-path requires a path argument\n");
             }
         } else if (std.mem.eql(u8, arg, "--profile")) {
             profile_mode = true;
@@ -460,8 +481,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             profile_mode = true;
             profile_json_path = args.next();
             if (profile_json_path == null) {
-                writeStderr("--profile-json requires a file path argument\n");
-                return;
+                usageError("--profile-json requires a file path argument\n");
             }
         } else if (std.mem.eql(u8, arg, "--coverage")) {
             coverage_mode = true;
@@ -470,8 +490,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             if (args.next()) |p| {
                 vm.coverage_xml_path = p;
             } else {
-                writeStderr("--coverage-xml requires a file path argument\n");
-                return;
+                usageError("--coverage-xml requires a file path argument\n");
             }
         } else if (std.mem.eql(u8, arg, "--sandbox")) {
             sandbox_mode = true;
@@ -484,8 +503,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         } else if (std.mem.eql(u8, arg, "-o")) {
             compile_output = args.next();
             if (compile_output == null) {
-                writeStderr("-o requires a file path argument\n");
-                return;
+                usageError("-o requires a file path argument\n");
             }
         } else if (std.mem.eql(u8, arg, "--disassemble")) {
             disassemble_mode = true;
@@ -497,16 +515,14 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                     vm.timeout_deadline_ns = clockNs() + ms * 1_000_000;
                 }
             } else {
-                writeStderr("--timeout requires a milliseconds argument\n");
-                return;
+                usageError("--timeout requires a milliseconds argument\n");
             }
         } else if (std.mem.eql(u8, arg, "--max-memory")) {
             if (args.next()) |mem_str| {
                 const limit = std.fmt.parseInt(usize, mem_str, 10) catch 0;
                 if (limit > 0) gc.memory_limit = limit;
             } else {
-                writeStderr("--max-memory requires a bytes argument\n");
-                return;
+                usageError("--max-memory requires a bytes argument\n");
             }
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             printUsage();
@@ -518,15 +534,23 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             if (args.next()) |shell| {
                 if (@import("completions.zig").kaappi(shell)) |script| {
                     writeStdout(script);
-                } else {
-                    writeStderr("unknown shell: ");
-                    writeStderr(shell);
-                    writeStderr("\nSupported: bash, zsh, fish\n");
+                    return;
                 }
-            } else {
-                writeStderr("--completions requires a shell name (bash, zsh, fish)\n");
+                writeStderr("unknown shell: ");
+                writeStderr(shell);
+                writeStderr("\nSupported: bash, zsh, fish\n");
+                std.process.exit(USAGE_ERROR_EXIT);
             }
-            return;
+            usageError("--completions requires a shell name (bash, zsh, fish)\n");
+        } else if (arg.len > 1 and arg[0] == '-') {
+            // Unknown flag. Treating it as a script filename hides the typo
+            // (the caller sees "Error opening file '--typo'" or a silent no-op),
+            // so reject it as a usage error instead. A lone "-" is left to fall
+            // through as a (nonexistent) filename to preserve prior behavior.
+            writeStderr("unknown option: ");
+            writeStderr(arg);
+            writeStderr("\nRun 'kaappi --help' for usage.\n");
+            std.process.exit(USAGE_ERROR_EXIT);
         } else {
             file_path = arg;
             break;
@@ -628,7 +652,9 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         if (file_path) |fp| {
             try native_compiler.compileNative(vm, fp, compile_output);
         } else {
-            writeStdout("Usage: kaappi compile <file.scm> [-o output]\n");
+            // A build subcommand with no file is misuse, not a help request:
+            // fail loudly so a caller with an empty "$FILE" variable notices.
+            usageError("Usage: kaappi compile <file.scm> [-o output]\n");
         }
         return;
     }
@@ -637,19 +663,19 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         if (file_path) |fp| {
             try disassembleFile(vm, fp);
         } else {
-            writeStdout("Usage: kaappi --disassemble <file.scm>\n");
+            usageError("Usage: kaappi --disassemble <file.scm>\n");
         }
     } else if (compile_mode) {
         if (file_path) |fp| {
             try compileFile(vm, fp, compile_output);
         } else {
-            writeStdout("Usage: kaappi --compile <file.scm> [-o output.sbc]\n");
+            usageError("Usage: kaappi --compile <file.scm> [-o output.sbc]\n");
         }
     } else if (emit_llvm_mode) {
         if (file_path) |fp| {
             try native_compiler.emitLlvmFile(vm, fp, compile_output);
         } else {
-            writeStdout("Usage: kaappi --emit-llvm <file.scm> [-o output.ll]\n");
+            usageError("Usage: kaappi --emit-llvm <file.scm> [-o output.ll]\n");
         }
     } else if (file_path) |fp| {
         try runFile(vm, fp);
@@ -1007,7 +1033,10 @@ fn runStdin(vm: *vm_mod.VM) !void {
 
 fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
     const allocator = vm.gc.allocator;
-    const source = readFileContents(allocator, path) catch return;
+    const source = readFileContents(allocator, path) catch {
+        script_had_error = true;
+        return;
+    };
     defer allocator.free(source);
 
     const saved_lib_dir = vm.current_lib_dir;
@@ -1022,6 +1051,7 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
         var errbuf: [256]u8 = undefined;
         const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
         writeStderr(s);
+        script_had_error = true;
         return;
     }) {
         const datum_lc = r.getLineCol();
@@ -1030,11 +1060,13 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
             writeStderr(s);
+            script_had_error = true;
             return;
         };
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
             _ = top_result catch |err| {
+                script_had_error = true;
                 const detail = vm.getErrorDetail();
                 if (detail.len > 0) {
                     var errbuf: [256]u8 = undefined;
@@ -1054,6 +1086,7 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: compile error: {}\n", .{ path, datum_lc.line, err }) catch "compile error\n";
             writeStderr(s);
+            script_had_error = true;
             continue;
         };
 
@@ -1065,6 +1098,7 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
 fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;
     const source = readFileContents(allocator, path) catch {
+        script_had_error = true;
         return;
     };
     defer allocator.free(source);
@@ -1107,6 +1141,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         var errbuf: [256]u8 = undefined;
         const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
         writeStderr(s);
+        script_had_error = true;
         return;
     }) {
         const datum_lc = r.getLineCol();
@@ -1115,6 +1150,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
             writeStderr(s);
+            script_had_error = true;
             return;
         };
 
@@ -1124,6 +1160,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         if (vm.handleTopLevelForm(expr)) |top_result| {
             const form_src = printer.valueToString(allocator, expr, .write) catch continue;
             _ = top_result catch |err| {
+                script_had_error = true;
                 const detail = vm.getErrorDetail();
                 if (detail.len > 0) {
                     var errbuf: [256]u8 = undefined;
@@ -1146,6 +1183,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: compile error: {}\n", .{ path, datum_lc.line, err }) catch "compile error\n";
             writeStderr(s);
+            script_had_error = true;
             continue;
         };
 
@@ -1156,11 +1194,13 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         const sbc_path = if (output_path) |op|
             allocator.dupe(u8, op) catch {
                 writeStderr("Error creating output path\n");
+                script_had_error = true;
                 return;
             }
         else
             getSbcPath(allocator, path) catch {
                 writeStderr("Error creating output path\n");
+                script_had_error = true;
                 return;
             };
         defer allocator.free(sbc_path);
@@ -1176,11 +1216,13 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
                 sbc_path,
             ) catch {
                 writeStderr("Error writing bytecode file\n");
+                script_had_error = true;
                 return;
             };
         } else {
             bytecode_file.writeFileWithTopLevel(allocator, compiled_funcs.items, source_hash, sbc_path) catch {
                 writeStderr("Error writing bytecode file\n");
+                script_had_error = true;
                 return;
             };
         }

--- a/tests/scheme/errors/exit-code.sh
+++ b/tests/scheme/errors/exit-code.sh
@@ -77,6 +77,39 @@ assert_exit_code "guarded error exits 0" 0 "$KAAPPI" "$TMPDIR_TESTS/guarded.scm"
 assert_stdin_exit_code "clean stdin exits 0" 0 '(display "ok")'
 assert_stdin_exit_code "stdin runtime error exits 1" 1 '(car 1)'
 
+# CLI usage errors exit 2 (getopt convention), distinct from script errors.
+# A missing argument to a value-taking flag must not silently exit 0.
+assert_exit_code "--lib-path without arg exits 2" 2 "$KAAPPI" --lib-path
+assert_exit_code "--timeout without arg exits 2" 2 "$KAAPPI" --timeout
+assert_exit_code "--max-memory without arg exits 2" 2 "$KAAPPI" --max-memory
+assert_exit_code "-o without arg exits 2" 2 "$KAAPPI" -o
+assert_exit_code "--coverage-xml without arg exits 2" 2 "$KAAPPI" --coverage-xml
+assert_exit_code "--profile-json without arg exits 2" 2 "$KAAPPI" --profile-json
+assert_exit_code "--completions without shell exits 2" 2 "$KAAPPI" --completions
+
+# Unknown completions shell is a usage error
+assert_exit_code "--completions unknown shell exits 2" 2 "$KAAPPI" --completions badshell
+
+# A typo'd flag must not be silently swallowed as a filename
+assert_exit_code "unknown flag exits 2" 2 "$KAAPPI" --typo-flag "$TMPDIR_TESTS/ok.scm"
+
+# Valid usage must still exit 0
+assert_exit_code "--version exits 0" 0 "$KAAPPI" --version
+assert_exit_code "--help exits 0" 0 "$KAAPPI" --help
+assert_exit_code "--completions bash exits 0" 0 "$KAAPPI" --completions bash
+
+# Compile-mode failures must be visible to CI too
+printf '(+ 1\n' > "$TMPDIR_TESTS/unbal.scm"
+assert_exit_code "--compile read error exits 1" 1 "$KAAPPI" --compile "$TMPDIR_TESTS/unbal.scm"
+assert_exit_code "--compile missing file exits 1" 1 "$KAAPPI" --compile "$TMPDIR_TESTS/nope.scm"
+assert_exit_code "--disassemble read error exits 1" 1 "$KAAPPI" --disassemble "$TMPDIR_TESTS/unbal.scm"
+
+# A build/inspect mode invoked with no file is a usage error, not exit 0
+assert_exit_code "--compile without file exits 2" 2 "$KAAPPI" --compile
+assert_exit_code "--disassemble without file exits 2" 2 "$KAAPPI" --disassemble
+assert_exit_code "--emit-llvm without file exits 2" 2 "$KAAPPI" --emit-llvm
+assert_exit_code "compile subcommand without file exits 2" 2 "$KAAPPI" compile
+
 echo ""
 echo "exit-code: $PASS pass, $FAIL fail"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Fixes #781.

## Problem

The interpreter exited `0` for every kind of failure except an explicit `(exit n)`, so shell scripts, Makefiles, and CI could not detect that kaappi was misinvoked or that a build/bundled step failed.

Script read/compile/runtime errors, missing files, and timeouts already flip the exit code (landed in #929 via `script_had_error`). This PR closes the remaining silent paths the issue calls out.

## Changes

**CLI usage errors → exit `2`** (getopt convention, distinct from the `1` used for script failures). Added a `usageError()` `noreturn` helper and routed through it:
- Missing argument to a value-taking flag: `--lib-path`, `--timeout`, `--max-memory`, `-o`, `--coverage-xml`, `--profile-json`, `--completions`
- Unknown `--completions` shell
- **Unknown flags** (e.g. `--typo-flag`) — previously swallowed as a script filename, hiding the typo; now rejected
- A build/inspect mode (`compile`, `--compile`, `--disassemble`, `--emit-llvm`) invoked with no file

**Compile-time and bundled-app failures → exit `1`** (the issue notes "compile errors ... invisible to CI"):
- `--compile` / `--disassemble` read and compile errors set `script_had_error`
- Standalone-binary runtime errors, preamble errors, and corrupt embedded bytecode now flag failure

## Verification

Every reproduction in the issue now behaves correctly:

| Invocation | Before | After |
|---|---|---|
| `kaappi boom.scm` (uncaught error) | 0 | 1 |
| `kaappi /nonexistent.scm` | 0 | 1 |
| `kaappi unbalanced.scm` (read error) | 0 | 1 |
| `kaappi --lib-path` (missing arg) | 0 | 2 |
| `kaappi --completions badshell` | 0 | 2 |
| `kaappi --timeout 200 loop.scm` | 0 | 1 |
| `kaappi --typo-flag script.scm` | 0 | 2 |
| `kaappi ex3.scm` (`(exit 3)`) | 3 | 3 |
| clean script | 0 | 0 |

- Extended `tests/scheme/errors/exit-code.sh` with 19 new cases (usage + compile-mode paths): **29 pass, 0 fail**. This suite runs in CI.
- `zig build test` and the full Scheme suite pass on a fresh checkout.

## Note (out of scope)

While testing I hit a **pre-existing** `.sbc` cache serialization bug (unrelated to this change): certain deep/large programs run correctly fresh but fail with `error.InvalidBytecode` when re-run from the cache the same binary just wrote (reproduces on plain `main`; hidden from CI because each test file runs once on a fresh checkout). Not addressed here — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)