### PR TITLE
Polish the bootstrapped map/for-each/dynamic-wind/force family (#1375)

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -48,5 +48,5 @@ jobs:
           pr-benchmark-file-path: pr-results.json
           base-benchmark-file-path: base-results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '200%'
+          alert-threshold: '120%'
           comment-always: true

--- a/README.md
+++ b/README.md
@@ -346,6 +346,23 @@ captured in tight inner loops. Continuations captured in one top-level REPL
 expression cannot re-enter subsequent top-level expressions (standard behavior
 shared by Guile, Chibi, Chicken, Chez, and Racket).
 
+### Fibers
+
+Callbacks driven by `map`, `for-each`, `vector-map`, `vector-for-each`,
+`string-map`, `string-for-each`, `dynamic-wind`, and `force` run in the
+bytecode dispatch loop, so a fiber can park inside them (e.g. block on an
+empty channel) and resume later. Other higher-order procedures are still
+native drivers — SRFI-1 (`fold`, `filter`, `find`, `any`, `every`, ...),
+`sort`, `hash-table-walk`/`hash-table-update!`, `assoc`/`member` with a
+custom predicate, `string-index`, `eval`, ... — and a fiber that blocks on
+an empty channel inside one of those callbacks cannot be parked: the native
+call's state lives on the Zig stack and cannot be suspended. If other fibers
+are runnable the scheduler still makes progress, but if the blocked receive
+is the only thing left it raises a deadlock error instead of suspending.
+Move blocking `channel-receive` calls into plain Scheme loops (named `let`,
+`do`) or the bytecode-driven procedures above when a fiber must wait inside
+iteration.
+
 ### OS threads (SRFI-18)
 
 Each OS thread gets its own GC with an independent heap. Values are deep-copied

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -237,6 +237,25 @@ pub fn registerSandboxed(vm: *vm_mod.VM) !void {
     }
 }
 
+/// Registration placeholder for procedures whose real implementation is
+/// Scheme source in vm_bootstrap.zig, installed at VM init right after
+/// registration. The spec entry must stay (it drives arity metadata and
+/// library exports), but the native body was retired when the Scheme
+/// version became the single implementation (#1375): a stub that errors
+/// makes a missing vm_bootstrap.install() fail loudly instead of silently
+/// falling back to a native implementation that has since diverged.
+pub fn bootstrapStub(comptime name: []const u8) types.NativeFnType {
+    const S = struct {
+        fn call(args: []const Value) PrimitiveError!Value {
+            _ = args;
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+            vm.setErrorDetail("'{s}' is implemented in Scheme (src/vm_bootstrap.zig) but vm_bootstrap.install() has not run for this VM", .{name});
+            return PrimitiveError.TypeError;
+        }
+    };
+    return &S.call;
+}
+
 pub fn reg(vm: *vm_mod.VM, name: []const u8, func: types.NativeFnType, arity: NativeFn.Arity) !void {
     if (std.debug.runtime_safety) {
         if (vm.globals.get(name) != null) {

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -24,7 +24,9 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "call/cc", .func = &callWithCurrentContinuation, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "call-with-escape-continuation", .func = &callWithEscapeContinuation, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "call/ec", .func = &callWithEscapeContinuation, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "dynamic-wind", .func = &dynamicWindFn, .arity = .{ .exact = 3 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
+    // dynamic-wind is implemented in Scheme (src/vm_bootstrap.zig); this
+    // entry keeps the arity metadata and library exports.
+    .{ .name = "dynamic-wind", .func = primitives.bootstrapStub("dynamic-wind"), .arity = .{ .exact = 3 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "values", .func = &valuesFn, .arity = .{ .variadic = 0 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "call-with-values", .func = &callWithValuesFn, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "%push-wind", .func = &pushWindFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.internal) },
@@ -260,52 +262,6 @@ fn callWithEscapeContinuation(args: []const Value) PrimitiveError!Value {
 
     // proc returned normally without escaping; the extent is over.
     cont_obj.valid = false;
-    return result;
-}
-
-fn dynamicWindFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const before = args[0];
-    const thunk = args[1];
-    const after = args[2];
-
-    if (!types.isProcedure(before)) return primitives.typeError("dynamic-wind", "procedure", args[0]);
-    if (!types.isProcedure(thunk)) return primitives.typeError("dynamic-wind", "procedure", args[1]);
-    if (!types.isProcedure(after)) return primitives.typeError("dynamic-wind", "procedure", args[2]);
-
-    // Call before thunk
-    _ = vm.callThunk(before) catch |err| {
-        return err;
-    };
-
-    // Push wind record
-    if (vm.wind_count >= vm_mod.MAX_WINDS) return PrimitiveError.OutOfMemory;
-    vm.wind_stack[vm.wind_count] = .{ .before = before, .after = after };
-    vm.wind_count += 1;
-
-    // Call thunk
-    const result = vm.callThunk(thunk) catch |err| {
-        // If continuation was invoked, the wind stack has been replaced
-        // so we shouldn't try to pop/call after
-        if (err == vm_mod.VMError.ContinuationInvoked) return PrimitiveError.ContinuationInvoked;
-
-        // On other errors, pop wind record and call after
-        vm.wind_count -= 1;
-        _ = vm.callThunk(after) catch |after_err| {
-            if (after_err == vm_mod.VMError.ContinuationInvoked)
-                return PrimitiveError.ContinuationInvoked;
-        };
-        return err;
-    };
-
-    // Pop wind record
-    vm.wind_count -= 1;
-
-    // Call after thunk
-    _ = vm.callThunk(after) catch |err| {
-        return err;
-    };
-
     return result;
 }
 

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -9,7 +9,9 @@ const LS = primitives.LibSet;
 const NativeFn = types.NativeFn;
 
 pub const specs = [_]primitives.PrimSpec{
-    .{ .name = "force", .func = &forceFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_lazy, .scheme_r5rs }) },
+    // force is implemented in Scheme (src/vm_bootstrap.zig); this entry keeps
+    // the arity metadata and library exports.
+    .{ .name = "force", .func = primitives.bootstrapStub("force"), .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_lazy, .scheme_r5rs }) },
     .{ .name = "promise?", .func = &promiseP, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_lazy }) },
     .{ .name = "make-promise", .func = &makePromiseFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_lazy }) },
     .{ .name = "%make-promise-lazy", .func = &makePromiseLazy, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
@@ -81,80 +83,4 @@ fn promiseMerge(args: []const Value) PrimitiveError!Value {
     gc.writeBarrier(&inner.header, types.makePointer(@ptrCast(outer)));
     outer.forcing = false;
     return types.VOID;
-}
-
-fn forceFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-
-    var current = args[0];
-    gc.pushRoot(&current);
-    defer gc.popRoot();
-
-    if (!types.isPromise(current)) return current;
-
-    while (true) {
-        if (!types.isPromise(current)) return current;
-        const promise = types.toPromise(current);
-
-        if (promise.forced) {
-            // Follow redirect: forced value is a promise only via SRFI-45 merge (inner → head), never a cycle.
-            current = promise.value;
-            continue;
-        }
-
-        const thunk = promise.value;
-        if (!types.isProcedure(thunk)) {
-            promise.forced = true;
-            return thunk;
-        }
-
-        promise.forcing = true;
-
-        const result = vm.callWithArgs(thunk, &[_]Value{}) catch |err| {
-            promise.forcing = false;
-            return err;
-        };
-
-        // SRFI-45 §8: after the thunk returns, check if another force
-        // has already completed this promise (re-entrant force).
-        if (promise.forced) {
-            promise.forcing = false;
-            current = promise.value;
-            continue;
-        }
-
-        if (types.isPromise(result)) {
-            const inner = types.toPromise(result);
-            // SRFI-45 §8: detect cyclic promise chains where a thunk
-            // returns a promise that is already being forced.
-            if (inner.forcing) {
-                promise.forcing = false;
-                vm.setErrorDetail("re-entrant forcing of promise", .{});
-                return PrimitiveError.TypeError; // bare-ok: detail set above
-            }
-            if (inner.forced) {
-                promise.forcing = false;
-                promise.forced = true;
-                promise.value = inner.value;
-                gc.writeBarrier(&promise.header, inner.value);
-                current = inner.value;
-                continue;
-            }
-            promise.value = inner.value;
-            gc.writeBarrier(&promise.header, inner.value);
-            inner.forced = true;
-            inner.value = types.makePointer(@ptrCast(promise));
-            gc.writeBarrier(&inner.header, types.makePointer(@ptrCast(promise)));
-            promise.forcing = false;
-            current = types.makePointer(@ptrCast(promise));
-            continue;
-        }
-
-        promise.forcing = false;
-        promise.forced = true;
-        promise.value = result;
-        gc.writeBarrier(&promise.header, result);
-        return result;
-    }
 }

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -25,8 +25,10 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "assoc", .func = &assocFn, .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 }) },
     .{ .name = "assq", .func = &assqFn, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 }) },
     .{ .name = "assv", .func = &assvFn, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 }) },
