### PR TITLE
Deliver multiple values when continuation invoked with != 1 arg

### DIFF
--- a/src/tests_continuations.zig
+++ b/src/tests_continuations.zig
@@ -160,6 +160,56 @@ test "values with zero values" {
     try std.testing.expectEqual(@as(i64, 99), types.toFixnum(result));
 }
 
+// Regression: #1169 — invoking a continuation with multiple arguments
+// must deliver all values, not just the first.
+test "call/cc multi-arg invocation in call-with-values" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(call-with-values
+        \\  (lambda () (call/cc (lambda (k) (k 1 2))))
+        \\  list)
+    );
+    try std.testing.expect(types.isPair(result));
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(types.car(result)));
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(types.car(types.cdr(result))));
+    try std.testing.expectEqual(types.NIL, types.cdr(types.cdr(result)));
+}
+
+test "call/cc zero-arg invocation in call-with-values" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(call-with-values
+        \\  (lambda () (call/cc (lambda (k) (k))))
+        \\  (lambda () 99))
+    );
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(result));
+}
+
+test "call/ec multi-arg invocation in call-with-values" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(call-with-values
+        \\  (lambda () (call/ec (lambda (k) (k 10 20 30))))
+        \\  list)
+    );
+    try std.testing.expect(types.isPair(result));
+    try std.testing.expectEqual(@as(i64, 10), types.toFixnum(types.car(result)));
+    try std.testing.expectEqual(@as(i64, 20), types.toFixnum(types.car(types.cdr(result))));
+    try std.testing.expectEqual(@as(i64, 30), types.toFixnum(types.car(types.cdr(types.cdr(result)))));
+}
+
 test "dynamic-wind with escape continuation" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/tests_continuations.zig
+++ b/src/tests_continuations.zig
@@ -210,6 +210,53 @@ test "call/ec multi-arg invocation in call-with-values" {
     try std.testing.expectEqual(@as(i64, 30), types.toFixnum(types.car(types.cdr(types.cdr(result)))));
 }
 
+test "apply continuation with multiple values (callWithArgs path)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(call-with-values
+        \\  (lambda () (call/cc (lambda (k) (car (list (apply k (list 1 2)))))))
+        \\  list)
+    );
+    try std.testing.expect(types.isPair(result));
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(types.car(result)));
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(types.car(types.cdr(result))));
+}
+
+test "apply continuation with zero values (callWithArgs path)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(call-with-values
+        \\  (lambda () (call/cc (lambda (k) (car (list (apply k '()))))))
+        \\  (lambda () 99))
+    );
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(result));
+}
+
+test "first-class call-with-values continuation (callWithArgs path)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(define cwv call-with-values)
+        \\(call-with-values
+        \\  (lambda () (call/cc (lambda (k0) (cwv (lambda () (values 1 2)) k0))))
+        \\  list)
+    );
+    try std.testing.expect(types.isPair(result));
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(types.car(result)));
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(types.car(types.cdr(result))));
+}
+
 test "dynamic-wind with escape continuation" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -11,6 +11,13 @@ const memory = @import("memory.zig");
 const vm_continuations = @import("vm_continuations.zig");
 const fiber_mod = @import("fiber.zig");
 
