### PR TITLE
Fix LLVM backend eval fallback losing lexical environment (#827)

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -338,19 +338,59 @@ pub const LLVMEmitter = struct {
 
     fn emitLetFallback(self: *LLVMEmitter, args: Value, sequential: bool) EmitError![]const u8 {
         const keyword = if (sequential) "let*" else "let";
-        const printed = printer.valueToString(self.allocator, args, .write) catch return error.OutOfMemory;
-        defer self.allocator.free(printed);
-        const source = std.fmt.allocPrint(self.allocator, "({s} {s})", .{ keyword, printed }) catch return error.OutOfMemory;
-        defer self.allocator.free(source);
-        const str_name = try self.internString(source);
+        // Build `(let bindings body ...)` by iterating the args list elements.
+        // The args value is `(bindings body ...)` — a list whose elements must
+        // be printed individually (not as one list) to avoid extra parens.
+        var source_buf: std.ArrayList(u8) = .empty;
+        defer source_buf.deinit(self.allocator);
+        source_buf.appendSlice(self.allocator, "(") catch return error.OutOfMemory;
+        source_buf.appendSlice(self.allocator, keyword) catch return error.OutOfMemory;
+        var current = args;
+        while (current != types.NIL and types.isPair(current)) {
+            source_buf.append(self.allocator, ' ') catch return error.OutOfMemory;
+            const elem = types.car(current);
+            const elem_str = printer.valueToString(self.allocator, elem, .write) catch return error.OutOfMemory;
+            defer self.allocator.free(elem_str);
+            source_buf.appendSlice(self.allocator, elem_str) catch return error.OutOfMemory;
+            current = types.cdr(current);
+        }
+        source_buf.append(self.allocator, ')') catch return error.OutOfMemory;
+        const str_name = try self.internString(source_buf.items);
         const tmp = try self.freshTemp();
-        try self.print("  {s} = call i64 @kaappi_eval(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, source.len });
+        try self.print("  {s} = call i64 @kaappi_eval(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, source_buf.items.len });
         return tmp;
     }
 
     fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool) EmitError![]const u8 {
         const bindings = types.car(args);
         const body_list = types.cdr(args);
+
+        // #827: If the let form (bindings or body) contains sub-expressions
+        // that need interpreter eval fallback (cond, do, letrec, etc.),
+        // compile the entire let via the interpreter to preserve correct
+        // lexical scoping.
+        if (lambda.sexprNeedsEvalFallback(args)) {
+            return self.emitLetFallback(args, sequential);
+        }
+        // #827: If the body contains a lambda that captures let-bound variable
+        // names, it cannot be compiled natively inside this scope (the lambda
+        // would be evaluated in the global environment, losing the bindings).
+        {
+            var var_names: [32][]const u8 = undefined;
+            var name_count: usize = 0;
+            var blist = bindings;
+            while (blist != types.NIL and types.isPair(blist)) : (blist = types.cdr(blist)) {
+                if (name_count >= 32) break;
+                const b = types.car(blist);
+                if (types.isPair(b) and types.isSymbol(types.car(b))) {
+                    var_names[name_count] = types.symbolName(types.car(b));
+                    name_count += 1;
+                }
+            }
+            if (name_count > 0 and lambda.bodyHasCapturingLambda(body_list, var_names[0..name_count])) {
+                return self.emitLetFallback(args, sequential);
+            }
+        }
 
         const saved_locals = self.locals;
         self.locals = if (saved_locals) |existing|
@@ -429,9 +469,16 @@ pub const LLVMEmitter = struct {
             const node = ir.lowerSingleExprTail(self.allocator, types.car(body_expr), expr_is_tail) catch {
                 self.locals.?.deinit();
                 self.locals = saved_locals;
-                return error.UnsupportedNodeType;
+                return self.emitLetFallback(args, sequential);
             };
-            last = try self.emitNode(node);
+            // #827: if emitNode fails (e.g. a lambda that cannot be eval'd in
+            // this lexical scope), fall back to evaluating the entire let form
+            // via the interpreter.
+            last = self.emitNode(node) catch {
+                self.locals.?.deinit();
+                self.locals = saved_locals;
+                return self.emitLetFallback(args, sequential);
+            };
             body_expr = rest;
         }
 

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -20,6 +20,14 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
     if (body_list == types.NIL) return null;
     if (!types.isPair(formals_val) and formals_val != types.NIL) return null;
 
+    // #827: reject if body contains forms needing interpreter eval fallback
+    {
+        var be = body_list;
+        while (be != types.NIL and types.isPair(be)) : (be = types.cdr(be)) {
+            if (sexprNeedsEvalFallback(types.car(be))) return null;
+        }
+    }
+
     var param_names: [16][]const u8 = undefined;
     var arity: u8 = 0;
     var rest_name: ?[]const u8 = null;
@@ -99,6 +107,14 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
         var be = body_list;
         while (be != types.NIL and types.isPair(be)) : (be = types.cdr(be)) {
             if (sexprContainsSetOrDefine(types.car(be))) return null;
+        }
+    }
+
+    // #827: reject if body contains forms needing interpreter eval fallback
+    {
+        var be2 = body_list;
+        while (be2 != types.NIL and types.isPair(be2)) : (be2 = types.cdr(be2)) {
+            if (sexprNeedsEvalFallback(types.car(be2))) return null;
         }
     }
 
@@ -313,6 +329,12 @@ pub fn bindParamsAsGlobals(self: *LLVMEmitter) EmitError!void {
 }
 
 fn emitLambdaViaEval(self: *LLVMEmitter, data: ir.LambdaData) EmitError![]const u8 {
+    // #827: Inside a lexical scope with local bindings (a let body),
+    // evaluating the lambda in the global environment would lose those
+    // bindings.  Signal failure so the enclosing let falls back to the
+    // interpreter, which handles scoping correctly.
+    if (self.locals != null) return error.UnsupportedNodeType;
+
     try bindParamsAsGlobals(self);
 
     var source_buf: std.ArrayList(u8) = .empty;
@@ -348,6 +370,14 @@ pub fn tryCompileLambdaNative(self: *LLVMEmitter, data: ir.LambdaData) ?[]const 
 
 pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: Value, body: Value) ?[]const u8 {
     if (body == types.NIL) return null;
+
+    // #827: reject if body contains forms needing interpreter eval fallback
+    {
+        var be = body;
+        while (be != types.NIL and types.isPair(be)) : (be = types.cdr(be)) {
+            if (sexprNeedsEvalFallback(types.car(be))) return null;
+        }
+    }
 
     var param_names: [16][]const u8 = undefined;
     var arity: u8 = 0;
@@ -575,6 +605,127 @@ fn emitRestListBuilder(self: *LLVMEmitter, fixed_arity: usize) EmitError!void {
 
     try self.print("{s}:\n", .{done_lbl});
     self.current_block = done_lbl;
+}
+
+// --- Eval-fallback detection helpers ---
+
+// True if `expr` (a raw S-expression) contains any form that the LLVM native
+// backend cannot compile and would dispatch to emitSexprEval.  Used by
+// emitLet and emitLambdaFunction to reject native compilation of the
+// enclosing scope when a sub-form would cross the native/interpreted boundary,
+// losing lexical bindings (#827).
+pub fn sexprNeedsEvalFallback(expr: Value) bool {
+    if (!types.isPair(expr)) return false;
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const name = types.symbolName(head);
+        if (isEvalFallbackForm(name)) return true;
+        if (std.mem.eql(u8, name, "quote")) return false;
+        // Named let: (let <symbol> ...) — not compiled natively.
+        if (std.mem.eql(u8, name, "let")) {
+            const rest = types.cdr(expr);
+            if (rest != types.NIL and types.isPair(rest) and types.isSymbol(types.car(rest))) return true;
+        }
+    }
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        if (sexprNeedsEvalFallback(types.car(cur))) return true;
+    }
+    return false;
+}
+
+fn isEvalFallbackForm(name: []const u8) bool {
+    const forms = [_][]const u8{
+        "letrec",     "letrec*",       "do",
+        "delay",      "delay-force",   "cond",
+        "case",       "case-lambda",   "guard",
+        "quasiquote", "parameterize",  "define-values",
+        "let-values", "let*-values",   "define-syntax",
+        "let-syntax", "letrec-syntax", "cond-expand",
+    };
+    for (forms) |f| {
+        if (std.mem.eql(u8, name, f)) return true;
+    }
+    return false;
+}
+
+// True if `body_list` (a cons list of body expressions) contains a lambda
+// whose body references any name in `local_names` (let-bound variables) that
+// is not shadowed by the lambda's own formals.  Such a lambda cannot be
+// compiled natively inside a let scope: the native closure tiers
+// (tryCompileNativeClosure / tryCompilePureLambdaAsNativeClosure) would
+// reject it, and emitLambdaViaEval would evaluate it in the global
+// environment where the let bindings are invisible (#827).
+pub fn bodyHasCapturingLambda(body_list: Value, local_names: []const []const u8) bool {
+    var expr = body_list;
+    while (expr != types.NIL and types.isPair(expr)) : (expr = types.cdr(expr)) {
+        if (exprHasCapturingLambda(types.car(expr), local_names)) return true;
+    }
+    return false;
+}
+
+fn exprHasCapturingLambda(expr: Value, local_names: []const []const u8) bool {
+    if (!types.isPair(expr)) return false;
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const name = types.symbolName(head);
+        if (std.mem.eql(u8, name, "lambda")) {
+            const rest = types.cdr(expr);
+            if (rest != types.NIL and types.isPair(rest)) {
+                const formals = types.car(rest);
+                const body = types.cdr(rest);
+                var formal_names: [32][]const u8 = undefined;
+                var formal_count: usize = 0;
+                var flist = formals;
+                while (types.isPair(flist)) : (flist = types.cdr(flist)) {
+                    const f = types.car(flist);
+                    if (types.isSymbol(f) and formal_count < 32) {
+                        formal_names[formal_count] = types.symbolName(f);
+                        formal_count += 1;
+                    }
+                }
+                // Rest-param symbol after dotted pair or bare symbol formals.
+                if (types.isSymbol(flist) and formal_count < 32) {
+                    formal_names[formal_count] = types.symbolName(flist);
+                    formal_count += 1;
+                }
+                if (types.isSymbol(formals) and formal_count < 32) {
+                    formal_names[formal_count] = types.symbolName(formals);
+                    formal_count += 1;
+                }
+                if (sexprReferencesNames(body, local_names, formal_names[0..formal_count])) return true;
+            }
+            return false;
+        }
+        if (std.mem.eql(u8, name, "quote")) return false;
+    }
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        if (exprHasCapturingLambda(types.car(cur), local_names)) return true;
+    }
+    return false;
+}
+
+// True if the S-expression references any symbol in `target_names` that is
+// not in `excluded_names`.  Does not descend into quoted data.
+fn sexprReferencesNames(expr: Value, target_names: []const []const u8, excluded_names: []const []const u8) bool {
+    if (types.isSymbol(expr)) {
+        const name = types.symbolName(expr);
+        for (excluded_names) |e| {
+            if (std.mem.eql(u8, name, e)) return false;
+        }
+        for (target_names) |t| {
+            if (std.mem.eql(u8, name, t)) return true;
+        }
+        return false;
+    }
+    if (!types.isPair(expr)) return false;
+    if (types.isSymbol(types.car(expr)) and std.mem.eql(u8, types.symbolName(types.car(expr)), "quote")) return false;
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        if (sexprReferencesNames(types.car(cur), target_names, excluded_names)) return true;
+    }
+    return false;
 }
 
 // --- Free variable analysis helpers (standalone, no self) ---

