### PR TITLE
Auto-file GitHub issues for scheduled fuzz findings

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -237,18 +237,27 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
+
   # A failure above is otherwise only visible as a red run in the Actions
   # tab (plus a notification email to whoever last touched the cron line).
-  # This job turns any failed job into a GitHub issue: one open issue per
-  # job, labeled fuzz-finding, with the run link, a bounded artifact
-  # excerpt, and replay instructions; while that issue stays open, repeat
+  # This job turns failures into GitHub issues under the fuzz-finding
+  # label, deduped by exact title: while an issue stays open, repeat
   # failures append comments instead of opening duplicates. Issues are
   # never auto-closed: seed bases rotate nightly, so a green run does not
-  # mean a finding is fixed. This is a SEPARATE job so the write-capable
-  # token never coexists with execution of fuzzer-generated programs — the
-  # three jobs above keep contents:read tokens and persist-credentials:
-  # false; this one runs no generated code (artifact contents are only
-  # copied into issue text).
+  # mean a finding is fixed.
+  #
+  # To avoid false-positive finding issues, filing is gated on the finding
+  # marker actually being present in the uploaded artifacts — the encoded
+  # crash input for the fuzz job, seed-<N>.scm divergences for the diff
+  # jobs. Failed jobs without their marker (toolchain/apt flakes, build or
+  # unit-test failures, job-level timeouts — a possible hang) are collected
+  # under a single "Fuzz CI: infrastructure or build failure" issue instead
+  # of wearing a divergence title.
+  #
+  # This is a SEPARATE job so the write-capable token never coexists with
+  # execution of fuzzer-generated programs — the three jobs above keep
+  # contents:read tokens and persist-credentials: false; this one runs no
+  # generated code (artifact contents are only copied into issue text).
   report:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -281,7 +290,7 @@ jobs:
 
           gh label create fuzz-finding -R "$GITHUB_REPOSITORY" --force \
             --color B60205 \
-            --description "Automated finding from the scheduled Fuzz workflow"
+            --description "Automated report from the scheduled Fuzz workflow"
 
           # excerpt DIR OUT — append a bounded artifact listing plus the first
           # divergence (or the fuzzer transcript tail) to OUT. Artifacts stay the
@@ -316,20 +325,23 @@ jobs:
             printf '</details>\n' >> "$out"
           }
 
-          # report_one RESULT JOB TITLE ARTIFACT_DIR HINT — file a new fuzz-finding
-          # issue for JOB, or append a comment if one with the same title is open.
-          report_one() {
-            result="$1"; job="$2"; title="$3"; dir="$4"; hint="$5"
-            [ "$result" = failure ] || return 0
-            body="body-$job.md"
+          # body_start LABEL HINT OUT — the report header shared by every issue kind.
+          body_start() {
+            label="$1"; hint="$2"; out="$3"
             {
-              printf '**Failed job:** `%s` — [run #%s](%s) (`%s`)\n\n' \
-                "$job" "$GITHUB_RUN_NUMBER" "$run_url" "$GITHUB_EVENT_NAME"
+              printf '**Failed job(s):** `%s` — [run #%s](%s) (`%s`)\n\n' \
+                "$label" "$GITHUB_RUN_NUMBER" "$run_url" "$GITHUB_EVENT_NAME"
               printf '%s\n\n' "$hint"
               printf 'Download everything: `gh run download %s -R %s` (artifacts are retained for 90 days).\n\n' \
                 "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY"
-            } > "$body"
-            excerpt "$dir" "$body"
+            } > "$out"
+          }
+
+          # file_or_append TITLE PREAMBLE BODY — dedup by exact title among open
+          # fuzz-finding issues: append BODY as a comment to the existing issue, or
+          # create a new one as PREAMBLE + BODY.
+          file_or_append() {
+            title="$1"; preamble="$2"; body="$3"
             num=$(gh issue list -R "$GITHUB_REPOSITORY" --state open --label fuzz-finding \
                     --json number,title \
                   | jq -r --arg t "$title" '[.[] | select(.title == $t)][0].number // empty')
@@ -337,35 +349,85 @@ jobs:
               gh issue comment "$num" -R "$GITHUB_REPOSITORY" --body-file "$body"
               echo "::notice::Appended failure report to existing issue #$num ($title)"
             else
-              full="full-$job.md"
-              {
-                printf 'Automated report from the [Fuzz workflow](%s). Triage runbook: [docs/dev/fuzzing.md](%s) — minimise the input, add a readable regression test, keep the encoded input as a corpus entry.\n\n' \
-                  "$run_url" "$runbook"
-                printf '> [!NOTE]\n'
-                printf '> A later green run does **not** mean this is fixed: nightly seed bases rotate, so a failing input will not recur on its own. Close this issue once the finding is minimised and fixed (or triaged as an oracle/generator bug). Until then, new failures of the same job append comments here instead of opening new issues.\n\n'
-                printf -- '---\n\n'
-                cat "$body"
-              } > "$full"
+              cat "$preamble" > full-issue.md
+              printf -- '---\n\n' >> full-issue.md
+              cat "$body" >> full-issue.md
               created=$(gh issue create -R "$GITHUB_REPOSITORY" --title "$title" \
-                --label fuzz-finding --body-file "$full")
+                --label fuzz-finding --body-file full-issue.md)
               echo "::notice::Filed $created ($title)"
             fi
           }
 
