### PR TITLE
Compile the LLVM native backend at -O2 with an IR-verify safety net

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -173,6 +173,9 @@ pub fn build(b: *std.Build) void {
         const cc_run = b.addSystemCommand(&.{"zig"});
         cc_run.addArg("cc");
         cc_run.addArg("-w");
+        // Optimize the emitted IR — the emitter relies on LLVM to clean up its
+        // deliberately naive output; -O0 leaves it all in place (#1492).
+        cc_run.addArg("-O2");
         cc_run.addFileArg(ll_output);
         cc_run.addArg("-o");
         const native_output = cc_run.addOutputFileArg("program");

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -75,7 +75,7 @@ NaN-boxed representation crosses C ABI trivially).
 ```bash
 zig build lib                                        # build libkaappi_rt.a
 kaappi --emit-llvm -o program.ll program.scm         # emit LLVM IR
-zig cc -w program.ll -o program \
+zig cc -w -O2 program.ll -o program \
     -Lzig-out/lib -lkaappi_rt -lc -lm -lpthread      # link native binary
 ./program                                            # run
 ```
@@ -90,6 +90,37 @@ zig build native -Dnative-src=program.scm            # all-in-one
 **Always use `zig cc` (not `clang`) for linking.** The Zig-compiled static
 library references `__zig_probe_stack` and other Zig compiler-rt intrinsics
 that `clang` cannot resolve.
+
+## Optimization and IR verification
+
+The emitter produces deliberately naive IR and relies on LLVM to clean it up:
+every immediate is `add i64 0, K` (`emitImm`), let-bindings / shadow-stack root
+slots / args arrays go through `alloca`/`load`/`store`, and `if`/`and`/`or`
+become long `br`/`phi` chains. All three link flows above pass **`-O2`** so
+mem2reg, instcombine, simplifycfg, and constant folding collapse this — at `-O0`
+none of the optimization that is the point of using LLVM runs. (Root-slot
+`alloca`s whose address escapes into `kaappi_gc_push_root` correctly stay in
+memory; the collector scans them.)
+
+Because the IR is hand-written, well-formedness bugs can pass `-O0` yet break or
+miscompile under `-O2`'s stricter verifier and passes (e.g. an orphan block left
+after a tail call, or mismatched `phi` operands). The e2e harness
+(`tests/e2e/run-e2e.sh`) verifies every emitted `.ll` before linking — with
+`opt -passes=verify`, `llvm-as`, or, when neither is on `PATH`, `zig cc -c`
+(same bundled LLVM that links the binary). The verifier runs **without** `-w`,
+so no malformed-IR diagnostic is hidden. To verify a single file by hand:
+
+```bash
+kaappi --emit-llvm -o program.ll program.scm
+opt -passes=verify -disable-output program.ll        # or: llvm-as -o /dev/null program.ll
+```
+
+The `-w` on the link commands only silences cosmetic warnings on generated IR
+for end users; a hard verifier **error** still fails the compile regardless.
+
+Cross-module inlining of the runtime primitives (`kaappi_fixnum_add`,
+`kaappi_car`, …) needs LTO and is tracked separately — `-O2` alone already
+cleans up the emitter's own IR substantially.
 
 ## LLVM IR Emission
 
@@ -203,8 +234,9 @@ via `kaappi_call_scheme`, which dispatches through the VM's `callWithArgs`
 
 End-to-end tests live in `tests/e2e/`:
 
-- `run-e2e.sh` — builds the runtime, runs BDD specs, compiles each test
-  program to native via LLVM IR, and diffs output against the interpreter
+- `run-e2e.sh` — builds the runtime, runs BDD specs, verifies each program's
+  emitted IR, compiles it to native via LLVM IR at `-O2`, and diffs output
+  against the interpreter
 - `test-llvm-backend.scm` — BDD specs using `kaappi-bdd`
 - `programs/*.scm` — test programs compiled to native binaries
 

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -298,6 +298,17 @@ fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, ou
     argv_buf[argc] = "-w";
     argc += 1;
 
