### PR TITLE
Honor KAAPPI_HOME in interpreter, ffi-open, and REPL (#1031)

### DIFF
--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+
+/// Returns the kaappi home directory path written into `buf`.
+/// Checks `KAAPPI_HOME` env var first; falls back to `$HOME/.kaappi`.
+/// Returns null if neither env var is available or the path exceeds `buf`.
+pub fn getHome(buf: []u8) ?[]const u8 {
+    if (std.c.getenv("KAAPPI_HOME")) |kh| {
+        const home = std.mem.sliceTo(kh, 0);
+        if (home.len > 0 and home.len <= buf.len) {
+            @memcpy(buf[0..home.len], home);
+            return buf[0..home.len];
+        }
+    }
+    const home_ptr = std.c.getenv("HOME") orelse return null;
+    const home = std.mem.sliceTo(home_ptr, 0);
+    const suffix = "/.kaappi";
+    const total = home.len + suffix.len;
+    if (total > buf.len) return null;
+    @memcpy(buf[0..home.len], home);
+    @memcpy(buf[home.len..][0..suffix.len], suffix);
+    return buf[0..total];
+}
+
+test "getHome falls back to HOME/.kaappi" {
+    var buf: [512]u8 = undefined;
+    if (getHome(&buf)) |home| {
+        try std.testing.expect(home.len > 0);
+        try std.testing.expect(std.mem.endsWith(u8, home, "/.kaappi") or
+            std.c.getenv("KAAPPI_HOME") != null);
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -655,15 +655,16 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         }
     }
 
-    // Auto-add ~/.kaappi/lib as a default library search path
+    // Auto-add $KAAPPI_HOME/lib (or ~/.kaappi/lib) as a default library search path
     if (!is_wasm) {
         const kaappi_lib_path = blk: {
-            const home = std.c.getenv("HOME") orelse break :blk null;
-            const home_len = std.mem.len(home);
-            const suffix = "/.kaappi/lib";
-            const path = allocator.alloc(u8, home_len + suffix.len) catch break :blk null;
-            @memcpy(path[0..home_len], home[0..home_len]);
-            @memcpy(path[home_len..], suffix);
+            const kaappi_paths = @import("kaappi_paths.zig");
+            var home_buf: [512]u8 = undefined;
+            const home = kaappi_paths.getHome(&home_buf) orelse break :blk null;
+            const lib_suffix = "/lib";
+            const path = allocator.alloc(u8, home.len + lib_suffix.len) catch break :blk null;
+            @memcpy(path[0..home.len], home);
+            @memcpy(path[home.len..][0..lib_suffix.len], lib_suffix);
             break :blk path;
         };
         if (kaappi_lib_path) |klp| {

--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -68,20 +68,20 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
         }
     }
 
-    // Try ~/.kaappi/lib/ as a fallback for installed packages
-    const home = std.c.getenv("HOME");
-    if (home) |h| {
-        const hlen = std.mem.len(h);
-        const prefix = "/.kaappi/lib/";
+    // Try $KAAPPI_HOME/lib/ (or ~/.kaappi/lib/) as a fallback for installed packages
+    const kaappi_paths = @import("kaappi_paths.zig");
+    var home_buf: [256]u8 = undefined;
+    if (kaappi_paths.getHome(&home_buf)) |kaappi_home| {
+        const lib_prefix = "/lib/";
         const suffixes = [_][]const u8{ "", ".dylib", ".so" };
         for (suffixes) |suffix| {
-            if (hlen + prefix.len + str.len + suffix.len < 512) {
+            if (kaappi_home.len + lib_prefix.len + str.len + suffix.len < 512) {
                 var pbuf: [512]u8 = undefined;
-                @memcpy(pbuf[0..hlen], h[0..hlen]);
-                @memcpy(pbuf[hlen..][0..prefix.len], prefix);
-                @memcpy(pbuf[hlen + prefix.len ..][0..str.len], str.data[0..str.len]);
-                @memcpy(pbuf[hlen + prefix.len + str.len ..][0..suffix.len], suffix);
-                const total = hlen + prefix.len + str.len + suffix.len;
+                @memcpy(pbuf[0..kaappi_home.len], kaappi_home);
+                @memcpy(pbuf[kaappi_home.len..][0..lib_prefix.len], lib_prefix);
+                @memcpy(pbuf[kaappi_home.len + lib_prefix.len ..][0..str.len], str.data[0..str.len]);
+                @memcpy(pbuf[kaappi_home.len + lib_prefix.len + str.len ..][0..suffix.len], suffix);
+                const total = kaappi_home.len + lib_prefix.len + str.len + suffix.len;
                 pbuf[total] = 0;
                 const pname: [*:0]const u8 = @ptrCast(pbuf[0..total :0]);
                 if (std.c.dlopen(pname, std.c.RTLD{ .LAZY = true })) |handle| {

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -411,11 +411,12 @@ pub fn repl(vm: *vm_mod.VM) !void {
 
     var hist_path_buf: [512]u8 = undefined;
     const hist_path: ?[*:0]const u8 = blk: {
-        const home_ptr: ?[*:0]const u8 = std.c.getenv("HOME");
-        const home = if (home_ptr) |p| std.mem.span(p) else break :blk null;
-        const dir = std.fmt.bufPrintZ(hist_path_buf[0..500], "{s}/.kaappi", .{home}) catch break :blk null;
+        const kaappi_paths = @import("kaappi_paths.zig");
+        var home_buf: [256]u8 = undefined;
+        const kaappi_home = kaappi_paths.getHome(&home_buf) orelse break :blk null;
+        const dir = std.fmt.bufPrintZ(hist_path_buf[0..500], "{s}", .{kaappi_home}) catch break :blk null;
         _ = std.c.mkdir(dir.ptr, 0o755);
-        const path = std.fmt.bufPrintZ(&hist_path_buf, "{s}/.kaappi/history", .{home}) catch break :blk null;
+        const path = std.fmt.bufPrintZ(&hist_path_buf, "{s}/history", .{kaappi_home}) catch break :blk null;
         break :blk path;
     };
     if (hist_path) |p| ln.historyLoad(p);

--- a/tests/scheme/errors/kaappi-home.sh
+++ b/tests/scheme/errors/kaappi-home.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Regression test for #1031: KAAPPI_HOME must be honored by the interpreter
+# and ffi-open, not just thottam.
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+assert_exit() {
+    local label="$1" expected="$2"
+    shift 2
+    local status=0
+    "$@" > /tmp/kaappi-home-test-out 2>&1 || status=$?
+    if [[ "$status" -eq "$expected" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected exit $expected, got $status"
+        cat /tmp/kaappi-home-test-out
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Create a library in a custom KAAPPI_HOME
+mkdir -p "$TMPDIR_TESTS/lib/kaappi"
+cat > "$TMPDIR_TESTS/lib/kaappi/test-home.sld" <<'SLD'
+(define-library (kaappi test-home)
+  (import (scheme base) (scheme write))
+  (export test-home-ok)
+  (begin
+    (define (test-home-ok) (display "home-ok") (newline))))
+SLD
+
+# Test script that imports the library
+cat > "$TMPDIR_TESTS/test-import.scm" <<'SCM'
+(import (kaappi test-home))
+(test-home-ok)
+SCM
+
+# With KAAPPI_HOME set, the library should be importable
+assert_exit "KAAPPI_HOME import succeeds" 0 \
+    env KAAPPI_HOME="$TMPDIR_TESTS" "$KAAPPI" "$TMPDIR_TESTS/test-import.scm"
+
+# Without KAAPPI_HOME (and no --lib-path), the library should NOT be found
+assert_exit "import fails without KAAPPI_HOME" 1 \
+    env -u KAAPPI_HOME "$KAAPPI" "$TMPDIR_TESTS/test-import.scm"
+
+echo ""
+echo "$PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

- Extract shared `src/kaappi_paths.zig` with `getHome(buf)` — checks `KAAPPI_HOME` env var first, falls back to `$HOME/.kaappi`
- Update `src/main.zig` library auto-discovery to use `kaappi_paths.getHome`
- Update `src/primitives_ffi.zig` dlopen fallback to use `kaappi_paths.getHome`
- Update `src/repl.zig` history path to use `kaappi_paths.getHome`

Fixes #1031

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/errors/kaappi-home.sh` — new regression test passes (KAAPPI_HOME import succeeds; import fails without it)
- [x] `bash tests/scheme/run-all.sh` — 1685 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)