### PR TITLE
SharedChannel core: shared-object protocol, promotion, reservation send/receive (KEP-0002 P1)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -230,6 +230,20 @@ pub fn build(b: *std.Build) void {
     const bench_reactor_step = b.step("bench-reactor", "Run the reactor wake-all/re-arm/timer benchmark");
     bench_reactor_step.dependOn(&run_bench_reactor.step);
 
+    // Benchmark executable (local fast-path + promoted envelope cost, KEP-0002 P1)
+    const bench_channel_mod = kaappiModule(b, options_mod, .{
+        .root = "src/bench_channel.zig",
+        .target = target,
+        .optimize = optimize,
+    });
+    const bench_channel_exe = b.addExecutable(.{
+        .name = "bench-channel",
+        .root_module = bench_channel_mod,
+    });
+    const run_bench_channel = b.addRunArtifact(bench_channel_exe);
+    const bench_channel_step = b.step("bench-channel", "Run the channel local fast-path & envelope-cost benchmark");
+    bench_channel_step.dependOn(&run_bench_channel.step);
+
     // Package manager (thottam)
     const thottam_mod = kaappiModule(b, options_mod, .{
         .root = "src/thottam.zig",

--- a/src/bench_channel.zig
+++ b/src/bench_channel.zig
@@ -1,0 +1,152 @@
+// KEP-0002 Phase 1 channel benchmark. Two measurements, no automated
+// pass/fail threshold -- run before/after and compare by eye, matching
+// bench_fibers.zig/bench_reactor.zig:
+//
+//   1. Local (unpromoted) channel send+receive ns/op -- the invariant-3
+//      fast-path regression gate ("An unpromoted channel is today's
+//      head/tail pair queue plus one pointer null-check ... 'Unmeasurable'
+//      is a Phase 1 benchmark gate, not an assumption"). Runs through a
+//      real VM/eval so the measurement includes the actual dispatch path
+//      (the new foreign-owner check and ch.shared null-check included).
+//   2. Promoted, single-thread channel send+receive ns/op -- the Phase 1
+//      installment of research/open-problems.md's P3 envelope-cost harness
+//      ("(A) per-message GC struct as specified"). Parameterized over
+//      P3's workload shapes (fixnum, small pair, 1 KiB string, 64 KiB
+//      bytevector); a 50-deep nested-pair chain stands in for P3's "deep
+//      record" shape until a full record-type harness lands. Phase 7 grows
+//      this into the full A/B/C/D matrix (arena backing, immediate fast
+//      path, immutable side-heap).
+//
+// Build/run:  zig build bench-channel
+//   (best with -Doptimize=ReleaseFast)
+
+const std = @import("std");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const vm_mod = @import("vm.zig");
+const primitives = @import("primitives.zig");
+const library = @import("library.zig");
+const shared_channel = @import("shared_channel.zig");
+const Value = types.Value;
+
+fn nowNs() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+fn nsPerOp(elapsed_ns: u64, ops: u64) f64 {
+    return @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, @floatFromInt(ops));
+}
+
+// Note: VM setup is inlined, not a shared helper -- see bench_fibers.zig's
+// identical note (vm_mod.setVMInstance stores the local `vm`'s address in a
+// threadlocal; a helper returning `vm` by value would leave that dangling).
+fn benchLocalFastPath(iters: u64) !f64 {
+    var gc = memory.GC.init(std.heap.c_allocator);
+    defer gc.deinit();
+    var vm: vm_mod.VM = try vm_mod.VM.init(&gc);
+    defer vm.deinit();
+    memory.setGCInstance(&gc);
+    vm_mod.setVMInstance(&vm);
+    try primitives.registerAll(&vm);
+    try vm_mod.vm_bootstrap.install(&vm);
+    try library.registerStandardLibraries(&vm.libraries, vm.globals);
+
+    var buf: [160]u8 = undefined;
+    const src = try std.fmt.bufPrint(&buf,
+        \\(import (scheme base) (kaappi fibers))
+        \\(define ch (make-channel))
+        \\(let loop ((i 0)) (when (< i {d}) (channel-send ch i) (channel-receive ch) (loop (+ i 1))))
+    , .{iters});
+
+    const start = nowNs();
+    _ = try vm.eval(src);
+    const elapsed = nowNs() - start;
+    return nsPerOp(elapsed, iters);
+}
+
+const Workload = struct {
+    name: []const u8,
+    build: *const fn (gc: *memory.GC) anyerror!Value,
+};
+
+fn buildFixnum(_: *memory.GC) anyerror!Value {
+    return types.makeFixnum(42);
+}
+
+fn buildSmallPair(gc: *memory.GC) anyerror!Value {
+    return gc.allocPair(types.makeFixnum(1), types.makeFixnum(2));
+}
+
+fn buildString1KiB(gc: *memory.GC) anyerror!Value {
+    var data: [1024]u8 = undefined;
+    @memset(&data, 'x');
+    return gc.allocString(&data);
+}
+
+fn buildBytevector64KiB(gc: *memory.GC) anyerror!Value {
+    var data: [64 * 1024]u8 = undefined;
+    @memset(&data, 0xAB);
+    return gc.allocBytevector(&data);
+}
+
+/// Stand-in for P3's "deep record" shape: a 50-deep nested-pair chain.
+fn buildDeepChain(gc: *memory.GC) anyerror!Value {
+    var v: Value = types.NIL;
+    var i: u32 = 0;
+    while (i < 50) : (i += 1) {
+        var root = v;
+        gc.pushRoot(&root);
+        v = try gc.allocPair(types.makeFixnum(i), root);
+        gc.popRoot();
+    }
+    return v;
+}
+
+const workloads = [_]Workload{
+    .{ .name = "fixnum", .build = buildFixnum },
+    .{ .name = "small pair", .build = buildSmallPair },
+    .{ .name = "1 KiB string", .build = buildString1KiB },
+    .{ .name = "64 KiB bytevector", .build = buildBytevector64KiB },
+    .{ .name = "50-deep chain", .build = buildDeepChain },
+};
+
+/// Promoted-channel send+receive, single OS thread (no cross-thread wakeup
+/// exists until Phase 3) -- measures envelope build/copy-in + copy-out cost
+/// in isolation, bypassing the VM entirely.
+fn benchPromotedPath(workload: Workload, iters: u64) !f64 {
+    const sc = try shared_channel.SharedChannel.create();
+    defer sc.release();
+
+    var src_gc = memory.GC.init(std.heap.c_allocator);
+    defer src_gc.deinit();
+    var dest_gc = memory.GC.init(std.heap.c_allocator);
+    defer dest_gc.deinit();
+
+    const payload = try workload.build(&src_gc);
+
+    const start = nowNs();
+    var i: u64 = 0;
+    while (i < iters) : (i += 1) {
+        _ = try shared_channel.send(sc, payload, null);
+        _ = try shared_channel.receive(sc, &dest_gc, null);
+    }
+    const elapsed = nowNs() - start;
+    return nsPerOp(elapsed, iters);
+}
+
+pub fn main() !void {
+    std.debug.print("=== KEP-0002 Phase 1: channel benchmarks ===\n\n", .{});
+
+    const local_iters: u64 = 200_000;
+    const local_ns = try benchLocalFastPath(local_iters);
+    std.debug.print("local (unpromoted) send+receive: {d:.1} ns/op over {d} iters\n\n", .{ local_ns, local_iters });
+
+    std.debug.print("promoted (single-thread) send+receive, by payload shape:\n", .{});
+    for (workloads) |wl| {
+        const iters: u64 = if (std.mem.eql(u8, wl.name, "64 KiB bytevector")) 2_000 else 20_000;
+        const ns = try benchPromotedPath(wl, iters);
+        std.debug.print("  {s:<20} {d:>10.1} ns/op over {d} iters\n", .{ wl.name, ns, iters });
+    }
+}

--- a/src/bench_channel.zig
+++ b/src/bench_channel.zig
@@ -53,7 +53,7 @@ fn benchLocalFastPath(iters: u64) !f64 {
     try vm_mod.vm_bootstrap.install(&vm);
     try library.registerStandardLibraries(&vm.libraries, vm.globals);
 
-    var buf: [160]u8 = undefined;
+    var buf: [256]u8 = undefined;
     const src = try std.fmt.bufPrint(&buf,
         \\(import (scheme base) (kaappi fibers))
         \\(define ch (make-channel))
@@ -68,6 +68,7 @@ fn benchLocalFastPath(iters: u64) !f64 {
 
 const Workload = struct {
     name: []const u8,
+    iters: u64,
     build: *const fn (gc: *memory.GC) anyerror!Value,
 };
 
@@ -105,11 +106,11 @@ fn buildDeepChain(gc: *memory.GC) anyerror!Value {
 }
 
 const workloads = [_]Workload{
-    .{ .name = "fixnum", .build = buildFixnum },
-    .{ .name = "small pair", .build = buildSmallPair },
-    .{ .name = "1 KiB string", .build = buildString1KiB },
-    .{ .name = "64 KiB bytevector", .build = buildBytevector64KiB },
-    .{ .name = "50-deep chain", .build = buildDeepChain },
+    .{ .name = "fixnum", .iters = 20_000, .build = buildFixnum },
+    .{ .name = "small pair", .iters = 20_000, .build = buildSmallPair },
+    .{ .name = "1 KiB string", .iters = 20_000, .build = buildString1KiB },
+    .{ .name = "64 KiB bytevector", .iters = 2_000, .build = buildBytevector64KiB },
+    .{ .name = "50-deep chain", .iters = 20_000, .build = buildDeepChain },
 };
 
 /// Promoted-channel send+receive, single OS thread (no cross-thread wakeup
@@ -145,8 +146,7 @@ pub fn main() !void {
 
     std.debug.print("promoted (single-thread) send+receive, by payload shape:\n", .{});
     for (workloads) |wl| {
-        const iters: u64 = if (std.mem.eql(u8, wl.name, "64 KiB bytevector")) 2_000 else 20_000;
-        const ns = try benchPromotedPath(wl, iters);
-        std.debug.print("  {s:<20} {d:>10.1} ns/op over {d} iters\n", .{ wl.name, ns, iters });
+        const ns = try benchPromotedPath(wl, wl.iters);
+        std.debug.print("  {s:<20} {d:>10.1} ns/op over {d} iters\n", .{ wl.name, ns, wl.iters });
     }
 }

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const types = @import("types.zig");
 const memory_mod = @import("memory.zig");
+const shared_channel = @import("shared_channel.zig");
 const GC = memory_mod.GC;
 
 const Value = types.Value;
@@ -1055,7 +1056,16 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             poisonAndDestroy(gc, @import("fiber.zig").Fiber, fiber);
         },
         .channel => {
-            poisonAndDestroy(gc, types.Channel, obj.as(types.Channel));
+            const ch = obj.as(types.Channel);
+            // KEP-0002 §1 rule 3: stubs are released by freeObject, from
+            // ANY path -- a real GC sweep, a test's GC.deinit(), or an
+            // envelope's own mini-GC tearing itself down through this same
+            // function. No separate envelope-specific bookkeeping exists.
+            if (ch.shared) |s| {
+                const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(s));
+                sc.release();
+            }
+            poisonAndDestroy(gc, types.Channel, ch);
         },
         .mutex => {
             poisonAndDestroy(gc, types.Mutex, obj.as(types.Mutex));

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -2,18 +2,27 @@ const std = @import("std");
 const types = @import("types.zig");
 const memory_mod = @import("memory.zig");
 const hashtable = @import("primitives_hashtable.zig");
+const shared_channel = @import("shared_channel.zig");
 
 const GC = memory_mod.GC;
 const Value = types.Value;
 
-pub fn deepCopy(gc: *GC, src: Value) !Value {
+/// Explicit (not inferred) so shared_channel.zig's Envelope.create ->
+/// GC.deepCopy -> gc_deep_copy.deepCopy -> deepCopyValue ->
+/// shared_channel.promoteChannel -> Envelope.create call chain doesn't form
+/// an unresolvable inferred-error-set cycle: promoteChannel/Envelope.create
+/// need to know deepCopy's error set before deepCopy's own inference (which
+/// recurses into promoteChannel for the .channel arm) can complete.
+pub const DeepCopyError = error{ OutOfMemory, UncopyableType };
+
+pub fn deepCopy(gc: *GC, src: Value) DeepCopyError!Value {
     if (!types.isPointer(src)) return src;
     var visited = std.AutoHashMap(usize, Value).init(gc.allocator);
     defer visited.deinit();
     return deepCopyValue(gc, src, &visited);
 }
 
-fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !Value {
+fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) DeepCopyError!Value {
     if (!types.isPointer(src)) return src;
 
     const src_ptr = @intFromPtr(types.toObject(src));
@@ -325,10 +334,39 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) !
             new_rs.prng = rs.prng;
             return new_val;
         },
+        // KEP-0002 §2: a channel is promoted (if not already) and aliased,
+        // never rejected outright. `gc` here is the *destination* heap, not
+        // the channel's owner -- ownership (invariant 4: promotion is legal
+        // only for the thread that owns the channel) is checked against
+        // `memory_mod.gc_instance`, the threadlocal for whichever thread is
+        // actually executing this copy. A foreign, not-yet-promoted channel
+        // reuses UncopyableType rather than a new error class, so
+        // thread-start!/thread-join! (primitives_srfi18.zig) -- whose
+        // deepCopy calls run on the destination thread, never the channel's
+        // owner, until KEP-0002 Phase 2 moves the thunk copy to the parent
+        // thread -- keep today's exact behavior and error message.
+        .channel => {
+            const ch = obj.as(types.Channel);
+            // Aliasing an already-promoted stub needs no ownership check
+            // (and no memory_mod.gc_instance at all) -- any thread that
+            // legitimately holds a stub Value may pass it along further.
+            // Only a not-yet-promoted channel needs the current-thread
+            // check, since promoting is the operation invariant 4 restricts.
+            const sc = if (ch.shared) |s|
+                @as(*shared_channel.SharedChannel, @ptrCast(@alignCast(s)))
+            else blk: {
+                const current_gc = memory_mod.gc_instance orelse return error.UncopyableType;
+                if (obj.owner != current_gc.id) return error.UncopyableType;
+                break :blk try shared_channel.promoteChannel(current_gc, ch);
+            };
+            sc.retain();
+            const new_val = try gc.allocChannelStub(sc);
+            try visited.put(src_ptr, new_val);
+            return new_val;
+        },
         .port,
         .continuation,
         .fiber,
-        .channel,
         .mutex,
         .condition_variable,
         .ffi_callback,

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -359,8 +359,12 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
                 if (obj.owner != current_gc.id) return error.UncopyableType;
                 break :blk try shared_channel.promoteChannel(current_gc, ch);
             };
-            sc.retain();
+            // Allocate before retaining: if allocChannelStub fails, no new
+            // stub exists to own the +1, and the source stub's own count
+            // (still held regardless) keeps the retain/release balance
+            // intact -- retaining first would leak sc's refcount on OOM.
             const new_val = try gc.allocChannelStub(sc);
+            sc.retain();
             try visited.put(src_ptr, new_val);
             return new_val;
         },

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -876,6 +876,23 @@ pub const GC = struct {
         return types.makePointer(@ptrCast(ch));
     }
 
+    /// A promoted-channel stub: a new counted reference to an existing
+    /// SharedChannel (KEP-0002 §2), allocated on this heap by deepCopy's
+    /// `.channel` alias arm. `shared` isn't a Value, so there's nothing to
+    /// root beyond the usual maybeCollect discipline.
+    pub fn allocChannelStub(self: *GC, shared: *anyopaque) !Value {
+        try self.maybeCollect();
+        const ch = try self.allocator.create(types.Channel);
+        ch.* = .{
+            .header = .{ .tag = .channel },
+            .head = types.NIL,
+            .tail = types.NIL,
+            .shared = shared,
+        };
+        self.finishAlloc(&ch.header, @sizeOf(types.Channel));
+        return types.makePointer(@ptrCast(ch));
+    }
+
     pub fn allocMutex(self: *GC, name: Value) !Value {
         self.rootArgs1(name);
         try self.maybeCollect();

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -110,7 +110,7 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
     // shared global, promoted or not -- is what silently corrupted memory
     // before this check existed (Motivation Path 2); now it's a diagnosis.
     if (ch_obj.owner != gc.id)
-        return raiseChannelError("channel belongs to another thread; pass it through the thread thunk to share it");
+        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
     const ch = ch_obj.as(types.Channel);
 
     if (ch.shared) |raw| {
@@ -123,8 +123,11 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
             // Phase 1 channels are always unbounded and open -- no
             // Scheme-level API sets capacity or closed yet (KEP-0002
             // Phase 4) -- so these branches are unreachable through
-            // make-channel's output.
-            .would_park, .closed => unreachable,
+            // make-channel's output. @panic (not `unreachable`, which is UB
+            // under ReleaseFast) so a Phase 4 gap that forgets to wire this
+            // switch fails loudly in every build mode instead of silently
+            // corrupting execution.
+            .would_park, .closed => @panic("channel-send: reached a shared-channel branch Phase 1's primitives don't wire up yet (capacity/close is Phase 4)"),
         };
     }
 
@@ -161,7 +164,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ch_obj = types.toObject(args[0]);
     if (ch_obj.owner != gc.id)
-        return raiseChannelError("channel belongs to another thread; pass it through the thread thunk to share it");
+        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
     const ch = ch_obj.as(types.Channel);
 
     if (ch.shared) |raw| {
@@ -173,8 +176,9 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
             .value => |v| v,
             // Phase 1 channels are always open (channel-close! is Phase 4)
             // and fiber-parking isn't wired to the shared path yet (Phase
-            // 3) -- unreachable through make-channel's output.
-            .would_park, .eof => unreachable,
+            // 3) -- unreachable through make-channel's output. @panic, not
+            // `unreachable` (UB under ReleaseFast) -- see channelSendFn.
+            .would_park, .eof => @panic("channel-receive: reached a shared-channel branch Phase 1's primitives don't wire up yet (capacity/close is Phase 4)"),
         };
     }
 
@@ -185,7 +189,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     if (vm.scheduler == null) {
         // No fibers exist, so nothing can ever send: blocking would hang.
-        return raiseDeadlockError("channel-receive: deadlock — channel is empty and no fibers are running");
+        return raiseFiberError("channel-receive: deadlock — channel is empty and no fibers are running");
     }
 
     // Capture before the recursive dispatch below: args is a slice into
@@ -229,28 +233,15 @@ fn blockOrDeadlock(vm: *vm_mod.VM, me: *fiber_mod.Fiber, my_idx: usize, wait_on:
         vm.yield_retry = true;
         return PrimitiveError.Yielded;
     }
-    return raiseDeadlockError(deadlock_msg);
+    return raiseFiberError(deadlock_msg);
 }
 
