### PR TITLE
Deep-copy native_fn/native_closure instead of aliasing across heaps (#958 follow-up)

### DIFF
--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -250,7 +250,36 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
             new_tx.def_env_val = t.def_env_val;
             return new_val;
         },
-        .native_fn, .native_closure, .ffi_library, .ffi_function => src,
+        .native_fn => {
+            // The fn pointer and name are static (registered with string
+            // literals, or rodata in a native binary), but the NativeFn object
+            // itself lives in the source heap. Copy it so a thread result
+            // survives the child heap being freed after thread-join!.
+            const nf = obj.as(types.NativeFn);
+            const new_val = try gc.allocNativeFn(nf.name, nf.func, nf.arity);
+            try visited.put(src_ptr, new_val);
+            return new_val;
+        },
+        .native_closure => {
+            // fn_ptr and name are static (code and rodata of a native binary),
+            // but the object and its upvalues live in the source heap.
+            const nc = obj.as(types.NativeClosure);
+            const placeholders = try gc.allocator.alloc(Value, nc.upvalues.len);
+            defer gc.allocator.free(placeholders);
+            @memset(placeholders, types.VOID);
+            const new_val = try gc.allocNativeClosure(nc.fn_ptr, placeholders, nc.arity, nc.name);
+            try visited.put(src_ptr, new_val);
+            const new_nc = types.toObject(new_val).as(types.NativeClosure);
+            for (nc.upvalues, 0..) |uv, i| {
+                new_nc.upvalues[i] = try deepCopyValue(gc, uv, visited);
+            }
+            return new_val;
+        },
+        // FFI objects wrap process-global dlopen handles that cannot be
+        // duplicated per-heap, so they are aliased. Known limitation: an FFI
+        // handle created inside a child thread and returned through
+        // thread-join! dangles once the child heap is freed.
+        .ffi_library, .ffi_function => src,
         .srfi18_time => try gc.allocSrfi18Time(obj.as(types.Srfi18Time).seconds),
         .random_source => {
             const rs = obj.as(types.RandomSource);

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -378,6 +378,98 @@ test "deepCopy shared structure" {
     try std.testing.expectEqual(cv.data[0], cv.data[1]);
 }
 
+fn testAdd1(args: []const types.Value) anyerror!types.Value {
+    return types.makeFixnum(types.toFixnum(args[0]) + 1);
+}
+
+fn testNativeClosureFn(_: ?*@import("vm.zig").VM, _: [*]const types.Value, _: u64, _: [*]const types.Value) callconv(.c) u64 {
+    return types.NIL;
+}
+
+test "deepCopy native_fn is copied, not aliased" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    const nf_val = try gc1.allocNativeFn("test-add1", &testAdd1, .{ .exact = 1 });
+    const copied = try gc2.deepCopy(nf_val);
+
+    try std.testing.expect(nf_val != copied);
+    const copy = types.toObject(copied).as(types.NativeFn);
+    try std.testing.expectEqualStrings("test-add1", copy.name);
+    try std.testing.expectEqual(types.NativeFn.Arity{ .exact = 1 }, copy.arity);
+    try std.testing.expectEqual(types.makeFixnum(42), try copy.func(&.{types.makeFixnum(41)}));
+}
+
+test "deepCopy native_closure copies upvalues into the target heap" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    const pair = try gc1.allocPair(types.makeFixnum(7), types.NIL);
+    const upvalues = [_]types.Value{ pair, types.makeFixnum(3) };
+    const nc_val = try gc1.allocNativeClosure(&testNativeClosureFn, &upvalues, 2, "test-nc");
+    const copied = try gc2.deepCopy(nc_val);
+
+    try std.testing.expect(nc_val != copied);
+    const copy = types.toObject(copied).as(types.NativeClosure);
+    try std.testing.expectEqual(@as(u8, 2), copy.arity);
+    try std.testing.expectEqualStrings("test-nc", copy.name);
+    try std.testing.expect(copy.upvalues[0] != pair);
+    const copied_pair = types.toObject(copy.upvalues[0]).as(types.Pair);
+    try std.testing.expectEqual(types.makeFixnum(7), copied_pair.car);
+    try std.testing.expectEqual(types.NIL, copied_pair.cdr);
+    try std.testing.expectEqual(types.makeFixnum(3), copy.upvalues[1]);
+}
+
+test "deepCopy preserves sharing of native procedures within one structure" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    const nf_val = try gc1.allocNativeFn("shared-fn", &testAdd1, .{ .exact = 1 });
+    const tail = try gc1.allocPair(nf_val, types.NIL);
+    const lst = try gc1.allocPair(nf_val, tail);
+
+    const copied = try gc2.deepCopy(lst);
+    const p1 = types.toObject(copied).as(types.Pair);
+    const p2 = types.toObject(p1.cdr).as(types.Pair);
+    try std.testing.expect(p1.car != nf_val);
+    try std.testing.expectEqual(p1.car, p2.car);
+}
+
+// The thread-join! scenario from issue #958: the child GC is deinited right
+// after the result is deep-copied to the parent. Before the fix, deepCopyValue
+// returned the child-heap pointer for native_fn/native_closure, so the
+// parent's result dangled into freed memory.
+test "deepCopy native procedures survive freeing the source heap" {
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    var copied_fn: types.Value = undefined;
+    var copied_nc: types.Value = undefined;
+    {
+        var gc1 = memory.GC.init(std.testing.allocator);
+        defer gc1.deinit();
+        const nf_val = try gc1.allocNativeFn("survive-add1", &testAdd1, .{ .exact = 1 });
+        const upvalues = [_]types.Value{types.makeFixnum(5)};
+        const nc_val = try gc1.allocNativeClosure(&testNativeClosureFn, &upvalues, 1, "survive-nc");
+        copied_fn = try gc2.deepCopy(nf_val);
+        copied_nc = try gc2.deepCopy(nc_val);
+    }
+
+    const nf = types.toObject(copied_fn).as(types.NativeFn);
+    try std.testing.expectEqualStrings("survive-add1", nf.name);
+    try std.testing.expectEqual(types.makeFixnum(42), try nf.func(&.{types.makeFixnum(41)}));
+
+    const nc = types.toObject(copied_nc).as(types.NativeClosure);
+    try std.testing.expectEqualStrings("survive-nc", nc.name);
+    try std.testing.expectEqual(types.makeFixnum(5), nc.upvalues[0]);
+}
+
 test "deepCopy rejects port" {
     var gc1 = memory.GC.init(std.testing.allocator);
     defer gc1.deinit();

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -437,3 +437,24 @@ test "child thread leaves no child-heap values in shared globals (#958)" {
         }
     }
 }
