### PR TITLE
Fix Unicode reader gaps and fold-case for non-ASCII identifiers

### DIFF
--- a/docs/dev/unicode-case-mapping.md
+++ b/docs/dev/unicode-case-mapping.md
@@ -6,18 +6,37 @@ Coverage reference for case conversion (`char-upcase`, `char-downcase`,
 
 ## Current coverage
 
-| Script | Range | Upcase | Downcase | Notes |
-|--------|-------|--------|----------|-------|
-| ASCII | U+0000-U+007F | Yes | Yes | Standard `toUpper`/`toLower` |
-| Latin-1 Supplement | U+00C0-U+00FF | Yes | Yes | +-0x20 mapping |
-| Latin Extended-A | U+0100-U+017E | Yes | Yes | Even/odd parity |
-| Latin Extended-B/IPA | U+0180-U+024F | Letter classification only | No case mapping | Pass-through |
-| Greek and Coptic | U+0370-U+03FF | Yes | Yes | Includes 6 accented mappings, final sigma |
-| Cyrillic | U+0400-U+04FF | Yes | Yes | U+0410-042F ↔ U+0430-044F |
-| Cyrillic Supplement | U+0500-U+052F | Letter classification only | No case mapping | Pass-through |
-| Armenian | U+0530-U+058F | Yes | Yes | +0x30 offset mapping |
-| Georgian (Mtavruli) | U+1C90-U+1CBA | Yes | Yes | ↔ Mkhedruli U+10D0-10FA |
-| Cherokee | U+13A0-U+13EF / U+AB70-U+ABBF | Yes | Yes | +0x97D0 offset |
+Case mappings are driven by auto-generated tables in `src/unicode_tables.zig`
+(derived from Unicode 15.1 `UnicodeData.txt` and `CaseFolding.txt`). Any
+codepoint with a simple case mapping in Unicode is handled automatically.
+
+| Script | Range | Upcase | Downcase | Identifier | Notes |
+|--------|-------|--------|----------|------------|-------|
+| ASCII | U+0000-U+007F | Yes | Yes | Yes | Standard `toUpper`/`toLower` |
+| Latin-1 Supplement | U+00C0-U+00FF | Yes | Yes | Yes | |
+| Latin Extended-A | U+0100-U+017E | Yes | Yes | Yes | Even/odd parity |
+| Latin Extended-B/IPA | U+0180-U+02AF | Yes | Yes | Yes | Table-driven |
+| Greek and Coptic | U+0370-U+03FF | Yes | Yes | Yes | Includes accented, final sigma |
+| Cyrillic | U+0400-U+04FF | Yes | Yes | Yes | |
+| Cyrillic Supplement | U+0500-U+052F | Yes | Yes | Yes | Even/odd parity |
+| Armenian | U+0530-U+058F | Yes | Yes | Yes | +0x30 offset |
+| Georgian (Mtavruli) | U+1C90-U+1CBA | Yes | Yes | Yes | ↔ Mkhedruli U+10D0-10FA |
+| Cherokee | U+13A0-U+13F5 / U+AB70-U+ABBF | Yes | Yes | Yes | |
+| Coptic | U+2C80-U+2CF3 | Yes | Yes | Yes | Even/odd parity |
+| Glagolitic | U+2C00-U+2C5F | Yes | Yes | Yes | +0x30 offset |
+| Deseret | U+10400-U+1044F | Yes | Yes | Yes | +0x28 offset (SMP) |
+| Osage | U+104B0-U+104FB | Yes | Yes | Yes | +0x28 offset (SMP) |
+| Warang Citi | U+118A0-U+118DF | Yes | Yes | Yes | +0x20 offset (SMP) |
+| Adlam | U+1E900-U+1E943 | Yes | Yes | Yes | +0x22 offset (SMP) |
+
+**Identifier** column = accepted as bare identifiers in the reader (no `|...|`
+quoting needed). The reader falls back to the Unicode case tables for any
+codepoint not in its hardcoded ranges, so new scripts added to
+`unicode_tables.zig` are automatically recognized as letters.
+
+Khutsuri Georgian (Asomtavruli U+10A0–U+10C5 ↔ Nuskhuri U+2D00–U+2D25) is
+covered by the case tables (upcase/downcase work) but is a historical script
+and not explicitly listed in the reader's fast path.
 
 String operations also handle multi-codepoint expansions:
 - `string-upcase`: ß→SS, ǰ→J+caron, ΐ/ΰ→decomposed, ff/fi/fl ligatures
@@ -27,23 +46,23 @@ String operations also handle multi-codepoint expansions:
 Examples:
 
 ```scheme
-(char-upcase #\ա)      ;=> #\Ա   (Armenian, U+0561 → U+0531)
-(char-upcase #\ꭰ)      ;=> #\Ꭰ   (Cherokee, U+AB70 → U+13A0)
-(string-upcase "աբգ")   ;=> "ԱԲԳ"
+(char-upcase #\ⲁ)      ;=> #\Ⲁ   (Coptic, U+2C81 → U+2C80)
+(char-downcase #\Ⰰ)    ;=> #\ⰰ   (Glagolitic, U+2C00 → U+2C30)
+(char-upcase #\𞤢)      ;=> #\𞤀   (Adlam, U+1E922 → U+1E900)
+(string-upcase "ⲁⲃⲅ")  ;=> "ⲀⲂⲄ"
 ```
 
-## Known gaps
+## Reader fold-case
 
-Tracked in [#920](https://github.com/kaappi/kaappi/issues/920):
+The `#!fold-case` directive folds identifiers using full Unicode case folding
+(`charFoldcase` per codepoint). This means non-ASCII identifiers are folded
+correctly:
 
-- Latin Extended-B/IPA and Cyrillic Supplement have letter classification
-  but no case mapping (pass-through).
-- Bicameral scripts not yet covered (all simple offset patterns): Coptic,
-  Glagolitic, Deseret, Osage, Warang Citi, Adlam. Khutsuri Georgian
-  (Asomtavruli ↔ Nuskhuri) was deliberately skipped as a historical script.
-- The reader's `#!fold-case` directive lowercases identifiers with
-  `std.ascii.toLower`, so non-ASCII identifiers are not folded
-  (`foldAndReturnSymbol` in `src/reader_tokens.zig`).
+```scheme
+#!fold-case
+(define ΑΒΓ 42)
+αβγ  ;=> 42  (Greek uppercase folds to lowercase)
+```
 
 ## Key files
 
@@ -52,8 +71,10 @@ Tracked in [#920](https://github.com/kaappi/kaappi/issues/920):
 | Character case ops | `src/primitives_char.zig` (`unicodeUpcase`/`unicodeDowncase`) |
 | Character predicates | `src/primitives_char.zig` (`isUnicodeUppercase`/`isUnicodeLowercase`) |
 | Letter classification | `src/primitives_char.zig` (`isUnicodeLetter`) |
+| Reader letter classification | `src/reader.zig` (`isUnicodeLetter`) |
 | String case ops | `src/primitives_char.zig` (`stringCaseMapExpanding`) |
 | Reader fold-case | `src/reader_tokens.zig` (`foldAndReturnSymbol`) |
+| Unicode tables | `src/unicode_tables.zig` (auto-generated from Unicode 15.1) |
 
 ## Tests
 
@@ -61,4 +82,6 @@ Tracked in [#920](https://github.com/kaappi/kaappi/issues/920):
 zig build test
 zig build run -- tests/scheme/compliance/chars.scm
 zig build run -- tests/scheme/compliance/unicode.scm
+zig build run -- tests/scheme/compliance/unicode-case.scm
+zig build run -- tests/scheme/compliance/fold-case-unicode.scm
 ```

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const unicode = @import("unicode_tables.zig");
 const Value = types.Value;
 
 pub const ReadError = error{
@@ -177,8 +178,22 @@ pub const Reader = struct {
         if (cp >= 0x4E00 and cp <= 0x9FFF) return true;
         if (cp >= 0xAC00 and cp <= 0xD7AF) return true;
         if (cp >= 0x3400 and cp <= 0x4DBF) return true;
+        if (cp >= 0x1C90 and cp <= 0x1CBA) return true;
         if (cp >= 0x1E00 and cp <= 0x1EFF) return true;
         if (cp >= 0x1F00 and cp <= 0x1FFF) return true;
+        if (cp >= 0x13A0 and cp <= 0x13F5) return true;
+        if (cp >= 0xAB70 and cp <= 0xABBF) return true;
+        if (cp >= 0x2C00 and cp <= 0x2C5F) return true;
+        if (cp >= 0x2C80 and cp <= 0x2CF3) return true;
+        if (cp >= 0x10400 and cp <= 0x1044F) return true;
+        if (cp >= 0x104B0 and cp <= 0x104FB) return true;
+        if (cp >= 0x118A0 and cp <= 0x118DF) return true;
+        if (cp >= 0x1E900 and cp <= 0x1E943) return true;
+        // Fall back to Unicode case tables: any cased letter is alphabetic
+        if (unicode.findLower(cp) != null) return true;
+        if (unicode.findUpper(cp) != null) return true;
+        if (unicode.containsU21(&unicode.extra_uppercase, cp)) return true;
+        if (unicode.containsU21(&unicode.extra_lowercase, cp)) return true;
         return false;
     }
 

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const reader_mod = @import("reader.zig");
+const primitives_char = @import("primitives_char.zig");
 const Reader = reader_mod.Reader;
 const ReadError = reader_mod.ReadError;
 const Token = reader_mod.Token;
@@ -225,9 +226,39 @@ pub fn foldAndReturnSymbol(self: *Reader, sym_text: []const u8) ReadError!Token 
     if (sym_text.len > Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
     const text = if (self.fold_case) blk: {
         self.token_buf.clearRetainingCapacity();
-        for (sym_text) |ch| {
+        var i: usize = 0;
+        while (i < sym_text.len) {
             if (self.token_buf.items.len >= Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
-            self.token_buf.append(self.gc.allocator, std.ascii.toLower(ch)) catch return ReadError.OutOfMemory;
+            const byte = sym_text[i];
+            if (byte < 0x80) {
+                self.token_buf.append(self.gc.allocator, std.ascii.toLower(byte)) catch return ReadError.OutOfMemory;
+                i += 1;
+            } else {
+                const seq_len = std.unicode.utf8ByteSequenceLength(byte) catch {
+                    self.token_buf.append(self.gc.allocator, byte) catch return ReadError.OutOfMemory;
+                    i += 1;
+                    continue;
+                };
+                if (i + seq_len > sym_text.len) {
+                    self.token_buf.append(self.gc.allocator, byte) catch return ReadError.OutOfMemory;
+                    i += 1;
+                    continue;
+                }
+                const cp = std.unicode.utf8Decode(sym_text[i .. i + seq_len]) catch {
+                    self.token_buf.append(self.gc.allocator, byte) catch return ReadError.OutOfMemory;
+                    i += 1;
+                    continue;
+                };
+                const folded = primitives_char.charFoldcase(cp);
+                var enc_buf: [4]u8 = undefined;
+                const enc_len = std.unicode.utf8Encode(folded, &enc_buf) catch {
+                    self.token_buf.append(self.gc.allocator, byte) catch return ReadError.OutOfMemory;
+                    i += 1;
+                    continue;
+                };
+                self.token_buf.appendSlice(self.gc.allocator, enc_buf[0..enc_len]) catch return ReadError.OutOfMemory;
+                i += seq_len;
+            }
         }
         break :blk self.token_buf.items;
     } else sym_text;

--- a/tests/scheme/compliance/fold-case-unicode.scm
+++ b/tests/scheme/compliance/fold-case-unicode.scm
@@ -1,0 +1,45 @@
+;; Regression test for #920: reader #!fold-case with Unicode identifiers
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "fold-case-unicode")
+
+;; --- Greek ---
+#!fold-case
+(define ΑΒΓ 100)
+(test-equal "Greek fold-case" 100 αβγ)
+(test-equal "Greek mixed case" 100 Αβγ)
+#!no-fold-case
+
+;; --- Cyrillic ---
+#!fold-case
+(define АБВ 200)
+(test-equal "Cyrillic fold-case" 200 абв)
+#!no-fold-case
+
+;; --- Latin-1 accented ---
+#!fold-case
+(define Ñoño 300)
+(test-equal "Latin-1 fold-case" 300 ñoño)
+#!no-fold-case
+
+;; --- Coptic ---
+#!fold-case
+(define Ⲁⲃ 400)
+(test-equal "Coptic fold-case" 400 ⲁⲃ)
+#!no-fold-case
+
+;; --- ASCII still works ---
+#!fold-case
+(define HELLO 42)
+(test-equal "ASCII fold-case" 42 hello)
+#!no-fold-case
+
+;; --- fold-case off means case-sensitive ---
+(define xyz 1)
+(define XYZ 2)
+(test-equal "no-fold-case lowercase" 1 xyz)
+(test-equal "no-fold-case uppercase" 2 XYZ)
+
+(let ((runner (test-runner-current)))
+  (test-end "fold-case-unicode")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/compliance/unicode-case.scm
+++ b/tests/scheme/compliance/unicode-case.scm
@@ -97,6 +97,32 @@
 (check "downcase Ⰰ" #\ⰰ (char-downcase #\Ⰰ))  ; 0x2C00 -> 0x2C30
 (check "upcase ⰰ" #\Ⰰ (char-upcase #\ⰰ))     ; 0x2C30 -> 0x2C00
 
+;; --- Warang Citi (SMP) ---
+(check "downcase 𑢠" #\𑣀 (char-downcase #\𑢠))  ; 0x118A0 -> 0x118C0
+(check "upcase 𑣀" #\𑢠 (char-upcase #\𑣀))     ; 0x118C0 -> 0x118A0
+(check "upper? 𑢠" #t (char-upper-case? #\𑢠))
+(check "lower? 𑣀" #t (char-lower-case? #\𑣀))
+
+;; --- Cyrillic Supplement ---
+(check "upcase ԁ" #\Ԁ (char-upcase #\ԁ))      ; 0x0501 -> 0x0500
+(check "downcase Ԁ" #\ԁ (char-downcase #\Ԁ))   ; 0x0500 -> 0x0501
+
+;; --- char-alphabetic? for all bicameral scripts ---
+(check "alpha? Coptic Ⲁ" #t (char-alphabetic? #\Ⲁ))
+(check "alpha? Coptic ⲁ" #t (char-alphabetic? #\ⲁ))
+(check "alpha? Glagolitic Ⰰ" #t (char-alphabetic? #\Ⰰ))
+(check "alpha? Glagolitic ⰰ" #t (char-alphabetic? #\ⰰ))
+(check "alpha? Cherokee Ꭰ" #t (char-alphabetic? #\Ꭰ))
+(check "alpha? Cherokee ꭰ" #t (char-alphabetic? #\ꭰ))
+(check "alpha? Deseret 𐐀" #t (char-alphabetic? #\𐐀))
+(check "alpha? Deseret 𐐨" #t (char-alphabetic? #\𐐨))
+(check "alpha? Osage 𐓀" #t (char-alphabetic? #\𐓀))
+(check "alpha? Osage 𐓨" #t (char-alphabetic? #\𐓨))
+(check "alpha? Warang Citi 𑢠" #t (char-alphabetic? #\𑢠))
+(check "alpha? Warang Citi 𑣀" #t (char-alphabetic? #\𑣀))
+(check "alpha? Adlam 𞤀" #t (char-alphabetic? #\𞤀))
+(check "alpha? Adlam 𞤢" #t (char-alphabetic? #\𞤢))
+
 ;; --- Case folding (char-foldcase) ---
 (check "foldcase A" #\a (char-foldcase #\A))
 (check "foldcase Σ" #\σ (char-foldcase #\Σ))


### PR DESCRIPTION
## Summary

Closes #920.

- Add 8 missing bicameral script ranges (Cherokee, Georgian Mtavruli, Coptic, Glagolitic, Deseret, Osage, Warang Citi, Adlam) to the reader's `isUnicodeLetter`, plus a fallback to the Unicode case tables for any cased letter not in the hardcoded ranges
- Replace byte-by-byte `std.ascii.toLower` in `foldAndReturnSymbol` with UTF-8-aware Unicode case folding via `charFoldcase`, so `#!fold-case` works for non-ASCII identifiers (Greek, Cyrillic, Coptic, etc.)
- Update `docs/dev/unicode-case-mapping.md` — the "known gaps" were stale (the auto-generated tables already covered all listed scripts; only the reader was missing them)

## Test plan

- [x] 20 new assertions in `tests/scheme/compliance/unicode-case.scm` (Warang Citi, Cyrillic Supplement, `char-alphabetic?` for all bicameral scripts)
- [x] New `tests/scheme/compliance/fold-case-unicode.scm` (8 SRFI-64 tests for Unicode fold-case in the reader)
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1673 pass, 0 fail
- [x] R7RS suite — 1395 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)