### PR TITLE
Fix native backend calls to bootstrapped procedures (#1376)

### DIFF
--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -131,14 +131,29 @@ pub export fn kaappi_create_native_closure(vm: ?*vm_mod.VM, fn_ptr: ?*anyopaque,
     return result;
 }
 
+/// Report a VM error that escaped to natively-compiled code and exit.
+/// Formats an uncaught Scheme exception into vm.last_error_detail first so
+/// the message names the actual failure instead of just the error class.
+fn fatalVMError(vm: *vm_mod.VM, context: []const u8, err: anyerror) noreturn {
+    vm.noteUncaughtException(err);
+    const detail = vm.getErrorDetail();
+    _ = std.posix.system.write(2, context.ptr, context.len);
+    if (detail.len > 0) {
+        _ = std.posix.system.write(2, ": ", 2);
+        _ = std.posix.system.write(2, detail.ptr, detail.len);
+    }
+    const name = @errorName(err);
+    _ = std.posix.system.write(2, " (", 2);
+    _ = std.posix.system.write(2, name.ptr, name.len);
+    _ = std.posix.system.write(2, ")\n", 2);
+    std.process.exit(1);
+}
+
 pub export fn kaappi_eval(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len: u64) callconv(.c) u64 {
     const v = vm orelse return 0;
     const len: usize = @intCast(src_len);
     const source = src_ptr[0..len];
-    const result = v.eval(source) catch {
-        _ = std.posix.system.write(2, "eval error\n", 11);
-        std.process.exit(1);
-    };
+    const result = v.eval(source) catch |err| fatalVMError(v, "eval error", err);
     return result;
 }
 
@@ -152,10 +167,8 @@ fn callPrimitive(name: []const u8, a: u64, b: u64) u64 {
         std.process.exit(1);
     };
     const args = [_]u64{ a, b };
-    return vm.callWithArgs(proc, &args) catch {
-        _ = std.posix.system.write(2, "runtime error in primitive\n", 27);
-        std.process.exit(1);
-    };
+    return vm.callWithArgs(proc, &args) catch |err|
+        fatalVMError(vm, "runtime error in primitive", err);
 }
 
 pub export fn kaappi_fixnum_add(a: u64, b: u64) callconv(.c) u64 {
@@ -247,10 +260,8 @@ pub export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]con
     };
     const n: usize = @intCast(nargs);
     const args: []const Value = if (n > 0 and args_ptr != null) args_ptr.?[0..n] else &.{};
-    const result = v.callWithArgs(callee, args) catch {
-        _ = std.posix.system.write(2, "runtime error in call\n", 22);
-        std.process.exit(1);
-    };
+    const result = v.callWithArgs(callee, args) catch |err|
+        fatalVMError(v, "runtime error in call", err);
     return result;
 }
 

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -338,3 +338,124 @@ test "native declare table covers all runtime exports in preamble" {
     }
     try std.testing.expectEqual(@as(usize, 21), native_decls.decls.len);
 }
