### PR TITLE
Break memory→vm circular dependency, add finishAlloc helper

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -5,7 +5,7 @@ const memory = @import("memory.zig");
 const Value = types.Value;
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
-const CallFrame = vm_mod.CallFrame;
+const CallFrame = types.CallFrame;
 
 pub const MAX_FIBERS = 64;
 
@@ -29,9 +29,9 @@ pub const Fiber = struct {
     registers: []Value,
     frames: []CallFrame,
     frame_count: usize,
-    handler_stack: [vm_mod.MAX_HANDLERS]vm_mod.ExceptionHandler,
+    handler_stack: [types.MAX_HANDLERS]types.ExceptionHandler,
     handler_count: usize,
-    wind_stack: [vm_mod.MAX_WINDS]types.WindRecord,
+    wind_stack: [types.MAX_WINDS]types.WindRecord,
     wind_count: usize,
     current_exception: ?Value,
     continuation_invoked: bool,

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -789,7 +789,7 @@ fn objectSize(obj: *Object) usize {
             const fiber = obj.as(@import("fiber.zig").Fiber);
             break :blk @sizeOf(@import("fiber.zig").Fiber) +
                 fiber.registers.len * @sizeOf(Value) +
-                fiber.frames.len * @sizeOf(@import("vm.zig").CallFrame);
+                fiber.frames.len * @sizeOf(types.CallFrame);
         },
         .channel => @sizeOf(types.Channel),
         .mutex => @sizeOf(types.Mutex),

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const types = @import("types.zig");
-const hashtable = @import("primitives_hashtable.zig");
 const Value = types.Value;
 const Object = types.Object;
 const ObjectTag = types.ObjectTag;
@@ -198,6 +197,12 @@ pub const GC = struct {
             self.stats.peak_bytes_allocated = self.bytes_allocated;
     }
 
+    pub inline fn finishAlloc(self: *GC, obj: *Object, size: usize) void {
+        self.bytes_allocated += size;
+        self.profileAlloc(size);
+        self.trackObject(obj);
+    }
+
     pub fn allocPair(self: *GC, car_val: Value, cdr_val: Value) !Value {
         try self.maybeCollect();
         const pair = try self.allocator.create(Pair);
@@ -206,10 +211,7 @@ pub const GC = struct {
             .car = car_val,
             .cdr = cdr_val,
         };
-        self.bytes_allocated += @sizeOf(Pair);
-
-        self.profileAlloc(@sizeOf(Pair));
-        self.trackObject(&pair.header);
+        self.finishAlloc(&pair.header, @sizeOf(Pair));
         return types.makePointer(@ptrCast(pair));
     }
 
@@ -241,8 +243,9 @@ pub const GC = struct {
             .header = .{ .tag = .symbol },
             .name = owned_name,
         };
-        self.bytes_allocated += @sizeOf(Symbol) + name.len;
-        self.profileAlloc(@sizeOf(Symbol) + name.len);
+        const size = @sizeOf(Symbol) + name.len;
+        self.bytes_allocated += size;
+        self.profileAlloc(size);
 
         if (is_child) {
             // The symbol lives in the parent's shared table and must outlive
@@ -276,10 +279,7 @@ pub const GC = struct {
             .data = owned,
             .len = data.len,
         };
-        self.bytes_allocated += @sizeOf(SchemeString) + data.len;
-
-        self.profileAlloc(@sizeOf(SchemeString) + data.len);
-        self.trackObject(&str.header);
+        self.finishAlloc(&str.header, @sizeOf(SchemeString) + data.len);
         return types.makePointer(@ptrCast(str));
     }
 
@@ -291,10 +291,7 @@ pub const GC = struct {
             .constants = .empty,
             .arity = 0,
         };
-        self.bytes_allocated += @sizeOf(Function);
-
-        self.profileAlloc(@sizeOf(Function));
-        self.trackObject(&func.header);
+        self.finishAlloc(&func.header, @sizeOf(Function));
         return func;
     }
 
@@ -311,11 +308,7 @@ pub const GC = struct {
             .func = func,
             .upvalues = upvalues,
         };
-        const closure_bytes = @sizeOf(Closure) + @as(usize, upvalue_count) * @sizeOf(Value);
-        self.bytes_allocated += closure_bytes;
-
-        self.profileAlloc(closure_bytes);
-        self.trackObject(&cls.header);
+        self.finishAlloc(&cls.header, @sizeOf(Closure) + @as(usize, upvalue_count) * @sizeOf(Value));
         return types.makePointer(@ptrCast(cls));
     }
 
