### PR TITLE
Add compileDesugared() helper centralizing sexpr rooting discipline (#1044)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -461,6 +461,13 @@ pub const Compiler = struct {
         self.populateDebugLocals();
     }
 
+    pub fn compileDesugared(self: *Compiler, form: Value, dst: u16, is_tail: bool) CompileError!void {
+        var rooted = form;
+        try self.gc.pushRoot(&rooted);
+        defer self.gc.popRoot();
+        return self.compileExpr(rooted, dst, is_tail);
+    }
+
     pub fn compileExpr(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
         if (types.isFixnum(expr)) {
             const idx = try self.addConstant(expr);

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -47,7 +47,7 @@ pub fn compileGuard(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compi
     // below is a fresh unrooted pair. The scoped defer restores the counter
     // on every path; leaking an increment would disable collection for the
     // rest of the process.
-    var form: Value = blk: {
+    const form: Value = blk: {
         gc.no_collect += 1;
         defer gc.no_collect -= 1;
 
@@ -85,9 +85,7 @@ pub fn compileGuard(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compi
         break :blk gc.allocPair(ec_sym, gc.allocPair(outer, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
     };
 
-    try gc.pushRoot(&form);
-    defer gc.popRoot();
-    return self.compileExpr(form, dst, is_tail);
+    return self.compileDesugared(form, dst, is_tail);
 }
 
 /// Append an element to the end of a proper list, returning a new list.
@@ -748,7 +746,7 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
     // below is a fresh unrooted pair. The scoped defer restores the counter
     // on every path; leaking an increment would disable collection for the
     // rest of the process.
-    var outer_let: Value = blk: {
+    const outer_let: Value = blk: {
         gc.no_collect += 1;
         defer gc.no_collect -= 1;
 
@@ -813,9 +811,7 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
         break :blk gc.allocPair(letstar_sym, gc.allocPair(let_bindings, outer_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
     };
 
-    try gc.pushRoot(&outer_let);
-    defer gc.popRoot();
-    return self.compileExpr(outer_let, dst, is_tail);
+    return self.compileDesugared(outer_let, dst, is_tail);
 }
 
 /// Compile (case-lambda (formals body ...) ...)
@@ -836,7 +832,7 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
     // below is a fresh unrooted pair. The scoped defer restores the counter
     // on every path (including the InvalidSyntax returns); leaking an
     // increment would disable collection for the rest of the process.
-    var outer_lambda: Value = blk: {
+    const outer_lambda: Value = blk: {
         gc.no_collect += 1;
         defer gc.no_collect -= 1;
 
@@ -922,7 +918,5 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
         break :blk try gc.allocPair(lambda_sym, try gc.allocPair(args_sym, try gc.allocPair(let_form, types.NIL)));
     };
 
-    try gc.pushRoot(&outer_lambda);
-    defer gc.popRoot();
-    return self.compileExpr(outer_lambda, dst, false);
+    return self.compileDesugared(outer_lambda, dst, false);
 }

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -309,9 +309,7 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
         }
         call_expr = self.gc.allocPair(unique_sym, call_expr) catch return CompileError.OutOfMemory;
     }
-    self.gc.pushRoot(&call_expr) catch return CompileError.OutOfMemory;
-    defer self.gc.popRoot();
-    try self.compileExpr(call_expr, dst, is_tail);
+    try self.compileDesugared(call_expr, dst, is_tail);
 
     self.endScope();
 }
@@ -615,7 +613,7 @@ pub fn compileLetValues(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
 
     // Build the nested apply chain under no_collect: `inner` is a growing
     // tree of fresh unrooted pairs and every iteration allocates (issue #1010).
-    var desugared: Value = blk: {
+    const desugared: Value = blk: {
         gc.no_collect += 1;
         defer gc.no_collect -= 1;
 
@@ -635,9 +633,7 @@ pub fn compileLetValues(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         break :blk inner;
     };
 
-    try gc.pushRoot(&desugared);
-    defer gc.popRoot();
-    try self.compileExpr(desugared, dst, is_tail);
+    try self.compileDesugared(desugared, dst, is_tail);
     self.endScope();
 }
 
@@ -649,13 +645,11 @@ pub fn compileLetStarValues(self: *Compiler, args: Value, dst: u16, is_tail: boo
     const body = types.cdr(args);
     if (body == types.NIL) return CompileError.InvalidSyntax;
 
-    var desugared = buildLetValues(self, bindings, body) catch |err| return switch (err) {
+    const desugared = buildLetValues(self, bindings, body) catch |err| return switch (err) {
         error.InvalidSyntax => CompileError.InvalidSyntax,
         else => CompileError.OutOfMemory,
     };
-    try self.gc.pushRoot(&desugared);
-    defer self.gc.popRoot();
-    return self.compileExpr(desugared, dst, is_tail);
+    return self.compileDesugared(desugared, dst, is_tail);
 }
 
 /// Build nested call-with-values for a list of bindings.


### PR DESCRIPTION
## Summary
- Adds `compileDesugared(self, form, dst, is_tail)` on `Compiler` that owns the `pushRoot`/`compileExpr`/`popRoot` choreography for freshly-built desugared S-expressions
- Replaces 6 call sites across `compiler_advanced.zig` (guard, parameterize, case-lambda) and `compiler_bindings.zig` (let-values, let*-values, named-let)
- Bonus: 5 `var` → `const` cleanups where the variable was only mutable for the now-removed `pushRoot(&x)` call

Closes #1044

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail (307 Scheme files + 1395 R7RS)
- [x] `zig build test -Dgc-threshold=1` — same failure count as unmodified code (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)