### PR TITLE
Unify VMError/PrimitiveError and collapse inline error switches

### DIFF
--- a/src/errors.zig
+++ b/src/errors.zig
@@ -1,0 +1,18 @@
+pub const KaappiError = error{
+    StackOverflow,
+    TypeError,
+    ArityMismatch,
+    UndefinedVariable,
+    NotAProcedure,
+    OutOfMemory,
+    InvalidBytecode,
+    DivisionByZero,
+    CompileError,
+    ExceptionRaised,
+    ContinuationInvoked,
+    IndexOutOfBounds,
+    InvalidArgument,
+    Yielded,
+    ExecutionTimeout,
+    Terminated,
+};

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -22,45 +22,7 @@ const primitives_hashtable = @import("primitives_hashtable.zig");
 const primitives_random = @import("primitives_random.zig");
 const primitives_filesystem = @import("primitives_filesystem.zig");
 
-pub const PrimitiveError = error{
-    TypeError,
-    DivisionByZero,
-    ArityMismatch,
-    OutOfMemory,
-    ExceptionRaised,
-    ContinuationInvoked,
-    IndexOutOfBounds,
-    InvalidArgument,
-    Yielded,
-    StackOverflow,
-    UndefinedVariable,
-    NotAProcedure,
-    InvalidBytecode,
-    CompileError,
-    ExecutionTimeout,
-    Terminated,
-};
-
-pub fn mapVMError(err: vm_mod.VMError) PrimitiveError {
-    return switch (err) {
-        vm_mod.VMError.TypeError => PrimitiveError.TypeError,
-        vm_mod.VMError.DivisionByZero => PrimitiveError.DivisionByZero,
-        vm_mod.VMError.ArityMismatch => PrimitiveError.ArityMismatch,
-        vm_mod.VMError.OutOfMemory => PrimitiveError.OutOfMemory,
-        vm_mod.VMError.ExceptionRaised => PrimitiveError.ExceptionRaised,
-        vm_mod.VMError.ContinuationInvoked => PrimitiveError.ContinuationInvoked,
-        vm_mod.VMError.IndexOutOfBounds => PrimitiveError.IndexOutOfBounds,
-        vm_mod.VMError.InvalidArgument => PrimitiveError.InvalidArgument,
-        vm_mod.VMError.Yielded => PrimitiveError.Yielded,
-        vm_mod.VMError.StackOverflow => PrimitiveError.StackOverflow,
-        vm_mod.VMError.UndefinedVariable => PrimitiveError.UndefinedVariable,
-        vm_mod.VMError.NotAProcedure => PrimitiveError.NotAProcedure,
-        vm_mod.VMError.InvalidBytecode => PrimitiveError.InvalidBytecode,
-        vm_mod.VMError.CompileError => PrimitiveError.CompileError,
-        vm_mod.VMError.ExecutionTimeout => PrimitiveError.ExecutionTimeout,
-        vm_mod.VMError.Terminated => PrimitiveError.Terminated,
-    };
-}
+pub const PrimitiveError = @import("errors.zig").KaappiError;
 
 fn registerCore(vm: *vm_mod.VM) !void {
     // Pairs and lists
@@ -678,7 +640,7 @@ fn applyFn(args: []const Value) PrimitiveError!Value {
     }
 
     return vm.callWithArgs(proc, call_args.items) catch |err| {
-        return mapVMError(err);
+        return err;
     };
 }
 

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -67,7 +67,7 @@ fn raiseContinuableFn(args: []const Value) PrimitiveError!Value {
     vm.popHandler();
     const result = vm.callHandler(handler, args[0], 0) catch |err| {
         vm.pushHandler(handler) catch {};
-        return primitives.mapVMError(err);
+        return err;
     };
     vm.pushHandler(handler) catch return PrimitiveError.OutOfMemory;
     return result;
@@ -100,7 +100,7 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
             gc.pushRoot(&exc);
             defer gc.popRoot();
             _ = vm.callHandler(handler_root, exc, 0) catch |herr| {
-                return primitives.mapVMError(herr);
+                return herr;
             };
             // Handler returned from non-continuable raise — re-raise per R7RS
             var reraise_msg = gc.allocString("handler returned") catch return PrimitiveError.OutOfMemory;
@@ -128,7 +128,7 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
         gc.pushRoot(&err_root);
         defer gc.popRoot();
         const handler_result = vm.callHandler(handler_root, err_root, 0) catch |herr| {
-            return primitives.mapVMError(herr);
+            return herr;
         };
         return handler_result;
     };