-          # There may be one fuzz artifact per matrix variant; excerpt the first.
-          fuzz_dir=$(find artifacts -maxdepth 1 -type d -name 'fuzz-artifacts-*' 2>/dev/null | sort | head -1 || true)
+          printf 'Automated report from the [Fuzz workflow](%s). Triage runbook: [docs/dev/fuzzing.md](%s) — minimise the input, add a readable regression test, keep the encoded input as a corpus entry.\n\n' \
+            "$run_url" "$runbook" > finding-preamble.md
+          printf '> [!NOTE]\n> A later green run does **not** mean this is fixed: nightly seed bases rotate, so a failing input will not recur on its own. Close this issue once the finding is minimised and fixed (or triaged as an oracle/generator bug). Until then, new failures of the same job append comments here instead of opening new issues.\n\n' \
+            >> finding-preamble.md
 
-          report_one "$RESULT_FUZZ" fuzz \
-            'Fuzz CI: bounded fuzzing failed (crash or test failure)' \
-            "${fuzz_dir:-artifacts/fuzz-artifacts-missing}" \
-            'The bounded fuzz pass failed: either the pre-fuzz `zig build test` phase failed, or a fuzz target found a crash. The encoded crashing input (a serialized Smith decision stream) is `.zig-cache/f/crash` inside the artifact; `fuzz-run.log` is the fuzzer transcript. Replay it per the runbook.'
+          # report_finding JOB TITLE DIR HINT — file a marker-confirmed finding.
+          report_finding() {
+            job="$1"; title="$2"; fdir="$3"; hint="$4"
+            fbody="body-$job.md"
+            body_start "$job" "$hint" "$fbody"
+            excerpt "$fdir" "$fbody"
+            file_or_append "$title" finding-preamble.md "$fbody"
+          }
 
