### PR TITLE
Fix LLVM backend set!/define ignoring lexical scope (#819)

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -652,17 +652,75 @@ pub const LLVMEmitter = struct {
     fn emitSet(self: *LLVMEmitter, data: ir.SetData) EmitError![]const u8 {
         if (!types.isSymbol(data.name)) return error.UnsupportedNodeType;
         const name = types.symbolName(data.name);
+        // Evaluate the new value with lexical scope respected, then store it
+        // into whichever slot `name` resolves to (local alloca, parameter,
+        // rest parameter, upvalue, or global). The old code always evaluated
+        // the value in the global environment and rebound a global (#819).
+        const val = try self.emitScopedValue(data.value);
+        try self.emitStoreToVariable(name, val);
+        return self.emitVoid();
+    }
+
+    fn inLexicalScope(self: *LLVMEmitter) bool {
+        return self.params != null or self.locals != null or
+            self.rest_param_name != null or self.upvalues != null;
+    }
+
+    // Emit a value expression, resolving variable references against the
+    // current lexical scope (params, locals, upvalues) rather than assuming
+    // the global environment.
+    fn emitScopedValue(self: *LLVMEmitter, value: Value) EmitError![]const u8 {
+        if (types.isSymbol(value)) return self.emitGlobalRef(value);
+        if (!types.isPair(value)) return self.emitConstant(value);
+        // At the top level there are no lexical bindings, so evaluate the value
+        // in the global environment via kaappi_eval. That also expands macro
+        // calls correctly; the standalone IR lowering below runs without a
+        // macro table and would mis-lower a top-level (set! x (some-macro ...)).
+        if (!self.inLexicalScope()) return self.emitEvalExpr(value);
+        const node = ir.lowerSingleExpr(self.allocator, value) catch return self.emitEvalExpr(value);
+        return self.emitNode(node);
+    }
+
+    // Store `val` into the slot that `name` denotes in the current scope.
+    // Resolution order mirrors emitGlobalRef's read path so writes and reads
+    // reach the same binding.
+    fn emitStoreToVariable(self: *LLVMEmitter, name: []const u8, val: []const u8) EmitError!void {
+        if (self.locals) |loc| {
+            if (loc.get(name)) |alloca_name| {
+                try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca_name });
+                return;
+            }
+        }
+        if (self.rest_param_name) |rp_name| {
+            if (std.mem.eql(u8, name, rp_name)) {
+                try self.print("  store i64 {s}, ptr {s}\n", .{ val, self.rest_param_alloca.? });
+                return;
+            }
+        }
+        if (self.params) |p| {
+            if (p.get(name)) |idx| {
+                const gep = try self.freshTemp();
+                try self.print("  {s} = getelementptr i64, ptr %args, i64 {d}\n", .{ gep, idx });
+                try self.print("  store i64 {s}, ptr {s}\n", .{ val, gep });
+                return;
+            }
+        }
+        if (self.upvalues) |uv| {
+            if (uv.get(name)) |idx| {
+                const gep = try self.freshTemp();
+                try self.print("  {s} = getelementptr i64, ptr %upvalues, i64 {d}\n", .{ gep, idx });
+                try self.print("  store i64 {s}, ptr {s}\n", .{ val, gep });
+                return;
+            }
+        }
+        // Not a lexical binding: set! an existing global, erroring if unbound.
         const sym_name = try self.internSymbol(name);
+        try self.print("  call void @kaappi_set_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym_name, name.len, val });
+    }
 
-        const val = if (types.isPair(data.value))
-            try self.emitEvalExpr(data.value)
-        else if (types.isSymbol(data.value))
-            try self.emitGlobalRef(data.value)
-        else
-            try self.emitConstant(data.value);
-
-        try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym_name, name.len, val });
-
+    // Emit an SSA temp holding the unspecified/void value (the result of set!
+    // and define).
+    fn emitVoid(self: *LLVMEmitter) EmitError![]const u8 {
         const result = try self.freshTemp();
         const void_val: i64 = @bitCast(types.VOID);
         try self.print("  {s} = add i64 0, {d}\n", .{ result, void_val });
@@ -765,6 +823,23 @@ pub const LLVMEmitter = struct {
     fn emitDefine(self: *LLVMEmitter, data: ir.DefineData) EmitError![]const u8 {
         if (!types.isSymbol(data.name)) return error.UnsupportedNodeType;
         const name = types.symbolName(data.name);
+
+        // Internal define inside a natively compiled lexical scope (a `let`
+        // body). self.locals is only populated while emitLet emits a body, so
+        // top-level and lambda-body defines fall through to the global path.
+        // Create a fresh local binding so the define shadows any global of the
+        // same name for the rest of the body, instead of overwriting it (#819).
+        if (self.locals != null) {
+            const alloca = try self.freshTemp();
+            try self.print("  {s} = alloca i64, align 8\n", .{alloca});
+            // Register before emitting the value so a self/mutual reference in
+            // the initializer resolves to this binding (letrec*-style).
+            self.locals.?.put(name, alloca) catch return error.OutOfMemory;
+            const val = try self.emitScopedValue(data.value);
+            try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
+            return self.emitVoid();
+        }
+
         const sym_name = try self.internSymbol(name);
 
         if (types.isPair(data.value)) {
@@ -784,10 +859,7 @@ pub const LLVMEmitter = struct {
 
         try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym_name, name.len, val });
 
-        const result = try self.freshTemp();
-        const void_val: i64 = @bitCast(types.VOID);
-        try self.print("  {s} = add i64 0, {d}\n", .{ result, void_val });
-        return result;
+        return self.emitVoid();
     }
 
     const lambda = @import("llvm_emit_lambda.zig");
@@ -957,6 +1029,7 @@ pub const LLVMEmitter = struct {
         try self.write("declare i64 @kaappi_global_lookup(ptr, ptr, i64)\n");
         try self.write("declare i64 @kaappi_call_scheme(ptr, i64, ptr, i64)\n");
         try self.write("declare void @kaappi_define_global(ptr, ptr, i64, i64)\n");
+        try self.write("declare void @kaappi_set_global(ptr, ptr, i64, i64)\n");
         try self.write("declare i64 @kaappi_make_string(ptr, ptr, i64)\n");
         try self.write("declare i64 @kaappi_intern_symbol(ptr, ptr, i64)\n");
         try self.write("declare i64 @kaappi_fixnum_add(i64, i64)\n");

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -91,6 +91,17 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     if (body_list == types.NIL) return null;
     if (!types.isPair(formals_val) and formals_val != types.NIL) return null;
 
+    // A closure copies its captured variables by value into an upvalue array,
+    // so a set! (or internal define) that mutates a captured binding cannot be
+    // represented natively. Reject any body containing set!/define and let the
+    // interpreter handle it (#819).
+    {
+        var be = body_list;
+        while (be != types.NIL and types.isPair(be)) : (be = types.cdr(be)) {
+            if (sexprContainsSetOrDefine(types.car(be))) return null;
+        }
+    }
+
     var param_names: [16][]const u8 = undefined;
     var arity: u8 = 0;
     var plist = formals_val;
@@ -425,21 +436,26 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     const saved_block = self.current_block;
     const saved_rest_alloca = self.rest_param_alloca;
     const saved_rest_name = self.rest_param_name;
+    const saved_locals = self.locals;
     self.buf = fn_buf;
     self.tmp_counter = 0;
     self.label_counter = 0;
+    // The new function is a fresh scope: an enclosing scope's local allocas are
+    // not valid SSA values here, so start with no locals (nested `let`s in this
+    // body install their own).
+    self.locals = null;
 
     var p = std.StringHashMap(u8).init(self.allocator);
     for (param_names, 0..) |pname, i| {
         p.put(pname, @intCast(i)) catch {
-            restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name);
+            restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name, saved_locals);
             return null;
         };
     }
     self.params = p;
 
     const body_lbl = std.fmt.allocPrint(self.allocator, "body_{d}", .{id}) catch {
-        restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name);
+        restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name, saved_locals);
         p.deinit();
         return null;
     };
