### PR TITLE
Make default-random-source a variable, not a procedure (#1192)

### DIFF
--- a/lib/srfi/27.sld
+++ b/lib/srfi/27.sld
@@ -8,6 +8,8 @@
           random-source-state-ref random-source-state-set!)
   (begin
 
+    (define default-random-source (%default-random-source))
+
     (define (random-source-make-integers rs)
       (lambda (n) (%rs-next-int rs n)))
 

--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -27,7 +27,7 @@ fn freshSeed() u64 {
 pub const specs = [_]primitives.PrimSpec{
     .{ .name = "random-integer", .func = &randomIntegerFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "random-real", .func = &randomRealFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "default-random-source", .func = &defaultRandomSourceFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%default-random-source", .func = &defaultRandomSourceFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "random-source?", .func = &randomSourcePFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "make-random-source", .func = &makeRandomSourceFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "random-source-randomize!", .func = &randomSourceRandomizeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -114,7 +114,7 @@ test "default-random-source is per-VM" {
     var vm1 = try th.makeTestVM(&gc1);
     defer vm1.deinit();
 
-    const rs1 = try vm1.eval("(default-random-source)");
+    const rs1 = try vm1.eval("(%default-random-source)");
     try std.testing.expect(types.isRandomSource(rs1));
 
     var gc2 = memory.GC.init(std.testing.allocator);
@@ -122,14 +122,14 @@ test "default-random-source is per-VM" {
     var vm2 = try th.makeTestVM(&gc2);
     defer vm2.deinit();
 
-    const rs2 = try vm2.eval("(default-random-source)");
+    const rs2 = try vm2.eval("(%default-random-source)");
     try std.testing.expect(types.isRandomSource(rs2));
 
     // Each VM must have its own default random source
     try std.testing.expect(rs1 != rs2);
 
     // VM1's source must still be its own after VM2 was created
-    const rs1_again = try vm1.eval("(default-random-source)");
+    const rs1_again = try vm1.eval("(%default-random-source)");
     try std.testing.expectEqual(rs1, rs1_again);
 }
 

--- a/tests/scheme/audit/primitives_random-audit.scm
+++ b/tests/scheme/audit/primitives_random-audit.scm
@@ -18,15 +18,11 @@
 ;; and random-real have been derived ... an assignment to default-random-source
 ;; does not change random or random-real" — i.e. it is a variable bound to a
 ;; random source, not a procedure.
-;; FAIL: #1192 (default-random-source is exported as a zero-argument procedure)
-;; (test #t (random-source? default-random-source))
-
-;; Kaappi's current calling convention returns the source when invoked.
-(test #t (random-source? (default-random-source)))
+(test #t (random-source? default-random-source))
 
 ;; random-integer draws from default-random-source: restoring the default
 ;; source's state reproduces the random-integer sequence.
-(let* ((d (default-random-source))
+(let* ((d default-random-source)
        (st (random-source-state-ref d))
        (x1 (random-integer 1000000)))
   (random-source-state-set! d st)

--- a/tests/scheme/coverage/library-coverage.scm
+++ b/tests/scheme/coverage/library-coverage.scm
@@ -88,7 +88,7 @@
 (check "srfi 1 loaded" (iota 3) '(0 1 2))
 
 (import (srfi 27))
-(check-true "srfi 27 loaded" (random-source? (default-random-source)))
+(check-true "srfi 27 loaded" (random-source? default-random-source))
 
 ;;; ---- define-values ----
 (define-values (dv-x dv-y dv-z) (values 10 20 30))

--- a/tests/scheme/coverage/random-coverage.scm
+++ b/tests/scheme/coverage/random-coverage.scm
@@ -29,7 +29,7 @@
   (check-true "random-real < 1" (< r 1.0)))
 
 ;;; ---- default-random-source ----
-(check-true "default-random-source" (random-source? (default-random-source)))
+(check-true "default-random-source" (random-source? default-random-source))
 
 ;;; ---- make-random-source ----
 (let ((rs (make-random-source)))

--- a/tests/scheme/smoke/srfi27-default-source.scm
+++ b/tests/scheme/smoke/srfi27-default-source.scm
@@ -1,0 +1,19 @@
+;; Regression test for #1192: default-random-source must be a variable
+;; bound to a random source, not a procedure.
+
+(import (scheme base) (scheme process-context) (srfi 27) (srfi 64))
+
+(test-begin "srfi27-default-source")
+
+(test-assert "default-random-source is a random source"
+  (random-source? default-random-source))
+
+(test-assert "default-random-source is not a procedure"
+  (not (procedure? default-random-source)))
+
+(test-assert "random-source-state-ref accepts default-random-source"
+  (pair? (random-source-state-ref default-random-source)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi27-default-source")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi27-state.scm
+++ b/tests/scheme/srfi/srfi27-state.scm
@@ -68,7 +68,7 @@
 (check-true "state-set! rejects all-zero state" zero-err)
 
 ;; Verify state words are integers (now bignums for full 64-bit)
-(define state-words (random-source-state-ref (default-random-source)))
+(define state-words (random-source-state-ref default-random-source))
 (check-true "state is a list of 4" (= 4 (length state-words)))
 (check-true "state words are integers"
   (and (integer? (car state-words))


### PR DESCRIPTION
## Summary

- Rename the `default-random-source` primitive to `%default-random-source` (internal) and define the public SRFI-27 binding as a variable in `lib/srfi/27.sld` that evaluates the procedure once at library load time
- Portable SRFI-27 code like `(random-source-state-ref default-random-source)` now works correctly instead of raising a type error
- Remove FAIL marker from audit test, add regression test

## Test plan

- [x] New regression test `tests/scheme/smoke/srfi27-default-source.scm` — verifies `default-random-source` is a random source, not a procedure
- [x] Audit test passes (49/49, FAIL marker removed)
- [x] SRFI-27 state test passes (8/8)
- [x] All 663 unit tests pass
- [x] All 1,391 R7RS tests pass

Closes #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)