### PR TITLE
Skip stress tests in Debug CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
           - os: ubuntu-latest
             optimize: Debug
             timeout: 30
-            skip_stress: "callcc-bench.scm r7rs-tail-procedures-gaps.scm r7rs-thin-forms-gaps.scm"
           - os: ubuntu-latest
             optimize: ReleaseFast
 
@@ -72,7 +71,7 @@ jobs:
       - name: Scheme suites
         run: bash tests/scheme/run-all.sh
         env:
-          KAAPPI_TEST_SKIP: ${{ matrix.skip_stress || '' }}
+          KAAPPI_TEST_SKIP: ${{ matrix.optimize == 'Debug' && 'callcc-bench.scm r7rs-tail-procedures-gaps.scm r7rs-thin-forms-gaps.scm' || '' }}
 
       - name: Sandbox escape tests
         run: bash tests/scheme/sandbox/sandbox-escape.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Scheme suites
         run: bash tests/scheme/run-all.sh
         env:
-          KAAPPI_SKIP: ${{ matrix.skip_stress || '' }}
+          KAAPPI_TEST_SKIP: ${{ matrix.skip_stress || '' }}
 
       - name: Sandbox escape tests
         run: bash tests/scheme/sandbox/sandbox-escape.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           - os: ubuntu-latest
             optimize: Debug
             timeout: 30
+            skip_stress: "callcc-bench.scm r7rs-tail-procedures-gaps.scm r7rs-thin-forms-gaps.scm"
           - os: ubuntu-latest
             optimize: ReleaseFast
 
@@ -70,6 +71,8 @@ jobs:
 
       - name: Scheme suites
         run: bash tests/scheme/run-all.sh
+        env:
+          KAAPPI_SKIP: ${{ matrix.skip_stress || '' }}
 
       - name: Sandbox escape tests
         run: bash tests/scheme/sandbox/sandbox-escape.sh

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -57,6 +57,12 @@
 bash tests/scheme/run-all.sh              # all suites (60s timeout per file)
 zig build run -- tests/scheme/smoke/foo.scm  # single file
 zig build run -- tests/scheme/r7rs/r7rs-tests.scm  # full R7RS suite
+
+# Override per-file timeout (default 60s)
+KAAPPI_TEST_TIMEOUT=120 bash tests/scheme/run-all.sh
+
+# Skip specific files (space-separated basenames)
+KAAPPI_TEST_SKIP="callcc-bench.scm" bash tests/scheme/run-all.sh
 ```
 
 ## Quirks

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -93,6 +93,7 @@ run_suite() {
                 if should_skip "$file"; then
                     echo "  SKIP  $file"
                     SKIPPED=$((SKIPPED + 1))
+                    matched=1
                     continue
                 fi
                 matched=1

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -15,10 +15,23 @@ TMPSTDOUT=$(mktemp /tmp/kaappi-r7rs-stdout-XXXXXX)
 TMPSTDERR=$(mktemp /tmp/kaappi-r7rs-stderr-XXXXXX)
 trap 'rm -f "$TMPOUT" "$TMPSTDOUT" "$TMPSTDERR"' EXIT
 
-TIMEOUT=60
+TIMEOUT="${KAAPPI_TIMEOUT:-60}"
 PASS=0
 FAIL=0
 TIMEDOUT=0
+SKIPPED=0
+
+# Space-separated basenames to skip (e.g. KAAPPI_SKIP="callcc-bench.scm foo.scm")
+SKIP="${KAAPPI_SKIP:-}"
+
+should_skip() {
+    local base
+    base=$(basename "$1")
+    for s in $SKIP; do
+        if [[ "$base" == "$s" ]]; then return 0; fi
+    done
+    return 1
+}
 R7RS_PASS=0
 R7RS_FAIL=0
 R7RS_STATUS_FAIL=0
@@ -77,6 +90,11 @@ run_suite() {
     for pattern in "$@"; do
         for file in $pattern; do
             if [[ -e "$file" ]]; then
+                if should_skip "$file"; then
+                    echo "  SKIP  $file"
+                    SKIPPED=$((SKIPPED + 1))
+                    continue
+                fi
                 matched=1
                 run_file "$file"
             fi
@@ -152,9 +170,9 @@ fi
 
 echo ""
 echo "=== Summary ==="
-echo "  Scheme files: $PASS pass, $FAIL fail, $TIMEDOUT timeout"
+echo "  Scheme files: $PASS pass, $FAIL fail, $TIMEDOUT timeout, $SKIPPED skipped"
 echo "  R7RS suite:   $R7RS_PASS pass, $R7RS_FAIL fail"
-echo "  Total:        $((PASS + R7RS_PASS)) pass, $((FAIL + R7RS_FAIL + R7RS_STATUS_FAIL + TIMEDOUT)) fail ($TIMEDOUT from timeouts)"
+echo "  Total:        $((PASS + R7RS_PASS)) pass, $((FAIL + R7RS_FAIL + R7RS_STATUS_FAIL + TIMEDOUT)) fail ($TIMEDOUT from timeouts, $SKIPPED skipped)"
 
 if [[ $FAIL -gt 0 || $TIMEDOUT -gt 0 || $R7RS_FAIL -gt 0 || $R7RS_STATUS_FAIL -gt 0 ]]; then
     exit 1

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -15,14 +15,14 @@ TMPSTDOUT=$(mktemp /tmp/kaappi-r7rs-stdout-XXXXXX)
 TMPSTDERR=$(mktemp /tmp/kaappi-r7rs-stderr-XXXXXX)
 trap 'rm -f "$TMPOUT" "$TMPSTDOUT" "$TMPSTDERR"' EXIT
 
-TIMEOUT="${KAAPPI_TIMEOUT:-60}"
+TIMEOUT="${KAAPPI_TEST_TIMEOUT:-60}"
 PASS=0
 FAIL=0
 TIMEDOUT=0
 SKIPPED=0
 
-# Space-separated basenames to skip (e.g. KAAPPI_SKIP="callcc-bench.scm foo.scm")
-SKIP="${KAAPPI_SKIP:-}"
+# Space-separated basenames to skip (e.g. KAAPPI_TEST_SKIP="callcc-bench.scm foo.scm")
+SKIP="${KAAPPI_TEST_SKIP:-}"
 
 should_skip() {
     local base


### PR DESCRIPTION
## Summary

Fixes #1364.

- Add `KAAPPI_SKIP` env var to `run-all.sh` — space-separated list of filenames to skip
- Add `KAAPPI_TIMEOUT` env var to override the default 60s per-file timeout
- CI Debug matrix entry sets `KAAPPI_SKIP` to skip the 3 stress files that exceed 60s under Debug builds (`callcc-bench.scm`, `r7rs-tail-procedures-gaps.scm`, `r7rs-thin-forms-gaps.scm`)
- All Release builds (ReleaseSafe, ReleaseFast, macOS, ARM) still run every test

## Test plan

- [x] Full `run-all.sh` passes locally with `KAAPPI_SKIP` set (410 pass, 3 skipped, 0 fail)
- [x] Skip logic unit-tested: matches correct files, ignores non-matching, no-ops when `KAAPPI_SKIP` is empty
- [ ] CI Debug build no longer times out on these 3 files
- [ ] CI Release builds still run all files (no `KAAPPI_SKIP` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)