### PR TITLE
Fix SRFI-158 gtake crash, SRFI-189 nothing procedure, SRFI-115 unknown char class

### DIFF
--- a/lib/srfi/115.sld
+++ b/lib/srfi/115.sld
@@ -27,6 +27,16 @@
 
     ;;; Compile SRE to data structure
 
+    ;; Every named char class %match-class understands. An unknown symbol
+    ;; must be a compile-time error, not a silent match-nothing (a typo
+    ;; like 'digit for 'numeric would otherwise just make every search
+    ;; return #f).
+    (define %class-names
+      '(alphabetic alpha numeric num lower-case lower upper-case upper
+        whitespace white space alphanumeric alphanum alnum
+        punctuation punct word hex-digit xdigit ascii
+        control cntrl graphic graph printing print))
+
     (define (%csre sre gc)
       (cond
         ((string? sre) (list 'lit sre))
@@ -34,7 +44,10 @@
         ((and (symbol? sre) (memq sre '(bos eos bol eol bow eow))) (list 'assert sre))
         ((eq? sre 'any) (list 'any))
         ((eq? sre 'nonl) (list 'nonl))
-        ((symbol? sre) (list 'class sre))
+        ((symbol? sre)
+         (if (memq sre %class-names)
+             (list 'class sre)
+             (error "regexp: unknown character class" sre)))
         ((not (pair? sre)) (error "regexp: invalid SRE" sre))
         (else
          (let ((h (car sre)))

--- a/lib/srfi/158-impl.scm
+++ b/lib/srfi/158-impl.scm
@@ -5,6 +5,17 @@
     (pred (car ls))
     ((lambda (x) (if x x (any pred (cdr ls)))) (pred (car ls)))))
 
+;; Call each generator in gs once, left to right, collecting the results.
+;; Must be plain Scheme recursion, not (map (lambda (g) (g)) gs): coroutine
+;; generators capture a continuation inside the call, and a continuation
+;; captured under the native map primitive cannot resume once that native
+;; frame has returned.
+(define (%call-generators gs)
+  (if (null? gs)
+    '()
+    (let ((v ((car gs))))
+      (cons v (%call-generators (cdr gs))))))
+
 ;; list->bytevector
 (define (list->bytevector list)
   (let ((vec (make-bytevector (length list) 0)))
@@ -259,13 +270,13 @@
          (if (eof-object? item) item (proc item)))))
     ((proc . gens)
      (lambda ()
-       (let ((items (map (lambda (x) (x)) gens)))
+       (let ((items (%call-generators gens)))
          (if (any eof-object? items) (eof-object) (apply proc items)))))))
     
 ;; gcombine
 (define (gcombine proc seed . gens)
   (lambda ()
-    (define items (map (lambda (x) (x)) gens))
+    (define items (%call-generators gens))
     (if (any eof-object? items)
       (eof-object)
       (let ()
@@ -457,7 +468,7 @@
 ;; generator-fold
 (define (generator-fold f seed . gs)
   (define (inner-fold seed)
-    (let ((vs (map (lambda (g) (g)) gs)))
+    (let ((vs (%call-generators gs)))
      (if (any eof-object? vs)
        seed
        (inner-fold (apply f (append vs (list seed)))))))
@@ -468,7 +479,7 @@
 ;; generator-for-each
 (define (generator-for-each f . gs)
   (let loop ()
-   (let ((vs (map (lambda (g) (g)) gs)))
+   (let ((vs (%call-generators gs)))
     (if (any eof-object? vs)
       (if #f #f)
       (begin (apply f vs)
@@ -477,7 +488,7 @@
 
 (define (generator-map->list f . gs)
   (let loop ((result '()))
-   (let ((vs (map (lambda (g) (g)) gs)))
+   (let ((vs (%call-generators gs)))
     (if (any eof-object? vs)
       (reverse result)
       (loop (cons (apply f vs) result))))))

--- a/lib/srfi/189.sld
+++ b/lib/srfi/189.sld
@@ -10,7 +10,10 @@
     (define-record-type <right> (right val) right? (val right-val))
     (define-record-type <left> (left val) left? (val left-val))
 
-    (define nothing (make-nothing))
+    ;; Per SRFI-189, nothing is a procedure: (nothing) returns the unique
+    ;; Nothing object.
+    (define %the-nothing (make-nothing))
+    (define (nothing) %the-nothing)
 
     (define (maybe? x) (or (just? x) (nothing? x)))
     (define (either? x) (or (right? x) (left? x)))
@@ -18,13 +21,13 @@
     (define (maybe-ref m) (if (just? m) (just-val m) (error "maybe-ref: nothing")))
     (define (maybe-ref/default m default) (if (just? m) (just-val m) default))
 
-    (define (maybe-map f m) (if (just? m) (just (f (just-val m))) nothing))
+    (define (maybe-map f m) (if (just? m) (just (f (just-val m))) %the-nothing))
     (define (maybe-filter pred m)
-      (if (and (just? m) (pred (just-val m))) m nothing))
-    (define (maybe-bind m f) (if (just? m) (f (just-val m)) nothing))
+      (if (and (just? m) (pred (just-val m))) m %the-nothing))
+    (define (maybe-bind m f) (if (just? m) (f (just-val m)) %the-nothing))
 
     (define (maybe->values m) (if (just? m) (just-val m) (values)))
-    (define (values->maybe . args) (if (null? args) nothing (just (car args))))
+    (define (values->maybe . args) (if (null? args) %the-nothing (just (car args))))
 
     (define (either-ref e) (if (right? e) (right-val e) (error "either-ref: left" (left-val e))))
     (define (either-ref/default e default) (if (right? e) (right-val e) default))

--- a/tests/scheme/srfi/srfi115.scm
+++ b/tests/scheme/srfi/srfi115.scm
@@ -127,6 +127,17 @@
 (check-true "valid?" (valid-sre? '(+ "a")))
 (check-true "valid? str" (valid-sre? "hello"))
 
+;; Unknown named char class must raise, not silently match nothing
+;; (regression: (+ digit) returned #f from regexp-search instead of
+;; erroring — 'digit is not a SRFI-115 class, 'numeric/'num is)
+(check-true "unknown class raises"
+  (guard (e (#t #t)) (regexp-search '(+ digit) "age: 25") #f))
+(check-true "unknown class raises in regexp"
+  (guard (e (#t #t)) (regexp 'digits) #f))
+(check-false "valid-sre? unknown class" (valid-sre? '(+ digit)))
+(check-true "known class aliases still valid"
+  (and (valid-sre? '(+ num)) (valid-sre? '(+ alpha)) (valid-sre? '(* space))))
+
 ;; Summary
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)

--- a/tests/scheme/srfi/srfi158.scm
+++ b/tests/scheme/srfi/srfi158.scm
@@ -1,0 +1,91 @@
+;; SRFI-158 generator tests.
+;;
+;; Regression focus: gtake, generator->list, and every other procedure that
+;; drives a list of generators used to call them via the native map
+;; primitive ((map (lambda (g) (g)) gs)). Coroutine generators capture a
+;; continuation inside that call, and a continuation captured under a
+;; native frame cannot resume after the native frame returns — the second
+;; call crashed with "type error in 'cdr': expected pair, got #<procedure>"
+;; or silently produced garbage. The impl now drives generators with plain
+;; Scheme recursion (%call-generators in lib/srfi/158-impl.scm).
+;;
+;; Uses manual counters rather than SRFI-64: importing (srfi 64) together
+;; with (srfi 158) currently triggers a separate, nondeterministic
+;; CompileError in the library loader (each library loads fine alone), so
+;; pulling in the SRFI-64 test framework here would make this regression
+;; test flaky for reasons unrelated to what it checks.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 158))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; gtake on an infinite generator (the original crash repro)
+(check "gtake range"
+  (generator->list (gtake (make-range-generator 0 100) 5))
+  '(0 1 2 3 4))
+
+;; generator->list with a count delegates to gtake
+(check "generator->list n"
+  (generator->list (make-range-generator 0 100) 3)
+  '(0 1 2))
+
+;; gtake with padding past the end of a finite generator
+(check "gtake padding"
+  (generator->list (gtake (generator 1 2) 4 'pad))
+  '(1 2 pad pad))
+
+;; generator->list over a coroutine generator (crashed in generator-fold)
+(check "coroutine generator->list"
+  (generator->list (make-coroutine-generator
+                    (lambda (yield) (yield 'a) (yield 'b) (yield 'c))))
+  '(a b c))
+
+;; generator-fold over multiple generators
+(check "generator-fold two gens"
+  (generator-fold (lambda (a b acc) (cons (+ a b) acc)) '()
+                  (generator 1 2 3) (generator 10 20 30))
+  '(33 22 11))
+
+;; gmap over multiple generators
+(check "gmap two gens"
+  (generator->list (gmap + (generator 1 2 3) (generator 10 20 30)))
+  '(11 22 33))
+
+;; gcombine threads a seed through the calls
+(check "gcombine"
+  (generator->list
+   (gcombine (lambda (x seed) (values (+ x seed) (+ seed 1)))
+             0 (generator 10 20 30)))
+  '(10 21 32))
+
+;; generator-for-each over multiple generators
+(check "generator-for-each"
+  (let ((acc '()))
+    (generator-for-each (lambda (a b) (set! acc (cons (+ a b) acc)))
+                        (generator 1 2) (generator 10 20))
+    acc)
+  '(22 11))
+
+;; generator-map->list over multiple generators
+(check "generator-map->list"
+  (generator-map->list + (generator 1 2 3) (generator 4 5 6))
+  '(5 7 9))
+
+;; generator->vector and ->string with a count (delegate through gtake)
+(check "generator->vector n"
+  (generator->vector (make-range-generator 5) 3)
+  #(5 6 7))
+(check "generator->string n"
+  (generator->string (generator #\k #\a #\a #\p #\p #\i) 6)
+  "kaappi")
+
+;; Summary
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1))

--- a/tests/scheme/srfi/srfi189.scm
+++ b/tests/scheme/srfi/srfi189.scm
@@ -1,0 +1,40 @@
+;; SRFI-189 Maybe/Either tests.
+;;
+;; Regression focus: nothing was exported as a value, but per SRFI-189 it
+;; is a procedure — (nothing) returns the unique Nothing object. Calling
+;; (nothing) raised "not a procedure".
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 64) (srfi 189))
+
+(test-begin "srfi-189")
+
+;; nothing is a procedure returning the unique Nothing object
+(test-assert "nothing? (nothing)" (nothing? (nothing)))
+(test-assert "nothing unique" (eq? (nothing) (nothing)))
+(test-assert "maybe? (nothing)" (maybe? (nothing)))
+(test-assert "just? (nothing) is false" (not (just? (nothing))))
+
+;; just / maybe basics
+(test-assert "just?" (just? (just 42)))
+(test-assert "nothing? just is false" (not (nothing? (just 42))))
+(test-equal "maybe-ref just" 7 (maybe-ref (just 7)))
+(test-equal "maybe-ref/default nothing" 'dflt (maybe-ref/default (nothing) 'dflt))
+(test-equal "maybe-ref/default just" 1 (maybe-ref/default (just 1) 'dflt))
+
+;; maybe-map / maybe-filter / maybe-bind propagate Nothing
+(test-equal "maybe-map just" 6 (maybe-ref (maybe-map (lambda (x) (* x 2)) (just 3))))
+(test-assert "maybe-map nothing" (nothing? (maybe-map (lambda (x) x) (nothing))))
+(test-assert "maybe-filter fail" (nothing? (maybe-filter odd? (just 2))))
+(test-equal "maybe-filter pass" 3 (maybe-ref (maybe-filter odd? (just 3))))
+(test-equal "maybe-bind just" 5
+  (maybe-ref (maybe-bind (just 4) (lambda (x) (just (+ x 1))))))
+(test-assert "maybe-bind nothing"
+  (nothing? (maybe-bind (nothing) (lambda (x) (just x)))))
+
+;; values->maybe
+(test-assert "values->maybe none" (nothing? (values->maybe)))
+(test-equal "values->maybe one" 9 (maybe-ref (values->maybe 9)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-189")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes three reproducible SRFI conformance bugs found while verifying code
examples for the kaappi-book. Each fix ships with a regression test.

## 1. SRFI-158 — `gtake` / `generator->list` crash

`generator-fold`, `generator-for-each`, `generator-map->list`, `gmap`, and
`gcombine` drove their generators via `(map (lambda (g) (g)) gs)`. `map` is a
native primitive, and a coroutine generator captures a continuation inside the
callback — that continuation cannot resume once the native `map` frame has
returned. The second invocation crashed with `type error in 'cdr': expected
pair, got #<procedure>` or silently corrupted VM state. This broke `gtake` and
`(generator->list gen n)`, which build on `make-coroutine-generator` and
`generator-fold`.

```scheme
(generator->list (gtake (make-range-generator 0 100) 5))
;; before: error "type error in 'cdr': expected pair, got #<procedure>"
;; after:  (0 1 2 3 4)
```

Fix: a `%call-generators` helper walks the generator list in plain Scheme,
keeping every frame the captured continuation needs inside the bytecode
dispatch session.

## 2. SRFI-189 — `nothing` must be a procedure

`nothing` was defined as the Nothing record instance itself, so the
spec-mandated call form `(nothing)` raised `not a procedure`. It now holds the
unique instance privately and exports `nothing` as a zero-argument procedure
returning it.

```scheme
(nothing? (nothing))   ; before: error "not a procedure"  after: #t
(eq? (nothing) (nothing))  ; #t
```

## 3. SRFI-115 — unknown named char class silently matches nothing

A bare symbol in an SRE compiled to a `class` node without validation, and the
matcher's fallback returned `#f` for names it didn't recognize. A typo like
`digit` (the valid name is `numeric`/`num`) therefore made every search silently
return `#f`. Class names are now validated at compile time.

```scheme
(regexp-search '(+ digit) "age: 25")
;; before: #f (silent)   after: error "regexp: unknown character class"
(valid-sre? '(+ digit))  ; #f
```

## Not included

Bug 1 from the book review (`alist->hash-table` producing invisible entries)
was already fixed on `main` by #939 — verified against the current build, no
change needed here.

## Testing

- New: `tests/scheme/srfi/srfi158.scm`, `tests/scheme/srfi/srfi189.scm`
- Extended: `tests/scheme/srfi/srfi115.scm` (unknown-class checks)
- Each new/extended suite was confirmed to fail against the pre-fix library
  code and pass with the fix.
- Full suite green: `zig build test` + `bash tests/scheme/run-all.sh`
  (283 Scheme files, 1395 R7RS tests, 0 failures).

`srfi158.scm` uses manual pass/fail counters rather than SRFI-64 (matching the
precedent set by #939's `hashtable-insert-occupied.scm`): importing `(srfi 64)`
together with `(srfi 158)` currently triggers a **separate, pre-existing**
nondeterministic `CompileError` in the library loader (each library loads fine
alone; `(srfi 64)`+`(srfi 189)` is fine). That loader bug is unrelated to these
fixes and is being tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
