### PR TITLE
Single-source the version string from build.zig.zon via build_options

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -21,7 +21,7 @@ If dirty, ask the user to commit or stash. If not on `main`, ask to switch.
 ## Step 1: Analyze changes and determine version
 
 ```bash
-grep 'pub const version' src/main.zig
+grep '\.version' build.zig.zon
 git tag -l 'v*' --sort=-v:refname | head -1
 git log $(git tag -l 'v*' --sort=-v:refname | head -1)..HEAD --oneline --no-merges
 git log $(git tag -l 'v*' --sort=-v:refname | head -1)..HEAD --stat --no-merges
@@ -68,24 +68,17 @@ The file uses Keep a Changelog format. After editing, it should look like:
 - Use today's date in YYYY-MM-DD format
 - Preserve all existing versioned sections below
 
-## Step 4: Update version strings
+## Step 4: Update version string
 
-Three files, all must match (no `v` prefix):
-
-**`src/main.zig` line 35:**
-```zig
-pub const version = "X.Y.Z";
-```
-
-**`src/thottam.zig` line 5:**
-```zig
-const version = "X.Y.Z";
-```
+One file — `build.zig.zon` is the single source of truth (no `v` prefix):
 
 **`build.zig.zon` line 3:**
 ```zig
 .version = "X.Y.Z",
 ```
+
+`src/main.zig` and `src/thottam.zig` read the version from `build_options`
+at build time, so they pick it up automatically.
 
 The docs site's `kaappi_version` (`../kaappi.github.io/mkdocs.yml`) is **not**
 bumped here — it lives in a separate repo and tracks the *released* artifact,

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const zon = @import("build.zig.zon");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
@@ -30,6 +31,7 @@ pub fn build(b: *std.Build) void {
     options.addOption(u32, "max_frames", max_frames);
     options.addOption(u32, "max_registers", max_registers);
     options.addOption(u32, "gc_initial_threshold", gc_threshold);
+    options.addOption([]const u8, "version", zon.version);
     const options_mod = options.createModule();
 
     const wf = b.addWriteFiles();

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -32,6 +32,8 @@ pub const fiber_mod = @import("fiber.zig");
 pub const primitives_fiber = @import("primitives_fiber.zig");
 
 const version = "0.1.0";
+const initialize_result =
+    "{\"capabilities\":{\"textDocumentSync\":1,\"completionProvider\":{\"resolveProvider\":false,\"triggerCharacters\":[]},\"hoverProvider\":true,\"documentSymbolProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true},\"serverInfo\":{\"name\":\"kaappi-lsp\",\"version\":\"" ++ version ++ "\"}}";
 
 fn log(msg: []const u8) void {
     _ = std.posix.system.write(2, msg.ptr, msg.len);
@@ -257,9 +259,7 @@ fn getArity(val: types.Value, buf: *[32]u8) ?[]const u8 {
 // ---- LSP handlers ----
 
 fn handleInitialize(allocator: std.mem.Allocator, id: []const u8) void {
-    sendResponse(allocator, id,
-        \\{"capabilities":{"textDocumentSync":1,"completionProvider":{"resolveProvider":false,"triggerCharacters":[]},"hoverProvider":true,"documentSymbolProvider":true,"definitionProvider":true,"referencesProvider":true},"serverInfo":{"name":"kaappi-lsp","version":"0.1.0"}}
-    );
+    sendResponse(allocator, id, initialize_result);
 }
 
 fn handleCompletion(allocator: std.mem.Allocator, vm: *vm_mod.VM, id: []const u8, params: std.json.ObjectMap) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,7 +42,7 @@ pub const ir_emitter = @import("ir_emitter.zig");
 pub const llvm_emit = @import("llvm_emit.zig");
 pub const native_compiler = @import("native_compiler.zig");
 
-pub const version = "0.12.0";
+pub const version = @import("build_options").version;
 
 fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const dylib_ext = if (builtin.os.tag == .macos) ".dylib" else ".so";
-const version = "0.12.0";
+const version = @import("build_options").version;
 
 const semver = @import("thottam_semver.zig");
 const proc = @import("thottam_proc.zig");

--- a/tests/scheme/smoke/version-flag.sh
+++ b/tests/scheme/smoke/version-flag.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Verify --version outputs the version from build.zig.zon
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+expected=$(grep '\.version' build.zig.zon | sed 's/.*"\(.*\)".*/\1/')
+output=$("$KAAPPI" --version 2>&1)
+
+if echo "$output" | grep -qF "$expected"; then
+    echo "PASS: --version contains $expected"
+else
+    echo "FAIL: expected '$expected' in output: $output"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #1060.

- Pipe `build.zig.zon`'s `.version` field through `build_options` so `main.zig` and `thottam.zig` derive the version at build time instead of hardcoding it
- Deduplicate the LSP version literal in `kaappi_lsp.zig` via comptime concatenation with the existing `version` constant
- Update the release skill to bump only `build.zig.zon` (down from 3 files)
- Add `tests/scheme/smoke/version-flag.sh` verifying `--version` output matches `build.zig.zon`

## Test plan

- [x] `zig build` succeeds
- [x] `zig build test` — all unit tests pass (including bytecode hash tests that exercise `main.version`)
- [x] `zig build run -- --version` outputs `Kaappi Scheme v0.12.0`
- [x] `bash tests/scheme/smoke/version-flag.sh` passes
- [x] `grep -rn '"0.12.0"' src/ build.zig` returns nothing — no hardcoded version strings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)