### PR TITLE
Raise on continuation resume across a returned native call

### DIFF
--- a/src/tests_continuations.zig
+++ b/src/tests_continuations.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const vm_mod = @import("vm.zig");
 
 test "call/cc basic — proc returns normally" {
     var gc = memory.GC.init(std.testing.allocator);
@@ -353,4 +354,27 @@ test "dynamic-wind after-thunk runs on nested escape under guard" {
     try std.testing.expectEqualStrings("before", types.symbolName(types.car(log)));
     try std.testing.expectEqualStrings("during", types.symbolName(types.car(types.cdr(log))));
     try std.testing.expectEqualStrings("after", types.symbolName(types.car(types.cdr(types.cdr(log)))));
+}
+
+test "continuation cannot resume across a returned native call" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Regression: a coroutine-style continuation captured inside the closure
+    // that native `map` drives (via callWithArgs), then resumed after `map`
+    // has already returned. The restored stack's callWithArgs-pushed frame
+    // would return into a register owned by the now-dead native map frame,
+    // silently corrupting results (the "#<builtin map>" garbage bug). The VM
+    // must instead raise a clear, catchable error.
+    _ = try vm.eval("(define k #f)");
+    _ = try vm.eval("(map (lambda (x) (call/cc (lambda (c) (set! k c) x))) '(1 2 3))");
+
+    // Without the fix this returns silently (delivering the closure result into
+    // a register owned by the dead native map frame); with the fix it raises.
+    // eval clears current_exception on the error path, so the message text is
+    // asserted at the Scheme level by tests/scheme/errors/error-format.sh.
+    const result = vm.eval("(k 99)");
+    try std.testing.expectError(vm_mod.VMError.ExceptionRaised, result);
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -364,6 +364,10 @@ pub const SavedFrame = struct {
     base: u32,
     dst: u16,
     saved_wind_count: u16,
+    // Mirrors CallFrame.returns_to_native (see vm.zig): the frame's result
+    // belongs to a re-entrant native Zig caller, so returning it into a
+    // caller frame register after that native has died is an error.
+    returns_to_native: bool,
     // Frame birth id (see CallFrame.seq in vm.zig). The u64 also forces
     // 8-byte alignment on wasm32, keeping the struct size a multiple of
     // @sizeOf(Value) without manual padding.

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -232,6 +232,16 @@ pub const CallFrame = struct {
     base: u32,
     dst: u16,
     saved_wind_count: u16 = 0,
+    // True for frames pushed by callWithArgs: the frame's result is consumed
+    // by the re-entrant native Zig caller (map, for-each, sort, apply, ...)
+    // via runUntil's return value, and dst is a placeholder. If such a frame
+    // returns inside an OUTER dispatch loop, that native caller has already
+    // returned (a continuation captured under it was resumed after the native
+    // call ended) — there is no register to deliver into and the native's
+    // iteration state is gone, so the dispatch loop raises an error instead
+    // of silently corrupting the caller's registers. Preserved across tail
+    // calls and continuation capture/restore, like seq.
+    returns_to_native: bool = false,
     // Birth id, unique per pushed frame (VM.nextFrameSeq). Tail calls reuse
     // the frame and keep its seq; continuation capture/restore preserves it.
     // Dispatch loops use it to tell whether a restored frame stack still
@@ -1029,7 +1039,10 @@ pub const VM = struct {
                 .code = func.code.items,
                 .ip = 0,
                 .base = base,
+                // The result is consumed by this runUntil's return value, not
+                // a caller register — dst is a placeholder (returns_to_native).
                 .dst = 0,
+                .returns_to_native = true,
                 .saved_wind_count = @intCast(self.wind_count),
                 .seq = self.nextFrameSeq(),
             };

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -44,6 +44,7 @@ pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u32) VMError!Value {
             .base = f.base,
             .dst = f.dst,
             .saved_wind_count = f.saved_wind_count,
+            .returns_to_native = f.returns_to_native,
             .seq = f.seq,
         };
     }
@@ -211,6 +212,7 @@ pub fn restoreContinuation(vm: *VM, cont: *types.Continuation, value: Value) VME
             .base = saved_frame.base,
             .dst = saved_frame.dst,
             .saved_wind_count = saved_frame.saved_wind_count,
+            .returns_to_native = saved_frame.returns_to_native,
             .seq = saved_frame.seq,
         };
     }

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -49,6 +49,28 @@ fn maybeRewindRetry(self: *VM, instr_len: usize) void {
     if (f.ip >= instr_len) f.ip -= instr_len;
 }
 