+
+// -- NativeClosure dispatch tests (#1376) --
+// Since #1374 map/for-each/dynamic-wind/force are bytecode closures
+// (vm_bootstrap.zig), so bytecode must be able to invoke natively-compiled
+// callbacks (NativeClosure) from every call path in the dispatch loop.
+// These build a NativeClosure by hand (as kaappi_create_native_closure
+// would) and drive it through each opcode/helper.
+
+const th = @import("testing_helpers.zig");
+const Value = types.Value;
+
+fn ncDouble(_: ?*th.VM, args: [*]const Value, nargs: u64, _: [*]const Value) callconv(.c) u64 {
+    std.debug.assert(nargs == 1);
+    return types.makeFixnum(types.toFixnum(args[0]) * 2);
+}
+
+fn ncAddUpvalue(_: ?*th.VM, args: [*]const Value, nargs: u64, upvalues: [*]const Value) callconv(.c) u64 {
+    std.debug.assert(nargs == 1);
+    return types.makeFixnum(types.toFixnum(args[0]) + types.toFixnum(upvalues[0]));
+}
+
+fn ncFortyTwo(_: ?*th.VM, _: [*]const Value, _: u64, _: [*]const Value) callconv(.c) u64 {
+    return types.makeFixnum(42);
+}
+
+fn ncIgnoreArg(_: ?*th.VM, _: [*]const Value, nargs: u64, _: [*]const Value) callconv(.c) u64 {
+    std.debug.assert(nargs == 1);
+    return types.makeFixnum(7);
+}
+
+fn setupNativeClosures(ctx: *th.TestContext) !void {
+    try ctx.vm.defineGlobal("nc-double", try ctx.gc.allocNativeClosure(&ncDouble, &.{}, 1, "nc-double"));
+    try ctx.vm.defineGlobal("nc-42", try ctx.gc.allocNativeClosure(&ncFortyTwo, &.{}, 0, "nc-42"));
+    try ctx.vm.defineGlobal("nc-ignore", try ctx.gc.allocNativeClosure(&ncIgnoreArg, &.{}, 1, "nc-ignore"));
+}
+
+test "bootstrapped map calls a NativeClosure callback (call opcode)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("(equal? (map nc-double (list 1 2 3)) (list 2 4 6))");
+    try std.testing.expectEqual(types.TRUE, result);
+}
+
+test "bootstrapped dynamic-wind calls NativeClosure thunks" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("(dynamic-wind nc-42 nc-42 nc-42)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "NativeClosure upvalues survive the dispatch-loop call path" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const upvals = [_]Value{types.makeFixnum(100)};
+    try ctx.vm.defineGlobal("nc-add100", try ctx.gc.allocNativeClosure(&ncAddUpvalue, &upvals, 1, "nc-add100"));
+    const result = try ctx.vm.eval("(equal? (map nc-add100 (list 1 2)) (list 101 102))");
+    try std.testing.expectEqual(types.TRUE, result);
+}
+
+test "bytecode tail-calls a NativeClosure (tail_call opcode)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("((lambda (f) (f 21)) nc-double)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "bytecode tail-applies a NativeClosure (tail_apply opcode)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("((lambda (f) (apply f (list 21))) nc-double)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "bytecode tail-calls a NativeClosure global (tail_call_global opcode)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("((lambda () (nc-double 21)))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "call/cc with a NativeClosure receiver (callHandler / tail_call_cc)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const non_tail = try ctx.vm.eval("(+ 0 (call-with-current-continuation nc-ignore))");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(non_tail));
+    const tail = try ctx.vm.eval("((lambda () (call-with-current-continuation nc-ignore)))");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(tail));
+}
+
+test "with-exception-handler NativeClosure thunk and handler (callThunk/callHandler)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const thunk_res = try ctx.vm.eval("(with-exception-handler (lambda (e) 0) nc-42)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(thunk_res));
+    const handler_res = try ctx.vm.eval("(with-exception-handler nc-ignore (lambda () (raise-continuable 1)))");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(handler_res));
+}
+
+test "NativeClosure arity mismatch raises a catchable error" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("(guard (e (#t 99)) (nc-double 1 2))");
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(result));
+}

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -327,6 +327,22 @@ pub fn mapNativeError(vm: *VM, err: anyerror, name: []const u8, args: []const Va
     };
 }
 
