### PR TITLE
Use globally-unique binding IDs for syntax-rules literal identity (#1272)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -31,10 +31,19 @@ pub const CompileError = error{
     JumpOutOfRange,
 };
 
+var next_binding_id: u32 = 0;
+
+pub fn freshBindingId() u32 {
+    const id = next_binding_id;
+    next_binding_id += 1;
+    return id;
+}
+
 const Local = struct {
     name: []const u8,
     depth: u16,
     slot: u16,
+    binding_id: u32,
     is_boxed: bool = false,
     // Register alias for a global, injected during macro expansion so a
     // template's free reference pierces use-site shadowing. set! through
@@ -263,6 +272,17 @@ pub const Compiler = struct {
         return null;
     }
 
+    pub fn resolveBindingId(self: *Compiler, name: []const u8) ?u32 {
+        var i: usize = self.locals.items.len;
+        while (i > 0) {
+            i -= 1;
+            if (std.mem.eql(u8, self.locals.items[i].name, name)) {
+                return self.locals.items[i].binding_id;
+            }
+        }
+        return null;
+    }
+
     /// Pure predicate: is `name` bound as a lexical variable — a local in this
     /// compiler or any enclosing compiler? Unlike `resolveUpvalue`, this has no
     /// side effects (it does not register upvalues), so the IR optimizer can
@@ -381,6 +401,7 @@ pub const Compiler = struct {
             .name = name,
             .depth = self.scope_depth,
             .slot = slot,
+            .binding_id = freshBindingId(),
         }) catch return CompileError.OutOfMemory;
     }
 

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -251,6 +251,7 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
             .name = types.symbolName(formals),
             .depth = 1,
             .slot = slot,
+            .binding_id = compiler_mod.freshBindingId(),
         }) catch return CompileError.OutOfMemory;
     } else {
         while (param_list != types.NIL) {
@@ -261,6 +262,7 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                     .name = types.symbolName(param_list),
                     .depth = 1,
                     .slot = slot,
+                    .binding_id = compiler_mod.freshBindingId(),
                 }) catch return CompileError.OutOfMemory;
                 break;
             }
@@ -272,6 +274,7 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                 .name = types.symbolName(param),
                 .depth = 1,
                 .slot = slot,
+                .binding_id = compiler_mod.freshBindingId(),
             }) catch return CompileError.OutOfMemory;
             arity += 1;
             param_list = types.cdr(param_list);
@@ -637,6 +640,7 @@ fn compileDefineFromIR(self: *Compiler, data: ir_mod.DefineData, dst: u16) Compi
             .name = types.symbolName(data.name),
             .depth = self.scope_depth,
             .slot = slot,
+            .binding_id = compiler_mod.freshBindingId(),
         }) catch return CompileError.OutOfMemory;
         try self.emitOp(.load_void);
         try self.emitU16(dst);

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -48,6 +48,7 @@ pub fn compileLambda(self: *Compiler, args: Value, dst: u16, name: ?[]const u8) 
             .name = types.symbolName(formals),
             .depth = 1,
             .slot = slot,
+            .binding_id = compiler_mod.freshBindingId(),
         }) catch return CompileError.OutOfMemory;
     } else {
         while (param_list != types.NIL) {
@@ -59,6 +60,7 @@ pub fn compileLambda(self: *Compiler, args: Value, dst: u16, name: ?[]const u8) 
                     .name = types.symbolName(param_list),
                     .depth = 1,
                     .slot = slot,
+                    .binding_id = compiler_mod.freshBindingId(),
                 }) catch return CompileError.OutOfMemory;
                 break;
             }
@@ -71,6 +73,7 @@ pub fn compileLambda(self: *Compiler, args: Value, dst: u16, name: ?[]const u8) 
                 .name = types.symbolName(param),
                 .depth = 1,
                 .slot = slot,
+                .binding_id = compiler_mod.freshBindingId(),
             }) catch return CompileError.OutOfMemory;
             arity += 1;
             param_list = types.cdr(param_list);
@@ -430,6 +433,7 @@ pub fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
                 .name = types.symbolName(target),
                 .depth = self.scope_depth,
                 .slot = slot,
+                .binding_id = compiler_mod.freshBindingId(),
             }) catch return CompileError.OutOfMemory;
             try self.emitOp(.load_void);
             try self.emitU16(dst);
