### PR TITLE
Resolve portable SRFI libraries via exe-relative lib/ fallback

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -115,6 +115,18 @@ pub fn build(b: *std.Build) void {
     exe.stack_size = 64 * 1024 * 1024; // 64 MB — u16 register widening increases compiler frame sizes
     b.installArtifact(exe);
 
+    // Portable library sources (.sld/.scm), installed next to the exe so a
+    // from-source build can resolve them via the exe-relative <exe_dir>/../lib
+    // search path (kaappi_paths.getExeRelativeLibDir) with no --lib-path and
+    // no ~/.kaappi/lib (#1523). Mirrors where `zig build lib` puts
+    // libkaappi_rt.a.
+    b.installDirectory(.{
+        .source_dir = b.path("lib"),
+        .install_dir = .lib,
+        .install_subdir = "",
+        .include_extensions = &.{ ".sld", ".scm" },
+    });
+
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| {

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -69,12 +69,16 @@ pub fn getExeRelativeLibDir(buf: []u8) ?[]const u8 {
     var path_buf: [1024]u8 = undefined;
     const exe_path: []const u8 = blk: {
         if (comptime @import("builtin").os.tag == .linux) {
+            // /proc/self/exe is a kernel-resolved canonical path already —
+            // no realpath needed. Reject a result that fills the whole
+            // buffer: readlink doesn't NUL-terminate, and an exact-length
+            // return means the real target may have been truncated.
             const n: isize = std.posix.system.readlink(
                 "/proc/self/exe",
                 &path_buf,
                 path_buf.len,
             );
-            if (n > 0) break :blk path_buf[0..@intCast(n)];
+            if (n > 0 and @as(usize, @intCast(n)) < path_buf.len) break :blk path_buf[0..@intCast(n)];
         }
 
         if (comptime @import("builtin").os.tag == .macos) {
@@ -82,6 +86,18 @@ pub fn getExeRelativeLibDir(buf: []u8) ?[]const u8 {
             const rc = std.c._NSGetExecutablePath(&path_buf, &size);
             if (rc == 0) {
                 const len = std.mem.indexOfScalar(u8, &path_buf, 0) orelse path_buf.len;
+                // _NSGetExecutablePath may return a symlinked or relative
+                // path (e.g. a Homebrew Cellar symlink), which would derive
+                // ../lib from the wrong tree — resolve it to the real path
+                // first. Fall back to the raw path if realpath fails or the
+                // buffer wasn't NUL-terminated within bounds.
+                if (len < path_buf.len) {
+                    var resolved_buf: [std.posix.PATH_MAX]u8 = undefined;
+                    if (std.c.realpath(path_buf[0..len :0], &resolved_buf)) |resolved| {
+                        const rlen = std.mem.indexOfScalar(u8, resolved[0..resolved_buf.len], 0) orelse resolved_buf.len;
+                        break :blk resolved[0..rlen];
+                    }
+                }
                 break :blk path_buf[0..len];
             }
         }
@@ -118,8 +134,11 @@ test "siblingLibDir returns null when the result doesn't fit the buffer" {
 }
 
 test "getExeRelativeLibDir returns a lib dir sibling to the exe's bin dir" {
+    // The test binary itself is always deeply nested (zig-cache output
+    // dirs on every supported platform), so this must not return null —
+    // asserting that keeps a regression in the platform probe from
+    // silently passing.
     var buf: [1024]u8 = undefined;
-    if (getExeRelativeLibDir(&buf)) |dir| {
-        try std.testing.expect(std.mem.endsWith(u8, dir, "/lib"));
-    }
+    const dir = getExeRelativeLibDir(&buf) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.endsWith(u8, dir, "/lib"));
 }

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -29,3 +29,97 @@ test "getHome falls back to HOME/.kaappi" {
             std.c.getenv("KAAPPI_HOME") != null);
     }
 }
+
+/// Computes `<parent-of-bin-dir>/lib` for an executable's own absolute
+/// path, written into `buf`. Split out from `getExeRelativeLibDir` so the
+/// path arithmetic is unit-testable with synthetic paths, independent of
+/// wherever the calling process actually happens to live on disk.
+///
+/// Returns null if `exe_path` isn't nested at least two directories deep
+/// or the resulting path doesn't fit `buf`.
+fn siblingLibDir(exe_path: []const u8, buf: []u8) ?[]const u8 {
+    if (exe_path.len == 0) return null;
+
+    const last_slash = std.mem.lastIndexOfScalar(u8, exe_path, '/') orelse return null;
+    if (last_slash == 0) return null;
+    const bin_dir = exe_path[0..last_slash];
+    const parent_slash = std.mem.lastIndexOfScalar(u8, bin_dir, '/') orelse return null;
+    if (parent_slash == 0) return null;
+    const parent = exe_path[0..parent_slash];
+
+    const suffix = "/lib";
+    if (parent.len + suffix.len > buf.len) return null;
+    @memcpy(buf[0..parent.len], parent);
+    @memcpy(buf[parent.len..][0..suffix.len], suffix);
+    return buf[0 .. parent.len + suffix.len];
+}
+
+/// Returns `<exe_dir>/../lib` — the sibling `lib/` directory next to the
+/// running executable's own `bin/` directory — written into `buf`. This is
+/// the shared layout for both a `zig build` tree (`zig-out/bin/kaappi` +
+/// `zig-out/lib/`) and an installed release (`<prefix>/bin/kaappi` +
+/// `<prefix>/lib/`), so a from-source binary run from any directory can
+/// still find `libkaappi_rt.a` or the portable-library `.sld` sources it
+/// was built alongside.
+///
+/// Returns null if the platform has no self-exe-path lookup, the
+/// executable isn't nested at least two directories deep, or the resulting
+/// path doesn't fit `buf`. Does not check whether the directory exists.
+pub fn getExeRelativeLibDir(buf: []u8) ?[]const u8 {
+    var path_buf: [1024]u8 = undefined;
+    const exe_path: []const u8 = blk: {
+        if (comptime @import("builtin").os.tag == .linux) {
+            const n: isize = std.posix.system.readlink(
+                "/proc/self/exe",
+                &path_buf,
+                path_buf.len,
+            );
+            if (n > 0) break :blk path_buf[0..@intCast(n)];
+        }
+
+        if (comptime @import("builtin").os.tag == .macos) {
+            var size: u32 = path_buf.len;
+            const rc = std.c._NSGetExecutablePath(&path_buf, &size);
+            if (rc == 0) {
+                const len = std.mem.indexOfScalar(u8, &path_buf, 0) orelse path_buf.len;
+                break :blk path_buf[0..len];
+            }
+        }
+
+        break :blk "";
+    };
+    return siblingLibDir(exe_path, buf);
+}
+
+test "siblingLibDir computes the parent-of-bin lib dir" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("/opt/kaappi/lib", siblingLibDir("/opt/kaappi/bin/kaappi", &buf).?);
+}
+
+test "siblingLibDir returns null for a bare filename with no directory" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expect(siblingLibDir("kaappi", &buf) == null);
+}
+
+test "siblingLibDir returns null when the exe has no parent-of-parent dir" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expect(siblingLibDir("/kaappi", &buf) == null);
+}
+
+test "siblingLibDir returns null for an exe only two levels below root" {
+    // "/opt" has no further parent — must not collapse to a bare "/lib".
+    var buf: [128]u8 = undefined;
+    try std.testing.expect(siblingLibDir("/opt/kaappi", &buf) == null);
+}
+
+test "siblingLibDir returns null when the result doesn't fit the buffer" {
+    var buf: [4]u8 = undefined;
+    try std.testing.expect(siblingLibDir("/opt/kaappi/bin/kaappi", &buf) == null);
+}
+
+test "getExeRelativeLibDir returns a lib dir sibling to the exe's bin dir" {
+    var buf: [1024]u8 = undefined;
+    if (getExeRelativeLibDir(&buf)) |dir| {
+        try std.testing.expect(std.mem.endsWith(u8, dir, "/lib"));
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -372,6 +372,24 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 if (z) |zz| _ = setenv(env_name, zz, 1);
             }
         }
