### PR TITLE
WASI backend: poll_oneoff reactor (KEP-0001 P4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Smoke test
         run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/smoke.scm
 
+      - name: Timer test (reactor poll_oneoff backend)
+        run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/timers.scm
+
   coverage:
     needs: test
     runs-on: ubuntu-22.04

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,17 +425,22 @@ The lockfile (`~/.kaappi/thottam.lock`) records source URLs for provenance.
 ## Fiber I/O reactor (KEP-0001)
 
 Each OS thread's scheduler owns a `Reactor` (`src/reactor.zig`:
-kqueue/epoll/WASI-timer backends + a userspace timer heap), created lazily
-with the scheduler by `fiber.ensureScheduler`. Port reads/writes that would
-block (`EAGAIN`) suspend the calling fiber instead of the thread
+kqueue/epoll/WASI-`poll_oneoff` backends + a userspace timer heap), created
+lazily with the scheduler by `fiber.ensureScheduler`. Port reads/writes that
+would block (`EAGAIN`) suspend the calling fiber instead of the thread
 (`fiber.waitForFd`): a fiber dispatched directly by a scheduler loop parks
 (`.io_waiting` + the yield-retry re-execution protocol — callers stash
 partial progress into `port.read_buf` first via
 `primitives_io.propagateReadErr`); the main fiber or one under re-entrant
