### PR TITLE
Extract shared error reporting helpers into toplevel_driver.zig (#1061)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -41,6 +41,7 @@ pub const ir_mod = @import("ir.zig");
 pub const ir_emitter = @import("ir_emitter.zig");
 pub const llvm_emit = @import("llvm_emit.zig");
 pub const native_compiler = @import("native_compiler.zig");
+pub const toplevel_driver = @import("toplevel_driver.zig");
 
 pub const version = @import("build_options").version;
 
@@ -131,34 +132,6 @@ fn printSingleResult(allocator: std.mem.Allocator, value: types.Value) void {
     defer allocator.free(s);
     writeStdout(s);
     writeStdout("\n");
-}
-
-fn printSourceSnippet(source: []const u8, line: u32) void {
-    if (line == 0 or source.len == 0) return;
-    var current_line: u32 = 1;
-    var line_start: usize = 0;
-    for (source, 0..) |c, i| {
-        if (current_line == line) {
-            var line_end = i;
-            while (line_end < source.len and source[line_end] != '\n') : (line_end += 1) {}
-            const snippet = source[line_start..line_end];
-            if (snippet.len > 0) {
-                writeStderr("    ");
-                writeStderr(snippet);
-                writeStderr("\n");
-            }
-            return;
-        }
-        if (c == '\n') {
-            current_line += 1;
-            line_start = i + 1;
-        }
-    }
-    if (current_line == line and line_start < source.len) {
-        writeStderr("    ");
-        writeStderr(source[line_start..]);
-        writeStderr("\n");
-    }
 }
 
 fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
@@ -833,39 +806,10 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                 const result = vm.execute(func) catch |err| {
                     vm.gc.popRoot();
                     script_had_error = true;
-                    const detail = vm.getErrorDetail();
-                    const err_line = vm.last_error_line;
-                    const err_source = vm.last_error_source orelse path;
-                    if (detail.len > 0) {
-                        var errbuf: [512]u8 = undefined;
-                        const s = if (err_line > 0)
-                            std.fmt.bufPrint(&errbuf, "{s}:{d}: error: {s}\n", .{ err_source, err_line, detail }) catch "runtime error\n"
-                        else
-                            std.fmt.bufPrint(&errbuf, "{s}: error: {s}\n", .{ err_source, detail }) catch "runtime error\n";
-                        writeStderr(s);
-                    } else {
-                        var errbuf: [512]u8 = undefined;
-                        const s = if (err_line > 0)
-                            std.fmt.bufPrint(&errbuf, "{s}:{d}: runtime error: {}\n", .{ err_source, err_line, err }) catch "runtime error\n"
-                        else
-                            std.fmt.bufPrint(&errbuf, "{s}: runtime error: {}\n", .{ err_source, err }) catch "runtime error\n";
-                        writeStderr(s);
-                    }
-                    if (err_line > 0) printSourceSnippet(source, err_line);
-                    const trace = vm.getLastStackTrace();
-                    if (trace.len > 1) {
-                        for (trace[1..]) |frame| {
-                            var tbuf: [256]u8 = undefined;
-                            if (frame.name) |name| {
-                                const ts = std.fmt.bufPrint(&tbuf, "  in {s} ({s}:{d})\n", .{ name, frame.source orelse "?", frame.line }) catch continue;
-                                writeStderr(ts);
-                            } else if (frame.line > 0) {
-                                const ts = std.fmt.bufPrint(&tbuf, "  called from {s}:{d}\n", .{ frame.source orelse "?", frame.line }) catch continue;
-                                writeStderr(ts);
-                            }
-                        }
-                    }
-                    vm.last_error_detail_len = 0;
+                    const loc = toplevel_driver.vmErrorLocation(vm, path, 0);
+                    toplevel_driver.reportRuntimeError(vm, err, loc);
+                    if (loc.line > 0) toplevel_driver.printSourceSnippet(source, loc.line);
+                    toplevel_driver.printStackTrace(vm);
                     continue;
                 };
                 vm.gc.popRoot();
@@ -886,24 +830,18 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
 
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
-        var errbuf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
-        writeStderr(s);
+        toplevel_driver.reportReadError(path, lc.line, lc.col, err);
         script_had_error = true;
         return;
     }) {
         const datum_lc = r.getLineCol();
         var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
-            writeStderr(s);
+            toplevel_driver.reportReadError(path, lc.line, lc.col, err);
             script_had_error = true;
             return;
         };
 
