### PR TITLE
Fix stream-unfold predicate sense and stream macro hygiene (#1215)

### DIFF
--- a/lib/srfi/41.sld
+++ b/lib/srfi/41.sld
@@ -31,15 +31,15 @@
 
     (define-syntax stream
       (syntax-rules ()
-        ((stream) stream-null)
+        ((stream) (delay '()))
         ((stream x rest ...)
          (stream-cons x (stream rest ...)))))
 
     (define (stream-unfold mapper pred gen seed)
       (define (unfold-loop s)
         (if (pred s)
-            stream-null
-            (stream-cons (mapper s) (unfold-loop (gen s)))))
+            (stream-cons (mapper s) (unfold-loop (gen s)))
+            stream-null))
       (unfold-loop seed))
 
     (define (stream-map proc strm)

--- a/lib/srfi/41.sld
+++ b/lib/srfi/41.sld
@@ -118,8 +118,12 @@
                        (apply stream-append (cdr strms))))))
 
     (define (stream-zip . strms)
+      (define (any-null? ss)
+        (and (not (null? ss))
+             (or (stream-null? (car ss))
+                 (any-null? (cdr ss)))))
       (define (zip-loop ss)
-        (if (or (null? ss) (stream-null? (car ss)))
+        (if (or (null? ss) (any-null? ss))
             stream-null
             (stream-cons (map stream-car ss)
                          (zip-loop (map stream-cdr ss)))))

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -145,7 +145,10 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
     }
     defer if (self.globals) |g| {
         const glk = globals_mod.acquireGlobalsWrite(g);
-        for (temp_globals[0..temp_global_count]) |tg| {
+        var tgi = temp_global_count;
+        while (tgi > 0) {
+            tgi -= 1;
+            const tg = temp_globals[tgi];
             if (tg.was_present) {
                 g.put(tg.name, tg.old_val.?) catch {};
             } else {

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -716,3 +716,15 @@ test "lambda parameter shadows a syntactic keyword in its body (#788)" {
     // An unshadowed keyword still compiles as the special form.
     try std.testing.expectEqual(@as(i64, 2), types.toFixnum(try vm.eval("((lambda (x) (if 1 2 3)) 0)")));
 }
+
+test "recursive variadic macro: sibling calls produce correct values (#1215)" {
+    try th.expectEval(
+        \\(begin
+        \\  (define-syntax my-list
+        \\    (syntax-rules ()
+        \\      ((my-list) '())
+        \\      ((my-list x rest ...)
+        \\       (cons x (my-list rest ...)))))
+        \\  (+ (car (my-list 10 20)) (car (my-list 30 40))))
+    , 40);
+}

--- a/tests/scheme/srfi/srfi41.scm
+++ b/tests/scheme/srfi/srfi41.scm
@@ -43,23 +43,20 @@
 ;;; --- finite stream operations ---
 (test 3 (stream-length (stream 1 2 3)))
 (test 6 (stream-fold + 0 (stream 1 2 3)))
-;; FAIL: #1215 (stream-append drops everything after the first stream)
-;; (test '(1 2 3 4) (stream->list (stream-append (stream 1 2) (stream 3 4))))
-;; FAIL: #1215 (stream-zip errors instead of stopping at the shortest stream)
-;; (test '((1 a) (2 b)) (stream->list (stream-zip (stream 1 2) (stream 'a 'b 'c))))
+(test '(1 2 3 4) (stream->list (stream-append (stream 1 2) (stream 3 4))))
+(test '((1 a) (2 b)) (stream->list (stream-zip (stream 1 2) (stream 'a 'b 'c))))
 (test '(a b c)
       (let ((acc '()))
         (stream-for-each (lambda (x) (set! acc (cons x acc))) (stream 'a 'b 'c))
         (reverse acc)))
 
 ;; stream-unfold: (stream-unfold map pred? gen base)
-;; FAIL: #1215 (stream-unfold predicate sense inverted)
-;; (test '(0 1 4 9)
-;;       (stream->list (stream-unfold
-;;                      (lambda (x) (* x x))
-;;                      (lambda (x) (< x 4))
-;;                      (lambda (x) (+ x 1))
-;;                      0)))
+(test '(0 1 4 9)
+      (stream->list (stream-unfold
+                     (lambda (x) (* x x))
+                     (lambda (x) (< x 4))
+                     (lambda (x) (+ x 1))
+                     0)))
 
 ;; stream-lambda
 (define double-all
@@ -76,5 +73,23 @@
 ;; (test '(0 1 2) (stream->list (stream-range 0 3)))
 ;; (test '(3 2 1) (stream->list (stream-reverse (stream 1 2 3))))
 ;; (test '(1 2 4) (stream->list (stream-take 3 (stream-iterate (lambda (x) (* 2 x)) 1))))
+
+;;; --- regression: #1215 stream-append with multiple streams ---
+(test '(1 2 3 4 5 6)
+      (stream->list (stream-append (stream 1 2) (stream 3 4) (stream 5 6))))
+(test '(1 2) (stream->list (stream-append (stream 1 2) (stream))))
+(test '(1 2) (stream->list (stream-append (stream) (stream 1 2))))
+
+;;; --- regression: #1215 stream-zip edge cases ---
+(test '() (stream->list (stream-zip (stream) (stream 1 2))))
+(test '((1 10)) (stream->list (stream-zip (stream 1) (stream 10 20))))
+
+;;; --- regression: #1215 stream-unfold edge cases ---
+(test '() (stream->list (stream-unfold values (lambda (x) #f) (lambda (x) (+ x 1)) 0)))
+(test '(0) (stream->list (stream-unfold values (lambda (x) (< x 1)) (lambda (x) (+ x 1)) 0)))
+
+;;; --- regression: #1215 stream macro as sibling arguments ---
+(test '(#t #t) (list (promise? (stream 1)) (promise? (stream 2))))
+(test '(#t #t #t) (list (promise? (stream 1)) (promise? (stream 2)) (promise? (stream 3))))
 
 (test-end "srfi-41")

--- a/tests/scheme/srfi/srfi41.scm
+++ b/tests/scheme/srfi/srfi41.scm
@@ -83,13 +83,17 @@
 ;;; --- regression: #1215 stream-zip edge cases ---
 (test '() (stream->list (stream-zip (stream) (stream 1 2))))
 (test '((1 10)) (stream->list (stream-zip (stream 1) (stream 10 20))))
+(test '((1 10)) (stream->list (stream-zip (stream 1 2) (stream 10))))
 
 ;;; --- regression: #1215 stream-unfold edge cases ---
 (test '() (stream->list (stream-unfold values (lambda (x) #f) (lambda (x) (+ x 1)) 0)))
 (test '(0) (stream->list (stream-unfold values (lambda (x) (< x 1)) (lambda (x) (+ x 1)) 0)))
 
-;;; --- regression: #1215 stream macro as sibling arguments ---
-(test '(#t #t) (list (promise? (stream 1)) (promise? (stream 2))))
-(test '(#t #t #t) (list (promise? (stream 1)) (promise? (stream 2)) (promise? (stream 3))))
+;;; --- regression: #1215 stream macro sibling arguments must produce correct content ---
+(define (two-streams) (list (stream->list (stream 1 2)) (stream->list (stream 3 4))))
+(test '((1 2) (3 4)) (two-streams))
+(define (three-streams)
+  (list (stream->list (stream 'a)) (stream->list (stream 'b)) (stream->list (stream 'c))))
+(test '((a) (b) (c)) (three-streams))
 
 (test-end "srfi-41")


### PR DESCRIPTION
## Summary

- **stream-unfold**: flip predicate sense — SRFI-41 says elements are produced *while* `pred?` holds, but the implementation stopped when `pred?` returned true
- **stream macro**: replace `stream-null` free-variable reference with `(delay '())` in the base-case template — the `collectSetTargets` pre-scan expands macros without VOID-marking free refs, causing `renameForHygiene` to give `stream-null` a hygienic prefix that breaks when two `(stream …)` calls appear as sibling arguments
- **temp_globals cleanup**: reverse the cleanup loop to LIFO order to prevent Phase-B entries from re-adding names that Phase-A2 correctly removed

Fixes `stream-unfold`, `stream-append`, and `stream-zip` as reported in #1215.

## Test plan

- [x] `zig build test` — 668 pass, 0 fail
- [x] `bash tests/scheme/run-all.sh` — 1801 pass, 0 fail
- [x] Uncommented 3 FAIL-marked tests in `tests/scheme/srfi/srfi41.scm`
- [x] Added 10 new regression tests for stream-append, stream-zip, stream-unfold edge cases, and sibling stream macro calls
- [x] Added Zig unit test for recursive variadic macro sibling calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)