### PR TITLE
Add fd->port to give a raw fd reactor-integrated I/O (#1478)

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -55,6 +55,11 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "with-output-to-file", .func = &withOutputToFile, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_file, .scheme_r5rs }), .sandbox = false },
     .{ .name = "open-binary-input-file", .func = &openBinaryInputFile, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_file), .sandbox = false },
     .{ .name = "open-binary-output-file", .func = &openBinaryOutputFile, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_file), .sandbox = false },
+    // Exposed via (kaappi ffi) — the library FFI socket code (kaappi-net)
+    // already imports — so a raw fd from an FFI call can be given reactor-
+    // integrated non-blocking I/O (#1478). Not in sandbox: it is a raw
+    // capability over an arbitrary descriptor.
+    .{ .name = "fd->port", .func = &fdToPort, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_ffi), .sandbox = false },
 };
 
 // ---------------------------------------------------------------------------
@@ -540,6 +545,32 @@ fn openBinaryOutputFile(args: []const Value) PrimitiveError!Value {
     const result = try openOutputFile(args);
     types.toObject(result).as(types.Port).is_binary = true;
     return result;
+}
+
+/// (fd->port fd) — wrap a raw OS file descriptor as a bidirectional binary
+/// port. Every read/write then goes through the same non-blocking,
+/// reactor-integrated path as file ports (readOneByte/portWriteBytes): an
+/// operation that would block suspends the calling fiber on the reactor
+/// instead of the OS thread, and the fd flips to O_NONBLOCK lazily the first
+/// time it's touched under a scheduler. This is the bridge that lets an FFI
+/// socket (kaappi-net) get real event-driven wakeup for free instead of a
+/// poll-then-sleep loop (#1478).
+///
+/// The port takes ownership of the fd: close-port closes it (fd > 2), wakes
+/// any fiber parked on it, and unregisters it from the reactor. The caller
+/// must not also close the fd through its own path, or the number could be
+/// recycled onto an unrelated port.
+fn fdToPort(args: []const Value) PrimitiveError!Value {
+    if (comptime is_wasm) return primitives.typeError("fd->port", "non-WASM platform", args[0]);
+    if (!types.isFixnum(args[0])) return primitives.typeError("fd->port", "file descriptor", args[0]);
+    const fd_i = types.toFixnum(args[0]);
+    // Reject the standard streams (whose blocking semantics other code
+    // relies on) and anything outside fd_t's range.
+    if (fd_i < 3 or fd_i > std.math.maxInt(i32)) return primitives.typeError("fd->port", "socket/pipe file descriptor (> 2)", args[0]);
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const port_val = gc.allocPort(@intCast(fd_i), true, true, "fd", false) catch return PrimitiveError.OutOfMemory;
+    types.toObject(port_val).as(types.Port).is_binary = true;
+    return port_val;
 }
 
 fn closePort(args: []const Value) PrimitiveError!Value {

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -383,3 +383,49 @@ test "file I/O with fibers active stays correct (files never EAGAIN)" {
     );
     try std.testing.expectEqual(types.TRUE, r);
 }
+
+// #1478: (fd->port fd) hands a raw FFI descriptor (a kaappi-net socket) the
+// same reactor-integrated, non-blocking I/O the built-in file ports get, so a
+// blocking-looking read suspends the fiber on the reactor instead of
+// busy-polling the fd with a 1ms sleep.
+
+test "#1478: fd->port read parks the fiber on the reactor until the peer writes" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The two fd->port ports take ownership of these fds; the GC's freeObject
+    // (or close-port) closes them, so the test must not close them itself.
+    const pipe = makePipe();
+
+    // reader parks on an empty pipe (EAGAIN -> reactor); writer fills it. If
+    // fd->port didn't route through the reactor, the reader would either
+    // block the whole thread on a blocking read or spin -- here it must wake
+    // exactly when the byte arrives and read it back.
+    var buf: [768]u8 = undefined;
+    const src = try std.fmt.bufPrint(&buf,
+        \\(import (kaappi ffi) (kaappi fibers) (scheme base))
+        \\(define rp (fd->port {d}))
+        \\(define wp (fd->port {d}))
+        \\(define reader (spawn (lambda () (read-u8 rp))))
+        \\(define writer (spawn (lambda () (write-u8 66 wp) (flush-output-port wp))))
+        \\(fiber-join writer)
+        \\(fiber-join reader)
+    , .{ pipe[0], pipe[1] });
+
+    const result = try vm.eval(src);
+    try std.testing.expectEqual(@as(i64, 66), types.toFixnum(result));
+}
+
+test "#1478: fd->port rejects the standard streams and non-fixnums" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(import (kaappi ffi))");
+    // fd 0/1/2 keep their blocking semantics -- fd->port must refuse them.
+    try std.testing.expectError(error.TypeError, vm.eval("(fd->port 1)"));
+    try std.testing.expectError(error.TypeError, vm.eval("(fd->port \"nope\")"));
+}


### PR DESCRIPTION
## Summary

Part of #1478. `kaappi-net`'s TCP sockets never reach the fiber I/O reactor — `tcp-recv`/`tcp-send` are bare blocking `send(2)`/`recv(2)` FFI calls, and `poll-read`/`poll-write` are a raw `fcntl`+`poll(2)` wrapper. None touch `Reactor.register`/`waitForFd`, so `http-listen-fiber` layers a fixed **1 ms poll-then-sleep loop** on top (a ~1 ms tax on every request even fully uncontended: 747 vs 3329 req/s at concurrency 1 in the Phase 7 benchmarks).

This is the **core half** of the fix: a primitive to bridge a raw FFI descriptor into the reactor. The `kaappi-net` adoption is a separate PR in that repo (pure Scheme — its sockets are already plain fd integers).

## Why a port, not a `wait-for-fd` primitive

A standalone "wait until this fd is ready" primitive can't work under the park/re-execution protocol: it never drains the fd, so a re-executed park would re-park forever. The primitives that *do* work (`readOneByte`/`portWriteBytes`) do **try-syscall-then-wait-on-EAGAIN as one unit**, and every port fd > 2 already flips to `O_NONBLOCK` lazily and suspends the fiber on the reactor.

So expose that machinery directly: **`(fd->port fd)`** wraps a raw descriptor as a bidirectional binary port. A socket fd then becomes a normal reactor-integrated port — `read-u8`/`read-bytevector!`/`write-bytevector` suspend the fiber on `EAGAIN` instead of busy-polling.

## Semantics

- **Bidirectional binary** (sockets are byte streams, read + write on one fd).
- **Owns the fd**: `close-port` closes it (fd > 2), wakes parked fibers, unregisters from the reactor. The caller must not also close it directly.
- **Refuses fd 0/1/2**, whose blocking semantics other code relies on, and non-fixnums.
- Lives in **`(kaappi ffi)`**, which FFI socket libraries already import.

## Tests

`tests_port_io.zig`: a reader fiber on an `fd->port` pipe **parks on the reactor and wakes exactly when the peer writes** (proves real event-driven wakeup, not polling); fd 0/1/2 and non-fixnums are rejected. Green under the full unit suite and `-Dgc-stress=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)