### PR TITLE
Preserve a closure's lib_env when deep-copying across threads (#1479)

### DIFF
--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -138,7 +138,23 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             new_func.source_line = func.source_line;
             new_func.source_name = func.source_name;
             new_func.global_cache = null;
-            new_func.env = null;
+            // Preserve the defining library's lib_env so a closure copied to
+            // a child OS thread can still resolve library-scoped names
+            // (#1479). `env` is a raw *StringHashMap pointer into the shared
+            // library registry (initForThread shares vm.libraries by pointer,
+            // and the parent keeps every lib_env alive), not a GC Value — the
+            // collector never traverses it, and looking a name up through it
+            // yields a parent-heap procedure the child runs exactly as it
+            // already runs any shared global. Nulling it (the old behavior)
+            // silently redirected the lookup to `self.globals`, where
+            // library-scoped imports don't live, so the child raised
+            // "undefined variable" for a name that worked at top level.
+            new_func.env = func.env;
+            // env_val (the eval/immutability Environment *object*) is a GC
+            // Value; leave it NIL rather than share a parent-heap object into
+            // the child heap. Runtime name resolution uses `env` (above), not
+            // env_val, so the thread thunk resolves correctly regardless; a
+            // normally loaded library has env_val == NIL here anyway.
             new_func.env_val = types.NIL;
             if (func.name) |name| {
                 if (func.owns_name) {

--- a/tests/scheme/smoke/lib1479/spawner.sld
+++ b/tests/scheme/smoke/lib1479/spawner.sld
@@ -1,0 +1,20 @@
+(define-library (lib1479 spawner)
+  (export run-in-thread run-in-thread/guarded)
+  (import (scheme base) (srfi 18) (lib1479 worker))
+  (begin
+    ;; run-in-thread is defined INSIDE this library body; its thread thunk
+    ;; calls do-work, exported from the *other* library (lib1479 worker).
+    (define (run-in-thread x)
+      (let ((t (make-thread (lambda () (do-work x)))))
+        (thread-start! t)
+        (thread-join! t)))
+    ;; Same shape as kaappi-http's http-listen-threaded: the thunk wraps the
+    ;; cross-library call in a guard. Before the fix, the undefined-variable
+    ;; error was caught here and swallowed (a silent hang for an HTTP client).
+    (define (run-in-thread/guarded x)
+      (let ((t (make-thread
+                 (lambda ()
+                   (guard (e (#t (list 'swallowed-error x)))
+                     (do-work x))))))
+        (thread-start! t)
+        (thread-join! t)))))

--- a/tests/scheme/smoke/lib1479/worker.sld
+++ b/tests/scheme/smoke/lib1479/worker.sld
@@ -1,0 +1,8 @@
+(define-library (lib1479 worker)
+  (export do-work)
+  (import (scheme base))
+  (begin
+    ;; A helper bound in THIS library's own scope -- do-work must resolve it
+    ;; through its own lib_env even when called from a child thread.
+    (define (helper x) (* x 2))
+    (define (do-work x) (+ (helper x) 1))))

--- a/tests/scheme/smoke/library-thread-cross-call-1479.scm
+++ b/tests/scheme/smoke/library-thread-cross-call-1479.scm
@@ -1,0 +1,24 @@
+;; Regression test for #1479: a procedure defined inside a define-library
+;; body that thread-start!s a thunk which calls into ANOTHER library's
+;; exported procedure. The thunk closure is deep-copied to the child OS
+;; thread; before the fix, deep-copy dropped the closure's lib_env
+;; (gc_deep_copy.zig set new_func.env = null), so the child raised "undefined
+;; variable" for the cross-library name. kaappi-http's http-listen-threaded
+;; hit exactly this -- its guard swallowed the error, so the client just saw
+;; a hung connection.
+(import (scheme base) (srfi 64) (lib1479 spawner))
+
+(test-begin "library-thread-cross-call-1479")
+
+;; do-work x = (+ (* x 2) 1); the child must resolve do-work across libraries
+;; AND do-work must resolve its own library-scoped `helper`.
+(test-equal "child thread resolves another library's procedure"
+            21 (run-in-thread 10))
+;; The http-shaped guarded thunk must now return the real result, not a
+;; swallowed undefined-variable error.
+(test-equal "guarded thunk returns the real cross-library result"
+            43 (run-in-thread/guarded 21))
+
+(let ((runner (test-runner-current)))
+  (test-end "library-thread-cross-call-1479")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Closes #1479. A procedure defined inside a `define-library` body that `thread-start!`s a thunk which calls into **another library's** exported procedure hung on every request in `kaappi-http`'s `http-listen-threaded` (and raised `undefined variable` when unguarded). The identical code defined at **top level** worked — the tell that this was about library scoping.

## Root cause

`GC.deepCopy` copies the thunk closure from the parent GC to the child OS thread's GC. It set `new_func.env = null`.

Runtime name resolution is `env = the_func.env orelse self.globals` (`vm_dispatch.zig`), and each `Function` carries its defining library's `lib_env` in `env`. Nulling it on copy silently redirected **every** lookup in the child to the shared `globals` map — where library-scoped imports don't live. So the child couldn't resolve the cross-library name:

- **unguarded** → `undefined variable 'b-work'` re-raised out of `thread-join!`
- **guarded** (http's shape) → the `guard` swallowed it and closed the socket → the client saw a **hung** connection

Top-level worked because a top-level import lands in `globals`, exactly where `env == null` already looks.

## Fix

Preserve `new_func.env = func.env`. This is safe and consistent with the existing share-nothing-except-the-registry threading model:

- `env` is a raw `*StringHashMap` pointer into the **shared** library registry — `VM.initForThread` shares `vm.libraries` by pointer and the parent keeps every `lib_env` alive for the child's lifetime. The child resolving names through it, and running the parent-heap procedures it finds, is exactly how it already runs any shared global (`car`, `+`, bootstrap closures…).
- It's **not** a GC `Value`, so the collector never traverses it and no cross-heap mark bit is written (`#958`). A `lib_env` is self-contained (imports copy in all of `(scheme base)` etc.), so resolving *all* names through it works.
- `env_val` (the eval/immutability Environment *object*, a GC `Value`) stays `NIL` rather than sharing a parent-heap object into the child heap. Runtime resolution uses `env`, not `env_val`, and a normally loaded library has `env_val == NIL` here anyway.

## Reproduction (core-only, no ecosystem libs)

Per the issue's suggested first step — confirmed this needs **no** `kaappi-net`/`kaappi-http`, just two throwaway libraries: a library-defined procedure whose thread thunk calls another library's export. That's captured as the regression test.

## Tests

`tests/scheme/smoke/library-thread-cross-call-1479.scm` (+ `lib1479/` fixtures) covers the plain form, the `guard`-wrapped http shape, and the callee resolving its **own** library-scoped helper. It **fails (exit 1) without the fix, passes with it**. Green: full unit suite, `-Dgc-stress=true` for the srfi18 cross-thread deep-copy tests, and the full Scheme suite (449 files, 0 fail, 0 timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)