@@ -327,10 +320,7 @@ pub const GC = struct {
             .name = name,
             .arity = arity,
         };
-        self.bytes_allocated += @sizeOf(NativeFn);
-
-        self.profileAlloc(@sizeOf(NativeFn));
-        self.trackObject(&nf.header);
+        self.finishAlloc(&nf.header, @sizeOf(NativeFn));
         return types.makePointer(@ptrCast(nf));
     }
 
@@ -347,9 +337,7 @@ pub const GC = struct {
             .arity = arity,
             .name = name,
         };
-        self.bytes_allocated += @sizeOf(types.NativeClosure) + upvalues.len * @sizeOf(Value);
-        self.profileAlloc(@sizeOf(types.NativeClosure));
-        self.trackObject(&nc.header);
+        self.finishAlloc(&nc.header, @sizeOf(types.NativeClosure) + upvalues.len * @sizeOf(Value));
         return types.makePointer(@ptrCast(nc));
     }
 
@@ -368,10 +356,7 @@ pub const GC = struct {
             .header = .{ .tag = .vector },
             .data = owned,
         };
-        self.bytes_allocated += @sizeOf(Vector) + data.len * @sizeOf(Value);
-
-        self.profileAlloc(@sizeOf(Vector) + data.len * @sizeOf(Value));
-        self.trackObject(&vec.header);
+        self.finishAlloc(&vec.header, @sizeOf(Vector) + data.len * @sizeOf(Value));
         return types.makePointer(@ptrCast(vec));
     }
 
@@ -385,10 +370,7 @@ pub const GC = struct {
             .header = .{ .tag = .vector },
             .data = data,
         };
-        self.bytes_allocated += @sizeOf(Vector) + size * @sizeOf(Value);
-
-        self.profileAlloc(@sizeOf(Vector) + size * @sizeOf(Value));
-        self.trackObject(&vec.header);
+        self.finishAlloc(&vec.header, @sizeOf(Vector) + size * @sizeOf(Value));
         return types.makePointer(@ptrCast(vec));
     }
 
@@ -400,10 +382,7 @@ pub const GC = struct {
             .message = message,
             .irritants = irritants,
         };
-        self.bytes_allocated += @sizeOf(types.ErrorObject);
-
-        self.profileAlloc(@sizeOf(types.ErrorObject));
-        self.trackObject(&err.header);
+        self.finishAlloc(&err.header, @sizeOf(types.ErrorObject));
         return types.makePointer(@ptrCast(err));
     }
 
@@ -424,10 +403,7 @@ pub const GC = struct {
             .templates = owned_tmps,
             .num_rules = num_rules,
         };
-        self.bytes_allocated += @sizeOf(Transformer) + (literals.len + patterns.len + templates.len) * @sizeOf(Value);
-
-        self.profileAlloc(@sizeOf(Transformer) + (literals.len + patterns.len + templates.len) * @sizeOf(Value));
-        self.trackObject(&tx.header);
+        self.finishAlloc(&tx.header, @sizeOf(Transformer) + (literals.len + patterns.len + templates.len) * @sizeOf(Value));
         return types.makePointer(@ptrCast(tx));
     }
 
@@ -441,10 +417,7 @@ pub const GC = struct {
             .name = owned_name,
             .num_fields = num_fields,
         };
-        self.bytes_allocated += @sizeOf(RecordType) + name.len;
-
-        self.profileAlloc(@sizeOf(RecordType) + name.len);
-        self.trackObject(&rt.header);
+        self.finishAlloc(&rt.header, @sizeOf(RecordType) + name.len);
         return types.makePointer(@ptrCast(rt));
     }
 
@@ -465,10 +438,7 @@ pub const GC = struct {
             .record_type = record_type,
             .fields = fields,
         };
-        self.bytes_allocated += @sizeOf(RecordInstance) + record_type.num_fields * @sizeOf(Value);
-
-        self.profileAlloc(@sizeOf(RecordInstance) + record_type.num_fields * @sizeOf(Value));
-        self.trackObject(&ri.header);
+        self.finishAlloc(&ri.header, @sizeOf(RecordInstance) + record_type.num_fields * @sizeOf(Value));
         return types.makePointer(@ptrCast(ri));
     }
 
