### PR TITLE
Fix non-exported library macros leaking to importers (#1332)

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -73,21 +73,27 @@ fn copyTransformerFreeRefs(
         _ = macro.collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &free_names, &free_count);
         for (free_names[0..free_count]) |fname| {
             if (env.get(fname)) |fval| {
+                const is_tx = types.isTransformer(fval);
                 if (target == vm.globals) {
-                    vm.globals_lock.lock();
-                    const missing = !target.contains(fname);
-                    if (missing) {
-                        target.put(fname, fval) catch {
-                            vm.globals_lock.unlock();
-                            return error.OutOfMemory;
-                        };
+                    // Non-exported transformer free refs go into vm.macros
+                    // only (below), not vm.globals — keeps non-exported
+                    // library macros from leaking as bindings (#1332).
+                    if (!is_tx) {
+                        vm.globals_lock.lock();
+                        const missing = !target.contains(fname);
+                        if (missing) {
+                            target.put(fname, fval) catch {
+                                vm.globals_lock.unlock();
+                                return error.OutOfMemory;
+                            };
+                        }
+                        vm.globals_lock.unlock();
+                        if (missing) vm.global_version +%= 1;
                     }
-                    vm.globals_lock.unlock();
-                    if (missing) vm.global_version +%= 1;
                 } else if (!target.contains(fname)) {
                     target.put(fname, fval) catch return error.OutOfMemory;
                 }
-                if (types.isTransformer(fval)) {
+                if (is_tx) {
                     // An exported macro may expand into a library-internal
                     // helper macro (e.g. SRFI 64 test-assert → %test-comp1body).
                     // The helper lives in the source library's lib_env, not the

--- a/tests/scheme/compliance/macro-export-scope.scm
+++ b/tests/scheme/compliance/macro-export-scope.scm
@@ -1,0 +1,72 @@
+;; Regression test for #1332: non-exported library macros leak to importers
+;;
+;; A library's non-exported define-syntax bindings should not be accessible
+;; from importing code. Only explicitly exported macros should be visible.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+;; Library with exported macro `outer` that uses non-exported helper macro.
+(define-library (test macro-scope)
+  (import (scheme base))
+  (export outer)
+  (begin
+    (define-syntax helper
+      (syntax-rules ()
+        ((helper x) (+ x 1))))
+    (define-syntax outer
+      (syntax-rules ()
+        ((outer x) (helper x))))
+    (define (secret) 42)))
+
+(import (test macro-scope))
+
+(test-begin "macro-export-scope")
+
+;; Exported macro works correctly (expansion chains through helper)
+(test-equal "exported macro expands" 6 (outer 5))
+
+;; Non-exported macro should not be accessible as a value
+(test-assert "non-exported macro not in globals"
+  (guard (exn (#t #t))
+    helper
+    #f))
+
+;; Non-exported procedure should not be accessible
+(test-assert "non-exported procedure not in globals"
+  (guard (exn (#t #t))
+    (secret)
+    #f))
+
+;; --- Transitive case: exported macro references helper that references
+;; another helper. Neither helper should leak.
+(define-library (test deep-scope)
+  (import (scheme base))
+  (export deep-outer)
+  (begin
+    (define-syntax deep-helper-2
+      (syntax-rules ()
+        ((deep-helper-2 x) (* x x))))
+    (define-syntax deep-helper-1
+      (syntax-rules ()
+        ((deep-helper-1 x) (deep-helper-2 x))))
+    (define-syntax deep-outer
+      (syntax-rules ()
+        ((deep-outer x) (deep-helper-1 x))))))
+
+(import (test deep-scope))
+
+(test-equal "transitive exported macro works" 25 (deep-outer 5))
+
+(test-assert "transitive helper-1 not in globals"
+  (guard (exn (#t #t))
+    deep-helper-1
+    #f))
+
+(test-assert "transitive helper-2 not in globals"
+  (guard (exn (#t #t))
+    deep-helper-2
+    #f))
+
+(let ((runner (test-runner-current)))
+  (test-end "macro-export-scope")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- Non-exported macros defined in a library's `begin` block were visible to importers as value bindings (e.g. `(display helper)` printed `#<transformer>`)
- `copyTransformerFreeRefs` now skips putting transformer free refs into `vm.globals` — they only go into `vm.macros` where the compiler needs them for expansion chains
- Non-exported procedures were already correctly private; this fix brings macro scoping to parity

## Test plan

- [x] New regression test `tests/scheme/compliance/macro-export-scope.scm` — exported macro works, non-exported macro/procedure not in globals, transitive helper chain
- [x] Zig unit tests pass
- [x] Full Scheme test suite: 1813 pass, 0 fail (including all 72 SRFIs with internal helper macros like SRFI-64's `%test-comp1body`)

Closes #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)