### PR TITLE
Fix SRFI-143 fxcopy-bit to accept boolean bit argument

### DIFF
--- a/lib/srfi/143.sld
+++ b/lib/srfi/143.sld
@@ -99,9 +99,9 @@
       (fxior (fxand mask n0) (fxand (fxnot mask) n1)))
 
     (define (fxcopy-bit index x bit)
-      (if (= bit 0)
-          (fxand x (fxnot (arithmetic-shift 1 index)))
-          (fxior x (arithmetic-shift 1 index))))
+      (if bit
+          (fxior x (arithmetic-shift 1 index))
+          (fxand x (fxnot (arithmetic-shift 1 index)))))
 
     (define (fxfirst-set-bit x)
       (if (= x 0) -1

--- a/tests/scheme/srfi/srfi143.scm
+++ b/tests/scheme/srfi/srfi143.scm
@@ -86,4 +86,11 @@
 (test 0 (fxfirst-set-bit 1))
 (test 2 (fxbit-field 13 1 3))
 
+(test 4 (fxcopy-bit 2 0 #t))
+(test 1 (fxcopy-bit 2 5 #f))
+(test 0 (fxcopy-bit 0 0 #f))
+(test 1 (fxcopy-bit 0 0 #t))
+(test 5 (fxcopy-bit 0 5 #t))
+(test 4 (fxcopy-bit 0 5 #f))
+
 (test-end "srfi-143")


### PR DESCRIPTION
## Summary

- Fix `fxcopy-bit` in `lib/srfi/143.sld` to accept boolean `#t`/`#f` as the bit argument per SRFI-143/151 spec, instead of numeric `0`/`1`
- Replace `(= bit 0)` with `(if bit ...)` — same fix pattern as #1316 (SRFI-151 `copy-bit`)
- Add 6 regression tests for `fxcopy-bit` with boolean arguments

Closes #1323

## Test plan

- [x] `fxcopy-bit` with `#t` sets the specified bit: `(fxcopy-bit 2 0 #t) → 4`
- [x] `fxcopy-bit` with `#f` clears the specified bit: `(fxcopy-bit 2 5 #f) → 1`
- [x] All 71 SRFI-143 tests pass (`zig build run -- tests/scheme/srfi/srfi143.scm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)