### PR TITLE
Chain nested-lambda captures in the native closure tiers (#1410)

### DIFF
--- a/src/fuzz_gen_native.zig
+++ b/src/fuzz_gen_native.zig
@@ -33,9 +33,11 @@
 //! - No lambda expressions inside let forms: emitLet falls back to eval
 //!   when a body lambda captures a let binding (#827), so the generator
 //!   avoids lambdas there entirely. Inline lambdas may capture enclosing
-//!   FUNCTION parameters (native closure upvalues), but only one level —
-//!   an inner lambda referencing an outer-outer parameter would fall back
-//!   to emitLambdaViaEval, which leaks parameters as globals.
+//!   FUNCTION parameters (native closure upvalues). Since #1410 the backend
+//!   chains captures through nested closures (an inner lambda can reach an
+//!   outer-outer parameter via the enclosing closure's upvalues), but this
+//!   generator still emits only one capture level — extending it to chained
+//!   captures would sharpen the oracle.
 //! - Variadic lambdas compile natively only with at least one fixed
 //!   parameter (`(lambda (a . rest) ...)`) and only in define position.
 //! - Cross-function calls appear only in top-level expressions and let
@@ -421,7 +423,9 @@ fn genInt(g: *Gen, ctx: *Ctx, depth_in: u32) Error!void {
             try g.emit("((lambda (");
             // At top level the body must be closed over its own params (pure
             // tier); inside a function body it may also capture that
-            // function's int parameters (upvalue tier) — one level only.
+            // function's int parameters (upvalue tier) — this generator
+            // emits one capture level (see the header comment; the backend
+            // itself chains deeper since #1410).
             var saved = try enterBody(g, ctx.fn_depth > 0);
             for (params, 0..) |p, i| {
                 if (i > 0) try g.emit(" ");

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -398,6 +398,10 @@ pub const LLVMEmitter = struct {
     }
 
     fn emitLetFallback(self: *LLVMEmitter, args: Value, sequential: bool) EmitError![]const u8 {
+        // The let form is about to be evaluated in the global environment;
+        // bind the enclosing frame's params/rest/upvalues as globals first
+        // or references to them inside the form come up undefined (#1410).
+        try lambda.bindParamsAsGlobals(self);
         const keyword = if (sequential) "let*" else "let";
         // Build `(let bindings body ...)` by iterating the args list elements.
         // The args value is `(bindings body ...)` — a list whose elements must
@@ -420,6 +424,18 @@ pub const LLVMEmitter = struct {
         const tmp = try self.freshTemp();
         try self.print("  {s} = call i64 @kaappi_eval(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, source_buf.items.len });
         return tmp;
+    }
+
+    // Abandon a partially emitted native let and compile the whole form via
+    // the interpreter instead. Pops the GC roots already pushed for emitted
+    // bindings (the natively computed values are dead once the interpreter
+    // re-evaluates the form; leaving their roots pushed would leak stack
+    // slots into the GC root set on every execution of this code path).
+    fn abandonLetForFallback(self: *LLVMEmitter, args: Value, sequential: bool, saved_locals: ?std.StringHashMap([]const u8), roots_pushed: usize) EmitError![]const u8 {
+        try self.emitPopRoots(roots_pushed);
+        self.locals.?.deinit();
+        self.locals = saved_locals;
+        return self.emitLetFallback(args, sequential);
     }
 
     fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool) EmitError![]const u8 {
@@ -468,27 +484,26 @@ pub const LLVMEmitter = struct {
             var blist = bindings;
             while (blist != types.NIL and types.isPair(blist)) {
                 if (count >= 32) {
-                    self.locals.?.deinit();
-                    self.locals = saved_locals;
-                    return self.emitLetFallback(args, sequential);
+                    return self.abandonLetForFallback(args, sequential, saved_locals, count);
                 }
                 const binding = types.car(blist);
                 const var_sym = types.car(binding);
                 const init_expr = types.car(types.cdr(binding));
                 if (!types.isSymbol(var_sym)) {
-                    self.locals.?.deinit();
-                    self.locals = saved_locals;
-                    return self.emitLetFallback(args, sequential);
+                    return self.abandonLetForFallback(args, sequential, saved_locals, count);
                 }
 
                 const node = ir.lowerSingleExpr(self.allocator(), init_expr) catch {
-                    self.locals.?.deinit();
-                    self.locals = saved_locals;
-                    return self.emitLetFallback(args, sequential);
+                    return self.abandonLetForFallback(args, sequential, saved_locals, count);
                 };
                 const alloca = try self.freshTemp();
                 try self.print("  {s} = alloca i64, align 8\n", .{alloca});
-                const val = try self.emitNode(node);
+                // #827: an init that cannot be emitted in this lexical scope
+                // (e.g. a lambda) sends the whole let to the interpreter,
+                // like the body path below.
+                const val = self.emitNode(node) catch {
+                    return self.abandonLetForFallback(args, sequential, saved_locals, count);
+                };
                 try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
                 try self.emitRootPushAlloca(alloca);
 
@@ -509,17 +524,15 @@ pub const LLVMEmitter = struct {
                 const var_sym = types.car(binding);
                 const init_expr = types.car(types.cdr(binding));
                 if (!types.isSymbol(var_sym)) {
-                    self.locals.?.deinit();
-                    self.locals = saved_locals;
-                    return self.emitLetFallback(args, sequential);
+                    return self.abandonLetForFallback(args, sequential, saved_locals, binding_root_count);
                 }
 
                 const node = ir.lowerSingleExpr(self.allocator(), init_expr) catch {
-                    self.locals.?.deinit();
-                    self.locals = saved_locals;
-                    return self.emitLetFallback(args, sequential);
+                    return self.abandonLetForFallback(args, sequential, saved_locals, binding_root_count);
                 };
-                const val = try self.emitNode(node);
+                const val = self.emitNode(node) catch {
+                    return self.abandonLetForFallback(args, sequential, saved_locals, binding_root_count);
+                };
                 const alloca = try self.freshTemp();
                 try self.print("  {s} = alloca i64, align 8\n", .{alloca});
                 try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
@@ -536,17 +549,13 @@ pub const LLVMEmitter = struct {
             const rest = types.cdr(body_expr);
             const expr_is_tail = is_tail and (rest == types.NIL or !types.isPair(rest));
             const node = ir.lowerSingleExprTail(self.allocator(), types.car(body_expr), expr_is_tail) catch {
-                self.locals.?.deinit();
-                self.locals = saved_locals;
-                return self.emitLetFallback(args, sequential);
+                return self.abandonLetForFallback(args, sequential, saved_locals, binding_root_count);
             };
             // #827: if emitNode fails (e.g. a lambda that cannot be eval'd in
             // this lexical scope), fall back to evaluating the entire let form
             // via the interpreter.
             last = self.emitNode(node) catch {
-                self.locals.?.deinit();
-                self.locals = saved_locals;
-                return self.emitLetFallback(args, sequential);
+                return self.abandonLetForFallback(args, sequential, saved_locals, binding_root_count);
             };
             body_expr = rest;
         }

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -143,18 +143,21 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     if (free_count == 0) return null;
 
     const outer_params = self.params orelse return null;
+    const outer_upvalues = self.upvalues;
     for (free_vars[0..free_count]) |fv| {
-        // Captures are copied out of the enclosing %args array, so a name
-        // bound by an enclosing let-local or rest parameter (which outrank
-        // params in emitGlobalRef's resolution order) cannot be captured
-        // here, and neither can a name living only in the enclosing
-        // closure's upvalue array (#1410).
+        // Captures are copied out of the enclosing frame at closure-creation
+        // time: params from its %args, and — when this lambda sits inside
+        // another native closure — chained captures from that closure's own
+        // %upvalues array (#1410). A name bound by an enclosing let-local or
+        // rest parameter (which outrank params in emitGlobalRef's resolution
+        // order) has no capturable slot, and any other name is unknown here;
+        // reject those and let the eval fallback handle the lambda.
         if (localsOrRestShadows(self, fv)) return null;
         if (outer_params.contains(fv)) continue;
-        if (self.upvalues) |uv| {
-            if (uv.contains(fv)) return null;
+        if (outer_upvalues) |uv| {
+            if (uv.contains(fv)) continue;
         }
-        if (!ir.isKnownGlobal(fv)) return null;
+        return null;
     }
 
     const id = self.lambda_counter;
@@ -172,6 +175,12 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
         self.current_fn_name = null;
         self.body_label = null;
         self.current_block = "entry";
+        // The enclosing function's let-locals and rest parameter are not in
+        // scope inside this closure's body; leaking them would misresolve
+        // names against the wrong frame's allocas.
+        self.locals = null;
+        self.rest_param_name = null;
+        self.rest_param_alloca = null;
 
         var p = std.StringHashMap(u8).init(self.backing_alloc);
         defer p.deinit();
@@ -179,12 +188,13 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
             p.put(pname, @intCast(i)) catch return null;
         }
 
+        // Every collected free variable passed the capture check above, so
+        // each one has a slot in the upvalue array this closure is created
+        // with (params-sourced and chained captures alike).
         var uv_map = std.StringHashMap(u8).init(self.backing_alloc);
         defer uv_map.deinit();
         for (free_vars[0..free_count], 0..) |fv, i| {
-            if (outer_params.contains(fv)) {
-                uv_map.put(fv, @intCast(i)) catch return null;
-            }
+            uv_map.put(fv, @intCast(i)) catch return null;
         }
         self.params = p;
         self.upvalues = uv_map;
@@ -209,15 +219,26 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     const uv_alloca = self.freshTemp() catch return null;
     self.print("  {s} = alloca [{d} x i64], align 8\n", .{ uv_alloca, free_count }) catch return null;
     for (free_vars[0..free_count], 0..) |fv, i| {
-        if (outer_params.get(fv)) |idx| {
+        const val = blk: {
+            if (outer_params.get(fv)) |idx| {
+                const gep_src = self.freshTemp() catch return null;
+                self.print("  {s} = getelementptr i64, ptr %args, i64 {d}\n", .{ gep_src, idx }) catch return null;
+                const v = self.freshTemp() catch return null;
+                self.print("  {s} = load i64, ptr {s}\n", .{ v, gep_src }) catch return null;
+                break :blk v;
+            }
+            // Chained capture (#1410): the value lives in the enclosing
+            // closure's own upvalue array, not in its %args.
+            const idx = outer_upvalues.?.get(fv).?;
             const gep_src = self.freshTemp() catch return null;
-            self.print("  {s} = getelementptr i64, ptr %args, i64 {d}\n", .{ gep_src, idx }) catch return null;
-            const val = self.freshTemp() catch return null;
-            self.print("  {s} = load i64, ptr {s}\n", .{ val, gep_src }) catch return null;
-            const gep_dst = self.freshTemp() catch return null;
-            self.print("  {s} = getelementptr i64, ptr {s}, i64 {d}\n", .{ gep_dst, uv_alloca, i }) catch return null;
-            self.print("  store i64 {s}, ptr {s}\n", .{ val, gep_dst }) catch return null;
-        }
+            self.print("  {s} = getelementptr i64, ptr %upvalues, i64 {d}\n", .{ gep_src, idx }) catch return null;
+            const v = self.freshTemp() catch return null;
+            self.print("  {s} = load i64, ptr {s}\n", .{ v, gep_src }) catch return null;
+            break :blk v;
+        };
+        const gep_dst = self.freshTemp() catch return null;
+        self.print("  {s} = getelementptr i64, ptr {s}, i64 {d}\n", .{ gep_dst, uv_alloca, i }) catch return null;
+        self.print("  store i64 {s}, ptr {s}\n", .{ val, gep_dst }) catch return null;
     }
 
     const name_str = self.internString(closure_name) catch return null;
@@ -226,6 +247,11 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     return result;
 }
 
+// Bind every name reachable in the current native frame — fixed params, the
+// rest parameter, and captured upvalues — as globals, so a form that falls
+// back to kaappi_eval (which runs in the global environment) still resolves
+// them. Leaving any of them out surfaces as "undefined variable" (or a
+// silently wrong value when a same-named global exists) at run time (#1410).
 pub fn bindParamsAsGlobals(self: *LLVMEmitter) EmitError!void {
     if (self.params) |p| {
         var iter = p.iterator();
@@ -238,6 +264,27 @@ pub fn bindParamsAsGlobals(self: *LLVMEmitter) EmitError!void {
             const val = try self.freshTemp();
             try self.print("  {s} = load i64, ptr {s}\n", .{ val, gep });
             try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym, pname.len, val });
+        }
+    }
+    if (self.rest_param_name) |rp| {
+        if (self.rest_param_alloca) |alloca| {
+            const sym = try self.internSymbol(rp);
+            const val = try self.freshTemp();
+            try self.print("  {s} = load i64, ptr {s}\n", .{ val, alloca });
+            try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym, rp.len, val });
+        }
+    }
+    if (self.upvalues) |uv| {
+        var iter = uv.iterator();
+        while (iter.next()) |entry| {
+            const uname = entry.key_ptr.*;
+            const idx = entry.value_ptr.*;
+            const sym = try self.internSymbol(uname);
+            const gep = try self.freshTemp();
+            try self.print("  {s} = getelementptr i64, ptr %upvalues, i64 {d}\n", .{ gep, idx });
+            const val = try self.freshTemp();
+            try self.print("  {s} = load i64, ptr {s}\n", .{ val, gep });
+            try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym, uname.len, val });
         }
     }
 }
@@ -370,6 +417,10 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         self.tmp_counter = 0;
         self.label_counter = 0;
         self.locals = null;
+        // This function is closed — it receives null for %upvalues at run
+        // time — so an upvalue map inherited from the enclosing emission
+        // scope must not leak into body emission or bindParamsAsGlobals.
+        self.upvalues = null;
 
         var p = std.StringHashMap(u8).init(self.backing_alloc);
         defer p.deinit();
@@ -384,6 +435,7 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         self.body_label = if (rest_name == null) body_lbl else null;
         self.current_block = body_lbl;
         self.rest_param_name = rest_name;
+        self.rest_param_alloca = null;
 
         const header = std.fmt.allocPrint(self.allocator(), "; {s}\ndefine i64 {s}(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) {{\nentry:\n  br label %{s}\n{s}:\n", .{ name orelse "(lambda)", fn_name, body_lbl, body_lbl }) catch return null;
         defer self.allocator().free(header);
@@ -673,12 +725,14 @@ fn nodeHasFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []c
         // global. Disqualify and fall back to the interpreter.
         .define => return true,
         .constant => return false,
-        // let/let* keep their contents as a raw S-expression, so references
-        // hidden inside them are invisible to the node-level cases above.
-        // Walk the raw form with proper binder scoping (#1407).
+        // let/let* and nested lambdas keep their contents as a raw
+        // S-expression, so references hidden inside them are invisible to
+        // the node-level cases above. Walk the raw forms with proper binder
+        // scoping (#1407, #1410).
         .let_form => return letSexprHasFreeVars(self, node.data.let_form.args, false, params),
         .let_star => return letSexprHasFreeVars(self, node.data.let_star.args, true, params),
-        .lambda, .passthrough, .sexpr_form => return false,
+        .lambda => return lambdaSexprHasFreeVars(self, node.data.lambda.args, params),
+        .passthrough, .sexpr_form => return false,
         .letrec, .letrec_star => return false,
     }
 }
