### PR TITLE
Fix top-level macros invisible inside bare-lambda bodies

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -162,7 +162,7 @@ pub const Compiler = struct {
         }) catch return CompileError.OutOfMemory;
     }
 
-    fn lookupMacro(self: *Compiler, name: []const u8) ?Value {
+    pub fn lookupMacro(self: *const Compiler, name: []const u8) ?Value {
         // Check this compiler's macros first
         if (self.macros.get(name)) |v| return v;
         // Then check parent chain

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -459,7 +459,9 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
 
             if (isSpecialForm(effective_name)) return ir.makePassthrough(expr);
 
-            if (macros) |m| {
+            if (ir.compiler) |c| {
+                if (c.lookupMacro(effective_name) != null) return ir.makePassthrough(expr);
+            } else if (macros) |m| {
                 if (m.get(effective_name) != null) return ir.makePassthrough(expr);
             }
         }

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -210,6 +210,35 @@ test "IR behavioral: macros" {
     try expectBehavioralParity("(define-syntax my-add (syntax-rules () ((my-add a b) (+ a b)))) (my-add 3 4)");
 }
 
+test "IR behavioral: macro in bare-lambda body (#1025)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    const result = try vm.eval(
+        \\(define-syntax my-add
+        \\  (syntax-rules ()
+        \\    ((_ a b) (+ a b))))
+        \\(define f (lambda () (my-add 1 2)))
+        \\(f)
+    );
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+}
+
+test "IR behavioral: macro in immediately-applied lambda (#1025)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+    const result = try vm.eval(
+        \\(define-syntax my-add
+        \\  (syntax-rules ()
+        \\    ((_ a b) (+ a b))))
+        \\((lambda () (my-add 1 2)))
+    );
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+}
+
 // --- Semantic analysis tests ---
 
 test "IR analysis: tail position in if" {


### PR DESCRIPTION
## Summary

Fixes #1025.

- `compileLambdaWithIR` lowered body forms with the child compiler's (empty) macro table, so `syntax-rules` macros from enclosing scopes were invisible inside `(define f (lambda () ...))` and `((lambda () ...))` bodies
- IR macro lookup now uses the compiler's `lookupMacro()` which walks the parent chain, falling back to the raw map for standalone lowering (IR parity tests, LLVM backend)
- Made `lookupMacro` public and const-correct (`*const Compiler`)

## Test plan

- [x] Two regression tests in `tests_ir.zig`: bare-lambda body and immediately-applied lambda
- [x] `zig build test` — all unit tests pass
- [x] `run-all.sh` — 1,683 pass, 0 fail
- [x] R7RS suite — 1,395 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)