+/// Package continuation arguments the same way `values` does:
+/// 1 arg → that arg directly, 0 or 2+ → MultipleValues.
+pub fn continuationArgValue(gc: *memory.GC, args: []const Value) VMError!Value {
+    if (args.len == 1) return args[0];
+    return gc.allocMultipleValues(args) catch return VMError.OutOfMemory;
+}
+
 pub fn clockNs() u64 {
     var ts: std.c.timespec = undefined;
     _ = std.c.clock_gettime(.MONOTONIC, &ts);
@@ -330,14 +337,7 @@ pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
     }
     if (types.isContinuation(callee)) {
         const cont = types.toObject(callee).as(types.Continuation);
-        // Mirror `values` semantics: 1 arg → that arg directly,
-        // 0 or 2+ args → MultipleValues (so call-with-values consumers
-        // receive the correct argument count).
-        const value = if (nargs == 1)
-            vm.registers[base + 1]
-        else
-            vm.gc.allocMultipleValues(vm.registers[base + 1 .. base + 1 + @as(usize, nargs)]) catch
-                return VMError.OutOfMemory;
+        const value = try continuationArgValue(vm.gc, vm.registers[base + 1 .. base + 1 + @as(usize, nargs)]);
 
         if (cont.is_escape) {
             // Escape continuation: unwind the live stack, no snapshot restore.
@@ -653,7 +653,7 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
     }
     if (types.isContinuation(proc)) {
         const cont = types.toObject(proc).as(types.Continuation);
-        const value = if (args.len == 0) types.VOID else args[0];
+        const value = try continuationArgValue(vm.gc, args);
         if (cont.is_escape) {
             try vm_continuations.invokeEscape(vm, cont, value);
             return VMError.ContinuationInvoked;

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -330,8 +330,14 @@ pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
     }
     if (types.isContinuation(callee)) {
         const cont = types.toObject(callee).as(types.Continuation);
-        // Get the value to pass (0 args => void, 1 arg => that arg)
-        const value = if (nargs == 0) types.VOID else vm.registers[base + 1];
+        // Mirror `values` semantics: 1 arg → that arg directly,
+        // 0 or 2+ args → MultipleValues (so call-with-values consumers
+        // receive the correct argument count).
+        const value = if (nargs == 1)
+            vm.registers[base + 1]
+        else
+            vm.gc.allocMultipleValues(vm.registers[base + 1 .. base + 1 + @as(usize, nargs)]) catch
+                return VMError.OutOfMemory;
 
         if (cont.is_escape) {
             // Escape continuation: unwind the live stack, no snapshot restore.

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -514,11 +514,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isContinuation(callee)) {
                     const cont = types.toObject(callee).as(types.Continuation);
-                    const value = if (nargs == 1)
-                        self.registers[abs_base + 1]
-                    else
-                        self.gc.allocMultipleValues(self.registers[abs_base + 1 .. abs_base + 1 + @as(usize, nargs)]) catch
-                            return VMError.OutOfMemory;
+                    const value = try vm_calls.continuationArgValue(self.gc, self.registers[abs_base + 1 .. abs_base + 1 + @as(usize, nargs)]);
                     if (cont.is_escape) {
                         try self.invokeEscape(cont, value);
                     } else {
@@ -666,11 +662,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isContinuation(proc)) {
                     const cont = types.toObject(proc).as(types.Continuation);
-                    const value = if (count == 1)
-                        flat_args[0]
-                    else
-                        self.gc.allocMultipleValues(flat_args[0..count]) catch
-                            return VMError.OutOfMemory;
+                    const value = try vm_calls.continuationArgValue(self.gc, flat_args[0..count]);
                     if (cont.is_escape) {
                         try self.invokeEscape(cont, value);
                     } else {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -514,7 +514,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isContinuation(callee)) {
                     const cont = types.toObject(callee).as(types.Continuation);
-                    const value = if (nargs == 0) types.VOID else self.registers[abs_base + 1];
+                    const value = if (nargs == 1)
+                        self.registers[abs_base + 1]
+                    else
+                        self.gc.allocMultipleValues(self.registers[abs_base + 1 .. abs_base + 1 + @as(usize, nargs)]) catch
+                            return VMError.OutOfMemory;
                     if (cont.is_escape) {
                         try self.invokeEscape(cont, value);
                     } else {
@@ -662,7 +666,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isContinuation(proc)) {
                     const cont = types.toObject(proc).as(types.Continuation);
-                    const value = if (count == 0) types.VOID else flat_args[0];
+                    const value = if (count == 1)
+                        flat_args[0]
+                    else
+                        self.gc.allocMultipleValues(flat_args[0..count]) catch
+                            return VMError.OutOfMemory;
                     if (cont.is_escape) {
                         try self.invokeEscape(cont, value);
                     } else {

--- a/tests/scheme/audit/primitives_control-audit.scm
+++ b/tests/scheme/audit/primitives_control-audit.scm
@@ -47,10 +47,9 @@
 (test 42 (call/cc (lambda (k) (+ 1 (k 42)))))
 (test 7 (call/cc (lambda (k) 7)))
 (test 42 (call-with-current-continuation (lambda (k) (k 42))))
-;; FAIL: #1169 (multi-argument continuation invocation drops values)
-;; (test '(1 2) (call-with-values
-;;                (lambda () (call/cc (lambda (k) (k 1 2))))
-;;                list))
+(test '(1 2) (call-with-values
+               (lambda () (call/cc (lambda (k) (k 1 2))))
+               list))
 (test 3 (let ((n 0) (k* #f))
           (call/cc (lambda (k) (set! k* k)))
           (set! n (+ n 1))


### PR DESCRIPTION
## Summary

Fixes #1169

- Continuation invocation (`call/cc` and `call/ec`) was silently dropping all but the first argument — `(k 1 2)` in a `call-with-values` producer delivered only `1` to the consumer
- When `nargs != 1`, wrap args in a `MultipleValues` object (mirroring `values` semantics) so `call-with-values` consumers receive the correct argument count
- Fixed in all three dispatch sites: `vm_dispatch.zig` (regular call + flat-args paths) and `vm_calls.zig` (`callValue` fallback)

## Test plan

- [x] Zig unit tests pass (`zig build test` — 639/639)
- [x] 3 new unit tests: `call/cc` multi-arg, `call/cc` zero-arg, `call/ec` multi-arg (all in `call-with-values` context)
- [x] Re-enabled audit test from `primitives_control-audit.scm`
- [x] Manual verification: `(call-with-values (lambda () (call/cc (lambda (k) (k 1 2)))) list)` → `(1 2)`
- [ ] Scheme test suite (`run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)