-        // Root the form: evaluating it (e.g. an import that loads a library)
-        // can trigger GC, which would otherwise reclaim the AST mid-walk.
         vm.gc.pushRoot(&expr) catch {
             writeStderr("error: out of memory while rooting expression\n");
             script_had_error = true;
@@ -911,22 +849,11 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         };
         defer vm.gc.popRoot();
 
-        // Check for special top-level forms (import, define-library)
         if (vm.handleTopLevelForm(expr)) |top_result| {
             has_imports = true;
             const result = top_result catch |err| {
                 script_had_error = true;
-                const detail = vm.getErrorDetail();
-                if (detail.len > 0) {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: error: {s}\n", .{ path, datum_lc.line, detail }) catch "runtime error\n";
-                    writeStderr(s);
-                } else {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: runtime error: {}\n", .{ path, datum_lc.line, err }) catch "runtime error\n";
-                    writeStderr(s);
-                }
-                vm.last_error_detail_len = 0;
+                toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
                 continue;
             };
             printTopLevelResult(allocator, result);
@@ -934,55 +861,24 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         }
 
         const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path) catch |err| {
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: compile error: {}\n", .{ path, datum_lc.line, err }) catch "compile error\n";
-            writeStderr(s);
+            toplevel_driver.reportCompileError(path, datum_lc.line, err);
             script_had_error = true;
             continue;
         };
 
-        // Collect for caching. Keep each collected function rooted for the rest
-        // of the run: the .sbc cache writer walks compiled_funcs at the end, so
-        // these pointers must survive GC triggered while executing later forms.
-        // (A plain ArrayList of *Function is not a GC root.)
         compiled_funcs.append(allocator, func) catch return error.OutOfMemory;
         vm.gc.extra_roots.append(allocator, types.makePointer(@ptrCast(func))) catch return error.OutOfMemory;
 
-        // Root the function to prevent GC from collecting it before execute wraps it in a closure
         var func_val = types.makePointer(@ptrCast(func));
         vm.gc.pushRoot(&func_val) catch return error.OutOfMemory;
 
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();
             script_had_error = true;
-            const detail = vm.getErrorDetail();
-            const err_line = if (vm.last_error_line > 0) vm.last_error_line else datum_lc.line;
-            const err_source = vm.last_error_source orelse path;
-            if (detail.len > 0) {
-                var errbuf: [512]u8 = undefined;
-                const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: error: {s}\n", .{ err_source, err_line, detail }) catch "runtime error\n";
-                writeStderr(s);
-            } else {
-                var errbuf: [512]u8 = undefined;
-                const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: runtime error: {}\n", .{ err_source, err_line, err }) catch "runtime error\n";
-                writeStderr(s);
-            }
-            printSourceSnippet(source, err_line);
-            // Print stack trace for file execution
-            const trace = vm.getLastStackTrace();
-            if (trace.len > 1) {
-                for (trace[1..]) |frame| {
-                    var tbuf: [256]u8 = undefined;
-                    if (frame.name) |name| {
-                        const ts = std.fmt.bufPrint(&tbuf, "  in {s} ({s}:{d})\n", .{ name, frame.source orelse "?", frame.line }) catch continue;
-                        writeStderr(ts);
-                    } else if (frame.line > 0) {
-                        const ts = std.fmt.bufPrint(&tbuf, "  called from {s}:{d}\n", .{ frame.source orelse "?", frame.line }) catch continue;
-                        writeStderr(ts);
-                    }
-                }
-            }
-            vm.last_error_detail_len = 0;
+            const loc = toplevel_driver.vmErrorLocation(vm, path, datum_lc.line);
+            toplevel_driver.reportRuntimeError(vm, err, loc);
+            toplevel_driver.printSourceSnippet(source, loc.line);
+            toplevel_driver.printStackTrace(vm);
             continue;
         };
         vm.gc.popRoot();
