### PR TITLE
Fix string-trim default criterion to use Unicode whitespace (#826)

### DIFF
--- a/src/primitives_char.zig
+++ b/src/primitives_char.zig
@@ -62,7 +62,7 @@ pub fn isUnicodeCased(cp: u21) bool {
     return unicode.inRanges(&unicode.cased_ranges, cp);
 }
 
-fn isUnicodeWhitespace(cp: u21) bool {
+pub fn isUnicodeWhitespace(cp: u21) bool {
     if (cp <= 127) {
         return switch (cp) {
             0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x20 => true,

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -94,10 +94,6 @@ fn stringSuffixPFn(args: []const Value) PrimitiveError!Value {
     return if (std.mem.endsWith(u8, s2_range.data, s1_range.data)) types.TRUE else types.FALSE;
 }
 
-fn isWhitespace(c: u8) bool {
-    return c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == 0x0B or c == 0x0C;
-}
-
 /// Call a predicate or char-set-contains? with a character.
 /// Handles both procedure arguments and SRFI-14 char-set record arguments.
 fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
@@ -169,7 +165,11 @@ fn stringTrimFn(args: []const Value) PrimitiveError!Value {
     const full_data = try getStringSlice("string-trim", args[0]);
     if (args.len <= 1) {
         var start: usize = 0;
-        while (start < full_data.len and isWhitespace(full_data[start])) start += 1;
+        while (start < full_data.len) {
+            const d = decodeForward(full_data, start);
+            if (d.len == 0 or !pchar.isUnicodeWhitespace(d.cp)) break;
+            start += d.len;
+        }
         return gc.allocString(full_data[start..]) catch return PrimitiveError.OutOfMemory;
     }
     const pred = args[1];
@@ -191,7 +191,12 @@ fn stringTrimRightFn(args: []const Value) PrimitiveError!Value {
     const full_data = try getStringSlice("string-trim-right", args[0]);
     if (args.len <= 1) {
         var end: usize = full_data.len;
-        while (end > 0 and isWhitespace(full_data[end - 1])) end -= 1;
+        while (end > 0) {
+            const cp_start = findPrevCpStart(full_data, end);
+            const d = decodeForward(full_data, cp_start);
+            if (d.len == 0 or !pchar.isUnicodeWhitespace(d.cp)) break;
+            end = cp_start;
+        }
         return gc.allocString(full_data[0..end]) catch return PrimitiveError.OutOfMemory;
     }
     const pred = args[1];
@@ -214,9 +219,18 @@ fn stringTrimBothFn(args: []const Value) PrimitiveError!Value {
     const full_data = try getStringSlice("string-trim-both", args[0]);
     if (args.len <= 1) {
         var start: usize = 0;
-        while (start < full_data.len and isWhitespace(full_data[start])) start += 1;
+        while (start < full_data.len) {
+            const d = decodeForward(full_data, start);
+            if (d.len == 0 or !pchar.isUnicodeWhitespace(d.cp)) break;
+            start += d.len;
+        }
         var end: usize = full_data.len;
-        while (end > start and isWhitespace(full_data[end - 1])) end -= 1;
+        while (end > start) {
+            const cp_start = findPrevCpStart(full_data, end);
+            const d = decodeForward(full_data, cp_start);
+            if (d.len == 0 or !pchar.isUnicodeWhitespace(d.cp)) break;
+            end = cp_start;
+        }
         return gc.allocString(full_data[start..end]) catch return PrimitiveError.OutOfMemory;
     }
     const pred = args[1];

--- a/tests/scheme/smoke/trim-whitespace.scm
+++ b/tests/scheme/smoke/trim-whitespace.scm
@@ -1,0 +1,53 @@
+;;; Regression test for #826: string-trim default criterion must match
+;;; char-whitespace? (Unicode White_Space property), not just SP/TAB/CR/LF.
+
+(import (scheme base) (scheme write) (scheme char) (srfi 13))
+
+(define pass 0)
+(define fail 0)
+
+(define-syntax check
+  (syntax-rules ()
+    ((_ expr expected name)
+     (let ((result expr))
+       (if (equal? result expected)
+           (set! pass (+ pass 1))
+           (begin
+             (set! fail (+ fail 1))
+             (display "FAIL: ") (display name) (newline)
+             (display "  expected: ") (write expected) (newline)
+             (display "  got:      ") (write result) (newline)))))))
+
+;; Vertical tab and form feed (single-byte, missed before 0x0B/0x0C fix)
+(check (string-trim "\x0B;\x0C;hi")       "hi"  "trim VT/FF left")
+(check (string-trim-right "hi\x0B;\x0C;") "hi"  "trim-right VT/FF")
+(check (string-trim-both "\x0B;hi\x0C;")  "hi"  "trim-both VT/FF")
+
+;; Multi-byte Unicode whitespace: NBSP (U+00A0)
+(check (string-trim "\x00A0;hi")       "hi"  "trim NBSP left")
+(check (string-trim-right "hi\x00A0;") "hi"  "trim-right NBSP")
+(check (string-trim-both "\x00A0;hi\x00A0;") "hi" "trim-both NBSP")
+
+;; EM SPACE (U+2003)
+(check (string-trim "\x2003;hi")       "hi"  "trim EM SPACE left")
+(check (string-trim-right "hi\x2003;") "hi"  "trim-right EM SPACE")
+
+;; IDEOGRAPHIC SPACE (U+3000)
+(check (string-trim "\x3000;hi")       "hi"  "trim IDEOGRAPHIC SPACE left")
+(check (string-trim-right "hi\x3000;") "hi"  "trim-right IDEOGRAPHIC SPACE")
+
+;; Mixed: regular space + NBSP + content + EM SPACE + tab
+(check (string-trim-both " \x00A0;hello\x2003;\t") "hello" "trim-both mixed")
+
+;; Default criterion must agree with explicit char-whitespace?
+(check (string-trim "\x0B;\x0C;hi" char-whitespace?) "hi"
+       "trim with explicit char-whitespace? (VT/FF)")
+(check (string-trim "\x00A0;hi" char-whitespace?) "hi"
+       "trim with explicit char-whitespace? (NBSP)")
+
+;; Empty / all-whitespace strings
+(check (string-trim "   ") "" "trim all-space")
+(check (string-trim-both "\x00A0;\x2003;\x3000;") "" "trim-both all-unicode-ws")
+
+(display pass) (display "/") (display (+ pass fail)) (display " passed") (newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

- Replace byte-level `isWhitespace(u8)` fast path in `string-trim`, `string-trim-right`, and `string-trim-both` with codepoint-decoding loops that call `isUnicodeWhitespace(u21)` — the same function backing `char-whitespace?`
- Make `isUnicodeWhitespace` pub in `primitives_char.zig` so `primitives_string_ext.zig` can call it
- Remove the now-unused `isWhitespace` helper

Fixes #826

## Test plan

- [x] 15 new regression tests in `tests/scheme/smoke/trim-whitespace.scm` covering VT/FF, NBSP, EM SPACE, IDEOGRAPHIC SPACE, mixed whitespace, and agreement with explicit `char-whitespace?`
- [x] Zig unit tests pass
- [x] Full Scheme suite passes (1813/1813)

🤖 Generated with [Claude Code](https://claude.com/claude-code)