### PR TITLE
Support import-set modifiers in environment (#1189)

### DIFF
--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -208,22 +208,13 @@ fn environmentFn(args: []const Value) PrimitiveError!Value {
     // Create a new environment containing bindings from the given import sets.
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const library_mod = @import("library.zig");
 
     const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;
     env_map.* = std.StringHashMap(Value).init(gc.allocator);
 
+    const vm_library = @import("vm_library.zig");
     for (args) |import_set| {
-        const lib_name = library_mod.libraryNameToString(gc.allocator, import_set) catch return PrimitiveError.TypeError; // bare-ok: invalid import set
-        defer gc.allocator.free(lib_name);
-
-        const vm_library = @import("vm_library.zig");
-        vm_library.ensureLibraryLoaded(vm, import_set, lib_name) catch return PrimitiveError.TypeError; // bare-ok: library load failure
-        const lib = vm.libraries.get(lib_name) orelse return PrimitiveError.TypeError; // bare-ok: library not found
-        var it = lib.exports.iterator();
-        while (it.next()) |entry| {
-            env_map.put(entry.key_ptr.*, entry.value_ptr.*) catch return PrimitiveError.OutOfMemory;
-        }
+        vm_library.processImportSet(vm, env_map, import_set) catch return PrimitiveError.TypeError; // bare-ok: invalid import set
     }
 
     return gc.allocEnvironment(env_map, true, true) catch return PrimitiveError.OutOfMemory;

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -339,6 +339,39 @@ test "eval tail position runs in constant frame depth (#1253)" {
 // guard desugars its body into a lambda, putting eval in tail position and
 // routing through get_global (not call_global). Without restricted_globals,
 // get_global falls back to vm.globals, letting car resolve.
+test "environment accepts import-set modifiers (#1189)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    // only
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(try ctx.vm.eval(
+        "(eval '(+ 1 2) (environment '(only (scheme base) +)))",
+    )));
+    // except
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(try ctx.vm.eval(
+        "(eval '(+ 1 2) (environment '(except (scheme base) car)))",
+    )));
+    // prefix
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(try ctx.vm.eval(
+        "(eval '(b:+ 3 4) (environment '(prefix (scheme base) b:)))",
+    )));
+    // rename
+    try std.testing.expectEqual(@as(i64, 30), types.toFixnum(try ctx.vm.eval(
+        "(eval '(add 10 20) (environment '(rename (scheme base) (+ add))))",
+    )));
+    // nested: only on prefix
+    try std.testing.expectEqual(@as(i64, 11), types.toFixnum(try ctx.vm.eval(
+        "(eval '(s:+ 5 6) (environment '(only (prefix (scheme base) s:) s:+)))",
+    )));
+    // only restricts excluded bindings
+    const result = try ctx.vm.eval(
+        \\(guard (e (#t 'restricted))
+        \\  (eval '(- 5 3) (environment '(only (scheme base) +))))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("restricted", types.symbolName(result));
+}
+
 test "null-environment eval in tail position respects restriction (#1253)" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -140,7 +140,7 @@ pub fn ensureLibraryLoaded(vm: *VM, import_set: Value, lib_name: []const u8) !vo
     tryLoadLibraryFromFile(vm, import_set) catch return error.CompileError;
 }
 
-fn processImportSet(vm: *VM, target: *std.StringHashMap(Value), import_set: Value) !void {
+pub fn processImportSet(vm: *VM, target: *std.StringHashMap(Value), import_set: Value) !void {
     if (!types.isPair(import_set)) return error.InvalidSyntax;
 
     const first = types.car(import_set);

--- a/tests/scheme/audit/primitives_r7rs-audit.scm
+++ b/tests/scheme/audit/primitives_r7rs-audit.scm
@@ -69,10 +69,9 @@
 (test 'caught (guard (e (#t 'caught)) (environment 42)))
 (test 'caught (guard (e (#t 'caught)) (environment '(no such library))))
 ;; R7RS 6.12: the arguments are IMPORT SETS, so only/except/prefix/rename
-;; must be accepted; kaappi only accepts plain library names.
-;; FAIL: #1189 (environment rejects import-set modifiers)
-;; (test 3 (eval '(+ 1 2) (environment '(only (scheme base) +))))
-;; (test 3 (eval '(base:+ 1 2) (environment '(prefix (scheme base) base:))))
+;; must be accepted.
+(test 3 (eval '(+ 1 2) (environment '(only (scheme base) +))))
+(test 3 (eval '(base:+ 1 2) (environment '(prefix (scheme base) base:))))
 
 ;;; --- interaction-environment / null-environment / scheme-report-environment ---
 (test #t (and (interaction-environment) #t))


### PR DESCRIPTION
## Summary

- Route `environment`'s arguments through `processImportSet` (the same path used by `import`) instead of manually calling `libraryNameToString`, which only accepted plain library names
- Adds support for `only`, `except`, `prefix`, `rename`, and nested combinations in `(environment ...)` as required by R7RS §6.12
- Enables two previously-disabled audit tests

## Test plan

- [x] Unit test covering all four modifiers (`only`, `except`, `prefix`, `rename`), nested modifiers (`only` on `prefix`), and restriction enforcement
- [x] Audit test `primitives_r7rs-audit.scm` passes (44/44)
- [x] R7RS test suite passes (0 failures)
- [x] `zig build test` passes with zero leaks

Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)