### PR TITLE
Break compiler→VM circular dependency via globals.zig

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -7,7 +7,7 @@ const advanced = @import("compiler_advanced.zig");
 const passthrough = @import("compiler_passthrough.zig");
 const ir_mod = @import("ir.zig");
 const compiler_ir = @import("compiler_ir.zig");
-const vm_mod = @import("vm.zig");
+const globals_mod = @import("globals.zig");
 const Value = types.Value;
 const OpCode = types.OpCode;
 
@@ -730,8 +730,8 @@ pub const Compiler = struct {
                     // child-thread readers for the whole dance (#958). glk is
                     // non-null exactly when g is the current thread's shared
                     // globals map.
-                    const glk = vm_mod.acquireGlobalsWrite(g);
-                    defer vm_mod.releaseGlobalsWrite(glk);
+                    const glk = globals_mod.acquireGlobalsWrite(g);
+                    defer globals_mod.releaseGlobalsWrite(glk);
                     for (tx.captured_locals) |cap| {
                         if (!g.contains(cap.name) and temp_global_count < 128) {
                             temp_globals[temp_global_count] = .{ .name = cap.name, .old_val = null, .was_present = false };
@@ -751,7 +751,7 @@ pub const Compiler = struct {
                     }
                     // Temporarily mark non-procedure free globals as VOID so
                     // renameForHygiene preserves them.
-                    if (vm_mod.vm_instance) |vm| {
+                    if (globals_mod.globals_ctx) |gctx| {
                         var cand_names: [64][]const u8 = undefined;
                         var cand_count: usize = 0;
                         var pv_names: [64][]const u8 = undefined;
@@ -770,11 +770,11 @@ pub const Compiler = struct {
                             // and we already hold its exclusive lock; else
                             // this read needs its own child-thread lock.
                             const in_vm = if (glk != null)
-                                (if (vm.globals.count() > 0) vm.globals.get(cname) else null)
+                                (if (gctx.globals.count() > 0) gctx.globals.get(cname) else null)
                             else in_vm_blk: {
-                                vm.lockGlobalsShared();
-                                defer vm.unlockGlobalsShared();
-                                break :in_vm_blk if (vm.globals.count() > 0) vm.globals.get(cname) else null;
+                                gctx.lockShared();
+                                defer gctx.unlockShared();
+                                break :in_vm_blk if (gctx.globals.count() > 0) gctx.globals.get(cname) else null;
                             };
                             const existing = in_g orelse in_vm;
                             if (existing) |val| {
@@ -795,7 +795,7 @@ pub const Compiler = struct {
                     }
                 }
                 defer if (self.globals) |g| {
-                    const glk = vm_mod.acquireGlobalsWrite(g);
+                    const glk = globals_mod.acquireGlobalsWrite(g);
                     for (temp_globals[0..temp_global_count]) |tg| {
                         if (tg.was_present) {
                             g.put(tg.name, tg.old_val.?) catch {};
@@ -803,7 +803,7 @@ pub const Compiler = struct {
                             _ = g.remove(tg.name);
                         }
                     }
-                    vm_mod.releaseGlobalsWrite(glk);
+                    globals_mod.releaseGlobalsWrite(glk);
                 };
                 // Suppress GC during expansion: the expanded form isn't
                 // rooted until pushRoot below, so a collection triggered

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -3,7 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const passthrough = @import("compiler_passthrough.zig");
-const vm_mod = @import("vm.zig");
+const globals_mod = @import("globals.zig");
 const Value = types.Value;
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
@@ -546,8 +546,8 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
     if (self.globals) |globals| {
         // Structural puts into the (possibly shared) globals map — exclude
         // SRFI-18 child-thread readers while sentinels are planted (#958).
-        const glk = vm_mod.acquireGlobalsWrite(globals);
-        defer vm_mod.releaseGlobalsWrite(glk);
+        const glk = globals_mod.acquireGlobalsWrite(globals);
+        defer globals_mod.releaseGlobalsWrite(glk);
         var scan = body;
         while (scan != types.NIL and types.isPair(scan)) {
             const form = types.car(scan);
@@ -585,7 +585,7 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
     defer {
         // Clean up pre-scanned names that are still VOID (not actually defined)
         if (self.globals) |globals| {
-            const glk = vm_mod.acquireGlobalsWrite(globals);
+            const glk = globals_mod.acquireGlobalsWrite(globals);
             for (prescan_names[0..prescan_count]) |pn| {
                 if (globals.get(pn)) |val| {
                     if (val == types.VOID) {
@@ -593,7 +593,7 @@ pub fn compileLetBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Com
                     }
                 }
             }
-            vm_mod.releaseGlobalsWrite(glk);
+            globals_mod.releaseGlobalsWrite(glk);
         }
     }
 

--- a/src/compiler_conditionals.zig
+++ b/src/compiler_conditionals.zig
@@ -369,11 +369,7 @@ pub fn evalFeatureReq(self: *Compiler, req: Value) bool {
                 if (std.mem.eql(u8, lib_name, l)) return true;
             }
             // Check the VM's live library registry and .sld files on disk
-            const vm_mod = @import("vm.zig");
-            if (vm_mod.vm_instance) |vm| {
-                if (vm.libraries.get(lib_name) != null) return true;
-                return @import("vm_library.zig").libraryFileExists(vm, lib_name_list);
-            }
+            if (@import("globals.zig").libraryExists(lib_name, lib_name_list)) return true;
             return false;
         }
     }

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
-const vm_mod = @import("vm.zig");
+const globals_mod = @import("globals.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
@@ -107,8 +107,8 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
     if (self.globals) |globals| {
         // Structural puts into the (possibly shared) globals map — exclude
         // SRFI-18 child-thread readers while sentinels are planted (#958).
-        const glk = vm_mod.acquireGlobalsWrite(globals);
-        defer vm_mod.releaseGlobalsWrite(glk);
+        const glk = globals_mod.acquireGlobalsWrite(globals);
+        defer globals_mod.releaseGlobalsWrite(glk);
         var scan = body;
         while (scan != types.NIL and types.isPair(scan)) {
             const form = types.car(scan);
@@ -142,13 +142,13 @@ pub fn compileBody(self: *Compiler, body: Value) CompileError!void {
     }
     defer {
         if (self.globals) |globals| {
-            const glk = vm_mod.acquireGlobalsWrite(globals);
+            const glk = globals_mod.acquireGlobalsWrite(globals);
             for (prescan_names.items) |pn| {
                 if (globals.get(pn)) |val| {
                     if (val == types.VOID) _ = globals.remove(pn);
                 }
             }
-            vm_mod.releaseGlobalsWrite(glk);
+            globals_mod.releaseGlobalsWrite(glk);
         }
     }
 

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const expander = @import("expander.zig");
 const compiler_mod = @import("compiler.zig");
-const vm_mod = @import("vm.zig");
+const globals_mod = @import("globals.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
@@ -226,8 +226,8 @@ fn tryConstantFold(self: *Compiler, expr: Value, dst: u16) bool {
     if (self.resolveLocal(name) != null) return false;
     if ((self.resolveUpvalue(name) catch null) != null) return false;
     if (self.globals) |globals| {
-        const glk = vm_mod.acquireGlobalsRead(globals);
-        defer vm_mod.releaseGlobalsRead(glk);
+        const glk = globals_mod.acquireGlobalsRead(globals);
+        defer globals_mod.releaseGlobalsRead(glk);
         if (globals.get(name)) |val| {
             if (!types.isPointer(val)) return false;
             const obj = types.toObject(val);

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -762,10 +762,10 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
     if (std.mem.startsWith(u8, name, "__hyg_")) return gc.allocSymbol(name);
     const in_binding = (scope & BINDING_FLAG) != 0;
     const clean_scope = scope & ~BINDING_FLAG;
-    const vm_mod = @import("vm.zig");
+    const gmod = @import("globals.zig");
     if (globals) |g| {
-        const glk = vm_mod.acquireGlobalsRead(g);
-        defer vm_mod.releaseGlobalsRead(glk);
+        const glk = gmod.acquireGlobalsRead(g);
+        defer gmod.releaseGlobalsRead(glk);
         if (g.get(name)) |val| {
             if (types.isProcedure(val) or types.isTransformer(val)) {
                 // A template binding of the same name in this expansion
@@ -789,10 +789,10 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
             }
         }
     }
-    if (vm_mod.vm_instance) |vm| {
-        vm.lockGlobalsShared();
-        const found = vm.globals.get(name);
-        vm.unlockGlobalsShared();
+    if (gmod.globals_ctx) |gctx| {
+        gctx.lockShared();
+        const found = gctx.globals.get(name);
+        gctx.unlockShared();
         if (found) |val| {
             if (types.isTransformer(val)) return gc.allocSymbol(name);
         }

--- a/src/globals.zig
+++ b/src/globals.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const types = @import("types.zig");
+const Value = types.Value;
+
+/// Minimal portable reader-writer spinlock (Zig 0.16 has no blocking
+/// std.Thread.RwLock; std.Io.RwLock needs an Io instance). Writer-preferring:
+/// once a writer sets its bit, new readers spin, existing readers drain, then
+/// the writer runs. Critical sections here are single hash-map operations, so
+/// spinning is bounded and short. Not reentrant — never nest acquisitions.
+pub const GlobalsRwLock = struct {
+    /// Bit 31 = writer holds/wants the lock; low 31 bits = active readers.
+    state: std.atomic.Value(u32) = .init(0),
+
+    const WRITER: u32 = 0x8000_0000;
+
+    pub fn lockShared(self: *GlobalsRwLock) void {
+        while (true) {
+            const s = self.state.load(.monotonic);
+            if (s & WRITER == 0) {
+                if (self.state.cmpxchgWeak(s, s + 1, .acquire, .monotonic) == null) return;
+            }
+            std.atomic.spinLoopHint();
+        }
+    }
+
+    pub fn unlockShared(self: *GlobalsRwLock) void {
+        _ = self.state.fetchSub(1, .release);
+    }
+
+    pub fn lock(self: *GlobalsRwLock) void {
+        while (true) {
+            const s = self.state.load(.monotonic);
+            if (s & WRITER == 0) {
+                if (self.state.cmpxchgWeak(s, s | WRITER, .acquire, .monotonic) == null) break;
+            }
+            std.atomic.spinLoopHint();
+        }
+        while (self.state.load(.acquire) != WRITER) std.atomic.spinLoopHint();
+    }
+
+    pub fn unlock(self: *GlobalsRwLock) void {
+        self.state.store(0, .release);
+    }
+};
+
+/// Thread-local snapshot of the VM's globals state, set by setVMInstance()
+/// and used by the compiler/expander for thread-safe globals access without
+/// importing vm.zig.
+pub const GlobalsContext = struct {
+    globals: *std.StringHashMap(Value),
+    globals_lock: *GlobalsRwLock,
+    owns_globals: bool,
+
+    pub fn lockShared(self: GlobalsContext) void {
+        if (!self.owns_globals) self.globals_lock.lockShared();
+    }
+
+    pub fn unlockShared(self: GlobalsContext) void {
+        if (!self.owns_globals) self.globals_lock.unlockShared();
+    }
+};
+
+pub threadlocal var globals_ctx: ?GlobalsContext = null;
+
+pub fn setGlobalsContext(ctx: GlobalsContext) void {
+    globals_ctx = ctx;
+}
+
+pub fn clearGlobalsContext() void {
+    globals_ctx = null;
+}
+
+/// Take the exclusive globals lock if `map` is the current thread's shared
+/// globals map, for compile-time code that only holds a map pointer (body
+/// prescans, macro-expansion temp globals). Returns the lock to hand to
+/// releaseGlobalsWrite, or null when no locking applies: `map` is a library
+/// env, or no VM is registered on this thread yet (startup — no child
+/// threads can exist before the first execute()).
+pub fn acquireGlobalsWrite(map: *const std.StringHashMap(Value)) ?*GlobalsRwLock {
+    const ctx = globals_ctx orelse return null;
+    if (@as(*const std.StringHashMap(Value), ctx.globals) != map) return null;
+    ctx.globals_lock.lock();
+    return ctx.globals_lock;
+}
+
+pub fn releaseGlobalsWrite(lock_arg: ?*GlobalsRwLock) void {
+    if (lock_arg) |l| l.unlock();
+}
+
+/// Shared-lock counterpart of acquireGlobalsWrite for read-only compile-time
+/// access. No-ops on the owner thread (its reads cannot race its own writes).
+pub fn acquireGlobalsRead(map: *const std.StringHashMap(Value)) ?*GlobalsRwLock {
+    const ctx = globals_ctx orelse return null;
+    if (ctx.owns_globals) return null;
+    if (@as(*const std.StringHashMap(Value), ctx.globals) != map) return null;
+    ctx.globals_lock.lockShared();
+    return ctx.globals_lock;
+}
+
+pub fn releaseGlobalsRead(lock_arg: ?*GlobalsRwLock) void {
+    if (lock_arg) |l| l.unlockShared();
+}
+
+/// Callback for cond-expand library existence checks. Registered by the VM
+/// so the compiler can check library availability without importing vm.zig.
+pub const LibraryExistsFn = *const fn (lib_name: []const u8, lib_name_list: Value) bool;
+pub var library_exists_checker: ?LibraryExistsFn = null;
+
+pub fn libraryExists(lib_name: []const u8, lib_name_list: Value) bool {
+    if (library_exists_checker) |checker| return checker(lib_name, lib_name_list);
+    return false;
+}

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
-const vm_mod = @import("vm.zig");
+const globals_mod = @import("globals.zig");
 
 const Value = types.Value;
 const OpCode = types.OpCode;
@@ -182,8 +182,8 @@ pub const IR = struct {
             if (st.contains(name)) return true;
         }
         const g = self.globals orelse return false;
-        const glk = vm_mod.acquireGlobalsRead(g);
-        defer vm_mod.releaseGlobalsRead(glk);
+        const glk = globals_mod.acquireGlobalsRead(g);
+        defer globals_mod.releaseGlobalsRead(glk);
         const val = g.get(name) orelse {
             // In a restricted environment, missing names mean "not available".
             // Return true so the IR does not inline the primitive; the VM

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const library_mod = @import("library.zig");
+pub const globals_mod = @import("globals.zig");
 const Value = types.Value;
 const OpCode = types.OpCode;
 
@@ -41,82 +42,25 @@ pub threadlocal var vm_instance: ?*VM = null;
 
 pub fn setVMInstance(vm: *VM) void {
     vm_instance = vm;
+    globals_mod.setGlobalsContext(.{
+        .globals = vm.globals,
+        .globals_lock = vm.globals_lock,
+        .owns_globals = vm.owns_globals,
+    });
+    globals_mod.library_exists_checker = &checkLibraryExists;
 }
 
-/// Minimal portable reader-writer spinlock (Zig 0.16 has no blocking
-/// std.Thread.RwLock; std.Io.RwLock needs an Io instance). Same approach as
-/// memory.zig's symbol_mutex spinlock. Writer-preferring: once a writer sets
-/// its bit, new readers spin, existing readers drain, then the writer runs.
-/// Critical sections here are single hash-map operations, so spinning is
-/// bounded and short. Not reentrant — never nest acquisitions.
-pub const GlobalsRwLock = struct {
-    /// Bit 31 = writer holds/wants the lock; low 31 bits = active readers.
-    state: std.atomic.Value(u32) = .init(0),
-
-    const WRITER: u32 = 0x8000_0000;
-
-    pub fn lockShared(self: *GlobalsRwLock) void {
-        while (true) {
-            const s = self.state.load(.monotonic);
-            if (s & WRITER == 0) {
-                if (self.state.cmpxchgWeak(s, s + 1, .acquire, .monotonic) == null) return;
-            }
-            std.atomic.spinLoopHint();
-        }
-    }
-
-    pub fn unlockShared(self: *GlobalsRwLock) void {
-        _ = self.state.fetchSub(1, .release);
-    }
-
-    pub fn lock(self: *GlobalsRwLock) void {
-        // Claim the writer bit (excludes other writers, stops new readers) …
-        while (true) {
-            const s = self.state.load(.monotonic);
-            if (s & WRITER == 0) {
-                if (self.state.cmpxchgWeak(s, s | WRITER, .acquire, .monotonic) == null) break;
-            }
-            std.atomic.spinLoopHint();
-        }
-        // … then wait for in-flight readers to drain.
-        while (self.state.load(.acquire) != WRITER) std.atomic.spinLoopHint();
-    }
-
-    pub fn unlock(self: *GlobalsRwLock) void {
-        self.state.store(0, .release);
-    }
-};
-
-/// Take the exclusive globals lock if `map` is the current thread's shared
-/// globals map, for compile-time code that only holds a map pointer (body
-/// prescans, macro-expansion temp globals). Returns the lock to hand to
-/// releaseGlobalsWrite, or null when no locking applies: `map` is a library
-/// env, or no VM is registered on this thread yet (startup — no child
-/// threads can exist before the first execute()).
-pub fn acquireGlobalsWrite(map: *const std.StringHashMap(Value)) ?*GlobalsRwLock {
-    const vm = vm_instance orelse return null;
-    if (@as(*const std.StringHashMap(Value), vm.globals) != map) return null;
-    vm.globals_lock.lock();
-    return vm.globals_lock;
+fn checkLibraryExists(lib_name: []const u8, lib_name_list: Value) bool {
+    const vm = vm_instance orelse return false;
+    if (vm.libraries.get(lib_name) != null) return true;
+    return vm_library.libraryFileExists(vm, lib_name_list);
 }
 
-pub fn releaseGlobalsWrite(lock: ?*GlobalsRwLock) void {
-    if (lock) |l| l.unlock();
-}
-
-/// Shared-lock counterpart of acquireGlobalsWrite for read-only compile-time
-/// access. No-ops on the owner thread (its reads cannot race its own writes).
-pub fn acquireGlobalsRead(map: *const std.StringHashMap(Value)) ?*GlobalsRwLock {
-    const vm = vm_instance orelse return null;
-    if (vm.owns_globals) return null;
-    if (@as(*const std.StringHashMap(Value), vm.globals) != map) return null;
-    vm.globals_lock.lockShared();
-    return vm.globals_lock;
-}
-
-pub fn releaseGlobalsRead(lock: ?*GlobalsRwLock) void {
-    if (lock) |l| l.unlockShared();
-}
+pub const GlobalsRwLock = globals_mod.GlobalsRwLock;
+pub const acquireGlobalsWrite = globals_mod.acquireGlobalsWrite;
+pub const releaseGlobalsWrite = globals_mod.releaseGlobalsWrite;
+pub const acquireGlobalsRead = globals_mod.acquireGlobalsRead;
+pub const releaseGlobalsRead = globals_mod.releaseGlobalsRead;
 
 /// Mark the VM's live roots during a GC cycle: the register window of every
 /// active call frame, the frame closures, the exception-handler stack,
@@ -466,7 +410,10 @@ pub const VM = struct {
         // later VM on the same thread (e.g. the next unit test) would reach a
         // freed globals map through vm_instance during compile-time macro
         // expansion, before its own first execute() re-registers it.
-        if (vm_instance == self) vm_instance = null;
+        if (vm_instance == self) {
+            vm_instance = null;
+            globals_mod.clearGlobalsContext();
+        }
         if (self.scheduler) |sched| {
             self.gc.allocator.destroy(sched);
             self.scheduler = null;


### PR DESCRIPTION
## Summary

- Extract `GlobalsRwLock`, globals lock helpers, and a `GlobalsContext` threadlocal into a new `src/globals.zig` module
- Compiler, IR, and expander files now import `globals.zig` instead of `vm.zig`, eliminating the bidirectional dependency
- VM registers a library-existence callback in `globals.zig` so `cond-expand` can check library availability without importing `vm.zig`

**Before:** compiler*.zig ↔ vm.zig (circular)
**After:** compiler*.zig → globals.zig ← vm.zig → compiler.zig (unidirectional)

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1683 pass, 0 fail (288 Scheme files + 1395 R7RS suite)
- [x] `grep -n '@import("vm' src/compiler*.zig src/ir.zig src/expander.zig` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)