### PR TITLE
Fix u8-ready? returning #f at EOF (R7RS requires #t)

### DIFF
--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -299,8 +299,8 @@ fn portWriteBytes(port: *types.Port, bytes: []const u8) void {
 }
 
 fn u8ReadyP(args: []const Value) PrimitiveError!Value {
-    const port = try getInputPort(args, 0, "u8-ready?");
-    if (port.peek_byte != null) return types.TRUE;
+    // For simplicity, always return #t (non-blocking check not worth the complexity)
+    _ = try getInputPort(args, 0, "u8-ready?");
     return types.TRUE;
 }
 

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -301,11 +301,7 @@ fn portWriteBytes(port: *types.Port, bytes: []const u8) void {
 fn u8ReadyP(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 0, "u8-ready?");
     if (port.peek_byte != null) return types.TRUE;
-    if (port.is_string_port) {
-        const data = port.string_data orelse return types.TRUE;
-        return if (port.string_pos < data.len) types.TRUE else types.FALSE;
-    }
-    return types.TRUE; // simplified
+    return types.TRUE;
 }
 
 fn readBytevectorFn(args: []const Value) PrimitiveError!Value {

--- a/tests/scheme/audit/primitives_bytevector-audit.scm
+++ b/tests/scheme/audit/primitives_bytevector-audit.scm
@@ -168,11 +168,8 @@
            (peek-u8 p)
            (u8-ready? p)))
 ;; R7RS 6.13.3: "If the port is at end of file then u8-ready? returns #t"
-;; (read-u8 at EOF returns the eof-object immediately — it cannot hang).
-;; The fix for #280 inverted this; char-ready? conforms, u8-ready? does not.
-;; FAIL: #1179 (u8-ready? returns #f at EOF; spec requires #t)
-;; (test #t (u8-ready? (open-input-bytevector #u8())))
-;; (test #t (let ((p (open-input-bytevector #u8(7)))) (read-u8 p) (u8-ready? p)))
+(test #t (u8-ready? (open-input-bytevector #u8())))
+(test #t (let ((p (open-input-bytevector #u8(7)))) (read-u8 p) (u8-ready? p)))
 
 ;;; --- write-u8 / open-output-bytevector / get-output-bytevector ---
 (test #u8(1 2 3)

--- a/tests/scheme/smoke/bytevector-port-fixes.scm
+++ b/tests/scheme/smoke/bytevector-port-fixes.scm
@@ -1,19 +1,8 @@
 ;; Regression tests for bytevector port fixes
-;; #280: u8-ready? always returns #t
 ;; #281: read-bytevector returns EOF when k=0
 ;; #282: get-output-bytevector accepts string ports
 
 (import (scheme base) (scheme write))
-
-;; ---- #280: u8-ready? returns #f at EOF ----
-(let ((p (open-input-bytevector #u8(1 2))))
-  (read-u8 p) (read-u8 p)
-  (display (u8-ready? p))          ; #f (port exhausted)
-  (newline))
-
-(let ((p (open-input-bytevector #u8(42))))
-  (display (u8-ready? p))          ; #t (data available)
-  (newline))
 
 ;; ---- #281: read-bytevector with k=0 ----
 (let ((p (open-input-bytevector #u8(1 2 3))))

--- a/tests/scheme/smoke/u8-ready-eof.scm
+++ b/tests/scheme/smoke/u8-ready-eof.scm
@@ -1,0 +1,20 @@
+;; Regression test for #1179: u8-ready? must return #t at EOF
+;; R7RS 6.13.3: "If the port is at end of file then u8-ready? returns #t."
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "u8-ready-eof")
+
+(test-assert "u8-ready? on empty bytevector port"
+  (u8-ready? (open-input-bytevector #u8())))
+
+(test-assert "u8-ready? after exhausting bytevector port"
+  (let ((p (open-input-bytevector #u8(7))))
+    (read-u8 p)
+    (u8-ready? p)))
+
+(test-assert "u8-ready? before EOF still #t"
+  (u8-ready? (open-input-bytevector #u8(1 2 3))))
+
+(let ((runner (test-runner-current)))
+  (test-end "u8-ready-eof")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Closes #1179.

- R7RS §6.13.3 requires `u8-ready?` to return `#t` at EOF (since `read-u8` returns the eof-object immediately and cannot hang). The `#280` fix incorrectly inverted this for string ports.
- Removed the string-port branch from `u8ReadyP` so it always returns `#t`, consistent with `char-ready?` which was already conforming.
- Enabled the two disabled audit tests and added a regression test.

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `zig build run -- tests/scheme/smoke/u8-ready-eof.scm` — regression test passes
- [x] `zig build run -- tests/scheme/audit/primitives_bytevector-audit.scm` — 118 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)