### PR TITLE
Fix heap corruption from SRFI-18 child threads touching shared parent state (#958)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,6 +430,9 @@ independently and the child heap is freed after `thread-join!`.
 - `VM.owns_globals` prevents child VM from freeing shared maps on deinit
 - `symbol_mutex` (spinlock) protects concurrent symbol interning (`src/memory.zig`)
 - Child GC/VM references stored in global `child_resources` map (`src/primitives_srfi18.zig`)
+- Every heap object records its owning GC (`Object.owner` / `GC.id`); marking skips
+  objects owned by another GC, so a child's collections never write mark bits on
+  parent-heap objects reached via shared globals (`src/gc_collect.zig`, #958)
 
 ## Claude Code harness
 

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -258,67 +258,51 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
         formals = self.gc.allocPair(var_names[i], formals) catch return CompileError.OutOfMemory;
     }
 
-    // Named let uses a global for the loop procedure. Use a unique gensym'd
-    // name to prevent collisions when multiple named lets use the same name.
+    // Bind the loop procedure to a boxed local (single-binding letrec) so the
+    // loop lambda captures itself as an upvalue. It used to be bound to a
+    // gensym'd global (__nlet_N_name), but executing that define_global from
+    // an SRFI-18 child thread wrote a child-heap closure into the shared
+    // globals map, leaving a dangling global after the child heap was freed
+    // (issue #958). A local also stops polluting the global namespace. The
+    // gensym rename is kept so nested named lets reusing a name stay distinct.
     const unique_sym = try makeUniqueLoopName(self.gc, types.symbolName(loop_name));
     const renamed_body = try renameInBody(self.gc, body, types.symbolName(loop_name), unique_sym);
     const renamed_lambda_args = self.gc.allocPair(formals, renamed_body) catch return CompileError.OutOfMemory;
 
-    // Use a fresh register for the closure to avoid overwriting live locals
-    // (e.g., when dst=0 and a parameter is also at register 0).
-    const loop_reg = try self.allocReg();
+    self.beginScope();
 
+    // Mirror compileLetrec: void-init the slot, bind, box, then assign.
+    const loop_reg = try self.allocReg();
     try self.emitOp(.load_void);
     try self.emitU16(loop_reg);
-    const name_sym_idx = try self.addConstant(unique_sym);
-    try self.emitOp(.define_global);
-    try self.emitU16(name_sym_idx);
+    try self.addLocal(types.symbolName(unique_sym), loop_reg);
+    try self.markLocalBoxedBySlot(loop_reg);
+
+    const tmp_reg = try self.allocReg();
+    try self.compileLambda(renamed_lambda_args, tmp_reg, types.symbolName(unique_sym));
+    try self.emitOp(.set_box_local);
     try self.emitU16(loop_reg);
+    try self.emitU16(tmp_reg);
+    self.freeReg(); // tmp_reg
 
-    try self.compileLambda(renamed_lambda_args, loop_reg, types.symbolName(unique_sym));
-
-    try self.emitOp(.define_global);
-    try self.emitU16(name_sym_idx);
-    try self.emitU16(loop_reg);
-
-    // Compile the initial call
-    const call_base = try self.allocReg();
-    self.freeReg();
-
-    if (call_base != loop_reg) {
-        try self.emitOp(.move);
-        try self.emitU16(call_base);
-        try self.emitU16(loop_reg);
+    // Compile the initial call (UNIQ init ...) through the normal call path:
+    // it reads the boxed local and handles tail position.
+    var call_expr: Value = types.NIL;
+    {
+        self.gc.no_collect += 1;
+        defer self.gc.no_collect -= 1;
+        var j = param_count;
+        while (j > 0) {
+            j -= 1;
+            call_expr = self.gc.allocPair(init_exprs[j], call_expr) catch return CompileError.OutOfMemory;
+        }
+        call_expr = self.gc.allocPair(unique_sym, call_expr) catch return CompileError.OutOfMemory;
     }
+    self.gc.pushRoot(&call_expr) catch return CompileError.OutOfMemory;
+    defer self.gc.popRoot();
+    try self.compileExpr(call_expr, dst, is_tail);
 
-    if (param_count > 255) return CompileError.InternalLimit;
-    const nargs: u8 = @intCast(param_count);
-    for (0..param_count) |j| {
-        const arg_reg = try self.allocReg();
-        _ = arg_reg;
-        try self.compileExpr(init_exprs[j], call_base + 1 + @as(u16, @intCast(j)), false);
-    }
-
-    if (is_tail) {
-        try self.emitOp(.tail_call);
-    } else {
-        try self.emitOp(.call);
-    }
-    try self.emitU16(call_base);
-    try self.emit(nargs);
-
-    // Result goes to dst
-    if (call_base != dst) {
-        try self.emitOp(.move);
-        try self.emitU16(dst);
-        try self.emitU16(call_base);
-    }
-
-    var k: u8 = 0;
-    while (k < nargs) : (k += 1) {
-        self.freeReg();
-    }
-    self.freeReg(); // free loop_reg
+    self.endScope();
 }
 
 // Collect the names of variables that are referenced free inside a nested

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -146,6 +146,13 @@ pub fn compileCall(self: *Compiler, expr: Value, dst: u16, is_tail: bool) Compil
     if (args_valid and is_tail and types.isSymbol(operator) and self.func.name != null) {
         const op_name = types.symbolName(operator);
         if (std.mem.eql(u8, op_name, self.func.name.?) and !self.func.is_variadic and nargs == self.func.arity) {
+            // A named-let loop gensym (__nlet_N_x) is compiler-introduced and
+            // unique, so a name match is always a self-reference even though
+            // it now resolves as a boxed upvalue (checked first to avoid
+            // resolveUpvalue registering a capture the fast path never reads).
+            if (std.mem.startsWith(u8, op_name, "__nlet_")) {
+                return compileSelfTailCall(self, expr, dst, nargs);
+            }
             if (self.resolveLocal(op_name) == null and (try self.resolveUpvalue(op_name)) == null) {
                 return compileSelfTailCall(self, expr, dst, nargs);
             }

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -75,7 +75,7 @@ fn clearOldMarks(gc: *GC) void {
 fn pruneRememberedSet(gc: *GC) void {
     var write_idx: usize = 0;
     for (gc.remembered_set.items) |obj| {
-        if (referencesYoung(obj)) {
+        if (referencesYoung(gc, obj)) {
             gc.remembered_set.items[write_idx] = obj;
             write_idx += 1;
         }
@@ -83,116 +83,116 @@ fn pruneRememberedSet(gc: *GC) void {
     gc.remembered_set.shrinkRetainingCapacity(write_idx);
 }
 
-fn referencesYoung(obj: *Object) bool {
+fn referencesYoung(gc: *GC, obj: *Object) bool {
     switch (obj.tag) {
         .pair => {
             const pair = obj.as(Pair);
-            if (isYoungPointer(pair.car) or isYoungPointer(pair.cdr)) return true;
+            if (isYoungPointer(gc, pair.car) or isYoungPointer(gc, pair.cdr)) return true;
         },
         .vector => {
             const vec = obj.as(types.Vector);
             for (vec.data) |item| {
-                if (isYoungPointer(item)) return true;
+                if (isYoungPointer(gc, item)) return true;
             }
         },
         .record_instance => {
             const ri = obj.as(RecordInstance);
-            if (isYoungPointer(types.makePointer(@ptrCast(ri.record_type)))) return true;
+            if (isYoungPointer(gc, types.makePointer(@ptrCast(ri.record_type)))) return true;
             for (ri.fields) |field| {
-                if (isYoungPointer(field)) return true;
+                if (isYoungPointer(gc, field)) return true;
             }
         },
         .hash_table => {
             const ht = obj.as(HashTable);
             for (ht.entries[0..ht.capacity]) |entry| {
                 if (entry.state == .occupied) {
-                    if (isYoungPointer(entry.key) or isYoungPointer(entry.value)) return true;
+                    if (isYoungPointer(gc, entry.key) or isYoungPointer(gc, entry.value)) return true;
                 }
             }
         },
         .closure => {
             const cls = obj.as(Closure);
-            if (isYoungPointer(types.makePointer(@ptrCast(cls.func)))) return true;
+            if (isYoungPointer(gc, types.makePointer(@ptrCast(cls.func)))) return true;
             for (cls.upvalues) |uv| {
-                if (isYoungPointer(uv)) return true;
+                if (isYoungPointer(gc, uv)) return true;
             }
         },
         .promise => {
-            if (isYoungPointer(obj.as(Promise).value)) return true;
+            if (isYoungPointer(gc, obj.as(Promise).value)) return true;
         },
         .parameter => {
             const param = obj.as(types.ParameterObject);
-            if (isYoungPointer(param.value) or isYoungPointer(param.converter)) return true;
+            if (isYoungPointer(gc, param.value) or isYoungPointer(gc, param.converter)) return true;
         },
         .transformer => {
             const tx = obj.as(Transformer);
             for (tx.literals) |lit| {
-                if (isYoungPointer(lit)) return true;
+                if (isYoungPointer(gc, lit)) return true;
             }
             for (tx.patterns) |pat| {
-                if (isYoungPointer(pat)) return true;
+                if (isYoungPointer(gc, pat)) return true;
             }
             for (tx.templates) |tmpl| {
-                if (isYoungPointer(tmpl)) return true;
+                if (isYoungPointer(gc, tmpl)) return true;
             }
-            if (isYoungPointer(tx.def_env_val)) return true;
+            if (isYoungPointer(gc, tx.def_env_val)) return true;
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);
-            if (isYoungPointer(err.message) or isYoungPointer(err.irritants) or isYoungPointer(err.uncaught_reason)) return true;
+            if (isYoungPointer(gc, err.message) or isYoungPointer(gc, err.irritants) or isYoungPointer(gc, err.uncaught_reason)) return true;
         },
         .continuation => {
             const cont = obj.as(Continuation);
             for (cont.registers) |reg| {
-                if (isYoungPointer(reg)) return true;
+                if (isYoungPointer(gc, reg)) return true;
             }
             for (cont.frames[0..cont.frame_count]) |frame| {
                 if (frame.closure) |cls| {
-                    if (isYoungPointer(types.makePointer(@ptrCast(cls)))) return true;
+                    if (isYoungPointer(gc, types.makePointer(@ptrCast(cls)))) return true;
                 }
                 if (frame.native) |nf| {
-                    if (isYoungPointer(types.makePointer(@ptrCast(nf)))) return true;
+                    if (isYoungPointer(gc, types.makePointer(@ptrCast(nf)))) return true;
                 }
             }
             for (cont.handlers[0..cont.handler_count]) |handler| {
-                if (isYoungPointer(handler.handler)) return true;
+                if (isYoungPointer(gc, handler.handler)) return true;
             }
             for (cont.wind_records[0..cont.wind_count]) |wr| {
-                if (isYoungPointer(wr.before) or isYoungPointer(wr.after)) return true;
+                if (isYoungPointer(gc, wr.before) or isYoungPointer(gc, wr.after)) return true;
             }
         },
         .multiple_values => {
             const mv = obj.as(MultipleValues);
             for (mv.values) |val| {
-                if (isYoungPointer(val)) return true;
+                if (isYoungPointer(gc, val)) return true;
             }
         },
         .rational => {
             const rat = obj.as(Rational);
-            if (isYoungPointer(rat.numerator) or isYoungPointer(rat.denominator)) return true;
+            if (isYoungPointer(gc, rat.numerator) or isYoungPointer(gc, rat.denominator)) return true;
         },
         .ffi_function => {
-            if (isYoungPointer(obj.as(FfiFunction).library)) return true;
+            if (isYoungPointer(gc, obj.as(FfiFunction).library)) return true;
         },
         .ffi_callback => {
-            if (isYoungPointer(obj.as(FfiCallback).closure)) return true;
+            if (isYoungPointer(gc, obj.as(FfiCallback).closure)) return true;
         },
         .fiber => {
             const fiber_mod = @import("fiber.zig");
             const fiber = obj.as(fiber_mod.Fiber);
-            if (isYoungPointer(fiber.thunk) or isYoungPointer(fiber.result) or
-                isYoungPointer(fiber.waiting_on) or isYoungPointer(fiber.name) or
-                isYoungPointer(fiber.specific)) return true;
+            if (isYoungPointer(gc, fiber.thunk) or isYoungPointer(gc, fiber.result) or
+                isYoungPointer(gc, fiber.waiting_on) or isYoungPointer(gc, fiber.name) or
+                isYoungPointer(gc, fiber.specific)) return true;
             if (fiber.current_exception) |exc| {
-                if (isYoungPointer(exc)) return true;
+                if (isYoungPointer(gc, exc)) return true;
             }
-            if (isYoungPointer(fiber.continuation_value)) return true;
+            if (isYoungPointer(gc, fiber.continuation_value)) return true;
             for (fiber.frames[0..fiber.frame_count]) |f| {
                 if (f.closure) |cls| {
-                    if (isYoungPointer(types.makePointer(@ptrCast(cls)))) return true;
+                    if (isYoungPointer(gc, types.makePointer(@ptrCast(cls)))) return true;
                 }
                 if (f.native) |nf| {
-                    if (isYoungPointer(types.makePointer(@ptrCast(nf)))) return true;
+                    if (isYoungPointer(gc, types.makePointer(@ptrCast(nf)))) return true;
                 }
                 const window: usize = if (f.closure) |cls| blk: {
                     const lc = cls.func.locals_count;
@@ -201,55 +201,55 @@ fn referencesYoung(obj: *Object) bool {
                 const end: usize = @min(@as(usize, f.base) + window, fiber.registers.len);
                 var r: usize = f.base;
                 while (r < end) : (r += 1) {
-                    if (isYoungPointer(fiber.registers[r])) return true;
+                    if (isYoungPointer(gc, fiber.registers[r])) return true;
                 }
             }
             for (fiber.handler_stack[0..fiber.handler_count]) |h| {
-                if (isYoungPointer(h.handler)) return true;
+                if (isYoungPointer(gc, h.handler)) return true;
             }
             for (fiber.wind_stack[0..fiber.wind_count]) |wr| {
-                if (isYoungPointer(wr.before) or isYoungPointer(wr.after)) return true;
+                if (isYoungPointer(gc, wr.before) or isYoungPointer(gc, wr.after)) return true;
             }
             var pit = fiber.param_overrides.valueIterator();
             while (pit.next()) |v| {
-                if (isYoungPointer(v.*)) return true;
+                if (isYoungPointer(gc, v.*)) return true;
             }
         },
         .channel => {
             const ch = obj.as(types.Channel);
-            if (isYoungPointer(ch.head) or isYoungPointer(ch.tail)) return true;
+            if (isYoungPointer(gc, ch.head) or isYoungPointer(gc, ch.tail)) return true;
         },
         .mutex => {
             const m = obj.as(types.Mutex);
-            if (isYoungPointer(m.name) or isYoungPointer(m.owner) or isYoungPointer(m.specific)) return true;
+            if (isYoungPointer(gc, m.name) or isYoungPointer(gc, m.owner) or isYoungPointer(gc, m.specific)) return true;
         },
         .condition_variable => {
             const cv = obj.as(types.ConditionVariable);
-            if (isYoungPointer(cv.name) or isYoungPointer(cv.specific)) return true;
+            if (isYoungPointer(gc, cv.name) or isYoungPointer(gc, cv.specific)) return true;
         },
         .function => {
             const func = obj.as(Function);
             for (func.constants.items) |c| {
-                if (isYoungPointer(c)) return true;
+                if (isYoungPointer(gc, c)) return true;
             }
             if (func.global_cache) |cache| {
                 for (cache) |c| {
-                    if (isYoungPointer(c)) return true;
+                    if (isYoungPointer(gc, c)) return true;
                 }
             }
-            if (isYoungPointer(func.env_val)) return true;
+            if (isYoungPointer(gc, func.env_val)) return true;
         },
         .native_closure => {
             const nc = obj.as(types.NativeClosure);
             for (nc.upvalues) |uv| {
-                if (isYoungPointer(uv)) return true;
+                if (isYoungPointer(gc, uv)) return true;
             }
         },
         .scheme_environment => {
             const se = obj.as(types.SchemeEnvironment);
             var vit = se.env.valueIterator();
             while (vit.next()) |val| {
-                if (isYoungPointer(val.*)) return true;
+                if (isYoungPointer(gc, val.*)) return true;
             }
         },
         .symbol, .string, .native_fn, .flonum, .port, .complex, .bytevector, .bignum, .record_type, .ffi_library, .file_info, .user_info, .group_info, .directory_object, .random_source, .srfi18_time => {},
@@ -257,9 +257,14 @@ fn referencesYoung(obj: *Object) bool {
     return false;
 }
 
-fn isYoungPointer(val: Value) bool {
+fn isYoungPointer(gc: *GC, val: Value) bool {
     if (!types.isPointer(val)) return false;
-    return types.toObject(val).generation == 0;
+    const obj = types.toObject(val);
+    // Foreign objects are never traced by this GC, so a reference to one
+    // never needs a remembered-set entry — and reading its generation bit
+    // would race the owning GC's collection cycle.
+    if (obj.owner != gc.id) return false;
+    return obj.generation == 0;
 }
 
 fn fullCollect(gc: *GC) void {
@@ -510,6 +515,14 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
     while (true) {
         if (!types.isPointer(cur)) return;
         const obj = types.toObject(cur);
+        // Never mark or trace an object owned by another GC. Its owner keeps
+        // it alive (shared globals are marked by the parent, interned symbols
+        // are never swept, a thread's thunk is extra-rooted until join), and
+        // writing this GC's mark bits into it would corrupt the owner's
+        // concurrent mark/sweep cycle — the owner would see a spurious
+        // "already marked" object, skip tracing its children, and sweep live
+        // descendants (#958).
+        if (obj.owner != gc.id) return;
         if (obj.marked) return;
         obj.marked = true;
 

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -52,6 +52,15 @@ pub const GcStats = struct {
 
 pub var symbol_mutex: std.atomic.Mutex = .unlocked;
 
+/// Monotonic source of unique GC ids (see `GC.id`). Never reused, so a live
+/// GC can never collide with a dead thread's id. Starts at 1 so 0 is never a
+/// valid id.
+var next_gc_id: u32 = 0;
+
+fn nextGcId() u32 {
+    return @atomicRmw(u32, &next_gc_id, .Add, 1, .monotonic) + 1;
+}
+
 pub fn spinLock(m: *std.atomic.Mutex) void {
     while (!m.tryLock()) std.atomic.spinLoopHint();
 }
@@ -80,6 +89,15 @@ pub const GC = struct {
     // For a child gc, points at the owning (parent) gc's `foreign_symbols`;
     // set alongside `shared_symbols` in `initForThread`.
     shared_foreign_symbols: ?*std.ArrayList(*Object) = null,
+    /// Unique id of this GC, stamped into `Object.owner` of every object it
+    /// tracks. Marking only touches objects whose owner matches the marking
+    /// GC (see gc_collect.zig); foreign objects are the owner's job to keep
+    /// alive. This is what stops an SRFI-18 child thread's collections from
+    /// racing the parent's mark/sweep on shared parent-heap objects (#958).
+    id: u32 = 0,
+    /// For a child gc: the parent gc's id, stamped on symbols the child
+    /// interns into the shared table (the parent owns and frees those).
+    shared_owner_id: u32 = 0,
     roots: std.ArrayList(*Value),
     extra_roots: std.ArrayList(Value),
     remembered_set: std.ArrayList(*Object),
@@ -101,6 +119,7 @@ pub const GC = struct {
             .extra_roots = .empty,
             .remembered_set = .empty,
             .source_lines = std.AutoHashMap(Value, u32).init(allocator),
+            .id = nextGcId(),
         };
     }
 
@@ -115,6 +134,8 @@ pub const GC = struct {
             .remembered_set = .empty,
             .source_lines = std.AutoHashMap(Value, u32).init(allocator),
             .gc_threshold = GC_THRESHOLD,
+            .id = nextGcId(),
+            .shared_owner_id = parent.id,
         };
     }
 
@@ -146,7 +167,10 @@ pub const GC = struct {
     pub fn writeBarrier(self: *GC, container: *Object, new_val: Value) void {
         if (container.generation == 1 and types.isPointer(new_val)) {
             const child = types.toObject(new_val);
-            if (child.generation == 0) {
+            // A foreign new_val (another GC's object) is never traced by this
+            // GC, so it needs no remembered-set entry — and reading its
+            // generation bit would race the owner's collection cycle.
+            if (child.owner == self.id and child.generation == 0) {
                 self.remembered_set.append(self.allocator, container) catch {};
             }
         }
@@ -157,6 +181,7 @@ pub const GC = struct {
     }
 
     pub fn trackObject(self: *GC, obj: *Object) void {
+        obj.owner = self.id;
         obj.next = self.objects;
         self.objects = obj;
         self.object_count += 1;
@@ -218,6 +243,9 @@ pub const GC = struct {
             // this child thread, so hand ownership to the parent (freed at the
             // parent's deinit). Appended under `symbol_mutex`, held here.
             // `shared_foreign_symbols` is set whenever `shared_symbols` is.
+            // Stamp the parent's id: the parent owns it, and the parent's
+            // markRoots pass over the shared table must not skip it.
+            sym.header.owner = self.shared_owner_id;
             self.shared_foreign_symbols.?.append(self.allocator, &sym.header) catch {
                 self.allocator.destroy(sym);
                 self.allocator.free(owned_name);

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -227,7 +227,12 @@ fn threadStartFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
 
+    // Root the thunk (the child deep-copies it from the parent heap) and the
+    // fiber itself (the child writes fiber.status / reads fiber.terminated
+    // for the whole run, so it must survive even if the program drops its
+    // last reference). Both are removed at thread-join!.
     gc.extra_roots.append(gc.allocator, fiber.thunk) catch return PrimitiveError.OutOfMemory;
+    gc.extra_roots.append(gc.allocator, args[0]) catch return PrimitiveError.OutOfMemory;
 
     fiber.status = .running;
     fiber.os_thread = std.Thread.spawn(.{}, threadEntryFn, .{
@@ -404,10 +409,16 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
 
         const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
 
-        // Remove thunk from extra_roots (added by thread-start! to keep it
-        // alive during deep-copy; the child is done now).
+        // Remove the thunk and fiber from extra_roots (added by thread-start!
+        // to keep them alive while the child runs; the child is done now).
         for (gc.extra_roots.items, 0..) |v, idx| {
             if (v == target.thunk) {
+                _ = gc.extra_roots.swapRemove(idx);
+                break;
+            }
+        }
+        for (gc.extra_roots.items, 0..) |v, idx| {
+            if (v == args[0]) {
                 _ = gc.extra_roots.swapRemove(idx);
                 break;
             }

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -284,3 +284,104 @@ test "parameter set before scheduler creation stays visible" {
     const fiber_val = try vm.eval("(fiber-join f)");
     try std.testing.expectEqual(@as(i64, 2), types.toFixnum(fiber_val));
 }
+
+// Regression for #958: an SRFI-18 child thread's GC used to mark (and trace
+// through) parent-heap objects reachable from its VM roots — e.g. a parent
+// closure the child executes after a shared-globals lookup. Those stale mark
+// bits corrupted the parent's next collection: markValueInner saw "already
+// marked", skipped tracing children, and sweepYoung freed live objects,
+// corrupting the C heap. Marking must never touch an object owned by another
+// GC.
+test "marking skips objects owned by another GC (#958)" {
+    var parent = memory.GC.init(std.testing.allocator);
+    defer parent.deinit();
+    var child = memory.GC.initForThread(std.testing.allocator, &parent);
+    defer child.deinit();
+
+    const parent_pair = try parent.allocPair(types.makeFixnum(1), types.NIL);
+    const parent_obj = types.toObject(parent_pair);
+
+    // Marking a foreign object directly is a no-op.
+    child.markValue(parent_pair);
+    try std.testing.expect(!parent_obj.marked);
+
+    // Tracing a child object must stop at the foreign edge: the child pair
+    // itself is marked, the parent pair it references is not.
+    const child_pair = try child.allocPair(parent_pair, types.NIL);
+    const child_obj = types.toObject(child_pair);
+    child.markValue(child_pair);
+    try std.testing.expect(child_obj.marked);
+    try std.testing.expect(!parent_obj.marked);
+    child_obj.marked = false;
+
+    // The owner still marks its own objects.
+    parent.markValue(parent_pair);
+    try std.testing.expect(parent_obj.marked);
+    parent_obj.marked = false;
+}
+
+// Regression for #958, end to end: a child OS thread that executes a
+// parent-heap closure (looked up via the shared globals map) triggers child
+// collections while running. Those collections must leave no stale mark bits
+// on the parent heap — between collections every mark bit is false, and the
+// parent's next cycle relies on that to trace its full object graph.
+test "child thread collections leave no stale marks on parent heap (#958)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // build-list is a parent-heap closure; 20000 elements exceeds the child
+    // GC threshold, so the child collects (and marks its roots — which
+    // include the parent-heap build-list closure frame) mid-run.
+    const result = try vm.eval(
+        \\(define (build-list n)
+        \\  (let loop ((i 0) (acc '()))
+        \\    (if (= i n) acc (loop (+ i 1) (cons i acc)))))
+        \\(let ((t (make-thread (lambda () (length (build-list 20000))))))
+        \\  (thread-start! t)
+        \\  (thread-join! t))
+    );
+    try std.testing.expectEqual(@as(i64, 20000), types.toFixnum(result));
+
+    var lists = [_]?*types.Object{ gc.objects, gc.old_objects };
+    for (&lists) |*head| {
+        var obj = head.*;
+        while (obj) |o| : (obj = o.next) {
+            try std.testing.expect(!o.marked);
+        }
+    }
+}
+
+// Regression for #958, the write direction: named let used to bind its loop
+// procedure to a gensym'd global (__nlet_N_name) via define_global. A child
+// OS thread executing a parent function containing a named let then wrote a
+// child-heap closure into the shared globals map, which dangled once the
+// child heap was freed at thread-join!. Named let now binds the loop
+// procedure to a boxed local, so nothing a child thread runs may leave
+// child-owned values in the shared globals map.
+test "child thread leaves no child-heap values in shared globals (#958)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // sum-to contains a named let; the child executes it via the shared
+    // globals map, exercising the loop-procedure binding on the child VM.
+    const result = try vm.eval(
+        \\(define (sum-to n)
+        \\  (let loop ((i 0) (acc 0))
+        \\    (if (= i n) acc (loop (+ i 1) (+ acc i)))))
+        \\(let ((t (make-thread (lambda () (sum-to 1000)))))
+        \\  (thread-start! t)
+        \\  (thread-join! t))
+    );
+    try std.testing.expectEqual(@as(i64, 499500), types.toFixnum(result));
+
+    var it = vm.globals.valueIterator();
+    while (it.next()) |v| {
+        if (types.isPointer(v.*)) {
+            try std.testing.expectEqual(gc.id, types.toObject(v.*).owner);
+        }
+    }
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -145,6 +145,13 @@ pub const Object = struct {
     marked: bool = false,
     generation: u1 = 0,
     survive_count: u2 = 0,
+    /// Id of the GC that tracks (and will free) this object. Marking skips
+    /// objects owned by another GC: an SRFI-18 child thread's heap can
+    /// reference parent-heap objects (shared globals, interned symbols,
+    /// closures being executed), and writing mark bits on those would corrupt
+    /// the parent GC's mark state — under-marking sweeps live objects (#958).
+    /// Fits in existing struct padding, so it adds no size.
+    owner: u32 = 0,
     next: ?*Object = null,
     // Force 8-byte alignment so all heap objects satisfy the pointer tag
     // check (v & 7 == 0). Without this, wasm32 allocators may return


### PR DESCRIPTION
## Summary

Fixes the flaky (30–40%) SIGSEGV/SIGABRT in `tests/scheme/smoke/deep-copy-list-801.scm` (#958). Running the test under guard malloc (`libgmalloc`) made the crash 100% deterministic and exposed two ways an SRFI-18 child OS thread corrupted parent-owned memory:

### 1. Named let wrote child-heap closures into the shared globals map

Named let bound its loop procedure to a gensym'd **global** (`__nlet_N_name`) via `define_global`, re-executed on **every call**. When a child thread ran a parent-heap function containing a named let (here: `make-long-list`, looked up via the shared globals map), it wrote a **child-heap closure** into the shared map. The child GC never roots shared globals (`owns_globals=false`), so that closure was freed by the child's next collection or by heap teardown at `thread-join!` — leaving a dangling global that the parent's next mark phase dereferenced. Corrupted-mark traversal then scribbled over freed pages, which is why the crash surfaced later in `malloc` on the main thread.

**Fix:** named let now binds the loop procedure to a **boxed local** (single-binding letrec, same machinery as `compileLetrec`), so executing it writes nothing shared — this also stops polluting the global namespace. The `self_tail_call` fast path is taught that a `__nlet_` name match is always a self-reference (the name now resolves as an upvalue, which previously disqualified it); loop microbenchmarks match the previous build (~2.0s for 20M iterations, before and after).

### 2. Child GC collections marked parent-heap objects

A child's frames/registers legitimately hold parent-heap pointers (the parent closure it executes, interned symbols, native fns). Each child collection **marked and traced** those parent objects. Stale/concurrent foreign mark bits corrupt the parent's own cycle: the parent sees a spuriously "already marked" object, skips tracing its children, and sweeps live descendants.

**Fix:** every heap object records its owning GC (`Object.owner: u32`, stamped by `trackObject` from a never-reused `GC.id`; fits in existing `Object` padding, so zero size cost). Marking, the write barrier, and remembered-set pruning skip objects owned by another GC — foreign liveness is the owner's job (shared globals are marked by the parent, interned symbols are never swept, the thunk is extra-rooted until join).

### Hardening

`thread-start!` now extra-roots the **fiber** as well as its thunk (removed at `thread-join!`): the child writes `fiber.status` and reads `fiber.terminated` for its whole run, so the fiber must survive even if the program drops its last reference mid-run.

## Verification

| Check | Before | After |
|---|---|---|
| `deep-copy-list-801.scm` under libgmalloc | 6/6 crash | 0/6 crash |
| `deep-copy-list-801.scm` plain ×30 | ~30–40% crash | 0/30 crash |
| `zig build test` (incl. 3 new regression tests) | — | pass |
| `run-all.sh` (252 files + 1395 R7RS) | — | 0 fail |
| Thread smoke tests + repro under `-Dgc-threshold=1` | — | pass |
| Named-let loop microbench (20M iters + non-tail rec) | ~2.05s | ~2.04s |

New regression tests in `src/tests_srfi18.zig`: direct cross-GC marking invariant, no stale marks on the parent heap after a child runs a parent closure, and no child-owned values in the shared globals map after a child runs a named let.

## Remaining known gap (pre-existing, not addressed here)

A child thread *reading* the shared globals map concurrently with the parent *rehashing* it (parent defines enough new globals mid-child-run to grow the map) is still unsynchronized. That's a narrower, read-side race and orthogonal to the write-path corruption fixed here; noting it for a follow-up.

Fixes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)