### PR TITLE
Fix SRFI-233 ini-file->alist missing (scheme char) import (#1223)

### DIFF
--- a/lib/srfi/233.sld
+++ b/lib/srfi/233.sld
@@ -1,5 +1,5 @@
 (define-library (srfi 233)
-  (import (scheme base) (scheme write))
+  (import (scheme base) (scheme char) (scheme write))
   (export ini-file->alist alist->ini-file)
   (begin
     (define (ini-file->alist port)

--- a/tests/scheme/srfi/srfi233.scm
+++ b/tests/scheme/srfi/srfi233.scm
@@ -1,45 +1,47 @@
-;; SRFI-233 (INI files) conformance tests — audit Phase 3e
-;; ini-file->alist fails on any non-empty input (#1223): the library's
-;; string-trim calls char-whitespace? without importing (scheme char).
+;; SRFI-233 (INI files) conformance tests
+;; Regression test for #1223: char-whitespace? was unbound because
+;; (scheme char) was not imported.
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi233.scm
 
-(import (scheme base) (srfi 233) (chibi test))
+(import (scheme base) (srfi 233) (srfi 64))
 
 (test-begin "srfi-233")
 
 (define (parse str)
   (ini-file->alist (open-input-string str)))
 
-;; empty input works (never reaches the broken string-trim)
-(test '() (parse ""))
+;; empty input
+(test-equal "empty input" '() (parse ""))
 
-;;; --- the writer is unaffected ---
+;;; --- the writer ---
 (define (unparse alist)
   (let ((p (open-output-string)))
     (alist->ini-file alist p)
     (get-output-string p)))
 
-(test "[sec]\nk = v\n\n" (unparse '(("sec" ("k" . "v")))))
-(test "" (unparse '()))
+(test-equal "write single section" "[sec]\nk = v\n\n" (unparse '(("sec" ("k" . "v")))))
+(test-equal "write empty" "" (unparse '()))
 
-;;; --- parsing (all blocked on #1223) ---
-;; FAIL: #1223 (ini-file->alist: char-whitespace? unbound — every parse fails)
-;; (let ((r (parse "[server]\nhost=localhost\nport=8080\n")))
-;;   (test 1 (length r))
-;;   (test "server" (car (car r)))
-;;   (let ((entries (cdr (car r))))
-;;     (test "localhost" (cdr (assoc "host" entries)))
-;;     (test "8080" (cdr (assoc "port" entries)))))
-;; FAIL: #1223 (ini-file->alist: char-whitespace? unbound)
-;; (let ((r (parse "[a]\nx=1\n[b]\ny=2\n")))
-;;   (test 2 (length r))
-;;   (test "1" (cdr (assoc "x" (cdr (car r))))))
-;; FAIL: #1223 (ini-file->alist: char-whitespace? unbound)
-;; (let ((r (parse "[s]\n; comment\n\nk=v\n")))
-;;   (test "v" (cdr (assoc "k" (cdr (car r))))))
-;; FAIL: #1223 (round trip blocked on the parser)
-;; (let* ((out (unparse '(("sec" ("k" . "v")))))
-;;        (back (parse out)))
-;;   (test "v" (cdr (assoc "k" (cdr (car back))))))
+;;; --- parsing ---
+(let ((r (parse "[server]\nhost=localhost\nport=8080\n")))
+  (test-equal "single section count" 1 (length r))
+  (test-equal "section name" "server" (car (car r)))
+  (let ((entries (cdr (car r))))
+    (test-equal "host value" "localhost" (cdr (assoc "host" entries)))
+    (test-equal "port value" "8080" (cdr (assoc "port" entries)))))
 
-(test-end "srfi-233")
+(let ((r (parse "[a]\nx=1\n[b]\ny=2\n")))
+  (test-equal "multi-section count" 2 (length r))
+  (test-equal "first section value" "1" (cdr (assoc "x" (cdr (car r))))))
+
+(let ((r (parse "[s]\n; comment\n\nk=v\n")))
+  (test-equal "comments and blanks skipped" "v" (cdr (assoc "k" (cdr (car r))))))
+
+;; round trip
+(let* ((out (unparse '(("sec" ("k" . "v")))))
+       (back (parse out)))
+  (test-equal "round trip" "v" (cdr (assoc "k" (cdr (car back))))))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-233")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- Add missing `(scheme char)` import to `lib/srfi/233.sld` — the library's internal `string-trim` calls `char-whitespace?` which lives in `(scheme char)`, causing every parse of non-empty input to fail with an unbound variable error
- Uncomment and enable all previously disabled parser tests in `tests/scheme/srfi/srfi233.scm`, migrate from `(chibi test)` to `(srfi 64)` with proper exit-on-failure

Closes #1223

## Test plan
- [x] All 11 SRFI-233 tests pass (empty input, writer, single section, multi-section, comments/blanks, round trip)
- [x] Exact reproduction from issue returns expected `(("s" ("k" . "v")))`

🤖 Generated with [Claude Code](https://claude.com/claude-code)