### PR TITLE
Fix current-input-port corruption under extreme GC pressure

### DIFF
--- a/src/tests_io.zig
+++ b/src/tests_io.zig
@@ -500,3 +500,15 @@ test "parameterize current-input-port redirects read-line" {
     const s = types.toObject(result).as(types.SchemeString);
     try std.testing.expectEqualStrings("test-line", s.data[0..s.len]);
 }
+
+test "current-input-port survives extreme GC pressure (#1013)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.gc_threshold = 1;
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(input-port? (current-input-port))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(output-port? (current-output-port))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(output-port? (current-error-port))"));
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -405,13 +405,13 @@ pub const VM = struct {
         };
         @memset(vm.registers, types.UNDEFINED);
         gc.root_marker = &markVMRoots;
-        // Pre-allocate standard ports
+        // Pre-allocate standard ports — root each immediately so GC
+        // triggered by the next allocPort cannot collect it (#1013).
         vm.stdin_port = gc.allocPort(0, true, false, "stdin", false) catch types.VOID;
-        vm.stdout_port = gc.allocPort(1, false, true, "stdout", false) catch types.VOID;
-        vm.stderr_port = gc.allocPort(2, false, true, "stderr", false) catch types.VOID;
-        // Root the standard ports so GC never collects them
         if (vm.stdin_port != types.VOID) try gc.extra_roots.append(gc.allocator, vm.stdin_port);
+        vm.stdout_port = gc.allocPort(1, false, true, "stdout", false) catch types.VOID;
         if (vm.stdout_port != types.VOID) try gc.extra_roots.append(gc.allocator, vm.stdout_port);
+        vm.stderr_port = gc.allocPort(2, false, true, "stderr", false) catch types.VOID;
         if (vm.stderr_port != types.VOID) try gc.extra_roots.append(gc.allocator, vm.stderr_port);
         return vm;
     }

--- a/tests/scheme/smoke/port-param-gc-1013.scm
+++ b/tests/scheme/smoke/port-param-gc-1013.scm
@@ -1,0 +1,24 @@
+;; Regression test for #1013: current-input-port parameter corrupted
+;; under extreme GC pressure. The port objects were not rooted between
+;; successive allocPort calls in VM.init, so GC could collect stdin
+;; before stdout was allocated.
+;;
+;; Run with: zig build -Dgc-threshold=1 run -- tests/scheme/smoke/port-param-gc-1013.scm
+
+(import (scheme base) (scheme write))
+
+(define (assert-true msg v)
+  (unless v
+    (display "FAIL: ") (display msg) (newline)
+    (error "assertion failed" msg)))
+
+(assert-true "current-input-port is an input port"
+  (input-port? (current-input-port)))
+
+(assert-true "current-output-port is an output port"
+  (output-port? (current-output-port)))
+
+(assert-true "current-error-port is an output port"
+  (output-port? (current-error-port)))
+
+(display "port-param-gc-1013: PASS") (newline)


### PR DESCRIPTION
Closes #1013.

## Summary
- Root each standard port in `gc.extra_roots` immediately after its `allocPort` call, before the next allocation can trigger GC
- Previously all three ports were allocated first, then rooted in a batch — with `gc-threshold=1`, GC during the second `allocPort` freed the unrooted stdin port

## Test plan
- [x] Unit test with `gc.gc_threshold = 1` verifying all three port parameters survive (`tests_io.zig`)
- [x] Scheme regression test (`tests/scheme/smoke/port-param-gc-1013.scm`)
- [x] `zig build test` passes
- [x] `bash tests/scheme/run-all.sh` passes (1683/1683)
- [x] Verified with `zig build -Dgc-threshold=1` and `-Dgc-threshold=2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)