### PR TITLE
Add shadow-stack GC rooting for native backend

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -269,10 +269,22 @@ pub const LLVMEmitter = struct {
         const callee = try self.emitNode(call.operator);
         const nargs = call.args.len;
 
+        var root_count: usize = 0;
+        if (nargs > 0) {
+            try self.emitRootPush(callee);
+            root_count += 1;
+        }
+
         var arg_tmps: [256][]const u8 = undefined;
         for (call.args, 0..) |arg, i| {
             arg_tmps[i] = try self.emitNode(arg);
+            if (i + 1 < nargs) {
+                try self.emitRootPush(arg_tmps[i]);
+                root_count += 1;
+            }
         }
+
+        try self.emitPopRoots(root_count);
 
         const result = try self.freshTemp();
 
@@ -305,9 +317,15 @@ pub const LLVMEmitter = struct {
 
     fn emitSelfTailCall(self: *LLVMEmitter, args: []const *ir.Node, body_lbl: []const u8) EmitError![]const u8 {
         var arg_tmps: [256][]const u8 = undefined;
+        var root_count: usize = 0;
         for (args, 0..) |arg, i| {
             arg_tmps[i] = try self.emitNode(arg);
+            if (i + 1 < args.len) {
+                try self.emitRootPush(arg_tmps[i]);
+                root_count += 1;
+            }
         }
+        try self.emitPopRoots(root_count);
 
         for (0..args.len) |i| {
             const gep = try self.freshTemp();
@@ -398,8 +416,10 @@ pub const LLVMEmitter = struct {
         else
             std.StringHashMap([]const u8).init(self.allocator);
 
+        var binding_root_count: usize = 0;
+
         if (!sequential) {
-            var init_vals: [32][]const u8 = undefined;
+            var binding_allocas: [32][]const u8 = undefined;
             var var_names: [32][]const u8 = undefined;
             var count: usize = 0;
             var blist = bindings;
@@ -423,18 +443,22 @@ pub const LLVMEmitter = struct {
                     self.locals = saved_locals;
                     return self.emitLetFallback(args, sequential);
                 };
-                init_vals[count] = try self.emitNode(node);
+                const alloca = try self.freshTemp();
+                try self.print("  {s} = alloca i64, align 8\n", .{alloca});
+                const val = try self.emitNode(node);
+                try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
+                try self.emitRootPushAlloca(alloca);
+
+                binding_allocas[count] = alloca;
                 var_names[count] = types.symbolName(var_sym);
                 count += 1;
                 blist = types.cdr(blist);
             }
 
             for (0..count) |i| {
-                const alloca = try self.freshTemp();
-                try self.print("  {s} = alloca i64, align 8\n", .{alloca});
-                try self.print("  store i64 {s}, ptr {s}\n", .{ init_vals[i], alloca });
-                self.locals.?.put(var_names[i], alloca) catch return error.OutOfMemory;
+                self.locals.?.put(var_names[i], binding_allocas[i]) catch return error.OutOfMemory;
             }
+            binding_root_count = count;
         } else {
             var blist = bindings;
             while (blist != types.NIL and types.isPair(blist)) {
@@ -456,6 +480,8 @@ pub const LLVMEmitter = struct {
                 const alloca = try self.freshTemp();
                 try self.print("  {s} = alloca i64, align 8\n", .{alloca});
                 try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
+                try self.emitRootPushAlloca(alloca);
+                binding_root_count += 1;
                 self.locals.?.put(types.symbolName(var_sym), alloca) catch return error.OutOfMemory;
                 blist = types.cdr(blist);
             }
@@ -482,6 +508,7 @@ pub const LLVMEmitter = struct {
             body_expr = rest;
         }
 
+        try self.emitPopRoots(binding_root_count);
         self.locals.?.deinit();
         self.locals = saved_locals;
         return last;
@@ -965,7 +992,9 @@ pub const LLVMEmitter = struct {
 
         const target = fn_name orelse return null;
         const a = self.emitNode(args[0]) catch return null;
+        self.emitRootPush(a) catch return null;
         const b = self.emitNode(args[1]) catch return null;
+        self.emitPopRoots(1) catch return null;
         const result = self.freshTemp() catch return null;
         self.print("  {s} = call i64 {s}(i64 {s}, i64 {s})\n", .{ result, target, a, b }) catch return null;
         return result;
@@ -991,9 +1020,15 @@ pub const LLVMEmitter = struct {
     fn emitDirectCall(self: *LLVMEmitter, fn_name: []const u8, args: []const *ir.Node, is_tail: bool) EmitError![]const u8 {
         const nargs = args.len;
         var arg_tmps: [256][]const u8 = undefined;
+        var root_count: usize = 0;
         for (args, 0..) |arg, i| {
             arg_tmps[i] = try self.emitNode(arg);
+            if (i + 1 < nargs) {
+                try self.emitRootPush(arg_tmps[i]);
+                root_count += 1;
+            }
         }
+        try self.emitPopRoots(root_count);
 
         const result = try self.freshTemp();
 
@@ -1114,6 +1149,25 @@ pub const LLVMEmitter = struct {
         try self.write("declare i64 @kaappi_is_null(i64)\n");
         try self.write("declare i64 @kaappi_create_native_closure(ptr, ptr, ptr, i64, i64, ptr, i64)\n");
         try self.write("declare i64 @kaappi_eval(ptr, ptr, i64)\n");
+        try self.write("declare void @kaappi_gc_push_root(ptr)\n");
+        try self.write("declare void @kaappi_gc_pop_roots(i64)\n");
+    }
+
+    fn emitRootPush(self: *LLVMEmitter, tmp: []const u8) EmitError!void {
+        const slot = try self.freshTemp();
+        try self.print("  {s} = alloca i64, align 8\n", .{slot});
+        try self.print("  store i64 {s}, ptr {s}\n", .{ tmp, slot });
+        try self.print("  call void @kaappi_gc_push_root(ptr {s})\n", .{slot});
+    }
+
+    fn emitRootPushAlloca(self: *LLVMEmitter, alloca: []const u8) EmitError!void {
+        try self.print("  call void @kaappi_gc_push_root(ptr {s})\n", .{alloca});
+    }
+
+    fn emitPopRoots(self: *LLVMEmitter, n: usize) EmitError!void {
+        if (n > 0) {
+            try self.print("  call void @kaappi_gc_pop_roots(i64 {d})\n", .{n});
+        }
     }
 
     pub fn freshTemp(self: *LLVMEmitter) EmitError![]const u8 {

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -14,6 +14,13 @@ export fn kaappi_runtime_init() callconv(.c) ?*vm_mod.VM {
 
     rt_gc = memory.GC.init(allocator);
 
+    if (std.c.getenv("KAAPPI_GC_THRESHOLD")) |env_ptr| {
+        const env = std.mem.span(env_ptr);
+        if (std.fmt.parseInt(usize, env, 10)) |threshold| {
+            rt_gc.gc_threshold = threshold;
+        } else |_| {}
+    }
+
     const vm = allocator.create(vm_mod.VM) catch return null;
     vm.* = vm_mod.VM.init(&rt_gc) catch {
         allocator.destroy(vm);
@@ -226,4 +233,21 @@ export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]const u
         std.process.exit(1);
     };
     return result;
+}
+
+// Shadow-stack GC rooting for natively compiled code.
+// The LLVM emitter stores intermediate Values in alloca slots and registers
+// them here so the GC can see them during collection.
+
+export fn kaappi_gc_push_root(slot: *Value) callconv(.c) void {
+    const gc = memory.gc_instance orelse return;
+    gc.pushRoot(slot) catch {};
+}
+
+export fn kaappi_gc_pop_roots(n: u64) callconv(.c) void {
+    const gc = memory.gc_instance orelse return;
+    var i: u64 = 0;
+    while (i < n) : (i += 1) {
+        gc.popRoot();
+    }
 }

--- a/tests/scheme/compile/native-gc-roots-1034.sh
+++ b/tests/scheme/compile/native-gc-roots-1034.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Regression test for #1034: GC safety of intermediate values in native code.
+#
+# The LLVM emitter stores intermediate Values in SSA temps/allocas that the
+# GC cannot see.  Without shadow-stack rooting, nested allocating calls like
+# (cons (make-string ...) (make-string ...)) can lose the first result when
+# the second call triggers collection.
+#
+# KAAPPI_GC_THRESHOLD=1 forces collection on every allocation in the native
+# runtime, making this deterministic rather than probabilistic.
+#
+# Usage: bash tests/scheme/compile/native-gc-roots-1034.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# Build interpreter + runtime library
+(cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+check_native() {
+    local src="$1" expected="$2" label="$3"
+    local bin="$DIR/${label}.bin"
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — native compile did not produce a binary" >&2
+        exit 1
+    fi
+    local out
+    out="$(KAAPPI_GC_THRESHOLD=1 "$bin")"
+    if [[ "$out" != "$expected" ]]; then
+        echo "FAIL: $label — expected '$expected', got '$out'" >&2
+        exit 1
+    fi
+}
+
+# --- Case 1: nested cons with allocating arguments ---
+cat > "$DIR/nested-cons.scm" << 'SCHEME'
+(define (make-pair)
+  (cons (cons 1 2) (cons 3 4)))
+(let ((p (make-pair)))
+  (display (car (car p)))
+  (display (cdr (car p)))
+  (display (car (cdr p)))
+  (display (cdr (cdr p)))
+  (newline))
+SCHEME
+
+check_native "$DIR/nested-cons.scm" "1234" "nested-cons"
+
+# --- Case 2: let bindings with allocating inits ---
+cat > "$DIR/let-alloc.scm" << 'SCHEME'
+(define (f)
+  (let ((a (cons 10 20))
+        (b (cons 30 40)))
+    (display (car a))
+    (display (cdr a))
+    (display (car b))
+    (display (cdr b))
+    (newline)))
+(f)
+SCHEME
+
+check_native "$DIR/let-alloc.scm" "10203040" "let-alloc"
+
+# --- Case 3: let* bindings with allocating inits ---
+cat > "$DIR/let-star-alloc.scm" << 'SCHEME'
+(define (g)
+  (let* ((a (cons 5 6))
+         (b (cons (car a) 7)))
+    (display (car b))
+    (display (cdr b))
+    (newline)))
+(g)
+SCHEME
+
+check_native "$DIR/let-star-alloc.scm" "57" "let-star-alloc"
+
+# --- Case 4: deeply nested calls building a list ---
+cat > "$DIR/deep-nest.scm" << 'SCHEME'
+(define (build-three a b c)
+  (cons a (cons b (cons c '()))))
+(let ((lst (build-three (cons 1 2) (cons 3 4) (cons 5 6))))
+  (display (car (car lst)))
+  (display (car (car (cdr lst))))
+  (display (car (car (cdr (cdr lst)))))
+  (newline))
+SCHEME
+
+check_native "$DIR/deep-nest.scm" "135" "deep-nest"
+
+# --- Case 5: inline binary (cons) with call arguments ---
+cat > "$DIR/inline-cons.scm" << 'SCHEME'
+(define (id x) x)
+(let ((p (cons (id (cons 1 2)) (id (cons 3 4)))))
+  (display (car (car p)))
+  (display (car (cdr p)))
+  (newline))
+SCHEME
+
+check_native "$DIR/inline-cons.scm" "13" "inline-cons"
+
+# --- Case 6: allocation-heavy recursive function ---
+cat > "$DIR/recursive-alloc.scm" << 'SCHEME'
+(define (make-list n)
+  (if (= n 0)
+      '()
+      (cons n (make-list (- n 1)))))
+
+(define (sum-list lst)
+  (if (null? lst)
+      0
+      (+ (car lst) (sum-list (cdr lst)))))
+
+(display (sum-list (make-list 50)))
+(newline)
+SCHEME
+
+check_native "$DIR/recursive-alloc.scm" "1275" "recursive-alloc"
+
+echo "PASS"


### PR DESCRIPTION
## Summary

Fixes #1034. The LLVM native backend stored intermediate Values in SSA temps/allocas invisible to the GC. Nested allocating calls like `(cons (f x) (g y))` could lose the first result when the second call triggers collection.

- Add `kaappi_gc_push_root` / `kaappi_gc_pop_roots` C-ABI exports wrapping `gc.pushRoot`/`popRoot`
- Emit rooting calls in 4 LLVM emitter call sites: `emitCallNode`, `tryEmitInlineBinary`, `emitDirectCall`, `emitSelfTailCall`
- Root `let`/`let*` binding allocas for the duration of body execution
- Add `KAAPPI_GC_THRESHOLD` env var for stress-testing native binaries
- New stress test (`native-gc-roots-1034.sh`) with 6 cases running under `KAAPPI_GC_THRESHOLD=1`

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/compile/native-gc-roots-1034.sh` — new stress test passes
- [x] All 8 existing compile tests pass
- [x] All 23 e2e native parity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)