### PR TITLE
Fix GC crash on stale VM registers after thread start/join cycles

### DIFF
--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -201,7 +201,10 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
     @memset(fiber.registers, types.UNDEFINED);
     fiber.status = .created;
 
-    if (args.len > 1) fiber.name = args[1];
+    if (args.len > 1) {
+        fiber.name = args[1];
+        gc.writeBarrier(&fiber.header, args[1]);
+    }
 
     return types.makePointer(@ptrCast(fiber));
 }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -198,20 +198,7 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
     const fiber = gc.allocFiber(thunk, ctx.sched.next_id) catch return PrimitiveError.OutOfMemory;
     ctx.sched.next_id += 1;
 
-    const closure = types.toObject(thunk).as(types.Closure);
     @memset(fiber.registers, types.UNDEFINED);
-    fiber.registers[0] = thunk;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    fiber.frames[0] = .{
-        .closure = closure,
-        .code = closure.func.code.items,
-        .ip = 0,
-        .base = 0,
-        .dst = 0,
-        .saved_wind_count = 0,
-        .seq = vm.nextFrameSeq(),
-    };
-    fiber.frame_count = 1;
     fiber.status = .created;
 
     if (args.len > 1) fiber.name = args[1];
@@ -507,7 +494,10 @@ fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value
         target.os_thread = null;
     }
 
+    target.frame_count = 0;
+
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const fiber_obj = types.toObject(fiber_val);
 
     // Remove the thunk and fiber from extra_roots (added by thread-start!
     // to keep them alive while the child runs; the child is done now).
@@ -537,10 +527,13 @@ fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value
                 }
                 return PrimitiveError.OutOfMemory;
             };
+            gc.writeBarrier(fiber_obj, target.result);
         }
         if (target.status == .errored) {
             if (res.exception) |exc| {
                 target.current_exception = gc.deepCopy(exc) catch null;
+                if (target.current_exception) |cv|
+                    gc.writeBarrier(fiber_obj, cv);
             }
         }
     }

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -125,6 +125,15 @@ pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
     };
     vm.frame_count = 1;
 
+    // Clear local registers to prevent the GC from scanning stale values
+    // left by the previous execute() call. Between calls frame_count is 0,
+    // so a GC triggered by allocClosure above can free objects that stale
+    // registers still point to.
+    const clear_end = @min(@as(usize, func.locals_count), vm.registers.len);
+    if (clear_end > 0) {
+        @memset(vm.registers[0..clear_end], types.UNDEFINED);
+    }
+
     if (vm.profile_mode) {
         vm.profile_time_depth = 1;
         vm.profile_time_stack[0] = .{ .func = func, .entry_ns = clockNs() };
@@ -392,6 +401,16 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u32, nargs: u8) VMErr
     // The callee is in base, args are in base+1..base+nargs
     // New frame's registers start at base (callee reg becomes r0 for the function)
     const new_base = if (base < std.math.maxInt(u32)) base + 1 else return VMError.StackOverflow;
