### PR TITLE
Range-check FFI args against declared narrow int types

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -162,11 +162,40 @@ fn validateArg(v: Value, t: FfiType) bool {
     };
 }
 
+fn checkNarrowIntRange(v: Value, declared: FfiType) error{TypeError}!void {
+    const wide = switch (declared) {
+        .int8, .uint8, .int16, .uint16, .char_type, .uint32, .uint64, .size_type => toIntArgOpt(v) orelse return error.TypeError,
+        else => return,
+    };
+    switch (declared) {
+        .int8 => {
+            if (wide < std.math.minInt(i8) or wide > std.math.maxInt(i8)) return error.TypeError;
+        },
+        .uint8, .char_type => {
+            if (wide < 0 or wide > std.math.maxInt(u8)) return error.TypeError;
+        },
+        .int16 => {
+            if (wide < std.math.minInt(i16) or wide > std.math.maxInt(i16)) return error.TypeError;
+        },
+        .uint16 => {
+            if (wide < 0 or wide > std.math.maxInt(u16)) return error.TypeError;
+        },
+        .uint32 => {
+            if (wide < 0 or wide > std.math.maxInt(u32)) return error.TypeError;
+        },
+        .uint64, .size_type => {
+            if (wide < 0) return error.TypeError;
+        },
+        else => {},
+    }
+}
+
 fn validateArgs(ffi_fn: *types.FfiFunction, args: []const Value) !void {
     for (0..ffi_fn.param_count) |i| {
         if (!validateArg(args[i], ffi_fn.param_types[i])) {
             return error.TypeError;
         }
+        try checkNarrowIntRange(args[i], ffi_fn.param_types[i]);
     }
 }
 
@@ -1150,4 +1179,89 @@ test "validateArg: accepts bignum for pointer type" {
 
     const big = try gc.allocBignumFromI64(0x1000);
     try std.testing.expect(validateArg(big, .pointer));
+}
+
+test "checkNarrowIntRange: int8 accepts [-128, 127]" {
+    try checkNarrowIntRange(types.makeFixnum(-128), .int8);
+    try checkNarrowIntRange(types.makeFixnum(127), .int8);
+    try checkNarrowIntRange(types.makeFixnum(0), .int8);
+}
+
+test "checkNarrowIntRange: int8 rejects out of range" {
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(128), .int8));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-129), .int8));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(200), .int8));
+}
+
+test "checkNarrowIntRange: uint8 accepts [0, 255]" {
+    try checkNarrowIntRange(types.makeFixnum(0), .uint8);
+    try checkNarrowIntRange(types.makeFixnum(255), .uint8);
+    try checkNarrowIntRange(types.makeFixnum(100), .uint8);
+}
+
+test "checkNarrowIntRange: uint8 rejects out of range" {
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(256), .uint8));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .uint8));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(300), .uint8));
+}
+
+test "checkNarrowIntRange: int16 accepts [-32768, 32767]" {
+    try checkNarrowIntRange(types.makeFixnum(-32768), .int16);
+    try checkNarrowIntRange(types.makeFixnum(32767), .int16);
+    try checkNarrowIntRange(types.makeFixnum(0), .int16);
+}
+
+test "checkNarrowIntRange: int16 rejects out of range" {
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(32768), .int16));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-32769), .int16));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(40000), .int16));
+}
+
+test "checkNarrowIntRange: uint16 accepts [0, 65535]" {
+    try checkNarrowIntRange(types.makeFixnum(0), .uint16);
+    try checkNarrowIntRange(types.makeFixnum(65535), .uint16);
+    try checkNarrowIntRange(types.makeFixnum(1000), .uint16);
+}
+
+test "checkNarrowIntRange: uint16 rejects out of range" {
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(65536), .uint16));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .uint16));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(70000), .uint16));
+}
+
+test "checkNarrowIntRange: uint32 accepts [0, 4294967295]" {
+    try checkNarrowIntRange(types.makeFixnum(0), .uint32);
+    try checkNarrowIntRange(types.makeFixnum(4294967295), .uint32);
+    try checkNarrowIntRange(types.makeFixnum(2147483648), .uint32);
+}
+
+test "checkNarrowIntRange: uint32 rejects out of range" {
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .uint32));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(4294967296), .uint32));
+}
+
+test "checkNarrowIntRange: char_type same as uint8" {
+    try checkNarrowIntRange(types.makeFixnum(0), .char_type);
+    try checkNarrowIntRange(types.makeFixnum(255), .char_type);
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(256), .char_type));
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .char_type));
+}
+
+test "checkNarrowIntRange: uint64 rejects negative" {
+    try checkNarrowIntRange(types.makeFixnum(0), .uint64);
+    try checkNarrowIntRange(types.makeFixnum(1000000), .uint64);
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .uint64));
+}
+
+test "checkNarrowIntRange: size_type rejects negative" {
+    try checkNarrowIntRange(types.makeFixnum(0), .size_type);
+    try checkNarrowIntRange(types.makeFixnum(1000000), .size_type);
+    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .size_type));
+}
+
+test "checkNarrowIntRange: non-narrow types pass through" {
+    try checkNarrowIntRange(types.makeFixnum(5000000000), .int);
+    try checkNarrowIntRange(types.makeFixnum(-5000000000), .long);
+    try checkNarrowIntRange(types.makeFixnum(999999), .int32);
+    try checkNarrowIntRange(types.makeFixnum(-999999), .int64);
 }