+/// Invoke a natively-compiled closure (LLVM backend). The emitted function
+/// reads its parameters lazily from the args pointer and may re-enter the
+/// VM, which can grow (realloc) vm.registers — so the pointer handed to it
+/// must not alias the register file. Copy args into a stack buffer; the
+/// originals stay reachable through the caller's storage (registers or
+/// rooted buffers), so the copies need no GC roots of their own.
+pub fn callNativeClosure(vm: *VM, nc: *types.NativeClosure, args: []const Value) VMError!Value {
+    if (args.len != nc.arity) {
+        vm.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ nc.name, nc.arity, args.len });
+        return VMError.ArityMismatch;
+    }
+    var buf: [256]Value = undefined;
+    @memcpy(buf[0..args.len], args);
+    return nc.fn_ptr(vm, &buf, args.len, nc.upvalues.ptr);
+}
+
 pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
     // Check closure first — by far the most common case in Scheme programs
     if (types.isClosure(callee)) {
@@ -334,6 +350,14 @@ pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
     }
     if (types.isNativeFn(callee)) {
         return callNative(vm, types.toObject(callee).as(types.NativeFn), base, nargs);
+    }
+    if (types.isNativeClosure(callee)) {
+        const nc = types.toObject(callee).as(types.NativeClosure);
+        if (@as(usize, base) + @as(usize, nargs) + 1 > vm.registers.len)
+            return VMError.StackOverflow;
+        const result = try callNativeClosure(vm, nc, vm.registers[base + 1 .. base + 1 + nargs]);
+        vm.registers[base] = result;
+        return;
     }
     if (types.isFfiFunction(callee)) {
         const ffi_fn = types.toObject(callee).as(types.FfiFunction);
@@ -645,6 +669,9 @@ pub fn callHandler(vm: *VM, handler_val: Value, arg: Value, return_dst: u8) VMEr
             return mapNativeError(vm, err, native.name, &args);
         };
         return result;
+    } else if (types.isNativeClosure(handler_val)) {
+        const nc = types.toObject(handler_val).as(types.NativeClosure);
+        return callNativeClosure(vm, nc, &[_]Value{arg});
     } else {
         vm.setErrorDetail("not a procedure", .{});
         return VMError.NotAProcedure;
@@ -671,6 +698,9 @@ pub fn callThunk(vm: *VM, thunk_val: Value) VMError!Value {
             return mapNativeError(vm, err, native.name, empty_args);
         };
         return result;
+    } else if (types.isNativeClosure(thunk_val)) {
+        const nc = types.toObject(thunk_val).as(types.NativeClosure);
+        return callNativeClosure(vm, nc, &.{});
     } else {
         return VMError.NotAProcedure;
     }
@@ -745,12 +775,7 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
         return callReentrant(vm, closure, base, 0, true);
     } else if (types.isNativeClosure(proc)) {
         const nc = types.toObject(proc).as(types.NativeClosure);
-        if (args.len != nc.arity) {
-            vm.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ nc.name, nc.arity, args.len });
-            return VMError.ArityMismatch;
-        }
-        const result = nc.fn_ptr(vm, args.ptr, args.len, nc.upvalues.ptr);
-        return result;
+        return callNativeClosure(vm, nc, args);
     } else if (types.isNativeFn(proc)) {
         const native = types.toObject(proc).as(types.NativeFn);
         switch (native.arity) {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -518,6 +518,20 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;
+                } else if (types.isNativeClosure(callee)) {
+                    const nc = types.toObject(callee).as(types.NativeClosure);
+                    // nc.fn_ptr may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
+                    const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
+                    const result = try vm_calls.callNativeClosure(self, nc, self.registers[abs_base + 1 .. abs_base + 1 + nargs]);
+                    self.frame_count -= 1;
+                    if (self.profile_mode) vm_calls.profilePopReturn(self);
+                    if (self.frame_count <= target_frame_count) return result;
+                    if (from_native_call) return raiseDeadNativeReturn(self);
+                    const caller = &self.frames[self.frame_count - 1];
+                    const ret_idx = try registerIndex(self, caller.base, return_dst);
+                    self.registers[ret_idx] = result;
                 } else if (types.isContinuation(callee)) {
                     const cont = types.toObject(callee).as(types.Continuation);
                     const value = try vm_calls.continuationArgValue(self.gc, self.registers[abs_base + 1 .. abs_base + 1 + @as(usize, nargs)]);
@@ -664,6 +678,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         if (err == error.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                         return vm_calls.mapNativeError(self, err, native.name, flat_args[0..count]);
                     };
+                    self.frame_count -= 1;
+                    if (self.frame_count <= target_frame_count) return result;
+                    if (from_native_call) return raiseDeadNativeReturn(self);
+                    const caller = &self.frames[self.frame_count - 1];
+                    const ret_idx = try registerIndex(self, caller.base, return_dst);
+                    self.registers[ret_idx] = result;
+                } else if (types.isNativeClosure(proc)) {
+                    const nc = types.toObject(proc).as(types.NativeClosure);
+                    // nc.fn_ptr may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
+                    const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
+                    const result = try vm_calls.callNativeClosure(self, nc, flat_args[0..count]);
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     if (from_native_call) return raiseDeadNativeReturn(self);
@@ -1056,6 +1083,20 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const caller = &self.frames[self.frame_count - 1];
                     const ret_idx = try registerIndex(self, caller.base, return_dst);
                     self.registers[ret_idx] = result;
+                } else if (types.isNativeClosure(callee)) {
+                    const nc = types.toObject(callee).as(types.NativeClosure);
+                    // nc.fn_ptr may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
+                    const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
+                    const result = try vm_calls.callNativeClosure(self, nc, self.registers[abs_base + 1 .. abs_base + 1 + nargs]);
+                    self.frame_count -= 1;
+                    if (self.profile_mode) vm_calls.profilePopReturn(self);
+                    if (self.frame_count <= target_frame_count) return result;
+                    if (from_native_call) return raiseDeadNativeReturn(self);
+                    const caller = &self.frames[self.frame_count - 1];
+                    const ret_idx = try registerIndex(self, caller.base, return_dst);
+                    self.registers[ret_idx] = result;
                 } else {
                     self.setErrorDetail("not a procedure", .{});
                     return VMError.NotAProcedure;
@@ -1168,6 +1209,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         }
                         return vm_calls.mapNativeError(self, err, native.name, nargs_slice);
                     };
