### PR TITLE
Fix SRFI-37 args-fold: short option matching, seed threading, option? export

### DIFF
--- a/lib/srfi/37.sld
+++ b/lib/srfi/37.sld
@@ -1,6 +1,6 @@
 (define-library (srfi 37)
   (import (scheme base))
-  (export args-fold
+  (export args-fold option?
           option option-names option-required-arg? option-optional-arg?
           option-processor)
   (begin
@@ -59,9 +59,10 @@
                  (let oloop ((operands rest) (seeds seeds))
                    (if (null? operands)
                        (apply values seeds)
-                       (let ((new-seeds (apply operand-proc (car operands) seeds)))
-                         (oloop (cdr operands)
-                                (if (list? new-seeds) new-seeds (list new-seeds)))))))
+                       (call-with-values
+                         (lambda () (apply operand-proc (car operands) seeds))
+                         (lambda new-seeds
+                           (oloop (cdr operands) new-seeds))))))
                 ((long-opt? arg)
                  (let* ((name (long-opt-name arg))
                         (opt-arg (long-opt-arg arg))
@@ -69,19 +70,22 @@
                    (if opt
                        (if (option-required-arg? opt)
                            (let* ((a (or opt-arg (if (pair? rest) (car rest) #f)))
-                                  (r (if (and (not opt-arg) (pair? rest)) (cdr rest) rest))
-                                  (new-seeds (apply (option-processor opt) opt name a seeds)))
-                             (loop r (if (list? new-seeds) new-seeds (list new-seeds))))
-                           (let ((new-seeds (apply (option-processor opt) opt name opt-arg seeds)))
-                             (loop rest (if (list? new-seeds) new-seeds (list new-seeds)))))
-                       (let ((new-seeds (apply unrecognized-proc
-                                               (%make-option (list name) #f #f #f) name #f seeds)))
-                         (loop rest (if (list? new-seeds) new-seeds (list new-seeds)))))))
+                                  (r (if (and (not opt-arg) (pair? rest)) (cdr rest) rest)))
+                             (call-with-values
+                               (lambda () (apply (option-processor opt) opt name a seeds))
+                               (lambda new-seeds (loop r new-seeds))))
+                           (call-with-values
+                             (lambda () (apply (option-processor opt) opt name opt-arg seeds))
+                             (lambda new-seeds (loop rest new-seeds))))
+                       (call-with-values
+                         (lambda () (apply unrecognized-proc
+                                          (%make-option (list name) #f #f #f) name #f seeds))
+                         (lambda new-seeds (loop rest new-seeds))))))
                 ((short-opt? arg)
                  (let sloop ((i 1) (seeds seeds) (rest rest))
                    (if (>= i (string-length arg))
                        (loop rest seeds)
-                       (let* ((ch (string (string-ref arg i)))
+                       (let* ((ch (string-ref arg i))
                               (opt (find-option options ch)))
                          (if opt
                              (if (option-required-arg? opt)
@@ -89,18 +93,20 @@
                                                (substring arg (+ i 1) (string-length arg))
                                                (if (pair? rest) (car rest) #f)))
                                         (r (if (< (+ i 1) (string-length arg))
-                                               rest (if (pair? rest) (cdr rest) rest)))
-                                        (new-seeds (apply (option-processor opt) opt ch a seeds)))
-                                   (loop r (if (list? new-seeds) new-seeds (list new-seeds))))
-                                 (let ((new-seeds (apply (option-processor opt) opt ch #f seeds)))
-                                   (sloop (+ i 1)
-                                          (if (list? new-seeds) new-seeds (list new-seeds))
-                                          rest)))
-                             (let ((new-seeds (apply unrecognized-proc
-                                                     (%make-option (list ch) #f #f #f) ch #f seeds)))
-                               (sloop (+ i 1)
-                                      (if (list? new-seeds) new-seeds (list new-seeds))
-                                      rest)))))))
+                                               rest (if (pair? rest) (cdr rest) rest))))
+                                   (call-with-values
+                                     (lambda () (apply (option-processor opt) opt ch a seeds))
+                                     (lambda new-seeds (loop r new-seeds))))
+                                 (call-with-values
+                                   (lambda () (apply (option-processor opt) opt ch #f seeds))
+                                   (lambda new-seeds
+                                     (sloop (+ i 1) new-seeds rest))))
+                             (call-with-values
+                               (lambda () (apply unrecognized-proc
+                                                 (%make-option (list ch) #f #f #f) ch #f seeds))
+                               (lambda new-seeds
+                                 (sloop (+ i 1) new-seeds rest))))))))
                 (else
-                 (let ((new-seeds (apply operand-proc arg seeds)))
-                   (loop rest (if (list? new-seeds) new-seeds (list new-seeds))))))))))))
+                 (call-with-values
+                   (lambda () (apply operand-proc arg seeds))
+                   (lambda new-seeds (loop rest new-seeds)))))))))))