+
+// Thread results are deep-copied child->parent at thread-join!, after which
+// the child heap is freed. deepCopyValue used to alias NativeFn objects
+// instead of copying them, so a result containing a primitive procedure kept
+// a raw pointer across the copy (issue #958 follow-up). The joined procedures
+// must be fresh parent-heap objects that are still callable.
+test "thread result containing primitive procedures is callable after join" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(let ((t (make-thread (lambda () (list car cdr)))))
+        \\  (thread-start! t)
+        \\  (let ((procs (thread-join! t)))
+        \\    (+ ((car procs) '(30 40))
+        \\       (car ((car (cdr procs)) '(30 12))))))
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}


### PR DESCRIPTION
## Summary

`deepCopyValue` in `src/gc_deep_copy.zig` returned the source-heap pointer for `native_fn` and `native_closure` objects instead of copying them. For SRFI-18 OS threads the child→parent copy at `thread-join!` is followed immediately by freeing the child heap (`freeChildResources`), so a thread result containing one of these left the parent holding a dangling pointer into freed memory. This is the remaining aliasing hole in deepCopy itself after #968 fixed the marking side of cross-heap references (#958).

## The fix

- **`native_fn`** — allocate a fresh `NativeFn` in the target GC. The fn pointer and name are static (string literals from `primitives.reg`), so only the object needs copying.
- **`native_closure`** — allocate a fresh `NativeClosure` (fn_ptr and name are code/rodata of a native binary), register it in the `visited` map before copying so shared and cyclic upvalue references resolve, then deep-copy each upvalue. Upvalues start as VOID placeholders so an aborted copy never leaves cross-heap pointers in the target object.
- **`ffi_library` / `ffi_function`** — still aliased, deliberately: they wrap process-global dlopen handles that cannot be duplicated per-heap. The known limitation (a child-created FFI handle returned through `thread-join!` still dangles) is now documented at the site.

Both directions benefit: parent→child thunk copies now give child threads heap-local copies of captured primitives instead of relying on foreign-owner checks, and child→parent result copies no longer dangle.

## Tests

Four unit tests in `src/tests_deepcopy.zig`; verified against the unfixed code, where three fail on aliasing/upvalue assertions and the fourth — which replays the join scenario by deiniting the source GC before reading the copy — dies with SIGABRT (the use-after-free):

- `deepCopy native_fn is copied, not aliased`
- `deepCopy native_closure copies upvalues into the target heap`
- `deepCopy preserves sharing of native procedures within one structure`
- `deepCopy native procedures survive freeing the source heap`

Plus an end-to-end `thread-join!` test in `src/tests_srfi18.zig` that returns primitive procedures from a thread and calls the copies after the child heap is freed.

Verified after rebasing onto main (past #968/#970/#971): `zig build test` 512/512 pass, all 8 SRFI-18 Scheme suites pass, full smoke suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)