### PR TITLE
Desugar define-record-type in body contexts (R7RS §5.5)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -635,6 +635,7 @@ pub const Compiler = struct {
                 if (std.mem.eql(u8, effective_name, "if")) return passthrough.compileIf(self, args, dst, is_tail);
                 if (std.mem.eql(u8, effective_name, "lambda")) return self.compileLambda(args, dst, null);
                 if (std.mem.eql(u8, effective_name, "define")) return self.compileDefine(args, dst);
+                if (std.mem.eql(u8, effective_name, "define-record-type")) return self.compileDefineRecordType(args, dst);
                 if (std.mem.eql(u8, effective_name, "define-values")) return self.compileDefineValues(args, dst);
                 if (std.mem.eql(u8, effective_name, "set!")) return self.compileSet(args, dst);
                 if (std.mem.eql(u8, effective_name, "begin")) return self.compileBegin(args, dst, is_tail);
@@ -737,6 +738,10 @@ pub const Compiler = struct {
 
     fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
         return compiler_lambda.compileDefine(self, args, dst);
+    }
+
+    fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileError!void {
+        return compiler_lambda.compileDefineRecordType(self, args, dst);
     }
 
     fn compileDefineValues(self: *Compiler, args: Value, dst: u16) CompileError!void {

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -8,6 +8,7 @@ const compiler_lambda = @import("compiler_lambda.zig");
 const macro = @import("compiler_macro.zig");
 const globals_mod = @import("globals.zig");
 const ir_mod = @import("ir.zig");
+const vm_records = @import("vm_records.zig");
 const Value = types.Value;
 const OpCode = types.OpCode;
 const Compiler = compiler_mod.Compiler;
@@ -320,6 +321,29 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                                 }
                             }
                         }
+                    } else if (std.mem.eql(u8, form_name, "define-record-type")) {
+                        if (vm_records.parseRecordSpec(types.cdr(form))) |spec| {
+                            if (!globals.contains(spec.ctor_name)) {
+                                globals.put(spec.ctor_name, types.VOID) catch {};
+                                prescan_names.append(child.gc.allocator, spec.ctor_name) catch {};
+                            }
+                            if (!globals.contains(spec.pred_name)) {
+                                globals.put(spec.pred_name, types.VOID) catch {};
+                                prescan_names.append(child.gc.allocator, spec.pred_name) catch {};
+                            }
+                            for (0..spec.field_count) |fi| {
+                                if (!globals.contains(spec.accessor_names[fi])) {
+                                    globals.put(spec.accessor_names[fi], types.VOID) catch {};
+                                    prescan_names.append(child.gc.allocator, spec.accessor_names[fi]) catch {};
+                                }
+                                if (spec.mutator_names[fi]) |mn| {
+                                    if (!globals.contains(mn)) {
+                                        globals.put(mn, types.VOID) catch {};
+                                        prescan_names.append(child.gc.allocator, mn) catch {};
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -376,6 +400,8 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                         all_def_count += 1;
                     }
                 } else break;
+            } else if (std.mem.eql(u8, hn, "define-record-type")) {
+                vm_records.collectRecordTypeDefNames(child.gc, types.cdr(expr), all_def_names[0..], &all_def_count) catch break;
             } else if (!std.mem.eql(u8, hn, "define-syntax")) {
                 break;
             }
@@ -410,6 +436,18 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                 tx_obj.def_env_val = child.lib_env_val;
             }
             child.macros.put(ds_name, tx_val) catch return CompileError.OutOfMemory;
+            current = types.cdr(current);
+            continue;
+        }
+        if (std.mem.eql(u8, head_name, "define-record-type")) {
+            vm_records.expandRecordTypeDefines(
+                child.gc,
+                types.cdr(expr),
+                def_names[0..],
+                def_inits[0..],
+                &def_count,
+                &child.gc.extra_roots,
+            ) catch break;
             current = types.cdr(current);
             continue;
         }

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -401,7 +401,10 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                     }
                 } else break;
             } else if (std.mem.eql(u8, hn, "define-record-type")) {
-                vm_records.collectRecordTypeDefNames(child.gc, types.cdr(expr), all_def_names[0..], &all_def_count) catch break;
+                vm_records.collectRecordTypeDefNames(child.gc, types.cdr(expr), all_def_names[0..], &all_def_count) catch |err| switch (err) {
+                    CompileError.InvalidSyntax => break,
+                    else => return err,
+                };
             } else if (!std.mem.eql(u8, hn, "define-syntax")) {
                 break;
             }
@@ -447,7 +450,10 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                 def_inits[0..],
                 &def_count,
                 &child.gc.extra_roots,
-            ) catch break;
+            ) catch |err| switch (err) {
+                CompileError.InvalidSyntax => break,
+                else => return err,
+            };
             current = types.cdr(current);
             continue;
         }

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -237,7 +237,10 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
                     }
                 } else break;
             } else if (std.mem.eql(u8, hn, "define-record-type")) {
-                vm_records.collectRecordTypeDefNames(self.gc, types.cdr(expr), all_def_names[0..], &all_def_count) catch break;
+                vm_records.collectRecordTypeDefNames(self.gc, types.cdr(expr), all_def_names[0..], &all_def_count) catch |err| switch (err) {
+                    CompileError.InvalidSyntax => break,
+                    else => return err,
+                };
             } else if (!(opts.handle_define_syntax and std.mem.eql(u8, hn, "define-syntax"))) {
                 break;
             }