+    // Compile the emitted IR at -O2. The emitter deliberately produces naive IR
+    // (every immediate as `add i64 0, K`, pervasive alloca/load/store, long
+    // br/phi chains) and relies on LLVM to clean it up — at -O0 none of that
+    // runs. mem2reg/instcombine/simplifycfg collapse it; GC root-slot allocas
+    // whose address escapes into kaappi_gc_push_root correctly stay in memory.
+    // Malformed IR is caught by the -w-free verifier in tests/e2e/run-e2e.sh;
+    // `-w` here only silences cosmetic warnings on generated IR for end users
+    // (a hard verifier error still fails the compile regardless of -w). See #1492.
+    argv_buf[argc] = "-O2";
+    argc += 1;
+
     const ll_z = allocator.dupeZ(u8, ll_path) catch return false;
     defer allocator.free(ll_z);
     argv_buf[argc] = ll_z;

--- a/tests/e2e/programs/tak.scm
+++ b/tests/e2e/programs/tak.scm
@@ -1,0 +1,11 @@
+; Takeuchi function — three-way recursion exercised natively (direct calls +
+; inlined arithmetic). Serves as the #1492 -O2 micro-benchmark parity case:
+; the native binary is built at -O2 and its output must match the interpreter.
+(define (tak x y z)
+  (if (not (< y x))
+      z
+      (tak (tak (- x 1) y z)
+           (tak (- y 1) z x)
+           (tak (- z 1) x y))))
+(display (tak 18 12 6))
+(newline)

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # End-to-end tests for the LLVM native backend.
-# Verifies: Scheme source → --emit-llvm → .ll → clang → native binary → correct output.
+# Verifies: Scheme source → --emit-llvm → .ll → verify IR → cc -O2 → native
+#           binary → output matches the interpreter.
 #
 # Usage: bash tests/e2e/run-e2e.sh
 
@@ -28,6 +29,33 @@ zig build lib
 
 KAAPPI="$REPO_DIR/zig-out/bin/kaappi"
 LIBDIR="$REPO_DIR/zig-out/lib"
+
+# C compiler used to link native binaries (defaults to `zig cc`).
+CC="${KAAPPI_CC:-zig cc}"
+
+# Pick an IR verifier once (#1492). The LLVM verifier catches malformed IR that
+# passes -O0 but breaks (or miscompiles) under -O2's stricter passes. Prefer the
+# standalone tools for clean diagnostics; when neither is on PATH (typical on CI
+# runners) fall back to `zig cc`, whose bundled LLVM parses and verifies the .ll
+# on its way to an object file — the same LLVM that links the binary, so this
+# step never silently no-ops. None of these pass -w, so diagnostics are visible.
+if command -v opt >/dev/null 2>&1; then
+    IR_VERIFIER="opt"
+elif command -v llvm-as >/dev/null 2>&1; then
+    IR_VERIFIER="llvm-as"
+else
+    IR_VERIFIER="cc"
+fi
+echo "IR verifier: $IR_VERIFIER"
+
+verify_ir() {
+    local ll_file="$1"
+    case "$IR_VERIFIER" in
+        opt)     opt -passes=verify -disable-output "$ll_file" ;;
+        llvm-as) llvm-as -o /dev/null "$ll_file" ;;
+        *)       $CC -c "$ll_file" -o "$TMPDIR/verify.o" ;;
+    esac
+}
 
 # --- Phase 1: BDD tests via interpreter ---
 
