### PR TITLE
Remove iteration cap from force trampoline for unbounded delay-force chains

### DIFF
--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -40,8 +40,7 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
 
     if (!types.isPromise(current)) return current;
 
-    var iterations: usize = 0;
-    while (iterations < 100000) : (iterations += 1) {
+    while (true) {
         if (!types.isPromise(current)) return current;
         const promise = types.toPromise(current);
 
@@ -99,6 +98,4 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
         gc.writeBarrier(&promise.header, result);
         return result;
     }
-
-    return primitives.typeError("force", "non-circular promise chain", args[0]);
 }

--- a/tests/scheme/compliance/r7rs-thin-forms-gaps.scm
+++ b/tests/scheme/compliance/r7rs-thin-forms-gaps.scm
@@ -16,10 +16,7 @@
   (if (= n 0) (delay 'end) (delay-force (df-chain (- n 1)))))
 (test-equal "delay-force chain forces in bounded space" 'end
   (force (df-chain 99999)))
-;; force's trampoline is capped at 100,000 iterations and mislabels longer
-;; legitimate chains as circular
-;; FAIL: #1242 (force reports long delay-force chains as circular)
-;; (test-equal "delay-force chain beyond 100k" 'end (force (df-chain 100000)))
+(test-equal "delay-force chain beyond 100k" 'end (force (df-chain 100001)))
 
 ;; force memoizes: the body runs once even when forced repeatedly
 (define force-count 0)


### PR DESCRIPTION
## Summary

- Remove the hardcoded 100,000 iteration cap from `force`'s trampoline loop in `primitives_lazy.zig`. R7RS 4.2.5 requires `delay-force` chains to force in bounded space with no limit on chain length — the cap was a heuristic cycle detector that falsely rejected legitimate long chains (SRFI-41 streams, SRFI-45 iterative algorithms).
- The existing `forcing` flag already detects re-entrant promise cycles, so the cap was redundant for cycle detection.
- Enable the previously disabled compliance test for chains beyond 100k.

Fixes #1242

## Test plan

- [x] `zig build test` — all Zig unit tests pass
- [x] `r7rs-thin-forms-gaps.scm` — 33/33 pass (was 32, now includes the 100k+ chain test)
- [x] Full R7RS suite — 0 failures
- [x] Verified `(force (chain 100000))` and `(force (chain 200000))` both return `end`
- [x] Verified circular promise `(define p (delay (force p)))` still errors (via native re-entrancy guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)