### PR TITLE
Handle consecutive ellipses in syntax-rules templates (#1243)

### DIFF
--- a/src/expander.zig
+++ b/src/expander.zig
@@ -691,8 +691,24 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
         }
     }
 
-    // First instantiate the rest (after the ellipsis)
-    const result = try instantiateTemplate(gc, rest_template, bindings, intro_scope, literals, macro_keyword, globals, macros);
+    // Consecutive ellipses (R7RS 4.3.2): (x ... ...) flattens depth-2
+    // bindings into a single list.  Count and strip leading ellipsis
+    // tokens from rest_template so the tail instantiation sees only the
+    // non-ellipsis remainder.
+    var extra_ellipsis: u32 = 0;
+    var true_rest = rest_template;
+    while (true_rest != types.NIL and types.isPair(true_rest)) {
+        const head = types.car(true_rest);
+        if (types.isSymbol(head) and isEllipsis(types.symbolName(head))) {
+            extra_ellipsis += 1;
+            true_rest = types.cdr(true_rest);
+        } else {
+            break;
+        }
+    }
+
+    // First instantiate the rest (after all consumed ellipses)
+    const result = try instantiateTemplate(gc, true_rest, bindings, intro_scope, literals, macro_keyword, globals, macros);
     var result_root = result;
     gc.pushRoot(&result_root);
     defer gc.popRoot();
@@ -735,11 +751,44 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
             }
             sub_count += 1;
         }
