### PR TITLE
Support optional environment-specifier in load (R7RS §6.14)

### DIFF
--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -27,7 +27,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "interaction-environment", .func = &interactionEnvironmentFn, .arity = .{ .exact = 0 }, .libs = LS.initMany(&.{ .scheme_eval, .scheme_r5rs, .scheme_repl }), .sandbox = false },
     .{ .name = "null-environment", .func = &nullEnvironmentFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_r5rs), .sandbox = false },
     .{ .name = "scheme-report-environment", .func = &schemeReportEnvironmentFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_r5rs), .sandbox = false },
-    .{ .name = "load", .func = &loadFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_load, .scheme_r5rs }), .sandbox = false },
+    .{ .name = "load", .func = &loadFn, .arity = .{ .variadic = 1 }, .libs = LS.initMany(&.{ .scheme_load, .scheme_r5rs }), .sandbox = false },
     .{ .name = "disassemble", .func = &disassembleFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base), .sandbox = false },
 };
 
@@ -238,6 +238,16 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 
+    // Optional environment-specifier (R7RS §6.14)
+    var env: ?*std.StringHashMap(Value) = null;
+    var env_val: Value = types.VOID;
+    if (args.len > 1) {
+        if (!types.isEnvironment(args[1])) return primitives.typeError("load", "environment", args[1]);
+        const se = types.toEnvironment(args[1]);
+        env = se.env;
+        env_val = args[1];
+    }
+
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
@@ -278,13 +288,21 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
     while (reader.hasMore() catch return PrimitiveError.TypeError) { // bare-ok: reader error in load
         const expr = reader.readDatum() catch return primitives.typeError("load", "valid datum", args[0]);
 
-        const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return primitives.typeError("load", "valid expression", args[0]);
-        {
+        if (env) |e| {
+            const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, e, env_val) catch return primitives.typeError("load", "valid expression", args[0]);
+            var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
+            compiler_mod.Compiler.unrootFunction(gc, func);
+            gc.pushRoot(&closure_val);
+            defer gc.popRoot();
+            last_result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
+                return err;
+            };
+        } else {
+            const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return primitives.typeError("load", "valid expression", args[0]);
             var func_val = types.makePointer(@ptrCast(func));
             gc.pushRoot(&func_val);
             defer gc.popRoot();
             compiler_mod.Compiler.unrootFunction(gc, func);
-
             last_result = vm.execute(func) catch |err| {
                 return err;
             };

--- a/tests/scheme/audit/primitives_r7rs-audit.scm
+++ b/tests/scheme/audit/primitives_r7rs-audit.scm
@@ -117,14 +117,13 @@
                   (delete-file load-probe-path)
                   r)))
 (test 'caught (guard (e (#t 'caught)) (load 42)))
