### PR TITLE
Add descriptive FFI call-time error messages (#1187)

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -41,6 +41,8 @@ fn schemeTypeName(v: Value) []const u8 {
     if (types.isNil(v)) return "nil";
     if (types.isPair(v)) return "pair";
     if (types.isSymbol(v)) return "symbol";
+    if (types.isVector(v)) return "vector";
+    if (types.isClosure(v) or types.isNativeFn(v)) return "procedure";
     return "object";
 }
 
@@ -280,6 +282,11 @@ fn validateArgsDetailed(ffi_fn: *types.FfiFunction, args: []const Value, vm: *VM
                     });
                     return error.TypeError;
                 }
+            } else {
+                vm.setErrorDetail("'{s}': argument {d} out of range for {s}", .{
+                    ffi_fn.name, i + 1, ffiTypeName(ffi_fn.param_types[i]),
+                });
+                return error.TypeError;
             }
         }
         if (nt == .string) {
@@ -436,6 +443,7 @@ fn callFfiGeneric(comptime N: u4, ffi_fn: *types.FfiFunction, args: []const Valu
 
 /// Main FFI call dispatcher. Routes to arity-specific handlers.
 pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC, vm: *VM) !Value {
+    vm.last_error_detail_len = 0;
     if (types.isFfiLibrary(ffi_fn.library)) {
         const lib = types.toObject(ffi_fn.library).as(types.FfiLibrary);
         if (lib.handle == null) {

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -1,8 +1,48 @@
 const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const VM = @import("vm.zig").VM;
 const Value = types.Value;
 const FfiType = types.FfiType;
+
+fn ffiTypeName(t: FfiType) []const u8 {
+    return switch (t) {
+        .int => "int",
+        .long => "long",
+        .double => "double",
+        .float => "float",
+        .string => "string",
+        .pointer => "pointer",
+        .void_type => "void",
+        .bool_type => "bool",
+        .uint8 => "uint8",
+        .int8 => "int8",
+        .int16 => "int16",
+        .int32 => "int32",
+        .int64 => "int64",
+        .uint16 => "uint16",
+        .uint32 => "uint32",
+        .uint64 => "uint64",
+        .size_type => "size_t",
+        .char_type => "char",
+    };
+}
+
+fn schemeTypeName(v: Value) []const u8 {
+    if (types.isFixnum(v)) return "integer";
+    if (types.isFlonum(v)) return "flonum";
+    if (types.isString(v)) return "string";
+    if (types.isBignum(v)) return "integer";
+    if (v == types.TRUE or v == types.FALSE) return "boolean";
+    if (types.isChar(v)) return "character";
+    if (types.isBytevector(v)) return "bytevector";
+    if (types.isFfiCallback(v)) return "ffi-callback";
+    if (types.isRationalObj(v)) return "rational";
+    if (types.isNil(v)) return "nil";
+    if (types.isPair(v)) return "pair";
+    if (types.isSymbol(v)) return "symbol";
+    return "object";
+}
 
 fn toIntArgOpt(v: Value) ?i64 {
     if (v == types.TRUE) return 1;
@@ -217,12 +257,46 @@ fn checkNarrowIntRange(v: Value, declared: FfiType) error{TypeError}!void {
     }
 }
 
-fn validateArgs(ffi_fn: *types.FfiFunction, args: []const Value) !void {
+fn validateArgsDetailed(ffi_fn: *types.FfiFunction, args: []const Value, vm: *VM) !void {
     for (0..ffi_fn.param_count) |i| {
         if (!validateArg(args[i], ffi_fn.param_types[i])) {
+            vm.setErrorDetail("'{s}': argument {d} must be {s}, got {s}", .{
+                ffi_fn.name, i + 1, ffiTypeName(ffi_fn.param_types[i]), schemeTypeName(args[i]),
+            });
             return error.TypeError;
         }
-        try checkNarrowIntRange(args[i], ffi_fn.param_types[i]);
+        checkNarrowIntRange(args[i], ffi_fn.param_types[i]) catch {
+            vm.setErrorDetail("'{s}': argument {d} out of range for {s}", .{
+                ffi_fn.name, i + 1, ffiTypeName(ffi_fn.param_types[i]),
+            });
+            return error.TypeError;
+        };
+        const nt = normalizeType(ffi_fn.param_types[i]);
+        if (nt == .int and ffi_fn.param_types[i] != .bool_type) {
+            if (toIntArgOpt(args[i])) |wide| {
+                if (std.math.cast(c_int, wide) == null) {
+                    vm.setErrorDetail("'{s}': argument {d} out of range for {s}", .{
+                        ffi_fn.name, i + 1, ffiTypeName(ffi_fn.param_types[i]),
+                    });
+                    return error.TypeError;
+                }
+            }
+        }
+        if (nt == .string) {
+            const str = types.toObject(args[i]).as(types.SchemeString);
+            if (str.len >= 4096) {
+                vm.setErrorDetail("'{s}': argument {d} string too long ({d} bytes, max 4095)", .{
+                    ffi_fn.name, i + 1, str.len,
+                });
+                return error.TypeError;
+            }
+            if (std.mem.indexOfScalar(u8, str.data[0..str.len], 0) != null) {
+                vm.setErrorDetail("'{s}': argument {d} string contains NUL byte", .{
+                    ffi_fn.name, i + 1,
+                });
+                return error.TypeError;
+            }
+        }
     }
 }
 
@@ -361,22 +435,32 @@ fn callFfiGeneric(comptime N: u4, ffi_fn: *types.FfiFunction, args: []const Valu
 }
 
 /// Main FFI call dispatcher. Routes to arity-specific handlers.
-pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Value {
+pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC, vm: *VM) !Value {
     if (types.isFfiLibrary(ffi_fn.library)) {
         const lib = types.toObject(ffi_fn.library).as(types.FfiLibrary);
-        if (lib.handle == null) return error.TypeError;
+        if (lib.handle == null) {
+            vm.setErrorDetail("'{s}': FFI library is closed", .{ffi_fn.name});
+            return error.TypeError;
+        }
     }
-    try validateArgs(ffi_fn, args);
+    try validateArgsDetailed(ffi_fn, args, vm);
     var bool_buf: [5]Value = undefined;
     const call_args = normalizeBoolArgs(ffi_fn, args, &bool_buf);
     const result = switch (ffi_fn.param_count) {
-        0 => try callFfiGeneric(0, ffi_fn, call_args, gc),
-        1 => try callFfiGeneric(1, ffi_fn, call_args, gc),
-        2 => try callFfiGeneric(2, ffi_fn, call_args, gc),
-        3 => try callFfiGeneric(3, ffi_fn, call_args, gc),
-        4 => try callFfi4(ffi_fn, call_args, gc),
-        5 => try callFfi5(ffi_fn, call_args, gc),
-        else => return error.TypeError,
+        0 => callFfiGeneric(0, ffi_fn, call_args, gc),
+        1 => callFfiGeneric(1, ffi_fn, call_args, gc),
+        2 => callFfiGeneric(2, ffi_fn, call_args, gc),
+        3 => callFfiGeneric(3, ffi_fn, call_args, gc),
+        4 => callFfi4(ffi_fn, call_args, gc),
+        5 => callFfi5(ffi_fn, call_args, gc),
+        else => {
+            vm.setErrorDetail("'{s}': unsupported parameter count ({d})", .{ ffi_fn.name, ffi_fn.param_count });
+            return error.TypeError;
+        },
+    } catch {
+        if (vm.last_error_detail_len == 0)
+            vm.setErrorDetail("'{s}': unsupported FFI signature", .{ffi_fn.name});
+        return error.TypeError;
     };
     if (ffi_fn.return_type == .bool_type) {
         if (types.isFixnum(result))

--- a/src/tests_ffi.zig
+++ b/src/tests_ffi.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const memory = @import("memory.zig");
 const types = @import("types.zig");
 const ffi = @import("ffi.zig");
+const th = @import("testing_helpers.zig");
 
 // A C-ABI function with a real `_Bool` parameter. In safe builds (the default)
 // the Zig compiler inserts a check that traps if the incoming byte is not 0 or
@@ -28,8 +29,9 @@ fn makeBoolFn(ptypes: []types.FfiType, ret: types.FfiType) types.FfiFunction {
 }
 
 test "ffi bool arg: non-0/1 integers coerced to 0/1, never trap (#796)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
     var ptypes = [_]types.FfiType{.bool_type};
     var fn_int = makeBoolFn(ptypes[0..], .int);
@@ -37,47 +39,49 @@ test "ffi bool arg: non-0/1 integers coerced to 0/1, never trap (#796)" {
     // 2 must be coerced to 1 before reaching the _Bool parameter — passing it
     // through raw aborts the process under the safety check. Before the fix
     // this returned 2 (or trapped); the raw integer must never reach _Bool.
-    const r2 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(2)}, &gc);
+    const r2 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(2)}, &ctx.gc, &ctx.vm);
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(r2));
 
     // Any nonzero value is true (C truthiness); zero is false.
-    const rneg = try ffi.callFfi(&fn_int, &.{types.makeFixnum(-5)}, &gc);
+    const rneg = try ffi.callFfi(&fn_int, &.{types.makeFixnum(-5)}, &ctx.gc, &ctx.vm);
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rneg));
 
-    const r0 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(0)}, &gc);
+    const r0 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(0)}, &ctx.gc, &ctx.vm);
     try std.testing.expectEqual(@as(i64, 0), types.toFixnum(r0));
 
     // #t / #f keep working as before (#418).
