### PR TITLE
Fix string-contains and string-replace start2/end2 handling (#1158)

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -36,7 +36,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "string-reverse", .func = &stringReverseFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_13) },
     .{ .name = "string-filter", .func = &stringFilterFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_13) },
     .{ .name = "string-delete", .func = &stringDeleteFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_13) },
-    .{ .name = "string-replace", .func = &stringReplaceFn, .arity = .{ .exact = 4 }, .libs = LS.initOne(.srfi_13) },
+    .{ .name = "string-replace", .func = &stringReplaceFn, .arity = .{ .variadic = 4 }, .libs = LS.initOne(.srfi_13) },
     .{ .name = "string-titlecase", .func = &stringTitlecaseFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_13) },
     .{ .name = "string-every", .func = &stringEveryFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_13) },
     .{ .name = "string-any", .func = &stringAnyFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_13) },
@@ -52,12 +52,14 @@ pub const specs = [_]primitives.PrimSpec{
 // SRFI-13 String Library
 // ---------------------------------------------------------------------------
 
-// (string-contains s1 s2 [start1 end1])
+// (string-contains s1 s2 [start1 end1 start2 end2])
 fn stringContainsFn(args: []const Value) PrimitiveError!Value {
     const full_s1 = try getStringSlice("string-contains", args[0]);
-    const s2 = try getStringSlice("string-contains", args[1]);
+    const full_s2 = try getStringSlice("string-contains", args[1]);
     const range = try parseStartEnd(full_s1, args, 2);
+    const s2_range = try parseStartEnd(full_s2, args, 4);
     const s1 = range.data;
+    const s2 = s2_range.data;
     if (s2.len == 0) return types.makeFixnum(@intCast(range.cp_offset));
     if (s2.len > s1.len) return types.FALSE;
 
@@ -620,10 +622,11 @@ fn stringDeleteFn(args: []const Value) PrimitiveError!Value {
     return gc.allocString(result.items) catch return PrimitiveError.OutOfMemory;
 }
 
+// (string-replace s1 s2 start1 end1 [start2 end2])
 fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const data1 = try getStringSlice("string-replace", args[0]);
-    const data2 = try getStringSlice("string-replace", args[1]);
+    const full_data2 = try getStringSlice("string-replace", args[1]);
     if (!types.isFixnum(args[2]) or !types.isFixnum(args[3])) return primitives.typeError("string-replace", "integer", if (!types.isFixnum(args[2])) args[2] else args[3]);
     const sv = types.toFixnum(args[2]);
     const ev = types.toFixnum(args[3]);
@@ -634,6 +637,8 @@ fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
     if (start > end) return primitives.typeError("string-replace", "valid index range (start <= end)", args[2]);
     const byte_start = pstr.utf8IndexToByteOffset(data1, start) orelse return PrimitiveError.IndexOutOfBounds;
     const byte_end = pstr.utf8IndexToByteOffset(data1, end) orelse return PrimitiveError.IndexOutOfBounds;
+    const s2_range = try parseStartEnd(full_data2, args, 4);
+    const data2 = s2_range.data;
     const new_len = byte_start + data2.len + (data1.len - byte_end);
     const alloc_buf = gc.allocator.alloc(u8, new_len) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(alloc_buf);

--- a/tests/scheme/audit/primitives_string_ext-audit.scm
+++ b/tests/scheme/audit/primitives_string_ext-audit.scm
@@ -13,8 +13,7 @@
 (test 2 (string-contains "abc" "" 2))      ; empty needle => start1
 (test 0 (string-contains "" ""))
 (test 3 (string-contains "ab\x3BB;\x3BB;x" "\x3BB;x")) ; codepoint index, not byte
-;; FAIL: #1158 (start2/end2 silently ignored — whole needle searched)
-;; (test 1 (string-contains "abc" "xbcx" 0 3 1 3))
+(test 1 (string-contains "abc" "xbcx" 0 3 1 3))
 
 ;;; --- string-prefix? / string-suffix? (full 6-arg forms work) ---
 (test #t (string-prefix? "ab" "abcd"))
@@ -89,8 +88,7 @@
 (test "aXYd" (string-replace "abcd" "XY" 1 3))
 (test "abcd" (string-replace "abcd" "" 2 2))
 (test "Hello World" (string-titlecase "hello wORLD"))
-;; FAIL: #1158 (string-replace rejects optional start2/end2 — arity error)
-;; (test "aYd" (string-replace "abcd" "XYZ" 1 3 1 2))
+(test "aYd" (string-replace "abcd" "XYZ" 1 3 1 2))
 
 ;;; --- every / any (return values per SRFI-13) ---
 (test #t (string-every char-alphabetic? "abc"))

--- a/tests/scheme/smoke/srfi13-start2-end2.scm
+++ b/tests/scheme/smoke/srfi13-start2-end2.scm
@@ -1,0 +1,33 @@
+;; Regression test for #1158: string-contains ignores start2/end2,
+;; string-replace rejects them with arity error.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 13) (srfi 64))
+
+(test-begin "srfi13-start2-end2")
+
+;;; string-contains with start2/end2
+(test-equal "contains: s2 sub-range matches"
+  1 (string-contains "abc" "xbcx" 0 3 1 3))
+(test-equal "contains: s2 sub-range no match"
+  #f (string-contains "abc" "xbcx" 0 3 0 2))
+(test-equal "contains: s2 sub-range empty"
+  0 (string-contains "abc" "xbcx" 0 3 2 2))
+(test-equal "contains: all six args"
+  2 (string-contains "XXbcXX" "YYbcYY" 2 4 2 4))
+(test-equal "contains: basic (no optional args)"
+  2 (string-contains "abcdef" "cd"))
+(test-equal "contains: start1/end1 only"
+  3 (string-contains "abcdef" "de" 2))
+
+;;; string-replace with start2/end2
+(test-equal "replace: s2 sub-range"
+  "aYd" (string-replace "abcd" "XYZ" 1 3 1 2))
+(test-equal "replace: s2 sub-range full"
+  "aXYZd" (string-replace "abcd" "XYZ" 1 3 0 3))
+(test-equal "replace: s2 sub-range empty"
+  "ad" (string-replace "abcd" "XYZ" 1 3 1 1))
+(test-equal "replace: basic (no start2/end2)"
+  "aXYd" (string-replace "abcd" "XY" 1 3))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi13-start2-end2")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- **string-contains**: now respects optional `start2`/`end2` arguments by applying `parseStartEnd` on s2 at arg index 4 (previously silently ignored, searching the whole needle)
- **string-replace**: changed arity from `exact=4` to `variadic=4` and added `parseStartEnd` on s2 at arg index 4 (previously rejected optional args with arity error)
- Both follow the same pattern already used by `string-prefix?` and `string-suffix?`

## Test plan
- [x] Re-enabled 2 disabled audit assertions in `primitives_string_ext-audit.scm` (89/89 pass)
- [x] Added `tests/scheme/smoke/srfi13-start2-end2.scm` with 10 regression tests covering both procedures with and without start2/end2
- [x] Zig unit tests pass
- [x] Issue reproduction cases produce correct results: `(string-contains "abc" "xbcx" 0 3 1 3)` → `1`, `(string-replace "abcd" "XYZ" 1 3 1 2)` → `"aYd"`

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)