### PR TITLE
Reject native compilation when a set! param is captured by a nested lambda

### DIFF
--- a/src/fuzz_gen.zig
+++ b/src/fuzz_gen.zig
@@ -456,6 +456,10 @@ pub const Gen = struct {
         try g.scope.append(g.gpa, .{ .name = name, .kind = kind });
     }
 
+    pub fn pushNonSettable(g: *Gen, name: []const u8, kind: Kind) Error!void {
+        try g.scope.append(g.gpa, .{ .name = name, .kind = kind, .settable = false });
+    }
+
     fn pushPatternVar(g: *Gen, name: []const u8) Error!void {
         try g.scope.append(g.gpa, .{ .name = name, .kind = .int, .settable = false });
     }

--- a/src/fuzz_gen_native.zig
+++ b/src/fuzz_gen_native.zig
@@ -206,7 +206,7 @@ fn genLambda(g: *Gen, ctx: *Ctx, arity: u8, variadic: bool) Error!void {
     for (params, 0..) |p, i| {
         if (i > 0) try g.emit(" ");
         try g.emit(p);
-        try g.scope.append(g.gpa, .{ .name = p, .kind = .int, .settable = false });
+        try g.pushNonSettable(p, .int);
     }
     if (variadic) {
         try g.emit(" . rest");
@@ -250,7 +250,7 @@ fn genFnDefine(g: *Gen, ctx: *Ctx) Error!void {
                 // Non-settable: inline lambdas in the body may capture these
                 // params, and set! of a captured param triggers the #1422
                 // guard, rejecting the whole function for native compilation.
-                try g.scope.append(g.gpa, .{ .name = p, .kind = .int, .settable = false });
+                try g.pushNonSettable(p, .int);
             }
             if (variadic) {
                 try g.emit(" . rest");
@@ -269,8 +269,8 @@ fn genFnDefine(g: *Gen, ctx: *Ctx) Error!void {
                 name, params[0], params[1], params[0], params[1], name, params[0],
             });
             var saved = try enterBody(g, false);
-            try g.scope.append(g.gpa, .{ .name = params[0], .kind = .int, .settable = false });
-            try g.scope.append(g.gpa, .{ .name = params[1], .kind = .int, .settable = false });
+            try g.pushNonSettable(params[0], .int);
+            try g.pushNonSettable(params[1], .int);
             var body_ctx: Ctx = .{ .fn_depth = 1 };
             try genInt(g, &body_ctx, 3);
             leaveBody(g, &saved);
@@ -282,7 +282,7 @@ fn genFnDefine(g: *Gen, ctx: *Ctx) Error!void {
             const op = rec_ops[g.ch.index(.op_pick, rec_ops.len)];
             try g.emitf("(define ({s} {s}) (if (<= {s} 0) ", .{ name, params[0], params[0] });
             var saved = try enterBody(g, false);
-            try g.scope.append(g.gpa, .{ .name = params[0], .kind = .int, .settable = false });
+            try g.pushNonSettable(params[0], .int);
             var body_ctx: Ctx = .{ .fn_depth = 1 };
             try genInt(g, &body_ctx, 2);
             try g.emitf(" ({s} ", .{op});

--- a/src/fuzz_gen_native.zig
+++ b/src/fuzz_gen_native.zig
@@ -112,6 +112,9 @@ const Ctx = struct {
     /// arguments run between closure creation (which snapshots captured
     /// params by value) and the call, so a set! of a captured param there
     /// diverges from the VM's location-based capture (#1422).
+    /// Note: set! of a define-position function's own params is prevented
+    /// separately by pushing those params with settable=false — the #1422
+    /// guard rejects functions whose params are both set! and captured.
     no_set: bool = false,
 };
 
@@ -203,7 +206,7 @@ fn genLambda(g: *Gen, ctx: *Ctx, arity: u8, variadic: bool) Error!void {
     for (params, 0..) |p, i| {
         if (i > 0) try g.emit(" ");
         try g.emit(p);
-        try g.pushBinding(p, .int);
+        try g.scope.append(g.gpa, .{ .name = p, .kind = .int, .settable = false });
     }
     if (variadic) {
         try g.emit(" . rest");
@@ -244,7 +247,10 @@ fn genFnDefine(g: *Gen, ctx: *Ctx) Error!void {
             var saved = try enterBody(g, false);
             for (params) |p| {
                 try g.emitf(" {s}", .{p});
-                try g.pushBinding(p, .int);
+                // Non-settable: inline lambdas in the body may capture these
+                // params, and set! of a captured param triggers the #1422
+                // guard, rejecting the whole function for native compilation.
+                try g.scope.append(g.gpa, .{ .name = p, .kind = .int, .settable = false });
             }
             if (variadic) {
                 try g.emit(" . rest");
@@ -263,8 +269,8 @@ fn genFnDefine(g: *Gen, ctx: *Ctx) Error!void {
                 name, params[0], params[1], params[0], params[1], name, params[0],
             });
             var saved = try enterBody(g, false);
-            try g.pushBinding(params[0], .int);
-            try g.pushBinding(params[1], .int);
+            try g.scope.append(g.gpa, .{ .name = params[0], .kind = .int, .settable = false });
+            try g.scope.append(g.gpa, .{ .name = params[1], .kind = .int, .settable = false });
             var body_ctx: Ctx = .{ .fn_depth = 1 };
             try genInt(g, &body_ctx, 3);
             leaveBody(g, &saved);
@@ -276,7 +282,7 @@ fn genFnDefine(g: *Gen, ctx: *Ctx) Error!void {
             const op = rec_ops[g.ch.index(.op_pick, rec_ops.len)];
             try g.emitf("(define ({s} {s}) (if (<= {s} 0) ", .{ name, params[0], params[0] });
             var saved = try enterBody(g, false);
-            try g.pushBinding(params[0], .int);
+            try g.scope.append(g.gpa, .{ .name = params[0], .kind = .int, .settable = false });
             var body_ctx: Ctx = .{ .fn_depth = 1 };
             try genInt(g, &body_ctx, 2);
             try g.emitf(" ({s} ", .{op});

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -360,6 +360,9 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
         param_list = types.cdr(param_list);
     }
 
+    // #1422: reject if a param is both set! and captured by a nested lambda.
+    if (bodyHasConflictingSetCapture(body, param_names[0..arity], rest_name)) return null;
+
     var body_ir = ir.IR.init(self.allocator());
     defer body_ir.deinit();
     // Parameters (including a rest parameter) shadow primitives of the same
@@ -659,6 +662,80 @@ fn sexprContainsSetOrDefine(expr: types.Value) bool {
         if (sexprContainsSetOrDefine(types.car(cur))) return true;
     }
     return false;
+}
+
+// True if the function body has a parameter that is both targeted by set!
+// and captured by a nested lambda.  The native upvalue-copy model snapshots
+// at closure creation, so a later set! of the same param is invisible to
+// the closure — diverging from the VM's by-location semantics (#1422).
+fn bodyHasConflictingSetCapture(body_list: Value, param_names: []const []const u8, rest_name: ?[]const u8) bool {
+    const total = param_names.len + @as(usize, if (rest_name != null) 1 else 0);
+    if (total == 0) return false;
+    var set_flags: [17]bool = @splat(false);
+
+    var expr = body_list;
+    while (expr != types.NIL and types.isPair(expr)) : (expr = types.cdr(expr)) {
+        sexprCollectSetTargets(types.car(expr), param_names, rest_name, &set_flags);
+    }
+
+    var any = false;
+    for (set_flags[0..total]) |f| {
+        if (f) {
+            any = true;
+            break;
+        }
+    }
+    if (!any) return false;
+
+    var flagged: [17][]const u8 = undefined;
+    var flagged_count: usize = 0;
+    for (param_names, 0..) |p, i| {
+        if (set_flags[i]) {
+            flagged[flagged_count] = p;
+            flagged_count += 1;
+        }
+    }
+    if (rest_name) |rn| {
+        if (set_flags[param_names.len]) {
+            flagged[flagged_count] = rn;
+            flagged_count += 1;
+        }
+    }
+
+    return bodyHasCapturingLambda(body_list, flagged[0..flagged_count]);
+}
+
+fn sexprCollectSetTargets(expr: Value, param_names: []const []const u8, rest_name: ?[]const u8, flags: *[17]bool) void {
+    if (!types.isPair(expr)) return;
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const h = types.symbolName(head);
+        if (std.mem.eql(u8, h, "quote")) return;
+        if (std.mem.eql(u8, h, "set!")) {
+            const rest = types.cdr(expr);
+            if (types.isPair(rest)) {
+                const target = types.car(rest);
+                if (types.isSymbol(target)) {
+                    const tname = types.symbolName(target);
+                    for (param_names, 0..) |p, i| {
+                        if (std.mem.eql(u8, tname, p)) {
+                            flags[i] = true;
+                            break;
+                        }
+                    }
+                    if (rest_name) |rn| {
+                        if (std.mem.eql(u8, tname, rn)) {
+                            flags[param_names.len] = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        sexprCollectSetTargets(types.car(cur), param_names, rest_name, flags);
+    }
 }
 
 fn hasFreeVars(self: *LLVMEmitter, nodes: []const *ir.Node, params: []const []const u8) bool {

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -50,6 +50,9 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
 
     if (rest_name != null) return null;
 
+    // #1422: reject if a param is both set! and captured by a nested lambda.
+    if (bodyHasConflictingSetCapture(body_list, param_names[0..arity], null)) return null;
+
     var body_ir = ir.IR.init(self.allocator());
     defer body_ir.deinit();
     // Parameters shadow primitives of the same name; don't fold calls to them

--- a/tests/scheme/compile/native-set-capture-divergence-1422.sh
+++ b/tests/scheme/compile/native-set-capture-divergence-1422.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Regression test for #1422: the native closure tiers copy captured variables
+# by value, so a set! of the captured binding after closure creation is
+# invisible to the closure — diverging from the VM's by-location semantics.
+#
+# The fix rejects native compilation of a function whose body contains both
+# a set! of a parameter and a nested lambda that captures that parameter,
+# falling back to the interpreter.
+#
+# Usage: bash tests/scheme/compile/native-set-capture-divergence-1422.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
+    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+fi
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+check() {
+    local name="$1" src="$2" expect_out="$3"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    local out
+    if ! out=$("$DIR/$name" 2>/dev/null); then
+        echo "FAIL: $name — binary exited nonzero" >&2
+        fail=1
+        return
+    fi
+
+    if [[ "$out" != "$expect_out" ]]; then
+        echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
+        fail=1
+    fi
+}
+
+# 1. Issue reproducer: set! of param u in a sibling argument, lambda captures u.
+check set-capture-inline \
+'(define (f0 u) ((lambda (a) (+ u a)) (let ((b 5)) (set! u 90) b)))
+(write (f0 1))
+(newline)' \
+'95'
+
+# 2. Variadic inner lambda (falls to eval fallback, same divergence via
+#    bindParamsAsGlobals snapshot).
+check set-capture-variadic \
+'(define (f0 u) ((lambda (a . rest) (+ u a)) (let ((b 5)) (set! u 90) b) 7))
+(write (f0 1))
+(newline)' \
+'95'
+
+# 3. Retained closure: set! runs between closure creation and call.
+check set-capture-retained \
+'(define (f x)
+  (let ((g (lambda () x)))
+    (set! x 42)
+    (g)))
+(write (f 1))
+(newline)' \
+'42'
+
+# 4. Shadowed param: the lambda (x) shadows f's x, so it does NOT capture f's x.
+#    The function should still compile natively.
+check set-shadowed-param \
+'(define (f x) (set! x 10) ((lambda (x) (+ x 1)) 3))
+(write (f 5))
+(newline)' \
+'4'
+
+# 5. No conflict: set! targets x but lambda captures y — no overlap.
+check set-different-param \
+'(define (f x y) (set! x 10) ((lambda () y)))
+(write (f 1 99))
+(newline)' \
+'99'
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-set-capture-divergence-1422: all cases passed"

--- a/tests/scheme/compile/native-set-capture-divergence-1422.sh
+++ b/tests/scheme/compile/native-set-capture-divergence-1422.sh
@@ -24,8 +24,11 @@ trap 'rm -rf "$DIR"' EXIT
 
 fail=0
 
+# Compile natively and check output.  When expect_native is "yes", also
+# verify that at least one user-defined native function was emitted; when
+# "no", verify that none were (the whole program fell back to eval).
 check() {
-    local name="$1" src="$2" expect_out="$3"
+    local name="$1" src="$2" expect_out="$3" expect_native="${4:-}"
 
     printf '%s' "$src" > "$DIR/$name.scm"
 
@@ -46,24 +49,42 @@ check() {
         echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
         fail=1
     fi
+
+    # Pin the compilation tier when requested.
+    if [[ -n "$expect_native" ]]; then
+        (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1) || true
+        if [[ "$expect_native" == "yes" ]]; then
+            if ! grep -q '^define i64 @lambda_' "$DIR/$name.ll" 2>/dev/null; then
+                echo "FAIL: $name — expected native fn definition in LLVM IR" >&2
+                fail=1
+            fi
+        elif [[ "$expect_native" == "no" ]]; then
+            if grep -q '^define i64 @lambda_' "$DIR/$name.ll" 2>/dev/null; then
+                echo "FAIL: $name — expected NO native fn definition (should fall back)" >&2
+                fail=1
+            fi
+        fi
+    fi
 }
 
-# 1. Issue reproducer: set! of param u in a sibling argument, lambda captures u.
+# 1. Issue reproducer (define-position): set! of param u in a sibling
+#    argument, lambda captures u.  Must fall back to interpreter.
 check set-capture-inline \
 '(define (f0 u) ((lambda (a) (+ u a)) (let ((b 5)) (set! u 90) b)))
 (write (f0 1))
 (newline)' \
-'95'
+'95' no
 
 # 2. Variadic inner lambda (falls to eval fallback, same divergence via
-#    bindParamsAsGlobals snapshot).
+#    bindParamsAsGlobals snapshot).  Must fall back.
 check set-capture-variadic \
 '(define (f0 u) ((lambda (a . rest) (+ u a)) (let ((b 5)) (set! u 90) b) 7))
 (write (f0 1))
 (newline)' \
-'95'
+'95' no
 
 # 3. Retained closure: set! runs between closure creation and call.
+#    Must fall back.
 check set-capture-retained \
 '(define (f x)
   (let ((g (lambda () x)))
@@ -71,22 +92,30 @@ check set-capture-retained \
     (g)))
 (write (f 1))
 (newline)' \
-'42'
+'42' no
 
-# 4. Shadowed param: the lambda (x) shadows f's x, so it does NOT capture f's x.
-#    The function should still compile natively.
+# 4. Inline lambda (tier 2): same divergence through
+#    tryCompilePureLambdaAsNativeClosure.  Must fall back.
+check set-capture-inline-lambda \
+'(write ((lambda (u) ((lambda (a) (+ u a)) (let ((b 5)) (set! u 90) b))) 1))
+(newline)' \
+'95' no
+
+# 5. Shadowed param: the lambda (x) shadows f's x, so it does NOT capture
+#    f's x.  The function should still compile natively.
 check set-shadowed-param \
 '(define (f x) (set! x 10) ((lambda (x) (+ x 1)) 3))
 (write (f 5))
 (newline)' \
-'4'
+'4' yes
 
-# 5. No conflict: set! targets x but lambda captures y — no overlap.
+# 6. No conflict: set! targets x but lambda captures y — no overlap.
+#    Should still compile natively.
 check set-different-param \
 '(define (f x y) (set! x 10) ((lambda () y)))
 (write (f 1 99))
 (newline)' \
-'99'
+'99' yes
 
 if [[ "$fail" -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
## Summary

- Add a guard in `tryCompileDefineFunction` that rejects native compilation when a function parameter is both targeted by `set!` anywhere in the body and captured by a nested lambda — the native upvalue-copy model snapshots at closure creation, making later mutations invisible to the closure (#1422)
- Update the native-subset fuzz generator to mark function params as non-settable so generated programs stay on the native path

## Test plan

- [x] `zig build test` — 728 unit tests pass (including the fuzz generator's native-subset fallback check)
- [x] `bash tests/scheme/compile/native-set-capture-divergence-1422.sh` — 5 cases: issue reproducers (output `95` instead of `6`), retained closure, shadowed param (still compiles natively), no-conflict different param (still compiles natively)
- [x] All existing `tests/scheme/compile/*.sh` pass — no regressions

Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)