### PR TITLE
Exit non-zero on every kaappi compile / --emit-llvm failure

### DIFF
--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -150,8 +150,8 @@ bash tests/fuzz/native-diff.sh 300 1200   # 300 programs starting at seed 1200
 
 The script builds anything missing (`zig build`, `zig build lib`,
 `zig build fuzz-gen`), probes that `kaappi compile` can actually link here
-(it finds `zig cc` on PATH; the probe is needed because `kaappi compile`
-reports toolchain failures on stderr but exits 0), then runs the batch. Each
+(it finds `zig cc` on PATH; the probe checks that the output binary appears,
+not just the exit status), then runs the batch. Each
 input is a generate + interpret + compile-and-link + run cycle (~1 s,
 dominated by linking) — orders of magnitude slower than in-process fuzzing,
 which is why this is a scheduled batch and not a `std.testing.fuzz` target.

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -13,7 +13,12 @@ const writeStderr = reporting.writeStderr;
 
 pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;
-    const source = file_utils.readWholeFile(allocator, path, 1024 * 1024) catch return;
+    const source = file_utils.readWholeFile(allocator, path, 1024 * 1024) catch |err| {
+        var errbuf: [1088]u8 = undefined;
+        const s = std.fmt.bufPrint(&errbuf, "Error opening file '{s}'\n", .{path}) catch "Error opening file\n";
+        writeStderr(s);
+        return err;
+    };
     defer allocator.free(source);
 
     const saved_lib_dir = vm.current_lib_dir;
@@ -41,14 +46,14 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         var errbuf: [256]u8 = undefined;
         const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
         writeStderr(s);
-        return;
+        return err;
     }) {
         const expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
             writeStderr(s);
-            return;
+            return err;
         };
 
         if (types.isPair(expr)) {
@@ -81,10 +86,10 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
             var errbuf: [256]u8 = undefined;
             const s = std.fmt.bufPrint(&errbuf, "IR lowering error: {}\n", .{err}) catch "IR error\n";
             writeStderr(s);
-            return;
+            return err;
         };
 
-        ir_nodes.append(allocator, root) catch return;
+        try ir_nodes.append(allocator, root);
 
         // Record any define/set! target from this form so that the next
         // form's constant folding does not assume the primitive is unmodified.
@@ -97,15 +102,15 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         var errbuf: [256]u8 = undefined;
         const s = std.fmt.bufPrint(&errbuf, "LLVM emit error: {}\n", .{err}) catch "emit error\n";
         writeStderr(s);
-        return;
+        return err;
     };
 
     const out_path = output_path orelse blk: {
         if (std.mem.endsWith(u8, path, ".scm")) {
             const base = path[0 .. path.len - 4];
-            break :blk std.fmt.allocPrint(allocator, "{s}.ll", .{base}) catch return;
+            break :blk try std.fmt.allocPrint(allocator, "{s}.ll", .{base});
         }
-        break :blk std.fmt.allocPrint(allocator, "{s}.ll", .{path}) catch return;
+        break :blk try std.fmt.allocPrint(allocator, "{s}.ll", .{path});
     };
     const should_free = output_path == null;
     defer if (should_free) allocator.free(out_path);
@@ -114,9 +119,9 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         .ACCMODE = .WRONLY,
         .CREAT = true,
         .TRUNC = true,
-    }, 0o644) catch {
+    }, 0o644) catch |err| {
         writeStderr("Failed to create output file\n");
-        return;
+        return err;
     };
     defer _ = std.posix.system.close(fd);
     const data = emitter.toSlice();
@@ -125,7 +130,7 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         const result = std.posix.system.write(fd, data.ptr + total, data.len - total);
         if (result <= 0) {
             writeStderr("Failed to write output\n");
-            return;
+            return error.WriteFailed;
         }
         total += @as(usize, @intCast(result));
     }
@@ -141,11 +146,11 @@ pub fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8)
     const pid = std.c.getpid();
     var ll_buf: [64]u8 = undefined;
     var ll_w: std.Io.Writer = .fixed(&ll_buf);
-    ll_w.print("/tmp/kaappi_native_{d}.ll", .{pid}) catch return;
+    try ll_w.print("/tmp/kaappi_native_{d}.ll", .{pid});
     const ll_path = ll_w.buffered();
     ll_buf[ll_path.len] = 0;
-    emitLlvmFile(vm, path, ll_path) catch return;
     defer _ = std.posix.system.unlink(@ptrCast(ll_path.ptr));