-    const rt = try ffi.callFfi(&fn_int, &.{types.TRUE}, &gc);
+    const rt = try ffi.callFfi(&fn_int, &.{types.TRUE}, &ctx.gc, &ctx.vm);
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rt));
 
-    const rf = try ffi.callFfi(&fn_int, &.{types.FALSE}, &gc);
+    const rf = try ffi.callFfi(&fn_int, &.{types.FALSE}, &ctx.gc, &ctx.vm);
     try std.testing.expectEqual(@as(i64, 0), types.toFixnum(rf));
 }
 
 test "ffi bool arg: bignum coerced to 0/1 (#796)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
     var ptypes = [_]types.FfiType{.bool_type};
     var fn_int = makeBoolFn(ptypes[0..], .int);
 
     // A value too large for a fixnum arrives as a bignum; it is still just a
     // truthy value for a bool parameter and must coerce to 1.
-    const big = try gc.allocBignumFromI64(0x1_0000_0000_0000);
-    const rbig = try ffi.callFfi(&fn_int, &.{big}, &gc);
+    const big = try ctx.gc.allocBignumFromI64(0x1_0000_0000_0000);
+    const rbig = try ffi.callFfi(&fn_int, &.{big}, &ctx.gc, &ctx.vm);
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rbig));
 }
 
 test "ffi bool arg with bool return normalizes both directions (#796)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
     var ptypes = [_]types.FfiType{.bool_type};
     var fn_bool = makeBoolFn(ptypes[0..], .bool_type);
 
