### PR TITLE
Show message and irritants for uncaught user-raised errors

### DIFF
--- a/src/tests_exceptions.zig
+++ b/src/tests_exceptions.zig
@@ -170,3 +170,47 @@ test "nested guard" {
     );
     try std.testing.expectEqual(@as(i64, 11), types.toFixnum(result));
 }
+
+test "uncaught (error ...) formats message and irritants into error detail" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = vm.eval("(error \"index out of range\" 5)");
+    try std.testing.expectError(VMError.ExceptionRaised, result);
+    try std.testing.expectEqualStrings("index out of range 5", vm.getErrorDetail());
+}
+
+test "uncaught raise of non-error value reports the raised value" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = vm.eval("(raise 42)");
+    try std.testing.expectError(VMError.ExceptionRaised, result);
+    try std.testing.expectEqualStrings("uncaught exception: 42", vm.getErrorDetail());
+}
+
+test "uncaught (error ...) with string irritant writes the irritant" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = vm.eval("(error \"bad input\" \"foo\" 7)");
+    try std.testing.expectError(VMError.ExceptionRaised, result);
+    try std.testing.expectEqualStrings("bad input \"foo\" 7", vm.getErrorDetail());
+}
+
+test "caught exception does not populate error detail" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval("(guard (e (#t 'ok)) (error \"boom\" 1))");
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("", vm.getErrorDetail());
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -577,6 +577,47 @@ pub const VM = struct {
         return self.last_error_detail[0..self.last_error_detail_len];
     }
 
+    /// Called from execute()'s error path, before resetExecutionState()
+    /// discards the pending exception. If the escaping error is an uncaught
+    /// Scheme exception and no native error detail was recorded, format the
+    /// exception payload (message + irritants for error objects) into the
+    /// detail buffer so top-level error printers show the message instead of
+    /// the raw Zig error name. Consumes the pending exception.
+    pub fn noteUncaughtException(self: *VM, err: anyerror) void {
+        if (err != error.ExceptionRaised) return;
+        const exc = self.current_exception orelse return;
+        self.current_exception = null;
+        if (self.last_error_detail_len != 0) return;
+
+        const printer = @import("printer.zig");
+        const allocator = self.gc.allocator;
+        var w: std.Io.Writer = .fixed(&self.last_error_detail);
+        if (types.isErrorObject(exc)) {
+            const eo = types.toObject(exc).as(types.ErrorObject);
+            if (printer.valueToString(allocator, eo.message, .display)) |msg| {
+                defer allocator.free(msg);
+                w.writeAll(msg) catch {};
+            } else |_| {}
+            var it = eo.irritants;
+            while (types.isPair(it)) {
+                const pair = types.toObject(it).as(types.Pair);
+                if (printer.valueToString(allocator, pair.car, .write)) |s| {
+                    defer allocator.free(s);
+                    w.writeAll(" ") catch {};
+                    w.writeAll(s) catch {};
+                } else |_| {}
+                it = pair.cdr;
+            }
+        } else {
+            w.writeAll("uncaught exception: ") catch {};
+            if (printer.valueToString(allocator, exc, .write)) |s| {
+                defer allocator.free(s);
+                w.writeAll(s) catch {};
+            } else |_| {}
+        }
+        self.last_error_detail_len = w.buffered().len;
+    }
+
     pub const StackFrame = struct {
         name: ?[]const u8,
         source: ?[]const u8,

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -131,6 +131,7 @@ pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
             vm.profile_time_depth = 0;
             vm.gc.profile_alloc_target = null;
         }
+        vm.noteUncaughtException(err);
         vm.resetExecutionState();
         return err;
     };

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -88,6 +88,25 @@ assert_file_output_contains "runtime error has backtrace" \
 assert_file_output_contains "backtrace has call site" \
     "$TMPDIR/backtrace.scm" "backtrace.scm:"
 
+# --- Uncaught user-raised errors ---
+# An uncaught (error ...) must print its message and irritants, not the
+# raw Zig error name (was: "runtime error: error.ExceptionRaised").
+echo
+echo "-- Uncaught (error ...) --"
+
+cat > "$TMPDIR/uncaught-error.scm" << 'SCHEME'
+(error "index out of range" 5)
+SCHEME
+
+assert_file_output_contains "uncaught (error ...) in script shows message and irritants" \
+    "$TMPDIR/uncaught-error.scm" "index out of range 5"
+
+assert_output_contains "uncaught (error ...) in REPL shows message and irritants" \
+    '(error "index out of range" 5)' "index out of range 5"
+
+assert_output_contains "uncaught raise of non-error value shows the value" \
+    '(raise 42)' "uncaught exception: 42"
+
 # --- Type error details ---
 echo
 echo "-- Type error diagnostics --"


### PR DESCRIPTION
## Problem

An uncaught user-raised error printed no message — only the raw Zig error name:

```scheme
(error "index out of range" 5)
```
```
t.scm:1: runtime error: error.ExceptionRaised
```

The message string and irritants were lost in every mode (script files, REPL, piped stdin), while built-in errors like `(car 5)` printed nicely because `getErrorDetail()` is populated for those.

## Root cause

`execute()`'s error path calls `resetExecutionState()`, which nulls `vm.current_exception` before returning the error. By the time the top-level printers in `main.zig`/`repl.zig` catch the error, the exception payload is gone, `getErrorDetail()` is empty, and they fall back to printing the Zig error name.

## Fix

Hook the single choke point where the payload is still alive: `execute()`'s error path, just before `resetExecutionState()`. The new `VM.noteUncaughtException()` formats the pending exception into the error detail buffer:

- error objects → `message irritant1 irritant2 ...` (message displayed, irritants written)
- any other raised value → `uncaught exception: <value>`

```
t.scm:1: error: index out of range 5
    (error "index out of range" 5)
```

Since every top-level form runs through `execute()` — script files, the `.sbc` cache path, bundled binaries, the interactive REPL, piped stdin, and library bodies executed during `import` — one hook fixes all modes.

Safety:
- Native diagnostics are never overridden: the dispatch loop zeroes the detail buffer before each native call, so a non-empty buffer at raise time is always a specific native error.
- Exceptions caught by `guard`/`with-exception-handler` are consumed inside `run()` and never reach this path.
- SRFI-18 child threads run their thunk via `callWithArgs`, not `execute`, so `thread-join!` exception propagation is unaffected.

## Tests

- `src/tests_exceptions.zig`: message + irritants formatting, non-error-object `raise`, string irritant written with quotes, and caught exceptions leaving the detail buffer empty.
- `tests/scheme/errors/error-format.sh`: uncaught `(error ...)` in script mode and REPL (stdin) mode, plus uncaught `(raise 42)`.

Verified: `zig build test`, error-format (25 pass) and exit-code (29 pass) suites, full Scheme suite (1654 pass, 0 fail incl. 1395-test R7RS suite), plus manual checks of script, piped-stdin, interactive-REPL (pty), and second-run `.sbc` cache paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)