### PR TITLE
Root hash-table-walk/fold snapshot entries to prevent use-after-free (#1181)

### DIFF
--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -293,6 +293,13 @@ fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
     const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(snapshot);
 
+    const scope = gc.rootedScope();
+    defer scope.release();
+    for (snapshot) |entry| {
+        gc.extra_roots.append(gc.allocator, entry.key) catch return PrimitiveError.OutOfMemory;
+        gc.extra_roots.append(gc.allocator, entry.value) catch return PrimitiveError.OutOfMemory;
+    }
+
     for (snapshot) |entry| {
         const call_args = [2]Value{ entry.key, entry.value };
         _ = vm.callWithArgs(proc, &call_args) catch |err| {
@@ -500,6 +507,13 @@ fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
 
     const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(snapshot);
+
+    const scope = gc.rootedScope();
+    defer scope.release();
+    for (snapshot) |entry| {
+        gc.extra_roots.append(gc.allocator, entry.key) catch return PrimitiveError.OutOfMemory;
+        gc.extra_roots.append(gc.allocator, entry.value) catch return PrimitiveError.OutOfMemory;
+    }
 
     for (snapshot) |entry| {
         const call_args = [3]Value{ entry.key, entry.value, acc };

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -293,6 +293,8 @@ fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
     const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(snapshot);
 
+    // Root all entries up front: the first callback can delete+allocate and
+    // free a not-yet-visited entry's key/value that only the snapshot holds.
     const scope = gc.rootedScope();
     defer scope.release();
     for (snapshot) |entry| {
@@ -508,6 +510,8 @@ fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
     const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(snapshot);
 
+    // Root all entries up front: the first callback can delete+allocate and
+    // free a not-yet-visited entry's key/value that only the snapshot holds.
     const scope = gc.rootedScope();
     defer scope.release();
     for (snapshot) |entry| {

--- a/tests/scheme/audit/primitives_hashtable-audit.scm
+++ b/tests/scheme/audit/primitives_hashtable-audit.scm
@@ -181,26 +181,23 @@
                                 (hash-table-set! ht (list k) v)
                                 (set! seen (+ seen 1))))
           seen))
-;; The walk/fold snapshot is invisible to the GC: if the callback deletes
-;; entries and allocates, the snapshot's keys/values are freed and reused,
-;; and the callback receives corrupted pairs. Passes on a default build;
-;; fails under -Dgc-stress=true (verified: 29/30 entries corrupted).
-;; FAIL: #1181 (walk/fold snapshot unrooted — use-after-free under GC pressure)
-;; (test '(435 0)
-;;     (let ((ht (make-hash-table)) (sum 0) (bad 0))
-;;       (do ((i 0 (+ i 1))) ((= i 30))
-;;         (hash-table-set! ht (cons i 'key) (cons i 'val)))
-;;       (hash-table-walk ht
-;;         (lambda (k v)
-;;           (do ((j 0 (+ j 1))) ((= j 30))
-;;             (hash-table-delete! ht (cons j 'key)))
-;;           (do ((j 0 (+ j 1))) ((= j 100))
-;;             (cons j (make-vector 4 j)))
-;;           (if (and (pair? k) (pair? v) (eq? (cdr k) 'key) (eq? (cdr v) 'val)
-;;                    (= (car k) (car v)))
-;;               (set! sum (+ sum (car k)))
-;;               (set! bad (+ bad 1)))))
-;;       (list sum bad)))
+;; Regression test for #1181: walk/fold snapshot keys/values must be rooted
+;; so GC doesn't free them when the callback deletes entries and allocates.
+(test '(435 0)
+    (let ((ht (make-hash-table)) (sum 0) (bad 0))
+      (do ((i 0 (+ i 1))) ((= i 30))
+        (hash-table-set! ht (cons i 'key) (cons i 'val)))
+      (hash-table-walk ht
+        (lambda (k v)
+          (do ((j 0 (+ j 1))) ((= j 30))
+            (hash-table-delete! ht (cons j 'key)))
+          (do ((j 0 (+ j 1))) ((= j 100))
+            (cons j (make-vector 4 j)))
+          (if (and (pair? k) (pair? v) (eq? (cdr k) 'key) (eq? (cdr v) 'val)
+                   (= (car k) (car v)))
+              (set! sum (+ sum (car k)))
+              (set! bad (+ bad 1)))))
+      (list sum bad)))
 
 ;;; --- update!/default ---
 (test 11 (let ((ht (make-hash-table)))

--- a/tests/scheme/smoke/hash-table-walk-gc-1181.scm
+++ b/tests/scheme/smoke/hash-table-walk-gc-1181.scm
@@ -1,0 +1,46 @@
+;; Regression test for #1181: hash-table-walk/fold snapshot must root
+;; keys/values so GC doesn't free them when the callback deletes entries
+;; and allocates.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 69))
+
+(test-begin "hash-table-walk-gc-1181")
+
+;; walk: callback deletes entries then allocates heavily
+(test-equal "walk snapshot survives GC"
+  '(435 0)
+  (let ((ht (make-hash-table)) (sum 0) (bad 0))
+    (do ((i 0 (+ i 1))) ((= i 30))
+      (hash-table-set! ht (cons i 'key) (cons i 'val)))
+    (hash-table-walk ht
+      (lambda (k v)
+        (do ((j 0 (+ j 1))) ((= j 30))
+          (hash-table-delete! ht (cons j 'key)))
+        (do ((j 0 (+ j 1))) ((= j 100))
+          (cons j (make-vector 4 j)))
+        (if (and (pair? k) (pair? v) (eq? (cdr k) 'key) (eq? (cdr v) 'val)
+                 (= (car k) (car v)))
+            (set! sum (+ sum (car k)))
+            (set! bad (+ bad 1)))))
+    (list sum bad)))
+
+;; fold: same pattern with accumulator
+(test-equal "fold snapshot survives GC"
+  435
+  (let ((ht (make-hash-table)))
+    (do ((i 0 (+ i 1))) ((= i 30))
+      (hash-table-set! ht (cons i 'key) (cons i 'val)))
+    (hash-table-fold ht
+      (lambda (k v acc)
+        (do ((j 0 (+ j 1))) ((= j 30))
+          (hash-table-delete! ht (cons j 'key)))
+        (do ((j 0 (+ j 1))) ((= j 100))
+          (cons j (make-vector 4 j)))
+        (if (and (pair? k) (pair? v) (eq? (cdr k) 'key) (eq? (cdr v) 'val)
+                 (= (car k) (car v)))
+            (+ acc (car k))
+            acc))
+      0)))
+
+(let ((runner (test-runner-current)))
+  (test-end "hash-table-walk-gc-1181")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Root all snapshot keys/values via `gc.rootedScope()` + `gc.extra_roots` in both `hashTableWalkFn` and `hashTableFoldFn` so the GC can trace them during collection
- Re-enable the `FAIL: #1181` audit test that was disabled pending the fix
- Add dedicated regression test covering both `hash-table-walk` and `hash-table-fold`

Closes #1181

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `zig build run -- tests/scheme/audit/primitives_hashtable-audit.scm` — 72/72 pass (default build)
- [x] `zig build -Dgc-stress=true run -- tests/scheme/audit/primitives_hashtable-audit.scm` — 72/72 pass (gc-stress)
- [x] `zig build run -- tests/scheme/smoke/hash-table-walk-gc-1181.scm` — 2/2 pass (default)
- [x] `zig build -Dgc-stress=true run -- tests/scheme/smoke/hash-table-walk-gc-1181.scm` — 2/2 pass (gc-stress)
- [ ] `bash tests/scheme/run-all.sh` — full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)