### PR TITLE
Fuzzing roadmap Phase 3: IR optimization switch + opt-vs-no-opt differential oracle

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,11 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # The limit applies PER FUZZ TEST (5 targets currently). The eval
-          # and token targets build a full VM per input (~20-50 ms), so they
-          # dominate the wall time: locally 200 per target is a ~2 minute
-          # pass, so 2K per target keeps a hosted runner well under the job
-          # timeout.
+          # The limit applies PER FUZZ TEST (7 targets currently). The eval,
+          # token, and grammar targets build a full VM per input (~20-50 ms)
+          # — and the differential target two of them — so they dominate the
+          # wall time: locally 200 per target is a ~2 minute pass, so 2K per
+          # target keeps a hosted runner well under the job timeout.
           - variant: default
             build-args: ''
             limit: 2K

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ zig build -Dgc-stress=true         # force GC on every allocation (stress testin
 ```
 
 CLI flags: `-h`/`--help`, `--version`, `--lib-path <path>`, `--compile`,
-`-o <file>`, `--disassemble`, `--sandbox`, `--gc-stats`,
+`-o <file>`, `--disassemble`, `--no-ir-opt` (disable IR optimization passes;
+also skips the `.sbc` cache — useful for miscompilation triage and
+`--disassemble` comparisons), `--sandbox`, `--gc-stats`,
 `--profile`, `--coverage`, `--completions <shell>`.
 Subcommand: `kaappi compile <file> [-o output]`
 compiles to native binary via LLVM. Version is defined as `pub const version`

--- a/docs/dev/fuzzing-feasibility.md
+++ b/docs/dev/fuzzing-feasibility.md
@@ -197,6 +197,11 @@ table:
 - **No structure-aware generation** and **no differential testing** — the two
   techniques that find the deepest bugs. The next section maps the research
   literature onto both.
+  *(Structure-aware generation closed 2026-07-10 by the grammar generator,
+  #1392. Differential testing partially closed the same day by the
+  optimized-vs-unoptimized oracle — the `--no-ir-opt` switch, #1393, plus
+  the `fuzz differential` target, #1394; the native-backend and external-
+  reference oracles, #1395/#1396, remain open.)*
 
 ## What the research literature says
 

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -20,6 +20,7 @@ Zig 0.16's built-in coverage-guided fuzzer (`std.testing.fuzz` +
 | `fuzz eval` | raw bytes (128) | full read → compile → VM execute via `vm.eval` |
 | `fuzz tokens` | token sequence | read → compile → execute of near-miss token soup |
 | `fuzz grammar` | generated program | compiler, VM, and GC on valid, well-bound R7RS programs |
+| `fuzz differential (opt vs no-opt)` | generated program | correctness oracle: IR optimization passes vs unoptimized baseline |
 
 The `fuzz tokens` target picks sequences from a Scheme token vocabulary
 instead of raw bytes, so its inputs get past the lexer without being confined
@@ -40,10 +41,25 @@ depth, literal sizes, loop iteration counts, and program bytes by
 construction. It needs no seed corpus: any decision stream decodes to a
 valid program.
 
+The `fuzz differential` target (Tier 3, #1394) is the first target that can
+catch **silently wrong values**, not just crashes: it evaluates each
+grammar-generated program twice — IR optimizations on and off (the switch
+from #1393, `ir.optimize_enabled` / CLI `--no-ir-opt`) — and compares a
+normalized observable: the printed final value plus the generator's globals
+(`g0`–`g2`), and the error *class* (value / compile error / runtime error),
+never error message text. Timeout, out-of-memory, and stack-overflow
+outcomes make a pair incomparable (skipped) rather than a divergence, since
+the two compilation paths legitimately do different amounts of work. Any
+other divergence fails the target with `error.DifferentialMismatch` and is a
+bug in an optimization pass (or in the baseline). To debug one: re-run the
+printed program under `kaappi file.scm` vs `kaappi --no-ir-opt file.scm` and
+minimise from there (`--no-ir-opt` skips the `.sbc` cache, so no stale-cache
+footguns).
+
 Ordinary Scheme read/compile/runtime errors are **expected** fuzz outcomes.
-Only crashes, panics, memory leaks (via `std.testing.allocator`), and
-sanitizer findings fail a target. VM execution is bounded by a 100 ms
-deadline per input.
+Only crashes, panics, memory leaks (via `std.testing.allocator`),
+sanitizer findings, and differential mismatches fail a target. VM execution
+is bounded by a 100 ms deadline per input.
 
 ## Running locally
 
@@ -55,10 +71,11 @@ zig build test --fuzz          # unbounded + web UI; Ctrl-C to stop
 zig build test --fuzz=1K -Dgc-stress=true   # GC collects on every allocation
 ```
 
