### PR TITLE
Honor lexical shadowing of keywords in IR lowering (#788)

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -139,9 +139,11 @@ pub const IR = struct {
     globals: ?*const std.StringHashMap(Value) = null,
     restricted_env: bool = false, // true when compiling in a restricted environment (environment procedure)
     // Enclosing compiler, when lowering happens inside one. Supplies lexical
-    // scope so isRedefined can see lambda parameters / enclosing locals that
-    // shadow a primitive (issue #790). Null for standalone lowering (Stage 1
-    // parity tests, ir_emitter), where only the globals check applies.
+    // scope so lowering can honor R7RS shadowing: a local or captured binding
+    // of a keyword (if, begin, +, ...) shadows the syntax/primitive, so the
+    // form must lower to an ordinary call rather than a special form or a fold
+    // (issues #788, #790). Null for standalone lowering (Stage 1 parity tests,
+    // ir_emitter), where only the globals check applies.
     compiler: ?*const compiler_mod.Compiler = null,
     // Extra lexically-bound names that shadow primitives, for lowering paths
     // that have no Compiler (the LLVM native backend passes a lambda's own
@@ -399,41 +401,53 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
             } else break;
         }
 
-        if (std.mem.eql(u8, effective_name, "if")) return lowerIf(ir, types.cdr(expr), macros);
-        if (std.mem.eql(u8, effective_name, "quote")) return lowerQuote(ir, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "begin")) return lowerBegin(ir, types.cdr(expr), macros);
-        if (std.mem.eql(u8, effective_name, "lambda")) return ir.makeLambda(types.cdr(expr), null);
-        if (std.mem.eql(u8, effective_name, "let")) return lowerLet(ir, expr);
-        if (std.mem.eql(u8, effective_name, "let*")) return ir.makeLetStar(types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "letrec")) return ir.makeLetrec(types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "letrec*")) return ir.makeLetrecStar(types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "define")) return lowerDefine(ir, expr);
-        if (std.mem.eql(u8, effective_name, "define-values")) return ir.makeSexprNode(.define_values, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "set!")) return lowerSet(ir, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "and")) return lowerList(ir, types.cdr(expr), .and_form, macros);
-        if (std.mem.eql(u8, effective_name, "or")) return lowerList(ir, types.cdr(expr), .or_form, macros);
-        if (std.mem.eql(u8, effective_name, "when")) return lowerCondBody(ir, types.cdr(expr), .when_form, macros);
-        if (std.mem.eql(u8, effective_name, "unless")) return lowerCondBody(ir, types.cdr(expr), .unless_form, macros);
-        if (std.mem.eql(u8, effective_name, "cond")) return ir.makeSexprNode(.cond, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "case")) return ir.makeSexprNode(.case_form, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "case-lambda")) return ir.makeSexprNode(.case_lambda, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "do")) return ir.makeSexprNode(.do_form, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "guard")) return ir.makeSexprNode(.guard, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "delay")) return ir.makeSexprNode(.delay, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "delay-force")) return ir.makeSexprNode(.delay_force, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "quasiquote")) return ir.makeSexprNode(.quasiquote, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "parameterize")) return ir.makeSexprNode(.parameterize, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "let-values")) return ir.makeSexprNode(.let_values, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "let*-values")) return ir.makeSexprNode(.let_star_values, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "define-syntax")) return ir.makeSexprNode(.define_syntax, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "let-syntax")) return ir.makeSexprNode(.let_syntax, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "letrec-syntax")) return ir.makeSexprNode(.letrec_syntax, types.cdr(expr));
-        if (std.mem.eql(u8, effective_name, "cond-expand")) return ir.makeSexprNode(.cond_expand, types.cdr(expr));
+        // R7RS has no reserved words: a lexical binding of a keyword shadows
+        // the syntax. If the (non-hygienic) head names a local or captured
+        // binding in the enclosing compiler scope, treat the form as an
+        // ordinary procedure call instead of a special form or macro use.
+        // Mirrors the `is_shadowed` guard in the legacy compileForm path.
+        // A hygienic rename (effective_name != name) is never shadowed: it
+        // came from a macro template and must keep its special-form meaning.
+        const is_shadowed = std.mem.eql(u8, effective_name, name) and
+            if (ir.compiler) |c| c.isLexicallyBound(name) else false;
 
