### PR TITLE
Remove dead opcodes and extract CallFrame.frameWindow helper

### DIFF
--- a/docs/dev/bytecode.md
+++ b/docs/dev/bytecode.md
@@ -5,7 +5,7 @@ the ISA — the `/bytecode-isa` skill points here.
 
 ## Instruction set
 
-32 opcodes, register-based, variable-length encoding. Operands are u8
+29 opcodes, register-based, variable-length encoding. Operands are u8
 (register/slot) or u16 (constant index, big-endian). Jump offsets are i16
 (signed, relative to the instruction after the jump). Defined in the
 `OpCode` enum in `src/types.zig`; executed by the dispatch loop in
@@ -23,28 +23,25 @@ the ISA — the `/bytecode-isa` skill points here.
 | 7 | `set_global` | sym_idx:u16, src:u8 | 4 | Set global from src |
 | 8 | `define_global` | sym_idx:u16, src:u8 | 4 | Define global from src |
 | 9 | `tail_apply` | base:u8, nargs:u8 | 3 | Tail apply with list unpacking |
-| 10 | `get_local` | dst:u8, slot:u8 | 3 | (unused, replaced by move) |
-| 11 | `set_local` | slot:u8, src:u8 | 3 | (unused, replaced by move) |
-| 12 | `get_upvalue` | dst:u8, idx:u8 | 3 | Load captured var → dst |
-| 13 | `set_upvalue` | idx:u8, src:u8 | 3 | Set captured var from src |
-| 14 | `call` | base:u8, nargs:u8 | 3 | Call fn at base with nargs args |
-| 15 | `tail_call` | base:u8, nargs:u8 | 3 | Tail call (reuses frame) |
-| 16 | `return` | src:u8 | 2 | Return value from src |
-| 17 | `jump` | offset:i16 | 3 | Unconditional relative jump |
-| 18 | `jump_false` | test:u8, offset:i16 | 4 | Jump if test is #f |
-| 19 | `jump_true` | test:u8, offset:i16 | 4 | Jump if test is not #f |
-| 20 | `closure` | dst:u8, func_idx:u16 | 4+ | Create closure, followed by upvalue capture pairs |
-| 21 | `close_upvalue` | slot:u8 | 2 | Box local for shared mutation |
-| 22 | `cons` | dst:u8, car:u8, cdr:u8 | 4 | Allocate pair → dst |
-| 23 | `push_handler` | handler:u8 | 2 | Push exception handler |
-| 24 | `pop_handler` | (none) | 1 | Pop exception handler |
-| 25 | `halt` | (none) | 1 | Stop execution |
-| 26 | `call_global` | base:u8, sym:u16, nargs:u8 | 5 | Fused get_global + call |
-| 27 | `tail_call_global` | base:u8, sym:u16, nargs:u8 | 5 | Fused get_global + tail_call |
-| 28 | `box_local` | reg:u8 | 2 | Wrap register in pair for mutation |
-| 29 | `get_box_local` | dst:u8, reg:u8 | 3 | Read car of boxed register |
-| 30 | `set_box_local` | reg:u8, src:u8 | 3 | Write car of boxed register |
-| 31 | `self_tail_call` | base:u8, nargs:u8 | 3 | Self-recursive tail call: copy args to frame base, reset IP |
+| 10 | `get_upvalue` | dst:u8, idx:u8 | 3 | Load captured var → dst |
+| 11 | `set_upvalue` | idx:u8, src:u8 | 3 | Set captured var from src |
+| 12 | `call` | base:u8, nargs:u8 | 3 | Call fn at base with nargs args |
+| 13 | `tail_call` | base:u8, nargs:u8 | 3 | Tail call (reuses frame) |
+| 14 | `return` | src:u8 | 2 | Return value from src |
+| 15 | `jump` | offset:i16 | 3 | Unconditional relative jump |
+| 16 | `jump_false` | test:u8, offset:i16 | 4 | Jump if test is #f |
+| 17 | `jump_true` | test:u8, offset:i16 | 4 | Jump if test is not #f |
+| 18 | `closure` | dst:u8, func_idx:u16 | 4+ | Create closure, followed by upvalue capture pairs |
+| 19 | `cons` | dst:u8, car:u8, cdr:u8 | 4 | Allocate pair → dst |
+| 20 | `push_handler` | handler:u8 | 2 | Push exception handler |
+| 21 | `pop_handler` | (none) | 1 | Pop exception handler |
+| 22 | `halt` | (none) | 1 | Stop execution |
+| 23 | `call_global` | base:u8, sym:u16, nargs:u8 | 5 | Fused get_global + call |
+| 24 | `tail_call_global` | base:u8, sym:u16, nargs:u8 | 5 | Fused get_global + tail_call |
+| 25 | `box_local` | reg:u8 | 2 | Wrap register in pair for mutation |
+| 26 | `get_box_local` | dst:u8, reg:u8 | 3 | Read car of boxed register |
+| 27 | `set_box_local` | reg:u8, src:u8 | 3 | Write car of boxed register |
+| 28 | `self_tail_call` | base:u8, nargs:u8 | 3 | Self-recursive tail call: copy args to frame base, reset IP |
 
 `self_tail_call` skips the global lookup, type check, and arity check for
 direct self-recursion and named `let` loops — see

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -10,7 +10,7 @@ const GC = memory.GC;
 
 // File format constants
 const MAGIC = [4]u8{ 'K', 'P', 'B', 'C' };
