### PR TITLE
Reject invalid --timeout and --max-memory values (#787)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -518,18 +518,26 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             disassemble_mode = true;
         } else if (std.mem.eql(u8, arg, "--timeout")) {
             if (args.next()) |ms_str| {
-                const ms = std.fmt.parseInt(u64, ms_str, 10) catch 0;
-                if (ms > 0) {
-                    const clockNs = @import("vm_calls.zig").clockNs;
-                    vm.timeout_deadline_ns = clockNs() + ms * 1_000_000;
+                const ms = std.fmt.parseInt(u64, ms_str, 10) catch {
+                    usageError("--timeout requires a positive integer milliseconds value\n");
+                };
+                if (ms == 0) {
+                    usageError("--timeout requires a positive integer milliseconds value\n");
                 }
+                const clockNs = @import("vm_calls.zig").clockNs;
+                vm.timeout_deadline_ns = clockNs() + ms * 1_000_000;
             } else {
                 usageError("--timeout requires a milliseconds argument\n");
             }
         } else if (std.mem.eql(u8, arg, "--max-memory")) {
             if (args.next()) |mem_str| {
-                const limit = std.fmt.parseInt(usize, mem_str, 10) catch 0;
-                if (limit > 0) gc.memory_limit = limit;
+                const limit = std.fmt.parseInt(usize, mem_str, 10) catch {
+                    usageError("--max-memory requires a positive integer bytes value\n");
+                };
+                if (limit == 0) {
+                    usageError("--max-memory requires a positive integer bytes value\n");
+                }
+                gc.memory_limit = limit;
             } else {
                 usageError("--max-memory requires a bytes argument\n");
             }

--- a/tests/scheme/errors/exit-code.sh
+++ b/tests/scheme/errors/exit-code.sh
@@ -87,6 +87,15 @@ assert_exit_code "--coverage-xml without arg exits 2" 2 "$KAAPPI" --coverage-xml
 assert_exit_code "--profile-json without arg exits 2" 2 "$KAAPPI" --profile-json
 assert_exit_code "--completions without shell exits 2" 2 "$KAAPPI" --completions
 
+# Invalid (non-numeric, zero) values for --timeout / --max-memory are usage errors (#787)
+assert_exit_code "--timeout non-numeric exits 2" 2 "$KAAPPI" --timeout abc "$TMPDIR_TESTS/ok.scm"
+assert_exit_code "--timeout trailing text exits 2" 2 "$KAAPPI" --timeout 5s "$TMPDIR_TESTS/ok.scm"
+assert_exit_code "--timeout zero exits 2" 2 "$KAAPPI" --timeout 0 "$TMPDIR_TESTS/ok.scm"
+assert_exit_code "--timeout negative exits 2" 2 "$KAAPPI" --timeout -1 "$TMPDIR_TESTS/ok.scm"
+assert_exit_code "--max-memory non-numeric exits 2" 2 "$KAAPPI" --max-memory lots "$TMPDIR_TESTS/ok.scm"
+assert_exit_code "--max-memory zero exits 2" 2 "$KAAPPI" --max-memory 0 "$TMPDIR_TESTS/ok.scm"
+assert_exit_code "--max-memory negative exits 2" 2 "$KAAPPI" --max-memory -1 "$TMPDIR_TESTS/ok.scm"
+
 # Unknown completions shell is a usage error
 assert_exit_code "--completions unknown shell exits 2" 2 "$KAAPPI" --completions badshell
 


### PR DESCRIPTION
## Summary

- Replace `catch 0` with explicit `usageError()` calls in `--timeout` and `--max-memory` argument parsing, so non-numeric (`abc`, `5s`, `lots`), zero, and negative values are rejected with exit code 2 instead of being silently ignored
- Add 7 regression tests to `tests/scheme/errors/exit-code.sh` covering all invalid-value cases

Closes #787

## Test plan

- [x] `zig build` compiles cleanly
- [x] `zig build test` passes
- [x] `bash tests/scheme/errors/exit-code.sh` — all 36 tests pass (7 new)
- [x] Valid values (`--timeout 200`, `--max-memory 1000000`) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)