### PR TITLE
Return exact results from sqrt for rational and bignum perfect squares

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -492,6 +492,26 @@ fn sqrtFn(args: []const Value) PrimitiveError!Value {
         const i = i_sign * @sqrt((mag - c.real) / 2.0);
         return gc.allocComplex(r, i) catch return PrimitiveError.OutOfMemory;
     }
+    if (types.isBignum(args[0]) and !bignum_mod.isNegative(args[0])) {
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+        const r = try isqrtNonNegative(gc, args[0]);
+        if (bignum_mod.isZero(r.rem)) return r.root;
+    }
+    if (types.isRationalObj(args[0])) {
+        const rat = types.toRational(args[0]);
+        if (!bignum_mod.isNegative(rat.numerator)) {
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const num_r = try isqrtNonNegative(gc, rat.numerator);
+            if (bignum_mod.isZero(num_r.rem)) {
+                var slot_root = gc.rootedSlot(num_r.root) catch return PrimitiveError.OutOfMemory;
+                defer slot_root.release();
+                const den_r = try isqrtNonNegative(gc, rat.denominator);
+                if (bignum_mod.isZero(den_r.rem)) {
+                    return arith.makeRationalReduced(gc, num_r.root, den_r.root);
+                }
+            }
+        }
+    }
     const f = try toF64(args[0]);
     if (f < 0.0) {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
@@ -506,22 +526,23 @@ fn sqrtFn(args: []const Value) PrimitiveError!Value {
     return makeFlonumVal(result);
 }
 
-fn exactIntegerSqrt(args: []const Value) PrimitiveError!Value {
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    if (types.isFixnum(args[0])) {
-        const n = types.toFixnum(args[0]);
-        if (n < 0) return primitives.typeError("exact-integer-sqrt", "non-negative integer", args[0]);
+const IsqrtResult = struct { root: Value, rem: Value };
+
+/// Floor integer square root of a non-negative exact integer (fixnum or
+/// bignum). Returns the root and remainder n - root*root, demoted to fixnums
+/// when they fit. The results are unrooted: callers must root them before
+/// allocating.
+fn isqrtNonNegative(gc: *memory.GC, n_val: Value) PrimitiveError!IsqrtResult {
+    if (types.isFixnum(n_val)) {
+        const n = types.toFixnum(n_val);
         const f: f64 = @floatFromInt(n);
         var s: i64 = @intFromFloat(@sqrt(f));
         while (s * s > n) s -= 1;
         while ((s + 1) * (s + 1) <= n) s += 1;
-        const rem = n - s * s;
-        const vals = [_]Value{ types.makeFixnum(s), types.makeFixnum(rem) };
-        return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
+        return .{ .root = types.makeFixnum(s), .rem = types.makeFixnum(n - s * s) };
     }
-    if (types.isBignum(args[0])) {
-        if (bignum_mod.isNegative(args[0])) return primitives.typeError("exact-integer-sqrt", "non-negative integer", args[0]);
-        const n = args[0];
+    {
+        const n = n_val;
         // Use f64 sqrt as initial guess. When the number is too large
         // for f64, compute bit-length and use (n >> shift) for the
         // approximation, then shift the result back.
@@ -593,12 +614,25 @@ fn exactIntegerSqrt(args: []const Value) PrimitiveError!Value {
             s1_sq = bignum_mod.mul(gc, s1, s1) catch return PrimitiveError.OutOfMemory;
         }
         const rem = bignum_mod.sub(gc, n, s2) catch return PrimitiveError.OutOfMemory;
-        var slot_rem = gc.rootedSlot(rem) catch return PrimitiveError.OutOfMemory;
-        defer slot_rem.release();
-        const vals = [_]Value{ bignum_mod.demote(s), bignum_mod.demote(rem) };
-        return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
+        return .{ .root = bignum_mod.demote(s), .rem = bignum_mod.demote(rem) };
     }
-    return primitives.typeError("exact-integer-sqrt", "exact integer", args[0]);
+}
+
+fn exactIntegerSqrt(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (!types.isFixnum(args[0]) and !types.isBignum(args[0])) {
+        return primitives.typeError("exact-integer-sqrt", "exact integer", args[0]);
+    }
+    if (bignum_mod.isNegative(args[0])) {
+        return primitives.typeError("exact-integer-sqrt", "non-negative integer", args[0]);
+    }
+    const r = try isqrtNonNegative(gc, args[0]);
+    var slot_root = gc.rootedSlot(r.root) catch return PrimitiveError.OutOfMemory;
+    defer slot_root.release();
+    var slot_rem = gc.rootedSlot(r.rem) catch return PrimitiveError.OutOfMemory;
+    defer slot_rem.release();
+    const vals = [_]Value{ r.root, r.rem };
+    return gc.allocMultipleValues(&vals) catch return PrimitiveError.OutOfMemory;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -131,6 +131,22 @@ test "eval sqrt" {
     try std.testing.expectApproxEqAbs(@as(f64, 1.4142135623730951), types.toFlonum(r2), 1e-10);
 }
 
+test "sqrt exact rational and bignum perfect squares" {
+    // #1412: exact rationals whose numerator and denominator are both
+    // perfect squares return exact rationals, and bignum perfect squares
+    // return exact integer roots.
+    try th.expectEvalTrue("(let ((r (sqrt 9/4))) (and (exact? r) (= r 3/2)))");
+    try th.expectEvalTrue("(let ((r (sqrt 1/4))) (and (exact? r) (= r 1/2)))");
+    try th.expectEvalTrue("(let ((r (sqrt 16/9))) (and (exact? r) (= r 4/3)))");
+    try th.expectEvalTrue("(let ((r (sqrt (* 12345678901234567 12345678901234567)))) (and (exact? r) (= r 12345678901234567)))");
+    // Non-perfect squares stay inexact
+    try th.expectEvalTrue("(inexact? (sqrt 2/3))");
+    try th.expectEvalTrue("(inexact? (sqrt 9/2))");
+    try th.expectEvalTrue("(inexact? (sqrt 2/9))");
+    // exact-integer-sqrt still works through the shared helper
+    try th.expectEvalTrue("(call-with-values (lambda () (exact-integer-sqrt 17)) (lambda (s r) (and (= s 4) (= r 1))))");
+}
+
 test "eval expt" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/tests/scheme/compliance/sqrt-exact.scm
+++ b/tests/scheme/compliance/sqrt-exact.scm
@@ -1,0 +1,61 @@
+;; Regression tests for #1412: sqrt returns exact results for exact
+;; rational and bignum perfect squares (R7RS 6.2.6 encourages returning
+;; an exact result when the argument is exact and the root is exactly
+;; representable).
+(import (scheme base) (scheme complex) (scheme inexact)
+        (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "sqrt-exact")
+
+;; Exact integer perfect squares (pre-existing behavior)
+(test-equal "(sqrt 4)" 2 (sqrt 4))
+(test-assert "(sqrt 4) exact" (exact? (sqrt 4)))
+(test-equal "(sqrt 0)" 0 (sqrt 0))
+
+;; Exact rational perfect squares -> exact rationals
+(test-equal "(sqrt 9/4)" 3/2 (sqrt 9/4))
+(test-assert "(sqrt 9/4) exact" (exact? (sqrt 9/4)))
+(test-equal "(sqrt 1/4)" 1/2 (sqrt 1/4))
+(test-equal "(sqrt 16/9)" 4/3 (sqrt 16/9))
+(test-equal "(sqrt 100/49)" 10/7 (sqrt 100/49))
+
+;; Bignum perfect squares -> exact integer roots
+(define big 12345678901234567)  ; > 2^47, so (* big big) is a bignum
+(test-equal "bignum perfect square" big (sqrt (* big big)))
+(test-assert "bignum sqrt exact" (exact? (sqrt (* big big))))
+
+;; Rationals with bignum components
+(test-equal "bignum numerator" (/ big 2) (sqrt (/ (* big big) 4)))
+(test-equal "bignum denominator" (/ 3 big) (sqrt (/ 9 (* big big))))
+
+;; Non-perfect squares stay inexact
+(test-assert "(sqrt 2) inexact" (inexact? (sqrt 2)))
+(test-assert "(sqrt 2/3) inexact" (inexact? (sqrt 2/3)))
+(test-assert "(sqrt 9/2) inexact" (inexact? (sqrt 9/2)))   ; num square, den not
+(test-assert "(sqrt 2/9) inexact" (inexact? (sqrt 2/9)))   ; den square, num not
+(test-assert "bignum non-square inexact" (inexact? (sqrt (* big big big))))
+(test-approximate "(sqrt 9/2) value" 2.1213203435596424 (sqrt 9/2) 1e-9)
+
+;; Inexact arguments keep returning inexact results
+(test-assert "(sqrt 4.0) inexact" (inexact? (sqrt 4.0)))
+(test-equal "(sqrt 4.0)" 2.0 (sqrt 4.0))
+
+;; Negative exact rational -> complex (inexact) result, not an error
+(test-approximate "(sqrt -9/4) imag" 1.5 (imag-part (sqrt -9/4)) 1e-9)
+(test-approximate "(sqrt -9/4) real" 0.0 (real-part (sqrt -9/4)) 1e-9)
+
+;; exact-integer-sqrt still works through the shared helper
+(test-equal "(exact-integer-sqrt 17)" '(4 1)
+  (call-with-values (lambda () (exact-integer-sqrt 17)) list))
+(test-equal "(exact-integer-sqrt 0)" '(0 0)
+  (call-with-values (lambda () (exact-integer-sqrt 0)) list))
+(test-equal "exact-integer-sqrt bignum" (list big 0)
+  (call-with-values (lambda () (exact-integer-sqrt (* big big))) list))
+(test-equal "exact-integer-sqrt bignum remainder" (list big 1)
+  (call-with-values (lambda () (exact-integer-sqrt (+ (* big big) 1))) list))
+(test-assert "exact-integer-sqrt negative raises"
+  (guard (e (#t #t)) (exact-integer-sqrt -5) #f))
+
+(let ((runner (test-runner-current)))
+  (test-end "sqrt-exact")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #1412

## Problem

`(sqrt 9/4)` returned inexact `1.5` even though the exact result `3/2` is representable. Worse, bignum perfect squares went through f64 and could return a **wrong** answer, not merely an inexact one:

```scheme
(sqrt 9/4)                                    ; 1.5                  → now 3/2
(sqrt 1/4)                                    ; 0.5                  → now 1/2
(sqrt (* 12345678901234567 12345678901234567)) ; 12345678901234568.0 (off by one!) → now 12345678901234567
```

R7RS §6.2.6 encourages exact results for exact arguments when representable; Chez, Chibi, Gauche, and Guile all return `3/2` for `(sqrt 9/4)`.

## Change

- Extract the integer square root logic (fixnum fast path + bignum Newton iteration, previously inline in `exact-integer-sqrt`) into a shared `isqrtNonNegative` helper in `src/primitives_numeric.zig`. `exactIntegerSqrt` becomes a thin wrapper with the same type/negative error behavior.
- `sqrtFn` gains two exact paths before the inexact fallback:
  - non-negative exact **bignum** whose root has zero remainder → exact integer root
  - exact **rational** with non-negative numerator where numerator *and* denominator are perfect squares → exact rational root (via `makeRationalReduced`)
- Everything else is unchanged: mixed cases (`9/2`, `2/9`) stay inexact, negative exact values still produce an inexact complex result, inexact arguments stay inexact.

GC safety: the numerator's root is held in a `rootedSlot` across the denominator's isqrt (which allocates); `isqrtNonNegative` documents that its results are unrooted and `exactIntegerSqrt` roots them before `allocMultipleValues` (which runs `maybeCollect` before copying its slice).

## Tests

- `src/tests_numeric.zig`: new unit test covering exact rational/bignum roots, inexact fall-throughs, and `exact-integer-sqrt` through the shared helper.
- `tests/scheme/compliance/sqrt-exact.scm`: 27 SRFI-64 assertions (exact rationals, bignum-component rationals, non-perfect squares, negative rational → complex, inexact args, `exact-integer-sqrt` incl. bignum remainder and error cases), with the exit-on-fail epilogue.
- `zig build test` green; full Scheme suite green (428 files + R7RS: **1823 pass, 0 fail**).
- All 27 compliance assertions also pass under a `-Dgc-stress=true` build.

While stress-testing this I found a pre-existing, unrelated silent-corruption bug — bignum÷bignum division returns `1` under gc-stress — reproduced at `main` and filed as #1414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)