### PR TITLE
Route sub-expression compilation through the IR pipeline

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -443,7 +443,18 @@ pub const Compiler = struct {
         var rooted = form;
         self.gc.pushRoot(&rooted);
         defer self.gc.popRoot();
-        return self.compileExpr(rooted, dst, is_tail);
+        return self.compileExprViaIR(rooted, dst, is_tail);
+    }
+
+    pub fn compileExprViaIR(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
+        var ir = ir_mod.IR.init(self.gc.allocator);
+        ir.globals = self.globals;
+        ir.restricted_env = self.restricted_env;
+        ir.compiler = self;
+        ir.set_targets = self.set_targets;
+        defer ir.deinit();
+        const root = try ir_mod.lowerAndOptimize(&ir, expr, &self.macros, is_tail);
+        try compiler_ir.compileFromNode(self, root, dst, is_tail);
     }
 
     pub fn compileExpr(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -111,7 +111,7 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
 
     // Compile key expression into a dedicated register
     const key_reg = try self.allocReg();
-    try self.compileExpr(key_expr, key_reg, false);
+    try self.compileExprViaIR(key_expr, key_reg, false);
 
     var end_jumps: std.ArrayList(usize) = .empty;
     defer end_jumps.deinit(self.gc.allocator);
@@ -328,7 +328,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
             // Evaluate the expression
             const rest = types.cdr(tmpl);
             if (rest == types.NIL) return CompileError.InvalidSyntax;
-            try self.compileExpr(types.car(rest), dst, false);
+            try self.compileExprViaIR(types.car(rest), dst, false);
             return;
         } else {
             // Nested unquote: decrement depth, rebuild the form
@@ -619,7 +619,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
         nc_held = false;
         gc.pushRoot(&seg0);
         defer gc.popRoot();
-        return self.compileExpr(seg0, dst, false);
+        return self.compileExprViaIR(seg0, dst, false);
     }
 
     // Build (append seg1 seg2 ... segN)
@@ -634,7 +634,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
     nc_held = false;
     gc.pushRoot(&append_call);
     defer gc.popRoot();
-    return self.compileExpr(append_call, dst, false);
+    return self.compileExprViaIR(append_call, dst, false);
 }
 
 /// Build an S-expression (list expr1 expr2 ...) where each expr is either
@@ -706,7 +706,7 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
 
     if (binding_count == 0) {
         // No bindings: just compile the body
-        return self.compileExpr(gc.allocPair(begin_sym, body) catch return CompileError.OutOfMemory, dst, is_tail);
+        return self.compileDesugared(gc.allocPair(begin_sym, body) catch return CompileError.OutOfMemory, dst, is_tail);
     }
 
     // Collect param/value exprs and generate old/new/param-value symbols

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -89,7 +89,7 @@ pub fn compileLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compile
                     std.mem.eql(u8, types.symbolName(body_expr), types.symbolName(var_name)))
                 {
                     const init_expr = types.car(types.cdr(binding));
-                    try self.compileExpr(init_expr, dst, true);
+                    try self.compileExprViaIR(init_expr, dst, true);
                     return;
                 }
             }
@@ -114,7 +114,7 @@ pub fn compileLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compile
 
         if (count >= MAX_LET_BINDINGS) return CompileError.TooManyLocals;
         const slot = try self.allocReg();
-        try self.compileExpr(init_expr, slot, false);
+        try self.compileExprViaIR(init_expr, slot, false);
         slots[count] = slot;
         names[count] = types.symbolName(var_name);
         count += 1;
@@ -152,7 +152,7 @@ pub fn compileLetStar(self: *Compiler, args: Value, dst: u16, is_tail: bool) Com
         const init_expr = types.car(types.cdr(binding));
 
         const slot = try self.allocReg();
-        try self.compileExpr(init_expr, slot, false);
+        try self.compileExprViaIR(init_expr, slot, false);
         try self.addLocal(types.symbolName(var_name), slot);
 
         binding_list = types.cdr(binding_list);