@@ -491,10 +461,7 @@ pub const GC = struct {
             .string_out_len = 0,
             .string_out_cap = 0,
         };
-        self.bytes_allocated += @sizeOf(Port);
-
-        self.profileAlloc(@sizeOf(Port));
-        self.trackObject(&port.header);
+        self.finishAlloc(&port.header, @sizeOf(Port));
         return types.makePointer(@ptrCast(port));
     }
 
@@ -516,10 +483,7 @@ pub const GC = struct {
             .string_data = owned,
             .string_pos = 0,
         };
-        self.bytes_allocated += @sizeOf(Port) + data.len;
-
-        self.profileAlloc(@sizeOf(Port) + data.len);
-        self.trackObject(&port.header);
+        self.finishAlloc(&port.header, @sizeOf(Port) + data.len);
         return types.makePointer(@ptrCast(port));
     }
 
@@ -543,10 +507,7 @@ pub const GC = struct {
             .string_out_len = 0,
             .string_out_cap = initial_cap,
         };
-        self.bytes_allocated += @sizeOf(Port) + initial_cap;
-
-        self.profileAlloc(@sizeOf(Port) + initial_cap);
-        self.trackObject(&port.header);
+        self.finishAlloc(&port.header, @sizeOf(Port) + initial_cap);
         return types.makePointer(@ptrCast(port));
     }
 
@@ -559,10 +520,7 @@ pub const GC = struct {
             .header = .{ .tag = .bytevector },
             .data = owned,
         };
-        self.bytes_allocated += @sizeOf(Bytevector) + data.len;
-
-        self.profileAlloc(@sizeOf(Bytevector) + data.len);
-        self.trackObject(&bv.header);
+        self.finishAlloc(&bv.header, @sizeOf(Bytevector) + data.len);
         return types.makePointer(@ptrCast(bv));
     }
 
@@ -576,10 +534,7 @@ pub const GC = struct {
             .header = .{ .tag = .bytevector },
             .data = data,
         };
-        self.bytes_allocated += @sizeOf(Bytevector) + size;
-
-        self.profileAlloc(@sizeOf(Bytevector) + size);
-        self.trackObject(&bv.header);
+        self.finishAlloc(&bv.header, @sizeOf(Bytevector) + size);
         return types.makePointer(@ptrCast(bv));
     }
 
@@ -591,10 +546,7 @@ pub const GC = struct {
             .forced = forced,
             .value = value,
         };
-        self.bytes_allocated += @sizeOf(Promise);
-
-        self.profileAlloc(@sizeOf(Promise));
-        self.trackObject(&p.header);
+        self.finishAlloc(&p.header, @sizeOf(Promise));
         return types.makePointer(@ptrCast(p));
     }
 
@@ -663,12 +615,11 @@ pub const GC = struct {
             .dst_base = dst_base,
             .backing = backing,
         };
-        self.bytes_allocated += @sizeOf(Continuation) +
+        self.finishAlloc(&cont.header, @sizeOf(Continuation) +
             registers.len * @sizeOf(Value) +
             frames.len * @sizeOf(SavedFrame) +
             handlers.len * @sizeOf(SavedHandler) +
-            wind_records.len * @sizeOf(WindRecord);
-        self.trackObject(&cont.header);
+            wind_records.len * @sizeOf(WindRecord));
         return types.makePointer(@ptrCast(cont));
     }
 
@@ -704,10 +655,7 @@ pub const GC = struct {
             .target_wind_count = target_wind_count,
             .target_handler_count = target_handler_count,
         };
-        self.bytes_allocated += @sizeOf(Continuation);
-
-        self.profileAlloc(@sizeOf(Continuation));
-        self.trackObject(&cont.header);
+        self.finishAlloc(&cont.header, @sizeOf(Continuation));
         return types.makePointer(@ptrCast(cont));
     }
 
@@ -725,10 +673,7 @@ pub const GC = struct {
             .exact_real = exact_real,
             .exact_imag = exact_imag,
         };
-        self.bytes_allocated += @sizeOf(types.Complex);
-
-        self.profileAlloc(@sizeOf(types.Complex));
-        self.trackObject(&c.header);
+        self.finishAlloc(&c.header, @sizeOf(types.Complex));
         return types.makePointer(@ptrCast(c));
     }
 
