### PR TITLE
Fuzzing roadmap Phase 3: VM vs LLVM native backend differential harness

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,7 @@
 name: Fuzz
 
-# Scheduled bounded fuzzing of the targets in src/tests_fuzz.zig.
+# Scheduled bounded fuzzing of the targets in src/tests_fuzz.zig, plus the
+# offline VM-vs-native differential batch (tests/fuzz/native-diff.sh).
 # See docs/dev/fuzzing.md for the runbook (running locally, and turning a
 # failure into a regression test + corpus entry).
 
@@ -12,6 +13,14 @@ on:
     inputs:
       limit:
         description: 'Fuzz run limit per variant (number, K/M/G suffix allowed). Overrides the matrix defaults.'
+        required: false
+        default: ''
+      native-diff-count:
+        description: 'Number of programs for the VM-vs-native differential batch.'
+        required: false
+        default: ''
+      native-diff-base:
+        description: 'First seed for the differential batch (default: rotates per run).'
         required: false
         default: ''
 
@@ -98,5 +107,52 @@ jobs:
             .zig-cache/f/crash
             fuzz-run.log
             .zig-cache/tmp/libfuzzer.log
+          retention-days: 90
+          if-no-files-found: warn
+
+  # Offline differential batch: bytecode VM vs LLVM native backend (#1395).
+  # Each input is generate + interpret + compile-and-link + run, so this is a
+  # scheduled batch (~1s per program), not a std.testing.fuzz target. The
+  # seed base rotates per run so nightly batches cover fresh programs while
+  # staying reproducible: the base is printed in the log, the divergent
+  # programs themselves are uploaded, and any base can be replayed via
+  # workflow_dispatch or locally with
+  # `bash tests/fuzz/native-diff.sh <count> <base>`.
+  native-diff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 55
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@v1
+        with:
+          version: 0.16.0
+          cache-key: fuzz-native-diff
+
+      - name: Build interpreter, runtime library, and generator
+        run: |
+          zig build
+          zig build lib
+          zig build fuzz-gen
+
+      - name: Differential batch (VM vs native backend)
+        env:
+          COUNT: ${{ inputs.native-diff-count }}
+          BASE: ${{ inputs.native-diff-base }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          count="${COUNT:-300}"
+          base="${BASE:-$((RUN_NUMBER * 300))}"
+          bash tests/fuzz/native-diff.sh "$count" "$base"
+
+      # Each divergence comes with the program and both sides' stdout/stderr;
+      # see docs/dev/fuzzing.md for minimising it into a regression test.
+      - name: Upload divergences
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-diff-divergences
+          path: native-diff-results/
           retention-days: 90
           if-no-files-found: warn

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -53,7 +53,12 @@ jobs:
           #   build-args: '-Dgc-stress=true'
           #   limit: 200
     steps:
+      # Both jobs in this workflow execute fuzzer-generated programs (and
+      # the native-diff job runs binaries compiled from them), so don't
+      # leave the GITHUB_TOKEN sitting in git config for the process tree.
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Zig
         uses: xyzzylabs/setup-zig@v1
@@ -123,6 +128,8 @@ jobs:
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Zig
         uses: xyzzylabs/setup-zig@v1

--- a/build.zig
+++ b/build.zig
@@ -229,6 +229,21 @@ pub fn build(b: *std.Build) void {
     lsp_exe.stack_size = 64 * 1024 * 1024;
     b.installArtifact(lsp_exe);
 
+    // Fuzz program generator (driver for the offline differential harness,
+    // tests/fuzz/native-diff.sh). Dev/CI tool: installed only by this step,
+    // never by the default install, so it stays out of release artifacts.
+    const fuzz_gen_mod = kaappiModule(b, options_mod, .{
+        .root = "src/fuzz_gen_main.zig",
+        .target = target,
+        .optimize = optimize,
+    });
+    const fuzz_gen_exe = b.addExecutable(.{
+        .name = "kaappi-fuzz-gen",
+        .root_module = fuzz_gen_mod,
+    });
+    const fuzz_gen_step = b.step("fuzz-gen", "Build the fuzz program generator (zig-out/bin/kaappi-fuzz-gen)");
+    fuzz_gen_step.dependOn(&b.addInstallArtifact(fuzz_gen_exe, .{}).step);
+
     // Unit tests
     const test_mod = kaappiModule(b, options_mod, .{
         .target = target,

--- a/docs/dev/fuzzing-feasibility.md
+++ b/docs/dev/fuzzing-feasibility.md
@@ -200,8 +200,11 @@ table:
   *(Structure-aware generation closed 2026-07-10 by the grammar generator,
   #1392. Differential testing partially closed the same day by the
   optimized-vs-unoptimized oracle — the `--no-ir-opt` switch, #1393, plus
-  the `fuzz differential` target, #1394; the native-backend and external-
-  reference oracles, #1395/#1396, remain open.)*
+  the `fuzz differential` target, #1394 — and by the VM-vs-native-backend
+  batch harness, #1395: a native-subset generator mode
+  (`src/fuzz_gen_native.zig`) feeding `tests/fuzz/native-diff.sh`, run
+  nightly by the fuzz workflow. The external-reference oracle, #1396,
+  remains open.)*
 
 ## What the research literature says
 

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -183,15 +183,20 @@ Comparison rules:
   non-procedure global), because the VM echoes non-void top-level values but
   native binaries do not, and procedure values print differently by design
   (`#<procedure name>` vs `#<procedure>`).
-- **Both exit non-zero** — treated as a match without comparing stdout: the
+- **Both exit 1–127** — ordinary-error match, without comparing stdout: the
   VM reports a top-level error and continues with the next form, the native
   binary exits at the first error, so post-error output legitimately
   differs.
-- **Exit classes differ, stdout differs, or `kaappi compile` fails to
-  produce a binary** — divergence: the program plus both sides'
-  stdout/stderr land in the results dir and the script exits non-zero.
-- **Either side times out** (needs GNU `timeout`/`gtimeout` on PATH) — the
-  pair is skipped as incomparable.
+- **Any exit ≥ 128** — divergence: 128+N is death by signal N (segfault,
+  abort, …), which is never an ordinary Scheme error, so it is flagged even
+  when the other side also errored.
+- **Exit classes differ, stdout differs, or `kaappi compile` fails or times
+  out** — divergence: the program plus both sides' stdout/stderr land in
+  the results dir and the script exits non-zero.
+- **Either side's execution times out** (needs GNU `timeout`/`gtimeout` on
+  PATH) — the pair is skipped as incomparable. Compilation gets its own,
+  longer timeout so a hung linker on one seed is classified as a divergence
+  instead of stalling the batch.
 
 One caveat when triaging a divergence: argument evaluation order is
 unspecified in R7RS, and generated programs do mutate globals inside

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -133,6 +133,72 @@ special permissions: the eval harness registers only the sandboxed
 primitive set (no filesystem, process, FFI, or thread procedures), and
 everything runs in-process in the test binary.
 
+## The VM-vs-native differential batch (#1395)
+
+[`tests/fuzz/native-diff.sh`](../../tests/fuzz/native-diff.sh) diffs Kaappi's
+two evaluation paths against each other: each generated program runs through
+the bytecode VM (`kaappi prog.scm`) and through the LLVM native backend
+(`kaappi compile prog.scm -o prog.bin && ./prog.bin`), comparing stdout and
+exit class. This is the second internal correctness oracle (after
+opt-vs-no-opt) and the setup Midtgaard et al. (ICFP 2017) used to find
+bytecode-vs-native disagreements in OCaml.
+
+```bash
+bash tests/fuzz/native-diff.sh            # 100 programs, seeds 0..99
+bash tests/fuzz/native-diff.sh 300 1200   # 300 programs starting at seed 1200
+```
+
+The script builds anything missing (`zig build`, `zig build lib`,
+`zig build fuzz-gen`), probes that `kaappi compile` can actually link here
+(it finds `zig cc` on PATH; the probe is needed because `kaappi compile`
+reports toolchain failures on stderr but exits 0), then runs the batch. Each
+input is a generate + interpret + compile-and-link + run cycle (~1 s,
+dominated by linking) — orders of magnitude slower than in-process fuzzing,
+which is why this is a scheduled batch and not a `std.testing.fuzz` target.
+The `native-diff` job in `fuzz.yml` runs 300 programs nightly with a seed
+base that rotates per run (printed in the log; any base is replayable
+locally or via `workflow_dispatch` inputs `native-diff-count` /
+`native-diff-base`), and uploads divergences as the
+`native-diff-divergences` artifact.
+
+Programs come from the **native-subset generator**
+([`src/fuzz_gen_native.zig`](../../src/fuzz_gen_native.zig), built as
+`kaappi-fuzz-gen --native` via `zig build fuzz-gen`). The native backend
+falls back to `kaappi_eval` (the interpreter) for forms it cannot compile,
+so an unrestricted program would degrade the diff to VM-vs-VM; the subset
+generator emits only natively-compiled forms and encodes the backend's
+structural rules (function bodies reference only their own parameters and
+primitives, no lambdas inside `let`, computed `set!` values only inside
+lexical scopes, every top-level form void-valued with explicit `(write ...)`
+output — the module doc comment has the full list and the reasons). Two
+unit gates keep this honest: `tests_native.zig` asserts fixed-seed programs
+emit no unexpected `kaappi_eval` calls in the LLVM IR and that every defined
+function gets a native definition, and `tests_fuzz.zig` asserts the programs
+evaluate cleanly.
+
+Comparison rules:
+
+- **Both exit 0** — stdout must match byte-for-byte. The programs print all
+  observables explicitly (`write` of final expressions and of every
+  non-procedure global), because the VM echoes non-void top-level values but
+  native binaries do not, and procedure values print differently by design
+  (`#<procedure name>` vs `#<procedure>`).
+- **Both exit non-zero** — treated as a match without comparing stdout: the
+  VM reports a top-level error and continues with the next form, the native
+  binary exits at the first error, so post-error output legitimately
+  differs.
+- **Exit classes differ, stdout differs, or `kaappi compile` fails to
+  produce a binary** — divergence: the program plus both sides'
+  stdout/stderr land in the results dir and the script exits non-zero.
+- **Either side times out** (needs GNU `timeout`/`gtimeout` on PATH) — the
+  pair is skipped as incomparable.
+
+One caveat when triaging a divergence: argument evaluation order is
+unspecified in R7RS, and generated programs do mutate globals inside
+subexpressions. Both backends currently evaluate left-to-right, so a
+divergence is always an implementation inconsistency worth filing — but the
+fix may be "make the order consistent" rather than "wrong code".
+
 ## Turning a failure into a regression test
 
 Every fuzz finding follows the same three steps — no exceptions:
@@ -161,6 +227,13 @@ Every fuzz finding follows the same three steps — no exceptions:
    change to the generator's decision sequence re-interprets them). A
    differential mismatch reproduces outside the harness as
    `kaappi prog.scm` vs `kaappi --no-ir-opt prog.scm` disagreeing.
+
+   A `native-diff.sh` divergence is the easiest of all: the artifact already
+   IS the program text (`seed-N.scm` plus both sides' output). Reproduce
+   with `kaappi seed-N.scm` vs `kaappi compile seed-N.scm -o b && ./b`, and
+   minimise as ordinary Scheme — but keep the shrunken program inside the
+   native subset (check with the eval-count gate in `tests_native.zig`, or
+   just verify the divergence survives each shrink step).
 
 2. **Add a readable regression test** that fails without the fix and passes
    with it, per the repo's bug-fix rule:

--- a/src/fuzz_gen.zig
+++ b/src/fuzz_gen.zig
@@ -62,7 +62,7 @@ const local_names = [_][]const u8{ "a", "b", "c", "d", "e", "h", "u", "v" };
 /// after evaluation to widen its observable — a wrong fold inside
 /// `(define g1 ...)` is invisible in the program's final value alone.
 pub const global_names = [_][]const u8{ "g0", "g1", "g2" };
-const fn_names = [_][]const u8{ "f0", "f1" };
+pub const fn_names = [_][]const u8{ "f0", "f1" };
 const macro_names = [_][]const u8{ "m0", "m1" };
 const pattern_names = [_][]const u8{ "p", "q", "r" };
 
@@ -340,6 +340,16 @@ pub fn generateSeeded(seed: u64, gpa: Allocator) Error![]u8 {
     return generateWith(&ch, gpa);
 }
 
+/// Native-compilable subset (fuzz_gen_native.zig): programs restricted to
+/// forms the LLVM native backend compiles without interpreter fallback, for
+/// the offline VM-vs-native differential harness (tests/fuzz/native-diff.sh,
+/// issue #1395).
+pub fn generateNativeSeeded(seed: u64, gpa: Allocator) Error![]u8 {
+    var prng = std.Random.DefaultPrng.init(seed);
+    var ch: Chooser = .{ .random = prng.random() };
+    return generateNativeWith(&ch, gpa);
+}
+
 fn generateWith(ch: *Chooser, gpa: Allocator) Error![]u8 {
     var g: Gen = .{
         .ch = ch,
@@ -352,6 +362,21 @@ fn generateWith(ch: *Chooser, gpa: Allocator) Error![]u8 {
         g.aw.deinit();
     }
     try g.genProgram();
+    return g.aw.toOwnedSlice() catch return error.OutOfMemory;
+}
+
+fn generateNativeWith(ch: *Chooser, gpa: Allocator) Error![]u8 {
+    var g: Gen = .{
+        .ch = ch,
+        .aw = .init(gpa),
+        .gpa = gpa,
+    };
+    defer {
+        g.scope.deinit(gpa);
+        g.macros.deinit(gpa);
+        g.aw.deinit();
+    }
+    try @import("fuzz_gen_native.zig").genProgram(&g);
     return g.aw.toOwnedSlice() catch return error.OutOfMemory;
 }
 
@@ -1454,4 +1479,8 @@ test "generation is deterministic per seed" {
     const b = try generateSeeded(42, gpa);
     defer gpa.free(b);
     try std.testing.expectEqualStrings(a, b);
+}
+
+test {
+    _ = @import("fuzz_gen_native.zig");
 }

--- a/src/fuzz_gen_main.zig
+++ b/src/fuzz_gen_main.zig
@@ -48,10 +48,17 @@ pub fn main(init: std.process.Init.Minimal) !void {
     else
         try fuzz_gen.generateSeeded(s, gpa);
 
+    // reporting.writeToFd's loop, except failures are a hard non-zero exit:
+    // the harness redirects stdout to a file, and a silently truncated
+    // program would be diffed as if it were the real seed.
     var off: usize = 0;
     while (off < src.len) {
-        const n = std.posix.system.write(1, src.ptr + off, src.len - off);
-        if (n <= 0) std.process.exit(1);
-        off += @intCast(n);
+        const rc = std.posix.system.write(1, src.ptr + off, src.len - off);
+        if (rc < 0) {
+            if (std.posix.errno(rc) == .INTR) continue;
+            std.process.exit(1);
+        }
+        if (rc == 0) std.process.exit(1);
+        off += @as(usize, @intCast(rc));
     }
 }

--- a/src/fuzz_gen_main.zig
+++ b/src/fuzz_gen_main.zig
@@ -1,0 +1,57 @@
+//! Standalone driver for the fuzz program generators: prints the program
+//! for a given seed to stdout. Used by the offline differential harness
+//! (tests/fuzz/native-diff.sh, issue #1395), which needs reproducible
+//! programs from a shell script. Dev/CI tool only — built with
+//! `zig build fuzz-gen`, never part of the default install or releases.
+
+const std = @import("std");
+const fuzz_gen = @import("fuzz_gen.zig");
+
+fn fail(msg: []const u8) noreturn {
+    _ = std.posix.system.write(2, msg.ptr, msg.len);
+    std.process.exit(2);
+}
+
+fn usage() noreturn {
+    fail("usage: kaappi-fuzz-gen <seed> [--native|--full]\n" ++
+        "  --full    full R7RS grammar (default; fuzz_gen.zig)\n" ++
+        "  --native  native-compilable subset for the VM-vs-native\n" ++
+        "            differential harness (fuzz_gen_native.zig)\n");
+}
+
+pub fn main(init: std.process.Init.Minimal) !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var args = try init.args.iterateAllocator(gpa);
+    defer args.deinit();
+    _ = args.skip(); // argv[0]
+
+    var seed: ?u64 = null;
+    var native = false;
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--native")) {
+            native = true;
+        } else if (std.mem.eql(u8, arg, "--full")) {
+            native = false;
+        } else if (seed == null) {
+            seed = std.fmt.parseInt(u64, arg, 10) catch usage();
+        } else {
+            usage();
+        }
+    }
+    const s = seed orelse usage();
+
+    const src = if (native)
+        try fuzz_gen.generateNativeSeeded(s, gpa)
+    else
+        try fuzz_gen.generateSeeded(s, gpa);
+
+    var off: usize = 0;
+    while (off < src.len) {
+        const n = std.posix.system.write(1, src.ptr + off, src.len - off);
+        if (n <= 0) std.process.exit(1);
+        off += @intCast(n);
+    }
+}

--- a/src/fuzz_gen_native.zig
+++ b/src/fuzz_gen_native.zig
@@ -1,0 +1,840 @@
+//! Native-compilable-subset program generator for the bytecode-VM vs
+//! LLVM-native-backend differential oracle (fuzzing Tier 3, issue #1395).
+//!
+//! The native backend compiles part of the language natively and falls back
+//! to `kaappi_eval` (the interpreter) for the rest, so an unrestricted
+//! generated program would make the differential harness compare the VM
+//! mostly against itself. This generator emits only forms the backend
+//! compiles natively (llvm_emit.zig / llvm_emit_lambda.zig):
+//!
+//! - primitive calls (2-arg `+ - * < = cons car cdr null?` are inline
+//!   fast paths; the rest go through the native `kaappi_call_scheme`
+//!   bridge with its own argument-rooting codegen)
+//! - if / and / or / when / unless / begin, let / let*
+//! - top-level `(define name <literal|lambda>)` and `(define (f ...) body)`
+//!   including dotted (variadic) parameter lists, self-tail-calls
+//!   (compiled as loops), and non-tail self-recursion
+//! - set! (native everywhere, BUT a compound set! value is native only
+//!   inside a lexical scope: at top level emitScopedValue routes compound
+//!   values through kaappi_eval, so top-level set! uses literal values and
+//!   computed mutation happens inside let bodies)
+//!
+//! Structural rules the backend imposes — violating one silently drops the
+//! surrounding form to the interpreter, degrading the oracle to VM-vs-VM:
+//!
+//! - Function/lambda bodies may reference only their own parameters, their
+//!   own name (recursion), and the primitive names in `ir.isKnownGlobal`;
+//!   any other free variable makes tryCompileDefineFunction reject the
+//!   whole function (hasFreeVars). Outer bindings are hidden while a body
+//!   is generated.
+//! - Global defines: a compound non-lambda init expression goes through
+//!   kaappi_eval (emitDefine), so globals are initialized with literals
+//!   and mutated from inside let bodies.
+//! - No lambda expressions inside let forms: emitLet falls back to eval
+//!   when a body lambda captures a let binding (#827), so the generator
+//!   avoids lambdas there entirely. Inline lambdas may capture enclosing
+//!   FUNCTION parameters (native closure upvalues), but only one level —
+//!   an inner lambda referencing an outer-outer parameter would fall back
+//!   to emitLambdaViaEval, which leaks parameters as globals.
+//! - Variadic lambdas compile natively only with at least one fixed
+//!   parameter (`(lambda (a . rest) ...)`) and only in define position.
+//! - Cross-function calls appear only in top-level expressions and let
+//!   bodies: `f0` inside `f1`'s body would be a free variable (see above).
+//!
+//! Output discipline: `kaappi f.scm` echoes every non-void top-level value
+//! to stdout but a native binary echoes nothing, so EVERY top-level form
+//! here is void-valued (define / set! / when / unless / if-with-statement-
+//! arms / begin / let-ending-in-set! / write / newline) and all observable
+//! output is explicit: `(write ...)` of the final expressions plus of every
+//! non-procedure global (procedure values are never written — they print
+//! as `#<procedure name>` in the VM but `#<procedure>` natively, a
+//! representation difference by design, not a bug).
+//!
+//! Shares the Smith/PRNG Chooser, scope tracking, and byte-budget
+//! infrastructure with the full generator (fuzz_gen.zig).
+
+const std = @import("std");
+const gen_mod = @import("fuzz_gen.zig");
+
+const Gen = gen_mod.Gen;
+const Error = gen_mod.Error;
+const Cands = gen_mod.Cands;
+const Binding = gen_mod.Binding;
+
+const max_depth: u32 = 5;
+
+// Primitive vocabulary. Everything here is in ir.isKnownGlobal's primitive
+// list, so calls in function bodies do not count as free variables.
+const arith_ops = [_][]const u8{ "+", "-", "*", "min", "max" };
+const div_ops = [_][]const u8{ "quotient", "remainder", "modulo" };
+const cmp_ops = [_][]const u8{ "<", "<=", "=", ">", ">=" };
+const rec_ops = [_][]const u8{ "+", "*", "max" };
+
+/// Region context threaded through the expression recursion.
+const Ctx = struct {
+    /// >0 while inside a natively compiled function/lambda body. Governs
+    /// what an inline lambda may capture: at depth 0 its body must be
+    /// closed (pure native closure tier); deeper, it may reference the
+    /// enclosing function's int parameters (upvalue tier).
+    fn_depth: u8 = 0,
+    /// True inside let forms and inline-lambda bodies, where emitting a
+    /// further lambda would push the enclosing form off the native path
+    /// (#827 capture check; single-level upvalue capture).
+    no_lambda: bool = false,
+    /// True inside inline-lambda bodies: the capturing closure tier rejects
+    /// bodies containing set! ANYWHERE — even of a let-local — via the
+    /// blanket syntactic scan sexprContainsSetOrDefine (#819), so a set!
+    /// there would drop the lambda to emitLambdaViaEval. (Define-position
+    /// lambdas go through tryCompileDefineFunction, whose free-var check
+    /// does not descend into let forms, so set! inside their lets is fine.)
+    no_set: bool = false,
+};
+
+/// Shapes a let-bound value can take in native mode. Local mirror of the
+/// relevant fuzz_gen Kind cases so binding registration can be deferred
+/// (plain `let` inits must not see one another).
+const LetKind = union(enum) { int, list: u16, vec: u16 };
+
+pub fn genProgram(g: *Gen) Error!void {
+    var ctx: Ctx = .{};
+    const nglobals = g.ch.range(.count, 0, gen_mod.global_names.len);
+    for (0..nglobals) |_| try genGlobalDefine(g, &ctx);
+    const nfns = g.ch.range(.count, 0, gen_mod.fn_names.len);
+    for (0..nfns) |_| try genFnDefine(g, &ctx);
+
+    // Statements mutate globals (directly with literal values, or with
+    // computed values from inside let scopes). Only meaningful when a
+    // settable global exists.
+    if (g.hasVar(gen_mod.bindIsSettableAtom)) {
+        const nstmts = g.ch.range(.count, 0, 2);
+        for (0..nstmts) |_| {
+            try genStmt(g, &ctx, g.ch.range(.depth_pick, 1, 3), false);
+            try g.emit("\n");
+        }
+    }
+
+    const nwrites = g.ch.range(.count, 1, 3);
+    for (0..nwrites) |_| {
+        try g.emit("(write ");
+        const depth = g.ch.range(.depth_pick, 2, max_depth);
+        if (g.ch.chance(.coin, 1, 5)) {
+            try genBool(g, &ctx, depth);
+        } else {
+            try genInt(g, &ctx, depth);
+        }
+        try g.emit(")\n(newline)\n");
+    }
+
+    // Echo every non-procedure global so a wrong value stored by a set!
+    // statement is observable even when no write expression touched it
+    // (mirrors the widened observable of the opt-vs-no-opt oracle). Only
+    // top-level bindings remain in scope here.
+    for (g.scope.items) |b| {
+        if (b.kind != .int and b.kind != .boolean) continue;
+        try g.emitf("(write {s})\n(newline)\n", .{b.name});
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level definitions
+// ---------------------------------------------------------------------------
+
+fn genGlobalDefine(g: *Gen, ctx: *Ctx) Error!void {
+    const name = gen_mod.global_names[g.global_count];
+    g.global_count += 1;
+    const GKind = enum { int_lit, bool_lit, lambda };
+    var c: Cands(GKind) = .{};
+    c.add(.int_lit, 5);
+    c.add(.bool_lit, 2);
+    c.add(.lambda, 3);
+    switch (c.pick(g.ch)) {
+        .int_lit => {
+            try g.emitf("(define {s} {d})\n", .{ name, litInt(g) });
+            try g.pushBinding(name, .int);
+        },
+        .bool_lit => {
+            try g.emitf("(define {s} {s})\n", .{ name, boolLit(g) });
+            try g.pushBinding(name, .boolean);
+        },
+        .lambda => {
+            const variadic = g.ch.chance(.coin, 1, 4);
+            const arity: u8 = @intCast(g.ch.range(.arity, if (variadic) 1 else 0, 3));
+            try g.emitf("(define {s} ", .{name});
+            try genLambda(g, ctx, arity, variadic);
+            try g.emit(")\n");
+            try g.pushBinding(name, .{ .proc = .{ .arity = arity, .variadic = variadic } });
+        },
+    }
+}
+
+/// `(lambda (p... [. rest]) <int body>)` in define position, body generated
+/// under a hidden outer scope (only its own parameters are referenceable).
+fn genLambda(g: *Gen, ctx: *Ctx, arity: u8, variadic: bool) Error!void {
+    var nb: [4][]const u8 = undefined;
+    const params = g.pickNames(arity, &nb);
+    try g.emit("(lambda (");
+    var saved = try enterBody(g, false);
+    defer leaveBody(g, &saved);
+    for (params, 0..) |p, i| {
+        if (i > 0) try g.emit(" ");
+        try g.emit(p);
+        try g.pushBinding(p, .int);
+    }
+    if (variadic) {
+        try g.emit(" . rest");
+        try g.pushBinding("rest", .{ .list = .{ .len = .unknown, .mut = .all, .ints = true } });
+    }
+    try g.emit(") ");
+    var body_ctx: Ctx = .{ .fn_depth = ctx.fn_depth + 1 };
+    try genFnBody(g, &body_ctx, variadic, g.ch.range(.depth_pick, 2, 4));
+    try g.emit(")");
+}
+
+/// Function/lambda body: an int expression, with an optional null?-guarded
+/// use of the rest list when variadic (rest has no static length, so access
+/// must be guarded — and this exercises the native rest-list builder loop).
+fn genFnBody(g: *Gen, ctx: *Ctx, variadic: bool, depth: u32) Error!void {
+    if (variadic and g.ch.chance(.coin, 1, 2)) {
+        try g.emit("(if (null? rest) ");
+        try genInt(g, ctx, depth -| 1);
+        try g.emit(" (+ (car rest) ");
+        try genInt(g, ctx, depth -| 1);
+        try g.emit("))");
+    } else {
+        try genInt(g, ctx, depth);
+    }
+}
+
+fn genFnDefine(g: *Gen, ctx: *Ctx) Error!void {
+    _ = ctx;
+    const name = gen_mod.fn_names[g.fn_count];
+    g.fn_count += 1;
+    var nb: [4][]const u8 = undefined;
+    switch (g.ch.range(.shape, 0, 2)) {
+        0 => { // plain function, optionally variadic
+            const variadic = g.ch.chance(.coin, 1, 4);
+            const arity: u8 = @intCast(g.ch.range(.arity, if (variadic) 1 else 0, 3));
+            const params = g.pickNames(arity, &nb);
+            try g.emitf("(define ({s}", .{name});
+            var saved = try enterBody(g, false);
+            for (params) |p| {
+                try g.emitf(" {s}", .{p});
+                try g.pushBinding(p, .int);
+            }
+            if (variadic) {
+                try g.emit(" . rest");
+                try g.pushBinding("rest", .{ .list = .{ .len = .unknown, .mut = .all, .ints = true } });
+            }
+            try g.emit(") ");
+            var body_ctx: Ctx = .{ .fn_depth = 1 };
+            try genFnBody(g, &body_ctx, variadic, 3);
+            try g.emit(")\n");
+            leaveBody(g, &saved);
+            try g.pushBinding(name, .{ .proc = .{ .arity = arity, .variadic = variadic } });
+        },
+        1 => { // self-tail-recursive countdown: compiled as a native loop
+            const params = g.pickNames(2, &nb);
+            try g.emitf("(define ({s} {s} {s}) (if (<= {s} 0) {s} ({s} (- {s} 1) (modulo ", .{
+                name, params[0], params[1], params[0], params[1], name, params[0],
+            });
+            var saved = try enterBody(g, false);
+            try g.pushBinding(params[0], .int);
+            try g.pushBinding(params[1], .int);
+            var body_ctx: Ctx = .{ .fn_depth = 1 };
+            try genInt(g, &body_ctx, 3);
+            leaveBody(g, &saved);
+            try g.emitf(" {d}))))\n", .{gen_mod.acc_modulus});
+            try g.pushBinding(name, .{ .proc = .{ .arity = 2, .bounded_first = true } });
+        },
+        else => { // non-tail self-recursion: native call-stack frames
+            const params = g.pickNames(1, &nb);
+            const op = rec_ops[g.ch.index(.op_pick, rec_ops.len)];
+            try g.emitf("(define ({s} {s}) (if (<= {s} 0) ", .{ name, params[0], params[0] });
+            var saved = try enterBody(g, false);
+            try g.pushBinding(params[0], .int);
+            var body_ctx: Ctx = .{ .fn_depth = 1 };
+            try genInt(g, &body_ctx, 2);
+            try g.emitf(" ({s} ", .{op});
+            try genInt(g, &body_ctx, 2);
+            leaveBody(g, &saved);
+            try g.emitf(" ({s} (- {s} 1)))))\n", .{ name, params[0] });
+            try g.pushBinding(name, .{ .proc = .{ .arity = 1, .bounded_first = true } });
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scope hiding for function/lambda bodies
+// ---------------------------------------------------------------------------
+
+/// Swap in a fresh scope for a function/lambda body. With `keep_ints`, int
+/// bindings stay visible (an inline lambda inside a function body may
+/// capture that function's int parameters as native closure upvalues; its
+/// list-typed rest parameter must NOT leak in — the upvalue tier only
+/// accepts fixed parameters, and a rest reference would fall back to
+/// emitLambdaViaEval where `rest` is unbound).
+fn enterBody(g: *Gen, keep_ints: bool) Error!std.ArrayList(Binding) {
+    const saved = g.scope;
+    g.scope = .empty;
+    if (keep_ints) {
+        for (saved.items) |b| {
+            if (b.kind == .int) g.scope.append(g.gpa, b) catch return error.OutOfMemory;
+        }
+    }
+    return saved;
+}
+
+fn leaveBody(g: *Gen, saved: *std.ArrayList(Binding)) void {
+    g.scope.deinit(g.gpa);
+    g.scope = saved.*;
+}
+
+// ---------------------------------------------------------------------------
+// Integer expressions
+// ---------------------------------------------------------------------------
+
+fn litInt(g: *Gen) i64 {
+    return @as(i64, g.ch.range(.lit_pick, 0, 200)) - 100;
+}
+
+fn boolLit(g: *Gen) []const u8 {
+    return if (g.ch.chance(.coin, 1, 2)) "#t" else "#f";
+}
+
+const IntOp = enum {
+    lit,
+    ref,
+    arith,
+    abs_op,
+    divmod,
+    if_form,
+    and_or,
+    let_form,
+    begin_form,
+    call_proc,
+    inline_call,
+    car_op,
+    cadr_op,
+    list_len,
+    list_ref_op,
+    vec_ref,
+};
+
+fn genInt(g: *Gen, ctx: *Ctx, depth_in: u32) Error!void {
+    const depth = g.cap(depth_in);
+    var c: Cands(IntOp) = .{};
+    c.add(.lit, 5);
+    if (g.hasVar(gen_mod.bindIsInt)) c.add(.ref, 6);
+    if (depth > 0) {
+        c.add(.arith, 8);
+        c.add(.abs_op, 1);
+        c.add(.divmod, 3);
+        c.add(.if_form, 5);
+        c.add(.and_or, 2);
+        c.add(.let_form, 6);
+        c.add(.begin_form, 2);
+        if (g.hasVar(gen_mod.bindIsProc)) c.add(.call_proc, 6);
+        if (!ctx.no_lambda) c.add(.inline_call, 3);
+        if (g.hasVar(gen_mod.bindIsListIntsExactNonEmpty)) {
+            c.add(.car_op, 2);
+            c.add(.list_len, 1);
+            c.add(.list_ref_op, 2);
+        }
+        if (g.cdrVarAvail(.{ .ints = true, .non_empty = true })) c.add(.cadr_op, 1);
+        if (g.hasVar(gen_mod.bindIsIntVec)) c.add(.vec_ref, 3);
+    }
+    const d = depth -| 1;
+    switch (c.pick(g.ch)) {
+        .lit => try g.emitf("{d}", .{litInt(g)}),
+        .ref => try g.emit(g.pickVar(gen_mod.bindIsInt).?.name),
+        .arith => {
+            const op = arith_ops[g.ch.index(.op_pick, arith_ops.len)];
+            const nargs = g.ch.range(.nargs, 2, 3);
+            try g.emitf("({s}", .{op});
+            for (0..nargs) |_| {
+                try g.emit(" ");
+                try genInt(g, ctx, d);
+            }
+            try g.emit(")");
+        },
+        .abs_op => {
+            try g.emit("(abs ");
+            try genInt(g, ctx, d);
+            try g.emit(")");
+        },
+        .divmod => {
+            const op = div_ops[g.ch.index(.op_pick, div_ops.len)];
+            var divisor: i32 = @intCast(g.ch.range(.lit_pick, 1, 12));
+            if (g.ch.chance(.coin, 1, 4)) divisor = -divisor;
+            try g.emitf("({s} ", .{op});
+            try genInt(g, ctx, d);
+            try g.emitf(" {d})", .{divisor});
+        },
+        .if_form => {
+            try g.emit("(if ");
+            try genTest(g, ctx, d);
+            try g.emit(" ");
+            try genInt(g, ctx, d);
+            try g.emit(" ");
+            try genInt(g, ctx, d);
+            try g.emit(")");
+        },
+        .and_or => {
+            // All-integer arguments (never #f): both forms yield an integer
+            // while exercising the native short-circuit emission.
+            try g.emit(if (g.ch.chance(.coin, 1, 2)) "(and" else "(or");
+            const nargs = g.ch.range(.nargs, 2, 3);
+            for (0..nargs) |_| {
+                try g.emit(" ");
+                try genInt(g, ctx, d);
+            }
+            try g.emit(")");
+        },
+        .let_form => try genLetInt(g, ctx, d),
+        .begin_form => {
+            try g.emit("(begin ");
+            try genInt(g, ctx, d);
+            try g.emit(" ");
+            try genInt(g, ctx, d);
+            try g.emit(")");
+        },
+        .call_proc => {
+            const b = g.pickVar(gen_mod.bindIsProc).?;
+            const info = b.kind.proc;
+            var nargs: u32 = info.arity;
+            if (info.variadic) nargs += g.ch.range(.nargs, 0, 2);
+            try g.emitf("({s}", .{b.name});
+            for (0..nargs) |i| {
+                try g.emit(" ");
+                if (i == 0 and info.bounded_first) {
+                    try g.emitf("{d}", .{g.ch.range(.iters, 0, 12)});
+                } else {
+                    try genInt(g, ctx, d);
+                }
+            }
+            try g.emit(")");
+        },
+        .inline_call => {
+            const arity = g.ch.range(.arity, 0, 2);
+            var nb: [4][]const u8 = undefined;
+            const params = g.pickNames(arity, &nb);
+            try g.emit("((lambda (");
+            // At top level the body must be closed over its own params (pure
+            // tier); inside a function body it may also capture that
+            // function's int parameters (upvalue tier) — one level only.
+            var saved = try enterBody(g, ctx.fn_depth > 0);
+            for (params, 0..) |p, i| {
+                if (i > 0) try g.emit(" ");
+                try g.emit(p);
+                try g.pushBinding(p, .int);
+            }
+            try g.emit(") ");
+            var body_ctx: Ctx = .{ .fn_depth = ctx.fn_depth + 1, .no_lambda = true, .no_set = true };
+            try genInt(g, &body_ctx, d);
+            try g.emit(")");
+            leaveBody(g, &saved);
+            for (0..arity) |_| {
+                try g.emit(" ");
+                try genInt(g, ctx, d);
+            }
+            try g.emit(")");
+        },
+        .car_op => {
+            const b = g.pickVar(gen_mod.bindIsListIntsExactNonEmpty).?;
+            try g.emitf("(car {s})", .{b.name});
+        },
+        .cadr_op => {
+            const b = g.pickCdrVar(.{ .ints = true, .non_empty = true }).?;
+            try g.emitf("(car (cdr {s}))", .{b.name});
+        },
+        .list_len => {
+            const b = g.pickVar(gen_mod.bindIsListIntsExactNonEmpty).?;
+            try g.emitf("(length {s})", .{b.name});
+        },
+        .list_ref_op => {
+            const b = g.pickVar(gen_mod.bindIsListIntsExactNonEmpty).?;
+            const len = b.kind.list.len.exactLen().?;
+            try g.emitf("(list-ref {s} {d})", .{ b.name, g.ch.range(.idx_pick, 0, len - 1) });
+        },
+        .vec_ref => {
+            const b = g.pickVar(gen_mod.bindIsIntVec).?;
+            try g.emitf("(vector-ref {s} ", .{b.name});
+            try genIndex(g, ctx, d, b.kind.vector.len);
+            try g.emit(")");
+        },
+    }
+}
+
+/// In-range vector index: literal below `len` or `(modulo <int> len)`
+/// (modulo is never negative for a positive modulus).
+fn genIndex(g: *Gen, ctx: *Ctx, d: u32, len: u16) Error!void {
+    if (g.ch.chance(.idx_kind, 2, 3)) {
+        try g.emitf("{d}", .{g.ch.range(.idx_pick, 0, len - 1)});
+    } else {
+        try g.emit("(modulo ");
+        try genInt(g, ctx, @min(d, 1));
+        try g.emitf(" {d})", .{len});
+    }
+}
+
+fn genLetInt(g: *Gen, ctx: *Ctx, d: u32) Error!void {
+    const star = g.ch.chance(.coin, 1, 2);
+    const n = g.ch.range(.count, 1, 3);
+    var nb: [4][]const u8 = undefined;
+    const names = g.pickNames(n, &nb);
+    try g.emit(if (star) "(let* (" else "(let (");
+    const mark = g.scope.items.len;
+    var let_ctx: Ctx = .{ .fn_depth = ctx.fn_depth, .no_lambda = true, .no_set = ctx.no_set };
+    var stash: [3]LetKind = undefined;
+    for (0..n) |i| {
+        try g.emitf("({s} ", .{names[i]});
+        const lk = try genLetInit(g, &let_ctx, d);
+        try g.emit(") ");
+        // let: inits are evaluated in the outer scope, so bindings become
+        // visible only after all of them; let*: immediately.
+        stash[i] = lk;
+        if (star) try pushLetBinding(g, names[i], lk);
+    }
+    if (!star) for (0..n) |i| try pushLetBinding(g, names[i], stash[i]);
+    try g.emit(") ");
+    if (g.ch.chance(.coin, 1, 2)) {
+        try genStmt(g, &let_ctx, d, true);
+        try g.emit(" ");
+    }
+    try genInt(g, &let_ctx, d);
+    try g.emit(")");
+    g.scope.shrinkRetainingCapacity(mark);
+}
+
+/// A let-binding initializer. Lists and vectors live only as let locals in
+/// native mode: their construction is native here (cons is an inline
+/// primitive; list/vector/make-vector go through kaappi_call_scheme),
+/// whereas a compound global define init would route through kaappi_eval.
+fn genLetInit(g: *Gen, ctx: *Ctx, d: u32) Error!LetKind {
+    const K = enum { int, list, vec };
+    var c: Cands(K) = .{};
+    c.add(.int, 6);
+    if (d > 0) {
+        c.add(.list, 2);
+        c.add(.vec, 2);
+    }
+    switch (c.pick(g.ch)) {
+        .int => {
+            try genInt(g, ctx, d);
+            return .int;
+        },
+        .list => {
+            const len: u16 = @intCast(g.ch.range(.len_pick, 0, 4));
+            if (g.ch.chance(.coin, 1, 2)) {
+                try g.emit("(list");
+                for (0..len) |_| {
+                    try g.emit(" ");
+                    try genInt(g, ctx, d -| 1);
+                }
+                try g.emit(")");
+            } else {
+                for (0..len) |_| {
+                    try g.emit("(cons ");
+                    try genInt(g, ctx, d -| 1);
+                    try g.emit(" ");
+                }
+                try g.emit("'()");
+                for (0..len) |_| try g.emit(")");
+            }
+            return .{ .list = len };
+        },
+        .vec => {
+            const len: u16 = @intCast(g.ch.range(.len_pick, 1, 5));
+            if (g.ch.chance(.coin, 1, 2)) {
+                try g.emit("(vector");
+                for (0..len) |_| {
+                    try g.emit(" ");
+                    try genInt(g, ctx, d -| 1);
+                }
+                try g.emit(")");
+            } else {
+                try g.emitf("(make-vector {d} ", .{len});
+                try genInt(g, ctx, d -| 1);
+                try g.emit(")");
+            }
+            return .{ .vec = len };
+        },
+    }
+}
+
+fn pushLetBinding(g: *Gen, name: []const u8, lk: LetKind) Error!void {
+    switch (lk) {
+        .int => try g.pushBinding(name, .int),
+        .list => |len| try g.pushBinding(name, .{ .list = .{ .len = .{ .exact = len }, .mut = .all, .ints = true } }),
+        .vec => |len| try g.pushBinding(name, .{ .vector = .{ .len = len, .boxed = false } }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Booleans and tests
+// ---------------------------------------------------------------------------
+
+const BoolOp = enum { lit, ref, not_op, andor, cmp, zero_p, evenodd, null_p, pair_p };
+
+fn genBool(g: *Gen, ctx: *Ctx, depth_in: u32) Error!void {
+    const depth = g.cap(depth_in);
+    var c: Cands(BoolOp) = .{};
+    c.add(.lit, 3);
+    if (g.hasVar(gen_mod.bindIsBool)) c.add(.ref, 4);
+    if (depth > 0) {
+        c.add(.not_op, 2);
+        c.add(.andor, 3);
+        c.add(.cmp, 7);
+        c.add(.zero_p, 2);
+        c.add(.evenodd, 2);
+        if (g.listVarAvail(.{})) {
+            c.add(.null_p, 2);
+            c.add(.pair_p, 1);
+        }
+    }
+    const d = depth -| 1;
+    switch (c.pick(g.ch)) {
+        .lit => try g.emit(boolLit(g)),
+        .ref => try g.emit(g.pickVar(gen_mod.bindIsBool).?.name),
+        .not_op => {
+            try g.emit("(not ");
+            try genTest(g, ctx, d);
+            try g.emit(")");
+        },
+        .andor => {
+            try g.emit(if (g.ch.chance(.coin, 1, 2)) "(and " else "(or ");
+            try genBool(g, ctx, d);
+            try g.emit(" ");
+            try genBool(g, ctx, d);
+            try g.emit(")");
+        },
+        .cmp => {
+            const op = cmp_ops[g.ch.index(.op_pick, cmp_ops.len)];
+            try g.emitf("({s} ", .{op});
+            try genInt(g, ctx, d);
+            try g.emit(" ");
+            try genInt(g, ctx, d);
+            try g.emit(")");
+        },
+        .zero_p => {
+            try g.emit("(zero? ");
+            try genInt(g, ctx, d);
+            try g.emit(")");
+        },
+        .evenodd => {
+            try g.emit(if (g.ch.chance(.coin, 1, 2)) "(even? " else "(odd? ");
+            try genInt(g, ctx, d);
+            try g.emit(")");
+        },
+        .null_p => try g.emitf("(null? {s})", .{g.pickListVar(.{}).?.name}),
+        .pair_p => try g.emitf("(pair? {s})", .{g.pickListVar(.{}).?.name}),
+    }
+}
+
+/// Test position: only #f is false, so always-truthy int tests are
+/// deliberate dead-branch fodder for the native if/and/or emission.
+fn genTest(g: *Gen, ctx: *Ctx, d: u32) Error!void {
+    if (g.ch.chance(.coin, 3, 5)) return genBool(g, ctx, d);
+    try genInt(g, ctx, d);
+}
+
+// ---------------------------------------------------------------------------
+// Statements — every statement is void-valued (see output discipline above)
+// ---------------------------------------------------------------------------
+
+const StmtOp = enum { noop, set_lit, set_expr, vec_set, let_stmt, when_form, if_stmt, begin2 };
+
+fn genStmt(g: *Gen, ctx: *Ctx, depth_in: u32, in_scope: bool) Error!void {
+    const depth = g.cap(depth_in);
+    var c: Cands(StmtOp) = .{};
+    // Always available: keeps the candidate list non-empty at depth 0 when
+    // nothing is settable in scope.
+    c.add(.noop, 1);
+    // set! with a literal value compiles natively even at top level; a
+    // compound value does so only inside a lexical scope (emitScopedValue).
+    if (!ctx.no_set and g.hasVar(gen_mod.bindIsSettableAtom)) c.add(.set_lit, 3);
+    if (!ctx.no_set and in_scope and g.hasVar(gen_mod.bindIsSettableInt)) c.add(.set_expr, 6);
+    if (in_scope and g.hasVar(gen_mod.bindIsIntVec)) c.add(.vec_set, 5);
+    if (depth > 0) {
+        if (!in_scope) c.add(.let_stmt, 5);
+        c.add(.when_form, 3);
+        c.add(.if_stmt, 2);
+        c.add(.begin2, 2);
+    }
+    const d = depth -| 1;
+    switch (c.pick(g.ch)) {
+        .noop => try g.emit("(when #f 0)"),
+        .set_lit => {
+            const b = g.pickVar(gen_mod.bindIsSettableAtom).?;
+            if (b.kind == .boolean) {
+                try g.emitf("(set! {s} {s})", .{ b.name, boolLit(g) });
+            } else {
+                try g.emitf("(set! {s} {d})", .{ b.name, litInt(g) });
+            }
+        },
+        .set_expr => {
+            const b = g.pickVar(gen_mod.bindIsSettableInt).?;
+            try g.emitf("(set! {s} ", .{b.name});
+            try genInt(g, ctx, d);
+            try g.emit(")");
+        },
+        .vec_set => {
+            const b = g.pickVar(gen_mod.bindIsIntVec).?;
+            try g.emitf("(vector-set! {s} ", .{b.name});
+            try genIndex(g, ctx, d, b.kind.vector.len);
+            try g.emit(" ");
+            try genInt(g, ctx, d);
+            try g.emit(")");
+        },
+        .let_stmt => {
+            // (let (bindings) stmt+): ends in a statement, so the let's own
+            // value stays void (no top-level echo) while set!/vector-set!
+            // get a lexical scope where compound values compile natively.
+            const n = g.ch.range(.count, 1, 2);
+            var nb: [4][]const u8 = undefined;
+            const names = g.pickNames(n, &nb);
+            try g.emit("(let (");
+            const mark = g.scope.items.len;
+            var let_ctx: Ctx = .{ .fn_depth = ctx.fn_depth, .no_lambda = true, .no_set = ctx.no_set };
+            var stash: [3]LetKind = undefined;
+            for (0..n) |i| {
+                try g.emitf("({s} ", .{names[i]});
+                stash[i] = try genLetInit(g, &let_ctx, d);
+                try g.emit(") ");
+            }
+            for (0..n) |i| try pushLetBinding(g, names[i], stash[i]);
+            try g.emit(") ");
+            const nstmts = g.ch.range(.count, 1, 2);
+            for (0..nstmts) |i| {
+                if (i > 0) try g.emit(" ");
+                try genStmt(g, &let_ctx, d, true);
+            }
+            try g.emit(")");
+            g.scope.shrinkRetainingCapacity(mark);
+        },
+        .when_form => {
+            try g.emit(if (g.ch.chance(.coin, 2, 3)) "(when " else "(unless ");
+            try genTest(g, ctx, d);
+            try g.emit(" ");
+            try genStmt(g, ctx, d, in_scope);
+            try g.emit(")");
+        },
+        .if_stmt => {
+            try g.emit("(if ");
+            try genTest(g, ctx, d);
+            try g.emit(" ");
+            try genStmt(g, ctx, d, in_scope);
+            try g.emit(" ");
+            try genStmt(g, ctx, d, in_scope);
+            try g.emit(")");
+        },
+        .begin2 => {
+            try g.emit("(begin ");
+            try genStmt(g, ctx, d, in_scope);
+            try g.emit(" ");
+            try genStmt(g, ctx, d, in_scope);
+            try g.emit(")");
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Forms/procedures whose presence would mean the program left the
+/// native-compilable subset (each would compile to a kaappi_eval fallback).
+const forbidden_fragments = [_][]const u8{
+    "(cond",          "(case",
+    "(do ",           "(letrec",
+    "(guard",         "(raise",
+    "(delay",         "(force",
+    "call/cc",        "call-with",
+    "dynamic-wind",   "(map",
+    "(apply",         "(fold",
+    "(for-each",      "quasiquote",
+    "`",              "define-syntax",
+    "(string",        "(char",
+    "bytevector",     "(let lp",
+    "(lambda rest",   "(quote",
+    "(values",        "(let-values",
+    "(define-values",
+};
+
+/// Top-level forms must all be void-valued; these are the only heads the
+/// generator may emit at line start (one top-level form per line).
+const allowed_top_prefixes = [_][]const u8{
+    "(define ", "(set! ", "(when ",  "(unless ", "(if ",
+    "(begin ",  "(let (", "(let* (", "(write ",  "(newline)",
+};
+
+fn assertNativeSubset(src: []const u8) !void {
+    for (forbidden_fragments) |f| {
+        try std.testing.expect(std.mem.indexOf(u8, src, f) == null);
+    }
+    // The only quote character allowed is the empty-list literal '() —
+    // any other quoted datum would be a pointer constant that emitConstant
+    // routes through kaappi_eval.
+    var i: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, src, i, '\'')) |pos| {
+        try std.testing.expect(pos + 2 < src.len);
+        try std.testing.expect(src[pos + 1] == '(' and src[pos + 2] == ')');
+        i = pos + 1;
+    }
+    var lines = std.mem.splitScalar(u8, src, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        var ok = false;
+        for (allowed_top_prefixes) |p| {
+            if (std.mem.startsWith(u8, line, p)) {
+                ok = true;
+                break;
+            }
+        }
+        try std.testing.expect(ok);
+    }
+}
+
+test "native-mode fixed-seed programs parse, compile, stay bounded and in subset" {
+    const memory = @import("memory.zig");
+    const reader_mod = @import("reader.zig");
+    const compiler_mod = @import("compiler.zig");
+    const types = @import("types.zig");
+    const gpa = std.testing.allocator;
+
+    var seed: u64 = 0;
+    while (seed < 2000) : (seed += 1) {
+        const src = try gen_mod.generateNativeSeeded(seed, gpa);
+        defer gpa.free(src);
+        errdefer std.debug.print("seed {d} program:\n{s}\n", .{ seed, src });
+        try std.testing.expect(src.len < gen_mod.expected_max_bytes);
+        try assertNativeSubset(src);
+
+        var gc = memory.GC.init(gpa);
+        defer gc.deinit();
+        // No VM marks compile-time temporaries as roots here; suppress
+        // collection (bounded allocation per seed) as the full-mode test does.
+        gc.no_collect += 1;
+        var macros = std.StringHashMap(types.Value).init(gpa);
+        defer macros.deinit();
+        var globals = std.StringHashMap(types.Value).init(gpa);
+        defer globals.deinit();
+        var r = reader_mod.Reader.init(&gc, src);
+        defer r.deinit();
+        while (try r.hasMore()) {
+            var expr = try r.readDatum();
+            gc.pushRoot(&expr);
+            defer gc.popRoot();
+            _ = try compiler_mod.compileExpressionWithMacros(&gc, expr, &macros, &globals);
+        }
+    }
+}
+
+test "native-mode generation is deterministic per seed" {
+    const gpa = std.testing.allocator;
+    const a = try gen_mod.generateNativeSeeded(97, gpa);
+    defer gpa.free(a);
+    const b = try gen_mod.generateNativeSeeded(97, gpa);
+    defer gpa.free(b);
+    try std.testing.expectEqualStrings(a, b);
+}

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -498,6 +498,33 @@ test "grammar generator: majority of programs evaluate without error" {
     try std.testing.expect(ok * 100 >= total * 75);
 }
 
+// The native-subset generator (fuzz_gen_native.zig, #1395) is even more
+// conservative than the full grammar: no raise/guard, no loops beyond the
+// bounded recursion skeletons, everything in-bounds by construction — so
+// its programs should evaluate cleanly essentially always. The offline
+// VM-vs-native harness (tests/fuzz/native-diff.sh) skips nothing on clean
+// programs, so a drop here directly costs oracle coverage.
+test "native-subset generator: programs evaluate without error" {
+    if (@import("build_options").gc_stress) return error.SkipZigTest;
+    var ok: u32 = 0;
+    var total: u32 = 0;
+    var seed_n: u64 = 0;
+    while (seed_n < 60) : (seed_n += 1) {
+        const src = try fuzz_gen.generateNativeSeeded(seed_n, std.testing.allocator);
+        defer std.testing.allocator.free(src);
+        errdefer std.debug.print("seed {d} program:\n{s}\n", .{ seed_n, src });
+        switch (evalOneOutcome(src)) {
+            .ok => ok += 1,
+            .scheme_error => {},
+            .harness_unavailable => return error.SkipZigTest,
+        }
+        total += 1;
+    }
+    // Measured rate is 100% over the first 300 seeds; the threshold leaves
+    // room only for deadline jitter on a loaded CI machine.
+    try std.testing.expect(ok * 100 >= total * 90);
+}
+
 // ---------------------------------------------------------------------------
 // Differential oracle: optimized vs unoptimized evaluation (Tier 3, #1394)
 //

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -459,3 +459,75 @@ test "NativeClosure arity mismatch raises a catchable error" {
     const result = try ctx.vm.eval("(guard (e (#t 99)) (nc-double 1 2))");
     try std.testing.expectEqual(@as(i64, 99), types.toFixnum(result));
 }
+
+// -- Native-subset generator stays on the native path (#1395) --
+
+// The VM-vs-native differential oracle (tests/fuzz/native-diff.sh) is only
+// as strong as the generated programs' nativeness: every form that falls
+// back to the interpreter shrinks the diff to VM-vs-VM. This gate emits
+// fixed-seed native-subset programs through the LLVM emitter and counts
+// `kaappi_eval` calls in the IR. Defining a function/lambda legitimately
+// emits exactly ONE eval (emitDefine/emitPassthrough create the global
+// binding via the interpreter; call sites still use the direct native
+// path), so the expected count is the number of function/lambda defines
+// and anything above that means a generated form silently fell back.
+test "native-subset generator emits no unexpected kaappi_eval fallbacks" {
+    const fuzz_gen = @import("fuzz_gen.zig");
+    const gpa = std.testing.allocator;
+
+    var seed: u64 = 0;
+    while (seed < 200) : (seed += 1) {
+        const src = try fuzz_gen.generateNativeSeeded(seed, gpa);
+        defer gpa.free(src);
+        errdefer std.debug.print("seed {d} program:\n{s}\n", .{ seed, src });
+
+        // One eval expected per function define and per lambda-valued
+        // global define. The generator emits one top-level form per line.
+        var expected: usize = 0;
+        var names: [8][]const u8 = undefined;
+        var name_count: usize = 0;
+        var lines = std.mem.splitScalar(u8, src, '\n');
+        while (lines.next()) |line| {
+            var name: ?[]const u8 = null;
+            if (std.mem.startsWith(u8, line, "(define (")) {
+                const rest = line["(define (".len..];
+                const end = std.mem.indexOfAny(u8, rest, " )") orelse rest.len;
+                name = rest[0..end];
+            } else if (std.mem.startsWith(u8, line, "(define ") and
+                std.mem.indexOf(u8, line, "(lambda ") != null)
+            {
+                const rest = line["(define ".len..];
+                const end = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
+                name = rest[0..end];
+            }
+            if (name) |n| {
+                expected += 1;
+                names[name_count] = n;
+                name_count += 1;
+            }
+        }
+
+        var res = try emitMultiResult(src);
+        defer res.deinit();
+        const ll = res.toSlice();
+        const actual = std.mem.count(u8, ll, "call i64 @kaappi_eval(");
+        if (actual != expected) {
+            std.debug.print("seed {d}: expected {d} kaappi_eval calls, found {d}\n", .{ seed, expected, actual });
+            return error.NativeSubsetFellBackToEval;
+        }
+
+        // The eval count alone cannot see a function whose native
+        // compilation was REJECTED (the define-time eval is emitted either
+        // way and call sites just degrade to global lookups), so also
+        // require the named native function definition that the emitter
+        // tags with a `; <name>` header comment.
+        for (names[0..name_count]) |n| {
+            var needle_buf: [64]u8 = undefined;
+            const needle = try std.fmt.bufPrint(&needle_buf, "; {s}\ndefine i64 @lambda_", .{n});
+            if (std.mem.indexOf(u8, ll, needle) == null) {
+                std.debug.print("seed {d}: no native definition for {s}\n", .{ seed, n });
+                return error.NativeSubsetFellBackToEval;
+            }
+        }
+    }
+}

--- a/tests/fuzz/native-diff.sh
+++ b/tests/fuzz/native-diff.sh
@@ -17,13 +17,18 @@
 #   RESULTS_DIR  where divergences are written (default: ./native-diff-results)
 #
 # Comparison rules (rationale in docs/dev/fuzzing.md):
-#   both exit 0          -> stdout must match byte-for-byte
-#   both exit non-zero   -> error classes match; stdout is NOT compared (the
-#                           VM reports a top-level error and continues, the
-#                           native binary exits at the first error, so
-#                           post-error output legitimately differs)
-#   exit classes differ  -> divergence
-#   either side timed out-> pair skipped (incomparable)
+#   both exit 0             -> stdout must match byte-for-byte
+#   both exit 1..127        -> ordinary-error match; stdout is NOT compared
+#                              (the VM reports a top-level error and
+#                              continues, the native binary exits at the
+#                              first error, so post-error output
+#                              legitimately differs)
+#   any exit >= 128         -> divergence: 128+N is death by signal N
+#                              (segfault, abort, ...), never an ordinary
+#                              Scheme error on either side
+#   exit classes differ     -> divergence (error on one side only)
+#   compile fails/times out -> divergence (generated programs must compile)
+#   either side timed out   -> pair skipped (incomparable)
 #
 # This is process-spawn + link per input — orders of magnitude slower than
 # in-process fuzzing — so it runs as a scheduled batch in CI (fuzz.yml), not
@@ -46,22 +51,28 @@ GEN=zig-out/bin/kaappi-fuzz-gen
 
 # GNU timeout when available (Linux/CI); on macOS without coreutils the
 # programs are bounded by construction, so running without one is acceptable.
-TIMEOUT_CMD=""
+# Compilation gets a longer budget than execution: it forks the system
+# linker, and a hang there would otherwise stall the whole batch.
+TIMEOUT_BIN=""
 for c in timeout gtimeout; do
   if command -v "$c" >/dev/null 2>&1; then
-    TIMEOUT_CMD="$c 10"
+    TIMEOUT_BIN="$c"
     break
   fi
 done
+RUN_TIMEOUT="${TIMEOUT_BIN:+$TIMEOUT_BIN 10}"
+COMPILE_TIMEOUT="${TIMEOUT_BIN:+$TIMEOUT_BIN 60}"
 
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/native-diff.XXXXXX") || exit 1
 trap 'rm -rf "$WORK"' EXIT
 
 # Fail fast when the native toolchain is unavailable: `kaappi compile`
 # reports link/toolchain errors on stderr but still exits 0, so probe with a
-# trivial program and check that the output binary actually appears.
+# trivial program and check that the output binary actually appears. The
+# probe also warms the linker's compiler-rt cache, so per-seed compiles fit
+# the tighter COMPILE_TIMEOUT; its own budget is generous for a cold cache.
 printf '(write 42)\n(newline)\n' > "$WORK/probe.scm"
-"$KAAPPI" compile "$WORK/probe.scm" -o "$WORK/probe.bin" > "$WORK/probe.log" 2>&1
+${TIMEOUT_BIN:+$TIMEOUT_BIN 300} "$KAAPPI" compile "$WORK/probe.scm" -o "$WORK/probe.bin" > "$WORK/probe.log" 2>&1
 if [ ! -x "$WORK/probe.bin" ]; then
   echo "native-diff: 'kaappi compile' cannot produce binaries here:" >&2
   cat "$WORK/probe.log" >&2
@@ -87,29 +98,38 @@ while [ "$i" -lt "$N" ]; do
   seed=$((BASE + i))
   i=$((i + 1))
   prog="$WORK/seed-$seed.scm"
+  # Clear per-seed transients so save_divergence can never attach a stale
+  # file from an earlier seed (nat.out/nat.err are only written when the
+  # compile succeeds).
+  rm -f "$WORK/vm.out" "$WORK/vm.err" "$WORK/nat.out" "$WORK/nat.err" "$WORK/compile.log"
   "$GEN" "$seed" --native > "$prog" || {
     echo "native-diff: generator failed for seed $seed" >&2
     exit 1
   }
 
-  $TIMEOUT_CMD "$KAAPPI" "$prog" > "$WORK/vm.out" 2> "$WORK/vm.err"
+  $RUN_TIMEOUT "$KAAPPI" "$prog" > "$WORK/vm.out" 2> "$WORK/vm.err"
   vm_exit=$?
 
   bin="$WORK/seed-$seed.bin"
   rm -f "$bin"
-  "$KAAPPI" compile "$prog" -o "$bin" > "$WORK/compile.log" 2>&1
+  $COMPILE_TIMEOUT "$KAAPPI" compile "$prog" -o "$bin" > "$WORK/compile.log" 2>&1
+  compile_exit=$?
   if [ ! -x "$bin" ]; then
-    echo "seed $seed: DIVERGENCE — native compilation failed (generated programs must always compile)" >&2
+    if [ -n "$TIMEOUT_BIN" ] && { [ "$compile_exit" -eq 124 ] || [ "$compile_exit" -eq 137 ]; }; then
+      echo "seed $seed: DIVERGENCE — native compilation timed out" >&2
+    else
+      echo "seed $seed: DIVERGENCE — native compilation failed (generated programs must always compile)" >&2
+    fi
     save_divergence
     divergent=$((divergent + 1))
     continue
   fi
 
-  $TIMEOUT_CMD "$bin" > "$WORK/nat.out" 2> "$WORK/nat.err"
+  $RUN_TIMEOUT "$bin" > "$WORK/nat.out" 2> "$WORK/nat.err"
   nat_exit=$?
 
   # 124 = timeout(1) expiry, 137 = SIGKILL after expiry: incomparable pair.
-  if [ -n "$TIMEOUT_CMD" ] && { [ "$vm_exit" -eq 124 ] || [ "$vm_exit" -eq 137 ] ||
+  if [ -n "$TIMEOUT_BIN" ] && { [ "$vm_exit" -eq 124 ] || [ "$vm_exit" -eq 137 ] ||
     [ "$nat_exit" -eq 124 ] || [ "$nat_exit" -eq 137 ]; }; then
     skipped=$((skipped + 1))
     rm -f "$bin" "$prog" "${prog%.scm}.sbc"
@@ -119,6 +139,11 @@ while [ "$i" -lt "$N" ]; do
   mismatch=""
   if [ "$vm_exit" -eq 0 ] && [ "$nat_exit" -eq 0 ]; then
     cmp -s "$WORK/vm.out" "$WORK/nat.out" || mismatch="stdout differs (both exited 0)"
+  elif [ "$vm_exit" -ge 128 ] || [ "$nat_exit" -ge 128 ]; then
+    # 128+N = killed by signal N. A segfault/abort is a crash finding even
+    # when the other side also errored, so it must never be absorbed into
+    # the ordinary-error match below.
+    mismatch="signal-terminated exit (vm=$vm_exit native=$nat_exit)"
   elif [ "$vm_exit" -eq 0 ] || [ "$nat_exit" -eq 0 ]; then
     mismatch="exit class differs (vm=$vm_exit native=$nat_exit)"
   fi

--- a/tests/fuzz/native-diff.sh
+++ b/tests/fuzz/native-diff.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Differential harness: bytecode VM vs LLVM native backend (issue #1395).
+#
+# For each seed this generates a native-subset program (kaappi-fuzz-gen
+# --native; see src/fuzz_gen_native.zig for why the subset matters), runs it
+# through the interpreter (kaappi prog.scm) and through the native backend
+# (kaappi compile prog.scm -o prog.bin && ./prog.bin), and compares stdout
+# and exit class. Divergent programs are copied into RESULTS_DIR and the
+# script exits non-zero.
+#
+# Usage: bash tests/fuzz/native-diff.sh [N] [SEED_BASE]
+#   N          number of programs (default 100)
+#   SEED_BASE  first seed (default 0); seeds are BASE..BASE+N-1, and the
+#              same seed always yields the same program
+#
+# Environment:
+#   RESULTS_DIR  where divergences are written (default: ./native-diff-results)
+#
+# Comparison rules (rationale in docs/dev/fuzzing.md):
+#   both exit 0          -> stdout must match byte-for-byte
+#   both exit non-zero   -> error classes match; stdout is NOT compared (the
+#                           VM reports a top-level error and continues, the
+#                           native binary exits at the first error, so
+#                           post-error output legitimately differs)
+#   exit classes differ  -> divergence
+#   either side timed out-> pair skipped (incomparable)
+#
+# This is process-spawn + link per input — orders of magnitude slower than
+# in-process fuzzing — so it runs as a scheduled batch in CI (fuzz.yml), not
+# as a std.testing.fuzz target.
+
+set -u
+
+N="${1:-100}"
+BASE="${2:-0}"
+RESULTS_DIR="${RESULTS_DIR:-native-diff-results}"
+
+cd "$(dirname "$0")/../.." || exit 1
+
+KAAPPI=zig-out/bin/kaappi
+GEN=zig-out/bin/kaappi-fuzz-gen
+
+[ -x "$KAAPPI" ] || zig build || exit 1
+[ -f zig-out/lib/libkaappi_rt.a ] || zig build lib || exit 1
+[ -x "$GEN" ] || zig build fuzz-gen || exit 1
+
+# GNU timeout when available (Linux/CI); on macOS without coreutils the
+# programs are bounded by construction, so running without one is acceptable.
+TIMEOUT_CMD=""
+for c in timeout gtimeout; do
+  if command -v "$c" >/dev/null 2>&1; then
+    TIMEOUT_CMD="$c 10"
+    break
+  fi
+done
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/native-diff.XXXXXX") || exit 1
+trap 'rm -rf "$WORK"' EXIT
+
+# Fail fast when the native toolchain is unavailable: `kaappi compile`
+# reports link/toolchain errors on stderr but still exits 0, so probe with a
+# trivial program and check that the output binary actually appears.
+printf '(write 42)\n(newline)\n' > "$WORK/probe.scm"
+"$KAAPPI" compile "$WORK/probe.scm" -o "$WORK/probe.bin" > "$WORK/probe.log" 2>&1
+if [ ! -x "$WORK/probe.bin" ]; then
+  echo "native-diff: 'kaappi compile' cannot produce binaries here:" >&2
+  cat "$WORK/probe.log" >&2
+  exit 1
+fi
+
+divergent=0
+skipped=0
+compared=0
+
+echo "native-diff: seeds $BASE..$((BASE + N - 1))"
+
+save_divergence() {
+  mkdir -p "$RESULTS_DIR"
+  cp "$prog" "$RESULTS_DIR/"
+  for f in vm.out vm.err nat.out nat.err compile.log; do
+    [ -f "$WORK/$f" ] && cp "$WORK/$f" "$RESULTS_DIR/seed-$seed.$f"
+  done
+}
+
+i=0
+while [ "$i" -lt "$N" ]; do
+  seed=$((BASE + i))
+  i=$((i + 1))
+  prog="$WORK/seed-$seed.scm"
+  "$GEN" "$seed" --native > "$prog" || {
+    echo "native-diff: generator failed for seed $seed" >&2
+    exit 1
+  }
+
+  $TIMEOUT_CMD "$KAAPPI" "$prog" > "$WORK/vm.out" 2> "$WORK/vm.err"
+  vm_exit=$?
+
+  bin="$WORK/seed-$seed.bin"
+  rm -f "$bin"
+  "$KAAPPI" compile "$prog" -o "$bin" > "$WORK/compile.log" 2>&1
+  if [ ! -x "$bin" ]; then
+    echo "seed $seed: DIVERGENCE — native compilation failed (generated programs must always compile)" >&2
+    save_divergence
+    divergent=$((divergent + 1))
+    continue
+  fi
+
+  $TIMEOUT_CMD "$bin" > "$WORK/nat.out" 2> "$WORK/nat.err"
+  nat_exit=$?
+
+  # 124 = timeout(1) expiry, 137 = SIGKILL after expiry: incomparable pair.
+  if [ -n "$TIMEOUT_CMD" ] && { [ "$vm_exit" -eq 124 ] || [ "$vm_exit" -eq 137 ] ||
+    [ "$nat_exit" -eq 124 ] || [ "$nat_exit" -eq 137 ]; }; then
+    skipped=$((skipped + 1))
+    rm -f "$bin" "$prog" "${prog%.scm}.sbc"
+    continue
+  fi
+
+  mismatch=""
+  if [ "$vm_exit" -eq 0 ] && [ "$nat_exit" -eq 0 ]; then
+    cmp -s "$WORK/vm.out" "$WORK/nat.out" || mismatch="stdout differs (both exited 0)"
+  elif [ "$vm_exit" -eq 0 ] || [ "$nat_exit" -eq 0 ]; then
+    mismatch="exit class differs (vm=$vm_exit native=$nat_exit)"
+  fi
+  compared=$((compared + 1))
+
+  if [ -n "$mismatch" ]; then
+    echo "seed $seed: DIVERGENCE — $mismatch" >&2
+    save_divergence
+    divergent=$((divergent + 1))
+  fi
+  rm -f "$bin" "$prog" "${prog%.scm}.sbc"
+done
+
+echo "native-diff: $compared compared, $skipped skipped, $divergent divergent"
+if [ "$divergent" -gt 0 ]; then
+  echo "native-diff: divergent programs saved in $RESULTS_DIR/" >&2
+  exit 1
+fi


### PR DESCRIPTION
Implements #1395 (fuzzing roadmap Phase 3, third item): an offline differential harness that runs the same generated program through the bytecode VM and through the LLVM native backend and compares stdout + exit class.

## What's here

- **`src/fuzz_gen_native.zig`** — a native-compilable-subset generator mode. The backend falls back to `kaappi_eval` for forms it can't compile, so unrestricted programs would degrade the diff to VM-vs-VM. The module doc comment catalogs every structural rule the backend imposes (free-variable limits in function bodies, literal-only global inits, no lambdas in `let`, no `set!` in inline-lambda bodies, void-valued top-level forms with explicit `(write ...)` observables) and why each exists.
- **`zig build fuzz-gen`** (`src/fuzz_gen_main.zig`) — standalone seed-replayable generator driver for the shell harness. Dev/CI only; not in the default install or releases.
- **`tests/fuzz/native-diff.sh`** — the harness: generate → `kaappi prog.scm` vs `kaappi compile prog.scm -o bin && ./bin` → compare. Both-nonzero exits match without comparing stdout (the VM continues past top-level errors; native halts at the first). Probes the toolchain up front because `kaappi compile` reports link failures on stderr but exits 0.
- **CI** — a `native-diff` job in the fuzz workflow: 300 programs nightly (~5 min), rotating seed base (printed, replayable via `workflow_dispatch` or locally), divergences uploaded as artifacts.
- **Gates** — `tests_native.zig`: fixed-seed programs must emit no unexpected `kaappi_eval` calls in the LLVM IR *and* every defined function must get a named native definition (eval-counting alone cannot see a rejected function). `tests_fuzz.zig`: programs evaluate cleanly (measured 100% over 300 seeds). The eval-count gate caught a subset leak during development (inline lambdas with `set!` hit the #819 scan), which is exactly the failure mode it exists for.
- **Docs** — new runbook section in `docs/dev/fuzzing.md` (running, comparison rules, triage); status tick in `docs/dev/fuzzing-feasibility.md`.

## First findings — the oracle works

`bash tests/fuzz/native-diff.sh 100` runs clean; a 500-seed batch found **5 divergences, all one real miscompilation**, filed as #1407: the closure tiers' free-variable analysis doesn't descend into `let`/`let*`, so a lambda capturing an enclosing binding only through a `let` compiles as closed and the reference becomes a global lookup — `undefined variable` at runtime, or a *silently wrong value* when a same-named global exists. Minimal reproducer in the issue.

> **Note:** the nightly `native-diff` job will stay red until #1407 is fixed (~1% of seeds hit it). That's the oracle doing its job; artifacts identify the known signature (`undefined variable: <letter>` in `seed-N.nat.err`), so new divergence classes remain visible during triage.

## Acceptance criteria from #1395

- `bash tests/fuzz/native-diff.sh 100` runs clean on main *(or files real bugs — also success)* — ✅ both: 100 clean, wider batch filed #1407
- Reproducibility: same seed → same programs — ✅ (deterministic test + seed base printed in CI)
- CI job runs on schedule with artifacts for divergences — ✅
- Uses `zig cc` for linking — ✅ (`kaappi compile` finds zig on PATH first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
