### PR TITLE
Implement complete SRFI-132 sort library (22 procedures)

### DIFF
--- a/lib/srfi/132.sld
+++ b/lib/srfi/132.sld
@@ -192,41 +192,41 @@
 
     (define vector-delete-neighbor-dups
       (case-lambda
-        ((= vec)
-         (%vector-delete-neighbor-dups = vec 0 (vector-length vec)))
-        ((= vec start)
-         (%vector-delete-neighbor-dups = vec start (vector-length vec)))
-        ((= vec start end)
-         (%vector-delete-neighbor-dups = vec start end))))
+        ((elt= vec)
+         (%vector-delete-neighbor-dups elt= vec 0 (vector-length vec)))
+        ((elt= vec start)
+         (%vector-delete-neighbor-dups elt= vec start (vector-length vec)))
+        ((elt= vec start end)
+         (%vector-delete-neighbor-dups elt= vec start end))))
 
-    (define (%vector-delete-neighbor-dups = vec start end)
+    (define (%vector-delete-neighbor-dups elt= vec start end)
       (if (>= start end)
           #()
           (let loop ((i (+ start 1))
                      (acc (list (vector-ref vec start))))
             (cond
              ((= i end) (list->vector (reverse acc)))
-             ((= (car acc) (vector-ref vec i))
+             ((elt= (car acc) (vector-ref vec i))
               (loop (+ i 1) acc))
              (else
               (loop (+ i 1) (cons (vector-ref vec i) acc)))))))
 
     (define vector-delete-neighbor-dups!
       (case-lambda
-        ((= vec)
-         (%vector-delete-neighbor-dups! = vec 0 (vector-length vec)))
-        ((= vec start)
-         (%vector-delete-neighbor-dups! = vec start (vector-length vec)))
-        ((= vec start end)
-         (%vector-delete-neighbor-dups! = vec start end))))
+        ((elt= vec)
+         (%vector-delete-neighbor-dups! elt= vec 0 (vector-length vec)))
+        ((elt= vec start)
+         (%vector-delete-neighbor-dups! elt= vec start (vector-length vec)))
+        ((elt= vec start end)
+         (%vector-delete-neighbor-dups! elt= vec start end))))
 
