### PR TITLE
Fix mutex-lock!/mutex-unlock!+condvar giving up instantly across OS threads

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -488,13 +488,23 @@ fn wakeReadyFiber(f: *Fiber) void {
 /// `.suspended`+`timed_out` (an expired timed `.waiting` wait). Returns
 /// `false` only when nothing could ever produce a wakeup: genuine
 /// deadlock/done, the same meaning as the bare `break` this replaces.
-pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler) VMError!bool {
+///
+/// `cap_ns`, when given, additionally bounds the blocking wait itself
+/// (independent of any registered timer). Needed by waits that might
+/// resolve through state no reactor event announces — a mutex/condvar
+/// shared with another OS thread's own scheduler, which has no way to
+/// signal this one — so a long real timeout registered on `me` doesn't
+/// make this call block for that entire duration on the offhand chance a
+/// cross-thread resolution arrives sooner; the caller re-checks after each
+/// capped return. `null` preserves the original bounded-only-by-registered-
+/// timers behavior.
+pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool {
     const reactor = vm.reactor orelse return false;
     if (!sched.hasRunnableFibers() and reactor.isEmpty()) return false;
 
     var ready: std.ArrayList(*Fiber) = .empty;
     defer ready.deinit(vm.gc.allocator);
-    reactor.poll(null, &ready) catch return VMError.OutOfMemory;
+    reactor.poll(cap_ns, &ready) catch return VMError.OutOfMemory;
 
     for (ready.items) |f| wakeReadyFiber(f);
     return true;
@@ -512,14 +522,18 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler) VMError!bool {
 /// thread-join!, mutex-lock!, condition-variable waits, and thread-sleep!
 /// (KEP-0001 Phase 2) — call sites differ only in `Ctx.isDone`. `Ctx` is a
 /// small value type with an `isDone(self: Ctx) bool` method (comptime duck
-/// typing), e.g. `TargetWait{ .target = f }`.
+/// typing), e.g. `TargetWait{ .target = f }`. `Ctx` may optionally also
+/// define `pollCapNs(self: Ctx) ?u64` (see parkOnReactor) — omitted by
+/// every Ctx type except the SRFI-18 mutex/condvar waits, which need it for
+/// cross-OS-thread polling.
 pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberScheduler, me: *Fiber) VMError!bool {
     const my_idx = sched.current_idx;
     try sched.saveCurrentFiber();
+    const poll_cap_ns: ?u64 = if (@hasDecl(Ctx, "pollCapNs")) ctx.pollCapNs() else null;
 
     while (!ctx.isDone() and !me.timed_out) {
         const next_idx = sched.schedule() orelse {
-            if (!(try parkOnReactor(vm, sched))) break;
+            if (!(try parkOnReactor(vm, sched, poll_cap_ns))) break;
             continue;
         };
         if (next_idx == my_idx) break;

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -441,10 +441,15 @@ pub fn abandonFiberMutexes(gc: *memory.GC, fiber: *Fiber, sched: ?*FiberSchedule
         while (obj) |o| : (obj = o.next) {
             if (o.tag == .mutex) {
                 const m = o.as(types.Mutex);
-                if (m.locked and m.owner == fiber_val) {
-                    m.abandoned = true;
-                    m.locked = false;
+                if (@atomicLoad(bool, &m.locked, .acquire) and m.owner == fiber_val) {
+                    // Order matters: abandoned and owner must both be
+                    // published *before* the release-store below, so a
+                    // cross-thread acquirer that wins the locked CAS is
+                    // guaranteed to see them already updated (not stomp a
+                    // fresh owner write with VOID, or miss the abandonment).
+                    @atomicStore(bool, &m.abandoned, true, .release);
                     m.owner = types.VOID;
+                    @atomicStore(bool, &m.locked, false, .release);
                     if (sched) |s| s.wakeMutexWaiters(types.makePointer(@ptrCast(o)));
                 }
             }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -717,6 +717,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     if (tryClaimMutex(m)) {
         const ctx = try ensureScheduler();
         m.owner = resolveMutexOwner(args, if (ctx.vm.current_fiber) |cf| types.makePointer(@ptrCast(&cf.header)) else types.VOID);
+        if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
         if (tryClaimAbandoned(m)) return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
         return types.TRUE;
     }
@@ -762,6 +763,18 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         }
         if (done) {
             if (tryClaimMutex(m)) break;
+            // A local wake (the usual way runSchedulerStep reports "done")
+            // cancels me's pending reactor timer via cancelPendingTimer.
+            // Losing the claim race here means we're going back to waiting
+            // with the timer gone but me.deadline_ns still set -- re-add it
+            // (remove-first keeps this idempotent) or a timed mutex-lock!
+            // could block past its deadline, in the worst case unboundedly
+            // if crossThreadWaitPossible later turns false with no timer
+            // left to bound parkOnReactor's blocking wait.
+            if (deadline) |d| {
+                ctx.reactor.removeTimer(me);
+                try ctx.reactor.addTimer(d, me);
+            }
             me.status = .waiting;
             continue;
         }
@@ -771,6 +784,13 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
             return raiseError(.general, "mutex-lock!: deadlock — mutex will never be released (all fibers blocked)", types.VOID);
         }
         sleepNs(CROSS_THREAD_POLL_NS);
+        // Same timer restoration as above: a local wake earlier in this
+        // loop (see the `done` branch) may have already canceled the
+        // timer, and that state persists into this branch too.
+        if (deadline) |d| {
+            ctx.reactor.removeTimer(me);
+            try ctx.reactor.addTimer(d, me);
+        }
         me.status = .waiting;
     }
     // A cross-thread resolution never runs local wake bookkeeping (the
@@ -786,6 +806,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else types.makePointer(@ptrCast(&me.header)))
     else
         types.makePointer(@ptrCast(&me.header));
+    if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
 
     if (tryClaimAbandoned(m)) return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
     return types.TRUE;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -104,6 +104,42 @@ fn ensureScheduler() @TypeOf(fiber_mod.ensureScheduler(undefined)) {
     return fiber_mod.ensureScheduler(vm);
 }
 
+// 1ms, matching thread-join!'s existing OS-thread poll cadence.
+const CROSS_THREAD_POLL_NS: u64 = 1_000_000;
+
+// Number of thread-start!-spawned OS threads currently alive (incremented in
+// threadStartFn, decremented via defer in threadEntryFn on every exit path).
+// Lets crossThreadWaitPossible tell a real cross-OS-thread wait apart from a
+// genuine local deadlock -- see its comment.
+var live_child_threads: usize = 0;
+
+// True when some *other* OS thread could plausibly still change the mutex/
+// condvar state this scheduler is blocked on, so polling (instead of
+// accepting runSchedulerStep's "done == false" as a genuine deadlock) might
+// eventually pay off:
+//   - A spawned child thread's own scheduler (vm.owns_globals == false) may
+//     always be waiting on the main thread, which is "alive" for as long as
+//     the process runs -- always poll.
+//   - The main thread's scheduler only has something to gain from polling
+//     if at least one child thread currently exists to possibly unlock/
+//     signal from the outside; with none, runSchedulerStep reporting "not
+//     done" is a real, unrecoverable local deadlock (fiber.zig's
+//     parkOnReactor already found nothing locally runnable and no pending
+//     timer/fd event).
+//
+// Asymmetry this creates: a child thread that manages to genuinely
+// self-deadlock (e.g. waits on a mutex only it could ever unlock) now polls
+// forever rather than raising the deadlock error runSchedulerStep's "not
+// done" normally produces, since it always assumes the main thread might
+// still help -- indefinite blocking here is conformant with SRFI-18, but the
+// same shape of deadlock hangs on a child thread and errors on the main
+// thread, which is worth knowing when debugging one.
+fn crossThreadWaitPossible() bool {
+    const vm = vm_mod.vm_instance orelse return false;
+    if (!vm.owns_globals) return true;
+    return @atomicLoad(usize, &live_child_threads, .acquire) > 0;
+}
+
 fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
     if (timeout == types.FALSE) return null;
     if (types.isSrfi18Time(timeout)) {
@@ -227,14 +263,27 @@ fn threadStartFn(args: []const Value) PrimitiveError!Value {
     gc.extra_roots.append(gc.allocator, args[0]) catch return PrimitiveError.OutOfMemory;
 
     fiber.status = .running;
+    // Increment *before* spawning: if the child ran to completion before an
+    // increment placed after std.Thread.spawn executed, the decrement in
+    // threadEntryFn's defer could fire first and wrap the counter (or drop
+    // it one below the true count with other children alive), letting
+    // crossThreadWaitPossible wrongly conclude no other thread exists.
+    _ = @atomicRmw(usize, &live_child_threads, .Add, 1, .release);
     fiber.os_thread = std.Thread.spawn(.{}, threadEntryFn, .{
         fiber, gc.allocator, gc, vm,
-    }) catch return PrimitiveError.OutOfMemory;
+    }) catch {
+        _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
+        return PrimitiveError.OutOfMemory;
+    };
 
     return args[0];
 }
 
 fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_gc: *memory.GC, parent_vm: *vm_mod.VM) void {
+    // Balances the increment in threadStartFn on every exit path (including
+    // the early GC/VM-init failures below), so crossThreadWaitPossible's "is
+    // another OS thread still alive" check stays accurate.
+    defer _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
     _ = parent_gc;
     const child_gc = allocator.create(memory.GC) catch {
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
@@ -619,8 +668,8 @@ fn mutexStateFn(args: []const Value) PrimitiveError!Value {
     if (!types.isMutex(args[0]))
         return primitives.typeError("mutex-state", "mutex", args[0]);
     const m = types.toMutex(args[0]);
-    if (!m.locked) {
-        if (m.abandoned) {
+    if (!@atomicLoad(bool, &m.locked, .acquire)) {
+        if (@atomicLoad(bool, &m.abandoned, .acquire)) {
             const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
             return gc.allocSymbol("abandoned") catch return PrimitiveError.OutOfMemory;
         }
@@ -632,38 +681,43 @@ fn mutexStateFn(args: []const Value) PrimitiveError!Value {
     return gc.allocSymbol("not-owned") catch return PrimitiveError.OutOfMemory;
 }
 
+// The fiber/thread that resolves to be recorded as a mutex's new owner: an
+// explicit fiber (args[2]), explicitly "unowned" (args[2] == #f), or the
+// caller's own current fiber.
+fn resolveMutexOwner(args: []const Value, fallback: Value) Value {
+    if (args.len > 2 and types.isFiber(args[2])) return args[2];
+    if (args.len > 2 and args[2] == types.FALSE) return types.VOID;
+    return fallback;
+}
+
+// Atomically claims the mutex (false -> true). This is the single point of
+// arbitration between racing threads -- a plain load-then-store lets two
+// threads both observe "unlocked" and both believe they've acquired it,
+// corrupting mutual exclusion. Load-bearing now that cross-thread mutex
+// contention is a supported, polled-for wait (see crossThreadWaitPossible)
+// rather than something that resolved (buggily) on the first check.
+fn tryClaimMutex(m: *types.Mutex) bool {
+    return @cmpxchgStrong(bool, &m.locked, false, true, .acq_rel, .acquire) == null;
+}
+
+// Atomically claims (and clears) an abandoned flag. Only meaningful once
+// the caller has already won tryClaimMutex: it decides whether *this*
+// acquisition should also raise abandoned-mutex-exception, without letting
+// a second racing acquirer also see and report the same abandonment.
+fn tryClaimAbandoned(m: *types.Mutex) bool {
+    return @cmpxchgStrong(bool, &m.abandoned, true, false, .acq_rel, .acquire) == null;
+}
+
 fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     if (!types.isMutex(args[0]))
         return primitives.typeError("mutex-lock!", "mutex", args[0]);
 
     const m = types.toMutex(args[0]);
 
-    if (m.abandoned) {
-        m.abandoned = false;
-        m.locked = true;
+    if (tryClaimMutex(m)) {
         const ctx = try ensureScheduler();
-        m.owner = if (args.len > 2 and types.isFiber(args[2]))
-            args[2]
-        else if (args.len > 2 and args[2] == types.FALSE)
-            types.VOID
-        else if (ctx.vm.current_fiber) |cf|
-            types.makePointer(@ptrCast(&cf.header))
-        else
-            types.VOID;
-        return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
-    }
-
-    if (!m.locked) {
-        m.locked = true;
-        const ctx = try ensureScheduler();
-        m.owner = if (args.len > 2 and types.isFiber(args[2]))
-            args[2]
-        else if (args.len > 2 and args[2] == types.FALSE)
-            types.VOID
-        else if (ctx.vm.current_fiber) |cf|
-            types.makePointer(@ptrCast(&cf.header))
-        else
-            types.VOID;
+        m.owner = resolveMutexOwner(args, if (ctx.vm.current_fiber) |cf| types.makePointer(@ptrCast(&cf.header)) else types.VOID);
+        if (tryClaimAbandoned(m)) return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
         return types.TRUE;
     }
 
@@ -691,38 +745,56 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         try ctx.reactor.addTimer(d, me);
     }
 
-    const done = try fiber_mod.runSchedulerStep(MutexWait, .{ .m = m }, ctx.vm, ctx.sched, me);
+    // runSchedulerStep only returns done once it *observes* m.locked ==
+    // false; claiming it is still a race against any other thread making
+    // the same observation, so retry the claim and go back to waiting on
+    // failure instead of assuming we won. When runSchedulerStep reports
+    // "not done" (parkOnReactor found nothing locally runnable and no
+    // pending timer/fd event), that's only a genuine deadlock if no other
+    // OS thread could plausibly still unlock this mutex from the outside —
+    // otherwise poll briefly and retry.
+    while (true) {
+        const done = try fiber_mod.runSchedulerStep(MutexWait, .{ .m = m }, ctx.vm, ctx.sched, me);
+        if (me.timed_out) {
+            me.timed_out = false;
+            me.deadline_ns = null;
+            return types.FALSE;
+        }
+        if (done) {
+            if (tryClaimMutex(m)) break;
+            me.status = .waiting;
+            continue;
+        }
+        if (!crossThreadWaitPossible()) {
+            if (deadline != null) ctx.reactor.removeTimer(me);
+            me.deadline_ns = null;
+            return raiseError(.general, "mutex-lock!: deadlock — mutex will never be released (all fibers blocked)", types.VOID);
+        }
+        sleepNs(CROSS_THREAD_POLL_NS);
+        me.status = .waiting;
+    }
+    // A cross-thread resolution never runs local wake bookkeeping (the
+    // unlocking thread's scheduler/reactor doesn't even know `me` exists),
+    // so any timer registered above may still be pending; a local wake
+    // already canceled it (removeTimer is a no-op then), but skipping this
+    // for the cross-thread path would leave a stale entry that could later
+    // fire against a reused fiber slot.
+    if (deadline != null) ctx.reactor.removeTimer(me);
     me.deadline_ns = null;
 
-    if (me.timed_out) {
-        me.timed_out = false;
-        return types.FALSE;
-    }
-    if (!done) {
-        // Genuine deadlock: parkOnReactor gave up because nothing local
-        // could ever unlock this mutex (no other runnable fiber, no
-        // pending timer). Must not fall through to "assume success" —
-        // that would silently steal a lock still held elsewhere.
-        return raiseError(.general, "mutex-lock!: deadlock — mutex will never be released (all fibers blocked)", types.VOID);
-    }
-
-    m.locked = true;
     m.owner = if (owner_arg) |oa|
         (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else types.makePointer(@ptrCast(&me.header)))
     else
         types.makePointer(@ptrCast(&me.header));
 
-    if (m.abandoned) {
-        m.abandoned = false;
-        return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
-    }
+    if (tryClaimAbandoned(m)) return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
     return types.TRUE;
 }
 
 const MutexWait = struct {
     m: *types.Mutex,
     pub fn isDone(self: MutexWait) bool {
-        return !self.m.locked;
+        return !@atomicLoad(bool, &self.m.locked, .acquire);
     }
 };
 
@@ -731,13 +803,28 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("mutex-unlock!", "mutex", args[0]);
 
     const m = types.toMutex(args[0]);
-    m.locked = false;
+    const has_cv = args.len > 1 and types.isConditionVariable(args[1]);
+
+    // Snapshot the condvar's signal generation *before* releasing the mutex,
+    // while we still exclusively hold it. Per the SRFI-18 protocol, any
+    // signaler must acquire this same mutex before calling
+    // condition-variable-signal!/-broadcast!, so it cannot have bumped the
+    // generation yet -- snapshotting after the unlock would race a signaler
+    // that acquires the mutex in the gap and produce a lost wakeup (the
+    // waiter would then wait for a *second* signal that may never come).
+    const cv: ?*types.ConditionVariable = if (has_cv) types.toConditionVariable(args[1]) else null;
+    const start_gen: u64 = if (cv) |c| @atomicLoad(u64, &c.signal_generation, .acquire) else 0;
+
+    // Clear owner *before* the release-store: otherwise a cross-thread
+    // acquirer that wins the locked CAS right after the store below could
+    // write its own owner, and this line would then stomp it back to VOID.
     m.owner = types.VOID;
+    @atomicStore(bool, &m.locked, false, .release);
 
     const ctx = try ensureScheduler();
     ctx.sched.wakeMutexWaiters(args[0]);
 
-    if (args.len > 1 and types.isConditionVariable(args[1])) {
+    if (cv) |c| {
         var deadline: ?u64 = null;
         if (args.len > 2) {
             deadline = try timeoutToDeadlineNs(args[2]);
@@ -752,18 +839,36 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
             try ctx.reactor.addTimer(d, me);
         }
 
-        const done = try fiber_mod.runSchedulerStep(CondVarWait, .{ .me = me }, ctx.vm, ctx.sched, me);
+        // Each OS thread owns an independent FiberScheduler, so
+        // condition-variable-signal!/-broadcast! called on *another*
+        // thread only wakes fibers local to that thread's own scheduler
+        // (me.status never changes) -- the generation bump in
+        // CondVarWait.isDone is what a cross-thread waiter actually relies
+        // on. When runSchedulerStep reports "not done", poll and retry
+        // instead of treating it as a genuine deadlock whenever another OS
+        // thread could plausibly still signal from the outside.
+        while (true) {
+            const done = try fiber_mod.runSchedulerStep(CondVarWait, .{ .me = me, .cv = c, .start_gen = start_gen }, ctx.vm, ctx.sched, me);
+            if (me.timed_out) {
+                me.timed_out = false;
+                me.deadline_ns = null;
+                return types.FALSE;
+            }
+            if (done) break;
+            if (!crossThreadWaitPossible()) {
+                if (deadline != null) ctx.reactor.removeTimer(me);
+                me.deadline_ns = null;
+                return raiseError(.general, "mutex-unlock!: deadlock — condition variable will never be signaled (all fibers blocked)", types.VOID);
+            }
+            sleepNs(CROSS_THREAD_POLL_NS);
+            me.status = .waiting;
+        }
+        // See the matching comment in mutexLockFn: a cross-thread signal
+        // never runs local wake bookkeeping, so any timer registered above
+        // may still be pending (a local wake already canceled it --
+        // removeTimer is then a no-op).
+        if (deadline != null) ctx.reactor.removeTimer(me);
         me.deadline_ns = null;
-
-        if (me.timed_out) {
-            me.timed_out = false;
-            return types.FALSE;
-        }
-        if (!done) {
-            // Genuine deadlock: parkOnReactor gave up because nothing
-            // local could ever signal this condition variable.
-            return raiseError(.general, "mutex-unlock!: deadlock — condition variable will never be signaled (all fibers blocked)", types.VOID);
-        }
         return types.TRUE;
     }
 
@@ -772,8 +877,11 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
 
 const CondVarWait = struct {
     me: *fiber_mod.Fiber,
+    cv: *types.ConditionVariable,
+    start_gen: u64,
     pub fn isDone(self: CondVarWait) bool {
-        return self.me.status != .waiting;
+        return self.me.status != .waiting or
+            @atomicLoad(u64, &self.cv.signal_generation, .acquire) != self.start_gen;
     }
 };
 
@@ -816,6 +924,9 @@ fn condvarSignalFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("condition-variable-signal!", "condition-variable", args[0]);
     const ctx = try ensureScheduler();
     ctx.sched.wakeOneCondVarWaiter(args[0]);
+    // Bump the generation so a waiter parked on a different OS thread's
+    // scheduler (which never sees the local wake above) can poll for this.
+    _ = @atomicRmw(u64, &types.toConditionVariable(args[0]).signal_generation, .Add, 1, .release);
     return types.VOID;
 }
 
@@ -824,6 +935,7 @@ fn condvarBroadcastFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("condition-variable-broadcast!", "condition-variable", args[0]);
     const ctx = try ensureScheduler();
     ctx.sched.wakeAllCondVarWaiters(args[0]);
+    _ = @atomicRmw(u64, &types.toConditionVariable(args[0]).signal_generation, .Add, 1, .release);
     return types.VOID;
 }
 

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -796,6 +796,15 @@ const MutexWait = struct {
     pub fn isDone(self: MutexWait) bool {
         return !@atomicLoad(bool, &self.m.locked, .acquire);
     }
+    // Caps parkOnReactor's blocking wait so a long real timeout (registered
+    // separately on `me`) can't make it block for the whole duration on the
+    // offhand chance the mutex is unlocked by another OS thread sooner --
+    // that thread's own scheduler has no way to signal this one directly.
+    // See crossThreadWaitPossible's doc comment for when this applies.
+    pub fn pollCapNs(self: MutexWait) ?u64 {
+        _ = self;
+        return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
+    }
 };
 
 fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
@@ -882,6 +891,11 @@ const CondVarWait = struct {
     pub fn isDone(self: CondVarWait) bool {
         return self.me.status != .waiting or
             @atomicLoad(u64, &self.cv.signal_generation, .acquire) != self.start_gen;
+    }
+    // See MutexWait.pollCapNs.
+    pub fn pollCapNs(self: CondVarWait) ?u64 {
+        _ = self;
+        return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
     }
 };
 

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -91,7 +91,7 @@ test "parkOnReactor wakes a manually io_waiting fiber when its fd becomes readab
 
     writeByte(pipe[1], 'x');
 
-    const made_progress = try fiber_mod.parkOnReactor(vm, sched);
+    const made_progress = try fiber_mod.parkOnReactor(vm, sched, null);
     try std.testing.expect(made_progress);
     try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, f.status);
 }
@@ -108,7 +108,7 @@ test "parkOnReactor reports no progress (genuine deadlock) when nothing is pendi
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
     f.status = .completed; // neutralize: nothing left that could ever wake
 
-    const made_progress = try fiber_mod.parkOnReactor(vm, sched);
+    const made_progress = try fiber_mod.parkOnReactor(vm, sched, null);
     try std.testing.expect(!made_progress);
 }
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -665,6 +665,12 @@ pub const ConditionVariable = struct {
     header: Object,
     name: Value,
     specific: Value,
+    // Bumped (atomically) by condition-variable-signal!/-broadcast!. Each OS
+    // thread runs its own independent FiberScheduler, so a waiter parked by a
+    // *different* thread never observes that thread's local wakeOneCondVarWaiter/
+    // wakeAllCondVarWaiters bookkeeping; polling this counter is how a
+    // cross-thread waiter detects a signal happened.
+    signal_generation: u64 = 0,
 };
 
 pub const TimeType = enum(u8) {

--- a/tests/scheme/coverage/srfi18-coverage.scm
+++ b/tests/scheme/coverage/srfi18-coverage.scm
@@ -169,29 +169,29 @@
     (check-true "cv-signal wakes waiter" ready)))
 
 ;;; ---- Condition variable broadcast ----
