### PR TITLE
Preserve string/bytevector eq? identity in thread deep copy (#807)

### DIFF
--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -70,7 +70,9 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
         .symbol => try gc.allocSymbol(obj.as(types.Symbol).name),
         .string => {
             const s = obj.as(types.SchemeString);
-            return try gc.allocString(s.data[0..s.len]);
+            const new_val = try gc.allocString(s.data[0..s.len]);
+            try visited.put(src_ptr, new_val);
+            return new_val;
         },
         .vector => {
             const vec = obj.as(types.Vector);
@@ -82,7 +84,11 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
             }
             return new_val;
         },
-        .bytevector => try gc.allocBytevector(obj.as(types.Bytevector).data),
+        .bytevector => {
+            const new_val = try gc.allocBytevector(obj.as(types.Bytevector).data);
+            try visited.put(src_ptr, new_val);
+            return new_val;
+        },
         .flonum => try gc.allocFlonum(obj.as(types.Flonum).value),
         .complex => {
             const c = obj.as(types.Complex);

--- a/tests/scheme/smoke/deep-copy-string-bv-807.scm
+++ b/tests/scheme/smoke/deep-copy-string-bv-807.scm
@@ -1,0 +1,51 @@
+;; Regression test for #807: deep copy must preserve eq? identity
+;; for shared strings and bytevectors across thread boundaries.
+
+(import (scheme base) (srfi 18))
+
+(define (test name expected actual)
+  (unless (equal? expected actual)
+    (display "FAIL: ") (display name)
+    (display " expected ") (display expected)
+    (display " got ") (display actual) (newline)
+    (exit 1)))
+
+;; String sharing
+(let* ((s (make-string 3 #\a))
+       (lst (list s s)))
+  (test "parent string eq?" #t (eq? (car lst) (cadr lst)))
+  (let ((result (thread-join!
+                 (thread-start!
+                  (make-thread
+                   (lambda ()
+                     (let ((eq-result (eq? (car lst) (cadr lst))))
+                       (string-set! (car lst) 0 #\z)
+                       (list eq-result
+                             (string-ref (car lst) 0)
+                             (string-ref (cadr lst) 0)))))))))
+    (test "child string eq?" #t (car result))
+    (test "child string mutation visible via shared ref"
+          #\z (cadr result))
+    (test "child string mutation visible via second ref"
+          #\z (caddr result))))
+
+;; Bytevector sharing
+(let* ((bv (make-bytevector 3 0))
+       (lst (list bv bv)))
+  (test "parent bv eq?" #t (eq? (car lst) (cadr lst)))
+  (let ((result (thread-join!
+                 (thread-start!
+                  (make-thread
+                   (lambda ()
+                     (let ((eq-result (eq? (car lst) (cadr lst))))
+                       (bytevector-u8-set! (car lst) 0 42)
+                       (list eq-result
+                             (bytevector-u8-ref (car lst) 0)
+                             (bytevector-u8-ref (cadr lst) 0)))))))))
+    (test "child bv eq?" #t (car result))
+    (test "child bv mutation visible via shared ref"
+          42 (cadr result))
+    (test "child bv mutation visible via second ref"
+          42 (caddr result))))
+
+(display "OK") (newline)


### PR DESCRIPTION
## Summary

- Add missing `visited.put` for `.string` and `.bytevector` arms in `deepCopyValue` (`src/gc_deep_copy.zig`), preserving `eq?` identity and shared-mutation semantics across thread boundaries
- Add regression test covering both string and bytevector sharing across `thread-join!`

## Test plan

- [x] New test `tests/scheme/smoke/deep-copy-string-bv-807.scm` passes (string and bytevector `eq?` identity preserved, mutation visible through shared refs)
- [x] Existing deep-copy tests pass (`deep-copy-list-801.scm`, `record-cycle-deepcopy.scm`)
- [x] `zig build test` passes

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)