### PR TITLE
Fix correctness gaps in the /do-stress-test skill

### DIFF
--- a/.claude/skills/do-stress-test/SKILL.md
+++ b/.claude/skills/do-stress-test/SKILL.md
@@ -20,17 +20,21 @@ Key differences from `/do-linux-test`:
 
 ## Pre-flight
 
-### 1. Record branch and check for unpushed work
+### 1. Record branch, commit, and check for unpushed work
 
 ```bash
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMIT=$(git rev-parse HEAD)
 echo "Branch: $BRANCH"
+echo "Commit: $COMMIT"
 git status --porcelain
 git ls-remote --heads origin "$BRANCH"
 ```
 
 Only pushed commits are tested. If the branch has no remote tracking, ask the
-user to push first.
+user to push first. The **exact commit SHA** (`$COMMIT`) is used on the droplet
+so the report is attributable to a specific commit, not whatever the branch
+happens to point at minutes later.
 
 ### 2. Get SSH key fingerprint
 
@@ -67,26 +71,11 @@ Record the **droplet ID** immediately — it is needed for cleanup.
    done
    ```
 
-## Arm the 3-hour self-destruct timer
-
-Immediately after SSH is up. This guarantees destruction even if the Claude
-session dies mid-run. **3 hours 5 minutes** (11100 s) gives the run its full
-3-hour budget with a small margin:
-
-```bash
-DO_TOKEN=$(source ~/.zshrc 2>/dev/null && echo "$DIGITALOCEAN_API_TOKEN")
-ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-  root@$IP "nohup bash -c 'sleep 11100 && curl -sf -X DELETE \
-    -H \"Authorization: Bearer $DO_TOKEN\" \
-    https://api.digitalocean.com/v2/droplets/<DROPLET_ID>' \
-    > /dev/null 2>&1 &"
-```
-
-The token lives only in the process's memory on a throwaway droplet.
-
 ## Provision
 
-One SSH command (well under the Bash tool timeout):
+One SSH command (well under the Bash tool timeout). Replace `<COMMIT>` with the
+exact commit SHA from pre-flight (the heredoc is quoted, so no shell expansion
+happens — you must substitute it into the command text before running):
 
 ```bash
 ssh -i ~/.ssh/id_rsa \
@@ -113,23 +102,56 @@ echo "==== Installing dependencies ===="
 apt-get update -qq
 apt-get install -y -qq git make gcc libc6-dev > /dev/null 2>&1
 
-echo "==== Cloning repo (branch: <BRANCH>) ===="
-git clone --depth 1 --branch <BRANCH> https://github.com/kaappi/kaappi.git /workspace
+echo "==== Fetching exact commit <COMMIT> ===="
+git init /workspace
+cd /workspace
+git fetch --depth 1 https://github.com/kaappi/kaappi.git <COMMIT>
+git checkout FETCH_HEAD
+echo "HEAD: $(git rev-parse HEAD)"
 echo "PROVISION: OK"
 REMOTE
 ```
 
 ## Sanity check: plain build and test first
 
-Catch a broken commit in minutes before burning hours on the stress run:
+Catch a broken commit in minutes before burning hours on the stress run.
+Run build and test as **separate SSH commands** so each exit code is captured
+directly (never pipe through `tail` and inspect `$?` — that reports `tail`'s
+status, not the build's):
 
 ```bash
 ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-  root@$IP 'cd /workspace && zig build 2>&1 | tail -5 && zig build test 2>&1 | tail -5; echo "PLAIN: $?"'
