### PR TITLE
Share globals map by pointer with SRFI-18 children, lock rehashes (#958 follow-up)

### DIFF
--- a/src/bench.zig
+++ b/src/bench.zig
@@ -35,7 +35,7 @@ fn measure(allocator: std.mem.Allocator, prim: []const u8, depth: u32, iters: u3
     defer vm.deinit();
     try primitives.registerAll(&vm);
     primitives.setGCInstance(&gc);
-    try library.registerStandardLibraries(&vm.libraries, &vm.globals);
+    try library.registerStandardLibraries(&vm.libraries, vm.globals);
 
     // at-depth builds `depth` real (non-tail) frames to elevate the register
     // base; cap runs a tail loop performing `iters` escaping captures.

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -6,6 +6,7 @@ const forms = @import("compiler_forms.zig");
 const advanced = @import("compiler_advanced.zig");
 const passthrough = @import("compiler_passthrough.zig");
 const ir_mod = @import("ir.zig");
+const vm_mod = @import("vm.zig");
 const Value = types.Value;
 const OpCode = types.OpCode;
 
@@ -1208,6 +1209,13 @@ pub const Compiler = struct {
                 var global_free_names: [64][]const u8 = undefined;
                 var global_free_count: usize = 0;
                 if (self.globals) |g| {
+                    // The sentinel puts below structurally mutate the globals
+                    // map when g is the VM's shared one — exclude SRFI-18
+                    // child-thread readers for the whole dance (#958). glk is
+                    // non-null exactly when g is the current thread's shared
+                    // globals map.
+                    const glk = vm_mod.acquireGlobalsWrite(g);
+                    defer vm_mod.releaseGlobalsWrite(glk);
                     for (tx.captured_locals) |cap| {
                         if (!g.contains(cap.name) and temp_global_count < 128) {
                             temp_globals[temp_global_count] = .{ .name = cap.name, .old_val = null, .was_present = false };
@@ -1227,8 +1235,7 @@ pub const Compiler = struct {
                     }
                     // Temporarily mark non-procedure free globals as VOID so
                     // renameForHygiene preserves them.
-                    const vm_mod2 = @import("vm.zig");
-                    if (vm_mod2.vm_instance) |vm| {
+                    if (vm_mod.vm_instance) |vm| {
                         var cand_names: [64][]const u8 = undefined;
                         var cand_count: usize = 0;
                         var pv_names: [64][]const u8 = undefined;
@@ -1243,7 +1250,16 @@ pub const Compiler = struct {
                         }
                         for (cand_names[0..cand_count]) |cname| {
                             const in_g = g.get(cname);
-                            const in_vm = if (vm.globals.count() > 0) vm.globals.get(cname) else null;
+                            // glk != null means g IS the shared globals map
+                            // and we already hold its exclusive lock; else
+                            // this read needs its own child-thread lock.
+                            const in_vm = if (glk != null)
+                                (if (vm.globals.count() > 0) vm.globals.get(cname) else null)
+                            else in_vm_blk: {
+                                vm.lockGlobalsShared();
+                                defer vm.unlockGlobalsShared();
+                                break :in_vm_blk if (vm.globals.count() > 0) vm.globals.get(cname) else null;
+                            };
                             const existing = in_g orelse in_vm;
                             if (existing) |val| {
                                 if (!types.isProcedure(val) and !types.isTransformer(val) and val != types.VOID) {
@@ -1263,6 +1279,7 @@ pub const Compiler = struct {
                     }
                 }
                 defer if (self.globals) |g| {
+                    const glk = vm_mod.acquireGlobalsWrite(g);
                     for (temp_globals[0..temp_global_count]) |tg| {
                         if (tg.was_present) {
                             g.put(tg.name, tg.old_val.?) catch {};
@@ -1270,6 +1287,7 @@ pub const Compiler = struct {
                             _ = g.remove(tg.name);
                         }
                     }
+                    vm_mod.releaseGlobalsWrite(glk);
                 };
                 // Suppress GC during expansion: the expanded form isn't
                 // rooted until pushRoot below, so a collection triggered

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const passthrough = @import("compiler_passthrough.zig");
+const vm_mod = @import("vm.zig");
 const Value = types.Value;
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
@@ -532,6 +533,10 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
     var prescan_names: [64][]const u8 = undefined;
     var prescan_count: usize = 0;
     if (self.globals) |globals| {
+        // Structural puts into the (possibly shared) globals map — exclude
+        // SRFI-18 child-thread readers while sentinels are planted (#958).
+        const glk = vm_mod.acquireGlobalsWrite(globals);
+        defer vm_mod.releaseGlobalsWrite(glk);
         var scan = body;
         while (scan != types.NIL and types.isPair(scan)) {
             const form = types.car(scan);
@@ -569,6 +574,7 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
     defer {
         // Clean up pre-scanned names that are still VOID (not actually defined)
         if (self.globals) |globals| {
+            const glk = vm_mod.acquireGlobalsWrite(globals);
             for (prescan_names[0..prescan_count]) |pn| {
                 if (globals.get(pn)) |val| {
                     if (val == types.VOID) {
@@ -576,6 +582,7 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
                     }
                 }
             }
+            vm_mod.releaseGlobalsWrite(glk);
         }
     }
 

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
+const vm_mod = @import("vm.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
@@ -104,6 +105,10 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
     var prescan_names: std.ArrayList([]const u8) = .empty;
     defer prescan_names.deinit(self.gc.allocator);
     if (self.globals) |globals| {
+        // Structural puts into the (possibly shared) globals map — exclude
+        // SRFI-18 child-thread readers while sentinels are planted (#958).
+        const glk = vm_mod.acquireGlobalsWrite(globals);
+        defer vm_mod.releaseGlobalsWrite(glk);
         var scan = body;
         while (scan != types.NIL and types.isPair(scan)) {
             const form = types.car(scan);
@@ -137,11 +142,13 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
     }
     defer {
         if (self.globals) |globals| {
+            const glk = vm_mod.acquireGlobalsWrite(globals);
             for (prescan_names.items) |pn| {
                 if (globals.get(pn)) |val| {
                     if (val == types.VOID) _ = globals.remove(pn);
                 }
             }
+            vm_mod.releaseGlobalsWrite(glk);
         }
     }
 

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const expander = @import("expander.zig");
 const compiler_mod = @import("compiler.zig");
+const vm_mod = @import("vm.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
@@ -225,6 +226,8 @@ fn tryConstantFold(self: *Compiler, expr: Value, dst: u16) bool {
     if (self.resolveLocal(name) != null) return false;
     if ((self.resolveUpvalue(name) catch null) != null) return false;
     if (self.globals) |globals| {
+        const glk = vm_mod.acquireGlobalsRead(globals);
+        defer vm_mod.releaseGlobalsRead(glk);
         if (globals.get(name)) |val| {
             if (!types.isPointer(val)) return false;
             const obj = types.toObject(val);

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -762,7 +762,10 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
     if (std.mem.startsWith(u8, name, "__hyg_")) return gc.allocSymbol(name);
     const in_binding = (scope & BINDING_FLAG) != 0;
     const clean_scope = scope & ~BINDING_FLAG;
+    const vm_mod = @import("vm.zig");
     if (globals) |g| {
+        const glk = vm_mod.acquireGlobalsRead(g);
+        defer vm_mod.releaseGlobalsRead(glk);
         if (g.get(name)) |val| {
             if (types.isProcedure(val) or types.isTransformer(val)) {
                 // A template binding of the same name in this expansion
@@ -786,9 +789,11 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
             }
         }
     }
-    const vm_mod = @import("vm.zig");
     if (vm_mod.vm_instance) |vm| {
-        if (vm.globals.get(name)) |val| {
+        vm.lockGlobalsShared();
+        const found = vm.globals.get(name);
+        vm.unlockGlobalsShared();
+        if (found) |val| {
             if (types.isTransformer(val)) return gc.allocSymbol(name);
         }
     }

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
+const vm_mod = @import("vm.zig");
 
 const Value = types.Value;
 const OpCode = types.OpCode;
@@ -181,6 +182,8 @@ pub const IR = struct {
             if (st.contains(name)) return true;
         }
         const g = self.globals orelse return false;
+        const glk = vm_mod.acquireGlobalsRead(g);
+        defer vm_mod.releaseGlobalsRead(glk);
         const val = g.get(name) orelse {
             // In a restricted environment, missing names mean "not available".
             // Return true so the IR does not inline the primitive; the VM

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -790,7 +790,7 @@ fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8,
         };
 
         // Compile phase
-        _ = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, &vm.globals, 0, uri) catch {
+        _ = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, 0, uri) catch {
             const lc = r.getLineCol();
             if (has_diag) diag_buf.append(allocator, ',') catch {};
             has_diag = true;
@@ -883,7 +883,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer vm.deinit();
     try primitives.registerAll(&vm);
     primitives.setGCInstance(&gc);
-    try library.registerStandardLibraries(&vm.libraries, &vm.globals);
+    try library.registerStandardLibraries(&vm.libraries, vm.globals);
 
     var initialized = false;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -254,7 +254,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     if (comptime is_wasm) {
         try primitives.registerAll(vm);
         primitives.setGCInstance(&gc);
-        try library.registerStandardLibraries(&vm.libraries, &vm.globals);
+        try library.registerStandardLibraries(&vm.libraries, vm.globals);
 
         var wasi_args = try init.args.iterateAllocator(allocator);
         defer wasi_args.deinit();
@@ -279,12 +279,12 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     if (is_sandboxed) {
         try primitives.registerSandboxed(vm);
         primitives.setGCInstance(&gc);
-        try library.registerSandboxedLibraries(&vm.libraries, &vm.globals);
+        try library.registerSandboxedLibraries(&vm.libraries, vm.globals);
         vm.sandbox_mode = true;
     } else {
         try primitives.registerAll(vm);
         primitives.setGCInstance(&gc);
-        try library.registerStandardLibraries(&vm.libraries, &vm.globals);
+        try library.registerStandardLibraries(&vm.libraries, vm.globals);
     }
 
     // Standalone mode: run embedded bytecode and exit
@@ -847,7 +847,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             continue;
         }
 
-        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, &vm.globals, datum_lc.line, path) catch |err| {
+        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path) catch |err| {
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: compile error: {}\n", .{ path, datum_lc.line, err }) catch "compile error\n";
             writeStderr(s);
@@ -983,7 +983,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
             continue;
         }
 
-        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, &vm.globals, 0, "<stdin>") catch |err| {
+        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, 0, "<stdin>") catch |err| {
             const lc = r.getLineCol();
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "<stdin>:{d}: compile error: {}\n", .{ lc.line, err }) catch "compile error\n";
@@ -1082,7 +1082,7 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
             continue;
         }
 
-        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, &vm.globals, datum_lc.line, path) catch |err| {
+        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path) catch |err| {
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: compile error: {}\n", .{ path, datum_lc.line, err }) catch "compile error\n";
             writeStderr(s);
@@ -1179,7 +1179,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
             continue;
         }
 
-        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, &vm.globals, datum_lc.line, path) catch |err| {
+        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path) catch |err| {
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: compile error: {}\n", .{ path, datum_lc.line, err }) catch "compile error\n";
             writeStderr(s);

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -111,7 +111,7 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
                 if (std.mem.eql(u8, form_name, "define-syntax") or
                     std.mem.eql(u8, form_name, "define-record-type"))
                 {
-                    const func = compiler.compileExpressionWithMacros(vm.gc, expr, &vm.macros, &vm.globals) catch continue;
+                    const func = compiler.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch continue;
                     _ = vm.execute(func) catch {};
                     const passthrough_node = ir_instance.makePassthrough(expr) catch continue;
                     ir_nodes.append(allocator, passthrough_node) catch continue;

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -557,11 +557,15 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
 fn hashTableEquivFn(args: []const Value) PrimitiveError!Value {
     _ = try getHashTable("hash-table-equivalence-function", args[0]);
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
+    vm.lockGlobalsShared();
+    defer vm.unlockGlobalsShared();
     return vm.globals.get("equal?") orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
 }
 
 fn hashTableHashFn(args: []const Value) PrimitiveError!Value {
     _ = try getHashTable("hash-table-hash-function", args[0]);
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
+    vm.lockGlobalsShared();
+    defer vm.unlockGlobalsShared();
     return vm.globals.get("hash") orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
 }

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -215,7 +215,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
         return result;
     }
 
-    const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, &vm.globals) catch return PrimitiveError.TypeError;
+    const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return PrimitiveError.TypeError;
     var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
     compiler_mod.Compiler.unrootFunction(gc, func);
     gc.pushRoot(&closure_val) catch return PrimitiveError.OutOfMemory;
@@ -309,7 +309,7 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
     while (reader.hasMore() catch return PrimitiveError.TypeError) { // bare-ok: reader error in load
         const expr = reader.readDatum() catch return PrimitiveError.TypeError;
 
-        const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, &vm.globals) catch return PrimitiveError.TypeError;
+        const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return PrimitiveError.TypeError;
         {
             var func_val = types.makePointer(@ptrCast(func));
             gc.pushRoot(&func_val) catch return PrimitiveError.OutOfMemory;
@@ -376,7 +376,7 @@ fn interactionEnvironmentFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
-    return gc.allocEnvironment(&vm.globals, false) catch return PrimitiveError.OutOfMemory;
+    return gc.allocEnvironment(vm.globals, false) catch return PrimitiveError.OutOfMemory;
 }
 
 fn nullEnvironmentFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -121,7 +121,10 @@ fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
 
     // If pred is a record instance, try char-set-contains?
     if (types.isRecordInstance(pred)) {
-        const cs_contains = vm.globals.get("char-set-contains?") orelse return PrimitiveError.TypeError;
+        vm.lockGlobalsShared();
+        const cs_contains_opt = vm.globals.get("char-set-contains?");
+        vm.unlockGlobalsShared();
+        const cs_contains = cs_contains_opt orelse return PrimitiveError.TypeError;
         const result = vm.callWithArgs(cs_contains, &[_]Value{ pred, char_val }) catch |err| {
             return switch (err) {
                 vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -743,7 +743,7 @@ pub fn repl(vm: *vm_mod.VM) !void {
             if (types.isPair(expr) and types.isSymbol(types.car(expr))) {
                 const ename = types.symbolName(types.car(expr));
                 if (vm.macros.get(ename)) |transformer| {
-                    const expanded = expander.expandMacro(vm.gc, expr, transformer, &vm.globals, &vm.macros) catch {
+                    const expanded = expander.expandMacro(vm.gc, expr, transformer, vm.globals, &vm.macros) catch {
                         writeStderr("expansion error\n");
                         input_buf.clearRetainingCapacity();
                         continue;
@@ -994,13 +994,13 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
                     writeStdout("\n");
                 }
                 if (mode == .store_last) {
-                    vm.globals.put("_", dr) catch {};
+                    vm.globalsPut("_", dr) catch {};
                 }
             }
             continue;
         }
 
-        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, &vm.globals, 0, "<repl>") catch |err| {
+        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, 0, "<repl>") catch |err| {
             const lc = r.getLineCol();
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "<repl>:{d}: compile error: {}\n", .{ lc.line, err }) catch "compile error\n";
@@ -1057,7 +1057,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
                 writeStdout("\n");
             }
             if (mode == .store_last) {
-                vm.globals.put("_", result) catch {};
+                vm.globalsPut("_", result) catch {};
             }
         }
     }

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -27,7 +27,7 @@ export fn kaappi_runtime_init() callconv(.c) ?*vm_mod.VM {
         return null;
     };
     primitives.setGCInstance(&rt_gc);
-    library.registerStandardLibraries(&vm.libraries, &vm.globals) catch {
+    library.registerStandardLibraries(&vm.libraries, vm.globals) catch {
         vm.deinit();
         allocator.destroy(vm);
         return null;

--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -12,6 +12,6 @@ pub fn makeTestVM(gc: *memory.GC) !VM {
     var vm = try VM.init(gc);
     primitives_mod.setGCInstance(gc);
     try primitives_mod.registerAll(&vm);
-    try library_mod.registerStandardLibraries(&vm.libraries, &vm.globals);
+    try library_mod.registerStandardLibraries(&vm.libraries, vm.globals);
     return vm;
 }

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -80,7 +80,7 @@ test "fuzz eval" {
             vm_mod.setVMInstance(vm);
             primitives.registerAll(vm) catch return;
             primitives.setGCInstance(&gc);
-            library.registerStandardLibraries(&vm.libraries, &vm.globals) catch return;
+            library.registerStandardLibraries(&vm.libraries, vm.globals) catch return;
             vm.timeout_deadline_ns = @import("vm_calls.zig").clockNs() + 100_000_000;
             _ = vm.eval(input) catch return;
         }

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -7,6 +7,58 @@ const primitives = @import("primitives.zig");
 const srfi18 = @import("primitives_srfi18.zig");
 const vm_mod = @import("vm.zig");
 
+// Regression for the #958 globals read race: VM.initForThread used to share
+// the parent's globals map by struct copy, so the child's copied header kept
+// pointing at the old bucket array after any parent-side rehash — every
+// subsequent child lookup read freed memory and never saw newer bindings.
+// Sharing by pointer makes the child's view track the parent's map across
+// rehashes. This test is single-threaded on purpose: it checks the sharing
+// mechanics deterministically, without depending on race timing.
+test "child VM globals view survives parent-side rehash (#958)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    var child_gc = memory.GC.initForThread(std.testing.allocator, &gc);
+    defer child_gc.deinit();
+    var child_vm = try vm_mod.VM.initForThread(&child_gc, &vm);
+    defer child_vm.deinit();
+
+    try vm.defineGlobal("race-counter", types.makeFixnum(1));
+
+    // Force the parent's globals map through several rehashes.
+    var names: std.ArrayList([]u8) = .empty;
+    defer {
+        for (names.items) |n| std.testing.allocator.free(n);
+        names.deinit(std.testing.allocator);
+    }
+    var i: usize = 0;
+    while (i < 4000) : (i += 1) {
+        const name = try std.fmt.allocPrint(std.testing.allocator, "rehash-global-{d}", .{i});
+        try names.append(std.testing.allocator, name);
+        try vm.defineGlobal(name, types.makeFixnum(@intCast(i)));
+    }
+
+    // A binding added after the rehashes must be visible to the child.
+    try vm.defineGlobal("late-global", types.makeFixnum(4242));
+    const late = child_vm.globals.get("late-global");
+    try std.testing.expect(late != null);
+    try std.testing.expectEqual(@as(i64, 4242), types.toFixnum(late.?));
+
+    // An in-place update of a pre-existing binding lands in the parent's
+    // current bucket array; the child must read that array, not a stale copy.
+    try vm.defineGlobal("race-counter", types.makeFixnum(99));
+    const counter = child_vm.globals.get("race-counter");
+    try std.testing.expect(counter != null);
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(counter.?));
+
+    // A binding defined mid-rehash-burst must be visible too.
+    const mid = child_vm.globals.get(names.items[2000]);
+    try std.testing.expect(mid != null);
+    try std.testing.expectEqual(@as(i64, 2000), types.toFixnum(mid.?));
+}
+
 // Regression test: thread-terminate! on a busy-looping OS thread must stop
 // it so thread-join! returns (raising terminated-thread-exception) instead of
 // blocking forever in pthread_join. The child VM polls fiber.terminated at

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -43,6 +43,81 @@ pub fn setVMInstance(vm: *VM) void {
     vm_instance = vm;
 }
 
+/// Minimal portable reader-writer spinlock (Zig 0.16 has no blocking
+/// std.Thread.RwLock; std.Io.RwLock needs an Io instance). Same approach as
+/// memory.zig's symbol_mutex spinlock. Writer-preferring: once a writer sets
+/// its bit, new readers spin, existing readers drain, then the writer runs.
+/// Critical sections here are single hash-map operations, so spinning is
+/// bounded and short. Not reentrant — never nest acquisitions.
+pub const GlobalsRwLock = struct {
+    /// Bit 31 = writer holds/wants the lock; low 31 bits = active readers.
+    state: std.atomic.Value(u32) = .init(0),
+
+    const WRITER: u32 = 0x8000_0000;
+
+    pub fn lockShared(self: *GlobalsRwLock) void {
+        while (true) {
+            const s = self.state.load(.monotonic);
+            if (s & WRITER == 0) {
+                if (self.state.cmpxchgWeak(s, s + 1, .acquire, .monotonic) == null) return;
+            }
+            std.atomic.spinLoopHint();
+        }
+    }
+
+    pub fn unlockShared(self: *GlobalsRwLock) void {
+        _ = self.state.fetchSub(1, .release);
+    }
+
+    pub fn lock(self: *GlobalsRwLock) void {
+        // Claim the writer bit (excludes other writers, stops new readers) …
+        while (true) {
+            const s = self.state.load(.monotonic);
+            if (s & WRITER == 0) {
+                if (self.state.cmpxchgWeak(s, s | WRITER, .acquire, .monotonic) == null) break;
+            }
+            std.atomic.spinLoopHint();
+        }
+        // … then wait for in-flight readers to drain.
+        while (self.state.load(.acquire) != WRITER) std.atomic.spinLoopHint();
+    }
+
+    pub fn unlock(self: *GlobalsRwLock) void {
+        self.state.store(0, .release);
+    }
+};
+
+/// Take the exclusive globals lock if `map` is the current thread's shared
+/// globals map, for compile-time code that only holds a map pointer (body
+/// prescans, macro-expansion temp globals). Returns the lock to hand to
+/// releaseGlobalsWrite, or null when no locking applies: `map` is a library
+/// env, or no VM is registered on this thread yet (startup — no child
+/// threads can exist before the first execute()).
+pub fn acquireGlobalsWrite(map: *const std.StringHashMap(Value)) ?*GlobalsRwLock {
+    const vm = vm_instance orelse return null;
+    if (@as(*const std.StringHashMap(Value), vm.globals) != map) return null;
+    vm.globals_lock.lock();
+    return vm.globals_lock;
+}
+
+pub fn releaseGlobalsWrite(lock: ?*GlobalsRwLock) void {
+    if (lock) |l| l.unlock();
+}
+
+/// Shared-lock counterpart of acquireGlobalsWrite for read-only compile-time
+/// access. No-ops on the owner thread (its reads cannot race its own writes).
+pub fn acquireGlobalsRead(map: *const std.StringHashMap(Value)) ?*GlobalsRwLock {
+    const vm = vm_instance orelse return null;
+    if (vm.owns_globals) return null;
+    if (@as(*const std.StringHashMap(Value), vm.globals) != map) return null;
+    vm.globals_lock.lockShared();
+    return vm.globals_lock;
+}
+
+pub fn releaseGlobalsRead(lock: ?*GlobalsRwLock) void {
+    if (lock) |l| l.unlockShared();
+}
+
 /// Mark the VM's live roots during a GC cycle: the register window of every
 /// active call frame, the frame closures, the exception-handler stack,
 /// dynamic-wind thunks, the in-flight exception, and the global/macro tables.
@@ -187,7 +262,23 @@ pub const VM = struct {
     registers: []Value,
     frames: []CallFrame,
     frame_count: usize = 0,
-    globals: std.StringHashMap(Value),
+    /// Heap-allocated and shared BY POINTER with SRFI-18 child-thread VMs
+    /// (initForThread), so a parent-side rehash is seen by children instead
+    /// of leaving them on a freed bucket array (#958). Access protocol
+    /// (globals_lock):
+    ///   - structural mutation (put/remove — may rehash and free the bucket
+    ///     array) takes the exclusive lock, on any thread;
+    ///   - child threads (owns_globals == false) take the shared lock for
+    ///     every map read;
+    ///   - the owner thread reads lock-free: it is the only thread expected
+    ///     to structurally mutate the map, so its own reads cannot race.
+    /// Known gap: a child that defines globals via `eval` takes the exclusive
+    /// lock (protecting other children), but the owner's lock-free reads can
+    /// still race such writes — same limitation PR #968 documented for child
+    /// writes. The `macros` and `libraries` maps are still shared by struct
+    /// copy and have the analogous (much rarer) staleness hazard.
+    globals: *std.StringHashMap(Value),
+    globals_lock: *GlobalsRwLock,
     macros: std.StringHashMap(Value),
     output: std.ArrayList(u8),
     libraries: library_mod.LibraryRegistry,
@@ -267,11 +358,18 @@ pub const VM = struct {
         errdefer gc.allocator.free(frames);
         const registers = try gc.allocator.alloc(Value, INITIAL_REGISTER_CAPACITY);
         errdefer gc.allocator.free(registers);
+        const globals_map = try gc.allocator.create(std.StringHashMap(Value));
+        errdefer gc.allocator.destroy(globals_map);
+        globals_map.* = std.StringHashMap(Value).init(gc.allocator);
+        const globals_lock = try gc.allocator.create(GlobalsRwLock);
+        errdefer gc.allocator.destroy(globals_lock);
+        globals_lock.* = .{};
         var vm = VM{
             .gc = gc,
             .frames = frames,
             .registers = registers,
-            .globals = std.StringHashMap(Value).init(gc.allocator),
+            .globals = globals_map,
+            .globals_lock = globals_lock,
             .macros = std.StringHashMap(Value).init(gc.allocator),
             .output = .empty,
             .libraries = library_mod.LibraryRegistry.init(gc.allocator),
@@ -300,7 +398,12 @@ pub const VM = struct {
             .gc = gc,
             .frames = frames,
             .registers = registers,
+            // Shared by pointer: the child sees the parent's map through
+            // every rehash. Reads on this VM take the shared lock (see the
+            // `globals` field doc); a struct copy here would leave the child
+            // on a freed bucket array after the first parent-side rehash.
             .globals = parent.globals,
+            .globals_lock = parent.globals_lock,
             .macros = parent.macros,
             .output = .empty,
             .libraries = parent.libraries,
@@ -332,6 +435,8 @@ pub const VM = struct {
         }
         if (self.owns_globals) {
             self.globals.deinit();
+            self.gc.allocator.destroy(self.globals);
+            self.gc.allocator.destroy(self.globals_lock);
             self.macros.deinit();
             self.libraries.deinit();
         }
@@ -408,6 +513,10 @@ pub const VM = struct {
     pub fn findSimilarName(self: *VM, name: []const u8) ?[]const u8 {
         var best: ?[]const u8 = null;
         var best_dist: usize = 4;
+        // Locks internally — callers (dispatch error paths) must not hold
+        // the globals lock when calling this.
+        self.lockGlobalsShared();
+        defer self.unlockGlobalsShared();
         var iter = self.globals.keyIterator();
         while (iter.next()) |key| {
             const candidate = key.*;
@@ -512,8 +621,31 @@ pub const VM = struct {
         return self.last_stack_trace[0..self.last_stack_trace_len];
     }
 
-    pub fn defineGlobal(self: *VM, name: []const u8, value: Value) !void {
+    // -- Shared-globals locking (see the `globals` field doc) --
+
+    /// Take the globals read lock if this VM shares another VM's globals
+    /// (SRFI-18 child thread). The owner reads lock-free. Never nest: a
+    /// second lockShared while a writer is queued can deadlock.
+    pub inline fn lockGlobalsShared(self: *VM) void {
+        if (!self.owns_globals) self.globals_lock.lockShared();
+    }
+
+    pub inline fn unlockGlobalsShared(self: *VM) void {
+        if (!self.owns_globals) self.globals_lock.unlockShared();
+    }
+
+    /// Insert/overwrite a globals binding under the exclusive lock, so a
+    /// concurrent child-thread reader never observes a rehash in progress.
+    /// Does not bump global_version — use defineGlobal for definition
+    /// semantics.
+    pub fn globalsPut(self: *VM, name: []const u8, value: Value) !void {
+        self.globals_lock.lock();
+        defer self.globals_lock.unlock();
         try self.globals.put(name, value);
+    }
+
+    pub fn defineGlobal(self: *VM, name: []const u8, value: Value) !void {
+        try self.globalsPut(name, value);
         self.global_version +%= 1;
     }
 

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -161,7 +161,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const closure = frame.closure orelse return VMError.InvalidBytecode;
                 const func = closure.func;
                 const dst_idx = try registerIndex(self, frame.base, dst);
-                const env: *std.StringHashMap(Value) = func.env orelse &self.globals;
+                const env: *std.StringHashMap(Value) = func.env orelse self.globals;
                 if (func.env == null) {
                     if (func.global_cache) |cache| {
                         if (func.cache_version == self.global_version and
@@ -179,25 +179,28 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const sym = try constantAt(self, func, sym_idx);
                 if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                 const name = types.symbolName(sym);
-                const val = env.get(name) orelse blk: {
+                // Map reads under the child-thread shared lock; the error
+                // path runs after release (findSimilarName locks internally).
+                self.lockGlobalsShared();
+                const found: ?Value = env.get(name) orelse blk: {
                     if (func.env != null) {
                         if (self.globals.get(name)) |gval| break :blk gval;
                     }
                     const base = stripHygienicPrefix(name);
                     if (base.len != name.len) {
                         if (env.get(base)) |bval| break :blk bval;
-                        if (env != &self.globals) {
+                        if (env != self.globals) {
                             if (self.globals.get(base)) |gval| break :blk gval;
                         }
                     }
+                    break :blk null;
+                };
+                self.unlockGlobalsShared();
+                const val = found orelse {
                     if (self.findSimilarName(name)) |suggestion| {
                         self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, suggestion });
                     } else {
-                        if (self.findSimilarName(name)) |sug| {
-                            self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
-                        } else {
-                            self.setErrorDetail("undefined variable '{s}'", .{name});
-                        }
+                        self.setErrorDetail("undefined variable '{s}'", .{name});
                     }
                     return VMError.UndefinedVariable;
                 };
@@ -220,27 +223,38 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const closure = frame.closure orelse return VMError.InvalidBytecode;
                 const func = closure.func;
                 const src_idx = try registerIndex(self, frame.base, src);
-                const env: *std.StringHashMap(Value) = func.env orelse &self.globals;
+                const env: *std.StringHashMap(Value) = func.env orelse self.globals;
                 const sym = try constantAt(self, func, sym_idx);
                 if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                 const name = types.symbolName(sym);
+                const val = self.registers[src_idx];
                 // Mirror get_global's hygienic-prefix fallback: a template
                 // set! to a definition-site global compiles as set_global on
                 // the renamed name (__hyg_N_foo); writes must reach the same
                 // binding reads resolve to.
-                const ptr = env.getPtr(name) orelse blk: {
+                //
+                // Both the getPtr and the store through it stay inside the
+                // locked region: a parent-side rehash between them would
+                // leave `ptr` dangling on a child thread. The store itself
+                // is an in-place update (no rehash), so the shared lock is
+                // sufficient.
+                self.lockGlobalsShared();
+                const ptr: ?*Value = env.getPtr(name) orelse blk: {
                     const base = stripHygienicPrefix(name);
                     if (base.len != name.len) {
                         if (env.getPtr(base)) |bptr| break :blk bptr;
-                        if (env != &self.globals) {
+                        if (env != self.globals) {
                             if (self.globals.getPtr(base)) |gptr| break :blk gptr;
                         }
                     }
+                    break :blk null;
+                };
+                if (ptr) |p| p.* = val;
+                self.unlockGlobalsShared();
+                if (ptr == null) {
                     self.setErrorDetail("set!: unbound variable '{s}'", .{name});
                     return VMError.UndefinedVariable;
-                };
-                const val = self.registers[src_idx];
-                ptr.* = val;
+                }
                 if (func.env == null) {
                     self.global_version +%= 1;
                     if (func.global_cache) |cache| {
@@ -262,12 +276,20 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const closure = frame.closure orelse return VMError.InvalidBytecode;
                 const func = closure.func;
                 const src_idx = try registerIndex(self, frame.base, src);
-                const env: *std.StringHashMap(Value) = func.env orelse &self.globals;
+                const env: *std.StringHashMap(Value) = func.env orelse self.globals;
                 const sym = try constantAt(self, func, sym_idx);
                 if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                 const name = types.symbolName(sym);
                 const val = self.registers[src_idx];
-                env.put(name, val) catch return VMError.OutOfMemory;
+                if (env == self.globals) {
+                    // Structural mutation of the shared globals map: may
+                    // rehash, so it must exclude child-thread readers.
+                    self.globals_lock.lock();
+                    defer self.globals_lock.unlock();
+                    env.put(name, val) catch return VMError.OutOfMemory;
+                } else {
+                    env.put(name, val) catch return VMError.OutOfMemory;
+                }
                 if (func.env == null) {
                     self.global_version +%= 1;
                     if (func.global_cache) |cache| {
@@ -825,7 +847,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const nargs = readU8(self, frame);
                 const the_closure = frame.closure orelse return VMError.InvalidBytecode;
                 const the_func = the_closure.func;
-                const env: *std.StringHashMap(Value) = the_func.env orelse &self.globals;
+                const env: *std.StringHashMap(Value) = the_func.env orelse self.globals;
                 const base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, base_wide, nargs);
                 const base: u32 = try toBase(base_wide);
@@ -840,11 +862,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             const sym = try constantAt(self, the_func, sym_idx);
                             if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                             const name = types.symbolName(sym);
-                            const val = env.get(name) orelse val_blk: {
+                            self.lockGlobalsShared();
+                            const found: ?Value = env.get(name) orelse val_blk: {
                                 const b = stripHygienicPrefix(name);
                                 if (b.len != name.len) {
                                     if (env.get(b)) |bval| break :val_blk bval;
                                 }
+                                break :val_blk null;
+                            };
+                            self.unlockGlobalsShared();
+                            const val = found orelse {
                                 if (self.findSimilarName(name)) |sug| {
                                     self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
                                 } else {
@@ -861,11 +888,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         const sym = try constantAt(self, the_func, sym_idx);
                         if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                         const name = types.symbolName(sym);
-                        const val = env.get(name) orelse val_blk2: {
+                        self.lockGlobalsShared();
+                        const found: ?Value = env.get(name) orelse val_blk2: {
                             const b = stripHygienicPrefix(name);
                             if (b.len != name.len) {
                                 if (env.get(b)) |bval| break :val_blk2 bval;
                             }
+                            break :val_blk2 null;
+                        };
+                        self.unlockGlobalsShared();
+                        const val = found orelse {
                             if (self.findSimilarName(name)) |sug| {
                                 self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
                             } else {
@@ -894,7 +926,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const sym = try constantAt(self, the_func, sym_idx);
                     if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                     const name = types.symbolName(sym);
-                    const val = env.get(name) orelse {
+                    self.lockGlobalsShared();
+                    const found = env.get(name);
+                    self.unlockGlobalsShared();
+                    const val = found orelse {
                         if (self.findSimilarName(name)) |sug| {
                             self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
                         } else {
@@ -949,7 +984,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const nargs = readU8(self, frame);
                 const closure = frame.closure orelse return VMError.InvalidBytecode;
                 const func = closure.func;
-                const env: *std.StringHashMap(Value) = func.env orelse &self.globals;
+                const env: *std.StringHashMap(Value) = func.env orelse self.globals;
                 const abs_base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, abs_base_wide, nargs);
                 const abs_base: u32 = try toBase(abs_base_wide);
@@ -968,11 +1003,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const sym = try constantAt(self, func, sym_idx);
                     if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                     const name = types.symbolName(sym);
-                    callee = env.get(name) orelse callee_blk: {
+                    self.lockGlobalsShared();
+                    const found: ?Value = env.get(name) orelse callee_blk: {
                         const b = stripHygienicPrefix(name);
                         if (b.len != name.len) {
                             if (env.get(b)) |bval| break :callee_blk bval;
                         }
+                        break :callee_blk null;
+                    };
+                    self.unlockGlobalsShared();
+                    callee = found orelse {
                         if (self.findSimilarName(name)) |sug| {
                             self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, sug });
                         } else {

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -20,7 +20,7 @@ pub fn eval(vm: *VM, source: []const u8) VMError!Value {
             last_result = result catch |err| return err;
             continue;
         }
-        const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
+        const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return VMError.CompileError;
         {
             var func_val = types.makePointer(@ptrCast(func));
             vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
@@ -59,7 +59,7 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
         if (handleTopLevelForm(vm, form)) |result| {
             last = result catch |err| return err;
         } else {
-            const func = compiler_mod.compileExpressionWithMacros(vm.gc, form, &vm.macros, &vm.globals) catch return VMError.CompileError;
+            const func = compiler_mod.compileExpressionWithMacros(vm.gc, form, &vm.macros, vm.globals) catch return VMError.CompileError;
             var func_val = types.makePointer(@ptrCast(func));
             vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
             defer vm.gc.popRoot();
@@ -80,7 +80,7 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
     if (!types.isPair(rest)) return VMError.CompileError;
     const expr = types.car(rest);
 
-    const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
+    const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return VMError.CompileError;
     var func_val = types.makePointer(@ptrCast(func));
     vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
     defer vm.gc.popRoot();
@@ -103,8 +103,7 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
                 j -= 1;
                 list = vm.gc.allocPair(mv2.values[j], list) catch return VMError.OutOfMemory;
             }
-            vm.globals.put(types.symbolName(formals), list) catch return VMError.OutOfMemory;
-            vm.global_version +%= 1;
+            vm.defineGlobal(types.symbolName(formals), list) catch return VMError.OutOfMemory;
         } else {
             var formal = formals;
             var i: usize = 0;
@@ -125,8 +124,7 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
                         j -= 1;
                         rest_list = vm.gc.allocPair(mv2.values[j], rest_list) catch return VMError.OutOfMemory;
                     }
-                    vm.globals.put(types.symbolName(formal), rest_list) catch return VMError.OutOfMemory;
-                    vm.global_version +%= 1;
+                    vm.defineGlobal(types.symbolName(formal), rest_list) catch return VMError.OutOfMemory;
                     formal = types.NIL;
                     i = mv.values.len;
                     break;
@@ -134,8 +132,7 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
                 if (!types.isPair(formal)) return VMError.CompileError;
                 const var_sym = types.car(formal);
                 if (!types.isSymbol(var_sym)) return VMError.CompileError;
-                vm.globals.put(types.symbolName(var_sym), mv.values[i]) catch return VMError.OutOfMemory;
-                vm.global_version +%= 1;
+                vm.defineGlobal(types.symbolName(var_sym), mv.values[i]) catch return VMError.OutOfMemory;
                 formal = types.cdr(formal);
                 i += 1;
             }
@@ -151,17 +148,14 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
             vm.gc.pushRoot(&result_root) catch return VMError.OutOfMemory;
             defer vm.gc.popRoot();
             const list = vm.gc.allocPair(result_root, types.NIL) catch return VMError.OutOfMemory;
-            vm.globals.put(types.symbolName(formals), list) catch return VMError.OutOfMemory;
-            vm.global_version +%= 1;
+            vm.defineGlobal(types.symbolName(formals), list) catch return VMError.OutOfMemory;
         } else if (types.isPair(formals)) {
             const var_sym = types.car(formals);
             if (types.isSymbol(var_sym)) {
-                vm.globals.put(types.symbolName(var_sym), result) catch return VMError.OutOfMemory;
-                vm.global_version +%= 1;
+                vm.defineGlobal(types.symbolName(var_sym), result) catch return VMError.OutOfMemory;
                 const next = types.cdr(formals);
                 if (types.isSymbol(next)) {
-                    vm.globals.put(types.symbolName(next), types.NIL) catch return VMError.OutOfMemory;
-                    vm.global_version +%= 1;
+                    vm.defineGlobal(types.symbolName(next), types.NIL) catch return VMError.OutOfMemory;
                 }
             }
         }

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -12,9 +12,18 @@ const VMError = vm_mod.VMError;
 
 /// Import a binding into the target environment, routing macros to vm.macros.
 fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, val: Value) !void {
-    target.put(name, val) catch return error.OutOfMemory;
+    if (target == vm.globals) {
+        // Structural put into the shared globals map — exclude concurrent
+        // child-thread readers (#958). Held only around the put; the
+        // transformer recursion below takes the lock again per insert.
+        vm.globals_lock.lock();
+        defer vm.globals_lock.unlock();
+        target.put(name, val) catch return error.OutOfMemory;
+    } else {
+        target.put(name, val) catch return error.OutOfMemory;
+    }
     if (types.isTransformer(val)) {
-        if (target == &vm.globals) {
+        if (target == vm.globals) {
             vm.macros.put(name, val) catch return error.OutOfMemory;
         }
         const tx = types.toObject(val).as(types.Transformer);
@@ -23,7 +32,7 @@ fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, v
         try copyTransformerFreeRefs(vm, target, tx, &visited, 0);
         return;
     }
-    if (target == &vm.globals) {
+    if (target == vm.globals) {
         vm.global_version +%= 1;
     }
 }
@@ -62,9 +71,19 @@ fn copyTransformerFreeRefs(
         _ = passthrough.collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &free_names, &free_count);
         for (free_names[0..free_count]) |fname| {
             if (env.get(fname)) |fval| {
-                if (!target.contains(fname)) {
+                if (target == vm.globals) {
+                    vm.globals_lock.lock();
+                    const missing = !target.contains(fname);
+                    if (missing) {
+                        target.put(fname, fval) catch {
+                            vm.globals_lock.unlock();
+                            return error.OutOfMemory;
+                        };
+                    }
+                    vm.globals_lock.unlock();
+                    if (missing) vm.global_version +%= 1;
+                } else if (!target.contains(fname)) {
                     target.put(fname, fval) catch return error.OutOfMemory;
-                    if (target == &vm.globals) vm.global_version +%= 1;
                 }
                 if (types.isTransformer(fval)) {
                     // An exported macro may expand into a library-internal
@@ -74,7 +93,7 @@ fn copyTransformerFreeRefs(
                     // so the compiler expands it at the use site. This is the
                     // only leg that reaches vm.macros, keeping importBinding the
                     // sole path into it (issue #877).
-                    if (target == &vm.globals and !vm.macros.contains(fname)) {
+                    if (target == vm.globals and !vm.macros.contains(fname)) {
                         vm.macros.put(fname, fval) catch return error.OutOfMemory;
                     }
                     try copyTransformerFreeRefs(vm, target, types.toObject(fval).as(types.Transformer), visited, depth + 1);
@@ -109,7 +128,7 @@ pub fn handleImportInto(vm: *VM, target: *std.StringHashMap(Value), args: Value)
 
 /// Handle (import import-set ...) — top-level variant that imports into vm.globals.
 pub fn handleImport(vm: *VM, args: Value) VMError!Value {
-    return handleImportInto(vm, &vm.globals, args);
+    return handleImportInto(vm, vm.globals, args);
 }
 
 /// Ensure a library is loaded and registered. If already in vm.libraries, no-op.
@@ -242,7 +261,7 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
         if (vm.handleTopLevelForm(expr)) |result| {
             _ = result catch |err| return err;
         } else {
-            const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, &vm.globals) catch return error.InvalidSyntax;
+            const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return error.InvalidSyntax;
             var func_val = types.makePointer(@ptrCast(func));
             try vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
@@ -577,7 +596,7 @@ fn evalIncludedForm(vm: *VM, expr: Value, path: []const u8, line: u32) void {
         return;
     }
 
-    const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, &vm.globals) catch |err| {
+    const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch |err| {
         reportIncludeError(vm, path, line, null, err);
         return;
     };

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -103,9 +103,12 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
     // Intern the name via allocSymbol so it persists
     const internal_sym = vm.gc.allocSymbol(internal_name_buf) catch return VMError.OutOfMemory;
     const internal_name = types.symbolName(internal_sym);
-    const target_env: *std.StringHashMap(Value) = vm.current_lib_env orelse &vm.globals;
-    target_env.put(internal_name, rt_val) catch return VMError.OutOfMemory;
-    if (vm.current_lib_env == null) vm.global_version +%= 1;
+    if (vm.current_lib_env) |lib_env| {
+        lib_env.put(internal_name, rt_val) catch return VMError.OutOfMemory;
+    } else {
+        // Locked structural put + version bump (#958).
+        vm.defineGlobal(internal_name, rt_val) catch return VMError.OutOfMemory;
+    }
 
     // Map constructor field names to their indices in the all_fields array
     var ctor_field_indices: [256]usize = undefined;
@@ -184,7 +187,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         const func = if (vm.current_lib_env) |env|
             compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL) catch return VMError.CompileError
         else
-            compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
+            compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
         const func_val = types.makePointer(@ptrCast(func));
         body_list = func_val;
         compiler_mod.Compiler.unrootFunction(vm.gc, func);
@@ -211,7 +214,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         const func = if (vm.current_lib_env) |env|
             compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL) catch return VMError.CompileError
         else
-            compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
+            compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
         define_expr = types.makePointer(@ptrCast(func));
         compiler_mod.Compiler.unrootFunction(vm.gc, func);
         _ = vm.execute(func) catch |err| return err;
@@ -239,7 +242,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const func = if (vm.current_lib_env) |env|
                 compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL) catch return VMError.CompileError
             else
-                compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
+                compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(@ptrCast(func));
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = vm.execute(func) catch |err| return err;
@@ -266,7 +269,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const func = if (vm.current_lib_env) |env|
                 compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL) catch return VMError.CompileError
             else
-                compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, &vm.globals) catch return VMError.CompileError;
+                compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(@ptrCast(func));
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = vm.execute(func) catch |err| return err;

--- a/tests/scheme/srfi/srfi18-globals-rehash.scm
+++ b/tests/scheme/srfi/srfi18-globals-rehash.scm
@@ -1,0 +1,42 @@
+;; Regression test for issue #958 (globals read race, follow-up to PR #968):
+;; a child thread's view of the globals map must track the parent's map
+;; across rehashes. Before the fix, VM.initForThread copied the map header
+;; by value, so the first parent-side rehash left the child reading the old
+;; (freed) bucket array forever — a set! that landed in the new array was
+;; never observed by the child, and this test timed out.
+;;
+;; The parent defines enough fresh globals to force several rehashes while
+;; the child polls a global, then flips the flag. Deterministic given the
+;; fix: the child sees 'go on its next locked read.
+
+(import (scheme base) (scheme write) (srfi 18))
+
+(define flag 'wait)
+
+(define child
+  (make-thread
+   (lambda ()
+     (let loop ((i 0))
+       (cond ((eq? flag 'go) 'saw-it)
+             ((> i 50000000) 'timeout)
+             (else (loop (+ i 1))))))))
+
+(thread-start! child)
+
+;; Force the parent globals map through multiple rehashes while the child runs.
+(let loop ((i 0))
+  (when (< i 3000)
+    (eval (list 'define
+                (string->symbol (string-append "rehash-var-" (number->string i)))
+                i))
+    (loop (+ i 1))))
+
+(set! flag 'go)
+
+(let ((r (thread-join! child)))
+  (if (eq? r 'saw-it)
+      (begin (display "OK") (newline))
+      (begin (display "FAIL: child never observed post-rehash write: ")
+             (display r)
+             (newline)
+             (exit 1))))


### PR DESCRIPTION
Follow-up to #968, which fixed the child WRITE path for #958 and documented the remaining globals **read race** as a known gap. This closes that gap.

## The bug (reproduces on current main)

`VM.initForThread` shared the parent's globals `StringHashMap` **by struct copy**. Two failure modes:

1. **Use-after-free:** a parent-side `put()` that triggers a rehash reallocates the bucket array and frees the old one — which the child's copied header still points to. Every subsequent child global lookup reads freed memory.
2. **Permanent staleness:** even when the freed memory happens to survive, the child's copied header never tracks the parent's new array, so the child never sees bindings defined (or `set!`) after the first rehash.

The new regression test `tests/scheme/srfi/srfi18-globals-rehash.scm` (child polls a global while the parent defines 3000 fresh globals, then flips a flag) **bus-errors inside `hash_map.getIndex` on current main**, verified against a clean `origin/main` build:

```
Bus error at address 0x...
std/hash_map.zig:984:39: in getIndex (kaappi)
src/vm_dispatch.zig: in runUntil (kaappi)
src/primitives_srfi18.zig:301: in threadEntryFn (kaappi)
```

## The fix

Share by pointer + a reader-writer lock on the shared path only:

- `VM.globals` is now a heap-allocated `*StringHashMap(Value)` shared by pointer with child VMs, paired with a shared `VM.globals_lock`. A parent-side rehash is therefore *seen* by children instead of leaving them on a freed array.
- **Locking protocol** (documented on the field):
  - structural mutation (put/remove — anything that can rehash) takes the **exclusive** lock, on any thread;
  - child threads (`owns_globals == false`) take the **shared** lock for every map read;
  - **the owner thread reads lock-free** — it is the only thread expected to structurally mutate the map.
- Zig 0.16 has no blocking `std.Thread.RwLock` (`std.Io.RwLock` needs an `Io`), so `GlobalsRwLock` is a small portable writer-preferring spinlock in the same style as `memory.zig`'s `symbol_mutex`.
- Locked sites beyond the obvious dispatch handlers (`get/set/define/call/tail_call_global`, `findSimilarName`):
  - the **compile-time sentinel puts** in `compileBody`/`compileLetBody` prescans and `compiler.zig`'s macro-expansion temp-globals dance — the parent compiles top-level forms interleaved with execution, so these rehash-capable puts run while children execute. `vm.acquireGlobalsWrite(map)` engages only when the map is the current thread's shared globals (library envs pass through unlocked);
  - child-side eval-compile reads (hygiene in `expander.zig`, constant folding in `compiler_passthrough.zig`/`ir.zig`) via `acquireGlobalsRead`;
  - runtime read paths reachable from child threads in `primitives_hashtable.zig` / `primitives_string_ext.zig`;
  - import (`vm_library.zig`), `define-record-type` (`vm_records.zig`), `define-values` (`vm_eval.zig`), REPL `_`.
- `set_global` keeps the `getPtr` **and** the store through it inside one locked region — a rehash between them would leave the pointer dangling on a child.

## Parent fast-path benchmark

`get_global` is hot, so the owner path takes no lock — only a pointer deref plus a predicted `owns_globals` branch. Worst-case microbenchmarks (ReleaseSafe, macOS ARM, 50M uncached global reads / 20M global `set!`s, medians of repeated runs):

| bench | main | this PR | delta |
|---|---|---|---|
| uncached global read loop | 3.78s | 3.88s | ~+2.5% |
| global `set!` loop | 2.17s | 2.25s | ~+3% |

The closure/native inline-cache path (`func.global_cache`) is untouched and takes no lock.

## Tests

- `tests/scheme/srfi/srfi18-globals-rehash.scm` — deterministic end-to-end regression: bus-errors on main, passes here (the child observes a post-rehash `set!`).
- `src/tests_srfi18.zig` — single-threaded mechanical test that the child's view tracks the parent map across rehashes (late defines, in-place updates, mid-burst defines).
- Full suites green: `zig build test`, all 260 Scheme files + 1395 R7RS tests (0 timeouts), `zig build wasm`.

## Remaining known gaps (documented on the `globals` field)

- A child that defines globals via `eval` takes the exclusive lock (protecting other children), but the owner's lock-free reads can still race such writes — same class of limitation #968 documented for child writes.
- The `macros` and `libraries` maps are still shared by struct copy and have the analogous (much rarer) staleness hazard — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)