### PR TITLE
KEP-0001 Phase 7: performance evaluation, edge-triggered go/no-go, thread-sleep! fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ zig build run -- --version         # show version string
 zig build test                     # run all unit tests
 zig build test -Dtest-filter=tests_io  # only tests whose names match (repeatable)
 zig build bench                    # call/cc vs call/ec capture micro-benchmark
+zig build bench-fibers              # per-fiber switch time, RSS, register/frame footprint (KEP-0001 P7)
+zig build bench-reactor             # reactor ONESHOT re-arm, wake-all, timer-granularity costs (KEP-0001 P7)
 zig build coverage                 # unit test code coverage (requires kcov)
 zig build coverage-scheme -- f.scm # Scheme file code coverage (requires kcov)
 zig build -Dbundle-src=program.scm # standalone binary (compile + embed in one step)

--- a/build.zig
+++ b/build.zig
@@ -202,6 +202,34 @@ pub fn build(b: *std.Build) void {
     const bench_step = b.step("bench", "Run the call/cc capture benchmark");
     bench_step.dependOn(&run_bench.step);
 
+    // Benchmark executable (per-fiber memory & switch-time, KEP-0001 P7 Q5)
+    const bench_fibers_mod = kaappiModule(b, options_mod, .{
+        .root = "src/bench_fibers.zig",
+        .target = target,
+        .optimize = optimize,
+    });
+    const bench_fibers_exe = b.addExecutable(.{
+        .name = "bench-fibers",
+        .root_module = bench_fibers_mod,
+    });
+    const run_bench_fibers = b.addRunArtifact(bench_fibers_exe);
+    const bench_fibers_step = b.step("bench-fibers", "Run the per-fiber memory & switch-time benchmark");
+    bench_fibers_step.dependOn(&run_bench_fibers.step);
+
+    // Benchmark executable (reactor wake-all/re-arm/timer costs, KEP-0001 P7 Q1/Q2/Q3)
+    const bench_reactor_mod = kaappiModule(b, options_mod, .{
+        .root = "src/bench_reactor.zig",
+        .target = target,
+        .optimize = optimize,
+    });
+    const bench_reactor_exe = b.addExecutable(.{
+        .name = "bench-reactor",
+        .root_module = bench_reactor_mod,
+    });
+    const run_bench_reactor = b.addRunArtifact(bench_reactor_exe);
+    const bench_reactor_step = b.step("bench-reactor", "Run the reactor wake-all/re-arm/timer benchmark");
+    bench_reactor_step.dependOn(&run_bench_reactor.step);
+
     // Package manager (thottam)
     const thottam_mod = kaappiModule(b, options_mod, .{
         .root = "src/thottam.zig",

--- a/docs/dev/kep-0001-phase7-benchmarks.md
+++ b/docs/dev/kep-0001-phase7-benchmarks.md
@@ -1,0 +1,313 @@
+# KEP-0001 Phase 7: Performance Evaluation
+
+Tracking issue: [#1445](https://github.com/kaappi/kaappi/issues/1445). Epic:
+[#1438](https://github.com/kaappi/kaappi/issues/1438). Phases 1–6 are merged;
+this phase measures the reactor's real-world costs and confirms (or
+overturns, with data) the design decisions recorded in [keps#2](https://github.com/kaappi/keps/pull/2).
+
+All benchmark sources live in `src/bench_reactor.zig` (Q1/Q2/Q3, run with
+`zig build bench-reactor`) and `src/bench_fibers.zig` (Q5, run with
+`zig build bench-fibers`). Server benchmarks used a one-off load generator
+(no `wrk`/`hey`/`ab` available in this workspace) — see the ecosystem
+benchmark section below for how to reproduce.
+
+## Summary
+
+| Question | Decision | Confirmed? |
+|---|---|---|
+| Q1 — wake-all herd cost | Wake-all (not wake-head-only) | **Confirmed** — no measurable herd cost at the reactor level |
+| Q2 — timer granularity | ms + ceil-round on Linux, no `timerfd` | **Confirmed** — no workload needs sub-ms precision |
+| Q3 — ONESHOT vs LT | ONESHOT | **Confirmed** — re-arm cost is well under the cost of the adjacent I/O syscall it accompanies |
+| Q5 — per-fiber memory | Live-window save/restore | **Partially confirmed** — memory is bounded and modest, but per-switch *time* degrades with total live-fiber count (see below) — the actual residual this phase was meant to surface |
+| Edge-triggered migration | — | **No-go for now** (see below) |
+
+Prerequisite fix landed before any of this could be measured safely: see
+"Prerequisite: #1463" below.
+
+## Q1 — Wake-all herd cost
+
+`src/bench_reactor.zig`'s `benchWakeAllFanout`: N fake fibers registered as
+waiters on one shared fd, one real write, measuring how long `poll()` takes
+to wake all N (confirming wake-all, not wake-head-only).
+
+macOS (kqueue):
+
+| N | woken | poll (ns) | ns/woken-fiber |
+|---|---|---|---|
+| 2 | 2 | 2000 | 1000.0 |
+| 10 | 10 | 2000 | 200.0 |
+| 100 | 100 | 1000 | 10.0 |
+| 1000 | 1000 | 4000 | 4.0 |
+
+Linux (epoll, aarch64 container):
+
+| N | woken | poll (ns) | ns/woken-fiber |
+|---|---|---|---|
+| 2 | 2 | 3584 | 1792.0 |
+| 10 | 10 | 1542 | 154.2 |
+| 100 | 100 | 2125 | 21.3 |
+| 1000 | 1000 | 10500 | 10.5 |
+
+`poll()`'s own wake-all fan-out cost does **not** grow with N — it's
+dominated by a small fixed per-call cost (array copy), not a per-waiter one.
+The KEP's wake-head-only-FIFO fallback is not warranted at the reactor
+level. (The real per-waiter cost of wake-all — every registered fiber
+retrying its syscall and only one winning — is an *application*-level
+tradeoff, not a reactor one; see the fiber HTTP server latency numbers
+below, where it plausibly contributes at high concurrency.)
+
+## Q2 — Timer granularity
+
+`src/bench_reactor.zig`'s `benchTimerGranularity`: schedules one timer at a
+known deadline, measures how late `poll()` actually returns.
+
+macOS (kqueue, ns-precision `timespec` API):
+
+| requested | late by |
+|---|---|
+| 1ms | +133µs |
+| 5ms | +631µs |
+| 20ms | +1033µs |
+| 100ms | +1018µs |
+
+Linux (epoll, in a podman/QEMU-virtualized container — expect extra jitter
+from virtualization on top of the numbers below):
+
+| requested | late by |
+|---|---|
+| 1ms | +260µs |
+| 5ms | +215µs |
+| 20ms | +660µs |
+| 100ms | +2412µs |
+
+Two things worth noting: (1) even kqueue's nanosecond-precision timer API
+shows a practical floor around ~1ms once the requested duration is more
+than a few ms — this is OS thread-scheduling wake-up latency, not a kaappi
+limitation, and it means kqueue's theoretical precision advantage over
+epoll's ms-ceil-rounding (`msFromNs`, `src/reactor.zig:487-491`) mostly
+doesn't show up in practice. (2) A grep across the test suites and
+ecosystem repos (`kaappi-net`, `kaappi-pg`, `kaappi-http`) found no
+`thread-sleep!` interval below 1ms in real (non-microbenchmark) code — the
+Q2 decision holds: nothing in this codebase needs sub-ms deadlines, so the
+`timerfd` escape hatch stays unbuilt.
+
+## Q3 — ONESHOT re-arm cost
+
+`src/bench_reactor.zig`'s `benchRearmVsIo`: 100,000 cycles of `register()`
+(the `epoll_ctl`/`kevent` call) vs. an adjacent `read(2)`+`write(2)` pair on
+the same pipe.
+
+| Backend | register() (arm) | read+write (io) | ratio |
+|---|---|---|---|
+| macOS (kqueue) | 338.5 ns | 442.1 ns | 0.77x |
+| Linux (epoll) | 173.8 ns | 372.9 ns | 0.47x |
+| Linux, wake-all fan-out with an OS-thread instead of a fiber (not measured) | — | — | — |
+
+On both platforms the re-arm call is *cheaper* than the I/O syscall pair
+it accompanies every cycle. There is no meaningful overhead here for
+edge-triggered mode to eliminate.
+
+## Q5 — Per-fiber memory and switch time
+
+`src/bench_fibers.zig`. Three things were measured: raw switch/spawn cost
+at scale, RSS, and whether the native-frame `frameWindow()` fallback
+(`types.zig:546-551`, 256 registers for any frame with no attached
+closure) measurably inflates a fiber's saved register/frame arrays.
+
+### Switch time degrades with total live-fiber count
+
+Spawning N fibers, each yielding 50 times in a tight loop, then joining all:
+
+| fibers | ns/switch | RSS |
+|---|---|---|
+| 100 | ~465 ns | +0 MB |
+| 1,000 | ~3,300–4,600 ns | +0 MB |
+| 10,000 | ~93,000–99,000 ns | +0.06 MB |
+
+Consistent across three separate runs. Isolating spawn cost alone (0 yield
+rounds, just N `spawn` + `fiber-join` pairs) shows the same shape: ~10–30
+µs/spawn at 100–1,000 fibers, jumping to ~250–280 µs/spawn at 10,000.
+
+**Root cause**: `FiberScheduler.schedule()` (`src/fiber.zig:302-325`) does a
+full round-robin scan over *every* slot in `sched.fibers.items` (including
+completed/errored ones still occupying a slot) to find the next runnable
+fiber — O(fiber count) per dispatch, called on every single switch.
+`FiberScheduler.addFiber()` (`src/fiber.zig:86-99`) does the same kind of
+O(fiber count) linear scan for a free slot on every spawn. Per-fiber
+memory itself stays flat and modest (the RSS deltas above are noise-level
+until 10k, where it's still only +0.06MB) — it's *switch time*, not memory,
+that's the real Q5 residual, and it degrades by roughly two orders of
+magnitude between 100 and 10,000 concurrently-live fibers.
+
+This is not just a synthetic-benchmark artifact — it shows up end-to-end in
+the HTTP server benchmarks below (`http-listen-fiber`'s p99 latency at
+1,000 concurrent connections is *worse* than the naive sequential server's).
+**Follow-up filed**: replacing the O(n) scan with an actual ready queue
+(the KEP's Q1 discussion already floated "wake-head-only FIFO" for a
+related reason — this is the same class of fix).
+
+### Native-frame register/frame inflation: not observed
+
+Compared fibers yielding from a pure-bytecode tail loop against fibers
+yielding from inside `for-each`'s native call frame, across recursion
+depths 0, 10, 60, and 300 (with up to 7 extra bound locals per frame to
+vary register pressure). In every configuration tested, both kinds
+allocated identical register/frame array sizes (e.g. 256 registers / 32
+frames at shallow depth, growing identically to 4096/512 at depth 300 with
+extra locals). **No inflation was observed in practice** across this
+range — the initial per-fiber capacities (`INITIAL_FIBER_REGISTER_CAPACITY
+= 256`, `INITIAL_FIBER_FRAME_CAPACITY = 32`, `types.zig:527-528`) appear to
+already absorb the native-frame fallback's window without forcing a
+reallocation in these scenarios, or the outer non-tail call chain's own
+register usage already dominates whatever the native frame's flat 256
+contributes. This is a genuine null result, not a methodology gap that
+was worked around — three different attempts at making the two cases
+diverge (shallow, deep, and register-heavy-deep) all showed no difference.
+A more surgical Zig-level instrumentation of `liveRegisterSpan` directly
+would be needed to fully rule out inflation in *all* possible call shapes,
+but nothing tested here found it.
+
+## Edge-triggered migration: **no-go for now**
+
+The KEP is explicit that migrating to `EPOLLET`/`EV_CLEAR` should not be
+done without a soak test, since edge-triggering without strict drain
+discipline hangs fibers. Given that constraint, this phase evaluates
+whether there's even a reason to take on that risk, rather than building
+and soak-testing a parallel backend under time pressure inside a
+measurement phase.
+
+The Q3 data above answers this directly: on both kqueue and epoll, the
+ONESHOT re-arm cost is *already cheaper* than the I/O syscall it
+accompanies (0.77x on macOS, 0.47x on Linux). There is no overhead left
+for edge-triggered mode to remove. **Recommendation: no-go.** Revisit only
+if future profiling under a real production workload shows re-arm cost
+actually dominating — nothing measured here suggests that will happen.
+
+## Ecosystem server benchmarks
+
+Compared `kaappi-http`'s four server models (`http-listen`,
+`http-listen-threaded`, `http-listen-prefork` with 4 workers,
+`http-listen-fiber`) at 1, 100, and 1,000 concurrent connections, one
+request per connection (`Connection: close`), against a trivial `"Hello,
+World!"` handler. No load-gen tool was available in this workspace, so a
+minimal Python client (threaded, one connection per request) was used
+instead — not a substitute for `wrk`, but sufficient to compare the four
+models against each other on the same client.
+
+**`http-listen-threaded` could not be benchmarked** — see "New bug found"
+below; it hangs on every request in this environment, confirmed
+pre-existing (reproduces on an unmodified `main` build, unrelated to any
+change in this phase).
+
+| model | concurrency | req/s | p50 | p99 | max | RSS |
+|---|---|---|---|---|---|---|
+| sequential | 1 | 3329 | 0.20ms | 4.45ms | 4.45ms | — |
+| sequential | 100 | 10103 | 7.32ms | 22.20ms | 24.34ms | — |
+| sequential | 1000 | 9707 | 14.65ms | 351.60ms | 372.29ms | 6.9 MB |
+| prefork (4w) | 1 | 3089 | 0.23ms | 3.86ms | 3.86ms | — |
+| prefork (4w) | 100 | 11016 | 6.06ms | 27.59ms | 29.20ms | — |
+| prefork (4w) | 1000 | 11142 | 15.24ms | 52.94ms | 92.91ms | 6.0 MB (parent only — 4 workers each hold their own heap, not counted) |
+| fiber | 1 | 747 | 1.25ms | 5.66ms | 5.66ms | — |
+| fiber | 100 | 9060 | 1.46ms | 48.48ms | 49.03ms | — |
+| fiber | 1000 | 8116 | 1.73ms | 490.24ms | 500.29ms | 15.3 MB |
+
+Two findings worth calling out:
+
+1. **`http-listen-fiber` pays a ~1ms tax on every request, even
+   uncontended** (conc=1 req/s is 747 vs. sequential's 3329 — 4.5x slower
+   for a single client with zero contention). This matches what the code
+   review at the start of this phase found: `fiber-recv`/`fiber-send`
+   (`kaappi-http/lib/kaappi/http/server.sld:105-119`) poll the fd once and,
+   if not immediately ready, `(thread-sleep! 0.001)` before retrying —
+   which means the fiber server's I/O never actually registers with
+   `Reactor.register`/`waitForFd` at all (`kaappi-net`'s raw TCP fds never
+   reach `src/reactor.zig`); it's a fixed 1ms poll-then-sleep loop layered
+   on top, not real event-driven wakeup. **Follow-up filed**: wire
+   `kaappi-net`'s raw sockets into the reactor properly.
+
+2. **`http-listen-fiber`'s p99 at 1,000 concurrent connections (490ms) is
+   *worse* than the naive sequential server's (352ms)** — despite fibers
+   being the model designed for exactly this workload. This is the
+   FiberScheduler O(n) scan cost from the Q5 section above showing up
+   end-to-end: every read/write retry across 1,000 live connections pays
+   an ever-growing scheduling-scan tax. The reactor's own mechanics (Q1,
+   Q3) are not the bottleneck; the scheduler's dispatch-loop scan is.
+
+10,000-connection runs were not attempted locally — macOS's low default
+`ulimit -n` and the two findings above (which already show real
+degradation at 1,000) made a 10k run unlikely to produce more useful
+signal than cost. A dedicated Linux run would be the right way to get
+that data point once the two follow-ups above are addressed.
+
+### Reproducing
+
+```
+cd kaappi-http
+# terminal 1
+DYLD_LIBRARY_PATH=..:../../kaappi-net zig-out/bin/kaappi \
+  --lib-path ../kaappi-net/lib --lib-path lib bench_server_app.scm fiber
+# terminal 2 (no wrk/hey in this workspace -- see scratch script in this PR's description)
+python3 http_load_gen.py 19999 1000 5000
+```
+
+## New bug found: `http-listen-threaded` hangs (pre-existing)
+
+While setting up the server benchmarks, `http-listen-threaded` hung on
+every single request — confirmed to reproduce on an unmodified `main`
+build (stashed this phase's changes and rebuilt to verify), so it
+predates this phase and is unrelated to the `#1463` fix below.
+
+**Minimal repro**: a `define-library`-defined procedure that calls
+`thread-start!` with a thunk which itself calls into *another* library's
+exported procedure (here, `(kaappi http parse)`'s `make-http-buffer` /
+`http-read-request`) hangs the child OS thread — it never gets past that
+call. The *identical* code, with the exact same imports, hangs only when
+the calling procedure is defined inside a library body; moved verbatim to
+top-level script code, it works correctly. Bisected imports
+(`(kaappi fibers)`, `(kaappi ffi)`, `(kaappi http net)` vs. `(kaappi net)`
+directly) ruled those out — the only remaining variable is
+library-body-defined vs. top-level-defined for the thread-spawning
+procedure itself.
+
+This points at something in how a child OS thread's VM
+(`VM.initForThread`, which shares the parent's globals/libraries) resolves
+bindings for a closure whose *defining* environment is a library body,
+when that closure calls into a second library's procedure from inside the
+child thread. Root-causing and fixing this fully is a separate, deeper
+investigation than this benchmarking phase — filing as a follow-up rather
+than fixing here.
+
+## Prerequisite: #1463 (fixed this phase)
+
+`thread-sleep!` (`src/primitives_srfi18.zig`) lacked the
+`dispatched_from_scheduler`-aware yield-retry branch `fiber.waitForFd` has
+(`src/fiber.zig:552-576`) — a scheduler-dispatched fiber calling
+`thread-sleep!` always drove the scheduler recursively instead of
+unwinding flatly, so concurrent fibers each retrying via short
+`thread-sleep!` calls grew the native call stack without bound. Confirmed
+via a regression test that segfaults (stack overflow) without the fix and
+passes with it (`src/tests_srfi18.zig`). This was a **necessary
+prerequisite** for this phase: `http-listen-fiber`'s
+`fiber-recv`/`fiber-send` use exactly this poll-then-`thread-sleep!`
+pattern, and benchmarking it at any real concurrency (as confirmed by a
+500- and 1,000-concurrent-connection stress test after the fix) would
+very likely have hung or crashed instead of producing numbers.
+
+## Follow-ups to file
+
+1. `FiberScheduler.schedule()`/`addFiber()` O(fiber count) scans don't
+   scale past ~1,000 concurrently-live fibers — replace with an O(1)/O(log
+   n) ready-queue design. Directly explains the `http-listen-fiber` p99
+   regression above.
+2. Wire `kaappi-net`'s raw TCP sockets into `Reactor.register`/`waitForFd`
+   properly, so `http-listen-fiber` gets genuine event-driven wakeup
+   instead of a fixed 1ms poll-then-sleep loop.
+3. `http-listen-threaded` hangs on every request — pre-existing,
+   reproducible, isolated to library-defined-procedure + cross-thread +
+   cross-library-call. Needs a deeper VM/threading investigation.
+4. `kaappi-net`'s `net.sld` and `kaappi-pg`'s `pg.sld` have comments noting
+   they avoid `thread-sleep!` in retry loops "until [the core] follow-up
+   lands" (referring to the same bug as #1463) — now that the core fix has
+   landed, those comments are stale and the workaround could be
+   revisited (low priority, not urgent since the `yield`-based workaround
+   already works).

--- a/docs/dev/kep-0001-phase7-benchmarks.md
+++ b/docs/dev/kep-0001-phase7-benchmarks.md
@@ -8,6 +8,8 @@ overturns, with data) the design decisions recorded in [keps#2](https://github.c
 All benchmark sources live in `src/bench_reactor.zig` (Q1/Q2/Q3, run with
 `zig build bench-reactor`) and `src/bench_fibers.zig` (Q5, run with
 `zig build bench-fibers`). Server benchmarks used a one-off load generator
+committed at
+[`kaappi-http/benchmarks/`](https://github.com/kaappi/kaappi-http/tree/main/benchmarks)
 (no `wrk`/`hey`/`ab` available in this workspace) — see the ecosystem
 benchmark section below for how to reproduce.
 
@@ -30,23 +32,27 @@ Prerequisite fix landed before any of this could be measured safely: see
 waiters on one shared fd, one real write, measuring how long `poll()` takes
 to wake all N (confirming wake-all, not wake-head-only).
 
+The result list is preallocated to N entries before the timed region starts,
+so the numbers below measure `poll()`'s own dispatch/fan-out work, not
+`ArrayList` growth.
+
 macOS (kqueue):
 
 | N | woken | poll (ns) | ns/woken-fiber |
 |---|---|---|---|
 | 2 | 2 | 2000 | 1000.0 |
-| 10 | 10 | 2000 | 200.0 |
+| 10 | 10 | 1000 | 100.0 |
 | 100 | 100 | 1000 | 10.0 |
-| 1000 | 1000 | 4000 | 4.0 |
+| 1000 | 1000 | 2000 | 2.0 |
 
 Linux (epoll, aarch64 container):
 
 | N | woken | poll (ns) | ns/woken-fiber |
 |---|---|---|---|
-| 2 | 2 | 3584 | 1792.0 |
-| 10 | 10 | 1542 | 154.2 |
-| 100 | 100 | 2125 | 21.3 |
-| 1000 | 1000 | 10500 | 10.5 |
+| 2 | 2 | 1291 | 645.5 |
+| 10 | 10 | 500 | 50.0 |
+| 100 | 100 | 792 | 7.9 |
+| 1000 | 1000 | 4084 | 4.1 |
 
 `poll()`'s own wake-all fan-out cost does **not** grow with N — it's
 dominated by a small fixed per-call cost (array copy), not a per-waiter one.
@@ -61,24 +67,29 @@ below, where it plausibly contributes at high concurrency.)
 `src/bench_reactor.zig`'s `benchTimerGranularity`: schedules one timer at a
 known deadline, measures how late `poll()` actually returns.
 
+The result list is checked to actually contain the fiber before its
+lateness is recorded (rather than trusting any `poll()` return to mean the
+timer fired), so a spurious wake or wall-clock oddity would surface as a
+hard error rather than a silently bogus number.
+
 macOS (kqueue, ns-precision `timespec` API):
 
 | requested | late by |
 |---|---|
-| 1ms | +133µs |
-| 5ms | +631µs |
-| 20ms | +1033µs |
-| 100ms | +1018µs |
+| 1ms | +254µs |
+| 5ms | +1264µs |
+| 20ms | +2007µs |
+| 100ms | +2014µs |
 
 Linux (epoll, in a podman/QEMU-virtualized container — expect extra jitter
 from virtualization on top of the numbers below):
 
 | requested | late by |
 |---|---|
-| 1ms | +260µs |
-| 5ms | +215µs |
-| 20ms | +660µs |
-| 100ms | +2412µs |
+| 1ms | +197µs |
+| 5ms | +144µs |
+| 20ms | +1420µs |
+| 100ms | +5151µs |
 
 Two things worth noting: (1) even kqueue's nanosecond-precision timer API
 shows a practical floor around ~1ms once the requested duration is more
@@ -99,13 +110,20 @@ the same pipe.
 
 | Backend | register() (arm) | read+write (io) | ratio |
 |---|---|---|---|
-| macOS (kqueue) | 338.5 ns | 442.1 ns | 0.77x |
-| Linux (epoll) | 173.8 ns | 372.9 ns | 0.47x |
-| Linux, wake-all fan-out with an OS-thread instead of a fiber (not measured) | — | — | — |
+| macOS (kqueue) | 339.7 ns | 441.2 ns | 0.77x |
+| Linux (epoll) | 171.9 ns | 347.3 ns | 0.49x |
 
 On both platforms the re-arm call is *cheaper* than the I/O syscall pair
 it accompanies every cycle. There is no meaningful overhead here for
 edge-triggered mode to eliminate.
+
+Caveat: the timed region includes `Reactor.register()`'s waiter-list
+bookkeeping and `removeWaiter()` (used here to reset state between cycles),
+not only the raw `epoll_ctl`/`kevent` syscall — so `arm_ns` is really "one
+register+remove cycle," slightly more than the syscall alone. `removeWaiter`
+is pure userspace `ArrayList.swapRemove` on a 1-element list, so its
+contribution is on the order of nanoseconds; it doesn't change the
+arm-vs-io conclusion.
 
 ## Q5 — Per-fiber memory and switch time
 
@@ -116,17 +134,35 @@ closure) measurably inflates a fiber's saved register/frame arrays.
 
 ### Switch time degrades with total live-fiber count
 
-Spawning N fibers, each yielding 50 times in a tight loop, then joining all:
+Spawning N fibers, each yielding 50 times in a tight loop, then joining all
+(`elapsed_ns` includes the surrounding source eval, spawn, join, and GC —
+see the caveat after the table):
 
 | fibers | ns/switch | RSS |
 |---|---|---|
-| 100 | ~465 ns | +0 MB |
-| 1,000 | ~3,300–4,600 ns | +0 MB |
-| 10,000 | ~93,000–99,000 ns | +0.06 MB |
+| 100 | ~416–470 ns | +0 MB |
+| 1,000 | ~3,000–4,600 ns | +0.03 MB |
+| 10,000 | ~17,700–99,000 ns | +0.09 MB |
 
-Consistent across three separate runs. Isolating spawn cost alone (0 yield
-rounds, just N `spawn` + `fiber-join` pairs) shows the same shape: ~10–30
-µs/spawn at 100–1,000 fibers, jumping to ~250–280 µs/spawn at 10,000.
+RSS is `ru_maxrss`, a process-lifetime high-water mark, not an independent
+per-row peak — later rows only show a nonzero delta once they need more
+than the largest row measured so far in that process already reached.
+Read the deltas as "additional peak beyond the running max," not
+per-N-in-isolation numbers.
+
+Consistent across four separate runs (the ns/switch range above spans all
+of them — the wide range at 10,000 fibers in particular reflects one run
+using `std.heap.DebugAllocator`, since replaced with `std.heap.c_allocator`
+for the allocation-bookkeeping overhead DebugAllocator otherwise adds
+directly to the timed region — 17.7ms is the corrected, post-fix number).
+Isolating spawn cost alone (0 yield rounds, just N `spawn` + `fiber-join`
+pairs) shows the same shape: ~18–32 µs/spawn at 100–1,000 fibers, jumping
+to ~310–320 µs/spawn at 10,000. This total includes non-switch overhead
+(source evaluation, list construction, GC) that a tighter benchmark would
+subtract via a matched baseline; the O(n) root cause below was confirmed
+independently by reading `FiberScheduler`'s source, not solely inferred
+from these numbers, so the conclusion doesn't depend on isolating the
+switch cost perfectly.
 
 **Root cause**: `FiberScheduler.schedule()` (`src/fiber.zig:302-325`) does a
 full round-robin scan over *every* slot in `sched.fibers.items` (including
@@ -135,7 +171,7 @@ fiber — O(fiber count) per dispatch, called on every single switch.
 `FiberScheduler.addFiber()` (`src/fiber.zig:86-99`) does the same kind of
 O(fiber count) linear scan for a free slot on every spawn. Per-fiber
 memory itself stays flat and modest (the RSS deltas above are noise-level
-until 10k, where it's still only +0.06MB) — it's *switch time*, not memory,
+until 10k, where it's still only +0.09MB) — it's *switch time*, not memory,
 that's the real Q5 residual, and it degrades by roughly two orders of
 magnitude between 100 and 10,000 concurrently-live fibers.
 
@@ -146,26 +182,59 @@ the HTTP server benchmarks below (`http-listen-fiber`'s p99 latency at
 (the KEP's Q1 discussion already floated "wake-head-only FIFO" for a
 related reason — this is the same class of fix).
 
-### Native-frame register/frame inflation: not observed
+### Native-frame register/frame inflation: inconclusive
 
-Compared fibers yielding from a pure-bytecode tail loop against fibers
-yielding from inside `for-each`'s native call frame, across recursion
-depths 0, 10, 60, and 300 (with up to 7 extra bound locals per frame to
-vary register pressure). In every configuration tested, both kinds
-allocated identical register/frame array sizes (e.g. 256 registers / 32
-frames at shallow depth, growing identically to 4096/512 at depth 300 with
-extra locals). **No inflation was observed in practice** across this
-range — the initial per-fiber capacities (`INITIAL_FIBER_REGISTER_CAPACITY
-= 256`, `INITIAL_FIBER_FRAME_CAPACITY = 32`, `types.zig:527-528`) appear to
-already absorb the native-frame fallback's window without forcing a
-reallocation in these scenarios, or the outer non-tail call chain's own
-register usage already dominates whatever the native frame's flat 256
-contributes. This is a genuine null result, not a methodology gap that
-was worked around — three different attempts at making the two cases
-diverge (shallow, deep, and register-heavy-deep) all showed no difference.
-A more surgical Zig-level instrumentation of `liveRegisterSpan` directly
-would be needed to fully rule out inflation in *all* possible call shapes,
-but nothing tested here found it.
+This comparison went through two designs; the first was wrong, and the
+second's result is honestly inconclusive rather than a clean negative.
+
+**First attempt (wrong): `for-each`.** Compared fibers yielding from a
+pure-bytecode tail loop against fibers yielding from inside `for-each`'s
+callback, across recursion depths 0–300. Both kinds always measured
+identically. The reason: `for-each` is pure bootstrap Scheme
+(`src/vm_bootstrap.zig`), not a Zig primitive — calling its callback never
+pushes a native frame at all, so both "bytecode" and "native" cases were
+exercising the same bytecode path the whole time.
+
+**Second attempt: `with-exception-handler`.** This one is a genuine native
+primitive (`src/primitives_control.zig`) that calls its thunk via
+`vm.callThunk` → `callReentrant` (`src/vm_calls.zig`), so it does push a
+real frame for the thunk's invocation. `yield` deliberately no-ops under
+`native_reentry_depth > 0` (`src/primitives_fiber.zig`, the #1184
+limitation this reflects), so `thread-sleep!` — which has no such
+re-entrancy guard — was used as the suspension point instead, in both the
+bytecode and native cases for a fair comparison.
+
+At the only configuration confirmed safe to run (N=1 fiber, depth-10
+non-tail recursion before the suspension point), both cases still measured
+identically: 256 registers / 32 frames. Two things stood in the way of a
+more conclusive test:
+
+1. At shallow depth, `liveRegisterSpan` never exceeds the 256-register
+   initial floor (`INITIAL_FIBER_REGISTER_CAPACITY`, `types.zig:527`) for
+   either case, so `registers.len` reads the same regardless of what's
+   "really" needed underneath that floor — the array simply never
+   reallocates.
+2. Pushing recursion deep enough to force a real reallocation (depth 100+)
+   crashed with a native stack overflow, even at just N=2 concurrently-
+   dispatched fibers. Nested `runUntil` calls clear
+   `dispatched_from_scheduler` for their extent (`src/vm_dispatch.zig:80-87`)
+   — the same mechanism that makes `yield` no-op under re-entrancy — so a
+   blocking `thread-sleep!` inside `with-exception-handler`'s thunk always
+   drives the scheduler recursively rather than flat-unwinding, and
+   concurrently-dispatched fibers each doing this chain-nest the native
+   stack. This is a narrower, previously-unknown variant of the same class
+   of problem `#1463` fixed (narrower because it specifically needs a
+   blocking call nested inside a re-entrant native frame, not just any
+   retry loop) — noted here rather than filed as its own follow-up, since
+   it's adjacent to the already-documented #1184 limitation and out of
+   scope for this measurement phase to fix.
+
+**Bottom line**: whether the 256-register fallback measurably inflates a
+fiber's footprint in practice remains an open question. Answering it
+properly needs either direct Zig-level instrumentation of
+`liveRegisterSpan` (bypassing the black-box register-array-size approach
+entirely) or a way to force deep recursion without a blocking call sitting
+inside the native frame — both out of scope here.
 
 ## Edge-triggered migration: **no-go for now**
 
@@ -178,7 +247,7 @@ measurement phase.
 
 The Q3 data above answers this directly: on both kqueue and epoll, the
 ONESHOT re-arm cost is *already cheaper* than the I/O syscall it
-accompanies (0.77x on macOS, 0.47x on Linux). There is no overhead left
+accompanies (0.77x on macOS, 0.49x on Linux). There is no overhead left
 for edge-triggered mode to remove. **Recommendation: no-go.** Revisit only
 if future profiling under a real production workload shows re-arm cost
 actually dominating — nothing measured here suggests that will happen.
@@ -241,13 +310,16 @@ that data point once the two follow-ups above are addressed.
 
 ### Reproducing
 
-```
+Server app and load generator committed at
+[`kaappi-http/benchmarks/`](https://github.com/kaappi/kaappi-http/tree/main/benchmarks):
+
+```sh
 cd kaappi-http
-# terminal 1
-DYLD_LIBRARY_PATH=..:../../kaappi-net zig-out/bin/kaappi \
-  --lib-path ../kaappi-net/lib --lib-path lib bench_server_app.scm fiber
-# terminal 2 (no wrk/hey in this workspace -- see scratch script in this PR's description)
-python3 http_load_gen.py 19999 1000 5000
+# terminal 1: model = sequential | threaded | prefork | fiber
+DYLD_LIBRARY_PATH=..:../kaappi-net kaappi \
+  --lib-path ../kaappi-net/lib --lib-path lib benchmarks/bench_server_app.scm fiber
+# terminal 2
+python3 benchmarks/http_load_gen.py 19999 1000 5000
 ```
 
 ## New bug found: `http-listen-threaded` hangs (pre-existing)
@@ -293,21 +365,33 @@ pattern, and benchmarking it at any real concurrency (as confirmed by a
 500- and 1,000-concurrent-connection stress test after the fix) would
 very likely have hung or crashed instead of producing numbers.
 
-## Follow-ups to file
+Hardening added during review: the fresh-call path now clears
+`me.deadline_ns` and removes the timer (`errdefer`) if `addTimer` or the
+subsequent scheduler drive fails (OOM-only today), so an error there can't
+leave the fiber's redispatch-vs-fresh-call discriminator in a stale state
+for its *next* `thread-sleep!` call. The `errdefer` explicitly excludes
+`error.Yielded`, since that's the intentional flat-unwind signal the
+discriminator exists to survive, not a real error to clean up after.
 
-1. `FiberScheduler.schedule()`/`addFiber()` O(fiber count) scans don't
+## Follow-ups (filed)
+
+1. [#1477](https://github.com/kaappi/kaappi/issues/1477) —
+   `FiberScheduler.schedule()`/`addFiber()` O(fiber count) scans don't
    scale past ~1,000 concurrently-live fibers — replace with an O(1)/O(log
    n) ready-queue design. Directly explains the `http-listen-fiber` p99
    regression above.
-2. Wire `kaappi-net`'s raw TCP sockets into `Reactor.register`/`waitForFd`
+2. [#1478](https://github.com/kaappi/kaappi/issues/1478) — wire
+   `kaappi-net`'s raw TCP sockets into `Reactor.register`/`waitForFd`
    properly, so `http-listen-fiber` gets genuine event-driven wakeup
    instead of a fixed 1ms poll-then-sleep loop.
-3. `http-listen-threaded` hangs on every request — pre-existing,
+3. [#1479](https://github.com/kaappi/kaappi/issues/1479) —
+   `http-listen-threaded` hangs on every request — pre-existing,
    reproducible, isolated to library-defined-procedure + cross-thread +
    cross-library-call. Needs a deeper VM/threading investigation.
-4. `kaappi-net`'s `net.sld` and `kaappi-pg`'s `pg.sld` have comments noting
-   they avoid `thread-sleep!` in retry loops "until [the core] follow-up
-   lands" (referring to the same bug as #1463) — now that the core fix has
+4. [#1480](https://github.com/kaappi/kaappi/issues/1480) — `kaappi-net`'s
+   `net.sld` and `kaappi-pg`'s `pg.sld` have comments noting they avoid
+   `thread-sleep!` in retry loops "until [the core] follow-up lands"
+   (referring to the same bug as #1463) — now that the core fix has
    landed, those comments are stale and the workaround could be
    revisited (low priority, not urgent since the `yield`-based workaround
    already works).

--- a/src/bench_fibers.zig
+++ b/src/bench_fibers.zig
@@ -1,0 +1,239 @@
+// Per-fiber memory and switch-time benchmark (KEP-0001 Phase 7, Q5 — the one
+// design question the KEP left fully open: "per-fiber memory → live-window
+// save/restore with small initial capacities; RSS/switch-time magnitude
+// measured in P7").
+//
+// Two things are measured:
+//
+//   1. RSS delta and per-yield switch time for N concurrently-live fibers
+//      (100 / 1k / 10k), each doing a minimal yield loop.
+//   2. Whether the 256-register frameWindow() fallback for native frames
+//      (types.zig:546-551 — a frame with no attached closure, e.g. mid-`for-each`,
+//      reports a flat 256-register window instead of its real usage) measurably
+//      inflates a fiber's saved register/frame arrays. Compared by spawning
+//      fibers that yield from a pure bytecode tail loop against fibers that
+//      yield from inside `for-each`'s native call frame.
+//
+// Build/run:  zig build bench-fibers
+//   (best with -Doptimize=ReleaseFast)
+
+const std = @import("std");
+const builtin = @import("builtin");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const vm_mod = @import("vm.zig");
+const primitives = @import("primitives.zig");
+const library = @import("library.zig");
+const fiber_mod = @import("fiber.zig");
+const Value = types.Value;
+
+fn nowNs() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+// Matches the layout `getrusage(2)` fills in on both Linux (glibc) and
+// Darwin: two `timeval`s (16 bytes each on both platforms' LP64 ABIs, even
+// though the field widths inside differ) followed by a run of `long`s. Only
+// `ru_maxrss` is read, so the rest is left as opaque padding.
+const RUsage = extern struct {
+    _times: [32]u8 = undefined,
+    ru_maxrss: i64 = 0,
+    _rest: [13 * 8]u8 = undefined,
+};
+extern "c" fn getrusage(who: c_int, usage: *RUsage) c_int;
+const RUSAGE_SELF: c_int = 0;
+
+fn rssMb() f64 {
+    var ru: RUsage = undefined;
+    _ = getrusage(RUSAGE_SELF, &ru);
+    // ru_maxrss is bytes on Darwin, KiB on Linux.
+    const divisor: f64 = if (builtin.os.tag == .macos) 1024.0 * 1024.0 else 1024.0;
+    return @as(f64, @floatFromInt(ru.ru_maxrss)) / divisor;
+}
+
+// Note: VM setup is inlined (not a shared helper) because vm_mod.setVMInstance
+// stores the address of the local `vm` in a threadlocal — a helper that
+// constructed `vm` and returned it by value would leave that threadlocal
+// dangling once the helper's stack frame unwound.
+
+const FiberFootprint = struct {
+    count: usize = 0,
+    registers_bytes_total: u64 = 0,
+    frames_bytes_total: u64 = 0,
+    registers_len_max: usize = 0,
+    frames_len_max: usize = 0,
+};
+
+/// Walks a Scheme list of fiber Values (as returned by `spawn-n` below),
+/// summing each fiber's *allocated* register/frame array sizes — the
+/// steady-state per-fiber footprint saveCurrentFiber grew it to, which
+/// persists after the fiber completes (arrays never shrink back down).
+fn fiberListFootprint(list: Value) FiberFootprint {
+    var fp = FiberFootprint{};
+    var cur = list;
+    while (types.isPair(cur)) {
+        const fiber_val = types.car(cur);
+        const fiber = types.toObject(fiber_val).as(fiber_mod.Fiber);
+        fp.count += 1;
+        fp.registers_bytes_total += fiber.registers.len * @sizeOf(Value);
+        fp.frames_bytes_total += fiber.frames.len * @sizeOf(types.CallFrame);
+        fp.registers_len_max = @max(fp.registers_len_max, fiber.registers.len);
+        fp.frames_len_max = @max(fp.frames_len_max, fiber.frames.len);
+        cur = types.cdr(cur);
+    }
+    return fp;
+}
+
+const SwitchBenchResult = struct {
+    n: u32,
+    rounds: u32,
+    elapsed_ns: u64,
+    rss_before_mb: f64,
+    rss_after_mb: f64,
+};
+
+/// Spawns `n` fibers, each yielding `rounds` times in a pure-bytecode tail
+/// loop, then joins them all. Measures wall time (-> per-switch time) and
+/// RSS delta.
+fn benchSwitchTime(allocator: std.mem.Allocator, n: u32, rounds: u32) !SwitchBenchResult {
+    var gc = memory.GC.init(allocator);
+    defer gc.deinit();
+    var vm = try vm_mod.VM.init(&gc);
+    defer vm.deinit();
+    vm_mod.setVMInstance(&vm);
+    memory.setGCInstance(&gc);
+    try primitives.registerAll(&vm);
+    try vm_mod.vm_bootstrap.install(&vm);
+    try library.registerStandardLibraries(&vm.libraries, vm.globals);
+
+    const rss_before = rssMb();
+
+    const src = try std.fmt.allocPrint(allocator,
+        \\(define (fiber-body)
+        \\  (let loop ((k 0)) (if (= k {d}) k (begin (yield) (loop (+ k 1))))))
+        \\(define (spawn-n n proc)
+        \\  (let loop ((i 0) (acc '()))
+        \\    (if (= i n) acc (loop (+ i 1) (cons (spawn proc) acc)))))
+        \\(define fibers (spawn-n {d} fiber-body))
+        \\(for-each fiber-join fibers)
+        \\(length fibers)
+    , .{ rounds, n });
+    defer allocator.free(src);
+
+    const start_ns = nowNs();
+    _ = try vm.eval(src);
+    const elapsed_ns = nowNs() - start_ns;
+
+    const rss_after = rssMb();
+
+    return .{ .n = n, .rounds = rounds, .elapsed_ns = elapsed_ns, .rss_before_mb = rss_before, .rss_after_mb = rss_after };
+}
+
+/// Spawns `n` fibers with the given body ("bytecode-only tail loop" vs
+/// "yields from inside for-each's native frame"), joins them, then inspects
+/// the fibers' own register/frame arrays directly (not via RSS, which is
+/// noisy at small N) to see whether frameWindow()'s 256-register fallback
+/// for native frames actually inflates the saved window.
+fn benchFootprint(allocator: std.mem.Allocator, n: u32, native_frame: bool) !FiberFootprint {
+    var gc = memory.GC.init(allocator);
+    defer gc.deinit();
+    var vm = try vm_mod.VM.init(&gc);
+    defer vm.deinit();
+    vm_mod.setVMInstance(&vm);
+    memory.setGCInstance(&gc);
+    try primitives.registerAll(&vm);
+    try vm_mod.vm_bootstrap.install(&vm);
+    try library.registerStandardLibraries(&vm.libraries, vm.globals);
+
+    // Non-tail recursion to depth 60 before the yield/native-call, so the
+    // active frame's `base` is well above 0 by the time it happens — a
+    // fair test needs the native frame's flat 256-register window to
+    // compete against a *non-zero* base, otherwise both cases trivially
+    // fit inside the 256-register initial capacity and "inflation" never
+    // shows up as a real reallocation.
+    const body_name = if (native_frame) "native-fiber-body" else "bytecode-fiber-body";
+    const src = try std.fmt.allocPrint(allocator,
+        \\(define (bytecode-fiber-body)
+        \\  (define (level d)
+        \\    (if (= d 0)
+        \\        (let loop ((k 0)) (if (= k 1) k (begin (yield) (loop (+ k 1)))))
+        \\        (begin (level (- d 1)) d)))
+        \\  (level 10))
+        \\(define (native-fiber-body)
+        \\  (define (level d)
+        \\    (if (= d 0)
+        \\        (for-each (lambda (x) (yield)) (iota 1))
+        \\        (begin (level (- d 1)) d)))
+        \\  (level 10))
+        \\(define (spawn-n n proc)
+        \\  (let loop ((i 0) (acc '()))
+        \\    (if (= i n) acc (loop (+ i 1) (cons (spawn proc) acc)))))
+        \\(define fibers (spawn-n {d} {s}))
+        \\(for-each fiber-join fibers)
+        \\fibers
+    , .{ n, body_name });
+    defer allocator.free(src);
+
+    const fibers_list = try vm.eval(src);
+    return fiberListFootprint(fibers_list);
+}
+
+pub fn main() !void {
+    var da = std.heap.DebugAllocator(.{}).init;
+    defer _ = da.deinit();
+    const allocator = da.allocator();
+
+    std.debug.print("=== Q5: spawn-only cost (0 yield rounds -- isolates FiberScheduler.addFiber) ===\n", .{});
+    std.debug.print("{s:>8} | {s:>14} | {s:>10}\n", .{ "fibers", "ns/spawn+join", "total ms" });
+    std.debug.print("---------+----------------+-----------\n", .{});
+    for ([_]u32{ 100, 1_000, 10_000 }) |n| {
+        const r = try benchSwitchTime(allocator, n, 0);
+        const ns_per = @as(f64, @floatFromInt(r.elapsed_ns)) / @as(f64, @floatFromInt(n));
+        std.debug.print("{d:>8} | {d:>14.1} | {d:>9.2}\n", .{ n, ns_per, @as(f64, @floatFromInt(r.elapsed_ns)) / 1e6 });
+    }
+
+    std.debug.print("\n=== Q5: per-fiber switch time & RSS ===\n", .{});
+    std.debug.print("{s:>8} | {s:>8} | {s:>12} | {s:>10} | {s:>10} | {s:>10}\n", .{ "fibers", "rounds", "ns/switch", "rss before", "rss after", "delta MB" });
+    std.debug.print("---------+----------+--------------+------------+------------+-----------\n", .{});
+    const ns_list = [_]u32{ 100, 1_000, 10_000 };
+    var switch_results: [ns_list.len]SwitchBenchResult = undefined;
+    for (ns_list, 0..) |n, i| {
+        const rounds: u32 = 50;
+        const r = try benchSwitchTime(allocator, n, rounds);
+        switch_results[i] = r;
+        const total_switches = @as(f64, @floatFromInt(n)) * @as(f64, @floatFromInt(rounds));
+        const ns_per_switch = @as(f64, @floatFromInt(r.elapsed_ns)) / total_switches;
+        std.debug.print("{d:>8} | {d:>8} | {d:>9.1} ns | {d:>7.2} MB | {d:>7.2} MB | {d:>7.2} MB\n", .{ n, rounds, ns_per_switch, r.rss_before_mb, r.rss_after_mb, r.rss_after_mb - r.rss_before_mb });
+    }
+
+    std.debug.print("\n=== Q5: does the 256-register native-frame fallback inflate per-fiber windows? ===\n", .{});
+    std.debug.print("{s:>8} | {s:>10} | {s:>14} | {s:>14} | {s:>10} | {s:>10}\n", .{ "fibers", "kind", "avg regs/fiber", "avg frames/fbr", "regs KB", "frames KB" });
+    std.debug.print("---------+------------+----------------+----------------+------------+-----------\n", .{});
+    const footprint_ns = [_]u32{ 100, 1_000 };
+    for (footprint_ns) |n| {
+        for ([_]bool{ false, true }) |native_frame| {
+            const fp = try benchFootprint(allocator, n, native_frame);
+            const avg_regs = @as(f64, @floatFromInt(fp.registers_bytes_total / @sizeOf(Value))) / @as(f64, @floatFromInt(fp.count));
+            const avg_frames = @as(f64, @floatFromInt(fp.frames_bytes_total / @sizeOf(types.CallFrame))) / @as(f64, @floatFromInt(fp.count));
+            std.debug.print("{d:>8} | {s:>10} | {d:>14.1} | {d:>14.1} | {d:>9.1} | {d:>9.1}\n", .{
+                n,
+                if (native_frame) "native" else "bytecode",
+                avg_regs,
+                avg_frames,
+                @as(f64, @floatFromInt(fp.registers_bytes_total)) / 1024.0,
+                @as(f64, @floatFromInt(fp.frames_bytes_total)) / 1024.0,
+            });
+        }
+    }
+
+    // Machine-readable summary lines, matching bench.zig's convention.
+    // Reuses the results already collected above instead of re-running the
+    // (expensive at 10k fibers -- see the O(n) FiberScheduler.schedule() scan
+    // noted in the write-up) switch-time benchmark a second time.
+    for (switch_results) |r| {
+        const secs = @as(f64, @floatFromInt(r.elapsed_ns)) / 1e9;
+        std.debug.print("name: fiber_switch_{d}, time: {d:.6}, status: ok, min: {d:.6}, max: {d:.6}, iterations: {d}\n", .{ r.n, secs, secs, secs, r.n * r.rounds });
+    }
+}

--- a/src/bench_fibers.zig
+++ b/src/bench_fibers.zig
@@ -6,19 +6,25 @@
 // Two things are measured:
 //
 //   1. RSS delta and per-yield switch time for N concurrently-live fibers
-//      (100 / 1k / 10k), each doing a minimal yield loop.
+//      (100 / 1k / 10k), each doing a minimal yield loop. RSS is reported
+//      via `ru_maxrss`, which is a *process-lifetime high-water mark*, not
+//      a per-call-site peak -- later rows in the same process run only show
+//      a nonzero delta once they need more than any earlier row already
+//      reached. Read the deltas as "additional peak RSS beyond what the
+//      largest case measured so far already required", not as independent
+//      per-N measurements.
 //   2. Whether the 256-register frameWindow() fallback for native frames
-//      (types.zig:546-551 — a frame with no attached closure, e.g. mid-`for-each`,
-//      reports a flat 256-register window instead of its real usage) measurably
+//      (types.zig:546-551 — a frame with no attached closure) measurably
 //      inflates a fiber's saved register/frame arrays. Compared by spawning
-//      fibers that yield from a pure bytecode tail loop against fibers that
-//      yield from inside `for-each`'s native call frame.
+//      fibers that suspend (via thread-sleep!) from plain bytecode against
+//      fibers that suspend from inside a genuinely native call frame
+//      (with-exception-handler's thunk invocation — see benchFootprint's
+//      doc comment for why `for-each` doesn't work for this).
 //
 // Build/run:  zig build bench-fibers
 //   (best with -Doptimize=ReleaseFast)
 
 const std = @import("std");
-const builtin = @import("builtin");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const vm_mod = @import("vm.zig");
@@ -33,24 +39,11 @@ fn nowNs() u64 {
     return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
 }
 
-// Matches the layout `getrusage(2)` fills in on both Linux (glibc) and
-// Darwin: two `timeval`s (16 bytes each on both platforms' LP64 ABIs, even
-// though the field widths inside differ) followed by a run of `long`s. Only
-// `ru_maxrss` is read, so the rest is left as opaque padding.
-const RUsage = extern struct {
-    _times: [32]u8 = undefined,
-    ru_maxrss: i64 = 0,
-    _rest: [13 * 8]u8 = undefined,
-};
-extern "c" fn getrusage(who: c_int, usage: *RUsage) c_int;
-const RUSAGE_SELF: c_int = 0;
-
 fn rssMb() f64 {
-    var ru: RUsage = undefined;
-    _ = getrusage(RUSAGE_SELF, &ru);
+    const ru = std.posix.getrusage(std.posix.rusage.SELF);
     // ru_maxrss is bytes on Darwin, KiB on Linux.
-    const divisor: f64 = if (builtin.os.tag == .macos) 1024.0 * 1024.0 else 1024.0;
-    return @as(f64, @floatFromInt(ru.ru_maxrss)) / divisor;
+    const divisor: f64 = if (@import("builtin").os.tag == .macos) 1024.0 * 1024.0 else 1024.0;
+    return @as(f64, @floatFromInt(ru.maxrss)) / divisor;
 }
 
 // Note: VM setup is inlined (not a shared helper) because vm_mod.setVMInstance
@@ -131,11 +124,48 @@ fn benchSwitchTime(allocator: std.mem.Allocator, n: u32, rounds: u32) !SwitchBen
     return .{ .n = n, .rounds = rounds, .elapsed_ns = elapsed_ns, .rss_before_mb = rss_before, .rss_after_mb = rss_after };
 }
 
-/// Spawns `n` fibers with the given body ("bytecode-only tail loop" vs
-/// "yields from inside for-each's native frame"), joins them, then inspects
+/// Spawns `n` fibers with the given body ("bytecode-only" vs. "suspends
+/// from inside a genuinely native call frame"), joins them, then inspects
 /// the fibers' own register/frame arrays directly (not via RSS, which is
 /// noisy at small N) to see whether frameWindow()'s 256-register fallback
 /// for native frames actually inflates the saved window.
+///
+/// `for-each` was tried first and discarded: it's pure bootstrap Scheme
+/// (`src/vm_bootstrap.zig`), not a Zig primitive, so calling its callback
+/// never pushes a native (`locals_count == 0`-flavored, see
+/// `CallFrame.frameWindow()`) frame at all -- both "bytecode" and "native"
+/// cases were exercising identical bytecode paths, which is why they always
+/// measured identically regardless of recursion depth.
+/// `with-exception-handler` (`src/primitives_control.zig`) is a genuine
+/// native primitive that calls its thunk via `vm.callThunk` ->
+/// `callReentrant` (`src/vm_calls.zig`), which pushes a real frame for the
+/// thunk closure and increments `native_reentry_depth`. `yield` deliberately
+/// no-ops under `native_reentry_depth > 0` (`src/primitives_fiber.zig`, the
+/// #1184 limitation), so `thread-sleep!` is used as the suspension point
+/// instead -- it has no such re-entrancy guard.
+///
+/// This still did not demonstrate measurable inflation, for two compounding
+/// reasons found during development (kept here rather than in the doc,
+/// since they're implementation-level detail about *this benchmark*, not a
+/// KEP-0001 finding): (1) at low concurrency and shallow recursion (N=1-5,
+/// depth 10) `liveRegisterSpan` never exceeds the 256-register initial
+/// floor for either case, so `registers.len` reads identically regardless
+/// of what's "really" needed underneath that floor; (2) pushing recursion
+/// deep enough to force a real reallocation (depth 100+) makes
+/// `thread-sleep!` inside `with-exception-handler`'s thunk crash with a
+/// native stack overflow even at just N=2 concurrently-dispatched fibers --
+/// nested `runUntil` calls clear `dispatched_from_scheduler`
+/// (`src/vm_dispatch.zig:80-87`) for their extent the same way they make
+/// `yield` no-op, so a blocking `thread-sleep!` there always drives the
+/// scheduler recursively rather than flat-unwinding, and concurrently-
+/// dispatched fibers each doing this chain-nest. This is a *different*,
+/// narrower version of the same class of problem #1463 fixed -- narrower
+/// because it needs a blocking call nested inside a re-entrant native frame
+/// specifically, not just any retry loop -- and is left unfixed here as
+/// out of scope for a measurement phase. Given this, N=1 and a shallow
+/// depth were kept as the only combination confirmed safe to run; the
+/// "no inflation observed" result below should be read as inconclusive
+/// (blind spot 1) rather than a clean negative.
 fn benchFootprint(allocator: std.mem.Allocator, n: u32, native_frame: bool) !FiberFootprint {
     var gc = memory.GC.init(allocator);
     defer gc.deinit();
@@ -147,24 +177,24 @@ fn benchFootprint(allocator: std.mem.Allocator, n: u32, native_frame: bool) !Fib
     try vm_mod.vm_bootstrap.install(&vm);
     try library.registerStandardLibraries(&vm.libraries, vm.globals);
 
-    // Non-tail recursion to depth 60 before the yield/native-call, so the
-    // active frame's `base` is well above 0 by the time it happens — a
-    // fair test needs the native frame's flat 256-register window to
-    // compete against a *non-zero* base, otherwise both cases trivially
-    // fit inside the 256-register initial capacity and "inflation" never
-    // shows up as a real reallocation.
+    // Non-tail recursion to depth 10 before the suspension point, so the
+    // active frame's `base` is above 0 by the time it happens. Kept shallow
+    // deliberately -- see the doc comment above for why deeper recursion
+    // here is unsafe to run.
     const body_name = if (native_frame) "native-fiber-body" else "bytecode-fiber-body";
     const src = try std.fmt.allocPrint(allocator,
         \\(define (bytecode-fiber-body)
         \\  (define (level d)
         \\    (if (= d 0)
-        \\        (let loop ((k 0)) (if (= k 1) k (begin (yield) (loop (+ k 1)))))
+        \\        (thread-sleep! 0.0001)
         \\        (begin (level (- d 1)) d)))
         \\  (level 10))
         \\(define (native-fiber-body)
         \\  (define (level d)
         \\    (if (= d 0)
-        \\        (for-each (lambda (x) (yield)) (iota 1))
+        \\        (with-exception-handler
+        \\          (lambda (e) #f)
+        \\          (lambda () (thread-sleep! 0.0001)))
         \\        (begin (level (- d 1)) d)))
         \\  (level 10))
         \\(define (spawn-n n proc)
@@ -181,9 +211,10 @@ fn benchFootprint(allocator: std.mem.Allocator, n: u32, native_frame: bool) !Fib
 }
 
 pub fn main() !void {
-    var da = std.heap.DebugAllocator(.{}).init;
-    defer _ = da.deinit();
-    const allocator = da.allocator();
+    // Not DebugAllocator: its per-allocation bookkeeping (stack-trace
+    // capture, canaries) would contaminate both the timing and RSS numbers
+    // this benchmark exists to measure.
+    const allocator = std.heap.c_allocator;
 
     std.debug.print("=== Q5: spawn-only cost (0 yield rounds -- isolates FiberScheduler.addFiber) ===\n", .{});
     std.debug.print("{s:>8} | {s:>14} | {s:>10}\n", .{ "fibers", "ns/spawn+join", "total ms" });
@@ -211,7 +242,12 @@ pub fn main() !void {
     std.debug.print("\n=== Q5: does the 256-register native-frame fallback inflate per-fiber windows? ===\n", .{});
     std.debug.print("{s:>8} | {s:>10} | {s:>14} | {s:>14} | {s:>10} | {s:>10}\n", .{ "fibers", "kind", "avg regs/fiber", "avg frames/fbr", "regs KB", "frames KB" });
     std.debug.print("---------+------------+----------------+----------------+------------+-----------\n", .{});
-    const footprint_ns = [_]u32{ 100, 1_000 };
+    // N=1 only -- see benchFootprint's doc comment. Concurrent fibers each
+    // suspending inside with-exception-handler's thunk chain-nest the
+    // native stack (confirmed crashing at N=2 with deep-enough recursion);
+    // the footprint question only needs one fiber's own array sizes, not
+    // concurrency, so N=1 sidesteps that entirely.
+    const footprint_ns = [_]u32{1};
     for (footprint_ns) |n| {
         for ([_]bool{ false, true }) |native_frame| {
             const fp = try benchFootprint(allocator, n, native_frame);

--- a/src/bench_reactor.zig
+++ b/src/bench_reactor.zig
@@ -1,0 +1,169 @@
+// Direct reactor benchmark (KEP-0001 Phase 7): exercises real epoll_ctl/
+// kevent registration and wake-all fan-out independent of the VM/Scheme
+// layer, following the same pattern as src/tests_reactor.zig (pipe fds +
+// fake `Fiber` locals with only `.status` set, driven straight against
+// `Reactor.register`/`poll`).
+//
+// This is the *only* way to measure the reactor's own costs in this
+// codebase today: kaappi-net's raw TCP sockets never call into
+// Reactor.register/waitForFd at all (see the KEP-0001 Phase 7 write-up),
+// so an HTTP-server-level benchmark can't observe these numbers.
+//
+// Measures:
+//   Q3 - ONESHOT re-arm cost (`register()`'s call into `backend.arm`) vs.
+//        an adjacent read(2)/write(2) syscall pair on the same fd.
+//   Q1 - wake-all fan-out cost: N fake fibers registered as waiters on one
+//        shared fd, one real write, how long `poll()` takes to wake all N.
+//   Q2 - timer granularity: scheduled deadline vs. actual fire time.
+//
+// Build/run:  zig build bench-reactor
+
+const std = @import("std");
+const reactor_mod = @import("reactor.zig");
+const fiber_mod = @import("fiber.zig");
+const Reactor = reactor_mod.Reactor;
+const Fiber = fiber_mod.Fiber;
+
+fn nowNs() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+fn makePipe() [2]std.c.fd_t {
+    var fds: [2]std.c.fd_t = undefined;
+    if (std.c.pipe(&fds) != 0) unreachable;
+    return fds;
+}
+
+fn closeFd(fd: std.c.fd_t) void {
+    _ = std.posix.system.close(fd);
+}
+
+const RearmResult = struct { arm_ns: f64, io_ns: f64 };
+
+/// Q3: register()'s epoll_ctl/kevent call vs. an adjacent read(2)+write(2)
+/// pair, on the same pipe, averaged over `iters` cycles.
+fn benchRearmVsIo(iters: u32) !RearmResult {
+    var reactor = try Reactor.init(std.heap.page_allocator);
+    defer reactor.deinit();
+
+    const pipe = makePipe();
+    defer closeFd(pipe[0]);
+    defer closeFd(pipe[1]);
+
+    var fiber: Fiber = undefined;
+    fiber.status = .io_waiting;
+
+    const arm_start = nowNs();
+    var i: u32 = 0;
+    while (i < iters) : (i += 1) {
+        try reactor.register(pipe[0], .read, &fiber);
+        // Reset waiter-list state before the next cycle's register() call,
+        // isolating just the kernel arm cost rather than accumulating an
+        // ever-growing waiter list.
+        reactor.removeWaiter(pipe[0], &fiber);
+    }
+    const arm_elapsed = nowNs() - arm_start;
+
+    var buf: [1]u8 = .{0};
+    const io_start = nowNs();
+    i = 0;
+    while (i < iters) : (i += 1) {
+        _ = std.posix.system.write(pipe[1], &buf, 1);
+        _ = std.posix.system.read(pipe[0], &buf, 1);
+    }
+    const io_elapsed = nowNs() - io_start;
+
+    return .{
+        .arm_ns = @as(f64, @floatFromInt(arm_elapsed)) / @as(f64, @floatFromInt(iters)),
+        .io_ns = @as(f64, @floatFromInt(io_elapsed)) / @as(f64, @floatFromInt(iters)),
+    };
+}
+
+const FanoutResult = struct { n: u32, woken: usize, poll_ns: u64 };
+
+/// Q1: N fake fibers registered as waiters on one shared fd (read
+/// interest); one real write; how long poll() takes to wake all N and
+/// confirm every one of them actually gets woken (wake-all, not
+/// wake-head-only).
+fn benchWakeAllFanout(allocator: std.mem.Allocator, n: u32) !FanoutResult {
+    var reactor = try Reactor.init(allocator);
+    defer reactor.deinit();
+
+    const pipe = makePipe();
+    defer closeFd(pipe[0]);
+    defer closeFd(pipe[1]);
+
+    const fibers = try allocator.alloc(Fiber, n);
+    defer allocator.free(fibers);
+    for (fibers) |*f| {
+        f.status = .io_waiting;
+        try reactor.register(pipe[0], .read, f);
+    }
+
+    var buf: [1]u8 = .{'x'};
+    _ = std.posix.system.write(pipe[1], &buf, 1);
+
+    var ready: std.ArrayList(*Fiber) = .empty;
+    defer ready.deinit(allocator);
+
+    const start = nowNs();
+    try reactor.poll(5_000_000_000, &ready);
+    const elapsed = nowNs() - start;
+
+    return .{ .n = n, .woken = ready.items.len, .poll_ns = elapsed };
+}
+
+const TimerResult = struct { requested_ns: u64, actual_late_ns: i64 };
+
+/// Q2: schedules one timer at a known deadline and measures how late (or
+/// early) the reactor's poll() actually returns relative to it.
+fn benchTimerGranularity(requested_ns: u64) !TimerResult {
+    var reactor = try Reactor.init(std.heap.page_allocator);
+    defer reactor.deinit();
+
+    var fiber: Fiber = undefined;
+    fiber.status = .waiting;
+
+    const deadline = nowNs() + requested_ns;
+    try reactor.addTimer(deadline, &fiber);
+
+    var ready: std.ArrayList(*Fiber) = .empty;
+    defer ready.deinit(std.heap.page_allocator);
+    try reactor.poll(requested_ns + 5_000_000_000, &ready);
+
+    const actual = nowNs();
+    return .{ .requested_ns = requested_ns, .actual_late_ns = @as(i64, @intCast(actual)) - @as(i64, @intCast(deadline)) };
+}
+
+pub fn main() !void {
+    const target_os = @import("builtin").target.os.tag;
+    std.debug.print("reactor backend: {s}\n\n", .{@tagName(target_os)});
+
+    std.debug.print("=== Q3: ONESHOT re-arm cost vs. adjacent read(2)/write(2) ===\n", .{});
+    const iters: u32 = 100_000;
+    const r = try benchRearmVsIo(iters);
+    std.debug.print("register() (arm):    {d:>8.1} ns/call\n", .{r.arm_ns});
+    std.debug.print("read+write (io):      {d:>8.1} ns/call\n", .{r.io_ns});
+    std.debug.print("arm/io ratio:         {d:>8.2}x\n\n", .{r.arm_ns / r.io_ns});
+
+    std.debug.print("=== Q1: wake-all fan-out cost (N waiters on one shared fd) ===\n", .{});
+    std.debug.print("{s:>6} | {s:>8} | {s:>12} | {s:>14}\n", .{ "n", "woken", "poll ns", "ns/woken-fiber" });
+    std.debug.print("--------+----------+--------------+----------------\n", .{});
+    for ([_]u32{ 2, 10, 100, 1000 }) |n| {
+        const fr = try benchWakeAllFanout(std.heap.page_allocator, n);
+        std.debug.print("{d:>6} | {d:>8} | {d:>12} | {d:>14.1}\n", .{ fr.n, fr.woken, fr.poll_ns, @as(f64, @floatFromInt(fr.poll_ns)) / @as(f64, @floatFromInt(fr.n)) });
+    }
+
+    std.debug.print("\n=== Q2: timer granularity (requested vs. actual fire time) ===\n", .{});
+    std.debug.print("{s:>14} | {s:>14}\n", .{ "requested ms", "late by (ns)" });
+    std.debug.print("----------------+----------------\n", .{});
+    for ([_]u64{ 1_000_000, 5_000_000, 20_000_000, 100_000_000 }) |req_ns| {
+        const tr = try benchTimerGranularity(req_ns);
+        std.debug.print("{d:>14.1} | {d:>14}\n", .{ @as(f64, @floatFromInt(req_ns)) / 1e6, tr.actual_late_ns });
+    }
+
+    std.debug.print("\nname: reactor_arm, time: {d:.9}, status: ok, min: {d:.9}, max: {d:.9}, iterations: {d}\n", .{ r.arm_ns / 1e9, r.arm_ns / 1e9, r.arm_ns / 1e9, iters });
+    std.debug.print("name: reactor_io, time: {d:.9}, status: ok, min: {d:.9}, max: {d:.9}, iterations: {d}\n", .{ r.io_ns / 1e9, r.io_ns / 1e9, r.io_ns / 1e9, iters });
+}

--- a/src/bench_reactor.zig
+++ b/src/bench_reactor.zig
@@ -70,8 +70,10 @@ fn benchRearmVsIo(iters: u32) !RearmResult {
     const io_start = nowNs();
     i = 0;
     while (i < iters) : (i += 1) {
-        _ = std.posix.system.write(pipe[1], &buf, 1);
-        _ = std.posix.system.read(pipe[0], &buf, 1);
+        const wrote = std.posix.system.write(pipe[1], &buf, 1);
+        if (wrote != 1) return error.ShortWrite;
+        const bytes_read = std.posix.system.read(pipe[0], &buf, 1);
+        if (bytes_read != 1) return error.ShortRead;
     }
     const io_elapsed = nowNs() - io_start;
 
@@ -103,10 +105,15 @@ fn benchWakeAllFanout(allocator: std.mem.Allocator, n: u32) !FanoutResult {
     }
 
     var buf: [1]u8 = .{'x'};
-    _ = std.posix.system.write(pipe[1], &buf, 1);
+    const wrote = std.posix.system.write(pipe[1], &buf, 1);
+    if (wrote != 1) return error.ShortWrite;
 
     var ready: std.ArrayList(*Fiber) = .empty;
     defer ready.deinit(allocator);
+    // Reserve capacity for all N wakeups before starting the clock, so the
+    // timed region measures poll()'s own dispatch/fan-out work rather than
+    // the result-buffer's growth reallocations.
+    try ready.ensureTotalCapacity(allocator, n);
 
     const start = nowNs();
     try reactor.poll(5_000_000_000, &ready);
@@ -126,14 +133,20 @@ fn benchTimerGranularity(requested_ns: u64) !TimerResult {
     var fiber: Fiber = undefined;
     fiber.status = .waiting;
 
-    const deadline = nowNs() + requested_ns;
-    try reactor.addTimer(deadline, &fiber);
-
     var ready: std.ArrayList(*Fiber) = .empty;
     defer ready.deinit(std.heap.page_allocator);
+    try ready.ensureTotalCapacity(std.heap.page_allocator, 1);
+
+    const deadline = nowNs() + requested_ns;
+    try reactor.addTimer(deadline, &fiber);
     try reactor.poll(requested_ns + 5_000_000_000, &ready);
 
     const actual = nowNs();
+    var fired = false;
+    for (ready.items) |f| {
+        if (f == &fiber) fired = true;
+    }
+    if (!fired) return error.TimerDidNotFire;
     return .{ .requested_ns = requested_ns, .actual_late_ns = @as(i64, @intCast(actual)) - @as(i64, @intCast(deadline)) };
 }
 

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -413,21 +413,49 @@ const SleepWait = struct {
 /// nanosleep (KEP-0001 Phase 2): siblings run while this fiber sleeps, and
 /// the reactor's blocking wait — not a busy nanosleep loop — is what
 /// actually waits out the duration.
+///
+/// Gives this the same `dispatched_from_scheduler`-aware yield-retry branch
+/// `fiber.waitForFd` has (#1463): a fiber dispatched directly by a scheduler
+/// loop must unwind flatly (`error.Yielded`) rather than nest a recursive
+/// `runSchedulerStep` call, or concurrent fibers each retrying via short
+/// `thread-sleep!` calls grow the native stack without bound. Unlike a read
+/// primitive, thread-sleep! has no buffer to stash partial progress in —
+/// the equivalent state is `me.deadline_ns`/`me.timed_out` on the fiber
+/// itself, which (unlike the Scheme-level `seconds` argument) survives the
+/// unwind. The `me.deadline_ns != null` check on entry distinguishes a
+/// fresh call from a redispatch after yielding, so a retry consumes the
+/// existing timer instead of computing a new deadline and restarting the
+/// sleep on every redispatch.
 fn threadSleepFn(args: []const Value) PrimitiveError!Value {
     if (args[0] == types.FALSE) return PrimitiveError.TypeError; // bare-ok: type guard
-    const seconds = try getSleepSeconds(args[0]);
-    if (seconds <= 0) return types.VOID;
-    const total_ns: u64 = @intFromFloat(@max(0.0, seconds * 1e9));
 
     const ctx = try ensureScheduler();
     const me = ctx.vm.current_fiber orelse return types.VOID;
-    const deadline = fiber_mod.clockNs() + total_ns;
+    const my_idx = ctx.sched.current_idx;
 
-    me.waiting_on = types.VOID;
-    me.status = .waiting;
-    me.timed_out = false;
-    me.deadline_ns = deadline;
-    try ctx.reactor.addTimer(deadline, me);
+    if (me.deadline_ns == null) {
+        const seconds = try getSleepSeconds(args[0]);
+        if (seconds <= 0) return types.VOID;
+        const total_ns: u64 = @intFromFloat(@max(0.0, seconds * 1e9));
+        const deadline = fiber_mod.clockNs() + total_ns;
+
+        me.waiting_on = types.VOID;
+        me.status = .waiting;
+        me.timed_out = false;
+        me.deadline_ns = deadline;
+        try ctx.reactor.addTimer(deadline, me);
+    } else if (me.timed_out) {
+        // Redispatched after the timer we armed on a prior entry already
+        // fired -- nothing left to wait for.
+        me.timed_out = false;
+        me.deadline_ns = null;
+        return types.VOID;
+    }
+
+    if (my_idx != 0 and ctx.vm.dispatched_from_scheduler) {
+        ctx.vm.yield_retry = true;
+        return PrimitiveError.Yielded;
+    }
 
     _ = try fiber_mod.runSchedulerStep(SleepWait, .{}, ctx.vm, ctx.sched, me);
     me.timed_out = false;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -443,6 +443,17 @@ fn threadSleepFn(args: []const Value) PrimitiveError!Value {
         me.status = .waiting;
         me.timed_out = false;
         me.deadline_ns = deadline;
+        // OOM below (addTimer or runSchedulerStep's own allocations) would
+        // otherwise leave deadline_ns set with no timer actually pending --
+        // the next thread-sleep! call on this fiber would then misread its
+        // fresh call as a redispatch and wait on a stale deadline forever.
+        // error.Yielded is not a real error here (it's the intentional
+        // flat-unwind signal the deadline_ns discriminator exists to
+        // survive), so it must not trip this cleanup.
+        errdefer |err| if (err != PrimitiveError.Yielded) {
+            me.deadline_ns = null;
+            ctx.reactor.removeTimer(me);
+        };
         try ctx.reactor.addTimer(deadline, me);
     } else if (me.timed_out) {
         // Redispatched after the timer we armed on a prior entry already

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -515,8 +515,30 @@ test "concurrent thread-sleep! retries across fibers resolve without unbounded s
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
+    // gc-stress collects on every allocation, so the full retry count adds
+    // wall time and allocator churn without more coverage -- scale it down,
+    // like tests_robustness.zig does for its own iteration-heavy loops.
+    const n: i64 = if (@import("build_options").gc_stress) 300 else 3000;
+
     _ = try vm.eval("(import (srfi 18))");
-    const result = try vm.eval(
+    const result = try vm.eval(if (@import("build_options").gc_stress)
+        \\(define signal #f)
+        \\(define (poll-until-signal)
+        \\  (let loop ((n 0))
+        \\    (if signal
+        \\        n
+        \\        (begin (thread-sleep! 0.0001) (loop (+ n 1))))))
+        \\(define setter
+        \\  (spawn (lambda ()
+        \\    (let loop ((n 0))
+        \\      (if (>= n 300)
+        \\          (begin (set! signal #t) n)
+        \\          (begin (thread-sleep! 0.0001) (loop (+ n 1))))))))
+        \\(define waiter (spawn poll-until-signal))
+        \\(define setter-result (fiber-join setter))
+        \\(define waiter-result (fiber-join waiter))
+        \\(list setter-result waiter-result signal)
+    else
         \\(define signal #f)
         \\(define (poll-until-signal)
         \\  (let loop ((n 0))
@@ -532,10 +554,26 @@ test "concurrent thread-sleep! retries across fibers resolve without unbounded s
         \\(define waiter (spawn poll-until-signal))
         \\(define setter-result (fiber-join setter))
         \\(define waiter-result (fiber-join waiter))
-        \\(and (= setter-result 3000)
-        \\     (>= waiter-result 0)
-        \\     (<= waiter-result 3000)
-        \\     signal)
+        \\(list setter-result waiter-result signal)
     );
-    try std.testing.expectEqual(types.TRUE, result);
+
+    const setter_result = types.toFixnum(types.car(result));
+    const rest = types.cdr(result);
+    const waiter_result = types.toFixnum(types.car(rest));
+    const signal = types.car(types.cdr(rest));
+
+    try std.testing.expectEqual(n, setter_result);
+    // The waiter must have actually retried through thread-sleep! at least
+    // once (the regression this test exists to catch is specifically about
+    // *repeated* retries) -- `(>= waiter-result 0)` would be vacuously true
+    // for any non-negative starting value and prove nothing.
+    try std.testing.expect(waiter_result > 0);
+    // A loose sanity ceiling only, not `<= n`: that tighter bound holds today
+    // solely because the O(fiber count) round-robin scheduler happens to
+    // dispatch the setter before the waiter every wake round (#1477) -- once
+    // that scan is replaced with a ready queue, dispatch order within a wake
+    // round is no longer guaranteed, and the waiter could legitimately run
+    // more retries than the setter without indicating any regression.
+    try std.testing.expect(waiter_result < 100_000);
+    try std.testing.expectEqual(types.TRUE, signal);
 }

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -498,3 +498,44 @@ test "thread-yield! in child OS thread does not busy-spin or leak Yielded" {
     );
     try std.testing.expectEqual(types.TRUE, result);
 }
+
+// Regression for #1463: threadSleepFn used to always drive the scheduler in
+// place (a nested runSchedulerStep call) regardless of how the calling fiber
+// was dispatched, unlike fiber.waitForFd's dispatched_from_scheduler-aware
+// flat unwind. Two scheduler-dispatched fibers each retrying through many
+// short thread-sleep! calls — one polling for a flag the other sets after a
+// bounded number of iterations — nested one more native stack frame per
+// hand-off, growing without bound until the underlying condition resolved.
+// This test's fiber count and iteration bound are large enough that the
+// pre-fix nesting would run deep; it must complete promptly rather than
+// crash or stall.
+test "concurrent thread-sleep! retries across fibers resolve without unbounded stack growth (#1463)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (srfi 18))");
+    const result = try vm.eval(
+        \\(define signal #f)
+        \\(define (poll-until-signal)
+        \\  (let loop ((n 0))
+        \\    (if signal
+        \\        n
+        \\        (begin (thread-sleep! 0.0001) (loop (+ n 1))))))
+        \\(define setter
+        \\  (spawn (lambda ()
+        \\    (let loop ((n 0))
+        \\      (if (>= n 3000)
+        \\          (begin (set! signal #t) n)
+        \\          (begin (thread-sleep! 0.0001) (loop (+ n 1))))))))
+        \\(define waiter (spawn poll-until-signal))
+        \\(define setter-result (fiber-join setter))
+        \\(define waiter-result (fiber-join waiter))
+        \\(and (= setter-result 3000)
+        \\     (>= waiter-result 0)
+        \\     (<= waiter-result 3000)
+        \\     signal)
+    );
+    try std.testing.expectEqual(types.TRUE, result);
+}


### PR DESCRIPTION
## Summary

Phase 7 (measurement) of the KEP-0001 event-loop-reactor epic — closes out
the epic's last open item. Full results, methodology, and data tables in
[docs/dev/kep-0001-phase7-benchmarks.md](docs/dev/kep-0001-phase7-benchmarks.md).

- **Prerequisite fix (#1463)**: `thread-sleep!` lacked the same
  `dispatched_from_scheduler`-aware yield-retry branch `fiber.waitForFd` has,
  causing unbounded native stack growth under concurrent fibers each
  retrying via short `thread-sleep!` calls — exactly the pattern
  `kaappi-http`'s `http-listen-fiber` uses. Needed before any of this phase's
  benchmarking could be done safely. Regression test confirmed to segfault
  without the fix, pass with it.
- **Q1 (wake-all herd cost)**: confirmed negligible — `poll()`'s wake-all
  fan-out doesn't scale with waiter count (measured on both kqueue and
  epoll).
- **Q2 (timer granularity)**: confirmed — no workload in this codebase needs
  sub-ms precision; `timerfd` escape hatch stays unbuilt.
- **Q3 (ONESHOT re-arm cost)**: confirmed negligible on both backends
  (register() cost is 0.77x of an adjacent read+write pair on macOS, 0.47x
  on Linux) → **edge-triggered migration: no-go for now**.
- **Q5 (per-fiber memory/switch time — the one fully-open question)**:
  memory is bounded and modest, but `FiberScheduler.schedule()`/`addFiber()`
  do an O(fiber count) scan per dispatch/spawn, degrading switch time by
  ~2 orders of magnitude between 100 and 10,000 live fibers. This shows up
  end-to-end in the HTTP server benchmarks below.
- **Server benchmarks**: compared `http-listen`/`-prefork`/`-fiber` at
  100/1,000 concurrent connections (no `wrk`/`hey` in this workspace, used a
  small Python load generator instead). `http-listen-fiber` pays a ~1ms tax
  even uncontended (its I/O never actually reaches the reactor — see
  follow-ups) and its p99 at 1,000 connections is *worse* than the naive
  sequential server's, tracing back to the scheduler O(n) scan above.
- **`http-listen-threaded` could not be benchmarked** — found and isolated a
  pre-existing hang (confirmed on unmodified `main`, unrelated to this PR's
  changes): a library-defined procedure that `thread-start!`s a thunk which
  calls into *another* library's procedure hangs the child thread; identical
  code at top-level works. Filing as a follow-up rather than fixing here.

New benchmark tools added: `zig build bench-fibers`, `zig build bench-reactor`.

Four follow-up issues filed for the residual findings (linked in the
doc and the tracking issue comment).

## Test plan

- [x] `zig build test` (full unit suite) green
- [x] `bash tests/scheme/run-all.sh` (1834 tests) green
- [x] New regression test confirmed to fail (segfault) without the fix,
      pass with it
- [x] `zig fmt --check` clean on all changed/new files
- [x] Stress-tested `http-listen-fiber` at 50/500/1,000 concurrent
      connections post-fix (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)