-The limit applies **per fuzz test** (six targets currently), and per-input
+The limit applies **per fuzz test** (seven targets currently), and per-input
 cost varies enormously by target: reader/compiler/loader inputs are
 microseconds, but the eval, token, and grammar targets construct a full VM
-per input (~20–50 ms) and dominate the wall time. As a rule of thumb, `--fuzz=200` is
+per input (~20–50 ms) — and the differential target two of them — and
+dominate the wall time. As a rule of thumb, `--fuzz=200` is
 a ~2-minute pass and `--fuzz=20K` is half an hour or more on a fast machine.
 
 The fuzzer's working corpus persists in `.zig-cache/f/` and accumulates
@@ -133,15 +150,17 @@ Every fuzz finding follows the same three steps — no exceptions:
    disappear. Scheme inputs minimise well structurally: drop list elements,
    replace subexpressions with literals, shorten identifiers.
 
-   The `fuzz grammar` target's stream is a sequence of `u64` grammar
-   decisions with no simple hand-decoding; reproduce by replaying the
-   artifact verbatim as a `.corpus` entry on that target, and recover the
-   failing *program text* by temporarily printing the generated source (to
-   stderr, never fd 1) in the target body during the replay. Once you have
-   the program text, minimise it as ordinary Scheme and add the minimised
-   source as a `seed()` corpus entry on the **eval** target — source seeds
-   are stable, decision streams are not (any change to the generator's
-   decision sequence re-interprets them).
+   The `fuzz grammar` and `fuzz differential` targets' streams are sequences
+   of `u64` grammar decisions with no simple hand-decoding; reproduce by
+   replaying the artifact verbatim as a `.corpus` entry on the target that
+   failed, and recover the failing *program text* by temporarily printing
+   the generated source (to stderr, never fd 1) in the target body during
+   the replay. Once you have the program text, minimise it as ordinary
+   Scheme and add the minimised source as a `seed()` corpus entry on the
+   **eval** target — source seeds are stable, decision streams are not (any
+   change to the generator's decision sequence re-interprets them). A
+   differential mismatch reproduces outside the harness as
+   `kaappi prog.scm` vs `kaappi --no-ir-opt prog.scm` disagreeing.
 
 2. **Add a readable regression test** that fails without the fix and passes
    with it, per the repo's bug-fix rule:

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -20,6 +20,7 @@ const FlagId = enum {
     emit_llvm,
     output,
     disassemble,
+    no_ir_opt,
     sandbox,
     gc_stats,
     profile,
@@ -47,6 +48,7 @@ const flags = [_]FlagDesc{
     .{ .long = "--emit-llvm", .short = null, .takes_value = false, .id = .emit_llvm, .value_name = "" },
     .{ .long = "-o", .short = null, .takes_value = true, .id = .output, .value_name = "file path" },
     .{ .long = "--disassemble", .short = null, .takes_value = false, .id = .disassemble, .value_name = "" },
+    .{ .long = "--no-ir-opt", .short = null, .takes_value = false, .id = .no_ir_opt, .value_name = "" },
     .{ .long = "--sandbox", .short = null, .takes_value = false, .id = .sandbox, .value_name = "" },
     .{ .long = "--gc-stats", .short = null, .takes_value = false, .id = .gc_stats, .value_name = "" },
     .{ .long = "--profile", .short = null, .takes_value = false, .id = .profile, .value_name = "" },
@@ -89,6 +91,7 @@ pub const Options = struct {
     max_memory: ?usize = null,
 
     sandbox_mode: bool = false,
+    no_ir_opt: bool = false,
 
     lib_path_buf: [16][]const u8 = undefined,
     lib_path_count: usize = 0,
@@ -175,6 +178,7 @@ pub fn parse(args: std.process.Args) Options {
                 .emit_llvm => opts.emit_llvm_mode = true,
                 .output => opts.compile_output = value.?,
                 .disassemble => opts.disassemble_mode = true,
+                .no_ir_opt => opts.no_ir_opt = true,
                 .sandbox => opts.sandbox_mode = true,
                 .gc_stats => opts.gc_stats_mode = true,
                 .profile => opts.profile_mode = true,
@@ -241,6 +245,7 @@ pub fn printUsage() void {
             "  --emit-llvm        Emit LLVM IR text (.ll)\n" ++
             "  -o <file>          Output path\n" ++
             "  --disassemble      Disassemble bytecode\n" ++
+            "  --no-ir-opt        Disable IR optimization passes (skips .sbc cache)\n" ++
             "  --sandbox          Restrict filesystem and process access\n" ++
             "  --gc-stats         Print GC statistics on exit\n" ++
             "  --profile          Enable profiling\n" ++
@@ -460,6 +465,13 @@ test "parse: multiple lib paths" {
     try std.testing.expectEqual(@as(usize, 2), opts.lib_path_count);
     try std.testing.expectEqualStrings("/a", opts.libPaths()[0]);
     try std.testing.expectEqualStrings("/b", opts.libPaths()[1]);
+}
+
+test "parse: no-ir-opt" {
+    const argv = [_][*:0]const u8{ "kaappi", "--no-ir-opt", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expect(opts.no_ir_opt);
+    try std.testing.expectEqualStrings("test.scm", opts.file_path.?);
 }
 
 test "parse: disassemble mode" {

--- a/src/fuzz_gen.zig
+++ b/src/fuzz_gen.zig
@@ -58,7 +58,10 @@ const max_inner_iters: u32 = 5;
 // ---------------------------------------------------------------------------
 
 const local_names = [_][]const u8{ "a", "b", "c", "d", "e", "h", "u", "v" };
-const global_names = [_][]const u8{ "g0", "g1", "g2" };
+/// Public: the differential oracle (tests_fuzz.zig) prints these globals
+/// after evaluation to widen its observable — a wrong fold inside
+/// `(define g1 ...)` is invisible in the program's final value alone.
+pub const global_names = [_][]const u8{ "g0", "g1", "g2" };
 const fn_names = [_][]const u8{ "f0", "f1" };
 const macro_names = [_][]const u8{ "m0", "m1" };
 const pattern_names = [_][]const u8{ "p", "q", "r" };

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -568,6 +568,15 @@ pub fn lower(irn: *IR, expr: Value) CompileError!*Node {
     return lowerWithMacros(irn, expr, null);
 }
 
+/// Master switch for IR optimization: when false, `lowerAndOptimize` skips
+/// the five optimization passes and `tryFoldFromAST` stops folding during
+/// lowering. Analysis (`markTailPositions`) always runs — it is required for
+/// correctness, not an optimization. Threadlocal (like `vm_instance`) so
+/// SRFI-18 child threads keep the default regardless of the parent's setting.
+/// Toggled by the `--no-ir-opt` CLI flag and by the differential fuzz oracle
+/// in tests_fuzz.zig (#1393).
+pub threadlocal var optimize_enabled: bool = true;
+
 pub fn lowerAndOptimize(
     ir_instance: *IR,
     expr: Value,
@@ -576,6 +585,7 @@ pub fn lowerAndOptimize(
 ) CompileError!*Node {
     var node = try lowerWithMacros(ir_instance, expr, macros);
     markTailPositions(node, is_tail);
+    if (!optimize_enabled) return node;
     node = foldConstants(ir_instance, node);
     node = eliminateDeadBranches(ir_instance, node);
     node = simplifyBooleans(ir_instance, node);
@@ -748,6 +758,7 @@ fn lowerCall(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value)) CompileEr
 }
 
 fn tryFoldFromAST(ir: *IR, expr: Value) ?*Node {
+    if (!optimize_enabled) return null;
     const operator = types.car(expr);
     if (!types.isSymbol(operator)) return null;
     const name = types.symbolName(operator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -409,11 +409,18 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         }
     } else if (opts.compile_mode) {
         if (opts.file_path) |fp| {
-            // Without -o, --compile writes to the cache location that plain
-            // runs load from; don't let it poison the cache with
-            // unoptimized bytecode (cache keys don't include the flag).
-            if (opts.no_ir_opt and opts.compile_output == null) {
-                usageError("--no-ir-opt with --compile requires -o <file> (the default output path is the bytecode cache)\n");
+            // --no-ir-opt must not write unoptimized bytecode where plain
+            // runs load their cache from (cache keys don't include the
+            // flag). That location is both the default output (no -o) and
+            // the natural explicit choice (-o program.sbc), so refuse both.
+            if (opts.no_ir_opt) {
+                const clobbers = if (opts.compile_output) |op|
+                    outputIsBytecodeCache(allocator, fp, op)
+                else
+                    true;
+                if (clobbers) {
+                    usageError("--no-ir-opt --compile requires -o <file> that is not the source's .sbc cache path (plain runs would load the unoptimized bytecode as their cache)\n");
+                }
             }
             try compileFile(vm, fp, opts.compile_output);
         } else {
@@ -442,6 +449,30 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
 
 fn getSbcPath(allocator: std.mem.Allocator, scm_path: []const u8) ![]u8 {
     return bytecode_file.getSbcPath(allocator, scm_path);
+}
+
+/// True when `output_path` is the `.sbc` cache location that plain runs of
+/// `src_path` load from. Lexical comparison after normalizing `.`/`..`
+/// segments — symlinks and absolute-vs-relative aliases of the same file are
+/// not detected, but the natural spellings (`prog.sbc`, `./prog.sbc`) are.
+fn outputIsBytecodeCache(allocator: std.mem.Allocator, src_path: []const u8, output_path: []const u8) bool {
+    const cache_path = getSbcPath(allocator, src_path) catch return false;
+    defer allocator.free(cache_path);
+    const out_norm = std.fs.path.resolve(allocator, &.{output_path}) catch return false;
+    defer allocator.free(out_norm);
+    const cache_norm = std.fs.path.resolve(allocator, &.{cache_path}) catch return false;
+    defer allocator.free(cache_norm);
+    return std.mem.eql(u8, out_norm, cache_norm);
+}
+
+test "outputIsBytecodeCache detects cache-path collisions" {
+    const gpa = std.testing.allocator;
+    try std.testing.expect(outputIsBytecodeCache(gpa, "prog.scm", "prog.sbc"));
+    try std.testing.expect(outputIsBytecodeCache(gpa, "prog.scm", "./prog.sbc"));
+    try std.testing.expect(outputIsBytecodeCache(gpa, "dir/prog.scm", "dir/prog.sbc"));
+    try std.testing.expect(outputIsBytecodeCache(gpa, "dir/prog.scm", "dir/../dir/prog.sbc"));
+    try std.testing.expect(!outputIsBytecodeCache(gpa, "prog.scm", "prog.noopt.sbc"));
+    try std.testing.expect(!outputIsBytecodeCache(gpa, "prog.scm", "out/prog.sbc"));
 }
 
 fn runFile(vm: *vm_mod.VM, path: []const u8) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -207,6 +207,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     if (opts.action == .exit_ok) return;
 
     // Apply parsed options to VM/GC
+    if (opts.no_ir_opt) ir_mod.optimize_enabled = false;
     if (opts.timeout_ms) |ms| {
         const clockNs = @import("vm_calls.zig").clockNs;
         vm.timeout_deadline_ns = clockNs() + ms * 1_000_000;
@@ -408,6 +409,12 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         }
     } else if (opts.compile_mode) {
         if (opts.file_path) |fp| {
+            // Without -o, --compile writes to the cache location that plain
+            // runs load from; don't let it poison the cache with
+            // unoptimized bytecode (cache keys don't include the flag).
+            if (opts.no_ir_opt and opts.compile_output == null) {
+                usageError("--no-ir-opt with --compile requires -o <file> (the default output path is the bytecode cache)\n");
+            }
             try compileFile(vm, fp, opts.compile_output);
         } else {
             usageError("Usage: kaappi --compile <file.scm> [-o output.sbc]\n");
@@ -453,8 +460,11 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
 
     const source_hash = bytecode_file.sourceHash(source);
 
-    // Try loading cached bytecode (skip in sandbox mode — no filesystem side effects)
-    const sbc_path = if (vm.sandbox_mode) null else getSbcPath(allocator, path) catch null;
+    // Try loading cached bytecode (skip in sandbox mode — no filesystem side
+    // effects — and under --no-ir-opt: cache keys don't include the flag, so
+    // a no-opt run must neither reuse optimized bytecode nor poison the cache
+    // with unoptimized bytecode).
+    const sbc_path = if (vm.sandbox_mode or !ir_mod.optimize_enabled) null else getSbcPath(allocator, path) catch null;
     defer if (sbc_path) |p| allocator.free(p);
 
     if (sbc_path) |sp| {

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -8,6 +8,8 @@ const primitives = @import("primitives.zig");
 const library = @import("library.zig");
 const types = @import("types.zig");
 const fuzz_gen = @import("fuzz_gen.zig");
+const ir_mod = @import("ir.zig");
+const printer = @import("printer.zig");
 
 const Context = @TypeOf(.{});
 
@@ -192,6 +194,36 @@ fn evalOne(input: []const u8) void {
 }
 
 fn evalOneOutcome(input: []const u8) EvalOutcome {
+    var out = evalNormalized(input, true, std.testing.allocator);
+    defer out.deinit(std.testing.allocator);
+    return switch (out) {
+        .value => .ok,
+        .harness_unavailable => .harness_unavailable,
+        .compile_error, .runtime_error, .resource_limit => .scheme_error,
+    };
+}
+
+/// Normalized observable of one evaluation, for differential comparison:
+/// the printed result (write mode) or the error CLASS — never error message
+/// text. Resource outcomes (deadline, heap, stack) legitimately depend on
+/// how much work each compilation path does, so they make a differential
+/// pair incomparable rather than counting as divergence.
+const NormalizedOutcome = union(enum) {
+    value: []u8, // owned; printer.zig write-mode
+    compile_error, // read or compile (vm.eval folds both into CompileError)
+    runtime_error,
+    resource_limit,
+    harness_unavailable,
+
+    fn deinit(self: *NormalizedOutcome, gpa: std.mem.Allocator) void {
+        switch (self.*) {
+            .value => |s| gpa.free(s),
+            else => {},
+        }
+    }
+};
+
+fn evalNormalized(input: []const u8, optimize: bool, gpa: std.mem.Allocator) NormalizedOutcome {
     // Redirect fd 1 to /dev/null for the duration: generated programs can
     // call (display ...), and the test binary's stdout is the build-runner
     // IPC pipe — a stray write there deadlocks the run.
@@ -232,8 +264,41 @@ fn evalOneOutcome(input: []const u8) EvalOutcome {
     library.registerSandboxedLibraries(&vm.libraries, vm.globals) catch return .harness_unavailable;
     vm.sandbox_mode = true;
     vm.timeout_deadline_ns = @import("vm_calls.zig").clockNs() + 100_000_000;
-    _ = vm.eval(input) catch return .scheme_error;
-    return .ok;
+
+    // Toggle only around user-program evaluation, after the bootstrap and
+    // library registration above compiled with the default setting.
+    ir_mod.optimize_enabled = optimize;
+    defer ir_mod.optimize_enabled = true;
+    const result = vm.eval(input) catch |err| return switch (err) {
+        error.CompileError => .compile_error,
+        error.ExecutionTimeout, error.OutOfMemory, error.StackOverflow => .resource_limit,
+        else => .runtime_error,
+    };
+
+    // The observable is the final expression's value PLUS the generator's
+    // fixed globals: `vm.eval` returns only the last top-level value, so a
+    // wrong value inside `(define g1 ...)` (a void-valued form) would
+    // otherwise stay invisible unless the last expression happens to be
+    // sensitive to it. Closures print as `#<procedure name>` — no
+    // addresses — so proc-valued globals compare deterministically.
+    var parts: std.ArrayList(u8) = .empty;
+    defer parts.deinit(gpa);
+    appendPrinted(&parts, gpa, result) catch return .harness_unavailable;
+    for (fuzz_gen.global_names) |gn| {
+        const gv = vm.globals.get(gn) orelse continue;
+        parts.appendSlice(gpa, "\n") catch return .harness_unavailable;
+        parts.appendSlice(gpa, gn) catch return .harness_unavailable;
+        parts.appendSlice(gpa, "=") catch return .harness_unavailable;
+        appendPrinted(&parts, gpa, gv) catch return .harness_unavailable;
+    }
+    const printed = parts.toOwnedSlice(gpa) catch return .harness_unavailable;
+    return .{ .value = printed };
+}
+
+fn appendPrinted(parts: *std.ArrayList(u8), gpa: std.mem.Allocator, value: types.Value) !void {
+    const s = try printer.valueToString(gpa, value, .write);
+    defer gpa.free(s);
+    try parts.appendSlice(gpa, s);
 }
 
 test "fuzz reader" {
@@ -431,4 +496,82 @@ test "grammar generator: majority of programs evaluate without error" {
     // load-sensitive: a real generator regression tanks the rate, CI
     // jitter must not.
     try std.testing.expect(ok * 100 >= total * 75);
+}
+
+// ---------------------------------------------------------------------------
+// Differential oracle: optimized vs unoptimized evaluation (Tier 3, #1394)
+//
+// Crash-only fuzzing never surfaces silently-wrong values — the majority
+// class of compiler bugs (EMI; Pałka et al. found GHC optimizer bugs within
+// ~20k random tests with exactly this oracle). Evaluate the same generated
+// program with IR optimizations on and off; any divergence in the normalized
+// observable is a bug in an optimization pass (or in the baseline).
+//
+// The generator already emits nothing observably nondeterministic: no time,
+// random, or I/O forms, and `eq?` only on interned symbols (never on heap
+// literals, where identity is unspecified and may legitimately differ
+// between compilation paths).
+// ---------------------------------------------------------------------------
+
+fn diffOne(src: []const u8) !void {
+    var opt = evalNormalized(src, true, std.testing.allocator);
+    defer opt.deinit(std.testing.allocator);
+    if (opt == .harness_unavailable or opt == .resource_limit) return;
+    var noopt = evalNormalized(src, false, std.testing.allocator);
+    defer noopt.deinit(std.testing.allocator);
+    if (noopt == .harness_unavailable or noopt == .resource_limit) return;
+
+    const match = switch (opt) {
+        .value => |s| noopt == .value and std.mem.eql(u8, s, noopt.value),
+        .compile_error => noopt == .compile_error,
+        .runtime_error => noopt == .runtime_error,
+        .resource_limit, .harness_unavailable => unreachable,
+    };
+    if (!match) {
+        // stderr, never fd 1 (the build-runner IPC pipe).
+        std.debug.print("differential mismatch on program:\n{s}\n--- opt observable ---\n{s}\n--- no-opt observable ---\n{s}\n", .{
+            src, describeOutcome(opt), describeOutcome(noopt),
+        });
+        return error.DifferentialMismatch;
+    }
+}
+
+fn describeOutcome(o: NormalizedOutcome) []const u8 {
+    return switch (o) {
+        .value => |s| s,
+        else => @tagName(o),
+    };
+}
+
+test "fuzz differential (opt vs no-opt)" {
+    try std.testing.fuzz(Context{}, struct {
+        fn testOne(_: Context, smith: *std.testing.Smith) anyerror!void {
+            const src = fuzz_gen.generateProgram(smith, std.testing.allocator) catch return;
+            defer std.testing.allocator.free(src);
+            try diffOne(src);
+        }
+    }.testOne, .{});
+}
+
+// Deterministic regression gate for the oracle itself: fixed-seed programs
+// must agree between the two compilation paths on every `zig build test`
+// run, not just under --fuzz. A failure here is a real optimizer (or
+// baseline) bug — minimise the printed program into a Scheme regression
+// test per repo policy. 60 seeds keeps the cost near the majority-evaluate
+// gate above (each seed builds two VMs); planted-bug measurement: an
+// off-by-one planted in the `*` constant fold diverges at seed 30 (and 3
+// more within 500), so this window has real detection power.
+test "differential oracle: fixed-seed programs agree opt vs no-opt" {
+    // Under gc-stress both runs hit the 100 ms deadline and every pair
+    // becomes incomparable resource_limit outcomes — the test would pass
+    // while measuring nothing, at ~2 VM builds per seed. Skip.
+    if (@import("build_options").gc_stress) return error.SkipZigTest;
+    var seed_n: u64 = 0;
+    while (seed_n < 60) : (seed_n += 1) {
+        const src = try fuzz_gen.generateSeeded(seed_n, std.testing.allocator);
+        defer std.testing.allocator.free(src);
+        // diffOne already prints the program and both observables.
+        errdefer std.debug.print("(fixed seed {d})\n", .{seed_n});
+        try diffOne(src);
+    }
 }

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -769,11 +769,31 @@ test "IR opt switch: folded patterns evaluate identically without optimization" 
         .{ .src = "(or #f 7)", .want = 7 },
         .{ .src = "(let ((x (* 2 3))) (+ x (if #t 1 0)))", .want = 7 },
     };
-    for (cases) |case| try th.expectEval(case.src, case.want);
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    for (cases) |case| {
+        try std.testing.expectEqual(case.want, types.toFixnum(try ctx.vm.eval(case.src)));
+    }
 
     ir_mod.optimize_enabled = false;
     defer ir_mod.optimize_enabled = true;
-    for (cases) |case| try th.expectEval(case.src, case.want);
+    for (cases) |case| {
+        try std.testing.expectEqual(case.want, types.toFixnum(try ctx.vm.eval(case.src)));
+    }
+}
+
+test "IR opt switch: self-tail-call still optimized without IR optimization" {
+    // markTailPositions must keep running when optimization is off — it is
+    // analysis, and it is what compiles self-tail-calls as loops. 100k
+    // iterations would overflow the frame stack otherwise (mirrors the
+    // bare-lambda self-tail-call test above, which runs optimized).
+    ir_mod.optimize_enabled = false;
+    defer ir_mod.optimize_enabled = true;
+    try th.expectEval(
+        \\(define f (lambda (n acc) (if (= n 0) acc (f (- n 1) (+ acc 1)))))
+        \\(f 100000 0)
+    , 100000);
 }
 
 test "IR opt switch: disabling optimization changes emitted bytecode" {

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -746,3 +746,48 @@ test "IR: line-table entries recorded for IR-compiled code" {
     }
     try std.testing.expect(child_has_lines);
 }
+
+// --- Issue #1393: optimization on/off switch ---
+
+test "IR opt switch: folded patterns evaluate identically without optimization" {
+    // One case per folding/simplification pattern: AST fold (+,-,*,cmp),
+    // unary folds (not, zero?, negate), dead-branch elimination, boolean
+    // simplification, identity elimination, begin simplification.
+    const cases = [_]struct { src: []const u8, want: i64 }{
+        .{ .src = "(+ 1 2)", .want = 3 },
+        .{ .src = "(* 6 7)", .want = 42 },
+        .{ .src = "(- 5)", .want = -5 },
+        .{ .src = "(if (< 1 2) 10 20)", .want = 10 },
+        .{ .src = "(if (not #f) 10 20)", .want = 10 },
+        .{ .src = "(if (zero? 0) 1 2)", .want = 1 },
+        .{ .src = "(if #t 1 2)", .want = 1 },
+        .{ .src = "(if #f 1 2)", .want = 2 },
+        .{ .src = "(if (< 1 2) (+ 3 4) 99)", .want = 7 },
+        .{ .src = "(begin 1 2 3)", .want = 3 },
+        .{ .src = "(begin (+ 40 2))", .want = 42 },
+        .{ .src = "(and 1 2 3)", .want = 3 },
+        .{ .src = "(or #f 7)", .want = 7 },
+        .{ .src = "(let ((x (* 2 3))) (+ x (if #t 1 0)))", .want = 7 },
+    };
+    for (cases) |case| try th.expectEval(case.src, case.want);
+
+    ir_mod.optimize_enabled = false;
+    defer ir_mod.optimize_enabled = true;
+    for (cases) |case| try th.expectEval(case.src, case.want);
+}
+
+test "IR opt switch: disabling optimization changes emitted bytecode" {
+    // (if #t 1 2) collapses to a single constant load when dead-branch
+    // elimination runs; without it the test, branch, and both arms are all
+    // emitted. Different code proves the switch is live.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const opt_func = try compiler_mod.compileExpression(&gc, try readExpr(&gc, "(if #t 1 2)"));
+    const opt_len = opt_func.code.items.len;
+
+    ir_mod.optimize_enabled = false;
+    defer ir_mod.optimize_enabled = true;
+    const noopt_func = try compiler_mod.compileExpression(&gc, try readExpr(&gc, "(if #t 1 2)"));
+    try std.testing.expect(opt_len < noopt_func.code.items.len);
+}


### PR DESCRIPTION
First half of Phase 3 of the fuzzing roadmap (#1397): the Tier 3 enabler and the first correctness oracle. The remaining Phase 3 items (#1395 native-backend diff, #1396 external-reference diff) are separate follow-ups per the epic's one-at-a-time design.

## #1393 — `--no-ir-opt` switch

- `ir.optimize_enabled` (threadlocal, matching the `vm_instance` pattern) gates the five optimization passes **and** AST-level constant folding in `tryFoldFromAST`; `markTailPositions` always runs (analysis, not optimization).
- CLI flag `--no-ir-opt`, listed in `--help` and CLAUDE.md.
- No-opt runs skip the `.sbc` cache entirely (keys don't include the flag); `--no-ir-opt --compile` without `-o` is refused since the default output path is the cache location.

**Acceptance:** `--disassemble` on `(if #t 1 2)` → single `load_const` optimized vs full test/branch/arms unoptimized; regression tests cover one case per folded pattern; full Scheme suite under `--no-ir-opt`: **1821 pass, 0 fail** (stale `.sbc` caches deleted first — the flag makes them unreachable anyway).

## #1394 — `fuzz differential (opt vs no-opt)` target

- Generates a program via `fuzz_gen` (#1392), evaluates it in two fresh sandboxed VMs — optimizations on and off — and compares a normalized observable: printed final value (write mode) **plus the generator's globals `g0`–`g2`**, and the error class (never message text). Divergence → `error.DifferentialMismatch`, with the program and both observables printed to stderr for triage.
- Timeout / OOM / stack-overflow outcomes make a pair incomparable (skip) rather than a divergence — the two paths legitimately do different amounts of work.
- The globals widening is load-bearing: `vm.eval` returns only the last top-level value, so a wrong fold inside `(define g1 …)` is invisible in the final value alone. Planted-bug check: an off-by-one in the `*` constant fold is caught at fixed seed 30 (3 more within 500 seeds); without the globals it went undetected across all 500.
- A 60-seed deterministic gate runs on every `zig build test`; the CI fuzz job (#1390) picks the target up automatically. The generator emits nothing observably nondeterministic (no time/random/I-O forms; `eq?` only on interned symbols), so no exclusion knob was needed.

## Validation

- `zig build test`: 703/703
- `bash tests/scheme/run-all.sh` with `--no-ir-opt`: 1821 pass, 0 fail, 0 timeouts
- `zig build test --fuzz=200`: exit 0, no `.zig-cache/f/crash` marker, all 7 target corpora updated
- `zig fmt --check`: clean

Closes #1393
Closes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)