### PR TITLE
Add RootedSlot/RootedScope helpers, migrate 36 manual extra_roots sites (#1054)

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1128,6 +1128,43 @@ pub const GC = struct {
     pub fn popRoot(self: *GC) void {
         self.root_count -= 1;
     }
+
+    pub const RootedSlot = struct {
+        gc: *GC,
+        idx: usize,
+
+        pub fn set(self: RootedSlot, val: Value) void {
+            self.gc.extra_roots.items[self.idx] = val;
+        }
+
+        pub fn get(self: RootedSlot) Value {
+            return self.gc.extra_roots.items[self.idx];
+        }
+
+        pub fn release(self: RootedSlot) void {
+            if (self.idx == self.gc.extra_roots.items.len - 1) {
+                _ = self.gc.extra_roots.pop();
+            }
+        }
+    };
+
+    pub fn rootedSlot(self: *GC, val: Value) error{OutOfMemory}!RootedSlot {
+        self.extra_roots.append(self.allocator, val) catch return error.OutOfMemory;
+        return .{ .gc = self, .idx = self.extra_roots.items.len - 1 };
+    }
+
+    pub const RootedScope = struct {
+        gc: *GC,
+        base: usize,
+
+        pub fn release(self: RootedScope) void {
+            self.gc.extra_roots.shrinkRetainingCapacity(self.base);
+        }
+    };
+
+    pub fn rootedScope(self: *GC) RootedScope {
+        return .{ .gc = self, .base = self.extra_roots.items.len };
+    }
 };
 
 // ---------------------------------------------------------------------------
@@ -1222,4 +1259,45 @@ test "allocNativeClosure triggers GC" {
     // Without maybeCollect, object_count would be 10.
     // With it, GC runs and collects unrooted closures.
     try std.testing.expect(gc.object_count < 10);
+}
+
+test "rootedSlot set/get/release" {
+    var gc = GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const v1 = types.makeFixnum(10);
+    const v2 = types.makeFixnum(20);
+    const v3 = types.makeFixnum(30);
+
+    var slot_a = try gc.rootedSlot(v1);
+    try std.testing.expectEqual(v1, slot_a.get());
+    try std.testing.expectEqual(@as(usize, 1), gc.extra_roots.items.len);
+
+    var slot_b = try gc.rootedSlot(v2);
+    try std.testing.expectEqual(v2, slot_b.get());
+    try std.testing.expectEqual(@as(usize, 2), gc.extra_roots.items.len);
+
+    slot_b.set(v3);
+    try std.testing.expectEqual(v3, slot_b.get());
+    try std.testing.expectEqual(v1, slot_a.get());
+
+    slot_b.release();
+    try std.testing.expectEqual(@as(usize, 1), gc.extra_roots.items.len);
+    slot_a.release();
+    try std.testing.expectEqual(@as(usize, 0), gc.extra_roots.items.len);
+}
+
+test "rootedScope release" {
+    var gc = GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    gc.extra_roots.append(gc.allocator, types.makeFixnum(1)) catch unreachable;
+    const scope = gc.rootedScope();
+    gc.extra_roots.append(gc.allocator, types.makeFixnum(2)) catch unreachable;
+    gc.extra_roots.append(gc.allocator, types.makeFixnum(3)) catch unreachable;
+    try std.testing.expectEqual(@as(usize, 3), gc.extra_roots.items.len);
+
+    scope.release();
+    try std.testing.expectEqual(@as(usize, 1), gc.extra_roots.items.len);
+    try std.testing.expectEqual(types.makeFixnum(1), gc.extra_roots.items[0]);
 }

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -77,20 +77,13 @@ fn ratPartsVal(v: Value) PrimitiveError!RatPartsVal {
 }
 
 fn allocRationalRooted(gc: *@import("memory.zig").GC, n: i64, d: i64) PrimitiveError!Value {
-    var num = try makeFixnumChecked(n);
-    gc.extra_roots.append(gc.allocator, num) catch return PrimitiveError.OutOfMemory;
-    var den = try makeFixnumChecked(d);
-    gc.extra_roots.append(gc.allocator, den) catch return PrimitiveError.OutOfMemory;
-    num = gc.extra_roots.items[gc.extra_roots.items.len - 2];
-    den = gc.extra_roots.items[gc.extra_roots.items.len - 1];
-    const result = gc.allocRational(num, den) catch {
-        _ = gc.extra_roots.pop();
-        _ = gc.extra_roots.pop();
-        return PrimitiveError.OutOfMemory;
-    };
-    _ = gc.extra_roots.pop();
-    _ = gc.extra_roots.pop();
-    return result;
+    const num = try makeFixnumChecked(n);
+    var slot_num = gc.rootedSlot(num) catch return PrimitiveError.OutOfMemory;
+    defer slot_num.release();
+    const den = try makeFixnumChecked(d);
+    var slot_den = gc.rootedSlot(den) catch return PrimitiveError.OutOfMemory;
+    defer slot_den.release();
+    return gc.allocRational(slot_num.get(), slot_den.get()) catch return PrimitiveError.OutOfMemory;
 }
 
 /// Construct a reduced rational (or integer if den divides num).
@@ -125,43 +118,42 @@ pub fn makeRationalReduced(gc: *@import("memory.zig").GC, num_val: Value, den_va
 
     var num = num_val;
     var den = den_val;
-    // Root num and den across all bignum allocations below.
-    gc.extra_roots.append(gc.allocator, num) catch return PrimitiveError.OutOfMemory;
-    gc.extra_roots.append(gc.allocator, den) catch return PrimitiveError.OutOfMemory;
-    defer {
-        if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-    }
+    var slot_num = gc.rootedSlot(num) catch return PrimitiveError.OutOfMemory;
+    defer slot_num.release();
+    var slot_den = gc.rootedSlot(den) catch return PrimitiveError.OutOfMemory;
+    defer slot_den.release();
 
     // Ensure positive denominator
     if (bignum_mod.isNegative(den)) {
         num = bignum_mod.negate(gc, num) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.items[gc.extra_roots.items.len - 2] = num;
+        slot_num.set(num);
         den = bignum_mod.negate(gc, den) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.items[gc.extra_roots.items.len - 1] = den;
+        slot_den.set(den);
     }
 
-    // Reduce by GCD — root abs_num and g across allocating calls
-    var abs_num = bignum_mod.absVal(gc, num) catch return PrimitiveError.OutOfMemory;
-    gc.extra_roots.append(gc.allocator, abs_num) catch return PrimitiveError.OutOfMemory;
-    var g = den;
-    gc.extra_roots.append(gc.allocator, g) catch return PrimitiveError.OutOfMemory;
-    while (!bignum_mod.isZero(abs_num)) {
-        const t = abs_num;
-        abs_num = bignum_mod.remainder(gc, g, abs_num) catch return PrimitiveError.OutOfMemory;
-        abs_num = bignum_mod.absVal(gc, abs_num) catch return PrimitiveError.OutOfMemory;
-        g = t;
-        gc.extra_roots.items[gc.extra_roots.items.len - 2] = abs_num;
-        gc.extra_roots.items[gc.extra_roots.items.len - 1] = g;
-    }
-    _ = gc.extra_roots.pop();
-    _ = gc.extra_roots.pop();
-    // g is now gcd(|num|, den)
-    if (!bignum_mod.isZero(g) and bignum_mod.compare(g, types.makeFixnum(1)) != 0) {
-        num = bignum_mod.quotient(gc, num, g) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.items[gc.extra_roots.items.len - 2] = num;
-        den = bignum_mod.quotient(gc, den, g) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.items[gc.extra_roots.items.len - 1] = den;
+    // Reduce by GCD
+    {
+        var abs_num = bignum_mod.absVal(gc, num) catch return PrimitiveError.OutOfMemory;
+        var slot_abs = gc.rootedSlot(abs_num) catch return PrimitiveError.OutOfMemory;
+        defer slot_abs.release();
+        var g = den;
+        var slot_g = gc.rootedSlot(g) catch return PrimitiveError.OutOfMemory;
+        defer slot_g.release();
+        while (!bignum_mod.isZero(abs_num)) {
+            const t = abs_num;
+            abs_num = bignum_mod.remainder(gc, g, abs_num) catch return PrimitiveError.OutOfMemory;
+            abs_num = bignum_mod.absVal(gc, abs_num) catch return PrimitiveError.OutOfMemory;
+            g = t;
+            slot_abs.set(abs_num);
+            slot_g.set(g);
+        }
+        // g is now gcd(|num|, den)
+        if (!bignum_mod.isZero(g) and bignum_mod.compare(g, types.makeFixnum(1)) != 0) {
+            num = bignum_mod.quotient(gc, num, g) catch return PrimitiveError.OutOfMemory;
+            slot_num.set(num);
+            den = bignum_mod.quotient(gc, den, g) catch return PrimitiveError.OutOfMemory;
+            slot_den.set(den);
+        }
     }
 
     // Demote to fixnum if possible
@@ -269,14 +261,12 @@ fn anyBignum(args: []const Value) bool {
 fn bignumAddAll(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var result: Value = types.makeFixnum(0);
-    gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
-    defer {
-        if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-    }
+    var slot = gc.rootedSlot(result) catch return PrimitiveError.OutOfMemory;
+    defer slot.release();
     for (args) |a| {
         if (!types.isFixnum(a) and !types.isBignum(a)) return PrimitiveError.TypeError;
         result = bignum_mod.add(gc, result, a) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.items[gc.extra_roots.items.len - 1] = result;
+        slot.set(result);
     }
     return result;
 }
@@ -289,14 +279,12 @@ fn bignumSubAll(args: []const Value) PrimitiveError!Value {
     }
     var result = args[0];
     if (!types.isFixnum(result) and !types.isBignum(result)) return PrimitiveError.TypeError;
-    gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
-    defer {
-        if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-    }
+    var slot = gc.rootedSlot(result) catch return PrimitiveError.OutOfMemory;
+    defer slot.release();
     for (args[1..]) |a| {
         if (!types.isFixnum(a) and !types.isBignum(a)) return PrimitiveError.TypeError;
         result = bignum_mod.sub(gc, result, a) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.items[gc.extra_roots.items.len - 1] = result;
+        slot.set(result);
     }
     return result;
 }
@@ -304,14 +292,12 @@ fn bignumSubAll(args: []const Value) PrimitiveError!Value {
 fn bignumMulAll(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var result: Value = types.makeFixnum(1);
-    gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
-    defer {
-        if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-    }
+    var slot = gc.rootedSlot(result) catch return PrimitiveError.OutOfMemory;
+    defer slot.release();
     for (args) |a| {
         if (!types.isFixnum(a) and !types.isBignum(a)) return PrimitiveError.TypeError;
         result = bignum_mod.mul(gc, result, a) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.items[gc.extra_roots.items.len - 1] = result;
+        slot.set(result);
     }
     return result;
 }
@@ -338,25 +324,22 @@ fn add(args: []const Value) PrimitiveError!Value {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var acc_num: Value = types.makeFixnum(0);
         var acc_den: Value = types.makeFixnum(1);
-        gc.extra_roots.append(gc.allocator, acc_num) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, acc_den) catch return PrimitiveError.OutOfMemory;
-        defer {
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        }
+        var slot_num = gc.rootedSlot(acc_num) catch return PrimitiveError.OutOfMemory;
+        defer slot_num.release();
+        var slot_den = gc.rootedSlot(acc_den) catch return PrimitiveError.OutOfMemory;
+        defer slot_den.release();
         for (args) |a| {
             if (types.isFlonum(a)) {
                 const acc_f = try toF64Ext(acc_num) / try toF64Ext(acc_den);
                 return makeFlonumVal(acc_f + types.toFlonum(a));
             }
             const parts = try ratPartsVal(a);
-            // acc_num/acc_den + a_num/a_den = (acc_num*a_den + a_num*acc_den) / (acc_den*a_den)
             const t1 = bignum_mod.mul(gc, acc_num, parts.den) catch return PrimitiveError.OutOfMemory;
             const t2 = bignum_mod.mul(gc, parts.num, acc_den) catch return PrimitiveError.OutOfMemory;
             acc_num = bignum_mod.add(gc, t1, t2) catch return PrimitiveError.OutOfMemory;
             acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.items[gc.extra_roots.items.len - 2] = acc_num;
-            gc.extra_roots.items[gc.extra_roots.items.len - 1] = acc_den;
+            slot_num.set(acc_num);
+            slot_den.set(acc_den);
         }
         return makeRationalReduced(gc, acc_num, acc_den);
     }
@@ -403,12 +386,10 @@ fn sub(args: []const Value) PrimitiveError!Value {
             acc_num = bignum_mod.negate(gc, acc_num) catch return PrimitiveError.OutOfMemory;
             return makeRationalReduced(gc, acc_num, acc_den);
         }
-        gc.extra_roots.append(gc.allocator, acc_num) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, acc_den) catch return PrimitiveError.OutOfMemory;
-        defer {
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        }
+        var slot_num = gc.rootedSlot(acc_num) catch return PrimitiveError.OutOfMemory;
+        defer slot_num.release();
+        var slot_den = gc.rootedSlot(acc_den) catch return PrimitiveError.OutOfMemory;
+        defer slot_den.release();
         for (args[1..]) |a| {
             if (types.isFlonum(a)) {
                 const acc_f = try toF64Ext(acc_num) / try toF64Ext(acc_den);
@@ -419,8 +400,8 @@ fn sub(args: []const Value) PrimitiveError!Value {
             const t2 = bignum_mod.mul(gc, parts.num, acc_den) catch return PrimitiveError.OutOfMemory;
             acc_num = bignum_mod.sub(gc, t1, t2) catch return PrimitiveError.OutOfMemory;
             acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.items[gc.extra_roots.items.len - 2] = acc_num;
-            gc.extra_roots.items[gc.extra_roots.items.len - 1] = acc_den;
+            slot_num.set(acc_num);
+            slot_den.set(acc_den);
         }
         return makeRationalReduced(gc, acc_num, acc_den);
     }
@@ -469,12 +450,10 @@ fn mul(args: []const Value) PrimitiveError!Value {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var acc_num: Value = types.makeFixnum(1);
         var acc_den: Value = types.makeFixnum(1);
-        gc.extra_roots.append(gc.allocator, acc_num) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, acc_den) catch return PrimitiveError.OutOfMemory;
-        defer {
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        }
+        var slot_num = gc.rootedSlot(acc_num) catch return PrimitiveError.OutOfMemory;
+        defer slot_num.release();
+        var slot_den = gc.rootedSlot(acc_den) catch return PrimitiveError.OutOfMemory;
+        defer slot_den.release();
         for (args) |a| {
             if (types.isFlonum(a)) {
                 const acc_f = try toF64Ext(acc_num) / try toF64Ext(acc_den);
@@ -483,8 +462,8 @@ fn mul(args: []const Value) PrimitiveError!Value {
             const parts = try ratPartsVal(a);
             acc_num = bignum_mod.mul(gc, acc_num, parts.num) catch return PrimitiveError.OutOfMemory;
             acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.items[gc.extra_roots.items.len - 2] = acc_num;
-            gc.extra_roots.items[gc.extra_roots.items.len - 1] = acc_den;
+            slot_num.set(acc_num);
+            slot_den.set(acc_den);
         }
         return makeRationalReduced(gc, acc_num, acc_den);
     }
@@ -551,20 +530,17 @@ fn divFn(args: []const Value) PrimitiveError!Value {
         const init = try ratPartsVal(args[0]);
         var acc_num: Value = init.num;
         var acc_den: Value = init.den;
-        gc.extra_roots.append(gc.allocator, acc_num) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, acc_den) catch return PrimitiveError.OutOfMemory;
-        defer {
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        }
+        var slot_num = gc.rootedSlot(acc_num) catch return PrimitiveError.OutOfMemory;
+        defer slot_num.release();
+        var slot_den = gc.rootedSlot(acc_den) catch return PrimitiveError.OutOfMemory;
+        defer slot_den.release();
         for (args[1..]) |a| {
             const parts = try ratPartsVal(a);
             if (bignum_mod.isZero(parts.num)) return raiseDivByZero();
-            // (acc_num/acc_den) / (a_num/a_den) = (acc_num*a_den) / (acc_den*a_num)
             acc_num = bignum_mod.mul(gc, acc_num, parts.den) catch return PrimitiveError.OutOfMemory;
             acc_den = bignum_mod.mul(gc, acc_den, parts.num) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.items[gc.extra_roots.items.len - 2] = acc_num;
-            gc.extra_roots.items[gc.extra_roots.items.len - 1] = acc_den;
+            slot_num.set(acc_num);
+            slot_den.set(acc_den);
         }
         return makeRationalReduced(gc, acc_num, acc_den);
     }
@@ -609,24 +585,20 @@ fn divFn(args: []const Value) PrimitiveError!Value {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var num_val = args[0];
         var den_val: Value = types.makeFixnum(1);
-        gc.extra_roots.append(gc.allocator, num_val) catch return PrimitiveError.OutOfMemory;
-        defer {
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        }
-        gc.extra_roots.append(gc.allocator, den_val) catch return PrimitiveError.OutOfMemory;
-        defer {
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        }
+        var slot_num = gc.rootedSlot(num_val) catch return PrimitiveError.OutOfMemory;
+        defer slot_num.release();
+        var slot_den = gc.rootedSlot(den_val) catch return PrimitiveError.OutOfMemory;
+        defer slot_den.release();
         for (args[1..]) |a| {
             if (bignum_mod.isZero(a)) return raiseDivByZero();
             const rem = bignum_mod.remainder(gc, num_val, a) catch return PrimitiveError.OutOfMemory;
             if (bignum_mod.isZero(rem)) {
                 num_val = bignum_mod.quotient(gc, num_val, a) catch return PrimitiveError.OutOfMemory;
                 num_val = bignum_mod.demote(num_val);
-                gc.extra_roots.items[gc.extra_roots.items.len - 2] = num_val;
+                slot_num.set(num_val);
             } else {
                 den_val = bignum_mod.mul(gc, den_val, a) catch return PrimitiveError.OutOfMemory;
-                gc.extra_roots.items[gc.extra_roots.items.len - 1] = den_val;
+                slot_den.set(den_val);
             }
         }
         if (types.isFixnum(den_val) and types.toFixnum(den_val) == 1) return num_val;
@@ -829,16 +801,14 @@ fn cmpPair(a: Value, b: Value) PrimitiveError!i8 {
             const mantissa: i64 = @intCast(mantissa_bits | 0x0010000000000000);
             if (exp >= 0) {
                 var exact = gc.allocBignumFromI64(mantissa) catch return PrimitiveError.OutOfMemory;
-                gc.extra_roots.append(gc.allocator, exact) catch return PrimitiveError.OutOfMemory;
-                defer {
-                    if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-                }
+                var slot = gc.rootedSlot(exact) catch return PrimitiveError.OutOfMemory;
+                defer slot.release();
                 const two = types.makeFixnum(2);
                 const shift = types.makeFixnum(exp);
                 const scale = bignum_mod.expt(gc, two, shift) catch return PrimitiveError.OutOfMemory;
-                exact = gc.extra_roots.items[gc.extra_roots.items.len - 1];
+                exact = slot.get();
                 exact = bignum_mod.mul(gc, exact, scale) catch return PrimitiveError.OutOfMemory;
-                gc.extra_roots.items[gc.extra_roots.items.len - 1] = exact;
+                slot.set(exact);
                 if (fb < 0) exact = bignum_mod.negate(gc, exact) catch return PrimitiveError.OutOfMemory;
                 return bignum_mod.compare(a, exact);
             }
@@ -1011,13 +981,10 @@ fn absVal(args: []const Value) PrimitiveError!Value {
         }
         if (types.isBignum(r.numerator)) {
             if (bignum_mod.isNegative(r.numerator)) {
-                var abs_num = bignum_mod.absVal(gc, r.numerator) catch return PrimitiveError.OutOfMemory;
-                gc.extra_roots.append(gc.allocator, abs_num) catch return PrimitiveError.OutOfMemory;
-                defer {
-                    if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-                }
-                abs_num = gc.extra_roots.items[gc.extra_roots.items.len - 1];
-                return gc.allocRational(abs_num, r.denominator) catch return PrimitiveError.OutOfMemory;
+                const abs_num = bignum_mod.absVal(gc, r.numerator) catch return PrimitiveError.OutOfMemory;
+                var slot = gc.rootedSlot(abs_num) catch return PrimitiveError.OutOfMemory;
+                defer slot.release();
+                return gc.allocRational(slot.get(), r.denominator) catch return PrimitiveError.OutOfMemory;
             }
             return args[0];
         }
@@ -1160,27 +1127,24 @@ fn gcdFn(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(result);
     }
     if (anyBignum(args)) {
-        // Bignum GCD: use Euclidean algorithm with bignum ops
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return numberTypeError(args[0]);
         var result = bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
-        defer {
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        }
+        var slot_result = gc.rootedSlot(result) catch return PrimitiveError.OutOfMemory;
+        defer slot_result.release();
         for (args[1..]) |a| {
             if (!types.isFixnum(a) and !types.isBignum(a)) return numberTypeError(a);
             var b_val = bignum_mod.absVal(gc, a) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.append(gc.allocator, b_val) catch return PrimitiveError.OutOfMemory;
+            var slot_b = gc.rootedSlot(b_val) catch return PrimitiveError.OutOfMemory;
             while (!bignum_mod.isZero(b_val)) {
                 const t = b_val;
                 b_val = bignum_mod.remainder(gc, result, b_val) catch return PrimitiveError.OutOfMemory;
                 b_val = bignum_mod.absVal(gc, b_val) catch return PrimitiveError.OutOfMemory;
                 result = t;
-                gc.extra_roots.items[gc.extra_roots.items.len - 2] = result;
-                gc.extra_roots.items[gc.extra_roots.items.len - 1] = b_val;
+                slot_result.set(result);
+                slot_b.set(b_val);
             }
-            _ = gc.extra_roots.pop();
+            slot_b.release();
         }
         return result;
     }
@@ -1210,28 +1174,25 @@ fn lcmFn(args: []const Value) PrimitiveError!Value {
         return makeFlonumVal(result);
     }
     if (anyBignum(args)) {
-        // Bignum LCM: lcm(a,b) = |a*b| / gcd(a,b)
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         var result = bignum_mod.absVal(gc, args[0]) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
-        defer {
-            if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-        }
+        var slot_result = gc.rootedSlot(result) catch return PrimitiveError.OutOfMemory;
+        defer slot_result.release();
         for (args[1..]) |a| {
             var b_abs = bignum_mod.absVal(gc, a) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.append(gc.allocator, b_abs) catch return PrimitiveError.OutOfMemory;
+            var slot_b = gc.rootedSlot(b_abs) catch return PrimitiveError.OutOfMemory;
             const gcd_args = [_]Value{ result, b_abs };
             const g = try gcdFn(&gcd_args);
-            b_abs = gc.extra_roots.items[gc.extra_roots.items.len - 1];
+            b_abs = slot_b.get();
             if (bignum_mod.isZero(g)) {
                 result = types.makeFixnum(0);
             } else {
                 const q = bignum_mod.quotient(gc, result, g) catch return PrimitiveError.OutOfMemory;
-                b_abs = gc.extra_roots.items[gc.extra_roots.items.len - 1];
+                b_abs = slot_b.get();
                 result = bignum_mod.mul(gc, q, b_abs) catch return PrimitiveError.OutOfMemory;
             }
-            _ = gc.extra_roots.pop();
-            gc.extra_roots.items[gc.extra_roots.items.len - 1] = result;
+            slot_b.release();
+            slot_result.set(result);
         }
         return result;
     }
@@ -1252,10 +1213,8 @@ fn lcmFn(args: []const Value) PrimitiveError!Value {
             if (ov[1] != 0) {
                 const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
                 var big_result = bignum_mod.mul(gc, try makeFixnumChecked(partial), try makeFixnumChecked(abs_b)) catch return PrimitiveError.OutOfMemory;
-                gc.extra_roots.append(gc.allocator, big_result) catch return PrimitiveError.OutOfMemory;
-                defer {
-                    if (gc.extra_roots.items.len > 0) _ = gc.extra_roots.pop();
-                }
+                var slot = gc.rootedSlot(big_result) catch return PrimitiveError.OutOfMemory;
+                defer slot.release();
                 idx += 1;
                 while (idx < args.len) : (idx += 1) {
                     const b_abs = bignum_mod.absVal(gc, args[idx]) catch return PrimitiveError.OutOfMemory;
@@ -1267,7 +1226,7 @@ fn lcmFn(args: []const Value) PrimitiveError!Value {
                         const q = bignum_mod.quotient(gc, big_result, g2) catch return PrimitiveError.OutOfMemory;
                         big_result = bignum_mod.mul(gc, q, b_abs) catch return PrimitiveError.OutOfMemory;
                     }
-                    gc.extra_roots.items[gc.extra_roots.items.len - 1] = big_result;
+                    slot.set(big_result);
                 }
                 return big_result;
             }

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -145,27 +145,27 @@ pub fn registerNumeric(vm: *vm_mod.VM) !void {
 fn rationalFloor(r: *types.Rational) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
-    gc.extra_roots.append(gc.allocator, q) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    var slot = gc.rootedSlot(q) catch return PrimitiveError.OutOfMemory;
+    defer slot.release();
     const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
-    if (bignum_mod.isZero(rem)) return bignum_mod.demote(q);
+    if (bignum_mod.isZero(rem)) return bignum_mod.demote(slot.get());
     if (bignum_mod.isNegative(r.numerator)) {
-        return bignum_mod.demote(bignum_mod.sub(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory);
+        return bignum_mod.demote(bignum_mod.sub(gc, slot.get(), types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory);
     }
-    return bignum_mod.demote(q);
+    return bignum_mod.demote(slot.get());
 }
 
 fn rationalCeiling(r: *types.Rational) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
-    gc.extra_roots.append(gc.allocator, q) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    var slot = gc.rootedSlot(q) catch return PrimitiveError.OutOfMemory;
+    defer slot.release();
     const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
-    if (bignum_mod.isZero(rem)) return bignum_mod.demote(q);
+    if (bignum_mod.isZero(rem)) return bignum_mod.demote(slot.get());
     if (bignum_mod.isPositive(r.numerator) or bignum_mod.isZero(r.numerator)) {
-        return bignum_mod.demote(bignum_mod.add(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory);
+        return bignum_mod.demote(bignum_mod.add(gc, slot.get(), types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory);
     }
-    return bignum_mod.demote(q);
+    return bignum_mod.demote(slot.get());
 }
 
 fn rationalTruncate(r: *types.Rational) PrimitiveError!Value {
@@ -176,12 +176,12 @@ fn rationalTruncate(r: *types.Rational) PrimitiveError!Value {
 fn rationalRound(r: *types.Rational) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
-    gc.extra_roots.append(gc.allocator, q) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    var slot_q = gc.rootedSlot(q) catch return PrimitiveError.OutOfMemory;
+    defer slot_q.release();
     const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
-    if (bignum_mod.isZero(rem)) return bignum_mod.demote(q);
-    gc.extra_roots.append(gc.allocator, rem) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    if (bignum_mod.isZero(rem)) return bignum_mod.demote(slot_q.get());
+    var slot_rem = gc.rootedSlot(rem) catch return PrimitiveError.OutOfMemory;
+    defer slot_rem.release();
     const abs_rem = bignum_mod.absVal(gc, rem) catch return PrimitiveError.OutOfMemory;
     const double_rem = bignum_mod.mul(gc, abs_rem, types.makeFixnum(2)) catch return PrimitiveError.OutOfMemory;
     const cmp = bignum_mod.compare(double_rem, r.denominator);
@@ -312,8 +312,8 @@ pub fn exactFn(args: []const Value) PrimitiveError!Value {
             break :blk gc.allocBignumFromLimbs(&[1]u64{m}, 1, positive) catch return PrimitiveError.OutOfMemory;
         };
         if (neg_exp == 0) return num_val;
-        gc.extra_roots.append(gc.allocator, num_val) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
+        var slot_num = gc.rootedSlot(num_val) catch return PrimitiveError.OutOfMemory;
+        defer slot_num.release();
         // Build denominator 2^neg_exp
         const den_val = blk: {
             if (neg_exp < 47) {
@@ -328,17 +328,17 @@ pub fn exactFn(args: []const Value) PrimitiveError!Value {
             limbs[word_shift] = @as(u64, 1) << bit_shift;
             break :blk gc.allocBignumFromLimbs(limbs, total, true) catch return PrimitiveError.OutOfMemory;
         };
-        gc.extra_roots.append(gc.allocator, den_val) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
-        return gc.allocRational(num_val, den_val) catch return PrimitiveError.OutOfMemory;
+        var slot_den = gc.rootedSlot(den_val) catch return PrimitiveError.OutOfMemory;
+        defer slot_den.release();
+        return gc.allocRational(slot_num.get(), slot_den.get()) catch return PrimitiveError.OutOfMemory;
     }
     if (types.isComplex(args[0])) {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const c = types.toComplex(args[0]);
         const real_flo = types.makeFlonum(c.real);
         const real_exact = try exactFn(&[1]Value{real_flo});
-        gc.extra_roots.append(gc.allocator, real_exact) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
+        var slot = gc.rootedSlot(real_exact) catch return PrimitiveError.OutOfMemory;
+        defer slot.release();
         const imag_flo = types.makeFlonum(c.imag);
         const imag_exact = try exactFn(&[1]Value{imag_flo});
         if (types.isFixnum(imag_exact) and types.toFixnum(imag_exact) == 0) return real_exact;
@@ -397,8 +397,8 @@ fn exptFn(args: []const Value) PrimitiveError!Value {
         if (exp == 0) return types.makeFixnum(1);
         const abs_exp = types.makeFixnum(if (exp < 0) -exp else exp);
         const num_pow = bignum_mod.expt(gc, r.numerator, abs_exp) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, num_pow) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
+        var slot = gc.rootedSlot(num_pow) catch return PrimitiveError.OutOfMemory;
+        defer slot.release();
         const den_pow = bignum_mod.expt(gc, r.denominator, abs_exp) catch return PrimitiveError.OutOfMemory;
         if (exp > 0) {
             return arith.makeRationalReduced(gc, num_pow, den_pow);
@@ -493,8 +493,8 @@ fn squareFn(args: []const Value) PrimitiveError!Value {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const rat = types.toRational(args[0]);
         const num_sq = bignum_mod.mul(gc, rat.numerator, rat.numerator) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, num_sq) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
+        var slot = gc.rootedSlot(num_sq) catch return PrimitiveError.OutOfMemory;
+        defer slot.release();
         const den_sq = bignum_mod.mul(gc, rat.denominator, rat.denominator) catch return PrimitiveError.OutOfMemory;
         return @import("primitives_arithmetic.zig").makeRationalReduced(gc, num_sq, den_sq);
     }
@@ -573,9 +573,8 @@ fn exactIntegerSqrt(args: []const Value) PrimitiveError!Value {
             const approx_i: i64 = if (approx < 1.0) 1 else if (approx >= @as(f64, @floatFromInt(std.math.maxInt(i48)))) std.math.maxInt(i48) else @intFromFloat(approx);
             s = try arith.makeFixnumChecked(approx_i);
         }
-        gc.extra_roots.append(gc.allocator, s) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
-        const s_root_idx = gc.extra_roots.items.len - 1;
+        var slot_s = gc.rootedSlot(s) catch return PrimitiveError.OutOfMemory;
+        defer slot_s.release();
         // Newton iterations: s = (s + n/s) / 2
         const two = types.makeFixnum(2);
         var iters: usize = 0;
@@ -586,37 +585,35 @@ fn exactIntegerSqrt(args: []const Value) PrimitiveError!Value {
             const next = bignum_mod.quotient(gc, sum, two) catch return PrimitiveError.OutOfMemory;
             if (bignum_mod.compare(next, s) == 0) break;
             s = next;
-            gc.extra_roots.items[s_root_idx] = s;
+            slot_s.set(s);
         }
         // Adjust downward: ensure s*s <= n
         var s2 = bignum_mod.mul(gc, s, s) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, s2) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
-        const s2_root_idx = gc.extra_roots.items.len - 1;
+        var slot_s2 = gc.rootedSlot(s2) catch return PrimitiveError.OutOfMemory;
+        defer slot_s2.release();
         while (bignum_mod.compare(s2, n) > 0) {
             s = bignum_mod.sub(gc, s, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.items[s_root_idx] = s;
+            slot_s.set(s);
             s2 = bignum_mod.mul(gc, s, s) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.items[s2_root_idx] = s2;
+            slot_s2.set(s2);
         }
         // Adjust upward: ensure (s+1)^2 > n
         var s1 = bignum_mod.add(gc, s, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, s1) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
-        const s1_root_idx = gc.extra_roots.items.len - 1;
+        var slot_s1 = gc.rootedSlot(s1) catch return PrimitiveError.OutOfMemory;
+        defer slot_s1.release();
         var s1_sq = bignum_mod.mul(gc, s1, s1) catch return PrimitiveError.OutOfMemory;
         while (bignum_mod.compare(s1_sq, n) <= 0) {
             s = s1;
-            gc.extra_roots.items[s_root_idx] = s;
+            slot_s.set(s);
             s2 = s1_sq;
-            gc.extra_roots.items[s2_root_idx] = s2;
+            slot_s2.set(s2);
             s1 = bignum_mod.add(gc, s, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.items[s1_root_idx] = s1;
+            slot_s1.set(s1);
             s1_sq = bignum_mod.mul(gc, s1, s1) catch return PrimitiveError.OutOfMemory;
         }
         const rem = bignum_mod.sub(gc, n, s2) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, rem) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
+        var slot_rem = gc.rootedSlot(rem) catch return PrimitiveError.OutOfMemory;
+        defer slot_rem.release();
         const vals = [_]Value{ bignum_mod.demote(s), bignum_mod.demote(rem) };
         return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
     }
@@ -1056,17 +1053,16 @@ fn parseExactDecimal(gc: *@import("memory.zig").GC, s: []const u8) PrimitiveErro
 
     if (scale == 0) return mantissa_val;
 
-    // Root mantissa before allocating 10^|scale|
-    gc.extra_roots.append(gc.allocator, mantissa_val) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    var slot_m = gc.rootedSlot(mantissa_val) catch return PrimitiveError.OutOfMemory;
+    defer slot_m.release();
 
     const abs_scale: i64 = if (scale < 0) -scale else scale;
     const pow10 = bignum_mod.expt(gc, types.makeFixnum(10), types.makeFixnum(abs_scale)) catch return PrimitiveError.OutOfMemory;
-    mantissa_val = gc.extra_roots.items[gc.extra_roots.items.len - 1];
+    mantissa_val = slot_m.get();
 
     if (scale < 0) {
-        gc.extra_roots.append(gc.allocator, pow10) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
+        var slot_p = gc.rootedSlot(pow10) catch return PrimitiveError.OutOfMemory;
+        defer slot_p.release();
         return bignum_mod.mul(gc, mantissa_val, pow10) catch return PrimitiveError.OutOfMemory;
     }
 
@@ -1353,13 +1349,13 @@ fn floorQuotient(args: []const Value) PrimitiveError!Value {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         const q = bignum_mod.quotient(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, q) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
+        var slot = gc.rootedSlot(q) catch return PrimitiveError.OutOfMemory;
+        defer slot.release();
         const rem = bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
         if (!bignum_mod.isZero(rem) and (bignum_mod.isNegative(args[0]) != bignum_mod.isNegative(args[1]))) {
-            return bignum_mod.sub(gc, q, types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory;
+            return bignum_mod.sub(gc, slot.get(), types.makeFixnum(1)) catch return PrimitiveError.OutOfMemory;
         }
-        return q;
+        return slot.get();
     }
     if (!types.isFixnum(args[0]) or !types.isFixnum(args[1])) return primitives.typeError("floor-quotient", "integer", if (!types.isFixnum(args[0])) args[0] else args[1]);
     const a = types.toFixnum(args[0]);
@@ -1380,8 +1376,8 @@ fn floorRemainder(args: []const Value) PrimitiveError!Value {
         if (bignum_mod.isZero(args[1])) return raiseDivByZero();
         const rem = bignum_mod.remainder(gc, args[0], args[1]) catch return PrimitiveError.OutOfMemory;
         if (bignum_mod.isZero(rem)) return types.makeFixnum(0);
-        gc.extra_roots.append(gc.allocator, rem) catch return PrimitiveError.OutOfMemory;
-        defer _ = gc.extra_roots.pop();
+        var slot = gc.rootedSlot(rem) catch return PrimitiveError.OutOfMemory;
+        defer slot.release();
         if (bignum_mod.isNegative(rem) != bignum_mod.isNegative(args[1])) {
             return bignum_mod.add(gc, rem, args[1]) catch return PrimitiveError.OutOfMemory;
         }
@@ -1397,11 +1393,11 @@ fn floorRemainder(args: []const Value) PrimitiveError!Value {
 fn floorDivide(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q_val = try floorQuotient(args);
-    gc.extra_roots.append(gc.allocator, q_val) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    var slot_q = gc.rootedSlot(q_val) catch return PrimitiveError.OutOfMemory;
+    defer slot_q.release();
     const r_val = try floorRemainder(args);
-    gc.extra_roots.append(gc.allocator, r_val) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    var slot_r = gc.rootedSlot(r_val) catch return PrimitiveError.OutOfMemory;
+    defer slot_r.release();
     const vals = [_]Value{ q_val, r_val };
     return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
 }
@@ -1445,11 +1441,11 @@ fn truncateRemainder(args: []const Value) PrimitiveError!Value {
 fn truncateDivide(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const q_val = try truncateQuotient(args);
-    gc.extra_roots.append(gc.allocator, q_val) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    var slot_q = gc.rootedSlot(q_val) catch return PrimitiveError.OutOfMemory;
+    defer slot_q.release();
     const r_val = try truncateRemainder(args);
-    gc.extra_roots.append(gc.allocator, r_val) catch return PrimitiveError.OutOfMemory;
-    defer _ = gc.extra_roots.pop();
+    var slot_r = gc.rootedSlot(r_val) catch return PrimitiveError.OutOfMemory;
+    defer slot_r.release();
     const vals = [_]Value{ q_val, r_val };
     return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
 }

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -679,8 +679,8 @@ fn filterMapFn(args: []const Value) PrimitiveError!Value {
 
     var results: std.ArrayList(Value) = .empty;
     defer results.deinit(gc.allocator);
-    const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     var iter = MultiListIter.init(args[1..], false);
     while (try iter.next("filter-map")) |call_args| {
@@ -703,8 +703,8 @@ fn appendMapFn(args: []const Value) PrimitiveError!Value {
 
     var all_elems: std.ArrayList(Value) = .empty;
     defer all_elems.deinit(gc.allocator);
-    const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     var iter = MultiListIter.init(args[1..], false);
     while (try iter.next("append-map")) |call_args| {
@@ -1532,8 +1532,8 @@ fn unfoldFn(args: []const Value) PrimitiveError!Value {
 
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
-    const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
     gc.pushRoot(&seed);
     defer gc.popRoot();
 
@@ -1763,8 +1763,8 @@ fn mapInOrderFn(args: []const Value) PrimitiveError!Value {
 
     var results: std.ArrayList(Value) = .empty;
     defer results.deinit(gc.allocator);
-    const extra_roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(extra_roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     var iter = MultiListIter.init(args[1..], false);
     while (try iter.next("map-in-order")) |call_args| {

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -336,8 +336,8 @@ fn vectorMapFn(args: []const Value) PrimitiveError!Value {
     const results = gc.allocator.alloc(Value, min_len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(results);
 
-    const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     var stack_buf: [256]Value = undefined;
     const call_args = if (vec_count > 256)
@@ -670,8 +670,8 @@ fn vectorUnfoldFn(args: []const Value) PrimitiveError!Value {
     const new_data = gc.allocator.alloc(Value, length) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(new_data);
 
-    const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     const call_count = 1 + seeds.items.len;
     var stack_buf: [257]Value = undefined;
@@ -726,8 +726,8 @@ fn vectorUnfoldRightFn(args: []const Value) PrimitiveError!Value {
     const new_data = gc.allocator.alloc(Value, length) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(new_data);
 
-    const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     const call_count = 1 + seeds.items.len;
     var stack_buf_r: [257]Value = undefined;
@@ -824,8 +824,8 @@ fn vectorCumulateFn(args: []const Value) PrimitiveError!Value {
     const vec = types.toVector(args[2]);
     const new_data = gc.allocator.alloc(Value, vec.data.len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(new_data);
-    const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
     for (0..vec.data.len) |i| {
         const call_args_buf = [2]Value{ acc, vec.data[i] };
         acc = try callVM(f, &call_args_buf);
@@ -850,8 +850,8 @@ fn vectorPartitionFn(args: []const Value) PrimitiveError!Value {
     // element whose only remaining reference is the yes/no accumulator. Those
     // lists are invisible to the GC, so root every classified element to keep
     // it alive across later predicate calls (which can trigger collection).
-    const roots_base = gc.extra_roots.items.len;
-    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     for (vec.data) |elem| {
         const call_args_buf = [1]Value{elem};


### PR DESCRIPTION
## Summary

- Add `GC.RootedSlot` (get/set/release) and `GC.RootedScope` (snapshot/shrink) helpers to `src/memory.zig` with unit tests
- Migrate all 31 manual `gc.extra_roots.items[len-N]` index-poke sites in `primitives_arithmetic.zig` and `primitives_numeric.zig` to named `rootedSlot()` handles
- Migrate 9 manual `roots_base`/`shrinkRetainingCapacity` sites in `primitives_vector.zig` and `primitives_srfi1.zig` to `rootedScope()`

Closes #1054

## Test plan

- [x] `zig build test` — all unit tests pass (including new RootedSlot/RootedScope tests)
- [x] `zig build run -- tests/scheme/audit/primitives_arithmetic-audit.scm` — 97/97 pass
- [x] `zig build run -- tests/scheme/audit/primitives_numeric-audit.scm` — 119/119 pass
- [x] `zig build run -- tests/scheme/r7rs/r7rs-tests.scm` — 1395/1395 pass
- [x] `bash tests/scheme/run-all.sh` — 1702/1702 pass
- [x] GC stress (`-Dgc-stress=true`): arithmetic + numeric audits pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)