### PR TITLE
Envelopes at thread boundaries: thread-start!/join! via envelopes (KEP-0002 P2)

### DIFF
--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -340,11 +340,16 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         // only for the thread that owns the channel) is checked against
         // `memory_mod.gc_instance`, the threadlocal for whichever thread is
         // actually executing this copy. A foreign, not-yet-promoted channel
-        // reuses UncopyableType rather than a new error class, so
-        // thread-start!/thread-join! (primitives_srfi18.zig) -- whose
-        // deepCopy calls run on the destination thread, never the channel's
-        // owner, until KEP-0002 Phase 2 moves the thunk copy to the parent
-        // thread -- keep today's exact behavior and error message.
+        // reuses UncopyableType rather than a new error class. Since
+        // KEP-0002 Phase 2 (primitives_srfi18.zig), thread-start!'s deepCopy
+        // of the thunk runs on the parent thread (the channel's owner, if it
+        // owns one) via an Envelope built before the child is ever spawned,
+        // and thread-join!'s result/exception cross the same way built on
+        // the child thread -- both legal promotion sites. This arm is only
+        // reached with a mismatched owner when a channel is reached through
+        // a shared global instead of being captured by a thunk or message
+        // (Motivation Path 2), which is exactly the case this error exists
+        // to catch.
         .channel => {
             const ch = obj.as(types.Channel);
             // Aliasing an already-promoted stub needs no ownership check

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -95,7 +95,13 @@ const ChildThreadResources = struct {
     child_gc: *memory.GC,
     child_vm: *vm_mod.VM,
     result: JoinResult = .none,
-    exception: ?*shared_channel.Envelope = null,
+    // Same shape as `result` (not a bare `?*Envelope`): an exception whose
+    // payload is itself uncopyable (R7RS `raise` permits raising an
+    // arbitrary value, including a port or a foreign-owned channel) or
+    // whose envelope build hits OOM needs to surface as *something*
+    // diagnostic at thread-join!, not silently collapse into a void
+    // reason -- see reapOsThread's `.failed` arm for the synthesized error.
+    exception: JoinResult = .none,
 };
 
 // Entries are freed only when a thread is joined (freeChildResources called
@@ -112,7 +118,7 @@ const ChildRegistry = struct {
         try self.map.put(key, res);
     }
 
-    fn storeResult(self: *ChildRegistry, key: usize, result: JoinResult, exception: ?*shared_channel.Envelope) void {
+    fn storeResult(self: *ChildRegistry, key: usize, result: JoinResult, exception: JoinResult) void {
         memory.spinLock(&self.mutex);
         defer memory.spinUnlock(&self.mutex);
         if (self.map.getPtr(key)) |entry| {
@@ -128,8 +134,8 @@ const ChildRegistry = struct {
     // fiber ownership is otherwise unchecked -- both retrieve the SAME
     // *Envelope pointer and both call env.deinit() on it: a double-free.
     // Clearing under the lock means at most one caller ever sees a non-.none
-    // result/non-null exception to consume.
-    const TakenResult = struct { result: JoinResult, exception: ?*shared_channel.Envelope };
+    // result/non-.none exception to consume.
+    const TakenResult = struct { result: JoinResult, exception: JoinResult };
 
     fn takeResult(self: *ChildRegistry, key: usize) TakenResult {
         memory.spinLock(&self.mutex);
@@ -137,10 +143,10 @@ const ChildRegistry = struct {
         if (self.map.getPtr(key)) |entry| {
             const taken: TakenResult = .{ .result = entry.result, .exception = entry.exception };
             entry.result = .none;
-            entry.exception = null;
+            entry.exception = .none;
             return taken;
         }
-        return .{ .result = .none, .exception = null };
+        return .{ .result = .none, .exception = .none };
     }
 
     fn fetchRemove(self: *ChildRegistry, key: usize) ?ChildThreadResources {
@@ -340,10 +346,10 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
         // and thread-join! surfaces this as "uncaught exception in thread",
         // matching a thunk that fails mid-flight instead of at the boundary.
         // No child_gc/child_vm exists yet for this failure (nothing was ever
-        // spawned), so the usual child_registry.storeResult path used by
-        // every post-spawn failure in threadEntryFn doesn't apply here --
-        // this is the one place a fiber's error state is set directly.
-        fiber.current_exception = try makeErrorWithType(.general, "thread thunk contains uncopyable type (port, continuation, etc.)", types.NIL);
+        // spawned), so child_registry.storeResult -- which every *post-spawn*
+        // failure in threadEntryFn goes through instead -- doesn't apply
+        // here: this is the one place a fiber's error state is set directly.
+        fiber.current_exception = try makeErrorWithType(.general, "thread thunk contains an uncopyable type (port, continuation, etc.), or a channel owned by another thread", types.NIL);
         gc.writeBarrier(&fiber.header, fiber.current_exception.?);
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         return args[0];
@@ -440,12 +446,18 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
         // Built on this (owning) thread, mirroring thread-start!'s thunk
         // copy: this is the only place a channel raised in the exception
         // can legally promote (gc_instance == child_gc here, not the
-        // parent's gc it would be at join time).
-        const exc_envelope = if (child_vm.current_exception) |exc|
-            shared_channel.Envelope.create(exc) catch null
+        // parent's gc it would be at join time). A `.failed` build (an
+        // uncopyable type, or a channel owned by neither this thread nor
+        // the parent) still reaches reapOsThread as something diagnostic
+        // rather than silently becoming a void join reason.
+        const exc_result: JoinResult = if (child_vm.current_exception) |exc|
+            if (shared_channel.Envelope.create(exc)) |env|
+                .{ .envelope = env }
+            else |err|
+                .{ .failed = err }
         else
-            null;
-        child_registry.storeResult(@intFromPtr(fiber), .none, exc_envelope);
+            .none;
+        child_registry.storeResult(@intFromPtr(fiber), .none, exc_result);
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         return;
     };
@@ -463,7 +475,7 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
         .{ .envelope = env }
     else |err|
         .{ .failed = err };
-    child_registry.storeResult(@intFromPtr(fiber), join_result, null);
+    child_registry.storeResult(@intFromPtr(fiber), join_result, .none);
     @atomicStore(fiber_mod.FiberStatus, &fiber.status, .completed, .release);
 }
 
@@ -768,18 +780,44 @@ fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value
             .failed => |err| {
                 freeChildResources(fiber_key);
                 if (err == error.UncopyableType) {
-                    return raiseError(.general, "thread-join!: result contains uncopyable type (port, continuation, etc.)", types.VOID);
+                    // Same DeepCopyError for two different causes: a
+                    // genuinely uncopyable type (port, continuation, ...),
+                    // or a channel reached by the child through a shared
+                    // global rather than the thunk/message it was legally
+                    // handed -- gc_deep_copy.zig's `.channel` arm returns
+                    // UncopyableType for both, so this message covers both
+                    // rather than mis-describing the second as a type error.
+                    return raiseError(.general, "thread-join!: result contains an uncopyable type (port, continuation, etc.), or a channel owned by another thread", types.VOID);
                 }
                 return PrimitiveError.OutOfMemory;
             },
         }
     }
     if (target.status == .errored) {
-        if (res.exception) |exc_env| {
-            target.current_exception = gc.deepCopy(exc_env.value) catch null;
-            if (target.current_exception) |cv|
-                gc.writeBarrier(fiber_obj, cv);
-            exc_env.deinit();
+        switch (res.exception) {
+            .none => {},
+            .envelope => |exc_env| {
+                target.current_exception = gc.deepCopy(exc_env.value) catch null;
+                if (target.current_exception) |cv|
+                    gc.writeBarrier(fiber_obj, cv);
+                exc_env.deinit();
+            },
+            .failed => {
+                // The exception itself couldn't cross the boundary (an
+                // uncopyable type, or a channel owned by neither the
+                // parent nor the child -- e.g. reached via a shared
+                // global from inside the raising thunk). Before this a
+                // bare `catch null` here silently left the join reason as
+                // void; synthesize something diagnostic instead of losing
+                // the failure entirely.
+                target.current_exception = makeErrorWithType(
+                    .general,
+                    "uncaught exception in thread: the exception value contains an uncopyable type, or a channel owned by another thread",
+                    types.VOID,
+                ) catch null;
+                if (target.current_exception) |cv|
+                    gc.writeBarrier(fiber_obj, cv);
+            },
         }
     }
     freeChildResources(fiber_key);

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -5,6 +5,8 @@ const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
 const fiber_mod = @import("fiber.zig");
 const memory = @import("memory.zig");
+const shared_channel = @import("shared_channel.zig");
+const gc_deep_copy = @import("gc_deep_copy.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -73,17 +75,33 @@ pub const wasm_specs = blk: {
     break :blk out;
 };
 
+/// KEP-0002 Phase 2: what a completed thunk produced, crossing the thread
+/// boundary the same way the thunk itself crossed at thread-start! -- via an
+/// Envelope built on the *owning* thread (the child, for a result), not
+/// deep-copied directly out of the child's still-allocated heap by the
+/// parent at join time. This is what makes a channel created and returned
+/// by the child legally promotable (promotion requires gc_instance to be
+/// the channel's owner, which only holds true while the child itself is
+/// still running). `.failed` records why building the envelope itself
+/// failed (UncopyableType or OutOfMemory) so reapOsThread can raise the
+/// exact same errors the old direct-deepCopy-at-join path did.
+const JoinResult = union(enum) {
+    none, // thunk returned void; nothing to copy out
+    envelope: *shared_channel.Envelope,
+    failed: gc_deep_copy.DeepCopyError,
+};
+
 const ChildThreadResources = struct {
     child_gc: *memory.GC,
     child_vm: *vm_mod.VM,
-    result: Value = types.VOID,
-    exception: ?Value = null,
+    result: JoinResult = .none,
+    exception: ?*shared_channel.Envelope = null,
 };
 
 // Entries are freed only when a thread is joined (freeChildResources called
 // from reapOsThread). Threads that complete but are never joined leak their
-// child VM and GC — the result must survive until the parent deep-copies it,
-// and automatic cleanup would race with that copy.
+// child VM and GC — the result must survive until the parent copies it out
+// of its envelope, and automatic cleanup would race with that copy.
 const ChildRegistry = struct {
     map: std.AutoHashMap(usize, ChildThreadResources),
     mutex: std.atomic.Mutex,
@@ -94,7 +112,7 @@ const ChildRegistry = struct {
         try self.map.put(key, res);
     }
 
-    fn storeResult(self: *ChildRegistry, key: usize, result: Value, exception: ?Value) void {
+    fn storeResult(self: *ChildRegistry, key: usize, result: JoinResult, exception: ?*shared_channel.Envelope) void {
         memory.spinLock(&self.mutex);
         defer memory.spinUnlock(&self.mutex);
         if (self.map.getPtr(key)) |entry| {
@@ -103,10 +121,26 @@ const ChildRegistry = struct {
         }
     }
 
-    fn get(self: *ChildRegistry, key: usize) ?ChildThreadResources {
+    // Atomically reads AND clears result/exception (leaving child_gc/child_vm
+    // in place for freeChildResources' own fetchRemove). A plain get() would
+    // let two racing reapOsThread calls for the same fiber_key -- reachable
+    // today only through a fiber value reached via a shared global, since
+    // fiber ownership is otherwise unchecked -- both retrieve the SAME
+    // *Envelope pointer and both call env.deinit() on it: a double-free.
+    // Clearing under the lock means at most one caller ever sees a non-.none
+    // result/non-null exception to consume.
+    const TakenResult = struct { result: JoinResult, exception: ?*shared_channel.Envelope };
+
+    fn takeResult(self: *ChildRegistry, key: usize) TakenResult {
         memory.spinLock(&self.mutex);
         defer memory.spinUnlock(&self.mutex);
-        return self.map.get(key);
+        if (self.map.getPtr(key)) |entry| {
+            const taken: TakenResult = .{ .result = entry.result, .exception = entry.exception };
+            entry.result = .none;
+            entry.exception = null;
+            return taken;
+        }
+        return .{ .result = .none, .exception = null };
     }
 
     fn fetchRemove(self: *ChildRegistry, key: usize) ?ChildThreadResources {
@@ -292,12 +326,39 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
 
-    // Root the thunk (the child deep-copies it from the parent heap) and the
-    // fiber itself (the child writes fiber.status / reads fiber.terminated
-    // for the whole run, so it must survive even if the program drops its
-    // last reference). Both are removed at thread-join!.
-    gc.extra_roots.append(gc.allocator, fiber.thunk) catch return PrimitiveError.OutOfMemory;
-    gc.extra_roots.append(gc.allocator, args[0]) catch return PrimitiveError.OutOfMemory;
+    // KEP-0002 Phase 2: copy the thunk into an envelope on THIS (the owning)
+    // thread, before ever spawning the child. This closes the old
+    // concurrent-copy race (the child used to deepCopy fiber.thunk directly
+    // out of the still-running parent heap) and is the only place a channel
+    // captured by the thunk can legally promote -- promotion requires
+    // gc_instance to be the channel's owner, which is only true here, now,
+    // on the parent thread.
+    const envelope = shared_channel.Envelope.create(fiber.thunk) catch |err| {
+        if (err != error.UncopyableType) return PrimitiveError.OutOfMemory;
+        // Mirror the old error shape exactly: thread-start! itself never
+        // raises -- the fiber is left .errored (no OS thread ever spawned)
+        // and thread-join! surfaces this as "uncaught exception in thread",
+        // matching a thunk that fails mid-flight instead of at the boundary.
+        // No child_gc/child_vm exists yet for this failure (nothing was ever
+        // spawned), so the usual child_registry.storeResult path used by
+        // every post-spawn failure in threadEntryFn doesn't apply here --
+        // this is the one place a fiber's error state is set directly.
+        fiber.current_exception = try makeErrorWithType(.general, "thread thunk contains uncopyable type (port, continuation, etc.)", types.NIL);
+        gc.writeBarrier(&fiber.header, fiber.current_exception.?);
+        @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
+        return args[0];
+    };
+
+    // Root the fiber itself: the child writes fiber.status / reads
+    // fiber.terminated for the whole run, so it must survive even if the
+    // program drops its last reference. Removed at thread-join!. (The
+    // thunk needs no separate root -- its envelope snapshot is independent
+    // of the parent heap, and fiber.thunk itself is already traced by
+    // markFiberState whenever the fiber is.)
+    gc.extra_roots.append(gc.allocator, args[0]) catch {
+        envelope.deinit();
+        return PrimitiveError.OutOfMemory;
+    };
 
     fiber.status = .running;
     // Increment *before* spawning: if the child ran to completion before an
@@ -307,21 +368,26 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     // crossThreadWaitPossible wrongly conclude no other thread exists.
     _ = @atomicRmw(usize, &live_child_threads, .Add, 1, .release);
     fiber.os_thread = std.Thread.spawn(.{}, threadEntryFn, .{
-        fiber, gc.allocator, gc, vm,
+        fiber, gc.allocator, vm, envelope,
     }) catch {
         _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
+        envelope.deinit();
         return PrimitiveError.OutOfMemory;
     };
 
     return args[0];
 }
 
-fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_gc: *memory.GC, parent_vm: *vm_mod.VM) void {
+fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_vm: *vm_mod.VM, envelope: *shared_channel.Envelope) void {
     // Balances the increment in threadStartFn on every exit path (including
     // the early GC/VM-init failures below), so crossThreadWaitPossible's "is
     // another OS thread still alive" check stays accurate.
     defer _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
-    _ = parent_gc;
+    // envelope is owned solely by this function (unlike the result/exception
+    // envelopes built below, which escape into child_registry for the
+    // parent to consume) -- every exit path needs it freed exactly once.
+    defer envelope.deinit();
+
     const child_gc = allocator.create(memory.GC) catch {
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         return;
@@ -360,30 +426,44 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_g
         return;
     };
 
-    const child_thunk = child_gc.deepCopy(fiber.thunk) catch |err| {
-        if (err == error.UncopyableType) {
-            const exc = child_gc.allocErrorObject(
-                child_gc.allocString("thread thunk contains uncopyable type (port, continuation, etc.)") catch types.VOID,
-                types.NIL,
-            ) catch null;
-            child_registry.storeResult(@intFromPtr(fiber), types.VOID, exc);
-        }
+    // Copy the thunk out of the envelope into this thread's own fresh heap.
+    // thread-start! already ran the forward copy on the parent thread and
+    // rejected anything uncopyable before ever spawning this thread, so
+    // this copy-out can only fail on OOM.
+    const child_thunk = child_gc.deepCopy(envelope.value) catch {
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         return;
     };
 
     const result = child_vm.callWithArgs(child_thunk, &.{}) catch {
         if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
-        child_registry.storeResult(@intFromPtr(fiber), types.VOID, child_vm.current_exception);
+        // Built on this (owning) thread, mirroring thread-start!'s thunk
+        // copy: this is the only place a channel raised in the exception
+        // can legally promote (gc_instance == child_gc here, not the
+        // parent's gc it would be at join time).
+        const exc_envelope = if (child_vm.current_exception) |exc|
+            shared_channel.Envelope.create(exc) catch null
+        else
+            null;
+        child_registry.storeResult(@intFromPtr(fiber), .none, exc_envelope);
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         return;
     };
 
     if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
 
-    // Store result in child_resources (not on the fiber) so the parent
-    // GC never traverses a child-heap pointer (Race C).
-    child_registry.storeResult(@intFromPtr(fiber), result, null);
+    // Store the result in child_resources (not on the fiber) so the parent
+    // GC never traverses a child-heap pointer (Race C) -- and, since Phase
+    // 2, as an envelope rather than a raw Value, so a channel the thunk
+    // created and returned promotes correctly (see the exception path
+    // above for why this must run on this thread).
+    const join_result: JoinResult = if (result == types.VOID)
+        .none
+    else if (shared_channel.Envelope.create(result)) |env|
+        .{ .envelope = env }
+    else |err|
+        .{ .failed = err };
+    child_registry.storeResult(@intFromPtr(fiber), join_result, null);
     @atomicStore(fiber_mod.FiberStatus, &fiber.status, .completed, .release);
 }
 
@@ -649,14 +729,10 @@ fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const fiber_obj = types.toObject(fiber_val);
 
-    // Remove the thunk and fiber from extra_roots (added by thread-start!
-    // to keep them alive while the child runs; the child is done now).
-    for (gc.extra_roots.items, 0..) |v, idx| {
-        if (v == target.thunk) {
-            _ = gc.extra_roots.swapRemove(idx);
-            break;
-        }
-    }
+    // Remove the fiber from extra_roots (added by thread-start! to keep it
+    // alive while the child runs; the child is done now). The thunk itself
+    // is no longer separately rooted -- thread-start! consumed it into an
+    // envelope before ever spawning the child.
     for (gc.extra_roots.items, 0..) |v, idx| {
         if (v == fiber_val) {
             _ = gc.extra_roots.swapRemove(idx);
@@ -665,26 +741,45 @@ fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value
     }
     const fiber_key = @intFromPtr(target);
 
-    // Retrieve result/exception from child_registry (stored there to
-    // avoid the parent GC traversing child-heap pointers via the fiber).
-    if (child_registry.get(fiber_key)) |res| {
-        if (target.status == .completed and res.result != types.VOID) {
-            target.result = gc.deepCopy(res.result) catch |err| {
-                target.result = types.VOID;
+    // Retrieve the result/exception envelope from child_registry (stored
+    // there, not on the fiber, so the parent GC never traverses a
+    // child-heap pointer). KEP-0002 Phase 2: both crossed by envelope, built
+    // on the child thread that owns them -- the same mechanism thread-start!
+    // uses for the thunk, and the only way a channel the thunk created or
+    // raised can legally promote. takeResult (not a plain get) atomically
+    // clears both fields under the registry lock, so a fiber joined twice
+    // concurrently -- reachable via a shared global, since fiber ownership
+    // itself is otherwise unchecked -- can't hand the same *Envelope to two
+    // callers, which would double-free it.
+    const res = child_registry.takeResult(fiber_key);
+    if (target.status == .completed) {
+        switch (res.result) {
+            .none => {},
+            .envelope => |env| {
+                target.result = gc.deepCopy(env.value) catch {
+                    target.result = types.VOID;
+                    env.deinit();
+                    freeChildResources(fiber_key);
+                    return PrimitiveError.OutOfMemory;
+                };
+                gc.writeBarrier(fiber_obj, target.result);
+                env.deinit();
+            },
+            .failed => |err| {
                 freeChildResources(fiber_key);
                 if (err == error.UncopyableType) {
                     return raiseError(.general, "thread-join!: result contains uncopyable type (port, continuation, etc.)", types.VOID);
                 }
                 return PrimitiveError.OutOfMemory;
-            };
-            gc.writeBarrier(fiber_obj, target.result);
+            },
         }
-        if (target.status == .errored) {
-            if (res.exception) |exc| {
-                target.current_exception = gc.deepCopy(exc) catch null;
-                if (target.current_exception) |cv|
-                    gc.writeBarrier(fiber_obj, cv);
-            }
+    }
+    if (target.status == .errored) {
+        if (res.exception) |exc_env| {
+            target.current_exception = gc.deepCopy(exc_env.value) catch null;
+            if (target.current_exception) |cv|
+                gc.writeBarrier(fiber_obj, cv);
+            exc_env.deinit();
         }
     }
     freeChildResources(fiber_key);

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -549,30 +549,21 @@ test "Motivation Path 2 regression: a channel reached through a shared global ra
 // ---------------------------------------------------------------------------
 
 test "KEP-0002 Phase 2: thunk snapshot -- mutation after thread-start! returns is not visible to the child" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-
     // The envelope copy runs synchronously inside thread-start!, before it
     // ever returns -- so this is deterministic, not a race the test might
     // get lucky on. Before Phase 2, the child deepCopy'd fiber.thunk at some
     // arbitrary later point, so this mutation could (nondeterministically)
     // have already been visible.
-    const result = try ctx.vm.eval(
+    try th.expectEval(
         \\(let* ((v (vector 1))
         \\       (t (make-thread (lambda () (vector-ref v 0)))))
         \\  (thread-start! t)
         \\  (vector-set! v 0 999)
         \\  (thread-join! t))
-    );
-    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(result));
+    , 1);
 }
 
 test "KEP-0002 Phase 2: Motivation Path 1 -- a channel captured in the thread thunk now works end-to-end" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-
     // Before Phase 1+2: the child errored with "thread thunk contains
     // uncopyable type" (deepCopy rejected channels outright). Now: `ch` is
     // promoted on the parent thread as part of the envelope build (the only
@@ -580,14 +571,13 @@ test "KEP-0002 Phase 2: Motivation Path 1 -- a channel captured in the thread th
     // out, and the send completes entirely before thread-join! returns --
     // so the parent's subsequent receive needs no wakeup machinery
     // (Phase 2's scope explicitly excludes a receiver parking first).
-    const result = try ctx.vm.eval(
+    try th.expectEval(
         \\(let* ((ch (make-channel))
         \\       (t (make-thread (lambda () (channel-send ch 42)))))
         \\  (thread-start! t)
         \\  (thread-join! t)
         \\  (channel-receive ch))
-    );
-    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+    , 42);
 }
 
 test "KEP-0002 Phase 2: a channel created and returned by the child promotes correctly" {
@@ -611,6 +601,28 @@ test "KEP-0002 Phase 2: a channel created and returned by the child promotes cor
     );
     try std.testing.expect(types.isSymbol(result));
     try std.testing.expectEqualStrings("hello", types.symbolName(result));
+}
+
+test "KEP-0002 Phase 2: a thunk returning an uncopyable value raises the .failed path at thread-join!" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // Phase 2 rewired this from a join-side deepCopy error into a
+    // child-side Envelope.create error (JoinResult.failed), surfaced by
+    // reapOsThread's .failed arm -- pins that path specifically, distinct
+    // from the "uncopyable thunk" test above, which never reaches
+    // threadEntryFn at all (rejected before the OS thread is spawned).
+    const caught = try ctx.vm.eval(
+        \\(let* ((t (make-thread (lambda () (open-input-string "x")))))
+        \\  (thread-start! t)
+        \\  (guard (e ((error-object? e)
+        \\             (string-contains (error-object-message e) "uncopyable")))
+        \\    (thread-join! t)
+        \\    #f))
+    );
+    // string-contains returns the match index (a truthy fixnum), not #t.
+    try std.testing.expect(caught != types.FALSE);
 }
 
 test "KEP-0002 Phase 2: uncopyable thunk is detected synchronously in thread-start!, never spawns an OS thread" {
@@ -656,8 +668,21 @@ test "KEP-0002 Phase 2: thread churn -- repeated cross-thread channel round trip
         // sends across the thread boundary, joins (tearing down the child's
         // heap immediately), and receives -- exercising exactly the
         // "envelope queued by a thread that has already exited its heap"
-        // path the KEP's acceptance criteria call out.
-        const result = try ctx.vm.eval(
+        // path the KEP's acceptance criteria call out. Each iteration spawns
+        // a real OS thread, so scale the count down under -Dgc-stress=true
+        // like tests_robustness.zig's loop-heavy tests -- a stress build
+        // already collects on every allocation, so a smaller N adds no less
+        // coverage of the leak check below, just less wall time.
+        const result = try ctx.vm.eval(if (@import("build_options").gc_stress)
+            \\(let loop ((i 0) (acc 0))
+            \\  (if (= i 5)
+            \\      acc
+            \\      (let* ((ch (make-channel))
+            \\             (t (make-thread (lambda () (channel-send ch i)))))
+            \\        (thread-start! t)
+            \\        (thread-join! t)
+            \\        (loop (+ i 1) (+ acc (channel-receive ch))))))
+        else
             \\(let loop ((i 0) (acc 0))
             \\  (if (= i 20)
             \\      acc
@@ -667,7 +692,8 @@ test "KEP-0002 Phase 2: thread churn -- repeated cross-thread channel round trip
             \\        (thread-join! t)
             \\        (loop (+ i 1) (+ acc (channel-receive ch))))))
         );
-        try std.testing.expectEqual(@as(i64, 190), types.toFixnum(result)); // sum 0..19
+        const expected_sum: i64 = if (@import("build_options").gc_stress) 10 else 190; // sum 0..N-1
+        try std.testing.expectEqual(expected_sum, types.toFixnum(result));
     }
     // ctx.deinit() above frees every tracked object regardless of Scheme-
     // level reachability, including each iteration's channel stub -- so
@@ -698,9 +724,23 @@ test "KEP-0002 Phase 2: an exception raised in the child carrying a channel prom
             \\    (thread-join! t)
             \\    'not-caught))
         );
-        const inner_ch = types.toObject(result);
-        try std.testing.expectEqual(types.ObjectTag.channel, inner_ch.tag);
-        try std.testing.expect(inner_ch.as(types.Channel).shared != null);
+        try std.testing.expect(types.isChannel(result));
+        const inner_ch = types.toObject(result).as(types.Channel);
+        try std.testing.expect(inner_ch.shared != null);
+
+        // Verify the queued 'irritant-marker itself survived promotion --
+        // not just that promotion succeeded -- since this drains a
+        // non-empty local queue during the exception-envelope build, a
+        // different code path than the "channel created and returned"
+        // test above (whose channel is empty until inside the envelope).
+        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(inner_ch.shared.?));
+        const recv_outcome = try shared_channel.receive(sc, &ctx.gc, null);
+        const drained = switch (recv_outcome) {
+            .value => |v| v,
+            else => return error.TestUnexpectedResult,
+        };
+        try std.testing.expect(types.isSymbol(drained));
+        try std.testing.expectEqualStrings("irritant-marker", types.symbolName(drained));
     }
     try std.testing.expectEqual(baseline, shared_object.liveCount());
 }

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -533,3 +533,174 @@ test "Motivation Path 2 regression: a channel reached through a shared global ra
     try std.testing.expect(types.isSymbol(recv_result));
     try std.testing.expectEqualStrings("deadlocked", types.symbolName(recv_result));
 }
+
+// ---------------------------------------------------------------------------
+// KEP-0002 Phase 2 (#1467): envelopes at thread boundaries.
+//
+// thread-start! now copies the thunk into an envelope on the *parent*
+// thread, before Thread.spawn -- the child copies out of the envelope into
+// its own fresh heap instead of deepCopy-ing fiber.thunk directly out of the
+// still-running parent heap. thread-join!'s result/exception cross the same
+// way, built on the *child* thread right before it exits. Both directions
+// are exercised here with real OS threads (make-thread/thread-start!), since
+// the whole point of Phase 2 is the parent/child-thread timing -- a
+// white-box, single-thread test of Envelope.create (already covered by
+// Phase 1's tests above) can't observe the race Phase 2 closes.
+// ---------------------------------------------------------------------------
+
+test "KEP-0002 Phase 2: thunk snapshot -- mutation after thread-start! returns is not visible to the child" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // The envelope copy runs synchronously inside thread-start!, before it
+    // ever returns -- so this is deterministic, not a race the test might
+    // get lucky on. Before Phase 2, the child deepCopy'd fiber.thunk at some
+    // arbitrary later point, so this mutation could (nondeterministically)
+    // have already been visible.
+    const result = try ctx.vm.eval(
+        \\(let* ((v (vector 1))
+        \\       (t (make-thread (lambda () (vector-ref v 0)))))
+        \\  (thread-start! t)
+        \\  (vector-set! v 0 999)
+        \\  (thread-join! t))
+    );
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(result));
+}
+
+test "KEP-0002 Phase 2: Motivation Path 1 -- a channel captured in the thread thunk now works end-to-end" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // Before Phase 1+2: the child errored with "thread thunk contains
+    // uncopyable type" (deepCopy rejected channels outright). Now: `ch` is
+    // promoted on the parent thread as part of the envelope build (the only
+    // legal place, per invariant 4), aliased into the child's heap on copy-
+    // out, and the send completes entirely before thread-join! returns --
+    // so the parent's subsequent receive needs no wakeup machinery
+    // (Phase 2's scope explicitly excludes a receiver parking first).
+    const result = try ctx.vm.eval(
+        \\(let* ((ch (make-channel))
+        \\       (t (make-thread (lambda () (channel-send ch 42)))))
+        \\  (thread-start! t)
+        \\  (thread-join! t)
+        \\  (channel-receive ch))
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "KEP-0002 Phase 2: a channel created and returned by the child promotes correctly" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // The join result now crosses via an envelope built on the CHILD thread
+    // (the channel's owner) rather than deepCopy'd by the parent at join
+    // time -- which is what makes this legal at all: promotion requires
+    // gc_instance to match the channel's owner, true only while the child
+    // itself is still running.
+    const result = try ctx.vm.eval(
+        \\(let* ((t (make-thread (lambda ()
+        \\                          (let ((inner (make-channel)))
+        \\                            (channel-send inner 'hello)
+        \\                            inner)))))
+        \\  (thread-start! t)
+        \\  (let ((returned-ch (thread-join! t)))
+        \\    (channel-receive returned-ch)))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("hello", types.symbolName(result));
+}
+
+test "KEP-0002 Phase 2: uncopyable thunk is detected synchronously in thread-start!, never spawns an OS thread" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // `m` must be a genuine lexical upvalue of the thunk (let*-bound, not a
+    // top-level define) -- a global mutex reference is the *supported*
+    // sharing path (see srfi18.scm's own header comment) and would resolve
+    // through vm.globals without ever touching deepCopy at all, defeating
+    // the point of this test.
+    _ = try ctx.vm.eval(
+        \\(define t (let* ((m (make-mutex))) (make-thread (lambda () (mutex-lock! m)))))
+    );
+    _ = try ctx.vm.eval("(thread-start! t)");
+
+    const t_val = try ctx.vm.eval("t");
+    const fiber = types.toObject(t_val).as(@import("fiber.zig").Fiber);
+    // White-box: thread-start! caught the UncopyableType error while
+    // building the envelope and never called std.Thread.spawn at all.
+    try std.testing.expect(fiber.os_thread == null);
+    try std.testing.expectEqual(@import("fiber.zig").FiberStatus.errored, fiber.status);
+
+    // Scheme-visible behavior is unchanged: thread-join! still reraises it
+    // as an uncaught-exception in the thread (matches
+    // tests/scheme/srfi/srfi18.scm's "OS threads cannot capture sync
+    // primitives" test).
+    const caught = try ctx.vm.eval(
+        \\(guard (e (#t (uncaught-exception? e))) (thread-join! t) #f)
+    );
+    try std.testing.expectEqual(types.TRUE, caught);
+}
+
+test "KEP-0002 Phase 2: thread churn -- repeated cross-thread channel round trips leave no refcount leak" {
+    const baseline = shared_object.liveCount();
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+
+        // Each iteration promotes a fresh channel (captured by the thunk),
+        // sends across the thread boundary, joins (tearing down the child's
+        // heap immediately), and receives -- exercising exactly the
+        // "envelope queued by a thread that has already exited its heap"
+        // path the KEP's acceptance criteria call out.
+        const result = try ctx.vm.eval(
+            \\(let loop ((i 0) (acc 0))
+            \\  (if (= i 20)
+            \\      acc
+            \\      (let* ((ch (make-channel))
+            \\             (t (make-thread (lambda () (channel-send ch i)))))
+            \\        (thread-start! t)
+            \\        (thread-join! t)
+            \\        (loop (+ i 1) (+ acc (channel-receive ch))))))
+        );
+        try std.testing.expectEqual(@as(i64, 190), types.toFixnum(result)); // sum 0..19
+    }
+    // ctx.deinit() above frees every tracked object regardless of Scheme-
+    // level reachability, including each iteration's channel stub -- so
+    // every promoted SharedChannel's refcount must have already reached
+    // zero (destroyed) via ordinary send/receive/envelope teardown well
+    // before this point, or it would still show up here.
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "KEP-0002 Phase 2: an exception raised in the child carrying a channel promotes via the exception envelope" {
+    const baseline = shared_object.liveCount();
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+
+        // The exception object (an error-object wrapping the channel as an
+        // irritant) is built into an envelope on the child thread -- the
+        // same promotion-legality argument as a returned value, but via the
+        // errored path in threadEntryFn instead of the completed path.
+        const result = try ctx.vm.eval(
+            \\(let* ((t (make-thread (lambda ()
+            \\                          (let ((inner (make-channel)))
+            \\                            (channel-send inner 'irritant-marker)
+            \\                            (error "boom" inner))))))
+            \\  (thread-start! t)
+            \\  (guard (e (#t (car (error-object-irritants (uncaught-exception-reason e)))))
+            \\    (thread-join! t)
+            \\    'not-caught))
+        );
+        const inner_ch = types.toObject(result);
+        try std.testing.expectEqual(types.ObjectTag.channel, inner_ch.tag);
+        try std.testing.expect(inner_ch.as(types.Channel).shared != null);
+    }
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}

--- a/tests/scheme/srfi/srfi18-cross-thread-channels.scm
+++ b/tests/scheme/srfi/srfi18-cross-thread-channels.scm
@@ -1,0 +1,122 @@
+;; KEP-0002 Phase 2 (#1467): envelopes at thread boundaries.
+;;
+;; thread-start! now copies the thunk into an envelope on the parent thread,
+;; before spawning the child -- the only place a channel captured by the
+;; thunk can legally promote (KEP-0002 Phase 1, #1482). thread-join!'s
+;; result/exception cross the same way, via an envelope built on the child
+;; thread right before it exits. Together these make cross-thread channels
+;; actually usable end to end for the first time.
+;;
+;; Phase 3 (#1468) has not landed yet, so every scenario here is restricted
+;; to "send completes before receive is attempted" interleavings: a receive
+;; on an empty *shared* channel has no wakeup machinery to park on yet.
+;; Ordering is made deterministic via thread-join! (which only returns once
+;; the child is fully done, including any sends it made) rather than by
+;; timing/luck.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (kaappi fibers) (srfi 64))
+
+(test-begin "srfi18-cross-thread-channels")
+
+;; --- Motivation Path 1: a channel captured lexically in the thread thunk ---
+;; Before Phase 1+2: deepCopy rejected the channel outright ("thread thunk
+;; contains uncopyable type"). Now: `ch` is promoted on the parent thread as
+;; part of the envelope build, aliased into the child's heap on copy-out.
+(test-equal "channel captured in thread thunk: send from child, receive from parent"
+  42
+  (let* ((ch (make-channel))
+         (t (make-thread (lambda () (channel-send ch 42)))))
+    (thread-start! t)
+    (thread-join! t)
+    (channel-receive ch)))
+
+;; --- Thunk snapshot: mutation after thread-start! returns is invisible ---
+;; The envelope copy runs synchronously inside thread-start!, before it ever
+;; returns, so this is deterministic -- not a race the test might get lucky
+;; on. Before Phase 2, the child deepCopy'd fiber.thunk at some arbitrary
+;; later point, so this mutation could (nondeterministically) already have
+;; been visible to it.
+(test-equal "thunk snapshot: mutation after thread-start! not visible to child"
+  1
+  (let* ((v (vector 1))
+         (t (make-thread (lambda () (vector-ref v 0)))))
+    (thread-start! t)
+    (vector-set! v 0 999)
+    (thread-join! t)))
+
+;; --- A channel created and returned by the child ---
+;; The join result crosses via an envelope built on the CHILD thread (the
+;; channel's owner), not deepCopy'd by the parent at join time -- promotion
+;; requires gc_instance to match the channel's owner, true only while the
+;; child itself is still running.
+(test-equal "channel created and returned by the child promotes correctly"
+  'hello
+  (let* ((t (make-thread (lambda ()
+                            (let ((inner (make-channel)))
+                              (channel-send inner 'hello)
+                              inner)))))
+    (thread-start! t)
+    (let ((returned-ch (thread-join! t)))
+      (channel-receive returned-ch))))
+
+;; --- Reply-channel identity survives two promotion/alias hops ---
+;; `tasks` is sent to *before* thread-start!, so thread-start!'s promotion
+;; drains its (already-populated) local queue into the shared representation
+;; -- the worker's receive never parks. `reply`, nested inside that queued
+;; message, is promoted transitively during the same drain. thread-join!
+;; establishes the happens-before edge that makes the final receive safe.
+(test-equal "reply-channel identity survives a captured round trip"
+  42
+  (let* ((tasks (make-channel))
+         (reply (make-channel))
+         (worker (make-thread
+                   (lambda ()
+                     (let* ((msg (channel-receive tasks))
+                            (task-reply (cdr msg)))
+                       (channel-send task-reply (* 2 (car msg))))))))
+    (channel-send tasks (cons 21 reply))
+    (thread-start! worker)
+    (thread-join! worker)
+    (channel-receive reply)))
+
+;; --- Repeated cross-thread round trips (thread churn) ---
+(test-equal "20 sequential cross-thread channel round trips"
+  190 ; sum 0..19
+  (let loop ((i 0) (acc 0))
+    (if (= i 20)
+        acc
+        (let* ((ch (make-channel))
+               (t (make-thread (lambda () (channel-send ch i)))))
+          (thread-start! t)
+          (thread-join! t)
+          (loop (+ i 1) (+ acc (channel-receive ch)))))))
+
+;; --- Motivation Path 2 regression: a channel reached through a shared
+;; global (not captured by the thunk) still raises a descriptive
+;; foreign-owner error instead of corrupting memory. Phase 2 only changes
+;; how the thunk *itself* crosses the boundary, so this must be unaffected.
+;; `ch-path2` must be a genuine top-level define (a real global, resolved
+;; through vm.globals) rather than let-bound -- an internal define inside a
+;; `let` body is lexically scoped (R7RS letrec* semantics) and would be
+;; captured as a thunk upvalue instead, testing Path 1 again by accident.
+(define ch-path2 (make-channel))
+(test-assert "channel reached through a shared global still raises (not captured by thunk)"
+  (guard (e (#t #t))
+    (thread-join! (thread-start! (make-thread (lambda () (channel-send ch-path2 42)))))
+    #f))
+
+;; --- A thunk that still legitimately captures an uncopyable type (mutex)
+;; keeps failing exactly as before -- Phase 2 changes *when* the thunk is
+;; copied (parent-side, before spawn), not *what* is copyable.
+(test-assert "thunk capturing a mutex still raises uncaught-exception at join"
+  (let* ((t (let* ((m (make-mutex)))
+              (make-thread (lambda () (mutex-lock! m))))))
+    (thread-start! t)
+    (guard (e (#t (uncaught-exception? e)))
+      (thread-join! t)
+      #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-cross-thread-channels")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Implements KEP-0002 Phase 2 (#1467), building on Phase 1's SharedChannel core (#1482).

- `thread-start!` now copies the thunk into a `shared_channel.Envelope` on the **parent** thread, before `std.Thread.spawn`, instead of letting the child `deepCopy` `fiber.thunk` out of the still-running parent heap asynchronously. This closes the old concurrent-copy race and is the only place a channel captured by the thunk can legally promote (promotion requires `gc_instance` to match the channel's owner).
- `thread-join!`'s result/exception now cross the same way: built into an envelope on the **child** thread right before it exits, instead of being deep-copied directly out of the child's heap by the parent at join time. Retires `child_registry`'s raw-`Value` special case, and makes a channel *created and returned* by the child promote correctly too.
- The process-global live-thread counter this phase calls for already exists (`live_child_threads`, from #1455) — no new code needed.
- Fixed a double-free the envelope model exposes: `child_registry`'s result/exception lookup was a peek (`get`), so two racing `thread-join!` calls on the same fiber (reachable via a shared global, since fiber ownership is otherwise unchecked) could both retrieve and free the same `*Envelope`. Replaced with an atomic take (`takeResult`) that clears both fields under the registry lock.

Motivation Path 1 (a channel captured in the thread thunk) now works end to end; Motivation Path 2 (a channel reached through a shared global) is unaffected and still raises the foreign-owner error.

## Test plan

- [x] `zig build test` — full unit suite green
- [x] `zig build test -Dgc-stress=true` — full suite green (thread-churn/leak tests included)
- [x] `bash tests/scheme/run-all.sh` — 1835/0 (440 Scheme files + 1395 R7RS)
- [x] `zig fmt --check` clean
- [x] New tests: thunk-snapshot (parent mutation after `thread-start!` not visible to child), Motivation Path 1 end-to-end, a channel created+returned by the child, reply-channel identity across two promotion/alias hops, 20-thread churn with no refcount leak, synchronous uncopyable-thunk error shape
- [x] Manually measured `thread-start!`/`thread-join!` overhead for a trivial thunk before/after: ~34-38μs either way (within noise, dominated by OS thread creation, not the extra envelope copy)
- [x] Adversarial code review (8 independent finder angles + verify pass) — found and fixed a real double-free race plus a couple of cleanup items

🤖 Generated with [Claude Code](https://claude.com/claude-code)