### PR TITLE
Add regression test for nested-wait dirty-snapshot hazard (#1490)

### DIFF
--- a/tests/scheme/smoke/nested-wait-under-sleep-dirty-snapshot-1490.scm
+++ b/tests/scheme/smoke/nested-wait-under-sleep-dirty-snapshot-1490.scm
@@ -1,0 +1,98 @@
+;; Regression test for #1490: a spawned fiber's blocking wait, nested inside
+;; another fiber's own timed wait, must not let the scheduler resume the
+;; ancestor from a stale mid-native-call snapshot.
+;;
+;; This is the same dirty-snapshot dispatch corruption class as #1487
+;; (mutex-nested-dispatch-dirty-snapshot-1487.scm), but reached through a
+;; distinct *trigger*: not a mutex-unlock! wake from a dispatched sibling,
+;; but reactor-TIMER theft. Trace, for the channel-receive case below:
+;;
+;;   1. main (fiber 0) calls (thread-sleep! 0.01): status .waiting, registers
+;;      a reactor timer, drives via runSchedulerStep -- its native frame now
+;;      live on the Zig stack (driving = true, #1521).
+;;   2. that drive dispatches the spawned fiber, which blocks in channel-
+;;      receive on an empty channel and starts its OWN nested runSchedulerStep.
+;;   3. the nested drive finds nothing else runnable and parks in the reactor,
+;;      bounded by the nearest timer in the shared heap -- which is fiber 0's
+;;      0.01s SLEEP timer, not the spawned fiber's (channel-receive here
+;;      registers none).
+;;   4. that timer pops, flipping fiber 0 (the ancestor, two runSchedulerStep
+;;      frames up) from .waiting to .suspended.
+;;   5. without the #1521 driving guard, the nested drive's own
+;;      scheduleForDispatch() would now select fiber 0 and restoreFiber+
+;;      runUntil it a SECOND time, from a stale IP, while its original
+;;      thread-sleep! drive is still live -- corrupting frame/handler/wind
+;;      bookkeeping, surfacing as `panic: integer overflow` in invokeEscape.
+;;
+;; The generic `driving` flag (set for the whole extent of any
+;; runSchedulerStep call, excluded from scheduleForDispatch/hasRunnableFibers)
+;; closes this: fiber 0 is never re-dispatched from the nested drive; its own
+;; timed_out flag ends its own drive loop cleanly instead.
+;;
+;; Confirmed via A/B (scheduleForDispatch -> scheduleImpl(false)): every
+;; scenario below crashes 15/15 without the guard and passes 15/15 with it.
+;;
+;; Each scenario spawns a fiber that blocks FOREVER (no sender / never-freed
+;; slot / never-unlocked mutex / never-signalled condvar), then polls with a
+;; thread-sleep! loop and returns a sentinel. The outer guard matches the
+;; issue's minimal repro: a live exception-handler frame is what the
+;; corrupted escape-continuation call reaches through, so the corruption
+;; surfaces reliably (as a process-aborting panic) when the bug is present.
+;; When the bug is fixed, each scenario simply returns 'ok.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (srfi 64) (kaappi fibers))
+
+(test-begin "nested-wait-under-sleep-dirty-snapshot-1490")
+
+;; Poll for `n` short sleeps, so the ancestor fiber holds a live thread-sleep!
+;; drive (with a reactor timer) across the spawned fiber's nested wait.
+(define (sleep-poll n)
+  (let loop ((i 0))
+    (when (< i n)
+      (thread-sleep! 0.01)
+      (loop (+ i 1)))))
+
+;; Scenario A -- the issue's headline repro: plain (untimed) channel-receive.
+(test-equal "channel-receive nested under thread-sleep! loop"
+  'ok
+  (guard (e (#t 'outer-caught))
+    (let ((ch (make-channel)))
+      (spawn (lambda () (channel-receive ch)))  ; blocks forever: no sender
+      (sleep-poll 20)
+      'ok)))
+
+;; Scenario B -- local channel-send blocked on a full bounded channel.
+(test-equal "channel-send (full bounded) nested under thread-sleep! loop"
+  'ok
+  (guard (e (#t 'outer-caught))
+    (let ((ch (make-channel 1)))
+      (channel-send ch 'fill)                    ; channel now full
+      (spawn (lambda () (channel-send ch 'x)))   ; blocks forever: no receiver
+      (sleep-poll 20)
+      'ok)))
+
+;; Scenario C -- mutex-lock! on a mutex held by the ancestor.
+(test-equal "mutex-lock! nested under thread-sleep! loop"
+  'ok
+  (guard (e (#t 'outer-caught))
+    (let ((m (make-mutex)))
+      (mutex-lock! m)                            ; held by main; never unlocked
+      (spawn (lambda () (mutex-lock! m)))        ; blocks forever
+      (sleep-poll 20)
+      'ok)))
+
+;; Scenario D -- condition-variable wait (mutex-unlock! with a condvar).
+(test-equal "condition-variable wait nested under thread-sleep! loop"
+  'ok
+  (guard (e (#t 'outer-caught))
+    (let ((m (make-mutex)) (cv (make-condition-variable)))
+      (spawn (lambda ()
+               (mutex-lock! m)
+               (mutex-unlock! m cv)))            ; waits on cv forever
+      (sleep-poll 20)
+      'ok)))
+
+(let ((runner (test-runner-current)))
+  (test-end "nested-wait-under-sleep-dirty-snapshot-1490")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## What

Adds an end-to-end regression test for issue #1490 — a spawned fiber's blocking wait, nested inside another fiber's live `thread-sleep!` drive, corrupting the ancestor's frame state and crashing with `panic: integer overflow` in `invokeEscape`.

## Why this is test-only

**Issue #1490 was already fixed by #1521's generic `driving` guard.** #1490 was filed 2026-07-13 10:02; #1521 merged 20:04 the same day (commit `1da7cf32`). #1490 is the same dirty-snapshot dispatch corruption class as #1487, and #1521 landed #1490's own suggested approach (b): a `Fiber.driving` flag set for the whole extent of any `runSchedulerStep` call and excluded from `scheduleForDispatch()`/`hasRunnableFibers()`, so an ancestor fiber can never be re-dispatched from a deeper nesting level.

What #1490 adds over #1487 is a **distinct trigger**. #1487's existing test (`mutex-nested-dispatch-dirty-snapshot-1487.scm`) reaches the hazard via a *mutex-unlock wake*. #1490 reaches it via **reactor-timer theft**: the spawned fiber's nested `parkOnReactor` blocks bounded by the nearest timer in the shared heap — which is the *ancestor's* own `thread-sleep!` timer, not the spawned fiber's. That timer pop flips the ancestor `.suspended`; without the guard, the nested drive re-dispatches it from a stale, mid-native-call snapshot. The local channel-receive/channel-send wait paths #1490 names had no dedicated coverage at all.

This test also completes the condvar/channel end-to-end repro that #1521's review deliberately deferred as a follow-up.

## The test

`tests/scheme/smoke/nested-wait-under-sleep-dirty-snapshot-1490.scm` — 4 scenarios, each a spawned fiber that blocks forever nested under a `thread-sleep!` polling loop:
- plain (untimed) `channel-receive` — the issue's headline repro
- local `channel-send` on a full bounded channel
- `mutex-lock!` on a held mutex
- `condition-variable` wait (`mutex-unlock!` with a condvar)

## Verification

A/B via `scheduleForDispatch → scheduleImpl(false)` (neutralizing the #1521 guard), rebuild each side:

| | without guard | with guard |
|---|---|---|
| all 4 scenarios (standalone, 15 runs each) | 15/15 crash | 15/15 pass |
| this test file (10 runs) | 10/10 fail (exit 134, `panic: integer overflow`) | 10/10 pass |

Crashes reproduce the issue's exact signature. Also confirmed: full `zig build test` green, 37 concurrency-related smoke tests green. No source changes — `src/fiber.zig` is byte-identical to `main`.

Note: the PCT stress harness (`src/pct_stress.zig`) the issue suggested does **not** apply here — it injects cross-OS-thread yields at shared-channel lock points, but #1490 is a single-thread cooperative-nesting bug, so a deterministic Scheme test is the correct merge gate.

Closes #1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)