### PR TITLE
Parse #e decimal strings exactly without f64 round-trip (#856)

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -953,7 +953,7 @@ pub fn makeComplexOrRealEx(real: f64, imag: f64, exact_real: bool, exact_imag: b
 
 const Exactness = enum { unspecified, exact, inexact };
 
-fn applyExactness(gc: *@import("memory.zig").GC, val: Value, exactness: Exactness) PrimitiveError!Value {
+fn applyExactness(_: *@import("memory.zig").GC, val: Value, exactness: Exactness) PrimitiveError!Value {
     switch (exactness) {
         .unspecified => return val,
         .inexact => {
@@ -980,30 +980,100 @@ fn applyExactness(gc: *@import("memory.zig").GC, val: Value, exactness: Exactnes
             if (types.isFlonum(val)) {
                 const f = types.toFlonum(val);
                 if (std.math.isNan(f) or std.math.isInf(f)) return types.FALSE;
-                const trunc_val = @trunc(f);
-                if (f == trunc_val) {
-                    return try safeFloatToExactInt(trunc_val);
-                }
-                var num = f;
-                var den: f64 = 1.0;
-                var i: u32 = 0;
-                while (i < 15) : (i += 1) {
-                    if (num == @trunc(num)) break;
-                    num *= 10.0;
-                    den *= 10.0;
-                }
-                const min_i64: f64 = @floatFromInt(std.math.minInt(i64));
-                const max_i64_f: f64 = @floatFromInt(std.math.maxInt(i64));
-                if (num < min_i64 or num >= max_i64_f or den < min_i64 or den >= max_i64_f) {
-                    return try safeFloatToExactInt(f);
-                }
-                const n: i64 = @intFromFloat(num);
-                const d: i64 = @intFromFloat(den);
-                return arith.makeRationalFromReader(gc, n, d) catch return PrimitiveError.OutOfMemory;
+                return exactFn(&.{val});
             }
             return val;
         },
     }
+}
+
+fn parseExactDecimal(gc: *@import("memory.zig").GC, s: []const u8) PrimitiveError!?Value {
+    var pos: usize = 0;
+    var negative = false;
+
+    if (pos < s.len and (s[pos] == '+' or s[pos] == '-')) {
+        negative = s[pos] == '-';
+        pos += 1;
+    }
+
+    const int_start = pos;
+    while (pos < s.len and s[pos] >= '0' and s[pos] <= '9') pos += 1;
+    const int_part = s[int_start..pos];
+
+    var frac_part: []const u8 = &.{};
+    if (pos < s.len and s[pos] == '.') {
+        pos += 1;
+        const frac_start = pos;
+        while (pos < s.len and s[pos] >= '0' and s[pos] <= '9') pos += 1;
+        frac_part = s[frac_start..pos];
+    }
+
+    if (int_part.len == 0 and frac_part.len == 0) return null;
+
+    var exponent: i64 = 0;
+    if (pos < s.len and (s[pos] == 'e' or s[pos] == 'E')) {
+        pos += 1;
+        if (pos >= s.len) return null;
+        var exp_neg = false;
+        if (s[pos] == '+' or s[pos] == '-') {
+            exp_neg = s[pos] == '-';
+            pos += 1;
+        }
+        const exp_start = pos;
+        while (pos < s.len and s[pos] >= '0' and s[pos] <= '9') pos += 1;
+        if (pos == exp_start) return null;
+        exponent = std.fmt.parseInt(i64, s[exp_start..pos], 10) catch return null;
+        if (exp_neg) exponent = -exponent;
+    }
+
+    if (pos != s.len) return null;
+
+    const scale = @as(i64, @intCast(frac_part.len)) - exponent;
+
+    // Build mantissa digit string: [sign] int_part ++ frac_part
+    const sign_len: usize = if (negative) 1 else 0;
+    const mantissa_len = sign_len + int_part.len + frac_part.len;
+    if (mantissa_len == 0) return types.makeFixnum(0);
+
+    const buf = gc.allocator.alloc(u8, mantissa_len) catch return PrimitiveError.OutOfMemory;
+    defer gc.allocator.free(buf);
+    var off: usize = 0;
+    if (negative) {
+        buf[0] = '-';
+        off = 1;
+    }
+    @memcpy(buf[off .. off + int_part.len], int_part);
+    @memcpy(buf[off + int_part.len ..], frac_part);
+
+    // Parse mantissa as exact integer
+    var mantissa_val: Value = undefined;
+    if (std.fmt.parseInt(i64, buf, 10)) |n| {
+        if (n == 0) return types.makeFixnum(0);
+        mantissa_val = try arith.makeFixnumChecked(n);
+    } else |err| {
+        if (err == error.Overflow) {
+            mantissa_val = bignum_mod.parseBignumString(gc, buf, 10) catch return PrimitiveError.OutOfMemory;
+            if (bignum_mod.isZero(mantissa_val)) return types.makeFixnum(0);
+        } else return null;
+    }
+
+    if (scale == 0) return mantissa_val;
+
+    // Root mantissa before allocating 10^|scale|
+    gc.extra_roots.append(gc.allocator, mantissa_val) catch return PrimitiveError.OutOfMemory;
+    defer _ = gc.extra_roots.pop();
+
+    const abs_scale: i64 = if (scale < 0) -scale else scale;
+    const pow10 = bignum_mod.expt(gc, types.makeFixnum(10), types.makeFixnum(abs_scale)) catch return PrimitiveError.OutOfMemory;
+    mantissa_val = gc.extra_roots.items[gc.extra_roots.items.len - 1];
+
+    if (scale < 0) {
+        gc.extra_roots.append(gc.allocator, pow10) catch return PrimitiveError.OutOfMemory;
+        defer _ = gc.extra_roots.pop();
+        return bignum_mod.mul(gc, mantissa_val, pow10) catch return PrimitiveError.OutOfMemory;
+    }
+
+    return @as(?Value, try arith.makeRationalReduced(gc, mantissa_val, pow10));
 }
 
 fn stringToNumber(args: []const Value) PrimitiveError!Value {
@@ -1111,6 +1181,10 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
     }
 
     if (radix == 10) {
+        if (exactness == .exact) {
+            if (try parseExactDecimal(gc, s)) |v| return v;
+        }
+
         if (std.fmt.parseFloat(f64, s)) |f| {
             return applyExactness(gc, types.makeFlonum(f), exactness);
         } else |_| {}

--- a/tests/scheme/smoke/exact-prefix-856.scm
+++ b/tests/scheme/smoke/exact-prefix-856.scm
@@ -1,0 +1,35 @@
+;; Regression test for #856: string->number #e prefix wrong for small/large decimals
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "exact-prefix-856")
+
+;; Core bug cases — use expressions for rationals whose denominator exceeds i64
+(test-equal "#e1e-20" (/ 1 (expt 10 20)) (string->number "#e1e-20"))
+(test-equal "#e1.5e-15" (/ 3 (expt 2 1) (expt 10 15)) (string->number "#e1.5e-15"))
+(test-equal "#e1e400 is exact" #t (exact? (string->number "#e1e400")))
+(test-equal "#e1e400 value" (expt 10 400) (string->number "#e1e400"))
+
+;; Results must be exact
+(test-assert "#e1e-20 exact" (exact? (string->number "#e1e-20")))
+(test-assert "#e1.5e-15 exact" (exact? (string->number "#e1.5e-15")))
+
+;; Edge cases
+(test-equal "#e.5" 1/2 (string->number "#e.5"))
+(test-equal "#e5." 5 (string->number "#e5."))
+(test-equal "#e-1e-20" (/ -1 (expt 10 20)) (string->number "#e-1e-20"))
+(test-equal "#e0.0" 0 (string->number "#e0.0"))
+(test-equal "#e1e0" 1 (string->number "#e1e0"))
+(test-equal "#e-0.0" 0 (string->number "#e-0.0"))
+
+;; Existing behavior preserved
+(test-equal "#e0.1" 1/10 (string->number "#e0.1"))
+(test-equal "#e1.5" 3/2 (string->number "#e1.5"))
+(test-equal "#e2.0" 2 (string->number "#e2.0"))
+(test-equal "#e1e20" (expt 10 20) (string->number "#e1e20"))
+(test-equal "#e+inf.0" #f (string->number "#e+inf.0"))
+(test-equal "#e+nan.0" #f (string->number "#e+nan.0"))
+(test-assert "3.14 inexact" (inexact? (string->number "3.14")))
+
+(let ((runner (test-runner-current)))
+  (test-end "exact-prefix-856")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Fix `string->number` with `#e` prefix producing wrong exact values for small-scale decimals (`#e1e-20` → 0, `#e1.5e-15` off by 50%) and returning `#f` beyond f64 range (`#e1e400`)
- New `parseExactDecimal` function parses the decimal string directly into mantissa digits + exponent, constructing the exact result via bignum arithmetic — no f64 intermediate
- Simplify `applyExactness` fallback to delegate to `exactFn`'s IEEE 754 bit decomposition instead of the buggy 15-step multiply-by-10 loop

Closes #856

## Test plan

- [x] New regression test `tests/scheme/smoke/exact-prefix-856.scm` (19 cases: core bugs, edge cases, regressions)
- [x] Existing `string-to-number-prefix.scm` and `exactness-prefix.scm` pass unchanged
- [x] `zig build test` passes
- [x] Full `run-all.sh`: 1667 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)