### PR TITLE
Capture let/lambda locals in define-syntax transformers (#1271)

### DIFF
--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -441,6 +441,7 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
                 tx_obj.def_env = env;
                 tx_obj.def_env_val = child.lib_env_val;
             }
+            try macro.captureLocalsOnTransformer(&child, tx_val);
             child.macros.put(ds_name, tx_val) catch return CompileError.OutOfMemory;
             current = types.cdr(current);
             continue;

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -321,6 +321,7 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
                 tx.def_env = env;
                 tx.def_env_val = self.lib_env_val;
             }
+            try macro.captureLocalsOnTransformer(self, transformer);
             self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
         } else {
             break;

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -259,8 +259,8 @@ pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!
         tx.def_env_val = self.lib_env_val;
     }
 
-    // Store in macro table; inside a body, track the registration so
-    // the enclosing body scope removes it on exit (R7RS 5.3).
+    try captureLocalsOnTransformer(self, transformer);
+
     const name = types.symbolName(keyword);
     try self.recordBodyMacro(name);
     self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
@@ -391,7 +391,7 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
     restoreMacros(self, saved_names.items, saved_values.items);
 }
 
-fn captureLocalsOnTransformer(self: *Compiler, transformer: Value) CompileError!void {
+pub fn captureLocalsOnTransformer(self: *Compiler, transformer: Value) CompileError!void {
     if (self.locals.items.len == 0) return;
     const tx = types.toObject(transformer).as(types.Transformer);
     const caps = self.gc.allocator.alloc(types.CapturedLocal, self.locals.items.len) catch return CompileError.OutOfMemory;

--- a/tests/scheme/hygiene/define-syntax-capture.scm
+++ b/tests/scheme/hygiene/define-syntax-capture.scm
@@ -1,0 +1,76 @@
+;; Regression test for #1271: define-syntax must capture let/lambda
+;; bindings from its definition scope (same as let-syntax).
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "define-syntax-capture")
+
+;; --- let binding ---
+(test-equal "let binding captured by define-syntax"
+  7
+  (let ((y 7))
+    (define-syntax gety (syntax-rules () ((_) y)))
+    (gety)))
+
+;; --- let* binding ---
+(test-equal "let* binding captured by define-syntax"
+  7
+  (let* ((y 7))
+    (define-syntax gety (syntax-rules () ((_) y)))
+    (gety)))
+
+;; --- lambda parameter ---
+(test-equal "lambda parameter captured by define-syntax"
+  7
+  ((lambda (y)
+     (define-syntax gety (syntax-rules () ((_) y)))
+     (gety)) 7))
+
+;; --- let + intervening define before define-syntax ---
+(test-equal "let binding with intervening define"
+  7
+  (let ((y 7))
+    (define z 1)
+    (define-syntax gety (syntax-rules () ((_) y)))
+    (gety)))
+
+;; --- Multiple captured locals ---
+(test-equal "multiple let bindings captured"
+  15
+  (let ((a 5) (b 10))
+    (define-syntax sum-ab (syntax-rules () ((_) (+ a b))))
+    (sum-ab)))
+
+;; --- Nested let scopes ---
+(test-equal "inner let binding shadows outer in define-syntax"
+  20
+  (let ((x 10))
+    (let ((x 20))
+      (define-syntax getx (syntax-rules () ((_) x)))
+      (getx))))
+
+;; --- let-syntax parity: both should behave the same ---
+(test-equal "let-syntax captures let binding (baseline)"
+  7
+  (let ((y 7))
+    (let-syntax ((gety (syntax-rules () ((_) y))))
+      (gety))))
+
+;; --- Global reference still works ---
+(define g 99)
+(test-equal "global reference in define-syntax template"
+  99
+  (let ((y 7))
+    (define-syntax getg (syntax-rules () ((_) g)))
+    (getg)))
+
+;; --- Internal define in procedure body still works ---
+(test-equal "internal define captured by body define-syntax"
+  7
+  (let ()
+    (define y 7)
+    (define-syntax gety (syntax-rules () ((_) y)))
+    (gety)))
+
+(let ((runner (test-runner-current)))
+  (test-end "define-syntax-capture")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- `define-syntax` inside `let`/`let*`/`lambda` bodies failed to resolve free references to enclosing lexical bindings — the hygiene renamer emitted `__hyg_N_var` identifiers that were never mapped back, producing "undefined variable" errors
- Added `captureLocalsOnTransformer` calls to all three `define-syntax` code paths, matching the existing `let-syntax` behavior
- Made `captureLocalsOnTransformer` public so `compiler_lambda.zig` and `compiler_ir.zig` can call it

## Test plan

- [x] New regression test `tests/scheme/hygiene/define-syntax-capture.scm` (9 cases: let, let*, lambda, intervening define, multiple locals, nested scopes, let-syntax parity, global ref, internal define)
- [x] All 1788 existing tests pass (0 failures)
- [x] R7RS suite: 1395 pass, 0 fail

Closes #1271

🤖 Generated with [Claude Code](https://claude.com/claude-code)