### PR TITLE
Root callWithArgs return values in map, fold, and unfold primitives

### DIFF
--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -494,6 +494,9 @@ fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
     const proc = args[1];
     var acc = args[2];
 
+    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
+
     const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(snapshot);
 

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -388,11 +388,18 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
         }
 
         // Call procedure
-        const result = vm.callWithArgs(proc, call_args[0..list_count]) catch |err| {
+        var result = vm.callWithArgs(proc, call_args[0..list_count]) catch |err| {
             return primitives.mapVMError(err);
         };
 
-        const new_pair = gc.allocPair(result, types.NIL) catch return PrimitiveError.OutOfMemory;
+        // Root result: callWithArgs pops its frame, so the return value has
+        // no GC root until it is consed into the result list.
+        gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+        const new_pair = gc.allocPair(result, types.NIL) catch {
+            gc.popRoot();
+            return PrimitiveError.OutOfMemory;
+        };
+        gc.popRoot();
         if (result_head == types.NIL) {
             result_head = new_pair;
         } else {

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -133,10 +133,14 @@ fn isTruthyResult(v: Value) bool {
 
 // (fold proc init list1 ...)
 fn foldFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     var acc = args[1];
     const list_count = args.len - 2;
     if (list_count == 0) return PrimitiveError.ArityMismatch;
+
+    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     // Current pointers for each list
     var currents: [256]Value = undefined;
@@ -210,6 +214,8 @@ fn foldRightFn(args: []const Value) PrimitiveError!Value {
 
     // Fold from right to left
     var acc = init;
+    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     var call_args_buf: [257]Value = undefined;
     var idx = min_len;
     while (idx > 0) {
@@ -225,6 +231,7 @@ fn foldRightFn(args: []const Value) PrimitiveError!Value {
 
 // (reduce f ridentity list)
 fn reduceFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     const ridentity = args[1];
     var lst = args[2];
@@ -233,6 +240,8 @@ fn reduceFn(args: []const Value) PrimitiveError!Value {
     if (!types.isPair(lst)) return primitives.typeError("reduce", "pair", lst);
 
     var acc = types.car(lst);
+    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     lst = types.cdr(lst);
 
     while (lst != types.NIL) {
@@ -266,6 +275,8 @@ fn reduceRightFn(args: []const Value) PrimitiveError!Value {
     if (elems.items.len == 0) return ridentity;
 
     var acc = elems.items[elems.items.len - 1];
+    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     var idx = elems.items.len - 1;
     while (idx > 0) {
         idx -= 1;
@@ -1877,6 +1888,8 @@ fn unfoldRightFn(args: []const Value) PrimitiveError!Value {
     var result: Value = if (args.len > 4) args[4] else types.NIL;
     gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
     defer gc.popRoot();
+    gc.pushRoot(&seed) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     while (true) {
         const stop_args = [1]Value{seed};
@@ -1884,8 +1897,13 @@ fn unfoldRightFn(args: []const Value) PrimitiveError!Value {
         if (isTruthyResult(stop)) break;
 
         const map_args = [1]Value{seed};
-        const val = try callVM(f, &map_args);
-        result = gc.allocPair(val, result) catch return PrimitiveError.OutOfMemory;
+        var val = try callVM(f, &map_args);
+        gc.pushRoot(&val) catch return PrimitiveError.OutOfMemory;
+        result = gc.allocPair(val, result) catch {
+            gc.popRoot();
+            return PrimitiveError.OutOfMemory;
+        };
+        gc.popRoot();
 
         const succ_args = [1]Value{seed};
         seed = try callVM(g, &succ_args);
@@ -2043,10 +2061,14 @@ fn pairForEachFn(args: []const Value) PrimitiveError!Value {
 
 // (pair-fold kons knil list1 ...) — like fold but passes pairs not elements
 fn pairFoldFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     var acc = args[1];
     const list_count = args.len - 2;
     if (list_count == 0) return PrimitiveError.ArityMismatch;
+
+    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     var currents: [256]Value = undefined;
     for (0..list_count) |i| {
@@ -2104,6 +2126,8 @@ fn pairFoldRightFn(args: []const Value) PrimitiveError!Value {
     }
 
     var acc = init;
+    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
     var call_args_buf: [257]Value = undefined;
     var idx = min_len;
     while (idx > 0) {
@@ -2129,6 +2153,7 @@ fn mapInOrderFn(args: []const Value) PrimitiveError!Value {
     defer results.deinit(gc.allocator);
     var call_args_buf: [256]Value = undefined;
 
+    const extra_roots_base = gc.extra_roots.items.len;
     while (true) {
         var all_pairs = true;
         for (0..list_count) |i| {
@@ -2142,8 +2167,10 @@ fn mapInOrderFn(args: []const Value) PrimitiveError!Value {
         for (0..list_count) |i| call_args_buf[i] = types.car(currents[i]);
         const result = try callVM(proc, call_args_buf[0..list_count]);
         results.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
+        gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
         for (0..list_count) |i| currents[i] = types.cdr(currents[i]);
     }
+    gc.extra_roots.shrinkRetainingCapacity(extra_roots_base);
 
     var result_list: Value = types.NIL;
     gc.pushRoot(&result_list) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -798,6 +798,8 @@ fn stringUnfoldFn(args: []const Value) PrimitiveError!Value {
     const f = args[1];
     const g = args[2];
     var seed = args[3];
+    gc.pushRoot(&seed) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(gc.allocator);
@@ -835,6 +837,8 @@ fn stringUnfoldRightFn(args: []const Value) PrimitiveError!Value {
     const f = args[1];
     const g = args[2];
     var seed = args[3];
+    gc.pushRoot(&seed) catch return PrimitiveError.OutOfMemory;
+    defer gc.popRoot();
 
     var chars: std.ArrayList(u21) = .empty;
     defer chars.deinit(gc.allocator);

--- a/tests/scheme/smoke/map-gc-root-1093.scm
+++ b/tests/scheme/smoke/map-gc-root-1093.scm
@@ -1,0 +1,47 @@
+;; Regression test for #1093: map's callWithArgs result was unrooted
+;; before the subsequent allocPair, allowing GC to collect it.
+;; This caused SRFI-115 regexp compiled structures to be corrupted
+;; when GC timing aligned (observed as "unknown tag 0.0" or
+;; "type error in 'car': expected pair, got #<procedure>").
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 64) (srfi 115))
+
+(test-begin "map-gc-root-1093")
+
+;; Exercise map with a callback that allocates, creating GC pressure.
+(test-equal "map result survives GC"
+  '((a . 1) (b . 2) (c . 3))
+  (map (lambda (x y) (cons x y)) '(a b c) '(1 2 3)))
+
+;; Longer list to increase chance of GC firing mid-map
+(let ((xs (map (lambda (n) (cons n (make-string 100 #\x)))
+              '(1 2 3 4 5 6 7 8 9 10))))
+  (test-equal "map 10 elements" 10 (length xs))
+  (test-equal "map element intact" 1 (car (car xs))))
+
+;; SRFI-115 regexp-replace-all — the original failing case.
+(test-equal "regexp-replace-all #1093"
+  "f00 b00"
+  (regexp-replace-all "o" "foo boo" "0"))
+
+;; Run multiple times to exercise different GC timings
+(let loop ((i 0))
+  (when (< i 50)
+    (test-equal (string-append "regexp-replace-all iter " (number->string i))
+      "f00 b00 m00"
+      (regexp-replace-all "o" "foo boo moo" "0"))
+    (loop (+ i 1))))
+
+;; fold with a callback that allocates — exercises the acc rooting fix
+(test-equal "fold cons"
+  '(3 2 1)
+  (fold cons '() '(1 2 3)))
+
+(test-equal "fold allocating callback"
+  '((3 . "x") (2 . "x") (1 . "x"))
+  (fold (lambda (x acc) (cons (cons x "x") acc)) '() '(1 2 3)))
+
+(let ((runner (test-runner-current)))
+  (test-end "map-gc-root-1093")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- `callWithArgs` pops its temporary VM frame before returning, leaving the return value with no GC root — only a Zig stack local. If the next allocation triggers a collection, the value is swept and its memory reused.
- This caused the SRFI-115 "unknown tag 0.0" / "type error in 'car': expected pair, got #\<procedure\>" errors: `map` is used by `%csre` to build compiled regexp structures, and the unrooted callback results became dangling pointers after GC.
- Root the return value via `pushRoot`/`popRoot` (or `extra_roots`) in each affected primitive: `map`, `fold`, `fold-right`, `reduce`, `reduce-right`, `pair-fold`, `pair-fold-right`, `unfold-right`, `map-in-order`, `hash-table-fold`, `string-unfold`, `string-unfold-right`

Fixes #1093.

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1701 pass, 0 fail (306 Scheme files + 1395 R7RS)
- [x] SRFI-115 test with `-Dgc-threshold=1` — 68/68 pass
- [x] New regression test `tests/scheme/smoke/map-gc-root-1093.scm` — 56 assertions including 50 iterations of `regexp-replace-all`
- [x] Pre-existing `srfi1-gc-stress.scm` failure on main (`append-map` GC corruption) now passes with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)