### PR TITLE
Phase 2.7: control primitives audit tests

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -126,7 +126,7 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 - [x] 2.4: `primitives_io.zig` (ports) (2026-07-05, no bugs — 49 audit tests; closed-port errors, write label semantics, binary ports all conform)
 - [x] 2.5: `primitives_filesystem.zig` (SRFI-170) (2026-07-05, #1161–#1164; 65 audit tests + 3 disabled — group-info-by-name gid=0 via upstream Zig getgrnam misdeclaration, bare-fixnum time objects, missing chown sentinels, SRFI-60 export gap found in passing; covers SRFI-170 for Phase 3.1)
 - [x] 2.6: `primitives_srfi1.zig` (SRFI-1) (2026-07-05, #1166; 105 audit tests + 2 disabled — take-right/drop-right reject dotted lists; fold/unfold/lset/predicate semantics all conform; gc-stress clean)
-- [ ] 2.7: `primitives_control.zig` (call/cc, guard)
+- [x] 2.7: `primitives_control.zig` (call/cc, guard) (2026-07-05, #1168–#1169; 33 audit tests + 2 disabled — set! rollback on continuation re-entry (hangs!), multi-value continuation invocation drops values; dynamic-wind spec example conforms)
 - [ ] 2.8: `primitives_vector.zig`
 - [ ] 2.9: `primitives_list.zig`
 - [ ] 2.10: `primitives_bytevector.zig`

--- a/tests/scheme/audit/primitives_control-audit.scm
+++ b/tests/scheme/audit/primitives_control-audit.scm
@@ -1,0 +1,125 @@
+;; Audit tests for src/primitives_control.zig — exceptions, call/cc,
+;; dynamic-wind, values. Audit campaign Phase 2.7 (#1137).
+;; Procedure-level correctness; deep continuation interactions
+;; (call/cc + guard + parameterize) are Phase 4B's unit.
+;; Run directly and read the printed counts — run-all.sh only sees exit codes.
+
+(import (scheme base) (scheme write))
+(import (chibi test))
+
+(test-begin "primitives_control audit")
+
+;;; --- values / call-with-values ---
+(test 0 (call-with-values (lambda () (values)) (lambda args (length args))))
+(test 42 (+ 1 (values 41)))
+(test '(1 2 3) (call-with-values (lambda () (values 1 2 3)) list))
+(test -1 (call-with-values * -))
+
+;;; --- raise / raise-continuable / with-exception-handler ---
+(test 101 (with-exception-handler (lambda (c) 100)
+            (lambda () (+ 1 (raise-continuable 'k)))))
+;; handler returning from plain raise triggers a secondary exception
+(test 'secondary-raised
+  (guard (outer (#t 'secondary-raised))
+    (with-exception-handler (lambda (c) 'ignored)
+      (lambda () (raise 'first) 'not-reached))))
+;; handler runs with the OUTER handler installed
+(test '(outer-saw from-handler)
+  (guard (e (#t (list 'outer-saw e)))
+    (with-exception-handler (lambda (c) (raise 'from-handler))
+      (lambda () (raise 'inner)))))
+;; raise of a non-error object arrives unchanged
+(test '(#f sym) (guard (e (#t (list (error-object? e) e))) (raise 'sym)))
+
+;;; --- error objects ---
+(test '(#t "m" (1 2))
+  (guard (e (#t (list (error-object? e)
+                      (error-object-message e)
+                      (error-object-irritants e))))
+    (error "m" 1 2)))
+(test '() (guard (e (#t (error-object-irritants e))) (error "m")))
+(test #f (error-object? 42))
+(test #f (guard (e (#t (file-error? e))) (error "x")))
+(test #f (guard (e (#t (read-error? e))) (error "x")))
+(test #t (guard (e (#t #t)) (error-object-message 42)))
+
+;;; --- call/cc ---
+(test 42 (call/cc (lambda (k) (+ 1 (k 42)))))
+(test 7 (call/cc (lambda (k) 7)))
+(test 42 (call-with-current-continuation (lambda (k) (k 42))))
+;; FAIL: #1169 (multi-argument continuation invocation drops values)
+;; (test '(1 2) (call-with-values
+;;                (lambda () (call/cc (lambda (k) (k 1 2))))
+;;                list))
+;; FAIL: #1168 (set! of non-captured local rolls back on re-entry — HANGS)
+;; (test 3 (let ((n 0) (k* #f))
+;;           (call/cc (lambda (k) (set! k* k)))
+;;           (set! n (+ n 1))
+;;           (if (< n 3) (k* #f))
+;;           n))
+;; re-entry with heap-cell and closure-captured counters works (contrast #1168)
+(test 3 (let ((n (vector 0)) (k* #f))
+          (call/cc (lambda (k) (set! k* k)))
+          (vector-set! n 0 (+ (vector-ref n 0) 1))
+          (if (< (vector-ref n 0) 3) (k* #f))
+          (vector-ref n 0)))
+(test 3 (let ((n 0) (k* #f))
+          (define (read-n) n)
+          (call/cc (lambda (k) (set! k* k)))
+          (set! n (+ n 1))
+          (if (< (read-n) 3) (k* #f))
+          n))
+
+;;; --- call/ec ---
+(test 42 (call/ec (lambda (k) (+ 1 (k 42)))))
+(test 7 (call-with-escape-continuation (lambda (k) 7)))
+
+;;; --- dynamic-wind ---
+(test '(in body out)
+  (let ((acc '()))
+    (dynamic-wind (lambda () (set! acc (cons 'in acc)))
+                  (lambda () (set! acc (cons 'body acc)) 'r)
+                  (lambda () (set! acc (cons 'out acc))))
+    (reverse acc)))
+(test 'val (dynamic-wind (lambda () 1) (lambda () 'val) (lambda () 2)))
+(test '(a b) (call-with-values
+               (lambda () (dynamic-wind (lambda () 1)
+                                        (lambda () (values 'a 'b))
+                                        (lambda () 2)))
+               list))
+;; after-thunk runs when the body escapes
+(test '(in out)
+  (let ((acc '()))
+    (call/cc (lambda (k)
+      (dynamic-wind (lambda () (set! acc (cons 'in acc)))
+                    (lambda () (k 'escaped))
+                    (lambda () (set! acc (cons 'out acc))))))
+    (reverse acc)))
+;; R7RS 6.10 spec example: re-entry re-runs before-thunk
+(test '(connect talk1 disconnect connect talk2 disconnect)
+  (let ((path '()) (c #f))
+    (let ((add (lambda (s) (set! path (cons s path)))))
+      (dynamic-wind
+        (lambda () (add 'connect))
+        (lambda () (add (call/cc (lambda (c0) (set! c c0) 'talk1))))
+        (lambda () (add 'disconnect)))
+      (if (< (length path) 4)
+          (c 'talk2)
+          (reverse path)))))
+;; errors in before-thunk propagate; after-thunk runs when body raises
+(test 'caught (guard (e (#t 'caught))
+  (dynamic-wind (lambda () (error "in-before")) (lambda () 'body) (lambda () 'after))))
+(test #t (let ((ran #f))
+           (guard (e (#t ran))
+             (dynamic-wind (lambda () 1)
+                           (lambda () (error "boom"))
+                           (lambda () (set! ran #t))))))
+
+;;; --- type errors are catchable ---
+(test #t (guard (e (#t #t)) (call/cc 42)))
+(test #t (guard (e (#t #t)) (dynamic-wind 1 2 3)))
+(test #t (guard (e (#t #t)) (call-with-values 42 list)))
+(test #t (guard (e (#t #t)) (with-exception-handler 42 (lambda () 1))))
+(test #t (guard (e (#t #t)) (call/ec "k")))
+
+(test-end "primitives_control audit")


### PR DESCRIPTION
Phase 2.7 of the audit campaign (#1137): audit of `src/primitives_control.zig` (16 procedures — exceptions, call/cc, call/ec, dynamic-wind, values).

## Bugs filed

| Issue | Severity | Finding |
|-------|----------|---------|
| #1168 | **wrong-result / hang** | re-entrant call/cc rolls back `set!` mutations of non-closure-captured locals — the register snapshot violates R7RS store semantics; generator/loop idioms infinite-loop. Heap cells and closure-captured locals survive re-entry correctly (contrast tests committed enabled) |
| #1169 | wrong-result | invoking a continuation with multiple arguments drops all but the first value (`(call-with-values (lambda () (call/cc (lambda (k) (k 1 2)))) list)` => `(1)`) |

## What conforms

The R7RS 6.10 dynamic-wind spec example (connect/talk1/disconnect/connect/talk2/disconnect) including continuation re-entry through the wind, after-thunk on escape and on raise, raise-continuable resumption, secondary exceptions when a raise handler returns, and handler-runs-in-outer-handler-env semantics.

Test file: `tests/scheme/audit/primitives_control-audit.scm` — 33 passing assertions + 2 disabled `;; FAIL: #NNNN` regression tests (the #1168 one hangs without a fix — keep it commented until then). gc-stress clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)