### PR TITLE
Honor explicit #f thread arg in mutex-lock! as locked/not-owned (#1154)

### DIFF
--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -695,6 +695,8 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         const ctx = try ensureScheduler();
         m.owner = if (args.len > 2 and types.isFiber(args[2]))
             args[2]
+        else if (args.len > 2 and args[2] == types.FALSE)
+            types.VOID
         else if (ctx.vm.current_fiber) |cf|
             types.makePointer(@ptrCast(cf))
         else
@@ -707,6 +709,8 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         const ctx = try ensureScheduler();
         m.owner = if (args.len > 2 and types.isFiber(args[2]))
             args[2]
+        else if (args.len > 2 and args[2] == types.FALSE)
+            types.VOID
         else if (ctx.vm.current_fiber) |cf|
             types.makePointer(@ptrCast(cf))
         else
@@ -739,6 +743,8 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     m.locked = true;
     m.owner = if (args.len > 2 and types.isFiber(args[2]))
         args[2]
+    else if (args.len > 2 and args[2] == types.FALSE)
+        types.VOID
     else
         types.makePointer(@ptrCast(me));
 

--- a/tests/scheme/audit/primitives_srfi18-audit.scm
+++ b/tests/scheme/audit/primitives_srfi18-audit.scm
@@ -91,10 +91,9 @@
 (let ((m (make-mutex)))
   (mutex-lock! m)
   (test #f (mutex-lock! m 0.05)))
-;; FAIL: #1154 (explicit #f thread argument must yield locked/not-owned)
-;; (let ((m (make-mutex)))
-;;   (mutex-lock! m #f #f)
-;;   (test 'not-owned (mutex-state m)))
+(let ((m (make-mutex)))
+  (mutex-lock! m #f #f)
+  (test 'not-owned (mutex-state m)))
 
 ;;; --- condition variables ---
 (let ((cv (make-condition-variable 'audit-cv)))

--- a/tests/scheme/smoke/mutex-lock-false-owner.scm
+++ b/tests/scheme/smoke/mutex-lock-false-owner.scm
@@ -1,0 +1,26 @@
+;; Regression test for #1154: mutex-lock! with explicit #f thread argument
+;; must yield locked/not-owned, not assign the current thread as owner.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64))
+
+(test-begin "mutex-lock-false-owner")
+
+;; Basic case: lock with #f thread, #f timeout
+(let ((m (make-mutex)))
+  (mutex-lock! m #f #f)
+  (test-equal "mutex-state is not-owned" 'not-owned (mutex-state m)))
+
+;; Lock with #f thread, no timeout
+(let ((m (make-mutex)))
+  (mutex-lock! m #f #f)
+  (test-assert "mutex is locked" (not (eq? (mutex-state m) 'not-abandoned))))
+
+;; Default (no thread arg) should still assign the current thread
+(let ((m (make-mutex)))
+  (mutex-lock! m)
+  (test-assert "default lock assigns current thread"
+    (not (eq? (mutex-state m) 'not-owned))))
+
+(let ((runner (test-runner-current)))
+  (test-end "mutex-lock-false-owner")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Fix `mutex-lock!` to treat an explicit `#f` thread argument as locked/not-owned per SRFI-18, instead of falling back to the current thread as owner
- Patch all three owner-assignment sites in `mutexLockFn` (abandoned path, fast-lock path, contended path)
- Re-enable the disabled audit test and add a dedicated regression test

## Test plan

- [x] New regression test `tests/scheme/smoke/mutex-lock-false-owner.scm` passes
- [x] Re-enabled audit test in `primitives_srfi18-audit.scm` passes (76/76)
- [x] SRFI-18 test suite passes (44/44)
- [x] Zig unit tests pass

Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)