### PR TITLE
Skip .sbc bytecode cache in sandbox mode (#785)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -749,8 +749,8 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
 
     const source_hash = bytecode_file.sourceHash(source);
 
-    // Try loading cached bytecode
-    const sbc_path = getSbcPath(allocator, path) catch null;
+    // Try loading cached bytecode (skip in sandbox mode — no filesystem side effects)
+    const sbc_path = if (vm.sandbox_mode) null else getSbcPath(allocator, path) catch null;
     defer if (sbc_path) |p| allocator.free(p);
 
     if (sbc_path) |sp| {

--- a/tests/scheme/sandbox/sandbox-escape.sh
+++ b/tests/scheme/sandbox/sandbox-escape.sh
@@ -90,6 +90,22 @@ assert_works "hash tables" '(let ((h (make-hash-table))) (hash-table-set! h "k" 
 assert_works "green fibers" '(import (kaappi fibers)) (fiber-join (spawn (lambda () 42)))'
 
 echo
+echo "=== Bytecode cache (#785) ==="
+
+# Sandbox must not write .sbc bytecode cache files
+tmpdir=$(mktemp -d)
+echo '(display "hello")(newline)' > "$tmpdir/hello.scm"
+"$KAAPPI" --sandbox "$tmpdir/hello.scm" > /dev/null 2>&1 || true
+if [ -f "$tmpdir/hello.sbc" ]; then
+    echo "FAIL: --sandbox wrote .sbc cache file"
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: --sandbox did not write .sbc cache"
+    PASS=$((PASS + 1))
+fi
+rm -rf "$tmpdir"
+
+echo
 echo "=== Resource limits ==="
 
 # Timeout test


### PR DESCRIPTION
## Summary

- Gate the `.sbc` bytecode cache path on `vm.sandbox_mode` so sandboxed runs neither load nor create cache files on disk — `--sandbox` promises no filesystem side effects
- Add regression test to the sandbox escape test suite verifying no `.sbc` is written

Closes #785

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/sandbox/sandbox-escape.sh` — all 37 tests pass (including new cache test)
- [x] Manual verification: `kaappi --sandbox hello.scm` no longer creates `hello.sbc`; without `--sandbox` it still does

🤖 Generated with [Claude Code](https://claude.com/claude-code)