### PR TITLE
Fix SRFI-13 wrong-typed optional args silently ignored (#1159)

### DIFF
--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -501,7 +501,10 @@ fn stringPadFn(args: []const Value) PrimitiveError!Value {
     if (tlv < 0) return primitives.typeError("string-pad", "non-negative integer", args[1]);
     const target_len: usize = @intCast(tlv);
     var pad_buf: [4]u8 = undefined;
-    const pad_cp: u21 = if (args.len > 2 and types.isChar(args[2])) types.toChar(args[2]) else ' ';
+    const pad_cp: u21 = if (args.len > 2) blk: {
+        if (!types.isChar(args[2])) return primitives.typeError("string-pad", "char", args[2]);
+        break :blk types.toChar(args[2]);
+    } else ' ';
     const pad_len = std.unicode.utf8Encode(pad_cp, &pad_buf) catch
         return primitives.typeError("string-pad", "valid character", args[2]);
     const range = try parseStartEnd(full_data, args, 3);
@@ -529,7 +532,10 @@ fn stringPadRightFn(args: []const Value) PrimitiveError!Value {
     if (tlv < 0) return primitives.typeError("string-pad-right", "non-negative integer", args[1]);
     const target_len: usize = @intCast(tlv);
     var pad_buf: [4]u8 = undefined;
-    const pad_cp: u21 = if (args.len > 2 and types.isChar(args[2])) types.toChar(args[2]) else ' ';
+    const pad_cp: u21 = if (args.len > 2) blk: {
+        if (!types.isChar(args[2])) return primitives.typeError("string-pad-right", "char", args[2]);
+        break :blk types.toChar(args[2]);
+    } else ' ';
     const pad_len = std.unicode.utf8Encode(pad_cp, &pad_buf) catch
         return primitives.typeError("string-pad-right", "valid character", args[2]);
     const range = try parseStartEnd(full_data, args, 3);
@@ -845,7 +851,8 @@ fn stringUnfoldFn(args: []const Value) PrimitiveError!Value {
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(gc.allocator);
 
-    if (args.len > 4 and types.isString(args[4])) {
+    if (args.len > 4) {
+        if (!types.isString(args[4])) return primitives.typeError("string-unfold", "string", args[4]);
         const base = types.toObject(args[4]).as(types.SchemeString);
         result.appendSlice(gc.allocator, base.data[0..base.len]) catch return PrimitiveError.OutOfMemory;
     }
@@ -863,10 +870,9 @@ fn stringUnfoldFn(args: []const Value) PrimitiveError!Value {
 
     if (args.len > 5) {
         const final_val = try callVM(args[5], &[1]Value{seed});
-        if (types.isString(final_val)) {
-            const fs = types.toObject(final_val).as(types.SchemeString);
-            result.appendSlice(gc.allocator, fs.data[0..fs.len]) catch return PrimitiveError.OutOfMemory;
-        }
+        if (!types.isString(final_val)) return primitives.typeError("string-unfold", "string", final_val);
+        const fs = types.toObject(final_val).as(types.SchemeString);
+        result.appendSlice(gc.allocator, fs.data[0..fs.len]) catch return PrimitiveError.OutOfMemory;
     }
     return gc.allocString(result.items) catch return PrimitiveError.OutOfMemory;
 }
@@ -898,10 +904,9 @@ fn stringUnfoldRightFn(args: []const Value) PrimitiveError!Value {
 
     if (args.len > 5) {
         const final_val = try callVM(args[5], &[1]Value{seed});
-        if (types.isString(final_val)) {
-            const fs = types.toObject(final_val).as(types.SchemeString);
-            result.appendSlice(gc.allocator, fs.data[0..fs.len]) catch return PrimitiveError.OutOfMemory;
-        }
+        if (!types.isString(final_val)) return primitives.typeError("string-unfold-right", "string", final_val);
+        const fs = types.toObject(final_val).as(types.SchemeString);
+        result.appendSlice(gc.allocator, fs.data[0..fs.len]) catch return PrimitiveError.OutOfMemory;
     }
 
     var i = chars.items.len;
@@ -912,7 +917,8 @@ fn stringUnfoldRightFn(args: []const Value) PrimitiveError!Value {
         result.appendSlice(gc.allocator, tmp[0..n]) catch return PrimitiveError.OutOfMemory;
     }
 
-    if (args.len > 4 and types.isString(args[4])) {
+    if (args.len > 4) {
+        if (!types.isString(args[4])) return primitives.typeError("string-unfold-right", "string", args[4]);
         const base = types.toObject(args[4]).as(types.SchemeString);
         result.appendSlice(gc.allocator, base.data[0..base.len]) catch return PrimitiveError.OutOfMemory;
     }

--- a/tests/scheme/audit/primitives_string_ext-audit.scm
+++ b/tests/scheme/audit/primitives_string_ext-audit.scm
@@ -75,8 +75,8 @@
 (test "**x" (string-pad "x" 3 #\*))
 (test "\x3BB;\x3BB;x" (string-pad "x" 3 #\x3BB)) ; multibyte pad char
 (test "" (string-pad "abc" 0))
-;; FAIL: #1159 (non-char pad argument silently ignored)
-;; (test #t (guard (e (#t #t)) (string-pad "x" 5 "*") #f))
+(test #t (guard (e (#t #t)) (string-pad "x" 5 "*") #f))
+(test #t (guard (e (#t #t)) (string-pad-right "x" 5 "*") #f))
 
 ;;; --- reverse / filter / delete / replace / titlecase ---
 (test "cba" (string-reverse "abc"))
@@ -124,10 +124,20 @@
   (string-tabulate (lambda (i) (error "cb")) 2)))
 (test 'caught (guard (e (#t 'caught))
   (string-every (lambda (c) (error "cb")) "abc")))
-;; FAIL: #1159 (non-string base silently ignored)
-;; (test #t (guard (e (#t #t))
-;;   (string-unfold (lambda (s) (> s 2)) (lambda (s) #\a) (lambda (s) (+ s 1)) 0 #\Z)
-;;   #f))
+(test #t (guard (e (#t #t))
+  (string-unfold (lambda (s) (> s 2)) (lambda (s) #\a) (lambda (s) (+ s 1)) 0 #\Z)
+  #f))
+(test #t (guard (e (#t #t))
+  (string-unfold-right (lambda (s) (> s 2)) (lambda (s) #\a) (lambda (s) (+ s 1)) 0 #\Z)
+  #f))
+(test #t (guard (e (#t #t))
+  (string-unfold (lambda (s) #t) (lambda (s) #\a) (lambda (s) s) 0
+                 "" (lambda (s) 42))
+  #f))
+(test #t (guard (e (#t #t))
+  (string-unfold-right (lambda (s) #t) (lambda (s) #\a) (lambda (s) s) 0
+                       "" (lambda (s) 42))
+  #f))
 
 ;;; --- type errors are catchable, not crashes ---
 (test #t (guard (e (#t #t)) (string-contains 42 "x")))


### PR DESCRIPTION
## Summary

- `string-pad` / `string-pad-right`: a non-char pad argument (e.g. `"*"` instead of `#\*`) was silently ignored, defaulting to space. Now raises a type error.
- `string-unfold` / `string-unfold-right`: a non-string `base` argument (e.g. `#\Z`) was silently skipped. Now raises a type error.
- `string-unfold` / `string-unfold-right`: a `make-final` callback returning a non-string value was silently dropped. Now raises a type error.

All six sites followed the same pattern: `if (args.len > N and types.isXxx(args[N]))` treated wrong-typed arguments as absent instead of erroring.

Closes #1159

## Test plan

- [x] Uncommented the two `FAIL: #1159` markers in `primitives_string_ext-audit.scm`
- [x] Added 4 new tests covering `string-pad-right`, `string-unfold-right` base, and both `make-final` return value checks
- [x] All 95 audit tests pass
- [x] Full Scheme test suite: 1808 pass, 0 fail
- [x] Zig unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)