-    (define (%vector-delete-neighbor-dups! = vec start end)
+    (define (%vector-delete-neighbor-dups! elt= vec start end)
       (if (>= start end)
           start
           (let loop ((i (+ start 1)) (j (+ start 1)))
             (cond
              ((= i end) j)
-             ((= (vector-ref vec (- j 1)) (vector-ref vec i))
+             ((elt= (vector-ref vec (- j 1)) (vector-ref vec i))
               (loop (+ i 1) j))
              (else
               (vector-set! vec j (vector-ref vec i))

--- a/lib/srfi/132.sld
+++ b/lib/srfi/132.sld
@@ -1,8 +1,18 @@
 (define-library (srfi 132)
-  (import (scheme base))
-  (export list-sorted? list-sort list-stable-sort list-sort!
-          vector-sorted? vector-sort vector-stable-sort vector-sort!)
+  (import (scheme base) (scheme case-lambda))
+  (export list-sorted? list-sort list-stable-sort list-sort! list-stable-sort!
+          list-merge list-merge!
+          vector-sorted? vector-sort vector-stable-sort vector-sort!
+          vector-stable-sort!
+          vector-merge vector-merge!
+          list-delete-neighbor-dups list-delete-neighbor-dups!
+          vector-delete-neighbor-dups vector-delete-neighbor-dups!
+          vector-find-median vector-find-median!
+          vector-select! vector-separate!)
   (begin
+
+    ;; --- List helpers ---
+
     (define (list-sorted? less? lst)
       (or (null? lst) (null? (cdr lst))
           (and (not (less? (cadr lst) (car lst)))
@@ -11,8 +21,10 @@
     (define (%merge less? a b)
       (cond ((null? a) b)
             ((null? b) a)
-            ((less? (car b) (car a)) (cons (car b) (%merge less? a (cdr b))))
-            (else (cons (car a) (%merge less? (cdr a) b)))))
+            ((less? (car b) (car a))
+             (cons (car b) (%merge less? a (cdr b))))
+            (else
+             (cons (car a) (%merge less? (cdr a) b)))))
 
     (define (%merge-sort less? lst)
       (if (or (null? lst) (null? (cdr lst))) lst
@@ -25,24 +37,258 @@
             (values (reverse acc) slow)
             (loop (cdr slow) (cddr fast) (cons (car slow) acc)))))
 
+    ;; --- Vector helpers ---
+
+    (define (%vector-sorted? less? vec start end)
+      (or (<= (- end start) 1)
+          (let loop ((i (+ start 1)))
+            (or (= i end)
+                (and (not (less? (vector-ref vec i)
+                                 (vector-ref vec (- i 1))))
+                     (loop (+ i 1)))))))
+
+    (define (%vector-sort-range less? vec start end)
+      (let ((len (- end start)))
+        (if (= len 0)
+            #()
+            (list->vector
+             (%merge-sort less? (vector->list (vector-copy vec start end)))))))
+
+    (define (%vector-sort-range! less? vec start end)
+      (when (> (- end start) 1)
+        (let ((sorted (%vector-sort-range less? vec start end)))
+          (vector-copy! vec start sorted))))
+
+    (define (%vector-merge-ranges less? v1 s1 e1 v2 s2 e2)
+      (let* ((len1 (- e1 s1))
+             (len2 (- e2 s2))
+             (result (make-vector (+ len1 len2))))
+        (let loop ((i1 s1) (i2 s2) (j 0))
+          (cond
+           ((= i1 e1)
+            (vector-copy! result j v2 i2 e2)
+            result)
+           ((= i2 e2)
+            (vector-copy! result j v1 i1 e1)
+            result)
+           ((less? (vector-ref v2 i2) (vector-ref v1 i1))
+            (vector-set! result j (vector-ref v2 i2))
+            (loop i1 (+ i2 1) (+ j 1)))
+           (else
+            (vector-set! result j (vector-ref v1 i1))
+            (loop (+ i1 1) i2 (+ j 1)))))))
+
+    (define (%vector-merge-ranges! less? to at v1 s1 e1 v2 s2 e2)
+      (let loop ((i1 s1) (i2 s2) (j at))
+        (cond
+         ((= i1 e1)
+          (vector-copy! to j v2 i2 e2))
+         ((= i2 e2)
+          (vector-copy! to j v1 i1 e1))
+         ((less? (vector-ref v2 i2) (vector-ref v1 i1))
+          (vector-set! to j (vector-ref v2 i2))
+          (loop i1 (+ i2 1) (+ j 1)))
+         (else
+          (vector-set! to j (vector-ref v1 i1))
+          (loop (+ i1 1) i2 (+ j 1))))))
+
+    ;; --- List sort procedures ---
+
     (define (list-sort less? lst) (%merge-sort less? lst))
     (define (list-stable-sort less? lst) (%merge-sort less? lst))
     (define (list-sort! less? lst) (%merge-sort less? lst))
+    (define list-stable-sort! list-sort!)
 
-    (define (vector-sorted? less? vec)
-      (let ((len (vector-length vec)))
-        (or (<= len 1)
-            (let loop ((i 1))
-              (or (= i len)
-                  (and (not (less? (vector-ref vec i) (vector-ref vec (- i 1))))
-                       (loop (+ i 1))))))))
+    ;; --- List merge procedures ---
 
-    (define (vector-sort less? vec)
-      (list->vector (list-sort less? (vector->list vec))))
-    (define (vector-stable-sort less? vec) (vector-sort less? vec))
-    (define (vector-sort! less? vec)
-      (let ((sorted (vector-sort less? vec)))
-        (let loop ((i 0))
-          (if (< i (vector-length vec))
-              (begin (vector-set! vec i (vector-ref sorted i))
-                     (loop (+ i 1)))))))))
+    (define (list-merge less? lis1 lis2) (%merge less? lis1 lis2))
+    (define (list-merge! less? lis1 lis2) (%merge less? lis1 lis2))
+
+    ;; --- List delete-neighbor-dups ---
+
+    (define (list-delete-neighbor-dups = lis)
+      (if (null? lis)
+          '()
+          (let loop ((prev (car lis)) (rest (cdr lis)) (acc (list (car lis))))
+            (cond
+             ((null? rest) (reverse acc))
+             ((= prev (car rest)) (loop prev (cdr rest) acc))
+             (else (loop (car rest) (cdr rest) (cons (car rest) acc)))))))
+
+    (define list-delete-neighbor-dups! list-delete-neighbor-dups)
+
+    ;; --- Vector sorted? ---
+
+    (define vector-sorted?
+      (case-lambda
+        ((less? vec) (%vector-sorted? less? vec 0 (vector-length vec)))
+        ((less? vec start) (%vector-sorted? less? vec start (vector-length vec)))
+        ((less? vec start end) (%vector-sorted? less? vec start end))))
+
+    ;; --- Vector sort procedures ---
+
+    (define vector-sort
+      (case-lambda
+        ((less? vec)
+         (%vector-sort-range less? vec 0 (vector-length vec)))
+        ((less? vec start)
+         (%vector-sort-range less? vec start (vector-length vec)))
+        ((less? vec start end)
+         (%vector-sort-range less? vec start end))))
+
+    (define vector-stable-sort vector-sort)
+
+    (define vector-sort!
+      (case-lambda
+        ((less? vec)
+         (%vector-sort-range! less? vec 0 (vector-length vec)))
+        ((less? vec start)
+         (%vector-sort-range! less? vec start (vector-length vec)))
+        ((less? vec start end)
+         (%vector-sort-range! less? vec start end))))
+
+    (define vector-stable-sort! vector-sort!)
+
+    ;; --- Vector merge procedures ---
+
+    (define vector-merge
+      (case-lambda
+        ((less? v1 v2)
+         (%vector-merge-ranges less? v1 0 (vector-length v1)
+                               v2 0 (vector-length v2)))
+        ((less? v1 v2 s1)
+         (%vector-merge-ranges less? v1 s1 (vector-length v1)
+                               v2 0 (vector-length v2)))
+        ((less? v1 v2 s1 e1)
+         (%vector-merge-ranges less? v1 s1 e1
+                               v2 0 (vector-length v2)))
+        ((less? v1 v2 s1 e1 s2)
+         (%vector-merge-ranges less? v1 s1 e1
+                               v2 s2 (vector-length v2)))
+        ((less? v1 v2 s1 e1 s2 e2)
+         (%vector-merge-ranges less? v1 s1 e1 v2 s2 e2))))
+
+    (define vector-merge!
+      (case-lambda
+        ((less? to v1 v2)
+         (%vector-merge-ranges! less? to 0 v1 0 (vector-length v1)
+                                v2 0 (vector-length v2)))
+        ((less? to v1 v2 start)
+         (%vector-merge-ranges! less? to start v1 0 (vector-length v1)
+                                v2 0 (vector-length v2)))
+        ((less? to v1 v2 start s1)
+         (%vector-merge-ranges! less? to start v1 s1 (vector-length v1)
+                                v2 0 (vector-length v2)))
+        ((less? to v1 v2 start s1 e1)
+         (%vector-merge-ranges! less? to start v1 s1 e1
+                                v2 0 (vector-length v2)))
+        ((less? to v1 v2 start s1 e1 s2)
+         (%vector-merge-ranges! less? to start v1 s1 e1
+                                v2 s2 (vector-length v2)))
+        ((less? to v1 v2 start s1 e1 s2 e2)
+         (%vector-merge-ranges! less? to start v1 s1 e1 v2 s2 e2))))
+
+    ;; --- Vector delete-neighbor-dups ---
+
+    (define vector-delete-neighbor-dups
+      (case-lambda
+        ((= vec)
+         (%vector-delete-neighbor-dups = vec 0 (vector-length vec)))
+        ((= vec start)
+         (%vector-delete-neighbor-dups = vec start (vector-length vec)))
+        ((= vec start end)
+         (%vector-delete-neighbor-dups = vec start end))))
+
+    (define (%vector-delete-neighbor-dups = vec start end)
+      (if (>= start end)
+          #()
+          (let loop ((i (+ start 1))
+                     (acc (list (vector-ref vec start))))
+            (cond
+             ((= i end) (list->vector (reverse acc)))
+             ((= (car acc) (vector-ref vec i))
+              (loop (+ i 1) acc))
+             (else
+              (loop (+ i 1) (cons (vector-ref vec i) acc)))))))
+
+    (define vector-delete-neighbor-dups!
+      (case-lambda
+        ((= vec)
+         (%vector-delete-neighbor-dups! = vec 0 (vector-length vec)))
+        ((= vec start)
+         (%vector-delete-neighbor-dups! = vec start (vector-length vec)))
+        ((= vec start end)
+         (%vector-delete-neighbor-dups! = vec start end))))
+
+    (define (%vector-delete-neighbor-dups! = vec start end)
+      (if (>= start end)
+          start
+          (let loop ((i (+ start 1)) (j (+ start 1)))
+            (cond
+             ((= i end) j)
+             ((= (vector-ref vec (- j 1)) (vector-ref vec i))
+              (loop (+ i 1) j))
+             (else
+              (vector-set! vec j (vector-ref vec i))
+              (loop (+ i 1) (+ j 1)))))))
+
+    ;; --- Vector find-median ---
+
+    (define vector-find-median
+      (case-lambda
+        ((less? v knil)
+         (%vector-find-median less? v knil (lambda (a b) (/ (+ a b) 2))))
+        ((less? v knil mean)
+         (%vector-find-median less? v knil mean))))
+
+    (define (%vector-find-median less? v knil mean)
+      (let ((n (vector-length v)))
+        (cond
+         ((= n 0) knil)
+         (else
+          (let ((sorted (vector-sort less? v)))
+            (if (odd? n)
+                (vector-ref sorted (quotient n 2))
+                (mean (vector-ref sorted (- (quotient n 2) 1))
+                      (vector-ref sorted (quotient n 2)))))))))
+
+    (define vector-find-median!
+      (case-lambda
+        ((less? v knil)
+         (%vector-find-median! less? v knil (lambda (a b) (/ (+ a b) 2))))
+        ((less? v knil mean)
+         (%vector-find-median! less? v knil mean))))
+
+    (define (%vector-find-median! less? v knil mean)
+      (let ((n (vector-length v)))
+        (cond
+         ((= n 0) knil)
+         (else
+          (vector-sort! less? v)
+          (if (odd? n)
+              (vector-ref v (quotient n 2))
+              (mean (vector-ref v (- (quotient n 2) 1))
+                    (vector-ref v (quotient n 2))))))))
+
+    ;; --- Vector select! and separate! ---
+
+    (define vector-select!
+      (case-lambda
+        ((less? v k)
+         (%vector-sort-range! less? v 0 (vector-length v))
+         (vector-ref v k))
+        ((less? v k start)
+         (%vector-sort-range! less? v start (vector-length v))
+         (vector-ref v (+ start k)))
+        ((less? v k start end)
+         (%vector-sort-range! less? v start end)
+         (vector-ref v (+ start k)))))
+
+    (define vector-separate!
+      (case-lambda
+        ((less? v k)
+         (%vector-sort-range! less? v 0 (vector-length v)))
+        ((less? v k start)
+         (%vector-sort-range! less? v start (vector-length v)))
+        ((less? v k start end)
+         (%vector-sort-range! less? v start end))))))

--- a/tests/scheme/srfi/srfi132.scm
+++ b/tests/scheme/srfi/srfi132.scm
@@ -139,6 +139,10 @@
 (test-equal "vector-delete-neighbor-dups: subrange"
   #(1 2 3) (vector-delete-neighbor-dups = #(0 1 1 2 2 3 3 9) 1 7))
 
+;; non-numeric predicate (regression: = parameter must not shadow numeric =)
+(test-equal "vector-delete-neighbor-dups: char=?"
+  #(#\a #\b #\c) (vector-delete-neighbor-dups char=? #(#\a #\a #\b #\b #\c)))
+
 ;;; --- vector-delete-neighbor-dups! (returns end index) ---
 (let ((v (vector 1 1 2 2 3 3)))
   (test-equal "vector-delete-neighbor-dups!: returns end index"
@@ -156,6 +160,11 @@
 
 (test-equal "vector-delete-neighbor-dups!: empty range"
   3 (vector-delete-neighbor-dups! = #(1 2 3) 3 3))
+
+;; non-numeric predicate (regression: elt= parameter must not shadow numeric =)
+(let ((v (vector #\a #\a #\b #\c #\c)))
+  (test-equal "vector-delete-neighbor-dups!: char=?"
+    3 (vector-delete-neighbor-dups! char=? v)))
 
 ;;; --- vector-find-median / vector-find-median! ---
 (test-equal "vector-find-median: odd count"
@@ -188,10 +197,11 @@
 ;;; --- vector-separate! ---
 (let ((v (vector 5 3 1 4 2)))
   (vector-separate! < v 2)
-  (test-equal "vector-separate!: smallest 2 in first positions"
-    1 (vector-ref v 0))
-  (test-equal "vector-separate!: smallest 2 in first positions (2)"
-    2 (vector-ref v 1)))
+  (let ((first-two (list (vector-ref v 0) (vector-ref v 1))))
+    (test-assert "vector-separate!: 1 in first 2 positions"
+      (member 1 first-two))
+    (test-assert "vector-separate!: 2 in first 2 positions"
+      (member 2 first-two))))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-132")

--- a/tests/scheme/srfi/srfi132.scm
+++ b/tests/scheme/srfi/srfi132.scm
@@ -1,64 +1,198 @@
-;; SRFI-132 (sort libraries) conformance tests — audit Phase 3.4
-;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi132.scm
+;; SRFI-132 (sort libraries) conformance tests
+;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi132.scm
 
-(import (scheme base) (srfi 132) (chibi test))
+(import (scheme base) (srfi 132) (srfi 64))
 
 (test-begin "srfi-132")
 
-;;; --- list-sorted? / vector-sorted? ---
-(test #t (list-sorted? < '()))
-(test #t (list-sorted? < '(1)))
-(test #t (list-sorted? < '(1 2 2 3)))
-(test #f (list-sorted? < '(1 3 2)))
-(test #t (vector-sorted? < #()))
-(test #t (vector-sorted? < #(1 2 2 3)))
-(test #f (vector-sorted? < #(2 1)))
+;;; --- list-sorted? ---
+(test-equal "list-sorted?: empty" #t (list-sorted? < '()))
+(test-equal "list-sorted?: singleton" #t (list-sorted? < '(1)))
+(test-equal "list-sorted?: sorted with dups" #t (list-sorted? < '(1 2 2 3)))
+(test-equal "list-sorted?: unsorted" #f (list-sorted? < '(1 3 2)))
 
-;;; --- list-sort / list-stable-sort / list-sort! ---
-(test '() (list-sort < '()))
-(test '(1) (list-sort < '(1)))
-(test '(1 1 3 4 5 9) (list-sort < '(3 1 4 1 5 9)))
-(test '(9 5 4 3 1 1) (list-sort > '(3 1 4 1 5 9)))
-(test '(1 2 3) (list-sort < '(1 2 3)))
-(test '(1 1 3 4 5 9) (list-sort! < (list 3 1 4 1 5 9)))
+;;; --- vector-sorted? (with optional start/end) ---
+(test-equal "vector-sorted?: empty" #t (vector-sorted? < #()))
+(test-equal "vector-sorted?: sorted" #t (vector-sorted? < #(1 2 2 3)))
+(test-equal "vector-sorted?: unsorted" #f (vector-sorted? < #(2 1)))
+(test-equal "vector-sorted?: subrange sorted"
+  #t (vector-sorted? < #(9 1 2 3 0) 1 4))
+(test-equal "vector-sorted?: subrange unsorted"
+  #f (vector-sorted? < #(1 2 3 0 5) 2 5))
+(test-equal "vector-sorted?: start only"
+  #t (vector-sorted? < #(9 1 2 3) 1))
 
-;; input list is not required to survive list-sort (non-destructive here),
-;; but list-sort must not share structure changes with the input for the
-;; plain variant
+;;; --- list-sort / list-stable-sort / list-sort! / list-stable-sort! ---
+(test-equal "list-sort: empty" '() (list-sort < '()))
+(test-equal "list-sort: singleton" '(1) (list-sort < '(1)))
+(test-equal "list-sort: multiple" '(1 1 3 4 5 9) (list-sort < '(3 1 4 1 5 9)))
+(test-equal "list-sort: reverse" '(9 5 4 3 1 1) (list-sort > '(3 1 4 1 5 9)))
+(test-equal "list-sort: already sorted" '(1 2 3) (list-sort < '(1 2 3)))
+(test-equal "list-sort!: basic" '(1 1 3 4 5 9) (list-sort! < (list 3 1 4 1 5 9)))
+(test-equal "list-stable-sort!: basic"
+  '(1 2 3) (list-stable-sort! < (list 3 1 2)))
+
+;; non-destructive: input unchanged
 (define src '(3 1 2))
-(test '(1 2 3) (list-sort < src))
-(test '(3 1 2) src)
+(test-equal "list-sort: non-destructive result" '(1 2 3) (list-sort < src))
+(test-equal "list-sort: non-destructive input" '(3 1 2) src)
 
-;; stability: equal keys keep their original relative order
+;; stability: equal keys keep original relative order
 (define recs '((2 . a) (1 . b) (2 . c) (1 . d)))
-(test '((1 . b) (1 . d) (2 . a) (2 . c))
-      (list-stable-sort (lambda (x y) (< (car x) (car y))) recs))
+(test-equal "list-stable-sort: stability"
+  '((1 . b) (1 . d) (2 . a) (2 . c))
+  (list-stable-sort (lambda (x y) (< (car x) (car y))) recs))
 
-;;; --- vector-sort / vector-stable-sort / vector-sort! ---
-(test #(1 1 3 4 5 9) (vector-sort < #(3 1 4 1 5 9)))
+;;; --- vector-sort / vector-stable-sort / vector-sort! / vector-stable-sort! ---
+(test-equal "vector-sort: basic" #(1 1 3 4 5 9) (vector-sort < #(3 1 4 1 5 9)))
+(test-equal "vector-sort: empty" #() (vector-sort < #()))
+
 (define vsrc (vector 3 1 2))
-(test #(1 2 3) (vector-sort < vsrc))
-(test #(3 1 2) vsrc)                       ; input untouched
+(test-equal "vector-sort: non-destructive result" #(1 2 3) (vector-sort < vsrc))
+(test-equal "vector-sort: non-destructive input" #(3 1 2) vsrc)
+
 (vector-sort! < vsrc)
-(test #(1 2 3) vsrc)                       ; in-place variant mutates
+(test-equal "vector-sort!: mutates" #(1 2 3) vsrc)
 
-(test #((1 . b) (1 . d) (2 . a) (2 . c))
-      (vector-stable-sort (lambda (x y) (< (car x) (car y)))
-                          (vector '(2 . a) '(1 . b) '(2 . c) '(1 . d))))
+;; start/end parameters
+(test-equal "vector-sort: start/end"
+  #(2 3 4) (vector-sort < #(9 4 3 2 9) 1 4))
+(test-equal "vector-sort: start only"
+  #(2 3 9) (vector-sort < #(5 9 3 2) 1))
 
-;; SRFI-132: vector procedures accept optional start/end
-;; FAIL: #1231 (vector-sort and friends lack start/end parameters)
-;; (test #(2 3 4) (vector-sort < #(9 4 3 2 9) 1 4))
-;; FAIL: #1231 (vector-sorted? lacks start/end parameters)
-;; (test #t (vector-sorted? < #(9 1 2 3 0) 1 4))
+(let ((v (vector 5 3 1 4 2)))
+  (vector-sort! < v 1 4)
+  (test-equal "vector-sort!: subrange" #(5 1 3 4 2) v))
 
-;;; --- missing exports ---
-;; FAIL: #1231 (list-merge, list-merge!, vector-merge, vector-merge!,
-;;   list-delete-neighbor-dups (+!), vector-delete-neighbor-dups (+!),
-;;   vector-find-median (+!), vector-select!, vector-separate!,
-;;   list-stable-sort!, vector-stable-sort! not exported)
-;; (test '(1 2 3 4 5 6) (list-merge < '(1 3 5) '(2 4 6)))
-;; (test '(1 2 3) (list-delete-neighbor-dups = '(1 1 2 2 3)))
-;; (test 3 (vector-find-median < #(5 1 3 4 2) 'unused))
+;; stability
+(test-equal "vector-stable-sort: stability"
+  #((1 . b) (1 . d) (2 . a) (2 . c))
+  (vector-stable-sort (lambda (x y) (< (car x) (car y)))
+                      (vector '(2 . a) '(1 . b) '(2 . c) '(1 . d))))
 
-(test-end "srfi-132")
+(let ((v (vector 5 3 1 4 2)))
+  (vector-stable-sort! < v)
+  (test-equal "vector-stable-sort!: mutates" #(1 2 3 4 5) v))
+
+;;; --- list-merge / list-merge! ---
+(test-equal "list-merge: basic"
+  '(1 2 3 4 5 6) (list-merge < '(1 3 5) '(2 4 6)))
+(test-equal "list-merge: empty first"
+  '(1 2 3) (list-merge < '() '(1 2 3)))
+(test-equal "list-merge: empty second"
+  '(1 2 3) (list-merge < '(1 2 3) '()))
+(test-equal "list-merge: both empty"
+  '() (list-merge < '() '()))
+(test-equal "list-merge: duplicates"
+  '(1 1 2 2 3 3) (list-merge < '(1 2 3) '(1 2 3)))
+(test-equal "list-merge!: basic"
+  '(1 2 3 4 5 6) (list-merge! < '(1 3 5) '(2 4 6)))
+
+;; stability: on ties, first list's element comes first
+(test-equal "list-merge: stability"
+  '((1 . a) (1 . b) (2 . a) (2 . b))
+  (list-merge (lambda (x y) (< (car x) (car y)))
+              '((1 . a) (2 . a))
+              '((1 . b) (2 . b))))
+
+;;; --- vector-merge / vector-merge! ---
+(test-equal "vector-merge: basic"
+  #(1 2 3 4 5 6) (vector-merge < #(1 3 5) #(2 4 6)))
+(test-equal "vector-merge: empty inputs"
+  #() (vector-merge < #() #()))
+(test-equal "vector-merge: one empty"
+  #(1 2 3) (vector-merge < #(1 2 3) #()))
+(test-equal "vector-merge: with subranges"
+  #(2 3 4 5) (vector-merge < #(9 2 4 8) #(0 3 5 7) 1 3 1 3))
+
+(let ((target (make-vector 6 0)))
+  (vector-merge! < target #(1 3 5) #(2 4 6))
+  (test-equal "vector-merge!: basic" #(1 2 3 4 5 6) target))
+
+(let ((target (make-vector 8 0)))
+  (vector-merge! < target #(1 3 5) #(2 4 6) 1)
+  (test-equal "vector-merge!: with start offset" #(0 1 2 3 4 5 6 0) target))
+
+;;; --- list-delete-neighbor-dups ---
+(test-equal "list-delete-neighbor-dups: basic"
+  '(1 2 3) (list-delete-neighbor-dups = '(1 1 2 2 3)))
+(test-equal "list-delete-neighbor-dups: no dups"
+  '(1 2 7 0 -2) (list-delete-neighbor-dups = '(1 2 7 0 -2)))
+(test-equal "list-delete-neighbor-dups: all same"
+  '(5) (list-delete-neighbor-dups = '(5 5 5 5)))
+(test-equal "list-delete-neighbor-dups: empty"
+  '() (list-delete-neighbor-dups = '()))
+(test-equal "list-delete-neighbor-dups: singleton"
+  '(1) (list-delete-neighbor-dups = '(1)))
+(test-equal "list-delete-neighbor-dups: unsorted with neighbors"
+  '(1 2 7 0 -2) (list-delete-neighbor-dups = '(1 1 2 7 7 7 0 -2 -2)))
+(test-equal "list-delete-neighbor-dups!: basic"
+  '(1 2 3) (list-delete-neighbor-dups! = '(1 1 2 2 3)))
+
+;;; --- vector-delete-neighbor-dups ---
+(test-equal "vector-delete-neighbor-dups: basic"
+  #(1 2 7 0 -2) (vector-delete-neighbor-dups = #(1 1 2 7 7 7 0 -2 -2)))
+(test-equal "vector-delete-neighbor-dups: empty"
+  #() (vector-delete-neighbor-dups = #()))
+(test-equal "vector-delete-neighbor-dups: no dups"
+  #(1 2 3) (vector-delete-neighbor-dups = #(1 2 3)))
+(test-equal "vector-delete-neighbor-dups: subrange"
+  #(1 2 3) (vector-delete-neighbor-dups = #(0 1 1 2 2 3 3 9) 1 7))
+
+;;; --- vector-delete-neighbor-dups! (returns end index) ---
+(let ((v (vector 1 1 2 2 3 3)))
+  (test-equal "vector-delete-neighbor-dups!: returns end index"
+    3 (vector-delete-neighbor-dups! = v))
+  (test-equal "vector-delete-neighbor-dups!: packed elements"
+    1 (vector-ref v 0))
+  (test-equal "vector-delete-neighbor-dups!: packed elements 2"
+    2 (vector-ref v 1))
+  (test-equal "vector-delete-neighbor-dups!: packed elements 3"
+    3 (vector-ref v 2)))
+
+(let ((v (vector 0 0 0 1 1 2 2 3 3 4 4 5 5 6 6)))
+  (test-equal "vector-delete-neighbor-dups!: with start"
+    9 (vector-delete-neighbor-dups! = v 3)))
+
+(test-equal "vector-delete-neighbor-dups!: empty range"
+  3 (vector-delete-neighbor-dups! = #(1 2 3) 3 3))
+
+;;; --- vector-find-median / vector-find-median! ---
+(test-equal "vector-find-median: odd count"
+  3 (vector-find-median < #(5 1 3 4 2) 'empty))
+(test-equal "vector-find-median: empty"
+  'empty (vector-find-median < #() 'empty))
+(test-equal "vector-find-median: singleton"
+  42 (vector-find-median < #(42) 'empty))
+(test-equal "vector-find-median: even count default mean"
+  5/2 (vector-find-median < #(1 2 3 4) 'empty))
+(test-equal "vector-find-median: custom mean"
+  3 (vector-find-median < #(1 2 3 4) 'empty max))
+
+(let ((v (vector 5 1 3 4 2)))
+  (test-equal "vector-find-median!: odd count"
+    3 (vector-find-median! < v 'empty))
+  (test-equal "vector-find-median!: sorts in place"
+    #(1 2 3 4 5) v))
+
+;;; --- vector-select! ---
+(test-equal "vector-select!: minimum"
+  1 (vector-select! < (vector 5 3 1 4 2) 0))
+(test-equal "vector-select!: median"
+  3 (vector-select! < (vector 5 3 1 4 2) 2))
+(test-equal "vector-select!: maximum"
+  5 (vector-select! < (vector 5 3 1 4 2) 4))
+(test-equal "vector-select!: subrange"
+  2 (vector-select! < (vector 9 5 3 1 4 2 8) 1 1 6))
+
+;;; --- vector-separate! ---
+(let ((v (vector 5 3 1 4 2)))
+  (vector-separate! < v 2)
+  (test-equal "vector-separate!: smallest 2 in first positions"
+    1 (vector-ref v 0))
+  (test-equal "vector-separate!: smallest 2 in first positions (2)"
+    2 (vector-ref v 1)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-132")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Closes #1231

- Implement all 14 missing SRFI-132 procedures: `list-stable-sort!`, `vector-stable-sort!`, `list-merge`, `list-merge!`, `vector-merge`, `vector-merge!`, `list-delete-neighbor-dups`, `list-delete-neighbor-dups!`, `vector-delete-neighbor-dups`, `vector-delete-neighbor-dups!`, `vector-find-median`, `vector-find-median!`, `vector-select!`, `vector-separate!`
- Retrofit existing vector procedures (`vector-sorted?`, `vector-sort`, `vector-stable-sort`, `vector-sort!`) with optional `start`/`end` range parameters via `case-lambda`
- Expand test suite from ~20 to 73 tests covering all 22 procedures including subranges, stability, edge cases, and `vector-delete-neighbor-dups!` integer return type

## Test plan

- [x] All 73 SRFI-132 tests pass
- [x] Full test suite passes (1806 pass, 0 fail)
- [x] Zig unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)