### PR TITLE
Root bignum intermediates in rational arithmetic and string->number

### DIFF
--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -324,6 +324,10 @@ fn add(args: []const Value) PrimitiveError!Value {
         defer slot_num.release();
         var slot_den = gc.rootedSlot(acc_den) catch return PrimitiveError.OutOfMemory;
         defer slot_den.release();
+        var slot_t1 = gc.rootedSlot(types.NIL) catch return PrimitiveError.OutOfMemory;
+        defer slot_t1.release();
+        var slot_t2 = gc.rootedSlot(types.NIL) catch return PrimitiveError.OutOfMemory;
+        defer slot_t2.release();
         for (args) |a| {
             if (types.isFlonum(a)) {
                 const acc_f = try toF64Ext(acc_num) / try toF64Ext(acc_den);
@@ -331,10 +335,12 @@ fn add(args: []const Value) PrimitiveError!Value {
             }
             const parts = try ratPartsVal(a);
             const t1 = bignum_mod.mul(gc, acc_num, parts.den) catch return PrimitiveError.OutOfMemory;
+            slot_t1.set(t1);
             const t2 = bignum_mod.mul(gc, parts.num, acc_den) catch return PrimitiveError.OutOfMemory;
+            slot_t2.set(t2);
             acc_num = bignum_mod.add(gc, t1, t2) catch return PrimitiveError.OutOfMemory;
-            acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
             slot_num.set(acc_num);
+            acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
             slot_den.set(acc_den);
         }
         return makeRationalReduced(gc, acc_num, acc_den);
@@ -386,6 +392,10 @@ fn sub(args: []const Value) PrimitiveError!Value {
         defer slot_num.release();
         var slot_den = gc.rootedSlot(acc_den) catch return PrimitiveError.OutOfMemory;
         defer slot_den.release();
+        var slot_t1 = gc.rootedSlot(types.NIL) catch return PrimitiveError.OutOfMemory;
+        defer slot_t1.release();
+        var slot_t2 = gc.rootedSlot(types.NIL) catch return PrimitiveError.OutOfMemory;
+        defer slot_t2.release();
         for (args[1..]) |a| {
             if (types.isFlonum(a)) {
                 const acc_f = try toF64Ext(acc_num) / try toF64Ext(acc_den);
@@ -393,10 +403,12 @@ fn sub(args: []const Value) PrimitiveError!Value {
             }
             const parts = try ratPartsVal(a);
             const t1 = bignum_mod.mul(gc, acc_num, parts.den) catch return PrimitiveError.OutOfMemory;
+            slot_t1.set(t1);
             const t2 = bignum_mod.mul(gc, parts.num, acc_den) catch return PrimitiveError.OutOfMemory;
+            slot_t2.set(t2);
             acc_num = bignum_mod.sub(gc, t1, t2) catch return PrimitiveError.OutOfMemory;
-            acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
             slot_num.set(acc_num);
+            acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
             slot_den.set(acc_den);
         }
         return makeRationalReduced(gc, acc_num, acc_den);
@@ -457,8 +469,8 @@ fn mul(args: []const Value) PrimitiveError!Value {
             }
             const parts = try ratPartsVal(a);
             acc_num = bignum_mod.mul(gc, acc_num, parts.num) catch return PrimitiveError.OutOfMemory;
-            acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
             slot_num.set(acc_num);
+            acc_den = bignum_mod.mul(gc, acc_den, parts.den) catch return PrimitiveError.OutOfMemory;
             slot_den.set(acc_den);
         }
         return makeRationalReduced(gc, acc_num, acc_den);
@@ -534,8 +546,8 @@ fn divFn(args: []const Value) PrimitiveError!Value {
             const parts = try ratPartsVal(a);
             if (bignum_mod.isZero(parts.num)) return raiseDivByZero();
             acc_num = bignum_mod.mul(gc, acc_num, parts.den) catch return PrimitiveError.OutOfMemory;
-            acc_den = bignum_mod.mul(gc, acc_den, parts.num) catch return PrimitiveError.OutOfMemory;
             slot_num.set(acc_num);
+            acc_den = bignum_mod.mul(gc, acc_den, parts.num) catch return PrimitiveError.OutOfMemory;
             slot_den.set(acc_den);
         }
         return makeRationalReduced(gc, acc_num, acc_den);

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1124,6 +1124,8 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
                 };
             };
             if (num_val == types.FALSE) return types.FALSE;
+            var slot_num = gc.rootedSlot(num_val) catch return PrimitiveError.OutOfMemory;
+            defer slot_num.release();
             const den_val: Value = if (std.fmt.parseInt(i64, den_str, radix)) |den| blk: {
                 if (den == 0) return types.FALSE;
                 break :blk try arith.makeFixnumChecked(den);

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -323,3 +323,38 @@ test "types.toF64 handles bignums (#792)" {
     try std.testing.expect(f2 > 0.0);
     try std.testing.expect(f2 < 1e-19);
 }
+
+test "bignum rational arithmetic survives GC stress (#1414)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // 2^50 and 2^48 both exceed the ±2^47 fixnum range, so the rational
+    // accumulator loops in +, -, *, / allocate a bignum on every update.
+    _ = try vm.eval("(define big-a 1125899906842624)");
+    _ = try vm.eval("(define big-b 281474976710656)");
+
+    // Collect on every allocation: an unrooted intermediate is freed and its
+    // memory reused by the next accumulator update, aliasing the operands.
+    gc.stress = true;
+
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= 4 (/ big-a big-b))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= 1407374883553280 (+ big-a big-b))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= 844424930131968 (- big-a big-b))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= 4 (* big-a (/ 1 big-b)))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= (/ 5 big-a) (+ (/ 1 big-a) (/ 1 big-b)))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval(
+        "(= 1000000007 (/ (* 1234567890123456789 1000000007) 1234567890123456789))",
+    ));
+    // string->number's rational parse holds the numerator bignum across the
+    // denominator parse — same unrooted-intermediate hazard. First case takes
+    // the makeFixnumChecked branch (parts fit i64), second takes the
+    // parseBignumString branch (parts >= 2^63).
+    try std.testing.expectEqual(types.TRUE, try vm.eval(
+        "(= 4 (string->number \"1125899906842624/281474976710656\"))",
+    ));
+    try std.testing.expectEqual(types.TRUE, try vm.eval(
+        "(= 2 (string->number \"36893488147419103232/18446744073709551616\"))",
+    ));
+}

