### PR TITLE
Print all values of a multiple-values result at the top level

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -112,6 +112,25 @@ fn usageError(msg: []const u8) noreturn {
     std.process.exit(USAGE_ERROR_EXIT);
 }
 
+// Multiple values print one per line, matching other Scheme REPLs
+// (Chez, Guile, Racket, Chibi). Void results print nothing.
+fn printTopLevelResult(allocator: std.mem.Allocator, result: types.Value) void {
+    if (types.isMultipleValues(result)) {
+        const mv = types.toObject(result).as(types.MultipleValues);
+        for (mv.values) |val| printSingleResult(allocator, val);
+    } else {
+        printSingleResult(allocator, result);
+    }
+}
+
+fn printSingleResult(allocator: std.mem.Allocator, value: types.Value) void {
+    if (value == types.VOID) return;
+    const s = printer.valueToString(allocator, value, .write) catch return;
+    defer allocator.free(s);
+    writeStdout(s);
+    writeStdout("\n");
+}
+
 fn printSourceSnippet(source: []const u8, line: u32) void {
     if (line == 0 or source.len == 0) return;
     var current_line: u32 = 1;
@@ -431,17 +450,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             };
             vm.gc.popRoot();
 
-            var display_result = result;
-            if (types.isMultipleValues(display_result)) {
-                const mv = types.toObject(display_result).as(types.MultipleValues);
-                display_result = if (mv.values.len > 0) mv.values[0] else types.VOID;
-            }
-            if (display_result != types.VOID) {
-                const s = printer.valueToString(allocator, display_result, .write) catch continue;
-                defer allocator.free(s);
-                writeStdout(s);
-                writeStdout("\n");
-            }
+            printTopLevelResult(allocator, result);
         }
         return;
     }
@@ -773,17 +782,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                 };
                 vm.gc.popRoot();
 
-                var display_result = result;
-                if (types.isMultipleValues(display_result)) {
-                    const mv = types.toObject(display_result).as(types.MultipleValues);
-                    display_result = if (mv.values.len > 0) mv.values[0] else types.VOID;
-                }
-                if (display_result != types.VOID) {
-                    const s = printer.valueToString(allocator, display_result, .write) catch continue;
-                    defer allocator.free(s);
-                    writeStdout(s);
-                    writeStdout("\n");
-                }
+                printTopLevelResult(allocator, result);
             }
             return;
         }
@@ -833,17 +832,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                 vm.last_error_detail_len = 0;
                 continue;
             };
-            var dr = result;
-            if (types.isMultipleValues(dr)) {
-                const mv = types.toObject(dr).as(types.MultipleValues);
-                dr = if (mv.values.len > 0) mv.values[0] else types.VOID;
-            }
-            if (dr != types.VOID) {
-                const s = printer.valueToString(allocator, dr, .write) catch continue;
-                defer allocator.free(s);
-                writeStdout(s);
-                writeStdout("\n");
-            }
+            printTopLevelResult(allocator, result);
             continue;
         }
 
@@ -901,18 +890,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         };
         vm.gc.popRoot();
 
-        // Unwrap MultipleValues for display (extract first value)
-        var display_result = result;
-        if (types.isMultipleValues(display_result)) {
-            const mv = types.toObject(display_result).as(types.MultipleValues);
-            display_result = if (mv.values.len > 0) mv.values[0] else types.VOID;
-        }
-        if (display_result != types.VOID) {
-            const s = printer.valueToString(allocator, display_result, .write) catch continue;
-            defer allocator.free(s);
-            writeStdout(s);
-            writeStdout("\n");
-        }
+        printTopLevelResult(allocator, result);
     }
 
     // Cache compiled bytecode (skip when imports are used — GC may have freed
@@ -969,17 +947,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
                 vm.last_error_detail_len = 0;
                 continue;
             };
-            var dr = result;
-            if (types.isMultipleValues(dr)) {
-                const mv = types.toObject(dr).as(types.MultipleValues);
-                dr = if (mv.values.len > 0) mv.values[0] else types.VOID;
-            }
-            if (dr != types.VOID) {
-                const s = printer.valueToString(allocator, dr, .write) catch continue;
-                defer allocator.free(s);
-                writeStdout(s);
-                writeStdout("\n");
-            }
+            printTopLevelResult(allocator, result);
             continue;
         }
 
@@ -1017,17 +985,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
         };
         vm.gc.popRoot();
 
