### PR TITLE
Add SRFI-9 and SRFI-39 conformance tests (audit Phase 3.1)

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -141,7 +141,7 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 
 **Phase 3 — SRFI conformance**
 - [x] 3.0: Run all 35 existing SRFI test files, capture failures (2026-07-05, no failures — all 35 files pass individually under timeout 30 at 96ce73b: chibi-test files all print 0 fail, SRFI-64 files report 0 unexpected failures (srfi64.scm's 1 "expected failure" is an intentional test-expect-fail), exit-code files all print their OK markers; no hangs, no escaped errors)
-- [ ] 3.1: Built-in SRFIs without adequate tests (9, 39, 170)
+- [x] 3.1: Built-in SRFIs without adequate tests (9, 39, 170) (2026-07-05, #1202–#1203 + #560 reopened; 68 tests + 6 disabled — parameterize installs bindings sequentially (SRFI-39 "1010" example fails), record redefinition retargets old ctors/predicates via call-time __record_type_ lookup, define-record-type still broken in lambda/let bodies (begin was fixed); constructors map fields by name, converters, disjointness, escape-restore all conform; 170 covered by 2.5)
 - [ ] 3a: SRFIs 0, 6, 17, 23, 26 (syntax extensions)
 - [ ] 3b: SRFIs 37, 38, 43, 116, 117, 134 (records, arrays, immutable data)
 - [ ] 3c: SRFIs 41, 42, 45, 143, 144 (lazy evaluation, math)

--- a/tests/scheme/srfi/srfi39.scm
+++ b/tests/scheme/srfi/srfi39.scm
@@ -1,0 +1,114 @@
+;; SRFI-39 (parameter objects) conformance tests — audit Phase 3.1
+;; SRFI-39 is built-in: make-parameter is a primitive (primitives_r7rs.zig),
+;; parameterize a compiler form (compiler_advanced.zig).
+;; See docs/audit-strategy.md. Run directly and read the pass/fail counts:
+;;   zig-out/bin/kaappi tests/scheme/srfi/srfi39.scm
+
+(import (scheme base) (srfi 39) (chibi test))
+
+(test-begin "srfi-39")
+
+;;; --- creation and zero-argument read ---
+;; SRFI-39: the parameter is "bound in the global dynamic environment to a
+;; cell containing the value returned by the call (converter init)"
+(define plain (make-parameter 10))
+(test 10 (plain))
+(test #t (procedure? plain))
+
+;; converter runs on the initial value at creation time
+(define doubled (make-parameter 5 (lambda (v) (* v 2))))
+(test 10 (doubled))
+
+;; converter errors at creation are catchable
+(test #t (guard (e (#t (error-object? e)))
+           (make-parameter 0 (lambda (v) (error "bad init")))
+           #f))
+
+;;; --- one-argument call assigns through the converter (SRFI-39) ---
+(define radix (make-parameter 10))
+(test 10 (radix))
+(radix 2)
+(test 2 (radix))
+(radix 16)
+(test 16 (radix))
+
+(doubled 3)
+(test 6 (doubled))
+
+;; SRFI-39 example: a converter that rejects bad values —
+;; "(write-shared 0)  ;gives an error"
+(define write-shared
+  (make-parameter #f (lambda (x)
+                       (if (boolean? x) x (error "only booleans are valid")))))
+(test #t (guard (e (#t (error-object? e))) (write-shared 0) #f))
+(write-shared #t)
+(test #t (write-shared))
+
+;;; --- the spec's prompt example ---
+(define prompt
+  (make-parameter 123 (lambda (x) (if (string? x) x (number->string x)))))
+(test "123" (prompt))
+(prompt ">")
+(test ">" (prompt))
+
+;;; --- parameterize (R7RS 4.2.6 / SRFI-39) ---
+(radix 2)
+(test 2 (radix))
+(test 16 (parameterize ((radix 16)) (radix)))
+(test 2 (radix))                       ; restored on exit
+
+;; converter runs on parameterize values; restore does NOT re-run it
+(define conv-count 0)
+(define counted
+  (make-parameter 0 (lambda (v) (set! conv-count (+ conv-count 1)) v)))
+(test 1 conv-count)                    ; init conversion
+(test 5 (parameterize ((counted 5)) (counted)))
+(test 2 conv-count)                    ; one more for the new binding
+(test 0 (counted))                     ; old value restored...
+(test 2 conv-count)                    ; ...without converting again
+
+;; converter errors inside parameterize are catchable
+(test #t (guard (e (#t (error-object? e)))
+           (parameterize ((write-shared 'nope)) 'unreached)
+           #f))
+
+;; nesting and restoration
+(define q (make-parameter 'out))
+(test 'b (parameterize ((q 'a)) (parameterize ((q 'b)) (q))))
+(test 'a (parameterize ((q 'a)) (parameterize ((q 'b)) (q)) (q)))
+(test 'out (q))
+
+;; a non-local exit restores the outer value
+(test 'out (guard (e (#t (q)))
+             (parameterize ((q 'in)) (raise 'boom))))
+(test 'out (q))
+
+;; rebinding a parameter to its current value
+(test 2 (parameterize ((radix (radix))) (radix)))
+
+;; multiple independent parameters bind together
+(define px (make-parameter 1))
+(define py (make-parameter 2))
+(test '(10 20) (parameterize ((px 10) (py 20)) (list (px) (py))))
+(test '(1 2) (list (px) (py)))
+
+;; parameterize on a non-parameter raises
+(test #t (guard (e (#t #t)) (parameterize ((42 1)) 'x) #f))
+
+;;; --- the spec's radix/prompt/f example block ---
+(define (f n) (number->string n (radix)))
+(radix 2)
+(test "1010" (f 10))
+(test "12" (parameterize ((radix 8)) (f 10)))
+
+;; SRFI-39 (normative example): value expressions are evaluated before any
+;; of the new bindings take effect —
+;;   (parameterize ((radix 8) (prompt (f 10))) (prompt))  ==>  "1010"
+;; Kaappi installs bindings sequentially, so (f 10) sees radix = 8:
+;; FAIL: #1202 (parameterize installs bindings sequentially)
+;; (test "1010" (parameterize ((radix 8) (prompt (f 10))) (prompt)))
+;; FAIL: #1202 (parameterize installs bindings sequentially)
+;; (let ((a (make-parameter 1)) (b (make-parameter 0)))
+;;   (test 1 (parameterize ((a 2) (b (a))) (b))))
+
+(test-end "srfi-39")

--- a/tests/scheme/srfi/srfi9.scm
+++ b/tests/scheme/srfi/srfi9.scm
@@ -1,0 +1,116 @@
+;; SRFI-9 (define-record-type) conformance tests — audit Phase 3.1
+;; SRFI-9 is built-in: (srfi 9) is a marker library; the form itself is
+;; handled by the VM (vm_records.zig). See docs/audit-strategy.md.
+;; Run directly and read the pass/fail counts:
+;;   zig-out/bin/kaappi tests/scheme/srfi/srfi9.scm
+
+(import (scheme base) (srfi 9) (chibi test))
+
+(test-begin "srfi-9")
+
+;;; --- the spec's <pare> example, verbatim semantics ---
+(define-record-type <pare>
+  (kons x y)
+  pare?
+  (x kar set-kar!)
+  (y kdr))
+
+(test #t (pare? (kons 1 2)))
+(test #f (pare? (cons 1 2)))
+(test 1 (kar (kons 1 2)))
+(test 2 (kdr (kons 1 2)))
+(test 3 (let ((k (kons 1 2)))
+          (set-kar! k 3)
+          (kar k)))
+
+;;; --- constructor field tags map by name, not position ---
+(define-record-type swap (mk-swap b a) swap? (a get-a) (b get-b))
+(let ((s (mk-swap 'B-val 'A-val)))
+  (test 'A-val (get-a s))
+  (test 'B-val (get-b s)))
+
+;;; --- constructor may list a subset of fields ---
+;; SRFI-9: "The initial values of all other fields are unspecified."
+(define-record-type part (mk-part x) part? (x get-x) (y get-y set-y!))
+(let ((p (mk-part 1)))
+  (test 1 (get-x p))
+  (test 'readable (begin (get-y p) 'readable))   ; unspecified but no crash
+  (set-y! p 42)
+  (test 42 (get-y p)))
+
+;;; --- disjointness ---
+;; SRFI-9: "Records are disjoint from the types listed in Section 4.2 of R5RS."
+(let ((r (kons 1 2)))
+  (test #f (pair? r))
+  (test #f (vector? r))
+  (test #f (procedure? r))
+  (test #f (string? r))
+  (test #f (symbol? r))
+  (test #f (boolean? r))
+  (test #f (char? r))
+  (test #f (number? r))
+  (test #f (null? r)))
+;; and other types do not satisfy record predicates
+(test #f (pare? 42))
+(test #f (pare? '()))
+(test #f (pare? "record"))
+(test #f (pare? #(1 2)))
+
+;;; --- distinct record types are mutually disjoint ---
+(test #f (swap? (kons 1 2)))
+(test #f (pare? (mk-swap 1 2)))
+
+;;; --- equivalence: records compare by identity ---
+(let ((r1 (kons 1 2)) (r2 (kons 1 2)))
+  (test #t (equal? r1 r1))
+  (test #t (eqv? r1 r1))
+  (test #f (equal? r1 r2))
+  (test #f (eqv? r1 r2)))
+
+;;; --- records nest and travel through data structures ---
+(let* ((inner (kons 'i1 'i2))
+       (outer (kons inner (list inner))))
+  (test 'i1 (kar (kar outer)))
+  (test #t (eq? inner (car (kdr outer)))))
+
+;;; --- accessors/modifiers on non-records raise ---
+(test #t (guard (e (#t (error-object? e))) (kar 42) #f))
+(test #t (guard (e (#t (error-object? e))) (kar '()) #f))
+(test #t (guard (e (#t (error-object? e))) (set-kar! "x" 1) #f))
+
+;; Cross-type access is silently accepted (accessors skip the type check):
+;; FAIL: #1199 (record accessors/mutators do not check the record type)
+;; (test #t (guard (e (#t (error-object? e))) (get-a (kons 1 2)) #f))
+
+;;; --- generativity ---
+;; SRFI-9: "each use creates a new record type that is distinct from all
+;; existing types"
+(define-record-type tt (mk-tt) tt?)
+(define old-inst (mk-tt))
+(define old-pred tt?)
+(define old-mk mk-tt)
+(define-record-type tt (mk-tt v) tt? (v tt-v))
+
+;; the new predicate rejects instances of the old type
+(test #f (tt? old-inst))
+
+;; ...but previously-created procedures must keep referring to the OLD type.
+;; The desugar resolves the __record_type_ global at call time, so they
+;; silently retarget to the new type:
+;; FAIL: #1203 (record-type redefinition retargets old constructors/predicates)
+;; (test #t (old-pred old-inst))
+;; FAIL: #1203 (record-type redefinition retargets old constructors/predicates)
+;; (test #f (tt? (old-mk)))
+
+;;; --- define-record-type inside begin (R7RS 5.5: outermost level or body) ---
+(begin
+  (define-record-type bt (mk-bt v) bt? (v bt-v))
+  (test 7 (bt-v (mk-bt 7))))
+
+;; ...but inside a <body> it is compiled as an expression and fails:
+;; FAIL: #560 (define-record-type not desugared in lambda/let bodies)
+;; (test 8 (let ()
+;;           (define-record-type lt (mk-lt v) lt? (v lt-v))
+;;           (lt-v (mk-lt 8))))
+
+(test-end "srfi-9")


### PR DESCRIPTION
Part of the systematic audit campaign (#1137). Phase 3.1 covers the two built-in SRFIs that had no dedicated tests — SRFI-9 (records) and SRFI-39 (parameters); SRFI-170 was already audited by Phase 2.5.

## Coverage

| File | Pass | Disabled (FAIL markers) |
|------|-----:|------------------------|
| `tests/scheme/srfi/srfi9.scm` | 36 | 4 |
| `tests/scheme/srfi/srfi39.scm` | 32 | 2 |

## Issues

- #1202 — **`parameterize` installs bindings sequentially**: later value expressions observe earlier bindings, so the normative SRFI-39 example `(parameterize ((radix 8) (prompt (f 10))) (prompt))` returns `"12"` instead of `"1010"`, and `(parameterize ((a 2) (b (a))) (b))` gives a different answer than the clause-swapped form. R7RS 4.2.6 requires value evaluation as a phase before the new dynamic environment takes effect. Affects `(scheme base)` too, not just `(srfi 39)`
- #1203 — **record-type redefinition retargets previously-created constructors/predicates**: the desugar resolves the hidden ` __record_type_<name>` global at call time, so after redefining a type, the old predicate rejects its own instances and the old constructor mints records of the *new* type (which the new accessors then index out of bounds). SRFI-9 generativity requires old procedures to keep their type
- #560 (reopened) — `define-record-type` inside lambda/let bodies is still compiled as an expression (`undefined variable` at runtime); the earlier fix covered only `begin`. R7RS 5.5 allows the form "either at the outermost level or in a body"
- one disabled line references the known #1199 (cross-type accessor check)

## What conforms

- SRFI-9: the spec's `<pare>` example verbatim; constructor field tags map **by name** with subset/reordered field lists; unspecified fields readable and settable; records disjoint from all R5RS types and from each other; identity-based `equal?`/`eqv?`; `begin`-level definitions
- SRFI-39: converter runs at creation, one-argument assignment, and parameterize entry — never on restore (verified by call counting); one-argument assignment `(radix 2)`; nesting, `raise`-escape restoration, rebind-to-current, converter errors catchable everywhere

Full suite green: 333 Scheme files + 1395 R7RS assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)