### PR TITLE
Implement SRFI-17 generalized set! with pre-defined setters

### DIFF
--- a/lib/srfi/17.sld
+++ b/lib/srfi/17.sld
@@ -1,10 +1,46 @@
 ;;; SRFI 17 — Generalized set!
 (define-library (srfi 17)
-  (import (scheme base))
+  (import (scheme base) (scheme cxr))
   (export setter getter-with-setter)
   (begin
 
-    (define setters '())
+    (define setters
+      (list
+        (cons car   set-car!)
+        (cons cdr   set-cdr!)
+        (cons vector-ref vector-set!)
+        (cons string-ref string-set!)
+        ;; 2-deep compositions
+        (cons caar  (lambda (p v) (set-car! (car p) v)))
+        (cons cadr  (lambda (p v) (set-car! (cdr p) v)))
+        (cons cdar  (lambda (p v) (set-cdr! (car p) v)))
+        (cons cddr  (lambda (p v) (set-cdr! (cdr p) v)))
+        ;; 3-deep compositions
+        (cons caaar (lambda (p v) (set-car! (caar p) v)))
+        (cons caadr (lambda (p v) (set-car! (cadr p) v)))
+        (cons cadar (lambda (p v) (set-car! (cdar p) v)))
+        (cons caddr (lambda (p v) (set-car! (cddr p) v)))
+        (cons cdaar (lambda (p v) (set-cdr! (caar p) v)))
+        (cons cdadr (lambda (p v) (set-cdr! (cadr p) v)))
+        (cons cddar (lambda (p v) (set-cdr! (cdar p) v)))
+        (cons cdddr (lambda (p v) (set-cdr! (cddr p) v)))
+        ;; 4-deep compositions
+        (cons caaaar (lambda (p v) (set-car! (caaar p) v)))
+        (cons caaadr (lambda (p v) (set-car! (caadr p) v)))
+        (cons caadar (lambda (p v) (set-car! (cadar p) v)))
+        (cons caaddr (lambda (p v) (set-car! (caddr p) v)))
+        (cons cadaar (lambda (p v) (set-car! (cdaar p) v)))
+        (cons cadadr (lambda (p v) (set-car! (cdadr p) v)))
+        (cons caddar (lambda (p v) (set-car! (cddar p) v)))
+        (cons cadddr (lambda (p v) (set-car! (cdddr p) v)))
+        (cons cdaaar (lambda (p v) (set-cdr! (caaar p) v)))
+        (cons cdaadr (lambda (p v) (set-cdr! (caadr p) v)))
+        (cons cdadar (lambda (p v) (set-cdr! (cadar p) v)))
+        (cons cdaddr (lambda (p v) (set-cdr! (caddr p) v)))
+        (cons cddaar (lambda (p v) (set-cdr! (cdaar p) v)))
+        (cons cddadr (lambda (p v) (set-cdr! (cdadr p) v)))
+        (cons cdddar (lambda (p v) (set-cdr! (cddar p) v)))
+        (cons cddddr (lambda (p v) (set-cdr! (cdddr p) v)))))
 
     (define (setter proc)
       (let ((entry (assq proc setters)))

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -785,39 +785,45 @@ pub fn compileSet(self: *Compiler, args: Value, dst: u16) CompileError!void {
 
     // SRFI-17 generalized set!: (set! (proc arg ...) val)
     // Desugar to: ((setter proc) arg ... val) and compile as a call.
+    // Defensive fallback — the IR path (lowerSet) handles this first;
+    // this branch fires only if compilation routes through compileExpr.
+    // Requires (srfi 17) imported so the global `setter` is defined.
     if (types.isPair(target)) {
         const proc = types.car(target);
         const proc_args = types.cdr(target);
         const val_expr = types.car(rest);
 
-        // Build (setter proc)
-        const setter_sym = self.gc.allocSymbol("setter") catch return CompileError.OutOfMemory;
-        const setter_proc_pair = self.gc.allocPair(proc, types.NIL) catch return CompileError.OutOfMemory;
-        var setter_call = self.gc.allocPair(setter_sym, setter_proc_pair) catch return CompileError.OutOfMemory;
-        self.gc.pushRoot(&setter_call);
-        defer self.gc.popRoot();
-
-        // Build args: append val to proc_args → (arg1 arg2 ... val)
-        var ext_args = self.gc.allocPair(val_expr, types.NIL) catch return CompileError.OutOfMemory;
-        // Collect proc_args into stack buffer, then prepend in reverse
         var arg_buf: [16]Value = undefined;
         var n_args: usize = 0;
         var cur = proc_args;
         while (cur != types.NIL) {
             if (!types.isPair(cur)) return CompileError.InvalidSyntax;
-            if (n_args >= 16) return CompileError.InvalidSyntax;
+            if (n_args >= 16) return CompileError.InternalLimit;
             arg_buf[n_args] = types.car(cur);
             n_args += 1;
             cur = types.cdr(cur);
         }
-        var i = n_args;
-        while (i > 0) {
-            i -= 1;
-            ext_args = self.gc.allocPair(arg_buf[i], ext_args) catch return CompileError.OutOfMemory;
-        }
 
-        // Build ((setter proc) arg1 ... val) and compile as expression
-        const desugared = self.gc.allocPair(setter_call, ext_args) catch return CompileError.OutOfMemory;
+        // Suppress GC during S-expression construction — intermediate
+        // pairs are not reachable from any root until `desugared` is
+        // rooted (same pattern as compileDefineValues, issue #1010).
+        var desugared: Value = undefined;
+        {
+            self.gc.no_collect += 1;
+            defer self.gc.no_collect -= 1;
+            const setter_sym = self.gc.allocSymbol("setter") catch return CompileError.OutOfMemory;
+            const setter_proc_pair = self.gc.allocPair(proc, types.NIL) catch return CompileError.OutOfMemory;
+            const setter_call = self.gc.allocPair(setter_sym, setter_proc_pair) catch return CompileError.OutOfMemory;
+            var ext_args = self.gc.allocPair(val_expr, types.NIL) catch return CompileError.OutOfMemory;
+            var i = n_args;
+            while (i > 0) {
+                i -= 1;
+                ext_args = self.gc.allocPair(arg_buf[i], ext_args) catch return CompileError.OutOfMemory;
+            }
+            desugared = self.gc.allocPair(setter_call, ext_args) catch return CompileError.OutOfMemory;
+        }
+        self.gc.pushRoot(&desugared);
+        defer self.gc.popRoot();
         return self.compileExprViaIR(desugared, dst, false);
     }
 

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -782,6 +782,45 @@ pub fn compileSet(self: *Compiler, args: Value, dst: u16) CompileError!void {
     const target = types.car(args);
     const rest = types.cdr(args);
     if (rest == types.NIL) return CompileError.InvalidSyntax;
+
+    // SRFI-17 generalized set!: (set! (proc arg ...) val)
+    // Desugar to: ((setter proc) arg ... val) and compile as a call.
+    if (types.isPair(target)) {
+        const proc = types.car(target);
+        const proc_args = types.cdr(target);
+        const val_expr = types.car(rest);
+
+        // Build (setter proc)
+        const setter_sym = self.gc.allocSymbol("setter") catch return CompileError.OutOfMemory;
+        const setter_proc_pair = self.gc.allocPair(proc, types.NIL) catch return CompileError.OutOfMemory;
+        var setter_call = self.gc.allocPair(setter_sym, setter_proc_pair) catch return CompileError.OutOfMemory;
+        self.gc.pushRoot(&setter_call);
+        defer self.gc.popRoot();
+
+        // Build args: append val to proc_args → (arg1 arg2 ... val)
+        var ext_args = self.gc.allocPair(val_expr, types.NIL) catch return CompileError.OutOfMemory;
+        // Collect proc_args into stack buffer, then prepend in reverse
+        var arg_buf: [16]Value = undefined;
+        var n_args: usize = 0;
+        var cur = proc_args;
+        while (cur != types.NIL) {
+            if (!types.isPair(cur)) return CompileError.InvalidSyntax;
+            if (n_args >= 16) return CompileError.InvalidSyntax;
+            arg_buf[n_args] = types.car(cur);
+            n_args += 1;
+            cur = types.cdr(cur);
+        }
+        var i = n_args;
+        while (i > 0) {
+            i -= 1;
+            ext_args = self.gc.allocPair(arg_buf[i], ext_args) catch return CompileError.OutOfMemory;
+        }
+
+        // Build ((setter proc) arg1 ... val) and compile as expression
+        const desugared = self.gc.allocPair(setter_call, ext_args) catch return CompileError.OutOfMemory;
+        return self.compileExprViaIR(desugared, dst, false);
+    }
+
     if (!types.isSymbol(target)) return CompileError.InvalidSyntax;
 
     const value_expr = types.car(rest);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -650,10 +650,42 @@ fn lowerDefine(ir: *IR, expr: Value) CompileError!*Node {
 fn lowerSet(ir: *IR, args: Value) CompileError!*Node {
     if (args == types.NIL) return CompileError.InvalidSyntax;
     const name = types.car(args);
-    if (!types.isSymbol(name)) return CompileError.InvalidSyntax;
     const rest = types.cdr(args);
     if (rest == types.NIL) return CompileError.InvalidSyntax;
-    return ir.makeSet(name, types.car(rest));
+
+    if (types.isSymbol(name)) {
+        return ir.makeSet(name, types.car(rest));
+    }
+
+    // SRFI-17 generalized set!: (set! (proc arg ...) val)
+    // Desugar to: ((setter proc) arg ... val)
+    if (types.isPair(name)) {
+        const c = ir.compiler orelse return CompileError.InvalidSyntax;
+        const proc = types.car(name);
+        const proc_args = types.cdr(name);
+        const val_expr = types.car(rest);
+
+        // Build (setter proc) call node
+        const setter_sym = c.gc.allocSymbol("setter") catch return CompileError.OutOfMemory;
+        const setter_ref = try ir.makeGlobalRef(setter_sym);
+        const proc_node = try lowerWithMacros(ir, proc, null);
+        const setter_call = try ir.makeCall(setter_ref, &.{proc_node});
+
+        // Collect proc_args + val into argument list
+        var arg_nodes: std.ArrayList(*Node) = .empty;
+        defer arg_nodes.deinit(ir.allocator);
+        var cur = proc_args;
+        while (cur != types.NIL) {
+            if (!types.isPair(cur)) return CompileError.InvalidSyntax;
+            arg_nodes.append(ir.allocator, try lowerWithMacros(ir, types.car(cur), null)) catch return CompileError.OutOfMemory;
+            cur = types.cdr(cur);
+        }
+        arg_nodes.append(ir.allocator, try lowerWithMacros(ir, val_expr, null)) catch return CompileError.OutOfMemory;
+
+        return ir.makeCall(setter_call, arg_nodes.items);
+    }
+
+    return CompileError.InvalidSyntax;
 }
 
 fn lowerList(ir: *IR, args: Value, tag: NodeTag, macros: ?*std.StringHashMap(Value)) CompileError!*Node {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -659,6 +659,10 @@ fn lowerSet(ir: *IR, args: Value) CompileError!*Node {
 
     // SRFI-17 generalized set!: (set! (proc arg ...) val)
     // Desugar to: ((setter proc) arg ... val)
+    // Requires (srfi 17) imported so the global `setter` is defined.
+    // Needs ir.compiler for symbol interning; the LLVM native backend
+    // (compiler-less lowering) falls through to InvalidSyntax — it
+    // would need an eval fallback for this form anyway.
     if (types.isPair(name)) {
         const c = ir.compiler orelse return CompileError.InvalidSyntax;
         const proc = types.car(name);

--- a/tests/scheme/srfi/srfi17.scm
+++ b/tests/scheme/srfi/srfi17.scm
@@ -1,7 +1,7 @@
 ;; SRFI-17 (generalized set!) conformance tests — audit Phase 3a
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi17.scm
 
-(import (scheme base) (srfi 17) (chibi test))
+(import (scheme base) (scheme cxr) (srfi 17) (chibi test))
 
 (test-begin "srfi-17")
 
@@ -19,17 +19,33 @@
 ;; setter on an unregistered procedure raises
 (test #t (guard (e (#t (error-object? e))) (setter (lambda (x) x)) #f))
 
-;;; --- pre-defined setters (SRFI-17: "The following standard procedures
-;;; have pre-defined setters": car, cdr, caXXr/cdXXr, string-ref, vector-ref)
-;; FAIL: #1205 (SRFI-17 stub: no pre-defined setters)
-;; (test '(9 2) (let ((p (list 1 2))) ((setter car) p 9) p))
-;; FAIL: #1205 (SRFI-17 stub: no pre-defined setters)
-;; (test #(1 9) (let ((v (vector 1 2))) ((setter vector-ref) v 1 9) v))
+;;; --- pre-defined setters ---
+(test '(9 2) (let ((p (list 1 2))) ((setter car) p 9) p))
+(test '(1 . 9) (let ((p (cons 1 2))) ((setter cdr) p 9) p))
+(test #(1 9) (let ((v (vector 1 2))) ((setter vector-ref) v 1 9) v))
+(test "axc" (let ((s (string-copy "abc"))) ((setter string-ref) s 1 #\x) s))
 
 ;;; --- generalized set! syntax: (set! (proc arg ...) value) ---
-;; FAIL: #1205 (SRFI-17 stub: generalized set! not supported)
-;; (test '(9 2) (let ((p (list 1 2))) (set! (car p) 9) p))
-;; FAIL: #1205 (SRFI-17 stub: generalized set! not supported)
-;; (test #(1 9) (let ((v (vector 1 2))) (set! (vector-ref v 1) 9) v))
+(test '(9 2) (let ((p (list 1 2))) (set! (car p) 9) p))
+(test '(1 . 9) (let ((p (cons 1 2))) (set! (cdr p) 9) p))
+(test #(1 9) (let ((v (vector 1 2))) (set! (vector-ref v 1) 9) v))
+(test "axc" (let ((s (string-copy "abc"))) (set! (string-ref s 1) #\x) s))
+
+;;; --- generalized set! with user-defined setter ---
+(test 42 (let ((s (vector 0)))
+           (define my-ref
+             (getter-with-setter
+               (lambda (v i) (vector-ref v i))
+               (lambda (v i val) (vector-set! v i val))))
+           (set! (my-ref s 0) 42)
+           (my-ref s 0)))
+
+;;; --- cXXr setters ---
+(test '((9 2) 3)
+  (let ((p (list (list 1 2) 3))) (set! (caar p) 9) p))
+(test '(1 9 3)
+  (let ((p (list 1 2 3))) (set! (cadr p) 9) p))
+(test '((1 . 9) 3)
+  (let ((p (list (cons 1 2) 3))) (set! (cdar p) 9) p))
 
 (test-end "srfi-17")

--- a/tests/scheme/srfi/srfi17.scm
+++ b/tests/scheme/srfi/srfi17.scm
@@ -47,5 +47,7 @@
   (let ((p (list 1 2 3))) (set! (cadr p) 9) p))
 (test '((1 . 9) 3)
   (let ((p (list (cons 1 2) 3))) (set! (cdar p) 9) p))
+(test '(1 2 3 99 5)
+  (let ((l (list 1 2 3 4 5))) (set! (cadddr l) 99) l))
 
 (test-end "srfi-17")


### PR DESCRIPTION
## Summary

- Compiler desugars `(set! (proc arg ...) val)` → `((setter proc) arg ... val)` in both the IR lowering path (`lowerSet`) and the legacy compiler path (`compileSet`)
- SRFI-17 library registers 32 pre-defined setters: `car`, `cdr`, `vector-ref`, `string-ref`, and all 28 cXXr compositions
- 16 tests covering pre-defined setters, generalized set! syntax, user-defined setters via `getter-with-setter`, and cXXr compositions

Closes #1205

## Test plan

- [x] `zig build test` — unit tests pass
- [x] `zig build run -- tests/scheme/srfi/srfi17.scm` — 16 pass, 0 fail
- [x] `bash tests/scheme/run-all.sh` — 1807 pass, 0 fail
- [x] Manual: `(import (srfi 17)) (let ((p (list 1 2))) (set! (car p) 99) p)` → `(99 2)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)