-    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(2)}, &gc));
-    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(0)}, &gc));
-    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.TRUE}, &gc));
-    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.FALSE}, &gc));
+    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(2)}, &ctx.gc, &ctx.vm));
+    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(0)}, &ctx.gc, &ctx.vm));
+    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.TRUE}, &ctx.gc, &ctx.vm));
+    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.FALSE}, &ctx.gc, &ctx.vm));
 }

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -322,11 +322,14 @@ pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
     }
     if (types.isFfiFunction(callee)) {
         const ffi_fn = types.toObject(callee).as(types.FfiFunction);
-        if (nargs != ffi_fn.param_count) return VMError.ArityMismatch;
+        if (nargs != ffi_fn.param_count) {
+            vm.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ ffi_fn.name, ffi_fn.param_count, nargs });
+            return VMError.ArityMismatch;
+        }
         const ffi_mod = @import("ffi.zig");
-        const result = ffi_mod.callFfi(ffi_fn, vm.registers[base + 1 .. base + 1 + nargs], vm.gc) catch {
+        const result = ffi_mod.callFfi(ffi_fn, vm.registers[base + 1 .. base + 1 + nargs], vm.gc, vm) catch {
             if (vm.last_error_detail_len == 0)
-                vm.setErrorDetail("unsupported FFI signature for '{s}'", .{ffi_fn.name});
+                vm.setErrorDetail("'{s}': unsupported FFI signature", .{ffi_fn.name});
             return VMError.TypeError;
         };
         vm.registers[base] = result;
@@ -647,11 +650,14 @@ pub fn callThunk(vm: *VM, thunk_val: Value) VMError!Value {
 pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
     if (types.isFfiFunction(proc)) {
         const ffi_fn = types.toObject(proc).as(types.FfiFunction);
-        if (args.len != ffi_fn.param_count) return VMError.ArityMismatch;
+        if (args.len != ffi_fn.param_count) {
+            vm.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ ffi_fn.name, ffi_fn.param_count, args.len });
+            return VMError.ArityMismatch;
+        }
         const ffi_mod = @import("ffi.zig");
-        return ffi_mod.callFfi(ffi_fn, args, vm.gc) catch {
+        return ffi_mod.callFfi(ffi_fn, args, vm.gc, vm) catch {
             if (vm.last_error_detail_len == 0)
-                vm.setErrorDetail("unsupported FFI signature for '{s}'", .{ffi_fn.name});
+                vm.setErrorDetail("'{s}': unsupported FFI signature", .{ffi_fn.name});
             return VMError.TypeError;
         };
     }

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -533,11 +533,14 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     return VMError.ContinuationInvoked;
                 } else if (types.isFfiFunction(callee)) {
                     const ffi_fn = types.toObject(callee).as(types.FfiFunction);
-                    if (nargs != ffi_fn.param_count) return VMError.ArityMismatch;
+                    if (nargs != ffi_fn.param_count) {
+                        self.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ ffi_fn.name, ffi_fn.param_count, nargs });
+                        return VMError.ArityMismatch;
+                    }
                     const ffi_mod = @import("ffi.zig");
                     const return_dst = frame.dst;
                     const from_native_call = frame.returns_to_native;