-        if (isSpecialForm(effective_name)) return ir.makePassthrough(expr);
+        if (!is_shadowed) {
+            if (std.mem.eql(u8, effective_name, "if")) return lowerIf(ir, types.cdr(expr), macros);
+            if (std.mem.eql(u8, effective_name, "quote")) return lowerQuote(ir, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "begin")) return lowerBegin(ir, types.cdr(expr), macros);
+            if (std.mem.eql(u8, effective_name, "lambda")) return ir.makeLambda(types.cdr(expr), null);
+            if (std.mem.eql(u8, effective_name, "let")) return lowerLet(ir, expr);
+            if (std.mem.eql(u8, effective_name, "let*")) return ir.makeLetStar(types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "letrec")) return ir.makeLetrec(types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "letrec*")) return ir.makeLetrecStar(types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "define")) return lowerDefine(ir, expr);
+            if (std.mem.eql(u8, effective_name, "define-values")) return ir.makeSexprNode(.define_values, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "set!")) return lowerSet(ir, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "and")) return lowerList(ir, types.cdr(expr), .and_form, macros);
+            if (std.mem.eql(u8, effective_name, "or")) return lowerList(ir, types.cdr(expr), .or_form, macros);
+            if (std.mem.eql(u8, effective_name, "when")) return lowerCondBody(ir, types.cdr(expr), .when_form, macros);
+            if (std.mem.eql(u8, effective_name, "unless")) return lowerCondBody(ir, types.cdr(expr), .unless_form, macros);
+            if (std.mem.eql(u8, effective_name, "cond")) return ir.makeSexprNode(.cond, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "case")) return ir.makeSexprNode(.case_form, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "case-lambda")) return ir.makeSexprNode(.case_lambda, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "do")) return ir.makeSexprNode(.do_form, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "guard")) return ir.makeSexprNode(.guard, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "delay")) return ir.makeSexprNode(.delay, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "delay-force")) return ir.makeSexprNode(.delay_force, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "quasiquote")) return ir.makeSexprNode(.quasiquote, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "parameterize")) return ir.makeSexprNode(.parameterize, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "let-values")) return ir.makeSexprNode(.let_values, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "let*-values")) return ir.makeSexprNode(.let_star_values, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "define-syntax")) return ir.makeSexprNode(.define_syntax, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "let-syntax")) return ir.makeSexprNode(.let_syntax, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "letrec-syntax")) return ir.makeSexprNode(.letrec_syntax, types.cdr(expr));
+            if (std.mem.eql(u8, effective_name, "cond-expand")) return ir.makeSexprNode(.cond_expand, types.cdr(expr));
 
-        if (macros) |m| {
-            if (m.get(effective_name) != null) return ir.makePassthrough(expr);
+            if (isSpecialForm(effective_name)) return ir.makePassthrough(expr);
+
+            if (macros) |m| {
+                if (m.get(effective_name) != null) return ir.makePassthrough(expr);
+            }
         }
 
         if (tryFoldFromAST(ir, expr)) |folded| return folded;

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -578,3 +578,36 @@ test "keyword shadowed by an enclosing-scope binding compiles as a call inside a
     _ = try vm.eval("(define-syntax my-if (syntax-rules () ((_ a b c) (if a b c))))");
     try std.testing.expectEqualStrings("yes", types.symbolName(try vm.eval("(my-if #t 'yes 'no)")));
 }
+
+test "lambda parameter shadows a syntactic keyword in its body (#788)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // A lambda body is lowered through the IR, which dispatches special forms
+    // by name. When a parameter shadows a keyword the body must compile as an
+    // ordinary call to the parameter, not the special form. Previously the IR
+    // path ignored lexical scope and (e.g.) folded (if 1 2 3) to a special
+    // form — eliminateDeadBranches even constant-folded it to 2.
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(try vm.eval("((lambda (if) (if 1 2 3)) (lambda (a b c) 99))")));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((lambda (and) (and 1 2)) list) '(1 2))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((lambda (or) (or 1 2)) list) '(1 2))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((lambda (begin) (begin 1 2)) list) '(1 2))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((lambda (when) (when 1 2)) list) '(1 2))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? ((lambda (unless) (unless 1 2)) list) '(1 2))"));
+    try std.testing.expectEqual(@as(i64, -5), types.toFixnum(try vm.eval("((lambda (quote) (quote 5)) -)")));
+
+    // The shadow holds inside nested forms lowered by the same IR pass.
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(try vm.eval("((lambda (if) (begin (if 1 2 3))) (lambda (a b c) 99))")));
+
+    // And across a lambda boundary, where the keyword resolves as an upvalue
+    // captured from the outer parameter.
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(try vm.eval("(((lambda (if) (lambda () (if 1 2 3))) (lambda (a b c) 99)))")));
+
+    // A shadowed primitive must not be constant-folded as the builtin either.
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(try vm.eval("((lambda (+) (+ 1 2)) *)")));
+
+    // An unshadowed keyword still compiles as the special form.
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(try vm.eval("((lambda (x) (if 1 2 3)) 0)")));
+}

