### PR TITLE
Call sched_yield in thread-yield! when no cooperative scheduler exists (#948)

### DIFF
--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -324,7 +324,10 @@ fn storeChildResult(fiber_key: usize, result: Value, exception: ?Value) void {
 
 fn threadYieldFn(_: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    if (vm.scheduler == null) return types.VOID;
+    if (vm.scheduler == null) {
+        std.Thread.yield() catch {};
+        return types.VOID;
+    }
     vm.yielded = true;
     return types.VOID;
 }

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -458,3 +458,23 @@ test "thread result containing primitive procedures is callable after join" {
     );
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
 }
+
+// thread-yield! in a schedulerless child OS thread used to be a silent no-op,
+// causing busy-spin at 100% CPU. After the fix it calls std.Thread.yield()
+// (sched_yield). This test verifies that the yield path coexists with
+// thread-terminate! without leaking error.Yielded (#948).
+test "thread-yield! in child OS thread does not busy-spin or leak Yielded" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(let ((t (make-thread (lambda () (let loop () (thread-yield!) (loop))))))
+        \\  (thread-start! t)
+        \\  (thread-terminate! t)
+        \\  (guard (e (#t (terminated-thread-exception? e)))
+        \\    (thread-join! t)))
+    );
+    try std.testing.expectEqual(types.TRUE, result);
+}


### PR DESCRIPTION
## Summary

- `thread-yield!` in a schedulerless VM (child OS thread) was a silent no-op, causing `(let loop () (thread-yield!) (loop))` to busy-spin at 100% CPU
- Now calls `std.Thread.yield()` (`sched_yield` on POSIX) to hand the CPU to the OS scheduler, matching SRFI-18 semantics
- Adds regression test verifying the yield path coexists with `thread-terminate!` without leaking `error.Yielded`

Closes #948

## Test plan

- [x] `zig build test` passes (all unit tests including new SRFI-18 test)
- [ ] `bash tests/scheme/run-all.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)