### PR TITLE
Report syntax-error message and irritants

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -9,8 +9,16 @@ const macro = @import("compiler_macro.zig");
 const ir_mod = @import("ir.zig");
 const compiler_ir = @import("compiler_ir.zig");
 const globals_mod = @import("globals.zig");
+const printer = @import("printer.zig");
 const Value = types.Value;
 const OpCode = types.OpCode;
+
+pub threadlocal var syntax_error_detail: [512]u8 = [_]u8{0} ** 512;
+pub threadlocal var syntax_error_detail_len: usize = 0;
+
+pub fn getSyntaxErrorDetail() []const u8 {
+    return syntax_error_detail[0..syntax_error_detail_len];
+}
 
 pub const CompileError = error{
     OutOfMemory,
@@ -666,7 +674,10 @@ pub const Compiler = struct {
                 if (std.mem.eql(u8, effective_name, "parameterize")) return advanced.compileParameterize(self, args, dst, is_tail);
 
                 // syntax-error
-                if (std.mem.eql(u8, effective_name, "syntax-error")) return CompileError.InvalidSyntax;
+                if (std.mem.eql(u8, effective_name, "syntax-error")) {
+                    formatSyntaxError(args);
+                    return CompileError.InvalidSyntax;
+                }
 
                 // Macro forms (kept in compiler.zig)
                 if (std.mem.eql(u8, effective_name, "define-syntax")) return macro.compileDefineSyntax(self, args, dst);
@@ -777,6 +788,24 @@ pub const Compiler = struct {
         }
     }
 };
