### PR TITLE
Reject directories and propagate read errors in readFileContents

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -180,6 +180,16 @@ fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     }
     defer _ = std.c.close(fd);
 
+    if (comptime !is_wasm) {
+        var stat: std.c.Stat = undefined;
+        if (std.c.fstat(fd, &stat) == 0) {
+            if (stat.mode & std.posix.S.IFMT == std.posix.S.IFDIR) {
+                std.debug.print("Error: '{s}' is a directory\n", .{path});
+                return error.IsDir;
+            }
+        }
+    }
+
     const max_size: usize = 1024 * 1024;
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(allocator);
@@ -189,8 +199,10 @@ fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
         const raw = std.c.read(fd, &tmp, tmp.len);
         if (raw == 0) break;
         if (raw < 0) {
-            if (std.posix.errno(raw) == .INTR) continue;
-            break;
+            const e = std.posix.errno(raw);
+            if (e == .INTR) continue;
+            std.debug.print("Error reading file '{s}': {s}\n", .{ path, @tagName(e) });
+            return error.InputOutput;
         }
         const bytes_read: usize = @intCast(raw);
         if (result.items.len + bytes_read > max_size) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
-const is_wasm = @import("builtin").os.tag == .wasi;
+const builtin_os = @import("builtin").os;
+const is_wasm = builtin_os.tag == .wasi;
+const is_linux = builtin_os.tag == .linux;
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 pub const types = @import("types.zig");
 pub const memory = @import("memory.zig");
@@ -181,12 +183,18 @@ fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     defer _ = std.c.close(fd);
 
     if (comptime !is_wasm) {
-        var stat: std.c.Stat = undefined;
-        if (std.c.fstat(fd, &stat) == 0) {
-            if (stat.mode & std.posix.S.IFMT == std.posix.S.IFDIR) {
-                std.debug.print("Error: '{s}' is a directory\n", .{path});
-                return error.IsDir;
-            }
+        const is_dir = if (comptime is_linux) blk: {
+            const linux = std.os.linux;
+            var sx: linux.Statx = undefined;
+            const rc = linux.statx(fd, "", 0x1000, .{ .TYPE = true }, &sx);
+            break :blk rc <= @as(usize, std.math.maxInt(isize)) and (sx.mode & std.posix.S.IFMT == std.posix.S.IFDIR);
+        } else blk: {
+            var stat: std.c.Stat = undefined;
+            break :blk std.c.fstat(fd, &stat) == 0 and (stat.mode & std.posix.S.IFMT == std.posix.S.IFDIR);
+        };
+        if (is_dir) {
+            std.debug.print("Error: '{s}' is a directory\n", .{path});
+            return error.IsDir;
         }
     }
 

--- a/tests/scheme/errors/exit-code.sh
+++ b/tests/scheme/errors/exit-code.sh
@@ -104,6 +104,12 @@ assert_exit_code "--compile read error exits 1" 1 "$KAAPPI" --compile "$TMPDIR_T
 assert_exit_code "--compile missing file exits 1" 1 "$KAAPPI" --compile "$TMPDIR_TESTS/nope.scm"
 assert_exit_code "--disassemble read error exits 1" 1 "$KAAPPI" --disassemble "$TMPDIR_TESTS/unbal.scm"
 
+# Passing a directory must error, not silently run an empty program (#789)
+mkdir -p "$TMPDIR_TESTS/adir"
+assert_exit_code "directory as script exits 1" 1 "$KAAPPI" "$TMPDIR_TESTS/adir"
+assert_exit_code "--compile directory exits 1" 1 "$KAAPPI" --compile "$TMPDIR_TESTS/adir"
+assert_exit_code "--disassemble directory exits 1" 1 "$KAAPPI" --disassemble "$TMPDIR_TESTS/adir"
+
 # A build/inspect mode invoked with no file is a usage error, not exit 0
 assert_exit_code "--compile without file exits 2" 2 "$KAAPPI" --compile
 assert_exit_code "--disassemble without file exits 2" 2 "$KAAPPI" --disassemble


### PR DESCRIPTION
## Summary

- `readFileContents` now uses `fstat` to detect directories and returns `error.IsDir` with a clear message (`Error: 'path' is a directory`)
- Read errors other than `EINTR` are now reported and propagated as `error.InputOutput` instead of silently treated as EOF
- Affects all modes: script execution, `--compile`, and `--disassemble`

Fixes #789

## Test plan

- [x] Added 3 regression tests to `tests/scheme/errors/exit-code.sh` (directory as script, `--compile` directory, `--disassemble` directory)
- [x] All 32 exit-code tests pass
- [x] `zig build test` passes
- [x] Normal file execution still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)