### PR TITLE
Fix dirty-snapshot dispatch hazard in mutex-lock!/condition-variable-wait

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -47,6 +47,28 @@ pub const Fiber = struct {
     param_overrides: std.AutoHashMap(usize, Value),
     deadline_ns: ?u64 = null,
     timed_out: bool = false,
+    /// True for the entire extent of a runSchedulerStep call this fiber
+    /// itself invoked (set/cleared there, never by callers) -- i.e. this
+    /// fiber's own native frame is still live on the Zig call stack,
+    /// mid-nested-dispatch. scheduleForDispatch() and hasRunnableFibers()
+    /// must never select/count such a fiber as an actual dispatch target,
+    /// even if some wake function flips its `status` to .suspended while
+    /// driving is true: since the whole scheduler runs on one OS thread, a
+    /// fiber with driving == true is always an ancestor of whichever call
+    /// is currently asking (it can only have gotten a nested dispatch by
+    /// dispatching *something*, and that something's own call tree is what
+    /// is presently executing) -- dispatching it from anywhere but its own
+    /// loop would resume its bytecode from a stale, mid-native-call
+    /// register snapshot with the destination register never written (see
+    /// runSchedulerStep's doc comment; #1487). Ancestors can never make
+    /// independent progress while a descendant is active regardless, so
+    /// excluding them from dispatch changes no genuine liveness outcome --
+    /// only the parked fiber's own loop ever consumes its wake. Plain
+    /// schedule() (yieldFn/threadYieldFn's advisory check; vm_calls.zig's
+    /// non-nested switchTo dispatch) deliberately does NOT exclude driving
+    /// fibers -- see scheduleForDispatch's doc comment for why excluding
+    /// them there too reproduces #1440's symptom by a different path.
+    driving: bool = false,
     terminated: bool = false,
     os_thread: ?std.Thread = null,
     /// Set together with `.io_waiting` when a blocking I/O primitive parks
@@ -304,7 +326,39 @@ pub const FiberScheduler = struct {
     /// promptness argument applies to I/O: a zero-timeout reactor poll per
     /// tick wakes ready I/O waiters even while a busy/yielding sibling
     /// keeps the loop from ever reaching parkOnReactor's blocking poll.
+    ///
+    /// Does NOT exclude `driving` fibers — see `scheduleForDispatch`'s doc
+    /// comment for why that exclusion must not live here. This is the
+    /// general "would *anything* becoming runnable matter" query: yieldFn/
+    /// threadYieldFn use it only to decide whether arming the Yielded
+    /// unwind is worthwhile (the returned index itself is discarded), and
+    /// vm_calls.zig's top-level scheduleNextAfterYield/runWithScheduler
+    /// dispatch via switchTo, which — unlike runSchedulerStep — never nests
+    /// another drive, so it carries none of the corruption risk `driving`
+    /// guards against.
     pub fn schedule(self: *FiberScheduler) ?usize {
+        return self.scheduleImpl(false);
+    }
+
+    /// Like `schedule`, but also excludes `driving` fibers — see that
+    /// field's doc comment (#1487). Used only by runSchedulerStep's own
+    /// dispatch loop, the sole call site that actually restoreFiber+
+    /// vm.runUntil()s whatever index this returns: selecting a `driving`
+    /// fiber there would resume its stale, mid-native-call register
+    /// snapshot from a different fiber's nested drive. Plain `schedule()`
+    /// must keep finding these fibers for its other callers (see its own
+    /// doc comment) — excluding them there instead reproduces #1440's
+    /// symptom by a different path: a busy sibling's `(yield)` calls
+    /// yieldFn/threadYieldFn's own `schedule() == null` advisory check,
+    /// which would then see nothing runnable (the driving ancestor whose
+    /// wait *just* resolved is invisible) and silently no-op instead of
+    /// actually yielding, starving that ancestor's own loop of the turn it
+    /// needs to notice and exit.
+    pub fn scheduleForDispatch(self: *FiberScheduler) ?usize {
+        return self.scheduleImpl(true);
+    }
+
+    fn scheduleImpl(self: *FiberScheduler, exclude_driving: bool) ?usize {
         if (self.vm.reactor) |reactor| {
             // KEP-0002 §5's normative consume protocol, checked every tick
             // (not just when idle) for the same promptness reason as the
@@ -331,20 +385,30 @@ pub const FiberScheduler = struct {
         while (i <= n) : (i += 1) {
             const idx = (self.current_idx + i) % n;
             if (self.fibers.items[idx]) |f| {
-                if (f.status == .created or f.status == .suspended) return idx;
+                if ((f.status == .created or f.status == .suspended) and (!exclude_driving or !f.driving)) return idx;
             }
         }
         return null;
     }
 
     /// Used only by parkOnReactor's deadlock check, which runs after
-    /// schedule() has already found nothing .created/.suspended — so this
-    /// deliberately does NOT count .running: under recursive dispatch
-    /// (runSchedulerStep calling runSchedulerStep), every fiber on the
-    /// current call chain back to main is still .running (none flip to
+    /// scheduleForDispatch() has already found nothing .created/.suspended
+    /// — so this deliberately does NOT count .running: under recursive
+    /// dispatch (runSchedulerStep calling runSchedulerStep), every fiber on
+    /// the current call chain back to main is still .running (none flip to
     /// .waiting until they themselves decide to park), so treating .running
     /// as "other progress possible" would make a genuine deadlock loop
     /// forever in reactor.poll() instead of ever detecting it.
+    ///
+    /// Must mirror scheduleForDispatch()'s own `!driving` exclusion (NOT
+    /// plain schedule()'s, which deliberately omits it — see that
+    /// function's doc comment): a fiber that got woken (.suspended) while
+    /// its own nested runSchedulerStep call is still live is always an
+    /// ancestor of whoever's asking (#1487), and scheduleForDispatch() will
+    /// never actually dispatch it — counting it here would make
+    /// parkOnReactor proceed to a real, potentially uncapped reactor.poll()
+    /// with nothing left to ever wake it: a hang, not just a missed
+    /// deadlock error.
     pub fn hasRunnableFibers(self: *FiberScheduler) bool {
         // KEP-0002 §5: a fiber parked on a promoted channel with a live
         // ThreadNotifier registration is "alive, waiting" even though it
@@ -353,7 +417,7 @@ pub const FiberScheduler = struct {
         if (self.shared_waiters.items.len != 0) return true;
         for (self.fibers.items) |f| {
             if (f) |fiber| {
-                if (fiber.status == .created or fiber.status == .suspended)
+                if ((fiber.status == .created or fiber.status == .suspended) and !fiber.driving)
                     return true;
                 if (fiber.status == .waiting and fiber.deadline_ns != null)
                     return true;
@@ -720,13 +784,43 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool
 /// define `pollCapNs(self: Ctx) ?u64` (see parkOnReactor) — omitted by
 /// every Ctx type except the SRFI-18 mutex/condvar waits, which need it for
 /// cross-OS-thread polling.
+///
+/// `me.driving` brackets the whole call (set here, cleared on every exit
+/// via `defer`) regardless of whether the caller also set `me.status =
+/// .waiting` first: it marks that `me`'s native frame is live on the Zig
+/// call stack for the duration, which scheduleForDispatch()/
+/// hasRunnableFibers() must never treat as dispatchable no matter what
+/// happens to `status` while this runs (plain schedule() deliberately
+/// keeps finding `me` regardless — see its own doc comment for why that
+/// half of this split matters just as much as the exclusion does). Without
+/// the exclusion, a wake delivered to `me` by something *this* call itself
+/// (transitively) dispatches — e.g. a sibling fiber's own nested
+/// runSchedulerStep unlocking a mutex `me` is waiting on — flips
+/// `me.status` to `.suspended` while `me`'s real, mid-native-call state is
+/// this saved snapshot; a scheduleForDispatch() reached through that
+/// sibling's own loop (whose `next_idx == my_idx` guard only protects *its
+/// own* index, not `me`'s) would then dispatch `me` from the stale
+/// snapshot, resuming bytecode past the in-flight primitive call with the
+/// destination register never written (#1487; the exact corruption already
+/// fixed for channelReceiveShared's dispatched-fiber path in #1485, but
+/// reachable here from *any* caller of this function, main fiber included,
+/// since a fiber with `driving == true` is always an ancestor of whichever
+/// call is currently asking — the whole scheduler runs on one OS thread, so
+/// it can only have gotten a nested dispatch by dispatching something whose
+/// own call tree is what's presently executing. Ancestors can never make
+/// independent progress while a descendant is active regardless, so
+/// excluding them from selection changes no genuine liveness outcome —
+/// only the parked fiber's own loop, right here, ever consumes its wake).
 pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberScheduler, me: *Fiber) VMError!bool {
     const my_idx = sched.current_idx;
     try sched.saveCurrentFiber();
     const poll_cap_ns: ?u64 = if (@hasDecl(Ctx, "pollCapNs")) ctx.pollCapNs() else null;
 
+    me.driving = true;
+    defer me.driving = false;
+
     while (!ctx.isDone() and !me.timed_out) {
-        const next_idx = sched.schedule() orelse {
+        const next_idx = sched.scheduleForDispatch() orelse {
             if (!(try parkOnReactor(vm, sched, poll_cap_ns))) break;
             continue;
         };

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -824,6 +824,11 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
             if (!(try parkOnReactor(vm, sched, poll_cap_ns))) break;
             continue;
         };
+        // Unreachable in practice since `driving` (set above) now excludes
+        // `me` from scheduleForDispatch() at every index, but kept as
+        // defense-in-depth: this is the narrower guard `driving` subsumes
+        // (it only ever protected this loop's own re-selection of itself,
+        // not the cross-fiber case #1487 fixes).
         if (next_idx == my_idx) break;
 
         try sched.restoreFiber(next_idx);

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -214,14 +214,13 @@ test "sweepSharedWaiters does not clobber a fiber no longer .waiting" {
 // than per call site.
 
 test "scheduleForDispatch() does not select a .suspended fiber whose own nested drive is still live, but plain schedule() still does" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = vm.scheduler.?;
-    const f_val = try vm.eval("f");
+    _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = ctx.vm.scheduler.?;
+    const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
     // Mirrors what a nested wake looks like mid-flight: something woke f
@@ -247,14 +246,13 @@ test "scheduleForDispatch() does not select a .suspended fiber whose own nested 
 }
 
 test "hasRunnableFibers does not count a .suspended fiber whose own nested drive is still live" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = vm.scheduler.?;
-    const f_val = try vm.eval("f");
+    _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = ctx.vm.scheduler.?;
+    const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
     // Must mirror scheduleForDispatch()'s own exclusion -- otherwise
@@ -271,29 +269,28 @@ test "hasRunnableFibers does not count a .suspended fiber whose own nested drive
 }
 
 test "runSchedulerStep sets driving for its whole extent and clears it on return" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = vm.scheduler.?;
+    _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = ctx.vm.scheduler.?;
     const main_fiber = sched.fibers.items[0].?;
-    const f = types.toObject(try vm.eval("f")).as(fiber_mod.Fiber);
+    const f = types.toObject(try ctx.vm.eval("f")).as(fiber_mod.Fiber);
     try std.testing.expect(!main_fiber.driving);
 
     // f completes in one dispatch; the interesting assertion is that
     // driving is cleared again once runSchedulerStep returns normally.
-    _ = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = f }, vm, sched, main_fiber);
+    _ = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = f }, ctx.vm, sched, main_fiber);
     try std.testing.expect(!main_fiber.driving);
     try std.testing.expectEqual(fiber_mod.FiberStatus.completed, f.status);
 
     // The no-progress-possible (genuine deadlock) exit must clear it too.
-    _ = try vm.eval("(define g (spawn (lambda () 1)))");
-    const g = types.toObject(try vm.eval("g")).as(fiber_mod.Fiber);
+    _ = try ctx.vm.eval("(define g (spawn (lambda () 1)))");
+    const g = types.toObject(try ctx.vm.eval("g")).as(fiber_mod.Fiber);
     g.status = .errored; // neutralize: nothing left for schedule() to find
-    const target_fiber = try gc.allocFiber(types.VOID, 999); // never completes/errors
-    const done = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = target_fiber }, vm, sched, main_fiber);
+    const target_fiber = try ctx.gc.allocFiber(types.VOID, 999); // never completes/errors
+    const done = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = target_fiber }, ctx.vm, sched, main_fiber);
     try std.testing.expect(!main_fiber.driving);
     try std.testing.expect(!done);
 }

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -208,6 +208,136 @@ test "sweepSharedWaiters does not clobber a fiber no longer .waiting" {
     try std.testing.expectEqual(@as(usize, 0), sched.shared_waiters.items.len);
 }
 
