### PR TITLE
Implement SRFI-61 general cond clause (generator guard => receiver)

### DIFF
--- a/lib/srfi/61.sld
+++ b/lib/srfi/61.sld
@@ -1,7 +1,25 @@
 ;;; SRFI 61 — A more general cond clause
-;;; Kaappi's cond already supports => clauses from R7RS.
-;;; This SRFI adds (test => receiver) with a guard procedure.
+;;; Extends cond with (generator guard => receiver) clauses.
 (define-library (srfi 61)
   (import (scheme base))
-  (export)
-  (begin))
+  (export cond)
+  (begin
+    (define-syntax cond
+      (syntax-rules (=> else)
+        ((cond (else expr1 expr2 ...))
+         (begin expr1 expr2 ...))
+        ((cond (generator guard => receiver) rest ...)
+         (call-with-values (lambda () generator)
+           (lambda args
+             (if (apply guard args)
+                 (apply receiver args)
+                 (cond rest ...)))))
+        ((cond (test => proc) rest ...)
+         (let ((t test))
+           (if t (proc t) (cond rest ...))))
+        ((cond (test) rest ...)
+         (or test (cond rest ...)))
+        ((cond (test body1 body2 ...) rest ...)
+         (if test (begin body1 body2 ...) (cond rest ...)))
+        ((cond)
+         (if #f #f))))))

--- a/tests/scheme/srfi/srfi61.scm
+++ b/tests/scheme/srfi/srfi61.scm
@@ -1,5 +1,4 @@
-;; SRFI-61 (a more general cond clause) conformance tests — audit Phase 3d
-;; The library is currently an empty stub (#1206); base cond still works.
+;; SRFI-61 (a more general cond clause) conformance tests
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi61.scm
 
 (import (scheme base) (srfi 61) (chibi test))
@@ -11,15 +10,35 @@
 (test 'b (cond (#f 'a) (else 'b)))
 (test 2 (cond ((assv 1 '((1 . 2))) => cdr) (else 'no)))
 
+;; test-only clause returns the test value
+(test 42 (cond (42)))
+
 ;;; --- the SRFI-61 (generator guard => receiver) clause ---
-;; "⟨generator⟩ is evaluated. It may return arbitrarily many values. ⟨Guard⟩
-;;  is applied to [those values] ... If ⟨guard⟩ returns a true value ...
-;;  ⟨receiver⟩ is applied with an equivalent argument list."
-;; FAIL: #1206 (SRFI-61 general cond clause not implemented; library is empty)
-;; (test 3 (cond ((values 1 2) (lambda (a b) #t) => (lambda (a b) (+ a b)))
-;;               (else 'no)))
-;; FAIL: #1206 (SRFI-61 general cond clause not implemented; library is empty)
-;; (test 'skipped (cond ((values 1 2) (lambda (a b) #f) => (lambda (a b) 'used))
-;;                      (else 'skipped)))
+
+;; multi-value generator, guard succeeds
+(test 3 (cond ((values 1 2) (lambda (a b) #t) => (lambda (a b) (+ a b)))
+              (else 'no)))
+
+;; multi-value generator, guard fails — falls through to else
+(test 'skipped (cond ((values 1 2) (lambda (a b) #f) => (lambda (a b) 'used))
+                     (else 'skipped)))
+
+;; single-value generator with guard
+(test 10 (cond (5 positive? => (lambda (x) (* x 2)))
+               (else 'no)))
+
+;; single-value guard fails, falls to next clause
+(test 'neg (cond (-1 positive? => (lambda (x) (* x 2)))
+                 (else 'neg)))
+
+;; SRFI-61 clause mixed with standard clauses
+(test 'second (cond (#f 'first)
+                    (42 number? => (lambda (x) 'second))
+                    (else 'third)))
+
+;; guard fails, next SRFI-61 clause matches
+(test 'b (cond ((values 1) (lambda (x) (> x 5)) => (lambda (x) 'a))
+               ((values 2) (lambda (x) (< x 5)) => (lambda (x) 'b))
+               (else 'c)))
 
 (test-end "srfi-61")


### PR DESCRIPTION
## Summary

- Replace the empty `lib/srfi/61.sld` stub with a `syntax-rules` macro that shadows the built-in `cond`, adding the `(generator guard => receiver)` clause form per the SRFI-61 spec
- The generator may return multiple values via `call-with-values`; the guard is applied to them, and if true the receiver gets the same argument list
- All standard R7RS `cond` clause forms are preserved by the macro

Closes #1206

## Test plan

- [x] 10 SRFI-61 tests pass (multi-value generators, guard success/failure, single-value guards, mixed clauses, chained SRFI-61 clauses)
- [x] Full test suite: 1807 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)