### PR TITLE
Fix SRFI-43 vector library to match spec (#1209)

### DIFF
--- a/lib/srfi/43.sld
+++ b/lib/srfi/43.sld
@@ -1,9 +1,10 @@
 ;;; SRFI 43 — Vector Library
 ;;; SRFI-43 iteration procedures pass the index as the first callback
-;;; argument; SRFI-133 does not.  Procedures with identical semantics
-;;; are re-exported directly from SRFI-133.
+;;; argument; SRFI-133 does not.  The six iteration procedures are
+;;; redefined below; remaining procedures are re-exported from
+;;; (scheme base) and (srfi 133).
 (define-library (srfi 43)
-  (import (scheme base)
+  (import (except (scheme base) vector-map vector-for-each)
           (except (srfi 133)
                   vector-map! vector-count
                   vector-fold vector-fold-right))

--- a/lib/srfi/43.sld
+++ b/lib/srfi/43.sld
@@ -1,7 +1,12 @@
-;;; SRFI 43 — Vector Library (predecessor to SRFI 133)
-;;; Re-exports from SRFI 133 with SRFI 43 names
+;;; SRFI 43 — Vector Library
+;;; SRFI-43 iteration procedures pass the index as the first callback
+;;; argument; SRFI-133 does not.  Procedures with identical semantics
+;;; are re-exported directly from SRFI-133.
 (define-library (srfi 43)
-  (import (scheme base) (srfi 133))
+  (import (scheme base)
+          (except (srfi 133)
+                  vector-map! vector-count
+                  vector-fold vector-fold-right))
   (export make-vector vector vector? vector-ref vector-set! vector-length
           vector-fold vector-fold-right
           vector-map vector-map!
@@ -10,28 +15,75 @@
           vector-index vector-index-right
           vector-skip vector-skip-right
           vector-any vector-every
+          vector-binary-search
           vector-copy vector-copy!
-          vector-reverse-copy
-          vector->list list->vector
+          vector-reverse-copy vector-reverse-copy!
           vector-fill!
           vector-swap!
+          vector-reverse!
           vector-append vector-concatenate
-          vector-empty?)
+          vector-empty?
+          vector-unfold vector-unfold-right
+          vector=
+          vector->list list->vector
+          reverse-vector->list reverse-list->vector)
   (begin
-    (define (vector-fold kons knil vec)
-      (let ((len (vector-length vec)))
-        (let loop ((i 0) (acc knil))
-          (if (= i len) acc
-              (loop (+ i 1) (kons acc (vector-ref vec i)))))))
+    ;; SRFI-43 vector-fold: (kons i state elt1 elt2 ...) — left to right
+    (define (vector-fold kons knil . vecs)
+      (let ((len (apply min (map vector-length vecs))))
+        (let loop ((i 0) (state knil))
+          (if (= i len) state
+              (loop (+ i 1)
+                    (apply kons i state
+                           (map (lambda (v) (vector-ref v i)) vecs)))))))
 
-    (define (vector-fold-right kons knil vec)
-      (let loop ((i (- (vector-length vec) 1)) (acc knil))
-        (if (< i 0) acc
-            (loop (- i 1) (kons acc (vector-ref vec i))))))
+    ;; SRFI-43 vector-fold-right: (kons i state elt1 elt2 ...) — right to left
+    (define (vector-fold-right kons knil . vecs)
+      (let ((len (apply min (map vector-length vecs))))
+        (let loop ((i (- len 1)) (state knil))
+          (if (< i 0) state
+              (loop (- i 1)
+                    (apply kons i state
+                           (map (lambda (v) (vector-ref v i)) vecs)))))))
 
-    (define (vector-map! f vec)
-      (let ((len (vector-length vec)))
+    ;; SRFI-43 vector-map: (f i elt1 elt2 ...) — returns new vector
+    (define (vector-map f . vecs)
+      (let* ((len (apply min (map vector-length vecs)))
+             (result (make-vector len)))
         (let loop ((i 0))
           (when (< i len)
-            (vector-set! vec i (f (vector-ref vec i)))
-            (loop (+ i 1))))))))
+            (vector-set! result i
+                         (apply f i (map (lambda (v) (vector-ref v i)) vecs)))
+            (loop (+ i 1))))
+        result))
+
+    ;; SRFI-43 vector-map!: (f i elt1 elt2 ...) — mutates first vector
+    (define (vector-map! f vec . vecs)
+      (let ((len (apply min (vector-length vec)
+                        (map vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i len)
+            (vector-set! vec i
+                         (apply f i
+                                (cons (vector-ref vec i)
+                                      (map (lambda (v) (vector-ref v i)) vecs))))
+            (loop (+ i 1))))))
+
+    ;; SRFI-43 vector-for-each: (f i elt1 elt2 ...) — left to right
+    (define (vector-for-each f . vecs)
+      (let ((len (apply min (map vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i len)
+            (apply f i (map (lambda (v) (vector-ref v i)) vecs))
+            (loop (+ i 1))))))
+
+    ;; SRFI-43 vector-count: (pred? i elt1 elt2 ...)
+    (define (vector-count pred? . vecs)
+      (let ((len (apply min (map vector-length vecs))))
+        (let loop ((i 0) (count 0))
+          (if (= i len) count
+              (loop (+ i 1)
+                    (if (apply pred? i
+                               (map (lambda (v) (vector-ref v i)) vecs))
+                        (+ count 1)
+                        count))))))))

