### PR TITLE
Centralize LLVM native/eval-fallback boundary in one comptime table (#1068)

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -45,6 +45,107 @@ pub const NodeTag = enum {
     passthrough,
 };
 
+pub const LLVMCapability = enum { native, eval_fallback };
+
+pub const LLVMNodeEntry = struct {
+    tag: NodeTag,
+    capability: LLVMCapability,
+    form_name: ?[]const u8 = null,
+    include_in_name_set: bool = true,
+};
+
+pub const llvm_node_table: [34]LLVMNodeEntry = .{
+    .{ .tag = .constant, .capability = .native },
+    .{ .tag = .global_ref, .capability = .native },
+    .{ .tag = .call, .capability = .native },
+    .{ .tag = .@"if", .capability = .native },
+    .{ .tag = .begin, .capability = .native },
+    .{ .tag = .and_form, .capability = .native },
+    .{ .tag = .or_form, .capability = .native },
+    .{ .tag = .when_form, .capability = .native },
+    .{ .tag = .unless_form, .capability = .native },
+    .{ .tag = .define, .capability = .native },
+    .{ .tag = .set_form, .capability = .native },
+    .{ .tag = .lambda, .capability = .native },
+    .{ .tag = .let_form, .capability = .native, .form_name = "let" },
+    .{ .tag = .let_star, .capability = .native, .form_name = "let*" },
+    .{ .tag = .letrec, .capability = .eval_fallback, .form_name = "letrec" },
+    .{ .tag = .letrec_star, .capability = .eval_fallback, .form_name = "letrec*" },
+    .{ .tag = .do_form, .capability = .eval_fallback, .form_name = "do" },
+    .{ .tag = .delay, .capability = .eval_fallback, .form_name = "delay" },
+    .{ .tag = .delay_force, .capability = .eval_fallback, .form_name = "delay-force" },
+    .{ .tag = .cond, .capability = .eval_fallback, .form_name = "cond" },
+    .{ .tag = .case_form, .capability = .eval_fallback, .form_name = "case" },
+    .{ .tag = .case_lambda, .capability = .eval_fallback, .form_name = "case-lambda" },
+    .{ .tag = .guard, .capability = .eval_fallback, .form_name = "guard" },
+    .{ .tag = .quasiquote, .capability = .eval_fallback, .form_name = "quasiquote" },
+    .{ .tag = .parameterize, .capability = .eval_fallback, .form_name = "parameterize" },
+    .{ .tag = .define_values, .capability = .eval_fallback, .form_name = "define-values" },
+    .{ .tag = .let_values, .capability = .eval_fallback, .form_name = "let-values" },
+    .{ .tag = .let_star_values, .capability = .eval_fallback, .form_name = "let*-values" },
+    .{ .tag = .define_syntax, .capability = .eval_fallback, .form_name = "define-syntax" },
+    .{ .tag = .named_let, .capability = .eval_fallback, .form_name = "let", .include_in_name_set = false },
+    .{ .tag = .let_syntax, .capability = .eval_fallback, .form_name = "let-syntax" },
+    .{ .tag = .letrec_syntax, .capability = .eval_fallback, .form_name = "letrec-syntax" },
+    .{ .tag = .cond_expand, .capability = .eval_fallback, .form_name = "cond-expand" },
+    .{ .tag = .passthrough, .capability = .native },
+};
+
+const eval_fallback_name_count = countEvalFallbackNames();
+
+fn countEvalFallbackNames() usize {
+    var count: usize = 0;
+    for (llvm_node_table) |entry| {
+        if (entry.capability == .eval_fallback and entry.include_in_name_set and entry.form_name != null)
+            count += 1;
+    }
+    return count;
+}
+
+pub const eval_fallback_form_names: [eval_fallback_name_count][]const u8 = blk: {
+    var names: [eval_fallback_name_count][]const u8 = undefined;
+    var i: usize = 0;
+    for (llvm_node_table) |entry| {
+        if (entry.capability == .eval_fallback and entry.include_in_name_set) {
+            if (entry.form_name) |name| {
+                names[i] = name;
+                i += 1;
+            }
+        }
+    }
+    break :blk names;
+};
+
+pub fn llvmCapability(tag: NodeTag) LLVMCapability {
+    for (llvm_node_table) |entry| {
+        if (entry.tag == tag) return entry.capability;
+    }
+    unreachable;
+}
+
+pub fn llvmFormName(tag: NodeTag) ?[]const u8 {
+    for (llvm_node_table) |entry| {
+        if (entry.tag == tag) return entry.form_name;
+    }
+    return null;
+}
+
+comptime {
+    const fields = @typeInfo(NodeTag).@"enum".fields;
+    if (llvm_node_table.len != fields.len)
+        @compileError("llvm_node_table must have exactly one entry per NodeTag");
+    var seen: [fields.len]bool = .{false} ** fields.len;
+    for (llvm_node_table) |entry| {
+        const idx = @intFromEnum(entry.tag);
+        if (seen[idx])
+            @compileError("duplicate tag in llvm_node_table");
+        seen[idx] = true;
+    }
+    for (seen) |s| {
+        if (!s) @compileError("missing tag in llvm_node_table");
+    }
+}
+
 pub const Annotations = struct {
     is_tail: bool = false,
     is_primitive_call: bool = false,

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -180,11 +180,14 @@ pub const LLVMEmitter = struct {
             .lambda => try self.emitLambda(node.data.lambda),
             .let_form => try self.emitLet(node.data.let_form.args, false, node.ann.is_tail),
             .let_star => try self.emitLet(node.data.let_star.args, true, node.ann.is_tail),
-            .letrec, .letrec_star, .named_let => try self.emitSexprEval(node),
-            .do_form, .delay, .delay_force, .cond, .case_form, .case_lambda, .guard => try self.emitSexprEval(node),
-            .quasiquote, .parameterize, .define_values, .let_values, .let_star_values => try self.emitSexprEval(node),
-            .define_syntax, .let_syntax, .letrec_syntax, .cond_expand => try self.emitSexprEval(node),
             .passthrough => try self.emitPassthrough(node.data.passthrough),
+            inline else => |tag| {
+                comptime {
+                    if (ir.llvmCapability(tag) != .eval_fallback)
+                        @compileError("unhandled native tag in emitNode: " ++ @tagName(tag));
+                }
+                return try self.emitSexprEval(node);
+            },
         };
     }
 
@@ -825,54 +828,25 @@ pub const LLVMEmitter = struct {
     }
 
     fn emitSexprEval(self: *LLVMEmitter, node: *const ir.Node) EmitError![]const u8 {
-        const args = switch (node.tag) {
-            .let_form => node.data.let_form.args,
-            .let_star => node.data.let_star.args,
-            .letrec => node.data.letrec.args,
-            .letrec_star => node.data.letrec_star.args,
-            .named_let => node.data.named_let.args,
-            .do_form => node.data.do_form.args,
-            .delay => node.data.delay.args,
-            .delay_force => node.data.delay_force.args,
-            .cond => node.data.cond.args,
-            .case_form => node.data.case_form.args,
-            .case_lambda => node.data.case_lambda.args,
-            .guard => node.data.guard.args,
-            .quasiquote => node.data.quasiquote.args,
-            .parameterize => node.data.parameterize.args,
-            .define_values => node.data.define_values.args,
-            .let_values => node.data.let_values.args,
-            .let_star_values => node.data.let_star_values.args,
-            .define_syntax => node.data.define_syntax.args,
-            .let_syntax => node.data.let_syntax.args,
-            .letrec_syntax => node.data.letrec_syntax.args,
-            .cond_expand => node.data.cond_expand.args,
-            else => return error.UnsupportedNodeType,
+        const args: Value = switch (node.tag) {
+            .constant,
+            .global_ref,
+            .call,
+            .@"if",
+            .begin,
+            .and_form,
+            .or_form,
+            .when_form,
+            .unless_form,
+            .define,
+            .set_form,
+            .lambda,
+            .passthrough,
+            => return error.UnsupportedNodeType,
+            inline else => |tag| @field(@field(node.data, @tagName(tag)), "args"),
         };
-        const form_name = switch (node.tag) {
-            .let_form => "let",
-            .let_star => "let*",
-            .letrec => "letrec",
-            .letrec_star => "letrec*",
-            .named_let => "let",
-            .do_form => "do",
-            .delay => "delay",
-            .delay_force => "delay-force",
-            .cond => "cond",
-            .case_form => "case",
-            .case_lambda => "case-lambda",
-            .guard => "guard",
-            .quasiquote => "quasiquote",
-            .parameterize => "parameterize",
-            .define_values => "define-values",
-            .let_values => "let-values",
-            .let_star_values => "let*-values",
-            .define_syntax => "define-syntax",
-            .let_syntax => "let-syntax",
-            .letrec_syntax => "letrec-syntax",
-            .cond_expand => "cond-expand",
-            else => return error.UnsupportedNodeType,
-        };
+        const form_name: []const u8 = ir.llvmFormName(node.tag) orelse
+            return error.UnsupportedNodeType;
 
         try lambda.bindParamsAsGlobals(self);
 

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -476,15 +476,7 @@ pub fn sexprNeedsEvalFallback(expr: Value) bool {
 }
 
 fn isEvalFallbackForm(name: []const u8) bool {
-    const forms = [_][]const u8{
-        "letrec",     "letrec*",       "do",
-        "delay",      "delay-force",   "cond",
-        "case",       "case-lambda",   "guard",
-        "quasiquote", "parameterize",  "define-values",
-        "let-values", "let*-values",   "define-syntax",
-        "let-syntax", "letrec-syntax", "cond-expand",
-    };
-    for (forms) |f| {
+    for (ir.eval_fallback_form_names) |f| {
         if (std.mem.eql(u8, name, f)) return true;
     }
     return false;
@@ -650,7 +642,14 @@ fn nodeHasFreeVars(node: *const ir.Node, params: []const []const u8) bool {
         // global. Disqualify and fall back to the interpreter.
         .define => return true,
         .constant => return false,
-        else => return false,
+        .lambda, .passthrough, .let_form, .let_star => return false,
+        inline else => |tag| {
+            comptime {
+                if (ir.llvmCapability(tag) != .eval_fallback)
+                    @compileError("unhandled native tag in nodeHasFreeVars: " ++ @tagName(tag));
+            }
+            return false;
+        },
     }
 }
 
@@ -712,6 +711,12 @@ fn collectNodeFreeVars(node: *const ir.Node, params: []const []const u8, buf: *[
             collectNodeFreeVars(node.data.unless_form.test_expr, params, buf, count);
             collectFreeVars(node.data.unless_form.body, params, buf, count);
         },
-        else => {},
+        .constant, .define, .set_form, .lambda, .passthrough, .let_form, .let_star => {},
+        inline else => |tag| {
+            comptime {
+                if (ir.llvmCapability(tag) != .eval_fallback)
+                    @compileError("unhandled native tag in collectNodeFreeVars: " ++ @tagName(tag));
+            }
+        },
     }
 }


### PR DESCRIPTION
## Summary

- Adds a single `llvm_node_table` in `ir.zig` mapping every `NodeTag` to `{ .native, .eval_fallback }` with its Scheme-level form name, validated at comptime (one entry per tag, no duplicates, no gaps)
- Replaces four unsynchronized classification sites with table-derived dispatch: `emitNode`, `emitSexprEval`, `isEvalFallbackForm`, `nodeHasFreeVars`/`collectNodeFreeVars`
- Adding a new `NodeTag` without classifying it in the table is now a compile error instead of a silent miscompile (#827-class bugs)

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail
- [x] All `tests/scheme/compile/*.sh` — LLVM backend regression tests pass (set-define-lexical-scope-819, native-rebind-stale-call-822, native-gc-roots-1034, native-param-shadow-fold-790)

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)