### PR TITLE
Check peek_byte before returning EOF in string-port read (#799)

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -615,14 +615,30 @@ fn raiseReadError(gc: *@import("memory.zig").GC) PrimitiveError!Value {
     return primitives_control.raiseFn(&raise_args);
 }
 
+fn readFromPeekByteOnly(gc: *@import("memory.zig").GC, port: *types.Port) PrimitiveError!Value {
+    const b = port.peek_byte.?;
+    port.peek_byte = null;
+    const source: [1]u8 = .{b};
+    var reader = reader_mod.Reader.init(gc, &source);
+    defer reader.deinit();
+    const maybe_datum = parseDatumForRead(&reader) catch |err| {
+        if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
+        return raiseReadError(gc);
+    };
+    return maybe_datum orelse types.EOF;
+}
+
 fn readDatumFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = try getInputPort(args, 0, "read");
 
     // For string ports, read directly from the string data
     if (port.is_string_port) {
-        const data = port.string_data orelse return types.EOF;
-        if (port.string_pos >= data.len) return types.EOF;
+        const data = port.string_data orelse {
+            if (port.peek_byte != null) return readFromPeekByteOnly(gc, port);
+            return types.EOF;
+        };
+        if (port.string_pos >= data.len and port.peek_byte == null) return types.EOF;
 
         // Handle any peeked byte
         var source: []const u8 = data[port.string_pos..];

--- a/tests/scheme/smoke/read-string-port-peek-799.scm
+++ b/tests/scheme/smoke/read-string-port-peek-799.scm
@@ -1,0 +1,25 @@
+;; Regression test for #799: (read) on a string port must consume a
+;; pending peek_byte instead of returning EOF.
+
+(import (scheme base) (scheme read) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "read-string-port-peek-799")
+
+;; Case 1: read-line pushes back a byte after consuming \r
+(let ((p (open-input-string "a\rb")))
+  (test-equal "read-line consumes up to CR" "a" (read-line p))
+  (test-equal "read sees pushed-back byte after read-line" 'b (read p)))
+
+;; Case 2: peek-u8 sets peek_byte, then read must see it
+(let ((p (open-input-string "5")))
+  (test-equal "peek-u8 returns byte" 53 (peek-u8 p))
+  (test-equal "read sees datum after peek-u8" 5 (read p)))
+
+;; Case 3: peek-char then read on a single-char string
+(let ((p (open-input-string "x")))
+  (peek-char p)
+  (test-equal "read sees datum after peek-char" 'x (read p)))
+
+(let ((runner (test-runner-current)))
+  (test-end "read-string-port-peek-799")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Fix `readDatumFn` string-port branch returning EOF without checking pending `peek_byte`, causing `(read)` to miss the last datum after `read-line` (with `\r`) or `peek-u8`/`peek-char`
- Add `readFromPeekByteOnly` helper for the edge case where `string_data` is null but a peek byte remains
- Gate both EOF early-return paths on `peek_byte == null`

Closes #799

## Test plan

- [x] New SRFI-64 regression test (`read-string-port-peek-799.scm`) with 5 assertions covering read-line+read, peek-u8+read, and peek-char+read
- [x] All 1,673 existing tests pass (278 Scheme files + 1,395 R7RS)
- [x] `zig build test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)