### PR TITLE
Check record type in accessors and mutators (#1199)

### DIFF
--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -509,7 +509,8 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
                 const p = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
                 const v = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
                 const idx = types.makeFixnum(@intCast(fi));
-                const body = gc.makeList(&[_]Value{ rs, p, idx, v }) catch return CompileError.OutOfMemory;
+                const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
+                const body = gc.makeList(&[_]Value{ rs, p, idx, v, rt_ref }) catch return CompileError.OutOfMemory;
                 const np = gc.allocPair(gc.allocSymbol(mn) catch return CompileError.OutOfMemory, gc.makeList(&[_]Value{ p, v }) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
                 forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, np, body }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
             }
@@ -524,7 +525,8 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
             const rr = gc.allocSymbol("%record-ref") catch return CompileError.OutOfMemory;
             const p = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
             const idx = types.makeFixnum(@intCast(fi));
-            const body = gc.makeList(&[_]Value{ rr, p, idx }) catch return CompileError.OutOfMemory;
+            const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
+            const body = gc.makeList(&[_]Value{ rr, p, idx, rt_ref }) catch return CompileError.OutOfMemory;
             const np = gc.allocPair(gc.allocSymbol(spec.accessor_names[fi]) catch return CompileError.OutOfMemory, gc.makeList(&[_]Value{p}) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
             forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, np, body }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
         }

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -160,8 +160,8 @@ const core_specs = [_]PrimSpec{
     .{ .name = "%make-record-type", .func = &makeRecordTypeFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "%make-record", .func = &makeRecordFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "%record?", .func = &recordCheckFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%record-ref", .func = &recordRefFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%record-set!", .func = &recordSetFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%record-ref", .func = &recordRefFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%record-set!", .func = &recordSetFn, .arity = .{ .exact = 4 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "apply", .func = &applyFn, .arity = .{ .variadic = 2 }, .libs = BR },
 };
 
@@ -823,26 +823,30 @@ fn recordCheckFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn recordRefFn(args: []const Value) PrimitiveError!Value {
-    // args[0] = record instance, args[1] = field index (fixnum)
-    if (!types.isRecordInstance(args[0])) return typeError("record-ref", "record", args[0]);
-    if (!types.isFixnum(args[1])) return typeError("record-ref", "exact integer", args[1]);
+    // args[0] = record instance, args[1] = field index (fixnum), args[2] = expected record type
+    const rt = types.toObject(args[2]).as(types.RecordType);
+    if (!types.isRecordInstance(args[0])) return typeError("%record-ref", rt.name, args[0]);
     const ri = types.toObject(args[0]).as(types.RecordInstance);
+    if (ri.record_type != rt) return typeError("%record-ref", rt.name, args[0]);
+    if (!types.isFixnum(args[1])) return typeError("%record-ref", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const idx: usize = @intCast(raw_idx);
-    if (idx >= ri.fields.len) return indexError("record-ref", raw_idx, ri.fields.len);
+    if (idx >= ri.fields.len) return indexError("%record-ref", raw_idx, ri.fields.len);
     return ri.fields[idx];
 }
 
 fn recordSetFn(args: []const Value) PrimitiveError!Value {
-    // args[0] = record instance, args[1] = field index (fixnum), args[2] = new value
-    if (!types.isRecordInstance(args[0])) return typeError("record-set!", "record", args[0]);
-    if (!types.isFixnum(args[1])) return typeError("record-set!", "exact integer", args[1]);
+    // args[0] = record instance, args[1] = field index (fixnum), args[2] = new value, args[3] = expected record type
+    const rt = types.toObject(args[3]).as(types.RecordType);
+    if (!types.isRecordInstance(args[0])) return typeError("%record-set!", rt.name, args[0]);
     const ri = types.toObject(args[0]).as(types.RecordInstance);
+    if (ri.record_type != rt) return typeError("%record-set!", rt.name, args[0]);
+    if (!types.isFixnum(args[1])) return typeError("%record-set!", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const idx: usize = @intCast(raw_idx);
-    if (idx >= ri.fields.len) return indexError("record-set!", raw_idx, ri.fields.len);
+    if (idx >= ri.fields.len) return indexError("%record-set!", raw_idx, ri.fields.len);
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     ri.fields[idx] = args[2];
     return types.VOID;

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -824,6 +824,7 @@ fn recordCheckFn(args: []const Value) PrimitiveError!Value {
 
 fn recordRefFn(args: []const Value) PrimitiveError!Value {
     // args[0] = record instance, args[1] = field index (fixnum), args[2] = expected record type
+    if (!types.isRecordType(args[2])) return typeError("%record-ref", "record-type", args[2]);
     const rt = types.toObject(args[2]).as(types.RecordType);
     if (!types.isRecordInstance(args[0])) return typeError("%record-ref", rt.name, args[0]);
     const ri = types.toObject(args[0]).as(types.RecordInstance);
@@ -838,6 +839,7 @@ fn recordRefFn(args: []const Value) PrimitiveError!Value {
 
 fn recordSetFn(args: []const Value) PrimitiveError!Value {
     // args[0] = record instance, args[1] = field index (fixnum), args[2] = new value, args[3] = expected record type
+    if (!types.isRecordType(args[3])) return typeError("%record-set!", "record-type", args[3]);
     const rt = types.toObject(args[3]).as(types.RecordType);
     if (!types.isRecordInstance(args[0])) return typeError("%record-set!", rt.name, args[0]);
     const ri = types.toObject(args[0]).as(types.RecordInstance);

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -138,7 +138,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
 
     // Generate accessors and mutators for each field
     for (0..all_field_count) |fi| {
-        // Accessor: (define (accessor p) (%record-ref p <index>))
+        // Accessor: (define (accessor p) (%record-ref p <index> __record_type_X))
         {
             vm.gc.no_collect += 1;
             errdefer vm.gc.no_collect -= 1;
@@ -147,8 +147,9 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const acc_sym = vm.gc.allocSymbol(spec.accessor_names[fi]) catch return VMError.OutOfMemory;
             const record_ref_sym = vm.gc.allocSymbol("%record-ref") catch return VMError.OutOfMemory;
             const idx_val = types.makeFixnum(@intCast(fi));
+            const type_ref = vm.gc.allocSymbol(internal_name) catch return VMError.OutOfMemory;
 
-            const body = vm.gc.makeList(&[_]Value{ record_ref_sym, p_sym, idx_val }) catch return VMError.OutOfMemory;
+            const body = vm.gc.makeList(&[_]Value{ record_ref_sym, p_sym, idx_val, type_ref }) catch return VMError.OutOfMemory;
             const name_and_params = vm.gc.makeList(&[_]Value{ acc_sym, p_sym }) catch return VMError.OutOfMemory;
             var define_expr = vm.gc.makeList(&[_]Value{ define_sym, name_and_params, body }) catch return VMError.OutOfMemory;
             vm.gc.no_collect -= 1;
@@ -164,7 +165,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             _ = vm.execute(func) catch |err| return err;
         }
 
-        // Mutator (if specified): (define (mutator p v) (%record-set! p <index> v))
+        // Mutator (if specified): (define (mutator p v) (%record-set! p <index> v __record_type_X))
         if (spec.mutator_names[fi]) |mut_name| {
             vm.gc.no_collect += 1;
             errdefer vm.gc.no_collect -= 1;
@@ -174,8 +175,9 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const mut_sym = vm.gc.allocSymbol(mut_name) catch return VMError.OutOfMemory;
             const record_set_sym = vm.gc.allocSymbol("%record-set!") catch return VMError.OutOfMemory;
             const idx_val = types.makeFixnum(@intCast(fi));
+            const type_ref = vm.gc.allocSymbol(internal_name) catch return VMError.OutOfMemory;
 
-            const body = vm.gc.makeList(&[_]Value{ record_set_sym, p_sym, idx_val, v_sym }) catch return VMError.OutOfMemory;
+            const body = vm.gc.makeList(&[_]Value{ record_set_sym, p_sym, idx_val, v_sym, type_ref }) catch return VMError.OutOfMemory;
             const name_and_params = vm.gc.makeList(&[_]Value{ mut_sym, p_sym, v_sym }) catch return VMError.OutOfMemory;
             var define_expr = vm.gc.makeList(&[_]Value{ define_sym, name_and_params, body }) catch return VMError.OutOfMemory;
             vm.gc.no_collect -= 1;
@@ -426,14 +428,15 @@ pub fn expandRecordTypeDefines(
         count.* += 1;
     }
 
-    // 4. Accessors: (define (acc p) (%record-ref p idx))
+    // 4. Accessors: (define (acc p) (%record-ref p idx __rt))
     for (0..spec.field_count) |fi| {
         const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
         const rr_sym = gc.allocSymbol("%record-ref") catch return CompileError.OutOfMemory;
         const p_sym = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
         const idx = types.makeFixnum(@intCast(fi));
+        const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
 
-        const body = gc.makeList(&[_]Value{ rr_sym, p_sym, idx }) catch return CompileError.OutOfMemory;
+        const body = gc.makeList(&[_]Value{ rr_sym, p_sym, idx, rt_ref }) catch return CompileError.OutOfMemory;
         const params = gc.makeList(&[_]Value{p_sym}) catch return CompileError.OutOfMemory;
         def_inits[count.*] = gc.makeList(&[_]Value{ lambda_sym, params, body }) catch return CompileError.OutOfMemory;
         def_names[count.*] = spec.accessor_names[fi];
@@ -441,7 +444,7 @@ pub fn expandRecordTypeDefines(
         count.* += 1;
     }
 
-    // 5. Mutators: (define (mut! p v) (%record-set! p idx v))
+    // 5. Mutators: (define (mut! p v) (%record-set! p idx v __rt))
     for (0..spec.field_count) |fi| {
         if (spec.mutator_names[fi]) |mname| {
             const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
@@ -449,8 +452,9 @@ pub fn expandRecordTypeDefines(
             const p_sym = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
             const v_sym = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
             const idx = types.makeFixnum(@intCast(fi));
+            const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
 
-            const body = gc.makeList(&[_]Value{ rs_sym, p_sym, idx, v_sym }) catch return CompileError.OutOfMemory;
+            const body = gc.makeList(&[_]Value{ rs_sym, p_sym, idx, v_sym, rt_ref }) catch return CompileError.OutOfMemory;
             const params = gc.makeList(&[_]Value{ p_sym, v_sym }) catch return CompileError.OutOfMemory;
             def_inits[count.*] = gc.makeList(&[_]Value{ lambda_sym, params, body }) catch return CompileError.OutOfMemory;
             def_names[count.*] = mname;

--- a/tests/scheme/audit/primitives_core-audit.scm
+++ b/tests/scheme/audit/primitives_core-audit.scm
@@ -306,7 +306,8 @@
 (test #t (guard (e (#t (error-object? e))) (set-point-x! (make-blob 9) 42) #f))
 
 ;; internal record primitives reject garbage directly
-(test #t (guard (e (#t (error-object? e))) (%record-ref 5 0) #f))
+(test #t (guard (e (#t (error-object? e))) (%record-ref 5 0 #t) #f))
+(test #t (guard (e (#t (error-object? e))) (%record-set! 5 0 99 #t) #f))
 (test #t (guard (e (#t (error-object? e))) (%make-record 5) #f))
 
 (test-end "primitives_core audit")

--- a/tests/scheme/audit/primitives_core-audit.scm
+++ b/tests/scheme/audit/primitives_core-audit.scm
@@ -301,11 +301,9 @@
 (test #t (guard (e (#t (error-object? e))) (point-x 42) #f))
 (test #t (guard (e (#t (error-object? e))) (set-point-x! "p" 1) #f))
 ;; R7RS 5.5: "It is an error to pass an accessor a value which is not a
-;; record of the appropriate type." — cross-type access is silently accepted:
-;; FAIL: #1199 (record accessors/mutators do not check the record type)
-;; (test #t (guard (e (#t (error-object? e))) (point-x (make-blob 9)) #f))
-;; FAIL: #1199 (record accessors/mutators do not check the record type)
-;; (test #t (guard (e (#t (error-object? e))) (set-point-x! (make-blob 9) 42) #f))
+;; record of the appropriate type."
+(test #t (guard (e (#t (error-object? e))) (point-x (make-blob 9)) #f))
+(test #t (guard (e (#t (error-object? e))) (set-point-x! (make-blob 9) 42) #f))
 
 ;; internal record primitives reject garbage directly
 (test #t (guard (e (#t (error-object? e))) (%record-ref 5 0) #f))

--- a/tests/scheme/smoke/record-type-check.scm
+++ b/tests/scheme/smoke/record-type-check.scm
@@ -1,0 +1,42 @@
+;; Regression test for #1199: record accessors/mutators must check the record type
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "record-type-check")
+
+(define-record-type point (make-point x y) point? (x point-x set-point-x!) (y point-y))
+(define-record-type blob  (make-blob v)    blob?  (v blob-v))
+
+;; Basic accessor/mutator work on the correct type
+(test-equal "accessor on correct type" 1 (point-x (make-point 1 2)))
+(test-equal "second field accessor" 2 (point-y (make-point 1 2)))
+(let ((p (make-point 10 20)))
+  (set-point-x! p 99)
+  (test-equal "mutator on correct type" 99 (point-x p)))
+
+;; Predicate correctly discriminates types
+(test-assert "predicate true" (point? (make-point 1 2)))
+(test-assert "predicate false for other record" (not (point? (make-blob 9))))
+
+;; Cross-type accessor must error (was silently returning wrong field)
+(test-assert "accessor rejects wrong record type"
+  (guard (e (#t (error-object? e))) (point-x (make-blob 9)) #f))
+
+;; Cross-type mutator must error (was silently overwriting wrong field)
+(test-assert "mutator rejects wrong record type"
+  (guard (e (#t (error-object? e))) (set-point-x! (make-blob 9) 42) #f))
+
+;; Non-record arguments must still error
+(test-assert "accessor rejects non-record"
+  (guard (e (#t (error-object? e))) (point-x 42) #f))
+(test-assert "mutator rejects non-record"
+  (guard (e (#t (error-object? e))) (set-point-x! "not-a-record" 1) #f))
+
+;; Records defined in body context (let body)
+(test-assert "body-context record type checking"
+  (let ()
+    (define-record-type color (make-color r) color? (r color-r))
+    (guard (e (#t (error-object? e))) (color-r (make-blob 5)) #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "record-type-check")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/record-type-check.scm
+++ b/tests/scheme/smoke/record-type-check.scm
@@ -31,6 +31,12 @@
 (test-assert "mutator rejects non-record"
   (guard (e (#t (error-object? e))) (set-point-x! "not-a-record" 1) #f))
 
+;; Internal primitives reject bad type argument without panicking
+(test-assert "%record-ref rejects non-record-type type arg"
+  (guard (e (#t (error-object? e))) (%record-ref (make-point 1 2) 0 5) #f))
+(test-assert "%record-set! rejects non-record-type type arg"
+  (guard (e (#t (error-object? e))) (%record-set! (make-point 1 2) 0 99 5) #f))
+
 ;; Records defined in body context (let body)
 (test-assert "body-context record type checking"
   (let ()


### PR DESCRIPTION
## Summary

- Record accessors and mutators now verify the argument is an instance of the correct record type, not just any record
- Passes the expected `RecordType` pointer to `%record-ref` / `%record-set!` primitives, which compare it against the instance's `record_type` field
- All three desugaring paths updated: VM top-level (`handleDefineRecordType`), body-context expansion (`expandRecordTypeDefines`), and compiler dispatch (`compileDefineRecordType`)

Fixes #1199

## Test plan

- [x] New regression test `tests/scheme/smoke/record-type-check.scm` — 10 tests covering cross-type accessor/mutator errors, non-record errors, correct-type access, and body-context records
- [x] Enabled previously disabled audit tests in `primitives_core-audit.scm`
- [x] Zig unit tests pass
- [x] R7RS suite: 1395 pass, 0 fail
- [x] Full suite: 1785 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)