-                    const result = ffi_mod.callFfi(ffi_fn, self.registers[abs_base + 1 .. abs_base + 1 + nargs], self.gc) catch return VMError.TypeError;
+                    const result = ffi_mod.callFfi(ffi_fn, self.registers[abs_base + 1 .. abs_base + 1 + nargs], self.gc, self) catch return VMError.TypeError;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     if (from_native_call) return raiseDeadNativeReturn(self);
@@ -680,13 +683,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     return VMError.ContinuationInvoked;
                 } else if (types.isFfiFunction(proc)) {
                     const ffi_fn = types.toObject(proc).as(types.FfiFunction);
-                    if (count != ffi_fn.param_count) return VMError.ArityMismatch;
+                    if (count != ffi_fn.param_count) {
+                        self.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ ffi_fn.name, ffi_fn.param_count, count });
+                        return VMError.ArityMismatch;
+                    }
                     const ffi_mod = @import("ffi.zig");
                     // FFI callbacks may re-enter the VM and grow self.frames,
                     // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
                     const from_native_call = frame.returns_to_native;
-                    const result = ffi_mod.callFfi(ffi_fn, flat_args[0..count], self.gc) catch return VMError.TypeError;
+                    const result = ffi_mod.callFfi(ffi_fn, flat_args[0..count], self.gc, self) catch return VMError.TypeError;
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     if (from_native_call) return raiseDeadNativeReturn(self);

--- a/tests/scheme/ffi/error-messages.scm
+++ b/tests/scheme/ffi/error-messages.scm
@@ -5,7 +5,6 @@
 
 (define lib (ffi-open #f))
 (define c-abs (ffi-fn lib "abs" '(int) 'int))
-(define c-sqrt (ffi-fn lib "sqrt" '(double) 'double))
 (define c-strlen (ffi-fn lib "strlen" '(string) 'size_t))
 
 ;; Wrong argument type: flonum for int
@@ -24,13 +23,13 @@
     (c-abs "x")
     #f))
 
-;; Arity mismatch: too many arguments
+;; Arity mismatch: too many arguments (use abs from libc, always available)
 (test-assert "arity mismatch names function and counts"
   (guard (e (#t (let ((msg (error-object-message e)))
-                  (and (string-contains msg "sqrt")
-                       (string-contains msg "1")
-                       (string-contains msg "2")))))
-    (c-sqrt 1.0 2.0)
+                  (and (string-contains msg "abs")
+                       (string-contains msg "expected")
+                       (string-contains msg "got")))))
+    (c-abs 1 2)
     #f))
 
 ;; NUL byte in string argument
