### PR TITLE
Fix read after peek-char reordering stream bytes (#804)

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -656,16 +656,7 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(gc.allocator);
 
-    // Consume any existing read buffer first
-    if (port.read_buf) |rb| {
-        const pos = rb.len - port.read_buf_len;
-        buf.appendSlice(gc.allocator, rb[pos .. pos + port.read_buf_len]) catch return PrimitiveError.OutOfMemory;
-        gc.allocator.free(rb);
-        port.read_buf = null;
-        port.read_buf_len = 0;
-    }
-
-    // Consume any peeked bytes
+    // Drain in chronological order: peek_byte → peek_extra → read_buf → fd
     if (port.peek_byte) |b| {
         buf.append(gc.allocator, b) catch return PrimitiveError.OutOfMemory;
         port.peek_byte = null;
@@ -675,6 +666,13 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
         port.peek_extra[0] = port.peek_extra[1];
         port.peek_extra[1] = port.peek_extra[2];
         port.peek_extra_len -= 1;
+    }
+    if (port.read_buf) |rb| {
+        const pos = rb.len - port.read_buf_len;
+        buf.appendSlice(gc.allocator, rb[pos .. pos + port.read_buf_len]) catch return PrimitiveError.OutOfMemory;
+        gc.allocator.free(rb);
+        port.read_buf = null;
+        port.read_buf_len = 0;
     }
 
     // Read from fd, parsing incrementally so that interactive terminals

--- a/src/tests_io.zig
+++ b/src/tests_io.zig
@@ -467,6 +467,26 @@ test "parameterize current-output-port redirects display" {
     try std.testing.expectEqualStrings("hello", s.data[0..s.len]);
 }
 
+test "read after peek-char preserves stream order (#804)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(let ((p (open-input-string "(x)abc de")))
+        \\  (let ((r1 (read p)))
+        \\    (let ((pc (peek-char p)))
+        \\      (let ((r2 (read p)))
+        \\        (let ((r3 (read p)))
+        \\          (let ((sp (open-output-string)))
+        \\            (write (list r1 pc r2 r3) sp)
+        \\            (get-output-string sp)))))))
+    );
+    const s = types.toObject(result).as(types.SchemeString);
+    try std.testing.expectEqualStrings("((x) #\\a abc de)", s.data[0..s.len]);
+}
+
 test "parameterize current-input-port redirects read-line" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/tests/scheme/smoke/read-peek-reorder-804.scm
+++ b/tests/scheme/smoke/read-peek-reorder-804.scm
@@ -1,0 +1,34 @@
+;;; Regression test for #804: (read) after peek-char reorders the stream
+
+(import (scheme base) (scheme read) (scheme write))
+
+(define (check name actual expected)
+  (when (not (equal? actual expected))
+    (display "FAIL: ")
+    (display name)
+    (display " expected ")
+    (write expected)
+    (display " got ")
+    (write actual)
+    (newline)
+    (error "test failed" name)))
+
+(define p (open-input-string "(x)abc de"))
+
+(let ((r1 (read p)))
+  (check "r1" r1 '(x))
+
+  (let ((pc (peek-char p)))
+    (check "peek-char" pc #\a)
+
+    (let ((r2 (read p)))
+      (check "r2" r2 'abc)
+
+      (let ((r3 (read p)))
+        (check "r3" r3 'de)
+
+        (let ((r4 (read p)))
+          (check "r4" (eof-object? r4) #t))))))
+
+(display "ok")
+(newline)


### PR DESCRIPTION
## Summary

- `readDatumFn` assembled its parse buffer as `read_buf ++ peek_byte ++ peek_extra`, but `peek_byte` holds a byte taken from the *front* of `read_buf` (via `peek-char`), so it must come first
- Reorder drain to `peek_byte → peek_extra → read_buf → fd`, matching `readOneByte`'s chronological order

## Test plan

- [x] Zig unit test (`read after peek-char preserves stream order (#804)`)
- [x] Scheme regression test (`tests/scheme/smoke/read-peek-reorder-804.scm`)
- [x] `zig build test` passes
- [ ] CI green

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)