### PR TITLE
Isolate macro tables for custom environments in eval/load (#1269)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -980,11 +980,9 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
     c.func.env = env;
     c.func.env_val = env_val;
     c.func.restricted_globals = c.restricted_env;
-    if (!types.isEnvironment(env_val) or !types.toEnvironment(env_val).immutable) {
-        var out_it = c.macros.iterator();
-        while (out_it.next()) |entry| {
-            vm_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return CompileError.OutOfMemory;
-        }
+    var out_it = c.macros.iterator();
+    while (out_it.next()) |entry| {
+        vm_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return CompileError.OutOfMemory;
     }
     ok = true;
     return c.func;

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -179,7 +179,22 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
     if (args.len > 1) {
         if (!types.isEnvironment(args[1])) return primitives.typeError("eval", "environment", args[1]);
         const se = types.toEnvironment(args[1]);
-        const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, se.env, args[1], false) catch return PrimitiveError.TypeError; // bare-ok: compile error
+
+        // Interaction environment: macros persist globally (#1269).
+        // Custom environments: isolated macro table, discarded after compilation.
+        var local_macros: std.StringHashMap(Value) = undefined;
+        const use_local = (se.env != vm.globals);
+        if (use_local) {
+            local_macros = std.StringHashMap(Value).init(gc.allocator);
+            var mit = vm.macros.iterator();
+            while (mit.next()) |entry| {
+                local_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return PrimitiveError.OutOfMemory;
+            }
+        }
+        defer if (use_local) local_macros.deinit();
+
+        const macro_target: *std.StringHashMap(Value) = if (use_local) &local_macros else &vm.macros;
+        const func = compiler_mod.compileExpressionInEnv(gc, expr, macro_target, se.env, args[1], false) catch return PrimitiveError.TypeError; // bare-ok: compile error
         var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
         compiler_mod.Compiler.unrootFunction(gc, func);
         gc.pushRoot(&closure_val);
@@ -277,12 +292,27 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
     var reader = reader_mod.Reader.init(gc, contents.items);
     defer reader.deinit();
 
+    // Custom environments get an isolated macro table so define-syntax
+    // does not leak into the global scope (#1269). The local table lives
+    // outside the loop so macros from earlier expressions remain visible.
+    var local_macros: std.StringHashMap(Value) = undefined;
+    const use_local = if (env) |e| (e != vm.globals) else false;
+    if (use_local) {
+        local_macros = std.StringHashMap(Value).init(gc.allocator);
+        var mit = vm.macros.iterator();
+        while (mit.next()) |entry| {
+            local_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return PrimitiveError.OutOfMemory;
+        }
+    }
+    defer if (use_local) local_macros.deinit();
+    const macro_target: *std.StringHashMap(Value) = if (use_local) &local_macros else &vm.macros;
+
     var last_result: Value = types.VOID;
     while (reader.hasMore() catch return PrimitiveError.TypeError) { // bare-ok: reader error in load
         const expr = reader.readDatum() catch return primitives.typeError("load", "valid datum", args[0]);
 
         if (env) |e| {
-            const func = compiler_mod.compileExpressionInEnv(gc, expr, &vm.macros, e, env_val, false) catch return primitives.typeError("load", "valid expression", args[0]);
+            const func = compiler_mod.compileExpressionInEnv(gc, expr, macro_target, e, env_val, false) catch return primitives.typeError("load", "valid expression", args[0]);
             var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
             compiler_mod.Compiler.unrootFunction(gc, func);
             gc.pushRoot(&closure_val);

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -331,6 +331,47 @@ test "define-syntax in custom environment does not leak to global scope (#1269)"
     try std.testing.expectEqualStrings("not-leaked", types.symbolName(result));
 }
 
+// Genuine regression guard: constructs a mutable non-global environment
+// (unreachable from Scheme) where define-syntax succeeds but must not leak.
+test "define-syntax in mutable non-global env does not leak (#1269)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // Build a mutable env with the same bindings as globals but a distinct map
+    const env_map = try ctx.gc.allocator.create(std.StringHashMap(types.Value));
+    env_map.* = std.StringHashMap(types.Value).init(ctx.gc.allocator);
+    var git = ctx.vm.globals.iterator();
+    while (git.next()) |entry| {
+        try env_map.put(entry.key_ptr.*, entry.value_ptr.*);
+    }
+    var env_val = try ctx.gc.allocEnvironment(env_map, true, false);
+    ctx.gc.pushRoot(&env_val);
+    defer ctx.gc.popRoot();
+
+    // Expose the mutable env so eval can reach it
+    try ctx.vm.globals.put("__test-mut-env", env_val);
+
+    const before_count = ctx.vm.macros.count();
+
+    // define-syntax succeeds (env is mutable) but must not leak to vm.macros
+    _ = try ctx.vm.eval(
+        \\(eval '(define-syntax mut-leak-test
+        \\         (syntax-rules () ((_ x) (+ x 1))))
+        \\      __test-mut-env)
+    );
+
+    try std.testing.expectEqual(before_count, ctx.vm.macros.count());
+
+    // The macro must not be usable at global scope
+    const result = try ctx.vm.eval(
+        \\(guard (e (#t 'not-leaked))
+        \\  (eval '(mut-leak-test 5) (interaction-environment)))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("not-leaked", types.symbolName(result));
+}
+
 test "define-syntax in interaction-environment persists globally (#1269)" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -310,6 +310,39 @@ test "eval define-syntax into immutable environment signals error (#1147)" {
     try std.testing.expectEqualStrings("error-signaled", types.symbolName(result));
 }
 
+test "define-syntax in custom environment does not leak to global scope (#1269)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const before_count = ctx.vm.macros.count();
+    // define-syntax errors (immutable env) — verify no macro leaked despite the attempt
+    _ = try ctx.vm.eval(
+        \\(guard (e (#t 'ok))
+        \\  (eval '(define-syntax leaked-mac-1269 (syntax-rules () ((_) 999)))
+        \\        (environment '(scheme base))))
+    );
+    try std.testing.expectEqual(before_count, ctx.vm.macros.count());
+    // Verify the macro is not usable at global scope
+    const result = try ctx.vm.eval(
+        \\(guard (e (#t 'not-leaked))
+        \\  (eval '(leaked-mac-1269) (interaction-environment)))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("not-leaked", types.symbolName(result));
+}
+
+test "define-syntax in interaction-environment persists globally (#1269)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    _ = try ctx.vm.eval(
+        \\(eval '(define-syntax ie-mac-1269 (syntax-rules () ((_) 42)))
+        \\      (interaction-environment))
+    );
+    const result = try ctx.vm.eval("(ie-mac-1269)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
 test "interaction-environment allows define (#1147)" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -1187,6 +1187,12 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const expr_val = self.registers[abs_base];
 
                 const compiler_mod = @import("compiler.zig");
+
+                // Local macro table for custom environment isolation (#1269)
+                var local_macros: std.StringHashMap(Value) = undefined;
+                var use_local_macros = false;
+                defer if (use_local_macros) local_macros.deinit();
+
                 const func_val = blk: {
                     if (nargs >= 2) {
                         if (!types.isEnvironment(self.registers[abs_base + 1])) {
@@ -1197,7 +1203,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             return VMError.TypeError;
                         }
                         const se = types.toEnvironment(self.registers[abs_base + 1]);
-                        break :blk compiler_mod.compileExpressionInEnv(self.gc, expr_val, &self.macros, se.env, self.registers[abs_base + 1], true) catch return VMError.CompileError;
+                        const macro_target: *std.StringHashMap(Value) = if (se.env == self.globals) &self.macros else mt: {
+                            local_macros = std.StringHashMap(Value).init(self.gc.allocator);
+                            var mit = self.macros.iterator();
+                            while (mit.next()) |entry| {
+                                local_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return VMError.OutOfMemory;
+                            }
+                            use_local_macros = true;
+                            break :mt &local_macros;
+                        };
+                        break :blk compiler_mod.compileExpressionInEnv(self.gc, expr_val, macro_target, se.env, self.registers[abs_base + 1], true) catch return VMError.CompileError;
                     }
                     break :blk compiler_mod.compileExpressionWithMacrosAt(self.gc, expr_val, &self.macros, self.globals, 0, null, true) catch return VMError.CompileError;
                 };

--- a/tests/scheme/smoke/eval-macro-leak-1269.scm
+++ b/tests/scheme/smoke/eval-macro-leak-1269.scm
@@ -1,0 +1,25 @@
+;; Regression test for #1269: define-syntax in a custom environment must not
+;; leak into the global macro table.
+(import (scheme base) (scheme write) (scheme eval) (scheme process-context)
+        (srfi 64))
+
+(test-begin "eval-macro-leak-1269")
+
+;; define-syntax via (interaction-environment) must persist (REPL semantics)
+(eval '(define-syntax ie-mac (syntax-rules () ((_ x) (+ x 100))))
+      (interaction-environment))
+(test-equal "macro in interaction-environment persists" 142 (ie-mac 42))
+
+;; define-syntax into immutable (environment ...) signals error and does not leak
+(test-equal "define-syntax into immutable env errors" 'caught
+  (guard (e (#t 'caught))
+    (eval '(define-syntax leaked (syntax-rules () ((_ x) (+ x 999))))
+          (environment '(scheme base)))))
+
+(test-equal "macro from failed define-syntax does not leak" 'not-leaked
+  (guard (e (#t 'not-leaked))
+    (eval '(leaked 1) (interaction-environment))))
+
+(let ((runner (test-runner-current)))
+  (test-end "eval-macro-leak-1269")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- **Move macro-table isolation from `compileExpressionInEnv` to its three callers** (`evalFn`, `loadFn`, `tail_eval` opcode handler): when the environment is not the interaction environment (`se.env != vm.globals`), a local copy of `vm.macros` is created and passed as the merge-back target — discarded after compilation so no macros leak
- **Remove the immutability guard** from `compileExpressionInEnv` (added in #1275) — now redundant since callers control which table receives the merge-back
- For `load`, the local macro table lives **outside the expression loop** so macros from earlier expressions remain visible to later ones in the same file

Closes #1269

## Test plan

- [x] New Zig unit test: `define-syntax` in custom env does not leak to global scope
- [x] New Zig unit test: `define-syntax` in `(interaction-environment)` persists globally
- [x] New Scheme regression test: `tests/scheme/smoke/eval-macro-leak-1269.scm`
- [x] Existing `load-env-1190.scm` test passes (load with env specifier)
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 1795 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)