-          report_one "$RESULT_NATIVE" native-diff \
+          infra_jobs=""
+
+          # check_job RESULT JOB TITLE MARKER DIR HINT — route a failed job to its
+          # finding issue when the finding marker is present, or collect it for the
+          # shared infrastructure issue when it is not.
+          check_job() {
+            result="$1"; job="$2"; title="$3"; marker="$4"; dir="$5"; hint="$6"
+            [ "$result" = failure ] || return 0
+            if [ -n "$marker" ]; then
+              report_finding "$job" "$title" "$dir" "$hint"
+            else
+              infra_jobs="$infra_jobs $job"
+            fi
+          }
+
+          # Finding markers: a real finding always ships in the artifact — the
+          # encoded crash input for the fuzz job, seed-<N>.scm divergences for the
+          # diff jobs. A failed job without its marker is a toolchain/apt flake, a
+          # build or unit-test failure, or a job-level timeout (a possible hang) —
+          # those are reported below under an honest title instead of a finding one.
+          crash=$(find artifacts -type f -path '*fuzz-artifacts-*' -name crash 2>/dev/null | head -1 || true)
+          if [ -n "$crash" ]; then
+            fuzz_dir="${crash%/.zig-cache/f/crash}"
+          else
+            # No crash, but a test-phase failure still uploads fuzz-run.log.
+            fuzz_dir=$(find artifacts -maxdepth 1 -type d -name 'fuzz-artifacts-*' 2>/dev/null | sort | head -1 || true)
+            fuzz_dir="${fuzz_dir:-artifacts/fuzz-artifacts-missing}"
+          fi
+          native_marker=$(find artifacts/native-diff-divergences -name 'seed-*.scm' 2>/dev/null | head -1 || true)
+          oracle_marker=$(find artifacts/oracle-diff-divergences -name 'seed-*.scm' 2>/dev/null | head -1 || true)
+
+          check_job "$RESULT_FUZZ" fuzz \
+            'Fuzz CI: bounded fuzzing found a crash' \
+            "$crash" "$fuzz_dir" \
+            'A fuzz target found a crash. The encoded crashing input (a serialized Smith decision stream) is `.zig-cache/f/crash` inside the artifact; `fuzz-run.log` is the fuzzer transcript. Replay it per the runbook.'
+
+          check_job "$RESULT_NATIVE" native-diff \
             'Fuzz CI: VM vs native backend divergence' \
-            artifacts/native-diff-divergences \
+            "$native_marker" artifacts/native-diff-divergences \
             'A generated program behaved differently on the bytecode VM vs the LLVM native backend. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{vm,nat}.{out,err}` and `seed-<N>.compile.log`. The seed base is printed near the top of the job log; the same seed always regenerates the same program: `bash tests/fuzz/native-diff.sh <count> <base>`.'
 
-          report_one "$RESULT_ORACLE" oracle-diff \
+          check_job "$RESULT_ORACLE" oracle-diff \
             'Fuzz CI: Kaappi vs Chibi oracle divergence' \
-            artifacts/oracle-diff-divergences \
+            "$oracle_marker" artifacts/oracle-diff-divergences \
             'Kaappi and Chibi Scheme disagreed on a portable-subset program. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{kaappi,chibi}.{out,err}`; `oracle-version.txt` records the oracle version. Triage protocol (Kaappi bug / oracle bug / generator leak) is in the header of `tests/fuzz/oracle-diff.sh`. Replay: `bash tests/fuzz/oracle-diff.sh <count> <base>`.'
+
+          if [ -n "$infra_jobs" ]; then
+            printf 'Automated report from the [Fuzz workflow](%s): a job failed WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM), a build or unit-test failure unrelated to fuzzing, or a job-level timeout. A timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious.\n\n' \
+              "$run_url" > infra-preamble.md
+            printf '> [!NOTE]\n> Close this issue once the failed run is explained (or the underlying breakage is fixed); further artifact-less failures append comments here.\n\n' \
+              >> infra-preamble.md
+            body_start "${infra_jobs# }" \
+              'The failed job(s) uploaded no finding artifact, so this is not (necessarily) a fuzz finding. Check the run log for a setup or build step failure, a unit-test failure, or a job cancelled at its timeout.' \
+              body-infra.md
+            case " $infra_jobs " in
+              *' fuzz '*) excerpt "$fuzz_dir" body-infra.md ;;
+            esac
+            file_or_append 'Fuzz CI: infrastructure or build failure' infra-preamble.md body-infra.md
+          fi

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,7 +5,9 @@ name: Fuzz
 # (tests/fuzz/native-diff.sh) and Kaappi vs Chibi Scheme
 # (tests/fuzz/oracle-diff.sh). See docs/dev/fuzzing.md for the runbook
 # (running locally, and turning a failure into a regression test + corpus
