### PR TITLE
Replace last inline VMError switches with shared mapVMError helper

### DIFF
--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -570,12 +570,7 @@ fn stringForEachFn(args: []const Value) PrimitiveError!Value {
             call_args[si] = types.makeChar(cp);
         }
         _ = vm.callWithArgs(proc, call_args[0..str_count]) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => primitives.typeError("string-for-each", "valid arguments", proc),
-            };
+            return primitives.mapVMError(err);
         };
     }
     return types.VOID;
@@ -616,12 +611,7 @@ fn stringMapFn(args: []const Value) PrimitiveError!Value {
             call_args[si] = types.makeChar(cp);
         }
         const result = vm.callWithArgs(proc, call_args[0..str_count]) catch |err| {
-            return switch (err) {
-                vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-                vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-                vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-                else => primitives.typeError("string-map", "valid arguments", proc),
-            };
+            return primitives.mapVMError(err);
         };
         if (!types.isChar(result)) return primitives.typeError("string-map", "character", result);
         const cp = types.toChar(result);


### PR DESCRIPTION
## Summary
- Replaced the last 2 inline VMError-to-PrimitiveError switch blocks in `string-for-each` and `string-map` with calls to the shared `primitives.mapVMError()` helper
- The `else => TypeError` catch-all in these switches was collapsing unexpected VM errors (e.g. StackOverflow, InvalidArgument) into misleading TypeErrors — the shared helper preserves the actual error variant

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1683 pass, 0 fail
- [x] Verified no inline VMError switch blocks remain in any `primitives_*.zig` file (only the canonical one in `mapVMError` itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)