-;; R7RS 6.14: (load filename environment-specifier) — the optional second
-;; argument is rejected with an arity error.
-;; FAIL: #1190 (load does not accept the optional environment-specifier)
-;; (test 3 (begin
-;;           (with-output-to-file load-probe-path (lambda () (write '(+ 1 2))))
-;;           (let ((v (load load-probe-path (interaction-environment))))
-;;             (delete-file load-probe-path)
-;;             v)))
+;; R7RS 6.14: (load filename environment-specifier)
+(begin
+  (with-output-to-file load-probe-path
+    (lambda () (display "(define _load-env-audit-var (+ 1 2))")))
+  (load load-probe-path (interaction-environment))
+  (delete-file load-probe-path)
+  (test 3 _load-env-audit-var))
 
 ;;; --- parameters (make-parameter, converter behavior) ---
 (test 10 (let ((p (make-parameter 10))) (p)))

--- a/tests/scheme/smoke/load-env-1190.scm
+++ b/tests/scheme/smoke/load-env-1190.scm
@@ -1,41 +1,36 @@
 ;; Regression test for #1190: load with optional environment-specifier
 (import (scheme base) (scheme write) (scheme file) (scheme load) (scheme eval)
-        (scheme process-context))
+        (scheme process-context) (srfi 64))
 
 (define tmp "/tmp/kaappi-load-env-1190.scm")
-(define pass 0)
-(define fail 0)
 
-(define (check name expected actual)
-  (if (equal? expected actual)
-    (set! pass (+ pass 1))
-    (begin (set! fail (+ fail 1))
-           (display "FAIL: ") (display name)
-           (display " expected ") (write expected)
-           (display " got ") (write actual) (newline))))
+(test-begin "load-env-1190")
 
 ;; Single-argument form works (load evaluates for side effects)
 (with-output-to-file tmp (lambda () (display "(define load-test-var-1 42)")))
 (load tmp)
-(check "single-arg load defines variable" 42 load-test-var-1)
+(test-equal "single-arg load defines variable" 42 load-test-var-1)
 
 ;; Two-argument form with (interaction-environment)
 (with-output-to-file tmp (lambda () (display "(define load-test-var-2 99)")))
 (load tmp (interaction-environment))
-(check "load with interaction-environment" 99 load-test-var-2)
+(test-equal "load with interaction-environment" 99 load-test-var-2)
 
-;; Two-argument form with a custom environment — does not leak into globals
+;; Two-argument form with a custom environment — defines go into that env
+(define custom-env (environment '(scheme base) '(scheme eval)))
 (with-output-to-file tmp (lambda () (display "(define load-test-var-3 77)")))
-(load tmp (environment '(scheme base)))
-(check "load with custom env does not define globally" 'caught
+(load tmp custom-env)
+(test-equal "load defines into custom env" 77 (eval 'load-test-var-3 custom-env))
+(test-equal "load with custom env does not define globally" 'caught
   (guard (e (#t 'caught)) load-test-var-3))
 
 ;; Non-environment second arg raises an error
 (with-output-to-file tmp (lambda () (display "(+ 1 2)")))
-(check "load with bad env type" 'caught
+(test-equal "load with bad env type" 'caught
   (guard (e (#t 'caught)) (load tmp 42)))
 
 (delete-file tmp)
 
-(display pass) (display " passed, ") (display fail) (display " failed") (newline)
-(when (> fail 0) (exit 1))
+(let ((runner (test-runner-current)))
+  (test-end "load-env-1190")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/load-env-1190.scm
+++ b/tests/scheme/smoke/load-env-1190.scm
@@ -1,0 +1,41 @@
+;; Regression test for #1190: load with optional environment-specifier
+(import (scheme base) (scheme write) (scheme file) (scheme load) (scheme eval)
+        (scheme process-context))
+
+(define tmp "/tmp/kaappi-load-env-1190.scm")
+(define pass 0)
+(define fail 0)
+
+(define (check name expected actual)
+  (if (equal? expected actual)
+    (set! pass (+ pass 1))
+    (begin (set! fail (+ fail 1))
+           (display "FAIL: ") (display name)
+           (display " expected ") (write expected)
+           (display " got ") (write actual) (newline))))
+
+;; Single-argument form works (load evaluates for side effects)
+(with-output-to-file tmp (lambda () (display "(define load-test-var-1 42)")))
+(load tmp)
+(check "single-arg load defines variable" 42 load-test-var-1)
+
+;; Two-argument form with (interaction-environment)
+(with-output-to-file tmp (lambda () (display "(define load-test-var-2 99)")))
+(load tmp (interaction-environment))
+(check "load with interaction-environment" 99 load-test-var-2)
+
+;; Two-argument form with a custom environment — does not leak into globals
+(with-output-to-file tmp (lambda () (display "(define load-test-var-3 77)")))
+(load tmp (environment '(scheme base)))
+(check "load with custom env does not define globally" 'caught
+  (guard (e (#t 'caught)) load-test-var-3))
+
+;; Non-environment second arg raises an error
+(with-output-to-file tmp (lambda () (display "(+ 1 2)")))
+(check "load with bad env type" 'caught
+  (guard (e (#t 'caught)) (load tmp 42)))
+
+(delete-file tmp)
+
+(display pass) (display " passed, ") (display fail) (display " failed") (newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

- Change `load`'s arity from `.exact = 1` to `.variadic = 1` to accept the optional environment-specifier argument per R7RS §6.14
- When an environment is supplied, compile expressions via `compileExpressionInEnv` and execute via `callWithArgs` (matching the `eval` pattern)
- Un-skip the disabled audit test for `#1190`, rewritten to verify via `define` side effect
- Add regression test covering single-arg, `interaction-environment`, custom `environment`, and type-error cases

Closes #1190

## Test plan

- [x] New regression test `tests/scheme/smoke/load-env-1190.scm` (4 checks pass)
- [x] Audit test `primitives_r7rs-audit.scm` (42 pass, 0 fail)
- [x] Zig unit tests pass
- [x] R7RS suite (1395 pass, 0 fail)
- [x] Full Scheme test suite (1777 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)