+
+fn formatSyntaxError(args: Value) void {
+    var w: std.Io.Writer = .fixed(&syntax_error_detail);
+    var rest = args;
+    // First argument is the message string.
+    if (types.isPair(rest)) {
+        const msg = types.car(rest);
+        printer.printValue(&w, msg, .display) catch {};
+        rest = types.cdr(rest);
+    }
+    // Remaining arguments are irritants.
+    while (types.isPair(rest)) {
+        w.print(" ", .{}) catch {};
+        printer.printValue(&w, types.car(rest), .write) catch {};
+        rest = types.cdr(rest);
+    }
+    syntax_error_detail_len = w.buffered().len;
+}
 
 /// Recursively collect the symbol names that appear as the target of a
 /// `(set! <name> ...)` anywhere in `expr` into `out`. Used to suppress

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -840,6 +840,7 @@ fn collectSetTargets(expr: Value, out: *std.StringHashMap(void)) CompileError!vo
 // ---------------------------------------------------------------------------
 
 pub fn compileExpression(gc: *memory.GC, expr: Value) CompileError!*types.Function {
+    syntax_error_detail_len = 0;
     var c = try Compiler.init(gc);
     const roots_base = gc.extra_roots.items.len;
     var ok = false;
@@ -858,6 +859,7 @@ pub fn compileExpressionWithMacros(gc: *memory.GC, expr: Value, vm_macros: *std.
 }
 
 pub fn compileExpressionWithMacrosAt(gc: *memory.GC, expr: Value, vm_macros: *std.StringHashMap(Value), vm_globals: ?*std.StringHashMap(Value), source_line: u32, source_name: ?[]const u8) CompileError!*types.Function {
+    syntax_error_detail_len = 0;
     var c = try Compiler.init(gc);
     const roots_base = gc.extra_roots.items.len;
     c.globals = vm_globals;
@@ -883,6 +885,7 @@ pub fn compileExpressionWithMacrosAt(gc: *memory.GC, expr: Value, vm_macros: *st
 }
 
 pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.StringHashMap(Value), env: *std.StringHashMap(Value), env_val: Value) CompileError!*types.Function {
+    syntax_error_detail_len = 0;
     var c = try Compiler.init(gc);
     const roots_base = gc.extra_roots.items.len;
     c.globals = env;

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -19,9 +19,11 @@ pub fn reportReadError(source_name: []const u8, line: u32, col: u32, err: anyerr
 pub fn reportCompileError(source_name: []const u8, line: u32, err: anyerror) void {
     const detail = compiler_mod.getSyntaxErrorDetail();
     if (detail.len > 0) {
-        var buf: [768]u8 = undefined;
-        const s = std.fmt.bufPrint(&buf, "{s}:{d}: syntax-error: {s}\n", .{ source_name, line, detail }) catch "compile error\n";
-        writeStderr(s);
+        var buf: [256]u8 = undefined;
+        const prefix = std.fmt.bufPrint(&buf, "{s}:{d}: syntax-error: ", .{ source_name, line }) catch "syntax-error: ";
+        writeStderr(prefix);
+        writeStderr(detail);
+        writeStderr("\n");
         compiler_mod.syntax_error_detail_len = 0;
     } else {
         var buf: [256]u8 = undefined;

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const vm_mod = @import("vm.zig");
+const compiler_mod = @import("compiler.zig");
 const reporting = @import("reporting.zig");
 
 const writeStderr = reporting.writeStderr;
@@ -16,9 +17,17 @@ pub fn reportReadError(source_name: []const u8, line: u32, col: u32, err: anyerr
 }
 
 pub fn reportCompileError(source_name: []const u8, line: u32, err: anyerror) void {
-    var buf: [256]u8 = undefined;
-    const s = std.fmt.bufPrint(&buf, "{s}:{d}: compile error: {}\n", .{ source_name, line, err }) catch "compile error\n";
-    writeStderr(s);
+    const detail = compiler_mod.getSyntaxErrorDetail();
+    if (detail.len > 0) {
+        var buf: [768]u8 = undefined;
+        const s = std.fmt.bufPrint(&buf, "{s}:{d}: syntax-error: {s}\n", .{ source_name, line, detail }) catch "compile error\n";
+        writeStderr(s);
+        compiler_mod.syntax_error_detail_len = 0;
+    } else {
+        var buf: [256]u8 = undefined;
+        const s = std.fmt.bufPrint(&buf, "{s}:{d}: compile error: {}\n", .{ source_name, line, err }) catch "compile error\n";
+        writeStderr(s);
+    }
 }
 
 pub fn reportRuntimeError(vm: *vm_mod.VM, err: anyerror, location: ?Location) void {

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -75,6 +75,10 @@ assert_output_contains "syntax-error from macro includes message" \
 assert_output_contains "syntax-error has location" \
     '(syntax-error "msg")' '<stdin>:1:'
 
+assert_output_contains "caught syntax-error does not leak into next compile error" \
+    '(import (scheme base)) (guard (e (#t #t)) (eval (quote (syntax-error "STALE" 999)) (environment (quote (scheme base))))) (if)' \
+    'compile error'
+
 # --- Runtime errors include file:line ---
 echo
 echo "-- Runtime errors from files --"

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -58,6 +58,23 @@ assert_output_contains "compile error has location" \
 assert_output_contains "compile error has 'compile error'" \
     '(if)' 'compile error'
 
+# --- syntax-error includes message and irritants (#1142) ---
+echo
+echo "-- syntax-error diagnostics --"
+
+assert_output_contains "syntax-error includes message" \
+    '(syntax-error "custom msg")' 'syntax-error: custom msg'
+
+assert_output_contains "syntax-error includes irritants" \
+    '(syntax-error "custom msg" 42)' 'syntax-error: custom msg 42'
+
+assert_output_contains "syntax-error from macro includes message" \
+    '(define-syntax bad (syntax-rules () ((_ x) (syntax-error "bad usage" x)))) (bad 1)' \
+    'syntax-error: bad usage 1'
+
+assert_output_contains "syntax-error has location" \
+    '(syntax-error "msg")' '<stdin>:1:'
+
 # --- Runtime errors include file:line ---
 echo
 echo "-- Runtime errors from files --"


### PR DESCRIPTION
## Summary
- **Fixes #1142** — `syntax-error` was discarding its message and irritants, reporting only a bare `error.InvalidSyntax`
- Formats the message (display mode) and irritants (write mode) into a threadlocal buffer in the compiler, consumed by `reportCompileError`
- Output now reads `file:line: syntax-error: custom msg 42` instead of `file:line: compile error: error.InvalidSyntax`

## Test plan
- [x] 4 new tests in `tests/scheme/errors/error-format.sh`: message only, message+irritant, from inside a macro, location present
- [x] All 50 error format tests pass
- [x] Zig unit tests pass
- [x] R7RS test suite: 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)