### PR TITLE
Deduplicate export lists and add drift test (#1053)

### DIFF
--- a/src/library.zig
+++ b/src/library.zig
@@ -102,127 +102,423 @@ pub const LibraryRegistry = struct {
     }
 };
 
+// ---------------------------------------------------------------------------
+// Export name lists — single source of truth for both standard and sandboxed
+// library registration. Exposed as pub const so the drift test can verify
+// every name resolves in globals after registerAll.
+// ---------------------------------------------------------------------------
+
+pub const scheme_base_names = [_][]const u8{
+    // Arithmetic
+    "+",                      "-",                              "*",                  "/",
+    "quotient",               "remainder",                      "modulo",             "=",
+    "<",                      ">",                              "<=",                 ">=",
+    "zero?",                  "positive?",                      "negative?",          "abs",
+    "min",                    "max",                            "even?",              "odd?",
+    "gcd",                    "lcm",
+    // Rounding
+                               "floor",              "ceiling",
+    "truncate",               "round",
+    // Exactness
+                             "exact?",             "inexact?",
+    "exact-integer?",         "exact",                          "inexact",
+    // Powers
+               "expt",
+    "square",                 "sqrt",                           "exact-integer-sqrt",
+    // Pairs and lists
+    "cons",
+    "car",                    "cdr",                            "set-car!",           "set-cdr!",
+    "list",                   "length",                         "append",             "reverse",
+    "caar",                   "cadr",                           "cdar",               "cddr",
+    "list-ref",               "list-tail",                      "list-set!",          "list-copy",
+    "make-list",              "member",                         "memq",               "memv",
+    "assoc",                  "assq",                           "assv",
+    // Higher-order list functions
+                  "map",
+    "for-each",
+    // Type predicates
+                  "pair?",                          "null?",              "number?",
+    "integer?",               "real?",                          "complex?",           "rational?",
+    "symbol?",                "string?",                        "boolean?",           "char?",
+    "procedure?",             "list?",
+    // Equivalence
+                             "eq?",                "eqv?",
+    "equal?",
+    // Boolean
+                    "not",                            "boolean=?",          "symbol=?",
+    // String operations
+    "number->string",         "string->number",                 "string-length",      "string-append",
+    "symbol->string",         "string->symbol",                 "string",             "make-string",
+    "string-ref",             "string-set!",                    "substring",          "string-copy",
+    "string-copy!",           "string-fill!",                   "string->list",       "list->string",
+    "string-for-each",        "string-map",                     "string<?",           "string<=?",
+    "string=?",               "string>=?",                      "string>?",
+    // Char operations (base library subset)
+              "char->integer",
+    "integer->char",          "char<?",                         "char<=?",            "char=?",
+    "char>=?",                "char>?",
+    // I/O (also in scheme.write)
+                            "display",            "write",
+    "newline",
+    // Misc
+                   "apply",                          "error",
+    // Exception system (R7RS 6.11)
+                 "raise",
+    "raise-continuable",      "with-exception-handler",         "error-object?",      "error-object-message",
+    "error-object-irritants", "file-error?",                    "read-error?",
+    // Record system internal primitives (used by define-record-type)
+           "%make-record-type",
+    "%make-record",           "%record?",                       "%record-ref",        "%record-set!",
+    // Port and I/O (R7RS 6.13)
+    "current-input-port",     "current-output-port",            "current-error-port", "port?",
+    "input-port?",            "output-port?",                   "textual-port?",      "binary-port?",
+    "input-port-open?",       "output-port-open?",              "close-port",         "close-input-port",
+    "close-output-port",      "read-char",                      "peek-char",          "read-line",
+    "char-ready?",            "write-char",                     "write-string",       "eof-object?",
+    "eof-object",
+    // Continuations (R7RS 6.10)
+                "call-with-current-continuation", "call/cc",            "call-with-escape-continuation",
+    "call/ec",                "dynamic-wind",                   "values",             "call-with-values",
+    // Complex numbers
+    "make-rectangular",       "make-polar",                     "real-part",          "imag-part",
+    "magnitude",              "angle",
+    // Vectors (R7RS 6.8)
+                             "vector",             "make-vector",
+    "vector?",                "vector-length",                  "vector-ref",         "vector-set!",
+    "vector->list",           "list->vector",                   "vector-fill!",       "vector-copy",
+    "vector-copy!",           "vector-append",                  "vector-for-each",    "vector-map",
+    "vector->string",
+    // Bytevectors (R7RS 6.9)
+            "bytevector?",                    "make-bytevector",    "bytevector",
+    "bytevector-length",      "bytevector-u8-ref",              "bytevector-u8-set!", "bytevector-copy",
+    "bytevector-copy!",       "bytevector-append",              "utf8->string",       "string->utf8",
+    // String ports
+    "open-input-string",      "open-output-string",             "get-output-string",
+    // Additional I/O
+     "read-string",
+    "flush-output-port",
+    // Integer division
+         "floor-quotient",                 "floor-remainder",    "floor/",
+    "truncate-quotient",      "truncate-remainder",             "truncate/",
+    // Rational
+             "numerator",
+    "denominator",            "rationalize",
+    // Aliases
+                       "exact->inexact",     "inexact->exact",
+    // Misc
+    "features",
+    // Promises
+                  "make-promise",                   "promise?",
+    // Parameters
+              "make-parameter",
+    // File I/O wrappers
+    "call-with-port",
+    // Binary I/O
+            "read-u8",                        "peek-u8",            "u8-ready?",
+    "write-u8",               "read-bytevector",                "write-bytevector",
+    // Bytevector ports
+      "open-input-bytevector",
+    "open-output-bytevector", "get-output-bytevector",          "read-bytevector!",
+    // String/vector conversion
+      "string->vector",
+};
+
+pub const scheme_write_names = [_][]const u8{
+    "display",      "write",
+    "write-shared", "write-simple",
+};
+
+pub const scheme_inexact_names = [_][]const u8{
+    "sin", "cos", "tan",  "asin",    "acos",      "atan",
+    "exp", "log", "sqrt", "finite?", "infinite?", "nan?",
+};
+
+pub const scheme_read_names = [_][]const u8{"read"};
+
+pub const scheme_char_names = [_][]const u8{
+    "char-alphabetic?", "char-numeric?",    "char-whitespace?",
+    "char-upper-case?", "char-lower-case?", "char-upcase",
+    "char-downcase",    "char-foldcase",    "digit-value",
+    "char-ci<?",        "char-ci<=?",       "char-ci=?",
+    "char-ci>=?",       "char-ci>?",        "string-ci<?",
+    "string-ci<=?",     "string-ci=?",      "string-ci>=?",
+    "string-ci>?",      "string-upcase",    "string-downcase",
+    "string-foldcase",
+};
+
+pub const scheme_lazy_names = [_][]const u8{
+    "delay", "delay-force", "force", "make-promise", "promise?",
+};
+
+pub const scheme_time_names = [_][]const u8{
+    "current-second", "current-jiffy", "jiffies-per-second",
+};
+
+pub const scheme_pc_names = [_][]const u8{
+    "command-line",             "exit",                      "emergency-exit",
+    "get-environment-variable", "get-environment-variables",
+};
+
+pub const scheme_eval_names = [_][]const u8{ "eval", "environment", "interaction-environment" };
+
+pub const scheme_repl_names = [_][]const u8{"interaction-environment"};
+
+pub const scheme_load_names = [_][]const u8{"load"};
+
+// (scheme r5rs) — R5RS compatibility. Per R7RS Appendix A, this library
+// provides the full R5RS identifier set (except transcript-on/off, which
+// Kaappi does not implement). exact/inexact appear under their R5RS names
+// (exact->inexact, inexact->exact), which are registered as globals, so no
+// renaming is needed. Syntactic keywords (define, lambda, if, cond,
+// syntax-rules, ...) are recognized directly by the compiler rather than
+// stored as runtime values, so the globals.get guard below skips them —
+// the same as (scheme base) above. Listing them keeps this a faithful,
+// auditable transcription of the Appendix A table.
+pub const scheme_r5rs_names = [_][]const u8{
+    "*",                         "+",                              "...",
+    "/",                         "<",                              "<=",
+    "=",                         "=>",                             ">",
+    ">=",                        "abs",                            "acos",
+    "and",                       "angle",                          "append",
+    "apply",                     "asin",                           "assoc",
+    "assq",                      "assv",                           "atan",
+    "begin",                     "boolean?",                       "caaaar",
+    "caaadr",                    "caaar",                          "caadar",
+    "caaddr",                    "caadr",                          "caar",
+    "cadaar",                    "cadadr",                         "cadar",
+    "caddar",                    "cadddr",                         "caddr",
+    "cadr",                      "call-with-current-continuation", "call-with-input-file",
+    "call-with-output-file",     "call-with-values",               "car",
+    "case",                      "cdaaar",                         "cdaadr",
+    "cdaar",                     "cdadar",                         "cdaddr",
+    "cdadr",                     "cdar",                           "cddaar",
+    "cddadr",                    "cddar",                          "cdddar",
+    "cddddr",                    "cdddr",                          "cddr",
+    "cdr",                       "ceiling",                        "char->integer",
+    "char-alphabetic?",          "char-ci<=?",                     "char-ci<?",
+    "char-ci=?",                 "char-ci>=?",                     "char-ci>?",
+    "char-downcase",             "char-lower-case?",               "char-numeric?",
+    "char-ready?",               "char-upcase",                    "char-upper-case?",
+    "char-whitespace?",          "char<=?",                        "char<?",
+    "char=?",                    "char>=?",                        "char>?",
+    "char?",                     "close-input-port",               "close-output-port",
+    "complex?",                  "cond",                           "cons",
+    "cos",                       "current-input-port",             "current-output-port",
+    "define",                    "define-syntax",                  "delay",
+    "denominator",               "display",                        "do",
+    "dynamic-wind",              "else",                           "eof-object?",
+    "eq?",                       "equal?",                         "eqv?",
+    "eval",                      "even?",                          "exact->inexact",
+    "exact?",                    "exp",                            "expt",
+    "floor",                     "for-each",                       "force",
+    "gcd",                       "if",                             "imag-part",
+    "inexact->exact",            "inexact?",                       "input-port?",
+    "integer->char",             "integer?",                       "interaction-environment",
+    "lambda",                    "lcm",                            "length",
+    "let",                       "let*",                           "let-syntax",
+    "letrec",                    "letrec-syntax",                  "list",
+    "list->string",              "list->vector",                   "list-ref",
+    "list-tail",                 "list?",                          "load",
+    "log",                       "magnitude",                      "make-polar",
+    "make-rectangular",          "make-string",                    "make-vector",
+    "map",                       "max",                            "member",
+    "memq",                      "memv",                           "min",
+    "modulo",                    "negative?",                      "newline",
+    "not",                       "null-environment",               "null?",
+    "number->string",            "number?",                        "numerator",
+    "odd?",                      "open-input-file",                "open-output-file",
+    "or",                        "output-port?",                   "pair?",
+    "peek-char",                 "positive?",                      "procedure?",
+    "quasiquote",                "quote",                          "quotient",
+    "rational?",                 "rationalize",                    "read",
+    "read-char",                 "real-part",                      "real?",
+    "remainder",                 "reverse",                        "round",
+    "scheme-report-environment", "set!",                           "set-car!",
+    "set-cdr!",                  "sin",                            "sqrt",
+    "string",                    "string->list",                   "string->number",
+    "string->symbol",            "string-append",                  "string-ci<=?",
+    "string-ci<?",               "string-ci=?",                    "string-ci>=?",
+    "string-ci>?",               "string-copy",                    "string-fill!",
+    "string-length",             "string-ref",                     "string-set!",
+    "string<=?",                 "string<?",                       "string=?",
+    "string>=?",                 "string>?",                       "string?",
+    "substring",                 "symbol->string",                 "symbol?",
+    "syntax-rules",              "tan",                            "truncate",
+    "values",                    "vector",                         "vector->list",
+    "vector-fill!",              "vector-length",                  "vector-ref",
+    "vector-set!",               "vector?",                        "with-input-from-file",
+    "with-output-to-file",       "write",                          "write-char",
+    "zero?",
+};
+
+pub const scheme_file_names = [_][]const u8{
+    "open-input-file",        "open-output-file",
+    "open-binary-input-file", "open-binary-output-file",
+    "file-exists?",           "delete-file",
+    "call-with-input-file",   "call-with-output-file",
+    "with-input-from-file",   "with-output-to-file",
+    "create-directory",       "delete-directory",
+};
+
+pub const scheme_cxr_names = [_][]const u8{
+    // Two-level (also in base)
+    "caar",   "cadr",   "cdar",   "cddr",
+    // Three-level
+    "caaar",  "caadr",  "cadar",  "caddr",
+    "cdaar",  "cdadr",  "cddar",  "cdddr",
+    // Four-level
+    "caaaar", "caaadr", "caadar", "caaddr",
+    "cadaar", "cadadr", "caddar", "cadddr",
+    "cdaaar", "cdaadr", "cdadar", "cdaddr",
+    "cddaar", "cddadr", "cdddar", "cddddr",
+};
+
+pub const scheme_complex_names = [_][]const u8{
+    "make-rectangular", "make-polar",
+    "real-part",        "imag-part",
+    "magnitude",        "angle",
+};
+
+pub const kaappi_ffi_names = [_][]const u8{
+    "ffi-open",           "ffi-fn",       "ffi-close",
+    "ffi-bytevector-ptr", "ffi-callback", "ffi-callback-release",
+    "ffi-callback?",
+};
+
+pub const kaappi_fiber_names = [_][]const u8{
+    "spawn",        "yield",        "fiber-join",      "fiber?",
+    "make-channel", "channel-send", "channel-receive", "channel?",
+};
+
+pub const srfi18_names = [_][]const u8{
+    "current-thread",             "thread?",                       "make-thread",
+    "thread-name",                "thread-specific",               "thread-specific-set!",
+    "thread-start!",              "thread-yield!",                 "thread-sleep!",
+    "thread-terminate!",          "thread-join!",                  "mutex?",
+    "make-mutex",                 "mutex-name",                    "mutex-specific",
+    "mutex-specific-set!",        "mutex-state",                   "mutex-lock!",
+    "mutex-unlock!",              "condition-variable?",           "make-condition-variable",
+    "condition-variable-name",    "condition-variable-specific",   "condition-variable-specific-set!",
+    "condition-variable-signal!", "condition-variable-broadcast!", "current-time",
+    "time?",                      "time->seconds",                 "seconds->time",
+    "join-timeout-exception?",    "abandoned-mutex-exception?",    "terminated-thread-exception?",
+    "uncaught-exception?",        "uncaught-exception-reason",
+};
+
+pub const srfi18_base_reexports = [_][]const u8{
+    "with-exception-handler",
+    "raise",
+};
+
+pub const srfi1_names = [_][]const u8{
+    "cons",              "car",             "cdr",          "pair?",
+    "null?",             "list",            "length",       "append",
+    "reverse",           "map",             "for-each",     "member",
+    "memq",              "memv",            "assoc",        "assq",
+    "assv",              "list-ref",        "set-car!",     "set-cdr!",
+    "list-copy",         "make-list",       "caar",         "cadr",
+    "cdar",              "cddr",            "fold",         "fold-right",
+    "reduce",            "reduce-right",    "filter",       "remove",
+    "partition",         "find",            "find-tail",    "any",
+    "every",             "count",           "iota",         "zip",
+    "concatenate",       "take",            "drop",         "take-while",
+    "drop-while",        "filter-map",      "append-map",   "last",
+    "last-pair",         "proper-list?",    "dotted-list?", "circular-list?",
+    "lset-intersection", "lset-difference", "lset=",        "lset-adjoin",
+    "lset-union",        "lset-xor",        "xcons",        "cons*",
+    "list-tabulate",     "circular-list",   "not-pair?",    "null-list?",
+    "list=",             "first",           "second",       "third",
+    "fourth",            "fifth",           "sixth",        "seventh",
+    "eighth",            "ninth",           "tenth",        "car+cdr",
+    "take-right",        "drop-right",      "split-at",     "list-index",
+    "span",              "break",           "delete",       "delete-duplicates",
+    "alist-cons",        "alist-copy",      "alist-delete", "unfold",
+    "unfold-right",      "append-reverse",  "length+",      "unzip1",
+    "unzip2",            "pair-for-each",   "pair-fold",    "pair-fold-right",
+    "map-in-order",
+};
+
+pub const srfi13_names = [_][]const u8{
+    "string-contains",   "string-prefix?",      "string-suffix?",
+    "string-trim",       "string-trim-right",   "string-trim-both",
+    "string-index",      "string-count",        "string-split",
+    "string-join",       "string-concatenate",
+    // Also include standard string ops
+     "string-length",
+    "string-append",     "substring",           "string-copy",
+    "string-ref",        "string-set!",         "string<?",
+    "string<=?",         "string=?",            "string>=?",
+    "string>?",          "string-upcase",       "string-downcase",
+    "string-foldcase",   "string-take",         "string-drop",
+    "string-take-right", "string-drop-right",   "string-pad",
+    "string-pad-right",  "string-reverse",      "string-filter",
+    "string-delete",     "string-replace",      "string-titlecase",
+    "string-every",      "string-any",          "string-tabulate",
+    "string-unfold",     "string-unfold-right", "string-index-right",
+    "string-skip",       "string-skip-right",
+};
+
+pub const srfi39_names = [_][]const u8{"make-parameter"};
+
+pub const srfi69_names = [_][]const u8{
+    "make-hash-table",          "hash-table?",
+    "hash-table-ref",           "hash-table-set!",
+    "hash-table-delete!",       "hash-table-exists?",
+    "hash-table-size",          "hash-table-keys",
+    "hash-table-values",        "hash-table-walk",
+    "hash-table->alist",        "alist->hash-table",
+    "hash-table-copy",          "hash-table-update!/default",
+    "hash",                     "string-hash",
+    "string-ci-hash",           "hash-by-identity",
+    "hash-table-ref/default",   "hash-table-fold",
+    "hash-table-merge!",        "hash-table-equivalence-function",
+    "hash-table-hash-function",
+};
+
+pub const srfi133_names = [_][]const u8{
+    "vector",              "make-vector",              "vector?",             "vector-length",
+    "vector-ref",          "vector-set!",              "vector->list",        "list->vector",
+    "vector->string",      "string->vector",           "vector-fill!",        "vector-copy",
+    "vector-copy!",        "vector-append",            "vector-for-each",     "vector-map",
+    "vector-empty?",       "vector-count",             "vector-any",          "vector-every",
+    "vector-index",        "vector-index-right",       "vector-skip",         "vector-skip-right",
+    "vector-swap!",        "vector-reverse!",          "vector-reverse-copy", "vector-unfold",
+    "vector-unfold-right", "vector-binary-search",     "vector-concatenate",  "vector-cumulate",
+    "vector-partition",    "vector-append-subvectors",
+};
+
+pub const srfi170_names = [_][]const u8{
+    "directory-files",           "file-info",                    "file-info?",
+    "file-info-directory?",      "file-info-regular?",           "file-info-symlink?",
+    "file-info-fifo?",           "file-info-socket?",            "file-info-device?",
+    "file-info:size",            "file-info:mtime",              "file-info:mode",
+    "file-info:device",          "file-info:inode",              "file-info:nlinks",
+    "file-info:uid",             "file-info:gid",                "file-info:rdev",
+    "file-info:blksize",         "file-info:blocks",             "file-info:atime",
+    "file-info:ctime",           "create-directory",             "delete-directory",
+    "rename-file",               "create-symlink",               "read-symlink",
+    "create-hard-link",          "real-path",                    "set-file-mode",
+    "truncate-file",             "create-fifo",                  "set-file-owner",
+    "set-file-times",            "pid",                          "umask",
+    "set-umask!",                "current-directory",            "set-current-directory!",
+    "user-uid",                  "user-gid",                     "user-effective-uid",
+    "user-effective-gid",        "user-supplementary-gids",      "nice",
+    "set-environment-variable!", "delete-environment-variable!", "terminal?",
+    "user-info",                 "user-info?",                   "user-info:name",
+    "user-info:uid",             "user-info:gid",                "user-info:home-dir",
+    "user-info:shell",           "user-info:full-name",          "group-info",
+    "group-info?",               "group-info:name",              "group-info:gid",
+    "open-directory",            "read-directory",               "close-directory",
+    "posix-time",                "monotonic-time",               "file-info-type",
+    "temp-file-prefix",          "create-temp-file",
+};
+
 /// Register the standard R7RS libraries from the VM's globals map.
 /// This should be called after primitives.registerAll has populated the globals.
 pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.StringHashMap(Value)) !void {
     const allocator = registry.allocator;
 
     // (scheme base) — all standard procedures
-    const scheme_base_names = [_][]const u8{
-        // Arithmetic
-        "+",                      "-",                              "*",                  "/",
-        "quotient",               "remainder",                      "modulo",             "=",
-        "<",                      ">",                              "<=",                 ">=",
-        "zero?",                  "positive?",                      "negative?",          "abs",
-        "min",                    "max",                            "even?",              "odd?",
-        "gcd",                    "lcm",
-        // Rounding
-                                   "floor",              "ceiling",
-        "truncate",               "round",
-        // Exactness
-                                 "exact?",             "inexact?",
-        "exact-integer?",         "exact",                          "inexact",
-        // Powers
-                   "expt",
-        "square",                 "sqrt",                           "exact-integer-sqrt",
-        // Pairs and lists
-        "cons",
-        "car",                    "cdr",                            "set-car!",           "set-cdr!",
-        "list",                   "length",                         "append",             "reverse",
-        "caar",                   "cadr",                           "cdar",               "cddr",
-        "list-ref",               "list-tail",                      "list-set!",          "list-copy",
-        "make-list",              "member",                         "memq",               "memv",
-        "assoc",                  "assq",                           "assv",
-        // Higher-order list functions
-                      "map",
-        "for-each",
-        // Type predicates
-                      "pair?",                          "null?",              "number?",
-        "integer?",               "real?",                          "complex?",           "rational?",
-        "symbol?",                "string?",                        "boolean?",           "char?",
-        "procedure?",             "list?",
-        // Equivalence
-                                 "eq?",                "eqv?",
-        "equal?",
-        // Boolean
-                        "not",                            "boolean=?",          "symbol=?",
-        // String operations
-        "number->string",         "string->number",                 "string-length",      "string-append",
-        "symbol->string",         "string->symbol",                 "string",             "make-string",
-        "string-ref",             "string-set!",                    "substring",          "string-copy",
-        "string-copy!",           "string-fill!",                   "string->list",       "list->string",
-        "string-for-each",        "string-map",                     "string<?",           "string<=?",
-        "string=?",               "string>=?",                      "string>?",
-        // Char operations (base library subset)
-                  "char->integer",
-        "integer->char",          "char<?",                         "char<=?",            "char=?",
-        "char>=?",                "char>?",
-        // I/O (also in scheme.write)
-                                "display",            "write",
-        "newline",
-        // Misc
-                       "apply",                          "error",
-        // Exception system (R7RS 6.11)
-                     "raise",
-        "raise-continuable",      "with-exception-handler",         "error-object?",      "error-object-message",
-        "error-object-irritants", "file-error?",                    "read-error?",
-        // Record system internal primitives (used by define-record-type)
-               "%make-record-type",
-        "%make-record",           "%record?",                       "%record-ref",        "%record-set!",
-        // Port and I/O (R7RS 6.13)
-        "current-input-port",     "current-output-port",            "current-error-port", "port?",
-        "input-port?",            "output-port?",                   "textual-port?",      "binary-port?",
-        "input-port-open?",       "output-port-open?",              "close-port",         "close-input-port",
-        "close-output-port",      "read-char",                      "peek-char",          "read-line",
-        "char-ready?",            "write-char",                     "write-string",       "eof-object?",
-        "eof-object",
-        // Continuations (R7RS 6.10)
-                    "call-with-current-continuation", "call/cc",            "call-with-escape-continuation",
-        "call/ec",                "dynamic-wind",                   "values",             "call-with-values",
-        // Complex numbers
-        "make-rectangular",       "make-polar",                     "real-part",          "imag-part",
-        "magnitude",              "angle",
-        // Vectors (R7RS 6.8)
-                                 "vector",             "make-vector",
-        "vector?",                "vector-length",                  "vector-ref",         "vector-set!",
-        "vector->list",           "list->vector",                   "vector-fill!",       "vector-copy",
-        "vector-copy!",           "vector-append",                  "vector-for-each",    "vector-map",
-        "vector->string",
-        // Bytevectors (R7RS 6.9)
-                "bytevector?",                    "make-bytevector",    "bytevector",
-        "bytevector-length",      "bytevector-u8-ref",              "bytevector-u8-set!", "bytevector-copy",
-        "bytevector-copy!",       "bytevector-append",              "utf8->string",       "string->utf8",
-        // String ports
-        "open-input-string",      "open-output-string",             "get-output-string",
-        // Additional I/O
-         "read-string",
-        "flush-output-port",
-        // Integer division
-             "floor-quotient",                 "floor-remainder",    "floor/",
-        "truncate-quotient",      "truncate-remainder",             "truncate/",
-        // Rational
-                 "numerator",
-        "denominator",            "rationalize",
-        // Aliases
-                           "exact->inexact",     "inexact->exact",
-        // Misc
-        "features",
-        // Promises
-                      "make-promise",                   "promise?",
-        // Parameters
-                  "make-parameter",
-        // File I/O wrappers
-        "call-with-port",
-        // Binary I/O
-                "read-u8",                        "peek-u8",            "u8-ready?",
-        "write-u8",               "read-bytevector",                "write-bytevector",
-        // Bytevector ports
-          "open-input-bytevector",
-        "open-output-bytevector", "get-output-bytevector",          "read-bytevector!",
-        // String/vector conversion
-          "string->vector",
-    };
-
     var base = Library.init(allocator, "scheme.base");
     for (scheme_base_names) |name| {
         if (globals.get(name)) |val| {
@@ -231,11 +527,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(base);
 
-    // (scheme write) — write/display procedures
-    const scheme_write_names = [_][]const u8{
-        "display",      "write",
-        "write-shared", "write-simple",
-    };
+    // (scheme write)
     var write_lib = Library.init(allocator, "scheme.write");
     for (scheme_write_names) |name| {
         if (globals.get(name)) |val| {
@@ -244,11 +536,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(write_lib);
 
-    // (scheme inexact) — inexact math procedures
-    const scheme_inexact_names = [_][]const u8{
-        "sin", "cos", "tan",  "asin",    "acos",      "atan",
-        "exp", "log", "sqrt", "finite?", "infinite?", "nan?",
-    };
+    // (scheme inexact)
     var inexact_lib = Library.init(allocator, "scheme.inexact");
     for (scheme_inexact_names) |name| {
         if (globals.get(name)) |val| {
@@ -258,7 +546,6 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     try registry.register(inexact_lib);
 
     // (scheme read)
-    const scheme_read_names = [_][]const u8{"read"};
     var read_lib = Library.init(allocator, "scheme.read");
     for (scheme_read_names) |name| {
         if (globals.get(name)) |val| {
@@ -267,17 +554,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(read_lib);
 
-    // (scheme char) — character classification and case operations
-    const scheme_char_names = [_][]const u8{
-        "char-alphabetic?", "char-numeric?",    "char-whitespace?",
-        "char-upper-case?", "char-lower-case?", "char-upcase",
-        "char-downcase",    "char-foldcase",    "digit-value",
-        "char-ci<?",        "char-ci<=?",       "char-ci=?",
-        "char-ci>=?",       "char-ci>?",        "string-ci<?",
-        "string-ci<=?",     "string-ci=?",      "string-ci>=?",
-        "string-ci>?",      "string-upcase",    "string-downcase",
-        "string-foldcase",
-    };
+    // (scheme char)
     var char_lib = Library.init(allocator, "scheme.char");
     for (scheme_char_names) |name| {
         if (globals.get(name)) |val| {
@@ -286,10 +563,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(char_lib);
 
-    // (scheme lazy) — delay/force/promises
-    const scheme_lazy_names = [_][]const u8{
-        "delay", "delay-force", "force", "make-promise", "promise?",
-    };
+    // (scheme lazy)
     var lazy_lib = Library.init(allocator, "scheme.lazy");
     for (scheme_lazy_names) |name| {
         if (globals.get(name)) |val| {
@@ -298,10 +572,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(lazy_lib);
 
-    // (scheme time) — time procedures
-    const scheme_time_names = [_][]const u8{
-        "current-second", "current-jiffy", "jiffies-per-second",
-    };
+    // (scheme time)
     var time_lib = Library.init(allocator, "scheme.time");
     for (scheme_time_names) |name| {
         if (globals.get(name)) |val| {
@@ -310,11 +581,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(time_lib);
 
-    // (scheme process-context) — process procedures
-    const scheme_pc_names = [_][]const u8{
-        "command-line",             "exit",                      "emergency-exit",
-        "get-environment-variable", "get-environment-variables",
-    };
+    // (scheme process-context)
     var pc_lib = Library.init(allocator, "scheme.process-context");
     for (scheme_pc_names) |name| {
         if (globals.get(name)) |val| {
@@ -323,8 +590,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(pc_lib);
 
-    // (scheme eval) — eval/environment
-    const scheme_eval_names = [_][]const u8{ "eval", "environment", "interaction-environment" };
+    // (scheme eval)
     var eval_lib = Library.init(allocator, "scheme.eval");
     for (scheme_eval_names) |name| {
         if (globals.get(name)) |val| {
@@ -333,8 +599,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(eval_lib);
 
-    // (scheme repl) — REPL support (R7RS §6.4)
-    const scheme_repl_names = [_][]const u8{"interaction-environment"};
+    // (scheme repl) — R7RS §6.4
     var repl_lib = Library.init(allocator, "scheme.repl");
     for (scheme_repl_names) |name| {
         if (globals.get(name)) |val| {
@@ -343,8 +608,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(repl_lib);
 
-    // (scheme load) — load procedure
-    const scheme_load_names = [_][]const u8{"load"};
+    // (scheme load)
     var load_lib = Library.init(allocator, "scheme.load");
     for (scheme_load_names) |name| {
         if (globals.get(name)) |val| {
@@ -353,91 +617,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(load_lib);
 
-    // (scheme r5rs) — R5RS compatibility. Per R7RS Appendix A, this library
-    // provides the full R5RS identifier set (except transcript-on/off, which
-    // Kaappi does not implement). exact/inexact appear under their R5RS names
-    // (exact->inexact, inexact->exact), which are registered as globals, so no
-    // renaming is needed. Syntactic keywords (define, lambda, if, cond,
-    // syntax-rules, ...) are recognized directly by the compiler rather than
-    // stored as runtime values, so the globals.get guard below skips them —
-    // the same as (scheme base) above. Listing them keeps this a faithful,
-    // auditable transcription of the Appendix A table.
-    const scheme_r5rs_names = [_][]const u8{
-        "*",                         "+",                              "...",
-        "/",                         "<",                              "<=",
-        "=",                         "=>",                             ">",
-        ">=",                        "abs",                            "acos",
-        "and",                       "angle",                          "append",
-        "apply",                     "asin",                           "assoc",
-        "assq",                      "assv",                           "atan",
-        "begin",                     "boolean?",                       "caaaar",
-        "caaadr",                    "caaar",                          "caadar",
-        "caaddr",                    "caadr",                          "caar",
-        "cadaar",                    "cadadr",                         "cadar",
-        "caddar",                    "cadddr",                         "caddr",
-        "cadr",                      "call-with-current-continuation", "call-with-input-file",
-        "call-with-output-file",     "call-with-values",               "car",
-        "case",                      "cdaaar",                         "cdaadr",
-        "cdaar",                     "cdadar",                         "cdaddr",
-        "cdadr",                     "cdar",                           "cddaar",
-        "cddadr",                    "cddar",                          "cdddar",
-        "cddddr",                    "cdddr",                          "cddr",
-        "cdr",                       "ceiling",                        "char->integer",
-        "char-alphabetic?",          "char-ci<=?",                     "char-ci<?",
-        "char-ci=?",                 "char-ci>=?",                     "char-ci>?",
-        "char-downcase",             "char-lower-case?",               "char-numeric?",
-        "char-ready?",               "char-upcase",                    "char-upper-case?",
-        "char-whitespace?",          "char<=?",                        "char<?",
-        "char=?",                    "char>=?",                        "char>?",
-        "char?",                     "close-input-port",               "close-output-port",
-        "complex?",                  "cond",                           "cons",
-        "cos",                       "current-input-port",             "current-output-port",
-        "define",                    "define-syntax",                  "delay",
-        "denominator",               "display",                        "do",
-        "dynamic-wind",              "else",                           "eof-object?",
-        "eq?",                       "equal?",                         "eqv?",
-        "eval",                      "even?",                          "exact->inexact",
-        "exact?",                    "exp",                            "expt",
-        "floor",                     "for-each",                       "force",
-        "gcd",                       "if",                             "imag-part",
-        "inexact->exact",            "inexact?",                       "input-port?",
-        "integer->char",             "integer?",                       "interaction-environment",
-        "lambda",                    "lcm",                            "length",
-        "let",                       "let*",                           "let-syntax",
-        "letrec",                    "letrec-syntax",                  "list",
-        "list->string",              "list->vector",                   "list-ref",
-        "list-tail",                 "list?",                          "load",
-        "log",                       "magnitude",                      "make-polar",
-        "make-rectangular",          "make-string",                    "make-vector",
-        "map",                       "max",                            "member",
-        "memq",                      "memv",                           "min",
-        "modulo",                    "negative?",                      "newline",
-        "not",                       "null-environment",               "null?",
-        "number->string",            "number?",                        "numerator",
-        "odd?",                      "open-input-file",                "open-output-file",
-        "or",                        "output-port?",                   "pair?",
-        "peek-char",                 "positive?",                      "procedure?",
-        "quasiquote",                "quote",                          "quotient",
-        "rational?",                 "rationalize",                    "read",
-        "read-char",                 "real-part",                      "real?",
-        "remainder",                 "reverse",                        "round",
-        "scheme-report-environment", "set!",                           "set-car!",
-        "set-cdr!",                  "sin",                            "sqrt",
-        "string",                    "string->list",                   "string->number",
-        "string->symbol",            "string-append",                  "string-ci<=?",
-        "string-ci<?",               "string-ci=?",                    "string-ci>=?",
-        "string-ci>?",               "string-copy",                    "string-fill!",
-        "string-length",             "string-ref",                     "string-set!",
-        "string<=?",                 "string<?",                       "string=?",
-        "string>=?",                 "string>?",                       "string?",
-        "substring",                 "symbol->string",                 "symbol?",
-        "syntax-rules",              "tan",                            "truncate",
-        "values",                    "vector",                         "vector->list",
-        "vector-fill!",              "vector-length",                  "vector-ref",
-        "vector-set!",               "vector?",                        "with-input-from-file",
-        "with-output-to-file",       "write",                          "write-char",
-        "zero?",
-    };
+    // (scheme r5rs)
     var r5rs_lib = Library.init(allocator, "scheme.r5rs");
     for (scheme_r5rs_names) |name| {
         if (globals.get(name)) |val| {
@@ -446,15 +626,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(r5rs_lib);
 
-    // (scheme file) — file I/O procedures
-    const scheme_file_names = [_][]const u8{
-        "open-input-file",        "open-output-file",
-        "open-binary-input-file", "open-binary-output-file",
-        "file-exists?",           "delete-file",
-        "call-with-input-file",   "call-with-output-file",
-        "with-input-from-file",   "with-output-to-file",
-        "create-directory",       "delete-directory",
-    };
+    // (scheme file)
     var file_lib = Library.init(allocator, "scheme.file");
     for (scheme_file_names) |name| {
         if (globals.get(name)) |val| {
@@ -463,19 +635,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(file_lib);
 
-    // (scheme cxr) — three/four-level car/cdr compositions
-    const scheme_cxr_names = [_][]const u8{
-        // Two-level (also in base)
-        "caar",   "cadr",   "cdar",   "cddr",
-        // Three-level
-        "caaar",  "caadr",  "cadar",  "caddr",
-        "cdaar",  "cdadr",  "cddar",  "cdddr",
-        // Four-level
-        "caaaar", "caaadr", "caadar", "caaddr",
-        "cadaar", "cadadr", "caddar", "cadddr",
-        "cdaaar", "cdaadr", "cdadar", "cdaddr",
-        "cddaar", "cddadr", "cdddar", "cddddr",
-    };
+    // (scheme cxr)
     var cxr_lib = Library.init(allocator, "scheme.cxr");
     for (scheme_cxr_names) |name| {
         if (globals.get(name)) |val| {
@@ -484,12 +644,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(cxr_lib);
 
-    // (scheme complex) — complex number procedures
-    const scheme_complex_names = [_][]const u8{
-        "make-rectangular", "make-polar",
-        "real-part",        "imag-part",
-        "magnitude",        "angle",
-    };
+    // (scheme complex)
     var complex_lib = Library.init(allocator, "scheme.complex");
     for (scheme_complex_names) |name| {
         if (globals.get(name)) |val| {
@@ -498,18 +653,12 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(complex_lib);
 
-    // (scheme case-lambda) — case-lambda is a compiler syntax form,
-    // so the library just needs to exist for (import (scheme case-lambda)) to work.
+    // (scheme case-lambda) — compiler syntax form, library just needs to exist
     const case_lambda_lib = Library.init(allocator, "scheme.case-lambda");
     try registry.register(case_lambda_lib);
 
-    // (kaappi ffi) — C FFI library (not available in WASM)
+    // (kaappi ffi) — not available in WASM
     if (!is_wasm) {
-        const kaappi_ffi_names = [_][]const u8{
-            "ffi-open",           "ffi-fn",       "ffi-close",
-            "ffi-bytevector-ptr", "ffi-callback", "ffi-callback-release",
-            "ffi-callback?",
-        };
         var ffi_lib = Library.init(allocator, "kaappi.ffi");
         for (kaappi_ffi_names) |name| {
             if (globals.get(name)) |val| {
@@ -519,11 +668,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
         try registry.register(ffi_lib);
     }
 
-    // (kaappi fibers) — green threads
-    const kaappi_fiber_names = [_][]const u8{
-        "spawn",        "yield",        "fiber-join",      "fiber?",
-        "make-channel", "channel-send", "channel-receive", "channel?",
-    };
+    // (kaappi fibers)
     var fiber_lib = Library.init(allocator, "kaappi.fibers");
     for (kaappi_fiber_names) |name| {
         if (globals.get(name)) |val| {
@@ -534,31 +679,13 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
 
     // SRFI-18: Multithreading support (not available in WASM)
     if (!is_wasm) {
-        const srfi18_names = [_][]const u8{
-            "current-thread",             "thread?",                       "make-thread",
-            "thread-name",                "thread-specific",               "thread-specific-set!",
-            "thread-start!",              "thread-yield!",                 "thread-sleep!",
-            "thread-terminate!",          "thread-join!",                  "mutex?",
-            "make-mutex",                 "mutex-name",                    "mutex-specific",
-            "mutex-specific-set!",        "mutex-state",                   "mutex-lock!",
-            "mutex-unlock!",              "condition-variable?",           "make-condition-variable",
-            "condition-variable-name",    "condition-variable-specific",   "condition-variable-specific-set!",
-            "condition-variable-signal!", "condition-variable-broadcast!", "current-time",
-            "time?",                      "time->seconds",                 "seconds->time",
-            "join-timeout-exception?",    "abandoned-mutex-exception?",    "terminated-thread-exception?",
-            "uncaught-exception?",        "uncaught-exception-reason",
-        };
         var srfi18_lib = Library.init(allocator, "srfi.18");
         for (srfi18_names) |name| {
             if (globals.get(name)) |val| {
                 try srfi18_lib.addExport(name, val);
             }
         }
-        const base_reexports = [_][]const u8{
-            "with-exception-handler",
-            "raise",
-        };
-        for (base_reexports) |name| {
+        for (srfi18_base_reexports) |name| {
             if (globals.get(name)) |val| {
                 try srfi18_lib.addExport(name, val);
             }
@@ -567,33 +694,6 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
 
     // SRFI-1: List Library
-    const srfi1_names = [_][]const u8{
-        "cons",              "car",             "cdr",          "pair?",
-        "null?",             "list",            "length",       "append",
-        "reverse",           "map",             "for-each",     "member",
-        "memq",              "memv",            "assoc",        "assq",
-        "assv",              "list-ref",        "set-car!",     "set-cdr!",
-        "list-copy",         "make-list",       "caar",         "cadr",
-        "cdar",              "cddr",            "fold",         "fold-right",
-        "reduce",            "reduce-right",    "filter",       "remove",
-        "partition",         "find",            "find-tail",    "any",
-        "every",             "count",           "iota",         "zip",
-        "concatenate",       "take",            "drop",         "take-while",
-        "drop-while",        "filter-map",      "append-map",   "last",
-        "last-pair",         "proper-list?",    "dotted-list?", "circular-list?",
-        "lset-intersection", "lset-difference", "lset=",        "lset-adjoin",
-        "lset-union",        "lset-xor",        "xcons",        "cons*",
-        "list-tabulate",     "circular-list",   "not-pair?",    "null-list?",
-        "list=",             "first",           "second",       "third",
-        "fourth",            "fifth",           "sixth",        "seventh",
-        "eighth",            "ninth",           "tenth",        "car+cdr",
-        "take-right",        "drop-right",      "split-at",     "list-index",
-        "span",              "break",           "delete",       "delete-duplicates",
-        "alist-cons",        "alist-copy",      "alist-delete", "unfold",
-        "unfold-right",      "append-reverse",  "length+",      "unzip1",
-        "unzip2",            "pair-for-each",   "pair-fold",    "pair-fold-right",
-        "map-in-order",
-    };
     var srfi1_lib = Library.init(allocator, "srfi.1");
     for (srfi1_names) |name| {
         if (globals.get(name)) |val| {
@@ -607,25 +707,6 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     try registry.register(srfi9_lib);
 
     // SRFI-13: String Library
-    const srfi13_names = [_][]const u8{
-        "string-contains",   "string-prefix?",      "string-suffix?",
-        "string-trim",       "string-trim-right",   "string-trim-both",
-        "string-index",      "string-count",        "string-split",
-        "string-join",       "string-concatenate",
-        // Also include standard string ops
-         "string-length",
-        "string-append",     "substring",           "string-copy",
-        "string-ref",        "string-set!",         "string<?",
-        "string<=?",         "string=?",            "string>=?",
-        "string>?",          "string-upcase",       "string-downcase",
-        "string-foldcase",   "string-take",         "string-drop",
-        "string-take-right", "string-drop-right",   "string-pad",
-        "string-pad-right",  "string-reverse",      "string-filter",
-        "string-delete",     "string-replace",      "string-titlecase",
-        "string-every",      "string-any",          "string-tabulate",
-        "string-unfold",     "string-unfold-right", "string-index-right",
-        "string-skip",       "string-skip-right",
-    };
     var srfi13_lib = Library.init(allocator, "srfi.13");
     for (srfi13_names) |name| {
         if (globals.get(name)) |val| {
@@ -636,26 +717,16 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
 
     // SRFI-27: Random Numbers — now a portable .sld wrapping native globals
 
-    // SRFI-39: Parameter objects (alias for existing make-parameter/parameterize)
+    // SRFI-39: Parameter objects
     var srfi39_lib = Library.init(allocator, "srfi.39");
-    if (globals.get("make-parameter")) |v| try srfi39_lib.addExport("make-parameter", v);
+    for (srfi39_names) |name| {
+        if (globals.get(name)) |val| {
+            try srfi39_lib.addExport(name, val);
+        }
+    }
     try registry.register(srfi39_lib);
 
     // SRFI-69: Hash Tables
-    const srfi69_names = [_][]const u8{
-        "make-hash-table",          "hash-table?",
-        "hash-table-ref",           "hash-table-set!",
-        "hash-table-delete!",       "hash-table-exists?",
-        "hash-table-size",          "hash-table-keys",
-        "hash-table-values",        "hash-table-walk",
-        "hash-table->alist",        "alist->hash-table",
-        "hash-table-copy",          "hash-table-update!/default",
-        "hash",                     "string-hash",
-        "string-ci-hash",           "hash-by-identity",
-        "hash-table-ref/default",   "hash-table-fold",
-        "hash-table-merge!",        "hash-table-equivalence-function",
-        "hash-table-hash-function",
-    };
     var srfi69_lib = Library.init(allocator, "srfi.69");
     for (srfi69_names) |name| {
         if (globals.get(name)) |val| {
@@ -664,18 +735,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     }
     try registry.register(srfi69_lib);
 
-    // SRFI-133: Vector Library (alias for existing vector ops)
-    const srfi133_names = [_][]const u8{
-        "vector",              "make-vector",              "vector?",             "vector-length",
-        "vector-ref",          "vector-set!",              "vector->list",        "list->vector",
-        "vector->string",      "string->vector",           "vector-fill!",        "vector-copy",
-        "vector-copy!",        "vector-append",            "vector-for-each",     "vector-map",
-        "vector-empty?",       "vector-count",             "vector-any",          "vector-every",
-        "vector-index",        "vector-index-right",       "vector-skip",         "vector-skip-right",
-        "vector-swap!",        "vector-reverse!",          "vector-reverse-copy", "vector-unfold",
-        "vector-unfold-right", "vector-binary-search",     "vector-concatenate",  "vector-cumulate",
-        "vector-partition",    "vector-append-subvectors",
-    };
+    // SRFI-133: Vector Library
     var srfi133_lib = Library.init(allocator, "srfi.133");
     for (srfi133_names) |name| {
         if (globals.get(name)) |val| {
@@ -686,31 +746,6 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
 
     // SRFI-170: POSIX API (not available in WASM)
     if (!is_wasm) {
-        const srfi170_names = [_][]const u8{
-            "directory-files",           "file-info",                    "file-info?",
-            "file-info-directory?",      "file-info-regular?",           "file-info-symlink?",
-            "file-info-fifo?",           "file-info-socket?",            "file-info-device?",
-            "file-info:size",            "file-info:mtime",              "file-info:mode",
-            "file-info:device",          "file-info:inode",              "file-info:nlinks",
-            "file-info:uid",             "file-info:gid",                "file-info:rdev",
-            "file-info:blksize",         "file-info:blocks",             "file-info:atime",
-            "file-info:ctime",           "create-directory",             "delete-directory",
-            "rename-file",               "create-symlink",               "read-symlink",
-            "create-hard-link",          "real-path",                    "set-file-mode",
-            "truncate-file",             "create-fifo",                  "set-file-owner",
-            "set-file-times",            "pid",                          "umask",
-            "set-umask!",                "current-directory",            "set-current-directory!",
-            "user-uid",                  "user-gid",                     "user-effective-uid",
-            "user-effective-gid",        "user-supplementary-gids",      "nice",
-            "set-environment-variable!", "delete-environment-variable!", "terminal?",
-            "user-info",                 "user-info?",                   "user-info:name",
-            "user-info:uid",             "user-info:gid",                "user-info:home-dir",
-            "user-info:shell",           "user-info:full-name",          "group-info",
-            "group-info?",               "group-info:name",              "group-info:gid",
-            "open-directory",            "read-directory",               "close-directory",
-            "posix-time",                "monotonic-time",               "file-info-type",
-            "temp-file-prefix",          "create-temp-file",
-        };
         var srfi170_lib = Library.init(allocator, "srfi.170");
         for (srfi170_names) |name| {
             if (globals.get(name)) |val| {
@@ -744,65 +779,20 @@ fn isSandboxBlocked(name: []const u8) bool {
 pub fn registerSandboxedLibraries(registry: *LibraryRegistry, globals: *std.StringHashMap(Value)) !void {
     const allocator = registry.allocator;
 
-    // (scheme base) — filter out file I/O procedures
-    const scheme_base_names = [_][]const u8{
-        "+",                      "-",                              "*",                  "/",
-        "quotient",               "remainder",                      "modulo",             "=",
-        "<",                      ">",                              "<=",                 ">=",
-        "zero?",                  "positive?",                      "negative?",          "abs",
-        "min",                    "max",                            "even?",              "odd?",
-        "gcd",                    "lcm",                            "floor",              "ceiling",
-        "truncate",               "round",                          "exact?",             "inexact?",
-        "exact-integer?",         "exact",                          "inexact",            "expt",
-        "square",                 "sqrt",                           "exact-integer-sqrt", "cons",
-        "car",                    "cdr",                            "set-car!",           "set-cdr!",
-        "list",                   "length",                         "append",             "reverse",
-        "caar",                   "cadr",                           "cdar",               "cddr",
-        "list-ref",               "list-tail",                      "list-set!",          "list-copy",
-        "make-list",              "member",                         "memq",               "memv",
-        "assoc",                  "assq",                           "assv",               "map",
-        "for-each",               "pair?",                          "null?",              "number?",
-        "integer?",               "real?",                          "complex?",           "rational?",
-        "symbol?",                "string?",                        "boolean?",           "char?",
-        "procedure?",             "list?",                          "eq?",                "eqv?",
-        "equal?",                 "not",                            "boolean=?",          "symbol=?",
-        "number->string",         "string->number",                 "string-length",      "string-append",
-        "symbol->string",         "string->symbol",                 "string",             "make-string",
-        "string-ref",             "string-set!",                    "substring",          "string-copy",
-        "string-copy!",           "string-fill!",                   "string->list",       "list->string",
-        "string-for-each",        "string-map",                     "string<?",           "string<=?",
-        "string=?",               "string>=?",                      "string>?",           "char->integer",
-        "integer->char",          "char<?",                         "char<=?",            "char=?",
-        "char>=?",                "char>?",                         "display",            "write",
-        "newline",                "apply",                          "error",              "raise",
-        "raise-continuable",      "with-exception-handler",         "error-object?",      "error-object-message",
-        "error-object-irritants", "file-error?",                    "read-error?",        "%make-record-type",
-        "%make-record",           "%record?",                       "%record-ref",        "%record-set!",
-        "current-input-port",     "current-output-port",            "current-error-port", "port?",
-        "input-port?",            "output-port?",                   "textual-port?",      "binary-port?",
-        "input-port-open?",       "output-port-open?",              "close-port",         "close-input-port",
-        "close-output-port",      "read-char",                      "peek-char",          "read-line",
-        "char-ready?",            "write-char",                     "write-string",       "eof-object?",
-        "eof-object",             "call-with-current-continuation", "call/cc",            "call-with-escape-continuation",
-        "call/ec",                "dynamic-wind",                   "values",             "call-with-values",
-        "make-rectangular",       "make-polar",                     "real-part",          "imag-part",
-        "magnitude",              "angle",                          "vector",             "make-vector",
-        "vector?",                "vector-length",                  "vector-ref",         "vector-set!",
-        "vector->list",           "list->vector",                   "vector-fill!",       "vector-copy",
-        "vector-copy!",           "vector-append",                  "vector-for-each",    "vector-map",
-        "vector->string",         "bytevector?",                    "make-bytevector",    "bytevector",
-        "bytevector-length",      "bytevector-u8-ref",              "bytevector-u8-set!", "bytevector-copy",
-        "bytevector-copy!",       "bytevector-append",              "utf8->string",       "string->utf8",
-        "open-input-string",      "open-output-string",             "get-output-string",  "read-string",
-        "flush-output-port",      "floor-quotient",                 "floor-remainder",    "floor/",
-        "truncate-quotient",      "truncate-remainder",             "truncate/",          "numerator",
-        "denominator",            "rationalize",                    "exact->inexact",     "inexact->exact",
-        "features",               "make-promise",                   "promise?",           "make-parameter",
-        "call-with-port",         "read-u8",                        "peek-u8",            "u8-ready?",
-        "write-u8",               "read-bytevector",                "write-bytevector",   "open-input-bytevector",
-        "open-output-bytevector", "get-output-bytevector",          "read-bytevector!",   "string->vector",
+    // Helper: register a library from a shared name list
+    const H = struct {
+        fn registerLib(a: std.mem.Allocator, reg: *LibraryRegistry, lib_name: []const u8, names: []const []const u8, g: *std.StringHashMap(Value)) !void {
+            var lib = Library.init(a, lib_name);
+            for (names) |name| {
+                if (g.get(name)) |val| {
+                    try lib.addExport(name, val);
+                }
+            }
+            try reg.register(lib);
+        }
     };
 
+    // (scheme base) — filter out file I/O procedures via isSandboxBlocked
     var base = Library.init(allocator, "scheme.base");
     for (scheme_base_names) |name| {
         if (!isSandboxBlocked(name)) {
@@ -813,251 +803,37 @@ pub fn registerSandboxedLibraries(registry: *LibraryRegistry, globals: *std.Stri
     }
     try registry.register(base);
 
-    // (scheme write)
-    const scheme_write_names = [_][]const u8{
-        "display", "write", "write-shared", "write-simple",
-    };
-    var write_lib = Library.init(allocator, "scheme.write");
-    for (scheme_write_names) |name| {
-        if (globals.get(name)) |val| {
-            try write_lib.addExport(name, val);
-        }
-    }
-    try registry.register(write_lib);
+    // Safe libraries — identical to standard registration
+    try H.registerLib(allocator, registry, "scheme.write", &scheme_write_names, globals);
+    try H.registerLib(allocator, registry, "scheme.read", &scheme_read_names, globals);
+    try H.registerLib(allocator, registry, "scheme.char", &scheme_char_names, globals);
+    try H.registerLib(allocator, registry, "scheme.inexact", &scheme_inexact_names, globals);
+    try H.registerLib(allocator, registry, "scheme.lazy", &scheme_lazy_names, globals);
+    try H.registerLib(allocator, registry, "scheme.time", &scheme_time_names, globals);
+    try H.registerLib(allocator, registry, "scheme.cxr", &scheme_cxr_names, globals);
+    try H.registerLib(allocator, registry, "scheme.complex", &scheme_complex_names, globals);
 
-    // (scheme read)
-    const scheme_read_names = [_][]const u8{"read"};
-    var read_lib = Library.init(allocator, "scheme.read");
-    for (scheme_read_names) |name| {
-        if (globals.get(name)) |val| {
-            try read_lib.addExport(name, val);
-        }
-    }
-    try registry.register(read_lib);
-
-    // (scheme char)
-    const scheme_char_names = [_][]const u8{
-        "char-alphabetic?", "char-numeric?",    "char-whitespace?",
-        "char-upper-case?", "char-lower-case?", "char-upcase",
-        "char-downcase",    "char-foldcase",    "digit-value",
-        "char-ci<?",        "char-ci<=?",       "char-ci=?",
-        "char-ci>=?",       "char-ci>?",        "string-ci<?",
-        "string-ci<=?",     "string-ci=?",      "string-ci>=?",
-        "string-ci>?",      "string-upcase",    "string-downcase",
-        "string-foldcase",
-    };
-    var char_lib = Library.init(allocator, "scheme.char");
-    for (scheme_char_names) |name| {
-        if (globals.get(name)) |val| {
-            try char_lib.addExport(name, val);
-        }
-    }
-    try registry.register(char_lib);
-
-    // (scheme inexact)
-    const scheme_inexact_names = [_][]const u8{
-        "sin", "cos", "tan",  "asin",    "acos",      "atan",
-        "exp", "log", "sqrt", "finite?", "infinite?", "nan?",
-    };
-    var inexact_lib = Library.init(allocator, "scheme.inexact");
-    for (scheme_inexact_names) |name| {
-        if (globals.get(name)) |val| {
-            try inexact_lib.addExport(name, val);
-        }
-    }
-    try registry.register(inexact_lib);
-
-    // (scheme lazy)
-    const scheme_lazy_names = [_][]const u8{
-        "delay", "delay-force", "force", "make-promise", "promise?",
-    };
-    var lazy_lib = Library.init(allocator, "scheme.lazy");
-    for (scheme_lazy_names) |name| {
-        if (globals.get(name)) |val| {
-            try lazy_lib.addExport(name, val);
-        }
-    }
-    try registry.register(lazy_lib);
-
-    // (scheme time)
-    const scheme_time_names = [_][]const u8{
-        "current-second", "current-jiffy", "jiffies-per-second",
-    };
-    var time_lib = Library.init(allocator, "scheme.time");
-    for (scheme_time_names) |name| {
-        if (globals.get(name)) |val| {
-            try time_lib.addExport(name, val);
-        }
-    }
-    try registry.register(time_lib);
-
-    // (scheme cxr)
-    const scheme_cxr_names = [_][]const u8{
-        "caar",   "cadr",   "cdar",   "cddr",
-        "caaar",  "caadr",  "cadar",  "caddr",
-        "cdaar",  "cdadr",  "cddar",  "cdddr",
-        "caaaar", "caaadr", "caadar", "caaddr",
-        "cadaar", "cadadr", "caddar", "cadddr",
-        "cdaaar", "cdaadr", "cdadar", "cdaddr",
-        "cddaar", "cddadr", "cdddar", "cddddr",
-    };
-    var cxr_lib = Library.init(allocator, "scheme.cxr");
-    for (scheme_cxr_names) |name| {
-        if (globals.get(name)) |val| {
-            try cxr_lib.addExport(name, val);
-        }
-    }
-    try registry.register(cxr_lib);
-
-    // (scheme complex)
-    const scheme_complex_names = [_][]const u8{
-        "make-rectangular", "make-polar",
-        "real-part",        "imag-part",
-        "magnitude",        "angle",
-    };
-    var complex_lib = Library.init(allocator, "scheme.complex");
-    for (scheme_complex_names) |name| {
-        if (globals.get(name)) |val| {
-            try complex_lib.addExport(name, val);
-        }
-    }
-    try registry.register(complex_lib);
-
-    // (scheme case-lambda)
+    // (scheme case-lambda) — compiler syntax form, library just needs to exist
     const case_lambda_lib = Library.init(allocator, "scheme.case-lambda");
     try registry.register(case_lambda_lib);
 
-    // SKIP: scheme.file, scheme.load, scheme.eval, scheme.repl, scheme.process-context, kaappi.ffi, srfi.170
+    // SKIP: scheme.file, scheme.load, scheme.eval, scheme.repl,
+    //       scheme.process-context, scheme.r5rs, kaappi.ffi,
+    //       srfi.18, srfi.170
 
-    // Safe built-in SRFIs
-    // SRFI-1
-    const srfi1_names = [_][]const u8{
-        "cons",              "car",             "cdr",          "pair?",
-        "null?",             "list",            "length",       "append",
-        "reverse",           "map",             "for-each",     "member",
-        "memq",              "memv",            "assoc",        "assq",
-        "assv",              "list-ref",        "set-car!",     "set-cdr!",
-        "list-copy",         "make-list",       "caar",         "cadr",
-        "cdar",              "cddr",            "fold",         "fold-right",
-        "reduce",            "reduce-right",    "filter",       "remove",
-        "partition",         "find",            "find-tail",    "any",
-        "every",             "count",           "iota",         "zip",
-        "concatenate",       "take",            "drop",         "take-while",
-        "drop-while",        "filter-map",      "append-map",   "last",
-        "last-pair",         "proper-list?",    "dotted-list?", "circular-list?",
-        "lset-intersection", "lset-difference", "lset=",        "lset-adjoin",
-        "lset-union",        "lset-xor",        "xcons",        "cons*",
-        "list-tabulate",     "circular-list",   "not-pair?",    "null-list?",
-        "list=",             "first",           "second",       "third",
-        "fourth",            "fifth",           "sixth",        "seventh",
-        "eighth",            "ninth",           "tenth",        "car+cdr",
-        "take-right",        "drop-right",      "split-at",     "list-index",
-        "span",              "break",           "delete",       "delete-duplicates",
-        "alist-cons",        "alist-copy",      "alist-delete", "unfold",
-        "unfold-right",      "append-reverse",  "length+",      "unzip1",
-        "unzip2",            "pair-for-each",   "pair-fold",    "pair-fold-right",
-        "map-in-order",
-    };
-    var srfi1_lib = Library.init(allocator, "srfi.1");
-    for (srfi1_names) |name| {
-        if (globals.get(name)) |val| {
-            try srfi1_lib.addExport(name, val);
-        }
-    }
-    try registry.register(srfi1_lib);
+    // Safe SRFIs
+    try H.registerLib(allocator, registry, "srfi.1", &srfi1_names, globals);
+    try H.registerLib(allocator, registry, "srfi.13", &srfi13_names, globals);
+    try H.registerLib(allocator, registry, "srfi.39", &srfi39_names, globals);
+    try H.registerLib(allocator, registry, "srfi.69", &srfi69_names, globals);
+    try H.registerLib(allocator, registry, "srfi.133", &srfi133_names, globals);
 
     // SRFI-9
     const srfi9_lib = Library.init(allocator, "srfi.9");
     try registry.register(srfi9_lib);
 
-    // SRFI-13
-    const srfi13_names = [_][]const u8{
-        "string-contains",   "string-prefix?",      "string-suffix?",
-        "string-trim",       "string-trim-right",   "string-trim-both",
-        "string-index",      "string-count",        "string-split",
-        "string-join",       "string-concatenate",  "string-length",
-        "string-append",     "substring",           "string-copy",
-        "string-ref",        "string-set!",         "string<?",
-        "string<=?",         "string=?",            "string>=?",
-        "string>?",          "string-upcase",       "string-downcase",
-        "string-foldcase",   "string-take",         "string-drop",
-        "string-take-right", "string-drop-right",   "string-pad",
-        "string-pad-right",  "string-reverse",      "string-filter",
-        "string-delete",     "string-replace",      "string-titlecase",
-        "string-every",      "string-any",          "string-tabulate",
-        "string-unfold",     "string-unfold-right", "string-index-right",
-        "string-skip",       "string-skip-right",
-    };
-    var srfi13_lib = Library.init(allocator, "srfi.13");
-    for (srfi13_names) |name| {
-        if (globals.get(name)) |val| {
-            try srfi13_lib.addExport(name, val);
-        }
-    }
-    try registry.register(srfi13_lib);
-
-    // SRFI-39
-    var srfi39_lib = Library.init(allocator, "srfi.39");
-    if (globals.get("make-parameter")) |v| try srfi39_lib.addExport("make-parameter", v);
-    try registry.register(srfi39_lib);
-
-    // SRFI-69
-    const srfi69_names = [_][]const u8{
-        "make-hash-table",          "hash-table?",
-        "hash-table-ref",           "hash-table-set!",
-        "hash-table-delete!",       "hash-table-exists?",
-        "hash-table-size",          "hash-table-keys",
-        "hash-table-values",        "hash-table-walk",
-        "hash-table->alist",        "alist->hash-table",
-        "hash-table-copy",          "hash-table-update!/default",
-        "hash",                     "string-hash",
-        "string-ci-hash",           "hash-by-identity",
-        "hash-table-ref/default",   "hash-table-fold",
-        "hash-table-merge!",        "hash-table-equivalence-function",
-        "hash-table-hash-function",
-    };
-    var srfi69_lib = Library.init(allocator, "srfi.69");
-    for (srfi69_names) |name| {
-        if (globals.get(name)) |val| {
-            try srfi69_lib.addExport(name, val);
-        }
-    }
-    try registry.register(srfi69_lib);
-
-    // SRFI-133
-    const srfi133_names = [_][]const u8{
-        "vector",              "make-vector",              "vector?",             "vector-length",
-        "vector-ref",          "vector-set!",              "vector->list",        "list->vector",
-        "vector->string",      "string->vector",           "vector-fill!",        "vector-copy",
-        "vector-copy!",        "vector-append",            "vector-for-each",     "vector-map",
-        "vector-empty?",       "vector-count",             "vector-any",          "vector-every",
-        "vector-index",        "vector-index-right",       "vector-skip",         "vector-skip-right",
-        "vector-swap!",        "vector-reverse!",          "vector-reverse-copy", "vector-unfold",
-        "vector-unfold-right", "vector-binary-search",     "vector-concatenate",  "vector-cumulate",
-        "vector-partition",    "vector-append-subvectors",
-    };
-    var srfi133_lib = Library.init(allocator, "srfi.133");
-    for (srfi133_names) |name| {
-        if (globals.get(name)) |val| {
-            try srfi133_lib.addExport(name, val);
-        }
-    }
-    try registry.register(srfi133_lib);
-
-    // SKIP: srfi.18 (OS threads blocked in sandbox to prevent thread bombs)
-
     // (kaappi fibers) — green threads (safe for sandbox)
-    const kaappi_sb_fiber_names = [_][]const u8{
-        "spawn",        "yield",        "fiber-join",      "fiber?",
-        "make-channel", "channel-send", "channel-receive", "channel?",
-    };
-    var fiber_sb_lib = Library.init(allocator, "kaappi.fibers");
-    for (kaappi_sb_fiber_names) |name| {
-        if (globals.get(name)) |val| {
-            try fiber_sb_lib.addExport(name, val);
-        }
-    }
-    try registry.register(fiber_sb_lib);
+    try H.registerLib(allocator, registry, "kaappi.fibers", &kaappi_fiber_names, globals);
 }
 
 /// Convert a library name from an S-expression list like (scheme base) to

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -439,3 +439,70 @@ test "retired lib_env values survive GC (#820)" {
     const result = try vm.eval("(length (get))");
     try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
 }
+
+test "export list names resolve in globals (drift guard)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Syntax keywords handled by the compiler — not in globals by design
+    const syntax_keywords = [_][]const u8{
+        "define",        "lambda",         "if",           "cond",
+        "case",          "and",            "or",           "begin",
+        "let",           "let*",           "letrec",       "letrec*",
+        "let-syntax",    "letrec-syntax",  "do",           "quote",
+        "quasiquote",    "set!",           "syntax-rules", "define-syntax",
+        "else",          "=>",             "...",          "define-record-type",
+        "define-values", "define-library", "import",       "case-lambda",
+        "when",          "unless",         "guard",        "include",
+        "include-ci",    "parameterize",   "delay",        "delay-force",
+    };
+
+    const all_lists = .{
+        .{ "scheme.base", &library_mod.scheme_base_names },
+        .{ "scheme.write", &library_mod.scheme_write_names },
+        .{ "scheme.inexact", &library_mod.scheme_inexact_names },
+        .{ "scheme.read", &library_mod.scheme_read_names },
+        .{ "scheme.char", &library_mod.scheme_char_names },
+        .{ "scheme.lazy", &library_mod.scheme_lazy_names },
+        .{ "scheme.time", &library_mod.scheme_time_names },
+        .{ "scheme.process-context", &library_mod.scheme_pc_names },
+        .{ "scheme.eval", &library_mod.scheme_eval_names },
+        .{ "scheme.repl", &library_mod.scheme_repl_names },
+        .{ "scheme.load", &library_mod.scheme_load_names },
+        .{ "scheme.r5rs", &library_mod.scheme_r5rs_names },
+        .{ "scheme.file", &library_mod.scheme_file_names },
+        .{ "scheme.cxr", &library_mod.scheme_cxr_names },
+        .{ "scheme.complex", &library_mod.scheme_complex_names },
+        .{ "kaappi.ffi", &library_mod.kaappi_ffi_names },
+        .{ "kaappi.fibers", &library_mod.kaappi_fiber_names },
+        .{ "srfi.18", &library_mod.srfi18_names },
+        .{ "srfi.18 (reexports)", &library_mod.srfi18_base_reexports },
+        .{ "srfi.1", &library_mod.srfi1_names },
+        .{ "srfi.13", &library_mod.srfi13_names },
+        .{ "srfi.39", &library_mod.srfi39_names },
+        .{ "srfi.69", &library_mod.srfi69_names },
+        .{ "srfi.133", &library_mod.srfi133_names },
+        .{ "srfi.170", &library_mod.srfi170_names },
+    };
+
+    inline for (all_lists) |entry| {
+        for (entry[1]) |name| {
+            // Skip syntax keywords — the compiler handles them, not globals
+            var is_syntax = false;
+            for (&syntax_keywords) |kw| {
+                if (std.mem.eql(u8, name, kw)) {
+                    is_syntax = true;
+                    break;
+                }
+            }
+            if (is_syntax) continue;
+
+            if (vm.globals.get(name) == null) {
+                std.debug.print("DRIFT: {s} lists \"{s}\" but it is not in globals\n", .{ entry[0], name });
+                return error.TestUnexpectedResult;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Hoists all 25 library export name arrays from inside `registerStandardLibraries()` to file-scope `pub const` declarations, shared by both standard and sandboxed registration
- Rewrites `registerSandboxedLibraries()` to reference the shared consts, eliminating 13 duplicate array declarations (~260 lines removed, net -156)
- Adds a drift-guard unit test that asserts every non-syntax name in every export list resolves in `globals` after `registerAll` — a typo or missing primitive now fails the test instead of silently dropping the export

Phases 1 and 2 of #1053. Phase 3 (comptime spec tables) is deferred per the issue.

## Test plan
- [x] `zig build test` — 566 tests pass (including new drift guard test)
- [x] `bash tests/scheme/run-all.sh` — 1701 tests pass (1395 R7RS + 306 scheme files)
- [x] Sandbox smoke tests: `(display "hi")` works, `(open-input-file ...)` correctly errors as undefined
- [x] Sandbox library imports verified: `(scheme base)`, `(scheme char)`, `(srfi 1)` all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)