### PR TITLE
Handle cond-expand and nested include-library-declarations in ILD

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -1054,6 +1054,75 @@ fn compileLibInclude(vm: *VM, lib_env: *std.StringHashMap(Value), file_list_val:
     }
 }
 
+fn processLibDeclaration(
+    vm: *VM,
+    lib_env: *std.StringHashMap(Value),
+    declaration: Value,
+    export_names: *std.ArrayList([]const u8),
+    export_renames: *std.ArrayList(?[]const u8),
+) VMError!void {
+    if (!types.isPair(declaration)) return VMError.CompileError;
+    const decl_head = types.car(declaration);
+    if (!types.isSymbol(decl_head)) return VMError.CompileError;
+    const decl_name = types.symbolName(decl_head);
+
+    if (std.mem.eql(u8, decl_name, "export")) {
+        var id_list = types.cdr(declaration);
+        while (id_list != types.NIL) {
+            if (!types.isPair(id_list)) return VMError.CompileError;
+            const id = types.car(id_list);
+            if (types.isSymbol(id)) {
+                export_names.append(vm.gc.allocator, types.symbolName(id)) catch return VMError.OutOfMemory;
+                export_renames.append(vm.gc.allocator, null) catch return VMError.OutOfMemory;
+            } else if (types.isPair(id)) {
+                const rename_head = types.car(id);
+                if (types.isSymbol(rename_head) and std.mem.eql(u8, types.symbolName(rename_head), "rename")) {
+                    const rename_args = types.cdr(id);
+                    if (types.isPair(rename_args)) {
+                        const internal = types.car(rename_args);
+                        const rest = types.cdr(rename_args);
+                        if (types.isPair(rest) and types.isSymbol(internal)) {
+                            const external = types.car(rest);
+                            if (types.isSymbol(external)) {
+                                export_names.append(vm.gc.allocator, types.symbolName(internal)) catch return VMError.OutOfMemory;
+                                export_renames.append(vm.gc.allocator, types.symbolName(external)) catch return VMError.OutOfMemory;
+                            }
+                        }
+                    }
+                }
+            }
+            id_list = types.cdr(id_list);
+        }
+    } else if (std.mem.eql(u8, decl_name, "import")) {
+        _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch return VMError.CompileError;
+    } else if (std.mem.eql(u8, decl_name, "begin")) {
+        try compileLibBeginBlock(vm, lib_env, types.cdr(declaration));
+    } else if (std.mem.eql(u8, decl_name, "include") or std.mem.eql(u8, decl_name, "include-ci")) {
+        try compileLibInclude(vm, lib_env, types.cdr(declaration));
+    } else if (std.mem.eql(u8, decl_name, "include-library-declarations")) {
+        try includeLibraryDeclarations(vm, lib_env, types.cdr(declaration), export_names, export_renames);
+    } else if (std.mem.eql(u8, decl_name, "cond-expand")) {
+        var clauses = types.cdr(declaration);
+        while (clauses != types.NIL) {
+            if (!types.isPair(clauses)) break;
+            const clause = types.car(clauses);
+            clauses = types.cdr(clauses);
+            if (!types.isPair(clause)) continue;
+            const feature_req = types.car(clause);
+            var clause_decls = types.cdr(clause);
+            const is_else = types.isSymbol(feature_req) and std.mem.eql(u8, types.symbolName(feature_req), "else");
+            if (is_else or evalLibFeatureReq(vm, feature_req)) {
+                while (clause_decls != types.NIL) {
+                    if (!types.isPair(clause_decls)) break;
+                    try processLibDeclaration(vm, lib_env, types.car(clause_decls), export_names, export_renames);
+                    clause_decls = types.cdr(clause_decls);
+                }
+                break;
+            }
+        }
+    }
+}
+
 fn includeLibraryDeclarations(
     vm: *VM,
     lib_env: *std.StringHashMap(Value),
@@ -1093,45 +1162,7 @@ fn includeLibraryDeclarations(
             var declaration = file_reader.readDatum() catch return VMError.CompileError;
             vm.gc.pushRoot(&declaration) catch return VMError.CompileError;
             defer vm.gc.popRoot();
-            if (!types.isPair(declaration)) return VMError.CompileError;
-            const decl_head = types.car(declaration);
-            if (!types.isSymbol(decl_head)) return VMError.CompileError;
-            const decl_name = types.symbolName(decl_head);
-
-            if (std.mem.eql(u8, decl_name, "export")) {
-                var id_list = types.cdr(declaration);
-                while (id_list != types.NIL) {
-                    if (!types.isPair(id_list)) return VMError.CompileError;
-                    const id = types.car(id_list);
-                    if (types.isSymbol(id)) {
-                        export_names.append(vm.gc.allocator, types.symbolName(id)) catch return VMError.OutOfMemory;
-                        export_renames.append(vm.gc.allocator, null) catch return VMError.OutOfMemory;
-                    } else if (types.isPair(id)) {
-                        const rename_head = types.car(id);
-                        if (types.isSymbol(rename_head) and std.mem.eql(u8, types.symbolName(rename_head), "rename")) {
-                            const rename_args = types.cdr(id);
-                            if (types.isPair(rename_args)) {
-                                const internal = types.car(rename_args);
-                                const rest = types.cdr(rename_args);
-                                if (types.isPair(rest) and types.isSymbol(internal)) {
-                                    const external = types.car(rest);
-                                    if (types.isSymbol(external)) {
-                                        export_names.append(vm.gc.allocator, types.symbolName(internal)) catch return VMError.OutOfMemory;
-                                        export_renames.append(vm.gc.allocator, types.symbolName(external)) catch return VMError.OutOfMemory;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    id_list = types.cdr(id_list);
-                }
-            } else if (std.mem.eql(u8, decl_name, "import")) {
-                _ = handleImportInto(vm, lib_env, types.cdr(declaration)) catch return VMError.CompileError;
-            } else if (std.mem.eql(u8, decl_name, "begin")) {
-                try compileLibBeginBlock(vm, lib_env, types.cdr(declaration));
-            } else if (std.mem.eql(u8, decl_name, "include") or std.mem.eql(u8, decl_name, "include-ci")) {
-                try compileLibInclude(vm, lib_env, types.cdr(declaration));
-            }
+            try processLibDeclaration(vm, lib_env, declaration, export_names, export_renames);
         }
 
         file_list = types.cdr(file_list);

--- a/tests/scheme/compliance/fixtures/ild-cond-expand.scm
+++ b/tests/scheme/compliance/fixtures/ild-cond-expand.scm
@@ -1,0 +1,3 @@
+(export inner-x)
+(cond-expand
+  (else (begin (define inner-x 'from-cond-expand))))

--- a/tests/scheme/compliance/fixtures/ild-nested-inner.scm
+++ b/tests/scheme/compliance/fixtures/ild-nested-inner.scm
@@ -1,0 +1,2 @@
+(export inner-y)
+(begin (define inner-y 'nested-ild))

--- a/tests/scheme/compliance/fixtures/ild-nested-outer.scm
+++ b/tests/scheme/compliance/fixtures/ild-nested-outer.scm
@@ -1,0 +1,1 @@
+(include-library-declarations "fixtures/ild-nested-inner.scm")

--- a/tests/scheme/compliance/include-lib-decls.scm
+++ b/tests/scheme/compliance/include-lib-decls.scm
@@ -1,25 +1,47 @@
-;; Test include-library-declarations — R7RS §5.3.2
+;; Test include-library-declarations — R7RS §5.6.1
 ;;
-;; The exports fixture lives in fixtures/ so run-all.sh doesn't execute it
-;; as a standalone test — it is only meaningful spliced into define-library.
+;; Fixtures live in fixtures/ so run-all.sh doesn't execute them
+;; as standalone tests — they are only meaningful spliced into define-library.
 
-(define-library (test include-lib-decls)
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "include-library-declarations")
+
+;; Basic export via include-library-declarations
+(define-library (test ild basic)
   (import (scheme base))
   (include-library-declarations "fixtures/include-lib-decls-exports.scm")
   (begin
     (define (my-add a b) (+ a b))
     (define (my-mul a b) (* a b))))
 
-(import (scheme base) (scheme write) (scheme process-context)
-        (test include-lib-decls))
+(import (test ild basic))
 
-(unless (= 7 (my-add 3 4))
-  (display "FAIL my-add") (newline)
-  (exit 1))
+(test-equal "basic export via include-library-declarations"
+  7 (my-add 3 4))
+(test-equal "basic export via include-library-declarations (2)"
+  30 (my-mul 5 6))
 
-(unless (= 30 (my-mul 5 6))
-  (display "FAIL my-mul") (newline)
-  (exit 1))
+;; Regression #874: cond-expand inside include-library-declarations
+(define-library (test ild cond-expand)
+  (import (scheme base))
+  (include-library-declarations "fixtures/ild-cond-expand.scm"))
 
-(display "include-lib-decls-ok")
-(newline)
+(import (test ild cond-expand))
+
+(test-equal "cond-expand inside include-library-declarations"
+  'from-cond-expand inner-x)
+
+;; Regression #874: nested include-library-declarations
+(define-library (test ild nested)
+  (import (scheme base))
+  (include-library-declarations "fixtures/ild-nested-outer.scm"))
+
+(import (test ild nested))
+
+(test-equal "nested include-library-declarations"
+  'nested-ild inner-y)
+
+(let ((runner (test-runner-current)))
+  (test-end "include-library-declarations")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Extract per-declaration processing from `includeLibraryDeclarations` into `processLibDeclaration` with all six R7RS library declaration types (export, import, begin, include/include-ci, **cond-expand**, **include-library-declarations**)
- `cond-expand` evaluates feature requirements and recursively processes matched clause declarations
- Nested `include-library-declarations` calls `includeLibraryDeclarations` recursively
- Existing test converted to SRFI-64 and extended with two regression cases

Fixes #874

## Test plan

- [x] New test: `cond-expand` inside `include-library-declarations` defines and exports a binding
- [x] New test: nested `include-library-declarations` (outer includes inner) defines and exports a binding
- [x] Existing `include-library-declarations` basic export test still passes
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 261 Scheme files pass, 1395 R7RS tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)