-const VERSION: u16 = 7;
+const VERSION: u16 = 8;
 const MAX_FUNCTIONS: u32 = 16_384;
 const MAX_TOP_LEVEL_FUNCTIONS: u32 = 4_096;
 const MAX_CODE_BYTES: u32 = 4_194_304;
@@ -509,7 +509,7 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
                 const idx = try readU16FromCode(code, &ip);
                 if (idx >= func.constants.items.len) return BytecodeError.CorruptedFile;
             },
-            .load_nil, .load_true, .load_false, .load_void, .@"return", .close_upvalue, .push_handler, .box_local => {
+            .load_nil, .load_true, .load_false, .load_void, .@"return", .push_handler, .box_local => {
                 if (ip + 2 > code.len) return BytecodeError.CorruptedFile;
                 ip += 2;
             },
@@ -520,10 +520,6 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
             .call, .tail_call, .tail_apply, .self_tail_call => {
                 if (ip + 3 > code.len) return BytecodeError.CorruptedFile;
                 ip += 3;
-            },
-            .get_local, .set_local => {
-                if (ip + 4 > code.len) return BytecodeError.CorruptedFile;
-                ip += 4;
             },
             .get_global => {
                 if (ip + 4 > code.len) return BytecodeError.CorruptedFile;

--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -75,13 +75,12 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
         .get_global => 4,
         .set_global, .define_global => 4,
         .tail_apply => 3,
-        .get_local, .set_local, .get_upvalue, .set_upvalue => 4,
+        .get_upvalue, .set_upvalue => 4,
         .call, .tail_call => 3,
         .@"return" => 2,
         .jump => 2,
         .jump_false, .jump_true => 4,
         .closure => 4,
-        .close_upvalue => 2,
         .cons => 6,
         .push_handler => 2,
         .pop_handler, .halt => 0,
@@ -159,13 +158,6 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
             const nargs = code[ip];
             ip += 1;
             const s = std.fmt.bufPrint(&buf, "tail_apply      r{d}, {d}\n", .{ base, nargs }) catch "tail_apply\n";
-            writeStderr(s);
-        },
-        .get_local, .set_local => {
-            const a = readU16(code, &ip);
-            const b = readU16(code, &ip);
-            const oname = @tagName(op);
-            const s = std.fmt.bufPrint(&buf, "{s: <16}r{d}, r{d}\n", .{ oname, a, b }) catch "get/set_local\n";
             writeStderr(s);
         },
         .get_upvalue => {
@@ -258,11 +250,6 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
                     }
                 }
             }