-# entry).
+# entry). Failures are auto-filed as GitHub issues labeled `fuzz-finding`
+# by the trailing `report` job — see that job's comment for the dedup and
+# token-isolation design.
 
 on:
   schedule:
@@ -112,7 +114,10 @@ jobs:
 
       # f/crash holds the crashing input as a serialized Smith decision
       # stream (see docs/dev/fuzzing.md for turning it into a regression
-      # test); libfuzzer.log has the fuzzer's own transcript.
+      # test); libfuzzer.log has the fuzzer's own transcript. Both live
+      # under the hidden .zig-cache/ directory, which upload-artifact
+      # excludes by default — without include-hidden-files the artifact
+      # would silently contain only fuzz-run.log.
       - name: Upload fuzz artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -122,6 +127,7 @@ jobs:
             .zig-cache/f/crash
             fuzz-run.log
             .zig-cache/tmp/libfuzzer.log
+          include-hidden-files: true
           retention-days: 90
           if-no-files-found: warn
 
@@ -188,12 +194,12 @@ jobs:
     steps:
       # This job executes fuzzer-generated programs; don't leave the
       # GITHUB_TOKEN sitting in git config for the process tree.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install Zig
-        uses: xyzzylabs/setup-zig@v1
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
         with:
           version: 0.16.0
           cache-key: fuzz-oracle-diff
@@ -230,3 +236,136 @@ jobs:
           path: oracle-diff-results/
           retention-days: 90
           if-no-files-found: warn