@@ -66,9 +94,20 @@ assert_native_parity() {
         return
     fi
 
+    # Safety net: verify the IR is well-formed before -O2 gets a chance to turn a
+    # latent malformed-IR bug into a miscompile or a confusing link failure.
+    local verify_output
+    if ! verify_output=$(verify_ir "$ll_file" 2>&1); then
+        echo "  verify: $verify_output"
+        echo "FAIL: $label — IR verification failed"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    # Link at -O2 (no -w): the emitter leans on LLVM to clean up its naive IR,
+    # and dropping -w surfaces any diagnostics instead of hiding them.
     local clang_output
-    local cc="${KAAPPI_CC:-zig cc}"
-    if ! clang_output=$($cc -w "$ll_file" -o "$native_bin" -L"$LIBDIR" -lkaappi_rt -lc -lm -lpthread 2>&1); then
+    if ! clang_output=$($CC -O2 "$ll_file" -o "$native_bin" -L"$LIBDIR" -lkaappi_rt -lc -lm -lpthread 2>&1); then
         echo "  cc: $clang_output"
         echo "FAIL: $label — clang linking failed"
         FAIL=$((FAIL + 1))


### PR DESCRIPTION
Part of #1491. Closes #1492.

## Problem

`tryLink` invoked the linker with no `-O` flag, so LLVM compiled the emitter's
deliberately naive IR at **-O0** — none of the optimization that is the reason
to use LLVM ran. Every immediate was `add i64 0, K`, let-bindings / shadow-stack
root slots / args arrays went through `alloca`/`load`/`store`, and `if`/`and`/`or`
became long `br`/`phi` chains, all left in place.

## Change

- **Pass `-O2`** in `tryLink` (`kaappi compile`), the `zig build native` step,
  the documented manual flow, and the e2e harness. mem2reg / instcombine /
  simplifycfg / constant-folding collapse the scaffolding. Root-slot `alloca`s
  whose address escapes into `kaappi_gc_push_root` correctly stay in memory for
  GC scanning.
- **IR-verify safety net (paired):** `tests/e2e/run-e2e.sh` now verifies every
  emitted `.ll` before linking, choosing `opt -passes=verify` → `llvm-as` →
  `zig cc -c` (the last is what CI uses, since `opt`/`llvm-as` aren't on the
  runner `PATH`; it's the same bundled LLVM that links the binary, so the step
  never silently no-ops — confirmed it rejects both parser errors and
  verifier-level ones like *"Instruction does not dominate all uses"*). The
  verifier runs **without** `-w` so no malformed-IR diagnostic is hidden. `-w`
  stays on the user-facing compile, where it only silences cosmetic warnings on
  generated IR (a hard verifier **error** still fails regardless).
- New `tests/e2e/programs/tak.scm` locks in the `-O2` native path on multi-way
  recursion (the issue's named micro-benchmark).
- Docs: new "Optimization and IR verification" section in
  `docs/dev/llvm-backend.md`.

## Acceptance criteria

- [x] Native binaries built with `-O2`; `tests/e2e/run-e2e.sh` green — **24/24**,
  native output diffs identically against the interpreter.
- [x] CI verifies emitted IR is well-formed (verify step, `-w`-free).
- [x] Micro-benchmark shows the expected speedup: `fib(38)` **1.11x**
  (-O0 1.605s → -O2 1.441s), `tak(27,18,9)` **1.10x**, both identical output;
  IR shrinks (fib 67 → 51 instruction lines, all `add i64 0,K` immediates
  folded).

The modest wall-clock gain is expected: arithmetic is still opaque
`kaappi_fixnum_*` cross-module calls that `-O2` can't inline without LTO
(tracked separately as #1493). `-O2` alone cleans up the emitter's own IR
substantially, as the issue anticipated.

## Verification

`zig fmt --check src/` clean · `zig build test` exit 0 · e2e 24/24 under **both**
the `opt` and `zig cc`-fallback verifiers.

## Follow-up found (out of scope, flagged separately)

While choosing a benchmark I hit a *pre-existing* correctness bug: native
**self-tail-call loops overflow the stack** and SIGSEGV past ~350k iterations
(100k works, 400k crashes at the 8 MB limit) — `emitRootPush` emits GC root-slot
`alloca`s inside the loop body, and LLVM only auto-frees entry-block allocas, so
they accumulate ~24 B/iteration. Independent of `-O2` (identical at `-O0`).
Benchmarked with non-tail `fib`/`tak` to sidestep it. Fix = hoist the allocas to
the entry block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)