+    try emitLlvmFile(vm, path, ll_path);
 
     const out_path = output_path orelse blk: {
         if (std.mem.endsWith(u8, path, ".scm")) {
@@ -156,22 +161,29 @@ pub fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8)
 
     const lib_dir = findLibDir(allocator) orelse {
         writeStderr("Cannot find libkaappi_rt.a. Build it with: zig build lib\n");
-        return;
+        return error.RuntimeLibraryNotFound;
     };
 
-    const lib_flag = std.fmt.allocPrint(allocator, "-L{s}", .{lib_dir}) catch return;
+    const lib_flag = try std.fmt.allocPrint(allocator, "-L{s}", .{lib_dir});
     defer allocator.free(lib_flag);
 
+    var found_compiler = false;
     const compilers = [_][]const u8{ "zig", "cc", "clang", "gcc" };
     for (compilers) |cc| {
         const cc_path = findInPath(allocator, cc) orelse continue;
         defer allocator.free(cc_path);
+        found_compiler = true;
         if (tryLink(allocator, cc_path, ll_path, out_path, lib_flag, std.mem.eql(u8, cc, "zig"))) {
             return;
         }
     }
 
+    if (found_compiler) {
+        writeStderr("Linking failed (see C compiler diagnostics above).\n");
+        return error.LinkFailed;
+    }
     writeStderr("No C compiler found. Install zig, clang, or gcc.\n");
+    return error.NoCCompilerFound;
 }
 
 fn findInPath(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {

--- a/tests/fuzz/native-diff.sh
+++ b/tests/fuzz/native-diff.sh
@@ -66,11 +66,12 @@ COMPILE_TIMEOUT="${TIMEOUT_BIN:+$TIMEOUT_BIN 60}"
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/native-diff.XXXXXX") || exit 1
 trap 'rm -rf "$WORK"' EXIT
 
-# Fail fast when the native toolchain is unavailable: `kaappi compile`
-# reports link/toolchain errors on stderr but still exits 0, so probe with a
-# trivial program and check that the output binary actually appears. The
-# probe also warms the linker's compiler-rt cache, so per-seed compiles fit
-# the tighter COMPILE_TIMEOUT; its own budget is generous for a cold cache.
+# Fail fast when the native toolchain is unavailable: probe with a trivial
+# program and check that the output binary actually appears (`kaappi compile`
+# exits non-zero on link/toolchain errors, but the binary check also guards
+# against a compile that lies about success). The probe also warms the
+# linker's compiler-rt cache, so per-seed compiles fit the tighter
+# COMPILE_TIMEOUT; its own budget is generous for a cold cache.
 printf '(write 42)\n(newline)\n' > "$WORK/probe.scm"
 ${TIMEOUT_BIN:+$TIMEOUT_BIN 300} "$KAAPPI" compile "$WORK/probe.scm" -o "$WORK/probe.bin" > "$WORK/probe.log" 2>&1
 if [ ! -x "$WORK/probe.bin" ]; then

--- a/tests/scheme/errors/exit-code.sh
+++ b/tests/scheme/errors/exit-code.sh
@@ -113,6 +113,47 @@ assert_exit_code "--compile read error exits 1" 1 "$KAAPPI" --compile "$TMPDIR_T
 assert_exit_code "--compile missing file exits 1" 1 "$KAAPPI" --compile "$TMPDIR_TESTS/nope.scm"
 assert_exit_code "--disassemble read error exits 1" 1 "$KAAPPI" --disassemble "$TMPDIR_TESTS/unbal.scm"
 
+# Native-compile subcommand failures must also exit non-zero. A missing
+# libkaappi_rt.a used to print an error but exit 0 with no output binary,
+# so exit-code-checking harnesses (e.g. tests/fuzz/native-diff.sh) saw
+# success. Source-level failures share the --emit-llvm path.
+assert_exit_code "compile missing file exits 1" 1 "$KAAPPI" compile "$TMPDIR_TESTS/nope.scm" -o "$TMPDIR_TESTS/nat-out"
+assert_exit_code "compile read error exits 1" 1 "$KAAPPI" compile "$TMPDIR_TESTS/unbal.scm" -o "$TMPDIR_TESTS/nat-out"
+assert_exit_code "--emit-llvm missing file exits 1" 1 "$KAAPPI" --emit-llvm "$TMPDIR_TESTS/nope.scm"
+assert_exit_code "--emit-llvm read error exits 1" 1 "$KAAPPI" --emit-llvm "$TMPDIR_TESTS/unbal.scm"
+
+# Missing runtime library: run an isolated copy of the binary from a bare
+# directory so the exe-relative and cwd-relative libkaappi_rt.a lookups all
+# miss. Skipped when a system-wide runtime is installed (last fallback).
+if [[ -f /usr/local/lib/libkaappi_rt.a ]]; then
+    echo "SKIP: compile without libkaappi_rt.a exits 1 (system-wide runtime installed)"
+else
+    mkdir -p "$TMPDIR_TESTS/isobin"
+    cp "$KAAPPI" "$TMPDIR_TESTS/isobin/kaappi"
+    status=0
+    (cd "$TMPDIR_TESTS" && env -u KAAPPI_LIB_DIR ./isobin/kaappi compile ok.scm -o nat-out) > /dev/null 2>&1 || status=$?
+    if [[ "$status" -eq 1 ]]; then
+        echo "PASS: compile without libkaappi_rt.a exits 1"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: compile without libkaappi_rt.a — expected exit 1, got $status"
+        FAIL=$((FAIL + 1))
+    fi
+fi
+
+# Missing C compiler / failing linker: a dummy libkaappi_rt.a satisfies the
+# library lookup, and PATH controls what compiler the link step can find.
+mkdir -p "$TMPDIR_TESTS/fakelib" "$TMPDIR_TESTS/emptypath" "$TMPDIR_TESTS/fakecc"
+touch "$TMPDIR_TESTS/fakelib/libkaappi_rt.a"
+printf '#!/bin/sh\nexit 1\n' > "$TMPDIR_TESTS/fakecc/cc"
+chmod +x "$TMPDIR_TESTS/fakecc/cc"
+assert_exit_code "compile without C compiler exits 1" 1 \
+    env KAAPPI_LIB_DIR="$TMPDIR_TESTS/fakelib" PATH="$TMPDIR_TESTS/emptypath" \
+    "$KAAPPI" compile "$TMPDIR_TESTS/ok.scm" -o "$TMPDIR_TESTS/nat-out"
+assert_exit_code "compile with failing linker exits 1" 1 \
+    env KAAPPI_LIB_DIR="$TMPDIR_TESTS/fakelib" PATH="$TMPDIR_TESTS/fakecc" \
+    "$KAAPPI" compile "$TMPDIR_TESTS/ok.scm" -o "$TMPDIR_TESTS/nat-out"
+
 # Passing a directory must error, not silently run an empty program (#789)
 mkdir -p "$TMPDIR_TESTS/adir"
 assert_exit_code "directory as script exits 1" 1 "$KAAPPI" "$TMPDIR_TESTS/adir"


### PR DESCRIPTION
## Problem

`kaappi compile file.scm -o out` printed "Cannot find libkaappi_rt.a. Build it with: zig build lib" when the runtime static library was missing — but still **exited 0** and produced no output binary. The same held for every other failure in the native-compile pipeline (no C compiler on PATH, linker failure, unreadable input, LLVM emit errors), so exit-code-checking callers such as CI scripts and the `tests/fuzz/native-diff.sh` differential harness treated failures as success. A missing input file was worse still: silent, no message at all.

## Fix

`mainInner` already maps any error propagated out of `mainImpl` to exit code 1, and both call sites already used `try` — the errors just never left `native_compiler.zig`:

- **`compileNative`**: missing `libkaappi_rt.a` → `error.RuntimeLibraryNotFound`; no compiler found → `error.NoCCompilerFound`; all link attempts failed → `error.LinkFailed`. When a compiler *was* found but linking failed, it now prints "Linking failed (see C compiler diagnostics above)" instead of the misleading "No C compiler found". The temp `.ll` cleanup `defer` now also runs on failure.
- **`emitLlvmFile`** (shared by `kaappi compile` and `--emit-llvm`): missing input (now prints `Error opening file '<path>'` instead of nothing), read errors, IR lowering errors, LLVM emit errors, and output create/write failures all propagate.

Stale comments documenting the old exit-0 behavior in `tests/fuzz/native-diff.sh` and `docs/dev/fuzzing.md` are updated; the probe's binary-existence check stays as a belt-and-suspenders guard.

## Tests

Seven new hermetic assertions in `tests/scheme/errors/exit-code.sh`:

- `compile` / `--emit-llvm` on a missing file and on a file with a read error
- missing runtime library: runs an isolated copy of the binary from a bare directory so the exe-relative and cwd-relative lookups all miss (skipped if a system-wide `/usr/local/lib/libkaappi_rt.a` exists)
- missing C compiler: dummy `libkaappi_rt.a` satisfies the lib lookup, PATH points at an empty directory
- failing linker: PATH contains only a stub `cc` that exits 1, so no real toolchain run is needed

All seven fail with "expected exit 1, got 0" against a pre-fix build and pass after the fix (48/48 in the suite). `zig build test` and all nine `tests/scheme/compile/*.sh` native-compile suites (success paths) still pass; a real `kaappi compile` still exits 0 and produces a working binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)