### PR TITLE
Panic on writeBarrier remembered-set OOM instead of silently dropping (#1036)

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -177,7 +177,7 @@ pub const GC = struct {
             // GC, so it needs no remembered-set entry — and reading its
             // generation bit would race the owner's collection cycle.
             if (child.owner == self.id and child.generation == 0) {
-                self.remembered_set.append(self.allocator, container) catch {};
+                self.remembered_set.append(self.allocator, container) catch @panic("GC writeBarrier: remembered set OOM");
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace `catch {}` with `catch @panic("GC writeBarrier: remembered set OOM")` in `writeBarrier` (`src/memory.zig:180`)
- A dropped remembered-set entry lets minor GC sweep a live young object — silent heap corruption
- Follows the precedent set for mark-stack OOM in `gc_collect.zig` (#1014)

Closes #1036

## Test plan
- [x] `zig build test` passes
- [x] Behavior change only observable under allocation failure (OOM → panic instead of silent corruption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)