### PR TITLE
Invalidate stale native call sites after set!/define rebinding

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -17,6 +17,7 @@ pub const LLVMEmitter = struct {
     string_decls: std.ArrayList([]const u8),
     lambda_defs: std.ArrayList([]const u8),
     native_fns: std.StringHashMap(NativeLambda),
+    rebound_globals: std.StringHashMap(void),
     params: ?std.StringHashMap(u8),
     upvalues: ?std.StringHashMap(u8),
     tmp_counter: u32,
@@ -39,6 +40,7 @@ pub const LLVMEmitter = struct {
             .string_decls = .empty,
             .lambda_defs = .empty,
             .native_fns = std.StringHashMap(NativeLambda).init(allocator),
+            .rebound_globals = std.StringHashMap(void).init(allocator),
             .params = null,
             .upvalues = null,
             .tmp_counter = 0,
@@ -56,6 +58,7 @@ pub const LLVMEmitter = struct {
         self.string_decls.deinit(self.allocator);
         self.lambda_defs.deinit(self.allocator);
         self.native_fns.deinit();
+        self.rebound_globals.deinit();
     }
 
     pub fn emitProgram(self: *LLVMEmitter, nodes: []const *ir.Node) EmitError!void {
@@ -253,7 +256,7 @@ pub const LLVMEmitter = struct {
                     }
                 }
             }
-            if (!is_shadowed) {
+            if (!is_shadowed and !self.rebound_globals.contains(op_name)) {
                 if (call.args.len == 2) {
                     if (self.tryEmitInlineBinary(op_name, call.args)) |result| return result;
                 }
@@ -658,6 +661,14 @@ pub const LLVMEmitter = struct {
         // the value in the global environment and rebound a global (#819).
         const val = try self.emitScopedValue(data.value);
         try self.emitStoreToVariable(name, val);
+
+        // When set! targets a global, invalidate the native_fns entry so
+        // later call sites fall back to kaappi_global_lookup (#822).
+        if (!self.isNameShadowed(name)) {
+            _ = self.native_fns.fetchRemove(name);
+            self.rebound_globals.put(name, {}) catch {};
+        }
+
         return self.emitVoid();
     }
 
@@ -812,7 +823,11 @@ pub const LLVMEmitter = struct {
                         const fn_name = types.symbolName(types.car(target));
                         const formals = types.cdr(target);
                         const body = types.cdr(rest);
-                        _ = self.tryCompileDefineFunction(fn_name, formals, body);
+                        _ = self.native_fns.fetchRemove(fn_name);
+                        self.rebound_globals.put(fn_name, {}) catch {};
+                        if (self.tryCompileDefineFunction(fn_name, formals, body) != null) {
+                            _ = self.rebound_globals.fetchRemove(fn_name);
+                        }
                     }
                 }
             }
@@ -842,11 +857,20 @@ pub const LLVMEmitter = struct {
 
         const sym_name = try self.internSymbol(name);
 
+        // Remove any stale native_fns entry before attempting native
+        // compilation; tryCompileLambdaNative re-registers if it succeeds.
+        // Mark the name rebound so inline primitive dispatch is suppressed
+        // for later call sites (#822).
+        _ = self.native_fns.fetchRemove(name);
+        self.rebound_globals.put(name, {}) catch {};
+
         if (types.isPair(data.value)) {
             const head = types.car(data.value);
             if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "lambda")) {
                 const lambda_data = ir.LambdaData{ .args = types.cdr(data.value), .name = name };
-                _ = self.tryCompileLambdaNative(lambda_data);
+                if (self.tryCompileLambdaNative(lambda_data) != null) {
+                    _ = self.rebound_globals.fetchRemove(name);
+                }
             }
         }
 

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -79,6 +79,13 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     var ir_instance = ir_mod.IR.init(allocator);
     defer ir_instance.deinit();
 
+    // Track names that are targets of define or set! in previous top-level
+    // forms so constant folding does not inline primitive semantics for a
+    // name that will be rebound at runtime (#822).
+    var redefined_names = std.StringHashMap(void).init(allocator);
+    defer redefined_names.deinit();
+    ir_instance.set_targets = &redefined_names;
+
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
         var errbuf: [256]u8 = undefined;
@@ -137,6 +144,10 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         root = ir_mod.simplifyBegin(&ir_instance, root);
 
         ir_nodes.append(allocator, root) catch return;
+
+        // Record any define/set! target from this form so that the next
+        // form's constant folding does not assume the primitive is unmodified.
+        collectRedefinedNames(expr, &redefined_names);
     }
 
     var emitter = llvm_emit.LLVMEmitter.init(allocator);