@@ -219,7 +219,7 @@ fn callWithCurrentContinuation(args: []const Value) PrimitiveError!Value {
 
     // Call proc(continuation)
     const result = vm.callHandler(proc, cont_val, base_reg) catch |err| {
-        return primitives.mapVMError(err);
+        return err;
     };
 
     // If proc returned normally (without invoking the continuation),
@@ -255,7 +255,7 @@ fn callWithEscapeContinuation(args: []const Value) PrimitiveError!Value {
     const result = vm.callHandler(proc, cont_val, base_reg) catch |err| {
         // The extent has ended (escape unwound through here, or proc errored).
         cont_obj.valid = false;
-        return primitives.mapVMError(err);
+        return err;
     };
 
     // proc returned normally without escaping; the extent is over.
@@ -275,7 +275,7 @@ fn dynamicWindFn(args: []const Value) PrimitiveError!Value {
 
     // Call before thunk
     _ = vm.callThunk(before) catch |err| {
-        return primitives.mapVMError(err);
+        return err;
     };
 
     // Push wind record
@@ -295,7 +295,7 @@ fn dynamicWindFn(args: []const Value) PrimitiveError!Value {
             if (after_err == vm_mod.VMError.ContinuationInvoked)
                 return PrimitiveError.ContinuationInvoked;
         };
-        return primitives.mapVMError(err);
+        return err;
     };
 
     // Pop wind record
@@ -303,7 +303,7 @@ fn dynamicWindFn(args: []const Value) PrimitiveError!Value {
 
     // Call after thunk
     _ = vm.callThunk(after) catch |err| {
-        return primitives.mapVMError(err);
+        return err;
     };
 
     return result;
@@ -325,7 +325,7 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
 
     // Call producer
     const produced = vm.callThunk(producer) catch |err| {
-        return primitives.mapVMError(err);
+        return err;
     };
 
     // Call consumer with the produced values
@@ -336,14 +336,14 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
     if (types.isMultipleValues(produced_root)) {
         const mv = types.toObject(produced_root).as(types.MultipleValues);
         const result = vm.callWithArgs(consumer, mv.values) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
         return result;
     } else {
         // Single value -- call consumer with one argument (use callWithArgs
         // so arity is validated, matching the multi-value path)
         const result = vm.callWithArgs(consumer, &[_]Value{produced}) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
         return result;
     }

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -202,7 +202,7 @@ fn hashTableRefFn(args: []const Value) PrimitiveError!Value {
         if (types.isProcedure(args[2])) {
             const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             return vm.callWithArgs(args[2], &[_]Value{}) catch |err| {
-                return primitives.mapVMError(err);
+                return err;
             };
         }
         return args[2]; // non-procedure default (for backwards compat)
@@ -295,7 +295,7 @@ fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
     for (snapshot) |entry| {
         const call_args = [2]Value{ entry.key, entry.value };
         _ = vm.callWithArgs(proc, &call_args) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
     }
     return types.VOID;
@@ -384,7 +384,7 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
 
     const call_args = [1]Value{old_val};
     const new_val = vm.callWithArgs(proc, &call_args) catch |err| {
-        return primitives.mapVMError(err);
+        return err;
     };
 
     try growIfNeeded(ht);
@@ -503,7 +503,7 @@ fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
     for (snapshot) |entry| {
         const call_args = [3]Value{ entry.key, entry.value, acc };
         acc = vm.callWithArgs(proc, &call_args) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
     }
     return acc;

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -893,7 +893,7 @@ fn callWithInputFile(args: []const Value) PrimitiveError!Value {
     const result = vm.callWithArgs(args[1], &[_]Value{port_val}) catch |err| {
         // Close port on error
         _ = closePort(&[_]Value{port_val}) catch {};
-        return primitives.mapVMError(err);
+        return err;
     };
     // Close port
     _ = try closePort(&[_]Value{port_val});
@@ -906,7 +906,7 @@ fn callWithOutputFile(args: []const Value) PrimitiveError!Value {
     const port_val = try openOutputFile(&[_]Value{args[0]});
     const result = vm.callWithArgs(args[1], &[_]Value{port_val}) catch |err| {
         _ = closePort(&[_]Value{port_val}) catch {};
-        return primitives.mapVMError(err);
+        return err;
     };
     _ = try closePort(&[_]Value{port_val});
     return result;
@@ -918,7 +918,7 @@ fn callWithPort(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const result = vm.callWithArgs(args[1], &[_]Value{args[0]}) catch |err| {
         _ = closePort(&[_]Value{args[0]}) catch {};
-        return primitives.mapVMError(err);
+        return err;
     };
     _ = try closePort(&[_]Value{args[0]});
     return result;
@@ -933,7 +933,7 @@ fn withInputFromFile(args: []const Value) PrimitiveError!Value {
     const result = vm.callWithArgs(args[1], &[_]Value{}) catch |err| {
         setCurrentPort(vm, vm.current_input_port_param, saved);
         _ = closePort(&[_]Value{port_val}) catch {};
-        return primitives.mapVMError(err);
+        return err;
     };
     setCurrentPort(vm, vm.current_input_port_param, saved);
     _ = try closePort(&[_]Value{port_val});
@@ -949,7 +949,7 @@ fn withOutputToFile(args: []const Value) PrimitiveError!Value {
     const result = vm.callWithArgs(args[1], &[_]Value{}) catch |err| {
         setCurrentPort(vm, vm.current_output_port_param, saved);
         _ = closePort(&[_]Value{port_val}) catch {};
-        return primitives.mapVMError(err);
+        return err;
     };
     setCurrentPort(vm, vm.current_output_port_param, saved);
     _ = try closePort(&[_]Value{port_val});

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -56,7 +56,7 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
 
         const result = vm.callWithArgs(thunk, &[_]Value{}) catch |err| {
             promise.forcing = false;
-            return primitives.mapVMError(err);
+            return err;
         };
 
         // SRFI-45 §8: after the thunk returns, check if another force

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -148,7 +148,7 @@ fn memberFn(args: []const Value) PrimitiveError!Value {
             const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             const call_args = [2]Value{ args[0], types.car(current) };
             const result = vm.callWithArgs(compare, &call_args) catch |err| {
-                return primitives.mapVMError(err);
+                return err;
             };
             if (result != types.FALSE) return current;
         } else {
@@ -257,7 +257,7 @@ fn assocFn(args: []const Value) PrimitiveError!Value {
             const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             const call_args = [2]Value{ args[0], types.car(pair) };
             const result = vm.callWithArgs(compare, &call_args) catch |err| {
-                return primitives.mapVMError(err);
+                return err;
             };
             if (result != types.FALSE) return pair;
         } else {
@@ -389,7 +389,7 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
 
         // Call procedure
         var result = vm.callWithArgs(proc, call_args[0..list_count]) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
 
         // Root result: callWithArgs pops its frame, so the return value has
@@ -451,7 +451,7 @@ fn forEachFn(args: []const Value) PrimitiveError!Value {
 
         // Call procedure (discard result)
         _ = vm.callWithArgs(proc, call_args[0..list_count]) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
 
         // Advance each list

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -202,7 +202,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
         defer gc.popRoot();
 
         const result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
         return result;
     }
@@ -214,7 +214,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     defer gc.popRoot();
 
     const result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
-        return primitives.mapVMError(err);
+        return err;
     };
     return result;
 }
@@ -304,7 +304,7 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
             compiler_mod.Compiler.unrootFunction(gc, func);
 
             last_result = vm.execute(func) catch |err| {
-                return primitives.mapVMError(err);
+                return err;
             };
         }
     }
@@ -327,7 +327,7 @@ fn makeParameterFn(args: []const Value) PrimitiveError!Value {
     if (converter != types.NIL) {
         const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
         val = vm.callWithArgs(converter, &[_]Value{init}) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
     }
     return gc.allocParameter(val, converter) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -119,7 +119,7 @@ pub fn registerSrfi1(vm: *vm_mod.VM) !void {
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     return vm.callWithArgs(proc, call_args) catch |err| {
-        return primitives.mapVMError(err);
+        return err;
     };
 }
 

--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -476,7 +476,7 @@ fn stringForEachFn(args: []const Value) PrimitiveError!Value {
             call_args[si] = types.makeChar(cp);
         }
         _ = vm.callWithArgs(proc, call_args[0..str_count]) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
     }
     return types.VOID;
@@ -517,7 +517,7 @@ fn stringMapFn(args: []const Value) PrimitiveError!Value {
             call_args[si] = types.makeChar(cp);
         }
         const result = vm.callWithArgs(proc, call_args[0..str_count]) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
         if (!types.isChar(result)) return primitives.typeError("string-map", "character", result);
         const cp = types.toChar(result);

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -108,7 +108,7 @@ fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
     // If pred is a procedure, call it directly
     if (types.isProcedure(pred)) {
         const result = vm.callWithArgs(pred, &[_]Value{char_val}) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
         return types.isTruthy(result);
     }
@@ -120,7 +120,7 @@ fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
         vm.unlockGlobalsShared();
         const cs_contains = cs_contains_opt orelse return PrimitiveError.TypeError;
         const result = vm.callWithArgs(cs_contains, &[_]Value{ pred, char_val }) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
         return types.isTruthy(result);
     }
@@ -402,7 +402,7 @@ fn stringConcatenateFn(args: []const Value) PrimitiveError!Value {
 
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    return vm.callWithArgs(proc, call_args) catch |err| return primitives.mapVMError(err);
+    return vm.callWithArgs(proc, call_args) catch |err| return err;
 }
 
 fn stringTakeFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -304,7 +304,7 @@ fn vectorForEachFn(args: []const Value) PrimitiveError!Value {
         }
 
         _ = vm.callWithArgs(proc, call_args) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
     }
 
@@ -351,7 +351,7 @@ fn vectorMapFn(args: []const Value) PrimitiveError!Value {
         }
 
         results[i] = vm.callWithArgs(proc, call_args) catch |err| {
-            return primitives.mapVMError(err);
+            return err;
         };
         gc.extra_roots.append(gc.allocator, results[i]) catch return PrimitiveError.OutOfMemory;
     }
@@ -403,7 +403,7 @@ fn vectorToStringFn(args: []const Value) PrimitiveError!Value {
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     return vm.callWithArgs(proc, call_args) catch |err| {
-        return primitives.mapVMError(err);
+        return err;
     };
 }
 

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -11,24 +11,7 @@ pub const vm_library = @import("vm_library.zig");
 pub const vm_records = @import("vm_records.zig");
 pub const vm_continuations = @import("vm_continuations.zig");
 
-pub const VMError = error{
-    StackOverflow,
-    TypeError,
-    ArityMismatch,
-    UndefinedVariable,
-    NotAProcedure,
-    OutOfMemory,
-    InvalidBytecode,
-    DivisionByZero,
-    CompileError,
-    ExceptionRaised,
-    ContinuationInvoked,
-    IndexOutOfBounds,
-    InvalidArgument,
-    Yielded,
-    ExecutionTimeout,
-    Terminated,
-};
+pub const VMError = @import("errors.zig").KaappiError;
 
 pub const INITIAL_FRAME_CAPACITY = types.INITIAL_FRAME_CAPACITY;
 pub const INITIAL_REGISTER_CAPACITY = types.INITIAL_REGISTER_CAPACITY;

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -252,12 +252,32 @@ fn mainFiberResult(sched: *fiber_mod.FiberScheduler) Value {
     return types.VOID;
 }
 
-pub fn handleNativeError(_: *VM, err: anyerror, _: u32, _: u8) VMError {
+pub fn mapNativeError(vm: *VM, err: anyerror, name: []const u8, args: []const Value) VMError {
     return switch (err) {
-        error.TypeError => VMError.TypeError,
+        error.TypeError => blk: {
+            if (vm.last_error_detail_len == 0) {
+                if (args.len > 0) {
+                    const p = @import("printer.zig");
+                    const s = p.valueToString(vm.gc.allocator, args[0], .write) catch "";
+                    defer if (s.len > 0) vm.gc.allocator.free(s);
+                    vm.setErrorDetail("type error in '{s}': got {s}", .{ name, s });
+                } else {
+                    vm.setErrorDetail("type error in '{s}'", .{name});
+                }
+            }
+            break :blk VMError.TypeError;
+        },
         error.DivisionByZero => VMError.DivisionByZero,
-        error.IndexOutOfBounds => VMError.IndexOutOfBounds,
-        error.InvalidArgument => VMError.InvalidArgument,
+        error.IndexOutOfBounds => blk_iob: {
+            if (vm.last_error_detail_len == 0)
+                vm.setErrorDetail("index out of bounds in '{s}'", .{name});
+            break :blk_iob VMError.IndexOutOfBounds;
+        },
+        error.InvalidArgument => blk_ia: {
+            if (vm.last_error_detail_len == 0)
+                vm.setErrorDetail("invalid argument in '{s}'", .{name});
+            break :blk_ia VMError.InvalidArgument;
+        },
         error.OutOfMemory => VMError.OutOfMemory,
         error.ExceptionRaised => VMError.ExceptionRaised,
         error.ContinuationInvoked => VMError.ContinuationInvoked,
@@ -462,45 +482,7 @@ pub fn callNative(vm: *VM, native: *types.NativeFn, base: u32, nargs: u8) VMErro
             vm.profile_last_ns = clockNs();
             vm.gc.profile_alloc_target = saved_alloc_target;
         }
-        return switch (err) {
-            error.TypeError => blk: {
-                if (vm.last_error_detail_len == 0) {
-                    if (args.len > 0) {
-                        const p = @import("printer.zig");
-                        const s = p.valueToString(vm.gc.allocator, args[0], .write) catch "";
-                        defer if (s.len > 0) vm.gc.allocator.free(s);
-                        vm.setErrorDetail("type error in '{s}': got {s}", .{ native.name, s });
-                    } else {
-                        vm.setErrorDetail("type error in '{s}'", .{native.name});
-                    }
-                }
-                break :blk VMError.TypeError;
-            },
-            error.DivisionByZero => VMError.DivisionByZero,
-            error.IndexOutOfBounds => blk_iob: {
-                if (vm.last_error_detail_len == 0)
-                    vm.setErrorDetail("index out of bounds in '{s}'", .{native.name});
-                break :blk_iob VMError.IndexOutOfBounds;
-            },
-            error.InvalidArgument => blk_ia: {
-                if (vm.last_error_detail_len == 0)
-                    vm.setErrorDetail("invalid argument in '{s}'", .{native.name});
-                break :blk_ia VMError.InvalidArgument;
-            },
-            error.OutOfMemory => VMError.OutOfMemory,
-            error.ExceptionRaised => VMError.ExceptionRaised,
-            error.ContinuationInvoked => VMError.ContinuationInvoked,
-            error.Yielded => VMError.Yielded,
-            error.ArityMismatch => VMError.ArityMismatch,
-            error.StackOverflow => VMError.StackOverflow,
-            error.UndefinedVariable => VMError.UndefinedVariable,
-            error.NotAProcedure => VMError.NotAProcedure,
-            error.InvalidBytecode => VMError.InvalidBytecode,
-            error.CompileError => VMError.CompileError,
-            error.ExecutionTimeout => VMError.ExecutionTimeout,
-            error.Terminated => VMError.Terminated,
-            else => VMError.InvalidBytecode,
-        };
+        return mapNativeError(vm, err, native.name, args);
     };
 
     if (vm.profile_mode) {
@@ -591,35 +573,7 @@ pub fn callHandler(vm: *VM, handler_val: Value, arg: Value, return_dst: u8) VMEr
         const args = [1]Value{arg};
         vm.last_error_detail_len = 0;
         const result = native.func(&args) catch |err| {
-            return switch (err) {
-                error.TypeError => blk: {
-                    if (vm.last_error_detail_len == 0) {
-                        if (args.len > 0) {
-                            const p = @import("printer.zig");
-                            const s = p.valueToString(vm.gc.allocator, args[0], .write) catch "";
-                            defer if (s.len > 0) vm.gc.allocator.free(s);
-                            vm.setErrorDetail("type error in '{s}': got {s}", .{ native.name, s });
-                        } else {
-                            vm.setErrorDetail("type error in '{s}'", .{native.name});
-                        }
-                    }
-                    break :blk VMError.TypeError;
-                },
-                error.DivisionByZero => VMError.DivisionByZero,
-                error.IndexOutOfBounds => blk_iob: {
-                    if (vm.last_error_detail_len == 0)
-                        vm.setErrorDetail("index out of bounds in '{s}'", .{native.name});
-                    break :blk_iob VMError.IndexOutOfBounds;
-                },
-                error.InvalidArgument => blk_ia: {
-                    vm.setErrorDetail("invalid argument in '{s}'", .{native.name});
-                    break :blk_ia VMError.InvalidArgument;
-                },
-                error.OutOfMemory => VMError.OutOfMemory,
-                error.ExceptionRaised => VMError.ExceptionRaised,
-                error.ContinuationInvoked => VMError.ContinuationInvoked,
-                else => VMError.InvalidBytecode,
-            };
+            return mapNativeError(vm, err, native.name, &args);
         };
         return result;
     } else {
@@ -645,22 +599,7 @@ pub fn callThunk(vm: *VM, thunk_val: Value) VMError!Value {
         const native = types.toObject(thunk_val).as(types.NativeFn);
         const empty_args: []const Value = &.{};
         const result = native.func(empty_args) catch |err| {
-            return switch (err) {
-                error.TypeError => VMError.TypeError,
-                error.DivisionByZero => VMError.DivisionByZero,
-                error.IndexOutOfBounds => blk_iob: {
-                    vm.setErrorDetail("index out of bounds in '{s}'", .{native.name});
-                    break :blk_iob VMError.IndexOutOfBounds;
-                },
-                error.InvalidArgument => blk_ia: {
-                    vm.setErrorDetail("invalid argument in '{s}'", .{native.name});
-                    break :blk_ia VMError.InvalidArgument;
-                },
-                error.OutOfMemory => VMError.OutOfMemory,
-                error.ExceptionRaised => VMError.ExceptionRaised,
-                error.ContinuationInvoked => VMError.ContinuationInvoked,
-                else => VMError.InvalidBytecode,
-            };
+            return mapNativeError(vm, err, native.name, empty_args);
         };
         return result;
     } else {
@@ -754,36 +693,7 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
         }
         vm.last_error_detail_len = 0;
         const result = native.func(args) catch |err| {
-            return switch (err) {
-                error.TypeError => blk: {
-                    if (vm.last_error_detail_len == 0) {
-                        if (args.len > 0) {
-                            const p = @import("printer.zig");
-                            const s = p.valueToString(vm.gc.allocator, args[0], .write) catch "";
-                            defer if (s.len > 0) vm.gc.allocator.free(s);
-                            vm.setErrorDetail("type error in '{s}': got {s}", .{ native.name, s });
-                        } else {
-                            vm.setErrorDetail("type error in '{s}'", .{native.name});
-                        }
-                    }
-                    break :blk VMError.TypeError;
-                },
-                error.DivisionByZero => VMError.DivisionByZero,
-                error.IndexOutOfBounds => blk_iob: {
-                    if (vm.last_error_detail_len == 0)
-                        vm.setErrorDetail("index out of bounds in '{s}'", .{native.name});
-                    break :blk_iob VMError.IndexOutOfBounds;
-                },
-                error.InvalidArgument => blk_ia: {
-                    vm.setErrorDetail("invalid argument in '{s}'", .{native.name});
-                    break :blk_ia VMError.InvalidArgument;
-                },
-                error.OutOfMemory => VMError.OutOfMemory,
-                error.ExceptionRaised => VMError.ExceptionRaised,
-                error.ContinuationInvoked => VMError.ContinuationInvoked,
-                error.Yielded => VMError.Yielded,
-                else => VMError.InvalidBytecode,
-            };
+            return mapNativeError(vm, err, native.name, args);
         };
         return result;
     } else {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -506,37 +506,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             return VMError.ContinuationInvoked;
                         }
                         if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
-                        return switch (err) {
-                            error.TypeError => blk: {
-                                if (self.last_error_detail_len == 0)
-                                    self.setErrorDetail("type error in '{s}'", .{native.name});
-                                break :blk VMError.TypeError;
-                            },
-                            error.DivisionByZero => VMError.DivisionByZero,
-                            error.IndexOutOfBounds => blk_iob: {
-                                if (self.last_error_detail_len == 0)
-                                    self.setErrorDetail("index out of bounds in '{s}'", .{native.name});
-                                break :blk_iob VMError.IndexOutOfBounds;
-                            },
-                            error.InvalidArgument => blk_ia: {
-                                if (self.last_error_detail_len == 0)
-                                    self.setErrorDetail("invalid argument in '{s}'", .{native.name});
-                                break :blk_ia VMError.InvalidArgument;
-                            },
-                            error.OutOfMemory => VMError.OutOfMemory,
-                            error.ExceptionRaised => VMError.ExceptionRaised,
-                            error.ContinuationInvoked => VMError.ContinuationInvoked,
-                            error.Yielded => VMError.Yielded,
-                            error.ArityMismatch => VMError.ArityMismatch,
-                            error.StackOverflow => VMError.StackOverflow,
-                            error.UndefinedVariable => VMError.UndefinedVariable,
-                            error.NotAProcedure => VMError.NotAProcedure,
-                            error.InvalidBytecode => VMError.InvalidBytecode,
-                            error.CompileError => VMError.CompileError,
-                            error.ExecutionTimeout => VMError.ExecutionTimeout,
-                            error.Terminated => VMError.Terminated,
-                            else => VMError.InvalidBytecode,
-                        };
+                        return vm_calls.mapNativeError(self, err, native.name, nargs_slice);
                     };
                     if (self.profile_mode) {
                         native.profile_time_ns +%= vm_calls.clockNs() -% native_start;
@@ -690,25 +660,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             return VMError.ContinuationInvoked;
                         }
                         if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
-                        return switch (err) {
-                            error.TypeError => VMError.TypeError,
-                            error.DivisionByZero => VMError.DivisionByZero,
-                            error.IndexOutOfBounds => VMError.IndexOutOfBounds,
-                            error.InvalidArgument => VMError.InvalidArgument,
-                            error.OutOfMemory => VMError.OutOfMemory,
-                            error.ExceptionRaised => VMError.ExceptionRaised,
-                            error.Yielded => VMError.Yielded,
-                            error.ArityMismatch => VMError.ArityMismatch,
-                            error.StackOverflow => VMError.StackOverflow,
-                            error.UndefinedVariable => VMError.UndefinedVariable,
-                            error.NotAProcedure => VMError.NotAProcedure,
-                            error.InvalidBytecode => VMError.InvalidBytecode,
-                            error.CompileError => VMError.CompileError,
-                            error.ExecutionTimeout => VMError.ExecutionTimeout,
-                            error.Terminated => VMError.Terminated,
-                            error.ContinuationInvoked => VMError.ContinuationInvoked,
-                            else => VMError.InvalidBytecode,
-                        };
+                        return vm_calls.mapNativeError(self, err, native.name, flat_args[0..count]);
                     };
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
@@ -948,7 +900,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 return VMError.ContinuationInvoked;
                             }
                             if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
-                            return vm_calls.handleNativeError(self, err, base, nargs);
+                            return vm_calls.mapNativeError(self, err, native.name, args);
                         };
                         self.registers[base] = result;
                     } else {
@@ -1062,7 +1014,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 return VMError.ContinuationInvoked;
                             }
                             if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
