### PR TITLE
Patch datum-label references inside vectors (#1213)

### DIFF
--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -67,6 +67,7 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
                 return placeholder;
             } else {
                 self.labels[n] = datum;
+                patchPlaceholder(self.gc, datum, placeholder);
                 return datum;
             }
         },
@@ -216,6 +217,53 @@ fn readVector(self: *Reader) ReadError!Value {
     }
 
     return self.gc.allocVector(elems.items) catch return ReadError.OutOfMemory;
+}
+
+/// Walk `datum` and replace every occurrence of `placeholder` with `datum`.
+/// Handles pairs (car/cdr) and vectors (slots). Uses an iterative traversal
+/// with a visited set to tolerate cycles from previously-resolved labels.
+fn patchPlaceholder(gc: *@import("memory.zig").GC, datum: Value, placeholder: Value) void {
+    var stack: std.ArrayList(Value) = .empty;
+    defer stack.deinit(gc.allocator);
+    var visited: std.ArrayList(Value) = .empty;
+    defer visited.deinit(gc.allocator);
+
+    stack.append(gc.allocator, datum) catch return;
+
+    while (stack.items.len > 0) {
+        const val = stack.pop().?;
+
+        for (visited.items) |v| {
+            if (v == val) break;
+        } else {
+            visited.append(gc.allocator, val) catch return;
+
+            if (types.isPair(val)) {
+                if (types.car(val) == placeholder) {
+                    types.setCar(val, datum);
+                } else {
+                    const car = types.car(val);
+                    if (types.isPair(car) or types.isVector(car))
+                        stack.append(gc.allocator, car) catch return;
+                }
+                if (types.cdr(val) == placeholder) {
+                    types.setCdr(val, datum);
+                } else {
+                    const cdr = types.cdr(val);
+                    if (types.isPair(cdr) or types.isVector(cdr))
+                        stack.append(gc.allocator, cdr) catch return;
+                }
+            } else if (types.isVector(val)) {
+                for (types.toVector(val).data) |*slot| {
+                    if (slot.* == placeholder) {
+                        slot.* = datum;
+                    } else if (types.isPair(slot.*) or types.isVector(slot.*)) {
+                        stack.append(gc.allocator, slot.*) catch return;
+                    }
+                }
+            }
+        }
+    }
 }
 
 fn readBytevector(self: *Reader) ReadError!Value {

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -63,11 +63,13 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
             self.labels[n] = placeholder;
             if (types.isPair(datum)) {
                 types.setCar(placeholder, types.car(datum));
+                self.gc.writeBarrier(types.toObject(placeholder), types.car(datum));
                 types.setCdr(placeholder, types.cdr(datum));
+                self.gc.writeBarrier(types.toObject(placeholder), types.cdr(datum));
                 return placeholder;
             } else {
                 self.labels[n] = datum;
-                patchPlaceholder(self.gc, datum, placeholder);
+                patchPlaceholder(self.gc, datum, placeholder) catch return ReadError.OutOfMemory;
                 return datum;
             }
         },
@@ -219,47 +221,48 @@ fn readVector(self: *Reader) ReadError!Value {
     return self.gc.allocVector(elems.items) catch return ReadError.OutOfMemory;
 }
 
+const memory = @import("memory.zig");
+
 /// Walk `datum` and replace every occurrence of `placeholder` with `datum`.
 /// Handles pairs (car/cdr) and vectors (slots). Uses an iterative traversal