--- a/tests/scheme/smoke/lambda-param-shadows-keyword-788.scm
+++ b/tests/scheme/smoke/lambda-param-shadows-keyword-788.scm
@@ -1,0 +1,46 @@
+;; Regression test for #788: IR lowering treated locally-shadowed syntactic
+;; keywords (if, and, begin, quote, when, ...) as special forms inside lambda
+;; bodies. R7RS has no reserved words, so a lambda parameter binding the name
+;; of a keyword must shadow the syntax and the body must compile as a call to
+;; the parameter. Manual pass/fail because SRFI-64 relies on the very keywords
+;; this test shadows.
+(import (scheme base) (scheme write))
+
+(define failures 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      #t
+      (begin (set! failures (+ failures 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write actual) (newline))))
+
+;; Parameter shadows a special form; the body is an ordinary call to it.
+(check "if shadowed"     99      ((lambda (if)     (if 1 2 3))  (lambda (a b c) 99)))
+(check "and shadowed"    '(1 2)  ((lambda (and)    (and 1 2))   list))
+(check "or shadowed"     '(1 2)  ((lambda (or)     (or 1 2))    list))
+(check "begin shadowed"  '(1 2)  ((lambda (begin)  (begin 1 2)) list))
+(check "when shadowed"   '(1 2)  ((lambda (when)   (when 1 2))  list))
+(check "unless shadowed" '(1 2)  ((lambda (unless) (unless 1 2)) list))
+(check "quote shadowed"  -5      ((lambda (quote)  (quote 5))   -))
+
+;; The shadow holds inside nested forms lowered by the same IR pass.
+(check "shadow inside begin" 99
+       ((lambda (if) (begin (if 1 2 3))) (lambda (a b c) 99)))
+
+;; And across a lambda boundary, where the keyword resolves as an upvalue
+;; captured from the outer parameter.
+(check "shadow via upvalue" 99
+       (((lambda (if) (lambda () (if 1 2 3))) (lambda (a b c) 99))))
+
+;; A shadowed primitive must not be constant-folded as the builtin.
+(check "primitive + shadowed" 2 ((lambda (+) (+ 1 2)) *))
+
+;; Control: an unshadowed keyword still compiles as the special form.
+(check "if not shadowed" 2 ((lambda (x) (if 1 2 3)) 0))
+
+(if (= failures 0)
+    (display "all passed")
+    (begin (display failures) (display " failures")))
+(newline)
+(if (> failures 0) (exit 1))


### PR DESCRIPTION
## Summary

Fixes #788. IR lowering (`lowerFormWithMacros` in `src/ir.zig`) dispatched special forms — `if`, `and`, `begin`, `quote`, `when`, `unless`, … — purely by symbol name, with no knowledge of lexical scope. When a lambda parameter shadowed a keyword, the body (lowered through the IR in `compileLambdaWithIR`) still compiled as the special form instead of a call to the parameter. R7RS has no reserved words, so a lexical binding must shadow the syntax. The legacy `compileForm` path already did this via its `is_shadowed` guard (which is why `let`-shadowing worked); the IR path had no access to locals.

```scheme
(display ((lambda (if)    (if 1 2 3)) (lambda (a b c) 99)))  ; was 2,  now 99
(display ((lambda (and)   (and 1 2))  list))                 ; was 2,  now (1 2)
(display ((lambda (begin) (begin 1 2)) list))                ; was 2,  now (1 2)
(display ((lambda (quote) (quote 5))  -))                    ; was 5,  now -5
(display ((lambda (when)  (when 1 2)) list))                 ; was 2,  now (1 2)
```

## Fix

Guards the special-form/macro dispatch in `lowerFormWithMacros` with a shadow check that mirrors the legacy `compileForm`: a non-hygienic head naming a local or captured binding lowers to an ordinary `call` node. A hygienic rename (`effective_name != name`) is never treated as shadowed, so a macro that expands to a genuine `if` keeps its special-form meaning.

This builds on the `IR.compiler` reference and `Compiler.isLexicallyBound` probe already added for #790 (the constant-fold shadow guard). The shadow now covers nested forms lowered by the same pass (`(lambda (if) (begin (if 1 2 3)))`) and keywords captured as upvalues across a lambda boundary.

## Tests

- `src/tests_macros.zig` — `lambda parameter shadows a syntactic keyword in its body (#788)`: direct param shadow of if/and/or/begin/when/unless/quote, shadow inside nested `begin`, shadow via upvalue, shadowed primitive not folded, and an unshadowed-keyword control.
- `tests/scheme/smoke/lambda-param-shadows-keyword-788.scm` — end-to-end regression covering the same cases.

## Verification

- `zig fmt --check`, `zig build` — clean
- `zig build test` — pass
- Full Scheme suite (`run-all.sh`, fresh tree) — 255 pass + R7RS 1395 pass. The only non-pass was `deep-copy-list-801.scm`, a pre-existing intermittent SRFI-18 thread crash (issue #958, ~3/10 on `main` too), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)