### PR TITLE
Add SRFI-174 timespec-hash, timespec->inexact, inexact->timespec

### DIFF
--- a/lib/srfi/174.sld
+++ b/lib/srfi/174.sld
@@ -1,7 +1,8 @@
 (define-library (srfi 174)
   (import (scheme base))
   (export timespec timespec? timespec-seconds timespec-nanoseconds
-          timespec=? timespec<? timespec>? timespec<=? timespec>=?)
+          timespec=? timespec<? timespec>? timespec<=? timespec>=?
+          timespec->inexact inexact->timespec timespec-hash)
   (begin
     (define-record-type <timespec>
       (timespec seconds nanoseconds)
@@ -20,4 +21,18 @@
 
     (define (timespec>? a b) (timespec<? b a))
     (define (timespec<=? a b) (not (timespec>? a b)))
-    (define (timespec>=? a b) (not (timespec<? a b)))))
+    (define (timespec>=? a b) (not (timespec<? a b)))
+
+    (define (timespec->inexact ts)
+      (+ (inexact (timespec-seconds ts))
+         (/ (inexact (timespec-nanoseconds ts)) 1e9)))
+
+    (define (inexact->timespec x)
+      (let* ((s (exact (floor x)))
+             (ns (exact (truncate (* (- x s) 1e9)))))
+        (timespec s ns)))
+
+    (define (timespec-hash ts)
+      (let ((s (timespec-seconds ts))
+            (ns (timespec-nanoseconds ts)))
+        (abs (+ (* s 1000000007) ns))))))

--- a/tests/scheme/srfi/srfi174.scm
+++ b/tests/scheme/srfi/srfi174.scm
@@ -34,11 +34,15 @@
 (test #t (timespec>=? (timespec 1 5) (timespec 1 5)))
 (test #f (timespec>=? (timespec 0 5) (timespec 1 5)))
 
-;;; --- missing exports ---
-;; FAIL: #1235 (timespec-hash, timespec->inexact, inexact->timespec
-;;   not exported)
-;; (test #t (exact-integer? (timespec-hash (timespec 1 2))))
-;; (test 1.5 (timespec->inexact (timespec 1 500000000)))
-;; (test #t (timespec=? (timespec 1 500000000) (inexact->timespec 1.5)))
+;;; --- conversions and hashing ---
+(test 1.5 (timespec->inexact (timespec 1 500000000)))
+(test 0.0 (timespec->inexact (timespec 0 0)))
+(test #t (timespec=? (timespec 1 500000000) (inexact->timespec 1.5)))
+(test #t (timespec=? (timespec 0 0) (inexact->timespec 0.0)))
+(test #t (timespec=? (timespec -2 750000000) (inexact->timespec -1.25)))
+(test -1.25 (timespec->inexact (timespec -2 750000000)))
+(test #t (exact-integer? (timespec-hash (timespec 1 2))))
+(test #t (>= (timespec-hash (timespec 1 2)) 0))
+(test (timespec-hash (timespec 3 4)) (timespec-hash (timespec 3 4)))
 
 (test-end "srfi-174")


### PR DESCRIPTION
Closes #1235

## Summary
- Add three missing SRFI-174 procedures: `timespec->inexact`, `inexact->timespec`, `timespec-hash`
- `inexact->timespec` uses `floor` (not `truncate`) so nanoseconds stays non-negative, consistent with POSIX convention and the existing comparison operators
- Uncomment and expand tests (28 pass)

## Test plan
- [x] `zig build run -- tests/scheme/srfi/srfi174.scm` — 28/28 pass
- [x] `zig build test` — unit tests pass
- [x] Manual verification of issue reproduction (all three procedures work)
- [x] Negative-seconds round-trip: `(inexact->timespec -1.25)` → `(timespec -2 750000000)` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)