-    .{ .name = "map", .func = &mapFn, .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 }) },
-    .{ .name = "for-each", .func = &forEachFn, .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 }) },
+    // map and for-each are implemented in Scheme (src/vm_bootstrap.zig);
+    // these entries keep the arity metadata and library exports.
+    .{ .name = "map", .func = primitives.bootstrapStub("map"), .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 }) },
+    .{ .name = "for-each", .func = primitives.bootstrapStub("for-each"), .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 }) },
     .{ .name = "boolean=?", .func = &booleanEqP, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "symbol=?", .func = &symbolEqP, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "features", .func = &featuresFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
@@ -342,129 +344,6 @@ fn symbolEqP(args: []const Value) PrimitiveError!Value {
         if (a != args[0]) return types.FALSE;
     }
     return types.TRUE;
-}
-
-// ---------------------------------------------------------------------------
-// map and for-each (higher-order list functions)
-// ---------------------------------------------------------------------------
-
-fn mapFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = getGC() orelse return PrimitiveError.OutOfMemory;
-    const proc = args[0];
-    if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("map", "procedure", proc);
-
-    const list_count = args.len - 1;
-    std.debug.assert(list_count > 0);
-
-    // Build result list incrementally (rooted head + tail)
-    var result_head: Value = types.NIL;
-    gc.pushRoot(&result_head);
-    defer gc.popRoot();
-
-    var result_tail: Value = types.NIL;
-    gc.pushRoot(&result_tail);
-    defer gc.popRoot();
-
-    // Current pointers for each list
-    var currents: [256]Value = undefined;
-    for (0..list_count) |i| {
-        currents[i] = args[1 + i];
-    }
-
-    var call_args: [256]Value = undefined;
-
-    while (true) {
-        // Check if any list is exhausted
-        var all_pairs = true;
-        for (0..list_count) |i| {
-            if (currents[i] == types.NIL) {
-                all_pairs = false;
-                break;
-            }
-            if (!types.isPair(currents[i])) return primitives.typeError("map", "proper list", currents[i]);
-        }
-        if (!all_pairs) break;
-
-        // Extract car of each list
-        for (0..list_count) |i| {
-            call_args[i] = types.car(currents[i]);
-        }
-
-        // Call procedure
-        var result = vm.callWithArgs(proc, call_args[0..list_count]) catch |err| {
-            return err;
-        };
-
-        // Root result: callWithArgs pops its frame, so the return value has
-        // no GC root until it is consed into the result list.
-        gc.pushRoot(&result);
-        const new_pair = gc.allocPair(result, types.NIL) catch {
-            gc.popRoot();
-            return PrimitiveError.OutOfMemory;
-        };
-        gc.popRoot();
-        if (result_head == types.NIL) {
-            result_head = new_pair;
-        } else {
-            types.setCdr(result_tail, new_pair);
-        }
-        result_tail = new_pair;
-
-        // Advance each list
-        for (0..list_count) |i| {
-            currents[i] = types.cdr(currents[i]);
-        }
-    }
-
-    return result_head;
-}
-
-fn forEachFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const proc = args[0];
-    if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("for-each", "procedure", proc);
-
-    const list_count = args.len - 1;
-    std.debug.assert(list_count > 0);
-
-    // Current pointers for each list
-    var currents: [256]Value = undefined;
-    for (0..list_count) |i| {
-        currents[i] = args[1 + i];
-    }
-
-    var call_args: [256]Value = undefined;
-
-    while (true) {
-        // Check if any list is exhausted
-        var all_pairs = true;
-        for (0..list_count) |i| {
-            if (currents[i] == types.NIL) {
-                all_pairs = false;
-                break;
-            }
-            if (!types.isPair(currents[i])) return primitives.typeError("for-each", "proper list", currents[i]);
-        }
-        if (!all_pairs) break;
-
-        // Extract car of each list
-        for (0..list_count) |i| {
-            call_args[i] = types.car(currents[i]);
-        }
-
-        // Call procedure (discard result)
-        _ = vm.callWithArgs(proc, call_args[0..list_count]) catch |err| {
-            return err;
-        };
-
-        // Advance each list
-        for (0..list_count) |i| {
-            currents[i] = types.cdr(currents[i]);
-        }
-    }
-
-    return types.VOID;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -20,8 +20,11 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "string->list", .func = &stringToListFn, .arity = .{ .variadic = 1 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "list->string", .func = &listToStringFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "string->vector", .func = &stringToVectorFn, .arity = .{ .variadic = 1 }, .libs = LS.initMany(&.{ .scheme_base, .srfi_133 }) },
-    .{ .name = "string-for-each", .func = &stringForEachFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "string-map", .func = &stringMapFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.scheme_base) },
+    // string-for-each and string-map are implemented in Scheme
+    // (src/vm_bootstrap.zig); these entries keep the arity metadata and
+    // library exports.
+    .{ .name = "string-for-each", .func = primitives.bootstrapStub("string-for-each"), .arity = .{ .variadic = 2 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "string-map", .func = primitives.bootstrapStub("string-map"), .arity = .{ .variadic = 2 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "string<?", .func = &stringLtFn, .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_13 }) },
     .{ .name = "string<=?", .func = &stringLeFn, .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_13 }) },
     .{ .name = "string=?", .func = &stringEqFn, .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_13 }) },
@@ -426,89 +429,6 @@ fn stringToVectorFn(args: []const Value) PrimitiveError!Value {
         byte_i += utf8ByteLenAt(data, byte_i);
     }
     return gc.allocVector(vec_data[0..range_count]) catch return PrimitiveError.OutOfMemory;