--- a/tests/scheme/ffi/narrow-range.scm
+++ b/tests/scheme/ffi/narrow-range.scm
@@ -1,0 +1,71 @@
+;; Regression test for #795: narrow int parameter types (int8/uint8/int16/
+;; uint16/uint32/char) must be range-checked against the declared type,
+;; not just the carrier (c_int/c_long).
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "narrow-range")
+
+(define libm (ffi-open "libm"))
+(define libc (ffi-open #f))
+
+;; ---- uint8 [0, 255] ----
+(define abs-u8 (ffi-fn libm "abs" '(uint8) 'int))
+(test-equal "uint8 valid: 0" 0 (abs-u8 0))
+(test-equal "uint8 valid: 42" 42 (abs-u8 42))
+(test-equal "uint8 valid: 255" 255 (abs-u8 255))
+(test-error "uint8 reject: 256" (abs-u8 256))
+(test-error "uint8 reject: -1" (abs-u8 -1))
+(test-error "uint8 reject: 300" (abs-u8 300))
+
+;; ---- int8 [-128, 127] ----
+(define abs-i8 (ffi-fn libm "abs" '(int8) 'int))
+(test-equal "int8 valid: 42" 42 (abs-i8 42))
+(test-equal "int8 valid: -42" 42 (abs-i8 -42))
+(test-equal "int8 valid: 127" 127 (abs-i8 127))
+(test-equal "int8 valid: -128" 128 (abs-i8 -128))
+(test-error "int8 reject: 128" (abs-i8 128))
+(test-error "int8 reject: -129" (abs-i8 -129))
+(test-error "int8 reject: 200" (abs-i8 200))
+
+;; ---- int16 [-32768, 32767] ----
+(define abs-i16 (ffi-fn libm "abs" '(int16) 'int))
+(test-equal "int16 valid: 1000" 1000 (abs-i16 1000))
+(test-equal "int16 valid: 32767" 32767 (abs-i16 32767))
+(test-equal "int16 valid: -32768" 32768 (abs-i16 -32768))
+(test-error "int16 reject: 32768" (abs-i16 32768))
+(test-error "int16 reject: -32769" (abs-i16 -32769))
+(test-error "int16 reject: 40000" (abs-i16 40000))
+
+;; ---- uint16 [0, 65535] ----
+(define abs-u16 (ffi-fn libm "abs" '(uint16) 'int))
+(test-equal "uint16 valid: 1000" 1000 (abs-u16 1000))
+(test-equal "uint16 valid: 65535" 65535 (abs-u16 65535))
+(test-error "uint16 reject: 65536" (abs-u16 65536))
+(test-error "uint16 reject: -1" (abs-u16 -1))
+(test-error "uint16 reject: 70000" (abs-u16 70000))
+
+;; ---- char [0, 255] ----
+(define abs-char (ffi-fn libm "abs" '(char) 'int))
+(test-equal "char valid: 65" 65 (abs-char 65))
+(test-equal "char valid: 0" 0 (abs-char 0))
+(test-equal "char valid: 255" 255 (abs-char 255))
+(test-error "char reject: 256" (abs-char 256))
+(test-error "char reject: -1" (abs-char -1))
+(test-error "char reject: 300" (abs-char 300))
+
+;; ---- uint32 [0, 4294967295] ----
+(define c-htonl (ffi-fn libc "htonl" '(uint32) 'uint32))
+(test-assert "uint32 valid: 0" (number? (c-htonl 0)))
+(test-assert "uint32 valid: 2^31" (number? (c-htonl 2147483648)))
+(test-assert "uint32 valid: 2^32-1" (number? (c-htonl 4294967295)))
+(test-error "uint32 reject: -1" (c-htonl -1))
+(test-error "uint32 reject: 2^32" (c-htonl 4294967296))
+(test-error "uint32 reject: 2^35" (c-htonl (expt 2 35)))
+
+(ffi-close libm)
+(ffi-close libc)
+
+(let ((runner (test-runner-current)))
+  (test-end "narrow-range")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Fix `normalizeType()` erasing declared width before validation — `int8`/`uint8`/`int16`/`uint16`/`uint32`/`char` args were only checked against the carrier type's range (`c_int` or `c_long`), silently wrapping out-of-range values
- Add `checkNarrowIntRange()` in `validateArgs()` to enforce the declared type's exact range before dispatch
- Add 14 Zig unit tests covering boundary values for each narrow type
- Add 36 Scheme integration tests (`tests/scheme/ffi/narrow-range.scm`) verifying acceptance and rejection through actual FFI calls

Closes #795

## Test plan

- [x] `zig build test` — all unit tests pass (including 14 new `checkNarrowIntRange` tests)
- [x] `zig build run -- tests/scheme/ffi/narrow-range.scm` — 36/36 pass
- [x] `zig build run -- tests/scheme/ffi/int-range.scm` — existing test still passes
- [x] `zig build run -- tests/scheme/ffi/uint32-range.scm` — existing test still passes (valid uint32 values in [0, 2^32-1] accepted)
- [x] `bash tests/scheme/run-all.sh` — 1657 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)