### PR TITLE
Expand macros during set! target pre-scan (#1250)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -79,7 +79,7 @@ pub const Compiler = struct {
     // so nested lambda bodies see the same suppression set. Consulted by the
     // constant folders (IR and legacy) to avoid folding calls to a name that
     // may be reassigned before the call executes.
-    set_targets: ?*const std.StringHashMap(void) = null,
+    set_targets: ?*std.StringHashMap(void) = null,
     scope_depth: u16 = 0,
     next_register: u16 = 0,
     parent: ?*Compiler = null,
@@ -341,6 +341,15 @@ pub const Compiler = struct {
         }
     }
 
+    /// Scan `expr` for set! targets and add them to the current set_targets map.
+    /// Called from expandAndCompileMacroUse after expansion to discover targets
+    /// introduced by macro templates (#1250).
+    pub fn scanSetTargets(self: *Compiler, expr: Value) CompileError!void {
+        if (self.set_targets) |st| {
+            try collectSetTargets(self, expr, st, 0);
+        }
+    }
+
     /// Box a local if its name is a set! target anywhere in the top-level form.
     /// R7RS §3.4: set! modifies the store (a heap location), not the
     /// continuation. Register-allocated mutated locals violate this when a
@@ -422,7 +431,7 @@ pub const Compiler = struct {
         // (including in nested lambda bodies, which inherit this set).
         var set_targets = std.StringHashMap(void).init(self.gc.allocator);
         defer set_targets.deinit();
-        try collectSetTargets(expr_root, &set_targets);
+        try collectSetTargets(self, expr_root, &set_targets, 0);
         self.set_targets = &set_targets;
         defer self.set_targets = null;
 
@@ -836,10 +845,12 @@ fn formatSyntaxError(args: Value) void {
 /// Recursively collect the symbol names that appear as the target of a
 /// `(set! <name> ...)` anywhere in `expr` into `out`. Used to suppress
 /// constant folding of those names within the enclosing form (see
-/// Compiler.set_targets). Conservative: it scans every sub-form except the
-/// interior of `quote`d data. Iterates the cdr spine to stay bounded on long
-/// lists and only recurses into car sub-forms.
-fn collectSetTargets(expr: Value, out: *std.StringHashMap(void)) CompileError!void {
+/// Compiler.set_targets) and to box locals for correct continuation
+/// semantics (R7RS §3.4). Conservative: it scans every sub-form except
+/// the interior of `quote`d data. When a known macro is encountered,
+/// it is expanded and the expansion is scanned (#1250).
+fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void), depth: u16) CompileError!void {
+    if (depth > 256) return;
     var cur = expr;
     while (types.isPair(cur)) {
         const head = types.car(cur);
@@ -854,9 +865,30 @@ fn collectSetTargets(expr: Value, out: *std.StringHashMap(void)) CompileError!vo
                         out.put(types.symbolName(target), {}) catch return CompileError.OutOfMemory;
                     }
                 }
+            } else if (self.lookupMacro(types.symbolName(head))) |transformer| {
+                self.gc.no_collect += 1;
+                const expanded = expander.expandMacro(
+                    self.gc,
+                    cur,
+                    transformer,
+                    self.globals,
+                    &self.macros,
+                    .{},
+                ) catch {
+                    self.gc.no_collect -= 1;
+                    try collectSetTargets(self, head, out, depth);
+                    cur = types.cdr(cur);
+                    continue;
+                };
+                var expanded_root = expanded;
+                self.gc.pushRoot(&expanded_root);
+                self.gc.no_collect -= 1;
+                try collectSetTargets(self, expanded_root, out, depth + 1);
+                self.gc.popRoot();
+                return;
             }
         }
-        try collectSetTargets(head, out);
+        try collectSetTargets(self, head, out, depth);
         cur = types.cdr(cur);
     }
 }

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -866,6 +866,11 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
                     }
                 }
             } else if (self.lookupMacro(types.symbolName(head))) |transformer| {
+                // Best-effort expansion: uses an empty UseSiteBindingCheck
+                // (no locals exist at pre-scan time), so patterns with
+                // literals may diverge from the real expansion.  Part B
+                // (scanSetTargets in expandAndCompileMacroUse) corrects
+                // any misses at real-expansion time.
                 self.gc.no_collect += 1;
                 const expanded = expander.expandMacro(
                     self.gc,
@@ -876,15 +881,14 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
                     .{},
                 ) catch {
                     self.gc.no_collect -= 1;
-                    try collectSetTargets(self, head, out, depth);
                     cur = types.cdr(cur);
                     continue;
                 };
                 var expanded_root = expanded;
                 self.gc.pushRoot(&expanded_root);
+                defer self.gc.popRoot();
                 self.gc.no_collect -= 1;
                 try collectSetTargets(self, expanded_root, out, depth + 1);
-                self.gc.popRoot();
                 return;
             }
         }

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -161,6 +161,7 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
     self.gc.pushRoot(&expanded_root);
     defer self.gc.popRoot();
     self.gc.no_collect -= 1;