-;; Fiber path again -- see the "Mutex contention" note above. fiber-join on
-;; t1 before either fiber has reached the cv wait drives the scheduler (via
-;; its own "run something else while target isn't done" loop) far enough
-;; for both t1 and t2 to lock m, release it via mutex-unlock!+cv, and park
-;; on cv -- exactly the state broadcast! needs to find waiters to wake.
+;; Same shape as the signal test above (main waits, t wakes it), just
+;; calling broadcast! instead of signal! -- deliberately *not* two waiters:
+;; with two fibers simultaneously parked on cv and nothing else locally
+;; runnable, the driving fiber-join would have nothing left to schedule and
+;; give up immediately rather than hang on a fiber-only deadlock it can't
+;; distinguish from a real one (this PR only teaches that judgment call to
+;; real OS threads, which can tell whether another thread might still
+;; resolve it -- see crossThreadWaitPossible in primitives_srfi18.zig), so
+;; both fibers would "complete" without broadcast! ever actually running,
+;; and the check would pass for the wrong reason.
 (let ((m (make-mutex))
       (cv (make-condition-variable))
-      (count 0))
-  (let ((t1 (spawn
-             (lambda ()
-               (mutex-lock! m)
-               (mutex-unlock! m cv)
-               (set! count (+ count 1)))))
-        (t2 (spawn
-             (lambda ()
-               (mutex-lock! m)
-               (mutex-unlock! m cv)
-               (set! count (+ count 1))))))
-    (fiber-join t1)
-    (condition-variable-broadcast! cv)
-    (fiber-join t1)
-    (fiber-join t2)
-    (check "cv-broadcast wakes all" count 2)))
+      (ready #f))
+  (let ((t (spawn
+            (lambda ()
+              (mutex-lock! m)
+              (set! ready #t)
+              (condition-variable-broadcast! cv)
+              (mutex-unlock! m)))))
+    (mutex-lock! m)
+    (mutex-unlock! m cv)
+    (fiber-join t)
+    (check-true "cv-broadcast wakes waiter" ready)))
 
 ;;; ---- Time objects ----
 (check-true "time? current-time" (time? (current-time)))

--- a/tests/scheme/coverage/srfi18-coverage.scm
+++ b/tests/scheme/coverage/srfi18-coverage.scm
@@ -1,4 +1,4 @@
-(import (scheme base) (scheme write) (srfi 18))
+(import (scheme base) (scheme write) (srfi 18) (kaappi fibers))
 
 (define pass 0)
 (define fail 0)
@@ -119,18 +119,22 @@
   (mutex-unlock! m))
 
 ;;; ---- Mutex contention ----
