### PR TITLE
Root SRFI-1 filter-map/append-map/unfold callback results via extra_roots (#1027)

### DIFF
--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -815,6 +815,8 @@ fn filterMapFn(args: []const Value) PrimitiveError!Value {
 
     var results: std.ArrayList(Value) = .empty;
     defer results.deinit(gc.allocator);
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
     var call_args_buf: [256]Value = undefined;
 
     while (true) {
@@ -835,6 +837,7 @@ fn filterMapFn(args: []const Value) PrimitiveError!Value {
         const result = try callVM(proc, call_args_buf[0..list_count]);
         if (isTruthyResult(result)) {
             results.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
+            gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
         }
 
         for (0..list_count) |i| {
@@ -867,6 +870,8 @@ fn appendMapFn(args: []const Value) PrimitiveError!Value {
 
     var all_elems: std.ArrayList(Value) = .empty;
     defer all_elems.deinit(gc.allocator);
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
     var call_args_buf: [256]Value = undefined;
 
     while (true) {
@@ -889,7 +894,9 @@ fn appendMapFn(args: []const Value) PrimitiveError!Value {
         var sub = result;
         while (sub != types.NIL) {
             if (!types.isPair(sub)) return primitives.typeError("append-map", "pair", sub);
-            all_elems.append(gc.allocator, types.car(sub)) catch return PrimitiveError.OutOfMemory;
+            const elem = types.car(sub);
+            all_elems.append(gc.allocator, elem) catch return PrimitiveError.OutOfMemory;
+            gc.extra_roots.append(gc.allocator, elem) catch return PrimitiveError.OutOfMemory;
             sub = types.cdr(sub);
         }
 
@@ -1822,6 +1829,10 @@ fn unfoldFn(args: []const Value) PrimitiveError!Value {
 
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    gc.pushRoot(&seed) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     while (true) {
         const stop_args = [1]Value{seed};
@@ -1831,6 +1842,7 @@ fn unfoldFn(args: []const Value) PrimitiveError!Value {
         const map_args = [1]Value{seed};
         const val = try callVM(f, &map_args);
         elems.append(gc.allocator, val) catch return PrimitiveError.OutOfMemory;
+        gc.extra_roots.append(gc.allocator, val) catch return PrimitiveError.OutOfMemory;
 
         const succ_args = [1]Value{seed};
         seed = try callVM(g, &succ_args);

--- a/tests/scheme/srfi/srfi1-gc-stress.scm
+++ b/tests/scheme/srfi/srfi1-gc-stress.scm
@@ -76,6 +76,29 @@
   (check "unfold first" (car result) 0)
   (check "unfold last" (list-ref result 499) 499))
 
+;; filter-map: allocating callback (cons creates heap pressure) — regression #1027
+(let ((result (filter-map (lambda (x) (cons x x))
+                          (list-tabulate 500 values))))
+  (check "filter-map length" (length result) 500)
+  (check "filter-map first" (car result) '(0 . 0))
+  (check "filter-map last" (list-ref result 499) '(499 . 499)))
+
+;; append-map: allocating callback — regression #1027
+(let ((result (append-map (lambda (x) (list (cons x x)))
+                          (list-tabulate 500 values))))
+  (check "append-map length" (length result) 500)
+  (check "append-map first" (car result) '(0 . 0))
+  (check "append-map last" (list-ref result 499) '(499 . 499)))
+
+;; unfold with allocating callbacks — regression #1027
+(let ((result (unfold (lambda (i) (= i 500))
+                      (lambda (i) (cons i (* i i)))
+                      (lambda (i) (+ i 1))
+                      0)))
+  (check "unfold-alloc length" (length result) 500)
+  (check "unfold-alloc first" (car result) '(0 . 0))
+  (check "unfold-alloc last" (list-ref result 499) '(499 . 249001)))
+
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "SRFI-1 GC stress tests failed" fail))


### PR DESCRIPTION
## Summary
- `filterMapFn`, `appendMapFn`, and `unfoldFn` accumulated `callVM` results in plain `ArrayList` locals invisible to GC `markRoots` — any subsequent callback could collect previously-stored values
- Applied the established `extra_roots` save/restore idiom (matching `vector-map` in `primitives_vector.zig`) to all three functions
- Rooted `unfold`'s `seed` variable via `pushRoot` since it's updated by callbacks across iterations
- Added GC stress tests with allocating lambdas (`cons` creates heap pressure) for all three procedures

Fixes #1027

## Test plan
- [x] `zig build test` — unit tests pass
- [x] `zig build run -- tests/scheme/srfi/srfi1-gc-stress.scm` — 27/27 pass
- [x] `zig build -Dgc-threshold=1 run -- tests/scheme/srfi/srfi1-gc-stress.scm` — 27/27 pass under max GC stress
- [x] `bash tests/scheme/run-all.sh` — 1685 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)