### PR TITLE
Address PR #1485 review nits: stale comment, timed_out hoist, peer-death doc

### DIFF
--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -186,6 +186,18 @@ const SharedChannelPoll = struct {
 /// its own stub, per §1), or some other OS thread is alive at all. Reuses
 /// primitives_srfi18.zig's existing crossThreadWaitPossible rather than
 /// duplicating its live-thread-count logic.
+///
+/// Accepted liveness gap, KEP-0002 §5: this is checked once, right before
+/// parking -- not re-evaluated while parked. If the peer that made this
+/// return `true` (the only other stub holder, or the only other live
+/// thread) exits afterward without ever sending, the parked receiver hangs
+/// forever: a stub's release doesn't ring anything, and the parked fiber
+/// staying enrolled in the shared-waiter registry keeps hasRunnableFibers()
+/// true, so the deadlock detector never fires either. This is the same
+/// Go-style "send on a channel nobody will ever receive from" hang as an
+/// unbuffered channel with no reader; §5 accepts it deliberately, and §6's
+/// planned `(channel-receive ch [timeout [timeout-val]])` (Phase 4, not yet
+/// implemented) is the intended escape hatch.
 fn sharedWakeupPossible(sc: *shared_channel.SharedChannel) bool {
     return sc.refCount() > 1 or srfi18.crossThreadWaitPossible();
 }
@@ -274,6 +286,13 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
 
         // Drive local siblings once. `me` stays .running -- see
         // SharedChannelPoll's doc comment for why that's load-bearing.
+        // Reset first: runSchedulerStep's generic loop bails whenever
+        // `me.timed_out` is true, regardless of Ctx, so a stale flag left
+        // by an unrelated earlier timed wait would silently skip this
+        // drive entirely and let the park decision below run with the
+        // world still active -- quiescence-before-park is what makes that
+        // decision safe.
+        me.timed_out = false;
         _ = try fiber_mod.runSchedulerStep(SharedChannelPoll, .{ .sc = sc }, ctx.vm, ctx.sched, me);
         if (sc.peekReady()) continue; // loop back to 1: re-derive via receive()
 
@@ -296,7 +315,10 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         me.status = .waiting;
         me.waiting_on = ch_val;
         vm.gc.writeBarrier(&me.header, ch_val);
-        me.timed_out = false; // defensive: stale flag from an unrelated earlier timed wait
+        // Already reset above, before the SharedChannelPoll drive -- nothing
+        // between there and here can set it true again (`me` stays .running
+        // for that whole drive, and wakeReadyFiber only flips `.waiting`
+        // fibers).
         ctx.sched.enrollSharedWaiter(me) catch |err| {
             me.status = .running;
             me.waiting_on = types.VOID;

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -337,12 +337,17 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
             for (sched.fibers.items) |maybe_f| {
                 const f = maybe_f orelse continue;
                 if (f.status == .waiting and f.waiting_on == ch_val) {
-                    // Propagate, don't swallow: registerRecvWaiter above
-                    // (once hoisted) already succeeded or @panic'd on OOM,
-                    // so a remote send WILL ring this thread's notifier --
-                    // silently dropping this fiber's enrollment here would
-                    // leave it .waiting with nothing left to ever flip it
-                    // back, a permanent hang.
+                    // Propagate, don't swallow: registerRecvWaiter runs
+                    // once, after this loop finishes (not before it), so on
+                    // an enrollSharedWaiter OOM mid-loop no notifier is ever
+                    // registered for `sc`. Fibers already enrolled by prior
+                    // iterations become stale-but-harmless registry entries
+                    // -- any future sweep on this scheduler flips them
+                    // regardless of channel, and their retry re-registers
+                    // per §4 -- while fibers not yet reached stay `.waiting`
+                    // with no path left to wake them. Both are OOM-only
+                    // corners of an already-failing promotion; accepted
+                    // rather than un-enrolling on this error path.
                     try sched.enrollSharedWaiter(f);
                     migrated_any = true;
                 }


### PR DESCRIPTION
## Summary

Closes out the three non-blocking items carried over from the final review round of PR #1485 (KEP-0002 Phase 3, #1468), which was merged without acting on them.

- `promoteChannel`'s migration-loop comment claimed `registerRecvWaiter` ran "above" the loop; it actually runs once, after it. Corrected the comment, and documented the OOM-mid-loop corner this creates: fibers enrolled by earlier iterations become stale-but-self-healing registry entries (any future sweep on the scheduler flips them regardless of channel, and their retry re-registers), while fibers not yet reached stay `.waiting` with no path left to wake them. Both are OOM-only corners of an already-failing promotion — accepted rather than un-enrolling on that error path, per the reviewer's own framing of this as optional.
- `channelReceiveShared` reset `me.timed_out` *after* the `SharedChannelPoll` local-sibling drive instead of before it. `runSchedulerStep`'s generic loop bails whenever `me.timed_out` is true regardless of `Ctx`, so a stale flag left by an unrelated earlier timed wait could silently skip the drive and let the park decision run with the world still active. Hoisted the reset above the drive (verified nothing between the new reset point and the old one can set it true again, since `me` stays `.running` for the whole drive and `wakeReadyFiber` only touches `.waiting` fibers).
- Documented the KEP-0002 §5 accepted liveness gap on `sharedWakeupPossible`: a receiver parked after this returns `true` hangs forever if the peer (the only other stub holder, or the only other live thread) exits without ever sending — a stub release rings nothing, and the parked fiber's own shared-waiter registry entry keeps `hasRunnableFibers()` true, so the deadlock detector never fires either. This is the same Go-style hang as an unbuffered channel with no reader; §5 accepts it deliberately, and §6's planned per-call timeout (`(channel-receive ch [timeout [timeout-val]])`, Phase 4) is the intended escape hatch.

No functional/API change — comments plus a defensive ordering fix for a currently-unreached path.

## Test plan

- [x] `zig build test` — unit suite green
- [x] `zig build` — clean build
- [x] `bash tests/scheme/run-all.sh` — 1835 pass, 0 fail (440 Scheme files + 1395 R7RS)
- [x] `zig build stress-channel -- 424242 8 8 500` — PASS
- [x] `zig fmt --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)