-        const expanded = try instantiateTemplate(gc, elem_template, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
-        var expanded_root = expanded;
-        gc.pushRoot(&expanded_root);
-        result_root = try gc.allocPair(expanded_root, result_root);
-        gc.popRoot();
+
+        if (extra_ellipsis == 0) {
+            const expanded = try instantiateTemplate(gc, elem_template, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
+            var expanded_root = expanded;
+            gc.pushRoot(&expanded_root);
+            result_root = try gc.allocPair(expanded_root, result_root);
+            gc.popRoot();
+        } else {
+            // Build synthetic template (elem_template ... ...) with
+            // extra_ellipsis ellipsis symbols, then instantiate it.
+            // instantiateTemplate will re-detect the ellipsis pattern and
+            // recurse into instantiateEllipsis with one fewer level.
+            const ellipsis_name = active_custom_ellipsis orelse "...";
+            var synth = types.NIL;
+            gc.pushRoot(&synth);
+            {
+                var ei: u32 = 0;
+                while (ei < extra_ellipsis) : (ei += 1) {
+                    const dots = try gc.allocSymbol(ellipsis_name);
+                    synth = try gc.allocPair(dots, synth);
+                }
+            }
+            synth = try gc.allocPair(elem_template, synth);
+
+            const expanded_list = try instantiateTemplate(gc, synth, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
+            gc.popRoot(); // synth
+
+            // Splice expanded_list (a proper list) into result_root.
+            if (expanded_list != types.NIL and types.isPair(expanded_list)) {
+                var tail = expanded_list;
+                while (types.isPair(types.cdr(tail))) {
+                    tail = types.cdr(tail);
+                }
+                gc.writeBarrier(types.toObject(tail), result_root);
+                types.setCdr(tail, result_root);
+                result_root = expanded_list;
+            }
+        }
     }
 
     return result_root;

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -697,7 +697,7 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
     // non-ellipsis remainder.
     var extra_ellipsis: u32 = 0;
     var true_rest = rest_template;
-    while (true_rest != types.NIL and types.isPair(true_rest)) {
+    while (types.isPair(true_rest)) {
         const head = types.car(true_rest);
         if (types.isSymbol(head) and isEllipsis(types.symbolName(head))) {
             extra_ellipsis += 1;
@@ -712,6 +712,22 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
     var result_root = result;
     gc.pushRoot(&result_root);
     defer gc.popRoot();
+
+    // When extra ellipses are present, build the synthetic template
+    // (elem_template ... ...) once outside the loop — it is invariant
+    // across iterations and instantiateTemplate only reads it.
+    var synth = types.NIL;
+    if (extra_ellipsis > 0) {
+        gc.pushRoot(&synth);
+        const ellipsis_name = active_custom_ellipsis orelse "...";
+        var ei: u32 = 0;
+        while (ei < extra_ellipsis) : (ei += 1) {
+            const dots = try gc.allocSymbol(ellipsis_name);
+            synth = try gc.allocPair(dots, synth);
+        }
+        synth = try gc.allocPair(elem_template, synth);
+    }
+    defer if (extra_ellipsis > 0) gc.popRoot();
 
     // Generate copies in reverse so we build the list from right to left
     var i = repeat_count;
@@ -759,24 +775,7 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
             result_root = try gc.allocPair(expanded_root, result_root);
             gc.popRoot();
         } else {
-            // Build synthetic template (elem_template ... ...) with
-            // extra_ellipsis ellipsis symbols, then instantiate it.
-            // instantiateTemplate will re-detect the ellipsis pattern and
-            // recurse into instantiateEllipsis with one fewer level.
-            const ellipsis_name = active_custom_ellipsis orelse "...";
-            var synth = types.NIL;
-            gc.pushRoot(&synth);
-            {
-                var ei: u32 = 0;
-                while (ei < extra_ellipsis) : (ei += 1) {
-                    const dots = try gc.allocSymbol(ellipsis_name);
-                    synth = try gc.allocPair(dots, synth);
-                }
-            }
-            synth = try gc.allocPair(elem_template, synth);
-
             const expanded_list = try instantiateTemplate(gc, synth, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
-            gc.popRoot(); // synth
 
             // Splice expanded_list (a proper list) into result_root.
             if (expanded_list != types.NIL and types.isPair(expanded_list)) {

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -500,6 +500,15 @@ test "syntax-rules doubled ellipsis flattens depth-2 bindings (#1243)" {
     // No groups
     const r5 = try vm.eval("(equal? (flatten2 ()) '())");
     try std.testing.expectEqual(types.TRUE, r5);
+
+    // Custom ellipsis identifier
+    _ = try vm.eval(
+        \\(define-syntax flatten-custom
+        \\  (syntax-rules ::: ()
+        \\    ((_ ((x :::) :::)) '(x ::: :::))))
+    );
+    const r6 = try vm.eval("(equal? (flatten-custom ((1 2) (3 4))) '(1 2 3 4))");
+    try std.testing.expectEqual(types.TRUE, r6);
 }
 
 test "hygiene: template set! of a free global writes through to the global" {

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -471,6 +471,37 @@ test "syntax-rules nested ellipsis: depth-2 pattern variables" {
     try std.testing.expectEqual(@as(i64, 79), types.toFixnum(result));
 }
 
+test "syntax-rules doubled ellipsis flattens depth-2 bindings (#1243)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-syntax flatten2
+        \\  (syntax-rules ()
+        \\    ((_ ((x ...) ...)) '(x ... ...))))
+    );
+    const result = try vm.eval("(equal? (flatten2 ((1 2) (3 4) (5))) '(1 2 3 4 5))");
+    try std.testing.expectEqual(types.TRUE, result);
+
+    // Single group
+    const r2 = try vm.eval("(equal? (flatten2 ((10 20 30))) '(10 20 30))");
+    try std.testing.expectEqual(types.TRUE, r2);
+
+    // Empty groups mixed in
+    const r3 = try vm.eval("(equal? (flatten2 ((1) () (2 3))) '(1 2 3))");
+    try std.testing.expectEqual(types.TRUE, r3);
+
+    // All empty
+    const r4 = try vm.eval("(equal? (flatten2 (() ())) '())");
+    try std.testing.expectEqual(types.TRUE, r4);
+
+    // No groups
+    const r5 = try vm.eval("(equal? (flatten2 ()) '())");
+    try std.testing.expectEqual(types.TRUE, r5);
+}
+
 test "hygiene: template set! of a free global writes through to the global" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/tests/scheme/compliance/r7rs-hygiene-gaps.scm
+++ b/tests/scheme/compliance/r7rs-hygiene-gaps.scm
@@ -16,12 +16,11 @@
 
 ;; "They are replaced in the output by all of the elements they match in
 ;; the input" — doubled ellipsis flattens one level
-;; FAIL: #1243 (doubled ellipsis produces garbage with a literal ...)
-;; (define-syntax flatten2
-;;   (syntax-rules ()
-;;     ((_ ((x ...) ...)) '(x ... ...))))
-;; (test-equal "doubled ellipsis flattens" '(1 2 3 4 5)
-;;   (flatten2 ((1 2) (3 4) (5))))
+(define-syntax flatten2
+  (syntax-rules ()
+    ((_ ((x ...) ...)) '(x ... ...))))
+(test-equal "doubled ellipsis flattens" '(1 2 3 4 5)
+  (flatten2 ((1 2) (3 4) (5))))
 
 ;;; --- (... ...) escape + macro-generating macro (p. 24 example) ---
 (define-syntax be-like-begin


### PR DESCRIPTION
## Summary

- Teach `instantiateEllipsis` in `src/expander.zig` to detect and strip consecutive `...` tokens from `rest_template`. When extra ellipses are present, each outer iteration builds a synthetic template with the remaining ellipses and recurses, then splices the resulting list into the output.
- Fixes the R7RS 4.3.2 flattening construct `(x ... ...)` which previously produced garbage (`(() () () ...)`) instead of the expected flat list.
- Uncomments the disabled compliance test and adds a Zig unit test with edge cases (single group, empty groups, no groups).

Closes #1243

## Test plan

- [x] New Zig unit test passes (`zig build test`)
- [x] Uncommented Scheme compliance test passes (14/14 in `r7rs-hygiene-gaps.scm`)
- [x] Full R7RS suite passes (1395/1395)
- [x] GC stress test passes (`-Dgc-stress=true`)
- [x] Full `run-all.sh` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)