### PR TITLE
Fix peek-char returning raw lead byte for multi-byte UTF-8 on fd ports (#798)

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -502,6 +502,22 @@ fn peekCharFn(args: []const Value) PrimitiveError!Value {
                 const cp = std.unicode.utf8Decode(utf8_buf[0..seq_len]) catch return types.makeChar(@intCast(b));
                 return types.makeChar(cp);
             }
+        } else {
+            var utf8_buf: [4]u8 = undefined;
+            utf8_buf[0] = b;
+            port.peek_byte = null;
+            var i: usize = 1;
+            while (i < seq_len) : (i += 1) {
+                utf8_buf[i] = readOneByte(port) orelse break;
+            }
+            port.peek_byte = b;
+            if (i >= seq_len) {
+                const extra_len = seq_len - 1;
+                for (0..extra_len) |j| port.peek_extra[j] = utf8_buf[j + 1];
+                port.peek_extra_len = @intCast(extra_len);
+                const cp = std.unicode.utf8Decode(utf8_buf[0..seq_len]) catch return types.makeChar(@intCast(b));
+                return types.makeChar(cp);
+            }
         }
         return types.makeChar(@intCast(b));
     }

--- a/tests/scheme/smoke/peek-char-fd-utf8-798.scm
+++ b/tests/scheme/smoke/peek-char-fd-utf8-798.scm
@@ -1,0 +1,88 @@
+;; Regression test for #798: peek-char returns raw lead byte when a
+;; pushed-back byte starts a multi-byte UTF-8 char on a file port.
+
+(import (scheme base) (scheme write) (scheme file) (scheme process-context))
+
+(define pass #t)
+(define (check name actual expected)
+  (unless (equal? actual expected)
+    (display "FAIL ") (display name)
+    (display ": expected ") (display expected)
+    (display " got ") (display actual) (newline)
+    (set! pass #f)))
+
+;; Test 1: read-line consumes \r, pushes back lead byte of multi-byte char
+;; File contents: a \r € x  (bytes: 61 0D E2 82 AC 78)
+(define f1 "/tmp/kaappi-test-798-1.txt")
+(let ((p (open-output-file f1)))
+  (write-bytevector (bytevector #x61 #x0D #xE2 #x82 #xAC #x78) p)
+  (close-output-port p))
+
+(let ((p (open-input-file f1)))
+  (let ((line (read-line p)))
+    (check "read-line" line "a")
+    (let ((pc (peek-char p))
+          (rc (read-char p)))
+      (check "peek-char after read-line" (char->integer pc) 8364)
+      (check "read-char after peek-char" (char->integer rc) 8364)
+      (check "peek-char == read-char" (eqv? pc rc) #t)
+      (let ((x (read-char p)))
+        (check "next char" x #\x))))
+  (close-input-port p))
+
+;; Test 2: peek-u8 sets peek_byte, then peek-char on multi-byte char
+;; File contents: € a b c  (bytes: E2 82 AC 61 62 63)
+(define f2 "/tmp/kaappi-test-798-2.txt")
+(let ((p (open-output-file f2)))
+  (write-bytevector (bytevector #xE2 #x82 #xAC #x61 #x62 #x63) p)
+  (close-output-port p))
+
+(let ((p (open-input-file f2)))
+  (let ((pb (peek-u8 p)))
+    (check "peek-u8" pb #xE2)
+    (let ((pc (peek-char p))
+          (rc (read-char p)))
+      (check "peek-char after peek-u8" (char->integer pc) 8364)
+      (check "read-char after peek-u8+peek-char" (char->integer rc) 8364)
+      (check "peek==read after peek-u8" (eqv? pc rc) #t)))
+  (close-input-port p))
+
+;; Test 3: 2-byte UTF-8 char (é = U+00E9, bytes C3 A9)
+(define f3 "/tmp/kaappi-test-798-3.txt")
+(let ((p (open-output-file f3)))
+  (write-bytevector (bytevector #x61 #x0D #xC3 #xA9 #x62) p)
+  (close-output-port p))
+
+(let ((p (open-input-file f3)))
+  (read-line p)
+  (let ((pc (peek-char p))
+        (rc (read-char p)))
+    (check "2-byte peek-char" (char->integer pc) #xE9)
+    (check "2-byte read-char" (char->integer rc) #xE9)
+    (check "2-byte peek==read" (eqv? pc rc) #t))
+  (close-input-port p))
+
+;; Test 4: 4-byte UTF-8 char (𝄞 = U+1D11E, bytes F0 9D 84 9E)
+(define f4 "/tmp/kaappi-test-798-4.txt")
+(let ((p (open-output-file f4)))
+  (write-bytevector (bytevector #x61 #x0D #xF0 #x9D #x84 #x9E #x62) p)
+  (close-output-port p))
+
+(let ((p (open-input-file f4)))
+  (read-line p)
+  (let ((pc (peek-char p))
+        (rc (read-char p)))
+    (check "4-byte peek-char" (char->integer pc) #x1D11E)
+    (check "4-byte read-char" (char->integer rc) #x1D11E)
+    (check "4-byte peek==read" (eqv? pc rc) #t))
+  (close-input-port p))
+
+;; Cleanup
+(delete-file f1)
+(delete-file f2)
+(delete-file f3)
+(delete-file f4)
+
+(if pass
+    (begin (display "All peek-char fd UTF-8 tests passed") (newline))
+    (begin (display "SOME TESTS FAILED") (newline) (exit 1)))


### PR DESCRIPTION
## Summary

- Fix `peekCharFn` to read UTF-8 continuation bytes from the fd when `peek_byte` holds a multi-byte lead byte but `peek_extra` is empty (the case after `read-line` pushes back a byte following `\r`, or after `peek-u8`)
- Temporarily clears `peek_byte`, reads continuation bytes via `readOneByte`, restores `peek_byte`, and stashes continuation bytes in `peek_extra` so `read-char` consumes them correctly
- Add regression test covering 2-byte, 3-byte, and 4-byte UTF-8 chars with both `read-line` pushback and `peek-u8` scenarios

Closes #798

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] Regression test `tests/scheme/smoke/peek-char-fd-utf8-798.scm` passes
- [x] `bash tests/scheme/run-all.sh` — 1673 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)