### PR TITLE
Remove dead code: unused fn, unreachable logic, dead param, doubled comment (#1075)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -401,7 +401,6 @@ pub const Compiler = struct {
         ir_mod.markConstants(root);
 
         // Optimization passes
-        // Optimization passes
         root = ir_mod.foldConstants(&ir, root);
         root = ir_mod.eliminateDeadBranches(&ir, root);
         root = ir_mod.simplifyBooleans(&ir, root);

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -163,10 +163,10 @@ pub fn compileLetStar(self: *Compiler, args: Value, dst: u16, is_tail: bool) Com
 }
 
 pub fn compileLetrec(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
-    return compileLetrecImpl(self, args, dst, is_tail, false);
+    return compileLetrecImpl(self, args, dst, is_tail);
 }
 
-fn compileLetrecImpl(self: *Compiler, args: Value, dst: u16, is_tail: bool, _: bool) CompileError!void {
+fn compileLetrecImpl(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
     if (args == types.NIL) return CompileError.InvalidSyntax;
     const bindings = types.car(args);
     const body = types.cdr(args);
@@ -220,7 +220,7 @@ fn compileLetrecImpl(self: *Compiler, args: Value, dst: u16, is_tail: bool, _: b
 }
 
 pub fn compileLetrecStar(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
-    return compileLetrecImpl(self, args, dst, is_tail, true);
+    return compileLetrecImpl(self, args, dst, is_tail);
 }
 
 pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -509,10 +509,6 @@ pub const LLVMEmitter = struct {
         return last;
     }
 
-    fn emitSexprEvalValue(self: *LLVMEmitter, args: Value) EmitError![]const u8 {
-        return self.emitEvalExpr(args);
-    }
-
     fn emitIf(self: *LLVMEmitter, data: ir.IfData) EmitError![]const u8 {
         const test_val = try self.emitNode(data.test_expr);
 

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -76,13 +76,9 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
     }
     if (body_count == 0) return null;
 
-    const extra: u8 = if (rest_name != null) 1 else 0;
     var allowed: [17][]const u8 = undefined;
     @memcpy(allowed[0..arity], param_names[0..arity]);
-    if (rest_name) |rn| {
-        allowed[arity] = rn;
-    }
-    if (hasFreeVars(body_nodes[0..body_count], allowed[0 .. arity + extra])) return null;
+    if (hasFreeVars(body_nodes[0..body_count], allowed[0..arity])) return null;
 
     const fn_name = emitLambdaFunction(self, data.name, param_names[0..arity], body_nodes[0..body_count], rest_name) orelse return null;
 


### PR DESCRIPTION
## Summary

- Delete unused `emitSexprEvalValue` (zero callers) in `llvm_emit.zig`
- Remove unreachable rest-param handling in `llvm_emit_lambda.zig` (early `return null` makes `extra`/`allowed` rest logic dead)
- Remove dead `_: bool` discriminator from `compileLetrecImpl` — `compileLetrec` and `compileLetrecStar` are identical calls
- Remove doubled `// Optimization passes` comment in `compiler.zig`

The 5th item from the issue (`short_false` temp) was already cleaned up in aaa28f3.

Closes #1075

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)