### PR TITLE
Preserve line tables in .sbc bytecode cache

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -10,7 +10,7 @@ const GC = memory.GC;
 
 // File format constants
 const MAGIC = [4]u8{ 'K', 'P', 'B', 'C' };
-const VERSION: u16 = 6;
+const VERSION: u16 = 7;
 const MAX_FUNCTIONS: u32 = 16_384;
 const MAX_TOP_LEVEL_FUNCTIONS: u32 = 4_096;
 const MAX_CODE_BYTES: u32 = 4_194_304;
@@ -640,6 +640,14 @@ fn writeFunctionsToBuffer(w: *Writer, allocator: std.mem.Allocator, top_level_fu
         for (func.constants.items) |constant| {
             try writeConstant(w, allocator, constant, all_funcs, 0);
         }
+
+        // Debug info: source_line and line_table (added in v7)
+        try w.writeU32(allocator, func.source_line);
+        try w.writeU32(allocator, @intCast(func.line_table.items.len));
+        for (func.line_table.items) |entry| {
+            try w.writeU16(allocator, entry.offset);
+            try w.writeU32(allocator, entry.line);
+        }
     }
 
     return all_funcs_list;
@@ -805,6 +813,16 @@ fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?Deser
         for (0..const_count) |_| {
             const val = readConstant(&r, gc, all_funcs, 0) catch return null;
             func.constants.append(allocator, val) catch return BytecodeError.OutOfMemory;
+        }
+
+        // Debug info: source_line and line_table (added in v7)
+        func.source_line = r.readU32() catch return null;
+        const line_count = r.readU32() catch return null;
+        if (line_count > MAX_CODE_BYTES) return null;
+        for (0..line_count) |_| {
+            const offset = r.readU16() catch return null;
+            const line = r.readU32() catch return null;
+            func.line_table.append(allocator, .{ .offset = offset, .line = line }) catch return BytecodeError.OutOfMemory;
         }
     }
 
@@ -1307,6 +1325,50 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
     try std.testing.expectEqual(@as(f64, 4.0), loaded_cx.imag);
 }
 
+test "bytecode round-trip: line table and source_line preserved" {
+    const allocator = std.testing.allocator;
+    var gc = GC.init(allocator);
+    defer gc.deinit();
+
+    const func = try gc.allocFunction();
+    func.code.append(allocator, @intFromEnum(types.OpCode.load_const)) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.code.append(allocator, @intFromEnum(types.OpCode.@"return")) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.constants.append(allocator, types.makeFixnum(42)) catch unreachable;
+    func.arity = 1;
+    func.locals_count = 2;
+    func.source_line = 5;
+    func.line_table.append(allocator, .{ .offset = 0, .line = 5 }) catch unreachable;
+    func.line_table.append(allocator, .{ .offset = 5, .line = 7 }) catch unreachable;
+
+    var funcs_arr = [_]*Function{func};
+    const hash: u64 = 11111;
+    const path = "/tmp/kaappi_test_linetable.sbc";
+
+    try writeFileWithTopLevel(allocator, &funcs_arr, hash, path);
+    defer _ = std.posix.system.unlink(@ptrCast(path));
+
+    const result = try readFileWithTopLevel(&gc, hash, path);
+    try std.testing.expect(result != null);
+
+    const loaded = result.?;
+    defer allocator.free(loaded.funcs);
+
+    const lf = loaded.funcs[0];
+    try std.testing.expectEqual(@as(u32, 5), lf.source_line);
+    try std.testing.expectEqual(@as(usize, 2), lf.line_table.items.len);
+    try std.testing.expectEqual(@as(u16, 0), lf.line_table.items[0].offset);
+    try std.testing.expectEqual(@as(u32, 5), lf.line_table.items[0].line);
+    try std.testing.expectEqual(@as(u16, 5), lf.line_table.items[1].offset);
+    try std.testing.expectEqual(@as(u32, 7), lf.line_table.items[1].line);
+    try std.testing.expectEqual(@as(u32, 7), lf.lineForOffset(6));
+}
+
 test "bytecode validation rejects invalid opcode" {
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
@@ -1334,6 +1396,8 @@ test "bytecode validation rejects invalid opcode" {
     try w.writeU32(allocator, 1); // code_len
     try w.writeU8(allocator, 0xFF);
     try w.writeU32(allocator, 0); // const_count
+    try w.writeU32(allocator, 0); // source_line
+    try w.writeU32(allocator, 0); // line_table count
 
     const path = "/tmp/kaappi_test_invalid_opcode.sbc";
     const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -819,6 +819,13 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                 }
             }
 
