### PR TITLE
Clear stale gap registers before fiber suspension snapshot (#1529)

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -412,6 +412,13 @@ pub const FiberScheduler = struct {
         const span = liveRegisterSpan(vm.frames[0..vm.frame_count], vm.registers.len);
         try growFiberRegisters(vm.gc.allocator, fiber, span);
         try growFiberFrames(vm.gc.allocator, fiber, vm.frame_count);
+        // The copy below spans dead gap registers between live frame windows.
+        // While this fiber was running it was GC-marked per-frame (markVMRoots),
+        // so a gap slot's stale pointer could already have been freed; copying it
+        // into fiber.registers would then let markFiberState trace it after the
+        // fiber suspends → use-after-free (#1529, sibling of #1464). Scrub the
+        // gaps first; no frame reads a gap slot, so this is behavior-preserving.
+        vm.clearGapRegisters(span);
         @memcpy(fiber.registers[0..span], vm.registers[0..span]);
         fiber.frame_count = vm.frame_count;
         @memcpy(fiber.frames[0..vm.frame_count], vm.frames[0..vm.frame_count]);

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -422,3 +422,48 @@ test "hasRunnableFibers reports a shared-waiter-registry entry as alive" {
 
     try std.testing.expect(sched.hasRunnableFibers());
 }
+
+// Regression (#1529, sibling of the call/cc #1464 fix): a fiber that suspends
+// while inside a re-entrant native frame (here a `guard` thunk) must not save
+// stale pointers from dead "gap" registers into its snapshot. The `guard`
+// bumps the frame base well past the thunk's own window, so registers between
+// the windows form a gap; `make-junk` before the guard leaves dead heap values
+// lingering there. While the fiber runs it is GC-marked per-frame (markVMRoots
+// skips gaps), so an allocation inside the guard frees that gap junk; the
+// fiber then blocks on channel-receive and saveCurrentFiber copies the now
+// contiguous [0,span) span -- gaps included -- into fiber.registers. A later
+// collection while the fiber is suspended marks that snapshot contiguously
+// (markFiberState), dereferencing the freed pointers. Under -Dgc-stress=true
+// with the testing allocator (which unmaps freed pages) that read segfaults
+// without saveCurrentFiber's clearGapRegisters scrub. The result 16 (= 7 + 9)
+// also confirms the live values w and v survive the scrub intact.
+test "fiber suspend does not save stale gap registers (#1529)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const result = try ctx.vm.eval(
+        \\(import (kaappi fibers))
+        \\(define ch (make-channel))
+        \\(define out #f)
+        \\(define (make-junk n)
+        \\  (let loop ((i 0) (acc '()))
+        \\    (if (< i n) (loop (+ i 1) (cons (make-vector 4000 i) acc)) acc)))
+        \\(spawn
+        \\  (lambda ()
+        \\    (make-junk 6)
+        \\    (guard (e (#t 'caught))
+        \\      (let ((w (list 7 7 7)) (v (list 9 9 9)))
+        \\        (make-junk 3)
+        \\        (channel-receive ch)
+        \\        (set! out (+ (car w) (car v)))))))
+        \\(spawn
+        \\  (lambda ()
+        \\    (let loop ((i 0)) (when (< i 200) (list i i i) (loop (+ i 1))))
+        \\    (channel-send ch 'go)
+        \\    (let loop ((i 0)) (when (< i 200) (list i i i) (loop (+ i 1))))))
+        \\(yield)(yield)(yield)(yield)
+        \\out
+    );
+    try std.testing.expectEqual(@as(i64, 16), types.toFixnum(result));
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -695,6 +695,43 @@ pub const VM = struct {
         return vm_continuations.performWindTransition(self, target_winds, target_count);
     }
 
+    /// Clear register slots in `[0, max_reg)` that no live frame window covers,
+    /// setting each to UNDEFINED. Such gap slots are dead (no frame reads them),
+    /// but one vacated by a returned call frame typically still holds that
+    /// frame's last pointer. The GC root marker walks only per-frame windows, so
+    /// those pointers keep nothing alive and a later collection frees their
+    /// targets — which is why any copy of the contiguous `[0, max_reg)` range
+    /// must not preserve them verbatim (#1464). Both call/cc continuation
+    /// capture (`captureContinuation`) and fiber suspension
+    /// (`FiberScheduler.saveCurrentFiber`, #1529) snapshot that contiguous range
+    /// and later trace it, so both scrub the gaps through here first. Clearing is
+    /// behavior-preserving: no frame ever reads a gap slot (a continuation/fiber
+    /// restore copies them back but they stay dead).
+    ///
+    /// Frame bases are non-decreasing (every call places its callee's frame past
+    /// the caller's own base, and continuation restore preserves that order), so
+    /// a single ordered sweep that tracks the highest covered register finds the
+    /// gaps with no scratch buffer — keeping call/cc capture allocation-free on
+    /// the hot path (a bitmap here regressed the call_cc benchmark ~1.9x).
+    pub fn clearGapRegisters(self: *VM, max_reg: usize) void {
+        var covered_end: usize = 0;
+        var prev_base: usize = 0;
+        for (self.frames[0..self.frame_count]) |f| {
+            const base: usize = f.base;
+            std.debug.assert(base >= prev_base); // relied on for gap correctness
+            prev_base = base;
+            if (base > covered_end) {
+                const gap_end = @min(base, max_reg);
+                @memset(self.registers[covered_end..gap_end], types.UNDEFINED);
+                if (gap_end == max_reg) return;
+            }
+            const win_end = base + f.frameWindow();
+            if (win_end > covered_end) covered_end = win_end;
+        }
+        if (covered_end < max_reg)
+            @memset(self.registers[covered_end..max_reg], types.UNDEFINED);
+    }
+
     const vm_dispatch = @import("vm_dispatch.zig");
 
     pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) VMError!Value {

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -1,4 +1,3 @@
-const std = @import("std");
 const types = @import("types.zig");
 const Value = types.Value;
 
@@ -7,38 +6,6 @@ const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
 const MAX_HANDLERS = vm_mod.MAX_HANDLERS;
 const MAX_WINDS = vm_mod.MAX_WINDS;
-
-/// Clear register slots in `[0, max_reg)` that no live frame window covers,
-/// setting each to UNDEFINED. Such gap slots are dead (no frame reads them),
-/// but one vacated by a returned call frame typically still holds that frame's
-/// last pointer. The GC root marker walks only per-frame windows, so those
-/// pointers keep nothing alive and a later collection frees their targets —
-/// which is why a continuation snapshot taken over the contiguous `[0, max_reg)`
-/// range must not copy them verbatim (#1464). Called before every snapshot.
-///
-/// Frame bases are non-decreasing (every call places its callee's frame past
-/// the caller's own base, and continuation restore preserves that order), so a
-/// single ordered sweep that tracks the highest covered register finds the gaps
-/// with no scratch buffer — keeping call/cc capture allocation-free on the hot
-/// path (a bitmap here regressed the call_cc benchmark ~1.9x).
-fn clearGapRegisters(vm: *VM, max_reg: usize) void {
-    var covered_end: usize = 0;
-    var prev_base: usize = 0;
-    for (vm.frames[0..vm.frame_count]) |f| {
-        const base: usize = f.base;
-        std.debug.assert(base >= prev_base); // relied on for gap correctness
-        prev_base = base;
-        if (base > covered_end) {
-            const gap_end = @min(base, max_reg);
-            @memset(vm.registers[covered_end..gap_end], types.UNDEFINED);
-            if (gap_end == max_reg) return;
-        }
-        const win_end = base + f.frameWindow();
-        if (win_end > covered_end) covered_end = win_end;
-    }
-    if (covered_end < max_reg)
-        @memset(vm.registers[covered_end..max_reg], types.UNDEFINED);
-}
 
 /// Capture the current continuation state.
 /// dst_reg is the register offset within the caller's frame where the result of call/cc will go.
@@ -91,7 +58,7 @@ pub fn captureContinuation(vm: *VM, dst_reg: u16, dst_base: u32) VMError!Value {
     // which spans dead gaps between live frame windows. Scrub stale pointers
     // out of those gaps first so the snapshot can't outlive their targets
     // (#1464); restore never reads a gap slot, so this is behavior-preserving.
-    clearGapRegisters(vm, max_reg);
+    vm.clearGapRegisters(max_reg);
 
     const cont_val = vm.gc.allocContinuation(
         vm.registers[0..max_reg],


### PR DESCRIPTION
Fixes #1529.

## Problem

The fiber scheduler has the same GC use-after-free that #1464/#1528 fixed for `call/cc`. `markVMRoots` marks a **running** fiber's registers per frame window, skipping the dead "gap" slots between live windows (slots a returned call frame vacated but that still hold its last heap pointer). But `saveCurrentFiber` copies `vm.registers[0..span]` **contiguously** into the fiber's snapshot, and `markFiberState` marks that snapshot contiguously.

So a gap slot's stale pointer — freed during the fiber's run because per-frame marking never protected it — is copied into the fiber's saved registers when it suspends, and a later collection while the fiber is parked traces the dangling pointer → segfault (reading a freed object's fields).

The gap comes from re-entrant native frames (`guard`/`dynamic-wind` thunks) that bump the frame base well past the caller's window, exactly as in #1464.

## Fix

- Move `clearGapRegisters` (the allocation-free ordered sweep from #1528) from `vm_continuations.zig` to a shared `pub fn` method on `VM` in `vm.zig`.
- `captureContinuation` calls `vm.clearGapRegisters(max_reg)` (unchanged behavior).
- `saveCurrentFiber` calls `vm.clearGapRegisters(span)` before the register `@memcpy`.

Scrubbing dead gap slots to `UNDEFINED` is behavior-preserving: no frame ever reads a gap slot (restore copies them back, but they stay dead). The benchmark stays at baseline since the call/cc path runs the identical sweep, now via a method.

## Regression test

`"fiber suspend does not save stale gap registers (#1529)"` in `tests_scheduler.zig` **segfaults without the fix and passes with it** under `-Dgc-stress=true`. Three ingredients were needed to make it deterministic:

1. Suspend via a **blocking wait under a reentrant frame** (`channel-receive` inside `guard`) — `yield` no-ops under reentrant frames (#1184), so it can't create the gap.
2. Gap junk must be **big page-backed allocations** (`make-vector 4000`) so freeing them unmaps pages; small objects stay mapped and `markValueInner`'s `owner != gc.id` guard silently absorbs the read.
3. `std.testing.allocator` unmaps freed pages (the standalone binary's allocator doesn't), so it reproduces as a unit test.

## Verification

- Full unit suite: **865/865 pass**.
- Regression test: crashes with fix off, passes with fix on, under gc-stress.
- `continuations` / `tests_scheduler` / `fiber` suites under `-Dgc-stress=true`: all pass (incl. the fiber-switch storage-bound test).
- `zig build bench` (call/cc capture): at baseline.
- `zig fmt --check` and release build: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)