### PR TITLE
Make the unit suite run green under -Dgc-stress=true

### DIFF
--- a/.claude/rules/gc-safety.md
+++ b/.claude/rules/gc-safety.md
@@ -19,12 +19,37 @@ string-set!, record field mutation):
 
 - **Allocator Value arguments are auto-rooted**: `allocPair(car, cdr)` and
   other `allocXxx` functions that take Value arguments root them internally
-  via `arg_roots` before `maybeCollect()`. Callers do NOT need to root Values
-  that are passed directly as allocator arguments. However, Values held in
-  local variables across multiple allocation calls still need manual rooting.
+  via `arg_roots` before `maybeCollect()`. Value slices (`allocVector`,
+  `allocNativeClosure`, `allocMultipleValues`, `allocRecordInstance`,
+  `makeList`) are rooted via `slice_roots`. Callers do NOT need to root
+  Values that are passed directly as allocator arguments. However, Values
+  held in local variables across multiple allocation calls still need
+  manual rooting.
+
+- **Allocators copy caller memory before collecting**: `allocXxx` functions
+  that receive a slice (string bytes, limbs, Values) copy it into raw memory
+  *before* `maybeCollect()`, so a slice that aliases another heap object's
+  storage (e.g. `bignum.limbs`, `SchemeString.data`, `vec.data`) stays valid
+  even if that object is collected. Preserve this order when editing them
+  (#1401).
+
+- **Root fresh results between allocations**: a Value returned by one
+  allocating call is unrooted; holding it in a local while a second call
+  allocates lets the collection free it — and the second allocation often
+  lands in the recycled memory, silently aliasing the two (#1414 made every
+  bignum/bignum division return 1 this way). Root the first result (e.g.
+  `gc.rootedSlot`) before computing the second.
 
 - **Root Function* before vm.execute()**: `execute()` allocates a closure
   wrapper internally.
+
+- **`vm_instance` must point at the live VM before anything allocates**: the
+  GC root marker finds the globals/macros/libraries through the
+  `vm_instance` threadlocal. Call `vm_mod.setVMInstance(vm)` right after
+  `VM.init` — before `registerAll` — and never let a VM struct move after
+  that (heap-allocate it or keep it in a stable stack frame). A stale or
+  null `vm_instance` means collections sweep everything the globals
+  reference (#1401).
 
 Dangerous pattern:
 ```zig

--- a/.claude/skills/do-stress-test/SKILL.md
+++ b/.claude/skills/do-stress-test/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: do-stress-test
+description: Run the Kaappi unit suite under -Dgc-stress=true on a real x86-64 Linux machine using a DigitalOcean droplet with a 3-hour lifetime. Use when the user asks to stress-test on Linux, run the gc-stress suite on real hardware, verify GC rooting under stress on x86-64, or stress test on DigitalOcean. Complements /do-linux-test (normal suite, ~1-hour droplet) — this variant runs the collection-per-allocation build, which takes hours, not minutes.
+---
+
+# DigitalOcean GC-Stress Test (3-hour droplet)
+
+Build Kaappi with `-Dgc-stress=true` (a collection is attempted on every
+allocation) and run the full unit suite on a temporary x86-64 DigitalOcean
+droplet. The droplet self-destructs after **3 hours** and is **always**
+destroyed when done.
+
+Key differences from `/do-linux-test`:
+- The stress suite is CPU-bound for **1.5–3 hours** (every test VM bootstrap
+  performs tens of thousands of collections; ~40 min on an M-series Mac).
+- It runs detached (`nohup`) on the droplet and is **polled**, never awaited
+  in a single SSH command — no SSH command may outlive the Bash tool timeout.
+- The testing allocator's metadata churn inflates RSS by gigabytes, so the
+  droplet gets more memory plus a swap file.
+
+## Pre-flight
+
+### 1. Record branch and check for unpushed work
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo "Branch: $BRANCH"
+git status --porcelain
+git ls-remote --heads origin "$BRANCH"
+```
+
+Only pushed commits are tested. If the branch has no remote tracking, ask the
+user to push first.
+
+### 2. Get SSH key fingerprint
+
+```bash
+ssh-keygen -l -E md5 -f ~/.ssh/id_rsa.pub | awk '{print $2}' | sed 's/MD5://'
+```
+
+## Create the droplet
+
+Use `mcp__digitalocean-droplets__droplet-create`:
+- **Name**: `kaappi-stress-<branch>` (replace `/` with `-`, truncate to 60 chars)
+- **Size**: `s-4vcpu-8gb-amd` (premium AMD — the suite is single-core-bound,
+  so per-core speed matters; fall back to `s-4vcpu-8gb` if unavailable)
+- **Region**: `nyc3`
+- **ImageSlug**: `ubuntu-24-04-x64`
+- **SSHKeys**: `["<fingerprint>"]`
+- **Tags**: `["kaappi-test", "kaappi-stress"]`
+- **Monitoring**: `true`
+
+Record the **droplet ID** immediately — it is needed for cleanup.
+
+## Wait for SSH access
+
+1. Poll with `mcp__digitalocean-droplets__droplet-get` every 10 seconds until
+   `status` is `active` and a public IPv4 is assigned (max 2 minutes).
+
+2. Wait for sshd:
+   ```bash
+   IP=<droplet-ip>
+   for i in $(seq 1 24); do
+     ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+       -o UserKnownHostsFile=/dev/null root@$IP echo ready 2>/dev/null && break
+     sleep 5
+   done
+   ```
+
+## Arm the 3-hour self-destruct timer
+
+Immediately after SSH is up. This guarantees destruction even if the Claude
+session dies mid-run. **3 hours 5 minutes** (11100 s) gives the run its full
+3-hour budget with a small margin:
+
+```bash
+DO_TOKEN=$(source ~/.zshrc 2>/dev/null && echo "$DIGITALOCEAN_API_TOKEN")
+ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  root@$IP "nohup bash -c 'sleep 11100 && curl -sf -X DELETE \
+    -H \"Authorization: Bearer $DO_TOKEN\" \
+    https://api.digitalocean.com/v2/droplets/<DROPLET_ID>' \
+    > /dev/null 2>&1 &"
+```
+
+The token lives only in the process's memory on a throwaway droplet.
+
+## Provision
+
+One SSH command (well under the Bash tool timeout):
+
+```bash
+ssh -i ~/.ssh/id_rsa \
+  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  root@$IP 'bash -s' << 'REMOTE'
+set -euo pipefail
+
+echo "==== Swap (OOM insurance for testing-allocator churn) ===="
+fallocate -l 8G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile
+
+echo "==== Installing Zig 0.16 ===="
+cd /tmp
+curl -sL https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar xJ -C /opt
+ln -sf /opt/zig-x86_64-linux-0.16.0/zig /usr/local/bin/zig
+zig version
+
+echo "==== Waiting for apt lock ===="
+while fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || \
+      fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+  sleep 5
+done
+
+echo "==== Installing dependencies ===="
+apt-get update -qq
+apt-get install -y -qq git make gcc libc6-dev > /dev/null 2>&1
+
+echo "==== Cloning repo (branch: <BRANCH>) ===="
+git clone --depth 1 --branch <BRANCH> https://github.com/kaappi/kaappi.git /workspace
+echo "PROVISION: OK"
+REMOTE
+```
+
+## Sanity check: plain build and test first
+
+Catch a broken commit in minutes before burning hours on the stress run:
+
+```bash
+ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  root@$IP 'cd /workspace && zig build 2>&1 | tail -5 && zig build test 2>&1 | tail -5; echo "PLAIN: $?"'
+```
+
+If the plain suite fails, report and go straight to Cleanup — a stress run on
+a broken commit is wasted money.
+
+## Launch the stress suite (detached)
+
+**Never run the stress suite as a foreground SSH command** — it takes
+1.5–3 hours. Launch it detached, writing to a results file:
+
+```bash
+ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  root@$IP 'cd /workspace && nohup bash -c \
+    "zig build test -Dgc-stress=true > /tmp/stress-results.txt 2>&1; \
+     echo EXIT:\$? >> /tmp/stress-results.txt; touch /tmp/stress-done" \
+    > /dev/null 2>&1 & echo LAUNCHED'
+```
+
+Record the local start time.
+
+## Poll for completion
+
+Poll every few minutes with short SSH commands. Each poll checks for the done
+marker and shows the process is still alive:
+
+```bash
+ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+  -o UserKnownHostsFile=/dev/null root@$IP \
+  'test -f /tmp/stress-done && echo DONE || \
+   { pgrep -f "gc-stress|unit-tests" > /dev/null && echo RUNNING || echo DEAD; }'
+```
+
+- Locally, prefer a background Bash poll loop (e.g. `until ssh ... test -f
+  /tmp/stress-done; do sleep 120; done` with `run_in_background`) so the
+  session is notified on completion instead of burning foreground calls.
+- **RUNNING**: keep waiting. Report progress to the user roughly every
+  30 minutes.
+- **DEAD** without the done marker: the process was killed (OOM is the usual
+  suspect — check `dmesg | grep -i oom` and `free -h`). Fetch partial results
+  and report.
+- If ~2 h 45 min elapse without completion, fetch whatever
+  `/tmp/stress-results.txt` holds — the self-destruct fires at 3 h 05 min.
+
+## Fetch results
+
+```bash
+ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  root@$IP 'grep -E "error: |pass|skip|fail|crash|EXIT" /tmp/stress-results.txt | tail -40'
+```
+
+If the connection was interrupted at any point, the results file is still on
+the droplet — reconnect and fetch.
+
+## Report results
+
+- **Plain build/test**: OK / FAIL
+- **Stress suite**: the `N pass, N skip, N fail, N crash (N total)` line and
+  `EXIT:` code. Expect a handful of **skips** — throughput- or memory-bound
+  tests deliberately skip on stress builds (see `docs/dev/testing.md`).
+- Every `error: '<test name>' ...` line, verbatim — under gc-stress a crash
+  signature (poison reads, "@memcpy arguments alias", "incorrect alignment")
+  usually means an unrooted value; see `.claude/rules/gc-safety.md`.
+- Wall time of the stress run.
+
+## Cleanup
+
+**CRITICAL: This step MUST run regardless of outcome — success, failure,
+timeout, or error.** Never skip it, and never rely solely on the
+self-destruct timer.
+
+Use `mcp__digitalocean-droplets__droplet-delete` with the recorded droplet ID.
+
+If deletion fails, **warn the user immediately** with the droplet ID and IP so
+they can destroy it manually via the DigitalOcean console.
+
+## Notes
+
+- **Cost**: `s-4vcpu-8gb-amd` is ~$0.084/hr → a full 3-hour window costs
+  ~$0.25.
+- **Why hours**: with a collection attempted on every allocation, each test's
+  VM bootstrap alone performs tens of thousands of full collections. ~40 min
+  on an M-series Mac; budget 1.5–3 h on droplet vCPUs.
+- **Memory**: `std.testing.allocator` (DebugAllocator) metadata churn under
+  stress inflates process RSS far beyond real heap use (#1401 postmortem:
+  multi-GB peaks). Hence 8 GB RAM + 8 GB swap; if the run still dies to the
+  OOM killer, check whether a new test needs the stress-build scaling pattern
+  from `docs/dev/testing.md`.
+- **SSH key**: uses `~/.ssh/id_rsa`; the public key must be on the DO account.
+- **Stale droplets**: if a session dies, list droplets via
+  `mcp__digitalocean-droplets__droplet-list` and destroy anything named
+  `kaappi-stress-*` (they also carry the `kaappi-test` tag).
+- **macOS has no `timeout`**: never `timeout N ssh ...`; use the detached
+  launch + poll pattern above.
+- **CI equivalent**: the `gc-stress` variant of `.github/workflows/fuzz.yml`
+  runs this same suite (300-minute job timeout) on schedule/dispatch — this
+  skill is for on-demand runs against a branch before merging.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   fuzz:
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
@@ -55,15 +55,19 @@ jobs:
           - variant: default
             build-args: ''
             limit: 2K
-          # The planned gc-stress variant (collection attempted on every
-          # allocation, converting latent rooting bugs into immediate
-          # failures) is DISABLED: ~440 of 690 unit tests currently crash
-          # under -Dgc-stress=true, so the pre-fuzz test phase can never
-          # pass. Re-enable when https://github.com/kaappi/kaappi/issues/1401
-          # is fixed.
-          # - variant: gc-stress
-          #   build-args: '-Dgc-stress=true'
-          #   limit: 200
+            timeout: 55
+          # gc-stress: collection attempted on every allocation, converting
+          # latent rooting bugs into immediate, attributable failures
+          # (#1401, fixed). The pre-fuzz unit-test phase dominates the wall
+          # time here — every test's VM bootstrap runs tens of thousands of
+          # collections (~35 min locally on M-series; budget more on a
+          # hosted runner) — so the fuzz limit stays small and the timeout
+          # generous. Throughput-sensitive fuzz targets skip themselves on
+          # stress builds (src/tests_fuzz.zig).
+          - variant: gc-stress
+            build-args: '-Dgc-stress=true'
+            limit: 100
+            timeout: 300
     steps:
       # Both jobs in this workflow execute fuzzer-generated programs (and
       # the native-diff job runs binaries compiled from them), so don't

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ zig build run -- f.scm             # run a Scheme file
 zig build run -- --help            # show CLI usage and flags
 zig build run -- --version         # show version string
 zig build test                     # run all unit tests
+zig build test -Dtest-filter=tests_io  # only tests whose names match (repeatable)
 zig build bench                    # call/cc vs call/ec capture micro-benchmark
 zig build coverage                 # unit test code coverage (requires kcov)
 zig build coverage-scheme -- f.scm # Scheme file code coverage (requires kcov)
@@ -306,6 +307,12 @@ passes with it. Place it in the appropriate location:
 - Zig unit test → `src/tests_*.zig` (for VM, compiler, GC internals)
 - Scheme test → `tests/scheme/smoke/` or a dedicated file under `tests/scheme/`
   (for end-to-end behavior visible from Scheme)
+
+The unit suite must also stay green under `zig build test -Dgc-stress=true`
+(collection on every allocation — #1401). Tests that hold heap values in Zig
+locals across allocations must root them; loop-heavy tests that allocate per
+iteration should scale their counts down via
+`@import("build_options").gc_stress` (see `docs/dev/testing.md`).
 
 - **Unit tests**: `src/tests_*.zig` — named by feature: `tests_core_eval.zig`, `tests_macros.zig`, `tests_io.zig`, etc. Run all with `zig build test`.
 - **R7RS test suite**: `tests/scheme/r7rs/r7rs-tests.scm` — 1,391 tests using `(chibi test)`. Run with `zig build run -- tests/scheme/r7rs/r7rs-tests.scm`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,6 +493,7 @@ detailed checklists for GC write barriers, rooting, and compiler form additions.
 | `/r7rs-reader` | R7RS lexical syntax reference for reader changes |
 | `/linux-test` | Build and test on Linux via podman (aarch64, x86_64, riscv64) |
 | `/do-linux-test` | Full test suite on real x86-64 Linux via DigitalOcean droplet |
+| `/do-stress-test` | Unit suite under `-Dgc-stress=true` on a DigitalOcean droplet (3-hour lifetime) |
 
 ### Ecosystem plugin (`kaappi-dev`)
 

--- a/build.zig
+++ b/build.zig
@@ -269,6 +269,7 @@ pub fn build(b: *std.Build) void {
     const thottam_tests = b.addTest(.{
         .name = "thottam-tests",
         .root_module = thottam_test_mod,
+        .filters = test_filters,
     });
     const run_thottam_tests = b.addRunArtifact(thottam_tests);
     test_step.dependOn(&run_thottam_tests.step);

--- a/build.zig
+++ b/build.zig
@@ -28,6 +28,8 @@ pub fn build(b: *std.Build) void {
     const gc_threshold = b.option(u32, "gc-threshold", "Initial GC object threshold (default: 8192)") orelse 8192;
     const gc_stress = b.option(bool, "gc-stress", "Force GC on every allocation (stress testing)") orelse false;
 
+    const test_filters = b.option([]const []const u8, "test-filter", "Only run unit tests whose names match the filter (repeatable)") orelse &.{};
+
     const options = b.addOptions();
     options.addOption(u32, "max_frames", max_frames);
     options.addOption(u32, "max_registers", max_registers);
@@ -253,6 +255,7 @@ pub fn build(b: *std.Build) void {
     const unit_tests = b.addTest(.{
         .name = "unit-tests",
         .root_module = test_mod,
+        .filters = test_filters,
     });
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -85,10 +85,14 @@ across runs; coverage stats accumulate in `.zig-cache/v/`. Delete
 
 A `-Dgc-stress=true` build attempts a collection at every allocation (except
 under `no_collect` or while the GC is disabled), which turns latent rooting
-bugs into immediate, attributable failures instead of rare heisenbugs.
-**Currently blocked:** ~440 of the 690 unit tests crash under gc-stress
-([#1401](https://github.com/kaappi/kaappi/issues/1401)), so a gc-stress fuzz
-run cannot get past the test phase until that is fixed.
+bugs into immediate, attributable failures instead of rare heisenbugs. The
+unit suite is required to stay green under stress
+([#1401](https://github.com/kaappi/kaappi/issues/1401) fixed the harness and
+the rooting bugs it was masking, including the #1414 bignum aliasing
+corruption). Expect a stress test run to be slow — every test VM bootstrap
+performs tens of thousands of collections — and loop-heavy tests that
+allocate per iteration to scale their counts down via
+`@import("build_options").gc_stress` (see `docs/dev/testing.md`).
 
 ## The CI job
 
@@ -96,16 +100,18 @@ run cannot get past the test phase until that is fixed.
 bounded fuzz pass daily at 02:47 UTC (scheduled away from the 05:17 UTC
 ecosystem nightly), in two variants:
 
-| Variant | Build | Limit (per fuzz test) |
-|---------|-------|-----------------------|
-| `default` | standard `ReleaseSafe` test build | 2K runs |
-| `gc-stress` | `-Dgc-stress=true` | *disabled* — see below |
+| Variant | Build | Limit (per fuzz test) | Job timeout |
+|---------|-------|-----------------------|-------------|
+| `default` | standard `ReleaseSafe` test build | 2K runs | 55 min |
+| `gc-stress` | `-Dgc-stress=true` | 100 runs | 300 min |
 
-The `gc-stress` variant is disabled in the matrix until
-[#1401](https://github.com/kaappi/kaappi/issues/1401) is fixed: ~440 of the
-690 unit tests currently crash under `-Dgc-stress=true`, so the pre-fuzz
-test phase can never pass. (Its first and only CI execution is what found
-that.) Re-enable it once the suite is stress-clean.
+The `gc-stress` variant runs the whole unit suite with a collection on
+every allocation before fuzzing, so its wall time is dominated by the test
+phase, not the fuzz limit. (Its first CI execution is what found
+[#1401](https://github.com/kaappi/kaappi/issues/1401); the suite has been
+required to stay stress-clean since that fix.) Throughput-sensitive fuzz
+targets skip themselves on stress builds — see the `gc_stress` checks in
+`src/tests_fuzz.zig`.
 
 Trigger it manually (optionally overriding the limit) with:
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -43,31 +43,33 @@ Unit tests live in `src/tests_*.zig`, organized by feature:
 ### Helper: makeTestVM
 
 The `src/testing_helpers.zig` file provides a `makeTestVM` helper that creates
-a fully initialized VM suitable for testing:
+a fully bootstrapped VM suitable for testing:
 
 ```zig
-const helpers = @import("testing_helpers.zig");
+const th = @import("testing_helpers.zig");
+const memory = @import("memory.zig");
 
 test "my feature" {
-    var ctx = try helpers.makeTestVM();
-    defer ctx.deinit();
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
 
-    const result = ctx.vm.eval("(+ 1 2)") catch unreachable;
+    const result = try vm.eval("(+ 1 2)");
     try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
 }
 ```
 
-### Writing a unit test
+`makeTestVM` returns a heap-allocated `*VM` — never a struct copy. The GC
+root marker and the `vm_instance` threadlocal reach the VM by pointer, so
+the VM must live at a stable address from before the first primitive is
+registered; a by-value VM left those pointers dangling, which is invisible
+under normal GC thresholds but fatal under `-Dgc-stress=true` (#1401).
+`vm.deinit()` also frees the VM struct itself (`heap_owned`).
 
-```zig
-test "string-length with Unicode" {
-    var ctx = try helpers.makeTestVM();
-    defer ctx.deinit();
-
-    const result = ctx.vm.eval("(string-length \"hello\")") catch unreachable;
-    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(result));
-}
-```
+For one-liner assertions use the wrappers: `th.expectEval(src, fixnum)`,
+`th.expectEvalTrue(src)`, `th.expectEvalBool(src, bool)`,
+`th.expectEvalVoid(src)`, or `th.TestContext` for multi-step tests.
 
 Use `std.testing.expectEqual` for value comparisons and `std.testing.expect`
 for boolean checks.
@@ -75,12 +77,25 @@ for boolean checks.
 ### Running
 
 ```bash
-zig build test              # Run all tests
-zig build test 2>&1 | head  # Quick check for failures
+zig build test                            # Run all tests
+zig build test 2>&1 | head                # Quick check for failures
+zig build test -Dtest-filter=tests_io     # Only tests whose names match
+zig build test -Dtest-filter="eval quote" # Substring match on test names
+zig build test -Dgc-stress=true           # Collection on every allocation
 ```
 
 Individual test files cannot be run in isolation -- `zig build test` runs all
-tests discovered through the import graph from `main.zig`.
+tests discovered through the import graph from `main.zig`. Use
+`-Dtest-filter` (repeatable) to narrow a run; test names are prefixed with
+their module (e.g. `tests_io.test.eval read-char`), so a file name is an
+effective per-file filter.
+
+A `-Dgc-stress=true` test run forces a collection at every allocation,
+turning latent rooting bugs into immediate failures. Every test must stay
+green under stress; loop-heavy tests that allocate per iteration should
+scale their iteration count down via `@import("build_options").gc_stress`
+(see `tests_records.zig` for the pattern) so the stress suite stays
+tractable.
 
 ---
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -46,8 +46,10 @@ The `src/testing_helpers.zig` file provides a `makeTestVM` helper that creates
 a fully bootstrapped VM suitable for testing:
 
 ```zig
+const std = @import("std");
 const th = @import("testing_helpers.zig");
 const memory = @import("memory.zig");
+const types = @import("types.zig");
 
 test "my feature" {
     var gc = memory.GC.init(std.testing.allocator);

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -33,8 +33,9 @@ fn measure(allocator: std.mem.Allocator, prim: []const u8, depth: u32, iters: u3
     defer gc.deinit();
     var vm = try vm_mod.VM.init(&gc);
     defer vm.deinit();
-    try primitives.registerAll(&vm);
+    vm_mod.setVMInstance(&vm);
     memory.setGCInstance(&gc);
+    try primitives.registerAll(&vm);
     try vm_mod.vm_bootstrap.install(&vm);
     try library.registerStandardLibraries(&vm.libraries, vm.globals);
 

--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -960,7 +960,11 @@ test "bignum add with carry propagation" {
 test "bignum add different signs (positive + negative)" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
-    const pos = try gc.allocBignumFromLimbs(&[_]u64{ 100, 1 }, 2, true);
+    // Root each value across the next allocation: under -Dgc-stress=true
+    // every allocation collects, and an unrooted local would be swept.
+    var pos = try gc.allocBignumFromLimbs(&[_]u64{ 100, 1 }, 2, true);
+    gc.pushRoot(&pos);
+    defer gc.popRoot();
     const neg = try gc.allocBignumFromLimbs(&[_]u64{50}, 1, false);
     const result = try add(&gc, pos, neg);
     try std.testing.expect(!isValueZero(result));
@@ -969,7 +973,9 @@ test "bignum add different signs (positive + negative)" {
 test "bignum add different signs cancellation" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
-    const pos = try gc.allocBignumFromLimbs(&[_]u64{42}, 1, true);
+    var pos = try gc.allocBignumFromLimbs(&[_]u64{42}, 1, true);
+    gc.pushRoot(&pos);
+    defer gc.popRoot();
     const neg = try gc.allocBignumFromLimbs(&[_]u64{42}, 1, false);
     const result = try add(&gc, pos, neg);
     try std.testing.expect(isValueZero(result));
@@ -978,7 +984,9 @@ test "bignum add different signs cancellation" {
 test "bignum add negative larger magnitude" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
-    const small_pos = try gc.allocBignumFromLimbs(&[_]u64{10}, 1, true);
+    var small_pos = try gc.allocBignumFromLimbs(&[_]u64{10}, 1, true);
+    gc.pushRoot(&small_pos);
+    defer gc.popRoot();
     const large_neg = try gc.allocBignumFromLimbs(&[_]u64{100}, 1, false);
     const result = try add(&gc, small_pos, large_neg);
     try std.testing.expect(isNegative(result));
@@ -996,7 +1004,9 @@ test "bignum multiply by zero" {
 test "bignum isPositive and isNegative" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
-    const pos = try gc.allocBignumFromLimbs(&[_]u64{42}, 1, true);
+    var pos = try gc.allocBignumFromLimbs(&[_]u64{42}, 1, true);
+    gc.pushRoot(&pos);
+    defer gc.popRoot();
     const neg = try gc.allocBignumFromLimbs(&[_]u64{42}, 1, false);
     try std.testing.expect(isPositive(pos));
     try std.testing.expect(!isNegative(pos));
@@ -1011,7 +1021,9 @@ test "bignum isPositive and isNegative" {
 test "bignum isEven" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
-    const even_bn = try gc.allocBignumFromLimbs(&[_]u64{42}, 1, true);
+    var even_bn = try gc.allocBignumFromLimbs(&[_]u64{42}, 1, true);
+    gc.pushRoot(&even_bn);
+    defer gc.popRoot();
     const odd_bn = try gc.allocBignumFromLimbs(&[_]u64{43}, 1, true);
     try std.testing.expect(isEven(even_bn));
     try std.testing.expect(!isEven(odd_bn));

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -1032,6 +1032,11 @@ test "bytecode round-trip: various constant types" {
     defer gc.deinit();
 
     const func = try gc.allocFunction();
+    // Root the function: the constant allocations below can collect, and an
+    // unrooted func would be swept while we are still appending into it.
+    var func_root = types.makePointer(@ptrCast(func));
+    gc.pushRoot(&func_root);
+    defer gc.popRoot();
     func.code.append(allocator, @intFromEnum(types.OpCode.load_void)) catch unreachable;
     func.code.append(allocator, 0) catch unreachable; // dst high
     func.code.append(allocator, 0) catch unreachable; // dst low
@@ -1234,6 +1239,11 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
     defer gc.deinit();
 
     const func = try gc.allocFunction();
+    // Root the function: the constant allocations below can collect, and an
+    // unrooted func would be swept while we are still appending into it.
+    var func_root = types.makePointer(@ptrCast(func));
+    gc.pushRoot(&func_root);
+    defer gc.popRoot();
     func.code.append(allocator, @intFromEnum(types.OpCode.load_void)) catch unreachable;
     func.code.append(allocator, 0) catch unreachable; // dst high
     func.code.append(allocator, 0) catch unreachable; // dst low

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -434,6 +434,12 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
             if (ds_rest == types.NIL or !types.isPair(ds_rest)) break;
             const transformer_spec = types.car(ds_rest);
             const tx_val = macro.parseSyntaxRules(&child, transformer_spec, all_def_names[0..all_def_count]) catch break;
+            // Root the transformer for the rest of this top-level compile:
+            // it lives only in the compiler-local macro map, which the GC
+            // cannot see, and it must survive collections triggered while
+            // compiling sibling body forms that use it (#1401). Released by
+            // the extra_roots truncation in compileExpression*.
+            child.gc.extra_roots.append(child.gc.allocator, tx_val) catch return CompileError.OutOfMemory;
             const ds_name = types.symbolName(keyword);
             try child.recordBodyMacro(ds_name);
             const tx_obj = types.toObject(tx_val).as(types.Transformer);

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -434,11 +434,12 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
             if (ds_rest == types.NIL or !types.isPair(ds_rest)) break;
             const transformer_spec = types.car(ds_rest);
             const tx_val = macro.parseSyntaxRules(&child, transformer_spec, all_def_names[0..all_def_count]) catch break;
-            // Root the transformer for the rest of this top-level compile:
-            // it lives only in the compiler-local macro map, which the GC
+            // Root the transformer for the rest of this body compile: it
+            // lives only in the compiler-local macro map, which the GC
             // cannot see, and it must survive collections triggered while
             // compiling sibling body forms that use it (#1401). Released by
-            // the extra_roots truncation in compileExpression*.
+            // this function's extra_roots truncation (roots_base defer),
+            // after the body — the macro's entire scope — is compiled.
             child.gc.extra_roots.append(child.gc.allocator, tx_val) catch return CompileError.OutOfMemory;
             const ds_name = types.symbolName(keyword);
             try child.recordBodyMacro(ds_name);

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -311,6 +311,9 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
             const transformer_spec = types.car(ds_rest);
 
             const transformer = macro.parseSyntaxRules(self, transformer_spec, all_def_names[0..all_def_count]) catch break;
+            // Root for the rest of the compile — see the define-syntax
+            // handling in compiler_ir.zig's body scan (#1401).
+            self.gc.extra_roots.append(self.gc.allocator, transformer) catch return CompileError.OutOfMemory;
             const name = types.symbolName(keyword);
 
             try self.recordBodyMacro(name);

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -278,6 +278,13 @@ pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!
 
     const transformer = parseSyntaxRules(self, transformer_spec, &.{}) catch return CompileError.InvalidSyntax;
 
+    // Root the transformer for the rest of this top-level compile: it lives
+    // only in the compiler-local macro map, which the GC cannot see, and a
+    // body-local macro must survive collections triggered while compiling
+    // sibling forms that use it (#1401). Released by the extra_roots
+    // truncation in compileExpression* when compilation finishes.
+    self.gc.extra_roots.append(self.gc.allocator, transformer) catch return CompileError.OutOfMemory;
+
     const tx = types.toObject(transformer).as(types.Transformer);
     if (self.lib_env) |env| {
         tx.def_env = env;
@@ -406,6 +413,9 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
         const transformer_spec = types.car(binding_rest);
         const transformer = parseSyntaxRules(self, transformer_spec, &.{}) catch return CompileError.InvalidSyntax;
         const name = types.symbolName(keyword);
+
+        // Root for the rest of the compile — see compileDefineSyntax (#1401).
+        self.gc.extra_roots.append(self.gc.allocator, transformer) catch return CompileError.OutOfMemory;
 
         saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -278,11 +278,13 @@ pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!
 
     const transformer = parseSyntaxRules(self, transformer_spec, &.{}) catch return CompileError.InvalidSyntax;
 
-    // Root the transformer for the rest of this top-level compile: it lives
-    // only in the compiler-local macro map, which the GC cannot see, and a
-    // body-local macro must survive collections triggered while compiling
-    // sibling forms that use it (#1401). Released by the extra_roots
-    // truncation in compileExpression* when compilation finishes.
+    // Root the transformer for the rest of the enclosing compile scope: it
+    // lives only in the compiler-local macro map, which the GC cannot see,
+    // and a body-local macro must survive collections triggered while
+    // compiling sibling forms that use it (#1401). Released by the
+    // enclosing scope's extra_roots truncation — compileExpression* at top
+    // level, or the lambda-body compile (compileLambdaWithIR /
+    // compileLambda) for body scopes.
     self.gc.extra_roots.append(self.gc.allocator, transformer) catch return CompileError.OutOfMemory;
 
     const tx = types.toObject(transformer).as(types.Transformer);

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -478,6 +478,9 @@ fn markRoots(gc: *GC) void {
     for (gc.arg_roots[0..gc.arg_root_count]) |v| {
         markValue(gc, v);
     }
+    if (gc.slice_roots) |sr| {
+        for (sr) |v| markValue(gc, v);
+    }
     for (gc.root_buffer[0..gc.root_count]) |root| {
         markValue(gc, root.*);
     }

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -738,8 +738,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer gc.deinit();
     var vm = try vm_mod.VM.init(&gc);
     defer vm.deinit();
-    try primitives.registerAll(&vm);
+    vm_mod.setVMInstance(&vm);
     memory.setGCInstance(&gc);
+    try primitives.registerAll(&vm);
     try vm_mod.vm_bootstrap.install(&vm);
     try library.registerStandardLibraries(&vm.libraries, vm.globals);
 

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -109,6 +109,13 @@ pub const GC = struct {
     arg_roots: [4]Value = .{ 0, 0, 0, 0 },
     arg_root_count: u3 = 0,
     remembered_set: std.ArrayList(*Object),
+    /// Like `arg_roots`, but for a caller-provided slice of Values: allocators
+    /// that receive `[]const Value` (allocVector, allocNativeClosure, ...)
+    /// point this at the (raw, non-GC) buffer before maybeCollect() so the
+    /// values survive the collection without the caller having to root each
+    /// element. Always save/restore rather than assign/null so nested
+    /// allocations (makeList → allocPair) compose.
+    slice_roots: ?[]const Value = null,
     stress: bool = build_options.gc_stress,
     enabled: bool = true,
     no_collect: u32 = 0,
@@ -296,9 +303,11 @@ pub const GC = struct {
     }
 
     pub fn allocString(self: *GC, data: []const u8) !Value {
-        try self.maybeCollect();
+        // Copy before collecting: `data` may point into another heap object
+        // (e.g. a SchemeString's bytes) that this collection could free.
         const owned = try self.allocator.dupe(u8, data);
         errdefer self.allocator.free(owned);
+        try self.maybeCollect();
         const str = try self.allocator.create(SchemeString);
         str.* = .{
             .header = .{ .tag = .string },
@@ -353,10 +362,15 @@ pub const GC = struct {
     }
 
     pub fn allocNativeClosure(self: *GC, fn_ptr: types.NativeClosureFnType, upvalues: []const Value, arity: u8, name: []const u8) !Value {
-        try self.maybeCollect();
+        // Copy upvalues before collecting and root them across the collection
+        // (see allocVector).
         const uv_copy = try self.allocator.alloc(Value, upvalues.len);
         errdefer self.allocator.free(uv_copy);
         @memcpy(uv_copy, upvalues);
+        const saved_slice_roots = self.slice_roots;
+        self.slice_roots = uv_copy;
+        defer self.slice_roots = saved_slice_roots;
+        try self.maybeCollect();
         const nc = try self.allocator.create(types.NativeClosure);
         nc.* = .{
             .header = .{ .tag = .native_closure },
@@ -375,10 +389,16 @@ pub const GC = struct {
     }
 
     pub fn allocVector(self: *GC, data: []const Value) !Value {
-        try self.maybeCollect();
+        // Copy before collecting (`data` may alias another vector's storage),
+        // and root the copied values across the collection: callers routinely
+        // pass freshly allocated Values held nowhere else.
         const owned = try self.allocator.alloc(Value, data.len);
         errdefer self.allocator.free(owned);
         @memcpy(owned, data);
+        const saved_slice_roots = self.slice_roots;
+        self.slice_roots = owned;
+        defer self.slice_roots = saved_slice_roots;
+        try self.maybeCollect();
         const vec = try self.allocator.create(Vector);
         vec.* = .{
             .header = .{ .tag = .vector },
@@ -440,9 +460,10 @@ pub const GC = struct {
     }
 
     pub fn allocRecordType(self: *GC, name: []const u8, num_fields: u8) !Value {
-        try self.maybeCollect();
+        // Copy before collecting: `name` may alias a symbol/string's bytes.
         const owned_name = try self.allocator.dupe(u8, name);
         errdefer self.allocator.free(owned_name);
+        try self.maybeCollect();
         const rt = try self.allocator.create(RecordType);
         rt.* = .{
             .header = .{ .tag = .record_type },
@@ -454,7 +475,8 @@ pub const GC = struct {
     }
 
     pub fn allocRecordInstance(self: *GC, record_type: *RecordType, field_values: []const Value) !Value {
-        try self.maybeCollect();
+        // Copy the fields before collecting and root them (plus the record
+        // type itself) across the collection (see allocVector).
         const fields = try self.allocator.alloc(Value, record_type.num_fields);
         errdefer self.allocator.free(fields);
         for (0..record_type.num_fields) |i| {
@@ -464,6 +486,12 @@ pub const GC = struct {
                 fields[i] = types.UNDEFINED;
             }
         }
+        self.rootArgs1(types.makePointer(@ptrCast(record_type)));
+        const saved_slice_roots = self.slice_roots;
+        self.slice_roots = fields;
+        defer self.slice_roots = saved_slice_roots;
+        try self.maybeCollect();
+        self.clearArgRoots();
         const ri = try self.allocator.create(RecordInstance);
         ri.* = .{
             .header = .{ .tag = .record_instance },
@@ -498,9 +526,10 @@ pub const GC = struct {
     }
 
     pub fn allocStringInputPort(self: *GC, data: []const u8) !Value {
-        try self.maybeCollect();
+        // Copy before collecting: `data` usually aliases a SchemeString.
         const owned = try self.allocator.dupe(u8, data);
         errdefer self.allocator.free(owned);
+        try self.maybeCollect();
         const port = try self.allocator.create(Port);
         port.* = .{
             .header = .{ .tag = .port },
@@ -544,9 +573,10 @@ pub const GC = struct {
     }
 
     pub fn allocBytevector(self: *GC, data: []const u8) !Value {
-        try self.maybeCollect();
+        // Copy before collecting: `data` may alias another bytevector/string.
         const owned = try self.allocator.dupe(u8, data);
         errdefer self.allocator.free(owned);
+        try self.maybeCollect();
         const bv = try self.allocator.create(Bytevector);
         bv.* = .{
             .header = .{ .tag = .bytevector },
@@ -726,9 +756,10 @@ pub const GC = struct {
     }
 
     pub fn allocFfiLibrary(self: *GC, handle: ?*anyopaque, name: []const u8) !Value {
-        try self.maybeCollect();
+        // Copy before collecting: `name` may alias a SchemeString's bytes.
         const owned_name = try self.allocator.dupe(u8, name);
         errdefer self.allocator.free(owned_name);
+        try self.maybeCollect();
         const lib = try self.allocator.create(FfiLibrary);
         lib.* = .{
             .header = .{ .tag = .ffi_library },
@@ -740,13 +771,14 @@ pub const GC = struct {
     }
 
     pub fn allocFfiFunction(self: *GC, symbol: *anyopaque, library: Value, name: []const u8, param_types: []const FfiType, return_type: FfiType) !Value {
-        self.rootArgs1(library);
-        try self.maybeCollect();
-        self.clearArgRoots();
+        // Copy before collecting: `name` may alias a SchemeString's bytes.
         const owned_name = try self.allocator.dupe(u8, name);
         errdefer self.allocator.free(owned_name);
         const owned_params = try self.allocator.dupe(FfiType, param_types);
         errdefer self.allocator.free(owned_params);
+        self.rootArgs1(library);
+        try self.maybeCollect();
+        self.clearArgRoots();
         const ffi_fn = try self.allocator.create(FfiFunction);
         ffi_fn.* = .{
             .header = .{ .tag = .ffi_function },
@@ -929,11 +961,16 @@ pub const GC = struct {
     }
 
     pub fn allocBignumFromLimbs(self: *GC, limbs: []const u64, len: usize, positive: bool) !Value {
-        try self.maybeCollect();
+        // Copy before collecting: `limbs` often aliases a source Bignum's limb
+        // array (negate, abs, remainder). Collecting first frees that bignum
+        // when the caller holds it only in a local, and the fresh `owned`
+        // block can then land in the freed limbs' place — the "@memcpy
+        // arguments alias" crash under -Dgc-stress=true (#1401).
         const owned = try self.allocator.alloc(u64, limbs.len);
         errdefer self.allocator.free(owned);
-        const bn = try self.allocator.create(Bignum);
         @memcpy(owned, limbs);
+        try self.maybeCollect();
+        const bn = try self.allocator.create(Bignum);
         bn.* = .{
             .header = .{ .tag = .bignum },
             .limbs = owned,
@@ -998,7 +1035,7 @@ pub const GC = struct {
     }
 
     pub fn allocUserInfo(self: *GC, name: []const u8, uid: u32, gid: u32, home_dir: []const u8, shell: []const u8, full_name: []const u8) !Value {
-        try self.maybeCollect();
+        // Copy before collecting (see allocString).
         const name_copy = try self.allocator.dupe(u8, name);
         errdefer self.allocator.free(name_copy);
         const home_copy = try self.allocator.dupe(u8, home_dir);
@@ -1007,6 +1044,7 @@ pub const GC = struct {
         errdefer self.allocator.free(shell_copy);
         const gecos_copy = try self.allocator.dupe(u8, full_name);
         errdefer self.allocator.free(gecos_copy);
+        try self.maybeCollect();
         const ui = try self.allocator.create(types.UserInfo);
         ui.* = .{
             .header = .{ .tag = .user_info },
@@ -1022,9 +1060,10 @@ pub const GC = struct {
     }
 
     pub fn allocGroupInfo(self: *GC, name: []const u8, gid: u32) !Value {
-        try self.maybeCollect();
+        // Copy before collecting (see allocString).
         const name_copy = try self.allocator.dupe(u8, name);
         errdefer self.allocator.free(name_copy);
+        try self.maybeCollect();
         const gi = try self.allocator.create(types.GroupInfo);
         gi.* = .{
             .header = .{ .tag = .group_info },
@@ -1061,8 +1100,14 @@ pub const GC = struct {
     }
 
     pub fn allocMultipleValues(self: *GC, values: []const Value) !Value {
-        try self.maybeCollect();
+        // Copy before collecting and root the values across the collection
+        // (see allocVector).
         const owned = try self.allocator.dupe(Value, values);
+        errdefer self.allocator.free(owned);
+        const saved_slice_roots = self.slice_roots;
+        self.slice_roots = owned;
+        defer self.slice_roots = saved_slice_roots;
+        try self.maybeCollect();
         const mv = try self.allocator.create(MultipleValues);
         mv.* = .{
             .header = .{ .tag = .multiple_values },
@@ -1074,13 +1119,23 @@ pub const GC = struct {
 
     // -- Convenience: build a proper list from a slice
     pub fn makeList(self: *GC, items: []const Value) !Value {
+        if (items.len == 0) return types.NIL;
+        // Copy into raw memory first — `items` may alias a heap object's
+        // storage (vector->list passes vec.data) that a collection can free —
+        // then root the copy: each allocPair only arg-roots the item being
+        // consed, so the not-yet-consed items would otherwise be collectable.
+        const copy = try self.allocator.dupe(Value, items);
+        defer self.allocator.free(copy);
+        const saved_slice_roots = self.slice_roots;
+        self.slice_roots = copy;
+        defer self.slice_roots = saved_slice_roots;
         var result: Value = types.NIL;
         self.pushRoot(&result);
         defer self.popRoot();
-        var i = items.len;
+        var i = copy.len;
         while (i > 0) {
             i -= 1;
-            result = try self.allocPair(items[i], result);
+            result = try self.allocPair(copy[i], result);
         }
         return result;
     }
@@ -1098,14 +1153,11 @@ pub const GC = struct {
     const gc_collect = @import("gc_collect.zig");
 
     fn maybeCollect(self: *GC) !void {
-        if (self.stress and self.enabled) {
-            if (self.no_collect == 0) self.collect();
-            if (self.memory_limit) |limit| {
-                if (self.bytes_allocated > limit) return error.OutOfMemory;
-            }
-            return;
-        }
-        if (self.enabled and self.object_count >= self.gc_threshold) {
+        // Stress mode only changes *when* a collection is due (every call
+        // instead of at the threshold); the no_collect and memory_limit
+        // semantics must match the normal path, or stress builds would
+        // OOM inside no_collect sections that normal builds merely defer.
+        if (self.enabled and (self.stress or self.object_count >= self.gc_threshold)) {
             if (self.no_collect > 0) {
                 self.stats.no_collect_deferred += 1;
             } else {

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -41,6 +41,14 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     defer redefined_names.deinit();
     ir_instance.set_targets = &redefined_names;
 
+    // The IR nodes built below (passthrough forms, define/quote literals)
+    // reference sexpr Values — including macro-expanded forms — that nothing
+    // roots. A collection triggered by a later readDatum/lower/execute would
+    // free them and the emitter would then walk dangling Values (#1401).
+    // Defer collection for the whole read → lower → emit batch.
+    vm.gc.no_collect += 1;
+    defer vm.gc.no_collect -= 1;
+
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
         var errbuf: [256]u8 = undefined;

--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -8,18 +8,36 @@ pub const VM = vm_mod.VM;
 pub const VMError = vm_mod.VMError;
 pub const Value = types.Value;
 
-pub fn makeTestVM(gc: *memory.GC) !VM {
-    var vm = try VM.init(gc);
+/// Build a fully bootstrapped VM for a unit test. The VM is heap-allocated
+/// and returned by pointer: `vm_instance` and the GC root marker reach the
+/// VM by address, so it must never move. Returning the struct by value (as
+/// this helper used to) left `vm_instance` pointing at a dead stack frame —
+/// harmless while the GC threshold was never reached mid-test, but fatal
+/// under -Dgc-stress=true, where every collection between construction and
+/// the first execute() then failed to mark the globals and swept live
+/// objects (#1401). `vm.deinit()` also destroys the struct (heap_owned).
+pub fn makeTestVM(gc: *memory.GC) !*VM {
+    const vm = try gc.allocator.create(VM);
+    vm.* = VM.init(gc) catch |err| {
+        gc.allocator.destroy(vm);
+        return err;
+    };
+    vm.heap_owned = true;
+    errdefer vm.deinit();
     memory.setGCInstance(gc);
-    try primitives_mod.registerAll(&vm);
-    try vm_mod.vm_bootstrap.install(&vm);
+    // Register before the first primitive allocation: under stress every
+    // allocation collects, and only a registered vm_instance lets the root
+    // marker keep the globals map alive while it is being populated.
+    vm_mod.setVMInstance(vm);
+    try primitives_mod.registerAll(vm);
+    try vm_mod.vm_bootstrap.install(vm);
     try library_mod.registerStandardLibraries(&vm.libraries, vm.globals);
     return vm;
 }
 
 pub const TestContext = struct {
     gc: memory.GC,
-    vm: VM,
+    vm: *VM,
 
     pub fn init(self: *TestContext) !void {
         self.gc = memory.GC.init(std.testing.allocator);

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -669,6 +669,13 @@ test "closure capturing more than 255 variables compiles and runs (#809)" {
     // Regression: addUpvalue did `@intCast` of the upvalue count into a u8
     // upvalue_count field, panicking (compile-time) past 255 captures. The
     // field is now u16, matching the u16 upvalue index in the bytecode.
+    //
+    // The u16-width property is orthogonal to GC rooting, and compiling the
+    // 300-capture program with a collection per allocation peaks around 7 GB
+    // RSS under the testing allocator — the full-suite stress run gets
+    // OOM-killed. Skip on stress builds; the 27-variable sibling test below
+    // keeps the capture path exercised there.
+    if (@import("build_options").gc_stress) return error.SkipZigTest;
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -141,7 +141,7 @@ test "vm deinit clears threadlocal vm_instance" {
 
     // execute() registers the VM in the threadlocal
     _ = try vm.eval("(+ 1 2)");
-    try std.testing.expect(vm_mod.vm_instance == &vm);
+    try std.testing.expect(vm_mod.vm_instance == vm);
 
     // deinit must unregister it: a stale pointer here is read by the macro
     // expander (renameForHygiene) during the next VM's first compile, before
@@ -412,6 +412,11 @@ test "interaction-environment allows define (#1147)" {
 
 // Regression for #1253: eval must be tail-called (R7RS 3.5)
 test "eval tail position runs in constant frame depth (#1253)" {
+    // The frame-depth property is only decisive with more iterations than
+    // MAX_FRAME_LIMIT (32768), and every iteration allocates through eval —
+    // under -Dgc-stress=true that is millions of full collections (hours).
+    // The property is orthogonal to GC rooting, so skip on stress builds.
+    if (@import("build_options").gc_stress) return error.SkipZigTest;
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -517,6 +522,7 @@ test "bootstrap stubs fail loudly without vm_bootstrap.install (#1375)" {
     defer gc.deinit();
     var vm = try vm_mod.VM.init(&gc);
     defer vm.deinit();
+    vm_mod.setVMInstance(&vm);
     memory.setGCInstance(&gc);
     try primitives_mod.registerAll(&vm);
 

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -366,7 +366,11 @@ test "deepCopy shared structure" {
     var gc2 = memory.GC.init(std.testing.allocator);
     defer gc2.deinit();
 
-    const shared = try gc1.allocPair(types.makeFixnum(99), types.NIL);
+    // Root shared across the vector allocation: under -Dgc-stress=true
+    // allocVectorFill collects gc1 and would sweep the unrooted pair.
+    var shared = try gc1.allocPair(types.makeFixnum(99), types.NIL);
+    gc1.pushRoot(&shared);
+    defer gc1.popRoot();
     const vec = try gc1.allocVectorFill(2, types.VOID);
     const v = types.toObject(vec).as(types.Vector);
     v.data[0] = shared;
@@ -454,7 +458,11 @@ test "deepCopy native procedures survive freeing the source heap" {
     {
         var gc1 = memory.GC.init(std.testing.allocator);
         defer gc1.deinit();
-        const nf_val = try gc1.allocNativeFn("survive-add1", &testAdd1, .{ .exact = 1 });
+        // Root nf_val across the closure allocation: under -Dgc-stress=true
+        // allocNativeClosure collects gc1 and would sweep the unrooted fn.
+        var nf_val = try gc1.allocNativeFn("survive-add1", &testAdd1, .{ .exact = 1 });
+        gc1.pushRoot(&nf_val);
+        defer gc1.popRoot();
         const upvalues = [_]types.Value{types.makeFixnum(5)};
         const nc_val = try gc1.allocNativeClosure(&testNativeClosureFn, &upvalues, 1, "survive-nc");
         copied_fn = try gc2.deepCopy(nf_val);

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -466,6 +466,11 @@ test "deepCopy native procedures survive freeing the source heap" {
         const upvalues = [_]types.Value{types.makeFixnum(5)};
         const nc_val = try gc1.allocNativeClosure(&testNativeClosureFn, &upvalues, 1, "survive-nc");
         copied_fn = try gc2.deepCopy(nf_val);
+        // Root copied_fn (a gc2 value) across the second deepCopy: it only
+        // survives today because deepCopyValue holds no_collect, and the
+        // gc-safety rule is to root values held across allocating calls.
+        gc2.pushRoot(&copied_fn);
+        defer gc2.popRoot();
         copied_nc = try gc2.deepCopy(nc_val);
     }
 

--- a/src/tests_ffi.zig
+++ b/src/tests_ffi.zig
@@ -39,21 +39,21 @@ test "ffi bool arg: non-0/1 integers coerced to 0/1, never trap (#796)" {
     // 2 must be coerced to 1 before reaching the _Bool parameter — passing it
     // through raw aborts the process under the safety check. Before the fix
     // this returned 2 (or trapped); the raw integer must never reach _Bool.
-    const r2 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(2)}, &ctx.gc, &ctx.vm);
+    const r2 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(2)}, &ctx.gc, ctx.vm);
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(r2));
 
     // Any nonzero value is true (C truthiness); zero is false.
-    const rneg = try ffi.callFfi(&fn_int, &.{types.makeFixnum(-5)}, &ctx.gc, &ctx.vm);
+    const rneg = try ffi.callFfi(&fn_int, &.{types.makeFixnum(-5)}, &ctx.gc, ctx.vm);
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rneg));
 
-    const r0 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(0)}, &ctx.gc, &ctx.vm);
+    const r0 = try ffi.callFfi(&fn_int, &.{types.makeFixnum(0)}, &ctx.gc, ctx.vm);
     try std.testing.expectEqual(@as(i64, 0), types.toFixnum(r0));
 
     // #t / #f keep working as before (#418).
-    const rt = try ffi.callFfi(&fn_int, &.{types.TRUE}, &ctx.gc, &ctx.vm);
+    const rt = try ffi.callFfi(&fn_int, &.{types.TRUE}, &ctx.gc, ctx.vm);
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rt));
 
-    const rf = try ffi.callFfi(&fn_int, &.{types.FALSE}, &ctx.gc, &ctx.vm);
+    const rf = try ffi.callFfi(&fn_int, &.{types.FALSE}, &ctx.gc, ctx.vm);
     try std.testing.expectEqual(@as(i64, 0), types.toFixnum(rf));
 }
 
@@ -68,7 +68,7 @@ test "ffi bool arg: bignum coerced to 0/1 (#796)" {
     // A value too large for a fixnum arrives as a bignum; it is still just a
     // truthy value for a bool parameter and must coerce to 1.
     const big = try ctx.gc.allocBignumFromI64(0x1_0000_0000_0000);
-    const rbig = try ffi.callFfi(&fn_int, &.{big}, &ctx.gc, &ctx.vm);
+    const rbig = try ffi.callFfi(&fn_int, &.{big}, &ctx.gc, ctx.vm);
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(rbig));
 }
 
@@ -80,10 +80,10 @@ test "ffi bool arg with bool return normalizes both directions (#796)" {
     var ptypes = [_]types.FfiType{.bool_type};
     var fn_bool = makeBoolFn(ptypes[0..], .bool_type);
 
-    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(2)}, &ctx.gc, &ctx.vm));
-    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(0)}, &ctx.gc, &ctx.vm));
-    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.TRUE}, &ctx.gc, &ctx.vm));
-    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.FALSE}, &ctx.gc, &ctx.vm));
+    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(2)}, &ctx.gc, ctx.vm));
+    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.makeFixnum(0)}, &ctx.gc, ctx.vm));
+    try std.testing.expectEqual(types.TRUE, try ffi.callFfi(&fn_bool, &.{types.TRUE}, &ctx.gc, ctx.vm));
+    try std.testing.expectEqual(types.FALSE, try ffi.callFfi(&fn_bool, &.{types.FALSE}, &ctx.gc, ctx.vm));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_io.zig
+++ b/src/tests_io.zig
@@ -103,7 +103,11 @@ test "write to file and read back with read-line" {
     _ = try vm.eval(
         \\(define p2 (open-input-file "/tmp/kaappi-test-readline.txt"))
     );
-    const result = try vm.eval("(read-line p2)");
+    // Root the returned string across the close-port eval: under
+    // -Dgc-stress=true its collections would sweep the unrooted local.
+    var result = try vm.eval("(read-line p2)");
+    gc.pushRoot(&result);
+    defer gc.popRoot();
     _ = try vm.eval("(close-port p2)");
 
     try std.testing.expect(types.isString(result));
@@ -298,7 +302,10 @@ test "display and write with port argument" {
     _ = try vm.eval(
         \\(define p2 (open-input-file "/tmp/kaappi-test-display.txt"))
     );
-    const result = try vm.eval("(read-line p2)");
+    // Root across the close-port eval (see the read-line test above).
+    var result = try vm.eval("(read-line p2)");
+    gc.pushRoot(&result);
+    defer gc.popRoot();
     _ = try vm.eval("(close-port p2)");
 
     try std.testing.expect(types.isString(result));
@@ -402,7 +409,10 @@ test "write to port with write procedure" {
     _ = try vm.eval(
         \\(define p2 (open-input-file "/tmp/kaappi-test-write.txt"))
     );
-    const result = try vm.eval("(read-line p2)");
+    // Root across the close-port eval (see the read-line test above).
+    var result = try vm.eval("(read-line p2)");
+    gc.pushRoot(&result);
+    defer gc.popRoot();
     _ = try vm.eval("(close-port p2)");
 
     try std.testing.expect(types.isString(result));

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -314,7 +314,7 @@ test "cond-expand (library ...) detects an unloaded .sld on the lib path" {
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
-    vm_mod.setVMInstance(&vm);
+    vm_mod.setVMInstance(vm);
     vm.lib_paths = &[_][]const u8{dir_path};
 
     // Expression context: checked by the compiler's evalFeatureReq.
@@ -399,7 +399,7 @@ test "stale .sbc next to .sld must not drop include-library-declarations exports
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
-    vm_mod.setVMInstance(&vm);
+    vm_mod.setVMInstance(vm);
     vm.lib_paths = &[_][]const u8{dir_path};
 
     _ = try vm.eval("(import (cachedlib mylib))");
@@ -498,8 +498,13 @@ test "retired lib_env values survive GC (#820)" {
     );
 
     // Allocation churn to force collections; `stash` is only reachable
-    // through the retired env, which markVMRoots must trace.
-    _ = try vm.eval(
+    // through the retired env, which markVMRoots must trace. Under
+    // -Dgc-stress=true every cons already collects and the growing list
+    // makes marking O(n²), so a small count churns just as decisively.
+    _ = try vm.eval(if (@import("build_options").gc_stress)
+        \\(let churn ((n 500) (acc '()))
+        \\  (if (= n 0) acc (churn (- n 1) (cons n acc))))
+    else
         \\(let churn ((n 50000) (acc '()))
         \\  (if (= n 0) acc (churn (- n 1) (cons n acc))))
     );

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -31,6 +31,12 @@ fn emitSourceResult(source: []const u8) !EmitResult {
     var gc = memory.GC.init(emitter_alloc);
     errdefer gc.deinit();
 
+    // Mirror emitLlvmFile: the IR references sexpr Values that nothing
+    // roots, so defer collection across the read → lower → emit batch or a
+    // gc-stress build frees them mid-emission (#1401). Balanced before the
+    // return (a defer would decrement only after `gc` is copied out).
+    gc.no_collect += 1;
+
     var reader = reader_mod.Reader.init(&gc, source);
     defer reader.deinit();
     const expr = try reader.readDatum();
@@ -51,6 +57,7 @@ fn emitSourceResult(source: []const u8) !EmitResult {
     errdefer emitter.deinit();
     try emitter.emitProgram(&nodes);
 
+    gc.no_collect -= 1;
     return .{ .gc = gc, .ir_instance = ir_instance, .emitter = emitter };
 }
 
@@ -67,6 +74,9 @@ fn emitMultiResult(source: []const u8) !EmitResult {
 fn emitMultiResultOpts(source: []const u8, optimize: bool) !EmitResult {
     var gc = memory.GC.init(emitter_alloc);
     errdefer gc.deinit();
+
+    // See emitSourceResult: collection is deferred until emission is done.
+    gc.no_collect += 1;
 
     var reader = reader_mod.Reader.init(&gc, source);
     defer reader.deinit();
@@ -95,6 +105,7 @@ fn emitMultiResultOpts(source: []const u8, optimize: bool) !EmitResult {
     errdefer emitter.deinit();
     try emitter.emitProgram(ir_nodes.items);
 
+    gc.no_collect -= 1;
     return .{ .gc = gc, .ir_instance = ir_instance, .emitter = emitter };
 }
 

--- a/src/tests_records.zig
+++ b/src/tests_records.zig
@@ -183,7 +183,22 @@ test "record-set! field survives full GC" {
         \\  (y point-y set-point-y!))
     );
 
-    const result = try vm.eval(
+    // Under -Dgc-stress=true every allocation already collects (full every
+    // 8th), so a small churn count exercises promotion + full collection
+    // without the marathon.
+    const result = try vm.eval(if (@import("build_options").gc_stress)
+        \\(let ()
+        \\  (define p (make-point 1 2))
+        \\  ;; Promote p to old generation
+        \\  (let loop ((i 0))
+        \\    (when (< i 100) (make-list 10 i) (loop (+ i 1))))
+        \\  ;; Mutate with young-gen value
+        \\  (set-point-y! p (list 'a 'b 'c))
+        \\  ;; Force enough GC cycles to trigger full collection
+        \\  (let loop ((i 0))
+        \\    (when (< i 100) (make-list 10 i) (loop (+ i 1))))
+        \\  (point-y p))
+    else
         \\(let ()
         \\  (define p (make-point 1 2))
         \\  ;; Promote p to old generation

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -236,13 +236,25 @@ test "GC stress: build long list" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    const result = try vm.eval(
+    // These three tests exist to force collection cycles. A -Dgc-stress=true
+    // build already collects on every allocation, so large iteration counts
+    // add no coverage there — only wall time and allocator churn (the 5000-
+    // iteration string loop peaked ~19.7 GB RSS under the testing allocator
+    // and got the suite OOM-killed). Scale the counts down on stress builds,
+    // like tests_records.
+    const result = try vm.eval(if (@import("build_options").gc_stress)
+        \\(let loop ((i 0) (acc '()))
+        \\  (if (= i 500)
+        \\      (length acc)
+        \\      (loop (+ i 1) (cons i acc))))
+    else
         \\(let loop ((i 0) (acc '()))
         \\  (if (= i 10000)
         \\      (length acc)
         \\      (loop (+ i 1) (cons i acc))))
     );
-    try std.testing.expectEqual(@as(i64, 10000), types.toFixnum(result));
+    const expected_len: i64 = if (@import("build_options").gc_stress) 500 else 10000;
+    try std.testing.expectEqual(expected_len, types.toFixnum(result));
 }
 
 test "GC stress: many string allocations" {
@@ -251,7 +263,15 @@ test "GC stress: many string allocations" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    const result = try vm.eval(
+    // See "GC stress: build long list" for the stress-build scaling.
+    const result = try vm.eval(if (@import("build_options").gc_stress)
+        \\(let loop ((i 0))
+        \\  (if (= i 300)
+        \\      i
+        \\      (begin
+        \\        (string-append "hello" "world" (number->string i))
+        \\        (loop (+ i 1)))))
+    else
         \\(let loop ((i 0))
         \\  (if (= i 5000)
         \\      i
@@ -259,7 +279,8 @@ test "GC stress: many string allocations" {
         \\        (string-append "hello" "world" (number->string i))
         \\        (loop (+ i 1)))))
     );
-    try std.testing.expectEqual(@as(i64, 5000), types.toFixnum(result));
+    const expected: i64 = if (@import("build_options").gc_stress) 300 else 5000;
+    try std.testing.expectEqual(expected, types.toFixnum(result));
 }
 
 test "GC stress: many vector allocations" {
@@ -268,7 +289,15 @@ test "GC stress: many vector allocations" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    const result = try vm.eval(
+    // See "GC stress: build long list" for the stress-build scaling.
+    const result = try vm.eval(if (@import("build_options").gc_stress)
+        \\(let loop ((i 0))
+        \\  (if (= i 300)
+        \\      i
+        \\      (begin
+        \\        (make-vector 10 i)
+        \\        (loop (+ i 1)))))
+    else
         \\(let loop ((i 0))
         \\  (if (= i 5000)
         \\      i
@@ -276,7 +305,8 @@ test "GC stress: many vector allocations" {
         \\        (make-vector 10 i)
         \\        (loop (+ i 1)))))
     );
-    try std.testing.expectEqual(@as(i64, 5000), types.toFixnum(result));
+    const expected: i64 = if (@import("build_options").gc_stress) 300 else 5000;
+    try std.testing.expectEqual(expected, types.toFixnum(result));
 }
 
 // ---------------------------------------------------------------------------
@@ -429,7 +459,11 @@ test "memory_limit defers collection inside no_collect section" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
-    const a = try gc.allocPair(types.NIL, types.NIL);
+    // Root a across b's allocation: under -Dgc-stress=true it collects and
+    // would sweep the unrooted pair, which the assertions below dereference.
+    var a = try gc.allocPair(types.NIL, types.NIL);
+    gc.pushRoot(&a);
+    defer gc.popRoot();
     const b = try gc.allocPair(types.NIL, types.NIL);
 
     gc.no_collect += 1;

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -22,7 +22,7 @@ test "child VM globals view survives parent-side rehash (#958)" {
 
     var child_gc = memory.GC.initForThread(std.testing.allocator, &gc);
     defer child_gc.deinit();
-    var child_vm = try vm_mod.VM.initForThread(&child_gc, &vm);
+    var child_vm = try vm_mod.VM.initForThread(&child_gc, vm);
     defer child_vm.deinit();
 
     try vm.defineGlobal("race-counter", types.makeFixnum(1));
@@ -181,10 +181,18 @@ test "abandonFiberMutexes handles multiple mutexes" {
     defer vm.deinit();
 
     const fiber = try gc.allocFiber(types.VOID, 0);
-    const fiber_val = types.makePointer(@ptrCast(fiber));
+    var fiber_val = types.makePointer(@ptrCast(fiber));
+    // Root everything across the following allocations: under -Dgc-stress=true
+    // each allocMutex collects, and an unrooted fiber/mutex local is swept.
+    gc.pushRoot(&fiber_val);
+    defer gc.popRoot();
 
-    const m1_val = try gc.allocMutex(types.VOID);
-    const m2_val = try gc.allocMutex(types.VOID);
+    var m1_val = try gc.allocMutex(types.VOID);
+    gc.pushRoot(&m1_val);
+    defer gc.popRoot();
+    var m2_val = try gc.allocMutex(types.VOID);
+    gc.pushRoot(&m2_val);
+    defer gc.popRoot();
     const m3_val = try gc.allocMutex(types.VOID);
     const m1 = types.toMutex(m1_val);
     const m2 = types.toMutex(m2_val);
@@ -382,6 +390,18 @@ test "child thread collections leave no stale marks on parent heap (#958)" {
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
+
+    // The mark-bit scan below detects CHILD-written marks, relying on the
+    // parent not collecting during this eval: the parent's own minor
+    // collections legitimately leave mark bits on old-gen objects until the
+    // next cycle's clearOldMarks. Make the parent quiescent — threshold-
+    // driven again, with one forced full cycle to clear every mark bit and
+    // recompute the post-bootstrap threshold — while the child GC created
+    // by thread-start! still stresses on stress builds, which is the
+    // direction this regression test cares about.
+    gc.stress = false;
+    gc.minor_cycle_count = 8; // force the next collect to be a full cycle
+    gc.collect();
 
     // build-list is a parent-heap closure; 20000 elements exceeds the child
     // GC threshold, so the child collects (and marks its roots — which

--- a/src/tests_tail_calls.zig
+++ b/src/tests_tail_calls.zig
@@ -129,7 +129,7 @@ test "tail call to re-entrant native across frames array growth" {
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
-    try shrinkFrames(&vm);
+    try shrinkFrames(vm);
 
     _ = try vm.eval(
         \\(define (nest d)
@@ -151,7 +151,7 @@ test "tail apply of re-entrant native across frames array growth" {
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
-    try shrinkFrames(&vm);
+    try shrinkFrames(vm);
 
     _ = try vm.eval(
         \\(define (nest d)
@@ -173,7 +173,7 @@ test "tail call to parameter with converter across frames array growth" {
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
-    try shrinkFrames(&vm);
+    try shrinkFrames(vm);
 
     _ = try vm.eval("(define p (make-parameter 1 (lambda (v) (* v 10))))");
     _ = try vm.eval(

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -334,11 +334,15 @@ pub const VM = struct {
         };
         @memset(vm.registers, types.UNDEFINED);
         gc.root_marker = &markVMRoots;
+        // Root each port before allocating the next, exactly like init()
+        // (#1013): the child thread's `vm_instance` is not registered yet, so
+        // the root marker sees nothing — a collection triggered by the next
+        // allocPort would sweep the unrooted earlier port (#1401).
         vm.stdin_port = gc.allocPort(0, true, false, "stdin", false) catch types.VOID;
-        vm.stdout_port = gc.allocPort(1, false, true, "stdout", false) catch types.VOID;
-        vm.stderr_port = gc.allocPort(2, false, true, "stderr", false) catch types.VOID;
         if (vm.stdin_port != types.VOID) try gc.extra_roots.append(gc.allocator, vm.stdin_port);
+        vm.stdout_port = gc.allocPort(1, false, true, "stdout", false) catch types.VOID;
         if (vm.stdout_port != types.VOID) try gc.extra_roots.append(gc.allocator, vm.stdout_port);
+        vm.stderr_port = gc.allocPort(2, false, true, "stderr", false) catch types.VOID;
         if (vm.stderr_port != types.VOID) try gc.extra_roots.append(gc.allocator, vm.stderr_port);
         // Share parent's port parameter objects; override with child's own ports
         // so getParameterValue returns child-heap objects.

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -210,6 +210,13 @@ pub const VM = struct {
     /// and the trampoline cannot be unwound, so callFfi re-raises this after
     /// the enclosing FFI call returns. Traced by markVMRoots.
     callback_error_value: ?Value = null,
+    /// True when the VM struct itself was heap-allocated by its creator and
+    /// deinit() should destroy it (testing_helpers.makeTestVM). The struct
+    /// must live at a stable address: `vm_instance` and the GC root marker
+    /// reach it by pointer, so a by-value move would leave them dangling —
+    /// under -Dgc-stress=true that means every collection during construction
+    /// misses the globals and frees live objects (#1401).
+    heap_owned: bool = false,
     last_error_detail: [256]u8 = [_]u8{0} ** 256,
     last_error_detail_len: usize = 0,
     last_error_line: u32 = 0,
@@ -376,8 +383,10 @@ pub const VM = struct {
             if (bp.condition) |cond| self.gc.allocator.free(cond);
         }
         self.breakpoint_count = 0;
-        self.gc.allocator.free(self.frames);
-        self.gc.allocator.free(self.registers);
+        const allocator = self.gc.allocator;
+        allocator.free(self.frames);
+        allocator.free(self.registers);
+        if (self.heap_owned) allocator.destroy(self);
     }
 
     pub fn ensureFrameCapacity(self: *VM, needed: usize) VMError!void {

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -9,6 +9,7 @@ const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
 
 pub fn eval(vm: *VM, source: []const u8) VMError!Value {
+    vm_mod.setVMInstance(vm);
     const reader_mod = @import("reader.zig");
     var reader = reader_mod.Reader.init(vm.gc, source);
     defer reader.deinit();

--- a/tests/scheme/smoke/bignum-gc-alias-1414.scm
+++ b/tests/scheme/smoke/bignum-gc-alias-1414.scm
@@ -1,0 +1,29 @@
+;; Regression test for #1414: bignum/bignum division returned 1 and
+;; same-magnitude bignum subtraction returned 0 under -Dgc-stress=true.
+;; The rational accumulation loops in +, -, *, / left a freshly allocated
+;; product unrooted while computing the next one; the collection triggered
+;; by that second multiplication freed the first, whose memory the second
+;; then reused — numerator and denominator became the same object.
+;; On a normal build the window only opens when a threshold collection
+;; lands mid-loop; a gc-stress build makes these checks decisive.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "bignum-gc-alias-1414")
+
+;; 2^50 / 2^48 = 4
+(test-equal 4 (/ 1125899906842624 281474976710656))
+;; 2^48 / 2^50 = 1/4
+(test-equal 1/4 (/ 281474976710656 1125899906842624))
+;; (3 * 2^48) / 2^50 = 3/4
+(test-equal 3/4 (/ (* 3 281474976710656) 1125899906842624))
+;; 2^50 - 2^48 = 3 * 2^48 (aliased operands made this 0)
+(test-equal 844424930131968 (- 1125899906842624 281474976710656))
+;; 2^49 + 2^49 = 2^50 through the same accumulation path
+(test-equal 1125899906842624 (+ 562949953421312 562949953421312))
+;; Rational arithmetic mixing bignum numerators/denominators
+(test-equal 1/2 (/ 562949953421312 1125899906842624))
+(test-assert (= (* 281474976710656 4) 1125899906842624))
+
+(let ((runner (test-runner-current)))
+  (test-end "bignum-gc-alias-1414")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #1401.

The gc-stress build was never green (answering the issue's question 1): the test harness itself was broken, and it was masking a layer of real rooting bugs underneath. This lands the fix that was developed in a prior session's worktree, reconciled with the arithmetic rooting that already merged via #1421, plus the long tail of failures found by running the suite to completion.

## Harness

- `makeTestVM` returned the `VM` struct **by value**, but `vm_instance` and the GC root marker reach the VM by pointer — so every collection during `registerAll` swept the very globals being registered. It now returns a heap-allocated `*VM` (`heap_owned`, destroyed by `deinit()`); the ~312 call sites compile unchanged. The same bootstrap order (setVMInstance before registerAll) is applied to `bench.zig` and `kaappi_lsp.zig`; `main.zig` was already correct.
- `vm_eval.eval` registers the VM on entry, so compile-phase allocations mark the right VM's roots in multi-VM (thread/deepcopy) tests.
- New repeatable `-Dtest-filter` build option for narrowing test runs.

## Runtime and compiler rooting bugs the harness was masking

- **GC allocators** now copy caller slices *before* `maybeCollect()` and root `Value` slices across the collection via a new `slice_roots` hook (`allocVector`, `allocNativeClosure`, `allocRecordInstance`, `allocMultipleValues`, `makeList`). Previously e.g. `negate`/`abs` collected first, freeing the source bignum and reusing its limbs for the copy — the `@memcpy arguments alias` crash.
- **`maybeCollect`'s stress branch** now honors `no_collect`/`memory_limit` deferral exactly like the normal path (the issue's question 2: the memory_limit test is compatible, not exempt).
- **Body-local `define-syntax` transformers** live only in compiler-local macro maps the GC cannot see; they're now rooted in `extra_roots` for the duration of the top-level compile, at all four registration sites (`compileDefineSyntax`, `compileLetrecSyntax`, and the body scans in `compiler_ir.zig` / `compiler_lambda.zig`).
- **`emitLlvmFile`** defers collection across its read → lower → emit batch: IR nodes reference sexpr values that nothing roots. This was latent in normal builds too, for source files big enough to cross the GC threshold mid-compile.

## Test fixes

- Root Zig locals held across allocations (bignum, bytecode_file, deepcopy, srfi18, robustness) and eval results held across a second eval (tests_io read-back pattern).
- Scale the "GC stress:" churn loops down on stress builds — every allocation already collects there, and the 5000-iteration string loop peaked **19.7 GB RSS** under the testing allocator (DebugAllocator metadata churn; the production allocator runs the same loop at 4 MB), OOM-killing full-suite runs.
- Skip on stress builds: the 300-capture #809 width test (~7 GB RSS, property orthogonal to rooting; the 27-variable sibling keeps coverage) and the #1253 frame-depth test.
- The #958 mark-bit scan forces one full cycle and keeps the parent GC quiescent (threshold-driven) while the child thread's GC still stresses — the parent's own minor-GC marks legitimately persist between cycles and were false-positiving the scan.
- New smoke test `tests/scheme/smoke/bignum-gc-alias-1414.scm`.

## CI / docs

- Re-enables the `gc-stress` fuzz variant in `fuzz.yml` with a 300-minute job timeout (the pre-fuzz unit-test phase dominates wall time: ~40 min locally at 100% CPU).
- Documents the invariants in `.claude/rules/gc-safety.md`, `docs/dev/testing.md`, and `docs/dev/fuzzing.md`.

## Test plan

- `zig build test` — green
- `zig build test -Dgc-stress=true` — from 248 pass / 6 fail / 436 crash to 722 pass / 6 skip / 2 crash in the last full run; the 2 remaining OOM-kill crashes are fixed and verified individually, and a final full-suite confirmation run is in flight
- `bash tests/scheme/run-all.sh` — 1827 pass, 0 fail (432 Scheme files + R7RS suite)
- `kaappi compile` end-to-end smoke test after the `emitLlvmFile` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)