### PR TITLE
Improve parallel-issues skill: label filter, triage rules, body-based grouping

### DIFF
--- a/.claude/skills/parallel-issues/SKILL.md
+++ b/.claude/skills/parallel-issues/SKILL.md
@@ -1,32 +1,70 @@
 ---
-description: Group open GitHub issues into parallel sets for concurrent Claude Code sessions. Use when the user asks to batch issues, plan parallel work, triage open issues for parallel fixing, or create issue sets.
+name: parallel-issues
+description: Group open GitHub issues into parallel sets for concurrent Claude Code sessions. Use when the user asks to batch issues, plan parallel work, triage open issues for parallel fixing, or create issue sets. Accepts an optional label to restrict which issues are considered.
+argument-hint: "[label]"
 ---
 
 # Parallel Issue Sets
 
-Look up all open GitHub issues with:
+An optional label may be passed as an argument: `$ARGUMENTS`
+
+Look up open GitHub issues with:
 
 ```bash
-gh issue list --state open --limit 100 --json number,title,labels
+gh issue list --state open --limit 500 --json number,title,labels,assignees,body
 ```
 
-Create numbered sets of issues that can be worked on by parallel Claude Code sessions. Auto-merge is enabled so PRs land independently in any order.
+If a label argument was provided, add `--label "<label>"` (quoted — labels may
+contain spaces). If the filtered list comes back empty, say so and stop; don't
+fall back to all open issues.
 
-## Rules
+If the returned count equals the limit, raise the limit and rerun — a silently
+truncated list would drop issues from the plan.
 
-- Every issue in a set MUST touch different source files/subsystems (no file overlap, no merge conflicts).
-- No two issues in a set should be closely related (don't pair issues from the same feature area).
-- Maximize set size (maximize parallelism).
-- Pick issues in dependency order across sets (foundational fixes in earlier sets).
-- Wait for all PRs in a set to merge before launching the next set.
+Titles rarely say which files an issue touches; bodies usually do, and the
+grouping rules below depend on knowing that. Read the bodies. If the tracker
+is too large to fetch every body, fetch `number,title,labels,assignees` first,
+triage from titles, and `gh issue view <n>` the issues whose subsystem is
+unclear.
+
+## Which issues qualify
+
+Skip issues that can't be handed to an independent fix session:
+
+- **Epics, tracking, and meta issues** — title prefixes like "Epic:",
+  "Tracking:", "Meta:", or labels to that effect. They span many subsystems
+  and aren't one-PR-sized.
+- **Assigned issues** — someone (or another session) is already on them.
+- **Issues with an open linked PR** — a fix is already in flight; a second
+  session would duplicate it. Add `--search "-linked:pr"` to filter these
+  server-side when in doubt.
+- **Not-actionable issues** — labels like blocked, question, discussion,
+  wontfix, duplicate.
+
+## Grouping rules
+
+- Every issue in a set must touch different source files/subsystems. The sets
+  are worked by concurrent sessions and auto-merge lands their PRs in any
+  order, so any file overlap means merge conflicts.
+- Don't pair closely related issues (same feature area) even when the files
+  differ — the fixes may interact.
+- Prefer larger sets (more parallelism), but cap a set at ~8 issues unless
+  the user asks for more — a set larger than the user can launch and monitor
+  at once adds no real throughput.
+- Order sets by dependency: foundational fixes in earlier sets, work that
+  builds on them later.
 
 ## Output format
 
-For each set, output only the issue numbers as a comma-separated list on one line:
+For each set, output only the issue numbers as a comma-separated list on one
+line:
 
 ```
 Set 1: NNN, NNN, NNN, ...
 Set 2: NNN, NNN, ...
 ```
 
-No commands, no cleanup, no explanations. Just the set number and issue numbers.
+No commands, no cleanup, no explanations — these lines get pasted straight
+into a session launcher, so anything else mixed in breaks the paste. (Context,
+not output: the user waits for all PRs in a set to merge before launching the
+next set — that's why the cross-set dependency ordering above matters.)

--- a/.claude/skills/parallel-issues/evals/evals.json
+++ b/.claude/skills/parallel-issues/evals/evals.json
@@ -1,0 +1,40 @@
+{
+  "skill_name": "parallel-issues",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "I want to burn down the open issue backlog with parallel Claude Code sessions. Batch the open issues into parallel sets I can launch concurrently.",
+      "expected_output": "Numbered sets of issue numbers (Set 1: ..., Set 2: ...), each set conflict-free, excluding epic/tracking/meta issues, no set larger than ~8 issues, nothing but set lines in the final answer.",
+      "files": [],
+      "expectations": [
+        "Response contains at least two 'Set N:' lines with comma-separated issue numbers",
+        "No issue number appears in more than one set",
+        "Epic/tracking meta-issues (1137, 1245, 1246) are excluded from all sets",
+        "No set contains more than 8 issues",
+        "Every issue number in the sets is a real open issue",
+        "Deliverable consists of set lines only (no commands or prose mixed in)"
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "Plan parallel work for the open issues labeled macros — group them into sets I can run concurrent sessions on. (skill argument: macros)",
+      "expected_output": "Sets containing only macros-labeled open issues (currently 1139, 1140, 1142, 1237, 1243), all of them covered, correct set-line format.",
+      "files": [],
+      "expectations": [
+        "Only macros-labeled open issues (1139, 1140, 1142, 1237, 1243) appear in the sets",
+        "All five macros-labeled issues are covered exactly once",
+        "Response consists of set lines in the required format"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Batch the open issues labeled documentation into parallel sets. (skill argument: documentation)",
+      "expected_output": "A statement that no open issues carry that label, and no sets — must not fall back to batching the whole tracker.",
+      "files": [],
+      "expectations": [
+        "Response states that no open issues carry the 'documentation' label",
+        "Response contains no set lines (no fallback to batching the whole tracker)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The `/parallel-issues` skill grouped issues from `number,title,labels` alone, so it couldn't verify its own core rule (no file overlap within a set), and it happily batched epics, assigned issues, and issues whose fixes were already in flight.

- Accept an optional label argument (`$ARGUMENTS`, with `argument-hint`) to scope the batch, e.g. `/parallel-issues macros`; empty result = stop, no fallback
- Fetch issue **bodies** and assignees — bodies are where the file paths live, and grouping accuracy depends on them (fallback guidance for very large trackers)
- Skip issues that can't be handed to an independent session: epics/tracking/meta, assigned, open linked PR, blocked/question/wontfix/duplicate
- Raise `--limit` to 500 and rerun if the count hits the limit (silent truncation would drop issues from the plan)
- Cap sets at ~8 issues so output matches launchable parallelism
- Explain the *why* behind the strict set-line output format; add `name:` frontmatter

## Validation

Ran the skill-creator eval loop against the live tracker (3 test cases, new skill vs pre-change snapshot):

| | pass rate | mean time | mean tokens |
|---|---|---|---|
| new skill | **11/11** | 232s | 78.2k |
| old skill | 9/11 | 236s | 71.4k |

Both baseline failures map 1:1 to the new rules: the old skill batched meta-issues #1137/#1245/#1246 (as their own sets) and produced sets of up to 18 issues; it also scheduled three issues that already had open PRs. Label filtering and empty-label behavior pass in both versions. Cost: ~9% more tokens from reading bodies, no wall-clock penalty.

Eval definitions are committed at `.claude/skills/parallel-issues/evals/evals.json` for future iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)