@@ -450,20 +466,20 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     self.rest_param_name = rest_name;
 
     const header = std.fmt.allocPrint(self.allocator, "; {s}\ndefine i64 {s}(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) {{\nentry:\n  br label %{s}\n{s}:\n", .{ name orelse "(lambda)", fn_name, body_lbl, body_lbl }) catch {
-        restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name);
+        restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name, saved_locals);
         p.deinit();
         return null;
     };
     defer self.allocator.free(header);
     self.write(header) catch {
-        restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name);
+        restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name, saved_locals);
         p.deinit();
         return null;
     };
 
     if (rest_name != null) {
         emitRestListBuilder(self, param_names.len) catch {
-            restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name);
+            restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name, saved_locals);
             p.deinit();
             fn_buf.deinit(self.allocator);
             return null;
@@ -473,7 +489,7 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     var last_val: []const u8 = "";
     for (body_nodes) |node| {
         last_val = self.emitNode(node) catch {
-            restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name);
+            restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name, saved_locals);
             p.deinit();
             fn_buf.deinit(self.allocator);
             return null;
@@ -481,14 +497,14 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     }
 
     self.print("  ret i64 {s}\n}}\n", .{last_val}) catch {
-        restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name);
+        restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name, saved_locals);
         p.deinit();
         fn_buf.deinit(self.allocator);
         return null;
     };
 
     fn_buf = self.buf;