@@ -1013,23 +909,17 @@ fn runStdin(vm: *vm_mod.VM) !void {
 
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
-        var errbuf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&errbuf, "<stdin>:{d}:{d}: read error: {}\n", .{ lc.line, lc.col, err }) catch "read error\n";
-        writeStderr(s);
+        toplevel_driver.reportReadError("<stdin>", lc.line, lc.col, err);
         script_had_error = true;
         return;
     }) {
         var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "<stdin>:{d}:{d}: read error: {}\n", .{ lc.line, lc.col, err }) catch "read error\n";
-            writeStderr(s);
+            toplevel_driver.reportReadError("<stdin>", lc.line, lc.col, err);
             script_had_error = true;
             return;
         };
 
-        // Root the form: evaluating it (e.g. an import that loads a library)
-        // can trigger GC, which would otherwise reclaim the AST mid-walk.
         vm.gc.pushRoot(&expr) catch {
             writeStderr("error: out of memory while rooting expression\n");
             script_had_error = true;
@@ -1040,17 +930,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
         if (vm.handleTopLevelForm(expr)) |top_result| {
             const result = top_result catch |err| {
                 script_had_error = true;
-                const detail = vm.getErrorDetail();
-                if (detail.len > 0) {
-                    writeStderr("error: ");
-                    writeStderr(detail);
-                    writeStderr("\n");
-                } else {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "runtime error: {}\n", .{err}) catch "runtime error\n";
-                    writeStderr(s);
-                }
-                vm.last_error_detail_len = 0;
+                toplevel_driver.reportRuntimeError(vm, err, null);
                 continue;
             };
             printTopLevelResult(allocator, result);
@@ -1059,9 +939,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
 
         const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, 0, "<stdin>") catch |err| {
             const lc = r.getLineCol();
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "<stdin>:{d}: compile error: {}\n", .{ lc.line, err }) catch "compile error\n";
-            writeStderr(s);
+            toplevel_driver.reportCompileError("<stdin>", lc.line, err);
             script_had_error = true;
             return;
         };
@@ -1076,17 +954,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();
             script_had_error = true;
-            const detail = vm.getErrorDetail();
-            if (detail.len > 0) {
-                writeStderr("error: ");
-                writeStderr(detail);
-                writeStderr("\n");
-            } else {
-                var errbuf: [256]u8 = undefined;
-                const s = std.fmt.bufPrint(&errbuf, "runtime error: {}\n", .{err}) catch "runtime error\n";
-                writeStderr(s);
-            }
-            vm.last_error_detail_len = 0;
+            toplevel_driver.reportRuntimeError(vm, err, null);
             continue;
         };
         vm.gc.popRoot();
@@ -1112,24 +980,18 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
 
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
-        var errbuf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
-        writeStderr(s);
+        toplevel_driver.reportReadError(path, lc.line, lc.col, err);
         script_had_error = true;
         return;
     }) {
         const datum_lc = r.getLineCol();
         var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
-            writeStderr(s);
+            toplevel_driver.reportReadError(path, lc.line, lc.col, err);
             script_had_error = true;
             return;
         };
 
