### PR TITLE
Propagate InvalidSyntax from let*-values and guard (#1032)

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -57,7 +57,10 @@ pub fn compileGuard(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compi
             const raise_call = gc.allocPair(raise_sym, gc.allocPair(var_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
             const else_sym = gc.allocSymbol("else") catch return CompileError.OutOfMemory;
             const else_clause = gc.allocPair(else_sym, gc.allocPair(raise_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-            cond_clauses = appendToList(self, clauses, else_clause) catch return CompileError.OutOfMemory;
+            cond_clauses = appendToList(self, clauses, else_clause) catch |err| return switch (err) {
+                error.InvalidSyntax => CompileError.InvalidSyntax,
+                else => CompileError.OutOfMemory,
+            };
         }
 
         const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -826,7 +826,10 @@ pub fn compileLetStarValues(self: *Compiler, args: Value, dst: u16, is_tail: boo
     const body = types.cdr(args);
     if (body == types.NIL) return CompileError.InvalidSyntax;
 
-    var desugared = buildLetValues(self, bindings, body) catch return CompileError.OutOfMemory;
+    var desugared = buildLetValues(self, bindings, body) catch |err| return switch (err) {
+        error.InvalidSyntax => CompileError.InvalidSyntax,
+        else => CompileError.OutOfMemory,
+    };
     try self.gc.pushRoot(&desugared);
     defer self.gc.popRoot();
     return self.compileExpr(desugared, dst, is_tail);

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -178,6 +178,13 @@ assert_output_contains "resume across dead native call is an error" \
     '(define k #f) (map (lambda (x) (call/cc (lambda (c) (set! k c) x))) (list 1 2 3)) (k 99)' \
     "continuation cannot resume across a returned native call"
 
+# Issue #1032: malformed let*-values and guard must report InvalidSyntax, not OOM
+assert_output_contains "malformed let*-values reports InvalidSyntax" \
+    '(let*-values (42) 1)' "InvalidSyntax"
+
+assert_output_contains "malformed guard clause reports InvalidSyntax" \
+    '(guard (e (#t "ok") . bad) 1)' "InvalidSyntax"
+
 # Issue #78: mismatched-length ellipsis template variables must be rejected
 # with a clean compile error, not read uninitialized memory. (Moved from
 # tests/scheme/smoke/ellipsis-mismatch.scm: the rejection happens at macro


### PR DESCRIPTION
## Summary
- `compileLetStarValues` and `compileGuard` used blanket `catch return CompileError.OutOfMemory` on calls to `buildLetValues` and `appendToList`, which can also return `error.InvalidSyntax`
- Replaced with error-specific switches so malformed syntax gets the correct `InvalidSyntax` diagnostic instead of a misleading "out of memory"
- Added regression tests to `tests/scheme/errors/error-format.sh`

Fixes #1032

## Test plan
- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/errors/error-format.sh` — all 33 tests pass (including 2 new)
- [x] Verified manually: `(let*-values (42) 1)` and `(guard (e (#t "ok") . bad) 1)` now report `InvalidSyntax`

🤖 Generated with [Claude Code](https://claude.com/claude-code)