### PR TITLE
GC safety by construction: arg_roots, infallible pushRoot, stress mode (#1045)

### DIFF
--- a/.claude/rules/gc-safety.md
+++ b/.claude/rules/gc-safety.md
@@ -14,7 +14,14 @@ string-set!, record field mutation):
 
 - **Root before allocating**: if you hold a pointer to a heap object and then
   allocate (which may trigger GC), root the value first with
-  `gc.pushRoot(&val)` / `gc.popRoot()`.
+  `gc.pushRoot(&val)` / `gc.popRoot()`. `pushRoot` is infallible (panics on
+  overflow at 1024 slots) — no `try` or `catch` needed.
+
+- **Allocator Value arguments are auto-rooted**: `allocPair(car, cdr)` and
+  other `allocXxx` functions that take Value arguments root them internally
+  via `arg_roots` before `maybeCollect()`. Callers do NOT need to root Values
+  that are passed directly as allocator arguments. However, Values held in
+  local variables across multiple allocation calls still need manual rooting.
 
 - **Root Function* before vm.execute()**: `execute()` allocates a closure
   wrapper internally.
@@ -32,6 +39,7 @@ const b = try gc.allocPair(a, z);
 gc.popRoot();
 ```
 
-Stress-test with `-Dgc-threshold=1` to force collection on every allocation.
+Stress-test with `-Dgc-stress=true` to force collection on every allocation.
+In Debug builds, freed objects are poisoned with `0xAA` to catch use-after-free.
 
 Rationale and full patterns: `docs/dev/gc-safety-and-error-handling.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ zig build -Dbundle=program.sbc     # standalone binary from pre-compiled .sbc
 zig build -Dmax-frames=1024        # initial frame capacity (default: 480, grows to 32768)
 zig build -Dmax-registers=4096     # initial register count (default: 2048, grows to 65536)
 zig build -Dgc-threshold=16384     # custom initial GC threshold (default: 8192)