@@ -740,10 +685,7 @@ pub const GC = struct {
             .value = init_value,
             .converter = converter,
         };
-        self.bytes_allocated += @sizeOf(types.ParameterObject);
-
-        self.profileAlloc(@sizeOf(types.ParameterObject));
-        self.trackObject(&p.header);
+        self.finishAlloc(&p.header, @sizeOf(types.ParameterObject));
         return types.makePointer(@ptrCast(p));
     }
 
@@ -757,10 +699,7 @@ pub const GC = struct {
             .handle = handle,
             .name = owned_name,
         };
-        self.bytes_allocated += @sizeOf(FfiLibrary) + name.len;
-
-        self.profileAlloc(@sizeOf(FfiLibrary) + name.len);
-        self.trackObject(&lib.header);
+        self.finishAlloc(&lib.header, @sizeOf(FfiLibrary) + name.len);
         return types.makePointer(@ptrCast(lib));
     }
 
@@ -780,10 +719,7 @@ pub const GC = struct {
             .return_type = return_type,
             .param_count = @intCast(param_types.len),
         };
-        self.bytes_allocated += @sizeOf(FfiFunction) + name.len + param_types.len * @sizeOf(FfiType);
-
-        self.profileAlloc(@sizeOf(FfiFunction) + name.len + param_types.len * @sizeOf(FfiType));
-        self.trackObject(&ffi_fn.header);
+        self.finishAlloc(&ffi_fn.header, @sizeOf(FfiFunction) + name.len + param_types.len * @sizeOf(FfiType));
         return types.makePointer(@ptrCast(ffi_fn));
     }
 
@@ -797,10 +733,7 @@ pub const GC = struct {
             .fn_ptr = fn_ptr,
             .active = true,
         };
-        self.bytes_allocated += @sizeOf(FfiCallback);
-
-        self.profileAlloc(@sizeOf(FfiCallback));
-        self.trackObject(&cb.header);
+        self.finishAlloc(&cb.header, @sizeOf(FfiCallback));
         return types.makePointer(@ptrCast(cb));
     }
 
@@ -811,20 +744,16 @@ pub const GC = struct {
             .header = .{ .tag = .random_source },
             .prng = std.Random.DefaultPrng.init(seed),
         };
-        self.bytes_allocated += @sizeOf(RandomSource);
-
-        self.profileAlloc(@sizeOf(RandomSource));
-        self.trackObject(&rs.header);
+        self.finishAlloc(&rs.header, @sizeOf(RandomSource));
         return types.makePointer(@ptrCast(rs));
     }
 
     pub fn allocFiber(self: *GC, thunk: Value, id: u32) !*@import("fiber.zig").Fiber {
         try self.maybeCollect();
         const fiber_mod = @import("fiber.zig");
-        const vm_m = @import("vm.zig");
-        const registers = try self.allocator.alloc(Value, vm_m.INITIAL_REGISTER_CAPACITY);
+        const registers = try self.allocator.alloc(Value, types.INITIAL_REGISTER_CAPACITY);
         errdefer self.allocator.free(registers);
-        const frames = try self.allocator.alloc(vm_m.CallFrame, vm_m.INITIAL_FRAME_CAPACITY);
+        const frames = try self.allocator.alloc(types.CallFrame, types.INITIAL_FRAME_CAPACITY);
         errdefer self.allocator.free(frames);
         const fiber = try self.allocator.create(fiber_mod.Fiber);
         fiber.* = .{
@@ -852,13 +781,9 @@ pub const GC = struct {
             .param_overrides = std.AutoHashMap(usize, Value).init(self.allocator),
         };
         @memset(fiber.registers, types.UNDEFINED);
-        const total_size = @sizeOf(fiber_mod.Fiber) +
+        self.finishAlloc(&fiber.header, @sizeOf(fiber_mod.Fiber) +
             registers.len * @sizeOf(Value) +
-            frames.len * @sizeOf(vm_m.CallFrame);
-        self.bytes_allocated += total_size;
-
-        self.profileAlloc(total_size);
-        self.trackObject(&fiber.header);
+            frames.len * @sizeOf(types.CallFrame));
         return fiber;
     }
 
@@ -870,10 +795,7 @@ pub const GC = struct {
             .head = types.NIL,
             .tail = types.NIL,
         };
-        self.bytes_allocated += @sizeOf(types.Channel);
-
-        self.profileAlloc(@sizeOf(types.Channel));
-        self.trackObject(&ch.header);
+        self.finishAlloc(&ch.header, @sizeOf(types.Channel));
         return types.makePointer(@ptrCast(ch));
     }
 