@@ -757,23 +811,26 @@ fn collectNodeFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const
             if (!collectNodeFreeVars(self, node.data.unless_form.test_expr, params, buf, count)) return false;
             return collectFreeVars(self, node.data.unless_form.body, params, buf, count);
         },
-        // See nodeHasFreeVars: let/let* contents are a raw S-expression and
-        // must be walked with binder scoping, or captures hidden inside them
-        // are silently compiled as global lookups (#1407).
+        // See nodeHasFreeVars: let/let* and nested lambda contents are raw
+        // S-expressions and must be walked with binder scoping, or captures
+        // hidden inside them are silently compiled as global lookups
+        // (#1407, #1410).
         .let_form => return collectLetSexprFreeVars(self, node.data.let_form.args, false, params, buf, count),
         .let_star => return collectLetSexprFreeVars(self, node.data.let_star.args, true, params, buf, count),
-        .constant, .define, .set_form, .lambda, .passthrough, .sexpr_form => return true,
+        .lambda => return collectLambdaSexprFreeVars(self, node.data.lambda.args, params, buf, count),
+        .constant, .define, .set_form, .passthrough, .sexpr_form => return true,
         .letrec, .letrec_star => return true,
     }
 }
 
-// --- Scope-aware free-name walk over raw let/let* forms (#1407) ---
+// --- Scope-aware free-name walk over raw let/let*/lambda forms (#1407, #1410) ---
 //
