### PR TITLE
Fix posix-time/monotonic-time to return SRFI-19 time objects (#1162)

### DIFF
--- a/lib/srfi/19.sld
+++ b/lib/srfi/19.sld
@@ -19,27 +19,20 @@
           leap-year?)
   (begin
 
+    ;; time?, make-time, time-type, time-second, time-nanosecond are
+    ;; built-in primitives imported from (scheme time).
+
     (define time-utc 'time-utc)
     (define time-tai 'time-tai)
     (define time-monotonic 'time-monotonic)
     (define time-duration 'time-duration)
-
-    (define-record-type <time>
-      (%make-time type nanosecond second)
-      time?
-      (type time-type)
-      (nanosecond time-nanosecond)
-      (second time-second))
-
-    (define (make-time type nanosecond second)
-      (%make-time type nanosecond second))
 
     (define (current-time . args)
       (let ((type (if (pair? args) (car args) time-utc))
             (secs (current-second)))
         (let ((s (exact (truncate secs)))
               (ns (exact (truncate (* (- secs (truncate secs)) 1000000000)))))
-          (%make-time type ns s))))
+          (make-time type ns s))))
 
     ;; Comparison
     (define (time=? t1 t2)
@@ -58,23 +51,23 @@
       (let ((ds (- (time-second t1) (time-second t2)))
             (dn (- (time-nanosecond t1) (time-nanosecond t2))))
         (if (< dn 0)
-            (%make-time time-duration (+ dn 1000000000) (- ds 1))
-            (%make-time time-duration dn ds))))
+            (make-time time-duration (+ dn 1000000000) (- ds 1))
+            (make-time time-duration dn ds))))
     (define time-difference! time-difference)
 
     (define (add-duration t dur)
       (let ((s (+ (time-second t) (time-second dur)))
             (ns (+ (time-nanosecond t) (time-nanosecond dur))))
         (if (>= ns 1000000000)
-            (%make-time (time-type t) (- ns 1000000000) (+ s 1))
-            (%make-time (time-type t) ns s))))
+            (make-time (time-type t) (- ns 1000000000) (+ s 1))
+            (make-time (time-type t) ns s))))
 
     (define (subtract-duration t dur)
       (let ((s (- (time-second t) (time-second dur)))
             (ns (- (time-nanosecond t) (time-nanosecond dur))))
         (if (< ns 0)
-            (%make-time (time-type t) (+ ns 1000000000) (- s 1))
-            (%make-time (time-type t) ns s))))
+            (make-time (time-type t) (+ ns 1000000000) (- s 1))
+            (make-time (time-type t) ns s))))
 
     ;; Date record
     (define-record-type <date>
@@ -172,7 +165,7 @@
             (secs (+ (* (date-hour date) 3600)
                      (* (date-minute date) 60)
                      (date-second date))))
-        (%make-time time-utc
+        (make-time time-utc
                     (date-nanosecond date)
                     (- (+ (* epoch-days 86400) secs)
                        (date-zone-offset date)))))

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -294,7 +294,10 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
         // handle created inside a child thread and returned through
         // thread-join! dangles once the child heap is freed.
         .ffi_library, .ffi_function => src,