+/// A frame with returns_to_native set (pushed by vm.callWithArgs) delivers its
+/// result via its own runUntil session's return value; its dst is a
+/// placeholder. When such a frame returns while frame_count is still above
+/// the dispatching loop's target, that session — the native Zig caller (map,
+/// for-each, sort, apply, ...) that owned the result — has already returned:
+/// a continuation captured under the native call was resumed after the call
+/// ended. There is no register to deliver into and the native's iteration
+/// state is gone, so raise a catchable Scheme error instead of silently
+/// writing the value into an unrelated caller register.
+fn raiseDeadNativeReturn(self: *VM) VMError {
+    var msg = self.gc.allocString("continuation cannot resume across a returned native call") catch
+        return VMError.OutOfMemory;
+    self.gc.pushRoot(&msg) catch return VMError.OutOfMemory;
+    const err_obj = self.gc.allocErrorObject(msg, types.NIL) catch {
+        self.gc.popRoot();
+        return VMError.OutOfMemory;
+    };
+    self.gc.popRoot();
+    self.current_exception = err_obj;
+    return VMError.ExceptionRaised;
+}
+
 /// Continuation-invoked handling: after a restore/escape delivers its value,
 /// execution must resume in the innermost dispatch loop whose scope-root
 /// frame is still live (checked by frame birth id, see resumesHere). Loops