-native frames drives the scheduler in place instead. Port fds (never 0/1/2,
-never in WASI builds) flip to `O_NONBLOCK` lazily, only once a scheduler
-exists — sequential programs keep blocking fds and their exact syscall
-profile. Ports on fd > 2 buffer writes in `port.write_buf` until
+native frames drives the scheduler in place instead. Port fds (never 0/1/2)
+flip to `O_NONBLOCK` lazily, only once a scheduler exists — sequential
+programs keep blocking fds and their exact syscall profile. On WASI the
+flip is the host-capability probe: `fd_fdstat_set_flags(NONBLOCK)` failing
+(e.g. the playground's browser shim) leaves ports blocking, so nothing ever
+registers an fd and the reactor degrades to CLOCK-only `poll_oneoff` waits —
+timers and `thread-sleep!` (the one SRFI-18 primitive registered on WASM,
+as a global; the `(srfi 18)` library itself stays native-only) always work.
+Ports on fd > 2 buffer writes in `port.write_buf` until
 `flush-output-port`, `close-port`, a read on the same port, or the 8 KiB
 high-water mark; `close-port` flushes, wakes fibers parked on the fd
 (`fiber.wakeIoWaitersOnFd` — their retry sees `is_open == false` and raises

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -199,7 +199,11 @@ pub const all_specs = core_specs ++
     primitives_random.specs ++
     (if (is_wasm) no_specs else primitives_filesystem.specs) ++
     @import("primitives_fiber.zig").specs ++
-    (if (is_wasm) no_specs else @import("primitives_srfi18.zig").specs);
+    // SRFI-18's OS-thread machinery cannot exist on WASM, but its
+    // fiber-safe subset (thread-sleep!, the KEP-0001 Phase 4 timer path)
+    // can: wasm_specs is the comptime-filtered `.wasm = true` slice, so
+    // the WASM build never references std.Thread.spawn and friends.
+    (if (is_wasm) @import("primitives_srfi18.zig").wasm_specs else @import("primitives_srfi18.zig").specs);
 
 comptime {
     @setEvalBranchQuota(all_specs.len * all_specs.len * 30);

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -147,11 +147,26 @@ fn isBufferedFdPort(port: *types.Port) bool {
 /// mode), so flipping them would leak non-blocking mode outside this
 /// process. Without a scheduler nothing is flipped and sequential programs
 /// keep blocking fds. Pub only for tests_port_io's guard checks.
+///
+/// On WASI this doubles as the host-capability probe (KEP-0001 Phase 4):
+/// fd readiness is best-effort per the KEP, and a host that rejects
+/// fd_fdstat_set_flags(NONBLOCK) — the playground's browser shim does —
+/// keeps the port on a blocking fd, so no read ever EAGAINs, nothing
+/// registers with the reactor, and I/O degrades to single-fiber blocking
+/// exactly where the host can't support better.
 pub fn maybeSetNonblocking(port: *types.Port) void {
-    if (comptime is_wasm) return; // WASI fd readiness is KEP-0001 Phase 4
     if (port.nonblocking or port.is_string_port or port.fd <= 2) return;
     const vm = vm_mod.vm_instance orelse return;
     if (vm.scheduler == null) return;
+    if (comptime is_wasm) {
+        var stat: std.os.wasi.fdstat_t = undefined;
+        if (std.os.wasi.fd_fdstat_get(port.fd, &stat) != .SUCCESS) return;
+        var flags = stat.fs_flags;
+        flags.NONBLOCK = true;
+        if (std.os.wasi.fd_fdstat_set_flags(port.fd, flags) != .SUCCESS) return;
+        port.nonblocking = true;
+        return;
+    }
     const flags = std.c.fcntl(port.fd, std.posix.F.GETFL, @as(c_int, 0));
     if (flags < 0) return;
     const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
@@ -253,7 +268,6 @@ fn drainWriteBuffer(port: *types.Port) PrimitiveError!void {
             const e = std.posix.errno(rc);
             if (e == .INTR) continue;
             if (e == .AGAIN) {
-                if (comptime is_wasm) break;
                 try waitPortFd(port, .write);
                 continue;
             }
@@ -624,7 +638,6 @@ pub fn readOneByte(port: *types.Port) PrimitiveError!?u8 {
             const e = std.posix.errno(raw);
             if (e == .INTR) continue;
             if (e == .AGAIN) {
-                if (comptime is_wasm) return null;
                 try waitPortFd(port, .read);
                 continue;
             }
@@ -954,7 +967,6 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
             const e = std.posix.errno(raw_n);
             if (e == .INTR) continue;
             if (e == .AGAIN) {
-                if (comptime is_wasm) break;
                 // Mid-datum would-block: a parked retry re-executes this
                 // primitive from the top, so the partial accumulation goes
                 // back into port.read_buf and is re-drained on entry. The

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
@@ -18,7 +19,12 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "thread-specific-set!", .func = &threadSpecificSetFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "thread-start!", .func = &threadStartFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "thread-yield!", .func = &threadYieldFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
-    .{ .name = "thread-sleep!", .func = &threadSleepFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
+    // wasm: the one SRFI-18 entry point with no OS-thread dependency that
+    // KEP-0001 Phase 4 needs Scheme-visible — it parks the current fiber
+    // on the reactor's timer heap, which the WASI backend waits out with a
+    // poll_oneoff CLOCK subscription. Registered as a global only; the
+    // (srfi 18) library itself stays unavailable on WASM.
+    .{ .name = "thread-sleep!", .func = &threadSleepFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = true },
     .{ .name = "thread-terminate!", .func = &threadTerminateFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "thread-join!", .func = &threadJoinFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "mutex?", .func = &mutexPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
@@ -44,6 +50,27 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "terminated-thread-exception?", .func = &terminatedThreadPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "uncaught-exception?", .func = &uncaughtExceptionPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
     .{ .name = "uncaught-exception-reason", .func = &uncaughtExceptionReasonFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_18), .sandbox = false, .wasm = false },
+};
+
+/// The `.wasm = true` subset of `specs`, what primitives.zig registers on
+/// wasm32-wasi (KEP-0001 Phase 4). Filtered at comptime so the WASM
+/// build's spec table never references the OS-thread functions: a
+/// function pointer in runtime data forces codegen of its body, and
+/// std.Thread.spawn (threadStartFn) is a compile error single-threaded.
+pub const wasm_specs = blk: {
+    var count: usize = 0;
+    for (specs) |s| {
+        if (s.wasm) count += 1;
+    }
+    var out: [count]primitives.PrimSpec = undefined;
+    var i: usize = 0;
+    for (specs) |s| {
+        if (s.wasm) {
+            out[i] = s;
+            i += 1;
+        }
+    }
+    break :blk out;
 };
 
 const ChildThreadResources = struct {
@@ -244,6 +271,16 @@ fn threadSpecificSetFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn threadStartFn(args: []const Value) PrimitiveError!Value {
+    // Unregistered on WASM (spec .wasm = false) but the body must still
+    // compile there: the comptime spec-table filter (wasm_specs) evaluates
+    // the full `specs` array, which analyzes every referenced function.
+    // The else-branch is what keeps std.Thread.spawn out of the
+    // single-threaded wasm32 build — only the taken branch of a
+    // comptime-known if is analyzed.
+    if (comptime is_wasm) return PrimitiveError.TypeError else return threadStartImpl(args);
+}
+
+fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     if (!types.isFiber(args[0]))
         return primitives.typeError("thread-start!", "thread", args[0]);
 
@@ -850,7 +887,7 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
     // that acquires the mutex in the gap and produce a lost wakeup (the
     // waiter would then wait for a *second* signal that may never come).
     const cv: ?*types.ConditionVariable = if (has_cv) types.toConditionVariable(args[1]) else null;
-    const start_gen: u64 = if (cv) |c| @atomicLoad(u64, &c.signal_generation, .acquire) else 0;
+    const start_gen: u64 = if (cv) |c| loadSignalGeneration(c) else 0;
 
     // Clear owner *before* the release-store: otherwise a cross-thread
     // acquirer that wins the locked CAS right after the store below could
@@ -912,13 +949,34 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
     return types.TRUE;
 }
 
+/// signal_generation is a u64 and wasm32 has no 64-bit atomics; the WASM
+/// build is single-threaded, so a plain load is equivalent there. Only the
+/// taken branch of the comptime if is analyzed, keeping @atomicLoad(u64)
+/// out of the wasm32 build.
+fn loadSignalGeneration(cv: *types.ConditionVariable) u64 {
+    if (comptime is_wasm) {
+        return cv.signal_generation;
+    } else {
+        return @atomicLoad(u64, &cv.signal_generation, .acquire);
+    }
+}
+
+/// See loadSignalGeneration for why WASM takes the plain-access branch.
+fn bumpSignalGeneration(cv: *types.ConditionVariable) void {
+    if (comptime is_wasm) {
+        cv.signal_generation +%= 1;
+    } else {
+        _ = @atomicRmw(u64, &cv.signal_generation, .Add, 1, .release);
+    }
+}
+
 const CondVarWait = struct {
     me: *fiber_mod.Fiber,
     cv: *types.ConditionVariable,
     start_gen: u64,
     pub fn isDone(self: CondVarWait) bool {
         return self.me.status != .waiting or
-            @atomicLoad(u64, &self.cv.signal_generation, .acquire) != self.start_gen;
+            loadSignalGeneration(self.cv) != self.start_gen;
     }
     // See MutexWait.pollCapNs.
     pub fn pollCapNs(self: CondVarWait) ?u64 {
@@ -968,7 +1026,7 @@ fn condvarSignalFn(args: []const Value) PrimitiveError!Value {
     ctx.sched.wakeOneCondVarWaiter(args[0]);
     // Bump the generation so a waiter parked on a different OS thread's
     // scheduler (which never sees the local wake above) can poll for this.
-    _ = @atomicRmw(u64, &types.toConditionVariable(args[0]).signal_generation, .Add, 1, .release);
+    bumpSignalGeneration(types.toConditionVariable(args[0]));
     return types.VOID;
 }
 
@@ -977,7 +1035,7 @@ fn condvarBroadcastFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("condition-variable-broadcast!", "condition-variable", args[0]);
     const ctx = try ensureScheduler();
     ctx.sched.wakeAllCondVarWaiters(args[0]);
-    _ = @atomicRmw(u64, &types.toConditionVariable(args[0]).signal_generation, .Add, 1, .release);
+    bumpSignalGeneration(types.toConditionVariable(args[0]));
     return types.VOID;
 }
 

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -1,10 +1,11 @@
-//! Per-OS-thread I/O readiness multiplexer (KEP-0001 Phases 1-2).
+//! Per-OS-thread I/O readiness multiplexer (KEP-0001).
 //!
 //! One `Reactor` belongs to one OS thread's scheduler. A fiber that would
 //! block on a fd registers its interest and parks; `poll` blocks once,
 //! bounded by the nearest timer deadline, and reports every fiber that
 //! became runnable (fd readiness or timer expiry). Wired into the
-//! scheduler in KEP-0001 Phase 2 (fiber.zig's runSchedulerStep). See
+//! scheduler in KEP-0001 Phase 2 (fiber.zig's runSchedulerStep). Backends:
+//! kqueue (macOS/BSD), epoll (Linux), poll_oneoff (WASI, Phase 4). See
 //! https://github.com/kaappi/keps/blob/main/keps/0001-event-loop-reactor.md
 const std = @import("std");
 const builtin = @import("builtin");
@@ -28,7 +29,7 @@ const ReadyEvent = struct { fd: i32, readable: bool, writable: bool };
 const Backend = switch (builtin.os.tag) {
     .macos, .ios, .tvos, .watchos, .visionos => KqueueBackend,
     .linux => EpollBackend,
-    .wasi => WasiBackend,
+    .wasi => WasiPollBackend,
     else => @compileError("reactor: unsupported OS (kqueue/epoll/wasi only)"),
 };
 
@@ -71,7 +72,7 @@ pub const Reactor = struct {
     pub fn init(allocator: std.mem.Allocator) !Reactor {
         return .{
             .allocator = allocator,
-            .backend = try Backend.init(),
+            .backend = try Backend.init(allocator),
             .regs = std.AutoHashMap(i32, Reg).init(allocator),
             .timers = .empty,
         };
@@ -298,7 +299,9 @@ const KqueueBackend = struct {
     raw: [max_events_per_poll]std.c.Kevent = undefined,
     ready: [max_events_per_poll]ReadyEvent = undefined,
 
-    fn init() !KqueueBackend {
+    /// Owns no allocations — the allocator is part of the uniform
+    /// three-backend init signature (WasiPollBackend needs it).
+    fn init(_: std.mem.Allocator) !KqueueBackend {
         const kq = std.c.kqueue();
         if (kq < 0) return error.Unexpected;
         return .{ .kq = kq };
@@ -406,7 +409,7 @@ const EpollBackend = struct {
     raw: [max_events_per_poll]linux.epoll_event = undefined,
     ready: [max_events_per_poll]ReadyEvent = undefined,
 
-    fn init() !EpollBackend {
+    fn init(_: std.mem.Allocator) !EpollBackend {
         // CLOEXEC: without it the epoll fd leaks into every child the core
         // spawns (thottam_proc.zig, native_compiler.zig via
         // std.process.Child). kqueue needs no equivalent — kqueue(2) fds
@@ -489,56 +492,164 @@ fn msFromNs(timeout_ns: ?u64) i32 {
 }
 
 // ---------------------------------------------------------------------------
-// WASI backend — timer-only stopgap.
+// WASI poll_oneoff backend (KEP-0001 Phase 4)
 //
-// The full design (build a subscription_t[] — one fd_read/fd_write per
-// registration plus one CLOCK subscription at the nearest deadline, call
-// std.os.wasi.poll_oneoff) is KEP-0001 Phase 4. Nothing registers a port's
-// fd with the reactor before Phase 3, so on wasm32-wasi today the only
-// path that must actually work is a plain wait bounded by the timer
-// heap's nearest deadline — exactly what thread-sleep! and timed
-// mutex/join/condvar waits need. arm() is unreachable until Phase 3 lands
-// I/O primitive changes (gated by the existing is_wasm flag, per the
-// KEP's cross-platform section: WASI falls back to single-fiber blocking
-// I/O where poll_oneoff socket support is unavailable).
+// poll_oneoff is stateless: there is no kernel object that remembers
+// interest between calls (the kqueue/epoll fd of the other backends).
+// `interests` is that state, kept in userspace — arm() records the armed
+// directions per fd, and every wait() rebuilds the full subscription list
+// from it: one FD_READ/FD_WRITE subscription per armed direction plus one
+// CLOCK subscription bounding the wait (the mio wasi model). An event
+// disarms the direction it reports, giving ONESHOT parity with the other
+// backends: "armed ⇔ a fiber is parked" holds by construction, and a
+// stale interest (waiter removed via removeWaiter) fires at most once
+// before self-clearing.
+//
+// Fd readiness is best-effort by design (KEP-0001 cross-platform
+// section) — the capability probe lives in primitives_io's
+// maybeSetNonblocking: a host that rejects fd_fdstat_set_flags(NONBLOCK)
+// keeps its ports on blocking fds, so no EAGAIN, no registrations, and
+// this backend degrades to single-fiber blocking I/O with CLOCK-only
+// waits. That is exactly the playground's browser shim, which supports
+// only a single CLOCK subscription per call — satisfied here since no fd
+// can ever register there. wasmtime implements the full API.
 // ---------------------------------------------------------------------------
 
-const WasiBackend = struct {
-    fn init() !WasiBackend {
-        return .{};
+const WasiPollBackend = struct {
+    const wasi = std.os.wasi;
+
+    const Dirs = struct { read: bool, write: bool };
+
+    allocator: std.mem.Allocator,
+    /// fd → armed directions; the userspace stand-in for kernel knotes.
+    interests: std.AutoArrayHashMapUnmanaged(i32, Dirs) = .empty,
+    /// Scratch buffers rebuilt each wait(); persistent so they grow to the
+    /// working set once and stay there.
+    subs: std.ArrayList(wasi.subscription_t) = .empty,
+    events: std.ArrayList(wasi.event_t) = .empty,
+    ready: std.ArrayList(ReadyEvent) = .empty,
+
+    fn init(allocator: std.mem.Allocator) !WasiPollBackend {
+        return .{ .allocator = allocator };
     }
 
-    fn deinit(self: *WasiBackend) void {
-        _ = self;
+    fn deinit(self: *WasiPollBackend) void {
+        self.interests.deinit(self.allocator);
+        self.subs.deinit(self.allocator);
+        self.events.deinit(self.allocator);
+        self.ready.deinit(self.allocator);
     }
 
-    fn arm(self: *WasiBackend, fd: i32, wants_read: bool, wants_write: bool, first_time: bool) !void {
-        _ = self;
-        _ = fd;
-        _ = wants_read;
-        _ = wants_write;
-        _ = first_time;
-        return error.Unexpected;
-    }
-
-    fn disarmAll(self: *WasiBackend, fd: i32) void {
-        _ = self;
-        _ = fd;
-    }
-
-    fn wait(self: *WasiBackend, timeout_ns: ?u64) ![]const ReadyEvent {
-        _ = self;
-        if (timeout_ns) |ns| {
-            var ts: std.c.timespec = .{
-                .sec = @intCast(ns / 1_000_000_000),
-                .nsec = @intCast(ns % 1_000_000_000),
-            };
-            while (true) {
-                const ret = std.c.nanosleep(&ts, &ts);
-                if (ret == 0) break;
-                if (std.posix.errno(ret) != .INTR) return error.Unexpected;
-            }
+    /// Both reactor call sites pass the fd's complete desired state
+    /// (register: the current waiter lists; poll's re-arm: what remains
+    /// after a fire), so this replaces rather than accumulates — epoll's
+    /// CTL_MOD, minus the kernel. `first_time` is irrelevant: there is no
+    /// kernel registry to ADD-versus-MOD against.
+    fn arm(self: *WasiPollBackend, fd: i32, wants_read: bool, wants_write: bool, _: bool) !void {
+        if (!wants_read and !wants_write) {
+            _ = self.interests.swapRemove(fd);
+            return;
         }
-        return &[_]ReadyEvent{};
+        try self.interests.put(self.allocator, fd, .{ .read = wants_read, .write = wants_write });
+    }
+
+    fn disarmAll(self: *WasiPollBackend, fd: i32) void {
+        _ = self.interests.swapRemove(fd);
+    }
+
+    fn subFd(fd: i32, comptime tag: wasi.eventtype_t) wasi.subscription_t {
+        return .{
+            // The fd, not a fiber pointer — same discipline as kqueue's
+            // udata/epoll's data.fd (a collected fiber must never be
+            // reachable from a stale host event).
+            .userdata = @intCast(fd),
+            .u = .{ .tag = tag, .u = switch (tag) {
+                .FD_READ => .{ .fd_read = .{ .fd = fd } },
+                .FD_WRITE => .{ .fd_write = .{ .fd = fd } },
+                else => @compileError("subFd is for fd subscriptions"),
+            } },
+        };
+    }
+
+    fn wait(self: *WasiPollBackend, timeout_ns: ?u64) ![]const ReadyEvent {
+        self.subs.clearRetainingCapacity();
+        var it = self.interests.iterator();
+        while (it.next()) |entry| {
+            const fd = entry.key_ptr.*;
+            if (entry.value_ptr.read) try self.subs.append(self.allocator, subFd(fd, .FD_READ));
+            if (entry.value_ptr.write) try self.subs.append(self.allocator, subFd(fd, .FD_WRITE));
+        }
+        if (timeout_ns) |ns| {
+            // Relative (flags = 0), not ABSTIME: the reactor core already
+            // reduced the timer heap's nearest deadline to a relative
+            // bound in effectiveTimeout(), same as the kqueue timespec and
+            // epoll ms paths. Re-deriving an absolute deadline here would
+            // just add a clock read and couple this code to clockNs()'s
+            // clock domain. Nanosecond-native, so no ceil-rounding is
+            // needed (the epoll-only concern of resolved question 2);
+            // "may fire late, never early" holds either way.
+            try self.subs.append(self.allocator, .{
+                .userdata = 0,
+                .u = .{ .tag = .CLOCK, .u = .{ .clock = .{
+                    .id = .MONOTONIC,
+                    .timeout = ns,
+                    .precision = 0,
+                    .flags = 0,
+                } } },
+            });
+        }
+        // No subscriptions means no bound and nothing armed: poll_oneoff
+        // rejects nsubscriptions == 0 (INVAL). Unreachable through the
+        // scheduler — parkOnReactor checks isEmpty() first — so this is
+        // only a direct-caller guard; an empty return beats a hard error.
+        if (self.subs.items.len == 0) return &[_]ReadyEvent{};
+
+        try self.events.ensureTotalCapacity(self.allocator, self.subs.items.len);
+        self.events.items.len = self.subs.items.len;
+        var nevents: usize = 0;
+        const rc = wasi.poll_oneoff(&self.subs.items[0], &self.events.items[0], self.subs.items.len, &nevents);
+        switch (rc) {
+            .SUCCESS => {},
+            .INTR => return &[_]ReadyEvent{},
+            else => return error.Unexpected,
+        }
+
+        self.ready.clearRetainingCapacity();
+        outer: for (self.events.items[0..nevents]) |ev| {
+            // Timer expiry is decided by the reactor against clockNs()
+            // (popExpiredTimers); the CLOCK event only ends the wait.
+            if (ev.type == .CLOCK) continue;
+            const fd: i32 = @intCast(ev.userdata);
+            // A per-subscription error (BADF on a raced-away fd, rights)
+            // or hangup wakes both directions defensively — the retried
+            // syscall surfaces the real outcome, and retrying a
+            // not-actually-ready direction is always safe under the
+            // park-and-retry protocol (same policy as epoll's HUP/ERR).
+            const broken = ev.@"error" != .SUCCESS or
+                (ev.fd_readwrite.flags & wasi.EVENT_FD_READWRITE_HANGUP) != 0;
+            const readable = ev.type == .FD_READ or broken;
+            const writable = ev.type == .FD_WRITE or broken;
+            self.clearInterest(fd, readable, writable);
+            for (self.ready.items) |*re| {
+                if (re.fd == fd) {
+                    if (readable) re.readable = true;
+                    if (writable) re.writable = true;
+                    continue :outer;
+                }
+            }
+            try self.ready.append(self.allocator, .{ .fd = fd, .readable = readable, .writable = writable });
+        }
+        return self.ready.items;
+    }
+
+    /// The ONESHOT half of the emulation: a delivered direction disarms
+    /// itself, so the next wait() cannot re-report it unless the reactor
+    /// re-arms (kqueue's per-filter knote deletion, not epoll's whole-fd
+    /// disarm — an untouched direction stays armed for its own waiters).
+    fn clearInterest(self: *WasiPollBackend, fd: i32, readable: bool, writable: bool) void {
+        const dirs = self.interests.getPtr(fd) orelse return;
+        if (readable) dirs.read = false;
+        if (writable) dirs.write = false;
+        if (!dirs.read and !dirs.write) _ = self.interests.swapRemove(fd);
     }
 };

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -615,6 +615,13 @@ const WasiPollBackend = struct {
         }
 
         self.ready.clearRetainingCapacity();
+        // Reserved before the loop runs any clearInterest: a fallible
+        // append after an interest was disarmed would consume the event
+        // without delivering it — the waiter would never be woken and
+        // never re-armed (the same consumed-but-undelivered invariant
+        // Reactor.poll guards with its own up-front ensureUnusedCapacity).
+        // Dedup can only shrink the count, so nevents bounds the appends.
+        try self.ready.ensureTotalCapacity(self.allocator, nevents);
         outer: for (self.events.items[0..nevents]) |ev| {
             // Timer expiry is decided by the reactor against clockNs()
             // (popExpiredTimers); the CLOCK event only ends the wait.
@@ -637,7 +644,7 @@ const WasiPollBackend = struct {
                     continue :outer;
                 }
             }
-            try self.ready.append(self.allocator, .{ .fd = fd, .readable = readable, .writable = writable });
+            self.ready.appendAssumeCapacity(.{ .fd = fd, .readable = readable, .writable = writable });
         }
         return self.ready.items;
     }

--- a/tests/wasm/timers.scm
+++ b/tests/wasm/timers.scm
@@ -1,0 +1,63 @@
+;;; Kaappi WASM timer test (KEP-0001 Phase 4).
+;;; Exercises the WASI reactor backend's CLOCK subscription under a real
+;;; WASI runtime: thread-sleep! parks the fiber on the reactor's timer
+;;; heap, and the scheduler's blocking wait is a poll_oneoff call bounded
+;;; by the nearest deadline. Any FAIL line (or a hang) fails CI.
+
+(define failures 0)
+(define (check label ok)
+  (display (if ok "PASS " "FAIL "))
+  (display label)
+  (newline)
+  (if (not ok) (set! failures (+ failures 1))))
+
+(define (now-seconds)
+  (/ (current-jiffy) (jiffies-per-second)))
+
+;; Main-fiber sleep: the current fiber drives the scheduler in place and
+;; the reactor waits out the deadline. Never wakes early.
+(define t0 (now-seconds))
+(thread-sleep! 0.15)
+(check "main-fiber sleep waits out the full duration"
+       (>= (- (now-seconds) t0) 0.15))
+
+;; Zero and negative durations return immediately (no reactor round trip).
+(define t1 (now-seconds))
+(thread-sleep! 0)
+(thread-sleep! -1)
+(check "zero/negative sleep returns immediately"
+       (< (- (now-seconds) t1) 0.1))
+
+;; Two sleeping fibers park on the same timer heap; the nearer deadline
+;; wakes first regardless of spawn order.
+(define order '())
+(define slow (spawn (lambda ()
+                      (thread-sleep! 0.08)
+                      (set! order (cons 'slow order)))))
+(define fast (spawn (lambda ()
+                      (thread-sleep! 0.02)
+                      (set! order (cons 'fast order)))))
+(fiber-join slow)
+(fiber-join fast)
+(check "nearer deadline wakes first" (equal? (reverse order) '(fast slow)))
+
+;; A sleeping fiber must not stall a runnable sibling: the worker finishes
+;; its (yield-punctuated) loop while the sleeper is still parked.
+(define progress 0)
+(define sleeper (spawn (lambda () (thread-sleep! 0.1) progress)))
+(define worker (spawn (lambda ()
+                        (let loop ((i 0))
+                          (if (< i 5)
+                              (begin (set! progress (+ progress 1))
+                                     (yield)
+                                     (loop (+ i 1)))
+                              'done)))))
+(define worker-result (fiber-join worker))
+(check "sleeping fiber does not block a runnable sibling"
+       (and (equal? worker-result 'done)
+            (= progress 5)
+            (= (fiber-join sleeper) 5)))
+
+(if (> failures 0)
+    (begin (display "TIMER TESTS FAILED") (newline) (exit 1))
+    (begin (display "all timer tests passed") (newline)))


### PR DESCRIPTION
Implements #1442 (KEP-0001 Phase 4). Design: [KEP-0001 §2](https://github.com/kaappi/keps/blob/main/keps/0001-event-loop-reactor.md#2-backends).

## What

- **`WasiPollBackend`** replaces the timer-only stopgap in `src/reactor.zig`. `poll_oneoff` is stateless, so the backend keeps the kernel's bookkeeping in userspace: `arm()` records armed directions per fd in an interest map, and every `wait()` rebuilds the subscription list from it — one `FD_READ`/`FD_WRITE` subscription per armed direction plus one `CLOCK` subscription bounding the wait (the `mio` wasi model). Returned events map back to registrations by fd via `userdata`; per-subscription errors and `HANGUP` wake both directions defensively (same policy as epoll `HUP`/`ERR`); a delivered direction disarms itself for ONESHOT parity (per-filter, like kqueue — an untouched direction stays armed for its own waiters).
- **`maybeSetNonblocking` is the WASI host-capability probe**: it now attempts `fd_fdstat_set_flags(NONBLOCK)`, and the three `is_wasm` EAGAIN gates in `primitives_io.zig` are removed. A host that refuses the flip keeps ports blocking — no EAGAIN, no fd registrations, CLOCK-only waits — degrading to single-fiber blocking I/O exactly where the host lacks support, per the KEP's cross-platform section.
- **`thread-sleep!` registers on WASM** (the one SRFI-18 entry point with no OS-thread dependency), making the timer path Scheme-visible there. The WASM spec table is a comptime-filtered `wasm_specs` subset; since that forces the whole file to compile on wasm32-wasi, `threadStartFn`'s `std.Thread.spawn` moved behind a comptime branch and the `u64 signal_generation` atomics (wasm32 has no 64-bit atomics; the build is single-threaded) take a plain-access branch. The `(srfi 18)` library itself stays native-only; native behavior is unchanged.
- **`tests/wasm/timers.scm`** runs under wasmtime in the CI wasm job.

## Design deviations from the issue text

- **Relative `CLOCK`, not ABSTIME.** The issue (quoting the KEP sketch) says ABSTIME at the nearest deadline, but the Phase 1 reactor core already reduces the timer heap's nearest deadline to a *relative* bound in `effectiveTimeout()` for all backends. ABSTIME here would re-derive the absolute deadline it came from, add a clock read per poll, and couple the backend to `clockNs()`'s clock domain. Behavior is identical ("may fire late, never early").
- **Fd path is dormant on today's WASM builds**: `open-input-file`/`open-output-file` are native-only, so no fd>2 port can exist on WASM yet. The fd half of the backend is compile-verified and engages the day file/socket ports land there.

## Playground

Unaffected, verified against the shim source (`wasi-shim-bundle.mjs`): its `poll_oneoff` accepts only a single CLOCK subscription — which is all it can ever receive, because its `fd_fdstat_set_flags` returns NOTSUP, so no port ever goes non-blocking in the browser and no fd subscription can exist. `poll_oneoff` was already in the import set (wasi-libc implements the old stopgap's `nanosleep` through it). `thread-sleep!` becomes *callable* in the playground (previously an unbound-variable error); the shim serves it with its pre-existing busy-wait loop, stalling only the worker thread.

## Verification

- `zig build test` green (macOS native); `zig build -Dtarget=x86_64-linux` compiles (epoll backend init-signature change)
- `bash tests/scheme/run-all.sh`: 1834 pass, 0 fail; R7RS 1395/1395
- `zig build wasm` green; `wasmtime run` on `tests/wasm/smoke.scm` and `tests/wasm/timers.scm` both pass
- Timer test timing: 0.03 s CPU over 0.4 s wall — the process genuinely blocks in `poll_oneoff` during sleeps instead of spinning

Closes #1442

🤖 Generated with [Claude Code](https://claude.com/claude-code)