@@ -291,7 +294,10 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
                 def_inits[0..],
                 &def_count,
                 &self.gc.extra_roots,
-            ) catch break;
+            ) catch |err| switch (err) {
+                CompileError.InvalidSyntax => break,
+                else => return err,
+            };
         } else if (opts.handle_define_syntax and std.mem.eql(u8, head_name, "define-syntax")) {
             const ds_args = types.cdr(expr);
             if (ds_args == types.NIL or !types.isPair(ds_args)) break;
@@ -473,6 +479,116 @@ pub fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
     }
 
     return CompileError.InvalidSyntax;
+}
+
+/// General-dispatch handler for define-record-type.
+/// Builds define S-expressions and compiles each one, so that compileDefine's
+/// in_body_scope path creates local variables when appropriate.
+/// Covers positions the leading-define body scanner doesn't reach
+/// (e.g. let-values bodies, begin-splicing inside lambdas).
+pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileError!void {
+    const gc = self.gc;
+    const spec = vm_records.parseRecordSpec(args) orelse return CompileError.InvalidSyntax;
+    const internal_name = try vm_records.internRecordTypeName(gc, spec.type_name);
+
+    gc.no_collect += 1;
+    errdefer gc.no_collect -= 1;
+
+    const define_sym = gc.allocSymbol("define") catch return CompileError.OutOfMemory;
+
+    // Build all define forms as a list (consing in reverse)
+    var forms = types.NIL;
+
+    // Mutators (reverse order)
+    {
+        var fi = spec.field_count;
+        while (fi > 0) {
+            fi -= 1;
+            if (spec.mutator_names[fi]) |mn| {
+                const rs = gc.allocSymbol("%record-set!") catch return CompileError.OutOfMemory;
+                const p = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
+                const v = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
+                const idx = types.makeFixnum(@intCast(fi));
+                const body = gc.makeList(&[_]Value{ rs, p, idx, v }) catch return CompileError.OutOfMemory;
+                const np = gc.allocPair(gc.allocSymbol(mn) catch return CompileError.OutOfMemory, gc.makeList(&[_]Value{ p, v }) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+                forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, np, body }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
+            }
+        }
+    }
+
+    // Accessors (reverse order)
+    {
+        var fi = spec.field_count;
+        while (fi > 0) {
+            fi -= 1;
+            const rr = gc.allocSymbol("%record-ref") catch return CompileError.OutOfMemory;
+            const p = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
+            const idx = types.makeFixnum(@intCast(fi));
+            const body = gc.makeList(&[_]Value{ rr, p, idx }) catch return CompileError.OutOfMemory;
+            const np = gc.allocPair(gc.allocSymbol(spec.accessor_names[fi]) catch return CompileError.OutOfMemory, gc.makeList(&[_]Value{p}) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, np, body }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
+        }
+    }
+
+    // Predicate
+    {
+        const rc = gc.allocSymbol("%record?") catch return CompileError.OutOfMemory;
+        const v = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
+        const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
+        const body = gc.makeList(&[_]Value{ rc, v, rt_ref }) catch return CompileError.OutOfMemory;
+        const np = gc.allocPair(gc.allocSymbol(spec.pred_name) catch return CompileError.OutOfMemory, gc.makeList(&[_]Value{v}) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, np, body }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
+    }
+
+    // Constructor
+    {
+        const mr = gc.allocSymbol("%make-record") catch return CompileError.OutOfMemory;
+        const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
+        var body_elems: [258]Value = undefined;
+        body_elems[0] = mr;
+        body_elems[1] = rt_ref;
+        for (0..spec.field_count) |fi| {
+            var found = false;
+            for (0..spec.ctor_field_count) |ci| {
+                if (spec.ctor_field_indices[ci] == fi) {
+                    body_elems[2 + fi] = gc.allocSymbol(spec.ctor_fields[ci]) catch return CompileError.OutOfMemory;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                const if_sym = gc.allocSymbol("if") catch return CompileError.OutOfMemory;
+                body_elems[2 + fi] = gc.makeList(&[_]Value{ if_sym, types.FALSE, types.FALSE }) catch return CompileError.OutOfMemory;
+            }
+        }
+        const body = gc.makeList(body_elems[0 .. 2 + spec.field_count]) catch return CompileError.OutOfMemory;
+        var param_syms: [256]Value = undefined;
+        for (0..spec.ctor_field_count) |ci| {
+            param_syms[ci] = gc.allocSymbol(spec.ctor_fields[ci]) catch return CompileError.OutOfMemory;
+        }
+        const np = gc.allocPair(gc.allocSymbol(spec.ctor_name) catch return CompileError.OutOfMemory, gc.makeList(param_syms[0..spec.ctor_field_count]) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, np, body }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
+    }
+
+    // Internal record type: (define __rt (%make-record-type "name" n))
+    {
+        const mrt = gc.allocSymbol("%make-record-type") catch return CompileError.OutOfMemory;
+        const ns = gc.allocString(spec.type_name) catch return CompileError.OutOfMemory;
+        const nf = types.makeFixnum(@intCast(spec.field_count));
+        const init = gc.makeList(&[_]Value{ mrt, ns, nf }) catch return CompileError.OutOfMemory;
+        const rt_sym = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
+        forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, rt_sym, init }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
+    }
+
+    gc.no_collect -= 1;
+
+    gc.pushRoot(&forms);
+    defer gc.popRoot();
+    var current = forms;
+    while (current != types.NIL and types.isPair(current)) {
+        try self.compileExprViaIR(types.car(current), dst, false);
+        current = types.cdr(current);
+    }
 }
 
 pub fn compileDefineValues(self: *Compiler, args: Value, dst: u16) CompileError!void {

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -4,6 +4,7 @@ const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const globals_mod = @import("globals.zig");
 const macro = @import("compiler_macro.zig");
+const vm_records = @import("vm_records.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
@@ -146,6 +147,29 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
                                 }
                             }
                         }
