### PR TITLE
Separate let-syntax from letrec-syntax scoping (#1140)

### DIFF
--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -202,10 +202,14 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
     // Temporarily swap sibling keywords to their outer values.
     const peer_names = tx.let_syntax_peer_names;
     const peer_outer = tx.let_syntax_peer_vals;
-    var saved_peer: [32]?Value = undefined;
-    if (peer_names.len > 0 and peer_names.len <= 32) {
+    const saved_peer = if (peer_names.len > 0)
+        self.gc.allocator.alloc(?Value, peer_names.len) catch null
+    else
+        null;
+    defer if (saved_peer) |sp| self.gc.allocator.free(sp);
+    if (saved_peer) |sp| {
         for (peer_names, peer_outer, 0..) |pn, pv, i| {
-            saved_peer[i] = self.macros.get(pn);
+            sp[i] = self.macros.get(pn);
             if (pv != types.NIL) {
                 self.macros.put(pn, pv) catch {};
             } else {
@@ -214,9 +218,9 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
         }
     }
     const result_err = self.compileExpr(expanded_root, dst, is_tail);
-    if (peer_names.len > 0 and peer_names.len <= 32) {
+    if (saved_peer) |sp| {
         for (peer_names, 0..) |pn, i| {
-            if (saved_peer[i]) |old| {
+            if (sp[i]) |old| {
                 self.macros.put(pn, old) catch {};
             } else {
                 _ = self.macros.remove(pn);
@@ -276,9 +280,10 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
 
     // Phase 1: Parse ALL transformer specs before registering any.
     // self.macros still has the outer values during this phase.
-    var kw_names: [32][]const u8 = undefined;
-    var tx_vals: [32]Value = undefined;
-    var bind_n: usize = 0;
+    var kw_names: std.ArrayList([]const u8) = .empty;
+    defer kw_names.deinit(self.gc.allocator);
+    var tx_vals: std.ArrayList(Value) = .empty;
+    defer tx_vals.deinit(self.gc.allocator);
     var roots_pushed: usize = 0;
 
     var binding_list = bindings;
@@ -291,22 +296,23 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         const binding_rest = types.cdr(binding);
         if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
         const transformer_spec = types.car(binding_rest);
-        if (bind_n >= 32) return CompileError.InvalidSyntax;
-        tx_vals[bind_n] = parseSyntaxRules(self, transformer_spec, &.{}) catch return CompileError.InvalidSyntax;
-        self.gc.pushRoot(&tx_vals[bind_n]);
+        tx_vals.append(self.gc.allocator, parseSyntaxRules(self, transformer_spec, &.{}) catch
+            return CompileError.InvalidSyntax) catch return CompileError.OutOfMemory;
+        self.gc.pushRoot(&tx_vals.items[tx_vals.items.len - 1]);
         roots_pushed += 1;
-        kw_names[bind_n] = types.symbolName(keyword);
-        bind_n += 1;
+        kw_names.append(self.gc.allocator, types.symbolName(keyword)) catch return CompileError.OutOfMemory;
         binding_list = types.cdr(binding_list);
     }
     defer for (0..roots_pushed) |_| self.gc.popRoot();
 
     // Build peer snapshot: each keyword's outer macro value (NIL = unbound).
-    // Computed once before registration, duped per transformer so each
-    // owns its own copy (avoids double-free when GC cleans up).
-    var peer_snap_names: [32][]const u8 = undefined;
-    var peer_snap_vals: [32]Value = undefined;
-    for (kw_names[0..bind_n], 0..) |name, i| {
+    // Duped per transformer so each owns its own copy.
+    const bind_n = kw_names.items.len;
+    const peer_snap_names = self.gc.allocator.alloc([]const u8, bind_n) catch return CompileError.OutOfMemory;
+    defer self.gc.allocator.free(peer_snap_names);
+    const peer_snap_vals = self.gc.allocator.alloc(Value, bind_n) catch return CompileError.OutOfMemory;
+    defer self.gc.allocator.free(peer_snap_vals);
+    for (kw_names.items, 0..) |name, i| {
         peer_snap_names[i] = name;
         peer_snap_vals[i] = self.macros.get(name) orelse types.NIL;
     }
@@ -317,47 +323,18 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
     var saved_values: std.ArrayList(?Value) = .empty;
     defer saved_values.deinit(self.gc.allocator);
 
-    for (kw_names[0..bind_n], tx_vals[0..bind_n]) |name, transformer| {
+    for (kw_names.items, tx_vals.items) |name, transformer| {
         saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
-
+        captureLocalsOnTransformer(self, transformer);
         const tx = types.toObject(transformer).as(types.Transformer);
-        if (self.locals.items.len > 0) {
-            const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return CompileError.OutOfMemory;
-            for (self.locals.items, 0..) |local, ci| {
-                caps[ci] = .{ .name = local.name, .slot = local.slot };
-            }
-            tx.captured_locals = caps;
-        }
-        tx.let_syntax_peer_names = self.gc.allocator.dupe([]const u8, peer_snap_names[0..bind_n]) catch return CompileError.OutOfMemory;
-        tx.let_syntax_peer_vals = self.gc.allocator.dupe(Value, peer_snap_vals[0..bind_n]) catch return CompileError.OutOfMemory;
+        tx.let_syntax_peer_names = self.gc.allocator.dupe([]const u8, peer_snap_names) catch return CompileError.OutOfMemory;
+        tx.let_syntax_peer_vals = self.gc.allocator.dupe(Value, peer_snap_vals) catch return CompileError.OutOfMemory;
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
     }
 
-    self.beginScope();
-    const saved_body_scope = self.in_body_scope;
-    self.in_body_scope = true;
-    const macro_mark = self.beginBodyMacroScope();
-    errdefer self.endBodyMacroScope(macro_mark) catch {};
-    var current = body;
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const expr = types.car(current);
-        current = types.cdr(current);
-        const tail = is_tail and current == types.NIL;
-        try self.compileExprViaIR(expr, dst, tail);
-    }
-    try self.endBodyMacroScope(macro_mark);
-    self.in_body_scope = saved_body_scope;
-    self.endScope();
-
-    for (saved_names.items, saved_values.items) |name, saved_val| {
-        if (saved_val) |old_val| {
-            try self.macros.put(name, old_val);
-        } else {
-            _ = self.macros.remove(name);
-        }
-    }
+    try compileSyntaxBody(self, body, dst, is_tail);
+    restoreMacros(self, saved_names.items, saved_values.items);
 }
 
 pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
@@ -386,19 +363,26 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
 
         saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
-
-        if (self.locals.items.len > 0) {
-            const tx = types.toObject(transformer).as(types.Transformer);
-            const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return CompileError.OutOfMemory;
-            for (self.locals.items, 0..) |local, ci| {
-                caps[ci] = .{ .name = local.name, .slot = local.slot };
-            }
-            tx.captured_locals = caps;
-        }
+        captureLocalsOnTransformer(self, transformer);
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
         binding_list = types.cdr(binding_list);
     }
 
+    try compileSyntaxBody(self, body, dst, is_tail);
+    restoreMacros(self, saved_names.items, saved_values.items);
+}
+
+fn captureLocalsOnTransformer(self: *Compiler, transformer: Value) void {
+    if (self.locals.items.len == 0) return;
+    const tx = types.toObject(transformer).as(types.Transformer);
+    const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return;
+    for (self.locals.items, 0..) |local, ci| {
+        caps[ci] = .{ .name = local.name, .slot = local.slot };
+    }
+    tx.captured_locals = caps;
+}
+
+fn compileSyntaxBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) CompileError!void {
     self.beginScope();
     const saved_body_scope = self.in_body_scope;
     self.in_body_scope = true;
@@ -415,10 +399,12 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
     try self.endBodyMacroScope(macro_mark);
     self.in_body_scope = saved_body_scope;
     self.endScope();
+}
 
-    for (saved_names.items, saved_values.items) |name, saved_val| {
+fn restoreMacros(self: *Compiler, names: [][]const u8, values: []?Value) void {
+    for (names, values) |name, saved_val| {
         if (saved_val) |old_val| {
-            try self.macros.put(name, old_val);
+            self.macros.put(name, old_val) catch {};
         } else {
             _ = self.macros.remove(name);
         }

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -202,8 +202,9 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
     // Temporarily swap sibling keywords to their outer values.
     const peer_names = tx.let_syntax_peer_names;
     const peer_outer = tx.let_syntax_peer_vals;
+    std.debug.assert(peer_names.len == peer_outer.len);
     const saved_peer = if (peer_names.len > 0)
-        self.gc.allocator.alloc(?Value, peer_names.len) catch null
+        self.gc.allocator.alloc(?Value, peer_names.len) catch return CompileError.OutOfMemory
     else
         null;
     defer if (saved_peer) |sp| self.gc.allocator.free(sp);
@@ -280,10 +281,24 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
 
     // Phase 1: Parse ALL transformer specs before registering any.
     // self.macros still has the outer values during this phase.
+    //
+    // Count bindings first, then pre-allocate tx_vals to exact capacity
+    // so pushRoot pointers into its backing buffer stay valid across
+    // subsequent appends (GC safety: no reallocation after rooting).
+    var bind_count: usize = 0;
+    var count_list = bindings;
+    while (count_list != types.NIL) {
+        if (!types.isPair(count_list)) return CompileError.InvalidSyntax;
+        bind_count += 1;
+        count_list = types.cdr(count_list);
+    }
+
     var kw_names: std.ArrayList([]const u8) = .empty;
     defer kw_names.deinit(self.gc.allocator);
+    kw_names.ensureTotalCapacity(self.gc.allocator, bind_count) catch return CompileError.OutOfMemory;
     var tx_vals: std.ArrayList(Value) = .empty;
     defer tx_vals.deinit(self.gc.allocator);
+    tx_vals.ensureTotalCapacity(self.gc.allocator, bind_count) catch return CompileError.OutOfMemory;
     var roots_pushed: usize = 0;
 
     var binding_list = bindings;
@@ -296,11 +311,11 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         const binding_rest = types.cdr(binding);
         if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
         const transformer_spec = types.car(binding_rest);
-        tx_vals.append(self.gc.allocator, parseSyntaxRules(self, transformer_spec, &.{}) catch
-            return CompileError.InvalidSyntax) catch return CompileError.OutOfMemory;
+        tx_vals.appendAssumeCapacity(parseSyntaxRules(self, transformer_spec, &.{}) catch
+            return CompileError.InvalidSyntax);
         self.gc.pushRoot(&tx_vals.items[tx_vals.items.len - 1]);
         roots_pushed += 1;
-        kw_names.append(self.gc.allocator, types.symbolName(keyword)) catch return CompileError.OutOfMemory;
+        kw_names.appendAssumeCapacity(types.symbolName(keyword));
         binding_list = types.cdr(binding_list);
     }
     defer for (0..roots_pushed) |_| self.gc.popRoot();
@@ -326,7 +341,7 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
     for (kw_names.items, tx_vals.items) |name, transformer| {
         saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
-        captureLocalsOnTransformer(self, transformer);
+        try captureLocalsOnTransformer(self, transformer);
         const tx = types.toObject(transformer).as(types.Transformer);
         tx.let_syntax_peer_names = self.gc.allocator.dupe([]const u8, peer_snap_names) catch return CompileError.OutOfMemory;
         tx.let_syntax_peer_vals = self.gc.allocator.dupe(Value, peer_snap_vals) catch return CompileError.OutOfMemory;
@@ -363,7 +378,7 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
 
         saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
-        captureLocalsOnTransformer(self, transformer);
+        try captureLocalsOnTransformer(self, transformer);
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
         binding_list = types.cdr(binding_list);
     }
@@ -372,10 +387,10 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
     restoreMacros(self, saved_names.items, saved_values.items);
 }
 
-fn captureLocalsOnTransformer(self: *Compiler, transformer: Value) void {
+fn captureLocalsOnTransformer(self: *Compiler, transformer: Value) CompileError!void {
     if (self.locals.items.len == 0) return;
     const tx = types.toObject(transformer).as(types.Transformer);
-    const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return;
+    const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return CompileError.OutOfMemory;
     for (self.locals.items, 0..) |local, ci| {
         caps[ci] = .{ .name = local.name, .slot = local.slot };
     }

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -197,7 +197,32 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
             .is_global_alias = true,
         });
     }
+    // R7RS 4.3.1: let-syntax transformers resolve free macro references
+    // from the definition-site environment, not the use-site environment.
+    // Temporarily swap sibling keywords to their outer values.
+    const peer_names = tx.let_syntax_peer_names;
+    const peer_outer = tx.let_syntax_peer_vals;
+    var saved_peer: [32]?Value = undefined;
+    if (peer_names.len > 0 and peer_names.len <= 32) {
+        for (peer_names, peer_outer, 0..) |pn, pv, i| {
+            saved_peer[i] = self.macros.get(pn);
+            if (pv != types.NIL) {
+                self.macros.put(pn, pv) catch {};
+            } else {
+                _ = self.macros.remove(pn);
+            }
+        }
+    }
     const result_err = self.compileExpr(expanded_root, dst, is_tail);
+    if (peer_names.len > 0 and peer_names.len <= 32) {
+        for (peer_names, 0..) |pn, i| {
+            if (saved_peer[i]) |old| {
+                self.macros.put(pn, old) catch {};
+            } else {
+                _ = self.macros.remove(pn);
+            }
+        }
+    }
     // Remove injected locals
     while (self.locals.items.len > saved_locals_len) {
         _ = self.locals.pop();
@@ -249,42 +274,64 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
     const body = types.cdr(args);
     if (body == types.NIL) return CompileError.InvalidSyntax;
 
-    var saved_names: std.ArrayList([]const u8) = .empty;
-    defer saved_names.deinit(self.gc.allocator);
-    var saved_values: std.ArrayList(?Value) = .empty;
-    defer saved_values.deinit(self.gc.allocator);
+    // Phase 1: Parse ALL transformer specs before registering any.
+    // self.macros still has the outer values during this phase.
+    var kw_names: [32][]const u8 = undefined;
+    var tx_vals: [32]Value = undefined;
+    var bind_n: usize = 0;
+    var roots_pushed: usize = 0;
 
     var binding_list = bindings;
     while (binding_list != types.NIL) {
         if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
         const binding = types.car(binding_list);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
-
         const keyword = types.car(binding);
         if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
         const binding_rest = types.cdr(binding);
         if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
         const transformer_spec = types.car(binding_rest);
-        const transformer = parseSyntaxRules(self, transformer_spec, &.{}) catch return CompileError.InvalidSyntax;
+        if (bind_n >= 32) return CompileError.InvalidSyntax;
+        tx_vals[bind_n] = parseSyntaxRules(self, transformer_spec, &.{}) catch return CompileError.InvalidSyntax;
+        self.gc.pushRoot(&tx_vals[bind_n]);
+        roots_pushed += 1;
+        kw_names[bind_n] = types.symbolName(keyword);
+        bind_n += 1;
+        binding_list = types.cdr(binding_list);
+    }
+    defer for (0..roots_pushed) |_| self.gc.popRoot();
 
-        const name = types.symbolName(keyword);
+    // Build peer snapshot: each keyword's outer macro value (NIL = unbound).
+    // Computed once before registration, duped per transformer so each
+    // owns its own copy (avoids double-free when GC cleans up).
+    var peer_snap_names: [32][]const u8 = undefined;
+    var peer_snap_vals: [32]Value = undefined;
+    for (kw_names[0..bind_n], 0..) |name, i| {
+        peer_snap_names[i] = name;
+        peer_snap_vals[i] = self.macros.get(name) orelse types.NIL;
+    }
 
+    // Phase 2: Save outer values and register all bindings.
+    var saved_names: std.ArrayList([]const u8) = .empty;
+    defer saved_names.deinit(self.gc.allocator);
+    var saved_values: std.ArrayList(?Value) = .empty;
+    defer saved_values.deinit(self.gc.allocator);
+
+    for (kw_names[0..bind_n], tx_vals[0..bind_n]) |name, transformer| {
         saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
 
+        const tx = types.toObject(transformer).as(types.Transformer);
         if (self.locals.items.len > 0) {
-            const tx = types.toObject(transformer).as(types.Transformer);
             const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return CompileError.OutOfMemory;
-            if (caps.len > 0) {
-                for (self.locals.items, 0..) |local, ci| {
-                    caps[ci] = .{ .name = local.name, .slot = local.slot };
-                }
-                tx.captured_locals = caps;
+            for (self.locals.items, 0..) |local, ci| {
+                caps[ci] = .{ .name = local.name, .slot = local.slot };
             }
+            tx.captured_locals = caps;
         }
+        tx.let_syntax_peer_names = self.gc.allocator.dupe([]const u8, peer_snap_names[0..bind_n]) catch return CompileError.OutOfMemory;
+        tx.let_syntax_peer_vals = self.gc.allocator.dupe(Value, peer_snap_vals[0..bind_n]) catch return CompileError.OutOfMemory;
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
-
-        binding_list = types.cdr(binding_list);
     }
 
     self.beginScope();
@@ -314,7 +361,68 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
 }
 
 pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
-    return compileLetSyntax(self, args, dst, is_tail);
+    if (args == types.NIL) return CompileError.InvalidSyntax;
+    const bindings = types.car(args);
+    const body = types.cdr(args);
+    if (body == types.NIL) return CompileError.InvalidSyntax;
+
+    var saved_names: std.ArrayList([]const u8) = .empty;
+    defer saved_names.deinit(self.gc.allocator);
+    var saved_values: std.ArrayList(?Value) = .empty;
+    defer saved_values.deinit(self.gc.allocator);
+
+    var binding_list = bindings;
+    while (binding_list != types.NIL) {
+        if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
+        const binding = types.car(binding_list);
+        if (!types.isPair(binding)) return CompileError.InvalidSyntax;
+        const keyword = types.car(binding);
+        if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
+        const binding_rest = types.cdr(binding);
+        if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
+        const transformer_spec = types.car(binding_rest);
+        const transformer = parseSyntaxRules(self, transformer_spec, &.{}) catch return CompileError.InvalidSyntax;
+        const name = types.symbolName(keyword);
+
+        saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
+        saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
+
+        if (self.locals.items.len > 0) {
+            const tx = types.toObject(transformer).as(types.Transformer);
+            const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return CompileError.OutOfMemory;
+            for (self.locals.items, 0..) |local, ci| {
+                caps[ci] = .{ .name = local.name, .slot = local.slot };
+            }
+            tx.captured_locals = caps;
+        }
+        self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
+        binding_list = types.cdr(binding_list);
+    }
+
+    self.beginScope();
+    const saved_body_scope = self.in_body_scope;
+    self.in_body_scope = true;
+    const macro_mark = self.beginBodyMacroScope();
+    errdefer self.endBodyMacroScope(macro_mark) catch {};
+    var current = body;
+    while (current != types.NIL) {
+        if (!types.isPair(current)) return CompileError.InvalidSyntax;
+        const expr = types.car(current);
+        current = types.cdr(current);
+        const tail = is_tail and current == types.NIL;
+        try self.compileExprViaIR(expr, dst, tail);
+    }
+    try self.endBodyMacroScope(macro_mark);
+    self.in_body_scope = saved_body_scope;
+    self.endScope();
+
+    for (saved_names.items, saved_values.items) |name, saved_val| {
+        if (saved_val) |old_val| {
+            try self.macros.put(name, old_val);
+        } else {
+            _ = self.macros.remove(name);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -138,6 +138,9 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
                 if (isYoungPointer(gc, tmpl)) return true;
             }
             if (isYoungPointer(gc, tx.def_env_val)) return true;
+            for (tx.let_syntax_peer_vals) |pv| {
+                if (isYoungPointer(gc, pv)) return true;
+            }
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);
@@ -388,6 +391,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
             for (tx.patterns) |pat| markValue(gc, pat);
             for (tx.templates) |tmpl| markValue(gc, tmpl);
             markValue(gc, tx.def_env_val);
+            for (tx.let_syntax_peer_vals) |pv| markValue(gc, pv);
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);
@@ -586,6 +590,9 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
                 worklist.append(gc.allocator, tmpl) catch @panic("GC mark: worklist OOM");
             }
             worklist.append(gc.allocator, tx.def_env_val) catch @panic("GC mark: worklist OOM");
+            for (tx.let_syntax_peer_vals) |pv| {
+                worklist.append(gc.allocator, pv) catch @panic("GC mark: worklist OOM");
+            }
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);
@@ -754,7 +761,8 @@ fn objectSize(obj: *Object) usize {
         .transformer => blk: {
             const t = obj.as(Transformer);
             break :blk @sizeOf(Transformer) + t.literals.len * @sizeOf(Value) +
-                t.patterns.len * @sizeOf(Value) + t.templates.len * @sizeOf(Value);
+                t.patterns.len * @sizeOf(Value) + t.templates.len * @sizeOf(Value) +
+                t.let_syntax_peer_vals.len * @sizeOf(Value);
         },
         .error_object => @sizeOf(types.ErrorObject),
         .record_type => @sizeOf(RecordType) + obj.as(RecordType).name.len,
@@ -873,6 +881,8 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             gc.allocator.free(tx.templates);
             if (tx.captured_locals.len > 0) gc.allocator.free(tx.captured_locals);
             if (tx.literal_bound.len > 0) gc.allocator.free(tx.literal_bound);
+            if (tx.let_syntax_peer_names.len > 0) gc.allocator.free(tx.let_syntax_peer_names);
+            if (tx.let_syntax_peer_vals.len > 0) gc.allocator.free(tx.let_syntax_peer_vals);
             poisonAndDestroy(gc, Transformer, tx);
         },
         .error_object => {

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -254,6 +254,12 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
             }
             new_tx.def_env = t.def_env;
             new_tx.def_env_val = t.def_env_val;
+            if (t.let_syntax_peer_vals.len > 0) {
+                const peer_vals = try gc.allocator.alloc(Value, t.let_syntax_peer_vals.len);
+                for (t.let_syntax_peer_vals, 0..) |v, i| peer_vals[i] = try deepCopyValue(gc, v, visited);
+                new_tx.let_syntax_peer_vals = peer_vals;
+                new_tx.let_syntax_peer_names = gc.allocator.dupe([]const u8, t.let_syntax_peer_names) catch &.{};
+            }
             return new_val;
         },
         .native_fn => {

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -256,9 +256,11 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
             new_tx.def_env_val = t.def_env_val;
             if (t.let_syntax_peer_vals.len > 0) {
                 const peer_vals = try gc.allocator.alloc(Value, t.let_syntax_peer_vals.len);
+                errdefer gc.allocator.free(peer_vals);
                 for (t.let_syntax_peer_vals, 0..) |v, i| peer_vals[i] = try deepCopyValue(gc, v, visited);
+                const peer_names = gc.allocator.dupe([]const u8, t.let_syntax_peer_names) catch return error.OutOfMemory;
                 new_tx.let_syntax_peer_vals = peer_vals;
-                new_tx.let_syntax_peer_names = gc.allocator.dupe([]const u8, t.let_syntax_peer_names) catch &.{};
+                new_tx.let_syntax_peer_names = peer_names;
             }
             return new_val;
         },

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -132,6 +132,40 @@ test "letrec-syntax basic" {
     try std.testing.expectEqual(@as(i64, 99), types.toFixnum(result));
 }
 
+test "let-syntax sibling keywords use outer scope (#1140)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define-syntax m (syntax-rules () ((_) 'outer)))");
+    // call-m's template (m) must resolve to the OUTER m, not the sibling
+    const result = try vm.eval(
+        \\(let-syntax ((m      (syntax-rules () ((_) 'inner)))
+        \\             (call-m (syntax-rules () ((_) (m)))))
+        \\  (call-m))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("outer", types.symbolName(result));
+}
+
+test "letrec-syntax sibling keywords see inner scope" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define-syntax m (syntax-rules () ((_) 'outer)))");
+    // letrec-syntax: call-m's template (m) must resolve to the INNER m
+    const result = try vm.eval(
+        \\(letrec-syntax ((m      (syntax-rules () ((_) 'inner)))
+        \\                (call-m (syntax-rules () ((_) (m)))))
+        \\  (call-m))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("inner", types.symbolName(result));
+}
+
 test "define-syntax nested expansion" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/types.zig
+++ b/src/types.zig
@@ -377,6 +377,8 @@ pub const Transformer = struct {
     def_env_val: Value = NIL,
     custom_ellipsis: ?[]const u8 = null,
     literal_bound: []u16 = &.{},
+    let_syntax_peer_names: [][]const u8 = &.{},
+    let_syntax_peer_vals: []Value = &.{},
 };
 
 pub const ErrorObject = struct {

--- a/tests/scheme/compliance/r7rs-expressions-gaps.scm
+++ b/tests/scheme/compliance/r7rs-expressions-gaps.scm
@@ -151,12 +151,11 @@
 ;; the transformer specs themselves are resolved in the OUTER environment,
 ;; so a transformer in the same let-syntax sees the outer m. (p. 22)
 (define-syntax m-outer (syntax-rules () ((_) 'outer)))
-;; FAIL: #1140 (let-syntax transformers see sibling keywords)
-;; (test-equal "let-syntax transformer sees outer keyword"
-;;   'outer
-;;   (let-syntax ((m-outer (syntax-rules () ((_) 'inner)))
-;;                (call-m (syntax-rules () ((_) (m-outer)))))
-;;     (call-m)))
+(test-equal "let-syntax transformer sees outer keyword"
+  'outer
+  (let-syntax ((m-outer (syntax-rules () ((_) 'inner)))
+               (call-m (syntax-rules () ((_) (m-outer)))))
+    (call-m)))
 ;; letrec-syntax: "Each binding of a <keyword> has the <transformer spec>s
 ;; as well as the <body> within its region" — sibling transformers see the
 ;; NEW binding. (p. 22)


### PR DESCRIPTION
## Summary

- `let-syntax` was incorrectly giving `letrec-syntax` semantics — sibling macro bindings could see each other's keywords, violating R7RS 4.3.1
- Refactored `compileLetSyntax` to parse all transformer specs before registering any bindings, storing each keyword's outer macro value on the Transformer struct
- Added macro swap in `expandAndCompileMacroUse` so template free references resolve to the definition-site environment during result compilation
- Separated `compileLetrecSyntax` into its own function preserving the register-while-parsing behavior

## Test plan

- [x] New Zig unit tests for both `let-syntax` (outer scope) and `letrec-syntax` (inner scope) sibling keyword resolution
- [x] Enabled previously disabled SRFI-64 test in `r7rs-expressions-gaps.scm`
- [x] All 1782 Scheme tests pass (387 files + 1395 R7RS), 0 failures
- [x] All Zig unit tests pass
- [x] GC stress mode (`-Dgc-stress=true`) passes cleanly

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)