### PR TITLE
Extract shared parseOptionalRange helper for optional start/end args

### DIFF
--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -220,6 +220,27 @@ pub fn typeError(proc: []const u8, expected: []const u8, got: Value) PrimitiveEr
     return PrimitiveError.TypeError;
 }
 
+pub const Range = struct { start: usize, end: usize };
+
+pub fn parseOptionalRange(args: []const Value, arg_offset: usize, max_len: usize, proc_name: []const u8) PrimitiveError!Range {
+    var start: usize = 0;
+    var end: usize = max_len;
+    if (args.len > arg_offset) {
+        if (!types.isFixnum(args[arg_offset])) return typeError(proc_name, "exact integer", args[arg_offset]);
+        const s = types.toFixnum(args[arg_offset]);
+        if (s < 0 or @as(usize, @intCast(s)) > max_len) return typeError(proc_name, "valid index", args[arg_offset]);
+        start = @intCast(s);
+    }
+    if (args.len > arg_offset + 1) {
+        if (!types.isFixnum(args[arg_offset + 1])) return typeError(proc_name, "exact integer", args[arg_offset + 1]);
+        const e = types.toFixnum(args[arg_offset + 1]);
+        if (e < 0 or @as(usize, @intCast(e)) > max_len) return typeError(proc_name, "valid index", args[arg_offset + 1]);
+        end = @intCast(e);
+    }
+    if (start > end) return typeError(proc_name, "start <= end", args[arg_offset]);
+    return .{ .start = start, .end = end };
+}
+
 fn safeValueDescription(buf: *[128]u8, value: Value) []const u8 {
     if (types.isFixnum(value)) {
         return std.fmt.bufPrint(buf, "{d}", .{types.toFixnum(value)}) catch "?";

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -106,22 +106,9 @@ fn bytevectorCopy(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const bv = types.toBytevector(args[0]);
 
-    var start: usize = 0;
-    var end: usize = bv.data.len;
-
-    if (args.len > 1) {
-        if (!types.isFixnum(args[1])) return primitives.typeError("bytevector-copy", "exact integer", args[1]);
-        const s = types.toFixnum(args[1]);
-        if (s < 0) return primitives.typeError("bytevector-copy", "non-negative integer", args[1]);
-        start = @intCast(@as(u64, @bitCast(s)));
-    }
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("bytevector-copy", "exact integer", args[2]);
-        const e = types.toFixnum(args[2]);
-        if (e < 0) return primitives.typeError("bytevector-copy", "non-negative integer", args[2]);
-        end = @intCast(@as(u64, @bitCast(e)));
-    }
-    if (start > end or end > bv.data.len) return primitives.typeError("bytevector-copy", "valid range", args[0]);
+    const range = try primitives.parseOptionalRange(args, 1, bv.data.len, "bytevector-copy");
+    const start = range.start;
+    const end = range.end;
     return gc.allocBytevector(bv.data[start..end]) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -137,22 +124,9 @@ fn bytevectorCopyBang(args: []const Value) PrimitiveError!Value {
     const at: usize = @intCast(@as(u64, @bitCast(at_val)));
     const from = types.toBytevector(args[2]);
 
-    var start: usize = 0;
-    var end: usize = from.data.len;
-
-    if (args.len > 3) {
-        if (!types.isFixnum(args[3])) return primitives.typeError("bytevector-copy!", "exact integer", args[3]);
-        const s = types.toFixnum(args[3]);
-        if (s < 0) return primitives.typeError("bytevector-copy!", "non-negative integer", args[3]);
-        start = @intCast(@as(u64, @bitCast(s)));
-    }
-    if (args.len > 4) {
-        if (!types.isFixnum(args[4])) return primitives.typeError("bytevector-copy!", "exact integer", args[4]);
-        const e = types.toFixnum(args[4]);
-        if (e < 0) return primitives.typeError("bytevector-copy!", "non-negative integer", args[4]);
-        end = @intCast(@as(u64, @bitCast(e)));
-    }
-    if (start > end or end > from.data.len) return primitives.typeError("bytevector-copy!", "valid range", args[2]);
+    const range = try primitives.parseOptionalRange(args, 3, from.data.len, "bytevector-copy!");
+    const start = range.start;
+    const end = range.end;
     const count = end - start;
     if (at + count > to.data.len) return primitives.typeError("bytevector-copy!", "valid range", args[0]);
 
@@ -194,21 +168,9 @@ fn utf8ToString(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const bv = types.toBytevector(args[0]);
 
-    var start: usize = 0;
-    var end: usize = bv.data.len;
-    if (args.len > 1) {
-        if (!types.isFixnum(args[1])) return primitives.typeError("utf8->string", "exact integer", args[1]);
-        const s = types.toFixnum(args[1]);
-        if (s < 0) return primitives.typeError("utf8->string", "non-negative integer", args[1]);
-        start = @intCast(@as(u64, @bitCast(s)));
-    }
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("utf8->string", "exact integer", args[2]);
-        const e = types.toFixnum(args[2]);
-        if (e < 0) return primitives.typeError("utf8->string", "non-negative integer", args[2]);
-        end = @intCast(@as(u64, @bitCast(e)));
-    }
-    if (start > end or end > bv.data.len) return primitives.typeError("utf8->string", "valid range", args[0]);
+    const range = try primitives.parseOptionalRange(args, 1, bv.data.len, "utf8->string");
+    const start = range.start;
+    const end = range.end;
     return gc.allocString(bv.data[start..end]) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -219,21 +181,9 @@ fn stringToUtf8(args: []const Value) PrimitiveError!Value {
     const string_mod = @import("primitives_string.zig");
 
     const cp_count = string_mod.utf8CodepointCount(str.data[0..str.len]);
-    var start_cp: usize = 0;
-    var end_cp: usize = cp_count;
-    if (args.len > 1) {
-        if (!types.isFixnum(args[1])) return primitives.typeError("string->utf8", "exact integer", args[1]);
-        const s = types.toFixnum(args[1]);
-        if (s < 0) return primitives.typeError("string->utf8", "non-negative integer", args[1]);
-        start_cp = @intCast(@as(u64, @bitCast(s)));
-    }
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("string->utf8", "exact integer", args[2]);
-        const e = types.toFixnum(args[2]);
-        if (e < 0) return primitives.typeError("string->utf8", "non-negative integer", args[2]);
-        end_cp = @intCast(@as(u64, @bitCast(e)));
-    }
-    if (start_cp > end_cp or end_cp > cp_count) return primitives.typeError("string->utf8", "valid range", args[0]);
+    const range = try primitives.parseOptionalRange(args, 1, cp_count, "string->utf8");
+    const start_cp = range.start;
+    const end_cp = range.end;
     const byte_start = string_mod.utf8IndexToByteOffset(str.data[0..str.len], start_cp) orelse return primitives.typeError("string->utf8", "valid index", args[0]);
     const byte_end = string_mod.utf8IndexToByteOffset(str.data[0..str.len], end_cp) orelse return primitives.typeError("string->utf8", "valid index", args[0]);
     return gc.allocBytevector(str.data[byte_start..byte_end]) catch return PrimitiveError.OutOfMemory;
@@ -392,21 +342,9 @@ fn writeBytevectorFn(args: []const Value) PrimitiveError!Value {
     const bv = types.toBytevector(args[0]);
     const port = try getOutputPort(args, 1, "write-bytevector");
 
-    var start: usize = 0;
-    var end: usize = bv.data.len;
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("write-bytevector", "exact integer", args[2]);
-        const s = types.toFixnum(args[2]);
-        if (s < 0) return primitives.typeError("write-bytevector", "non-negative integer", args[2]);
-        start = @intCast(@as(u64, @bitCast(s)));
-    }
-    if (args.len > 3) {
-        if (!types.isFixnum(args[3])) return primitives.typeError("write-bytevector", "exact integer", args[3]);
-        const e = types.toFixnum(args[3]);
-        if (e < 0) return primitives.typeError("write-bytevector", "non-negative integer", args[3]);
-        end = @intCast(@as(u64, @bitCast(e)));
-    }
-    if (start > end or end > bv.data.len) return primitives.typeError("write-bytevector", "valid range", args[0]);
+    const range = try primitives.parseOptionalRange(args, 2, bv.data.len, "write-bytevector");
+    const start = range.start;
+    const end = range.end;
 
     if (port.is_string_port) {
         portWriteBytes(port, bv.data[start..end]);
@@ -455,21 +393,9 @@ fn readBytevectorMut(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 1, "read-bytevector!");
     const len = bv.data.len;
 
-    var start: usize = 0;
-    var end: usize = len;
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("read-bytevector!", "exact integer", args[2]);
-        const s = types.toFixnum(args[2]);
-        if (s < 0) return PrimitiveError.IndexOutOfBounds;
-        start = @intCast(s);
-    }
-    if (args.len > 3) {
-        if (!types.isFixnum(args[3])) return primitives.typeError("read-bytevector!", "exact integer", args[3]);
-        const e = types.toFixnum(args[3]);
-        if (e < 0) return PrimitiveError.IndexOutOfBounds;
-        end = @intCast(e);
-    }
-    if (start > end or end > len) return primitives.typeError("read-bytevector!", "valid range", args[0]);
+    const range = try primitives.parseOptionalRange(args, 2, len, "read-bytevector!");
+    const start = range.start;
+    const end = range.end;
 
     var read_count: usize = 0;
     while (start + read_count < end) {

--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -249,21 +249,9 @@ fn stringCopyFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     const cp_count = utf8CodepointCount(data);
-    var start_cp: usize = 0;
-    var end_cp: usize = cp_count;
-    if (args.len > 1) {
-        if (!types.isFixnum(args[1])) return primitives.typeError("string-copy", "exact integer", args[1]);
-        const s = types.toFixnum(args[1]);
-        if (s < 0 or @as(usize, @intCast(s)) > cp_count) return primitives.typeError("string-copy", "valid index", args[1]);
-        start_cp = @intCast(s);
-    }
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("string-copy", "exact integer", args[2]);
-        const e = types.toFixnum(args[2]);
-        if (e < 0 or @as(usize, @intCast(e)) > cp_count) return primitives.typeError("string-copy", "valid index", args[2]);
-        end_cp = @intCast(e);
-    }
-    if (start_cp > end_cp) return primitives.typeError("string-copy", "start <= end", args[1]);
+    const range = try primitives.parseOptionalRange(args, 1, cp_count, "string-copy");
+    const start_cp = range.start;
+    const end_cp = range.end;
     const byte_start = utf8IndexToByteOffset(data, start_cp) orelse return primitives.typeError("string-copy", "valid index", args[1]);
     const byte_end = utf8IndexToByteOffset(data, end_cp) orelse return primitives.typeError("string-copy", "valid index", args[2]);
     return gc.allocString(data[byte_start..byte_end]) catch return PrimitiveError.OutOfMemory;
@@ -287,21 +275,9 @@ fn stringCopyBangFn(args: []const Value) PrimitiveError!Value {
     const from_data = try getStringSlice(args[2]);
     const from_cp_count = utf8CodepointCount(from_data);
 
-    var start_cp: usize = 0;
-    var end_cp: usize = from_cp_count;
-    if (args.len > 3) {
-        if (!types.isFixnum(args[3])) return primitives.typeError("string-copy!", "exact integer", args[3]);
-        const s = types.toFixnum(args[3]);
-        if (s < 0 or @as(usize, @intCast(s)) > from_cp_count) return primitives.typeError("string-copy!", "valid index", args[3]);
-        start_cp = @intCast(s);
-    }
-    if (args.len > 4) {
-        if (!types.isFixnum(args[4])) return primitives.typeError("string-copy!", "exact integer", args[4]);
-        const e = types.toFixnum(args[4]);
-        if (e < 0 or @as(usize, @intCast(e)) > from_cp_count) return primitives.typeError("string-copy!", "valid index", args[4]);
-        end_cp = @intCast(e);
-    }
-    if (start_cp > end_cp) return primitives.typeError("string-copy!", "start <= end", args[3]);
+    const range = try primitives.parseOptionalRange(args, 3, from_cp_count, "string-copy!");
+    const start_cp = range.start;
+    const end_cp = range.end;
     const copy_cp_count = end_cp - start_cp;
     if (at_cp + copy_cp_count > to_cp_count) return primitives.typeError("string-copy!", "valid range", args[1]);
 
@@ -351,24 +327,9 @@ fn stringFillFn(args: []const Value) PrimitiveError!Value {
     const data = str.data[0..str.len];
     const cp = types.toChar(args[1]);
     const char_count = utf8CodepointCount(data);
-    var start_cp: usize = 0;
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("string-fill!", "exact integer", args[2]);
-        const k = types.toFixnum(args[2]);
-        if (k < 0) return primitives.typeError("string-fill!", "non-negative integer", args[2]);
-        start_cp = @intCast(@as(u64, @bitCast(k)));
-    }
-    var end_cp: usize = char_count;
-    if (args.len > 3) {
-        if (!types.isFixnum(args[3])) return primitives.typeError("string-fill!", "exact integer", args[3]);
-        const k = types.toFixnum(args[3]);
-        if (k < 0) return primitives.typeError("string-fill!", "non-negative integer", args[3]);
-        end_cp = @intCast(@as(u64, @bitCast(k)));
-    }
-    if (start_cp > end_cp) return primitives.typeError("string-fill!", "start <= end", args[2]);
-    if (end_cp > char_count) return PrimitiveError.IndexOutOfBounds;
-    const start = start_cp;
-    const end = end_cp;
+    const range = try primitives.parseOptionalRange(args, 2, char_count, "string-fill!");
+    const start = range.start;
+    const end = range.end;
     var fill_buf: [4]u8 = undefined;
     const fill_len = std.unicode.utf8Encode(cp, &fill_buf) catch return primitives.typeError("string-fill!", "valid character", args[1]);
     // Build new string: [0..start] unchanged, [start..end] filled, [end..] unchanged
@@ -402,21 +363,9 @@ fn stringToListFn(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     const cp_count = utf8CodepointCount(data);
-    var start_cp: usize = 0;
-    var end_cp: usize = cp_count;
-    if (args.len > 1) {
-        if (!types.isFixnum(args[1])) return primitives.typeError("string->list", "exact integer", args[1]);
-        const s = types.toFixnum(args[1]);
-        if (s < 0 or @as(usize, @intCast(s)) > cp_count) return primitives.typeError("string->list", "valid index", args[1]);
-        start_cp = @intCast(s);
-    }
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("string->list", "exact integer", args[2]);
-        const e = types.toFixnum(args[2]);
-        if (e < 0 or @as(usize, @intCast(e)) > cp_count) return primitives.typeError("string->list", "valid index", args[2]);
-        end_cp = @intCast(e);
-    }
-    if (start_cp > end_cp) return primitives.typeError("string->list", "start <= end", args[1]);
+    const range = try primitives.parseOptionalRange(args, 1, cp_count, "string->list");
+    const start_cp = range.start;
+    const end_cp = range.end;
     // Collect codepoints in the range
     const byte_start = utf8IndexToByteOffset(data, start_cp) orelse return primitives.typeError("string->list", "valid index", args[1]);
     const range_count = end_cp - start_cp;
@@ -493,21 +442,9 @@ fn stringToVectorFn(args: []const Value) PrimitiveError!Value {
     const str = types.toObject(args[0]).as(types.SchemeString);
     const data = str.data[0..str.len];
     const cp_count = utf8CodepointCount(data);
-    var start_cp: usize = 0;
-    var end_cp: usize = cp_count;
-    if (args.len > 1) {
-        if (!types.isFixnum(args[1])) return primitives.typeError("string->vector", "exact integer", args[1]);
-        const s = types.toFixnum(args[1]);
-        if (s < 0 or @as(usize, @intCast(s)) > cp_count) return primitives.typeError("string->vector", "valid index", args[1]);
-        start_cp = @intCast(s);
-    }
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("string->vector", "exact integer", args[2]);
-        const e = types.toFixnum(args[2]);
-        if (e < 0 or @as(usize, @intCast(e)) > cp_count) return primitives.typeError("string->vector", "valid index", args[2]);
-        end_cp = @intCast(e);
-    }
-    if (start_cp > end_cp) return primitives.typeError("string->vector", "start <= end", args[1]);
+    const range = try primitives.parseOptionalRange(args, 1, cp_count, "string->vector");
+    const start_cp = range.start;
+    const end_cp = range.end;
     const range_count = end_cp - start_cp;
     const byte_start = utf8IndexToByteOffset(data, start_cp) orelse return primitives.typeError("string->vector", "valid index", args[1]);
     const vec_data = gc.allocator.alloc(Value, range_count) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -139,27 +139,11 @@ const Range = struct {
 };
 
 fn parseStartEnd(data: []const u8, args: []const Value, start_arg_idx: usize) PrimitiveError!Range {
-    var byte_start: usize = 0;
-    var byte_end: usize = data.len;
-    var cp_offset: usize = 0;
-
-    if (args.len > start_arg_idx) {
-        if (!types.isFixnum(args[start_arg_idx])) return PrimitiveError.TypeError;
-        const sv = types.toFixnum(args[start_arg_idx]);
-        if (sv < 0) return PrimitiveError.TypeError; // bare-ok: generic helper, no proc name
-        const start_cp: usize = @intCast(sv);
-        byte_start = pstr.utf8IndexToByteOffset(data, start_cp) orelse return PrimitiveError.IndexOutOfBounds;
-        cp_offset = start_cp;
-    }
-    if (args.len > start_arg_idx + 1) {
-        if (!types.isFixnum(args[start_arg_idx + 1])) return PrimitiveError.TypeError;
-        const ev = types.toFixnum(args[start_arg_idx + 1]);
-        if (ev < 0) return PrimitiveError.TypeError; // bare-ok: generic helper, no proc name
-        const end_cp: usize = @intCast(ev);
-        byte_end = pstr.utf8IndexToByteOffset(data, end_cp) orelse return PrimitiveError.IndexOutOfBounds;
-    }
-    if (byte_start > byte_end) return PrimitiveError.TypeError;
-    return .{ .data = data[byte_start..byte_end], .byte_start = byte_start, .byte_end = byte_end, .cp_offset = cp_offset };
+    const cp_count = utf8CodepointCount(data);
+    const range = try primitives.parseOptionalRange(args, start_arg_idx, cp_count, "string");
+    const byte_start = pstr.utf8IndexToByteOffset(data, range.start) orelse return PrimitiveError.IndexOutOfBounds;
+    const byte_end = pstr.utf8IndexToByteOffset(data, range.end) orelse return PrimitiveError.IndexOutOfBounds;
+    return .{ .data = data[byte_start..byte_end], .byte_start = byte_start, .byte_end = byte_end, .cp_offset = range.start };
 }
 
 fn decodeForward(data: []const u8, pos: usize) struct { cp: u21, len: usize } {

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -126,22 +126,9 @@ fn vectorToListFn(args: []const Value) PrimitiveError!Value {
     const vec = types.toVector(args[0]);
     const len = vec.data.len;
 
-    var start: usize = 0;
-    var end: usize = len;
-
-    if (args.len > 1) {
-        if (!types.isFixnum(args[1])) return primitives.typeError("vector->list", "exact non-negative integer", args[1]);
-        const s = types.toFixnum(args[1]);
-        if (s < 0 or @as(usize, @intCast(s)) > len) return primitives.typeError("vector->list", "valid index", args[1]);
-        start = @intCast(s);
-    }
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("vector->list", "exact non-negative integer", args[2]);
-        const e = types.toFixnum(args[2]);
-        if (e < 0 or @as(usize, @intCast(e)) > len) return primitives.typeError("vector->list", "valid index", args[2]);
-        end = @intCast(e);
-    }
-    if (start > end) return primitives.typeError("vector->list", "start <= end", args[1]);
+    const range = try primitives.parseOptionalRange(args, 1, len, "vector->list");
+    const start = range.start;
+    const end = range.end;
 
     var result: Value = types.NIL;
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
@@ -190,22 +177,9 @@ fn vectorFillFn(args: []const Value) PrimitiveError!Value {
     const vec = types.toVector(args[0]);
     const len = vec.data.len;
 
-    var start: usize = 0;
-    var end: usize = len;
-
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("vector-fill!", "exact non-negative integer", args[2]);
-        const s = types.toFixnum(args[2]);
-        if (s < 0 or @as(usize, @intCast(s)) > len) return primitives.typeError("vector-fill!", "valid index", args[2]);
-        start = @intCast(s);
-    }
-    if (args.len > 3) {
-        if (!types.isFixnum(args[3])) return primitives.typeError("vector-fill!", "exact non-negative integer", args[3]);
-        const e = types.toFixnum(args[3]);
-        if (e < 0 or @as(usize, @intCast(e)) > len) return primitives.typeError("vector-fill!", "valid index", args[3]);
-        end = @intCast(e);
-    }
-    if (start > end) return primitives.typeError("vector-fill!", "start <= end", args[2]);
+    const range = try primitives.parseOptionalRange(args, 2, len, "vector-fill!");
+    const start = range.start;
+    const end = range.end;
     if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     @memset(vec.data[start..end], args[1]);
     return types.VOID;
@@ -221,22 +195,9 @@ fn vectorCopyFn(args: []const Value) PrimitiveError!Value {
     const vec = types.toVector(args[0]);
     const len = vec.data.len;
 
-    var start: usize = 0;
-    var end: usize = len;
-
-    if (args.len > 1) {
-        if (!types.isFixnum(args[1])) return primitives.typeError("vector-copy", "exact non-negative integer", args[1]);
-        const s = types.toFixnum(args[1]);
-        if (s < 0 or @as(usize, @intCast(s)) > len) return primitives.typeError("vector-copy", "valid index", args[1]);
-        start = @intCast(s);
-    }
-    if (args.len > 2) {
-        if (!types.isFixnum(args[2])) return primitives.typeError("vector-copy", "exact non-negative integer", args[2]);
-        const e = types.toFixnum(args[2]);
-        if (e < 0 or @as(usize, @intCast(e)) > len) return primitives.typeError("vector-copy", "valid index", args[2]);
-        end = @intCast(e);
-    }
-    if (start > end) return primitives.typeError("vector-copy", "start <= end", args[1]);
+    const range = try primitives.parseOptionalRange(args, 1, len, "vector-copy");
+    const start = range.start;
+    const end = range.end;
 
     return gc.allocVector(vec.data[start..end]) catch return PrimitiveError.OutOfMemory;
 }
@@ -258,22 +219,9 @@ fn vectorCopyBangFn(args: []const Value) PrimitiveError!Value {
     const from_vec = types.toVector(args[2]);
     const from_len = from_vec.data.len;
 
-    var start: usize = 0;
-    var end: usize = from_len;
-
-    if (args.len > 3) {
-        if (!types.isFixnum(args[3])) return primitives.typeError("vector-copy!", "exact non-negative integer", args[3]);
-        const s = types.toFixnum(args[3]);
-        if (s < 0 or @as(usize, @intCast(s)) > from_len) return primitives.typeError("vector-copy!", "valid index", args[3]);
-        start = @intCast(s);
-    }
-    if (args.len > 4) {
-        if (!types.isFixnum(args[4])) return primitives.typeError("vector-copy!", "exact non-negative integer", args[4]);
-        const e = types.toFixnum(args[4]);
-        if (e < 0 or @as(usize, @intCast(e)) > from_len) return primitives.typeError("vector-copy!", "valid index", args[4]);
-        end = @intCast(e);
-    }
-    if (start > end) return primitives.typeError("vector-copy!", "start <= end", args[3]);
+    const range = try primitives.parseOptionalRange(args, 3, from_len, "vector-copy!");
+    const start = range.start;
+    const end = range.end;
 
     const count = end - start;
     if (at + count > to_vec.data.len) return primitives.typeError("vector-copy!", "valid index range", args[1]);


### PR DESCRIPTION
## Summary

- Add `pub fn parseOptionalRange` and `pub const Range` to `primitives.zig` — validates optional start/end fixnum arguments against a max length, returning `{start, end}`
- Replace 16 inline copies of the same 10-line pattern across `primitives_vector.zig` (4), `primitives_bytevector.zig` (6), `primitives_string.zig` (5), and `primitives_string_ext.zig` (1)
- Net: +71 / -255 lines

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1683 pass, 0 fail (288 Scheme files + 1395 R7RS suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)