-fn raiseDeadlockError(msg: []const u8) PrimitiveError {
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
-    var msg_root = message;
-    gc.pushRoot(&msg_root);
-    const err_val = gc.allocErrorObject(msg_root, types.NIL) catch {
-        gc.popRoot();
-        return PrimitiveError.OutOfMemory;
-    };
-    gc.popRoot();
-    vm.current_exception = err_val;
-    return PrimitiveError.ExceptionRaised;
-}
-
-/// Same shape as raiseDeadlockError, kept separate since the message isn't
-/// about deadlocks: the foreign-owner check (KEP-0002 §2) and a shared-path
-/// uncopyable payload both need this.
-fn raiseChannelError(msg: []const u8) PrimitiveError {
+/// Raises a generic ErrorObject carrying `msg`. Named for this file's scope
+/// (fiber/channel primitives), not any one caller: deadlocks, the
+/// foreign-owner check (KEP-0002 §2), and a shared-path uncopyable payload
+/// all just need a message wrapped into a catchable exception -- the
+/// function name never reaches the user, only `msg` does.
+fn raiseFiberError(msg: []const u8) PrimitiveError {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
@@ -274,7 +265,7 @@ fn translateSharedChannelError(err: anyerror, proc: []const u8) PrimitiveError {
         var buf: [96]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "{s}: value contains an uncopyable type (port, continuation, etc.)", .{proc}) catch
             return PrimitiveError.OutOfMemory;
-        return raiseChannelError(msg);
+        return raiseFiberError(msg);
     }
     return PrimitiveError.OutOfMemory;
 }

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -4,6 +4,7 @@ const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
 const memory = @import("memory.zig");
 const fiber_mod = @import("fiber.zig");