-                            return vm_calls.handleNativeError(self, err, abs_base, nargs);
+                            return vm_calls.mapNativeError(self, err, native.name, args);
                         }
                     else blk: {
                         native.profile_calls += 1;
@@ -1080,37 +1032,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 return VMError.ContinuationInvoked;
                             }
                             if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
-                            return switch (err) {
-                                error.TypeError => b2: {
-                                    if (self.last_error_detail_len == 0)
-                                        self.setErrorDetail("type error in '{s}'", .{native.name});
-                                    break :b2 VMError.TypeError;
-                                },
-                                error.DivisionByZero => VMError.DivisionByZero,
-                                error.IndexOutOfBounds => b_iob: {
-                                    if (self.last_error_detail_len == 0)
-                                        self.setErrorDetail("index out of bounds in '{s}'", .{native.name});
-                                    break :b_iob VMError.IndexOutOfBounds;
-                                },
-                                error.InvalidArgument => b_ia: {
-                                    if (self.last_error_detail_len == 0)
-                                        self.setErrorDetail("invalid argument in '{s}'", .{native.name});
-                                    break :b_ia VMError.InvalidArgument;
-                                },
-                                error.OutOfMemory => VMError.OutOfMemory,
-                                error.ExceptionRaised => VMError.ExceptionRaised,
-                                error.ContinuationInvoked => VMError.ContinuationInvoked,
-                                error.Yielded => VMError.Yielded,
-                                error.ArityMismatch => VMError.ArityMismatch,
-                                error.StackOverflow => VMError.StackOverflow,
-                                error.UndefinedVariable => VMError.UndefinedVariable,
-                                error.NotAProcedure => VMError.NotAProcedure,
-                                error.InvalidBytecode => VMError.InvalidBytecode,
-                                error.CompileError => VMError.CompileError,
-                                error.ExecutionTimeout => VMError.ExecutionTimeout,
-                                error.Terminated => VMError.Terminated,
-                                else => VMError.InvalidBytecode,
-                            };
+                            return vm_calls.mapNativeError(self, err, native.name, args);
                         };
                         native.profile_time_ns +%= vm_calls.clockNs() -% native_start;
                         self.profile_last_ns = vm_calls.clockNs();

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -193,6 +193,12 @@ assert_output_contains "mismatched ellipsis lengths rejected cleanly" \
     '(define-syntax zip (syntax-rules () ((zip (a ...) (b ...)) (quote ((a b) ...))))) (zip (1 2 3) (4 5))' \
     "compile error"
 