@@ -297,6 +308,37 @@ fn getExeRelativeLibDir(allocator: std.mem.Allocator) ?[]const u8 {
     if (checkLibDir(allocator, lib_dir)) return lib_dir;
     allocator.free(lib_dir);
     return null;
+}
+
+fn collectRedefinedNames(expr: types.Value, map: *std.StringHashMap(void)) void {
+    if (!types.isPair(expr)) return;
+    const head = types.car(expr);
+    if (!types.isSymbol(head)) return;
+    const form = types.symbolName(head);
+
+    if (std.mem.eql(u8, form, "define")) {
+        const rest = types.cdr(expr);
+        if (rest == types.NIL or !types.isPair(rest)) return;
+        const target = types.car(rest);
+        if (types.isSymbol(target)) {
+            map.put(types.symbolName(target), {}) catch {};
+        } else if (types.isPair(target) and types.isSymbol(types.car(target))) {
+            map.put(types.symbolName(types.car(target)), {}) catch {};
+        }
+    } else if (std.mem.eql(u8, form, "set!")) {
+        const rest = types.cdr(expr);
+        if (rest == types.NIL or !types.isPair(rest)) return;
+        const target = types.car(rest);
+        if (types.isSymbol(target)) {
+            map.put(types.symbolName(target), {}) catch {};
+        }
+    } else if (std.mem.eql(u8, form, "begin")) {
+        var body = types.cdr(expr);
+        while (body != types.NIL and types.isPair(body)) {
+            collectRedefinedNames(types.car(body), map);
+            body = types.cdr(body);
+        }
+    }
 }
 
 fn checkLibDir(allocator: std.mem.Allocator, dir: []const u8) bool {

--- a/tests/scheme/compile/native-rebind-stale-call-822.sh
+++ b/tests/scheme/compile/native-rebind-stale-call-822.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Regression test for #822: LLVM native backend kept invoking stale native code
+# after set!/define rebound a procedure name. Three mechanisms were affected:
+#
+# 1. native_fns direct calls — set! or non-lambda define did not remove the
+#    entry, so later call sites still dispatched to the old native function.
+# 2. Inline primitives — tryEmitInlineBinary/tryEmitInlineUnary used the
+#    original primitive even after a top-level (define + -).
+#
+# Each case must produce the same output from the native binary as from the
+# interpreter.
+#
+# Usage: bash tests/scheme/compile/native-rebind-stale-call-822.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
+    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+fi
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+check() {
+    local name="$1" src="$2" expect_out="$3" expect_status="$4"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    if ! (cd "$DIR" && "$KAAPPI_ABS" compile "$name.scm" -o "$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    set +e
+    local out status
+    out=$("$DIR/$name" 2>/dev/null)
+    status=$?
+    set -e
+
+    if [[ "$out" != "$expect_out" ]]; then
+        echo "FAIL: $name — native stdout '$out' != expected '$expect_out'" >&2
+        fail=1
+    fi
+    if [[ "$status" -ne "$expect_status" ]]; then
+        echo "FAIL: $name — native exit $status != expected $expect_status" >&2
+        fail=1
+    fi
+}
+
+# 1. set! replacing a natively compiled function.
+check set-replace-native \
+'(define (f x) (+ x 1))
+(set! f (lambda (x) (* x 2)))
+(display (f 5))
+(newline)' \
+'10' 0
+
+# 2. define aliasing one function to another.
+check define-alias \
+'(define (f x) (+ x 1))
+(define (g x) (* x 3))
+(define f g)
+(display (f 5))
+(newline)' \
+'15' 0
+
+# 3. Redefining an arithmetic primitive.
+check redefine-primitive \
+'(define + -)
+(display (+ 10 3))
+(newline)' \
+'7' 0
+
+# 4. Redefining car/cdr (unary inline primitives).
+check redefine-car \
+'(define car cdr)
+(display (car (cons 1 2)))
+(newline)' \
+'2' 0
+
+# 5. Redefining cons (binary inline primitive).
+check redefine-cons \
+'(define original-cons cons)
+(define (cons a b) (original-cons b a))
+(display (car (cons 1 2)))
+(newline)' \
+'2' 0
+
+# 6. Redefine then re-define with a new native lambda — the new native
+#    version should be used.
+check redefine-then-redefine \
+'(define (f x) (+ x 1))
+(define f (lambda (x) (* x 10)))
+(define (f x) (+ x 100))
+(display (f 5))
+(newline)' \
+'105' 0
+
+# 7. null? redefined (unary inline primitive).
+check redefine-null \
+'(define null? pair?)
+(display (null? (list 1 2)))
+(newline)' \
+'#t' 0
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-rebind-stale-call-822: all cases passed"


### PR DESCRIPTION
## Summary

Fixes #822.

- **LLVM emitter**: track globally-rebound names in a `rebound_globals` set; `emitSet`, `emitDefine`, and `emitPassthrough` remove stale `native_fns` entries and mark names as rebound so later call sites fall through to `kaappi_global_lookup` + `kaappi_call_scheme`
- **Inline primitive dispatch**: `emitCallNode` checks `rebound_globals` before inlining `+`, `-`, `*`, `<`, `=`, `cons`, `car`, `cdr`, `null?`
- **IR constant folding**: `collectRedefinedNames` in `native_compiler.zig` feeds define/set! targets across top-level forms into the IR's `set_targets`, suppressing constant folding for rebound primitives (e.g. `(+ 10 3)` → `13`)

## Test plan

- [x] New regression test `native-rebind-stale-call-822.sh` with 7 cases: set! replacing native fn, define aliasing, redefining arithmetic/unary/binary primitives, re-define recovery, null? redefinition
- [x] All existing compile tests pass (`set-define-lexical-scope-819.sh`, `native-param-shadow-fold-790.sh`, etc.)
- [x] `zig build test` — all unit tests pass
- [x] `run-all.sh` — 1656 pass, 0 fail, 0 timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)