+const shared_channel = @import("shared_channel.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -103,7 +104,30 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("channel-send", "channel", args[0]);
 
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const ch = types.toObject(args[0]).as(types.Channel);
+    const ch_obj = types.toObject(args[0]);
+    // KEP-0002 §2: the only legal cross-thread handle is a locally owned
+    // stub created by deepCopy. A foreign object -- reached through a
+    // shared global, promoted or not -- is what silently corrupted memory
+    // before this check existed (Motivation Path 2); now it's a diagnosis.
+    if (ch_obj.owner != gc.id)
+        return raiseChannelError("channel belongs to another thread; pass it through the thread thunk to share it");
+    const ch = ch_obj.as(types.Channel);
+
+    if (ch.shared) |raw| {
+        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
+        const outcome = shared_channel.send(sc, args[1], null) catch |err| {
+            return translateSharedChannelError(err, "channel-send");
+        };
+        return switch (outcome) {
+            .sent => types.VOID,
+            // Phase 1 channels are always unbounded and open -- no
+            // Scheme-level API sets capacity or closed yet (KEP-0002
+            // Phase 4) -- so these branches are unreachable through
+            // make-channel's output.
+            .would_park, .closed => unreachable,
+        };
+    }
+
     const new_pair = gc.allocPair(args[1], types.NIL) catch return PrimitiveError.OutOfMemory;
 
     if (ch.tail != types.NIL and types.isPair(ch.tail)) {
@@ -111,7 +135,6 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
         tail_obj.as(types.Pair).cdr = new_pair;
         gc.writeBarrier(tail_obj, new_pair);
     }
-    const ch_obj = types.toObject(args[0]);
     ch.tail = new_pair;
     gc.writeBarrier(ch_obj, new_pair);
     if (ch.head == types.NIL) {
@@ -135,7 +158,25 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[0]))
         return primitives.typeError("channel-receive", "channel", args[0]);
 
