### PR TITLE
Keep .sbc-loaded functions rooted for the whole run

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -749,8 +749,18 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
     const all_funcs = allocator.alloc(*Function, func_count) catch return BytecodeError.OutOfMemory;
     defer allocator.free(all_funcs);
 
+    // Root every loaded function in gc.extra_roots. During the load this keeps
+    // functions alive while readConstant allocates. On success we KEEP them
+    // rooted for the rest of the run (keep_roots = true below): the caller
+    // executes the top-level functions one at a time, and a GC triggered while
+    // running one form must not reclaim the other, not-yet-executed functions
+    // (nor the shared nested functions they reference). This mirrors the fresh
+    // compile path, where main.zig leaves every compiled top-level function in
+    // gc.extra_roots for the whole run. On any error path the functions are
+    // still reachable garbage, so we drop the roots to let them be collected.
     const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    var keep_roots = false;
+    defer if (!keep_roots) gc.extra_roots.shrinkRetainingCapacity(roots_base);
     for (0..func_count) |i| {
         all_funcs[i] = gc.allocFunction() catch return BytecodeError.OutOfMemory;
         gc.extra_roots.append(allocator, types.makePointer(@ptrCast(all_funcs[i]))) catch return BytecodeError.OutOfMemory;
@@ -891,6 +901,9 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
 
     const result = allocator.alloc(*Function, func_count) catch return BytecodeError.OutOfMemory;
     @memcpy(result, all_funcs);
+    // Load succeeded: keep the functions rooted for the rest of the run so a GC
+    // during execution of one top-level form cannot free the others.
+    keep_roots = true;
     return .{ .funcs = result, .top_level_count = top_level_count, .bundled_files = bundled_files, .preamble = preamble };
 }
 