+                    } else if (std.mem.eql(u8, form_name, "define-record-type")) {
+                        if (vm_records.parseRecordSpec(types.cdr(form))) |spec| {
+                            if (!globals.contains(spec.ctor_name)) {
+                                globals.put(spec.ctor_name, types.VOID) catch {};
+                                prescan_names.append(self.gc.allocator, spec.ctor_name) catch {};
+                            }
+                            if (!globals.contains(spec.pred_name)) {
+                                globals.put(spec.pred_name, types.VOID) catch {};
+                                prescan_names.append(self.gc.allocator, spec.pred_name) catch {};
+                            }
+                            for (0..spec.field_count) |fi| {
+                                if (!globals.contains(spec.accessor_names[fi])) {
+                                    globals.put(spec.accessor_names[fi], types.VOID) catch {};
+                                    prescan_names.append(self.gc.allocator, spec.accessor_names[fi]) catch {};
+                                }
+                                if (spec.mutator_names[fi]) |mn| {
+                                    if (!globals.contains(mn)) {
+                                        globals.put(mn, types.VOID) catch {};
+                                        prescan_names.append(self.gc.allocator, mn) catch {};
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -212,6 +236,8 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
                         all_def_count += 1;
                     }
                 } else break;
+            } else if (std.mem.eql(u8, hn, "define-record-type")) {
+                vm_records.collectRecordTypeDefNames(self.gc, types.cdr(expr), all_def_names[0..], &all_def_count) catch break;
             } else if (!(opts.handle_define_syntax and std.mem.eql(u8, hn, "define-syntax"))) {
                 break;
             }
@@ -257,6 +283,15 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
             } else {
                 break;
             }
+        } else if (std.mem.eql(u8, head_name, "define-record-type")) {
+            vm_records.expandRecordTypeDefines(
+                self.gc,
+                types.cdr(expr),
+                def_names_arr[0..],
+                def_inits[0..],
+                &def_count,
+                &self.gc.extra_roots,
+            ) catch break;
         } else if (opts.handle_define_syntax and std.mem.eql(u8, head_name, "define-syntax")) {
             const ds_args = types.cdr(expr);
             if (ds_args == types.NIL or !types.isPair(ds_args)) break;

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -12,86 +12,15 @@ const VMError = vm_mod.VMError;
 
 /// Handle (define-record-type name (ctor field ...) pred (field accessor [mutator]) ...)
 /// Desugars into define forms using internal record primitives.
+/// Used for top-level and library-body contexts (VM interpreter path).
 pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
-    // Parse: name
-    if (!types.isPair(args)) return VMError.CompileError;
-    const type_name_sym = types.car(args);
-    if (!types.isSymbol(type_name_sym)) return VMError.CompileError;
-    const type_name = types.symbolName(type_name_sym);
+    const spec = parseRecordSpec(args) orelse return VMError.CompileError;
 
-    // Parse: (constructor field ...)
-    const rest1 = types.cdr(args);
-    if (!types.isPair(rest1)) return VMError.CompileError;
-    const ctor_spec = types.car(rest1);
-    if (!types.isPair(ctor_spec)) return VMError.CompileError;
-    const ctor_name_sym = types.car(ctor_spec);
-    if (!types.isSymbol(ctor_name_sym)) return VMError.CompileError;
-    const ctor_name = types.symbolName(ctor_name_sym);
-
-    // Collect constructor field names (order matters: these are the args to the constructor)
-    var ctor_fields: [256][]const u8 = undefined;
-    var ctor_field_count: usize = 0;
-    var cf = types.cdr(ctor_spec);
-    while (cf != types.NIL) {
-        if (!types.isPair(cf)) return VMError.CompileError;
-        const field_sym = types.car(cf);
-        if (!types.isSymbol(field_sym)) return VMError.CompileError;
-        if (ctor_field_count >= 256) return VMError.CompileError;
-        ctor_fields[ctor_field_count] = types.symbolName(field_sym);
-        ctor_field_count += 1;
-        cf = types.cdr(cf);
-    }
-
-    // Parse: predicate name
-    const rest2 = types.cdr(rest1);
-    if (!types.isPair(rest2)) return VMError.CompileError;
-    const pred_name_sym = types.car(rest2);
-    if (!types.isSymbol(pred_name_sym)) return VMError.CompileError;
-    const pred_name = types.symbolName(pred_name_sym);
-
-    // Collect all field specs to determine field_names and total field count
-    // Field specs: (field-name accessor [mutator])
-    var all_field_names: [256][]const u8 = undefined;
-    var all_field_count: usize = 0;
-    var accessor_names: [256][]const u8 = undefined;
-    var mutator_names: [256]?[]const u8 = undefined;
-
-    var field_specs = types.cdr(rest2);
-    while (field_specs != types.NIL) {
-        if (!types.isPair(field_specs)) return VMError.CompileError;
-        const spec = types.car(field_specs);
-        if (!types.isPair(spec)) return VMError.CompileError;
-
-        // (field-name accessor [mutator])
-        const fname_sym = types.car(spec);
-        if (!types.isSymbol(fname_sym)) return VMError.CompileError;
-        if (all_field_count >= 256) return VMError.CompileError;
-        const fname = types.symbolName(fname_sym);
-        for (all_field_names[0..all_field_count]) |existing| {
-            if (std.mem.eql(u8, existing, fname)) return VMError.CompileError;
-        }
-        all_field_names[all_field_count] = fname;
-
-        const spec_rest = types.cdr(spec);
-        if (!types.isPair(spec_rest)) return VMError.CompileError;
-        const acc_sym = types.car(spec_rest);
-        if (!types.isSymbol(acc_sym)) return VMError.CompileError;
-        accessor_names[all_field_count] = types.symbolName(acc_sym);
-
-        // Optional mutator
-        const spec_rest2 = types.cdr(spec_rest);
-        if (spec_rest2 != types.NIL and types.isPair(spec_rest2)) {
-            const mut_sym = types.car(spec_rest2);
-            if (!types.isSymbol(mut_sym)) return VMError.CompileError;
-            mutator_names[all_field_count] = types.symbolName(mut_sym);
-            if (types.cdr(spec_rest2) != types.NIL) return VMError.CompileError;
-        } else {
-            mutator_names[all_field_count] = null;
-        }
-
-        all_field_count += 1;
-        field_specs = types.cdr(field_specs);
-    }
+    const type_name = spec.type_name;
+    const ctor_name = spec.ctor_name;
+    const pred_name = spec.pred_name;
+    const all_field_count = spec.field_count;
+    const ctor_field_count = spec.ctor_field_count;
 
     const num_fields: u8 = @intCast(all_field_count);
 
@@ -103,28 +32,12 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
     // Store in a global with an internal name (space prefix prevents user access)
     const internal_name_buf = std.fmt.allocPrint(vm.gc.allocator, " __record_type_{s}", .{type_name}) catch return VMError.OutOfMemory;
     defer vm.gc.allocator.free(internal_name_buf);
-    // Intern the name via allocSymbol so it persists
     const internal_sym = vm.gc.allocSymbol(internal_name_buf) catch return VMError.OutOfMemory;
     const internal_name = types.symbolName(internal_sym);
     if (vm.current_lib_env) |lib_env| {
         lib_env.put(internal_name, rt_val) catch return VMError.OutOfMemory;
     } else {
-        // Locked structural put + version bump (#958).
         vm.defineGlobal(internal_name, rt_val) catch return VMError.OutOfMemory;
-    }
-
-    // Map constructor field names to their indices in the all_fields array
-    var ctor_field_indices: [256]usize = undefined;
-    for (0..ctor_field_count) |ci| {
-        var found = false;
-        for (0..all_field_count) |fi| {
-            if (std.mem.eql(u8, ctor_fields[ci], all_field_names[fi])) {
-                ctor_field_indices[ci] = fi;
-                found = true;
-                break;
-            }
-        }
-        if (!found) return VMError.CompileError;
     }
 
     // Generate constructor:
@@ -152,8 +65,8 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         for (0..all_field_count) |fi| {
             var found_in_ctor = false;
             for (0..ctor_field_count) |ci| {
-                if (ctor_field_indices[ci] == fi) {
-                    body_args[2 + fi] = vm.gc.allocSymbol(ctor_fields[ci]) catch return VMError.OutOfMemory;
+                if (spec.ctor_field_indices[ci] == fi) {
+                    body_args[2 + fi] = vm.gc.allocSymbol(spec.ctor_fields[ci]) catch return VMError.OutOfMemory;
                     found_in_ctor = true;
                     break;
                 }
@@ -172,7 +85,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         // Build parameter list
         var param_syms: [256]Value = undefined;
         for (0..ctor_field_count) |ci| {
-            param_syms[ci] = vm.gc.allocSymbol(ctor_fields[ci]) catch return VMError.OutOfMemory;
+            param_syms[ci] = vm.gc.allocSymbol(spec.ctor_fields[ci]) catch return VMError.OutOfMemory;
         }
         const params = vm.gc.makeList(param_syms[0..ctor_field_count]) catch return VMError.OutOfMemory;
 
@@ -231,7 +144,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             errdefer vm.gc.no_collect -= 1;
             const define_sym = vm.gc.allocSymbol("define") catch return VMError.OutOfMemory;
             const p_sym = vm.gc.allocSymbol("p") catch return VMError.OutOfMemory;
-            const acc_sym = vm.gc.allocSymbol(accessor_names[fi]) catch return VMError.OutOfMemory;
+            const acc_sym = vm.gc.allocSymbol(spec.accessor_names[fi]) catch return VMError.OutOfMemory;
             const record_ref_sym = vm.gc.allocSymbol("%record-ref") catch return VMError.OutOfMemory;
             const idx_val = types.makeFixnum(@intCast(fi));
 
@@ -252,7 +165,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         }
 
         // Mutator (if specified): (define (mutator p v) (%record-set! p <index> v))
-        if (mutator_names[fi]) |mut_name| {
+        if (spec.mutator_names[fi]) |mut_name| {
             vm.gc.no_collect += 1;
             errdefer vm.gc.no_collect -= 1;
             const define_sym = vm.gc.allocSymbol("define") catch return VMError.OutOfMemory;
@@ -384,7 +297,7 @@ pub fn parseRecordSpec(args: Value) ?RecordSpec {
     return spec;
 }
 
-fn internRecordTypeName(gc: *GC, type_name: []const u8) CompileError![]const u8 {
+pub fn internRecordTypeName(gc: *GC, type_name: []const u8) CompileError![]const u8 {
     const buf = std.fmt.allocPrint(gc.allocator, " __record_type_{s}", .{type_name}) catch
         return CompileError.OutOfMemory;
     defer gc.allocator.free(buf);

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
 const types = @import("types.zig");
 const compiler_mod = @import("compiler.zig");
+const memory = @import("memory.zig");
 const Value = types.Value;
+const GC = memory.GC;
+const CompileError = compiler_mod.CompileError;
 
 const vm_mod = @import("vm.zig");
 const VM = vm_mod.VM;
@@ -277,4 +280,271 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
     }
 
     return types.VOID;
+}
+
+// --- Body-context define-record-type expansion ---
+
+pub const RecordSpec = struct {
+    type_name: []const u8,
+    ctor_name: []const u8,
+    ctor_fields: [256][]const u8,
+    ctor_field_count: usize,
+    pred_name: []const u8,
+    field_names: [256][]const u8,
+    field_count: usize,
+    accessor_names: [256][]const u8,
+    mutator_names: [256]?[]const u8,
+    ctor_field_indices: [256]usize,
+};
+
+/// Parse (define-record-type name (ctor field...) pred (field acc [mut])...)
+/// args is the cdr of the full form (everything after 'define-record-type').
+/// Returns null on malformed input.
+pub fn parseRecordSpec(args: Value) ?RecordSpec {
+    if (!types.isPair(args)) return null;
+    const type_name_sym = types.car(args);
+    if (!types.isSymbol(type_name_sym)) return null;
+
+    var spec: RecordSpec = undefined;
+    spec.type_name = types.symbolName(type_name_sym);
+
+    const rest1 = types.cdr(args);
+    if (!types.isPair(rest1)) return null;
+    const ctor_spec = types.car(rest1);
+    if (!types.isPair(ctor_spec)) return null;
+    const ctor_name_sym = types.car(ctor_spec);
+    if (!types.isSymbol(ctor_name_sym)) return null;
+    spec.ctor_name = types.symbolName(ctor_name_sym);
+
+    spec.ctor_field_count = 0;
+    var cf = types.cdr(ctor_spec);
+    while (cf != types.NIL) {
+        if (!types.isPair(cf)) return null;
+        const fsym = types.car(cf);
+        if (!types.isSymbol(fsym)) return null;
+        if (spec.ctor_field_count >= 256) return null;
+        spec.ctor_fields[spec.ctor_field_count] = types.symbolName(fsym);
+        spec.ctor_field_count += 1;
+        cf = types.cdr(cf);
+    }
+
+    const rest2 = types.cdr(rest1);
+    if (!types.isPair(rest2)) return null;
+    const pred_sym = types.car(rest2);
+    if (!types.isSymbol(pred_sym)) return null;
+    spec.pred_name = types.symbolName(pred_sym);
+
+    spec.field_count = 0;
+    var fs = types.cdr(rest2);
+    while (fs != types.NIL) {
+        if (!types.isPair(fs)) return null;
+        const fspec = types.car(fs);
+        if (!types.isPair(fspec)) return null;
+        const fname_sym = types.car(fspec);
+        if (!types.isSymbol(fname_sym)) return null;
+        if (spec.field_count >= 256) return null;
+        const fname = types.symbolName(fname_sym);
+        for (spec.field_names[0..spec.field_count]) |existing| {
+            if (std.mem.eql(u8, existing, fname)) return null;
+        }
+        spec.field_names[spec.field_count] = fname;
+
+        const spec_rest = types.cdr(fspec);
+        if (!types.isPair(spec_rest)) return null;
+        const acc_sym = types.car(spec_rest);
+        if (!types.isSymbol(acc_sym)) return null;
+        spec.accessor_names[spec.field_count] = types.symbolName(acc_sym);
+
+        const spec_rest2 = types.cdr(spec_rest);
+        if (spec_rest2 != types.NIL and types.isPair(spec_rest2)) {
+            const mut_sym = types.car(spec_rest2);
+            if (!types.isSymbol(mut_sym)) return null;
+            spec.mutator_names[spec.field_count] = types.symbolName(mut_sym);
+            if (types.cdr(spec_rest2) != types.NIL) return null;
+        } else {
+            spec.mutator_names[spec.field_count] = null;
+        }
+
+        spec.field_count += 1;
+        fs = types.cdr(fs);
+    }
+
+    for (0..spec.ctor_field_count) |ci| {
+        var found = false;
+        for (0..spec.field_count) |fi| {
+            if (std.mem.eql(u8, spec.ctor_fields[ci], spec.field_names[fi])) {
+                spec.ctor_field_indices[ci] = fi;
+                found = true;
+                break;
+            }
+        }
+        if (!found) return null;
+    }
+
+    return spec;
+}
+
+fn internRecordTypeName(gc: *GC, type_name: []const u8) CompileError![]const u8 {
+    const buf = std.fmt.allocPrint(gc.allocator, " __record_type_{s}", .{type_name}) catch
+        return CompileError.OutOfMemory;
+    defer gc.allocator.free(buf);
+    const sym = gc.allocSymbol(buf) catch return CompileError.OutOfMemory;
+    return types.symbolName(sym);
+}
+
+/// Collect all names that a define-record-type form defines.
+/// Used in the first pass of body scanning for macro visibility.
+pub fn collectRecordTypeDefNames(
+    gc: *GC,
+    form_args: Value,
+    names: [][]const u8,
+    count: *usize,
+) CompileError!void {
+    const spec = parseRecordSpec(form_args) orelse return CompileError.InvalidSyntax;
+    const internal_name = try internRecordTypeName(gc, spec.type_name);
+
+    var needed: usize = 3 + spec.field_count;
+    for (0..spec.field_count) |fi| {
+        if (spec.mutator_names[fi] != null) needed += 1;
+    }
+    if (count.* + needed > names.len) return CompileError.TooManyLocals;
+
+    names[count.*] = internal_name;
+    count.* += 1;
+    names[count.*] = spec.ctor_name;
+    count.* += 1;
+    names[count.*] = spec.pred_name;
+    count.* += 1;
+    for (0..spec.field_count) |fi| {
+        names[count.*] = spec.accessor_names[fi];
+        count.* += 1;
+        if (spec.mutator_names[fi]) |mn| {
+            names[count.*] = mn;
+            count.* += 1;
+        }
+    }
+}
+
+/// Expand a define-record-type form into equivalent define entries.
+/// Appends names and init S-expressions to the provided arrays.
+pub fn expandRecordTypeDefines(
+    gc: *GC,
+    form_args: Value,
+    def_names: [][]const u8,
+    def_inits: []Value,
+    count: *usize,
+    extra_roots: *std.ArrayList(Value),
+) CompileError!void {
+    const spec = parseRecordSpec(form_args) orelse return CompileError.InvalidSyntax;
+    const internal_name = try internRecordTypeName(gc, spec.type_name);
+
+    var needed: usize = 3 + spec.field_count;
+    for (0..spec.field_count) |fi| {
+        if (spec.mutator_names[fi] != null) needed += 1;
+    }
+    if (count.* + needed > def_names.len) return CompileError.TooManyLocals;
+
+    const saved_count = count.*;
+    errdefer count.* = saved_count;
+
+    gc.no_collect += 1;
+    errdefer gc.no_collect -= 1;
+
+    // 1. (define __rt (%make-record-type "name" num_fields))
+    {
+        const mrt_sym = gc.allocSymbol("%make-record-type") catch return CompileError.OutOfMemory;
+        const name_str = gc.allocString(spec.type_name) catch return CompileError.OutOfMemory;
+        const nf_val = types.makeFixnum(@intCast(spec.field_count));
+        def_inits[count.*] = gc.makeList(&[_]Value{ mrt_sym, name_str, nf_val }) catch return CompileError.OutOfMemory;
+        def_names[count.*] = internal_name;
+        extra_roots.append(gc.allocator, def_inits[count.*]) catch return CompileError.OutOfMemory;
+        count.* += 1;
+    }
+
+    // 2. (define (ctor f1 f2) (%make-record __rt f_for_0 f_for_1 ...))
+    {
+        const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+        const mr_sym = gc.allocSymbol("%make-record") catch return CompileError.OutOfMemory;
+        const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
+
+        var body_elems: [258]Value = undefined;
+        body_elems[0] = mr_sym;
+        body_elems[1] = rt_ref;
+        for (0..spec.field_count) |fi| {
+            var found = false;
+            for (0..spec.ctor_field_count) |ci| {
+                if (spec.ctor_field_indices[ci] == fi) {
+                    body_elems[2 + fi] = gc.allocSymbol(spec.ctor_fields[ci]) catch return CompileError.OutOfMemory;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                const if_sym = gc.allocSymbol("if") catch return CompileError.OutOfMemory;
+                body_elems[2 + fi] = gc.makeList(&[_]Value{ if_sym, types.FALSE, types.FALSE }) catch return CompileError.OutOfMemory;
+            }
+        }
+        const body = gc.makeList(body_elems[0 .. 2 + spec.field_count]) catch return CompileError.OutOfMemory;
+
+        var param_syms: [256]Value = undefined;
+        for (0..spec.ctor_field_count) |ci| {
+            param_syms[ci] = gc.allocSymbol(spec.ctor_fields[ci]) catch return CompileError.OutOfMemory;
+        }
+        const params = gc.makeList(param_syms[0..spec.ctor_field_count]) catch return CompileError.OutOfMemory;
+
+        def_inits[count.*] = gc.makeList(&[_]Value{ lambda_sym, params, body }) catch return CompileError.OutOfMemory;
+        def_names[count.*] = spec.ctor_name;
+        extra_roots.append(gc.allocator, def_inits[count.*]) catch return CompileError.OutOfMemory;
+        count.* += 1;
+    }
+
+    // 3. (define (pred? v) (%record? v __rt))
+    {
+        const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+        const rc_sym = gc.allocSymbol("%record?") catch return CompileError.OutOfMemory;
+        const v_sym = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
+        const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
+
+        const body = gc.makeList(&[_]Value{ rc_sym, v_sym, rt_ref }) catch return CompileError.OutOfMemory;
+        const params = gc.makeList(&[_]Value{v_sym}) catch return CompileError.OutOfMemory;
+        def_inits[count.*] = gc.makeList(&[_]Value{ lambda_sym, params, body }) catch return CompileError.OutOfMemory;
+        def_names[count.*] = spec.pred_name;
+        extra_roots.append(gc.allocator, def_inits[count.*]) catch return CompileError.OutOfMemory;
+        count.* += 1;
+    }
+
+    // 4. Accessors: (define (acc p) (%record-ref p idx))
+    for (0..spec.field_count) |fi| {
+        const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+        const rr_sym = gc.allocSymbol("%record-ref") catch return CompileError.OutOfMemory;
+        const p_sym = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
+        const idx = types.makeFixnum(@intCast(fi));
+
+        const body = gc.makeList(&[_]Value{ rr_sym, p_sym, idx }) catch return CompileError.OutOfMemory;
+        const params = gc.makeList(&[_]Value{p_sym}) catch return CompileError.OutOfMemory;
+        def_inits[count.*] = gc.makeList(&[_]Value{ lambda_sym, params, body }) catch return CompileError.OutOfMemory;
+        def_names[count.*] = spec.accessor_names[fi];
+        extra_roots.append(gc.allocator, def_inits[count.*]) catch return CompileError.OutOfMemory;
+        count.* += 1;
+    }
+
+    // 5. Mutators: (define (mut! p v) (%record-set! p idx v))
+    for (0..spec.field_count) |fi| {
+        if (spec.mutator_names[fi]) |mname| {
+            const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
+            const rs_sym = gc.allocSymbol("%record-set!") catch return CompileError.OutOfMemory;
+            const p_sym = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
+            const v_sym = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
+            const idx = types.makeFixnum(@intCast(fi));
+
+            const body = gc.makeList(&[_]Value{ rs_sym, p_sym, idx, v_sym }) catch return CompileError.OutOfMemory;
+            const params = gc.makeList(&[_]Value{ p_sym, v_sym }) catch return CompileError.OutOfMemory;
+            def_inits[count.*] = gc.makeList(&[_]Value{ lambda_sym, params, body }) catch return CompileError.OutOfMemory;
+            def_names[count.*] = mname;
+            extra_roots.append(gc.allocator, def_inits[count.*]) catch return CompileError.OutOfMemory;
+            count.* += 1;
+        }
+    }
+
+    gc.no_collect -= 1;
 }

--- a/tests/scheme/smoke/560-record-body.scm
+++ b/tests/scheme/smoke/560-record-body.scm
@@ -89,6 +89,20 @@
     (define-record-type lr (mk-lr v) lr? (v lr-v))
     (lr-v (mk-lr (f 3)))))
 
+;;; let-values body (R7RS §5.3.2)
+(test-equal "record in let-values body"
+  3
+  (let-values (((a b) (values 1 2)))
+    (define-record-type lv (mk-lv v) lv? (v lv-v))
+    (lv-v (mk-lv (+ a b)))))
+
+;;; let*-values body
+(test-equal "record in let*-values body"
+  10
+  (let*-values (((x) (values 10)))
+    (define-record-type lsv (mk-lsv v) lsv? (v lsv-v))
+    (lsv-v (mk-lsv x))))
+
 (let ((runner (test-runner-current)))
   (test-end "560-record-body")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/560-record-body.scm
+++ b/tests/scheme/smoke/560-record-body.scm
@@ -1,0 +1,94 @@
+;; Regression test for #560: define-record-type in body contexts
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "560-record-body")
+
+;;; let body
+(test-equal "record in let body"
+  42
+  (let ()
+    (define-record-type pt (make-pt x) pt? (x get-x))
+    (get-x (make-pt 42))))
+
+;;; lambda body
+(test-equal "record in lambda body"
+  7
+  ((lambda ()
+     (define-record-type lb (mk-lb v) lb? (v lb-v))
+     (lb-v (mk-lb 7)))))
+
+;;; multiple fields
+(test-equal "record with multiple fields in body"
+  '(1 2)
+  (let ()
+    (define-record-type pair2 (mk a b) pair2? (a get-a) (b get-b))
+    (let ((p (mk 1 2)))
+      (list (get-a p) (get-b p)))))
+
+;;; mutator in body
+(test-equal "record with mutator in body"
+  99
+  (let ()
+    (define-record-type cell (mk-cell v) cell? (v cell-val set-cell-val!))
+    (let ((c (mk-cell 0)))
+      (set-cell-val! c 99)
+      (cell-val c))))
+
+;;; predicate in body
+(test-assert "record predicate in body"
+  (let ()
+    (define-record-type tag (mk-tag) tag?)
+    (tag? (mk-tag))))
+
+(test-assert "record predicate negative"
+  (let ()
+    (define-record-type tag2 (mk-tag2) tag2?)
+    (not (tag2? 42))))
+
+;;; nested let: inner record type does not leak
+(test-equal "nested records are independent"
+  '(10 20)
+  (let ()
+    (define-record-type outer (mk-o v) outer? (v o-v))
+    (let ()
+      (define-record-type inner (mk-i v) inner? (v i-v))
+      (list (o-v (mk-o 10)) (i-v (mk-i 20))))))
+
+;;; generative pattern: fresh record type per call
+(test-assert "generative record types are distinct"
+  (let ()
+    (define (make-fresh)
+      (define-record-type gen (mk-gen) gen?)
+      (cons mk-gen gen?))
+    (let ((a (make-fresh))
+          (b (make-fresh)))
+      (not ((cdr b) ((car a)))))))
+
+;;; record with define-syntax sibling in body
+(test-equal "record with define-syntax in body"
+  5
+  (let ()
+    (define-record-type ds-rec (mk-ds v) ds-rec? (v ds-val))
+    (define-syntax ds-get
+      (syntax-rules ()
+        ((_ r) (ds-val r))))
+    (ds-get (mk-ds 5))))
+
+;;; constructor field order differs from field spec order
+(test-equal "constructor field reordering in body"
+  '(2 1)
+  (let ()
+    (define-record-type swapped (mk-sw b a) swapped? (a sw-a) (b sw-b))
+    (let ((s (mk-sw 1 2)))
+      (list (sw-a s) (sw-b s)))))
+
+;;; letrec body
+(test-equal "record in letrec body"
+  3
+  (letrec ((f (lambda (x) x)))
+    (define-record-type lr (mk-lr v) lr? (v lr-v))
+    (lr-v (mk-lr (f 3)))))
+
+(let ((runner (test-runner-current)))
+  (test-end "560-record-body")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi9.scm
+++ b/tests/scheme/srfi/srfi9.scm
@@ -107,10 +107,9 @@
   (define-record-type bt (mk-bt v) bt? (v bt-v))
   (test 7 (bt-v (mk-bt 7))))
 
-;; ...but inside a <body> it is compiled as an expression and fails:
-;; FAIL: #560 (define-record-type not desugared in lambda/let bodies)
-;; (test 8 (let ()
-;;           (define-record-type lt (mk-lt v) lt? (v lt-v))
-;;           (lt-v (mk-lt 8))))
+;;; --- define-record-type inside a <body> (R7RS 5.5: body context) ---
+(test 8 (let ()
+          (define-record-type lt (mk-lt v) lt? (v lt-v))
+          (lt-v (mk-lt 8))))
 
 (test-end "srfi-9")


### PR DESCRIPTION
Fixes #560

## Summary

- `define-record-type` now works inside `let`, `lambda`, `letrec`, and other body contexts, as required by R7RS §5.5
- Desugars into equivalent `define` forms using existing `%make-record-type`, `%make-record`, `%record?`, `%record-ref`, `%record-set!` primitives
- The desugared defines enter the existing letrec* body-scanning machinery, so scoping is correct in all contexts
- Updated both body scanners (legacy in `compiler_lambda.zig` and IR path in `compiler_ir.zig`) plus globals prescans

## Test plan

- [x] Enabled previously disabled SRFI-9 body test (37/37 pass)
- [x] New `560-record-body.scm` regression test (11 cases: let, lambda, nested, mutators, predicates, generative pattern, field reordering, define-syntax interaction, letrec)
- [x] GC stress test (`-Dgc-stress=true`) passes
- [x] Full R7RS suite (1395 pass, 0 fail)
- [x] Full `run-all.sh` (1783 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)