### PR TITLE
Add stable KP diagnostic codes to every error path (#1504)

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -27,6 +27,7 @@ investigation produced analysis worth keeping.
 | [fuzzing.md](fuzzing.md) | Fuzzing runbook: the targets, the scheduled CI job, turning a failure into a regression test |
 | [github-actions.md](github-actions.md) | Workflow hardening rules: SHA-pinned actions, `persist-credentials: false`, least-privilege tokens |
 | [gc-safety-and-error-handling.md](gc-safety-and-error-handling.md) | Rooting, write barriers, and error propagation patterns contributors must follow |
+| [diagnostics.md](diagnostics.md) | Diagnostic `KP` codes: the registry, the taxonomy, the stability policy, how to add a code |
 | [claude-code-harness.md](claude-code-harness.md) | Hooks, permissions, path-scoped rules, and skills for AI-assisted development |
 
 ## Design decisions

--- a/docs/dev/diagnostics.md
+++ b/docs/dev/diagnostics.md
@@ -1,0 +1,140 @@
+# Diagnostic codes and the stability policy
+
+Every user-facing diagnostic Kaappi prints carries a stable `KP`-prefixed code:
+
+```
+err.scm:2: error[KP3001]: undefined variable 'countr'. Did you mean 'count'?
+```
+
+The code is the part a tool — an AI agent, a CI gate, an editor — matches on. The
+message after it is free to improve release to release; the code is the contract.
+
+**Source:** `src/diagnostics.zig` (the registry) · **Tests:** `src/tests_diagnostics.zig`
+and `tests/scheme/errors/error-format.sh`
+
+This is the keystone of the "machine legibility" campaign
+([kaappi#1503](https://github.com/kaappi/kaappi/issues/1503)); the design record
+is [KEP-0005](https://github.com/kaappi/keps/blob/main/keps/0005-diagnostic-contract.md).
+Later phases (`--diagnostics=json`, `kaappi explain`, `error-object-code`) all
+read from this one registry.
+
+---
+
+## The registry
+
+`src/diagnostics.zig` is the single source of truth. One comptime `table` binds
+together, per diagnostic, the three things that used to live apart:
+
+- **the code** — a `Code` enum value whose *integer is the KP number*, so
+  `undefined_variable = 3001` renders as `"KP3001"`;
+- **the message template** — the human message (currently a complete sentence;
+  it gains `{…}` placeholders as raise sites pass structured arguments);
+- **the explanation** — prose for `kaappi explain <code>` (surfaced in a later
+  phase; populated now so the registry is complete).
+
+A `comptime` block enforces registry integrity *at build time*: every `Code` has
+exactly one entry, no two entries collide, and every entry has a non-empty name,
+template, and explanation. A malformed registry fails `zig build`.
+
+## The taxonomy
+
+The leading digit tells an agent which pipeline stage a diagnostic came from:
+
+| Range | Stage | Source of truth |
+|-------|-------|-----------------|
+| `KP1xxx` | Read / lexical | `reader*.zig` |
+| `KP2xxx` | Expand / compile | `expander.zig`, `compiler*.zig`, `ir.zig` |
+| `KP3xxx` | Runtime | `vm*.zig`, `primitives*.zig` |
+| `KP4xxx` | Static analysis / lint | `kaappi check` — reserved ([#1511](https://github.com/kaappi/kaappi/issues/1511)) |
+| `KP9xxx` | Internal / resource | internal-compiler-error and out-of-memory paths |
+
+Ranges are deliberately sparse (1000 codes per stage). Granularity target: **one
+code per user-distinguishable condition** — finer than the internal `KaappiError`
+enum, which maps *many-to-one* onto codes. The `Code` namespace is curated and
+independent of the internal Zig error sets on purpose (KEP-0005 "Alternatives
+considered"): a coarse `TypeError` can later fan out into several codes without
+touching the enum.
+
+## The output format
+
+The stage word is kept for the human reader; the bracketed code is inserted
+before the colon:
+
+```
+<stdin>:1:12: read error[KP1002]: unexpected character
+<stdin>:1: compile error[KP2001]: invalid syntax
+<stdin>:1: syntax-error[KP2002]: bad usage 1
+err.scm:2: error[KP3001]: undefined variable 'countr'. Did you mean 'count'?
+```
+
+All reporting flows through `src/toplevel_driver.zig` (`reportReadError`,
+`reportCompileError`, `reportRuntimeError`), which the REPL, file runner, and
+stdin runner share. The bundled-binary and `include` paths use the same registry.
+
+## How a diagnostic gets its code
+
+Two mechanisms, by stage:
+
+- **Read and compile errors** are Zig error enums (`ReadError`, `CompileError`).
+  `diagnostics.readErrorCode` / `compileErrorCode` map them to codes and the
+  registry supplies the message. This is what retired the old
+  `read error: error.UnexpectedChar` leaks — a raw Zig error name never reaches
+  the user; unknown values resolve to a stage-appropriate catch-all.
+
+- **Runtime errors** come in two worlds. Errors that propagate as a native
+  `VMError` (undefined variable, type error, arity, …) are coded by
+  `diagnostics.runtimeErrorCode` from the escaping error. Errors *raised as
+  error objects* (division by zero, and anything from `raise`/`error`) carry
+  their code **on the object** — `ErrorObject.code`, stamped at the raise site
+  via `GC.allocErrorObjectCoded`. `VM.noteUncaughtException` lifts that code to
+  the reporting layer. A user `(error …)` is uncoded (`.uncategorized`) and
+  surfaces as the generic `KP3000` "uncaught exception"; the `KP` namespace is
+  reserved to the implementation.
+
+Carrying the code on the object (rather than in transient VM state) is what makes
+it survive `guard` catch/re-raise, and it is the seed the Phase-4
+`error-object-code` accessor will read.
+
+### The migration is incremental
+
+Not every raise site is coded yet — that is a long tail (KEP-0005 "Drawbacks").
+The high-traffic diagnostics are coded first; an unmigrated error-object raise
+simply shows `KP3000` until its site is stamped. `runtimeErrorCode` /
+`readErrorCode` / `compileErrorCode` guarantee that *some* real code and message
+always print, so no path ever regresses to leaking a Zig name.
+
+## Stability policy — the contract
+
+This is the load-bearing commitment, and the reason a registry beats scattered
+strings:
+
+1. **Once a code appears in a released version, it is never renumbered and never
+   reused for a different meaning.** A diagnostic that is removed leaves its code
+   permanently reserved — add a tombstone entry, do not recycle the number.
+2. A code's **message text and explanation may be reworded freely.** That is the
+   whole point of separating the stable code from the mutable prose.
+3. A code's **severity may tighten or relax** across a major version (an error
+   demoted to a warning, say), but the code persists.
+4. **Pre-1.0 latitude.** Until Kaappi reaches a stability milestone, codes are
+   *intended* stable but the registry may be renumbered in bulk **once**, loudly,
+   if the initial taxonomy proves wrong — after which rule 1 is absolute.
+
+Because the `Code` enum's integer value *is* the KP number, "never renumber"
+means: never change an existing enum value. New codes take the next free ordinal
+in their stage range.
+
+## Adding a new code
+
+1. Add a `Code` enum value in the right stage range with the next free ordinal,
+   and a matching `table` entry (name, template, explanation). The comptime gate
+   fails the build if you forget the entry or collide a number.
+2. Route the raise site to it:
+   - reader/compiler: add the `error.Xxx => .your_code` arm to
+     `readErrorCode` / `compileErrorCode`;
+   - runtime native error: add the arm to `runtimeErrorCode`;
+   - runtime error object: stamp it at the raise site with
+     `gc.allocErrorObjectCoded(msg, irritants, .your_code)`.
+3. Add assertions to `tests/scheme/errors/error-format.sh` (the code appears; no
+   Zig name leaks) and, if useful, a unit test in `src/tests_diagnostics.zig`.
+4. Keep the explanation genuinely explanatory — it is what `kaappi explain` will
+   show.

--- a/src/diagnostics.zig
+++ b/src/diagnostics.zig
@@ -1,0 +1,476 @@
+//! Diagnostic registry — the single source of truth for Kaappi's user-facing
+//! diagnostic codes (KEP-0005, kaappi#1504).
+//!
+//! Every diagnostic Kaappi prints carries a stable `KP`-prefixed code so that
+//! tools — AI agents, CI gates, editors — can match on an identifier instead of
+//! scraping prose that is free to be reworded. The leading digit encodes the
+//! pipeline stage the diagnostic came from:
+//!
+//!   KP1xxx  read / lexical      (reader.zig, reader_tokens.zig, reader_datum.zig)
+//!   KP2xxx  expand / compile    (expander.zig, compiler*.zig, ir.zig)
+//!   KP3xxx  runtime             (vm*.zig, primitives*.zig)
+//!   KP4xxx  static analysis     (`kaappi check`, reserved — kaappi#1511)
+//!   KP9xxx  internal / resource (internal-compiler-error and out-of-memory paths)
+//!
+//! Stability policy (KEP-0005 §5): once a code ships in a released version it is
+//! NEVER renumbered and NEVER reused for a different meaning. A retired code is
+//! reserved forever (a tombstone entry). Message text and explanations may be
+//! reworded freely — that is the whole point of separating the stable code from
+//! the mutable prose. See docs/dev/diagnostics.md.
+//!
+//! This registry is the keystone of the "machine legibility" campaign
+//! (kaappi#1503): `--diagnostics=json`, `kaappi explain`, and `error-object-code`
+//! all hang off it in later phases. Phase 1 (this file) gives every read /
+//! expand / compile / runtime error a code in text output and retires the raw
+//! `error.XxxYyy` Zig-enum leaks.
+
+const std = @import("std");
+
+pub const Severity = enum {
+    /// Halts execution; the process exits non-zero.
+    err,
+    /// Advisory; does not by itself stop the program. Reserved for KP4xxx lint.
+    warning,
+};
+
+/// A stable diagnostic code. The integer value IS the KP number, so
+/// `undefined_variable` (= 3001) renders as "KP3001". Ordinals are a permanent
+/// contract: never change or reuse an existing value once released (KEP-0005 §5).
+/// New codes take the next free ordinal in their stage range.
+pub const Code = enum(u16) {
+    // -- KP1xxx — Read / lexical --------------------------------------------
+    unexpected_eof = 1001,
+    unexpected_char = 1002,
+    unexpected_right_paren = 1003,
+    invalid_number = 1004,
+    invalid_character_name = 1005,
+    unterminated_string = 1006,
+    invalid_escape = 1007,
+    dot_outside_list = 1008,
+    nesting_too_deep = 1009,
+    token_too_long = 1010,
+
+    // -- KP2xxx — Expand / compile ------------------------------------------
+    invalid_syntax = 2001,
+    syntax_error = 2002,
+    macro_expansion_limit = 2003,
+
+    // -- KP3xxx — Runtime ---------------------------------------------------
+    uncaught_exception = 3000,
+    undefined_variable = 3001,
+    type_error = 3002,
+    arity_mismatch = 3003,
+    division_by_zero = 3004,
+    not_a_procedure = 3005,
+    index_out_of_bounds = 3006,
+    invalid_argument = 3007,
+    stack_overflow = 3008,
+    execution_timeout = 3009,
+
+    // -- KP9xxx — Internal / resource exhaustion ----------------------------
+    uncategorized = 9000,
+    internal_error = 9001,
+    out_of_memory = 9002,
+
+    /// Width of a rendered code, e.g. "KP3001" — always "KP" + 4 digits.
+    pub const render_width = 6;
+
+    /// Render this code as "KPnnnn" into `buf`. Returns the written slice.
+    pub fn render(self: Code, buf: *[render_width]u8) []const u8 {
+        return std.fmt.bufPrint(buf, "KP{d:0>4}", .{@intFromEnum(self)}) catch unreachable;
+    }
+
+    /// The registry entry for this code.
+    pub fn info(self: Code) Diagnostic {
+        return lookup(self);
+    }
+
+    /// The human-readable message template. In Phase 1 (kaappi#1504) most
+    /// templates are complete sentences with no placeholders; a richer message
+    /// supplied at the raise site (the VM/compiler "detail" buffers) overrides
+    /// this when present. The template is the fallback that replaces the old
+    /// raw-Zig-error-name output.
+    pub fn message(self: Code) []const u8 {
+        return lookup(self).template;
+    }
+};
+
+pub const Diagnostic = struct {
+    code: Code,
+    /// Kebab-case short name, e.g. "undefined-variable". Stable alongside the code.
+    name: []const u8,
+    /// Human-readable message / template (see `Code.message`).
+    template: []const u8,
+    /// Prose explanation surfaced by `kaappi explain <code>` (kaappi#1507).
+    /// Must be non-empty for every entry — enforced at compile time below.
+    explanation: []const u8,
+    severity: Severity = .err,
+};
+
+/// The registry. One entry per `Code`; completeness and uniqueness are enforced
+/// by the `comptime` block at the bottom of this file, so this array is the
+/// single source of truth an agent, the docs generator, and `kaappi explain`
+/// all read from.
+pub const table = [_]Diagnostic{
+    // -- KP1xxx — Read / lexical --------------------------------------------
+    .{
+        .code = .unexpected_eof,
+        .name = "unexpected-eof",
+        .template = "unexpected end of input",
+        .explanation =
+        \\The reader reached the end of the input while a datum was still open —
+        \\most often an unclosed '(' or an unterminated string or block comment.
+        \\Check that every '(' has a matching ')' and every '"' is closed.
+        ,
+    },
+    .{
+        .code = .unexpected_char,
+        .name = "unexpected-char",
+        .template = "unexpected character",
+        .explanation =
+        \\The reader encountered a character that cannot begin or continue a datum
+        \\at this position. A common cause is a malformed '#'-syntax such as an
+        \\unknown '#\name' character literal or a stray '#'.
+        ,
+    },
+    .{
+        .code = .unexpected_right_paren,
+        .name = "unexpected-right-paren",
+        .template = "unexpected ')'",
+        .explanation =
+        \\A ')' appeared with no matching '(' still open. Usually there is one
+        \\closing parenthesis too many, or an earlier '(' was already closed.
+        ,
+    },
+    .{
+        .code = .invalid_number,
+        .name = "invalid-number",
+        .template = "invalid number literal",
+        .explanation =
+        \\A token that looked like a number could not be parsed as one — for
+        \\example a malformed radix prefix (#x, #o, #b, #e, #i), a bad exponent,
+        \\or a rational with a zero denominator.
+        ,
+    },
+    .{
+        .code = .invalid_character_name,
+        .name = "invalid-character-name",
+        .template = "invalid character name",
+        .explanation =
+        \\A '#\...' character literal named something the reader does not know.
+        \\Valid forms are a single character (#\a), a named character
+        \\(#\newline, #\space, #\tab, ...), or a hex escape (#\x41).
+        ,
+    },
+    .{
+        .code = .unterminated_string,
+        .name = "unterminated-string",
+        .template = "unterminated string literal",
+        .explanation =
+        \\A string opened with '"' was never closed before end of input. Add the
+        \\closing '"', or escape any literal '"' inside the string as '\"'.
+        ,
+    },
+    .{
+        .code = .invalid_escape,
+        .name = "invalid-escape",
+        .template = "invalid escape sequence",
+        .explanation =
+        \\A '\' inside a string was followed by a character that is not a valid
+        \\escape. R7RS allows \a \b \t \n \r \" \\ \x<hex>; and a line-continuation
+        \\'\' followed by whitespace and a newline.
+        ,
+    },
+    .{
+        .code = .dot_outside_list,
+        .name = "dot-outside-list",
+        .template = "'.' outside of a list",
+        .explanation =
+        \\A '.' (dotted-pair marker) appeared where it is not allowed. It is legal
+        \\only before the final element inside a list, as in (a . b) or (a b . c).
+        ,
+    },
+    .{
+        .code = .nesting_too_deep,
+        .name = "nesting-too-deep",
+        .template = "nesting too deep",
+        .explanation =
+        \\The datum nests more deeply than the reader's fixed limit. This usually
+        \\means unbalanced parentheses producing runaway nesting rather than a
+        \\genuinely deep literal.
+        ,
+    },
+    .{
+        .code = .token_too_long,
+        .name = "token-too-long",
+        .template = "token too long",
+        .explanation =
+        \\A single token (identifier, number, or string) exceeded the reader's
+        \\maximum token length. Split the input or shorten the token.
+        ,
+    },
+
+    // -- KP2xxx — Expand / compile ------------------------------------------
+    .{
+        .code = .invalid_syntax,
+        .name = "invalid-syntax",
+        .template = "invalid syntax",
+        .explanation =
+        \\A special form was written incorrectly — for example an 'if' with no
+        \\test, a 'define' with no body, or a 'lambda' whose parameter list is not
+        \\a proper list of identifiers. Check the form against its expected shape.
+        ,
+    },
+    .{
+        .code = .syntax_error,
+        .name = "syntax-error",
+        .template = "syntax error",
+        .explanation =
+        \\A macro rejected its use, either via the R7RS 'syntax-error' keyword or
+        \\because no 'syntax-rules' pattern matched the form. The accompanying
+        \\message describes what the macro expected.
+        ,
+    },
+    .{
+        .code = .macro_expansion_limit,
+        .name = "macro-expansion-limit",
+        .template = "macro expansion limit exceeded",
+        .explanation =
+        \\Macro expansion did not terminate within the implementation's step
+        \\limit, which almost always indicates a macro that expands into itself
+        \\without a base case.
+        ,
+    },
+
+    // -- KP3xxx — Runtime ---------------------------------------------------
+    .{
+        .code = .uncaught_exception,
+        .name = "uncaught-exception",
+        .template = "uncaught exception",
+        .explanation =
+        \\An object was raised (via 'raise', 'error', 'assert', or a library) and
+        \\reached the top level without being caught. Wrap the code in 'guard' or
+        \\'with-exception-handler' to handle it. The message shown is the payload
+        \\of the raised object.
+        ,
+    },
+    .{
+        .code = .undefined_variable,
+        .name = "undefined-variable",
+        .template = "undefined variable",
+        .explanation =
+        \\A variable was referenced that has no binding in scope. Check for a typo
+        \\(Kaappi suggests the nearest defined name), a missing 'import', or a
+        \\'define' that has not run yet because it appears after the reference.
+        ,
+    },
+    .{
+        .code = .type_error,
+        .name = "type-error",
+        .template = "type error",
+        .explanation =
+        \\A procedure was applied to an argument of the wrong type — for example
+        \\'car' on a non-pair or '+' on a non-number. The message names the
+        \\procedure, the type it expected, and the value it got.
+        ,
+    },
+    .{
+        .code = .arity_mismatch,
+        .name = "arity-mismatch",
+        .template = "wrong number of arguments",
+        .explanation =
+        \\A procedure was called with a number of arguments its parameter list
+        \\cannot accept. The message shows how many arguments were expected versus
+        \\how many were supplied.
+        ,
+    },
+    .{
+        .code = .division_by_zero,
+        .name = "division-by-zero",
+        .template = "division by zero",
+        .explanation =
+        \\An exact division, 'modulo', 'remainder', or 'quotient' had a zero
+        \\divisor. Guard the divisor, or use inexact arithmetic where the result
+        \\is a floating-point infinity or NaN instead of an error.
+        ,
+    },
+    .{
+        .code = .not_a_procedure,
+        .name = "not-a-procedure",
+        .template = "attempt to call a non-procedure",
+        .explanation =
+        \\The operator position of a call evaluated to something that is not a
+        \\procedure, as in (5 6). Check for an extra pair of parentheses or a name
+        \\that is bound to a value rather than a procedure.
+        ,
+    },
+    .{
+        .code = .index_out_of_bounds,
+        .name = "index-out-of-bounds",
+        .template = "index out of bounds",
+        .explanation =
+        \\An index passed to a sequence operation (vector-ref, string-ref,
+        \\list-ref, bytevector-u8-ref, ...) was negative or not less than the
+        \\length of the sequence.
+        ,
+    },
+    .{
+        .code = .invalid_argument,
+        .name = "invalid-argument",
+        .template = "invalid argument",
+        .explanation =
+        \\An argument was of an acceptable type but outside the range or shape the
+        \\procedure allows — for example a start index greater than an end index,
+        \\or a value a procedure explicitly rejects.
+        ,
+    },
+    .{
+        .code = .stack_overflow,
+        .name = "stack-overflow",
+        .template = "stack overflow",
+        .explanation =
+        \\The call stack grew past its limit, almost always from unbounded
+        \\non-tail recursion. Rewrite the recursion to be in tail position, or use
+        \\an explicit accumulator or loop.
+        ,
+    },
+    .{
+        .code = .execution_timeout,
+        .name = "execution-timeout",
+        .template = "execution timed out",
+        .explanation =
+        \\Execution exceeded a configured time budget and was interrupted. This is
+        \\a sandbox / watchdog limit, not a fault in the program's logic per se.
+        ,
+    },
+
+    // -- KP9xxx — Internal / resource exhaustion ----------------------------
+    .{
+        .code = .uncategorized,
+        .name = "uncategorized",
+        .template = "error",
+        .explanation =
+        \\A diagnostic that has not yet been assigned a specific code. Seeing this
+        \\code is itself a gap worth reporting: the underlying condition should get
+        \\its own registry entry.
+        ,
+    },
+    .{
+        .code = .internal_error,
+        .name = "internal-error",
+        .template = "internal compiler error",
+        .explanation =
+        \\Kaappi hit a condition that should not be reachable — a corrupt bytecode
+        \\stream or an internal limit. This indicates a bug in Kaappi itself;
+        \\please report it with the program that triggered it.
+        ,
+    },
+    .{
+        .code = .out_of_memory,
+        .name = "out-of-memory",
+        .template = "out of memory",
+        .explanation =
+        \\Memory allocation failed. The program (or a single datum, program text,
+        \\or data structure within it) is too large for the available heap.
+        ,
+    },
+};
+
+/// Look up the registry entry for a code. Completeness is guaranteed at compile
+/// time, so this never fails for a valid `Code`.
+pub fn lookup(code: Code) Diagnostic {
+    inline for (table) |d| {
+        if (d.code == code) return d;
+    }
+    unreachable;
+}
+
+// -- Internal bridge: Zig error set -> curated code -------------------------
+//
+// These map the implementation's internal error enums (ReadError, CompileError,
+// ExpandError, the VM's KaappiError) onto curated registry codes. They are an
+// implementation detail, NOT a public "the enum IS the code" contract: the code
+// space is deliberately separate and curated (KEP-0005 "Alternatives
+// considered"), so a coarse Zig error such as TypeError can later fan out into
+// several codes without touching the enum. Every branch resolves to a real code
+// so no raw `error.XxxYyy` name can reach the user; unknown values fall back to
+// a stage-appropriate catch-all rather than leaking.
+
+/// Reader-stage error -> KP1xxx code.
+pub fn readErrorCode(err: anyerror) Code {
+    return switch (err) {
+        error.UnexpectedEof => .unexpected_eof,
+        error.UnexpectedChar => .unexpected_char,
+        error.UnexpectedRightParen => .unexpected_right_paren,
+        error.InvalidNumber => .invalid_number,
+        error.InvalidCharacterName => .invalid_character_name,
+        error.UnterminatedString => .unterminated_string,
+        error.InvalidEscape => .invalid_escape,
+        error.DotNotInList => .dot_outside_list,
+        error.NestingTooDeep => .nesting_too_deep,
+        error.TokenTooLong => .token_too_long,
+        error.OutOfMemory => .out_of_memory,
+        else => .unexpected_char,
+    };
+}
+
+/// Expand/compile-stage error -> KP2xxx code. Callers that already have a
+/// syntax-error detail string should use `.syntax_error` directly instead.
+pub fn compileErrorCode(err: anyerror) Code {
+    return switch (err) {
+        error.InvalidSyntax, error.UndefinedVariable, error.JumpOutOfRange => .invalid_syntax,
+        error.MacroExpansionLimit => .macro_expansion_limit,
+        error.NoMatchingPattern,
+        error.EllipsisCountMismatch,
+        error.EllipsisDepthMismatch,
+        error.PatternTooComplex,
+        error.ScopeTableFull,
+        => .syntax_error,
+        error.TooManyConstants, error.TooManyLocals, error.InternalLimit, error.InvalidBytecode => .internal_error,
+        error.OutOfMemory => .out_of_memory,
+        else => .invalid_syntax,
+    };
+}
+
+/// Runtime-stage error -> KP3xxx code. Control-flow signals (Yielded,
+/// ContinuationInvoked, Terminated) are not diagnostics and should never reach
+/// the reporting layer; if one does it falls to `.uncategorized`.
+pub fn runtimeErrorCode(err: anyerror) Code {
+    return switch (err) {
+        error.ExceptionRaised => .uncaught_exception,
+        error.UndefinedVariable => .undefined_variable,
+        error.TypeError => .type_error,
+        error.ArityMismatch => .arity_mismatch,
+        error.DivisionByZero => .division_by_zero,
+        error.NotAProcedure => .not_a_procedure,
+        error.IndexOutOfBounds => .index_out_of_bounds,
+        error.InvalidArgument => .invalid_argument,
+        error.StackOverflow => .stack_overflow,
+        error.ExecutionTimeout => .execution_timeout,
+        error.OutOfMemory => .out_of_memory,
+        error.InvalidBytecode => .internal_error,
+        error.CompileError => .invalid_syntax,
+        else => .uncategorized,
+    };
+}
+
+// -- Registry integrity (compile-time gate) ---------------------------------
+//
+// Enforces the invariants KEP-0005 §5 asks a CI gate to check, but at build
+// time: every code has exactly one entry, no two entries collide, and every
+// entry carries a name, template, and explanation.
+comptime {
+    for (std.enums.values(Code)) |c| {
+        var count: usize = 0;
+        for (table) |d| {
+            if (d.code == c) count += 1;
+        }
+        if (count == 0) @compileError("diagnostics registry: code '" ++ @tagName(c) ++ "' has no table entry");
+        if (count > 1) @compileError("diagnostics registry: code '" ++ @tagName(c) ++ "' has duplicate table entries");
+    }
+    for (table) |d| {
+        if (d.name.len == 0) @compileError("diagnostics registry: entry '" ++ @tagName(d.code) ++ "' has an empty name");
+        if (d.template.len == 0) @compileError("diagnostics registry: entry '" ++ @tagName(d.code) ++ "' has an empty template");
+        if (d.explanation.len == 0) @compileError("diagnostics registry: entry '" ++ @tagName(d.code) ++ "' has an empty explanation");
+    }
+}

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -243,6 +243,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             try visited.put(src_ptr, new_val);
             const new_e = types.toObject(new_val).as(types.ErrorObject);
             new_e.error_type = e.error_type;
+            new_e.code = e.code;
             new_e.message = try deepCopyValue(gc, e.message, visited);
             new_e.irritants = try deepCopyValue(gc, e.irritants, visited);
             new_e.uncaught_reason = try deepCopyValue(gc, e.uncaught_reason, visited);

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,7 @@ pub const ir_mod = @import("ir.zig");
 pub const llvm_emit = @import("llvm_emit.zig");
 pub const native_compiler = @import("native_compiler.zig");
 pub const toplevel_driver = @import("toplevel_driver.zig");
+pub const diagnostics = @import("diagnostics.zig");
 pub const cli = @import("cli.zig");
 pub const config = @import("config.zig");
 
@@ -275,16 +276,14 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                         _ = top_result catch |err| {
                             script_had_error = true;
                             const detail = vm.getErrorDetail();
-                            if (detail.len > 0) {
-                                writeStderr("preamble error: ");
-                                writeStderr(detail);
-                                writeStderr("\n");
-                            } else {
-                                var errbuf: [256]u8 = undefined;
-                                const s = std.fmt.bufPrint(&errbuf, "preamble error: {}\n", .{err}) catch "preamble error\n";
-                                writeStderr(s);
-                            }
+                            const code = toplevel_driver.runtimeCode(vm, err);
+                            const msg = if (detail.len > 0) detail else code.message();
+                            var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+                            var errbuf: [256]u8 = undefined;
+                            const s = std.fmt.bufPrint(&errbuf, "preamble error[{s}]: {s}\n", .{ code.render(&cbuf), msg }) catch "preamble error\n";
+                            writeStderr(s);
                             vm.last_error_detail_len = 0;
+                            vm.last_error_code = .uncategorized;
                         };
                     }
                 }
@@ -299,15 +298,14 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 vm.gc.popRoot();
                 script_had_error = true;
                 const detail = vm.getErrorDetail();
-                if (detail.len > 0) {
-                    writeStderr(detail);
-                    writeStderr("\n");
-                } else {
-                    var errbuf: [256]u8 = undefined;
-                    const s = std.fmt.bufPrint(&errbuf, "runtime error: {}\n", .{err}) catch "runtime error\n";
-                    writeStderr(s);
-                }
+                const code = toplevel_driver.runtimeCode(vm, err);
+                const msg = if (detail.len > 0) detail else code.message();
+                var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+                var errbuf: [256]u8 = undefined;
+                const s = std.fmt.bufPrint(&errbuf, "error[{s}]: {s}\n", .{ code.render(&cbuf), msg }) catch "runtime error\n";
+                writeStderr(s);
                 vm.last_error_detail_len = 0;
+                vm.last_error_code = .uncategorized;
                 continue;
             };
             vm.gc.popRoot();
@@ -960,6 +958,7 @@ test {
     _ = llvm_emit;
     _ = native_compiler;
     _ = toplevel_driver;
+    _ = diagnostics;
     _ = repl_mod;
     _ = cli;
     _ = config;

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const types = @import("types.zig");
+const diagnostics = @import("diagnostics.zig");
 const Value = types.Value;
 const Object = types.Object;
 const ObjectTag = types.ObjectTag;
@@ -428,6 +429,15 @@ pub const GC = struct {
     }
 
     pub fn allocErrorObject(self: *GC, message: Value, irritants: Value) !Value {
+        return self.allocErrorObjectCoded(message, irritants, .uncategorized);
+    }
+
+    /// Like `allocErrorObject` but stamps a stable diagnostic code (KEP-0005).
+    /// Implementation raise sites that map to a specific registry code use this;
+    /// user errors and unmigrated sites use `allocErrorObject` (code
+    /// `.uncategorized`, which surfaces as the KP3000 "uncaught exception" code
+    /// at the top level).
+    pub fn allocErrorObjectCoded(self: *GC, message: Value, irritants: Value, code: diagnostics.Code) !Value {
         self.rootArgs2(message, irritants);
         try self.maybeCollect();
         self.clearArgRoots();
@@ -436,6 +446,7 @@ pub const GC = struct {
             .header = .{ .tag = .error_object },
             .message = message,
             .irritants = irritants,
+            .code = code,
         };
         self.finishAlloc(&err.header, @sizeOf(types.ErrorObject));
         return types.makePointer(@ptrCast(err));

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -8,6 +8,7 @@ const llvm_emit = @import("llvm_emit.zig");
 const file_utils = @import("file_utils.zig");
 const reporting = @import("reporting.zig");
 const kaappi_paths = @import("kaappi_paths.zig");
+const diagnostics = @import("diagnostics.zig");
 
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
@@ -52,15 +53,19 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
 
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
+        const code = diagnostics.readErrorCode(err);
+        var cbuf: [diagnostics.Code.render_width]u8 = undefined;
         var errbuf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
+        const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error[{s}]: {s}\n", .{ path, lc.line, lc.col, code.render(&cbuf), code.message() }) catch "read error\n";
         writeStderr(s);
         return err;
     }) {
         const expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
+            const code = diagnostics.readErrorCode(err);
+            var cbuf: [diagnostics.Code.render_width]u8 = undefined;
             var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error: {}\n", .{ path, lc.line, lc.col, err }) catch "read error\n";
+            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error[{s}]: {s}\n", .{ path, lc.line, lc.col, code.render(&cbuf), code.message() }) catch "read error\n";
             writeStderr(s);
             return err;
         };
@@ -92,8 +97,10 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         }
 
         const root = ir_mod.lowerAndOptimize(&ir_instance, expr, &vm.macros, false) catch |err| {
+            const code = diagnostics.compileErrorCode(err);
+            var cbuf: [diagnostics.Code.render_width]u8 = undefined;
             var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "IR lowering error: {}\n", .{err}) catch "IR error\n";
+            const s = std.fmt.bufPrint(&errbuf, "compile error[{s}]: {s}\n", .{ code.render(&cbuf), code.message() }) catch "compile error\n";
             writeStderr(s);
             return err;
         };
@@ -108,8 +115,10 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     var emitter = llvm_emit.LLVMEmitter.init(allocator);
     defer emitter.deinit();
     emitter.emitProgram(ir_nodes.items) catch |err| {
+        const code = diagnostics.Code.internal_error;
+        var cbuf: [diagnostics.Code.render_width]u8 = undefined;
         var errbuf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&errbuf, "LLVM emit error: {}\n", .{err}) catch "emit error\n";
+        const s = std.fmt.bufPrint(&errbuf, "error[{s}]: LLVM emit failed: {s}\n", .{ code.render(&cbuf), code.message() }) catch "internal error\n";
         writeStderr(s);
         return err;
     };

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -180,7 +180,7 @@ pub fn raiseDivByZero() PrimitiveError!Value {
     var msg = gc.allocString("division by zero") catch return PrimitiveError.DivisionByZero;
     gc.pushRoot(&msg);
     defer gc.popRoot();
-    const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.DivisionByZero;
+    const err_obj = gc.allocErrorObjectCoded(msg, types.NIL, .division_by_zero) catch return PrimitiveError.DivisionByZero;
     vm.current_exception = err_obj;
     return PrimitiveError.ExceptionRaised;
 }

--- a/src/tests_diagnostics.zig
+++ b/src/tests_diagnostics.zig
@@ -1,0 +1,97 @@
+//! Tests for the diagnostic registry (KEP-0005, #1504).
+//!
+//! Registry integrity (uniqueness, completeness, non-empty fields) is also
+//! enforced at compile time by the `comptime` block in diagnostics.zig; these
+//! runtime tests exercise the public API (render, lookup, the internal
+//! error->code mappings) and the end-to-end stamping of codes onto error
+//! objects.
+
+const std = @import("std");
+const diagnostics = @import("diagnostics.zig");
+const types = @import("types.zig");
+const th = @import("testing_helpers.zig");
+const Code = diagnostics.Code;
+
+test "code renders as KPnnnn" {
+    var buf: [Code.render_width]u8 = undefined;
+    try std.testing.expectEqualStrings("KP1002", Code.unexpected_char.render(&buf));
+    try std.testing.expectEqualStrings("KP2002", Code.syntax_error.render(&buf));
+    try std.testing.expectEqualStrings("KP3000", Code.uncaught_exception.render(&buf));
+    try std.testing.expectEqualStrings("KP3001", Code.undefined_variable.render(&buf));
+    try std.testing.expectEqualStrings("KP3004", Code.division_by_zero.render(&buf));
+    try std.testing.expectEqualStrings("KP9000", Code.uncategorized.render(&buf));
+}
+
+test "every code resolves to a complete registry entry" {
+    for (std.enums.values(Code)) |c| {
+        const d = diagnostics.lookup(c);
+        try std.testing.expectEqual(c, d.code);
+        try std.testing.expect(d.name.len > 0);
+        try std.testing.expect(d.template.len > 0);
+        try std.testing.expect(d.explanation.len > 0);
+    }
+}
+
+test "no two registry entries share a code" {
+    for (diagnostics.table, 0..) |a, i| {
+        for (diagnostics.table[i + 1 ..]) |b| {
+            try std.testing.expect(a.code != b.code);
+        }
+    }
+}
+
+test "reader errors map to read-stage codes with no leak fallback" {
+    try std.testing.expectEqual(Code.unexpected_eof, diagnostics.readErrorCode(error.UnexpectedEof));
+    try std.testing.expectEqual(Code.unexpected_char, diagnostics.readErrorCode(error.UnexpectedChar));
+    try std.testing.expectEqual(Code.unexpected_right_paren, diagnostics.readErrorCode(error.UnexpectedRightParen));
+    try std.testing.expectEqual(Code.unterminated_string, diagnostics.readErrorCode(error.UnterminatedString));
+    try std.testing.expectEqual(Code.dot_outside_list, diagnostics.readErrorCode(error.DotNotInList));
+    // An unrecognized reader error still resolves to a real read-stage code
+    // rather than leaking the Zig error name.
+    try std.testing.expectEqual(Code.unexpected_char, diagnostics.readErrorCode(error.SomeFutureReaderError));
+}
+
+test "compile errors map to compile-stage codes" {
+    try std.testing.expectEqual(Code.invalid_syntax, diagnostics.compileErrorCode(error.InvalidSyntax));
+    try std.testing.expectEqual(Code.macro_expansion_limit, diagnostics.compileErrorCode(error.MacroExpansionLimit));
+    try std.testing.expectEqual(Code.syntax_error, diagnostics.compileErrorCode(error.NoMatchingPattern));
+    try std.testing.expectEqual(Code.internal_error, diagnostics.compileErrorCode(error.TooManyConstants));
+    try std.testing.expectEqual(Code.invalid_syntax, diagnostics.compileErrorCode(error.SomeFutureCompileError));
+}
+
+test "runtime errors map to runtime-stage codes" {
+    try std.testing.expectEqual(Code.undefined_variable, diagnostics.runtimeErrorCode(error.UndefinedVariable));
+    try std.testing.expectEqual(Code.type_error, diagnostics.runtimeErrorCode(error.TypeError));
+    try std.testing.expectEqual(Code.arity_mismatch, diagnostics.runtimeErrorCode(error.ArityMismatch));
+    try std.testing.expectEqual(Code.not_a_procedure, diagnostics.runtimeErrorCode(error.NotAProcedure));
+    try std.testing.expectEqual(Code.index_out_of_bounds, diagnostics.runtimeErrorCode(error.IndexOutOfBounds));
+    try std.testing.expectEqual(Code.uncaught_exception, diagnostics.runtimeErrorCode(error.ExceptionRaised));
+    // Control-flow signals are not diagnostics — they must never surface a
+    // stage-specific code.
+    try std.testing.expectEqual(Code.uncategorized, diagnostics.runtimeErrorCode(error.Yielded));
+    try std.testing.expectEqual(Code.uncategorized, diagnostics.runtimeErrorCode(error.ContinuationInvoked));
+}
+
+test "division-by-zero error object carries the division_by_zero code" {
+    // Division raises through the exception system, so the specific code has to
+    // ride on the object to survive to the reporting layer (KEP-0005 §4).
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const result = try ctx.vm.eval("(guard (e (#t e)) (/ 1 0))");
+    try std.testing.expect(types.isErrorObject(result));
+    const eo = types.toObject(result).as(types.ErrorObject);
+    try std.testing.expectEqual(Code.division_by_zero, eo.code);
+}
+
+test "user (error ...) objects are uncoded" {
+    // The KP namespace is reserved to the implementation; a user error carries
+    // no code (surfaces as the generic KP3000 uncaught-exception at top level).
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const result = try ctx.vm.eval("(guard (e (#t e)) (error \"boom\" 1 2))");
+    try std.testing.expect(types.isErrorObject(result));
+    const eo = types.toObject(result).as(types.ErrorObject);
+    try std.testing.expectEqual(Code.uncategorized, eo.code);
+}

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const vm_mod = @import("vm.zig");
 const compiler_mod = @import("compiler.zig");
 const reporting = @import("reporting.zig");
+const diagnostics = @import("diagnostics.zig");
 
 const writeStderr = reporting.writeStderr;
 
@@ -10,58 +11,76 @@ pub const Location = struct {
     line: u32,
 };
 
+// Every diagnostic Kaappi prints carries a stable KP code (KEP-0005, #1504).
+// The leading digit encodes the stage: KP1xxx read, KP2xxx compile, KP3xxx
+// runtime. The stage word ("read error" / "compile error" / runtime "error")
+// is kept for the human reader; the bracketed code is the machine handle. The
+// registry also supplies the fallback message that replaces the raw
+// `error.XxxYyy` Zig-enum names these paths used to leak.
+
 pub fn reportReadError(source_name: []const u8, line: u32, col: u32, err: anyerror) void {
+    const code = diagnostics.readErrorCode(err);
+    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
     var buf: [256]u8 = undefined;
-    const s = std.fmt.bufPrint(&buf, "{s}:{d}:{d}: read error: {}\n", .{ source_name, line, col, err }) catch "read error\n";
+    const s = std.fmt.bufPrint(&buf, "{s}:{d}:{d}: read error[{s}]: {s}\n", .{
+        source_name, line, col, code.render(&cbuf), code.message(),
+    }) catch "read error\n";
     writeStderr(s);
 }
 
 pub fn reportCompileError(source_name: []const u8, line: u32, err: anyerror) void {
+    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
     const detail = compiler_mod.getSyntaxErrorDetail();
     if (detail.len > 0) {
+        const code = diagnostics.Code.syntax_error;
         var buf: [256]u8 = undefined;
-        const prefix = std.fmt.bufPrint(&buf, "{s}:{d}: syntax-error: ", .{ source_name, line }) catch "syntax-error: ";
+        const prefix = std.fmt.bufPrint(&buf, "{s}:{d}: syntax-error[{s}]: ", .{ source_name, line, code.render(&cbuf) }) catch "syntax-error: ";
         writeStderr(prefix);
         writeStderr(detail);
         writeStderr("\n");
         compiler_mod.syntax_error_detail_len = 0;
     } else {
+        const code = diagnostics.compileErrorCode(err);
         var buf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&buf, "{s}:{d}: compile error: {}\n", .{ source_name, line, err }) catch "compile error\n";
+        const s = std.fmt.bufPrint(&buf, "{s}:{d}: compile error[{s}]: {s}\n", .{ source_name, line, code.render(&cbuf), code.message() }) catch "compile error\n";
         writeStderr(s);
     }
 }
 
 pub fn reportRuntimeError(vm: *vm_mod.VM, err: anyerror, location: ?Location) void {
     const detail = vm.getErrorDetail();
+    const code = runtimeCode(vm, err);
+    // A raise-site detail (e.g. "type error in 'car': ...") is richer than the
+    // registry template, so prefer it when present; the code rides along either
+    // way and the template is the no-detail fallback that killed the Zig leak.
+    const msg = if (detail.len > 0) detail else code.message();
+    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+    const code_str = code.render(&cbuf);
     if (location) |loc| {
-        if (detail.len > 0) {
-            var buf: [512]u8 = undefined;
-            const s = if (loc.line > 0)
-                std.fmt.bufPrint(&buf, "{s}:{d}: error: {s}\n", .{ loc.source, loc.line, detail }) catch "runtime error\n"
-            else
-                std.fmt.bufPrint(&buf, "{s}: error: {s}\n", .{ loc.source, detail }) catch "runtime error\n";
-            writeStderr(s);
-        } else {
-            var buf: [512]u8 = undefined;
-            const s = if (loc.line > 0)
-                std.fmt.bufPrint(&buf, "{s}:{d}: runtime error: {}\n", .{ loc.source, loc.line, err }) catch "runtime error\n"
-            else
-                std.fmt.bufPrint(&buf, "{s}: runtime error: {}\n", .{ loc.source, err }) catch "runtime error\n";
-            writeStderr(s);
-        }
+        var buf: [512]u8 = undefined;
+        const s = if (loc.line > 0)
+            std.fmt.bufPrint(&buf, "{s}:{d}: error[{s}]: {s}\n", .{ loc.source, loc.line, code_str, msg }) catch "runtime error\n"
+        else
+            std.fmt.bufPrint(&buf, "{s}: error[{s}]: {s}\n", .{ loc.source, code_str, msg }) catch "runtime error\n";
+        writeStderr(s);
     } else {
-        if (detail.len > 0) {
-            writeStderr("error: ");
-            writeStderr(detail);
-            writeStderr("\n");
-        } else {
-            var buf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&buf, "runtime error: {}\n", .{err}) catch "runtime error\n";
-            writeStderr(s);
-        }
+        var buf: [512]u8 = undefined;
+        const s = std.fmt.bufPrint(&buf, "error[{s}]: {s}\n", .{ code_str, msg }) catch "runtime error\n";
+        writeStderr(s);
     }
     vm.last_error_detail_len = 0;
+    vm.last_error_code = .uncategorized;
+}
+
+/// The diagnostic code for a runtime error: the code carried on the raised
+/// error object if any (set in noteUncaughtException), else one derived from the
+/// escaping Zig error. Callers outside `reportRuntimeError` (the bundled-binary
+/// and include paths) use this so every runtime-error surface agrees.
+pub fn runtimeCode(vm: *vm_mod.VM, err: anyerror) diagnostics.Code {
+    return if (vm.last_error_code != .uncategorized)
+        vm.last_error_code
+    else
+        diagnostics.runtimeErrorCode(err);
 }
 
 pub fn vmErrorLocation(vm: *vm_mod.VM, fallback_source: []const u8, fallback_line: u32) Location {

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const build_options = @import("build_options");
+const diagnostics = @import("diagnostics.zig");
 
 /// A Scheme value packed into a 64-bit word (NaN-boxing).
 ///
@@ -410,6 +411,12 @@ pub const ErrorObject = struct {
     irritants: Value, // list
     error_type: ErrorType = .general,
     uncaught_reason: Value = VOID,
+    /// Stable diagnostic code (KEP-0005, #1504). Defaults to `.uncategorized`
+    /// for user errors — `(error ...)` — and any raise site not yet migrated;
+    /// implementation raise sites stamp a specific code. Carried on the object
+    /// so it survives catch/re-raise and is the seed the Phase-4
+    /// `error-object-code` accessor reads.
+    code: diagnostics.Code = .uncategorized,
 };
 
 pub const RecordType = struct {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const diagnostics = @import("diagnostics.zig");
 const compiler_mod = @import("compiler.zig");
 const library_mod = @import("library.zig");
 const reactor_mod = @import("reactor.zig");
@@ -225,6 +226,11 @@ pub const VM = struct {
     last_error_detail_len: usize = 0,
     last_error_line: u32 = 0,
     last_error_source: ?[]const u8 = null,
+    // Diagnostic code of the escaping error (KEP-0005, #1504). Set by
+    // noteUncaughtException from the raised error object; reset per top-level
+    // form in resetExecutionState. When `.uncategorized`, the reporting layer
+    // derives a code from the Zig error instead.
+    last_error_code: diagnostics.Code = .uncategorized,
     last_stack_trace: [16]StackFrame = undefined,
     last_stack_trace_len: usize = 0,
     // Debugger state
@@ -547,6 +553,13 @@ pub const VM = struct {
         if (err != error.ExceptionRaised) return;
         const exc = self.current_exception orelse return;
         self.current_exception = null;
+        // Carry the raised object's stable diagnostic code to the reporting
+        // layer (KEP-0005), whether or not a native detail was already recorded.
+        // `.uncategorized` here means "uncoded raise" and the reporter falls
+        // back to the generic KP3000 uncaught-exception code.
+        if (types.isErrorObject(exc)) {
+            self.last_error_code = types.toObject(exc).as(types.ErrorObject).code;
+        }
         if (self.last_error_detail_len != 0) return;
 
         const printer = @import("printer.zig");

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -106,6 +106,10 @@ pub fn profileTailCall(vm: *VM, new_func: *types.Function) void {
 pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
     vm_mod.setVMInstance(vm);
     vm.resetExecutionState();
+    // Clear the diagnostic code at entry (not in resetExecutionState, which also
+    // runs on the error-exit path *after* noteUncaughtException has recorded the
+    // escaping error's code — see the last_error_detail save/restore there).
+    vm.last_error_code = .uncategorized;
 
     // Each top-level form starts on the main fiber. A previous form may have
     // left the scheduler positioned on a spawned fiber, or the main fiber

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -4,6 +4,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const library_mod = @import("library.zig");
+const diagnostics = @import("diagnostics.zig");
 const file_utils = @import("file_utils.zig");
 const Value = types.Value;
 
@@ -732,12 +733,16 @@ fn evalIncludedForm(vm: *VM, expr: Value, path: []const u8, line: u32) void {
 }
 
 fn reportIncludeError(vm: *VM, path: []const u8, line: u32, detail: ?[]const u8, err: anyerror) void {
-    _ = vm;
-    var buf: [320]u8 = undefined;
-    const s = if (detail) |d| (if (d.len > 0)
-        std.fmt.bufPrint(&buf, "{s}:{d}: error: {s}\n", .{ path, line, d }) catch "include error\n"
+    // Prefer a code carried on the raised error object; else derive from the
+    // escaping Zig error (KEP-0005).
+    const code = if (vm.last_error_code != .uncategorized)
+        vm.last_error_code
     else
-        std.fmt.bufPrint(&buf, "{s}:{d}: runtime error: {}\n", .{ path, line, err }) catch "include error\n") else std.fmt.bufPrint(&buf, "{s}:{d}: error: {}\n", .{ path, line, err }) catch "include error\n";
+        diagnostics.runtimeErrorCode(err);
+    const msg = if (detail) |d| (if (d.len > 0) d else code.message()) else code.message();
+    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+    var buf: [320]u8 = undefined;
+    const s = std.fmt.bufPrint(&buf, "{s}:{d}: error[{s}]: {s}\n", .{ path, line, code.render(&cbuf), msg }) catch "include error\n";
     vm_mod.writeStderr(s);
 }
 

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -25,4 +25,5 @@ test {
     _ = @import("tests_reactor.zig");
     _ = @import("tests_scheduler.zig");
     _ = @import("tests_port_io.zig");
+    _ = @import("tests_diagnostics.zig");
 }

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -38,6 +38,24 @@ assert_file_output_contains() {
     fi
 }
 
+# Assert the interpreter output for an input does NOT leak a raw Zig error
+# name. Zig renders an error value as "error.Xxx" (a dotted, capitalized tag),
+# which must never reach the user — every path maps to a registry message
+# instead (KEP-0005, #1504).
+assert_no_zig_leak() {
+    local label="$1"
+    local input="$2"
+    local output
+    output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
+    if echo "$output" | grep -qE 'error\.[A-Z][A-Za-z]+'; then
+        echo "FAIL: $label — leaked a Zig error name: $(echo "$output" | grep -oE 'error\.[A-Z][A-Za-z]+' | head -1)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
 echo "=== Error format tests ==="
 echo
 
@@ -63,14 +81,14 @@ echo
 echo "-- syntax-error diagnostics --"
 
 assert_output_contains "syntax-error includes message" \
-    '(syntax-error "custom msg")' 'syntax-error: custom msg'
+    '(syntax-error "custom msg")' 'syntax-error[KP2002]: custom msg'
 
 assert_output_contains "syntax-error includes irritants" \
-    '(syntax-error "custom msg" 42)' 'syntax-error: custom msg 42'
+    '(syntax-error "custom msg" 42)' 'syntax-error[KP2002]: custom msg 42'
 
 assert_output_contains "syntax-error from macro includes message" \
     '(define-syntax bad (syntax-rules () ((_ x) (syntax-error "bad usage" x)))) (bad 1)' \
-    'syntax-error: bad usage 1'
+    'syntax-error[KP2002]: bad usage 1'
 
 assert_output_contains "syntax-error has location" \
     '(syntax-error "msg")' '<stdin>:1:'
@@ -148,8 +166,8 @@ assert_output_contains "division by zero" \
 echo
 echo "-- Stack overflow --"
 
-assert_output_contains "stack overflow is reported" \
-    '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 50000)' "StackOverflow"
+assert_output_contains "stack overflow is reported with code" \
+    '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 50000)' "error[KP3008]: stack overflow"
 
 # --- Library import errors ---
 echo
@@ -199,12 +217,13 @@ assert_output_contains "error message preserved through dynamic-wind after with 
     '(dynamic-wind (lambda () #t) (lambda () (error "REAL-MSG")) (lambda () (display "")))' \
     "REAL-MSG"
 
-# Issue #1032: malformed let*-values and guard must report InvalidSyntax, not OOM
-assert_output_contains "malformed let*-values reports InvalidSyntax" \
-    '(let*-values (42) 1)' "InvalidSyntax"
+# Issue #1032: malformed let*-values and guard must report a clean compile
+# error (KP2001 invalid-syntax), not OOM and not a leaked Zig error name.
+assert_output_contains "malformed let*-values reports invalid syntax" \
+    '(let*-values (42) 1)' "compile error[KP2001]: invalid syntax"
 
-assert_output_contains "malformed guard clause reports InvalidSyntax" \
-    '(guard (e (#t "ok") . bad) 1)' "InvalidSyntax"
+assert_output_contains "malformed guard clause reports invalid syntax" \
+    '(guard (e (#t "ok") . bad) 1)' "compile error[KP2001]: invalid syntax"
 
 # Issue #78: mismatched-length ellipsis template variables must be rejected
 # with a clean compile error, not read uninitialized memory. (Moved from
@@ -224,24 +243,27 @@ assert_output_contains "apply-position type error includes diagnostic" \
 echo
 echo "-- Uncaught exceptions --"
 
+# An uncaught user (error ...) or raised value carries the generic KP3000
+# "uncaught exception" code; the specific KP namespace is reserved to the
+# implementation, so user errors do not get a more specific code.
 assert_output_contains "uncaught (error ...) shows message" \
-    '(error "something went wrong" 42)' 'error: something went wrong 42'
+    '(error "something went wrong" 42)' 'error[KP3000]: something went wrong 42'
 
 assert_output_contains "uncaught (error ...) writes irritants" \
-    '(error "kaboom" (list 1 2) "x")' 'error: kaboom (1 2) "x"'
+    '(error "kaboom" (list 1 2) "x")' 'error[KP3000]: kaboom (1 2) "x"'
 
 assert_output_contains "uncaught raise of non-error object shows the value" \
-    "(raise 'oops)" 'error: uncaught exception: oops'
+    "(raise 'oops)" 'error[KP3000]: uncaught exception: oops'
 
 assert_output_contains "uncaught exception inside procedure shows message" \
-    '(define (f) (error "boom" 1)) (f)' 'error: boom 1'
+    '(define (f) (error "boom" 1)) (f)' 'error[KP3000]: boom 1'
 
 cat > "$TMPDIR/uncaught.scm" << 'SCHEME'
 (error "script boom" 7)
 SCHEME
 
 assert_file_output_contains "uncaught (error ...) in script shows message" \
-    "$TMPDIR/uncaught.scm" 'error: script boom 7'
+    "$TMPDIR/uncaught.scm" 'error[KP3000]: script boom 7'
 
 rm -rf "$TMPDIR"
 
@@ -304,6 +326,55 @@ assert_output_contains "dynamic-wind bad after names dynamic-wind" \
 
 assert_output_contains "%push-wind is not globally reachable" \
     '(%push-wind car car)' "undefined variable"
+
+# --- Diagnostic codes appear per stage (KEP-0005, #1504) ---
+echo
+echo "-- Diagnostic codes (KEP-0005) --"
+
+# Read stage: KP1xxx, and the raw Zig error name is gone.
+assert_output_contains "reader error carries a KP1xxx code" \
+    '(define x #\bogus)' 'read error[KP1'
+assert_output_contains "unterminated string is KP1006" \
+    '(display "abc' 'read error[KP1006]'
+assert_output_contains "unexpected right paren is KP1003" \
+    '(+ 1 2))' 'read error[KP1003]'
+
+# Compile stage: KP2xxx.
+assert_output_contains "empty if is a KP2xxx compile error" \
+    '(if)' 'compile error[KP2'
+
+# Runtime stage: KP3xxx, one code per user-distinguishable condition.
+assert_output_contains "undefined variable is KP3001" \
+    '(display countr)' 'error[KP3001]'
+assert_output_contains "type error is KP3002" \
+    '(car 5)' 'error[KP3002]'
+assert_output_contains "arity mismatch is KP3003" \
+    '((lambda (x) x) 1 2)' 'error[KP3003]'
+assert_output_contains "division by zero is KP3004" \
+    '(/ 1 0)' 'error[KP3004]: division by zero'
+assert_output_contains "not a procedure is KP3005" \
+    '(5 6)' 'error[KP3005]'
+assert_output_contains "index out of bounds is KP3006" \
+    '(vector-ref (vector 1 2) 9)' 'error[KP3006]'
+# A user (error ...) is uncoded -> generic KP3000, not a specific KP.
+assert_output_contains "uncaught user error is KP3000" \
+    '(error "boom")' 'error[KP3000]: boom'
+
+# --- No leaked Zig error names on any path (KEP-0005, #1504) ---
+echo
+echo "-- No leaked Zig error names --"
+assert_no_zig_leak "reader error path"       '(define x #\bogus)'
+assert_no_zig_leak "unterminated string"     '(display "abc'
+assert_no_zig_leak "empty if compile error"  '(if)'
+assert_no_zig_leak "malformed let*-values"   '(let*-values (42) 1)'
+assert_no_zig_leak "undefined variable"      '(display countr)'
+assert_no_zig_leak "type error"              '(car 5)'
+assert_no_zig_leak "arity mismatch"          '((lambda (x) x) 1 2)'
+assert_no_zig_leak "division by zero"        '(/ 1 0)'
+assert_no_zig_leak "not a procedure"         '(5 6)'
+assert_no_zig_leak "stack overflow"          '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 50000)'
+assert_no_zig_leak "uncaught user error"     '(error "boom" 1)'
+assert_no_zig_leak "raised non-error value"  '(raise 42)'
 
 echo
 echo "=== Results ==="

--- a/tests/scheme/robustness/robustness.sh
+++ b/tests/scheme/robustness/robustness.sh
@@ -15,7 +15,9 @@ assert_error() {
     local expr="$2"
     local output
     output=$(echo "$expr" | "$KAAPPI" 2>&1 || true)
-    if echo "$output" | grep -q "error:"; then
+    # Match both the coded form ("error[KP3002]:", KEP-0005) and any legacy
+    # "error:" prefix.
+    if echo "$output" | grep -qE 'error(\[|:)'; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else

--- a/tests/scheme/sandbox/sandbox-escape.sh
+++ b/tests/scheme/sandbox/sandbox-escape.sh
@@ -118,9 +118,10 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# Memory limit test
+# Memory limit test. The out-of-memory diagnostic is KP9002 (KEP-0005); match
+# the stable code, not the old leaked Zig error name ("OutOfMemory").
 output=$(echo '(define (eat n a) (if (= n 0) a (eat (- n 1) (cons n a)))) (eat 1000000 (list))' | "$KAAPPI" --max-memory 100000 2>&1 || true)
-if echo "$output" | grep -qF "OutOfMemory"; then
+if echo "$output" | grep -qF "KP9002"; then
     echo "PASS: --max-memory stops excessive allocation"
     PASS=$((PASS + 1))
 else


### PR DESCRIPTION
Closes #1504. Phase 1 of the diagnostic contract ([KEP-0005](https://github.com/kaappi/keps/blob/main/keps/0005-diagnostic-contract.md)) and the keystone of the machine-legibility campaign (#1503).

## What

Every user-facing diagnostic now carries a stable `KP`-prefixed code, and the raw `error.XxxYyy` Zig-name leaks are gone.

```
<stdin>:1:12: read error: error.UnexpectedChar   →  read error[KP1002]: unexpected character
<stdin>:1: compile error: error.InvalidSyntax     →  compile error[KP2001]: invalid syntax
error: undefined variable 'countr'. Did you mean…  →  error[KP3001]: undefined variable 'countr'. Did you mean 'count'?
error: division by zero                            →  error[KP3004]: division by zero
```

The code is the stable machine handle; the message after it stays free to improve.

## How

- **`src/diagnostics.zig`** — a comptime registry of 26 codes across the KEP taxonomy (`KP1xxx` read, `KP2xxx` compile, `KP3xxx` runtime, `KP9xxx` internal). Each entry binds code + name + message template + `kaappi explain` prose + severity. The `Code` enum's integer value *is* the KP number, and a **comptime integrity gate** fails the build on any duplicate, missing, or empty-field entry (the KEP's registry-integrity check, enforced at build time).
- **Centralized output** — all reporting flows through `toplevel_driver.zig`; the bundled-binary, `include`, and native-compile duplicate paths were also de-leaked.
- **Two error worlds, both coded** — native-propagating `VMError`s are coded by `runtimeErrorCode`; errors *raised as objects* (division-by-zero, `error`, `raise`) carry the code on a new internal `ErrorObject.code` field (`GC.allocErrorObjectCoded`, lifted to reporting by `noteUncaughtException`). This is the robust representation the Phase-4 `error-object-code` accessor reuses. Division-by-zero is stamped `KP3004`; the long tail shows generic `KP3000` until migrated; user `(error …)` stays uncoded (`KP` is reserved to the implementation). `error_type` and the R7RS error accessors are untouched.

## Acceptance criteria

- [x] Registry file with the diagnostics enumerated and coded — `src/diagnostics.zig`
- [x] Codes appear in text output for read/expand/compile/runtime errors
- [x] No `error.XxxYyy` Zig names in any user-facing message — `assert_no_zig_leak` grep test + a 13-case battery
- [x] `tests/scheme/errors/error-format.sh` extended to assert codes — **79 pass**
- [x] Stability policy documented — `docs/dev/diagnostics.md` (+ README index)

## Testing

- Unit suite green, including new `src/tests_diagnostics.zig` (render, lookup, error→code maps, end-to-end object stamping)
- Full Scheme suite: **1845 pass / 0 fail** (450 files + 1395 R7RS)
- All `tests/scheme/errors/*.sh` pass; `-Dgc-stress=true` clean on the new alloc path; `zig build wasm` clean; `zig fmt` clean

One subtle bug fixed along the way: `last_error_code` must reset at `execute()` *entry*, not in `resetExecutionState` — which also runs on the error-*exit* path, after `noteUncaughtException` records the escaping error's code (the same reason the detail buffer is save/restored there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