+# --- Issue #1046: apply-position type errors must include procedure name ---
+echo
+echo "-- Apply-position error detail (issue #1046) --"
+assert_output_contains "apply-position type error includes diagnostic" \
+    '(apply + (list 1 "x"))' "type error"
+
 # --- Uncaught exceptions carry message and irritants ---
 echo
 echo "-- Uncaught exceptions --"


### PR DESCRIPTION
## Summary

- Define one `KaappiError` in dependency-free `src/errors.zig`; alias both `VMError` and `PrimitiveError` to it
- Delete `mapVMError` (now identity) and its 39 call sites across 11 primitives files
- Replace 8 drifted inline `anyerror → VMError` switches with one `mapNativeError()` in `vm_calls.zig`
- Fix three drift bugs: CALL_NATIVE_VARIADIC gains detail-defaulting, three partial switches gain full 16-variant coverage, `InvalidArgument` detail respects the `last_error_detail_len` guard

Net: -199 lines. Closes #1046.

## Test plan

- [x] `zig build test` — all Zig unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1395 R7RS + 306 Scheme files pass
- [x] `bash tests/scheme/errors/error-format.sh` — 34/34 pass (includes new apply-position regression test)
- [x] `bash tests/scheme/errors/exit-code.sh` — 39/39 pass
- [x] GC stress build (`-Dgc-stress=true`) — error paths verified under forced collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)