-}
-
-// ---------------------------------------------------------------------------
-// (string-for-each proc str1 ...)
-// ---------------------------------------------------------------------------
-
-fn stringForEachFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const proc = args[0];
-    if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("string-for-each", "procedure", proc);
-
-    const str_count = args.len - 1;
-    std.debug.assert(str_count > 0);
-    if (str_count > 256) return PrimitiveError.ArityMismatch;
-
-    // Find minimum codepoint length
-    var min_cp_len: usize = std.math.maxInt(usize);
-    for (args[1..]) |a| {
-        const data = try getStringSlice("string-for-each", a);
-        const cp_len = utf8CodepointCount(data);
-        if (cp_len < min_cp_len) min_cp_len = cp_len;
-    }
-
-    var call_args: [256]Value = undefined;
-    for (0..min_cp_len) |cp_idx| {
-        for (0..str_count) |si| {
-            const data = try getStringSlice("string-for-each", args[1 + si]);
-            const byte_off = utf8IndexToByteOffset(data, cp_idx) orelse return primitives.typeError("string-for-each", "valid UTF-8 string", args[1 + si]);
-            const cp = utf8DecodeAt(data, byte_off) orelse return primitives.typeError("string-for-each", "valid UTF-8 string", args[1 + si]);
-            call_args[si] = types.makeChar(cp);
-        }
-        _ = vm.callWithArgs(proc, call_args[0..str_count]) catch |err| {
-            return err;
-        };
-    }
-    return types.VOID;
-}
-
-// ---------------------------------------------------------------------------
-// (string-map proc str1 ...)
-// ---------------------------------------------------------------------------
-
-fn stringMapFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const proc = args[0];
-    if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("string-map", "procedure", proc);
-
-    const str_count = args.len - 1;
-    std.debug.assert(str_count > 0);
-    if (str_count > 256) return PrimitiveError.ArityMismatch;
-
-    // Find minimum codepoint length
-    var min_cp_len: usize = std.math.maxInt(usize);
-    for (args[1..]) |a| {
-        const data = try getStringSlice("string-map", a);
-        const cp_len = utf8CodepointCount(data);
-        if (cp_len < min_cp_len) min_cp_len = cp_len;
-    }
-
-    // Collect result chars
-    var result_buf: std.ArrayList(u8) = .empty;
-    defer result_buf.deinit(gc.allocator);
-
-    var call_args: [256]Value = undefined;
-    for (0..min_cp_len) |cp_idx| {
-        for (0..str_count) |si| {
-            const data = try getStringSlice("string-map", args[1 + si]);
-            const byte_off = utf8IndexToByteOffset(data, cp_idx) orelse return primitives.typeError("string-map", "valid UTF-8 string", args[1 + si]);
-            const cp = utf8DecodeAt(data, byte_off) orelse return primitives.typeError("string-map", "valid UTF-8 string", args[1 + si]);
-            call_args[si] = types.makeChar(cp);
-        }
-        const result = vm.callWithArgs(proc, call_args[0..str_count]) catch |err| {
-            return err;
-        };
-        if (!types.isChar(result)) return primitives.typeError("string-map", "character", result);
-        const cp = types.toChar(result);
-        var tmp: [4]u8 = undefined;
-        const n = std.unicode.utf8Encode(cp, &tmp) catch return primitives.typeError("string-map", "valid character", result);
-        result_buf.appendSlice(gc.allocator, tmp[0..n]) catch return PrimitiveError.OutOfMemory;
-    }
-
-    return gc.allocString(result_buf.items) catch return PrimitiveError.OutOfMemory;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -21,8 +21,11 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "vector-copy", .func = &vectorCopyFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "vector-copy!", .func = &vectorCopyBangFn, .arity = .{ .variadic = 3 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "vector-append", .func = &vectorAppendFn, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "vector-for-each", .func = &vectorForEachFn, .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
-    .{ .name = "vector-map", .func = &vectorMapFn, .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
+    // vector-for-each and vector-map are implemented in Scheme
+    // (src/vm_bootstrap.zig); these entries keep the arity metadata and
+    // library exports.
+    .{ .name = "vector-for-each", .func = primitives.bootstrapStub("vector-for-each"), .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
+    .{ .name = "vector-map", .func = primitives.bootstrapStub("vector-map"), .arity = .{ .variadic = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "vector->string", .func = &vectorToStringFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "vector-empty?", .func = &vectorEmptyFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_133) },
     .{ .name = "vector-count", .func = &vectorCountFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_133) },
@@ -280,95 +283,6 @@ fn vectorAppendFn(args: []const Value) PrimitiveError!Value {
     }
 
     return gc.allocVector(data) catch return PrimitiveError.OutOfMemory;
-}
-
-// ---------------------------------------------------------------------------
-// (vector-for-each proc v1 v2 ...)
-// ---------------------------------------------------------------------------
-
-fn vectorForEachFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const proc = args[0];
-    if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("vector-for-each", "procedure", proc);
-
-    // Validate all vector arguments and find minimum length
-    const vec_count = args.len - 1;
-    if (vec_count == 0) return primitives.typeError("vector-for-each", "at least one vector argument", types.VOID);
-
-    var min_len: usize = std.math.maxInt(usize);
-    for (args[1..]) |a| {
-        if (!types.isVector(a)) return primitives.typeError("vector-for-each", "vector", a);
-        const vlen = types.toVector(a).data.len;
-        if (vlen < min_len) min_len = vlen;
-    }
-
-    // Iterate over elements
-    var stack_buf: [256]Value = undefined;
-    const call_args = if (vec_count > 256)
-        gc.allocator.alloc(Value, vec_count) catch return PrimitiveError.OutOfMemory
-    else
-        stack_buf[0..vec_count];
-    defer if (vec_count > 256) gc.allocator.free(call_args);
-    for (0..min_len) |i| {
-        for (0..vec_count) |vi| {
-            call_args[vi] = types.toVector(args[1 + vi]).data[i];
-        }
-
-        _ = vm.callWithArgs(proc, call_args) catch |err| {
-            return err;
-        };
-    }
-
-    return types.VOID;
-}
-
-// ---------------------------------------------------------------------------
-// (vector-map proc v1 v2 ...)
-// ---------------------------------------------------------------------------
-
-fn vectorMapFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const proc = args[0];
-    if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return primitives.typeError("vector-map", "procedure", proc);
-
-    // Validate all vector arguments and find minimum length
-    const vec_count = args.len - 1;
-    if (vec_count == 0) return primitives.typeError("vector-map", "at least one vector argument", types.VOID);
-
-    var min_len: usize = std.math.maxInt(usize);
-    for (args[1..]) |a| {
-        if (!types.isVector(a)) return primitives.typeError("vector-map", "vector", a);
-        const vlen = types.toVector(a).data.len;
-        if (vlen < min_len) min_len = vlen;
-    }
-
-    // Allocate result buffer
-    const results = gc.allocator.alloc(Value, min_len) catch return PrimitiveError.OutOfMemory;
-    defer gc.allocator.free(results);
-
-    const scope = gc.rootedScope();
-    defer scope.release();
-
-    var stack_buf: [256]Value = undefined;
-    const call_args = if (vec_count > 256)
-        gc.allocator.alloc(Value, vec_count) catch return PrimitiveError.OutOfMemory
-    else
-        stack_buf[0..vec_count];
-    defer if (vec_count > 256) gc.allocator.free(call_args);
-    for (0..min_len) |i| {
-        for (0..vec_count) |vi| {
-            call_args[vi] = types.toVector(args[1 + vi]).data[i];
-        }
-
-        results[i] = vm.callWithArgs(proc, call_args) catch |err| {
-            return err;
-        };
-        gc.extra_roots.append(gc.allocator, results[i]) catch return PrimitiveError.OutOfMemory;
-    }
-
-    return gc.allocVector(results) catch return PrimitiveError.OutOfMemory;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -506,3 +506,23 @@ test "Unicode symbol write/read round-trip (#1268)" {
     );
     try std.testing.expectEqual(types.TRUE, result);
 }
+
+test "bootstrap stubs fail loudly without vm_bootstrap.install (#1375)" {
+    // A VM that registers primitives but never runs vm_bootstrap.install()
+    // must raise a clear error from the bootstrapped procedures instead of
+    // silently reverting to retired native implementations.
+    const vm_mod = @import("vm.zig");
+    const primitives_mod = @import("primitives.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try vm_mod.VM.init(&gc);
+    defer vm.deinit();
+    memory.setGCInstance(&gc);
+    try primitives_mod.registerAll(&vm);
+
+    const result = vm.eval("(map (lambda (x) x) (list 1 2 3))");
+    try std.testing.expectError(vm_mod.VMError.TypeError, result);
+    const detail = vm.last_error_detail[0..vm.last_error_detail_len];
+    try std.testing.expect(std.mem.indexOf(u8, detail, "vm_bootstrap.install") != null);
+    try std.testing.expect(std.mem.indexOf(u8, detail, "'map'") != null);
+}

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -513,7 +513,18 @@ test "every spec name resolves in globals (drift guard)" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    for (&@import("primitives.zig").all_specs) |spec| {
+    for (&primitives_mod.all_specs) |spec| {
+        // .internal-only helpers are deliberately removed from globals by
+        // vm_bootstrap.install() after being captured by the bootstrapped
+        // closures (#1375) — they must NOT resolve.
+        const internal_only = spec.libs.eql(primitives_mod.LibSet.initOne(.internal));
+        if (internal_only) {
+            if (vm.globals.get(spec.name) != null) {
+                std.debug.print("DRIFT: internal spec \"{s}\" is still in globals\n", .{spec.name});
+                return error.TestUnexpectedResult;
+            }
+            continue;
+        }
         if (vm.globals.get(spec.name) == null) {
             std.debug.print("DRIFT: spec \"{s}\" is not in globals\n", .{spec.name});
             return error.TestUnexpectedResult;

--- a/src/vm_bootstrap.zig
+++ b/src/vm_bootstrap.zig
@@ -190,63 +190,73 @@ const vector_map_src =
     \\            result)))))
 ;
 