+
+    // Clear local registers beyond the args to prevent the GC from
+    // scanning stale values left by previous frames at this base.
+    const used: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else @as(usize, nargs);
+    const clear_start = @as(usize, new_base) + used;
+    const clear_end = @min(@as(usize, new_base) + @as(usize, func.locals_count), vm.registers.len);
+    if (clear_end > clear_start) {
+        @memset(vm.registers[clear_start..clear_end], types.UNDEFINED);
+    }
+
     vm.frames[vm.frame_count] = .{
         .closure = closure,
         .code = func.code.items,

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -11,6 +11,16 @@ const memory = @import("memory.zig");
 const vm_continuations = @import("vm_continuations.zig");
 const fiber_mod = @import("fiber.zig");
 
+/// Clear local registers beyond `used` args up to `locals_count` to prevent
+/// the GC from scanning stale values left by previously popped frames.
+fn clearFrameLocals(vm: *VM, base: u32, used: usize, locals_count: u16) void {
+    const clear_start = @as(usize, base) + used;
+    const clear_end = @min(@as(usize, base) + @as(usize, locals_count), vm.registers.len);
+    if (clear_end > clear_start) {
+        @memset(vm.registers[clear_start..clear_end], types.UNDEFINED);
+    }
+}
+
 /// Package continuation arguments the same way `values` does:
 /// 1 arg → that arg directly, 0 or 2+ → MultipleValues.
 pub fn continuationArgValue(gc: *memory.GC, args: []const Value) VMError!Value {
@@ -124,15 +134,7 @@ pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
         .seq = vm.nextFrameSeq(),
     };
     vm.frame_count = 1;
-
-    // Clear local registers to prevent the GC from scanning stale values
-    // left by the previous execute() call. Between calls frame_count is 0,
-    // so a GC triggered by allocClosure above can free objects that stale
-    // registers still point to.
-    const clear_end = @min(@as(usize, func.locals_count), vm.registers.len);
-    if (clear_end > 0) {
-        @memset(vm.registers[0..clear_end], types.UNDEFINED);
-    }
+    clearFrameLocals(vm, 0, 0, func.locals_count);
 
     if (vm.profile_mode) {
         vm.profile_time_depth = 1;
@@ -401,15 +403,7 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u32, nargs: u8) VMErr
     // The callee is in base, args are in base+1..base+nargs
     // New frame's registers start at base (callee reg becomes r0 for the function)
     const new_base = if (base < std.math.maxInt(u32)) base + 1 else return VMError.StackOverflow;
-
-    // Clear local registers beyond the args to prevent the GC from
-    // scanning stale values left by previous frames at this base.
-    const used: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else @as(usize, nargs);
-    const clear_start = @as(usize, new_base) + used;
-    const clear_end = @min(@as(usize, new_base) + @as(usize, func.locals_count), vm.registers.len);
-    if (clear_end > clear_start) {
-        @memset(vm.registers[clear_start..clear_end], types.UNDEFINED);
-    }
+    clearFrameLocals(vm, new_base, if (func.is_variadic) @as(usize, func.arity) + 1 else @as(usize, nargs), func.locals_count);
 
     vm.frames[vm.frame_count] = .{
         .closure = closure,
@@ -544,6 +538,10 @@ fn callReentrant(vm: *VM, closure: *types.Closure, base: u32, dst: u8, returns_t
         return VMError.StackOverflow;
     }
     try vm.ensureFrameCapacity(vm.frame_count + 1);
+
+    const func = closure.func;
+    const used: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else @as(usize, func.arity);
+    clearFrameLocals(vm, base, used, func.locals_count);
 
     vm.native_reentry_depth += 1;
     defer vm.native_reentry_depth -= 1;

--- a/tests/scheme/smoke/thread-frame-gc-1156.scm
+++ b/tests/scheme/smoke/thread-frame-gc-1156.scm
@@ -1,0 +1,38 @@
+;; Regression test for #1156: GC crash on stale fiber frame closure pointer.
+;; OS thread fibers had a dead frame[0] with a raw *Closure that became
+;; stale under gc-stress. Exercises multiple thread start/join cycles
+;; with timeout patterns to reproduce the original allocation pressure.
+
+(import (scheme base) (scheme write) (srfi 18))
+
+(define (run-test)
+  ;; Basic start/join cycle
+  (let ((t (make-thread (lambda () 'done))))
+    (thread-start! t)
+    (let ((r (thread-join! t)))
+      (unless (eq? r 'done)
+        (error "basic join failed" r))))
+
+  ;; Timeout join then successful join (the pattern from the crash)
+  (let ((t (make-thread (lambda () (thread-sleep! 0.3) 'slow))))
+    (thread-start! t)
+    (let ((r (thread-join! t 0.01 'timeout)))
+      (unless (eq? r 'timeout)
+        (error "timeout join failed" r)))
+    (let ((r (thread-join! t)))
+      (unless (eq? r 'slow)
+        (error "re-join failed" r))))
+
+  ;; Multiple cycles to increase allocation pressure
+  (let loop ((i 0))
+    (when (< i 5)
+      (let ((t (make-thread (lambda () (+ i 1)))))
+        (thread-start! t)
+        (let ((r (thread-join! t)))
+          (unless (= r (+ i 1))
+            (error "cycle join failed" i r))))
+      (loop (+ i 1)))))
+
+(run-test)
+(display "thread-frame-gc-1156: PASS")
+(newline)

--- a/tests/scheme/smoke/thread-frame-gc-1156.scm
+++ b/tests/scheme/smoke/thread-frame-gc-1156.scm
@@ -1,38 +1,30 @@
-;; Regression test for #1156: GC crash on stale fiber frame closure pointer.
-;; OS thread fibers had a dead frame[0] with a raw *Closure that became
-;; stale under gc-stress. Exercises multiple thread start/join cycles
-;; with timeout patterns to reproduce the original allocation pressure.
+;; Regression test for #1156: GC crash on stale VM registers after
+;; thread start/join cycles under gc-stress.
 
-(import (scheme base) (scheme write) (srfi 18))
+(import (scheme base) (scheme write) (srfi 18) (srfi 64))
 
-(define (run-test)
-  ;; Basic start/join cycle
-  (let ((t (make-thread (lambda () 'done))))
-    (thread-start! t)
-    (let ((r (thread-join! t)))
-      (unless (eq? r 'done)
-        (error "basic join failed" r))))
+(test-begin "thread-frame-gc-1156")
 
-  ;; Timeout join then successful join (the pattern from the crash)
-  (let ((t (make-thread (lambda () (thread-sleep! 0.3) 'slow))))
-    (thread-start! t)
-    (let ((r (thread-join! t 0.01 'timeout)))
-      (unless (eq? r 'timeout)
-        (error "timeout join failed" r)))
-    (let ((r (thread-join! t)))
-      (unless (eq? r 'slow)
-        (error "re-join failed" r))))
+;; Basic start/join cycle
+(let ((t (make-thread (lambda () 'done))))
+  (thread-start! t)
+  (test-equal 'done (thread-join! t)))
 
-  ;; Multiple cycles to increase allocation pressure
-  (let loop ((i 0))
-    (when (< i 5)
-      (let ((t (make-thread (lambda () (+ i 1)))))
-        (thread-start! t)
-        (let ((r (thread-join! t)))
-          (unless (= r (+ i 1))
-            (error "cycle join failed" i r))))
-      (loop (+ i 1)))))
+;; Timeout join then successful join (the pattern from the crash)
+(let ((t (make-thread (lambda () (thread-sleep! 0.3) 'slow))))
+  (thread-start! t)
+  (test-equal 'timeout (thread-join! t 0.01 'timeout))
+  (test-equal 'slow (thread-join! t)))
 
-(run-test)
-(display "thread-frame-gc-1156: PASS")
-(newline)
+;; Multiple cycles to increase allocation pressure
+(let loop ((i 0))
+  (when (< i 5)
+    (let ((t (make-thread (lambda () (+ i 1)))))
+      (thread-start! t)
+      (test-equal (+ i 1) (thread-join! t)))
+    (loop (+ i 1))))
+
+(let ((runner (test-runner-current)))
+  (test-end "thread-frame-gc-1156")
+  (when (> (test-runner-fail-count runner) 0)
+    (exit 1)))


### PR DESCRIPTION
## Summary

- Clear local registers in `execute()` and `callClosure()` to prevent the GC from scanning stale pointers left by previous frames at the same register base
- Remove dead frame setup from `makeThreadFn` — OS thread fibers create their own VM and never use the parent fiber's `frames[0]`
- Add missing write barriers and defensive `frame_count=0` in `reapOsThread` after joining the OS thread

Fixes #1156.

**Root cause:** Between `execute()` calls (top-level form evaluations), `frame_count` drops to 0. A GC cycle during this gap doesn't scan any VM registers, so objects reachable only from stale register values are freed. When the next `execute()` pushes a frame covering those registers, the GC encounters dangling pointers — SIGSEGV.

## Test plan

- [x] 30/30 passes of `primitives_srfi18-audit.scm` under `-Dgc-stress=true` (was ~60% crash rate before fix)
- [x] New regression test `tests/scheme/smoke/thread-frame-gc-1156.scm` passes under both normal and gc-stress builds
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1776 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)