### PR TITLE
Fix random-real open interval per SRFI-27 (#1195)

### DIFF
--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -66,8 +66,7 @@ fn randomRealFn(args: []const Value) PrimitiveError!Value {
     ensureDefaultRS();
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     const rs = try getRS("random-real", vm.default_random_source);
-    const r = rs.prng.random();
-    return types.makeFlonum(r.float(f64));
+    return types.makeFlonum(openUnitReal(rs));
 }
 
 fn defaultRandomSourceFn(args: []const Value) PrimitiveError!Value {
@@ -159,8 +158,14 @@ fn rsNextIntFn(args: []const Value) PrimitiveError!Value {
 // (%rs-next-real rs) — used by random-source-make-reals closure
 fn rsNextRealFn(args: []const Value) PrimitiveError!Value {
     const rs = try getRS("%rs-next-real", args[0]);
-    const r = rs.prng.random();
-    return types.makeFlonum(r.float(f64));
+    return types.makeFlonum(openUnitReal(rs));
+}
+
+// SRFI-27 requires 0 < x < 1 (open interval); Zig's float(f64) returns [0, 1).
+fn openUnitReal(rs: *types.RandomSource) f64 {
+    var x = rs.prng.random().float(f64);
+    while (x == 0.0) x = rs.prng.random().float(f64);
+    return x;
 }
 
 fn randomBelow(proc: []const u8, rs: *types.RandomSource, bound: Value) PrimitiveError!Value {

--- a/tests/scheme/coverage/random-coverage.scm
+++ b/tests/scheme/coverage/random-coverage.scm
@@ -25,7 +25,7 @@
 
 ;;; ---- random-real ----
 (let ((r (random-real)))
-  (check-true "random-real >= 0" (>= r 0.0))
+  (check-true "random-real > 0" (> r 0.0))
   (check-true "random-real < 1" (< r 1.0)))
 
 ;;; ---- default-random-source ----


### PR DESCRIPTION
## Summary
- SRFI-27 requires `random-real` to return values in the open interval (0, 1), but Zig's `std.Random.float(f64)` returns [0, 1) — 0.0 is theoretically possible (~2^-1022 probability)
- Add `openUnitReal()` retry-loop helper, used by both `randomRealFn` and `rsNextRealFn`
- Tighten coverage test assertion from `>=` to `>`

Closes #1195

## Test plan
- [x] `zig build test` passes
- [x] `primitives_random-audit.scm` passes (54/54)
- [x] Coverage test updated to assert `(> r 0.0)` instead of `(>= r 0.0)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)