### PR TITLE
Bound fuzz eval by instruction count under gc-stress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Run the fuzz generator-coverage gates (grammar/native/portable evaluate-rate and the differential oracle) under `-Dgc-stress=true` by bounding evaluation with an instruction budget instead of the wall-clock deadline a stress build makes meaningless (#1447)
+
 ## [0.14.1] - 2026-07-11
 
 ### Added

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -59,7 +59,10 @@ footguns).
 Ordinary Scheme read/compile/runtime errors are **expected** fuzz outcomes.
 Only crashes, panics, memory leaks (via `std.testing.allocator`),
 sanitizer findings, and differential mismatches fail a target. VM execution
-is bounded by a 100 ms deadline per input.
+is bounded per input by a 100 ms wall-clock deadline — or, under
+`-Dgc-stress=true` (where a full collection on every allocation makes
+wall-clock time meaningless), by a speed-independent instruction-count budget
+instead (#1447).
 
 ## Running locally
 
@@ -109,9 +112,11 @@ The `gc-stress` variant runs the whole unit suite with a collection on
 every allocation before fuzzing, so its wall time is dominated by the test
 phase, not the fuzz limit. (Its first CI execution is what found
 [#1401](https://github.com/kaappi/kaappi/issues/1401); the suite has been
-required to stay stress-clean since that fix.) Throughput-sensitive fuzz
-targets skip themselves on stress builds — see the `gc_stress` checks in
-`src/tests_fuzz.zig`.
+required to stay stress-clean since that fix.) The deterministic
+generator-coverage gates and the differential-oracle regression gate stay
+meaningful on stress builds by bounding evaluation with an instruction-count
+budget rather than the wall-clock deadline — see `eval_instruction_limit` in
+`src/tests_fuzz.zig` (#1447).
 
 Trigger it manually (optionally overriding the limit) with:
 

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -183,9 +183,23 @@ test "fuzz seed .sbc fixture stays loadable" {
 
 // ---------------------------------------------------------------------------
 // Shared eval harness: full read -> compile -> VM execute of one input, with
-// a 100 ms execution deadline. Ordinary Scheme errors are expected outcomes;
+// a per-program execution bound. Ordinary Scheme errors are expected outcomes;
 // only panics, crashes, and leaks fail the target.
-// ---------------------------------------------------------------------------
+//
+// A normal build bounds by a 100 ms wall clock. A gc-stress build runs a full
+// collection on every allocation, so wall-clock time balloons by orders of
+// magnitude while a program still executes the SAME number of bytecode
+// instructions — a 100 ms deadline there converts correct-but-slow programs
+// into timeouts and makes the generator-coverage gates below measure GC speed
+// instead of generator correctness (#1447). Under gc-stress we therefore bound
+// by instruction count (speed-independent: identical on either build) and keep
+// only a loose wall-clock backstop against a pathological input. The 2M budget
+// clears the largest correct generator program (~35k instructions, measured
+// over 300 seeds of each generator) by ~50x while staying well under the
+// loop-heavy tail (>10M instructions) the gates intentionally count as misses.
+const gc_stress = @import("build_options").gc_stress;
+const eval_deadline_ns: u64 = if (gc_stress) 120_000_000_000 else 100_000_000;
+const eval_instruction_limit: ?u64 = if (gc_stress) 2_000_000 else null;
 
 const EvalOutcome = enum { ok, scheme_error, harness_unavailable };
 
@@ -263,7 +277,8 @@ fn evalNormalized(input: []const u8, optimize: bool, gpa: std.mem.Allocator) Nor
     vm_mod.vm_bootstrap.install(vm) catch return .harness_unavailable;
     library.registerSandboxedLibraries(&vm.libraries, vm.globals) catch return .harness_unavailable;
     vm.sandbox_mode = true;
-    vm.timeout_deadline_ns = @import("vm_calls.zig").clockNs() + 100_000_000;
+    vm.timeout_deadline_ns = @import("vm_calls.zig").clockNs() + eval_deadline_ns;
+    vm.instruction_limit = eval_instruction_limit;
 
     // Toggle only around user-program evaluation, after the bootstrap and
     // library registration above compiled with the default setting.
@@ -470,11 +485,9 @@ test "fuzz grammar" {
 // generator change made programs start dying at runtime — fix the generator
 // or consciously re-baseline.
 test "grammar generator: majority of programs evaluate without error" {
-    // A gc-stress build slows evaluation by orders of magnitude, so the
-    // 100 ms deadline converts slow-but-correct programs into errors and
-    // the rate stops measuring the generator. Skip: the CI gc-stress
-    // variant still replays the fuzz targets themselves.
-    if (@import("build_options").gc_stress) return error.SkipZigTest;
+    // Runs under gc-stress too: evalNormalized bounds by instruction count
+    // there (not the 100 ms wall clock), so this still measures the generator's
+    // correctness rate rather than GC speed (#1447).
     var ok: u32 = 0;
     var total: u32 = 0;
     var seed_n: u64 = 0;
@@ -506,7 +519,7 @@ test "grammar generator: majority of programs evaluate without error" {
 // VM-vs-native harness (tests/fuzz/native-diff.sh) skips nothing on clean
 // programs, so a drop here directly costs oracle coverage.
 test "native-subset generator: programs evaluate without error" {
-    if (@import("build_options").gc_stress) return error.SkipZigTest;
+    // Runs under gc-stress: bounded by instruction count, not wall clock (#1447).
     var ok: u32 = 0;
     var total: u32 = 0;
     var seed_n: u64 = 0;
@@ -532,7 +545,7 @@ test "native-subset generator: programs evaluate without error" {
 // sides exit cleanly, so every runtime error costs oracle coverage AND
 // suggests the generator leaked outside its total-by-construction subset.
 test "portable-subset generator: programs evaluate without error" {
-    if (@import("build_options").gc_stress) return error.SkipZigTest;
+    // Runs under gc-stress: bounded by instruction count, not wall clock (#1447).
     var ok: u32 = 0;
     var total: u32 = 0;
     var seed_n: u64 = 0;
@@ -616,10 +629,9 @@ test "fuzz differential (opt vs no-opt)" {
 // off-by-one planted in the `*` constant fold diverges at seed 30 (and 3
 // more within 500), so this window has real detection power.
 test "differential oracle: fixed-seed programs agree opt vs no-opt" {
-    // Under gc-stress both runs hit the 100 ms deadline and every pair
-    // becomes incomparable resource_limit outcomes — the test would pass
-    // while measuring nothing, at ~2 VM builds per seed. Skip.
-    if (@import("build_options").gc_stress) return error.SkipZigTest;
+    // Runs under gc-stress: evalNormalized bounds by instruction count there,
+    // so both compilation paths run to completion and produce comparable
+    // observables rather than degenerating into resource_limit pairs (#1447).
     var seed_n: u64 = 0;
     while (seed_n < 60) : (seed_n += 1) {
         const src = try fuzz_gen.generateSeeded(seed_n, std.testing.allocator);

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -575,3 +575,41 @@ test "macro expansion limit returns compile error deterministically" {
     try std.testing.expectError(th.VMError.CompileError, result);
     try std.testing.expectEqual(roots_before, gc.root_count);
 }
+
+// ---------------------------------------------------------------------------
+// Instruction-count execution bound (#1447)
+//
+// A speed-independent alternative to the wall-clock timeout_deadline_ns: the
+// fuzz eval harness uses it under gc-stress, where a full collection on every
+// allocation makes wall-clock time meaningless while the program still runs
+// the same number of bytecode instructions.
+// ---------------------------------------------------------------------------
+
+test "vm: instruction_limit aborts a long-running loop" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // A bounded loop far longer than the limit: hits the budget early, yet
+    // still terminates on its own if the budget check ever regresses (so this
+    // fails as a wrong value rather than hanging).
+    vm.instruction_limit = 50_000;
+    const result = vm.eval(
+        \\(define (loop n) (if (= n 0) 'done (loop (- n 1))))
+        \\(loop 100000000)
+    );
+    try std.testing.expectError(th.VMError.ExecutionTimeout, result);
+}
+
+test "vm: instruction_limit does not trip a short program" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // A generous budget must let an ordinary program run to completion.
+    vm.instruction_limit = 50_000;
+    const result = try vm.eval("(let loop ((n 0) (acc 0)) (if (= n 100) acc (loop (+ n 1) (+ acc n))))");
+    try std.testing.expectEqual(@as(i64, 4950), types.toFixnum(result));
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -246,6 +246,13 @@ pub const VM = struct {
     sandbox_mode: bool = false,
     timeout_deadline_ns: ?u64 = null,
     instruction_counter: u64 = 0,
+    /// Optional speed-independent execution bound: when set, `runUntil` aborts
+    /// with ExecutionTimeout once `instruction_counter` reaches it. A wall-clock
+    /// deadline is meaningless under a gc-stress build (a full collection on
+    /// every allocation slows execution by orders of magnitude while the program
+    /// runs the same number of instructions), so the fuzz eval harness bounds by
+    /// instruction count there instead. See src/tests_fuzz.zig.
+    instruction_limit: ?u64 = null,
     owns_globals: bool = true,
     /// Virtual filesystem for standalone binary: maps file paths → source content.
     /// Populated from .sbc bundled files section; checked before disk reads.

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -105,6 +105,12 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     return VMError.ExecutionTimeout;
                 }
             }
+            if (self.instruction_limit) |limit| {
+                if (self.instruction_counter >= limit) {
+                    self.setErrorDetail("execution instruction limit exceeded", .{});
+                    return VMError.ExecutionTimeout;
+                }
+            }
         }
 
         const frame = &self.frames[self.frame_count - 1];


### PR DESCRIPTION
## Summary

The four fuzz **generator-coverage regression gates** in `src/tests_fuzz.zig` were unconditionally skipped under `-Dgc-stress=true`:

- grammar generator: majority evaluate without error
- native-subset generator: programs evaluate without error
- portable-subset generator: programs evaluate without error
- differential oracle: fixed-seed programs agree opt vs no-opt

A gc-stress build runs a full collection on **every allocation**, slowing evaluation by orders of magnitude, so the fixed **100 ms per-program deadline** degenerated into "did it time out" rather than measuring generator correctness. The gates skipped rather than emit a false-negative-prone signal — so a stress build had **zero** coverage of these regressions.

## Fix

A gc-stress build executes the **same number of bytecode instructions** as a normal build — only wall-clock time changes. So bound by **instruction count** there instead (issue's preferred option 1: "drop the deadline and use an iteration/step budget"):

- New `VM.instruction_limit: ?u64` field, checked in `runUntil` **inside the existing per-1024-instruction block** (alongside the wall-clock/terminate checks) — zero hot-path cost.
- `evalNormalized` sets the budget to **2M instructions** under gc-stress and keeps only a loose wall-clock backstop. Normal builds are **unchanged** (limit stays `null`, 100 ms deadline as before).

The 2M budget was chosen from measured data over 300 seeds of each generator: the largest *correct* program runs ~35k instructions, while the loop-heavy tail the gates intentionally count as misses runs **>10M** — nothing lands between ~1M and 10M, so 2M cleanly separates them (~50x margin over correct programs).

## Validation

Under `-Dgc-stress=true` the gates now measure generator correctness instead of GC speed:

| Gate | Result | Threshold |
|------|--------|-----------|
| grammar | 56/60 (93.3%) | ≥75% |
| native | 60/60 (100%) | ≥90% |
| portable | 60/60 (100%) | ≥90% |
| differential oracle | 57/60 pairs compared & agree (was **0** compared) | — |

- Full normal-build unit suite: green.
- New direct unit tests for the mechanism (`src/tests_robustness.zig`): green on both normal and gc-stress builds.

## Scope

One fix resolves all four sibling issues (they share the `evalNormalized` harness and root cause).

Closes #1447, closes #1448, closes #1449, closes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)