### PR TITLE
Fix SRFI-1 take-right/drop-right to accept dotted lists (#1166)

### DIFF
--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -1108,55 +1108,52 @@ fn carCdrFn(args: []const Value) PrimitiveError!Value {
     return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
 }
 
-// (take-right list k)
+// (take-right list k) — flist may be proper or dotted
 fn takeRightFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("take-right", "integer", args[1]);
     const k = types.toFixnum(args[1]);
     if (k < 0) return primitives.typeError("take-right", "non-negative integer", args[1]);
-    // Find list length
-    var len: i64 = 0;
-    var current = args[0];
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return primitives.typeError("take-right", "pair", current);
-        current = types.cdr(current);
-        len += 1;
-    }
-    // drop (len - k) elements
-    const to_drop = len - k;
-    if (to_drop < 0) return primitives.typeError("take-right", "valid index (k <= length)", args[1]);
-    current = args[0];
+
+    // Advance lead pointer k steps
+    var lead = args[0];
     var i: i64 = 0;
-    while (i < to_drop) : (i += 1) {
-        current = types.cdr(current);
+    while (i < k) : (i += 1) {
+        if (!types.isPair(lead)) return primitives.typeError("take-right", "valid index (k <= length)", args[1]);
+        lead = types.cdr(lead);
     }
-    return current;
+
+    // Advance both until lead hits end (nil or dotted tail)
+    var lag = args[0];
+    while (types.isPair(lead)) {
+        lead = types.cdr(lead);
+        lag = types.cdr(lag);
+    }
+    return lag;
 }
 
-// (drop-right list k)
+// (drop-right list k) — flist may be proper or dotted
 fn dropRightFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[1])) return primitives.typeError("drop-right", "integer", args[1]);
     const k = types.toFixnum(args[1]);
     if (k < 0) return primitives.typeError("drop-right", "non-negative integer", args[1]);
-    // Find list length
-    var len: i64 = 0;
-    var current = args[0];
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return primitives.typeError("drop-right", "pair", current);
-        current = types.cdr(current);
-        len += 1;
-    }
-    const to_take = len - k;
-    if (to_take < 0) return primitives.typeError("drop-right", "valid index (k <= length)", args[1]);
-    const count: usize = @intCast(to_take);
 
+    // Advance lead pointer k steps
+    var lead = args[0];
+    var i: i64 = 0;
+    while (i < k) : (i += 1) {
+        if (!types.isPair(lead)) return primitives.typeError("drop-right", "valid index (k <= length)", args[1]);
+        lead = types.cdr(lead);
+    }
+
+    // Collect elements from lag while lead advances to end
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
-    current = args[0];
-    var i: usize = 0;
-    while (i < count) : (i += 1) {
-        elems.append(gc.allocator, types.car(current)) catch return PrimitiveError.OutOfMemory;
-        current = types.cdr(current);
+    var lag = args[0];
+    while (types.isPair(lead)) {
+        elems.append(gc.allocator, types.car(lag)) catch return PrimitiveError.OutOfMemory;
+        lead = types.cdr(lead);
+        lag = types.cdr(lag);
     }
 
     return buildList(gc, elems.items, types.NIL);

--- a/tests/scheme/audit/primitives_srfi1-audit.scm
+++ b/tests/scheme/audit/primitives_srfi1-audit.scm
@@ -46,10 +46,10 @@
 (test '(1 2 3) (drop-right '(1 2 3 4 5) 2))
 (test '((1 2) (3 4)) (call-with-values (lambda () (split-at '(1 2 3 4) 2)) list))
 (test #t (guard (e (#t #t)) (take '(1) 5)))
-;; FAIL: #1166 (take-right/drop-right reject dotted lists)
-;; (test '(2 3 . d) (take-right '(1 2 3 . d) 2))
-;; FAIL: #1166
-;; (test '(1) (drop-right '(1 2 3 . d) 2))
+(test '(2 3 . d) (take-right '(1 2 3 . d) 2))
+(test 'd (take-right '(1 2 3 . d) 0))
+(test '(1) (drop-right '(1 2 3 . d) 2))
+(test '(1 2 3) (drop-right '(1 2 3 . d) 0))
 
 ;;; --- span / break / partition return two values ---
 (test '((2 4) (1 3)) (call-with-values (lambda () (span even? '(2 4 1 3))) list))

--- a/tests/scheme/smoke/srfi1-take-drop-right-dotted.scm
+++ b/tests/scheme/smoke/srfi1-take-drop-right-dotted.scm
@@ -1,0 +1,22 @@
+;; Regression test for #1166: take-right/drop-right reject dotted lists
+(import (scheme base) (scheme write) (scheme process-context) (srfi 1) (srfi 64))
+
+(test-begin "srfi1-take-drop-right-dotted")
+
+;; SRFI-1 spec examples for dotted lists
+(test-equal "take-right dotted k=2" '(2 3 . d) (take-right '(1 2 3 . d) 2))
+(test-equal "take-right dotted k=0" 'd (take-right '(1 2 3 . d) 0))
+(test-equal "drop-right dotted k=2" '(1) (drop-right '(1 2 3 . d) 2))
+(test-equal "drop-right dotted k=0" '(1 2 3) (drop-right '(1 2 3 . d) 0))
+
+;; Proper lists still work
+(test-equal "take-right proper" '(4 5) (take-right '(1 2 3 4 5) 2))
+(test-equal "drop-right proper" '(1 2 3) (drop-right '(1 2 3 4 5) 2))
+(test-equal "take-right all" '(1 2 3) (take-right '(1 2 3) 3))
+(test-equal "drop-right all" '() (drop-right '(1 2 3) 3))
+(test-equal "take-right none" '() (take-right '(1 2 3) 0))
+(test-equal "drop-right none" '(1 2 3) (drop-right '(1 2 3) 0))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi1-take-drop-right-dotted")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Replace two-pass length-count approach in `take-right`/`drop-right` with a lead/lag two-pointer walk that naturally handles dotted tails
- Uncomment and expand the disabled audit tests for dotted-list cases
- Add dedicated regression test in `tests/scheme/smoke/`

Closes #1166

## Test plan

- [x] All four SRFI-1 spec examples pass: `(take-right '(1 2 3 . d) 2)`, `(take-right '(1 2 3 . d) 0)`, `(drop-right '(1 2 3 . d) 2)`, `(drop-right '(1 2 3 . d) 0)`
- [x] Proper-list behavior unchanged (take-right/drop-right on proper lists)
- [x] Edge cases: k=0, k=length
- [x] SRFI-1 audit suite: 109 pass, 0 fail
- [x] `zig build test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)