@@ -888,10 +810,7 @@ pub const GC = struct {
             .abandoned = false,
             .specific = types.VOID,
         };
-        self.bytes_allocated += @sizeOf(types.Mutex);
-
-        self.profileAlloc(@sizeOf(types.Mutex));
-        self.trackObject(&m.header);
+        self.finishAlloc(&m.header, @sizeOf(types.Mutex));
         return types.makePointer(@ptrCast(m));
     }
 
@@ -903,10 +822,7 @@ pub const GC = struct {
             .name = name,
             .specific = types.VOID,
         };
-        self.bytes_allocated += @sizeOf(types.ConditionVariable);
-
-        self.profileAlloc(@sizeOf(types.ConditionVariable));
-        self.trackObject(&cv.header);
+        self.finishAlloc(&cv.header, @sizeOf(types.ConditionVariable));
         return types.makePointer(@ptrCast(cv));
     }
 
@@ -917,10 +833,7 @@ pub const GC = struct {
             .header = .{ .tag = .srfi18_time },
             .seconds = seconds,
         };
-        self.bytes_allocated += @sizeOf(types.Srfi18Time);
-
-        self.profileAlloc(@sizeOf(types.Srfi18Time));
-        self.trackObject(&t.header);
+        self.finishAlloc(&t.header, @sizeOf(types.Srfi18Time));
         return types.makePointer(@ptrCast(t));
     }
 
@@ -943,10 +856,7 @@ pub const GC = struct {
             .count = 0,
             .capacity = cap,
         };
-        self.bytes_allocated += @sizeOf(HashTable) + cap * @sizeOf(HashEntry);
-
-        self.profileAlloc(@sizeOf(HashTable) + initial_capacity * @sizeOf(HashEntry));
-        self.trackObject(&ht.header);
+        self.finishAlloc(&ht.header, @sizeOf(HashTable) + cap * @sizeOf(HashEntry));
         return types.makePointer(@ptrCast(ht));
     }
 
@@ -963,10 +873,7 @@ pub const GC = struct {
             .len = if (mag == 0) 0 else 1,
             .positive = n >= 0,
         };
-        self.bytes_allocated += @sizeOf(Bignum) + @sizeOf(u64);
-
-        self.profileAlloc(@sizeOf(Bignum) + @sizeOf(u64));
-        self.trackObject(&bn.header);
+        self.finishAlloc(&bn.header, @sizeOf(Bignum) + @sizeOf(u64));
         return types.makePointer(@ptrCast(bn));
     }
 
@@ -982,10 +889,7 @@ pub const GC = struct {
             .len = len,
             .positive = positive,
         };
-        self.bytes_allocated += @sizeOf(Bignum) + limbs.len * @sizeOf(u64);
-
-        self.profileAlloc(@sizeOf(Bignum) + limbs.len * @sizeOf(u64));
-        self.trackObject(&bn.header);
+        self.finishAlloc(&bn.header, @sizeOf(Bignum) + limbs.len * @sizeOf(u64));
         return types.makePointer(@ptrCast(bn));
     }
 
@@ -997,10 +901,7 @@ pub const GC = struct {
             .numerator = num,
             .denominator = den,
         };
-        self.bytes_allocated += @sizeOf(Rational);
-
-        self.profileAlloc(@sizeOf(Rational));
-        self.trackObject(&rat.header);
+        self.finishAlloc(&rat.header, @sizeOf(Rational));
         return types.makePointer(@ptrCast(rat));
     }
 
@@ -1039,10 +940,7 @@ pub const GC = struct {
             .gid = info.gid,
             .file_type = info.file_type,
         };
-        self.bytes_allocated += @sizeOf(types.FileInfo);
-
-        self.profileAlloc(@sizeOf(types.FileInfo));
-        self.trackObject(&fi.header);
+        self.finishAlloc(&fi.header, @sizeOf(types.FileInfo));
         return types.makePointer(@ptrCast(fi));
     }
 
