### PR TITLE
Extract macro-expansion machinery into compiler_macro.zig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 | `expander.zig` | ~320 | Macro expansion engine (syntax-rules) |
 | `printer.zig` | ~300 | Value → string (write mode and display mode) |
 
-### Compiler & IR (8 files)
+### Compiler & IR (9 files)
 | File | Responsibility |
 |------|---------------|
 | `ir.zig` | IR node types (33), AST→IR lowering, 3 analysis passes, 5 optimization passes |
@@ -162,6 +162,7 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 | `compiler_conditionals.zig` | and, or, when, unless, cond, cond-expand |
 | `compiler_bindings.zig` | let, let*, letrec, letrec*, named let, do, let-values, let*-values |
 | `compiler_advanced.zig` | case, case-lambda, guard, quasiquote |
+| `compiler_macro.zig` | define-syntax, let-syntax, letrec-syntax, macro expansion, syntax-rules parsing, hygiene free-ref collection |
 | `compiler_forms.zig` | Re-export hub (thin file, don't edit directly) |
 
 ### VM (split into 8 files)

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -41,6 +41,7 @@ Forms are split by semantic domain. Add new forms to the right file:
 | `compiler_conditionals.zig` | and, or, when, unless, cond, cond-expand |
 | `compiler_bindings.zig` | let, let*, letrec, letrec*, named let, do |
 | `compiler_advanced.zig` | case, case-lambda, guard, quasiquote |
+| `compiler_macro.zig` | define-syntax, let-syntax, letrec-syntax, macro expansion, syntax-rules parsing, hygiene free-ref collection |
 
 Then add the re-export in `compiler_forms.zig` (thin hub — don't add logic there).
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -5,6 +5,7 @@ const expander = @import("expander.zig");
 const forms = @import("compiler_forms.zig");
 const advanced = @import("compiler_advanced.zig");
 const passthrough = @import("compiler_passthrough.zig");
+const macro = @import("compiler_macro.zig");
 const ir_mod = @import("ir.zig");
 const compiler_ir = @import("compiler_ir.zig");
 const globals_mod = @import("globals.zig");
@@ -46,8 +47,6 @@ const BodyMacro = struct {
 
 const build_options = @import("build_options");
 const MAX_COMPILER_REGISTERS: u16 = std.math.maxInt(u16);
-const MAX_MACRO_EXPANSION_DEPTH: u16 = 256;
-const MAX_MACRO_EXPANSION_STEPS: u32 = 10_000;
 
 pub const Compiler = struct {
     gc: *memory.GC,
@@ -593,15 +592,7 @@ pub const Compiler = struct {
         if (types.isSymbol(head)) {
             const name = types.symbolName(head);
 
-            // Check if this identifier came from a macro template (hygienic rename).
-            // Hygienic names like __hyg_N_let or __hyg_N___hyg_M_let should
-            // be treated as their base form. Strip all __hyg_N_ prefixes.
-            var effective_name = name;
-            while (std.mem.startsWith(u8, effective_name, "__hyg_")) {
-                if (std.mem.indexOfScalar(u8, effective_name[6..], '_')) |sep| {
-                    effective_name = effective_name[6 + sep + 1 ..];
-                } else break;
-            }
+            const effective_name = types.stripHygienicPrefix(name);
 
             // If the effective name is a variable binding in scope but NOT a
             // hygienic rename, it's a function call, not a special form. The
@@ -655,9 +646,9 @@ pub const Compiler = struct {
                 if (std.mem.eql(u8, effective_name, "syntax-error")) return CompileError.InvalidSyntax;
 
                 // Macro forms (kept in compiler.zig)
-                if (std.mem.eql(u8, effective_name, "define-syntax")) return self.compileDefineSyntax(args, dst);
-                if (std.mem.eql(u8, effective_name, "let-syntax")) return self.compileLetSyntax(args, dst, is_tail);
-                if (std.mem.eql(u8, effective_name, "letrec-syntax")) return self.compileLetrecSyntax(args, dst, is_tail);
+                if (std.mem.eql(u8, effective_name, "define-syntax")) return macro.compileDefineSyntax(self, args, dst);
+                if (std.mem.eql(u8, effective_name, "let-syntax")) return macro.compileLetSyntax(self, args, dst, is_tail);
+                if (std.mem.eql(u8, effective_name, "letrec-syntax")) return macro.compileLetrecSyntax(self, args, dst, is_tail);
                 if (std.mem.eql(u8, effective_name, "syntax-rules")) return CompileError.InvalidSyntax;
             } // end if (!is_local)
 
@@ -670,178 +661,7 @@ pub const Compiler = struct {
             else
                 null;
             if (macro_hit) |transformer| {
-                if (self.macro_expansion_depth >= MAX_MACRO_EXPANSION_DEPTH or
-                    self.macro_expansion_steps >= MAX_MACRO_EXPANSION_STEPS)
-                {
-                    return CompileError.MacroExpansionLimit;
-                }
-                self.macro_expansion_depth += 1;
-                self.macro_expansion_steps += 1;
-                defer self.macro_expansion_depth -= 1;
-                // Build merged macro view including parent scopes
-                var merged_macros = std.StringHashMap(Value).init(self.gc.allocator);
-                defer merged_macros.deinit();
-                var p: ?*Compiler = self.parent;
-                while (p) |par| : (p = par.parent) {
-                    var it = par.macros.iterator();
-                    while (it.next()) |entry| {
-                        try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
-                    }
-                }
-                var it = self.macros.iterator();
-                while (it.next()) |entry| {
-                    try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
-                }
-                const tx = types.toObject(transformer).as(types.Transformer);
-                // Temporarily add/modify globals so the expander doesn't
-                // rename template free references.
-                const TempGlobal = struct { name: []const u8, old_val: ?Value, was_present: bool };
-                var temp_globals: [128]TempGlobal = undefined;
-                var temp_global_count: usize = 0;
-                // Track non-procedure global free vars that need local injection
-                // to prevent shadowing by use-site locals (R7RS 4.3.1).
-                var global_free_names: [64][]const u8 = undefined;
-                var global_free_count: usize = 0;
-                if (self.globals) |g| {
-                    // The sentinel puts below structurally mutate the globals
-                    // map when g is the VM's shared one — exclude SRFI-18
-                    // child-thread readers for the whole dance (#958). glk is
-                    // non-null exactly when g is the current thread's shared
-                    // globals map.
-                    const glk = globals_mod.acquireGlobalsWrite(g);
-                    defer globals_mod.releaseGlobalsWrite(glk);
-                    for (tx.captured_locals) |cap| {
-                        if (!g.contains(cap.name) and temp_global_count < 128) {
-                            temp_globals[temp_global_count] = .{ .name = cap.name, .old_val = null, .was_present = false };
-                            temp_global_count += 1;
-                            try g.put(cap.name, types.VOID);
-                        }
-                    }
-                    if (tx.def_env) |env| {
-                        var env_it = env.iterator();
-                        while (env_it.next()) |entry| {
-                            if (!g.contains(entry.key_ptr.*) and temp_global_count < 128) {
-                                temp_globals[temp_global_count] = .{ .name = entry.key_ptr.*, .old_val = null, .was_present = false };
-                                temp_global_count += 1;
-                                try g.put(entry.key_ptr.*, entry.value_ptr.*);
-                            }
-                        }
-                    }
-                    // Temporarily mark non-procedure free globals as VOID so
-                    // renameForHygiene preserves them.
-                    if (globals_mod.globals_ctx) |gctx| {
-                        var cand_names: [64][]const u8 = undefined;
-                        var cand_count: usize = 0;
-                        var pv_names: [64][]const u8 = undefined;
-                        var pv_count: usize = 0;
-                        for (tx.patterns[0..tx.num_rules]) |pat| {
-                            if (!passthrough.collectSymbols(pat, &pv_names, &pv_count)) return CompileError.InternalLimit;
-                        }
-                        for (tx.templates[0..tx.num_rules]) |tmpl| {
-                            if (!passthrough.collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &cand_names, &cand_count)) {
-                                return CompileError.InternalLimit;
-                            }
-                        }
-                        for (cand_names[0..cand_count]) |cname| {
-                            const in_g = g.get(cname);
-                            // glk != null means g IS the shared globals map
-                            // and we already hold its exclusive lock; else
-                            // this read needs its own child-thread lock.
-                            const in_vm = if (glk != null)
-                                (if (gctx.globals.count() > 0) gctx.globals.get(cname) else null)
-                            else in_vm_blk: {
-                                gctx.lockShared();
-                                defer gctx.unlockShared();
-                                break :in_vm_blk if (gctx.globals.count() > 0) gctx.globals.get(cname) else null;
-                            };
-                            const existing = in_g orelse in_vm;
-                            if (existing) |val| {
-                                if (!types.isProcedure(val) and !types.isTransformer(val) and val != types.VOID) {
-                                    if (temp_global_count < 128) {
-                                        temp_globals[temp_global_count] = .{ .name = cname, .old_val = in_g, .was_present = in_g != null };
-                                        temp_global_count += 1;
-                                        try g.put(cname, types.VOID);
-                                    }
-                                    // Track for local injection after expansion
-                                    if (global_free_count < 64) {
-                                        global_free_names[global_free_count] = cname;
-                                        global_free_count += 1;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                defer if (self.globals) |g| {
-                    const glk = globals_mod.acquireGlobalsWrite(g);
-                    for (temp_globals[0..temp_global_count]) |tg| {
-                        if (tg.was_present) {
-                            g.put(tg.name, tg.old_val.?) catch {};
-                        } else {
-                            _ = g.remove(tg.name);
-                        }
-                    }
-                    globals_mod.releaseGlobalsWrite(glk);
-                };
-                // Suppress GC during expansion: the expanded form isn't
-                // rooted until pushRoot below, so a collection triggered
-                // by allocPair inside expandMacro could free AST nodes
-                // that the partially-built result references.
-                self.gc.no_collect += 1;
-                const expanded = expander.expandMacro(self.gc, expr, transformer, self.globals, &merged_macros) catch |err| {
-                    self.gc.no_collect -= 1;
-                    return switch (err) {
-                        error.OutOfMemory => CompileError.OutOfMemory,
-                        error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
-                        error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch => CompileError.InvalidSyntax,
-                    };
-                };
-                var expanded_root = expanded;
-                self.gc.pushRoot(&expanded_root);
-                defer self.gc.popRoot();
-                self.gc.no_collect -= 1;
-                const saved_locals_len = self.locals.items.len;
-                for (tx.captured_locals) |cap| {
-                    try self.locals.append(self.gc.allocator, .{
-                        .name = cap.name,
-                        .depth = self.scope_depth,
-                        .slot = cap.slot,
-                    });
-                }
-                try injectHygienicCapturedLocals(self, expanded_root, tx.captured_locals);
-                // Inject non-procedure global free vars as locals so
-                // use-site locals don't shadow the definition-site
-                // global binding (R7RS 4.3.1 referential transparency).
-                for (global_free_names[0..global_free_count]) |gname| {
-                    // Skip if already covered by captured_locals
-                    var already_captured = false;
-                    for (tx.captured_locals) |cap| {
-                        if (std.mem.eql(u8, cap.name, gname)) {
-                            already_captured = true;
-                            break;
-                        }
-                    }
-                    if (already_captured) continue;
-                    // Load the global value into a fresh register
-                    const gslot = self.allocReg() catch continue;
-                    const gsym = self.gc.allocSymbol(gname) catch continue;
-                    const gsym_idx = self.addConstant(gsym) catch continue;
-                    self.emitOp(.get_global) catch continue;
-                    self.emitU16(gslot) catch continue;
-                    self.emitU16(gsym_idx) catch continue;
-                    try self.locals.append(self.gc.allocator, .{
-                        .name = gname,
-                        .depth = self.scope_depth,
-                        .slot = gslot,
-                        .is_global_alias = true,
-                    });
-                }
-                const result_err = self.compileExpr(expanded_root, dst, is_tail);
-                // Remove injected locals
-                while (self.locals.items.len > saved_locals_len) {
-                    _ = self.locals.pop();
-                }
-                return result_err;
+                return macro.expandAndCompileMacroUse(self, expr, name, transformer, dst, is_tail);
             }
         }
 
@@ -890,179 +710,6 @@ pub const Compiler = struct {
         return compiler_lambda.compileDelayForce(self, args, dst);
     }
 
-    // -- Macro forms --
-
-    pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!void {
-        if (args == types.NIL) return CompileError.InvalidSyntax;
-        const keyword = types.car(args);
-        if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
-        const rest = types.cdr(args);
-        if (rest == types.NIL) return CompileError.InvalidSyntax;
-        const transformer_spec = types.car(rest);
-
-        // Parse the syntax-rules form and get a transformer value
-        const transformer = passthrough.parseSyntaxRules(self, transformer_spec) catch return CompileError.InvalidSyntax;
-
-        const tx = types.toObject(transformer).as(types.Transformer);
-        if (self.lib_env) |env| {
-            tx.def_env = env;
-            tx.def_env_val = self.lib_env_val;
-        }
-
-        // Store in macro table; inside a body, track the registration so
-        // the enclosing body scope removes it on exit (R7RS 5.3).
-        const name = types.symbolName(keyword);
-        try self.recordBodyMacro(name);
-        self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
-
-        // A define-syntax at a library's top level (not nested in a lambda/let
-        // body scope) is also stored in the library environment. lib_env is
-        // per-library and GC-rooted, so the macro persists across the library's
-        // body forms and is found by lib_env export resolution — without
-        // leaking into the process-global macro table (issue #877). At the REPL
-        // top level lib_env is null, so ordinary define-syntax is unaffected.
-        if (self.body_macro_depth == 0) {
-            if (self.lib_env) |env| {
-                env.put(name, transformer) catch return CompileError.OutOfMemory;
-            }
-        }
-
-        // define-syntax returns void
-        try self.emitOp(.load_void);
-        try self.emitU16(dst);
-    }
-
-    fn stripHygPrefix(name: []const u8) []const u8 {
-        var n = name;
-        while (std.mem.startsWith(u8, n, "__hyg_")) {
-            if (std.mem.indexOfScalar(u8, n[6..], '_')) |sep| {
-                n = n[6 + sep + 1 ..];
-            } else break;
-        }
-        return n;
-    }
-
-    fn injectHygienicCapturedLocals(self: *Compiler, expr: Value, captured: []const types.CapturedLocal) CompileError!void {
-        if (captured.len == 0) return;
-        try injectHygCapturedWalk(self, expr, captured);
-    }
-
-    fn injectHygCapturedWalk(self: *Compiler, expr: Value, captured: []const types.CapturedLocal) CompileError!void {
-        if (types.isSymbol(expr)) {
-            const name = types.symbolName(expr);
-            if (!std.mem.startsWith(u8, name, "__hyg_")) return;
-            const base = stripHygPrefix(name);
-            if (base.len == name.len) return;
-            for (captured) |cap| {
-                if (std.mem.eql(u8, cap.name, base)) {
-                    var already = false;
-                    for (self.locals.items) |loc| {
-                        if (std.mem.eql(u8, loc.name, name)) {
-                            already = true;
-                            break;
-                        }
-                    }
-                    if (!already) {
-                        try self.locals.append(self.gc.allocator, .{
-                            .name = name,
-                            .depth = self.scope_depth,
-                            .slot = cap.slot,
-                        });
-                    }
-                    return;
-                }
-            }
-            return;
-        }
-        if (types.isPair(expr)) {
-            try injectHygCapturedWalk(self, types.car(expr), captured);
-            try injectHygCapturedWalk(self, types.cdr(expr), captured);
-        }
-    }
-
-    pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
-        if (args == types.NIL) return CompileError.InvalidSyntax;
-        const bindings = types.car(args);
-        const body = types.cdr(args);
-        if (body == types.NIL) return CompileError.InvalidSyntax;
-
-        // Save current macro table entries so we can restore
-        var saved_names: std.ArrayList([]const u8) = .empty;
-        defer saved_names.deinit(self.gc.allocator);
-        var saved_values: std.ArrayList(?Value) = .empty;
-        defer saved_values.deinit(self.gc.allocator);
-
-        // Process syntax bindings
-        var binding_list = bindings;
-        while (binding_list != types.NIL) {
-            if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
-            const binding = types.car(binding_list);
-            if (!types.isPair(binding)) return CompileError.InvalidSyntax;
-
-            const keyword = types.car(binding);
-            if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
-            const binding_rest = types.cdr(binding);
-            if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
-            const transformer_spec = types.car(binding_rest);
-            const transformer = passthrough.parseSyntaxRules(self, transformer_spec) catch return CompileError.InvalidSyntax;
-
-            const name = types.symbolName(keyword);
-
-            // Save any existing macro with this name
-            saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
-            saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
-
-            // Capture current locals for referential transparency
-            if (self.locals.items.len > 0) {
-                const tx = types.toObject(transformer).as(types.Transformer);
-                const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return CompileError.OutOfMemory;
-                if (caps.len > 0) {
-                    for (self.locals.items, 0..) |local, ci| {
-                        caps[ci] = .{ .name = local.name, .slot = local.slot };
-                    }
-                    tx.captured_locals = caps;
-                }
-            }
-            self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
-
-            binding_list = types.cdr(binding_list);
-        }
-
-        // Compile body in a new scope
-        self.beginScope();
-        const saved_body_scope = self.in_body_scope;
-        self.in_body_scope = true;
-        const macro_mark = self.beginBodyMacroScope();
-        errdefer self.endBodyMacroScope(macro_mark) catch {};
-        var current = body;
-        while (current != types.NIL) {
-            if (!types.isPair(current)) return CompileError.InvalidSyntax;
-            const expr = types.car(current);
-            current = types.cdr(current);
-            const tail = is_tail and current == types.NIL;
-            try self.compileExpr(expr, dst, tail);
-        }
-        try self.endBodyMacroScope(macro_mark);
-        self.in_body_scope = saved_body_scope;
-        self.endScope();
-
-        // Restore macro table
-        for (saved_names.items, saved_values.items) |name, saved_val| {
-            if (saved_val) |old_val| {
-                try self.macros.put(name, old_val);
-            } else {
-                _ = self.macros.remove(name);
-            }
-        }
-    }
-
-    pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
-        // letrec-syntax is the same as let-syntax for our purposes since we
-        // process all bindings before compiling the body, and the transformer
-        // specs can reference each other through the macro table.
-        return self.compileLetSyntax(args, dst, is_tail);
-    }
-
     pub fn emitLoadValue(self: *Compiler, dst: u16, val: Value) CompileError!void {
         if (val == types.NIL) {
             try self.emitOp(.load_nil);
@@ -1082,18 +729,6 @@ pub const Compiler = struct {
     }
 };
 
-/// Strip hygiene-rename prefixes (`__hyg_<n>_`) so macro-introduced `set!`
-/// forms are recognized. Mirrors the stripping in ir.lowerFormWithMacros.
-fn effectiveSymbolName(name: []const u8) []const u8 {
-    var n = name;
-    while (std.mem.startsWith(u8, n, "__hyg_")) {
-        if (std.mem.indexOfScalar(u8, n[6..], '_')) |sep| {
-            n = n[6 + sep + 1 ..];
-        } else break;
-    }
-    return n;
-}
-
 /// Recursively collect the symbol names that appear as the target of a
 /// `(set! <name> ...)` anywhere in `expr` into `out`. Used to suppress
 /// constant folding of those names within the enclosing form (see
@@ -1105,7 +740,7 @@ fn collectSetTargets(expr: Value, out: *std.StringHashMap(void)) CompileError!vo
     while (types.isPair(cur)) {
         const head = types.car(cur);
         if (types.isSymbol(head)) {
-            const hname = effectiveSymbolName(types.symbolName(head));
+            const hname = types.stripHygienicPrefix(types.symbolName(head));
             if (std.mem.eql(u8, hname, "quote")) return; // literal data, not code
             if (std.mem.eql(u8, hname, "set!")) {
                 const rest = types.cdr(cur);

--- a/src/compiler_forms.zig
+++ b/src/compiler_forms.zig
@@ -2,6 +2,7 @@ pub const conditionals = @import("compiler_conditionals.zig");
 pub const bindings = @import("compiler_bindings.zig");
 pub const advanced = @import("compiler_advanced.zig");
 pub const lambda = @import("compiler_lambda.zig");
+pub const macro_forms = @import("compiler_macro.zig");
 
 // Re-export all public functions so existing callers don't break
 
@@ -36,3 +37,8 @@ pub const compileCase = advanced.compileCase;
 pub const compileCaseLambda = advanced.compileCaseLambda;
 pub const compileQuasiquote = advanced.compileQuasiquote;
 pub const compileParameterize = advanced.compileParameterize;
+
+// Macro forms
+pub const compileDefineSyntax = macro_forms.compileDefineSyntax;
+pub const compileLetSyntax = macro_forms.compileLetSyntax;
+pub const compileLetrecSyntax = macro_forms.compileLetrecSyntax;

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -5,6 +5,7 @@ const compiler_mod = @import("compiler.zig");
 const forms = @import("compiler_forms.zig");
 const advanced = @import("compiler_advanced.zig");
 const compiler_lambda = @import("compiler_lambda.zig");
+const macro = @import("compiler_macro.zig");
 const globals_mod = @import("globals.zig");
 const ir_mod = @import("ir.zig");
 const Value = types.Value;
@@ -51,10 +52,10 @@ pub fn compileFromNode(self: *Compiler, node: *ir_mod.Node, dst: u16, is_tail: b
         .define_values => try compiler_lambda.compileDefineValues(self, node.data.define_values.args, dst),
         .let_values => try forms.compileLetValues(self, node.data.let_values.args, dst, tail),
         .let_star_values => try forms.compileLetStarValues(self, node.data.let_star_values.args, dst, tail),
-        .define_syntax => try self.compileDefineSyntax(node.data.define_syntax.args, dst),
+        .define_syntax => try macro.compileDefineSyntax(self, node.data.define_syntax.args, dst),
         .named_let => try forms.compileNamedLet(self, node.data.named_let.args, dst, tail),
-        .let_syntax => try self.compileLetSyntax(node.data.let_syntax.args, dst, tail),
-        .letrec_syntax => try self.compileLetrecSyntax(node.data.letrec_syntax.args, dst, tail),
+        .let_syntax => try macro.compileLetSyntax(self, node.data.let_syntax.args, dst, tail),
+        .letrec_syntax => try macro.compileLetrecSyntax(self, node.data.letrec_syntax.args, dst, tail),
         .cond_expand => try forms.compileCondExpand(self, node.data.cond_expand.args, dst, is_tail),
         .passthrough => try self.compileExpr(node.data.passthrough, dst, is_tail),
     }
@@ -123,13 +124,7 @@ fn compileCallFromIR(self: *Compiler, call: ir_mod.CallData, dst: u16, is_tail: 
             if (self.resolveLocal(types.symbolName(sym)) == null) {
                 if ((try self.resolveUpvalue(types.symbolName(sym))) == null) {
                     const op_name = types.symbolName(sym);
-                    const is_cont = std.mem.eql(u8, op_name, "call-with-current-continuation") or
-                        std.mem.eql(u8, op_name, "call/cc") or
-                        std.mem.eql(u8, op_name, "call/ec") or
-                        std.mem.eql(u8, op_name, "call-with-escape-continuation") or
-                        std.mem.eql(u8, op_name, "call-with-values") or
-                        std.mem.eql(u8, op_name, "dynamic-wind") or
-                        std.mem.eql(u8, op_name, "with-exception-handler");
+                    const is_cont = types.isContinuationBarrier(op_name);
                     if (!is_cont) {
                         return compileCallGlobalFromIR(self, sym, call.args, dst, nargs, is_tail);
                     }

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -3,7 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const globals_mod = @import("globals.zig");
-const passthrough = @import("compiler_passthrough.zig");
+const macro = @import("compiler_macro.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
@@ -225,7 +225,7 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
             if (ds_rest == types.NIL or !types.isPair(ds_rest)) break;
             const transformer_spec = types.car(ds_rest);
 
-            const transformer = passthrough.parseSyntaxRules(self, transformer_spec) catch break;
+            const transformer = macro.parseSyntaxRules(self, transformer_spec) catch break;
             const name = types.symbolName(keyword);
 
             try self.recordBodyMacro(name);

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -1,0 +1,559 @@
+const std = @import("std");
+const types = @import("types.zig");
+const compiler_mod = @import("compiler.zig");
+const expander = @import("expander.zig");
+const globals_mod = @import("globals.zig");
+const Compiler = compiler_mod.Compiler;
+const CompileError = compiler_mod.CompileError;
+const Value = types.Value;
+
+const MAX_MACRO_EXPANSION_DEPTH: u16 = 256;
+const MAX_MACRO_EXPANSION_STEPS: u32 = 10_000;
+
+pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, transformer: Value, dst: u16, is_tail: bool) CompileError!void {
+    _ = name;
+    if (self.macro_expansion_depth >= MAX_MACRO_EXPANSION_DEPTH or
+        self.macro_expansion_steps >= MAX_MACRO_EXPANSION_STEPS)
+    {
+        return CompileError.MacroExpansionLimit;
+    }
+    self.macro_expansion_depth += 1;
+    self.macro_expansion_steps += 1;
+    defer self.macro_expansion_depth -= 1;
+    // Build merged macro view including parent scopes
+    var merged_macros = std.StringHashMap(Value).init(self.gc.allocator);
+    defer merged_macros.deinit();
+    var p: ?*Compiler = self.parent;
+    while (p) |par| : (p = par.parent) {
+        var it = par.macros.iterator();
+        while (it.next()) |entry| {
+            try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
+        }
+    }
+    var it = self.macros.iterator();
+    while (it.next()) |entry| {
+        try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
+    }
+    const tx = types.toObject(transformer).as(types.Transformer);
+    // Temporarily add/modify globals so the expander doesn't
+    // rename template free references.
+    const TempGlobal = struct { name: []const u8, old_val: ?Value, was_present: bool };
+    var temp_globals: [128]TempGlobal = undefined;
+    var temp_global_count: usize = 0;
+    // Track non-procedure global free vars that need local injection
+    // to prevent shadowing by use-site locals (R7RS 4.3.1).
+    var global_free_names: [64][]const u8 = undefined;
+    var global_free_count: usize = 0;
+    if (self.globals) |g| {
+        // The sentinel puts below structurally mutate the globals
+        // map when g is the VM's shared one — exclude SRFI-18
+        // child-thread readers for the whole dance (#958). glk is
+        // non-null exactly when g is the current thread's shared
+        // globals map.
+        const glk = globals_mod.acquireGlobalsWrite(g);
+        defer globals_mod.releaseGlobalsWrite(glk);
+        for (tx.captured_locals) |cap| {
+            if (!g.contains(cap.name) and temp_global_count < 128) {
+                temp_globals[temp_global_count] = .{ .name = cap.name, .old_val = null, .was_present = false };
+                temp_global_count += 1;
+                try g.put(cap.name, types.VOID);
+            }
+        }
+        if (tx.def_env) |env| {
+            var env_it = env.iterator();
+            while (env_it.next()) |entry| {
+                if (!g.contains(entry.key_ptr.*) and temp_global_count < 128) {
+                    temp_globals[temp_global_count] = .{ .name = entry.key_ptr.*, .old_val = null, .was_present = false };
+                    temp_global_count += 1;
+                    try g.put(entry.key_ptr.*, entry.value_ptr.*);
+                }
+            }
+        }
+        // Temporarily mark non-procedure free globals as VOID so
+        // renameForHygiene preserves them.
+        if (globals_mod.globals_ctx) |gctx| {
+            var cand_names: [64][]const u8 = undefined;
+            var cand_count: usize = 0;
+            var pv_names: [64][]const u8 = undefined;
+            var pv_count: usize = 0;
+            for (tx.patterns[0..tx.num_rules]) |pat| {
+                if (!collectSymbols(pat, &pv_names, &pv_count)) return CompileError.InternalLimit;
+            }
+            for (tx.templates[0..tx.num_rules]) |tmpl| {
+                if (!collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &cand_names, &cand_count)) {
+                    return CompileError.InternalLimit;
+                }
+            }
+            for (cand_names[0..cand_count]) |cname| {
+                const in_g = g.get(cname);
+                // glk != null means g IS the shared globals map
+                // and we already hold its exclusive lock; else
+                // this read needs its own child-thread lock.
+                const in_vm = if (glk != null)
+                    (if (gctx.globals.count() > 0) gctx.globals.get(cname) else null)
+                else in_vm_blk: {
+                    gctx.lockShared();
+                    defer gctx.unlockShared();
+                    break :in_vm_blk if (gctx.globals.count() > 0) gctx.globals.get(cname) else null;
+                };
+                const existing = in_g orelse in_vm;
+                if (existing) |val| {
+                    if (!types.isProcedure(val) and !types.isTransformer(val) and val != types.VOID) {
+                        if (temp_global_count < 128) {
+                            temp_globals[temp_global_count] = .{ .name = cname, .old_val = in_g, .was_present = in_g != null };
+                            temp_global_count += 1;
+                            try g.put(cname, types.VOID);
+                        }
+                        // Track for local injection after expansion
+                        if (global_free_count < 64) {
+                            global_free_names[global_free_count] = cname;
+                            global_free_count += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    defer if (self.globals) |g| {
+        const glk = globals_mod.acquireGlobalsWrite(g);
+        for (temp_globals[0..temp_global_count]) |tg| {
+            if (tg.was_present) {
+                g.put(tg.name, tg.old_val.?) catch {};
+            } else {
+                _ = g.remove(tg.name);
+            }
+        }
+        globals_mod.releaseGlobalsWrite(glk);
+    };
+    // Suppress GC during expansion: the expanded form isn't
+    // rooted until pushRoot below, so a collection triggered
+    // by allocPair inside expandMacro could free AST nodes
+    // that the partially-built result references.
+    self.gc.no_collect += 1;
+    const expanded = expander.expandMacro(self.gc, expr, transformer, self.globals, &merged_macros) catch |err| {
+        self.gc.no_collect -= 1;
+        return switch (err) {
+            error.OutOfMemory => CompileError.OutOfMemory,
+            error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
+            error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch => CompileError.InvalidSyntax,
+        };
+    };
+    var expanded_root = expanded;
+    self.gc.pushRoot(&expanded_root);
+    defer self.gc.popRoot();
+    self.gc.no_collect -= 1;
+    const saved_locals_len = self.locals.items.len;
+    for (tx.captured_locals) |cap| {
+        try self.locals.append(self.gc.allocator, .{
+            .name = cap.name,
+            .depth = self.scope_depth,
+            .slot = cap.slot,
+        });
+    }
+    try injectHygienicCapturedLocals(self, expanded_root, tx.captured_locals);
+    // Inject non-procedure global free vars as locals so
+    // use-site locals don't shadow the definition-site
+    // global binding (R7RS 4.3.1 referential transparency).
+    for (global_free_names[0..global_free_count]) |gname| {
+        // Skip if already covered by captured_locals
+        var already_captured = false;
+        for (tx.captured_locals) |cap| {
+            if (std.mem.eql(u8, cap.name, gname)) {
+                already_captured = true;
+                break;
+            }
+        }
+        if (already_captured) continue;
+        // Load the global value into a fresh register
+        const gslot = self.allocReg() catch continue;
+        const gsym = self.gc.allocSymbol(gname) catch continue;
+        const gsym_idx = self.addConstant(gsym) catch continue;
+        self.emitOp(.get_global) catch continue;
+        self.emitU16(gslot) catch continue;
+        self.emitU16(gsym_idx) catch continue;
+        try self.locals.append(self.gc.allocator, .{
+            .name = gname,
+            .depth = self.scope_depth,
+            .slot = gslot,
+            .is_global_alias = true,
+        });
+    }
+    const result_err = self.compileExpr(expanded_root, dst, is_tail);
+    // Remove injected locals
+    while (self.locals.items.len > saved_locals_len) {
+        _ = self.locals.pop();
+    }
+    return result_err;
+}
+
+// ---------------------------------------------------------------------------
+// Macro definition forms
+// ---------------------------------------------------------------------------
+
+pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!void {
+    if (args == types.NIL) return CompileError.InvalidSyntax;
+    const keyword = types.car(args);
+    if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
+    const rest = types.cdr(args);
+    if (rest == types.NIL) return CompileError.InvalidSyntax;
+    const transformer_spec = types.car(rest);
+
+    const transformer = parseSyntaxRules(self, transformer_spec) catch return CompileError.InvalidSyntax;
+
+    const tx = types.toObject(transformer).as(types.Transformer);
+    if (self.lib_env) |env| {
+        tx.def_env = env;
+        tx.def_env_val = self.lib_env_val;
+    }
+
+    // Store in macro table; inside a body, track the registration so
+    // the enclosing body scope removes it on exit (R7RS 5.3).
+    const name = types.symbolName(keyword);
+    try self.recordBodyMacro(name);
+    self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
+
+    // A define-syntax at a library's top level (not nested in a lambda/let
+    // body scope) is also stored in the library environment (issue #877).
+    if (self.body_macro_depth == 0) {
+        if (self.lib_env) |env| {
+            env.put(name, transformer) catch return CompileError.OutOfMemory;
+        }
+    }
+
+    try self.emitOp(.load_void);
+    try self.emitU16(dst);
+}
+
+pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
+    if (args == types.NIL) return CompileError.InvalidSyntax;
+    const bindings = types.car(args);
+    const body = types.cdr(args);
+    if (body == types.NIL) return CompileError.InvalidSyntax;
+
+    var saved_names: std.ArrayList([]const u8) = .empty;
+    defer saved_names.deinit(self.gc.allocator);
+    var saved_values: std.ArrayList(?Value) = .empty;
+    defer saved_values.deinit(self.gc.allocator);
+
+    var binding_list = bindings;
+    while (binding_list != types.NIL) {
+        if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
+        const binding = types.car(binding_list);
+        if (!types.isPair(binding)) return CompileError.InvalidSyntax;
+
+        const keyword = types.car(binding);
+        if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
+        const binding_rest = types.cdr(binding);
+        if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
+        const transformer_spec = types.car(binding_rest);
+        const transformer = parseSyntaxRules(self, transformer_spec) catch return CompileError.InvalidSyntax;
+
+        const name = types.symbolName(keyword);
+
+        saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
+        saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
+
+        if (self.locals.items.len > 0) {
+            const tx = types.toObject(transformer).as(types.Transformer);
+            const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return CompileError.OutOfMemory;
+            if (caps.len > 0) {
+                for (self.locals.items, 0..) |local, ci| {
+                    caps[ci] = .{ .name = local.name, .slot = local.slot };
+                }
+                tx.captured_locals = caps;
+            }
+        }
+        self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
+
+        binding_list = types.cdr(binding_list);
+    }
+
+    self.beginScope();
+    const saved_body_scope = self.in_body_scope;
+    self.in_body_scope = true;
+    const macro_mark = self.beginBodyMacroScope();
+    errdefer self.endBodyMacroScope(macro_mark) catch {};
+    var current = body;
+    while (current != types.NIL) {
+        if (!types.isPair(current)) return CompileError.InvalidSyntax;
+        const expr = types.car(current);
+        current = types.cdr(current);
+        const tail = is_tail and current == types.NIL;
+        try self.compileExpr(expr, dst, tail);
+    }
+    try self.endBodyMacroScope(macro_mark);
+    self.in_body_scope = saved_body_scope;
+    self.endScope();
+
+    for (saved_names.items, saved_values.items) |name, saved_val| {
+        if (saved_val) |old_val| {
+            try self.macros.put(name, old_val);
+        } else {
+            _ = self.macros.remove(name);
+        }
+    }
+}
+
+pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
+    return compileLetSyntax(self, args, dst, is_tail);
+}
+
+// ---------------------------------------------------------------------------
+// Syntax-rules parsing
+// ---------------------------------------------------------------------------
+
+pub fn parseSyntaxRules(self: *Compiler, spec: Value) CompileError!Value {
+    if (!types.isPair(spec)) return CompileError.InvalidSyntax;
+    const head = types.car(spec);
+    if (!types.isSymbol(head)) return CompileError.InvalidSyntax;
+    if (!std.mem.eql(u8, types.symbolName(head), "syntax-rules")) return CompileError.InvalidSyntax;
+
+    const rest = types.cdr(spec);
+    if (rest == types.NIL) return CompileError.InvalidSyntax;
+
+    var custom_ellipsis: ?[]const u8 = null;
+    var after_ellipsis = rest;
+    const first_arg = types.car(rest);
+    if (types.isSymbol(first_arg) and !types.isPair(first_arg)) {
+        const name_str = types.symbolName(first_arg);
+        if (!std.mem.eql(u8, name_str, "_")) {
+            custom_ellipsis = name_str;
+            after_ellipsis = types.cdr(rest);
+            if (after_ellipsis == types.NIL) return CompileError.InvalidSyntax;
+        }
+    }
+
+    const literals_list = types.car(after_ellipsis);
+    const rules = types.cdr(after_ellipsis);
+
+    var literals_buf: [32]Value = undefined;
+    var lit_count: usize = 0;
+    var lit = literals_list;
+    while (lit != types.NIL) {
+        if (!types.isPair(lit)) return CompileError.InvalidSyntax;
+        if (lit_count >= 32) return CompileError.InvalidSyntax;
+        literals_buf[lit_count] = types.car(lit);
+        lit_count += 1;
+        lit = types.cdr(lit);
+    }
+
+    var patterns_buf: [32]Value = undefined;
+    var templates_buf: [32]Value = undefined;
+    var rule_count: usize = 0;
+    var rule = rules;
+    while (rule != types.NIL) {
+        if (!types.isPair(rule)) return CompileError.InvalidSyntax;
+        const r = types.car(rule);
+        if (!types.isPair(r)) return CompileError.InvalidSyntax;
+        if (rule_count >= 32) return CompileError.InvalidSyntax;
+        patterns_buf[rule_count] = types.car(r);
+        const r_rest = types.cdr(r);
+        if (r_rest == types.NIL) return CompileError.InvalidSyntax;
+        templates_buf[rule_count] = types.car(r_rest);
+        rule_count += 1;
+        rule = types.cdr(rule);
+    }
+
+    if (rule_count == 0) return CompileError.InvalidSyntax;
+
+    const tx_val = self.gc.allocTransformer(
+        literals_buf[0..lit_count],
+        patterns_buf[0..rule_count],
+        templates_buf[0..rule_count],
+    ) catch return CompileError.OutOfMemory;
+    if (custom_ellipsis) |ce| {
+        types.toObject(tx_val).as(types.Transformer).custom_ellipsis = ce;
+    }
+    return tx_val;
+}
+
+// ---------------------------------------------------------------------------
+// Hygienic captured-local injection
+// ---------------------------------------------------------------------------
+
+fn injectHygienicCapturedLocals(self: *Compiler, expr: Value, captured: []const types.CapturedLocal) CompileError!void {
+    if (captured.len == 0) return;
+    try injectHygCapturedWalk(self, expr, captured);
+}
+
+fn injectHygCapturedWalk(self: *Compiler, expr: Value, captured: []const types.CapturedLocal) CompileError!void {
+    if (types.isSymbol(expr)) {
+        const name = types.symbolName(expr);
+        if (!std.mem.startsWith(u8, name, "__hyg_")) return;
+        const base = types.stripHygienicPrefix(name);
+        if (base.len == name.len) return;
+        for (captured) |cap| {
+            if (std.mem.eql(u8, cap.name, base)) {
+                var already = false;
+                for (self.locals.items) |loc| {
+                    if (std.mem.eql(u8, loc.name, name)) {
+                        already = true;
+                        break;
+                    }
+                }
+                if (!already) {
+                    try self.locals.append(self.gc.allocator, .{
+                        .name = name,
+                        .depth = self.scope_depth,
+                        .slot = cap.slot,
+                    });
+                }
+                return;
+            }
+        }
+        return;
+    }
+    if (types.isPair(expr)) {
+        try injectHygCapturedWalk(self, types.car(expr), captured);
+        try injectHygCapturedWalk(self, types.cdr(expr), captured);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free-reference collection for macro hygiene
+// ---------------------------------------------------------------------------
+
+pub fn collectSymbols(expr: Value, out: *[64][]const u8, count: *usize) bool {
+    if (types.isSymbol(expr)) {
+        const n = types.symbolName(expr);
+        for (out[0..count.*]) |e| {
+            if (std.mem.eql(u8, e, n)) return true;
+        }
+        if (count.* >= 64) return false;
+        out[count.*] = n;
+        count.* += 1;
+        return true;
+    }
+    if (types.isPair(expr)) {
+        if (!collectSymbols(types.car(expr), out, count)) return false;
+        return collectSymbols(types.cdr(expr), out, count);
+    }
+    return true;
+}
+
+pub fn collectFreeRefs(template: Value, pat_vars: []const []const u8, literals: []const Value, out: *[64][]const u8, count: *usize) bool {
+    return collectFreeRefsWithLocals(template, pat_vars, literals, &.{}, out, count);
+}
+
+fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, literals: []const Value, local_binds: []const []const u8, out: *[64][]const u8, count: *usize) bool {
+    if (types.isSymbol(template)) {
+        const name = types.symbolName(template);
+        for (pat_vars) |pv| {
+            if (std.mem.eql(u8, pv, name)) return true;
+        }
+        for (local_binds) |lb| {
+            if (std.mem.eql(u8, lb, name)) return true;
+        }
+        for (literals) |lit| {
+            if (types.isSymbol(lit) and std.mem.eql(u8, types.symbolName(lit), name)) return true;
+        }
+        if (expander.isWellKnown(name)) return true;
+        for (out[0..count.*]) |e| {
+            if (std.mem.eql(u8, e, name)) return true;
+        }
+        if (count.* >= 64) return false;
+        out[count.*] = name;
+        count.* += 1;
+        return true;
+    }
+    if (!types.isPair(template)) return true;
+    const head = types.car(template);
+    const rest = types.cdr(template);
+    if (types.isSymbol(head)) {
+        const hname = types.symbolName(head);
+        if (isLetForm(hname)) {
+            if (rest != types.NIL and types.isPair(rest)) {
+                var bab = rest;
+                if (types.isSymbol(types.car(rest))) bab = types.cdr(rest);
+                if (bab != types.NIL and types.isPair(bab)) {
+                    var let_names: [16][]const u8 = undefined;
+                    var let_count: usize = 0;
+                    for (local_binds) |lb| {
+                        if (let_count < 16) {
+                            let_names[let_count] = lb;
+                            let_count += 1;
+                        }
+                    }
+                    var binds = types.car(bab);
+                    while (types.isPair(binds)) {
+                        const b = types.car(binds);
+                        if (types.isPair(b)) {
+                            const bname = types.car(b);
+                            if (types.isSymbol(bname) and let_count < 16) {
+                                let_names[let_count] = types.symbolName(bname);
+                                let_count += 1;
+                            }
+                            const init_rest2 = types.cdr(b);
+                            if (init_rest2 != types.NIL and types.isPair(init_rest2))
+                                if (!collectFreeRefsWithLocals(types.car(init_rest2), pat_vars, literals, local_binds, out, count)) return false;
+                        }
+                        binds = types.cdr(binds);
+                    }
+                    if (!collectFreeRefsWithLocals(types.cdr(bab), pat_vars, literals, let_names[0..let_count], out, count)) return false;
+                }
+            }
+            return true;
+        }
+        if (std.mem.eql(u8, hname, "lambda")) {
+            if (rest != types.NIL and types.isPair(rest)) {
+                var lam_names: [16][]const u8 = undefined;
+                var lam_count: usize = 0;
+                for (local_binds) |lb| {
+                    if (lam_count < 16) {
+                        lam_names[lam_count] = lb;
+                        lam_count += 1;
+                    }
+                }
+                var params = types.car(rest);
+                while (types.isPair(params)) {
+                    const pp = types.car(params);
+                    if (types.isSymbol(pp) and lam_count < 16) {
+                        lam_names[lam_count] = types.symbolName(pp);
+                        lam_count += 1;
+                    }
+                    params = types.cdr(params);
+                }
+                if (types.isSymbol(params) and lam_count < 16) {
+                    lam_names[lam_count] = types.symbolName(params);
+                    lam_count += 1;
+                }
+                if (!collectFreeRefsWithLocals(types.cdr(rest), pat_vars, literals, lam_names[0..lam_count], out, count)) return false;
+            }
+            return true;
+        }
+        if (std.mem.eql(u8, hname, "define")) {
+            if (rest != types.NIL and types.isPair(rest))
+                if (!collectFreeRefsWithLocals(types.cdr(rest), pat_vars, literals, local_binds, out, count)) return false;
+            return true;
+        }
+        if (std.mem.eql(u8, hname, "syntax-rules")) {
+            if (rest != types.NIL and types.isPair(rest)) {
+                var sr_names: [64][]const u8 = undefined;
+                var sr_count: usize = 0;
+                for (local_binds) |lb| {
+                    if (sr_count < 64) {
+                        sr_names[sr_count] = lb;
+                        sr_count += 1;
+                    }
+                }
+                var sr_rules = types.cdr(rest);
+                while (types.isPair(sr_rules)) {
+                    const sr_rule = types.car(sr_rules);
+                    if (types.isPair(sr_rule)) {
+                        if (!collectSymbols(types.car(sr_rule), @ptrCast(&sr_names), &sr_count)) return false;
+                    }
+                    sr_rules = types.cdr(sr_rules);
+                }
+                if (!collectFreeRefsWithLocals(rest, pat_vars, literals, sr_names[0..sr_count], out, count)) return false;
+            }
+            return true;
+        }
+    }
+    if (!collectFreeRefsWithLocals(head, pat_vars, literals, local_binds, out, count)) return false;
+    return collectFreeRefsWithLocals(rest, pat_vars, literals, local_binds, out, count);
+}
+
+fn isLetForm(name: []const u8) bool {
+    return std.mem.eql(u8, name, "let") or std.mem.eql(u8, name, "let*") or
+        std.mem.eql(u8, name, "letrec") or std.mem.eql(u8, name, "letrec*");
+}

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const types = @import("types.zig");
-const expander = @import("expander.zig");
 const compiler_mod = @import("compiler.zig");
 const globals_mod = @import("globals.zig");
 const Compiler = compiler_mod.Compiler;
@@ -57,71 +56,6 @@ pub fn compileIf(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     }
 }
 
-pub fn parseSyntaxRules(self: *Compiler, spec: Value) CompileError!Value {
-    if (!types.isPair(spec)) return CompileError.InvalidSyntax;
-    const head = types.car(spec);
-    if (!types.isSymbol(head)) return CompileError.InvalidSyntax;
-    if (!std.mem.eql(u8, types.symbolName(head), "syntax-rules")) return CompileError.InvalidSyntax;
-
-    const rest = types.cdr(spec);
-    if (rest == types.NIL) return CompileError.InvalidSyntax;
-
-    var custom_ellipsis: ?[]const u8 = null;
-    var after_ellipsis = rest;
-    const first_arg = types.car(rest);
-    if (types.isSymbol(first_arg) and !types.isPair(first_arg)) {
-        const name_str = types.symbolName(first_arg);
-        if (!std.mem.eql(u8, name_str, "_")) {
-            custom_ellipsis = name_str;
-            after_ellipsis = types.cdr(rest);
-            if (after_ellipsis == types.NIL) return CompileError.InvalidSyntax;
-        }
-    }
-
-    const literals_list = types.car(after_ellipsis);
-    const rules = types.cdr(after_ellipsis);
-
-    var literals_buf: [32]Value = undefined;
-    var lit_count: usize = 0;
-    var lit = literals_list;
-    while (lit != types.NIL) {
-        if (!types.isPair(lit)) return CompileError.InvalidSyntax;
-        if (lit_count >= 32) return CompileError.InvalidSyntax;
-        literals_buf[lit_count] = types.car(lit);
-        lit_count += 1;
-        lit = types.cdr(lit);
-    }
-
-    var patterns_buf: [32]Value = undefined;
-    var templates_buf: [32]Value = undefined;
-    var rule_count: usize = 0;
-    var rule = rules;
-    while (rule != types.NIL) {
-        if (!types.isPair(rule)) return CompileError.InvalidSyntax;
-        const r = types.car(rule);
-        if (!types.isPair(r)) return CompileError.InvalidSyntax;
-        if (rule_count >= 32) return CompileError.InvalidSyntax;
-        patterns_buf[rule_count] = types.car(r);
-        const r_rest = types.cdr(r);
-        if (r_rest == types.NIL) return CompileError.InvalidSyntax;
-        templates_buf[rule_count] = types.car(r_rest);
-        rule_count += 1;
-        rule = types.cdr(rule);
-    }
-
-    if (rule_count == 0) return CompileError.InvalidSyntax;
-
-    const tx_val = self.gc.allocTransformer(
-        literals_buf[0..lit_count],
-        patterns_buf[0..rule_count],
-        templates_buf[0..rule_count],
-    ) catch return CompileError.OutOfMemory;
-    if (custom_ellipsis) |ce| {
-        types.toObject(tx_val).as(types.Transformer).custom_ellipsis = ce;
-    }
-    return tx_val;
-}
-
 pub fn compileCall(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
     const operator = types.car(expr);
 
@@ -163,13 +97,7 @@ pub fn compileCall(self: *Compiler, expr: Value, dst: u16, is_tail: bool) Compil
     if (!is_tail and args_valid and types.isSymbol(operator) and self.resolveLocal(types.symbolName(operator)) == null) {
         if ((try self.resolveUpvalue(types.symbolName(operator))) == null) {
             const op_name = types.symbolName(operator);
-            const is_cont = std.mem.eql(u8, op_name, "call-with-current-continuation") or
-                std.mem.eql(u8, op_name, "call/cc") or
-                std.mem.eql(u8, op_name, "call/ec") or
-                std.mem.eql(u8, op_name, "call-with-escape-continuation") or
-                std.mem.eql(u8, op_name, "call-with-values") or
-                std.mem.eql(u8, op_name, "dynamic-wind") or
-                std.mem.eql(u8, op_name, "with-exception-handler");
+            const is_cont = types.isContinuationBarrier(op_name);
             if (!is_cont) {
                 return compileCallGlobal(self, expr, operator, dst, is_tail);
             }
@@ -410,153 +338,4 @@ fn compileCallGlobal(self: *Compiler, expr: Value, operator: Value, dst: u16, is
         try self.emitU16(base);
         self.freeReg();
     }
-}
-
-// ---------------------------------------------------------------------------
-// Free-reference collection for macro hygiene
-// ---------------------------------------------------------------------------
-
-pub fn collectSymbols(expr: Value, out: *[64][]const u8, count: *usize) bool {
-    if (types.isSymbol(expr)) {
-        const n = types.symbolName(expr);
-        for (out[0..count.*]) |e| {
-            if (std.mem.eql(u8, e, n)) return true;
-        }
-        if (count.* >= 64) return false;
-        out[count.*] = n;
-        count.* += 1;
-        return true;
-    }
-    if (types.isPair(expr)) {
-        if (!collectSymbols(types.car(expr), out, count)) return false;
-        return collectSymbols(types.cdr(expr), out, count);
-    }
-    return true;
-}
-
-pub fn collectFreeRefs(template: Value, pat_vars: []const []const u8, literals: []const Value, out: *[64][]const u8, count: *usize) bool {
-    return collectFreeRefsWithLocals(template, pat_vars, literals, &.{}, out, count);
-}
-
-fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, literals: []const Value, local_binds: []const []const u8, out: *[64][]const u8, count: *usize) bool {
-    if (types.isSymbol(template)) {
-        const name = types.symbolName(template);
-        for (pat_vars) |pv| {
-            if (std.mem.eql(u8, pv, name)) return true;
-        }
-        for (local_binds) |lb| {
-            if (std.mem.eql(u8, lb, name)) return true;
-        }
-        for (literals) |lit| {
-            if (types.isSymbol(lit) and std.mem.eql(u8, types.symbolName(lit), name)) return true;
-        }
-        if (expander.isWellKnown(name)) return true;
-        for (out[0..count.*]) |e| {
-            if (std.mem.eql(u8, e, name)) return true;
-        }
-        if (count.* >= 64) return false;
-        out[count.*] = name;
-        count.* += 1;
-        return true;
-    }
-    if (!types.isPair(template)) return true;
-    const head = types.car(template);
-    const rest = types.cdr(template);
-    if (types.isSymbol(head)) {
-        const hname = types.symbolName(head);
-        if (isLetForm(hname)) {
-            if (rest != types.NIL and types.isPair(rest)) {
-                var bab = rest;
-                if (types.isSymbol(types.car(rest))) bab = types.cdr(rest);
-                if (bab != types.NIL and types.isPair(bab)) {
-                    var let_names: [16][]const u8 = undefined;
-                    var let_count: usize = 0;
-                    for (local_binds) |lb| {
-                        if (let_count < 16) {
-                            let_names[let_count] = lb;
-                            let_count += 1;
-                        }
-                    }
-                    var binds = types.car(bab);
-                    while (types.isPair(binds)) {
-                        const b = types.car(binds);
-                        if (types.isPair(b)) {
-                            const bname = types.car(b);
-                            if (types.isSymbol(bname) and let_count < 16) {
-                                let_names[let_count] = types.symbolName(bname);
-                                let_count += 1;
-                            }
-                            const init_rest2 = types.cdr(b);
-                            if (init_rest2 != types.NIL and types.isPair(init_rest2))
-                                if (!collectFreeRefsWithLocals(types.car(init_rest2), pat_vars, literals, local_binds, out, count)) return false;
-                        }
-                        binds = types.cdr(binds);
-                    }
-                    if (!collectFreeRefsWithLocals(types.cdr(bab), pat_vars, literals, let_names[0..let_count], out, count)) return false;
-                }
-            }
-            return true;
-        }
-        if (std.mem.eql(u8, hname, "lambda")) {
-            if (rest != types.NIL and types.isPair(rest)) {
-                var lam_names: [16][]const u8 = undefined;
-                var lam_count: usize = 0;
-                for (local_binds) |lb| {
-                    if (lam_count < 16) {
-                        lam_names[lam_count] = lb;
-                        lam_count += 1;
-                    }
-                }
-                var params = types.car(rest);
-                while (types.isPair(params)) {
-                    const p = types.car(params);
-                    if (types.isSymbol(p) and lam_count < 16) {
-                        lam_names[lam_count] = types.symbolName(p);
-                        lam_count += 1;
-                    }
-                    params = types.cdr(params);
-                }
-                if (types.isSymbol(params) and lam_count < 16) {
-                    lam_names[lam_count] = types.symbolName(params);
-                    lam_count += 1;
-                }
-                if (!collectFreeRefsWithLocals(types.cdr(rest), pat_vars, literals, lam_names[0..lam_count], out, count)) return false;
-            }
-            return true;
-        }
-        if (std.mem.eql(u8, hname, "define")) {
-            if (rest != types.NIL and types.isPair(rest))
-                if (!collectFreeRefsWithLocals(types.cdr(rest), pat_vars, literals, local_binds, out, count)) return false;
-            return true;
-        }
-        if (std.mem.eql(u8, hname, "syntax-rules")) {
-            if (rest != types.NIL and types.isPair(rest)) {
-                var sr_names: [64][]const u8 = undefined;
-                var sr_count: usize = 0;
-                for (local_binds) |lb| {
-                    if (sr_count < 64) {
-                        sr_names[sr_count] = lb;
-                        sr_count += 1;
-                    }
-                }
-                var rules = types.cdr(rest);
-                while (types.isPair(rules)) {
-                    const rule = types.car(rules);
-                    if (types.isPair(rule)) {
-                        if (!collectSymbols(types.car(rule), @ptrCast(&sr_names), &sr_count)) return false;
-                    }
-                    rules = types.cdr(rules);
-                }
-                if (!collectFreeRefsWithLocals(rest, pat_vars, literals, sr_names[0..sr_count], out, count)) return false;
-            }
-            return true;
-        }
-    }
-    if (!collectFreeRefsWithLocals(head, pat_vars, literals, local_binds, out, count)) return false;
-    return collectFreeRefsWithLocals(rest, pat_vars, literals, local_binds, out, count);
-}
-
-fn isLetForm(name: []const u8) bool {
-    return std.mem.eql(u8, name, "let") or std.mem.eql(u8, name, "let*") or
-        std.mem.eql(u8, name, "letrec") or std.mem.eql(u8, name, "letrec*");
 }

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -415,12 +415,7 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
     if (types.isSymbol(head)) {
         const name = types.symbolName(head);
 
-        var effective_name = name;
-        while (std.mem.startsWith(u8, effective_name, "__hyg_")) {
-            if (std.mem.indexOfScalar(u8, effective_name[6..], '_')) |sep| {
-                effective_name = effective_name[6 + sep + 1 ..];
-            } else break;
-        }
+        const effective_name = types.stripHygienicPrefix(name);
 
         // R7RS has no reserved words: a lexical binding of a keyword shadows
         // the syntax. If the (non-hygienic) head names a local or captured

--- a/src/ir_emitter.zig
+++ b/src/ir_emitter.zig
@@ -100,13 +100,7 @@ pub const Emitter = struct {
             const sym = call.operator.data.global_ref;
             if (types.isSymbol(sym)) {
                 const op_name = types.symbolName(sym);
-                const is_cont = std.mem.eql(u8, op_name, "call-with-current-continuation") or
-                    std.mem.eql(u8, op_name, "call/cc") or
-                    std.mem.eql(u8, op_name, "call/ec") or
-                    std.mem.eql(u8, op_name, "call-with-escape-continuation") or
-                    std.mem.eql(u8, op_name, "call-with-values") or
-                    std.mem.eql(u8, op_name, "dynamic-wind") or
-                    std.mem.eql(u8, op_name, "with-exception-handler");
+                const is_cont = types.isContinuationBarrier(op_name);
 
                 if (!is_cont) {
                     return self.emitCallGlobal(sym, call.args, dst, nargs, is_tail);

--- a/src/types.zig
+++ b/src/types.zig
@@ -1056,6 +1056,26 @@ pub fn symbolName(v: Value) []const u8 {
     return toObject(v).as(Symbol).name;
 }
 
+pub fn stripHygienicPrefix(name: []const u8) []const u8 {
+    var n = name;
+    while (std.mem.startsWith(u8, n, "__hyg_")) {
+        if (std.mem.indexOfScalar(u8, n[6..], '_')) |sep| {
+            n = n[6 + sep + 1 ..];
+        } else break;
+    }
+    return n;
+}
+
+pub fn isContinuationBarrier(name: []const u8) bool {
+    return std.mem.eql(u8, name, "call-with-current-continuation") or
+        std.mem.eql(u8, name, "call/cc") or
+        std.mem.eql(u8, name, "call/ec") or
+        std.mem.eql(u8, name, "call-with-escape-continuation") or
+        std.mem.eql(u8, name, "call-with-values") or
+        std.mem.eql(u8, name, "dynamic-wind") or
+        std.mem.eql(u8, name, "with-exception-handler");
+}
+
 // ---------------------------------------------------------------------------
 // Box helpers (upvalue box = pair whose cdr is VOID)
 // ---------------------------------------------------------------------------

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -15,16 +15,6 @@ const vm_debug = @import("vm_debug.zig");
 const vm_library = @import("vm_library.zig");
 const vm_records = @import("vm_records.zig");
 
-fn stripHygienicPrefix(name: []const u8) []const u8 {
-    var n = name;
-    while (std.mem.startsWith(u8, n, "__hyg_")) {
-        if (std.mem.indexOfScalar(u8, n[6..], '_')) |sep| {
-            n = n[6 + sep + 1 ..];
-        } else break;
-    }
-    return n;
-}
-
 /// True when a just-restored (or escape-unwound) frame stack should resume in
 /// THIS dispatch loop: the new stack must still contain the loop's scope-root
 /// frame, identified by birth id — frame depth alone can't distinguish "these
@@ -228,7 +218,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (func.env != null) {
                         if (self.globals.get(name)) |gval| break :blk gval;
                     }
-                    const base = stripHygienicPrefix(name);
+                    const base = types.stripHygienicPrefix(name);
                     if (base.len != name.len) {
                         if (env.get(base)) |bval| break :blk bval;
                         if (env != self.globals) {
@@ -275,7 +265,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 // sufficient.
                 self.lockGlobalsShared();
                 const ptr: ?*Value = env.getPtr(name) orelse blk: {
-                    const base = stripHygienicPrefix(name);
+                    const base = types.stripHygienicPrefix(name);
                     if (base.len != name.len) {
                         if (env.getPtr(base)) |bptr| break :blk bptr;
                         if (env != self.globals) {
@@ -1260,7 +1250,7 @@ noinline fn raiseUndefinedVariable(self: *VM, name: []const u8) VMError {
 inline fn lookupGlobalLocked(self: *VM, env: *std.StringHashMap(Value), name: []const u8) ?Value {
     self.lockGlobalsShared();
     const found: ?Value = env.get(name) orelse blk: {
-        const b = stripHygienicPrefix(name);
+        const b = types.stripHygienicPrefix(name);
         if (b.len != name.len) {
             if (env.get(b)) |bval| break :blk bval;
         }

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -6,7 +6,7 @@ const library_mod = @import("library.zig");
 const file_utils = @import("file_utils.zig");
 const Value = types.Value;
 
-const passthrough = @import("compiler_passthrough.zig");
+const macro = @import("compiler_macro.zig");
 const vm_mod = @import("vm.zig");
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
@@ -62,14 +62,14 @@ fn copyTransformerFreeRefs(
     var pv_names: [64][]const u8 = undefined;
     var pv_count: usize = 0;
     for (tx.patterns[0..tx.num_rules]) |pat| {
-        if (!passthrough.collectSymbols(pat, &pv_names, &pv_count)) break;
+        if (!macro.collectSymbols(pat, &pv_names, &pv_count)) break;
     }
     for (tx.templates[0..tx.num_rules]) |tmpl| {
         // Per-template array: bounds each template at 64 free refs instead
         // of 64 across all rules of the transformer.
         var free_names: [64][]const u8 = undefined;
         var free_count: usize = 0;
-        _ = passthrough.collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &free_names, &free_count);
+        _ = macro.collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &free_names, &free_count);
         for (free_names[0..free_count]) |fname| {
             if (env.get(fname)) |fval| {
                 if (target == vm.globals) {


### PR DESCRIPTION
## Summary

- Extract ~175 lines of macro-use machinery from `compileForm()` into `compiler_macro.zig:expandAndCompileMacroUse()`
- Move `compileDefineSyntax`, `compileLetSyntax`, `compileLetrecSyntax` from `compiler.zig` to `compiler_macro.zig`
- Move `parseSyntaxRules`, `collectSymbols`, `collectFreeRefs` from `compiler_passthrough.zig` to `compiler_macro.zig`
- Consolidate `stripHygienicPrefix` (5 copies → 1 in `types.zig`) and `isContinuationBarrier` (3 copies → 1 in `types.zig`)
- `compiler.zig`: 1254 → 889 lines; `compiler_passthrough.zig`: 562 → 341 lines (now purely passthrough compilation)

Pure refactoring — no behavioral changes.

Closes #1043

## Test plan

- [x] `zig build` — clean compilation
- [x] `zig build test` — all unit tests pass (including `tests_macros.zig` 27+ tests)
- [x] `bash tests/scheme/run-all.sh` — all 318+ Scheme tests pass (smoke, compliance, continuations, hygiene, SRFI, FFI, audit, errors)
- [x] All 7 hygiene test files pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)