### PR TITLE
Add expect* typed accessors and eliminate bare TypeErrors (#1057)

### DIFF
--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -280,6 +280,37 @@ pub fn typeError(proc: []const u8, expected: []const u8, got: Value) PrimitiveEr
     return PrimitiveError.TypeError;
 }
 
+pub fn expectPair(proc: []const u8, v: Value) PrimitiveError!*types.Pair {
+    if (!types.isPair(v)) return typeError(proc, "pair", v);
+    return types.toPair(v);
+}
+
+pub fn expectVector(proc: []const u8, v: Value) PrimitiveError!*types.Vector {
+    if (!types.isVector(v)) return typeError(proc, "vector", v);
+    return types.toVector(v);
+}
+
+pub fn expectFixnum(proc: []const u8, v: Value) PrimitiveError!i64 {
+    if (!types.isFixnum(v)) return typeError(proc, "exact integer", v);
+    return types.toFixnum(v);
+}
+
+pub fn expectChar(proc: []const u8, v: Value) PrimitiveError!u21 {
+    if (!types.isChar(v)) return typeError(proc, "char", v);
+    return types.toChar(v);
+}
+
+pub fn expectString(proc: []const u8, v: Value) PrimitiveError![]const u8 {
+    if (!types.isString(v)) return typeError(proc, "string", v);
+    const str = types.toObject(v).as(types.SchemeString);
+    return str.data[0..str.len];
+}
+
+pub fn expectPort(proc: []const u8, v: Value) PrimitiveError!*types.Port {
+    if (!types.isPort(v)) return typeError(proc, "port", v);
+    return types.toObject(v).as(types.Port);
+}
+
 pub fn indexError(proc: []const u8, index: i64, len: usize) PrimitiveError {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.IndexOutOfBounds;
     vm.setErrorDetail("{s}: index {d} out of range for length {d}", .{ proc, index, len });
@@ -383,15 +414,15 @@ fn length(args: []const Value) PrimitiveError!Value {
     var slow = args[0];
     var fast = args[0];
     while (fast != types.NIL) {
-        if (!types.isPair(fast)) return PrimitiveError.TypeError;
+        if (!types.isPair(fast)) return typeError("length", "proper list", fast);
         fast = types.cdr(fast);
         count += 1;
         if (fast == types.NIL) break;
-        if (!types.isPair(fast)) return PrimitiveError.TypeError;
+        if (!types.isPair(fast)) return typeError("length", "proper list", fast);
         fast = types.cdr(fast);
         count += 1;
         slow = types.cdr(slow);
-        if (slow == fast) return PrimitiveError.TypeError;
+        if (slow == fast) return typeError("length", "proper list", fast);
     }
     return types.makeFixnum(count);
 }
@@ -411,7 +442,7 @@ fn append(args: []const Value) PrimitiveError!Value {
         var elems: std.ArrayList(Value) = .empty;
         defer elems.deinit(gc.allocator);
         while (lst != types.NIL) {
-            if (!types.isPair(lst)) return PrimitiveError.TypeError;
+            if (!types.isPair(lst)) return typeError("append", "proper list", lst);
             elems.append(gc.allocator, types.car(lst)) catch return PrimitiveError.OutOfMemory;
             lst = types.cdr(lst);
         }
@@ -431,7 +462,7 @@ fn reverse(args: []const Value) PrimitiveError!Value {
     defer gc.popRoot();
     var current = args[0];
     while (current != types.NIL) {
-        if (!types.isPair(current)) return PrimitiveError.TypeError;
+        if (!types.isPair(current)) return typeError("reverse", "proper list", current);
         result = gc.allocPair(types.car(current), result) catch return PrimitiveError.OutOfMemory;
         current = types.cdr(current);
     }
@@ -668,9 +699,7 @@ fn notFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn stringLength(args: []const Value) PrimitiveError!Value {
-    if (!types.isString(args[0])) return PrimitiveError.TypeError;
-    const str = types.toObject(args[0]).as(types.SchemeString);
-    const data = str.data[0..str.len];
+    const data = try expectString("string-length", args[0]);
     // Count UTF-8 codepoints, not bytes
     var count: usize = 0;
     var i: usize = 0;
@@ -686,7 +715,7 @@ fn stringAppend(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var total_len: usize = 0;
     for (args) |a| {
-        if (!types.isString(a)) return PrimitiveError.TypeError;
+        if (!types.isString(a)) return typeError("string-append", "string", a);
         total_len += types.toObject(a).as(types.SchemeString).len;
     }
     var result = gc.allocator.alloc(u8, total_len) catch return PrimitiveError.OutOfMemory;
@@ -701,7 +730,7 @@ fn stringAppend(args: []const Value) PrimitiveError!Value {
 }
 
 fn symbolToString(args: []const Value) PrimitiveError!Value {
-    if (!types.isSymbol(args[0])) return PrimitiveError.TypeError;
+    if (!types.isSymbol(args[0])) return typeError("symbol->string", "symbol", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const val = gc.allocString(types.symbolName(args[0])) catch return PrimitiveError.OutOfMemory;
     // R7RS: strings returned by symbol->string are immutable
@@ -717,7 +746,7 @@ fn applyFn(args: []const Value) PrimitiveError!Value {
     const vm = @import("vm.zig").vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
-    if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return PrimitiveError.TypeError;
+    if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return typeError("apply", "procedure", proc);
 
     // Collect all arguments: args[1..n-1] are individual, args[n-1] is a list
     var call_args: std.ArrayList(Value) = .empty;
@@ -731,7 +760,7 @@ fn applyFn(args: []const Value) PrimitiveError!Value {
     // Flatten the last arg (must be a proper list)
     var rest = args[args.len - 1];
     while (rest != types.NIL) {
-        if (!types.isPair(rest)) return PrimitiveError.TypeError;
+        if (!types.isPair(rest)) return typeError("apply", "proper list", rest);
         call_args.append(gc.allocator, types.car(rest)) catch return PrimitiveError.OutOfMemory;
         rest = types.cdr(rest);
     }
@@ -748,26 +777,24 @@ fn applyFn(args: []const Value) PrimitiveError!Value {
 fn makeRecordTypeFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     // args[0] = name (string), args[1] = num_fields (fixnum)
-    if (!types.isString(args[0])) return PrimitiveError.TypeError;
-    if (!types.isFixnum(args[1])) return PrimitiveError.TypeError;
-    const str = types.toObject(args[0]).as(types.SchemeString);
-    const nf = types.toFixnum(args[1]);
+    const name_data = try expectString("%make-record-type", args[0]);
+    const nf = try expectFixnum("%make-record-type", args[1]);
     if (nf < 0 or nf > 255) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const num_fields: u8 = @intCast(nf);
-    return gc.allocRecordType(str.data[0..str.len], num_fields) catch return PrimitiveError.OutOfMemory;
+    return gc.allocRecordType(name_data, num_fields) catch return PrimitiveError.OutOfMemory;
 }
 
 fn makeRecordFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     // args[0] = record_type, args[1..] = field values
-    if (!types.isRecordType(args[0])) return PrimitiveError.TypeError;
+    if (!types.isRecordType(args[0])) return typeError("%make-record", "record-type", args[0]);
     const rt = types.toObject(args[0]).as(types.RecordType);
     return gc.allocRecordInstance(rt, args[1..]) catch return PrimitiveError.OutOfMemory;
 }
 
 fn recordCheckFn(args: []const Value) PrimitiveError!Value {
     // args[0] = value to check, args[1] = record_type
-    if (!types.isRecordType(args[1])) return PrimitiveError.TypeError;
+    if (!types.isRecordType(args[1])) return typeError("record?", "record-type", args[1]);
     const rt = types.toObject(args[1]).as(types.RecordType);
     if (!types.isRecordInstance(args[0])) return types.FALSE;
     const ri = types.toObject(args[0]).as(types.RecordInstance);
@@ -776,25 +803,25 @@ fn recordCheckFn(args: []const Value) PrimitiveError!Value {
 
 fn recordRefFn(args: []const Value) PrimitiveError!Value {
     // args[0] = record instance, args[1] = field index (fixnum)
-    if (!types.isRecordInstance(args[0])) return PrimitiveError.TypeError;
-    if (!types.isFixnum(args[1])) return PrimitiveError.TypeError;
+    if (!types.isRecordInstance(args[0])) return typeError("record-ref", "record", args[0]);
+    if (!types.isFixnum(args[1])) return typeError("record-ref", "exact integer", args[1]);
     const ri = types.toObject(args[0]).as(types.RecordInstance);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const idx: usize = @intCast(raw_idx);
-    if (idx >= ri.fields.len) return PrimitiveError.TypeError;
+    if (idx >= ri.fields.len) return indexError("record-ref", raw_idx, ri.fields.len);
     return ri.fields[idx];
 }
 
 fn recordSetFn(args: []const Value) PrimitiveError!Value {
     // args[0] = record instance, args[1] = field index (fixnum), args[2] = new value
-    if (!types.isRecordInstance(args[0])) return PrimitiveError.TypeError;
-    if (!types.isFixnum(args[1])) return PrimitiveError.TypeError;
+    if (!types.isRecordInstance(args[0])) return typeError("record-set!", "record", args[0]);
+    if (!types.isFixnum(args[1])) return typeError("record-set!", "exact integer", args[1]);
     const ri = types.toObject(args[0]).as(types.RecordInstance);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const idx: usize = @intCast(raw_idx);
-    if (idx >= ri.fields.len) return PrimitiveError.TypeError;
+    if (idx >= ri.fields.len) return indexError("record-set!", raw_idx, ri.fields.len);
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     ri.fields[idx] = args[2];
     return types.VOID;
@@ -805,30 +832,30 @@ fn recordSetFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn caarFn(args: []const Value) PrimitiveError!Value {
-    if (!types.isPair(args[0])) return PrimitiveError.TypeError;
+    if (!types.isPair(args[0])) return typeError("caar", "pair", args[0]);
     const a = types.car(args[0]);
-    if (!types.isPair(a)) return PrimitiveError.TypeError;
+    if (!types.isPair(a)) return typeError("caar", "pair", a);
     return types.car(a);
 }
 
 fn cadrFn(args: []const Value) PrimitiveError!Value {
-    if (!types.isPair(args[0])) return PrimitiveError.TypeError;
+    if (!types.isPair(args[0])) return typeError("cadr", "pair", args[0]);
     const d = types.cdr(args[0]);
-    if (!types.isPair(d)) return PrimitiveError.TypeError;
+    if (!types.isPair(d)) return typeError("cadr", "pair", d);
     return types.car(d);
 }
 
 fn cdarFn(args: []const Value) PrimitiveError!Value {
-    if (!types.isPair(args[0])) return PrimitiveError.TypeError;
+    if (!types.isPair(args[0])) return typeError("cdar", "pair", args[0]);
     const a = types.car(args[0]);
-    if (!types.isPair(a)) return PrimitiveError.TypeError;
+    if (!types.isPair(a)) return typeError("cdar", "pair", a);
     return types.cdr(a);
 }
 
 fn cddrFn(args: []const Value) PrimitiveError!Value {
-    if (!types.isPair(args[0])) return PrimitiveError.TypeError;
+    if (!types.isPair(args[0])) return typeError("cddr", "pair", args[0]);
     const d = types.cdr(args[0]);
-    if (!types.isPair(d)) return PrimitiveError.TypeError;
+    if (!types.isPair(d)) return typeError("cddr", "pair", d);
     return types.cdr(d);
 }
 

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -74,7 +74,7 @@ fn ratPartsVal(v: Value) PrimitiveError!RatPartsVal {
         const r = types.toRational(v);
         return .{ .num = r.numerator, .den = r.denominator };
     }
-    return PrimitiveError.TypeError;
+    return primitives.typeError("arithmetic", "rational number", v);
 }
 
 fn allocRationalRooted(gc: *@import("memory.zig").GC, n: i64, d: i64) PrimitiveError!Value {
@@ -260,7 +260,7 @@ fn bignumAddAll(args: []const Value) PrimitiveError!Value {
     var slot = gc.rootedSlot(result) catch return PrimitiveError.OutOfMemory;
     defer slot.release();
     for (args) |a| {
-        if (!types.isFixnum(a) and !types.isBignum(a)) return PrimitiveError.TypeError;
+        if (!types.isFixnum(a) and !types.isBignum(a)) return primitives.typeError("+", "exact integer", a);
         result = bignum_mod.add(gc, result, a) catch return PrimitiveError.OutOfMemory;
         slot.set(result);
     }
@@ -270,15 +270,15 @@ fn bignumAddAll(args: []const Value) PrimitiveError!Value {
 fn bignumSubAll(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (args.len == 1) {
-        if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return PrimitiveError.TypeError;
+        if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) return primitives.typeError("-", "exact integer", args[0]);
         return bignum_mod.negate(gc, args[0]) catch return PrimitiveError.OutOfMemory;
     }
     var result = args[0];
-    if (!types.isFixnum(result) and !types.isBignum(result)) return PrimitiveError.TypeError;
+    if (!types.isFixnum(result) and !types.isBignum(result)) return primitives.typeError("-", "exact integer", result);
     var slot = gc.rootedSlot(result) catch return PrimitiveError.OutOfMemory;
     defer slot.release();
     for (args[1..]) |a| {
-        if (!types.isFixnum(a) and !types.isBignum(a)) return PrimitiveError.TypeError;
+        if (!types.isFixnum(a) and !types.isBignum(a)) return primitives.typeError("-", "exact integer", a);
         result = bignum_mod.sub(gc, result, a) catch return PrimitiveError.OutOfMemory;
         slot.set(result);
     }
@@ -291,7 +291,7 @@ fn bignumMulAll(args: []const Value) PrimitiveError!Value {
     var slot = gc.rootedSlot(result) catch return PrimitiveError.OutOfMemory;
     defer slot.release();
     for (args) |a| {
-        if (!types.isFixnum(a) and !types.isBignum(a)) return PrimitiveError.TypeError;
+        if (!types.isFixnum(a) and !types.isBignum(a)) return primitives.typeError("*", "exact integer", a);
         result = bignum_mod.mul(gc, result, a) catch return PrimitiveError.OutOfMemory;
         slot.set(result);
     }
@@ -352,7 +352,7 @@ fn add(args: []const Value) PrimitiveError!Value {
 }
 
 fn sub(args: []const Value) PrimitiveError!Value {
-    if (args.len == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len > 0);
     if (isAnyComplex(args)) {
         const first = try toComplexParts(args[0]);
         if (args.len == 1) return makeComplexOrReal(-first.real, -first.imag);
@@ -475,7 +475,7 @@ fn mul(args: []const Value) PrimitiveError!Value {
 }
 
 fn divFn(args: []const Value) PrimitiveError!Value {
-    if (args.len == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len > 0);
     if (isAnyComplex(args)) {
         const first = try toComplexParts(args[0]);
         if (args.len == 1) {
@@ -546,7 +546,7 @@ fn divFn(args: []const Value) PrimitiveError!Value {
         var n = types.toFixnum(args[0]);
         var d: i64 = 1;
         for (args[1..]) |a| {
-            if (!types.isFixnum(a)) return PrimitiveError.TypeError;
+            if (!types.isFixnum(a)) return primitives.typeError("/", "number", a);
             const b = types.toFixnum(a);
             if (b == 0) return raiseDivByZero();
             // n/d / b = n / (d*b)
@@ -626,7 +626,8 @@ fn quotient(args: []const Value) PrimitiveError!Value {
         if (b == 0) return raiseDivByZero();
         return makeFlonumVal(@trunc(a / b));
     }
-    if (!types.isFixnum(args[0]) or !types.isFixnum(args[1])) return PrimitiveError.TypeError;
+    if (!types.isFixnum(args[0])) return primitives.typeError("quotient", "integer", args[0]);
+    if (!types.isFixnum(args[1])) return primitives.typeError("quotient", "integer", args[1]);
     const b = types.toFixnum(args[1]);
     if (b == 0) return raiseDivByZero();
     return makeFixnumChecked(@divTrunc(types.toFixnum(args[0]), b));
@@ -648,7 +649,8 @@ fn remainder(args: []const Value) PrimitiveError!Value {
         if (b == 0) return raiseDivByZero();
         return makeFlonumVal(@rem(a, b));
     }
-    if (!types.isFixnum(args[0]) or !types.isFixnum(args[1])) return PrimitiveError.TypeError;
+    if (!types.isFixnum(args[0])) return primitives.typeError("remainder", "integer", args[0]);
+    if (!types.isFixnum(args[1])) return primitives.typeError("remainder", "integer", args[1]);
     const b = types.toFixnum(args[1]);
     if (b == 0) return raiseDivByZero();
     return types.makeFixnum(@rem(types.toFixnum(args[0]), b));
@@ -677,7 +679,8 @@ fn modulo(args: []const Value) PrimitiveError!Value {
         if (r != 0 and (r < 0) != (b < 0)) r += b;
         return makeFlonumVal(r);
     }
-    if (!types.isFixnum(args[0]) or !types.isFixnum(args[1])) return PrimitiveError.TypeError;
+    if (!types.isFixnum(args[0])) return primitives.typeError("modulo", "integer", args[0]);
+    if (!types.isFixnum(args[1])) return primitives.typeError("modulo", "integer", args[1]);
     const b = types.toFixnum(args[1]);
     if (b == 0) return raiseDivByZero();
     return types.makeFixnum(@mod(types.toFixnum(args[0]), b));
@@ -989,7 +992,7 @@ fn absVal(args: []const Value) PrimitiveError!Value {
     if (types.isFlonum(args[0])) {
         return makeFlonumVal(@abs(types.toFlonum(args[0])));
     }
-    return PrimitiveError.TypeError;
+    return numberTypeError(args[0]);
 }
 
 fn minVal(args: []const Value) PrimitiveError!Value {
@@ -1015,10 +1018,10 @@ fn minVal(args: []const Value) PrimitiveError!Value {
         }
         return result;
     }
-    if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
+    if (!types.isFixnum(args[0])) return numberTypeError(args[0]);
     var result = types.toFixnum(args[0]);
     for (args[1..]) |a| {
-        if (!types.isFixnum(a)) return PrimitiveError.TypeError;
+        if (!types.isFixnum(a)) return numberTypeError(a);
         const n = types.toFixnum(a);
         if (n < result) result = n;
     }
@@ -1048,10 +1051,10 @@ fn maxVal(args: []const Value) PrimitiveError!Value {
         }
         return result;
     }
-    if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
+    if (!types.isFixnum(args[0])) return numberTypeError(args[0]);
     var result = types.toFixnum(args[0]);
     for (args[1..]) |a| {
-        if (!types.isFixnum(a)) return PrimitiveError.TypeError;
+        if (!types.isFixnum(a)) return numberTypeError(a);
         const n = types.toFixnum(a);
         if (n > result) result = n;
     }
@@ -1071,7 +1074,7 @@ fn evenP(args: []const Value) PrimitiveError!Value {
             return primitives.typeError("even?", "integer", args[0]);
         return if (@rem(f, 2.0) == 0.0) types.TRUE else types.FALSE;
     }
-    return PrimitiveError.TypeError;
+    return primitives.typeError("even?", "integer", args[0]);
 }
 
 fn oddP(args: []const Value) PrimitiveError!Value {
@@ -1087,7 +1090,7 @@ fn oddP(args: []const Value) PrimitiveError!Value {
             return primitives.typeError("odd?", "integer", args[0]);
         return if (@rem(f, 2.0) != 0.0) types.TRUE else types.FALSE;
     }
-    return PrimitiveError.TypeError;
+    return primitives.typeError("odd?", "integer", args[0]);
 }
 
 fn gcdF64(a_in: f64, b_in: f64) f64 {
@@ -1144,11 +1147,11 @@ fn gcdFn(args: []const Value) PrimitiveError!Value {
         }
         return result;
     }
-    if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
+    if (!types.isFixnum(args[0])) return primitives.typeError("gcd", "integer", args[0]);
     var result = types.toFixnum(args[0]);
     if (result < 0) result = -result;
     for (args[1..]) |a| {
-        if (!types.isFixnum(a)) return PrimitiveError.TypeError;
+        if (!types.isFixnum(a)) return primitives.typeError("gcd", "integer", a);
         result = gcdTwo(result, types.toFixnum(a));
     }
     return try makeFixnumChecked(result);
@@ -1192,12 +1195,12 @@ fn lcmFn(args: []const Value) PrimitiveError!Value {
         }
         return result;
     }
-    if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
+    if (!types.isFixnum(args[0])) return primitives.typeError("lcm", "integer", args[0]);
     var result = types.toFixnum(args[0]);
     if (result < 0) result = -result;
     var idx: usize = 1;
     while (idx < args.len) : (idx += 1) {
-        if (!types.isFixnum(args[idx])) return PrimitiveError.TypeError;
+        if (!types.isFixnum(args[idx])) return primitives.typeError("lcm", "integer", args[idx]);
         const b = types.toFixnum(args[idx]);
         const g = gcdTwo(result, b);
         if (g == 0) {

--- a/src/primitives_char.zig
+++ b/src/primitives_char.zig
@@ -38,12 +38,6 @@ pub const specs = [_]primitives.PrimSpec{
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn getStringSlice(proc: []const u8, v: Value) PrimitiveError![]const u8 {
-    if (!types.isString(v)) return primitives.typeError(proc, "string", v);
-    const str = types.toObject(v).as(types.SchemeString);
-    return str.data[0..str.len];
-}
-
 // ---------------------------------------------------------------------------
 // Unicode classification helpers
 // ---------------------------------------------------------------------------
@@ -379,8 +373,8 @@ fn foldCompareStrings(a: []const u8, b: []const u8) std.math.Order {
 
 fn compareCiStrings(proc: []const u8, args: []const Value, comptime cmp: enum { lt, le, eq, ge, gt }) PrimitiveError!Value {
     for (0..args.len - 1) |i| {
-        const a = try getStringSlice(proc, args[i]);
-        const b = try getStringSlice(proc, args[i + 1]);
+        const a = try primitives.expectString(proc, args[i]);
+        const b = try primitives.expectString(proc, args[i + 1]);
         const order = foldCompareStrings(a, b);
         const pass = switch (cmp) {
             .lt => order == .lt,
@@ -452,17 +446,17 @@ fn stringCaseMap(data: []const u8, comptime case_fn: fn (u21) u21) PrimitiveErro
 }
 
 fn stringUpcaseFn(args: []const Value) PrimitiveError!Value {
-    const data = try getStringSlice("string-upcase", args[0]);
+    const data = try primitives.expectString("string-upcase", args[0]);
     return stringCaseMapExpanding(data, .upcase);
 }
 
 fn stringDowncaseFn(args: []const Value) PrimitiveError!Value {
-    const data = try getStringSlice("string-downcase", args[0]);
+    const data = try primitives.expectString("string-downcase", args[0]);
     return stringCaseMapExpanding(data, .downcase);
 }
 
 fn stringFoldcaseFn(args: []const Value) PrimitiveError!Value {
-    const data = try getStringSlice("string-foldcase", args[0]);
+    const data = try primitives.expectString("string-foldcase", args[0]);
     return stringCaseMapExpanding(data, .foldcase);
 }
 

--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -35,16 +35,16 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
 
     if (args[0] == types.FALSE) {
         // Open default process (all linked symbols including libc)
-        const handle = std.c.dlopen(null, std.c.RTLD{ .LAZY = true }) orelse return PrimitiveError.TypeError;
+        const handle = std.c.dlopen(null, std.c.RTLD{ .LAZY = true }) orelse return primitives.typeError("ffi-open", "openable library", args[0]);
         return gc.allocFfiLibrary(handle, "default") catch return PrimitiveError.OutOfMemory;
     }
 
-    if (!types.isString(args[0])) return PrimitiveError.TypeError;
+    if (!types.isString(args[0])) return primitives.typeError("ffi-open", "string", args[0]);
     const str = types.toObject(args[0]).as(types.SchemeString);
 
     // Build null-terminated name
     var buf: [256]u8 = undefined;
-    if (str.len >= buf.len) return PrimitiveError.TypeError;
+    if (str.len >= buf.len) return primitives.typeError("ffi-open", "string shorter than 256 bytes", args[0]);
     @memcpy(buf[0..str.len], str.data[0..str.len]);
     buf[str.len] = 0;
     const cname: [*:0]const u8 = @ptrCast(buf[0..str.len :0]);
@@ -99,7 +99,7 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
     } else {
         vm.setErrorDetail("ffi-open: cannot open '{s}'", .{str.data[0..str.len]});
     }
-    return PrimitiveError.TypeError;
+    return PrimitiveError.TypeError; // bare-ok: detail set above
 }
 
 /// (ffi-fn lib "name" '(param-types...) 'return-type)
@@ -109,17 +109,17 @@ fn ffiFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     // arg0: library
-    if (!types.isFfiLibrary(args[0])) return PrimitiveError.TypeError;
+    if (!types.isFfiLibrary(args[0])) return primitives.typeError("ffi-fn", "ffi-library", args[0]);
     const lib = types.toObject(args[0]).as(types.FfiLibrary);
-    const handle = lib.handle orelse return PrimitiveError.TypeError; // library closed
+    const handle = lib.handle orelse return primitives.typeError("ffi-fn", "open ffi-library", args[0]);
 
     // arg1: symbol name (string)
-    if (!types.isString(args[1])) return PrimitiveError.TypeError;
+    if (!types.isString(args[1])) return primitives.typeError("ffi-fn", "string", args[1]);
     const name_str = types.toObject(args[1]).as(types.SchemeString);
 
     // Build null-terminated name for dlsym
     var name_buf: [256]u8 = undefined;
-    if (name_str.len >= name_buf.len) return PrimitiveError.TypeError;
+    if (name_str.len >= name_buf.len) return primitives.typeError("ffi-fn", "string shorter than 256 bytes", args[1]);
     @memcpy(name_buf[0..name_str.len], name_str.data[0..name_str.len]);
     name_buf[name_str.len] = 0;
     const cname: [*:0]const u8 = @ptrCast(name_buf[0..name_str.len :0]);
@@ -132,7 +132,7 @@ fn ffiFn(args: []const Value) PrimitiveError!Value {
         } else {
             vm.setErrorDetail("ffi-fn: symbol '{s}' not found", .{name_str.data[0..name_str.len]});
         }
-        return PrimitiveError.TypeError;
+        return PrimitiveError.TypeError; // bare-ok: detail set above
     };
 
     // arg2: parameter type list (a Scheme list of symbols)
@@ -140,20 +140,20 @@ fn ffiFn(args: []const Value) PrimitiveError!Value {
     var param_count: u8 = 0;
     var param_list = args[2];
     while (param_list != types.NIL) {
-        if (!types.isPair(param_list)) return PrimitiveError.TypeError;
+        if (!types.isPair(param_list)) return primitives.typeError("ffi-fn", "proper list of types", args[2]);
         if (param_count >= 16) {
             const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             vm.setErrorDetail("ffi-fn: too many parameters (max 16)", .{});
-            return PrimitiveError.TypeError;
+            return PrimitiveError.TypeError; // bare-ok: detail set above
         }
         const type_sym = types.car(param_list);
-        param_types_buf[param_count] = parseType(type_sym) orelse return PrimitiveError.TypeError;
+        param_types_buf[param_count] = parseType(type_sym) orelse return primitives.typeError("ffi-fn", "valid FFI type symbol", type_sym);
         param_count += 1;
         param_list = types.cdr(param_list);
     }
 
     // arg3: return type (a symbol)
-    const return_type = parseType(args[3]) orelse return PrimitiveError.TypeError;
+    const return_type = parseType(args[3]) orelse return primitives.typeError("ffi-fn", "valid FFI type symbol", args[3]);
 
     return gc.allocFfiFunction(
         symbol,
@@ -168,7 +168,7 @@ fn ffiFn(args: []const Value) PrimitiveError!Value {
 /// Closes a previously opened FFI library.
 fn ffiClose(args: []const Value) PrimitiveError!Value {
     try checkSandbox("ffi-close");
-    if (!types.isFfiLibrary(args[0])) return PrimitiveError.TypeError;
+    if (!types.isFfiLibrary(args[0])) return primitives.typeError("ffi-close", "ffi-library", args[0]);
     const lib = types.toObject(args[0]).as(types.FfiLibrary);
     if (lib.handle) |handle| {
         _ = std.c.dlclose(handle);
@@ -190,18 +190,18 @@ fn ffiCallbackFn(args: []const Value) PrimitiveError!Value {
     var param_count: u8 = 0;
     var param_list = args[1];
     while (param_list != types.NIL) {
-        if (!types.isPair(param_list)) return PrimitiveError.TypeError;
-        if (param_count >= 8) return PrimitiveError.TypeError;
-        param_types[param_count] = parseType(types.car(param_list)) orelse return PrimitiveError.TypeError;
+        if (!types.isPair(param_list)) return primitives.typeError("ffi-callback", "proper list of types", args[1]);
+        if (param_count >= 8) return primitives.typeError("ffi-callback", "at most 8 parameter types", args[1]);
+        param_types[param_count] = parseType(types.car(param_list)) orelse return primitives.typeError("ffi-callback", "valid FFI type symbol", types.car(param_list));
         param_count += 1;
         param_list = types.cdr(param_list);
     }
-    const ret_type = parseType(args[2]) orelse return PrimitiveError.TypeError;
+    const ret_type = parseType(args[2]) orelse return primitives.typeError("ffi-callback", "valid FFI type symbol", args[2]);
 
     const sig = matchCallbackSig(param_types[0..param_count], ret_type) orelse {
         const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
         vm.setErrorDetail("ffi-callback: unsupported callback signature", .{});
-        return PrimitiveError.TypeError;
+        return PrimitiveError.TypeError; // bare-ok: detail set above
     };
 
     const slot = ffi_callback.allocSlot(proc, sig) orelse {

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -75,7 +75,7 @@ fn getOutputPort(args: []const Value, arg_idx: usize, proc: []const u8) Primitiv
     }
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const port_val = currentOutputPortValue(vm);
-    if (!types.isPort(port_val)) return PrimitiveError.TypeError;
+    if (!types.isPort(port_val)) return primitives.typeError(proc, "port", port_val);
     return types.toObject(port_val).as(types.Port);
 }
 
@@ -90,7 +90,7 @@ fn getInputPort(args: []const Value, arg_idx: usize, proc: []const u8) Primitive
     }
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const port_val = currentInputPortValue(vm);
-    if (!types.isPort(port_val)) return PrimitiveError.TypeError;
+    if (!types.isPort(port_val)) return primitives.typeError(proc, "port", port_val);
     return types.toObject(port_val).as(types.Port);
 }
 
@@ -246,7 +246,7 @@ fn raiseFileError(gc: *@import("memory.zig").GC, msg_text: []const u8, irritant:
 }
 
 fn openInputFile(args: []const Value) PrimitiveError!Value {
-    if (comptime is_wasm) return PrimitiveError.TypeError;
+    if (comptime is_wasm) return primitives.typeError("open-input-file", "non-WASM platform", args[0]);
     if (!types.isString(args[0])) return primitives.typeError("open-input-file", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
@@ -268,7 +268,7 @@ fn openInputFile(args: []const Value) PrimitiveError!Value {
 }
 
 fn openOutputFile(args: []const Value) PrimitiveError!Value {
-    if (comptime is_wasm) return PrimitiveError.TypeError;
+    if (comptime is_wasm) return primitives.typeError("open-output-file", "non-WASM platform", args[0]);
     if (!types.isString(args[0])) return primitives.typeError("open-output-file", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
@@ -794,7 +794,7 @@ fn flushOutputPort(args: []const Value) PrimitiveError!Value {
 }
 
 fn deleteFile(args: []const Value) PrimitiveError!Value {
-    if (comptime is_wasm) return PrimitiveError.TypeError;
+    if (comptime is_wasm) return primitives.typeError("delete-file", "non-WASM platform", args[0]);
     if (!types.isString(args[0])) return primitives.typeError("delete-file", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -99,5 +99,5 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
         return result;
     }
 
-    return PrimitiveError.TypeError;
+    return primitives.typeError("force", "non-circular promise chain", args[0]);
 }

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -354,12 +354,13 @@ fn mapFn(args: []const Value) PrimitiveError!Value {
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("map", "procedure", proc);
 
     const list_count = args.len - 1;
-    if (list_count == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(list_count > 0);
 
     // Build result list incrementally (rooted head + tail)
     var result_head: Value = types.NIL;
     gc.pushRoot(&result_head);
     defer gc.popRoot();
+
     var result_tail: Value = types.NIL;
     gc.pushRoot(&result_tail);
     defer gc.popRoot();
@@ -424,7 +425,7 @@ fn forEachFn(args: []const Value) PrimitiveError!Value {
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("for-each", "procedure", proc);
 
     const list_count = args.len - 1;
-    if (list_count == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(list_count > 0);
 
     // Current pointers for each list
     var currents: [256]Value = undefined;

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -398,7 +398,7 @@ fn exptFn(args: []const Value) PrimitiveError!Value {
             zr = c.real;
             zi = c.imag;
         } else {
-            zr = toF64Ext(args[0]) catch return PrimitiveError.TypeError;
+            zr = toF64Ext(args[0]) catch return primitives.typeError("expt", "number", args[0]);
             zi = 0.0;
         }
         if (types.isComplex(args[1])) {
@@ -406,7 +406,7 @@ fn exptFn(args: []const Value) PrimitiveError!Value {
             wr = c.real;
             wi = c.imag;
         } else {
-            wr = toF64Ext(args[1]) catch return PrimitiveError.TypeError;
+            wr = toF64Ext(args[1]) catch return primitives.typeError("expt", "number", args[1]);
             wi = 0.0;
         }
         // Special case: integer exponent with complex base — use repeated multiplication
@@ -908,7 +908,7 @@ pub fn toComplexParts(v: Value) PrimitiveError!struct { real: f64, imag: f64 } {
     if (types.isFlonum(v)) return .{ .real = types.toFlonum(v), .imag = 0.0 };
     if (types.isBignum(v)) return .{ .real = bignum_mod.toF64(v), .imag = 0.0 };
     if (types.isRationalObj(v)) return .{ .real = try toF64Ext(v), .imag = 0.0 };
-    return PrimitiveError.TypeError;
+    return primitives.typeError("arithmetic", "number", v);
 }
 
 pub fn makeComplexOrReal(real: f64, imag: f64) PrimitiveError!Value {

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -189,7 +189,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
         return result;
     }
 
-    const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return PrimitiveError.TypeError;
+    const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return primitives.typeError("eval", "valid expression", args[0]);
     var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
     compiler_mod.Compiler.unrootFunction(gc, func);
     gc.pushRoot(&closure_val);
@@ -276,9 +276,9 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
 
     var last_result: Value = types.VOID;
     while (reader.hasMore() catch return PrimitiveError.TypeError) { // bare-ok: reader error in load
-        const expr = reader.readDatum() catch return PrimitiveError.TypeError;
+        const expr = reader.readDatum() catch return primitives.typeError("load", "valid datum", args[0]);
 
-        const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return PrimitiveError.TypeError;
+        const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return primitives.typeError("load", "valid expression", args[0]);
         {
             var func_val = types.makePointer(@ptrCast(func));
             gc.pushRoot(&func_val);

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -151,7 +151,7 @@ fn foldFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     var acc = args[1];
-    if (args.len < 3) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 3);
 
     gc.pushRoot(&acc);
     defer gc.popRoot();
@@ -171,7 +171,7 @@ fn foldRightFn(args: []const Value) PrimitiveError!Value {
     const proc = args[0];
     const init = args[1];
     const list_count = args.len - 2;
-    if (list_count == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(list_count > 0);
 
     // For fold-right, we need to collect all elements first
     // Collect elements from each list
@@ -394,7 +394,7 @@ fn findTailFn(args: []const Value) PrimitiveError!Value {
 // (any pred list1 ...) — returns first truthy pred result
 fn anyFn(args: []const Value) PrimitiveError!Value {
     const pred = args[0];
-    if (args.len < 2) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 2);
 
     var iter = MultiListIter.init(args[1..], false);
     while (try iter.next("any")) |call_args| {
@@ -408,7 +408,7 @@ fn anyFn(args: []const Value) PrimitiveError!Value {
 // (every pred list1 ...) — returns last truthy result or #f
 fn everyFn(args: []const Value) PrimitiveError!Value {
     const pred = args[0];
-    if (args.len < 2) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 2);
 
     var iter = MultiListIter.init(args[1..], false);
     var last_result: Value = types.TRUE;
@@ -424,7 +424,7 @@ fn everyFn(args: []const Value) PrimitiveError!Value {
 // (count pred list1 ...) — count satisfying elements
 fn countFn(args: []const Value) PrimitiveError!Value {
     const pred = args[0];
-    if (args.len < 2) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 2);
 
     var iter = MultiListIter.init(args[1..], false);
     var n: i64 = 0;
@@ -645,7 +645,7 @@ fn dropWhileFn(args: []const Value) PrimitiveError!Value {
 fn filterMapFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
-    if (args.len < 2) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 2);
 
     var results: std.ArrayList(Value) = .empty;
     defer results.deinit(gc.allocator);
@@ -669,7 +669,7 @@ fn filterMapFn(args: []const Value) PrimitiveError!Value {
 fn appendMapFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
-    if (args.len < 2) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 2);
 
     var all_elems: std.ArrayList(Value) = .empty;
     defer all_elems.deinit(gc.allocator);
@@ -929,7 +929,7 @@ fn xconsFn(args: []const Value) PrimitiveError!Value {
 // (cons* a1 a2 ... an) — like list but last element is tail
 fn consStarFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    if (args.len == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len > 0);
     if (args.len == 1) return args[0];
     var result = args[args.len - 1];
     gc.pushRoot(&result);
@@ -1195,7 +1195,7 @@ fn splitAtFn(args: []const Value) PrimitiveError!Value {
 // (list-index pred list1 ...) — index of first match
 fn listIndexFn(args: []const Value) PrimitiveError!Value {
     const pred = args[0];
-    if (args.len < 2) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 2);
 
     var iter = MultiListIter.init(args[1..], false);
     var idx: i64 = 0;
@@ -1657,7 +1657,7 @@ fn unzip2Fn(args: []const Value) PrimitiveError!Value {
 // (pair-for-each proc list1 ...) — like for-each but passes pairs not elements
 fn pairForEachFn(args: []const Value) PrimitiveError!Value {
     const proc = args[0];
-    if (args.len < 2) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 2);
 
     var iter = MultiListIter.init(args[1..], true);
     while (try iter.next("pair-for-each")) |call_args| {
@@ -1672,7 +1672,7 @@ fn pairFoldFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     var acc = args[1];
-    if (args.len < 3) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 3);
 
     gc.pushRoot(&acc);
     defer gc.popRoot();
@@ -1692,7 +1692,7 @@ fn pairFoldRightFn(args: []const Value) PrimitiveError!Value {
     const proc = args[0];
     const init = args[1];
     const list_count = args.len - 2;
-    if (list_count == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(list_count > 0);
 
     var all_pairs: [256]std.ArrayList(Value) = undefined;
     for (0..list_count) |i| all_pairs[i] = .empty;
@@ -1729,7 +1729,7 @@ fn pairFoldRightFn(args: []const Value) PrimitiveError!Value {
 fn mapInOrderFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
-    if (args.len < 2) return PrimitiveError.ArityMismatch;
+    std.debug.assert(args.len >= 2);
 
     var results: std.ArrayList(Value) = .empty;
     defer results.deinit(gc.allocator);

--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -40,8 +40,8 @@ pub const specs = [_]primitives.PrimSpec{
 // Helpers
 // ---------------------------------------------------------------------------
 
-pub fn getStringSlice(v: Value) PrimitiveError![]const u8 {
-    if (!types.isString(v)) return primitives.typeError("string operation", "string", v);
+pub fn getStringSlice(proc: []const u8, v: Value) PrimitiveError![]const u8 {
+    if (!types.isString(v)) return primitives.typeError(proc, "string", v);
     const str = types.toObject(v).as(types.SchemeString);
     return str.data[0..str.len];
 }
@@ -147,7 +147,7 @@ fn makeStringFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn stringRefFn(args: []const Value) PrimitiveError!Value {
-    const data = try getStringSlice(args[0]);
+    const data = try getStringSlice("string-ref", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-ref", "exact integer", args[1]);
     const k = types.toFixnum(args[1]);
     const str_len = utf8CodepointCount(data);
@@ -205,7 +205,7 @@ fn stringSetFn(args: []const Value) PrimitiveError!Value {
 
 fn substringFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data = try getStringSlice(args[0]);
+    const data = try getStringSlice("substring", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("substring", "exact integer", args[1]);
     if (!types.isFixnum(args[2])) return primitives.typeError("substring", "exact integer", args[2]);
     const start_i = types.toFixnum(args[1]);
@@ -227,7 +227,7 @@ fn substringFn(args: []const Value) PrimitiveError!Value {
 
 fn stringCopyFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data = try getStringSlice(args[0]);
+    const data = try getStringSlice("string-copy", args[0]);
     const cp_count = utf8CodepointCount(data);
     const range = try primitives.parseOptionalRange(args, 1, cp_count, "string-copy");
     const start_cp = range.start;
@@ -252,7 +252,7 @@ fn stringCopyBangFn(args: []const Value) PrimitiveError!Value {
     const at_val = types.toFixnum(args[1]);
     if (at_val < 0) return primitives.typeError("string-copy!", "non-negative integer", args[1]);
     const at_cp: usize = @intCast(at_val);
-    const from_data = try getStringSlice(args[2]);
+    const from_data = try getStringSlice("string-copy!", args[2]);
     const from_cp_count = utf8CodepointCount(from_data);
 
     const range = try primitives.parseOptionalRange(args, 3, from_cp_count, "string-copy!");
@@ -341,7 +341,7 @@ fn stringFillFn(args: []const Value) PrimitiveError!Value {
 
 fn stringToListFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data = try getStringSlice(args[0]);
+    const data = try getStringSlice("string->list", args[0]);
     const cp_count = utf8CodepointCount(data);
     const range = try primitives.parseOptionalRange(args, 1, cp_count, "string->list");
     const start_cp = range.start;
@@ -438,13 +438,13 @@ fn stringForEachFn(args: []const Value) PrimitiveError!Value {
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("string-for-each", "procedure", proc);
 
     const str_count = args.len - 1;
-    if (str_count == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(str_count > 0);
     if (str_count > 256) return PrimitiveError.ArityMismatch;
 
     // Find minimum codepoint length
     var min_cp_len: usize = std.math.maxInt(usize);
     for (args[1..]) |a| {
-        const data = try getStringSlice(a);
+        const data = try getStringSlice("string-for-each", a);
         const cp_len = utf8CodepointCount(data);
         if (cp_len < min_cp_len) min_cp_len = cp_len;
     }
@@ -452,7 +452,7 @@ fn stringForEachFn(args: []const Value) PrimitiveError!Value {
     var call_args: [256]Value = undefined;
     for (0..min_cp_len) |cp_idx| {
         for (0..str_count) |si| {
-            const data = try getStringSlice(args[1 + si]);
+            const data = try getStringSlice("string-for-each", args[1 + si]);
             const byte_off = utf8IndexToByteOffset(data, cp_idx) orelse return primitives.typeError("string-for-each", "valid UTF-8 string", args[1 + si]);
             const cp = utf8DecodeAt(data, byte_off) orelse return primitives.typeError("string-for-each", "valid UTF-8 string", args[1 + si]);
             call_args[si] = types.makeChar(cp);
@@ -475,13 +475,13 @@ fn stringMapFn(args: []const Value) PrimitiveError!Value {
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("string-map", "procedure", proc);
 
     const str_count = args.len - 1;
-    if (str_count == 0) return PrimitiveError.ArityMismatch;
+    std.debug.assert(str_count > 0);
     if (str_count > 256) return PrimitiveError.ArityMismatch;
 
     // Find minimum codepoint length
     var min_cp_len: usize = std.math.maxInt(usize);
     for (args[1..]) |a| {
-        const data = try getStringSlice(a);
+        const data = try getStringSlice("string-map", a);
         const cp_len = utf8CodepointCount(data);
         if (cp_len < min_cp_len) min_cp_len = cp_len;
     }
@@ -493,7 +493,7 @@ fn stringMapFn(args: []const Value) PrimitiveError!Value {
     var call_args: [256]Value = undefined;
     for (0..min_cp_len) |cp_idx| {
         for (0..str_count) |si| {
-            const data = try getStringSlice(args[1 + si]);
+            const data = try getStringSlice("string-map", args[1 + si]);
             const byte_off = utf8IndexToByteOffset(data, cp_idx) orelse return primitives.typeError("string-map", "valid UTF-8 string", args[1 + si]);
             const cp = utf8DecodeAt(data, byte_off) orelse return primitives.typeError("string-map", "valid UTF-8 string", args[1 + si]);
             call_args[si] = types.makeChar(cp);
@@ -517,8 +517,8 @@ fn stringMapFn(args: []const Value) PrimitiveError!Value {
 
 fn compareStrings(args: []const Value, comptime cmp: enum { lt, le, eq, ge, gt }) PrimitiveError!Value {
     for (0..args.len - 1) |i| {
-        const a = try getStringSlice(args[i]);
-        const b = try getStringSlice(args[i + 1]);
+        const a = try getStringSlice("string-compare", args[i]);
+        const b = try getStringSlice("string-compare", args[i + 1]);
         const order = std.mem.order(u8, a, b);
         const pass = switch (cmp) {
             .lt => order == .lt,
@@ -576,7 +576,7 @@ fn numberToStringFn(args: []const Value) PrimitiveError!Value {
 fn stringToNumberFn(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string->number", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const s = try getStringSlice(args[0]);
+    const s = try getStringSlice("string->number", args[0]);
 
     if (std.mem.eql(u8, s, "+inf.0")) return types.makeFlonum(std.math.inf(f64));
     if (std.mem.eql(u8, s, "-inf.0")) return types.makeFlonum(-std.math.inf(f64));

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -54,8 +54,8 @@ pub const specs = [_]primitives.PrimSpec{
 
 // (string-contains s1 s2 [start1 end1])
 fn stringContainsFn(args: []const Value) PrimitiveError!Value {
-    const full_s1 = try getStringSlice(args[0]);
-    const s2 = try getStringSlice(args[1]);
+    const full_s1 = try getStringSlice("string-contains", args[0]);
+    const s2 = try getStringSlice("string-contains", args[1]);
     const range = try parseStartEnd(full_s1, args, 2);
     const s1 = range.data;
     if (s2.len == 0) return types.makeFixnum(@intCast(range.cp_offset));
@@ -76,8 +76,8 @@ fn stringContainsFn(args: []const Value) PrimitiveError!Value {
 
 // (string-prefix? s1 s2 [start1 end1 start2 end2])
 fn stringPrefixPFn(args: []const Value) PrimitiveError!Value {
-    const full_s1 = try getStringSlice(args[0]);
-    const full_s2 = try getStringSlice(args[1]);
+    const full_s1 = try getStringSlice("string-prefix?", args[0]);
+    const full_s2 = try getStringSlice("string-prefix?", args[1]);
     const s1_range = try parseStartEnd(full_s1, args, 2);
     const s2_range = try parseStartEnd(full_s2, args, 4);
     return if (std.mem.startsWith(u8, s2_range.data, s1_range.data)) types.TRUE else types.FALSE;
@@ -85,8 +85,8 @@ fn stringPrefixPFn(args: []const Value) PrimitiveError!Value {
 
 // (string-suffix? s1 s2 [start1 end1 start2 end2])
 fn stringSuffixPFn(args: []const Value) PrimitiveError!Value {
-    const full_s1 = try getStringSlice(args[0]);
-    const full_s2 = try getStringSlice(args[1]);
+    const full_s1 = try getStringSlice("string-suffix?", args[0]);
+    const full_s2 = try getStringSlice("string-suffix?", args[1]);
     const s1_range = try parseStartEnd(full_s1, args, 2);
     const s2_range = try parseStartEnd(full_s2, args, 4);
     return if (std.mem.endsWith(u8, s2_range.data, s1_range.data)) types.TRUE else types.FALSE;
@@ -119,7 +119,7 @@ fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
         vm.lockGlobalsShared();
         const cs_contains_opt = vm.globals.get("char-set-contains?");
         vm.unlockGlobalsShared();
-        const cs_contains = cs_contains_opt orelse return PrimitiveError.TypeError;
+        const cs_contains = cs_contains_opt orelse return PrimitiveError.TypeError; // bare-ok: infrastructure guard
         const result = vm.callWithArgs(cs_contains, &[_]Value{ pred, char_val }) catch |err| {
             return err;
         };
@@ -164,7 +164,7 @@ fn findPrevCpStart(data: []const u8, pos: usize) usize {
 // (string-trim s [pred [start end]])
 fn stringTrimFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-trim", args[0]);
     if (args.len <= 1) {
         var start: usize = 0;
         while (start < full_data.len and isWhitespace(full_data[start])) start += 1;
@@ -186,7 +186,7 @@ fn stringTrimFn(args: []const Value) PrimitiveError!Value {
 // (string-trim-right s [pred [start end]])
 fn stringTrimRightFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-trim-right", args[0]);
     if (args.len <= 1) {
         var end: usize = full_data.len;
         while (end > 0 and isWhitespace(full_data[end - 1])) end -= 1;
@@ -209,7 +209,7 @@ fn stringTrimRightFn(args: []const Value) PrimitiveError!Value {
 // (string-trim-both s [pred [start end]])
 fn stringTrimBothFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-trim-both", args[0]);
     if (args.len <= 1) {
         var start: usize = 0;
         while (start < full_data.len and isWhitespace(full_data[start])) start += 1;
@@ -240,14 +240,14 @@ fn stringTrimBothFn(args: []const Value) PrimitiveError!Value {
 
 // (string-index s pred [start end])
 fn stringIndexFn(args: []const Value) PrimitiveError!Value {
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-index", args[0]);
     const pred = args[1];
     const range = try parseStartEnd(full_data, args, 2);
 
     var byte_i: usize = 0;
     var cp_idx: usize = range.cp_offset;
     while (byte_i < range.data.len) {
-        const cp = utf8DecodeAt(range.data, byte_i) orelse return PrimitiveError.TypeError;
+        const cp = utf8DecodeAt(range.data, byte_i) orelse return primitives.typeError("string-index", "valid UTF-8 string", args[0]);
         if (try callPredOrCharset(pred, cp)) return types.makeFixnum(@intCast(cp_idx));
         byte_i += utf8ByteLenAt(range.data, byte_i);
         cp_idx += 1;
@@ -257,14 +257,14 @@ fn stringIndexFn(args: []const Value) PrimitiveError!Value {
 
 // (string-count s pred [start end])
 fn stringCountFn(args: []const Value) PrimitiveError!Value {
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-count", args[0]);
     const pred = args[1];
     const range = try parseStartEnd(full_data, args, 2);
 
     var byte_i: usize = 0;
     var count: i64 = 0;
     while (byte_i < range.data.len) {
-        const cp = utf8DecodeAt(range.data, byte_i) orelse return PrimitiveError.TypeError;
+        const cp = utf8DecodeAt(range.data, byte_i) orelse return primitives.typeError("string-count", "valid UTF-8 string", args[0]);
         if (try callPredOrCharset(pred, cp)) count += 1;
         byte_i += utf8ByteLenAt(range.data, byte_i);
     }
@@ -274,8 +274,8 @@ fn stringCountFn(args: []const Value) PrimitiveError!Value {
 // (string-split s delimiter) -> list of strings
 fn stringSplitFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data = try getStringSlice(args[0]);
-    const delim = try getStringSlice(args[1]);
+    const data = try getStringSlice("string-split", args[0]);
+    const delim = try getStringSlice("string-split", args[1]);
 
     if (delim.len == 0) {
         // Split into individual characters
@@ -334,7 +334,7 @@ fn stringSplitFn(args: []const Value) PrimitiveError!Value {
 fn stringJoinFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const delim: []const u8 = if (args.len > 1)
-        (try getStringSlice(args[1]))
+        (try getStringSlice("string-join", args[1]))
     else
         " ";
 
@@ -344,7 +344,7 @@ fn stringJoinFn(args: []const Value) PrimitiveError!Value {
     var current = args[0];
     while (current != types.NIL) {
         if (!types.isPair(current)) return primitives.typeError("string-join", "list", args[0]);
-        const s = try getStringSlice(types.car(current));
+        const s = try getStringSlice("string-join", types.car(current));
         total += s.len;
         count += 1;
         current = types.cdr(current);
@@ -363,7 +363,7 @@ fn stringJoinFn(args: []const Value) PrimitiveError!Value {
             pos += delim.len;
         }
         first = false;
-        const s = try getStringSlice(types.car(current));
+        const s = try getStringSlice("string-join", types.car(current));
         @memcpy(buf[pos .. pos + s.len], s);
         pos += s.len;
         current = types.cdr(current);
@@ -378,7 +378,7 @@ fn stringConcatenateFn(args: []const Value) PrimitiveError!Value {
     var current = args[0];
     while (current != types.NIL) {
         if (!types.isPair(current)) return primitives.typeError("string-concatenate", "list", args[0]);
-        const s = try getStringSlice(types.car(current));
+        const s = try getStringSlice("string-concatenate", types.car(current));
         total += s.len;
         current = types.cdr(current);
     }
@@ -389,7 +389,7 @@ fn stringConcatenateFn(args: []const Value) PrimitiveError!Value {
     var pos: usize = 0;
     current = args[0];
     while (current != types.NIL) {
-        const s = try getStringSlice(types.car(current));
+        const s = try getStringSlice("string-concatenate", types.car(current));
         @memcpy(buf[pos .. pos + s.len], s);
         pos += s.len;
         current = types.cdr(current);
@@ -408,7 +408,7 @@ fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
 
 fn stringTakeFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data = try getStringSlice(args[0]);
+    const data = try getStringSlice("string-take", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-take", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-take", "non-negative integer", args[1]);
@@ -419,7 +419,7 @@ fn stringTakeFn(args: []const Value) PrimitiveError!Value {
 
 fn stringDropFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data = try getStringSlice(args[0]);
+    const data = try getStringSlice("string-drop", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-drop", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-drop", "non-negative integer", args[1]);
@@ -430,7 +430,7 @@ fn stringDropFn(args: []const Value) PrimitiveError!Value {
 
 fn stringTakeRightFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data = try getStringSlice(args[0]);
+    const data = try getStringSlice("string-take-right", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-take-right", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-take-right", "non-negative integer", args[1]);
@@ -444,7 +444,7 @@ fn stringTakeRightFn(args: []const Value) PrimitiveError!Value {
 
 fn stringDropRightFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data = try getStringSlice(args[0]);
+    const data = try getStringSlice("string-drop-right", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-drop-right", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-drop-right", "non-negative integer", args[1]);
@@ -458,7 +458,7 @@ fn stringDropRightFn(args: []const Value) PrimitiveError!Value {
 
 fn stringPadFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-pad", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-pad", "integer", args[1]);
     const tlv = types.toFixnum(args[1]);
     if (tlv < 0) return primitives.typeError("string-pad", "non-negative integer", args[1]);
@@ -486,7 +486,7 @@ fn stringPadFn(args: []const Value) PrimitiveError!Value {
 
 fn stringPadRightFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-pad-right", args[0]);
     if (!types.isFixnum(args[1])) return primitives.typeError("string-pad-right", "integer", args[1]);
     const tlv = types.toFixnum(args[1]);
     if (tlv < 0) return primitives.typeError("string-pad-right", "non-negative integer", args[1]);
@@ -515,7 +515,7 @@ fn stringPadRightFn(args: []const Value) PrimitiveError!Value {
 // (string-reverse s [start end])
 fn stringReverseFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-reverse", args[0]);
     const r = try parseStartEnd(full_data, args, 1);
     const data = r.data;
     if (data.len == 0) return gc.allocString("") catch return PrimitiveError.OutOfMemory;
@@ -545,7 +545,7 @@ fn stringReverseFn(args: []const Value) PrimitiveError!Value {
 fn stringFilterFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
-    const full_data = try getStringSlice(args[1]);
+    const full_data = try getStringSlice("string-filter", args[1]);
     const range = try parseStartEnd(full_data, args, 2);
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(gc.allocator);
@@ -567,7 +567,7 @@ fn stringFilterFn(args: []const Value) PrimitiveError!Value {
 fn stringDeleteFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
-    const full_data = try getStringSlice(args[1]);
+    const full_data = try getStringSlice("string-delete", args[1]);
     const range = try parseStartEnd(full_data, args, 2);
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(gc.allocator);
@@ -587,8 +587,8 @@ fn stringDeleteFn(args: []const Value) PrimitiveError!Value {
 
 fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const data1 = try getStringSlice(args[0]);
-    const data2 = try getStringSlice(args[1]);
+    const data1 = try getStringSlice("string-replace", args[0]);
+    const data2 = try getStringSlice("string-replace", args[1]);
     if (!types.isFixnum(args[2]) or !types.isFixnum(args[3])) return primitives.typeError("string-replace", "integer", if (!types.isFixnum(args[2])) args[2] else args[3]);
     const sv = types.toFixnum(args[2]);
     const ev = types.toFixnum(args[3]);
@@ -611,7 +611,7 @@ fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
 // (string-titlecase s [start end])
 fn stringTitlecaseFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-titlecase", args[0]);
     const range = try parseStartEnd(full_data, args, 1);
     const data = range.data;
     if (data.len == 0) return gc.allocString("") catch return PrimitiveError.OutOfMemory;
@@ -720,7 +720,7 @@ fn stringTitlecaseFn(args: []const Value) PrimitiveError!Value {
 // (string-every pred s [start end])
 fn stringEveryFn(args: []const Value) PrimitiveError!Value {
     const pred = args[0];
-    const full_data = try getStringSlice(args[1]);
+    const full_data = try getStringSlice("string-every", args[1]);
     const range = try parseStartEnd(full_data, args, 2);
     var last: Value = types.TRUE;
     var i: usize = 0;
@@ -747,7 +747,7 @@ fn stringEveryFn(args: []const Value) PrimitiveError!Value {
 // (string-any pred s [start end])
 fn stringAnyFn(args: []const Value) PrimitiveError!Value {
     const pred = args[0];
-    const full_data = try getStringSlice(args[1]);
+    const full_data = try getStringSlice("string-any", args[1]);
     const range = try parseStartEnd(full_data, args, 2);
     var i: usize = 0;
     while (i < range.data.len) {
@@ -782,7 +782,7 @@ fn stringTabulateFn(args: []const Value) PrimitiveError!Value {
         const r = try callVM(proc, &[1]Value{types.makeFixnum(@intCast(i))});
         if (!types.isChar(r)) return primitives.typeError("string-tabulate", "char", r);
         var tmp: [4]u8 = undefined;
-        const n = std.unicode.utf8Encode(types.toChar(r), &tmp) catch return PrimitiveError.TypeError;
+        const n = std.unicode.utf8Encode(types.toChar(r), &tmp) catch return primitives.typeError("string-tabulate", "valid character", r);
         result.appendSlice(gc.allocator, tmp[0..n]) catch return PrimitiveError.OutOfMemory;
     }
     return gc.allocString(result.items) catch return PrimitiveError.OutOfMemory;
@@ -816,7 +816,7 @@ fn stringUnfoldFn(args: []const Value) PrimitiveError!Value {
         const ch = try callVM(f, &[1]Value{seed});
         if (!types.isChar(ch)) return primitives.typeError("string-unfold", "char", ch);
         var tmp: [4]u8 = undefined;
-        const n = std.unicode.utf8Encode(types.toChar(ch), &tmp) catch return PrimitiveError.TypeError;
+        const n = std.unicode.utf8Encode(types.toChar(ch), &tmp) catch return primitives.typeError("string-unfold", "valid character", ch);
         result.appendSlice(gc.allocator, tmp[0..n]) catch return PrimitiveError.OutOfMemory;
         seed = try callVM(g, &[1]Value{seed});
     }
@@ -882,7 +882,7 @@ fn stringUnfoldRightFn(args: []const Value) PrimitiveError!Value {
 
 // (string-index-right s pred [start end])
 fn stringIndexRightFn(args: []const Value) PrimitiveError!Value {
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-index-right", args[0]);
     const pred = args[1];
     const range = try parseStartEnd(full_data, args, 2);
     var last_match: ?usize = null;
@@ -906,7 +906,7 @@ fn stringIndexRightFn(args: []const Value) PrimitiveError!Value {
 
 // (string-skip s pred [start end])
 fn stringSkipFn(args: []const Value) PrimitiveError!Value {
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-skip", args[0]);
     const pred = args[1];
     const range = try parseStartEnd(full_data, args, 2);
     var byte_i: usize = 0;
@@ -929,7 +929,7 @@ fn stringSkipFn(args: []const Value) PrimitiveError!Value {
 
 // (string-skip-right s pred [start end])
 fn stringSkipRightFn(args: []const Value) PrimitiveError!Value {
-    const full_data = try getStringSlice(args[0]);
+    const full_data = try getStringSlice("string-skip-right", args[0]);
     const pred = args[1];
     const range = try parseStartEnd(full_data, args, 2);
     var last_match: ?usize = null;

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -306,7 +306,11 @@ pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
         const ffi_fn = types.toObject(callee).as(types.FfiFunction);
         if (nargs != ffi_fn.param_count) return VMError.ArityMismatch;
         const ffi_mod = @import("ffi.zig");
-        const result = ffi_mod.callFfi(ffi_fn, vm.registers[base + 1 .. base + 1 + nargs], vm.gc) catch return VMError.TypeError;
+        const result = ffi_mod.callFfi(ffi_fn, vm.registers[base + 1 .. base + 1 + nargs], vm.gc) catch {
+            if (vm.last_error_detail_len == 0)
+                vm.setErrorDetail("unsupported FFI signature for '{s}'", .{ffi_fn.name});
+            return VMError.TypeError;
+        };
         vm.registers[base] = result;
         return;
     }
@@ -612,7 +616,11 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
         const ffi_fn = types.toObject(proc).as(types.FfiFunction);
         if (args.len != ffi_fn.param_count) return VMError.ArityMismatch;
         const ffi_mod = @import("ffi.zig");
-        return ffi_mod.callFfi(ffi_fn, args, vm.gc) catch return VMError.TypeError;
+        return ffi_mod.callFfi(ffi_fn, args, vm.gc) catch {
+            if (vm.last_error_detail_len == 0)
+                vm.setErrorDetail("unsupported FFI signature for '{s}'", .{ffi_fn.name});
+            return VMError.TypeError;
+        };
     }
     if (types.isParameter(proc)) {
         const param = types.toObject(proc).as(types.ParameterObject);

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -224,6 +224,46 @@ assert_file_output_contains "uncaught (error ...) in script shows message" \
 
 rm -rf "$TMPDIR"
 
+# --- Issue #1057: error-message consistency sweep ---
+echo
+echo "-- Consistent error messages (issue #1057) --"
+
+assert_output_contains "caar type error names procedure" \
+    '(caar 42)' "caar"
+
+assert_output_contains "caar type error names expected type" \
+    '(caar 42)' "pair"
+
+assert_output_contains "cadr type error names procedure" \
+    '(cadr 42)' "cadr"
+
+assert_output_contains "string-length type error names expected type" \
+    '(string-length 42)' "string"
+
+assert_output_contains "string-append type error includes proc" \
+    '(string-append "a" 42)' "string-append"
+
+assert_output_contains "symbol->string type error names expected type" \
+    '(symbol->string 42)' "symbol"
+
+assert_output_contains "gcd type error names expected type" \
+    '(gcd "x" 3)' "integer"
+
+assert_output_contains "even? type error names procedure" \
+    '(even? "x")' "even?"
+
+assert_output_contains "abs type error names expected type" \
+    '(abs "x")' "number"
+
+assert_output_contains "length type error on dotted list" \
+    '(length (cons 1 2))' "proper list"
+
+assert_output_contains "reverse type error names procedure" \
+    '(reverse (cons 1 2))' "reverse"
+
+assert_output_contains "apply type error for non-procedure" \
+    '(apply 42 (list 1))' "procedure"
+
 echo
 echo "=== Results ==="
 echo "Passed: $PASS"


### PR DESCRIPTION
## Summary

- Add 6 typed accessor functions (`expectPair`, `expectVector`, `expectFixnum`, `expectChar`, `expectString`, `expectPort`) to `primitives.zig` that combine type-check + cast and produce consistent "type error in 'proc': expected X, got Y" messages
- Eliminate all 77 bare `PrimitiveError.TypeError` returns across 10 primitives files — every TypeError now names the procedure and expected type
- Parameterize `getStringSlice` with the procedure name (was hardcoded as `"string operation"`), update ~47 callsites with correct R7RS/SRFI-13 names
- Convert 19 dead in-primitive `ArityMismatch` checks to `std.debug.assert` (dispatch already validates arity via `callNative`)
- Add FFI error detail in `vm_calls.zig` — unsupported FFI signatures now report the function name
- Add 12 new assertions to `error-format.sh`

Closes #1057

## Test plan

- [x] `zig build` — compiles clean
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/errors/error-format.sh` — 46/46 pass (12 new)
- [x] `zig build run -- tests/scheme/r7rs/r7rs-tests.scm` — 1395 pass, 0 fail
- [x] `bash tests/scheme/run-all.sh` — 1702 pass, 0 fail
- [x] Manual spot checks: `(caar 42)` → "type error in 'caar': expected pair, got 42"

🤖 Generated with [Claude Code](https://claude.com/claude-code)