### PR TITLE
Fix SRFI-210 set!-values shadowing bug (#1224)

### DIFF
--- a/lib/srfi/210.sld
+++ b/lib/srfi/210.sld
@@ -18,7 +18,17 @@
       (syntax-rules ()
         ((set!-values (var ...) producer)
          (call-with-values (lambda () producer)
-           (lambda (var ...) (set! var var) ...)))))
+           (lambda args
+             (set!-values-aux (var ...) args))))))
+
+    (define-syntax set!-values-aux
+      (syntax-rules ()
+        ((set!-values-aux () args)
+         (if #f #f))
+        ((set!-values-aux (var . vars) args)
+         (begin
+           (set! var (car args))
+           (set!-values-aux vars (cdr args))))))
 
     (define-syntax case-receive
       (syntax-rules (else)

--- a/tests/scheme/srfi/srfi210.scm
+++ b/tests/scheme/srfi/srfi210.scm
@@ -25,11 +25,19 @@
 (test 'many (case-receive (values 1 2 3) ((a) 'one) ((a b) 'two) (else 'many)))
 
 ;; set!-values assigns existing variables:
-;; FAIL: #1224 (set!-values is a no-op — assigns the consumer's own params)
-;; (define sv-a 0)
-;; (define sv-b 0)
-;; (set!-values (sv-a sv-b) (values 10 20))
-;; (test '(10 20) (list sv-a sv-b))
+(define sv-a 0)
+(define sv-b 0)
+(set!-values (sv-a sv-b) (values 10 20))
+(test '(10 20) (list sv-a sv-b))
+
+;; set!-values with single variable
+(define sv-c 0)
+(set!-values (sv-c) (values 99))
+(test 99 sv-c)
+
+;; set!-values overwrites previous set!-values results
+(set!-values (sv-a sv-b) (values 30 40))
+(test '(30 40) (list sv-a sv-b))
 
 ;; bind/mv chains a producer through transducers
 (test 3 (bind/mv (values 1 2) +))


### PR DESCRIPTION
## Summary
- Fix `set!-values` macro in `lib/srfi/210.sld` — the consumer lambda's parameters shadowed the outer variables, so `(set! var var)` was a no-op
- Use a rest-arg lambda with a `set!-values-aux` helper macro that walks the value list and assigns each to the correct outer variable
- Enable the disabled test and add edge cases (single variable, repeated use)

Closes #1224

## Test plan
- [x] `zig build run -- tests/scheme/srfi/srfi210.scm` — 33 pass, 0 fail
- [x] Minimal repro from the issue now returns `(10 20)` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)