### PR TITLE
Fix alist->hash-table arity, root top-level forms, add book-bug regression tests

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -808,7 +808,9 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                     var pr = reader.Reader.init(vm.gc, src);
                     defer pr.deinit();
                     while (pr.hasMore() catch break) {
-                        const expr = pr.readDatum() catch break;
+                        var expr = pr.readDatum() catch break;
+                        vm.gc.pushRoot(&expr) catch break;
+                        defer vm.gc.popRoot();
                         if (vm.handleTopLevelForm(expr)) |top_result| {
                             _ = top_result catch {};
                         }
@@ -861,7 +863,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         return;
     }) {
         const datum_lc = r.getLineCol();
-        const expr = r.readDatum() catch |err| {
+        var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
@@ -869,6 +871,15 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             script_had_error = true;
             return;
         };
+
+        // Root the form: evaluating it (e.g. an import that loads a library)
+        // can trigger GC, which would otherwise reclaim the AST mid-walk.
+        vm.gc.pushRoot(&expr) catch {
+            writeStderr("error: out of memory while rooting expression\n");
+            script_had_error = true;
+            return;
+        };
+        defer vm.gc.popRoot();
 
         // Check for special top-level forms (import, define-library)
         if (vm.handleTopLevelForm(expr)) |top_result| {
@@ -978,7 +989,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
         script_had_error = true;
         return;
     }) {
-        const expr = r.readDatum() catch |err| {
+        var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "<stdin>:{d}:{d}: read error: {}\n", .{ lc.line, lc.col, err }) catch "read error\n";
@@ -986,6 +997,15 @@ fn runStdin(vm: *vm_mod.VM) !void {
             script_had_error = true;
             return;
         };
+
+        // Root the form: evaluating it (e.g. an import that loads a library)
+        // can trigger GC, which would otherwise reclaim the AST mid-walk.
+        vm.gc.pushRoot(&expr) catch {
+            writeStderr("error: out of memory while rooting expression\n");
+            script_had_error = true;
+            return;
+        };
+        defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
             const result = top_result catch |err| {
@@ -1069,7 +1089,7 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
         return;
     }) {
         const datum_lc = r.getLineCol();
-        const expr = r.readDatum() catch |err| {
+        var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
@@ -1077,6 +1097,15 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
             script_had_error = true;
             return;
         };
+
+        // Root the form: evaluating it (e.g. an import that loads a library)
+        // can trigger GC, which would otherwise reclaim the AST mid-walk.
+        vm.gc.pushRoot(&expr) catch {
+            writeStderr("error: out of memory while rooting expression\n");
+            script_had_error = true;
+            return;
+        };
+        defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
             _ = top_result catch |err| {

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -24,7 +24,7 @@ pub fn registerHashTable(vm: *vm_mod.VM) !void {
     try reg(vm, "hash-table-values", &hashTableValuesFn, .{ .exact = 1 });
     try reg(vm, "hash-table-walk", &hashTableWalkFn, .{ .exact = 2 });
     try reg(vm, "hash-table->alist", &hashTableToAlistFn, .{ .exact = 1 });
-    try reg(vm, "alist->hash-table", &alistToHashTableFn, .{ .exact = 1 });
+    try reg(vm, "alist->hash-table", &alistToHashTableFn, .{ .variadic = 1 });
     try reg(vm, "hash-table-copy", &hashTableCopyFn, .{ .exact = 1 });
     try reg(vm, "hash-table-update!/default", &hashTableUpdateDefaultFn, .{ .exact = 4 });
     try reg(vm, "hash", &hashFn, .{ .variadic = 1 });
@@ -335,7 +335,8 @@ fn hashTableToAlistFn(args: []const Value) PrimitiveError!Value {
     return result;
 }
 
-// (alist->hash-table alist)
+// (alist->hash-table alist) or (alist->hash-table alist equal-proc hash-proc)
+// The optional comparator/hash args are accepted and ignored, like make-hash-table.
 fn alistToHashTableFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -977,13 +977,21 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
         writeStderr(s);
         break :blk false;
     }) {
-        const expr = r.readDatum() catch |err| {
+        var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "<repl>:{d}:{d}: read error: {}\n", .{ lc.line, lc.col, err }) catch "read error\n";
             writeStderr(s);
             break;
         };
+
+        // Root the form: evaluating it (e.g. an import that loads a library)
+        // can trigger GC, which would otherwise reclaim the AST mid-walk.
+        vm.gc.pushRoot(&expr) catch {
+            writeStderr("error: out of memory while rooting expression\n");
+            break;
+        };
+        defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
             const result = top_result catch |err| {

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -15,7 +15,11 @@ pub fn eval(vm: *VM, source: []const u8) VMError!Value {
 
     var last_result: Value = types.VOID;
     while (reader.hasMore() catch return VMError.CompileError) {
-        const expr = reader.readDatum() catch return VMError.CompileError;
+        var expr = reader.readDatum() catch return VMError.CompileError;
+        // Root the form: evaluating it (e.g. an import that loads a library)
+        // can trigger GC, which would otherwise reclaim the AST mid-walk.
+        vm.gc.pushRoot(&expr) catch return VMError.OutOfMemory;
+        defer vm.gc.popRoot();
         if (handleTopLevelForm(vm, expr)) |result| {
             last_result = result catch |err| return err;
             continue;

--- a/tests/scheme/continuations/coroutine-repl-echo.scm
+++ b/tests/scheme/continuations/coroutine-repl-echo.scm
@@ -1,0 +1,72 @@
+;; Regression: a continuation captured with call/cc must survive the top-level
+;; value-echo. Both file mode and piped-stdin mode print each non-void
+;; top-level result, and that printing path previously misdetected the escape
+;; as leaving the continuation, so the *next* re-entry through the saved
+;; continuation failed with "not a procedure". Wrapping every call in
+;; (display ...) hid the bug because the result was then consumed instead of
+;; echoed. These forms are therefore left BARE on purpose: if the bug returns,
+;; the second coroutine call raises "not a procedure" and the script exits
+;; non-zero, which run-all.sh flags.
+;;
+;; Covers two coroutine shapes:
+;;   1. Two saved continuations in top-level globals (resume / return).
+;;   2. The same machinery captured in closure state via a factory.
+
+(define resume #f)
+(define return #f)
+
+(define (yield value)
+  (call/cc (lambda (k)
+             (set! resume k)
+             (return value))))
+
+(define (coroutine-run proc)
+  (call/cc (lambda (caller)
+             (set! return caller)
+             (if resume
+                 (resume #f)
+                 (proc yield)))))
+
+(define (counter yield)
+  (yield "one")
+  (yield "two")
+  "three")
+
+;; Bare echo — must print "one" "two" "three" without breaking the saved
+;; continuation between calls.
+(coroutine-run counter)
+(coroutine-run counter)
+(coroutine-run counter)
+
+;; ---- Closure-state factory: each coroutine owns its own resume/return ----
+
+(define (make-coroutine proc)
+  (let ((resume #f)
+        (return #f))
+    (define (yield value)
+      (call/cc (lambda (k)
+                 (set! resume k)
+                 (return value))))
+    (lambda ()
+      (call/cc (lambda (caller)
+                 (set! return caller)
+                 (if resume
+                     (resume #f)
+                     (proc yield)))))))
+
+(define gen
+  (make-coroutine
+    (lambda (yield)
+      (yield 'a)
+      (yield 'b)
+      'c)))
+
+;; Bare echo again — prints a, b, c across three re-entries.
+(gen)
+(gen)
+(gen)
+
+;; A visible marker so a passing run is obvious; if any call above regressed,
+;; the runtime error aborts before reaching here and flips the exit code.
+(display "coroutine-repl-echo ok")
+(newline)

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -178,6 +178,29 @@ assert_output_contains "mismatched ellipsis lengths rejected cleanly" \
     '(define-syntax zip (syntax-rules () ((zip (a ...) (b ...)) (quote ((a b) ...))))) (zip (1 2 3) (4 5))' \
     "compile error"
 
+# --- Uncaught exceptions carry message and irritants ---
+echo
+echo "-- Uncaught exceptions --"
+
+assert_output_contains "uncaught (error ...) shows message" \
+    '(error "something went wrong" 42)' 'error: something went wrong 42'
+
+assert_output_contains "uncaught (error ...) writes irritants" \
+    '(error "kaboom" (list 1 2) "x")' 'error: kaboom (1 2) "x"'
+
+assert_output_contains "uncaught raise of non-error object shows the value" \
+    "(raise 'oops)" 'error: uncaught exception: oops'
+
+assert_output_contains "uncaught exception inside procedure shows message" \
+    '(define (f) (error "boom" 1)) (f)' 'error: boom 1'
+
+cat > "$TMPDIR/uncaught.scm" << 'SCHEME'
+(error "script boom" 7)
+SCHEME
+
+assert_file_output_contains "uncaught (error ...) in script shows message" \
+    "$TMPDIR/uncaught.scm" 'error: script boom 7'
+
 rm -rf "$TMPDIR"
 
 echo

--- a/tests/scheme/smoke/fiber-pipeline.scm
+++ b/tests/scheme/smoke/fiber-pipeline.scm
@@ -87,6 +87,45 @@
           (loop (cons val acc)))))
   '(15 25))
 
+;; --- generic variadic pipeline builder (kaappi-book shape) ---------------
+;; The book's `pipeline` builds every stage inside one recursive `let loop`,
+;; so each spawned fiber closes over the loop-local `ch` and `procs`. A
+;; two-or-more-stage pipeline built this way used to make the scheduler
+;; return void (the consumer spun forever emitting garbage / the program
+;; dropped remaining forms). Verify it now delivers every value in order.
+(define (pipeline input-ch . stages)
+  (let loop ((ch input-ch) (procs stages))
+    (if (null? procs)
+        ch
+        (let ((out-ch (make-channel)))
+          (spawn (lambda ()
+            (let process ()
+              (let ((val (channel-receive ch)))
+                (unless (eq? val 'eof)
+                  (channel-send out-ch ((car procs) val))
+                  (process))))
+            (channel-send out-ch 'eof)))
+          (loop out-ch (cdr procs))))))
+
+(define gsrc (make-channel))
+(define gout
+  (pipeline gsrc
+            (lambda (x) (* x x))   ; square
+            (lambda (x) (+ x 1))   ; add 1
+            (lambda (x) (* x 10)))) ; scale
+(define gproducer
+  (spawn (lambda ()
+    (for-each (lambda (n) (channel-send gsrc n)) '(1 2 3 4 5))
+    (channel-send gsrc 'eof))))
+
+(check "variadic pipeline (three stages) delivers all values"
+  (let loop ((acc '()))
+    (let ((val (channel-receive gout)))
+      (if (eq? val 'eof)
+          (reverse acc)
+          (loop (cons val acc)))))
+  '(20 50 100 170 260))
+
 ;; --- deadlock with a blocked fiber ---------------------------------------
 ;; Main and a spawned fiber both wait on a channel nobody sends to:
 ;; the main receive must raise, not return an unspecified value.

--- a/tests/scheme/srfi/srfi69-ext.scm
+++ b/tests/scheme/srfi/srfi69-ext.scm
@@ -78,6 +78,13 @@
   (check "alist size" (hash-table-size ht) 2)
   (check "->alist length" (length (hash-table->alist ht)) 2))
 
+;;; alist->hash-table accepts SRFI-69 optional equality and hash arguments
+(let ((ht (alist->hash-table '((a . 1) (b . 2)) equal?)))
+  (check "alist w/ equality arg populated" (hash-table-ref ht 'b) 2)
+  (check "alist w/ equality arg size" (hash-table-size ht) 2))
+(let ((ht (alist->hash-table '((a . 1)) equal? hash)))
+  (check "alist w/ equality+hash args" (hash-table-ref ht 'a) 1))
+
 ;;; Summary
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)


### PR DESCRIPTION
Closes out the kaappi-book REPL-listing verification sweep (8 interpreter bugs found replaying every listing against v0.11.0). Most were already fixed on main; this PR ships the one remaining code fix, hardens a GC pattern, and locks the fixed behaviors in with regression tests.

## Code changes

**`alist->hash-table` accepts SRFI-69 optional arguments** — the primitive was registered `exact = 1`, so the spec-conforming `(alist->hash-table lst equal?)` raised an arity error. Now variadic, accepting-and-ignoring the comparator/hash args exactly like `make-hash-table` does.

**Root top-level forms during evaluation** — the file runner, stdin runner, bundle preamble, REPL input loop, and `eval()` evaluated freshly read datums without a GC root. An import that loads a whole `.sld` library allocates enough to trigger a collection mid-walk of the form's own AST. Recent GC work on main fixed the reported failures; this completes the rooting pattern (already used by the script runner and `loadLibrarySource`) at the five remaining call sites so those paths don't depend on collection timing.

## Regression tests (for fixes already on main, previously untested)

| Test | Bug it locks in |
|------|----------------|
| `errors/error-format.sh` (+5 cases) | Uncaught exceptions print message + irritants (`error: something went wrong 42`), not `runtime error: error.ExceptionRaised` — error objects, non-error raises, script mode |
| `continuations/coroutine-repl-echo.scm` (new) | call/cc continuations survive the top-level value echo; on v0.11.0 the second re-entry failed with "not a procedure". Forms deliberately bare — display-wrapping consumed the value and hid the bug. Covers top-level-global and closure-factory coroutine shapes |
| `smoke/fiber-pipeline.scm` (+1 case) | The book's generic variadic `pipeline` builder (each stage's fiber closes over one recursive loop's locals); 2+ stages used to make `channel-receive` return garbage (#978) |

## Verified

- `zig build test` — pass
- `bash tests/scheme/run-all.sh` — 1681 pass, 0 fail (286 Scheme files + 1395 R7RS)
- `errors/error-format.sh` 30 pass / `errors/exit-code.sh` 39 pass
- kaappi-book `check-repl` against this build: 729 listings, 714 passed, 15 ignored (was 23), 0 failed
- coroutine test confirmed failing on v0.11.0, passing here; import stress confirmed under `-Dgc-threshold=1`

## Not fixed here

The sweep also surfaced a deeper GC bug in library include-loading — filed with full diagnosis and a deterministic reproducer as #1010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)