### PR TITLE
Export owner/unchanged and group/unchanged constants from SRFI-170 (#1163)

### DIFF
--- a/src/library.zig
+++ b/src/library.zig
@@ -112,6 +112,8 @@ const extra_exports = [_]ExtraExport{
     .{ .name = "current-input-port", .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "current-output-port", .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "current-error-port", .libs = LS.initOne(.scheme_base) },
+    .{ .name = "owner/unchanged", .libs = LS.initOne(.srfi_170) },
+    .{ .name = "group/unchanged", .libs = LS.initOne(.srfi_170) },
 };
 
 fn addExportsForLib(library: *Library, lib: Lib, globals: *std.StringHashMap(Value), sandboxed: bool) !void {

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -210,8 +210,10 @@ pub fn registerAll(vm: *vm_mod.VM) !void {
         if (!is_wasm or spec.wasm)
             try reg(vm, spec.name, spec.func, spec.arity);
     }
-    try vm.defineGlobal("owner/unchanged", types.makeFixnum(-1));
-    try vm.defineGlobal("group/unchanged", types.makeFixnum(-1));
+    if (comptime !is_wasm) {
+        try vm.defineGlobal("owner/unchanged", types.makeFixnum(-1));
+        try vm.defineGlobal("group/unchanged", types.makeFixnum(-1));
+    }
 }
 
 pub fn registerSandboxed(vm: *vm_mod.VM) !void {

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -210,6 +210,8 @@ pub fn registerAll(vm: *vm_mod.VM) !void {
         if (!is_wasm or spec.wasm)
             try reg(vm, spec.name, spec.func, spec.arity);
     }
+    try vm.defineGlobal("owner/unchanged", types.makeFixnum(-1));
+    try vm.defineGlobal("group/unchanged", types.makeFixnum(-1));
 }
 
 pub fn registerSandboxed(vm: *vm_mod.VM) !void {

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -72,9 +72,8 @@
 ;; chown to self is always permitted (spec: 3-arg chown-style signature)
 (test #t (begin (set-file-owner (string-append D "/a.txt") (user-uid) (user-gid)) #t))
 (test #t (begin (set-file-times (string-append D "/a.txt")) #t))
-;; FAIL: #1163 (owner/unchanged, group/unchanged constants not exported)
-;; (test #t (begin (set-file-owner (string-append D "/a.txt")
-;;                                 owner/unchanged group/unchanged) #t))
+(test #t (begin (set-file-owner (string-append D "/a.txt")
+                                owner/unchanged group/unchanged) #t))
 
 ;;; --- temp files ---
 (test #t (procedure? temp-file-prefix))     ; parameter object

--- a/tests/scheme/srfi/srfi-170-chown-constants.scm
+++ b/tests/scheme/srfi/srfi-170-chown-constants.scm
@@ -1,0 +1,30 @@
+;; Regression test for #1163: owner/unchanged and group/unchanged constants
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 170))
+
+(test-begin "srfi-170-chown-constants")
+
+;; Constants must be exported and equal to -1 (POSIX "unchanged" sentinel)
+(test-equal "owner/unchanged is -1" -1 owner/unchanged)
+(test-equal "group/unchanged is -1" -1 group/unchanged)
+
+;; set-file-owner with both unchanged should be a no-op
+(let ((tmp (create-temp-file)))
+  (test-assert "set-file-owner with unchanged constants"
+    (begin (set-file-owner tmp owner/unchanged group/unchanged) #t))
+  (delete-file tmp))
+
+;; set-file-owner with only owner unchanged
+(let ((tmp (create-temp-file)))
+  (test-assert "set-file-owner owner/unchanged keeps owner"
+    (begin (set-file-owner tmp owner/unchanged (user-gid)) #t))
+  (delete-file tmp))
+
+;; set-file-owner with only group unchanged
+(let ((tmp (create-temp-file)))
+  (test-assert "set-file-owner group/unchanged keeps group"
+    (begin (set-file-owner tmp (user-uid) group/unchanged) #t))
+  (delete-file tmp))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-170-chown-constants")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary
- Define `owner/unchanged` and `group/unchanged` as fixnum(-1) globals, exported from `(srfi 170)`
- These SRFI-170 constants let `set-file-owner` express partial chown (change only owner or only group)
- Enable the previously disabled audit test for these constants

## Test plan
- [x] New `tests/scheme/srfi/srfi-170-chown-constants.scm` — verifies constants are -1 and `set-file-owner` accepts them
- [x] Re-enabled audit test in `primitives_filesystem-audit.scm` passes
- [x] `zig build test` passes
- [x] Full audit suite passes

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)