+// Strings are UTF-8; indexing by codepoint (string-ref) rescans from byte 0
+// each call, so an index-driven loop is O(n^2). Convert to char lists once
+// (one O(n) pass per string) and walk pairs instead.
 const string_for_each_src =
     \\(define string-for-each
-    \\  (let ((null? null?) (car car) (cdr cdr) (cons cons) (apply apply)
-    \\        (string-length string-length) (string-ref string-ref)
-    \\        (procedure? procedure?) (not not) (error error)
-    \\        (< <) (>= >=) (+ +))
+    \\  (let ((null? null?) (pair? pair?) (car car) (cdr cdr) (cons cons)
+    \\        (apply apply) (string->list string->list)
+    \\        (procedure? procedure?) (not not) (error error))
     \\    (lambda (proc str1 . strs)
     \\      (if (not (procedure? proc))
     \\          (error "type error in 'string-for-each': expected procedure, got" proc))
     \\      (if (null? strs)
-    \\          (let ((len (string-length str1)))
-    \\            (do ((i 0 (+ i 1))) ((>= i len))
-    \\              (proc (string-ref str1 i))))
-    \\          (let ((len (let min-len ((s strs) (m (string-length str1)))
-    \\                       (if (null? s) m
-    \\                           (let ((n (string-length (car s))))
-    \\                             (min-len (cdr s) (if (< n m) n m))))))
-    \\                (all (cons str1 strs)))
-    \\            (do ((i 0 (+ i 1))) ((>= i len))
-    \\              (apply proc
-    \\                (let refs ((s all))
-    \\                  (if (null? s) '()
-    \\                      (cons (string-ref (car s) i)
-    \\                            (refs (cdr s))))))))))))
+    \\          (let loop ((l (string->list str1)))
+    \\            (when (pair? l)
+    \\              (proc (car l))
+    \\              (loop (cdr l))))
+    \\          (let loop ((ls (let conv ((s (cons str1 strs)))
+    \\                           (if (null? s) '()
+    \\                               (cons (string->list (car s)) (conv (cdr s)))))))
+    \\            (let ((go (let check ((l ls))
+    \\                        (if (null? l) #t
+    \\                            (if (null? (car l)) #f (check (cdr l)))))))
+    \\              (when go
+    \\                (apply proc
+    \\                  (let cars ((l ls))
+    \\                    (if (null? l) '()
+    \\                        (cons (car (car l)) (cars (cdr l))))))
+    \\                (loop
+    \\                  (let cdrs ((l ls))
+    \\                    (if (null? l) '()
+    \\                        (cons (cdr (car l)) (cdrs (cdr l)))))))))))))
 ;
 
+// Same char-list traversal as string-for-each (see comment there).
 const string_map_src =
     \\(define string-map
-    \\  (let ((null? null?) (car car) (cdr cdr) (cons cons) (apply apply)
-    \\        (string-length string-length) (string-ref string-ref)
+    \\  (let ((null? null?) (pair? pair?) (car car) (cdr cdr) (cons cons)
+    \\        (apply apply) (string->list string->list)
     \\        (list->string list->string) (reverse reverse)
-    \\        (procedure? procedure?) (not not) (error error)
-    \\        (< <) (>= >=) (+ +))
+    \\        (procedure? procedure?) (not not) (error error))
     \\    (lambda (proc str1 . strs)
     \\      (if (not (procedure? proc))
     \\          (error "type error in 'string-map': expected procedure, got" proc))
-    \\      (let ((len (if (null? strs)
-    \\                     (string-length str1)
-    \\                     (let min-len ((s strs) (m (string-length str1)))
-    \\                       (if (null? s) m
-    \\                           (let ((n (string-length (car s))))
-    \\                             (min-len (cdr s) (if (< n m) n m)))))))
-    \\            (all (cons str1 strs)))
-    \\        (list->string
-    \\          (let loop ((i 0) (acc '()))
-    \\            (if (>= i len)
-    \\                (reverse acc)
-    \\                (loop (+ i 1)
-    \\                  (cons
-    \\                    (if (null? strs)
-    \\                        (proc (string-ref str1 i))
-    \\                        (apply proc
-    \\                          (let refs ((s all))
-    \\                            (if (null? s) '()
-    \\                                (cons (string-ref (car s) i)
-    \\                                      (refs (cdr s)))))))
-    \\                    acc)))))))))
+    \\      (if (null? strs)
+    \\          (let loop ((l (string->list str1)) (acc '()))
+    \\            (if (pair? l)
+    \\                (loop (cdr l) (cons (proc (car l)) acc))
+    \\                (list->string (reverse acc))))
+    \\          (let loop ((ls (let conv ((s (cons str1 strs)))
+    \\                           (if (null? s) '()
+    \\                               (cons (string->list (car s)) (conv (cdr s))))))
+    \\                     (acc '()))
+    \\            (let ((go (let check ((l ls))
+    \\                        (if (null? l) #t
+    \\                            (if (null? (car l)) #f (check (cdr l)))))))
+    \\              (if go
+    \\                  (loop
+    \\                    (let cdrs ((l ls))
+    \\                      (if (null? l) '()
+    \\                          (cons (cdr (car l)) (cdrs (cdr l)))))
+    \\                    (cons
+    \\                      (apply proc
+    \\                        (let cars ((l ls))
+    \\                          (if (null? l) '()
+    \\                              (cons (car (car l)) (cars (cdr l))))))
+    \\                      acc))
+    \\                  (list->string (reverse acc)))))))))
 ;
 
 // Validates all three arguments before running (before), so a bad-argument

--- a/src/vm_bootstrap.zig
+++ b/src/vm_bootstrap.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+const reporting = @import("reporting.zig");
 const vm_mod = @import("vm.zig");
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
@@ -7,12 +9,49 @@ const VMError = vm_mod.VMError;
 /// that fibers can park and continuations can be captured/restored inside
 /// callbacks. Called at init time between registerAll() and
 /// registerStandardLibraries(). Each (define ...) overwrites the native
-/// version already in vm.globals.
+/// stub already in vm.globals (see primitives.bootstrapStub).
+///
+/// Every definition is wrapped in a `let` that captures its dependencies
+/// (car, cdr, apply, %push-wind, ...) as closure upvalues at install time,
+/// so a later top-level redefinition of a base binding cannot change the
+/// behavior of these procedures — matching the immunity the native
+/// implementations had (#1375).
 pub fn install(vm: *VM) VMError!void {
-    inline for (definitions) |src| {
-        _ = try vm.eval(src);
+    inline for (definitions, 0..) |src, i| {
+        _ = vm.eval(src) catch |err| {
+            // A failed bootstrap would otherwise abort VM startup with a bare
+            // exit code; say which definition broke.
+            var buf: [128]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "vm_bootstrap.install: definition {d} ({s}...) failed: {s}\n", .{ i, src[0..@min(src.len, 24)], @errorName(err) }) catch "vm_bootstrap.install failed\n";
+            reporting.writeStderr(msg);
+            return err;
+        };
     }
+    // The %-helpers registered by primitives_control.zig / primitives_lazy.zig
+    // exist only to be captured by the closures above. Remove them from the
+    // global namespace so they cannot be reached without an import: calling
+    // %push-wind without a matching %pop-wind corrupts the wind stack, and
+    // the %promise-* mutators can corrupt promise state (#1375).
+    {
+        vm.globals_lock.lock();
+        defer vm.globals_lock.unlock();
+        for (internal_helpers) |name| {
+            _ = vm.globals.remove(name);
+        }
+    }
+    vm.global_version +%= 1;
 }
+
+const internal_helpers = [_][]const u8{
+    "%push-wind",
+    "%pop-wind",
+    "%promise-forced?",
+    "%promise-forcing?",
+    "%promise-value",
+    "%promise-complete!",
+    "%promise-set-forcing!",
+    "%promise-merge!",
+};
 
 const definitions = [_][]const u8{
     for_each_src,
@@ -26,196 +65,266 @@ const definitions = [_][]const u8{
 };
 
 const for_each_src =
-    \\(define (for-each proc . lists)
-    \\  (if (null? (cdr lists))
-    \\      (let loop ((lst (car lists)))
-    \\        (if (pair? lst)
-    \\            (begin (proc (car lst)) (loop (cdr lst)))
-    \\            (if (null? lst)
-    \\                (if #f #f)
-    \\                (error "for-each: not a proper list"))))
-    \\      (let loop ((lsts lists))
-    \\        (let ((go (let check ((l lsts))
-    \\                    (if (null? l) #t
-    \\                        (if (null? (car l)) #f
-    \\                            (if (not (pair? (car l)))
-    \\                                (error "for-each: not a proper list")
-    \\                                (check (cdr l))))))))
-    \\          (when go
-    \\            (apply proc
-    \\              (let cars ((l lsts))
-    \\                (if (null? l) '()
-    \\                    (cons (car (car l)) (cars (cdr l))))))
-    \\            (loop
-    \\              (let cdrs ((l lsts))
-    \\                (if (null? l) '()
-    \\                    (cons (cdr (car l)) (cdrs (cdr l)))))))))))
+    \\(define for-each
+    \\  (let ((null? null?) (pair? pair?) (car car) (cdr cdr) (cons cons)
+    \\        (apply apply) (procedure? procedure?) (not not) (error error))
+    \\    (lambda (proc list1 . lists)
+    \\      (if (not (procedure? proc))
+    \\          (error "type error in 'for-each': expected procedure, got" proc))
+    \\      (if (null? lists)
+    \\          (let loop ((lst list1))
+    \\            (if (pair? lst)
+    \\                (begin (proc (car lst)) (loop (cdr lst)))
+    \\                (if (null? lst)
+    \\                    (if #f #f)
+    \\                    (error "for-each: not a proper list"))))
+    \\          (let loop ((lsts (cons list1 lists)))
+    \\            (let ((go (let check ((l lsts))
+    \\                        (if (null? l) #t
+    \\                            (if (null? (car l)) #f
+    \\                                (if (not (pair? (car l)))
+    \\                                    (error "for-each: not a proper list")
+    \\                                    (check (cdr l))))))))
+    \\              (when go
+    \\                (apply proc
+    \\                  (let cars ((l lsts))
+    \\                    (if (null? l) '()
+    \\                        (cons (car (car l)) (cars (cdr l))))))
+    \\                (loop
+    \\                  (let cdrs ((l lsts))
+    \\                    (if (null? l) '()
+    \\                        (cons (cdr (car l)) (cdrs (cdr l)))))))))))))
 ;
 
 const map_src =
-    \\(define (map proc . lists)
-    \\  (if (null? (cdr lists))
-    \\      (let loop ((lst (car lists)) (acc '()))
-    \\        (if (pair? lst)
-    \\            (loop (cdr lst) (cons (proc (car lst)) acc))
-    \\            (if (null? lst)
-    \\                (reverse acc)
-    \\                (error "map: not a proper list"))))
-    \\      (let loop ((lsts lists) (acc '()))
-    \\        (let ((go (let check ((l lsts))
-    \\                    (if (null? l) #t
-    \\                        (if (null? (car l)) #f
-    \\                            (if (not (pair? (car l)))
-    \\                                (error "map: not a proper list")
-    \\                                (check (cdr l))))))))
-    \\          (if go
-    \\              (loop
-    \\                (let cdrs ((l lsts))
-    \\                  (if (null? l) '()
-    \\                      (cons (cdr (car l)) (cdrs (cdr l)))))
-    \\                (cons
-    \\                  (apply proc
-    \\                    (let cars ((l lsts))
+    \\(define map
+    \\  (let ((null? null?) (pair? pair?) (car car) (cdr cdr) (cons cons)
+    \\        (reverse reverse) (apply apply) (procedure? procedure?)
+    \\        (not not) (error error))
+    \\    (lambda (proc list1 . lists)
+    \\      (if (not (procedure? proc))
+    \\          (error "type error in 'map': expected procedure, got" proc))
+    \\      (if (null? lists)
+    \\          (let loop ((lst list1) (acc '()))
+    \\            (if (pair? lst)
+    \\                (loop (cdr lst) (cons (proc (car lst)) acc))
+    \\                (if (null? lst)
+    \\                    (reverse acc)
+    \\                    (error "map: not a proper list"))))
+    \\          (let loop ((lsts (cons list1 lists)) (acc '()))
+    \\            (let ((go (let check ((l lsts))
+    \\                        (if (null? l) #t
+    \\                            (if (null? (car l)) #f
+    \\                                (if (not (pair? (car l)))
+    \\                                    (error "map: not a proper list")
+    \\                                    (check (cdr l))))))))
+    \\              (if go
+    \\                  (loop
+    \\                    (let cdrs ((l lsts))
     \\                      (if (null? l) '()
-    \\                          (cons (car (car l)) (cars (cdr l))))))
-    \\                  acc))
-    \\              (reverse acc))))))
+    \\                          (cons (cdr (car l)) (cdrs (cdr l)))))
+    \\                    (cons
+    \\                      (apply proc
+    \\                        (let cars ((l lsts))
+    \\                          (if (null? l) '()
+    \\                              (cons (car (car l)) (cars (cdr l))))))
+    \\                      acc))
+    \\                  (reverse acc))))))))
 ;
 
 const vector_for_each_src =
-    \\(define (vector-for-each proc . vecs)
-    \\  (let ((len (let min-len ((v vecs) (m #f))
-    \\              (if (null? v) m
-    \\                  (let ((n (vector-length (car v))))
-    \\                    (min-len (cdr v) (if (or (not m) (< n m)) n m)))))))
-    \\    (if (null? (cdr vecs))
-    \\        (let ((vec (car vecs)))
-    \\          (do ((i 0 (+ i 1))) ((>= i len))
-    \\            (proc (vector-ref vec i))))
-    \\        (do ((i 0 (+ i 1))) ((>= i len))
-    \\          (apply proc
-    \\            (let refs ((v vecs))
-    \\              (if (null? v) '()
-    \\                  (cons (vector-ref (car v) i)
-    \\                        (refs (cdr v))))))))))
+    \\(define vector-for-each
+    \\  (let ((null? null?) (car car) (cdr cdr) (cons cons) (apply apply)
+    \\        (vector-length vector-length) (vector-ref vector-ref)
+    \\        (procedure? procedure?) (not not) (error error)
+    \\        (< <) (>= >=) (+ +))
+    \\    (lambda (proc vec1 . vecs)
+    \\      (if (not (procedure? proc))
+    \\          (error "type error in 'vector-for-each': expected procedure, got" proc))
+    \\      (if (null? vecs)
+    \\          (let ((len (vector-length vec1)))
+    \\            (do ((i 0 (+ i 1))) ((>= i len))
+    \\              (proc (vector-ref vec1 i))))
+    \\          (let ((len (let min-len ((v vecs) (m (vector-length vec1)))
+    \\                       (if (null? v) m
+    \\                           (let ((n (vector-length (car v))))
+    \\                             (min-len (cdr v) (if (< n m) n m))))))
+    \\                (all (cons vec1 vecs)))
+    \\            (do ((i 0 (+ i 1))) ((>= i len))
+    \\              (apply proc
+    \\                (let refs ((v all))
+    \\                  (if (null? v) '()
+    \\                      (cons (vector-ref (car v) i)
+    \\                            (refs (cdr v))))))))))))
 ;
 
 const vector_map_src =
-    \\(define (vector-map proc . vecs)
-    \\  (let* ((len (let min-len ((v vecs) (m #f))
-    \\               (if (null? v) m
-    \\                   (let ((n (vector-length (car v))))
-    \\                     (min-len (cdr v) (if (or (not m) (< n m)) n m))))))
-    \\         (result (make-vector len)))
-    \\    (if (null? (cdr vecs))
-    \\        (let ((vec (car vecs)))
-    \\          (do ((i 0 (+ i 1))) ((>= i len))
-    \\            (vector-set! result i (proc (vector-ref vec i)))))
-    \\        (do ((i 0 (+ i 1))) ((>= i len))
-    \\          (vector-set! result i
-    \\            (apply proc
-    \\              (let refs ((v vecs))
-    \\                (if (null? v) '()
-    \\                    (cons (vector-ref (car v) i)
-    \\                          (refs (cdr v)))))))))
-    \\    result))
+    \\(define vector-map
+    \\  (let ((null? null?) (car car) (cdr cdr) (cons cons) (apply apply)
+    \\        (vector-length vector-length) (vector-ref vector-ref)
+    \\        (vector-set! vector-set!) (make-vector make-vector)
+    \\        (procedure? procedure?) (not not) (error error)
+    \\        (< <) (>= >=) (+ +))
+    \\    (lambda (proc vec1 . vecs)
+    \\      (if (not (procedure? proc))
+    \\          (error "type error in 'vector-map': expected procedure, got" proc))
+    \\      (if (null? vecs)
+    \\          (let* ((len (vector-length vec1))
+    \\                 (result (make-vector len)))
+    \\            (do ((i 0 (+ i 1))) ((>= i len))
+    \\              (vector-set! result i (proc (vector-ref vec1 i))))
+    \\            result)
+    \\          (let* ((len (let min-len ((v vecs) (m (vector-length vec1)))
+    \\                        (if (null? v) m
+    \\                            (let ((n (vector-length (car v))))
+    \\                              (min-len (cdr v) (if (< n m) n m))))))
+    \\                 (all (cons vec1 vecs))
+    \\                 (result (make-vector len)))
+    \\            (do ((i 0 (+ i 1))) ((>= i len))
+    \\              (vector-set! result i
+    \\                (apply proc
+    \\                  (let refs ((v all))
+    \\                    (if (null? v) '()
+    \\                        (cons (vector-ref (car v) i)
+    \\                              (refs (cdr v))))))))
+    \\            result)))))
 ;
 
 const string_for_each_src =
-    \\(define (string-for-each proc . strs)
-    \\  (let ((len (let min-len ((s strs) (m #f))
-    \\              (if (null? s) m
-    \\                  (let ((n (string-length (car s))))
-    \\                    (min-len (cdr s) (if (or (not m) (< n m)) n m)))))))
-    \\    (if (null? (cdr strs))
-    \\        (let ((str (car strs)))
-    \\          (do ((i 0 (+ i 1))) ((>= i len))
-    \\            (proc (string-ref str i))))
-    \\        (do ((i 0 (+ i 1))) ((>= i len))
-    \\          (apply proc
-    \\            (let refs ((s strs))
-    \\              (if (null? s) '()
-    \\                  (cons (string-ref (car s) i)
-    \\                        (refs (cdr s))))))))))
+    \\(define string-for-each
+    \\  (let ((null? null?) (car car) (cdr cdr) (cons cons) (apply apply)
+    \\        (string-length string-length) (string-ref string-ref)
+    \\        (procedure? procedure?) (not not) (error error)
+    \\        (< <) (>= >=) (+ +))
+    \\    (lambda (proc str1 . strs)
+    \\      (if (not (procedure? proc))
+    \\          (error "type error in 'string-for-each': expected procedure, got" proc))
+    \\      (if (null? strs)
+    \\          (let ((len (string-length str1)))
+    \\            (do ((i 0 (+ i 1))) ((>= i len))
+    \\              (proc (string-ref str1 i))))
+    \\          (let ((len (let min-len ((s strs) (m (string-length str1)))
+    \\                       (if (null? s) m
+    \\                           (let ((n (string-length (car s))))
+    \\                             (min-len (cdr s) (if (< n m) n m))))))
+    \\                (all (cons str1 strs)))
+    \\            (do ((i 0 (+ i 1))) ((>= i len))
+    \\              (apply proc
+    \\                (let refs ((s all))
+    \\                  (if (null? s) '()
+    \\                      (cons (string-ref (car s) i)
+    \\                            (refs (cdr s))))))))))))
 ;
 
 const string_map_src =
-    \\(define (string-map proc . strs)
-    \\  (let ((len (let min-len ((s strs) (m #f))
-    \\              (if (null? s) m
-    \\                  (let ((n (string-length (car s))))
-    \\                    (min-len (cdr s) (if (or (not m) (< n m)) n m)))))))
-    \\    (list->string
-    \\      (let loop ((i 0) (acc '()))
-    \\        (if (>= i len)
-    \\            (reverse acc)
-    \\            (loop (+ i 1)
-    \\              (cons
-    \\                (if (null? (cdr strs))
-    \\                    (proc (string-ref (car strs) i))
-    \\                    (apply proc
-    \\                      (let refs ((s strs))
-    \\                        (if (null? s) '()
-    \\                            (cons (string-ref (car s) i)
-    \\                                  (refs (cdr s)))))))
-    \\                acc)))))))
+    \\(define string-map
+    \\  (let ((null? null?) (car car) (cdr cdr) (cons cons) (apply apply)
+    \\        (string-length string-length) (string-ref string-ref)
+    \\        (list->string list->string) (reverse reverse)
+    \\        (procedure? procedure?) (not not) (error error)
+    \\        (< <) (>= >=) (+ +))
+    \\    (lambda (proc str1 . strs)
+    \\      (if (not (procedure? proc))
+    \\          (error "type error in 'string-map': expected procedure, got" proc))
+    \\      (let ((len (if (null? strs)
+    \\                     (string-length str1)
+    \\                     (let min-len ((s strs) (m (string-length str1)))
+    \\                       (if (null? s) m
+    \\                           (let ((n (string-length (car s))))
+    \\                             (min-len (cdr s) (if (< n m) n m)))))))
+    \\            (all (cons str1 strs)))
+    \\        (list->string
+    \\          (let loop ((i 0) (acc '()))
+    \\            (if (>= i len)
+    \\                (reverse acc)
+    \\                (loop (+ i 1)
+    \\                  (cons
+    \\                    (if (null? strs)
+    \\                        (proc (string-ref str1 i))
+    \\                        (apply proc
+    \\                          (let refs ((s all))
+    \\                            (if (null? s) '()
+    \\                                (cons (string-ref (car s) i)
+    \\                                      (refs (cdr s)))))))
+    \\                    acc)))))))))
 ;
 
+// Validates all three arguments before running (before), so a bad-argument
+// call cannot leak before's side effects, and errors name 'dynamic-wind'
+// rather than the internal %push-wind (#1375).
 const dynamic_wind_src =
-    \\(define (dynamic-wind before thunk after)
-    \\  (before)
-    \\  (%push-wind before after)
-    \\  (let ((result (thunk)))
-    \\    (%pop-wind)
-    \\    (after)
-    \\    result))
+    \\(define dynamic-wind
+    \\  (let ((%push-wind %push-wind) (%pop-wind %pop-wind)
+    \\        (procedure? procedure?) (not not) (error error))
+    \\    (lambda (before thunk after)
+    \\      (if (not (procedure? before))
+    \\          (error "type error in 'dynamic-wind': expected procedure, got" before))
+    \\      (if (not (procedure? thunk))
+    \\          (error "type error in 'dynamic-wind': expected procedure, got" thunk))
+    \\      (if (not (procedure? after))
+    \\          (error "type error in 'dynamic-wind': expected procedure, got" after))
+    \\      (before)
+    \\      (%push-wind before after)
+    \\      (let ((result (thunk)))
+    \\        (%pop-wind)
+    \\        (after)
+    \\        result))))
 ;
 
 const force_src =
-    \\(define (force p)
-    \\  (if (not (promise? p)) p
-    \\      (let loop ((current p))
-    \\        (if (not (promise? current)) current
-    \\            (if (%promise-forced? current)
-    \\                (loop (%promise-value current))
-    \\                (let ((thunk (%promise-value current)))
-    \\                  (if (not (procedure? thunk))
-    \\                      (begin (%promise-complete! current thunk) thunk)
-    \\                      (begin
-    \\                        (%promise-set-forcing! current #t)
-    \\                        ;; Clear `forcing` on ABNORMAL exit only (raise or
-    \\                        ;; call/cc escape), matching the native forceFn's
-    \\                        ;; `catch |err|`. Normal returns keep it set so the
-    \\                        ;; (%promise-forcing? result) cycle check below can
-    \\                        ;; see it; the exit paths clear it explicitly.
-    \\                        (let* ((ok #f)
-    \\                               (result
-    \\                                (dynamic-wind
-    \\                                  (lambda () #f)
-    \\                                  (lambda ()
-    \\                                    (let ((r (thunk))) (set! ok #t) r))
-    \\                                  (lambda ()
-    \\                                    (if (not ok)
-    \\                                        (%promise-set-forcing! current #f))))))
-    \\                          (if (%promise-forced? current)
-    \\                              (begin
-    \\                                (%promise-set-forcing! current #f)
-    \\                                (loop (%promise-value current)))
-    \\                              (if (promise? result)
-    \\                                  (if (%promise-forcing? result)
-    \\                                      (begin
-    \\                                        (%promise-set-forcing! current #f)
-    \\                                        (error "re-entrant forcing of promise"))
-    \\                                      (if (%promise-forced? result)
-    \\                                          (begin
-    \\                                            (%promise-set-forcing! current #f)
-    \\                                            (%promise-complete! current (%promise-value result))
-    \\                                            (loop (%promise-value result)))
-    \\                                          (begin
-    \\                                            (%promise-merge! current result)
-    \\                                            (loop current))))
+    \\(define force
+    \\  (let ((promise? promise?) (procedure? procedure?) (not not)
+    \\        (dynamic-wind dynamic-wind) (error error)
+    \\        (%promise-forced? %promise-forced?)
+    \\        (%promise-forcing? %promise-forcing?)
+    \\        (%promise-value %promise-value)
+    \\        (%promise-complete! %promise-complete!)
+    \\        (%promise-set-forcing! %promise-set-forcing!)
+    \\        (%promise-merge! %promise-merge!))
+    \\    (lambda (p)
+    \\      (if (not (promise? p)) p
+    \\          (let loop ((current p))
+    \\            (if (not (promise? current)) current
+    \\                (if (%promise-forced? current)
+    \\                    (loop (%promise-value current))
+    \\                    (let ((thunk (%promise-value current)))
+    \\                      (if (not (procedure? thunk))
+    \\                          (begin (%promise-complete! current thunk) thunk)
+    \\                          (begin
+    \\                            (%promise-set-forcing! current #t)
+    \\                            ;; Clear `forcing` on ABNORMAL exit only (raise or
+    \\                            ;; call/cc escape), matching the native forceFn's
+    \\                            ;; `catch |err|`. Normal returns keep it set so the
+    \\                            ;; (%promise-forcing? result) cycle check below can
+    \\                            ;; see it; the exit paths clear it explicitly.
+    \\                            (let* ((ok #f)
+    \\                                   (result
+    \\                                    (dynamic-wind
+    \\                                      (lambda () #f)
+    \\                                      (lambda ()
+    \\                                        (let ((r (thunk))) (set! ok #t) r))
+    \\                                      (lambda ()
+    \\                                        (if (not ok)
+    \\                                            (%promise-set-forcing! current #f))))))
+    \\                              (if (%promise-forced? current)
     \\                                  (begin
     \\                                    (%promise-set-forcing! current #f)
-    \\                                    (%promise-complete! current result)
-    \\                                    result))))))))))))
+    \\                                    (loop (%promise-value current)))
+    \\                                  (if (promise? result)
+    \\                                      (if (%promise-forcing? result)
+    \\                                          (begin
+    \\                                            (%promise-set-forcing! current #f)
+    \\                                            (error "re-entrant forcing of promise"))
+    \\                                          (if (%promise-forced? result)
+    \\                                              (begin
+    \\                                                (%promise-set-forcing! current #f)
+    \\                                                (%promise-complete! current (%promise-value result))
+    \\                                                (loop (%promise-value result)))
+    \\                                              (begin
+    \\                                                (%promise-merge! current result)
+    \\                                                (loop current))))
+    \\                                      (begin
+    \\                                        (%promise-set-forcing! current #f)
+    \\                                        (%promise-complete! current result)
+    \\                                        result))))))))))))))
 ;

--- a/tests/scheme/audit/primitives_lazy-audit.scm
+++ b/tests/scheme/audit/primitives_lazy-audit.scm
@@ -112,13 +112,21 @@
 
 ;; A call/cc escape out of the thunk must also reset the forcing flag
 ;; (the native forceFn cleared it on any abnormal exit, escapes included).
+;; The flag itself is no longer observable (%promise-forcing? is not
+;; globally reachable since #1375), so probe it behaviorally: if the escape
+;; left it set, forcing p through a delay-force chain would raise
+;; "re-entrant forcing of promise" instead of re-running the thunk.
 (let ()
   (define p #f)
+  (define fired #f)
   (define v (call/cc (lambda (escape)
-                       (set! p (delay (escape 'out)))
+                       (set! p (delay (if fired
+                                          'done
+                                          (begin (set! fired #t)
+                                                 (escape 'out)))))
                        (force p))))
   (test 'out v)
-  (test #f (%promise-forcing? p)))
+  (test 'done (force (delay-force p))))
 
 ;;; --- continuation captured in a promise thunk, reinvoked after force ---
 ;; force is bytecode-driven (#1347): a full continuation captured inside

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -285,6 +285,26 @@ assert_output_contains "reverse type error names procedure" \
 assert_output_contains "apply type error for non-procedure" \
     '(apply 42 (list 1))' "procedure"
 
+# --- #1375: bootstrapped iteration procedures report clean arity/type errors,
+# not leaked internals ('cdr', 'make-vector', '%push-wind') ---
+echo
+echo "-- Bootstrapped procedure diagnostics (#1375) --"
+assert_output_contains "(map car) reports map arity" \
+    '(map car)' "'map': expected at least 2 arguments, got 1"
+
+assert_output_contains "(vector-map +) reports vector-map arity" \
+    '(vector-map +)' "'vector-map': expected at least 2 arguments, got 1"
+
+assert_output_contains "(map 5 ...) names map" \
+    '(map 5 (list 1 2 3))' "type error in 'map': expected procedure, got 5"
+
+assert_output_contains "dynamic-wind bad after names dynamic-wind" \
+    '(dynamic-wind (lambda () #t) (lambda () 1) 42)' \
+    "type error in 'dynamic-wind': expected procedure, got 42"
+
+assert_output_contains "%push-wind is not globally reachable" \
+    '(%push-wind car car)' "undefined variable"
+
 echo
 echo "=== Results ==="
 echo "Passed: $PASS"

--- a/tests/scheme/smoke/trampoline-polish-1375.scm
+++ b/tests/scheme/smoke/trampoline-polish-1375.scm
@@ -1,0 +1,169 @@
+;; Regression test for #1375: follow-up polish for the Scheme-bootstrapped
+;; map/for-each/vector-map/vector-for-each/string-map/string-for-each/
+;; dynamic-wind/force family (PR #1374).
+;;
+;; Covers:
+;;   1. zero-sequence misuse raises clean arity errors (not leaked internals)
+;;      and non-procedure proc raises a type error naming the procedure
+;;   2. the %-helpers (%push-wind, %promise-*, ...) are not globally callable
+;;   3. iteration procedures are immune to top-level redefinition of the
+;;      base procedures they use internally
+;;   4. dynamic-wind validates all arguments before running `before`
+(import (scheme base) (scheme char) (scheme lazy) (scheme write)
+        (scheme process-context) (srfi 13) (srfi 64))
+
+(test-begin "trampoline-polish-1375")
+
+;; --- 1. arity errors -------------------------------------------------------
+
+(define (error-message thunk)
+  (guard (e (#t (if (error-object? e) (error-object-message e) 'not-error-object)))
+    (thunk)
+    'no-error))
+
+(test-assert "(map car) raises an arity error"
+  (string-contains (error-message (lambda () (map car)))
+                   "expected at least 2 arguments"))
+
+(test-assert "(for-each car) raises an arity error"
+  (string-contains (error-message (lambda () (for-each car)))
+                   "expected at least 2 arguments"))
+
+(test-assert "(vector-map +) raises an arity error"
+  (string-contains (error-message (lambda () (vector-map +)))
+                   "expected at least 2 arguments"))
+
+(test-assert "(vector-for-each +) raises an arity error"
+  (string-contains (error-message (lambda () (vector-for-each +)))
+                   "expected at least 2 arguments"))
+
+(test-assert "(string-map char-upcase) raises an arity error"
+  (string-contains (error-message (lambda () (string-map char-upcase)))
+                   "expected at least 2 arguments"))
+
+(test-assert "(string-for-each write-char) raises an arity error"
+  (string-contains (error-message (lambda () (string-for-each write-char)))
+                   "expected at least 2 arguments"))
+
+;; --- 1b. non-procedure first argument names the procedure ------------------
+
+(test-assert "(map 5 ...) type error names map"
+  (string-contains (error-message (lambda () (map 5 '(1 2 3)))) "'map'"))
+
+(test-assert "(for-each 5 ...) type error names for-each"
+  (string-contains (error-message (lambda () (for-each 5 '(1)))) "'for-each'"))
+
+(test-assert "(vector-map 5 ...) type error names vector-map"
+  (string-contains (error-message (lambda () (vector-map 5 #(1)))) "'vector-map'"))
+
+(test-assert "(vector-for-each 5 ...) type error names vector-for-each"
+  (string-contains (error-message (lambda () (vector-for-each 5 #(1))))
+                   "'vector-for-each'"))
+
+(test-assert "(string-map 5 ...) type error names string-map"
+  (string-contains (error-message (lambda () (string-map 5 "a"))) "'string-map'"))
+
+(test-assert "(string-for-each 5 ...) type error names string-for-each"
+  (string-contains (error-message (lambda () (string-for-each 5 "a")))
+                   "'string-for-each'"))
+
+;; --- 2. %-helpers are not reachable without an import ----------------------
+
+(define-syntax unbound?
+  (syntax-rules ()
+    ((_ name) (guard (e (#t 'unbound)) name))))
+
+(test-equal "%push-wind is unbound" 'unbound (unbound? %push-wind))
+(test-equal "%pop-wind is unbound" 'unbound (unbound? %pop-wind))
+(test-equal "%promise-forced? is unbound" 'unbound (unbound? %promise-forced?))
+(test-equal "%promise-forcing? is unbound" 'unbound (unbound? %promise-forcing?))
+(test-equal "%promise-value is unbound" 'unbound (unbound? %promise-value))
+(test-equal "%promise-complete! is unbound" 'unbound (unbound? %promise-complete!))
+(test-equal "%promise-set-forcing! is unbound" 'unbound (unbound? %promise-set-forcing!))
+(test-equal "%promise-merge! is unbound" 'unbound (unbound? %promise-merge!))
+
+;; --- 3. immunity to top-level redefinition ---------------------------------
+
+;; map uses reverse internally; a top-level redefinition must not change
+;; map's behavior (the bootstrap captures its dependencies at install time).
+(define %original-reverse reverse)
+(define reverse (lambda (x) 'HIJACKED))
+(define hijacked-map-result (map (lambda (x) (* 2 x)) '(1 2 3)))
+(set! reverse %original-reverse)
+(test-equal "map immune to reverse redefinition" '(2 4 6) hijacked-map-result)
+
+(define %original-apply apply)
+(define apply (lambda args 'HIJACKED))
+(define hijacked-multi-map (map + '(1 2) '(10 20)))
+(set! apply %original-apply)
+(test-equal "multi-list map immune to apply redefinition"
+            '(11 22) hijacked-multi-map)
+
+;; --- 4. dynamic-wind validates arguments before running before -------------
+
+(define before-ran #f)
+(define dw-error
+  (error-message
+   (lambda ()
+     (dynamic-wind (lambda () (set! before-ran #t)) (lambda () 1) 42))))
+(test-equal "dynamic-wind rejects bad after without running before"
+            #f before-ran)
+(test-assert "dynamic-wind bad-argument error names dynamic-wind"
+  (string-contains dw-error "'dynamic-wind'"))
+(test-assert "dynamic-wind error does not leak %push-wind"
+  (not (string-contains dw-error "%push-wind")))
+
+(define dw-thunk-error
+  (error-message (lambda () (dynamic-wind (lambda () #t) 7 (lambda () #t)))))
+(test-assert "dynamic-wind bad thunk names dynamic-wind"
+  (string-contains dw-thunk-error "'dynamic-wind'"))
+
+;; --- behavior spot checks (multi-sequence paths were restructured) ---------
+
+(test-equal "single-list map" '(2 4 6) (map (lambda (x) (* 2 x)) '(1 2 3)))
+(test-equal "two-list map" '(11 22 33) (map + '(1 2 3) '(10 20 30)))
+(test-equal "three-list map" '(111 222) (map + '(1 2) '(10 20) '(100 200)))
+(test-equal "map stops at shortest list" '(11) (map + '(1) '(10 20 30)))
+(test-equal "map on empty list" '() (map car '()))
+
+(define fe-acc '())
+(for-each (lambda (a b) (set! fe-acc (cons (+ a b) fe-acc))) '(1 2) '(10 20))
+(test-equal "two-list for-each" '(22 11) fe-acc)
+
+(test-equal "single-vector vector-map" #(2 4) (vector-map (lambda (x) (* 2 x)) #(1 2)))
+(test-equal "two-vector vector-map" #(11 22) (vector-map + #(1 2) #(10 20)))
+(test-equal "vector-map stops at shortest" #(11) (vector-map + #(1 2 3) #(10)))
+(test-equal "vector-map on empty vector" #() (vector-map + #()))
+
+(define vfe-acc '())
+(vector-for-each (lambda (a b) (set! vfe-acc (cons (+ a b) vfe-acc))) #(1 2) #(10 20))
+(test-equal "two-vector vector-for-each" '(22 11) vfe-acc)
+
+(test-equal "single-string string-map" "ABC" (string-map char-upcase "abc"))
+(test-equal "two-string string-map stops at shortest"
+            "ab" (string-map (lambda (a b) a) "abc" "xy"))
+(test-equal "string-map on empty string" "" (string-map char-upcase ""))
+
+(define sfe-acc '())
+(string-for-each (lambda (a b) (set! sfe-acc (cons (cons a b) sfe-acc))) "ab" "xyz")
+(test-equal "two-string string-for-each" '((#\b . #\y) (#\a . #\x)) sfe-acc)
+
+(test-assert "improper list error names map"
+  (string-contains
+   (error-message (lambda () (map (lambda (x) x) '(1 2 . 3)))) "map"))
+
+;; dynamic-wind and force still work normally
+(define dw-order '())
+(dynamic-wind
+  (lambda () (set! dw-order (cons 'before dw-order)))
+  (lambda () (set! dw-order (cons 'during dw-order)))
+  (lambda () (set! dw-order (cons 'after dw-order))))
+(test-equal "dynamic-wind runs before/during/after"
+            '(after during before) dw-order)
+
+(test-equal "force of delay" 42 (force (delay 42)))
+(test-equal "force of non-promise" 7 (force 7))
+
+(let ((runner (test-runner-current)))
+  (test-end "trampoline-polish-1375")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/trampoline-polish-1375.scm
+++ b/tests/scheme/smoke/trampoline-polish-1375.scm
@@ -164,6 +164,17 @@
 (test-equal "force of delay" 42 (force (delay 42)))
 (test-equal "force of non-promise" 7 (force 7))
 
+;; string-map/string-for-each must be linear in string length: an
+;; index-driven (string-ref s i) loop is O(n^2) because UTF-8 codepoint
+;; indexing rescans from byte 0. Quadratic behavior takes minutes on
+;; 300k chars and trips the suite's per-file timeout; linear is instant.
+(define big-string (make-string 300000 #\x))
+(define sfe-count 0)
+(string-for-each (lambda (c) (set! sfe-count (+ sfe-count 1))) big-string)
+(test-equal "string-for-each over 300k chars is linear" 300000 sfe-count)
+(test-equal "string-map over 300k chars is linear"
+            300000 (string-length (string-map char-upcase big-string)))
+
 (let ((runner (test-runner-current)))
   (test-end "trampoline-polish-1375")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #1375 — all seven follow-up polish items from the PR #1374 review.

## 1. Clean arity/type errors for misuse (item 1)

The bootstrapped lambda lists now require the first sequence positionally
(`(proc list1 . lists)`), so the VM itself reports the same arity error the
native versions did, and each procedure type-checks `proc` up front:

```scheme
(map car)          ; ⇒ 'map': expected at least 2 arguments, got 1
(vector-map +)     ; ⇒ 'vector-map': expected at least 2 arguments, got 1
(map 5 '(1 2 3))   ; ⇒ type error in 'map': expected procedure, got 5
```

## 2. `%`-helpers no longer globally callable (item 2)

The issue suggested this needed a broader import-gating change; it turned out
to be achievable locally. Each bootstrap definition is wrapped in a `let`
that captures its dependencies (including `%push-wind`/`%pop-wind`/
`%promise-*`) as closure upvalues at install time, and `install()` then
**removes the eight `%`-helpers from `vm.globals`** (they are registered in
no library, so they are now fully unreachable):

```scheme
%push-wind   ; ⇒ error: undefined variable '%push-wind'
```

The globals drift-guard unit test now asserts the inverse for
`.internal`-only specs: they must NOT resolve after init.

## 3. Immunity to base-binding redefinition (item 3)

The same `let` captures cover every base procedure the implementations use
(`car`, `cdr`, `cons`, `reverse`, `apply`, `error`, arithmetic, ...), so the
hijack from the issue is gone — matching the immunity the native versions had:

```scheme
(define reverse (lambda (x) 'HIJACKED))
(map (lambda (x) x) '(1 2 3))   ; ⇒ (1 2 3)
```

A/B benchmark vs main (median of the self-timing harness, 2 rounds):
`list` +4.7%, `vector`/`string`/`closures` within noise — well inside the
restored 120% alert threshold.

## 4. dynamic-wind argument validation order (item 4)

All three arguments are validated before `(before)` runs, and the errors
name `dynamic-wind` instead of `%push-wind`:

```scheme
(dynamic-wind (lambda () (display "SIDE-EFFECT")) (lambda () 1) 42)
; ⇒ type error in 'dynamic-wind': expected procedure, got 42   (nothing displayed)
```

## 5. Dead native implementations retired (item 5)

`mapFn`, `forEachFn`, `vectorMapFn`, `vectorForEachFn`, `stringMapFn`,
`stringForEachFn`, `dynamicWindFn`, `forceFn` (~460 lines) are deleted. The
spec entries remain (they drive arity metadata and library exports) but now
point at `primitives.bootstrapStub(name)`, which raises
`'map' is implemented in Scheme (src/vm_bootstrap.zig) but
vm_bootstrap.install() has not run for this VM` — so a future missing
`install()` fails loudly instead of silently reverting to divergent native
behavior. `install()` itself also reports which definition failed to eval
instead of aborting startup with a bare exit code.

## 6. Narrowed README fibers limitation (item 6)

Re-added the "Fibers" known-limitation scoped to the still-native drivers.
Verified empirically both ways: a fiber blocking on an empty channel inside
a SRFI-1 `fold` callback still raises the deadlock error (with no other
runnable fiber) while the identical program under `map` parks and completes;
and with a runnable sibling fiber the native driver still makes progress.

## 7. Benchmark alert threshold restored (item 7)

`.github/workflows/benchmark-pr.yml` `alert-threshold` back to `120%`.

## Tests

- `tests/scheme/smoke/trampoline-polish-1375.scm` — 45 assertions covering
  all four behavioral items plus multi-sequence spot checks.
- `tests/scheme/errors/error-format.sh` — 5 new diagnostics assertions.
- `src/tests_core_eval.zig` — unit test that a VM without
  `vm_bootstrap.install()` raises the stub error.
- `src/tests_libraries.zig` — drift guard extended for hidden internal specs.
- `tests/scheme/audit/primitives_lazy-audit.scm` — the one test that called
  `%promise-forcing?` directly now probes the forcing flag behaviorally
  (via a `delay-force` chain that would raise "re-entrant forcing" if the
  flag leaked).

Full run: `zig build test` (674 pass), `bash tests/scheme/run-all.sh` green,
sandbox suite green, `zig build wasm` builds, `--sandbox` boots and runs the
bootstrapped procedures.

## Pre-existing #1374 regressions found while verifying (not addressed here)

- #1376 — native backend: `map`/`dynamic-wind` fail with "runtime error in
  call" in `kaappi compile` binaries (reproduced identically on main).
- #1377 — `dynamic-wind` raises "uncaught exception in thread" inside
  SRFI-18 threads (reproduced identically on main; v0.13.0 works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