--- a/tests/scheme/smoke/llvm-let-scope-827.scm
+++ b/tests/scheme/smoke/llvm-let-scope-827.scm
@@ -1,0 +1,80 @@
+;; Regression test for #827: LLVM native backend eval fallback inside
+;; let/lambda bodies must not lose the lexical environment.
+;;
+;; These tests run through the interpreter (which handles scoping
+;; correctly), verifying the semantics that the native backend must
+;; reproduce.  The LLVM backend fix ensures that when a let or lambda
+;; body contains forms needing eval fallback (cond, do, letrec, etc.),
+;; the entire enclosing form is evaluated by the interpreter instead of
+;; splitting the lexical scope across the native/interpreted boundary.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "llvm-let-scope-827")
+
+;; Repro 1: cond inside a let body — the cond must see let-bound x.
+(test-equal "cond inside let"
+  5
+  (let ((x 5)) (cond ((> x 1) x) (else 0))))
+
+;; Repro 2: lambda capturing a let local — the lambda must close over y.
+(test-equal "lambda capturing let local"
+  10
+  ((let ((y 10)) (lambda () y))))
+
+;; Repro 3: parameter must not clobber a same-named global.
+(define x 100)
+(define (f x) (cond ((> x 0) x) (else 0)))
+(test-equal "function returns param, not global" 5 (f 5))
+(test-equal "global x unchanged after call" 100 x)
+
+;; Additional edge cases:
+
+;; let* with cond referencing earlier binding
+(test-equal "let* cond references earlier binding"
+  11
+  (let* ((a 10) (b (+ a 1)))
+    (cond ((> b 5) b) (else 0))))
+
+;; Nested let with cond in inner body
+(test-equal "nested let with cond"
+  6
+  (let ((x 5))
+    (let ((y (+ x 1)))
+      (cond ((> y 3) y) (else 0)))))
+
+;; do inside a let body
+(test-equal "do inside let"
+  55
+  (let ((n 10))
+    (do ((i 0 (+ i 1))
+         (sum 0 (+ sum i)))
+        ((= i n) (+ sum n)))))
+
+;; letrec inside a let body
+(test-equal "letrec inside let"
+  #t
+  (let ((x 5))
+    (letrec ((even? (lambda (n) (if (= n 0) #t (odd? (- n 1)))))
+             (odd?  (lambda (n) (if (= n 0) #f (even? (- n 1))))))
+      (odd? x))))
+
+;; case inside a lambda body
+(define (classify n)
+  (case n
+    ((1 2 3) 'small)
+    ((4 5 6) 'medium)
+    (else 'large)))
+(test-equal "case inside define" 'medium (classify 5))
+(test-equal "case inside define (else)" 'large (classify 99))
+
+;; lambda with let local in a let* binding init
+(test-equal "lambda capturing let* local in init"
+  10
+  (let* ((y 10)
+         (f (lambda () y)))
+    (f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "llvm-let-scope-827")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Prevent the LLVM native backend from splitting a lexical scope across the native/interpreted boundary, which lost `let`-bound locals and clobbered globals via `bindParamsAsGlobals`
- When a `let` or lambda body contains sub-forms that need interpreter eval fallback (`cond`, `do`, `letrec`, etc.), the entire enclosing form is now evaluated by the interpreter instead
- Also fix a pre-existing bug in `emitLetFallback` that serialized the let args with an extra layer of parentheses

Fixes #827

## Test plan

- [x] All 3 reproductions from the issue now produce identical output in interpreter and native modes
- [x] Regression test added: `tests/scheme/smoke/llvm-let-scope-827.scm` (11 assertions)
- [x] Full test suite passes: 1662 tests, 0 failures (267 Scheme files + 1395 R7RS)
- [x] `zig build test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)