### PR TITLE
Clear stale gap registers before call/cc continuation capture (#1464)

### DIFF
--- a/src/tests_continuations.zig
+++ b/src/tests_continuations.zig
@@ -537,3 +537,25 @@ test "escape continuation from inside map exits map early" {
     );
     try std.testing.expectEqualStrings("escaped", types.symbolName(result));
 }
+
+// Regression (#1464, fuzz-derived): call/cc must not snapshot stale pointers
+// left in dead "gap" registers between live frame windows. The first form
+// leaves heap pointers in low registers; the guard/call/cc form then captures
+// a contiguous register range spanning those now-dead slots. Under gc-stress
+// the collector frees the stale targets — markVMRoots walks only per-frame
+// windows, so nothing keeps them alive — and marking the continuation's
+// snapshot would dereference a freed object without the gap-clearing fix.
+test "call/cc does not capture stale gap registers (#1464)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Evaluating without a crash (especially under -Dgc-stress=true) is the
+    // assertion; the second form's value (1) is incidental.
+    const result = try vm.eval(
+        \\(define g0 (let* ((h '(1 2 3)) (u (lambda (a b c) c))) 0))
+        \\(guard (e (#t 1)) (call/cc (lambda (k) (let ((u (lambda (a b) b)) (v 1)) v))))
+    );
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(result));
+}

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -15,25 +15,29 @@ const MAX_WINDS = vm_mod.MAX_WINDS;
 /// pointers keep nothing alive and a later collection frees their targets —
 /// which is why a continuation snapshot taken over the contiguous `[0, max_reg)`
 /// range must not copy them verbatim (#1464). Called before every snapshot.
+///
+/// Frame bases are non-decreasing (every call places its callee's frame past
+/// the caller's own base, and continuation restore preserves that order), so a
+/// single ordered sweep that tracks the highest covered register finds the gaps
+/// with no scratch buffer — keeping call/cc capture allocation-free on the hot
+/// path (a bitmap here regressed the call_cc benchmark ~1.9x).
 fn clearGapRegisters(vm: *VM, max_reg: usize) void {
-    if (max_reg == 0) return;
-    // The union of live frame windows is exactly what markVMRoots protects.
-    const covered = vm.gc.allocator.alloc(bool, max_reg) catch {
-        // No scratch memory: leave the registers as-is. The snapshot may then
-        // copy a stale gap pointer (the pre-existing hazard), but this is only
-        // reachable under genuine OOM, where capture is about to fail anyway.
-        return;
-    };
-    defer vm.gc.allocator.free(covered);
-    @memset(covered, false);
+    var covered_end: usize = 0;
+    var prev_base: usize = 0;
     for (vm.frames[0..vm.frame_count]) |f| {
-        const start = @min(@as(usize, f.base), max_reg);
-        const end = @min(@as(usize, f.base) + f.frameWindow(), max_reg);
-        for (covered[start..end]) |*c| c.* = true;
+        const base: usize = f.base;
+        std.debug.assert(base >= prev_base); // relied on for gap correctness
+        prev_base = base;
+        if (base > covered_end) {
+            const gap_end = @min(base, max_reg);
+            @memset(vm.registers[covered_end..gap_end], types.UNDEFINED);
+            if (gap_end == max_reg) return;
+        }
+        const win_end = base + f.frameWindow();
+        if (win_end > covered_end) covered_end = win_end;
     }
-    for (vm.registers[0..max_reg], covered) |*slot, is_covered| {
-        if (!is_covered) slot.* = types.UNDEFINED;
-    }
+    if (covered_end < max_reg)
+        @memset(vm.registers[covered_end..max_reg], types.UNDEFINED);
 }
 
 /// Capture the current continuation state.

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -8,6 +8,34 @@ const VMError = vm_mod.VMError;
 const MAX_HANDLERS = vm_mod.MAX_HANDLERS;
 const MAX_WINDS = vm_mod.MAX_WINDS;
 
+/// Clear register slots in `[0, max_reg)` that no live frame window covers,
+/// setting each to UNDEFINED. Such gap slots are dead (no frame reads them),
+/// but one vacated by a returned call frame typically still holds that frame's
+/// last pointer. The GC root marker walks only per-frame windows, so those
+/// pointers keep nothing alive and a later collection frees their targets —
+/// which is why a continuation snapshot taken over the contiguous `[0, max_reg)`
+/// range must not copy them verbatim (#1464). Called before every snapshot.
+fn clearGapRegisters(vm: *VM, max_reg: usize) void {
+    if (max_reg == 0) return;
+    // The union of live frame windows is exactly what markVMRoots protects.
+    const covered = vm.gc.allocator.alloc(bool, max_reg) catch {
+        // No scratch memory: leave the registers as-is. The snapshot may then
+        // copy a stale gap pointer (the pre-existing hazard), but this is only
+        // reachable under genuine OOM, where capture is about to fail anyway.
+        return;
+    };
+    defer vm.gc.allocator.free(covered);
+    @memset(covered, false);
+    for (vm.frames[0..vm.frame_count]) |f| {
+        const start = @min(@as(usize, f.base), max_reg);
+        const end = @min(@as(usize, f.base) + f.frameWindow(), max_reg);
+        for (covered[start..end]) |*c| c.* = true;
+    }
+    for (vm.registers[0..max_reg], covered) |*slot, is_covered| {
+        if (!is_covered) slot.* = types.UNDEFINED;
+    }
+}
+
 /// Capture the current continuation state.
 /// dst_reg is the register offset within the caller's frame where the result of call/cc will go.
 /// dst_base is the base register of the caller's frame.
@@ -54,6 +82,12 @@ pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u32) VMError!Value {
             .frame_count = h.frame_count,
         };
     }
+
+    // The snapshot below copies the contiguous [0, max_reg) register range,
+    // which spans dead gaps between live frame windows. Scrub stale pointers
+    // out of those gaps first so the snapshot can't outlive their targets
+    // (#1464); restore never reads a gap slot, so this is behavior-preserving.
+    clearGapRegisters(vm, max_reg);
 
     const cont_val = vm.gc.allocContinuation(
         vm.registers[0..max_reg],


### PR DESCRIPTION
## Summary

Fixes #1464 — a real GC use-after-free surfaced by the `gc-stress` fuzz job (which the report workflow misfiled as an "infrastructure or build failure"; the run's `.zig-cache/f/crash` was an actual finding).

A full `call/cc` continuation snapshots the **contiguous** register range `[0, max_reg)`. That range spans "gap" registers between live frame windows — slots vacated by returned frames that still hold that frame's last heap pointer. `markVMRoots` marks only **per-frame windows**, so it never keeps a gap target alive; under gc-stress the collector frees it, leaving the gap register dangling. `captureContinuation` copied the gap verbatim into the snapshot, and marking that continuation later dereferenced the freed object — a segfault in `markValueInner` reading `obj.owner` (`0xAA` freed-memory poison in Debug).

The fix (`clearGapRegisters`) scrubs the dead gap slots to `UNDEFINED` before the snapshot, so it covers exactly what the root marker protects. It's behavior-preserving: no frame ever reads a gap slot, and restore copies them back dead.

## Reproduction & test

I decoded the crash's Smith decision stream through `fuzz_gen.generateProgram`, then delta-debugged the 2240-byte program down to a deterministic minimal case, now a regression test in `tests_continuations.zig`:

```scheme
(define g0 (let* ((h '(1 2 3)) (u (lambda (a b c) c))) 0))
(guard (e (#t 1)) (call/cc (lambda (k) (let ((u (lambda (a b) b)) (v 1)) v))))
```

It segfaults without the fix under `-Dgc-stress=true` and passes with it. The prior top-level form is load-bearing — it leaves the stale pointers in low registers (cross-form register persistence).

## Verification

- Full normal unit suite: pass
- Full `zig build test -Dgc-stress=true`: pass (854 pass, 6 intentional skips)
- Regression test: crashes without the fix, passes with it

## Follow-up (not in this PR)

The fiber scheduler has the identical inconsistency — `saveCurrentFiber`/`markFiberState` use a contiguous register span while running fibers are marked per-frame (`FiberScheduler.markRoots` skips the running fiber). It's real by inspection but I couldn't build a crashing reproducer (very layout-sensitive), so it's kept out of this focused fix and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)