### PR TITLE
Handle bignums in types.toF64 for correct FFI double/float marshaling

### DIFF
--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -294,3 +294,32 @@ test "eval string->number" {
     const r3 = try vm.eval("(string->number \"hello\")");
     try std.testing.expectEqual(types.FALSE, r3);
 }
+
+test "types.toF64 handles bignums (#792)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Single-limb bignum
+    const big1 = try vm.eval("(expt 2 60)");
+    try std.testing.expect(types.isBignum(big1));
+    try std.testing.expectApproxEqRel(@as(f64, 1152921504606846976.0), types.toF64(big1), 1e-10);
+
+    // Multi-limb bignum
+    const big2 = try vm.eval("(expt 10 20)");
+    try std.testing.expect(types.isBignum(big2));
+    try std.testing.expect(types.toF64(big2) > 9.9e19);
+
+    // Bignum-backed rational: numerator is bignum
+    const rat1 = try vm.eval("(/ (expt 10 20) 3)");
+    const f1 = types.toF64(rat1);
+    try std.testing.expect(f1 > 3.3e19);
+
+    // Bignum-backed rational: denominator is bignum
+    const rat2 = try vm.eval("(/ 1 (expt 10 20))");
+    const f2 = types.toF64(rat2);
+    try std.testing.expect(std.math.isFinite(f2));
+    try std.testing.expect(f2 > 0.0);
+    try std.testing.expect(f2 < 1e-19);
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -852,6 +852,7 @@ pub fn toFlonum(v: Value) f64 {
 pub fn toF64(v: Value) f64 {
     if (isFixnum(v)) return @floatFromInt(toFixnum(v));
     if (isFlonum(v)) return toFlonum(v);
+    if (isBignum(v)) return bignumToF64(toBignum(v));
     if (isRationalObj(v)) {
         const r = toRational(v);
         const n = toF64(r.numerator);
@@ -859,6 +860,26 @@ pub fn toF64(v: Value) f64 {
         return n / d;
     }
     return 0.0;
+}
+
+fn bignumToF64(bn: *const Bignum) f64 {
+    if (bn.len == 0) return 0.0;
+    if (bn.len == 1) {
+        const r: f64 = @floatFromInt(bn.limbs[0]);
+        return if (bn.positive) r else -r;
+    }
+    const hi = bn.limbs[bn.len - 1];
+    const lo = bn.limbs[bn.len - 2];
+    var sticky: u64 = 0;
+    for (bn.limbs[0 .. bn.len - 2]) |limb| sticky |= limb;
+    const lo_adj: u64 = if (sticky != 0 and lo & 1 == 0) lo | 1 else lo;
+    const combined: u128 = (@as(u128, hi) << 64) | @as(u128, lo_adj);
+    var result: f64 = @floatFromInt(combined);
+    const remaining: u32 = @intCast((bn.len - 2) * 64);
+    const scale: f64 = std.math.scalbn(@as(f64, 1.0), @as(i32, @intCast(remaining)));
+    result *= scale;
+    if (!bn.positive) result = -result;
+    return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/scheme/smoke/types-toF64-bignum-792.scm
+++ b/tests/scheme/smoke/types-toF64-bignum-792.scm
@@ -1,0 +1,23 @@
+;; Regression test for #792: types.toF64 missing bignum case
+;; Bignum-backed rationals passed as FFI double args marshaled as
+;; 0.0 (bignum numerator) or +inf.0 (bignum denominator).
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "types-toF64-bignum-792")
+
+;; Direct bignum → inexact conversion (exercises the same toF64 path)
+(test-assert "bignum to inexact is finite"
+  (finite? (inexact (expt 10 20))))
+
+(test-assert "bignum-numerator rational to inexact"
+  (> (inexact (/ (expt 10 20) 3)) 3e19))
+
+(test-assert "bignum-denominator rational to inexact"
+  (< (inexact (/ 1 (expt 10 20))) 1e-19))
+
+(test-assert "bignum-denominator rational is not +inf.0"
+  (finite? (inexact (/ 1 (expt 10 20)))))
+
+(let ((runner (test-runner-current)))
+  (test-end "types-toF64-bignum-792")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Add `bignumToF64` helper to `src/types.zig` and a bignum check in `toF64()` so bignum values convert to `f64` correctly instead of falling through to `return 0.0`
- Fixes FFI `double`/`float` argument marshaling for bignum-backed rationals, which previously silently produced `0.0` (bignum numerator) or `+inf.0` (bignum denominator)
- Uses a local helper rather than importing `bignum.zig` to avoid a circular dependency

Closes #792

## Test plan

- [x] Unit test in `src/tests_numeric.zig` exercises `types.toF64` directly with single-limb bignums, multi-limb bignums, and bignum-backed rationals (both numerator and denominator cases)
- [x] Scheme regression test `tests/scheme/smoke/types-toF64-bignum-792.scm` verifies end-to-end behavior
- [x] `zig build test` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)