--- a/tests/scheme/compliance/bignum-rational-gc.scm
+++ b/tests/scheme/compliance/bignum-rational-gc.scm
@@ -1,0 +1,49 @@
+;;; Regression tests for #1414: bignum/bignum arithmetic returned wrong
+;;; results when a GC ran between accumulator updates in the rational
+;;; paths of +, -, *, / (visible under -Dgc-stress=true builds, where the
+;;; unrooted intermediate was collected and its memory reused, aliasing
+;;; the operands: / and * collapsed to 1, + doubled one operand, - gave 0).
+
+(import (scheme base) (scheme process-context) (srfi 64))
+
+(test-begin "bignum-rational-gc")
+
+;; 2^50 and 2^48: both exceed the ±2^47 fixnum range, so both are bignums.
+(define big-a 1125899906842624)
+(define big-b 281474976710656)
+
+(test-group "bignum/bignum division (#1414)"
+  (test-eqv "2^50 / 2^48" 4 (/ big-a big-b))
+  (test-eqv "2^50 / 2^50" 1 (/ big-a big-a))
+  (test-eqv "2^48 / 2^50 is exact 1/4" 1/4 (/ big-b big-a))
+  (test-eqv "multi-limb product / bignum"
+            1000000007
+            (/ (* 1234567890123456789 1000000007) 1234567890123456789)))
+
+(test-group "bignum/bignum addition and subtraction"
+  (test-eqv "2^50 + 2^48" 1407374883553280 (+ big-a big-b))
+  (test-eqv "2^50 - 2^48" 844424930131968 (- big-a big-b))
+  (test-eqv "unary minus bignum" -1125899906842624 (- big-a)))
+
+(test-group "bignum multiplication with rationals"
+  (test-eqv "2^50 * 2^48" 316912650057057350374175801344 (* big-a big-b))
+  (test-eqv "2^50 * 1/2^48" 4 (* big-a (/ 1 big-b)))
+  (test-eqv "rational add with bignum denominators"
+            (/ 5 big-a)
+            (+ (/ 1 big-a) (/ 1 big-b))))
+
+;; string->number's rational parse holds the numerator bignum across the
+;; denominator parse — the same unrooted-intermediate hazard as above.
+(test-group "string->number bignum rationals"
+  (test-eqv "bignum/bignum parts fitting i64"
+            4 (string->number "1125899906842624/281474976710656"))
+  (test-eqv "parts overflowing i64 (2^65/2^64)"
+            2 (string->number "36893488147419103232/18446744073709551616"))
+  (test-eqv "negative bignum numerator"
+            -4 (string->number "-1125899906842624/281474976710656"))
+  (test-eqv "fixnum/bignum stays exact"
+            (/ 1 big-b) (string->number "1/281474976710656")))
+
+(define %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "bignum-rational-gc")
+(if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
Fixes #1414.

## Bug

Under `-Dgc-stress=true` builds, any division with both operands bignums silently returned 1:

```scheme
(/ 1125899906842624 281474976710656)  ; => 1, expected 4
```

Investigating showed the whole family is affected, not just `/`:

| Expression | gc-stress result | expected |
|---|---|---|
| `(/ 2^50 2^48)` | 1 | 4 |
| `(+ 2^50 2^48)` | 2^49 | 2^50 + 2^48 |
| `(- 2^50 2^48)` | 0 | 3·2^48 |
| `(* 2^50 1/2^48)` | 1 | 4 |
| `(string->number "2^50/2^48")` | 1 | 4 |

## Root cause

The rational accumulator loops in `add`, `sub`, `mul`, and `divFn` (`src/primitives_arithmetic.zig`) stored each fresh `bignum_mod` result in a Zig local and updated the GC root slots only **after both** accumulator updates:

```zig
acc_num = bignum_mod.mul(gc, acc_num, parts.den) ...;  // fresh bignum, only in a local
acc_den = bignum_mod.mul(gc, acc_den, parts.num) ...;  // allocates → GC collects acc_num
slot_num.set(acc_num);                                  // too late — dangling
slot_den.set(acc_den);
```

The collection triggered inside the second call frees the first result, and the second call's own allocation reuses that memory — so `acc_num` ends up aliasing `acc_den`. Numerator == denominator explains the exact symptoms: `/` and `*` collapse to 1, `+` doubles one operand (`t1` aliases `t2`), `-` returns 0. This is the unrooted-fresh-value class from `.claude/rules/gc-safety.md`; normal builds are only safe by timing (the GC threshold rarely fires between the two calls), so this was a latent wrong-result bug in ordinary builds too.

`string->number`'s rational parse (`src/primitives_numeric.zig`) had the same defect: the parsed numerator bignum was held unrooted across the denominator parse (both the `makeFixnumChecked` and `parseBignumString` branches allocate).

Reader rational literals are **not** affected (`makeRationalFromReader` takes already-parsed `i64`s), verified under stress.

## Fix

Root each fresh accumulator in its slot immediately after the call that produced it, before the next allocating call; root the `t1`/`t2` cross-multiplication temporaries in `+`/`-` in dedicated slots; root `string->number`'s numerator across the denominator parse. No behavior change beyond keeping the intermediates alive.

## Tests

- `src/tests_numeric.zig` — "bignum rational arithmetic survives GC stress (#1414)": sets `gc.stress = true` at runtime on a normal test build and exercises `/`, `+`, `-`, `*` (incl. rational and multi-limb GCD cases) and both `string->number` branches. Verified to fail without the fix (714 pass / 1 fail — exactly this test) and pass with it.
- `tests/scheme/compliance/bignum-rational-gc.scm` — same coverage at the Scheme level (SRFI-64), runs in the normal suite and under stress builds.

## Verification

- `-Dgc-stress=true` build: original repro prints 4; full `tests/scheme/compliance` suite passes; `string->number` cases correct in both parse branches.
- Normal build: `zig build test` all pass; `bash tests/scheme/run-all.sh` — 1823 pass, 0 fail (428 Scheme files + 1395 R7RS).

Found in passing (being handled separately): the reader rejects rational literals whose parts overflow i64 (`36893488147419103232/18446744073709551616` → read error) — valid R7RS syntax, pre-existing loud failure, not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
