### PR TITLE
Move parameterize converter application outside dynamic-wind extent

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -677,8 +677,8 @@ fn buildQQListExpr(gc: *@import("memory.zig").GC, quote_sym: Value, list_sym: Va
 ///
 /// Desugars to:
 ///   (let ((%pp0 p1) (%pp1 p2) ... (%pv0 v1) (%pv1 v2) ...)
-///     (let* ((old0 (%pp0)) (new0 (begin (%pp0 %pv0) (%pp0)))
-///            (old1 (%pp1)) (new1 (begin (%pp1 %pv1) (%pp1))) ...)
+///     (let* ((old0 (%pp0)) (new0 (%parameter-convert %pp0 %pv0))
+///            (old1 (%pp1)) (new1 (%parameter-convert %pp1 %pv1)) ...)
 ///       (dynamic-wind
 ///         (lambda () (%parameter-set! %pp0 new0) (%parameter-set! %pp1 new1) ...)
 ///         (lambda () body ...)
@@ -686,9 +686,9 @@ fn buildQQListExpr(gc: *@import("memory.zig").GC, quote_sym: Value, list_sym: Va
 ///
 /// The outer `let` evaluates all param and value expressions before any
 /// parameter cell is mutated (R7RS §4.2.6, SRFI-39). The inner `let*`
-/// sequentially saves old values and installs new ones through each
-/// parameter's converter. The before-thunk uses %parameter-set! to avoid
-/// re-applying the converter on continuation re-entry.
+/// saves old values and runs converters without mutating cells.
+/// All mutation happens inside `dynamic-wind`, so converter errors and
+/// continuation re-entries are safe.
 pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
     if (args == types.NIL) return CompileError.InvalidSyntax;
     const bindings = types.car(args);
@@ -779,20 +779,18 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
             outer_bindings = gc.allocPair(pp_pair, outer_bindings) catch return CompileError.OutOfMemory;
         }
 
-        // Inner let*: save old values and compute new (converted) values.
-        //   (let* ((old0 (%pp0)) (new0 (begin (%pp0 %pv0) (%pp0)))
-        //          (old1 (%pp1)) (new1 (begin (%pp1 %pv1) (%pp1))) ...)
+        // Inner let*: save old values and convert new values without mutation.
+        //   (let* ((old0 (%pp0)) (new0 (%parameter-convert %pp0 %pv0))
+        //          (old1 (%pp1)) (new1 (%parameter-convert %pp1 %pv1)) ...)
         //     (dynamic-wind ...))
+        const pconv_sym = gc.allocSymbol("%parameter-convert") catch return CompileError.OutOfMemory;
         var inner_bindings: Value = types.NIL;
         i = binding_count;
         while (i > 0) {
             i -= 1;
-            // (new_i (begin (%pp_i %pv_i) (%pp_i)))
-            const set_call = gc.allocPair(param_syms[i], gc.allocPair(val_syms[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-            const get_call = gc.allocPair(param_syms[i], types.NIL) catch return CompileError.OutOfMemory;
-            const begin_body = gc.allocPair(set_call, gc.allocPair(get_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
-            const begin_expr = gc.allocPair(begin_sym, begin_body) catch return CompileError.OutOfMemory;
-            const new_pair = gc.allocPair(new_syms[i], gc.allocPair(begin_expr, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            // (new_i (%parameter-convert %pp_i %pv_i))
+            const conv_call = gc.allocPair(pconv_sym, gc.allocPair(param_syms[i], gc.allocPair(val_syms[i], types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+            const new_pair = gc.allocPair(new_syms[i], gc.allocPair(conv_call, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
             inner_bindings = gc.allocPair(new_pair, inner_bindings) catch return CompileError.OutOfMemory;
 
             // (old_i (%pp_i))

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -22,6 +22,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "get-environment-variables", .func = &getEnvVars, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_process_context), .sandbox = false },
     .{ .name = "make-parameter", .func = &makeParameterFn, .arity = .{ .variadic = 1 }, .libs = LS.initMany(&.{ .scheme_base, .srfi_39 }) },
     .{ .name = "%parameter-set!", .func = &parameterSetDirectFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%parameter-convert", .func = &parameterConvertFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "eval", .func = &evalFn, .arity = .{ .variadic = 1 }, .libs = LS.initMany(&.{ .scheme_eval, .scheme_r5rs }), .sandbox = false },
     .{ .name = "environment", .func = &environmentFn, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.scheme_eval), .sandbox = false },
     .{ .name = "interaction-environment", .func = &interactionEnvironmentFn, .arity = .{ .exact = 0 }, .libs = LS.initMany(&.{ .scheme_eval, .scheme_r5rs, .scheme_repl }), .sandbox = false },
@@ -344,6 +345,14 @@ fn parameterSetDirectFn(args: []const Value) PrimitiveError!Value {
         if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     }
     return types.VOID;
+}
+
+fn parameterConvertFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isParameter(args[0])) return primitives.typeError("%parameter-convert", "parameter", args[0]);
+    const param = types.toObject(args[0]).as(types.ParameterObject);
+    if (param.converter == types.NIL) return args[1];
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    return vm.callWithArgs(param.converter, &[_]Value{args[1]}) catch |err| return err;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/scheme/smoke/parameterize-convert-1266.scm
+++ b/tests/scheme/smoke/parameterize-convert-1266.scm
@@ -1,0 +1,58 @@
+;;; Regression tests for #1266: parameterize converter mutations must not
+;;; leak outside dynamic-wind extent.
+
+(import (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define-syntax test
+  (syntax-rules ()
+    ((_ name expected actual)
+     (let ((e expected) (a actual))
+       (if (equal? e a)
+           (set! pass (+ pass 1))
+           (begin
+             (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (display e)
+             (display " got ") (display a) (newline)))))))
+
+;; 1. A later converter must NOT observe an earlier binding's new value.
+;;    SRFI-39 ref impl converts all values before installing any binding.
+(let ()
+  (define a (make-parameter 1))
+  (define b (make-parameter 0 (lambda (v) (a))))
+  (test "converter sees old value"
+        1
+        (parameterize ((a 2) (b 99)) (b))))
+
+;; 2. A converter error mid-install must not permanently leak an earlier
+;;    mutation — dynamic-wind's after-thunk must restore all parameters.
+(let ()
+  (define p (make-parameter 1))
+  (define w (make-parameter #t (lambda (x)
+              (if (boolean? x) x (error "bad")))))
+  (test "converter error does not leak"
+        1
+        (guard (e (#t (p)))
+          (parameterize ((p 2) (w 'oops)) 'x))))
+
+;; 3. Duplicate params must restore the original value, not a mid-install
+;;    snapshot.
+(let ()
+  (define q (make-parameter 0))
+  (parameterize ((q 1) (q 2))
+    (test "duplicate param body value" 2 (q)))
+  (test "duplicate param restores original" 0 (q)))
+
+;; 4. Basic converter still works (sanity).
+(let ()
+  (define p (make-parameter 0 (lambda (v) (* v 10))))
+  (test "converter applied in parameterize" 50
+        (parameterize ((p 5)) (p)))
+  (test "original restored after parameterize" 0 (p)))
+
+(display pass) (display " pass, ")
+(display fail) (display " fail") (newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

Fixes #1266.

- Add `%parameter-convert` primitive that applies a parameter's converter without mutating the cell
- Update `compileParameterize` desugaring so the inner `let*` uses `(%parameter-convert %pp %pv)` instead of the mutating `(begin (%pp %pv) (%pp))` idiom
- All parameter cell mutation now happens inside `dynamic-wind`'s before/after thunks, making converter errors and continuation re-entries safe

This fixes three consequences of the old desugaring:
1. A later converter no longer observes an earlier binding's new value
2. A converter error mid-install no longer permanently leaks an earlier mutation
3. Duplicate params now correctly restore the original value

## Test plan

- [x] New regression tests in `tests/scheme/smoke/parameterize-convert-1266.scm` (6 tests covering all three bug scenarios + converter sanity)
- [x] Full R7RS suite: 1395 pass, 0 fail
- [x] Full Scheme suite: 1788 pass, 0 fail
- [x] Zig unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)