### PR TITLE
Unify platform feature lists across (features) and cond-expand (#1177)

### DIFF
--- a/src/compiler_conditionals.zig
+++ b/src/compiler_conditionals.zig
@@ -262,15 +262,7 @@ pub fn compileCondExpand(self: *Compiler, args: Value, dst: u16, is_tail: bool) 
 pub fn evalFeatureReq(self: *Compiler, req: Value) bool {
     if (types.isSymbol(req)) {
         const name = types.symbolName(req);
-        // Hardcoded feature identifiers
-        const known_features = [_][]const u8{
-            "r7rs",
-            "kaappi",
-            "ieee-float",
-            "posix",
-            "exact-closed",
-        };
-        for (known_features) |f| {
+        for (types.platform_features) |f| {
             if (std.mem.eql(u8, name, f)) return true;
         }
         return false;

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -473,12 +473,10 @@ fn forEachFn(args: []const Value) PrimitiveError!Value {
 fn featuresFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     const gc = getGC() orelse return PrimitiveError.OutOfMemory;
-    // Return a list of feature identifiers
-    const r7rs = gc.allocSymbol("r7rs") catch return PrimitiveError.OutOfMemory;
-    const kaappi = gc.allocSymbol("kaappi") catch return PrimitiveError.OutOfMemory;
-    const ieee_float = gc.allocSymbol("ieee-float") catch return PrimitiveError.OutOfMemory;
-    const posix_sym = gc.allocSymbol("posix") catch return PrimitiveError.OutOfMemory;
-    const items = [_]Value{ r7rs, kaappi, ieee_float, posix_sym };
+    var items: [types.platform_features.len]Value = undefined;
+    for (types.platform_features, 0..) |name, i| {
+        items[i] = gc.allocSymbol(name) catch return PrimitiveError.OutOfMemory;
+    }
     return gc.makeList(&items) catch return PrimitiveError.OutOfMemory;
 }
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -1194,6 +1194,8 @@ test "truthiness" {
     try std.testing.expect(!isTruthy(FALSE));
 }
 
+pub const platform_features = [_][]const u8{ "r7rs", "kaappi", "ieee-float", "posix", "exact-closed", "exact-complex" };
+
 test "nil is not a pointer" {
     try std.testing.expect(!isPointer(NIL));
     try std.testing.expect(isNil(NIL));

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -467,8 +467,7 @@ fn tryLoadLibraryFromFile(vm: *VM, name_list: Value) !void {
 fn evalLibFeatureReq(vm: *VM, req: Value) bool {
     if (types.isSymbol(req)) {
         const name = types.symbolName(req);
-        const known = [_][]const u8{ "r7rs", "kaappi", "ieee-float", "posix", "exact-closed", "exact-complex" };
-        for (known) |f| {
+        for (types.platform_features) |f| {
             if (std.mem.eql(u8, name, f)) return true;
         }
         return false;

--- a/tests/scheme/audit/primitives_list-audit.scm
+++ b/tests/scheme/audit/primitives_list-audit.scm
@@ -212,9 +212,9 @@
 ;; true, and library-level cond-expand additionally treats exact-complex as
 ;; true — but (features) lists neither, violating the 6.14 sentence above.
 (test 'yes (cond-expand (exact-closed 'yes) (else 'no)))
-;; FAIL: #1177 ((features) and the two cond-expand evaluators disagree)
-;; (test #t (and (memq 'exact-closed (features)) #t))
-;; (test 'yes (cond-expand (exact-complex 'yes) (else 'no)))  ; expr-level says no, library-level says yes
+(test #t (and (memq 'exact-closed (features)) #t))
+(test 'yes (cond-expand (exact-complex 'yes) (else 'no)))
+(test #t (and (memq 'exact-complex (features)) #t))
 
 ;;; --- string->symbol ---
 (test 'mISSISSIppi (string->symbol "mISSISSIppi"))

--- a/tests/scheme/smoke/features-consistency.scm
+++ b/tests/scheme/smoke/features-consistency.scm
@@ -1,0 +1,23 @@
+;; Regression test for #1177: (features), expression cond-expand, and
+;; library cond-expand must agree on the same feature set.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "features-consistency")
+
+;; (features) must return all platform features
+(test-assert "r7rs in features" (and (memq 'r7rs (features)) #t))
+(test-assert "kaappi in features" (and (memq 'kaappi (features)) #t))
+(test-assert "ieee-float in features" (and (memq 'ieee-float (features)) #t))
+(test-assert "posix in features" (and (memq 'posix (features)) #t))
+(test-assert "exact-closed in features" (and (memq 'exact-closed (features)) #t))
+(test-assert "exact-complex in features" (and (memq 'exact-complex (features)) #t))
+
+;; Expression-level cond-expand must agree
+(test-equal "expr cond-expand exact-closed" 'yes
+  (cond-expand (exact-closed 'yes) (else 'no)))
+(test-equal "expr cond-expand exact-complex" 'yes
+  (cond-expand (exact-complex 'yes) (else 'no)))
+
+(let ((runner (test-runner-current)))
+  (test-end "features-consistency")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Three call sites hardcoded divergent feature lists: `(features)` lacked `exact-closed` and `exact-complex`, expression-level `cond-expand` lacked `exact-complex`, while library-level `cond-expand` had both — violating R7RS §6.14 which requires `(features)` to return exactly the identifiers `cond-expand` treats as true.
- Introduces a single `types.platform_features` constant consulted by all three sites (`featuresFn`, `evalFeatureReq`, `evalLibFeatureReq`).
- Enables previously disabled audit assertions and adds a dedicated regression test.

## Test plan

- [x] New regression test `tests/scheme/smoke/features-consistency.scm` (8 assertions)
- [x] Audit test `tests/scheme/audit/primitives_list-audit.scm` — 117/117 pass (previously had FAIL markers)
- [x] R7RS suite §6.14 — 13/13 pass
- [x] Full `zig build test` passes

Closes #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)