### PR TITLE
Phase 1B: R7RS 6.1-6.5 conformance gap tests

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -115,7 +115,7 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 
 **Phase 1 — R7RS spec gap analysis** (independent; run in parallel)
 - [x] 1A: Expressions & syntax (4.1–4.3) + Libraries (5.6–5.7) (2026-07-05, #1139–#1142; 34 new gap tests, 3 disabled pending fixes; libraries 5.6 fully green)
-- [ ] 1B: Equivalence, numbers, booleans, lists, symbols (6.1–6.5)
+- [x] 1B: Equivalence, numbers, booleans, lists, symbols (6.1–6.5) (2026-07-05, no bugs found — 40 gap tests all pass, incl. circular equal? termination and numeric I/O round-trips)
 - [ ] 1C: Characters, strings, vectors, bytevectors (6.6–6.9)
 - [ ] 1D: Control, exceptions, eval, I/O, system (6.10–6.14)
 

--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -114,7 +114,7 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 - [x] 0: Baseline run, tracking issue, labels created, `audit-baseline.sh` committed (2026-07-05, #1137; baseline fully green at b2317e8 — 0 failures across all suites, no issues filed)
 
 **Phase 1 — R7RS spec gap analysis** (independent; run in parallel)
-- [ ] 1A: Expressions & syntax (4.1–4.3) + Libraries (5.6–5.7)
+- [x] 1A: Expressions & syntax (4.1–4.3) + Libraries (5.6–5.7) (2026-07-05, #1139–#1142; 34 new gap tests, 3 disabled pending fixes; libraries 5.6 fully green)
 - [ ] 1B: Equivalence, numbers, booleans, lists, symbols (6.1–6.5)
 - [ ] 1C: Characters, strings, vectors, bytevectors (6.6–6.9)
 - [ ] 1D: Control, exceptions, eval, I/O, system (6.10–6.14)

--- a/tests/scheme/compliance/fixtures/include-ci-upper.scm
+++ b/tests/scheme/compliance/fixtures/include-ci-upper.scm
@@ -1,0 +1,2 @@
+;; Mixed-case on purpose: include-ci must read this as if #!fold-case were in effect.
+(DEFINE Folded-Value 42)

--- a/tests/scheme/compliance/fixtures/include-plain.scm
+++ b/tests/scheme/compliance/fixtures/include-plain.scm
@@ -1,0 +1,1 @@
+(define included-value 7)

--- a/tests/scheme/compliance/r7rs-datatypes-gaps.scm
+++ b/tests/scheme/compliance/r7rs-datatypes-gaps.scm
@@ -1,0 +1,134 @@
+;; R7RS sections 6.1-6.5 conformance gap tests — audit Phase 1B.
+;; Covers spec requirements not exercised by tests/scheme/r7rs/r7rs-tests.scm
+;; sections 6.1 (equivalence), 6.2 (numbers), 6.3 (booleans), 6.4 (lists),
+;; 6.5 (symbols). Spec references cite docs/errata-corrected-r7rs.pdf.
+
+(import (scheme base) (scheme write) (scheme read) (scheme process-context)
+        (srfi 64))
+
+(test-begin "r7rs-datatypes-gaps")
+
+;; --- 6.1 eqv? ---
+;; "one of obj1 and obj2 is an exact number but the other is an inexact
+;; number" => #f (p. 30)
+(test-equal "eqv? mixed exactness" #f (eqv? 2 2.0))
+;; "(eqv? 0.0 +nan.0) => #f" (p. 31)
+(test-equal "eqv? 0.0 vs +nan.0" #f (eqv? 0.0 +nan.0))
+;; "both inexact numbers ... numerically equal" => #t
+(test-equal "eqv? equal flonums" #t (eqv? 2.0 2.0))
+;; "Note that (eqv? 0.0 -0.0) will return #f if negative zero is
+;; distinguished" (p. 31) — Kaappi distinguishes negative zero (IEEE 754),
+;; so this pins the distinguished behavior; = must still treat them equal.
+(test-equal "eqv? distinguishes negative zero" #f (eqv? 0.0 -0.0))
+(test-equal "= treats negative zero as equal" #t (= 0.0 -0.0))
+;; "both exact numbers and are numerically equal" — exercises the bignum
+;; heap path (fixnums are immediates; bignums must compare by value).
+(test-equal "eqv? equal bignums" #t (eqv? (expt 2 100) (expt 2 100)))
+;; records: same location => #t, distinct locations => #f (p. 30)
+(define-record-type <eqv-rec> (mk-eqv-rec a) eqv-rec? (a eqv-rec-a))
+(let ((r (mk-eqv-rec 1)))
+  (test-equal "eqv? same record" #t (eqv? r r)))
+(test-equal "eqv? distinct records" #f (eqv? (mk-eqv-rec 1) (mk-eqv-rec 1)))
+
+;; --- 6.1 equal? ---
+;; "Even if its arguments are circular data structures, equal? must always
+;; terminate." (p. 32) — a hang here is a conformance failure.
+(test-equal "equal? on equivalent circular lists terminates"
+  #t
+  (let ((x (list 'a 'b))
+        (y (list 'a 'b 'a 'b)))
+    (set-cdr! (cdr x) x)                 ; x = #1=(a b . #1#)
+    (set-cdr! (cdr (cdr (cdr y))) y)     ; y = #2=(a b a b . #2#)
+    (equal? x y)))
+(test-equal "equal? on circular vectors terminates"
+  #t
+  (let ((v1 (make-vector 2 0)) (v2 (make-vector 2 0)))
+    (vector-set! v1 0 v1) (vector-set! v1 1 v1)
+    (vector-set! v2 0 v2) (vector-set! v2 1 v2)
+    (equal? v1 v2)))
+(test-equal "equal? on mixed pair/vector cycles terminates"
+  #t
+  (let ((p1 (list 1 2)) (p2 (list 1 2)))
+    (set-cdr! (cdr p1) (vector p1))
+    (set-cdr! (cdr p2) (vector p2))
+    (equal? p1 p2)))
+;; equal? recursively compares bytevectors (p. 32)
+(test-equal "equal? bytevectors" #t (equal? #u8(1 2 3) #u8(1 2 3)))
+(test-equal "equal? unequal bytevectors" #f (equal? #u8(1 2 3) #u8(1 2 4)))
+
+;; --- 6.2.7 Numerical input and output ---
+;; number->string/string->number round-trip in every radix (p. 39):
+;; (eqv? number (string->number (number->string number radix) radix)) => #t
+(test-equal "number->string radix 16" "ff" (number->string 255 16))
+(test-equal "number->string radix 2" "11111111" (number->string 255 2))
+(test-equal "number->string radix 8" "377" (number->string 255 8))
+(test-equal "radix round-trip 16" 255 (string->number (number->string 255 16) 16))
+(test-equal "inexact round-trip via decimal"
+  #t (eqv? 0.1 (string->number (number->string 0.1))))
+;; exactness prefixes, radix prefixes, and their combination (6.2.5, p. 34)
+(test-equal "string->number #o octal" 127 (string->number "#o177"))
+(test-equal "string->number #e decimal" 3/2 (string->number "#e1.5"))
+(test-equal "string->number #i rational" 1.5 (string->number "#i6/4"))
+(test-equal "string->number #e#x combined" 16 (string->number "#e#x10"))
+(test-equal "string->number #x#e combined" 16 (string->number "#x#e10"))
+;; "a default radix that will be overridden if an explicit radix prefix is
+;; present in string" (p. 40)
+(test-equal "explicit prefix overrides radix argument"
+  127 (string->number "#o177" 10))
+;; invalid notations return #f, never an error (p. 40)
+(test-equal "string->number 1/0 is #f" #f (string->number "1/0"))
+(test-equal "string->number empty is #f" #f (string->number ""))
+(test-equal "string->number bare sign is #f" #f (string->number "+"))
+
+;; --- 6.2.6 exact / numerator / denominator edges ---
+(test-equal "exact of .5 is 1/2" 1/2 (exact .5))
+;; "The denominator of 0 is defined to be 1." (p. 37)
+(test-equal "denominator of 0" 1 (denominator 0))
+
+;; --- 6.3 Booleans ---
+;; "they can be written #true and #false, respectively" (p. 40)
+(test-equal "#true long literal" #t #true)
+(test-equal "#false long literal" #f #false)
+(test-equal "not of #true" #f (not #true))
+
+;; --- 6.4 Pairs and lists ---
+;; append: "If there are no arguments, the empty list is returned. If there
+;; is exactly one argument, it is returned." (p. 42)
+(test-equal "append with no arguments" '() (append))
+(let ((x (list 1 2)))
+  (test-equal "append single argument returned itself" #t (eq? x (append x))))
+;; "the resulting list is always newly allocated, except that it shares
+;; structure with the last argument" (p. 42)
+(let ((tail (list 'c 'd)))
+  (test-equal "append shares the last argument" #t
+    (eq? tail (cddr (append '(a b) tail)))))
+;; list-tail returns the shared sublist, not a copy (definition, p. 42)
+(let ((x (list 'a 'b 'c 'd)))
+  (test-equal "list-tail shares structure" #t (eq? (cddr x) (list-tail x 2))))
+;; "The list argument can be circular" for list-ref (p. 42)
+(test-equal "list-ref on circular list"
+  2
+  (let ((c (list 1 2 3)))
+    (set-cdr! (cddr c) c)
+    (list-ref c 7)))
+;; make-list without fill still has the right length (p. 42)
+(test-equal "make-list without fill" 2 (length (make-list 2)))
+
+;; --- 6.5 Symbols ---
+;; "any symbol ... written out using the write procedure, will read back in
+;; as the identical symbol" (p. 43) — requires |...| pipe notation for
+;; symbols containing delimiters.
+(let* ((s (string->symbol "he llo"))
+       (p (open-output-string)))
+  (write s p)
+  (test-equal "write/read symbol round-trip" #t
+    (eq? s (read (open-input-string (get-output-string p))))))
+(let* ((s (string->symbol "K. Harper, M.D."))
+       (p (open-output-string)))
+  (write s p)
+  (test-equal "write/read round-trip with punctuation" #t
+    (eq? s (read (open-input-string (get-output-string p))))))
+
+(let ((runner (test-runner-current)))
+  (test-end "r7rs-datatypes-gaps")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/compliance/r7rs-expressions-gaps.scm
+++ b/tests/scheme/compliance/r7rs-expressions-gaps.scm
@@ -1,0 +1,172 @@
+;; R7RS sections 4.1-4.3 conformance gap tests — audit Phase 1A.
+;; Covers spec requirements not exercised by tests/scheme/r7rs/r7rs-tests.scm.
+;; Spec references cite docs/errata-corrected-r7rs.pdf.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "r7rs-expressions-gaps")
+
+;; --- 4.1.2 Literal expressions ---
+;; "Numerical constants, string constants, character constants, vector
+;; constants, bytevector constants, and boolean constants evaluate to
+;; themselves; they need not be quoted." (p. 12)
+(test-equal "unquoted vector self-evaluates" '#(1 2 3) #(1 2 3))
+(test-equal "unquoted bytevector self-evaluates" '#u8(64 65) #u8(64 65))
+
+;; --- 4.1.4 Procedures ---
+;; Rest parameter is bound to a newly allocated list of leftover args —
+;; the empty list when the fixed formals consume everything. (p. 13)
+(test-equal "rest arg is () when exactly matched" '() ((lambda (x y . z) z) 3 4))
+
+;; --- 4.1.7 Inclusion ---
+;; include reads files with case preserved; paths resolve relative to the
+;; including file. (p. 14)
+(include "fixtures/include-plain.scm")
+(test-equal "include splices definitions" 7 included-value)
+
+;; include-ci "reads each file as if it began with the #!fold-case
+;; directive, while include does not." (p. 14)
+;; FAIL: #1141 (include-ci does not fold case — ci flag is discarded)
+;; (include-ci "fixtures/include-ci-upper.scm")
+;; (test-equal "include-ci folds case" 42 folded-value)
+
+;; --- 4.2.1 Conditionals: cond ---
+;; "If the selected <clause> contains only the <test> and no <expression>s,
+;; then the value of the <test> is returned as the result." (p. 14)
+(test-equal "cond test-only clause returns test value" 'hello (cond (#f) ('hello)))
+(test-equal "cond test-only first clause" 42 (cond (42) (else #f)))
+
+;; --- 4.2.1 Conditionals: and / or ---
+;; and: "If all the expressions evaluate to true values, the values of the
+;; last expression are returned." (p. 15) — plural: multiple values pass through.
+(test-equal "and passes through multiple values"
+  '(1 2) (call-with-values (lambda () (and #t (values 1 2))) list))
+;; or: "the value of the first expression that evaluates to a true value is
+;; returned" — values (plural) per errata; first true expression's values.
+(test-equal "or passes through multiple values"
+  '(1 2) (call-with-values (lambda () (or (values 1 2) #f)) list))
+
+;; --- 4.2.1 cond-expand (expression form) ---
+;; Feature requirements: feature identifier, (library ...), and/or/not. (p. 15)
+(test-equal "cond-expand (library ...) requirement"
+  'has-base (cond-expand ((library (scheme base)) 'has-base) (else 'no)))
+(test-equal "cond-expand and/not requirements"
+  'ok (cond-expand ((and r7rs (not this-feature-does-not-exist)) 'ok) (else 'no)))
+(test-equal "cond-expand or requirement"
+  'yes (cond-expand ((or this-feature-does-not-exist r7rs) 'yes) (else 'no)))
+(test-equal "cond-expand else clause"
+  'fallback (cond-expand (this-feature-does-not-exist 'no) (else 'fallback)))
+
+;; --- 4.2.2 Binding constructs ---
+;; let*: "The <variable>s need not be distinct." (p. 16)
+(test-equal "let* allows duplicate variables" 2 (let* ((x 1) (x (+ x 1))) x))
+
+;; let-values: a single-identifier <formals> captures all values as a list,
+;; and dotted <formals> capture leftovers, as in lambda. (p. 17)
+(test-equal "let-values single-identifier formals"
+  '(1 2 3) (let-values ((x (values 1 2 3))) x))
+(test-equal "let-values dotted formals"
+  '(1 (2 3)) (let-values (((a . r) (values 1 2 3))) (list a r)))
+
+;; let-values: "The <init>s are evaluated in the current environment" —
+;; not in the environment extended by earlier formals (unlike let*-values). (p. 17)
+(test-equal "let-values inits see outer environment"
+  'outer
+  (let ((a 'outer))
+    (let-values (((a) (values 'inner))
+                 ((b) (values a)))
+      b)))
+
+;; --- 4.2.4 Iteration: do ---
+;; "A <step> can be omitted, in which case the effect is the same as if
+;; (<variable> <init> <variable>) had been written." (p. 18)
+(test-equal "do with omitted step keeps binding"
+  'k (do ((i 0 (+ i 1)) (c 'k)) ((= i 3) c)))
+
+;; --- 4.2.6 Dynamic bindings ---
+;; "Initially, this value is the value of (converter init)." (p. 20)
+(test-equal "make-parameter applies converter to init"
+  10 (let ((p (make-parameter 5 (lambda (x) (* x 2))))) (p)))
+;; parameterize passes new values through the converter; a converter that
+;; raises propagates the error (spec example: (parameterize ((radix 0)) ...)
+;; => error, p. 20).
+(test-equal "parameterize converter error propagates"
+  'err
+  (let ((radix (make-parameter
+                10
+                (lambda (x) (if (and (exact-integer? x) (<= 2 x 16))
+                                x
+                                (error "invalid radix"))))))
+    (guard (e (#t 'err))
+      (parameterize ((radix 0)) (radix)))))
+;; "Then the previous values of the parameters are restored" after the body. (p. 20)
+(test-equal "nested parameterize restores values"
+  '(3 2 1)
+  (let ((p (make-parameter 1)) (acc '()))
+    (parameterize ((p 2))
+      (parameterize ((p 3))
+        (set! acc (cons (p) acc)))
+      (set! acc (cons (p) acc)))
+    (set! acc (cons (p) acc))
+    (reverse acc)))
+
+;; --- 4.2.8 Quasiquotation ---
+;; Improper-list templates: `((foo ,(- 10 3)) ,@(cdr '(c)) . ,(car '(cons)))
+;; => ((foo 7) . cons) (spec example, p. 21)
+(test-equal "quasiquote improper-list template"
+  '((foo 7) . cons)
+  `((foo ,(- 10 3)) ,@(cdr '(c)) . ,(car '(cons))))
+(test-equal "quasiquote unquote in cdr position"
+  '(1 . 2) `(1 . ,(+ 1 1)))
+
+;; --- 4.3.2 Pattern language: constants ---
+;; "P is a constant and E is equal to P in the sense of the equal?
+;; procedure" (p. 24) — string and numeric constants in patterns.
+(let ()
+  (define-syntax const-pat
+    (syntax-rules ()
+      ((_ "hello") 'str)
+      ((_ 42) 'num)
+      ((_ x) 'other)))
+  (test-equal "string constant pattern matches" 'str (const-pat "hello"))
+  (test-equal "numeric constant pattern matches" 'num (const-pat 42))
+  (test-equal "non-constant falls through" 'other (const-pat z)))
+
+;; --- 4.3.2 Pattern language: literal identifier matching ---
+;; "An input identifier matches a literal if and only if it is an identifier
+;; and either both its occurrence in the macro expression and its occurrence
+;; in the macro definition have the same lexical binding, or the two
+;; identifiers are the same and both have no lexical binding." (p. 23)
+(define-syntax has-lit
+  (syntax-rules (lit)
+    ((_ lit) 'is-literal)
+    ((_ x) 'not-literal)))
+(test-equal "unbound literal matches unbound use" 'is-literal (has-lit lit))
+;; FAIL: #1139 (literal matching ignores lexical bindings)
+;; (test-equal "locally rebound literal must not match"
+;;   'not-literal (let ((lit 42)) (has-lit lit)))
+
+;; --- 4.3.1 Binding constructs for syntactic keywords ---
+;; let-syntax: "The <body> is expanded in the syntactic environment obtained
+;; by extending the syntactic environment of the let-syntax expression" —
+;; the transformer specs themselves are resolved in the OUTER environment,
+;; so a transformer in the same let-syntax sees the outer m. (p. 22)
+(define-syntax m-outer (syntax-rules () ((_) 'outer)))
+;; FAIL: #1140 (let-syntax transformers see sibling keywords)
+;; (test-equal "let-syntax transformer sees outer keyword"
+;;   'outer
+;;   (let-syntax ((m-outer (syntax-rules () ((_) 'inner)))
+;;                (call-m (syntax-rules () ((_) (m-outer)))))
+;;     (call-m)))
+;; letrec-syntax: "Each binding of a <keyword> has the <transformer spec>s
+;; as well as the <body> within its region" — sibling transformers see the
+;; NEW binding. (p. 22)
+(test-equal "letrec-syntax transformer sees sibling keyword"
+  'inner
+  (letrec-syntax ((m-rec (syntax-rules () ((_) 'inner)))
+                  (call-m-rec (syntax-rules () ((_) (m-rec)))))
+    (call-m-rec)))
+
+(let ((runner (test-runner-current)))
+  (test-end "r7rs-expressions-gaps")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/compliance/r7rs-libraries-gaps.scm
+++ b/tests/scheme/compliance/r7rs-libraries-gaps.scm
@@ -1,0 +1,90 @@
+;; R7RS sections 5.6 (Libraries) conformance gap tests — audit Phase 1A.
+;; Covers library-system requirements not exercised by smoke/libraries.scm
+;; or the R7RS suite. Spec references cite docs/errata-corrected-r7rs.pdf.
+
+;; --- 5.6.1: library names may contain exact non-negative integers (p. 28)
+(define-library (gaps 0 numeric)
+  (import (scheme base))
+  (export numeric-name-ok)
+  (begin (define numeric-name-ok 'yes)))
+
+;; --- 5.6.1: a library with zero declarations is valid
+(define-library (gaps empty))
+
+;; --- 5.6.1: (export (rename internal external)) (p. 28)
+(define-library (gaps renamed-export)
+  (import (scheme base))
+  (export (rename internal-name public-name))
+  (begin (define internal-name 'renamed-ok)))
+
+;; Shared-state fixture for the single-instantiation test below.
+(define-library (gaps state)
+  (import (scheme base))
+  (export state-get state-bump)
+  (begin
+    (define v 0)
+    (define (state-get) v)
+    (define (state-bump) (set! v (+ v 1)))))
+
+(define-library (gaps state-writer)
+  (import (scheme base) (gaps state))
+  (export bump-through-writer)
+  (begin (define (bump-through-writer) (state-bump))))
+
+(define-library (gaps state-reader)
+  (import (scheme base) (gaps state))
+  (export read-through-reader)
+  (begin (define (read-through-reader) (state-get))))
+
+;; Fixture with several exports for import-set combinations.
+(define-library (gaps abc)
+  (import (scheme base))
+  (export ga gb gc)
+  (begin (define ga 1) (define gb 2) (define gc 3)))
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "r7rs-libraries-gaps")
+
+(import (gaps 0 numeric))
+(test-equal "library name with integer component" 'yes numeric-name-ok)
+
+(import (gaps renamed-export))
+(test-equal "export (rename ...) exposes external name" 'renamed-ok public-name)
+
+;; --- 5.2: nested import sets (p. 25) ---
+;; prefix of only
+(import (prefix (only (gaps abc) ga gb) p-))
+(test-equal "prefix of only" '(1 2) (list p-ga p-gb))
+;; rename of prefix — the shape used in the spec's own 5.6.2 example:
+;; (rename (prefix (example grid) grid-) (grid-make make-grid))
+(import (rename (prefix (gaps abc) g-) (g-ga renamed-ga)))
+(test-equal "rename of prefix" '(1 2) (list renamed-ga g-gb))
+;; only of except
+(import (only (except (gaps abc) gb) ga gc))
+(test-equal "only of except" '(1 3) (list ga gc))
+
+;; --- 5.6.1: import merging (p. 28) ---
+;; "(import (only (foo) a)) followed by (import (only (foo) b)) has the same
+;; effect as (import (only (foo) a b))."
+(define-library (gaps two)
+  (import (scheme base))
+  (export ta tb)
+  (begin (define ta 10) (define tb 20)))
+(import (only (gaps two) ta))
+(import (only (gaps two) tb))
+(test-equal "successive only imports merge" '(10 20) (list ta tb))
+
+;; --- 5.6.1: single instantiation (p. 28) ---
+;; "Regardless of the number of times that a library is loaded, each program
+;; or library that imports bindings from a library must do so from a single
+;; loading of that library" — mutation through one importer is visible
+;; through another.
+(import (gaps state-writer) (gaps state-reader))
+(bump-through-writer)
+(bump-through-writer)
+(test-equal "library instantiated once (shared state)" 2 (read-through-reader))
+
+(let ((runner (test-runner-current)))
+  (test-end "r7rs-libraries-gaps")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Replaces #1144 (auto-closed when its stacked base branch was deleted during the #1143 merge).

Phase 1B of the audit campaign (#1137): R7RS sections 6.1-6.5. **No bugs found** — all 40 assertions pass, including equal? termination on circular lists/vectors/mixed cycles, eqv? exactness/negative-zero/bignum/record rules, numeric I/O round-trips and prefix combinations, and symbol pipe-notation write/read round-trips.

New file: `tests/scheme/compliance/r7rs-datatypes-gaps.scm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)