### PR TITLE
Phase 5 synthesis: harden run-all.sh, check final tracker box

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -150,12 +150,12 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 - [x] 3.4: Upgrade smoke-only SRFIs to behavioral tests (98, 125, 128, 132, 141, 151, 152, 174, 175, 195, 219, 232) (2026-07-05, #1229–#1238; 402 tests + ~60 disabled — SRFI-219 dead on arrival (imported define macro can't shadow the built-in special form, #1237 is a core expander bug), SRFI-232 currying is strictly unary chains, balanced/ aliased to round/, default comparator not a total order (pairs/vectors/cross-type unordered) + eq/eqv comparators unhashable, hash-table-ref/find ignore success/proc-result (125), string-every drops last value (152), ascii-digit-value treats letters as digits (175), copy-bit rejects spec booleans + eqv/bits->list arity (151, beyond #1214), 14 of 22 SRFI-132 exports missing, timespec conversions missing (174); SRFI-98 and 195 fully conform)
 
 **Phase 4 — Compiler & VM edge cases**
-- [ ] 4A: Tail positions in derived forms + thin-coverage forms
-- [ ] 4B: Continuation interactions (dynamic-wind, guard, parameterize, values)
-- [ ] 4C: Macro hygiene + define-library import sets
+- [x] 4A: Tail positions in derived forms + thin-coverage forms (2026-07-05, #1240–#1242; 54 tests + 6 disabled — call-with-values consumer, call/cc receiver, and eval are NOT tail-called (§3.5 requires; native re-entry panics at ~1024 via #1191's mechanism), let*-values body is not a tail context (even 1 clause; let-values is fine), force caps promise chains at 100k iterations and mislabels longer legit delay-force chains as circular; apply/cond=>/case-lambda/do/let-syntax and all other §3.5 contexts verified at 1e5–1e6 depth; parameterize/define-values/letrec*/letrec-syntax thin coverage conforms except sequential-binding #1202)
+- [x] 4B: Continuation interactions (2026-07-05, no new issues; 22 tests + 1 disabled (#1169) — R7RS 6.10 connect/talk/disconnect re-entry example exact, multi-shot segments, parameterize captured+restored across re-entry, escape/afters inner-to-outer, guard =>/else/re-raise, raise-continuable resume, handler-return secondary exception, mv through dynamic-wind all conform; state kept global to dodge #1168)
+- [x] 4C: Macro hygiene + define-library import sets (2026-07-05, #1243; 23 tests + 1 disabled — doubled-ellipsis template (x ... ...) produces garbage with a literal ... instead of flattening; be-like-begin/(... ...) escape, custom ellipsis, vector patterns, tail patterns after ellipsis, =>-shadowing (p.24 example!), macro exports through prefix/only/rename/except and only-of-rename, cond-expand library declarations all conform; circular imports cleanly detected with nonzero exit)
 
 **Phase 5 — Synthesis**
-- [ ] 5: Deduplicate, group by root cause, prioritize, update tracking issue
+- [x] 5: Deduplicate, group by root cause, prioritize, update tracking issue (2026-07-05 — 87 findings filed over the campaign, 81 still open, 6 already fixed (#1176 #1178 #1180 #1184 #1185 #1188 — their FAIL markers still need re-enabling); no duplicates found (dedup enforced at filing time); grouped into 9 root-cause clusters with 2 epics filed (native re-entrancy, portable-SRFI quality); priority order + 197-marker inventory posted on #1137; run-all.sh hardened to parse chibi-test/SRFI-64 fail counts so exit-0 failures no longer pass silently)
 
 ---
 

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -40,8 +40,18 @@ run_file() {
         return
     fi
     if [[ $status -eq 0 ]]; then
-        echo "  PASS  $file"
-        PASS=$((PASS + 1))
+        # chibi-test files exit 0 even when assertions fail (the shim's
+        # "N pass, M fail" summary is the only signal), and SRFI-64 files
+        # rely on their own exit-on-fail epilogue. Trust the printed
+        # counts, not just the exit code.
+        if grep -Eq '(^|[^0-9])[1-9][0-9]* fail|unexpected (failures|errors) +[1-9]' "$TMPOUT"; then
+            echo "  FAIL  $file  (failing assertions reported despite exit 0)"
+            cat "$TMPOUT"
+            FAIL=$((FAIL + 1))
+        else
+            echo "  PASS  $file"
+            PASS=$((PASS + 1))
+        fi
     else
         echo "  FAIL  $file"
         cat "$TMPOUT"


### PR DESCRIPTION
## Summary

Final phase of the audit campaign (tracking: see #1137). The synthesis itself is posted on the tracking issue — this PR carries the two repo changes:

**1. run-all.sh hardening** (the doc's recommended Phase 5 step): each passing file's output is now scanned for chibi-test `N fail` counts and SRFI-64 `unexpected failures` — the chibi shim exits 0 even when assertions fail (see #1196), so failing files previously sailed through on exit code alone. Verified both directions: a deliberately failing chibi file is now caught; `srfi64.scm`'s intentional `test-expect-fail` still passes.

**2. Tracker**: Phase 5 box checked — all 35 campaign boxes are now done.

## Synthesis (posted on the tracking issue)

- **87 findings** across the campaign; 81 open, 6 already fixed (their disabled tests still need re-enabling — files listed on #1137)
- **9 root-cause clusters**, priority-ordered; **2 epics filed**: see #1245 (native VM re-entrancy — the only uncatchable crashes reachable from pure R7RS code) and see #1246 (portable SRFI library quality — 27 issues, ~120 disabled assertions)
- **197 `;; FAIL:` markers** in tests/ — each a pre-written regression test its fix re-enables

## Test results

Full suite with the hardened script: **373 Scheme files pass, 0 fail; R7RS 1395 pass, 0 fail** (2 of 3 runs; one run showed 2 unreproducible failures — a pre-existing flake, most likely SRFI-18 timing, observed identically-treed against both green runs; the hardened script's future runs will name such files since FAIL output is printed inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)