### PR TITLE
Fix spurious wind unwind on return into native-callback frames (#1377)

### DIFF
--- a/src/tests_continuations.zig
+++ b/src/tests_continuations.zig
@@ -453,6 +453,37 @@ test "dynamic-wind after-thunk runs on nested escape under guard" {
     try std.testing.expectEqualStrings("after", types.symbolName(types.car(types.cdr(types.cdr(log)))));
 }
 
+test "dynamic-wind tail-called from a native-driven callback (#1377)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // member invokes the predicate via callWithArgs, which pushes a
+    // returns_to_native frame; the predicate tail-calls dynamic-wind,
+    // reusing that frame, so the wind pushed by dynamic-wind's own
+    // bytecode sits above the frame's saved_wind_count. The Return
+    // opcode's caller-wind cleanup used to unwind it as soon as the
+    // wound thunk returned, making the subsequent %pop-wind underflow
+    // (#1377 — same failure as dynamic-wind inside an SRFI-18 thread
+    // thunk). The thunk must yield its value through a real `return`
+    // opcode (not a native tail call) to reach that path.
+    _ = try vm.eval("(define trace '())");
+    _ = try vm.eval(
+        \\(define result
+        \\  (member 2 '(1 2 3)
+        \\    (lambda (x y)
+        \\      (dynamic-wind
+        \\        (lambda () (set! trace (cons 'b trace)))
+        \\        (lambda () (if (equal? x y) #t #f))
+        \\        (lambda () (set! trace (cons 'a trace)))))))
+    );
+    // Predicate ran for 1 (no match) then 2 (match): before/after fired
+    // exactly once per call and member returned the tail from the match.
+    const ok = try vm.eval("(and (equal? result '(2 3)) (equal? trace '(a b a b)))");
+    try std.testing.expectEqual(types.TRUE, ok);
+}
+
 test "full continuation re-entry inside map — generator-style" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -748,24 +748,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     return result;
                 }
                 if (from_native_call) return raiseDeadNativeReturn(self);
-                // Unwind any winds that were pushed by native
-                // functions (via callReentrant) between this frame
-                // and the caller — only when the caller itself was
-                // pushed by a native re-entry. Bytecode callers
-                // (e.g. Scheme-level dynamic-wind) manage their own
-                // winds via %push-wind/%pop-wind and must not be
-                // unwound here.
-                // callThunk may re-enter the VM and grow self.frames — copy
-                // the caller's fields instead of holding a pointer across it.
-                const caller_returns_to_native = self.frames[self.frame_count - 1].returns_to_native;
-                const caller_wind_count = self.frames[self.frame_count - 1].saved_wind_count;
+                // Do NOT unwind winds above the caller's saved_wind_count
+                // here: a callee's return never exits the caller's dynamic
+                // extent. The caller's own bytecode may have pushed winds
+                // after the frame was entered (Scheme-level dynamic-wind
+                // via %push-wind — including in returns_to_native callback
+                // frames such as SRFI-18 thread thunks, #1377); it pops
+                // them itself via %pop-wind. Unbalanced winds are cleaned
+                // up at the frame's own return above, at the scope-root
+                // return, and on the callReentrant/execute error paths.
                 const caller_base = self.frames[self.frame_count - 1].base;
-                if (caller_returns_to_native) {
-                    while (self.wind_count > caller_wind_count) {
-                        self.wind_count -= 1;
-                        _ = self.callThunk(self.wind_stack[self.wind_count].after) catch {};
-                    }
-                }
                 const ret_idx = try registerIndex(self, caller_base, return_dst);
                 self.registers[ret_idx] = result;
             },

--- a/tests/scheme/srfi/srfi18-dynamic-wind.scm
+++ b/tests/scheme/srfi/srfi18-dynamic-wind.scm
@@ -1,0 +1,120 @@
+;; Regression test for #1377: dynamic-wind inside SRFI-18 child threads.
+;;
+;; Since PR #1374, dynamic-wind is a Scheme closure that manages the wind
+;; stack via %push-wind/%pop-wind in its own bytecode. A thread thunk is
+;; invoked through callWithArgs, which pushes a returns_to_native frame;
+;; when the thunk tail-calls dynamic-wind that frame is reused. The Return
+;; opcode's caller-wind cleanup then spuriously unwound the wind record
+;; pushed by dynamic-wind's own bytecode as soon as the wound thunk
+;; returned, so the subsequent %pop-wind underflowed and the thread died
+;; with "uncaught exception in thread".
+(import (scheme base) (scheme write) (scheme process-context)
+        (scheme lazy) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; --- dynamic-wind in tail position of the thread thunk (#1377 repro) ---
+(let ((t (make-thread (lambda ()
+                        (dynamic-wind (lambda () #f)
+                                      (lambda () 42)
+                                      (lambda () #f))))))
+  (thread-start! t)
+  (check "dynamic-wind tail in thread thunk" (thread-join! t) 42))
+
+;; --- dynamic-wind in non-tail position of the thread thunk ---
+(let ((t (make-thread (lambda ()
+                        (let ((r (dynamic-wind (lambda () #f)
+                                               (lambda () 42)
+                                               (lambda () #f))))
+                          (+ r 1))))))
+  (thread-start! t)
+  (check "dynamic-wind non-tail in thread thunk" (thread-join! t) 43))
+
+;; --- before/after run exactly once each, in order ---
+;; The trace is built on the child heap and returned through thread-join!.
+(let ((t (make-thread (lambda ()
+                        (let ((trace '()))
+                          (let ((r (dynamic-wind
+                                    (lambda () (set! trace (cons 'before trace)))
+                                    (lambda () (set! trace (cons 'during trace)) 'val)
+                                    (lambda () (set! trace (cons 'after trace))))))
+                            (list r (reverse trace))))))))
+  (thread-start! t)
+  (check "dynamic-wind before/after order in thread"
+         (thread-join! t) '(val (before during after))))
+
+;; --- nested dynamic-wind in a thread ---
+(let ((t (make-thread (lambda ()
+                        (dynamic-wind
+                         (lambda () #f)
+                         (lambda ()
+                           (dynamic-wind (lambda () #f)
+                                         (lambda () 7)
+                                         (lambda () #f)))
+                         (lambda () #f))))))
+  (thread-start! t)
+  (check "nested dynamic-wind in thread" (thread-join! t) 7))
+
+;; --- after-thunk runs when the wound thunk raises; join sees the error ---
+(let ((t (make-thread (lambda ()
+                        (dynamic-wind (lambda () #f)
+                                      (lambda () (raise 'boom))
+                                      (lambda () #f))))))
+  (thread-start! t)
+  (check "dynamic-wind raise in thread joins as uncaught-exception"
+         (guard (e (#t (if (uncaught-exception? e) 'uncaught 'other)))
+           (thread-join! t))
+         'uncaught))
+
+;; --- escape continuation out of the wound thunk in a thread ---
+(let ((t (make-thread (lambda ()
+                        (let ((log '()))
+                          (let ((v (call/cc
+                                    (lambda (k)
+                                      (dynamic-wind
+                                       (lambda () (set! log (cons 'b log)))
+                                       (lambda () (k 'escaped) 'never)
+                                       (lambda () (set! log (cons 'a log))))))))
+                            (list v (reverse log))))))))
+  (thread-start! t)
+  (check "escape from dynamic-wind thunk in thread"
+         (thread-join! t) '(escaped (b a))))
+
+;; --- guard + raise through dynamic-wind in a thread ---
+(let ((t (make-thread (lambda ()
+                        (let ((log '()))
+                          (let ((v (guard (e (#t (list 'caught e)))
+                                     (dynamic-wind
+                                      (lambda () (set! log (cons 'b log)))
+                                      (lambda () (raise 'oops))
+                                      (lambda () (set! log (cons 'a log)))))))
+                            (list v (reverse log))))))))
+  (thread-start! t)
+  (check "guard+raise through dynamic-wind in thread"
+         (thread-join! t) '((caught oops) (b a))))
+
+;; --- parameterize (compiles to dynamic-wind) in a thread ---
+(define p (make-parameter 1))
+(let ((t (make-thread (lambda () (parameterize ((p 5)) (p))))))
+  (thread-start! t)
+  (check "parameterize in thread" (thread-join! t) 5))
+
+;; --- force (uses dynamic-wind internally) in a thread ---
+(let ((t (make-thread (lambda () (force (delay (* 6 7)))))))
+  (thread-start! t)
+  (check "force in thread" (thread-join! t) 42))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

Fixes #1377 — since #1374, `dynamic-wind` raised "uncaught exception in thread" inside SRFI-18 child threads:

```scheme
(import (srfi 18))
(define t (make-thread (lambda () (dynamic-wind (lambda () #f) (lambda () 42) (lambda () #f)))))
(thread-start! t)
(display (thread-join! t))   ; error before this fix; 42 after
```

## Root cause

Since #1374, `dynamic-wind` is a Scheme closure whose bytecode manages the wind stack via `%push-wind`/`%pop-wind`. A callback invoked from native code through `callWithArgs` (an SRFI-18 thread thunk, a `member`/`sort` predicate, …) runs in a frame pushed with `returns_to_native = true`, and a **tail call** to `dynamic-wind` reuses that frame — keeping its flags and its frame-entry `saved_wind_count`.

The Return opcode's caller-wind cleanup (`if (caller_returns_to_native) unwind to caller.saved_wind_count`) then mistook the wind record legitimately pushed by the frame's *own bytecode* for an orphaned native wind: as soon as the wound thunk returned, it ran the after-thunk and popped the record, so `dynamic-wind`'s closing `%pop-wind` underflowed and raised. In a thread that surfaced as "uncaught exception in thread".

**The bug was not thread-specific.** The same failure fired without threads from any `callWithArgs`-driven callback, e.g.:

```scheme
(member 2 '(1 2 3)
  (lambda (x y)
    (dynamic-wind (lambda () #f)
                  (lambda () (if (equal? x y) #t #f))
                  (lambda () #f))))
;; before: error: type error in '%pop-wind' — after: (2 3)
```

CI stayed green because nothing exercised `dynamic-wind` inside `make-thread`, and existing callback tests either called `dynamic-wind` in non-tail position (fresh frame, `returns_to_native = false`) or ended their thunks in native calls (`(= a b)`, `(display x)`), which return through the tail-call native fast path and never execute a Return opcode.

## Fix

Delete the caller-wind cleanup from the Return opcode handler. A callee's return never exits the caller's dynamic extent, so unwinding the caller's winds at that point is never correct. The cleanup existed for winds pushed by the pre-#1374 *native* `dynamic-wind`, which could be orphaned when a continuation restore discarded the native's Zig frame; since #1374 every wind is pushed and popped by bytecode, and unbalanced winds are still cleaned up at the frame's own return, the scope-root return, and the `callReentrant`/`execute` error paths.

## Tests

- `tests/scheme/srfi/srfi18-dynamic-wind.scm` (new): dynamic-wind in tail/non-tail position of a thread thunk, before/after ordering, nesting, raise → `uncaught-exception` at join, escape continuation out of the wound thunk, guard+raise, `parameterize`-in-thread, `force`-in-thread
- `src/tests_continuations.zig`: no-thread regression — `member` predicate tail-calling `dynamic-wind` with a thunk that returns via a real Return opcode
- Both **fail on the unfixed build** (thread tests error with "uncaught exception in thread"; Zig test fails 1/674) and pass with the fix

## Verification

- `zig build test`: 675/675 pass
- `bash tests/scheme/run-all.sh`: 422 files pass, 0 fail, 0 timeout
- R7RS suite: 1395 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
