### PR TITLE
Fix epoll stale-fire stranding of opposite-direction waiters

### DIFF
--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -143,7 +143,10 @@ pub const Reactor = struct {
     /// the poll/close paths (an error unwinding waitForFd's scheduler
     /// drive) — those paths clear the lists themselves. A kernel ONESHOT
     /// left armed with no listed waiter fires once into the stale-event
-    /// path of poll() and is dropped there. No-op if absent.
+    /// path of poll() and is dropped there; on epoll that stale fire still
+    /// disarms the whole fd (not just the removed direction), so poll()
+    /// re-arms for whatever the other direction still needs regardless of
+    /// whether this event matched a live waiter (#1462). No-op if absent.
     pub fn removeWaiter(self: *Reactor, fd: i32, fiber: *Fiber) void {
         const reg = self.regs.getPtr(fd) orelse return;
         var lists = [_]*std.ArrayList(*Fiber){ &reg.read_waiters, &reg.write_waiters };
@@ -226,7 +229,6 @@ pub const Reactor = struct {
         for (events) |ev| {
             const reg = self.regs.getPtr(ev.fd) orelse continue; // stale event; already unregistered
 
-            var fired = false;
             // Reserved up front so the drain below can't fail mid-way: a
             // failure after the kernel's ONESHOT event was consumed but
             // before all waiters were moved to `ready` would strand the
@@ -237,20 +239,22 @@ pub const Reactor = struct {
             if (ev.readable and reg.read_waiters.items.len > 0) {
                 for (reg.read_waiters.items) |f| ready.appendAssumeCapacity(f);
                 reg.read_waiters.clearRetainingCapacity();
-                fired = true;
             }
             if (ev.writable and reg.write_waiters.items.len > 0) {
                 for (reg.write_waiters.items) |f| ready.appendAssumeCapacity(f);
                 reg.write_waiters.clearRetainingCapacity();
-                fired = true;
             }
-            if (!fired) continue;
 
             // epoll's ONESHOT disarms the *whole* fd registration on any
-            // fire, even a direction that didn't fire (unlike kqueue, where
-            // read/write are independent knotes and an untouched filter
-            // stays armed). Re-arm for whatever's left. Harmless no-op
-            // redundant EV_ADD on kqueue.
+            // fire — including a "stale" fire whose direction has no live
+            // waiter (e.g. removeWaiter already dropped it) — unlike
+            // kqueue, where read/write are independent knotes and an
+            // untouched filter stays armed. Re-arm unconditionally for
+            // whatever waiters remain, even when this event matched none:
+            // gating the re-arm on `fired` left a stale fire's untouched
+            // direction disarmed in the kernel with its waiter still
+            // parked and still listed, so no deadlock detector would catch
+            // it either (#1462). Harmless no-op redundant EV_ADD on kqueue.
             const remaining_read = reg.read_waiters.items.len > 0;
             const remaining_write = reg.write_waiters.items.len > 0;
             if (remaining_read or remaining_write) {

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -417,3 +417,101 @@ test "closing the peer wakes a parked read waiter (EOF/HUP mapped to broken)" {
     try std.testing.expectEqual(@as(usize, 1), ready.items.len);
     try std.testing.expectEqual(&fiber_a, ready.items[0]);
 }
+
+fn setNonblocking(fd: std.c.fd_t) void {
+    const flags = std.c.fcntl(fd, std.posix.F.GETFL, @as(c_int, 0));
+    std.testing.expect(flags >= 0) catch unreachable;
+    const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
+    std.testing.expect(std.c.fcntl(fd, std.posix.F.SETFL, flags | nonblock) >= 0) catch unreachable;
+}
+
+/// Shrinks the kernel send buffer so `fillSendBuffer` reaches EAGAIN after
+/// a few KB instead of needing megabytes of writes.
+fn setSmallSndbuf(fd: std.c.fd_t) void {
+    const size: c_int = 2048;
+    std.posix.setsockopt(fd, std.posix.SOL.SOCKET, std.posix.SO.SNDBUF, std.mem.asBytes(&size)) catch unreachable;
+}
+
+/// Writes to `fd` (already non-blocking) until the send buffer is full and
+/// a write returns EAGAIN, proving the fd is not writable. Bounded so a
+/// platform that doesn't honor the shrunk SO_SNDBUF fails loudly instead of
+/// spinning forever.
+fn fillSendBuffer(fd: std.c.fd_t) void {
+    var buf: [4096]u8 = [_]u8{0} ** 4096;
+    var iterations: usize = 0;
+    while (iterations < 4096) : (iterations += 1) {
+        const n = std.posix.system.write(fd, &buf, buf.len);
+        if (n < 0) {
+            std.testing.expectEqual(std.posix.E.AGAIN, std.posix.errno(n)) catch unreachable;
+            return;
+        }
+    }
+    @panic("fillSendBuffer: fd never became unwritable (SO_SNDBUF not honored?)");
+}
+
+/// Reads `fd` (already non-blocking) to EAGAIN, discarding everything —
+/// frees up the peer's send buffer.
+fn drainSocket(fd: std.c.fd_t) void {
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = std.posix.system.read(fd, &buf, buf.len);
+        if (n < 0) {
+            std.testing.expectEqual(std.posix.E.AGAIN, std.posix.errno(n)) catch unreachable;
+            return;
+        }
+        if (n == 0) return;
+    }
+}
+
+test "a stale ONESHOT fire on one direction re-arms the fd for the surviving waiter (#1462)" {
+    // removeWaiter only edits the waiter lists — it never touches the
+    // kernel registration (see its doc comment). If the removed waiter's
+    // direction fires before the surviving direction does, epoll's
+    // EPOLLONESHOT disarms the *whole* fd, not just the direction that
+    // fired. poll() must re-arm for whatever waiters remain even when the
+    // fired event matched none of them ("stale"), or the surviving waiter
+    // is left parked on an fd the kernel no longer watches — a permanent,
+    // silent hang with no timers pending to bound the wait.
+    //
+    // kqueue's independent per-direction knotes make this scenario
+    // impossible to strand there, so this test can only demonstrate the
+    // bug on Linux (epoll); it still passes on macOS/kqueue as a no-op
+    // regression guard.
+    var reactor = try Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+
+    const pair = makeSocketPair();
+    defer closeFd(pair[0]);
+    defer closeFd(pair[1]);
+
+    setNonblocking(pair[0]);
+    setSmallSndbuf(pair[0]);
+    fillSendBuffer(pair[0]); // pair[0] is now not writable
+
+    var fiber_r: Fiber = undefined;
+    fiber_r.status = .io_waiting;
+    var fiber_w: Fiber = undefined;
+    fiber_w.status = .io_waiting;
+    try reactor.register(pair[0], .read, &fiber_r);
+    try reactor.register(pair[0], .write, &fiber_w); // kernel armed IN|OUT|ONESHOT
+
+    reactor.removeWaiter(pair[0], &fiber_r); // read waiter gone; kernel stays armed for IN
+
+    writeByte(pair[1], 'x'); // pair[0] becomes readable -> a stale IN fire
+
+    var ready = newReady();
+    defer ready.deinit(std.testing.allocator);
+    try reactor.poll(300_000_000, &ready); // the stale fire is dropped
+    try std.testing.expectEqual(@as(usize, 0), ready.items.len);
+
+    // Free up pair[0]'s send buffer so it becomes writable, then confirm
+    // the surviving write waiter still wakes. Without the fix this poll
+    // times out on Linux: the stale fire above left the fd disarmed in
+    // the kernel and nothing ever re-registers it.
+    setNonblocking(pair[1]);
+    drainSocket(pair[1]);
+    try reactor.poll(300_000_000, &ready);
+
+    try std.testing.expectEqual(@as(usize, 1), ready.items.len);
+    try std.testing.expectEqual(&fiber_w, ready.items[0]);
+}


### PR DESCRIPTION
## Summary

`Reactor.poll()` gated its re-arm step behind `if (!fired) continue;`, so a stale ONESHOT fire — an event arriving for a direction whose waiter list is already empty (e.g. after `removeWaiter`) — skipped re-arming entirely. On epoll, a ONESHOT fire disarms the *whole* fd registration, not just the direction that fired (unlike kqueue's independent per-direction knotes), so any waiter still parked on the opposite direction was permanently stranded on an fd the kernel no longer watches. With no timers pending, the scheduler would block forever in `epoll_wait` — a silent hang, undetectable by `isEmpty()` since the waiter is still listed.

Fix: re-arm unconditionally whenever waiters remain after the drain, regardless of whether this particular event matched a live waiter. Also updated `removeWaiter`'s doc comment, which didn't account for the stale drop also disarming the opposite direction on epoll.

## Test plan

- [x] Added the regression test from the issue's spec to `src/tests_reactor.zig`, using a socketpair with a shrunk `SO_SNDBUF` so one direction can be made unwritable while a read waiter is removed and fires stale.
- [x] `zig build test` passes (macOS/kqueue, native + `-Dgc-stress=true`).
- [x] `zig fmt --check` clean.
- [x] Verified on real Linux/epoll via cross-compiled unit tests run in a podman x86_64 container:
  - With the fix: all 18 reactor tests pass.
  - With the fix reverted: the new test fails exactly as predicted (`expected 1, found 0` — the write waiter never wakes), failing gracefully within the bounded 300ms timeout rather than hanging.
- [x] kqueue is immune to this bug (independent per-direction knotes), so the test is a no-op guard on macOS but a real regression catch on Linux/epoll — matches the issue's own note.

Fixes #1462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)