### PR TITLE
Fix group-info by name returning gid 0 (#1161)

### DIFF
--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -18,6 +18,8 @@ extern "c" fn getgroups(size: c_int, list: [*]std.c.gid_t) c_int;
 extern "c" fn nice(inc: c_int) c_int;
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+// std.c.getgrnam is misdeclared as returning ?*passwd (Zig 0.16 bug)
+extern "c" fn getgrnam(name: [*:0]const u8) ?*std.c.group;
 const is_linux = @import("builtin").os.tag == .linux;
 
 fn validateMode(gc: *GC, val: Value) PrimitiveError!std.c.mode_t {
@@ -893,7 +895,7 @@ fn groupInfoFn(args: []const Value) PrimitiveError!Value {
         try validatePathNoNul(name, args[0]);
         const name_z = gc.allocator.dupeZ(u8, name) catch return PrimitiveError.OutOfMemory;
         defer gc.allocator.free(name_z);
-        const g = std.c.getgrnam(name_z) orelse return types.FALSE;
+        const g = getgrnam(name_z) orelse return types.FALSE;
         const name_str = std.mem.span(g.name.?);
         return gc.allocGroupInfo(name_str, g.gid) catch return PrimitiveError.OutOfMemory;
     } else return primitives.typeError("group-info", "string or integer", args[0]);

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -130,9 +130,8 @@
   (test #t (group-info? gi))
   (test #t (string? (group-info:name gi)))
   (test (user-gid) (group-info:gid gi)))
-;; FAIL: #1161 (group-info by name returns gid 0 — Zig std.c.getgrnam misdeclared)
-;; (test (user-gid)
-;;   (group-info:gid (group-info (group-info:name (group-info (user-gid))))))
+(test (user-gid)
+  (group-info:gid (group-info (group-info:name (group-info (user-gid))))))
 
 ;;; --- time ---
 (test #t (>= (monotonic-time) 0))

--- a/tests/scheme/smoke/group-info-by-name-1161.scm
+++ b/tests/scheme/smoke/group-info-by-name-1161.scm
@@ -1,0 +1,21 @@
+;; Regression test for #1161: group-info by name returned gid 0
+;; std.c.getgrnam was misdeclared as returning ?*passwd instead of ?*group
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 170))
+
+(test-begin "group-info-by-name")
+
+(let* ((gid (user-gid))
+       (gi-by-id (group-info gid))
+       (name (group-info:name gi-by-id))
+       (gi-by-name (group-info name)))
+  (test-equal "by-name gid matches by-id gid"
+    (group-info:gid gi-by-id)
+    (group-info:gid gi-by-name))
+  (test-equal "by-name name matches by-id name"
+    (group-info:name gi-by-id)
+    (group-info:name gi-by-name)))
+
+(let ((runner (test-runner-current)))
+  (test-end "group-info-by-name")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- `std.c.getgrnam` in Zig 0.16 is misdeclared as returning `?*passwd` instead of `?*group`, causing `(group-info "staff")` to always return gid 0
- Declare a local `extern "c" fn getgrnam` with the correct `?*std.c.group` return type
- Uncomment the disabled audit test and add a dedicated regression test

Closes #1161

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `zig-out/bin/kaappi tests/scheme/smoke/group-info-by-name-1161.scm` — regression test passes (2/2)
- [x] `zig-out/bin/kaappi tests/scheme/audit/primitives_filesystem-audit.scm` — audit suite passes (66/66)
- [x] Verified `(group-info:gid (group-info "staff"))` returns 20 (was 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)