@@ -1066,10 +964,7 @@ pub const GC = struct {
             .shell = shell_copy,
             .full_name = gecos_copy,
         };
-        self.bytes_allocated += @sizeOf(types.UserInfo) + name.len + home_dir.len + shell.len + full_name.len;
-
-        self.profileAlloc(@sizeOf(types.UserInfo) + name.len + home_dir.len + shell.len + full_name.len);
-        self.trackObject(&ui.header);
+        self.finishAlloc(&ui.header, @sizeOf(types.UserInfo) + name.len + home_dir.len + shell.len + full_name.len);
         return types.makePointer(@ptrCast(ui));
     }
 
@@ -1083,10 +978,7 @@ pub const GC = struct {
             .name = name_copy,
             .gid = gid,
         };
-        self.bytes_allocated += @sizeOf(types.GroupInfo) + name.len;
-
-        self.profileAlloc(@sizeOf(types.GroupInfo) + name.len);
-        self.trackObject(&gi.header);
+        self.finishAlloc(&gi.header, @sizeOf(types.GroupInfo) + name.len);
         return types.makePointer(@ptrCast(gi));
     }
 
@@ -1098,10 +990,7 @@ pub const GC = struct {
             .env = env_map,
             .owned = owned,
         };
-        self.bytes_allocated += @sizeOf(types.SchemeEnvironment);
-
-        self.profileAlloc(@sizeOf(types.SchemeEnvironment));
-        self.trackObject(&se.header);
+        self.finishAlloc(&se.header, @sizeOf(types.SchemeEnvironment));
         return types.makePointer(@ptrCast(se));
     }
 
@@ -1113,10 +1002,7 @@ pub const GC = struct {
             .dir = dir,
             .include_dotfiles = include_dotfiles,
         };
-        self.bytes_allocated += @sizeOf(types.DirectoryObject);
-
-        self.profileAlloc(@sizeOf(types.DirectoryObject));
-        self.trackObject(&d.header);
+        self.finishAlloc(&d.header, @sizeOf(types.DirectoryObject));
         return types.makePointer(@ptrCast(d));
     }
 
@@ -1128,10 +1014,7 @@ pub const GC = struct {
             .header = .{ .tag = .multiple_values },
             .values = owned,
         };
-        self.bytes_allocated += @sizeOf(MultipleValues) + values.len * @sizeOf(Value);
-
-        self.profileAlloc(@sizeOf(MultipleValues) + values.len * @sizeOf(Value));
-        self.trackObject(&mv.header);
+        self.finishAlloc(&mv.header, @sizeOf(MultipleValues) + values.len * @sizeOf(Value));
         return types.makePointer(@ptrCast(mv));
     }
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+const build_options = @import("build_options");
 
 /// A Scheme value packed into a 64-bit word (NaN-boxing).
 ///
@@ -480,6 +481,39 @@ pub const SavedHandler = struct {
 pub const WindRecord = struct {
     before: Value,
     after: Value,
+};
+
+// --- Live execution frame types (used by VM, fiber, and GC) ---
+
+pub const INITIAL_FRAME_CAPACITY: usize = build_options.max_frames;
+pub const INITIAL_REGISTER_CAPACITY: usize = build_options.max_registers;
+pub const MAX_FRAME_LIMIT: usize = 32768;
+pub const MAX_REGISTER_LIMIT: usize = 65536;
+pub const MAX_HANDLERS = 64;
+pub const MAX_WINDS = 64;
+
+pub const ExceptionHandler = struct {
+    handler: Value,
+    frame_count: usize,
+};
+
+pub const CallFrame = struct {
+    closure: ?*Closure,
+    native: ?*NativeFn = null,
+    code: []const u8,
+    ip: usize,
+    base: u32,
+    dst: u16,
+    saved_wind_count: u16 = 0,
+    returns_to_native: bool = false,
+    seq: u64 = 0,
+
+    pub fn frameWindow(self: CallFrame) usize {
+        return if (self.closure) |cls| blk: {
+            const lc = cls.func.locals_count;
+            break :blk if (lc == 0) 256 else @as(usize, lc);
+        } else 256;
+    }
 };
 
 /// A captured continuation (R7RS call/cc).

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -30,13 +30,12 @@ pub const VMError = error{
     Terminated,
 };
 
-const build_options = @import("build_options");
-pub const INITIAL_FRAME_CAPACITY: usize = build_options.max_frames;
-pub const INITIAL_REGISTER_CAPACITY: usize = build_options.max_registers;
-pub const MAX_FRAME_LIMIT: usize = 32768;
-pub const MAX_REGISTER_LIMIT: usize = 65536;
-pub const MAX_HANDLERS = 64;
-pub const MAX_WINDS = 64;
+pub const INITIAL_FRAME_CAPACITY = types.INITIAL_FRAME_CAPACITY;
+pub const INITIAL_REGISTER_CAPACITY = types.INITIAL_REGISTER_CAPACITY;
+pub const MAX_FRAME_LIMIT = types.MAX_FRAME_LIMIT;
+pub const MAX_REGISTER_LIMIT = types.MAX_REGISTER_LIMIT;
+pub const MAX_HANDLERS = types.MAX_HANDLERS;
+pub const MAX_WINDS = types.MAX_WINDS;
 
 pub threadlocal var vm_instance: ?*VM = null;
 
@@ -140,10 +139,7 @@ fn markVMRoots(gc: *memory.GC) void {
     }
 }
 
