### PR TITLE
Delete dead identifyPrimitives/markConstants IR passes (#1041)

### DIFF
--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -25,7 +25,7 @@ pub fn compileFromNode(self: *Compiler, node: *ir_mod.Node, dst: u16, is_tail: b
     switch (node.tag) {
         .constant => try self.emitLoadValue(dst, node.data.constant),
         .global_ref => try self.compileVariable(node.data.global_ref, dst),
-        .call => try compileCallFromIR(self, node.data.call, dst, tail, node.ann.is_primitive_call),
+        .call => try compileCallFromIR(self, node.data.call, dst, tail),
         .@"if" => try compileIfFromIR(self, node.data.@"if", dst, tail),
         .begin => try compileBeginFromIR(self, node.data.begin, dst, tail),
         .and_form => try compileAndFromIR(self, node.data.and_form, dst, tail),
@@ -97,8 +97,7 @@ fn compileBeginFromIR(self: *Compiler, exprs: []const *ir_mod.Node, dst: u16, is
     }
 }
 
-fn compileCallFromIR(self: *Compiler, call: ir_mod.CallData, dst: u16, is_tail: bool, is_primitive: bool) CompileError!void {
-    _ = is_primitive;
+fn compileCallFromIR(self: *Compiler, call: ir_mod.CallData, dst: u16, is_tail: bool) CompileError!void {
     if (call.args.len > 255) return CompileError.InternalLimit;
     const nargs: u8 = @intCast(call.args.len);
 

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -47,9 +47,6 @@ pub const NodeTag = enum {
 
 pub const Annotations = struct {
     is_tail: bool = false,
-    is_primitive_call: bool = false,
-    primitive_name: ?[]const u8 = null,
-    is_constant: bool = false,
     source_line: u32 = 0,
 };
 
@@ -493,8 +490,6 @@ pub fn lowerAndOptimize(
 ) CompileError!*Node {
     var node = try lowerWithMacros(ir_instance, expr, macros);
     markTailPositions(node, is_tail);
-    identifyPrimitives(node);
-    markConstants(node);
     node = foldConstants(ir_instance, node);
     node = eliminateDeadBranches(ir_instance, node);
     node = simplifyBooleans(ir_instance, node);
@@ -799,148 +794,6 @@ const primitives = [_][]const u8{
     "raise",          "raise-continuable", "error",        "for-each",                      "string-for-each",  "vector-for-each", "vector-map",
     "string-map",     "assoc",             "assq",         "assv",                          "member",           "memq",            "memv",
 };
-
-pub fn identifyPrimitives(node: *Node) void {
-    switch (node.tag) {
-        .call => {
-            if (node.data.call.operator.tag == .global_ref) {
-                const sym = node.data.call.operator.data.global_ref;
-                if (types.isSymbol(sym)) {
-                    const name = types.symbolName(sym);
-                    for (primitives) |p| {
-                        if (std.mem.eql(u8, name, p)) {
-                            node.ann.is_primitive_call = true;
-                            node.ann.primitive_name = name;
-                            break;
-                        }
-                    }
-                }
-            }
-            identifyPrimitives(node.data.call.operator);
-            for (node.data.call.args) |arg| identifyPrimitives(arg);
-        },
-        .@"if" => {
-            identifyPrimitives(node.data.@"if".test_expr);
-            identifyPrimitives(node.data.@"if".consequent);
-            if (node.data.@"if".alternate) |alt| identifyPrimitives(alt);
-        },
-        .begin => {
-            for (node.data.begin) |expr| identifyPrimitives(expr);
-        },
-        .and_form => {
-            for (node.data.and_form) |expr| identifyPrimitives(expr);
-        },
-        .or_form => {
-            for (node.data.or_form) |expr| identifyPrimitives(expr);
-        },
-        .when_form => {
-            identifyPrimitives(node.data.when_form.test_expr);
-            for (node.data.when_form.body) |expr| identifyPrimitives(expr);
-        },
-        .unless_form => {
-            identifyPrimitives(node.data.unless_form.test_expr);
-            for (node.data.unless_form.body) |expr| identifyPrimitives(expr);
-        },
-        .constant, .global_ref, .passthrough => {},
-        .define,
-        .set_form,
-        .lambda,
-        .let_form,
-        .let_star,
-        .letrec,
-        .letrec_star,
-        .do_form,
-        .delay,
-        .delay_force,
-        .cond,
-        .case_form,
-        .case_lambda,
-        .guard,
-        .quasiquote,
-        .parameterize,
-        .define_values,
-        .let_values,
-        .let_star_values,
-        .define_syntax,
-        .named_let,
-        .let_syntax,
-        .letrec_syntax,
-        .cond_expand,
-        => {},
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Semantic analysis: constant expression detection
-// ---------------------------------------------------------------------------
-
-pub fn markConstants(node: *Node) void {
-    switch (node.tag) {
-        .constant => node.ann.is_constant = true,
-        .@"if" => {
-            markConstants(node.data.@"if".test_expr);
-            markConstants(node.data.@"if".consequent);
-            if (node.data.@"if".alternate) |alt| markConstants(alt);
-        },
-        .begin => {
-            for (node.data.begin) |expr| markConstants(expr);
-            if (node.data.begin.len > 0) {
-                node.ann.is_constant = node.data.begin[node.data.begin.len - 1].ann.is_constant;
-            }
-        },
-        .call => {
-            markConstants(node.data.call.operator);
-            var all_const = node.data.call.operator.tag == .global_ref;
-            for (node.data.call.args) |arg| {
-                markConstants(arg);
-                if (!arg.ann.is_constant) all_const = false;
-            }
-            if (all_const and node.ann.is_primitive_call) {
-                node.ann.is_constant = true;
-            }
-        },
-        .and_form => {
-            for (node.data.and_form) |expr| markConstants(expr);
-        },
-        .or_form => {
-            for (node.data.or_form) |expr| markConstants(expr);
-        },
-        .when_form => {
-            markConstants(node.data.when_form.test_expr);
-            for (node.data.when_form.body) |expr| markConstants(expr);
-        },
-        .unless_form => {
-            markConstants(node.data.unless_form.test_expr);
-            for (node.data.unless_form.body) |expr| markConstants(expr);
-        },
-        .global_ref, .passthrough => {},
-        .define,
-        .set_form,
-        .lambda,
-        .let_form,
-        .let_star,
-        .letrec,
-        .letrec_star,
-        .do_form,
-        .delay,
-        .delay_force,
-        .cond,
-        .case_form,
-        .case_lambda,
-        .guard,
-        .quasiquote,
-        .parameterize,
-        .define_values,
-        .let_values,
-        .let_star_values,
-        .define_syntax,
-        .named_let,
-        .let_syntax,
-        .letrec_syntax,
-        .cond_expand,
-        => {},
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Optimization: constant folding on the IR

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -275,39 +275,6 @@ test "IR analysis: tail position in and/or" {
     try std.testing.expect(root.data.and_form[2].ann.is_tail);
 }
 
-test "IR analysis: primitive identification on Call node" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var ir = ir_mod.IR.init(std.testing.allocator);
-    defer ir.deinit();
-
-    const plus_sym = try gc.allocSymbol("+");
-    const op = try ir.makeGlobalRef(plus_sym);
-    const arg1 = try ir.makeConst(types.makeFixnum(1));
-    const arg2 = try ir.makeConst(types.makeFixnum(2));
-    const call = try ir.makeCall(op, &.{ arg1, arg2 });
-
-    ir_mod.identifyPrimitives(call);
-    try std.testing.expect(call.ann.is_primitive_call);
-    try std.testing.expect(std.mem.eql(u8, call.ann.primitive_name.?, "+"));
-}
-
-test "IR analysis: non-primitive not marked" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var ir = ir_mod.IR.init(std.testing.allocator);
-    defer ir.deinit();
-
-    const my_fn = try gc.allocSymbol("my-function");
-    const op = try ir.makeGlobalRef(my_fn);
-    const arg = try ir.makeConst(types.makeFixnum(1));
-    const call = try ir.makeCall(op, &.{arg});
-
-    ir_mod.identifyPrimitives(call);
-    try std.testing.expect(!call.ann.is_primitive_call);
-    try std.testing.expect(call.ann.primitive_name == null);
-}
-
 test "IR optimization: constant folding on Call" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -461,42 +428,6 @@ test "IR optimization: dead branch elimination — non-constant test unchanged" 
 
     const result = ir_mod.eliminateDeadBranches(&ir, if_node);
     try std.testing.expect(result.tag == .@"if");
-}
-
-test "IR analysis: constant detection — literal is constant" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var ir = ir_mod.IR.init(std.testing.allocator);
-    defer ir.deinit();
-    const node = try ir.makeConst(types.makeFixnum(42));
-    ir_mod.markConstants(node);
-    try std.testing.expect(node.ann.is_constant);
-}
-
-test "IR analysis: constant detection — primitive call with const args" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var ir = ir_mod.IR.init(std.testing.allocator);
-    defer ir.deinit();
-    const plus_sym = try gc.allocSymbol("+");
-    const op = try ir.makeGlobalRef(plus_sym);
-    const a = try ir.makeConst(types.makeFixnum(1));
-    const b = try ir.makeConst(types.makeFixnum(2));
-    const call = try ir.makeCall(op, &.{ a, b });
-    ir_mod.identifyPrimitives(call);
-    ir_mod.markConstants(call);
-    try std.testing.expect(call.ann.is_constant);
-}
-
-test "IR analysis: constant detection — variable ref is not constant" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var ir = ir_mod.IR.init(std.testing.allocator);
-    defer ir.deinit();
-    const x_sym = try gc.allocSymbol("x");
-    const node = try ir.makeGlobalRef(x_sym);
-    ir_mod.markConstants(node);
-    try std.testing.expect(!node.ann.is_constant);
 }
 
 test "IR optimization: boolean simplification — not not preserved for correctness" {

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -40,8 +40,6 @@ fn emitSourceResult(source: []const u8) !EmitResult {
 
     var root = try ir_mod.lower(&ir_instance, expr);
     ir_mod.markTailPositions(root, false);
-    ir_mod.identifyPrimitives(root);
-    ir_mod.markConstants(root);
     root = ir_mod.foldConstants(&ir_instance, root);
     root = ir_mod.eliminateDeadBranches(&ir_instance, root);
     root = ir_mod.simplifyBooleans(&ir_instance, root);
@@ -73,8 +71,6 @@ fn emitMultiResult(source: []const u8) !EmitResult {
         const expr = try reader.readDatum();
         var root = try ir_mod.lower(&ir_instance, expr);
         ir_mod.markTailPositions(root, false);
-        ir_mod.identifyPrimitives(root);
-        ir_mod.markConstants(root);
         root = ir_mod.foldConstants(&ir_instance, root);
         root = ir_mod.eliminateDeadBranches(&ir_instance, root);
         root = ir_mod.simplifyBooleans(&ir_instance, root);


### PR DESCRIPTION
## Summary

- Remove `identifyPrimitives` and `markConstants` analysis passes (~140 lines) that produced `is_primitive_call`, `primitive_name`, and `is_constant` annotations consumed by no backend
- Remove the three dead annotation fields from the `Annotations` struct, the dead `is_primitive` parameter from `compileCallFromIR`, and 5 test blocks that only asserted the removed annotations
- Keep the `primitives` list and `isKnownGlobal` (used by the LLVM backend) and the live `is_tail`/`source_line` annotations

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] R7RS suite — 1,395 pass, 0 fail
- [x] `bash tests/scheme/run-all.sh` — 1,702 pass, 0 fail
- [x] `grep` confirms zero remaining references to deleted identifiers

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)