### PR TITLE
Reject non-environment second argument to eval (#1270)

### DIFF
--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -175,6 +175,9 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     const expr = args[0];
 
     // If an environment specifier is provided, compile in that environment
+    if (args.len > 1) {
+        if (!types.isEnvironment(args[1])) return primitives.typeError("eval", "environment", args[1]);
+    }
     if (args.len > 1 and types.isEnvironment(args[1])) {
         const se = types.toEnvironment(args[1]);
         const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env, args[1]) catch return PrimitiveError.TypeError; // bare-ok: compile error

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -177,8 +177,6 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     // If an environment specifier is provided, compile in that environment
     if (args.len > 1) {
         if (!types.isEnvironment(args[1])) return primitives.typeError("eval", "environment", args[1]);
-    }
-    if (args.len > 1 and types.isEnvironment(args[1])) {
         const se = types.toEnvironment(args[1]);
         const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env, args[1]) catch return PrimitiveError.TypeError; // bare-ok: compile error
         var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -1181,7 +1181,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
 
                 const compiler_mod = @import("compiler.zig");
                 const func_val = blk: {
-                    if (nargs >= 2 and types.isEnvironment(self.registers[abs_base + 1])) {
+                    if (nargs >= 2) {
+                        if (!types.isEnvironment(self.registers[abs_base + 1])) {
+                            self.setErrorDetail("type error in 'eval': expected environment", .{});
+                            return VMError.TypeError;
+                        }
                         const se = types.toEnvironment(self.registers[abs_base + 1]);
                         break :blk compiler_mod.compileExpressionInEnv(self.gc, expr_val, &self.macros, se.env, self.registers[abs_base + 1]) catch return VMError.CompileError;
                     }

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -1183,7 +1183,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const func_val = blk: {
                     if (nargs >= 2) {
                         if (!types.isEnvironment(self.registers[abs_base + 1])) {
-                            self.setErrorDetail("type error in 'eval': expected environment", .{});
+                            const p = @import("printer.zig");
+                            const s = p.valueToString(self.gc.allocator, self.registers[abs_base + 1], .write) catch "";
+                            defer if (s.len > 0) self.gc.allocator.free(s);
+                            self.setErrorDetail("type error in 'eval': expected environment, got {s}", .{if (s.len > 0) s else "?"});
                             return VMError.TypeError;
                         }
                         const se = types.toEnvironment(self.registers[abs_base + 1]);

--- a/tests/scheme/compliance/eval.scm
+++ b/tests/scheme/compliance/eval.scm
@@ -25,7 +25,10 @@
   (test-assert "eval with boolean env raises error"
     (guard (e (#t #t))
       (eval '(+ 1 2) #t)
-      #f)))
+      #f))
+  (test-assert "eval with bad env in tail position raises error"
+    (guard (e (#t #t))
+      ((lambda () (eval '(+ 1 2) 42))))))
 
 ;; --- eval list construction ---
 (test-group "eval list"

--- a/tests/scheme/compliance/eval.scm
+++ b/tests/scheme/compliance/eval.scm
@@ -12,6 +12,21 @@
 (test-group "eval with environment"
   (test-eqv "eval with scheme base environment" 12 (eval '(* 3 4) (environment '(scheme base)))))
 
+;; --- eval rejects non-environment second argument (#1270) ---
+(test-group "eval bad env type"
+  (test-assert "eval with fixnum env raises error"
+    (guard (e (#t #t))
+      (eval '(+ 1 2) 42)
+      #f))
+  (test-assert "eval with string env raises error"
+    (guard (e (#t #t))
+      (eval '(+ 1 2) "not-an-env")
+      #f))
+  (test-assert "eval with boolean env raises error"
+    (guard (e (#t #t))
+      (eval '(+ 1 2) #t)
+      #f)))
+
 ;; --- eval list construction ---
 (test-group "eval list"
   (test-equal "eval quoted list" '(1 2 3) (eval '(list 1 2 3))))

--- a/tests/scheme/compliance/eval.scm
+++ b/tests/scheme/compliance/eval.scm
@@ -28,7 +28,8 @@
       #f))
   (test-assert "eval with bad env in tail position raises error"
     (guard (e (#t #t))
-      ((lambda () (eval '(+ 1 2) 42))))))
+      ((lambda () (eval '(+ 1 2) 42)))
+      #f)))
 
 ;; --- eval list construction ---
 (test-group "eval list"


### PR DESCRIPTION
## Summary

- `eval` silently ignored a non-environment second argument, evaluating in the
  global environment instead of raising a type error
- The bug existed in **two code paths**: the `evalFn` native function
  (`primitives_r7rs.zig`) and the `tail_eval` bytecode opcode
  (`vm_dispatch.zig`) — the tail-position path was the harder one to catch
- Both now reject non-environment values, matching `load`'s behavior per R7RS §6.12

## Test plan

- [x] Regression tests added to `tests/scheme/compliance/eval.scm` (fixnum, string, boolean as bad env)
- [x] `zig build test` passes
- [x] Full Scheme suite passes (1784 pass, 0 fail)

Closes #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)