### PR TITLE
Disable the gc-stress fuzz variant pending #1401

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -30,15 +30,19 @@ jobs:
           # and token targets build a full VM per input (~20-50 ms), so they
           # dominate the wall time: locally 200 per target is a ~2 minute
           # pass, so 2K per target keeps a hosted runner well under the job
-          # timeout. The gc-stress variant attempts a collection on every
-          # allocation (converting latent rooting bugs into immediate
-          # failures), so it gets a far smaller budget for the same time.
+          # timeout.
           - variant: default
             build-args: ''
             limit: 2K
-          - variant: gc-stress
-            build-args: '-Dgc-stress=true'
-            limit: 200
+          # The planned gc-stress variant (collection attempted on every
+          # allocation, converting latent rooting bugs into immediate
+          # failures) is DISABLED: ~440 of 690 unit tests currently crash
+          # under -Dgc-stress=true, so the pre-fuzz test phase can never
+          # pass. Re-enable when https://github.com/kaappi/kaappi/issues/1401
+          # is fixed.
+          # - variant: gc-stress
+          #   build-args: '-Dgc-stress=true'
+          #   limit: 200
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -54,6 +54,9 @@ across runs; coverage stats accumulate in `.zig-cache/v/`. Delete
 A `-Dgc-stress=true` build attempts a collection at every allocation (except
 under `no_collect` or while the GC is disabled), which turns latent rooting
 bugs into immediate, attributable failures instead of rare heisenbugs.
+**Currently blocked:** ~440 of the 690 unit tests crash under gc-stress
+([#1401](https://github.com/kaappi/kaappi/issues/1401)), so a gc-stress fuzz
+run cannot get past the test phase until that is fixed.
 
 ## The CI job
 
@@ -64,7 +67,13 @@ ecosystem nightly), in two variants:
 | Variant | Build | Limit (per fuzz test) |
 |---------|-------|-----------------------|
 | `default` | standard `ReleaseSafe` test build | 2K runs |
-| `gc-stress` | `-Dgc-stress=true` | 200 runs |
+| `gc-stress` | `-Dgc-stress=true` | *disabled* — see below |
+
+The `gc-stress` variant is disabled in the matrix until
+[#1401](https://github.com/kaappi/kaappi/issues/1401) is fixed: ~440 of the
+690 unit tests currently crash under `-Dgc-stress=true`, so the pre-fuzz
+test phase can never pass. (Its first and only CI execution is what found
+that.) Re-enable it once the suite is stress-clean.
 
 Trigger it manually (optionally overriding the limit) with:
 


### PR DESCRIPTION
The gc-stress variant of the nightly fuzz workflow found, on its first execution ([run 29073769556](https://github.com/kaappi/kaappi/actions/runs/29073769556)), that **~440 of 690 unit tests crash under `-Dgc-stress=true`** — reproduced locally on aarch64 macOS with a plain (non-instrumented) build, so it is neither platform- nor fuzzer-specific. Full evidence in #1401.

Because `zig build test --fuzz` runs the entire unit-test suite before fuzzing, the variant can never pass until the suite is stress-clean; its job hung after the test-phase failures and was killed by the 55-minute timeout. This PR comments the variant out of the matrix (with a pointer to #1401) and marks it blocked in the runbook, keeping the nightly green and meaningful.

The default variant is unaffected — it went green in ~4 minutes on the same dispatch run, completing the last #1390 acceptance criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)