+
+  # A failure above is otherwise only visible as a red run in the Actions
+  # tab (plus a notification email to whoever last touched the cron line).
+  # This job turns any failed job into a GitHub issue: one open issue per
+  # job, labeled fuzz-finding, with the run link, a bounded artifact
+  # excerpt, and replay instructions; while that issue stays open, repeat
+  # failures append comments instead of opening duplicates. Issues are
+  # never auto-closed: seed bases rotate nightly, so a green run does not
+  # mean a finding is fixed. This is a SEPARATE job so the write-capable
+  # token never coexists with execution of fuzzer-generated programs — the
+  # three jobs above keep contents:read tokens and persist-credentials:
+  # false; this one runs no generated code (artifact contents are only
+  # copied into issue text).
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [fuzz, native-diff, oracle-diff]
+    if: failure()
+    permissions:
+      issues: write
+      actions: read # download this run's failure artifacts for the excerpt
+    steps:
+      # No checkout: the job needs nothing from the repo, and gh targets it
+      # via -R. Each artifact lands in its own subdirectory of artifacts/.
+      - name: Download failure artifacts
+        continue-on-error: true # a job may have died before its upload step
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+
+      - name: File or update finding issues
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT_FUZZ: ${{ needs.fuzz.result }}
+          RESULT_NATIVE: ${{ needs.native-diff.result }}
+          RESULT_ORACLE: ${{ needs.oracle-diff.result }}
+        run: |
+          set -euo pipefail
+
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          runbook="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/main/docs/dev/fuzzing.md"
+
+          gh label create fuzz-finding -R "$GITHUB_REPOSITORY" --force \
+            --color B60205 \
+            --description "Automated finding from the scheduled Fuzz workflow"
+
+          # excerpt DIR OUT — append a bounded artifact listing plus the first
+          # divergence (or the fuzzer transcript tail) to OUT. Artifacts stay the
+          # authoritative copy; this is only enough to eyeball the finding.
+          excerpt() {
+            dir="$1"; out="$2"
+            if [ ! -d "$dir" ]; then
+              printf '_No artifact was uploaded (the job may have died before its upload step); see the run log._\n' >> "$out"
+              return 0
+            fi
+            {
+              printf '<details><summary>Artifact excerpt</summary>\n\n```\n'
+              (cd "$dir" && find . -type f | sort | head -40)
+              printf '```\n'
+            } >> "$out"
+            scm=$(find "$dir" -name 'seed-*.scm' | sort | head -1 || true)
+            if [ -n "$scm" ]; then
+              base=$(basename "$scm" .scm)
+              for f in "$scm" $(find "$(dirname "$scm")" -name "$base.*" ! -name '*.scm' | sort); do
+                [ -f "$f" ] || continue
+                printf '\n`%s`:\n\n```\n' "$(basename "$f")" >> "$out"
+                head -c 1500 "$f" >> "$out"
+                printf '\n```\n' >> "$out"
+              done
+            fi
+            log=$(find "$dir" -name 'fuzz-run.log' | head -1 || true)
+            if [ -n "$log" ]; then
+              printf '\nTail of `fuzz-run.log`:\n\n```\n' >> "$out"
+              tail -c 2000 "$log" >> "$out"
+              printf '\n```\n' >> "$out"
+            fi
+            printf '</details>\n' >> "$out"
+          }
+
+          # report_one RESULT JOB TITLE ARTIFACT_DIR HINT — file a new fuzz-finding
+          # issue for JOB, or append a comment if one with the same title is open.
+          report_one() {
+            result="$1"; job="$2"; title="$3"; dir="$4"; hint="$5"
+            [ "$result" = failure ] || return 0
+            body="body-$job.md"
+            {
+              printf '**Failed job:** `%s` — [run #%s](%s) (`%s`)\n\n' \
+                "$job" "$GITHUB_RUN_NUMBER" "$run_url" "$GITHUB_EVENT_NAME"
+              printf '%s\n\n' "$hint"
+              printf 'Download everything: `gh run download %s -R %s` (artifacts are retained for 90 days).\n\n' \
+                "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY"
+            } > "$body"
+            excerpt "$dir" "$body"
+            num=$(gh issue list -R "$GITHUB_REPOSITORY" --state open --label fuzz-finding \
+                    --json number,title \
+                  | jq -r --arg t "$title" '[.[] | select(.title == $t)][0].number // empty')
+            if [ -n "$num" ]; then
+              gh issue comment "$num" -R "$GITHUB_REPOSITORY" --body-file "$body"
+              echo "::notice::Appended failure report to existing issue #$num ($title)"
+            else
+              full="full-$job.md"
+              {
+                printf 'Automated report from the [Fuzz workflow](%s). Triage runbook: [docs/dev/fuzzing.md](%s) — minimise the input, add a readable regression test, keep the encoded input as a corpus entry.\n\n' \
+                  "$run_url" "$runbook"
+                printf '> [!NOTE]\n'
+                printf '> A later green run does **not** mean this is fixed: nightly seed bases rotate, so a failing input will not recur on its own. Close this issue once the finding is minimised and fixed (or triaged as an oracle/generator bug). Until then, new failures of the same job append comments here instead of opening new issues.\n\n'
+                printf -- '---\n\n'
+                cat "$body"
+              } > "$full"
+              created=$(gh issue create -R "$GITHUB_REPOSITORY" --title "$title" \
+                --label fuzz-finding --body-file "$full")
+              echo "::notice::Filed $created ($title)"
+            fi
+          }
+
+          # There may be one fuzz artifact per matrix variant; excerpt the first.
+          fuzz_dir=$(find artifacts -maxdepth 1 -type d -name 'fuzz-artifacts-*' 2>/dev/null | sort | head -1 || true)
+
+          report_one "$RESULT_FUZZ" fuzz \
+            'Fuzz CI: bounded fuzzing failed (crash or test failure)' \
+            "${fuzz_dir:-artifacts/fuzz-artifacts-missing}" \
+            'The bounded fuzz pass failed: either the pre-fuzz `zig build test` phase failed, or a fuzz target found a crash. The encoded crashing input (a serialized Smith decision stream) is `.zig-cache/f/crash` inside the artifact; `fuzz-run.log` is the fuzzer transcript. Replay it per the runbook.'
+
+          report_one "$RESULT_NATIVE" native-diff \
+            'Fuzz CI: VM vs native backend divergence' \
+            artifacts/native-diff-divergences \
+            'A generated program behaved differently on the bytecode VM vs the LLVM native backend. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{vm,nat}.{out,err}` and `seed-<N>.compile.log`. The seed base is printed near the top of the job log; the same seed always regenerates the same program: `bash tests/fuzz/native-diff.sh <count> <base>`.'
+
+          report_one "$RESULT_ORACLE" oracle-diff \
+            'Fuzz CI: Kaappi vs Chibi oracle divergence' \
+            artifacts/oracle-diff-divergences \
+            'Kaappi and Chibi Scheme disagreed on a portable-subset program. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{kaappi,chibi}.{out,err}`; `oracle-version.txt` records the oracle version. Triage protocol (Kaappi bug / oracle bug / generator leak) is in the header of `tests/fuzz/oracle-diff.sh`. Replay: `bash tests/fuzz/oracle-diff.sh <count> <base>`.'

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -133,10 +133,16 @@ fuzz pass, `native-diff`, or `oracle-diff`) is auto-filed as a GitHub
 issue by the trailing `report` job — one open issue per job, labeled
 `fuzz-finding`, containing the run link, a bounded artifact excerpt (the
 first divergent program plus both sides' output, or the fuzzer transcript
-tail), and replay instructions. While that issue stays open, repeat
-failures append comments to it instead of opening duplicates. Issues are
-never auto-closed: seed bases rotate nightly, so a later green run does
-not mean a finding is fixed — close the issue once the input is minimised
+tail), and replay instructions. A finding-titled issue is only filed when
+the finding marker is actually present in the uploaded artifacts (the
+encoded crash input for the fuzz job, `seed-<N>.scm` divergences for the
+diff jobs); failed jobs without their marker — toolchain flakes, build or
+unit-test failures, job-level timeouts (a possible hang) — are collected
+under a single shared issue titled `Fuzz CI: infrastructure or build
+failure` instead. While an issue stays open, repeat failures append
+comments to it instead of opening duplicates. Issues are never
+auto-closed: seed bases rotate nightly, so a later green run does not
+mean a finding is fixed — close the issue once the input is minimised
 into a regression test. The `report` job is the only one with a
 write-capable token (`issues: write`) and executes no fuzzer-generated
 code; the three fuzzing jobs keep read-only tokens and

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -128,10 +128,24 @@ across runs via `actions/cache` with a rolling key, so nightly coverage
 accumulates instead of restarting from the seeds; the cache is only saved
 on success, so crash state never leaks into the next run.
 
