### PR TITLE
Fix SRFI-37 short optional-arg dropping trailing characters

### DIFF
--- a/lib/srfi/37.sld
+++ b/lib/srfi/37.sld
@@ -97,10 +97,16 @@
                                    (call-with-values
                                      (lambda () (apply (option-processor opt) opt ch a seeds))
                                      (lambda new-seeds (loop r new-seeds))))
-                                 (call-with-values
-                                   (lambda () (apply (option-processor opt) opt ch #f seeds))
-                                   (lambda new-seeds
-                                     (sloop (+ i 1) new-seeds rest))))
+                                 (if (and (option-optional-arg? opt)
+                                          (< (+ i 1) (string-length arg)))
+                                     (let ((a (substring arg (+ i 1) (string-length arg))))
+                                       (call-with-values
+                                         (lambda () (apply (option-processor opt) opt ch a seeds))
+                                         (lambda new-seeds (loop rest new-seeds))))
+                                     (call-with-values
+                                       (lambda () (apply (option-processor opt) opt ch #f seeds))
+                                       (lambda new-seeds
+                                         (sloop (+ i 1) new-seeds rest)))))
                              (call-with-values
                                (lambda () (apply unrecognized-proc
                                                  (%make-option (list ch) #f #f #f) ch #f seeds))

--- a/tests/scheme/srfi/srfi37.scm
+++ b/tests/scheme/srfi/srfi37.scm
@@ -112,6 +112,43 @@
 ;;; --- empty args ---
 (test-equal "empty args" 0 (args-fold '() opts unrec count-operand 0))
 
+;;; --- short optional-arg (#1350: trailing chars dropped) ---
+(define opt-p
+  (option '(#\p) #f #t
+          (lambda (opt name arg seed) (cons (list name arg) seed))))
+
+(test-equal "short optional-arg inline"
+  '((#\p "X"))
+  (args-fold '("-pX") (list opt-p)
+             (lambda (o n a s) s) (lambda (op s) s) '()))
+
+(test-equal "short optional-arg multi-char"
+  '((#\p "val"))
+  (args-fold '("-pval") (list opt-p)
+             (lambda (o n a s) s) (lambda (op s) s) '()))
+
+(test-equal "short optional-arg absent"
+  '((#\p #f))
+  (args-fold '("-p") (list opt-p)
+             (lambda (o n a s) s) (lambda (op s) s) '()))
+
+(test-equal "short optional-arg absent, next is operand"
+  '(("file") (#\p #f))
+  (args-fold '("-p" "file") (list opt-p)
+             (lambda (o n a s) s) (lambda (op s) (cons (list op) s)) '()))
+
+(test-equal "combined short, optional-arg last with value"
+  '((#\p "X") (#\v #f))
+  (let ((v (option '(#\v) #f #f (lambda (o n a s) (cons (list n a) s)))))
+    (args-fold '("-vpX") (list v opt-p)
+               (lambda (o n a s) s) (lambda (op s) s) '())))
+
+(test-equal "combined short, optional-arg last no value"
+  '((#\p #f) (#\v #f))
+  (let ((v (option '(#\v) #f #f (lambda (o n a s) (cons (list n a) s)))))
+    (args-fold '("-vp") (list v opt-p)
+               (lambda (o n a s) s) (lambda (op s) s) '())))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-37")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- Fix `args-fold` short-option parsing to check `option-optional-arg?` when trailing characters exist after the option letter, passing them as the argument instead of scanning them as further short options
- Add 6 regression tests covering short optional-arg inline, absent, with operand, and combined with other short options

Closes #1350

## Test plan
- [x] New regression tests pass (`tests/scheme/srfi/srfi37.scm` — 35 tests total)
- [x] Full test suite passes (1807 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)