### PR TITLE
Export lazy and eager from SRFI-45

### DIFF
--- a/lib/srfi/45.sld
+++ b/lib/srfi/45.sld
@@ -1,4 +1,8 @@
 (define-library (srfi 45)
   (import (scheme base) (scheme lazy))
-  (export delay force delay-force make-promise promise?)
-  (begin))
+  (export delay force delay-force make-promise promise? lazy eager)
+  (begin
+    (define-syntax lazy
+      (syntax-rules ()
+        ((lazy expr) (delay-force expr))))
+    (define (eager x) (make-promise x))))

--- a/tests/scheme/srfi/srfi45.scm
+++ b/tests/scheme/srfi/srfi45.scm
@@ -30,11 +30,8 @@
 ;; "lazy: Takes an expression of type (Promise a) and returns a promise";
 ;; "eager: ... (eager expression) is equivalent to (let ((value expression))
 ;;  (delay value))"
-;; FAIL: #1207 (lazy and eager are not exported from (srfi 45))
-;; (test 1 (force (lazy (delay 1))))
-;; FAIL: #1207 (lazy and eager are not exported from (srfi 45))
-;; (test 2 (force (eager 2)))
-;; FAIL: #1207 (lazy and eager are not exported from (srfi 45))
-;; (test #t (promise? (eager 5)))
+(test 1 (force (lazy (delay 1))))
+(test 2 (force (eager 2)))
+(test #t (promise? (eager 5)))
 
 (test-end "srfi-45")


### PR DESCRIPTION
Closes #1207

## Summary
- Add `lazy` (syntax alias for `delay-force`) and `eager` (procedure wrapping `make-promise`) to `lib/srfi/45.sld`
- Enable the 3 previously disabled tests in `tests/scheme/srfi/srfi45.scm`

## Test plan
- [x] `zig build run -- tests/scheme/srfi/srfi45.scm` — 10/10 pass (3 newly enabled)
- [x] `zig build test` — all unit tests pass
- [x] Manual verification of issue reproduction case

🤖 Generated with [Claude Code](https://claude.com/claude-code)