@@ -464,6 +468,7 @@ pub fn compileDefine(self: *Compiler, args: Value, dst: u16) CompileError!void {
                 .name = types.symbolName(name),
                 .depth = self.scope_depth,
                 .slot = slot,
+                .binding_id = compiler_mod.freshBindingId(),
             }) catch return CompileError.OutOfMemory;
             try self.emitOp(.load_void);
             try self.emitU16(dst);

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -10,7 +10,7 @@ const Value = types.Value;
 const MAX_MACRO_EXPANSION_DEPTH: u16 = 256;
 const MAX_MACRO_EXPANSION_STEPS: u32 = 10_000;
 
-fn resolveLocalSkipAliases(ctx: ?*const anyopaque, name: []const u8) u16 {
+fn resolveLocalSkipAliases(ctx: ?*const anyopaque, name: []const u8) u32 {
     const self: *const Compiler = @ptrCast(@alignCast(ctx.?));
     var comp: ?*const Compiler = self;
     while (comp) |c| {
@@ -18,7 +18,7 @@ fn resolveLocalSkipAliases(ctx: ?*const anyopaque, name: []const u8) u16 {
         while (i > 0) {
             i -= 1;
             const local = c.locals.items[i];
-            if (!local.is_global_alias and std.mem.eql(u8, local.name, name)) return local.slot;
+            if (!local.is_global_alias and std.mem.eql(u8, local.name, name)) return local.binding_id;
         }
         comp = c.parent;
     }
@@ -167,6 +167,7 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
             .name = cap.name,
             .depth = self.scope_depth,
             .slot = cap.slot,
+            .binding_id = compiler_mod.freshBindingId(),
         });
     }
     try injectHygienicCapturedLocals(self, expanded_root, tx.captured_locals);
@@ -194,6 +195,7 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
             .name = gname,
             .depth = self.scope_depth,
             .slot = gslot,
+            .binding_id = compiler_mod.freshBindingId(),
             .is_global_alias = true,
         });
     }