@@ -39,6 +38,25 @@
                   (and (string-contains msg "strlen")
                        (string-contains msg "NUL")))))
     (c-strlen (string #\a #\null #\b))
+    #f))
+
+;; Closed library
+(test-assert "closed library error names function"
+  (let ((lib2 (ffi-open #f)))
+    (let ((c-abs2 (ffi-fn lib2 "abs" '(int) 'int)))
+      (ffi-close lib2)
+      (guard (e (#t (let ((msg (error-object-message e)))
+                      (and (string-contains msg "abs")
+                           (string-contains msg "closed")))))
+        (c-abs2 42)
+        #f))))
+
+;; Integer out of range for int parameter
+(test-assert "out-of-range integer error names function"
+  (guard (e (#t (let ((msg (error-object-message e)))
+                  (and (string-contains msg "abs")
+                       (string-contains msg "range")))))
+    (c-abs (expt 2 40))
     #f))
 
 (let ((runner (test-runner-current)))

--- a/tests/scheme/ffi/error-messages.scm
+++ b/tests/scheme/ffi/error-messages.scm
@@ -1,0 +1,46 @@
+;; Regression test for #1187: FFI call-time errors carry descriptive messages
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "ffi-error-messages")
+
+(define lib (ffi-open #f))
+(define c-abs (ffi-fn lib "abs" '(int) 'int))
+(define c-sqrt (ffi-fn lib "sqrt" '(double) 'double))
+(define c-strlen (ffi-fn lib "strlen" '(string) 'size_t))
+
+;; Wrong argument type: flonum for int
+(test-assert "type error names function and expected type"
+  (guard (e (#t (let ((msg (error-object-message e)))
+                  (and (string-contains msg "abs")
+                       (string-contains msg "int")))))
+    (c-abs -3.0)
+    #f))
+
+;; Wrong argument type: string for int
+(test-assert "type error names actual type"
+  (guard (e (#t (let ((msg (error-object-message e)))
+                  (and (string-contains msg "abs")
+                       (string-contains msg "string")))))
+    (c-abs "x")
+    #f))
+
+;; Arity mismatch: too many arguments
+(test-assert "arity mismatch names function and counts"
+  (guard (e (#t (let ((msg (error-object-message e)))
+                  (and (string-contains msg "sqrt")
+                       (string-contains msg "1")
+                       (string-contains msg "2")))))
+    (c-sqrt 1.0 2.0)
+    #f))
+
+;; NUL byte in string argument
+(test-assert "NUL-in-string error names function"
+  (guard (e (#t (let ((msg (error-object-message e)))
+                  (and (string-contains msg "strlen")
+                       (string-contains msg "NUL")))))
+    (c-strlen (string #\a #\null #\b))
+    #f))
+
+(let ((runner (test-runner-current)))
+  (test-end "ffi-error-messages")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Pass VM to `callFfi` so it can set `vm.setErrorDetail` with the FFI function name, argument position, and expected/actual types at each failure point
- Add `ffiTypeName`/`schemeTypeName` helpers and `validateArgsDetailed` in `src/ffi.zig` covering wrong type, NUL-in-string, string-too-long, int range overflow, closed library, and unsupported signature errors
- Add arity mismatch error details at all 4 FFI call sites in `vm_dispatch.zig` and `vm_calls.zig`

Before: `(c-abs -3.0)` → `"error"`
After: `(c-abs -3.0)` → `"'abs': argument 1 must be int, got flonum"`

Closes #1187

## Test plan

- [x] Unit tests pass (`zig build test`)
- [x] Full Scheme suite passes (1813 pass, 0 fail)
- [x] All existing FFI tests pass
- [x] New regression test `tests/scheme/ffi/error-messages.scm` covers all 4 error categories from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)