### PR TITLE
Port self-tail-call optimization and line-table recording to IR path (#1035)

### DIFF
--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -13,6 +13,14 @@ const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 
 pub fn compileFromNode(self: *Compiler, node: *ir_mod.Node, dst: u16, is_tail: bool) CompileError!void {
+    if (node.ann.source_line > 0 and node.ann.source_line != self.current_line) {
+        self.current_line = node.ann.source_line;
+        try self.func.line_table.append(self.gc.allocator, .{
+            .offset = @intCast(self.func.code.items.len),
+            .line = node.ann.source_line,
+        });
+    }
+
     const tail = if (node.ann.is_tail) true else is_tail;
     switch (node.tag) {
         .constant => try self.emitLoadValue(dst, node.data.constant),
@@ -94,6 +102,21 @@ fn compileCallFromIR(self: *Compiler, call: ir_mod.CallData, dst: u16, is_tail: 
     if (call.args.len > 255) return CompileError.InternalLimit;
     const nargs: u8 = @intCast(call.args.len);
 
+    if (is_tail and call.operator.tag == .global_ref and self.func.name != null) {
+        const sym = call.operator.data.global_ref;
+        if (types.isSymbol(sym)) {
+            const op_name = types.symbolName(sym);
+            if (std.mem.eql(u8, op_name, self.func.name.?) and !self.func.is_variadic and nargs == self.func.arity) {
+                if (std.mem.startsWith(u8, op_name, "__nlet_")) {
+                    return compileSelfTailCallFromIR(self, call, dst, nargs);
+                }
+                if (self.resolveLocal(op_name) == null and (try self.resolveUpvalue(op_name)) == null) {
+                    return compileSelfTailCallFromIR(self, call, dst, nargs);
+                }
+            }
+        }
+    }
+
     if (!is_tail and call.operator.tag == .global_ref) {
         const sym = call.operator.data.global_ref;
         if (types.isSymbol(sym)) {
@@ -142,6 +165,29 @@ fn compileCallFromIR(self: *Compiler, call: ir_mod.CallData, dst: u16, is_tail: 
         try self.emitOp(.move);
         try self.emitU16(dst);
         try self.emitU16(base);
+        self.freeReg();
+    }
+}
+
+fn compileSelfTailCallFromIR(self: *Compiler, call: ir_mod.CallData, dst: u16, nargs: u8) CompileError!void {
+    const needs_rebase = (dst + 1 != self.next_register);
+    const base = if (needs_rebase) try self.allocReg() else dst;
+
+    for (call.args) |arg| {
+        const arg_reg = try self.allocReg();
+        try compileFromNode(self, arg, arg_reg, false);
+    }
+
+    try self.emitOp(.self_tail_call);
+    try self.emitU16(base);
+    try self.emit(nargs);
+
+    var i: u8 = 0;
+    while (i < nargs) : (i += 1) {
+        self.freeReg();
+    }
+
+    if (needs_rebase) {
         self.freeReg();
     }
 }
@@ -514,6 +560,11 @@ fn compileDefineFromIR(self: *Compiler, data: ir_mod.DefineData, dst: u16) Compi
     val_root = ir_mod.simplifyBooleans(&ir, val_root);
     val_root = ir_mod.eliminateIdentity(&ir, val_root);
     val_root = ir_mod.simplifyBegin(&ir, val_root);
+
+    if (val_root.tag == .lambda) {
+        val_root.data.lambda.name = types.symbolName(data.name);
+    }
+
     try compileFromNode(self, val_root, dst, false);
 
     if (self.func.constants.items.len > 0) {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -50,6 +50,7 @@ pub const Annotations = struct {
     is_primitive_call: bool = false,
     primitive_name: ?[]const u8 = null,
     is_constant: bool = false,
+    source_line: u32 = 0,
 };
 
 pub const Node = struct {
@@ -396,7 +397,13 @@ pub fn lowerWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
     }
 
     if (types.isPair(expr)) {
-        return lowerFormWithMacros(ir, expr, macros);
+        const node = try lowerFormWithMacros(ir, expr, macros);
+        if (ir.compiler) |c| {
+            if (c.gc.source_lines.get(expr)) |line| {
+                node.ann.source_line = line;
+            }
+        }
+        return node;
     }
 
     return CompileError.InvalidSyntax;

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -900,3 +900,76 @@ test "IR: bare lambda define-value form (#1026)" {
     );
     try std.testing.expectEqual(@as(i64, 15), types.toFixnum(result));
 }
+
+// -- Issue #1035: self-tail-call + line-table for IR path --
+
+test "IR: bare-lambda define emits self_tail_call" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const source = "(define f (lambda (n) (if (= n 0) 0 (f (- n 1)))))";
+    var reader = reader_mod.Reader.init(&gc, source);
+    defer reader.deinit();
+    const expr = try reader.readDatum();
+    const func = try compiler_mod.compileExpression(&gc, expr);
+
+    var found_self_tail_call = false;
+    var found_generic_tail_call = false;
+    for (func.constants.items) |c| {
+        if (!types.isFunction(c)) continue;
+        const child = types.toObject(c).as(types.Function);
+        var ip: usize = 0;
+        while (ip < child.code.items.len) {
+            const raw = child.code.items[ip];
+            if (raw == @intFromEnum(types.OpCode.self_tail_call)) {
+                found_self_tail_call = true;
+            }
+            if (raw == @intFromEnum(types.OpCode.tail_call)) {
+                found_generic_tail_call = true;
+            }
+            ip += 1;
+        }
+    }
+    try std.testing.expect(found_self_tail_call);
+    try std.testing.expect(!found_generic_tail_call);
+}
+
+test "IR: bare-lambda self-tail-call does not overflow stack" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(define f (lambda (n acc) (if (= n 0) acc (f (- n 1) (+ acc 1)))))
+        \\(f 100000 0)
+    );
+    try std.testing.expectEqual(@as(i64, 100000), types.toFixnum(result));
+}
+
+test "IR: line-table entries recorded for IR-compiled code" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const source =
+        \\(define f
+        \\  (lambda (x)
+        \\    (if (= x 0)
+        \\        0
+        \\        (+ x 1))))
+    ;
+    var reader = reader_mod.Reader.init(&gc, source);
+    defer reader.deinit();
+    const expr = try reader.readDatum();
+    const func = try compiler_mod.compileExpression(&gc, expr);
+
+    var child_has_lines = false;
+    for (func.constants.items) |c| {
+        if (!types.isFunction(c)) continue;
+        const child = types.toObject(c).as(types.Function);
+        if (child.line_table.items.len > 0) {
+            child_has_lines = true;
+        }
+    }
+    try std.testing.expect(child_has_lines);
+}

--- a/tests/scheme/smoke/bare-lambda-self-tail-call.scm
+++ b/tests/scheme/smoke/bare-lambda-self-tail-call.scm
@@ -1,0 +1,17 @@
+;; Regression test for issue #1035:
+;; (define f (lambda ...)) must compile self-recursive tail calls as
+;; self_tail_call (a loop), not generic tail_call.
+
+;; Without the optimization, 100k recursions would overflow the stack.
+(define count-down
+  (lambda (n acc)
+    (if (= n 0)
+        acc
+        (count-down (- n 1) (+ acc 1)))))
+
+(define result (count-down 100000 0))
+(unless (= result 100000)
+  (error "bare-lambda self-tail-call failed" result))
+
+(display "OK")
+(newline)


### PR DESCRIPTION
## Summary

- **Self-tail-call optimization**: `(define f (lambda (n) (f ...)))` now compiles the recursive tail call as `self_tail_call` (a loop) instead of generic `tail_call`. Fixed by injecting the define's name into the lambda IR node before body compilation and adding self-tail-call detection to `compileCallFromIR`.
- **Line-table attribution**: IR-compiled code now records per-line source positions for error reporting. Added `source_line` to IR `Annotations`, populated during lowering from `gc.source_lines`, and emitted in `compileFromNode`.

## Test plan

- [x] Bytecode test: `self_tail_call` opcode present in bare-lambda define
- [x] Behavioral test: 100k-deep recursion via bare-lambda (stack overflow without fix)
- [x] Line-table test: IR-compiled lambda has populated `line_table`
- [x] Scheme smoke test: `bare-lambda-self-tail-call.scm`
- [x] `zig build test` — all unit tests pass
- [x] `zig build bench` — no perf regression
- [x] `bash tests/scheme/run-all.sh` — 1683 pass, 0 fail

Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)