+            // Set source_name on all loaded functions — the path is valid
+            // for the entire runFile scope, matching the fresh-compile path
+            // where the compiler sets source_name to the same pointer.
+            for (loaded.funcs) |func| {
+                func.source_name = path;
+            }
+
             const top_count = @min(loaded.top_level_count, @as(u32, @intCast(loaded.funcs.len)));
             for (loaded.funcs[0..top_count]) |func| {
                 var func_val = types.makePointer(@ptrCast(func));
@@ -827,14 +834,36 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                     vm.gc.popRoot();
                     script_had_error = true;
                     const detail = vm.getErrorDetail();
+                    const err_line = vm.last_error_line;
+                    const err_source = vm.last_error_source orelse path;
                     if (detail.len > 0) {
-                        var errbuf: [256]u8 = undefined;
-                        const s = std.fmt.bufPrint(&errbuf, "{s}: error: {s}\n", .{ path, detail }) catch "runtime error\n";
+                        var errbuf: [512]u8 = undefined;
+                        const s = if (err_line > 0)
+                            std.fmt.bufPrint(&errbuf, "{s}:{d}: error: {s}\n", .{ err_source, err_line, detail }) catch "runtime error\n"
+                        else
+                            std.fmt.bufPrint(&errbuf, "{s}: error: {s}\n", .{ err_source, detail }) catch "runtime error\n";
                         writeStderr(s);
                     } else {
-                        var errbuf: [256]u8 = undefined;
-                        const s = std.fmt.bufPrint(&errbuf, "{s}: runtime error: {}\n", .{ path, err }) catch "runtime error\n";
+                        var errbuf: [512]u8 = undefined;
+                        const s = if (err_line > 0)
+                            std.fmt.bufPrint(&errbuf, "{s}:{d}: runtime error: {}\n", .{ err_source, err_line, err }) catch "runtime error\n"
+                        else
+                            std.fmt.bufPrint(&errbuf, "{s}: runtime error: {}\n", .{ err_source, err }) catch "runtime error\n";
                         writeStderr(s);
+                    }
+                    if (err_line > 0) printSourceSnippet(source, err_line);
+                    const trace = vm.getLastStackTrace();
+                    if (trace.len > 1) {
+                        for (trace[1..]) |frame| {
+                            var tbuf: [256]u8 = undefined;
+                            if (frame.name) |name| {
+                                const ts = std.fmt.bufPrint(&tbuf, "  in {s} ({s}:{d})\n", .{ name, frame.source orelse "?", frame.line }) catch continue;
+                                writeStderr(ts);
+                            } else if (frame.line > 0) {
+                                const ts = std.fmt.bufPrint(&tbuf, "  called from {s}:{d}\n", .{ frame.source orelse "?", frame.line }) catch continue;
+                                writeStderr(ts);
+                            }
+                        }
                     }
                     vm.last_error_detail_len = 0;
                     continue;

--- a/tests/scheme/errors/test-source-snippet.sh
+++ b/tests/scheme/errors/test-source-snippet.sh
@@ -24,7 +24,8 @@ assert_contains() {
 }
 
 # Test: runtime error shows source snippet
-TMPFILE=$(mktemp /tmp/kaappi_err_XXXXXX.scm)
+TMPDIR=$(mktemp -d)
+TMPFILE="$TMPDIR/test.scm"
 echo '(define (foo x) (+ x 1))
 (foo "hello")' > "$TMPFILE"
 output=$("$KAAPPI" "$TMPFILE" 2>&1 || true)
@@ -36,7 +37,7 @@ else
     echo "  got: $output"
     FAIL=$((FAIL + 1))
 fi
-rm -f "$TMPFILE"
+rm -rf "$TMPDIR"
 
 echo ""
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Fixes #1096 — source snippets and line numbers silently disappeared from runtime error messages whenever a `.sbc` bytecode cache existed for the erroring file.

- **Serialize `source_line` and `line_table`** in the `.sbc` format (version bump v6 → v7; stale caches auto-invalidate)
- **Set `source_name`** on deserialized functions from the file path, matching the fresh-compile path
- **Mirror full error diagnostics** in the cached code path: line numbers, `printSourceSnippet()`, and stack traces — previously this path only printed the file name without any location info
- **Fix non-portable `mktemp`** in `test-source-snippet.sh` — `mktemp /tmp/kaappi_err_XXXXXX.scm` doesn't randomize on macOS because the template must end with X characters; use `mktemp -d` instead

## Test plan

- [x] New unit test: `bytecode round-trip: line table and source_line preserved` — verifies `source_line`, `line_table` entries, and `lineForOffset` survive serialization
- [x] `test-source-snippet.sh` passes on first and subsequent runs (cache hit path)
- [x] All error tests pass (`error-format.sh`, `exit-code.sh`)
- [x] Full test suite: 1700 pass, 0 fail (305 Scheme files + 1395 R7RS)
- [x] `zig build test` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)