### PR TITLE
Build chibi-scheme from source in oracle-diff CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -188,10 +188,9 @@ jobs:
   # subset (#1396). This is the only oracle that catches conformance bugs
   # where BOTH Kaappi evaluation paths agree but are wrong. Two interpreter
   # runs per program (no linking), so it is much cheaper per seed than
-  # native-diff. The oracle version is whatever ubuntu-latest's apt ships;
-  # the harness records the exact version in the log and in any divergence
-  # artifact, and CHIBI can pin a specific binary if the distro version
-  # ever proves flaky.
+  # native-diff. The oracle is built from source at a pinned tag — Ubuntu
+  # noble's apt ships 0.9.1 which is too old for the generated programs
+  # (#1429). Bump the tag below when a newer release is needed.
   oracle-diff:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -210,8 +209,10 @@ jobs:
 
       - name: Install Chibi Scheme (the oracle)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y chibi-scheme
+          git clone --depth=1 --branch=0.11 https://github.com/ashinn/chibi-scheme.git /tmp/chibi-src
+          cd /tmp/chibi-src
+          make -j"$(nproc)"
+          sudo make install
           chibi-scheme -V
 
       - name: Build interpreter and generator
@@ -234,7 +235,7 @@ jobs:
       # header (Kaappi bug / oracle bug / generator leak).
       - name: Upload divergences
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: oracle-diff-divergences
           path: oracle-diff-results/

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -188,9 +188,9 @@ jobs:
   # subset (#1396). This is the only oracle that catches conformance bugs
   # where BOTH Kaappi evaluation paths agree but are wrong. Two interpreter
   # runs per program (no linking), so it is much cheaper per seed than
-  # native-diff. The oracle is built from source at a pinned tag — Ubuntu
+  # native-diff. The oracle is built from source at a pinned tag+SHA — Ubuntu
   # noble's apt ships 0.9.1 which is too old for the generated programs
-  # (#1429). Bump the tag below when a newer release is needed.
+  # (#1429). Bump the tag and SHA below when a newer release is needed.
   oracle-diff:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -209,8 +209,9 @@ jobs:
 
       - name: Install Chibi Scheme (the oracle)
         run: |
-          git clone --depth=1 --branch=0.11 https://github.com/ashinn/chibi-scheme.git /tmp/chibi-src
+          git clone --depth=1 --branch=0.12 https://github.com/ashinn/chibi-scheme.git /tmp/chibi-src
           cd /tmp/chibi-src
+          test "$(git rev-parse HEAD)" = 08e23be118e7de8cf29d606bc4793371c0ace680
           make -j"$(nproc)"
           sudo make install
           chibi-scheme -V
@@ -233,6 +234,11 @@ jobs:
       # Each divergence comes with the program, both sides' stdout/stderr,
       # and the oracle version; the triage protocol lives in the script
       # header (Kaappi bug / oracle bug / generator leak).
+      #
+      # IMPORTANT: keep at v7.0.1 — later versions default to archive: true,
+      # which wraps the files in a zip that hides the seed-*.scm markers
+      # from the report job's `find`, silently misclassifying real findings
+      # as infrastructure failures (#1429).
       - name: Upload divergences
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -239,8 +239,9 @@ are wrong. The oracle is Chibi Scheme (closest R7RS-small alignment, small
 install) under its default invocation; the harness prints and records the
 exact version, and `CHIBI=/path/to/binary` pins one explicitly. Note the
 repo's `(chibi test)` shim is implemented *in Kaappi* — the oracle must be a