-        .srfi18_time => try gc.allocSrfi18Time(obj.as(types.Srfi18Time).seconds),
+        .srfi18_time => {
+            const t = obj.as(types.Srfi18Time);
+            return try gc.allocSrfi18Time(t.seconds, t.nanoseconds, t.time_type);
+        },
         .random_source => {
             const rs = obj.as(types.RandomSource);
             const new_val = try gc.allocRandomSource(0);

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -872,12 +872,14 @@ pub const GC = struct {
         return types.makePointer(@ptrCast(cv));
     }
 
-    pub fn allocSrfi18Time(self: *GC, seconds: f64) !Value {
+    pub fn allocSrfi18Time(self: *GC, seconds: i64, nanoseconds: i64, time_type: types.TimeType) !Value {
         try self.maybeCollect();
         const t = try self.allocator.create(types.Srfi18Time);
         t.* = .{
             .header = .{ .tag = .srfi18_time },
             .seconds = seconds,
+            .nanoseconds = nanoseconds,
+            .time_type = time_type,
         };
         self.finishAlloc(&t.header, @sizeOf(types.Srfi18Time));
         return types.makePointer(@ptrCast(t));

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -611,6 +611,22 @@ fn setFileOwnerFn(args: []const Value) PrimitiveError!Value {
 const TIME_NOW: i64 = -1;
 const TIME_UNCHANGED: i64 = -2;
 
+fn timeArgToTimespec(args: []const Value, idx: usize) std.c.timespec {
+    if (args.len <= idx) return std.c.UTIME.NOW;
+    const v = args[idx];
+    if (types.isSrfi18Time(v)) {
+        const t = types.toSrfi18Time(v);
+        return .{ .sec = @intCast(t.seconds), .nsec = @intCast(t.nanoseconds) };
+    }
+    if (types.isFixnum(v)) {
+        const val = types.toFixnum(v);
+        if (val == TIME_NOW) return std.c.UTIME.NOW;
+        if (val == TIME_UNCHANGED) return std.c.UTIME.OMIT;
+        return .{ .sec = @intCast(val), .nsec = 0 };
+    }
+    return std.c.UTIME.NOW;
+}
+
 fn setFileTimesFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("set-file-times", "string", args[0]);
@@ -621,31 +637,8 @@ fn setFileTimesFn(args: []const Value) PrimitiveError!Value {
 
     var times: [2]std.c.timespec = undefined;
 
-    if (args.len > 1 and types.isFixnum(args[1])) {
-        const atime_val = types.toFixnum(args[1]);
-        if (atime_val == TIME_NOW) {
-            times[0] = std.c.UTIME.NOW;
-        } else if (atime_val == TIME_UNCHANGED) {
-            times[0] = std.c.UTIME.OMIT;
-        } else {
-            times[0] = .{ .sec = @intCast(atime_val), .nsec = 0 };
-        }
-    } else {
-        times[0] = std.c.UTIME.NOW;
-    }
-
-    if (args.len > 2 and types.isFixnum(args[2])) {
-        const mtime_val = types.toFixnum(args[2]);
-        if (mtime_val == TIME_NOW) {
-            times[1] = std.c.UTIME.NOW;
-        } else if (mtime_val == TIME_UNCHANGED) {
-            times[1] = std.c.UTIME.OMIT;
-        } else {
-            times[1] = .{ .sec = @intCast(mtime_val), .nsec = 0 };
-        }
-    } else {
-        times[1] = std.c.UTIME.NOW;
-    }
+    times[0] = timeArgToTimespec(args, 1);
+    times[1] = timeArgToTimespec(args, 2);
 
     if (std.c.utimensat(std.posix.AT.FDCWD, path_z, &times, 0) != 0) {
         return raiseFileError(gc, "cannot set file times", args[0]);
@@ -976,16 +969,18 @@ fn closeDirectoryFn(args: []const Value) PrimitiveError!Value {
 
 fn posixTimeFn(args: []const Value) PrimitiveError!Value {
     _ = args;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var ts: std.c.timespec = undefined;
     _ = std.c.clock_gettime(.REALTIME, &ts);
-    return types.makeFixnum(@as(i64, @intCast(ts.sec)));
+    return gc.allocSrfi18Time(@intCast(ts.sec), @intCast(ts.nsec), .utc) catch return PrimitiveError.OutOfMemory;
 }
 
 fn monotonicTimeFn(args: []const Value) PrimitiveError!Value {
     _ = args;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var ts: std.c.timespec = undefined;
     _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return types.makeFixnum(@as(i64, @intCast(ts.sec)));
+    return gc.allocSrfi18Time(@intCast(ts.sec), @intCast(ts.nsec), .monotonic) catch return PrimitiveError.OutOfMemory;
 }
 
 // (file-info-type fi) — return type as symbol

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -15,6 +15,11 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "current-second", .func = &currentSecond, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_time) },
     .{ .name = "current-jiffy", .func = &currentJiffy, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_time) },
     .{ .name = "jiffies-per-second", .func = &jiffiesPerSecond, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_time) },
+    .{ .name = "time?", .func = &timePredFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_time, .srfi_18 }) },
+    .{ .name = "make-time", .func = &makeTimeFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.scheme_time) },
+    .{ .name = "time-type", .func = &timeTypeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
+    .{ .name = "time-second", .func = &timeSecondFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
+    .{ .name = "time-nanosecond", .func = &timeNanosecondFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
     .{ .name = "command-line", .func = &commandLine, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_process_context), .sandbox = false },
     .{ .name = "exit", .func = &exitFn, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.scheme_process_context), .sandbox = false },
     .{ .name = "emergency-exit", .func = &emergencyExitFn, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.scheme_process_context), .sandbox = false },
