### PR TITLE
Add random, lazy, and cxr audit tests (audit Phases 2.15-2.17)

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -134,9 +134,9 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 - [ ] 2.12: `primitives_fiber.zig`
 - [ ] 2.13: `primitives_ffi.zig`
 - [ ] 2.14: `primitives_r7rs.zig`
-- [ ] 2.15: `primitives_random.zig` (SRFI-27)
-- [ ] 2.16: `primitives_lazy.zig`
-- [ ] 2.17: `primitives_cxr.zig`
+- [x] 2.15: `primitives_random.zig` (SRFI-27) (2026-07-05, #1192–#1196; 49 audit tests + 5 disabled — default-random-source is a procedure not a variable, fixnum-only n/i/j, make-reals ignores unit, random-real [0,1) code-inspection, chibi-test shim swallows errored assertions)
+- [x] 2.16: `primitives_lazy.zig` (2026-07-05, #1191; 35 audit tests + 1 disabled — direct re-entrant force panics via GC root stack overflow (general VM nested-native-re-entrancy crash); delay-force chains, memoization, SRFI-45 cycle detection all conform)
+- [x] 2.17: `primitives_cxr.zig` (2026-07-05, no bugs — 41 audit tests; all 24 accessors correct via self-labeling trees, catchable errors on every bad input)
 - [ ] 2.18: `primitives.zig` (core)
 
 **Phase 3 — SRFI conformance**

--- a/tests/scheme/audit/primitives_cxr-audit.scm
+++ b/tests/scheme/audit/primitives_cxr-audit.scm
@@ -1,0 +1,95 @@
+;; Audit tests for src/primitives_cxr.zig — audit Phase 2.17
+;; All 24 three- and four-level car/cdr compositions from (scheme cxr).
+;; See docs/audit-strategy.md. Run directly and read the pass/fail counts:
+;;   zig-out/bin/kaappi tests/scheme/audit/primitives_cxr-audit.scm
+
+(import (scheme base) (scheme cxr) (chibi test))
+
+(test-begin "primitives_cxr audit")
+
+;; Self-labeling complete trees: the leaf reached by each accessor holds that
+;; accessor's own name. Letters in a cxr name apply right-to-left, so the leaf
+;; label is "c" + reverse(root->leaf path) + "r".
+(define (build depth path)
+  (if (= depth 0)
+      (string->symbol
+       (string-append "c" (list->string (reverse (string->list path))) "r"))
+      (cons (build (- depth 1) (string-append path "a"))
+            (build (- depth 1) (string-append path "d")))))
+(define t3 (build 3 ""))
+(define t4 (build 4 ""))
+
+;;; --- three-level compositions ---
+(test 'caaar (caaar t3))
+(test 'caadr (caadr t3))
+(test 'cadar (cadar t3))
+(test 'caddr (caddr t3))
+(test 'cdaar (cdaar t3))
+(test 'cdadr (cdadr t3))
+(test 'cddar (cddar t3))
+(test 'cdddr (cdddr t3))
+
+;;; --- four-level compositions ---
+(test 'caaaar (caaaar t4))
+(test 'caaadr (caaadr t4))
+(test 'caadar (caadar t4))
+(test 'caaddr (caaddr t4))
+(test 'cadaar (cadaar t4))
+(test 'cadadr (cadadr t4))
+(test 'caddar (caddar t4))
+(test 'cadddr (cadddr t4))
+(test 'cdaaar (cdaaar t4))
+(test 'cdaadr (cdaadr t4))
+(test 'cdadar (cdadar t4))
+(test 'cdaddr (cdaddr t4))
+(test 'cddaar (cddaar t4))
+(test 'cddadr (cddadr t4))
+(test 'cdddar (cdddar t4))
+(test 'cddddr (cddddr t4))
+
+;;; --- classics on flat lists ---
+(test 'c (caddr '(a b c d e)))
+(test 'd (cadddr '(a b c d e)))
+(test '(d e) (cdddr '(a b c d e)))
+(test '(e) (cddddr '(a b c d e)))
+(test '() (cdddr '(1 2 3)))
+(test '() (cddddr '(1 2 3 4)))
+(test 'b (cadadr '(a (a b))))
+
+;;; --- first-class procedure values ---
+(test '(3 6) (map caddr '((1 2 3) (4 5 6))))
+(test 3 (apply caddr (list '(1 2 3 4))))
+
+;;; --- every accessor raises a catchable error on '() ---
+(define all-cxrs
+  (list caaar caadr cadar caddr cdaar cdadr cddar cdddr
+        caaaar caaadr caadar caaddr cadaar cadadr caddar cadddr
+        cdaaar cdaadr cdadar cdaddr cddaar cddadr cdddar cddddr))
+(test 24 (length all-cxrs))
+(test #t
+      (let loop ((ps all-cxrs))
+        (cond ((null? ps) #t)
+              ((guard (e (#t (error-object? e))) ((car ps) '()) #f)
+               (loop (cdr ps)))
+              (else #f))))
+
+;;; --- every accessor raises a catchable error on a non-pair ---
+(test #t
+      (let loop ((ps all-cxrs))
+        (cond ((null? ps) #t)
+              ((guard (e (#t (error-object? e))) ((car ps) 42) #f)
+               (loop (cdr ps)))
+              (else #f))))
+
+;;; --- structure too shallow / dotted ---
+(test #t (guard (e (#t (error-object? e))) (cadddr '(1 2 3)) #f))
+(test #t (guard (e (#t (error-object? e))) (caddr '(1 2 . 3)) #f))
+(test #t (guard (e (#t (error-object? e))) (cddddr "abc") #f))
+(test #t (guard (e (#t (error-object? e))) (caaar '(1 2 3)) #f))
+
+;;; --- accessors see mutation (no copying) ---
+(let ((t (list (list 1 2 3))))
+  (set-car! (cdr (car t)) 99)
+  (test 99 (cadar t)))
+
+(test-end "primitives_cxr audit")

--- a/tests/scheme/audit/primitives_lazy-audit.scm
+++ b/tests/scheme/audit/primitives_lazy-audit.scm
@@ -1,0 +1,106 @@
+;; Audit tests for src/primitives_lazy.zig — audit Phase 2.16
+;; Covers force, promise?, make-promise plus the delay/delay-force compiler
+;; forms they back (R7RS 4.2.5, SRFI-45 semantics).
+;; See docs/audit-strategy.md. Run directly and read the pass/fail counts:
+;;   zig-out/bin/kaappi tests/scheme/audit/primitives_lazy-audit.scm
+
+(import (scheme base) (scheme lazy) (chibi test))
+
+(test-begin "primitives_lazy audit")
+
+;;; --- force / delay basics and memoization (R7RS 4.2.5) ---
+(test 3 (force (delay (+ 1 2))))
+
+;; the thunk runs exactly once; later forces return the cached value
+(let ()
+  (define count 0)
+  (define p (delay (begin (set! count (+ count 1)) count)))
+  (test 1 (force p))
+  (test 1 (force p))
+  (test 1 count))
+
+;; delayed expression does not run until forced
+(let ()
+  (define ran #f)
+  (define p (delay (begin (set! ran #t) 'v)))
+  (test #f ran)
+  (test 'v (force p))
+  (test #t ran))
+
+;;; --- force on non-promise (R7RS: may be returned unchanged) ---
+(test 42 (force 42))
+(test "s" (force "s"))
+(test '() (force '()))
+(test #t (eq? car (force car)))
+
+;;; --- promise? ---
+(test #t (promise? (delay 1)))
+(test #t (promise? (delay-force (delay 1))))
+(test #t (promise? (make-promise 1)))
+(test #f (promise? 1))
+(test #f (promise? car))
+(test #f (promise? '(delay 1)))
+(test #f (promise? "promise"))
+;; forcing does not change promise-ness
+(let ((p (delay 1)))
+  (force p)
+  (test #t (promise? p)))
+
+;;; --- make-promise ---
+(test 4 (force (make-promise 4)))
+;; R7RS: "If argument is already a promise, it is returned." — same object.
+(let ((p (delay 1)))
+  (test #t (eq? p (make-promise p))))
+(let ((p (make-promise 5)))
+  (test #t (eq? p (make-promise p))))
+;; eager: the argument is evaluated, not wrapped as a thunk
+(test #t (eq? car (force (make-promise car))))
+(let ()
+  (define count 0)
+  (make-promise (set! count (+ count 1)))
+  (test 1 count))
+
+;;; --- delay-force (iterative forcing, R7RS 4.2.5 / SRFI-45) ---
+(test 42 (force (delay-force (delay 42))))
+(test 42 (force (delay-force (delay-force (delay 42)))))
+
+;; a 50000-deep delay-force chain must force in bounded space
+(letrec ((chain (lambda (n)
+                  (if (= n 0)
+                      (delay 'done)
+                      (delay-force (chain (- n 1)))))))
+  (test 'done (force (chain 50000))))
+
+;; memoization through delay-force: the body runs once
+(let ()
+  (define count 0)
+  (define p (delay-force (begin (set! count (+ count 1)) (delay count))))
+  (test 1 (force p))
+  (test 1 (force p))
+  (test 1 count))
+
+;;; --- error propagation through force ---
+(test "boom" (guard (e (#t (error-object-message e)))
+               (force (delay (error "boom")))))
+(test "deep" (guard (e (#t (error-object-message e)))
+               (force (delay-force (delay-force (delay (error "deep")))))))
+
+;;; --- SRFI-45 §8 cycle detection ---
+;; a delay-force whose thunk returns the promise currently being forced is
+;; detected and raises a catchable error
+(define cyc (delay-force cyc))
+(test 'caught (guard (e (#t 'caught)) (force cyc)))
+
+;; Direct re-entrant force — the thunk calls (force p) on its own promise —
+;; crashes the interpreter with an uncatchable Zig panic
+;; ("GC root stack overflow (1024)") instead of raising a Scheme error:
+;; FAIL: #1191 (deep native re-entrancy overflows the GC root stack — panic)
+;; (define selfp (delay (force selfp)))
+;; (test 'caught (guard (e (#t 'caught)) (force selfp)))
+
+;;; --- stream-style self-reference after memoization ---
+(letrec ((ones (delay (cons 1 (delay (force ones))))))
+  (test 1 (car (force ones)))
+  (test 1 (car (force (cdr (force ones))))))
+
+(test-end "primitives_lazy audit")

--- a/tests/scheme/audit/primitives_random-audit.scm
+++ b/tests/scheme/audit/primitives_random-audit.scm
@@ -1,0 +1,238 @@
+;; Audit tests for src/primitives_random.zig (SRFI-27) — audit Phase 2.15
+;; See docs/audit-strategy.md. Run directly and read the pass/fail counts:
+;;   zig-out/bin/kaappi tests/scheme/audit/primitives_random-audit.scm
+
+(import (scheme base) (scheme read) (srfi 27) (chibi test))
+
+(test-begin "primitives_random audit")
+
+;;; --- random-source? ---
+(test #t (random-source? (make-random-source)))
+(test #f (random-source? 42))
+(test #f (random-source? "rs"))
+(test #f (random-source? #f))
+(test #f (random-source? '()))
+
+;;; --- default-random-source ---
+;; SRFI-27: "default-random-source — A random source from which random-integer
+;; and random-real have been derived ... an assignment to default-random-source
+;; does not change random or random-real" — i.e. it is a variable bound to a
+;; random source, not a procedure.
+;; FAIL: #1192 (default-random-source is exported as a zero-argument procedure)
+;; (test #t (random-source? default-random-source))
+
+;; Kaappi's current calling convention returns the source when invoked.
+(test #t (random-source? (default-random-source)))
+
+;; random-integer draws from default-random-source: restoring the default
+;; source's state reproduces the random-integer sequence.
+(let* ((d (default-random-source))
+       (st (random-source-state-ref d))
+       (x1 (random-integer 1000000)))
+  (random-source-state-set! d st)
+  (test x1 (random-integer 1000000)))
+
+;;; --- random-integer ---
+;; n = 1 has only one possible result
+(test 0 (random-integer 1))
+
+;; 500 draws over {0..9}: all in range, exact integers, and every value hit
+;; (probability of missing a value is ~1e-22)
+(let loop ((i 0) (seen '()) (ok #t))
+  (if (= i 500)
+      (begin
+        (test #t ok)
+        (test 10 (length seen)))
+      (let ((r (random-integer 10)))
+        (loop (+ i 1)
+              (if (member r seen) seen (cons r seen))
+              (and ok (exact? r) (integer? r) (>= r 0) (< r 10))))))
+
+;; large fixnum range works
+(let ((r (random-integer (expt 2 40))))
+  (test #t (and (>= r 0) (< r (expt 2 40)))))
+
+;; SRFI-27: "The argument n must be a positive integer, otherwise an error is
+;; signalled." (expt 2 64) is a positive integer, so it must be accepted.
+;; FAIL: #1193 (random-integer rejects exact integers wider than fixnums)
+;; (test #t (let ((r (random-integer (expt 2 64))))
+;;            (and (>= r 0) (< r (expt 2 64)))))
+
+;; invalid arguments raise catchable errors
+(test #t (guard (e (#t (error-object? e))) (random-integer 0) #f))
+(test #t (guard (e (#t (error-object? e))) (random-integer -5) #f))
+(test #t (guard (e (#t (error-object? e))) (random-integer "10") #f))
+(test #t (guard (e (#t (error-object? e))) (random-integer 'ten) #f))
+
+;;; --- random-real ---
+;; SRFI-27: "The next number 0 < x < 1 obtained from default-random-source."
+(let loop ((i 0) (ok #t))
+  (if (= i 200)
+      (test #t ok)
+      (let ((r (random-real)))
+        (loop (+ i 1) (and ok (real? r) (inexact? r) (> r 0) (< r 1))))))
+
+;;; --- make-random-source determinism ---
+;; SRFI-27: "Each random source obtained as (make-random-source) generates the
+;; same stream of values, unless the state is modified"
+(let* ((s1 (make-random-source))
+       (s2 (make-random-source))
+       (r1 (random-source-make-integers s1))
+       (r2 (random-source-make-integers s2)))
+  (test (r1 1000000) (r2 1000000))
+  (test (r1 1000000) (r2 1000000))
+  (test (r1 1000000) (r2 1000000)))
+
+;;; --- source independence ---
+;; advancing one source must not perturb another
+(let* ((s1 (make-random-source))
+       (s2 (make-random-source))
+       (r1 (random-source-make-integers s1))
+       (r2 (random-source-make-integers s2))
+       (first (r1 1000000)))
+  (r1 1000000) (r1 1000000) (r1 1000000)
+  (test first (r2 1000000)))
+
+;;; --- random-source-make-integers ---
+(let* ((s (make-random-source))
+       (rand (random-source-make-integers s)))
+  (test 0 (rand 1))
+  (let ((r (rand 100)))
+    (test #t (and (>= r 0) (< r 100))))
+  (test #t (guard (e (#t (error-object? e))) (rand 0) #f))
+  (test #t (guard (e (#t (error-object? e))) (rand -1) #f))
+  (test #t (guard (e (#t (error-object? e))) (rand 1.5) #f))
+  ;; bignum range must be accepted (same requirement as random-integer)
+  ;; FAIL: #1193 (%rs-next-int rejects exact integers wider than fixnums)
+  ;; (test #t (let ((r (rand (expt 2 64)))) (and (>= r 0) (< r (expt 2 64)))))
+  )
+
+;; a generator made from a non-source raises when called
+(test #t (guard (e (#t (error-object? e)))
+           ((random-source-make-integers 42) 5) #f))
+
+;;; --- random-source-make-reals ---
+(let* ((s (make-random-source))
+       (rand (random-source-make-reals s)))
+  (let ((r (rand)))
+    (test #t (and (inexact? r) (> r 0) (< r 1)))))
+
+;; flonum unit: results are flonums in (0,1) — type matches unit
+(let* ((s (make-random-source))
+       (rand (random-source-make-reals s 0.5)))
+  (let ((r (rand)))
+    (test #t (and (inexact? r) (> r 0) (< r 1)))))
+
+;; SRFI-27: "The numbers created by rand are of the same numerical type as
+;; unit and the potential output values are spaced by at most unit." With an
+;; exact unit the results must be exact.
+;; FAIL: #1194 (random-source-make-reals ignores the unit argument)
+;; (test #t (exact? ((random-source-make-reals (make-random-source) 1/10))))
+
+;; unit outside (0,1) is rejected
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-make-reals (make-random-source) 2) #f))
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-make-reals (make-random-source) 0) #f))
+
+;;; --- random-source-randomize! ---
+;; SRFI-27: "Makes an effort to set the state of the random source s to a
+;; truly random state." A randomized source should diverge from a fresh one.
+(let* ((s1 (make-random-source))
+       (s2 (make-random-source)))
+  (random-source-randomize! s1)
+  (let ((r1 (random-source-make-integers s1))
+        (r2 (random-source-make-integers s2)))
+    (test #f (and (= (r1 (expt 2 40)) (r2 (expt 2 40)))
+                  (= (r1 (expt 2 40)) (r2 (expt 2 40)))
+                  (= (r1 (expt 2 40)) (r2 (expt 2 40)))))))
+(test #t (guard (e (#t (error-object? e))) (random-source-randomize! 42) #f))
+
+;;; --- random-source-pseudo-randomize! ---
+;; SRFI-27: "Changes the state of the random source s into the initial state
+;; of the (i, j)-th independent random source, where i and j are non-negative
+;; integers." Same (i,j) must give the same stream.
+(let ((s1 (make-random-source)) (s2 (make-random-source)))
+  (random-source-pseudo-randomize! s1 5 7)
+  (random-source-pseudo-randomize! s2 5 7)
+  (let ((r1 (random-source-make-integers s1))
+        (r2 (random-source-make-integers s2)))
+    (test (r1 1000000) (r2 1000000))
+    (test (r1 1000000) (r2 1000000))))
+
+;; distinct (i,j) give distinct streams (with very high probability)
+(let ((s1 (make-random-source)) (s2 (make-random-source)))
+  (random-source-pseudo-randomize! s1 0 1)
+  (random-source-pseudo-randomize! s2 1 0)
+  (let ((r1 (random-source-make-integers s1))
+        (r2 (random-source-make-integers s2)))
+    (test #f (and (= (r1 (expt 2 40)) (r2 (expt 2 40)))
+                  (= (r1 (expt 2 40)) (r2 (expt 2 40)))))))
+
+;; invalid arguments raise catchable errors
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-pseudo-randomize! 42 0 0) #f))
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-pseudo-randomize! (make-random-source) -1 0) #f))
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-pseudo-randomize! (make-random-source) 0 -1) #f))
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-pseudo-randomize! (make-random-source) 0.5 0) #f))
+
+;; i and j are unbounded non-negative integers
+;; FAIL: #1193 (pseudo-randomize! rejects exact integers wider than fixnums)
+;; (test #t (begin (random-source-pseudo-randomize!
+;;                  (make-random-source) (expt 2 64) 1)
+;;                 #t))
+
+;;; --- random-source-state-ref / random-source-state-set! ---
+;; round-trip reproduces the stream
+(let* ((s (make-random-source))
+       (rand (random-source-make-integers s)))
+  (rand 100) (rand 100)
+  (let* ((st (random-source-state-ref s))
+         (a (rand 1000000))
+         (b (rand 1000000)))
+    (random-source-state-set! s st)
+    (test a (rand 1000000))
+    (test b (rand 1000000))))
+
+;; state transplant between sources
+(let* ((s1 (make-random-source))
+       (s2 (make-random-source))
+       (r1 (random-source-make-integers s1))
+       (r2 (random-source-make-integers s2)))
+  (random-source-randomize! s1)
+  (random-source-state-set! s2 (random-source-state-ref s1))
+  (test (r1 1000000) (r2 1000000)))
+
+;; SRFI-27: "It is, however, required that a state possess an external
+;; representation." write → read round-trip must reproduce the stream.
+(let ((s (make-random-source)))
+  (random-source-randomize! s)
+  (let* ((st (random-source-state-ref s))
+         (str (let ((p (open-output-string)))
+                (write st p)
+                (get-output-string p)))
+         (st2 (read (open-input-string str)))
+         (rand (random-source-make-integers s))
+         (a (rand 1000000)))
+    (random-source-state-set! s st2)
+    (test a (rand 1000000))))
+
+;; invalid states raise catchable errors
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-state-set! (make-random-source) '()) #f))
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-state-set! (make-random-source) '(1 2 3)) #f))
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-state-set! (make-random-source) 42) #f))
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-state-set! (make-random-source) '(1 2 3 "x")) #f))
+;; all-zero state would wedge the Xoshiro generator
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-state-set! (make-random-source) '(0 0 0 0)) #f))
+(test #t (guard (e (#t (error-object? e)))
+           (random-source-state-ref 42) #f))
+
+(test-end "primitives_random audit")


### PR DESCRIPTION
Part of the systematic audit campaign (#1137). Batched session covering the three smallest primitives files, per `docs/audit-strategy.md` ("2.15–2.17 fit in one session").

## Coverage

| File | Audit test | Pass | Disabled (FAIL markers) |
|------|-----------|-----:|------------------------|
| `primitives_random.zig` (SRFI-27, 11 procs) | `primitives_random-audit.scm` | 49 | 5 |
| `primitives_lazy.zig` (4 procs + delay/delay-force forms) | `primitives_lazy-audit.scm` | 35 | 1 |
| `primitives_cxr.zig` (24 procs) | `primitives_cxr-audit.scm` | 41 | 0 |

## Issues filed

- #1191 — **crash**: direct re-entrant `force` panics with `GC root stack overflow (1024)`; same panic from nested `map` at depth 2000, so it's a general VM nested-native-re-entrancy problem, not promise-specific
- #1192 — `default-random-source` exported as a zero-arg procedure; SRFI-27 specifies a variable
- #1193 — `random-integer`, the `random-source-make-integers` generator, and `random-source-pseudo-randomize!` reject exact integers wider than fixnums
- #1194 — `random-source-make-reals` validates the optional `unit` argument then ignores it (exact unit must produce exact results)
- #1195 — `random-real`/`%rs-next-real` use Zig's `[0,1)` float generator; spec requires strictly `0 < x < 1` (code inspection; probability ~2^-1022, no test possible)
- #1196 — `(chibi test)` shim's `test` macro lets exceptions escape: errored assertions aren't counted as failures and abort sibling tests in the same enclosing form (observed in this session: 54-assertion file printed "49 pass, 2 fail" with 3 errored assertions uncounted)

## What conforms

- **cxr**: all 24 three/four-level accessors verified via self-labeling complete trees (each leaf holds its accessor's name); catchable errors on `'()`, non-pairs, shallow and dotted structures; first-class/`apply`/`map` usage
- **lazy**: memoization runs thunks exactly once, 50000-deep `delay-force` chains force in bounded space, SRFI-45 §8 cycle detection catches thunk-returns-forced-promise, error propagation through `force` is catchable, `make-promise` idempotence (`eq?`) holds
- **random**: fresh sources are deterministic and identical, sources are independent, state ref/set round-trips (including through `write`/`read` external representation), `pseudo-randomize!` streams reproduce per (i,j) and diverge across (i,j), all invalid-argument paths raise catchable errors

Crash findings were re-verified on a `-Dgc-stress=true` build (unchanged — deterministic depth issue, not GC timing).

Full suite green: 322 Scheme files + 1395 R7RS assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)