@@ -208,7 +208,7 @@ fn compileLetrecImpl(self: *Compiler, args: Value, dst: u16, is_tail: bool) Comp
 
     // Phase 2: evaluate inits and assign to boxed locals
     for (0..count) |i| {
-        try self.compileExpr(inits[i], dst, false);
+        try self.compileExprViaIR(inits[i], dst, false);
         try self.emitOp(.set_box_local);
         try self.emitU16(slots[i]);
         try self.emitU16(dst);
@@ -402,7 +402,7 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
 
         if (var_count >= MAX_LET_BINDINGS) return CompileError.TooManyLocals;
         const slot = try self.allocReg();
-        try self.compileExpr(init_expr, slot, false);
+        try self.compileExprViaIR(init_expr, slot, false);
         var_slots[var_count] = slot;
         var_names[var_count] = types.symbolName(var_name);
 
@@ -462,7 +462,7 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     const loop_start = self.currentOffset();
 
     // Test
-    try self.compileExpr(test_expr, dst, false);
+    try self.compileExprViaIR(test_expr, dst, false);
     try self.emitOp(.jump_true);
     try self.emitU16(dst);
     const exit_jump = self.currentOffset();
@@ -472,7 +472,7 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     var cmd = commands;
     while (cmd != types.NIL) {
         if (!types.isPair(cmd)) return CompileError.InvalidSyntax;
-        try self.compileExpr(types.car(cmd), dst, false);
+        try self.compileExprViaIR(types.car(cmd), dst, false);
         cmd = types.cdr(cmd);
     }
 
@@ -482,7 +482,7 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     for (0..var_count) |j| {
         if (has_step[j]) {
             const temp = try self.allocReg();
-            try self.compileExpr(step_exprs[j], temp, false);
+            try self.compileExprViaIR(step_exprs[j], temp, false);
             temp_slots[step_count] = temp;
             step_count += 1;
         }
@@ -527,7 +527,7 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
             const expr = types.car(result);
             result = types.cdr(result);
             const tail = is_tail and result == types.NIL;
-            try self.compileExpr(expr, dst, tail);
+            try self.compileExprViaIR(expr, dst, tail);
         }
     }
 
@@ -596,7 +596,7 @@ pub fn compileLetValues(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         defer gc.popRoot();
         const slot = try self.allocReg();
         temp_slots[i] = slot;
-        try self.compileExpr(cwv_expr, slot, false);
+        try self.compileExprViaIR(cwv_expr, slot, false);
     }
 
     // Now build nested (apply (lambda (formals) ...) temp) from inside out

