### PR TITLE
Harden the --no-ir-opt compile guard (post-merge review of #1405)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -419,7 +419,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 else
                     true;
                 if (clobbers) {
-                    usageError("--no-ir-opt --compile requires -o <file> that is not the source's .sbc cache path (plain runs would load the unoptimized bytecode as their cache)\n");
+                    usageError("--no-ir-opt --compile requires -o <file> that is neither the source's .sbc cache path nor a symlink (plain runs would load the unoptimized bytecode as their cache)\n");
                 }
             }
             try compileFile(vm, fp, opts.compile_output);
@@ -451,18 +451,31 @@ fn getSbcPath(allocator: std.mem.Allocator, scm_path: []const u8) ![]u8 {
     return bytecode_file.getSbcPath(allocator, scm_path);
 }
 
-/// True when `output_path` is the `.sbc` cache location that plain runs of
-/// `src_path` load from. Lexical comparison after normalizing `.`/`..`
-/// segments — symlinks and absolute-vs-relative aliases of the same file are
-/// not detected, but the natural spellings (`prog.sbc`, `./prog.sbc`) are.
+/// True when `output_path` may be the `.sbc` cache location that plain runs
+/// of `src_path` load from. Fails CLOSED: an allocation failure or a
+/// symlinked output (the write would follow the link to an unknown target)
+/// counts as a collision, so --no-ir-opt can never poison the cache through
+/// this guard — the caller refuses with a usage error either way.
+/// Path comparison is lexical after normalizing `.`/`..` segments;
+/// symlinked *parent directories* and absolute-vs-relative aliases of the
+/// same file are still not detected.
 fn outputIsBytecodeCache(allocator: std.mem.Allocator, src_path: []const u8, output_path: []const u8) bool {
-    const cache_path = getSbcPath(allocator, src_path) catch return false;
+    if (pathIsSymlink(allocator, output_path)) return true;
+    const cache_path = getSbcPath(allocator, src_path) catch return true;
     defer allocator.free(cache_path);
-    const out_norm = std.fs.path.resolve(allocator, &.{output_path}) catch return false;
+    const out_norm = std.fs.path.resolve(allocator, &.{output_path}) catch return true;
     defer allocator.free(out_norm);
-    const cache_norm = std.fs.path.resolve(allocator, &.{cache_path}) catch return false;
+    const cache_norm = std.fs.path.resolve(allocator, &.{cache_path}) catch return true;
     defer allocator.free(cache_norm);
     return std.mem.eql(u8, out_norm, cache_norm);
+}
+
+fn pathIsSymlink(allocator: std.mem.Allocator, path: []const u8) bool {
+    // Treat an unrepresentable path as a symlink (fail closed).
+    const path_z = allocator.dupeZ(u8, path) catch return true;
+    defer allocator.free(path_z);
+    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    return std.c.readlink(path_z, &buf, buf.len) >= 0;
 }
 
 test "outputIsBytecodeCache detects cache-path collisions" {
@@ -473,6 +486,30 @@ test "outputIsBytecodeCache detects cache-path collisions" {
     try std.testing.expect(outputIsBytecodeCache(gpa, "dir/prog.scm", "dir/../dir/prog.sbc"));
     try std.testing.expect(!outputIsBytecodeCache(gpa, "prog.scm", "prog.noopt.sbc"));
     try std.testing.expect(!outputIsBytecodeCache(gpa, "prog.scm", "out/prog.sbc"));
+}
+
+test "outputIsBytecodeCache refuses symlinked outputs" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.symLink(std.testing.io, "prog.sbc", "alias.sbc", .{});
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", gpa);
+    defer gpa.free(dir_path);
+
+    const src = try std.fs.path.join(gpa, &.{ dir_path, "prog.scm" });
+    defer gpa.free(src);
+    const alias = try std.fs.path.join(gpa, &.{ dir_path, "alias.sbc" });
+    defer gpa.free(alias);
+    const distinct = try std.fs.path.join(gpa, &.{ dir_path, "other.sbc" });
+    defer gpa.free(distinct);
+
+    try std.testing.expect(outputIsBytecodeCache(gpa, src, alias));
+    try std.testing.expect(!outputIsBytecodeCache(gpa, src, distinct));
+}
+
+test "outputIsBytecodeCache fails closed on allocation failure" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    try std.testing.expect(outputIsBytecodeCache(failing.allocator(), "prog.scm", "prog.noopt.sbc"));
 }
 
 fn runFile(vm: *vm_mod.VM, path: []const u8) !void {

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -267,8 +267,9 @@ fn evalNormalized(input: []const u8, optimize: bool, gpa: std.mem.Allocator) Nor
 
     // Toggle only around user-program evaluation, after the bootstrap and
     // library registration above compiled with the default setting.
+    const saved_opt = ir_mod.optimize_enabled;
     ir_mod.optimize_enabled = optimize;
-    defer ir_mod.optimize_enabled = true;
+    defer ir_mod.optimize_enabled = saved_opt;
     const result = vm.eval(input) catch |err| return switch (err) {
         error.CompileError => .compile_error,
         error.ExecutionTimeout, error.OutOfMemory, error.StackOverflow => .resource_limit,

--- a/src/tests_ir.zig
+++ b/src/tests_ir.zig
@@ -769,15 +769,18 @@ test "IR opt switch: folded patterns evaluate identically without optimization" 
         .{ .src = "(or #f 7)", .want = 7 },
         .{ .src = "(let ((x (* 2 3))) (+ x (if #t 1 0)))", .want = 7 },
     };
+    const saved_opt = ir_mod.optimize_enabled;
+    defer ir_mod.optimize_enabled = saved_opt;
+
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
+    ir_mod.optimize_enabled = true;
     for (cases) |case| {
         try std.testing.expectEqual(case.want, types.toFixnum(try ctx.vm.eval(case.src)));
     }
 
     ir_mod.optimize_enabled = false;
-    defer ir_mod.optimize_enabled = true;
     for (cases) |case| {
         try std.testing.expectEqual(case.want, types.toFixnum(try ctx.vm.eval(case.src)));
     }
@@ -788,8 +791,9 @@ test "IR opt switch: self-tail-call still optimized without IR optimization" {
     // analysis, and it is what compiles self-tail-calls as loops. 100k
     // iterations would overflow the frame stack otherwise (mirrors the
     // bare-lambda self-tail-call test above, which runs optimized).
+    const saved_opt = ir_mod.optimize_enabled;
+    defer ir_mod.optimize_enabled = saved_opt;
     ir_mod.optimize_enabled = false;
-    defer ir_mod.optimize_enabled = true;
     try th.expectEval(
         \\(define f (lambda (n acc) (if (= n 0) acc (f (- n 1) (+ acc 1)))))
         \\(f 100000 0)
@@ -800,14 +804,17 @@ test "IR opt switch: disabling optimization changes emitted bytecode" {
     // (if #t 1 2) collapses to a single constant load when dead-branch
     // elimination runs; without it the test, branch, and both arms are all
     // emitted. Different code proves the switch is live.
+    const saved_opt = ir_mod.optimize_enabled;
+    defer ir_mod.optimize_enabled = saved_opt;
+
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
+    ir_mod.optimize_enabled = true;
     const opt_func = try compiler_mod.compileExpression(&gc, try readExpr(&gc, "(if #t 1 2)"));
     const opt_len = opt_func.code.items.len;
 
     ir_mod.optimize_enabled = false;
-    defer ir_mod.optimize_enabled = true;
     const noopt_func = try compiler_mod.compileExpression(&gc, try readExpr(&gc, "(if #t 1 2)"));
     try std.testing.expect(opt_len < noopt_func.code.items.len);
 }


### PR DESCRIPTION
Follow-up for the three CodeRabbit findings posted on #1405 after it merged.

- **Fail closed** (Major, quick win — valid): `outputIsBytecodeCache` treated allocation/normalization failure as "no collision", which could let an unoptimized cache write through. Any failure now counts as a collision; worst case is a spurious usage error, never a poisoned cache. Regression test with `std.testing.FailingAllocator`.
- **Symlink alias** (Major — valid, though the limitation was documented and deliberate): `-o alias.sbc` where `alias.sbc -> prog.sbc` bypassed the lexical comparison. Under `--no-ir-opt --compile`, a symlinked output is now refused outright (`std.c.readlink` probe, same pattern as SRFI-170). Symlinked *parent directories* remain undetected — full canonicalization of not-yet-existing outputs isn't worth the machinery for a footgun guard; the doc comment says so. Regression test via `std.testing.tmpDir`; verified end-to-end (symlinked `-o` exits 2, distinct real file compiles).
- **Save/restore `optimize_enabled`** (Minor — valid): the opt-switch tests and the differential fuzz harness restored the flag by assigning `true` rather than the saved value, and optimized baselines assumed it was already enabled. All toggles now save/restore and set their baseline explicitly, so filtered or reordered test runs can't leak state.

`zig build test` passes (includes the two new guard tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)