### PR TITLE
Fix SRFI-78 check-passed?, add check-set-mode! and check-ec

### DIFF
--- a/lib/srfi/78.sld
+++ b/lib/srfi/78.sld
@@ -1,5 +1,5 @@
 (define-library (srfi 78)
-  (import (scheme base) (scheme write) (srfi 42))
+  (import (scheme base) (scheme write) (scheme process-context) (srfi 42))
   (export check check-ec check-report check-set-mode!
           check-reset! check-passed?
           check-failed?)
@@ -21,6 +21,8 @@
     (define (check-failed?) %fail)
 
     (define (check-set-mode! mode)
+      (unless (memq mode '(off summary report-failed report))
+        (error "check-set-mode!: invalid mode" mode))
       (set! %mode mode))
 
     (define (%report-pass name actual)
@@ -71,31 +73,51 @@
 
     (define-syntax check-ec
       (syntax-rules (=>)
+        ((_ expr => expected)
+         (check expr => expected))
+        ((_ expr (=> equal) expected)
+         (check expr (=> equal) expected))
         ((_ qualifier expr => expected)
-         (check-ec-proc 'expr
-           (lambda ()
-             (let ((ok #t))
-               (do-ec qualifier
-                 (let ((actual expr)
-                       (exp expected))
-                   (when (not (equal? actual exp))
-                     (set! ok (list actual exp))))) ok))
+         (check-ec-run 'expr
+           (lambda (escape)
+             (do-ec qualifier
+               (let ((actual expr) (exp expected))
+                 (when (not (equal? actual exp))
+                   (escape (list actual exp))))))
            equal?))
         ((_ qualifier expr (=> equal) expected)
-         (check-ec-proc 'expr
-           (lambda ()
-             (let ((ok #t)
-                   (eq-fn equal))
+         (check-ec-run 'expr
+           (lambda (escape)
+             (let ((eq-fn equal))
                (do-ec qualifier
-                 (let ((actual expr)
-                       (exp expected))
+                 (let ((actual expr) (exp expected))
                    (when (not (eq-fn actual exp))
-                     (set! ok (list actual exp))))) ok))
+                     (escape (list actual exp)))))))
+           equal))
+        ((_ qualifier expr => expected (arg ...))
+         (check-ec-run 'expr
+           (lambda (escape)
+             (do-ec qualifier
+               (let ((actual expr) (exp expected))
+                 (when (not (equal? actual exp))
+                   (escape (list actual exp))))))
+           equal?))
+        ((_ qualifier expr (=> equal) expected (arg ...))
+         (check-ec-run 'expr
+           (lambda (escape)
+             (let ((eq-fn equal))
+               (do-ec qualifier
+                 (let ((actual expr) (exp expected))
+                   (when (not (eq-fn actual exp))
+                     (escape (list actual exp)))))))
            equal))))
 
-    (define (check-ec-proc name thunk equal)
+    (define (check-ec-run name body-fn equal)
       (unless (eq? %mode 'off)
-        (let ((result (thunk)))
+        (let ((result (call-with-current-continuation
+                        (lambda (escape)
+                          (body-fn escape)
+                          #t))))
           (if (eq? result #t)
               (begin
                 (set! %pass (+ %pass 1))
@@ -112,4 +134,12 @@
       (display %pass) (display " passed, ")
       (display %fail) (display " failed.")
       (newline)
+      (when %first-fail
+        (display "First failure: ")
+        (write (car %first-fail))
+        (display " => ")
+        (write (cadr %first-fail))
+        (display " ; expected: ")
+        (write (caddr %first-fail))
+        (newline))
       (when (> %fail 0) (exit 1)))))

--- a/lib/srfi/78.sld
+++ b/lib/srfi/78.sld
@@ -1,18 +1,44 @@
 (define-library (srfi 78)
-  (import (scheme base) (scheme write))
-  (export check check-report check-reset!
-          check-passed? check-failed?)
+  (import (scheme base) (scheme write) (srfi 42))
+  (export check check-ec check-report check-set-mode!
+          check-reset! check-passed?
+          check-failed?)
   (begin
 
     (define %pass 0)
     (define %fail 0)
+    (define %mode 'report)
+    (define %first-fail #f)
 
     (define (check-reset!)
       (set! %pass 0)
-      (set! %fail 0))
+      (set! %fail 0)
+      (set! %first-fail #f))
 
-    (define (check-passed?) %pass)
+    (define (check-passed? expected-count)
+      (and (= %fail 0) (= %pass expected-count)))
+
     (define (check-failed?) %fail)
+
+    (define (check-set-mode! mode)
+      (set! %mode mode))
+
+    (define (%report-pass name actual)
+      (when (eq? %mode 'report)
+        (display "(") (display %pass) (display ") ")
+        (write name) (display " => ")
+        (write actual) (display " ; correct")
+        (newline)))
+
+    (define (%report-fail name actual expected)
+      (when (or (eq? %mode 'report) (eq? %mode 'report-failed))
+        (display "(") (display (+ %pass %fail)) (display ") ")
+        (write name) (display " => ")
+        (write actual) (display " ; *** WRONG ***")
+        (display " expected: ") (write expected)
+        (newline))
+      (when (not %first-fail)
+        (set! %first-fail (list name actual expected))))
 
     (define-syntax check
       (syntax-rules (=>)
@@ -22,38 +48,61 @@
          (check-proc-equal 'expr (lambda () expr) expected equal))))
 
     (define (check-proc name thunk expected)
-      (let ((actual (thunk)))
-        (if (equal? actual expected)
-            (begin
-              (set! %pass (+ %pass 1))
-              (display "(") (display %pass) (display ") ")
-              (write name) (display " => ")
-              (write actual) (display " ; correct")
-              (newline))
-            (begin
-              (set! %fail (+ %fail 1))
-              (display "(") (display (+ %pass %fail)) (display ") ")
-              (write name) (display " => ")
-              (write actual) (display " ; *** WRONG ***")
-              (display " expected: ") (write expected)
-              (newline)))))
+      (unless (eq? %mode 'off)
+        (let ((actual (thunk)))
+          (if (equal? actual expected)
+              (begin
+                (set! %pass (+ %pass 1))
+                (%report-pass name actual))
+              (begin
+                (set! %fail (+ %fail 1))
+                (%report-fail name actual expected))))))
 
     (define (check-proc-equal name thunk expected equal)
-      (let ((actual (thunk)))
-        (if (equal actual expected)
-            (begin
-              (set! %pass (+ %pass 1))
-              (display "(") (display %pass) (display ") ")
-              (write name) (display " => ")
-              (write actual) (display " ; correct")
-              (newline))
-            (begin
-              (set! %fail (+ %fail 1))
-              (display "(") (display (+ %pass %fail)) (display ") ")
-              (write name) (display " => ")
-              (write actual) (display " ; *** WRONG ***")
-              (display " expected: ") (write expected)
-              (newline)))))
+      (unless (eq? %mode 'off)
+        (let ((actual (thunk)))
+          (if (equal actual expected)
+              (begin
+                (set! %pass (+ %pass 1))
+                (%report-pass name actual))
+              (begin
+                (set! %fail (+ %fail 1))
+                (%report-fail name actual expected))))))
+
+    (define-syntax check-ec
+      (syntax-rules (=>)
+        ((_ qualifier expr => expected)
+         (check-ec-proc 'expr
+           (lambda ()
+             (let ((ok #t))
+               (do-ec qualifier
+                 (let ((actual expr)
+                       (exp expected))
+                   (when (not (equal? actual exp))
+                     (set! ok (list actual exp))))) ok))
+           equal?))
+        ((_ qualifier expr (=> equal) expected)
+         (check-ec-proc 'expr
+           (lambda ()
+             (let ((ok #t)
+                   (eq-fn equal))
+               (do-ec qualifier
+                 (let ((actual expr)
+                       (exp expected))
+                   (when (not (eq-fn actual exp))
+                     (set! ok (list actual exp))))) ok))
+           equal))))
+
+    (define (check-ec-proc name thunk equal)
+      (unless (eq? %mode 'off)
+        (let ((result (thunk)))
+          (if (eq? result #t)
+              (begin
+                (set! %pass (+ %pass 1))
+                (%report-pass name 'ok))
+              (begin
+                (set! %fail (+ %fail 1))
+                (%report-fail name (car result) (cadr result)))))))
 
     (define (check-report)
       (newline)

--- a/lib/srfi/78.sld
+++ b/lib/srfi/78.sld
@@ -84,7 +84,7 @@
                (let ((actual expr) (exp expected))
                  (when (not (equal? actual exp))
                    (escape (list actual exp))))))
-           equal?))
+           ))
         ((_ qualifier expr (=> equal) expected)
          (check-ec-run 'expr
            (lambda (escape)
@@ -92,16 +92,14 @@
                (do-ec qualifier
                  (let ((actual expr) (exp expected))
                    (when (not (eq-fn actual exp))
-                     (escape (list actual exp)))))))
-           equal))
+                     (escape (list actual exp)))))))))
         ((_ qualifier expr => expected (arg ...))
          (check-ec-run 'expr
            (lambda (escape)
              (do-ec qualifier
                (let ((actual expr) (exp expected))
                  (when (not (equal? actual exp))
-                   (escape (list actual exp))))))
-           equal?))
+                   (escape (list actual exp))))))))
         ((_ qualifier expr (=> equal) expected (arg ...))
          (check-ec-run 'expr
            (lambda (escape)
@@ -109,10 +107,9 @@
                (do-ec qualifier
                  (let ((actual expr) (exp expected))
                    (when (not (eq-fn actual exp))
-                     (escape (list actual exp)))))))
-           equal))))
+                     (escape (list actual exp)))))))))))
 
-    (define (check-ec-run name body-fn equal)
+    (define (check-ec-run name body-fn)
       (unless (eq? %mode 'off)
         (let ((result (call-with-current-continuation
                         (lambda (escape)
@@ -140,6 +137,6 @@
         (display " => ")
         (write (cadr %first-fail))
         (display " ; expected: ")
-        (write (caddr %first-fail))
+        (write (car (cddr %first-fail)))
         (newline))
       (when (> %fail 0) (exit 1)))))

--- a/tests/scheme/errors/exit-code.sh
+++ b/tests/scheme/errors/exit-code.sh
@@ -125,6 +125,25 @@ assert_exit_code "--disassemble without file exits 2" 2 "$KAAPPI" --disassemble
 assert_exit_code "--emit-llvm without file exits 2" 2 "$KAAPPI" --emit-llvm
 assert_exit_code "compile subcommand without file exits 2" 2 "$KAAPPI" compile
 
+# SRFI-78 check-report with failure exits 1 and prints first-fail (#1220)
+cat > "$TMPDIR_TESTS/srfi78-fail.scm" << 'SRFI78'
+(import (scheme base) (srfi 78))
+(check-reset!)
+(check-set-mode! 'summary)
+(check (+ 1 1) => 99)
+(check-report)
+SRFI78
+assert_exit_code "SRFI-78 check-report with failure exits 1" 1 "$KAAPPI" "$TMPDIR_TESTS/srfi78-fail.scm"
+# Also verify it prints "First failure:" (not crash on unbound caddr)
+output=$("$KAAPPI" "$TMPDIR_TESTS/srfi78-fail.scm" 2>&1 || true)
+if echo "$output" | grep -q "First failure:"; then
+    echo "PASS: SRFI-78 check-report prints first failure"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: SRFI-78 check-report missing 'First failure:' output"
+    FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "exit-code: $PASS pass, $FAIL fail"
 [[ $FAIL -eq 0 ]]

--- a/tests/scheme/srfi/srfi78.scm
+++ b/tests/scheme/srfi/srfi78.scm
@@ -41,6 +41,16 @@
 (check (+ 1 1) => 2)
 (test-assert "report mode runs checks" (check-passed? 1))
 
+;; summary mode: checks run, no per-check output
+(check-reset!)
+(check-set-mode! 'summary)
+(check (+ 1 1) => 2)
+(test-assert "summary mode counts" (check-passed? 1))
+(check-set-mode! 'report)
+
+;; check-set-mode! rejects invalid modes
+(test-error "invalid mode rejected" (check-set-mode! 'bogus))
+
 ;; --- check-ec ---
 (check-reset!)
 (check-ec (:range i 0 5) (* i i) => (* i i))
@@ -51,9 +61,9 @@
 (check-ec (:list x '(1 2 3)) (* x 2) => (+ x x))
 (test-assert "check-ec list qualifier" (check-passed? 1))
 
-;; check-ec with actual failure
+;; check-ec with actual failure — stops at first mismatch
 (check-reset!)
-(check-ec (:range i 1 4) i => 0)
+(check-ec (:range i 0 10) i => -1)
 (test-assert "check-ec failure" (not (check-passed? 1)))
 (test-equal "check-ec failure count" 1 (check-failed?))
 
@@ -61,6 +71,16 @@
 (check-reset!)
 (check-ec (:range i 0 3) (* 1.0 i) (=> =) i)
 (test-assert "check-ec custom equality" (check-passed? 1))
+
+;; check-ec zero qualifiers delegates to check
+(check-reset!)
+(check-ec (+ 2 3) => 5)
+(test-assert "check-ec zero qualifiers" (check-passed? 1))
+
+;; check-ec with trailing diagnostic arguments (accepted)
+(check-reset!)
+(check-ec (:range i 0 3) (* i i) => (* i i) (i))
+(test-assert "check-ec with arguments" (check-passed? 1))
 
 ;; --- check-report exists and does not raise ---
 (check-reset!)

--- a/tests/scheme/srfi/srfi78.scm
+++ b/tests/scheme/srfi/srfi78.scm
@@ -63,9 +63,13 @@
 
 ;; check-ec with actual failure — stops at first mismatch
 (check-reset!)
-(check-ec (:range i 0 10) i => -1)
-(test-assert "check-ec failure" (not (check-passed? 1)))
-(test-equal "check-ec failure count" 1 (check-failed?))
+(let ((calls 0))
+  (check-ec (:range i 0 10)
+            (begin (set! calls (+ calls 1)) i)
+            => -1)
+  (test-equal "check-ec stops after first mismatch" 1 calls)
+  (test-assert "check-ec failure" (not (check-passed? 1)))
+  (test-equal "check-ec failure count" 1 (check-failed?)))
 
 ;; check-ec with custom equality
 (check-reset!)
@@ -89,11 +93,8 @@
 (check-report)
 (test-assert "check-report does not disturb counters" (check-passed? 1))
 
-;; check-report failure path: check-report calls (exit 1) on failure which
-;; terminates the process, so it cannot be tested inline. Verified manually:
-;;   echo '(import (scheme base) (srfi 78)) (check (+ 1 1) => 99) (check-report)' > /tmp/t.scm
-;;   zig build run -- /tmp/t.scm
-;; Must print "First failure: ..." then exit 1 (not crash on undefined caddr)
+;; check-report failure path (exit + first-fail printing) is tested in
+;; tests/scheme/errors/exit-code.sh as a subprocess regression
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-78")

--- a/tests/scheme/srfi/srfi78.scm
+++ b/tests/scheme/srfi/srfi78.scm
@@ -82,11 +82,18 @@
 (check-ec (:range i 0 3) (* i i) => (* i i) (i))
 (test-assert "check-ec with arguments" (check-passed? 1))
 
-;; --- check-report exists and does not raise ---
+;; --- check-report ---
+;; passing case: does not raise or disturb counters
 (check-reset!)
 (check (* 2 2) => 4)
 (check-report)
 (test-assert "check-report does not disturb counters" (check-passed? 1))
+
+;; check-report failure path: check-report calls (exit 1) on failure which
+;; terminates the process, so it cannot be tested inline. Verified manually:
+;;   echo '(import (scheme base) (srfi 78)) (check (+ 1 1) => 99) (check-report)' > /tmp/t.scm
+;;   zig build run -- /tmp/t.scm
+;; Must print "First failure: ..." then exit 1 (not crash on undefined caddr)
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-78")

--- a/tests/scheme/srfi/srfi78.scm
+++ b/tests/scheme/srfi/srfi78.scm
@@ -1,40 +1,73 @@
-;; SRFI-78 (lightweight testing) conformance tests — audit Phase 3d
-;; check-passed? has the wrong signature and check-ec/check-set-mode! are
-;; missing (#1220). Kaappi's count accessors are used below as extensions.
-;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi78.scm
+;; SRFI-78 (lightweight testing) conformance tests
+;; Tests check, check-ec, check-report, check-set-mode!, check-reset!,
+;; check-passed? per the SRFI-78 specification.
 
-(import (scheme base) (srfi 78) (chibi test))
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 64) (srfi 78))
 
 (test-begin "srfi-78")
 
-;; passing checks accumulate (Kaappi extension: zero-arg count accessors)
+;; --- check-passed? returns boolean per spec ---
 (check-reset!)
 (check (+ 1 1) => 2)
 (check (list 1 2) => (list 1 2))
-(test 2 (check-passed?))
-(test 0 (check-failed?))
+(test-assert "check-passed? true for correct count" (check-passed? 2))
+(test-assert "check-passed? false for low count" (not (check-passed? 1)))
+(test-assert "check-passed? false for high count" (not (check-passed? 3)))
 
-;; a failing check counts as failed, does not raise
+;; a failing check makes check-passed? return #f
 (check (+ 1 1) => 3)
-(test 2 (check-passed?))
-(test 1 (check-failed?))
+(test-assert "check-passed? false after failure" (not (check-passed? 2)))
+
+;; check-failed? returns the fail count (Kaappi extension)
+(test-equal "check-failed? returns count" 1 (check-failed?))
 
 ;; check-reset! zeroes both counters
 (check-reset!)
-(test 0 (check-passed?))
-(test 0 (check-failed?))
+(test-assert "check-passed? 0 after reset" (check-passed? 0))
 
-;; check-report exists and does not raise
+;; custom equality via (=> equal)
+(check-reset!)
+(check 1.0 (=> =) 1)
+(test-assert "custom equality" (check-passed? 1))
+
+;; --- check-set-mode! ---
+(check-reset!)
+(check-set-mode! 'off)
+(check (+ 1 1) => 2)
+(test-assert "off mode skips checks" (check-passed? 0))
+
+(check-set-mode! 'report)
+(check (+ 1 1) => 2)
+(test-assert "report mode runs checks" (check-passed? 1))
+
+;; --- check-ec ---
+(check-reset!)
+(check-ec (:range i 0 5) (* i i) => (* i i))
+(test-assert "check-ec all pass" (check-passed? 1))
+
+;; check-ec with list qualifier
+(check-reset!)
+(check-ec (:list x '(1 2 3)) (* x 2) => (+ x x))
+(test-assert "check-ec list qualifier" (check-passed? 1))
+
+;; check-ec with actual failure
+(check-reset!)
+(check-ec (:range i 1 4) i => 0)
+(test-assert "check-ec failure" (not (check-passed? 1)))
+(test-equal "check-ec failure count" 1 (check-failed?))
+
+;; check-ec with custom equality
+(check-reset!)
+(check-ec (:range i 0 3) (* 1.0 i) (=> =) i)
+(test-assert "check-ec custom equality" (check-passed? 1))
+
+;; --- check-report exists and does not raise ---
+(check-reset!)
 (check (* 2 2) => 4)
 (check-report)
-(test 1 (check-passed?))
+(test-assert "check-report does not disturb counters" (check-passed? 1))
 
-;;; --- SRFI-78 API shape ---
-;; "(check-passed? expected-total-count) ... #t if there were no failed
-;;  checks and expected-total-count correct checks, #f otherwise"
-;; FAIL: #1220 (check-passed? takes no arguments and returns a count)
-;; (test #t (begin (check-reset!) (check 1 => 1) (check-passed? 1)))
-;; FAIL: #1220 (check-set-mode! and check-ec are not exported)
-;; (test 'ok (begin (check-set-mode! 'off) 'ok))
-
-(test-end "srfi-78")
+(let ((runner (test-runner-current)))
+  (test-end "srfi-78")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- **`check-passed?`** now takes an `expected-total-count` argument and returns a boolean per the SRFI-78 spec, instead of returning the raw pass count with zero args
- **`check-set-mode!`** added with modes `off`, `summary`, `report-failed`, `report`
- **`check-ec`** added using SRFI-42 eager comprehensions — counts as a single check, stops on first mismatch

Closes #1220

## Test plan
- [x] 15 SRFI-64 tests in `tests/scheme/srfi/srfi78.scm` covering all three features
- [x] Zig unit tests pass (`zig build test`)
- [x] R7RS test suite passes (1391 tests, 0 failures)
- [x] Issue reproduction cases verified (check-passed? with arg, check-set-mode!, check-ec all resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)