+    try self.scanSetTargets(expanded_root);
     const saved_locals_len = self.locals.items.len;
     for (tx.captured_locals) |cap| {
         try self.locals.append(self.gc.allocator, .{

--- a/tests/scheme/continuations/callcc-set-store.scm
+++ b/tests/scheme/continuations/callcc-set-store.scm
@@ -125,6 +125,17 @@
        n))
    0))
 
+;; 13. Nested macro: outer macro expands to inner macro that does set! — #1250
+(define-syntax apply-twice
+  (syntax-rules ()
+    ((_ op v) (begin (op v) (op v)))))
+(test-equal "nested macro-introduced set! persists" 4
+  (let ((n 0) (k* #f))
+    (call/cc (lambda (k) (set! k* k)))
+    (apply-twice inc! n)
+    (if (< n 4) (k* #f))
+    n))
+
 (let ((runner (test-runner-current)))
   (test-end "callcc-set-store")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/continuations/callcc-set-store.scm
+++ b/tests/scheme/continuations/callcc-set-store.scm
@@ -1,30 +1,20 @@
 ;; Regression test for #1168: set! of non-captured locals must persist
 ;; across continuation re-entry (R7RS §3.4 store semantics).
-;;
-;; Known gap (#1250): macro-introduced set! bypasses collectSetTargets
-;; (pre-expansion scan), so boxing is not applied.
-;;
-;; FAIL: #1250 macro-introduced set! (inc! wrapper) — HANGS
-;; (define-syntax inc! (syntax-rules () ((_ v) (set! v (+ v 1)))))
-;; (test-equal "macro-introduced set! persists" 3
-;;   (let ((n 0) (k* #f))
-;;     (call/cc (lambda (k) (set! k* k)))
-;;     (inc! n)
-;;     (if (< n 3) (k* #f))
-;;     n))
-;;
-;; FAIL: #1250 macro that expands to entire let+set! — HANGS
-;; (define-syntax counter-loop
-;;   (syntax-rules ()
-;;     ((_ limit)
-;;      (let ((n 0) (k* #f))
-;;        (call/cc (lambda (k) (set! k* k)))
-;;        (set! n (+ n 1))
-;;        (if (< n limit) (k* #f))
-;;        n))))
-;; (test-equal "macro-expanded let+set! persists" 3
-;;   (counter-loop 3))
+;; Tests 9-12: regression for #1250 (macro-introduced set!).
 (import (scheme base) (scheme process-context) (srfi 64))
+
+(define-syntax inc!
+  (syntax-rules ()
+    ((_ v) (set! v (+ v 1)))))
+
+(define-syntax counter-loop
+  (syntax-rules ()
+    ((_ limit)
+     (let ((n 0) (k* #f))
+       (call/cc (lambda (k) (set! k* k)))
+       (set! n (+ n 1))
+       (if (< n limit) (k* #f))
+       n))))
 
 (test-begin "callcc-set-store")
 
@@ -104,6 +94,36 @@
     (set! n (+ n 1))
     (if (< (read-n) 3) (k* #f))
     n))
+
+;; 9. Macro-introduced set! (inc! wrapper) — #1250
+(test-equal "macro-introduced set! persists" 3
+  (let ((n 0) (k* #f))
+    (call/cc (lambda (k) (set! k* k)))
+    (inc! n)
+    (if (< n 3) (k* #f))
+    n))
+
+;; 10. Macro that expands to entire let+set! — #1250
+(test-equal "macro-expanded let+set! persists" 3
+  (counter-loop 3))
+
+;; 11. let* with macro-introduced set! — #1250
+(test-equal "let*: macro-introduced set! persists" 3
+  (let* ((n 0) (k* #f))
+    (call/cc (lambda (k) (set! k* k)))
+    (inc! n)
+    (if (< n 3) (k* #f))
+    n))
+
+;; 12. Lambda param with macro-introduced set! — #1250
+(test-equal "lambda param: macro-introduced set! persists" 3
+  ((lambda (n)
+     (let ((k* #f))
+       (call/cc (lambda (k) (set! k* k)))
+       (inc! n)
+       (if (< n 3) (k* #f))
+       n))
+   0))
 
 (let ((runner (test-runner-current)))
   (test-end "callcc-set-store")


### PR DESCRIPTION
## Summary

- `collectSetTargets` now expands known macros to discover `set!` targets introduced by macro templates (Part A — catches use-site targets like `n` in `(inc! n)`)
- Post-expansion scan in `expandAndCompileMacroUse` catches template-introduced targets whose hygienic names only stabilize at real expansion time (Part B — catches `counter-loop`-style macros)
- Adds 4 regression tests covering `let`, `let*`, lambda param, and whole-form macro expansion

## Test plan

- [x] `zig build test` — all unit tests pass
- [x] `zig build run -- tests/scheme/continuations/callcc-set-store.scm` — 12/12 pass (4 new)
- [x] R7RS suite — 1395 pass, 0 fail
- [x] `bash tests/scheme/run-all.sh` — 1789 pass, 0 fail

Fixes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)