### PR TITLE
Accept multiple comma-separated labels in /parallel-issues skill

### DIFF
--- a/.claude/skills/parallel-issues/SKILL.md
+++ b/.claude/skills/parallel-issues/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: parallel-issues
-description: Group open GitHub issues into parallel sets for concurrent Claude Code sessions. Use when the user asks to batch issues, plan parallel work, triage open issues for parallel fixing, or create issue sets. Accepts an optional label to restrict which issues are considered.
-argument-hint: "[label]"
+description: Group open GitHub issues into parallel sets for concurrent Claude Code sessions. Use when the user asks to batch issues, plan parallel work, triage open issues for parallel fixing, or create issue sets. Accepts an optional label (or multiple comma-separated labels) to restrict which issues are considered.
+argument-hint: "[label[,label,...]]"
 ---
 
 # Parallel Issue Sets
 
-An optional label may be passed as an argument: `$ARGUMENTS`
+Optional labels may be passed as a comma-separated argument: `$ARGUMENTS`
 
 Look up open GitHub issues with:
 
@@ -14,9 +14,11 @@ Look up open GitHub issues with:
 gh issue list --state open --limit 500 --json number,title,labels,assignees,body
 ```
 
-If a label argument was provided, add `--label "<label>"` (quoted — labels may
-contain spaces). If the filtered list comes back empty, say so and stop; don't
-fall back to all open issues.
+If labels were provided, split them on commas (trimming whitespace) and add a
+separate `--label "<label>"` flag for each one (quoted — labels may contain
+spaces). Multiple `--label` flags AND-filter: an issue must carry all of them.
+If the filtered list comes back empty, say so and stop; don't fall back to
+all open issues or fewer labels.
 
 If the returned count equals the limit, raise the limit and rerun — a silently
 truncated list would drop issues from the plan.

--- a/.claude/skills/parallel-issues/evals/evals.json
+++ b/.claude/skills/parallel-issues/evals/evals.json
@@ -35,6 +35,17 @@
         "Response states that no open issues carry the 'documentation' label",
         "Response contains no set lines (no fallback to batching the whole tracker)"
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Group the open issues that are labeled both bug and macros into parallel sets. (skill argument: bug,macros)",
+      "expected_output": "Sets containing only issues that carry BOTH the bug and macros labels, correct set-line format. If no issues match, a statement that none match with no fallback.",
+      "files": [],
+      "expectations": [
+        "gh issue list is called with both --label \"bug\" and --label \"macros\"",
+        "Only issues carrying both labels appear in the sets",
+        "Response does not fall back to a single label or all issues if the intersection is empty"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The `/parallel-issues` skill now accepts multiple comma-separated labels (e.g. `/parallel-issues bug,macros`)
- Each label becomes a separate `--label` flag for `gh issue list`, which AND-filters them
- The no-fallback rule applies to the full label set — won't drop labels or fall back to unfiltered results
- Added eval case for multi-label filtering

## Test plan
- [ ] `/parallel-issues macros` still works (single label, existing behavior)
- [ ] `/parallel-issues bug,macros` filters to issues carrying both labels
- [ ] `/parallel-issues nonexistent,macros` reports no matches without fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)