--- a/tests/scheme/srfi/srfi43.scm
+++ b/tests/scheme/srfi/srfi43.scm
@@ -1,59 +1,117 @@
-;; SRFI-43 (vector library) conformance tests — audit Phase 3b
-;; NOTE: Kaappi's (srfi 43) currently re-exports SRFI-133-style procedures;
-;; the index-passing callback convention and 8 exports are missing (#1209).
-;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi43.scm
+;; SRFI-43 (vector library) conformance tests
+;; Covers index-passing callback convention and all exported procedures.
+;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi43.scm
 
 (import (scheme base) (srfi 43) (chibi test))
 
 (test-begin "srfi-43")
 
-;;; --- procedures whose semantics agree between SRFI-43 and SRFI-133 ---
-(test #t (vector-empty? #()))
-(test #f (vector-empty? #(1)))
+;;; --- constructors ---
+(test #(0 0) (make-vector 2 0))
+(test #(1 2 3) (vector 1 2 3))
+(test #(0 1 2) (vector-unfold (lambda (i) (values i)) 3))
+(test #(0 1 2) (vector-unfold (lambda (i x) (values x (+ x 1))) 3 0))
+(test #(2 1 0) (vector-unfold-right (lambda (i x) (values x (+ x 1))) 3 0))
+(test #(0 1 2) (vector-unfold-right (lambda (i) (values i)) 3))
 (test #(1 2 3 4) (vector-append #(1 2) #(3 4)))
 (test #(1 2 3 4) (vector-concatenate (list #(1 2) #(3 4))))
-(test #(9 2 1) (let ((v (vector 1 2 9))) (vector-swap! v 0 2) v))
-(test '(1 2 3) (vector->list #(1 2 3)))
-(test #(1 2 3) (list->vector '(1 2 3)))
-(test #(0 0) (make-vector 2 0))
-(test #(7 7 7) (let ((v (vector 1 2 3))) (vector-fill! v 7) v))
 (test #(1 2) (vector-copy #(1 2)))
-(test #(5 6 3) (let ((v (vector 1 2 3))) (vector-copy! v 0 #(5 6)) v))
+(test #(3 2 1) (vector-reverse-copy #(1 2 3)))
 
-;; searching (SRFI-43 predicates receive elements, no index)
+;;; --- predicates ---
+(test #t (vector? #()))
+(test #f (vector? 42))
+(test #t (vector-empty? #()))
+(test #f (vector-empty? #(1)))
+(test #t (vector= eqv? #(1 2) #(1 2)))
+(test #f (vector= eqv? #(1 2) #(1 3)))
+(test #t (vector= eqv? #() #()))
+(test #t (vector= eqv?))
+(test #t (vector= eqv? #(1)))
+
+;;; --- selectors ---
+(test 2 (vector-ref #(1 2 3) 1))
+(test 3 (vector-length #(1 2 3)))
+
+;;; --- iteration: index-passing callbacks (core of #1209) ---
+
+;; vector-map: (f i elt ...) -> vector
+(test #(10 11 12) (vector-map (lambda (i x) (+ i x)) #(10 10 10)))
+(test #(a b c) (vector-map (lambda (i x) x) #(a b c)))
+;; multi-vector
+(test #(0 2 4) (vector-map (lambda (i a b) (+ a b)) #(0 1 2) #(0 1 2)))
+
+;; vector-map!: (f i elt ...) -> void, mutates first vector
+(test #(10 12 14) (let ((v (vector 10 11 12)))
+                    (vector-map! (lambda (i x) (+ x i)) v)
+                    v))
+;; multi-vector map!
+(test #(5 7 9) (let ((v (vector 1 2 3)))
+                 (vector-map! (lambda (i a b) (+ a b)) v #(4 5 6))
+                 v))
+
+;; vector-for-each: (f i elt ...) -> void
+(test '((0 . a) (1 . b))
+      (let ((acc '()))
+        (vector-for-each (lambda (i x) (set! acc (cons (cons i x) acc))) #(a b))
+        (reverse acc)))
+;; multi-vector for-each
+(test '((0 1 4) (1 2 5) (2 3 6))
+      (let ((acc '()))
+        (vector-for-each (lambda (i a b) (set! acc (cons (list i a b) acc)))
+                         #(1 2 3) #(4 5 6))
+        (reverse acc)))
+
+;; vector-fold: (kons i state elt ...) -> value
+(test '(c b a) (vector-fold (lambda (i state x) (cons x state)) '() #(a b c)))
+(test '((2 . c) (1 . b) (0 . a))
+      (vector-fold (lambda (i state x) (cons (cons i x) state)) '() #(a b c)))
+;; multi-vector fold
+(test 9 (vector-fold (lambda (i state a b) (+ state a b)) 0 #(1 1 1) #(2 2 2)))
+
+;; vector-fold-right: (kons i state elt ...) -> value, right to left
+(test '(a b c) (vector-fold-right (lambda (i state x) (cons x state)) '() #(a b c)))
+(test '((0 . a) (1 . b) (2 . c))
+      (vector-fold-right (lambda (i state x) (cons (cons i x) state)) '() #(a b c)))
+
+;; vector-count: (pred? i elt ...) -> integer
+(test 2 (vector-count (lambda (i x) (even? x)) #(1 2 4)))
+(test 0 (vector-count (lambda (i x) (even? x)) #(1 3 5)))
+;; count using index
+(test 3 (vector-count (lambda (i x) (= i x)) #(0 1 2)))
+;; multi-vector count
+(test 2 (vector-count (lambda (i a b) (= a b)) #(1 2 3) #(1 9 3)))
+
+;;; --- searching (element-only callbacks, same as SRFI-133) ---
 (test 1 (vector-index even? #(1 2 3)))
 (test #f (vector-index even? #(1 3 5)))
 (test 2 (vector-index-right even? #(2 1 4 5)))
 (test 1 (vector-skip odd? #(1 2 3)))
+(test 1 (vector-skip-right odd? #(1 2 5)))
 (test #t (vector-any even? #(1 2 3)))
 (test #f (vector-any even? #(1 3 5)))
 (test #t (vector-every odd? #(1 3 5)))
 (test #f (vector-every odd? #(1 2 5)))
+(test 1 (vector-binary-search #(1 3 5 7 9) 3
+          (lambda (x y) (- x y))))
+(test #f (vector-binary-search #(1 3 5 7 9) 4
+           (lambda (x y) (- x y))))
 
-;; vector-map! mutates in place (element-only callback agrees when arity 1
-;; is used with a single vector under SRFI-133 style; SRFI-43 passes the
-;; index — covered by the disabled tests below)
-(test #(2 4 6) (let ((v (vector 1 2 3))) (vector-map! (lambda (x) (* 2 x)) v) v))
+;;; --- mutators ---
+(test #(9 2 1) (let ((v (vector 1 2 9))) (vector-swap! v 0 2) v))
+(test #(7 7 7) (let ((v (vector 1 2 3))) (vector-fill! v 7) v))
+(test #(3 2 1) (let ((v (vector 1 2 3))) (vector-reverse! v) v))
+(test #(1 3 2) (let ((v (vector 1 2 3))) (vector-reverse! v 1) v))
+(test #(5 6 3) (let ((v (vector 1 2 3))) (vector-copy! v 0 #(5 6)) v))
+(test #(1 6 5) (let ((v (vector 1 2 3)))
+                 (vector-reverse-copy! v 1 #(5 6))
+                 v))
 
-;;; --- SRFI-43 index-passing callback convention (spec-quoted in #1209) ---
-;; FAIL: #1209 (SRFI-43 procedures use SRFI-133 semantics — no index arg)
-;; (test #(10 11 12) (vector-map (lambda (i x) (+ i x)) #(10 10 10)))
-;; FAIL: #1209 (SRFI-43 procedures use SRFI-133 semantics — no index arg)
-;; (test '(c b a) (vector-fold (lambda (i state x) (cons x state)) '() #(a b c)))
-;; FAIL: #1209 (SRFI-43 procedures use SRFI-133 semantics — no index arg)
-;; (test '((0 . a) (1 . b))
-;;       (let ((acc '()))
-;;         (vector-for-each (lambda (i x) (set! acc (cons (cons i x) acc))) #(a b))
-;;         (reverse acc)))
-;; FAIL: #1209 (SRFI-43 procedures use SRFI-133 semantics — no index arg)
-;; (test 2 (vector-count (lambda (i x) (even? x)) #(1 2 4)))
-
-;;; --- missing SRFI-43 exports ---
-;; FAIL: #1209 (vector-unfold, vector=, vector-binary-search, vector-reverse!,
-;;              vector-reverse-copy!, reverse-vector->list, reverse-list->vector
-;;              are not exported)
-;; (test #(0 1 2) (vector-unfold (lambda (i) (values i)) 3))
-;; (test #t (vector= eqv? #(1 2) #(1 2)))
-;; (test '(3 2 1) (reverse-vector->list #(1 2 3)))
+;;; --- conversion ---
+(test '(1 2 3) (vector->list #(1 2 3)))
+(test #(1 2 3) (list->vector '(1 2 3)))
+(test '(3 2 1) (reverse-vector->list #(1 2 3)))
+(test '(2 1) (reverse-vector->list #(1 2 3) 0 2))
+(test #(3 2 1) (reverse-list->vector '(1 2 3)))
 
 (test-end "srfi-43")


### PR DESCRIPTION
## Summary

- Rewrite 6 iteration procedures (`vector-map`, `vector-map!`, `vector-for-each`, `vector-count`, `vector-fold`, `vector-fold-right`) with correct SRFI-43 calling convention — callbacks receive the index as the first argument, and multi-vector operation is supported
- Add 8 missing exports re-exported from SRFI-133: `vector-unfold`, `vector-unfold-right`, `vector=`, `vector-binary-search`, `vector-reverse!`, `vector-reverse-copy!`, `reverse-vector->list`, `reverse-list->vector`
- Expand test suite from 22 to 59 tests covering all exported procedures

## Test plan

- [x] All 59 SRFI-43 tests pass
- [x] Full Scheme test suite passes (1806 pass, 0 fail)
- [x] Zig unit tests pass

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)