### PR TITLE
Deduplicate file-reading and SLD-path resolution

### DIFF
--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -3,6 +3,7 @@ const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const main = @import("main.zig");
+const file_utils = @import("file_utils.zig");
 const Value = types.Value;
 const Function = types.Function;
 const OpCode = types.OpCode;
@@ -578,32 +579,6 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
     }
 }
 
-fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    if (comptime is_wasm) return error.FileNotFound;
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{}, 0) catch {
-        return error.FileNotFound;
-    };
-    defer _ = std.posix.system.close(fd);
-
-    const max_size: usize = 4 * 1024 * 1024;
-    var result: std.ArrayList(u8) = .empty;
-    defer result.deinit(allocator);
-
-    var tmp: [4096]u8 = undefined;
-    while (true) {
-        const bytes_read = std.posix.read(fd, &tmp) catch {
-            return error.ReadError;
-        };
-        if (bytes_read == 0) break;
-        if (result.items.len + bytes_read > max_size) {
-            return error.ReadError;
-        }
-        result.appendSlice(allocator, tmp[0..bytes_read]) catch return error.OutOfMemory;
-    }
-
-    return result.toOwnedSlice(allocator);
-}
-
 // ---------------------------------------------------------------------------
 // Enhanced writeFile that records the top-level function count
 // ---------------------------------------------------------------------------
