### PR TITLE
Add conformance tests for 28 portable SRFIs (audit Phases 3a-3e)

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -141,12 +141,12 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 
 **Phase 3 — SRFI conformance**
 - [x] 3.0: Run all 35 existing SRFI test files, capture failures (2026-07-05, no failures — all 35 files pass individually under timeout 30 at 96ce73b: chibi-test files all print 0 fail, SRFI-64 files report 0 unexpected failures (srfi64.scm's 1 "expected failure" is an intentional test-expect-fail), exit-code files all print their OK markers; no hangs, no escaped errors)
-- [ ] 3.1: Built-in SRFIs without adequate tests (9, 39, 170)
-- [ ] 3a: SRFIs 0, 6, 17, 23, 26 (syntax extensions)
-- [ ] 3b: SRFIs 37, 38, 43, 116, 117, 134 (records, arrays, immutable data)
-- [ ] 3c: SRFIs 41, 42, 45, 143, 144 (lazy evaluation, math)
-- [ ] 3d: SRFIs 60, 61, 78, 87, 197, 210, 227 (bitwise, testing, pipelines)
-- [ ] 3e: SRFIs 4, 127, 130, 233, 235 (vectors, cursors, combinators)
+- [x] 3.1: Built-in SRFIs without adequate tests (9, 39, 170) (2026-07-05, #1202–#1203 + #560 reopened; 68 tests + 6 disabled — parameterize installs bindings sequentially (SRFI-39 "1010" example fails), record redefinition retargets old ctors/predicates via call-time __record_type_ lookup, define-record-type still broken in lambda/let bodies (begin was fixed); constructors map fields by name, converters, disjointness, escape-restore all conform; 170 covered by 2.5)
+- [x] 3a: SRFIs 0, 6, 17, 23, 26 (syntax extensions) (2026-07-05, #1205 + #1208; 54 tests + 9 disabled — SRFI-17 is a stub (no generalized set!, no predefined setters), cut/cute hardcoded patterns (cute re-evaluates per call, later slots swallowed, no operator slots, arity cap); cond-expand/string ports/error all conform)
+- [x] 3b: SRFIs 37, 38, 43, 116, 117, 134 (2026-07-05, #1209, #1211–#1213; 125 tests + 12 disabled — SRFI-43 is SRFI-133-in-disguise (no index callbacks, 8 exports missing), args-fold short options/seed threading broken, ideque-filter calls unbound filter, reader drops datum-label refs inside vectors (breaks SRFI-38 vector cycles); queues/ideques/ilists otherwise conform)
+- [x] 3c: SRFIs 41, 42, 45, 143, 144 (2026-07-05, #1207, #1210, #1214–#1217, #1226; 157 tests + 20 disabled — bitwise and/ior/xor wrong for ALL negative operands (SRFI-151 helpers, inherited by 60/143), stream-unfold inverted + append truncates + zip crashes, comprehensions single-qualifier only, lazy/eager missing, flmax/fxmax-class arity caps; core streams/fixnum/flonum surfaces conform)
+- [x] 3d: SRFIs 60, 61, 78, 87, 197, 210, 227 (2026-07-05, #1206, #1218–#1220, #1222, #1224; 91 tests + 14 disabled — SRFI-61 empty stub, chain ignores _ placeholder (nest missing), value returns wrong element + set!-values is a no-op, check-passed? wrong signature, opt*-lambda aliased to opt-lambda; case-=> and positive-operand SRFI-60 conform)
+- [x] 3e: SRFIs 4, 127, 130, 233, 235 (2026-07-05, #1221, #1223, #1225; 122 tests + 8 disabled — SRFI-4 integer kinds are indistinguishable bytevector aliases with unchecked signed ranges, ini-file->alist dead (char-whitespace? unbound), SRFI-235 missing 24/36 exports; lseqs and cursor strings fully conform)
 - [ ] 3.4: Upgrade smoke-only SRFIs to behavioral tests (98, 125, 128, 132, 141, 151, 152, 174, 175, 195, 219, 232)
 
 **Phase 4 — Compiler & VM edge cases**

--- a/tests/scheme/srfi/srfi0.scm
+++ b/tests/scheme/srfi/srfi0.scm
@@ -1,0 +1,39 @@
+;; SRFI-0 (cond-expand) conformance tests — audit Phase 3a
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi0.scm
+
+(import (scheme base) (srfi 0) (chibi test))
+
+(test-begin "srfi-0")
+
+;; else clause
+(test 'e (cond-expand (this-feature-does-not-exist 'x) (else 'e)))
+
+;; a real feature matches (r7rs is required of conforming implementations)
+(test 'r7 (cond-expand (r7rs 'r7) (else 'no)))
+
+;; and / or / not requirements
+(test 'a (cond-expand ((and r7rs r7rs) 'a) (else 'no)))
+(test 'no (cond-expand ((and r7rs this-feature-does-not-exist) 'x) (else 'no)))
+(test 'o (cond-expand ((or this-feature-does-not-exist r7rs) 'o) (else 'no)))
+(test 'no (cond-expand ((or nope-1 nope-2) 'x) (else 'no)))
+(test 'n (cond-expand ((not this-feature-does-not-exist) 'n) (else 'no)))
+(test 'no (cond-expand ((not r7rs) 'x) (else 'no)))
+
+;; empty (and) is true, empty (or) is false
+(test 'a (cond-expand ((and) 'a) (else 'no)))
+(test 'no (cond-expand ((or) 'x) (else 'no)))
+
+;; library clauses
+(test 'lib (cond-expand ((library (scheme base)) 'lib) (else 'no)))
+(test 'nolib (cond-expand ((library (kaappi totally absent)) 'x) (else 'nolib)))
+
+;; nested requirements
+(test 'nested (cond-expand ((and (or nope r7rs) (not nope-2)) 'nested) (else 'no)))
+
+;; first matching clause wins
+(test 'first (cond-expand (r7rs 'first) (r7rs 'second) (else 'no)))
+
+;; multiple body forms
+(test 2 (cond-expand (r7rs (define-values (a) 1) (+ a 1)) (else 'no)))
+
+(test-end "srfi-0")

--- a/tests/scheme/srfi/srfi116.scm
+++ b/tests/scheme/srfi/srfi116.scm
@@ -1,0 +1,57 @@
+;; SRFI-116 (immutable list library) conformance tests — audit Phase 3b
+;; Kaappi implements ilists as ordinary lists; these tests cover the
+;; behavioral surface of the exported subset.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi116.scm
+
+(import (scheme base) (srfi 116) (chibi test))
+
+(test-begin "srfi-116")
+
+;;; --- constructors and accessors ---
+(test 1 (icar (ipair 1 2)))
+(test 2 (icdr (ipair 1 2)))
+(test 'a (icar (ilist 'a 'b 'c)))
+(test '(b c) (ilist->list (icdr (ilist 'a 'b 'c))))
+(test 3 (ilength (ilist 1 2 3)))
+(test 0 (ilength inull))
+(test #t (inull? inull))
+(test #f (inull? (ilist 1)))
+(test #t (ipair? (ipair 1 2)))
+(test #t (ilist? (ilist 1 2)))
+
+;; ipair* (like cons*)
+(test 1 (icar (ipair* 1 2 3)))
+
+;; nested accessors
+(test 'b (icadr (ilist 'a 'b 'c)))
+(test 'a (icaar (ilist (ilist 'a) 'b)))
+
+;;; --- indexing ---
+(test 'c (ilist-ref (ilist 'a 'b 'c) 2))
+(test '(c) (ilist->list (ilist-tail (ilist 'a 'b 'c) 2)))
+
+;;; --- transformations ---
+(test '(3 2 1) (ilist->list (ireverse (ilist 1 2 3))))
+(test '(1 2 3 4) (ilist->list (iappend (ilist 1 2) (ilist 3 4))))
+(test '(2 4 6) (ilist->list (imap (lambda (x) (* 2 x)) (ilist 1 2 3))))
+(test '(2) (ilist->list (ifilter even? (ilist 1 2 3))))
+(test '(1 3) (ilist->list (iremove even? (ilist 1 2 3))))
+(test 6 (ifold + 0 (ilist 1 2 3)))
+(test '(1 2 3) (ilist->list (ifold-right ipair inull (ilist 1 2 3))))
+
+;;; --- searching ---
+(test 2 (ifind even? (ilist 1 2 3)))
+(test #f (ifind even? (ilist 1 3 5)))
+(test #t (iany even? (ilist 1 2)))
+(test #f (ievery even? (ilist 1 2)))
+
+;;; --- conversions round trip ---
+(test '(1 2 3) (ilist->list (list->ilist '(1 2 3))))
+
+;;; --- ifor-each order ---
+(test '(a b c)
+      (let ((acc '()))
+        (ifor-each (lambda (x) (set! acc (cons x acc))) (ilist 'a 'b 'c))
+        (reverse acc)))
+
+(test-end "srfi-116")

--- a/tests/scheme/srfi/srfi117.scm
+++ b/tests/scheme/srfi/srfi117.scm
@@ -1,0 +1,71 @@
+;; SRFI-117 (mutable queues / list queues) conformance tests — Phase 3b
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi117.scm
+
+(import (scheme base) (srfi 117) (chibi test))
+
+(test-begin "srfi-117")
+
+;;; --- construction and basic state ---
+(test #t (list-queue? (list-queue)))
+(test #t (list-queue-empty? (list-queue)))
+(test #f (list-queue-empty? (list-queue 1)))
+(test '(1 2 3) (list-queue-list (list-queue 1 2 3)))
+(test '(1 2) (list-queue-list (make-list-queue (list 1 2))))
+
+;;; --- front / back ---
+(let ((q (list-queue 1 2 3)))
+  (test 1 (list-queue-front q))
+  (test 3 (list-queue-back q)))
+
+;;; --- adding ---
+(let ((q (list-queue 2)))
+  (list-queue-add-front! q 1)
+  (list-queue-add-back! q 3)
+  (test '(1 2 3) (list-queue-list q))
+  (test 1 (list-queue-front q))
+  (test 3 (list-queue-back q)))
+
+;; FIFO behavior from empty
+(let ((q (list-queue)))
+  (list-queue-add-back! q 'a)
+  (list-queue-add-back! q 'b)
+  (list-queue-add-back! q 'c)
+  (test 'a (list-queue-remove-front! q))
+  (test 'b (list-queue-remove-front! q))
+  (test '(c) (list-queue-list q)))
+
+;;; --- removing from both ends ---
+(let ((q (list-queue 1 2 3)))
+  (test 1 (list-queue-remove-front! q))
+  (test 3 (list-queue-remove-back! q))
+  (test '(2) (list-queue-list q))
+  (test 2 (list-queue-remove-front! q))
+  (test #t (list-queue-empty? q)))
+
+;; removing from an empty queue raises
+(test #t (guard (e (#t #t)) (list-queue-remove-front! (list-queue)) #f))
+(test #t (guard (e (#t #t)) (list-queue-remove-back! (list-queue)) #f))
+
+;;; --- append / concatenate ---
+(test '(1 2 3 4)
+      (list-queue-list (list-queue-append (list-queue 1 2) (list-queue 3 4))))
+(test '(1 2 3)
+      (list-queue-list (list-queue-concatenate
+                        (list (list-queue 1) (list-queue 2) (list-queue 3)))))
+
+;;; --- map / for-each ---
+(test '(2 4 6)
+      (list-queue-list (list-queue-map (lambda (x) (* 2 x)) (list-queue 1 2 3))))
+(test '(1 2 3)
+      (let ((acc '()))
+        (list-queue-for-each (lambda (x) (set! acc (cons x acc))) (list-queue 1 2 3))
+        (reverse acc)))
+
+;;; --- first-last returns both views ---
+(call-with-values
+    (lambda () (list-queue-first-last (list-queue 1 2 3)))
+  (lambda (first last)
+    (test 1 (car first))
+    (test 3 (car last))))
+
+(test-end "srfi-117")

--- a/tests/scheme/srfi/srfi127.scm
+++ b/tests/scheme/srfi/srfi127.scm
@@ -1,0 +1,59 @@
+;; SRFI-127 (lazy sequences) conformance tests — audit Phase 3e
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi127.scm
+
+(import (scheme base) (srfi 127) (chibi test))
+
+(test-begin "srfi-127")
+
+(define (make-gen lst)
+  (lambda ()
+    (if (null? lst)
+        (eof-object)
+        (let ((x (car lst))) (set! lst (cdr lst)) x))))
+
+;;; --- construction ---
+(test '() (generator->lseq (make-gen '())))
+(let ((s (generator->lseq (make-gen '(1 2 3)))))
+  (test #t (lseq? s))
+  (test 1 (lseq-car s))
+  (test 1 (lseq-first s))
+  (test 2 (lseq-car (lseq-cdr s)))
+  (test '(1 2 3) (lseq->list s)))
+
+;; an ordinary list is an lseq
+(test #t (lseq? '(1 2 3)))
+(test '(1 2) (lseq->list (list->lseq '(1 2))))
+
+;;; --- laziness: the generator is consumed on demand ---
+(define pulls 0)
+(define lazy-seq
+  (generator->lseq
+   (lambda () (set! pulls (+ pulls 1)) (if (> pulls 10) (eof-object) pulls))))
+(test 1 pulls)                        ; generator->lseq pulls exactly one
+(test 1 (lseq-car lazy-seq))
+(test 1 pulls)                        ; car does not pull more
+
+;;; --- operations ---
+(define (seq123) (generator->lseq (make-gen '(1 2 3))))
+(test 3 (lseq-length (seq123)))
+(test '(2 4 6) (lseq->list (lseq-map (lambda (x) (* 2 x)) (seq123))))
+(test '(2) (lseq->list (lseq-filter even? (seq123))))
+(test '(1 2) (lseq->list (lseq-take (seq123) 2)))
+(test '(3) (lseq->list (lseq-drop (seq123) 2)))
+(test 2 (lseq-ref (seq123) 1))
+(test '(1 2 3 4) (lseq->list (lseq-append (list->lseq '(1 2)) (list->lseq '(3 4)))))
+(test #t (lseq-any even? (seq123)))
+(test #f (lseq-any (lambda (x) (> x 5)) (seq123)))
+(test #t (lseq-every positive? (seq123)))
+(test #f (lseq-every even? (seq123)))
+(test '(1 2 3)
+      (let ((acc '()))
+        (lseq-for-each (lambda (x) (set! acc (cons x acc))) (seq123))
+        (reverse acc)))
+(test #t (lseq=? = (seq123) (seq123)))
+(test #f (lseq=? = (seq123) (list->lseq '(1 2))))
+
+;; lseq-realize forces the whole sequence
+(test '(1 2 3) (lseq-realize (seq123)))
+
+(test-end "srfi-127")

--- a/tests/scheme/srfi/srfi130.scm
+++ b/tests/scheme/srfi/srfi130.scm
@@ -1,0 +1,61 @@
+;; SRFI-130 (cursor-based string library) conformance tests — Phase 3e
+;; Kaappi represents cursors as codepoint indexes, which SRFI-130 permits.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi130.scm
+
+(import (scheme base) (srfi 130) (chibi test))
+
+(test-begin "srfi-130")
+
+;;; --- cursor basics ---
+(define s "hello")
+(test #t (string-cursor? (string-cursor-start s)))
+(test #t (string-cursor=? (string-cursor-start s) (string-index->cursor s 0)))
+(test 0 (string-cursor->index s (string-cursor-start s)))
+(test 5 (string-cursor->index s (string-cursor-end s)))
+
+(let ((c (string-cursor-start s)))
+  (test #\h (string-cursor-ref s c))
+  (test #\e (string-cursor-ref s (string-cursor-next s c)))
+  (test 2 (string-cursor->index s (string-cursor-forward s c 2)))
+  (test #t (string-cursor<? c (string-cursor-next s c)))
+  (test #t (string-cursor<=? c c))
+  (test #t (string-cursor>=? (string-cursor-end s) c)))
+
+(let ((e (string-cursor-end s)))
+  (test #\o (string-cursor-ref s (string-cursor-prev s e)))
+  (test 3 (string-cursor->index s (string-cursor-back s e 2))))
+
+;;; --- substring/cursors ---
+(test "ell" (substring/cursors s (string-index->cursor s 1) (string-index->cursor s 4)))
+(test "" (substring/cursors s (string-cursor-start s) (string-cursor-start s)))
+
+;;; --- searching ---
+(test 2 (string-cursor->index s (string-contains s "ll")))
+(test #f (string-contains s "xyz"))
+(test 0 (string-cursor->index s (string-contains s "")))
+(test 3 (string-cursor->index "abcabc" (string-contains-right "abcabc" "abc")))
+
+;;; --- prefixes/suffixes ---
+(test #t (string-prefix? "he" s))
+(test #f (string-prefix? "lo" s))
+(test #t (string-suffix? "lo" s))
+(test #f (string-suffix? "he" s))
+(test #t (string-prefix? "" s))
+
+;;; --- take/drop/count/filter/remove ---
+(test "he" (string-take s 2))
+(test "llo" (string-drop s 2))
+(test "lo" (string-take-right s 2))
+(test "hel" (string-drop-right s 2))
+(test 2 (string-count s (lambda (c) (char=? c #\l))))
+(test "ll" (string-filter (lambda (c) (char=? c #\l)) s))
+(test "heo" (string-remove (lambda (c) (char=? c #\l)) s))
+
+;;; --- multibyte: cursors are codepoint positions ---
+(define u "aλ𝄞b")
+(test 4 (string-cursor->index u (string-cursor-end u)))
+(test #\x3bb (string-cursor-ref u (string-cursor-next u (string-cursor-start u))))
+(test "λ𝄞" (substring/cursors u (string-index->cursor u 1) (string-index->cursor u 3)))
+(test 1 (string-cursor->index u (string-contains u "λ")))
+
+(test-end "srfi-130")

--- a/tests/scheme/srfi/srfi134.scm
+++ b/tests/scheme/srfi/srfi134.scm
@@ -1,0 +1,65 @@
+;; SRFI-134 (immutable deques) conformance tests — audit Phase 3b
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi134.scm
+
+(import (scheme base) (srfi 134) (chibi test))
+
+(test-begin "srfi-134")
+
+;;; --- construction ---
+(test #t (ideque? (ideque)))
+(test #t (ideque-empty? (ideque)))
+(test #f (ideque-empty? (ideque 1)))
+(test '(1 2 3) (ideque->list (ideque 1 2 3)))
+(test '(1 2 3) (ideque->list (list->ideque '(1 2 3))))
+(test 3 (ideque-length (ideque 1 2 3)))
+(test 0 (ideque-length (ideque)))
+
+;;; --- front / back ---
+(let ((d (ideque 1 2 3)))
+  (test 1 (ideque-front d))
+  (test 3 (ideque-back d)))
+
+;;; --- persistence: add/remove return new deques, original unchanged ---
+(let* ((d (ideque 2))
+       (d2 (ideque-add-front d 1))
+       (d3 (ideque-add-back d2 3)))
+  (test '(2) (ideque->list d))
+  (test '(1 2) (ideque->list d2))
+  (test '(1 2 3) (ideque->list d3)))
+
+(let* ((d (ideque 1 2 3))
+       (df (ideque-remove-front d))
+       (db (ideque-remove-back d)))
+  (test '(1 2 3) (ideque->list d))
+  (test '(2 3) (ideque->list df))
+  (test '(1 2) (ideque->list db)))
+
+;; alternating operations across both ends
+(let loop ((d (ideque)) (i 0))
+  (if (< i 4)
+      (loop (ideque-add-back (ideque-add-front d i) (* 10 i)) (+ i 1))
+      (test '(3 2 1 0 0 10 20 30) (ideque->list d))))
+
+;; removing from an empty deque raises
+(test #t (guard (e (#t #t)) (ideque-remove-front (ideque)) #f))
+(test #t (guard (e (#t #t)) (ideque-remove-back (ideque)) #f))
+
+;;; --- higher-order operations ---
+(test '(2 4 6) (ideque->list (ideque-map (lambda (x) (* 2 x)) (ideque 1 2 3))))
+(test 6 (ideque-fold + 0 (ideque 1 2 3)))
+;; FAIL: #1212 (ideque-filter calls unbound 'filter' inside the library)
+;; (test '(2) (ideque->list (ideque-filter even? (ideque 1 2 3))))
+(test '(1 2 3 4) (ideque->list (ideque-append (ideque 1 2) (ideque 3 4))))
+(test '(1 2 3)
+      (let ((acc '()))
+        (ideque-for-each (lambda (x) (set! acc (cons x acc))) (ideque 1 2 3))
+        (reverse acc)))
+
+;;; --- indexing and predicates over elements ---
+(test 'b (ideque-ref (ideque 'a 'b 'c) 1))
+(test #t (ideque-any even? (ideque 1 2 3)))
+(test #f (ideque-any even? (ideque 1 3 5)))
+(test #t (ideque-every odd? (ideque 1 3 5)))
+(test #f (ideque-every odd? (ideque 1 2 5)))
+
+(test-end "srfi-134")

--- a/tests/scheme/srfi/srfi143.scm
+++ b/tests/scheme/srfi/srfi143.scm
@@ -1,0 +1,81 @@
+;; SRFI-143 (fixnums) conformance tests — audit Phase 3c
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi143.scm
+
+(import (scheme base) (srfi 143) (chibi test))
+
+(test-begin "srfi-143")
+
+;;; --- constants and fixnum? ---
+(test #t (>= fx-width 14))                       ; SRFI-143 minimum
+(test #t (= fx-greatest (- (expt 2 (- fx-width 1)) 1)))
+(test #t (= fx-least (- (expt 2 (- fx-width 1)))))
+(test #t (fixnum? 0))
+(test #t (fixnum? fx-greatest))
+(test #t (fixnum? fx-least))
+(test #f (fixnum? (+ fx-greatest 1)))
+(test #f (fixnum? 1.0))
+(test #f (fixnum? 1/2))
+(test #f (fixnum? 'a))
+
+;;; --- comparisons ---
+(test #t (fx=? 1 1))
+(test #t (fx<? 1 2))
+(test #f (fx<? 2 1))
+(test #t (fx>? 3 2))
+(test #t (fx<=? 1 1))
+(test #t (fx>=? 2 2))
+;; FAIL: #1226 (comparison predicates accept exactly 2 arguments)
+;; (test #t (fx<? 1 2 3))
+;; (test #t (fx>? 3 2 1))
+
+;;; --- predicates ---
+(test #t (fxzero? 0))
+(test #f (fxzero? 1))
+(test #t (fxpositive? 1))
+(test #f (fxpositive? 0))
+(test #t (fxnegative? -1))
+(test #t (fxodd? 3))
+(test #t (fxeven? 4))
+(test #f (fxeven? 3))
+
+;;; --- arithmetic ---
+(test 5 (fx+ 2 3))
+(test -1 (fx- 2 3))
+(test 6 (fx* 2 3))
+(test -2 (fxneg 2))
+(test 3 (fxquotient 7 2))
+(test -3 (fxquotient -7 2))
+(test 1 (fxremainder 7 2))
+(test -1 (fxremainder -7 2))
+(test 5 (fxabs -5))
+(test 9 (fxsquare 3))
+(test 3 (fxmax 1 3))
+(test 1 (fxmin 2 1))
+;; FAIL: #1226 (fxmax/fxmin accept exactly 2 arguments)
+;; (test 3 (fxmax 1 3 2))
+;; (test 1 (fxmin 2 1 3))
+
+;;; --- bitwise ---
+(test 10 (fxand 11 26))
+(test 11 (fxior 3 10))
+(test 6 (fxxor 3 5))
+(test -11 (fxnot 10))
+(test 8 (fxarithmetic-shift 1 3))
+(test 2 (fxarithmetic-shift 16 -3))
+(test 8 (fxarithmetic-shift-left 1 3))
+(test 2 (fxarithmetic-shift-right 16 3))
+(test 3 (fxbit-count 7))
+(test 1 (fxbit-count 8))
+(test 4 (fxlength 8))
+(test 0 (fxlength 0))
+;; FAIL: #1214 (fxand broken for negative operands; fxif inherits it)
+;; (test 9 (fxif 3 1 8))
+(test #t (fxbit-set? 0 1))
+(test #f (fxbit-set? 1 1))
+(test #t (fxbit-set? 2 4))
+(test 2 (fxfirst-set-bit 12))
+(test -1 (fxfirst-set-bit 0))
+(test 0 (fxfirst-set-bit 1))
+(test 2 (fxbit-field 13 1 3))
+
+(test-end "srfi-143")

--- a/tests/scheme/srfi/srfi144.scm
+++ b/tests/scheme/srfi/srfi144.scm
@@ -1,0 +1,76 @@
+;; SRFI-144 (flonums) conformance tests — audit Phase 3c
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi144.scm
+
+(import (scheme base) (srfi 144) (chibi test))
+
+(test-begin "srfi-144")
+
+;;; --- constants ---
+(test #t (< 2.718281 fl-e 2.718282))
+(test #t (< 3.141592 fl-pi 3.141593))
+(test #t (< 0.318309 fl-1/pi 0.318310))
+(test #t (flonum? fl-greatest))
+(test #t (> fl-greatest 1e308))
+(test #t (> fl-least 0.0))
+(test #t (< fl-least 1e-300))
+(test #t (< 0.0 fl-epsilon 1e-10))
+
+;;; --- predicates ---
+(test #t (flonum? 1.5))
+(test #f (flonum? 1))
+(test #f (flonum? 1/2))
+(test #t (flzero? 0.0))
+(test #t (flpositive? 1.0))
+(test #t (flnegative? -1.0))
+(test #t (flinteger? 2.0))
+(test #f (flinteger? 2.5))
+(test #t (flfinite? 1.0))
+(test #f (flfinite? +inf.0))
+(test #t (flinfinite? +inf.0))
+(test #f (flinfinite? 1.0))
+(test #t (flnan? +nan.0))
+(test #f (flnan? 1.0))
+(test #t (flodd? 3.0))
+(test #t (fleven? 4.0))
+
+;;; --- arithmetic and comparisons ---
+(test 5.0 (fl+ 2.0 3.0))
+(test -1.0 (fl- 2.0 3.0))
+(test 6.0 (fl* 2.0 3.0))
+(test 2.5 (fl/ 5.0 2.0))
+(test #t (fl= 1.0 1.0))
+(test #t (fl< 1.0 2.0))
+(test #t (fl> 2.0 1.0))
+(test #t (fl<= 1.0 1.0))
+(test #t (fl>= 1.0 1.0))
+(test 5.0 (flabs -5.0))
+(test 3.0 (flmax 1.0 3.0))
+(test 1.0 (flmin 2.0 1.0))
+;; FAIL: #1217 (flmax/flmin accept exactly 2 arguments; spec is variadic)
+;; (test 3.0 (flmax 1.0 3.0 2.0))
+;; (test 1.0 (flmin 2.0 1.0 3.0))
+
+;;; --- rounding ---
+(test 1.0 (flfloor 1.7))
+(test 2.0 (flceiling 1.2))
+(test 1.0 (fltruncate 1.7))
+(test -1.0 (fltruncate -1.7))
+(test 2.0 (flround 1.5))
+
+;;; --- transcendental ---
+(test 3.0 (flsqrt 9.0))
+(test 1.0 (flexp 0.0))
+(test 0.0 (fllog 1.0))
+(test 0.0 (flsin 0.0))
+(test 1.0 (flcos 0.0))
+(test 0.0 (fltan 0.0))
+(test 0.0 (flasin 0.0))
+(test 0.0 (flatan 0.0))
+(test 8.0 (flexpt 2.0 3.0))
+
+;;; --- conversions ---
+(test 2 (fl->exact 2.0))
+(test 2.0 (exact->fl 2))
+(test 3.0 (fixnum->flonum 3))
+
+(test-end "srfi-144")

--- a/tests/scheme/srfi/srfi17.scm
+++ b/tests/scheme/srfi/srfi17.scm
@@ -1,0 +1,35 @@
+;; SRFI-17 (generalized set!) conformance tests — audit Phase 3a
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi17.scm
+
+(import (scheme base) (srfi 17) (chibi test))
+
+(test-begin "srfi-17")
+
+;;; --- getter-with-setter (works for user-registered getters) ---
+(define storage (vector 1 2 3))
+(define my-get
+  (getter-with-setter
+   (lambda (i) (vector-ref storage i))
+   (lambda (i v) (vector-set! storage i v))))
+(test 2 (my-get 1))
+((setter my-get) 1 99)
+(test 99 (my-get 1))
+(test 1 (my-get 0))
+
+;; setter on an unregistered procedure raises
+(test #t (guard (e (#t (error-object? e))) (setter (lambda (x) x)) #f))
+
+;;; --- pre-defined setters (SRFI-17: "The following standard procedures
+;;; have pre-defined setters": car, cdr, caXXr/cdXXr, string-ref, vector-ref)
+;; FAIL: #1205 (SRFI-17 stub: no pre-defined setters)
+;; (test '(9 2) (let ((p (list 1 2))) ((setter car) p 9) p))
+;; FAIL: #1205 (SRFI-17 stub: no pre-defined setters)
+;; (test #(1 9) (let ((v (vector 1 2))) ((setter vector-ref) v 1 9) v))
+
+;;; --- generalized set! syntax: (set! (proc arg ...) value) ---
+;; FAIL: #1205 (SRFI-17 stub: generalized set! not supported)
+;; (test '(9 2) (let ((p (list 1 2))) (set! (car p) 9) p))
+;; FAIL: #1205 (SRFI-17 stub: generalized set! not supported)
+;; (test #(1 9) (let ((v (vector 1 2))) (set! (vector-ref v 1) 9) v))
+
+(test-end "srfi-17")

--- a/tests/scheme/srfi/srfi197.scm
+++ b/tests/scheme/srfi/srfi197.scm
@@ -1,0 +1,39 @@
+;; SRFI-197 (pipeline operators) conformance tests — audit Phase 3d
+;; chain currently threads the value as first argument instead of
+;; substituting _ (#1219); the enabled tests use only shapes where the two
+;; conventions coincide.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi197.scm
+
+(import (scheme base) (srfi 197) (chibi test))
+
+(test-begin "srfi-197")
+
+;;; --- shapes where first-argument insertion matches _-in-first-position ---
+(test 3 (chain 1 (+ 2)))
+(test 6 (chain 1 (+ 2) (* 2)))
+(test '(1 2) (chain 1 (list 2)))
+(test 4 (chain 16 (- 12)))
+
+;; bare identity chain
+(test 5 (chain 5))
+
+;;; --- chain-and short-circuits on #f ---
+(define (to-false x) #f)
+(define (boom x) (error "must not run"))
+(test 3 (chain-and 1 (+ 2)))
+(test #f (chain-and #f (+ 2)))
+(test #f (chain-and 1 (+ 1) (to-false) (boom)))
+
+;;; --- chain-lambda ---
+(test 7 ((chain-lambda (+ 2) (+ 4)) 1))
+
+;;; --- SRFI-197 placeholder semantics ---
+;; "(chain x (a b _)) ; => (a b x)"
+;; FAIL: #1219 (chain does not substitute the _ placeholder)
+;; (test -9 (chain 10 (- 1 _)))
+;; FAIL: #1219 (chain does not substitute the _ placeholder)
+;; (test '(a x) (chain 'x (list 'a _)))
+;; FAIL: #1219 (nest and nest-reverse are not exported)
+;; (test '(a (b (c))) (nest (list 'a _) (list 'b _) (list 'c)))
+
+(test-end "srfi-197")

--- a/tests/scheme/srfi/srfi210.scm
+++ b/tests/scheme/srfi/srfi210.scm
@@ -1,0 +1,60 @@
+;; SRFI-210 (procedures and syntax for multiple values) tests — Phase 3d
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi210.scm
+
+(import (scheme base) (srfi 195) (srfi 210) (chibi test))
+
+(test-begin "srfi-210")
+
+;;; --- syntax ---
+(test '(1 2) (with-values (values 1 2) list))
+(test 3 (with-values (values 1 2) +))
+
+(test '(1 2 3) (list/mv 1 (values 2 3)))
+(test '(1 2) (list/mv (values 1 2)))
+(test #(1 2 3) (vector/mv 1 (values 2 3)))
+(test 6 (apply/mv + 1 (values 2 3)))
+(test '(1 2 3 4) (call/mv list (values 1 2) (values 3 4)))
+(test 'b (value/mv 1 'a (values 'b 'c)))
+(test 2 (coarity (values 1 2)))
+(test 0 (coarity (values)))
+(test 1 (coarity 42))
+
+;; case-receive dispatches on value count
+(test 'one (case-receive (values 1) ((a) 'one) ((a b) 'two) (else 'many)))
+(test 'two (case-receive (values 1 2) ((a) 'one) ((a b) 'two) (else 'many)))
+(test 'many (case-receive (values 1 2 3) ((a) 'one) ((a b) 'two) (else 'many)))
+
+;; set!-values assigns existing variables:
+;; FAIL: #1224 (set!-values is a no-op — assigns the consumer's own params)
+;; (define sv-a 0)
+;; (define sv-b 0)
+;; (set!-values (sv-a sv-b) (values 10 20))
+;; (test '(10 20) (list sv-a sv-b))
+
+;; bind/mv chains a producer through transducers
+(test 3 (bind/mv (values 1 2) +))
+
+;;; --- procedures ---
+(test '(1 2) (with-values (list-values '(1 2)) list))
+(test '(1 2) (with-values (vector-values #(1 2)) list))
+(test '(7) (with-values (box-values (box 7)) list))
+(test '(1 2) (with-values (identity 1 2) list))
+(test 5 (identity 5))
+
+(test 9 ((compose-left (lambda (x) (+ x 1)) (lambda (x) (* x 3))) 2))
+(test 7 ((compose-right (lambda (x) (+ x 1)) (lambda (x) (* x 3))) 2))
+(test '(2 4) (with-values ((map-values (lambda (x) (* 2 x))) 1 2) list))
+
+(test 6 (bind 5 (lambda (x) (+ x 1))))
+(test 3 (bind/list '(1 2) +))
+(test 3 (bind/box (box (values 1 2)) +))
+
+;;; --- value: (value index obj0 ... objn-1) returns obj_index ---
+;; FAIL: #1218 (value returns its first argument instead of the index-th object)
+;; (test 'b (value 1 'a 'b))
+;; FAIL: #1218 (value returns its first argument instead of the index-th object)
+;; (test 'x (value 0 'x))
+;; FAIL: #1218 (box/mv is not exported)
+;; (test '(1 2 3) (unbox (box/mv 1 (values 2 3))))
+
+(test-end "srfi-210")

--- a/tests/scheme/srfi/srfi227.scm
+++ b/tests/scheme/srfi/srfi227.scm
@@ -1,0 +1,50 @@
+;; SRFI-227 (optional arguments) conformance tests — audit Phase 3d
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi227.scm
+
+(import (scheme base) (srfi 227) (chibi test))
+
+(test-begin "srfi-227")
+
+;;; --- all-optional forms ---
+(define f1 (opt-lambda ((a 1)) a))
+(test 1 (f1))
+(test 9 (f1 9))
+
+(define f2 (opt-lambda ((a 1) (b 2)) (list a b)))
+(test '(1 2) (f2))
+(test '(9 2) (f2 9))
+(test '(9 8) (f2 9 8))
+
+;;; --- required + optional ---
+(define g1 (opt-lambda (r (a 10)) (list r a)))
+(test '(5 10) (g1 5))
+(test '(5 6) (g1 5 6))
+
+(define g2 (opt-lambda (r (a 10) (b 20)) (list r a b)))
+(test '(5 10 20) (g2 5))
+(test '(5 6 20) (g2 5 6))
+(test '(5 6 7) (g2 5 6 7))
+
+(define g3 (opt-lambda (r s (a 10)) (list r s a)))
+(test '(1 2 10) (g3 1 2))
+(test '(1 2 3) (g3 1 2 3))
+
+;;; --- plain formals fall back to lambda ---
+(define plain (opt-lambda (a b) (+ a b)))
+(test 3 (plain 1 2))
+
+;;; --- opt*-lambda: defaults see earlier parameters (let*-like) ---
+(define s1 (opt*-lambda ((a 2) (b (* a 3))) (list a b)))
+(test '(5 15) (s1 5))
+(test '(5 9) (s1 5 9))
+;; with zero arguments the default of b must see a's default:
+;; FAIL: #1222 (opt*-lambda is an alias of opt-lambda; zero-arg case uses
+;;              parallel let, so (* a 3) cannot see a)
+;; (test '(2 6) (s1))
+
+;;; --- let-optionals ---
+(test '(1 2) (let-optionals '(1) ((a 0) (b 2)) (list a b)))
+(test '(0 2) (let-optionals '() ((a 0) (b 2)) (list a b)))
+(test '(1 9) (let-optionals '(1 9) ((a 0) (b 2)) (list a b)))
+
+(test-end "srfi-227")

--- a/tests/scheme/srfi/srfi23.scm
+++ b/tests/scheme/srfi/srfi23.scm
@@ -1,0 +1,27 @@
+;; SRFI-23 (error reporting mechanism) conformance tests — audit Phase 3a
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi23.scm
+
+(import (scheme base) (srfi 23) (chibi test))
+
+(test-begin "srfi-23")
+
+;; error raises a catchable condition
+(test #t (guard (e (#t (error-object? e))) (error "boom") #f))
+
+;; message and irritants are preserved
+(test "boom" (guard (e (#t (error-object-message e))) (error "boom" 1 2)))
+(test '(1 2) (guard (e (#t (error-object-irritants e))) (error "boom" 1 2)))
+(test '() (guard (e (#t (error-object-irritants e))) (error "no-irritants")))
+
+;; irritants keep arbitrary structure
+(test '((a b) #(1) "s")
+      (guard (e (#t (error-object-irritants e)))
+        (error "msg" '(a b) #(1) "s")))
+
+;; error unwinds from nested expressions
+(test 'deep (guard (e (#t 'deep)) (+ 1 (error "inside"))))
+
+;; the raised object is not an ordinary value
+(test #f (guard (e (#t (string? e))) (error "boom") #f))
+
+(test-end "srfi-23")

--- a/tests/scheme/srfi/srfi233.scm
+++ b/tests/scheme/srfi/srfi233.scm
@@ -1,0 +1,45 @@
+;; SRFI-233 (INI files) conformance tests — audit Phase 3e
+;; ini-file->alist fails on any non-empty input (#1223): the library's
+;; string-trim calls char-whitespace? without importing (scheme char).
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi233.scm
+
+(import (scheme base) (srfi 233) (chibi test))
+
+(test-begin "srfi-233")
+
+(define (parse str)
+  (ini-file->alist (open-input-string str)))
+
+;; empty input works (never reaches the broken string-trim)
+(test '() (parse ""))
+
+;;; --- the writer is unaffected ---
+(define (unparse alist)
+  (let ((p (open-output-string)))
+    (alist->ini-file alist p)
+    (get-output-string p)))
+
+(test "[sec]\nk = v\n\n" (unparse '(("sec" ("k" . "v")))))
+(test "" (unparse '()))
+
+;;; --- parsing (all blocked on #1223) ---
+;; FAIL: #1223 (ini-file->alist: char-whitespace? unbound — every parse fails)
+;; (let ((r (parse "[server]\nhost=localhost\nport=8080\n")))
+;;   (test 1 (length r))
+;;   (test "server" (car (car r)))
+;;   (let ((entries (cdr (car r))))
+;;     (test "localhost" (cdr (assoc "host" entries)))
+;;     (test "8080" (cdr (assoc "port" entries)))))
+;; FAIL: #1223 (ini-file->alist: char-whitespace? unbound)
+;; (let ((r (parse "[a]\nx=1\n[b]\ny=2\n")))
+;;   (test 2 (length r))
+;;   (test "1" (cdr (assoc "x" (cdr (car r))))))
+;; FAIL: #1223 (ini-file->alist: char-whitespace? unbound)
+;; (let ((r (parse "[s]\n; comment\n\nk=v\n")))
+;;   (test "v" (cdr (assoc "k" (cdr (car r))))))
+;; FAIL: #1223 (round trip blocked on the parser)
+;; (let* ((out (unparse '(("sec" ("k" . "v")))))
+;;        (back (parse out)))
+;;   (test "v" (cdr (assoc "k" (cdr (car back))))))
+
+(test-end "srfi-233")

--- a/tests/scheme/srfi/srfi235.scm
+++ b/tests/scheme/srfi/srfi235.scm
@@ -1,0 +1,68 @@
+;; SRFI-235 (combinators) conformance tests — audit Phase 3e
+;; 24 of 36 exports are missing and all-of/conjoin have return-value
+;; deviations (#1221); tests cover the present surface.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi235.scm
+
+(import (scheme base) (srfi 235) (chibi test))
+
+(test-begin "srfi-235")
+
+;;; --- constantly / complement ---
+(test 7 ((constantly 7) 'ignored 'args))
+(test '(1 2) (call-with-values (lambda () ((constantly 1 2) 'x)) list))
+(test #t ((complement even?) 3))
+(test #f ((complement even?) 4))
+(test #t ((complement member) 'x '(a b)))
+
+;;; --- swap / flip ---
+;; SRFI-235: ((swap proc) obj1 obj2 . objs) => (apply proc obj2 obj1 objs)
+(test '(2 . 1) ((swap cons) 1 2))
+(test '(2 1 3 4) ((swap list) 1 2 3 4))
+;; SRFI-235: ((flip proc) . objs) => (apply proc (reverse objs))
+(test '(3 2 1) ((flip list) 1 2 3))
+(test '(2 . 1) ((flip cons) 1 2))
+
+;;; --- on ---
+;; SRFI-235: ((on reducer mapper) obj ...) applies mapper to each obj then
+;; reducer to the results
+(test 5 ((on + car) '(2 x) '(3 y)))
+(test #t ((on = car) '(1 a) '(1 b)))
+
+;;; --- each-of ---
+(let ((acc '()))
+  (((lambda ps (apply each-of ps))
+    (lambda (x) (set! acc (cons (list 'a x) acc)))
+    (lambda (x) (set! acc (cons (list 'b x) acc))))
+   7)
+  (test '((a 7) (b 7)) (reverse acc)))
+
+;;; --- all-of / any-of ---
+(test #t ((all-of even?) '(2 4 6)))
+(test #f ((all-of even?) '(2 3)))
+(test #t ((all-of even?) '()))
+(test #t ((any-of even?) '(1 2)))
+(test #f ((any-of even?) '(1 3)))
+(test #f ((any-of even?) '()))
+;; SRFI-235: all-of "returns last call result" when all satisfied
+;; FAIL: #1221 (all-of returns #t instead of the last predicate result)
+;; (test 2 ((all-of (lambda (x) x)) '(1 2)))
+
+;;; --- conjoin / disjoin ---
+(test #t ((conjoin number? odd?) 3))
+(test #f ((conjoin number? odd?) 4))
+(test #f ((conjoin number? odd?) 'x))
+(test #t ((conjoin) 'anything))
+(test #t ((disjoin number? symbol?) 'x))
+(test #t ((disjoin number? symbol?) 1))
+(test #f ((disjoin number? symbol?) "s"))
+(test #f ((disjoin) 'anything))
+;; FAIL: #1221 (conjoin returns #t instead of the last predicate value)
+;; (test 5 ((conjoin (lambda (x) x)) 5))
+
+;;; --- missing exports ---
+;; FAIL: #1221 (left-section, right-section, apply-chain, group-by,
+;;              begin-procedure, always, never, boolean, ... not exported)
+;; (test 7 ((left-section + 3) 4))
+;; (test #t (always 'x))
+
+(test-end "srfi-235")

--- a/tests/scheme/srfi/srfi26.scm
+++ b/tests/scheme/srfi/srfi26.scm
@@ -1,0 +1,54 @@
+;; SRFI-26 (cut / cute) conformance tests — audit Phase 3a
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi26.scm
+
+(import (scheme base) (srfi 26) (chibi test))
+
+(test-begin "srfi-26")
+
+;;; --- basic slots ---
+(test 6 ((cut + 1 <>) 5))
+;; FAIL: #1208 (cut: later slots swallowed by earlier fixed-arg patterns)
+;; (test '(1 a 2) ((cut list <> 'a <>) 1 2))
+(test 9 ((cut car '(9 8))))
+(test '(2 4 6) (map (cut * 2 <>) '(1 2 3)))
+(test '(b) ((cut cdr <>) '(a b)))
+
+;; zero-slot cut defers evaluation to call time
+(define calls 0)
+(define (probe) (set! calls (+ calls 1)) calls)
+(define th (cut probe))
+(test 0 calls)
+(test 1 (th))
+(test 2 (th))
+
+;;; --- rest-slot <...> ---
+(test '(1 2 3) ((cut list <...>) 1 2 3))
+;; FAIL: #1208 (cut: (cut f <> <...>) shadowed by the (cut f <> b) pattern)
+;; (test '(1 2 3) ((cut list <> <...>) 1 2 3))
+(test '() ((cut list <...>)))
+
+;; <...> after a fixed argument:
+;; FAIL: #1208 (cut: <...> only supported in 3 hardcoded positions)
+;; (test '(1 2 3) ((cut list 1 <...>) 2 3))
+
+;;; --- operator-position slot: (cut <> a b) => (lambda (f) (f a b)) ---
+;; FAIL: #1208 (cut: operator-position slots unsupported)
+;; (test 3 ((cut <> 1 2) +))
+
+;;; --- arity beyond the hardcoded patterns ---
+;; SRFI-26 example: (cut list 1 <> 3 <> 5) => (lambda (x2 x4) (list 1 x2 3 x4 5))
+;; FAIL: #1208 (cut: arity capped by hardcoded pattern set — expand-time error)
+;; (test '(1 2 3 4 5) ((cut list 1 <> 3 <> 5) 2 4))
+
+;;; --- cute: non-slot expressions evaluate once, at construction ---
+;; SRFI-26: "cute evaluates the non-slot expressions at the time the
+;; procedure is constructed"
+(define n 0)
+(define (tick) (set! n (+ n 1)) 10)
+(define f (cute + (tick) <>))
+(test 11 (f 1))
+(test 12 (f 2))
+;; FAIL: #1208 (cute is an alias of cut — re-evaluates per call; n is 2 here)
+;; (test 1 n)
+
+(test-end "srfi-26")

--- a/tests/scheme/srfi/srfi37.scm
+++ b/tests/scheme/srfi/srfi37.scm
@@ -1,0 +1,66 @@
+;; SRFI-37 (args-fold) conformance tests — audit Phase 3b
+;; NOTE: several args-fold defects are tracked in #1211; the enabled tests
+;; below use long options and non-list seeds to stay clear of them.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi37.scm
+
+(import (scheme base) (srfi 37) (chibi test))
+
+(test-begin "srfi-37")
+
+;;; --- option record surface ---
+(define verbose
+  (option '(#\v "verbose") #f #f
+          (lambda (opt name arg n) (+ n 1))))
+(define output
+  (option '(#\o "output") #t #f
+          (lambda (opt name arg n) (if (equal? arg "out") 100 -1))))
+
+(test '(#\v "verbose") (option-names verbose))
+(test #f (option-required-arg? verbose))
+(test #t (option-required-arg? output))
+(test #f (option-optional-arg? output))
+(test #t (procedure? (option-processor verbose)))
+
+;; option? is not exported:
+;; FAIL: #1211 (option? missing from (srfi 37) exports)
+;; (test #t (option? verbose))
+
+;;; --- args-fold with long options and a numeric seed ---
+(define (unrec opt name arg n) -999)
+(define (count-operand op n) (+ n 10))
+(define opts (list verbose output))
+
+(test 1 (args-fold '("--verbose") opts unrec count-operand 0))
+(test 2 (args-fold '("--verbose" "--verbose") opts unrec count-operand 0))
+
+;; required argument via --name=value and via the following token
+(test 100 (args-fold '("--output=out") opts unrec count-operand 0))
+(test 100 (args-fold '("--output" "out") opts unrec count-operand 0))
+
+;; operands
+(test 10 (args-fold '("file") opts unrec count-operand 0))
+(test 21 (args-fold '("a" "b" "--verbose") opts unrec count-operand 0))
+
+;; unrecognized long option hits the fallback
+(test -999 (args-fold '("--nope") opts unrec count-operand 0))
+
+;;; --- spec deviations (see #1211) ---
+;; short options never match their char names (compared as strings):
+;; FAIL: #1211 (short char-name options unmatched)
+;; (test 1 (args-fold '("-v") opts unrec count-operand 0))
+;; the name passed to processors for short options must be the char:
+;; FAIL: #1211 (short option name passed as string, not char)
+;; (test #\v (args-fold '("-v")
+;;                      (list (option '(#\v) #f #f (lambda (o name a s) name)))
+;;                      unrec count-operand 'none))
+;; a processor may return a list as its (single) seed:
+;; FAIL: #1211 (list-valued seeds are splatted into multiple seeds)
+;; (test '(verbose)
+;;       (args-fold '("--verbose")
+;;                  (list (option '(#\v "verbose") #f #f
+;;                                (lambda (o n a acc) (cons 'verbose acc))))
+;;                  (lambda (o n a acc) acc)
+;;                  (lambda (op acc) acc)
+;;                  '()))
+
+(test-end "srfi-37")

--- a/tests/scheme/srfi/srfi38.scm
+++ b/tests/scheme/srfi/srfi38.scm
@@ -1,0 +1,55 @@
+;; SRFI-38 (external representation of shared structure) tests — Phase 3b
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi38.scm
+
+(import (scheme base) (scheme read) (scheme write) (srfi 38) (chibi test))
+
+(test-begin "srfi-38")
+
+(define (wss->string obj)
+  (let ((p (open-output-string)))
+    (write-with-shared-structure obj p)
+    (get-output-string p)))
+
+(define (rt obj)                     ; write/read round trip
+  (read-with-shared-structure (open-input-string (wss->string obj))))
+
+;;; --- plain data is written normally ---
+(test "(1 2 3)" (wss->string '(1 2 3)))
+(test "#(a b)" (wss->string #(a b)))
+(test '(1 (2) "x") (rt '(1 (2) "x")))
+
+;;; --- cyclic list round trip ---
+(let ((c (list 1 2)))
+  (set-cdr! (cdr c) c)
+  (let ((c2 (rt c)))
+    (test 1 (car c2))
+    (test 2 (cadr c2))
+    (test #t (eq? c2 (cddr c2)))))       ; cycle reconstructed
+
+;;; --- shared (acyclic) substructure preserved ---
+(let* ((x (list 'a))
+       (shared (list x x))
+       (s2 (rt shared)))
+  (test '(a) (car s2))
+  (test #t (eq? (car s2) (cadr s2))))
+
+;;; --- self-referential vector ---
+;; write side emits correct labels ("#0=#(1 #0#)") but the reader does not
+;; patch label references inside vectors:
+;; FAIL: #1213 (reader: datum-label references inside vectors unpatched)
+;; (let ((v (vector 1 2)))
+;;   (vector-set! v 1 v)
+;;   (let ((v2 (rt v)))
+;;     (test 1 (vector-ref v2 0))
+;;     (test #t (eq? v2 (vector-ref v2 1)))))
+
+;;; --- labels parse via plain read too (R7RS datum labels) ---
+(let ((c (read (open-input-string "#0=(1 2 . #0#)"))))
+  (test 1 (car c))
+  (test #t (eq? c (cddr c))))
+
+;;; --- default port arguments exist (write to current-output via string port) ---
+(test #t (procedure? write-with-shared-structure))
+(test #t (procedure? read-with-shared-structure))
+
+(test-end "srfi-38")

--- a/tests/scheme/srfi/srfi4.scm
+++ b/tests/scheme/srfi/srfi4.scm
@@ -1,0 +1,72 @@
+;; SRFI-4 (homogeneous numeric vector datatypes) tests — audit Phase 3e
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi4.scm
+
+(import (scheme base) (srfi 4) (chibi test))
+
+(test-begin "srfi-4")
+
+;;; --- u8 ---
+(let ((v (make-u8vector 3 7)))
+  (test #t (u8vector? v))
+  (test 3 (u8vector-length v))
+  (test 7 (u8vector-ref v 0))
+  (u8vector-set! v 1 255)
+  (test 255 (u8vector-ref v 1))
+  (test '(7 255 7) (u8vector->list v)))
+(test #t (u8vector? (u8vector 1 2)))
+(test '(1 2) (u8vector->list (list->u8vector '(1 2))))
+(test #f (u8vector? "not"))
+
+;;; --- s8 signed range ---
+(let ((v (s8vector -128 0 127)))
+  (test #t (s8vector? v))
+  (test -128 (s8vector-ref v 0))
+  (test 127 (s8vector-ref v 2))
+  (s8vector-set! v 1 -1)
+  (test -1 (s8vector-ref v 1)))
+(test '(-5 5) (s8vector->list (list->s8vector '(-5 5))))
+
+;;; --- u16 / s16 ---
+(let ((v (u16vector 0 65535)))
+  (test 65535 (u16vector-ref v 1))
+  (test 2 (u16vector-length v)))
+(let ((v (s16vector -32768 32767)))
+  (test -32768 (s16vector-ref v 0))
+  (test 32767 (s16vector-ref v 1)))
+(test '(1 2) (u16vector->list (list->u16vector '(1 2))))
+
+;;; --- u32 / s32 ---
+(let ((v (u32vector 4294967295)))
+  (test 4294967295 (u32vector-ref v 0)))
+(let ((v (s32vector -2147483648 2147483647)))
+  (test -2147483648 (s32vector-ref v 0))
+  (test 2147483647 (s32vector-ref v 1)))
+(test 4 (u32vector-length (make-u32vector 4 0)))
+
+;;; --- f32 / f64 ---
+(let ((v (f64vector 1.5 -2.5)))
+  (test #t (f64vector? v))
+  (test 1.5 (f64vector-ref v 0))
+  (f64vector-set! v 1 3.25)
+  (test 3.25 (f64vector-ref v 1)))
+(let ((v (f32vector 0.5)))
+  (test #t (f32vector? v))
+  (test 0.5 (f32vector-ref v 0)))
+(test '(1.0 2.0) (f64vector->list (list->f64vector '(1.0 2.0))))
+
+;;; --- type disjointness among the vector kinds ---
+;; FAIL: #1225 (integer vector kinds are indistinguishable bytevector aliases)
+;; (test #f (s8vector? (u8vector 1)))
+;; FAIL: #1225 (integer vector kinds are indistinguishable bytevector aliases)
+;; (test #f (u16vector? (u8vector 1)))
+(test #f (f64vector? (u32vector 1)))
+(test #f (u8vector? (vector 1)))
+
+;;; --- out-of-range / bad-index errors are catchable ---
+(test #t (guard (e (#t #t)) (u8vector-set! (u8vector 1) 0 256) #f))
+(test #t (guard (e (#t #t)) (u8vector-set! (u8vector 1) 0 -1) #f))
+(test #t (guard (e (#t #t)) (u8vector-ref (u8vector 1) 5) #f))
+;; FAIL: #1225 (signed setters accept out-of-range values; 128 wraps to -128)
+;; (test #t (guard (e (#t #t)) (s8vector-set! (s8vector 1) 0 128) #f))
+
+(test-end "srfi-4")

--- a/tests/scheme/srfi/srfi41.scm
+++ b/tests/scheme/srfi/srfi41.scm
@@ -1,0 +1,80 @@
+;; SRFI-41 (streams) conformance tests — audit Phase 3c
+;; 15 derived-library exports are missing (#1210); tests cover what exists.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi41.scm
+
+(import (scheme base) (srfi 41) (chibi test))
+
+(test-begin "srfi-41")
+
+;;; --- primitives ---
+(test #t (stream-null? stream-null))
+(test #t (stream? stream-null))
+(test #f (stream-pair? stream-null))
+
+(define s12 (stream-cons 1 (stream-cons 2 stream-null)))
+(test #t (stream-pair? s12))
+(test #t (stream? s12))
+(test #f (stream-null? s12))
+(test 1 (stream-car s12))
+(test 2 (stream-car (stream-cdr s12)))
+(test #t (stream-null? (stream-cdr (stream-cdr s12))))
+
+;; stream-cons delays its element and tail
+(define evaluated #f)
+(define lazy-s (stream-cons (begin (set! evaluated #t) 'v) stream-null))
+(test #f evaluated)
+(test 'v (stream-car lazy-s))
+(test #t evaluated)
+
+;;; --- construction helpers ---
+(test '(1 2 3) (stream->list (stream 1 2 3)))
+(test '(1 2 3) (stream->list (list->stream '(1 2 3))))
+(test '() (stream->list (stream)))
+
+;;; --- infinite streams stay lazy ---
+(define (ints n) (stream-cons n (ints (+ n 1))))
+(define nat (ints 0))
+(test '(0 1 2 3 4) (stream->list (stream-take 5 nat)))
+(test 7 (stream-ref nat 7))
+(test '(0 2 4) (stream->list (stream-take 3 (stream-filter even? nat))))
+(test '(0 10 20) (stream->list (stream-take 3 (stream-map (lambda (x) (* 10 x)) nat))))
+(test '(5 6) (stream->list (stream-take 2 (stream-drop 5 nat))))
+
+;;; --- finite stream operations ---
+(test 3 (stream-length (stream 1 2 3)))
+(test 6 (stream-fold + 0 (stream 1 2 3)))
+;; FAIL: #1215 (stream-append drops everything after the first stream)
+;; (test '(1 2 3 4) (stream->list (stream-append (stream 1 2) (stream 3 4))))
+;; FAIL: #1215 (stream-zip errors instead of stopping at the shortest stream)
+;; (test '((1 a) (2 b)) (stream->list (stream-zip (stream 1 2) (stream 'a 'b 'c))))
+(test '(a b c)
+      (let ((acc '()))
+        (stream-for-each (lambda (x) (set! acc (cons x acc))) (stream 'a 'b 'c))
+        (reverse acc)))
+
+;; stream-unfold: (stream-unfold map pred? gen base)
+;; FAIL: #1215 (stream-unfold predicate sense inverted)
+;; (test '(0 1 4 9)
+;;       (stream->list (stream-unfold
+;;                      (lambda (x) (* x x))
+;;                      (lambda (x) (< x 4))
+;;                      (lambda (x) (+ x 1))
+;;                      0)))
+
+;; stream-lambda
+(define double-all
+  (stream-lambda (s)
+    (if (stream-null? s)
+        stream-null
+        (stream-cons (* 2 (stream-car s)) (double-all (stream-cdr s))))))
+(test '(2 4 6) (stream->list (double-all (stream 1 2 3))))
+
+;;; --- missing derived exports (#1210) ---
+;; FAIL: #1210 (define-stream, stream-range, stream-from, stream-let,
+;;              stream-match, stream-of, stream-iterate, stream-scan,
+;;              stream-reverse, stream-concat, ... not exported)
+;; (test '(0 1 2) (stream->list (stream-range 0 3)))
+;; (test '(3 2 1) (stream->list (stream-reverse (stream 1 2 3))))
+;; (test '(1 2 4) (stream->list (stream-take 3 (stream-iterate (lambda (x) (* 2 x)) 1))))
+
+(test-end "srfi-41")

--- a/tests/scheme/srfi/srfi42.scm
+++ b/tests/scheme/srfi/srfi42.scm
@@ -1,0 +1,64 @@
+;; SRFI-42 (eager comprehensions) conformance tests — audit Phase 3c
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi42.scm
+
+(import (scheme base) (srfi 42) (chibi test))
+
+(test-begin "srfi-42")
+
+;;; --- list-ec with the core generators ---
+(test '(0 1 2 3) (list-ec (:range i 4) i))
+(test '(2 3 4) (list-ec (:range i 2 5) i))
+(test '(0 2 4) (list-ec (:range i 0 6 2) i))
+(test '(a b) (list-ec (:list x '(a b)) x))
+;; FAIL: #1216 (:string unusable in list-ec)
+;; (test '(#\a #\b) (list-ec (:string c "ab") c))
+;; FAIL: #1216 (:vector unusable in list-ec)
+;; (test '(1 2) (list-ec (:vector x #(1 2)) x))
+
+;;; --- accumulators ---
+(test 6 (sum-ec (:range i 4) i))
+(test 24 (product-ec (:list x '(2 3 4)) x))
+(test 0 (min-ec (:range i 4) i))
+(test 3 (max-ec (:range i 4) i))
+(test 0 (first-ec 'none (:range i 4) i))
+(test 3 (last-ec 'none (:range i 4) i))
+(test 'none (first-ec 'none (:range i 0) i))
+(test #t (any?-ec (:range i 4) (even? i)))
+(test #f (every?-ec (:range i 4) (even? i)))
+(test #t (every?-ec (:list x '(2 4)) (even? x)))
+(test "ab" (string-ec (:list c '(#\a #\b)) c))
+(test #(0 1) (vector-ec (:range i 2) i))
+(test '(1 2 3 4) (append-ec (:list xs '((1 2) (3 4))) xs))
+
+;;; --- do-ec for effects ---
+(test '(0 1 2)
+      (let ((acc '()))
+        (do-ec (:range i 3) (set! acc (cons i acc)))
+        (reverse acc)))
+
+;;; --- fold-ec ---
+;; FAIL: #1216 (fold-ec signature lacks the expression slot; spec form rejected)
+;; (test 6 (fold-ec 0 (:range i 4) i +))
+
+;;; --- nested generators (cartesian product, later loops fastest) ---
+;; FAIL: #1216 (no multi-qualifier nesting)
+;; (test '((1 . 3) (1 . 4) (2 . 3) (2 . 4))
+;;       (list-ec (:list a '(1 2)) (:list b '(3 4)) (cons a b)))
+
+;;; --- guards ---
+;; FAIL: #1216 (no (if ...) guards)
+;; (test '(0 2 4) (list-ec (:range i 6) (if (even? i)) i))
+
+;;; --- :let and :while / :until ---
+;; FAIL: #1216 (:let unusable in list-ec)
+;; (test '(10) (list-ec (:let x 10) x))
+;; FAIL: #1216 (:while unusable in list-ec)
+;; (test '(0 1 2) (list-ec (:range i 100) (:while (< i 3)) i))
+;; FAIL: #1216 (:until unusable in list-ec)
+;; (test '(0 1 2 3) (list-ec (:range i 100) (:until (= i 3)) i))
+
+;;; --- :integers with :while (infinite generator must stay bounded) ---
+;; FAIL: #1216 (:integers+:while unsupported)
+;; (test '(0 1 2) (list-ec (:integers i) (:while (< i 3)) i))
+
+(test-end "srfi-42")

--- a/tests/scheme/srfi/srfi43.scm
+++ b/tests/scheme/srfi/srfi43.scm
@@ -1,0 +1,59 @@
+;; SRFI-43 (vector library) conformance tests — audit Phase 3b
+;; NOTE: Kaappi's (srfi 43) currently re-exports SRFI-133-style procedures;
+;; the index-passing callback convention and 8 exports are missing (#1209).
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi43.scm
+
+(import (scheme base) (srfi 43) (chibi test))
+
+(test-begin "srfi-43")
+
+;;; --- procedures whose semantics agree between SRFI-43 and SRFI-133 ---
+(test #t (vector-empty? #()))
+(test #f (vector-empty? #(1)))
+(test #(1 2 3 4) (vector-append #(1 2) #(3 4)))
+(test #(1 2 3 4) (vector-concatenate (list #(1 2) #(3 4))))
+(test #(9 2 1) (let ((v (vector 1 2 9))) (vector-swap! v 0 2) v))
+(test '(1 2 3) (vector->list #(1 2 3)))
+(test #(1 2 3) (list->vector '(1 2 3)))
+(test #(0 0) (make-vector 2 0))
+(test #(7 7 7) (let ((v (vector 1 2 3))) (vector-fill! v 7) v))
+(test #(1 2) (vector-copy #(1 2)))
+(test #(5 6 3) (let ((v (vector 1 2 3))) (vector-copy! v 0 #(5 6)) v))
+
+;; searching (SRFI-43 predicates receive elements, no index)
+(test 1 (vector-index even? #(1 2 3)))
+(test #f (vector-index even? #(1 3 5)))
+(test 2 (vector-index-right even? #(2 1 4 5)))
+(test 1 (vector-skip odd? #(1 2 3)))
+(test #t (vector-any even? #(1 2 3)))
+(test #f (vector-any even? #(1 3 5)))
+(test #t (vector-every odd? #(1 3 5)))
+(test #f (vector-every odd? #(1 2 5)))
+
+;; vector-map! mutates in place (element-only callback agrees when arity 1
+;; is used with a single vector under SRFI-133 style; SRFI-43 passes the
+;; index — covered by the disabled tests below)
+(test #(2 4 6) (let ((v (vector 1 2 3))) (vector-map! (lambda (x) (* 2 x)) v) v))
+
+;;; --- SRFI-43 index-passing callback convention (spec-quoted in #1209) ---
+;; FAIL: #1209 (SRFI-43 procedures use SRFI-133 semantics — no index arg)
+;; (test #(10 11 12) (vector-map (lambda (i x) (+ i x)) #(10 10 10)))
+;; FAIL: #1209 (SRFI-43 procedures use SRFI-133 semantics — no index arg)
+;; (test '(c b a) (vector-fold (lambda (i state x) (cons x state)) '() #(a b c)))
+;; FAIL: #1209 (SRFI-43 procedures use SRFI-133 semantics — no index arg)
+;; (test '((0 . a) (1 . b))
+;;       (let ((acc '()))
+;;         (vector-for-each (lambda (i x) (set! acc (cons (cons i x) acc))) #(a b))
+;;         (reverse acc)))
+;; FAIL: #1209 (SRFI-43 procedures use SRFI-133 semantics — no index arg)
+;; (test 2 (vector-count (lambda (i x) (even? x)) #(1 2 4)))
+
+;;; --- missing SRFI-43 exports ---
+;; FAIL: #1209 (vector-unfold, vector=, vector-binary-search, vector-reverse!,
+;;              vector-reverse-copy!, reverse-vector->list, reverse-list->vector
+;;              are not exported)
+;; (test #(0 1 2) (vector-unfold (lambda (i) (values i)) 3))
+;; (test #t (vector= eqv? #(1 2) #(1 2)))
+;; (test '(3 2 1) (reverse-vector->list #(1 2 3)))
+
+(test-end "srfi-43")

--- a/tests/scheme/srfi/srfi45.scm
+++ b/tests/scheme/srfi/srfi45.scm
@@ -1,0 +1,40 @@
+;; SRFI-45 (primitives for lazy evaluation) conformance tests — Phase 3c
+;; The library currently exports only the R7RS names; lazy and eager are
+;; missing (#1207). Iterative-forcing behavior itself is covered in depth
+;; by tests/scheme/audit/primitives_lazy-audit.scm.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi45.scm
+
+(import (scheme base) (srfi 45) (chibi test))
+
+(test-begin "srfi-45")
+
+;;; --- the R7RS-name surface works ---
+(test 3 (force (delay (+ 1 2))))
+(test #t (promise? (delay 1)))
+(test #t (promise? (make-promise 1)))
+(test 42 (force (delay-force (delay 42))))
+
+;; memoization
+(let ()
+  (define count 0)
+  (define p (delay (begin (set! count (+ count 1)) count)))
+  (test 1 (force p))
+  (test 1 (force p)))
+
+;; bounded-space iterative forcing through delay-force chains
+(letrec ((chain (lambda (n)
+                  (if (= n 0) (delay 'done) (delay-force (chain (- n 1)))))))
+  (test 'done (force (chain 10000))))
+
+;;; --- SRFI-45's own names ---
+;; "lazy: Takes an expression of type (Promise a) and returns a promise";
+;; "eager: ... (eager expression) is equivalent to (let ((value expression))
+;;  (delay value))"
+;; FAIL: #1207 (lazy and eager are not exported from (srfi 45))
+;; (test 1 (force (lazy (delay 1))))
+;; FAIL: #1207 (lazy and eager are not exported from (srfi 45))
+;; (test 2 (force (eager 2)))
+;; FAIL: #1207 (lazy and eager are not exported from (srfi 45))
+;; (test #t (promise? (eager 5)))
+
+(test-end "srfi-45")

--- a/tests/scheme/srfi/srfi6.scm
+++ b/tests/scheme/srfi/srfi6.scm
@@ -1,0 +1,55 @@
+;; SRFI-6 (basic string ports) conformance tests — audit Phase 3a
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi6.scm
+
+(import (scheme base) (scheme read) (scheme write) (srfi 6) (chibi test))
+
+(test-begin "srfi-6")
+
+;;; --- open-input-string ---
+(define ip (open-input-string "(a b) 42 \"str\" #\\x"))
+(test '(a b) (read ip))
+(test 42 (read ip))
+(test "str" (read ip))
+(test #\x (read ip))
+(test #t (eof-object? (read ip)))
+(test #t (eof-object? (read ip)))          ; stays at EOF
+
+;; char-level reads
+(define ip2 (open-input-string "xy"))
+(test #\x (peek-char ip2))
+(test #\x (read-char ip2))
+(test #\y (read-char ip2))
+(test #t (eof-object? (read-char ip2)))
+
+;; empty source
+(test #t (eof-object? (read (open-input-string ""))))
+
+;;; --- open-output-string / get-output-string ---
+(define op (open-output-string))
+(test "" (get-output-string op))
+(write 'hello op)
+(display " " op)
+(write "wo" op)
+(test "hello \"wo\"" (get-output-string op))
+
+;; the port keeps accumulating after get-output-string
+(display "+" op)
+(test "hello \"wo\"+" (get-output-string op))
+
+;; each get-output-string result is independent of later writes
+(define op2 (open-output-string))
+(display "ab" op2)
+(define snap (get-output-string op2))
+(display "cd" op2)
+(test "ab" snap)
+(test "abcd" (get-output-string op2))
+
+;; SRFI-6 example shape: reverse a datum through string ports
+(define (rev-datum s)
+  (let ((in (open-input-string s))
+        (out (open-output-string)))
+    (write (reverse (read in)) out)
+    (get-output-string out)))
+(test "(c b a)" (rev-datum "(a b c)"))
+
+(test-end "srfi-6")

--- a/tests/scheme/srfi/srfi60.scm
+++ b/tests/scheme/srfi/srfi60.scm
@@ -1,0 +1,56 @@
+;; SRFI-60 (integers as bits) conformance tests — audit Phase 3d
+;; Negative-operand results are broken by the shared SRFI-151 helpers
+;; (#1214); missing bitwise-* aliases are #1164.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi60.scm
+
+(import (scheme base) (srfi 60) (chibi test))
+
+(test-begin "srfi-60")
+
+;;; --- positive-operand bitwise ops ---
+(test 10 (logand 11 26))
+(test 11 (logior 3 10))
+(test 6 (logxor 3 5))
+(test -11 (lognot 10))
+(test 9 (lognot -10))
+
+;;; --- logtest / logbit? ---
+(test #t (logtest 3 6))
+(test #f (logtest 1 4))
+(test #f (logbit? 0 2))
+(test #t (logbit? 1 2))
+(test #t (logbit? 2 4))
+
+;;; --- shifts ---
+(test 16 (ash 1 4))
+(test 2 (ash 8 -2))
+(test -16 (ash -1 4))
+
+;;; --- counting ---
+(test 3 (logcount 13))
+(test 0 (logcount 0))
+(test 4 (integer-length 8))
+(test 0 (integer-length 0))
+(test 3 (integer-length -8))
+
+;;; --- bit-field ---
+(test 2 (bit-field 13 1 3))
+(test 0 (bit-field 6 0 1))
+
+;;; --- negative-operand semantics (two's complement, SRFI-60 example set) ---
+;; FAIL: #1214 (bitwise and/ior/xor ignore two's-complement sign)
+;; (test 8 (logand -4 8))
+;; (test 5 (logand -1 5))
+;; (test -8 (logand -4 -6))
+;; (test -2 (logior -4 2))
+;; (test -6 (logxor -1 5))
+;; (test 9 (bitwise-merge 3 1 8))
+;; FAIL: #1214 (arithmetic right shift truncates instead of flooring)
+;; (test -4 (ash -15 -2))
+
+;;; --- bitwise-* canonical names (SRFI-60 dual naming) ---
+;; FAIL: #1164 (bitwise-and/-ior/-xor/-not aliases not exported from (srfi 60))
+;; (test 10 (bitwise-and 11 26))
+;; (test 11 (bitwise-ior 3 10))
+
+(test-end "srfi-60")

--- a/tests/scheme/srfi/srfi61.scm
+++ b/tests/scheme/srfi/srfi61.scm
@@ -1,0 +1,25 @@
+;; SRFI-61 (a more general cond clause) conformance tests — audit Phase 3d
+;; The library is currently an empty stub (#1206); base cond still works.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi61.scm
+
+(import (scheme base) (srfi 61) (chibi test))
+
+(test-begin "srfi-61")
+
+;; importing (srfi 61) must not break ordinary cond
+(test 'a (cond (#t 'a) (else 'b)))
+(test 'b (cond (#f 'a) (else 'b)))
+(test 2 (cond ((assv 1 '((1 . 2))) => cdr) (else 'no)))
+
+;;; --- the SRFI-61 (generator guard => receiver) clause ---
+;; "⟨generator⟩ is evaluated. It may return arbitrarily many values. ⟨Guard⟩
+;;  is applied to [those values] ... If ⟨guard⟩ returns a true value ...
+;;  ⟨receiver⟩ is applied with an equivalent argument list."
+;; FAIL: #1206 (SRFI-61 general cond clause not implemented; library is empty)
+;; (test 3 (cond ((values 1 2) (lambda (a b) #t) => (lambda (a b) (+ a b)))
+;;               (else 'no)))
+;; FAIL: #1206 (SRFI-61 general cond clause not implemented; library is empty)
+;; (test 'skipped (cond ((values 1 2) (lambda (a b) #f) => (lambda (a b) 'used))
+;;                      (else 'skipped)))
+
+(test-end "srfi-61")

--- a/tests/scheme/srfi/srfi78.scm
+++ b/tests/scheme/srfi/srfi78.scm
@@ -1,0 +1,40 @@
+;; SRFI-78 (lightweight testing) conformance tests — audit Phase 3d
+;; check-passed? has the wrong signature and check-ec/check-set-mode! are
+;; missing (#1220). Kaappi's count accessors are used below as extensions.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi78.scm
+
+(import (scheme base) (srfi 78) (chibi test))
+
+(test-begin "srfi-78")
+
+;; passing checks accumulate (Kaappi extension: zero-arg count accessors)
+(check-reset!)
+(check (+ 1 1) => 2)
+(check (list 1 2) => (list 1 2))
+(test 2 (check-passed?))
+(test 0 (check-failed?))
+
+;; a failing check counts as failed, does not raise
+(check (+ 1 1) => 3)
+(test 2 (check-passed?))
+(test 1 (check-failed?))
+
+;; check-reset! zeroes both counters
+(check-reset!)
+(test 0 (check-passed?))
+(test 0 (check-failed?))
+
+;; check-report exists and does not raise
+(check (* 2 2) => 4)
+(check-report)
+(test 1 (check-passed?))
+
+;;; --- SRFI-78 API shape ---
+;; "(check-passed? expected-total-count) ... #t if there were no failed
+;;  checks and expected-total-count correct checks, #f otherwise"
+;; FAIL: #1220 (check-passed? takes no arguments and returns a count)
+;; (test #t (begin (check-reset!) (check 1 => 1) (check-passed? 1)))
+;; FAIL: #1220 (check-set-mode! and check-ec are not exported)
+;; (test 'ok (begin (check-set-mode! 'off) 'ok))
+
+(test-end "srfi-78")

--- a/tests/scheme/srfi/srfi87.scm
+++ b/tests/scheme/srfi/srfi87.scm
@@ -1,0 +1,36 @@
+;; SRFI-87 (=> in case clauses) conformance tests — audit Phase 3d
+;; The feature is provided by the built-in R7RS case form; (srfi 87) is a
+;; marker library.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi87.scm
+
+(import (scheme base) (srfi 87) (chibi test))
+
+(test-begin "srfi-87")
+
+;; => in a matching clause receives the key
+(test 20 (case 2 ((1 2 3) => (lambda (x) (* x 10))) (else 0)))
+(test 'two (case 2
+             ((1) => (lambda (x) 'one))
+             ((2) => (lambda (x) 'two))
+             (else 'other)))
+
+;; => in the else clause receives the key
+(test 9 (case 9 ((1 2) => (lambda (x) 'small)) (else => (lambda (x) x))))
+(test 'composite (case 6
+                   ((2 3 5 7) 'prime)
+                   (else => (lambda (x) 'composite))))
+
+;; mixing plain and => clauses
+(test 'plain (case 1 ((1) 'plain) ((2) => (lambda (x) 'arrow)) (else 'no)))
+(test 4 (case 2 ((1) 'plain) ((2) => (lambda (x) (* x x))) (else 'no)))
+
+;; the receiver is evaluated only when its clause matches
+(define hits 0)
+(define (bump! tag) (lambda (x) (set! hits (+ hits 1)) tag))
+(test 'b (case 'b
+           ((a) => (bump! 'a))
+           ((b) => (bump! 'b))
+           (else => (bump! 'e))))
+(test 1 hits)
+
+(test-end "srfi-87")


### PR DESCRIPTION
## Summary

Phases 3a–3e of the audit campaign (tracking: see #1137): conformance test files for 28 portable SRFIs, batched in five units:

| Unit | SRFIs | Files |
|------|-------|-------|
| 3a | 0, 6, 17, 23, 26 | `srfi0.scm`, `srfi6.scm`, `srfi17.scm`, `srfi23.scm`, `srfi26.scm` |
| 3b | 37, 38, 43, 116, 117, 134 | `srfi37.scm`, `srfi38.scm`, `srfi43.scm`, `srfi116.scm`, `srfi117.scm`, `srfi134.scm` |
| 3c | 41, 42, 45, 143, 144 | `srfi41.scm`, `srfi42.scm`, `srfi45.scm`, `srfi143.scm`, `srfi144.scm` |
| 3d | 60, 61, 78, 87, 197, 210, 227 | `srfi60.scm`, `srfi61.scm`, `srfi78.scm`, `srfi87.scm`, `srfi197.scm`, `srfi210.scm`, `srfi227.scm` |
| 3e | 4, 127, 130, 233, 235 | `srfi4.scm`, `srfi127.scm`, `srfi130.scm`, `srfi233.scm`, `srfi235.scm` |

**549 passing assertions**; ~63 assertions disabled with `;; FAIL: #NNNN` markers pointing at the 22 issues filed during this phase (see #1205–#1226) plus the earlier reader datum-label issue (see #1164).

## Notable findings

- **Bitwise magnitude semantics** — SRFI-151 helpers (shared by SRFI 60/143) compute bitwise ops on magnitudes, wrong for all negative operands (see #1214, see #1226)
- **SRFI-4 integer vector kinds are bytevector aliases** — `s8vector?`/`u16vector?` etc. are all `bytevector?`; no type disjointness, no range checks on signed setters (see #1225)
- **SRFI-210 `value` returns its first argument** regardless of index, and `set!-values` is a self-assignment no-op (see #1218, see #1224)
- **SRFI-233 parser fails on any non-empty input** — internal string-trim calls `char-whitespace?` without importing `(scheme char)` (see #1223)
- **SRFI-37 short options never match and list seeds get splatted** (see #1211); tests use long options + numeric seeds
- **SRFI-38 vector cycles** are a reader-level datum-label bug (see #1164, see #1213)
- **SRFI-134 `ideque-filter` calls unbound `filter`** (see #1212)

## Test results

- All 28 files: exit 0, printed pass counts match expected, no escaped errors
- Full suite: **359 Scheme files pass, 0 fail; R7RS suite 1395 pass, 0 fail**

Tracker `docs/audit-strategy.md` updated: 3a–3e boxes checked with issue lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)