-        var display_result = result;
-        if (types.isMultipleValues(display_result)) {
-            const mv = types.toObject(display_result).as(types.MultipleValues);
-            display_result = if (mv.values.len > 0) mv.values[0] else types.VOID;
-        }
-        if (display_result != types.VOID) {
-            const s = printer.valueToString(allocator, display_result, .write) catch continue;
-            defer allocator.free(s);
-            writeStdout(s);
-            writeStdout("\n");
-        }
+        printTopLevelResult(allocator, result);
     }
 }
 

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -935,6 +935,19 @@ fn describeSymbol(vm: *vm_mod.VM, allocator: std.mem.Allocator, name: []const u8
 
 const EvalMode = enum { normal, store_last, show_type };
 
+// Multiple values print one per line, matching other Scheme REPLs
+// (Chez, Guile, Racket, Chibi). Void values print nothing.
+fn printValuesLines(allocator: std.mem.Allocator, values: []const types.Value) void {
+    for (values) |val| {
+        if (val == types.VOID) continue;
+        const s = printer.prettyPrint(allocator, val, 80) catch
+            (printer.valueToString(allocator, val, .write) catch continue);
+        defer allocator.free(s);
+        writeStdout(s);
+        writeStdout("\n");
+    }
+}
+
 fn evalInputTyped(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u8, mode: EvalMode) void {
     evalInputInner(vm, allocator, input, mode);
 }
@@ -981,6 +994,13 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
             if (types.isMultipleValues(dr)) {
                 const mv = types.toObject(dr).as(types.MultipleValues);
                 dr = if (mv.values.len > 0) mv.values[0] else types.VOID;
+                if (mode != .show_type) {
+                    printValuesLines(allocator, mv.values);
+                    if (mode == .store_last and dr != types.VOID) {
+                        vm.globalsPut("_", dr) catch {};
+                    }
+                    continue;
+                }
             }
             if (dr != types.VOID) {
                 if (mode == .show_type) {
@@ -1044,20 +1064,32 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
         };
         vm.gc.popRoot();
 
-        if (result != types.VOID) {
+        var display_result = result;
+        if (types.isMultipleValues(display_result)) {
+            const mv = types.toObject(display_result).as(types.MultipleValues);
+            display_result = if (mv.values.len > 0) mv.values[0] else types.VOID;
+            if (mode != .show_type) {
+                printValuesLines(allocator, mv.values);
+                if (mode == .store_last and display_result != types.VOID) {
+                    vm.globalsPut("_", display_result) catch {};
+                }
+                continue;
+            }
+        }
+        if (display_result != types.VOID) {
             if (mode == .show_type) {
                 writeStdout("; ");
-                writeStdout(getTypeName(result));
+                writeStdout(getTypeName(display_result));
                 writeStdout("\n");
             } else {
-                const s = printer.prettyPrint(allocator, result, 80) catch
-                    (printer.valueToString(allocator, result, .write) catch continue);
+                const s = printer.prettyPrint(allocator, display_result, 80) catch
+                    (printer.valueToString(allocator, display_result, .write) catch continue);
                 defer allocator.free(s);
                 writeStdout(s);
                 writeStdout("\n");
             }
             if (mode == .store_last) {
-                vm.globalsPut("_", result) catch {};
+                vm.globalsPut("_", display_result) catch {};
             }
         }
     }

--- a/tests/scheme/smoke/repl-multiple-values.sh
+++ b/tests/scheme/smoke/repl-multiple-values.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Regression test: a multiple-values result at the top level prints every
+# value, one per line, matching other Scheme REPLs (Chez, Guile, Racket,
+# Chibi). Previously only the first value was printed:
+#   (values 3 2)  =>  3        (the 2 was silently dropped)
+# Covers piped-stdin mode and file mode (both fresh compile and .sbc cache).
+
+set -e
+
+KAAPPI="${1:-${KAAPPI:-zig-out/bin/kaappi}}"
+
+fail=0
+
+check() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label"
+        echo "  expected: $(printf '%q' "$expected")"
+        echo "  actual:   $(printf '%q' "$actual")"
+        fail=1
+    fi
+}
+
+# --- piped stdin mode ---
+check "stdin (values 3 2)" "$(printf '3\n2')" "$(echo '(values 3 2)' | $KAAPPI)"
+check "stdin (values) prints nothing" "" "$(echo '(values)' | $KAAPPI)"
+check "stdin single value unchanged" "3" "$(echo '(+ 1 2)' | $KAAPPI)"
+check "stdin procedure returning values" "$(printf '3\n2')" \
+    "$(printf '(define (divide a b) (values (quotient a b) (remainder a b)))\n(divide 17 5)\n' | $KAAPPI)"
+
+# --- file mode ---
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+printf '(values 3 2)\n(values)\n(values 42)\n' > "$tmpdir/mv.scm"
+check "file mode (fresh compile)" "$(printf '3\n2\n42')" "$($KAAPPI "$tmpdir/mv.scm")"
+check "file mode (cached .sbc)" "$(printf '3\n2\n42')" "$($KAAPPI "$tmpdir/mv.scm")"
+
+exit $fail


### PR DESCRIPTION
Fixes #972.

## Problem

Every top-level result-printing path truncated a multiple-values result to its first value — `(values 3 2)` printed just `3`. The interactive REPL's compiled path didn't unwrap at all and echoed the raw object (`#<values 3 2>`). Standard Schemes (Chez, Guile, Racket, Chibi) print all values, one per line. Discovered while reviewing the kaappi-book, which shows `(divide 17 5)` printing both `3` and `2` at the REPL.

## Changes

- **src/main.zig** — new `printTopLevelResult` helper replaces six copy-pasted first-value-only blocks (embedded-bytecode path, runFile cached/fresh/top-level-form paths, runStdin top-level-form/compiled paths). Each value prints on its own line; `(values)` and void values print nothing.
- **src/repl.zig** — new `printValuesLines` helper (pretty-printing, consistent with single-value REPL output) wired into both display paths of `evalInputInner`. Handles `.store_last` mode — the REPL main loop evaluates with it, not `.normal` — so `_` still binds the first value and `,type` still reports the first value's type.
- **tests/scheme/smoke/repl-multiple-values.sh** — regression test: stdin ×4 (multiple values, zero values, single value, procedure returning values) and file mode ×2 (fresh compile + `.sbc` cache), following the existing smoke `.sh` precedent.

## Verification

- New regression test passes; fails without the fix.
- Interactive REPL exercised through a real pty (`TERM=dumb`): `(values 3 2)` → `3` / `2`, `(values)` → nothing, `_` and `,type` behavior preserved.
- `-Dbundle-src` standalone binary prints all values.
- `zig build test` passes; full `tests/scheme/run-all.sh` passes (1395/1395 R7RS). The only failures seen during suite runs were confirmed pre-existing on unmodified main: the flaky #958 crash and an untracked `.sbc` cache-corruption bug (repro filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)