### PR TITLE
Port layer: non-blocking reads/writes, write buffering, (read) EAGAIN path (KEP-0001 P3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,28 @@ The lockfile (`~/.kaappi/thottam.lock`) records source URLs for provenance.
 - `Makefile` — builds `.dylib` (if C code)
 - All FFI signatures must match entries in `src/ffi.zig` dispatch tables
 
+## Fiber I/O reactor (KEP-0001)
+
+Each OS thread's scheduler owns a `Reactor` (`src/reactor.zig`:
+kqueue/epoll/WASI-timer backends + a userspace timer heap), created lazily
+with the scheduler by `fiber.ensureScheduler`. Port reads/writes that would
+block (`EAGAIN`) suspend the calling fiber instead of the thread
+(`fiber.waitForFd`): a fiber dispatched directly by a scheduler loop parks
+(`.io_waiting` + the yield-retry re-execution protocol — callers stash
+partial progress into `port.read_buf` first via
+`primitives_io.propagateReadErr`); the main fiber or one under re-entrant
+native frames drives the scheduler in place instead. Port fds (never 0/1/2,
+never in WASI builds) flip to `O_NONBLOCK` lazily, only once a scheduler
+exists — sequential programs keep blocking fds and their exact syscall
+profile. Ports on fd > 2 buffer writes in `port.write_buf` until
+`flush-output-port`, `close-port`, a read on the same port, or the 8 KiB
+high-water mark; `close-port` flushes, wakes fibers parked on the fd
+(`fiber.wakeIoWaitersOnFd` — their retry sees `is_open == false` and raises
+cleanly), and unregisters the fd from the reactor. `readOneByte` /
+`portWriteBytes` in `src/primitives_io.zig` are the single byte
+source/sink for every textual *and* binary port primitive — hook new I/O
+through them, not around them.
+
 ## OS threads (SRFI-18)
 
 `thread-start!` spawns real OS threads via `std.Thread.spawn`. Each child

--- a/README.md
+++ b/README.md
@@ -363,6 +363,17 @@ Move blocking `channel-receive` calls into plain Scheme loops (named `let`,
 `do`) or the bytecode-driven procedures above when a fiber must wait inside
 iteration.
 
+Port I/O that would block (a socket or pipe read/write with no data or a
+full kernel buffer) parks the fiber on the per-thread reactor instead of
+blocking the OS thread, so fibers reading different connections interleave.
+The main fiber — or a fiber inside a native-driver callback — cannot be
+parked; it instead dispatches sibling fibers in place while it waits, so
+progress continues either way. Ports on fds other than 0/1/2 buffer output
+until `flush-output-port`, `close-port`, a read on the same port, the
+buffer filling (8 KiB), or program exit; stdin/stdout/stderr remain
+unbuffered. WASI builds keep blocking single-fiber I/O (the reactor's WASI
+backend is timer-only until KEP-0001 Phase 4).
+
 ### OS threads (SRFI-18)
 
 Each OS thread gets its own GC with an independent heap. Values are deep-copied

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -560,10 +560,14 @@ pub fn waitForFd(vm: *VM, fd: std.posix.fd_t, interest: reactor_mod.Interest) VM
     // checks that every registered waiter is .io_waiting.
     const prev_status = me.status;
     me.status = .io_waiting;