-        // Root the form: evaluating it (e.g. an import that loads a library)
-        // can trigger GC, which would otherwise reclaim the AST mid-walk.
         vm.gc.pushRoot(&expr) catch {
             writeStderr("error: out of memory while rooting expression\n");
             script_had_error = true;
@@ -1140,25 +1002,13 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
         if (vm.handleTopLevelForm(expr)) |top_result| {
             _ = top_result catch |err| {
                 script_had_error = true;
-                const detail = vm.getErrorDetail();
-                if (detail.len > 0) {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: error: {s}\n", .{ path, datum_lc.line, detail }) catch "runtime error\n";
-                    writeStderr(s);
-                } else {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: runtime error: {}\n", .{ path, datum_lc.line, err }) catch "runtime error\n";
-                    writeStderr(s);
-                }
-                vm.last_error_detail_len = 0;
+                toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
             };
             continue;
         }
 
         const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path) catch |err| {
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: compile error: {}\n", .{ path, datum_lc.line, err }) catch "compile error\n";
-            writeStderr(s);
+            toplevel_driver.reportCompileError(path, datum_lc.line, err);
             script_had_error = true;
             continue;
         };
@@ -1211,18 +1061,14 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
 
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
-        var errbuf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
-        writeStderr(s);
+        toplevel_driver.reportReadError(path, lc.line, lc.col, err);
         script_had_error = true;
         return;
     }) {
         const datum_lc = r.getLineCol();
         var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
-            writeStderr(s);
+            toplevel_driver.reportReadError(path, lc.line, lc.col, err);
             script_had_error = true;
             return;
         };
@@ -1234,17 +1080,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
             const form_src = printer.valueToString(allocator, expr, .write) catch continue;
             _ = top_result catch |err| {
                 script_had_error = true;
-                const detail = vm.getErrorDetail();
-                if (detail.len > 0) {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: error: {s}\n", .{ path, datum_lc.line, detail }) catch "runtime error\n";
-                    writeStderr(s);
-                } else {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: runtime error: {}\n", .{ path, datum_lc.line, err }) catch "runtime error\n";
-                    writeStderr(s);
-                }
-                vm.last_error_detail_len = 0;
+                toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
             };
             preamble.append(allocator, form_src) catch {
                 allocator.free(form_src);
@@ -1253,9 +1089,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         }
 
         const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path) catch |err| {
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}: compile error: {}\n", .{ path, datum_lc.line, err }) catch "compile error\n";
-            writeStderr(s);
+            toplevel_driver.reportCompileError(path, datum_lc.line, err);
             script_had_error = true;
             continue;
         };
@@ -1343,5 +1177,6 @@ test {
     _ = ir_emitter;
     _ = llvm_emit;
     _ = native_compiler;
+    _ = toplevel_driver;
     _ = repl_mod;
 }

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -8,6 +8,7 @@ const printer = @import("printer.zig");
 const vm_library = @import("vm_library.zig");
 const reporting = @import("reporting.zig");
 const expander = @import("expander.zig");
+const toplevel_driver = @import("toplevel_driver.zig");
 const ln = if (is_wasm) struct {} else @import("linenoise.zig");
 
 const version = @import("main.zig").version;
@@ -939,21 +940,15 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
 
     while (r.hasMore() catch |err| blk: {
         const lc = r.getLineCol();
-        var errbuf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&errbuf, "<repl>:{d}:{d}: read error: {}\n", .{ lc.line, lc.col, err }) catch "read error\n";
-        writeStderr(s);
+        toplevel_driver.reportReadError("<repl>", lc.line, lc.col, err);
         break :blk false;
     }) {
         var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "<repl>:{d}:{d}: read error: {}\n", .{ lc.line, lc.col, err }) catch "read error\n";
-            writeStderr(s);
+            toplevel_driver.reportReadError("<repl>", lc.line, lc.col, err);
             break;
         };
 
