### PR TITLE
Fix SRFI-134 ideque-filter calling unbound 'filter' (#1212)

### DIFF
--- a/lib/srfi/134.sld
+++ b/lib/srfi/134.sld
@@ -83,8 +83,13 @@
       (if (null? lst) seed
           (fold-left f (f seed (car lst)) (cdr lst))))
 
+    (define (filter-list pred lst)
+      (cond ((null? lst) '())
+            ((pred (car lst)) (cons (car lst) (filter-list pred (cdr lst))))
+            (else (filter-list pred (cdr lst)))))
+
     (define (ideque-filter pred dq)
-      (list->ideque (filter pred (ideque->list dq))))
+      (list->ideque (filter-list pred (ideque->list dq))))
 
     (define (ideque-append . dqs)
       (list->ideque (apply append (map ideque->list dqs))))

--- a/tests/scheme/srfi/srfi134.scm
+++ b/tests/scheme/srfi/srfi134.scm
@@ -47,8 +47,7 @@
 ;;; --- higher-order operations ---
 (test '(2 4 6) (ideque->list (ideque-map (lambda (x) (* 2 x)) (ideque 1 2 3))))
 (test 6 (ideque-fold + 0 (ideque 1 2 3)))
-;; FAIL: #1212 (ideque-filter calls unbound 'filter' inside the library)
-;; (test '(2) (ideque->list (ideque-filter even? (ideque 1 2 3))))
+(test '(2) (ideque->list (ideque-filter even? (ideque 1 2 3))))
 (test '(1 2 3 4) (ideque->list (ideque-append (ideque 1 2) (ideque 3 4))))
 (test '(1 2 3)
       (let ((acc '()))


### PR DESCRIPTION
## Summary

- `ideque-filter` called `filter` which isn't in `(scheme base)` — every call failed with "undefined variable"
- Added a local `filter-list` helper (consistent with the existing local `fold-left` in the same file)
- Re-enabled the previously disabled test case

Closes #1212

## Test plan

- [x] `ideque-filter` returns `(2)` for `(ideque-filter even? (ideque 1 2 3))`
- [x] Full SRFI-134 test suite passes (28/28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)