-// The IR keeps let/let* contents as a raw S-expression (ir.LetData.args), so
-// the node-level free-variable analysis cannot see references inside them.
-// This walk descends into the raw form tracking binder scopes (let binders,
-// nested lambda formals) and reports every referenced name that is neither
-// bound nor a known global — the same rule the .global_ref arms apply.
+// The IR keeps let/let* contents (ir.LetData.args) and lambda contents
+// (ir.LambdaData.args) as raw S-expressions, so the node-level free-variable
+// analysis cannot see references inside them. This walk descends into the
+// raw form tracking binder scopes (let binders, nested lambda formals) and
+// reports every referenced name that is neither bound nor a known global —
+// the same rule the .global_ref arms apply.
 // `inexact` is set when the walk meets something it cannot scope precisely
 // (internal define, an eval-fallback form, malformed bindings, overflow);
 // callers must then treat the analysis as failed and refuse to compile the
@@ -834,6 +891,20 @@ fn letSexprHasFreeVars(self: *LLVMEmitter, args: Value, sequential: bool, params
 fn collectLetSexprFreeVars(self: *LLVMEmitter, args: Value, sequential: bool, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
     var w = FreeNameWalk{ .emitter = self, .params = params, .buf = buf, .count = count };
     walkLetSexpr(&w, args, sequential);
+    return !w.inexact;
+}
+
+// args is the raw `(formals body ...)` tail of a nested lambda IR node
+// (ir.LambdaData.args), the same shape walkLambdaSexpr consumes.
+fn lambdaSexprHasFreeVars(self: *LLVMEmitter, args: Value, params: []const []const u8) bool {
+    var w = FreeNameWalk{ .emitter = self, .params = params };
+    walkLambdaSexpr(&w, args);
+    return w.found or w.inexact;
+}
+
+fn collectLambdaSexprFreeVars(self: *LLVMEmitter, args: Value, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
+    var w = FreeNameWalk{ .emitter = self, .params = params, .buf = buf, .count = count };
+    walkLambdaSexpr(&w, args);
     return !w.inexact;
 }
 

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -376,6 +376,105 @@ test "LLVM emit: param shadowing a primitive is captured through a let" {
     try std.testing.expect(std.mem.indexOf(u8, ll, "c\"car\"") == null);
 }
 
+// -- Free variables hidden inside nested lambdas (#1410) --
+// The closure tiers' free-variable analysis must also descend into nested
+// .lambda IR nodes, and tier 1 must be able to chain a capture from the
+// enclosing closure's %upvalues (not just its %args). Before the fix, a
+// lambda whose only reference to an enclosing binding lived inside an inner
+// lambda compiled as a *closed* closure and the inner lambda's eval fallback
+// resolved the name globally: "undefined variable" at runtime.
+
+test "LLVM emit: capture through a nested lambda chains upvalues natively (#1410)" {
+    var res = try emitSourceResult("(define g0 (lambda (u) ((lambda (a) (lambda (c) u)) 1)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // Both the middle and the inner lambda become capturing native closures
+    // (one upvalue, arity 1 each): the middle copies u from g0's %args, the
+    // inner chains it out of the middle closure's %upvalues.
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_"));
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, ", i64 1, i64 1, ptr"));
+    try expectContains(ll, "getelementptr i64, ptr %upvalues, i64 0");
+    // u must never degrade to a global lookup / interned symbol...
+    try std.testing.expect(std.mem.indexOf(u8, ll, "c\"u\"") == null);
+    // ...and nothing may fall back to eval beyond the define-time binding.
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_eval("));
+}
+
+test "LLVM emit: depth-3 nested capture chains through every closure level (#1410)" {
+    var res = try emitSourceResult("(define g0 (lambda (u) (lambda (a) (lambda (b) (lambda (c) u)))))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expectEqual(@as(usize, 3), std.mem.count(u8, ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_"));
+    try std.testing.expect(std.mem.indexOf(u8, ll, "c\"u\"") == null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_eval("));
+}
+
+test "LLVM emit: capture through a let-wrapped nested lambda chains natively (#1410)" {
+    var res = try emitSourceResult("(define g0 (lambda (u) ((lambda (a) (let ((b 1)) (lambda (c) u))) 1)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_"));
+    try std.testing.expect(std.mem.indexOf(u8, ll, "c\"u\"") == null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_eval("));
+}
+
+test "LLVM emit: eval fallback inside a native closure republishes upvalues (#1410)" {
+    // The variadic inner lambda can never be a native closure (no tier
+    // accepts a rest parameter), so it falls back to eval inside the middle
+    // closure — and the fallback must first bind the captured u as a global.
+    var res = try emitSourceResult("(define g0 (lambda (u) ((lambda (a) (lambda (c . r) u)) 1)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_"));
+    try expectContains(ll, "c\"u\"");
+    try expectContains(ll, "@kaappi_define_global");
+    try expectContains(ll, "getelementptr i64, ptr %upvalues, i64 0");
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "call i64 @kaappi_eval("));
+}
+
+test "LLVM emit: eval fallback republishes the enclosing rest parameter (#1410)" {
+    // The inner lambda captures the rest list, which no closure tier can
+    // express; its eval fallback must bind xs (loaded from the rest-list
+    // alloca) as a global, not just the fixed params.
+    var res = try emitSourceResult("(define f (lambda (u . xs) (lambda (c) xs)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "c\"xs\"");
+    try expectContains(ll, "@kaappi_define_global");
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "call i64 @kaappi_eval("));
+}
+
+test "LLVM emit: let eval fallback republishes enclosing params (#1410)" {
+    // bodyHasCapturingLambda (#827) sends this let to the interpreter; the
+    // fallback must bind u first or the binding init comes up undefined.
+    var res = try emitSourceResult("(define (f u) (let ((b u)) (lambda (c) b)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "c\"u\"");
+    try expectContains(ll, "@kaappi_define_global");
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "call i64 @kaappi_eval("));
+}
+
+test "LLVM emit: lambda in a let binding init falls back instead of aborting (#1410)" {
+    // Before the fix the init's emission error propagated out of emitLet and
+    // aborted the whole native compilation (emitSourceResult here failed).
+    var res = try emitSourceResult("(let ((b (lambda (c) glob))) (b 0))");
+    defer res.deinit();
+    try expectContains(res.toSlice(), "call i64 @kaappi_eval");
+}
+
+test "LLVM emit: abandoned native let pops the binding roots it pushed (#1410)" {
+    // 17 params exceed the closure tiers' 16-param cap, so the let body's
+    // lambda fails emission after the binding for b was emitted and rooted;
+    // the fallback path must pop that root or every execution of the
+    // enclosing function leaks a GC root slot.
+    var res = try emitSourceResult("(define (f u) (let ((b 1)) (lambda (p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17) p1)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "call void @kaappi_gc_push_root(");
+    try expectContains(ll, "call void @kaappi_gc_pop_roots(i64 1)");
+}
+
 // -- Begin --
 
 test "LLVM emit: begin sequence" {

--- a/tests/scheme/compile/native-nested-closure-1410.sh
+++ b/tests/scheme/compile/native-nested-closure-1410.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Regression test for #1410 (LLVM native backend): the closure tiers' free-
+# variable analysis treated nested .lambda IR nodes as opaque, so a lambda
+# whose only reference to an enclosing binding lived inside an inner lambda
+# compiled as a *closed* native closure, and the inner lambda's eval fallback
+# resolved the captured name as an (undefined) global at run time.
+#
+# The fix has three parts, each covered below:
+#   1. the analysis descends into nested lambda bodies,
+#   2. tier 1 chains captures from the enclosing closure's %upvalues,
+#   3. every eval-fallback boundary (emitLambdaViaEval, emitFormEval,
+#      emitLetFallback) republishes the full frame — params, the rest
+#      parameter, and upvalues — as globals first, and an abandoned native
+#      let pops the GC roots it had pushed.
+#
+# Usage: bash tests/scheme/compile/native-nested-closure-1410.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# The native backend needs libkaappi_rt.a; build it once.
+(cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+check_native() {
+    local label="$1" expected="$2"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — native compile did not produce a binary" >&2
+        exit 1
+    fi
+    local out
+    if ! out="$("$bin")"; then
+        echo "FAIL: $label — binary exited nonzero (output: '$out')" >&2
+        exit 1
+    fi
+    if [[ "$out" != "$expected" ]]; then
+        echo "FAIL: $label — expected '$expected', got '$out'" >&2
+        exit 1
+    fi
+}
+
+# 1. The issue's reproducer: capture reaches u only through an inner lambda.
+cat > "$DIR/nested.scm" << 'SCHEME'
+(define g0 (lambda (u) ((lambda (a) (lambda (c) u)) 1)))
+(write ((g0 5) 0))
+(newline)
+SCHEME
+check_native "nested" "5"
+
+# 2. The let-wrapped variant from the issue.
+cat > "$DIR/nested-let.scm" << 'SCHEME'
+(define g0 (lambda (u) ((lambda (a) (let ((b 1)) (lambda (c) u))) 1)))
+(write ((g0 5) 0))
+(newline)
+SCHEME
+check_native "nested-let" "5"
+
+# 3. Chained captures are per-instance copies: closures made by separate
+#    calls must not alias (this is what distinguishes real upvalue chaining
+#    from the bind-as-global eval fallback).
+cat > "$DIR/retention.scm" << 'SCHEME'
+(define g0 (lambda (u) ((lambda (a) (lambda (c) u)) 1)))
+(define f5 (g0 5))
+(define f7 (g0 7))
+(write (f5 0)) (newline)
+(write (f7 0)) (newline)
+(define g1 (lambda (u) (lambda (a) (lambda (b) (lambda (c) u)))))
+(define h3 (((g1 3) 1) 2))
+(define h9 (((g1 9) 1) 2))
+(write (h3 0)) (newline)
+(write (h9 0)) (newline)
+SCHEME
+check_native "retention" "$(printf '5\n7\n3\n9')"
+
+# 4. A variadic inner lambda can never be a native closure; its eval
+#    fallback must republish the captured upvalue u.
+cat > "$DIR/variadic-inner.scm" << 'SCHEME'
+(define g0 (lambda (u) ((lambda (a) (lambda (c . r) u)) 1)))
+(write ((g0 5) 0))
+(newline)
+SCHEME
+check_native "variadic-inner" "5"
+
+# 5. Capture of both a let-local and the outer param: the let's eval
+#    fallback (#827) must republish the upvalue u alongside the params.
+cat > "$DIR/let-mixed.scm" << 'SCHEME'
+(define g0 (lambda (u) ((lambda (a) (let ((b 2)) (lambda (c) (cons u b)))) 1)))
+(write ((g0 5) 0))
+(newline)
+SCHEME
+check_native "let-mixed" "(5 . 2)"
+
+# 6. The rest parameter must be republished at eval boundaries too.
+cat > "$DIR/rest-capture.scm" << 'SCHEME'
+(define f (lambda (u . xs) (lambda (c) xs)))
+(write ((f 5 1 2) 0))
+(newline)
+SCHEME
+check_native "rest-capture" "(1 2)"
+
+# 7. emitLetFallback must republish the enclosing function's params before
+#    evaluating the let form (here u is referenced by a binding init).
+cat > "$DIR/let-fallback-param.scm" << 'SCHEME'
+(define (f u) (let ((b u)) (lambda (c) b)))
+(write ((f 5) 0))
+(newline)
+SCHEME
+check_native "let-fallback-param" "5"
+
+# 8. A closed lambda inside a capturing closure: its own eval fallback must
+#    NOT inherit the enclosing closure's upvalue map (a closed function
+#    receives null for %upvalues — loading from it would crash).
+cat > "$DIR/closed-inside-closure.scm" << 'SCHEME'
+(define g0 (lambda (u) ((lambda (a) (cons u ((lambda (x) (lambda (c . r) x)) 2))) 1)))
+(define pair (g0 5))
+(write (car pair)) (newline)
+(write ((cdr pair) 0)) (newline)
+SCHEME
+check_native "closed-inside-closure" "$(printf '5\n2')"
+
+# 9. An abandoned native let (body lambda exceeds the 16-param tier cap)
+#    must pop the GC roots pushed for its bindings: 2000 calls would
+#    overflow the 1024-slot root stack if the fallback path leaked them.
+cat > "$DIR/root-balance.scm" << 'SCHEME'
+(define (f u)
+  (let ((b 1))
+    (lambda (p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17) p1)))
+(define (loop n)
+  (if (> n 0)
+      (begin (f n) (loop (- n 1)))
+      'done))
+(write (loop 2000))
+(newline)
+SCHEME
+check_native "root-balance" "done"
+
+# 10. A lambda in a let *binding init* previously aborted native compilation
+#     outright (the emission error escaped emitLet); it must fall back.
+cat > "$DIR/init-lambda.scm" << 'SCHEME'
+(define glob 9)
+(let ((b (lambda (c) glob))) (write (b 0)) (newline))
+SCHEME
+check_native "init-lambda" "9"
+
+echo "PASS"


### PR DESCRIPTION
Fixes #1410.

## Root cause

Both halves of the closure tiers' free-variable analysis in `llvm_emit_lambda.zig` treated nested `.lambda` IR nodes as opaque (`nodeHasFreeVars` returned false, `collectNodeFreeVars` collected nothing), so a lambda whose only reference to an enclosing binding lived inside an inner lambda was misclassified as **closed**. The inner lambda then fell to `emitLambdaViaEval`, which binds only the enclosing function's fixed params as globals — the captured name resolved as an undefined global at run time.

Baselining the issue's reproducer surfaced a whole family of "eval boundary loses the lexical frame" siblings, all fixed here.

## The fix

1. **Descent** — `nodeHasFreeVars` / `collectNodeFreeVars` now walk nested lambda bodies with the same scope-tracking raw-sexpr walk (`FreeNameWalk`) that #1409 added for let/let*, so hidden captures are visible.
2. **Upvalue chaining in tier 1** — `tryCompileNativeClosure` can satisfy a free variable from the enclosing closure's `%upvalues` (not just its `%args`), emitting the copy from the enclosing upvalue array. The issue's reproducer (and its depth-N generalization) now compiles **fully native** with correct per-instance capture semantics — closures made by separate calls don't alias.
3. **Full-frame republication at eval boundaries** — `bindParamsAsGlobals` now also binds the **rest parameter** (from its alloca) and **upvalues** (from `%upvalues`), and `emitLetFallback` calls it before evaluating. This closes the sibling holes: variadic inner lambdas, rest-parameter captures, let fallbacks that referenced enclosing params, and mixed let-local + upvalue captures.

Supporting hardening on the same paths:
- `emitLambdaFunction` nulls the inherited upvalue map (closed functions receive `null` for `%upvalues` at run time — a leaked map would make the new binding code load from null); tier-1 emission nulls stale `locals`/rest state.
- An abandoned native let (`abandonLetForFallback`) now **pops the GC roots** it had pushed for emitted bindings — previously every execution of that fallback path leaked root-stack slots (overflowing the 1024-slot root stack after enough calls).
- A lambda in a let **binding init** now falls back to the interpreter instead of aborting the entire native compilation (on main, `(let ((b (lambda (c) glob))) ...)` at top level produced no `.ll` at all).

## Behavior notes

- Shapes where every link is tier-compilable stay native end-to-end (verified by emitted-IR assertions: no `kaappi_eval` beyond the define-time one, captured names never interned as symbols).
- Shapes with an un-compilable link (e.g. variadic inner lambda) fall back with the frame republished as globals — correct for the dominant single-use pattern, with the same known last-call-wins limitation every existing `bindParamsAsGlobals` boundary has.
- The analysis descent makes tier-2/define-function classification more conservative for nested lambdas referencing not-yet-defined user globals (they now fall back to interpreted closures, matching how *direct* references to unknown names have always been treated). The native-subset fuzz gate (200 fixed seeds requiring zero unexpected fallbacks) confirms no generated shape regressed.

## Verification

| Check | Result |
|---|---|
| VM vs native on 10 reproducer shapes (both issue variants, depth-3, variadic inner, rest-param capture, let-fallback params, mixed capture, init-lambda, 2 working controls) | all match |
| Per-instance retention (`(g0 5)` / `(g0 7)` closures must not alias, depth 2 and 4) | matches VM |
| `zig build test` (incl. 8 new emit-level regression tests + native-subset fuzz gate) | pass |
| New tests on unfixed source | all fail (verified by stashing the src changes) |
| `bash tests/scheme/run-all.sh` (incl. new `native-nested-closure-1410.sh`) | 1823 pass / 0 fail |
| `bash tests/e2e/run-e2e.sh` | 23/23 |
| `bash tests/fuzz/native-diff.sh 300 0` | 300 compared, 0 divergent |

The root-balance e2e case calls a fallback-inside-function 2000 times — it crashes with a root-stack overflow without the pop fix.

Related: #1407 / #1409 (the let/let* direction of the same analysis gap), #827 (let fallback machinery), #1395 (differential harness this strengthens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)