-        // Root the form: evaluating it (e.g. an import that loads a library)
-        // can trigger GC, which would otherwise reclaim the AST mid-walk.
         vm.gc.pushRoot(&expr) catch {
             writeStderr("error: out of memory while rooting expression\n");
             break;
@@ -962,17 +957,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
             const result = top_result catch |err| {
-                const detail = vm.getErrorDetail();
-                if (detail.len > 0) {
-                    writeStderr("error: ");
-                    writeStderr(detail);
-                    writeStderr("\n");
-                } else {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "runtime error: {}\n", .{err}) catch "runtime error\n";
-                    writeStderr(s);
-                }
-                vm.last_error_detail_len = 0;
+                toplevel_driver.reportRuntimeError(vm, err, null);
                 break;
             };
             var dr = result;
@@ -1008,9 +993,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
 
         const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, 0, "<repl>") catch |err| {
             const lc = r.getLineCol();
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "<repl>:{d}: compile error: {}\n", .{ lc.line, err }) catch "compile error\n";
-            writeStderr(s);
+            toplevel_driver.reportCompileError("<repl>", lc.line, err);
             break;
         };
 
@@ -1022,30 +1005,8 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
 
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();
-            const detail = vm.getErrorDetail();
-            if (detail.len > 0) {
-                writeStderr("error: ");
-                writeStderr(detail);
-                writeStderr("\n");
-            } else {
-                var errbuf: [256]u8 = undefined;
-                const s = std.fmt.bufPrint(&errbuf, "runtime error: {}\n", .{err}) catch "runtime error\n";
-                writeStderr(s);
-            }
-            const trace = vm.getLastStackTrace();
-            if (trace.len > 1) {
-                for (trace[1..]) |sf| {
-                    var tbuf: [256]u8 = undefined;
-                    if (sf.name) |name| {
-                        const ts = std.fmt.bufPrint(&tbuf, "  in {s} ({s}:{d})\n", .{ name, sf.source orelse "?", sf.line }) catch continue;
-                        writeStderr(ts);
-                    } else if (sf.line > 0) {
-                        const ts = std.fmt.bufPrint(&tbuf, "  called from {s}:{d}\n", .{ sf.source orelse "?", sf.line }) catch continue;
-                        writeStderr(ts);
-                    }
-                }
-            }
-            vm.last_error_detail_len = 0;
+            toplevel_driver.reportRuntimeError(vm, err, null);
+            toplevel_driver.printStackTrace(vm);
             break;
         };
         vm.gc.popRoot();

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -1,0 +1,119 @@
+const std = @import("std");
+const vm_mod = @import("vm.zig");
+
+fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
+    var total: usize = 0;
+    while (total < bytes.len) {
+        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
+        if (result <= 0) {
+            if (result < 0 and std.posix.errno(result) == .INTR) continue;
+            break;
+        }
+        const written: usize = @intCast(result);
+        total += written;
+    }
+}
+
+fn writeStderr(bytes: []const u8) void {
+    writeToFd(2, bytes);
+}
+
+pub const Location = struct {
+    source: []const u8,
+    line: u32,
+};
+
+pub fn reportReadError(source_name: []const u8, line: u32, col: u32, err: anyerror) void {
+    var buf: [256]u8 = undefined;
+    const s = std.fmt.bufPrint(&buf, "{s}:{d}:{d}: read error: {}\n", .{ source_name, line, col, err }) catch "read error\n";
+    writeStderr(s);
+}
+
+pub fn reportCompileError(source_name: []const u8, line: u32, err: anyerror) void {
+    var buf: [256]u8 = undefined;
+    const s = std.fmt.bufPrint(&buf, "{s}:{d}: compile error: {}\n", .{ source_name, line, err }) catch "compile error\n";
+    writeStderr(s);
+}
+
+pub fn reportRuntimeError(vm: *vm_mod.VM, err: anyerror, location: ?Location) void {
+    const detail = vm.getErrorDetail();
+    if (location) |loc| {
+        if (detail.len > 0) {
+            var buf: [512]u8 = undefined;
+            const s = if (loc.line > 0)
+                std.fmt.bufPrint(&buf, "{s}:{d}: error: {s}\n", .{ loc.source, loc.line, detail }) catch "runtime error\n"
+            else
+                std.fmt.bufPrint(&buf, "{s}: error: {s}\n", .{ loc.source, detail }) catch "runtime error\n";
+            writeStderr(s);
+        } else {
+            var buf: [512]u8 = undefined;
+            const s = if (loc.line > 0)
+                std.fmt.bufPrint(&buf, "{s}:{d}: runtime error: {}\n", .{ loc.source, loc.line, err }) catch "runtime error\n"
+            else
+                std.fmt.bufPrint(&buf, "{s}: runtime error: {}\n", .{ loc.source, err }) catch "runtime error\n";
+            writeStderr(s);
+        }
+    } else {
+        if (detail.len > 0) {
+            writeStderr("error: ");
+            writeStderr(detail);
+            writeStderr("\n");
+        } else {
+            var buf: [256]u8 = undefined;
+            const s = std.fmt.bufPrint(&buf, "runtime error: {}\n", .{err}) catch "runtime error\n";
+            writeStderr(s);
+        }
+    }
+    vm.last_error_detail_len = 0;
+}
+
+pub fn vmErrorLocation(vm: *vm_mod.VM, fallback_source: []const u8, fallback_line: u32) Location {
+    return .{
+        .source = vm.last_error_source orelse fallback_source,
+        .line = if (vm.last_error_line > 0) vm.last_error_line else fallback_line,
+    };
+}
+
+pub fn printStackTrace(vm: *vm_mod.VM) void {
+    const trace = vm.getLastStackTrace();
+    if (trace.len > 1) {
+        for (trace[1..]) |frame| {
+            var buf: [256]u8 = undefined;
+            if (frame.name) |name| {
+                const s = std.fmt.bufPrint(&buf, "  in {s} ({s}:{d})\n", .{ name, frame.source orelse "?", frame.line }) catch continue;
+                writeStderr(s);
+            } else if (frame.line > 0) {
+                const s = std.fmt.bufPrint(&buf, "  called from {s}:{d}\n", .{ frame.source orelse "?", frame.line }) catch continue;
+                writeStderr(s);
+            }
+        }
+    }
+}
+
+pub fn printSourceSnippet(source: []const u8, line: u32) void {
+    if (line == 0 or source.len == 0) return;
+    var current_line: u32 = 1;
+    var line_start: usize = 0;
+    for (source, 0..) |c, i| {
+        if (current_line == line) {
+            var line_end = i;
+            while (line_end < source.len and source[line_end] != '\n') : (line_end += 1) {}
+            const snippet = source[line_start..line_end];
+            if (snippet.len > 0) {
+                writeStderr("    ");
+                writeStderr(snippet);
+                writeStderr("\n");
+            }
+            return;
+        }
+        if (c == '\n') {
+            current_line += 1;
+            line_start = i + 1;
+        }
+    }
+    if (current_line == line and line_start < source.len) {
+        writeStderr("    ");
+        writeStderr(source[line_start..]);
+        writeStderr("\n");
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicated read→compile→execute→report error formatting from 5 call sites into a new `src/toplevel_driver.zig` with 6 public helpers: `reportReadError`, `reportCompileError`, `reportRuntimeError`, `vmErrorLocation`, `printStackTrace`, `printSourceSnippet`
- Each call site keeps its own loop and control flow (`break`/`continue`/`return`) but delegates error formatting to the shared helpers
- Net -85 lines (238 deleted, 153 added across 3 files)

Closes #1061

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/errors/error-format.sh` — all 33 format assertions pass
- [x] `bash tests/scheme/errors/exit-code.sh` — all 39 exit code assertions pass
- [x] `bash tests/scheme/errors/test-source-snippet.sh` — source snippet test passes
- [x] `bash tests/scheme/errors/reader-token-errors.sh` — reader error tests pass
- [x] `bash tests/scheme/errors/reader-hasmore-errors.sh` — hasMore error tests pass
- [x] `printf '(car 1)' | zig-out/bin/kaappi` — REPL error format verified manually
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)