-The job needs no services, network access beyond checkout/toolchain, or
-special permissions: the eval harness registers only the sandboxed
-primitive set (no filesystem, process, FFI, or thread procedures), and
-everything runs in-process in the test binary.
+**How findings reach you:** any failed job in the workflow (the bounded
+fuzz pass, `native-diff`, or `oracle-diff`) is auto-filed as a GitHub
+issue by the trailing `report` job — one open issue per job, labeled
+`fuzz-finding`, containing the run link, a bounded artifact excerpt (the
+first divergent program plus both sides' output, or the fuzzer transcript
+tail), and replay instructions. While that issue stays open, repeat
+failures append comments to it instead of opening duplicates. Issues are
+never auto-closed: seed bases rotate nightly, so a later green run does
+not mean a finding is fixed — close the issue once the input is minimised
+into a regression test. The `report` job is the only one with a
+write-capable token (`issues: write`) and executes no fuzzer-generated
+code; the three fuzzing jobs keep read-only tokens and
+`persist-credentials: false`.
+
+The fuzzing jobs themselves need no services, network access beyond
+checkout/toolchain, or special permissions: the eval harness registers
+only the sandboxed primitive set (no filesystem, process, FFI, or thread
+procedures), and everything runs in-process in the test binary.
 
 ## The VM-vs-native differential batch (#1395)
 