+zig build -Dgc-stress=true         # force GC on every allocation (stress testing)
 ```
 
 CLI flags: `-h`/`--help`, `--version`, `--lib-path <path>`, `--compile`,

--- a/build.zig
+++ b/build.zig
@@ -26,11 +26,13 @@ pub fn build(b: *std.Build) void {
     const max_registers = b.option(u32, "max-registers", "Initial register count (default: 2048, grows to 65536)") orelse 2048;
 
     const gc_threshold = b.option(u32, "gc-threshold", "Initial GC object threshold (default: 8192)") orelse 8192;
+    const gc_stress = b.option(bool, "gc-stress", "Force GC on every allocation (stress testing)") orelse false;
 
     const options = b.addOptions();
     options.addOption(u32, "max_frames", max_frames);
     options.addOption(u32, "max_registers", max_registers);
     options.addOption(u32, "gc_initial_threshold", gc_threshold);
+    options.addOption(bool, "gc_stress", gc_stress);
     options.addOption([]const u8, "version", zon.version);
     const options_mod = options.createModule();
 

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -416,7 +416,7 @@ fn readConstant(r: *Reader, gc: *GC, all_funcs: []*Function, depth: u32) !Value 
             const car_val = try readConstant(r, gc, all_funcs, depth + 1);
             // Root car to protect from GC during cdr read
             var car_root = car_val;
-            try gc.pushRoot(&car_root);
+            gc.pushRoot(&car_root);
             defer gc.popRoot();
             const cdr_val = try readConstant(r, gc, all_funcs, depth + 1);
             return gc.allocPair(car_root, cdr_val) catch return BytecodeError.OutOfMemory;
@@ -425,7 +425,7 @@ fn readConstant(r: *Reader, gc: *GC, all_funcs: []*Function, depth: u32) !Value 
             const len = try r.readU32();
             if (len > MAX_VECTOR_LEN) return BytecodeError.CorruptedFile;
             var vec_val = gc.allocVectorFill(len, types.NIL) catch return BytecodeError.OutOfMemory;
-            try gc.pushRoot(&vec_val);
+            gc.pushRoot(&vec_val);
             defer gc.popRoot();
             for (0..len) |i| {
                 const elem = try readConstant(r, gc, all_funcs, depth + 1);
@@ -458,7 +458,7 @@ fn readConstant(r: *Reader, gc: *GC, all_funcs: []*Function, depth: u32) !Value 
             const num = try readConstant(r, gc, all_funcs, depth + 1);
             if (!types.isFixnum(num) and !types.isBignum(num)) return BytecodeError.CorruptedFile;
             var num_root = num;
-            try gc.pushRoot(&num_root);
+            gc.pushRoot(&num_root);
             defer gc.popRoot();
             const den = try readConstant(r, gc, all_funcs, depth + 1);
             if (!types.isFixnum(den) and !types.isBignum(den)) return BytecodeError.CorruptedFile;

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -374,7 +374,7 @@ pub const Compiler = struct {
         // this, not-yet-compiled tails of the form (e.g. string literals) can
         // be swept mid-compilation and end up as dangling constant-pool entries.
         var expr_root = expr;
-        try self.gc.pushRoot(&expr_root);
+        self.gc.pushRoot(&expr_root);
         defer self.gc.popRoot();
 
         // Scan the whole top-level form for `set!` targets so the constant
@@ -443,7 +443,7 @@ pub const Compiler = struct {
 
     pub fn compileDesugared(self: *Compiler, form: Value, dst: u16, is_tail: bool) CompileError!void {
         var rooted = form;
-        try self.gc.pushRoot(&rooted);
+        self.gc.pushRoot(&rooted);
         defer self.gc.popRoot();
         return self.compileExpr(rooted, dst, is_tail);
     }
@@ -797,10 +797,7 @@ pub const Compiler = struct {
                     };
                 };
                 var expanded_root = expanded;
-                self.gc.pushRoot(&expanded_root) catch {
-                    self.gc.no_collect -= 1;
-                    return CompileError.OutOfMemory;
-                };
+                self.gc.pushRoot(&expanded_root);
                 defer self.gc.popRoot();
                 self.gc.no_collect -= 1;
                 const saved_locals_len = self.locals.items.len;

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -288,7 +288,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
             }
             break :blk l;
         };
-        try gc.pushRoot(&list);
+        gc.pushRoot(&list);
         defer gc.popRoot();
         // Compile the list at the current quasiquote depth
         const fn_reg = try self.allocReg();
@@ -617,7 +617,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
         var seg0 = segments_buf[0];
         gc.no_collect -= 1;
         nc_held = false;
-        try gc.pushRoot(&seg0);
+        gc.pushRoot(&seg0);
         defer gc.popRoot();
         return self.compileExpr(seg0, dst, false);
     }
@@ -632,7 +632,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
     var append_call = gc.allocPair(append_sym, args_list) catch return CompileError.OutOfMemory;
     gc.no_collect -= 1;
     nc_held = false;
-    try gc.pushRoot(&append_call);
+    gc.pushRoot(&append_call);
     defer gc.popRoot();
     return self.compileExpr(append_call, dst, false);
 }

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -277,7 +277,7 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
         const renamed_body = try renameInBody(self.gc, body, types.symbolName(loop_name), unique_sym);
         renamed_lambda_args = self.gc.allocPair(formals, renamed_body) catch return CompileError.OutOfMemory;
     }
-    self.gc.pushRoot(&renamed_lambda_args) catch return CompileError.OutOfMemory;
+    self.gc.pushRoot(&renamed_lambda_args);
     defer self.gc.popRoot();
 
     self.beginScope();
@@ -592,7 +592,7 @@ pub fn compileLetValues(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
             const producer_lambda = gc.allocPair(lambda_sym, gc.allocPair(types.NIL, producer_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
             break :blk gc.allocPair(cwv_sym, gc.allocPair(producer_lambda, gc.allocPair(list_sym, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
         };
-        try gc.pushRoot(&cwv_expr);
+        gc.pushRoot(&cwv_expr);
         defer gc.popRoot();
         const slot = try self.allocReg();
         temp_slots[i] = slot;

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -374,7 +374,7 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
             const lambda_sym = child.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
             {
                 var lambda_args = child.gc.allocPair(param_formals, def_rest) catch return CompileError.OutOfMemory;
-                child.gc.pushRoot(&lambda_args) catch return CompileError.OutOfMemory;
+                child.gc.pushRoot(&lambda_args);
                 defer child.gc.popRoot();
                 def_inits[def_count] = child.gc.allocPair(lambda_sym, lambda_args) catch return CompileError.OutOfMemory;
             }

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -207,7 +207,7 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
                 const lambda_sym = self.gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
                 {
                     var lambda_args = self.gc.allocPair(param_formals, def_rest) catch return CompileError.OutOfMemory;
-                    self.gc.pushRoot(&lambda_args) catch return CompileError.OutOfMemory;
+                    self.gc.pushRoot(&lambda_args);
                     defer self.gc.popRoot();
                     def_inits[def_count] = self.gc.allocPair(lambda_sym, lambda_args) catch return CompileError.OutOfMemory;
                 }
@@ -369,7 +369,7 @@ pub fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
         const param_formals = types.cdr(target);
 
         var lambda_args = self.gc.allocPair(param_formals, rest) catch return CompileError.OutOfMemory;
-        self.gc.pushRoot(&lambda_args) catch return CompileError.OutOfMemory;
+        self.gc.pushRoot(&lambda_args);
         defer self.gc.popRoot();
         try compileLambda(self, lambda_args, dst, types.symbolName(name));
 
@@ -447,13 +447,13 @@ pub fn compileDefineValues(self: *Compiler, args: Value, dst: u16) CompileError!
     // Step 1: emit (define name (if #f #f)) for each name
     for (names_buf[0..name_count]) |name| {
         var def_args = try buildVoidDefineArgs(self, name);
-        self.gc.pushRoot(&def_args) catch return CompileError.OutOfMemory;
+        self.gc.pushRoot(&def_args);
         defer self.gc.popRoot();
         try compileDefine(self, def_args, dst);
     }
     if (rest_name) |rn| {
         var def_args = try buildVoidDefineArgs(self, rn);
-        self.gc.pushRoot(&def_args) catch return CompileError.OutOfMemory;
+        self.gc.pushRoot(&def_args);
         defer self.gc.popRoot();
         try compileDefine(self, def_args, dst);
     }
@@ -550,7 +550,7 @@ pub fn compileDefineValues(self: *Compiler, args: Value, dst: u16) CompileError!
         }
     }
 
-    self.gc.pushRoot(&final_form) catch return CompileError.OutOfMemory;
+    self.gc.pushRoot(&final_form);
     defer self.gc.popRoot();
     if (is_single) {
         try compileSet(self, final_form, dst);

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -531,7 +531,7 @@ fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_scop
         if (is_let_form) {
             const new_car = try instantiateTemplate(gc, elem, bindings, intro_scope, literals, macro_keyword, globals, macros);
             var car_root = new_car;
-            try gc.pushRoot(&car_root);
+            gc.pushRoot(&car_root);
             defer gc.popRoot();
             const let_rest = types.cdr(template);
             if (let_rest != types.NIL and types.isPair(let_rest)) {
@@ -539,11 +539,11 @@ fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_scop
                 const body = types.cdr(let_rest);
                 const new_bindings = try instantiateLetBindings(gc, binding_list, bindings, intro_scope | BINDING_FLAG, literals, macro_keyword, globals, macros);
                 var bindings_root = new_bindings;
-                try gc.pushRoot(&bindings_root);
+                gc.pushRoot(&bindings_root);
                 defer gc.popRoot();
                 const new_body = try instantiateTemplate(gc, body, bindings, intro_scope & ~BINDING_FLAG, literals, macro_keyword, globals, macros);
                 var body_root = new_body;
-                try gc.pushRoot(&body_root);
+                gc.pushRoot(&body_root);
                 defer gc.popRoot();
                 const inner = try gc.allocPair(bindings_root, body_root);
                 return gc.allocPair(car_root, inner);
@@ -554,7 +554,7 @@ fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_scop
     // Regular pair: recurse
     const new_car = try instantiateTemplate(gc, types.car(template), bindings, intro_scope & ~BINDING_FLAG, literals, macro_keyword, globals, macros);
     var car_root = new_car;
-    try gc.pushRoot(&car_root);
+    gc.pushRoot(&car_root);
     defer gc.popRoot();
     const new_cdr = try instantiateTemplate(gc, types.cdr(template), bindings, intro_scope & ~BINDING_FLAG, literals, macro_keyword, globals, macros);
     return gc.allocPair(car_root, new_cdr);
@@ -567,7 +567,7 @@ fn instantiateLetBindings(gc: *GC, binding_list: Value, bindings: []Binding, sco
     if (!types.isPair(pair)) {
         const new_pair = try instantiateTemplate(gc, pair, bindings, scope, literals, macro_keyword, globals, macros);
         var pair_root = new_pair;
-        try gc.pushRoot(&pair_root);
+        gc.pushRoot(&pair_root);
         defer gc.popRoot();
         const new_rest = try instantiateLetBindings(gc, types.cdr(binding_list), bindings, scope, literals, macro_keyword, globals, macros);
         return gc.allocPair(pair_root, new_rest);
@@ -576,15 +576,15 @@ fn instantiateLetBindings(gc: *GC, binding_list: Value, bindings: []Binding, sco
     const init_and_rest = types.cdr(pair);
     const new_var = try instantiateTemplate(gc, var_name, bindings, scope, literals, macro_keyword, globals, macros);
     var var_root = new_var;
-    try gc.pushRoot(&var_root);
+    gc.pushRoot(&var_root);
     defer gc.popRoot();
     const new_init = try instantiateTemplate(gc, init_and_rest, bindings, scope & ~@as(u32, 0x20000000), literals, macro_keyword, globals, macros);
     var init_root = new_init;
-    try gc.pushRoot(&init_root);
+    gc.pushRoot(&init_root);
     defer gc.popRoot();
     const new_pair = try gc.allocPair(var_root, init_root);
     var np_root = new_pair;
-    try gc.pushRoot(&np_root);
+    gc.pushRoot(&np_root);
     defer gc.popRoot();
     const new_rest = try instantiateLetBindings(gc, types.cdr(binding_list), bindings, scope, literals, macro_keyword, globals, macros);
     return gc.allocPair(np_root, new_rest);
@@ -627,7 +627,7 @@ fn instantiateNestedSyntaxRules(gc: *GC, template: Value, bindings: []Binding, i
     // Recurse with filtered bindings
     const new_car = try instantiateTemplate(gc, types.car(template), filtered[0..filt_count], intro_scope, literals, macro_keyword, globals, macros);
     var car_root = new_car;
-    try gc.pushRoot(&car_root);
+    gc.pushRoot(&car_root);
     defer gc.popRoot();
     const new_cdr = try instantiateTemplate(gc, types.cdr(template), filtered[0..filt_count], intro_scope, literals, macro_keyword, globals, macros);
     return gc.allocPair(car_root, new_cdr);
@@ -666,7 +666,7 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
     // First instantiate the rest (after the ellipsis)
     const result = try instantiateTemplate(gc, rest_template, bindings, intro_scope, literals, macro_keyword, globals, macros);
     var result_root = result;
-    try gc.pushRoot(&result_root);
+    gc.pushRoot(&result_root);
     defer gc.popRoot();
 
     // Generate copies in reverse so we build the list from right to left
@@ -709,7 +709,7 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
         }
         const expanded = try instantiateTemplate(gc, elem_template, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
         var expanded_root = expanded;
-        try gc.pushRoot(&expanded_root);
+        gc.pushRoot(&expanded_root);
         result_root = try gc.allocPair(expanded_root, result_root);
         gc.popRoot();
     }
@@ -736,7 +736,7 @@ fn substitutePatternVarsOnly(gc: *GC, template: Value, bindings: []Binding) !Val
     if (!types.isPair(template)) return template;
     const new_car = try substitutePatternVarsOnly(gc, types.car(template), bindings);
     var car_root = new_car;
-    try gc.pushRoot(&car_root);
+    gc.pushRoot(&car_root);
     const new_cdr = try substitutePatternVarsOnly(gc, types.cdr(template), bindings);
     gc.popRoot();
     return gc.allocPair(car_root, new_cdr);

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -89,7 +89,7 @@ pub const FiberScheduler = struct {
 
     pub fn spawnFiber(self: *FiberScheduler, thunk: Value) !*Fiber {
         var thunk_val = thunk;
-        try self.vm.gc.pushRoot(&thunk_val);
+        self.vm.gc.pushRoot(&thunk_val);
         const fiber = try self.vm.gc.allocFiber(thunk_val, self.next_id);
         self.vm.gc.popRoot();
         self.next_id += 1;

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const memory_mod = @import("memory.zig");
 const GC = memory_mod.GC;
@@ -51,7 +52,8 @@ pub fn collect(gc: *GC) void {
     }
     const mark_end = clockNs();
     gc.stats.total_mark_ns +%= mark_end -% mark_start;
-    gc.gc_threshold = @max(GC_THRESHOLD, gc.object_count * 4);
+    if (!gc.stress)
+        gc.gc_threshold = @max(GC_THRESHOLD, gc.object_count * 4);
 }
 
 fn minorCollect(gc: *GC) void {
@@ -466,7 +468,10 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
 }
 
 fn markRoots(gc: *GC) void {
-    for (gc.roots.items) |root| {
+    for (gc.arg_roots[0..gc.arg_root_count]) |v| {
+        markValue(gc, v);
+    }
+    for (gc.root_buffer[0..gc.root_count]) |root| {
         markValue(gc, root.*);
     }
     for (gc.extra_roots.items) |v| {
@@ -799,26 +804,33 @@ fn objectSize(obj: *Object) usize {
     };
 }
 
+inline fn poisonAndDestroy(gc: *GC, comptime T: type, ptr: *T) void {
+    if (builtin.mode == .Debug) {
+        @memset(@as([*]u8, @ptrCast(ptr))[0..@sizeOf(T)], 0xAA);
+    }
+    gc.allocator.destroy(ptr);
+}
+
 pub fn freeObject(gc: *GC, obj: *Object) void {
     switch (obj.tag) {
         .pair => {
             const pair = obj.as(Pair);
-            gc.allocator.destroy(pair);
+            poisonAndDestroy(gc, Pair, pair);
         },
         .symbol => {
             const sym = obj.as(Symbol);
             gc.allocator.free(sym.name);
-            gc.allocator.destroy(sym);
+            poisonAndDestroy(gc, Symbol, sym);
         },
         .string => {
             const str = obj.as(SchemeString);
             gc.allocator.free(str.data);
-            gc.allocator.destroy(str);
+            poisonAndDestroy(gc, SchemeString, str);
         },
         .closure => {
             const cls = obj.as(Closure);
             gc.allocator.free(cls.upvalues);
-            gc.allocator.destroy(cls);
+            poisonAndDestroy(gc, Closure, cls);
         },
         .function => {
             const func = obj.as(Function);
@@ -834,25 +846,25 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             if (func.owns_name) {
                 if (func.name) |n| gc.allocator.free(n);
             }
-            gc.allocator.destroy(func);
+            poisonAndDestroy(gc, Function, func);
         },
         .native_fn => {
             const nf = obj.as(NativeFn);
-            gc.allocator.destroy(nf);
+            poisonAndDestroy(gc, NativeFn, nf);
         },
         .native_closure => {
             const nc = obj.as(types.NativeClosure);
             gc.allocator.free(nc.upvalues);
-            gc.allocator.destroy(nc);
+            poisonAndDestroy(gc, types.NativeClosure, nc);
         },
         .flonum => {
             const flo = obj.as(Flonum);
-            gc.allocator.destroy(flo);
+            poisonAndDestroy(gc, Flonum, flo);
         },
         .vector => {
             const vec = obj.as(Vector);
             gc.allocator.free(vec.data);
-            gc.allocator.destroy(vec);
+            poisonAndDestroy(gc, Vector, vec);
         },
         .transformer => {
             const tx = obj.as(Transformer);
@@ -860,30 +872,30 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             gc.allocator.free(tx.patterns);
             gc.allocator.free(tx.templates);
             if (tx.captured_locals.len > 0) gc.allocator.free(tx.captured_locals);
-            gc.allocator.destroy(tx);
+            poisonAndDestroy(gc, Transformer, tx);
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);
-            gc.allocator.destroy(err);
+            poisonAndDestroy(gc, types.ErrorObject, err);
         },
         .record_type => {
             const rt = obj.as(RecordType);
             gc.allocator.free(rt.name);
-            gc.allocator.destroy(rt);
+            poisonAndDestroy(gc, RecordType, rt);
         },
         .record_instance => {
             const ri = obj.as(RecordInstance);
             gc.allocator.free(ri.fields);
-            gc.allocator.destroy(ri);
+            poisonAndDestroy(gc, RecordInstance, ri);
         },
         .bytevector => {
             const bv = obj.as(Bytevector);
             gc.allocator.free(bv.data);
-            gc.allocator.destroy(bv);
+            poisonAndDestroy(gc, Bytevector, bv);
         },
         .promise => {
             const p = obj.as(Promise);
-            gc.allocator.destroy(p);
+            poisonAndDestroy(gc, Promise, p);
         },
         .port => {
             const port = obj.as(Port);
@@ -904,7 +916,7 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             if (port.string_out_buf) |sb| {
                 gc.allocator.free(sb);
             }
-            gc.allocator.destroy(port);
+            poisonAndDestroy(gc, Port, port);
         },
         .continuation => {
             const cont = obj.as(Continuation);
@@ -912,37 +924,37 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             // the single backing allocation; free it once. Escape
             // continuations have no backing (empty slice).
             if (cont.backing.len > 0) gc.allocator.free(cont.backing);
-            gc.allocator.destroy(cont);
+            poisonAndDestroy(gc, Continuation, cont);
         },
         .multiple_values => {
             const mv = obj.as(MultipleValues);
             gc.allocator.free(mv.values);
-            gc.allocator.destroy(mv);
+            poisonAndDestroy(gc, MultipleValues, mv);
         },
         .complex => {
             const c = obj.as(types.Complex);
-            gc.allocator.destroy(c);
+            poisonAndDestroy(gc, types.Complex, c);
         },
         .parameter => {
             const p = obj.as(types.ParameterObject);
-            gc.allocator.destroy(p);
+            poisonAndDestroy(gc, types.ParameterObject, p);
         },
         .hash_table => {
             const ht = obj.as(HashTable);
             gc.allocator.free(ht.entries);
-            gc.allocator.destroy(ht);
+            poisonAndDestroy(gc, HashTable, ht);
         },
         .ffi_library => {
             const lib = obj.as(FfiLibrary);
             // Do NOT dlclose here -- let ffi-close handle that explicitly
             gc.allocator.free(lib.name);
-            gc.allocator.destroy(lib);
+            poisonAndDestroy(gc, FfiLibrary, lib);
         },
         .ffi_function => {
             const ffi_fn = obj.as(FfiFunction);
             gc.allocator.free(ffi_fn.name);
             gc.allocator.free(ffi_fn.param_types);
-            gc.allocator.destroy(ffi_fn);
+            poisonAndDestroy(gc, FfiFunction, ffi_fn);
         },
         .ffi_callback => {
             const cb = obj.as(FfiCallback);
@@ -950,20 +962,20 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                 const ffi_cb = @import("ffi_callback.zig");
                 ffi_cb.releaseSlot(cb.slot_index);
             }
-            gc.allocator.destroy(cb);
+            poisonAndDestroy(gc, FfiCallback, cb);
         },
         .bignum => {
             const bn = obj.as(Bignum);
             gc.allocator.free(bn.limbs);
-            gc.allocator.destroy(bn);
+            poisonAndDestroy(gc, Bignum, bn);
         },
         .rational => {
             const rat = obj.as(Rational);
-            gc.allocator.destroy(rat);
+            poisonAndDestroy(gc, Rational, rat);
         },
         .file_info => {
             const fi = obj.as(types.FileInfo);
-            gc.allocator.destroy(fi);
+            poisonAndDestroy(gc, types.FileInfo, fi);
         },
         .user_info => {
             const ui = obj.as(types.UserInfo);
@@ -971,12 +983,12 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             gc.allocator.free(ui.home_dir);
             gc.allocator.free(ui.shell);
             gc.allocator.free(ui.full_name);
-            gc.allocator.destroy(ui);
+            poisonAndDestroy(gc, types.UserInfo, ui);
         },
         .group_info => {
             const gi = obj.as(types.GroupInfo);
             gc.allocator.free(gi.name);
-            gc.allocator.destroy(gi);
+            poisonAndDestroy(gc, types.GroupInfo, gi);
         },
         .directory_object => {
             const d = obj.as(types.DirectoryObject);
@@ -984,29 +996,29 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                 _ = std.c.closedir(@ptrCast(@alignCast(dir)));
                 d.dir = null;
             }
-            gc.allocator.destroy(d);
+            poisonAndDestroy(gc, types.DirectoryObject, d);
         },
         .random_source => {
-            gc.allocator.destroy(obj.as(RandomSource));
+            poisonAndDestroy(gc, RandomSource, obj.as(RandomSource));
         },
         .fiber => {
             const fiber = obj.as(@import("fiber.zig").Fiber);
             fiber.param_overrides.deinit();
             gc.allocator.free(fiber.frames);
             gc.allocator.free(fiber.registers);
-            gc.allocator.destroy(fiber);
+            poisonAndDestroy(gc, @import("fiber.zig").Fiber, fiber);
         },
         .channel => {
-            gc.allocator.destroy(obj.as(types.Channel));
+            poisonAndDestroy(gc, types.Channel, obj.as(types.Channel));
         },
         .mutex => {
-            gc.allocator.destroy(obj.as(types.Mutex));
+            poisonAndDestroy(gc, types.Mutex, obj.as(types.Mutex));
         },
         .condition_variable => {
-            gc.allocator.destroy(obj.as(types.ConditionVariable));
+            poisonAndDestroy(gc, types.ConditionVariable, obj.as(types.ConditionVariable));
         },
         .srfi18_time => {
-            gc.allocator.destroy(obj.as(types.Srfi18Time));
+            poisonAndDestroy(gc, types.Srfi18Time, obj.as(types.Srfi18Time));
         },
         .scheme_environment => {
             const se = obj.as(types.SchemeEnvironment);
@@ -1014,7 +1026,7 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                 se.env.deinit();
                 gc.allocator.destroy(se.env);
             }
-            gc.allocator.destroy(se);
+            poisonAndDestroy(gc, types.SchemeEnvironment, se);
         },
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -283,7 +283,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 defer pr.deinit();
                 while (pr.hasMore() catch break) {
                     var expr = pr.readDatum() catch break;
-                    gc.pushRoot(&expr) catch break;
+                    gc.pushRoot(&expr);
                     defer gc.popRoot();
                     if (vm.handleTopLevelForm(expr)) |top_result| {
                         _ = top_result catch |err| {
@@ -308,7 +308,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         const top_count = @min(loaded.top_level_count, @as(u32, @intCast(loaded.funcs.len)));
         for (loaded.funcs[0..top_count]) |func| {
             var func_val = types.makePointer(@ptrCast(func));
-            vm.gc.pushRoot(&func_val) catch return error.OutOfMemory;
+            vm.gc.pushRoot(&func_val);
             const result = vm.execute(func) catch |err| {
                 vm.gc.popRoot();
                 script_had_error = true;
@@ -501,7 +501,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                     defer pr.deinit();
                     while (pr.hasMore() catch break) {
                         var expr = pr.readDatum() catch break;
-                        vm.gc.pushRoot(&expr) catch break;
+                        vm.gc.pushRoot(&expr);
                         defer vm.gc.popRoot();
                         if (vm.handleTopLevelForm(expr)) |top_result| {
                             _ = top_result catch {};
@@ -520,7 +520,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             const top_count = @min(loaded.top_level_count, @as(u32, @intCast(loaded.funcs.len)));
             for (loaded.funcs[0..top_count]) |func| {
                 var func_val = types.makePointer(@ptrCast(func));
-                vm.gc.pushRoot(&func_val) catch return error.OutOfMemory;
+                vm.gc.pushRoot(&func_val);
                 const result = vm.execute(func) catch |err| {
                     vm.gc.popRoot();
                     script_had_error = true;
@@ -560,11 +560,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             return;
         };
 
-        vm.gc.pushRoot(&expr) catch {
-            writeStderr("error: out of memory while rooting expression\n");
-            script_had_error = true;
-            return;
-        };
+        vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
@@ -588,7 +584,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         vm.gc.extra_roots.append(allocator, types.makePointer(@ptrCast(func))) catch return error.OutOfMemory;
 
         var func_val = types.makePointer(@ptrCast(func));
-        vm.gc.pushRoot(&func_val) catch return error.OutOfMemory;
+        vm.gc.pushRoot(&func_val);
 
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();
@@ -638,11 +634,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
             return;
         };
 
-        vm.gc.pushRoot(&expr) catch {
-            writeStderr("error: out of memory while rooting expression\n");
-            script_had_error = true;
-            return;
-        };
+        vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
@@ -663,11 +655,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
         };
 
         var func_val = types.makePointer(@ptrCast(func));
-        vm.gc.pushRoot(&func_val) catch {
-            writeStderr("error: out of memory while rooting function\n");
-            script_had_error = true;
-            return;
-        };
+        vm.gc.pushRoot(&func_val);
 
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();
@@ -710,11 +698,7 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
             return;
         };
 
-        vm.gc.pushRoot(&expr) catch {
-            writeStderr("error: out of memory while rooting expression\n");
-            script_had_error = true;
-            return;
-        };
+        vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
@@ -791,7 +775,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
             return;
         };
 
-        vm.gc.pushRoot(&expr) catch continue;
+        vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |top_result| {

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -103,9 +103,13 @@ pub const GC = struct {
     /// For a child gc: the parent gc's id, stamped on symbols the child
     /// interns into the shared table (the parent owns and frees those).
     shared_owner_id: u32 = 0,
-    roots: std.ArrayList(*Value),
+    root_buffer: [1024]*Value = undefined,
+    root_count: u16 = 0,
     extra_roots: std.ArrayList(Value),
+    arg_roots: [4]Value = .{ 0, 0, 0, 0 },
+    arg_root_count: u3 = 0,
     remembered_set: std.ArrayList(*Object),
+    stress: bool = build_options.gc_stress,
     enabled: bool = true,
     no_collect: u32 = 0,
     bytes_allocated: usize = 0,
@@ -120,7 +124,6 @@ pub const GC = struct {
         return .{
             .allocator = allocator,
             .symbols = std.StringHashMap(Value).init(allocator),
-            .roots = .empty,
             .extra_roots = .empty,
             .remembered_set = .empty,
             .source_lines = std.AutoHashMap(Value, u32).init(allocator),
@@ -134,7 +137,6 @@ pub const GC = struct {
             .symbols = std.StringHashMap(Value).init(allocator),
             .shared_symbols = &parent.symbols,
             .shared_foreign_symbols = &parent.foreign_symbols,
-            .roots = .empty,
             .extra_roots = .empty,
             .remembered_set = .empty,
             .source_lines = std.AutoHashMap(Value, u32).init(allocator),
@@ -163,7 +165,6 @@ pub const GC = struct {
         for (self.foreign_symbols.items) |o| gc_collect.freeObject(self, o);
         self.foreign_symbols.deinit(self.allocator);
         self.symbols.deinit();
-        self.roots.deinit(self.allocator);
         self.extra_roots.deinit(self.allocator);
         self.remembered_set.deinit(self.allocator);
         self.source_lines.deinit();
@@ -197,6 +198,21 @@ pub const GC = struct {
             self.stats.peak_bytes_allocated = self.bytes_allocated;
     }
 
+    inline fn rootArgs1(self: *GC, a: Value) void {
+        self.arg_roots[0] = a;
+        self.arg_root_count = 1;
+    }
+
+    inline fn rootArgs2(self: *GC, a: Value, b: Value) void {
+        self.arg_roots[0] = a;
+        self.arg_roots[1] = b;
+        self.arg_root_count = 2;
+    }
+
+    inline fn clearArgRoots(self: *GC) void {
+        self.arg_root_count = 0;
+    }
+
     pub inline fn finishAlloc(self: *GC, obj: *Object, size: usize) void {
         self.bytes_allocated += size;
         self.profileAlloc(size);
@@ -204,7 +220,9 @@ pub const GC = struct {
     }
 
     pub fn allocPair(self: *GC, car_val: Value, cdr_val: Value) !Value {
+        self.rootArgs2(car_val, cdr_val);
         try self.maybeCollect();
+        self.clearArgRoots();
         const pair = try self.allocator.create(Pair);
         pair.* = .{
             .header = .{ .tag = .pair },
@@ -296,7 +314,9 @@ pub const GC = struct {
     }
 
     pub fn allocClosure(self: *GC, func: *Function) !Value {
+        self.rootArgs1(types.makePointer(@ptrCast(func)));
         try self.maybeCollect();
+        self.clearArgRoots();
         const upvalue_count = func.upvalue_count;
         const upvalues = try self.allocator.alloc(Value, upvalue_count);
         errdefer self.allocator.free(upvalues);
@@ -361,7 +381,9 @@ pub const GC = struct {
     }
 
     pub fn allocVectorFill(self: *GC, size: usize, fill: Value) !Value {
+        self.rootArgs1(fill);
         try self.maybeCollect();
+        self.clearArgRoots();
         const data = try self.allocator.alloc(Value, size);
         errdefer self.allocator.free(data);
         @memset(data, fill);
@@ -375,7 +397,9 @@ pub const GC = struct {
     }
 
     pub fn allocErrorObject(self: *GC, message: Value, irritants: Value) !Value {
+        self.rootArgs2(message, irritants);
         try self.maybeCollect();
+        self.clearArgRoots();
         const err = try self.allocator.create(types.ErrorObject);
         err.* = .{
             .header = .{ .tag = .error_object },
@@ -539,7 +563,9 @@ pub const GC = struct {
     }
 
     pub fn allocPromise(self: *GC, forced: bool, value: Value) !Value {
+        self.rootArgs1(value);
         try self.maybeCollect();
+        self.clearArgRoots();
         const p = try self.allocator.create(Promise);
         p.* = .{
             .header = .{ .tag = .promise },
@@ -678,7 +704,9 @@ pub const GC = struct {
     }
 
     pub fn allocParameter(self: *GC, init_value: Value, converter: Value) !Value {
+        self.rootArgs2(init_value, converter);
         try self.maybeCollect();
+        self.clearArgRoots();
         const p = try self.allocator.create(types.ParameterObject);
         p.* = .{
             .header = .{ .tag = .parameter },
@@ -704,7 +732,9 @@ pub const GC = struct {
     }
 
     pub fn allocFfiFunction(self: *GC, symbol: *anyopaque, library: Value, name: []const u8, param_types: []const FfiType, return_type: FfiType) !Value {
+        self.rootArgs1(library);
         try self.maybeCollect();
+        self.clearArgRoots();
         const owned_name = try self.allocator.dupe(u8, name);
         errdefer self.allocator.free(owned_name);
         const owned_params = try self.allocator.dupe(FfiType, param_types);
@@ -724,7 +754,9 @@ pub const GC = struct {
     }
 
     pub fn allocFfiCallback(self: *GC, closure: Value, slot_index: u8, fn_ptr: *anyopaque) !Value {
+        self.rootArgs1(closure);
         try self.maybeCollect();
+        self.clearArgRoots();
         const cb = try self.allocator.create(FfiCallback);
         cb.* = .{
             .header = .{ .tag = .ffi_callback },
@@ -749,7 +781,9 @@ pub const GC = struct {
     }
 
     pub fn allocFiber(self: *GC, thunk: Value, id: u32) !*@import("fiber.zig").Fiber {
+        self.rootArgs1(thunk);
         try self.maybeCollect();
+        self.clearArgRoots();
         const fiber_mod = @import("fiber.zig");
         const registers = try self.allocator.alloc(Value, types.INITIAL_REGISTER_CAPACITY);
         errdefer self.allocator.free(registers);
@@ -800,7 +834,9 @@ pub const GC = struct {
     }
 
     pub fn allocMutex(self: *GC, name: Value) !Value {
+        self.rootArgs1(name);
         try self.maybeCollect();
+        self.clearArgRoots();
         const m = try self.allocator.create(types.Mutex);
         m.* = .{
             .header = .{ .tag = .mutex },
@@ -815,7 +851,9 @@ pub const GC = struct {
     }
 
     pub fn allocConditionVariable(self: *GC, name: Value) !Value {
+        self.rootArgs1(name);
         try self.maybeCollect();
+        self.clearArgRoots();
         const cv = try self.allocator.create(types.ConditionVariable);
         cv.* = .{
             .header = .{ .tag = .condition_variable },
@@ -894,7 +932,9 @@ pub const GC = struct {
     }
 
     pub fn allocRational(self: *GC, num: Value, den: Value) !Value {
+        self.rootArgs2(num, den);
         try self.maybeCollect();
+        self.clearArgRoots();
         const rat = try self.allocator.create(Rational);
         rat.* = .{
             .header = .{ .tag = .rational },
@@ -1021,7 +1061,7 @@ pub const GC = struct {
     // -- Convenience: build a proper list from a slice
     pub fn makeList(self: *GC, items: []const Value) !Value {
         var result: Value = types.NIL;
-        try self.pushRoot(&result);
+        self.pushRoot(&result);
         defer self.popRoot();
         var i = items.len;
         while (i > 0) {
@@ -1044,6 +1084,13 @@ pub const GC = struct {
     const gc_collect = @import("gc_collect.zig");
 
     fn maybeCollect(self: *GC) !void {
+        if (self.stress and self.enabled) {
+            if (self.no_collect == 0) self.collect();
+            if (self.memory_limit) |limit| {
+                if (self.bytes_allocated > limit) return error.OutOfMemory;
+            }
+            return;
+        }
         if (self.enabled and self.object_count >= self.gc_threshold) {
             if (self.no_collect > 0) {
                 self.stats.no_collect_deferred += 1;
@@ -1071,12 +1118,15 @@ pub const GC = struct {
         gc_collect.markValue(self, v);
     }
 
-    pub fn pushRoot(self: *GC, root: *Value) !void {
-        try self.roots.append(self.allocator, root);
+    pub fn pushRoot(self: *GC, root: *Value) void {
+        if (self.root_count >= self.root_buffer.len)
+            @panic("GC root stack overflow (1024)");
+        self.root_buffer[self.root_count] = root;
+        self.root_count += 1;
     }
 
     pub fn popRoot(self: *GC) void {
-        _ = self.roots.pop();
+        self.root_count -= 1;
     }
 };
 
@@ -1143,7 +1193,7 @@ test "gc preserves rooted objects" {
 
     var rooted = try gc.allocPair(types.makeFixnum(42), types.NIL);
     _ = try gc.allocPair(types.makeFixnum(99), types.NIL);
-    try gc.pushRoot(&rooted);
+    gc.pushRoot(&rooted);
 
     gc.collect();
     try std.testing.expectEqual(@as(usize, 1), gc.object_count);

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -343,7 +343,7 @@ fn append(args: []const Value) PrimitiveError!Value {
     if (args.len == 1) return args[0];
 
     var result = args[args.len - 1];
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var i = args.len - 1;
     while (i > 0) {
@@ -368,7 +368,7 @@ fn append(args: []const Value) PrimitiveError!Value {
 fn reverse(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var current = args[0];
     while (current != types.NIL) {

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -185,7 +185,7 @@ pub fn raiseDivByZero() PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.DivisionByZero;
     const gc = memory.gc_instance orelse return PrimitiveError.DivisionByZero;
     var msg = gc.allocString("division by zero") catch return PrimitiveError.DivisionByZero;
-    gc.pushRoot(&msg) catch return PrimitiveError.DivisionByZero;
+    gc.pushRoot(&msg);
     defer gc.popRoot();
     const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.DivisionByZero;
     vm.current_exception = err_obj;
@@ -760,7 +760,7 @@ fn compareExactReals(a: Value, b: Value) PrimitiveError!i8 {
     const nb = exactNumerator(b);
     const db = exactDenominator(b);
     var p1 = bignum_mod.mul(gc, na, db) catch return PrimitiveError.OutOfMemory;
-    gc.pushRoot(&p1) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&p1);
     defer gc.popRoot();
     const p2 = bignum_mod.mul(gc, nb, da) catch return PrimitiveError.OutOfMemory;
     return bignum_mod.compare(p1, p2);
@@ -777,7 +777,7 @@ fn compareExactVsFlonum(a: Value, f: f64) PrimitiveError!i8 {
     }
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var f_exact = try numeric.exactFn(&[1]Value{types.makeFlonum(f)});
-    gc.pushRoot(&f_exact) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&f_exact);
     defer gc.popRoot();
     return try compareExactReals(a, f_exact);
 }

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -93,18 +93,18 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
             vm.popHandler();
             var handler_root = handler;
             const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-            gc.pushRoot(&handler_root) catch return PrimitiveError.OutOfMemory;
+            gc.pushRoot(&handler_root);
             defer gc.popRoot();
             var exc = vm.current_exception orelse types.FALSE;
             vm.current_exception = null;
-            gc.pushRoot(&exc) catch return PrimitiveError.OutOfMemory;
+            gc.pushRoot(&exc);
             defer gc.popRoot();
             _ = vm.callHandler(handler_root, exc, 0) catch |herr| {
                 return primitives.mapVMError(herr);
             };
             // Handler returned from non-continuable raise — re-raise per R7RS
             var reraise_msg = gc.allocString("handler returned") catch return PrimitiveError.OutOfMemory;
-            gc.pushRoot(&reraise_msg) catch return PrimitiveError.OutOfMemory;
+            gc.pushRoot(&reraise_msg);
             defer gc.popRoot();
             const reraise_err = gc.allocErrorObject(reraise_msg, types.NIL) catch return PrimitiveError.OutOfMemory;
             vm.current_exception = reraise_err;
@@ -118,14 +118,14 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
             gc.allocString(detail) catch return PrimitiveError.OutOfMemory
         else
             gc.allocString("error") catch return PrimitiveError.OutOfMemory;
-        gc.pushRoot(&msg_str) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&msg_str);
         defer gc.popRoot();
         const err_obj = gc.allocErrorObject(msg_str, types.NIL) catch return PrimitiveError.OutOfMemory;
         var handler_root = handler;
-        gc.pushRoot(&handler_root) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&handler_root);
         defer gc.popRoot();
         var err_root = err_obj;
-        gc.pushRoot(&err_root) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&err_root);
         defer gc.popRoot();
         const handler_result = vm.callHandler(handler_root, err_root, 0) catch |herr| {
             return primitives.mapVMError(herr);
@@ -174,7 +174,7 @@ fn errorFn(args: []const Value) PrimitiveError!Value {
 
     // Build irritants list from remaining args
     var irritants: Value = types.NIL;
-    gc.pushRoot(&irritants) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&irritants);
     defer gc.popRoot();
     if (args.len > 1) {
         var i = args.len;
@@ -214,7 +214,7 @@ fn callWithCurrentContinuation(args: []const Value) PrimitiveError!Value {
 
     // Root the continuation so it survives GC during the proc call
     var cont_val = cont;
-    vm.gc.pushRoot(&cont_val) catch return PrimitiveError.OutOfMemory;
+    vm.gc.pushRoot(&cont_val);
     defer vm.gc.popRoot();
 
     // Call proc(continuation)
@@ -248,7 +248,7 @@ fn callWithEscapeContinuation(args: []const Value) PrimitiveError!Value {
 
     // Root the continuation so it survives GC during the proc call.
     var cont_val = cont;
-    vm.gc.pushRoot(&cont_val) catch return PrimitiveError.OutOfMemory;
+    vm.gc.pushRoot(&cont_val);
     defer vm.gc.popRoot();
     const cont_obj = types.toObject(cont_val).as(types.Continuation);
 
@@ -331,7 +331,7 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
     // Call consumer with the produced values
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var produced_root = produced;
-    gc.pushRoot(&produced_root) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&produced_root);
     defer gc.popRoot();
     if (types.isMultipleValues(produced_root)) {
         const mv = types.toObject(produced_root).as(types.MultipleValues);

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -237,7 +237,7 @@ fn raiseDeadlockError(msg: []const u8) PrimitiveError {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
     var msg_root = message;
-    gc.pushRoot(&msg_root) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg_root);
     const err_val = gc.allocErrorObject(msg_root, types.NIL) catch {
         gc.popRoot();
         return PrimitiveError.OutOfMemory;

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -199,11 +199,11 @@ pub fn registerFilesystem(vm: *vm_mod.VM) !void {
 fn raiseFileError(gc: *GC, msg_text: []const u8, irritant: Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     var msg = gc.allocString(msg_text) catch return PrimitiveError.OutOfMemory;
-    gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg);
     defer gc.popRoot();
     const irritants = gc.allocPair(irritant, types.NIL) catch return PrimitiveError.OutOfMemory;
     var irritants_root = irritants;
-    gc.pushRoot(&irritants_root) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&irritants_root);
     defer gc.popRoot();
     const err_obj = gc.allocErrorObject(msg, irritants_root) catch return PrimitiveError.OutOfMemory;
     types.toObject(err_obj).as(types.ErrorObject).error_type = .file;
@@ -243,10 +243,10 @@ fn directoryFiles(args: []const Value) PrimitiveError!Value {
     defer _ = std.c.closedir(dir);
 
     var str_val: Value = types.NIL;
-    gc.pushRoot(&str_val) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&str_val);
     defer gc.popRoot();
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
 
     while (std.c.readdir(dir)) |entry| {
@@ -746,7 +746,7 @@ fn userSupplementaryGidsFn(args: []const Value) PrimitiveError!Value {
     if (n < 0) return raiseFileError(gc, "cannot query supplementary groups", types.NIL);
 
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
 
     var i: usize = @intCast(n);

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -257,7 +257,7 @@ fn hashTableKeysFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-keys", args[0]);
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     for (ht.entries[0..ht.capacity]) |entry| {
         if (entry.state == .occupied) {
@@ -272,7 +272,7 @@ fn hashTableValuesFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-values", args[0]);
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     for (ht.entries[0..ht.capacity]) |entry| {
         if (entry.state == .occupied) {
@@ -306,12 +306,12 @@ fn hashTableToAlistFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table->alist", args[0]);
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     for (ht.entries[0..ht.capacity]) |entry| {
         if (entry.state == .occupied) {
             var pair = gc.allocPair(entry.key, entry.value) catch return PrimitiveError.OutOfMemory;
-            gc.pushRoot(&pair) catch return PrimitiveError.OutOfMemory;
+            gc.pushRoot(&pair);
             result = gc.allocPair(pair, result) catch {
                 gc.popRoot();
                 return PrimitiveError.OutOfMemory;
@@ -494,7 +494,7 @@ fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
     const proc = args[1];
     var acc = args[2];
 
-    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&acc);
     defer gc.popRoot();
 
     const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -291,11 +291,11 @@ fn outputPortOpenP(args: []const Value) PrimitiveError!Value {
 fn raiseFileError(gc: *@import("memory.zig").GC, msg_text: []const u8, irritant: Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     var msg = gc.allocString(msg_text) catch return PrimitiveError.OutOfMemory;
-    gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg);
     defer gc.popRoot();
     const irritants = gc.allocPair(irritant, types.NIL) catch return PrimitiveError.OutOfMemory;
     var irritants_root = irritants;
-    gc.pushRoot(&irritants_root) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&irritants_root);
     defer gc.popRoot();
     const err_obj = gc.allocErrorObject(msg, irritants_root) catch return PrimitiveError.OutOfMemory;
     types.toObject(err_obj).as(types.ErrorObject).error_type = .file;
@@ -606,7 +606,7 @@ fn parseDatumForRead(reader: *reader_mod.Reader) reader_mod.ReadError!?Value {
 
 fn raiseReadError(gc: *@import("memory.zig").GC) PrimitiveError!Value {
     var msg = gc.allocString("read error") catch return PrimitiveError.OutOfMemory;
-    gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg);
     defer gc.popRoot();
     const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.OutOfMemory;
     const errObj = types.toObject(err_obj).as(types.ErrorObject);
@@ -864,13 +864,13 @@ fn deleteFile(args: []const Value) PrimitiveError!Value {
     const result = std.posix.system.unlink(path_z);
     if (result < 0) {
         var msg = gc.allocString("cannot delete file") catch return PrimitiveError.OutOfMemory;
-        gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&msg);
         defer gc.popRoot();
         var irritant = gc.allocString(path) catch return PrimitiveError.OutOfMemory;
-        gc.pushRoot(&irritant) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&irritant);
         defer gc.popRoot();
         var irr_list = gc.allocPair(irritant, types.NIL) catch return PrimitiveError.OutOfMemory;
-        gc.pushRoot(&irr_list) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&irr_list);
         defer gc.popRoot();
         const err_obj = gc.allocErrorObject(msg, irr_list) catch return PrimitiveError.OutOfMemory;
         types.toObject(err_obj).as(types.ErrorObject).error_type = .file;

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -34,7 +34,7 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     var current = args[0];
-    gc.pushRoot(&current) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&current);
     defer gc.popRoot();
 
     if (!types.isPromise(current)) return current;

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -108,7 +108,7 @@ fn listCopyFn(args: []const Value) PrimitiveError!Value {
     }
     // Build the copy from the end
     var result: Value = current; // NIL for proper, last cdr for improper
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var i = elems.items.len;
     while (i > 0) {
@@ -125,7 +125,7 @@ fn makeListFn(args: []const Value) PrimitiveError!Value {
     if (k < 0) return primitives.typeError("make-list", "non-negative integer", args[0]);
     const fill: Value = if (args.len > 1) args[1] else types.UNDEFINED;
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var i: i64 = 0;
     while (i < k) : (i += 1) {
@@ -356,10 +356,10 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
 
     // Build result list incrementally (rooted head + tail)
     var result_head: Value = types.NIL;
-    gc.pushRoot(&result_head) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result_head);
     defer gc.popRoot();
     var result_tail: Value = types.NIL;
-    gc.pushRoot(&result_tail) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result_tail);
     defer gc.popRoot();
 
     // Current pointers for each list
@@ -394,7 +394,7 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
 
         // Root result: callWithArgs pops its frame, so the return value has
         // no GC root until it is consed into the result list.
-        gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&result);
         const new_pair = gc.allocPair(result, types.NIL) catch {
             gc.popRoot();
             return PrimitiveError.OutOfMemory;

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -95,11 +95,11 @@ fn commandLine(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
 
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
 
     var str_val: Value = types.NIL;
-    gc.pushRoot(&str_val) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&str_val);
     defer gc.popRoot();
 
     var i = vm.command_line_args.len;
@@ -159,15 +159,15 @@ fn getEnvVars(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
 
     var pair_val: Value = types.NIL;
-    gc.pushRoot(&pair_val) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&pair_val);
     defer gc.popRoot();
 
     var key_val: Value = types.NIL;
-    gc.pushRoot(&key_val) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&key_val);
     defer gc.popRoot();
 
     var i: usize = 0;
@@ -198,7 +198,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
         const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env, args[1]) catch return PrimitiveError.TypeError; // bare-ok: compile error
         var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
         compiler_mod.Compiler.unrootFunction(gc, func);
-        gc.pushRoot(&closure_val) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&closure_val);
         defer gc.popRoot();
 
         const result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
@@ -210,7 +210,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return PrimitiveError.TypeError;
     var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
     compiler_mod.Compiler.unrootFunction(gc, func);
-    gc.pushRoot(&closure_val) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&closure_val);
     defer gc.popRoot();
 
     const result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
@@ -263,12 +263,12 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
     const fd = std.c.open(path_z, .{});
     if (fd < 0) {
         var msg = gc.allocString("cannot open file") catch return PrimitiveError.OutOfMemory;
-        gc.pushRoot(&msg) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&msg);
         defer gc.popRoot();
         const irritant = args[0];
         const irritants = gc.allocPair(irritant, types.NIL) catch return PrimitiveError.OutOfMemory;
         var irritants_root = irritants;
-        gc.pushRoot(&irritants_root) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&irritants_root);
         defer gc.popRoot();
         const err_obj = gc.allocErrorObject(msg, irritants_root) catch return PrimitiveError.OutOfMemory;
         types.toObject(err_obj).as(types.ErrorObject).error_type = .file;
@@ -299,7 +299,7 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
         const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return PrimitiveError.TypeError;
         {
             var func_val = types.makePointer(@ptrCast(func));
-            gc.pushRoot(&func_val) catch return PrimitiveError.OutOfMemory;
+            gc.pushRoot(&func_val);
             defer gc.popRoot();
             compiler_mod.Compiler.unrootFunction(gc, func);
 
@@ -322,7 +322,7 @@ fn makeParameterFn(args: []const Value) PrimitiveError!Value {
     const converter: Value = if (args.len > 1) args[1] else types.NIL;
     // If converter provided, apply it to initial value
     var val = init;
-    gc.pushRoot(&val) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&val);
     defer gc.popRoot();
     if (converter != types.NIL) {
         const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM

--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -112,7 +112,7 @@ fn randomSourceStateRefFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const rs = try getRS("random-source-state-ref", args[0]);
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var i: usize = 4;
     while (i > 0) {

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -129,7 +129,7 @@ fn isTruthyResult(v: Value) bool {
 
 fn buildList(gc: *memory.GC, items: []const Value, tail: Value) PrimitiveError!Value {
     var result = tail;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var i = items.len;
     while (i > 0) {
@@ -183,7 +183,7 @@ fn foldFn(args: []const Value) PrimitiveError!Value {
     var acc = args[1];
     if (args.len < 3) return PrimitiveError.ArityMismatch;
 
-    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&acc);
     defer gc.popRoot();
 
     var iter = MultiListIter.init(args[2..], false);
@@ -231,7 +231,7 @@ fn foldRightFn(args: []const Value) PrimitiveError!Value {
 
     // Fold from right to left
     var acc = init;
-    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&acc);
     defer gc.popRoot();
     var call_args_buf: [257]Value = undefined;
     var idx = min_len;
@@ -257,7 +257,7 @@ fn reduceFn(args: []const Value) PrimitiveError!Value {
     if (!types.isPair(lst)) return primitives.typeError("reduce", "pair", lst);
 
     var acc = types.car(lst);
-    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&acc);
     defer gc.popRoot();
     lst = types.cdr(lst);
 
@@ -292,7 +292,7 @@ fn reduceRightFn(args: []const Value) PrimitiveError!Value {
     if (elems.items.len == 0) return ridentity;
 
     var acc = elems.items[elems.items.len - 1];
-    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&acc);
     defer gc.popRoot();
     var idx = elems.items.len - 1;
     while (idx > 0) {
@@ -378,7 +378,7 @@ fn partitionFn(args: []const Value) PrimitiveError!Value {
     }
 
     var yes_list = try buildList(gc, yes.items, types.NIL);
-    gc.pushRoot(&yes_list) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&yes_list);
     defer gc.popRoot();
     const no_list = try buildList(gc, no.items, types.NIL);
     const vals = [2]Value{ yes_list, no_list };
@@ -490,14 +490,14 @@ fn iotaFn(args: []const Value) PrimitiveError!Value {
         if (args.len > 2) step = primitives.toF64(args[2]) catch return primitives.typeError("iota", "number", args[2]);
 
         var result: Value = types.NIL;
-        gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&result);
         defer gc.popRoot();
         var i = cnt;
         while (i > 0) {
             i -= 1;
             const v = start + @as(f64, @floatFromInt(i)) * step;
             var fval = types.makeFlonum(v);
-            gc.pushRoot(&fval) catch return PrimitiveError.OutOfMemory;
+            gc.pushRoot(&fval);
             result = gc.allocPair(fval, result) catch {
                 gc.popRoot();
                 return PrimitiveError.OutOfMemory;
@@ -518,7 +518,7 @@ fn iotaFn(args: []const Value) PrimitiveError!Value {
         }
 
         var result: Value = types.NIL;
-        gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&result);
         defer gc.popRoot();
         var i = cnt;
         while (i > 0) {
@@ -570,7 +570,7 @@ fn concatenateFn(args: []const Value) PrimitiveError!Value {
     if (sublists.items.len == 0) return types.NIL;
 
     var result = sublists.items[sublists.items.len - 1];
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var idx = sublists.items.len - 1;
     while (idx > 0) {
@@ -962,7 +962,7 @@ fn consStarFn(args: []const Value) PrimitiveError!Value {
     if (args.len == 0) return PrimitiveError.ArityMismatch;
     if (args.len == 1) return args[0];
     var result = args[args.len - 1];
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var i = args.len - 1;
     while (i > 0) {
@@ -1000,7 +1000,7 @@ fn circularListFn(args: []const Value) PrimitiveError!Value {
     var first: Value = undefined;
     var last_pair: Value = undefined;
     first = gc.allocPair(args[0], types.NIL) catch return PrimitiveError.OutOfMemory;
-    gc.pushRoot(&first) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&first);
     defer gc.popRoot();
     last_pair = first;
     for (args[1..]) |a| {
@@ -1212,7 +1212,7 @@ fn splitAtFn(args: []const Value) PrimitiveError!Value {
     }
 
     var prefix = try buildList(gc, elems.items, types.NIL);
-    gc.pushRoot(&prefix) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&prefix);
     defer gc.popRoot();
     const vals = [2]Value{ prefix, current };
     return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
@@ -1258,7 +1258,7 @@ fn spanFn(args: []const Value) PrimitiveError!Value {
     }
 
     var prefix = try buildList(gc, elems.items, types.NIL);
-    gc.pushRoot(&prefix) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&prefix);
     defer gc.popRoot();
     const vals = [2]Value{ prefix, current };
     return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
@@ -1284,7 +1284,7 @@ fn breakFn(args: []const Value) PrimitiveError!Value {
     }
 
     var prefix = try buildList(gc, elems.items, types.NIL);
-    gc.pushRoot(&prefix) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&prefix);
     defer gc.popRoot();
     const vals = [2]Value{ prefix, current };
     return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
@@ -1436,7 +1436,7 @@ fn lsetAdjoinFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     var result = args[1];
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
 
     for (args[2..]) |elt| {
@@ -1455,7 +1455,7 @@ fn lsetUnionFn(args: []const Value) PrimitiveError!Value {
     if (list_count == 0) return types.NIL;
 
     var result = args[1];
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
 
     for (args[2..]) |lst| {
@@ -1481,7 +1481,7 @@ fn lsetXorFn(args: []const Value) PrimitiveError!Value {
     if (list_count == 1) return args[1];
 
     var result = args[1];
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
 
     for (args[2..]) |lst| {
@@ -1534,7 +1534,7 @@ fn unfoldFn(args: []const Value) PrimitiveError!Value {
     defer elems.deinit(gc.allocator);
     const roots_base = gc.extra_roots.items.len;
     defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
-    gc.pushRoot(&seed) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&seed);
     defer gc.popRoot();
 
     while (true) {
@@ -1567,9 +1567,9 @@ fn unfoldRightFn(args: []const Value) PrimitiveError!Value {
     const g = args[2];
     var seed = args[3];
     var result: Value = if (args.len > 4) args[4] else types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
-    gc.pushRoot(&seed) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&seed);
     defer gc.popRoot();
 
     while (true) {
@@ -1579,7 +1579,7 @@ fn unfoldRightFn(args: []const Value) PrimitiveError!Value {
 
         const map_args = [1]Value{seed};
         var val = try callVM(f, &map_args);
-        gc.pushRoot(&val) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&val);
         result = gc.allocPair(val, result) catch {
             gc.popRoot();
             return PrimitiveError.OutOfMemory;
@@ -1601,7 +1601,7 @@ fn appendReverseFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var current = args[0];
     var result = args[1];
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     while (current != types.NIL) {
         if (!types.isPair(current)) return primitives.typeError("append-reverse", "pair", current);
@@ -1677,7 +1677,7 @@ fn unzip2Fn(args: []const Value) PrimitiveError!Value {
     }
 
     var list1 = try buildList(gc, firsts.items, types.NIL);
-    gc.pushRoot(&list1) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&list1);
     defer gc.popRoot();
     const list2 = try buildList(gc, seconds.items, types.NIL);
     const vals = [2]Value{ list1, list2 };
@@ -1704,7 +1704,7 @@ fn pairFoldFn(args: []const Value) PrimitiveError!Value {
     var acc = args[1];
     if (args.len < 3) return PrimitiveError.ArityMismatch;
 
-    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&acc);
     defer gc.popRoot();
 
     var iter = MultiListIter.init(args[2..], true);
@@ -1742,7 +1742,7 @@ fn pairFoldRightFn(args: []const Value) PrimitiveError!Value {
     }
 
     var acc = init;
-    gc.pushRoot(&acc) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&acc);
     defer gc.popRoot();
     var call_args_buf: [257]Value = undefined;
     var idx = min_len;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -143,7 +143,7 @@ fn makeErrorWithType(error_type: types.ErrorObject.ErrorType, msg: []const u8, r
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
     var msg_root = message;
-    gc.pushRoot(&msg_root) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg_root);
     const err_val = gc.allocErrorObject(msg_root, types.NIL) catch {
         gc.popRoot();
         return PrimitiveError.OutOfMemory;

--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -378,7 +378,7 @@ fn stringToListFn(args: []const Value) PrimitiveError!Value {
     }
     // Build list from back
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var idx = range_count;
     while (idx > 0) {

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -279,7 +279,7 @@ fn stringSplitFn(args: []const Value) PrimitiveError!Value {
     if (delim.len == 0) {
         // Split into individual characters
         var result: Value = types.NIL;
-        gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&result);
         defer gc.popRoot();
         var byte_i = data.len;
         while (byte_i > 0) {
@@ -289,7 +289,7 @@ fn stringSplitFn(args: []const Value) PrimitiveError!Value {
                 start -= 1;
             }
             var str_val = gc.allocString(data[start..byte_i]) catch return PrimitiveError.OutOfMemory;
-            gc.pushRoot(&str_val) catch return PrimitiveError.OutOfMemory;
+            gc.pushRoot(&str_val);
             result = gc.allocPair(str_val, result) catch {
                 gc.popRoot();
                 return PrimitiveError.OutOfMemory;
@@ -315,10 +315,10 @@ fn stringSplitFn(args: []const Value) PrimitiveError!Value {
     }
 
     var str_val: Value = types.NIL;
-    gc.pushRoot(&str_val) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&str_val);
     defer gc.popRoot();
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var i = splits.items.len;
     while (i > 0) {
@@ -798,7 +798,7 @@ fn stringUnfoldFn(args: []const Value) PrimitiveError!Value {
     const f = args[1];
     const g = args[2];
     var seed = args[3];
-    gc.pushRoot(&seed) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&seed);
     defer gc.popRoot();
 
     var result: std.ArrayList(u8) = .empty;
@@ -837,7 +837,7 @@ fn stringUnfoldRightFn(args: []const Value) PrimitiveError!Value {
     const f = args[1];
     const g = args[2];
     var seed = args[3];
-    gc.pushRoot(&seed) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&seed);
     defer gc.popRoot();
 
     var chars: std.ArrayList(u21) = .empty;

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -128,7 +128,7 @@ fn vectorToListFn(args: []const Value) PrimitiveError!Value {
     const end = range.end;
 
     var result: Value = types.NIL;
-    gc.pushRoot(&result) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result);
     defer gc.popRoot();
     var i = end;
     while (i > start) {
@@ -869,7 +869,7 @@ fn vectorPartitionFn(args: []const Value) PrimitiveError!Value {
     @memcpy(combined[0..yes.items.len], yes.items);
     @memcpy(combined[yes.items.len..], no.items);
     var result_vec = gc.allocVector(combined) catch return PrimitiveError.OutOfMemory;
-    gc.pushRoot(&result_vec) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&result_vec);
     defer gc.popRoot();
     const count_val = types.makeFixnum(@intCast(yes.items.len));
 

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -53,7 +53,7 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
             // Pre-allocate a placeholder pair for circular references.
             // Root it so GC doesn't free it during the nested readDatum.
             var placeholder = self.gc.allocPair(types.VOID, types.NIL) catch return ReadError.OutOfMemory;
-            self.gc.pushRoot(&placeholder) catch return ReadError.OutOfMemory;
+            self.gc.pushRoot(&placeholder);
             self.labels[n] = placeholder;
             const datum = readDatum(self) catch |err| {
                 self.gc.popRoot();
@@ -92,7 +92,7 @@ fn readList(self: *Reader) ReadError!Value {
     const list_line = self.getLineCol().line;
     const first = try readDatum(self);
     var first_root = first;
-    try self.gc.pushRoot(&first_root);
+    self.gc.pushRoot(&first_root);
     defer self.gc.popRoot();
 
     try self.skipWhitespaceAndCommentsChecked();
@@ -101,7 +101,7 @@ fn readList(self: *Reader) ReadError!Value {
             self.pos += 1;
             const rest = try readDatum(self);
             var rest_root = rest;
-            try self.gc.pushRoot(&rest_root);
+            self.gc.pushRoot(&rest_root);
             defer self.gc.popRoot();
             try self.skipWhitespaceAndCommentsChecked();
             if (self.pos >= self.source.len or self.source[self.pos] != ')') {
@@ -116,7 +116,7 @@ fn readList(self: *Reader) ReadError!Value {
 
     const rest = try readListTail(self);
     var rest_root = rest;
-    try self.gc.pushRoot(&rest_root);
+    self.gc.pushRoot(&rest_root);
     defer self.gc.popRoot();
     const pair = self.gc.allocPair(first_root, rest_root) catch return ReadError.OutOfMemory;
     self.gc.source_lines.put(pair, list_line) catch {};
@@ -125,10 +125,10 @@ fn readList(self: *Reader) ReadError!Value {
 
 fn readListTail(self: *Reader) ReadError!Value {
     var result: Value = types.NIL;
-    try self.gc.pushRoot(&result);
+    self.gc.pushRoot(&result);
     defer self.gc.popRoot();
     var elem: Value = types.NIL;
-    try self.gc.pushRoot(&elem);
+    self.gc.pushRoot(&elem);
     defer self.gc.popRoot();
 
     var tail: Value = types.NIL;
@@ -177,17 +177,17 @@ fn readListTail(self: *Reader) ReadError!Value {
 fn readAbbreviation(self: *Reader, keyword: []const u8) ReadError!Value {
     const datum = try readDatum(self);
     var datum_root = datum;
-    try self.gc.pushRoot(&datum_root);
+    self.gc.pushRoot(&datum_root);
     defer self.gc.popRoot();
 
     const sym = self.gc.allocSymbol(keyword) catch return ReadError.OutOfMemory;
     var sym_root = sym;
-    try self.gc.pushRoot(&sym_root);
+    self.gc.pushRoot(&sym_root);
     defer self.gc.popRoot();
 
     const rest = self.gc.allocPair(datum_root, types.NIL) catch return ReadError.OutOfMemory;
     var rest_root = rest;
-    try self.gc.pushRoot(&rest_root);
+    self.gc.pushRoot(&rest_root);
     defer self.gc.popRoot();
     return self.gc.allocPair(sym_root, rest_root) catch return ReadError.OutOfMemory;
 }

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -615,11 +615,7 @@ pub fn repl(vm: *vm_mod.VM) !void {
             defer ir.deinit();
             var import_list = types.NIL;
             var import_root = import_list;
-            vm.gc.pushRoot(&import_root) catch {
-                writeStderr("out of memory\n");
-                input_buf.clearRetainingCapacity();
-                continue;
-            };
+            vm.gc.pushRoot(&import_root);
             var read_ok = true;
             while (ir.hasMore() catch false) {
                 var datum = ir.readDatum() catch {
@@ -627,11 +623,7 @@ pub fn repl(vm: *vm_mod.VM) !void {
                     read_ok = false;
                     break;
                 };
-                vm.gc.pushRoot(&datum) catch {
-                    writeStderr("out of memory\n");
-                    read_ok = false;
-                    break;
-                };
+                vm.gc.pushRoot(&datum);
                 var pair = vm.gc.allocPair(datum, types.NIL) catch {
                     vm.gc.popRoot();
                     writeStderr("out of memory\n");
@@ -949,10 +941,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
             break;
         };
 
-        vm.gc.pushRoot(&expr) catch {
-            writeStderr("error: out of memory while rooting expression\n");
-            break;
-        };
+        vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |top_result| {
@@ -998,10 +987,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
         };
 
         var func_val = types.makePointer(@ptrCast(func));
-        vm.gc.pushRoot(&func_val) catch {
-            writeStderr("error: out of memory while rooting function\n");
-            break;
-        };
+        vm.gc.pushRoot(&func_val);
 
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -220,14 +220,8 @@ pub export fn kaappi_cons(a: u64, b: u64) callconv(.c) u64 {
     };
     var val_a = a;
     var val_b = b;
-    gc.pushRoot(&val_a) catch {
-        _ = std.posix.system.write(2, "OOM: cons push root failed\n", 27);
-        std.process.exit(1);
-    };
-    gc.pushRoot(&val_b) catch {
-        _ = std.posix.system.write(2, "OOM: cons push root failed\n", 27);
-        std.process.exit(1);
-    };
+    gc.pushRoot(&val_a);
+    gc.pushRoot(&val_b);
     const result = gc.allocPair(val_a, val_b) catch {
         _ = std.posix.system.write(2, "OOM: failed to allocate pair\n", 29);
         std.process.exit(1);
@@ -261,10 +255,7 @@ pub export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]con
 
 pub export fn kaappi_gc_push_root(slot: *Value) callconv(.c) void {
     const gc = memory.gc_instance orelse return;
-    gc.pushRoot(slot) catch {
-        _ = std.posix.system.write(2, "OOM: GC push root failed\n", 25);
-        std.process.exit(1);
-    };
+    gc.pushRoot(slot);
 }
 
 pub export fn kaappi_gc_pop_roots(n: u64) callconv(.c) void {

--- a/src/tests_bytecode_cache.zig
+++ b/src/tests_bytecode_cache.zig
@@ -85,7 +85,7 @@ test "bytecode cache: deserialized top-level functions survive a mid-run GC" {
     // The round-tripped bytecode executes and returns each constant.
     for (loaded.funcs[0..loaded.top_level_count], want) |func, w| {
         var fv = types.makePointer(@ptrCast(func));
-        try gc.pushRoot(&fv);
+        gc.pushRoot(&fv);
         defer gc.popRoot();
         const r = try vm.execute(func);
         try std.testing.expect(types.isFixnum(r));
@@ -103,7 +103,7 @@ test "bytecode cache: deserialized top-level functions survive a mid-run GC" {
     // ...and they remain executable after the collection.
     for (loaded.funcs[0..loaded.top_level_count], want) |func, w| {
         var fv = types.makePointer(@ptrCast(func));
-        try gc.pushRoot(&fv);
+        gc.pushRoot(&fv);
         defer gc.popRoot();
         const r = try vm.execute(func);
         try std.testing.expect(types.isFixnum(r));
@@ -158,7 +158,7 @@ fn expectSbcEquivalence(source: []const u8) !void {
     var result: types.Value = types.VOID;
     for (loaded.funcs[0..loaded.top_level_count]) |func| {
         var fv = types.makePointer(@ptrCast(func));
-        try gc2.pushRoot(&fv);
+        gc2.pushRoot(&fv);
         defer gc2.popRoot();
         result = try vm2.execute(func);
     }

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -72,7 +72,7 @@ test "deepCopy long flat list does not overflow the stack (issue #801)" {
     // cdr-spine recursion in deepCopyValue crashed the process here.
     const n: i64 = 200_000;
     var lst = types.NIL;
-    try gc1.pushRoot(&lst); // keep the partial list alive across collections
+    gc1.pushRoot(&lst); // keep the partial list alive across collections
     defer gc1.popRoot();
     var i: i64 = n - 1;
     while (i >= 0) : (i -= 1) {
@@ -106,7 +106,7 @@ test "deepCopy long improper list preserves the tail (issue #801)" {
     // "immediate cdr" break path at depth.
     const n: i64 = 100_000;
     var lst = types.makeFixnum(-1);
-    try gc1.pushRoot(&lst);
+    gc1.pushRoot(&lst);
     defer gc1.popRoot();
     var i: i64 = n - 1;
     while (i >= 0) : (i -= 1) {

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -351,11 +351,11 @@ test "root stack symmetry after compile errors" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    const roots_before = gc.roots.items.len;
+    const roots_before = gc.root_count;
     for (0..25) |_| {
         const result = vm.eval("(if 1)");
         try std.testing.expectError(th.VMError.CompileError, result);
-        try std.testing.expectEqual(roots_before, gc.roots.items.len);
+        try std.testing.expectEqual(roots_before, gc.root_count);
     }
 }
 
@@ -365,11 +365,11 @@ test "root stack symmetry after raised exceptions" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    const roots_before = gc.roots.items.len;
+    const roots_before = gc.root_count;
     for (0..25) |_| {
         const result = vm.eval("(raise 42)");
         try std.testing.expectError(th.VMError.ExceptionRaised, result);
-        try std.testing.expectEqual(roots_before, gc.roots.items.len);
+        try std.testing.expectEqual(roots_before, gc.root_count);
     }
 }
 
@@ -483,7 +483,7 @@ test "macro expansion limit returns compile error deterministically" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    const roots_before = gc.roots.items.len;
+    const roots_before = gc.root_count;
     const result = vm.eval(
         \\(define-syntax loop
         \\  (syntax-rules ()
@@ -491,5 +491,5 @@ test "macro expansion limit returns compile error deterministically" {
         \\(loop)
     );
     try std.testing.expectError(th.VMError.CompileError, result);
-    try std.testing.expectEqual(roots_before, gc.roots.items.len);
+    try std.testing.expectEqual(roots_before, gc.root_count);
 }

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -91,7 +91,7 @@ pub fn invokeEscape(vm: *VM, cont: *types.Continuation, value: Value) VMError!vo
         // Invoked after its call/ec call already returned — no live target.
         var msg = vm.gc.allocString("escape continuation invoked outside its dynamic extent") catch
             return VMError.OutOfMemory;
-        try vm.gc.pushRoot(&msg);
+        vm.gc.pushRoot(&msg);
         const err = vm.gc.allocErrorObject(msg, types.NIL) catch {
             vm.gc.popRoot();
             return VMError.OutOfMemory;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -62,7 +62,7 @@ fn maybeRewindRetry(self: *VM, instr_len: usize) void {
 noinline fn raiseDeadNativeReturn(self: *VM) VMError {
     var msg = self.gc.allocString("continuation cannot resume across a returned native call") catch
         return VMError.OutOfMemory;
-    self.gc.pushRoot(&msg) catch return VMError.OutOfMemory;
+    self.gc.pushRoot(&msg);
     const err_obj = self.gc.allocErrorObject(msg, types.NIL) catch {
         self.gc.popRoot();
         return VMError.OutOfMemory;
@@ -771,7 +771,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const src = readU16(self, frame);
                 const src_idx = try registerIndex(self, frame.base, src);
                 var result = self.registers[src_idx];
-                self.gc.pushRoot(&result) catch return VMError.OutOfMemory;
+                self.gc.pushRoot(&result);
                 defer self.gc.popRoot();
                 const return_dst = frame.dst;
                 const from_native_call = frame.returns_to_native;
@@ -817,7 +817,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const func = types.toObject(func_val).as(types.Function);
 
                 var cls_val = self.gc.allocClosure(func) catch return VMError.OutOfMemory;
-                self.gc.pushRoot(&cls_val) catch return VMError.OutOfMemory;
+                self.gc.pushRoot(&cls_val);
                 var cls = types.toObject(cls_val).as(types.Closure);
 
                 for (cls.upvalues, 0..) |_, i| {
@@ -1272,7 +1272,7 @@ inline fn lookupGlobalLocked(self: *VM, env: *std.StringHashMap(Value), name: []
 
 pub fn buildRestList(gc: *memory.GC, args: []const Value) VMError!Value {
     var rest_list: Value = types.NIL;
-    gc.pushRoot(&rest_list) catch return VMError.OutOfMemory;
+    gc.pushRoot(&rest_list);
     var i: usize = args.len;
     while (i > 0) {
         i -= 1;

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -18,7 +18,7 @@ pub fn eval(vm: *VM, source: []const u8) VMError!Value {
         var expr = reader.readDatum() catch return VMError.CompileError;
         // Root the form: evaluating it (e.g. an import that loads a library)
         // can trigger GC, which would otherwise reclaim the AST mid-walk.
-        vm.gc.pushRoot(&expr) catch return VMError.OutOfMemory;
+        vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
         if (handleTopLevelForm(vm, expr)) |result| {
             last_result = result catch |err| return err;
@@ -27,7 +27,7 @@ pub fn eval(vm: *VM, source: []const u8) VMError!Value {
         const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return VMError.CompileError;
         {
             var func_val = types.makePointer(@ptrCast(func));
-            vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
+            vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             last_result = vm.execute(func) catch |err| return err;
@@ -47,7 +47,7 @@ pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
     // this datum, and most callers pass a freshly read, unrooted expr. Without
     // this, the import form itself can be swept mid-walk (issue #1010).
     var expr_root = expr;
-    vm.gc.pushRoot(&expr_root) catch return VMError.OutOfMemory;
+    vm.gc.pushRoot(&expr_root);
     defer vm.gc.popRoot();
 
     if (std.mem.eql(u8, name, "import")) return vm_library.handleImport(vm, types.cdr(expr));
@@ -73,7 +73,7 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
         } else {
             const func = compiler_mod.compileExpressionWithMacros(vm.gc, form, &vm.macros, vm.globals) catch return VMError.CompileError;
             var func_val = types.makePointer(@ptrCast(func));
-            vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
+            vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             last = vm.execute(func) catch |err| return err;
@@ -86,7 +86,7 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
 fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
     if (!types.isPair(args)) return VMError.CompileError;
     var formals = types.car(args);
-    vm.gc.pushRoot(&formals) catch return VMError.OutOfMemory;
+    vm.gc.pushRoot(&formals);
     defer vm.gc.popRoot();
     const rest = types.cdr(args);
     if (!types.isPair(rest)) return VMError.CompileError;
@@ -94,7 +94,7 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
 
     const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return VMError.CompileError;
     var func_val = types.makePointer(@ptrCast(func));
-    vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
+    vm.gc.pushRoot(&func_val);
     defer vm.gc.popRoot();
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
     const result = vm.execute(func) catch |err| return err;
@@ -104,10 +104,10 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
         if (types.isSymbol(formals)) {
             // (define-values x (values 1 2 3)) → x = (1 2 3)
             var result_root = result;
-            vm.gc.pushRoot(&result_root) catch return VMError.OutOfMemory;
+            vm.gc.pushRoot(&result_root);
             defer vm.gc.popRoot();
             var list: Value = types.NIL;
-            vm.gc.pushRoot(&list) catch return VMError.OutOfMemory;
+            vm.gc.pushRoot(&list);
             defer vm.gc.popRoot();
             const mv2 = types.toObject(result_root).as(types.MultipleValues);
             var j: usize = mv2.values.len;
@@ -125,10 +125,10 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
                     // Rest parameter: (define-values (a b . rest) ...)
                     has_rest = true;
                     var result_root = result;
-                    vm.gc.pushRoot(&result_root) catch return VMError.OutOfMemory;
+                    vm.gc.pushRoot(&result_root);
                     defer vm.gc.popRoot();
                     var rest_list: Value = types.NIL;
-                    vm.gc.pushRoot(&rest_list) catch return VMError.OutOfMemory;
+                    vm.gc.pushRoot(&rest_list);
                     defer vm.gc.popRoot();
                     const mv2 = types.toObject(result_root).as(types.MultipleValues);
                     var j: usize = mv2.values.len;
@@ -157,7 +157,7 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
         if (types.isSymbol(formals)) {
             // (define-values x expr) → x = (result)
             var result_root = result;
-            vm.gc.pushRoot(&result_root) catch return VMError.OutOfMemory;
+            vm.gc.pushRoot(&result_root);
             defer vm.gc.popRoot();
             const list = vm.gc.allocPair(result_root, types.NIL) catch return VMError.OutOfMemory;
             vm.defineGlobal(types.symbolName(formals), list) catch return VMError.OutOfMemory;

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -256,7 +256,7 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
 
     while (rdr.hasMore() catch return error.InvalidSyntax) {
         var expr = rdr.readDatum() catch return error.InvalidSyntax;
-        vm.gc.pushRoot(&expr) catch return error.OutOfMemory;
+        vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
         if (vm.handleTopLevelForm(expr)) |result| {
@@ -264,7 +264,7 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
         } else {
             const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return error.InvalidSyntax;
             var func_val = types.makePointer(@ptrCast(func));
-            try vm.gc.pushRoot(&func_val);
+            vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = try vm.execute(func);
@@ -565,7 +565,7 @@ pub fn handleTopLevelInclude(vm: *VM, args: Value, ci: bool) VMError!Value {
     // trigger GC, which would otherwise reclaim the pair list and filename
     // strings we are still walking.
     var file_list = args;
-    vm.gc.pushRoot(&file_list) catch return VMError.OutOfMemory;
+    vm.gc.pushRoot(&file_list);
     defer vm.gc.popRoot();
 
     while (file_list != types.NIL) {
@@ -628,10 +628,7 @@ fn evalIncludedForm(vm: *VM, expr: Value, path: []const u8, line: u32) void {
         collect.append(vm.gc.allocator, func) catch {};
     }
     var func_val = types.makePointer(@ptrCast(func));
-    vm.gc.pushRoot(&func_val) catch {
-        reportIncludeError(vm, path, line, null, error.OutOfMemory);
-        return;
-    };
+    vm.gc.pushRoot(&func_val);
     defer vm.gc.popRoot();
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
     _ = vm.execute(func) catch |err| {
@@ -798,7 +795,7 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
 
     // Root the AST so it survives GC during nested library loading
     // (e.g. when (import (srfi 35)) triggers loading a .sld file).
-    vm.gc.pushRoot(&decls) catch return VMError.OutOfMemory;
+    vm.gc.pushRoot(&decls);
     defer vm.gc.popRoot();
 
     const lib_name = library_mod.libraryNameToString(vm.gc.allocator, name_list) catch return VMError.CompileError;
@@ -927,7 +924,7 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
         collect.append(vm.gc.allocator, func) catch return VMError.OutOfMemory;
     }
     var func_val = types.makePointer(@ptrCast(func));
-    vm.gc.pushRoot(&func_val) catch return VMError.OutOfMemory;
+    vm.gc.pushRoot(&func_val);
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
     defer vm.gc.popRoot();
     _ = try vm.execute(func);
@@ -1066,7 +1063,7 @@ fn includeLibraryDeclarations(
 
         while (file_reader.hasMore() catch return VMError.CompileError) {
             var declaration = file_reader.readDatum() catch return VMError.CompileError;
-            vm.gc.pushRoot(&declaration) catch return VMError.CompileError;
+            vm.gc.pushRoot(&declaration);
             defer vm.gc.popRoot();
             try processLibDeclaration(vm, lib_env, declaration, export_names, export_renames);
         }

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -94,7 +94,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
 
     // Create the RecordType value
     var rt_val = vm.gc.allocRecordType(type_name, num_fields) catch return VMError.OutOfMemory;
-    vm.gc.pushRoot(&rt_val) catch return VMError.OutOfMemory;
+    vm.gc.pushRoot(&rt_val);
     defer vm.gc.popRoot();
 
     // Store in a global with an internal name (space prefix prevents user access)
@@ -163,7 +163,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         }
 
         var body_list = vm.gc.makeList(body_args[0 .. 2 + all_field_count]) catch return VMError.OutOfMemory;
-        vm.gc.pushRoot(&body_list) catch return VMError.OutOfMemory;
+        vm.gc.pushRoot(&body_list);
         defer vm.gc.popRoot();
 
         // Build parameter list
@@ -208,7 +208,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         const name_and_params = vm.gc.makeList(&[_]Value{ pred_sym, v_sym }) catch return VMError.OutOfMemory;
         var define_expr = vm.gc.makeList(&[_]Value{ define_sym, name_and_params, body }) catch return VMError.OutOfMemory;
         vm.gc.no_collect -= 1;
-        vm.gc.pushRoot(&define_expr) catch return VMError.OutOfMemory;
+        vm.gc.pushRoot(&define_expr);
         defer vm.gc.popRoot();
 
         const func = if (vm.current_lib_env) |env|
@@ -236,7 +236,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const name_and_params = vm.gc.makeList(&[_]Value{ acc_sym, p_sym }) catch return VMError.OutOfMemory;
             var define_expr = vm.gc.makeList(&[_]Value{ define_sym, name_and_params, body }) catch return VMError.OutOfMemory;
             vm.gc.no_collect -= 1;
-            vm.gc.pushRoot(&define_expr) catch return VMError.OutOfMemory;
+            vm.gc.pushRoot(&define_expr);
             defer vm.gc.popRoot();
 
             const func = if (vm.current_lib_env) |env|
@@ -263,7 +263,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const name_and_params = vm.gc.makeList(&[_]Value{ mut_sym, p_sym, v_sym }) catch return VMError.OutOfMemory;
             var define_expr = vm.gc.makeList(&[_]Value{ define_sym, name_and_params, body }) catch return VMError.OutOfMemory;
             vm.gc.no_collect -= 1;
-            vm.gc.pushRoot(&define_expr) catch return VMError.OutOfMemory;
+            vm.gc.pushRoot(&define_expr);
             defer vm.gc.popRoot();
 
             const func = if (vm.current_lib_env) |env|


### PR DESCRIPTION
## Summary

- **arg_roots buffer**: `allocXxx` functions that take Value arguments now root them internally via a fixed `[4]Value` buffer before `maybeCollect()`, eliminating the structural cause of the recurring "unrooted fresh value" bug class (#1010, #1013, #1027)
- **Infallible pushRoot**: replaced the growable `ArrayList(*Value)` with a fixed `[1024]*Value` buffer — `pushRoot` is now `void` (panics on overflow), removing ~181 `catch return`/`try` noise sites across 35 files
- **GC stress mode**: `-Dgc-stress=true` forces `collect()` on every `maybeCollect()` call regardless of threshold growth; in Debug builds, freed objects are poisoned with `0xAA` to surface use-after-free immediately

## Test plan

- [x] `zig build test` — 602/602 unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1702/1702 Scheme tests pass (307 files + 1395 R7RS)
- [x] `zig build test -Dgc-stress=true` — stress mode exposes pre-existing unrooted-value bugs (expected; validates the harness works)
- [ ] CI passes on all platforms (macOS ARM, Linux x86_64, Linux ARM, RISC-V)
- [ ] Benchmark gate: no regression on alloc hot path (arg_roots adds 2-3 word stores per allocation)

Supersedes #1124. Closes #1045

🤖 Generated with [Claude Code](https://claude.com/claude-code)