### PR TITLE
Stop --sandbox pre-scan at filename boundary

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -306,12 +306,40 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         return;
     }
 
-    // Pre-scan args for --sandbox (must happen before primitive registration)
+    // Pre-scan args for --sandbox (must happen before primitive registration).
+    // Stop at the first non-flag argument (the script filename) so that
+    // script arguments like `kaappi script.scm --sandbox` are not hijacked.
     var is_sandboxed = false;
     {
         var pre_args = init.args.iterate();
+        _ = pre_args.skip(); // skip argv[0]
         while (pre_args.next()) |arg| {
-            if (std.mem.eql(u8, arg, "--sandbox")) is_sandboxed = true;
+            if (std.mem.eql(u8, arg, "--sandbox")) {
+                is_sandboxed = true;
+            } else if (std.mem.eql(u8, arg, "--lib-path") or
+                std.mem.eql(u8, arg, "--timeout") or
+                std.mem.eql(u8, arg, "--max-memory") or
+                std.mem.eql(u8, arg, "--profile-json") or
+                std.mem.eql(u8, arg, "--coverage-xml") or
+                std.mem.eql(u8, arg, "-o") or
+                std.mem.eql(u8, arg, "--completions"))
+            {
+                _ = pre_args.skip(); // consume the flag's value
+            } else if (std.mem.eql(u8, arg, "--gc-stats") or
+                std.mem.eql(u8, arg, "--profile") or
+                std.mem.eql(u8, arg, "--coverage") or
+                std.mem.eql(u8, arg, "--compile") or
+                std.mem.eql(u8, arg, "--emit-llvm") or
+                std.mem.eql(u8, arg, "--disassemble") or
+                std.mem.eql(u8, arg, "--help") or
+                std.mem.eql(u8, arg, "-h") or
+                std.mem.eql(u8, arg, "--version") or
+                std.mem.eql(u8, arg, "compile"))
+            {
+                // recognized boolean flag — keep scanning
+            } else {
+                break; // filename or unknown flag — stop scanning
+            }
         }
     }
 

--- a/tests/scheme/smoke/sandbox-script-arg-783.sh
+++ b/tests/scheme/smoke/sandbox-script-arg-783.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Regression test for #783: --sandbox as a script argument must not activate
+# sandboxing. The pre-scan must stop at the filename boundary.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# A script that uses sandboxed-out procedures (open-output-file, command-line)
+cat > "$tmpdir/writer.scm" <<'SCM'
+(import (scheme base) (scheme write) (scheme file) (scheme process-context))
+(define args (command-line))
+(display args)
+(newline)
+SCM
+
+# 1) --sandbox AFTER the filename is a script argument — must NOT sandbox
+output=$("$KAAPPI" "$tmpdir/writer.scm" --sandbox 2>&1)
+if echo "$output" | grep -qF -- "--sandbox"; then
+    echo "PASS: --sandbox after filename passed through as script arg"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: --sandbox after filename was not in (command-line) — output: $output"
+    FAIL=$((FAIL + 1))
+fi
+
+# 2) --sandbox BEFORE the filename is an interpreter flag — must sandbox
+output=$("$KAAPPI" --sandbox "$tmpdir/writer.scm" 2>&1 || true)
+if echo "$output" | grep -qi "error"; then
+    echo "PASS: --sandbox before filename activates sandboxing"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: --sandbox before filename did not sandbox — output: $output"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "Passed: $PASS / $((PASS + FAIL))"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Fix the `--sandbox` pre-scan in `mainImpl` to stop at the script filename boundary, matching the main flag loop's termination logic
- Previously, `kaappi script.scm --sandbox` would silently activate sandbox mode even though `--sandbox` is a script argument
- Add regression test verifying both directions: `--sandbox` after filename is pass-through, before filename activates sandboxing

Closes #783

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1672/1672 pass (including new test)
- [x] `bash tests/scheme/sandbox/sandbox-escape.sh` — all 37 sandbox boundaries hold
- [x] Manual: `kaappi script.scm --sandbox` shows `--sandbox` in `(command-line)`, no sandbox errors
- [x] Manual: `kaappi --sandbox script.scm` correctly activates sandboxing

🤖 Generated with [Claude Code](https://claude.com/claude-code)