-pub const ExceptionHandler = struct {
-    handler: Value, // the handler procedure
-    frame_count: usize, // saved call stack depth for unwinding
-};
+pub const ExceptionHandler = types.ExceptionHandler;
 
 fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;
@@ -162,38 +158,7 @@ pub fn writeStderr(bytes: []const u8) void {
     writeToFd(2, bytes);
 }
 
-pub const CallFrame = struct {
-    closure: ?*types.Closure,
-    native: ?*types.NativeFn = null,
-    code: []const u8,
-    ip: usize,
-    base: u32,
-    dst: u16,
-    saved_wind_count: u16 = 0,
-    // True for frames pushed by callWithArgs: the frame's result is consumed
-    // by the re-entrant native Zig caller (map, for-each, sort, apply, ...)
-    // via runUntil's return value, and dst is a placeholder. If such a frame
-    // returns inside an OUTER dispatch loop, that native caller has already
-    // returned (a continuation captured under it was resumed after the native
-    // call ended) — there is no register to deliver into and the native's
-    // iteration state is gone, so the dispatch loop raises an error instead
-    // of silently corrupting the caller's registers. Preserved across tail
-    // calls and continuation capture/restore, like seq.
-    returns_to_native: bool = false,
-    // Birth id, unique per pushed frame (VM.nextFrameSeq). Tail calls reuse
-    // the frame and keep its seq; continuation capture/restore preserves it.
-    // Dispatch loops use it to tell whether a restored frame stack still
-    // contains the loop's own scope-root frame (resume here) or jumps to a
-    // different program point (propagate ContinuationInvoked outward).
-    seq: u64 = 0,
-
-    pub fn frameWindow(self: CallFrame) usize {
-        return if (self.closure) |cls| blk: {
-            const lc = cls.func.locals_count;
-            break :blk if (lc == 0) 256 else @as(usize, lc);
-        } else 256;
-    }
-};
+pub const CallFrame = types.CallFrame;
 
 pub const StepMode = enum { none, step, next, step_out, continue_to_break };
 


### PR DESCRIPTION
## Summary

- Move `CallFrame`, `ExceptionHandler`, and 6 capacity constants from `vm.zig` to `types.zig`, breaking the `memory.zig → fiber.zig → vm.zig → memory.zig` circular dependency. `vm.zig` re-exports for backward compatibility.
- Add `GC.finishAlloc()` inline helper that consolidates the `bytes_allocated += size; profileAlloc(size); trackObject(...)` bookkeeping repeated in every allocator (~70 lines saved, stats guaranteed in sync).
- Fix three `profileAlloc` size mismatches: `allocNativeClosure` (missing upvalues size), `allocContinuation` (missing call entirely), `allocHashTable` (used `initial_capacity` instead of rounded `cap`).
- Delete unused `primitives_hashtable.zig` import from `memory.zig`.
- Include `frameWindow` method from #1112 in the moved `CallFrame` definition.

Supersedes #1113. Closes #1050

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] R7RS suite — 1395/1395 pass
- [x] `bash tests/scheme/run-all.sh` — 1702/1702 pass, 0 fail
- [x] `grep -rn '@import("vm.zig")' src/memory.zig src/gc_collect.zig` — no vm.zig imports remain in memory layer (only test helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)