### PR TITLE
Add debug-checked Object.as(), typed accessors, and box helpers (#1051)

### DIFF
--- a/src/types.zig
+++ b/src/types.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const std = @import("std");
 
 /// A Scheme value packed into a 64-bit word (NaN-boxing).
@@ -207,7 +208,54 @@ pub const Object = struct {
     _align: Align = .{},
     const Align = if (@alignOf(?*Object) < 8) struct { _: u64 align(8) = 0 } else struct {};
 
+    fn expectedTag(comptime T: type) ?ObjectTag {
+        return switch (T) {
+            Pair => .pair,
+            Symbol => .symbol,
+            SchemeString => .string,
+            Closure => .closure,
+            NativeFn => .native_fn,
+            NativeClosure => .native_closure,
+            Vector => .vector,
+            Bytevector => .bytevector,
+            Port => .port,
+            RecordType => .record_type,
+            Function => .function,
+            Flonum => .flonum,
+            Transformer => .transformer,
+            ErrorObject => .error_object,
+            RecordInstance => .record_instance,
+            Continuation => .continuation,
+            MultipleValues => .multiple_values,
+            Complex => .complex,
+            Promise => .promise,
+            ParameterObject => .parameter,
+            FfiLibrary => .ffi_library,
+            FfiFunction => .ffi_function,
+            FfiCallback => .ffi_callback,
+            HashTable => .hash_table,
+            Bignum => .bignum,
+            Rational => .rational,
+            FileInfo => .file_info,
+            UserInfo => .user_info,
+            GroupInfo => .group_info,
+            DirectoryObject => .directory_object,
+            RandomSource => .random_source,
+            Channel => .channel,
+            Mutex => .mutex,
+            ConditionVariable => .condition_variable,
+            Srfi18Time => .srfi18_time,
+            SchemeEnvironment => .scheme_environment,
+            else => null,
+        };
+    }
+
     pub fn as(self: *Object, comptime T: type) *T {
+        if (builtin.mode == .Debug) {
+            if (comptime expectedTag(T)) |expected| {
+                std.debug.assert(self.tag == expected);
+            }
+        }
         return @ptrCast(@alignCast(self));
     }
 };
@@ -671,6 +719,10 @@ pub fn isPair(v: Value) bool {
     return isPointer(v) and toObject(v).tag == .pair;
 }
 
+pub fn toPair(v: Value) *Pair {
+    return toObject(v).as(Pair);
+}
+
 pub fn isSymbol(v: Value) bool {
     return isPointer(v) and toObject(v).tag == .symbol;
 }
@@ -683,8 +735,16 @@ pub fn isClosure(v: Value) bool {
     return isPointer(v) and toObject(v).tag == .closure;
 }
 
+pub fn toClosure(v: Value) *Closure {
+    return toObject(v).as(Closure);
+}
+
 pub fn isNativeFn(v: Value) bool {
     return isPointer(v) and toObject(v).tag == .native_fn;
+}
+
+pub fn toNativeFn(v: Value) *NativeFn {
+    return toObject(v).as(NativeFn);
 }
 
 pub fn isNativeClosure(v: Value) bool {
@@ -701,6 +761,10 @@ pub fn isProcedure(v: Value) bool {
 
 pub fn isContinuation(v: Value) bool {
     return isPointer(v) and toObject(v).tag == .continuation;
+}
+
+pub fn toContinuation(v: Value) *Continuation {
+    return toObject(v).as(Continuation);
 }
 
 pub fn isMultipleValues(v: Value) bool {
@@ -939,23 +1003,39 @@ fn bignumToF64(bn: *const Bignum) f64 {
 // ---------------------------------------------------------------------------
 
 pub fn car(v: Value) Value {
-    return toObject(v).as(Pair).car;
+    return toPair(v).car;
 }
 
 pub fn cdr(v: Value) Value {
-    return toObject(v).as(Pair).cdr;
+    return toPair(v).cdr;
 }
 
 pub fn setCar(v: Value, val: Value) void {
-    toObject(v).as(Pair).car = val;
+    toPair(v).car = val;
 }
 
 pub fn setCdr(v: Value, val: Value) void {
-    toObject(v).as(Pair).cdr = val;
+    toPair(v).cdr = val;
 }
 
 pub fn symbolName(v: Value) []const u8 {
     return toObject(v).as(Symbol).name;
+}
+
+// ---------------------------------------------------------------------------
+// Box helpers (upvalue box = pair whose cdr is VOID)
+// ---------------------------------------------------------------------------
+
+pub fn isBox(v: Value) bool {
+    return isPair(v) and cdr(v) == VOID;
+}
+
+pub fn boxGet(v: Value) Value {
+    return toPair(v).car;
+}
+
+pub fn boxSet(v: Value, val: Value) void {
+    toPair(v).car = val;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -352,8 +352,8 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 if (idx >= closure.upvalues.len) return VMError.InvalidBytecode;
                 const uv = closure.upvalues[idx];
                 const dst_idx = try registerIndex(self, frame.base, dst);
-                self.registers[dst_idx] = if (types.isPair(uv) and types.cdr(uv) == types.VOID)
-                    types.car(uv)
+                self.registers[dst_idx] = if (types.isBox(uv))
+                    types.boxGet(uv)
                 else
                     uv;
             },
@@ -364,9 +364,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 if (idx >= closure.upvalues.len) return VMError.InvalidBytecode;
                 const src_idx = try registerIndex(self, frame.base, src);
                 const uv = closure.upvalues[idx];
-                if (types.isPair(uv) and types.cdr(uv) == types.VOID) {
+                if (types.isBox(uv)) {
                     self.gc.writeBarrier(types.toObject(uv), self.registers[src_idx]);
-                    types.setCar(uv, self.registers[src_idx]);
+                    types.boxSet(uv, self.registers[src_idx]);
                 } else {
                     self.gc.writeBarrier(&closure.header, self.registers[src_idx]);
                     closure.upvalues[idx] = self.registers[src_idx];
@@ -872,7 +872,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (is_local) {
                         const local_idx = try registerIndex(self, frame.base, index);
                         var val = self.registers[local_idx];
-                        if (!types.isPair(val) or types.cdr(val) != types.VOID) {
+                        if (!types.isBox(val)) {
                             const box = self.gc.allocPair(val, types.VOID) catch return VMError.OutOfMemory;
                             cls = types.toObject(cls_val).as(types.Closure);
                             self.registers[local_idx] = box;
@@ -1248,12 +1248,8 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const reg = readU16(self, frame);
                 const reg_idx = try registerIndex(self, frame.base, reg);
                 const val = self.registers[reg_idx];
-                // Idempotent: if the register already holds a box (a pair whose
-                // cdr is VOID, the box marker used throughout), leave it alone.
-                // Without this, a box_local that re-executes on a loop back-edge
-                // would wrap the previous box in a fresh one, and the inner box
-                // pair would leak out as a Scheme value (issue #803).
-                if (!types.isPair(val) or types.cdr(val) != types.VOID) {
+                // Idempotent: leave existing boxes alone (issue #803).
+                if (!types.isBox(val)) {
                     const box = self.gc.allocPair(val, types.VOID) catch return VMError.OutOfMemory;
                     self.registers[reg_idx] = box;
                 }
@@ -1264,8 +1260,8 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const dst_idx = try registerIndex(self, frame.base, dst_r);
                 const reg_idx = try registerIndex(self, frame.base, reg);
                 const val = self.registers[reg_idx];
-                if (types.isPair(val) and types.cdr(val) == types.VOID) {
-                    self.registers[dst_idx] = types.car(val);
+                if (types.isBox(val)) {
+                    self.registers[dst_idx] = types.boxGet(val);
                 } else {
                     const box = self.gc.allocPair(val, types.VOID) catch return VMError.OutOfMemory;
                     self.registers[reg_idx] = box;
@@ -1278,9 +1274,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const reg_idx = try registerIndex(self, frame.base, reg);
                 const src_idx = try registerIndex(self, frame.base, src);
                 const val = self.registers[reg_idx];
-                if (types.isPair(val) and types.cdr(val) == types.VOID) {
+                if (types.isBox(val)) {
                     self.gc.writeBarrier(types.toObject(val), self.registers[src_idx]);
-                    types.setCar(val, self.registers[src_idx]);
+                    types.boxSet(val, self.registers[src_idx]);
                 } else {
                     const box = self.gc.allocPair(self.registers[src_idx], types.VOID) catch return VMError.OutOfMemory;
                     self.registers[reg_idx] = box;


### PR DESCRIPTION
## Summary

- **Debug assertion in `Object.as()`**: comptime tag map covering all 35 in-file struct types; asserts tag match in Debug builds, zero cost in ReleaseSafe/Fast
- **Four missing `toXxx` accessors**: `toPair`, `toClosure`, `toNativeFn`, `toContinuation` — the hottest types that were missing convenience accessors all other types had
- **Box helpers**: `isBox`/`boxGet`/`boxSet` for the upvalue box convention (pair whose cdr is VOID), replacing 6 open-coded patterns in `vm_dispatch.zig`
- Updated `car`/`cdr`/`setCar`/`setCdr` to use `toPair` internally

## Test plan

- [x] `zig build test` — unit tests pass (debug mode exercises the new assertions)
- [x] `zig build` — ReleaseSafe build succeeds (assertions compiled out)
- [x] `bash tests/scheme/run-all.sh` — 1699 pass, 0 new failures

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)