+
+        // Last-resort fallback: <exe_dir>/../lib, so a from-source build
+        // (`zig build`, no installer, no ~/.kaappi/lib) can still resolve
+        // portable SRFI .sld sources when run from outside the checkout
+        // (#1523). Checked after ~/.kaappi/lib so an existing install is
+        // never shadowed by whatever the running binary was built from.
+        const exe_lib_path = blk: {
+            const kaappi_paths = @import("kaappi_paths.zig");
+            var exe_lib_buf: [1024]u8 = undefined;
+            const elp = kaappi_paths.getExeRelativeLibDir(&exe_lib_buf) orelse break :blk null;
+            break :blk allocator.dupe(u8, elp) catch null;
+        };
+        if (exe_lib_path) |elp| {
+            if (lib_path_count < 16) {
+                lib_paths[lib_path_count] = elp;
+                lib_path_count += 1;
+            }
+        }
     }
 
     vm.lib_paths = lib_paths[0..lib_path_count];

--- a/src/main.zig
+++ b/src/main.zig
@@ -337,8 +337,9 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     }
 
     if (!is_wasm) {
+        const kaappi_paths = @import("kaappi_paths.zig");
+
         const kaappi_lib_path = blk: {
-            const kaappi_paths = @import("kaappi_paths.zig");
             var home_buf: [512]u8 = undefined;
             const home = kaappi_paths.getHome(&home_buf) orelse break :blk null;
             const lib_suffix = "/lib";
@@ -379,7 +380,6 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         // (#1523). Checked after ~/.kaappi/lib so an existing install is
         // never shadowed by whatever the running binary was built from.
         const exe_lib_path = blk: {
-            const kaappi_paths = @import("kaappi_paths.zig");
             var exe_lib_buf: [1024]u8 = undefined;
             const elp = kaappi_paths.getExeRelativeLibDir(&exe_lib_buf) orelse break :blk null;
             break :blk allocator.dupe(u8, elp) catch null;

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -7,6 +7,7 @@ const ir_mod = @import("ir.zig");
 const llvm_emit = @import("llvm_emit.zig");
 const file_utils = @import("file_utils.zig");
 const reporting = @import("reporting.zig");
+const kaappi_paths = @import("kaappi_paths.zig");
 
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
@@ -235,40 +236,10 @@ fn findLibDir(allocator: std.mem.Allocator) ?[]const u8 {
 }
 
 fn getExeRelativeLibDir(allocator: std.mem.Allocator) ?[]const u8 {
-    var path_buf: [1024]u8 = undefined;
-    const exe_path: []const u8 = blk: {
-        if (comptime @import("builtin").os.tag == .linux) {
-            const n: isize = std.posix.system.readlink(
-                "/proc/self/exe",
-                &path_buf,
-                path_buf.len,
-            );
-            if (n > 0) break :blk path_buf[0..@intCast(n)];
-        }
-
-        if (comptime @import("builtin").os.tag == .macos) {
-            var size: u32 = path_buf.len;
-            const rc = std.c._NSGetExecutablePath(&path_buf, &size);
-            if (rc == 0) {
-                const len = std.mem.indexOfScalar(u8, &path_buf, 0) orelse path_buf.len;
-                break :blk path_buf[0..len];
-            }
-        }
-
-        break :blk "";
-    };
-    if (exe_path.len == 0) return null;
-
-    const last_slash = std.mem.lastIndexOfScalar(u8, exe_path, '/') orelse return null;
-    if (last_slash == 0) return null;
-    const bin_dir = exe_path[0..last_slash];
-    const parent_slash = std.mem.lastIndexOfScalar(u8, bin_dir, '/') orelse return null;
-    const parent = exe_path[0..parent_slash];
-
-    const lib_dir = std.fmt.allocPrint(allocator, "{s}/lib", .{parent}) catch return null;
-    if (checkLibDir(allocator, lib_dir)) return lib_dir;
-    allocator.free(lib_dir);
-    return null;
+    var buf: [1024]u8 = undefined;
+    const dir = kaappi_paths.getExeRelativeLibDir(&buf) orelse return null;
+    if (!checkLibDir(allocator, dir)) return null;
+    return allocator.dupe(u8, dir) catch null;
 }
 
 fn collectRedefinedNames(expr: types.Value, map: *std.StringHashMap(void)) void {

--- a/tests/scheme/smoke/exe-relative-lib-1523.sh
+++ b/tests/scheme/smoke/exe-relative-lib-1523.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Regression test for #1523: a from-source build (`zig build`, no installer,
+# no ~/.kaappi/lib) must resolve portable SRFI .sld libraries when the
+# binary is invoked from a directory unrelated to the source checkout, with
+# no --lib-path. build.zig installs lib/ into zig-out/lib/ next to the exe,
+# and main.zig adds <exe_dir>/../lib as a fallback search path
+# (kaappi_paths.getExeRelativeLibDir) so the two line up.
+#
+# The cwd must actually change to an unrelated directory (not just point
+# the script argument elsewhere) — resolveLibraryPath's cwd-relative "" and
+# "lib/" prefixes are checked before any search path, and this repo's own
+# checkout has a lib/srfi/151.sld that would otherwise mask a broken fix.
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+# Runs the isolated binary with cwd = $TMPDIR_TESTS/elsewhere, a fake empty
+# HOME, and no --lib-path.
+run_isolated() {
+    (cd "$TMPDIR_TESTS/elsewhere" && \
+        env -u KAAPPI_HOME -u KAAPPI_LIB_DIR HOME="$TMPDIR_TESTS/emptyhome" \
+        "$TMPDIR_TESTS/dist/bin/kaappi" portable-srfi.scm)
+}
+
+assert_isolated_exit() {
+    local label="$1" expected="$2"
+    local status=0
+    run_isolated > "$TMPDIR_TESTS/out.txt" 2>&1 || status=$?
+    if [[ "$status" -eq "$expected" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected exit $expected, got $status"
+        cat "$TMPDIR_TESTS/out.txt"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+SRC_LIB_DIR="$(dirname "$KAAPPI_ABS")/../lib"
+
+if [[ ! -f "$SRC_LIB_DIR/srfi/151.sld" ]]; then
+    echo "SKIP: exe-relative-lib-1523 (no $SRC_LIB_DIR/srfi/151.sld — rebuild with 'zig build')"
+    exit 0
+fi
+
+# Isolated distribution layout: <dist>/bin/kaappi + <dist>/lib/... , mirroring
+# both a `zig build` tree and an installed release.
+mkdir -p "$TMPDIR_TESTS/dist/bin" "$TMPDIR_TESTS/elsewhere" "$TMPDIR_TESTS/emptyhome"
+cp "$KAAPPI_ABS" "$TMPDIR_TESTS/dist/bin/kaappi"
+cp -r "$SRC_LIB_DIR" "$TMPDIR_TESTS/dist/lib"
+
+cat > "$TMPDIR_TESTS/elsewhere/portable-srfi.scm" <<'SCM'
+(import (scheme base) (scheme write) (srfi 151))
+(display (bitwise-ior 1 2))
+(newline)
+SCM
+
+# The exact repro from #1523: cwd outside the checkout, HOME pointed at an
+# empty directory (so ~/.kaappi/lib can't mask the failure), no --lib-path.
+assert_isolated_exit "portable SRFI resolves via exe-relative lib/ with no --lib-path" 0
+
+if grep -q "^3$" "$TMPDIR_TESTS/out.txt"; then
+    echo "PASS: (bitwise-ior 1 2) prints 3"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: unexpected output for (bitwise-ior 1 2)"
+    cat "$TMPDIR_TESTS/out.txt"
+    FAIL=$((FAIL + 1))
+fi
+
+# Negative control: the same isolated binary with no sibling lib/ at all
+# must fail the same way the bug report did, proving the positive case above
+# actually exercises the exe-relative fallback rather than some other path.
+# The .sbc bytecode cache from the run above would otherwise let this load
+# straight from cached bytecode without re-resolving the library — delete it
+# first so the negative control genuinely re-imports (srfi 151).
+rm -rf "$TMPDIR_TESTS/dist/lib"
+rm -f "$TMPDIR_TESTS/elsewhere/portable-srfi.sbc"
+assert_isolated_exit "portable SRFI import fails without a sibling lib/" 1
+
+echo ""
+echo "$PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

- `resolveLibraryPath` only checked cwd-relative paths, `--lib-path`, the running script's own directory, and `~/.kaappi/lib` — none of which point at a `zig build`-produced binary's own source tree, so a from-source binary run from any other directory (no prior `thottam`/installer setup) couldn't resolve portable (non-built-in) SRFI `.sld` libraries.
- Adds a shared exe-relative lib-dir lookup (`kaappi_paths.getExeRelativeLibDir`/`siblingLibDir`), mirroring the `<exe_dir>/../lib` search already used to find `libkaappi_rt.a` for the native backend.
- `build.zig` now installs `lib/` into `zig-out/lib/` alongside the exe (via `b.installDirectory`) so the two line up.
- `main.zig` adds that directory as a last-resort fallback to `vm.lib_paths`, after `~/.kaappi/lib` so an existing install is never shadowed.
- `native_compiler.zig`'s near-duplicate local copy of the exe-path lookup now delegates to the shared helper instead of duplicating the platform-specific logic.

Fixes #1523.

## Test plan

- [x] Reproduced the exact issue scenario (fresh checkout copy, `zig build`, run from an unrelated directory with `HOME` pointed at an empty dir, no `--lib-path`) — failed before the fix with the reported `library not found: (srfi.151)` error, succeeds after.
- [x] Added `tests/scheme/smoke/exe-relative-lib-1523.sh`: isolates a built `bin/kaappi` + sibling `lib/` into a temp "distribution" layout, runs from an unrelated cwd with empty `HOME`, asserts a portable SRFI import succeeds with no `--lib-path`, plus a negative control (same binary, no sibling `lib/`, must fail the same way the bug did).
- [x] Added Zig unit tests for `siblingLibDir`/`getExeRelativeLibDir` in `src/kaappi_paths.zig`, including an edge case a review pass caught (a 2-level exe path like `/opt/kaappi` was collapsing to a bogus root `/lib` instead of returning `null`).
- [x] `zig build test` — all unit tests pass.
- [x] `bash tests/scheme/run-all.sh` — 1839/1839 pass (444 Scheme files + 1395 R7RS suite).
- [x] `zig fmt --check` clean.
- [x] Re-verified `kaappi compile` (LLVM native backend, via the refactored `native_compiler.zig`) still links and runs correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)