-    ctx.reactor.register(fd, interest, me) catch {
+    ctx.reactor.register(fd, interest, me) catch |err| {
         me.status = prev_status;
         me.io_fd = null;
-        return VMError.OutOfMemory;
+        if (err == error.OutOfMemory) return VMError.OutOfMemory;
+        // A kernel-level arm failure (EBADF on a raced-away fd, resource
+        // limits) is not an OOM; surface it diagnosably.
+        vm.setErrorDetail("cannot wait on fd {d}: reactor registration failed", .{fd});
+        return VMError.InvalidArgument;
     };
 
     if (my_idx != 0 and vm.dispatched_from_scheduler) {

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -272,6 +272,19 @@ pub const FiberScheduler = struct {
         self.vm.current_fiber = next;
     }
 
+    /// True iff any fiber is parked on fd readiness. Gates the per-tick
+    /// zero-timeout reactor poll in schedule() — an O(fiber count) scan,
+    /// but it early-exits at the first hit, and when it misses (no I/O
+    /// waiters) it saves a kevent/epoll_wait syscall per dispatch tick.
+    fn anyIoWaiting(self: *FiberScheduler) bool {
+        for (self.fibers.items) |f| {
+            if (f) |fiber| {
+                if (fiber.status == .io_waiting) return true;
+            }
+        }
+        return false;
+    }
+
     /// Round-robins over `created`/`suspended` fibers. Before selecting,
     /// pops any already-expired timers off the reactor's heap and flips
     /// their fibers to `.suspended` — checked on *every* call, not just
@@ -281,11 +294,21 @@ pub const FiberScheduler = struct {
     /// the old per-fiber sweep folds into the shared timer heap, but the
     /// heap must still be checked every tick — a heap peek/pop is cheaper
     /// than the old O(fiber count) sweep it replaces, not less prompt).
+    ///
+    /// When fibers are parked on fd readiness (KEP-0001 Phase 3), the same
+    /// promptness argument applies to I/O: a zero-timeout reactor poll per
+    /// tick wakes ready I/O waiters even while a busy/yielding sibling
+    /// keeps the loop from ever reaching parkOnReactor's blocking poll.
     pub fn schedule(self: *FiberScheduler) ?usize {
         if (self.vm.reactor) |reactor| {
             var expired: std.ArrayList(*Fiber) = .empty;
             defer expired.deinit(self.vm.gc.allocator);
-            reactor.popExpiredTimers(&expired) catch {};
+            if (self.anyIoWaiting()) {
+                // poll(0) also pops expired timers internally.
+                reactor.poll(0, &expired) catch {};
+            } else {
+                reactor.popExpiredTimers(&expired) catch {};
+            }
             for (expired.items) |f| wakeReadyFiber(f);
         }
 
@@ -472,13 +495,98 @@ pub const TargetWait = struct {
 /// per-tick expired-timer check (non-blocking).
 fn wakeReadyFiber(f: *Fiber) void {
     switch (f.status) {
-        .io_waiting => f.status = .suspended,
+        .io_waiting => {
+            f.status = .suspended;
+            f.io_fd = null;
+        },
         .waiting => {
             f.status = .suspended;
             f.timed_out = true;
         },
         else => {},
     }
+}
+
+/// Wakes every fiber parked on fd readiness for `fd` — close-port's half of
+/// the close discipline (KEP-0001 Phase 3, resolved question 4). The woken
+/// fibers retry their I/O primitive, observe `is_open == false`, and raise a
+/// clean "port closed" error instead of sleeping on an fd that will never
+/// fire (the caller unregisters it from the reactor right after this).
+/// Mirrors wakeChannelWaiters' iterate-and-flip discipline.
+pub fn wakeIoWaitersOnFd(sched: *FiberScheduler, fd: std.posix.fd_t) void {
+    for (sched.fibers.items) |f| {
+        if (f) |fiber| {
+            if (fiber.status == .io_waiting and fiber.io_fd == fd) {
+                fiber.status = .suspended;
+                fiber.io_fd = null;
+            }
+        }
+    }
+}
+
+/// Wait until the current fiber's own fd readiness resolves: done as soon
+/// as something (reactor poll, close-port wake) flips it out of io_waiting.
+const IoWait = struct {
+    me: *Fiber,
+    pub fn isDone(self: IoWait) bool {
+        return self.me.status != .io_waiting;
+    }
+};
+
+/// Blocks the current fiber until `fd` is ready for `interest` (KEP-0001
+/// Phase 3). Two modes, chosen by whether the fiber can be safely parked:
+///
+/// - **Park** (a spawned fiber dispatched directly by a scheduler loop):
+///   registers with the reactor, flips to `.io_waiting`, arms the
+///   yield-retry ip rewind, and returns `error.Yielded` — the same
+///   park-and-retry protocol as blockOrDeadlock. The whole primitive
+///   re-executes when the fd fires, so callers with partial progress must
+///   stash it (e.g. into `port.read_buf`) before propagating the error.
+///
+/// - **Drive** (the main fiber, or any fiber under re-entrant native frames
+///   that cannot be rewound): registers likewise, then drives the scheduler
+///   in place — exactly the thread-sleep! pattern — until the reactor
+///   reports the fd ready or a close-port wake intervenes, then returns so
+///   the caller retries its syscall. Blocking main on I/O this way keeps
+///   sibling fibers running while preserving blocking-read semantics.
+pub fn waitForFd(vm: *VM, fd: std.posix.fd_t, interest: reactor_mod.Interest) VMError!void {
+    const ctx = try ensureScheduler(vm);
+    const me = vm.current_fiber orelse return VMError.InvalidArgument;
+    const my_idx = ctx.sched.current_idx;
+
+    me.io_fd = fd;
+    me.io_interest = interest;
+    // Status must flip before register(): the reactor's debug assertion
+    // checks that every registered waiter is .io_waiting.
+    const prev_status = me.status;
+    me.status = .io_waiting;
+    ctx.reactor.register(fd, interest, me) catch {
+        me.status = prev_status;
+        me.io_fd = null;
+        return VMError.OutOfMemory;
+    };
+
+    if (my_idx != 0 and vm.dispatched_from_scheduler) {
+        vm.yield_retry = true;
+        return VMError.Yielded;
+    }
+
+    // An fd wait has no deadline; a stale timed_out left by an earlier
+    // timed wait would make runSchedulerStep return before the fd is
+    // ready, degrading this wait into an EAGAIN retry spin.
+    me.timed_out = false;
+
+    // The normal wake paths (reactor poll, close-port) both remove `me`
+    // from the waiter lists before flipping its status; this cleanup only
+    // has work to do when an error below unwinds the wait mid-flight —
+    // without it, the fiber would linger in the lists in a non-io_waiting
+    // status and trip register()'s staleness assertion later.
+    defer {
+        ctx.reactor.removeWaiter(fd, me);
+        me.io_fd = null;
+        me.status = .running;
+    }
+    _ = try runSchedulerStep(IoWait, .{ .me = me }, vm, ctx.sched, me);
 }
 
 /// Called when sched.schedule() finds nothing immediately runnable. Blocks

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -790,6 +790,7 @@ fn objectSize(obj: *Object) usize {
             if (port.string_data) |sd| s += sd.len;
             if (port.string_out_buf) |_| s += port.string_out_cap;
             if (port.read_buf) |rb| s += rb.len;
+            if (port.write_buf) |wb| s += wb.len;
             break :blk s;
         },
         .continuation => @sizeOf(Continuation) + obj.as(Continuation).backing.len * @sizeOf(Value),
@@ -929,7 +930,24 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             const port = obj.as(Port);
             // Close the fd if still open and not stdin/stdout/stderr
             if (port.is_open and port.fd > 2 and !port.is_string_port) {
+                // Best-effort flush of buffered output before the fd is lost.
+                // No parking is possible during a sweep, so a would-block
+                // (EAGAIN) or any other failure just drops the remainder —
+                // programs that need the data call flush-output-port or
+                // close-port instead of leaking the port to the collector.
+                if (port.write_buf) |wb| {
+                    var start = port.write_buf_start;
+                    while (start < port.write_buf_len) {
+                        const rc = std.posix.system.write(port.fd, wb.ptr + start, port.write_buf_len - start);
+                        if (rc < 0 and std.posix.errno(rc) == .INTR) continue;
+                        if (rc <= 0) break;
+                        start += @as(usize, @intCast(rc));
+                    }
+                }
                 _ = std.posix.system.close(port.fd);
+            }
+            if (port.write_buf) |wb| {
+                gc.allocator.free(wb);
             }
             if (port.owns_name) {
                 gc.allocator.free(port.name);

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -229,33 +229,16 @@ fn getOutputPort(args: []const Value, arg_idx: usize, proc_name: []const u8) Pri
     return types.toObject(port_val).as(types.Port);
 }
 
-fn portReadOneByte(port: *types.Port) ?u8 {
-    if (port.peek_byte) |b| {
-        port.peek_byte = null;
-        return b;
-    }
-    if (port.is_string_port) {
-        const data = port.string_data orelse return null;
-        if (port.string_pos >= data.len) return null;
-        const b = data[port.string_pos];
-        port.string_pos += 1;
-        return b;
-    }
-    var buf: [1]u8 = undefined;
-    while (true) {
-        const raw = std.posix.system.read(port.fd, &buf, buf.len);
-        if (raw < 0) {
-            if (std.posix.errno(raw) == .INTR) continue;
-            return null;
-        }
-        if (raw == 0) return null;
-        return buf[0];
-    }
-}
+// Byte source/sink shared with the textual primitives (primitives_io) so
+// binary reads drain the same software buffers — peek_extra, read_buf, a
+// parked read's stashed partial progress — and binary writes share the
+// same write buffer and reactor suspension points (KEP-0001 Phase 3).
+const portReadOneByte = primitives_io.readOneByte;
+const portWriteBytes = primitives_io.portWriteBytes;
 
 fn readU8Fn(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 0, "read-u8");
-    const byte = portReadOneByte(port) orelse return types.EOF;
+    const byte = try portReadOneByte(port) orelse return types.EOF;
     return types.makeFixnum(@intCast(byte));
 }
 
@@ -264,7 +247,7 @@ fn peekU8Fn(args: []const Value) PrimitiveError!Value {
     if (port.peek_byte) |b| {
         return types.makeFixnum(@intCast(b));
     }
-    const byte = portReadOneByte(port) orelse return types.EOF;
+    const byte = try portReadOneByte(port) orelse return types.EOF;
     port.peek_byte = byte;
     return types.makeFixnum(@intCast(byte));
 }
@@ -275,33 +258,8 @@ fn writeU8Fn(args: []const Value) PrimitiveError!Value {
     if (n < 0 or n > 255) return primitives.typeError("write-u8", "exact integer 0-255", args[0]);
     const port = try getOutputPort(args, 1, "write-u8");
     const byte: u8 = @intCast(@as(u64, @bitCast(n)));
-    if (port.is_string_port) {
-        portWriteBytes(port, &[_]u8{byte});
-    } else {
-        primitives_io.writeToFd(port.fd, &[_]u8{byte});
-    }
+    try portWriteBytes(port, &[_]u8{byte});
     return types.VOID;
-}
-
-fn portWriteBytes(port: *types.Port, bytes: []const u8) void {
-    if (!port.is_string_port) {
-        primitives_io.writeToFd(port.fd, bytes);
-        return;
-    }
-    // String output port: grow buffer as needed
-    const gc = memory.gc_instance orelse return;
-    var buf = port.string_out_buf orelse return;
-    const len = port.string_out_len;
-    const cap = port.string_out_cap;
-    if (len + bytes.len > cap) {
-        const new_cap = @max(cap * 2, len + bytes.len);
-        const new_buf = gc.allocator.realloc(buf, new_cap) catch return;
-        port.string_out_buf = new_buf;
-        buf = new_buf;
-        port.string_out_cap = new_cap;
-    }
-    @memcpy(buf[len .. len + bytes.len], bytes);
-    port.string_out_len = len + bytes.len;
 }
 
 fn u8ReadyP(args: []const Value) PrimitiveError!Value {
@@ -326,7 +284,8 @@ fn readBytevectorFn(args: []const Value) PrimitiveError!Value {
 
     var read_count: usize = 0;
     while (read_count < count) {
-        const byte = portReadOneByte(port) orelse break;
+        const byte = (portReadOneByte(port) catch |err|
+            return primitives_io.propagateReadErr(port, err, &.{buf[0..read_count]})) orelse break;
         buf[read_count] = byte;
         read_count += 1;
     }
@@ -344,11 +303,7 @@ fn writeBytevectorFn(args: []const Value) PrimitiveError!Value {
     const start = range.start;
     const end = range.end;
 
-    if (port.is_string_port) {
-        portWriteBytes(port, bv.data[start..end]);
-    } else {
-        primitives_io.writeToFd(port.fd, bv.data[start..end]);
-    }
+    try portWriteBytes(port, bv.data[start..end]);
     return types.VOID;
 }
 
@@ -398,7 +353,10 @@ fn readBytevectorMut(args: []const Value) PrimitiveError!Value {
 
     var read_count: usize = 0;
     while (start + read_count < end) {
-        const byte = portReadOneByte(port) orelse break;
+        // Bytes already delivered into the caller's bytevector are re-read
+        // and re-written identically by the parked retry.
+        const byte = (portReadOneByte(port) catch |err|
+            return primitives_io.propagateReadErr(port, err, &.{bv.data[start .. start + read_count]})) orelse break;
         bv.data[start + read_count] = byte;
         read_count += 1;
     }

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -705,7 +705,7 @@ fn peekCharFn(args: []const Value) PrimitiveError!Value {
                 // continuation bytes consumed; the re-executed peek-char
                 // finds peek_byte empty and re-reads them from read_buf.
                 utf8_buf[i] = (readOneByte(port) catch |err|
-                    return propagateReadErr(port, err, &.{ utf8_buf[0..1], utf8_buf[1..i] })) orelse break;
+                    return propagateReadErr(port, err, &.{utf8_buf[0..i]})) orelse break;
             }
             port.peek_byte = b;
             if (i >= seq_len) {
@@ -913,7 +913,12 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
 
     // Read from fd, parsing incrementally so that interactive terminals
     // return as soon as a complete datum is available (#847).
-    if (port.write_buf_len > port.write_buf_start) try drainWriteBuffer(port);
+    if (port.write_buf_len > port.write_buf_start) {
+        // A park in this drain must preserve the bytes already moved out
+        // of peek_byte/peek_extra/read_buf into `buf` above — a bare try
+        // would unwind without stashing and the retry would lose them.
+        drainWriteBuffer(port) catch |err| return propagateReadErr(port, err, &.{buf.items});
+    }
     maybeSetNonblocking(port);
     var tmp: [4096]u8 = undefined;
     while (true) {

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -7,6 +7,8 @@ const memory = @import("memory.zig");
 const printer = @import("printer.zig");
 const reader_mod = @import("reader.zig");
 const primitives_control = @import("primitives_control.zig");
+const fiber_mod = @import("fiber.zig");
+const reactor_mod = @import("reactor.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -112,12 +114,233 @@ fn currentErrorPortValue(vm: *vm_mod.VM) Value {
     return vm.stderr_port;
 }
 
-fn writeToPort(port: *types.Port, bytes: []const u8) void {
+// ---------------------------------------------------------------------------
+// Non-blocking port I/O (KEP-0001 Phase 3)
+//
+// Reads and buffered-write drains that would block suspend the calling
+// fiber on the reactor (fiber.waitForFd) instead of blocking the OS thread.
+// A fiber dispatched directly by a scheduler loop parks — its primitive
+// re-executes on readiness, so every read site with partial progress
+// stashes it into port.read_buf first (propagateReadErr). The main fiber
+// (or one under re-entrant native frames) drives the scheduler in place and
+// resumes here. Sequential programs never create a scheduler, so their
+// ports stay blocking and their syscall profile is unchanged.
+// ---------------------------------------------------------------------------
+
+/// Pending-output span above which a buffered port drains to the fd before
+/// accepting more bytes (suspending the writer as needed). Bounds per-port
+/// buffer memory at roughly this plus the largest single write.
+const write_high_water: usize = 8192;
+
+/// Ports whose writes accumulate in `write_buf`: real-fd ports other than
+/// stdin/stdout/stderr. fd 0/1/2 keep the historical unbuffered
+/// direct-write behavior (REPL echo and diagnostic ordering depend on it);
+/// string ports have their own growable buffer.
+fn isBufferedFdPort(port: *types.Port) bool {
+    return !port.is_string_port and port.fd > 2;
+}
+
+/// Lazily flips the port's fd to O_NONBLOCK the first time it is used while
+/// a fiber scheduler exists — the precondition for any reactor wait to
+/// engage. Never touches fd 0/1/2: those share their open file description
+/// with the shell/terminal (and linenoise reads fd 0 directly in REPL
+/// mode), so flipping them would leak non-blocking mode outside this
+/// process. Without a scheduler nothing is flipped and sequential programs
+/// keep blocking fds. Pub only for tests_port_io's guard checks.
+pub fn maybeSetNonblocking(port: *types.Port) void {
+    if (comptime is_wasm) return; // WASI fd readiness is KEP-0001 Phase 4
+    if (port.nonblocking or port.is_string_port or port.fd <= 2) return;
+    const vm = vm_mod.vm_instance orelse return;
+    if (vm.scheduler == null) return;
+    const flags = std.c.fcntl(port.fd, std.posix.F.GETFL, @as(c_int, 0));
+    if (flags < 0) return;
+    const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
+    if (std.c.fcntl(port.fd, std.posix.F.SETFL, flags | nonblock) < 0) return;
+    port.nonblocking = true;
+}
+
+/// Suspends the current fiber until the port's fd is ready for `interest`,
+/// then confirms the port survived the wait. A parked fiber propagates
+/// error.Yielded from inside waitForFd (the re-executed primitive re-checks
+/// the port via getInputPort/getOutputPort); a scheduler-driving waiter
+/// resumes here, so the is_open re-check — a sibling may have closed the
+/// port while we waited — must raise the clean "port closed" error itself.
+fn waitPortFd(port: *types.Port, interest: reactor_mod.Interest) PrimitiveError!void {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidArgument;
+    try fiber_mod.waitForFd(vm, port.fd, interest);
+    if (!port.is_open) return raisePortClosedDuringIo();
+}
+
+fn raisePortClosedDuringIo() PrimitiveError {
+    const gc = memory.gc_instance orelse return PrimitiveError.InvalidArgument;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidArgument;
+    var msg = gc.allocString("port closed while I/O was blocked on it") catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg);
+    defer gc.popRoot();
+    const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.OutOfMemory;
+    types.toObject(err_obj).as(types.ErrorObject).error_type = .file;
+    vm.current_exception = err_obj;
+    return PrimitiveError.ExceptionRaised;
+}
+
+/// Preserves a read primitive's partial progress across a park-and-retry.
+/// The bytes go to the *front* of port.read_buf — the first software buffer
+/// the retry drains — ahead of any bytes an inner reader (a mid-sequence
+/// UTF-8 read) already stashed while unwinding, since each outer frame's
+/// bytes are chronologically earlier. `parts` concatenate in order.
+fn stashPartialRead(port: *types.Port, parts: []const []const u8) PrimitiveError!void {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    var total: usize = 0;
+    for (parts) |p| total += p.len;
+    if (total == 0) return;
+    // The peek buffers drain before the fd is ever touched, so no partial
+    // read can be unwinding while they still hold bytes.
+    std.debug.assert(port.peek_byte == null and port.peek_extra_len == 0);
+    const old = port.read_buf;
+    const old_len = port.read_buf_len;
+    const saved = gc.allocator.alloc(u8, total + old_len) catch return PrimitiveError.OutOfMemory;
+    var off: usize = 0;
+    for (parts) |p| {
+        @memcpy(saved[off..][0..p.len], p);
+        off += p.len;
+    }
+    if (old) |rb| {
+        // Live span is the *last* read_buf_len bytes (consumption advances
+        // from the front by shrinking the count).
+        @memcpy(saved[off..][0..old_len], rb[rb.len - old_len ..]);
+        gc.allocator.free(rb);
+    }
+    port.read_buf = saved;
+    port.read_buf_len = saved.len;
+}
+
+/// Propagates a read-path error; for a park (error.Yielded) first preserves
+/// the caller's partial progress so the re-executed primitive resumes
+/// losslessly. If preserving fails, the park is aborted — the fiber comes
+/// back off the reactor so its waiter lists never hold a non-parked fiber —
+/// and OutOfMemory propagates instead.
+pub fn propagateReadErr(port: *types.Port, err: PrimitiveError, parts: []const []const u8) PrimitiveError {
+    if (err != PrimitiveError.Yielded) return err;
+    stashPartialRead(port, parts) catch {
+        unparkCurrentFiber(port);
+        return PrimitiveError.OutOfMemory;
+    };
+    return PrimitiveError.Yielded;
+}
+
+fn unparkCurrentFiber(port: *types.Port) void {
+    const vm = vm_mod.vm_instance orelse return;
+    const me = vm.current_fiber orelse return;
+    if (vm.reactor) |r| r.removeWaiter(port.fd, me);
+    me.status = .running;
+    me.io_fd = null;
+    vm.yield_retry = false;
+}
+
+/// Drains the port's pending write buffer to the fd until empty. On EAGAIN
+/// the writer suspends on write readiness; `write_buf_start` records drain
+/// progress, so the wait can be a parked primitive's full re-execution and
+/// still resume with exactly the remaining slice.
+fn drainWriteBuffer(port: *types.Port) PrimitiveError!void {
+    while (port.write_buf_start < port.write_buf_len) {
+        // Re-fetch each pass: a scheduler drive inside waitPortFd can run a
+        // sibling fiber that appends to this same port and reallocs the
+        // buffer (or a concurrent close-port drains it for us).
+        const buf = port.write_buf orelse break;
+        maybeSetNonblocking(port);
+        const rc = std.posix.system.write(port.fd, buf.ptr + port.write_buf_start, port.write_buf_len - port.write_buf_start);
+        if (rc < 0) {
+            const e = std.posix.errno(rc);
+            if (e == .INTR) continue;
+            if (e == .AGAIN) {
+                if (comptime is_wasm) break;
+                try waitPortFd(port, .write);
+                continue;
+            }
+            // Parity with the historical writeToFd loop: other write errors
+            // (EPIPE, EIO) are swallowed. Drop the unwritable remainder so
+            // the buffer cannot grow without bound against a dead fd.
+            break;
+        }
+        if (rc == 0) break;
+        port.write_buf_start += @as(usize, @intCast(rc));
+    }
+    port.write_buf_start = 0;
+    port.write_buf_len = 0;
+}
+
+fn appendWriteBuf(port: *types.Port, bytes: []const u8) PrimitiveError!void {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    var buf = port.write_buf orelse blk: {
+        const b = gc.allocator.alloc(u8, @max(bytes.len, 1024)) catch return PrimitiveError.OutOfMemory;
+        port.write_buf = b;
+        break :blk b;
+    };
+    if (port.write_buf_len + bytes.len > buf.len) {
+        // Compact the live span to the front, then grow if still needed.
+        const pending = port.write_buf_len - port.write_buf_start;
+        if (port.write_buf_start > 0) {
+            std.mem.copyForwards(u8, buf[0..pending], buf[port.write_buf_start..port.write_buf_len]);
+            port.write_buf_start = 0;
+            port.write_buf_len = pending;
+        }
+        if (port.write_buf_len + bytes.len > buf.len) {
+            const new_cap = @max(buf.len * 2, port.write_buf_len + bytes.len);
+            const nb = gc.allocator.realloc(buf, new_cap) catch return PrimitiveError.OutOfMemory;
+            port.write_buf = nb;
+            buf = nb;
+        }
+    }
+    @memcpy(buf[port.write_buf_len..][0..bytes.len], bytes);
+    port.write_buf_len += bytes.len;
+}
+
+/// Best-effort blocking drain of every open buffered port's pending
+/// output. Called by `exit` (R7RS runs cleanup; emergency-exit does not) —
+/// std.process.exit skips GC teardown, which is where leaked ports
+/// otherwise flush (gc_collect.freeObject). No parking: a would-block
+/// remainder is dropped, exactly like freeObject's flush.
+pub fn flushAllOpenPorts(gc: *memory.GC) void {
+    const lists = [_]?*types.Object{ gc.objects, gc.old_objects };
+    for (lists) |head| {
+        var obj = head;
+        while (obj) |o| : (obj = o.next) {
+            if (o.tag != .port) continue;
+            const port = o.as(types.Port);
+            if (!port.is_open or port.is_string_port or port.fd <= 2) continue;
+            const wb = port.write_buf orelse continue;
+            while (port.write_buf_start < port.write_buf_len) {
+                const rc = std.posix.system.write(port.fd, wb.ptr + port.write_buf_start, port.write_buf_len - port.write_buf_start);
+                if (rc < 0 and std.posix.errno(rc) == .INTR) continue;
+                if (rc <= 0) break;
+                port.write_buf_start += @as(usize, @intCast(rc));
+            }
+        }
+    }
+}
+
+/// Port-layer byte sink for every write primitive (display, write,
+/// write-char, write-string, write-u8, write-bytevector). String ports
+/// append to their growable buffer; fd 0/1/2 write straight through;
+/// buffered fd ports accumulate in `write_buf`, draining when the pending
+/// span crosses `write_high_water`, at flush-output-port, at close-port,
+/// and before a read on the same port. The drain — never the append — is
+/// the only point that can suspend the calling fiber, and it runs *before*
+/// the new bytes are appended, so a parked primitive's re-execution cannot
+/// duplicate output.
+pub fn portWriteBytes(port: *types.Port, bytes: []const u8) PrimitiveError!void {
     if (port.is_string_port) {
         stringPortWrite(port, bytes);
         return;
     }
-    writeToFd(port.fd, bytes);
+    if (!isBufferedFdPort(port)) {
+        writeToFd(port.fd, bytes);
+        return;
+    }
+    if ((port.write_buf_len - port.write_buf_start) + bytes.len > write_high_water) {
+        try drainWriteBuffer(port);
+    }
+    try appendWriteBuf(port, bytes);
 }
 
 fn stringPortWrite(port: *types.Port, bytes: []const u8) void {
@@ -145,7 +368,7 @@ fn display(args: []const Value) PrimitiveError!Value {
     const port = try getOutputPort(args, 1, "display");
     const s = printer.valueToString(gc.allocator, args[0], .display) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(s);
-    writeToPort(port, s);
+    try portWriteBytes(port, s);
     return types.VOID;
 }
 
@@ -154,7 +377,7 @@ fn write(args: []const Value) PrimitiveError!Value {
     const port = try getOutputPort(args, 1, "write");
     const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(s);
-    writeToPort(port, s);
+    try portWriteBytes(port, s);
     return types.VOID;
 }
 
@@ -163,13 +386,13 @@ fn writeShared(args: []const Value) PrimitiveError!Value {
     const port = try getOutputPort(args, 1, "write-shared");
     const s = printer.valueToString(gc.allocator, args[0], .shared) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(s);
-    writeToPort(port, s);
+    try portWriteBytes(port, s);
     return types.VOID;
 }
 
 fn newline(args: []const Value) PrimitiveError!Value {
     const port = try getOutputPort(args, 0, "newline");
-    writeToPort(port, "\n");
+    try portWriteBytes(port, "\n");
     return types.VOID;
 }
 
@@ -308,6 +531,12 @@ fn openBinaryOutputFile(args: []const Value) PrimitiveError!Value {
 fn closePort(args: []const Value) PrimitiveError!Value {
     if (!types.isPort(args[0])) return primitives.typeError("close-port", "port", args[0]);
     const port = types.toObject(args[0]).as(types.Port);
+    // Flush buffered output while the fd is still writable. This can
+    // suspend the calling fiber; a parked close-port re-executes from the
+    // top with the drain progress preserved in the port.
+    if (port.is_open and !port.is_string_port and port.write_buf_len > port.write_buf_start) {
+        try drainWriteBuffer(port);
+    }
     if (port.read_buf) |rb| {
         if (memory.gc_instance) |gc| {
             gc.allocator.free(rb);
@@ -315,14 +544,40 @@ fn closePort(args: []const Value) PrimitiveError!Value {
         port.read_buf = null;
         port.read_buf_len = 0;
     }
-    if (port.is_open and port.fd > 2 and !port.is_string_port) {
-        _ = std.posix.system.close(port.fd);
+    if (port.write_buf) |wb| {
+        if (memory.gc_instance) |gc| {
+            gc.allocator.free(wb);
+        }
+        port.write_buf = null;
+        port.write_buf_start = 0;
+        port.write_buf_len = 0;
+    }
+    if (port.is_open and !port.is_string_port) {
+        // Close discipline (KEP-0001 Phase 3, resolved question 4): wake
+        // every fiber parked on this fd — the retry observes
+        // is_open == false and raises a clean error — and drop the reactor
+        // registration before the fd number can be closed and recycled.
+        if (vm_mod.vm_instance) |vm| {
+            if (vm.scheduler) |sched| fiber_mod.wakeIoWaitersOnFd(sched, port.fd);
+            if (vm.reactor) |r| r.unregister(port.fd);
+        }
+        if (port.fd > 2) _ = std.posix.system.close(port.fd);
     }
     port.is_open = false;
     return types.VOID;
 }
 
-fn readOneByte(port: *types.Port) ?u8 {
+/// Single byte source for every textual and binary port read primitive
+/// (read-char, peek-char, read-line, read-string, read-u8, peek-u8,
+/// read-bytevector, ...). Drains the software buffers — peek_byte,
+/// peek_extra, read_buf, string data — before touching the fd, so buffered
+/// data costs zero syscalls. The fd path flushes this port's own pending
+/// writes first (a socket port's request must reach the peer before we
+/// wait on its response); on EAGAIN the calling fiber suspends on read
+/// readiness. Errors only with Yielded (parked; caller stashes partial
+/// progress via propagateReadErr), OutOfMemory, or ExceptionRaised (port
+/// closed mid-wait); `null` still means EOF.
+pub fn readOneByte(port: *types.Port) PrimitiveError!?u8 {
     // Check peek buffer first
     if (port.peek_byte) |b| {
         port.peek_byte = null;
@@ -336,7 +591,8 @@ fn readOneByte(port: *types.Port) ?u8 {
         port.peek_extra_len -= 1;
         return b;
     }
-    // Check read buffer (from prior (read) that buffered excess)
+    // Check read buffer (from prior (read) that buffered excess, or a
+    // parked read primitive's stashed partial progress)
     if (port.read_buf) |rb| {
         if (port.read_buf_len > 0) {
             const pos = rb.len - port.read_buf_len;
@@ -359,11 +615,19 @@ fn readOneByte(port: *types.Port) ?u8 {
         port.string_pos += 1;
         return byte;
     }
+    if (port.write_buf_len > port.write_buf_start) try drainWriteBuffer(port);
+    maybeSetNonblocking(port);
     var buf: [1]u8 = undefined;
     while (true) {
         const raw = std.posix.system.read(port.fd, &buf, buf.len);
         if (raw < 0) {
-            if (std.posix.errno(raw) == .INTR) continue;
+            const e = std.posix.errno(raw);
+            if (e == .INTR) continue;
+            if (e == .AGAIN) {
+                if (comptime is_wasm) return null;
+                try waitPortFd(port, .read);
+                continue;
+            }
             return null;
         }
         if (raw == 0) return null;
@@ -377,27 +641,30 @@ const Utf8ReadResult = struct {
     len: u3,
 };
 
-fn readUtf8CharWithBytes(port: *types.Port) ?Utf8ReadResult {
-    const lead = readOneByte(port) orelse return null;
+fn readUtf8CharWithBytes(port: *types.Port) PrimitiveError!?Utf8ReadResult {
+    const lead = try readOneByte(port) orelse return null;
     const seq_len = std.unicode.utf8ByteSequenceLength(lead) catch return .{ .codepoint = @intCast(lead), .bytes = .{ lead, 0, 0, 0 }, .len = 1 };
     if (seq_len == 1) return .{ .codepoint = @intCast(lead), .bytes = .{ lead, 0, 0, 0 }, .len = 1 };
     var buf: [4]u8 = .{ 0, 0, 0, 0 };
     buf[0] = lead;
     for (1..seq_len) |i| {
-        buf[i] = readOneByte(port) orelse return .{ .codepoint = @intCast(lead), .bytes = buf, .len = @intCast(i) };
+        // A park mid-sequence stashes the bytes already consumed so the
+        // re-executed primitive re-reads the identical prefix.
+        buf[i] = (readOneByte(port) catch |err| return propagateReadErr(port, err, &.{buf[0..i]})) orelse
+            return .{ .codepoint = @intCast(lead), .bytes = buf, .len = @intCast(i) };
     }
     const cp = std.unicode.utf8Decode(buf[0..seq_len]) catch return .{ .codepoint = @intCast(lead), .bytes = buf, .len = @intCast(seq_len) };
     return .{ .codepoint = cp, .bytes = buf, .len = @intCast(seq_len) };
 }
 
-fn readUtf8Char(port: *types.Port) ?u21 {
-    const result = readUtf8CharWithBytes(port) orelse return null;
+fn readUtf8Char(port: *types.Port) PrimitiveError!?u21 {
+    const result = try readUtf8CharWithBytes(port) orelse return null;
     return result.codepoint;
 }
 
 fn readCharFn(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 0, "read-char");
-    const cp = readUtf8Char(port) orelse return types.EOF;
+    const cp = try readUtf8Char(port) orelse return types.EOF;
     return types.makeChar(cp);
 }
 
@@ -434,7 +701,11 @@ fn peekCharFn(args: []const Value) PrimitiveError!Value {
             port.peek_byte = null;
             var i: usize = 1;
             while (i < seq_len) : (i += 1) {
-                utf8_buf[i] = readOneByte(port) orelse break;
+                // A park here stashes the cleared peek byte plus any
+                // continuation bytes consumed; the re-executed peek-char
+                // finds peek_byte empty and re-reads them from read_buf.
+                utf8_buf[i] = (readOneByte(port) catch |err|
+                    return propagateReadErr(port, err, &.{ utf8_buf[0..1], utf8_buf[1..i] })) orelse break;
             }
             port.peek_byte = b;
             if (i >= seq_len) {
@@ -448,7 +719,7 @@ fn peekCharFn(args: []const Value) PrimitiveError!Value {
         return types.makeChar(@intCast(b));
     }
     const port2 = port;
-    const result = readUtf8CharWithBytes(port2) orelse return types.EOF;
+    const result = try readUtf8CharWithBytes(port2) orelse return types.EOF;
     const len: usize = @intCast(result.len);
     if (port2.is_string_port and port2.string_pos >= len) {
         port2.string_pos -= len;
@@ -470,15 +741,20 @@ fn readLineFn(args: []const Value) PrimitiveError!Value {
     defer line_buf.deinit(gc.allocator);
 
     while (true) {
-        const byte = readOneByte(port) orelse {
-            // EOF
-            if (line_buf.items.len == 0) return types.EOF;
-            break;
-        };
+        const byte = (readOneByte(port) catch |err|
+            return propagateReadErr(port, err, &.{line_buf.items})) orelse
+            {
+                // EOF
+                if (line_buf.items.len == 0) return types.EOF;
+                break;
+            };
         if (byte == '\n') break;
         if (byte == '\r') {
-            // Check for \r\n
-            const next = readOneByte(port);
+            // Check for \r\n. A park here must re-stash the '\r' too — it
+            // was consumed but not appended, and the re-executed read-line
+            // needs to see it again to reach this same decision point.
+            const next = readOneByte(port) catch |err|
+                return propagateReadErr(port, err, &.{ line_buf.items, "\r" });
             if (next) |nb| {
                 if (nb != '\n') {
                     port.peek_byte = nb; // put it back
@@ -505,7 +781,7 @@ fn writeCharFn(args: []const Value) PrimitiveError!Value {
     const cp = types.toChar(args[0]);
     var buf: [4]u8 = undefined;
     const len = std.unicode.utf8Encode(cp, &buf) catch return primitives.typeError("write-char", "valid unicode character", args[0]);
-    writeToPort(port, buf[0..len]);
+    try portWriteBytes(port, buf[0..len]);
     return types.VOID;
 }
 
@@ -533,7 +809,7 @@ fn writeStringFn(args: []const Value) PrimitiveError!Value {
     if (start_cp > end_cp or end_cp > cp_count) return primitives.typeError("write-string", "valid range", args[0]);
     const byte_start = string_mod.utf8IndexToByteOffset(data, start_cp) orelse return primitives.typeError("write-string", "valid start index", args[0]);
     const byte_end = string_mod.utf8IndexToByteOffset(data, end_cp) orelse return primitives.typeError("write-string", "valid end index", args[0]);
-    writeToPort(port, data[byte_start..byte_end]);
+    try portWriteBytes(port, data[byte_start..byte_end]);
     return types.VOID;
 }
 
@@ -637,6 +913,8 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
 
     // Read from fd, parsing incrementally so that interactive terminals
     // return as soon as a complete datum is available (#847).
+    if (port.write_buf_len > port.write_buf_start) try drainWriteBuffer(port);
+    maybeSetNonblocking(port);
     var tmp: [4096]u8 = undefined;
     while (true) {
         // Try to parse a datum from what we already have.
@@ -668,7 +946,19 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
 
         const raw_n = std.posix.system.read(port.fd, &tmp, tmp.len);
         if (raw_n < 0) {
-            if (std.posix.errno(raw_n) == .INTR) continue;
+            const e = std.posix.errno(raw_n);
+            if (e == .INTR) continue;
+            if (e == .AGAIN) {
+                if (comptime is_wasm) break;
+                // Mid-datum would-block: a parked retry re-executes this
+                // primitive from the top, so the partial accumulation goes
+                // back into port.read_buf and is re-drained on entry. The
+                // scheduler-driving path resumes right here with `buf`
+                // intact and just reads again.
+                waitPortFd(port, .read) catch |err|
+                    return propagateReadErr(port, err, &.{buf.items});
+                continue;
+            }
             break;
         }
         if (raw_n == 0) break; // EOF
@@ -779,7 +1069,11 @@ fn readStringFn(args: []const Value) PrimitiveError!Value {
 
     var chars_read: usize = 0;
     while (chars_read < count) {
-        const cp = readUtf8Char(port) orelse break;
+        // On a park, readUtf8Char has already stashed its own mid-sequence
+        // bytes; prepending the accumulated characters keeps the retry's
+        // byte stream chronological.
+        const cp = (readUtf8Char(port) catch |err|
+            return propagateReadErr(port, err, &.{result.items})) orelse break;
         var buf: [4]u8 = undefined;
         const len = std.unicode.utf8Encode(cp, &buf) catch break;
         result.appendSlice(gc.allocator, buf[0..len]) catch return PrimitiveError.OutOfMemory;
@@ -790,10 +1084,11 @@ fn readStringFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn flushOutputPort(args: []const Value) PrimitiveError!Value {
-    // For our implementation, flushing is a no-op since we write directly
-    if (args.len > 0) {
-        if (!types.isPort(args[0])) return primitives.typeError("flush-output-port", "port", args[0]);
-    }
+    const port = try getOutputPort(args, 0, "flush-output-port");
+    // String ports and the unbuffered standard fds have nothing pending;
+    // buffered fd ports drain fully (suspending the fiber as needed —
+    // idempotent across a parked retry since progress lives in the port).
+    if (isBufferedFdPort(port)) try drainWriteBuffer(port);
     return types.VOID;
 }
 

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -119,6 +119,14 @@ fn exitFn(args: []const Value) PrimitiveError!Value {
     // exit skips GC teardown (std.process.exit), which is where leaked
     // ports otherwise flush their buffered output; emergency-exit
     // deliberately skips this cleanup (R7RS 6.14).
+    //
+    // Known limitation: gc_instance is threadlocal, so this flushes only
+    // the calling thread's ports. Another SRFI-18 OS thread's buffered
+    // ports cannot be flushed from here safely — that thread may be
+    // mid-write on them concurrently, and walking its heap without
+    // stopping it would race. Matches the share-nothing thread model:
+    // each thread owns its ports; a thread that wants its output durable
+    // across another thread's exit must flush or close it itself.
     if (memory.gc_instance) |gc| @import("primitives_io.zig").flushAllOpenPorts(gc);
     std.process.exit(code);
 }

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -116,6 +116,10 @@ fn exitFn(args: []const Value) PrimitiveError!Value {
             _ = vm.callWithArgs(vm.wind_stack[i].after, &[_]Value{}) catch {};
         }
     }
+    // exit skips GC teardown (std.process.exit), which is where leaked
+    // ports otherwise flush their buffered output; emergency-exit
+    // deliberately skips this cleanup (R7RS 6.14).
+    if (memory.gc_instance) |gc| @import("primitives_io.zig").flushAllOpenPorts(gc);
     std.process.exit(code);
 }
 

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -435,8 +435,15 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
         // A terminated fiber may have been mid-timed-wait (mutex-lock!,
         // thread-join!, condvar wait, thread-sleep!) with a pending entry
         // on the reactor's timer heap. Cancel it now — otherwise it fires
-        // later against whatever fiber ends up reusing this slot.
+        // later against whatever fiber ends up reusing this slot. Likewise
+        // an io_waiting fiber (a parked port read/write, KEP-0001 Phase 3)
+        // still sits in the reactor's fd waiter lists; pull it out so the
+        // dead fiber can't linger there as a stale registration.
         ctx.reactor.removeTimer(fiber);
+        if (fiber.io_fd) |io_fd| {
+            ctx.reactor.removeWaiter(io_fd, fiber);
+            fiber.io_fd = null;
+        }
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         ctx.sched.wakeWaiters(fiber);
     }

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -91,10 +91,21 @@ pub const Reactor = struct {
     /// Registers `fiber` as waiting for `interest` on `fd`. On success the
     /// fd is armed with the OS (ONESHOT — resolved question 3: the
     /// registration exists only while a fiber is parked, by construction).
+    /// The caller must have already flipped `fiber` to `.io_waiting`.
     pub fn register(self: *Reactor, fd: i32, interest: Interest, fiber: *Fiber) !void {
         const gop = try self.regs.getOrPut(fd);
         if (!gop.found_existing) gop.value_ptr.* = .{};
         const reg = gop.value_ptr;
+
+        // Every waiter already listed for this fd must still be parked: a
+        // completed/errored/suspended fiber here means a close-port ran
+        // without waking waiters and unregistering, and this fd number has
+        // been recycled onto an unrelated port (resolved KEP-0001
+        // question 4 — the assertion that keeps that invariant honest).
+        if (comptime builtin.mode == .Debug) {
+            for (reg.read_waiters.items) |f| std.debug.assert(f.status == .io_waiting);
+            for (reg.write_waiters.items) |f| std.debug.assert(f.status == .io_waiting);
+        }
 
         switch (interest) {
             .read => try reg.read_waiters.append(self.allocator, fiber),
@@ -123,6 +134,27 @@ pub const Reactor = struct {
             self.backend.disarmAll(fd);
             reg.read_waiters.deinit(self.allocator);
             reg.write_waiters.deinit(self.allocator);
+        }
+    }
+
+    /// Removes `fiber` from `fd`'s waiter lists without waking it or
+    /// disturbing other waiters. Cleanup for a wait that resolves outside
+    /// the poll/close paths (an error unwinding waitForFd's scheduler
+    /// drive) — those paths clear the lists themselves. A kernel ONESHOT
+    /// left armed with no listed waiter fires once into the stale-event
+    /// path of poll() and is dropped there. No-op if absent.
+    pub fn removeWaiter(self: *Reactor, fd: i32, fiber: *Fiber) void {
+        const reg = self.regs.getPtr(fd) orelse return;
+        var lists = [_]*std.ArrayList(*Fiber){ &reg.read_waiters, &reg.write_waiters };
+        for (&lists) |list| {
+            var i: usize = 0;
+            while (i < list.items.len) {
+                if (list.items[i] == fiber) {
+                    _ = list.swapRemove(i);
+                } else {
+                    i += 1;
+                }
+            }
         }
     }
 
@@ -393,13 +425,26 @@ const EpollBackend = struct {
     /// read/write knotes. `first_time` selects EPOLL_CTL_ADD (fresh fd) vs
     /// EPOLL_CTL_MOD (re-arm) since ADD on an already-tracked fd fails
     /// EEXIST, even while dormant after a ONESHOT fire.
+    ///
+    /// `first_time` is advisory, not authoritative: a port freed by the GC
+    /// closes its fd without unregistering, which silently removes the fd
+    /// from the epoll set while the Reactor's Reg (kernel_registered=true)
+    /// survives. When the fd number is recycled onto a new port, the
+    /// resulting MOD hits ENOENT — retry as ADD (and symmetrically ADD →
+    /// EEXIST retries as MOD). kqueue needs no equivalent: EV_ADD is
+    /// create-or-recreate either way.
     fn arm(self: *EpollBackend, fd: i32, wants_read: bool, wants_write: bool, first_time: bool) !void {
         var events: u32 = linux.EPOLL.ONESHOT;
         if (wants_read) events |= linux.EPOLL.IN;
         if (wants_write) events |= linux.EPOLL.OUT;
         var ev: linux.epoll_event = .{ .events = events, .data = .{ .fd = fd } };
         const op: u32 = if (first_time) linux.EPOLL.CTL_ADD else linux.EPOLL.CTL_MOD;
-        const rc = linux.epoll_ctl(self.epfd, op, fd, &ev);
+        var rc = linux.epoll_ctl(self.epfd, op, fd, &ev);
+        if (linux.errno(rc) == .NOENT and op == linux.EPOLL.CTL_MOD) {
+            rc = linux.epoll_ctl(self.epfd, linux.EPOLL.CTL_ADD, fd, &ev);
+        } else if (linux.errno(rc) == .EXIST and op == linux.EPOLL.CTL_ADD) {
+            rc = linux.epoll_ctl(self.epfd, linux.EPOLL.CTL_MOD, fd, &ev);
+        }
         if (linux.errno(rc) != .SUCCESS) return error.Unexpected;
     }
 

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -1,0 +1,341 @@
+// KEP-0001 Phase 3: non-blocking port reads/writes through the reactor.
+// Complements tests_reactor.zig (Phase 1, reactor in isolation) and
+// tests_scheduler.zig (Phase 2, scheduler/reactor plumbing). These tests
+// exercise the port layer end-to-end over real pipes: fibers parking on
+// EAGAIN and resuming losslessly, the main fiber driving the scheduler
+// while it waits, write buffering with real flush, and the close-port
+// wake discipline.
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const fiber_mod = @import("fiber.zig");
+const primitives_io = @import("primitives_io.zig");
+
+fn makePipe() [2]std.c.fd_t {
+    var fds: [2]std.c.fd_t = undefined;
+    if (std.c.pipe(&fds) != 0) unreachable;
+    return fds;
+}
+
+fn setNonblockingFd(fd: std.c.fd_t) void {
+    const flags = std.c.fcntl(fd, std.posix.F.GETFL, @as(c_int, 0));
+    const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
+    _ = std.c.fcntl(fd, std.posix.F.SETFL, flags | nonblock);
+}
+
+/// Wraps `fd` in a port and binds it to `name` as a global. The port owns
+/// the fd from here on: the GC's freeObject (or an explicit close-port)
+/// closes it, so tests must not close it again themselves.
+fn definePortGlobal(vm: *th.VM, name: []const u8, fd: std.c.fd_t, is_input: bool, is_output: bool) !*types.Port {
+    const port_val = try vm.gc.allocPort(fd, is_input, is_output, name, false);
+    try vm.defineGlobal(name, port_val);
+    return types.toObject(port_val).as(types.Port);
+}
+
+test "two fibers reading two pipes park and interleave through the reactor" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe1 = makePipe();
+    const pipe2 = makePipe();
+    _ = try definePortGlobal(vm, "rp1", pipe1[0], true, false);
+    _ = try definePortGlobal(vm, "wp1", pipe1[1], false, true);
+    _ = try definePortGlobal(vm, "rp2", pipe2[0], true, false);
+    _ = try definePortGlobal(vm, "wp2", pipe2[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    // Both readers park on empty pipes before the writer runs; the writer
+    // fills pipe 2 first, then pipe 1. If either read blocked the OS
+    // thread instead of parking, the writer would never run and this test
+    // would deadlock rather than pass.
+    _ = try vm.eval("(define f1 (spawn (lambda () (read-char rp1))))");
+    _ = try vm.eval("(define f2 (spawn (lambda () (read-char rp2))))");
+    _ = try vm.eval(
+        \\(define w (spawn (lambda ()
+        \\  (write-char #\b wp2) (flush-output-port wp2)
+        \\  (write-char #\a wp1) (flush-output-port wp1))))
+    );
+    const r1 = try vm.eval("(fiber-join f1)");
+    const r2 = try vm.eval("(fiber-join f2)");
+    try std.testing.expectEqual(types.makeChar('a'), r1);
+    try std.testing.expectEqual(types.makeChar('b'), r2);
+}
+
+test "main fiber read drives the scheduler while it waits" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    // The producer only runs while main's read-line waits: main (fiber 0)
+    // cannot park-and-retry, so its wait must dispatch siblings in place.
+    _ = try vm.eval(
+        \\(define w (spawn (lambda ()
+        \\  (write-string "hello\n" wp) (flush-output-port wp))))
+    );
+    const r = try vm.eval("(equal? (read-line rp) \"hello\")");
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "write larger than the pipe buffer parks the writer; a reader fiber drains it losslessly" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    // 100000 bytes exceeds any platform's default pipe capacity (16-64 KiB),
+    // so the flush hits EAGAIN mid-buffer and the writer suspends on write
+    // readiness; the reader's read-string in turn parks whenever the pipe
+    // runs dry. The final count and spot-checks prove no byte was lost or
+    // duplicated across those park/retry cycles.
+    _ = try vm.eval("(define n 100000)");
+    _ = try vm.eval(
+        \\(define writer (spawn (lambda ()
+        \\  (write-string (make-string n #\x) wp)
+        \\  (flush-output-port wp)
+        \\  (close-port wp))))
+    );
+    _ = try vm.eval(
+        \\(define reader (spawn (lambda ()
+        \\  (let loop ((total 0) (ok #t))
+        \\    (let ((s (read-string 4096 rp)))
+        \\      (if (eof-object? s)
+        \\          (and ok (= total n))
+        \\          (loop (+ total (string-length s))
+        \\                (and ok (string=? s (make-string (string-length s) #\x))))))))))
+    );
+    const r = try vm.eval("(fiber-join reader)");
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "(read) parked mid-datum resumes with the buffered prefix" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers) (srfi 18))");
+    _ = try vm.eval("(define f (spawn (lambda () (read rp))))");
+    // The sleep forces real sequencing: the reader wakes on the first
+    // chunk, parses an incomplete datum, hits EAGAIN, and must stash
+    // "(1 2 " into port.read_buf before parking again. If that stash were
+    // lost, the retry would parse "3)" alone and error.
+    _ = try vm.eval(
+        \\(define w (spawn (lambda ()
+        \\  (write-string "(1 2 " wp) (flush-output-port wp)
+        \\  (thread-sleep! 0.05)
+        \\  (write-string "3)" wp) (flush-output-port wp))))
+    );
+    const r = try vm.eval("(equal? (fiber-join f) '(1 2 3))");
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "closing a port with a parked reader raises a clean error in that fiber" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    _ = try vm.eval(
+        \\(define f (spawn (lambda ()
+        \\  (guard (e (#t (list 'caught (error-object? e))))
+        \\    (read-char rp)
+        \\    'not-reached))))
+    );
+    _ = try vm.eval("(define closer (spawn (lambda () (close-port rp))))");
+    // The join completing at all is the "nothing hangs" half of the
+    // acceptance criterion; the guard result is the "clean error" half.
+    const r = try vm.eval("(equal? (fiber-join f) '(caught #t))");
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "thread-terminate! pulls a parked reader off the reactor; the fd stays usable" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers) (srfi 18))");
+    _ = try vm.eval("(define f (spawn (lambda () (read-char rp))))");
+    // Dispatch f so it parks on the empty pipe, then kill it. Terminate
+    // must remove f from the reactor's waiter list for this fd (mirroring
+    // its removeTimer discipline) or the dead fiber would linger there as
+    // a stale registration for the next reader below.
+    _ = try vm.eval("(fiber-join (spawn (lambda () 1)))");
+    const f_val = try vm.eval("f");
+    try std.testing.expectEqual(fiber_mod.FiberStatus.io_waiting, types.toObject(f_val).as(fiber_mod.Fiber).status);
+    _ = try vm.eval("(thread-terminate! f)");
+    try std.testing.expectEqual(@as(?std.posix.fd_t, null), types.toObject(f_val).as(fiber_mod.Fiber).io_fd);
+
+    _ = try vm.eval("(define g (spawn (lambda () (read-char rp))))");
+    _ = try vm.eval("(define w (spawn (lambda () (write-char #\\k wp) (flush-output-port wp))))");
+    const r = try vm.eval("(fiber-join g)");
+    try std.testing.expectEqual(types.makeChar('k'), r);
+}
+
+test "port write buffer holds bytes until flush; close-port flushes the remainder" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    setNonblockingFd(pipe[0]); // test-side reads must not block on an empty pipe
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+    defer _ = std.posix.system.close(pipe[0]); // read end stays Zig-owned
+
+    _ = try vm.eval("(write-char #\\z wp)");
+    var buf: [8]u8 = undefined;
+    // Buffered: nothing reaches the pipe before the flush.
+    try std.testing.expect(std.posix.system.read(pipe[0], &buf, buf.len) < 0);
+    _ = try vm.eval("(flush-output-port wp)");
+    try std.testing.expectEqual(@as(isize, 1), std.posix.system.read(pipe[0], &buf, buf.len));
+    try std.testing.expectEqual(@as(u8, 'z'), buf[0]);
+
+    _ = try vm.eval("(write-char #\\q wp)");
+    _ = try vm.eval("(close-port wp)");
+    try std.testing.expectEqual(@as(isize, 1), std.posix.system.read(pipe[0], &buf, buf.len));
+    try std.testing.expectEqual(@as(u8, 'q'), buf[0]);
+}
+
+test "a read on the same port flushes its pending writes first" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // One bidirectional port over a socketpair: the request must reach the
+    // peer before the port waits for the response, or request/response
+    // protocols over one port would deadlock on the unflushed request.
+    var fds: [2]std.c.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds));
+    _ = try definePortGlobal(vm, "sp", fds[0], true, true);
+    defer _ = std.posix.system.close(fds[1]); // peer end stays Zig-owned
+
+    // Stage the peer's response up front so the read completes immediately
+    // once the flush-before-read has happened.
+    _ = std.posix.system.write(fds[1], "y", 1);
+
+    _ = try vm.eval("(write-char #\\x sp)"); // buffered request
+    const r = try vm.eval("(read-char sp)");
+    try std.testing.expectEqual(types.makeChar('y'), r);
+
+    var buf: [8]u8 = undefined;
+    try std.testing.expectEqual(@as(isize, 1), std.posix.system.read(fds[1], &buf, buf.len));
+    try std.testing.expectEqual(@as(u8, 'x'), buf[0]);
+}
+
+test "binary read-u8 drains bytes a prior (read) left in the port buffer" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    defer _ = std.posix.system.close(pipe[1]);
+
+    // (read) slurps a 4 KiB chunk, consumes "(a)", and stashes " 7" in
+    // port.read_buf. The old binary-side byte reader had its own copy that
+    // skipped read_buf entirely, silently losing these bytes.
+    _ = std.posix.system.write(pipe[1], "(a) 7", 5);
+    const datum_ok = try vm.eval("(equal? (read rp) '(a))");
+    try std.testing.expectEqual(types.TRUE, datum_ok);
+    const b = try vm.eval("(read-u8 rp)");
+    try std.testing.expectEqual(types.makeFixnum(' '), b);
+    const b2 = try vm.eval("(read-u8 rp)");
+    try std.testing.expectEqual(types.makeFixnum('7'), b2);
+}
+
+test "lazy O_NONBLOCK: set only for fd > 2 and only once a scheduler exists" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    const rport = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    defer _ = std.posix.system.close(pipe[1]);
+
+    // Sequential program: reads never flip the fd, so blocking semantics
+    // and the syscall profile are untouched.
+    _ = std.posix.system.write(pipe[1], "a", 1);
+    _ = try vm.eval("(read-char rp)");
+    try std.testing.expect(!rport.nonblocking);
+
+    // The guard itself: fd 0/1/2 never flip even with a scheduler running.
+    _ = try vm.eval("(import (kaappi fibers)) (fiber-join (spawn (lambda () 1)))");
+    const stdin_port = types.toObject(vm.stdin_port).as(types.Port);
+    primitives_io.maybeSetNonblocking(stdin_port);
+    try std.testing.expect(!stdin_port.nonblocking);
+
+    // A real-fd port does flip on its next use now that fibers exist.
+    _ = std.posix.system.write(pipe[1], "b", 1);
+    _ = try vm.eval("(read-char rp)");
+    try std.testing.expect(rport.nonblocking);
+}
+
+test "flush-output-port accepts string ports and the default port" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const r = try vm.eval(
+        \\(let ((sp (open-output-string)))
+        \\  (write-string "ab" sp)
+        \\  (flush-output-port sp)
+        \\  (flush-output-port)
+        \\  (get-output-string sp))
+    );
+    const s = types.toObject(r).as(types.SchemeString);
+    try std.testing.expectEqualStrings("ab", s.data[0..s.len]);
+}
+
+test "file I/O with fibers active stays correct (files never EAGAIN)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    defer _ = std.posix.system.unlink("/tmp/kaappi-port-io-test.txt");
+    const r = try vm.eval(
+        \\(begin
+        \\  (import (kaappi fibers))
+        \\  (fiber-join (spawn (lambda () 1)))
+        \\  (let ((out (open-output-file "/tmp/kaappi-port-io-test.txt")))
+        \\    (write-string "line one" out)
+        \\    (close-port out))
+        \\  (let* ((in (open-input-file "/tmp/kaappi-port-io-test.txt"))
+        \\         (line (read-line in)))
+        \\    (close-port in)
+        \\    (equal? line "line one")))
+    );
+    try std.testing.expectEqual(types.TRUE, r);
+}

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -251,6 +251,50 @@ test "a read on the same port flushes its pending writes first" {
     try std.testing.expectEqual(@as(u8, 'x'), buf[0]);
 }
 
+test "(read) must not lose read_buf when its write drain parks" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Bidirectional port over a socketpair with tiny kernel buffers so a
+    // buffered-write drain hits EAGAIN.
+    var fds: [2]std.c.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds));
+    const small: c_int = 4096;
+    try std.posix.setsockopt(fds[0], std.posix.SOL.SOCKET, std.posix.SO.SNDBUF, &std.mem.toBytes(small));
+    try std.posix.setsockopt(fds[1], std.posix.SOL.SOCKET, std.posix.SO.RCVBUF, &std.mem.toBytes(small));
+    _ = try definePortGlobal(vm, "sp", fds[0], true, true);
+    _ = try definePortGlobal(vm, "peer", fds[1], true, true);
+
+    // The first (read sp) consumes (a) and stashes " (b)" into port.read_buf.
+    _ = std.posix.system.write(fds[1], "(a) (b)", 7);
+    const first = try vm.eval("(equal? (read sp) '(a))");
+    try std.testing.expectEqual(types.TRUE, first);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    // f buffers a 20 KB write (a single write-string is appended whole —
+    // the high-water drain only flushes *prior* pending bytes), then calls
+    // (read sp). readDatumFn moves read_buf's " (b)" into its local buf,
+    // then drains the write buffer, which EAGAINs against the tiny socket
+    // buffers and parks f. If the Yielded unwound without stashing buf,
+    // " (b)" would be gone and f's retry would read "(c)" off the fd
+    // instead.
+    _ = try vm.eval(
+        \\(define f (spawn (lambda ()
+        \\  (write-string (make-string 20000 #\x) sp)
+        \\  (read sp))))
+    );
+    _ = try vm.eval(
+        \\(define g (spawn (lambda ()
+        \\  (read-string 20000 peer)
+        \\  (write-string "(c)" peer)
+        \\  (flush-output-port peer))))
+    );
+    const got_b = try vm.eval("(equal? (fiber-join f) '(b))");
+    try std.testing.expectEqual(types.TRUE, got_b);
+}
+
 test "binary read-u8 drains bytes a prior (read) left in the port buffer" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -1,8 +1,10 @@
 // KEP-0001 Phase 1: reactor core, tested in isolation (no scheduler caller
 // yet — that's Phase 2). These are plain Zig tests against real fds; no VM
-// or GC is involved. Fake *Fiber values are bare stack locals: reactor.zig
-// never dereferences a parked fiber, it only stores and later returns the
-// pointer, so distinct addresses are all a test needs.
+// or GC is involved. Fake *Fiber values are stack locals with only `status`
+// initialized (to .io_waiting, what a genuinely parked fiber carries): the
+// reactor stores and returns the pointers without touching execution state,
+// but register()'s Debug-build staleness assertion reads the status of
+// every already-listed waiter (Phase 3).
 const std = @import("std");
 const reactor_mod = @import("reactor.zig");
 const fiber_mod = @import("fiber.zig");
@@ -41,6 +43,7 @@ test "register + poll wakes the fiber when the fd becomes readable" {
     defer closeFd(pipe[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     try reactor.register(pipe[0], .read, &fiber_a);
 
     writeByte(pipe[1], 'x');
@@ -62,6 +65,7 @@ test "poll times out with an empty ready list when nothing fires" {
     defer closeFd(pipe[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     try reactor.register(pipe[0], .read, &fiber_a); // never written to
 
     var ready = newReady();
@@ -80,7 +84,9 @@ test "multiple waiters on one fd direction are all woken (wake-all)" {
     defer closeFd(pipe[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     var fiber_b: Fiber = undefined;
+    fiber_b.status = .io_waiting;
     try reactor.register(pipe[0], .read, &fiber_a);
     try reactor.register(pipe[0], .read, &fiber_b);
 
@@ -109,6 +115,7 @@ test "a write end is immediately ready for write interest" {
     defer closeFd(pipe[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     try reactor.register(pipe[1], .write, &fiber_a);
 
     var ready = newReady();
@@ -124,6 +131,7 @@ test "addTimer fires when its deadline passes" {
     defer reactor.deinit();
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     const deadline = fiber_mod.clockNs() + 1_000_000; // 1ms out
     try reactor.addTimer(deadline, &fiber_a);
 
@@ -144,7 +152,9 @@ test "the nearer of an fd timeout and a timer deadline bounds the wait" {
     defer closeFd(pipe[1]);
 
     var fiber_fd: Fiber = undefined;
+    fiber_fd.status = .io_waiting;
     var fiber_timer: Fiber = undefined;
+    fiber_timer.status = .io_waiting;
     try reactor.register(pipe[0], .read, &fiber_fd); // never written to
     try reactor.addTimer(fiber_mod.clockNs() + 1_000_000, &fiber_timer); // 1ms
 
@@ -163,6 +173,7 @@ test "removeTimer cancels a pending timer so it never fires" {
     defer reactor.deinit();
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     try reactor.addTimer(fiber_mod.clockNs() + 1_000_000, &fiber_a);
     reactor.removeTimer(&fiber_a);
 
@@ -183,6 +194,7 @@ test "unregister drops the registration; a later write wakes nobody" {
     defer closeFd(pipe[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     try reactor.register(pipe[0], .read, &fiber_a);
     reactor.unregister(pipe[0]);
 
@@ -204,6 +216,7 @@ test "isEmpty is true after a fired oneshot drains its waiters, even though the 
     defer closeFd(pipe[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     try reactor.register(pipe[0], .read, &fiber_a);
     writeByte(pipe[1], 'x');
 
@@ -232,6 +245,7 @@ test "re-registering a fd after a fired oneshot re-arms correctly" {
     defer closeFd(pipe[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     try reactor.register(pipe[0], .read, &fiber_a);
     writeByte(pipe[1], 'x');
 
@@ -242,8 +256,61 @@ test "re-registering a fd after a fired oneshot re-arms correctly" {
     ready.clearRetainingCapacity();
 
     var fiber_b: Fiber = undefined;
+    fiber_b.status = .io_waiting;
     try reactor.register(pipe[0], .read, &fiber_b);
     writeByte(pipe[1], 'y');
+
+    try reactor.poll(5_000_000_000, &ready);
+    try std.testing.expectEqual(@as(usize, 1), ready.items.len);
+    try std.testing.expectEqual(&fiber_b, ready.items[0]);
+}
+
+test "a recycled fd number registers cleanly over a stale Reg left by a close without unregister" {
+    // A port freed by the GC closes its fd without reactor.unregister —
+    // the kernel silently drops the fd from the epoll set, but the Reg
+    // (kernel_registered=true, empty waiter lists) survives in the map.
+    // When the fd number is recycled onto a new port, register() must
+    // still succeed: epoll's CTL_MOD hits ENOENT on the untracked fd and
+    // must self-heal by retrying as CTL_ADD. kqueue is immune (EV_ADD
+    // recreates), so this is a Linux regression guard that also passes
+    // on macOS.
+    var reactor = try Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+
+    const pipe_old = makePipe();
+    defer closeFd(pipe_old[1]);
+    var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
+    try reactor.register(pipe_old[0], .read, &fiber_a);
+
+    // Drain the registration so the waiter lists empty out but the Reg
+    // (and its kernel_registered flag) stay behind, then "GC-free" the
+    // port: close the fd with no unregister.
+    writeByte(pipe_old[1], 'x');
+    var ready = newReady();
+    defer ready.deinit(std.testing.allocator);
+    try reactor.poll(5_000_000_000, &ready);
+    try std.testing.expectEqual(@as(usize, 1), ready.items.len);
+    ready.clearRetainingCapacity();
+    closeFd(pipe_old[0]);
+
+    // Recycle the exact fd number onto a fresh pipe. POSIX hands out the
+    // lowest free fd, so pipe() usually reuses it directly; dup2 forces
+    // the number when the allocator happened to pick another.
+    const pipe_new = makePipe();
+    defer closeFd(pipe_new[1]);
+    var recycled: std.c.fd_t = pipe_new[0];
+    if (pipe_new[0] != pipe_old[0]) {
+        recycled = std.c.dup2(pipe_new[0], pipe_old[0]);
+        try std.testing.expectEqual(pipe_old[0], recycled);
+        closeFd(pipe_new[0]);
+    }
+    defer closeFd(recycled);
+
+    var fiber_b: Fiber = undefined;
+    fiber_b.status = .io_waiting;
+    try reactor.register(recycled, .read, &fiber_b);
+    writeByte(pipe_new[1], 'y');
 
     try reactor.poll(5_000_000_000, &ready);
     try std.testing.expectEqual(@as(usize, 1), ready.items.len);
@@ -262,7 +329,9 @@ test "two fds: only the one that becomes ready wakes its fiber" {
     defer closeFd(pipe_b[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     var fiber_b: Fiber = undefined;
+    fiber_b.status = .io_waiting;
     try reactor.register(pipe_a[0], .read, &fiber_a);
     try reactor.register(pipe_b[0], .read, &fiber_b);
 
@@ -297,7 +366,9 @@ test "one fd with both read and write interest: a fired direction re-arms the ot
     defer closeFd(pair[1]);
 
     var fiber_read: Fiber = undefined;
+    fiber_read.status = .io_waiting;
     var fiber_write: Fiber = undefined;
+    fiber_write.status = .io_waiting;
     // pair[0] is immediately writable (empty send buffer) but not yet
     // readable (nothing sent from pair[1] yet).
     try reactor.register(pair[0], .write, &fiber_write);
@@ -333,6 +404,7 @@ test "closing the peer wakes a parked read waiter (EOF/HUP mapped to broken)" {
     defer if (!closed_peer) closeFd(pair[1]);
 
     var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
     try reactor.register(pair[0], .read, &fiber_a);
 
     closeFd(pair[1]);

--- a/src/types.zig
+++ b/src/types.zig
@@ -461,6 +461,17 @@ pub const Port = struct {
     is_binary: bool = false,
     read_buf: ?[]u8 = null,
     read_buf_len: usize = 0,
+    // Non-blocking port state (KEP-0001 Phase 3):
+    /// O_NONBLOCK has been set on `fd` (lazily, the first time a read/write
+    /// runs while a fiber scheduler exists). Never set for fd 0/1/2.
+    nonblocking: bool = false,
+    /// Pending output not yet written to `fd` (owned, growable). The live
+    /// span is [write_buf_start..write_buf_len) — `start` records drain
+    /// progress so a write that would block can suspend mid-buffer and a
+    /// retry resumes with the remaining slice.
+    write_buf: ?[]u8 = null,
+    write_buf_start: usize = 0,
+    write_buf_len: usize = 0,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -23,4 +23,5 @@ test {
     _ = @import("tests_native.zig");
     _ = @import("tests_reactor.zig");
     _ = @import("tests_scheduler.zig");
+    _ = @import("tests_port_io.zig");
 }

--- a/tests/scheme/smoke/port-write-buffer.scm
+++ b/tests/scheme/smoke/port-write-buffer.scm
@@ -2,16 +2,10 @@
 ;; flush-output-port, close-port, or a read on the same port. Checks the
 ;; user-visible buffering contract end to end: bytes must NOT be on disk
 ;; before the first flush, and MUST be after flush/close.
-(import (scheme base) (scheme write) (scheme file) (srfi 170))
+(import (scheme base) (scheme write) (scheme file) (scheme process-context)
+        (srfi 64) (srfi 170))
 
-(define pass 0)
-(define fail 0)
-(define (check name got expected)
-  (if (equal? got expected) (set! pass (+ pass 1))
-      (begin (set! fail (+ fail 1))
-             (display "FAIL: ") (display name)
-             (display " expected ") (write expected)
-             (display " got ") (write got) (newline))))
+(test-begin "port-write-buffer")
 
 (define test-file "/tmp/kaappi-port-write-buffer-test.txt")
 (when (file-exists? test-file) (delete-file test-file))
@@ -21,17 +15,17 @@
 
 (define out (open-output-file test-file))
 (write-string "hello" out)
-(check "writes buffer until flushed" (size-of test-file) 0)
+(test-equal "writes buffer until flushed" 0 (size-of test-file))
 
 (flush-output-port out)
-(check "flush-output-port drains the buffer" (size-of test-file) 5)
+(test-equal "flush-output-port drains the buffer" 5 (size-of test-file))
 
 (write-string " world" out)
 (close-port out)
-(check "close-port flushes the remainder" (size-of test-file) 11)
+(test-equal "close-port flushes the remainder" 11 (size-of test-file))
 
 (define in (open-input-file test-file))
-(check "round trip" (read-line in) "hello world")
+(test-equal "round trip" "hello world" (read-line in))
 (close-port in)
 (delete-file test-file)
 
@@ -39,13 +33,10 @@
 (define sp (open-output-string))
 (write-string "ab" sp)
 (flush-output-port sp)
-(check "string port flush is harmless" (get-output-string sp) "ab")
+(test-equal "string port flush is harmless" "ab" (get-output-string sp))
 (flush-output-port)
+(test-assert "default-port flush returns" #t)
 
-(display "port-write-buffer: ")
-(display pass)
-(display " passed, ")
-(display fail)
-(display " failed")
-(newline)
-(when (> fail 0) (exit 1))
+(let ((runner (test-runner-current)))
+  (test-end "port-write-buffer")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/port-write-buffer.scm
+++ b/tests/scheme/smoke/port-write-buffer.scm
@@ -1,0 +1,51 @@
+;; KEP-0001 Phase 3 (#1441): file ports buffer output until
+;; flush-output-port, close-port, or a read on the same port. Checks the
+;; user-visible buffering contract end to end: bytes must NOT be on disk
+;; before the first flush, and MUST be after flush/close.
+(import (scheme base) (scheme write) (scheme file) (srfi 170))
+
+(define pass 0)
+(define fail 0)
+(define (check name got expected)
+  (if (equal? got expected) (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name)
+             (display " expected ") (write expected)
+             (display " got ") (write got) (newline))))
+
+(define test-file "/tmp/kaappi-port-write-buffer-test.txt")
+(when (file-exists? test-file) (delete-file test-file))
+
+(define (size-of path)
+  (file-info:size (file-info path #t)))
+
+(define out (open-output-file test-file))
+(write-string "hello" out)
+(check "writes buffer until flushed" (size-of test-file) 0)
+
+(flush-output-port out)
+(check "flush-output-port drains the buffer" (size-of test-file) 5)
+
+(write-string " world" out)
+(close-port out)
+(check "close-port flushes the remainder" (size-of test-file) 11)
+
+(define in (open-input-file test-file))
+(check "round trip" (read-line in) "hello world")
+(close-port in)
+(delete-file test-file)
+
+;; String ports and the default (stdout) port accept flush as a no-op.
+(define sp (open-output-string))
+(write-string "ab" sp)
+(flush-output-port sp)
+(check "string port flush is harmless" (get-output-string sp) "ab")
+(flush-output-port)
+
+(display "port-write-buffer: ")
+(display pass)
+(display " passed, ")
+(display fail)
+(display " failed")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
Closes #1441. Part of #1438 (KEP-0001); builds on Phase 1 (#1446) and Phase 2 (#1453). Design: [KEP-0001 §4](https://github.com/kaappi/keps/blob/main/keps/0001-event-loop-reactor.md#4-io-primitive-changes).

Port reads and writes that would block now suspend the calling fiber on the reactor instead of blocking the OS thread — the KEP's motivating example (fibers reading different sockets interleaving on one thread) works end to end.

## How blocking works now (`fiber.waitForFd`)

Two modes, mirroring the existing channel protocol:

- **Park** — a spawned fiber dispatched directly by a scheduler loop registers with the reactor, flips to `.io_waiting`, arms the yield-retry ip rewind, and unwinds with `error.Yielded` (same protocol as `blockOrDeadlock`). The primitive re-executes on readiness, so every read site with partial progress stashes it into `port.read_buf` first (`propagateReadErr`) — the retry re-drains it losslessly. `read-line` re-stashes a consumed-but-unappended `\r`; a mid-sequence UTF-8 read re-stashes its prefix; `(read)` re-stashes the partial datum text.
- **Drive** — the main fiber (or any fiber under re-entrant native frames, which cannot be rewound) instead drives the scheduler in place — the `thread-sleep!` pattern — until the reactor reports the fd ready, then retries the syscall. Blocking main on I/O keeps sibling fibers running while preserving blocking-read semantics.

`schedule()` additionally does a zero-timeout reactor poll per dispatch tick whenever any fiber is `.io_waiting` (the Phase-2 expired-timer argument applied to fds), so a busy/yielding sibling can't starve a parked reader.

## Reads

`readOneByte` — already the single byte source behind `read-char`/`peek-char`/`read-line`/`read-string` — becomes the EAGAIN choke point and is now also shared by the binary primitives: `primitives_bytevector.zig`'s private `portReadOneByte`/`portWriteBytes` duplicates are deleted. That consolidation fixes a latent bug: the binary reader skipped `peek_extra` and `read_buf`, so `read-u8` after a `(read)` that buffered excess bytes silently lost them (regression-tested).

## Writes

- Ports on fd > 2 get a per-port `write_buf`: appends return immediately; the buffer drains at `flush-output-port` (real now, was a no-op), `close-port`, a read on the same port (a socket request must reach the peer before waiting on the response), the 8 KiB high-water mark, GC finalization, and `exit` (R7RS cleanup; `emergency-exit` skips it). fd 0/1/2 stay unbuffered and blocking — REPL echo and diagnostics unchanged; `reporting.zig` keeps the blocking writer.
- The drain — never the append — is the only suspension point, and it runs *before* new bytes are appended, so a parked primitive's re-execution can't duplicate output; `write_buf_start` preserves mid-buffer progress across retries.

## Lazy `O_NONBLOCK`

Flipped per-port on first fd use, only once a scheduler exists, never for fd 0/1/2, never on WASI. Sequential programs keep blocking fds and their exact syscall profile; buffered data still costs zero syscalls (all software buffers drain before the fd is touched). An fd handed to us already non-blocking now waits properly through the reactor instead of misreporting EAGAIN as EOF.

## Close discipline (resolved KEP question 4)

`close-port` flushes pending output, wakes every fiber parked on the fd (`wakeIoWaitersOnFd` — their retry observes `is_open == false` and raises a clean error), unregisters the fd from the reactor, then closes. `register()` gains the Debug-build assertion that every already-listed waiter is still `.io_waiting`. Two adjacent holes found and fixed while wiring this:

- `thread-terminate!` now pulls an `io_waiting` victim out of the reactor's waiter lists (mirroring its existing `removeTimer`), so a dead fiber can't linger as a stale registration.
- epoll's `arm()` self-heals fd recycling: a port freed by the GC closes its fd (silently dropping it from the epoll set) without unregistering, so the next registration on the recycled fd number retries `CTL_MOD`↔`CTL_ADD` on `ENOENT`/`EEXIST` instead of failing. kqueue is immune; regression-tested with a forced fd reuse.

## kaappi-net

`set-nonblocking`/`poll-read`/`nb-accept` marked superseded in the kaappi-net repo (comment-only change, kept for compatibility) — see companion PR there.

## Acceptance criteria → tests (`src/tests_port_io.zig`, `tests/scheme/smoke/port-write-buffer.scm`)

- Two fibers reading two pipes interleave; a 100 KB write parks mid-buffer and a reader fiber drains it losslessly.
- Closing a port with a parked reader raises a clean error in that fiber; nothing hangs. Same for `thread-terminate!`.
- `(read)` parked mid-datum resumes with the buffered prefix.
- Main-fiber reads drive the scheduler (producer fiber runs while main waits).
- REPL unchanged: fd 0/1/2 never flipped (unit-tested guard) plus interactive pty runs — prompt/eval, and `(read-char)` from terminal stdin with a live scheduler — behave identically to the main-branch binary.
- File I/O buffered-data reads take zero new syscalls (all software buffers checked before the fd); `zig build test` (791), `tests/scheme/run-all.sh` (438 files + 1395 R7RS), gc-stress and Debug-assert runs, and wasm/x86_64-linux/riscv64-linux cross-builds are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
