### PR TITLE
Consolidate writeToFd/writeStdout/writeStderr into reporting.zig (#1067)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,32 +1,13 @@
 const std = @import("std");
 const completions = @import("completions.zig");
+const reporting = @import("reporting.zig");
 
 pub const version = @import("build_options").version;
 
 pub const USAGE_ERROR_EXIT: u8 = 2;
 
-// ── I/O helpers (private copies — main.zig keeps its own) ──────────────
-
-fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
-    var total: usize = 0;
-    while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) {
-            if (result < 0 and std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        const written: usize = @intCast(result);
-        total += written;
-    }
-}
-
-fn writeStdout(bytes: []const u8) void {
-    writeToFd(1, bytes);
-}
-
-fn writeStderr(bytes: []const u8) void {
-    writeToFd(2, bytes);
-}
+const writeStdout = reporting.writeStdout;
+const writeStderr = reporting.writeStderr;
 
 // ── Flag table ─────────────────────────────────────────────────────────
 

--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -4,6 +4,7 @@ const OpCode = types.OpCode;
 const Value = types.Value;
 const printer = @import("printer.zig");
 const memory = @import("memory.zig");
+const reporting = @import("reporting.zig");
 
 pub fn disassemble(func: *types.Function, allocator: std.mem.Allocator) void {
     printHeader(func, allocator);
@@ -492,14 +493,5 @@ threadlocal var suppress_output: bool = false;
 
 fn writeStderr(bytes: []const u8) void {
     if (suppress_output) return;
-    var total: usize = 0;
-    while (total < bytes.len) {
-        const result: isize = std.posix.system.write(2, bytes.ptr + total, bytes.len - total);
-        if (result < 0) {
-            if (std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        if (result == 0) break;
-        total += @intCast(result);
-    }
+    reporting.writeToFd(2, bytes);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -47,26 +47,8 @@ pub const cli = @import("cli.zig");
 
 pub const version = @import("build_options").version;
 
-fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
-    var total: usize = 0;
-    while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) {
-            if (result < 0 and std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        const written: usize = @intCast(result);
-        total += written;
-    }
-}
-
-fn writeStdout(bytes: []const u8) void {
-    writeToFd(1, bytes);
-}
-
-fn writeStderr(bytes: []const u8) void {
-    writeToFd(2, bytes);
-}
+const writeStdout = reporting.writeStdout;
+const writeStderr = reporting.writeStderr;
 
 const usageError = cli.usageError;
 

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -6,27 +6,10 @@ const vm_mod = @import("vm.zig");
 const ir_mod = @import("ir.zig");
 const llvm_emit = @import("llvm_emit.zig");
 const file_utils = @import("file_utils.zig");
+const reporting = @import("reporting.zig");
 
-fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
-    var total: usize = 0;
-    while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) {
-            if (result < 0 and std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        const written: usize = @intCast(result);
-        total += written;
-    }
-}
-
-fn writeStdout(bytes: []const u8) void {
-    writeToFd(1, bytes);
-}
-
-fn writeStderr(bytes: []const u8) void {
-    writeToFd(2, bytes);
-}
+const writeStdout = reporting.writeStdout;
+const writeStderr = reporting.writeStderr;
 
 pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -101,26 +101,10 @@ pub fn registerIOSandboxed(vm: *vm_mod.VM) !void {
 // Port helpers
 // ---------------------------------------------------------------------------
 
-pub fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
-    var total: usize = 0;
-    while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result < 0) {
-            if (std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        if (result == 0) break;
-        total += @as(usize, @intCast(result));
-    }
-}
-
-pub fn writeStdout(bytes: []const u8) void {
-    writeToFd(1, bytes);
-}
-
-pub fn writeStderr(bytes: []const u8) void {
-    writeToFd(2, bytes);
-}
+const reporting = @import("reporting.zig");
+pub const writeToFd = reporting.writeToFd;
+pub const writeStdout = reporting.writeStdout;
+pub const writeStderr = reporting.writeStderr;
 
 /// Get the output port: use args[arg_idx] if provided, else current-output-port.
 fn getOutputPort(args: []const Value, arg_idx: usize, proc: []const u8) PrimitiveError!*types.Port {

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -24,26 +24,8 @@ fn getTerminalWidth() u16 {
     return 80;
 }
 
-fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
-    var total: usize = 0;
-    while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) {
-            if (result < 0 and std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        const written: usize = @intCast(result);
-        total += written;
-    }
-}
-
-fn writeStdout(bytes: []const u8) void {
-    writeToFd(1, bytes);
-}
-
-fn writeStderr(bytes: []const u8) void {
-    writeToFd(2, bytes);
-}
+const writeStdout = reporting.writeStdout;
+const writeStderr = reporting.writeStderr;
 
 fn isIdentBreak(c: u8) bool {
     return switch (c) {

--- a/src/reporting.zig
+++ b/src/reporting.zig
@@ -5,7 +5,7 @@ pub const vm_mod = @import("vm.zig");
 pub const library_mod = @import("library.zig");
 const file_utils = @import("file_utils.zig");
 
-fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
+pub fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
         const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
@@ -16,6 +16,10 @@ fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
         if (result == 0) break;
         total += @as(usize, @intCast(result));
     }
+}
+
+pub fn writeStdout(bytes: []const u8) void {
+    writeToFd(1, bytes);
 }
 
 pub fn writeStderr(bytes: []const u8) void {
@@ -444,16 +448,7 @@ pub fn writeCoverageXml(vm: *vm_mod.VM, path: []const u8) void {
     };
     defer _ = std.posix.system.close(fd);
 
-    var written: usize = 0;
-    while (written < xml.items.len) {
-        const result = std.posix.system.write(fd, xml.items.ptr + written, xml.items.len - written);
-        if (result < 0) {
-            if (std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        if (result == 0) break;
-        written += @as(usize, @intCast(result));
-    }
+    writeToFd(fd, xml.items);
 }
 
 fn getCallCount(val: types.Value) ?u64 {

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -62,7 +62,11 @@ fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
         const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) break;
+        if (result < 0) {
+            if (std.posix.errno(result) == .INTR) continue;
+            break;
+        }
+        if (result == 0) break;
         total += @as(usize, @intCast(result));
     }
 }

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -1,22 +1,8 @@
 const std = @import("std");
 const vm_mod = @import("vm.zig");
+const reporting = @import("reporting.zig");
 
-fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
-    var total: usize = 0;
-    while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result <= 0) {
-            if (result < 0 and std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        const written: usize = @intCast(result);
-        total += written;
-    }
-}
-
-fn writeStderr(bytes: []const u8) void {
-    writeToFd(2, bytes);
-}
+const writeStderr = reporting.writeStderr;
 
 pub const Location = struct {
     source: []const u8,

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -124,22 +124,7 @@ fn markVMRoots(gc: *memory.GC) void {
 
 pub const ExceptionHandler = types.ExceptionHandler;
 
-fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
-    var total: usize = 0;
-    while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
-        if (result < 0) {
-            if (std.posix.errno(result) == .INTR) continue;
-            break;
-        }
-        if (result == 0) break;
-        total += @as(usize, @intCast(result));
-    }
-}
-
-pub fn writeStderr(bytes: []const u8) void {
-    writeToFd(2, bytes);
-}
+pub const writeStderr = @import("reporting.zig").writeStderr;
 
 pub const CallFrame = types.CallFrame;
 


### PR DESCRIPTION
## Summary

- One canonical `writeToFd`/`writeStdout`/`writeStderr` in `reporting.zig` (pub, with EINTR retry), replacing 9 copy-pasted definitions across the interpreter
- `vm.zig` and `primitives_io.zig` keep `pub const` re-exports so transitive consumers (`vm_debug`, `vm_library`, `primitives_control`, `primitives_bytevector`) need no changes
- `disassembler.zig` keeps its `suppress_output` guard, delegates the actual write to `reporting.writeToFd`
- `thottam.zig` keeps its own copy (separate binary) but gains EINTR retry — the only file that was missing it
- Bonus: replaced an inline write loop in `reporting.zig`'s XML coverage output with a `writeToFd` call

Net -126 lines.

Closes #1067

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail
- [x] `bash tests/scheme/errors/error-format.sh` — 34 pass
- [x] `bash tests/scheme/errors/exit-code.sh` — 39 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)