### PR TITLE
KEP-0002 Phase 4: capacity, timeouts, close for cross-thread channels

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -876,6 +876,23 @@ pub const GC = struct {
         return types.makePointer(@ptrCast(ch));
     }
 
+    /// KEP-0002 §6: a bounded channel, `(make-channel capacity)`. Separate
+    /// from allocChannel (rather than an optional parameter) so the
+    /// pre-Phase-4 call sites that construct an unbounded channel need no
+    /// changes.
+    pub fn allocChannelBounded(self: *GC, capacity: u32) !Value {
+        try self.maybeCollect();
+        const ch = try self.allocator.create(types.Channel);
+        ch.* = .{
+            .header = .{ .tag = .channel },
+            .head = types.NIL,
+            .tail = types.NIL,
+            .capacity = capacity,
+        };
+        self.finishAlloc(&ch.header, @sizeOf(types.Channel));
+        return types.makePointer(@ptrCast(ch));
+    }
+
     /// A promoted-channel stub: a new counted reference to an existing
     /// SharedChannel (KEP-0002 §2), allocated on this heap by deepCopy's
     /// `.channel` alias arm. `shared` isn't a Value, so there's nothing to

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -371,6 +371,30 @@ fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: 
             .would_park => {},
         }
 
+        // A prior loop iteration may have parked, armed a timer, and then
+        // woken *spuriously* -- sweepSharedWaiters (fiber.zig) flips a
+        // .waiting fiber to .suspended unconditionally on any notify, with
+        // no notion of "was this really my event", and does not touch
+        // deadline_ns or cancel the reactor timer. Left armed, that timer
+        // is still live while the drive below runs with `me` .running --
+        // and wakeReadyFiber only ever sets `timed_out` for a .waiting (or
+        // io_waiting) fiber, so a fiber pop while `me` is .running is
+        // silently dropped (schedule()'s per-tick popExpiredTimers, or
+        // parkOnReactor's own poll, both call wakeReadyFiber the same way),
+        // permanently losing the timeout for the rest of this wait.
+        //
+        // Detach it from the *reactor's* heap only -- `me.deadline_ns`
+        // itself is deliberately left set, as the sole authoritative record
+        // of the original absolute deadline. The park step below always
+        // re-adds a timer if it doesn't resolve things, preferring this
+        // preserved value over a freshly re-parsed `deadline_ns` argument
+        // (`me.deadline_ns orelse deadline_ns`) -- clearing the field here
+        // instead would make every re-arm fall through to `deadline_ns`,
+        // which is recomputed as "now + relative seconds" on every fresh
+        // native call (see channelSendFn), silently extending the timeout
+        // on every spurious wake instead of honoring the original one.
+        if (me.deadline_ns != null) ctx.reactor.removeTimer(me);
+
         // Drive local siblings once. See SharedChannelPoll's doc comment
         // (channelReceiveShared) for why `me` must stay .running throughout.
         me.timed_out = false;
@@ -381,11 +405,9 @@ fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: 
             me.status = .waiting;
             me.waiting_on = ch_val;
             vm.gc.writeBarrier(&me.header, ch_val);
