### PR TITLE
Store a persistent mark worklist on the GC struct

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -525,6 +525,12 @@ pub fn markValue(gc: *GC, v: Value) void {
         markValueInner(gc, item, &gc.mark_worklist);
     }
     gc.marking = false;
+
+    // Cap retained capacity so one pathologically wide object (e.g. a
+    // 10M-element vector) doesn't keep ~80 MB allocated forever.
+    const max_retained = 64 * 1024;
+    if (gc.mark_worklist.capacity > max_retained)
+        gc.mark_worklist.clearAndFree(gc.allocator);
 }
 
 fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -508,21 +508,23 @@ fn markRoots(gc: *GC) void {
 
 pub fn markValue(gc: *GC, v: Value) void {
     // Use an explicit worklist to avoid native stack overflow on deeply
-    // nested pair/vector structures (issue #864). Values that would
-    // previously be handled by a recursive markValue call are pushed
-    // onto the worklist and processed iteratively.
-    var worklist: std.ArrayList(Value) = .empty;
-    defer worklist.deinit(gc.allocator);
+    // nested pair/vector structures (issue #864). The worklist lives on
+    // the GC struct so its capacity persists across calls — no per-call
+    // alloc/free churn (issue #1428).
+    const is_root_call = !gc.marking;
+    gc.marking = true;
 
-    worklist.ensureTotalCapacity(gc.allocator, 1024) catch
-        @panic("GC mark: worklist OOM");
+    markValueInner(gc, v, &gc.mark_worklist);
 
-    markValueInner(gc, v, &worklist);
+    // Re-entrant call (e.g. markFiberState → gc.markValue): the outer
+    // drain loop will process items we just pushed.
+    if (!is_root_call) return;
 
-    while (worklist.items.len > 0) {
-        const item = worklist.pop().?;
-        markValueInner(gc, item, &worklist);
+    while (gc.mark_worklist.items.len > 0) {
+        const item = gc.mark_worklist.pop().?;
+        markValueInner(gc, item, &gc.mark_worklist);
     }
+    gc.marking = false;
 }
 
 fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -126,6 +126,8 @@ pub const GC = struct {
     source_lines: std.AutoHashMap(Value, u32) = undefined,
     stats: GcStats = .{},
     minor_cycle_count: u32 = 0,
+    mark_worklist: std.ArrayList(Value) = .empty,
+    marking: bool = false,
 
     pub const INITIAL_ROOT_CAPACITY: usize = 1024;
     pub const MAX_ROOT_CAPACITY: usize = 65536;
@@ -182,6 +184,7 @@ pub const GC = struct {
         self.allocator.free(self.root_buffer);
         self.extra_roots.deinit(self.allocator);
         self.remembered_set.deinit(self.allocator);
+        self.mark_worklist.deinit(self.allocator);
         self.source_lines.deinit();
     }
 
@@ -1375,4 +1378,28 @@ test "rootedScope release" {
     scope.release();
     try std.testing.expectEqual(@as(usize, 1), gc.extra_roots.items.len);
     try std.testing.expectEqual(types.makeFixnum(1), gc.extra_roots.items[0]);
+}
+
+test "mark worklist retains capacity across collections" {
+    var gc = GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+
+    // Build a nested pair tree so markValueInner pushes onto the worklist.
+    var inner = try gc.allocPair(types.makeFixnum(1), types.makeFixnum(2));
+    gc.pushRoot(&inner);
+    var rooted = try gc.allocPair(inner, inner);
+    gc.pushRoot(&rooted);
+
+    gc.collect();
+    try std.testing.expect(!gc.marking);
+    const cap_after_first = gc.mark_worklist.capacity;
+    try std.testing.expect(cap_after_first > 0);
+
+    gc.collect();
+    try std.testing.expect(!gc.marking);
+    try std.testing.expectEqual(cap_after_first, gc.mark_worklist.capacity);
+
+    gc.popRoot();
+    gc.popRoot();
 }


### PR DESCRIPTION
## Summary

Fixes #1428.

- Move the `markValue` worklist from a per-call local to a `mark_worklist` field on the `GC` struct so its capacity persists across calls — eliminates thousands of 8 KB alloc/free cycles per collection.
- Add a `marking` re-entrancy guard so fiber marking (`markFiberState` → `gc.markValue`) shares the buffer safely: re-entrant calls push items and return, the outermost call owns the drain loop.
- RSS on the "GC stress:" test filter drops from ~19.7 GB to ~1.15 GB.

## Test plan

- [x] `zig build test` — 731/731 pass
- [x] `zig build test -Dgc-stress=true` — all pass
- [x] R7RS suite — 1395 pass, 0 fail
- [x] Full Scheme suite — 1827 pass, 0 fail
- [x] RSS comparison: `/usr/bin/time -l zig build test -Dgc-stress=true -Dtest-filter="GC stress:"` — ~1.15 GB (was ~19.7 GB)
- [x] New unit test: `mark worklist retains capacity across collections`

🤖 Generated with [Claude Code](https://claude.com/claude-code)