--- a/src/tests_bytecode_cache.zig
+++ b/src/tests_bytecode_cache.zig
@@ -1,0 +1,110 @@
+// Regression tests for the .sbc bytecode cache (src/bytecode_file.zig).
+//
+// A program that runs correctly on a fresh compile used to fail with
+// error.InvalidBytecode when re-run from its cached .sbc — but only for
+// programs that allocate enough to trigger a GC mid-run (deep-mark-864.scm,
+// env-uaf.scm, gcd-gc-843.scm, lambda-leak-832.scm, deep-copy-list-801.scm).
+//
+// Cause: deserialization rooted the loaded functions only for the duration of
+// the load and dropped them from the root set on return. A collection fired
+// while executing one top-level form then reclaimed the *other*, not-yet-run
+// top-level functions, so calling them read freed bytecode. A fresh compile
+// never hits this because main.zig keeps every compiled top-level function in
+// gc.extra_roots for the whole run (see main.zig comment near compiled_funcs).
+
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const bytecode_file = @import("bytecode_file.zig");
+
+const GC = memory.GC;
+const Function = types.Function;
+
+// A trivial top-level function: load constant #0 into r0 and return it.
+fn makeReturnConstFunc(gc: *GC, n: i64) !*Function {
+    const a = gc.allocator;
+    const func = try gc.allocFunction();
+    try func.code.append(a, @intFromEnum(types.OpCode.load_const));
+    try func.code.append(a, 0); // dst hi
+    try func.code.append(a, 0); // dst lo (r0)
+    try func.code.append(a, 0); // const idx hi
+    try func.code.append(a, 0); // const idx lo (#0)
+    try func.code.append(a, @intFromEnum(types.OpCode.@"return"));
+    try func.code.append(a, 0); // src hi
+    try func.code.append(a, 0); // src lo (r0)
+    try func.constants.append(a, types.makeFixnum(n));
+    func.arity = 0;
+    func.locals_count = 1;
+    return func;
+}
+
+// Walk the GC's live-object lists (young + old) and report whether `obj` is
+// still present. Only compares pointer identity — never dereferences `obj` —
+// so it is safe to call with a pointer to an object that may have been freed.
+fn gcHoldsObject(gc: *GC, obj: *types.Object) bool {
+    var it = gc.objects;
+    while (it) |o| : (it = o.next) {
+        if (o == obj) return true;
+    }
+    it = gc.old_objects;
+    while (it) |o| : (it = o.next) {
+        if (o == obj) return true;
+    }
+    return false;
+}
+
+test "bytecode cache: deserialized top-level functions survive a mid-run GC" {
+    const allocator = std.testing.allocator;
+    var gc = GC.init(allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Three independent top-level thunks, each returning a distinct fixnum —
+    // standing in for a program's sequence of top-level forms.
+    const f0 = try makeReturnConstFunc(&gc, 111);
+    const f1 = try makeReturnConstFunc(&gc, 222);
+    const f2 = try makeReturnConstFunc(&gc, 333);
+
+    var funcs_arr = [_]*Function{ f0, f1, f2 };
+    const hash: u64 = 0x5BC0;
+    const path = "/tmp/kaappi_test_sbc_survive_gc.sbc";
+    try bytecode_file.writeFileWithTopLevel(allocator, &funcs_arr, hash, path);
+    defer _ = std.posix.system.unlink(@ptrCast(path));
+
+    const loaded = (try bytecode_file.readFileWithTopLevel(&gc, hash, path)) orelse
+        return error.TestUnexpectedResult;
+    defer allocator.free(loaded.funcs);
+    try std.testing.expectEqual(@as(u32, 3), loaded.top_level_count);
+
+    const want = [_]i64{ 111, 222, 333 };
+
+    // The round-tripped bytecode executes and returns each constant.
+    for (loaded.funcs[0..loaded.top_level_count], want) |func, w| {
+        var fv = types.makePointer(@ptrCast(func));
+        try gc.pushRoot(&fv);
+        defer gc.popRoot();
+        const r = try vm.execute(func);
+        try std.testing.expect(types.isFixnum(r));
+        try std.testing.expectEqual(w, types.toFixnum(r));
+    }
+
+    // A collection that fires while the runtime sits between top-level forms
+    // (nothing externally rooted) must not reclaim the loaded functions.
+    // Before the fix this freed f1/f2 and the assertions below caught it.
+    gc.collect();
+    for (loaded.funcs) |func| {
+        try std.testing.expect(gcHoldsObject(&gc, &func.header));
+    }
+
+    // ...and they remain executable after the collection.
+    for (loaded.funcs[0..loaded.top_level_count], want) |func, w| {
+        var fv = types.makePointer(@ptrCast(func));
+        try gc.pushRoot(&fv);
+        defer gc.popRoot();
+        const r = try vm.execute(func);
+        try std.testing.expect(types.isFixnum(r));
+        try std.testing.expectEqual(w, types.toFixnum(r));
+    }
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -18,4 +18,5 @@ test {
     _ = @import("tests_ir.zig");
     _ = @import("tests_srfi18.zig");
     _ = @import("tests_ffi.zig");
+    _ = @import("tests_bytecode_cache.zig");
 }


### PR DESCRIPTION
## Problem

Several Scheme programs run correctly on a fresh compile but fail with `error.InvalidBytecode` when re-run from their cached `.sbc` — but only when they allocate enough to trigger a GC mid-run (`deep-mark-864.scm`, `env-uaf.scm`, `gcd-gc-843.scm`, `lambda-leak-832.scm`).

```
find tests -name '*.sbc' -delete
./zig-out/bin/kaappi tests/scheme/smoke/deep-mark-864.scm   # run 1: prints #t, exit 0 (writes .sbc)
./zig-out/bin/kaappi tests/scheme/smoke/deep-mark-864.scm   # run 2: error.InvalidBytecode
```

This is pre-existing and reproduces on `main`. It stays hidden because `run-all.sh` runs each file once on a fresh checkout; a stale/newly-written `.sbc` next to a test triggers it.

## Root cause

Not a byte-level encoding defect — a byte-diff of a passing vs. failing `.sbc` showed them identical except the source hash and one literal constant; both pass `validateFunctionBytecode`. The trigger threshold is exactly 8192 (the default GC threshold), and the error prints once per not-yet-executed top-level form.

The defect is a **GC-rooting lifetime gap in deserialization**:

- The fresh-compile path compiles and executes top-level forms one at a time and keeps every compiled function permanently in `gc.extra_roots` (see the comment near `compiled_funcs` in `main.zig`: *"these pointers must survive GC triggered while executing later forms."*).
- `deserializeFromBuffer` rooted the loaded functions only for the duration of the load and dropped them from `gc.extra_roots` on return (`defer gc.extra_roots.shrinkRetainingCapacity(roots_base)`). `main.zig` then rooted only the currently-executing top-level function.
- A GC firing while running one form reclaimed the **other, not-yet-executed** top-level functions, so calling them next read freed bytecode → `error.InvalidBytecode` (one error per later form).

## Fix

Keep the deserialized functions rooted on success (mirroring the fresh-compile path) while still dropping the roots on every error path, via a `keep_roots` flag in `deserializeFromBuffer`.

## Test

`src/tests_bytecode_cache.zig` round-trips top-level functions through `writeFileWithTopLevel`/`readFileWithTopLevel`, forces a `gc.collect()` with nothing externally rooted, then asserts the loaded functions stay live and executable. It fails cleanly (`TestUnexpectedResult`) before the fix and passes after — deterministic, no use-after-free.

## Verification

- `zig build test` → **506/506 pass**.
- `deep-mark-864`, `env-uaf`, `gcd-gc-843`, `lambda-leak-832` → pass reliably run-then-rerun-from-cache (5× each); each confirmed to actually produce an `.sbc`.
- Full `smoke/` sweep, fresh + cached → all pass, no regressions.

## Note

`deep-copy-list-801.scm` was originally suspected but is unrelated: it imports `(srfi 18)` so it is never cached (no `.sbc`), and it segfaults intermittently on unmodified `main` during *compilation* — a separate pre-existing SRFI-18 deep-copy/threading race, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)