@@ -499,11 +501,11 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
     // Binding identity — not just bound/unbound — is needed so that two
     // different bindings with the same name don't falsely match.
     if (lit_count > 0) {
-        const slots = self.gc.allocator.alloc(u16, lit_count) catch return CompileError.OutOfMemory;
+        const slots = self.gc.allocator.alloc(u32, lit_count) catch return CompileError.OutOfMemory;
         for (literals_buf[0..lit_count], 0..) |lv, li| {
             slots[li] = if (types.isSymbol(lv)) blk: {
                 const lname = types.symbolName(lv);
-                if (self.resolveLocal(lname)) |s| break :blk s;
+                if (self.resolveBindingId(lname)) |bid| break :blk bid;
                 for (extra_bound) |eb| {
                     if (std.mem.eql(u8, eb, lname)) break :blk expander.LITERAL_BOUND_PENDING;
                 }
@@ -544,6 +546,7 @@ fn injectHygCapturedWalk(self: *Compiler, expr: Value, captured: []const types.C
                         .name = name,
                         .depth = self.scope_depth,
                         .slot = cap.slot,
+                        .binding_id = compiler_mod.freshBindingId(),
                     });
                 }
                 return;

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -125,14 +125,14 @@ const Binding = struct {
 // Public API
 // ---------------------------------------------------------------------------
 
-pub const LITERAL_UNBOUND: u16 = 0xFFFF;
-pub const LITERAL_BOUND_PENDING: u16 = 0xFFFE;
+pub const LITERAL_UNBOUND: u32 = 0xFFFFFFFF;
+pub const LITERAL_BOUND_PENDING: u32 = 0xFFFFFFFE;
 
 pub const UseSiteBindingCheck = struct {
     ctx: ?*const anyopaque = null,
-    resolve_fn: ?*const fn (?*const anyopaque, []const u8) u16 = null,
+    resolve_fn: ?*const fn (?*const anyopaque, []const u8) u32 = null,
 
-    pub fn resolve(self: UseSiteBindingCheck, name: []const u8) u16 {
+    pub fn resolve(self: UseSiteBindingCheck, name: []const u8) u32 {
         if (self.resolve_fn) |f| return f(self.ctx, name);
         return LITERAL_UNBOUND;
     }
@@ -211,7 +211,7 @@ pub const ExpandError = error{
 // Pattern matching
 // ---------------------------------------------------------------------------
 
-fn matchPattern(pattern: Value, input: Value, literals: []const Value, bindings: *[MAX_BINDINGS]Binding, count: *usize, gc: ?*GC, literal_bound: []const u16, use_check: UseSiteBindingCheck) bool {
+fn matchPattern(pattern: Value, input: Value, literals: []const Value, bindings: *[MAX_BINDINGS]Binding, count: *usize, gc: ?*GC, literal_bound: []const u32, use_check: UseSiteBindingCheck) bool {
     // Symbol patterns
     if (types.isSymbol(pattern)) {
         const name = types.symbolName(pattern);
@@ -292,7 +292,7 @@ fn matchPattern(pattern: Value, input: Value, literals: []const Value, bindings:
     return false;
 }
 
-fn matchListPattern(pattern: Value, input: Value, literals: []const Value, bindings: *[MAX_BINDINGS]Binding, count: *usize, gc: ?*GC, literal_bound: []const u16, use_check: UseSiteBindingCheck) bool {
+fn matchListPattern(pattern: Value, input: Value, literals: []const Value, bindings: *[MAX_BINDINGS]Binding, count: *usize, gc: ?*GC, literal_bound: []const u32, use_check: UseSiteBindingCheck) bool {
     var pat = pattern;
     var inp = input;
 
@@ -349,7 +349,7 @@ fn countPairs(v: Value) ?usize {
     return n;
 }
 
-fn matchEllipsis(elem_pattern: Value, rest_pattern: Value, input: Value, literals: []const Value, bindings: *[MAX_BINDINGS]Binding, count: *usize, gc: ?*GC, literal_bound: []const u16, use_check: UseSiteBindingCheck) bool {
+fn matchEllipsis(elem_pattern: Value, rest_pattern: Value, input: Value, literals: []const Value, bindings: *[MAX_BINDINGS]Binding, count: *usize, gc: ?*GC, literal_bound: []const u32, use_check: UseSiteBindingCheck) bool {
     // Count how many elements the rest_pattern needs (handles improper lists)
     const rest_len = countPairs(rest_pattern) orelse return false;
     const input_len = countPairs(input) orelse return false;

--- a/src/types.zig
+++ b/src/types.zig
@@ -376,7 +376,7 @@ pub const Transformer = struct {
     def_env: ?*std.StringHashMap(Value) = null,
     def_env_val: Value = NIL,
     custom_ellipsis: ?[]const u8 = null,
-    literal_bound: []u16 = &.{},
+    literal_bound: []u32 = &.{},
     let_syntax_peer_names: [][]const u8 = &.{},
     let_syntax_peer_vals: []Value = &.{},
 };

--- a/tests/scheme/hygiene/literal-binding.scm
+++ b/tests/scheme/hygiene/literal-binding.scm
@@ -114,6 +114,26 @@
      (define lit 42)
      (m lit))))
 
+;; --- Cross-frame: nested lambda shadows same-name literal (#1272) ---
+(test-equal "cross-frame literal shadow — different binding identity"
+  'no
+  ((lambda (lit)
+     (define-syntax m
+       (syntax-rules (lit)
+         ((_ lit) 'yes)
+         ((_ x)   'no)))
+     ((lambda (lit) (m lit)) 99)) 1))
+
+;; Positive: same-frame literal still matches through nested lambda call
+(test-equal "cross-frame same literal — matches"
+  'yes
+  ((lambda (lit)
+     (define-syntax m
+       (syntax-rules (lit)
+         ((_ lit) 'yes)
+         ((_ x)   'no)))
+     (m lit)) 1))
+
 (let ((runner (test-runner-current)))
   (test-end "literal-binding")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Replace per-frame register slot numbers (`u16`) with monotonic binding IDs (`u32`) for `syntax-rules` literal identity comparison. Slot indices are scoped to their owning `Compiler` frame, so two different bindings in nested lambdas occupying the same register slot falsely compared as equal.
- Add `binding_id: u32` to the `Local` struct, assigned via `freshBindingId()` at every local creation site.
- Widen `Transformer.literal_bound`, `LITERAL_UNBOUND`/`LITERAL_BOUND_PENDING` sentinels, and `UseSiteBindingCheck.resolve` from `u16` to `u32`.

Fixes #1272.

## Test plan

- [x] Reproduction case now returns `no` (was `yes`): `((lambda (lit) (define-syntax m (syntax-rules (lit) ((_ lit) 'yes) ((_ x) 'no))) ((lambda (lit) (m lit)) 99)) 1)`
- [x] Same-frame case still correct (`not-literal`)
- [x] Same-binding positive case still matches (`is-literal`)
- [x] Unbound-matches-unbound still works
- [x] Two new regression tests in `tests/scheme/hygiene/literal-binding.scm`
- [x] All 1784 tests pass (1395 R7RS + 389 Scheme files)
- [x] `zig build test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)