-real installed `chibi-scheme` (`apt-get install chibi-scheme` /
-`brew install chibi-scheme`).
+real installed `chibi-scheme` (`brew install chibi-scheme` for local use;
+CI builds from source at a pinned tag — Ubuntu noble's apt ships 0.9.1
+which is too old, #1429).
 
 ```bash
 bash tests/fuzz/oracle-diff.sh            # 100 programs, seeds 0..99
@@ -295,9 +296,10 @@ fixed-seed programs stay ASCII/void-valued/in-vocabulary, and
 The `oracle-diff` job in `fuzz.yml` runs 1000 programs nightly with a seed
 base that rotates per run (replayable via `workflow_dispatch` inputs
 `oracle-diff-count` / `oracle-diff-base` or locally), and uploads
-divergences as the `oracle-diff-divergences` artifact. Chibi comes from
-ubuntu-latest's apt; the recorded version makes any divergence reproducible
-against the exact oracle even after a distro bump. Gauche can be added
+divergences as the `oracle-diff-divergences` artifact. Chibi is built from
+source at a pinned tag (0.11 as of #1429 — Ubuntu noble's apt has 0.9.1
+which lacks features the generated programs use); the recorded version makes
+any divergence reproducible against the exact oracle. Gauche can be added
 later as a second, separately pinned opinion.
 
 ## Turning a failure into a regression test

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -240,7 +240,7 @@ install) under its default invocation; the harness prints and records the
 exact version, and `CHIBI=/path/to/binary` pins one explicitly. Note the
 repo's `(chibi test)` shim is implemented *in Kaappi* — the oracle must be a
 real installed `chibi-scheme` (`brew install chibi-scheme` for local use;
-CI builds from source at a pinned tag — Ubuntu noble's apt ships 0.9.1
+CI builds from source at a pinned tag+SHA — Ubuntu noble's apt ships 0.9.1
 which is too old, #1429).
 
 ```bash
@@ -297,7 +297,7 @@ The `oracle-diff` job in `fuzz.yml` runs 1000 programs nightly with a seed
 base that rotates per run (replayable via `workflow_dispatch` inputs
 `oracle-diff-count` / `oracle-diff-base` or locally), and uploads
 divergences as the `oracle-diff-divergences` artifact. Chibi is built from
-source at a pinned tag (0.11 as of #1429 — Ubuntu noble's apt has 0.9.1
+source at a pinned tag+SHA (0.12 as of #1429 — Ubuntu noble's apt has 0.9.1
 which lacks features the generated programs use); the recorded version makes
 any divergence reproducible against the exact oracle. Gauche can be added
 later as a second, separately pinned opinion.

--- a/tests/fuzz/oracle-diff.sh
+++ b/tests/fuzz/oracle-diff.sh
@@ -12,8 +12,9 @@
 # programs open with an explicit (import (scheme base) (scheme char)
 # (scheme lazy) (scheme write)), so no dialect flags are needed — unlike,
 # say, Guile, which would need R7RS mode selected explicitly. Install it
-# with `apt-get install chibi-scheme` or `brew install chibi-scheme`, or
-# point CHIBI at a specific binary to pin a version exactly.
+# with `brew install chibi-scheme` (or build from source — Ubuntu noble's
+# apt ships 0.9.1 which is too old, #1429), or point CHIBI at a specific
+# binary to pin a version exactly.
 #
 # Usage: bash tests/fuzz/oracle-diff.sh [N] [SEED_BASE]
 #   N          number of programs (default 100)


### PR DESCRIPTION
## Summary

Fixes #1429.

- Build chibi-scheme from source at tag `0.11` instead of using `apt-get install` — Ubuntu noble ships 0.9.1 which is too old for the portable-subset programs (985/1000 false divergences).
- Pin `upload-artifact` to v7.0.1 SHA (matching the other upload steps) — the unpinned `@v7` tag resolved to a newer version whose `archive: true` default prevented the report job from finding `.scm` marker files, misclassifying the failure as an infrastructure issue.
- Update `docs/dev/fuzzing.md` to document the version pinning.

## Test plan

- [x] Ran `oracle-diff.sh 100 3000` locally with chibi 0.12.0 — 0 divergences (the same seed range that was 985/1000 divergent in CI with chibi 0.9.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)