### PR TITLE
Implement string-join grammar argument per SRFI-13 (#825)

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -330,15 +330,31 @@ fn stringSplitFn(args: []const Value) PrimitiveError!Value {
     return result;
 }
 
-// (string-join list-of-strings) or (string-join list-of-strings delimiter)
+const Grammar = enum { infix, strict_infix, prefix, suffix };
+
+fn parseGrammar(arg: Value) PrimitiveError!Grammar {
+    if (!types.isSymbol(arg)) return primitives.typeError("string-join", "symbol (infix, strict-infix, prefix, or suffix)", arg);
+    const name = types.symbolName(arg);
+    if (std.mem.eql(u8, name, "infix")) return .infix;
+    if (std.mem.eql(u8, name, "strict-infix")) return .strict_infix;
+    if (std.mem.eql(u8, name, "prefix")) return .prefix;
+    if (std.mem.eql(u8, name, "suffix")) return .suffix;
+    return primitives.typeError("string-join", "symbol (infix, strict-infix, prefix, or suffix)", arg);
+}
+
+// (string-join list [delimiter [grammar]])
 fn stringJoinFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const delim: []const u8 = if (args.len > 1)
         (try getStringSlice("string-join", args[1]))
     else
         " ";
+    const grammar: Grammar = if (args.len > 2)
+        try parseGrammar(args[2])
+    else
+        .infix;
 
-    // Calculate total length
+    // Count elements and total string length
     var total: usize = 0;
     var count: usize = 0;
     var current = args[0];
@@ -349,8 +365,20 @@ fn stringJoinFn(args: []const Value) PrimitiveError!Value {
         count += 1;
         current = types.cdr(current);
     }
-    if (count == 0) return gc.allocString("") catch return PrimitiveError.OutOfMemory;
-    total += (count - 1) * delim.len;
+
+    if (count == 0) {
+        if (grammar == .strict_infix) {
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidArgument;
+            vm.setErrorDetail("string-join: strict-infix grammar requires a non-empty list", .{});
+            return PrimitiveError.InvalidArgument;
+        }
+        return gc.allocString("") catch return PrimitiveError.OutOfMemory;
+    }
+
+    total += switch (grammar) {
+        .infix, .strict_infix => (count - 1) * delim.len,
+        .prefix, .suffix => count * delim.len,
+    };
 
     const buf = gc.allocator.alloc(u8, total) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(buf);
@@ -358,7 +386,10 @@ fn stringJoinFn(args: []const Value) PrimitiveError!Value {
     var first = true;
     current = args[0];
     while (current != types.NIL) {
-        if (!first and delim.len > 0) {
+        if (grammar == .prefix and delim.len > 0) {
+            @memcpy(buf[pos .. pos + delim.len], delim);
+            pos += delim.len;
+        } else if ((grammar == .infix or grammar == .strict_infix) and !first and delim.len > 0) {
             @memcpy(buf[pos .. pos + delim.len], delim);
             pos += delim.len;
         }
@@ -366,6 +397,10 @@ fn stringJoinFn(args: []const Value) PrimitiveError!Value {
         const s = try getStringSlice("string-join", types.car(current));
         @memcpy(buf[pos .. pos + s.len], s);
         pos += s.len;
+        if (grammar == .suffix and delim.len > 0) {
+            @memcpy(buf[pos .. pos + delim.len], delim);
+            pos += delim.len;
+        }
         current = types.cdr(current);
     }
     return gc.allocString(buf) catch return PrimitiveError.OutOfMemory;

--- a/tests/scheme/audit/primitives_string_ext-audit.scm
+++ b/tests/scheme/audit/primitives_string_ext-audit.scm
@@ -52,12 +52,9 @@
 (test "" (string-join '()))
 (test "abcd" (string-concatenate '("ab" "cd")))
 (test "" (string-concatenate '()))
-;; FAIL: #825 (grammar argument ignored)
-;; (test "a:b:" (string-join '("a" "b") ":" 'suffix))
-;; FAIL: #825
-;; (test ":a:b" (string-join '("a" "b") ":" 'prefix))
-;; FAIL: #825 (strict-infix on empty list must raise)
-;; (test #t (guard (e (#t #t)) (string-join '() ":" 'strict-infix) #f))
+(test "a:b:" (string-join '("a" "b") ":" 'suffix))
+(test ":a:b" (string-join '("a" "b") ":" 'prefix))
+(test #t (guard (e (#t #t)) (string-join '() ":" 'strict-infix) #f))
 
 ;;; --- take / drop (+ right variants), bounds ---
 (test "ab" (string-take "abcd" 2))

--- a/tests/scheme/coverage/string-ext-coverage.scm
+++ b/tests/scheme/coverage/string-ext-coverage.scm
@@ -78,7 +78,7 @@
 (check "string-join single" (string-join '("hello") " ") "hello")
 (check "string-join empty list" (string-join '() " ") "")
 (check "string-join empty sep" (string-join '("a" "b" "c") "") "abc")
-(check "string-join no sep" (string-join '("a" "b" "c")) "abc")
+(check "string-join no sep" (string-join '("a" "b" "c")) "a b c")
 
 ;;; ---- string-concatenate ----
 (check "string-concatenate" (string-concatenate '("a" "b" "c")) "abc")

--- a/tests/scheme/smoke/string-join-grammar.scm
+++ b/tests/scheme/smoke/string-join-grammar.scm
@@ -1,0 +1,44 @@
+;; Regression test for #825: string-join grammar argument
+(import (scheme base) (scheme write) (scheme process-context) (srfi 13) (srfi 64))
+
+(test-begin "string-join-grammar")
+
+;; Default delimiter is a single space
+(test-equal "default delim" "one two three" (string-join '("one" "two" "three")))
+(test-equal "default delim single" "hello" (string-join '("hello")))
+(test-equal "default delim empty" "" (string-join '()))
+
+;; Explicit infix grammar
+(test-equal "infix" "a-b-c" (string-join '("a" "b" "c") "-" 'infix))
+(test-equal "infix single" "a" (string-join '("a") "-" 'infix))
+(test-equal "infix empty list" "" (string-join '() "-" 'infix))
+
+;; strict-infix: like infix but errors on empty list
+(test-equal "strict-infix" "a-b-c" (string-join '("a" "b" "c") "-" 'strict-infix))
+(test-equal "strict-infix single" "a" (string-join '("a") "-" 'strict-infix))
+(test-assert "strict-infix empty list errors"
+  (guard (e (#t #t)) (string-join '() "-" 'strict-infix) #f))
+
+;; prefix: delimiter before each element
+(test-equal "prefix" "/usr/local/bin" (string-join '("usr" "local" "bin") "/" 'prefix))
+(test-equal "prefix single" "/a" (string-join '("a") "/" 'prefix))
+(test-equal "prefix empty list" "" (string-join '() "/" 'prefix))
+
+;; suffix: delimiter after each element
+(test-equal "suffix" "a;b;c;" (string-join '("a" "b" "c") ";" 'suffix))
+(test-equal "suffix single" "a;" (string-join '("a") ";" 'suffix))
+(test-equal "suffix empty list" "" (string-join '() ";" 'suffix))
+
+;; Multi-char delimiter
+(test-equal "multi-char infix" "a, b, c" (string-join '("a" "b" "c") ", " 'infix))
+(test-equal "multi-char prefix" "::a::b" (string-join '("a" "b") "::" 'prefix))
+(test-equal "multi-char suffix" "a<>b<>" (string-join '("a" "b") "<>" 'suffix))
+
+;; Empty delimiter
+(test-equal "empty delim infix" "abc" (string-join '("a" "b" "c") "" 'infix))
+(test-equal "empty delim prefix" "abc" (string-join '("a" "b" "c") "" 'prefix))
+(test-equal "empty delim suffix" "abc" (string-join '("a" "b" "c") "" 'suffix))
+
+(let ((runner (test-runner-current)))
+  (test-end "string-join-grammar")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Implement the optional `grammar` argument for `string-join` per SRFI-13: `'infix` (default), `'strict-infix`, `'prefix`, and `'suffix`
- `'strict-infix` with an empty list now raises an error instead of silently returning `""`
- Fix stale test expectation for default delimiter (was `""`, already corrected to `" "` in prior work)

## Test plan

- [x] New regression test `tests/scheme/smoke/string-join-grammar.scm` — 21 cases covering all grammars, edge cases (empty list, single element, empty delimiter, multi-char delimiter)
- [x] Uncommented 3 previously-disabled audit tests for suffix, prefix, and strict-infix
- [x] Fixed stale coverage test expectation
- [x] Full suite: 1796/1796 pass

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)