### PR TITLE
Fix hygiene: use-site arg no longer captured by same-name def-site local (#1288)

### DIFF
--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -68,10 +68,12 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
         const glk = globals_mod.acquireGlobalsWrite(g);
         defer globals_mod.releaseGlobalsWrite(glk);
         for (tx.captured_locals) |cap| {
-            if (!g.contains(cap.name) and temp_global_count < 128) {
-                temp_globals[temp_global_count] = .{ .name = cap.name, .old_val = null, .was_present = false };
-                temp_global_count += 1;
-                try g.put(cap.name, types.VOID);
+            if (temp_global_count < 128) {
+                if (g.get(cap.name)) |gval| {
+                    temp_globals[temp_global_count] = .{ .name = cap.name, .old_val = gval, .was_present = true };
+                    temp_global_count += 1;
+                    _ = g.remove(cap.name);
+                }
             }
         }
         if (tx.def_env) |env| {
@@ -163,14 +165,6 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
     self.gc.no_collect -= 1;
     try self.scanSetTargets(expanded_root);
     const saved_locals_len = self.locals.items.len;
-    for (tx.captured_locals) |cap| {
-        try self.locals.append(self.gc.allocator, .{
-            .name = cap.name,
-            .depth = self.scope_depth,
-            .slot = cap.slot,
-            .binding_id = compiler_mod.freshBindingId(),
-        });
-    }
     try injectHygienicCapturedLocals(self, expanded_root, tx.captured_locals);
     // Inject non-procedure global free vars as locals so
     // use-site locals don't shadow the definition-site
@@ -533,25 +527,27 @@ fn injectHygCapturedWalk(self: *Compiler, expr: Value, captured: []const types.C
         if (!std.mem.startsWith(u8, name, "__hyg_")) return;
         const base = types.stripHygienicPrefix(name);
         if (base.len == name.len) return;
+        var best_cap: ?types.CapturedLocal = null;
         for (captured) |cap| {
-            if (std.mem.eql(u8, cap.name, base)) {
-                var already = false;
-                for (self.locals.items) |loc| {
-                    if (std.mem.eql(u8, loc.name, name)) {
-                        already = true;
-                        break;
-                    }
+            if (std.mem.eql(u8, cap.name, base)) best_cap = cap;
+        }
+        if (best_cap) |cap| {
+            var already = false;
+            for (self.locals.items) |loc| {
+                if (std.mem.eql(u8, loc.name, name)) {
+                    already = true;
+                    break;
                 }
-                if (!already) {
-                    try self.locals.append(self.gc.allocator, .{
-                        .name = name,
-                        .depth = self.scope_depth,
-                        .slot = cap.slot,
-                        .binding_id = compiler_mod.freshBindingId(),
-                    });
-                }
-                return;
             }
+            if (!already) {
+                try self.locals.append(self.gc.allocator, .{
+                    .name = name,
+                    .depth = self.scope_depth,
+                    .slot = cap.slot,
+                    .binding_id = compiler_mod.freshBindingId(),
+                });
+            }
+            return;
         }
         return;
     }

--- a/tests/scheme/hygiene/arg-vs-free.scm
+++ b/tests/scheme/hygiene/arg-vs-free.scm
@@ -1,0 +1,56 @@
+;; Regression test for #1288: use-site macro argument mis-resolved
+;; to a captured def-site local of the same name.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "arg-vs-free")
+
+;; Core bug: pattern variable substitution carries use-site `y` (100),
+;; but the template free reference `y` must bind to the def-site `y` (7).
+(test-equal "define-syntax: arg same name as captured local"
+  107
+  (let ((y 7))
+    (define-syntax m (syntax-rules () ((_ x) (+ x y))))
+    (let ((y 100))
+      (m y))))
+
+(test-equal "let-syntax: arg same name as captured local"
+  107
+  (let ((y 7))
+    (let-syntax ((m (syntax-rules () ((_ x) (+ x y)))))
+      (let ((y 100))
+        (m y)))))
+
+;; Multiple captured locals, one collides with the argument
+(test-equal "two captured locals, arg collides with one"
+  112
+  (let ((a 5) (b 7))
+    (define-syntax m (syntax-rules () ((_ x) (+ x a b))))
+    (let ((b 100))
+      (m b))))
+
+;; Argument collides with captured local used in binding position
+(test-equal "captured local in template let, arg collision"
+  107
+  (let ((x 7))
+    (define-syntax m (syntax-rules () ((_ y) (let ((z y)) (+ z x)))))
+    (let ((x 100))
+      (m x))))
+
+;; No collision (baseline — should already work)
+(test-equal "no name collision"
+  107
+  (let ((y 7))
+    (define-syntax m (syntax-rules () ((_ x) (+ x y))))
+    (m 100)))
+
+;; Argument is a complex expression, not a bare symbol
+(test-equal "complex arg, no collision"
+  110
+  (let ((y 7))
+    (define-syntax m (syntax-rules () ((_ x) (+ x y))))
+    (let ((y 100))
+      (m (+ y 3)))))
+
+(let ((runner (test-runner-current)))
+  (test-end "arg-vs-free")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Template free references are now hygienically renamed to `__hyg_N_<name>` instead of being kept bare via VOID sentinels, so `injectHygienicCapturedLocals` maps them to the correct captured slot while use-site argument symbols keep their original binding
- Removed bare-name captured-local injection from `self.locals` — rely solely on `injectHygienicCapturedLocals` for the renamed `__hyg_*` symbols
- Fixed `injectHygCapturedWalk` to use last-match (innermost scope) when multiple captured locals share a name

## Test plan

- [x] New regression tests in `tests/scheme/hygiene/arg-vs-free.scm` (6 cases: define-syntax collision, let-syntax collision, multi-capture collision, template-let collision, no-collision baseline, complex-arg)
- [x] All existing hygiene tests pass (10 files)
- [x] Full R7RS suite: 1395 pass, 0 fail
- [x] Full Scheme suite: 398 pass, 0 fail, 0 timeout
- [x] Zig unit tests pass

Closes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)