### PR TITLE
Resurrect 11 orphaned regression tests, harden run-all.sh (#1029)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,6 @@ jobs:
       - name: Robustness tests
         run: bash tests/scheme/robustness/robustness.sh
 
-      - name: Error format tests
-        run: bash tests/scheme/errors/error-format.sh
-
-      - name: Exit code tests
-        run: bash tests/scheme/errors/exit-code.sh
-
       - name: E2E tests (LLVM native backend)
         if: matrix.optimize == 'ReleaseSafe' && matrix.os != 'macos-latest'
         run: |

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -12,7 +12,7 @@
 | `ffi/` | C FFI integration | yes |
 | `audit/` | Auto-generated primitives audit tests | yes |
 | `r7rs/` | Full R7RS suite (1,391 tests, `chibi test`) | yes (special) |
-| `errors/` | Error message format and exit code regression (`error-format.sh`, `exit-code.sh`) | no |
+| `errors/` | Error message format, exit code, and reader error regression tests | yes |
 | `bench/` | Micro-benchmarks (no assertions, timing only) | no |
 | `coverage/` | Coverage gap-fillers (`zig build coverage-scheme`) | no |
 | `deferred/` | Pre-compiled `.sbc` bytecode tests | no |

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -10,6 +10,11 @@ if [[ ! -x zig-out/bin/kaappi ]]; then
 fi
 KAAPPI=zig-out/bin/kaappi
 
+TMPOUT=$(mktemp /tmp/kaappi-test-XXXXXX)
+TMPSTDOUT=$(mktemp /tmp/kaappi-r7rs-stdout-XXXXXX)
+TMPSTDERR=$(mktemp /tmp/kaappi-r7rs-stderr-XXXXXX)
+trap 'rm -f "$TMPOUT" "$TMPSTDOUT" "$TMPSTDERR"' EXIT
+
 TIMEOUT=60
 PASS=0
 FAIL=0
@@ -21,7 +26,7 @@ R7RS_STATUS_FAIL=0
 run_file() {
     local file="$1"
     local output pid status
-    "$KAAPPI" "$file" > /tmp/kaappi-test-out 2>&1 &
+    "$KAAPPI" "$file" > "$TMPOUT" 2>&1 &
     pid=$!
     if wait_with_timeout "$pid" "$TIMEOUT"; then
         status=0
@@ -30,7 +35,7 @@ run_file() {
         kill "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true
         echo "  TIMEOUT  $file  (killed after ${TIMEOUT}s)"
-        cat /tmp/kaappi-test-out
+        cat "$TMPOUT"
         TIMEDOUT=$((TIMEDOUT + 1))
         return
     fi
@@ -39,7 +44,7 @@ run_file() {
         PASS=$((PASS + 1))
     else
         echo "  FAIL  $file"
-        cat /tmp/kaappi-test-out
+        cat "$TMPOUT"
         FAIL=$((FAIL + 1))
     fi
 }
@@ -73,19 +78,20 @@ run_suite() {
     echo ""
 }
 
-run_suite "Smoke tests" tests/scheme/smoke/*.scm
-run_suite "Compliance tests" tests/scheme/compliance/*.scm
-run_suite "Continuation tests" tests/scheme/continuations/*.scm
-run_suite "Hygiene tests" tests/scheme/hygiene/*.scm
-run_suite "SRFI tests" tests/scheme/srfi/*.scm
-run_suite "FFI tests" tests/scheme/ffi/*.scm
-run_suite "Audit tests" tests/scheme/audit/*.scm
-
-echo "=== Compile tests ==="
-for test_script in tests/scheme/compile/*.sh; do
-    if [[ -x "$test_script" ]]; then
+run_shell_suite() {
+    local title="$1" dir="$2"
+    local matched=0
+    echo "=== $title ==="
+    for test_script in "$dir"/*.sh; do
+        [[ -e "$test_script" ]] || continue
+        if [[ ! -x "$test_script" ]]; then
+            echo "  FAIL  $test_script  (not executable)"
+            FAIL=$((FAIL + 1))
+            continue
+        fi
+        matched=1
         set +e
-        bash "$test_script" "$KAAPPI" > /tmp/kaappi-test-out 2>&1
+        KAAPPI="$KAAPPI" bash "$test_script" "$KAAPPI" > "$TMPOUT" 2>&1
         status=$?
         set -e
         if [[ $status -eq 0 ]]; then
@@ -93,19 +99,32 @@ for test_script in tests/scheme/compile/*.sh; do
             PASS=$((PASS + 1))
         else
             echo "  FAIL  $test_script"
-            cat /tmp/kaappi-test-out
+            cat "$TMPOUT"
             FAIL=$((FAIL + 1))
         fi
+    done
+    if [[ $matched -eq 0 ]]; then
+        echo "  (no tests matched)"
     fi
-done
-echo ""
+    echo ""
+}
+
+run_suite "Smoke tests" tests/scheme/smoke/*.scm
+run_shell_suite "Smoke shell tests" tests/scheme/smoke
+run_suite "Compliance tests" tests/scheme/compliance/*.scm
+run_suite "Continuation tests" tests/scheme/continuations/*.scm
+run_suite "Hygiene tests" tests/scheme/hygiene/*.scm
+run_suite "SRFI tests" tests/scheme/srfi/*.scm
+run_suite "FFI tests" tests/scheme/ffi/*.scm
+run_suite "Audit tests" tests/scheme/audit/*.scm
+run_shell_suite "Error tests" tests/scheme/errors
+run_shell_suite "Compile tests" tests/scheme/compile
 
 echo "=== R7RS test suite ==="
 set +e
-# Capture stdout and stderr separately to preserve panic messages
-"$KAAPPI" tests/scheme/r7rs/r7rs-tests.scm > /tmp/kaappi-r7rs-stdout 2> /tmp/kaappi-r7rs-stderr
+"$KAAPPI" tests/scheme/r7rs/r7rs-tests.scm > "$TMPSTDOUT" 2> "$TMPSTDERR"
 R7RS_STATUS=$?
-R7RS_OUTPUT="$(cat /tmp/kaappi-r7rs-stdout /tmp/kaappi-r7rs-stderr)"
+R7RS_OUTPUT="$(cat "$TMPSTDOUT" "$TMPSTDERR")"
 set -e
 
 R7RS_PASS=$(printf "%s\n" "$R7RS_OUTPUT" | awk '{for (i = 1; i < NF; i++) { w=$(i+1); gsub(",", "", w); if ($i ~ /^[0-9]+$/ && w == "pass") s += $i }} END {print s + 0}')
@@ -114,9 +133,9 @@ echo "  $R7RS_PASS pass, $R7RS_FAIL fail"
 if [[ $R7RS_STATUS -ne 0 ]]; then
     echo "  FAIL  tests/scheme/r7rs/r7rs-tests.scm (exit $R7RS_STATUS)"
     echo "--- stderr output ---"
-    cat /tmp/kaappi-r7rs-stderr 2>/dev/null || true
+    cat "$TMPSTDERR" 2>/dev/null || true
     echo "--- last 20 lines stdout ---"
-    tail -20 /tmp/kaappi-r7rs-stdout 2>/dev/null || true
+    tail -20 "$TMPSTDOUT" 2>/dev/null || true
     echo "--- end crash context ---"
     R7RS_STATUS_FAIL=1
 fi

--- a/tests/scheme/smoke/native-arith-regression.scm
+++ b/tests/scheme/smoke/native-arith-regression.scm
@@ -1,5 +1,5 @@
-;; JIT arithmetic NaN-boxing regression test
-;; Exercises JIT-compiled fixnum arithmetic, comparisons, and predicates
+;; Native backend arithmetic NaN-boxing regression test
+;; Exercises natively compiled fixnum arithmetic, comparisons, and predicates
 ;; with positive, negative, zero, and mixed-sign operands.
 
 (import (scheme base) (scheme write) (scheme process-context))
@@ -34,7 +34,7 @@
 (define (get-car x) (car x))
 (define (get-cdr x) (cdr x))
 
-;; Call each function 200+ times to trigger JIT compilation (threshold=100)
+;; Call each function 200+ times to trigger native compilation (threshold=100)
 (let loop ((i 0))
   (when (< i 200)
     (add 1 2) (sub 5 3) (mul 2 3) (lt? 1 2) (gt? 2 1) (le? 1 1) (ge? 1 1) (eq? 5 5)
@@ -43,7 +43,7 @@
     (add -1 -2) (sub -1 1) (mul -2 3) (lt? -1 1) (gt? 1 -1) (eq? -1 -1)
     (loop (+ i 1))))
 
-;; Now test with JIT-compiled versions
+;; Now test with natively compiled versions
 (check "add positive" 5 (add 2 3))
 (check "add zero" 42 (add 42 0))
 (check "add negative" -3 (add -1 -2))

--- a/tests/scheme/smoke/native-self-call-regression.scm
+++ b/tests/scheme/smoke/native-self-call-regression.scm
@@ -1,6 +1,6 @@
 ;; Regression test for emitSelfCallSequence frame-base off-by-one bug.
 ;;
-;; Bug: When the JIT self-call optimization is enabled, emitSelfCallSequence
+;; Bug: When the native self-call optimization is enabled, emitSelfCallSequence
 ;; computes the callee's frame base incorrectly (off by one register slot).
 ;; The callee's FRAME_PTR points one slot before the actual frame base,
 ;; causing register reads/writes to hit wrong slots.  The return value ends
@@ -13,11 +13,9 @@
 ;;   4. The arity matches
 ;;
 ;; This test defines a minimal non-tail self-recursive function and runs
-;; it enough times to trigger JIT compilation (threshold = 100 calls).
+;; it enough times to trigger native compilation (threshold = 100 calls).
 ;; If the self-call frame base is wrong, the return value will be
 ;; corrupted and the final result will differ from the expected answer.
-;;
-;; Run:  zig build run -- tests/scheme/jit-self-call-regression.scm
 
 (import (scheme base) (scheme write) (scheme process-context))
 
@@ -56,10 +54,10 @@
       0
       (+ 1 (count-down (- n 1)))))
 
-;; Must call >100 times per function to cross JIT threshold.
+;; Must call >100 times per function to cross native compilation threshold.
 ;; count-down(10) makes 10 recursive non-tail calls per invocation.
 ;; 20 outer iterations * 10 calls = 200 total calls to count-down,
-;; enough to JIT-compile it and then exercise the JIT code path.
+;; enough to natively compile it and then exercise the native code path.
 
 (define (repeat f n expected)
   (if (= n 0)
@@ -67,14 +65,14 @@
       (begin (f expected)  ; warm up call_count
              (repeat f (- n 1) expected))))
 
-(display "=== JIT self-call regression ===") (newline)
+(display "=== Native self-call regression ===") (newline)
 
 (check "count-down 0"  0  (count-down 0))
 (check "count-down 1"  1  (count-down 1))
 (check "count-down 10" 10 (count-down 10))
 
-;; Warm up to trigger JIT, then verify post-JIT correctness.
-(check "count-down 10 post-JIT" 10 (repeat count-down 20 10))
+;; Warm up to trigger native compilation, then verify post-compilation correctness.
+(check "count-down 10 post-native" 10 (repeat count-down 20 10))
 
 ;; ---------- Test 2: multi-arg self-recursion (sum-range) ----------
 ;;
@@ -87,7 +85,7 @@
       (+ lo (sum-range (+ lo 1) hi))))
 
 (check "sum-range 1..10" 55 (sum-range 1 10))
-(check "sum-range 1..10 post-JIT" 55 (repeat (lambda (x) (sum-range 1 x)) 20 10))
+(check "sum-range 1..10 post-native" 55 (repeat (lambda (x) (sum-range 1 x)) 20 10))
 
 ;; ---------- Test 3: nested self-call (double recursion) ----------
 ;;
@@ -102,7 +100,7 @@
       (+ (fib-like (- n 1)) (fib-like (- n 2)))))
 
 (check "fib-like 10" 55 (fib-like 10))
-(check "fib-like 10 post-JIT" 55 (repeat fib-like 25 10))
+(check "fib-like 10 post-native" 55 (repeat fib-like 25 10))
 
 ;; ---------- Summary ----------
 


### PR DESCRIPTION
## Summary

- Add `run_shell_suite()` to `run-all.sh` that discovers and runs `*.sh` scripts per suite directory — applied to `smoke/`, `errors/`, and `compile/` (replacing the inline compile loop)
- Move 2 loose `.scm` files from `tests/scheme/` top level into `smoke/` with accurate "native" naming (was stale "JIT")
- Replace hardcoded `/tmp/kaappi-test-out` paths with `mktemp` + trap cleanup for concurrent-safe runs
- Fail (not skip) on non-executable `.sh` files
- Remove now-redundant CI steps for `errors/error-format.sh` and `errors/exit-code.sh` (covered by `run-all.sh`)

Previously orphaned tests now running:
- `smoke/`: `repl-history-newline-821.sh`, `profile-json-escaping.sh`, `read-interactive-847.sh`, `repl-multiple-values.sh`, `sandbox-script-arg-783.sh`, `step-debug-mode-823.sh`
- `errors/`: `reader-token-errors.sh`, `reader-hasmore-errors.sh`, `test-source-snippet.sh`
- `smoke/`: `native-arith-regression.scm`, `native-self-call-regression.scm` (moved from top level)

## Test plan

- [x] `bash tests/scheme/run-all.sh` — all 1,698 tests pass (303 Scheme + 1,395 R7RS), including all 11 previously orphaned tests
- [x] Verified "Smoke shell tests" section shows all 6 `.sh` files
- [x] Verified "Error tests" section shows all 5 `.sh` files
- [x] Verified renamed `.scm` files appear in "Smoke tests" section
- [ ] CI passes on all matrix targets

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)