### PR TITLE
Cross-thread wakeup: ThreadNotifier, unconditional sweep, shared-waiter registry (KEP-0002 P3)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -244,6 +244,23 @@ pub fn build(b: *std.Build) void {
     const bench_channel_step = b.step("bench-channel", "Run the channel local fast-path & envelope-cost benchmark");
     bench_channel_step.dependOn(&run_bench_channel.step);
 
+    // PCT-style randomized scheduling stress test (KEP-0002 P2 method step 2, Phase 3)
+    const stress_channel_mod = kaappiModule(b, options_mod, .{
+        .root = "src/stress_channel.zig",
+        .target = target,
+        .optimize = optimize,
+    });
+    const stress_channel_exe = b.addExecutable(.{
+        .name = "stress-channel",
+        .root_module = stress_channel_mod,
+    });
+    const run_stress_channel = b.addRunArtifact(stress_channel_exe);
+    if (b.args) |args| {
+        run_stress_channel.addArgs(args);
+    }
+    const stress_channel_step = b.step("stress-channel", "Run the SharedChannel/ThreadNotifier PCT-style randomized scheduling stress test (optional: -- <seed> <producers> <consumers> <per-producer>)");
+    stress_channel_step.dependOn(&run_stress_channel.step);
+
     // Package manager (thottam)
     const thottam_mod = kaappiModule(b, options_mod, .{
         .root = "src/thottam.zig",

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -69,6 +69,9 @@ pub const FiberScheduler = struct {
     current_idx: usize,
     next_id: u32,
     vm: *VM,
+    /// KEP-0002 §5's per-scheduler shared-waiter registry -- see
+    /// enrollSharedWaiter/sweepSharedWaiters below.
+    shared_waiters: std.ArrayList(*Fiber),
 
     pub fn init(vm: *VM) FiberScheduler {
         return .{
@@ -76,11 +79,13 @@ pub const FiberScheduler = struct {
             .current_idx = 0,
             .next_id = 0,
             .vm = vm,
+            .shared_waiters = .empty,
         };
     }
 
     pub fn deinit(self: *FiberScheduler, allocator: std.mem.Allocator) void {
         self.fibers.deinit(allocator);
+        self.shared_waiters.deinit(allocator);
     }
 
     pub fn addFiber(self: *FiberScheduler, fiber: *Fiber) !void {
@@ -301,6 +306,14 @@ pub const FiberScheduler = struct {
     /// keeps the loop from ever reaching parkOnReactor's blocking poll.
     pub fn schedule(self: *FiberScheduler) ?usize {
         if (self.vm.reactor) |reactor| {
+            // KEP-0002 §5's normative consume protocol, checked every tick
+            // (not just when idle) for the same promptness reason as the
+            // timer/I/O checks below: a notify arriving after the last swap
+            // still rang the notifier's fd, which poll() observes
+            // immediately; one arriving before it was swept right here. No
+            // interleaving loses a wakeup.
+            while (reactor.notifier.wake_pending.swap(false, .acq_rel)) self.sweepSharedWaiters();
+
             var expired: std.ArrayList(*Fiber) = .empty;
             defer expired.deinit(self.vm.gc.allocator);
             if (self.anyIoWaiting()) {
@@ -333,6 +346,11 @@ pub const FiberScheduler = struct {
     /// as "other progress possible" would make a genuine deadlock loop
     /// forever in reactor.poll() instead of ever detecting it.
     pub fn hasRunnableFibers(self: *FiberScheduler) bool {
+        // KEP-0002 §5: a fiber parked on a promoted channel with a live
+        // ThreadNotifier registration is "alive, waiting" even though it
+        // matches none of the local wait categories below -- another OS
+        // thread may still send/receive and wake it via sweepSharedWaiters.
+        if (self.shared_waiters.items.len != 0) return true;
         for (self.fibers.items) |f| {
             if (f) |fiber| {
                 if (fiber.status == .created or fiber.status == .suspended)
@@ -377,6 +395,60 @@ pub const FiberScheduler = struct {
                 }
             }
         }
+    }
+
+    /// KEP-0002 §5's per-scheduler shared-waiter registry: a fiber joins
+    /// when it parks on a promoted channel (channelReceiveShared,
+    /// promoteChannel's §2 step 4 migration) and leaves via
+    /// removeSharedWaiter or the unconditional sweep below. Owned and
+    /// mutated only by this scheduler's own thread -- no lock needed. Holds
+    /// fiber pointers, not heap Values, so it adds no GC roots of its own:
+    /// it's a secondary index into `fibers`, which markRoots already marks
+    /// unconditionally regardless of status.
+    pub fn enrollSharedWaiter(self: *FiberScheduler, fiber: *Fiber) !void {
+        for (self.shared_waiters.items) |existing| {
+            if (existing == fiber) return; // dedup
+        }
+        try self.shared_waiters.append(self.vm.gc.allocator, fiber);
+    }
+
+    /// No-op if `fiber` isn't enrolled. Called after a park attempt resolves
+    /// (channelReceiveShared) and by thread-terminate! (which flips a
+    /// victim's status directly, bypassing the sweep) -- without this, a
+    /// terminated fiber's slot could be reused by addFiber while a stale
+    /// pointer to the old fiber object still sits in this registry.
+    pub fn removeSharedWaiter(self: *FiberScheduler, fiber: *Fiber) void {
+        for (self.shared_waiters.items, 0..) |f, i| {
+            if (f == fiber) {
+                _ = self.shared_waiters.swapRemove(i);
+                return;
+            }
+        }
+    }
+
+    /// KEP-0002 §5, model-checked to be UNCONDITIONAL (kaappi/keps#12,
+    /// "model finding 1"): a readiness-filtered sweep is a proven lost
+    /// wakeup. Rings snapshot-and-clear the SharedChannel waiter lists
+    /// (shared_channel.zig), so a fiber that was rung but lost the retry
+    /// race to a faster thread has no registration left -- if the sweep
+    /// also declines to flip it, nothing ever will. Flipping every entry
+    /// makes the wake-all discipline literal: woken fibers retry their
+    /// primitive, and losers re-park and re-register under the channel's
+    /// own lock. The cost is spurious retries bounded by the registry
+    /// length, which only ever holds shared-channel waiters.
+    pub fn sweepSharedWaiters(self: *FiberScheduler) void {
+        for (self.shared_waiters.items) |f| {
+            // Guards a fiber whose .waiting status was already cleared by
+            // another path before this sweep ran (thread-terminate!'s
+            // direct removal, or an entry left behind after an OOM unwound
+            // channelReceiveShared before its own removeSharedWaiter call) --
+            // flipping it again would be harmless but pointless.
+            if (f.status == .waiting) {
+                f.status = .suspended;
+                f.waiting_on = types.VOID;
+            }
+        }
+        self.shared_waiters.clearRetainingCapacity();
     }
 
     pub fn wakeMutexWaiters(self: *FiberScheduler, mutex_val: Value) void {
@@ -612,11 +684,21 @@ pub fn waitForFd(vm: *VM, fd: std.posix.fd_t, interest: reactor_mod.Interest) VM
 /// timers behavior.
 pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool {
     const reactor = vm.reactor orelse return false;
+    // Consume protocol (KEP-0002 §5) before the deadlock check: a notify
+    // that arrived just before this call must not be missed by
+    // hasRunnableFibers() reading a shared_waiters entry the sweep would
+    // otherwise have already cleared.
+    while (reactor.notifier.wake_pending.swap(false, .acq_rel)) sched.sweepSharedWaiters();
     if (!sched.hasRunnableFibers() and reactor.isEmpty()) return false;
 
     var ready: std.ArrayList(*Fiber) = .empty;
     defer ready.deinit(vm.gc.allocator);
     reactor.poll(cap_ns, &ready) catch return VMError.OutOfMemory;
+    // A notify arriving *during* the blocking poll() above is what actually
+    // interrupted it; its wake_pending flag needs consuming here even though
+    // poll()'s own ReadyEvent list never surfaces the notifier's own event
+    // (reactor.zig's wait() implementations filter it out).
+    while (reactor.notifier.wake_pending.swap(false, .acq_rel)) sched.sweepSharedWaiters();
 
     for (ready.items) |f| wakeReadyFiber(f);
     return true;

--- a/src/pct_stress.zig
+++ b/src/pct_stress.zig
@@ -1,0 +1,44 @@
+//! KEP-0002 Phase 3 (#1468): PCT-style randomized scheduling stress helper
+//! for shared_object.zig/shared_channel.zig's lock/atomic operations
+//! (KEP-0002 research plan, P2 method step 2 -- "seed-controlled yield
+//! injection at every lock acquire/release and atomic op ... seed printed
+//! on failure for deterministic replay", modeled on Burckhardt et al.'s PCT
+//! (ASPLOS 2010) and tokio-rs/loom's "model checking as a unit test"
+//! ergonomics).
+//!
+//! Runtime-gated (not comptime), off by default: `enabled` starts false, so
+//! `zig build test`'s ordinary run pays no cost and sees no behavior
+//! change -- `maybeYield()` is a single branch that returns immediately
+//! unless a stress harness (src/stress_channel.zig) has explicitly turned
+//! it on. This deliberately does not touch memory.zig's spinLock/spinUnlock
+//! themselves (used throughout the codebase for unrelated locks); the yield
+//! points are wired in only at shared_channel.zig's own lock wrappers and
+//! shared_object.zig's retain/release, so the coupling stays local to
+//! KEP-0002.
+const std = @import("std");
+
+pub var enabled: bool = false;
+
+threadlocal var rng: ?std.Random.DefaultPrng = null;
+
+/// Seeds this OS thread's own PRNG deterministically from the harness's
+/// single top-level seed plus a thread-distinguishing tag, so an entire
+/// multi-thread run replays exactly from one printed seed (CHESS's
+/// reproducibility discipline). Call once per thread before it starts
+/// hammering shared_channel.zig/shared_object.zig.
+pub fn seedThread(base_seed: u64, thread_tag: u64) void {
+    rng = std.Random.DefaultPrng.init(base_seed ^ (thread_tag *% 0x9E3779B97F4A7C15));
+}
+
+/// Called at curated lock-acquire/release and atomic-op points. A no-op
+/// unless `enabled` and this thread has been seeded. PCT randomizes context
+/// switches at exactly these points rather than everywhere -- far more
+/// effective at surfacing real interleaving bugs than naive, uncontrolled
+/// thread scheduling (the point of the technique, not an approximation of
+/// it).
+pub fn maybeYield() void {
+    if (!enabled) return;
+    var r = rng orelse return; // an un-seeded thread (e.g. the main test thread) opts out
+    defer rng = r;
+    if (r.random().boolean()) std.Thread.yield() catch {};
+}

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -166,6 +166,19 @@ const SharedChannelWait = struct {
     }
 };
 
+/// Drives OTHER local fibers without ever touching `me`'s own status --
+/// `me` stays .running for the whole call, so schedule()'s round-robin can
+/// never independently re-pick it while its own native call (this one) is
+/// still live on the Zig stack. Isolating this into its own Ctx type keeps
+/// that invariant visually obvious at every call site: nothing here sets
+/// `me.status`, unlike SharedChannelWait/ChannelWait's actual park.
+const SharedChannelPoll = struct {
+    sc: *shared_channel.SharedChannel,
+    pub fn isDone(self: SharedChannelPoll) bool {
+        return self.sc.peekReady();
+    }
+};
+
 /// KEP-0002 §5's deadlock-heuristic disjunct: block (park, waiting for a
 /// remote send/receive) rather than raise a local deadlock whenever another
 /// thread could plausibly still act on this channel -- either it still
@@ -177,48 +190,79 @@ fn sharedWakeupPossible(sc: *shared_channel.SharedChannel) bool {
     return sc.refCount() > 1 or srfi18.crossThreadWaitPossible();
 }
 
-/// KEP-0002 §4/§5 send/receive on the shared representation, replacing
-/// Phase 1's `@panic` on `.would_park` -- a real, already-reachable SIGABRT
-/// before this fix (a channel captured by a thread-start! thunk promotes in
-/// place on both sides; either side calling channel-receive on the empty
-/// promoted channel before the other sends crashed the process).
+/// KEP-0002 §4/§5 receive on the shared representation, replacing Phase 1's
+/// `@panic` on `.would_park` -- a real, already-reachable SIGABRT before
+/// this fix (a channel captured by a thread-start! thunk promotes in place
+/// on both sides; either side calling channel-receive on the empty promoted
+/// channel before the other sends crashed the process).
 ///
-/// Always calls shared_channel.receive() FIRST each loop iteration -- that's
-/// what performs the actual sc.recv_waiters registration, as a side effect
-/// of returning `.would_park` -- and only *then* decides to park. Parking
-/// before registering would leave nothing to ever ring the fiber awake: a
-/// permanent hang inside parkOnReactor's blocking poll, strictly worse than
-/// today's clean deadlock error. This ordering also directly implements the
-/// required "a rung receiver that loses the pop race re-parks, re-registers"
-/// regression (§5, model finding 1): losing the race just means another
-/// `.would_park` on the next loop iteration, which re-registers via the same
-/// receive() call.
-///
-/// Deliberately does not reuse blockOrDeadlock's yield_retry trick: that
-/// helper is sound for a *local* channel because a later local channel-send
-/// can still find and flip the fiber via wakeChannelWaiters even after
-/// runSchedulerStep reports "not done". For a *promoted* channel nothing
-/// ever calls wakeChannelWaiters again -- a yield_retry-parked fiber not
-/// enrolled in the shared-waiter registry would never wake. So this always
-/// raises immediately when sharedWakeupPossible() is false, uniformly for
-/// the main fiber and any spawned fiber (runSchedulerStep is already called
-/// unconditionally regardless of dispatched_from_scheduler), which is what
-/// satisfies §5's "the main-fiber case follows the same rule" without any
-/// special-casing: the main fiber genuinely blocks in parkOnReactor's
-/// reactor.poll() exactly like any other fiber.
+/// Per loop iteration:
+///  1. Call shared_channel.receive() -- the notifier is registered
+///     unconditionally (not gated on sharedWakeupPossible), because a purely
+///     LOCAL sibling fiber's channel-send on this channel also rings via the
+///     same recv_waiters/notifier path (self-ring): a channel can be
+///     promoted (e.g. transiently, by a thread that captured it and exited)
+///     while every actual sender/receiver stays on this thread the whole
+///     time, and that must keep working exactly like it did before
+///     promotion.
+///  2. If empty, drive OTHER local fibers once (SharedChannelPoll) -- `me`
+///     stays .running throughout, mirroring channelReceiveFn's local-channel
+///     path (ChannelWait). Loop back to 1 if driving made the channel ready.
+///  3. Otherwise park. The two branches are NOT symmetric, and the asymmetry
+///     is load-bearing, not an oversight:
+///       - A fiber dispatched directly by a scheduler loop (my_idx != 0 and
+///         vm.dispatched_from_scheduler) ALWAYS parks via the flat
+///         yield_retry unwind (KEP-0002 §4 receive step 8: ".waiting on the
+///         stub, yield_retry rewind"), unconditionally -- exactly like
+///         blockOrDeadlock's existing behavior for every non-main fiber.
+///         Whether this is a genuine, permanent deadlock is not this
+///         fiber's call to make (the existing local-channel path doesn't
+///         make that call either): that's detected wherever something else
+///         -- typically the main fiber, via fiber-join or another
+///         blockOrDeadlock call -- eventually finds nothing progressing.
+///         Gating this branch on sharedWakeupPossible() was an earlier,
+///         confirmed-buggy version of this function: it raised a false
+///         deadlock the instant a channel was ever transiently promoted
+///         and then the "remote" side exited, even though a purely local
+///         sibling fiber was one form away from sending (verified via a
+///         concrete repro). This branch must also never nest another
+///         drive after setting `.waiting` -- see SharedChannelPoll's and
+///         runSchedulerStep's own doc comments: doing so would make `me`
+///         visible to schedule()'s round-robin while `me`'s own call is
+///         still live on the Zig stack, letting an unrelated fiber's own
+///         nested runSchedulerStep dispatch `me`'s mid-call snapshot and
+///         resume bytecode past the in-flight receive() call with the
+///         destination register never written (confirmed via a second,
+///         separate repro: two spawned fibers each parked on their own
+///         promoted channel, the second one woken "received" the stale
+///         callee register instead of its real value). yield_retry instead
+///         unwinds this whole native call via error.Yielded before `me`
+///         ever becomes independently dispatchable, and a later redispatch
+///         re-executes this entire function from the top (re-registering
+///         via step 1's receive() call).
+///       - The main fiber (or a fiber blocked under re-entrant native
+///         frames that cannot be safely rewound) CANNOT yield_retry, so it
+///         drives in place instead (waitForFd's precedent) via a genuine
+///         park + SharedChannelWait, then loops back to 1. Here
+///         sharedWakeupPossible() is load-bearing: self-enrolling in
+///         shared_waiters makes hasRunnableFibers() (and therefore
+///         parkOnReactor's own "nothing can ever happen" detection) always
+///         see this fiber's own entry, so parkOnReactor can never
+///         independently conclude "genuine deadlock" the way it does for
+///         purely local waits -- something has to decide "no local or
+///         remote path could ever help" before parking, or a truly
+///         deadlocked main fiber would block in reactor.poll() forever
+///         instead of raising a clean error.
 fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_val: Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     const ctx = try fiber_mod.ensureScheduler(vm);
-    const me = ctx.sched.fibers.items[ctx.sched.current_idx].?;
+    const my_idx = ctx.sched.current_idx;
+    const me = ctx.sched.fibers.items[my_idx].?;
     const notifier = ctx.reactor.notifyHandle();
+    const is_dispatched = my_idx != 0 and vm.dispatched_from_scheduler;
 
     while (true) {
-        const wakeup_possible = sharedWakeupPossible(sc);
-        // A null notifier when no wakeup is possible: registering would be
-        // pointless (nothing will ever ring it) and would leave a dangling
-        // entry for nothing -- matches send()/receive()'s existing
-        // null-is-safe convention from Phase 1.
-        const outcome = shared_channel.receive(sc, gc, if (wakeup_possible) notifier else null) catch |err|
+        const outcome = shared_channel.receive(sc, gc, notifier) catch |err|
             return translateSharedChannelError(err, "channel-receive");
         switch (outcome) {
             .value => |v| return v,
@@ -227,19 +271,46 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             .eof => @panic("channel-receive: .eof unreachable before channel-close! (Phase 4)"),
             .would_park => {},
         }
-        if (!wakeup_possible)
+
+        // Drive local siblings once. `me` stays .running -- see
+        // SharedChannelPoll's doc comment for why that's load-bearing.
+        _ = try fiber_mod.runSchedulerStep(SharedChannelPoll, .{ .sc = sc }, ctx.vm, ctx.sched, me);
+        if (sc.peekReady()) continue; // loop back to 1: re-derive via receive()
+
+        if (is_dispatched) {
+            me.status = .waiting;
+            me.waiting_on = ch_val;
+            vm.gc.writeBarrier(&me.header, ch_val);
+            ctx.sched.enrollSharedWaiter(me) catch |err| {
+                me.status = .running;
+                me.waiting_on = types.VOID;
+                return err;
+            };
+            vm.yield_retry = true;
+            return PrimitiveError.Yielded;
+        }
+
+        if (!sharedWakeupPossible(sc))
             return raiseFiberError("channel-receive: deadlock — channel is empty and no other thread can send");
 
         me.status = .waiting;
         me.waiting_on = ch_val;
         vm.gc.writeBarrier(&me.header, ch_val);
         me.timed_out = false; // defensive: stale flag from an unrelated earlier timed wait
-        try ctx.sched.enrollSharedWaiter(me);
-        _ = try fiber_mod.runSchedulerStep(SharedChannelWait, .{ .me = me }, ctx.vm, ctx.sched, me);
+        ctx.sched.enrollSharedWaiter(me) catch |err| {
+            me.status = .running;
+            me.waiting_on = types.VOID;
+            return err;
+        };
+        _ = fiber_mod.runSchedulerStep(SharedChannelWait, .{ .me = me }, ctx.vm, ctx.sched, me) catch |err| {
+            ctx.sched.removeSharedWaiter(me);
+            me.status = .running;
+            me.waiting_on = types.VOID;
+            return err;
+        };
         ctx.sched.removeSharedWaiter(me);
-        // Loop back: re-derive wakeup_possible and re-call receive(), which
-        // both re-registers if still empty and picks up a value if one
-        // arrived while parked.
+        // Loop back to 1: re-registers if still empty, picks up a value if
+        // one arrived while parked.
     }
 }
 

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -5,6 +5,7 @@ const primitives = @import("primitives.zig");
 const memory = @import("memory.zig");
 const fiber_mod = @import("fiber.zig");
 const shared_channel = @import("shared_channel.zig");
+const srfi18 = @import("primitives_srfi18.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -120,14 +121,15 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
         };
         return switch (outcome) {
             .sent => types.VOID,
-            // Phase 1 channels are always unbounded and open -- no
+            // Channels are still always unbounded and open -- no
             // Scheme-level API sets capacity or closed yet (KEP-0002
-            // Phase 4) -- so these branches are unreachable through
-            // make-channel's output. @panic (not `unreachable`, which is UB
-            // under ReleaseFast) so a Phase 4 gap that forgets to wire this
-            // switch fails loudly in every build mode instead of silently
-            // corrupting execution.
-            .would_park, .closed => @panic("channel-send: reached a shared-channel branch Phase 1's primitives don't wire up yet (capacity/close is Phase 4)"),
+            // Phase 4) -- so these branches remain unreachable through
+            // make-channel's output even after Phase 3 (#1468) wires up
+            // channel-receive's own .would_park branch below. @panic (not
+            // `unreachable`, which is UB under ReleaseFast) so a Phase 4
+            // gap that forgets to wire this switch fails loudly in every
+            // build mode instead of silently corrupting execution.
+            .would_park, .closed => @panic("channel-send: reached a shared-channel branch Phase 4 doesn't wire up yet (capacity/close)"),
         };
     }
 
@@ -157,6 +159,90 @@ const ChannelWait = struct {
     }
 };
 
+const SharedChannelWait = struct {
+    me: *fiber_mod.Fiber,
+    pub fn isDone(self: SharedChannelWait) bool {
+        return self.me.status != .waiting;
+    }
+};
+
+/// KEP-0002 §5's deadlock-heuristic disjunct: block (park, waiting for a
+/// remote send/receive) rather than raise a local deadlock whenever another
+/// thread could plausibly still act on this channel -- either it still
+/// holds another counted reference (an envelope in flight counts too, via
+/// its own stub, per §1), or some other OS thread is alive at all. Reuses
+/// primitives_srfi18.zig's existing crossThreadWaitPossible rather than
+/// duplicating its live-thread-count logic.
+fn sharedWakeupPossible(sc: *shared_channel.SharedChannel) bool {
+    return sc.refCount() > 1 or srfi18.crossThreadWaitPossible();
+}
+
+/// KEP-0002 §4/§5 send/receive on the shared representation, replacing
+/// Phase 1's `@panic` on `.would_park` -- a real, already-reachable SIGABRT
+/// before this fix (a channel captured by a thread-start! thunk promotes in
+/// place on both sides; either side calling channel-receive on the empty
+/// promoted channel before the other sends crashed the process).
+///
+/// Always calls shared_channel.receive() FIRST each loop iteration -- that's
+/// what performs the actual sc.recv_waiters registration, as a side effect
+/// of returning `.would_park` -- and only *then* decides to park. Parking
+/// before registering would leave nothing to ever ring the fiber awake: a
+/// permanent hang inside parkOnReactor's blocking poll, strictly worse than
+/// today's clean deadlock error. This ordering also directly implements the
+/// required "a rung receiver that loses the pop race re-parks, re-registers"
+/// regression (§5, model finding 1): losing the race just means another
+/// `.would_park` on the next loop iteration, which re-registers via the same
+/// receive() call.
+///
+/// Deliberately does not reuse blockOrDeadlock's yield_retry trick: that
+/// helper is sound for a *local* channel because a later local channel-send
+/// can still find and flip the fiber via wakeChannelWaiters even after
+/// runSchedulerStep reports "not done". For a *promoted* channel nothing
+/// ever calls wakeChannelWaiters again -- a yield_retry-parked fiber not
+/// enrolled in the shared-waiter registry would never wake. So this always
+/// raises immediately when sharedWakeupPossible() is false, uniformly for
+/// the main fiber and any spawned fiber (runSchedulerStep is already called
+/// unconditionally regardless of dispatched_from_scheduler), which is what
+/// satisfies §5's "the main-fiber case follows the same rule" without any
+/// special-casing: the main fiber genuinely blocks in parkOnReactor's
+/// reactor.poll() exactly like any other fiber.
+fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_val: Value) PrimitiveError!Value {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    const me = ctx.sched.fibers.items[ctx.sched.current_idx].?;
+    const notifier = ctx.reactor.notifyHandle();
+
+    while (true) {
+        const wakeup_possible = sharedWakeupPossible(sc);
+        // A null notifier when no wakeup is possible: registering would be
+        // pointless (nothing will ever ring it) and would leave a dangling
+        // entry for nothing -- matches send()/receive()'s existing
+        // null-is-safe convention from Phase 1.
+        const outcome = shared_channel.receive(sc, gc, if (wakeup_possible) notifier else null) catch |err|
+            return translateSharedChannelError(err, "channel-receive");
+        switch (outcome) {
+            .value => |v| return v,
+            // channel-close! is Phase 4 -- sc.closed is always false, so
+            // receive's reserved==0-and-closed eof branch is unreachable.
+            .eof => @panic("channel-receive: .eof unreachable before channel-close! (Phase 4)"),
+            .would_park => {},
+        }
+        if (!wakeup_possible)
+            return raiseFiberError("channel-receive: deadlock — channel is empty and no other thread can send");
+
+        me.status = .waiting;
+        me.waiting_on = ch_val;
+        vm.gc.writeBarrier(&me.header, ch_val);
+        me.timed_out = false; // defensive: stale flag from an unrelated earlier timed wait
+        try ctx.sched.enrollSharedWaiter(me);
+        _ = try fiber_mod.runSchedulerStep(SharedChannelWait, .{ .me = me }, ctx.vm, ctx.sched, me);
+        ctx.sched.removeSharedWaiter(me);
+        // Loop back: re-derive wakeup_possible and re-call receive(), which
+        // both re-registers if still empty and picks up a value if one
+        // arrived while parked.
+    }
+}
+
 fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[0]))
         return primitives.typeError("channel-receive", "channel", args[0]);
@@ -169,17 +255,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
 
     if (ch.shared) |raw| {
         const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
-        const outcome = shared_channel.receive(sc, gc, null) catch |err| {
-            return translateSharedChannelError(err, "channel-receive");
-        };
-        return switch (outcome) {
-            .value => |v| v,
-            // Phase 1 channels are always open (channel-close! is Phase 4)
-            // and fiber-parking isn't wired to the shared path yet (Phase
-            // 3) -- unreachable through make-channel's output. @panic, not
-            // `unreachable` (UB under ReleaseFast) -- see channelSendFn.
-            .would_park, .eof => @panic("channel-receive: reached a shared-channel branch Phase 1's primitives don't wire up yet (capacity/close is Phase 4)"),
-        };
+        return channelReceiveShared(sc, gc, args[0]);
     }
 
     if (ch.head != types.NIL and types.isPair(ch.head)) {

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -201,7 +201,11 @@ var live_child_threads: usize = 0;
 // still help -- indefinite blocking here is conformant with SRFI-18, but the
 // same shape of deadlock hangs on a child thread and errors on the main
 // thread, which is worth knowing when debugging one.
-fn crossThreadWaitPossible() bool {
+//
+// `pub` since KEP-0002 Phase 3 (#1468): primitives_fiber.zig's shared-channel
+// deadlock heuristic (§5, "wakeup possible whenever ... other live OS threads
+// exist") reuses this exact same disjunct rather than duplicating it.
+pub fn crossThreadWaitPossible() bool {
     const vm = vm_mod.vm_instance orelse return false;
     if (!vm.owns_globals) return true;
     return @atomicLoad(usize, &live_child_threads, .acquire) > 0;
@@ -612,6 +616,11 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
             ctx.reactor.removeWaiter(io_fd, fiber);
             fiber.io_fd = null;
         }
+        // Same reasoning, KEP-0002 Phase 3 (#1468): a fiber parked on a
+        // promoted channel sits in the scheduler's shared-waiter registry
+        // (fiber.zig), not just .waiting -- pull it out so a later sweep
+        // never touches a slot addFiber has since reused for another fiber.
+        ctx.sched.removeSharedWaiter(fiber);
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         ctx.sched.wakeWaiters(fiber);
     }

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -98,11 +98,21 @@ pub const ThreadNotifier = struct {
                     .udata = 0,
                 }};
                 var zero_ts: std.c.timespec = .{ .sec = 0, .nsec = 0 };
-                _ = std.c.kevent(self.backend.kq, &triggers, 1, triggers[0..0].ptr, 0, &zero_ts);
+                // Retry on EINTR: an unretried signal-interrupted kevent()
+                // here would leave wake_pending set but no OS event ever
+                // posted, and the reactor blocked in poll() has no other
+                // way to learn a notify happened.
+                while (true) {
+                    const rc = std.c.kevent(self.backend.kq, &triggers, 1, triggers[0..0].ptr, 0, &zero_ts);
+                    if (rc >= 0 or std.posix.errno(rc) != .INTR) break;
+                }
             },
             .linux => {
                 const one: u64 = 1;
-                _ = std.posix.system.write(self.backend.fd, @ptrCast(&one), @sizeOf(u64));
+                while (true) {
+                    const rc = std.posix.system.write(self.backend.fd, @ptrCast(&one), @sizeOf(u64));
+                    if (rc >= 0 or std.posix.errno(rc) != .INTR) break;
+                }
             },
             .wasi => {},
             else => unreachable,
@@ -167,10 +177,18 @@ pub const Reactor = struct {
     notifier: *ThreadNotifier,
 
     pub fn init(allocator: std.mem.Allocator) !Reactor {
-        var backend = try Backend.init(allocator);
-        errdefer backend.deinit();
+        // Notifier allocated *before* the backend, not after: on kqueue,
+        // closing the backend's raw `kq` is now releaseNotifier's job alone
+        // (KqueueBackend.deinit is a no-op -- see its doc comment), so an
+        // `errdefer backend.deinit()` guarding a later notifier-allocation
+        // failure would leak `kq` (and, on epoll, `notify_fd`) with nobody
+        // left to close it. Ordering it first means a Backend.init failure
+        // has nothing of ours to clean up (each backend's own init already
+        // unwinds its own partial resources internally), and the notifier
+        // errdefer below covers both failure points uniformly.
         const notifier = try std.heap.c_allocator.create(ThreadNotifier);
         errdefer std.heap.c_allocator.destroy(notifier);
+        var backend = try Backend.init(allocator);
         notifier.* = .{ .backend = backend.notifierBackend() };
         _ = notifier_live_count.fetchAdd(1, .monotonic);
         return .{

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -63,18 +63,122 @@ const Reg = struct {
     }
 };
 
+/// KEP-0002 §5: cross-thread wakeup handle, one per Reactor (one per OS
+/// thread). Registrations come only from SharedChannel waiter lists (§7);
+/// the creating Reactor holds the base +1 (mirrors shared_object.init's
+/// "the creating stub is the first counted reference"), released at
+/// Reactor.deinit. Allocated from std.heap.c_allocator (not the Reactor's
+/// own allocator) because it must be able to outlive this thread's Reactor
+/// whenever another thread still holds a registration on it -- same
+/// rationale as SharedChannel/Envelope (KEP-0002 §1).
+pub const ThreadNotifier = struct {
+    refcount: std.atomic.Value(u32) = std.atomic.Value(u32).init(1),
+    wake_pending: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// Cleared at Reactor.deinit -- notify() on a dead handle is a no-op.
+    /// Does NOT gate memory safety (the refcount does); it only skips a
+    /// syscall that would otherwise touch a backend resource whose closing
+    /// may already be in flight (see releaseNotifier).
+    alive: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),
+    backend: NotifierBackend,
+
+    /// Thread-safe: sets wake_pending (release store) then rings the OS
+    /// primitive -- always both, so a notify racing the consume protocol's
+    /// swap loop (fiber.zig) is never lost (KEP-0002 §5).
+    pub fn notify(self: *ThreadNotifier) void {
+        self.wake_pending.store(true, .release);
+        if (!self.alive.load(.acquire)) return;
+        switch (builtin.os.tag) {
+            .macos, .ios, .tvos, .watchos, .visionos => {
+                var triggers = [1]std.c.Kevent{.{
+                    .ident = 0,
+                    .filter = std.c.EVFILT.USER,
+                    .flags = 0,
+                    .fflags = std.c.NOTE.TRIGGER,
+                    .data = 0,
+                    .udata = 0,
+                }};
+                var zero_ts: std.c.timespec = .{ .sec = 0, .nsec = 0 };
+                _ = std.c.kevent(self.backend.kq, &triggers, 1, triggers[0..0].ptr, 0, &zero_ts);
+            },
+            .linux => {
+                const one: u64 = 1;
+                _ = std.posix.system.write(self.backend.fd, @ptrCast(&one), @sizeOf(u64));
+            },
+            .wasi => {},
+            else => unreachable,
+        }
+    }
+};
+
+/// Backend-specific data `notify()` needs to ring the live OS primitive.
+/// Populated once, from the already-initialized backend, when the owning
+/// Reactor is constructed (see Reactor.init / each backend's
+/// `notifierBackend`).
+const NotifierBackend = switch (builtin.os.tag) {
+    .macos, .ios, .tvos, .watchos, .visionos => struct { kq: i32 },
+    .linux => struct { fd: i32 },
+    .wasi => struct {},
+    else => @compileError("reactor: unsupported OS (kqueue/epoll/wasi only)"),
+};
+
+/// KEP-0002 §7 leak-check hook, mirrors shared_object.liveCount() --
+/// ThreadNotifier is deliberately NOT a shared_object.Header instance (its
+/// references come only from SharedChannel waiter lists, never GC stubs),
+/// so it needs its own counterpart.
+var notifier_live_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+
+pub fn notifierLiveCount() usize {
+    return notifier_live_count.load(.monotonic);
+}
+
+pub fn retainNotifier(n: *ThreadNotifier) void {
+    _ = n.refcount.fetchAdd(1, .monotonic);
+}
+
+/// Drops one reference. At the zero transition, closes the backend OS
+/// resource and frees the struct -- ownership of that close is deliberately
+/// concentrated entirely here rather than split with Reactor.deinit/backend
+/// deinit, which would risk a double-close on kqueue (the notifier's
+/// EVFILT.USER knote shares `kq` with ordinary fd polling -- see
+/// KqueueBackend.deinit). Safe even though another thread might be
+/// concurrently calling notify(): a thread only ever touches `n` while it
+/// still holds one of its references (ring() calls notify() strictly before
+/// releasing its own registration's ref), so no release can observe the
+/// zero transition while another holder is still using the object -- the
+/// same acq_rel argument shared_object.release already relies on.
+pub fn releaseNotifier(n: *ThreadNotifier) void {
+    if (n.refcount.fetchSub(1, .acq_rel) == 1) {
+        switch (builtin.os.tag) {
+            .macos, .ios, .tvos, .watchos, .visionos => _ = std.posix.system.close(n.backend.kq),
+            .linux => _ = std.posix.system.close(n.backend.fd),
+            .wasi => {},
+            else => unreachable,
+        }
+        std.heap.c_allocator.destroy(n);
+        _ = notifier_live_count.fetchSub(1, .monotonic);
+    }
+}
+
 pub const Reactor = struct {
     allocator: std.mem.Allocator,
     backend: Backend,
     regs: std.AutoHashMap(i32, Reg),
     timers: TimerHeap,
+    notifier: *ThreadNotifier,
 
     pub fn init(allocator: std.mem.Allocator) !Reactor {
+        var backend = try Backend.init(allocator);
+        errdefer backend.deinit();
+        const notifier = try std.heap.c_allocator.create(ThreadNotifier);
+        errdefer std.heap.c_allocator.destroy(notifier);
+        notifier.* = .{ .backend = backend.notifierBackend() };
+        _ = notifier_live_count.fetchAdd(1, .monotonic);
         return .{
             .allocator = allocator,
-            .backend = try Backend.init(allocator),
+            .backend = backend,
             .regs = std.AutoHashMap(i32, Reg).init(allocator),
             .timers = .empty,
+            .notifier = notifier,
         };
     }
 
@@ -86,7 +190,20 @@ pub const Reactor = struct {
         }
         self.regs.deinit();
         self.timers.deinit(self.allocator);
+        // Order matters: flip `alive` before releasing, so a notify() that
+        // wins a race against this release still observes `alive == false`
+        // and skips the syscall instead of touching a resource this thread
+        // is about to hand off (or close) via releaseNotifier below.
+        self.notifier.alive.store(false, .release);
+        releaseNotifier(self.notifier);
         self.backend.deinit();
+    }
+
+    /// KEP-0002 §5's `Reactor.notifyHandle()`. Exposes this thread's own
+    /// cross-thread wakeup handle -- callers register it in a SharedChannel's
+    /// waiter lists, never construct one themselves.
+    pub fn notifyHandle(self: *Reactor) *ThreadNotifier {
+        return self.notifier;
     }
 
     /// Registers `fiber` as waiting for `interest` on `fd`. On success the
@@ -304,15 +421,40 @@ const KqueueBackend = struct {
     ready: [max_events_per_poll]ReadyEvent = undefined,
 
     /// Owns no allocations — the allocator is part of the uniform
-    /// three-backend init signature (WasiPollBackend needs it).
+    /// three-backend init signature (WasiPollBackend needs it). Also
+    /// registers the one persistent EVFILT.USER knote (KEP-0002 §5) that
+    /// ThreadNotifier.notify() rings later -- EV.CLEAR means it self-clears
+    /// on retrieval, so no separate drain step is needed in wait().
     fn init(_: std.mem.Allocator) !KqueueBackend {
         const kq = std.c.kqueue();
         if (kq < 0) return error.Unexpected;
-        return .{ .kq = kq };
+        var self: KqueueBackend = .{ .kq = kq };
+        var reg = std.c.Kevent{
+            .ident = 0,
+            .filter = std.c.EVFILT.USER,
+            .flags = std.c.EV.ADD | std.c.EV.CLEAR,
+            .fflags = 0,
+            .data = 0,
+            .udata = 0,
+        };
+        self.apply((&reg)[0..1]) catch {
+            _ = std.posix.system.close(kq);
+            return error.Unexpected;
+        };
+        return self;
     }
 
+    fn notifierBackend(self: *const KqueueBackend) NotifierBackend {
+        return .{ .kq = self.kq };
+    }
+
+    /// No-op: `kq` is shared with the notifier's EVFILT.USER registration
+    /// (KEP-0002 §5), so exactly one place may ever close it -- concentrated
+    /// entirely in releaseNotifier's zero-transition (reactor.zig top-level)
+    /// instead of here, to avoid a double-close race on whichever release
+    /// happens last. raw/ready are inline arrays, owning nothing else.
     fn deinit(self: *KqueueBackend) void {
-        _ = std.posix.system.close(self.kq);
+        _ = self;
     }
 
     fn filterFor(interest: Interest) i16 {
@@ -387,6 +529,12 @@ const KqueueBackend = struct {
         const n: usize = @intCast(rc);
         var count: usize = 0;
         outer: for (self.raw[0..n]) |kev| {
+            // The notifier's own EVFILT.USER trigger (KEP-0002 §5) — never
+            // let it merge into a ReadyEvent slot by ident, since ident=0
+            // could otherwise collide with a real fd 0 (stdin) READ event
+            // in the same batch. wake_pending was already set by notify()
+            // before this event was posted; nothing further to do here.
+            if (kev.filter == std.c.EVFILT.USER) continue;
             const fd: i32 = @intCast(kev.ident);
             const broken = (kev.flags & std.c.EV.EOF) != 0;
             const is_read = kev.filter == std.c.EVFILT.READ;
@@ -410,6 +558,14 @@ const KqueueBackend = struct {
 
 const EpollBackend = struct {
     epfd: i32,
+    /// The notifier's eventfd (KEP-0002 §5) -- a fd independent of `epfd`,
+    /// registered into it but never ONESHOT ("unlike fd registrations, the
+    /// notifier must stay armed"). Closing it is releaseNotifier's job
+    /// (reactor.zig top-level), not EpollBackend.deinit's -- unlike kqueue,
+    /// epfd and notify_fd are different fds, so no double-close risk exists
+    /// either way; the split just keeps ownership consistent across both
+    /// backends.
+    notify_fd: i32,
     raw: [max_events_per_poll]linux.epoll_event = undefined,
     ready: [max_events_per_poll]ReadyEvent = undefined,
 
@@ -420,7 +576,28 @@ const EpollBackend = struct {
         // are never inherited across fork by design.
         const rc = linux.epoll_create1(linux.EPOLL.CLOEXEC);
         if (linux.errno(rc) != .SUCCESS) return error.Unexpected;
-        return .{ .epfd = @intCast(rc) };
+        const epfd: i32 = @intCast(rc);
+
+        const efd_rc = linux.eventfd(0, linux.EFD.NONBLOCK | linux.EFD.CLOEXEC);
+        if (linux.errno(efd_rc) != .SUCCESS) {
+            _ = linux.close(epfd);
+            return error.Unexpected;
+        }
+        const notify_fd: i32 = @intCast(efd_rc);
+
+        var ev: linux.epoll_event = .{ .events = linux.EPOLL.IN, .data = .{ .fd = notify_fd } };
+        const ctl_rc = linux.epoll_ctl(epfd, linux.EPOLL.CTL_ADD, notify_fd, &ev);
+        if (linux.errno(ctl_rc) != .SUCCESS) {
+            _ = linux.close(notify_fd);
+            _ = linux.close(epfd);
+            return error.Unexpected;
+        }
+
+        return .{ .epfd = epfd, .notify_fd = notify_fd };
+    }
+
+    fn notifierBackend(self: *const EpollBackend) NotifierBackend {
+        return .{ .fd = self.notify_fd };
     }
 
     fn deinit(self: *EpollBackend) void {
@@ -470,6 +647,18 @@ const EpollBackend = struct {
 
         const n: usize = @intCast(rc);
         for (self.raw[0..n], 0..) |ev, i| {
+            if (ev.data.fd == self.notify_fd) {
+                // Level-triggered eventfd (KEP-0002 §5, deliberately not
+                // ONESHOT so it stays armed): must drain here or the next
+                // epoll_wait returns immediately forever. wake_pending was
+                // already set by notify() before this write; the ready
+                // slot itself is inert (Reactor.poll's regs lookup never
+                // finds an entry for notify_fd).
+                var drain_buf: [8]u8 = undefined;
+                _ = std.posix.system.read(self.notify_fd, &drain_buf, drain_buf.len);
+                self.ready[i] = .{ .fd = self.notify_fd, .readable = false, .writable = false };
+                continue;
+            }
             // epoll_wait always reports HUP/ERR even if not requested; a fd
             // in either state must wake both directions defensively (real
             // observed behavior varies by fd type on which bits accompany
@@ -535,6 +724,13 @@ const WasiPollBackend = struct {
 
     fn init(allocator: std.mem.Allocator) !WasiPollBackend {
         return .{ .allocator = allocator };
+    }
+
+    /// No real OS threads exist on WASI (thread-start! is already
+    /// is_wasm-gated before reaching any KEP-0002 code) -- nothing for
+    /// notify() to ring.
+    fn notifierBackend(_: *const WasiPollBackend) NotifierBackend {
+        return .{};
     }
 
     fn deinit(self: *WasiPollBackend) void {

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -2,30 +2,35 @@ const std = @import("std");
 const shared_object = @import("shared_object.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const reactor_mod = @import("reactor.zig");
+const vm_mod = @import("vm.zig");
+const pct_stress = @import("pct_stress.zig");
 const Value = types.Value;
 
-/// KEP-0002 §5's cross-thread wakeup handle. Refcounted, but -- unlike
-/// SharedChannel -- NOT an instance of the shared_object protocol: its
-/// references come only from SharedChannel waiter lists (§7), never from
-/// heap stubs, so it has its own plain refcount and is invisible to
-/// shared_object.liveCount()'s leak check.
-///
-/// Phase 1 wires up only the waiter-list bookkeeping (registration, dedup,
-/// snapshot-and-clear) needed to make promotion and send/receive correct
-/// and unit-testable. The reactor-backed notify() (kqueue EVFILT.USER /
-/// eventfd) is KEP-0002 Phase 3 (#1468); until then `ring` below just
-/// releases each registration's refcount.
-pub const ThreadNotifier = struct {
-    refcount: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
-};
-
-fn retainNotifier(n: *ThreadNotifier) void {
-    _ = n.refcount.fetchAdd(1, .monotonic);
+/// KEP-0002 Phase 3 (#1468) PCT stress hook: a no-op unless
+/// src/stress_channel.zig has enabled pct_stress, in which case it injects
+/// a randomized yield point around every SharedChannel lock acquire/release
+/// -- exactly the interleavings the model-checked send/receive protocol
+/// (§4) needs to survive under real scheduling, not just on paper.
+fn lockChannel(sc: *SharedChannel) void {
+    pct_stress.maybeYield();
+    memory.spinLock(&sc.lock);
+    pct_stress.maybeYield();
 }
 
-fn releaseNotifier(n: *ThreadNotifier) void {
-    _ = n.refcount.fetchSub(1, .acq_rel);
+fn unlockChannel(sc: *SharedChannel) void {
+    pct_stress.maybeYield();
+    memory.spinUnlock(&sc.lock);
 }
+
+/// KEP-0002 §5's cross-thread wakeup handle -- defined in reactor.zig (its
+/// ring mechanism needs the live kqueue/epoll backend internals that module
+/// owns privately). Aliased here under its original name so the rest of
+/// this file (registration, dedup, waiter lists, all written against Phase
+/// 1) reads unchanged.
+const ThreadNotifier = reactor_mod.ThreadNotifier;
+const retainNotifier = reactor_mod.retainNotifier;
+const releaseNotifier = reactor_mod.releaseNotifier;
 
 /// A message-sized private mini-heap (KEP-0002 §1): the sender's deepCopy
 /// fills it once, the receiver's deepCopy drains it once, then it is
@@ -129,6 +134,13 @@ pub const SharedChannel = struct {
         shared_object.release(&self.header);
     }
 
+    /// Heuristic-only read (KEP-0002 §5's deadlock-heuristic disjunct:
+    /// "wakeup possible whenever refcount > 1"). See
+    /// shared_object.loadRefcount's doc comment.
+    pub fn refCount(self: *SharedChannel) u32 {
+        return shared_object.loadRefcount(&self.header);
+    }
+
     /// §1 rule 4 / §7: zero destroys. Drains and deinits every queued
     /// envelope (recursively releasing any stub refcounts those messages
     /// hold -- this is what reclaims a channel that was only kept alive by
@@ -137,12 +149,12 @@ pub const SharedChannel = struct {
     fn destroyHook(header: *shared_object.Header) void {
         const self: *SharedChannel = @fieldParentPtr("header", header);
 
-        memory.spinLock(&self.lock);
+        lockChannel(self);
         var env = self.queue_head;
         self.queue_head = null;
         self.queue_tail = null;
         self.queue_len = 0;
-        memory.spinUnlock(&self.lock);
+        unlockChannel(self);
 
         while (env) |e| {
             const next = e.next;
@@ -190,17 +202,40 @@ pub const SharedChannel = struct {
 
     // -- §7 waiter lifecycle: caller holds `lock` --
 
+    /// §7 opportunistic pruning: while walking for the dedup check anyway,
+    /// drop any entry whose notifier has already gone dead (its owning
+    /// thread exited) -- "any path holding the lock" covers send, receive,
+    /// and promotion migration, since they all route through here. Not a
+    /// correctness requirement (a ring or destroy would eventually clear a
+    /// dead entry too -- "one harmless spurious sweep"), just keeps
+    /// long-lived channels from accumulating dead registrations.
     fn registerSendWaiter(self: *SharedChannel, n: *ThreadNotifier) void {
-        for (self.send_waiters.items) |existing| {
+        var i: usize = 0;
+        while (i < self.send_waiters.items.len) {
+            const existing = self.send_waiters.items[i];
             if (existing == n) return; // dedup: at most one entry per notifier per list
+            if (!existing.alive.load(.acquire)) {
+                _ = self.send_waiters.swapRemove(i);
+                releaseNotifier(existing);
+                continue;
+            }
+            i += 1;
         }
         self.send_waiters.append(std.heap.c_allocator, n) catch @panic("SharedChannel: send_waiters OOM");
         retainNotifier(n);
     }
 
     fn registerRecvWaiter(self: *SharedChannel, n: *ThreadNotifier) void {
-        for (self.recv_waiters.items) |existing| {
+        var i: usize = 0;
+        while (i < self.recv_waiters.items.len) {
+            const existing = self.recv_waiters.items[i];
             if (existing == n) return;
+            if (!existing.alive.load(.acquire)) {
+                _ = self.recv_waiters.swapRemove(i);
+                releaseNotifier(existing);
+                continue;
+            }
+            i += 1;
         }
         self.recv_waiters.append(std.heap.c_allocator, n) catch @panic("SharedChannel: recv_waiters OOM");
         retainNotifier(n);
@@ -218,11 +253,15 @@ pub const SharedChannel = struct {
 };
 
 /// §5: ring every notifier in a snapshot taken under the lock, after
-/// releasing it -- a live waiter list is never iterated unlocked. Phase 3
-/// (#1468) adds the real reactor notify() call here; Phase 1 just releases
-/// each registration's refcount, since nothing else consumes the snapshot.
+/// releasing it -- a live waiter list is never iterated unlocked. notify()
+/// runs strictly before releaseNotifier so this thread still holds its own
+/// +1 while touching `n` -- see releaseNotifier's doc comment (reactor.zig)
+/// for why that ordering is what makes concurrent teardown safe.
 fn ring(notifiers: []const *ThreadNotifier) void {
-    for (notifiers) |n| releaseNotifier(n);
+    for (notifiers) |n| {
+        n.notify();
+        releaseNotifier(n);
+    }
 }
 
 /// KEP-0002 §2. Promotes `ch` in place -- the existing heap object becomes
@@ -262,6 +301,32 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
         sc.pushBack(env);
         cur = next;
     }
+
+    // KEP-0002 §2 step 4: migrate any fiber already parked on the *local*
+    // representation before promotion (waiting_on == ch -- a receiver on
+    // the empty queue; sender-side migration doesn't apply yet, since the
+    // local Channel has no capacity to park a sender against until Phase
+    // 4). Promotion runs inside a primitive on the owning thread, so the
+    // local scheduler is quiescent and this scan is race-free. Without this
+    // step a fiber parked before promotion would hang forever: a remote
+    // send only rings *registered* notifiers. Enrolled unconditionally, not
+    // gated on sc.refCount() > 1 -- at this point refcount is still 1 (the
+    // caller in gc_deep_copy.zig retains the second stub only after this
+    // function returns), so gating here would always see 1 and wrongly
+    // skip migration.
+    if (vm_mod.vm_instance) |vm| {
+        if (vm.scheduler) |sched| {
+            const ch_val = types.makePointer(@ptrCast(&ch.header));
+            for (sched.fibers.items) |maybe_f| {
+                const f = maybe_f orelse continue;
+                if (f.status == .waiting and f.waiting_on == ch_val) {
+                    sc.registerRecvWaiter(vm.reactor.?.notifyHandle());
+                    sched.enrollSharedWaiter(f) catch {};
+                }
+            }
+        }
+    }
+
     return sc;
 }
 
@@ -279,26 +344,26 @@ pub const SendOutcome = union(enum) {
 /// (there is nothing yet to wake) rather than panicking, so a future caller
 /// that *can* reach this branch without a real notifier degrades safely.
 pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !SendOutcome {
-    memory.spinLock(&sc.lock);
+    lockChannel(sc);
     if (sc.closed) {
-        memory.spinUnlock(&sc.lock);
+        unlockChannel(sc);
         return .closed;
     }
     if (sc.capacity) |cap| {
         if (sc.queue_len + sc.reserved >= cap) {
             if (notifier) |n| sc.registerSendWaiter(n);
-            memory.spinUnlock(&sc.lock);
+            unlockChannel(sc);
             return .would_park;
         }
     }
     sc.reserved += 1;
-    memory.spinUnlock(&sc.lock);
+    unlockChannel(sc);
 
     // Built outside the lock: deepCopy allocates and must not hold the
     // channel mutex. A reservation was already taken, so the eventual push
     // (on success) is infallible.
     const env = Envelope.create(payload) catch |err| {
-        memory.spinLock(&sc.lock);
+        lockChannel(sc);
         sc.reserved -= 1;
         var snap: std.ArrayList(*ThreadNotifier) = .empty;
         defer snap.deinit(std.heap.c_allocator);
@@ -307,20 +372,20 @@ pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !Sen
         // (receive step 6's reserved==0 eof guard) if the channel closed
         // while this send was in flight.
         if (sc.closed) sc.snapshotAndClearRecvWaiters(&snap);
-        memory.spinUnlock(&sc.lock);
+        unlockChannel(sc);
         ring(snap.items);
         // Nothing was enqueued ("send fails ⇒ nothing sent"); Envelope
         // .create already tore itself down internally on failure.
         return err;
     };
 
-    memory.spinLock(&sc.lock);
+    lockChannel(sc);
     sc.reserved -= 1;
     sc.pushBack(env);
     var snap: std.ArrayList(*ThreadNotifier) = .empty;
     defer snap.deinit(std.heap.c_allocator);
     sc.snapshotAndClearRecvWaiters(&snap);
-    memory.spinUnlock(&sc.lock);
+    unlockChannel(sc);
     ring(snap.items);
     return .sent;
 }
@@ -334,24 +399,24 @@ pub const RecvOutcome = union(enum) {
 /// KEP-0002 §4 receive, on the shared representation, verbatim. `notifier`
 /// follows send()'s same null-is-safe convention on the park branch.
 pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifier) !RecvOutcome {
-    memory.spinLock(&sc.lock);
+    lockChannel(sc);
     if (sc.popFront()) |env| {
         var snap: std.ArrayList(*ThreadNotifier) = .empty;
         defer snap.deinit(std.heap.c_allocator);
         sc.snapshotAndClearSendWaiters(&snap); // a slot opened
-        memory.spinUnlock(&sc.lock);
+        unlockChannel(sc);
         ring(snap.items);
 
         const value = dest_gc.deepCopy(env.value) catch |err| {
             // "Receive fails ⇒ nothing received": the envelope is
             // untouched, its stubs keep their refcounts, the message stays
             // deliverable in order. Re-queue at the head, not the tail.
-            memory.spinLock(&sc.lock);
+            lockChannel(sc);
             sc.pushFront(env);
             var recv_snap: std.ArrayList(*ThreadNotifier) = .empty;
             defer recv_snap.deinit(std.heap.c_allocator);
             sc.snapshotAndClearRecvWaiters(&recv_snap);
-            memory.spinUnlock(&sc.lock);
+            unlockChannel(sc);
             ring(recv_snap.items);
             return err;
         };
@@ -359,13 +424,13 @@ pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifi
         return .{ .value = value };
     }
     if (sc.closed and sc.reserved == 0) {
-        memory.spinUnlock(&sc.lock);
+        unlockChannel(sc);
         return .eof;
     }
     // Reached with the channel open, or closed with admitted sends still in
     // flight: eof must not race a reservation, so the receiver parks and is
     // rung by the late push (or by send's failure-path closed-channel ring).
     if (notifier) |n| sc.registerRecvWaiter(n);
-    memory.spinUnlock(&sc.lock);
+    unlockChannel(sc);
     return .would_park;
 }

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -141,6 +141,18 @@ pub const SharedChannel = struct {
         return shared_object.loadRefcount(&self.header);
     }
 
+    /// Lock-protected peek: true iff a receive() call right now would find a
+    /// value or (once Phase 4 adds channel-close!) EOF. Used by
+    /// channelReceiveShared's local-drive loop (primitives_fiber.zig) to
+    /// decide whether driving local siblings found anything, without
+    /// unsafely reading queue_len/closed outside the lock -- unlike a purely
+    /// local Channel's queue, this one is genuinely cross-thread-visible.
+    pub fn peekReady(self: *SharedChannel) bool {
+        lockChannel(self);
+        defer unlockChannel(self);
+        return self.queue_len != 0 or self.closed;
+    }
+
     /// §1 rule 4 / §7: zero destroys. Drains and deinits every queued
     /// envelope (recursively releasing any stub refcounts those messages
     /// hold -- this is what reclaims a channel that was only kept alive by
@@ -317,13 +329,25 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
     if (vm_mod.vm_instance) |vm| {
         if (vm.scheduler) |sched| {
             const ch_val = types.makePointer(@ptrCast(&ch.header));
+            // Registers the notifier once, only if something actually
+            // matched -- registerRecvWaiter's own dedup makes calling it
+            // once per matching fiber idempotent, but hoisting it out reads
+            // clearer and does one lock/unlock instead of N.
+            var migrated_any = false;
             for (sched.fibers.items) |maybe_f| {
                 const f = maybe_f orelse continue;
                 if (f.status == .waiting and f.waiting_on == ch_val) {
-                    sc.registerRecvWaiter(vm.reactor.?.notifyHandle());
-                    sched.enrollSharedWaiter(f) catch {};
+                    // Propagate, don't swallow: registerRecvWaiter above
+                    // (once hoisted) already succeeded or @panic'd on OOM,
+                    // so a remote send WILL ring this thread's notifier --
+                    // silently dropping this fiber's enrollment here would
+                    // leave it .waiting with nothing left to ever flip it
+                    // back, a permanent hang.
+                    try sched.enrollSharedWaiter(f);
+                    migrated_any = true;
                 }
             }
+            if (migrated_any) sc.registerRecvWaiter(vm.reactor.?.notifyHandle());
         }
     }
 

--- a/src/shared_object.zig
+++ b/src/shared_object.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const pct_stress = @import("pct_stress.zig");
 
 /// KEP-0002 §1: the generic shared-object protocol. A shared object is a
 /// refcounted structure allocated from the process-global allocator
@@ -37,6 +38,9 @@ pub fn init(header: *Header, destroyFn: *const fn (*Header) void) void {
 /// +1: a new stub was created (deepCopy's alias arm, including a stub
 /// allocated inside an envelope heap).
 pub fn retain(header: *Header) void {
+    // KEP-0002 Phase 3 (#1468) PCT stress hook: no-op unless
+    // src/stress_channel.zig has enabled it -- see pct_stress.zig.
+    pct_stress.maybeYield();
     // Incrementing from a location that already holds a valid reference
     // needs no synchronization with any concurrent releaser (same
     // justification as Arc::clone / intrusive_ptr_add_ref).
@@ -47,6 +51,7 @@ pub fn retain(header: *Header) void {
 /// thread-join!, an envelope.deinit()). Runs the type's destroy hook
 /// exactly once, at the transition to zero.
 pub fn release(header: *Header) void {
+    pct_stress.maybeYield();
     // acq_rel: the decrement that takes refcount to zero must happen-after
     // every prior retain/release on other threads (so destroyFn never runs
     // while another thread is still mid-retain), and destroyFn's own reads
@@ -59,4 +64,11 @@ pub fn release(header: *Header) void {
 
 pub fn liveCount() usize {
     return live_count.load(.monotonic);
+}
+
+/// Heuristic-only read (KEP-0002 §5's deadlock-heuristic disjunct: "wakeup
+/// possible whenever refcount > 1"). `.monotonic` is correct here -- this
+/// only ever gates a block-vs-raise-deadlock decision, never memory safety.
+pub fn loadRefcount(header: *Header) u32 {
+    return header.refcount.load(.monotonic);
 }

--- a/src/stress_channel.zig
+++ b/src/stress_channel.zig
@@ -26,17 +26,37 @@ fn fail(comptime fmt: []const u8, args: anytype) noreturn {
     std.process.exit(1);
 }
 
+fn nowNs() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+// A no-progress window this long (no successful delivery anywhere) fails the
+// run instead of spinning forever -- a lost message otherwise busy-loops
+// consumers indefinitely on .would_park with no way to notice.
+const STALL_TIMEOUT_NS: u64 = 30 * std.time.ns_per_s;
+
+// Each producer's values are pre-partitioned into a disjoint range
+// (producer_id * VALUE_STRIDE + offset), so a value's origin decodes
+// directly without any side channel.
+const VALUE_STRIDE: i64 = 1_000_000;
+
+var seed: u64 = undefined;
+var last_progress_ns: std.atomic.Value(u64) = std.atomic.Value(u64).init(0);
+
 const Producer = struct {
     sc: *shared_channel.SharedChannel,
     count: usize,
-    start_val: i64,
+    producer_id: usize,
     thread_tag: u64,
 
     fn run(self: Producer) void {
         pct_stress.seedThread(seed, self.thread_tag);
         var i: usize = 0;
         while (i < self.count) : (i += 1) {
-            _ = shared_channel.send(self.sc, types.makeFixnum(self.start_val + @as(i64, @intCast(i))), null) catch |err|
+            const val = @as(i64, @intCast(self.producer_id)) * VALUE_STRIDE + @as(i64, @intCast(i));
+            _ = shared_channel.send(self.sc, types.makeFixnum(val), null) catch |err|
                 fail("producer: send failed: {t} (seed={d})\n", .{ err, seed });
         }
     }
@@ -46,7 +66,14 @@ const Consumer = struct {
     sc: *shared_channel.SharedChannel,
     target_total: usize,
     count: *std.atomic.Value(usize),
-    sum: *std.atomic.Value(i64),
+    // One flag per (producer_id, offset) pair, flat-indexed as
+    // producer_id * per_producer + offset -- an identity-aware oracle, not
+    // just an aggregate count/sum, so a lost delivery balanced by a
+    // duplicate elsewhere (which a count+sum check alone could miss) is
+    // caught immediately as either an out-of-range value or a
+    // double-delivery.
+    delivered: []std.atomic.Value(bool),
+    per_producer: usize,
     thread_tag: u64,
 
     fn run(self: Consumer) void {
@@ -63,17 +90,27 @@ const Consumer = struct {
                 fail("consumer: receive failed: {t} (seed={d})\n", .{ err, seed });
             switch (outcome) {
                 .value => |v| {
-                    _ = self.sum.fetchAdd(types.toFixnum(v), .monotonic);
+                    const val = types.toFixnum(v);
+                    const producer_id: usize = @intCast(@divTrunc(val, VALUE_STRIDE));
+                    const offset: usize = @intCast(@mod(val, VALUE_STRIDE));
+                    if (offset >= self.per_producer or producer_id * self.per_producer + offset >= self.delivered.len)
+                        fail("FAIL: delivered value {d} decodes outside the expected range (seed={d})\n", .{ val, seed });
+                    const index = producer_id * self.per_producer + offset;
+                    if (self.delivered[index].swap(true, .monotonic))
+                        fail("FAIL: duplicate delivery of value {d} (seed={d})\n", .{ val, seed });
+                    last_progress_ns.store(nowNs(), .monotonic);
                     _ = self.count.fetchAdd(1, .monotonic);
                 },
-                .would_park => std.Thread.yield() catch {},
+                .would_park => {
+                    if (nowNs() -| last_progress_ns.load(.monotonic) > STALL_TIMEOUT_NS)
+                        fail("FAIL: no delivery anywhere for {d}s -- likely a lost wakeup (seed={d})\n", .{ STALL_TIMEOUT_NS / std.time.ns_per_s, seed });
+                    std.Thread.yield() catch {};
+                },
                 .eof => fail("consumer: unexpected eof (seed={d})\n", .{seed}),
             }
         }
     }
 };
-
-var seed: u64 = undefined;
 
 fn defaultSeed() u64 {
     var ts: std.c.timespec = undefined;
@@ -97,22 +134,28 @@ pub fn main(init: std.process.Init.Minimal) !void {
     const n_producers: usize = if (args.next()) |s| try std.fmt.parseInt(usize, s, 10) else 8;
     const m_consumers: usize = if (args.next()) |s| try std.fmt.parseInt(usize, s, 10) else 8;
     const per_producer: usize = if (args.next()) |s| try std.fmt.parseInt(usize, s, 10) else 500;
+    if (per_producer >= @as(usize, @intCast(VALUE_STRIDE)))
+        fail("per-producer count {d} must be less than {d}\n", .{ per_producer, VALUE_STRIDE });
 
     var buf: [256]u8 = undefined;
     const banner = try std.fmt.bufPrint(&buf, "stress-channel: seed={d} producers={d} consumers={d} per_producer={d}\n", .{ seed, n_producers, m_consumers, per_producer });
     _ = std.posix.system.write(1, banner.ptr, banner.len);
 
     pct_stress.enabled = true;
+    last_progress_ns.store(nowNs(), .monotonic);
 
     const baseline = shared_object.liveCount();
     const notifier_baseline = reactor_mod.notifierLiveCount();
 
     const sc = try shared_channel.SharedChannel.create();
     var received_count = std.atomic.Value(usize).init(0);
-    var received_sum = std.atomic.Value(i64).init(0);
     const total = n_producers * per_producer;
 
     const allocator = std.heap.page_allocator;
+    const delivered = try allocator.alloc(std.atomic.Value(bool), total);
+    defer allocator.free(delivered);
+    for (delivered) |*d| d.* = std.atomic.Value(bool).init(false);
+
     const producers = try allocator.alloc(std.Thread, n_producers);
     defer allocator.free(producers);
     const consumers = try allocator.alloc(std.Thread, m_consumers);
@@ -122,7 +165,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
         producers[i] = try std.Thread.spawn(.{}, Producer.run, .{Producer{
             .sc = sc,
             .count = per_producer,
-            .start_val = @as(i64, @intCast(i * 1_000_000)),
+            .producer_id = i,
             .thread_tag = i,
         }});
     }
@@ -131,7 +174,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
             .sc = sc,
             .target_total = total,
             .count = &received_count,
-            .sum = &received_sum,
+            .delivered = delivered,
+            .per_producer = per_producer,
             .thread_tag = n_producers + i,
         }});
     }
@@ -140,17 +184,13 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     pct_stress.enabled = false;
 
+    // Every delivery was checked in-place (range + duplicate) as it
+    // happened; reaching exactly `total` non-duplicate deliveries out of
+    // exactly `total` possible (producer_id, offset) slots is a bijection,
+    // so this final count is sufficient to confirm full, exact-once
+    // coverage without a separate scan over `delivered`.
     if (received_count.load(.monotonic) != total)
         fail("FAIL: expected {d} deliveries, got {d} (seed={d})\n", .{ total, received_count.load(.monotonic), seed });
-
-    var expected_sum: i64 = 0;
-    for (0..n_producers) |i| {
-        var j: usize = 0;
-        while (j < per_producer) : (j += 1)
-            expected_sum += @as(i64, @intCast(i * 1_000_000)) + @as(i64, @intCast(j));
-    }
-    if (received_sum.load(.monotonic) != expected_sum)
-        fail("FAIL: expected sum {d}, got {d} -- duplicated or corrupted delivery (seed={d})\n", .{ expected_sum, received_sum.load(.monotonic), seed });
 
     sc.release();
     if (shared_object.liveCount() != baseline)

--- a/src/stress_channel.zig
+++ b/src/stress_channel.zig
@@ -1,0 +1,163 @@
+//! KEP-0002 Phase 3 (#1468): PCT-style randomized scheduling stress test for
+//! SharedChannel/ThreadNotifier (the KEP-0002 research plan's P2 method
+//! step 2). Spawns N producer / M consumer OS threads hammering one
+//! SharedChannel directly (white-box, no VM -- the same layer
+//! tests_shared_channel.zig's own stress test exercises, just with
+//! pct_stress's randomized yield injection turned on at every lock
+//! acquire/release and refcount op). Prints the seed on any failure for
+//! deterministic replay.
+//!
+//! Build/run:  zig build stress-channel
+//!             zig build stress-channel -- <seed>
+//!             zig build stress-channel -- <seed> <producers> <consumers> <per-producer>
+
+const std = @import("std");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const shared_channel = @import("shared_channel.zig");
+const shared_object = @import("shared_object.zig");
+const reactor_mod = @import("reactor.zig");
+const pct_stress = @import("pct_stress.zig");
+
+fn fail(comptime fmt: []const u8, args: anytype) noreturn {
+    var buf: [512]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, fmt, args) catch fmt;
+    _ = std.posix.system.write(2, msg.ptr, msg.len);
+    std.process.exit(1);
+}
+
+const Producer = struct {
+    sc: *shared_channel.SharedChannel,
+    count: usize,
+    start_val: i64,
+    thread_tag: u64,
+
+    fn run(self: Producer) void {
+        pct_stress.seedThread(seed, self.thread_tag);
+        var i: usize = 0;
+        while (i < self.count) : (i += 1) {
+            _ = shared_channel.send(self.sc, types.makeFixnum(self.start_val + @as(i64, @intCast(i))), null) catch |err|
+                fail("producer: send failed: {t} (seed={d})\n", .{ err, seed });
+        }
+    }
+};
+
+const Consumer = struct {
+    sc: *shared_channel.SharedChannel,
+    target_total: usize,
+    count: *std.atomic.Value(usize),
+    sum: *std.atomic.Value(i64),
+    thread_tag: u64,
+
+    fn run(self: Consumer) void {
+        pct_stress.seedThread(seed, self.thread_tag);
+        var local_reactor = reactor_mod.Reactor.init(std.heap.page_allocator) catch |err|
+            fail("consumer: Reactor.init failed: {t} (seed={d})\n", .{ err, seed });
+        defer local_reactor.deinit();
+        const notifier = local_reactor.notifyHandle();
+        var local_gc = memory.GC.init(std.heap.page_allocator);
+        defer local_gc.deinit();
+
+        while (self.count.load(.monotonic) < self.target_total) {
+            const outcome = shared_channel.receive(self.sc, &local_gc, notifier) catch |err|
+                fail("consumer: receive failed: {t} (seed={d})\n", .{ err, seed });
+            switch (outcome) {
+                .value => |v| {
+                    _ = self.sum.fetchAdd(types.toFixnum(v), .monotonic);
+                    _ = self.count.fetchAdd(1, .monotonic);
+                },
+                .would_park => std.Thread.yield() catch {},
+                .eof => fail("consumer: unexpected eof (seed={d})\n", .{seed}),
+            }
+        }
+    }
+};
+
+var seed: u64 = undefined;
+
+fn defaultSeed() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @bitCast(ts.sec)) ^ @as(u64, @intCast(ts.nsec));
+}
+
+pub fn main(init: std.process.Init.Minimal) !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var args = try init.args.iterateAllocator(gpa);
+    defer args.deinit();
+    _ = args.skip(); // argv[0]
+
+    seed = if (args.next()) |s|
+        std.fmt.parseInt(u64, s, 10) catch fail("invalid seed: {s}\n", .{s})
+    else
+        defaultSeed();
+    const n_producers: usize = if (args.next()) |s| try std.fmt.parseInt(usize, s, 10) else 8;
+    const m_consumers: usize = if (args.next()) |s| try std.fmt.parseInt(usize, s, 10) else 8;
+    const per_producer: usize = if (args.next()) |s| try std.fmt.parseInt(usize, s, 10) else 500;
+
+    var buf: [256]u8 = undefined;
+    const banner = try std.fmt.bufPrint(&buf, "stress-channel: seed={d} producers={d} consumers={d} per_producer={d}\n", .{ seed, n_producers, m_consumers, per_producer });
+    _ = std.posix.system.write(1, banner.ptr, banner.len);
+
+    pct_stress.enabled = true;
+
+    const baseline = shared_object.liveCount();
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+
+    const sc = try shared_channel.SharedChannel.create();
+    var received_count = std.atomic.Value(usize).init(0);
+    var received_sum = std.atomic.Value(i64).init(0);
+    const total = n_producers * per_producer;
+
+    const allocator = std.heap.page_allocator;
+    const producers = try allocator.alloc(std.Thread, n_producers);
+    defer allocator.free(producers);
+    const consumers = try allocator.alloc(std.Thread, m_consumers);
+    defer allocator.free(consumers);
+
+    for (0..n_producers) |i| {
+        producers[i] = try std.Thread.spawn(.{}, Producer.run, .{Producer{
+            .sc = sc,
+            .count = per_producer,
+            .start_val = @as(i64, @intCast(i * 1_000_000)),
+            .thread_tag = i,
+        }});
+    }
+    for (0..m_consumers) |i| {
+        consumers[i] = try std.Thread.spawn(.{}, Consumer.run, .{Consumer{
+            .sc = sc,
+            .target_total = total,
+            .count = &received_count,
+            .sum = &received_sum,
+            .thread_tag = n_producers + i,
+        }});
+    }
+    for (producers) |p| p.join();
+    for (consumers) |c| c.join();
+
+    pct_stress.enabled = false;
+
+    if (received_count.load(.monotonic) != total)
+        fail("FAIL: expected {d} deliveries, got {d} (seed={d})\n", .{ total, received_count.load(.monotonic), seed });
+
+    var expected_sum: i64 = 0;
+    for (0..n_producers) |i| {
+        var j: usize = 0;
+        while (j < per_producer) : (j += 1)
+            expected_sum += @as(i64, @intCast(i * 1_000_000)) + @as(i64, @intCast(j));
+    }
+    if (received_sum.load(.monotonic) != expected_sum)
+        fail("FAIL: expected sum {d}, got {d} -- duplicated or corrupted delivery (seed={d})\n", .{ expected_sum, received_sum.load(.monotonic), seed });
+
+    sc.release();
+    if (shared_object.liveCount() != baseline)
+        fail("FAIL: shared_object leak: baseline={d} now={d} (seed={d})\n", .{ baseline, shared_object.liveCount(), seed });
+    if (reactor_mod.notifierLiveCount() != notifier_baseline)
+        fail("FAIL: notifier leak: baseline={d} now={d} (seed={d})\n", .{ notifier_baseline, reactor_mod.notifierLiveCount(), seed });
+
+    const ok_msg = "stress-channel: PASS\n";
+    _ = std.posix.system.write(1, ok_msg.ptr, ok_msg.len);
+}

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -515,3 +515,69 @@ test "a stale ONESHOT fire on one direction re-arms the fd for the surviving wai
     try std.testing.expectEqual(@as(usize, 1), ready.items.len);
     try std.testing.expectEqual(&fiber_w, ready.items[0]);
 }
+
+// KEP-0002 Phase 3 (#1468): ThreadNotifier, the cross-thread wakeup handle
+// every Reactor now owns. notifierLiveCount() is a real process-global
+// counter (like shared_object.liveCount()), not reset between Zig tests --
+// every test captures its own baseline and asserts a return to it.
+
+test "notifierLiveCount tracks Reactor.init/deinit" {
+    const baseline = reactor_mod.notifierLiveCount();
+    var reactor = try Reactor.init(std.testing.allocator);
+    try std.testing.expectEqual(baseline + 1, reactor_mod.notifierLiveCount());
+    reactor.deinit();
+    try std.testing.expectEqual(baseline, reactor_mod.notifierLiveCount());
+}
+
+test "retainNotifier keeps the notifier alive past Reactor.deinit; releasing the last ref frees it" {
+    const baseline = reactor_mod.notifierLiveCount();
+    var reactor = try Reactor.init(std.testing.allocator);
+    const notifier = reactor.notifyHandle();
+
+    // Simulates a SharedChannel registration outliving this thread's own
+    // Reactor (KEP-0002 §7: "the refcount keeps the struct itself valid
+    // until the last entry is released").
+    reactor_mod.retainNotifier(notifier);
+
+    reactor.deinit(); // drops the base ref; one registration ref remains
+    try std.testing.expectEqual(baseline + 1, reactor_mod.notifierLiveCount());
+    try std.testing.expect(!notifier.alive.load(.acquire));
+
+    // notify() on a dead handle is a documented no-op -- must not touch the
+    // (already-closed-if-it-had-hit-zero, but here still-open) backend fd.
+    notifier.notify();
+    try std.testing.expect(notifier.wake_pending.load(.acquire));
+
+    reactor_mod.releaseNotifier(notifier); // last ref: frees + closes backend
+    try std.testing.expectEqual(baseline, reactor_mod.notifierLiveCount());
+}
+
+test "notify() from another OS thread interrupts a blocking poll()" {
+    var reactor = try Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+
+    const Ctx = struct {
+        notifier: *reactor_mod.ThreadNotifier,
+        fn run(self: @This()) void {
+            var ts: std.c.timespec = .{ .sec = 0, .nsec = 20_000_000 };
+            _ = std.c.nanosleep(&ts, &ts);
+            self.notifier.notify();
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, Ctx.run, .{Ctx{ .notifier = reactor.notifyHandle() }});
+    defer thread.join();
+
+    const start = fiber_mod.clockNs();
+    var ready = newReady();
+    defer ready.deinit(std.testing.allocator);
+    // A generous upper bound: if notify() failed to interrupt poll(), this
+    // would time out at 5s instead of returning promptly after ~20ms.
+    try reactor.poll(5_000_000_000, &ready);
+    const elapsed_ns = fiber_mod.clockNs() - start;
+
+    // Nothing fd-related fired; the notifier's own event is filtered out of
+    // ReadyEvent entirely (reactor.zig's wait() implementations).
+    try std.testing.expectEqual(@as(usize, 0), ready.items.len);
+    try std.testing.expect(reactor.notifier.wake_pending.load(.acquire));
+    try std.testing.expect(elapsed_ns < 1_000_000_000);
+}

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -140,3 +140,97 @@ test "fiber switch does not grow the fiber's own register storage to match a lar
     const result = try vm.eval("(fiber-join f)");
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
 }
+
+// KEP-0002 Phase 3 (#1468): the per-scheduler shared-waiter registry that
+// backs sweepSharedWaiters' unconditional flip.
+
+test "enrollSharedWaiter dedups by pointer; removeSharedWaiter is a no-op if absent" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+
+    try sched.enrollSharedWaiter(f);
+    try sched.enrollSharedWaiter(f); // dedup: still just one entry
+    try std.testing.expectEqual(@as(usize, 1), sched.shared_waiters.items.len);
+
+    sched.removeSharedWaiter(f);
+    try std.testing.expectEqual(@as(usize, 0), sched.shared_waiters.items.len);
+    sched.removeSharedWaiter(f); // no-op if already absent
+    try std.testing.expectEqual(@as(usize, 0), sched.shared_waiters.items.len);
+}
+
+test "sweepSharedWaiters unconditionally flips every enrolled .waiting fiber and clears the registry" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+
+    f.status = .waiting;
+    f.waiting_on = f_val; // arbitrary non-void Value, mirrors a real park
+    try sched.enrollSharedWaiter(f);
+
+    sched.sweepSharedWaiters();
+
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, f.status);
+    try std.testing.expectEqual(types.VOID, f.waiting_on);
+    try std.testing.expectEqual(@as(usize, 0), sched.shared_waiters.items.len);
+}
+
+test "sweepSharedWaiters does not clobber a fiber no longer .waiting" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+
+    f.status = .waiting;
+    try sched.enrollSharedWaiter(f);
+    // Simulates a path other than the sweep (e.g. thread-terminate!) moving
+    // the fiber out of .waiting without going through removeSharedWaiter
+    // first -- the registry entry is stale but must not corrupt the status.
+    f.status = .errored;
+
+    sched.sweepSharedWaiters();
+
+    try std.testing.expectEqual(fiber_mod.FiberStatus.errored, f.status);
+    try std.testing.expectEqual(@as(usize, 0), sched.shared_waiters.items.len);
+}
+
+test "hasRunnableFibers reports a shared-waiter-registry entry as alive" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    const sched = ctx.sched;
+    // Only the main fiber exists, and it's .running (deliberately not
+    // counted -- see hasRunnableFibers' doc comment).
+    try std.testing.expect(!sched.hasRunnableFibers());
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+    // .waiting with no deadline trips none of the pre-existing categories
+    // (created/suspended/waiting-with-deadline/io_waiting) -- isolates the
+    // new shared_waiters check from every other reason this could pass.
+    f.status = .waiting;
+    try sched.enrollSharedWaiter(f);
+
+    try std.testing.expect(sched.hasRunnableFibers());
+}

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -145,14 +145,13 @@ test "fiber switch does not grow the fiber's own register storage to match a lar
 // backs sweepSharedWaiters' unconditional flip.
 
 test "enrollSharedWaiter dedups by pointer; removeSharedWaiter is a no-op if absent" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = vm.scheduler.?;
-    const f_val = try vm.eval("f");
+    _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = ctx.vm.scheduler.?;
+    const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
     try sched.enrollSharedWaiter(f);
@@ -166,14 +165,13 @@ test "enrollSharedWaiter dedups by pointer; removeSharedWaiter is a no-op if abs
 }
 
 test "sweepSharedWaiters unconditionally flips every enrolled .waiting fiber and clears the registry" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = vm.scheduler.?;
-    const f_val = try vm.eval("f");
+    _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = ctx.vm.scheduler.?;
+    const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
     f.status = .waiting;
@@ -188,14 +186,13 @@ test "sweepSharedWaiters unconditionally flips every enrolled .waiting fiber and
 }
 
 test "sweepSharedWaiters does not clobber a fiber no longer .waiting" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = vm.scheduler.?;
-    const f_val = try vm.eval("f");
+    _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = ctx.vm.scheduler.?;
+    const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
     f.status = .waiting;
@@ -212,19 +209,18 @@ test "sweepSharedWaiters does not clobber a fiber no longer .waiting" {
 }
 
 test "hasRunnableFibers reports a shared-waiter-registry entry as alive" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    const ctx = try fiber_mod.ensureScheduler(vm);
-    const sched = ctx.sched;
+    const fctx = try fiber_mod.ensureScheduler(ctx.vm);
+    const sched = fctx.sched;
     // Only the main fiber exists, and it's .running (deliberately not
     // counted -- see hasRunnableFibers' doc comment).
     try std.testing.expect(!sched.hasRunnableFibers());
 
-    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const f_val = try vm.eval("f");
+    _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
     // .waiting with no deadline trips none of the pre-existing categories
     // (created/suspended/waiting-with-deadline/io_waiting) -- isolates the

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -30,6 +30,12 @@ fn testDestroyHook(_: *shared_object.Header) void {
     shared_object_test_destroy_count += 1;
 }
 
+fn nowNsForStressTest() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
 test "shared_object: init/retain/release destroys exactly at zero" {
     const baseline = shared_object.liveCount();
     shared_object_test_destroy_count = 0;
@@ -774,6 +780,82 @@ test "KEP-0002 Phase 2: an exception raised in the child carrying a channel prom
 // so it needs its own counter).
 // ---------------------------------------------------------------------------
 
+test "review regression: two spawned fibers each parked on their own promoted channel do not corrupt each other's result" {
+    // Confirmed VM corruption before this fix (PR #1485 review): drive-
+    // parking a scheduler-dispatched fiber (setting .waiting and continuing
+    // to nest runSchedulerStep in the same native frame) makes its mid-call
+    // snapshot dispatchable by an unrelated fiber's own nested drive loop.
+    // The second fiber woken received the stale callee register
+    // (#<builtin channel-receive>) instead of its real value. Fixed by
+    // always parking a dispatched fiber via the flat yield_retry unwind
+    // (KEP-0002 §4 receive step 8), never a nested drive.
+    const baseline = shared_object.liveCount();
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+
+        const result = try ctx.vm.eval(
+            \\(import (kaappi fibers))
+            \\(define ch1 (make-channel))
+            \\(define ch2 (make-channel))
+            \\(define (make-recv c) (lambda () (channel-receive c)))
+            \\(define f1 (spawn (make-recv ch1)))
+            \\(define f2 (spawn (make-recv ch2)))
+            \\(define (make-send2 a b)
+            \\  (lambda ()
+            \\    (thread-sleep! 0.1) (channel-send a 111)
+            \\    (thread-sleep! 0.1) (channel-send b 222)))
+            \\(thread-join! (thread-start! (make-thread (make-send2 ch1 ch2))))
+            \\(list (fiber-join f1) (fiber-join f2))
+        );
+        try std.testing.expectEqual(@as(i64, 111), types.toFixnum(types.car(result)));
+        try std.testing.expectEqual(@as(i64, 222), types.toFixnum(types.car(types.cdr(result))));
+    }
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+    try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
+}
+
+test "review regression: local sibling send still wakes a receiver after the channel is only transiently promoted" {
+    // Confirmed false-positive deadlock before this fix (PR #1485 review):
+    // channelReceiveShared raised immediately whenever sharedWakeupPossible()
+    // was false, even for a dispatched fiber -- breaking ordinary local
+    // fiber-to-fiber use of a channel the instant it was EVER promoted (even
+    // transiently, by a thread that captured a stub and exited without ever
+    // sending). Fixed: a dispatched fiber always parks unconditionally
+    // (matching blockOrDeadlock's existing behavior for every non-main
+    // fiber); sharedWakeupPossible() only gates the main-fiber's park-vs-
+    // raise decision, where it's load-bearing (self-enrollment defeats
+    // parkOnReactor's own deadlock detection).
+    const baseline = shared_object.liveCount();
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+
+        const result = try ctx.vm.eval(
+            \\(define ch (make-channel))
+            \\(define (probe c) (lambda () (channel? c)))
+            \\;; Transient promotion: a thread captures a stub, does nothing
+            \\;; with the channel, and exits -- refCount() and
+            \\;; crossThreadWaitPossible() both go back to "nothing remote"
+            \\;; afterward, exactly like a purely local channel.
+            \\(thread-join! (thread-start! (make-thread (probe ch))))
+            \\(import (kaappi fibers))
+            \\(define (make-recv c) (lambda () (channel-receive c)))
+            \\(define f (spawn (make-recv ch)))
+            \\(yield)
+            \\(channel-send ch 42)
+            \\(fiber-join f)
+        );
+        try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+    }
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+    try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
+}
+
 test "required regression: park locally -> promote -> remote send wakes (§2 step 4)" {
     const baseline = shared_object.liveCount();
     const notifier_baseline = reactor_mod.notifierLiveCount();
@@ -877,6 +959,7 @@ test "N producers / M consumers stress on the raw SharedChannel/ThreadNotifier p
     const m_consumers = 4;
     const per_producer: usize = if (@import("build_options").gc_stress) 25 else 250;
     const total = n_producers * per_producer;
+    const value_stride: i64 = 1_000_000; // each producer's values live in a disjoint range
 
     const baseline = shared_object.liveCount();
     const notifier_baseline = reactor_mod.notifierLiveCount();
@@ -884,18 +967,31 @@ test "N producers / M consumers stress on the raw SharedChannel/ThreadNotifier p
     const sc = try shared_channel.SharedChannel.create();
 
     var received_count = std.atomic.Value(usize).init(0);
-    var received_sum = std.atomic.Value(i64).init(0);
+    // One flag per (producer_id, offset) pair -- an identity-aware oracle,
+    // not just an aggregate count, so a lost delivery balanced by a
+    // duplicate elsewhere (which a count/sum check alone could miss) is
+    // caught immediately as an out-of-range value or a double-delivery.
+    var delivered: [total]std.atomic.Value(bool) = undefined;
+    for (&delivered) |*d| d.* = std.atomic.Value(bool).init(false);
+    var last_progress_ns = std.atomic.Value(u64).init(nowNsForStressTest());
 
     const Producer = struct {
-        fn run(s: *shared_channel.SharedChannel, count: usize, start_val: i64) void {
+        fn run(s: *shared_channel.SharedChannel, count: usize, producer_id: usize) void {
             var i: usize = 0;
             while (i < count) : (i += 1) {
-                _ = shared_channel.send(s, types.makeFixnum(start_val + @as(i64, @intCast(i))), null) catch unreachable;
+                const val = @as(i64, @intCast(producer_id)) * value_stride + @as(i64, @intCast(i));
+                _ = shared_channel.send(s, types.makeFixnum(val), null) catch unreachable;
             }
         }
     };
     const Consumer = struct {
-        fn run(s: *shared_channel.SharedChannel, target_total: usize, count: *std.atomic.Value(usize), sum: *std.atomic.Value(i64)) void {
+        fn run(
+            s: *shared_channel.SharedChannel,
+            target_total: usize,
+            count: *std.atomic.Value(usize),
+            deliv: []std.atomic.Value(bool),
+            progress_ns: *std.atomic.Value(u64),
+        ) void {
             var local_reactor = reactor_mod.Reactor.init(std.testing.allocator) catch unreachable;
             defer local_reactor.deinit();
             const local_notifier = local_reactor.notifyHandle();
@@ -906,13 +1002,29 @@ test "N producers / M consumers stress on the raw SharedChannel/ThreadNotifier p
                 const outcome = shared_channel.receive(s, &local_gc, local_notifier) catch unreachable;
                 switch (outcome) {
                     .value => |v| {
-                        _ = sum.fetchAdd(types.toFixnum(v), .monotonic);
+                        const val = types.toFixnum(v);
+                        const producer_id: usize = @intCast(@divTrunc(val, value_stride));
+                        const offset: usize = @intCast(@mod(val, value_stride));
+                        const index = producer_id * per_producer + offset;
+                        if (offset >= per_producer or index >= deliv.len)
+                            std.debug.panic("delivered value {d} decodes outside the expected range", .{val});
+                        if (deliv[index].swap(true, .monotonic))
+                            std.debug.panic("duplicate delivery of value {d}", .{val});
+                        progress_ns.store(nowNsForStressTest(), .monotonic);
                         _ = count.fetchAdd(1, .monotonic);
                     },
                     // White-box stress of SharedChannel/ThreadNotifier
                     // themselves, not the fiber-scheduler integration --
                     // busy-poll on a miss instead of a real scheduler park.
-                    .would_park => std.Thread.yield() catch {},
+                    .would_park => {
+                        // A lost message would otherwise spin every consumer
+                        // forever with no way to notice -- fail loudly
+                        // instead once no delivery has landed anywhere for
+                        // too long.
+                        if (nowNsForStressTest() -| progress_ns.load(.monotonic) > 10 * std.time.ns_per_s)
+                            std.debug.panic("no delivery progress for 10s -- likely a lost wakeup", .{});
+                        std.Thread.yield() catch {};
+                    },
                     .eof => unreachable,
                 }
             }
@@ -921,25 +1033,21 @@ test "N producers / M consumers stress on the raw SharedChannel/ThreadNotifier p
 
     var producers: [n_producers]std.Thread = undefined;
     for (0..n_producers) |i| {
-        producers[i] = try std.Thread.spawn(.{}, Producer.run, .{ sc, per_producer, @as(i64, @intCast(i * 1_000_000)) });
+        producers[i] = try std.Thread.spawn(.{}, Producer.run, .{ sc, per_producer, i });
     }
     var consumers: [m_consumers]std.Thread = undefined;
     for (0..m_consumers) |i| {
-        consumers[i] = try std.Thread.spawn(.{}, Consumer.run, .{ sc, total, &received_count, &received_sum });
+        consumers[i] = try std.Thread.spawn(.{}, Consumer.run, .{ sc, total, &received_count, delivered[0..total], &last_progress_ns });
     }
     for (producers) |p| p.join();
     for (consumers) |c| c.join();
 
+    // Every delivery was checked in-place (range + duplicate) as it
+    // happened; exactly `total` non-duplicate deliveries out of exactly
+    // `total` possible (producer_id, offset) slots is a bijection, so this
+    // final count confirms full, exact-once coverage without a separate
+    // scan over `delivered`.
     try std.testing.expectEqual(total, received_count.load(.monotonic));
-
-    var expected_sum: i64 = 0;
-    for (0..n_producers) |i| {
-        var j: usize = 0;
-        while (j < per_producer) : (j += 1) {
-            expected_sum += @as(i64, @intCast(i * 1_000_000)) + @as(i64, @intCast(j));
-        }
-    }
-    try std.testing.expectEqual(expected_sum, received_sum.load(.monotonic));
 
     sc.release();
     try std.testing.expectEqual(baseline, shared_object.liveCount());

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
 const shared_object = @import("shared_object.zig");
+const reactor_mod = @import("reactor.zig");
 const th = @import("testing_helpers.zig");
 
 // KEP-0002 Phase 1 (#1466). Everything here follows tests_deepcopy.zig's
@@ -386,11 +387,20 @@ test "send: bounded-and-full channel registers a send waiter and would park" {
     const sc = try shared_channel.SharedChannel.create();
     sc.capacity = 0;
 
-    var notifier = shared_channel.ThreadNotifier{};
-    const outcome = try shared_channel.send(sc, types.makeFixnum(1), &notifier);
+    // A real Reactor-backed notifier, not a bare struct literal: releasing
+    // the last registration ref now runs releaseNotifier's real
+    // close-backend-and-free teardown (KEP-0002 Phase 3), which requires a
+    // notifier actually allocated via std.heap.c_allocator (as Reactor.init
+    // does) rather than a stack local.
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const notifier = reactor.notifyHandle();
+
+    const outcome = try shared_channel.send(sc, types.makeFixnum(1), notifier);
     try std.testing.expectEqual(shared_channel.SendOutcome.would_park, outcome);
     try std.testing.expectEqual(@as(usize, 1), sc.send_waiters.items.len);
-    try std.testing.expectEqual(@as(u32, 1), notifier.refcount.load(.monotonic));
+    // 1 (Reactor's own base ref) + 1 (this registration).
+    try std.testing.expectEqual(@as(u32, 2), notifier.refcount.load(.monotonic));
 
     sc.release();
 }
@@ -398,13 +408,15 @@ test "send: bounded-and-full channel registers a send waiter and would park" {
 test "send: registering the same waiter twice does not double the refcount (§7 dedup)" {
     const sc = try shared_channel.SharedChannel.create();
     sc.capacity = 0;
-    var notifier = shared_channel.ThreadNotifier{};
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const notifier = reactor.notifyHandle();
 
-    _ = try shared_channel.send(sc, types.makeFixnum(1), &notifier);
-    _ = try shared_channel.send(sc, types.makeFixnum(2), &notifier);
+    _ = try shared_channel.send(sc, types.makeFixnum(1), notifier);
+    _ = try shared_channel.send(sc, types.makeFixnum(2), notifier);
 
     try std.testing.expectEqual(@as(usize, 1), sc.send_waiters.items.len);
-    try std.testing.expectEqual(@as(u32, 1), notifier.refcount.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 2), notifier.refcount.load(.monotonic));
 
     sc.release();
 }
@@ -494,12 +506,14 @@ test "receive: empty and open registers a recv waiter and would park" {
 
     var dest_gc = memory.GC.init(std.testing.allocator);
     defer dest_gc.deinit();
-    var notifier = shared_channel.ThreadNotifier{};
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const notifier = reactor.notifyHandle();
 
-    const outcome = try shared_channel.receive(sc, &dest_gc, &notifier);
+    const outcome = try shared_channel.receive(sc, &dest_gc, notifier);
     try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, outcome);
     try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
-    try std.testing.expectEqual(@as(u32, 1), notifier.refcount.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 2), notifier.refcount.load(.monotonic));
 
     sc.release();
 }
@@ -743,4 +757,225 @@ test "KEP-0002 Phase 2: an exception raised in the child carrying a channel prom
         try std.testing.expectEqualStrings("irritant-marker", types.symbolName(drained));
     }
     try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+// ---------------------------------------------------------------------------
+// KEP-0002 Phase 3 (#1468): cross-thread wakeup. ThreadNotifier, the
+// per-scheduler shared-waiter registry and its unconditional sweep, §2 step
+// 4 local-waiter migration, and channel-receive's real park+retry replacing
+// Phase 1's @panic on `.would_park` -- a real, already-reachable SIGABRT
+// before this fix (verified by hand against a pre-fix build: a channel
+// captured in a thread-start! thunk promotes on both sides, and either side
+// calling channel-receive on the still-empty channel before the other sends
+// crashed the process). Every test here also asserts
+// reactor_mod.notifierLiveCount() returns to baseline, alongside
+// shared_object.liveCount() -- the notifier leak-check counterpart Phase 3
+// adds (ThreadNotifier is deliberately not a shared_object.Header instance,
+// so it needs its own counter).
+// ---------------------------------------------------------------------------
+
+test "required regression: park locally -> promote -> remote send wakes (§2 step 4)" {
+    const baseline = shared_object.liveCount();
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+
+        // f parks on ch while ch is still local/unpromoted (no remote
+        // thread has touched it yet); thread-start! then promotes ch as
+        // part of building its thunk's envelope, which must migrate f into
+        // the shared-waiter registry -- without that, f would hang forever
+        // (a local channel-send is never called again on this channel; only
+        // the remote thread's channel-send runs, which rings only
+        // *registered* notifiers).
+        //
+        // `ch` is threaded through as an explicit parameter to make-recv/
+        // make-send, not referenced directly by a lambda closing over a
+        // top-level `define`: a lambda body referencing a top-level define
+        // compiles to a global-name lookup, not a closure upvalue, so
+        // thread-start!'s envelope build would never touch (or promote) it
+        // at all. Passing it as a parameter forces genuine capture.
+        const result = try ctx.vm.eval(
+            \\(import (kaappi fibers))
+            \\(define ch (make-channel))
+            \\(define (make-recv c) (lambda () (channel-receive c)))
+            \\(define (make-send c v) (lambda () (channel-send c v)))
+            \\(define f (spawn (make-recv ch)))
+            \\(yield) ; let f run and park LOCALLY on ch
+            \\(thread-join! (thread-start! (make-thread (make-send ch 42))))
+            \\(fiber-join f)
+        );
+        try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+    }
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+    try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
+}
+
+test "required regression: a rung receiver that loses the pop race re-parks and re-registers (§5 model finding 1)" {
+    const baseline = shared_object.liveCount();
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+
+    const sc = try shared_channel.SharedChannel.create();
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    const notifier = reactor.notifyHandle();
+
+    var dest_gc_a = memory.GC.init(std.testing.allocator);
+
+    // Receiver A finds the queue empty and registers.
+    const outcome1 = try shared_channel.receive(sc, &dest_gc_a, notifier);
+    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, outcome1);
+    try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
+
+    // A value arrives -- send()'s ring() rings (and releases) A's
+    // registration exactly like a real cross-thread notify would.
+    _ = try shared_channel.send(sc, types.makeFixnum(7), null);
+    try std.testing.expectEqual(@as(usize, 0), sc.recv_waiters.items.len);
+
+    // A faster receiver -- modeled as a second, bare receive() call, standing
+    // in for a different thread that won the retry race -- pops the value
+    // first. This is exactly what "loses the pop race" means: A was rung,
+    // but by the time it gets to retry, nothing is left.
+    var dest_gc_fast = memory.GC.init(std.testing.allocator);
+    const fast_outcome = try shared_channel.receive(sc, &dest_gc_fast, null);
+    const fast_value = switch (fast_outcome) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(fast_value));
+
+    // A retries -- exactly what channelReceiveShared's loop does after
+    // runSchedulerStep returns: the queue is empty again, so it must
+    // re-register, not treat "I was woken" as "a value is waiting for me".
+    const outcome2 = try shared_channel.receive(sc, &dest_gc_a, notifier);
+    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, outcome2);
+    try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
+
+    // A subsequent send correctly wakes A again -- no lost wakeup.
+    _ = try shared_channel.send(sc, types.makeFixnum(9), null);
+    const outcome3 = try shared_channel.receive(sc, &dest_gc_a, notifier);
+    const final_value = switch (outcome3) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(i64, 9), types.toFixnum(final_value));
+
+    dest_gc_fast.deinit();
+    dest_gc_a.deinit();
+    sc.release();
+    // reactor.deinit() releases the notifier's own base ref -- must run
+    // before the leak-count checks below, not as a function-scope `defer`
+    // (which would only fire after this test function itself returns, i.e.
+    // after these assertions already ran).
+    reactor.deinit();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+    try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
+}
+
+test "N producers / M consumers stress on the raw SharedChannel/ThreadNotifier primitives: no lost or duplicated deliveries, no leaks" {
+    const n_producers = 4;
+    const m_consumers = 4;
+    const per_producer: usize = if (@import("build_options").gc_stress) 25 else 250;
+    const total = n_producers * per_producer;
+
+    const baseline = shared_object.liveCount();
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+
+    const sc = try shared_channel.SharedChannel.create();
+
+    var received_count = std.atomic.Value(usize).init(0);
+    var received_sum = std.atomic.Value(i64).init(0);
+
+    const Producer = struct {
+        fn run(s: *shared_channel.SharedChannel, count: usize, start_val: i64) void {
+            var i: usize = 0;
+            while (i < count) : (i += 1) {
+                _ = shared_channel.send(s, types.makeFixnum(start_val + @as(i64, @intCast(i))), null) catch unreachable;
+            }
+        }
+    };
+    const Consumer = struct {
+        fn run(s: *shared_channel.SharedChannel, target_total: usize, count: *std.atomic.Value(usize), sum: *std.atomic.Value(i64)) void {
+            var local_reactor = reactor_mod.Reactor.init(std.testing.allocator) catch unreachable;
+            defer local_reactor.deinit();
+            const local_notifier = local_reactor.notifyHandle();
+            var local_gc = memory.GC.init(std.testing.allocator);
+            defer local_gc.deinit();
+
+            while (count.load(.monotonic) < target_total) {
+                const outcome = shared_channel.receive(s, &local_gc, local_notifier) catch unreachable;
+                switch (outcome) {
+                    .value => |v| {
+                        _ = sum.fetchAdd(types.toFixnum(v), .monotonic);
+                        _ = count.fetchAdd(1, .monotonic);
+                    },
+                    // White-box stress of SharedChannel/ThreadNotifier
+                    // themselves, not the fiber-scheduler integration --
+                    // busy-poll on a miss instead of a real scheduler park.
+                    .would_park => std.Thread.yield() catch {},
+                    .eof => unreachable,
+                }
+            }
+        }
+    };
+
+    var producers: [n_producers]std.Thread = undefined;
+    for (0..n_producers) |i| {
+        producers[i] = try std.Thread.spawn(.{}, Producer.run, .{ sc, per_producer, @as(i64, @intCast(i * 1_000_000)) });
+    }
+    var consumers: [m_consumers]std.Thread = undefined;
+    for (0..m_consumers) |i| {
+        consumers[i] = try std.Thread.spawn(.{}, Consumer.run, .{ sc, total, &received_count, &received_sum });
+    }
+    for (producers) |p| p.join();
+    for (consumers) |c| c.join();
+
+    try std.testing.expectEqual(total, received_count.load(.monotonic));
+
+    var expected_sum: i64 = 0;
+    for (0..n_producers) |i| {
+        var j: usize = 0;
+        while (j < per_producer) : (j += 1) {
+            expected_sum += @as(i64, @intCast(i * 1_000_000)) + @as(i64, @intCast(j));
+        }
+    }
+    try std.testing.expectEqual(expected_sum, received_sum.load(.monotonic));
+
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+    try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
+}
+
+test "KEP-0002 Phase 3 (#1468): main thread receives values sent concurrently by several real OS threads" {
+    const baseline = shared_object.liveCount();
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+
+        // Each thread-start! promotes ch (idempotently, aliasing after the
+        // first); each channel-send from a real OS thread rings the main
+        // thread's notifier; the main fiber's channelReceiveShared loop
+        // parks and retries across however many of the three sends haven't
+        // landed yet when it first calls receive(). `make-sender` takes `ch`
+        // as an explicit parameter -- see the migration test's comment above
+        // for why a lambda closing directly over a top-level define would
+        // never actually capture (and thus never promote) it.
+        const result = try ctx.vm.eval(
+            \\(define ch (make-channel))
+            \\(define (make-sender c n) (lambda () (channel-send c n)))
+            \\(define threads (list (make-thread (make-sender ch 1))
+            \\                      (make-thread (make-sender ch 2))
+            \\                      (make-thread (make-sender ch 3))))
+            \\(for-each thread-start! threads)
+            \\(let loop ((i 0) (acc 0))
+            \\  (if (= i 3)
+            \\      (begin (for-each thread-join! threads) acc)
+            \\      (loop (+ i 1) (+ acc (channel-receive ch)))))
+        );
+        try std.testing.expectEqual(@as(i64, 6), types.toFixnum(result));
+    }
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+    try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
 }


### PR DESCRIPTION
## Summary

Implements KEP-0002 Phase 3 (#1468): the reactor-backed cross-thread wakeup that Phases 1/2 (#1482/#1483) left as an unwired `@panic`.

**This closes a real, already-reachable crash**, not just a missing feature: a channel captured as a true lexical closure upvalue in a `thread-start!` thunk promotes in place on *both* sides (parent and child, since promotion mutates the shared heap object). Either side calling `channel-receive` on the still-empty promoted channel before the other sends hits Phase 1's placeholder `@panic` and SIGABRTs the process. I verified this against a pre-fix build before writing any code.

- **`src/reactor.zig`**: `ThreadNotifier` (kqueue `EVFILT.USER` / epoll `eventfd` / WASI no-op), one per `Reactor`. Base refcount owned by the creating `Reactor`; registrations are additive on top. Kernel-resource closing is concentrated entirely in `releaseNotifier`'s zero-transition (not split with backend `deinit`), since kqueue's notifier knote shares `kq` with ordinary fd polling — splitting it would risk a double-close race on whichever release happens last. `wait()`'s event loop filters the notifier's own event out of the ordinary `ReadyEvent` stream on both backends. New `notifierLiveCount()` leak-check counterpart to `shared_object.liveCount()` (`ThreadNotifier` is deliberately not a `shared_object.Header` instance).
- **`src/fiber.zig`**: the per-scheduler shared-waiter registry and its **unconditional** sweep — a readiness-filtered sweep is the exact model-checked lost-wakeup from kaappi/keps#12 ("finding 1"), not a style choice. The `wake_pending` consume-protocol swap-loop is wired into both `schedule()` (every tick) and `parkOnReactor()` (before blocking and again after `poll()` returns, since a notify arriving mid-block is what interrupted it). `hasRunnableFibers()` extended so the deadlock check doesn't fire while a fiber still has a live cross-thread wakeup path.
- **`src/shared_channel.zig`**: `ring()` now actually calls `.notify()`; §7 opportunistic dead-notifier pruning folded into the existing `register*Waiter` dedup walk; `promoteChannel` gains §2 step 4's local-waiter migration.
- **`src/primitives_fiber.zig`**: `channelReceiveFn`'s shared-path `@panic` replaced with `channelReceiveShared` — always calls `shared_channel.receive()` first each loop iteration (registration is a side effect of `.would_park`) and only then parks, never the other way around; parking before registering would leave nothing to ever ring the fiber awake. This ordering also directly implements the required "a rung receiver that loses the pop race re-parks, re-registers" regression.
- **`src/pct_stress.zig` + `src/stress_channel.zig`** (new) + `zig build stress-channel`: PCT-style randomized yield injection, off by default. Confirmed effective by deliberately reintroducing the "finding 1" bug and verifying both the harness and the deterministic unit test catch it, then reverting.

**Deferred to a follow-up** (documented, not silently dropped): UQ3 (`thread-join!`'s 1ms poll → notifier) needs a structurally distinct registration relationship from `SharedChannel`'s, and isn't "cheap" per the KEP's own bar for in-scope-now work.

## Test plan

- [x] Required regressions, as automated tests: "park locally → promote → remote send wakes" (§2 step 4); "a rung receiver that loses the pop race re-parks and re-registers" (§5, model finding 1)
- [x] `zig build test` and `zig build test -Dgc-stress=true` — full suite green (832 tests; 824 pass + 6 scaled-down skips under gc-stress)
- [x] `bash tests/scheme/run-all.sh` — 1835/0
- [x] `zig build stress-channel` across multiple seeds and heavier producer/consumer/message-count configurations — all pass
- [x] `zig build wasm` still compiles (WASI notifier backend is a no-op)
- [x] `zig fmt --check` clean
- [x] Re-ran kaappi#1455's mutex/condvar suite as part of the full test suite — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)