### PR TITLE
Follow redirect chain in force for delay-force intermediates

### DIFF
--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -45,6 +45,7 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
         const promise = types.toPromise(current);
 
         if (promise.forced) {
+            // Follow redirect: forced value is a promise only via SRFI-45 merge (inner → head), never a cycle.
             current = promise.value;
             continue;
         }

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -44,7 +44,10 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
         if (!types.isPromise(current)) return current;
         const promise = types.toPromise(current);
 
-        if (promise.forced) return promise.value;
+        if (promise.forced) {
+            current = promise.value;
+            continue;
+        }
 
         const thunk = promise.value;
         if (!types.isProcedure(thunk)) {
@@ -63,7 +66,8 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
         // has already completed this promise (re-entrant force).
         if (promise.forced) {
             promise.forcing = false;
-            return promise.value;
+            current = promise.value;
+            continue;
         }
 
         if (types.isPromise(result)) {
@@ -80,7 +84,8 @@ fn forceFn(args: []const Value) PrimitiveError!Value {
                 promise.forced = true;
                 promise.value = inner.value;
                 gc.writeBarrier(&promise.header, inner.value);
-                return inner.value;
+                current = inner.value;
+                continue;
             }
             promise.value = inner.value;
             gc.writeBarrier(&promise.header, inner.value);

--- a/tests/scheme/compliance/lazy.scm
+++ b/tests/scheme/compliance/lazy.scm
@@ -39,6 +39,21 @@
                   (if (> count x) count (force p)))))
   (test-eqv "recursive force with termination" 6 (force p)))
 
+;; Forcing intermediate promise of a completed delay-force chain (#1264)
+(test-group "delay-force chain intermediate"
+  (let ()
+    (define inner (delay 42))
+    (define outer (delay-force inner))
+    (test-eqv "force outer yields value" 42 (force outer))
+    (test-eqv "force inner after chain yields value" 42 (force inner)))
+  (let ()
+    (define a (delay 42))
+    (define b (delay-force a))
+    (define c (delay-force b))
+    (test-eqv "three-deep chain" 42 (force c))
+    (test-eqv "middle promise after chain" 42 (force b))
+    (test-eqv "innermost promise after chain" 42 (force a))))
+
 ;; Cyclic delay-force detected via forcing flag
 (let ()
   (define p (delay-force (delay p)))


### PR DESCRIPTION
Fixes #1264

## Summary

- `force` returns `#<promise>` instead of the memoized value when re-forcing an intermediate promise of a completed `delay-force` chain
- The SRFI-45 merge step redirects intermediate promises to point at the chain head, but the trampoline returned these redirect pointers directly at three sites instead of following them
- Changed all three `return promise.value` / `return inner.value` sites in `forceFn` to `current = ...; continue;` so the trampoline resolves the full chain

## Test plan

- [x] Added regression tests for two-deep and three-deep `delay-force` chains forcing intermediate promises
- [x] Lazy compliance tests pass (14/14)
- [x] R7RS test suite passes (0 failures)
- [x] Zig unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)