+;; OS threads (thread-start!) run on isolated heaps and cannot share mutexes
+;; or condition variables captured by a thread thunk's closure (deep-copying
+;; a thunk that closes over one raises "uncopyable type"), so contention is
+;; exercised on the same-heap fiber path instead -- matching the pattern in
+;; tests/scheme/srfi/srfi18.scm.
 (let ((m (make-mutex))
       (result '()))
   (mutex-lock! m)
-  (let ((t (make-thread
+  (let ((t (spawn
             (lambda ()
               (mutex-lock! m)
               (set! result (cons 'got-lock result))
               (mutex-unlock! m)))))
-    (thread-start! t)
     (set! result (cons 'main-holds result))
     (mutex-unlock! m)
-    (thread-join! t)
+    (fiber-join t)
     (check-true "mutex contention" (memq 'got-lock result))))
 
 ;;; ---- Mutex with timeout ----
@@ -149,40 +153,44 @@
   (check "condition-variable-specific" (condition-variable-specific cv) 'cv-data))
 
 ;;; ---- Condition variable signal ----
+;; Fiber path again -- see the "Mutex contention" note above.
 (let ((m (make-mutex))
       (cv (make-condition-variable))
       (ready #f))
-  (let ((t (make-thread
+  (let ((t (spawn
             (lambda ()
               (mutex-lock! m)
               (set! ready #t)
               (condition-variable-signal! cv)
               (mutex-unlock! m)))))
     (mutex-lock! m)
-    (thread-start! t)
     (mutex-unlock! m cv)
+    (fiber-join t)
     (check-true "cv-signal wakes waiter" ready)))
 
 ;;; ---- Condition variable broadcast ----
+;; Fiber path again -- see the "Mutex contention" note above. fiber-join on
+;; t1 before either fiber has reached the cv wait drives the scheduler (via
+;; its own "run something else while target isn't done" loop) far enough
+;; for both t1 and t2 to lock m, release it via mutex-unlock!+cv, and park
+;; on cv -- exactly the state broadcast! needs to find waiters to wake.
 (let ((m (make-mutex))
       (cv (make-condition-variable))
       (count 0))
-  (let ((t1 (make-thread
+  (let ((t1 (spawn
              (lambda ()
                (mutex-lock! m)
                (mutex-unlock! m cv)
                (set! count (+ count 1)))))
-        (t2 (make-thread
+        (t2 (spawn
              (lambda ()
                (mutex-lock! m)
                (mutex-unlock! m cv)
                (set! count (+ count 1))))))
-    (thread-start! t1)
-    (thread-start! t2)
-    (thread-sleep! 0.05)
+    (fiber-join t1)
     (condition-variable-broadcast! cv)
-    (thread-join! t1)
-    (thread-join! t2)
+    (fiber-join t1)
+    (fiber-join t2)
     (check "cv-broadcast wakes all" count 2)))
 
 ;;; ---- Time objects ----

--- a/tests/scheme/srfi/srfi18-cross-thread-wait.scm
+++ b/tests/scheme/srfi/srfi18-cross-thread-wait.scm
@@ -88,21 +88,34 @@
 ;; ---- condition-variable-broadcast! blocks both waiters for the signal ----
 ;; Same reasoning as above: each waiter measures its own elapsed wait time
 ;; rather than relying on a flag that thread-join! would make visible anyway.
+;;
+;; Unlike the signal test, this broadcast isn't ordered by bc-m: main issues
+;; it after a fixed sleep rather than while holding the mutex, so there's no
+;; guarantee a waiter thread has already reached mutex-unlock!+cv by then.
+;; If one hasn't (e.g. a slow/contended CI runner), it snapshots a
+;; generation *after* the bump and then waits for a second broadcast that
+;; never comes -- and a real OS thread never gives up that wait on its own
+;; (crossThreadWaitPossible is unconditionally true for a spawned thread, so
+;; it always assumes the main thread could still resolve it). A bounded
+;; per-waiter timeout turns that race into a reported failure instead of a
+;; hung CI job.
 (define bc-m (make-mutex))
 (define bc-cv (make-condition-variable))
 (define bc-elapsed-1 -1.0)
 (define bc-elapsed-2 -1.0)
+(define bc-woke-1 #f)
+(define bc-woke-2 #f)
 
 (define (bc-waiter-thunk-1)
   (mutex-lock! bc-m)
   (let ((t0 (current-time)))
-    (mutex-unlock! bc-m bc-cv)
+    (set! bc-woke-1 (mutex-unlock! bc-m bc-cv 5))
     (set! bc-elapsed-1 (- (time->seconds (current-time)) (time->seconds t0)))))
 
 (define (bc-waiter-thunk-2)
   (mutex-lock! bc-m)
   (let ((t0 (current-time)))
-    (mutex-unlock! bc-m bc-cv)
+    (set! bc-woke-2 (mutex-unlock! bc-m bc-cv 5))
     (set! bc-elapsed-2 (- (time->seconds (current-time)) (time->seconds t0)))))
 
 (let ((t1 (make-thread bc-waiter-thunk-1))
@@ -116,7 +129,9 @@
   (check-true "condition-variable-broadcast! blocks waiter 1 for the signal (not instant)"
     (>= bc-elapsed-1 0.1))
   (check-true "condition-variable-broadcast! blocks waiter 2 for the signal (not instant)"
-    (>= bc-elapsed-2 0.1)))
+    (>= bc-elapsed-2 0.1))
+  (check-true "condition-variable-broadcast! actually woke waiter 1 (not a timeout)" bc-woke-1)
+  (check-true "condition-variable-broadcast! actually woke waiter 2 (not a timeout)" bc-woke-2))
 
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)

--- a/tests/scheme/srfi/srfi18-cross-thread-wait.scm
+++ b/tests/scheme/srfi/srfi18-cross-thread-wait.scm
@@ -1,0 +1,123 @@
+;; Regression test: mutex-lock! and mutex-unlock!+condition-variable must
+;; block until the shared state actually changes when called from a real OS
+;; thread (make-thread/thread-start!) that has nothing else locally
+;; schedulable.
+;;
+;; Each OS thread runs its own independent FiberScheduler; mutex-unlock!/
+;; condition-variable-signal!/-broadcast! called on *another* OS thread only
+;; wake fibers local to that thread's own scheduler, so there is no
+;; cross-thread wakeup. Before this fix, whenever nothing was locally
+;; schedulable, mutex-lock! and mutex-unlock!+condvar-wait gave up
+;; immediately and unconditionally reported success -- so mutex-lock! on a
+;; mutex still held by a different thread returned #t at once (silently
+;; corrupting the lock), and mutex-unlock!+condvar returned before any
+;; signal had happened.
+;;
+;; Mutex/condition-variable objects are deep-copy-rejected when captured by
+;; a thread thunk's closure (see srfi18.scm's "OS threads cannot capture
+;; sync primitives" test) -- the supported way to share them across real OS
+;; threads is via top-level globals, which is what this test does.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (check-true name val)
+  (if val
+      (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1)) (display "FAIL: ") (display name) (newline))))
+
+;; ---- mutex-lock! blocks across OS threads until unlocked ----
+(define lock-m (make-mutex))
+(define lock-elapsed -1.0)
+
+(define (lock-waiter-thunk)
+  (let ((t0 (current-time)))
+    (mutex-lock! lock-m)
+    (set! lock-elapsed (- (time->seconds (current-time)) (time->seconds t0)))
+    (mutex-unlock! lock-m)))
+
+(mutex-lock! lock-m)
+(let ((t (make-thread lock-waiter-thunk)))
+  (thread-start! t)
+  (thread-sleep! 0.2)
+  (mutex-unlock! lock-m)
+  (thread-join! t)
+  (check-true "mutex-lock! blocks until the holder unlocks (not instant)"
+    (>= lock-elapsed 0.15)))
+
+;; ---- mutex-unlock!+condition-variable-signal! blocks for the signal ----
+;; thread-join! already blocks correctly (it has its own OS-thread poll
+;; loop), so simply checking a flag set by the signaling thread *after*
+;; joining would pass even with the bug: the signaler still eventually runs
+;; and sets the flag before it exits, regardless of whether the waiter's own
+;; mutex-unlock!+condvar call returned instantly or genuinely waited. So this
+;; measures the waiter's own elapsed time around the call, which the bug
+;; made ~instant instead of spanning the signaling thread's delay.
+(define cv-m (make-mutex))
+(define cv-cv (make-condition-variable))
+(define cv-elapsed -1.0)
+
+(define (cv-signal-thunk)
+  (thread-sleep! 0.2)
+  (mutex-lock! cv-m)
+  (condition-variable-signal! cv-cv)
+  (mutex-unlock! cv-m))
+
+(mutex-lock! cv-m)
+(let ((t (make-thread cv-signal-thunk)))
+  (thread-start! t)
+  (let ((t0 (current-time)))
+    (mutex-unlock! cv-m cv-cv)
+    (set! cv-elapsed (- (time->seconds (current-time)) (time->seconds t0))))
+  (thread-join! t)
+  (check-true "mutex-unlock!+condition-variable-signal! blocks for the signal (not instant)"
+    (>= cv-elapsed 0.1)))
+
+;; ---- condition-variable-broadcast! blocks both waiters for the signal ----
+;; Same reasoning as above: each waiter measures its own elapsed wait time
+;; rather than relying on a flag that thread-join! would make visible anyway.
+(define bc-m (make-mutex))
+(define bc-cv (make-condition-variable))
+(define bc-elapsed-1 -1.0)
+(define bc-elapsed-2 -1.0)
+
+(define (bc-waiter-thunk-1)
+  (mutex-lock! bc-m)
+  (let ((t0 (current-time)))
+    (mutex-unlock! bc-m bc-cv)
+    (set! bc-elapsed-1 (- (time->seconds (current-time)) (time->seconds t0)))))
+
+(define (bc-waiter-thunk-2)
+  (mutex-lock! bc-m)
+  (let ((t0 (current-time)))
+    (mutex-unlock! bc-m bc-cv)
+    (set! bc-elapsed-2 (- (time->seconds (current-time)) (time->seconds t0)))))
+
+(let ((t1 (make-thread bc-waiter-thunk-1))
+      (t2 (make-thread bc-waiter-thunk-2)))
+  (thread-start! t1)
+  (thread-start! t2)
+  (thread-sleep! 0.2)
+  (condition-variable-broadcast! bc-cv)
+  (thread-join! t1)
+  (thread-join! t2)
+  (check-true "condition-variable-broadcast! blocks waiter 1 for the signal (not instant)"
+    (>= bc-elapsed-1 0.1))
+  (check-true "condition-variable-broadcast! blocks waiter 2 for the signal (not instant)"
+    (>= bc-elapsed-2 0.1)))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

- Each OS thread runs its own independent `FiberScheduler`, so `mutex-lock!` and `mutex-unlock!+condition-variable-wait` had nothing to do the moment nothing was locally schedulable — always true for a real OS thread whose only fiber is its own top-level thunk. Both then unconditionally reported success without re-checking whether the guarded state had actually changed: `mutex-lock!` on a mutex still held by another thread returned `#t` at once (silently corrupting the lock), and `mutex-unlock!` with a condition variable returned before any signal had happened.
- Fix: poll the shared state (`Mutex.locked` / a new `ConditionVariable.signal_generation` counter) at a short interval instead of giving up immediately, but only when another OS thread could plausibly still change it (`crossThreadWaitPossible`) — a genuine local-only fiber deadlock still gives up right away, otherwise it would hang forever instead of terminating (which I hit and fixed during development). The condvar generation is snapshotted *before* releasing the mutex in `mutex-unlock!` to avoid a lost-wakeup race against a signaler that acquires the mutex in the gap.
- Mutex acquisition is now a `@cmpxchgStrong`-based claim (`tryClaimMutex`/`tryClaimAbandoned`) instead of a plain load-then-store, since cross-thread contention on the same mutex is now a real, tested code path rather than something that resolved (buggily) on the first check. `owner`/`abandoned` are published *before* the lock's release-store everywhere they're set, so a cross-thread acquirer that wins the race can't have its owner write silently stomped back to `VOID`.
- Also updates the stale `coverage/srfi18-coverage.scm` tests that captured a mutex/condvar in a thread thunk closure — unsupported by design, since OS threads run on isolated heaps (deep-copying such a closure correctly raises "uncopyable type", see `srfi18.scm`'s existing "OS threads cannot capture sync primitives" test) — to use the same-heap fiber pattern (`spawn`/`fiber-join`) that `srfi18.scm` already demonstrates works.

Fixes #1454.

### Rebased onto KEP-0001 Phase 2 (#1453)

`main` landed a concurrent refactor that collapsed the four scheduler-dispatch loops (mutex-lock!, condvar-wait, thread-join!, channel/fiber-join) into one shared `runSchedulerStep`/`parkOnReactor` backed by a real epoll/kqueue reactor. That refactor didn't fix this bug — it just changed the symptom from "silently corrupts and reports success" to "raises a spurious deadlock error," since it still couldn't tell a real local deadlock apart from a wait a *different* OS thread could still resolve. This PR now teaches it that distinction via `crossThreadWaitPossible`.

Rebasing surfaced one more real bug: a user-specified timeout made `parkOnReactor`'s blocking reactor wait swallow the *entire* timeout duration before ever re-checking for a cross-thread signal (confirmed by a real, reproducible test failure, not just reasoning). Fixed with a narrowly-scoped `pollCapNs()` duck-typed method that only the two SRFI-18 wait types opt into, capping the reactor's blocking wait to 1ms when a cross-thread resolution is plausible — every other caller (channel-receive, fiber-join, thread-join!, thread-sleep!) is unaffected and unchanged.

## Test plan

- [x] Tracked regression test `tests/scheme/srfi/srfi18-cross-thread-wait.scm`: real OS threads sharing a mutex/condvar via top-level globals, with timing assertions (6 checks, including a bounded-timeout + result assertion on the broadcast case so a missed signal fails loudly instead of hanging CI). Verified it fails reliably without the fix (checked against the true pre-fix baseline in a separate worktree, both before and after the KEP-0001 Phase 2 rebase) and passes reliably with it, across many repeated runs.
- [x] `tests/scheme/coverage/srfi18-coverage.scm` — all 54 checks pass reliably.
- [x] Full suite: `bash tests/scheme/run-all.sh` — 1833/1833 pass (438 Scheme files + 1395 R7RS tests, including the new KEP-0001 Phase 2 scheduler-stress tests), no regressions.
- [x] `zig build test` — all unit tests pass.
- [x] `zig fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)