@@ -936,7 +911,7 @@ pub fn readFromBuffer(gc: *GC, data: []const u8) !?DeserializeResult {
 
 pub fn readFileWithTopLevel(gc: *GC, source_hash: u64, path: []const u8) !?DeserializeResult {
     const allocator = gc.allocator;
-    const data = readFileContents(allocator, path) catch return null;
+    const data = file_utils.readWholeFile(allocator, path, 4 * 1024 * 1024) catch return null;
     defer allocator.free(data);
     return deserializeFromBuffer(gc, data, source_hash);
 }

--- a/src/file_utils.zig
+++ b/src/file_utils.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const builtin_os = @import("builtin").os;
+const is_wasm = builtin_os.tag == .wasi;
+
+pub fn readWholeFile(allocator: std.mem.Allocator, path: []const u8, max_size: usize) ![]u8 {
+    const fd = if (comptime is_wasm) blk: {
+        var result_fd: std.os.wasi.fd_t = undefined;
+        const rc = std.os.wasi.path_open(3, .{ .SYMLINK_FOLLOW = true }, path.ptr, path.len, .{}, .{ .FD_READ = true, .FD_SEEK = true }, .{ .FD_READ = true }, .{}, &result_fd);
+        if (rc != .SUCCESS) return error.FileNotFound;
+        break :blk @as(c_int, @intCast(result_fd));
+    } else blk: {
+        const path_z = allocator.dupeZ(u8, path) catch return error.OutOfMemory;
+        defer allocator.free(path_z);
+        const raw_fd = std.c.open(path_z, .{});
+        if (raw_fd < 0) return error.FileNotFound;
+        break :blk raw_fd;
+    };
+    defer _ = std.c.close(fd);
+
+    var result: std.ArrayList(u8) = .empty;
+    defer result.deinit(allocator);
+
+    var tmp: [4096]u8 = undefined;
+    while (true) {
+        const raw = std.c.read(fd, &tmp, tmp.len);
+        if (raw == 0) break;
+        if (raw < 0) {
+            if (std.posix.errno(raw) == .INTR) continue;
+            return error.InputOutput;
+        }
+        const bytes_read: usize = @intCast(raw);
+        if (result.items.len + bytes_read > max_size) return error.StreamTooLong;
+        result.appendSlice(allocator, tmp[0..bytes_read]) catch |err| return err;
+    }
+
+    return result.toOwnedSlice(allocator);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin_os = @import("builtin").os;
 const is_wasm = builtin_os.tag == .wasi;
 const is_linux = builtin_os.tag == .linux;
+const file_utils = @import("file_utils.zig");
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 pub const types = @import("types.zig");
 pub const memory = @import("memory.zig");
@@ -162,65 +163,37 @@ fn printSourceSnippet(source: []const u8, line: u32) void {
 }
 
 fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    const path_z = allocator.dupeZ(u8, path) catch return error.OutOfMemory;
-    defer allocator.free(path_z);
-
-    const fd = if (comptime is_wasm) blk: {
-        var result_fd: std.os.wasi.fd_t = undefined;
-        const rc = std.os.wasi.path_open(3, .{ .SYMLINK_FOLLOW = true }, path.ptr, path.len, .{}, .{ .FD_READ = true, .FD_SEEK = true }, .{ .FD_READ = true }, .{}, &result_fd);
-        if (rc != .SUCCESS) {
-            std.debug.print("Error opening file '{s}': {}\n", .{ path, rc });
-            break :blk @as(c_int, -1);
-        }
-        break :blk @as(c_int, @intCast(result_fd));
-    } else blk: {
-        break :blk std.c.open(path_z, .{});
-    };
-    if (fd < 0) {
-        std.debug.print("Error opening file '{s}'\n", .{path});
-        return error.FileNotFound;
-    }
-    defer _ = std.c.close(fd);
-
     if (comptime !is_wasm) {
-        const is_dir = if (comptime is_linux) blk: {
-            const linux = std.os.linux;
-            var sx: linux.Statx = undefined;
-            const rc = linux.statx(fd, "", 0x1000, .{ .TYPE = true }, &sx);
-            break :blk rc <= @as(usize, std.math.maxInt(isize)) and (sx.mode & std.posix.S.IFMT == std.posix.S.IFDIR);
-        } else blk: {
-            var stat: std.c.Stat = undefined;
-            break :blk std.c.fstat(fd, &stat) == 0 and (stat.mode & std.posix.S.IFMT == std.posix.S.IFDIR);
-        };
-        if (is_dir) {
-            std.debug.print("Error: '{s}' is a directory\n", .{path});
-            return error.IsDir;
+        const path_z = allocator.dupeZ(u8, path) catch return error.OutOfMemory;
+        defer allocator.free(path_z);
+        const probe_fd = std.c.open(path_z, .{});
+        if (probe_fd >= 0) {
+            defer _ = std.c.close(probe_fd);
+            const is_dir = if (comptime is_linux) blk: {
+                const linux = std.os.linux;
+                var sx: linux.Statx = undefined;
+                const rc = linux.statx(probe_fd, "", 0x1000, .{ .TYPE = true }, &sx);
+                break :blk rc <= @as(usize, std.math.maxInt(isize)) and (sx.mode & std.posix.S.IFMT == std.posix.S.IFDIR);
+            } else blk: {
+                var stat_buf: std.c.Stat = undefined;
+                break :blk std.c.fstat(probe_fd, &stat_buf) == 0 and (stat_buf.mode & std.posix.S.IFMT == std.posix.S.IFDIR);
+            };
+            if (is_dir) {
+                std.debug.print("Error: '{s}' is a directory\n", .{path});
+                return error.IsDir;
+            }
         }
     }
 
-    const max_size: usize = 1024 * 1024;
-    var result: std.ArrayList(u8) = .empty;
-    defer result.deinit(allocator);
-
-    var tmp: [4096]u8 = undefined;
-    while (true) {
-        const raw = std.c.read(fd, &tmp, tmp.len);
-        if (raw == 0) break;
-        if (raw < 0) {
-            const e = std.posix.errno(raw);
-            if (e == .INTR) continue;
-            std.debug.print("Error reading file '{s}': {s}\n", .{ path, @tagName(e) });
-            return error.InputOutput;
+    return file_utils.readWholeFile(allocator, path, 1024 * 1024) catch |err| {
+        switch (err) {
+            error.FileNotFound => std.debug.print("Error opening file '{s}'\n", .{path}),
+            error.StreamTooLong => std.debug.print("File too large\n", .{}),
+            error.InputOutput => std.debug.print("Error reading file '{s}'\n", .{path}),
+            else => std.debug.print("Error reading file '{s}'\n", .{path}),
         }
-        const bytes_read: usize = @intCast(raw);
-        if (result.items.len + bytes_read > max_size) {
-            std.debug.print("File too large\n", .{});
-            return error.StreamTooLong;
-        }
-        result.appendSlice(allocator, tmp[0..bytes_read]) catch |err| return err;
-    }
-
-    return result.toOwnedSlice(allocator);
+        return err;
+    };
 }
 
 fn readAllStdin(allocator: std.mem.Allocator) ![]u8 {

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -5,6 +5,7 @@ const compiler = @import("compiler.zig");
 const vm_mod = @import("vm.zig");
 const ir_mod = @import("ir.zig");
 const llvm_emit = @import("llvm_emit.zig");
+const file_utils = @import("file_utils.zig");
 
 fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;
@@ -27,43 +28,9 @@ fn writeStderr(bytes: []const u8) void {
     writeToFd(2, bytes);
 }
 
-fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    const path_z = allocator.dupeZ(u8, path) catch return error.OutOfMemory;
-    defer allocator.free(path_z);
-
-    const fd = std.c.open(path_z, .{});
-    if (fd < 0) {
-        std.debug.print("Error opening file '{s}'\n", .{path});
-        return error.FileNotFound;
-    }
-    defer _ = std.c.close(fd);
-
-    const max_size: usize = 1024 * 1024;
-    var result: std.ArrayList(u8) = .empty;
-    defer result.deinit(allocator);
-
-    var tmp: [4096]u8 = undefined;
-    while (true) {
-        const raw = std.c.read(fd, &tmp, tmp.len);
-        if (raw == 0) break;
-        if (raw < 0) {
-            if (std.posix.errno(raw) == .INTR) continue;
-            break;
-        }
-        const bytes_read: usize = @intCast(raw);
-        if (result.items.len + bytes_read > max_size) {
-            std.debug.print("File too large\n", .{});
-            return error.StreamTooLong;
-        }
-        result.appendSlice(allocator, tmp[0..bytes_read]) catch |err| return err;
-    }
-
-    return result.toOwnedSlice(allocator);
-}
-
 pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;
-    const source = readFileContents(allocator, path) catch return;
+    const source = file_utils.readWholeFile(allocator, path, 1024 * 1024) catch return;
     defer allocator.free(source);
 
     const saved_lib_dir = vm.current_lib_dir;

--- a/src/reporting.zig
+++ b/src/reporting.zig
@@ -3,6 +3,7 @@ pub const types = @import("types.zig");
 pub const memory = @import("memory.zig");
 pub const vm_mod = @import("vm.zig");
 pub const library_mod = @import("library.zig");
+const file_utils = @import("file_utils.zig");
 
 fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;
@@ -275,60 +276,6 @@ fn extractName(s: []const u8) ?[]const u8 {
     return s[0..end];
 }
 
-fn resolveSldPath(allocator: std.mem.Allocator, rel_path: []const u8, lib_paths: []const []const u8) ?[]u8 {
-    var bases: [18][]const u8 = undefined;
-    bases[0] = "";
-    bases[1] = "lib/";
-    var base_count: usize = 2;
-    for (lib_paths) |lp| {
-        if (base_count >= 18) break;
-        bases[base_count] = lp;
-        base_count += 1;
-    }
-
-    for (bases[0..base_count]) |base| {
-        var full: [513]u8 = undefined;
-        var len: usize = 0;
-        if (base.len > 0) {
-            if (base.len + 1 + rel_path.len >= full.len) continue;
-            @memcpy(full[0..base.len], base);
-            len = base.len;
-            if (base[base.len - 1] != '/') {
-                full[len] = '/';
-                len += 1;
-            }
-        }
-        if (len + rel_path.len >= full.len) continue;
-        @memcpy(full[len..][0..rel_path.len], rel_path);
-        len += rel_path.len;
-        const path_z = allocator.dupeZ(u8, full[0..len]) catch continue;
-        const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{}, 0) catch {
-            allocator.free(path_z);
-            continue;
-        };
-        _ = std.posix.system.close(fd);
-        allocator.free(path_z);
-        return allocator.dupe(u8, full[0..len]) catch null;
-    }
-    return null;
-}
-
-fn readFile(allocator: std.mem.Allocator, path: []const u8) ?[]u8 {
-    const path_z = allocator.dupeZ(u8, path) catch return null;
-    defer allocator.free(path_z);
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{}, 0) catch return null;
-    defer _ = std.posix.system.close(fd);
-
-    var result: std.ArrayList(u8) = .empty;
-    var tmp: [4096]u8 = undefined;
-    while (true) {
-        const n = std.posix.read(fd, &tmp) catch break;
-        if (n == 0) break;
-        result.appendSlice(allocator, tmp[0..n]) catch break;
-    }
-    return result.toOwnedSlice(allocator) catch null;
-}
-
 fn xmlEscape(out: *std.ArrayList(u8), allocator: std.mem.Allocator, s: []const u8) void {
     for (s) |c| {
         switch (c) {
@@ -459,10 +406,10 @@ pub fn writeCoverageXml(vm: *vm_mod.VM, path: []const u8) void {
         var define_map: ?DefineMap = null;
         var sld_source: ?[]u8 = null;
         {
-            const resolved = resolveSldPath(allocator, rel_path, vm.lib_paths);
+            const resolved = vm_mod.vm_library.resolveLibraryPath(allocator, rel_path, vm.lib_paths);
             if (resolved) |sld_path| {
                 defer allocator.free(sld_path);
-                sld_source = readFile(allocator, sld_path);
+                sld_source = file_utils.readWholeFile(allocator, sld_path, std.math.maxInt(usize)) catch null;
                 if (sld_source) |source| {
                     define_map = scanDefines(source);
                 }

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const library_mod = @import("library.zig");
+const file_utils = @import("file_utils.zig");
 const Value = types.Value;
 
 const passthrough = @import("compiler_passthrough.zig");
@@ -273,7 +274,7 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
 
 /// Resolve the full path for a library .sld file.
 /// Returns a heap-allocated path string, or null if not found.
-fn resolveLibraryPath(allocator: std.mem.Allocator, rel_path: []const u8, lib_paths: []const []const u8) ?[]u8 {
+pub fn resolveLibraryPath(allocator: std.mem.Allocator, rel_path: []const u8, lib_paths: []const []const u8) ?[]u8 {
     // Built-in search prefixes (relative to cwd)
     const builtin_prefixes = [_][]const u8{ "", "lib/" };
 
@@ -370,7 +371,7 @@ fn readFileOrBundled(allocator: std.mem.Allocator, path: []const u8, bundled: ?*
             return allocator.dupe(u8, src) catch return error.OutOfMemory;
         }
     }
-    return readFileContents(allocator, path);
+    return file_utils.readWholeFile(allocator, path, 1024 * 1024);
 }
 
 /// Record a file read for bundle collection during --compile.
@@ -435,7 +436,7 @@ fn tryLoadLibraryFromFile(vm: *VM, name_list: Value) !void {
     defer vm.current_lib_dir = saved_lib_dir;
 
     // Read the source file
-    const source = readFileContents(allocator, sld_path) catch return error.UndefinedVariable;
+    const source = file_utils.readWholeFile(allocator, sld_path, 1024 * 1024) catch return error.UndefinedVariable;
     defer allocator.free(source);
 
     // Record for bundling (use rel_path so findBundledSource can locate it
@@ -655,31 +656,6 @@ fn extractDir(path: []const u8) []const u8 {
         return path[0 .. pos + 1];
     }
     return "";
-}
-
-/// Read file contents (duplicated from main.zig since we can't import it)
-fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    const path_z = allocator.dupeZ(u8, path) catch return error.OutOfMemory;
-    defer allocator.free(path_z);
-
-    const fd = std.c.open(path_z, .{});
-    if (fd < 0) return error.InvalidSyntax;
-    defer _ = std.c.close(fd);
-
-    const max_size: usize = 1024 * 1024;
-    var result: std.ArrayList(u8) = .empty;
-    defer result.deinit(allocator);
-
-    var tmp: [4096]u8 = undefined;
-    while (true) {
-        const raw = std.c.read(fd, &tmp, tmp.len);
-        if (raw <= 0) break;
-        const bytes_read: usize = @intCast(raw);
-        if (result.items.len + bytes_read > max_size) return error.InvalidSyntax;
-        result.appendSlice(allocator, tmp[0..bytes_read]) catch return error.OutOfMemory;
-    }
-
-    return result.toOwnedSlice(allocator);
 }
 
 fn resolveImportBindings(vm: *VM, import_set: Value) anyerror!std.StringHashMap(Value) {


### PR DESCRIPTION
## Summary

Closes #1064.

- Add `src/file_utils.zig` with shared `readWholeFile(allocator, path, max)` — WASM support, EINTR retry, caller-specified max size
- Make `resolveLibraryPath` pub in `vm_library.zig`; delete the `resolveSldPath` clone in `reporting.zig` (had smaller buffer and hardcoded 18-path cap)
- Delete 5 private `readFileContents`/`readFile` copies across the interpreter tree (`main.zig`, `vm_library.zig`, `reporting.zig`, `native_compiler.zig`, `bytecode_file.zig`), replacing with calls to the shared function
- `thottam.zig` keeps its own copy (separate binary, should not pull in interpreter modules)

Net: +75 −200 lines (6 files changed, 1 new).

## Test plan

- [x] `zig build` — clean compile
- [x] `zig build test` — unit tests pass
- [x] `zig build run -- tests/scheme/r7rs/r7rs-tests.scm` — 1395 pass, 0 fail
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail
- [x] `kaappi --coverage --lib-path ../kaappi-json/lib ../kaappi-json/tests/test-json.scm` — coverage resolves correctly (5/5 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)