### PR TITLE
Scheduler integration: io_waiting, runSchedulerStep, reactor park (KEP-0001 P2)

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -2,12 +2,12 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const memory = @import("memory.zig");
+const reactor_mod = @import("reactor.zig");
+const Reactor = reactor_mod.Reactor;
 const Value = types.Value;
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
 const CallFrame = types.CallFrame;
-
-pub const MAX_FIBERS = 64;
 
 pub fn clockNs() u64 {
     var ts: std.c.timespec = undefined;
@@ -22,6 +22,7 @@ pub const FiberStatus = enum(u8) {
     completed,
     errored,
     waiting,
+    io_waiting,
 };
 
 pub const Fiber = struct {
@@ -48,43 +49,53 @@ pub const Fiber = struct {
     timed_out: bool = false,
     terminated: bool = false,
     os_thread: ?std.Thread = null,
+    /// Set together with `.io_waiting` when a blocking I/O primitive parks
+    /// on the reactor (KEP-0001 Phase 3). Unused by anything shipped in
+    /// Phase 2, but the fields must exist now so the scheduler/GC plumbing
+    /// can be built and tested ahead of the port-layer primitives.
+    io_fd: ?std.posix.fd_t = null,
+    io_interest: reactor_mod.Interest = .read,
+    /// Pins an in-flight read/write buffer across GC while a primitive is
+    /// parked on the reactor. Traced by markFiberState/referencesYoung.
+    io_buffer: Value = types.VOID,
 };
 
 pub const FiberScheduler = struct {
-    fibers: [MAX_FIBERS]?*Fiber,
-    fiber_count: usize,
+    /// Growable — no fiber-count ceiling (KEP-0001 Phase 2). Slots are
+    /// reused before growing (see addFiber), so long-running spawn/join
+    /// churn doesn't grow this unboundedly; concurrently-live fiber count
+    /// is bounded only by memory.
+    fibers: std.ArrayList(?*Fiber),
     current_idx: usize,
     next_id: u32,
     vm: *VM,
 
     pub fn init(vm: *VM) FiberScheduler {
         return .{
-            .fibers = .{null} ** MAX_FIBERS,
-            .fiber_count = 0,
+            .fibers = .empty,
             .current_idx = 0,
             .next_id = 0,
             .vm = vm,
         };
     }
 
+    pub fn deinit(self: *FiberScheduler, allocator: std.mem.Allocator) void {
+        self.fibers.deinit(allocator);
+    }
+
     pub fn addFiber(self: *FiberScheduler, fiber: *Fiber) !void {
-        if (self.fiber_count < MAX_FIBERS) {
-            self.fibers[self.fiber_count] = fiber;
-            self.fiber_count += 1;
-            return;
-        }
-        for (self.fibers[0..self.fiber_count], 0..) |f, i| {
+        for (self.fibers.items, 0..) |f, i| {
             if (f) |existing| {
                 if (existing.status == .completed or existing.status == .errored) {
-                    self.fibers[i] = fiber;
+                    self.fibers.items[i] = fiber;
                     return;
                 }
             } else {
-                self.fibers[i] = fiber;
+                self.fibers.items[i] = fiber;
                 return;
             }
         }
-        return VMError.StackOverflow;
+        try self.fibers.append(self.vm.gc.allocator, fiber);
     }
 
     pub fn spawnFiber(self: *FiberScheduler, thunk: Value) !*Fiber {
@@ -100,7 +111,7 @@ pub const FiberScheduler = struct {
         if (types.isClosure(thunk_val)) {
             closure = types.toObject(thunk_val).as(types.Closure);
         } else {
-            var fiber_root = types.makePointer(@ptrCast(fiber));
+            var fiber_root = types.makePointer(@ptrCast(&fiber.header));
             self.vm.gc.pushRoot(&fiber_root);
             const trampoline = try wrapInTrampoline(self.vm.gc, thunk_val);
             self.vm.gc.popRoot();
@@ -169,21 +180,50 @@ pub const FiberScheduler = struct {
         return closure_val;
     }
 
+    /// Upper bound (exclusive) of registers actually reachable from any
+    /// currently active frame: max over `frames` of `base + frameWindow()`,
+    /// clamped to `cap`. Shared by markFiberState (GC-marking bounds) and
+    /// saveCurrentFiber/restoreFiber (memcpy bounds) — a register beyond
+    /// every active frame's window can never be read again by the fiber
+    /// that owns `frames`, so it's neither live for GC nor worth copying.
+    fn liveRegisterSpan(frames: []const CallFrame, cap: usize) usize {
+        var span: usize = 0;
+        for (frames) |f| {
+            const end: usize = @min(@as(usize, f.base) + f.frameWindow(), cap);
+            if (end > span) span = end;
+        }
+        return span;
+    }
+
+    fn growFiberRegisters(allocator: std.mem.Allocator, fiber: *Fiber, needed: usize) void {
+        if (needed <= fiber.registers.len) return;
+        var new_cap = fiber.registers.len;
+        while (new_cap < needed) new_cap *= 2;
+        const new_regs = allocator.alloc(Value, new_cap) catch return;
+        allocator.free(fiber.registers);
+        fiber.registers = new_regs;
+    }
+
+    fn growFiberFrames(allocator: std.mem.Allocator, fiber: *Fiber, needed: usize) void {
+        if (needed <= fiber.frames.len) return;
+        var new_cap = fiber.frames.len;
+        while (new_cap < needed) new_cap *= 2;
+        const new_frames = allocator.alloc(CallFrame, new_cap) catch return;
+        allocator.free(fiber.frames);
+        fiber.frames = new_frames;
+    }
+
+    /// Copies only the live register/frame window (see liveRegisterSpan)
+    /// instead of the VM's entire register file — fiber switch cost no
+    /// longer scales with the VM's peak register-file capacity (KEP-0001
+    /// Phase 2, resolved question 5).
     pub fn saveCurrentFiber(self: *FiberScheduler) void {
-        const fiber = self.fibers[self.current_idx] orelse return;
+        const fiber = self.fibers.items[self.current_idx] orelse return;
         const vm = self.vm;
-        // Grow fiber's backing arrays if the VM grew beyond them
-        if (vm.registers.len > fiber.registers.len) {
-            const new_regs = vm.gc.allocator.alloc(Value, vm.registers.len) catch return;
-            vm.gc.allocator.free(fiber.registers);
-            fiber.registers = new_regs;
-        }
-        if (vm.frames.len > fiber.frames.len) {
-            const new_frames = vm.gc.allocator.alloc(CallFrame, vm.frames.len) catch return;
-            vm.gc.allocator.free(fiber.frames);
-            fiber.frames = new_frames;
-        }
-        @memcpy(fiber.registers[0..vm.registers.len], vm.registers);
+        const span = liveRegisterSpan(vm.frames[0..vm.frame_count], vm.registers.len);
+        growFiberRegisters(vm.gc.allocator, fiber, span);
+        growFiberFrames(vm.gc.allocator, fiber, vm.frame_count);
+        @memcpy(fiber.registers[0..span], vm.registers[0..span]);
         fiber.frame_count = vm.frame_count;
         @memcpy(fiber.frames[0..vm.frame_count], vm.frames[0..vm.frame_count]);
         @memcpy(fiber.handler_stack[0..vm.handler_count], vm.handler_stack[0..vm.handler_count]);
@@ -196,20 +236,12 @@ pub const FiberScheduler = struct {
     }
 
     pub fn restoreFiber(self: *FiberScheduler, idx: usize) void {
-        const fiber = self.fibers[idx] orelse return;
+        const fiber = self.fibers.items[idx] orelse return;
         const vm = self.vm;
-        // Grow VM's backing arrays if the fiber grew beyond them
-        if (fiber.registers.len > vm.registers.len) {
-            const new_regs = vm.gc.allocator.alloc(Value, fiber.registers.len) catch return;
-            vm.gc.allocator.free(vm.registers);
-            vm.registers = new_regs;
-        }
-        if (fiber.frames.len > vm.frames.len) {
-            const new_frames = vm.gc.allocator.alloc(CallFrame, fiber.frames.len) catch return;
-            vm.gc.allocator.free(vm.frames);
-            vm.frames = new_frames;
-        }
-        @memcpy(vm.registers[0..fiber.registers.len], fiber.registers[0..fiber.registers.len]);
+        const span = liveRegisterSpan(fiber.frames[0..fiber.frame_count], fiber.registers.len);
+        vm.ensureRegisterCapacity(span) catch return;
+        vm.ensureFrameCapacity(fiber.frame_count) catch return;
+        @memcpy(vm.registers[0..span], fiber.registers[0..span]);
         @memcpy(vm.frames[0..fiber.frame_count], fiber.frames[0..fiber.frame_count]);
         vm.frame_count = fiber.frame_count;
         @memcpy(vm.handler_stack[0..fiber.handler_count], fiber.handler_stack[0..fiber.handler_count]);
@@ -223,64 +255,72 @@ pub const FiberScheduler = struct {
 
     pub fn switchTo(self: *FiberScheduler, next_idx: usize) void {
         if (next_idx == self.current_idx) return;
-        const current = self.fibers[self.current_idx] orelse return;
+        const current = self.fibers.items[self.current_idx] orelse return;
 
         self.saveCurrentFiber();
         if (current.status == .running) current.status = .suspended;
 
         self.restoreFiber(next_idx);
-        const next = self.fibers[next_idx] orelse return;
+        const next = self.fibers.items[next_idx] orelse return;
         next.status = .running;
         self.current_idx = next_idx;
         self.vm.current_fiber = next;
     }
 
+    /// Round-robins over `created`/`suspended` fibers. Timed waits
+    /// (`.waiting` + `deadline_ns`) and `.io_waiting` are not selectable
+    /// here — their expiry/readiness is detected by the reactor's timer
+    /// heap and fd polling (parkOnReactor), not by a per-tick sweep here
+    /// (KEP-0001 Phase 2, resolved question 5 / folds the old deadline
+    /// sweep into the shared timer heap).
     pub fn schedule(self: *FiberScheduler) ?usize {
-        if (self.fiber_count == 0) return null;
-        const now = clockNs();
-        for (self.fibers[0..self.fiber_count]) |f| {
-            if (f) |fiber| {
-                if (fiber.status == .waiting) {
-                    if (fiber.deadline_ns) |deadline| {
-                        if (now >= deadline) {
-                            fiber.status = .suspended;
-                            fiber.timed_out = true;
-                            fiber.deadline_ns = null;
-                        }
-                    }
-                }
-            }
-        }
+        const n = self.fibers.items.len;
+        if (n == 0) return null;
         var i: usize = 1;
-        while (i <= self.fiber_count) : (i += 1) {
-            const idx = (self.current_idx + i) % self.fiber_count;
-            if (self.fibers[idx]) |f| {
+        while (i <= n) : (i += 1) {
+            const idx = (self.current_idx + i) % n;
+            if (self.fibers.items[idx]) |f| {
                 if (f.status == .created or f.status == .suspended) return idx;
             }
         }
         return null;
     }
 
+    /// Used only by parkOnReactor's deadlock check, which runs after
+    /// schedule() has already found nothing .created/.suspended — so this
+    /// deliberately does NOT count .running: under recursive dispatch
+    /// (runSchedulerStep calling runSchedulerStep), every fiber on the
+    /// current call chain back to main is still .running (none flip to
+    /// .waiting until they themselves decide to park), so treating .running
+    /// as "other progress possible" would make a genuine deadlock loop
+    /// forever in reactor.poll() instead of ever detecting it.
     pub fn hasRunnableFibers(self: *FiberScheduler) bool {
-        for (self.fibers[0..self.fiber_count]) |f| {
+        for (self.fibers.items) |f| {
             if (f) |fiber| {
-                if (fiber.status == .created or fiber.status == .suspended or fiber.status == .running)
+                if (fiber.status == .created or fiber.status == .suspended)
                     return true;
                 if (fiber.status == .waiting and fiber.deadline_ns != null)
+                    return true;
+                if (fiber.status == .io_waiting)
                     return true;
             }
         }
         return false;
     }
 
+    fn cancelPendingTimer(self: *FiberScheduler, fiber: *Fiber) void {
+        if (self.vm.reactor) |r| r.removeTimer(fiber);
+    }
+
     pub fn wakeWaiters(self: *FiberScheduler, completed_fiber: *Fiber) void {
-        const completed_val = types.makePointer(@ptrCast(completed_fiber));
-        for (self.fibers[0..self.fiber_count]) |f| {
+        const completed_val = types.makePointer(@ptrCast(&completed_fiber.header));
+        for (self.fibers.items) |f| {
             if (f) |fiber| {
                 if (fiber.status == .waiting and fiber.waiting_on == completed_val) {
                     fiber.status = .suspended;
                     fiber.result = completed_fiber.result;
                     self.vm.gc.writeBarrier(&fiber.header, completed_fiber.result);
+                    self.cancelPendingTimer(fiber);
                 }
             }
         }
@@ -290,21 +330,23 @@ pub const FiberScheduler = struct {
     /// channel-receive retry protocol). Waking all is safe: each re-executes
     /// channel-receive and re-parks if the channel is empty again.
     pub fn wakeChannelWaiters(self: *FiberScheduler, ch_val: Value) void {
-        for (self.fibers[0..self.fiber_count]) |f| {
+        for (self.fibers.items) |f| {
             if (f) |fiber| {
                 if (fiber.status == .waiting and fiber.waiting_on == ch_val) {
                     fiber.status = .suspended;
                     fiber.waiting_on = types.VOID;
+                    self.cancelPendingTimer(fiber);
                 }
             }
         }
     }
 
     pub fn wakeMutexWaiters(self: *FiberScheduler, mutex_val: Value) void {
-        for (self.fibers[0..self.fiber_count]) |f| {
+        for (self.fibers.items) |f| {
             if (f) |fiber| {
                 if (fiber.status == .waiting and fiber.waiting_on == mutex_val) {
                     fiber.status = .suspended;
+                    self.cancelPendingTimer(fiber);
                     return;
                 }
             }
@@ -312,10 +354,11 @@ pub const FiberScheduler = struct {
     }
 
     pub fn wakeOneCondVarWaiter(self: *FiberScheduler, cv_val: Value) void {
-        for (self.fibers[0..self.fiber_count]) |f| {
+        for (self.fibers.items) |f| {
             if (f) |fiber| {
                 if (fiber.status == .waiting and fiber.waiting_on == cv_val) {
                     fiber.status = .suspended;
+                    self.cancelPendingTimer(fiber);
                     return;
                 }
             }
@@ -323,25 +366,177 @@ pub const FiberScheduler = struct {
     }
 
     pub fn wakeAllCondVarWaiters(self: *FiberScheduler, cv_val: Value) void {
-        for (self.fibers[0..self.fiber_count]) |f| {
+        for (self.fibers.items) |f| {
             if (f) |fiber| {
                 if (fiber.status == .waiting and fiber.waiting_on == cv_val) {
                     fiber.status = .suspended;
+                    self.cancelPendingTimer(fiber);
                 }
             }
         }
     }
 
     pub fn markRoots(self: *FiberScheduler, gc: *memory.GC) void {
-        for (self.fibers[0..self.fiber_count]) |f| {
+        for (self.fibers.items) |f| {
             if (f) |fiber| {
-                gc.markValue(types.makePointer(@ptrCast(fiber)));
+                gc.markValue(types.makePointer(@ptrCast(&fiber.header)));
                 if (fiber.status == .running) continue;
                 markFiberState(gc, fiber);
             }
         }
     }
 };
+
+/// Lazily creates the scheduler and reactor together (one reactor per OS
+/// thread, matching the share-nothing model — each SRFI-18 child thread
+/// gets its own VM+GC+scheduler+reactor). All fiber/SRFI-18 entry points
+/// that need a scheduler call this instead of duplicating the setup.
+pub fn ensureScheduler(vm: *VM) VMError!struct { vm: *VM, sched: *FiberScheduler, reactor: *Reactor } {
+    if (vm.scheduler == null) {
+        const sched = vm.gc.allocator.create(FiberScheduler) catch return VMError.OutOfMemory;
+        sched.* = FiberScheduler.init(vm);
+        const main_fiber = vm.gc.allocFiber(types.VOID, sched.next_id) catch return VMError.OutOfMemory;
+        sched.next_id += 1;
+        main_fiber.status = .running;
+        sched.addFiber(main_fiber) catch return VMError.OutOfMemory;
+        vm.scheduler = sched;
+        vm.current_fiber = main_fiber;
+    }
+    if (vm.reactor == null) {
+        const r = vm.gc.allocator.create(Reactor) catch return VMError.OutOfMemory;
+        r.* = Reactor.init(vm.gc.allocator) catch {
+            vm.gc.allocator.destroy(r);
+            return VMError.OutOfMemory;
+        };
+        vm.reactor = r;
+    }
+    return .{ .vm = vm, .sched = vm.scheduler.?, .reactor = vm.reactor.? };
+}
+
+/// Releases every mutex `fiber` holds, marking it abandoned and waking any
+/// waiters — called whenever a dispatched (non-main) fiber errors out
+/// mid-turn, so a lock it held doesn't hang every other fiber waiting on it
+/// forever. Fiber 0 (main) is exempt at call sites: finishing or aborting
+/// one top-level form is not thread death, so its mutexes stay valid.
+pub fn abandonFiberMutexes(gc: *memory.GC, fiber: *Fiber, sched: ?*FiberScheduler) void {
+    const fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    var lists = [_]?*types.Object{ gc.objects, gc.old_objects };
+    for (&lists) |*head| {
+        var obj = head.*;
+        while (obj) |o| : (obj = o.next) {
+            if (o.tag == .mutex) {
+                const m = o.as(types.Mutex);
+                if (m.locked and m.owner == fiber_val) {
+                    m.abandoned = true;
+                    m.locked = false;
+                    m.owner = types.VOID;
+                    if (sched) |s| s.wakeMutexWaiters(types.makePointer(@ptrCast(o)));
+                }
+            }
+        }
+    }
+}
+
+/// Wait for `target` fiber to finish. Shared by fiber-join and
+/// thread-join!'s fiber path — the exact same wait condition.
+pub const TargetWait = struct {
+    target: *Fiber,
+    pub fn isDone(self: TargetWait) bool {
+        return self.target.status == .completed or self.target.status == .errored;
+    }
+};
+
+/// Called when sched.schedule() finds nothing immediately runnable. Blocks
+/// in the reactor — bounded by its own timer heap, so no separate
+/// "nearest deadline" computation is needed here — and flips every fiber
+/// it reports ready back to `.suspended` (io_waiting) or
+/// `.suspended`+`timed_out` (an expired timed `.waiting` wait). Returns
+/// `false` only when nothing could ever produce a wakeup: genuine
+/// deadlock/done, the same meaning as the bare `break` this replaces.
+pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler) VMError!bool {
+    const reactor = vm.reactor orelse return false;
+    if (!sched.hasRunnableFibers() and reactor.isEmpty()) return false;
+
+    var ready: std.ArrayList(*Fiber) = .empty;
+    defer ready.deinit(vm.gc.allocator);
+    reactor.poll(null, &ready) catch return VMError.OutOfMemory;
+
+    for (ready.items) |f| {
+        switch (f.status) {
+            .io_waiting => f.status = .suspended,
+            .waiting => {
+                f.status = .suspended;
+                f.timed_out = true;
+            },
+            else => {},
+        }
+    }
+    return true;
+}
+
+/// Drives the scheduler — dispatching other fibers, saving/restoring their
+/// state exactly as switchTo would — until `ctx.isDone()` becomes true or
+/// `me`'s own timed wait expires (`me.timed_out`), parking on the reactor
+/// (parkOnReactor) whenever nothing is immediately runnable. Returns
+/// `ctx.isDone()`: `true` means the wait resolved normally; `false` means
+/// either `me.timed_out` or genuine deadlock — the caller (which knows
+/// whether `me` had a deadline) distinguishes those via `me.timed_out`.
+///
+/// This is the single shared body behind channel-receive, fiber-join,
+/// thread-join!, mutex-lock!, condition-variable waits, and thread-sleep!
+/// (KEP-0001 Phase 2) — call sites differ only in `Ctx.isDone`. `Ctx` is a
+/// small value type with an `isDone(self: Ctx) bool` method (comptime duck
+/// typing), e.g. `TargetWait{ .target = f }`.
+pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberScheduler, me: *Fiber) VMError!bool {
+    const my_idx = sched.current_idx;
+    sched.saveCurrentFiber();
+
+    while (!ctx.isDone() and !me.timed_out) {
+        const next_idx = sched.schedule() orelse {
+            if (!(try parkOnReactor(vm, sched))) break;
+            continue;
+        };
+        if (next_idx == my_idx) break;
+
+        sched.restoreFiber(next_idx);
+        sched.current_idx = next_idx;
+        const fiber = sched.fibers.items[next_idx].?;
+        fiber.status = .running;
+        vm.current_fiber = fiber;
+
+        // A dangling yield_retry (a forwarding native converted a park's
+        // Yielded into another error) must not survive into this run.
+        vm.yield_retry = false;
+        vm.sched_dispatch_pending = true;
+        const result = vm.runUntil(0, 0) catch |err| {
+            if (err == VMError.Yielded) {
+                sched.saveCurrentFiber();
+                if (fiber.status == .running) fiber.status = .suspended;
+                continue;
+            }
+            fiber.status = .errored;
+            // Fiber 0 is the main fiber: finishing or aborting one
+            // top-level form is not thread death, so its mutexes stay
+            // valid.
+            if (next_idx != 0) abandonFiberMutexes(vm.gc, fiber, sched);
+            sched.saveCurrentFiber();
+            sched.wakeWaiters(fiber);
+            continue;
+        };
+        fiber.status = .completed;
+        fiber.result = result;
+        vm.gc.writeBarrier(&fiber.header, result);
+        if (next_idx != 0) abandonFiberMutexes(vm.gc, fiber, sched);
+        sched.saveCurrentFiber();
+        sched.wakeWaiters(fiber);
+    }
+
+    sched.restoreFiber(my_idx);
+    sched.current_idx = my_idx;
+    me.status = .running;
+    vm.current_fiber = me;
+    return ctx.isDone();
+}
 
 pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {
     gc.markValue(fiber.thunk);
@@ -353,11 +548,9 @@ pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {
     for (fiber.frames[0..fiber.frame_count]) |f| {
         if (f.closure) |cls| gc.markValue(types.makePointer(@ptrCast(cls)));
         if (f.native) |nf| gc.markValue(types.makePointer(@ptrCast(nf)));
-        const window = f.frameWindow();
-        const end: usize = @min(@as(usize, f.base) + window, fiber.registers.len);
-        var r: usize = f.base;
-        while (r < end) : (r += 1) gc.markValue(fiber.registers[r]);
     }
+    const span = FiberScheduler.liveRegisterSpan(fiber.frames[0..fiber.frame_count], fiber.registers.len);
+    for (fiber.registers[0..span]) |r| gc.markValue(r);
 
     for (fiber.handler_stack[0..fiber.handler_count]) |h| gc.markValue(h.handler);
 
@@ -371,4 +564,5 @@ pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {
 
     if (fiber.current_exception) |exc| gc.markValue(exc);
     gc.markValue(fiber.continuation_value);
+    gc.markValue(fiber.io_buffer);
 }

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -195,20 +195,20 @@ pub const FiberScheduler = struct {
         return span;
     }
 
-    fn growFiberRegisters(allocator: std.mem.Allocator, fiber: *Fiber, needed: usize) void {
+    fn growFiberRegisters(allocator: std.mem.Allocator, fiber: *Fiber, needed: usize) VMError!void {
         if (needed <= fiber.registers.len) return;
         var new_cap = fiber.registers.len;
         while (new_cap < needed) new_cap *= 2;
-        const new_regs = allocator.alloc(Value, new_cap) catch return;
+        const new_regs = try allocator.alloc(Value, new_cap);
         allocator.free(fiber.registers);
         fiber.registers = new_regs;
     }
 
-    fn growFiberFrames(allocator: std.mem.Allocator, fiber: *Fiber, needed: usize) void {
+    fn growFiberFrames(allocator: std.mem.Allocator, fiber: *Fiber, needed: usize) VMError!void {
         if (needed <= fiber.frames.len) return;
         var new_cap = fiber.frames.len;
         while (new_cap < needed) new_cap *= 2;
-        const new_frames = allocator.alloc(CallFrame, new_cap) catch return;
+        const new_frames = try allocator.alloc(CallFrame, new_cap);
         allocator.free(fiber.frames);
         fiber.frames = new_frames;
     }
@@ -217,12 +217,17 @@ pub const FiberScheduler = struct {
     /// instead of the VM's entire register file — fiber switch cost no
     /// longer scales with the VM's peak register-file capacity (KEP-0001
     /// Phase 2, resolved question 5).
-    pub fn saveCurrentFiber(self: *FiberScheduler) void {
+    ///
+    /// Propagates OOM instead of swallowing it: growFiberRegisters/Frames
+    /// must actually succeed before the memcpy below runs at the new
+    /// (larger) span, or the memcpy would read/write past a buffer that
+    /// silently stayed its old, smaller size.
+    pub fn saveCurrentFiber(self: *FiberScheduler) VMError!void {
         const fiber = self.fibers.items[self.current_idx] orelse return;
         const vm = self.vm;
         const span = liveRegisterSpan(vm.frames[0..vm.frame_count], vm.registers.len);
-        growFiberRegisters(vm.gc.allocator, fiber, span);
-        growFiberFrames(vm.gc.allocator, fiber, vm.frame_count);
+        try growFiberRegisters(vm.gc.allocator, fiber, span);
+        try growFiberFrames(vm.gc.allocator, fiber, vm.frame_count);
         @memcpy(fiber.registers[0..span], vm.registers[0..span]);
         fiber.frame_count = vm.frame_count;
         @memcpy(fiber.frames[0..vm.frame_count], vm.frames[0..vm.frame_count]);
@@ -235,12 +240,12 @@ pub const FiberScheduler = struct {
         fiber.continuation_value = vm.continuation_value;
     }
 
-    pub fn restoreFiber(self: *FiberScheduler, idx: usize) void {
+    pub fn restoreFiber(self: *FiberScheduler, idx: usize) VMError!void {
         const fiber = self.fibers.items[idx] orelse return;
         const vm = self.vm;
         const span = liveRegisterSpan(fiber.frames[0..fiber.frame_count], fiber.registers.len);
-        vm.ensureRegisterCapacity(span) catch return;
-        vm.ensureFrameCapacity(fiber.frame_count) catch return;
+        try vm.ensureRegisterCapacity(span);
+        try vm.ensureFrameCapacity(fiber.frame_count);
         @memcpy(vm.registers[0..span], fiber.registers[0..span]);
         @memcpy(vm.frames[0..fiber.frame_count], fiber.frames[0..fiber.frame_count]);
         vm.frame_count = fiber.frame_count;
@@ -253,27 +258,37 @@ pub const FiberScheduler = struct {
         vm.continuation_value = fiber.continuation_value;
     }
 
-    pub fn switchTo(self: *FiberScheduler, next_idx: usize) void {
+    pub fn switchTo(self: *FiberScheduler, next_idx: usize) VMError!void {
         if (next_idx == self.current_idx) return;
         const current = self.fibers.items[self.current_idx] orelse return;
 
-        self.saveCurrentFiber();
+        try self.saveCurrentFiber();
         if (current.status == .running) current.status = .suspended;
 
-        self.restoreFiber(next_idx);
+        try self.restoreFiber(next_idx);
         const next = self.fibers.items[next_idx] orelse return;
         next.status = .running;
         self.current_idx = next_idx;
         self.vm.current_fiber = next;
     }
 
-    /// Round-robins over `created`/`suspended` fibers. Timed waits
-    /// (`.waiting` + `deadline_ns`) and `.io_waiting` are not selectable
-    /// here — their expiry/readiness is detected by the reactor's timer
-    /// heap and fd polling (parkOnReactor), not by a per-tick sweep here
-    /// (KEP-0001 Phase 2, resolved question 5 / folds the old deadline
-    /// sweep into the shared timer heap).
+    /// Round-robins over `created`/`suspended` fibers. Before selecting,
+    /// pops any already-expired timers off the reactor's heap and flips
+    /// their fibers to `.suspended` — checked on *every* call, not just
+    /// when the scheduler goes idle (parkOnReactor), so a timed wait
+    /// resolves promptly even while a busy/yielding sibling keeps this
+    /// loop from ever going idle (KEP-0001 Phase 2, resolved question 5:
+    /// the old per-fiber sweep folds into the shared timer heap, but the
+    /// heap must still be checked every tick — a heap peek/pop is cheaper
+    /// than the old O(fiber count) sweep it replaces, not less prompt).
     pub fn schedule(self: *FiberScheduler) ?usize {
+        if (self.vm.reactor) |reactor| {
+            var expired: std.ArrayList(*Fiber) = .empty;
+            defer expired.deinit(self.vm.gc.allocator);
+            reactor.popExpiredTimers(&expired) catch {};
+            for (expired.items) |f| wakeReadyFiber(f);
+        }
+
         const n = self.fibers.items.len;
         if (n == 0) return null;
         var i: usize = 1;
@@ -446,6 +461,21 @@ pub const TargetWait = struct {
     }
 };
 
+/// Moves a fiber the reactor just reported ready (io fd readiness or an
+/// expired timer) from its wait status back to `.suspended` so schedule()
+/// can pick it up. Shared by parkOnReactor (blocking wait) and schedule()'s
+/// per-tick expired-timer check (non-blocking).
+fn wakeReadyFiber(f: *Fiber) void {
+    switch (f.status) {
+        .io_waiting => f.status = .suspended,
+        .waiting => {
+            f.status = .suspended;
+            f.timed_out = true;
+        },
+        else => {},
+    }
+}
+
 /// Called when sched.schedule() finds nothing immediately runnable. Blocks
 /// in the reactor — bounded by its own timer heap, so no separate
 /// "nearest deadline" computation is needed here — and flips every fiber
@@ -461,16 +491,7 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler) VMError!bool {
     defer ready.deinit(vm.gc.allocator);
     reactor.poll(null, &ready) catch return VMError.OutOfMemory;
 
-    for (ready.items) |f| {
-        switch (f.status) {
-            .io_waiting => f.status = .suspended,
-            .waiting => {
-                f.status = .suspended;
-                f.timed_out = true;
-            },
-            else => {},
-        }
-    }
+    for (ready.items) |f| wakeReadyFiber(f);
     return true;
 }
 
@@ -489,7 +510,7 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler) VMError!bool {
 /// typing), e.g. `TargetWait{ .target = f }`.
 pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberScheduler, me: *Fiber) VMError!bool {
     const my_idx = sched.current_idx;
-    sched.saveCurrentFiber();
+    try sched.saveCurrentFiber();
 
     while (!ctx.isDone() and !me.timed_out) {
         const next_idx = sched.schedule() orelse {
@@ -498,7 +519,7 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
         };
         if (next_idx == my_idx) break;
 
-        sched.restoreFiber(next_idx);
+        try sched.restoreFiber(next_idx);
         sched.current_idx = next_idx;
         const fiber = sched.fibers.items[next_idx].?;
         fiber.status = .running;
@@ -510,7 +531,7 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
         vm.sched_dispatch_pending = true;
         const result = vm.runUntil(0, 0) catch |err| {
             if (err == VMError.Yielded) {
-                sched.saveCurrentFiber();
+                try sched.saveCurrentFiber();
                 if (fiber.status == .running) fiber.status = .suspended;
                 continue;
             }
@@ -519,7 +540,7 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
             // top-level form is not thread death, so its mutexes stay
             // valid.
             if (next_idx != 0) abandonFiberMutexes(vm.gc, fiber, sched);
-            sched.saveCurrentFiber();
+            try sched.saveCurrentFiber();
             sched.wakeWaiters(fiber);
             continue;
         };
@@ -527,15 +548,20 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
         fiber.result = result;
         vm.gc.writeBarrier(&fiber.header, result);
         if (next_idx != 0) abandonFiberMutexes(vm.gc, fiber, sched);
-        sched.saveCurrentFiber();
+        try sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }
 
-    sched.restoreFiber(my_idx);
+    // Captured before the epilogue below touches `me`: CondVarWait's
+    // isDone() reads me.status, which the next line unconditionally
+    // forces to .running — evaluating ctx.isDone() after that would
+    // always report true regardless of whether the wait actually resolved.
+    const done = ctx.isDone();
+    try sched.restoreFiber(my_idx);
     sched.current_idx = my_idx;
     me.status = .running;
     vm.current_fiber = me;
-    return ctx.isDone();
+    return done;
 }
 
 pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -188,7 +188,7 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
             const fiber = obj.as(fiber_mod.Fiber);
             if (isYoungPointer(gc, fiber.thunk) or isYoungPointer(gc, fiber.result) or
                 isYoungPointer(gc, fiber.waiting_on) or isYoungPointer(gc, fiber.name) or
-                isYoungPointer(gc, fiber.specific)) return true;
+                isYoungPointer(gc, fiber.specific) or isYoungPointer(gc, fiber.io_buffer)) return true;
             if (fiber.current_exception) |exc| {
                 if (isYoungPointer(gc, exc)) return true;
             }

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -828,9 +828,9 @@ pub const GC = struct {
         try self.maybeCollect();
         self.clearArgRoots();
         const fiber_mod = @import("fiber.zig");
-        const registers = try self.allocator.alloc(Value, types.INITIAL_REGISTER_CAPACITY);
+        const registers = try self.allocator.alloc(Value, types.INITIAL_FIBER_REGISTER_CAPACITY);
         errdefer self.allocator.free(registers);
-        const frames = try self.allocator.alloc(types.CallFrame, types.INITIAL_FRAME_CAPACITY);
+        const frames = try self.allocator.alloc(types.CallFrame, types.INITIAL_FIBER_FRAME_CAPACITY);
         errdefer self.allocator.free(frames);
         const fiber = try self.allocator.create(fiber_mod.Fiber);
         fiber.* = .{

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -31,29 +31,10 @@ fn spawnFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("spawn", "procedure", proc);
 
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const ctx = try fiber_mod.ensureScheduler(vm);
 
-    if (vm.scheduler == null) {
-        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-        const sched = gc.allocator.create(fiber_mod.FiberScheduler) catch return PrimitiveError.OutOfMemory;
-        sched.* = fiber_mod.FiberScheduler.init(vm);
-
-        const main_fiber = gc.allocFiber(types.VOID, sched.next_id) catch return PrimitiveError.OutOfMemory;
-        sched.next_id += 1;
-        main_fiber.status = .running;
-        sched.addFiber(main_fiber) catch return PrimitiveError.OutOfMemory;
-        vm.scheduler = sched;
-        vm.current_fiber = main_fiber;
-    }
-
-    const sched = vm.scheduler.?;
-    const fiber = sched.spawnFiber(proc) catch |err| {
-        if (err == vm_mod.VMError.StackOverflow) {
-            vm.setErrorDetail("spawn: fiber limit exceeded (max {d})", .{fiber_mod.MAX_FIBERS});
-            return PrimitiveError.InvalidArgument;
-        }
-        return PrimitiveError.OutOfMemory;
-    };
-    return types.makePointer(@ptrCast(fiber));
+    const fiber = ctx.sched.spawnFiber(proc) catch return PrimitiveError.OutOfMemory;
+    return types.makePointer(@ptrCast(&fiber.header));
 }
 
 fn yieldFn(_: []const Value) PrimitiveError!Value {
@@ -80,9 +61,22 @@ fn fiberJoinFn(args: []const Value) PrimitiveError!Value {
     if (target.status == .completed) return target.result;
     if (target.status == .errored) return reraiseFiberError(target);
 
-    const result = try runSchedulerUntil(target, null, types.VOID);
+    // Capture before the recursive dispatch below: args is a slice into
+    // vm.registers, which runSchedulerStep can reallocate out from under
+    // it while running other fibers (ensureRegisterCapacity). Reading
+    // args[0] after that point would be a use-after-free.
+    const target_val = args[0];
+
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    const my_idx = ctx.sched.current_idx;
+    const me = ctx.sched.fibers.items[my_idx].?;
+
+    _ = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = target }, ctx.vm, ctx.sched, me);
+
+    if (target.status == .completed) return target.result;
     if (target.status == .errored) return reraiseFiberError(target);
-    return result;
+    return blockOrDeadlock(ctx.vm, me, my_idx, target_val, "fiber-join: deadlock — joined fiber can never complete (all fibers blocked)");
 }
 
 fn reraiseFiberError(fiber: *fiber_mod.Fiber) PrimitiveError {
@@ -130,6 +124,13 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
     return types.VOID;
 }
 
+const ChannelWait = struct {
+    ch: *types.Channel,
+    pub fn isDone(self: ChannelWait) bool {
+        return self.ch.head != types.NIL;
+    }
+};
+
 fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[0]))
         return primitives.typeError("channel-receive", "channel", args[0]);
@@ -146,7 +147,20 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         return raiseDeadlockError("channel-receive: deadlock — channel is empty and no fibers are running");
     }
 
-    return runSchedulerUntil(null, ch, args[0]);
+    // Capture before the recursive dispatch below: args is a slice into
+    // vm.registers, which runSchedulerStep can reallocate out from under
+    // it while running other fibers (ensureRegisterCapacity). Reading
+    // args[0] after that point would be a use-after-free.
+    const ch_val = args[0];
+
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    const my_idx = ctx.sched.current_idx;
+    const me = ctx.sched.fibers.items[my_idx].?;
+
+    _ = try fiber_mod.runSchedulerStep(ChannelWait, .{ .ch = ch }, ctx.vm, ctx.sched, me);
+
+    if (ch.head != types.NIL) return dequeueChannel(ch, ch_val);
+    return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, "channel-receive: deadlock — channel is empty and all fibers are blocked");
 }
 
 fn dequeueChannel(ch: *types.Channel, ch_val: Value) Value {
@@ -156,70 +170,6 @@ fn dequeueChannel(ch: *types.Channel, ch_val: Value) Value {
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(ch_val), pair.cdr);
     if (ch.head == types.NIL) ch.tail = types.NIL;
     return val;
-}
-
-fn runSchedulerUntil(target: ?*fiber_mod.Fiber, ch: ?*types.Channel, ch_val: Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const sched = vm.scheduler orelse return PrimitiveError.OutOfMemory;
-    const my_idx = sched.current_idx;
-    sched.saveCurrentFiber();
-
-    const done = struct {
-        fn check(t: ?*fiber_mod.Fiber, c: ?*types.Channel) bool {
-            if (t) |f| return f.status == .completed or f.status == .errored;
-            if (c) |channel| return channel.head != types.NIL;
-            return true;
-        }
-    }.check;
-
-    while (!done(target, ch)) {
-        const idx = sched.schedule() orelse break;
-
-        sched.restoreFiber(idx);
-        sched.current_idx = idx;
-        const fiber = sched.fibers[idx].?;
-        fiber.status = .running;
-        vm.current_fiber = fiber;
-
-        // A dangling yield_retry (a forwarding native converted a park's
-        // Yielded into another error) must not survive into this run.
-        vm.yield_retry = false;
-        vm.sched_dispatch_pending = true;
-        const result = vm.runUntil(0, 0) catch |err| {
-            if (err == vm_mod.VMError.Yielded) {
-                sched.saveCurrentFiber();
-                if (fiber.status == .running) fiber.status = .suspended;
-                continue;
-            }
-            fiber.status = .errored;
-            fiber.current_exception = vm.current_exception;
-            sched.saveCurrentFiber();
-            sched.wakeWaiters(fiber);
-            continue;
-        };
-        fiber.status = .completed;
-        fiber.result = result;
-        gc.writeBarrier(&fiber.header, result);
-        sched.saveCurrentFiber();
-        sched.wakeWaiters(fiber);
-    }
-
-    sched.restoreFiber(my_idx);
-    sched.current_idx = my_idx;
-    const me = sched.fibers[my_idx].?;
-    me.status = .running;
-    vm.current_fiber = me;
-
-    if (target) |f| {
-        if (f.status == .completed or f.status == .errored) return f.result;
-        return blockOrDeadlock(vm, me, my_idx, types.makePointer(@ptrCast(f)), "fiber-join: deadlock — joined fiber can never complete (all fibers blocked)");
-    }
-    if (ch) |channel| {
-        if (channel.head != types.NIL) return dequeueChannel(channel, ch_val);
-        return blockOrDeadlock(vm, me, my_idx, ch_val, "channel-receive: deadlock — channel is empty and all fibers are blocked");
-    }
-    return types.VOID;
 }
 
 /// The scheduler ran out of runnable fibers while this fiber's blocking

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -95,20 +95,13 @@ var child_registry: ChildRegistry = .{
     .mutex = .unlocked,
 };
 
-fn ensureScheduler() PrimitiveError!struct { vm: *vm_mod.VM, sched: *fiber_mod.FiberScheduler } {
+/// Thin per-file convenience wrapper: fetches vm_instance and delegates to
+/// fiber.ensureScheduler, which now lazily creates the reactor alongside
+/// the scheduler (KEP-0001 Phase 2) — the actual setup logic lives in one
+/// place instead of being duplicated per call site.
+fn ensureScheduler() @TypeOf(fiber_mod.ensureScheduler(undefined)) {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    if (vm.scheduler == null) {
-        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-        const sched = gc.allocator.create(fiber_mod.FiberScheduler) catch return PrimitiveError.OutOfMemory;
-        sched.* = fiber_mod.FiberScheduler.init(vm);
-        const main_fiber = gc.allocFiber(types.VOID, sched.next_id) catch return PrimitiveError.OutOfMemory;
-        sched.next_id += 1;
-        main_fiber.status = .running;
-        sched.addFiber(main_fiber) catch return PrimitiveError.OutOfMemory;
-        vm.scheduler = sched;
-        vm.current_fiber = main_fiber;
-    }
-    return .{ .vm = vm, .sched = vm.scheduler.? };
+    return fiber_mod.ensureScheduler(vm);
 }
 
 fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
@@ -155,25 +148,6 @@ fn raiseError(error_type: types.ErrorObject.ErrorType, msg: []const u8, reason: 
     return PrimitiveError.ExceptionRaised;
 }
 
-pub fn abandonFiberMutexes(gc: *memory.GC, fiber: *fiber_mod.Fiber, sched: ?*fiber_mod.FiberScheduler) void {
-    const fiber_val = types.makePointer(@ptrCast(fiber));
-    var lists = [_]?*types.Object{ gc.objects, gc.old_objects };
-    for (&lists) |*head| {
-        var obj = head.*;
-        while (obj) |o| : (obj = o.next) {
-            if (o.tag == .mutex) {
-                const m = o.as(types.Mutex);
-                if (m.locked and m.owner == fiber_val) {
-                    m.abandoned = true;
-                    m.locked = false;
-                    m.owner = types.VOID;
-                    if (sched) |s| s.wakeMutexWaiters(types.makePointer(@ptrCast(o)));
-                }
-            }
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Thread primitives
 // ---------------------------------------------------------------------------
@@ -181,7 +155,7 @@ pub fn abandonFiberMutexes(gc: *memory.GC, fiber: *fiber_mod.Fiber, sched: ?*fib
 fn currentThreadFn(_: []const Value) PrimitiveError!Value {
     const ctx = try ensureScheduler();
     const fiber = ctx.vm.current_fiber orelse return types.VOID;
-    return types.makePointer(@ptrCast(fiber));
+    return types.makePointer(@ptrCast(&fiber.header));
 }
 
 fn threadPredFn(args: []const Value) PrimitiveError!Value {
@@ -207,7 +181,7 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
         gc.writeBarrier(&fiber.header, args[1]);
     }
 
-    return types.makePointer(@ptrCast(fiber));
+    return types.makePointer(@ptrCast(&fiber.header));
 }
 
 fn threadNameFn(args: []const Value) PrimitiveError!Value {
@@ -313,13 +287,13 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_g
     };
 
     const result = child_vm.callWithArgs(child_thunk, &.{}) catch {
-        if (child_vm.current_fiber) |cf| abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
+        if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
         child_registry.storeResult(@intFromPtr(fiber), types.VOID, child_vm.current_exception);
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         return;
     };
 
-    if (child_vm.current_fiber) |cf| abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
+    if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
 
     // Store result in child_resources (not on the fiber) so the parent
     // GC never traverses a child-heap pointer (Race C).
@@ -343,20 +317,35 @@ fn threadYieldFn(_: []const Value) PrimitiveError!Value {
     return types.VOID;
 }
 
+const SleepWait = struct {
+    pub fn isDone(_: SleepWait) bool {
+        return false; // a pure sleep only ever ends via me.timed_out
+    }
+};
+
+/// A timed park on the reactor's timer heap instead of a whole-thread
+/// nanosleep (KEP-0001 Phase 2): siblings run while this fiber sleeps, and
+/// the reactor's blocking wait — not a busy nanosleep loop — is what
+/// actually waits out the duration.
 fn threadSleepFn(args: []const Value) PrimitiveError!Value {
     if (args[0] == types.FALSE) return PrimitiveError.TypeError; // bare-ok: type guard
     const seconds = try getSleepSeconds(args[0]);
     if (seconds <= 0) return types.VOID;
     const total_ns: u64 = @intFromFloat(@max(0.0, seconds * 1e9));
-    var ts: std.c.timespec = .{
-        .sec = @intCast(total_ns / 1_000_000_000),
-        .nsec = @intCast(total_ns % 1_000_000_000),
-    };
-    while (true) {
-        const ret = std.c.nanosleep(&ts, &ts);
-        if (ret == 0) break;
-        if (std.posix.errno(ret) != .INTR) break;
-    }
+
+    const ctx = try ensureScheduler();
+    const me = ctx.vm.current_fiber orelse return types.VOID;
+    const deadline = fiber_mod.clockNs() + total_ns;
+
+    me.waiting_on = types.VOID;
+    me.status = .waiting;
+    me.timed_out = false;
+    me.deadline_ns = deadline;
+    try ctx.reactor.addTimer(deadline, me);
+
+    _ = try fiber_mod.runSchedulerStep(SleepWait, .{}, ctx.vm, ctx.sched, me);
+    me.timed_out = false;
+    me.deadline_ns = null;
     return types.VOID;
 }
 
@@ -390,7 +379,7 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
     // Atomic: for OS threads the child VM polls this flag concurrently.
     @atomicStore(bool, &fiber.terminated, true, .monotonic);
 
-    if (memory.gc_instance) |gc| abandonFiberMutexes(gc, fiber, ctx.sched);
+    if (memory.gc_instance) |gc| fiber_mod.abandonFiberMutexes(gc, fiber, ctx.sched);
 
     const status = @atomicLoad(fiber_mod.FiberStatus, &fiber.status, .acquire);
     if (status != .completed and status != .errored) {
@@ -485,9 +474,12 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
         me.waiting_on = args[0];
         me.status = .waiting;
         me.timed_out = false;
-        if (deadline_ns) |d| me.deadline_ns = d;
+        if (deadline_ns) |d| {
+            me.deadline_ns = d;
+            try ctx.reactor.addTimer(d, me);
+        }
 
-        try runSchedulerUntilDone(target);
+        _ = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = target }, ctx.vm, ctx.sched, me);
 
         if (me.timed_out) {
             me.timed_out = false;
@@ -574,72 +566,6 @@ fn threadJoinResult(target: *fiber_mod.Fiber) PrimitiveError!Value {
     return target.result;
 }
 
-fn scheduleOrTimeout(sched: *fiber_mod.FiberScheduler, me: *fiber_mod.Fiber) ?usize {
-    if (sched.schedule()) |idx| return idx;
-    if (me.deadline_ns) |deadline| {
-        const now = fiber_mod.clockNs();
-        if (now < deadline) sleepNs(deadline - now);
-        me.timed_out = true;
-    }
-    return null;
-}
-
-fn runSchedulerUntilDone(target: *fiber_mod.Fiber) PrimitiveError!void {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const sched = vm.scheduler orelse return PrimitiveError.OutOfMemory;
-    const my_idx = sched.current_idx;
-    sched.saveCurrentFiber();
-
-    while (target.status != .completed and target.status != .errored) {
-        const me = sched.fibers[my_idx].?;
-        if (me.timed_out) break;
-
-        const next_idx = scheduleOrTimeout(sched, me) orelse break;
-        if (next_idx == my_idx) break;
-
-        sched.restoreFiber(next_idx);
-        sched.current_idx = next_idx;
-        const fiber = sched.fibers[next_idx].?;
-        fiber.status = .running;
-        vm.current_fiber = fiber;
-
-        // A dangling yield_retry (a forwarding native converted a park's
-        // Yielded into another error) must not survive into this run.
-        vm.yield_retry = false;
-        vm.sched_dispatch_pending = true;
-        const result = vm.runUntil(0, 0) catch |err| {
-            if (err == vm_mod.VMError.Yielded) {
-                sched.saveCurrentFiber();
-                if (fiber.status == .running) fiber.status = .suspended;
-                continue;
-            }
-            fiber.status = .errored;
-            // Fiber 0 is the main fiber: finishing or aborting one top-level
-            // form is not thread death, so its mutexes stay valid.
-            if (next_idx != 0) {
-                if (memory.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
-            }
-            sched.saveCurrentFiber();
-            sched.wakeWaiters(fiber);
-            continue;
-        };
-        fiber.status = .completed;
-        fiber.result = result;
-        if (memory.gc_instance) |gc| {
-            gc.writeBarrier(&fiber.header, result);
-            if (next_idx != 0) abandonFiberMutexes(gc, fiber, sched);
-        }
-        sched.saveCurrentFiber();
-        sched.wakeWaiters(fiber);
-    }
-
-    sched.restoreFiber(my_idx);
-    sched.current_idx = my_idx;
-    const me = sched.fibers[my_idx].?;
-    me.status = .running;
-    vm.current_fiber = me;
-}
-
 // ---------------------------------------------------------------------------
 // Mutex primitives
 // ---------------------------------------------------------------------------
@@ -706,7 +632,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         else if (args.len > 2 and args[2] == types.FALSE)
             types.VOID
         else if (ctx.vm.current_fiber) |cf|
-            types.makePointer(@ptrCast(cf))
+            types.makePointer(@ptrCast(&cf.header))
         else
             types.VOID;
         return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
@@ -720,7 +646,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         else if (args.len > 2 and args[2] == types.FALSE)
             types.VOID
         else if (ctx.vm.current_fiber) |cf|
-            types.makePointer(@ptrCast(cf))
+            types.makePointer(@ptrCast(&cf.header))
         else
             types.VOID;
         return types.TRUE;
@@ -732,15 +658,25 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         if (deadline != null and deadline.? == 0) return types.FALSE;
     }
 
+    // Capture before the recursive dispatch below: args is a slice into
+    // vm.registers, which runSchedulerStep can reallocate out from under
+    // it while running other fibers (ensureRegisterCapacity). Reading
+    // args[...] after that point would be a use-after-free.
+    const mutex_val = args[0];
+    const owner_arg: ?Value = if (args.len > 2) args[2] else null;
+
     const ctx = try ensureScheduler();
     const me = ctx.vm.current_fiber orelse return PrimitiveError.OutOfMemory;
 
-    me.waiting_on = args[0];
+    me.waiting_on = mutex_val;
     me.status = .waiting;
     me.timed_out = false;
-    if (deadline) |d| me.deadline_ns = d;
+    if (deadline) |d| {
+        me.deadline_ns = d;
+        try ctx.reactor.addTimer(d, me);
+    }
 
-    try runSchedulerUntilMutex(m, me);
+    _ = try fiber_mod.runSchedulerStep(MutexWait, .{ .m = m }, ctx.vm, ctx.sched, me);
     me.deadline_ns = null;
 
     if (me.timed_out) {
@@ -749,12 +685,10 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     }
 
     m.locked = true;
-    m.owner = if (args.len > 2 and types.isFiber(args[2]))
-        args[2]
-    else if (args.len > 2 and args[2] == types.FALSE)
-        types.VOID
+    m.owner = if (owner_arg) |oa|
+        (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else types.makePointer(@ptrCast(&me.header)))
     else
-        types.makePointer(@ptrCast(me));
+        types.makePointer(@ptrCast(&me.header));
 
     if (m.abandoned) {
         m.abandoned = false;
@@ -763,57 +697,12 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     return types.TRUE;
 }
 
-fn runSchedulerUntilMutex(m: *types.Mutex, me: *fiber_mod.Fiber) PrimitiveError!void {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const sched = vm.scheduler orelse return PrimitiveError.OutOfMemory;
-    const my_idx = sched.current_idx;
-    sched.saveCurrentFiber();
-
-    while (m.locked and !me.timed_out) {
-        const next_idx = scheduleOrTimeout(sched, me) orelse break;
-        if (next_idx == my_idx) break;
-
-        sched.restoreFiber(next_idx);
-        sched.current_idx = next_idx;
-        const fiber = sched.fibers[next_idx].?;
-        fiber.status = .running;
-        vm.current_fiber = fiber;
-
-        // A dangling yield_retry (a forwarding native converted a park's
-        // Yielded into another error) must not survive into this run.
-        vm.yield_retry = false;
-        vm.sched_dispatch_pending = true;
-        const result = vm.runUntil(0, 0) catch |err| {
-            if (err == vm_mod.VMError.Yielded) {
-                sched.saveCurrentFiber();
-                if (fiber.status == .running) fiber.status = .suspended;
-                continue;
-            }
-            fiber.status = .errored;
-            // Fiber 0 is the main fiber: finishing or aborting one top-level
-            // form is not thread death, so its mutexes stay valid.
-            if (next_idx != 0) {
-                if (memory.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
-            }
-            sched.saveCurrentFiber();
-            sched.wakeWaiters(fiber);
-            continue;
-        };
-        fiber.status = .completed;
-        fiber.result = result;
-        if (memory.gc_instance) |gc| {
-            gc.writeBarrier(&fiber.header, result);
-            if (next_idx != 0) abandonFiberMutexes(gc, fiber, sched);
-        }
-        sched.saveCurrentFiber();
-        sched.wakeWaiters(fiber);
+const MutexWait = struct {
+    m: *types.Mutex,
+    pub fn isDone(self: MutexWait) bool {
+        return !self.m.locked;
     }
-
-    sched.restoreFiber(my_idx);
-    sched.current_idx = my_idx;
-    me.status = .running;
-    vm.current_fiber = me;
-}
+};
 
 fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
     if (!types.isMutex(args[0]))
@@ -836,9 +725,12 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
         me.waiting_on = args[1];
         me.status = .waiting;
         me.timed_out = false;
-        if (deadline) |d| me.deadline_ns = d;
+        if (deadline) |d| {
+            me.deadline_ns = d;
+            try ctx.reactor.addTimer(d, me);
+        }
 
-        try runSchedulerUntilCondVar(me);
+        _ = try fiber_mod.runSchedulerStep(CondVarWait, .{ .me = me }, ctx.vm, ctx.sched, me);
         me.deadline_ns = null;
 
         if (me.timed_out) {
@@ -851,57 +743,12 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
     return types.TRUE;
 }
 
-fn runSchedulerUntilCondVar(me: *fiber_mod.Fiber) PrimitiveError!void {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const sched = vm.scheduler orelse return PrimitiveError.OutOfMemory;
-    const my_idx = sched.current_idx;
-    sched.saveCurrentFiber();
-
-    while (me.status == .waiting and !me.timed_out) {
-        const next_idx = scheduleOrTimeout(sched, me) orelse break;
-        if (next_idx == my_idx) break;
-
-        sched.restoreFiber(next_idx);
-        sched.current_idx = next_idx;
-        const fiber = sched.fibers[next_idx].?;
-        fiber.status = .running;
-        vm.current_fiber = fiber;
-
-        // A dangling yield_retry (a forwarding native converted a park's
-        // Yielded into another error) must not survive into this run.
-        vm.yield_retry = false;
-        vm.sched_dispatch_pending = true;
-        const result = vm.runUntil(0, 0) catch |err| {
-            if (err == vm_mod.VMError.Yielded) {
-                sched.saveCurrentFiber();
-                if (fiber.status == .running) fiber.status = .suspended;
-                continue;
-            }
-            fiber.status = .errored;
-            // Fiber 0 is the main fiber: finishing or aborting one top-level
-            // form is not thread death, so its mutexes stay valid.
-            if (next_idx != 0) {
-                if (memory.gc_instance) |gc| abandonFiberMutexes(gc, fiber, sched);
-            }
-            sched.saveCurrentFiber();
-            sched.wakeWaiters(fiber);
-            continue;
-        };
-        fiber.status = .completed;
-        fiber.result = result;
-        if (memory.gc_instance) |gc| {
-            gc.writeBarrier(&fiber.header, result);
-            if (next_idx != 0) abandonFiberMutexes(gc, fiber, sched);
-        }
-        sched.saveCurrentFiber();
-        sched.wakeWaiters(fiber);
+const CondVarWait = struct {
+    me: *fiber_mod.Fiber,
+    pub fn isDone(self: CondVarWait) bool {
+        return self.me.status != .waiting;
     }
-
-    sched.restoreFiber(my_idx);
-    sched.current_idx = my_idx;
-    me.status = .running;
-    vm.current_fiber = me;
-}
+};
 
 // ---------------------------------------------------------------------------
 // Condition variable primitives

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -383,6 +383,11 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
 
     const status = @atomicLoad(fiber_mod.FiberStatus, &fiber.status, .acquire);
     if (status != .completed and status != .errored) {
+        // A terminated fiber may have been mid-timed-wait (mutex-lock!,
+        // thread-join!, condvar wait, thread-sleep!) with a pending entry
+        // on the reactor's timer heap. Cancel it now — otherwise it fires
+        // later against whatever fiber ends up reusing this slot.
+        ctx.reactor.removeTimer(fiber);
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         ctx.sched.wakeWaiters(fiber);
     }
@@ -479,12 +484,22 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
             try ctx.reactor.addTimer(d, me);
         }
 
-        _ = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = target }, ctx.vm, ctx.sched, me);
+        const done = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = target }, ctx.vm, ctx.sched, me);
+        me.deadline_ns = null;
 
         if (me.timed_out) {
             me.timed_out = false;
             if (has_timeout_val) return timeout_val;
             return raiseError(.join_timeout, "thread-join! timed out", types.VOID);
+        }
+        if (!done) {
+            // Genuine deadlock: parkOnReactor gave up because nothing local
+            // could ever complete the joined fiber. Must not fall through
+            // to threadJoinResult, which would silently return VOID (the
+            // target's never-set default result) instead of erroring.
+            // me.waiting_on (not args[0]): args is a slice into
+            // vm.registers, which runSchedulerStep may have reallocated.
+            return raiseError(.general, "thread-join!: deadlock — joined fiber can never complete (all fibers blocked)", me.waiting_on);
         }
     }
 
@@ -676,12 +691,19 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         try ctx.reactor.addTimer(d, me);
     }
 
-    _ = try fiber_mod.runSchedulerStep(MutexWait, .{ .m = m }, ctx.vm, ctx.sched, me);
+    const done = try fiber_mod.runSchedulerStep(MutexWait, .{ .m = m }, ctx.vm, ctx.sched, me);
     me.deadline_ns = null;
 
     if (me.timed_out) {
         me.timed_out = false;
         return types.FALSE;
+    }
+    if (!done) {
+        // Genuine deadlock: parkOnReactor gave up because nothing local
+        // could ever unlock this mutex (no other runnable fiber, no
+        // pending timer). Must not fall through to "assume success" —
+        // that would silently steal a lock still held elsewhere.
+        return raiseError(.general, "mutex-lock!: deadlock — mutex will never be released (all fibers blocked)", types.VOID);
     }
 
     m.locked = true;
@@ -730,12 +752,17 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
             try ctx.reactor.addTimer(d, me);
         }
 
-        _ = try fiber_mod.runSchedulerStep(CondVarWait, .{ .me = me }, ctx.vm, ctx.sched, me);
+        const done = try fiber_mod.runSchedulerStep(CondVarWait, .{ .me = me }, ctx.vm, ctx.sched, me);
         me.deadline_ns = null;
 
         if (me.timed_out) {
             me.timed_out = false;
             return types.FALSE;
+        }
+        if (!done) {
+            // Genuine deadlock: parkOnReactor gave up because nothing
+            // local could ever signal this condition variable.
+            return raiseError(.general, "mutex-unlock!: deadlock — condition variable will never be signaled (all fibers blocked)", types.VOID);
         }
         return types.TRUE;
     }

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -665,6 +665,7 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                     .completed => "completed",
                     .errored => "errored",
                     .waiting => "waiting",
+                    .io_waiting => "io-waiting",
                 };
                 try writer.print("#<fiber {d} {s}>", .{ fiber.id, status_str });
             },

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -1,10 +1,10 @@
-//! Per-OS-thread I/O readiness multiplexer (KEP-0001 Phase 1).
+//! Per-OS-thread I/O readiness multiplexer (KEP-0001 Phases 1-2).
 //!
 //! One `Reactor` belongs to one OS thread's scheduler. A fiber that would
 //! block on a fd registers its interest and parks; `poll` blocks once,
 //! bounded by the nearest timer deadline, and reports every fiber that
-//! became runnable (fd readiness or timer expiry). This file has no
-//! scheduler caller yet — that wiring is KEP-0001 Phase 2. See
+//! became runnable (fd readiness or timer expiry). Wired into the
+//! scheduler in KEP-0001 Phase 2 (fiber.zig's runSchedulerStep). See
 //! https://github.com/kaappi/keps/blob/main/keps/0001-event-loop-reactor.md
 const std = @import("std");
 const builtin = @import("builtin");
@@ -28,8 +28,8 @@ const ReadyEvent = struct { fd: i32, readable: bool, writable: bool };
 const Backend = switch (builtin.os.tag) {
     .macos, .ios, .tvos, .watchos, .visionos => KqueueBackend,
     .linux => EpollBackend,
-    // WASI (poll_oneoff) arrives in KEP-0001 Phase 4.
-    else => @compileError("reactor: unsupported OS for KEP-0001 Phase 1 (kqueue/epoll only)"),
+    .wasi => WasiBackend,
+    else => @compileError("reactor: unsupported OS (kqueue/epoll/wasi only)"),
 };
 
 const TimerEntry = struct {
@@ -428,3 +428,58 @@ fn msFromNs(timeout_ns: ?u64) i32 {
     const ms = (ns +| 999_999) / 1_000_000;
     return if (ms > std.math.maxInt(i32)) std.math.maxInt(i32) else @intCast(ms);
 }
+
+// ---------------------------------------------------------------------------
+// WASI backend — timer-only stopgap.
+//
+// The full design (build a subscription_t[] — one fd_read/fd_write per
+// registration plus one CLOCK subscription at the nearest deadline, call
+// std.os.wasi.poll_oneoff) is KEP-0001 Phase 4. Nothing registers a port's
+// fd with the reactor before Phase 3, so on wasm32-wasi today the only
+// path that must actually work is a plain wait bounded by the timer
+// heap's nearest deadline — exactly what thread-sleep! and timed
+// mutex/join/condvar waits need. arm() is unreachable until Phase 3 lands
+// I/O primitive changes (gated by the existing is_wasm flag, per the
+// KEP's cross-platform section: WASI falls back to single-fiber blocking
+// I/O where poll_oneoff socket support is unavailable).
+// ---------------------------------------------------------------------------
+
+const WasiBackend = struct {
+    fn init() !WasiBackend {
+        return .{};
+    }
+
+    fn deinit(self: *WasiBackend) void {
+        _ = self;
+    }
+
+    fn arm(self: *WasiBackend, fd: i32, wants_read: bool, wants_write: bool, first_time: bool) !void {
+        _ = self;
+        _ = fd;
+        _ = wants_read;
+        _ = wants_write;
+        _ = first_time;
+        return error.Unexpected;
+    }
+
+    fn disarmAll(self: *WasiBackend, fd: i32) void {
+        _ = self;
+        _ = fd;
+    }
+
+    fn wait(self: *WasiBackend, timeout_ns: ?u64) ![]const ReadyEvent {
+        _ = self;
+        if (timeout_ns) |ns| {
+            var ts: std.c.timespec = .{
+                .sec = @intCast(ns / 1_000_000_000),
+                .nsec = @intCast(ns % 1_000_000_000),
+            };
+            while (true) {
+                const ret = std.c.nanosleep(&ts, &ts);
+                if (ret == 0) break;
+                if (std.posix.errno(ret) != .INTR) break;
+            }
+        }
+        return &[_]ReadyEvent{};
+    }
+};

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -238,7 +238,11 @@ pub const Reactor = struct {
         const now = fiber_mod.clockNs();
         while (self.timers.peek()) |top| {
             if (top.deadline_ns > now) break;
-            try ready.append(self.allocator, self.timers.pop().?.fiber);
+            // Append before popping: if the append allocation fails, the
+            // timer must stay in the heap so the fiber isn't stranded —
+            // popping first would drop it from both places on OOM.
+            try ready.append(self.allocator, top.fiber);
+            _ = self.timers.pop();
         }
     }
 

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -9,6 +9,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const fiber_mod = @import("fiber.zig");
+const memory = @import("memory.zig");
+const types = @import("types.zig");
 const Fiber = fiber_mod.Fiber;
 
 const linux = std.os.linux;
@@ -156,6 +158,21 @@ pub const Reactor = struct {
             if (!reg.isEmpty()) return false;
         }
         return true;
+    }
+
+    /// Belt-and-braces GC root: a reactor-parked fiber is always still
+    /// present in FiberScheduler.fibers[] (addFiber's slot-reuse only
+    /// overwrites .completed/.errored slots), so this is currently
+    /// redundant with FiberScheduler.markRoots. Kept as an explicit
+    /// second root so a fiber reachable only through the reactor can never
+    /// be collected even if that invariant is later weakened.
+    pub fn markRoots(self: *Reactor, gc: *memory.GC) void {
+        var it = self.regs.valueIterator();
+        while (it.next()) |reg| {
+            for (reg.read_waiters.items) |f| gc.markValue(types.makePointer(@ptrCast(&f.header)));
+            for (reg.write_waiters.items) |f| gc.markValue(types.makePointer(@ptrCast(&f.header)));
+        }
+        for (self.timers.items) |entry| gc.markValue(types.makePointer(@ptrCast(&entry.fiber.header)));
     }
 
     /// Blocks up to `timeout_ns` (or the nearest timer deadline, whichever

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -160,12 +160,12 @@ pub const Reactor = struct {
         return true;
     }
 
-    /// Belt-and-braces GC root: a reactor-parked fiber is always still
-    /// present in FiberScheduler.fibers[] (addFiber's slot-reuse only
-    /// overwrites .completed/.errored slots), so this is currently
-    /// redundant with FiberScheduler.markRoots. Kept as an explicit
-    /// second root so a fiber reachable only through the reactor can never
-    /// be collected even if that invariant is later weakened.
+    /// GC root, not just belt-and-braces: addFiber's slot-reuse overwrites
+    /// .completed/.errored slots in FiberScheduler.fibers[], and
+    /// thread-terminate! moves a victim straight to .errored. If terminate
+    /// ever raced ahead of removeTimer for a fiber's pending wait, that
+    /// fiber's only remaining reference would be here, in the timer heap —
+    /// this mark is what keeps it alive long enough for the pop to run.
     pub fn markRoots(self: *Reactor, gc: *memory.GC) void {
         var it = self.regs.valueIterator();
         while (it.next()) |reg| {
@@ -225,6 +225,16 @@ pub const Reactor = struct {
             }
         }
 
+        try self.popExpiredTimers(ready);
+    }
+
+    /// Moves every timer whose deadline has already passed into `ready`,
+    /// removing it from the heap. Called from `poll` (after an fd wait)
+    /// and separately from `FiberScheduler.schedule` on every dispatch
+    /// tick — not just when the scheduler goes idle — so a timed wait
+    /// resolves promptly even while other runnable fibers (a busy/yielding
+    /// sibling) mean `poll` is never reached at all.
+    pub fn popExpiredTimers(self: *Reactor, ready: *std.ArrayList(*Fiber)) !void {
         const now = fiber_mod.clockNs();
         while (self.timers.peek()) |top| {
             if (top.deadline_ns > now) break;
@@ -477,7 +487,7 @@ const WasiBackend = struct {
             while (true) {
                 const ret = std.c.nanosleep(&ts, &ts);
                 if (ret == 0) break;
-                if (std.posix.errno(ret) != .INTR) break;
+                if (std.posix.errno(ret) != .INTR) return error.Unexpected;
             }
         }
         return &[_]ReadyEvent{};

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -1,0 +1,142 @@
+// KEP-0001 Phase 2: scheduler <-> reactor integration. Complements
+// tests_reactor.zig (Phase 1, reactor in isolation) and tests_fibers.zig
+// (existing fiber/channel behavior). These tests exercise the new pieces
+// specifically: io_waiting exclusion/inclusion in scheduling decisions,
+// parkOnReactor's ready-list handling against a real fd, and the
+// live-window bound on per-fiber save/restore storage.
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const fiber_mod = @import("fiber.zig");
+const reactor_mod = @import("reactor.zig");
+
+fn makePipe() [2]std.c.fd_t {
+    var fds: [2]std.c.fd_t = undefined;
+    if (std.c.pipe(&fds) != 0) unreachable;
+    return fds;
+}
+
+fn closeFd(fd: std.c.fd_t) void {
+    _ = std.posix.system.close(fd);
+}
+
+fn writeByte(fd: std.c.fd_t, byte: u8) void {
+    const buf = [1]u8{byte};
+    const n = std.posix.system.write(fd, &buf, 1);
+    std.testing.expectEqual(@as(isize, 1), n) catch unreachable;
+}
+
+test "schedule() does not select an io_waiting fiber" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.created, f.status);
+
+    f.status = .io_waiting;
+    try std.testing.expectEqual(@as(?usize, null), sched.schedule());
+
+    f.status = .suspended;
+    try std.testing.expect(sched.schedule() != null);
+}
+
+test "hasRunnableFibers reports io_waiting as alive but not a merely-running ancestor" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+
+    // Main (id 0) is .running here (execute()'s prologue sets it on every
+    // top-level form); with f neutralized, nothing should look runnable —
+    // parkOnReactor's whole point is that a .running ancestor deep in its
+    // own recursive dispatch must not count as "other progress possible".
+    f.status = .completed;
+    try std.testing.expect(!sched.hasRunnableFibers());
+
+    f.status = .io_waiting;
+    try std.testing.expect(sched.hasRunnableFibers());
+}
+
+test "parkOnReactor wakes a manually io_waiting fiber when its fd becomes readable" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const reactor = vm.reactor.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+
+    const pipe = makePipe();
+    defer closeFd(pipe[0]);
+    defer closeFd(pipe[1]);
+
+    f.status = .io_waiting;
+    f.io_fd = pipe[0];
+    f.io_interest = .read;
+    try reactor.register(pipe[0], .read, f);
+
+    writeByte(pipe[1], 'x');
+
+    const made_progress = try fiber_mod.parkOnReactor(vm, sched);
+    try std.testing.expect(made_progress);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, f.status);
+}
+
+test "parkOnReactor reports no progress (genuine deadlock) when nothing is pending" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+    f.status = .completed; // neutralize: nothing left that could ever wake
+
+    const made_progress = try fiber_mod.parkOnReactor(vm, sched);
+    try std.testing.expect(!made_progress);
+}
+
+test "fiber switch does not grow the fiber's own register storage to match a large VM register file" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 42)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+    try std.testing.expect(f.registers.len < 1024);
+
+    // Simulate the VM having grown large from unrelated deep recursion
+    // elsewhere in the program, then switch to and back from the small
+    // fiber (main -> f saves main; f -> main saves f — the second switch
+    // is the one that would balloon f's storage if save/restore weren't
+    // live-window bounded, KEP-0001 Phase 2 resolved question 5).
+    try vm.ensureRegisterCapacity(8192);
+    sched.switchTo(1);
+    sched.switchTo(0);
+
+    try std.testing.expect(f.registers.len < 1024);
+
+    // The fiber's saved state must still be semantically correct after
+    // the dance above — bounded copying must not lose live data.
+    const result = try vm.eval("(fiber-join f)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -130,8 +130,8 @@ test "fiber switch does not grow the fiber's own register storage to match a lar
     // is the one that would balloon f's storage if save/restore weren't
     // live-window bounded, KEP-0001 Phase 2 resolved question 5).
     try vm.ensureRegisterCapacity(8192);
-    sched.switchTo(1);
-    sched.switchTo(0);
+    try sched.switchTo(1);
+    try sched.switchTo(0);
 
     try std.testing.expect(f.registers.len < 1024);
 

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -120,14 +120,14 @@ test "abandonFiberMutexes marks owned mutex abandoned" {
     defer vm.deinit();
 
     const fiber = try gc.allocFiber(types.VOID, 0);
-    const fiber_val = types.makePointer(@ptrCast(fiber));
+    const fiber_val = types.makePointer(@ptrCast(&fiber.header));
     const m_val = try gc.allocMutex(types.VOID);
     const m = types.toMutex(m_val);
 
     m.locked = true;
     m.owner = fiber_val;
 
-    srfi18.abandonFiberMutexes(&gc, fiber, null);
+    fiber_mod.abandonFiberMutexes(&gc, fiber, null);
 
     try std.testing.expect(m.abandoned);
     try std.testing.expect(!m.locked);
@@ -142,14 +142,14 @@ test "abandonFiberMutexes skips mutex owned by different fiber" {
 
     const fiber_a = try gc.allocFiber(types.VOID, 0);
     const fiber_b = try gc.allocFiber(types.VOID, 1);
-    const fiber_a_val = types.makePointer(@ptrCast(fiber_a));
+    const fiber_a_val = types.makePointer(@ptrCast(&fiber_a.header));
     const m_val = try gc.allocMutex(types.VOID);
     const m = types.toMutex(m_val);
 
     m.locked = true;
     m.owner = fiber_a_val;
 
-    srfi18.abandonFiberMutexes(&gc, fiber_b, null);
+    fiber_mod.abandonFiberMutexes(&gc, fiber_b, null);
 
     try std.testing.expect(!m.abandoned);
     try std.testing.expect(m.locked);
@@ -169,7 +169,7 @@ test "abandonFiberMutexes skips unlocked mutex" {
     m.locked = false;
     m.owner = types.VOID;
 
-    srfi18.abandonFiberMutexes(&gc, fiber, null);
+    fiber_mod.abandonFiberMutexes(&gc, fiber, null);
 
     try std.testing.expect(!m.abandoned);
 }
@@ -181,7 +181,7 @@ test "abandonFiberMutexes handles multiple mutexes" {
     defer vm.deinit();
 
     const fiber = try gc.allocFiber(types.VOID, 0);
-    var fiber_val = types.makePointer(@ptrCast(fiber));
+    var fiber_val = types.makePointer(@ptrCast(&fiber.header));
     // Root everything across the following allocations: under -Dgc-stress=true
     // each allocMutex collects, and an unrooted fiber/mutex local is swept.
     gc.pushRoot(&fiber_val);
@@ -205,7 +205,7 @@ test "abandonFiberMutexes handles multiple mutexes" {
     m3.locked = true;
     m3.owner = fiber_val;
 
-    srfi18.abandonFiberMutexes(&gc, fiber, null);
+    fiber_mod.abandonFiberMutexes(&gc, fiber, null);
 
     try std.testing.expect(m1.abandoned);
     try std.testing.expect(!m1.locked);
@@ -261,7 +261,7 @@ test "mutex-lock! on abandoned mutex raises abandoned-mutex-exception" {
     const m_val = try vm.eval("m");
     const m = types.toMutex(m_val);
     const sched_fiber = vm.current_fiber.?;
-    srfi18.abandonFiberMutexes(&gc, sched_fiber, vm.scheduler);
+    fiber_mod.abandonFiberMutexes(&gc, sched_fiber, vm.scheduler);
 
     try std.testing.expect(m.abandoned);
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -263,7 +263,12 @@ pub const Object = struct {
                 std.debug.assert(self.tag == expected);
             }
         }
-        return @ptrCast(@alignCast(self));
+        // Not a plain @ptrCast: "auto"-layout structs (every T here — none
+        // are extern) give Zig no guarantee that `header: Object` sits at
+        // byte offset 0, only that it's declared first. @fieldParentPtr
+        // computes the real offset regardless (see makePointer(&x.header)
+        // call sites, which is what self actually points at).
+        return @fieldParentPtr("header", self);
     }
 };
 
@@ -501,6 +506,15 @@ pub const MAX_FRAME_LIMIT: usize = 32768;
 pub const MAX_REGISTER_LIMIT: usize = 65536;
 pub const MAX_HANDLERS = 64;
 pub const MAX_WINDS = 64;
+
+/// Per-fiber initial storage (KEP-0001 Phase 2, resolved question 5) —
+/// deliberately much smaller than the VM's own INITIAL_REGISTER_CAPACITY/
+/// INITIAL_FRAME_CAPACITY. Fibers grow their own arrays geometrically as
+/// needed (see FiberScheduler.saveCurrentFiber); most fibers never touch
+/// more than a handful of frames, so starting small keeps per-fiber
+/// preallocation cheap even with thousands of concurrently-live fibers.
+pub const INITIAL_FIBER_REGISTER_CAPACITY: usize = 256;
+pub const INITIAL_FIBER_FRAME_CAPACITY: usize = 32;
 
 pub const ExceptionHandler = struct {
     handler: Value,

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const library_mod = @import("library.zig");
+const reactor_mod = @import("reactor.zig");
 pub const globals_mod = @import("globals.zig");
 const Value = types.Value;
 const OpCode = types.OpCode;
@@ -121,6 +122,10 @@ fn markVMRoots(gc: *memory.GC) void {
     // Mark fiber scheduler state (suspended fibers' execution state)
     if (vm.scheduler) |sched| {
         sched.markRoots(gc);
+    }
+    // Belt-and-braces: see Reactor.markRoots's doc comment.
+    if (vm.reactor) |r| {
+        r.markRoots(gc);
     }
 }
 
@@ -252,6 +257,9 @@ pub const VM = struct {
     default_random_source: Value = types.VOID,
     scheduler: ?*@import("fiber.zig").FiberScheduler = null,
     current_fiber: ?*@import("fiber.zig").Fiber = null,
+    /// Per-OS-thread I/O readiness/timer multiplexer (KEP-0001). Lazily
+    /// created together with `scheduler` by fiber.ensureScheduler.
+    reactor: ?*reactor_mod.Reactor = null,
     yielded: bool = false,
     /// Set by a blocking primitive (channel-receive, fiber-join) together with
     /// error.Yielded: the dispatch loop must rewind ip to the start of the
@@ -368,8 +376,14 @@ pub const VM = struct {
             globals_mod.clearGlobalsContext();
         }
         if (self.scheduler) |sched| {
+            sched.deinit(self.gc.allocator);
             self.gc.allocator.destroy(sched);
             self.scheduler = null;
+        }
+        if (self.reactor) |r| {
+            r.deinit();
+            self.gc.allocator.destroy(r);
+            self.reactor = null;
         }
         if (self.owns_globals) {
             self.globals.deinit();

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -189,7 +189,7 @@ pub fn run(vm: *VM) VMError!Value {
             // Route the yield through the scheduler instead of aborting
             // the top-level form.
             if (vm.scheduler) |sched| {
-                if (scheduleNextAfterYield(vm, sched)) {
+                if (try scheduleNextAfterYield(vm, sched)) {
                     return runWithScheduler(vm, sched);
                 }
                 return mainFiberResult(sched);
@@ -209,7 +209,7 @@ pub fn runWithScheduler(vm: *VM, sched: *fiber_mod.FiberScheduler) VMError!Value
         vm.sched_dispatch_pending = true;
         const result = vm.runUntil(0, 0) catch |err| {
             if (err == VMError.Yielded) {
-                if (scheduleNextAfterYield(vm, sched)) continue;
+                if (try scheduleNextAfterYield(vm, sched)) continue;
                 return mainFiberResult(sched);
             }
             return err;
@@ -219,13 +219,13 @@ pub fn runWithScheduler(vm: *VM, sched: *fiber_mod.FiberScheduler) VMError!Value
         current.status = .completed;
         current.result = result;
         vm.gc.writeBarrier(&current.header, result);
-        sched.saveCurrentFiber();
+        try sched.saveCurrentFiber();
         sched.wakeWaiters(current);
 
         if (sched.current_idx == 0) return result;
 
         if (sched.schedule()) |next_idx| {
-            sched.switchTo(next_idx);
+            try sched.switchTo(next_idx);
             continue;
         }
         // No runnable fibers remain and the last runUntil unwound out of a
@@ -242,9 +242,9 @@ pub fn runWithScheduler(vm: *VM, sched: *fiber_mod.FiberScheduler) VMError!Value
 /// one, or resume a main fiber whose join target completed. Returns false
 /// when nothing can be scheduled; the caller should then finish the
 /// top-level form with mainFiberResult().
-fn scheduleNextAfterYield(vm: *VM, sched: *fiber_mod.FiberScheduler) bool {
+fn scheduleNextAfterYield(vm: *VM, sched: *fiber_mod.FiberScheduler) VMError!bool {
     const current = sched.fibers.items[sched.current_idx] orelse return false;
-    sched.saveCurrentFiber();
+    try sched.saveCurrentFiber();
 
     if (current.status == .running) current.status = .suspended;
 
@@ -253,7 +253,7 @@ fn scheduleNextAfterYield(vm: *VM, sched: *fiber_mod.FiberScheduler) bool {
     }
 
     if (sched.schedule()) |next_idx| {
-        sched.switchTo(next_idx);
+        try sched.switchTo(next_idx);
         return true;
     }
     if (sched.fibers.items[0]) |main_fiber| {
@@ -263,7 +263,7 @@ fn scheduleNextAfterYield(vm: *VM, sched: *fiber_mod.FiberScheduler) bool {
                 const target = types.toObject(target_val).as(fiber_mod.Fiber);
                 if (target.status == .completed) {
                     main_fiber.result = target.result;
-                    sched.restoreFiber(0);
+                    try sched.restoreFiber(0);
                     sched.current_idx = 0;
                     vm.current_fiber = main_fiber;
                     main_fiber.status = .running;

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -112,7 +112,7 @@ pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
     // marked .completed (set when its form finished); both are per-form
     // states that must not leak into the next form.
     if (vm.scheduler) |sched| {
-        if (sched.fibers[0]) |main_fiber| {
+        if (sched.fibers.items[0]) |main_fiber| {
             sched.current_idx = 0;
             main_fiber.status = .running;
             vm.current_fiber = main_fiber;
@@ -215,7 +215,7 @@ pub fn runWithScheduler(vm: *VM, sched: *fiber_mod.FiberScheduler) VMError!Value
             return err;
         };
 
-        const current = sched.fibers[sched.current_idx] orelse return result;
+        const current = sched.fibers.items[sched.current_idx] orelse return result;
         current.status = .completed;
         current.result = result;
         vm.gc.writeBarrier(&current.header, result);
@@ -243,7 +243,7 @@ pub fn runWithScheduler(vm: *VM, sched: *fiber_mod.FiberScheduler) VMError!Value
 /// when nothing can be scheduled; the caller should then finish the
 /// top-level form with mainFiberResult().
 fn scheduleNextAfterYield(vm: *VM, sched: *fiber_mod.FiberScheduler) bool {
-    const current = sched.fibers[sched.current_idx] orelse return false;
+    const current = sched.fibers.items[sched.current_idx] orelse return false;
     sched.saveCurrentFiber();
 
     if (current.status == .running) current.status = .suspended;
@@ -256,7 +256,7 @@ fn scheduleNextAfterYield(vm: *VM, sched: *fiber_mod.FiberScheduler) bool {
         sched.switchTo(next_idx);
         return true;
     }
-    if (sched.fibers[0]) |main_fiber| {
+    if (sched.fibers.items[0]) |main_fiber| {
         if (main_fiber.status == .waiting) {
             const target_val = main_fiber.waiting_on;
             if (types.isFiber(target_val)) {
@@ -279,7 +279,7 @@ fn scheduleNextAfterYield(vm: *VM, sched: *fiber_mod.FiberScheduler) bool {
 /// result if its form completed (possibly inside a nested scheduler loop),
 /// VOID otherwise (deadlock — every fiber is blocked).
 fn mainFiberResult(sched: *fiber_mod.FiberScheduler) Value {
-    if (sched.fibers[0]) |main_fiber| {
+    if (sched.fibers.items[0]) |main_fiber| {
         if (main_fiber.status == .completed) return main_fiber.result;
     }
     return types.VOID;

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -22,4 +22,5 @@ test {
     _ = @import("tests_bytecode_cache.zig");
     _ = @import("tests_native.zig");
     _ = @import("tests_reactor.zig");
+    _ = @import("tests_scheduler.zig");
 }

--- a/tests/scheme/audit/primitives_fiber-audit.scm
+++ b/tests/scheme/audit/primitives_fiber-audit.scm
@@ -5,9 +5,9 @@
 ;; Run directly and read the printed counts — run-all.sh only sees exit codes.
 ;;
 ;; NOTE: test order matters. Deadlock tests leak permanently-parked fibers
-;; (that is inherent — there is no fiber-kill), and the spawn-limit test at
-;; the end deliberately fills every scheduler slot. Nothing that needs a
-;; free slot may run after it.
+;; (that is inherent — there is no fiber-kill), and the spawn test at the
+;; end deliberately spawns 70 more permanently-parked fibers. Nothing
+;; requiring a bounded fiber count may run after it.
 
 (import (scheme base) (scheme write) (kaappi fibers))
 (import (scheme process-context) (srfi 64))
@@ -111,8 +111,11 @@
                  (channel-receive (make-channel))
                  #f))
 
-;;; --- spawn limit (MAX_FIBERS = 64) — fills all remaining slots; keep last ---
-(test-equal '(limit-hit #t)
+;;; --- spawn limit — superseded by the growable fiber table (KEP-0001
+;;; Phase 2, kaappi/kaappi#1440): the fixed MAX_FIBERS=64 table this test
+;;; used to hit is gone, so 70 concurrently-parked spawns now succeed
+;;; outright instead of erroring at the old ceiling.
+(test-equal 'no-limit
     (guard (e (#t (list 'limit-hit (error-object? e))))
       (let loop ((i 0))
         (if (= i 70) 'no-limit

--- a/tests/scheme/smoke/fiber-channel-receive-waits-out-peer-sleep.scm
+++ b/tests/scheme/smoke/fiber-channel-receive-waits-out-peer-sleep.scm
@@ -1,0 +1,43 @@
+;; Regression test for KEP-0001's headline motivating bug (see the KEP's
+;; Motivation section): channel-receive must not falsely report deadlock
+;; when its only potential sender is currently in a timed sleep (about to
+;; send once it wakes) rather than genuinely stuck forever. Before Phase 2,
+;; channel-receive's idle branch was a bare `break` with no wait/retry, so
+;; a peer's pending timeout was invisible to it.
+
+(import (scheme base) (scheme write) (kaappi fibers) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+(define ch (make-channel))
+
+(define sender
+  (spawn (lambda ()
+           (thread-sleep! 0.1)
+           (channel-send ch 'delivered))))
+
+;; Must resolve once the sender wakes and sends, not raise a deadlock
+;; error and not hang.
+(check "delivered-after-peer-sleep" (channel-receive ch) 'delivered)
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))

--- a/tests/scheme/smoke/fiber-concurrent-many.scm
+++ b/tests/scheme/smoke/fiber-concurrent-many.scm
@@ -1,0 +1,52 @@
+;; Coverage test for KEP-0001 Phase 2 (kaappi/kaappi#1440): the fiber
+;; scheduler's table is now a growable list, not a fixed 64-slot array.
+;; Spawns 100 fibers BEFORE joining any of them, so all 100 are
+;; concurrently live at once — unlike fiber-slot-reuse.scm's sequential
+;; spawn-then-join pattern, which never has more than a couple of fibers
+;; alive simultaneously.
+
+(import (scheme base) (scheme write) (kaappi fibers))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+(define n 100)
+
+(define fibers
+  (let loop ((i 0) (acc '()))
+    (if (= i n)
+        (reverse acc)
+        (loop (+ i 1) (cons (spawn (lambda () (* i i))) acc)))))
+
+(define results (map fiber-join fibers))
+
+(check "fiber-count" (length results) n)
+(check "first-result" (car results) 0)
+(check "last-result" (list-ref results (- n 1)) (* (- n 1) (- n 1)))
+(check "all-fibers?"
+       (let loop ((fs fibers))
+         (cond ((null? fs) #t)
+               ((not (fiber? (car fs))) #f)
+               (else (loop (cdr fs)))))
+       #t)
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))

--- a/tests/scheme/smoke/fiber-sleep-does-not-stall-sibling.scm
+++ b/tests/scheme/smoke/fiber-sleep-does-not-stall-sibling.scm
@@ -1,0 +1,61 @@
+;; Regression test for KEP-0001 Phase 2 (kaappi/kaappi#1440): thread-sleep!
+;; is now a timed park on the reactor's timer heap instead of a
+;; whole-thread nanosleep, so a sibling fiber's unrelated work can finish
+;; WHILE this fiber sleeps, not just after it wakes.
+;;
+;; fiber-join's own round-robin dispatches the sleeper fiber first (it was
+;; spawned first), so measuring wall-clock time around fiber-join calls
+;; doesn't cleanly show this — the sleeper's own timed wait recursively
+;; drives the fast fiber to completion before ever returning control.
+;; Instead, the fast fiber timestamps its own completion, and that
+;; timestamp must land near the start, not near the end of the sleep.
+
+(import (scheme base) (scheme write) (kaappi fibers) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+(define (now) (time->seconds (current-time)))
+
+(define fast-done-at #f)
+(define sleep-seconds 0.3)
+(define t0 (now))
+
+(define sleeper (spawn (lambda () (thread-sleep! sleep-seconds) 'slept)))
+(define fast (spawn (lambda () (set! fast-done-at (now)) 'fast-done)))
+
+(define sleeper-result (fiber-join sleeper))
+(define t-end (now))
+(define fast-result (fiber-join fast))
+
+(check "sleeper-result" sleeper-result 'slept)
+(check "fast-result" fast-result 'fast-done)
+(check "fast-ran" (not (eq? fast-done-at #f)) #t)
+;; The fast fiber's own work is instant; if it ran DURING the sleep
+;; (not stalled behind it) its timestamp lands close to t0, well before
+;; the sleep's own duration elapses.
+(check "fast-ran-during-the-sleep-not-after"
+       (and fast-done-at (< (- fast-done-at t0) (/ sleep-seconds 2)))
+       #t)
+(check "sleep-actually-took-a-while" (>= (- t-end t0) (* sleep-seconds 0.8)) #t)
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))

--- a/tests/scheme/smoke/fiber-slot-reuse.scm
+++ b/tests/scheme/smoke/fiber-slot-reuse.scm
@@ -1,6 +1,8 @@
 ;; Regression test for #206: fiber scheduler slot exhaustion.
-;; Spawns more than MAX_FIBERS (64) total fibers over the program's
-;; lifetime. Without slot reclamation this crashes with StackOverflow.
+;; Spawns 100 fibers over the program's lifetime, more than the fiber
+;; table's original fixed 64-slot cap (since removed — KEP-0001 Phase 2,
+;; kaappi/kaappi#1440 — but slot reuse remains worth testing so completed
+;; fibers don't grow the table unboundedly).
 
 (import (scheme base)
         (scheme write))
@@ -22,7 +24,8 @@
         (newline))))
 
 ;; Spawn 100 fibers sequentially, each completing before the next.
-;; This requires slot reclamation since MAX_FIBERS = 64.
+;; Exercises slot reclamation (addFiber reuses a completed/errored slot
+;; before growing the table).
 (define results '())
 (let loop ((i 0))
   (when (< i 100)

--- a/tests/scheme/smoke/fiber-thread-join-deadline-cleared-after-resolve.scm
+++ b/tests/scheme/smoke/fiber-thread-join-deadline-cleared-after-resolve.scm
@@ -1,0 +1,67 @@
+;; Regression test for KEP-0001 Phase 2 (kaappi/kaappi#1440): thread-join!'s
+;; fiber path must clear me.deadline_ns once its wait resolves, exactly
+;; like thread-sleep!/mutex-lock!/mutex-unlock! already do.
+;;
+;; Before this fix, a timed thread-join! that resolved before its deadline
+;; left the stale deadline_ns in place. A later, unrelated *untimed* wait
+;; on the same fiber was then misread by hasRunnableFibers() as a live
+;; timed wait (`.waiting` + `deadline_ns != null`), even though the
+;; reactor no longer had a timer for it. That made parkOnReactor's
+;; deadlock check falsely conclude "more progress is possible" and block
+;; forever in reactor.poll(null) instead of detecting the genuine deadlock
+;; below (an untimed mutex-lock! on a mutex held by a fiber that can never
+;; release it).
+
+(import (scheme base) (scheme write) (kaappi fibers) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+;; Timed join that resolves well before its deadline — the stale
+;; deadline_ns bug requires a *resolved* (not timed-out) timed wait.
+(define f1 (spawn (lambda () (yield) 'quick)))
+(define kick (spawn (lambda () 'kick)))
+(fiber-join kick)
+(check "timed-join-result" (thread-join! f1 5.0) 'quick)
+
+;; A mutex held forever by a fiber blocked receiving on a channel no one
+;; will ever send to: any wait on `m` can never resolve.
+(define m (make-mutex))
+(define ch (make-channel))
+(define holder
+  (spawn (lambda ()
+           (mutex-lock! m)
+           (channel-send ch 'locked)
+           (channel-receive (make-channel)))))
+(check "holder-locked" (channel-receive ch) 'locked)
+
+;; Untimed lock on the permanently-held mutex: on the buggy code this
+;; hangs forever (caught by the test runner's timeout); on the fixed code
+;; it raises a deadlock error promptly.
+(define deadlock-detected
+  (guard (e (#t 'deadlock-raised))
+    (mutex-lock! m)
+    'unexpectedly-succeeded))
+
+(check "untimed-lock-on-dead-mutex-raises-deadlock" deadlock-detected 'deadlock-raised)
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))

--- a/tests/scheme/smoke/fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm
+++ b/tests/scheme/smoke/fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm
@@ -1,0 +1,65 @@
+;; Regression test for KEP-0001 Phase 2 (kaappi/kaappi#1440): a timed
+;; mutex-lock! must expire promptly even while a busy, repeatedly-yielding
+;; sibling fiber keeps the scheduler's dispatch loop from ever going idle.
+;;
+;; Before this fix, timer expiry was only checked in parkOnReactor (the
+;; idle branch of the scheduler), so a runnable sibling starved the timeout
+;; check: a 0.05s timeout fired only once the sibling finished (~0.74s in
+;; the reviewer's repro) instead of at ~0.05s. schedule() now pops expired
+;; reactor timers on every dispatch tick, not just when idle.
+
+(import (scheme base) (scheme write) (kaappi fibers) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ")
+        (display name)
+        (display " got=")
+        (write got)
+        (display " expected=")
+        (write expected)
+        (newline))))
+
+(define (now) (time->seconds (current-time)))
+
+(define m (make-mutex))
+(mutex-lock! m)
+
+(define waiter
+  (spawn (lambda ()
+           (let ((t0 (now)))
+             (let ((r (mutex-lock! m 0.05)))
+               (list r (- (now) t0)))))))
+
+;; Busy sibling: yields repeatedly without ever parking, so the scheduler's
+;; dispatch loop stays busy (never reaches the idle/parkOnReactor branch)
+;; for well over the waiter's 0.05s timeout.
+(define busy
+  (spawn (lambda ()
+           (let loop ((i 0))
+             (if (< i 8000000)
+                 (begin (yield) (loop (+ i 1)))
+                 'done)))))
+
+(define result (fiber-join waiter))
+
+(check "lock-timed-out" (car result) #f)
+;; Generous bound: must resolve well before the busy sibling's ~0.7s+
+;; runtime, not merely finish eventually.
+(check "resolved-near-timeout-not-after-sibling" (< (cadr result) 0.3) #t)
+
+(fiber-join busy)
+
+;; Summary
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary

Part of #1438 (KEP-0001, Phase 2). Closes #1440. Depends on Phase 1 (#1439/#1446, merged). Design: [KEP-0001 §3](https://github.com/kaappi/keps/blob/main/keps/0001-event-loop-reactor.md#3-scheduler-integration).

Wires the Phase 1 reactor into the fiber scheduler:

- **New `io_waiting` fiber status** plus `io_fd`/`io_interest`/`io_buffer` fields on `Fiber`. `schedule()` excludes it; `hasRunnableFibers()` includes it (used only by the reactor-park deadlock check, so it deliberately does *not* count `.running` — under recursive dispatch every fiber on the current call chain back to main is `.running`, so counting it would make a genuine deadlock spin in `reactor.poll()` forever instead of ever being detected).
- **One shared `runSchedulerStep`** replaces four structurally identical scheduler-dispatch loops (channel-receive/fiber-join, `thread-join!`, `mutex-lock!`, condition-variable waits). Its idle branch (`parkOnReactor`) replaces both the bare `break` and `scheduleOrTimeout`'s whole-thread `nanosleep` with a reactor park, bounded by the reactor's own timer heap.
- **`thread-sleep!`** is reimplemented as a timed reactor park instead of a blocking `nanosleep!` — sibling fibers now run while one sleeps.
- **Growable fiber table**: `FiberScheduler.fibers` is now a `std.ArrayList`, not a fixed 64-slot array. `spawn` beyond 64 concurrently-live fibers works; slot reuse for completed/errored fibers is preserved.
- **Live-window save/restore** (resolved question 5): per-fiber `saveCurrentFiber`/`restoreFiber` now copy only the live register/frame span (reusing the same `frameWindow()` computation `markFiberState` already used for GC marking) instead of the VM's entire register file, and per-fiber storage starts small (256 registers / 32 frames) instead of matching the VM's own capacity.
- **GC rooting**: `io_buffer` traced in `markFiberState`/`referencesYoung`; belt-and-braces `Reactor.markRoots`.

## Bugs found and fixed along the way

Both surfaced by this refactor, neither present before; both now covered by new tests.

1. **Struct-layout hazard**: `types.Object.as()` relied on every GC-tracked struct's `header: Object` field sitting at byte offset 0 — true by luck, not by any Zig guarantee (`struct` layout is unspecified for non-`extern` types). Adding fields to `Fiber` changed the compiler's chosen layout, moving `header` off offset 0 and silently breaking the pointer-tag-check pattern used throughout the interpreter (`isFiber`, `toObject(v).tag`, etc.). Fixed by switching every `Fiber`→`Value` encoding site to `makePointer(@ptrCast(&fiber.header))` and `Object.as()` to `@fieldParentPtr("header", self)`, both layout-independent.
2. **Use-after-free**: native-primitive `args: []const Value` slices point directly into `vm.registers`, which `runSchedulerStep` can reallocate (`ensureRegisterCapacity`) while recursively dispatching other fibers. Reading `args[...]` *after* that recursive dispatch (as the original code for `channel-receive`, `fiber-join`, and `mutex-lock!`'s owner-arg handling did) was reading potentially-freed memory. Fixed by capturing the needed `Value`s into locals before the recursive call, matching the pattern the pre-existing `channel-receive`/`fiber-join` code already used for this exact reason.

## Test plan

- [x] `zig build test` — 749/749 pass (5 new tests in `tests_scheduler.zig`)
- [x] `zig build test -Dgc-stress=true` — clean
- [x] `bash tests/scheme/run-all.sh` — 1830/1830 pass, 0 fail
- [x] 3 new Scheme smoke tests: >64 concurrently-live fibers, `thread-sleep!` doesn't stall a sibling, `channel-receive` resolves against a peer in a timed sleep (the false-deadlock scenario from the KEP's Motivation section)
- [x] Updated `primitives_fiber-audit.scm`'s spawn-limit test — its premise (a hard 64-fiber cap) is exactly what this phase removes, so it now expects the 70-spawn loop to succeed instead of erroring
- [x] Verified a `tests/scheme/coverage/srfi18-coverage.scm` failure ("cv-signal wakes waiter") is **pre-existing** on `main` (reproduces identically on `origin/main` before this branch, 5/5 runs) — unrelated cross-OS-thread mutex/condvar bug, flagged separately, not touched here

No I/O primitive changes in this PR — `readOneByte` etc. stay blocking. That's Phase 3 (#1441).

🤖 Generated with [Claude Code](https://claude.com/claude-code)