### PR TITLE
Fix string-titlecase word boundaries and Unicode case mapping (#824)

### DIFF
--- a/src/primitives_char.zig
+++ b/src/primitives_char.zig
@@ -121,7 +121,7 @@ fn isUnicodeLetter(cp: u21) bool {
     return false;
 }
 
-fn isUnicodeUppercase(cp: u21) bool {
+pub fn isUnicodeUppercase(cp: u21) bool {
     if (cp <= 127) return std.ascii.isUpper(@intCast(cp));
     // Check if this codepoint has a lowercase mapping (it's uppercase)
     if (unicode.findLower(cp) != null) return true;
@@ -129,7 +129,7 @@ fn isUnicodeUppercase(cp: u21) bool {
     return unicode.containsU21(&unicode.extra_uppercase, cp);
 }
 
-fn isUnicodeLowercase(cp: u21) bool {
+pub fn isUnicodeLowercase(cp: u21) bool {
     if (cp <= 127) return std.ascii.isLower(@intCast(cp));
     // Check if this codepoint has an uppercase mapping (it's lowercase)
     if (unicode.findUpper(cp) != null) return true;
@@ -184,12 +184,12 @@ fn isUnicodeNumeric(cp: u21) bool {
     return false;
 }
 
-fn unicodeUpcase(cp: u21) u21 {
+pub fn unicodeUpcase(cp: u21) u21 {
     if (cp <= 127) return @intCast(std.ascii.toUpper(@intCast(cp)));
     return unicode.findUpper(cp) orelse cp;
 }
 
-fn unicodeDowncase(cp: u21) u21 {
+pub fn unicodeDowncase(cp: u21) u21 {
     if (cp <= 127) return @intCast(std.ascii.toLower(@intCast(cp)));
     return unicode.findLower(cp) orelse cp;
 }
@@ -481,7 +481,7 @@ fn stringFoldcaseFn(args: []const Value) PrimitiveError!Value {
 
 const CaseMode = enum { upcase, downcase, foldcase };
 
-fn appendCodepoint(result: *std.ArrayList(u8), alloc: std.mem.Allocator, cp: u21) PrimitiveError!void {
+pub fn appendCodepoint(result: *std.ArrayList(u8), alloc: std.mem.Allocator, cp: u21) PrimitiveError!void {
     var tmp: [4]u8 = undefined;
     const n = std.unicode.utf8Encode(cp, &tmp) catch return PrimitiveError.OutOfMemory;
     result.appendSlice(alloc, tmp[0..n]) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -3,6 +3,8 @@ const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
 const pstr = @import("primitives_string.zig");
+const pchar = @import("primitives_char.zig");
+const unicode = @import("unicode_tables.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -646,21 +648,106 @@ fn stringTitlecaseFn(args: []const Value) PrimitiveError!Value {
     const range = try parseStartEnd(full_data, args, 1);
     const data = range.data;
     if (data.len == 0) return gc.allocString("") catch return PrimitiveError.OutOfMemory;
-    const alloc_buf = gc.allocator.alloc(u8, data.len) catch return PrimitiveError.OutOfMemory;
-    defer gc.allocator.free(alloc_buf);
-    @memcpy(alloc_buf, data);
+
+    var result: std.ArrayList(u8) = .empty;
+    defer result.deinit(gc.allocator);
+
+    var i: usize = 0;
     var word_start = true;
-    for (alloc_buf) |*c| {
-        if (c.* == ' ' or c.* == '\t' or c.* == '\n' or c.* == '\r') {
+    var prev_cased = false;
+    while (i < data.len) {
+        const seq_len = std.unicode.utf8ByteSequenceLength(data[i]) catch 1;
+        if (i + seq_len > data.len) {
+            result.append(gc.allocator, data[i]) catch return PrimitiveError.OutOfMemory;
+            i += 1;
+            continue;
+        }
+        const cp = std.unicode.utf8Decode(data[i .. i + seq_len]) catch {
+            result.append(gc.allocator, data[i]) catch return PrimitiveError.OutOfMemory;
+            i += 1;
+            continue;
+        };
+
+        const is_cased = pchar.isUnicodeUppercase(cp) or pchar.isUnicodeLowercase(cp);
+
+        if (!is_cased) {
+            result.appendSlice(gc.allocator, data[i .. i + seq_len]) catch return PrimitiveError.OutOfMemory;
             word_start = true;
         } else if (word_start) {
-            if (c.* >= 'a' and c.* <= 'z') c.* -= 32;
+            switch (cp) {
+                0x00DF => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 'S');
+                    try pchar.appendCodepoint(&result, gc.allocator, 's');
+                },
+                0x01F0 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 'J');
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x030C);
+                },
+                0x0390 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x0399);
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x0308);
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x0301);
+                },
+                0x03B0 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x03A5);
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x0308);
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x0301);
+                },
+                0xFB00 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 'F');
+                    try pchar.appendCodepoint(&result, gc.allocator, 'f');
+                },
+                0xFB01 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 'F');
+                    try pchar.appendCodepoint(&result, gc.allocator, 'i');
+                },
+                0xFB02 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 'F');
+                    try pchar.appendCodepoint(&result, gc.allocator, 'l');
+                },
+                0xFB03 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 'F');
+                    try pchar.appendCodepoint(&result, gc.allocator, 'f');
+                    try pchar.appendCodepoint(&result, gc.allocator, 'i');
+                },
+                0xFB04 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 'F');
+                    try pchar.appendCodepoint(&result, gc.allocator, 'f');
+                    try pchar.appendCodepoint(&result, gc.allocator, 'l');
+                },
+                else => try pchar.appendCodepoint(&result, gc.allocator, pchar.unicodeUpcase(cp)),
+            }
             word_start = false;
         } else {
-            if (c.* >= 'A' and c.* <= 'Z') c.* += 32;
+            switch (cp) {
+                0x0130 => {
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x0069);
+                    try pchar.appendCodepoint(&result, gc.allocator, 0x0307);
+                },
+                0x03A3 => {
+                    const next_cp = blk: {
+                        const ni = i + seq_len;
+                        if (ni >= data.len) break :blk @as(?u21, null);
+                        const nsl = std.unicode.utf8ByteSequenceLength(data[ni]) catch break :blk @as(?u21, null);
+                        if (ni + nsl > data.len) break :blk @as(?u21, null);
+                        break :blk std.unicode.utf8Decode(data[ni .. ni + nsl]) catch null;
+                    };
+                    const next_is_cased = if (next_cp) |nc|
+                        pchar.isUnicodeUppercase(nc) or pchar.isUnicodeLowercase(nc)
+                    else
+                        false;
+                    if (prev_cased and !next_is_cased)
+                        try pchar.appendCodepoint(&result, gc.allocator, 0x03C2)
+                    else
+                        try pchar.appendCodepoint(&result, gc.allocator, 0x03C3);
+                },
+                else => try pchar.appendCodepoint(&result, gc.allocator, pchar.unicodeDowncase(cp)),
+            }
         }
