### PR TITLE
Read rational literals with bignum numerators or denominators

### DIFF
--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -681,6 +681,7 @@ pub fn parseBignumString(gc: *memory.GC, digits: []const u8, radix: u8) !Value {
     const radix_u64: u64 = radix;
 
     var limbs = try gc.allocator.alloc(u64, 1);
+    errdefer gc.allocator.free(limbs);
     limbs[0] = 0;
     var len: usize = 0;
 
@@ -734,7 +735,10 @@ pub fn parseBignumString(gc: *memory.GC, digits: []const u8, radix: u8) !Value {
     }
 
     // Check if it fits in a fixnum
-    if (len == 0) return types.makeFixnum(0);
+    if (len == 0) {
+        gc.allocator.free(limbs);
+        return types.makeFixnum(0);
+    }
     if (len == 1 and limbs[0] <= @as(u64, @intCast(std.math.maxInt(i48)))) {
         const n: i64 = @intCast(limbs[0]);
         gc.allocator.free(limbs);

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -38,6 +38,9 @@ pub const Token = union(enum) {
     datum_label_ref: u32,
     bignum_str: struct { str: []const u8, radix: u8 },
     rational: struct { num: i64, den: i64 },
+    /// Rational literal whose numerator or denominator overflows i64.
+    /// Digit runs are parsed as bignums at datum construction.
+    big_rational: struct { num_str: []const u8, den_str: []const u8, radix: u8 },
     complex: struct { real: f64, imag: f64, exact_real: bool = false, exact_imag: bool = false },
     eof,
 };

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -32,6 +32,16 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
             const arith = @import("primitives_arithmetic.zig");
             return arith.makeRationalFromReader(self.gc, r.num, r.den) catch return ReadError.OutOfMemory;
         },
+        .big_rational => |r| {
+            const bignum_mod = @import("bignum.zig");
+            const arith = @import("primitives_arithmetic.zig");
+            const num = bignum_mod.parseBignumString(self.gc, r.num_str, r.radix) catch return ReadError.OutOfMemory;
+            var slot_num = self.gc.rootedSlot(num) catch return ReadError.OutOfMemory;
+            defer slot_num.release();
+            const den = bignum_mod.parseBignumString(self.gc, r.den_str, r.radix) catch return ReadError.OutOfMemory;
+            if (bignum_mod.isZero(den)) return ReadError.InvalidNumber;
+            return arith.makeRationalReduced(self.gc, slot_num.get(), den) catch return ReadError.OutOfMemory;
+        },
         .complex => |c| return self.gc.allocComplexEx(c.real, c.imag, c.exact_real, c.exact_imag) catch return ReadError.OutOfMemory,
         .boolean => |b| return if (b) types.TRUE else types.FALSE,
         .character => |c| return types.makeChar(c),

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -45,6 +45,36 @@ fn parseDecimalReal(s: []const u8) ?f64 {
     return std.fmt.parseFloat(f64, s) catch null;
 }
 
+/// Consume the '/' at the current position plus the following run of digits
+/// valid in `radix`, returning the denominator digit slice (possibly empty).
+fn scanDenominatorDigits(self: *Reader, radix: u8) []const u8 {
+    self.pos += 1; // skip '/'
+    const den_start = self.pos;
+    while (self.pos < self.source.len) {
+        const rc = self.source[self.pos];
+        const valid = switch (radix) {
+            2 => rc == '0' or rc == '1',
+            8 => rc >= '0' and rc <= '7',
+            16 => std.ascii.isHex(rc),
+            else => std.ascii.isDigit(rc),
+        };
+        if (!valid) break;
+        self.pos += 1;
+    }
+    return self.source[den_start..self.pos];
+}
+
+/// Build a big_rational token for a rational literal with an i64-overflowing
+/// numerator or denominator. Unlike the fixnum rational path (which admits
+/// trailing complex syntax like 1/2+3i), a bignum rational must end at a
+/// delimiter — otherwise the tail would be silently read as a second datum.
+fn bigRationalToken(self: *Reader, num_str: []const u8, den_str: []const u8, radix: u8) ReadError!Token {
+    if (den_str.len > Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
+    if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+        return ReadError.InvalidNumber;
+    return .{ .big_rational = .{ .num_str = num_str, .den_str = den_str, .radix = radix } };
+}
+
 pub fn readNumber(self: *Reader) ReadError!Token {
     if (self.pos >= self.source.len) return ReadError.InvalidNumber;
     const start = self.pos;
@@ -164,22 +194,27 @@ pub fn readNumber(self: *Reader) ReadError!Token {
         return .{ .flonum = f };
     } else {
         const n = std.fmt.parseInt(i64, num_str, 10) catch |err| {
-            if (err == error.Overflow) {
-                return .{ .bignum_str = .{ .str = num_str, .radix = 10 } };
+            if (err != error.Overflow) return ReadError.InvalidNumber;
+            // Numerator overflows i64: still check for a rational literal N/D
+            // so bignum numerators fall back to bignum parsing in the datum
+            // constructor instead of leaving '/' behind as a stray token.
+            if (self.pos < self.source.len and self.source[self.pos] == '/' and
+                self.pos + 1 < self.source.len and std.ascii.isDigit(self.source[self.pos + 1]))
+            {
+                const den_str = scanDenominatorDigits(self, 10);
+                return bigRationalToken(self, num_str, den_str, 10);
             }
-            return ReadError.InvalidNumber;
+            return .{ .bignum_str = .{ .str = num_str, .radix = 10 } };
         };
         // Check for rational literal: N/D
         if (self.pos < self.source.len and self.source[self.pos] == '/' and
             self.pos + 1 < self.source.len and std.ascii.isDigit(self.source[self.pos + 1]))
         {
-            self.pos += 1; // skip '/'
-            const den_start = self.pos;
-            while (self.pos < self.source.len and std.ascii.isDigit(self.source[self.pos])) {
-                self.pos += 1;
-            }
-            const den_str = self.source[den_start..self.pos];
-            const den = std.fmt.parseInt(i64, den_str, 10) catch return ReadError.InvalidNumber;
+            const den_str = scanDenominatorDigits(self, 10);
+            const den = std.fmt.parseInt(i64, den_str, 10) catch |err| {
+                if (err == error.Overflow) return bigRationalToken(self, num_str, den_str, 10);
+                return ReadError.InvalidNumber;
+            };
             // Check for complex after rational: 1/2+3/4i
             if (self.pos < self.source.len and (self.source[self.pos] == '+' or self.source[self.pos] == '-')) {
                 const csave = self.pos;
@@ -339,7 +374,7 @@ fn applyExactness(tok: Token, exact: ?bool) ReadError!Token {
     const want_exact = exact orelse return tok;
     if (want_exact) {
         return switch (tok) {
-            .fixnum, .rational, .bignum_str => tok,
+            .fixnum, .rational, .bignum_str, .big_rational => tok,
             .flonum => |f| blk: {
                 if (!std.math.isFinite(f)) break :blk Token{ .flonum = f };
                 const max_i64_f: f64 = @floatFromInt(@as(i64, std.math.maxInt(i64)));
@@ -390,6 +425,13 @@ fn applyExactness(tok: Token, exact: ?bool) ReadError!Token {
         .fixnum => |n| .{ .flonum = @floatFromInt(n) },
         .rational => |r| .{ .flonum = @as(f64, @floatFromInt(r.num)) / @as(f64, @floatFromInt(r.den)) },
         .bignum_str => |bs| .{ .flonum = std.fmt.parseFloat(f64, bs.str) catch return ReadError.InvalidNumber },
+        // Like .bignum_str, only decimal digit runs can go through parseFloat.
+        .big_rational => |r| blk: {
+            if (r.radix != 10) return ReadError.InvalidNumber;
+            const nf = std.fmt.parseFloat(f64, r.num_str) catch return ReadError.InvalidNumber;
+            const df = std.fmt.parseFloat(f64, r.den_str) catch return ReadError.InvalidNumber;
+            break :blk .{ .flonum = nf / df };
+        },
         else => ReadError.InvalidNumber,
     };
 }
@@ -557,30 +599,26 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
     if (num_str.len > Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
     if (num_str.len == 0 or (num_str.len == 1 and (num_str[0] == '+' or num_str[0] == '-'))) return ReadError.InvalidNumber;
     const n = std.fmt.parseInt(i64, num_str, radix) catch |err| {
-        if (err == error.Overflow) {
-            return .{ .bignum_str = .{ .str = num_str, .radix = radix } };
+        if (err != error.Overflow) return ReadError.InvalidNumber;
+        // Numerator overflows i64: still consume a rational N/D so the '/'
+        // does not get re-tokenized as the start of a symbol.
+        if (self.pos < self.source.len and self.source[self.pos] == '/') {
+            const slash_pos = self.pos;
+            const den_str = scanDenominatorDigits(self, radix);
+            if (den_str.len > 0) return bigRationalToken(self, num_str, den_str, radix);
+            self.pos = slash_pos; // no digits after '/', backtrack
         }
-        return ReadError.InvalidNumber;
+        return .{ .bignum_str = .{ .str = num_str, .radix = radix } };
     };
     // Check for rational literal: N/D (within same radix)
     if (self.pos < self.source.len and self.source[self.pos] == '/') {
         const slash_pos = self.pos;
-        self.pos += 1; // skip '/'
-        const den_start = self.pos;
-        while (self.pos < self.source.len) {
-            const rc = self.source[self.pos];
-            const valid = switch (radix) {
-                2 => rc == '0' or rc == '1',
-                8 => rc >= '0' and rc <= '7',
-                16 => std.ascii.isHex(rc),
-                else => std.ascii.isDigit(rc),
+        const den_str = scanDenominatorDigits(self, radix);
+        if (den_str.len > 0) {
+            const den = std.fmt.parseInt(i64, den_str, radix) catch |err| {
+                if (err == error.Overflow) return bigRationalToken(self, num_str, den_str, radix);
+                return ReadError.InvalidNumber;
             };
-            if (!valid) break;
-            self.pos += 1;
-        }
-        if (self.pos > den_start) {
-            const den_str = self.source[den_start..self.pos];
-            const den = std.fmt.parseInt(i64, den_str, radix) catch return ReadError.InvalidNumber;
             return .{ .rational = .{ .num = n, .den = den } };
         }
         // No digits after '/', backtrack

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -339,3 +339,25 @@ test "types.toF64 handles bignums (#792)" {
     try std.testing.expect(f2 > 0.0);
     try std.testing.expect(f2 < 1e-19);
 }
+
+test "reader accepts rational literals with bignum parts" {
+    // Regression: the tokenizer parsed rational parts as i64 with no bignum
+    // fallback, so 2^65/2^64 failed with a read error at the slash.
+    try th.expectEval("36893488147419103232/18446744073709551616", 2);
+    try th.expectEval("-36893488147419103232/18446744073709551616", -2);
+    try th.expectEval("#e36893488147419103232/18446744073709551616", 2);
+    // Radix-prefixed: 2^65/2^64 in hex, binary 2^65/2
+    try th.expectEval("#x20000000000000000/10000000000000000", 2);
+    try th.expectEvalTrue("(= #b100000000000000000000000000000000000000000000000000000000000000000/10 (expt 2 64))");
+    // bignum/fixnum reducing to a bignum integer
+    try th.expectEvalTrue("(= 36893488147419103232/2 (expt 2 64))");
+    // Irreducible results keep exact bignum parts
+    try th.expectEvalTrue("(= (numerator 36893488147419103232/3) (expt 2 65))");
+    try th.expectEval("(denominator 36893488147419103232/3)", 3);
+    try th.expectEvalTrue("(= (denominator 3/36893488147419103232) (expt 2 65))");
+    try th.expectEvalTrue("(exact? 36893488147419103232/3)");
+    // Inexact prefix divides as flonums
+    try th.expectEvalTrue("(= #i36893488147419103232/18446744073709551616 2.0)");
+    // Bignum/0 is a read error, matching 1/0
+    try th.expectEvalTrue("(guard (e ((read-error? e) #t) (#t #f)) (read (open-input-string \"36893488147419103232/0\")))");
+}

--- a/tests/scheme/compliance/reader-numerics.scm
+++ b/tests/scheme/compliance/reader-numerics.scm
@@ -47,6 +47,80 @@
     1152921504606846975
     (string->number "77777777777777777777" 8)))
 
+;; Rational literals whose numerator or denominator overflows i64 must fall
+;; back to bignum parsing instead of failing with a read error.
+;; 36893488147419103232 = 2^65, 18446744073709551616 = 2^64.
+(test-group "bignum rational literals"
+  ;; bignum/bignum reducing to a fixnum
+  (test-eqv "bignum/bignum reduces to fixnum"
+    2
+    36893488147419103232/18446744073709551616)
+
+  (test-eqv "negative bignum/bignum"
+    -2
+    -36893488147419103232/18446744073709551616)
+
+  ;; bignum/fixnum reducing to a bignum integer
+  (test-eqv "bignum/fixnum reduces to bignum"
+    18446744073709551616
+    36893488147419103232/2)
+
+  ;; Irreducible variants keep exact bignum parts
+  (test-eqv "bignum/fixnum numerator preserved"
+    36893488147419103232
+    (numerator 36893488147419103232/3))
+
+  (test-eqv "bignum/fixnum denominator preserved"
+    3
+    (denominator 36893488147419103232/3))
+
+  (test-eqv "negative bignum/fixnum numerator"
+    -36893488147419103232
+    (numerator -36893488147419103232/3))
+
+  (test-eqv "fixnum/bignum denominator preserved"
+    18446744073709551616
+    (denominator 3/18446744073709551616))
+
+  (test-eqv "bignum/bignum irreducible numerator"
+    36893488147419103232
+    (numerator 36893488147419103232/18446744073709551617))
+
+  (test-assert "bignum rational is exact"
+    (exact? 36893488147419103232/3))
+
+  (test-assert "matches string->number"
+    (= 36893488147419103232/3
+       (string->number "36893488147419103232/3")))
+
+  ;; Radix prefixes
+  (test-eqv "hex bignum rational" 2 #x20000000000000000/10000000000000000)
+  (test-eqv "octal bignum rational" 2 #o4000000000000000000000/2000000000000000000000)
+  (test-assert "binary bignum/fixnum rational"
+    (= #b100000000000000000000000000000000000000000000000000000000000000000/10
+       18446744073709551616))
+
+  ;; Exactness prefixes
+  (test-eqv "#e bignum rational" 2 #e36893488147419103232/18446744073709551616)
+  (test-eqv "#e#x bignum rational" 2 #e#x20000000000000000/10000000000000000)
+  (test-assert "#i bignum rational is inexact"
+    (and (inexact? #i36893488147419103232/18446744073709551616)
+         (= #i36893488147419103232/18446744073709551616 2.0)))
+
+  ;; Via (read ...) rather than a literal
+  (test-eqv "read from string port"
+    2
+    (read (open-input-string "36893488147419103232/18446744073709551616")))
+
+  ;; Zero denominator is a read error, matching 1/0
+  (test-assert "bignum/0 is a read error"
+    (guard (e ((read-error? e) #t) (#t #f))
+      (read (open-input-string "36893488147419103232/0"))))
+
+  (test-assert "bignum/00 is a read error"
+    (guard (e ((read-error? e) #t) (#t #f))
+      (read (open-input-string "36893488147419103232/00")))))
+
 (define %test-fail-count (test-runner-fail-count (test-runner-current)))
 (test-end "reader-numerics")
 (if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
## Problem

The tokenizer parsed rational literal parts as i64 with no bignum fallback, so valid R7RS syntax failed or misparsed:

- `36893488147419103232/18446744073709551616` (2^65/2^64) → `read error: error.UnexpectedChar` at the slash
- `3/36893488147419103232` (denominator overflow) → `error.InvalidNumber`
- `#x20000000000000000/10000000000000000` → **silently read as two datums** (a bignum, then a symbol `/1000…`), surfacing as "undefined variable"

`string->number` already accepted the same syntax and returned the reduced exact value.

## Fix

- New `big_rational` token (`num_str`/`den_str`/`radix`) produced by both `readNumber` and `readIntegerWithRadix` when either side overflows i64.
- Datum construction parses each side with `parseBignumString` — the numerator held in a `gc.rootedSlot` across the second parse per the GC-safety rules — then reduces via `makeRationalReduced`, so `2^65/2^64` reads as exact `2` and irreducible literals keep exact bignum parts.
- Exactness prefixes match fixnum-rational behavior: `#e` passes through, `#i` divides as flonums (decimal only, same limitation as `.bignum_str`).
- A big rational must end at a delimiter: the fixnum path admits complex tails (`1/2+3/4i`), but a lax bignum path would silently read `BIG/2+3i` as two datums. `BIG/0` is a `read-error?`, matching `1/0`.
- Denominator digit runs are capped at `MAX_TOKEN_BYTES` (numerators already were; before this change denominators were implicitly ≤19 digits).
- Fixes a latent leak in `parseBignumString`: the limbs buffer leaked on all-zero digit strings and error paths — previously unreachable since every caller required i64 overflow first, but the new `BIG/0` path hits it.

## Tests

- Zig regression test in `tests_numeric.zig` (all four numerator/denominator combos, negatives, radix + exactness prefixes, read-error on zero denominator).
- 19 new cases in `tests/scheme/compliance/reader-numerics.scm` (31 total in the file).
- `zig build test`: 717 pass, no leaks. Full Scheme suite: 1823 pass / 0 fail.
- Verified under `-Dgc-stress=true` (`.sbc` caches cleared so the reader actually runs): targeted literals and the full compliance file pass with a collection forced on every allocation.

## Note for reviewers

While stress-testing I reproduced #1414 (`(/ 2^50 2^48)` → 1 under gc-stress); that bug was in the arithmetic accumulator loops, not this reader path, and was fixed by PR #1421, which merged to main while this PR was open. The predicted `tests_numeric.zig` test-overlap conflict has been resolved by merging main into this branch (both test blocks kept; full unit suite passes on the merged tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