+                    self.frame_count -= 1;
+                    if (self.frame_count <= target_frame_count) return result;
+                    if (from_native_call) return raiseDeadNativeReturn(self);
+                    const caller = &self.frames[self.frame_count - 1];
+                    const ret_idx = try registerIndex(self, caller.base, return_dst);
+                    self.registers[ret_idx] = result;
+                } else if (types.isNativeClosure(receiver)) {
+                    const nc = types.toObject(receiver).as(types.NativeClosure);
+                    // nc.fn_ptr may re-enter the VM and grow self.frames,
+                    // invalidating `frame` — read dst before the call.
+                    const return_dst = frame.dst;
+                    const from_native_call = frame.returns_to_native;
+                    const result = try vm_calls.callNativeClosure(self, nc, &[_]Value{cont_val});
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     if (from_native_call) return raiseDeadNativeReturn(self);

--- a/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
+++ b/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Regression test for #1376: natively compiled programs calling bootstrapped
+# procedures (map, for-each, dynamic-wind, ... — Scheme closures installed by
+# src/vm_bootstrap.zig since #1374).
+#
+# The bootstrapped bytecode closure must be able to invoke the natively
+# compiled callback (a NativeClosure) from inside the bytecode dispatch loop:
+# the .call/.tail_call/.tail_apply/.tail_call_global opcodes and the
+# callValue/callThunk/callHandler helpers all need a native_closure arm.
+# Before the fix every case below died with "runtime error in call".
+#
+# Also covers the improved kaappi_call_scheme error path: failures must
+# report vm.last_error_detail instead of a bare "runtime error in call".
+#
+# Usage: bash tests/scheme/compile/native-bootstrap-callbacks-1376.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# Build interpreter + runtime library
+(cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+check_native() {
+    local src="$1" expected="$2" label="$3"
+    local bin="$DIR/${label}.bin"
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — native compile did not produce a binary" >&2
+        exit 1
+    fi
+    local out
+    out="$("$bin")"
+    if [[ "$out" != "$expected" ]]; then
+        echo "FAIL: $label — expected '$expected', got '$out'" >&2
+        exit 1
+    fi
+}
+
+# --- Case 1: map with a native callback (the #1376 repro) ---
+cat > "$DIR/map-single.scm" << 'SCHEME'
+(display (map (lambda (x) x) (list 1 2)))
+(newline)
+SCHEME
+
+check_native "$DIR/map-single.scm" "(1 2)" "map-single"
+
+# --- Case 2: multi-list map (callback reaches the closure via apply) ---
+cat > "$DIR/map-multi.scm" << 'SCHEME'
+(display (map (lambda (a b) (+ a b)) (list 1 2 3) (list 10 20 30)))
+(newline)
+SCHEME
+
+check_native "$DIR/map-multi.scm" "(11 22 33)" "map-multi"
+
+# --- Case 3: for-each with a side-effecting native callback ---
+cat > "$DIR/for-each.scm" << 'SCHEME'
+(for-each (lambda (x) (display x) (display " ")) (list 7 8 9))
+(newline)
+SCHEME
+
+check_native "$DIR/for-each.scm" "7 8 9 " "for-each"
+
+# --- Case 4: dynamic-wind with three native thunks ---
+cat > "$DIR/dynamic-wind.scm" << 'SCHEME'
+(dynamic-wind
+  (lambda () (display "before "))
+  (lambda () (display "during "))
+  (lambda () (display "after")))
+(newline)
+SCHEME
+
+check_native "$DIR/dynamic-wind.scm" "before during after" "dynamic-wind"
+
+# --- Case 5: map inside a dynamic-wind thunk ---
+cat > "$DIR/wind-map.scm" << 'SCHEME'
+(dynamic-wind
+  (lambda () (display "["))
+  (lambda () (display (map (lambda (x) (* x x)) (list 1 2 3))))
+  (lambda () (display "]")))
+(newline)
+SCHEME
+
+check_native "$DIR/wind-map.scm" "[(1 4 9)]" "wind-map"
+
+# --- Case 6: rest of the trampolined family + force still works ---
+cat > "$DIR/family.scm" << 'SCHEME'
+(display (vector-map (lambda (x) (+ x 1)) (vector 1 2 3)))
+(vector-for-each (lambda (x) (display x)) (vector 4 5))
+(display (string-map (lambda (c) (if (char=? c #\a) #\A c)) "abc"))
+(string-for-each (lambda (c) (display c)) "xy")
+(display (force (delay 42)))
+(newline)
+SCHEME
+
+check_native "$DIR/family.scm" "#(2 3 4)45Abcxy42" "family"
+
+# --- Case 7: callback capturing a local (native closure with upvalues) ---
+cat > "$DIR/upvalue.scm" << 'SCHEME'
+(define (add-to-all k lst)
+  (map (lambda (x) (+ x k)) lst))
+(display (add-to-all 10 (list 1 2 3)))
+(newline)
+SCHEME
+
+check_native "$DIR/upvalue.scm" "(11 12 13)" "upvalue"
+
+# --- Case 8: bytecode tail positions calling a native callback ---
+# A do-loop forces the defined procedure onto the interpreter (eval
+# fallback), so (f i) / (apply f ...) / (g 14) execute as bytecode
+# tail_call / tail_apply / tail_call_global with a NativeClosure callee.
+cat > "$DIR/tail-calls.scm" << 'SCHEME'
+(define (tail-call-it f)
+  (do ((i 0 (+ i 1)))
+      ((= i 3) (f i))))
+(display (tail-call-it (lambda (x) (* x 100))))
+(newline)
+(define (tail-apply-it f)
+  (do ((i 0 (+ i 1)))
+      ((= i 1) (apply f (list 7 8)))))
+(display (tail-apply-it (lambda (a b) (+ a b))))
+(newline)
+(define g #f)
+(define (setup!)
+  (set! g (lambda (x) (* x 3))))
+(setup!)
+(define (call-g)
+  (do ((i 0 (+ i 1)))
+      ((= i 1) (g 14))))
+(display (call-g))
+(newline)
+SCHEME
+
+check_native "$DIR/tail-calls.scm" "300
+15
+42" "tail-calls"
+
+# --- Case 9: call/cc with a native receiver (callHandler path) ---
+cat > "$DIR/callcc.scm" << 'SCHEME'
+(display (call-with-current-continuation (lambda (k) (k 99))))
+(display (call-with-current-continuation (lambda (k) 55)))
+(newline)
+SCHEME
+
+check_native "$DIR/callcc.scm" "9955" "callcc"
+
+# --- Case 10: errors escaping to native code report the detail ---
+cat > "$DIR/arity-err.scm" << 'SCHEME'
+(display (map (lambda (x y) x) (list 1 2)))
+SCHEME
+
+bin="$DIR/arity-err.bin"
+(cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/arity-err.scm" -o "$bin" > /dev/null 2>&1)
+set +e
+err_out="$("$bin" 2>&1)"
+status=$?
+set -e
+if [[ $status -eq 0 ]]; then
+    echo "FAIL: arity-err — expected non-zero exit" >&2
+    exit 1
+fi
+if [[ "$err_out" != *"expected 2 arguments, got 1"* ]]; then
+    echo "FAIL: arity-err — error detail missing, got '$err_out'" >&2
+    exit 1
+fi
+
+echo "PASS"


### PR DESCRIPTION
Fixes #1376.

## Problem

Since #1374 rewrote `map`/`for-each`/`dynamic-wind`/`force` as Scheme closures bootstrapped at VM init, natively compiled programs (`kaappi compile prog.scm -o prog`) died with a bare `runtime error in call` on the first call to any of them:

```scheme
(display (map (lambda (x) x) (list 1 2)))   ; => runtime error in call
```

Native code reaches the bootstrapped procedure as a **bytecode closure** through `kaappi_call_scheme` → `callWithArgs`; the bytecode then has to invoke the natively compiled callback — a `NativeClosure` — from inside the dispatch loop. Every dispatch site (`callValue`, `callThunk`, `callHandler`, and the `tail_call`/`tail_apply`/`tail_call_global`/`tail_call_cc` opcode arms) only handled Closure/NativeFn/Continuation/FfiFunction/Parameter, so the callback call failed with `NotAProcedure`. Pre-#1374 this was unreachable: NativeClosures were only ever invoked by the Zig primitives via `callWithArgs`, the one place that handled them.

## Fix

- New `vm_calls.callNativeClosure` helper, used by every dispatch site. It copies the arguments into a stack buffer before the call: emitted native functions read their parameters **lazily** from the args pointer, and re-entering the VM can grow (realloc) `vm.registers`, so a pointer into the register file could dangle. The originals stay reachable through the caller's storage, so the copies need no GC roots (verified with `KAAPPI_GC_THRESHOLD=1`).
- `native_closure` arms added to `callValue`, `callThunk`, `callHandler` (covers with-exception-handler thunks/handlers, call/cc receivers, wind transitions) and to the `tail_call`, `tail_apply`, `tail_call_global`, `tail_call_cc` opcodes.
- `kaappi_call_scheme` / `callPrimitive` / `kaappi_eval` exit paths now print `vm.last_error_detail` + the error name (formatting uncaught Scheme exceptions via `noteUncaughtException` first):
  ```
  runtime error in call: '(lambda)': expected 2 arguments, got 1 (ArityMismatch)
  runtime error in call: boom 1 (ExceptionRaised)
  ```

## Tests

- 9 unit tests in `src/tests_native.zig` drive a hand-built NativeClosure through each dispatch path (map callback, dynamic-wind thunks, upvalues, tail_call, tail_apply, tail_call_global, call/cc receiver, with-exception-handler thunk/handler, catchable arity error).
- `tests/scheme/compile/native-bootstrap-callbacks-1376.sh` compiles and runs the whole bootstrapped family natively (map single/multi-list, for-each, dynamic-wind, vector/string variants, force, bytecode tail positions via do-loop fallback, call/cc, and the error-detail output).
- Full suite: `zig build test` green; `tests/scheme/run-all.sh` 1816 pass / 0 fail; R7RS 1395/1395.

While testing I found a **pre-existing** native-backend bug (also fails on v0.13.0, unrelated to #1374): nested closure capture like `(define (run k) ((lambda () ((lambda () k)))))` mis-scopes because the inner lambda falls back to `emitLambdaViaEval` in the global environment. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)