-    restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name);
+    restoreState(self, saved_buf, saved_params, saved_tmp, saved_label, saved_fn_name, saved_body_label, saved_block, saved_rest_alloca, saved_rest_name, saved_locals);
     p.deinit();
 
     const fn_def = fn_buf.toOwnedSlice(self.allocator) catch return null;
@@ -497,7 +513,7 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     return fn_name;
 }
 
-fn restoreState(self: *LLVMEmitter, buf: std.ArrayList(u8), params: ?std.StringHashMap(u8), tmp: u32, label: u32, fn_name: ?[]const u8, body_label: ?[]const u8, block: []const u8, rest_alloca: ?[]const u8, rp_name: ?[]const u8) void {
+fn restoreState(self: *LLVMEmitter, buf: std.ArrayList(u8), params: ?std.StringHashMap(u8), tmp: u32, label: u32, fn_name: ?[]const u8, body_label: ?[]const u8, block: []const u8, rest_alloca: ?[]const u8, rp_name: ?[]const u8, locals: ?std.StringHashMap([]const u8)) void {
     self.buf = buf;
     self.params = params;
     self.tmp_counter = tmp;
@@ -507,6 +523,7 @@ fn restoreState(self: *LLVMEmitter, buf: std.ArrayList(u8), params: ?std.StringH
     self.current_block = block;
     self.rest_param_alloca = rest_alloca;
     self.rest_param_name = rp_name;
+    self.locals = locals;
 }
 
 fn emitRestListBuilder(self: *LLVMEmitter, fixed_arity: usize) EmitError!void {
@@ -562,6 +579,24 @@ fn emitRestListBuilder(self: *LLVMEmitter, fixed_arity: usize) EmitError!void {
 
 // --- Free variable analysis helpers (standalone, no self) ---
 
+// True if the raw S-expression contains a set! or define form anywhere (not
+// descending into quoted data). Used to reject closure bodies that mutate or
+// rebind captured state, which the native upvalue-copy model cannot express.
+fn sexprContainsSetOrDefine(expr: types.Value) bool {
+    if (!types.isPair(expr)) return false;
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const h = types.symbolName(head);
+        if (std.mem.eql(u8, h, "set!") or std.mem.eql(u8, h, "define")) return true;
+        if (std.mem.eql(u8, h, "quote")) return false;
+    }
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        if (sexprContainsSetOrDefine(types.car(cur))) return true;
+    }
+    return false;
+}
+
 fn hasFreeVars(nodes: []const *ir.Node, params: []const []const u8) bool {
     for (nodes) |node| {
         if (nodeHasFreeVars(node, params)) return true;
@@ -606,9 +641,40 @@ fn nodeHasFreeVars(node: *const ir.Node, params: []const []const u8) bool {
             if (nodeHasFreeVars(node.data.unless_form.test_expr, params)) return true;
             return hasFreeVars(node.data.unless_form.body, params);
         },
+        .set_form => {
+            // A set! is safe to compile in a body with no upvalues only when
+            // both the target and the value stay within our params/globals.
+            // Otherwise it mutates (or reads) a captured lexical variable that
+            // the native slot-store cannot reach, so disqualify and let the
+            // interpreter handle it. The value is a raw S-expr; a compound
+            // value is treated conservatively as possibly capturing (#819).
+            if (!types.isSymbol(node.data.set_form.name)) return true;
+            if (!valueIsBoundOrLiteral(node.data.set_form.name, params)) return true;
+            if (!valueIsBoundOrLiteral(node.data.set_form.value, params)) return true;
+            return false;
+        },
+        // An internal define introduces a binding that the native lambda-body
+        // emitter cannot install (it has no locals map), so it would leak to a
+        // global. Disqualify and fall back to the interpreter.
+        .define => return true,
         .constant => return false,
         else => return false,
     }
+}
+
+// A raw S-expr value that is trivially safe to reference inside a natively
+// compiled body with no upvalues: a literal, or a symbol that names one of our
+// params or a known global. Anything else (a compound expression, or a symbol
+// naming a captured lexical variable) is treated as unsafe.
+fn valueIsBoundOrLiteral(value: types.Value, params: []const []const u8) bool {
+    if (types.isSymbol(value)) {
+        const name = types.symbolName(value);
+        for (params) |p| {
+            if (std.mem.eql(u8, name, p)) return true;
+        }
+        return ir.isKnownGlobal(name);
+    }
+    return !types.isPair(value);
 }
 
 fn collectFreeVars(nodes: []const *ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) void {

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -66,6 +66,23 @@ export fn kaappi_define_global(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len:
     };
 }
 
+// set! on a global variable: mutate an existing binding, or error if the
+// variable is unbound (matching the interpreter's set! semantics). Distinct
+// from kaappi_define_global, which always creates/overwrites a binding.
+export fn kaappi_set_global(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len: u64, val: u64) callconv(.c) void {
+    const v = vm orelse return;
+    const len: usize = @intCast(name_len);
+    const name = name_ptr[0..len];
+    if (v.globals.getPtr(name)) |ptr| {
+        ptr.* = val;
+    } else {
+        _ = std.posix.system.write(2, "set!: unbound variable '", 24);
+        _ = std.posix.system.write(2, name_ptr, len);
+        _ = std.posix.system.write(2, "'\n", 2);
+        std.process.exit(1);
+    }
+}
+
 export fn kaappi_make_string(vm: ?*vm_mod.VM, str_ptr: [*]const u8, str_len: u64) callconv(.c) u64 {
     const v = vm orelse return 0;
     const len: usize = @intCast(str_len);

--- a/tests/scheme/compile/set-define-lexical-scope-819.sh
+++ b/tests/scheme/compile/set-define-lexical-scope-819.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Regression test for #819: LLVM native backend compiled set! and internal
+# define to kaappi_define_global unconditionally, ignoring lexical scope.
+# Mutations to parameters / let-locals were dropped, set! values referencing
+# lexical variables crashed, top-level set! on an unbound variable silently
+# defined it, and internal defines leaked into global scope.
+#
+# The native binary's output (and exit status) must match the interpreter's for
+# each reproduction.
+#
+# Usage: bash tests/scheme/compile/set-define-lexical-scope-819.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# `kaappi compile` needs libkaappi_rt.a (searched in <exe_dir>/../lib).
+if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
+    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+fi
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+# Compile a program natively and check its stdout + exit status match the
+# interpreter. For the error case we match the interpreter's exit status and a
+# substring (native diagnostics are terser than the interpreter's).
+check() {
+    local name="$1" src="$2" expect_out="$3" expect_status="$4"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    if ! (cd "$DIR" && "$KAAPPI_ABS" compile "$name.scm" -o "$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    set +e
+    local out status
+    out=$("$DIR/$name" 2>/dev/null)
+    status=$?
+    set -e
+
+    if [[ "$out" != "$expect_out" ]]; then
+        echo "FAIL: $name — native stdout '$out' != expected '$expect_out'" >&2
+        fail=1
+    fi
+    if [[ "$status" -ne "$expect_status" ]]; then
+        echo "FAIL: $name — native exit $status != expected $expect_status" >&2
+        fail=1
+    fi
+}
+
+# 1. set! on a parameter must mutate the parameter slot, not define a global.
+check set-param \
+'(define (f x) (set! x 10) x)
+(display (f 5))
+(newline)' \
+'10' 0
+
+# 2. set! value referencing a parameter must be evaluated in the local scope.
+check set-param-value \
+'(define (f x) (set! x (+ x 1)) x)
+(display (f 5))
+(newline)' \
+'6' 0
+
+# 3. set! on a let-local must mutate the local binding.
+check set-let-local \
+'(display (let ((x 1)) (set! x 2) x))
+(newline)' \
+'2' 0
+
+# 4. Top-level set! on an unbound variable must error, not silently define it.
+check set-unbound \
+'(set! zzz 5)
+(display zzz)
+(newline)' \
+'' 1
+
+# 5. Internal define inside a let body must be local, not overwrite a global.
+check internal-define-local \
+'(define z 100)
+(let ((x 1)) (define z x) (display z) (newline))
+(display z)
+(newline)' \
+'1
+100' 0
+
+# 6. set! on a nested let-local inside a natively compiled function body.
+check set-nested-let \
+'(define (f x)
+  (let ((acc 0))
+    (set! acc (+ acc x))
+    (set! acc (* acc 2))
+    acc))
+(display (f 5))
+(newline)' \
+'10' 0
+
+# 7. A closure mutating a captured variable (make-counter) must still produce
+#    correct results (it falls back to the interpreter).
+check closure-capture-mutate \
+'(define (make-counter)
+  (let ((n 0))
+    (lambda () (set! n (+ n 1)) n)))
+(define c (make-counter))
+(display (c)) (display " ") (display (c)) (display " ") (display (c))
+(newline)' \
+'1 2 3' 0
+
+# 8. set! on an existing top-level global must mutate it.
+check set-existing-global \
+'(define g 1)
+(set! g 42)
+(display g)
+(newline)' \
+'42' 0
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "set-define-lexical-scope-819: all cases passed"


### PR DESCRIPTION
Fixes #819.

## Problem

In the LLVM native backend (`kaappi compile`), `set!` and internal `define` always compiled to `kaappi_define_global`, regardless of whether the target was a lambda parameter, a `let`-bound local, an upvalue, or a global. As a result:

1. `set!` on a parameter was ignored (a same-named global was created instead).
2. `set!` values referencing a parameter crashed (`(+ x 1)` was evaluated by `kaappi_eval` in the global environment where `x` is unbound).
3. `set!` on a `let` local was ignored.
4. Top-level `set!` on an undefined variable silently defined it instead of erroring.
5. Internal `define` in a `let` body leaked to global scope.

The free-variable analysis that gates native compilation also never looked inside `set_form` nodes, so bodies containing `set!` wrongly passed the "safe to compile natively" check.

## Fix

- **`emitSet`** now evaluates the value with lexical scope respected and stores it into whichever slot the target denotes: local alloca, parameter (`%args`), rest-param alloca, upvalue, or — for a real global — the new **`kaappi_set_global`** runtime export, which mutates an existing binding or errors if unbound (matching the interpreter's `set!` semantics).
- **`emitDefine`** creates a fresh local binding for internal defines inside a natively compiled `let` body instead of overwriting a global.
- **`emitScopedValue`** evaluates values scope-aware, but at the top level routes through `kaappi_eval` so macro calls in `set!`/`define` values still expand (standalone IR lowering runs without a macro table).
- The free-variable analysis now inspects `set_form`/`define`, and `tryCompileNativeClosure` rejects any body containing `set!`/`define`, so a lambda that mutates or rebinds a captured variable (e.g. `make-counter`) falls back to the interpreter instead of miscompiling — a native closure copies its upvalues by value and cannot express shared mutation.
- `emitLambdaFunction` nulls the `locals` map for the fresh function scope, fixing a latent case where an outer scope's allocas leaked into a compiled lambda as invalid IR.

Simple cases like `(set! x 10)` still compile to a native store; cases the native model can't express (`(set! x (+ x 1))`, captured-variable mutation) correctly fall back to the interpreter.

## Testing

- New regression test `tests/scheme/compile/set-define-lexical-scope-819.sh` (auto-discovered by `run-all.sh`) covers all five reproductions plus nested-let mutation, closure capture mutation, and existing-global mutation. It **fails on baseline, passes with the fix**.
- All 5 issue reproductions + 8 edge cases: native output matches the interpreter (13/13).
- Native-vs-interpreter parity sweep over all smoke + jit tests (baseline vs fixed): **0 regressions**; additionally fixes `string-foreach-mutation.scm`.
- `zig build test` passes; R7RS suite 1395 pass / 0 fail; all `compile/` tests pass; `zig fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)