### PR TITLE
Pin the utf8->string rejection to its type error in the audit test

### DIFF
--- a/tests/scheme/audit/primitives_bytevector-audit.scm
+++ b/tests/scheme/audit/primitives_bytevector-audit.scm
@@ -129,6 +129,16 @@
 (test-equal 'caught (guard (e (#t 'caught)) (utf8->string #u8(#x41 #xFF #x42) 1 2)))
 (test-equal "A" (utf8->string #u8(#xFF #x41) 1))
 (test-equal 'caught (guard (e (#t 'caught)) (utf8->string #u8(#x41 #xCE #xBB) 0 2)))    ; range splits λ
+;; the rejection is a proper error object naming the conversion, not some
+;; unrelated condition
+(test-equal '(#t "type error in 'utf8->string'")
+  (guard (e (#t (list (error-object? e)
+                      (let ((m (error-object-message e)))
+                        (and (string? m)
+                             (>= (string-length m) 28)
+                             (substring m 0 28))))))
+    (utf8->string (bytevector #xFF))
+    'no-error))
 
 ;;; --- string->utf8 ---
 ;; R7RS 6.9 example


### PR DESCRIPTION
Follow-up to #1383 (review feedback that landed after auto-merge): the re-enabled invalid-UTF-8 assertions catch every condition via the audit corpus's `'caught` idiom, so an unrelated failure would still pass them. Add one assertion pinning `error-object?` and the `type error in 'utf8->string'` message prefix on the representative bad-lead-byte case.

Verified: 127/127 passes on ReleaseSafe and under `-Dgc-stress=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)