### PR TITLE
Signal read-error? when read hits EOF mid-datum (R7RS 6.13.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+#### I/O
+- `read` now signals an error satisfying `read-error?` when end of file is encountered in the middle of an incomplete datum (e.g. `(read (open-input-string "(unclosed"))`), as R7RS 6.13.2 requires, instead of silently returning the EOF object. EOF before any datum begins still returns the EOF object. Applies to both string ports and file ports.
+
 #### Libraries
 - Fix `define-syntax` in a library body registering the macro in the process-global macro table at load time — unexported library-body macros no longer leak to all code, and a macro imported from one library is no longer silently clobbered by loading another library that defines the same name (#877)
 

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -585,6 +585,26 @@ fn writeStringFn(args: []const Value) PrimitiveError!Value {
     return types.VOID;
 }
 
+/// Parses one datum with R7RS 6.13.2 `read` semantics: EOF before any datum
+/// text begins yields null (the caller returns the EOF object); EOF that
+/// interrupts an incomplete datum — including an unterminated comment —
+/// propagates as an error so the caller can signal one satisfying read-error?.
+fn parseDatumForRead(reader: *reader_mod.Reader) reader_mod.ReadError!?Value {
+    if (!try reader.hasMore()) return null;
+    return try reader.readDatum();
+}
+
+fn raiseReadError(gc: *@import("memory.zig").GC) PrimitiveError!Value {
+    var msg = gc.allocString("read error") catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
+    const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.OutOfMemory;
+    const errObj = types.toObject(err_obj).as(types.ErrorObject);
+    errObj.error_type = .read;
+    const raise_args = [1]Value{err_obj};
+    return primitives_control.raiseFn(&raise_args);
+}
+
 fn readDatumFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = try getInputPort(args, 0, "read");
@@ -609,17 +629,11 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
 
         var reader = reader_mod.Reader.init(gc, source);
         defer reader.deinit();
-        const datum = reader.readDatum() catch |err| {
-            if (err == reader_mod.ReadError.UnexpectedEof or err == reader_mod.ReadError.OutOfMemory) return types.EOF;
-            var msg = gc.allocString("read error") catch return PrimitiveError.OutOfMemory;
-            gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
-            defer gc.popRoot();
-            const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.OutOfMemory;
-            const errObj = types.toObject(err_obj).as(types.ErrorObject);
-            errObj.error_type = .read;
-            const raise_args = [1]Value{err_obj};
-            return primitives_control.raiseFn(&raise_args);
+        const maybe_datum = parseDatumForRead(&reader) catch |err| {
+            if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
+            return raiseReadError(gc);
         };
+        const datum = maybe_datum orelse return types.EOF;
         // Advance string_pos by amount consumed
         port.string_pos += reader.pos;
         if (combined.items.len > 0 and reader.pos > 0) {
@@ -671,17 +685,11 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
     // Parse one datum
     var reader = reader_mod.Reader.init(gc, buf.items);
     defer reader.deinit();
-    const datum = reader.readDatum() catch |err| {
-        if (err == reader_mod.ReadError.UnexpectedEof or err == reader_mod.ReadError.OutOfMemory) return types.EOF;
-        var msg = gc.allocString("read error") catch return PrimitiveError.OutOfMemory;
-        gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
-        defer gc.popRoot();
-        const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.OutOfMemory;
-        const errObj = types.toObject(err_obj).as(types.ErrorObject);
-        errObj.error_type = .read;
-        const raise_args = [1]Value{err_obj};
-        return primitives_control.raiseFn(&raise_args);
+    const maybe_datum = parseDatumForRead(&reader) catch |err| {
+        if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
+        return raiseReadError(gc);
     };
+    const datum = maybe_datum orelse return types.EOF;
 
     // Save unconsumed bytes back to port buffer
     const remaining = buf.items[reader.pos..];

--- a/tests/scheme/smoke/read-incomplete-datum.scm
+++ b/tests/scheme/smoke/read-incomplete-datum.scm
@@ -1,0 +1,59 @@
+;; Regression test: (read port) must signal an error satisfying read-error?
+;; when end of file is encountered mid-datum (R7RS 6.13.2), instead of
+;; returning the EOF object. EOF before any datum text still returns the
+;; EOF object. Covers both string ports and file ports.
+(import (scheme base) (scheme read) (scheme write) (scheme file)
+        (scheme process-context) (srfi 64))
+
+(define (read-raises-read-error? s)
+  (guard (e (#t (read-error? e)))
+    (read (open-input-string s))
+    #f))
+
+(test-begin "read-incomplete-datum")
+
+;; EOF mid-datum: must raise a read error
+(test-assert "unclosed list" (read-raises-read-error? "(unclosed"))
+(test-assert "unclosed nested list" (read-raises-read-error? "(a (b c"))
+(test-assert "unterminated string" (read-raises-read-error? "\"abc"))
+(test-assert "unclosed vector" (read-raises-read-error? "#(1 2"))
+(test-assert "unclosed bytevector" (read-raises-read-error? "#u8(1 2"))
+(test-assert "lone quote" (read-raises-read-error? "'"))
+(test-assert "unterminated block comment" (read-raises-read-error? "#| foo"))
+(test-assert "incomplete datum comment" (read-raises-read-error? "#;(1"))
+
+;; EOF before any datum begins: must return the EOF object
+(test-assert "empty input"
+  (eof-object? (read (open-input-string ""))))
+(test-assert "whitespace only"
+  (eof-object? (read (open-input-string "  \n\t "))))
+(test-assert "line comment only"
+  (eof-object? (read (open-input-string "; nothing"))))
+(test-assert "block comment only"
+  (eof-object? (read (open-input-string "#| done |#"))))
+(test-assert "datum comment only"
+  (eof-object? (read (open-input-string "#;(1 2)"))))
+
+;; Complete datum still reads normally, then EOF
+(test-equal "complete then eof" '(1 2)
+  (let ((p (open-input-string " (1 2) ")))
+    (let ((v (read p)))
+      (and (eof-object? (read p)) v))))
+
+;; File ports (fd path) follow the same rule
+(define test-file "/tmp/kaappi-read-incomplete-test.scm")
+(call-with-output-file test-file
+  (lambda (p) (write-string "(unclosed" p)))
+(test-assert "unclosed list from file port"
+  (guard (e (#t (read-error? e)))
+    (call-with-input-file test-file read)
+    #f))
+(call-with-output-file test-file
+  (lambda (p) (write-string "   ; just a comment\n" p)))
+(test-assert "whitespace-only file port"
+  (eof-object? (call-with-input-file test-file read)))
+(delete-file test-file)
+
+(let ((runner (test-runner-current)))
+  (test-end "read-incomplete-datum")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- `(read port)` now signals an error satisfying `read-error?` when end-of-file interrupts an incomplete datum (e.g. unclosed list, unterminated string), as R7RS 6.13.2 requires. Previously it silently returned the EOF object.
- EOF before any datum text begins (empty input, whitespace-only, comment-only) still returns the EOF object as before.
- Extracted `parseDatumForRead` and `raiseReadError` helpers to deduplicate the string-port and fd-port code paths in `readDatumFn`.

## Test plan

- [x] New Scheme test `tests/scheme/smoke/read-incomplete-datum.scm` covering unclosed lists, nested lists, unterminated strings, vectors, bytevectors, lone quotes, block comments, datum comments — and EOF-before-datum cases for empty, whitespace, line/block/datum comments
- [x] File port path tested alongside string ports
- [x] `zig build test` passes
- [x] `bash tests/scheme/run-all.sh` passes
- [x] R7RS suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)