-            if (me.deadline_ns == null) {
-                if (deadline_ns) |d| {
-                    me.deadline_ns = d;
-                    try ctx.reactor.addTimer(d, me);
-                }
+            if (me.deadline_ns orelse deadline_ns) |d| {
+                me.deadline_ns = d;
+                try ctx.reactor.addTimer(d, me);
             }
             ctx.sched.enrollSharedWaiter(me) catch |err| {
                 me.status = .running;
@@ -402,11 +424,9 @@ fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: 
         me.status = .waiting;
         me.waiting_on = ch_val;
         vm.gc.writeBarrier(&me.header, ch_val);
-        if (me.deadline_ns == null) {
-            if (deadline_ns) |d| {
-                me.deadline_ns = d;
-                try ctx.reactor.addTimer(d, me);
-            }
+        if (me.deadline_ns orelse deadline_ns) |d| {
+            me.deadline_ns = d;
+            try ctx.reactor.addTimer(d, me);
         }
         ctx.sched.enrollSharedWaiter(me) catch |err| {
             me.status = .running;
@@ -534,6 +554,17 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             .would_park => {},
         }
 
+        // A prior loop iteration may have parked, armed a timer, and then
+        // woken *spuriously* -- see channelSendShared's matching comment for
+        // the full reasoning. Detach any still-live timer from the
+        // *reactor's* heap only (never `me.deadline_ns` itself, which stays
+        // the authoritative record of the original absolute deadline) so a
+        // pop while this drive runs with `me` .running can't be silently
+        // dropped by wakeReadyFiber -- and the park step below can still
+        // re-arm using the preserved value instead of a freshly re-parsed
+        // (and wrongly extended) `deadline_ns` argument.
+        if (me.deadline_ns != null) ctx.reactor.removeTimer(me);
+
         // Drive local siblings once. `me` stays .running -- see
         // SharedChannelPoll's doc comment for why that's load-bearing.
         // Reset first: runSchedulerStep's generic loop bails whenever
@@ -550,11 +581,9 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             me.status = .waiting;
             me.waiting_on = ch_val;
             vm.gc.writeBarrier(&me.header, ch_val);
-            if (me.deadline_ns == null) {
-                if (deadline_ns) |d| {
-                    me.deadline_ns = d;
-                    try ctx.reactor.addTimer(d, me);
-                }
+            if (me.deadline_ns orelse deadline_ns) |d| {
+                me.deadline_ns = d;
+                try ctx.reactor.addTimer(d, me);
             }
             ctx.sched.enrollSharedWaiter(me) catch |err| {
                 me.status = .running;
@@ -575,11 +604,9 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         // between there and here can set it true again (`me` stays .running
         // for that whole drive, and wakeReadyFiber only flips `.waiting`
         // fibers).
-        if (me.deadline_ns == null) {
-            if (deadline_ns) |d| {
-                me.deadline_ns = d;
-                try ctx.reactor.addTimer(d, me);
-            }
+        if (me.deadline_ns orelse deadline_ns) |d| {
+            me.deadline_ns = d;
+            try ctx.reactor.addTimer(d, me);
         }
         ctx.sched.enrollSharedWaiter(me) catch |err| {
             me.status = .running;

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -16,10 +16,15 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "yield", .func = &yieldFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
     .{ .name = "fiber-join", .func = &fiberJoinFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
     .{ .name = "fiber?", .func = &fiberPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
-    .{ .name = "make-channel", .func = &makeChannelFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
-    .{ .name = "channel-send", .func = &channelSendFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.kaappi_fibers) },
-    .{ .name = "channel-receive", .func = &channelReceiveFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
+    // KEP-0002 §6 (#1469): optional capacity, [timeout [timeout-val]] on
+    // both send/receive, close!/closed?.
+    .{ .name = "make-channel", .func = &makeChannelFn, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "channel-send", .func = &channelSendFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "channel-receive", .func = &channelReceiveFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.kaappi_fibers) },
     .{ .name = "channel?", .func = &channelPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "channel-close!", .func = &channelCloseFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "channel-closed?", .func = &channelClosedFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "channel-timeout-exception?", .func = &channelTimeoutPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
 };
 
 fn getScheduler() ?*fiber_mod.FiberScheduler {
@@ -95,9 +100,16 @@ fn fiberPredFn(args: []const Value) PrimitiveError!Value {
     return if (types.isFiber(args[0])) types.TRUE else types.FALSE;
 }
 
-fn makeChannelFn(_: []const Value) PrimitiveError!Value {
+fn makeChannelFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    return gc.allocChannel() catch return PrimitiveError.OutOfMemory;
+    if (args.len == 0) return gc.allocChannel() catch return PrimitiveError.OutOfMemory;
+
+    if (!types.isFixnum(args[0])) return primitives.typeError("make-channel", "non-negative exact integer", args[0]);
+    const fx = types.toFixnum(args[0]);
+    if (fx < 0 or fx > std.math.maxInt(u32))
+        return primitives.typeError("make-channel", "non-negative exact integer", args[0]);
+    const capacity: u32 = @intCast(fx);
+    return gc.allocChannelBounded(capacity) catch return PrimitiveError.OutOfMemory;
 }
 
 fn channelSendFn(args: []const Value) PrimitiveError!Value {
@@ -114,26 +126,38 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
         return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
     const ch = ch_obj.as(types.Channel);
 
-    if (ch.shared) |raw| {
-        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
-        const outcome = shared_channel.send(sc, args[1], null) catch |err| {
-            return translateSharedChannelError(err, "channel-send");
-        };
-        return switch (outcome) {
-            .sent => types.VOID,
-            // Channels are still always unbounded and open -- no
-            // Scheme-level API sets capacity or closed yet (KEP-0002
-            // Phase 4) -- so these branches remain unreachable through
-            // make-channel's output even after Phase 3 (#1468) wires up
-            // channel-receive's own .would_park branch below. @panic (not
-            // `unreachable`, which is UB under ReleaseFast) so a Phase 4
-            // gap that forgets to wire this switch fails loudly in every
-            // build mode instead of silently corrupting execution.
-            .would_park, .closed => @panic("channel-send: reached a shared-channel branch Phase 4 doesn't wire up yet (capacity/close)"),
-        };
+    // KEP-0002 §6: the one backward-compat carve-out. Checked before any
+    // dispatch (both representations, no lock): a *sent* eof-object would
+    // be indistinguishable from channel-close!'s end-of-stream at the
+    // receiver.
+    if (args[1] == types.EOF)
+        return raiseFiberError("channel-send: cannot send an eof-object on a channel; use channel-close! to end the stream");
+
+    var deadline_ns: ?u64 = null;
+    var has_timeout_val = false;
+    var timeout_val: Value = types.VOID;
+    if (args.len > 2) {
+        deadline_ns = try srfi18.timeoutToDeadlineNs(args[2]);
+        if (args.len > 3) {
+            has_timeout_val = true;
+            timeout_val = args[3];
+        }
     }
 
-    const new_pair = gc.allocPair(args[1], types.NIL) catch return PrimitiveError.OutOfMemory;
+    if (ch.shared) |raw| {
+        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
+        return channelSendShared(sc, args[1], args[0], deadline_ns, has_timeout_val, timeout_val);
+    }
+
+    return channelSendLocal(ch, args[0], args[1], deadline_ns, has_timeout_val, timeout_val);
+}
+
+/// KEP-0002 §6: appends `payload` to the local (unpromoted) queue. Split out
+/// of channelSendLocal so both the immediate fast path and the post-park
+/// retry share one enqueue implementation.
+fn enqueueChannel(gc: *memory.GC, ch: *types.Channel, ch_val: Value, payload: Value) PrimitiveError!void {
+    const new_pair = gc.allocPair(payload, types.NIL) catch return PrimitiveError.OutOfMemory;
+    const ch_obj = types.toObject(ch_val);
 
     if (ch.tail != types.NIL and types.isPair(ch.tail)) {
         const tail_obj = types.toObject(ch.tail);
@@ -146,10 +170,89 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
         ch.head = new_pair;
         gc.writeBarrier(ch_obj, new_pair);
     }
+    ch.queue_len += 1;
     if (vm_mod.vm_instance) |vm| {
-        if (vm.scheduler) |sched| sched.wakeChannelWaiters(args[0]);
+        if (vm.scheduler) |sched| sched.wakeChannelWaiters(ch_val);
     }
-    return types.VOID;
+}
+
+/// A fiber parked waiting for room on a *local* bounded channel (KEP-0002
+/// §6). Mirrors ChannelWait's shape exactly; isDone is satisfied by either
+/// a freed slot or the channel becoming closed (channel-close! wakes both
+/// waiter roles via the same wakeChannelWaiters call).
+const ChannelSendWait = struct {
+    ch: *types.Channel,
+    pub fn isDone(self: ChannelSendWait) bool {
+        return self.ch.closed or self.ch.capacity == null or self.ch.queue_len < self.ch.capacity.?;
+    }
+};
+
+/// KEP-0002 §6 send, local (unpromoted) representation. No reservation
+/// concept is needed here (unlike the shared path): cooperative scheduling
+/// means nothing can run between the admission check and the enqueue, so
+/// the check-then-act sequence is already atomic with respect to every
+/// other fiber.
+fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_ns: ?u64, has_timeout_val: bool, timeout_val: Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+
+    // Admission order matches §4 step 2 then step 3: closed is checked
+    // before capacity, unconditionally, no scheduler touch needed.
+    if (ch.closed) return raiseFiberError("channel-send: send on closed channel");
+
+    const cap = ch.capacity orelse {
+        try enqueueChannel(gc, ch, ch_val, payload);
+        return types.VOID;
+    };
+    if (ch.queue_len < cap) {
+        try enqueueChannel(gc, ch, ch_val, payload);
+        return types.VOID;
+    }
+
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    // See channelReceiveFn's matching check: a timeout resolves this wait
+    // via the reactor timer alone, so "no fibers exist" is only a genuine
+    // deadlock when there is also no deadline to bound the wait.
+    if (vm.scheduler == null and deadline_ns == null) {
+        return raiseFiberError("channel-send: deadlock — channel is full and no fibers are running");
+    }
+
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    const my_idx = ctx.sched.current_idx;
+    const me = ctx.sched.fibers.items[my_idx].?;
+
+    // A local channel wait always resolves within this one call:
+    // runSchedulerStep drives siblings and, if nothing else is runnable,
+    // blocks in parkOnReactor -- which never mis-detects deadlock while
+    // `me`'s own timer is pending (reactor.isEmpty() is false whenever the
+    // timer heap is non-empty). No redispatch/yield-retry guard is needed
+    // here the way channelSendShared needs one: contrast that function's
+    // doc comment.
+    me.timed_out = false;
+    if (deadline_ns) |d| {
+        // .waiting is required for the timer to actually resolve the wait
+        // -- see channelReceiveFn's matching comment for why this is safe.
+        me.status = .waiting;
+        me.waiting_on = ch_val;
+        vm.gc.writeBarrier(&me.header, ch_val);
+        me.deadline_ns = d;
+        try ctx.reactor.addTimer(d, me);
+    }
+    _ = try fiber_mod.runSchedulerStep(ChannelSendWait, .{ .ch = ch }, ctx.vm, ctx.sched, me);
+    if (deadline_ns != null) {
+        ctx.reactor.removeTimer(me);
+        me.deadline_ns = null;
+    }
+    if (me.timed_out) {
+        me.timed_out = false;
+        return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID);
+    }
+
+    if (ch.closed) return raiseFiberError("channel-send: send on closed channel");
+    if (ch.queue_len < cap) {
+        try enqueueChannel(gc, ch, ch_val, payload);
+        return types.VOID;
+    }
+    return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, "channel-send: deadlock — channel is full and no fibers can receive");
 }
 
 const ChannelWait = struct {
@@ -179,6 +282,18 @@ const SharedChannelPoll = struct {
     }
 };
 
+/// Send-side counterpart to SharedChannelPoll, used by channelSendShared's
+/// local-sibling drive: "ready" means a slot opened up, the channel is
+/// unbounded, or it became closed (a closed channel's send() call raises
+/// immediately rather than parking, which is exactly what driving toward
+/// here is meant to unblock).
+const SharedChannelSendPoll = struct {
+    sc: *shared_channel.SharedChannel,
+    pub fn isDone(self: SharedChannelSendPoll) bool {
+        return self.sc.peekSendReady();
+    }
+};
+
 /// KEP-0002 §5's deadlock-heuristic disjunct: block (park, waiting for a
 /// remote send/receive) rather than raise a local deadlock whenever another
 /// thread could plausibly still act on this channel -- either it still
@@ -196,10 +311,124 @@ const SharedChannelPoll = struct {
 /// true, so the deadlock detector never fires either. This is the same
 /// Go-style "send on a channel nobody will ever receive from" hang as an
 /// unbuffered channel with no reader; §5 accepts it deliberately, and §6's
-/// planned `(channel-receive ch [timeout [timeout-val]])` (Phase 4, not yet
-/// implemented) is the intended escape hatch.
+/// `(channel-receive ch [timeout [timeout-val]])` / `(channel-send ch v
+/// [timeout [timeout-val]])` (KEP-0002 Phase 4) are the intended escape
+/// hatch.
 fn sharedWakeupPossible(sc: *shared_channel.SharedChannel) bool {
     return sc.refCount() > 1 or srfi18.crossThreadWaitPossible();
+}
+
+/// KEP-0002 §4/§6 send on the shared representation. Structural mirror of
+/// channelReceiveShared (see that function's extensive doc comment for why
+/// the is_dispatched/main-fiber split is asymmetric and load-bearing) --
+/// this is the send-side instantiation of the exact same shape, with
+/// SharedChannelSendPoll/peekSendReady in place of
+/// SharedChannelPoll/peekReady.
+///
+/// Timeout handling mirrors thread-sleep!'s documented `me.deadline_ns ==
+/// null` fresh-vs-redispatch discriminator (primitives_srfi18.zig): a
+/// dispatched fiber's parked wait resolves via yield_retry, which
+/// re-executes this entire function from Scheme bytecode on wake, so a
+/// relative timeout argument re-parsed on every redispatch would silently
+/// extend itself forever. `me.timed_out` is therefore checked once at
+/// entry (a fired timer means this call is a post-timeout redispatch, and
+/// no other work should run), and `me.deadline_ns`/the reactor timer are
+/// armed only the first time this wait actually parks (guarded by
+/// `me.deadline_ns == null`), never re-armed on a later loop iteration or
+/// redispatch of the same call.
+fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: Value, deadline_ns: ?u64, has_timeout_val: bool, timeout_val: Value) PrimitiveError!Value {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    const my_idx = ctx.sched.current_idx;
+    const me = ctx.sched.fibers.items[my_idx].?;
+    const notifier = ctx.reactor.notifyHandle();
+    const is_dispatched = my_idx != 0 and vm.dispatched_from_scheduler;
+
+    if (me.deadline_ns != null and me.timed_out) {
+        me.timed_out = false;
+        me.deadline_ns = null;
+        return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID);
+    }
+
+    while (true) {
+        const outcome = shared_channel.send(sc, payload, notifier) catch |err|
+            return translateSharedChannelError(err, "channel-send");
+        switch (outcome) {
+            .sent => {
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
+                return types.VOID;
+            },
+            .closed => {
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
+                return raiseFiberError("channel-send: send on closed channel");
+            },
+            .would_park => {},
+        }
+
+        // Drive local siblings once. See SharedChannelPoll's doc comment
+        // (channelReceiveShared) for why `me` must stay .running throughout.
+        me.timed_out = false;
+        _ = try fiber_mod.runSchedulerStep(SharedChannelSendPoll, .{ .sc = sc }, ctx.vm, ctx.sched, me);
+        if (sc.peekSendReady()) continue; // loop back to 1: re-derive via send()
+
+        if (is_dispatched) {
+            me.status = .waiting;
+            me.waiting_on = ch_val;
+            vm.gc.writeBarrier(&me.header, ch_val);
+            if (me.deadline_ns == null) {
+                if (deadline_ns) |d| {
+                    me.deadline_ns = d;
+                    try ctx.reactor.addTimer(d, me);
+                }
+            }
+            ctx.sched.enrollSharedWaiter(me) catch |err| {
+                me.status = .running;
+                me.waiting_on = types.VOID;
+                return err;
+            };
+            vm.yield_retry = true;
+            return PrimitiveError.Yielded;
+        }
+
+        if (!sharedWakeupPossible(sc) and deadline_ns == null)
+            return raiseFiberError("channel-send: deadlock — channel is full and no other thread can receive");
+
+        me.status = .waiting;
+        me.waiting_on = ch_val;
+        vm.gc.writeBarrier(&me.header, ch_val);
+        if (me.deadline_ns == null) {
+            if (deadline_ns) |d| {
+                me.deadline_ns = d;
+                try ctx.reactor.addTimer(d, me);
+            }
+        }
+        ctx.sched.enrollSharedWaiter(me) catch |err| {
+            me.status = .running;
+            me.waiting_on = types.VOID;
+            return err;
+        };
+        _ = fiber_mod.runSchedulerStep(SharedChannelWait, .{ .me = me }, ctx.vm, ctx.sched, me) catch |err| {
+            ctx.sched.removeSharedWaiter(me);
+            me.status = .running;
+            me.waiting_on = types.VOID;
+            return err;
+        };
+        ctx.sched.removeSharedWaiter(me);
+
+        if (me.timed_out) {
+            me.timed_out = false;
+            me.deadline_ns = null;
+            return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID);
+        }
+        // Loop back to 1: re-registers if still full, sends if a slot
+        // opened (or the channel closed) while parked.
+    }
 }
 
 /// KEP-0002 §4/§5 receive on the shared representation, replacing Phase 1's
@@ -265,7 +494,12 @@ fn sharedWakeupPossible(sc: *shared_channel.SharedChannel) bool {
 ///         remote path could ever help" before parking, or a truly
 ///         deadlocked main fiber would block in reactor.poll() forever
 ///         instead of raising a clean error.
-fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_val: Value) PrimitiveError!Value {
+///
+/// Timeout handling (KEP-0002 Phase 4) follows channelSendShared's exact
+/// discriminator -- see that function's doc comment for why a dispatched
+/// fiber's redispatch cannot simply re-parse `deadline_ns` from Scheme
+/// arguments.
+fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_val: Value, deadline_ns: ?u64, has_timeout_val: bool, timeout_val: Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     const ctx = try fiber_mod.ensureScheduler(vm);
     const my_idx = ctx.sched.current_idx;
@@ -273,14 +507,30 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
     const notifier = ctx.reactor.notifyHandle();
     const is_dispatched = my_idx != 0 and vm.dispatched_from_scheduler;
 
+    if (me.deadline_ns != null and me.timed_out) {
+        me.timed_out = false;
+        me.deadline_ns = null;
+        return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
+    }
+
     while (true) {
         const outcome = shared_channel.receive(sc, gc, notifier) catch |err|
             return translateSharedChannelError(err, "channel-receive");
         switch (outcome) {
-            .value => |v| return v,
-            // channel-close! is Phase 4 -- sc.closed is always false, so
-            // receive's reserved==0-and-closed eof branch is unreachable.
-            .eof => @panic("channel-receive: .eof unreachable before channel-close! (Phase 4)"),
+            .value => |v| {
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
+                return v;
+            },
+            .eof => {
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
+                return types.EOF;
+            },
             .would_park => {},
         }
 
@@ -300,6 +550,12 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             me.status = .waiting;
             me.waiting_on = ch_val;
             vm.gc.writeBarrier(&me.header, ch_val);
+            if (me.deadline_ns == null) {
+                if (deadline_ns) |d| {
+                    me.deadline_ns = d;
+                    try ctx.reactor.addTimer(d, me);
+                }
+            }
             ctx.sched.enrollSharedWaiter(me) catch |err| {
                 me.status = .running;
                 me.waiting_on = types.VOID;
@@ -309,7 +565,7 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             return PrimitiveError.Yielded;
         }
 
-        if (!sharedWakeupPossible(sc))
+        if (!sharedWakeupPossible(sc) and deadline_ns == null)
             return raiseFiberError("channel-receive: deadlock — channel is empty and no other thread can send");
 
         me.status = .waiting;
@@ -319,6 +575,12 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         // between there and here can set it true again (`me` stays .running
         // for that whole drive, and wakeReadyFiber only flips `.waiting`
         // fibers).
+        if (me.deadline_ns == null) {
+            if (deadline_ns) |d| {
+                me.deadline_ns = d;
+                try ctx.reactor.addTimer(d, me);
+            }
+        }
         ctx.sched.enrollSharedWaiter(me) catch |err| {
             me.status = .running;
             me.waiting_on = types.VOID;
@@ -331,6 +593,12 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             return err;
         };
         ctx.sched.removeSharedWaiter(me);
+
+        if (me.timed_out) {
+            me.timed_out = false;
+            me.deadline_ns = null;
+            return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
+        }
         // Loop back to 1: re-registers if still empty, picks up a value if
         // one arrived while parked.
     }
@@ -346,18 +614,37 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
     const ch = ch_obj.as(types.Channel);
 
+    var deadline_ns: ?u64 = null;
+    var has_timeout_val = false;
+    var timeout_val: Value = types.VOID;
+    if (args.len > 1) {
+        deadline_ns = try srfi18.timeoutToDeadlineNs(args[1]);
+        if (args.len > 2) {
+            has_timeout_val = true;
+            timeout_val = args[2];
+        }
+    }
+
     if (ch.shared) |raw| {
         const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
-        return channelReceiveShared(sc, gc, args[0]);
+        return channelReceiveShared(sc, gc, args[0], deadline_ns, has_timeout_val, timeout_val);
     }
 
     if (ch.head != types.NIL and types.isPair(ch.head)) {
         return dequeueChannel(ch, args[0]);
     }
 
+    // Closed and drained is permanently terminal on the local
+    // representation (no more sends can land once closed): short-circuit
+    // before ever touching the scheduler.
+    if (ch.closed) return types.EOF;
+
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
-    if (vm.scheduler == null) {
-        // No fibers exist, so nothing can ever send: blocking would hang.
+    // No timeout means a timer can never resolve this wait, so "no fibers
+    // exist" really is unrecoverable; with a timeout, ensureScheduler below
+    // lazily creates a scheduler+reactor and the wait resolves via the
+    // timer alone, with or without any other fiber ever existing.
+    if (vm.scheduler == null and deadline_ns == null) {
         return raiseFiberError("channel-receive: deadlock — channel is empty and no fibers are running");
     }
 
@@ -371,18 +658,58 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     const my_idx = ctx.sched.current_idx;
     const me = ctx.sched.fibers.items[my_idx].?;
 
+    // A local channel wait always resolves within this one call -- see
+    // channelSendLocal's doc comment for why no redispatch guard is needed.
+    me.timed_out = false;
+    if (deadline_ns) |d| {
+        // .waiting (not .running) is required here: wakeReadyFiber only
+        // flips timed_out for .waiting/.io_waiting fibers, so without this
+        // the timer would pop silently and the wait would fall through to
+        // blockOrDeadlock instead of timing out. schedule()'s round-robin
+        // still never re-picks `me` (it only picks .created/.suspended),
+        // and runSchedulerStep's epilogue unconditionally restores
+        // me.status = .running before returning, so this is safe exactly
+        // like every other timed wait in primitives_srfi18.zig (MutexWait,
+        // CondVarWait, thread-join!'s fiber path) that sets .waiting
+        // whether or not a deadline was actually given.
+        me.status = .waiting;
+        me.waiting_on = ch_val;
+        vm.gc.writeBarrier(&me.header, ch_val);
+        me.deadline_ns = d;
+        try ctx.reactor.addTimer(d, me);
+    }
     _ = try fiber_mod.runSchedulerStep(ChannelWait, .{ .ch = ch }, ctx.vm, ctx.sched, me);
+    if (deadline_ns != null) {
+        ctx.reactor.removeTimer(me);
+        me.deadline_ns = null;
+    }
+    if (me.timed_out) {
+        me.timed_out = false;
+        return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
+    }
 
     if (ch.head != types.NIL) return dequeueChannel(ch, ch_val);
+    if (ch.closed) return types.EOF;
     return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, "channel-receive: deadlock — channel is empty and all fibers are blocked");
 }
 
+/// Pops the head of a local (unpromoted) channel's queue. `ch.queue_len`
+/// tracking and the capacity-freed wake are guarded on `ch.capacity !=
+/// null` so the unbounded hot path (the common case) pays nothing beyond
+/// the existing decrement -- no sender can ever be parked waiting for space
+/// on an unbounded channel.
 fn dequeueChannel(ch: *types.Channel, ch_val: Value) Value {
     const pair = types.toObject(ch.head).as(types.Pair);
     const val = pair.car;
     ch.head = pair.cdr;
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(ch_val), pair.cdr);
     if (ch.head == types.NIL) ch.tail = types.NIL;
+    ch.queue_len -= 1;
+    if (ch.capacity != null) {
+        if (vm_mod.vm_instance) |vm| {
+            if (vm.scheduler) |sched| sched.wakeChannelWaiters(ch_val);
+        }
+    }
     return val;
 }
 
@@ -445,4 +772,55 @@ fn translateSharedChannelError(err: anyerror, proc: []const u8) PrimitiveError {
 /// `(channel? x)` gets `#f`-and-skip instead of a raise.
 fn channelPredFn(args: []const Value) PrimitiveError!Value {
     return if (types.isChannel(args[0])) types.TRUE else types.FALSE;
+}
+
+/// KEP-0002 §6 close!. Unlike channel?, this dereferences the channel (its
+/// `shared` pointer or local fields), so it needs the same foreign-owner
+/// check as send/receive, not channel?'s total-predicate convention.
+fn channelCloseFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isChannel(args[0]))
+        return primitives.typeError("channel-close!", "channel", args[0]);
+
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const ch_obj = types.toObject(args[0]);
+    if (ch_obj.owner != gc.id)
+        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
+    const ch = ch_obj.as(types.Channel);
+
+    if (ch.shared) |raw| {
+        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
+        // Local waiters were already migrated into the notifier protocol at
+        // promotion time (§2 step 4) -- no separate local wake is needed
+        // here, unlike the unpromoted branch below.
+        shared_channel.close(sc);
+        return types.VOID;
+    }
+
+    if (ch.closed) return types.VOID; // idempotent, matches §6 step 2
+    ch.closed = true;
+    if (vm_mod.vm_instance) |vm| {
+        if (vm.scheduler) |sched| sched.wakeChannelWaiters(args[0]);
+    }
+    return types.VOID;
+}
+
+fn channelClosedFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isChannel(args[0]))
+        return primitives.typeError("channel-closed?", "channel", args[0]);
+
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const ch_obj = types.toObject(args[0]);
+    if (ch_obj.owner != gc.id)
+        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
+    const ch = ch_obj.as(types.Channel);
+
+    if (ch.shared) |raw| {
+        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
+        return if (sc.isClosed()) types.TRUE else types.FALSE;
+    }
+    return if (ch.closed) types.TRUE else types.FALSE;
+}
+
+fn channelTimeoutPredFn(args: []const Value) PrimitiveError!Value {
+    return if (srfi18.isErrorOfType(args[0], .channel_timeout)) types.TRUE else types.FALSE;
 }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -211,7 +211,10 @@ pub fn crossThreadWaitPossible() bool {
     return @atomicLoad(usize, &live_child_threads, .acquire) > 0;
 }
 
-fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
+/// `pub` since KEP-0002 Phase 4 (#1469): primitives_fiber.zig's
+/// channel-send/channel-receive timeouts reuse this exact SRFI-18-shaped
+/// number-or-time-object-or-#f parsing rather than duplicating it.
+pub fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
     if (timeout == types.FALSE) return null;
     if (types.isSrfi18Time(timeout)) {
         const t = types.toSrfi18Time(timeout);
@@ -248,7 +251,10 @@ fn makeErrorWithType(error_type: types.ErrorObject.ErrorType, msg: []const u8, r
     return err_val;
 }
 
-fn raiseError(error_type: types.ErrorObject.ErrorType, msg: []const u8, reason: Value) PrimitiveError!Value {
+/// `pub` since KEP-0002 Phase 4 (#1469): primitives_fiber.zig's
+/// channel-timeout-exception? path reuses this instead of duplicating the
+/// typed-error-object construction.
+pub fn raiseError(error_type: types.ErrorObject.ErrorType, msg: []const u8, reason: Value) PrimitiveError!Value {
     const err_val = try makeErrorWithType(error_type, msg, reason);
     const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     vm.current_exception = err_val;
@@ -1252,7 +1258,8 @@ fn secondsToTimeFn(args: []const Value) PrimitiveError!Value {
 // Exception predicates
 // ---------------------------------------------------------------------------
 
-fn isErrorOfType(v: Value, error_type: types.ErrorObject.ErrorType) bool {
+/// `pub` since KEP-0002 Phase 4 (#1469): channel-timeout-exception?.
+pub fn isErrorOfType(v: Value, error_type: types.ErrorObject.ErrorType) bool {
     if (!types.isPointer(v)) return false;
     const obj = types.toObject(v);
     if (obj.tag != .error_object) return false;

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -105,12 +105,12 @@ pub const SharedChannel = struct {
     /// Slots claimed by in-flight sends (§4) -- always 0 outside a send()
     /// call in progress.
     reserved: u32 = 0,
-    /// null = unbounded. Always null in Phase 1: no Scheme-level API sets
-    /// this yet (make-channel with a capacity argument is Phase 4);
-    /// reachable in Phase 1 only via a white-box test that constructs a
-    /// SharedChannel directly.
+    /// null = unbounded (KEP-0002 §6, `make-channel`'s optional capacity
+    /// argument). Set once, by promoteChannel, from the local
+    /// representation's own `capacity` field -- never mutated after.
     capacity: ?u32 = null,
-    /// Always false in Phase 1: channel-close! is Phase 4.
+    /// KEP-0002 §6, `channel-close!`. Set once (true), by promoteChannel
+    /// (carried over from an already-closed local channel) or by close().
     closed: bool = false,
     recv_waiters: std.ArrayList(*ThreadNotifier) = .empty,
     send_waiters: std.ArrayList(*ThreadNotifier) = .empty,
@@ -151,6 +151,27 @@ pub const SharedChannel = struct {
         lockChannel(self);
         defer unlockChannel(self);
         return self.queue_len != 0 or self.closed;
+    }
+
+    /// Send-side counterpart to peekReady: true iff a send() call right now
+    /// would be admitted (a slot is free, unbounded, or closed -- a closed
+    /// channel "admits" in the sense that send() will immediately raise
+    /// rather than park, which is exactly the outcome
+    /// channelSendShared's local-drive loop needs to stop waiting on).
+    pub fn peekSendReady(self: *SharedChannel) bool {
+        lockChannel(self);
+        defer unlockChannel(self);
+        if (self.closed) return true;
+        const cap = self.capacity orelse return true;
+        return self.queue_len + self.reserved < cap;
+    }
+
+    /// KEP-0002 §6's `channel-closed?`, lock-protected like peekReady --
+    /// `closed` is genuinely cross-thread-visible once promoted.
+    pub fn isClosed(self: *SharedChannel) bool {
+        lockChannel(self);
+        defer unlockChannel(self);
+        return self.closed;
     }
 
     /// §1 rule 4 / §7: zero destroys. Drains and deinits every queued
@@ -290,6 +311,12 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
     std.debug.assert(ch.header.owner == gc.id);
 
     const sc = try SharedChannel.create();
+    // KEP-0002 §6: carried over from the local representation before
+    // publishing -- safe either way, since nothing can observe `sc` until
+    // `ch.shared` is set below. `sc.queue_len` needs no equivalent copy: the
+    // drain loop below derives it correctly via pushBack.
+    sc.capacity = ch.capacity;
+    sc.closed = ch.closed;
     // Publish before draining (§2 step 2): a queued local message may
     // contain this very channel (e.g. (channel-send ch (list ch))). With
     // `shared` already set, the drain's own Envelope.create -> deepCopy
@@ -316,30 +343,41 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
 
     // KEP-0002 §2 step 4: migrate any fiber already parked on the *local*
     // representation before promotion (waiting_on == ch -- a receiver on
-    // the empty queue; sender-side migration doesn't apply yet, since the
-    // local Channel has no capacity to park a sender against until Phase
-    // 4). Promotion runs inside a primitive on the owning thread, so the
-    // local scheduler is quiescent and this scan is race-free. Without this
-    // step a fiber parked before promotion would hang forever: a remote
-    // send only rings *registered* notifiers. Enrolled unconditionally, not
-    // gated on sc.refCount() > 1 -- at this point refcount is still 1 (the
-    // caller in gc_deep_copy.zig retains the second stub only after this
-    // function returns), so gating here would always see 1 and wrongly
-    // skip migration.
+    // the empty queue, or, since Phase 4 added local bounded-channel
+    // parking, a sender on a full queue). Promotion runs inside a primitive
+    // on the owning thread, so the local scheduler is quiescent and this
+    // scan is race-free. Without this step a fiber parked before promotion
+    // would hang forever: a remote send/receive only rings *registered*
+    // notifiers. Enrolled unconditionally, not gated on sc.refCount() > 1
+    // -- at this point refcount is still 1 (the caller in gc_deep_copy.zig
+    // retains the second stub only after this function returns), so gating
+    // here would always see 1 and wrongly skip migration.
+    //
+    // A migrated fiber's role (parked sender vs. parked receiver) isn't
+    // tracked anywhere -- `waiting_on` only records the channel, not why --
+    // so rather than adding a Fiber field just for this migration corner,
+    // the notifier is registered in *both* waiter lists. A spurious ring on
+    // the wrong list is harmless under the existing wake-all/retry
+    // discipline (the fiber just re-parks and re-registers correctly, this
+    // time through the real shared send()/receive() path); registering in
+    // only one risks a permanent hang if that guess is wrong (e.g. a
+    // migrated sender registered only in recv_waiters would never be rung
+    // by a remote receive freeing a slot).
     if (vm_mod.vm_instance) |vm| {
         if (vm.scheduler) |sched| {
             const ch_val = types.makePointer(@ptrCast(&ch.header));
             // Registers the notifier once, only if something actually
-            // matched -- registerRecvWaiter's own dedup makes calling it
-            // once per matching fiber idempotent, but hoisting it out reads
-            // clearer and does one lock/unlock instead of N.
+            // matched -- register{Recv,Send}Waiter's own dedup makes
+            // calling them once per matching fiber idempotent, but hoisting
+            // it out reads clearer and does one lock/unlock pair instead of
+            // N per list.
             var migrated_any = false;
             for (sched.fibers.items) |maybe_f| {
                 const f = maybe_f orelse continue;
                 if (f.status == .waiting and f.waiting_on == ch_val) {
-                    // Propagate, don't swallow: registerRecvWaiter runs
-                    // once, after this loop finishes (not before it), so on
-                    // an enrollSharedWaiter OOM mid-loop no notifier is ever
+                    // Propagate, don't swallow: registration runs once,
+                    // after this loop finishes (not before it), so on an
+                    // enrollSharedWaiter OOM mid-loop no notifier is ever
                     // registered for `sc`. Fibers already enrolled by prior
                     // iterations become stale-but-harmless registry entries
                     // -- any future sweep on this scheduler flips them
@@ -352,7 +390,11 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
                     migrated_any = true;
                 }
             }
-            if (migrated_any) sc.registerRecvWaiter(vm.reactor.?.notifyHandle());
+            if (migrated_any) {
+                const notifier = vm.reactor.?.notifyHandle();
+                sc.registerRecvWaiter(notifier);
+                sc.registerSendWaiter(notifier);
+            }
         }
     }
 
@@ -366,12 +408,10 @@ pub const SendOutcome = union(enum) {
 };
 
 /// KEP-0002 §4 send, on the shared representation, verbatim. `notifier` is
-/// registered only by the full-channel park branch, which is provably
-/// unreachable through the public Scheme API in Phase 1 (capacity is
-/// always null) -- callers that only ever pass unbounded/open channels may
-/// pass null; a null notifier on that branch simply registers nothing
-/// (there is nothing yet to wake) rather than panicking, so a future caller
-/// that *can* reach this branch without a real notifier degrades safely.
+/// registered only by the full-channel park branch (reachable once a
+/// caller passes a bounded channel, KEP-0002 §6); passing null there simply
+/// registers nothing (there is nothing yet to wake) rather than panicking,
+/// which callers that only ever operate on unbounded/open channels rely on.
 pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !SendOutcome {
     lockChannel(sc);
     if (sc.closed) {
@@ -462,4 +502,25 @@ pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifi
     if (notifier) |n| sc.registerRecvWaiter(n);
     unlockChannel(sc);
     return .would_park;
+}
+
+/// KEP-0002 §6 close, on the shared representation, verbatim: idempotent,
+/// wakes every waiter on both sides at once. A sender that already reserved
+/// its slot before this runs is unaffected (the `closed` check runs only at
+/// send's admission step) and completes its push normally -- reservation-
+/// as-admission is what makes an admitted message survive a concurrent
+/// close (model finding 2).
+pub fn close(sc: *SharedChannel) void {
+    lockChannel(sc);
+    if (sc.closed) {
+        unlockChannel(sc);
+        return;
+    }
+    sc.closed = true;
+    var snap: std.ArrayList(*ThreadNotifier) = .empty;
+    defer snap.deinit(std.heap.c_allocator);
+    sc.snapshotAndClearRecvWaiters(&snap);
+    sc.snapshotAndClearSendWaiters(&snap);
+    unlockChannel(sc);
+    ring(snap.items);
 }

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -768,13 +768,15 @@ test "required regression: workers looping until eof all see the admitted messag
 }
 
 test "required regression: copy failure of the last reserved send on a closed channel rings eof-waiting receivers (§4 step 9, model finding 3)" {
+    const baseline = shared_object.liveCount();
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+
     const sc = try shared_channel.SharedChannel.create();
     sc.reserved = 1; // an admitted send is in flight
     shared_channel.close(sc); // ... and the channel closes before it completes
     try std.testing.expectEqual(@as(u32, 1), sc.reserved);
 
     var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
-    defer reactor.deinit();
     const notifier = reactor.notifyHandle();
 
     // A receiver arriving inside the admitted send's copy window: the
@@ -805,6 +807,11 @@ test "required regression: copy failure of the last reserved send on a closed ch
     try std.testing.expectEqual(shared_channel.RecvOutcome.eof, try shared_channel.receive(sc, &dest_gc, null));
 
     sc.release();
+    // Explicit, not deferred -- must run before the leak-count checks
+    // below, which otherwise run before a function-scope `defer` would.
+    reactor.deinit();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+    try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
 }
 
 test "Motivation Path 2 regression: a channel reached through a shared global raises instead of corrupting memory" {

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -524,6 +524,289 @@ test "receive: empty and open registers a recv waiter and would park" {
     sc.release();
 }
 
+test "receive: copy-out failure re-queues at the head under a bounded channel too" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+    sc.capacity = 1;
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const payload = try src_gc.allocPair(types.makeFixnum(11), types.NIL);
+    _ = try shared_channel.send(sc, payload, null);
+    src_gc.deinit();
+
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    dest_gc.allocator = failing.allocator();
+    try std.testing.expectError(error.OutOfMemory, shared_channel.receive(sc, &dest_gc, null));
+    dest_gc.allocator = std.testing.allocator;
+    dest_gc.deinit();
+    try std.testing.expectEqual(@as(u32, 1), sc.queue_len); // FIFO preserved: still at capacity, not over
+
+    var dest_gc2 = memory.GC.init(std.testing.allocator);
+    const value = switch (try shared_channel.receive(sc, &dest_gc2, null)) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(i64, 11), types.toFixnum(types.car(value)));
+
+    dest_gc2.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "required regression: bounded channel tolerates the documented transient capacity overshoot -- admission stays strict, FIFO drains it (§4 receive step 5)" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    // Construct the overshoot state directly (KEP-0002 §4 receive step 5:
+    // "the pop's ring may already have admitted a sender into the freed
+    // slot [before a failed receive's own re-queue runs], so a bounded
+    // queue can transiently exceed its capacity by the number of
+    // concurrently failing receives"): two sends land while unbounded,
+    // then capacity clamps to 1 -- queue_len (2) now exceeds it, exactly
+    // the transient state a real failed-receive-races-a-fresh-send
+    // interleaving would leave behind.
+    // Each pair is sent immediately after it's allocated (not held in a
+    // local across the next allocPair call) -- gc-safety.md's "root fresh
+    // results between allocations" rule: an unrooted Value surviving a
+    // second allocation on the same GC risks the collector reusing its
+    // memory (-Dgc-stress=true collects on every allocation).
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const p1 = try src_gc.allocPair(types.makeFixnum(11), types.NIL);
+    _ = try shared_channel.send(sc, p1, null);
+    const p2 = try src_gc.allocPair(types.makeFixnum(22), types.NIL);
+    _ = try shared_channel.send(sc, p2, null);
+    src_gc.deinit();
+    sc.capacity = 1;
+    try std.testing.expectEqual(@as(u32, 2), sc.queue_len);
+
+    // Admission stays strict despite the overshoot: a new send still parks
+    // rather than compounding it further.
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const notifier = reactor.notifyHandle();
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(33), notifier));
+
+    // The overshoot drains with ordinary receives, FIFO order intact.
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    const first = switch (try shared_channel.receive(sc, &dest_gc, null)) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(i64, 11), types.toFixnum(types.car(first)));
+    try std.testing.expectEqual(@as(u32, 1), sc.queue_len); // exactly at capacity now
+
+    const second = switch (try shared_channel.receive(sc, &dest_gc, null)) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(i64, 22), types.toFixnum(types.car(second)));
+    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
+
+    dest_gc.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "close: idempotent and wakes both waiter lists" {
+    const sc = try shared_channel.SharedChannel.create();
+    sc.capacity = 0; // force full, so send() parks instead of completing
+
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const notifier = reactor.notifyHandle();
+
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    defer dest_gc.deinit();
+    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, try shared_channel.receive(sc, &dest_gc, notifier));
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(1), notifier));
+    try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
+    try std.testing.expectEqual(@as(usize, 1), sc.send_waiters.items.len);
+
+    shared_channel.close(sc);
+    try std.testing.expect(sc.closed);
+    try std.testing.expectEqual(@as(usize, 0), sc.recv_waiters.items.len);
+    try std.testing.expectEqual(@as(usize, 0), sc.send_waiters.items.len);
+    // Back to just the Reactor's own base ref -- both registrations released.
+    try std.testing.expectEqual(@as(u32, 1), notifier.refcount.load(.monotonic));
+
+    // Idempotent: a second close is a no-op (no double-release panic).
+    shared_channel.close(sc);
+    try std.testing.expect(sc.closed);
+
+    sc.release();
+}
+
+test "close: a message queued before close still deinits normally at destroy-at-zero" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const payload = try src_gc.allocPair(types.makeFixnum(1), types.NIL);
+    _ = try shared_channel.send(sc, payload, null);
+    src_gc.deinit();
+    try std.testing.expectEqual(@as(u32, 1), sc.queue_len);
+
+    shared_channel.close(sc);
+    try std.testing.expect(sc.closed);
+    try std.testing.expectEqual(@as(u32, 1), sc.queue_len); // close doesn't drain the queue
+
+    sc.release(); // destroy-at-zero deinits the still-queued envelope
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+/// Test-only replica of shared_channel.zig's private pushBack, built purely
+/// from SharedChannel's public fields (queue_head/queue_tail/queue_len).
+/// The two "required regression" tests below construct states that a
+/// send()/close() race would leave behind -- an admitted (reserved) send
+/// whose push completes strictly after a concurrent close() -- which the
+/// public API alone cannot reach deterministically (send()'s own
+/// closed-precheck would short-circuit a *fresh* call once closed is
+/// already true; only a send already past that check, mid-copy, resolves
+/// after close). This constructs the resulting queue state directly, the
+/// same way the file's existing white-box tests construct
+/// reserved/closed/capacity states directly rather than racing for them.
+fn testPushBack(sc: *shared_channel.SharedChannel, env: *shared_channel.Envelope) void {
+    env.next = null;
+    if (sc.queue_tail) |tail| tail.next = env else sc.queue_head = env;
+    sc.queue_tail = env;
+    sc.queue_len += 1;
+}
+
+/// Test-only replica of the snapshot-and-clear-then-ring step send(),
+/// receive(), and close() all perform under their own lock -- built from
+/// the public ArrayList/ThreadNotifier API. See testPushBack's doc comment
+/// for why the required-regression tests below need this instead of
+/// calling send()'s real failure path directly.
+fn testRingAndClear(list: *std.ArrayList(*reactor_mod.ThreadNotifier)) void {
+    for (list.items) |n| {
+        n.notify();
+        reactor_mod.releaseNotifier(n);
+    }
+    list.clearRetainingCapacity();
+}
+
+test "required regression: reserve, concurrent close, and the admitted push still completes and drains before eof (§4 step 9 / §6, model finding 2)" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    // §4 steps 1-7: a send is admitted (reservation taken) while the
+    // channel is still open.
+    sc.reserved = 1;
+
+    // channel-close! races in before the reservation's copy/push
+    // completes. Reservation-as-admission means this must not fail the
+    // already-admitted send.
+    shared_channel.close(sc);
+    try std.testing.expect(sc.closed);
+    try std.testing.expectEqual(@as(u32, 1), sc.reserved); // still outstanding
+
+    // §4 steps 9-12: the admitted send completes its copy and push.
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const payload = try src_gc.allocPair(types.makeFixnum(42), types.NIL);
+    const env = try shared_channel.Envelope.create(payload);
+    src_gc.deinit();
+    sc.reserved -= 1;
+    testPushBack(sc, env);
+
+    // A receiver must drain the admitted message, not observe a premature
+    // eof: reserved is now 0, but the message is sitting in the queue and
+    // is checked first.
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    const value = switch (try shared_channel.receive(sc, &dest_gc, null)) {
+        .value => |v| v,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(types.car(value)));
+
+    // Only now, with the queue drained and reserved == 0, does eof appear.
+    try std.testing.expectEqual(shared_channel.RecvOutcome.eof, try shared_channel.receive(sc, &dest_gc, null));
+
+    dest_gc.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "required regression: workers looping until eof all see the admitted message drained, not a premature eof (§6 reserved==0 rule, model finding 2)" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+
+    sc.reserved = 1;
+    shared_channel.close(sc);
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    const payload = try src_gc.allocPair(types.makeFixnum(7), types.NIL);
+    const env = try shared_channel.Envelope.create(payload);
+    src_gc.deinit();
+    sc.reserved -= 1;
+    testPushBack(sc, env);
+
+    // Four "workers" racing channel-receive in an until-eof loop: exactly
+    // one drains the admitted message; the rest see eof, never a
+    // premature one before the drain, and never park (the channel is
+    // closed with nothing left in flight after the first receive).
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    var value_count: u32 = 0;
+    var eof_count: u32 = 0;
+    var i: u32 = 0;
+    while (i < 4) : (i += 1) {
+        switch (try shared_channel.receive(sc, &dest_gc, null)) {
+            .value => |v| {
+                try std.testing.expectEqual(@as(i64, 7), types.toFixnum(types.car(v)));
+                value_count += 1;
+            },
+            .eof => eof_count += 1,
+            .would_park => return error.TestUnexpectedResult,
+        }
+    }
+    try std.testing.expectEqual(@as(u32, 1), value_count);
+    try std.testing.expectEqual(@as(u32, 3), eof_count);
+
+    dest_gc.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "required regression: copy failure of the last reserved send on a closed channel rings eof-waiting receivers (§4 step 9, model finding 3)" {
+    const sc = try shared_channel.SharedChannel.create();
+    sc.reserved = 1; // an admitted send is in flight
+    shared_channel.close(sc); // ... and the channel closes before it completes
+    try std.testing.expectEqual(@as(u32, 1), sc.reserved);
+
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const notifier = reactor.notifyHandle();
+
+    // A receiver arriving inside the admitted send's copy window: the
+    // queue is empty, but reserved != 0, so eof must not race the
+    // reservation -- it registers and parks instead (receive's own
+    // reserved==0 guard, exercised the ordinary way here).
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    defer dest_gc.deinit();
+    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, try shared_channel.receive(sc, &dest_gc, notifier));
+    try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
+
+    // The in-flight send's own copy now fails. send()'s real failure path
+    // (shared_channel.zig, the `if (sc.closed) sc.snapshotAndClearRecvWaiters`
+    // branch of its Envelope.create catch block) is what this models:
+    // reserved releases, and because the channel is closed, recv_waiters
+    // is rung too -- without that extra ring, the receiver above (parked
+    // strictly *after* close already rang once) would have no other path
+    // to ever wake. Replicated here via the same public building blocks
+    // that branch is written from (see testPushBack/testRingAndClear's
+    // doc comment for why a literal call can't land inside this window).
+    sc.reserved -= 1;
+    testRingAndClear(&sc.send_waiters); // none registered; exercises the no-op case too
+    testRingAndClear(&sc.recv_waiters);
+    try std.testing.expectEqual(@as(usize, 0), sc.recv_waiters.items.len);
+
+    // Retrying now, as the woken receiver would, observes reserved == 0
+    // and returns eof -- not a hang.
+    try std.testing.expectEqual(shared_channel.RecvOutcome.eof, try shared_channel.receive(sc, &dest_gc, null));
+
+    sc.release();
+}
+
 test "Motivation Path 2 regression: a channel reached through a shared global raises instead of corrupting memory" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/src/types.zig
+++ b/src/types.zig
@@ -402,6 +402,7 @@ pub const ErrorObject = struct {
         abandoned_mutex,
         terminated_thread,
         uncaught_exception,
+        channel_timeout,
     };
 
     header: Object,
@@ -657,6 +658,16 @@ pub const Channel = struct {
     header: Object,
     head: Value,
     tail: Value,
+    /// Local queue length (KEP-0002 §6) -- O(1) capacity admission checks
+    /// instead of walking the head/tail pair list. Unused once `shared` is
+    /// set (the SharedChannel tracks its own queue_len).
+    queue_len: u32 = 0,
+    /// null = unbounded (today's semantics). Local-representation only;
+    /// carried into the SharedChannel by promoteChannel on promotion.
+    capacity: ?u32 = null,
+    /// KEP-0002 §6: end-of-stream. Local-representation only; carried into
+    /// the SharedChannel by promoteChannel on promotion.
+    closed: bool = false,
     /// Set exactly once, by the owning thread (KEP-0002 §2). Actually
     /// `*shared_channel.SharedChannel` once promoted; kept opaque so
     /// types.zig -- the dependency-free base layer -- doesn't import a

--- a/tests/scheme/smoke/fiber-channel-capacity.scm
+++ b/tests/scheme/smoke/fiber-channel-capacity.scm
@@ -1,0 +1,61 @@
+;; KEP-0002 §6 (#1469): (make-channel capacity) on the local (unpromoted)
+;; representation -- a bounded channel parks the sender when full instead
+;; of growing without limit, and a receive frees a slot for a parked
+;; sender to resume into.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (kaappi fibers) (srfi 18) (srfi 64))
+
+(test-begin "fiber-channel-capacity")
+
+;; --- capacity 1: a second send parks until a receive frees the slot ---
+(test-equal "bounded channel: sender parks when full, resumes after a receive"
+  '(first second)
+  (let* ((ch (make-channel 1))
+         (order '()))
+    (channel-send ch 'first) ; fills the one slot, does not park
+    (spawn (lambda ()
+             (channel-send ch 'second))) ; must park: channel is full
+    (yield) ; let the spawned sender run and park
+    (set! order (cons (channel-receive ch) order)) ; frees the slot -- wakes it
+    (yield)
+    (set! order (cons (channel-receive ch) order))
+    (reverse order)))
+
+;; --- capacity 0: every send is permanently full (no rendezvous handoff;
+;; the reservation-based protocol has no direct sender/receiver pairing),
+;; so a timed send on it always times out ---
+(test-equal "capacity-0 channel: send always times out (degenerate, documented)"
+  'timed-out
+  (let ((ch (make-channel 0)))
+    (channel-send ch 1 0.05 'timed-out)))
+
+;; --- make-channel argument validation ---
+(test-assert "make-channel rejects a negative capacity"
+  (guard (e (#t #t)) (make-channel -1) #f))
+
+(test-assert "make-channel rejects a non-integer capacity"
+  (guard (e (#t #t)) (make-channel 1.5) #f))
+
+;; --- capacity survives multiple fill/drain cycles ---
+(test-equal "bounded channel: repeated fill-then-drain cycles"
+  '(0 1 2 3 4)
+  (let ((ch (make-channel 2)))
+    (let loop ((i 0) (acc '()))
+      (if (= i 5)
+          (reverse acc)
+          (begin
+            (channel-send ch i)
+            (loop (+ i 1) (cons (channel-receive ch) acc)))))))
+
+;; --- a spawned sender parked on a full channel deadlocks cleanly if
+;; nothing will ever receive (no timeout given) ---
+(test-assert "bounded channel: send with no receiver and no other fiber raises a deadlock error"
+  (guard (e (#t #t))
+    (let ((ch (make-channel 0)))
+      (channel-send ch 1)
+      #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "fiber-channel-capacity")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/fiber-channel-close.scm
+++ b/tests/scheme/smoke/fiber-channel-close.scm
@@ -1,0 +1,66 @@
+;; KEP-0002 §6 (#1469): channel-close!/channel-closed? on the local
+;; (unpromoted) representation -- end-of-stream as a first-class state.
+;; Receivers drain whatever is queued before eof; sends after close raise;
+;; close is idempotent; sending a literal eof-object is rejected (the one
+;; backward-compat carve-out, since it would be indistinguishable from
+;; close's own end-of-stream at the receiver).
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (kaappi fibers) (srfi 18) (srfi 64))
+
+(test-begin "fiber-channel-close")
+
+(test-assert "channel-closed? is #f on a fresh channel"
+  (not (channel-closed? (make-channel))))
+
+(test-equal "channel-close! drains queued values before eof"
+  '(1 2 done)
+  (let ((ch (make-channel)))
+    (channel-send ch 1)
+    (channel-send ch 2)
+    (channel-close! ch)
+    (list (channel-receive ch)
+          (channel-receive ch)
+          (if (eof-object? (channel-receive ch)) 'done 'not-done))))
+
+(test-assert "channel-closed? is #t after channel-close!"
+  (let ((ch (make-channel)))
+    (channel-close! ch)
+    (channel-closed? ch)))
+
+(test-assert "channel-close! is idempotent"
+  (let ((ch (make-channel)))
+    (channel-close! ch)
+    (channel-close! ch) ; must not raise
+    (channel-closed? ch)))
+
+(test-assert "channel-send on a closed channel raises"
+  (let ((ch (make-channel)))
+    (channel-close! ch)
+    (guard (e (#t #t)) (channel-send ch 1) #f)))
+
+(test-assert "sending a literal eof-object raises (use channel-close! instead)"
+  (let ((ch (make-channel)))
+    (guard (e (#t #t)) (channel-send ch (eof-object)) #f)))
+
+;; --- close wakes a parked receiver on an empty channel ---
+(test-equal "channel-close! wakes a fiber parked on channel-receive"
+  'eof
+  (let* ((ch (make-channel))
+         (f (spawn (lambda () (if (eof-object? (channel-receive ch)) 'eof 'value)))))
+    (yield) ; let the receiver run and park on the empty channel
+    (channel-close! ch)
+    (fiber-join f))) ; drives the scheduler until f completes -- no hang
+
+;; --- close wakes a parked sender on a full bounded channel too ---
+(test-assert "channel-close! wakes a fiber parked on channel-send (raises, not hangs)"
+  (let* ((ch (make-channel 0))
+         (f (spawn (lambda ()
+                     (guard (e (#t 'raised)) (channel-send ch 1) 'not-raised)))))
+    (yield) ; let the sender run and park (capacity 0: always full)
+    (channel-close! ch)
+    (eq? 'raised (fiber-join f))))
+
+(let ((runner (test-runner-current)))
+  (test-end "fiber-channel-close")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/fiber-channel-timeout.scm
+++ b/tests/scheme/smoke/fiber-channel-timeout.scm
@@ -1,0 +1,82 @@
+;; KEP-0002 §6 (#1469): [timeout [timeout-val]] on channel-receive and
+;; channel-send, SRFI-18 shape (same as thread-join!): without timeout-val,
+;; expiry raises channel-timeout-exception?; with one, it is returned
+;; instead. Covers both directions, with and without timeout-val, on both
+;; an empty/full local channel and one with data/room ready immediately
+;; (timeout must not fire when the operation can complete right away).
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (kaappi fibers) (srfi 18) (srfi 64))
+
+(test-begin "fiber-channel-timeout")
+
+;; --- receive: no timeout-val -> raises a channel-timeout-exception? ---
+(test-assert "channel-receive on an empty channel times out and raises"
+  (let ((ch (make-channel)))
+    (guard (e (#t (channel-timeout-exception? e)))
+      (channel-receive ch 0.05)
+      #f)))
+
+;; --- receive: with timeout-val -> returns it instead of raising ---
+(test-equal "channel-receive on an empty channel times out and returns timeout-val"
+  'gave-up
+  (let ((ch (make-channel)))
+    (channel-receive ch 0.05 'gave-up)))
+
+;; --- receive: a value already queued is returned immediately, ignoring
+;; the timeout entirely ---
+(test-equal "channel-receive with a ready value does not wait out the timeout"
+  42
+  (let ((ch (make-channel)))
+    (channel-send ch 42)
+    (channel-receive ch 5)))
+
+;; --- send: no timeout-val -> raises on a permanently-full channel ---
+(test-assert "channel-send on a full channel times out and raises"
+  (let ((ch (make-channel 0)))
+    (guard (e (#t (channel-timeout-exception? e)))
+      (channel-send ch 1 0.05)
+      #f)))
+
+;; --- send: with timeout-val -> returns it instead of raising ---
+(test-equal "channel-send on a full channel times out and returns timeout-val"
+  'gave-up
+  (let ((ch (make-channel 0)))
+    (channel-send ch 1 0.05 'gave-up)))
+
+;; --- send: room available completes immediately, ignoring the timeout ---
+(test-equal "channel-send with room available does not wait out the timeout"
+  'ok
+  (let ((ch (make-channel 1)))
+    (channel-send ch 1 5)
+    'ok))
+
+;; --- a fiber timing out on a shared wait still lets siblings run first ---
+;; fiber-join (not a thread-sleep!-based polling loop) drives the wait: a
+;; polling loop on the main fiber would itself be a *second*, concurrently
+;; pending timed wait (thread-sleep!) nested around this one, and nested
+;; timed waits on unrelated fibers are a separate, pre-existing scheduler
+;; hazard (#1490) this test must not trip over.
+(test-equal "a spawned fiber's channel-receive timeout does not block siblings"
+  '(sibling-done timed-out)
+  (let ((ch (make-channel))
+        (log '()))
+    (define timeout-fiber
+      (spawn (lambda ()
+               (guard (e (#t (set! log (cons 'timed-out log))))
+                 (channel-receive ch 0.1)))))
+    (define sibling-fiber
+      (spawn (lambda () (set! log (cons 'sibling-done log)))))
+    (fiber-join sibling-fiber)
+    (fiber-join timeout-fiber)
+    (reverse log)))
+
+;; --- channel-timeout-exception? is #f for other error kinds ---
+(test-assert "channel-timeout-exception? is #f for an ordinary error"
+  (guard (e (#t (not (channel-timeout-exception? e))))
+    (error "not a timeout")
+    #f))
+
+(let ((runner (test-runner-current)))
+  (test-end "fiber-channel-timeout")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-cross-thread-channels.scm
+++ b/tests/scheme/srfi/srfi18-cross-thread-channels.scm
@@ -7,12 +7,14 @@
 ;; thread right before it exits. Together these make cross-thread channels
 ;; actually usable end to end for the first time.
 ;;
-;; Phase 3 (#1468) has not landed yet, so every scenario here is restricted
-;; to "send completes before receive is attempted" interleavings: a receive
-;; on an empty *shared* channel has no wakeup machinery to park on yet.
-;; Ordering is made deterministic via thread-join! (which only returns once
+;; The scenarios through Phase 2's original tests below are restricted to
+;; "send completes before receive is attempted" interleavings, with
+;; ordering made deterministic via thread-join! (which only returns once
 ;; the child is fully done, including any sends it made) rather than by
-;; timing/luck.
+;; timing/luck. Phase 3 (#1468) added cross-thread wakeup (a receive parked
+;; on an empty shared channel now resolves when another thread sends) and
+;; Phase 4 (#1469) added capacity/timeouts/close!, both exercised further
+;; down this file.
 
 (import (scheme base) (scheme write) (scheme process-context)
         (srfi 18) (kaappi fibers) (srfi 64))
@@ -116,6 +118,54 @@
     (guard (e (#t (uncaught-exception? e)))
       (thread-join! t)
       #f)))
+
+;; --- KEP-0002 Phase 4 (#1469): capacity, timeouts, close, now exercised
+;; across real OS threads (Phase 3's cross-thread wakeup makes a receiver
+;; parked in one thread's scheduler resolvable by a send from another).
+
+;; --- bounded shared channel: a full channel backpressures a sender on
+;; another thread until the main thread drains a slot ---
+(test-equal "bounded shared channel: worker thread blocks on a full channel until the main thread receives"
+  '(1 2)
+  (let* ((ch (make-channel 1))
+         (t (make-thread (lambda ()
+                            (channel-send ch 1)  ; fills the one slot
+                            (channel-send ch 2))))) ; must park until drained
+    (thread-start! t)
+    (let ((first (channel-receive ch)))  ; frees the slot -- wakes the worker
+      (thread-join! t) ; only returns once the second send completes
+      (list first (channel-receive ch)))))
+
+;; --- channel-close! from the main thread wakes a channel-receive loop on
+;; a worker thread, draining what was already sent before eof ---
+(test-equal "channel-close! from the main thread wakes a worker's receive loop, draining queued sends first"
+  '(1 2 3)
+  (let* ((ch (make-channel))
+         (t (make-thread
+              (lambda ()
+                (let loop ((acc '()))
+                  (let ((v (channel-receive ch)))
+                    (if (eof-object? v)
+                        (reverse acc)
+                        (loop (cons v acc)))))))))
+    (thread-start! t)
+    (channel-send ch 1)
+    (channel-send ch 2)
+    (channel-send ch 3)
+    (channel-close! ch)
+    (thread-join! t)))
+
+;; --- a timed channel-receive on a shared channel is the documented escape
+;; hatch for §5's weakened deadlock detection: with no other live thread
+;; and no more references, a plain channel-receive would either deadlock
+;; or hang, but a timeout still resolves ---
+(test-equal "timed channel-receive on a shared channel with no future sender returns timeout-val, not a hang"
+  'gave-up
+  (let* ((ch (make-channel))
+         (t (make-thread (lambda () ch)))) ; capturing ch promotes it
+    (thread-start! t)
+    (thread-join! t) ; the thread is now gone; ch stays promoted (sticky)
+    (channel-receive ch 0.05 'gave-up)))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi18-cross-thread-channels")


### PR DESCRIPTION
## Summary

Implements KEP-0002 Phase 4 (issue #1469): the last phase on the critical path before the `(kaappi parallel)` library (Phase 5) can be built.

- **`(make-channel capacity)`** — bounded channels. `channel-send` on a full channel parks (local) or reserves-and-parks (shared, §4) until a receive frees a slot. `(make-channel 0)` is legal but permanently full (no rendezvous handoff — documented, not a bug).
- **`[timeout [timeout-val]]`** on both `channel-send` and `channel-receive`, SRFI-18 shape (same as `thread-join!`): without `timeout-val`, expiry raises `channel-timeout-exception?`; with one, it's returned instead. Works on both the local and shared (cross-thread) representations, including as the documented escape hatch for §5's weakened cross-thread deadlock detection.
- **`channel-close!` / `channel-closed?`** — first-class end-of-stream. Idempotent; wakes all waiters both directions; receivers drain whatever's queued before returning `(eof-object)`; sends after close raise; sending a literal `(eof-object)` is rejected (the one documented backward-compat carve-out).

The §4–6 protocol (reservation-as-admission, the `reserved == 0` EOF guard, unconditional waiter sweep) was already model-checked in Phase 1–3 — I re-ran `keps/research/tla/run.sh` (9 TLC configs) against the KEP's exact pseudocode before writing any code, and all 9 matched their expected pass/fail outcome. Most of the low-level protocol (`shared_channel.zig`'s `send`/`receive`) was already implemented and white-box tested from Phase 1; this phase wires `capacity`/`closed` through the Scheme-visible API, adds the local-channel equivalent, and adds `close()`.

## Also fixed

- Local-channel dispatch (`channelSendFn`/`channelReceiveFn`) was missing the `me.status = .waiting` transition needed for a reactor timer to actually resolve a local wait — without it, `wakeReadyFiber` silently no-ops on a `.running` fiber and a local timeout never fires. Caught by a real end-to-end run, not by the unit suite (which doesn't exercise the local-representation timeout path the same way).

## Found, filed separately (not fixed here — out of scope)

While testing, hit a **pre-existing** crash (`panic: integer overflow` in `invokeEscape`) reproducible with only `thread-sleep!` + an untimed `channel-receive` — no Phase 4 code involved. Root cause: nested `runSchedulerStep` calls can wrongly re-dispatch an *ancestor* fiber (several nesting levels up the real Zig call stack) when that ancestor's own timer pops from a deeper nesting level, corrupting its frame/handler-stack bookkeeping. Filed with full trace and a minimal repro as #1490. This phase's own tests avoid the trigger pattern (documented inline where relevant).

## Test plan

- [x] `zig build test` — full unit suite green, including new `tests_shared_channel.zig` coverage for `close()`, the four required interleaving tests from the model (reserve→concurrent-close→drain-before-eof; workers racing until-eof; failure-path rings eof-waiting receivers; failed-receive re-queue with transient capacity overshoot on a bounded channel)
- [x] `zig build test -Dgc-stress=true` — green
- [x] `bash tests/scheme/run-all.sh` — 1838/1838 pass (443 Scheme files + 1395 R7RS suite), including 3 new smoke test files and an extended `srfi18-cross-thread-channels.scm` (real OS threads: bounded-channel backpressure, close draining a worker's receive loop, timed receive as the deadlock-heuristic escape hatch)
- [x] `zig fmt --check` clean
- [x] Independent code-review pass (correctness-focused) — no findings
- [x] TLA+ model suite re-confirmed green against the KEP's pseudocode before implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)