### PR TITLE
Honor fold-case flag in include-ci (R7RS 4.1.7)

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -556,10 +556,6 @@ fn openIncludeFile(vm: *VM, file_path: []const u8) VMError!IncludeFile {
 /// with the next form, matching the per-form error isolation of the top-level
 /// file runner in `main.zig`.
 pub fn handleTopLevelInclude(vm: *VM, args: Value, ci: bool) VMError!Value {
-    // include-ci should fold case while reading; the reader currently only
-    // honors inline `#!fold-case` directives, so the two behave identically.
-    _ = ci;
-
     const reader_mod = @import("reader.zig");
 
     // Root the argument spine: evaluating included forms allocates and may
@@ -596,6 +592,7 @@ pub fn handleTopLevelInclude(vm: *VM, args: Value, ci: bool) VMError!Value {
         defer vm.current_lib_dir = saved_lib_dir;
 
         var file_reader = reader_mod.Reader.initWithName(vm.gc, inc.source, owned_path);
+        file_reader.fold_case = ci;
         defer file_reader.deinit();
 
         while (file_reader.hasMore() catch false) {
@@ -955,7 +952,7 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
 }
 
 /// Compile and evaluate included files in a library context.
-fn compileLibInclude(vm: *VM, lib_env: *std.StringHashMap(Value), file_list_val: Value) VMError!void {
+fn compileLibInclude(vm: *VM, lib_env: *std.StringHashMap(Value), file_list_val: Value, ci: bool) VMError!void {
     var file_list = file_list_val;
     while (file_list != types.NIL) {
         if (!types.isPair(file_list)) return VMError.CompileError;
@@ -975,6 +972,7 @@ fn compileLibInclude(vm: *VM, lib_env: *std.StringHashMap(Value), file_list_val:
 
         const reader_mod = @import("reader.zig");
         var file_reader = reader_mod.Reader.init(vm.gc, inc.source);
+        file_reader.fold_case = ci;
         defer file_reader.deinit();
 
         while (file_reader.hasMore() catch return VMError.CompileError) {
@@ -1030,7 +1028,7 @@ fn processLibDeclaration(
     } else if (std.mem.eql(u8, decl_name, "begin")) {
         try compileLibBeginBlock(vm, lib_env, types.cdr(declaration));
     } else if (std.mem.eql(u8, decl_name, "include") or std.mem.eql(u8, decl_name, "include-ci")) {
-        try compileLibInclude(vm, lib_env, types.cdr(declaration));
+        try compileLibInclude(vm, lib_env, types.cdr(declaration), std.mem.eql(u8, decl_name, "include-ci"));
     } else if (std.mem.eql(u8, decl_name, "include-library-declarations")) {
         try includeLibraryDeclarations(vm, lib_env, types.cdr(declaration), export_names, export_renames);
     } else if (std.mem.eql(u8, decl_name, "cond-expand")) {

--- a/tests/scheme/compliance/r7rs-expressions-gaps.scm
+++ b/tests/scheme/compliance/r7rs-expressions-gaps.scm
@@ -26,9 +26,8 @@
 
 ;; include-ci "reads each file as if it began with the #!fold-case
 ;; directive, while include does not." (p. 14)
-;; FAIL: #1141 (include-ci does not fold case — ci flag is discarded)
-;; (include-ci "fixtures/include-ci-upper.scm")
-;; (test-equal "include-ci folds case" 42 folded-value)
+(include-ci "fixtures/include-ci-upper.scm")
+(test-equal "include-ci folds case" 42 folded-value)
 
 ;; --- 4.2.1 Conditionals: cond ---
 ;; "If the selected <clause> contains only the <test> and no <expression>s,

--- a/tests/scheme/smoke/include-ci-1141.scm
+++ b/tests/scheme/smoke/include-ci-1141.scm
@@ -12,6 +12,13 @@
 (import (lib1141 ci-lib))
 (test-equal "library include-ci folds identifiers" 99 lib-folded-value)
 
+;; #!no-fold-case inside an include-ci'd file restores case sensitivity.
+;; The file defines no-fold-before (folded) then switches off folding and
+;; defines No-Fold-After (case-sensitive).
+(include-ci "lib1141/upper-with-nofold.scm")
+(test-equal "include-ci folds before #!no-fold-case" 10 no-fold-before)
+(test-equal "include-ci respects #!no-fold-case" 20 No-Fold-After)
+
 (let ((runner (test-runner-current)))
   (test-end "include-ci-1141")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/include-ci-1141.scm
+++ b/tests/scheme/smoke/include-ci-1141.scm
@@ -1,0 +1,17 @@
+;; Regression test for #1141: include-ci must fold case when reading files.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "include-ci-1141")
+
+;; Top-level include-ci: file defines (DEFINE Top-Level-Folded 77)
+(include-ci "lib1141/upper-toplevel.scm")
+(test-equal "top-level include-ci folds identifiers" 77 top-level-folded)
+
+;; Library include-ci: .sld uses (include-ci "upper-body.scm")
+;; which defines (DEFINE Lib-Folded-Value 99)
+(import (lib1141 ci-lib))
+(test-equal "library include-ci folds identifiers" 99 lib-folded-value)
+
+(let ((runner (test-runner-current)))
+  (test-end "include-ci-1141")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/lib1141/ci-lib.sld
+++ b/tests/scheme/smoke/lib1141/ci-lib.sld
@@ -1,0 +1,4 @@
+(define-library (lib1141 ci-lib)
+  (import (scheme base))
+  (export lib-folded-value)
+  (include-ci "upper-body.scm"))

--- a/tests/scheme/smoke/lib1141/upper-body.scm
+++ b/tests/scheme/smoke/lib1141/upper-body.scm
@@ -1,0 +1,2 @@
+;; Mixed-case: include-ci must fold this to lowercase.
+(DEFINE Lib-Folded-Value 99)

--- a/tests/scheme/smoke/lib1141/upper-toplevel.scm
+++ b/tests/scheme/smoke/lib1141/upper-toplevel.scm
@@ -1,0 +1,2 @@
+;; Mixed-case: include-ci must fold this to lowercase.
+(DEFINE Top-Level-Folded 77)

--- a/tests/scheme/smoke/lib1141/upper-with-nofold.scm
+++ b/tests/scheme/smoke/lib1141/upper-with-nofold.scm
@@ -1,0 +1,4 @@
+;; Starts folded (via include-ci), then #!no-fold-case restores case sensitivity.
+(DEFINE no-fold-before 10)
+#!no-fold-case
+(define No-Fold-After 20)


### PR DESCRIPTION
## Summary

Fixes #1141.

- Set `reader.fold_case = ci` in `handleTopLevelInclude` (top-level path) and `compileLibInclude` (library-declaration path) so `include-ci` reads files as if they began with `#!fold-case`, per R7RS 4.1.7.
- Enabled the disabled compliance test in `r7rs-expressions-gaps.scm`.
- Added regression test covering both top-level and `define-library` `include-ci`.

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1783 pass, 0 fail
- [x] New `include-ci-1141.scm` exercises top-level and library-context `include-ci` with mixed-case fixture files
- [x] Enabled compliance test (`include-ci folds case`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)