@@ -492,6 +514,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // native.func may re-enter the VM and grow self.frames,
                     // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
                     const result = native.func(nargs_slice) catch |err| {
                         if (self.profile_mode) {
                             native.profile_time_ns +%= vm_calls.clockNs() -% native_start;
@@ -539,6 +562,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (self.frame_count <= target_frame_count) {
                         return result;
                     }
+                    if (from_native_call) return raiseDeadNativeReturn(self);
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;
@@ -562,11 +586,13 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // FFI callbacks may re-enter the VM and grow self.frames,
                     // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
                     const result = ffi_mod.callFfi(ffi_fn, self.registers[abs_base + 1 .. abs_base + 1 + nargs], self.gc) catch return VMError.TypeError;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) {
                         return result;
                     }
+                    if (from_native_call) return raiseDeadNativeReturn(self);
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;
@@ -575,6 +601,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // callWithArgs on the converter re-enters the VM and may
                     // grow self.frames, invalidating `frame` — read dst first.
                     const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
                     const result = if (nargs == 0) self.getParameterValue(param) else blk: {
                         var new_val = self.registers[abs_base + 1];
                         if (param.converter != types.NIL) {
@@ -587,6 +614,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (self.frame_count <= target_frame_count) {
                         return result;
                     }
+                    if (from_native_call) return raiseDeadNativeReturn(self);
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;
@@ -690,6 +718,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // native.func may re-enter the VM and grow self.frames,
                     // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
                     const result = native.func(flat_args[0..count]) catch |err| {
                         if (err == error.ContinuationInvoked) {
                             if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
@@ -709,6 +738,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     };
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
+                    if (from_native_call) return raiseDeadNativeReturn(self);
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;
@@ -730,9 +760,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // FFI callbacks may re-enter the VM and grow self.frames,
                     // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
                     const result = ffi_mod.callFfi(ffi_fn, flat_args[0..count], self.gc) catch return VMError.TypeError;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
+                    if (from_native_call) return raiseDeadNativeReturn(self);
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;
@@ -741,6 +773,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // callWithArgs on the converter re-enters the VM and may
                     // grow self.frames, invalidating `frame` — read dst first.
                     const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
                     const result = if (count == 0) self.getParameterValue(param) else blk: {
                         var new_val = flat_args[0];
                         if (param.converter != types.NIL) {
@@ -751,6 +784,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     };
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
+                    if (from_native_call) return raiseDeadNativeReturn(self);
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;
@@ -766,6 +800,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 self.gc.pushRoot(&result) catch return VMError.OutOfMemory;
                 defer self.gc.popRoot();
                 const return_dst = frame.dst;
+                const from_native_call = frame.returns_to_native;
                 const frame_wind = frame.saved_wind_count;
                 self.frame_count -= 1;
                 if (self.profile_mode) vm_calls.profilePopReturn(self);
@@ -781,6 +816,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     }
                     return result;
                 }
+                if (from_native_call) return raiseDeadNativeReturn(self);
                 // Also unwind any winds that were pushed by native
                 // functions (e.g. dynamic-wind) between this frame
                 // and the caller. After a continuation restore the
@@ -1116,6 +1152,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // native.func may re-enter the VM and grow self.frames,
                     // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
                     const result = if (!self.profile_mode)
                         native.func(args) catch |err| {
                             if (err == error.ContinuationInvoked) {
@@ -1173,6 +1210,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.frame_count -= 1;
                     if (self.profile_mode) vm_calls.profilePopReturn(self);
                     if (self.frame_count <= target_frame_count) return result;
+                    if (from_native_call) return raiseDeadNativeReturn(self);
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -170,6 +170,14 @@ assert_output_contains "variadic closure arity error shows counts" \
 assert_output_contains "anonymous lambda arity error has no name" \
     '((lambda (x) x) 1 2)' "expected 1 arguments, got 2"
 
+# Continuation captured inside a native driver (map) and resumed after that
+# native call returned must raise a clear error, not silently corrupt results.
+echo
+echo "-- Continuation across returned native call --"
+assert_output_contains "resume across dead native call is an error" \
+    '(define k #f) (map (lambda (x) (call/cc (lambda (c) (set! k c) x))) (list 1 2 3)) (k 99)' \
+    "continuation cannot resume across a returned native call"
+
 # Issue #78: mismatched-length ellipsis template variables must be rejected
 # with a clean compile error, not read uninitialized memory. (Moved from
 # tests/scheme/smoke/ellipsis-mismatch.scm: the rejection happens at macro


### PR DESCRIPTION
## Problem

Resuming a captured continuation whose snapshot includes a frame pushed by `vm.callWithArgs` from a native primitive (`map`, `for-each`, `sort`, `apply`, ...) — **after that native Zig frame has returned** — silently corrupted results instead of raising an error.

Repro:

```scheme
(import (scheme base) (scheme write) (srfi 158))
(define g (make-coroutine-generator (lambda (yield) (yield 1) (yield 2))))
(display (map (lambda (f) (f)) (list g))) (newline) ; => (1) correct
(display (map (lambda (f) (f)) (list g))) (newline) ; => #<builtin map>  (garbage!)
```

The coroutine's `resume` continuation is captured under the first `map`'s `callWithArgs` dispatch session. When resumed during the second `map`, the restored stack's `callWithArgs`-pushed frame (`dst=0` placeholder) later returns in the outer dispatch loop — delivering its value into a register owned by the now-dead native `map` frame, whose iteration state is gone. Result: silent garbage.

## Fix

Mark frames pushed by `callWithArgs` with a new `returns_to_native` flag (on both `CallFrame` and `SavedFrame`, preserved across tail calls and continuation capture/restore, like `seq`). Their result is delivered by their own `runUntil` session's return value, so `dst` is only a placeholder.

At every result-delivery site in the dispatch loop (`call`/`apply` native + FFI + parameter, `tail_call`/`tail_apply`/`tail_call_global` native + FFI + parameter, and the `return` opcode), if a `returns_to_native` frame returns into an *outer* loop, raise a clear, catchable error — `continuation cannot resume across a returned native call` — instead of writing into an unrelated caller register.

SRFI-158's `%call-generators` was previously fixed to avoid driving generators from inside native `map`; this hardens the VM itself so the failure mode is a clear error rather than silent corruption.

## Tests

- **Zig unit test** (`src/tests_continuations.zig`): captures a continuation inside the closure `map` drives, then resumes it after `map` returned, asserting `VMError.ExceptionRaised`.
- **Scheme-level** (`tests/scheme/errors/error-format.sh`): asserts the diagnostic message text.

`zig build test` and the SRFI-158 repro both pass; the repro now raises the clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)