+// #1487: the generic `driving` guard, closing the dirty-snapshot dispatch
+// hazard for every runSchedulerStep caller at once (mutex-lock!,
+// condition-variable-wait, and any future nested-drive call site) rather
+// than per call site.
+
+test "scheduleForDispatch() does not select a .suspended fiber whose own nested drive is still live, but plain schedule() still does" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+
+    // Mirrors what a nested wake looks like mid-flight: something woke f
+    // (status flipped to .suspended, e.g. by wakeMutexWaiters) while f's
+    // own runSchedulerStep call is still live deeper on the Zig stack.
+    f.status = .suspended;
+    f.driving = true;
+    try std.testing.expectEqual(@as(?usize, null), sched.scheduleForDispatch());
+
+    // Plain schedule() must NOT exclude it -- yieldFn/threadYieldFn's own
+    // "is yielding worthwhile" advisory check relies on schedule() still
+    // finding f here (f's wait having just resolved is exactly the case
+    // where yielding IS worthwhile); excluding it there reproduces #1440's
+    // busy-sibling starvation by a different path (confirmed via
+    // tests/scheme/smoke/fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm
+    // regressing when schedule() itself carried this exclusion).
+    try std.testing.expect(sched.schedule() != null);
+
+    // Once f's own call concludes (driving cleared), it's a real dispatch
+    // target again too.
+    f.driving = false;
+    try std.testing.expect(sched.scheduleForDispatch() != null);
+}
+
+test "hasRunnableFibers does not count a .suspended fiber whose own nested drive is still live" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const f_val = try vm.eval("f");
+    const f = types.toObject(f_val).as(fiber_mod.Fiber);
+
+    // Must mirror scheduleForDispatch()'s own exclusion -- otherwise
+    // parkOnReactor would see "something's runnable" and proceed to a
+    // real, possibly uncapped reactor.poll() with nothing left to ever
+    // wake it (a hang), instead of promptly reporting "no progress
+    // possible right now".
+    f.status = .suspended;
+    f.driving = true;
+    try std.testing.expect(!sched.hasRunnableFibers());
+
+    f.driving = false;
+    try std.testing.expect(sched.hasRunnableFibers());
+}
+
+test "runSchedulerStep sets driving for its whole extent and clears it on return" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
+    const sched = vm.scheduler.?;
+    const main_fiber = sched.fibers.items[0].?;
+    const f = types.toObject(try vm.eval("f")).as(fiber_mod.Fiber);
+    try std.testing.expect(!main_fiber.driving);
+
+    // f completes in one dispatch; the interesting assertion is that
+    // driving is cleared again once runSchedulerStep returns normally.
+    _ = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = f }, vm, sched, main_fiber);
+    try std.testing.expect(!main_fiber.driving);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.completed, f.status);
+
+    // The no-progress-possible (genuine deadlock) exit must clear it too.
+    _ = try vm.eval("(define g (spawn (lambda () 1)))");
+    const g = types.toObject(try vm.eval("g")).as(fiber_mod.Fiber);
+    g.status = .errored; // neutralize: nothing left for schedule() to find
+    const target_fiber = try gc.allocFiber(types.VOID, 999); // never completes/errors
+    const done = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = target_fiber }, vm, sched, main_fiber);
+    try std.testing.expect(!main_fiber.driving);
+    try std.testing.expect(!done);
+}
+
+test "review regression: mutex-lock! contended through a 3-level nested dispatch does not corrupt an unrelated fiber's result" {
+    // Confirmed VM corruption without the driving guard (git-stash A/B, see
+    // tests/scheme/smoke/mutex-nested-dispatch-dirty-snapshot-1487.scm):
+    // fiber b sets .waiting on m1 and starts its own nested drive
+    // (mutexLockFn's while(true) + runSchedulerStep loop), which dispatches
+    // c. c sets .waiting on m2 and starts its own nested drive one level
+    // deeper, which repeatedly redispatches d as d alternates unlocking and
+    // yielding. When d unlocks m1 (waking b) without yet unlocking m2, it's
+    // c's own loop -- not b's -- that next calls scheduleForDispatch().
+    // Before the fix that loop could select b right there, resuming b's
+    // stale, mid-call snapshot from a *different* fiber's nested drive with
+    // the (mutex-lock! m1) destination register never written. Same
+    // corruption class as PR #1485's channelReceiveShared fix, reachable
+    // here because mutex-lock!/mutex-unlock!+condvar still nest a nested
+    // drive after setting .waiting regardless of dispatched status (#1487).
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const result = try ctx.vm.eval(
+        \\(import (srfi 18) (kaappi fibers))
+        \\(define m1 (make-mutex 'm1))
+        \\(define m2 (make-mutex 'm2))
+        \\(define d (spawn (lambda ()
+        \\  (mutex-lock! m1)
+        \\  (mutex-lock! m2)
+        \\  (thread-yield!)
+        \\  (mutex-unlock! m1)
+        \\  (thread-yield!)
+        \\  (mutex-unlock! m2)
+        \\  'd-done)))
+        \\(define b (spawn (lambda () (mutex-lock! m1))))
+        \\(define c (spawn (lambda () (mutex-lock! m2))))
+        \\(fiber-join d)
+        \\(list (fiber-join b) (fiber-join c))
+    );
+    try std.testing.expectEqual(types.TRUE, types.car(result));
+    try std.testing.expectEqual(types.TRUE, types.car(types.cdr(result)));
+}
+
 test "hasRunnableFibers reports a shared-waiter-registry entry as alive" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/tests/scheme/smoke/mutex-nested-dispatch-dirty-snapshot-1487.scm
+++ b/tests/scheme/smoke/mutex-nested-dispatch-dirty-snapshot-1487.scm
@@ -1,0 +1,55 @@
+;; Regression test for #1487: mutex-lock! sets a fiber .waiting and then
+;; keeps nested-driving other fibers in the same native frame (the
+;; while(true) + runSchedulerStep loop in mutexLockFn). If something wakes
+;; that fiber while its own nested drive is still live -- deeper on the Zig
+;; call stack, inside a *different* fiber's own nested drive -- the fiber
+;; becomes visible to schedule()'s round-robin before its real call has
+;; returned. A different fiber's own nested schedule() call could then
+;; dispatch its stale, mid-call register snapshot, resuming bytecode past
+;; the in-flight (mutex-lock! m) call with the destination register never
+;; written. This is the identical corruption class already fixed for
+;; channel-receive in PR #1485, just reachable here through mutex-lock!/
+;; mutex-unlock!+condvar instead of channelReceiveShared.
+;;
+;; Shape: fiber b parks on mutex m1 (held by d) and starts its own nested
+;; drive, which dispatches c. c parks on mutex m2 (also held by d) and
+;; starts its own nested drive one level deeper, which repeatedly
+;; redispatches d as d alternates unlocking and yielding. When d unlocks m1
+;; (waking b) without yet unlocking m2, it is c's own loop -- not b's --
+;; that next calls schedule(). Before the fix, schedule() could select b
+;; right there; with the fix (a generic `driving` flag that schedule()/
+;; hasRunnableFibers() never select/count, set for the whole extent of a
+;; fiber's own runSchedulerStep call), b's own loop is the only thing that
+;; ever consumes its wake.
+;;
+;; Confirmed via git-stash A/B: without the fix, `b`'s result comes back
+;; corrupted (not #t) instead of raising or hanging.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64) (kaappi fibers))
+
+(test-begin "mutex-nested-dispatch-dirty-snapshot-1487")
+
+(define m1 (make-mutex 'm1))
+(define m2 (make-mutex 'm2))
+
+(define d
+  (spawn (lambda ()
+           (mutex-lock! m1)
+           (mutex-lock! m2)
+           (thread-yield!)
+           (mutex-unlock! m1)
+           (thread-yield!)
+           (mutex-unlock! m2)
+           'd-done)))
+
+(define b (spawn (lambda () (mutex-lock! m1))))
+(define c (spawn (lambda () (mutex-lock! m2))))
+
+;; Drives d (and, as a side effect of d's yields, b and c) to completion.
+(test-equal "d completes normally" 'd-done (fiber-join d))
+(test-equal "b's mutex-lock! returns #t, not a corrupted snapshot" #t (fiber-join b))
+(test-equal "c's mutex-lock! returns #t, not a corrupted snapshot" #t (fiber-join c))
+
+(let ((runner (test-runner-current)))
+  (test-end "mutex-nested-dispatch-dirty-snapshot-1487")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/mutex-nested-dispatch-dirty-snapshot-1487.scm
+++ b/tests/scheme/smoke/mutex-nested-dispatch-dirty-snapshot-1487.scm
@@ -3,10 +3,10 @@
 ;; while(true) + runSchedulerStep loop in mutexLockFn). If something wakes
 ;; that fiber while its own nested drive is still live -- deeper on the Zig
 ;; call stack, inside a *different* fiber's own nested drive -- the fiber
-;; becomes visible to schedule()'s round-robin before its real call has
-;; returned. A different fiber's own nested schedule() call could then
-;; dispatch its stale, mid-call register snapshot, resuming bytecode past
-;; the in-flight (mutex-lock! m) call with the destination register never
+;; becomes visible to dispatch selection before its real call has returned.
+;; A different fiber's own nested dispatch-selection call could then select
+;; its stale, mid-call register snapshot, resuming bytecode past the
+;; in-flight (mutex-lock! m) call with the destination register never
 ;; written. This is the identical corruption class already fixed for
 ;; channel-receive in PR #1485, just reachable here through mutex-lock!/
 ;; mutex-unlock!+condvar instead of channelReceiveShared.
@@ -16,11 +16,14 @@
 ;; starts its own nested drive one level deeper, which repeatedly
 ;; redispatches d as d alternates unlocking and yielding. When d unlocks m1
 ;; (waking b) without yet unlocking m2, it is c's own loop -- not b's --
-;; that next calls schedule(). Before the fix, schedule() could select b
-;; right there; with the fix (a generic `driving` flag that schedule()/
-;; hasRunnableFibers() never select/count, set for the whole extent of a
-;; fiber's own runSchedulerStep call), b's own loop is the only thing that
-;; ever consumes its wake.
+;; that next calls scheduleForDispatch(). Before the fix (a single
+;; schedule() used for both dispatch selection and advisory checks), that
+;; call could select b right there; with the fix -- a generic `driving`
+;; flag, set for the whole extent of a fiber's own runSchedulerStep call,
+;; that scheduleForDispatch()/hasRunnableFibers() never select/count (but
+;; plain schedule() deliberately still does, for yieldFn/threadYieldFn's
+;; advisory checks) -- b's own loop is the only thing that ever consumes
+;; its wake.
 ;;
 ;; Confirmed via git-stash A/B: without the fix, `b`'s result comes back
 ;; corrupted (not #t) instead of raising or hanging.


### PR DESCRIPTION
## Summary

Closes #1487.

- `mutex-lock!`, condition-variable-wait (`mutex-unlock!` with a condvar), `thread-join!`'s fiber path, and timed local `channel-send`/`channel-receive` all set a fiber `.waiting` and then call `runSchedulerStep` recursively from the *same* native frame — the identical shape already fixed for shared channels in #1485. If something wakes that fiber (flips it `.suspended`) while its own nested drive is still live deeper on the Zig call stack, a *different* fiber's own nested `schedule()` call can dispatch it from a stale, mid-native-call register snapshot, resuming bytecode past the in-flight primitive call with the destination register never written. Confirmed via a 3-fiber nested mutex-contention repro (git-stash A/B) — without the fix, one fiber's `(mutex-lock! m)` result comes back corrupted instead of `#t`.
- Rather than rewriting each call site to use #1485's `yield_retry` discipline, this lands the issue's alternative suggestion: a generic `driving` guard on `Fiber`, set for the whole extent of any `runSchedulerStep` call and excluded from dispatch-selection regardless of status. A per-site rewrite would have silently broken cross-OS-thread mutex/condvar polling (which depends on the *specific* waiting loop's own periodic recheck) and reintroduced the exact lost-wakeup race the condvar generation-snapshot-before-unlock ordering exists to prevent. The generic guard sidesteps both — and, as a bonus, also closes the identical hazard in `thread-join!` and timed local channel-send/receive, which weren't named in the issue but turn out to have the same bug.
- First attempt at the guard baked the exclusion into `schedule()` itself, which broke `yieldFn`/`threadYieldFn`'s "is yielding worthwhile" advisory check — a busy sibling's `(yield)` calls stopped seeing a driving ancestor whose wait had just resolved, turning yield into a no-op and reproducing issue #1440's starvation symptom by a different path (caught by the existing `fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm` test, which failed consistently, not flakily). Fixed by splitting `schedule()` (unchanged, used by advisory checks and `vm_calls.zig`'s non-nested `switchTo` dispatch) from a new `scheduleForDispatch()` (excludes driving fibers, used only by `runSchedulerStep`'s own dispatch loop).

## Test plan

- [x] `zig build test` (unit suite) green
- [x] `zig build test -Dgc-stress=true` green
- [x] `bash tests/scheme/run-all.sh` — 1839 pass, 0 fail (incl. R7RS suite)
- [x] `zig build wasm` still compiles
- [x] `zig build -Dtarget=x86_64-linux` cross-compiles
- [x] `zig fmt --check` clean
- [x] New regression tests (Zig `tests_scheduler.zig` + Scheme `tests/scheme/smoke/mutex-nested-dispatch-dirty-snapshot-1487.scm`) confirmed to fail without the fix and pass with it via git-stash A/B
- [x] Previously-regressed `fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm` re-verified passing consistently (5/5 runs) after the schedule()/scheduleForDispatch split

🤖 Generated with [Claude Code](https://claude.com/claude-code)