+  root@$IP 'cd /workspace && zig build 2>&1 && echo "BUILD: OK" || echo "BUILD: FAIL"'
+```
+
+If the build fails, report and go straight to Cleanup.
+
+```bash
+ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  root@$IP 'cd /workspace && zig build test 2>&1 && echo "TEST: OK" || echo "TEST: FAIL"'
 ```
 
 If the plain suite fails, report and go straight to Cleanup — a stress run on
 a broken commit is wasted money.
+
+## Arm the 3-hour self-destruct timer
+
+Arm the timer **after** provisioning and the sanity check, immediately before
+launching the stress suite. This way the timer covers the actual stress run
+window, not the provisioning overhead. The droplet is guaranteed to be
+destroyed even if the Claude session dies mid-run. **3 hours 5 minutes**
+(11100 s) gives the run its full 3-hour budget with a small margin:
+
+```bash
+DO_TOKEN=$(source ~/.zshrc 2>/dev/null && echo "$DIGITALOCEAN_API_TOKEN")
+ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  root@$IP "nohup bash -c 'sleep 11100 && curl -sf -X DELETE \
+    -H \"Authorization: Bearer $DO_TOKEN\" \
+    https://api.digitalocean.com/v2/droplets/<DROPLET_ID>' \
+    > /dev/null 2>&1 &"
+```
+
+The token lives only in the process's memory on a throwaway droplet.
 
 ## Launch the stress suite (detached)
 
@@ -181,6 +203,7 @@ the droplet — reconnect and fetch.
 
 ## Report results
 
+- **Commit**: the exact SHA tested (from pre-flight)
 - **Plain build/test**: OK / FAIL
 - **Stress suite**: the `N pass, N skip, N fail, N crash (N total)` line and
   `EXIT:` code. Expect a handful of **skips** — throughput- or memory-bound

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -265,6 +265,26 @@ architectures:
 
 Uses `kaappi-builder` Docker images from `ci-images/builder/`.
 
+### `/do-linux-test`
+
+Build and run the full test suite (unit + Scheme) on a real x86-64 Linux
+machine via a temporary DigitalOcean droplet. Complements `/linux-test` by
+providing real hardware instead of emulation. Steps: create `s-2vcpu-4gb`
+droplet, install Zig 0.16, clone and build, run unit tests, run `run-all.sh`,
+fetch results, destroy the droplet. Self-destruct timer (55 min) guarantees
+cleanup even if the session dies. Uses `~/.ssh/id_rsa` and the DO API token
+from `~/.zshrc`. Cost: ~$0.03/hr, full run takes 10–15 minutes.
+
+### `/do-stress-test`
+
+Run the unit suite with `-Dgc-stress=true` (collection on every allocation) on
+a temporary DigitalOcean droplet. Same provisioning flow as `/do-linux-test` but
+with more resources (`s-4vcpu-8gb-amd`, 8 GB swap) and a 3-hour lifetime. The
+stress suite is CPU-bound for 1.5–3 hours, so it runs detached on the droplet
+and is polled for completion. Self-destruct timer arms immediately before the
+stress suite launch (after provisioning and a plain sanity check). Cost:
+~$0.084/hr, full 3-hour window costs ~$0.25.
+
 ## Ecosystem Plugin (`kaappi-dev`)
 
 The `infra/` repo hosts a Claude Code plugin called `kaappi-dev` that provides


### PR DESCRIPTION
## Summary

Fixes #1430 — correctness gaps found in the `/do-stress-test` skill during PR #1427 review.

- **Pipeline masking**: split sanity check into separate SSH commands with `&& echo OK || echo FAIL` pattern (matching `/do-linux-test`), instead of piping through `tail` which reported `tail`'s exit code
- **Commit pinning**: pre-flight now records `git rev-parse HEAD`; the droplet fetches that exact SHA instead of cloning a mutable branch, so reports are attributable to a specific commit
- **Substitution instruction**: added explicit note that `<COMMIT>` in the quoted heredoc must be substituted before running
- **Self-destruct timer**: moved from immediately after SSH to immediately before launching the stress suite, so provisioning and sanity check (~20 min) don't eat the 3-hour budget
- **Harness docs**: added `/do-stress-test` and `/do-linux-test` entries to `docs/dev/claude-code-harness.md`

## Test plan

- [ ] Verify skill file reads coherently end-to-end
- [ ] Verify harness doc entries are placed correctly after `/linux-test`
- [ ] Next invocation of `/do-stress-test` exercises the updated procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)