### PR TITLE
Add hash-table-update! procedure to SRFI-69 (#1182)

### DIFF
--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -24,6 +24,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "hash-table->alist", .func = &hashTableToAlistFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "alist->hash-table", .func = &alistToHashTableFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "hash-table-copy", .func = &hashTableCopyFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_69) },
+    .{ .name = "hash-table-update!", .func = &hashTableUpdateFn, .arity = .{ .variadic = 3 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "hash-table-update!/default", .func = &hashTableUpdateDefaultFn, .arity = .{ .exact = 4 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "hash", .func = &hashFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "string-hash", .func = &stringHashFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_69) },
@@ -377,6 +378,43 @@ fn hashTableCopyFn(args: []const Value) PrimitiveError!Value {
     @memcpy(dst.entries[0..src.capacity], src.entries[0..src.capacity]);
     dst.count = src.count;
     return dst_val;
+}
+
+// (hash-table-update! ht key function [thunk])
+fn hashTableUpdateFn(args: []const Value) PrimitiveError!Value {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const ht = try getHashTable("hash-table-update!", args[0]);
+    const key = args[1];
+    const proc = args[2];
+
+    const old_val = if (findKey(ht, key)) |idx|
+        ht.entries[idx].value
+    else if (args.len > 3) blk: {
+        break :blk vm.callWithArgs(args[3], &[_]Value{}) catch |err| {
+            return err;
+        };
+    } else {
+        return primitives.typeError("hash-table-update!", "key to be present or thunk", key);
+    };
+
+    const call_args = [1]Value{old_val};
+    const new_val = vm.callWithArgs(proc, &call_args) catch |err| {
+        return err;
+    };
+
+    try growIfNeeded(ht);
+    const slot = findSlot(ht, key);
+    if (memory.gc_instance) |gc| {
+        gc.writeBarrier(types.toObject(args[0]), key);
+        gc.writeBarrier(types.toObject(args[0]), new_val);
+    }
+    if (slot.found) {
+        ht.entries[slot.idx].value = new_val;
+    } else {
+        ht.entries[slot.idx] = .{ .key = key, .value = new_val, .state = .occupied };
+        ht.count += 1;
+    }
+    return types.VOID;
 }
 
 // (hash-table-update!/default ht key proc default)

--- a/tests/scheme/audit/primitives_hashtable-audit.scm
+++ b/tests/scheme/audit/primitives_hashtable-audit.scm
@@ -210,13 +210,10 @@
 (test 'caught (guard (e (#t 'caught))
                 (hash-table-update!/default (make-hash-table) 'k
                                             (lambda (x) (error "boom")) 0)))
-;; SRFI-69 also specifies hash-table-update! (with optional failure thunk);
-;; it is absent from (srfi 69) — only SRFI-125's Scheme lib defines one.
-;; FAIL: #1182 (hash-table-update! missing from (srfi 69))
-;; (test 11 (let ((ht (make-hash-table)))
-;;            (hash-table-set! ht 'k 10)
-;;            (hash-table-update! ht 'k (lambda (x) (+ x 1)))
-;;            (hash-table-ref ht 'k)))
+(test 11 (let ((ht (make-hash-table)))
+           (hash-table-set! ht 'k 10)
+           (hash-table-update! ht 'k (lambda (x) (+ x 1)))
+           (hash-table-ref ht 'k)))
 
 ;;; --- copy / merge! ---
 (test '(1 2) (let ((h1 (make-hash-table)))

--- a/tests/scheme/smoke/hash-table-update-1182.scm
+++ b/tests/scheme/smoke/hash-table-update-1182.scm
@@ -1,0 +1,30 @@
+;; Regression test for #1182: hash-table-update! missing from (srfi 69)
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 69))
+
+(test-begin "hash-table-update!-1182")
+
+;; Key exists — update it
+(test-equal "update existing key"
+  11
+  (let ((ht (make-hash-table)))
+    (hash-table-set! ht 'k 10)
+    (hash-table-update! ht 'k (lambda (x) (+ x 1)))
+    (hash-table-ref ht 'k)))
+
+;; Key absent with thunk — insert via thunk
+(test-equal "absent key with thunk"
+  1
+  (let ((ht (make-hash-table)))
+    (hash-table-update! ht 'k (lambda (x) (+ x 1)) (lambda () 0))
+    (hash-table-ref ht 'k)))
+
+;; Key absent without thunk — error
+(test-assert "absent key without thunk raises error"
+  (guard (e (#t #t))
+    (let ((ht (make-hash-table)))
+      (hash-table-update! ht 'k (lambda (x) x))
+      #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "hash-table-update!-1182")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- Register `hash-table-update!` as a built-in SRFI-69 procedure with signature `(ht key function [thunk])`
- When the key exists, applies `function` to the current value and stores the result
- When the key is absent, calls the optional `thunk` to get a seed value (or errors if no thunk)
- Enables the previously disabled audit test for this procedure

Closes #1182

## Test plan
- [x] New regression test (`tests/scheme/smoke/hash-table-update-1182.scm`) — key exists, absent+thunk, absent+no-thunk
- [x] Audit test (`tests/scheme/audit/primitives_hashtable-audit.scm`) — 73 pass, 0 fail
- [x] `zig build test` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)