@@ -416,4 +421,62 @@ fn schemeReportEnvironmentFn(args: []const Value) PrimitiveError!Value {
         }
     }
     return gc.allocEnvironment(env_map, true, true) catch return PrimitiveError.OutOfMemory;
+}
+
+// -------------------------------------------------------------------------
+// SRFI-19 time object primitives (in (scheme time) for WASM availability)
+// -------------------------------------------------------------------------
+
+fn timePredFn(args: []const Value) PrimitiveError!Value {
+    return if (types.isSrfi18Time(args[0])) types.TRUE else types.FALSE;
+}
+
+fn makeTimeFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (!types.isSymbol(args[0]))
+        return primitives.typeError("make-time", "symbol", args[0]);
+    const time_type = parseTimeType(types.symbolName(args[0])) orelse
+        return primitives.typeError("make-time", "time type symbol (time-utc, time-tai, time-monotonic, time-duration)", args[0]);
+    if (!types.isFixnum(args[1]))
+        return primitives.typeError("make-time", "integer", args[1]);
+    const ns = types.toFixnum(args[1]);
+    if (ns < 0 or ns >= 1_000_000_000)
+        return primitives.typeError("make-time", "nanosecond in [0, 999999999]", args[1]);
+    if (!types.isFixnum(args[2]))
+        return primitives.typeError("make-time", "integer", args[2]);
+    return gc.allocSrfi18Time(types.toFixnum(args[2]), ns, time_type) catch return PrimitiveError.OutOfMemory;
+}
+
+fn timeTypeFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (!types.isSrfi18Time(args[0]))
+        return primitives.typeError("time-type", "time", args[0]);
+    const t = types.toSrfi18Time(args[0]);
+    const name: []const u8 = switch (t.time_type) {
+        .utc => "time-utc",
+        .tai => "time-tai",
+        .monotonic => "time-monotonic",
+        .duration => "time-duration",
+    };
+    return gc.allocSymbol(name) catch return PrimitiveError.OutOfMemory;
+}
+
+fn timeSecondFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isSrfi18Time(args[0]))
+        return primitives.typeError("time-second", "time", args[0]);
+    return types.makeFixnum(types.toSrfi18Time(args[0]).seconds);
+}
+
+fn timeNanosecondFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isSrfi18Time(args[0]))
+        return primitives.typeError("time-nanosecond", "time", args[0]);
+    return types.makeFixnum(types.toSrfi18Time(args[0]).nanoseconds);
+}
+
+fn parseTimeType(name: []const u8) ?types.TimeType {
+    if (std.mem.eql(u8, name, "time-utc")) return .utc;
+    if (std.mem.eql(u8, name, "time-tai")) return .tai;
+    if (std.mem.eql(u8, name, "time-monotonic")) return .monotonic;
+    if (std.mem.eql(u8, name, "time-duration")) return .duration;
+    return null;
 }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -37,13 +37,8 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "condition-variable-signal!", .func = &condvarSignalFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "condition-variable-broadcast!", .func = &condvarBroadcastFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "current-time", .func = &currentTimeFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