-    const ch = types.toObject(args[0]).as(types.Channel);
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const ch_obj = types.toObject(args[0]);
+    if (ch_obj.owner != gc.id)
+        return raiseChannelError("channel belongs to another thread; pass it through the thread thunk to share it");
+    const ch = ch_obj.as(types.Channel);
+
+    if (ch.shared) |raw| {
+        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
+        const outcome = shared_channel.receive(sc, gc, null) catch |err| {
+            return translateSharedChannelError(err, "channel-receive");
+        };
+        return switch (outcome) {
+            .value => |v| v,
+            // Phase 1 channels are always open (channel-close! is Phase 4)
+            // and fiber-parking isn't wired to the shared path yet (Phase
+            // 3) -- unreachable through make-channel's output.
+            .would_park, .eof => unreachable,
+        };
+    }
 
     if (ch.head != types.NIL and types.isPair(ch.head)) {
         return dequeueChannel(ch, args[0]);
@@ -206,6 +247,42 @@ fn raiseDeadlockError(msg: []const u8) PrimitiveError {
     return PrimitiveError.ExceptionRaised;
 }
 
+/// Same shape as raiseDeadlockError, kept separate since the message isn't
+/// about deadlocks: the foreign-owner check (KEP-0002 §2) and a shared-path
+/// uncopyable payload both need this.
+fn raiseChannelError(msg: []const u8) PrimitiveError {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
+    var msg_root = message;
+    gc.pushRoot(&msg_root);
+    const err_val = gc.allocErrorObject(msg_root, types.NIL) catch {
+        gc.popRoot();
+        return PrimitiveError.OutOfMemory;
+    };
+    gc.popRoot();
+    vm.current_exception = err_val;
+    return PrimitiveError.ExceptionRaised;
+}
+
+/// shared_channel.send/.receive propagate Envelope.create's deepCopy error
+/// verbatim. Mirrors how primitives_srfi18.zig's thread-start!/thread-join!
+/// special-case UncopyableType into a descriptive message and otherwise
+/// fall back to OutOfMemory.
+fn translateSharedChannelError(err: anyerror, proc: []const u8) PrimitiveError {
+    if (err == error.UncopyableType) {
+        var buf: [96]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "{s}: value contains an uncopyable type (port, continuation, etc.)", .{proc}) catch
+            return PrimitiveError.OutOfMemory;
+        return raiseChannelError(msg);
+    }
+    return PrimitiveError.OutOfMemory;
+}
+
+/// A total predicate over arbitrary values, like every other `foo?` in the
+/// codebase -- deliberately NOT given the foreign-owner check (unlike
+/// channel-send/channel-receive), so a program defensively guarding with
+/// `(channel? x)` gets `#f`-and-skip instead of a raise.
 fn channelPredFn(args: []const Value) PrimitiveError!Value {
     return if (types.isChannel(args[0])) types.TRUE else types.FALSE;
 }

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -40,6 +40,20 @@ pub const Envelope = struct {
     /// built envelope, or it tears down everything it allocated and
     /// propagates deepCopy's error -- callers never have to decide whether
     /// a half-built envelope needs cleanup.
+    ///
+    /// Deliberate deviation from KEP-0002 §1's "the same way GC.initForThread
+    /// does (sharing the process-wide symbol table)": this uses plain
+    /// GC.init, a private per-envelope symbol table, so a message's symbols
+    /// are copied rather than aliased. An envelope can outlive the thread
+    /// that built it (§7: a sender may exit while its message is still
+    /// queued), so aliasing that thread's symbol table would leave the
+    /// envelope holding Symbol objects the owning GC could already have
+    /// freed by the time a receiver -- or destroyHook, on whichever thread
+    /// drops the last refcount -- reads the graph: a use-after-free. The
+    /// cost is that a symbol crossing a channel is `equal?` but not
+    /// necessarily `eq?` to the receiver's own copy of the same name;
+    /// revisit only alongside a genuinely process-global (not per-thread
+    /// chained) symbol table.
     pub fn create(payload: Value) !*Envelope {
         const gc = try std.heap.c_allocator.create(memory.GC);
         gc.* = memory.GC.init(std.heap.c_allocator);
@@ -54,6 +68,7 @@ pub const Envelope = struct {
         }
 
         const env = try std.heap.c_allocator.create(Envelope);
+        errdefer std.heap.c_allocator.destroy(env);
         env.* = .{ .gc = gc };
         env.value = try gc.deepCopy(payload);
         return env;
@@ -260,7 +275,9 @@ pub const SendOutcome = union(enum) {
 /// registered only by the full-channel park branch, which is provably
 /// unreachable through the public Scheme API in Phase 1 (capacity is
 /// always null) -- callers that only ever pass unbounded/open channels may
-/// pass null.
+/// pass null; a null notifier on that branch simply registers nothing
+/// (there is nothing yet to wake) rather than panicking, so a future caller
+/// that *can* reach this branch without a real notifier degrades safely.
 pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !SendOutcome {
     memory.spinLock(&sc.lock);
     if (sc.closed) {
@@ -269,7 +286,7 @@ pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !Sen
     }
     if (sc.capacity) |cap| {
         if (sc.queue_len + sc.reserved >= cap) {
-            sc.registerSendWaiter(notifier.?);
+            if (notifier) |n| sc.registerSendWaiter(n);
             memory.spinUnlock(&sc.lock);
             return .would_park;
         }
@@ -314,7 +331,8 @@ pub const RecvOutcome = union(enum) {
     eof,
 };
 
-/// KEP-0002 §4 receive, on the shared representation, verbatim.
+/// KEP-0002 §4 receive, on the shared representation, verbatim. `notifier`
+/// follows send()'s same null-is-safe convention on the park branch.
 pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifier) !RecvOutcome {
     memory.spinLock(&sc.lock);
     if (sc.popFront()) |env| {
@@ -347,7 +365,7 @@ pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifi
     // Reached with the channel open, or closed with admitted sends still in
     // flight: eof must not race a reservation, so the receiver parks and is
     // rung by the late push (or by send's failure-path closed-channel ring).
-    sc.registerRecvWaiter(notifier.?);
+    if (notifier) |n| sc.registerRecvWaiter(n);
     memory.spinUnlock(&sc.lock);
     return .would_park;
 }

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -1,0 +1,353 @@
+const std = @import("std");
+const shared_object = @import("shared_object.zig");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const Value = types.Value;
+
+/// KEP-0002 §5's cross-thread wakeup handle. Refcounted, but -- unlike
+/// SharedChannel -- NOT an instance of the shared_object protocol: its
+/// references come only from SharedChannel waiter lists (§7), never from
+/// heap stubs, so it has its own plain refcount and is invisible to
+/// shared_object.liveCount()'s leak check.
+///
+/// Phase 1 wires up only the waiter-list bookkeeping (registration, dedup,
+/// snapshot-and-clear) needed to make promotion and send/receive correct
+/// and unit-testable. The reactor-backed notify() (kqueue EVFILT.USER /
+/// eventfd) is KEP-0002 Phase 3 (#1468); until then `ring` below just
+/// releases each registration's refcount.
+pub const ThreadNotifier = struct {
+    refcount: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+};
+
+fn retainNotifier(n: *ThreadNotifier) void {
+    _ = n.refcount.fetchAdd(1, .monotonic);
+}
+
+fn releaseNotifier(n: *ThreadNotifier) void {
+    _ = n.refcount.fetchSub(1, .acq_rel);
+}
+
+/// A message-sized private mini-heap (KEP-0002 §1): the sender's deepCopy
+/// fills it once, the receiver's deepCopy drains it once, then it is
+/// destroyed wholesale.
+pub const Envelope = struct {
+    gc: *memory.GC,
+    value: Value = types.VOID,
+    next: ?*Envelope = null,
+
+    /// Builds a private mini-heap and deep-copies `payload` into it.
+    /// Atomic from the caller's perspective: either this returns a fully
+    /// built envelope, or it tears down everything it allocated and
+    /// propagates deepCopy's error -- callers never have to decide whether
+    /// a half-built envelope needs cleanup.
+    pub fn create(payload: Value) !*Envelope {
+        const gc = try std.heap.c_allocator.create(memory.GC);
+        gc.* = memory.GC.init(std.heap.c_allocator);
+        // Defense in depth: deepCopy's own no_collect guard already
+        // suppresses any collection attempt while filling this heap (see
+        // gc_deep_copy.zig); this additionally guards against ever running
+        // a real collect() on a heap that no other GC's root marker can see.
+        gc.enabled = false;
+        errdefer {
+            gc.deinit();
+            std.heap.c_allocator.destroy(gc);
+        }
+
+        const env = try std.heap.c_allocator.create(Envelope);
+        env.* = .{ .gc = gc };
+        env.value = try gc.deepCopy(payload);
+        return env;
+    }
+
+    /// Frees the entire message graph in one sweep -- gc.deinit() walks
+    /// every tracked object through gc_collect.freeObject, which releases
+    /// any stub refcounts the message holds (e.g. a channel-in-channel
+    /// self-send's aliased stub). No separate envelope-specific bookkeeping
+    /// exists; this is the same teardown path a real GC uses.
+    pub fn deinit(self: *Envelope) void {
+        self.gc.deinit();
+        std.heap.c_allocator.destroy(self.gc);
+        std.heap.c_allocator.destroy(self);
+    }
+};
+
+pub const SharedChannel = struct {
+    header: shared_object.Header = undefined,
+    // Zig 0.16 has no blocking std.Thread.Mutex (std.Io.Mutex needs an Io
+    // instance); this codebase's established substitute is memory.zig's
+    // lock-free spin mutex (matches memory.symbol_mutex, ChildRegistry.mutex
+    // in primitives_srfi18.zig). Held only for O(1) queue/waiter-list
+    // operations -- the envelope build always happens with it released.
+    lock: std.atomic.Mutex = .unlocked,
+    queue_head: ?*Envelope = null,
+    queue_tail: ?*Envelope = null,
+    queue_len: u32 = 0,
+    /// Slots claimed by in-flight sends (§4) -- always 0 outside a send()
+    /// call in progress.
+    reserved: u32 = 0,
+    /// null = unbounded. Always null in Phase 1: no Scheme-level API sets
+    /// this yet (make-channel with a capacity argument is Phase 4);
+    /// reachable in Phase 1 only via a white-box test that constructs a
+    /// SharedChannel directly.
+    capacity: ?u32 = null,
+    /// Always false in Phase 1: channel-close! is Phase 4.
+    closed: bool = false,
+    recv_waiters: std.ArrayList(*ThreadNotifier) = .empty,
+    send_waiters: std.ArrayList(*ThreadNotifier) = .empty,
+
+    /// §1 refcount state machine: creates with refcount 1 -- the promoting
+    /// object itself becomes the first counted stub.
+    pub fn create() !*SharedChannel {
+        const self = try std.heap.c_allocator.create(SharedChannel);
+        self.* = .{};
+        shared_object.init(&self.header, destroyHook);
+        return self;
+    }
+
+    /// +1: a new stub was created (deepCopy's alias arm).
+    pub fn retain(self: *SharedChannel) void {
+        shared_object.retain(&self.header);
+    }
+
+    /// -1: a stub was freed. Destroys at zero.
+    pub fn release(self: *SharedChannel) void {
+        shared_object.release(&self.header);
+    }
+
+    /// §1 rule 4 / §7: zero destroys. Drains and deinits every queued
+    /// envelope (recursively releasing any stub refcounts those messages
+    /// hold -- this is what reclaims a channel that was only kept alive by
+    /// a stub inside its own queue, once that queue itself is finally
+    /// drained), releases remaining waiter registrations, frees.
+    fn destroyHook(header: *shared_object.Header) void {
+        const self: *SharedChannel = @fieldParentPtr("header", header);
+
+        memory.spinLock(&self.lock);
+        var env = self.queue_head;
+        self.queue_head = null;
+        self.queue_tail = null;
+        self.queue_len = 0;
+        memory.spinUnlock(&self.lock);
+
+        while (env) |e| {
+            const next = e.next;
+            e.deinit();
+            env = next;
+        }
+
+        for (self.recv_waiters.items) |n| releaseNotifier(n);
+        for (self.send_waiters.items) |n| releaseNotifier(n);
+        self.recv_waiters.deinit(std.heap.c_allocator);
+        self.send_waiters.deinit(std.heap.c_allocator);
+        std.heap.c_allocator.destroy(self);
+    }
+
+    // -- intrusive FIFO: caller holds `lock` --
+
+    fn pushBack(self: *SharedChannel, env: *Envelope) void {
+        env.next = null;
+        if (self.queue_tail) |tail| {
+            tail.next = env;
+        } else {
+            self.queue_head = env;
+        }
+        self.queue_tail = env;
+        self.queue_len += 1;
+    }
+
+    fn popFront(self: *SharedChannel) ?*Envelope {
+        const env = self.queue_head orelse return null;
+        self.queue_head = env.next;
+        if (self.queue_head == null) self.queue_tail = null;
+        env.next = null;
+        self.queue_len -= 1;
+        return env;
+    }
+
+    /// §4 receive-side copy failure: re-queue at the head, FIFO preserved
+    /// ("receive fails ⇒ nothing received").
+    fn pushFront(self: *SharedChannel, env: *Envelope) void {
+        env.next = self.queue_head;
+        if (self.queue_head == null) self.queue_tail = env;
+        self.queue_head = env;
+        self.queue_len += 1;
+    }
+
+    // -- §7 waiter lifecycle: caller holds `lock` --
+
+    fn registerSendWaiter(self: *SharedChannel, n: *ThreadNotifier) void {
+        for (self.send_waiters.items) |existing| {
+            if (existing == n) return; // dedup: at most one entry per notifier per list
+        }
+        self.send_waiters.append(std.heap.c_allocator, n) catch @panic("SharedChannel: send_waiters OOM");
+        retainNotifier(n);
+    }
+
+    fn registerRecvWaiter(self: *SharedChannel, n: *ThreadNotifier) void {
+        for (self.recv_waiters.items) |existing| {
+            if (existing == n) return;
+        }
+        self.recv_waiters.append(std.heap.c_allocator, n) catch @panic("SharedChannel: recv_waiters OOM");
+        retainNotifier(n);
+    }
+
+    fn snapshotAndClearSendWaiters(self: *SharedChannel, out: *std.ArrayList(*ThreadNotifier)) void {
+        out.appendSlice(std.heap.c_allocator, self.send_waiters.items) catch @panic("SharedChannel: snapshot OOM");
+        self.send_waiters.clearRetainingCapacity();
+    }
+
+    fn snapshotAndClearRecvWaiters(self: *SharedChannel, out: *std.ArrayList(*ThreadNotifier)) void {
+        out.appendSlice(std.heap.c_allocator, self.recv_waiters.items) catch @panic("SharedChannel: snapshot OOM");
+        self.recv_waiters.clearRetainingCapacity();
+    }
+};
+
+/// §5: ring every notifier in a snapshot taken under the lock, after
+/// releasing it -- a live waiter list is never iterated unlocked. Phase 3
+/// (#1468) adds the real reactor notify() call here; Phase 1 just releases
+/// each registration's refcount, since nothing else consumes the snapshot.
+fn ring(notifiers: []const *ThreadNotifier) void {
+    for (notifiers) |n| releaseNotifier(n);
+}
+
+/// KEP-0002 §2. Promotes `ch` in place -- the existing heap object becomes
+/// stub #1, no new allocation for the promoting side. Callable only by the
+/// thread that owns the channel (invariant 4); the real, catchable
+/// enforcement of that is the ownership check in gc_deep_copy.zig's
+/// `.channel` arm, the only caller. This assert documents (and, in Debug/
+/// gc-stress builds, guards) the precondition at the one function whose
+/// contract depends on it.
+pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
+    if (ch.shared) |raw| {
+        return @ptrCast(@alignCast(raw));
+    }
+    std.debug.assert(ch.header.owner == gc.id);
+
+    const sc = try SharedChannel.create();
+    // Publish before draining (§2 step 2): a queued local message may
+    // contain this very channel (e.g. (channel-send ch (list ch))). With
+    // `shared` already set, the drain's own Envelope.create -> deepCopy
+    // sees an already-promoted channel and takes the alias path instead of
+    // starting a second, competing promotion that would split the queue.
+    ch.shared = sc;
+
+    var cur = ch.head;
+    ch.head = types.NIL;
+    ch.tail = types.NIL;
+    // A queued local message can itself be uncopyable (e.g. a port -- legal
+    // to have queued locally, since a purely local channel never copies
+    // anything). That propagates the error here with `ch` left promoted and
+    // the queue partially drained; not exercised by Phase 1's acceptance
+    // tests, and acceptable for a same-thread failure mode with no cross-
+    // heap sharing involved yet.
+    while (cur != types.NIL) {
+        const pair = types.toObject(cur).as(types.Pair);
+        const next = pair.cdr;
+        const env = try Envelope.create(pair.car);
+        sc.pushBack(env);
+        cur = next;
+    }
+    return sc;
+}
+
+pub const SendOutcome = union(enum) {
+    sent,
+    would_park,
+    closed,
+};
+
+/// KEP-0002 §4 send, on the shared representation, verbatim. `notifier` is
+/// registered only by the full-channel park branch, which is provably
+/// unreachable through the public Scheme API in Phase 1 (capacity is
+/// always null) -- callers that only ever pass unbounded/open channels may
+/// pass null.
+pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !SendOutcome {
+    memory.spinLock(&sc.lock);
+    if (sc.closed) {
+        memory.spinUnlock(&sc.lock);
+        return .closed;
+    }
+    if (sc.capacity) |cap| {
+        if (sc.queue_len + sc.reserved >= cap) {
+            sc.registerSendWaiter(notifier.?);
+            memory.spinUnlock(&sc.lock);
+            return .would_park;
+        }
+    }
+    sc.reserved += 1;
+    memory.spinUnlock(&sc.lock);
+
+    // Built outside the lock: deepCopy allocates and must not hold the
+    // channel mutex. A reservation was already taken, so the eventual push
+    // (on success) is infallible.
+    const env = Envelope.create(payload) catch |err| {
+        memory.spinLock(&sc.lock);
+        sc.reserved -= 1;
+        var snap: std.ArrayList(*ThreadNotifier) = .empty;
+        defer snap.deinit(std.heap.c_allocator);
+        sc.snapshotAndClearSendWaiters(&snap);
+        // A receiver may be parked waiting out this very reservation
+        // (receive step 6's reserved==0 eof guard) if the channel closed
+        // while this send was in flight.
+        if (sc.closed) sc.snapshotAndClearRecvWaiters(&snap);
+        memory.spinUnlock(&sc.lock);
+        ring(snap.items);
+        // Nothing was enqueued ("send fails ⇒ nothing sent"); Envelope
+        // .create already tore itself down internally on failure.
+        return err;
+    };
+
+    memory.spinLock(&sc.lock);
+    sc.reserved -= 1;
+    sc.pushBack(env);
+    var snap: std.ArrayList(*ThreadNotifier) = .empty;
+    defer snap.deinit(std.heap.c_allocator);
+    sc.snapshotAndClearRecvWaiters(&snap);
+    memory.spinUnlock(&sc.lock);
+    ring(snap.items);
+    return .sent;
+}
+
+pub const RecvOutcome = union(enum) {
+    value: Value,
+    would_park,
+    eof,
+};
+
+/// KEP-0002 §4 receive, on the shared representation, verbatim.
+pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifier) !RecvOutcome {
+    memory.spinLock(&sc.lock);
+    if (sc.popFront()) |env| {
+        var snap: std.ArrayList(*ThreadNotifier) = .empty;
+        defer snap.deinit(std.heap.c_allocator);
+        sc.snapshotAndClearSendWaiters(&snap); // a slot opened
+        memory.spinUnlock(&sc.lock);
+        ring(snap.items);
+
+        const value = dest_gc.deepCopy(env.value) catch |err| {
+            // "Receive fails ⇒ nothing received": the envelope is
+            // untouched, its stubs keep their refcounts, the message stays
+            // deliverable in order. Re-queue at the head, not the tail.
+            memory.spinLock(&sc.lock);
+            sc.pushFront(env);
+            var recv_snap: std.ArrayList(*ThreadNotifier) = .empty;
+            defer recv_snap.deinit(std.heap.c_allocator);
+            sc.snapshotAndClearRecvWaiters(&recv_snap);
+            memory.spinUnlock(&sc.lock);
+            ring(recv_snap.items);
+            return err;
+        };
+        env.deinit();
+        return .{ .value = value };
+    }
+    if (sc.closed and sc.reserved == 0) {
+        memory.spinUnlock(&sc.lock);
+        return .eof;
+    }
+    // Reached with the channel open, or closed with admitted sends still in
+    // flight: eof must not race a reservation, so the receiver parks and is
+    // rung by the late push (or by send's failure-path closed-channel ring).
+    sc.registerRecvWaiter(notifier.?);
+    memory.spinUnlock(&sc.lock);
+    return .would_park;
+}

--- a/src/shared_object.zig
+++ b/src/shared_object.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+
+/// KEP-0002 §1: the generic shared-object protocol. A shared object is a
+/// refcounted structure allocated from the process-global allocator
+/// (std.heap.c_allocator), outside every GC heap, so it can outlive any
+/// single thread's VM/GC. `SharedChannel` (src/shared_channel.zig) is the
+/// first instance; KEP-0003's SharedBuffer is the declared second.
+///
+/// Every reference to a shared object is a counted "stub" -- an ordinary
+/// GC-managed heap object owning exactly one refcount. `init` accounts for
+/// the promoting/creating stub (refcount 1); `retain`/`release` are the
+/// +1/-1 for every other stub created/freed afterward. The final `release`
+/// runs the type's own destroy hook, which may recursively release other
+/// shared objects' refcounts (e.g. a drained envelope releasing the stubs
+/// it contains).
+pub const Header = struct {
+    refcount: std.atomic.Value(u32),
+    destroyFn: *const fn (*Header) void,
+};
+
+/// Leak-check hook (KEP-0002 §1 rule 5 / §7): every live shared object not
+/// yet destroyed. The unit suite asserts this returns to its pre-test
+/// baseline once every handle a test took has been released -- an
+/// undestroyed shared object at that point is a bug.
+var live_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+
+/// Initialize a freshly allocated header with refcount 1 -- the promoting
+/// or creating stub is the first counted reference.
+pub fn init(header: *Header, destroyFn: *const fn (*Header) void) void {
+    header.* = .{
+        .refcount = std.atomic.Value(u32).init(1),
+        .destroyFn = destroyFn,
+    };
+    _ = live_count.fetchAdd(1, .monotonic);
+}
+
+/// +1: a new stub was created (deepCopy's alias arm, including a stub
+/// allocated inside an envelope heap).
+pub fn retain(header: *Header) void {
+    // Incrementing from a location that already holds a valid reference
+    // needs no synchronization with any concurrent releaser (same
+    // justification as Arc::clone / intrusive_ptr_add_ref).
+    _ = header.refcount.fetchAdd(1, .monotonic);
+}
+
+/// -1: a stub was freed (a heap collection, a child heap torn down at
+/// thread-join!, an envelope.deinit()). Runs the type's destroy hook
+/// exactly once, at the transition to zero.
+pub fn release(header: *Header) void {
+    // acq_rel: the decrement that takes refcount to zero must happen-after
+    // every prior retain/release on other threads (so destroyFn never runs
+    // while another thread is still mid-retain), and destroyFn's own reads
+    // of the object must happen-after all of those releases.
+    if (header.refcount.fetchSub(1, .acq_rel) == 1) {
+        header.destroyFn(header);
+        _ = live_count.fetchSub(1, .monotonic);
+    }
+}
+
+pub fn liveCount() usize {
+    return live_count.load(.monotonic);
+}

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -1,0 +1,449 @@
+const std = @import("std");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const shared_channel = @import("shared_channel.zig");
+const shared_object = @import("shared_object.zig");
+const th = @import("testing_helpers.zig");
+
+// KEP-0002 Phase 1 (#1466). Everything here follows tests_deepcopy.zig's
+// bare-GC pattern (no VM, no fiber scheduler) except the last regression
+// test, which drives a real VM and OS thread. Any test that exercises the
+// deepCopy ownership check must save/restore `memory.gc_instance`, a
+// process-global threadlocal not reset between Zig tests.
+//
+// shared_object.liveCount() is a real process-global counter (unlike
+// std.testing.allocator, it is NOT reset per test), so every test captures
+// its own baseline and asserts a return to that baseline rather than to
+// zero -- except the one test that demonstrates the documented refcount
+// cycle leak, which asserts a permanent +1.
+//
+// GC-safety note: SharedChannel/Envelope live outside every GC heap
+// (std.heap.c_allocator), so building/tearing them down never risks a
+// gc-stress collection. Where a test's own bare GC (gc1, outer_gc, ...)
+// performs more than one allocation with an unrooted Channel value live in
+// a Zig local across them, that value is rooted via pushRoot/popRoot per
+// .claude/rules/gc-safety.md.
+
+var shared_object_test_destroy_count: u32 = 0;
+fn testDestroyHook(_: *shared_object.Header) void {
+    shared_object_test_destroy_count += 1;
+}
+
+test "shared_object: init/retain/release destroys exactly at zero" {
+    const baseline = shared_object.liveCount();
+    shared_object_test_destroy_count = 0;
+
+    var header: shared_object.Header = undefined;
+    shared_object.init(&header, testDestroyHook);
+    try std.testing.expectEqual(baseline + 1, shared_object.liveCount());
+
+    shared_object.retain(&header);
+    shared_object.retain(&header);
+    shared_object.release(&header);
+    shared_object.release(&header);
+    try std.testing.expectEqual(@as(u32, 0), shared_object_test_destroy_count);
+    try std.testing.expectEqual(baseline + 1, shared_object.liveCount());
+
+    shared_object.release(&header);
+    try std.testing.expectEqual(@as(u32, 1), shared_object_test_destroy_count);
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "promoteChannel on an empty channel: refcount 1, queue empty, head/tail cleared" {
+    const baseline = shared_object.liveCount();
+    var gc1 = memory.GC.init(std.testing.allocator);
+
+    const ch_val = try gc1.allocChannel();
+    const ch = types.toObject(ch_val).as(types.Channel);
+
+    const sc = try shared_channel.promoteChannel(&gc1, ch);
+    try std.testing.expect(ch.shared != null);
+    try std.testing.expectEqual(@as(?*shared_channel.Envelope, null), sc.queue_head);
+    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
+    try std.testing.expectEqual(types.NIL, ch.head);
+    try std.testing.expectEqual(types.NIL, ch.tail);
+
+    // Idempotent: a second call returns the same SharedChannel, no new stub.
+    const sc_again = try shared_channel.promoteChannel(&gc1, ch);
+    try std.testing.expectEqual(sc, sc_again);
+
+    // `ch` itself is stub #1 (§1: "the promoting object itself becomes the
+    // first counted stub") -- gc1.deinit() releases sc's refcount via ch's
+    // own freeObject teardown. Do NOT also call sc.release() here: ch is
+    // still tracked by gc1, so that would double-release (and, since
+    // release() frees at zero, double-free) the same stub.
+    gc1.deinit();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "promoteChannel on a non-empty channel: drains FIFO order into envelopes" {
+    const baseline = shared_object.liveCount();
+    var gc1 = memory.GC.init(std.testing.allocator);
+
+    var ch_val = try gc1.allocChannel();
+    gc1.pushRoot(&ch_val);
+    const ch = types.toObject(ch_val).as(types.Channel);
+
+    // Enqueue 1, 2, 3 the same way channel-send's local path does.
+    var n: i64 = 1;
+    while (n <= 3) : (n += 1) {
+        const new_pair = try gc1.allocPair(types.makeFixnum(n), types.NIL);
+        if (ch.tail != types.NIL) {
+            types.toObject(ch.tail).as(types.Pair).cdr = new_pair;
+        }
+        ch.tail = new_pair;
+        if (ch.head == types.NIL) ch.head = new_pair;
+        gc1.writeBarrier(types.toObject(ch_val), new_pair);
+    }
+    gc1.popRoot();
+
+    const sc = try shared_channel.promoteChannel(&gc1, ch);
+
+    var expected: i64 = 1;
+    var env = sc.queue_head;
+    while (env) |e| : (expected += 1) {
+        try std.testing.expectEqual(expected, types.toFixnum(e.value));
+        env = e.next;
+    }
+    try std.testing.expectEqual(@as(i64, 4), expected);
+    try std.testing.expectEqual(@as(u32, 3), sc.queue_len);
+
+    // As above: ch owns stub #1, so gc1.deinit() alone releases it (and,
+    // recursively, sc's destroyHook then drains and deinits the 3 queued
+    // envelopes) -- no separate sc.release() call.
+    gc1.deinit();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "deepCopy .channel arm promotes on first encounter and aliases thereafter (channel-in-channel identity)" {
+    const baseline = shared_object.liveCount();
+    var gc1 = memory.GC.init(std.testing.allocator);
+    var gc2 = memory.GC.init(std.testing.allocator);
+    var gc3 = memory.GC.init(std.testing.allocator);
+
+    const ch_val = try gc1.allocChannel();
+    const ch = types.toObject(ch_val).as(types.Channel);
+    try std.testing.expect(ch.shared == null);
+
+    const saved_gc = memory.gc_instance;
+    memory.gc_instance = &gc1; // gc1 is the calling thread's own gc -- legal to promote
+    const stub2 = try gc2.deepCopy(ch_val);
+    const stub3 = try gc3.deepCopy(ch_val);
+    memory.gc_instance = saved_gc;
+
+    try std.testing.expect(ch.shared != null); // promoted by the first deepCopy
+
+    const sc2 = types.toObject(stub2).as(types.Channel).shared.?;
+    const sc3 = types.toObject(stub3).as(types.Channel).shared.?;
+    // Same SharedChannel across two independently-copied stubs: identity survives.
+    try std.testing.expectEqual(sc2, sc3);
+    try std.testing.expect(stub2 != stub3); // distinct heap objects, though
+
+    gc1.deinit();
+    gc2.deinit();
+    gc3.deinit();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "deepCopy .channel arm rejects a foreign, unpromoted channel" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+    var gc3 = memory.GC.init(std.testing.allocator);
+    defer gc3.deinit();
+
+    const ch_val = try gc1.allocChannel(); // owned by gc1, never promoted
+
+    const saved_gc = memory.gc_instance;
+    defer memory.gc_instance = saved_gc;
+    memory.gc_instance = &gc3; // gc3 is neither the owner nor the destination
+
+    try std.testing.expectError(error.UncopyableType, gc2.deepCopy(ch_val));
+    try std.testing.expect(types.toObject(ch_val).as(types.Channel).shared == null);
+}
+
+test "re-entrant promotion: a channel whose own queue contains itself (and the documented cycle leak)" {
+    const baseline = shared_object.liveCount();
+    var gc1 = memory.GC.init(std.testing.allocator);
+
+    var ch_val = try gc1.allocChannel();
+    gc1.pushRoot(&ch_val);
+    const ch = types.toObject(ch_val).as(types.Channel);
+    // Mirrors (channel-send ch ch) on the local path.
+    const self_pair = try gc1.allocPair(ch_val, types.NIL);
+    ch.head = self_pair;
+    ch.tail = self_pair;
+    gc1.writeBarrier(types.toObject(ch_val), self_pair);
+    gc1.popRoot();
+
+    const sc = try shared_channel.promoteChannel(&gc1, ch);
+
+    // The drain's own deepCopy meets `ch` again mid-promotion; with `shared`
+    // already published (step 2), it must take the alias path, not start a
+    // second, competing promotion.
+    try std.testing.expectEqual(@as(u32, 1), sc.queue_len);
+    const env = sc.queue_head.?;
+    const inner_ch = types.toObject(env.value).as(types.Channel);
+    try std.testing.expect(inner_ch.shared != null);
+    const inner_sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(inner_ch.shared.?));
+    try std.testing.expectEqual(sc, inner_sc);
+
+    // Known limitation (§1): the envelope holds a stub of `sc` itself, so
+    // dropping ch's own stub can never bring refcount to zero -- the last
+    // reference is the stub inside sc's own queue. This is the accepted
+    // refcount-cycle leak, not a bug: assert it is *present* and stable, so
+    // this test breaks loudly if the leak's behavior ever silently changes.
+    gc1.deinit();
+    try std.testing.expectEqual(baseline + 1, shared_object.liveCount());
+}
+
+test "refcount teardown: a channel-in-channel message drains and destroys recursively when never received" {
+    const baseline = shared_object.liveCount();
+    var outer_gc = memory.GC.init(std.testing.allocator);
+    var inner_gc = memory.GC.init(std.testing.allocator);
+
+    var outer_val = try outer_gc.allocChannel(); // channel A
+    outer_gc.pushRoot(&outer_val);
+    const outer_ch = types.toObject(outer_val).as(types.Channel);
+
+    const inner_val = try inner_gc.allocChannel(); // channel B, a DIFFERENT SharedChannel
+
+    const saved_gc = memory.gc_instance;
+    memory.gc_instance = &inner_gc; // B's owner, for its promotion
+    const b_stub_on_outer = try outer_gc.deepCopy(inner_val); // promotes B, aliases onto outer_gc
+    memory.gc_instance = saved_gc;
+
+    var b_stub_root = b_stub_on_outer;
+    outer_gc.pushRoot(&b_stub_root);
+    const pair = try outer_gc.allocPair(b_stub_on_outer, types.NIL); // A's local queue holds B's stub
+    outer_gc.popRoot();
+
+    outer_ch.head = pair;
+    outer_ch.tail = pair;
+    outer_gc.writeBarrier(types.toObject(outer_val), pair);
+    outer_gc.popRoot(); // outer_val
+
+    memory.gc_instance = &outer_gc; // A's owner, for its own promotion
+    const sc_a = try shared_channel.promoteChannel(&outer_gc, outer_ch);
+    memory.gc_instance = saved_gc;
+
+    try std.testing.expectEqual(@as(u32, 1), sc_a.queue_len);
+
+    // Neither channel is ever received. Dropping every stub (both GCs'
+    // teardown) must still recursively release B's refcount via A's queued
+    // envelope's own teardown -- no separate envelope bookkeeping exists.
+    outer_gc.deinit();
+    inner_gc.deinit();
+
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "send: succeeds on an unbounded, open channel and pushes an envelope" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const payload = try src_gc.allocPair(types.makeFixnum(7), types.NIL);
+
+    const outcome = try shared_channel.send(sc, payload, null);
+    try std.testing.expectEqual(shared_channel.SendOutcome.sent, outcome);
+    try std.testing.expectEqual(@as(u32, 1), sc.queue_len);
+    try std.testing.expectEqual(@as(u32, 0), sc.reserved);
+
+    src_gc.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "send: payload is deep-copied into an independent envelope heap" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const payload = try src_gc.allocPair(types.makeFixnum(1), types.NIL);
+
+    _ = try shared_channel.send(sc, payload, null);
+
+    // Mutate the original after sending -- the envelope's copy must be unaffected.
+    types.toObject(payload).as(types.Pair).car = types.makeFixnum(999);
+
+    const env = sc.queue_head.?;
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(types.car(env.value)));
+
+    src_gc.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "send: build failure leaves the queue and reservation untouched (send fails => nothing sent)" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const port = try src_gc.allocStringInputPort("x"); // uncopyable
+
+    try std.testing.expectError(error.UncopyableType, shared_channel.send(sc, port, null));
+    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
+    try std.testing.expectEqual(@as(u32, 0), sc.reserved);
+    try std.testing.expectEqual(@as(?*shared_channel.Envelope, null), sc.queue_head);
+
+    src_gc.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "send: bounded-and-full channel registers a send waiter and would park" {
+    // White-box: no Phase-1 Scheme API constructs a channel with a
+    // non-null capacity yet (KEP-0002 Phase 4) -- direct construction only.
+    const sc = try shared_channel.SharedChannel.create();
+    sc.capacity = 0;
+
+    var notifier = shared_channel.ThreadNotifier{};
+    const outcome = try shared_channel.send(sc, types.makeFixnum(1), &notifier);
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, outcome);
+    try std.testing.expectEqual(@as(usize, 1), sc.send_waiters.items.len);
+    try std.testing.expectEqual(@as(u32, 1), notifier.refcount.load(.monotonic));
+
+    sc.release();
+}
+
+test "send: registering the same waiter twice does not double the refcount (§7 dedup)" {
+    const sc = try shared_channel.SharedChannel.create();
+    sc.capacity = 0;
+    var notifier = shared_channel.ThreadNotifier{};
+
+    _ = try shared_channel.send(sc, types.makeFixnum(1), &notifier);
+    _ = try shared_channel.send(sc, types.makeFixnum(2), &notifier);
+
+    try std.testing.expectEqual(@as(usize, 1), sc.send_waiters.items.len);
+    try std.testing.expectEqual(@as(u32, 1), notifier.refcount.load(.monotonic));
+
+    sc.release();
+}
+
+test "send: on a closed channel returns .closed without mutating the queue" {
+    const sc = try shared_channel.SharedChannel.create();
+    sc.closed = true;
+
+    const outcome = try shared_channel.send(sc, types.makeFixnum(1), null);
+    try std.testing.expectEqual(shared_channel.SendOutcome.closed, outcome);
+    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
+
+    sc.release();
+}
+
+test "receive: pops a non-empty queue and deep-copies into the destination gc" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const payload = try src_gc.allocPair(types.makeFixnum(5), types.NIL);
+    _ = try shared_channel.send(sc, payload, null);
+    src_gc.deinit();
+
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    const outcome = try shared_channel.receive(sc, &dest_gc, null);
+    const value = switch (outcome) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(types.car(value)));
+    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
+
+    dest_gc.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "receive: copy-out failure re-queues the envelope at the head (receive fails => nothing received)" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const payload = try src_gc.allocPair(types.makeFixnum(11), types.NIL);
+    _ = try shared_channel.send(sc, payload, null);
+    src_gc.deinit();
+
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    dest_gc.allocator = failing.allocator();
+
+    try std.testing.expectError(error.OutOfMemory, shared_channel.receive(sc, &dest_gc, null));
+    try std.testing.expectEqual(@as(u32, 1), sc.queue_len); // FIFO preserved: still queued
+
+    dest_gc.allocator = std.testing.allocator; // restore before deinit (matches how it was built)
+    dest_gc.deinit();
+
+    // The message is still deliverable, in order, on a subsequent receive.
+    var dest_gc2 = memory.GC.init(std.testing.allocator);
+    const outcome = try shared_channel.receive(sc, &dest_gc2, null);
+    const value = switch (outcome) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(i64, 11), types.toFixnum(types.car(value)));
+
+    dest_gc2.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "receive: empty and closed with reserved==0 returns eof" {
+    const sc = try shared_channel.SharedChannel.create();
+    sc.closed = true;
+
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    defer dest_gc.deinit();
+
+    const outcome = try shared_channel.receive(sc, &dest_gc, null);
+    try std.testing.expectEqual(shared_channel.RecvOutcome.eof, outcome);
+
+    sc.release();
+}
+
+test "receive: empty and open registers a recv waiter and would park" {
+    const sc = try shared_channel.SharedChannel.create();
+
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    defer dest_gc.deinit();
+    var notifier = shared_channel.ThreadNotifier{};
+
+    const outcome = try shared_channel.receive(sc, &dest_gc, &notifier);
+    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, outcome);
+    try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
+    try std.testing.expectEqual(@as(u32, 1), notifier.refcount.load(.monotonic));
+
+    sc.release();
+}
+
+test "Motivation Path 2 regression: a channel reached through a shared global raises instead of corrupting memory" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Before this fix: the child's channel-send spliced a child-heap pair
+    // into the parent-heap channel, and a subsequent channel-receive read
+    // freed/garbage memory. After: the foreign-owner check on
+    // channel-send raises inside the child, reraised at thread-join!; the
+    // channel is left untouched, so channel-receive correctly deadlocks
+    // (nothing was ever sent) instead of returning corrupted data.
+    const result = try vm.eval(
+        \\(define ch (make-channel))
+        \\(define send-result
+        \\  (guard (e (#t 'caught))
+        \\    (thread-join! (thread-start! (make-thread (lambda () (channel-send ch 42)))))
+        \\    'not-caught))
+        \\(define recv-result
+        \\  (guard (e (#t 'deadlocked))
+        \\    (channel-receive ch)))
+        \\(list send-result recv-result)
+    );
+    const send_result = types.car(result);
+    const recv_result = types.car(types.cdr(result));
+    try std.testing.expect(types.isSymbol(send_result));
+    try std.testing.expectEqualStrings("caught", types.symbolName(send_result));
+    try std.testing.expect(types.isSymbol(recv_result));
+    try std.testing.expectEqualStrings("deadlocked", types.symbolName(recv_result));
+}

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -126,10 +126,10 @@ test "deepCopy .channel arm promotes on first encounter and aliases thereafter (
     try std.testing.expect(ch.shared == null);
 
     const saved_gc = memory.gc_instance;
+    defer memory.gc_instance = saved_gc;
     memory.gc_instance = &gc1; // gc1 is the calling thread's own gc -- legal to promote
     const stub2 = try gc2.deepCopy(ch_val);
     const stub3 = try gc3.deepCopy(ch_val);
-    memory.gc_instance = saved_gc;
 
     try std.testing.expect(ch.shared != null); // promoted by the first deepCopy
 
@@ -210,9 +210,9 @@ test "refcount teardown: a channel-in-channel message drains and destroys recurs
     const inner_val = try inner_gc.allocChannel(); // channel B, a DIFFERENT SharedChannel
 
     const saved_gc = memory.gc_instance;
+    defer memory.gc_instance = saved_gc;
     memory.gc_instance = &inner_gc; // B's owner, for its promotion
     const b_stub_on_outer = try outer_gc.deepCopy(inner_val); // promotes B, aliases onto outer_gc
-    memory.gc_instance = saved_gc;
 
     var b_stub_root = b_stub_on_outer;
     outer_gc.pushRoot(&b_stub_root);
@@ -226,7 +226,6 @@ test "refcount teardown: a channel-in-channel message drains and destroys recurs
 
     memory.gc_instance = &outer_gc; // A's owner, for its own promotion
     const sc_a = try shared_channel.promoteChannel(&outer_gc, outer_ch);
-    memory.gc_instance = saved_gc;
 
     try std.testing.expectEqual(@as(u32, 1), sc_a.queue_len);
 
@@ -237,6 +236,94 @@ test "refcount teardown: a channel-in-channel message drains and destroys recurs
     inner_gc.deinit();
 
     try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "reply-to worked example (§1): the received half, with the rc 1->2->3->2 progression" {
+    const baseline = shared_object.liveCount();
+    var sender_gc = memory.GC.init(std.testing.allocator);
+    var dest_gc = memory.GC.init(std.testing.allocator);
+
+    const saved_gc = memory.gc_instance;
+    defer memory.gc_instance = saved_gc;
+    memory.gc_instance = &sender_gc;
+
+    // "tasks" is already shared before this send, per the KEP's own framing.
+    // Rooted for the whole test: nothing else keeps it GC-reachable, and a
+    // gc-stress collection triggered by the *next* allocation would
+    // otherwise sweep it -- freeObject's .channel arm would then release
+    // tasks_sc's only refcount and destroy it out from under this test.
+    var tasks_val = try sender_gc.allocChannel();
+    sender_gc.pushRoot(&tasks_val);
+    const tasks_ch = types.toObject(tasks_val).as(types.Channel);
+    const tasks_sc = try shared_channel.promoteChannel(&sender_gc, tasks_ch);
+
+    // "reply" starts local to the sender -- rc 1 (its own stub) once sent.
+    var reply_val = try sender_gc.allocChannel();
+    sender_gc.pushRoot(&reply_val);
+    const reply_ch = types.toObject(reply_val).as(types.Channel);
+    try std.testing.expect(reply_ch.shared == null);
+
+    const send_outcome = try shared_channel.send(tasks_sc, reply_val, null);
+    try std.testing.expectEqual(shared_channel.SendOutcome.sent, send_outcome);
+    try std.testing.expect(reply_ch.shared != null); // promoted as a side effect of the send
+    const reply_sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(reply_ch.shared.?));
+
+    // Receive on a *different* heap: the copied-out value's alias arm runs
+    // against an envelope-owned stub (obj.owner = the envelope GC's id, not
+    // memory.gc_instance) -- exactly why the alias path deliberately skips
+    // the ownership check.
+    const recv_outcome = try shared_channel.receive(tasks_sc, &dest_gc, null);
+    const received_val = switch (recv_outcome) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    const received_ch = types.toObject(received_val).as(types.Channel);
+    try std.testing.expect(received_ch.shared != null);
+    const received_sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(received_ch.shared.?));
+
+    // Identity survives the round trip: a different heap object aliasing
+    // the same SharedChannel -- this is what makes reply-to patterns work.
+    try std.testing.expectEqual(reply_sc, received_sc);
+    try std.testing.expect(received_val != reply_val);
+
+    // rc is now 2 (reply's own stub + the received stub) -- the envelope's
+    // own transient stub already released via envelope.deinit() inside
+    // receive(). Tear down both remaining stubs (plus tasks' unrelated one).
+    sender_gc.popRoot(); // reply_val
+    sender_gc.popRoot(); // tasks_val
+    sender_gc.deinit();
+    dest_gc.deinit();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "primitive dispatch: channel-send/channel-receive route through the shared path once promoted" {
+    // th.TestContext doesn't reset memory.gc_instance on deinit (a pre-
+    // existing gap shared by every VM-based test); harmless there since
+    // nothing else reads the threadlocal outside an active eval, but this
+    // test also pokes shared_channel.zig directly, so restore explicitly.
+    const saved_gc = memory.gc_instance;
+    defer memory.gc_instance = saved_gc;
+
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define ch (make-channel))");
+    const ch_val = try ctx.vm.eval("ch");
+    const ch = types.toObject(ch_val).as(types.Channel);
+
+    // White-box promotion: Phase 1 has no Scheme-level way to reach this
+    // state (see the module doc comment), but channelSendFn/channelReceiveFn
+    // must still dispatch correctly once a channel *is* promoted, since
+    // Phases 2/3 build on exactly this contract.
+    _ = try shared_channel.promoteChannel(&ctx.gc, ch);
+    try std.testing.expect(ch.shared != null);
+
+    const send_result = try ctx.vm.eval("(channel-send ch 1)");
+    try std.testing.expectEqual(types.VOID, send_result);
+
+    const recv_result = try ctx.vm.eval("(channel-receive ch)");
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(recv_result));
 }
 
 test "send: succeeds on an unbounded, open channel and pushes an envelope" {
@@ -418,10 +505,9 @@ test "receive: empty and open registers a recv waiter and would park" {
 }
 
 test "Motivation Path 2 regression: a channel reached through a shared global raises instead of corrupting memory" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
     // Before this fix: the child's channel-send spliced a child-heap pair
     // into the parent-heap channel, and a subsequent channel-receive read
@@ -429,7 +515,7 @@ test "Motivation Path 2 regression: a channel reached through a shared global ra
     // channel-send raises inside the child, reraised at thread-join!; the
     // channel is left untouched, so channel-receive correctly deadlocks
     // (nothing was ever sent) instead of returning corrupted data.
-    const result = try vm.eval(
+    const result = try ctx.vm.eval(
         \\(define ch (make-channel))
         \\(define send-result
         \\  (guard (e (#t 'caught))

--- a/src/types.zig
+++ b/src/types.zig
@@ -657,6 +657,12 @@ pub const Channel = struct {
     header: Object,
     head: Value,
     tail: Value,
+    /// Set exactly once, by the owning thread (KEP-0002 §2). Actually
+    /// `*shared_channel.SharedChannel` once promoted; kept opaque so
+    /// types.zig -- the dependency-free base layer -- doesn't import a
+    /// feature module, matching the FfiLibrary.handle / DirectoryObject.dir
+    /// precedent for external handles.
+    shared: ?*anyopaque = null,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -15,6 +15,7 @@ test {
     _ = @import("tests_robustness.zig");
     _ = @import("tests_fuzz.zig");
     _ = @import("tests_deepcopy.zig");
+    _ = @import("tests_shared_channel.zig");
     _ = @import("tests_ir.zig");
     _ = @import("tests_srfi18.zig");
     _ = @import("tests_fibers.zig");


### PR DESCRIPTION
## Summary

Implements KEP-0002 Phase 1 (#1466), part of the cross-thread channels epic (#1465): the generic refcounted shared-object protocol and its first instance, `SharedChannel` — everything testable on a single OS thread, ahead of Phase 2 (envelopes at thread boundaries, #1467) and Phase 3 (cross-thread wakeup, #1468).

- `src/shared_object.zig` (new): refcounted header allocated from `std.heap.c_allocator`, `init`/`retain`/`release`, and a `liveCount()` leak-check hook.
- `src/shared_channel.zig` (new): `SharedChannel` (mutex, intrusive envelope FIFO, `reserved`/`capacity`/`closed`, waiter lists), `Envelope` (private mini-heap; sender `deepCopy` in, receiver `deepCopy` out), `promoteChannel` (owner-side, publish-before-drain so re-entrant self-sends alias instead of double-promoting), and the full §4 send/receive sequences (slot reservation, build-outside-the-lock, the copy-failure paths that keep "send fails ⇒ nothing sent" and "receive fails ⇒ nothing received, FIFO preserved").
- `types.Channel` gains a `shared: ?*anyopaque` field (kept opaque so the dependency-free `types.zig` doesn't import a feature module).
- `deepCopy`'s `.channel` arm promotes an owned, unpromoted channel (or aliases an already-shared one) instead of raising `UncopyableType` unconditionally; `freeObject` releases a stub's refcount on every teardown path (GC sweep, test `deinit()`, or an envelope's own mini-heap tearing itself down).
- `channel-send`/`channel-receive` gain a foreign-owner check — this turns the KEP's Motivation Path 2 (a channel reached through a shared global silently corrupting memory) into a descriptive, catchable error.
- `src/bench_channel.zig` + `zig build bench-channel`: local fast-path regression benchmark + a single-thread envelope-cost harness over five payload shapes, the Phase 1 installment of the KEPs repo's P3 research plan.

**Scope boundary:** `thread-start!`/`thread-join!` are unchanged. Their `deepCopy` calls run on the *destination* thread (child for the thunk copy, parent for the join result), never the channel's actual owner, so promotion isn't legally reachable through them yet — that's Phase 2's job (moving the thunk copy to the parent thread before spawn). A channel captured in a thread thunk still raises today's `"thread thunk contains uncopyable type"` error, unchanged.

## Test plan

- [x] `zig build test` — full unit suite green, including the new `tests_shared_channel.zig` (promote empty/non-empty queue, deepCopy promote+alias with channel-in-channel identity, foreign-owner rejection, re-entrant self-promotion and its documented refcount-cycle leak, recursive refcount teardown across two channels, send/receive success + failure paths with FIFO preservation, waiter registration/dedup, and a real-VM/real-thread regression test for Motivation Path 2)
- [x] `zig build test -Dgc-stress=true` — green
- [x] `bash tests/scheme/run-all.sh` + `zig build run -- tests/scheme/r7rs/r7rs-tests.scm` — 1834 pass, 0 fail (behaviorally invisible to existing single-threaded programs)
- [x] `zig build wasm` — still compiles (`std.Thread`-based locking degrades on the single-threaded wasm32 target; `thread-start!` is already `is_wasm`-gated before ever reaching `deepCopy`)
- [x] `zig build bench-channel -Doptimize=ReleaseFast` before/after: local unpromoted send+receive ~108ns/op baseline vs. ~110ns/op on this branch (within noise) — satisfies invariant 3's "unmeasurable" gate
- [x] Real x86-64 Linux (DigitalOcean droplet, destroyed after): build OK, unit tests OK, full Scheme/R7RS suite 1834/0
- [x] KEP merge gate: `research/tla/run.sh` in `kaappi/keps@8aa2f1fc` — all 9 configs match their expected outcome (6 pass, 3 intentional regression-witness failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)