### PR TITLE
Add A/B/C/D envelope-cost benchmark matrix (KEP-0002 Phase 7)

### DIFF
--- a/docs/dev/kep-0002-phase7-envelope-benchmarks.md
+++ b/docs/dev/kep-0002-phase7-envelope-benchmarks.md
@@ -1,0 +1,217 @@
+# KEP-0002 Phase 7 — envelope-cost A/B/C/D micro-benchmark (P3)
+
+This documents the **envelope-cost half** of KEP-0002 Phase 7
+([kaappi#1472](https://github.com/kaappi/kaappi/issues/1472)): the P3
+elision-lever matrix from
+[keps `research/open-problems.md` P3](https://github.com/kaappi/keps/blob/main/research/open-problems.md)
+and the pre-registered A/B/C/D decision it drives. It is the "run
+before/after, compare by eye" benchmark tier (like `bench-fibers` /
+`bench-reactor`), **not** the statistically-disciplined gate campaign.
+
+The other Phase 7 half — the `parallel-map` scaling curve that feeds the
+KEP-0003 acceptance gate ([kaappi#1474](https://github.com/kaappi/kaappi/issues/1474)),
+under the full Kalibera–Jones statistics of
+[keps `research/benchmarks/README.md`](https://github.com/kaappi/keps/blob/main/research/benchmarks/README.md)
+— is separate and still to do (see [Status](#status--what-remains)).
+
+## Running it
+
+```
+zig build bench-channel                        # ReleaseSafe: the shipped default
+zig build bench-channel -Doptimize=ReleaseFast # faster build, for contrast
+```
+
+The harness prints its build mode in the header. **The P3 decision reads
+the ReleaseSafe numbers**, because the shipped binary is ReleaseSafe
+(keps `research/benchmarks/README.md` §4.5) and the (B) verdict is
+build-mode sensitive (below).
+
+## What it measures
+
+Three sections (`src/bench_channel.zig`):
+
+1. **Local (unpromoted) send+receive** — the invariant-3 fast-path gate: a
+   channel that never crossed a thread is today's pair-queue plus two
+   null-checks. Runs through a real VM/eval.
+2. **The P3 A/B/C/D matrix** — for each lever × payload shape, a
+   send-side *build envelope* + receive-side *copy out* round trip,
+   reporting ns/message, allocations/message (via a counting allocator),
+   and the message's heap-object count.
+3. **Reference: real promoted send+receive** through `shared_channel`
+   (lever A, full spin-lock + queue), so the matrix's lever-A column ties
+   back to the shipped path.
+
+### The four levers
+
+| Lever | Envelope strategy |
+|-------|-------------------|
+| **A** | Per-message GC struct — a fresh private mini-heap + `deepCopy` in, torn down after copy-out. Exactly what `src/shared_channel.zig` ships. |
+| **B** | Reusable per-channel arena — one persistent GC reused message after message; only the copied-in graph is freed between uses, keeping the ~8 KiB root buffer + GC struct across the channel's life. |
+| **C** | A **plus** the immediate fast path — non-pointer NaN-boxed values (fixnums, booleans, chars; also nil/flonums) skip the envelope heap entirely (`deepCopy` would return them unchanged). |
+| **D** | C **plus** a refcounted immutable side-heap — large bytevectors/strings (≥ 8 KiB here) cross by a `shared_object` reference: one snapshot copy at creation, zero-copy on receive. |
+
+The workloads are P3's five shapes: fixnum, small pair, 1 KiB string,
+64 KiB bytevector, and a 50-deep nested-pair chain standing in for the
+"deep record" shape (same stand-in the Phase 1 harness used, until a
+record-type harness lands).
+
+## Results — macOS aarch64
+
+Reference machine: Apple **M3 Pro**, 12 physical cores (6P+6E,
+heterogeneous — noted per protocol §4.6), macOS 26.5.2, Zig 0.16.0,
+kaappi `5e86f231`. Machine idle, on power. These are single-run point
+estimates from this benchmark tier; the mechanical decision below reads
+only the outcomes that clear their thresholds by a wide margin (see
+[Caveats](#caveats)).
+
+### ns/message
+
+**ReleaseSafe (operative — shipped default):**
+
+| payload shape | A | B | C | D |
+|---|--:|--:|--:|--:|
+| fixnum | 256.8 | 5.4 | 2.4 | 2.3 |
+| small pair | 405.9 | 141.0 | 485.5 | 470.1 |
+| 1 KiB string | 555.9 | 238.0 | 479.9 | 540.0 |
+| 64 KiB bytevector | 5673.4 | 4714.6 | 5514.4 | 1996.6 |
+| 50-deep chain | 4819.7 | 4557.7 | 4885.3 | 4842.4 |
+
+**ReleaseFast (contrast):**
+
+| payload shape | A | B | C | D |
+|---|--:|--:|--:|--:|
+| fixnum | 60.1 | 3.8 | 2.2 | 2.2 |
+| small pair | 179.9 | 123.1 | 181.5 | 180.8 |
+| 1 KiB string | 254.7 | 188.7 | 255.6 | 255.4 |
+| 64 KiB bytevector | 2268.4 | 2120.0 | 2276.8 | 881.6 |
+| 50-deep chain | 4636.2 | 4656.0 | 4739.7 | 4546.9 |
+
+### allocations/message (deterministic, identical across both builds)
+
+| payload shape | A | B | C | D | msg heap objs |
+|---|--:|--:|--:|--:|--:|
+| fixnum | 2 | 0 | 0 | 0 | 0 |
+| small pair | 6 | 4 | 6 | 6 | 1 |
+| 1 KiB string | 8 | 6 | 8 | 8 | 1 |
+| 64 KiB bytevector | 8 | 6 | 8 | 2 | 1 |
+| 50-deep chain | 110 | 108 | 110 | 110 | 50 |
+
+The allocation column is the mechanism, exactly:
+
+- **A pays two fixed allocations per message** — the GC struct and its
+  ~8 KiB root buffer — *even for a fixnum whose message graph has zero
+  heap objects*. That fixed tax is what the other levers attack.
+- **B removes exactly those two** across every shape (6→4, 8→6, 110→108):
+  the arena is allocated once, not per message.
+- **C removes the whole envelope for immediates** (2→0 on the fixnum) and
+  is a no-op for pointer payloads (it falls through to A).
+- **D turns the 64 KiB copy into a refcount**: 8→2 allocations (the
+  side-buffer struct + its bytes, allocated once) and no copy-out.
+
+## The pre-registered P3 decision
+
+Thresholds verbatim from open-problems.md P3; the harness prints this
+block mechanically.
+
+### (C) immediate fast path — **SHIP**
+
+> (C) ships if immediates are ≥ 2× (A) for fixnum messages.
+
+Fixnum A/C = **107.9×** (ReleaseSafe), **27.8×** (ReleaseFast). Both
+build modes clear 2× by more than an order of magnitude, and C erases
+the two fixed allocations. This is the near-certain outcome P3
+predicted. **Recommend shipping C** — a `!isPointer(payload)` fast path
+in `shared_channel.send`/`receive` that carries the raw value instead of
+building an envelope.
+
+### (B) reusable arena — **ship candidate under ReleaseSafe, pending the second clause**
+
+> (B) replaces (A) only if it wins ≥ 30% on the small-message workloads
+> **and** survives the gc-stress/leak suite with no new lifetime rules
+> visible outside `shared_channel.zig`.
+
+B's improvement `(A−B)/A` on the small-message set:
+
+| shape | ReleaseSafe | ReleaseFast |
+|---|--:|--:|
+| fixnum | 97.9% | 93.7% |
+| small pair | 65.3% | 31.6% |
+| 1 KiB string | 57.2% | **25.9%** |
+
+**The verdict flips on build mode.** Under **ReleaseSafe (the shipped
+default)** all three small-message shapes clear ≥ 30% (57–98%) → the
+performance clause is **met**. Under ReleaseFast the 1 KiB string only
+reaches ~26% → not met. The swing cell is the 1 KiB string: safety
+checks make A's per-message GC-struct + root-buffer alloc/free costlier
+in absolute terms, so B's amortization recovers a larger share.
+
+Because the shipped binary is ReleaseSafe, **the operative reading is
+that B meets the performance bar.** But the *second clause is
+unproven*: the ≥30% result only licenses B if a real arena in
+`shared_channel.zig` survives gc-stress + the leak suite **without
+leaking any new lifetime rule outside that file**. That is an
+implementation-and-verification task, not something this micro-benchmark
+settles. The benchmark's arena is deliberately exercised only on
+symbol-free graphs (a symbol-bearing arena needs the symbol table
+preserved across resets — see `freeArena`'s comment); a shipped arena
+must handle symbol-bearing messages too. **Recommendation: treat B as a
+ship candidate; gate it on a `shared_channel.zig` arena prototype that
+passes gc-stress/leak with the lifetime rule contained.**
+
+### (D) refcounted side-heap — **measured only**
+
+> (D) is implemented behind a flag for measurement; its *shipping*
+> decision belongs to the KEP-0003 gate, not this benchmark.
+
+64 KiB bytevector A/D = **2.8×** (ReleaseSafe), **2.6×** (ReleaseFast),
+even in a 1:1 round trip (one snapshot copy vs. copy-in + copy-out). The
+larger lever — one copy shared across an N-worker fan-out instead of N
+copies — is what [kaappi#1474](https://github.com/kaappi/kaappi/issues/1474)
+measures. Recorded here; **not decided here.**
+
+## Caveats
+
+- **This is the eyeball tier, not the gate tier.** Single-run point
+  estimates, no bootstrap CIs, no invocation/iteration discipline. The
+  decision reads only outcomes that clear their thresholds by a wide
+  margin.
+- **The noise floor is visible in the fall-through cells.** C and D on
+  the small pair / 1 KiB string / chain execute the *identical* path as
+  A, so those cells should equal A. Under ReleaseSafe they spread ±15–20%
+  (e.g. C small-pair 485 vs A 406; C 1 KiB 480 vs A 556) — a direct read
+  on this tier's run-to-run variance, and the reason a borderline verdict
+  (ReleaseFast's 1 KiB string at 26%) is *not* trustworthy while the
+  wide-margin verdicts (C at 28–120×, B's ReleaseSafe small-message wins
+  at 57–98%) are.
+- **One machine.** macOS aarch64 only. No cross-machine agreement is
+  claimed for the P3 verdict yet (see below).
+
+## Status / what remains
+
+Done in this pass:
+
+- `src/bench_channel.zig` grown from the Phase 1 single-lever harness
+  into the full A/B/C/D matrix, with a counting allocator and the
+  mechanical P3 decision printer. Unit suite green; the file is a
+  standalone bench executable, outside the `test` graph.
+
+Still open for Phase 7 / #1472:
+
+1. **Second reference machine** — re-run on Linux x86_64 (≥ 8 physical
+   cores) and confirm the C and B verdicts agree. Only then is the P3
+   decision two-machine-solid.
+2. **Lever-B ship gate** — prototype the reusable arena inside
+   `shared_channel.zig` and run it under `-Dgc-stress=true` + the leak
+   suite, checking the lifetime rule stays contained. This is the P3 (B)
+   second clause; without it the ≥30% result is necessary but not
+   sufficient.
+3. **Lever-C ship** — the immediate fast path in the real
+   `send`/`receive`, with a regression test.
+4. **KEP-0002 UQ 1 amendment** — record the A/B/C/D outcome (ship C; B
+   pending clause 2; D deferred) into KEP-0002, per #1472's acceptance.
+   Best done after (1).
+5. **The gate campaign** — the `parallel-map` IP-*/FO-* workloads, the
+   parent-side copy-overhead-share instrumentation, the Kalibera–Jones
+   statistics driver, the CSV + classification worksheet, and lever D
+   wired behind a flag in the real path. That is the larger, separate
+   half of #1472 that feeds #1474.

--- a/src/bench_channel.zig
+++ b/src/bench_channel.zig
@@ -1,5 +1,5 @@
-// KEP-0002 Phase 1 channel benchmark. Two measurements, no automated
-// pass/fail threshold -- run before/after and compare by eye, matching
+// KEP-0002 channel benchmark. Three measurements, no automated pass/fail
+// threshold -- run before/after and compare by eye, matching
 // bench_fibers.zig/bench_reactor.zig:
 //
 //   1. Local (unpromoted) channel send+receive ns/op -- the invariant-3
@@ -7,26 +7,49 @@
 //      head/tail pair queue plus one pointer null-check ... 'Unmeasurable'
 //      is a Phase 1 benchmark gate, not an assumption"). Runs through a
 //      real VM/eval so the measurement includes the actual dispatch path
-//      (the new foreign-owner check and ch.shared null-check included).
-//   2. Promoted, single-thread channel send+receive ns/op -- the Phase 1
-//      installment of research/open-problems.md's P3 envelope-cost harness
-//      ("(A) per-message GC struct as specified"). Parameterized over
-//      P3's workload shapes (fixnum, small pair, 1 KiB string, 64 KiB
-//      bytevector); a 50-deep nested-pair chain stands in for P3's "deep
-//      record" shape until a full record-type harness lands. Phase 7 grows
-//      this into the full A/B/C/D matrix (arena backing, immediate fast
-//      path, immutable side-heap).
+//      (the foreign-owner check and ch.shared null-check included).
+//   2. The P3 envelope-cost A/B/C/D matrix (research/open-problems.md P3;
+//      research/benchmarks/README.md §7). Grown here from the Phase 1
+//      single-lever harness into the four elision levers the Phase 7
+//      decision is registered against:
+//        (A) per-message GC struct, exactly as src/shared_channel.zig ships;
+//        (B) a reusable per-channel arena behind the same envelope interface;
+//        (C) A plus the immediate fast path -- non-pointer values (fixnums,
+//            booleans, chars) skip the envelope heap entirely;
+//        (D) C plus a refcounted immutable side-heap for large bytevectors/
+//            strings -- one snapshot copy at creation, zero-copy on receive.
+//      Reported per lever x P3 payload shape: ns/message, allocations/message
+//      (counted alloc calls), and message heap-object count.
+//   3. A reference line: the *real* promoted send+receive through
+//      shared_channel (lever A, full lock + queue), so the matrix's lever-A
+//      column can be tied back to the shipped path and the Phase 1 numbers.
+//
+// The pre-registered P3 criteria (open-problems.md P3) are evaluated
+// mechanically at the end: (C) ships if immediates are >= 2x (A) on fixnums;
+// (B) replaces (A) only if it wins >= 30% on the small-message workloads.
+// (D)'s *shipping* decision is deferred to the KEP-0003 gate (kaappi#1474);
+// here it is only measured.
+//
+// Scope note: this is the single-thread envelope-cost micro-benchmark. The
+// per-message ns figures deliberately exclude the (lever-invariant) O(1)
+// queue push/pop and spin-lock pair -- measurement 3 keeps a real-path line
+// so that constant stays visible. The symbol-table lock-contention figure
+// (many threads, symbol-heavy records) and the parallel-map scaling curve
+// that feeds the gate are separate Phase 7 tasks, not part of this file.
 //
 // Build/run:  zig build bench-channel
 //   (best with -Doptimize=ReleaseFast)
 
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const gc_collect = @import("gc_collect.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
 const library = @import("library.zig");
 const shared_channel = @import("shared_channel.zig");
+const shared_object = @import("shared_object.zig");
 const Value = types.Value;
 
 fn nowNs() u64 {
@@ -39,33 +62,211 @@ fn nsPerOp(elapsed_ns: u64, ops: u64) f64 {
     return @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, @floatFromInt(ops));
 }
 
-// Note: VM setup is inlined, not a shared helper -- see bench_fibers.zig's
-// identical note (vm_mod.setVMInstance stores the local `vm`'s address in a
-// threadlocal; a helper returning `vm` by value would leave that dangling).
-fn benchLocalFastPath(iters: u64) !f64 {
-    var gc = memory.GC.init(std.heap.c_allocator);
-    defer gc.deinit();
-    var vm: vm_mod.VM = try vm_mod.VM.init(&gc);
-    defer vm.deinit();
-    memory.setGCInstance(&gc);
-    vm_mod.setVMInstance(&vm);
-    try primitives.registerAll(&vm);
-    try vm_mod.vm_bootstrap.install(&vm);
-    try library.registerStandardLibraries(&vm.libraries, vm.globals);
+// --------------------------------------------------------------------------
+// Counting allocator: wraps a backing allocator and tallies alloc() calls, so
+// the matrix can report a true allocations/message figure. This is what makes
+// the A-vs-B difference legible in the alloc column -- both deepCopy the same
+// object graph, but A allocates a fresh GC struct + its ~8 KiB root buffer per
+// message while B amortizes them across the channel's lifetime.
+// --------------------------------------------------------------------------
+const CountingAllocator = struct {
+    backing: std.mem.Allocator,
+    allocs: usize = 0,
 
-    var buf: [256]u8 = undefined;
-    const src = try std.fmt.bufPrint(&buf,
-        \\(import (scheme base) (kaappi fibers))
-        \\(define ch (make-channel))
-        \\(let loop ((i 0)) (when (< i {d}) (channel-send ch i) (channel-receive ch) (loop (+ i 1))))
-    , .{iters});
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = countAlloc,
+        .resize = countResize,
+        .remap = countRemap,
+        .free = countFree,
+    };
 
-    const start = nowNs();
-    _ = try vm.eval(src);
-    const elapsed = nowNs() - start;
-    return nsPerOp(elapsed, iters);
+    fn allocator(self: *CountingAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    fn countAlloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.allocs += 1;
+        return self.backing.vtable.alloc(self.backing.ptr, len, alignment, ret_addr);
+    }
+    fn countResize(ctx: *anyopaque, mem: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.vtable.resize(self.backing.ptr, mem, alignment, new_len, ret_addr);
+    }
+    fn countRemap(ctx: *anyopaque, mem: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.vtable.remap(self.backing.ptr, mem, alignment, new_len, ret_addr);
+    }
+    fn countFree(ctx: *anyopaque, mem: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.backing.vtable.free(self.backing.ptr, mem, alignment, ret_addr);
+    }
+};
+
+// --------------------------------------------------------------------------
+// Lever B support: free a message graph while keeping the GC's own buffers, so
+// one arena GC can back message after message. This is the whole of B's
+// "reusable per-channel arena" -- the arena's bookkeeping (root buffer, symbol
+// table, object-list head) is retained; only the copied-in message objects are
+// released. Precondition: the message graph holds no interned symbols (all
+// five P3 workloads are symbol-free), so the symbol table stays empty and no
+// freed Symbol can dangle behind a live table entry. A symbol-bearing arena
+// would additionally need the symbol table preserved across resets -- out of
+// scope for this micro-benchmark (it belongs with the symbol-contention task).
+fn freeArena(gc: *memory.GC) void {
+    var obj = gc.objects;
+    while (obj) |o| {
+        const next = o.next;
+        gc_collect.freeObject(gc, o);
+        obj = next;
+    }
+    obj = gc.old_objects;
+    while (obj) |o| {
+        const next = o.next;
+        gc_collect.freeObject(gc, o);
+        obj = next;
+    }
+    gc.objects = null;
+    gc.old_objects = null;
+    gc.object_count = 0;
+    gc.bytes_allocated = 0;
 }
 
+// --------------------------------------------------------------------------
+// Lever D support: a refcounted immutable side-heap buffer, allocated outside
+// every GC heap on the same shared_object protocol SharedChannel uses. The
+// payload bytes are snapshotted once at creation; crossing the channel is then
+// a refcount bump, not a copy. In a 1:1 round trip that halves the byte-copy
+// count (create-copy only, vs. copy-in + copy-out for A/C); the larger win --
+// one copy shared across an N-worker fan-out instead of N copies -- is what
+// the KEP-0003 gate campaign measures, and why D's shipping decision lives
+// there, not here.
+const SideBuf = struct {
+    header: shared_object.Header,
+    bytes: []u8,
+    alloc: std.mem.Allocator,
+
+    fn destroyHook(h: *shared_object.Header) void {
+        const self: *SideBuf = @fieldParentPtr("header", h);
+        const a = self.alloc;
+        a.free(self.bytes);
+        a.destroy(self);
+    }
+
+    fn create(a: std.mem.Allocator, src: []const u8) !*SideBuf {
+        const self = try a.create(SideBuf);
+        errdefer a.destroy(self);
+        const buf = try a.alloc(u8, src.len);
+        @memcpy(buf, src); // the one snapshot copy into the immutable side-heap
+        self.* = .{ .header = undefined, .bytes = buf, .alloc = a };
+        shared_object.init(&self.header, destroyHook); // refcount 1: sender's stub
+        return self;
+    }
+};
+
+// --------------------------------------------------------------------------
+// The four levers and the envelope strategies they select.
+// --------------------------------------------------------------------------
+const Lever = enum { a, b, c, d };
+
+fn leverName(l: Lever) []const u8 {
+    return switch (l) {
+        .a => "A",
+        .b => "B",
+        .c => "C",
+        .d => "D",
+    };
+}
+
+/// Bytes-backed payload (bytevector or string), for lever D's size gate.
+/// Returns null for every other shape.
+fn payloadBytes(v: Value) ?[]const u8 {
+    if (!types.isPointer(v)) return null;
+    const o = types.toObject(v);
+    return switch (o.tag) {
+        .bytevector => o.as(types.Bytevector).data,
+        .string => o.as(types.SchemeString).data,
+        else => null,
+    };
+}
+
+/// BEAM ships refcounted binaries above 64 bytes; the gate campaign sweeps
+/// 64 KiB..64 MiB where D dominates. In this micro-matrix an 8 KiB gate keeps
+/// D distinct from C on exactly the 64 KiB-bytevector cell (the 1 KiB string
+/// stays on the copy path), which is the contrast the matrix exists to show.
+const d_side_heap_threshold_bytes: usize = 8192;
+
+const BenchEnv = union(enum) {
+    heap: struct { gc: *memory.GC, owns_gc: bool, value: Value },
+    immediate: Value,
+    side: *SideBuf,
+};
+
+const LeverCtx = struct {
+    alloc: std.mem.Allocator,
+    arena_gc: ?*memory.GC, // lever B's persistent per-channel arena
+};
+
+/// Send side: build the message representation this lever prescribes.
+fn buildEnv(lever: Lever, payload: Value, ctx: *LeverCtx) !BenchEnv {
+    // Lever C/D immediate fast path: any non-pointer NaN-boxed value (fixnum,
+    // boolean, char, nil, flonum) is self-contained -- deepCopy would return
+    // it unchanged -- so it skips the envelope heap entirely.
+    if ((lever == .c or lever == .d) and !types.isPointer(payload)) {
+        return .{ .immediate = payload };
+    }
+    // Lever D side-heap: large immutable bytes cross by refcounted reference.
+    if (lever == .d) {
+        if (payloadBytes(payload)) |bytes| {
+            if (bytes.len >= d_side_heap_threshold_bytes) {
+                return .{ .side = try SideBuf.create(ctx.alloc, bytes) };
+            }
+        }
+    }
+    // Levers A/B, and the fall-through of C/D: a message heap + deepCopy in.
+    if (lever == .b) {
+        const g = ctx.arena_gc.?;
+        const v = try g.deepCopy(payload);
+        return .{ .heap = .{ .gc = g, .owns_gc = false, .value = v } };
+    }
+    const g = try ctx.alloc.create(memory.GC);
+    errdefer ctx.alloc.destroy(g);
+    g.* = memory.GC.init(ctx.alloc);
+    g.enabled = false; // never collect a heap no root marker can see (as Envelope.create)
+    const v = try g.deepCopy(payload);
+    return .{ .heap = .{ .gc = g, .owns_gc = true, .value = v } };
+}
+
+/// Receive side: copy/reference the value out into `dest_gc`, then tear the
+/// message representation down (freeing an owned GC, resetting a lever-B
+/// arena, or dropping the side-heap refcounts).
+fn consumeEnv(env: BenchEnv, dest_gc: *memory.GC, ctx: *LeverCtx) !void {
+    switch (env) {
+        .immediate => {
+            // deepCopy of a non-pointer is identity: nothing to copy out.
+        },
+        .side => |sb| {
+            shared_object.retain(&sb.header); // receiver acquires a reference (no copy)
+            shared_object.release(&sb.header); // sender's envelope reference drops
+            shared_object.release(&sb.header); // receiver, done with the message, drops its own
+        },
+        .heap => |h| {
+            _ = try dest_gc.deepCopy(h.value); // copy out into the receiver heap
+            if (h.owns_gc) {
+                h.gc.deinit();
+                ctx.alloc.destroy(h.gc);
+            } else {
+                freeArena(h.gc); // lever B: reset the reusable arena for the next message
+            }
+        },
+    }
+}
+
+// --------------------------------------------------------------------------
+// P3 workloads: fixnum, small pair, 1 KiB string, 64 KiB bytevector, deep
+// record (a 50-deep nested-pair chain stands in for the record shape until a
+// full record-type harness lands -- same stand-in the Phase 1 harness used).
+// --------------------------------------------------------------------------
 const Workload = struct {
     name: []const u8,
     iters: u64,
@@ -106,23 +307,128 @@ fn buildDeepChain(gc: *memory.GC) anyerror!Value {
 }
 
 const workloads = [_]Workload{
-    .{ .name = "fixnum", .iters = 20_000, .build = buildFixnum },
-    .{ .name = "small pair", .iters = 20_000, .build = buildSmallPair },
-    .{ .name = "1 KiB string", .iters = 20_000, .build = buildString1KiB },
-    .{ .name = "64 KiB bytevector", .iters = 2_000, .build = buildBytevector64KiB },
-    .{ .name = "50-deep chain", .iters = 20_000, .build = buildDeepChain },
+    .{ .name = "fixnum", .iters = 50_000, .build = buildFixnum },
+    .{ .name = "small pair", .iters = 50_000, .build = buildSmallPair },
+    .{ .name = "1 KiB string", .iters = 50_000, .build = buildString1KiB },
+    .{ .name = "64 KiB bytevector", .iters = 5_000, .build = buildBytevector64KiB },
+    .{ .name = "50-deep chain", .iters = 50_000, .build = buildDeepChain },
 };
 
-/// Promoted-channel send+receive, single OS thread (no cross-thread wakeup
-/// exists until Phase 3) -- measures envelope build/copy-in + copy-out cost
-/// in isolation, bypassing the VM entirely.
-fn benchPromotedPath(workload: Workload, iters: u64) !f64 {
+/// The three small-message workloads the P3 (B) criterion is read on -- the
+/// shapes where per-message fixed overhead can dominate.
+fn isSmallMessage(name: []const u8) bool {
+    return std.mem.eql(u8, name, "fixnum") or
+        std.mem.eql(u8, name, "small pair") or
+        std.mem.eql(u8, name, "1 KiB string");
+}
+
+const CellResult = struct {
+    ns: f64,
+    allocs_per_msg: f64,
+    heap_objs: usize,
+};
+
+/// One matrix cell: `iters` send+receive round trips for `lever` x `wl`.
+fn benchCell(lever: Lever, wl: Workload) !CellResult {
+    var src_gc = memory.GC.init(std.heap.c_allocator);
+    src_gc.enabled = false;
+    defer src_gc.deinit();
+    const payload = try wl.build(&src_gc);
+
+    var counter = CountingAllocator{ .backing = std.heap.c_allocator };
+    const ca = counter.allocator();
+
+    var dest_gc = memory.GC.init(ca);
+    dest_gc.enabled = false;
+    defer dest_gc.deinit();
+
+    var arena_storage: memory.GC = undefined;
+    var arena_ptr: ?*memory.GC = null;
+    if (lever == .b) {
+        arena_storage = memory.GC.init(ca);
+        arena_storage.enabled = false;
+        arena_ptr = &arena_storage;
+    }
+    defer if (arena_ptr) |g| g.deinit();
+
+    var ctx = LeverCtx{ .alloc = ca, .arena_gc = arena_ptr };
+
+    // Probe the message's heap-object count once, outside the timing loop.
+    const probe = try buildEnv(lever, payload, &ctx);
+    const heap_objs: usize = switch (probe) {
+        .heap => |h| h.gc.object_count,
+        else => 0,
+    };
+    try consumeEnv(probe, &dest_gc, &ctx);
+    freeArena(&dest_gc);
+
+    // Warm up so one-time capacity growth (dest heap, arena) doesn't land in
+    // the measured allocation tally.
+    const warmup = @min(wl.iters / 10, 1000);
+    var w: u64 = 0;
+    while (w < warmup) : (w += 1) {
+        const e = try buildEnv(lever, payload, &ctx);
+        try consumeEnv(e, &dest_gc, &ctx);
+        freeArena(&dest_gc);
+    }
+
+    const allocs_before = counter.allocs;
+    const start = nowNs();
+    var i: u64 = 0;
+    while (i < wl.iters) : (i += 1) {
+        const e = try buildEnv(lever, payload, &ctx);
+        try consumeEnv(e, &dest_gc, &ctx);
+        freeArena(&dest_gc); // free the received value; equal cost across levers
+    }
+    const elapsed = nowNs() - start;
+    const allocs = counter.allocs - allocs_before;
+
+    return .{
+        .ns = nsPerOp(elapsed, wl.iters),
+        .allocs_per_msg = @as(f64, @floatFromInt(allocs)) / @as(f64, @floatFromInt(wl.iters)),
+        .heap_objs = heap_objs,
+    };
+}
+
+// Note: VM setup is inlined, not a shared helper -- see bench_fibers.zig's
+// identical note (vm_mod.setVMInstance stores the local `vm`'s address in a
+// threadlocal; a helper returning `vm` by value would leave that dangling).
+fn benchLocalFastPath(iters: u64) !f64 {
+    var gc = memory.GC.init(std.heap.c_allocator);
+    defer gc.deinit();
+    var vm: vm_mod.VM = try vm_mod.VM.init(&gc);
+    defer vm.deinit();
+    memory.setGCInstance(&gc);
+    vm_mod.setVMInstance(&vm);
+    try primitives.registerAll(&vm);
+    try vm_mod.vm_bootstrap.install(&vm);
+    try library.registerStandardLibraries(&vm.libraries, vm.globals);
+
+    var buf: [256]u8 = undefined;
+    const src = try std.fmt.bufPrint(&buf,
+        \\(import (scheme base) (kaappi fibers))
+        \\(define ch (make-channel))
+        \\(let loop ((i 0)) (when (< i {d}) (channel-send ch i) (channel-receive ch) (loop (+ i 1))))
+    , .{iters});
+
+    const start = nowNs();
+    _ = try vm.eval(src);
+    const elapsed = nowNs() - start;
+    return nsPerOp(elapsed, iters);
+}
+
+/// Reference line: real promoted send+receive through shared_channel (lever A,
+/// full spin-lock + queue), so the matrix's lever-A column can be tied back to
+/// the shipped path. Uses the real Envelope.create, not the matrix builders.
+fn benchRealPromoted(workload: Workload, iters: u64) !f64 {
     const sc = try shared_channel.SharedChannel.create();
     defer sc.release();
 
     var src_gc = memory.GC.init(std.heap.c_allocator);
+    src_gc.enabled = false; // keep the payload alive; never collect it
     defer src_gc.deinit();
     var dest_gc = memory.GC.init(std.heap.c_allocator);
+    dest_gc.enabled = false;
     defer dest_gc.deinit();
 
     const payload = try workload.build(&src_gc);
@@ -132,21 +438,113 @@ fn benchPromotedPath(workload: Workload, iters: u64) !f64 {
     while (i < iters) : (i += 1) {
         _ = try shared_channel.send(sc, payload, null);
         _ = try shared_channel.receive(sc, &dest_gc, null);
+        freeArena(&dest_gc); // bound the receiver heap, matching the matrix harness
     }
     const elapsed = nowNs() - start;
     return nsPerOp(elapsed, iters);
 }
 
 pub fn main() !void {
-    std.debug.print("=== KEP-0002 Phase 1: channel benchmarks ===\n\n", .{});
+    std.debug.print("=== KEP-0002 channel benchmarks ===\n", .{});
+    // The P3 (B) decision is build-mode sensitive: safety checks make lever
+    // A's per-message GC-struct + root-buffer alloc/free relatively costlier,
+    // so B's amortization wins more under ReleaseSafe than ReleaseFast. The
+    // protocol's shipped default (research/benchmarks/README.md §4.5) is
+    // ReleaseSafe, so that is the operative build for the ship decision.
+    std.debug.print("build: {s} (shipped default is ReleaseSafe; decision reads this build)\n\n", .{@tagName(builtin.mode)});
 
     const local_iters: u64 = 200_000;
     const local_ns = try benchLocalFastPath(local_iters);
-    std.debug.print("local (unpromoted) send+receive: {d:.1} ns/op over {d} iters\n\n", .{ local_ns, local_iters });
+    std.debug.print("1. local (unpromoted) send+receive: {d:.1} ns/op over {d} iters\n\n", .{ local_ns, local_iters });
 
-    std.debug.print("promoted (single-thread) send+receive, by payload shape:\n", .{});
-    for (workloads) |wl| {
-        const ns = try benchPromotedPath(wl, wl.iters);
-        std.debug.print("  {s:<20} {d:>10.1} ns/op over {d} iters\n", .{ wl.name, ns, wl.iters });
+    // Run the whole matrix up front so the decision summary can read it.
+    const levers = [_]Lever{ .a, .b, .c, .d };
+    var results: [workloads.len][levers.len]CellResult = undefined;
+    for (workloads, 0..) |wl, wi| {
+        for (levers, 0..) |lever, li| {
+            results[wi][li] = try benchCell(lever, wl);
+        }
     }
+
+    std.debug.print("2. P3 envelope-cost matrix (build + copy-out round trip), single thread.\n\n", .{});
+
+    std.debug.print("   ns/op by lever:\n", .{});
+    std.debug.print("   {s:<20}{s:>11}{s:>11}{s:>11}{s:>11}\n", .{ "payload shape", "A", "B", "C", "D" });
+    for (workloads, 0..) |wl, wi| {
+        std.debug.print("   {s:<20}{d:>11.1}{d:>11.1}{d:>11.1}{d:>11.1}\n", .{
+            wl.name,
+            results[wi][0].ns,
+            results[wi][1].ns,
+            results[wi][2].ns,
+            results[wi][3].ns,
+        });
+    }
+
+    std.debug.print("\n   allocations/message by lever (counted alloc calls):\n", .{});
+    std.debug.print("   {s:<20}{s:>11}{s:>11}{s:>11}{s:>11}\n", .{ "payload shape", "A", "B", "C", "D" });
+    for (workloads, 0..) |wl, wi| {
+        std.debug.print("   {s:<20}{d:>11.2}{d:>11.2}{d:>11.2}{d:>11.2}\n", .{
+            wl.name,
+            results[wi][0].allocs_per_msg,
+            results[wi][1].allocs_per_msg,
+            results[wi][2].allocs_per_msg,
+            results[wi][3].allocs_per_msg,
+        });
+    }
+
+    std.debug.print("\n   message heap objects (deepCopy graph size, lever A):\n", .{});
+    for (workloads, 0..) |wl, wi| {
+        std.debug.print("   {s:<20}{d:>6}\n", .{ wl.name, results[wi][0].heap_objs });
+    }
+
+    std.debug.print("\n3. reference: real promoted send+receive (shared_channel, lever A, full lock+queue):\n", .{});
+    for (workloads) |wl| {
+        const ns = try benchRealPromoted(wl, wl.iters);
+        std.debug.print("   {s:<20}{d:>11.1} ns/op\n", .{ wl.name, ns });
+    }
+
+    // ----------------------------------------------------------------------
+    // Mechanical evaluation of the pre-registered P3 criteria.
+    // ----------------------------------------------------------------------
+    std.debug.print("\n=== P3 decision (open-problems.md P3, pre-registered) ===\n\n", .{});
+
+    // (C) ships if immediates are >= 2x (A) on fixnums.
+    const a_fixnum = results[0][0].ns; // workloads[0] == fixnum, levers[0] == A
+    const c_fixnum = results[0][2].ns; // levers[2] == C
+    const c_speedup = a_fixnum / c_fixnum;
+    std.debug.print("(C) immediate fast path: fixnum A={d:.1} ns, C={d:.1} ns -> {d:.1}x\n", .{ a_fixnum, c_fixnum, c_speedup });
+    std.debug.print("    criterion: C ships iff immediates >= 2x A on fixnums -> {s}\n\n", .{
+        if (c_speedup >= 2.0) "SHIP C" else "hold",
+    });
+
+    // (B) replaces (A) only if it wins >= 30% on the small-message workloads.
+    std.debug.print("(B) reusable arena vs. A, improvement = (A-B)/A:\n", .{});
+    var b_all_small_win = true;
+    var b_any_small = false;
+    for (workloads, 0..) |wl, wi| {
+        const a_ns = results[wi][0].ns;
+        const b_ns = results[wi][1].ns;
+        const impr = (a_ns - b_ns) / a_ns * 100.0;
+        const small = isSmallMessage(wl.name);
+        std.debug.print("    {s:<20} {d:>6.1}%{s}\n", .{
+            wl.name,
+            impr,
+            if (small) "   (small-message: gates the B decision)" else "",
+        });
+        if (small) {
+            b_any_small = true;
+            if (impr < 30.0) b_all_small_win = false;
+        }
+    }
+    std.debug.print("    criterion: B replaces A iff >= 30% on ALL small-message workloads\n", .{});
+    std.debug.print("               (and no new lifetime rules leak outside shared_channel.zig) -> {s}\n\n", .{
+        if (b_any_small and b_all_small_win) "REPLACE A with B (pending leak/gc-stress review)" else "keep A",
+    });
+
+    // (D) measured only; shipping decision belongs to the KEP-0003 gate.
+    const a_bv = results[3][0].ns; // workloads[3] == 64 KiB bytevector
+    const d_bv = results[3][3].ns; // levers[3] == D
+    const d_speedup = a_bv / d_bv;
+    std.debug.print("(D) side-heap (64 KiB bytevector): A={d:.1} ns, D={d:.1} ns -> {d:.1}x\n", .{ a_bv, d_bv, d_speedup });
+    std.debug.print("    measured only; D's shipping decision is the KEP-0003 gate (kaappi#1474).\n", .{});
 }


### PR DESCRIPTION
Part of #1472 (KEP-0002 Phase 7). This is the **envelope-cost half** — the P3 A/B/C/D elision-lever matrix from [keps `research/open-problems.md` P3](https://github.com/kaappi/keps/blob/main/research/open-problems.md) and the pre-registered decision it drives. It's the eyeball benchmark tier (like `bench-fibers`/`bench-reactor`), not the statistically-disciplined gate campaign.

## What this adds

Grows `src/bench_channel.zig` from the Phase 1 single-lever harness into the four levers the Phase 7 decision is registered against:

| Lever | Envelope strategy |
|-------|-------------------|
| **A** | Per-message GC struct — as `shared_channel.zig` ships today. |
| **B** | Reusable per-channel arena — one persistent GC reused message after message. |
| **C** | A + immediate fast path — non-pointer values (fixnums/booleans/chars) skip the envelope heap. |
| **D** | C + refcounted immutable side-heap — large bytevectors/strings cross by reference, one snapshot copy. |

Plus a counting allocator (true allocations/message), a build-mode-aware header, a real-path reference line, and a printer that evaluates the pre-registered P3 criteria mechanically.

Run with `zig build bench-channel` (ReleaseSafe, the shipped default) or `-Doptimize=ReleaseFast`.

## The recorded A/B/C/D decision (macOS aarch64, operative ReleaseSafe)

- **(C) SHIP** — fixnum immediate fast path is **108×** (28× ReleaseFast, 523× Debug) and erases the two fixed allocations (GC struct + ~8 KiB root buffer) that lever A pays per message *even for a zero-object fixnum*. Robust across all builds.
- **(B) ship candidate, clause 2 unproven** — meets ≥30% on all small messages under both safety-on builds (ReleaseSafe **57–98%**, Debug 65–99%) but the 1 KiB string dips to ~26% under ReleaseFast. ⚠️ **The verdict is build-mode sensitive**; since the shipped binary is ReleaseSafe (protocol §4.5) the operative reading is *replace A*, conditioned on the pre-registered second clause — a real arena in `shared_channel.zig` surviving gc-stress/leak with no lifetime rule leaking outside that file — which this micro-benchmark does not settle.
- **(D) measured only** — 64 KiB bytevector **2.8×** (8→2 allocations, no copy-out); shipping decision belongs to the KEP-0003 gate (#1474).

Full data, both build modes, and caveats: `docs/dev/kep-0002-phase7-envelope-benchmarks.md`.

## Validation

- Unit suite green; `zig fmt` clean; the bench is a standalone executable (outside the `test` graph).
- Ran clean under Debug / ReleaseSafe / ReleaseFast; Debug's use-after-free poisoning found nothing in the new memory code (lever B's `freeArena`, lever D's `SideBuf` refcount). Allocations/message are exactly deterministic.

## Not in this PR (rest of #1472)

Linux x86_64 re-run (two-machine agreement) · lever-B arena prototype in `shared_channel.zig` under gc-stress (the B clause-2 gate) · shipping C in the real send/receive · KEP-0002 UQ 1 amendment · the `parallel-map` gate campaign (IP-*/FO-* workloads, copy-overhead-share instrumentation, Kalibera–Jones driver, CSV + worksheet, lever D in the real path) that feeds #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)