-    .{ .name = "time?", .func = &timePredFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .srfi_18, .scheme_time }), .sandbox = false, .wasm = false },
     .{ .name = "time->seconds", .func = &timeToSecondsFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "seconds->time", .func = &secondsToTimeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
-    .{ .name = "make-time", .func = &makeTimeFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.scheme_time) },
-    .{ .name = "time-type", .func = &timeTypeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
-    .{ .name = "time-second", .func = &timeSecondFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
-    .{ .name = "time-nanosecond", .func = &timeNanosecondFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
     .{ .name = "join-timeout-exception?", .func = &joinTimeoutPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "abandoned-mutex-exception?", .func = &abandonedMutexPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "terminated-thread-exception?", .func = &terminatedThreadPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
@@ -121,7 +116,8 @@ fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
     if (types.isSrfi18Time(timeout)) {
         const t = types.toSrfi18Time(timeout);
         if (t.seconds < 0) return 0;
-        const sec_ns: u64 = @as(u64, @intCast(t.seconds)) * 1_000_000_000 + @as(u64, @intCast(t.nanoseconds));
+        const ns_clamped: u64 = if (t.nanoseconds > 0) @intCast(t.nanoseconds) else 0;
+        const sec_ns: u64 = @as(u64, @intCast(t.seconds)) * 1_000_000_000 + ns_clamped;
         var now_ts: std.c.timespec = undefined;
         _ = std.c.clock_gettime(.REALTIME, &now_ts);
         const now_ns = @as(u64, @intCast(now_ts.sec)) * 1_000_000_000 + @as(u64, @intCast(now_ts.nsec));
@@ -962,10 +958,6 @@ fn currentTimeFn(_: []const Value) PrimitiveError!Value {
     return gc.allocSrfi18Time(@intCast(ts.sec), @intCast(ts.nsec), .utc) catch return PrimitiveError.OutOfMemory;
 }
 
-fn timePredFn(args: []const Value) PrimitiveError!Value {
-    return if (types.isSrfi18Time(args[0])) types.TRUE else types.FALSE;
-}
-
 fn timeToSecondsFn(args: []const Value) PrimitiveError!Value {
     if (!types.isSrfi18Time(args[0]))
         return primitives.typeError("time->seconds", "time", args[0]);
@@ -977,57 +969,10 @@ fn secondsToTimeFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const secs = primitives.toF64(args[0]) catch
         return primitives.typeError("seconds->time", "number", args[0]);
-    const int_secs = @as(i64, @intFromFloat(@trunc(secs)));
-    const frac = secs - @trunc(secs);
+    const int_secs = @as(i64, @intFromFloat(@floor(secs)));
+    const frac = secs - @floor(secs);
     const ns = @as(i64, @intFromFloat(@round(frac * 1_000_000_000.0)));
     return gc.allocSrfi18Time(int_secs, ns, .utc) catch return PrimitiveError.OutOfMemory;
-}
-
-fn makeTimeFn(args: []const Value) PrimitiveError!Value {
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    if (!types.isSymbol(args[0]))
-        return primitives.typeError("make-time", "symbol", args[0]);
-    const time_type = parseTimeType(types.symbolName(args[0])) orelse
-        return primitives.typeError("make-time", "time type symbol (time-utc, time-tai, time-monotonic, time-duration)", args[0]);
-    if (!types.isFixnum(args[1]))
-        return primitives.typeError("make-time", "integer", args[1]);
-    if (!types.isFixnum(args[2]))
-        return primitives.typeError("make-time", "integer", args[2]);
-    return gc.allocSrfi18Time(types.toFixnum(args[2]), types.toFixnum(args[1]), time_type) catch return PrimitiveError.OutOfMemory;
-}
-
-fn timeTypeFn(args: []const Value) PrimitiveError!Value {
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    if (!types.isSrfi18Time(args[0]))
-        return primitives.typeError("time-type", "time", args[0]);
-    const t = types.toSrfi18Time(args[0]);
-    const name: []const u8 = switch (t.time_type) {
-        .utc => "time-utc",
-        .tai => "time-tai",
-        .monotonic => "time-monotonic",
-        .duration => "time-duration",
-    };
-    return gc.allocSymbol(name) catch return PrimitiveError.OutOfMemory;
-}
-
-fn timeSecondFn(args: []const Value) PrimitiveError!Value {
-    if (!types.isSrfi18Time(args[0]))
-        return primitives.typeError("time-second", "time", args[0]);
-    return types.makeFixnum(types.toSrfi18Time(args[0]).seconds);
-}
-
-fn timeNanosecondFn(args: []const Value) PrimitiveError!Value {
-    if (!types.isSrfi18Time(args[0]))
-        return primitives.typeError("time-nanosecond", "time", args[0]);
-    return types.makeFixnum(types.toSrfi18Time(args[0]).nanoseconds);
-}
-
-fn parseTimeType(name: []const u8) ?types.TimeType {
-    if (std.mem.eql(u8, name, "time-utc")) return .utc;
-    if (std.mem.eql(u8, name, "time-tai")) return .tai;
-    if (std.mem.eql(u8, name, "time-monotonic")) return .monotonic;
-    if (std.mem.eql(u8, name, "time-duration")) return .duration;
-    return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -37,9 +37,13 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "condition-variable-signal!", .func = &condvarSignalFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "condition-variable-broadcast!", .func = &condvarBroadcastFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "current-time", .func = &currentTimeFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
-    .{ .name = "time?", .func = &timePredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
+    .{ .name = "time?", .func = &timePredFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .srfi_18, .scheme_time }), .sandbox = false, .wasm = false },
     .{ .name = "time->seconds", .func = &timeToSecondsFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "seconds->time", .func = &secondsToTimeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
+    .{ .name = "make-time", .func = &makeTimeFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.scheme_time) },
+    .{ .name = "time-type", .func = &timeTypeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
+    .{ .name = "time-second", .func = &timeSecondFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
+    .{ .name = "time-nanosecond", .func = &timeNanosecondFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_time) },
     .{ .name = "join-timeout-exception?", .func = &joinTimeoutPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "abandoned-mutex-exception?", .func = &abandonedMutexPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "terminated-thread-exception?", .func = &terminatedThreadPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
@@ -116,7 +120,8 @@ fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
     if (timeout == types.FALSE) return null;
     if (types.isSrfi18Time(timeout)) {
         const t = types.toSrfi18Time(timeout);
-        const sec_ns: u64 = @intFromFloat(@max(0.0, t.seconds) * 1_000_000_000.0);
+        if (t.seconds < 0) return 0;
+        const sec_ns: u64 = @as(u64, @intCast(t.seconds)) * 1_000_000_000 + @as(u64, @intCast(t.nanoseconds));
         var now_ts: std.c.timespec = undefined;
         _ = std.c.clock_gettime(.REALTIME, &now_ts);
         const now_ns = @as(u64, @intCast(now_ts.sec)) * 1_000_000_000 + @as(u64, @intCast(now_ts.nsec));
@@ -367,7 +372,8 @@ fn getSleepSeconds(v: Value) PrimitiveError!f64 {
         var ts: std.c.timespec = undefined;
         _ = std.c.clock_gettime(.REALTIME, &ts);
         const now: f64 = @as(f64, @floatFromInt(ts.sec)) + @as(f64, @floatFromInt(ts.nsec)) / 1e9;
-        return t.seconds - now;
+        const target: f64 = @as(f64, @floatFromInt(t.seconds)) + @as(f64, @floatFromInt(t.nanoseconds)) / 1e9;
+        return target - now;
     }
     return PrimitiveError.TypeError; // bare-ok: type guard
 }
@@ -953,8 +959,7 @@ fn currentTimeFn(_: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var ts: std.c.timespec = undefined;
     _ = std.c.clock_gettime(.REALTIME, &ts);
-    const seconds = @as(f64, @floatFromInt(ts.sec)) + @as(f64, @floatFromInt(ts.nsec)) / 1_000_000_000.0;
-    return gc.allocSrfi18Time(seconds) catch return PrimitiveError.OutOfMemory;
+    return gc.allocSrfi18Time(@intCast(ts.sec), @intCast(ts.nsec), .utc) catch return PrimitiveError.OutOfMemory;
 }
 
 fn timePredFn(args: []const Value) PrimitiveError!Value {
@@ -964,14 +969,65 @@ fn timePredFn(args: []const Value) PrimitiveError!Value {
 fn timeToSecondsFn(args: []const Value) PrimitiveError!Value {
     if (!types.isSrfi18Time(args[0]))
         return primitives.typeError("time->seconds", "time", args[0]);
-    return types.makeFlonum(types.toSrfi18Time(args[0]).seconds);
+    const t = types.toSrfi18Time(args[0]);
+    return types.makeFlonum(@as(f64, @floatFromInt(t.seconds)) + @as(f64, @floatFromInt(t.nanoseconds)) / 1_000_000_000.0);
 }
 
 fn secondsToTimeFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const secs = primitives.toF64(args[0]) catch
         return primitives.typeError("seconds->time", "number", args[0]);
-    return gc.allocSrfi18Time(secs) catch return PrimitiveError.OutOfMemory;
+    const int_secs = @as(i64, @intFromFloat(@trunc(secs)));
+    const frac = secs - @trunc(secs);
+    const ns = @as(i64, @intFromFloat(@round(frac * 1_000_000_000.0)));
+    return gc.allocSrfi18Time(int_secs, ns, .utc) catch return PrimitiveError.OutOfMemory;
+}
+
+fn makeTimeFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (!types.isSymbol(args[0]))
+        return primitives.typeError("make-time", "symbol", args[0]);
+    const time_type = parseTimeType(types.symbolName(args[0])) orelse
+        return primitives.typeError("make-time", "time type symbol (time-utc, time-tai, time-monotonic, time-duration)", args[0]);
+    if (!types.isFixnum(args[1]))
+        return primitives.typeError("make-time", "integer", args[1]);
+    if (!types.isFixnum(args[2]))
+        return primitives.typeError("make-time", "integer", args[2]);
+    return gc.allocSrfi18Time(types.toFixnum(args[2]), types.toFixnum(args[1]), time_type) catch return PrimitiveError.OutOfMemory;
+}
+
+fn timeTypeFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (!types.isSrfi18Time(args[0]))
+        return primitives.typeError("time-type", "time", args[0]);
+    const t = types.toSrfi18Time(args[0]);
+    const name: []const u8 = switch (t.time_type) {
+        .utc => "time-utc",
+        .tai => "time-tai",
+        .monotonic => "time-monotonic",
+        .duration => "time-duration",
+    };
+    return gc.allocSymbol(name) catch return PrimitiveError.OutOfMemory;
+}
+
+fn timeSecondFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isSrfi18Time(args[0]))
+        return primitives.typeError("time-second", "time", args[0]);
+    return types.makeFixnum(types.toSrfi18Time(args[0]).seconds);
+}
+
+fn timeNanosecondFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isSrfi18Time(args[0]))
+        return primitives.typeError("time-nanosecond", "time", args[0]);
+    return types.makeFixnum(types.toSrfi18Time(args[0]).nanoseconds);
+}
+
+fn parseTimeType(name: []const u8) ?types.TimeType {
+    if (std.mem.eql(u8, name, "time-utc")) return .utc;
+    if (std.mem.eql(u8, name, "time-tai")) return .tai;
+    if (std.mem.eql(u8, name, "time-monotonic")) return .monotonic;
+    if (std.mem.eql(u8, name, "time-duration")) return .duration;
+    return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -697,7 +697,8 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                     .monotonic => "time-monotonic",
                     .duration => "time-duration",
                 };
-                try writer.print("#<time {s} {d}.{d:0>9}>", .{ type_name, t.seconds, @as(u64, @intCast(t.nanoseconds)) });
+                const ns: u64 = if (t.nanoseconds >= 0) @intCast(t.nanoseconds) else 0;
+                try writer.print("#<time {s} {d}.{d:0>9}>", .{ type_name, t.seconds, ns });
             },
             .bignum => {
                 const bignum_mod = @import("bignum.zig");

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -691,7 +691,13 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
             },
             .srfi18_time => {
                 const t = obj.as(types.Srfi18Time);
-                try writer.print("#<time {d:.6}>", .{t.seconds});
+                const type_name: []const u8 = switch (t.time_type) {
+                    .utc => "time-utc",
+                    .tai => "time-tai",
+                    .monotonic => "time-monotonic",
+                    .duration => "time-duration",
+                };
+                try writer.print("#<time {s} {d}.{d:0>9}>", .{ type_name, t.seconds, @as(u64, @intCast(t.nanoseconds)) });
             },
             .bignum => {
                 const bignum_mod = @import("bignum.zig");

--- a/src/tests_filesystem.zig
+++ b/src/tests_filesystem.zig
@@ -294,22 +294,32 @@ test "delete-environment-variable! removes variable" {
     ));
 }
 
