### PR TITLE
Fix GC corruption during library include-load (#1010)

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -42,39 +42,46 @@ pub fn compileGuard(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compi
     }
 
     const gc = self.gc;
-    gc.no_collect += 1;
 
-    var cond_clauses = clauses;
-    if (!has_else) {
-        const raise_sym = gc.allocSymbol("raise-continuable") catch return CompileError.OutOfMemory;
-        const raise_call = gc.allocPair(raise_sym, gc.allocPair(var_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        const else_sym = gc.allocSymbol("else") catch return CompileError.OutOfMemory;
-        const else_clause = gc.allocPair(else_sym, gc.allocPair(raise_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        cond_clauses = appendToList(self, clauses, else_clause) catch return CompileError.OutOfMemory;
-    }
+    // Build the desugared form with collection disabled: every intermediate
+    // below is a fresh unrooted pair. The scoped defer restores the counter
+    // on every path; leaking an increment would disable collection for the
+    // rest of the process.
+    var form: Value = blk: {
+        gc.no_collect += 1;
+        defer gc.no_collect -= 1;
 
-    const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-    const gk_counter = struct {
-        var n: u32 = 0;
+        var cond_clauses = clauses;
+        if (!has_else) {
+            const raise_sym = gc.allocSymbol("raise-continuable") catch return CompileError.OutOfMemory;
+            const raise_call = gc.allocPair(raise_sym, gc.allocPair(var_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            const else_sym = gc.allocSymbol("else") catch return CompileError.OutOfMemory;
+            const else_clause = gc.allocPair(else_sym, gc.allocPair(raise_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            cond_clauses = appendToList(self, clauses, else_clause) catch return CompileError.OutOfMemory;
+        }
+
+        const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+        const gk_counter = struct {
+            var n: u32 = 0;
+        };
+        gk_counter.n += 1;
+        var gk_buf: [32]u8 = undefined;
+        const gk_name = std.fmt.bufPrint(&gk_buf, "__gk{d}", .{gk_counter.n}) catch "__gk";
+        const gk = gc.allocSymbol(gk_name) catch return CompileError.OutOfMemory;
+
+        const cond_sym = gc.allocSymbol("cond") catch return CompileError.OutOfMemory;
+        const cond_form = gc.allocPair(cond_sym, cond_clauses) catch return CompileError.OutOfMemory;
+        const k_call = gc.allocPair(gk, gc.allocPair(cond_form, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const h_formals = gc.allocPair(var_sym, types.NIL) catch return CompileError.OutOfMemory;
+        const handler = gc.allocPair(lambda_sym, gc.allocPair(h_formals, gc.allocPair(k_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const thunk = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const weh_sym = gc.allocSymbol("with-exception-handler") catch return CompileError.OutOfMemory;
+        const weh = gc.allocPair(weh_sym, gc.allocPair(handler, gc.allocPair(thunk, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const outer = gc.allocPair(lambda_sym, gc.allocPair(gc.allocPair(gk, types.NIL) catch return CompileError.OutOfMemory, gc.allocPair(weh, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const ec_sym = gc.allocSymbol("call-with-escape-continuation") catch return CompileError.OutOfMemory;
+        break :blk gc.allocPair(ec_sym, gc.allocPair(outer, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
     };
-    gk_counter.n += 1;
-    var gk_buf: [32]u8 = undefined;
-    const gk_name = std.fmt.bufPrint(&gk_buf, "__gk{d}", .{gk_counter.n}) catch "__gk";
-    const gk = gc.allocSymbol(gk_name) catch return CompileError.OutOfMemory;
 
-    const cond_sym = gc.allocSymbol("cond") catch return CompileError.OutOfMemory;
-    const cond_form = gc.allocPair(cond_sym, cond_clauses) catch return CompileError.OutOfMemory;
-    const k_call = gc.allocPair(gk, gc.allocPair(cond_form, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-    const h_formals = gc.allocPair(var_sym, types.NIL) catch return CompileError.OutOfMemory;
-    const handler = gc.allocPair(lambda_sym, gc.allocPair(h_formals, gc.allocPair(k_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-    const thunk = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-    const weh_sym = gc.allocSymbol("with-exception-handler") catch return CompileError.OutOfMemory;
-    const weh = gc.allocPair(weh_sym, gc.allocPair(handler, gc.allocPair(thunk, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-    const outer = gc.allocPair(lambda_sym, gc.allocPair(gc.allocPair(gk, types.NIL) catch return CompileError.OutOfMemory, gc.allocPair(weh, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-    const ec_sym = gc.allocSymbol("call-with-escape-continuation") catch return CompileError.OutOfMemory;
-    var form = gc.allocPair(ec_sym, gc.allocPair(outer, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-
-    gc.no_collect -= 1;
     try gc.pushRoot(&form);
     defer gc.popRoot();
     return self.compileExpr(form, dst, is_tail);
@@ -302,13 +309,22 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
         // inner unquotes at depth > 0 remain literal (#850).
         const gc = self.gc;
         const vec = types.toVector(tmpl);
-        // Convert vector elements to a list
-        var list: Value = types.NIL;
-        var i = vec.data.len;
-        while (i > 0) {
-            i -= 1;
-            list = gc.allocPair(vec.data[i], list) catch return CompileError.OutOfMemory;
-        }
+        // Convert vector elements to a list. Built under no_collect (the
+        // growing list is fresh unrooted pairs, issue #1010), then rooted
+        // across the recursive compile.
+        var list: Value = blk: {
+            gc.no_collect += 1;
+            defer gc.no_collect -= 1;
+            var l: Value = types.NIL;
+            var i = vec.data.len;
+            while (i > 0) {
+                i -= 1;
+                l = gc.allocPair(vec.data[i], l) catch return CompileError.OutOfMemory;
+            }
+            break :blk l;
+        };
+        try gc.pushRoot(&list);
+        defer gc.popRoot();
         // Compile the list at the current quasiquote depth
         const fn_reg = try self.allocReg();
         const arg_reg = try self.allocReg();
@@ -513,7 +529,15 @@ fn hasUnquoteSplicing(tmpl: Value, depth: u8) bool {
 ///   (append (list (quote a)) (list 1 2) (list (quote b)))
 fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!void {
     const gc = self.gc;
+    // no_collect protects the fresh segment sexprs (stack buffers the GC
+    // cannot see) until the final form is rooted. The flag keeps the counter
+    // balanced on the error returns below without extending the window past
+    // the explicit decrements before each compileExpr.
     gc.no_collect += 1;
+    var nc_held = true;
+    defer if (nc_held) {
+        gc.no_collect -= 1;
+    };
     const quote_sym = gc.allocSymbol("quote") catch return CompileError.OutOfMemory;
     const list_sym = gc.allocSymbol("list") catch return CompileError.OutOfMemory;
     const append_sym = gc.allocSymbol("append") catch return CompileError.OutOfMemory;
@@ -619,6 +643,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
 
     if (seg_count == 0) {
         gc.no_collect -= 1;
+        nc_held = false;
         try self.emitOp(.load_nil);
         try self.emitU16(dst);
         return;
@@ -626,6 +651,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
     if (seg_count == 1) {
         var seg0 = segments_buf[0];
         gc.no_collect -= 1;
+        nc_held = false;
         try gc.pushRoot(&seg0);
         defer gc.popRoot();
         return self.compileExpr(seg0, dst, false);
@@ -640,6 +666,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
     }
     var append_call = gc.allocPair(append_sym, args_list) catch return CompileError.OutOfMemory;
     gc.no_collect -= 1;
+    nc_held = false;
     try gc.pushRoot(&append_call);
     defer gc.popRoot();
     return self.compileExpr(append_call, dst, false);
@@ -750,69 +777,75 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
         b = types.cdr(b);
     }
 
-    gc.no_collect += 1;
+    // Build the desugared form with collection disabled: every intermediate
+    // below is a fresh unrooted pair. The scoped defer restores the counter
+    // on every path; leaking an increment would disable collection for the
+    // rest of the process.
+    var outer_let: Value = blk: {
+        gc.no_collect += 1;
+        defer gc.no_collect -= 1;
 
-    // Build let bindings — each param expr is wrapped in a let* so it's
-    // evaluated exactly once. The let* is needed so earlier bindings are
-    // visible when later ones reference them.
-    //   (let* ((%pp0 <param-expr0>) (old0 (%pp0)) (new0 (begin (%pp0 v0) (%pp0)))
-    //          (%pp1 <param-expr1>) (old1 (%pp1)) (new1 (begin (%pp1 v1) (%pp1))) ...)
-    //     (dynamic-wind ...))
-    const letstar_sym = gc.allocSymbol("let*") catch return CompileError.OutOfMemory;
-    var let_bindings: Value = types.NIL;
-    var i = binding_count;
-    while (i > 0) {
-        i -= 1;
-        // (new_i (begin (%pp_i v_i) (%pp_i))) — set with converter, read back converted value
-        const set_call = gc.allocPair(param_syms[i], gc.allocPair(val_exprs[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        const get_call = gc.allocPair(param_syms[i], types.NIL) catch return CompileError.OutOfMemory;
-        const begin_body = gc.allocPair(set_call, gc.allocPair(get_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        const begin_expr = gc.allocPair(begin_sym, begin_body) catch return CompileError.OutOfMemory;
-        const new_pair = gc.allocPair(new_syms[i], gc.allocPair(begin_expr, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        let_bindings = gc.allocPair(new_pair, let_bindings) catch return CompileError.OutOfMemory;
+        // Build let bindings — each param expr is wrapped in a let* so it's
+        // evaluated exactly once. The let* is needed so earlier bindings are
+        // visible when later ones reference them.
+        //   (let* ((%pp0 <param-expr0>) (old0 (%pp0)) (new0 (begin (%pp0 v0) (%pp0)))
+        //          (%pp1 <param-expr1>) (old1 (%pp1)) (new1 (begin (%pp1 v1) (%pp1))) ...)
+        //     (dynamic-wind ...))
+        const letstar_sym = gc.allocSymbol("let*") catch return CompileError.OutOfMemory;
+        var let_bindings: Value = types.NIL;
+        var i = binding_count;
+        while (i > 0) {
+            i -= 1;
+            // (new_i (begin (%pp_i v_i) (%pp_i))) — set with converter, read back converted value
+            const set_call = gc.allocPair(param_syms[i], gc.allocPair(val_exprs[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            const get_call = gc.allocPair(param_syms[i], types.NIL) catch return CompileError.OutOfMemory;
+            const begin_body = gc.allocPair(set_call, gc.allocPair(get_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            const begin_expr = gc.allocPair(begin_sym, begin_body) catch return CompileError.OutOfMemory;
+            const new_pair = gc.allocPair(new_syms[i], gc.allocPair(begin_expr, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            let_bindings = gc.allocPair(new_pair, let_bindings) catch return CompileError.OutOfMemory;
 
-        // (old_i (%pp_i)) — save old value
-        const old_get = gc.allocPair(param_syms[i], types.NIL) catch return CompileError.OutOfMemory;
-        const old_pair = gc.allocPair(old_syms[i], gc.allocPair(old_get, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        let_bindings = gc.allocPair(old_pair, let_bindings) catch return CompileError.OutOfMemory;
+            // (old_i (%pp_i)) — save old value
+            const old_get = gc.allocPair(param_syms[i], types.NIL) catch return CompileError.OutOfMemory;
+            const old_pair = gc.allocPair(old_syms[i], gc.allocPair(old_get, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            let_bindings = gc.allocPair(old_pair, let_bindings) catch return CompileError.OutOfMemory;
 
-        // (%pp_i <param-expr_i>) — evaluate param expression once
-        const pp_pair = gc.allocPair(param_syms[i], gc.allocPair(param_exprs[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        let_bindings = gc.allocPair(pp_pair, let_bindings) catch return CompileError.OutOfMemory;
-    }
+            // (%pp_i <param-expr_i>) — evaluate param expression once
+            const pp_pair = gc.allocPair(param_syms[i], gc.allocPair(param_exprs[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            let_bindings = gc.allocPair(pp_pair, let_bindings) catch return CompileError.OutOfMemory;
+        }
 
-    const dw_sym = gc.allocSymbol("dynamic-wind") catch return CompileError.OutOfMemory;
-    const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-    const pset_sym = gc.allocSymbol("%parameter-set!") catch return CompileError.OutOfMemory;
+        const dw_sym = gc.allocSymbol("dynamic-wind") catch return CompileError.OutOfMemory;
+        const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+        const pset_sym = gc.allocSymbol("%parameter-set!") catch return CompileError.OutOfMemory;
 
-    // before-thunk: (%parameter-set! %pp_i new_i) — install pre-converted values
-    var before_body: Value = types.NIL;
-    i = binding_count;
-    while (i > 0) {
-        i -= 1;
-        const set_call = gc.allocPair(pset_sym, gc.allocPair(param_syms[i], gc.allocPair(new_syms[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        before_body = gc.allocPair(set_call, before_body) catch return CompileError.OutOfMemory;
-    }
-    const before_thunk = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, before_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        // before-thunk: (%parameter-set! %pp_i new_i) — install pre-converted values
+        var before_body: Value = types.NIL;
+        i = binding_count;
+        while (i > 0) {
+            i -= 1;
+            const set_call = gc.allocPair(pset_sym, gc.allocPair(param_syms[i], gc.allocPair(new_syms[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            before_body = gc.allocPair(set_call, before_body) catch return CompileError.OutOfMemory;
+        }
+        const before_thunk = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, before_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
 
-    const body_thunk = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const body_thunk = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
 
-    // after-thunk: (%parameter-set! %pp_i old_i) — restore old values
-    var after_body: Value = types.NIL;
-    i = binding_count;
-    while (i > 0) {
-        i -= 1;
-        const restore_call = gc.allocPair(pset_sym, gc.allocPair(param_syms[i], gc.allocPair(old_syms[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        after_body = gc.allocPair(restore_call, after_body) catch return CompileError.OutOfMemory;
-    }
-    const after_thunk = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, after_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        // after-thunk: (%parameter-set! %pp_i old_i) — restore old values
+        var after_body: Value = types.NIL;
+        i = binding_count;
+        while (i > 0) {
+            i -= 1;
+            const restore_call = gc.allocPair(pset_sym, gc.allocPair(param_syms[i], gc.allocPair(old_syms[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            after_body = gc.allocPair(restore_call, after_body) catch return CompileError.OutOfMemory;
+        }
+        const after_thunk = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, after_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
 
-    const dw_call = gc.allocPair(dw_sym, gc.allocPair(before_thunk, gc.allocPair(body_thunk, gc.allocPair(after_thunk, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const dw_call = gc.allocPair(dw_sym, gc.allocPair(before_thunk, gc.allocPair(body_thunk, gc.allocPair(after_thunk, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
 
-    const outer_body = gc.allocPair(dw_call, types.NIL) catch return CompileError.OutOfMemory;
-    var outer_let = gc.allocPair(letstar_sym, gc.allocPair(let_bindings, outer_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const outer_body = gc.allocPair(dw_call, types.NIL) catch return CompileError.OutOfMemory;
+        break :blk gc.allocPair(letstar_sym, gc.allocPair(let_bindings, outer_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+    };
 
-    gc.no_collect -= 1;
     try gc.pushRoot(&outer_let);
     defer gc.popRoot();
     return self.compileExpr(outer_let, dst, is_tail);
@@ -831,90 +864,97 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
 ///       (else (error "wrong number of arguments")))))
 pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!void {
     const gc = self.gc;
-    gc.no_collect += 1;
 
-    const lambda_sym = try gc.allocSymbol("lambda");
-    const let_sym = try gc.allocSymbol("let");
-    const cond_sym = try gc.allocSymbol("cond");
-    const eq_sym = try gc.allocSymbol("=");
-    const ge_sym = try gc.allocSymbol(">=");
-    const length_sym = try gc.allocSymbol("length");
-    const apply_sym = try gc.allocSymbol("apply");
-    const else_sym = try gc.allocSymbol("else");
-    const error_sym = try gc.allocSymbol("error");
-    const args_sym = try gc.allocSymbol("%cl-args");
-    const n_sym = try gc.allocSymbol("%cl-n");
+    // Build the desugared form with collection disabled: every intermediate
+    // below is a fresh unrooted pair. The scoped defer restores the counter
+    // on every path (including the InvalidSyntax returns); leaking an
+    // increment would disable collection for the rest of the process.
+    var outer_lambda: Value = blk: {
+        gc.no_collect += 1;
+        defer gc.no_collect -= 1;
 
-    var cond_clauses: Value = types.NIL;
-    var clause_list = args;
+        const lambda_sym = try gc.allocSymbol("lambda");
+        const let_sym = try gc.allocSymbol("let");
+        const cond_sym = try gc.allocSymbol("cond");
+        const eq_sym = try gc.allocSymbol("=");
+        const ge_sym = try gc.allocSymbol(">=");
+        const length_sym = try gc.allocSymbol("length");
+        const apply_sym = try gc.allocSymbol("apply");
+        const else_sym = try gc.allocSymbol("else");
+        const error_sym = try gc.allocSymbol("error");
+        const args_sym = try gc.allocSymbol("%cl-args");
+        const n_sym = try gc.allocSymbol("%cl-n");
 
-    // Values collected here stay reachable because no_collect is held until
-    // after the desugared form is fully built.
-    var clause_buf: std.ArrayList(Value) = .empty;
-    defer clause_buf.deinit(gc.allocator);
+        var cond_clauses: Value = types.NIL;
+        var clause_list = args;
 
-    while (clause_list != types.NIL) {
-        if (!types.isPair(clause_list)) return CompileError.InvalidSyntax;
-        const clause = types.car(clause_list);
-        clause_list = types.cdr(clause_list);
+        // Values collected here stay reachable because no_collect is held until
+        // after the desugared form is fully built.
+        var clause_buf: std.ArrayList(Value) = .empty;
+        defer clause_buf.deinit(gc.allocator);
 
-        if (!types.isPair(clause)) return CompileError.InvalidSyntax;
-        const formals = types.car(clause);
-        const body = types.cdr(clause);
-        if (body == types.NIL) return CompileError.InvalidSyntax;
+        while (clause_list != types.NIL) {
+            if (!types.isPair(clause_list)) return CompileError.InvalidSyntax;
+            const clause = types.car(clause_list);
+            clause_list = types.cdr(clause_list);
 
-        // Count arity from formals
-        var arity: i64 = 0;
-        var flist = formals;
-        while (flist != types.NIL) {
-            if (!types.isPair(flist)) break; // rest param
-            arity += 1;
-            flist = types.cdr(flist);
+            if (!types.isPair(clause)) return CompileError.InvalidSyntax;
+            const formals = types.car(clause);
+            const body = types.cdr(clause);
+            if (body == types.NIL) return CompileError.InvalidSyntax;
+
+            // Count arity from formals
+            var arity: i64 = 0;
+            var flist = formals;
+            while (flist != types.NIL) {
+                if (!types.isPair(flist)) break; // rest param
+                arity += 1;
+                flist = types.cdr(flist);
+            }
+
+            const has_rest = flist != types.NIL;
+            const arity_val = types.makeFixnum(arity);
+            const cmp_sym = if (has_rest) ge_sym else eq_sym;
+            const test_expr = try gc.allocPair(cmp_sym, try gc.allocPair(n_sym, try gc.allocPair(arity_val, types.NIL)));
+            // (lambda formals body...)
+            const inner_lambda = try gc.allocPair(lambda_sym, try gc.allocPair(formals, body));
+            // (apply inner_lambda args)
+            const apply_call = try gc.allocPair(apply_sym, try gc.allocPair(inner_lambda, try gc.allocPair(args_sym, types.NIL)));
+            // ((= n arity) (apply ...))
+            const cond_clause = try gc.allocPair(test_expr, try gc.allocPair(apply_call, types.NIL));
+
+            clause_buf.append(gc.allocator, cond_clause) catch return CompileError.OutOfMemory;
         }
 
-        const has_rest = flist != types.NIL;
-        const arity_val = types.makeFixnum(arity);
-        const cmp_sym = if (has_rest) ge_sym else eq_sym;
-        const test_expr = try gc.allocPair(cmp_sym, try gc.allocPair(n_sym, try gc.allocPair(arity_val, types.NIL)));
-        // (lambda formals body...)
-        const inner_lambda = try gc.allocPair(lambda_sym, try gc.allocPair(formals, body));
-        // (apply inner_lambda args)
-        const apply_call = try gc.allocPair(apply_sym, try gc.allocPair(inner_lambda, try gc.allocPair(args_sym, types.NIL)));
-        // ((= n arity) (apply ...))
-        const cond_clause = try gc.allocPair(test_expr, try gc.allocPair(apply_call, types.NIL));
+        // Build else clause: (else (error "wrong number of arguments"))
+        const err_msg = try gc.allocString("wrong number of arguments");
+        const err_call = try gc.allocPair(error_sym, try gc.allocPair(err_msg, types.NIL));
+        const else_clause = try gc.allocPair(else_sym, try gc.allocPair(err_call, types.NIL));
 
-        clause_buf.append(gc.allocator, cond_clause) catch return CompileError.OutOfMemory;
-    }
+        // Build cond clauses list (in order) ending with else
+        cond_clauses = try gc.allocPair(else_clause, types.NIL);
+        var ci = clause_buf.items.len;
+        while (ci > 0) {
+            ci -= 1;
+            cond_clauses = try gc.allocPair(clause_buf.items[ci], cond_clauses);
+        }
 
-    // Build else clause: (else (error "wrong number of arguments"))
-    const err_msg = try gc.allocString("wrong number of arguments");
-    const err_call = try gc.allocPair(error_sym, try gc.allocPair(err_msg, types.NIL));
-    const else_clause = try gc.allocPair(else_sym, try gc.allocPair(err_call, types.NIL));
+        // Build: (cond clauses...)
+        const cond_form = try gc.allocPair(cond_sym, cond_clauses);
 
-    // Build cond clauses list (in order) ending with else
-    cond_clauses = try gc.allocPair(else_clause, types.NIL);
-    var ci = clause_buf.items.len;
-    while (ci > 0) {
-        ci -= 1;
-        cond_clauses = try gc.allocPair(clause_buf.items[ci], cond_clauses);
-    }
+        // Build: (let ((n (length args))) cond_form)
+        // (length args)
+        const length_call = try gc.allocPair(length_sym, try gc.allocPair(args_sym, types.NIL));
+        // ((n (length args)))
+        const n_binding = try gc.allocPair(n_sym, try gc.allocPair(length_call, types.NIL));
+        const bindings = try gc.allocPair(n_binding, types.NIL);
+        // (let bindings cond_form)
+        const let_form = try gc.allocPair(let_sym, try gc.allocPair(bindings, try gc.allocPair(cond_form, types.NIL)));
 
-    // Build: (cond clauses...)
-    const cond_form = try gc.allocPair(cond_sym, cond_clauses);
+        // Build: (lambda args let_form)
+        break :blk try gc.allocPair(lambda_sym, try gc.allocPair(args_sym, try gc.allocPair(let_form, types.NIL)));
+    };
 
-    // Build: (let ((n (length args))) cond_form)
-    // (length args)
-    const length_call = try gc.allocPair(length_sym, try gc.allocPair(args_sym, types.NIL));
-    // ((n (length args)))
-    const n_binding = try gc.allocPair(n_sym, try gc.allocPair(length_call, types.NIL));
-    const bindings = try gc.allocPair(n_binding, types.NIL);
-    // (let bindings cond_form)
-    const let_form = try gc.allocPair(let_sym, try gc.allocPair(bindings, try gc.allocPair(cond_form, types.NIL)));
-
-    // Build: (lambda args let_form)
-    var outer_lambda = try gc.allocPair(lambda_sym, try gc.allocPair(args_sym, try gc.allocPair(let_form, types.NIL)));
-
-    gc.no_collect -= 1;
     try gc.pushRoot(&outer_lambda);
     defer gc.popRoot();
     return self.compileExpr(outer_lambda, dst, false);

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -251,14 +251,6 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
         binding_list = types.cdr(binding_list);
     }
 
-    // Build formals list (var1 var2 ...)
-    var formals: Value = types.NIL;
-    var i = param_count;
-    while (i > 0) {
-        i -= 1;
-        formals = self.gc.allocPair(var_names[i], formals) catch return CompileError.OutOfMemory;
-    }
-
     // Bind the loop procedure to a boxed local (single-binding letrec) so the
     // loop lambda captures itself as an upvalue. It used to be bound to a
     // gensym'd global (__nlet_N_name), but executing that define_global from
@@ -266,9 +258,28 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
     // globals map, leaving a dangling global after the child heap was freed
     // (issue #958). A local also stops polluting the global namespace. The
     // gensym rename is kept so nested named lets reusing a name stay distinct.
+    // (unique_sym is an interned symbol, kept alive by the symbol table.)
     const unique_sym = try makeUniqueLoopName(self.gc, types.symbolName(loop_name));
-    const renamed_body = try renameInBody(self.gc, body, types.symbolName(loop_name), unique_sym);
-    const renamed_lambda_args = self.gc.allocPair(formals, renamed_body) catch return CompileError.OutOfMemory;
+
+    // Build ((formals...) renamed-body...) under no_collect: the formals chain
+    // and renameInBody's partial copies are fresh unrooted pairs, and a
+    // collection landing mid-build sweeps them (issue #1010). Root the result
+    // for the compileLambda below, which also allocates.
+    var renamed_lambda_args: Value = types.NIL;
+    {
+        self.gc.no_collect += 1;
+        defer self.gc.no_collect -= 1;
+        var formals: Value = types.NIL;
+        var i = param_count;
+        while (i > 0) {
+            i -= 1;
+            formals = self.gc.allocPair(var_names[i], formals) catch return CompileError.OutOfMemory;
+        }
+        const renamed_body = try renameInBody(self.gc, body, types.symbolName(loop_name), unique_sym);
+        renamed_lambda_args = self.gc.allocPair(formals, renamed_body) catch return CompileError.OutOfMemory;
+    }
+    self.gc.pushRoot(&renamed_lambda_args) catch return CompileError.OutOfMemory;
+    defer self.gc.popRoot();
 
     self.beginScope();
 
@@ -593,6 +604,14 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
     var def_slots: [MAX_BODY_DEFS]u16 = undefined;
     var def_count: usize = 0;
 
+    // def_inits lives in a stack array the GC cannot see. The (define (name
+    // args...) body) case below allocates fresh lambda pairs into it, and both
+    // the rest of this scan and the init compileExpr calls allocate, so a
+    // collection would sweep the not-yet-compiled inits (issue #1010). Mirror
+    // them into extra_roots (by value, realloc-safe) for the duration.
+    const lb_roots_base = self.gc.extra_roots.items.len;
+    defer self.gc.extra_roots.shrinkRetainingCapacity(lb_roots_base);
+
     // Track define-syntax registrations (both the leading scan below and
     // any produced mid-body by macro expansion, which reach the macro table
     // via compileDefineSyntax) so they don't outlive the body (R7RS 5.3).
@@ -626,8 +645,13 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
                 def_names[def_count] = types.symbolName(fn_name);
                 const param_formals = types.cdr(target);
                 const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-                const lambda_args = self.gc.allocPair(param_formals, def_rest) catch return CompileError.OutOfMemory;
-                def_inits[def_count] = self.gc.allocPair(lambda_sym, lambda_args) catch return CompileError.OutOfMemory;
+                {
+                    var lambda_args = self.gc.allocPair(param_formals, def_rest) catch return CompileError.OutOfMemory;
+                    self.gc.pushRoot(&lambda_args) catch return CompileError.OutOfMemory;
+                    defer self.gc.popRoot();
+                    def_inits[def_count] = self.gc.allocPair(lambda_sym, lambda_args) catch return CompileError.OutOfMemory;
+                }
+                self.gc.extra_roots.append(self.gc.allocator, def_inits[def_count]) catch return CompileError.OutOfMemory;
                 def_count += 1;
             } else {
                 break;
@@ -737,15 +761,21 @@ pub fn compileLetValues(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
     const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
 
     for (0..count) |i| {
-        // Build (call-with-values (lambda () expr) list) and compile it
-        const producer_body = gc.allocPair(exprs[i], types.NIL) catch return CompileError.OutOfMemory;
-        const producer_lambda = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, producer_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        var cwv_expr = gc.allocPair(cwv_sym, gc.allocPair(producer_lambda, gc.allocPair(list_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        // Build (call-with-values (lambda () expr) list) and compile it.
+        // Built under no_collect (fresh unrooted pairs, issue #1010), then
+        // rooted across the compile.
+        var cwv_expr: Value = blk: {
+            gc.no_collect += 1;
+            defer gc.no_collect -= 1;
+            const producer_body = gc.allocPair(exprs[i], types.NIL) catch return CompileError.OutOfMemory;
+            const producer_lambda = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, producer_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            break :blk gc.allocPair(cwv_sym, gc.allocPair(producer_lambda, gc.allocPair(list_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        };
         try gc.pushRoot(&cwv_expr);
+        defer gc.popRoot();
         const slot = try self.allocReg();
         temp_slots[i] = slot;
         try self.compileExpr(cwv_expr, slot, false);
-        gc.popRoot();
     }
 
     // Now build nested (apply (lambda (formals) ...) temp) from inside out
@@ -760,21 +790,28 @@ pub fn compileLetValues(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         try self.addLocal(types.symbolName(temp_syms[i]), temp_slots[i]);
     }
 
-    var inner = body;
-    const begin_sym = gc.allocSymbol("begin") catch return CompileError.OutOfMemory;
-    inner = gc.allocPair(begin_sym, inner) catch return CompileError.OutOfMemory;
+    // Build the nested apply chain under no_collect: `inner` is a growing
+    // tree of fresh unrooted pairs and every iteration allocates (issue #1010).
+    var desugared: Value = blk: {
+        gc.no_collect += 1;
+        defer gc.no_collect -= 1;
 
-    var j = count;
-    while (j > 0) {
-        j -= 1;
-        const apply_sym = gc.allocSymbol("apply") catch return CompileError.OutOfMemory;
-        const inner_body = gc.allocPair(inner, types.NIL) catch return CompileError.OutOfMemory;
-        const consumer = gc.allocPair(lambda_sym, gc.allocPair(formals_arr[j], inner_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-        const temp_sym = temp_syms[j];
-        inner = gc.allocPair(apply_sym, gc.allocPair(consumer, gc.allocPair(temp_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-    }
+        var inner = body;
+        const begin_sym = gc.allocSymbol("begin") catch return CompileError.OutOfMemory;
+        inner = gc.allocPair(begin_sym, inner) catch return CompileError.OutOfMemory;
 
-    var desugared = inner;
+        var j = count;
+        while (j > 0) {
+            j -= 1;
+            const apply_sym = gc.allocSymbol("apply") catch return CompileError.OutOfMemory;
+            const inner_body = gc.allocPair(inner, types.NIL) catch return CompileError.OutOfMemory;
+            const consumer = gc.allocPair(lambda_sym, gc.allocPair(formals_arr[j], inner_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            const temp_sym = temp_syms[j];
+            inner = gc.allocPair(apply_sym, gc.allocPair(consumer, gc.allocPair(temp_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        }
+        break :blk inner;
+    };
+
     try gc.pushRoot(&desugared);
     defer gc.popRoot();
     try self.compileExpr(desugared, dst, is_tail);

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -162,6 +162,14 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
     var def_slots: [MAX_BODY_DEFS]u16 = undefined;
     var def_count: usize = 0;
 
+    // def_inits lives in a stack array the GC cannot see. The (define (name
+    // args...) body) case below allocates fresh lambda pairs into it, and both
+    // the rest of this scan and the phase-2 compileExpr calls allocate, so a
+    // collection would sweep the not-yet-compiled inits (issue #1010). Mirror
+    // them into extra_roots (by value, realloc-safe) for the duration.
+    const roots_base = self.gc.extra_roots.items.len;
+    defer self.gc.extra_roots.shrinkRetainingCapacity(roots_base);
+
     var current = body;
     // Scan leading defines
     while (current != types.NIL and types.isPair(current)) {
@@ -193,8 +201,13 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
             // Build (lambda (args...) body...) as init expression
             const param_formals = types.cdr(target);
             const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-            const lambda_args = self.gc.allocPair(param_formals, def_rest) catch return CompileError.OutOfMemory;
-            def_inits[def_count] = self.gc.allocPair(lambda_sym, lambda_args) catch return CompileError.OutOfMemory;
+            {
+                var lambda_args = self.gc.allocPair(param_formals, def_rest) catch return CompileError.OutOfMemory;
+                self.gc.pushRoot(&lambda_args) catch return CompileError.OutOfMemory;
+                defer self.gc.popRoot();
+                def_inits[def_count] = self.gc.allocPair(lambda_sym, lambda_args) catch return CompileError.OutOfMemory;
+            }
+            self.gc.extra_roots.append(self.gc.allocator, def_inits[def_count]) catch return CompileError.OutOfMemory;
             def_count += 1;
         } else {
             break;
@@ -331,7 +344,9 @@ pub fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
         if (!types.isSymbol(name)) return CompileError.InvalidSyntax;
         const param_formals = types.cdr(target);
 
-        const lambda_args = self.gc.allocPair(param_formals, rest) catch return CompileError.OutOfMemory;
+        var lambda_args = self.gc.allocPair(param_formals, rest) catch return CompileError.OutOfMemory;
+        self.gc.pushRoot(&lambda_args) catch return CompileError.OutOfMemory;
+        defer self.gc.popRoot();
         try compileLambda(self, lambda_args, dst, types.symbolName(name));
 
         if (self.in_body_scope) {
@@ -407,127 +422,135 @@ pub fn compileDefineValues(self: *Compiler, args: Value, dst: u16) CompileError!
 
     // Step 1: emit (define name (if #f #f)) for each name
     for (names_buf[0..name_count]) |name| {
-        const sym = self.gc.allocSymbol(name) catch return CompileError.OutOfMemory;
-        // Build (define name (if #f #f))
-        const void_expr = self.gc.allocPair(types.FALSE, types.NIL) catch return CompileError.OutOfMemory;
-        const if_args = self.gc.allocPair(types.FALSE, void_expr) catch return CompileError.OutOfMemory;
-        const if_sym = self.gc.allocSymbol("if") catch return CompileError.OutOfMemory;
-        const if_form = self.gc.allocPair(if_sym, if_args) catch return CompileError.OutOfMemory;
-        const def_rest = self.gc.allocPair(if_form, types.NIL) catch return CompileError.OutOfMemory;
-        const def_args = self.gc.allocPair(sym, def_rest) catch return CompileError.OutOfMemory;
+        var def_args = try buildVoidDefineArgs(self, name);
+        self.gc.pushRoot(&def_args) catch return CompileError.OutOfMemory;
+        defer self.gc.popRoot();
         try compileDefine(self, def_args, dst);
     }
     if (rest_name) |rn| {
-        if (name_count == 0) {
-            // Single symbol: (define-values x expr) → define x then set! to list
-            const sym = self.gc.allocSymbol(rn) catch return CompileError.OutOfMemory;
-            const void_expr = self.gc.allocPair(types.FALSE, types.NIL) catch return CompileError.OutOfMemory;
-            const if_args = self.gc.allocPair(types.FALSE, void_expr) catch return CompileError.OutOfMemory;
-            const if_sym = self.gc.allocSymbol("if") catch return CompileError.OutOfMemory;
-            const if_form = self.gc.allocPair(if_sym, if_args) catch return CompileError.OutOfMemory;
-            const def_rest = self.gc.allocPair(if_form, types.NIL) catch return CompileError.OutOfMemory;
-            const def_args = self.gc.allocPair(sym, def_rest) catch return CompileError.OutOfMemory;
-            try compileDefine(self, def_args, dst);
-        } else {
-            const sym = self.gc.allocSymbol(rn) catch return CompileError.OutOfMemory;
-            const void_expr = self.gc.allocPair(types.FALSE, types.NIL) catch return CompileError.OutOfMemory;
-            const if_args = self.gc.allocPair(types.FALSE, void_expr) catch return CompileError.OutOfMemory;
-            const if_sym = self.gc.allocSymbol("if") catch return CompileError.OutOfMemory;
-            const if_form = self.gc.allocPair(if_sym, if_args) catch return CompileError.OutOfMemory;
-            const def_rest = self.gc.allocPair(if_form, types.NIL) catch return CompileError.OutOfMemory;
-            const def_args = self.gc.allocPair(sym, def_rest) catch return CompileError.OutOfMemory;
-            try compileDefine(self, def_args, dst);
-        }
+        var def_args = try buildVoidDefineArgs(self, rn);
+        self.gc.pushRoot(&def_args) catch return CompileError.OutOfMemory;
+        defer self.gc.popRoot();
+        try compileDefine(self, def_args, dst);
     }
 
-    // Step 2: Build the consumer lambda params and set! body
-    // Consumer: (lambda (p0 p1 ... [. prest]) (set! x0 p0) (set! x1 p1) ... )
-    var consumer_body: Value = types.NIL;
+    // Steps 2+3 build chains of fresh unrooted pairs, each allocation able to
+    // sweep the previous ones, so collection is disabled for the whole build
+    // (issue #1010). The final form is rooted across the compile that follows.
+    var final_form: Value = types.NIL;
+    const is_single = name_count == 0 and rest_name != null;
+    {
+        self.gc.no_collect += 1;
+        defer self.gc.no_collect -= 1;
 
-    // Build set! forms from right to left
-    if (rest_name) |rn| {
-        if (name_count > 0) {
-            const rn_sym = self.gc.allocSymbol(rn) catch return CompileError.OutOfMemory;
-            const param_sym = self.gc.allocSymbol("__dv_rest") catch return CompileError.OutOfMemory;
+        // Step 2: Build the consumer lambda params and set! body
+        // Consumer: (lambda (p0 p1 ... [. prest]) (set! x0 p0) (set! x1 p1) ... )
+        var consumer_body: Value = types.NIL;
+
+        // Build set! forms from right to left
+        if (rest_name) |rn| {
+            if (name_count > 0) {
+                const rn_sym = self.gc.allocSymbol(rn) catch return CompileError.OutOfMemory;
+                const param_sym = self.gc.allocSymbol("__dv_rest") catch return CompileError.OutOfMemory;
+                const set_rest = self.gc.allocPair(param_sym, types.NIL) catch return CompileError.OutOfMemory;
+                const set_args = self.gc.allocPair(rn_sym, set_rest) catch return CompileError.OutOfMemory;
+                const set_sym = self.gc.allocSymbol("set!") catch return CompileError.OutOfMemory;
+                const set_form = self.gc.allocPair(set_sym, set_args) catch return CompileError.OutOfMemory;
+                consumer_body = self.gc.allocPair(set_form, consumer_body) catch return CompileError.OutOfMemory;
+            }
+        }
+
+        var i = name_count;
+        while (i > 0) {
+            i -= 1;
+            const orig_sym = self.gc.allocSymbol(names_buf[i]) catch return CompileError.OutOfMemory;
+            var param_name_buf: [32]u8 = undefined;
+            const pname = std.fmt.bufPrint(&param_name_buf, "__dv_{d}", .{i}) catch return CompileError.OutOfMemory;
+            const param_sym = self.gc.allocSymbol(pname) catch return CompileError.OutOfMemory;
             const set_rest = self.gc.allocPair(param_sym, types.NIL) catch return CompileError.OutOfMemory;
-            const set_args = self.gc.allocPair(rn_sym, set_rest) catch return CompileError.OutOfMemory;
+            const set_args = self.gc.allocPair(orig_sym, set_rest) catch return CompileError.OutOfMemory;
             const set_sym = self.gc.allocSymbol("set!") catch return CompileError.OutOfMemory;
             const set_form = self.gc.allocPair(set_sym, set_args) catch return CompileError.OutOfMemory;
             consumer_body = self.gc.allocPair(set_form, consumer_body) catch return CompileError.OutOfMemory;
         }
+
+        // Build consumer params list
+        var consumer_params: Value = if (rest_name != null and name_count > 0)
+            self.gc.allocSymbol("__dv_rest") catch return CompileError.OutOfMemory
+        else
+            types.NIL;
+
+        i = name_count;
+        while (i > 0) {
+            i -= 1;
+            var param_name_buf: [32]u8 = undefined;
+            const pname = std.fmt.bufPrint(&param_name_buf, "__dv_{d}", .{i}) catch return CompileError.OutOfMemory;
+            const param_sym = self.gc.allocSymbol(pname) catch return CompileError.OutOfMemory;
+            consumer_params = self.gc.allocPair(param_sym, consumer_params) catch return CompileError.OutOfMemory;
+        }
+
+        if (is_single) {
+            // Single-symbol case: (define-values x expr) needs list conversion
+            // Desugar: (define-values x expr) → (set! x (call-with-values (lambda () expr) list))
+            const rn_sym = self.gc.allocSymbol(rest_name.?) catch return CompileError.OutOfMemory;
+            const list_sym = self.gc.allocSymbol("list") catch return CompileError.OutOfMemory;
+
+            const producer_body = self.gc.allocPair(expr, types.NIL) catch return CompileError.OutOfMemory;
+            const producer_lambda = self.gc.allocPair(types.NIL, producer_body) catch return CompileError.OutOfMemory;
+            const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+            const producer = self.gc.allocPair(lambda_sym, producer_lambda) catch return CompileError.OutOfMemory;
+
+            const cwv_sym = self.gc.allocSymbol("call-with-values") catch return CompileError.OutOfMemory;
+            const cwv_3 = self.gc.allocPair(list_sym, types.NIL) catch return CompileError.OutOfMemory;
+            const cwv_2 = self.gc.allocPair(producer, cwv_3) catch return CompileError.OutOfMemory;
+            const cwv_form = self.gc.allocPair(cwv_sym, cwv_2) catch return CompileError.OutOfMemory;
+
+            const set_rest2 = self.gc.allocPair(cwv_form, types.NIL) catch return CompileError.OutOfMemory;
+            final_form = self.gc.allocPair(rn_sym, set_rest2) catch return CompileError.OutOfMemory;
+        } else {
+            // Build (lambda consumer_params consumer_body...)
+            const consumer_lambda_args = self.gc.allocPair(consumer_params, consumer_body) catch return CompileError.OutOfMemory;
+            const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+            const consumer = self.gc.allocPair(lambda_sym, consumer_lambda_args) catch return CompileError.OutOfMemory;
+
+            // Build (lambda () expr)
+            const producer_body = self.gc.allocPair(expr, types.NIL) catch return CompileError.OutOfMemory;
+            const producer_lambda = self.gc.allocPair(types.NIL, producer_body) catch return CompileError.OutOfMemory;
+            const producer = self.gc.allocPair(lambda_sym, producer_lambda) catch return CompileError.OutOfMemory;
+
+            // Build (call-with-values producer consumer)
+            const cwv_sym = self.gc.allocSymbol("call-with-values") catch return CompileError.OutOfMemory;
+            const cwv_3 = self.gc.allocPair(consumer, types.NIL) catch return CompileError.OutOfMemory;
+            const cwv_2 = self.gc.allocPair(producer, cwv_3) catch return CompileError.OutOfMemory;
+            final_form = self.gc.allocPair(cwv_sym, cwv_2) catch return CompileError.OutOfMemory;
+        }
     }
 
-    var i = name_count;
-    while (i > 0) {
-        i -= 1;
-        const orig_sym = self.gc.allocSymbol(names_buf[i]) catch return CompileError.OutOfMemory;
-        var param_name_buf: [32]u8 = undefined;
-        const pname = std.fmt.bufPrint(&param_name_buf, "__dv_{d}", .{i}) catch return CompileError.OutOfMemory;
-        const param_sym = self.gc.allocSymbol(pname) catch return CompileError.OutOfMemory;
-        const set_rest = self.gc.allocPair(param_sym, types.NIL) catch return CompileError.OutOfMemory;
-        const set_args = self.gc.allocPair(orig_sym, set_rest) catch return CompileError.OutOfMemory;
-        const set_sym = self.gc.allocSymbol("set!") catch return CompileError.OutOfMemory;
-        const set_form = self.gc.allocPair(set_sym, set_args) catch return CompileError.OutOfMemory;
-        consumer_body = self.gc.allocPair(set_form, consumer_body) catch return CompileError.OutOfMemory;
-    }
-
-    // Build consumer params list
-    var consumer_params: Value = if (rest_name != null and name_count > 0)
-        self.gc.allocSymbol("__dv_rest") catch return CompileError.OutOfMemory
-    else
-        types.NIL;
-
-    i = name_count;
-    while (i > 0) {
-        i -= 1;
-        var param_name_buf: [32]u8 = undefined;
-        const pname = std.fmt.bufPrint(&param_name_buf, "__dv_{d}", .{i}) catch return CompileError.OutOfMemory;
-        const param_sym = self.gc.allocSymbol(pname) catch return CompileError.OutOfMemory;
-        consumer_params = self.gc.allocPair(param_sym, consumer_params) catch return CompileError.OutOfMemory;
-    }
-
-    // Single-symbol case: (define-values x expr) needs list conversion
-    if (name_count == 0 and rest_name != null) {
-        // Desugar: (define-values x expr) → (set! x (call-with-values (lambda () expr) list))
-        const rn_sym = self.gc.allocSymbol(rest_name.?) catch return CompileError.OutOfMemory;
-        const list_sym = self.gc.allocSymbol("list") catch return CompileError.OutOfMemory;
-
-        const producer_body = self.gc.allocPair(expr, types.NIL) catch return CompileError.OutOfMemory;
-        const producer_lambda = self.gc.allocPair(types.NIL, producer_body) catch return CompileError.OutOfMemory;
-        const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-        const producer = self.gc.allocPair(lambda_sym, producer_lambda) catch return CompileError.OutOfMemory;
-
-        const cwv_sym = self.gc.allocSymbol("call-with-values") catch return CompileError.OutOfMemory;
-        const cwv_3 = self.gc.allocPair(list_sym, types.NIL) catch return CompileError.OutOfMemory;
-        const cwv_2 = self.gc.allocPair(producer, cwv_3) catch return CompileError.OutOfMemory;
-        const cwv_form = self.gc.allocPair(cwv_sym, cwv_2) catch return CompileError.OutOfMemory;
-
-        const set_rest2 = self.gc.allocPair(cwv_form, types.NIL) catch return CompileError.OutOfMemory;
-        const set_args2 = self.gc.allocPair(rn_sym, set_rest2) catch return CompileError.OutOfMemory;
-        try compileSet(self, set_args2, dst);
+    self.gc.pushRoot(&final_form) catch return CompileError.OutOfMemory;
+    defer self.gc.popRoot();
+    if (is_single) {
+        try compileSet(self, final_form, dst);
         return;
     }
 
-    // Build (lambda consumer_params consumer_body...)
-    const consumer_lambda_args = self.gc.allocPair(consumer_params, consumer_body) catch return CompileError.OutOfMemory;
-    const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-    const consumer = self.gc.allocPair(lambda_sym, consumer_lambda_args) catch return CompileError.OutOfMemory;
-
-    // Build (lambda () expr)
-    const producer_body = self.gc.allocPair(expr, types.NIL) catch return CompileError.OutOfMemory;
-    const producer_lambda = self.gc.allocPair(types.NIL, producer_body) catch return CompileError.OutOfMemory;
-    const producer = self.gc.allocPair(lambda_sym, producer_lambda) catch return CompileError.OutOfMemory;
-
-    // Build (call-with-values producer consumer)
-    const cwv_sym = self.gc.allocSymbol("call-with-values") catch return CompileError.OutOfMemory;
-    const cwv_3 = self.gc.allocPair(consumer, types.NIL) catch return CompileError.OutOfMemory;
-    const cwv_2 = self.gc.allocPair(producer, cwv_3) catch return CompileError.OutOfMemory;
-    const cwv_form = self.gc.allocPair(cwv_sym, cwv_2) catch return CompileError.OutOfMemory;
-
     // Compile the call-with-values expression
-    try self.compileExpr(cwv_form, dst, false);
+    try self.compileExpr(final_form, dst, false);
     try self.emitOp(.load_void);
     try self.emitU16(dst);
+}
+
+/// Build ((name (if #f #f))) define args for define-values pre-definitions,
+/// with collection disabled during the chain of fresh pair allocations.
+fn buildVoidDefineArgs(self: *Compiler, name: []const u8) CompileError!Value {
+    self.gc.no_collect += 1;
+    defer self.gc.no_collect -= 1;
+    const sym = self.gc.allocSymbol(name) catch return CompileError.OutOfMemory;
+    const void_expr = self.gc.allocPair(types.FALSE, types.NIL) catch return CompileError.OutOfMemory;
+    const if_args = self.gc.allocPair(types.FALSE, void_expr) catch return CompileError.OutOfMemory;
+    const if_sym = self.gc.allocSymbol("if") catch return CompileError.OutOfMemory;
+    const if_form = self.gc.allocPair(if_sym, if_args) catch return CompileError.OutOfMemory;
+    const def_rest = self.gc.allocPair(if_form, types.NIL) catch return CompileError.OutOfMemory;
+    return self.gc.allocPair(sym, def_rest) catch return CompileError.OutOfMemory;
 }
 
 pub fn compileSet(self: *Compiler, args: Value, dst: u16) CompileError!void {

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -38,6 +38,14 @@ pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
     if (!types.isSymbol(head)) return null;
     const name = types.symbolName(head);
 
+    // Root the form across the handlers: import/define-library load, compile,
+    // and execute entire libraries (GC runs many times) while still walking
+    // this datum, and most callers pass a freshly read, unrooted expr. Without
+    // this, the import form itself can be swept mid-walk (issue #1010).
+    var expr_root = expr;
+    vm.gc.pushRoot(&expr_root) catch return VMError.OutOfMemory;
+    defer vm.gc.popRoot();
+
     if (std.mem.eql(u8, name, "import")) return vm_library.handleImport(vm, types.cdr(expr));
     if (std.mem.eql(u8, name, "define-library")) return vm_library.handleDefineLibrary(vm, types.cdr(expr));
     if (std.mem.eql(u8, name, "define-record-type")) return vm_records.handleDefineRecordType(vm, types.cdr(expr));

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -411,7 +411,14 @@ fn tryLoadLibraryFromFile(vm: *VM, name_list: Value) !void {
             const saved_lib_dir = vm.current_lib_dir;
             vm.current_lib_dir = sld_dir;
             defer vm.current_lib_dir = saved_lib_dir;
-            loadLibrarySource(vm, found.source) catch return error.UndefinedVariable;
+            loadLibrarySource(vm, found.source) catch |err| {
+                // The library exists — don't let this surface as "library
+                // not found" (#1010).
+                if (vm.last_error_detail_len == 0) {
+                    vm.setErrorDetail("{s} while loading bundled library {s}", .{ @errorName(err), found.path });
+                }
+                return error.UndefinedVariable;
+            };
             return;
         }
     }
@@ -442,7 +449,13 @@ fn tryLoadLibraryFromFile(vm: *VM, name_list: Value) !void {
     // silently dropping exports from include-library-declarations and
     // cond-expand — if caching is ever reintroduced, serialize the export
     // table into the .sbc instead of re-deriving it from source.
-    loadLibrarySource(vm, source) catch {
+    loadLibrarySource(vm, source) catch |err| {
+        // The .sld file was found and read — a failure here is a load error,
+        // not a missing library. Say so instead of letting processImportSet
+        // report "library not found" (#1010).
+        if (vm.last_error_detail_len == 0) {
+            vm.setErrorDetail("{s} while loading library from {s}", .{ @errorName(err), sld_path });
+        }
         return error.UndefinedVariable;
     };
 }
@@ -994,7 +1007,24 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
             lib_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return VMError.OutOfMemory;
         }
     }
-    const func = compiler_mod.compileExpressionInEnv(vm.gc, expr, &lib_macros, lib_env, types.NIL) catch return VMError.CompileError;
+    const func = compiler_mod.compileExpressionInEnv(vm.gc, expr, &lib_macros, lib_env, types.NIL) catch |err| {
+        // Name the failing form so a broken library body surfaces as itself
+        // instead of being masked as "library not found" upstream (#1010).
+        if (vm.last_error_detail_len == 0) {
+            var def_name: []const u8 = "";
+            if (types.isPair(expr) and types.isPair(types.cdr(expr))) {
+                var target = types.car(types.cdr(expr));
+                if (types.isPair(target)) target = types.car(target);
+                if (types.isSymbol(target)) def_name = types.symbolName(target);
+            }
+            if (def_name.len > 0) {
+                vm.setErrorDetail("{s} while compiling library definition '{s}'", .{ @errorName(err), def_name });
+            } else {
+                vm.setErrorDetail("{s} while compiling library body form", .{@errorName(err)});
+            }
+        }
+        return VMError.CompileError;
+    };
     if (vm.lib_compile_collect) |collect| {
         collect.append(vm.gc.allocator, func) catch return VMError.OutOfMemory;
     }

--- a/tests/scheme/srfi/srfi-import-order.scm
+++ b/tests/scheme/srfi/srfi-import-order.scm
@@ -1,0 +1,49 @@
+;; Regression test for issue #1010: GC during library include-load corrupted
+;; compilation, so this exact import sequence failed with a CompileError
+;; masked as "library not found: (srfi.158)".
+;;
+;; Two distinct GC holes conspired:
+;;   1. compileNamedLet built its desugared lambda from fresh unrooted pairs
+;;      across renameInBody (which allocates enough to trigger a collection
+;;      on a large body such as gdelete-neighbor-dups in 158-impl.scm).
+;;   2. handleTopLevelForm never rooted the (import ...) datum itself, so a
+;;      collection during the library load could sweep the form mid-walk.
+;;
+;; The failure was a GC-timing window: it needed the heap state produced by
+;; importing (scheme base)/(scheme write) and then (srfi 115) before
+;; (srfi 158). Keep the sequence exactly as-is.
+(import (scheme base) (scheme write))
+(import (srfi 115))
+(import (srfi 158))
+
+;; The same window made importing (srfi 64) and (srfi 158) together fail
+;; nondeterministically (~75% of runs). Import it too while the heap is warm.
+(import (srfi 64))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+;; Exercise the definition whose compilation was corrupted (a large
+;; case-lambda containing a named let).
+(check "gdelete-neighbor-dups"
+  (generator->list (gdelete-neighbor-dups (generator 1 1 2 2 3 3 3 1)))
+  '(1 2 3 1))
+
+;; Exercise (srfi 115) to confirm the earlier import stayed intact.
+(check "regexp-matches"
+  (regexp-matches? '(+ alpha) "abc")
+  #t)
+
+(display "srfi-import-order: ")
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "srfi-import-order tests failed"))

--- a/tests/scheme/srfi/srfi158.scm
+++ b/tests/scheme/srfi/srfi158.scm
@@ -9,11 +9,11 @@
 ;; or silently produced garbage. The impl now drives generators with plain
 ;; Scheme recursion (%call-generators in lib/srfi/158-impl.scm).
 ;;
-;; Uses manual counters rather than SRFI-64: importing (srfi 64) together
-;; with (srfi 158) currently triggers a separate, nondeterministic
-;; CompileError in the library loader (each library loads fine alone), so
-;; pulling in the SRFI-64 test framework here would make this regression
-;; test flaky for reasons unrelated to what it checks.
+;; Uses manual counters rather than SRFI-64. (Importing (srfi 64) together
+;; with (srfi 158) used to trigger a nondeterministic CompileError in the
+;; library loader — a GC hole fixed with issue #1010 and covered by
+;; srfi-import-order.scm — but manual counters are kept so this file stays
+;; independent of the test framework.)
 (import (scheme base) (scheme write) (scheme process-context) (srfi 158))
 
 (define pass 0)


### PR DESCRIPTION
Fixes #1010.

## Root causes

Two GC holes conspired to make `(import (srfi 158))` after `(import (srfi 115))` fail with a CompileError masked as "library not found":

1. **`compileNamedLet` desugar was unrooted** ([src/compiler_bindings.zig](../blob/main/src/compiler_bindings.zig)): the fresh formals list was built from unrooted pairs, then held across `makeUniqueLoopName`/`renameInBody` — which allocate enough to trigger a collection on a large body like `gdelete-neighbor-dups`'s named let — and the desugared lambda args were never rooted across the nested `compileLambda`. A collection in that window swept the formals; `compileLambda` then read freed pair memory and returned `InvalidSyntax`.
2. **`handleTopLevelForm` never rooted the form** ([src/vm_eval.zig](../blob/main/src/vm_eval.zig)): the `(import ...)` datum itself was unreachable during the library load (thousands of allocations), so a collection could sweep it while `handleImportInto` was still walking it. Fixed at the dispatch chokepoint, covering all 12 call sites (script runner, REPL, stdin, eval, native compiler, nested begin, library loads).

Diagnosis matched the issue's prediction of the mechanism class, with one correction: marking is fully transitive from roots even in minor collections, so this wasn't a missing write barrier — both victims were simply unreachable (fresh desugar pairs held only in Zig locals / stack arrays the GC cannot see).

## Hardening (same bug class, found by audit)

- `compileBody` / `compileLetBody`: `def_inits` stack arrays hold fresh lambda pairs across the scan loop and the phase-2 init compiles — mirrored into `extra_roots` (the `readVector` idiom).
- `compileDefineValues`, `compileLetValues`, quasiquote vector branch: chains of fresh pairs built across allocations now use `no_collect` + rooting of the final form across the compile.
- **`no_collect` leaks on error paths** in `compileCaseLambda`, `compileGuard`, `compileParameterize`, `compileQQSplicing`: a malformed form (user-triggerable `InvalidSyntax`) returned without decrementing, permanently disabling collection for the process. All converted to scoped `defer`s that preserve the original collection windows.

## Error unmasking (issue angle 3)

When an `.sld` file is found and read but fails to load, the error now names the failing definition and file instead of "library not found":

```
usebad.scm:1: error: InvalidSyntax while compiling library definition 'broken'
```

A genuinely missing library still reports `library not found: (...)`.

## Also fixes

The nondeterministic CompileError when importing `(srfi 64)` and `(srfi 158)` together (~75% of runs) was this same bug — 8/8 runs pass now, and the stale comment in `tests/scheme/srfi/srfi158.scm` documenting it is updated.

## Testing

- New regression test `tests/scheme/srfi/srfi-import-order.scm` mirrors the issue's exact import sequence and exercises `gdelete-neighbor-dups` + `(srfi 115)`; verified it fails with the exact issue symptom (`library not found: (srfi.158)`) on the pre-fix build and passes with the fix.
- Both issue reproducers (min.scm and the private-library clone) pass.
- `zig build test`: all unit tests pass.
- `bash tests/scheme/run-all.sh`: 286 files + 1395 R7RS tests, 0 failures.
- GC-threshold sweep (`-Dgc-threshold=` 1, 500, 1000, 2000, 3000, 4000, 6000, 12000): all reproducers pass at every cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)