-        },
-        .close_upvalue => {
-            const slot = readU16(code, &ip);
-            const s = std.fmt.bufPrint(&buf, "close_upvalue   r{d}\n", .{slot}) catch "close_upvalue\n";
-            writeStderr(s);
         },
         .cons => {
             const dst = readU16(code, &ip);
@@ -412,14 +399,6 @@ test "disassemble all opcodes" {
     emit.op(func, allocator, .tail_apply);
     emit.u16val(func, allocator, 0); // base register
     emit.byte(func, allocator, 2); // nargs (stays u8)
-    // get_local r0, r1
-    emit.op(func, allocator, .get_local);
-    emit.u16val(func, allocator, 0);
-    emit.u16val(func, allocator, 1);
-    // set_local r0, r1
-    emit.op(func, allocator, .set_local);
-    emit.u16val(func, allocator, 0);
-    emit.u16val(func, allocator, 1);
     // get_upvalue r0, uv0
     emit.op(func, allocator, .get_upvalue);
     emit.u16val(func, allocator, 0); // dst
@@ -458,9 +437,6 @@ test "disassemble all opcodes" {
     emit.u16val(func, allocator, 0); // dst register
     emit.byte(func, allocator, 0); // const idx high
     emit.byte(func, allocator, 0); // const idx low
-    // close_upvalue r0
-    emit.op(func, allocator, .close_upvalue);
-    emit.u16val(func, allocator, 0); // register
     // cons r0, r1, r2
     emit.op(func, allocator, .cons);
     emit.u16val(func, allocator, 0); // dst

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -306,10 +306,7 @@ pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {
     for (fiber.frames[0..fiber.frame_count]) |f| {
         if (f.closure) |cls| gc.markValue(types.makePointer(@ptrCast(cls)));
         if (f.native) |nf| gc.markValue(types.makePointer(@ptrCast(nf)));
-        const window: usize = if (f.closure) |cls| blk: {
-            const lc = cls.func.locals_count;
-            break :blk if (lc == 0) 256 else @as(usize, lc);
-        } else 256;
+        const window = f.frameWindow();
         const end: usize = @min(@as(usize, f.base) + window, fiber.registers.len);
         var r: usize = f.base;
         while (r < end) : (r += 1) gc.markValue(fiber.registers[r]);

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -194,10 +194,7 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
                 if (f.native) |nf| {
                     if (isYoungPointer(gc, types.makePointer(@ptrCast(nf)))) return true;
                 }
-                const window: usize = if (f.closure) |cls| blk: {
-                    const lc = cls.func.locals_count;
-                    break :blk if (lc == 0) 256 else @as(usize, lc);
-                } else 256;
+                const window = f.frameWindow();
                 const end: usize = @min(@as(usize, f.base) + window, fiber.registers.len);
                 var r: usize = f.base;
                 while (r < end) : (r += 1) {

--- a/src/types.zig
+++ b/src/types.zig
@@ -1053,8 +1053,6 @@ pub const OpCode = enum(u8) {
     set_global, // sym_idx:u16, src:u8
     define_global, // sym_idx:u16, src:u8
     tail_apply, // base:u8, nargs:u8
-    get_local, // dst:u8, slot:u8
-    set_local, // slot:u8, src:u8
     get_upvalue, // dst:u8, idx:u8
     set_upvalue, // idx:u8, src:u8
     call, // base:u8, nargs:u8
@@ -1064,7 +1062,6 @@ pub const OpCode = enum(u8) {
     jump_false, // test:u8, offset:i16
     jump_true, // test:u8, offset:i16
     closure, // dst:u8, idx:u16
-    close_upvalue, // slot:u8
     cons, // dst:u8, car:u8, cdr:u8
     push_handler, // handler_reg:u8
     pop_handler, // (no operands)

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -77,13 +77,7 @@ fn markVMRoots(gc: *memory.GC) void {
     for (vm.frames[0..vm.frame_count]) |f| {
         if (f.closure) |cls| gc.markValue(types.makePointer(@ptrCast(cls)));
         if (f.native) |nf| gc.markValue(types.makePointer(@ptrCast(nf)));
-        // Conservatively mark the frame's whole register window. locals_count
-        // is the compiler-recorded high-water mark of registers the function
-        // can touch; a closure-less frame falls back to a safe upper bound.
-        const window: usize = if (f.closure) |cls| blk: {
-            const lc = cls.func.locals_count;
-            break :blk if (lc == 0) 256 else @as(usize, lc);
-        } else 256;
+        const window = f.frameWindow();
         const end: usize = @min(@as(usize, f.base) + window, vm.registers.len);
         var r: usize = f.base;
         while (r < end) : (r += 1) gc.markValue(vm.registers[r]);
@@ -192,6 +186,13 @@ pub const CallFrame = struct {
     // contains the loop's own scope-root frame (resume here) or jumps to a
     // different program point (propagate ContinuationInvoked outward).
     seq: u64 = 0,
+
+    pub fn frameWindow(self: CallFrame) usize {
+        return if (self.closure) |cls| blk: {
+            const lc = cls.func.locals_count;
+            break :blk if (lc == 0) 256 else @as(usize, lc);
+        } else 256;
+    }
 };
 
 pub const StepMode = enum { none, step, next, step_out, continue_to_break };

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -19,10 +19,7 @@ pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u32) VMError!Value {
     // stack, far tighter than the old conservative `base + 256` per frame.
     var max_reg: usize = 0;
     for (vm.frames[0..vm.frame_count]) |f| {
-        const window: usize = if (f.closure) |cls| blk: {
-            const lc = cls.func.locals_count;
-            break :blk if (lc == 0) 256 else lc; // 0 => unknown, stay safe
-        } else 256; // native/closure-less frame: conservative fallback
+        const window = f.frameWindow();
         const frame_end = @as(usize, f.base) + window;
         if (frame_end > max_reg) max_reg = frame_end;
     }

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -133,14 +133,12 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
             .set_global => 4,
             .define_global => 4,
             .tail_apply => 3,
-            .get_local, .set_local => 4,
             .get_upvalue, .set_upvalue => 4,
             .call, .tail_call => 3,
             .@"return" => 2,
             .jump => 2,
             .jump_false, .jump_true => 4,
             .closure => 4,
-            .close_upvalue => 2,
             .cons => 6,
             .push_handler => 2,
             .pop_handler, .halt => 0,
@@ -849,9 +847,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const dst_idx = try registerIndex(self, frame.base, dst);
                 self.registers[dst_idx] = cls_val;
             },
-            .close_upvalue => {
-                _ = readU16(self, frame);
-            },
             .cons => {
                 const dst = readU16(self, frame);
                 const car_reg = readU16(self, frame);
@@ -1194,7 +1189,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 }
                 frame.ip = 0;
             },
-            else => return VMError.InvalidBytecode,
         }
     }
     return types.VOID;


### PR DESCRIPTION
## Summary

Closes #1052.

- Remove `get_local`, `set_local`, `close_upvalue` from `OpCode` — never emitted by any compiler path. `get_local`/`set_local` fell through to `InvalidBytecode`; `close_upvalue` dispatched as a no-op. Cleaned from enum, dispatch operand table, dispatch handler, disassembler, bytecode validator, and disassembler test. Bytecode cache VERSION bumped 7 → 8.
- Extract the duplicated frame-register-window formula (`locals_count or 256`) into `CallFrame.frameWindow()`, replacing 4 identical inline copies across `vm.zig`, `gc_collect.zig`, `vm_continuations.zig`, and `fiber.zig` (the issue noted 3; `fiber.zig:markFiberState` was a 4th).
- Update `docs/dev/bytecode.md`: renumber 32 → 29 opcodes.

Net: −82 lines, +34 lines across 9 files.

## Test plan

- [x] `zig build test` — all unit tests pass (exhaustive switches catch any missed opcode references at compile time)
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail (307 Scheme files + 1395 R7RS suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)