### PR TITLE
Let imported macros shadow built-in special forms (#1237)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -679,6 +679,7 @@ pub const Compiler = struct {
             // special form handle the base case.
             if (!is_shadowed) {
                 const suppressed = if (self.suppress_macro_name) |smn| std.mem.eql(u8, name, smn) else false;
+                if (suppressed) self.suppress_macro_name = null;
                 if (!suppressed) {
                     const macro_hit: ?Value = if (self.lookupMacro(name)) |t|
                         if (self.resolveLocal(name) != null or (try self.resolveUpvalue(name)) != null) null else t

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -93,6 +93,10 @@ pub const Compiler = struct {
     current_line: u32 = 0,
     macro_expansion_depth: u16 = 0,
     macro_expansion_steps: u32 = 0,
+    // Set by expandAndCompileMacroUse when a macro expansion is a fixed
+    // point (output equals input).  compileForm skips the macro check
+    // for this keyword so the built-in special form handles it instead.
+    suppress_macro_name: ?[]const u8 = null,
 
     pub fn init(gc: *memory.GC) CompileError!Compiler {
         const func = gc.allocFunction() catch return CompileError.OutOfMemory;
@@ -667,6 +671,25 @@ pub const Compiler = struct {
             const is_shadowed = std.mem.eql(u8, effective_name, name) and
                 (self.resolveLocal(name) != null or (try self.resolveUpvalue(name)) != null);
 
+            // R7RS has no reserved words: an imported macro may shadow a
+            // special form keyword (e.g. SRFI-219 redefines `define`).
+            // Check macros BEFORE special forms so the macro wins.
+            // suppress_macro_name is set when a macro expansion produced a
+            // fixed-point (identity) — skip re-expansion to let the built-in
+            // special form handle the base case.
+            if (!is_shadowed) {
+                const suppressed = if (self.suppress_macro_name) |smn| std.mem.eql(u8, name, smn) else false;
+                if (!suppressed) {
+                    const macro_hit: ?Value = if (self.lookupMacro(name)) |t|
+                        if (self.resolveLocal(name) != null or (try self.resolveUpvalue(name)) != null) null else t
+                    else
+                        null;
+                    if (macro_hit) |transformer| {
+                        return macro.expandAndCompileMacroUse(self, expr, name, transformer, dst, is_tail);
+                    }
+                }
+            }
+
             // Primitive forms — only if not shadowed by local binding
             if (!is_shadowed) {
                 if (std.mem.eql(u8, effective_name, "quote")) return passthrough.compileQuote(self, args, dst);
@@ -716,18 +739,6 @@ pub const Compiler = struct {
                 if (std.mem.eql(u8, effective_name, "letrec-syntax")) return macro.compileLetrecSyntax(self, args, dst, is_tail);
                 if (std.mem.eql(u8, effective_name, "syntax-rules")) return CompileError.InvalidSyntax;
             } // end if (!is_local)
-
-            // Check if head is a macro keyword. A variable binding in scope
-            // shadows the macro (R7RS 5.3: a body's definitions shadow outer
-            // syntactic bindings), so a local or captured binding with the
-            // same name makes this a procedure call instead.
-            const macro_hit: ?Value = if (self.lookupMacro(name)) |t|
-                if (self.resolveLocal(name) != null or (try self.resolveUpvalue(name)) != null) null else t
-            else
-                null;
-            if (macro_hit) |transformer| {
-                return macro.expandAndCompileMacroUse(self, expr, name, transformer, dst, is_tail);
-            }
         }
 
         if (is_tail and types.isSymbol(head)) {

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -11,6 +11,9 @@ const Value = types.Value;
 const MAX_MACRO_EXPANSION_DEPTH: u16 = 256;
 const MAX_MACRO_EXPANSION_STEPS: u32 = 10_000;
 
+/// 128 levels is safe because the expander shares pattern-variable subtrees
+/// (a == b short-circuits at the shared node), so only the short template
+/// spine is actually traversed.
 fn valuesStructurallyEqual(a: Value, b: Value, depth: u16) bool {
     if (a == b) return true;
     if (depth == 0) return false;

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -3,12 +3,22 @@ const types = @import("types.zig");
 const compiler_mod = @import("compiler.zig");
 const expander = @import("expander.zig");
 const globals_mod = @import("globals.zig");
+const ir_mod = @import("ir.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
 
 const MAX_MACRO_EXPANSION_DEPTH: u16 = 256;
 const MAX_MACRO_EXPANSION_STEPS: u32 = 10_000;
+
+fn valuesStructurallyEqual(a: Value, b: Value, depth: u16) bool {
+    if (a == b) return true;
+    if (depth == 0) return false;
+    if (types.isPair(a) and types.isPair(b))
+        return valuesStructurallyEqual(types.car(a), types.car(b), depth - 1) and
+            valuesStructurallyEqual(types.cdr(a), types.cdr(b), depth - 1);
+    return false;
+}
 
 fn resolveLocalSkipAliases(ctx: ?*const anyopaque, name: []const u8) u32 {
     const self: *const Compiler = @ptrCast(@alignCast(ctx.?));
@@ -26,7 +36,6 @@ fn resolveLocalSkipAliases(ctx: ?*const anyopaque, name: []const u8) u32 {
 }
 
 pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, transformer: Value, dst: u16, is_tail: bool) CompileError!void {
-    _ = name;
     if (self.macro_expansion_depth >= MAX_MACRO_EXPANSION_DEPTH or
         self.macro_expansion_steps >= MAX_MACRO_EXPANSION_STEPS)
     {
@@ -215,6 +224,17 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
             }
         }
     }
+    // Fixed-point detection: if the expansion is structurally identical to
+    // the input (e.g. SRFI-219 rule 3: (define x e) → (define x e)) AND the
+    // keyword is a built-in special form, suppress macro re-expansion so the
+    // built-in handler takes over.  For non-special-form macros (e.g. a
+    // degenerate (loop) → (loop)), let the expansion-limit catch it instead.
+    const is_fixed_point = valuesStructurallyEqual(expanded_root, expr, 128) and
+        ir_mod.isSpecialForm(types.stripHygienicPrefix(name));
+    const saved_suppress = self.suppress_macro_name;
+    if (is_fixed_point) self.suppress_macro_name = name;
+    defer self.suppress_macro_name = saved_suppress;
+
     const result_err = self.compileExpr(expanded_root, dst, is_tail);
     if (saved_peer) |sp| {
         for (peer_names, 0..) |pn, i| {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -526,6 +526,15 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
             if (ir.compiler) |c| c.isLexicallyBound(name) else false;
 
         if (!is_shadowed) {
+            // R7RS has no reserved words: an imported macro may shadow a
+            // special form keyword (e.g. SRFI-219 redefines `define`).
+            // Check macros BEFORE special forms so the macro wins.
+            if (ir.compiler) |c| {
+                if (c.lookupMacro(name) != null) return ir.makePassthrough(expr);
+            } else if (macros) |m| {
+                if (m.get(name) != null) return ir.makePassthrough(expr);
+            }
+
             if (std.mem.eql(u8, effective_name, "if")) return lowerIf(ir, types.cdr(expr), macros);
             if (std.mem.eql(u8, effective_name, "quote")) return lowerQuote(ir, types.cdr(expr));
             if (std.mem.eql(u8, effective_name, "begin")) return lowerBegin(ir, types.cdr(expr), macros);
@@ -545,12 +554,6 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
                 return ir.makeSexprNode(form, types.cdr(expr));
 
             if (isSpecialForm(effective_name)) return ir.makePassthrough(expr);
-
-            if (ir.compiler) |c| {
-                if (c.lookupMacro(name) != null) return ir.makePassthrough(expr);
-            } else if (macros) |m| {
-                if (m.get(name) != null) return ir.makePassthrough(expr);
-            }
         }
 
         if (tryFoldFromAST(ir, expr)) |folded| return folded;

--- a/tests/scheme/srfi/srfi219.scm
+++ b/tests/scheme/srfi/srfi219.scm
@@ -1,8 +1,4 @@
-;; SRFI-219 (define higher-order lambda) conformance tests — audit Phase 3.4
-;; The library exports a syntax-rules define, but kaappi's compiler treats
-;; define as a built-in special form before consulting imported macros, so
-;; the curried patterns never engage: every (define ((f a) b) ...) form is
-;; rejected with "compile error: error.InvalidSyntax".
+;; SRFI-219 (define higher-order lambda) conformance tests
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi219.scm
 
 (import (scheme base) (srfi 219) (chibi test))
@@ -18,28 +14,23 @@
 (test '(1 2) (var-args 1 2))
 
 ;;; --- one level of currying ---
-;; FAIL: #1237 (imported define macro cannot shadow the built-in define;
-;;   curried heads are InvalidSyntax)
-;; (define ((adder n) m) (+ n m))
-;; (test 7 ((adder 3) 4))
-;; (define add5 (adder 5))
-;; (test 15 (add5 10))
+(define ((adder n) m) (+ n m))
+(test 7 ((adder 3) 4))
+(define add5 (adder 5))
+(test 15 (add5 10))
 
 ;;; --- two levels ---
-;; FAIL: #1237
-;; (define (((compose3 f) g) x) (f (g x)))
-;; (test 9 (((compose3 (lambda (n) (* n n))) (lambda (n) (+ n 1))) 2))
+(define (((compose3 f) g) x) (f (g x)))
+(test 9 (((compose3 (lambda (n) (* n n))) (lambda (n) (+ n 1))) 2))
 
 ;;; --- rest arguments at each level ---
-;; FAIL: #1237
-;; (define ((cat . xs) . ys) (append xs ys))
-;; (test '(1 2 3) ((cat 1 2) 3))
+(define ((cat . xs) . ys) (append xs ys))
+(test '(1 2 3) ((cat 1 2) 3))
 
 ;;; --- multi-expression bodies ---
-;; FAIL: #1237
-;; (define ((counter start) step)
-;;   (define next (+ start step))
-;;   next)
-;; (test 12 ((counter 10) 2))
+(define ((counter start) step)
+  (define next (+ start step))
+  next)
+(test 12 ((counter 10) 2))
 
 (test-end "srfi-219")

--- a/tests/scheme/srfi/srfi219.scm
+++ b/tests/scheme/srfi/srfi219.scm
@@ -33,4 +33,10 @@
   next)
 (test 12 ((counter 10) 2))
 
+;;; --- curried define inside let/begin bodies ---
+(define let-result (let () (define ((f a) b) (+ a b)) ((f 1) 2)))
+(test 3 let-result)
+(define begin-result (begin (define ((g a) b) (* a b)) ((g 4) 5)))
+(test 20 begin-result)
+
 (test-end "srfi-219")


### PR DESCRIPTION
## Summary

- Move macro lookup **ahead of** special-form string comparisons in both the IR lowering path (`ir.zig`) and the legacy compiler path (`compiler.zig`), so an imported `syntax-rules` macro named `define` (or any other keyword) is expanded instead of being short-circuited by the built-in handler.
- Add fixed-point detection in `expandAndCompileMacroUse`: when a macro expansion is structurally identical to its input **and** the keyword is a built-in special form, suppress re-expansion so the built-in handler takes over. This breaks the infinite loop from SRFI-219's identity rule `(define name expr) → (define name expr)` while preserving the expansion-limit guard for non-special-form recursive macros.

Fixes #1237.

## Test plan

- [x] `zig build test` — 660 unit tests pass (including the robustness test for degenerate `(loop)` macro)
- [x] SRFI-219 tests: one-level currying, two-level currying, rest args, multi-expression bodies (8 tests, all pass)
- [x] R7RS suite: 1395 pass, 0 fail
- [x] `run-all.sh`: 1794 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)