### PR TITLE
Increase CI timeout for Debug test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
   test:
     needs: format
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: ${{ matrix.timeout || 20 }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +49,7 @@ jobs:
         include:
           - os: ubuntu-latest
             optimize: Debug
+            timeout: 30
           - os: ubuntu-latest
             optimize: ReleaseFast
 


### PR DESCRIPTION
## Summary

- Bump the Debug matrix entry's `timeout-minutes` from 20 to 30 in the CI `test` job
- Other matrix entries (ReleaseSafe, ReleaseFast) keep the 20-minute default via `${{ matrix.timeout || 20 }}`

Debug builds are ~500x slower for allocation-heavy workloads. The Scheme test suite finishes just under 20 minutes, leaving no headroom for the post-job Zig cache upload (~982 MB), causing the job to be cancelled and blocking downstream `coverage` and `benchmark` jobs.

Closes #1295

## Test plan

- [ ] Verify the Debug CI job completes without timeout
- [ ] Verify ReleaseSafe/ReleaseFast jobs still use 20-minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)