### PR TITLE
Descend into let/let* in the native closure free-variable analysis

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -901,6 +901,7 @@ const primitives = [_][]const u8{
     "gcd",            "lcm",               "call/ec",      "call-with-escape-continuation", "call-with-values", "dynamic-wind",    "with-exception-handler",
     "raise",          "raise-continuable", "error",        "for-each",                      "string-for-each",  "vector-for-each", "vector-map",
     "string-map",     "assoc",             "assq",         "assv",                          "member",           "memq",            "memv",
+    "list-ref",
 };
 
 // ---------------------------------------------------------------------------

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -208,7 +208,11 @@ pub const LLVMEmitter = struct {
         return self.emitImm(@bitCast(value));
     }
 
-    fn isNameShadowed(self: *LLVMEmitter, name: []const u8) bool {
+    // Mirrors emitGlobalRef's lexical resolution order (locals, rest param,
+    // params, upvalues). Also consulted by the closure-tier free-variable
+    // analysis in llvm_emit_lambda.zig: a shadowed name is a capture even
+    // when a known global of the same name exists.
+    pub fn isNameShadowed(self: *LLVMEmitter, name: []const u8) bool {
         if (self.locals) |loc| {
             if (loc.get(name) != null) return true;
         }

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -70,7 +70,7 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
 
     var allowed: [17][]const u8 = undefined;
     @memcpy(allowed[0..arity], param_names[0..arity]);
-    if (hasFreeVars(body_nodes[0..body_count], allowed[0..arity])) return null;
+    if (hasFreeVars(self, body_nodes[0..body_count], allowed[0..arity])) return null;
 
     const fn_name = emitLambdaFunction(self, data.name, param_names[0..arity], body_nodes[0..body_count], rest_name) orelse return null;
 
@@ -139,12 +139,22 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
 
     var free_vars: [16][]const u8 = undefined;
     var free_count: usize = 0;
-    if (!collectFreeVars(body_nodes[0..body_count], param_names[0..arity], &free_vars, &free_count)) return null;
+    if (!collectFreeVars(self, body_nodes[0..body_count], param_names[0..arity], &free_vars, &free_count)) return null;
     if (free_count == 0) return null;
 
     const outer_params = self.params orelse return null;
     for (free_vars[0..free_count]) |fv| {
-        if (!outer_params.contains(fv) and !ir.isKnownGlobal(fv)) return null;
+        // Captures are copied out of the enclosing %args array, so a name
+        // bound by an enclosing let-local or rest parameter (which outrank
+        // params in emitGlobalRef's resolution order) cannot be captured
+        // here, and neither can a name living only in the enclosing
+        // closure's upvalue array (#1410).
+        if (localsOrRestShadows(self, fv)) return null;
+        if (outer_params.contains(fv)) continue;
+        if (self.upvalues) |uv| {
+            if (uv.contains(fv)) return null;
+        }
+        if (!ir.isKnownGlobal(fv)) return null;
     }
 
     const id = self.lambda_counter;
@@ -338,7 +348,7 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
         allowed[arity] = rn;
     }
     allowed[arity + extra] = name;
-    if (hasFreeVars(body_nodes[0..body_count], allowed[0 .. arity + extra + 1])) return null;
+    if (hasFreeVars(self, body_nodes[0..body_count], allowed[0 .. arity + extra + 1])) return null;
 
     return emitLambdaFunction(self, name, param_names[0..arity], body_nodes[0..body_count], rest_name);
 }
@@ -561,7 +571,25 @@ fn sexprReferencesNames(expr: Value, target_names: []const []const u8, excluded_
     return false;
 }
 
-// --- Free variable analysis helpers (standalone, no self) ---
+// --- Free variable analysis helpers ---
+//
+// These take the emitter because classification must respect the enclosing
+// emission scope: a name shadowed by an enclosing lexical binding (param,
+// let-local, rest parameter, upvalue) is a capture even when a known global
+// of the same name exists — `car` inside (lambda (car) ...) is the parameter,
+// not the primitive. The shadow check must run before isKnownGlobal.
+
+// Enclosing bindings that outrank the params array in emitGlobalRef's
+// resolution order and cannot be copied out of %args into an upvalue buffer.
+fn localsOrRestShadows(self: *LLVMEmitter, name: []const u8) bool {
+    if (self.locals) |loc| {
+        if (loc.get(name) != null) return true;
+    }
+    if (self.rest_param_name) |rp| {
+        if (std.mem.eql(u8, name, rp)) return true;
+    }
+    return false;
+}
 
 // True if the raw S-expression contains a set! or define form anywhere (not
 // descending into quoted data). Used to reject closure bodies that mutate or
@@ -581,14 +609,14 @@ fn sexprContainsSetOrDefine(expr: types.Value) bool {
     return false;
 }
 
