### PR TITLE
Unify typeName into types.zig, fix LSP hover for records/rationals/bignums

### DIFF
--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -358,35 +358,7 @@ fn getDocument(uri: []const u8) ?[]const u8 {
     return documents.get(uri);
 }
 
-// ---- Type name helper (same as main.zig) ----
-
-fn getTypeName(val: types.Value) []const u8 {
-    if (types.isFixnum(val)) return "integer";
-    if (val == types.NIL) return "nil";
-    if (val == types.TRUE or val == types.FALSE) return "boolean";
-    if (val == types.VOID) return "void";
-    if (val == types.EOF) return "eof-object";
-    if (types.isChar(val)) return "char";
-    if (!types.isPointer(val)) return "unknown";
-    const obj = types.toObject(val);
-    return switch (obj.tag) {
-        .pair => "pair",
-        .symbol => "symbol",
-        .string => "string",
-        .closure => "procedure",
-        .native_fn => "procedure",
-        .function => "function",
-        .vector => "vector",
-        .bytevector => "bytevector",
-        .port => "port",
-        .flonum => "number",
-        .transformer => "syntax",
-        .error_object => "error",
-        .continuation => "continuation",
-        .hash_table => "hash-table",
-        else => "object",
-    };
-}
+const getTypeName = types.typeName;
 
 fn getArity(val: types.Value, buf: *[32]u8) ?[]const u8 {
     if (!types.isPointer(val)) return null;

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -857,41 +857,7 @@ fn containsSubstring(haystack: []const u8, needle: []const u8) bool {
     return false;
 }
 
-fn getTypeName(val: types.Value) []const u8 {
-    if (types.isFixnum(val)) return "integer";
-    if (val == types.NIL) return "nil";
-    if (val == types.TRUE or val == types.FALSE) return "boolean";
-    if (val == types.VOID) return "void";
-    if (val == types.EOF) return "eof-object";
-    if (types.isChar(val)) return "char";
-    if (!types.isPointer(val)) return "unknown";
-    const obj = types.toObject(val);
-    return switch (obj.tag) {
-        .pair => "pair",
-        .symbol => "symbol",
-        .string => "string",
-        .closure => "procedure",
-        .native_fn => "procedure",
-        .function => "function",
-        .vector => "vector",
-        .bytevector => "bytevector",
-        .port => "port",
-        .flonum => "number",
-        .complex => "complex",
-        .transformer => "syntax",
-        .error_object => "error",
-        .record_type => "record-type",
-        .record_instance => "record",
-        .continuation => "continuation",
-        .multiple_values => "values",
-        .promise => "promise",
-        .parameter => "parameter",
-        .rational => "rational",
-        .bignum => "integer",
-        .hash_table => "hash-table",
-        else => "object",
-    };
-}
+const getTypeName = types.typeName;
 
 fn describeSymbol(vm: *vm_mod.VM, allocator: std.mem.Allocator, name: []const u8) void {
     const val_opt = vm.globals.get(name);

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -270,3 +270,48 @@ test "define_global (named let) does not re-bless stale cache (issue 812)" {
     const result = try vm.eval("(f)");
     try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
 }
+
+test "typeName covers all ObjectTags exhaustively" {
+    try std.testing.expectEqualStrings("integer", types.typeName(types.makeFixnum(42)));
+    try std.testing.expectEqualStrings("nil", types.typeName(types.NIL));
+    try std.testing.expectEqualStrings("boolean", types.typeName(types.TRUE));
+    try std.testing.expectEqualStrings("boolean", types.typeName(types.FALSE));
+    try std.testing.expectEqualStrings("void", types.typeName(types.VOID));
+    try std.testing.expectEqualStrings("eof-object", types.typeName(types.EOF));
+    try std.testing.expectEqualStrings("char", types.typeName(types.makeChar('A')));
+
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pair = try vm.eval("'(1 2)");
+    try std.testing.expectEqualStrings("pair", types.typeName(pair));
+    const sym = try vm.eval("'hello");
+    try std.testing.expectEqualStrings("symbol", types.typeName(sym));
+    const str = try vm.eval("\"abc\"");
+    try std.testing.expectEqualStrings("string", types.typeName(str));
+    const vec = try vm.eval("#(1 2 3)");
+    try std.testing.expectEqualStrings("vector", types.typeName(vec));
+    const bv = try vm.eval("#u8(1 2 3)");
+    try std.testing.expectEqualStrings("bytevector", types.typeName(bv));
+    const proc = try vm.eval("(lambda (x) x)");
+    try std.testing.expectEqualStrings("procedure", types.typeName(proc));
+    const builtin = try vm.eval("car");
+    try std.testing.expectEqualStrings("procedure", types.typeName(builtin));
+    const ht = try vm.eval("(let ((h (make-hash-table))) h)");
+    try std.testing.expectEqualStrings("hash-table", types.typeName(ht));
+    const prom = try vm.eval("(delay 42)");
+    try std.testing.expectEqualStrings("promise", types.typeName(prom));
+    const param = try vm.eval("(make-parameter 10)");
+    try std.testing.expectEqualStrings("parameter", types.typeName(param));
+    const rat = try vm.eval("1/3");
+    try std.testing.expectEqualStrings("rational", types.typeName(rat));
+    const big = try vm.eval("99999999999999999999");
+    try std.testing.expectEqualStrings("integer", types.typeName(big));
+    const rec = try vm.eval(
+        \\(begin (define-record-type <point> (make-point x y) point? (x point-x) (y point-y))
+        \\       (make-point 1 2))
+    );
+    try std.testing.expectEqualStrings("record", types.typeName(rec));
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -96,6 +96,54 @@ pub fn isTruthy(v: Value) bool {
     return v != FALSE;
 }
 
+pub fn typeName(val: Value) []const u8 {
+    if (isFixnum(val)) return "integer";
+    if (val == NIL) return "nil";
+    if (val == TRUE or val == FALSE) return "boolean";
+    if (val == VOID) return "void";
+    if (val == EOF) return "eof-object";
+    if (isChar(val)) return "char";
+    if (!isPointer(val)) return "unknown";
+    const obj = toObject(val);
+    return switch (obj.tag) {
+        .pair => "pair",
+        .symbol => "symbol",
+        .string => "string",
+        .closure, .native_fn, .native_closure => "procedure",
+        .function => "function",
+        .vector => "vector",
+        .bytevector => "bytevector",
+        .port => "port",
+        .flonum => "number",
+        .complex => "complex",
+        .transformer => "syntax",
+        .error_object => "error",
+        .record_type => "record-type",
+        .record_instance => "record",
+        .continuation => "continuation",
+        .multiple_values => "values",
+        .promise => "promise",
+        .parameter => "parameter",
+        .rational => "rational",
+        .bignum => "integer",
+        .hash_table => "hash-table",
+        .ffi_library => "ffi-library",
+        .ffi_function => "ffi-function",
+        .ffi_callback => "ffi-callback",
+        .fiber => "fiber",
+        .channel => "channel",
+        .mutex => "mutex",
+        .condition_variable => "condition-variable",
+        .srfi18_time => "time",
+        .file_info => "file-info",
+        .user_info => "user-info",
+        .group_info => "group-info",
+        .directory_object => "directory",
+        .random_source => "random-source",
+        .scheme_environment => "environment",
+    };
+}
+
 // ---------------------------------------------------------------------------
 // Heap object types
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1033.

- Adds a canonical `types.typeName(val)` with an **exhaustive** switch over all 37 `ObjectTag` variants (no `else` arm) — adding a new heap type now causes a compile error instead of silently returning "object".
- Replaces the duplicate `getTypeName` in `repl.zig` and `kaappi_lsp.zig` with `const getTypeName = types.typeName`.
- Fixes LSP hover reporting "object" for records, rationals, bignums, promises, parameters, complex numbers, record-types, and multiple-values.
- Also covers `native_closure` (was missing from both copies).

## Test plan

- [x] New unit test in `tests_core_eval.zig` exercises `typeName` on immediates (fixnum, nil, bool, void, eof, char) and heap types (pair, symbol, string, vector, bytevector, closure, native_fn, hash-table, promise, parameter, rational, bignum, record)
- [x] `zig build test` passes
- [x] `zig build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)