### PR TITLE
Use fstatat instead of open in file-exists? (#808)

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -723,9 +723,16 @@ fn fileExistsP(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    var stat_buf: std.c.Stat = undefined;
-    if (std.c.fstatat(std.posix.AT.FDCWD, path_z, &stat_buf, 0) != 0)
-        return types.FALSE;
+    if (comptime @import("builtin").os.tag == .linux) {
+        const linux = std.os.linux;
+        var sx: linux.Statx = undefined;
+        const rc = linux.statx(@bitCast(@as(i32, std.posix.AT.FDCWD)), path_z, 0, linux.STATX.BASIC_STATS, &sx);
+        if (rc > @as(usize, std.math.maxInt(isize))) return types.FALSE;
+    } else {
+        var stat_buf: std.c.Stat = undefined;
+        if (std.c.fstatat(std.posix.AT.FDCWD, path_z, &stat_buf, 0) != 0)
+            return types.FALSE;
+    }
     return types.TRUE;
 }
 

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -723,10 +723,9 @@ fn fileExistsP(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{}, 0) catch {
+    var stat_buf: std.c.Stat = undefined;
+    if (std.c.fstatat(std.posix.AT.FDCWD, path_z, &stat_buf, 0) != 0)
         return types.FALSE;
-    };
-    _ = std.posix.system.close(fd);
     return types.TRUE;
 }
 

--- a/src/tests_io.zig
+++ b/src/tests_io.zig
@@ -212,6 +212,44 @@ test "file-exists?" {
     ));
 }
 
+test "file-exists? returns #t for unreadable files" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const path: [*:0]const u8 = "/tmp/kaappi-test-noperm.txt";
+
+    // Create a file via Scheme, then remove all permissions
+    _ = try vm.eval(
+        \\(let ((p (open-output-file "/tmp/kaappi-test-noperm.txt"))) (close-port p))
+    );
+    if (std.c.chmod(path, 0o000) != 0) return error.SkipZigTest;
+    defer _ = std.posix.system.unlink(path);
+
+    try std.testing.expectEqual(types.TRUE, try vm.eval(
+        \\(file-exists? "/tmp/kaappi-test-noperm.txt")
+    ));
+}
+
+test "file-exists? returns #t for FIFOs" {
+    if (comptime @import("builtin").os.tag == .wasi) return error.SkipZigTest;
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const path: [*:0]const u8 = "/tmp/kaappi-test-fifo";
+    _ = std.posix.system.unlink(path);
+    const mkfifo = @extern(*const fn ([*:0]const u8, std.c.mode_t) callconv(.c) c_int, .{ .name = "mkfifo" });
+    if (mkfifo(path, 0o644) != 0) return error.SkipZigTest;
+    defer _ = std.posix.system.unlink(path);
+
+    try std.testing.expectEqual(types.TRUE, try vm.eval(
+        \\(file-exists? "/tmp/kaappi-test-fifo")
+    ));
+}
+
 test "read datum from file" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();


### PR DESCRIPTION
## Summary

- Replace `openat`+`close` with `fstatat` in `file-exists?` to check existence without opening the file
- Fixes hang on FIFOs (open blocks until a writer connects) and false `#f` on unreadable files (e.g. mode 000)
- Matches R7RS 6.14.1: "returns #t if the named file exists" — existence, not readability

## Test plan

- [x] New unit test: `file-exists?` returns `#t` for chmod 000 files
- [x] New unit test: `file-exists?` returns `#t` for FIFOs (without hanging)
- [x] Existing `file-exists?` tests still pass
- [x] Full Zig unit tests pass (`zig build test`)
- [x] Full Scheme test suite passes (1661 pass, 0 fail)

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)