+        prev_cased = is_cased;
+        i += seq_len;
     }
-    return gc.allocString(alloc_buf) catch return PrimitiveError.OutOfMemory;
+    return gc.allocString(result.items) catch return PrimitiveError.OutOfMemory;
 }
 
 // (string-every pred s [start end])

--- a/tests/scheme/smoke/string-titlecase.scm
+++ b/tests/scheme/smoke/string-titlecase.scm
@@ -1,0 +1,33 @@
+(import (scheme base) (scheme process-context) (srfi 13) (srfi 64))
+
+(define %test-fail-count 0)
+(test-begin "string-titlecase")
+
+;; Basic whitespace word boundaries
+(test-equal "basic whitespace" "Hello World" (string-titlecase "hello world"))
+(test-equal "mixed case" "Hello World" (string-titlecase "hELLO wORLD"))
+
+;; Non-whitespace word boundaries (issue #824)
+(test-equal "hyphen boundary" "One-Two-Three" (string-titlecase "one-two-three"))
+(test-equal "underscore boundary" "One_Two_Three" (string-titlecase "one_two_three"))
+(test-equal "digit boundary" "Hello2World" (string-titlecase "hello2world"))
+
+;; SRFI-13 spec example
+(test-equal "SRFI-13 example" "--Capitalize This--" (string-titlecase "--capitalize tHIS--"))
+
+;; Unicode case mapping (issue #824)
+(test-equal "unicode lowercase start" "\xc9;lan Vital" (string-titlecase "\xe9;lan vital"))
+
+;; Edge cases
+(test-equal "empty string" "" (string-titlecase ""))
+(test-equal "single char" "A" (string-titlecase "a"))
+(test-equal "single uppercase" "A" (string-titlecase "A"))
+(test-equal "all caps" "Hello" (string-titlecase "HELLO"))
+
+;; Optional start/end arguments
+(test-equal "start/end" "World" (string-titlecase "hello world" 6 11))
+(test-equal "start/end middle" "Two" (string-titlecase "one-two-three" 4 7))
+
+(set! %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "string-titlecase")
+(if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
## Summary

- Word boundaries now trigger on any non-cased character (per SRFI-13), not just ASCII whitespace — fixes `(string-titlecase "one-two-three")` → `"One-Two-Three"`
- Case mapping uses full Unicode tables via the existing `unicodeUpcase`/`unicodeDowncase` infrastructure — fixes `(string-titlecase "élan vital")` → `"Élan Vital"`
- Handles expanding special cases (eszett, ligatures, Greek final sigma, dotted-I) matching `string-upcase`/`string-downcase` behavior

Closes #824

## Test plan

- [x] `zig build test` — unit tests pass
- [x] New regression test (`tests/scheme/smoke/string-titlecase.scm`) — 13 cases covering hyphen/underscore/digit boundaries, SRFI-13 spec example, Unicode, edge cases, start/end args
- [x] R7RS test suite — 0 failures
- [x] Manual REPL verification of all three reproduction cases from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)