### PR DESCRIPTION
## Why

The Fuzz workflow (daily 02:47 UTC cron) fails the run and uploads artifacts when it finds something, but nothing pushes that at a human: GitHub only emails the actor of a scheduled run (whoever last touched the cron line), so findings could sit unnoticed while their artifacts age toward the 90-day expiry. Follow-up to the #1397 fuzzing roadmap (CI job from #1390).

## What

**New `report` job** (`needs: [fuzz, native-diff, oracle-diff]`, `if: failure()`) that files findings into the issue tracker:

- One open issue per failed job, with a fixed title (`Fuzz CI: bounded fuzzing found a crash` / `…VM vs native backend divergence` / `…Kaappi vs Chibi oracle divergence`) and the `fuzz-finding` label (created idempotently with `gh label create --force`).
- Issue body: run link, replay instructions per job, and a bounded artifact excerpt — file listing, the first divergent `seed-<N>.scm` with both sides' out/err, or the tail of `fuzz-run.log` (each file capped at 1.5 KB, well under comment limits).
- **False-positive gating:** a finding-titled issue is only filed when the finding marker is actually present in the uploaded artifacts (the encoded crash input at `.zig-cache/f/crash`, or `seed-<N>.scm` divergence files). Failed jobs without their marker — apt/toolchain flakes, a broken build on main, job-level timeouts — are collected under one deduped `Fuzz CI: infrastructure or build failure` issue that says plainly it is not (necessarily) a finding. They're reported rather than dropped because a job timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious.
- **Dedup:** while an issue with that exact title is open, later failures append comments instead of opening duplicates. During a fix iteration this builds a log of failing runs on one issue.
- **No auto-close:** seed bases rotate nightly, so a later green run does not mean a finding is fixed. Humans close after minimise → regression test → corpus entry (per the runbook, which this PR updates).

**Token isolation:** the three fuzzing jobs execute fuzzer-generated programs, which is why they run with `contents: read` and `persist-credentials: false`. The report job is deliberately separate: it holds the only write-capable token (`issues: write` + `actions: read` for artifact download), does no checkout, and executes no generated code — artifact contents are only copied into issue text.

**Two latent fixes noticed in passing:**

- `include-hidden-files: true` on the fuzz artifact upload — `.zig-cache/f/crash` (the authoritative encoded crashing input) and `libfuzzer.log` live under a hidden directory, which upload-artifact excludes by default. Until now a crash artifact would have silently contained only `fuzz-run.log`. (The marker gating also depends on this fix.)
- The oracle-diff job's `checkout@v7` / `setup-zig@v1` steps were the only ones in the file not SHA-pinned (repo standard since #1413); pinned to the same SHAs used by the other jobs.

## Testing

- `yaml.safe_load` parses; report-job structure asserted (needs/if/permissions/env); embedded script byte-identical to a standalone copy that passes `bash -n` and shellcheck.
- **Routing dry-run against a stubbed `gh`** in four scenarios: (A) fuzz job failed with no artifacts → infrastructure issue; (B) native-diff divergence marker → finding issue with program + both outputs excerpted; (C) crash marker → crash finding issue; (D) mixed run — oracle finding appended as a comment to an existing open issue (dedup) while the fuzz build failure filed the infrastructure issue with the `fuzz-run.log` tail.
- Dedup query (`gh issue list --label fuzz-finding` + jq exact-title match) run read-only against this repo: returns empty with exit 0 even while the label doesn't exist yet, so `set -e` is safe on first use.
- The live failure path can't be exercised without a real finding; first validation will be the next actual failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)