-test "posix-time returns reasonable epoch seconds" {
+test "posix-time returns SRFI-19 time object" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    try std.testing.expectEqual(types.TRUE, try vm.eval("(> (posix-time) 1700000000)"));
+    const result = try vm.eval("(posix-time)");
+    try std.testing.expect(types.isSrfi18Time(result));
+    const t = types.toSrfi18Time(result);
+    try std.testing.expect(t.seconds > 1700000000);
+    try std.testing.expect(t.nanoseconds >= 0 and t.nanoseconds < 1_000_000_000);
+    try std.testing.expectEqual(types.TimeType.utc, t.time_type);
 }
 
-test "monotonic-time returns non-negative" {
+test "monotonic-time returns SRFI-19 time object" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    try std.testing.expectEqual(types.TRUE, try vm.eval("(>= (monotonic-time) 0)"));
+    const result = try vm.eval("(monotonic-time)");
+    try std.testing.expect(types.isSrfi18Time(result));
+    const t = types.toSrfi18Time(result);
+    try std.testing.expect(t.seconds >= 0);
+    try std.testing.expect(t.nanoseconds >= 0 and t.nanoseconds < 1_000_000_000);
+    try std.testing.expectEqual(types.TimeType.monotonic, t.time_type);
 }
 
 test "rename-file works" {

--- a/src/types.zig
+++ b/src/types.zig
@@ -652,9 +652,18 @@ pub const ConditionVariable = struct {
     specific: Value,
 };
 
+pub const TimeType = enum(u8) {
+    utc,
+    tai,
+    monotonic,
+    duration,
+};
+
 pub const Srfi18Time = struct {
     header: Object,
-    seconds: f64,
+    seconds: i64,
+    nanoseconds: i64,
+    time_type: TimeType,
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -134,10 +134,8 @@
   (group-info:gid (group-info (group-info:name (group-info (user-gid))))))
 
 ;;; --- time ---
-(test #t (>= (monotonic-time) 0))
-(test #t (> (posix-time) 0))
-;; FAIL: #1162 (posix-time/monotonic-time must return SRFI-19 time objects)
-;; (test #t (let ((t (posix-time))) (and (not (number? t)) #t)))
+(test #t (not (number? (monotonic-time))))
+(test #t (not (number? (posix-time))))
 
 ;;; --- terminal? ---
 (test #f (terminal? (open-input-string "x")))

--- a/tests/scheme/coverage/filesystem-coverage.scm
+++ b/tests/scheme/coverage/filesystem-coverage.scm
@@ -1,4 +1,4 @@
-(import (scheme base) (scheme write) (scheme file) (srfi 170))
+(import (scheme base) (scheme write) (scheme file) (scheme time) (srfi 170))
 
 (define pass 0)
 (define fail 0)
@@ -146,8 +146,10 @@
 (check-true "real-path absolute" (char=? #\/ (string-ref (real-path ".") 0)))
 
 ;;; ---- posix-time / monotonic-time ----
-(check-true "posix-time positive" (> (posix-time) 0))
-(check-true "monotonic-time non-negative" (>= (monotonic-time) 0))
+(check-true "posix-time is time object" (time? (posix-time)))
+(check-true "posix-time seconds positive" (> (time-second (posix-time)) 0))
+(check-true "monotonic-time is time object" (time? (monotonic-time)))
+(check-true "monotonic-time seconds non-negative" (>= (time-second (monotonic-time)) 0))
 
 ;;; ---- current-second / current-jiffy / jiffies-per-second ----
 (check-true "current-second" (> (current-second) 0))

--- a/tests/scheme/smoke/srfi170-time-objects.scm
+++ b/tests/scheme/smoke/srfi170-time-objects.scm
@@ -1,0 +1,45 @@
+;; Regression test for #1162: posix-time/monotonic-time return SRFI-19 time objects
+(import (scheme base) (scheme write) (scheme time) (scheme process-context)
+        (srfi 19) (srfi 170) (srfi 64))
+
+(test-begin "srfi170-time-objects")
+
+;; posix-time returns an SRFI-19 time object
+(test-assert "posix-time returns time object" (time? (posix-time)))
+(test-equal "posix-time type is time-utc" 'time-utc (time-type (posix-time)))
+(test-assert "posix-time seconds > epoch" (> (time-second (posix-time)) 1700000000))
+(test-assert "posix-time nanoseconds in range"
+  (let ((ns (time-nanosecond (posix-time))))
+    (and (>= ns 0) (< ns 1000000000))))
+
+;; monotonic-time returns an SRFI-19 time object
+(test-assert "monotonic-time returns time object" (time? (monotonic-time)))
+(test-equal "monotonic-time type is time-monotonic"
+  'time-monotonic (time-type (monotonic-time)))
+(test-assert "monotonic-time seconds non-negative" (>= (time-second (monotonic-time)) 0))
+(test-assert "monotonic-time nanoseconds in range"
+  (let ((ns (time-nanosecond (monotonic-time))))
+    (and (>= ns 0) (< ns 1000000000))))
+
+;; SRFI-19 time operations work on posix-time results
+(test-assert "time-difference works"
+  (let* ((t1 (posix-time))
+         (t2 (posix-time))
+         (diff (time-difference t2 t1)))
+    (>= (time-second diff) 0)))
+
+;; SRFI-19 make-time creates compatible objects
+(test-assert "make-time creates time object" (time? (make-time 'time-utc 0 1000)))
+(test-equal "make-time second" 1000 (time-second (make-time 'time-utc 500 1000)))
+(test-equal "make-time nanosecond" 500 (time-nanosecond (make-time 'time-utc 500 1000)))
+(test-equal "make-time type" 'time-utc (time-type (make-time 'time-utc 0 0)))
+
+;; SRFI-19 current-time also returns compatible objects
+(test-assert "srfi-19 current-time is time?" (time? (current-time)))
+(test-equal "srfi-19 current-time default type" 'time-utc (time-type (current-time)))
+(test-equal "srfi-19 current-time monotonic type"
+  'time-monotonic (time-type (current-time 'time-monotonic)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi170-time-objects")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Extends the Zig-level `Srfi18Time` type with `nanoseconds: i64` and `time_type: TimeType` fields, unifying it as the canonical time representation for both SRFI-18 and SRFI-19
- Registers SRFI-19 time accessors (`make-time`, `time?`, `time-type`, `time-second`, `time-nanosecond`) as built-in primitives in `(scheme time)`
- Updates `lib/srfi/19.sld` to use the built-in time type instead of `define-record-type <time>`
- Fixes `posix-time` to return a `time-utc` object and `monotonic-time` to return a `time-monotonic` object, both with nanosecond precision
- Updates `set-file-times` to accept time objects in addition to fixnums

Closes #1162

## Test plan

- [x] `zig build test` — 667 unit tests pass (0 fail)
- [x] `bash tests/scheme/run-all.sh` — 1802 tests pass (0 fail)
- [x] SRFI-19 test suite — 112/112 pass
- [x] New regression test `tests/scheme/smoke/srfi170-time-objects.scm` — 16 assertions
- [x] Manual REPL verification: `(time? (posix-time))` → `#t`, `(time-type (posix-time))` → `time-utc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)