### PR TITLE
Phases 2.2-2.4: SRFI-13, char, and IO primitives audit tests

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -121,9 +121,9 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 
 **Phase 2 — Primitives audit** (independent; run in parallel; order = risk)
 - [x] 2.1: `primitives_srfi18.zig` (threads) (2026-07-05, #1153–#1156; 73 audit tests + 4 disabled — mutex timeout lock-steal, #f-thread owner, native thunks rejected, gc-stress SIGSEGV)
-- [ ] 2.2: `primitives_string_ext.zig` (SRFI-13)
-- [ ] 2.3: `primitives_char.zig` (Unicode)
-- [ ] 2.4: `primitives_io.zig` (ports)
+- [x] 2.2: `primitives_string_ext.zig` (SRFI-13) (2026-07-05, #825/#826 reopened + #1158–#1159; 84 audit tests + 6 disabled — join grammar, Unicode trim, s2 ranges, ignored optional args)
+- [x] 2.3: `primitives_char.zig` (Unicode) (2026-07-05, no new bugs — 59 audit tests; final-sigma, ligatures, Cherokee all conform; classification pending #1145)
+- [x] 2.4: `primitives_io.zig` (ports) (2026-07-05, no bugs — 49 audit tests; closed-port errors, write label semantics, binary ports all conform)
 - [ ] 2.5: `primitives_filesystem.zig` (SRFI-170)
 - [ ] 2.6: `primitives_srfi1.zig` (SRFI-1)
 - [ ] 2.7: `primitives_control.zig` (call/cc, guard)

--- a/tests/scheme/audit/primitives_char-audit.scm
+++ b/tests/scheme/audit/primitives_char-audit.scm
@@ -1,0 +1,97 @@
+;; Audit tests for src/primitives_char.zig — (scheme char) Unicode operations.
+;; Audit campaign Phase 2.3 (#1137). Complements compliance/chars.scm,
+;; compliance/r7rs-chars-strings-gaps.scm, and the R7RS suite section 6.6.
+;; Run directly and read the printed counts — run-all.sh only sees exit codes.
+
+(import (scheme base) (scheme char) (scheme write))
+(import (chibi test))
+
+(test-begin "primitives_char audit")
+
+;;; --- char-numeric? is Numeric_Type=Decimal only (R7RS 6.6) ---
+(test #t (char-numeric? #\5))
+(test #t (char-numeric? #\x0664))   ; Arabic-Indic four (Nd)
+(test #t (char-numeric? #\xFF13))   ; fullwidth three (Nd)
+(test #f (char-numeric? #\x00B2))   ; superscript two: No, not decimal
+(test #f (char-numeric? #\x2160))   ; Roman numeral: Nl, not decimal
+(test #f (char-numeric? #\a))
+
+;;; --- digit-value agrees with char-numeric? ---
+(test 3 (digit-value #\xFF13))
+(test #f (digit-value #\x00B2))
+(test 0 (digit-value #\x0AE6))
+
+;;; --- classification (see #1145 for the failing property-based cases) ---
+(test #t (char-alphabetic? #\x05D0))   ; Hebrew alef, uncased letter
+(test #f (char-alphabetic? #\x0664))   ; digits are not alphabetic
+(test #t (char-whitespace? #\x00A0))   ; NBSP
+(test #t (char-whitespace? #\x2028))   ; LINE SEPARATOR
+(test #t (char-whitespace? #\x2029))   ; PARAGRAPH SEPARATOR
+(test #t (char-whitespace? #\x0B))     ; vertical tab
+(test #f (char-whitespace? #\x200B))   ; ZERO WIDTH SPACE is NOT White_Space
+
+;;; --- case conversion: simple mappings ---
+(test #\a (char-downcase #\A))
+(test #\A (char-upcase #\a))
+(test 105 (char->integer (char-downcase #\x0130))) ; I-with-dot: simple = i
+(test #\x00DF (char-upcase #\x00DF))               ; sharp-s: no simple upcase
+(test #\x13A0 (char-upcase #\xAB70))               ; Cherokee case pair
+(test #\xAB70 (char-downcase #\x13A0))
+(test #\3 (char-upcase #\3))                       ; uncased returns argument
+(test #\x05D0 (char-downcase #\x05D0))
+
+;;; --- char-foldcase: simple fold ---
+(test #\a (char-foldcase #\A))
+(test #\x03C3 (char-foldcase #\x03A3))  ; capital sigma -> sigma
+(test #\x03C3 (char-foldcase #\x03C2))  ; final sigma -> sigma
+(test #\x00DF (char-foldcase #\x00DF))  ; sharp-s folds to itself (simple)
+
+;;; --- char-ci comparisons behave as if char-foldcase applied ---
+(test #t (char-ci=? #\A #\a))
+(test #t (char-ci=? #\x03A3 #\x03C2))   ; sigma ci= final sigma via fold
+(test #t (char-ci=? #\a #\A #\a))
+(test #f (char-ci=? #\a #\b))
+(test #t (char-ci<? #\a #\B #\c))
+(test #t (char-ci<=? #\a #\B #\b))
+(test #t (char-ci>? #\c #\B #\a))
+(test #t (char-ci>=? #\b #\B #\a))
+
+;;; --- string-ci comparisons via string-foldcase ---
+(test #t (string-ci=? "AbC" "aBc" "ABC"))
+(test #t (string-ci=? "Stra\xDF;e" "STRASSE"))     ; full fold: eszett = ss
+(test #t (string-ci=? "\x03A3;" "\x03C2;"))        ; sigma forms
+(test #t (string-ci<? "apple" "BANANA"))
+(test #f (string-ci<? "BANANA" "apple"))
+(test #t (string-ci<=? "a" "A"))
+(test #t (string-ci>=? "B" "a"))
+(test #f (string-ci>? "a" "B"))
+
+;;; --- string casing: full (multi-char) mappings ---
+(test "STRASSE" (string-upcase "Stra\xDF;e"))      ; length change
+(test "FFI" (string-upcase "\xFB03;"))             ; ligature expands
+(test "strasse" (string-foldcase "STRA\xDF;E"))
+(test 2 (string-length (string-downcase "\x0130;"))) ; I-dot -> i + U+0307
+;; Greek final sigma is contextual in string-downcase:
+(test "\x03BF;\x03C2;" (string-downcase "\x039F;\x03A3;"))         ; word-final
+(test "\x03BF;\x03C3;\x03BF;" (string-downcase "\x039F;\x03A3;\x039F;")) ; medial
+(test "" (string-upcase ""))
+(test "abc" (string-downcase "ABC"))
+
+;;; --- type errors are catchable ---
+(test #t (guard (e (#t #t)) (char-upcase 5)))
+(test #t (guard (e (#t #t)) (char-foldcase "a")))
+(test #t (guard (e (#t #t)) (digit-value 7)))
+(test #t (guard (e (#t #t)) (char-ci=? #\a 5)))
+(test #t (guard (e (#t #t)) (string-ci=? "a" 5)))
+(test #t (guard (e (#t #t)) (string-upcase 42)))
+(test #t (guard (e (#t #t)) (char-alphabetic? "a")))
+
+;;; --- #1145: property-based classification (disabled pending fix) ---
+;; FAIL: #1145 (titlecase Dz-caron is neither upper nor lower case)
+;; (test '(#f #f) (list (char-upper-case? #\x01C5) (char-lower-case? #\x01C5)))
+;; FAIL: #1145 (sharp-s is Lowercase despite no simple upcase mapping)
+;; (test #t (char-lower-case? #\x00DF))
+;; FAIL: #1145 (ordinal indicators are Alphabetic + Other_Lowercase)
+;; (test '(#t #t) (list (char-alphabetic? #\x00AA) (char-lower-case? #\x00AA)))
+
+(test-end "primitives_char audit")

--- a/tests/scheme/audit/primitives_io-audit.scm
+++ b/tests/scheme/audit/primitives_io-audit.scm
@@ -1,0 +1,110 @@
+;; Audit tests for src/primitives_io.zig — ports, file I/O, read/write.
+;; Audit campaign Phase 2.4 (#1137). Complements compliance/r7rs-control-io-gaps.scm
+;; (port lifecycle, CRLF read-line, bytevector ports) and the R7RS suite.
+;; Run directly and read the printed counts — run-all.sh only sees exit codes.
+
+(import (scheme base) (scheme write) (scheme read) (scheme file) (scheme char))
+(import (chibi test))
+
+(test-begin "primitives_io audit")
+
+;;; --- closed-port operations raise catchable errors ---
+(let ((cp (open-input-string "x")))
+  (close-port cp)
+  (test #t (guard (e (#t #t)) (read-char cp)))
+  (test #t (guard (e (#t #t)) (peek-char cp)))
+  (test #t (guard (e (#t #t)) (read-line cp)))
+  ;; "These routines have no effect if the port has already been closed."
+  (test 'ok (begin (close-port cp) 'ok)))
+(let ((cop (open-output-string)))
+  (close-port cop)
+  (test #t (guard (e (#t #t)) (write-char #\a cop)))
+  (test #t (guard (e (#t #t)) (write-string "s" cop))))
+
+;;; --- read-string boundaries ---
+(let ((rs (open-input-string "hello")))
+  (test "hel" (read-string 3 rs))
+  (test "lo" (read-string 10 rs))          ; short read at end
+  (test #t (eof-object? (read-string 1 rs))))
+(test "" (read-string 0 (open-input-string "x")))
+(test #t (eof-object? (read-string 5 (open-input-string ""))))
+
+;;; --- port type predicates ---
+(let ((sp (open-input-string "a")))
+  (test #t (port? sp))
+  (test #t (input-port? sp))
+  (test #f (output-port? sp))
+  (test #t (textual-port? sp))
+  (test #f (binary-port? sp))
+  (test #t (char-ready? sp)))
+(test #f (port? 42))
+(test #f (input-port? "not a port"))
+
+;;; --- write / write-shared / write-simple label semantics (R7RS 6.13.3) ---
+;; write: "Datum labels must not be used if there are no cycles."
+(test "((1 2) (1 2))"
+  (let ((x (list 1 2)) (po (open-output-string)))
+    (write (list x x) po) (get-output-string po)))
+;; write-shared: labels for ALL shared structure
+(test "(#0=(1 2) #0#)"
+  (let ((x (list 1 2)) (po (open-output-string)))
+    (write-shared (list x x) po) (get-output-string po)))
+;; write-simple: never labels
+(test "(1 2)"
+  (let ((po (open-output-string)))
+    (write-simple '(1 2) po) (get-output-string po)))
+
+;;; --- write escape behavior (R7RS 6.13.3) ---
+(test "\"a\\\"b\\\\c\""
+  (let ((po (open-output-string))) (write "a\"b\\c" po) (get-output-string po)))
+(test "a\"b"
+  (let ((po (open-output-string))) (display "a\"b" po) (get-output-string po)))
+(test "#\\a" (let ((po (open-output-string))) (write #\a po) (get-output-string po)))
+(test "#\\space" (let ((po (open-output-string))) (write #\space po) (get-output-string po)))
+(test "#\\newline" (let ((po (open-output-string))) (write #\newline po) (get-output-string po)))
+(test "#\\null" (let ((po (open-output-string))) (write #\null po) (get-output-string po)))
+(test "a" (let ((po (open-output-string))) (display #\a po) (get-output-string po)))
+
+;;; --- file I/O round trips ---
+(let ((path "/tmp/kaappi-audit-io-test.txt"))
+  (with-output-to-file path (lambda () (display "filedata")))
+  (test "filedata" (with-input-from-file path (lambda () (read-line))))
+  (test "file" (call-with-input-file path (lambda (port) (read-string 4 port))))
+  (call-with-output-file path (lambda (port) (write-string "over" port)))
+  (test "over" (call-with-input-file path (lambda (port) (read-line port))))
+  (delete-file path)
+  (test #f (file-exists? path)))
+;; binary file ports
+(let ((path "/tmp/kaappi-audit-io-bin.bin"))
+  (let ((bp (open-binary-output-file path)))
+    (write-u8 200 bp)
+    (close-port bp))
+  (let ((bp (open-binary-input-file path)))
+    (test #t (binary-port? bp))
+    (test 200 (read-u8 bp))
+    (test #t (eof-object? (read-u8 bp)))
+    (close-port bp))
+  (delete-file path))
+
+;;; --- error signalling ---
+(test #t (guard (e ((file-error? e) #t) (#t 'wrong-type))
+  (open-input-file "/nonexistent-kaappi-io-audit")))
+(test #t (guard (e ((file-error? e) #t) (#t 'wrong-type))
+  (delete-file "/nonexistent-kaappi-io-audit")))
+(test #t (guard (e (#t #t)) (call-with-input-file "/nonexistent-kaappi-io-audit" values)))
+
+;;; --- eof objects ---
+(test #t (eof-object? (eof-object)))
+(test #f (eof-object? 'eof))
+(test #t (eof-object? (read (open-input-string ""))))
+(test #t (eof-object? (read-char (open-input-string ""))))
+
+;;; --- type errors are catchable ---
+(test #t (guard (e (#t #t)) (read-char 42)))
+(test #t (guard (e (#t #t)) (write 1 42)))
+(test #t (guard (e (#t #t)) (open-input-file 42)))
+(test #t (guard (e (#t #t)) (get-output-string (open-input-string "x"))))
+(test #t (guard (e (#t #t)) (read-string "n" (open-input-string "x"))))
+(test #t (guard (e (#t #t)) (with-input-from-file 42 (lambda () 1))))
+
+(test-end "primitives_io audit")

--- a/tests/scheme/audit/primitives_string_ext-audit.scm
+++ b/tests/scheme/audit/primitives_string_ext-audit.scm
@@ -1,0 +1,147 @@
+;; Audit tests for src/primitives_string_ext.zig — SRFI-13 string library.
+;; Audit campaign Phase 2.2 (#1137). Complements tests/scheme/srfi/srfi13-*.scm.
+;; Run directly and read the printed counts — run-all.sh only sees exit codes.
+
+(import (scheme base) (scheme char) (scheme write) (srfi 13))
+(import (chibi test))
+
+(test-begin "primitives_string_ext audit")
+
+;;; --- string-contains ---
+(test 3 (string-contains "eek la bonza" " la"))
+(test #f (string-contains "abc" "xyz"))
+(test 2 (string-contains "abc" "" 2))      ; empty needle => start1
+(test 0 (string-contains "" ""))
+(test 3 (string-contains "ab\x3BB;\x3BB;x" "\x3BB;x")) ; codepoint index, not byte
+;; FAIL: #1158 (start2/end2 silently ignored — whole needle searched)
+;; (test 1 (string-contains "abc" "xbcx" 0 3 1 3))
+
+;;; --- string-prefix? / string-suffix? (full 6-arg forms work) ---
+(test #t (string-prefix? "ab" "abcd"))
+(test #f (string-prefix? "b" "abcd"))
+(test #t (string-suffix? "cd" "abcd"))
+(test #t (string-prefix? "bc" "abcd" 0 2 1 4))
+(test #t (string-prefix? "" "anything"))
+
+;;; --- string-trim family ---
+(test "x  " (string-trim "  x  " #\space))  ; string-trim is LEFT-only
+(test "x  " (string-trim "  x  "))
+(test "  x" (string-trim-right "  x  "))
+(test "x" (string-trim-both "  x  "))
+(test "a" (string-trim-both "xxaxx" #\x))
+(test "" (string-trim-both "   "))
+(test "x" (string-trim-both "\x0B;\x0C;x\x0B;\x0C;")) ; VT/FF in default set (#826 fix)
+;; FAIL: #826 (default criterion misses Unicode whitespace; byte-based)
+;; (test "x" (string-trim-both "\x00A0;x\x00A0;"))
+
+;;; --- string-index / -right / skip / count ---
+(test 1 (string-index "abc" #\b))
+(test #f (string-index "abc" #\z))
+(test 4 (string-index-right "abcabc" #\b))
+(test 2 (string-skip "  ab" #\space))
+(test 3 (string-count "banana" #\a))
+(test 1 (string-index "a\x3BB;c" #\x3BB))   ; codepoint criterion + index
+(test 2 (string-index "ab1de" char-numeric? 1 4)) ; range-restricted search
+(test 0 (string-count "" #\a))
+
+;;; --- string-split / join / concatenate ---
+(test '("a" "b" "" "c") (string-split "a,b,,c" ","))
+(test '("") (string-split "" ","))
+(test "x y" (string-join '("x" "y")))       ; default delimiter is one space
+(test "a:b" (string-join '("a" "b") ":"))
+(test "" (string-join '()))
+(test "abcd" (string-concatenate '("ab" "cd")))
+(test "" (string-concatenate '()))
+;; FAIL: #825 (grammar argument ignored)
+;; (test "a:b:" (string-join '("a" "b") ":" 'suffix))
+;; FAIL: #825
+;; (test ":a:b" (string-join '("a" "b") ":" 'prefix))
+;; FAIL: #825 (strict-infix on empty list must raise)
+;; (test #t (guard (e (#t #t)) (string-join '() ":" 'strict-infix) #f))
+
+;;; --- take / drop (+ right variants), bounds ---
+(test "ab" (string-take "abcd" 2))
+(test "cd" (string-drop "abcd" 2))
+(test "cd" (string-take-right "abcd" 2))
+(test "ab" (string-drop-right "abcd" 2))
+(test "\x3B1;\x3B2;" (string-take "\x3B1;\x3B2;\x3B3;\x3B4;" 2)) ; codepoints
+(test "" (string-take "abc" 0))
+(test "abc" (string-take "abc" 3))
+(test #t (guard (e (#t #t)) (string-take "ab" 5)))
+(test #t (guard (e (#t #t)) (string-drop "ab" 5)))
+(test #t (guard (e (#t #t)) (string-take "ab" -1)))
+
+;;; --- pad / pad-right ---
+(test "  x" (string-pad "x" 3))
+(test "x  " (string-pad-right "x" 3))
+(test "345" (string-pad "12345" 3))          ; truncates from the LEFT
+(test "123" (string-pad-right "12345" 3))    ; truncates from the right
+(test "**x" (string-pad "x" 3 #\*))
+(test "\x3BB;\x3BB;x" (string-pad "x" 3 #\x3BB)) ; multibyte pad char
+(test "" (string-pad "abc" 0))
+;; FAIL: #1159 (non-char pad argument silently ignored)
+;; (test #t (guard (e (#t #t)) (string-pad "x" 5 "*") #f))
+
+;;; --- reverse / filter / delete / replace / titlecase ---
+(test "cba" (string-reverse "abc"))
+(test "b\x3BB;a" (string-reverse "a\x3BB;b")) ; codepoint-wise reversal
+(test "" (string-reverse ""))
+(test "ab" (string-filter char-alphabetic? "a1b2"))  ; criterion FIRST
+(test "12" (string-delete char-alphabetic? "a1b2"))
+(test "heo" (string-delete #\l "hello"))
+(test "aXYd" (string-replace "abcd" "XY" 1 3))
+(test "abcd" (string-replace "abcd" "" 2 2))
+(test "Hello World" (string-titlecase "hello wORLD"))
+;; FAIL: #1158 (string-replace rejects optional start2/end2 — arity error)
+;; (test "aYd" (string-replace "abcd" "XYZ" 1 3 1 2))
+
+;;; --- every / any (return values per SRFI-13) ---
+(test #t (string-every char-alphabetic? "abc"))
+(test #f (string-every char-alphabetic? "ab1"))
+(test #t (string-every char-alphabetic? ""))     ; vacuous truth
+(test 3 (string-every (lambda (c) (digit-value c)) "123")) ; last value
+(test 3 (string-any (lambda (c) (and (char-numeric? c) (digit-value c))) "ab3c"))
+(test #f (string-any char-numeric? "abc"))
+(test #f (string-any char-numeric? ""))
+(test #t (string-every #\a "aaa"))               ; char criterion
+(test #t (string-any #\b "abc"))
+
+;;; --- tabulate / unfold / unfold-right ---
+(test "abc" (string-tabulate (lambda (i) (integer->char (+ 97 i))) 3))
+(test "" (string-tabulate (lambda (i) #\x) 0))
+(test #t (guard (e (#t #t)) (string-tabulate (lambda (i) 42) 1))) ; non-char result
+(test "abc" (string-unfold (lambda (s) (> s 2))
+                           (lambda (s) (integer->char (+ 97 s)))
+                           (lambda (s) (+ s 1)) 0))
+(test "B:abc:F" (string-unfold (lambda (s) (> s 2))
+                               (lambda (s) (integer->char (+ 97 s)))
+                               (lambda (s) (+ s 1)) 0
+                               "B:" (lambda (s) ":F")))
+;; unfold-right: make-final is the LEFT prefix, base is the RIGHT suffix
+(test ":FcbaB:" (string-unfold-right (lambda (s) (> s 2))
+                                     (lambda (s) (integer->char (+ 97 s)))
+                                     (lambda (s) (+ s 1)) 0
+                                     "B:" (lambda (s) ":F")))
+;; error propagation from callbacks
+(test 'caught (guard (e (#t 'caught))
+  (string-unfold (lambda (s) (error "stop")) (lambda (s) #\a) (lambda (s) s) 0)))
+(test 'caught (guard (e (#t 'caught))
+  (string-tabulate (lambda (i) (error "cb")) 2)))
+(test 'caught (guard (e (#t 'caught))
+  (string-every (lambda (c) (error "cb")) "abc")))
+;; FAIL: #1159 (non-string base silently ignored)
+;; (test #t (guard (e (#t #t))
+;;   (string-unfold (lambda (s) (> s 2)) (lambda (s) #\a) (lambda (s) (+ s 1)) 0 #\Z)
+;;   #f))
+
+;;; --- type errors are catchable, not crashes ---
+(test #t (guard (e (#t #t)) (string-contains 42 "x")))
+(test #t (guard (e (#t #t)) (string-take 42 1)))
+(test #t (guard (e (#t #t)) (string-join '("a" 5))))
+(test #t (guard (e (#t #t)) (string-join 42)))
+(test #t (guard (e (#t #t)) (string-concatenate '(42))))
+(test #t (guard (e (#t #t)) (string-split 42 ",")))
+(test #t (guard (e (#t #t)) (string-reverse 42)))
+(test #t (guard (e (#t #t)) (string-pad "x" "y")))
+
+(test-end "primitives_string_ext audit")


### PR DESCRIPTION
Phases 2.2–2.4 of the audit campaign (#1137), batched per the strategy's small-unit guidance: audits of `primitives_string_ext.zig` (SRFI-13), `primitives_char.zig` (Unicode), and `primitives_io.zig` (ports).

## Phase 2.2 — SRFI-13 (84 assertions, 6 disabled, gc-stress clean)

| Issue | Finding |
|-------|---------|
| #825 (reopened) | `string-join` grammar argument still ignored (delimiter default was fixed; `'suffix`/`'prefix`/`'strict-infix` still broken) |
| #826 (reopened) | default trim still misses Unicode whitespace (`\v`/`\f` were fixed; byte-based matcher can't see NBSP etc.) |
| #1158 | `string-contains` silently ignores start2/end2 (wrong result); `string-replace` rejects them (arity error) |
| #1159 | wrong-typed optional args silently ignored (pad char, unfold base/make-final) |

What conforms: codepoint indexing throughout, pad truncation directions, criterion-first `filter`/`delete`, `every`/`any` return-value semantics, `unfold-right` base/make-final placement, callback error propagation.

## Phase 2.3 — char (59 assertions, no new bugs)

Contextual final-sigma downcasing, ligature expansion (ﬃ→FFI), Cherokee case pairs, sigma foldcase equivalence, and `Numeric_Type=Decimal` discrimination all conform. Property-based classification assertions stay disabled pending #1145 (Phase 1C).

## Phase 2.4 — IO (49 assertions, no bugs)

Closed-port errors, `write`/`write-shared`/`write-simple` datum-label semantics, escape behavior, binary file ports, and `file-error?` discrimination all conform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)