--- a/tests/scheme/srfi/srfi37.scm
+++ b/tests/scheme/srfi/srfi37.scm
@@ -1,9 +1,8 @@
 ;; SRFI-37 (args-fold) conformance tests — audit Phase 3b
-;; NOTE: several args-fold defects are tracked in #1211; the enabled tests
-;; below use long options and non-list seeds to stay clear of them.
+;; Regression tests for #1211: short char-name matching, seed threading, option? export
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi37.scm
 
-(import (scheme base) (srfi 37) (chibi test))
+(import (scheme base) (scheme process-context) (srfi 37) (srfi 64))
 
 (test-begin "srfi-37")
 
@@ -15,52 +14,104 @@
   (option '(#\o "output") #t #f
           (lambda (opt name arg n) (if (equal? arg "out") 100 -1))))
 
-(test '(#\v "verbose") (option-names verbose))
-(test #f (option-required-arg? verbose))
-(test #t (option-required-arg? output))
-(test #f (option-optional-arg? output))
-(test #t (procedure? (option-processor verbose)))
+(test-equal "option-names" '(#\v "verbose") (option-names verbose))
+(test-equal "required-arg? false" #f (option-required-arg? verbose))
+(test-equal "required-arg? true" #t (option-required-arg? output))
+(test-equal "optional-arg? false" #f (option-optional-arg? output))
+(test-assert "processor is procedure" (procedure? (option-processor verbose)))
 
-;; option? is not exported:
-;; FAIL: #1211 (option? missing from (srfi 37) exports)
-;; (test #t (option? verbose))
+;; option? is exported (#1211 fix)
+(test-assert "option? positive" (option? verbose))
+(test-assert "option? negative" (not (option? 42)))
 
 ;;; --- args-fold with long options and a numeric seed ---
 (define (unrec opt name arg n) -999)
 (define (count-operand op n) (+ n 10))
 (define opts (list verbose output))
 
-(test 1 (args-fold '("--verbose") opts unrec count-operand 0))
-(test 2 (args-fold '("--verbose" "--verbose") opts unrec count-operand 0))
+(test-equal "long verbose" 1 (args-fold '("--verbose") opts unrec count-operand 0))
+(test-equal "long verbose x2" 2 (args-fold '("--verbose" "--verbose") opts unrec count-operand 0))
 
 ;; required argument via --name=value and via the following token
-(test 100 (args-fold '("--output=out") opts unrec count-operand 0))
-(test 100 (args-fold '("--output" "out") opts unrec count-operand 0))
+(test-equal "long --output=out" 100 (args-fold '("--output=out") opts unrec count-operand 0))
+(test-equal "long --output out" 100 (args-fold '("--output" "out") opts unrec count-operand 0))
 
 ;; operands
-(test 10 (args-fold '("file") opts unrec count-operand 0))
-(test 21 (args-fold '("a" "b" "--verbose") opts unrec count-operand 0))
+(test-equal "single operand" 10 (args-fold '("file") opts unrec count-operand 0))
+(test-equal "operands + long" 21 (args-fold '("a" "b" "--verbose") opts unrec count-operand 0))
 
 ;; unrecognized long option hits the fallback
-(test -999 (args-fold '("--nope") opts unrec count-operand 0))
+(test-equal "unrecognized long" -999 (args-fold '("--nope") opts unrec count-operand 0))
 
-;;; --- spec deviations (see #1211) ---
-;; short options never match their char names (compared as strings):
-;; FAIL: #1211 (short char-name options unmatched)
-;; (test 1 (args-fold '("-v") opts unrec count-operand 0))
-;; the name passed to processors for short options must be the char:
-;; FAIL: #1211 (short option name passed as string, not char)
-;; (test #\v (args-fold '("-v")
-;;                      (list (option '(#\v) #f #f (lambda (o name a s) name)))
-;;                      unrec count-operand 'none))
-;; a processor may return a list as its (single) seed:
-;; FAIL: #1211 (list-valued seeds are splatted into multiple seeds)
-;; (test '(verbose)
-;;       (args-fold '("--verbose")
-;;                  (list (option '(#\v "verbose") #f #f
-;;                                (lambda (o n a acc) (cons 'verbose acc))))
-;;                  (lambda (o n a acc) acc)
-;;                  (lambda (op acc) acc)
-;;                  '()))
+;;; --- short options (#1211 fix: char-name matching) ---
+(test-equal "short -v" 1 (args-fold '("-v") opts unrec count-operand 0))
+(test-equal "short -v -v" 2 (args-fold '("-v" "-v") opts unrec count-operand 0))
 
-(test-end "srfi-37")
+;; combined short options: -vv
+(test-equal "combined -vv" 2 (args-fold '("-vv") opts unrec count-operand 0))
+
+;; short option with required arg: -o out
+(test-equal "short -o out" 100 (args-fold '("-o" "out") opts unrec count-operand 0))
+
+;; short option with required arg attached: -oout
+(test-equal "short -oout" 100 (args-fold '("-oout") opts unrec count-operand 0))
+
+;; mixed short and long (output processor replaces seed with 100)
+(test-equal "mixed -v --output=out" 100
+  (args-fold '("-v" "--output=out") opts unrec count-operand 0))
+
+;; the name passed to processors for short options must be the char
+(test-equal "short name is char" #\v
+  (args-fold '("-v")
+             (list (option '(#\v) #f #f (lambda (o name a s) name)))
+             unrec count-operand 'none))
+
+;; unrecognized short option
+(test-equal "unrecognized short" -999 (args-fold '("-x") opts unrec count-operand 0))
+
+;;; --- list-valued seeds (#1211 fix: call-with-values threading) ---
+(test-equal "list seed via long opt" '(verbose)
+  (args-fold '("--verbose")
+             (list (option '(#\v "verbose") #f #f
+                           (lambda (o n a acc) (cons 'verbose acc))))
+             (lambda (o n a acc) acc)
+             (lambda (op acc) acc)
+             '()))
+
+;; accumulate into a list seed with short options
+(test-equal "list seed via combined short" '(b a)
+  (args-fold '("-ab")
+             (list (option '(#\a) #f #f (lambda (o n a acc) (cons 'a acc)))
+                   (option '(#\b) #f #f (lambda (o n a acc) (cons 'b acc))))
+             (lambda (o n a acc) acc)
+             (lambda (op acc) acc)
+             '()))
+
+;; operands accumulate into a list seed
+(test-equal "list seed via operands" '("z" "y")
+  (args-fold '("y" "z")
+             '()
+             (lambda (o n a acc) acc)
+             (lambda (op acc) (cons op acc))
+             '()))
+
+;;; --- multiple seeds ---
+(test-assert "multiple seeds"
+  (let-values (((a b) (args-fold '("--verbose")
+                                 (list (option '("verbose") #f #f
+                                               (lambda (o n a x y) (values (+ x 1) (+ y 10)))))
+                                 (lambda (o n a x y) (values x y))
+                                 (lambda (op x y) (values x y))
+                                 0 0)))
+    (and (= a 1) (= b 10))))
+
+;;; --- -- separator ---
+(test-equal "-- separator" 20 (args-fold '("--" "a" "b") opts unrec count-operand 0))
+(test-equal "option then --" 11 (args-fold '("--verbose" "--" "x") opts unrec count-operand 0))
+
+;;; --- empty args ---
+(test-equal "empty args" 0 (args-fold '() opts unrec count-operand 0))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-37")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #1211 — three bugs that made `args-fold` unusable for typical CLI parsing:

- **Short char-name options never matched** — the lookup built a string from the char (`"v"`) and compared it via `member` against names that are chars (`#\v`). Fixed by passing the char directly to `find-option`.
- **List-valued seeds were splatted** — the heuristic `(if (list? new-seeds) new-seeds (list new-seeds))` unwrapped any processor that legitimately returned a list as its single seed. Replaced all 8 sites with `call-with-values` to thread seeds correctly per the SRFI spec.
- **`option?` not exported** — added to the export list.

## Test plan

- [x] 29 SRFI-37 tests pass (up from ~12 with previously disabled tests now enabled)
- [x] Short options: `-v`, `-vv`, `-o out`, `-oout`, mixed `-v --output=out`
- [x] Char name passed to processors (not string)
- [x] List-valued seeds preserved through long opts, short opts, and operands
- [x] Multiple seeds via `values` threading
- [x] `option?` predicate works
- [x] Zig unit tests pass
- [x] R7RS test suite passes (1,391 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)