### PR TITLE
Fix fiber scheduler returning void for multi-stage channel pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Reject unknown flags (e.g. `--typo-flag`) with a usage error instead of silently treating them as a script filename (#781)
 - Exit non-zero on `--compile`/`--disassemble` read and compile errors, and on standalone-binary runtime and corrupt-bytecode errors, so build and bundled-app failures are visible to CI (#781)
 
+#### Fibers
+- Fix `channel-receive` silently returning an unspecified value when the value had to flow through two or more intermediate fiber stages: a fiber blocked with no runnable siblings now parks on the channel and is woken by the next `channel-send` (re-executing the receive), so multi-stage pipelines deliver values instead of spinning on garbage. A receive (or `fiber-join`) that can never be satisfied now raises a catchable deadlock error instead of returning void
+- `apply`-forwarded `channel-receive` propagates the park signal instead of collapsing it into a type error
+- Documented exit semantics: fibers still parked when the main program ends are discarded (Go-style), and a fiber blocking inside a native-driven callback (`map`, `for-each`, ...) raises a deadlock error when nothing else can run (see README known limitations)
+
 #### Package manager (thottam)
 - Fix version-pinned installs always failing with "Failed to checkout version": `git checkout -- <ref>` treats the ref as a pathspec, so use `--end-of-options` to keep the option-injection guard while resolving `<ref>` as a revision. Affected `install pkg@v1.0.0`, semver constraints, and `--locked` installs (#780)
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,17 @@ Green threads (fibers) for cooperative multitasking within one OS thread:
 (display (channel-receive ch))  ;=> hello from fiber
 ```
 
+Scheduling is cooperative: spawned fibers run when the main program blocks
+(`channel-receive` on an empty channel, `fiber-join`) or calls `(yield)`.
+A fiber that blocks on an empty channel is parked and woken by the next
+`channel-send` on that channel. When the main program ends, fibers that are
+still parked (e.g. workers that never received a stop sentinel) are simply
+discarded and the process exits — like goroutines in Go. If the main program
+blocks on a channel that no runnable or parked-and-wakeable fiber can ever
+send to, `channel-receive` raises a deadlock error (an `error` object,
+catchable with `guard`); the same applies to `fiber-join` on a fiber that can
+never complete.
+
 Real OS threads via SRFI-18 — each thread gets its own VM and GC, enabling
 true parallel I/O (e.g., thread-per-connection servers):
 
@@ -334,6 +345,16 @@ capture — negligible for most programs, but noticeable if continuations are
 captured in tight inner loops. Continuations captured in one top-level REPL
 expression cannot re-enter subsequent top-level expressions (standard behavior
 shared by Guile, Chibi, Chicken, Chez, and Racket).
+
+### Fibers
+
+A fiber that blocks on an empty channel inside a callback driven by a native
+higher-order procedure (`map`, `for-each`, `dynamic-wind`, `eval`, ...) cannot
+be parked: the native call's state lives on the Zig stack and cannot be
+suspended. If other fibers are runnable the scheduler still makes progress,
+but if the blocked receive is the only thing left it raises a deadlock error
+instead of suspending. Move blocking `channel-receive` calls into plain
+Scheme loops (named `let`, `do`) when a fiber must wait inside iteration.
 
 ### OS threads (SRFI-18)
 

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -239,6 +239,20 @@ pub const FiberScheduler = struct {
         }
     }
 
+    /// Wake every fiber parked on this channel (status .waiting via the
+    /// channel-receive retry protocol). Waking all is safe: each re-executes
+    /// channel-receive and re-parks if the channel is empty again.
+    pub fn wakeChannelWaiters(self: *FiberScheduler, ch_val: Value) void {
+        for (self.fibers[0..self.fiber_count]) |f| {
+            if (f) |fiber| {
+                if (fiber.status == .waiting and fiber.waiting_on == ch_val) {
+                    fiber.status = .suspended;
+                    fiber.waiting_on = types.VOID;
+                }
+            }
+        }
+    }
+
     pub fn wakeMutexWaiters(self: *FiberScheduler, mutex_val: Value) void {
         for (self.fibers[0..self.fiber_count]) |f| {
             if (f) |fiber| {

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -626,6 +626,10 @@ fn applyFn(args: []const Value) PrimitiveError!Value {
             @import("vm.zig").VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
             @import("vm.zig").VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
             @import("vm.zig").VMError.OutOfMemory => PrimitiveError.OutOfMemory,
+            // Parked fiber (yield_retry): apply is idempotent up to the
+            // block, so propagate and let the dispatch site retry the
+            // whole apply call on wake.
+            @import("vm.zig").VMError.Yielded => PrimitiveError.Yielded,
             else => PrimitiveError.TypeError, // bare-ok: catch fallback
         };
     };

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -118,6 +118,9 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
         ch.head = new_pair;
         gc.writeBarrier(ch_obj, new_pair);
     }
+    if (vm_mod.vm_instance) |vm| {
+        if (vm.scheduler) |sched| sched.wakeChannelWaiters(args[0]);
+    }
     return types.VOID;
 }
 
@@ -129,6 +132,12 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
 
     if (ch.head != types.NIL and types.isPair(ch.head)) {
         return dequeueChannel(ch, args[0]);
+    }
+
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    if (vm.scheduler == null) {
+        // No fibers exist, so nothing can ever send: blocking would hang.
+        return raiseDeadlockError("channel-receive: deadlock — channel is empty and no fibers are running");
     }
 
     return runSchedulerUntil(null, ch, args[0]);
@@ -167,6 +176,10 @@ fn runSchedulerUntil(target: ?*fiber_mod.Fiber, ch: ?*types.Channel, ch_val: Val
         fiber.status = .running;
         vm.current_fiber = fiber;
 
+        // A dangling yield_retry (a forwarding native converted a park's
+        // Yielded into another error) must not survive into this run.
+        vm.yield_retry = false;
+        vm.sched_dispatch_pending = true;
         const result = vm.runUntil(0, 0) catch |err| {
             if (err == vm_mod.VMError.Yielded) {
                 sched.saveCurrentFiber();
@@ -192,11 +205,49 @@ fn runSchedulerUntil(target: ?*fiber_mod.Fiber, ch: ?*types.Channel, ch_val: Val
     me.status = .running;
     vm.current_fiber = me;
 
-    if (target) |f| return f.result;
+    if (target) |f| {
+        if (f.status == .completed or f.status == .errored) return f.result;
+        return blockOrDeadlock(vm, me, my_idx, types.makePointer(@ptrCast(f)), "fiber-join: deadlock — joined fiber can never complete (all fibers blocked)");
+    }
     if (ch) |channel| {
         if (channel.head != types.NIL) return dequeueChannel(channel, ch_val);
+        return blockOrDeadlock(vm, me, my_idx, ch_val, "channel-receive: deadlock — channel is empty and all fibers are blocked");
     }
     return types.VOID;
+}
+
+/// The scheduler ran out of runnable fibers while this fiber's blocking
+/// condition is still unmet. A spawned fiber dispatched directly by a
+/// scheduler loop parks itself: status .waiting on the channel/fiber, and
+/// yield_retry makes the dispatch loop rewind ip so the blocking primitive
+/// re-executes when a channel-send (or fiber completion) wakes it. The main
+/// fiber — or a fiber blocked under re-entrant native frames (map/for-each
+/// callbacks, eval), which cannot be safely rewound — raises a deadlock
+/// error instead of returning an unspecified value.
+fn blockOrDeadlock(vm: *vm_mod.VM, me: *fiber_mod.Fiber, my_idx: usize, wait_on: Value, deadlock_msg: []const u8) PrimitiveError!Value {
+    if (my_idx != 0 and vm.dispatched_from_scheduler) {
+        me.status = .waiting;
+        me.waiting_on = wait_on;
+        vm.gc.writeBarrier(&me.header, wait_on);
+        vm.yield_retry = true;
+        return PrimitiveError.Yielded;
+    }
+    return raiseDeadlockError(deadlock_msg);
+}
+
+fn raiseDeadlockError(msg: []const u8) PrimitiveError {
+    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
+    var msg_root = message;
+    gc.pushRoot(&msg_root) catch return PrimitiveError.OutOfMemory;
+    const err_val = gc.allocErrorObject(msg_root, types.NIL) catch {
+        gc.popRoot();
+        return PrimitiveError.OutOfMemory;
+    };
+    gc.popRoot();
+    vm.current_exception = err_val;
+    return PrimitiveError.ExceptionRaised;
 }
 
 fn channelPredFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -532,6 +532,10 @@ fn runSchedulerUntilDone(target: *fiber_mod.Fiber) PrimitiveError!void {
         fiber.status = .running;
         vm.current_fiber = fiber;
 
+        // A dangling yield_retry (a forwarding native converted a park's
+        // Yielded into another error) must not survive into this run.
+        vm.yield_retry = false;
+        vm.sched_dispatch_pending = true;
         const result = vm.runUntil(0, 0) catch |err| {
             if (err == vm_mod.VMError.Yielded) {
                 sched.saveCurrentFiber();
@@ -697,6 +701,10 @@ fn runSchedulerUntilMutex(m: *types.Mutex, me: *fiber_mod.Fiber) PrimitiveError!
         fiber.status = .running;
         vm.current_fiber = fiber;
 
+        // A dangling yield_retry (a forwarding native converted a park's
+        // Yielded into another error) must not survive into this run.
+        vm.yield_retry = false;
+        vm.sched_dispatch_pending = true;
         const result = vm.runUntil(0, 0) catch |err| {
             if (err == vm_mod.VMError.Yielded) {
                 sched.saveCurrentFiber();
@@ -780,6 +788,10 @@ fn runSchedulerUntilCondVar(me: *fiber_mod.Fiber) PrimitiveError!void {
         fiber.status = .running;
         vm.current_fiber = fiber;
 
+        // A dangling yield_retry (a forwarding native converted a park's
+        // Yielded into another error) must not survive into this run.
+        vm.yield_retry = false;
+        vm.sched_dispatch_pending = true;
         const result = vm.runUntil(0, 0) catch |err| {
             if (err == vm_mod.VMError.Yielded) {
                 sched.saveCurrentFiber();

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -1,0 +1,202 @@
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const vm_mod = @import("vm.zig");
+
+// Regression tests for the fiber scheduler give-up path (#kaappi-book):
+// runSchedulerUntil used to silently return VOID when no fiber was runnable
+// while intermediate fibers sat blocked in nested channel-receive calls.
+// Multi-stage pipelines got VOID instead of blocking, and true deadlocks
+// spun forever instead of raising an error.
+
+test "channel values flow through a two-stage fiber pipeline" {
+    // Stage fibers block on channels that only fill after an outer-nested
+    // fiber runs — the non-LIFO case the recursive scheduler could not
+    // resume. Parked fibers must be woken by channel-send and re-execute
+    // their receive, not resume with an unspecified value.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define (add-stage in-ch proc)
+        \\  (let ((out-ch (make-channel)))
+        \\    (spawn (lambda ()
+        \\      (let process ()
+        \\        (let ((val (channel-receive in-ch)))
+        \\          (unless (eq? val 'eof)
+        \\            (channel-send out-ch (proc val))
+        \\            (process))))
+        \\      (channel-send out-ch 'eof)))
+        \\    out-ch))
+        \\(define source (make-channel))
+        \\(define output
+        \\  (add-stage (add-stage source (lambda (x) (* x x)))
+        \\             (lambda (x) (+ x 1))))
+        \\(spawn (lambda ()
+        \\  (for-each (lambda (n) (channel-send source n)) '(1 2 3 4 5))
+        \\  (channel-send source 'eof)))
+    );
+    const result = try vm.eval(
+        \\(let loop ((acc '()))
+        \\  (let ((val (channel-receive output)))
+        \\    (if (eq? val 'eof)
+        \\        (reverse acc)
+        \\        (loop (cons val acc)))))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(2 5 10 17 26)", s);
+}
+
+test "channel-receive with no scheduler raises deadlock error" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define ch (make-channel))");
+    const result = vm.eval("(channel-receive ch)");
+    try std.testing.expectError(vm_mod.VMError.ExceptionRaised, result);
+}
+
+test "channel-receive deadlock with blocked fibers raises instead of returning void" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define ch (make-channel))
+        \\(define f (spawn (lambda () (channel-receive ch))))
+    );
+    const result = vm.eval("(channel-receive ch)");
+    try std.testing.expectError(vm_mod.VMError.ExceptionRaised, result);
+}
+
+test "channel-receive deadlock error is catchable by guard" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(guard (e (#t (if (string=? "channel-receive: deadlock — channel is empty and no fibers are running"
+        \\                             (error-object-message e))
+        \\                  'deadlock-reported
+        \\                  'wrong-message)))
+        \\  (channel-receive (make-channel)))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("deadlock-reported", s);
+}
+
+test "fiber-join on a permanently blocked fiber raises deadlock error" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define ch (make-channel))
+        \\(define f (spawn (lambda () (channel-receive ch))))
+    );
+    const result = vm.eval("(fiber-join f)");
+    try std.testing.expectError(vm_mod.VMError.ExceptionRaised, result);
+}
+
+test "fiber parked on a channel resumes when a later top-level form sends" {
+    // The fiber parks (.waiting) during the first form; the send in a later
+    // form must wake it and re-execute its channel-receive.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define ch (make-channel))
+        \\(define out (make-channel))
+        \\(define f (spawn (lambda () (channel-send out (* 2 (channel-receive ch))))))
+        \\(yield)
+    );
+    _ = try vm.eval("(channel-send ch 21)");
+    const result = try vm.eval("(channel-receive out)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "fiber parked inside apply-forwarded channel-receive retries the apply" {
+    // apply invokes channel-receive through vm.callWithArgs without a new
+    // dispatch loop; the park signal (yield_retry + error.Yielded) must
+    // propagate through applyFn intact so the apply call is retried on wake
+    // (previously it was swallowed into a TypeError).
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define ch (make-channel))
+        \\(define out (make-channel))
+        \\(define f (spawn (lambda ()
+        \\  (channel-send out (apply channel-receive (list ch))))))
+        \\(yield)
+    );
+    _ = try vm.eval("(channel-send ch 21)");
+    const result = try vm.eval("(channel-receive out)");
+    try std.testing.expectEqual(@as(i64, 21), types.toFixnum(result));
+}
+
+test "fiber blocked inside for-each callback errors instead of corrupting" {
+    // A receive inside a native-driven callback cannot be parked (native
+    // frames sit between the fiber's bytecode and the scheduler). With
+    // nothing else runnable it must raise a deadlock error in that fiber —
+    // not return an unspecified value or rewind through the native call.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(define ch (make-channel))
+        \\(define f (spawn (lambda ()
+        \\  (guard (e (#t 'fiber-deadlock))
+        \\    (for-each (lambda (x) (channel-receive ch)) '(1 2))))))
+        \\(fiber-join f)
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("fiber-deadlock", s);
+}
+
+test "main fiber still blocked after guard-recovered deadlock can be unblocked" {
+    // A deadlock error must leave the scheduler in a usable state: parked
+    // fibers stay parked and a subsequent send lets everything drain.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define ch (make-channel))
+        \\(define out (make-channel))
+        \\(define f (spawn (lambda () (channel-send out (+ 1 (channel-receive ch))))))
+        \\(define first-try
+        \\  (guard (e (#t 'blocked))
+        \\    (channel-receive out)))
+    );
+    const first = try vm.eval("first-try");
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, first, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("blocked", s);
+
+    _ = try vm.eval("(channel-send ch 41)");
+    const result = try vm.eval("(channel-receive out)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -347,6 +347,20 @@ pub const VM = struct {
     scheduler: ?*@import("fiber.zig").FiberScheduler = null,
     current_fiber: ?*@import("fiber.zig").Fiber = null,
     yielded: bool = false,
+    /// Set by a blocking primitive (channel-receive, fiber-join) together with
+    /// error.Yielded: the dispatch loop must rewind ip to the start of the
+    /// calling instruction so the primitive re-executes when the fiber is
+    /// rescheduled, instead of resuming with an unwritten result register.
+    yield_retry: bool = false,
+    /// Set by a scheduler loop immediately before its runUntil(0, 0) call;
+    /// consumed by runUntil on entry into dispatched_from_scheduler.
+    sched_dispatch_pending: bool = false,
+    /// True while the innermost active runUntil was invoked directly by a
+    /// fiber scheduler loop. Blocking primitives may only park the current
+    /// fiber with yield_retry when this is set — otherwise Zig-native frames
+    /// (map/for-each callbacks, eval) sit between the fiber's bytecode and
+    /// the scheduler, and a retry would corrupt them.
+    dispatched_from_scheduler: bool = false,
     /// For child OS threads (SRFI-18): points at the parent-heap fiber's
     /// `terminated` flag. Checked at the periodic dispatch-loop safepoint so
     /// thread-terminate! from another thread can stop this VM. Written by the
@@ -1073,6 +1087,11 @@ pub const VM = struct {
                     error.OutOfMemory => VMError.OutOfMemory,
                     error.ExceptionRaised => VMError.ExceptionRaised,
                     error.ContinuationInvoked => VMError.ContinuationInvoked,
+                    // A blocking primitive parked the current fiber
+                    // (yield_retry); the signal must reach the dispatch site
+                    // of the forwarding native (e.g. apply) intact so the
+                    // whole forwarding call is retried on wake.
+                    error.Yielded => VMError.Yielded,
                     else => VMError.InvalidBytecode,
                 };
             };
@@ -1127,6 +1146,9 @@ pub const VM = struct {
         self.current_exception = null;
         self.continuation_invoked = false;
         self.continuation_value = types.VOID;
+        self.yield_retry = false;
+        self.sched_dispatch_pending = false;
+        self.dispatched_from_scheduler = false;
     }
 
     const vm_calls = @import("vm_calls.zig");

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -168,6 +168,12 @@ pub fn run(vm: *VM) VMError!Value {
 
 pub fn runWithScheduler(vm: *VM, sched: *fiber_mod.FiberScheduler) VMError!Value {
     while (true) {
+        // Fibers dispatched here (after the main fiber yields) may park
+        // themselves on an empty channel via the yield_retry protocol. A
+        // dangling yield_retry (a forwarding native converted a park's
+        // Yielded into another error) must not survive into this run.
+        vm.yield_retry = false;
+        vm.sched_dispatch_pending = true;
         const result = vm.runUntil(0, 0) catch |err| {
             if (err == VMError.Yielded) {
                 if (scheduleNextAfterYield(vm, sched)) continue;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -36,6 +36,19 @@ fn resumesHere(self: *VM, target_frame_count: usize, scope_root_seq: u64) bool {
     return self.frames[target_frame_count].seq == scope_root_seq;
 }
 
+/// A blocking primitive parked the current fiber and asked for a retry
+/// (vm.yield_retry + error.Yielded): rewind ip to the start of the call
+/// instruction so the primitive re-executes when the fiber is rescheduled.
+/// Must run at the dispatch site that directly invoked the native, where the
+/// instruction length (opcode byte + fixed operands) is known; the flag is
+/// cleared so outer frames propagating the same Yielded do not rewind again.
+fn maybeRewindRetry(self: *VM, instr_len: usize) void {
+    if (!self.yield_retry) return;
+    self.yield_retry = false;
+    const f = &self.frames[self.frame_count - 1];
+    if (f.ip >= instr_len) f.ip -= instr_len;
+}
+
 /// Continuation-invoked handling: after a restore/escape delivers its value,
 /// execution must resume in the innermost dispatch loop whose scope-root
 /// frame is still live (checked by frame birth id, see resumesHere). Loops
@@ -51,6 +64,14 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
         self.frames[target_frame_count].seq
     else
         0;
+    // Blocking primitives may park the current fiber (yield_retry) only when
+    // this loop was entered directly from a scheduler loop; nested runUntil
+    // calls (map/for-each callbacks, eval) clear the marker for their extent.
+    const from_scheduler = self.sched_dispatch_pending;
+    self.sched_dispatch_pending = false;
+    const saved_from_scheduler = self.dispatched_from_scheduler;
+    self.dispatched_from_scheduler = from_scheduler;
+    defer self.dispatched_from_scheduler = saved_from_scheduler;
     while (self.frame_count > target_frame_count) {
         if (self.yielded) {
             self.yielded = false;
@@ -378,6 +399,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             }
                             return VMError.ContinuationInvoked;
                         }
+                        if (err == VMError.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                         return err;
                     };
                 }
@@ -482,6 +504,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             }
                             return VMError.ContinuationInvoked;
                         }
+                        if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                         return switch (err) {
                             error.TypeError => blk: {
                                 if (self.last_error_detail_len == 0)
@@ -672,6 +695,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                             return VMError.ContinuationInvoked;
                         }
+                        if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                         return switch (err) {
                             error.TypeError => VMError.TypeError,
                             error.DivisionByZero => VMError.DivisionByZero,
@@ -913,6 +937,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                         if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                         return VMError.ContinuationInvoked;
                                     }
+                                    if (err == VMError.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                                     return err;
                                 };
                                 continue;
@@ -954,6 +979,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                 return VMError.ContinuationInvoked;
                             }
+                            if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                             return vm_calls.handleNativeError(self, err, base, nargs);
                         };
                         self.registers[base] = result;
@@ -963,6 +989,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                 return VMError.ContinuationInvoked;
                             }
+                            if (err == VMError.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                             return err;
                         };
                     }
@@ -1095,6 +1122,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                 return VMError.ContinuationInvoked;
                             }
+                            if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                             return vm_calls.handleNativeError(self, err, abs_base, nargs);
                         }
                     else blk: {
@@ -1112,6 +1140,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                                 return VMError.ContinuationInvoked;
                             }
+                            if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                             return switch (err) {
                                 error.TypeError => b2: {
                                     if (self.last_error_detail_len == 0)

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -17,6 +17,7 @@ test {
     _ = @import("tests_deepcopy.zig");
     _ = @import("tests_ir.zig");
     _ = @import("tests_srfi18.zig");
+    _ = @import("tests_fibers.zig");
     _ = @import("tests_ffi.zig");
     _ = @import("tests_bytecode_cache.zig");
 }

--- a/tests/scheme/smoke/fiber-blocked-exit.scm
+++ b/tests/scheme/smoke/fiber-blocked-exit.scm
@@ -1,0 +1,36 @@
+;; Regression test: a program whose worker fibers are still blocked on
+;; channel-receive when the main program ends must exit cleanly.
+;;
+;; Fibers only run while the main program blocks or yields; when the main
+;; program finishes, blocked fibers are discarded (Go-style). Previously a
+;; worker's blocked receive returned an unspecified value instead, so a
+;; sentinel-less worker loop spun forever and the process never exited
+;; (this test then times out).
+
+(import (scheme base)
+        (scheme write))
+
+(define work (make-channel))
+(define done (make-channel))
+
+;; Worker with no stop sentinel: after draining the two jobs it blocks on
+;; channel-receive forever.
+(define worker
+  (spawn (lambda ()
+    (let loop ((acc '()))
+      (let ((v (channel-receive work)))
+        (when (= (length (cons v acc)) 2)
+          (channel-send done (reverse (cons v acc))))
+        (loop (cons v acc)))))))
+
+(channel-send work 'a)
+(channel-send work 'b)
+
+(let ((jobs (channel-receive done)))
+  (unless (equal? jobs '(a b))
+    (error "worker did not process jobs" jobs)))
+
+(display "1 passed, 0 failed")
+(newline)
+;; Reaching here with the worker still parked on `work` must not prevent
+;; process exit.

--- a/tests/scheme/smoke/fiber-pipeline.scm
+++ b/tests/scheme/smoke/fiber-pipeline.scm
@@ -1,0 +1,118 @@
+;; Regression tests for the fiber scheduler give-up path.
+;;
+;; runSchedulerUntil used to return an unspecified value (VOID) when no
+;; fiber was runnable while intermediate fibers were blocked in nested
+;; channel-receive calls. Multi-stage pipelines therefore received garbage
+;; instead of data (consumer loops spun forever), and a genuinely
+;; deadlocked channel-receive returned VOID instead of raising an error.
+;;
+;; Now: a spawned fiber that cannot make progress parks on the channel and
+;; is woken by channel-send; a blocked main fiber (or a receive that can
+;; never be satisfied) raises a catchable deadlock error.
+
+(import (scheme base)
+        (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " got=") (write got)
+        (display " expected=") (write expected)
+        (newline))))
+
+;; --- deadlock with no scheduler (must run before any spawn) --------------
+;; No fiber exists, so nothing can ever send: receive must raise, not hang
+;; and not return an unspecified value.
+(check "receive with no fibers raises catchable deadlock error"
+  (guard (e (#t 'deadlock))
+    (channel-receive (make-channel)))
+  'deadlock)
+
+;; --- multi-stage pipeline (issue repro) ----------------------------------
+;; Values must flow through two intermediate fiber stages. Each stage
+;; blocks on a channel fed by another fiber that the recursive scheduler
+;; could not resume (non-LIFO blocking).
+(define (add-stage in-ch proc)
+  (let ((out-ch (make-channel)))
+    (spawn (lambda ()
+      (let process ()
+        (let ((val (channel-receive in-ch)))
+          (unless (eq? val 'eof)
+            (channel-send out-ch (proc val))
+            (process))))
+      (channel-send out-ch 'eof)))
+    out-ch))
+
+(define source (make-channel))
+(define output
+  (add-stage (add-stage source (lambda (x) (* x x)))
+             (lambda (x) (+ x 1))))
+
+(define producer
+  (spawn (lambda ()
+    (for-each (lambda (n) (channel-send source n)) '(1 2 3 4 5))
+    (channel-send source 'eof))))
+
+(check "two-stage pipeline delivers all values"
+  (let loop ((acc '()))
+    (let ((val (channel-receive output)))
+      (if (eq? val 'eof)
+          (reverse acc)
+          (loop (cons val acc)))))
+  '(2 5 10 17 26))
+
+;; --- three-stage pipeline -------------------------------------------------
+(define src3 (make-channel))
+(define out3
+  (add-stage (add-stage (add-stage src3 (lambda (x) (+ x 1)))
+                        (lambda (x) (* x 10)))
+             (lambda (x) (- x 5))))
+(define producer3
+  (spawn (lambda ()
+    (channel-send src3 1)
+    (channel-send src3 2)
+    (channel-send src3 'eof))))
+
+(check "three-stage pipeline delivers all values"
+  (let loop ((acc '()))
+    (let ((val (channel-receive out3)))
+      (if (eq? val 'eof)
+          (reverse acc)
+          (loop (cons val acc)))))
+  '(15 25))
+
+;; --- deadlock with a blocked fiber ---------------------------------------
+;; Main and a spawned fiber both wait on a channel nobody sends to:
+;; the main receive must raise, not return an unspecified value.
+(define dead-ch (make-channel))
+(define dead-fiber (spawn (lambda () (channel-receive dead-ch))))
+(check "receive that can never be satisfied raises"
+  (guard (e (#t 'deadlock))
+    (channel-receive dead-ch))
+  'deadlock)
+
+;; --- fiber-join on a permanently blocked fiber ---------------------------
+(define join-ch (make-channel))
+(define blocked-fiber (spawn (lambda () (channel-receive join-ch))))
+(check "fiber-join on blocked fiber raises"
+  (guard (e (#t 'deadlock))
+    (fiber-join blocked-fiber))
+  'deadlock)
+
+;; --- parked fiber is woken by a later send -------------------------------
+;; The deadlock above parked the fiber; sending on its channel must wake it
+;; so the join can complete.
+(channel-send join-ch 21)
+(check "parked fiber resumes after send and join completes"
+  (fiber-join blocked-fiber)
+  21)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0) (error "fiber pipeline tests failed" fail))


### PR DESCRIPTION
## Summary

- Fix `channel-receive` silently returning VOID when values had to flow through two or more intermediate fiber stages — the recursive scheduler could only resume LIFO, so non-LIFO blocking returned an unspecified value and consumer loops spun forever
- Introduce park-and-retry: a fiber blocked on an empty channel parks (`.waiting` on the channel) and is woken by the next `channel-send`, which rewinds ip so `channel-receive` re-executes on wake
- A `channel-receive` or `fiber-join` that can never be satisfied now raises a catchable deadlock error instead of returning void
- `apply`-forwarded `channel-receive` propagates the park signal instead of collapsing it into a type error
- Fibers blocked inside native callbacks (`map`, `for-each`, `eval`) raise a deadlock error when nothing else can run, rather than attempting to park through Zig stack frames
- Fibers still parked when the main program ends are discarded (Go-style); documented in README

## Test plan

- [x] 9 Zig unit tests in `src/tests_fibers.zig` (two-stage pipeline, deadlock detection, `guard` catchability, `fiber-join`, parked-fiber wake, `apply` forwarding, native-callback blocking, post-deadlock recovery)
- [x] `tests/scheme/smoke/fiber-pipeline.scm` — end-to-end: 2-stage and 3-stage pipelines, deadlock detection, parked-fiber wake after join
- [x] `tests/scheme/smoke/fiber-blocked-exit.scm` — process exits cleanly with parked workers
- [ ] `zig build test` passes
- [ ] `bash tests/scheme/run-all.sh` passes
- [ ] Linux CI (x86_64, aarch64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)