### PR TITLE
Relocate gc_instance threadlocal from primitives.zig to memory.zig

### DIFF
--- a/src/bench.zig
+++ b/src/bench.zig
@@ -34,7 +34,7 @@ fn measure(allocator: std.mem.Allocator, prim: []const u8, depth: u32, iters: u3
     var vm = try vm_mod.VM.init(&gc);
     defer vm.deinit();
     try primitives.registerAll(&vm);
-    primitives.setGCInstance(&gc);
+    memory.setGCInstance(&gc);
     try library.registerStandardLibraries(&vm.libraries, vm.globals);
 
     // at-depth builds `depth` real (non-tail) frames to elevate the register

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -882,7 +882,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     var vm = try vm_mod.VM.init(&gc);
     defer vm.deinit();
     try primitives.registerAll(&vm);
-    primitives.setGCInstance(&gc);
+    memory.setGCInstance(&gc);
     try library.registerStandardLibraries(&vm.libraries, vm.globals);
 
     var initialized = false;

--- a/src/main.zig
+++ b/src/main.zig
@@ -292,7 +292,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     // WASM: simplified entry — just run the file specified as argv[1]
     if (comptime is_wasm) {
         try primitives.registerAll(vm);
-        primitives.setGCInstance(&gc);
+        memory.setGCInstance(&gc);
         try library.registerStandardLibraries(&vm.libraries, vm.globals);
 
         var wasi_args = try init.args.iterateAllocator(allocator);
@@ -345,12 +345,12 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
 
     if (is_sandboxed) {
         try primitives.registerSandboxed(vm);
-        primitives.setGCInstance(&gc);
+        memory.setGCInstance(&gc);
         try library.registerSandboxedLibraries(&vm.libraries, vm.globals);
         vm.sandbox_mode = true;
     } else {
         try primitives.registerAll(vm);
-        primitives.setGCInstance(&gc);
+        memory.setGCInstance(&gc);
         try library.registerStandardLibraries(&vm.libraries, vm.globals);
     }
 

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -68,6 +68,12 @@ pub fn spinUnlock(m: *std.atomic.Mutex) void {
     m.unlock();
 }
 
+pub threadlocal var gc_instance: ?*GC = null;
+
+pub fn setGCInstance(gc: *GC) void {
+    gc_instance = gc;
+}
+
 pub const GC = struct {
     allocator: std.mem.Allocator,
     objects: ?*Object = null,

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -206,11 +206,7 @@ pub fn isNum(v: Value) bool {
 // GC / VM instances (pub for use by extracted modules)
 // ---------------------------------------------------------------------------
 
-pub threadlocal var gc_instance: ?*@import("memory.zig").GC = null;
-
-pub fn setGCInstance(gc: *@import("memory.zig").GC) void {
-    gc_instance = gc;
-}
+const memory = @import("memory.zig");
 
 pub fn typeError(proc: []const u8, expected: []const u8, got: Value) PrimitiveError {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
@@ -285,7 +281,7 @@ fn safeValueDescription(buf: *[128]u8, value: Value) []const u8 {
 // ---------------------------------------------------------------------------
 
 fn cons(args: []const Value) PrimitiveError!Value {
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocPair(args[0], args[1]) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -301,20 +297,20 @@ fn cdr(args: []const Value) PrimitiveError!Value {
 
 fn setCar(args: []const Value) PrimitiveError!Value {
     if (!types.isPair(args[0])) return typeError("set-car!", "pair", args[0]);
-    if (gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     types.setCar(args[0], args[1]);
     return types.VOID;
 }
 
 fn setCdr(args: []const Value) PrimitiveError!Value {
     if (!types.isPair(args[0])) return typeError("set-cdr!", "pair", args[0]);
-    if (gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     types.setCdr(args[0], args[1]);
     return types.VOID;
 }
 
 fn list(args: []const Value) PrimitiveError!Value {
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.makeList(args) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -337,7 +333,7 @@ fn length(args: []const Value) PrimitiveError!Value {
 }
 
 fn append(args: []const Value) PrimitiveError!Value {
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (args.len == 0) return types.NIL;
     if (args.len == 1) return args[0];
 
@@ -365,7 +361,7 @@ fn append(args: []const Value) PrimitiveError!Value {
 }
 
 fn reverse(args: []const Value) PrimitiveError!Value {
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var result: Value = types.NIL;
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
@@ -623,7 +619,7 @@ fn stringLength(args: []const Value) PrimitiveError!Value {
 }
 
 fn stringAppend(args: []const Value) PrimitiveError!Value {
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var total_len: usize = 0;
     for (args) |a| {
         if (!types.isString(a)) return PrimitiveError.TypeError;
@@ -642,7 +638,7 @@ fn stringAppend(args: []const Value) PrimitiveError!Value {
 
 fn symbolToString(args: []const Value) PrimitiveError!Value {
     if (!types.isSymbol(args[0])) return PrimitiveError.TypeError;
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const val = gc.allocString(types.symbolName(args[0])) catch return PrimitiveError.OutOfMemory;
     // R7RS: strings returned by symbol->string are immutable
     types.toObject(val).as(types.SchemeString).immutable = true;
@@ -655,7 +651,7 @@ fn symbolToString(args: []const Value) PrimitiveError!Value {
 
 fn applyFn(args: []const Value) PrimitiveError!Value {
     const vm = @import("vm.zig").vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return PrimitiveError.TypeError;
 
@@ -686,7 +682,7 @@ fn applyFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn makeRecordTypeFn(args: []const Value) PrimitiveError!Value {
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     // args[0] = name (string), args[1] = num_fields (fixnum)
     if (!types.isString(args[0])) return PrimitiveError.TypeError;
     if (!types.isFixnum(args[1])) return PrimitiveError.TypeError;
@@ -698,7 +694,7 @@ fn makeRecordTypeFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn makeRecordFn(args: []const Value) PrimitiveError!Value {
-    const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     // args[0] = record_type, args[1..] = field values
     if (!types.isRecordType(args[0])) return PrimitiveError.TypeError;
     const rt = types.toObject(args[0]).as(types.RecordType);
@@ -735,7 +731,7 @@ fn recordSetFn(args: []const Value) PrimitiveError!Value {
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const idx: usize = @intCast(raw_idx);
     if (idx >= ri.fields.len) return PrimitiveError.TypeError;
-    if (gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     ri.fields[idx] = args[2];
     return types.VOID;
 }

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const bignum_mod = @import("bignum.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
@@ -21,7 +22,7 @@ fn reg(vm: *vm_mod.VM, name: []const u8, func: types.NativeFnType, arity: Native
 pub fn makeFixnumChecked(n: i64) PrimitiveError!Value {
     if (n >= std.math.minInt(i48) and n <= std.math.maxInt(i48))
         return types.makeFixnum(n);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocBignumFromI64(n) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -180,7 +181,7 @@ fn isExactZero(v: Value) bool {
 /// (guard ...) can catch it.
 pub fn raiseDivByZero() PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.DivisionByZero;
-    const gc = primitives.gc_instance orelse return PrimitiveError.DivisionByZero;
+    const gc = memory.gc_instance orelse return PrimitiveError.DivisionByZero;
     var msg = gc.allocString("division by zero") catch return PrimitiveError.DivisionByZero;
     gc.pushRoot(&msg) catch return PrimitiveError.DivisionByZero;
     defer gc.popRoot();
@@ -264,7 +265,7 @@ fn anyBignum(args: []const Value) bool {
 }
 
 fn bignumAddAll(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var result: Value = types.makeFixnum(0);
     gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
     defer {
@@ -279,7 +280,7 @@ fn bignumAddAll(args: []const Value) PrimitiveError!Value {
 }
 
 fn bignumSubAll(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (args.len == 1) {
         if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return PrimitiveError.TypeError;
         return bignum_mod.negate(gc, args[0]) catch return PrimitiveError.OutOfMemory;
@@ -299,7 +300,7 @@ fn bignumSubAll(args: []const Value) PrimitiveError!Value {
 }
 
 fn bignumMulAll(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var result: Value = types.makeFixnum(1);
     gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
     defer {
@@ -332,7 +333,7 @@ fn add(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(sum);
     }
     if (anyRational(args) or (anyBignum(args) and !anyFlonum(args))) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var acc_num: Value = types.makeFixnum(0);
         var acc_den: Value = types.makeFixnum(1);
         gc.extra_roots.append(gc.allocator, acc_num) catch return PrimitiveError.OutOfMemory;
@@ -406,7 +407,7 @@ fn sub(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(result);
     }
     if (anyRational(args) or (anyBignum(args) and !anyFlonum(args))) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var acc_num: Value = undefined;
         var acc_den: Value = undefined;
         if (types.isFixnum(args[0])) {
@@ -503,7 +504,7 @@ fn mul(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(product);
     }
     if (anyRational(args) or (anyBignum(args) and !anyFlonum(args))) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var acc_num: Value = types.makeFixnum(1);
         var acc_den: Value = types.makeFixnum(1);
         gc.extra_roots.append(gc.allocator, acc_num) catch return PrimitiveError.OutOfMemory;
@@ -578,18 +579,18 @@ fn divFn(args: []const Value) PrimitiveError!Value {
         if (types.isFixnum(args[0])) {
             const a_val = types.toFixnum(args[0]);
             if (a_val == 0) return raiseDivByZero();
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             return makeRationalReduced(gc, types.makeFixnum(1), types.makeFixnum(a_val));
         }
         if (types.isRationalObj(args[0])) {
             // 1 / (n/d) = d/n
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             const r = types.toRational(args[0]);
             return makeRationalReduced(gc, r.denominator, r.numerator);
         }
         if (types.isBignum(args[0])) {
             if (bignum_mod.isZero(args[0])) return raiseDivByZero();
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             return makeRationalReduced(gc, types.makeFixnum(1), args[0]);
         }
         const a = try toF64Ext(args[0]);
@@ -598,7 +599,7 @@ fn divFn(args: []const Value) PrimitiveError!Value {
     }
     // Handle rational division: any rational arg means rational result
     if ((anyRational(args) or anyBignum(args)) and !anyFlonum(args)) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var acc_num: Value = undefined;
         var acc_den: Value = undefined;
         if (types.isFixnum(args[0])) {
@@ -647,7 +648,7 @@ fn divFn(args: []const Value) PrimitiveError!Value {
     }
     // All exact integers (fixnum or bignum) — try exact division, produce rational if needed
     if (!anyFlonum(args) and !anyBignum(args) and !anyRational(args)) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var n = types.toFixnum(args[0]);
         var d: i64 = 1;
         for (args[1..]) |a| {
@@ -683,7 +684,7 @@ fn divFn(args: []const Value) PrimitiveError!Value {
     }
     // Exact integer division with bignums: produce exact rational
     if (anyBignum(args) and !anyFlonum(args) and !anyRational(args)) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var num_val = args[0];
         var den_val: Value = types.makeFixnum(1);
         gc.extra_roots.append(gc.allocator, num_val) catch return PrimitiveError.OutOfMemory;
@@ -725,7 +726,7 @@ fn quotient(args: []const Value) PrimitiveError!Value {
     {
         if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
         if (!types.isFixnum(args[1]) and !types.isBignum(args[1])) return numberTypeError(args[1]);
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         return bignum_mod.quotient(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
     }
@@ -747,7 +748,7 @@ fn remainder(args: []const Value) PrimitiveError!Value {
     {
         if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
         if (!types.isFixnum(args[1]) and !types.isBignum(args[1])) return numberTypeError(args[1]);
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         return bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
     }
@@ -769,7 +770,7 @@ fn modulo(args: []const Value) PrimitiveError!Value {
     {
         if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
         if (!types.isFixnum(args[1]) and !types.isBignum(args[1])) return numberTypeError(args[1]);
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         const rem = bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(rem)) return types.makeFixnum(0);
@@ -831,7 +832,7 @@ fn compareExactReals(a: Value, b: Value) PrimitiveError!i8 {
         }
     }
     // General path: bignum cross-multiplication (handles bignum parts/overflow).
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const na = exactNumerator(a);
     const da = exactDenominator(a);
     const nb = exactNumerator(b);
@@ -852,7 +853,7 @@ fn compareExactVsFlonum(a: Value, f: f64) PrimitiveError!i8 {
         if (std.math.isNan(f)) return 1; // callers short-circuit NaN; be safe
         return if (f > 0) @as(i8, -1) else @as(i8, 1); // a < +inf ; a > -inf
     }
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var f_exact = try numeric.exactFn(&[1]Value{types.makeFlonum(f)});
     gc.pushRoot(&f_exact) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
@@ -892,13 +893,13 @@ fn cmpPair(a: Value, b: Value) PrimitiveError!i8 {
         // Same f64 value — check if bignum is exactly representable
         // Convert f64 → bignum → f64 round-trip to detect precision loss
         if (fb == @trunc(fb) and @abs(fb) < 4.5e18) {
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             const b_exact = gc.allocBignumFromI64(@intFromFloat(fb)) catch return PrimitiveError.OutOfMemory;
             return bignum_mod.compare(a, b_exact);
         }
         // For very large integer floats: convert float to exact bignum and compare
         if (fb == @trunc(fb)) {
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             const bits: u64 = @bitCast(fb);
             const biased_exp = @as(i64, @intCast((bits >> 52) & 0x7FF));
             const mantissa_bits = bits & 0x000FFFFFFFFFFFFF;
@@ -1067,17 +1068,17 @@ fn absVal(args: []const Value) PrimitiveError!Value {
     if (types.isFixnum(args[0])) {
         const n = types.toFixnum(args[0]);
         if (n == std.math.minInt(i64)) {
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             return bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
         }
         return makeFixnumChecked(if (n < 0) -n else n);
     }
     if (types.isBignum(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         return bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
     }
     if (types.isRationalObj(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const r = types.toRational(args[0]);
         // Denominator is always positive; just take abs of numerator
         if (types.isFixnum(r.numerator)) {
@@ -1238,7 +1239,7 @@ fn gcdFn(args: []const Value) PrimitiveError!Value {
     }
     if (anyBignum(args)) {
         // Bignum GCD: use Euclidean algorithm with bignum ops
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
         var result = bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
         gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
@@ -1288,7 +1289,7 @@ fn lcmFn(args: []const Value) PrimitiveError!Value {
     }
     if (anyBignum(args)) {
         // Bignum LCM: lcm(a,b) = |a*b| / gcd(a,b)
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var result = bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
         gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
         defer {
@@ -1327,7 +1328,7 @@ fn lcmFn(args: []const Value) PrimitiveError!Value {
             const abs_b: i64 = if (b < 0) -b else b;
             const ov = @mulWithOverflow(partial, abs_b);
             if (ov[1] != 0) {
-                const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+                const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
                 var big_result = bignum_mod.mul(gc, try makeFixnumChecked(partial), try makeFixnumChecked(abs_b)) catch return PrimitiveError.OutOfMemory;
                 gc.extra_roots.append(gc.allocator, big_result) catch return PrimitiveError.OutOfMemory;
                 defer {

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const primitives_io = @import("primitives_io.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
@@ -47,7 +48,7 @@ fn bytevectorP(args: []const Value) PrimitiveError!Value {
 
 fn makeBytevector(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("make-bytevector", "non-negative integer", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("make-bytevector", "non-negative integer", args[0]);
     const size: usize = @intCast(k);
@@ -61,7 +62,7 @@ fn makeBytevector(args: []const Value) PrimitiveError!Value {
 }
 
 fn bytevectorFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = gc.allocator.alloc(u8, args.len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(data);
     for (args, 0..) |a, i| {
@@ -103,7 +104,7 @@ fn bytevectorU8Set(args: []const Value) PrimitiveError!Value {
 
 fn bytevectorCopy(args: []const Value) PrimitiveError!Value {
     if (!types.isBytevector(args[0])) return primitives.typeError("bytevector-copy", "bytevector", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const bv = types.toBytevector(args[0]);
 
     const range = try primitives.parseOptionalRange(args, 1, bv.data.len, "bytevector-copy");
@@ -146,7 +147,7 @@ fn bytevectorCopyBang(args: []const Value) PrimitiveError!Value {
 }
 
 fn bytevectorAppend(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var total_len: usize = 0;
     for (args) |a| {
         if (!types.isBytevector(a)) return primitives.typeError("bytevector-append", "bytevector", a);
@@ -165,7 +166,7 @@ fn bytevectorAppend(args: []const Value) PrimitiveError!Value {
 
 fn utf8ToString(args: []const Value) PrimitiveError!Value {
     if (!types.isBytevector(args[0])) return primitives.typeError("utf8->string", "bytevector", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const bv = types.toBytevector(args[0]);
 
     const range = try primitives.parseOptionalRange(args, 1, bv.data.len, "utf8->string");
@@ -176,7 +177,7 @@ fn utf8ToString(args: []const Value) PrimitiveError!Value {
 
 fn stringToUtf8(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string->utf8", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const string_mod = @import("primitives_string.zig");
 
@@ -287,7 +288,7 @@ fn portWriteBytes(port: *types.Port, bytes: []const u8) void {
         return;
     }
     // String output port: grow buffer as needed
-    const gc = primitives.gc_instance orelse return;
+    const gc = memory.gc_instance orelse return;
     var buf = port.string_out_buf orelse return;
     const len = port.string_out_len;
     const cap = port.string_out_cap;
@@ -315,7 +316,7 @@ fn u8ReadyP(args: []const Value) PrimitiveError!Value {
 fn readBytevectorFn(args: []const Value) PrimitiveError!Value {
     // (read-bytevector k [port])
     if (!types.isFixnum(args[0])) return primitives.typeError("read-bytevector", "exact integer", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("read-bytevector", "non-negative integer", args[0]);
     const count: usize = @intCast(@as(u64, @bitCast(k)));
@@ -360,7 +361,7 @@ fn writeBytevectorFn(args: []const Value) PrimitiveError!Value {
 
 fn openInputBytevector(args: []const Value) PrimitiveError!Value {
     if (!types.isBytevector(args[0])) return primitives.typeError("open-input-bytevector", "bytevector", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port_val = gc.allocStringInputPort(bv_data: {
         const bv = types.toBytevector(args[0]);
         break :bv_data bv.data;
@@ -371,7 +372,7 @@ fn openInputBytevector(args: []const Value) PrimitiveError!Value {
 
 fn openOutputBytevector(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port_val = gc.allocStringOutputPort() catch return PrimitiveError.OutOfMemory;
     types.toObject(port_val).as(types.Port).is_binary = true;
     return port_val;
@@ -379,7 +380,7 @@ fn openOutputBytevector(args: []const Value) PrimitiveError!Value {
 
 fn getOutputBytevector(args: []const Value) PrimitiveError!Value {
     if (!types.isPort(args[0])) return primitives.typeError("get-output-bytevector", "output bytevector port", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = types.toObject(args[0]).as(types.Port);
     if (!port.is_string_port or !port.is_output or !port.is_binary) return primitives.typeError("get-output-bytevector", "output bytevector port", args[0]);
     const data = if (port.string_out_buf) |buf| buf[0..port.string_out_len] else &[_]u8{};

--- a/src/primitives_char.zig
+++ b/src/primitives_char.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const unicode = @import("unicode_tables.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
@@ -432,7 +433,7 @@ fn stringCiGtFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn stringCaseMap(data: []const u8, comptime case_fn: fn (u21) u21) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     // Case mapping may change byte lengths, so use a dynamic buffer
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(gc.allocator);
@@ -488,7 +489,7 @@ pub fn appendCodepoint(result: *std.ArrayList(u8), alloc: std.mem.Allocator, cp:
 }
 
 fn stringCaseMapExpanding(data: []const u8, mode: CaseMode) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(gc.allocator);
 

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const printer = @import("printer.zig");
 const primitives_io = @import("primitives_io.zig");
 const Value = types.Value;
@@ -40,7 +41,7 @@ pub fn registerControl(vm: *vm_mod.VM) !void {
 
 pub fn raiseFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse {
-        const gc = primitives.gc_instance orelse return PrimitiveError.TypeError; // bare-ok: no GC
+        const gc = memory.gc_instance orelse return PrimitiveError.TypeError; // bare-ok: no GC
         primitives_io.writeStderr("Error: unhandled exception: ");
         const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.TypeError; // bare-ok: print failed
         defer gc.allocator.free(s);
@@ -54,7 +55,7 @@ pub fn raiseFn(args: []const Value) PrimitiveError!Value {
 
 fn raiseContinuableFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse {
-        const gc = primitives.gc_instance orelse return PrimitiveError.TypeError; // bare-ok: no GC
+        const gc = memory.gc_instance orelse return PrimitiveError.TypeError; // bare-ok: no GC
         primitives_io.writeStderr("Error: unhandled exception: ");
         const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.TypeError; // bare-ok: print failed
         defer gc.allocator.free(s);
@@ -95,7 +96,7 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
         if (err == vm_mod.VMError.ExceptionRaised) {
             vm.popHandler();
             var handler_root = handler;
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             gc.pushRoot(&handler_root) catch return PrimitiveError.OutOfMemory;
             defer gc.popRoot();
             var exc = vm.current_exception orelse types.FALSE;
@@ -115,7 +116,7 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
         }
         vm.popHandler();
         // Convert VM-level errors into Scheme exceptions so guard can catch them
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const detail = vm.getErrorDetail();
         var msg_str = if (detail.len > 0)
             gc.allocString(detail) catch return PrimitiveError.OutOfMemory
@@ -170,7 +171,7 @@ fn readErrorP(args: []const Value) PrimitiveError!Value {
 }
 
 fn errorFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     // First arg is the message
     const message = args[0];
@@ -314,7 +315,7 @@ fn dynamicWindFn(args: []const Value) PrimitiveError!Value {
 
 fn valuesFn(args: []const Value) PrimitiveError!Value {
     if (args.len == 1) return args[0];
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocMultipleValues(args) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -332,7 +333,7 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
     };
 
     // Call consumer with the produced values
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var produced_root = produced;
     gc.pushRoot(&produced_root) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();

--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const vm_mod = @import("vm.zig");
 const Value = types.Value;
 const PrimitiveError = primitives.PrimitiveError;
@@ -29,7 +30,7 @@ fn checkSandbox(comptime name: []const u8) PrimitiveError!void {
 /// Opens a shared library. Pass #f for the default process (all linked symbols).
 fn ffiOpen(args: []const Value) PrimitiveError!Value {
     try checkSandbox("ffi-open");
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     if (args[0] == types.FALSE) {
         // Open default process (all linked symbols including libc)
@@ -104,7 +105,7 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
 /// Looks up a symbol in the library and creates an FfiFunction.
 fn ffiFn(args: []const Value) PrimitiveError!Value {
     try checkSandbox("ffi-fn");
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     // arg0: library
     if (!types.isFfiLibrary(args[0])) return PrimitiveError.TypeError;
@@ -178,7 +179,7 @@ fn ffiClose(args: []const Value) PrimitiveError!Value {
 /// (ffi-callback proc '(param-types) 'return-type)
 fn ffiCallbackFn(args: []const Value) PrimitiveError!Value {
     try checkSandbox("ffi-callback");
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     if (!types.isClosure(proc) and !types.isNativeFn(proc))
         return primitives.typeError("ffi-callback", "procedure", proc);
@@ -236,7 +237,7 @@ fn ffiBytevectorPtr(args: []const Value) PrimitiveError!Value {
     try checkSandbox("ffi-bytevector-ptr");
     if (!types.isBytevector(args[0]))
         return primitives.typeError("ffi-bytevector-ptr", "bytevector", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const bv = types.toObject(args[0]).as(types.Bytevector);
     if (bv.data.len == 0) return types.makeFixnum(0);
     const addr: usize = @intFromPtr(bv.data.ptr);

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const fiber_mod = @import("fiber.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
@@ -35,7 +36,7 @@ fn spawnFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
 
     if (vm.scheduler == null) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const sched = gc.allocator.create(fiber_mod.FiberScheduler) catch return PrimitiveError.OutOfMemory;
         sched.* = fiber_mod.FiberScheduler.init(vm);
 
@@ -94,7 +95,7 @@ fn fiberPredFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn makeChannelFn(_: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocChannel() catch return PrimitiveError.OutOfMemory;
 }
 
@@ -102,7 +103,7 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[0]))
         return primitives.typeError("channel-send", "channel", args[0]);
 
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ch = types.toObject(args[0]).as(types.Channel);
     const new_pair = gc.allocPair(args[1], types.NIL) catch return PrimitiveError.OutOfMemory;
 
@@ -147,14 +148,14 @@ fn dequeueChannel(ch: *types.Channel, ch_val: Value) Value {
     const pair = types.toObject(ch.head).as(types.Pair);
     const val = pair.car;
     ch.head = pair.cdr;
-    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(ch_val), pair.cdr);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(ch_val), pair.cdr);
     if (ch.head == types.NIL) ch.tail = types.NIL;
     return val;
 }
 
 fn runSchedulerUntil(target: ?*fiber_mod.Fiber, ch: ?*types.Channel, ch_val: Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const sched = vm.scheduler orelse return PrimitiveError.OutOfMemory;
     const my_idx = sched.current_idx;
     sched.saveCurrentFiber();
@@ -236,7 +237,7 @@ fn blockOrDeadlock(vm: *vm_mod.VM, me: *fiber_mod.Fiber, my_idx: usize, wait_on:
 }
 
 fn raiseDeadlockError(msg: []const u8) PrimitiveError {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
     var msg_root = message;

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -4,7 +4,8 @@ const primitives = @import("primitives.zig");
 const vm_mod = @import("vm.zig");
 const Value = types.Value;
 const PrimitiveError = primitives.PrimitiveError;
-const GC = @import("memory.zig").GC;
+const memory = @import("memory.zig");
+const GC = memory.GC;
 const arith = @import("primitives_arithmetic.zig");
 
 extern fn mkstemp(template: [*:0]u8) c_int;
@@ -218,7 +219,7 @@ fn extractPath(val: Value) ?[]const u8 {
 
 fn validatePathNoNul(path: []const u8, original: Value) PrimitiveError!void {
     if (std.mem.indexOfScalar(u8, path, 0) != null) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         _ = try raiseFileError(gc, "path contains embedded NUL byte", original);
     }
 }
@@ -228,7 +229,7 @@ fn validatePathNoNul(path: []const u8, original: Value) PrimitiveError!void {
 // -------------------------------------------------------------------------
 
 fn directoryFiles(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("directory-files", "string", args[0]);
     try validatePathNoNul(path, args[0]);
     const include_dotfiles = if (args.len > 1) types.isTruthy(args[1]) else false;
@@ -267,7 +268,7 @@ fn directoryFiles(args: []const Value) PrimitiveError!Value {
 // -------------------------------------------------------------------------
 
 fn fileInfoFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("file-info", "string", args[0]);
     try validatePathNoNul(path, args[0]);
     const follow = if (args.len > 1) types.isTruthy(args[1]) else true;
@@ -424,7 +425,7 @@ fn fileInfoDeviceP(args: []const Value) PrimitiveError!Value {
 // -------------------------------------------------------------------------
 
 fn createDirectoryFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("create-directory", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
@@ -443,7 +444,7 @@ fn createDirectoryFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn deleteDirectoryFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("delete-directory", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
@@ -461,7 +462,7 @@ fn deleteDirectoryFn(args: []const Value) PrimitiveError!Value {
 // -------------------------------------------------------------------------
 
 fn renameFileFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const old = extractPath(args[0]) orelse return primitives.typeError("rename-file", "string", args[0]);
     const new = extractPath(args[1]) orelse return primitives.typeError("rename-file", "string", args[1]);
     try validatePathNoNul(old, args[0]);
@@ -479,7 +480,7 @@ fn renameFileFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn createSymlinkFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const old = extractPath(args[0]) orelse return primitives.typeError("create-symlink", "string", args[0]);
     const new = extractPath(args[1]) orelse return primitives.typeError("create-symlink", "string", args[1]);
     try validatePathNoNul(old, args[0]);
@@ -497,7 +498,7 @@ fn createSymlinkFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn readSymlinkFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("read-symlink", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
@@ -516,7 +517,7 @@ fn readSymlinkFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn createHardLinkFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const old = extractPath(args[0]) orelse return primitives.typeError("create-hard-link", "string", args[0]);
     const new = extractPath(args[1]) orelse return primitives.typeError("create-hard-link", "string", args[1]);
     try validatePathNoNul(old, args[0]);
@@ -534,7 +535,7 @@ fn createHardLinkFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn realPathFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("real-path", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
@@ -550,7 +551,7 @@ fn realPathFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn setFileModeFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("set-file-mode", "string", args[0]);
     try validatePathNoNul(path, args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("set-file-mode", "integer", args[1]);
@@ -566,7 +567,7 @@ fn setFileModeFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn truncateFileFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("truncate-file", "string", args[0]);
     try validatePathNoNul(path, args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("truncate-file", "integer", args[1]);
@@ -582,7 +583,7 @@ fn truncateFileFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn createFifoFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("create-fifo", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
@@ -601,7 +602,7 @@ fn createFifoFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn setFileOwnerFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("set-file-owner", "string", args[0]);
     try validatePathNoNul(path, args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("set-file-owner", "integer", args[1]);
@@ -623,7 +624,7 @@ const TIME_NOW: i64 = -1;
 const TIME_UNCHANGED: i64 = -2;
 
 fn setFileTimesFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("set-file-times", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
@@ -681,7 +682,7 @@ fn umaskFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn setUmaskFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[0])) return primitives.typeError("set-umask!", "integer", args[0]);
     const mask = try validateMode(gc, args[0]);
     _ = std.c.umask(mask);
@@ -690,7 +691,7 @@ fn setUmaskFn(args: []const Value) PrimitiveError!Value {
 
 fn currentDirectoryFn(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var buf: [std.posix.PATH_MAX]u8 = undefined;
     const result = std.c.getcwd(&buf, buf.len) orelse {
         return raiseFileError(gc, "cannot get current directory", types.FALSE);
@@ -700,7 +701,7 @@ fn currentDirectoryFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn setCurrentDirectoryFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("set-current-directory!", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
@@ -735,7 +736,7 @@ fn userEffectiveGidFn(args: []const Value) PrimitiveError!Value {
 
 fn userSupplementaryGidsFn(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     const count = getgroups(0, undefined);
     if (count < 0) return raiseFileError(gc, "cannot query supplementary groups", types.NIL);
@@ -758,7 +759,7 @@ fn userSupplementaryGidsFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn niceFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var delta: c_int = 1;
     if (args.len > 0 and types.isFixnum(args[0])) {
         // Fixnums range up to ±2^47, but nice() takes a C int. An unchecked
@@ -785,7 +786,7 @@ fn niceFn(args: []const Value) PrimitiveError!Value {
 // -------------------------------------------------------------------------
 
 fn setEnvVarFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const name = extractPath(args[0]) orelse return primitives.typeError("set-environment-variable!", "string", args[0]);
     const value = extractPath(args[1]) orelse return primitives.typeError("set-environment-variable!", "string", args[1]);
     try validatePathNoNul(name, args[0]);
@@ -803,7 +804,7 @@ fn setEnvVarFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn deleteEnvVarFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const name = extractPath(args[0]) orelse return primitives.typeError("delete-environment-variable!", "string", args[0]);
     try validatePathNoNul(name, args[0]);
 
@@ -829,7 +830,7 @@ fn terminalP(args: []const Value) PrimitiveError!Value {
 // -------------------------------------------------------------------------
 
 fn userInfoFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     const pw = if (types.isFixnum(args[0])) blk: {
         const id_val = types.toFixnum(args[0]);
@@ -859,7 +860,7 @@ fn userInfoP(args: []const Value) PrimitiveError!Value {
 
 fn userInfoName(args: []const Value) PrimitiveError!Value {
     if (!types.isUserInfo(args[0])) return primitives.typeError("user-info:name", "user-info", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocString(types.toUserInfo(args[0]).name) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -875,24 +876,24 @@ fn userInfoGidFn(args: []const Value) PrimitiveError!Value {
 
 fn userInfoHomeDir(args: []const Value) PrimitiveError!Value {
     if (!types.isUserInfo(args[0])) return primitives.typeError("user-info:home-dir", "user-info", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocString(types.toUserInfo(args[0]).home_dir) catch return PrimitiveError.OutOfMemory;
 }
 
 fn userInfoShell(args: []const Value) PrimitiveError!Value {
     if (!types.isUserInfo(args[0])) return primitives.typeError("user-info:shell", "user-info", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocString(types.toUserInfo(args[0]).shell) catch return PrimitiveError.OutOfMemory;
 }
 
 fn userInfoFullName(args: []const Value) PrimitiveError!Value {
     if (!types.isUserInfo(args[0])) return primitives.typeError("user-info:full-name", "user-info", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocString(types.toUserInfo(args[0]).full_name) catch return PrimitiveError.OutOfMemory;
 }
 
 fn groupInfoFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     if (types.isFixnum(args[0])) {
         const id_val = types.toFixnum(args[0]);
@@ -918,7 +919,7 @@ fn groupInfoP(args: []const Value) PrimitiveError!Value {
 
 fn groupInfoName(args: []const Value) PrimitiveError!Value {
     if (!types.isGroupInfo(args[0])) return primitives.typeError("group-info:name", "group-info", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocString(types.toGroupInfo(args[0]).name) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -932,7 +933,7 @@ fn groupInfoGidFn(args: []const Value) PrimitiveError!Value {
 // -------------------------------------------------------------------------
 
 fn openDirectoryFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("open-directory", "string", args[0]);
     try validatePathNoNul(path, args[0]);
     const include_dotfiles = if (args.len > 1) types.isTruthy(args[1]) else false;
@@ -952,7 +953,7 @@ fn openDirectoryFn(args: []const Value) PrimitiveError!Value {
 
 fn readDirectoryFn(args: []const Value) PrimitiveError!Value {
     if (!types.isDirectoryObject(args[0])) return primitives.typeError("read-directory", "directory-object", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const d = types.toDirectoryObject(args[0]);
 
     const dir_ptr = d.dir orelse return types.EOF;
@@ -1001,7 +1002,7 @@ fn monotonicTimeFn(args: []const Value) PrimitiveError!Value {
 
 // (file-info-type fi) — return type as symbol
 fn fileInfoTypeFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFileInfo(args[0])) return primitives.typeError("file-info-type", "file-info", args[0]);
     const fi = types.toObject(args[0]).as(types.FileInfo);
     const name: []const u8 = switch (fi.file_type) {
@@ -1020,13 +1021,13 @@ fn fileInfoTypeFn(args: []const Value) PrimitiveError!Value {
 // (temp-file-prefix) — return tempdir path
 fn tempFilePrefixFn(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocString("/tmp/kaappi-") catch return PrimitiveError.OutOfMemory;
 }
 
 // (create-temp-file [prefix]) — create a temp file and return its path
 fn createTempFileFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     var prefix: []const u8 = "/tmp/kaappi-";
     if (args.len > 0 and types.isString(args[0])) {

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -47,7 +48,7 @@ fn getHashTable(proc: []const u8, v: Value) PrimitiveError!*HashTable {
     return types.toHashTable(v);
 }
 
-const GC = @import("memory.zig").GC;
+const GC = memory.GC;
 
 fn snapshotLiveEntries(gc: *GC, ht: *HashTable) ?[]HashEntry {
     if (ht.count == 0) return gc.allocator.alloc(HashEntry, 0) catch return null;
@@ -150,7 +151,7 @@ fn findSlot(ht: *HashTable, key: Value) struct { idx: usize, found: bool } {
 }
 
 fn rehash(ht: *HashTable) PrimitiveError!void {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const new_cap = if (ht.capacity == 0) 8 else ht.capacity * 2;
     const new_entries = gc.allocator.alloc(HashEntry, new_cap) catch return PrimitiveError.OutOfMemory;
     for (new_entries) |*e| {
@@ -185,7 +186,7 @@ fn growIfNeeded(ht: *HashTable) PrimitiveError!void {
 // (make-hash-table) or (make-hash-table equal-proc hash-proc)
 fn makeHashTableFn(args: []const Value) PrimitiveError!Value {
     _ = args; // ignore optional comparator/hash args; we always use equal?
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocHashTable(8) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -218,7 +219,7 @@ fn hashTableSetFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-set!", args[0]);
     try growIfNeeded(ht);
     const slot = findSlot(ht, args[1]);
-    if (primitives.gc_instance) |gc| {
+    if (memory.gc_instance) |gc| {
         gc.writeBarrier(types.toObject(args[0]), args[1]);
         gc.writeBarrier(types.toObject(args[0]), args[2]);
     }
@@ -257,7 +258,7 @@ fn hashTableSizeFn(args: []const Value) PrimitiveError!Value {
 
 // (hash-table-keys ht)
 fn hashTableKeysFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-keys", args[0]);
     var result: Value = types.NIL;
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
@@ -272,7 +273,7 @@ fn hashTableKeysFn(args: []const Value) PrimitiveError!Value {
 
 // (hash-table-values ht)
 fn hashTableValuesFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-values", args[0]);
     var result: Value = types.NIL;
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
@@ -288,7 +289,7 @@ fn hashTableValuesFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-walk ht proc) — call (proc key value) for each entry
 fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-walk", args[0]);
     const proc = args[1];
 
@@ -306,7 +307,7 @@ fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
 
 // (hash-table->alist ht)
 fn hashTableToAlistFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table->alist", args[0]);
     var result: Value = types.NIL;
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
@@ -328,7 +329,7 @@ fn hashTableToAlistFn(args: []const Value) PrimitiveError!Value {
 // (alist->hash-table alist) or (alist->hash-table alist equal-proc hash-proc)
 // The optional comparator/hash args are accepted and ignored, like make-hash-table.
 fn alistToHashTableFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
 
     // Count entries first
@@ -363,7 +364,7 @@ fn alistToHashTableFn(args: []const Value) PrimitiveError!Value {
 
 // (hash-table-copy ht)
 fn hashTableCopyFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const src = try getHashTable("hash-table-copy", args[0]);
     const dst_val = gc.allocHashTable(src.capacity) catch return PrimitiveError.OutOfMemory;
     const dst = types.toHashTable(dst_val);
@@ -392,7 +393,7 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
 
     try growIfNeeded(ht);
     const slot = findSlot(ht, key);
-    if (primitives.gc_instance) |gc| {
+    if (memory.gc_instance) |gc| {
         gc.writeBarrier(types.toObject(args[0]), key);
         gc.writeBarrier(types.toObject(args[0]), new_val);
     }
@@ -492,7 +493,7 @@ fn hashTableRefDefaultFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-fold ht f init) — fold over hash table entries
 fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-fold", args[0]);
     const proc = args[1];
     var acc = args[2];
@@ -515,7 +516,7 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
     const ht2 = try getHashTable("hash-table-merge!", args[1]);
     if (ht1 == ht2) return args[0];
 
-    const gc = primitives.gc_instance;
+    const gc = memory.gc_instance;
     for (ht2.entries[0..ht2.capacity]) |entry| {
         if (entry.state != .occupied) continue;
         const slot = findSlot(ht1, entry.key);

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -3,6 +3,7 @@ const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const printer = @import("printer.zig");
 const reader_mod = @import("reader.zig");
 const primitives_control = @import("primitives_control.zig");
@@ -195,7 +196,7 @@ fn writeToPort(port: *types.Port, bytes: []const u8) void {
 }
 
 fn stringPortWrite(port: *types.Port, bytes: []const u8) void {
-    const gc = primitives.gc_instance orelse return;
+    const gc = memory.gc_instance orelse return;
     var buf = port.string_out_buf orelse return;
     const len = port.string_out_len;
     const cap = port.string_out_cap;
@@ -215,7 +216,7 @@ fn stringPortWrite(port: *types.Port, bytes: []const u8) void {
 // ---------------------------------------------------------------------------
 
 fn display(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = try getOutputPort(args, 1, "display");
     const s = printer.valueToString(gc.allocator, args[0], .display) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(s);
@@ -224,7 +225,7 @@ fn display(args: []const Value) PrimitiveError!Value {
 }
 
 fn write(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = try getOutputPort(args, 1, "write");
     const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(s);
@@ -233,7 +234,7 @@ fn write(args: []const Value) PrimitiveError!Value {
 }
 
 fn writeShared(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = try getOutputPort(args, 1, "write-shared");
     const s = printer.valueToString(gc.allocator, args[0], .shared) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(s);
@@ -322,7 +323,7 @@ fn raiseFileError(gc: *@import("memory.zig").GC, msg_text: []const u8, irritant:
 fn openInputFile(args: []const Value) PrimitiveError!Value {
     if (comptime is_wasm) return PrimitiveError.TypeError;
     if (!types.isString(args[0])) return primitives.typeError("open-input-file", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 
@@ -344,7 +345,7 @@ fn openInputFile(args: []const Value) PrimitiveError!Value {
 fn openOutputFile(args: []const Value) PrimitiveError!Value {
     if (comptime is_wasm) return PrimitiveError.TypeError;
     if (!types.isString(args[0])) return primitives.typeError("open-output-file", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 
@@ -383,7 +384,7 @@ fn closePort(args: []const Value) PrimitiveError!Value {
     if (!types.isPort(args[0])) return primitives.typeError("close-port", "port", args[0]);
     const port = types.toObject(args[0]).as(types.Port);
     if (port.read_buf) |rb| {
-        if (primitives.gc_instance) |gc| {
+        if (memory.gc_instance) |gc| {
             gc.allocator.free(rb);
         }
         port.read_buf = null;
@@ -417,7 +418,7 @@ fn readOneByte(port: *types.Port) ?u8 {
             const byte = rb[pos];
             port.read_buf_len -= 1;
             if (port.read_buf_len == 0) {
-                if (primitives.gc_instance) |gc| {
+                if (memory.gc_instance) |gc| {
                     gc.allocator.free(rb);
                 }
                 port.read_buf = null;
@@ -537,7 +538,7 @@ fn peekCharFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn readLineFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = try getInputPort(args, 0, "read-line");
 
     var line_buf: std.ArrayList(u8) = .empty;
@@ -645,7 +646,7 @@ fn readFromPeekByteOnly(gc: *@import("memory.zig").GC, port: *types.Port) Primit
 }
 
 fn readDatumFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = try getInputPort(args, 0, "read");
 
     // For string ports, read directly from the string data
@@ -772,7 +773,7 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
 fn fileExistsP(args: []const Value) PrimitiveError!Value {
     if (comptime is_wasm) return types.FALSE;
     if (!types.isString(args[0])) return primitives.typeError("file-exists?", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 
@@ -807,20 +808,20 @@ fn eofObjectFn(args: []const Value) PrimitiveError!Value {
 
 fn openInputString(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("open-input-string", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     return gc.allocStringInputPort(str.data[0..str.len]) catch return PrimitiveError.OutOfMemory;
 }
 
 fn openOutputString(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocStringOutputPort() catch return PrimitiveError.OutOfMemory;
 }
 
 fn getOutputString(args: []const Value) PrimitiveError!Value {
     if (!types.isPort(args[0])) return primitives.typeError("get-output-string", "port", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = types.toObject(args[0]).as(types.Port);
     if (!port.is_string_port or !port.is_output) return primitives.typeError("get-output-string", "output string port", args[0]);
     const buf = port.string_out_buf orelse return gc.allocString("") catch return PrimitiveError.OutOfMemory;
@@ -834,7 +835,7 @@ fn getOutputString(args: []const Value) PrimitiveError!Value {
 fn readStringFn(args: []const Value) PrimitiveError!Value {
     // (read-string k [port]) -- read k characters
     if (!types.isFixnum(args[0])) return primitives.typeError("read-string", "integer", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("read-string", "non-negative integer", args[0]);
     const count: usize = @intCast(@as(u64, @bitCast(k)));
@@ -870,7 +871,7 @@ fn flushOutputPort(args: []const Value) PrimitiveError!Value {
 fn deleteFile(args: []const Value) PrimitiveError!Value {
     if (comptime is_wasm) return PrimitiveError.TypeError;
     if (!types.isString(args[0])) return primitives.typeError("delete-file", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 
@@ -1011,7 +1012,7 @@ fn writeU8Fn(args: []const Value) PrimitiveError!Value {
 
 fn readBytevectorFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("read-bytevector", "integer", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("read-bytevector", "non-negative integer", args[0]);
     const count: usize = @intCast(@as(u64, @bitCast(k)));

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const vm_mod = @import("vm.zig");
 const Value = types.Value;
 const PrimitiveError = primitives.PrimitiveError;
@@ -23,18 +24,18 @@ fn promiseP(args: []const Value) PrimitiveError!Value {
 
 fn makePromiseFn(args: []const Value) PrimitiveError!Value {
     if (types.isPromise(args[0])) return args[0];
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocPromise(true, args[0]) catch return PrimitiveError.OutOfMemory;
 }
 
 fn makePromiseLazy(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocPromise(false, args[0]) catch return PrimitiveError.OutOfMemory;
 }
 
 fn forceFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     var current = args[0];
     gc.pushRoot(&current) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -2,12 +2,13 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const bignum_mod = @import("bignum.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
 fn getGC() ?*@import("memory.zig").GC {
-    return primitives.gc_instance;
+    return memory.gc_instance;
 }
 const deepEqual = primitives.deepEqual;
 
@@ -75,7 +76,7 @@ fn listSetFn(args: []const Value) PrimitiveError!Value {
     while (current != types.NIL) {
         if (!types.isPair(current)) return primitives.typeError("list-set!", "pair", current);
         if (idx == k) {
-            if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(current), args[2]);
+            if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(current), args[2]);
             types.setCar(current, args[2]);
             return types.VOID;
         }

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const bignum_mod = @import("bignum.zig");
 const arith = @import("primitives_arithmetic.zig");
 const Value = types.Value;
@@ -29,7 +30,7 @@ fn safeFloatToExactInt(f: f64) PrimitiveError!Value {
 }
 
 fn floatToBignum(f: f64) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const positive = f >= 0;
     const abs_f = @abs(f);
     const bits: u64 = @bitCast(abs_f);
@@ -146,7 +147,7 @@ pub fn registerNumeric(vm: *vm_mod.VM) !void {
 // ---------------------------------------------------------------------------
 
 fn rationalFloor(r: *types.Rational) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
     gc.extra_roots.append(gc.allocator, q) catch return PrimitiveError.OutOfMemory;
     defer _ = gc.extra_roots.pop();
@@ -159,7 +160,7 @@ fn rationalFloor(r: *types.Rational) PrimitiveError!Value {
 }
 
 fn rationalCeiling(r: *types.Rational) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
     gc.extra_roots.append(gc.allocator, q) catch return PrimitiveError.OutOfMemory;
     defer _ = gc.extra_roots.pop();
@@ -172,12 +173,12 @@ fn rationalCeiling(r: *types.Rational) PrimitiveError!Value {
 }
 
 fn rationalTruncate(r: *types.Rational) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return bignum_mod.demote(bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory);
 }
 
 fn rationalRound(r: *types.Rational) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
     gc.extra_roots.append(gc.allocator, q) catch return PrimitiveError.OutOfMemory;
     defer _ = gc.extra_roots.pop();
@@ -287,7 +288,7 @@ pub fn exactFn(args: []const Value) PrimitiveError!Value {
         if (std.math.isNan(f) or std.math.isInf(f)) return primitives.typeError("exact", "finite number", args[0]);
         if (f == 0.0) return types.makeFixnum(0);
         if (f == @trunc(f)) return try safeFloatToExactInt(f);
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const positive = f >= 0;
         const bits: u64 = @bitCast(@abs(f));
         const raw_exp = @as(u11, @intCast((bits >> 52) & 0x7FF));
@@ -336,7 +337,7 @@ pub fn exactFn(args: []const Value) PrimitiveError!Value {
         return gc.allocRational(num_val, den_val) catch return PrimitiveError.OutOfMemory;
     }
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         const real_flo = types.makeFlonum(c.real);
         const real_exact = try exactFn(&[1]Value{real_flo});
@@ -363,7 +364,7 @@ fn inexactFn(args: []const Value) PrimitiveError!Value {
         const result = n / d;
         if (!std.math.isNan(result)) return makeFlonumVal(result);
         // Both overflow to inf — use bignum division for the integer part
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
         const q_f = try toF64Ext(q);
         const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
@@ -371,7 +372,7 @@ fn inexactFn(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(q_f + rem_f / d);
     }
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         return gc.allocComplex(c.real, c.imag) catch return PrimitiveError.OutOfMemory;
     }
@@ -385,7 +386,7 @@ fn inexactFn(args: []const Value) PrimitiveError!Value {
 fn exptFn(args: []const Value) PrimitiveError!Value {
     if ((types.isFixnum(args[0]) or types.isBignum(args[0])) and types.isFixnum(args[1])) {
         const exp = types.toFixnum(args[1]);
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (exp >= 0) {
             return bignum_mod.expt(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
         }
@@ -394,7 +395,7 @@ fn exptFn(args: []const Value) PrimitiveError!Value {
         return arith.makeRationalReduced(gc, types.makeFixnum(1), denom);
     }
     if (types.isRationalObj(args[0]) and types.isFixnum(args[1])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const r = types.toRational(args[0]);
         const exp = types.toFixnum(args[1]);
         if (exp == 0) return types.makeFixnum(1);
@@ -410,7 +411,7 @@ fn exptFn(args: []const Value) PrimitiveError!Value {
     }
     // Complex exponentiation: z^w = e^(w * ln(z))
     if (types.isComplex(args[0]) or types.isComplex(args[1])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var zr: f64 = undefined;
         var zi: f64 = undefined;
         var wr: f64 = undefined;
@@ -479,13 +480,13 @@ fn squareFn(args: []const Value) PrimitiveError!Value {
         const n = types.toFixnum(args[0]);
         const r = @mulWithOverflow(n, n);
         if (r[1] != 0) {
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             return bignum_mod.mul(gc, args[0], args[0]) catch return PrimitiveError.OutOfMemory;
         }
         return types.makeFixnum(r[0]);
     }
     if (types.isBignum(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         return bignum_mod.mul(gc, args[0], args[0]) catch return PrimitiveError.OutOfMemory;
     }
     if (types.isFlonum(args[0])) {
@@ -493,7 +494,7 @@ fn squareFn(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(f * f);
     }
     if (types.isRationalObj(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const rat = types.toRational(args[0]);
         const num_sq = bignum_mod.mul(gc, rat.numerator, rat.numerator) catch return PrimitiveError.OutOfMemory;
         gc.extra_roots.append(gc.allocator, num_sq) catch return PrimitiveError.OutOfMemory;
@@ -506,7 +507,7 @@ fn squareFn(args: []const Value) PrimitiveError!Value {
 
 fn sqrtFn(args: []const Value) PrimitiveError!Value {
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         const mag = @sqrt(c.real * c.real + c.imag * c.imag);
         const r = @sqrt((mag + c.real) / 2.0);
@@ -516,7 +517,7 @@ fn sqrtFn(args: []const Value) PrimitiveError!Value {
     }
     const f = try toF64(args[0]);
     if (f < 0.0) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const imag = @sqrt(-f);
         return gc.allocComplex(0.0, imag) catch return PrimitiveError.OutOfMemory;
     }
@@ -529,7 +530,7 @@ fn sqrtFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn exactIntegerSqrt(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (types.isFixnum(args[0])) {
         const n = types.toFixnum(args[0]);
         if (n < 0) return primitives.typeError("exact-integer-sqrt", "non-negative integer", args[0]);
@@ -632,7 +633,7 @@ fn exactIntegerSqrt(args: []const Value) PrimitiveError!Value {
 
 fn sinFn(args: []const Value) PrimitiveError!Value {
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         const re = @sin(c.real) * std.math.cosh(c.imag);
         const im = @cos(c.real) * std.math.sinh(c.imag);
@@ -644,7 +645,7 @@ fn sinFn(args: []const Value) PrimitiveError!Value {
 
 fn cosFn(args: []const Value) PrimitiveError!Value {
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         const re = @cos(c.real) * std.math.cosh(c.imag);
         const im = -@sin(c.real) * std.math.sinh(c.imag);
@@ -656,7 +657,7 @@ fn cosFn(args: []const Value) PrimitiveError!Value {
 
 fn tanFn(args: []const Value) PrimitiveError!Value {
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         const sin_re = @sin(c.real) * std.math.cosh(c.imag);
         const sin_im = @cos(c.real) * std.math.sinh(c.imag);
@@ -691,13 +692,13 @@ fn complexAsin(gc: anytype, re: f64, im: f64) PrimitiveError!Value {
 
 fn asinFn(args: []const Value) PrimitiveError!Value {
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         return complexAsin(gc, c.real, c.imag);
     }
     const f = try toF64(args[0]);
     if (f < -1.0 or f > 1.0) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         return complexAsin(gc, f, 0.0);
     }
     return makeFlonumVal(std.math.asin(f));
@@ -705,7 +706,7 @@ fn asinFn(args: []const Value) PrimitiveError!Value {
 
 fn acosFn(args: []const Value) PrimitiveError!Value {
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         const asin_val = try complexAsin(gc, c.real, c.imag);
         const pi_half = std.math.pi / 2.0;
@@ -718,7 +719,7 @@ fn acosFn(args: []const Value) PrimitiveError!Value {
     }
     const f = try toF64(args[0]);
     if (f < -1.0 or f > 1.0) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const asin_val = try complexAsin(gc, f, 0.0);
         const pi_half = std.math.pi / 2.0;
         if (types.isFlonum(asin_val)) return makeFlonumVal(pi_half - types.toFlonum(asin_val));
@@ -748,7 +749,7 @@ fn atanFn(args: []const Value) PrimitiveError!Value {
 
 fn expFn(args: []const Value) PrimitiveError!Value {
     if (types.isComplex(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         const exp_r = @exp(c.real);
         const re = exp_r * @cos(c.imag);
@@ -771,13 +772,13 @@ fn complexLog(gc: anytype, re: f64, im: f64) PrimitiveError!Value {
 fn logFn(args: []const Value) PrimitiveError!Value {
     if (args.len == 1) {
         if (types.isComplex(args[0])) {
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             const c = types.toComplex(args[0]);
             return complexLog(gc, c.real, c.imag);
         }
         const f = try toF64(args[0]);
         if (f < 0.0) {
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             return complexLog(gc, f, 0.0);
         }
         return makeFlonumVal(@log(f));
@@ -786,7 +787,7 @@ fn logFn(args: []const Value) PrimitiveError!Value {
     const z = try toF64(args[0]);
     const base = try toF64(args[1]);
     if (z < 0.0) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const mag = @sqrt(z * z);
         const log_re = @log(mag) / @log(base);
         const log_im = std.math.pi / @log(base);
@@ -841,7 +842,7 @@ fn nanP(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn numberToString(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var radix: u8 = 10;
     if (args.len > 1) {
         if (!types.isFixnum(args[1])) return primitives.typeError("number->string", "integer", args[1]);
@@ -941,7 +942,7 @@ pub fn makeComplexOrReal(real: f64, imag: f64) PrimitiveError!Value {
 }
 
 pub fn makeComplexOrRealEx(real: f64, imag: f64, exact_real: bool, exact_imag: bool) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (imag == 0.0) {
         if (exact_real and real == @trunc(real) and @abs(real) < 4.5e18) {
             return try safeFloatToExactInt(real);
@@ -1078,7 +1079,7 @@ fn parseExactDecimal(gc: *@import("memory.zig").GC, s: []const u8) PrimitiveErro
 
 fn stringToNumber(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string->number", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     var s = str.data[0..str.len];
 
@@ -1305,13 +1306,13 @@ fn magnitudeFn(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(@abs(types.toFlonum(args[0])));
     }
     if (types.isBignum(args[0])) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         return bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
     }
     if (types.isRationalObj(args[0])) {
         const r = types.toRational(args[0]);
         if (!bignum_mod.isNegative(r.numerator)) return args[0];
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const neg_num = bignum_mod.negate(gc, r.numerator) catch return PrimitiveError.OutOfMemory;
         return arith.makeRationalReduced(gc, neg_num, r.denominator);
     }
@@ -1353,7 +1354,7 @@ fn floorQuotient(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(@floor(a / b));
     }
     if (anyBignum(args)) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         const q = bignum_mod.quotient(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
         gc.extra_roots.append(gc.allocator, q) catch return PrimitiveError.OutOfMemory;
@@ -1379,7 +1380,7 @@ fn floorRemainder(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(a - @floor(a / b) * b);
     }
     if (anyBignum(args)) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         const rem = bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(rem)) return types.makeFixnum(0);
@@ -1398,7 +1399,7 @@ fn floorRemainder(args: []const Value) PrimitiveError!Value {
 }
 
 fn floorDivide(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q_val = try floorQuotient(args);
     gc.extra_roots.append(gc.allocator, q_val) catch return PrimitiveError.OutOfMemory;
     defer _ = gc.extra_roots.pop();
@@ -1417,7 +1418,7 @@ fn truncateQuotient(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(@trunc(a / b));
     }
     if (anyBignum(args)) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         return bignum_mod.quotient(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
     }
@@ -1435,7 +1436,7 @@ fn truncateRemainder(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(a - @trunc(a / b) * b);
     }
     if (anyBignum(args)) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         return bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
     }
@@ -1446,7 +1447,7 @@ fn truncateRemainder(args: []const Value) PrimitiveError!Value {
 }
 
 fn truncateDivide(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q_val = try truncateQuotient(args);
     gc.extra_roots.append(gc.allocator, q_val) catch return PrimitiveError.OutOfMemory;
     defer _ = gc.extra_roots.pop();
@@ -1536,7 +1537,7 @@ fn denominatorFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn rationalizeFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const x = try primitives.toF64(args[0]);
     const y = try primitives.toF64(args[1]);
     if (!std.math.isFinite(x)) return args[0];

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const reader_mod = @import("reader.zig");
 const compiler_mod = @import("compiler.zig");
 const printer = @import("printer.zig");
@@ -55,7 +56,7 @@ pub fn registerR7RSSandboxed(vm: *vm_mod.VM) !void {
 fn disassembleFn(args: []const Value) PrimitiveError!Value {
     if (!types.isClosure(args[0])) return primitives.typeError("disassemble", "procedure", args[0]);
     const closure = types.toObject(args[0]).as(types.Closure);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const disasm = @import("disassembler.zig");
     disasm.disassemble(closure.func, gc.allocator);
     return types.VOID;
@@ -94,7 +95,7 @@ fn jiffiesPerSecond(args: []const Value) PrimitiveError!Value {
 
 fn commandLine(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
 
     var result: Value = types.NIL;
@@ -140,7 +141,7 @@ fn emergencyExitFn(args: []const Value) PrimitiveError!Value {
 
 fn getEnvVar(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("get-environment-variable", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const name = str.data[0..str.len];
 
@@ -159,7 +160,7 @@ extern var environ: [*:null]?[*:0]const u8;
 
 fn getEnvVars(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     var result: Value = types.NIL;
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
@@ -192,7 +193,7 @@ fn getEnvVars(args: []const Value) PrimitiveError!Value {
 
 fn evalFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const expr = args[0];
 
     // If an environment specifier is provided, compile in that environment
@@ -226,7 +227,7 @@ fn environmentFn(args: []const Value) PrimitiveError!Value {
     // (environment import-set ...) — R7RS 6.12
     // Create a new environment containing bindings from the given import sets.
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const library_mod = @import("library.zig");
 
     const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;
@@ -255,7 +256,7 @@ fn environmentFn(args: []const Value) PrimitiveError!Value {
 fn loadFn(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("load", "string", args[0]);
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 
@@ -320,7 +321,7 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn makeParameterFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const init = args[0];
     const converter: Value = if (args.len > 1) args[1] else types.NIL;
     // If converter provided, apply it to initial value
@@ -343,7 +344,7 @@ fn parameterSetDirectFn(args: []const Value) PrimitiveError!Value {
         vm.setParameterValue(param, args[1]) catch return PrimitiveError.OutOfMemory;
     } else {
         param.value = args[1];
-        if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
+        if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     }
     return types.VOID;
 }
@@ -355,7 +356,7 @@ fn parameterSetDirectFn(args: []const Value) PrimitiveError!Value {
 fn interactionEnvironmentFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocEnvironment(vm.globals, false) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -363,7 +364,7 @@ fn nullEnvironmentFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("null-environment", "integer", args[0]);
     const version = types.toFixnum(args[0]);
     if (version != 5 and version != 7) return primitives.typeError("null-environment", "5 or 7", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;
     env_map.* = std.StringHashMap(Value).init(gc.allocator);
@@ -375,7 +376,7 @@ fn schemeReportEnvironmentFn(args: []const Value) PrimitiveError!Value {
     const version = types.toFixnum(args[0]);
     if (version != 5 and version != 7) return primitives.typeError("scheme-report-environment", "5 or 7", args[0]);
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;
     env_map.* = std.StringHashMap(Value).init(gc.allocator);

--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -87,7 +88,7 @@ fn randomSourcePFn(args: []const Value) PrimitiveError!Value {
 
 fn makeRandomSourceFn(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocRandomSource(0) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -112,7 +113,7 @@ fn randomSourcePseudoRandomizeFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn randomSourceStateRefFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const rs = try getRS("random-source-state-ref", args[0]);
     var result: Value = types.NIL;
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -179,7 +180,7 @@ fn foldFn(args: []const Value) PrimitiveError!Value {
 
 // (fold-right proc init list1 ...)
 fn foldRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     const init = args[1];
     const list_count = args.len - 2;
@@ -249,7 +250,7 @@ fn reduceFn(args: []const Value) PrimitiveError!Value {
 
 // (reduce-right f ridentity list)
 fn reduceRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     const ridentity = args[1];
     const lst = args[2];
@@ -284,7 +285,7 @@ fn reduceRightFn(args: []const Value) PrimitiveError!Value {
 
 // (filter pred list)
 fn filterFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var current = args[1];
 
@@ -316,7 +317,7 @@ fn filterFn(args: []const Value) PrimitiveError!Value {
 
 // (remove pred list) — opposite of filter
 fn removeFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var current = args[1];
 
@@ -347,7 +348,7 @@ fn removeFn(args: []const Value) PrimitiveError!Value {
 
 // (partition pred list) — returns two values: (matching, non-matching)
 fn partitionFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var current = args[1];
 
@@ -553,7 +554,7 @@ fn countFn(args: []const Value) PrimitiveError!Value {
 
 // (iota count) or (iota count start) or (iota count start step)
 fn iotaFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[0]) and !types.isFlonum(args[0])) return primitives.typeError("iota", "number", args[0]);
 
     const count_val = if (types.isFixnum(args[0])) types.toFixnum(args[0]) else @as(i64, @intFromFloat(types.toFlonum(args[0])));
@@ -612,7 +613,7 @@ fn iotaFn(args: []const Value) PrimitiveError!Value {
 
 // (zip list1 list2 ...) — transpose lists into list of lists
 fn zipFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const list_count = args.len;
     if (list_count == 0) return types.NIL;
 
@@ -665,7 +666,7 @@ fn zipFn(args: []const Value) PrimitiveError!Value {
 
 // (concatenate list-of-lists)
 fn concatenateFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     // Collect all sublists
     var sublists: std.ArrayList(Value) = .empty;
@@ -711,7 +712,7 @@ fn concatenateFn(args: []const Value) PrimitiveError!Value {
 
 // (take list k) — first k elements
 fn takeFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[1])) return primitives.typeError("take", "integer", args[1]);
     const k = types.toFixnum(args[1]);
     if (k < 0) return primitives.typeError("take", "non-negative integer", args[1]);
@@ -756,7 +757,7 @@ fn dropFn(args: []const Value) PrimitiveError!Value {
 
 // (take-while pred list)
 fn takeWhileFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var current = args[1];
 
@@ -806,7 +807,7 @@ fn dropWhileFn(args: []const Value) PrimitiveError!Value {
 
 // (filter-map proc list1 ...) — map + filter in one pass
 fn filterMapFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     const list_count = args.len - 1;
     if (list_count == 0) return PrimitiveError.ArityMismatch;
@@ -858,7 +859,7 @@ fn filterMapFn(args: []const Value) PrimitiveError!Value {
 
 // (append-map proc list1 ...) — map then append results
 fn appendMapFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     const list_count = args.len - 1;
     if (list_count == 0) return PrimitiveError.ArityMismatch;
@@ -1041,7 +1042,7 @@ fn memberByPred(pred: Value, elem: Value, list: Value) PrimitiveError!bool {
 
 // (lset-intersection = list1 list2 ...) — elements of list1 in ALL other lists
 fn lsetIntersectionFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     const list1 = args[1];
     const other_count = args.len - 2;
@@ -1082,7 +1083,7 @@ fn lsetIntersectionFn(args: []const Value) PrimitiveError!Value {
 
 // (lset-difference = list1 list2 ...) — elements of list1 NOT in any other list
 fn lsetDifferenceFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     const list1 = args[1];
     const other_count = args.len - 2;
@@ -1157,13 +1158,13 @@ fn lsetEqualFn(args: []const Value) PrimitiveError!Value {
 
 // (xcons d a) — reversed cons: (cons a d)
 fn xconsFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocPair(args[1], args[0]) catch return PrimitiveError.OutOfMemory;
 }
 
 // (cons* a1 a2 ... an) — like list but last element is tail
 fn consStarFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (args.len == 0) return PrimitiveError.ArityMismatch;
     if (args.len == 1) return args[0];
     var result = args[args.len - 1];
@@ -1179,7 +1180,7 @@ fn consStarFn(args: []const Value) PrimitiveError!Value {
 
 // (list-tabulate n init-proc) — build list by calling init-proc on 0..n-1
 fn listTabulateFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[0])) return primitives.typeError("list-tabulate", "integer", args[0]);
     const n = types.toFixnum(args[0]);
     if (n < 0) return primitives.typeError("list-tabulate", "non-negative integer", args[0]);
@@ -1207,7 +1208,7 @@ fn listTabulateFn(args: []const Value) PrimitiveError!Value {
 
 // (circular-list v1 v2 ...) — create circular list
 fn circularListFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (args.len == 0) return types.NIL;
     // Build the list first
     var first: Value = undefined;
@@ -1345,7 +1346,7 @@ fn tenthFn(args: []const Value) PrimitiveError!Value {
 
 // (car+cdr pair) — returns (values (car pair) (cdr pair))
 fn carCdrFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isPair(args[0])) return primitives.typeError("car+cdr", "pair", args[0]);
     const vals = [2]Value{ types.car(args[0]), types.cdr(args[0]) };
     return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
@@ -1377,7 +1378,7 @@ fn takeRightFn(args: []const Value) PrimitiveError!Value {
 
 // (drop-right list k)
 fn dropRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[1])) return primitives.typeError("drop-right", "integer", args[1]);
     const k = types.toFixnum(args[1]);
     if (k < 0) return primitives.typeError("drop-right", "non-negative integer", args[1]);
@@ -1415,7 +1416,7 @@ fn dropRightFn(args: []const Value) PrimitiveError!Value {
 
 // (split-at list k) — returns (values (take list k) (drop list k))
 fn splitAtFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[1])) return primitives.typeError("split-at", "integer", args[1]);
     const k = types.toFixnum(args[1]);
     if (k < 0) return primitives.typeError("split-at", "non-negative integer", args[1]);
@@ -1487,7 +1488,7 @@ fn listIndexFn(args: []const Value) PrimitiveError!Value {
 
 // (span pred list) — returns (values prefix suffix) where prefix is take-while
 fn spanFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var current = args[1];
 
@@ -1517,7 +1518,7 @@ fn spanFn(args: []const Value) PrimitiveError!Value {
 
 // (break pred list) — like span but splits where pred first succeeds
 fn breakFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var current = args[1];
 
@@ -1551,7 +1552,7 @@ fn breakFn(args: []const Value) PrimitiveError!Value {
 
 // (delete x list [=]) — remove all elements equal to x
 fn deleteFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const x = args[0];
     var current = args[1];
     // Optional equality predicate
@@ -1590,7 +1591,7 @@ fn deleteFn(args: []const Value) PrimitiveError!Value {
 
 // (delete-duplicates list [=]) — remove duplicate elements
 fn deleteDuplicatesFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
     const has_pred = args.len > 1;
 
@@ -1640,14 +1641,14 @@ fn deleteDuplicatesFn(args: []const Value) PrimitiveError!Value {
 
 // (alist-cons key datum alist) — (cons (cons key datum) alist)
 fn alistConsFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pair = gc.allocPair(args[0], args[1]) catch return PrimitiveError.OutOfMemory;
     return gc.allocPair(pair, args[2]) catch return PrimitiveError.OutOfMemory;
 }
 
 // (alist-copy alist) — shallow copy of association list
 fn alistCopyFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
 
     var elems: std.ArrayList(Value) = .empty;
@@ -1675,7 +1676,7 @@ fn alistCopyFn(args: []const Value) PrimitiveError!Value {
 
 // (alist-delete key alist [=]) — remove entries with matching key
 fn alistDeleteFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const key = args[0];
     var current = args[1];
     const has_pred = args.len > 2;
@@ -1720,7 +1721,7 @@ fn alistDeleteFn(args: []const Value) PrimitiveError!Value {
 
 // (lset-adjoin = list elt ...) — add elements not already present
 fn lsetAdjoinFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var result = args[1];
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
@@ -1736,7 +1737,7 @@ fn lsetAdjoinFn(args: []const Value) PrimitiveError!Value {
 
 // (lset-union = list1 ...) — union of all lists
 fn lsetUnionFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     const list_count = args.len - 1;
     if (list_count == 0) return types.NIL;
@@ -1761,7 +1762,7 @@ fn lsetUnionFn(args: []const Value) PrimitiveError!Value {
 
 // (lset-xor = list1 ...) — symmetric difference
 fn lsetXorFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     const list_count = args.len - 1;
     if (list_count == 0) return types.NIL;
@@ -1816,7 +1817,7 @@ fn lsetXorFn(args: []const Value) PrimitiveError!Value {
 
 // (unfold p f g seed [tail-gen]) — fundamental list constructor
 fn unfoldFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const p = args[0]; // stop predicate
     const f = args[1]; // map function
     const g = args[2]; // successor
@@ -1860,7 +1861,7 @@ fn unfoldFn(args: []const Value) PrimitiveError!Value {
 
 // (unfold-right p f g seed [tail]) — build list from right
 fn unfoldRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const p = args[0];
     const f = args[1];
     const g = args[2];
@@ -1890,7 +1891,7 @@ fn unfoldRightFn(args: []const Value) PrimitiveError!Value {
 
 // (append-reverse rev-head tail) — (append (reverse rev-head) tail)
 fn appendReverseFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
     var result = args[1];
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
@@ -1932,7 +1933,7 @@ fn lengthPlusFn(args: []const Value) PrimitiveError!Value {
 
 // (unzip1 list) — map car
 fn unzip1Fn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
@@ -1958,7 +1959,7 @@ fn unzip1Fn(args: []const Value) PrimitiveError!Value {
 
 // (unzip2 list) — returns (values (map car list) (map cadr list))
 fn unzip2Fn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
     var firsts: std.ArrayList(Value) = .empty;
     defer firsts.deinit(gc.allocator);
@@ -2071,7 +2072,7 @@ fn pairFoldFn(args: []const Value) PrimitiveError!Value {
 
 // (pair-fold-right kons knil list1 ...) — like fold-right but passes pairs
 fn pairFoldRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     const init = args[1];
     const list_count = args.len - 2;
@@ -2108,7 +2109,7 @@ fn pairFoldRightFn(args: []const Value) PrimitiveError!Value {
 
 // (map-in-order proc list1 ...) — same as map, guarantees left-to-right
 fn mapInOrderFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     const list_count = args.len - 1;
     if (list_count == 0) return PrimitiveError.ArityMismatch;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -72,7 +72,7 @@ pub fn registerSrfi18(vm: *vm_mod.VM) !void {
 fn ensureScheduler() PrimitiveError!struct { vm: *vm_mod.VM, sched: *fiber_mod.FiberScheduler } {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     if (vm.scheduler == null) {
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const sched = gc.allocator.create(fiber_mod.FiberScheduler) catch return PrimitiveError.OutOfMemory;
         sched.* = fiber_mod.FiberScheduler.init(vm);
         const main_fiber = gc.allocFiber(types.VOID, sched.next_id) catch return PrimitiveError.OutOfMemory;
@@ -105,7 +105,7 @@ fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
 }
 
 fn makeErrorWithType(error_type: types.ErrorObject.ErrorType, msg: []const u8, reason: Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
     var msg_root = message;
     gc.pushRoot(&msg_root) catch return PrimitiveError.OutOfMemory;
@@ -166,7 +166,7 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("make-thread", "procedure", thunk);
 
     const ctx = try ensureScheduler();
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     const fiber = gc.allocFiber(thunk, ctx.sched.next_id) catch return PrimitiveError.OutOfMemory;
     ctx.sched.next_id += 1;
@@ -211,7 +211,7 @@ fn threadSpecificSetFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("thread-specific-set!", "thread", args[0]);
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
     fiber.specific = args[1];
-    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     return types.VOID;
 }
 
@@ -224,7 +224,7 @@ fn threadStartFn(args: []const Value) PrimitiveError!Value {
     if (fiber.status != .created)
         return primitives.typeError("thread-start!", "new thread", args[0]);
 
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
 
     // Root the thunk (the child deep-copies it from the parent heap) and the
@@ -266,7 +266,7 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_g
     };
 
     vm_mod.vm_instance = child_vm;
-    primitives.gc_instance = child_gc;
+    memory.gc_instance = child_gc;
 
     // Let thread-terminate! from the parent stop this thread: the dispatch
     // loop safepoint polls this flag and unwinds with VMError.Terminated.
@@ -378,7 +378,7 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
     // Atomic: for OS threads the child VM polls this flag concurrently.
     @atomicStore(bool, &fiber.terminated, true, .monotonic);
 
-    if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, ctx.sched);
+    if (memory.gc_instance) |gc| abandonFiberMutexes(gc, fiber, ctx.sched);
 
     if (fiber.status != .completed and fiber.status != .errored) {
         fiber.status = .errored;
@@ -491,7 +491,7 @@ fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value
         target.os_thread = null;
     }
 
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     // Remove the thunk and fiber from extra_roots (added by thread-start!
     // to keep them alive while the child runs; the child is done now).
@@ -597,7 +597,7 @@ fn runSchedulerUntilDone(target: *fiber_mod.Fiber) PrimitiveError!void {
             // Fiber 0 is the main fiber: finishing or aborting one top-level
             // form is not thread death, so its mutexes stay valid.
             if (next_idx != 0) {
-                if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
+                if (memory.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
             }
             sched.saveCurrentFiber();
             sched.wakeWaiters(fiber);
@@ -605,7 +605,7 @@ fn runSchedulerUntilDone(target: *fiber_mod.Fiber) PrimitiveError!void {
         };
         fiber.status = .completed;
         fiber.result = result;
-        if (primitives.gc_instance) |gc| {
+        if (memory.gc_instance) |gc| {
             gc.writeBarrier(&fiber.header, result);
             if (next_idx != 0) abandonFiberMutexes(gc, fiber, sched);
         }
@@ -629,7 +629,7 @@ fn mutexPredFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn makeMutexFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const name = if (args.len > 0) args[0] else types.VOID;
     return gc.allocMutex(name) catch return PrimitiveError.OutOfMemory;
 }
@@ -650,7 +650,7 @@ fn mutexSpecificSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isMutex(args[0]))
         return primitives.typeError("mutex-specific-set!", "mutex", args[0]);
     types.toMutex(args[0]).specific = args[1];
-    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     return types.VOID;
 }
 
@@ -660,14 +660,14 @@ fn mutexStateFn(args: []const Value) PrimitiveError!Value {
     const m = types.toMutex(args[0]);
     if (!m.locked) {
         if (m.abandoned) {
-            const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             return gc.allocSymbol("abandoned") catch return PrimitiveError.OutOfMemory;
         }
-        const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         return gc.allocSymbol("not-abandoned") catch return PrimitiveError.OutOfMemory;
     }
     if (m.owner != types.VOID) return m.owner;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocSymbol("not-owned") catch return PrimitiveError.OutOfMemory;
 }
 
@@ -766,7 +766,7 @@ fn runSchedulerUntilMutex(m: *types.Mutex, me: *fiber_mod.Fiber) PrimitiveError!
             // Fiber 0 is the main fiber: finishing or aborting one top-level
             // form is not thread death, so its mutexes stay valid.
             if (next_idx != 0) {
-                if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
+                if (memory.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
             }
             sched.saveCurrentFiber();
             sched.wakeWaiters(fiber);
@@ -774,7 +774,7 @@ fn runSchedulerUntilMutex(m: *types.Mutex, me: *fiber_mod.Fiber) PrimitiveError!
         };
         fiber.status = .completed;
         fiber.result = result;
-        if (primitives.gc_instance) |gc| {
+        if (memory.gc_instance) |gc| {
             gc.writeBarrier(&fiber.header, result);
             if (next_idx != 0) abandonFiberMutexes(gc, fiber, sched);
         }
@@ -853,7 +853,7 @@ fn runSchedulerUntilCondVar(me: *fiber_mod.Fiber) PrimitiveError!void {
             // Fiber 0 is the main fiber: finishing or aborting one top-level
             // form is not thread death, so its mutexes stay valid.
             if (next_idx != 0) {
-                if (primitives.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
+                if (memory.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
             }
             sched.saveCurrentFiber();
             sched.wakeWaiters(fiber);
@@ -861,7 +861,7 @@ fn runSchedulerUntilCondVar(me: *fiber_mod.Fiber) PrimitiveError!void {
         };
         fiber.status = .completed;
         fiber.result = result;
-        if (primitives.gc_instance) |gc| {
+        if (memory.gc_instance) |gc| {
             gc.writeBarrier(&fiber.header, result);
             if (next_idx != 0) abandonFiberMutexes(gc, fiber, sched);
         }
@@ -884,7 +884,7 @@ fn condvarPredFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn makeCondvarFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const name = if (args.len > 0) args[0] else types.VOID;
     return gc.allocConditionVariable(name) catch return PrimitiveError.OutOfMemory;
 }
@@ -905,7 +905,7 @@ fn condvarSpecificSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isConditionVariable(args[0]))
         return primitives.typeError("condition-variable-specific-set!", "condition-variable", args[0]);
     types.toConditionVariable(args[0]).specific = args[1];
-    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     return types.VOID;
 }
 
@@ -930,7 +930,7 @@ fn condvarBroadcastFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn currentTimeFn(_: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var ts: std.c.timespec = undefined;
     _ = std.c.clock_gettime(.REALTIME, &ts);
     const seconds = @as(f64, @floatFromInt(ts.sec)) + @as(f64, @floatFromInt(ts.nsec)) / 1_000_000_000.0;
@@ -948,7 +948,7 @@ fn timeToSecondsFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn secondsToTimeFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const secs = primitives.toF64(args[0]) catch
         return primitives.typeError("seconds->time", "number", args[0]);
     return gc.allocSrfi18Time(secs) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -119,7 +120,7 @@ pub fn utf8ByteLenAt(data: []const u8, byte_offset: usize) usize {
 // ---------------------------------------------------------------------------
 
 fn stringFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     // Calculate total UTF-8 length
     var total: usize = 0;
     for (args) |a| {
@@ -145,7 +146,7 @@ fn stringFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn makeStringFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[0])) return primitives.typeError("make-string", "exact integer", args[0]);
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("make-string", "non-negative integer", args[0]);
@@ -189,7 +190,7 @@ fn stringSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string-set!", "string", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-set!", "exact integer", args[1]);
     if (!types.isChar(args[2])) return primitives.typeError("string-set!", "character", args[2]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     if (str.immutable) return primitives.typeError("string-set!", "mutable string", args[0]);
     const data = str.data[0..str.len];
@@ -228,7 +229,7 @@ fn stringSetFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn substringFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("substring", "exact integer", args[1]);
     if (!types.isFixnum(args[2])) return primitives.typeError("substring", "exact integer", args[2]);
@@ -250,7 +251,7 @@ fn substringFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn stringCopyFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     const cp_count = utf8CodepointCount(data);
     const range = try primitives.parseOptionalRange(args, 1, cp_count, "string-copy");
@@ -268,7 +269,7 @@ fn stringCopyFn(args: []const Value) PrimitiveError!Value {
 fn stringCopyBangFn(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string-copy!", "string", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-copy!", "exact integer", args[1]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const to_str = types.toObject(args[0]).as(types.SchemeString);
     if (to_str.immutable) return primitives.typeError("string-copy!", "mutable string", args[0]);
     const to_data = to_str.data[0..to_str.len];
@@ -325,7 +326,7 @@ fn stringCopyBangFn(args: []const Value) PrimitiveError!Value {
 fn stringFillFn(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string-fill!", "string", args[0]);
     if (!types.isChar(args[1])) return primitives.typeError("string-fill!", "character", args[1]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     if (str.immutable) return primitives.typeError("string-fill!", "mutable string", args[0]);
     const data = str.data[0..str.len];
@@ -364,7 +365,7 @@ fn stringFillFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn stringToListFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     const cp_count = utf8CodepointCount(data);
     const range = try primitives.parseOptionalRange(args, 1, cp_count, "string->list");
@@ -399,7 +400,7 @@ fn stringToListFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn listToStringFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     // Count chars and calculate utf8 length
     var total: usize = 0;
     var current = args[0];
@@ -431,7 +432,7 @@ fn listToStringFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn stringToSymbolFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     return gc.allocSymbol(data) catch return PrimitiveError.OutOfMemory;
 }
@@ -442,7 +443,7 @@ fn stringToSymbolFn(args: []const Value) PrimitiveError!Value {
 
 fn stringToVectorFn(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string->vector", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const data = str.data[0..str.len];
     const cp_count = utf8CodepointCount(data);
@@ -523,7 +524,7 @@ fn stringForEachFn(args: []const Value) PrimitiveError!Value {
 
 fn stringMapFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("string-map", "procedure", proc);
 
@@ -611,7 +612,7 @@ fn stringGtFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn numberToStringFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (types.isFixnum(args[0])) {
         var buf: [32]u8 = undefined;
         const s = std.fmt.bufPrint(&buf, "{d}", .{types.toFixnum(args[0])}) catch return PrimitiveError.OutOfMemory;
@@ -628,7 +629,7 @@ fn numberToStringFn(args: []const Value) PrimitiveError!Value {
 
 fn stringToNumberFn(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string->number", "string", args[0]);
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const s = try getStringSlice(args[0]);
 
     if (std.mem.eql(u8, s, "+inf.0")) return types.makeFlonum(std.math.inf(f64));

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const pstr = @import("primitives_string.zig");
 const pchar = @import("primitives_char.zig");
 const unicode = @import("unicode_tables.zig");
@@ -165,7 +166,7 @@ fn findPrevCpStart(data: []const u8, pos: usize) usize {
 
 // (string-trim s [pred [start end]])
 fn stringTrimFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const full_data = try getStringSlice(args[0]);
     if (args.len <= 1) {
         var start: usize = 0;
@@ -187,7 +188,7 @@ fn stringTrimFn(args: []const Value) PrimitiveError!Value {
 
 // (string-trim-right s [pred [start end]])
 fn stringTrimRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const full_data = try getStringSlice(args[0]);
     if (args.len <= 1) {
         var end: usize = full_data.len;
@@ -210,7 +211,7 @@ fn stringTrimRightFn(args: []const Value) PrimitiveError!Value {
 
 // (string-trim-both s [pred [start end]])
 fn stringTrimBothFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const full_data = try getStringSlice(args[0]);
     if (args.len <= 1) {
         var start: usize = 0;
@@ -275,7 +276,7 @@ fn stringCountFn(args: []const Value) PrimitiveError!Value {
 
 // (string-split s delimiter) -> list of strings
 fn stringSplitFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     const delim = try getStringSlice(args[1]);
 
@@ -334,7 +335,7 @@ fn stringSplitFn(args: []const Value) PrimitiveError!Value {
 
 // (string-join list-of-strings) or (string-join list-of-strings delimiter)
 fn stringJoinFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const delim: []const u8 = if (args.len > 1)
         (try getStringSlice(args[1]))
     else
@@ -375,7 +376,7 @@ fn stringJoinFn(args: []const Value) PrimitiveError!Value {
 
 // (string-concatenate list-of-strings) -> string
 fn stringConcatenateFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var total: usize = 0;
     var current = args[0];
     while (current != types.NIL) {
@@ -409,7 +410,7 @@ fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
 }
 
 fn stringTakeFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-take", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
@@ -420,7 +421,7 @@ fn stringTakeFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn stringDropFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-drop", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
@@ -431,7 +432,7 @@ fn stringDropFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn stringTakeRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-take-right", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
@@ -445,7 +446,7 @@ fn stringTakeRightFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn stringDropRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-drop-right", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
@@ -459,7 +460,7 @@ fn stringDropRightFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn stringPadFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const full_data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-pad", "integer", args[1]);
     const tlv = types.toFixnum(args[1]);
@@ -487,7 +488,7 @@ fn stringPadFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn stringPadRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const full_data = try getStringSlice(args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-pad-right", "integer", args[1]);
     const tlv = types.toFixnum(args[1]);
@@ -516,7 +517,7 @@ fn stringPadRightFn(args: []const Value) PrimitiveError!Value {
 
 // (string-reverse s [start end])
 fn stringReverseFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const full_data = try getStringSlice(args[0]);
     const r = try parseStartEnd(full_data, args, 1);
     const data = r.data;
@@ -545,7 +546,7 @@ fn stringReverseFn(args: []const Value) PrimitiveError!Value {
 
 // (string-filter pred s [start end])
 fn stringFilterFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     const full_data = try getStringSlice(args[1]);
     const range = try parseStartEnd(full_data, args, 2);
@@ -567,7 +568,7 @@ fn stringFilterFn(args: []const Value) PrimitiveError!Value {
 
 // (string-delete pred s [start end])
 fn stringDeleteFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     const full_data = try getStringSlice(args[1]);
     const range = try parseStartEnd(full_data, args, 2);
@@ -588,7 +589,7 @@ fn stringDeleteFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data1 = try getStringSlice(args[0]);
     const data2 = try getStringSlice(args[1]);
     if (!types.isFixnum(args[2]) or !types.isFixnum(args[3])) return primitives.typeError("string-replace", "integer", if (!types.isFixnum(args[2])) args[2] else args[3]);
@@ -612,7 +613,7 @@ fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
 
 // (string-titlecase s [start end])
 fn stringTitlecaseFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const full_data = try getStringSlice(args[0]);
     const range = try parseStartEnd(full_data, args, 1);
     const data = range.data;
@@ -772,7 +773,7 @@ fn stringAnyFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn stringTabulateFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     if (!types.isFixnum(args[1])) return primitives.typeError("string-tabulate", "integer", args[1]);
     const lv = types.toFixnum(args[1]);
@@ -796,7 +797,7 @@ fn stringTabulateFn(args: []const Value) PrimitiveError!Value {
 
 // (string-unfold p f g seed [base [make-final]])
 fn stringUnfoldFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const p = args[0];
     const f = args[1];
     const g = args[2];
@@ -833,7 +834,7 @@ fn stringUnfoldFn(args: []const Value) PrimitiveError!Value {
 
 // (string-unfold-right p f g seed [base [make-final]])
 fn stringUnfoldRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const p = args[0];
     const f = args[1];
     const g = args[2];

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const memory = @import("memory.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -52,7 +53,7 @@ pub fn registerVector(vm: *vm_mod.VM) !void {
 // ---------------------------------------------------------------------------
 
 fn vectorFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocVector(args) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -61,7 +62,7 @@ fn vectorFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn makeVectorFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[0])) return primitives.typeError("make-vector", "exact non-negative integer", args[0]);
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("make-vector", "exact non-negative integer", args[0]);
@@ -111,7 +112,7 @@ fn vectorSetFn(args: []const Value) PrimitiveError!Value {
     const vec = types.toVector(args[0]);
     const k = types.toFixnum(args[1]);
     if (k < 0 or @as(usize, @intCast(k)) >= vec.data.len) return primitives.indexError("vector-set!", k, vec.data.len);
-    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     vec.data[@intCast(k)] = args[2];
     return types.VOID;
 }
@@ -121,7 +122,7 @@ fn vectorSetFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn vectorToListFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isVector(args[0])) return primitives.typeError("vector->list", "vector", args[0]);
     const vec = types.toVector(args[0]);
     const len = vec.data.len;
@@ -146,7 +147,7 @@ fn vectorToListFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn listToVectorFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     // Count elements
     var count: usize = 0;
@@ -180,7 +181,7 @@ fn vectorFillFn(args: []const Value) PrimitiveError!Value {
     const range = try primitives.parseOptionalRange(args, 2, len, "vector-fill!");
     const start = range.start;
     const end = range.end;
-    if (primitives.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     @memset(vec.data[start..end], args[1]);
     return types.VOID;
 }
@@ -190,7 +191,7 @@ fn vectorFillFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn vectorCopyFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isVector(args[0])) return primitives.typeError("vector-copy", "vector", args[0]);
     const vec = types.toVector(args[0]);
     const len = vec.data.len;
@@ -226,7 +227,7 @@ fn vectorCopyBangFn(args: []const Value) PrimitiveError!Value {
     const count = end - start;
     if (at + count > to_vec.data.len) return primitives.typeError("vector-copy!", "valid index range", args[1]);
 
-    if (primitives.gc_instance) |gc| {
+    if (memory.gc_instance) |gc| {
         for (from_vec.data[start..end]) |val| {
             gc.writeBarrier(types.toObject(args[0]), val);
         }
@@ -251,7 +252,7 @@ fn vectorCopyBangFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn vectorAppendFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     // Calculate total length
     var total: usize = 0;
@@ -279,7 +280,7 @@ fn vectorAppendFn(args: []const Value) PrimitiveError!Value {
 
 fn vectorForEachFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("vector-for-each", "procedure", proc);
 
@@ -320,7 +321,7 @@ fn vectorForEachFn(args: []const Value) PrimitiveError!Value {
 
 fn vectorMapFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("vector-map", "procedure", proc);
 
@@ -367,7 +368,7 @@ fn vectorMapFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn vectorToStringFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isVector(args[0])) return primitives.typeError("vector->string", "vector", args[0]);
     const vec = types.toVector(args[0]);
     const len = vec.data.len;
@@ -434,7 +435,7 @@ fn vectorEmptyFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-count pred v1 ...)
 fn vectorCountFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     if (!types.isVector(args[1])) return primitives.typeError("vector-count", "vector", args[1]);
     const vec = types.toVector(args[1]);
@@ -468,7 +469,7 @@ fn vectorCountFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-any pred v1 ...)
 fn vectorAnyFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     if (!types.isVector(args[1])) return primitives.typeError("vector-any", "vector", args[1]);
     const vec = types.toVector(args[1]);
@@ -497,7 +498,7 @@ fn vectorAnyFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-every pred v1 ...)
 fn vectorEveryFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     if (!types.isVector(args[1])) return primitives.typeError("vector-every", "vector", args[1]);
     const vec = types.toVector(args[1]);
@@ -528,7 +529,7 @@ fn vectorEveryFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-index pred v1 ...)
 fn vectorIndexFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     if (!types.isVector(args[1])) return primitives.typeError("vector-index", "vector", args[1]);
     const vec = types.toVector(args[1]);
@@ -557,7 +558,7 @@ fn vectorIndexFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-index-right pred v1 ...)
 fn vectorIndexRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     if (!types.isVector(args[1])) return primitives.typeError("vector-index-right", "vector", args[1]);
     const vec = types.toVector(args[1]);
@@ -671,7 +672,7 @@ fn vectorReverseBangFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-reverse-copy vec [start [end]])
 fn vectorReverseCopyFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isVector(args[0])) return primitives.typeError("vector-reverse-copy", "vector", args[0]);
     const vec = types.toVector(args[0]);
     var start: usize = 0;
@@ -700,7 +701,7 @@ fn vectorReverseCopyFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-unfold f length [seeds ...])
 fn vectorUnfoldFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const f = args[0];
     if (!types.isFixnum(args[1])) return primitives.typeError("vector-unfold", "exact non-negative integer", args[1]);
     const len_val = types.toFixnum(args[1]);
@@ -756,7 +757,7 @@ fn vectorUnfoldFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-unfold-right f length [seeds ...])
 fn vectorUnfoldRightFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const f = args[0];
     if (!types.isFixnum(args[1])) return primitives.typeError("vector-unfold-right", "exact non-negative integer", args[1]);
     const len_val = types.toFixnum(args[1]);
@@ -837,7 +838,7 @@ fn vectorBinarySearchFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-concatenate list-of-vectors)
 fn vectorConcatenateFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
     var total_len: usize = 0;
     // First pass: compute total length
@@ -863,7 +864,7 @@ fn vectorConcatenateFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-cumulate f knil vec)
 fn vectorCumulateFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const f = args[0];
     var acc = args[1];
     if (!types.isVector(args[2])) return primitives.typeError("vector-cumulate", "vector", args[2]);
@@ -883,7 +884,7 @@ fn vectorCumulateFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-partition pred vec)
 fn vectorPartitionFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     if (!types.isVector(args[1])) return primitives.typeError("vector-partition", "vector", args[1]);
     const vec = types.toVector(args[1]);
@@ -924,7 +925,7 @@ fn vectorPartitionFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn vectorAppendSubvectorsFn(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (args.len % 3 != 0) return primitives.typeError("vector-append-subvectors", "multiple of 3 arguments", types.makeFixnum(@intCast(args.len)));
 
     var total: usize = 0;

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -26,7 +26,7 @@ export fn kaappi_runtime_init() callconv(.c) ?*vm_mod.VM {
         allocator.destroy(vm);
         return null;
     };
-    primitives.setGCInstance(&rt_gc);
+    memory.setGCInstance(&rt_gc);
     library.registerStandardLibraries(&vm.libraries, vm.globals) catch {
         vm.deinit();
         allocator.destroy(vm);
@@ -195,7 +195,7 @@ export fn kaappi_cdr(v: u64) callconv(.c) u64 {
 }
 
 export fn kaappi_cons(a: u64, b: u64) callconv(.c) u64 {
-    const gc = primitives.gc_instance orelse return 0;
+    const gc = memory.gc_instance orelse return 0;
     var val_a = a;
     var val_b = b;
     gc.pushRoot(&val_a) catch return 0;

--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -10,7 +10,7 @@ pub const Value = types.Value;
 
 pub fn makeTestVM(gc: *memory.GC) !VM {
     var vm = try VM.init(gc);
-    primitives_mod.setGCInstance(gc);
+    memory.setGCInstance(gc);
     try primitives_mod.registerAll(&vm);
     try library_mod.registerStandardLibraries(&vm.libraries, vm.globals);
     return vm;

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -79,7 +79,7 @@ test "fuzz eval" {
             }
             vm_mod.setVMInstance(vm);
             primitives.registerAll(vm) catch return;
-            primitives.setGCInstance(&gc);
+            memory.setGCInstance(&gc);
             library.registerStandardLibraries(&vm.libraries, vm.globals) catch return;
             vm.timeout_deadline_ns = @import("vm_calls.zig").clockNs() + 100_000_000;
             _ = vm.eval(input) catch return;


### PR DESCRIPTION
## Summary
- Move `gc_instance` threadlocal var and `setGCInstance` from `primitives.zig` to `memory.zig`, next to the GC struct it references
- Update all 27 files that referenced `primitives.gc_instance` / `primitives.setGCInstance` to use `memory.gc_instance` / `memory.setGCInstance`
- Clean up duplicate `@import("memory.zig")` calls in `primitives_filesystem.zig` and `primitives_hashtable.zig`

## Test plan
- [x] `zig build test` passes
- [x] `grep -rn 'primitives.gc_instance\|primitives.setGCInstance' src/` returns no matches
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)