--- a/src/compiler_conditionals.zig
+++ b/src/compiler_conditionals.zig
@@ -11,7 +11,7 @@ pub fn emitArrowCall(self: *Compiler, source_reg: u16, proc_expr: Value, dst: u1
     try self.emitOp(.move);
     try self.emitU16(arg_reg);
     try self.emitU16(source_reg);
-    try self.compileExpr(proc_expr, proc_reg, false);
+    try self.compileExprViaIR(proc_expr, proc_reg, false);
     if (is_tail) try self.emitOp(.tail_call) else try self.emitOp(.call);
     try self.emitU16(proc_reg);
     try self.emit(1);
@@ -51,9 +51,9 @@ fn compileShortCircuit(self: *Compiler, args: Value, dst: u16, is_tail: bool, em
         const rest = types.cdr(current);
 
         if (rest == types.NIL) {
-            try self.compileExpr(expr, dst, is_tail);
+            try self.compileExprViaIR(expr, dst, is_tail);
         } else {
-            try self.compileExpr(expr, dst, false);
+            try self.compileExprViaIR(expr, dst, false);
             try self.emitOp(jump_op);
             try self.emitU16(dst);
             end_jumps.append(self.gc.allocator, self.currentOffset()) catch return CompileError.TooManyLocals;
@@ -72,7 +72,7 @@ pub fn compileWhen(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
     const test_expr = types.car(args);
     const body = types.cdr(args);
 
-    try self.compileExpr(test_expr, dst, false);
+    try self.compileExprViaIR(test_expr, dst, false);
     try self.emitOp(.jump_false);
     try self.emitU16(dst);
     const false_jump = self.currentOffset();
@@ -83,7 +83,7 @@ pub fn compileWhen(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
         if (!types.isPair(current)) return CompileError.InvalidSyntax;
         const rest = types.cdr(current);
         const tail = is_tail and rest == types.NIL;
-        try self.compileExpr(types.car(current), dst, tail);
+        try self.compileExprViaIR(types.car(current), dst, tail);
         current = rest;
     }
 
@@ -103,7 +103,7 @@ pub fn compileUnless(self: *Compiler, args: Value, dst: u16, is_tail: bool) Comp
     const test_expr = types.car(args);
     const body = types.cdr(args);
 
-    try self.compileExpr(test_expr, dst, false);
+    try self.compileExprViaIR(test_expr, dst, false);
     try self.emitOp(.jump_true);
     try self.emitU16(dst);
     const true_jump = self.currentOffset();
@@ -114,7 +114,7 @@ pub fn compileUnless(self: *Compiler, args: Value, dst: u16, is_tail: bool) Comp
         if (!types.isPair(current)) return CompileError.InvalidSyntax;
         const rest = types.cdr(current);
         const tail = is_tail and rest == types.NIL;
-        try self.compileExpr(types.car(current), dst, tail);
+        try self.compileExprViaIR(types.car(current), dst, tail);
         current = rest;
     }
 
@@ -158,7 +158,7 @@ pub fn compileCond(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
         }
 
         // Compile test
-        try self.compileExpr(test_expr, dst, false);
+        try self.compileExprViaIR(test_expr, dst, false);
 
         // Check for => form (only if => is not rebound as a local variable)
         if (clause_body != types.NIL and types.isPair(clause_body)) {
@@ -222,7 +222,7 @@ pub fn compileCondBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Co
         const expr = types.car(current);
         current = types.cdr(current);
         const tail = is_tail and current == types.NIL;
-        try self.compileExpr(expr, dst, tail);
+        try self.compileExprViaIR(expr, dst, tail);
     }
 }
 

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -557,7 +557,15 @@ fn compileSetFromIR(self: *Compiler, data: ir_mod.SetData, dst: u16) CompileErro
     try compileFromNode(self, val_root, dst, false);
 
     if (self.resolveLocal(name)) |slot| {
-        if (self.isLocalBoxed(name)) {
+        if (self.isLocalGlobalAlias(name)) {
+            const sym_idx = try self.addConstant(data.name);
+            try self.emitOp(.set_global);
+            try self.emitU16(sym_idx);
+            try self.emitU16(dst);
+            try self.emitOp(.move);
+            try self.emitU16(slot);
+            try self.emitU16(dst);
+        } else if (self.isLocalBoxed(name)) {
             try self.emitOp(.set_box_local);
             try self.emitU16(slot);
             try self.emitU16(dst);

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -261,13 +261,13 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
         for (0..def_count) |i| {
             if (allocates_regs) {
                 last_dst = try self.allocReg();
-                try self.compileExpr(def_inits[i], last_dst, false);
+                try self.compileExprViaIR(def_inits[i], last_dst, false);
                 try self.emitOp(.set_box_local);
                 try self.emitU16(def_slots[i]);
                 try self.emitU16(last_dst);
                 self.freeReg();
             } else {
-                try self.compileExpr(def_inits[i], last_dst, false);
+                try self.compileExprViaIR(def_inits[i], last_dst, false);
                 try self.emitOp(.set_box_local);
                 try self.emitU16(def_slots[i]);
                 try self.emitU16(last_dst);
@@ -302,17 +302,17 @@ fn compileExprSequence(self: *Compiler, current: *Value, last_dst: *u16, allocat
         if (allocates_regs) {
             last_dst.* = try self.allocReg();
             if (is_last) {
-                try self.compileExpr(expr, last_dst.*, true);
+                try self.compileExprViaIR(expr, last_dst.*, true);
             } else {
                 const saved_next = self.next_register;
-                try self.compileExpr(expr, last_dst.*, false);
+                try self.compileExprViaIR(expr, last_dst.*, false);
                 if (self.next_register == saved_next) {
                     self.freeReg();
                 }
             }
         } else {
             const tail = (caller_tail orelse false) and is_last;
-            try self.compileExpr(expr, last_dst.*, tail);
+            try self.compileExprViaIR(expr, last_dst.*, tail);
         }
     }
 }
@@ -326,7 +326,7 @@ pub fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
         // (define x expr)
         if (rest == types.NIL) return CompileError.InvalidSyntax;
         const value_expr = types.car(rest);
-        try self.compileExpr(value_expr, dst, false);
+        try self.compileExprViaIR(value_expr, dst, false);
 
         // If the expression compiled to a lambda, set its name for debugging
         if (self.func.constants.items.len > 0) {
@@ -414,7 +414,7 @@ pub fn compileDefineValues(self: *Compiler, args: Value, dst: u16) CompileError!
 
     if (formals == types.NIL) {
         // (define-values () expr) — no bindings, just evaluate for side effects
-        try self.compileExpr(expr, dst, false);
+        try self.compileExprViaIR(expr, dst, false);
         try self.emitOp(.load_void);
         try self.emitU16(dst);
         return;
@@ -558,7 +558,7 @@ pub fn compileDefineValues(self: *Compiler, args: Value, dst: u16) CompileError!
     }
 
     // Compile the call-with-values expression
-    try self.compileExpr(final_form, dst, false);
+    try self.compileExprViaIR(final_form, dst, false);
     try self.emitOp(.load_void);
     try self.emitU16(dst);
 }
@@ -585,7 +585,7 @@ pub fn compileSet(self: *Compiler, args: Value, dst: u16) CompileError!void {
     if (!types.isSymbol(target)) return CompileError.InvalidSyntax;
 
     const value_expr = types.car(rest);
-    try self.compileExpr(value_expr, dst, false);
+    try self.compileExprViaIR(value_expr, dst, false);
 
     const name = types.symbolName(target);
     if (self.resolveLocal(name)) |slot| {
@@ -636,7 +636,7 @@ pub fn compileDelay(self: *Compiler, args: Value, dst: u16) CompileError!void {
     child.func.is_variadic = false;
     child.scope_depth = 1;
     const body_dst = child.allocReg() catch return CompileError.TooManyLocals;
-    try child.compileExpr(expr, body_dst, true);
+    try child.compileExprViaIR(expr, body_dst, true);
     try child.emitOp(.@"return");
     try child.emitU16(body_dst);
 
@@ -686,7 +686,7 @@ pub fn compileBegin(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compi
         const expr = types.car(current);
         current = types.cdr(current);
         const tail = is_tail and current == types.NIL;
-        try self.compileExpr(expr, dst, tail);
+        try self.compileExprViaIR(expr, dst, tail);
     }
 }
 

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -279,7 +279,7 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         const expr = types.car(current);
         current = types.cdr(current);
         const tail = is_tail and current == types.NIL;
-        try self.compileExpr(expr, dst, tail);
+        try self.compileExprViaIR(expr, dst, tail);
     }
     try self.endBodyMacroScope(macro_mark);
     self.in_body_scope = saved_body_scope;

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -23,14 +23,14 @@ pub fn compileIf(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     const consequent = types.car(rest);
     const rest2 = types.cdr(rest);
 
-    try self.compileExpr(test_expr, dst, false);
+    try self.compileExprViaIR(test_expr, dst, false);
 
     try self.emitOp(.jump_false);
     try self.emitU16(dst);
     const else_jump = self.currentOffset();
     try self.emitI16(0);
 
-    try self.compileExpr(consequent, dst, is_tail);
+    try self.compileExprViaIR(consequent, dst, is_tail);
 
     if (rest2 != types.NIL) {
         try self.emitOp(.jump);
@@ -40,7 +40,7 @@ pub fn compileIf(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
         try self.patchJump(else_jump);
 
         const alternate = types.car(rest2);
-        try self.compileExpr(alternate, dst, is_tail);
+        try self.compileExprViaIR(alternate, dst, is_tail);
 
         try self.patchJump(end_jump);
     } else {
@@ -109,13 +109,13 @@ pub fn compileCall(self: *Compiler, expr: Value, dst: u16, is_tail: bool) Compil
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
 
-    try self.compileExpr(operator, base, false);
+    try self.compileExprViaIR(operator, base, false);
 
     arg_list = types.cdr(expr);
     while (arg_list != types.NIL) {
         const arg = types.car(arg_list);
         const arg_reg = try self.allocReg();
-        try self.compileExpr(arg, arg_reg, false);
+        try self.compileExprViaIR(arg, arg_reg, false);
         arg_list = types.cdr(arg_list);
     }
 
@@ -240,7 +240,7 @@ fn compileSelfTailCall(self: *Compiler, expr: Value, dst: u16, nargs: u8) Compil
     while (arg_list != types.NIL) {
         const arg = types.car(arg_list);
         const arg_reg = try self.allocReg();
-        try self.compileExpr(arg, arg_reg, false);
+        try self.compileExprViaIR(arg, arg_reg, false);
         arg_list = types.cdr(arg_list);
     }
 
@@ -265,14 +265,14 @@ pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!voi
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
 
-    try self.compileExpr(types.car(arg_list), base, false);
+    try self.compileExprViaIR(types.car(arg_list), base, false);
     arg_list = types.cdr(arg_list);
 
     var nargs_count: usize = 0;
     while (arg_list != types.NIL) {
         if (!types.isPair(arg_list)) return CompileError.InvalidSyntax;
         const arg_reg = try self.allocReg();
-        try self.compileExpr(types.car(arg_list), arg_reg, false);
+        try self.compileExprViaIR(types.car(arg_list), arg_reg, false);
         nargs_count += 1;
         arg_list = types.cdr(arg_list);
     }
@@ -311,7 +311,7 @@ fn compileCallGlobal(self: *Compiler, expr: Value, operator: Value, dst: u16, is
         if (!types.isPair(arg_list)) return CompileError.InvalidSyntax;
         const arg = types.car(arg_list);
         const arg_reg = try self.allocReg();
-        try self.compileExpr(arg, arg_reg, false);
+        try self.compileExprViaIR(arg, arg_reg, false);
         nargs_count += 1;
         arg_list = types.cdr(arg_list);
     }

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -532,9 +532,9 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
             if (isSpecialForm(effective_name)) return ir.makePassthrough(expr);
 
             if (ir.compiler) |c| {
-                if (c.lookupMacro(effective_name) != null) return ir.makePassthrough(expr);
+                if (c.lookupMacro(name) != null) return ir.makePassthrough(expr);
             } else if (macros) |m| {
-                if (m.get(effective_name) != null) return ir.makePassthrough(expr);
+                if (m.get(name) != null) return ir.makePassthrough(expr);
             }
         }
 
@@ -928,7 +928,10 @@ pub fn foldConstants(ir: *IR, node: *Node) *Node {
         },
         .begin => {
             var changed = false;
-            var buf: [256]*Node = undefined;
+            var stack_buf: [256]*Node = undefined;
+            const heap_buf = if (node.data.begin.len > 256) (ir.allocator.alloc(*Node, node.data.begin.len) catch return node) else null;
+            defer if (heap_buf) |h| ir.allocator.free(h);
+            const buf: []*Node = heap_buf orelse &stack_buf;
             for (node.data.begin, 0..) |expr, i| {
                 buf[i] = foldConstants(ir, expr);
                 if (buf[i] != expr) changed = true;
@@ -967,7 +970,10 @@ pub fn eliminateDeadBranches(ir: *IR, node: *Node) *Node {
         },
         .begin => {
             var changed = false;
-            var buf: [256]*Node = undefined;
+            var stack_buf: [256]*Node = undefined;
+            const heap_buf = if (node.data.begin.len > 256) (ir.allocator.alloc(*Node, node.data.begin.len) catch return node) else null;
+            defer if (heap_buf) |h| ir.allocator.free(h);
+            const buf: []*Node = heap_buf orelse &stack_buf;
             for (node.data.begin, 0..) |expr, i| {
                 buf[i] = eliminateDeadBranches(ir, expr);
                 if (buf[i] != expr) changed = true;
@@ -1011,7 +1017,10 @@ pub fn simplifyBooleans(ir: *IR, node: *Node) *Node {
         },
         .begin => {
             var changed = false;
-            var buf: [256]*Node = undefined;
+            var stack_buf: [256]*Node = undefined;
+            const heap_buf = if (node.data.begin.len > 256) (ir.allocator.alloc(*Node, node.data.begin.len) catch return node) else null;
+            defer if (heap_buf) |h| ir.allocator.free(h);
+            const buf: []*Node = heap_buf orelse &stack_buf;
             for (node.data.begin, 0..) |expr, i| {
                 buf[i] = simplifyBooleans(ir, expr);
                 if (buf[i] != expr) changed = true;
@@ -1086,7 +1095,10 @@ pub fn eliminateIdentity(ir: *IR, node: *Node) *Node {
         },
         .begin => {
             var changed = false;
-            var buf: [256]*Node = undefined;
+            var stack_buf: [256]*Node = undefined;
+            const heap_buf = if (node.data.begin.len > 256) (ir.allocator.alloc(*Node, node.data.begin.len) catch return node) else null;
+            defer if (heap_buf) |h| ir.allocator.free(h);
+            const buf: []*Node = heap_buf orelse &stack_buf;
             for (node.data.begin, 0..) |expr, i| {
                 buf[i] = eliminateIdentity(ir, expr);
                 if (buf[i] != expr) changed = true;
@@ -1107,7 +1119,10 @@ pub fn simplifyBegin(ir: *IR, node: *Node) *Node {
         .begin => {
             if (node.data.begin.len == 1) return simplifyBegin(ir, @constCast(node.data.begin[0]));
             var changed = false;
-            var buf: [256]*Node = undefined;
+            var stack_buf: [256]*Node = undefined;
+            const heap_buf = if (node.data.begin.len > 256) (ir.allocator.alloc(*Node, node.data.begin.len) catch return node) else null;
+            defer if (heap_buf) |h| ir.allocator.free(h);
+            const buf: []*Node = heap_buf orelse &stack_buf;
             for (node.data.begin, 0..) |expr, i| {
                 buf[i] = simplifyBegin(ir, @constCast(expr));
                 if (buf[i] != expr) changed = true;


### PR DESCRIPTION
## Summary

Phase 4 of #1038 (retire the legacy `compileExpr` path). Adds `compileExprViaIR` so sub-expressions compiled by legacy form compilers re-enter the IR pipeline and receive all 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification).

- Adds `compileExprViaIR` bridge function on `Compiler` — lowers a raw s-expression to IR, runs optimization passes, emits bytecode
- Converts 48 `compileExpr` call sites across 7 compiler files (`compiler_passthrough`, `compiler_conditionals`, `compiler_bindings`, `compiler_lambda`, `compiler_advanced`, `compiler_macro`, `compiler.zig:compileDesugared`)
- Keeps `compileExpr` at 2 sites: the `.passthrough` arm in `compileFromNode` (macro dispatch entry) and `expandAndCompileMacroUse` (Phase 5 scope)

Also fixes three bugs exposed by the routing change:

- **IR macro lookup used stripped hygienic prefix** (`ir.zig`): `lowerFormWithMacros` used `effective_name` (stripped `__hyg_` prefix) for macro lookup, but macros defined by `let-syntax` inside expanded code are registered under their full hygienic name. Now uses `name` (matching `compileForm`'s behavior).
- **`compileSetFromIR` missing `is_global_alias` handling** (`compiler_ir.zig`): the IR path for `set!` didn't write through to the global for macro-injected alias locals — the exact divergence bug class this epic addresses. Adds the write-through + alias-refresh logic from the legacy `compileSet`.
- **Fixed 256-element buffer overflow in IR optimizer passes** (`ir.zig`): five optimization passes used `var buf: [256]*Node` for `begin` node children, panicking on forms with >256 sub-expressions. Now falls back to heap allocation when needed.

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 307 Scheme files pass, 0 fail
- [x] R7RS test suite — 1395 pass, 0 fail
- [x] `zig build -Dgc-stress=true test` — same results as base commit (pre-existing failures only)
- [x] Verified hyg error, set! alias, and large-form-body regressions are fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)