-fn hasFreeVars(nodes: []const *ir.Node, params: []const []const u8) bool {
+fn hasFreeVars(self: *LLVMEmitter, nodes: []const *ir.Node, params: []const []const u8) bool {
     for (nodes) |node| {
-        if (nodeHasFreeVars(node, params)) return true;
+        if (nodeHasFreeVars(self, node, params)) return true;
     }
     return false;
 }
 
-fn nodeHasFreeVars(node: *const ir.Node, params: []const []const u8) bool {
+fn nodeHasFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []const u8) bool {
     switch (node.tag) {
         .global_ref => {
             if (!types.isSymbol(node.data.global_ref)) return false;
@@ -596,34 +624,37 @@ fn nodeHasFreeVars(node: *const ir.Node, params: []const []const u8) bool {
             for (params) |p| {
                 if (std.mem.eql(u8, name, p)) return false;
             }
+            // An enclosing lexical binding outranks a known global of the
+            // same name: this reference is a capture, not the primitive.
+            if (self.isNameShadowed(name)) return true;
             if (ir.isKnownGlobal(name)) return false;
             return true;
         },
         .call => {
-            if (nodeHasFreeVars(node.data.call.operator, params)) return true;
+            if (nodeHasFreeVars(self, node.data.call.operator, params)) return true;
             for (node.data.call.args) |arg| {
-                if (nodeHasFreeVars(arg, params)) return true;
+                if (nodeHasFreeVars(self, arg, params)) return true;
             }
             return false;
         },
         .@"if" => {
-            if (nodeHasFreeVars(node.data.@"if".test_expr, params)) return true;
-            if (nodeHasFreeVars(node.data.@"if".consequent, params)) return true;
+            if (nodeHasFreeVars(self, node.data.@"if".test_expr, params)) return true;
+            if (nodeHasFreeVars(self, node.data.@"if".consequent, params)) return true;
             if (node.data.@"if".alternate) |alt| {
-                if (nodeHasFreeVars(alt, params)) return true;
+                if (nodeHasFreeVars(self, alt, params)) return true;
             }
             return false;
         },
-        .begin => return hasFreeVars(node.data.begin, params),
-        .and_form => return hasFreeVars(node.data.and_form, params),
-        .or_form => return hasFreeVars(node.data.or_form, params),
+        .begin => return hasFreeVars(self, node.data.begin, params),
+        .and_form => return hasFreeVars(self, node.data.and_form, params),
+        .or_form => return hasFreeVars(self, node.data.or_form, params),
         .when_form => {
-            if (nodeHasFreeVars(node.data.when_form.test_expr, params)) return true;
-            return hasFreeVars(node.data.when_form.body, params);
+            if (nodeHasFreeVars(self, node.data.when_form.test_expr, params)) return true;
+            return hasFreeVars(self, node.data.when_form.body, params);
         },
         .unless_form => {
-            if (nodeHasFreeVars(node.data.unless_form.test_expr, params)) return true;
-            return hasFreeVars(node.data.unless_form.body, params);
+            if (nodeHasFreeVars(self, node.data.unless_form.test_expr, params)) return true;
+            return hasFreeVars(self, node.data.unless_form.body, params);
         },
         .set_form => {
             // A set! is safe to compile in a body with no upvalues only when
@@ -633,8 +664,8 @@ fn nodeHasFreeVars(node: *const ir.Node, params: []const []const u8) bool {
             // interpreter handle it. The value is a raw S-expr; a compound
             // value is treated conservatively as possibly capturing (#819).
             if (!types.isSymbol(node.data.set_form.name)) return true;
-            if (!valueIsBoundOrLiteral(node.data.set_form.name, params)) return true;
-            if (!valueIsBoundOrLiteral(node.data.set_form.value, params)) return true;
+            if (!valueIsBoundOrLiteral(self, node.data.set_form.name, params)) return true;
+            if (!valueIsBoundOrLiteral(self, node.data.set_form.value, params)) return true;
             return false;
         },
         // An internal define introduces a binding that the native lambda-body
@@ -645,8 +676,8 @@ fn nodeHasFreeVars(node: *const ir.Node, params: []const []const u8) bool {
         // let/let* keep their contents as a raw S-expression, so references
         // hidden inside them are invisible to the node-level cases above.
         // Walk the raw form with proper binder scoping (#1407).
-        .let_form => return letSexprHasFreeVars(node.data.let_form.args, false, params),
-        .let_star => return letSexprHasFreeVars(node.data.let_star.args, true, params),
+        .let_form => return letSexprHasFreeVars(self, node.data.let_form.args, false, params),
+        .let_star => return letSexprHasFreeVars(self, node.data.let_star.args, true, params),
         .lambda, .passthrough, .sexpr_form => return false,
         .letrec, .letrec_star => return false,
     }
@@ -656,12 +687,15 @@ fn nodeHasFreeVars(node: *const ir.Node, params: []const []const u8) bool {
 // compiled body with no upvalues: a literal, or a symbol that names one of our
 // params or a known global. Anything else (a compound expression, or a symbol
 // naming a captured lexical variable) is treated as unsafe.
-fn valueIsBoundOrLiteral(value: types.Value, params: []const []const u8) bool {
+fn valueIsBoundOrLiteral(self: *LLVMEmitter, value: types.Value, params: []const []const u8) bool {
     if (types.isSymbol(value)) {
         const name = types.symbolName(value);
         for (params) |p| {
             if (std.mem.eql(u8, name, p)) return true;
         }
+        // A name shadowed by an enclosing lexical binding is a capture,
+        // not the known global it would otherwise resolve to.
+        if (self.isNameShadowed(name)) return false;
         return ir.isKnownGlobal(name);
     }
     return !types.isPair(value);
@@ -671,14 +705,14 @@ fn valueIsBoundOrLiteral(value: types.Value, params: []const []const u8) bool {
 // name buffer overflowed, or a let walk met a form it cannot scope). Callers
 // must then reject native closure compilation — emitting with an incomplete
 // free-variable set would leave the missed name to resolve as a global.
-fn collectFreeVars(nodes: []const *ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
+fn collectFreeVars(self: *LLVMEmitter, nodes: []const *ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
     for (nodes) |node| {
-        if (!collectNodeFreeVars(node, params, buf, count)) return false;
+        if (!collectNodeFreeVars(self, node, params, buf, count)) return false;
     }
     return true;
 }
 
-fn collectNodeFreeVars(node: *const ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
+fn collectNodeFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
     switch (node.tag) {
         .global_ref => {
             if (!types.isSymbol(node.data.global_ref)) return true;
@@ -686,7 +720,9 @@ fn collectNodeFreeVars(node: *const ir.Node, params: []const []const u8, buf: *[
             for (params) |p| {
                 if (std.mem.eql(u8, name, p)) return true;
             }
-            if (ir.isKnownGlobal(name)) return true;
+            // A shadowed known global is a capture; only an unshadowed one
+            // may be skipped as a genuine global reference.
+            if (ir.isKnownGlobal(name) and !self.isNameShadowed(name)) return true;
             for (buf[0..count.*]) |existing| {
                 if (std.mem.eql(u8, name, existing)) return true;
             }
@@ -696,36 +732,36 @@ fn collectNodeFreeVars(node: *const ir.Node, params: []const []const u8, buf: *[
             return true;
         },
         .call => {
-            if (!collectNodeFreeVars(node.data.call.operator, params, buf, count)) return false;
+            if (!collectNodeFreeVars(self, node.data.call.operator, params, buf, count)) return false;
             for (node.data.call.args) |arg| {
-                if (!collectNodeFreeVars(arg, params, buf, count)) return false;
+                if (!collectNodeFreeVars(self, arg, params, buf, count)) return false;
             }
             return true;
         },
         .@"if" => {
-            if (!collectNodeFreeVars(node.data.@"if".test_expr, params, buf, count)) return false;
-            if (!collectNodeFreeVars(node.data.@"if".consequent, params, buf, count)) return false;
+            if (!collectNodeFreeVars(self, node.data.@"if".test_expr, params, buf, count)) return false;
+            if (!collectNodeFreeVars(self, node.data.@"if".consequent, params, buf, count)) return false;
             if (node.data.@"if".alternate) |alt| {
-                if (!collectNodeFreeVars(alt, params, buf, count)) return false;
+                if (!collectNodeFreeVars(self, alt, params, buf, count)) return false;
             }
             return true;
         },
-        .begin => return collectFreeVars(node.data.begin, params, buf, count),
-        .and_form => return collectFreeVars(node.data.and_form, params, buf, count),
-        .or_form => return collectFreeVars(node.data.or_form, params, buf, count),
+        .begin => return collectFreeVars(self, node.data.begin, params, buf, count),
+        .and_form => return collectFreeVars(self, node.data.and_form, params, buf, count),
+        .or_form => return collectFreeVars(self, node.data.or_form, params, buf, count),
         .when_form => {
-            if (!collectNodeFreeVars(node.data.when_form.test_expr, params, buf, count)) return false;
-            return collectFreeVars(node.data.when_form.body, params, buf, count);
+            if (!collectNodeFreeVars(self, node.data.when_form.test_expr, params, buf, count)) return false;
+            return collectFreeVars(self, node.data.when_form.body, params, buf, count);
         },
         .unless_form => {
-            if (!collectNodeFreeVars(node.data.unless_form.test_expr, params, buf, count)) return false;
-            return collectFreeVars(node.data.unless_form.body, params, buf, count);
+            if (!collectNodeFreeVars(self, node.data.unless_form.test_expr, params, buf, count)) return false;
+            return collectFreeVars(self, node.data.unless_form.body, params, buf, count);
         },
         // See nodeHasFreeVars: let/let* contents are a raw S-expression and
         // must be walked with binder scoping, or captures hidden inside them
         // are silently compiled as global lookups (#1407).
-        .let_form => return collectLetSexprFreeVars(node.data.let_form.args, false, params, buf, count),
-        .let_star => return collectLetSexprFreeVars(node.data.let_star.args, true, params, buf, count),
+        .let_form => return collectLetSexprFreeVars(self, node.data.let_form.args, false, params, buf, count),
+        .let_star => return collectLetSexprFreeVars(self, node.data.let_star.args, true, params, buf, count),
         .constant, .define, .set_form, .lambda, .passthrough, .sexpr_form => return true,
         .letrec, .letrec_star => return true,
     }
@@ -744,6 +780,7 @@ fn collectNodeFreeVars(node: *const ir.Node, params: []const []const u8, buf: *[
 // enclosing lambda natively.
 
 const FreeNameWalk = struct {
+    emitter: *LLVMEmitter,
     params: []const []const u8,
     bound: [64][]const u8 = undefined,
     bound_count: usize = 0,
@@ -769,7 +806,9 @@ const FreeNameWalk = struct {
         for (w.bound[0..w.bound_count]) |b| {
             if (std.mem.eql(u8, name, b)) return;
         }
-        if (ir.isKnownGlobal(name)) return;
+        // A shadowed known global is a capture; only an unshadowed one is a
+        // genuine global reference (see the section comment above).
+        if (ir.isKnownGlobal(name) and !w.emitter.isNameShadowed(name)) return;
         w.found = true;
         if (w.buf) |buf| {
             const count = w.count.?;
@@ -786,14 +825,14 @@ const FreeNameWalk = struct {
     }
 };
 
-fn letSexprHasFreeVars(args: Value, sequential: bool, params: []const []const u8) bool {
-    var w = FreeNameWalk{ .params = params };
+fn letSexprHasFreeVars(self: *LLVMEmitter, args: Value, sequential: bool, params: []const []const u8) bool {
+    var w = FreeNameWalk{ .emitter = self, .params = params };
     walkLetSexpr(&w, args, sequential);
     return w.found or w.inexact;
 }
 
-fn collectLetSexprFreeVars(args: Value, sequential: bool, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
-    var w = FreeNameWalk{ .params = params, .buf = buf, .count = count };
+fn collectLetSexprFreeVars(self: *LLVMEmitter, args: Value, sequential: bool, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
+    var w = FreeNameWalk{ .emitter = self, .params = params, .buf = buf, .count = count };
     walkLetSexpr(&w, args, sequential);
     return !w.inexact;
 }

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -139,7 +139,7 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
 
     var free_vars: [16][]const u8 = undefined;
     var free_count: usize = 0;
-    collectFreeVars(body_nodes[0..body_count], param_names[0..arity], &free_vars, &free_count);
+    if (!collectFreeVars(body_nodes[0..body_count], param_names[0..arity], &free_vars, &free_count)) return null;
     if (free_count == 0) return null;
 
     const outer_params = self.params orelse return null;
@@ -642,7 +642,12 @@ fn nodeHasFreeVars(node: *const ir.Node, params: []const []const u8) bool {
         // global. Disqualify and fall back to the interpreter.
         .define => return true,
         .constant => return false,
-        .lambda, .passthrough, .let_form, .let_star, .sexpr_form => return false,
+        // let/let* keep their contents as a raw S-expression, so references
+        // hidden inside them are invisible to the node-level cases above.
+        // Walk the raw form with proper binder scoping (#1407).
+        .let_form => return letSexprHasFreeVars(node.data.let_form.args, false, params),
+        .let_star => return letSexprHasFreeVars(node.data.let_star.args, true, params),
+        .lambda, .passthrough, .sexpr_form => return false,
         .letrec, .letrec_star => return false,
     }
 }
@@ -662,50 +667,254 @@ fn valueIsBoundOrLiteral(value: types.Value, params: []const []const u8) bool {
     return !types.isPair(value);
 }
 
-fn collectFreeVars(nodes: []const *ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) void {
+// Both collectors return false when the analysis could not stay exact (a
+// name buffer overflowed, or a let walk met a form it cannot scope). Callers
+// must then reject native closure compilation — emitting with an incomplete
+// free-variable set would leave the missed name to resolve as a global.
+fn collectFreeVars(nodes: []const *ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
     for (nodes) |node| {
-        collectNodeFreeVars(node, params, buf, count);
+        if (!collectNodeFreeVars(node, params, buf, count)) return false;
+    }
+    return true;
+}
+
+fn collectNodeFreeVars(node: *const ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
+    switch (node.tag) {
+        .global_ref => {
+            if (!types.isSymbol(node.data.global_ref)) return true;
+            const name = types.symbolName(node.data.global_ref);
+            for (params) |p| {
+                if (std.mem.eql(u8, name, p)) return true;
+            }
+            if (ir.isKnownGlobal(name)) return true;
+            for (buf[0..count.*]) |existing| {
+                if (std.mem.eql(u8, name, existing)) return true;
+            }
+            if (count.* >= buf.len) return false;
+            buf[count.*] = name;
+            count.* += 1;
+            return true;
+        },
+        .call => {
+            if (!collectNodeFreeVars(node.data.call.operator, params, buf, count)) return false;
+            for (node.data.call.args) |arg| {
+                if (!collectNodeFreeVars(arg, params, buf, count)) return false;
+            }
+            return true;
+        },
+        .@"if" => {
+            if (!collectNodeFreeVars(node.data.@"if".test_expr, params, buf, count)) return false;
+            if (!collectNodeFreeVars(node.data.@"if".consequent, params, buf, count)) return false;
+            if (node.data.@"if".alternate) |alt| {
+                if (!collectNodeFreeVars(alt, params, buf, count)) return false;
+            }
+            return true;
+        },
+        .begin => return collectFreeVars(node.data.begin, params, buf, count),
+        .and_form => return collectFreeVars(node.data.and_form, params, buf, count),
+        .or_form => return collectFreeVars(node.data.or_form, params, buf, count),
+        .when_form => {
+            if (!collectNodeFreeVars(node.data.when_form.test_expr, params, buf, count)) return false;
+            return collectFreeVars(node.data.when_form.body, params, buf, count);
+        },
+        .unless_form => {
+            if (!collectNodeFreeVars(node.data.unless_form.test_expr, params, buf, count)) return false;
+            return collectFreeVars(node.data.unless_form.body, params, buf, count);
+        },
+        // See nodeHasFreeVars: let/let* contents are a raw S-expression and
+        // must be walked with binder scoping, or captures hidden inside them
+        // are silently compiled as global lookups (#1407).
+        .let_form => return collectLetSexprFreeVars(node.data.let_form.args, false, params, buf, count),
+        .let_star => return collectLetSexprFreeVars(node.data.let_star.args, true, params, buf, count),
+        .constant, .define, .set_form, .lambda, .passthrough, .sexpr_form => return true,
+        .letrec, .letrec_star => return true,
     }
 }
 
-fn collectNodeFreeVars(node: *const ir.Node, params: []const []const u8, buf: *[16][]const u8, count: *usize) void {
-    switch (node.tag) {
-        .global_ref => {
-            if (!types.isSymbol(node.data.global_ref)) return;
-            const name = types.symbolName(node.data.global_ref);
-            for (params) |p| {
-                if (std.mem.eql(u8, name, p)) return;
-            }
-            if (ir.isKnownGlobal(name)) return;
+// --- Scope-aware free-name walk over raw let/let* forms (#1407) ---
+//
+// The IR keeps let/let* contents as a raw S-expression (ir.LetData.args), so
+// the node-level free-variable analysis cannot see references inside them.
+// This walk descends into the raw form tracking binder scopes (let binders,
+// nested lambda formals) and reports every referenced name that is neither
+// bound nor a known global — the same rule the .global_ref arms apply.
+// `inexact` is set when the walk meets something it cannot scope precisely
+// (internal define, an eval-fallback form, malformed bindings, overflow);
+// callers must then treat the analysis as failed and refuse to compile the
+// enclosing lambda natively.
+
+const FreeNameWalk = struct {
+    params: []const []const u8,
+    bound: [64][]const u8 = undefined,
+    bound_count: usize = 0,
+    // When non-null, free names are appended here, deduplicated.
+    buf: ?*[16][]const u8 = null,
+    count: ?*usize = null,
+    found: bool = false,
+    inexact: bool = false,
+
+    fn pushBound(w: *FreeNameWalk, name: []const u8) void {
+        if (w.bound_count >= w.bound.len) {
+            w.inexact = true;
+            return;
+        }
+        w.bound[w.bound_count] = name;
+        w.bound_count += 1;
+    }
+
+    fn noteRef(w: *FreeNameWalk, name: []const u8) void {
+        for (w.params) |p| {
+            if (std.mem.eql(u8, name, p)) return;
+        }
+        for (w.bound[0..w.bound_count]) |b| {
+            if (std.mem.eql(u8, name, b)) return;
+        }
+        if (ir.isKnownGlobal(name)) return;
+        w.found = true;
+        if (w.buf) |buf| {
+            const count = w.count.?;
             for (buf[0..count.*]) |existing| {
                 if (std.mem.eql(u8, name, existing)) return;
             }
-            if (count.* < 16) {
-                buf[count.*] = name;
-                count.* += 1;
+            if (count.* >= buf.len) {
+                w.inexact = true;
+                return;
             }
-        },
-        .call => {
-            collectNodeFreeVars(node.data.call.operator, params, buf, count);
-            for (node.data.call.args) |arg| collectNodeFreeVars(arg, params, buf, count);
-        },
-        .@"if" => {
-            collectNodeFreeVars(node.data.@"if".test_expr, params, buf, count);
-            collectNodeFreeVars(node.data.@"if".consequent, params, buf, count);
-            if (node.data.@"if".alternate) |alt| collectNodeFreeVars(alt, params, buf, count);
-        },
-        .begin => collectFreeVars(node.data.begin, params, buf, count),
-        .and_form => collectFreeVars(node.data.and_form, params, buf, count),
-        .or_form => collectFreeVars(node.data.or_form, params, buf, count),
-        .when_form => {
-            collectNodeFreeVars(node.data.when_form.test_expr, params, buf, count);
-            collectFreeVars(node.data.when_form.body, params, buf, count);
-        },
-        .unless_form => {
-            collectNodeFreeVars(node.data.unless_form.test_expr, params, buf, count);
-            collectFreeVars(node.data.unless_form.body, params, buf, count);
-        },
-        .constant, .define, .set_form, .lambda, .passthrough, .let_form, .let_star, .sexpr_form => {},
-        .letrec, .letrec_star => {},
+            buf[count.*] = name;
+            count.* += 1;
+        }
+    }
+};
+
+fn letSexprHasFreeVars(args: Value, sequential: bool, params: []const []const u8) bool {
+    var w = FreeNameWalk{ .params = params };
+    walkLetSexpr(&w, args, sequential);
+    return w.found or w.inexact;
+}
+
+fn collectLetSexprFreeVars(args: Value, sequential: bool, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
+    var w = FreeNameWalk{ .params = params, .buf = buf, .count = count };
+    walkLetSexpr(&w, args, sequential);
+    return !w.inexact;
+}
+
+// args is the raw `(bindings body ...)` tail of a let/let* form. For let the
+// init expressions see only the enclosing scope; for let* each init also sees
+// the binders before it. The binders are in scope for the body either way.
+fn walkLetSexpr(w: *FreeNameWalk, args: Value, sequential: bool) void {
+    if (!types.isPair(args)) {
+        w.inexact = true;
+        return;
+    }
+    const bindings = types.car(args);
+    const saved = w.bound_count;
+    defer w.bound_count = saved;
+
+    var blist = bindings;
+    while (types.isPair(blist)) : (blist = types.cdr(blist)) {
+        const binding = types.car(blist);
+        if (!types.isPair(binding)) {
+            w.inexact = true;
+            return;
+        }
+        const var_sym = types.car(binding);
+        const init_list = types.cdr(binding);
+        if (!types.isSymbol(var_sym) or !types.isPair(init_list)) {
+            w.inexact = true;
+            return;
+        }
+        walkSexpr(w, types.car(init_list));
+        if (sequential) w.pushBound(types.symbolName(var_sym));
+    }
+    if (blist != types.NIL) {
+        w.inexact = true;
+        return;
+    }
+    if (!sequential) {
+        blist = bindings;
+        while (types.isPair(blist)) : (blist = types.cdr(blist)) {
+            w.pushBound(types.symbolName(types.car(types.car(blist))));
+        }
+    }
+    var body_expr = types.cdr(args);
+    while (types.isPair(body_expr)) : (body_expr = types.cdr(body_expr)) {
+        walkSexpr(w, types.car(body_expr));
+    }
+}
+
+// rest is the raw `(formals body ...)` tail of a lambda form.
+fn walkLambdaSexpr(w: *FreeNameWalk, rest: Value) void {
+    if (!types.isPair(rest)) {
+        w.inexact = true;
+        return;
+    }
+    const saved = w.bound_count;
+    defer w.bound_count = saved;
+
+    var f = types.car(rest);
+    while (types.isPair(f)) : (f = types.cdr(f)) {
+        const p = types.car(f);
+        if (!types.isSymbol(p)) {
+            w.inexact = true;
+            return;
+        }
+        w.pushBound(types.symbolName(p));
+    }
+    // Rest parameter: dotted tail, or bare-symbol formals.
+    if (f != types.NIL) {
+        if (!types.isSymbol(f)) {
+            w.inexact = true;
+            return;
+        }
+        w.pushBound(types.symbolName(f));
+    }
+    var body_expr = types.cdr(rest);
+    while (types.isPair(body_expr)) : (body_expr = types.cdr(body_expr)) {
+        walkSexpr(w, types.car(body_expr));
+    }
+}
+
+fn walkSexpr(w: *FreeNameWalk, expr: Value) void {
+    if (w.inexact) return;
+    if (types.isSymbol(expr)) {
+        w.noteRef(types.symbolName(expr));
+        return;
+    }
+    if (!types.isPair(expr)) return;
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const name = types.symbolName(head);
+        if (std.mem.eql(u8, name, "quote")) return;
+        if (std.mem.eql(u8, name, "lambda")) return walkLambdaSexpr(w, types.cdr(expr));
+        const is_let = std.mem.eql(u8, name, "let");
+        if (is_let or std.mem.eql(u8, name, "let*")) {
+            const rest = types.cdr(expr);
+            // Named let is rejected upstream by sexprNeedsEvalFallback; if
+            // one shows up anyway, give up rather than mis-scope its binders.
+            if (is_let and types.isPair(rest) and types.isSymbol(types.car(rest))) {
+                w.inexact = true;
+                return;
+            }
+            return walkLetSexpr(w, rest, !is_let);
+        }
+        // An internal define introduces a binding this walk does not model.
+        if (std.mem.eql(u8, name, "define")) {
+            w.inexact = true;
+            return;
+        }
+        // Forms the backend sends to eval fallback (cond, do, letrec, ...)
+        // are rejected upstream before this analysis runs; if one appears
+        // anyway, its binder structure is unknown — give up.
+        if (isEvalFallbackForm(name)) {
+            w.inexact = true;
+            return;
+        }
+    }
+    // Everything else (calls, if/begin/and/or/when/unless/set!, ...) is a
+    // plain expression tree: every symbol in it is a reference, and keyword
+    // heads are filtered out by isKnownGlobal inside noteRef.
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        walkSexpr(w, types.car(cur));
     }
 }

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -297,6 +297,57 @@ test "LLVM emit: let* sequential" {
     try expectContains(res.toSlice(), "alloca i64");
 }
 
+// -- Free variables hidden inside let/let* (#1407) --
+// The closure tiers' free-variable analysis must descend into raw let/let*
+// forms. Before the fix, a lambda capturing an enclosing param only through
+// a let compiled as a *closed* native closure and the reference degraded to
+// kaappi_global_lookup: "undefined variable" at runtime, or a silently wrong
+// value when a same-named global existed.
+
+test "LLVM emit: lambda capturing enclosing param through a let gets an upvalue (#1407)" {
+    var res = try emitSourceResult("(define g0 (lambda (u) ((lambda (a) (let ((b u)) b)) 1)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // Tier 1 must capture `u`: closure created with one upvalue (arity 1)...
+    try expectContains(ll, "@kaappi_create_native_closure");
+    try expectContains(ll, ", i64 1, i64 1, ptr");
+    // ...and the closure body must read it from the upvalue array.
+    try expectContains(ll, "ptr %upvalues, i64 0");
+    // The lambda-local name must never be interned for a global lookup.
+    try std.testing.expect(std.mem.indexOf(u8, ll, "c\"u\"") == null);
+}
+
+test "LLVM emit: lambda capturing enclosing param through a let* gets an upvalue (#1407)" {
+    var res = try emitSourceResult("(define g0 (lambda (u) ((lambda (a) (let* ((b u) (c b)) c)) 1)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "@kaappi_create_native_closure");
+    try expectContains(ll, ", i64 1, i64 1, ptr");
+    try expectContains(ll, "ptr %upvalues, i64 0");
+    try std.testing.expect(std.mem.indexOf(u8, ll, "c\"u\"") == null);
+}
+
+test "LLVM emit: top-level lambda with let-hidden free name falls back to eval (#1407)" {
+    // With no enclosing scope to capture from, both closure tiers must
+    // reject; emitLambdaViaEval resolves `u` in the global environment at
+    // call time, which is correct at top level.
+    var res = try emitSourceResult("(lambda (a) (let ((b u)) b))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "call i64 @kaappi_eval");
+    try std.testing.expect(std.mem.indexOf(u8, ll, "call i64 @kaappi_create_native_closure") == null);
+}
+
+test "LLVM emit: let over own params still compiles as a closed native closure" {
+    // Guard against over-conservatism: a let that only references the
+    // lambda's own params has no free variables and must stay native.
+    var res = try emitSourceResult("(lambda (a) (let ((b a)) b))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "@kaappi_create_native_closure");
+    try std.testing.expect(std.mem.indexOf(u8, ll, "call i64 @kaappi_eval") == null);
+}
+
 // -- Begin --
 
 test "LLVM emit: begin sequence" {

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -344,8 +344,36 @@ test "LLVM emit: let over own params still compiles as a closed native closure" 
     var res = try emitSourceResult("(lambda (a) (let ((b a)) b))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectContains(ll, "@kaappi_create_native_closure");
+    try expectContains(ll, "call i64 @kaappi_create_native_closure");
     try std.testing.expect(std.mem.indexOf(u8, ll, "call i64 @kaappi_eval") == null);
+}
+
+// -- Enclosing bindings that shadow primitives (#1407 review) --
+// The shadow check must outrank isKnownGlobal: a param named `car` is a
+// capture, not the primitive. Before the fix these compiled as closed
+// closures whose reference degraded to a global lookup, silently returning
+// the builtin instead of the captured value.
+
+test "LLVM emit: param shadowing a primitive is captured as an upvalue" {
+    var res = try emitSourceResult("(define g0 (lambda (car) ((lambda () car))))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // Tier 1 must capture `car`: one upvalue, arity 0...
+    try expectContains(ll, "call i64 @kaappi_create_native_closure");
+    try expectContains(ll, ", i64 1, i64 0, ptr");
+    // ...read from the upvalue array, never interned for a global lookup.
+    try expectContains(ll, "ptr %upvalues, i64 0");
+    try std.testing.expect(std.mem.indexOf(u8, ll, "c\"car\"") == null);
+}
+
+test "LLVM emit: param shadowing a primitive is captured through a let" {
+    var res = try emitSourceResult("(define g0 (lambda (car) ((lambda () (let ((x car)) x)))))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "call i64 @kaappi_create_native_closure");
+    try expectContains(ll, ", i64 1, i64 0, ptr");
+    try expectContains(ll, "ptr %upvalues, i64 0");
+    try std.testing.expect(std.mem.indexOf(u8, ll, "c\"car\"") == null);
 }
 
 // -- Begin --


### PR DESCRIPTION
Fixes #1407.

## Problem

The closure tiers' free-variable analysis in `src/llvm_emit_lambda.zig` treated `.let_form`/`.let_star` IR nodes as opaque (`nodeHasFreeVars` returned false, `collectNodeFreeVars` was a no-op), so a lambda that captures an enclosing binding only through a `let` — `(lambda (a) (let ((b u)) b))` with `u` an enclosing param — compiled as a **closed** native closure. The hidden reference then degraded to `kaappi_global_lookup`: an "undefined variable" exit at runtime, or a silently wrong value when a same-named global existed. Found by the VM-vs-native differential harness (#1395/#1408) at ~1% of generated programs.

## Fix (the precise direction from the issue)

`let`/`let*` keep their contents as a raw S-expression (`ir.LetData.args`), so the new `FreeNameWalk` walks that raw form with proper binder scoping:

- let binders vs let* binders (parallel-let inits see only the enclosing scope; sequential inits see prior binders),
- nested `lambda` formals, including dotted rest and bare-symbol formals,
- `quote` skipped; every other symbol is a reference, with form keywords filtered by the same `ir.isKnownGlobal` rule the `.global_ref` arms use.

The walk feeds both `hasFreeVars` (tier 2 / `tryCompileDefineFunction`) and `collectFreeVars` (tier 1), so tier 1 now captures let-hidden references as upvalues — the emission side (`emitGlobalRef`) already resolved upvalues correctly, so the reproducer compiles natively rather than falling back.

When the walk meets something it cannot scope precisely (internal `define`, an eval-fallback form, malformed bindings, scope-stack or name-buffer overflow) it reports the analysis as inexact and the tiers reject, falling back to the interpreter instead of emitting with an incomplete capture set. The collectors' new `bool` return also closes a latent edge where the 17th distinct free name was silently dropped.

## Tests

- `src/tests_native.zig`: upvalue capture asserted for the let and let* reproducers (closure created with one upvalue, body reads `%upvalues`, captured name never interned for a global lookup); top-level lambda with a let-hidden free name falls back to `kaappi_eval` (correct there — the name is a genuine global reference); and an over-conservatism guard: a let over the lambda's own params still compiles as a closed native closure. The three #1407 tests fail without the fix.
- `zig build test`: 709/709.

## Verification

- Both issue reproducers now print `5` via `kaappi compile` (previously `undefined variable: u` exit 1, and silently `99`).
- 12 hand-written differential probes match the VM: parallel-let init scoping, binder shadowing, `set!` of params in let bodies, user globals through lets, variadic/bare-symbol lambdas in lets, quoted data, let under `when`.
- `bash tests/fuzz/native-diff.sh 500 100` (harness from #1408, run locally with this fix applied on that branch): **500 compared, 0 skipped, 0 divergent** — previously divergent at seeds 145, 172, 176, 219, 474. This should turn the nightly `native-diff` job green once #1408 lands.

## Out of scope

A sibling bug where the *nested-lambda* direction is still opaque (`(define g0 (lambda (u) ((lambda (a) (lambda (c) u)) 1)))` — no let involved) diverges both before and after this change; it needs tier 1 to capture from the enclosing closure's upvalues, not just its params. Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)