-/// with a visited set to tolerate cycles from previously-resolved labels.
-fn patchPlaceholder(gc: *@import("memory.zig").GC, datum: Value, placeholder: Value) void {
+/// with a hash-set for O(1) cycle detection.
+fn patchPlaceholder(gc: *memory.GC, datum: Value, placeholder: Value) error{OutOfMemory}!void {
     var stack: std.ArrayList(Value) = .empty;
     defer stack.deinit(gc.allocator);
-    var visited: std.ArrayList(Value) = .empty;
-    defer visited.deinit(gc.allocator);
+    var visited = std.AutoHashMap(Value, void).init(gc.allocator);
+    defer visited.deinit();
 
-    stack.append(gc.allocator, datum) catch return;
+    try stack.append(gc.allocator, datum);
 
     while (stack.items.len > 0) {
         const val = stack.pop().?;
+        if (visited.contains(val)) continue;
+        try visited.put(val, {});
 
-        for (visited.items) |v| {
-            if (v == val) break;
-        } else {
-            visited.append(gc.allocator, val) catch return;
-
-            if (types.isPair(val)) {
-                if (types.car(val) == placeholder) {
-                    types.setCar(val, datum);
-                } else {
-                    const car = types.car(val);
-                    if (types.isPair(car) or types.isVector(car))
-                        stack.append(gc.allocator, car) catch return;
-                }
-                if (types.cdr(val) == placeholder) {
-                    types.setCdr(val, datum);
-                } else {
-                    const cdr = types.cdr(val);
-                    if (types.isPair(cdr) or types.isVector(cdr))
-                        stack.append(gc.allocator, cdr) catch return;
-                }
-            } else if (types.isVector(val)) {
-                for (types.toVector(val).data) |*slot| {
-                    if (slot.* == placeholder) {
-                        slot.* = datum;
-                    } else if (types.isPair(slot.*) or types.isVector(slot.*)) {
-                        stack.append(gc.allocator, slot.*) catch return;
-                    }
+        if (types.isPair(val)) {
+            if (types.car(val) == placeholder) {
+                types.setCar(val, datum);
+                gc.writeBarrier(types.toObject(val), datum);
+            } else {
+                const car = types.car(val);
+                if (types.isPair(car) or types.isVector(car))
+                    try stack.append(gc.allocator, car);
+            }
+            if (types.cdr(val) == placeholder) {
+                types.setCdr(val, datum);
+                gc.writeBarrier(types.toObject(val), datum);
+            } else {
+                const cdr = types.cdr(val);
+                if (types.isPair(cdr) or types.isVector(cdr))
+                    try stack.append(gc.allocator, cdr);
+            }
+        } else if (types.isVector(val)) {
+            for (types.toVector(val).data) |*slot| {
+                if (slot.* == placeholder) {
+                    slot.* = datum;
+                    gc.writeBarrier(types.toObject(val), datum);
+                } else if (types.isPair(slot.*) or types.isVector(slot.*)) {
+                    try stack.append(gc.allocator, slot.*);
                 }
             }
         }

--- a/tests/scheme/smoke/datum-label-vector.scm
+++ b/tests/scheme/smoke/datum-label-vector.scm
@@ -1,0 +1,34 @@
+;; Regression test for #1213: datum-label references inside vectors not patched
+(import (scheme base) (scheme read) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "datum-label-vector")
+
+;; Direct self-reference in vector
+(let ((v (read (open-input-string "#0=#(1 #0#)"))))
+  (test-equal "vector slot 0" 1 (vector-ref v 0))
+  (test-assert "vector self-ref" (eq? v (vector-ref v 1))))
+
+;; Reference nested in a pair inside the vector
+(let ((v (read (open-input-string "#0=#((#0#) 2)"))))
+  (test-assert "ref nested in pair inside vector"
+    (eq? v (car (vector-ref v 0)))))
+
+;; Multiple self-references in vector
+(let ((v (read (open-input-string "#0=#(#0# #0# #0#)"))))
+  (test-assert "all slots self-ref"
+    (and (eq? v (vector-ref v 0))
+         (eq? v (vector-ref v 1))
+         (eq? v (vector-ref v 2)))))
+
+;; Cyclic list still works (existing behavior)
+(let ((c (read (open-input-string "#0=(1 #0# 2)"))))
+  (test-assert "list self-ref" (eq? c (cadr c))))
+
+;; Vector ref inside list (pair case — placeholder IS the result)
+(let ((l (read (open-input-string "#0=(1 #(#0#) 3)"))))
+  (test-assert "vector-in-list ref"
+    (eq? l (vector-ref (cadr l) 0))))
+
+(let ((runner (test-runner-current)))
+  (test-end "datum-label-vector")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi38.scm
+++ b/tests/scheme/srfi/srfi38.scm
@@ -34,14 +34,11 @@
   (test #t (eq? (car s2) (cadr s2))))
 
 ;;; --- self-referential vector ---
-;; write side emits correct labels ("#0=#(1 #0#)") but the reader does not
-;; patch label references inside vectors:
-;; FAIL: #1213 (reader: datum-label references inside vectors unpatched)
-;; (let ((v (vector 1 2)))
-;;   (vector-set! v 1 v)
-;;   (let ((v2 (rt v)))
-;;     (test 1 (vector-ref v2 0))
-;;     (test #t (eq? v2 (vector-ref v2 1)))))
+(let ((v (vector 1 2)))
+  (vector-set! v 1 v)
+  (let ((v2 (rt v)))
+    (test 1 (vector-ref v2 0))
+    (test #t (eq? v2 (vector-ref v2 1)))))
 
 ;;; --- labels parse via plain read too (R7RS datum labels) ---
 (let ((c (read (open-input-string "#0=(1 2 . #0#)"))))


### PR DESCRIPTION
## Summary

- The reader resolved `#n#` datum-label forward references in pair cells but never walked vector slots, so `#0=#(1 #0#)` left the placeholder pair unpatched in slot 1
- Add `patchPlaceholder` in `reader_datum.zig` — an iterative walk over pairs (car/cdr) and vectors (slots) with a visited set for cycle safety — called for non-pair labeled datums
- Re-enable the SRFI-38 self-referential vector round-trip test and add a dedicated regression test covering direct, nested, and multi-slot self-references

Closes #1213

## Test plan

- [x] `zig build test` — all Zig unit tests pass
- [x] `zig build run -- tests/scheme/r7rs/r7rs-tests.scm` — all 1,391 R7RS tests pass
- [x] `zig build run -- tests/scheme/smoke/datum-label-vector.scm` — new regression test (6 assertions)
- [x] `zig build run -- tests/scheme/srfi/srfi38.scm` — 14 pass, 0 fail (re-enabled vector test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)