### PR TITLE
Fix VMError-to-PrimitiveError catch-all that collapsed errors into TypeError

### DIFF
--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -32,7 +32,35 @@ pub const PrimitiveError = error{
     IndexOutOfBounds,
     InvalidArgument,
     Yielded,
+    StackOverflow,
+    UndefinedVariable,
+    NotAProcedure,
+    InvalidBytecode,
+    CompileError,
+    ExecutionTimeout,
+    Terminated,
 };
+
+pub fn mapVMError(err: vm_mod.VMError) PrimitiveError {
+    return switch (err) {
+        vm_mod.VMError.TypeError => PrimitiveError.TypeError,
+        vm_mod.VMError.DivisionByZero => PrimitiveError.DivisionByZero,
+        vm_mod.VMError.ArityMismatch => PrimitiveError.ArityMismatch,
+        vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
+        vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
+        vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
+        vm_mod.VMError.IndexOutOfBounds => PrimitiveError.IndexOutOfBounds,
+        vm_mod.VMError.InvalidArgument => PrimitiveError.InvalidArgument,
+        vm_mod.VMError.Yielded => PrimitiveError.Yielded,
+        vm_mod.VMError.StackOverflow => PrimitiveError.StackOverflow,
+        vm_mod.VMError.UndefinedVariable => PrimitiveError.UndefinedVariable,
+        vm_mod.VMError.NotAProcedure => PrimitiveError.NotAProcedure,
+        vm_mod.VMError.InvalidBytecode => PrimitiveError.InvalidBytecode,
+        vm_mod.VMError.CompileError => PrimitiveError.CompileError,
+        vm_mod.VMError.ExecutionTimeout => PrimitiveError.ExecutionTimeout,
+        vm_mod.VMError.Terminated => PrimitiveError.Terminated,
+    };
+}
 
 fn registerCore(vm: *vm_mod.VM) !void {
     // Pairs and lists
@@ -622,16 +650,7 @@ fn applyFn(args: []const Value) PrimitiveError!Value {
     }
 
     return vm.callWithArgs(proc, call_args.items) catch |err| {
-        return switch (err) {
-            @import("vm.zig").VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            @import("vm.zig").VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            @import("vm.zig").VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            // Parked fiber (yield_retry): apply is idempotent up to the
-            // block, so propagate and let the dispatch site retry the
-            // whole apply call on wake.
-            @import("vm.zig").VMError.Yielded => PrimitiveError.Yielded,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return mapVMError(err);
     };
 }
 

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -70,12 +70,7 @@ fn raiseContinuableFn(args: []const Value) PrimitiveError!Value {
     vm.popHandler();
     const result = vm.callHandler(handler, args[0], 0) catch |err| {
         vm.pushHandler(handler) catch {};
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
     vm.pushHandler(handler) catch return PrimitiveError.OutOfMemory;
     return result;
@@ -108,12 +103,7 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
             gc.pushRoot(&exc) catch return PrimitiveError.OutOfMemory;
             defer gc.popRoot();
             _ = vm.callHandler(handler_root, exc, 0) catch |herr| {
-                return switch (herr) {
-                    vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                    vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                    vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                    else => PrimitiveError.TypeError, // bare-ok: catch fallback
-                };
+                return primitives.mapVMError(herr);
             };
             // Handler returned from non-continuable raise — re-raise per R7RS
             var reraise_msg = gc.allocString("handler returned") catch return PrimitiveError.OutOfMemory;
@@ -141,12 +131,7 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
         gc.pushRoot(&err_root) catch return PrimitiveError.OutOfMemory;
         defer gc.popRoot();
         const handler_result = vm.callHandler(handler_root, err_root, 0) catch |herr| {
-            return switch (herr) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(herr);
         };
         return handler_result;
     };
@@ -237,13 +222,7 @@ fn callWithCurrentContinuation(args: []const Value) PrimitiveError!Value {
 
     // Call proc(continuation)
     const result = vm.callHandler(proc, cont_val, base_reg) catch |err| {
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            vm_mod.VMError.ArityMismatch => PrimitiveError.TypeError,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 
     // If proc returned normally (without invoking the continuation),
@@ -279,13 +258,7 @@ fn callWithEscapeContinuation(args: []const Value) PrimitiveError!Value {
     const result = vm.callHandler(proc, cont_val, base_reg) catch |err| {
         // The extent has ended (escape unwound through here, or proc errored).
         cont_obj.valid = false;
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            vm_mod.VMError.ArityMismatch => PrimitiveError.TypeError,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 
     // proc returned normally without escaping; the extent is over.
@@ -305,12 +278,7 @@ fn dynamicWindFn(args: []const Value) PrimitiveError!Value {
 
     // Call before thunk
     _ = vm.callThunk(before) catch |err| {
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 
     // Push wind record
@@ -330,11 +298,7 @@ fn dynamicWindFn(args: []const Value) PrimitiveError!Value {
             if (after_err == vm_mod.VMError.ContinuationInvoked)
                 return PrimitiveError.ContinuationInvoked;
         };
-        return switch (err) {
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 
     // Pop wind record
@@ -342,12 +306,7 @@ fn dynamicWindFn(args: []const Value) PrimitiveError!Value {
 
     // Call after thunk
     _ = vm.callThunk(after) catch |err| {
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 
     return result;
@@ -369,12 +328,7 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
 
     // Call producer
     const produced = vm.callThunk(producer) catch |err| {
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 
     // Call consumer with the produced values
@@ -385,26 +339,14 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
     if (types.isMultipleValues(produced_root)) {
         const mv = types.toObject(produced_root).as(types.MultipleValues);
         const result = vm.callWithArgs(consumer, mv.values) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                vm_mod.VMError.ArityMismatch => PrimitiveError.ArityMismatch,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
         return result;
     } else {
         // Single value -- call consumer with one argument (use callWithArgs
         // so arity is validated, matching the multi-value path)
         const result = vm.callWithArgs(consumer, &[_]Value{produced}) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                vm_mod.VMError.ArityMismatch => PrimitiveError.ArityMismatch,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
         return result;
     }

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -205,12 +205,7 @@ fn hashTableRefFn(args: []const Value) PrimitiveError!Value {
         if (types.isProcedure(args[2])) {
             const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             return vm.callWithArgs(args[2], &[_]Value{}) catch |err| {
-                return switch (err) {
-                    vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                    vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                    vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                    else => PrimitiveError.TypeError, // bare-ok: catch fallback
-                };
+                return primitives.mapVMError(err);
             };
         }
         return args[2]; // non-procedure default (for backwards compat)
@@ -303,12 +298,7 @@ fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
     for (snapshot) |entry| {
         const call_args = [2]Value{ entry.key, entry.value };
         _ = vm.callWithArgs(proc, &call_args) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
     }
     return types.VOID;
@@ -397,12 +387,7 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
 
     const call_args = [1]Value{old_val};
     const new_val = vm.callWithArgs(proc, &call_args) catch |err| {
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 
     try growIfNeeded(ht);
@@ -518,12 +503,7 @@ fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
     for (snapshot) |entry| {
         const call_args = [3]Value{ entry.key, entry.value, acc };
         acc = vm.callWithArgs(proc, &call_args) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
     }
     return acc;

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -909,12 +909,7 @@ fn callWithInputFile(args: []const Value) PrimitiveError!Value {
     const result = vm.callWithArgs(args[1], &[_]Value{port_val}) catch |err| {
         // Close port on error
         _ = closePort(&[_]Value{port_val}) catch {};
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
     // Close port
     _ = try closePort(&[_]Value{port_val});
@@ -927,12 +922,7 @@ fn callWithOutputFile(args: []const Value) PrimitiveError!Value {
     const port_val = try openOutputFile(&[_]Value{args[0]});
     const result = vm.callWithArgs(args[1], &[_]Value{port_val}) catch |err| {
         _ = closePort(&[_]Value{port_val}) catch {};
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
     _ = try closePort(&[_]Value{port_val});
     return result;
@@ -944,12 +934,7 @@ fn callWithPort(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const result = vm.callWithArgs(args[1], &[_]Value{args[0]}) catch |err| {
         _ = closePort(&[_]Value{args[0]}) catch {};
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
     _ = try closePort(&[_]Value{args[0]});
     return result;
@@ -964,12 +949,7 @@ fn withInputFromFile(args: []const Value) PrimitiveError!Value {
     const result = vm.callWithArgs(args[1], &[_]Value{}) catch |err| {
         setCurrentPort(vm, vm.current_input_port_param, saved);
         _ = closePort(&[_]Value{port_val}) catch {};
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
     setCurrentPort(vm, vm.current_input_port_param, saved);
     _ = try closePort(&[_]Value{port_val});
@@ -985,12 +965,7 @@ fn withOutputToFile(args: []const Value) PrimitiveError!Value {
     const result = vm.callWithArgs(args[1], &[_]Value{}) catch |err| {
         setCurrentPort(vm, vm.current_output_port_param, saved);
         _ = closePort(&[_]Value{port_val}) catch {};
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
     setCurrentPort(vm, vm.current_output_port_param, saved);
     _ = try closePort(&[_]Value{port_val});

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -59,12 +59,7 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
 
         const result = vm.callWithArgs(thunk, &[_]Value{}) catch |err| {
             promise.forcing = false;
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
 
         // SRFI-45 §8: after the thunk returns, check if another force

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -151,11 +151,7 @@ fn memberFn(args: []const Value) PrimitiveError!Value {
             const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             const call_args = [2]Value{ args[0], types.car(current) };
             const result = vm.callWithArgs(compare, &call_args) catch |err| {
-                return switch (err) {
-                    vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                    vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                    else => PrimitiveError.TypeError, // bare-ok: catch fallback
-                };
+                return primitives.mapVMError(err);
             };
             if (result != types.FALSE) return current;
         } else {
@@ -264,11 +260,7 @@ fn assocFn(args: []const Value) PrimitiveError!Value {
             const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             const call_args = [2]Value{ args[0], types.car(pair) };
             const result = vm.callWithArgs(compare, &call_args) catch |err| {
-                return switch (err) {
-                    vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                    vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                    else => PrimitiveError.TypeError, // bare-ok: catch fallback
-                };
+                return primitives.mapVMError(err);
             };
             if (result != types.FALSE) return pair;
         } else {
@@ -400,12 +392,7 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
 
         // Call procedure
         const result = vm.callWithArgs(proc, call_args[0..list_count]) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
 
         const new_pair = gc.allocPair(result, types.NIL) catch return PrimitiveError.OutOfMemory;
@@ -460,12 +447,7 @@ fn forEachFn(args: []const Value) PrimitiveError!Value {
 
         // Call procedure (discard result)
         _ = vm.callWithArgs(proc, call_args[0..list_count]) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
 
         // Advance each list

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -205,12 +205,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
         defer gc.popRoot();
 
         const result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
         return result;
     }
@@ -222,12 +217,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     defer gc.popRoot();
 
     const result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
     return result;
 }
@@ -317,12 +307,7 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
             compiler_mod.Compiler.unrootFunction(gc, func);
 
             last_result = vm.execute(func) catch |err| {
-                return switch (err) {
-                    vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                    vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                    vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                    else => PrimitiveError.TypeError, // bare-ok: catch fallback
-                };
+                return primitives.mapVMError(err);
             };
         }
     }
@@ -345,12 +330,7 @@ fn makeParameterFn(args: []const Value) PrimitiveError!Value {
     if (converter != types.NIL) {
         const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
         val = vm.callWithArgs(converter, &[_]Value{init}) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
     }
     return gc.allocParameter(val, converter) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -122,12 +122,7 @@ pub fn registerSrfi1(vm: *vm_mod.VM) !void {
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     return vm.callWithArgs(proc, call_args) catch |err| {
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 }
 

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -111,12 +111,7 @@ fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
     // If pred is a procedure, call it directly
     if (types.isProcedure(pred)) {
         const result = vm.callWithArgs(pred, &[_]Value{char_val}) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
         return types.isTruthy(result);
     }
@@ -128,12 +123,7 @@ fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
         vm.unlockGlobalsShared();
         const cs_contains = cs_contains_opt orelse return PrimitiveError.TypeError;
         const result = vm.callWithArgs(cs_contains, &[_]Value{ pred, char_val }) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
         return types.isTruthy(result);
     }
@@ -431,12 +421,7 @@ fn stringConcatenateFn(args: []const Value) PrimitiveError!Value {
 
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    return vm.callWithArgs(proc, call_args) catch |err| switch (err) {
-        vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-        vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-        vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-        else => PrimitiveError.TypeError, // bare-ok: catch fallback
-    };
+    return vm.callWithArgs(proc, call_args) catch |err| return primitives.mapVMError(err);
 }
 
 fn stringTakeFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -359,12 +359,7 @@ fn vectorForEachFn(args: []const Value) PrimitiveError!Value {
         }
 
         _ = vm.callWithArgs(proc, call_args) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
     }
 
@@ -411,12 +406,7 @@ fn vectorMapFn(args: []const Value) PrimitiveError!Value {
         }
 
         results[i] = vm.callWithArgs(proc, call_args) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => PrimitiveError.TypeError, // bare-ok: catch fallback
-            };
+            return primitives.mapVMError(err);
         };
         gc.extra_roots.append(gc.allocator, results[i]) catch return PrimitiveError.OutOfMemory;
     }
@@ -483,12 +473,7 @@ fn vectorToStringFn(args: []const Value) PrimitiveError!Value {
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     return vm.callWithArgs(proc, call_args) catch |err| {
-        return switch (err) {
-            vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-            vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-            vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-            else => PrimitiveError.TypeError, // bare-ok: catch fallback
-        };
+        return primitives.mapVMError(err);
     };
 }
 

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -267,6 +267,14 @@ pub fn handleNativeError(_: *VM, err: anyerror, _: u32, _: u8) VMError {
         error.ExceptionRaised => VMError.ExceptionRaised,
         error.ContinuationInvoked => VMError.ContinuationInvoked,
         error.Yielded => VMError.Yielded,
+        error.ArityMismatch => VMError.ArityMismatch,
+        error.StackOverflow => VMError.StackOverflow,
+        error.UndefinedVariable => VMError.UndefinedVariable,
+        error.NotAProcedure => VMError.NotAProcedure,
+        error.InvalidBytecode => VMError.InvalidBytecode,
+        error.CompileError => VMError.CompileError,
+        error.ExecutionTimeout => VMError.ExecutionTimeout,
+        error.Terminated => VMError.Terminated,
         else => VMError.InvalidBytecode,
     };
 }
@@ -502,6 +510,14 @@ pub fn callNative(vm: *VM, native: *types.NativeFn, base: u32, nargs: u8) VMErro
             error.ExceptionRaised => VMError.ExceptionRaised,
             error.ContinuationInvoked => VMError.ContinuationInvoked,
             error.Yielded => VMError.Yielded,
+            error.ArityMismatch => VMError.ArityMismatch,
+            error.StackOverflow => VMError.StackOverflow,
+            error.UndefinedVariable => VMError.UndefinedVariable,
+            error.NotAProcedure => VMError.NotAProcedure,
+            error.InvalidBytecode => VMError.InvalidBytecode,
+            error.CompileError => VMError.CompileError,
+            error.ExecutionTimeout => VMError.ExecutionTimeout,
+            error.Terminated => VMError.Terminated,
             else => VMError.InvalidBytecode,
         };
     };

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -549,6 +549,14 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             error.ExceptionRaised => VMError.ExceptionRaised,
                             error.ContinuationInvoked => VMError.ContinuationInvoked,
                             error.Yielded => VMError.Yielded,
+                            error.ArityMismatch => VMError.ArityMismatch,
+                            error.StackOverflow => VMError.StackOverflow,
+                            error.UndefinedVariable => VMError.UndefinedVariable,
+                            error.NotAProcedure => VMError.NotAProcedure,
+                            error.InvalidBytecode => VMError.InvalidBytecode,
+                            error.CompileError => VMError.CompileError,
+                            error.ExecutionTimeout => VMError.ExecutionTimeout,
+                            error.Terminated => VMError.Terminated,
                             else => VMError.InvalidBytecode,
                         };
                     };
@@ -733,6 +741,15 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             error.OutOfMemory => VMError.OutOfMemory,
                             error.ExceptionRaised => VMError.ExceptionRaised,
                             error.Yielded => VMError.Yielded,
+                            error.ArityMismatch => VMError.ArityMismatch,
+                            error.StackOverflow => VMError.StackOverflow,
+                            error.UndefinedVariable => VMError.UndefinedVariable,
+                            error.NotAProcedure => VMError.NotAProcedure,
+                            error.InvalidBytecode => VMError.InvalidBytecode,
+                            error.CompileError => VMError.CompileError,
+                            error.ExecutionTimeout => VMError.ExecutionTimeout,
+                            error.Terminated => VMError.Terminated,
+                            error.ContinuationInvoked => VMError.ContinuationInvoked,
                             else => VMError.InvalidBytecode,
                         };
                     };
@@ -1199,6 +1216,14 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 error.ExceptionRaised => VMError.ExceptionRaised,
                                 error.ContinuationInvoked => VMError.ContinuationInvoked,
                                 error.Yielded => VMError.Yielded,
+                                error.ArityMismatch => VMError.ArityMismatch,
+                                error.StackOverflow => VMError.StackOverflow,
+                                error.UndefinedVariable => VMError.UndefinedVariable,
+                                error.NotAProcedure => VMError.NotAProcedure,
+                                error.InvalidBytecode => VMError.InvalidBytecode,
+                                error.CompileError => VMError.CompileError,
+                                error.ExecutionTimeout => VMError.ExecutionTimeout,
+                                error.Terminated => VMError.Terminated,
                                 else => VMError.InvalidBytecode,
                             };
                         };


### PR DESCRIPTION
## Summary

- The `else => PrimitiveError.TypeError` catch-all in 36 sites across 10 primitives files was destroying diagnostic information — a StackOverflow or InvalidBytecode from user callbacks would be reported as a generic type error
- Added 7 missing PrimitiveError variants (StackOverflow, UndefinedVariable, NotAProcedure, InvalidBytecode, CompileError, ExecutionTimeout, Terminated) to make PrimitiveError a superset of VMError
- Added an exhaustive `mapVMError` helper that replaces all 36 ad-hoc switch blocks with a single canonical mapping, and updated the reverse PrimitiveError→VMError switches in vm_dispatch.zig and vm_calls.zig

## Test plan

- [x] `zig build test` passes (all 16 unit test files)
- [ ] `bash tests/scheme/run-all.sh` for end-to-end verification
- [ ] Verify a stack overflow in a callback (e.g. via `with-exception-handler`) now reports "stack overflow" not "type error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)