### PR TITLE
Extract ir.lowerAndOptimize() to deduplicate the IR pipeline

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -393,19 +393,7 @@ pub const Compiler = struct {
         ir.compiler = self;
         ir.set_targets = self.set_targets;
         defer ir.deinit();
-        var root = try ir_mod.lowerWithMacros(&ir, expr_root, &self.macros);
-
-        // Analysis passes
-        ir_mod.markTailPositions(root, false);
-        ir_mod.identifyPrimitives(root);
-        ir_mod.markConstants(root);
-
-        // Optimization passes
-        root = ir_mod.foldConstants(&ir, root);
-        root = ir_mod.eliminateDeadBranches(&ir, root);
-        root = ir_mod.simplifyBooleans(&ir, root);
-        root = ir_mod.eliminateIdentity(&ir, root);
-        root = ir_mod.simplifyBegin(&ir, root);
+        const root = try ir_mod.lowerAndOptimize(&ir, expr_root, &self.macros, false);
 
         const dst = try self.allocReg();
         try compiler_ir.compileFromNode(self, root, dst, false);
@@ -439,15 +427,7 @@ pub const Compiler = struct {
             ir.compiler = self;
             ir.set_targets = self.set_targets;
             defer ir.deinit();
-            var root = try ir_mod.lowerWithMacros(&ir, expr, &self.macros);
-            ir_mod.markTailPositions(root, false);
-            ir_mod.identifyPrimitives(root);
-            ir_mod.markConstants(root);
-            root = ir_mod.foldConstants(&ir, root);
-            root = ir_mod.eliminateDeadBranches(&ir, root);
-            root = ir_mod.simplifyBooleans(&ir, root);
-            root = ir_mod.eliminateIdentity(&ir, root);
-            root = ir_mod.simplifyBegin(&ir, root);
+            const root = try ir_mod.lowerAndOptimize(&ir, expr, &self.macros, false);
 
             dst = try self.allocReg();
             try compiler_ir.compileFromNode(self, root, dst, false);

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -409,14 +409,7 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
             ir.compiler = &child;
             ir.set_targets = child.set_targets;
             defer ir.deinit();
-            var root = try ir_mod.lowerWithMacros(&ir, def_inits[i], &child.macros);
-            ir_mod.identifyPrimitives(root);
-            ir_mod.markConstants(root);
-            root = ir_mod.foldConstants(&ir, root);
-            root = ir_mod.eliminateDeadBranches(&ir, root);
-            root = ir_mod.simplifyBooleans(&ir, root);
-            root = ir_mod.eliminateIdentity(&ir, root);
-            root = ir_mod.simplifyBegin(&ir, root);
+            const root = try ir_mod.lowerAndOptimize(&ir, def_inits[i], &child.macros, false);
 
             try compileFromNode(&child, root, last_dst, false);
 
@@ -453,15 +446,7 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                 ir.compiler = &child;
                 ir.set_targets = child.set_targets;
                 defer ir.deinit();
-                var root = try ir_mod.lowerWithMacros(&ir, expr, &child.macros);
-                ir_mod.markTailPositions(root, rest == types.NIL);
-                ir_mod.identifyPrimitives(root);
-                ir_mod.markConstants(root);
-                root = ir_mod.foldConstants(&ir, root);
-                root = ir_mod.eliminateDeadBranches(&ir, root);
-                root = ir_mod.simplifyBooleans(&ir, root);
-                root = ir_mod.eliminateIdentity(&ir, root);
-                root = ir_mod.simplifyBegin(&ir, root);
+                const root = try ir_mod.lowerAndOptimize(&ir, expr, &child.macros, rest == types.NIL);
 
                 if (rest == types.NIL) {
                     try compileFromNode(&child, root, last_dst, true);
@@ -490,15 +475,7 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
             ir.compiler = &child;
             ir.set_targets = child.set_targets;
             defer ir.deinit();
-            var root = try ir_mod.lowerWithMacros(&ir, expr, &child.macros);
-            ir_mod.markTailPositions(root, rest == types.NIL);
-            ir_mod.identifyPrimitives(root);
-            ir_mod.markConstants(root);
-            root = ir_mod.foldConstants(&ir, root);
-            root = ir_mod.eliminateDeadBranches(&ir, root);
-            root = ir_mod.simplifyBooleans(&ir, root);
-            root = ir_mod.eliminateIdentity(&ir, root);
-            root = ir_mod.simplifyBegin(&ir, root);
+            const root = try ir_mod.lowerAndOptimize(&ir, expr, &child.macros, rest == types.NIL);
 
             if (rest == types.NIL) {
                 try compileFromNode(&child, root, last_dst, true);
@@ -528,14 +505,7 @@ fn compileDefineFromIR(self: *Compiler, data: ir_mod.DefineData, dst: u16) Compi
     ir.compiler = self;
     ir.set_targets = self.set_targets;
     defer ir.deinit();
-    var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
-    ir_mod.identifyPrimitives(val_root);
-    ir_mod.markConstants(val_root);
-    val_root = ir_mod.foldConstants(&ir, val_root);
-    val_root = ir_mod.eliminateDeadBranches(&ir, val_root);
-    val_root = ir_mod.simplifyBooleans(&ir, val_root);
-    val_root = ir_mod.eliminateIdentity(&ir, val_root);
-    val_root = ir_mod.simplifyBegin(&ir, val_root);
+    const val_root = try ir_mod.lowerAndOptimize(&ir, data.value, &self.macros, false);
 
     if (val_root.tag == .lambda) {
         val_root.data.lambda.name = types.symbolName(data.name);
@@ -584,14 +554,7 @@ fn compileSetFromIR(self: *Compiler, data: ir_mod.SetData, dst: u16) CompileErro
     ir.compiler = self;
     ir.set_targets = self.set_targets;
     defer ir.deinit();
-    var val_root = try ir_mod.lowerWithMacros(&ir, data.value, &self.macros);
-    ir_mod.identifyPrimitives(val_root);
-    ir_mod.markConstants(val_root);
-    val_root = ir_mod.foldConstants(&ir, val_root);
-    val_root = ir_mod.eliminateDeadBranches(&ir, val_root);
-    val_root = ir_mod.simplifyBooleans(&ir, val_root);
-    val_root = ir_mod.eliminateIdentity(&ir, val_root);
-    val_root = ir_mod.simplifyBegin(&ir, val_root);
+    const val_root = try ir_mod.lowerAndOptimize(&ir, data.value, &self.macros, false);
     try compileFromNode(self, val_root, dst, false);
 
     if (self.resolveLocal(name)) |slot| {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -485,22 +485,31 @@ pub fn lower(irn: *IR, expr: Value) CompileError!*Node {
     return lowerWithMacros(irn, expr, null);
 }
 
+pub fn lowerAndOptimize(
+    ir_instance: *IR,
+    expr: Value,
+    macros: ?*std.StringHashMap(Value),
+    is_tail: bool,
+) CompileError!*Node {
+    var node = try lowerWithMacros(ir_instance, expr, macros);
+    markTailPositions(node, is_tail);
+    identifyPrimitives(node);
+    markConstants(node);
+    node = foldConstants(ir_instance, node);
+    node = eliminateDeadBranches(ir_instance, node);
+    node = simplifyBooleans(ir_instance, node);
+    node = eliminateIdentity(ir_instance, node);
+    node = simplifyBegin(ir_instance, node);
+    return node;
+}
+
 pub fn lowerSingleExpr(allocator: std.mem.Allocator, expr: Value) CompileError!*Node {
     return lowerSingleExprTail(allocator, expr, false);
 }
 
 pub fn lowerSingleExprTail(allocator: std.mem.Allocator, expr: Value, is_tail: bool) CompileError!*Node {
     var scratch = IR.init(allocator);
-    const node = try lowerWithMacros(&scratch, expr, null);
-    identifyPrimitives(node);
-    markConstants(node);
-    if (is_tail) markTailPositions(node, true);
-    var opt = foldConstants(&scratch, node);
-    opt = eliminateDeadBranches(&scratch, opt);
-    opt = simplifyBooleans(&scratch, opt);
-    opt = eliminateIdentity(&scratch, opt);
-    opt = simplifyBegin(&scratch, opt);
-    return opt;
+    return lowerAndOptimize(&scratch, expr, null, is_tail);
 }
 
 fn lowerIf(ir: *IR, args: Value, macros: ?*std.StringHashMap(Value)) CompileError!*Node {

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -61,15 +61,7 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         if (body_count >= 64) return null;
         const expr = types.car(body_expr);
-        const node = ir.lowerWithMacros(&body_ir, expr, null) catch return null;
-        ir.markTailPositions(node, types.cdr(body_expr) == types.NIL);
-        ir.identifyPrimitives(node);
-        ir.markConstants(node);
-        var opt = ir.foldConstants(&body_ir, node);
-        opt = ir.eliminateDeadBranches(&body_ir, opt);
-        opt = ir.simplifyBooleans(&body_ir, opt);
-        opt = ir.eliminateIdentity(&body_ir, opt);
-        opt = ir.simplifyBegin(&body_ir, opt);
+        const opt = ir.lowerAndOptimize(&body_ir, expr, null, types.cdr(body_expr) == types.NIL) catch return null;
         body_nodes[body_count] = opt;
         body_count += 1;
         body_expr = types.cdr(body_expr);
@@ -138,15 +130,7 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         if (body_count >= 64) return null;
         const expr = types.car(body_expr);
-        const node = ir.lowerWithMacros(&body_ir, expr, null) catch return null;
-        ir.markTailPositions(node, types.cdr(body_expr) == types.NIL);
-        ir.identifyPrimitives(node);
-        ir.markConstants(node);
-        var opt = ir.foldConstants(&body_ir, node);
-        opt = ir.eliminateDeadBranches(&body_ir, opt);
-        opt = ir.simplifyBooleans(&body_ir, opt);
-        opt = ir.eliminateIdentity(&body_ir, opt);
-        opt = ir.simplifyBegin(&body_ir, opt);
+        const opt = ir.lowerAndOptimize(&body_ir, expr, null, types.cdr(body_expr) == types.NIL) catch return null;
         body_nodes[body_count] = opt;
         body_count += 1;
         body_expr = types.cdr(body_expr);
@@ -340,15 +324,7 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         if (body_count >= 64) return null;
         const expr = types.car(body_expr);
-        const node = ir.lowerWithMacros(&body_ir, expr, null) catch return null;
-        ir.markTailPositions(node, types.cdr(body_expr) == types.NIL);
-        ir.identifyPrimitives(node);
-        ir.markConstants(node);
-        var opt = ir.foldConstants(&body_ir, node);
-        opt = ir.eliminateDeadBranches(&body_ir, opt);
-        opt = ir.simplifyBooleans(&body_ir, opt);
-        opt = ir.eliminateIdentity(&body_ir, opt);
-        opt = ir.simplifyBegin(&body_ir, opt);
+        const opt = ir.lowerAndOptimize(&body_ir, expr, null, types.cdr(body_expr) == types.NIL) catch return null;
         body_nodes[body_count] = opt;
         body_count += 1;
         body_expr = types.cdr(body_expr);

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -94,21 +94,12 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
             }
         }
 
-        var root = ir_mod.lowerWithMacros(&ir_instance, expr, &vm.macros) catch |err| {
+        const root = ir_mod.lowerAndOptimize(&ir_instance, expr, &vm.macros, false) catch |err| {
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "IR lowering error: {}\n", .{err}) catch "IR error\n";
             writeStderr(s);
             return;
         };
-
-        ir_mod.markTailPositions(root, false);
-        ir_mod.identifyPrimitives(root);
-        ir_mod.markConstants(root);
-        root = ir_mod.foldConstants(&ir_instance, root);
-        root = ir_mod.eliminateDeadBranches(&ir_instance, root);
-        root = ir_mod.simplifyBooleans(&ir_instance, root);
-        root = ir_mod.eliminateIdentity(&ir_instance, root);
-        root = ir_mod.simplifyBegin(&ir_instance, root);
 
         ir_nodes.append(allocator, root) catch return;
 


### PR DESCRIPTION
## Summary
- Adds `ir.lowerAndOptimize()` — a single entry point for the 9-step IR pipeline (lower + 3 analysis passes + 5 optimization passes)
- Replaces 12 copy-pasted pipeline instances across `compiler.zig`, `compiler_ir.zig`, `native_compiler.zig`, and `llvm_emit_lambda.zig`
- Fixes a latent pass-order bug in `lowerSingleExprTail` where `identifyPrimitives`/`markConstants` ran before `markTailPositions`

Net: -111 lines, +30 lines. Adding a new optimization pass now requires editing one function instead of twelve.

Closes #1037

## Test plan
- [x] `zig build test` — all unit tests pass (including 85 IR parity tests)
- [x] `zig build` — clean release build
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail (307 Scheme files + 1395 R7RS suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)