### PR TITLE
Fix SRFI-133 vector-skip/vector-skip-right multi-vector form (#1171)

### DIFF
--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -30,8 +30,8 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "vector-every", .func = &vectorEveryFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_133) },
     .{ .name = "vector-index", .func = &vectorIndexFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_133) },
     .{ .name = "vector-index-right", .func = &vectorIndexRightFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_133) },
-    .{ .name = "vector-skip", .func = &vectorSkipFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_133) },
-    .{ .name = "vector-skip-right", .func = &vectorSkipRightFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_133) },
+    .{ .name = "vector-skip", .func = &vectorSkipFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_133) },
+    .{ .name = "vector-skip-right", .func = &vectorSkipRightFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_133) },
     .{ .name = "vector-swap!", .func = &vectorSwapFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.srfi_133) },
     .{ .name = "vector-reverse!", .func = &vectorReverseBangFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_133) },
     .{ .name = "vector-reverse-copy", .func = &vectorReverseCopyFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_133) },
@@ -586,12 +586,28 @@ fn vectorIndexRightFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-skip pred v1 ...) — index of first element NOT satisfying pred
 fn vectorSkipFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     if (!types.isVector(args[1])) return primitives.typeError("vector-skip", "vector", args[1]);
     const vec = types.toVector(args[1]);
+    const total_args = args.len - 1;
+    var stack_buf: [256]Value = undefined;
+    const call_args_buf = if (total_args > 256)
+        gc.allocator.alloc(Value, total_args) catch return PrimitiveError.OutOfMemory
+    else
+        stack_buf[0..total_args];
+    defer if (total_args > 256) gc.allocator.free(call_args_buf);
     for (0..vec.data.len) |i| {
-        const call_args_buf = [1]Value{vec.data[i]};
-        const result = try callVM(pred, &call_args_buf);
+        call_args_buf[0] = vec.data[i];
+        var arg_count: usize = 1;
+        for (args[2..]) |extra| {
+            if (!types.isVector(extra)) return primitives.typeError("vector-skip", "vector", extra);
+            const ev = types.toVector(extra);
+            if (i >= ev.data.len) return types.FALSE;
+            call_args_buf[arg_count] = ev.data[i];
+            arg_count += 1;
+        }
+        const result = try callVM(pred, call_args_buf[0..arg_count]);
         if (!types.isTruthy(result)) return types.makeFixnum(@intCast(i));
     }
     return types.FALSE;
@@ -599,14 +615,34 @@ fn vectorSkipFn(args: []const Value) PrimitiveError!Value {
 
 // (vector-skip-right pred v1 ...)
 fn vectorSkipRightFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const pred = args[0];
     if (!types.isVector(args[1])) return primitives.typeError("vector-skip-right", "vector", args[1]);
     const vec = types.toVector(args[1]);
-    var i = vec.data.len;
+    var min_len: usize = vec.data.len;
+    for (args[2..]) |extra| {
+        if (!types.isVector(extra)) return primitives.typeError("vector-skip-right", "vector", extra);
+        const ev = types.toVector(extra);
+        if (ev.data.len < min_len) min_len = ev.data.len;
+    }
+    const total_args = args.len - 1;
+    var stack_buf: [256]Value = undefined;
+    const call_args_buf = if (total_args > 256)
+        gc.allocator.alloc(Value, total_args) catch return PrimitiveError.OutOfMemory
+    else
+        stack_buf[0..total_args];
+    defer if (total_args > 256) gc.allocator.free(call_args_buf);
+    var i = min_len;
     while (i > 0) {
         i -= 1;
-        const call_args_buf = [1]Value{vec.data[i]};
-        const result = try callVM(pred, &call_args_buf);
+        call_args_buf[0] = vec.data[i];
+        var arg_count: usize = 1;
+        for (args[2..]) |extra| {
+            const ev = types.toVector(extra);
+            call_args_buf[arg_count] = ev.data[i];
+            arg_count += 1;
+        }
+        const result = try callVM(pred, call_args_buf[0..arg_count]);
         if (!types.isTruthy(result)) return types.makeFixnum(@intCast(i));
     }
     return types.FALSE;

--- a/tests/scheme/audit/primitives_vector-audit.scm
+++ b/tests/scheme/audit/primitives_vector-audit.scm
@@ -217,11 +217,8 @@
 (test 0 (vector-skip symbol? #(1 2 3)))
 (test 2 (vector-skip-right number? #(1 a b 2)))   ; b at index 2 is first non-number from the right
 (test 'caught (guard (e (#t 'caught)) (vector-skip number? '(1))))
-;; SRFI-133: (vector-skip pred? vec1 vec2 ...) accepts multiple vectors;
-;; registered with exact arity 2 so the multi-vector form raises an arity error.
-;; FAIL: #1171 (vector-skip/vector-skip-right reject the multi-vector form)
-;; (test 2 (vector-skip = #(1 2 3 4 5) #(1 2 -3 4)))
-;; (test 2 (vector-skip-right = #(1 2 3 4 5) #(1 2 -3 4 5)))
+(test 2 (vector-skip = #(1 2 3 4 5) #(1 2 -3 4)))
+(test 2 (vector-skip-right = #(1 2 3 4 5) #(1 2 -3 4 5)))
 
 ;;; --- SRFI-133: vector-swap! ---
 (test #(3 2 1) (let ((v (vector 1 2 3))) (vector-swap! v 0 2) v))


### PR DESCRIPTION
## Summary
- Change `vector-skip` and `vector-skip-right` arity from `.exact = 2` to `.variadic = 2` to accept multiple vectors per SRFI-133
- Implement multi-vector loop pattern (matching existing `vector-index` / `vector-index-right`)
- Enable previously disabled audit tests for the multi-vector form

Closes #1171

## Test plan
- [x] `zig build test` passes
- [x] `primitives_vector-audit.scm` passes (182/182, including 2 newly enabled multi-vector tests)
- [x] Manual verification of exact reproduction cases from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)