### PR TITLE
Add --diagnostics=json structured diagnostic output (#1505)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,9 @@ CLI flags: `-h`/`--help`, `--version`, `--lib-path <path>`, `--compile`,
 `-o <file>`, `--disassemble`, `--no-ir-opt` (disable IR optimization passes;
 also skips the `.sbc` cache — useful for miscompilation triage and
 `--disassemble` comparisons), `--sandbox`, `--gc-stats`,
-`--profile`, `--coverage`, `--completions <shell>`.
+`--profile`, `--coverage`, `--diagnostics=<text|json>` (JSON Lines of LSP
+`Diagnostic` objects on stderr — see `docs/dev/diagnostics-json.md`),
+`--completions <shell>`.
 Subcommand: `kaappi compile <file> [-o output]`
 compiles to native binary via LLVM. Version is defined as `pub const version`
 in `main.zig`. Environment: `KAAPPI_LIB_DIR` overrides `libkaappi_rt.a` lookup.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -28,6 +28,7 @@ investigation produced analysis worth keeping.
 | [github-actions.md](github-actions.md) | Workflow hardening rules: SHA-pinned actions, `persist-credentials: false`, least-privilege tokens |
 | [gc-safety-and-error-handling.md](gc-safety-and-error-handling.md) | Rooting, write barriers, and error propagation patterns contributors must follow |
 | [diagnostics.md](diagnostics.md) | Diagnostic `KP` codes: the registry, the taxonomy, the stability policy, how to add a code |
+| [diagnostics-json.md](diagnostics-json.md) | `--diagnostics=json`: the LSP `Diagnostic` JSON Lines schema shared by the CLI and the language server |
 | [claude-code-harness.md](claude-code-harness.md) | Hooks, permissions, path-scoped rules, and skills for AI-assisted development |
 
 ## Design decisions

--- a/docs/dev/diagnostics-json.md
+++ b/docs/dev/diagnostics-json.md
@@ -1,0 +1,115 @@
+# `--diagnostics=json` — machine-readable diagnostics
+
+By default Kaappi prints diagnostics as human-oriented text
+([diagnostics.md](diagnostics.md)). Passing `--diagnostics=json` switches the
+output to **JSON Lines** so an agent, CI gate, or editor can consume errors
+structurally instead of scraping prose:
+
+```
+kaappi --diagnostics=json file.scm
+```
+
+Each diagnostic is emitted as **one JSON object per line on stderr**. Program
+output on stdout is unaffected, so redirect the two apart:
+
+```
+kaappi --diagnostics=json file.scm 2>diagnostics.jsonl
+```
+
+`--diagnostics=text` is the explicit spelling of the default; any other value is
+a usage error.
+
+## The schema is the LSP `Diagnostic`
+
+We do **not** invent a schema. Each line is a Language Server Protocol
+[`Diagnostic`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic)
+object — the exact shape the Kaappi language server already publishes for
+`textDocument/publishDiagnostics`, and the shape editors and agents already
+understand. The CLI and the LSP share one serializer
+(`src/lsp_diagnostic.zig`), so the two can never drift.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `range` | `{ start, end }` of `{ line, character }` | **Zero-based**, per LSP. See *Positions* below. |
+| `severity` | integer | LSP `DiagnosticSeverity`: `1` Error, `2` Warning, `3` Information, `4` Hint. Every diagnostic is `1` today. |
+| `code` | string | The stable `KP` code from the [registry](diagnostics.md), e.g. `"KP3001"`. The machine handle; match on this, not on `message`. |
+| `source` | string | Always `"kaappi"`. |
+| `message` | string | Human-readable text. Free to be reworded release to release — do not match on it. |
+| `data.suggestions` | array | Present only when a fix is offered (see *Suggestions*). Omitted otherwise. |
+
+Example (an undefined variable with a "did you mean" fix):
+
+```json
+{"range":{"start":{"line":1,"character":9},"end":{"line":1,"character":15}},"severity":1,"code":"KP3001","source":"kaappi","message":"undefined variable 'countr'","data":{"suggestions":[{"kind":"rename","replacement":"count"}]}}
+```
+
+## Coverage — all four stages
+
+`--diagnostics=json` covers every pipeline stage a program can fail in. The
+leading digit of the code identifies the stage (full taxonomy in
+[diagnostics.md](diagnostics.md)):
+
+| Stage | Codes | Example trigger |
+|-------|-------|-----------------|
+| Read / lexical | `KP1xxx` | `(display "abc` → `KP1006` unterminated string |
+| Expand (macros / `syntax-rules`) | `KP2002` | `(syntax-error "bad" 42)` → `KP2002` |
+| Compile | `KP2xxx` | `(if)` → `KP2001` invalid syntax |
+| Runtime | `KP3xxx` | `(car 5)` → `KP3002` type error |
+
+## Positions
+
+LSP positions are **zero-based** for both `line` and `character`, so a reader
+error the text formatter prints as `file.scm:2:5` becomes
+`{"line":1,"character":4}`.
+
+Ranges are only as precise as the position Kaappi knows today:
+
+- **Read errors** have a line and column, so the range is a point at the error
+  column.
+- **Compile and runtime errors** have a line but no column, so the range is a
+  point at the start of that line (`character` 0); an unknown line maps to line
+  0.
+
+Ranges are points (`start == end`) for now; they widen into real spans as span
+tracking lands ([kaappi#1506](https://github.com/kaappi/kaappi/issues/1506)). The
+`code` and `message` are stable regardless.
+
+## Suggestions
+
+When Kaappi can offer a concrete fix it appears under `data.suggestions`, an
+array mirroring LSP code-action semantics. Today the only producer is the
+undefined-variable "did you mean" corrector:
+
+```json
+"data":{"suggestions":[{"kind":"rename","replacement":"count"}]}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `kind` | The flavour of fix. `"rename"` = substitute the flagged token. |
+| `replacement` | The text to substitute. |
+
+In JSON mode the redundant "Did you mean …?" hint is stripped from `message`
+(the structured suggestion is the canonical form); in text mode the hint stays
+inline.
+
+## Notes and limits
+
+- The stack trace and source snippet that text mode prints after a runtime error
+  are suppressed in JSON mode, so the stderr stream stays one parseable object
+  per line. Surfacing frames as LSP `relatedInformation` is future work.
+- A standalone **bundled** binary (`zig build -Dbundle-src=…`) still reports its
+  own top-level errors as text; `--diagnostics=json` governs the interpreter's
+  read/expand/compile/runtime funnel (`src/toplevel_driver.zig`), which the file
+  runner, stdin runner, and REPL share.
+
+## Where it lives
+
+| Piece | File |
+|-------|------|
+| Shared LSP `Diagnostic` shape + serializer | `src/lsp_diagnostic.zig` |
+| CLI flag parsing | `src/cli.zig` |
+| Reporting funnel (text ⇄ json switch) | `src/toplevel_driver.zig` |
+| Code registry (source of `code`/`message`) | `src/diagnostics.zig` |
+| LSP consumer of the same serializer | `src/kaappi_lsp.zig` |
+| Tests | `tests/scheme/errors/diagnostics-json.sh`, `src/lsp_diagnostic.zig` |

--- a/docs/dev/diagnostics.md
+++ b/docs/dev/diagnostics.md
@@ -18,6 +18,10 @@ is [KEP-0005](https://github.com/kaappi/keps/blob/main/keps/0005-diagnostic-cont
 Later phases (`--diagnostics=json`, `kaappi explain`, `error-object-code`) all
 read from this one registry.
 
+For the structured JSON form of these same diagnostics (the LSP `Diagnostic`
+shape emitted by `--diagnostics=json`), see
+[diagnostics-json.md](diagnostics-json.md).
+
 ---
 
 ## The registry

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -9,6 +9,12 @@ pub const USAGE_ERROR_EXIT: u8 = 2;
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
 
+// `--diagnostics=<format>` uses GNU `=` syntax (not a space-separated value like
+// the other value flags), so it is matched by prefix rather than via the flag
+// table. Kept as a named constant so the parse loop and the sandbox pre-scan
+// agree on the spelling.
+const diagnostics_prefix = "--diagnostics=";
+
 // ── Flag table ─────────────────────────────────────────────────────────
 
 const FlagId = enum {
@@ -71,8 +77,12 @@ fn lookupFlag(arg: []const u8) ?FlagDesc {
 
 // ── Options ────────────────────────────────────────────────────────────
 
+pub const DiagnosticsFormat = enum { text, json };
+
 pub const Options = struct {
     file_path: ?[]const u8 = null,
+
+    diagnostics_format: DiagnosticsFormat = .text,
 
     compile_mode: bool = false,
     native_compile_mode: bool = false,
@@ -123,6 +133,8 @@ pub fn preScanSandbox(args: std.process.Args) bool {
             if (f.takes_value) _ = iter.skip();
         } else if (std.mem.eql(u8, arg, "compile")) {
             // bare subcommand — keep scanning
+        } else if (std.mem.startsWith(u8, arg, diagnostics_prefix)) {
+            // `--diagnostics=…` carries its value inline — keep scanning.
         } else {
             break;
         }
@@ -138,6 +150,11 @@ pub fn parse(args: std.process.Args) Options {
     while (iter.next()) |arg| {
         if (std.mem.eql(u8, arg, "compile")) {
             opts.native_compile_mode = true;
+            continue;
+        }
+
+        if (std.mem.startsWith(u8, arg, diagnostics_prefix)) {
+            opts.diagnostics_format = parseDiagnosticsFormat(arg[diagnostics_prefix.len..]);
             continue;
         }
 
@@ -245,6 +262,7 @@ pub fn printUsage() void {
             "  --emit-llvm        Emit LLVM IR text (.ll)\n" ++
             "  -o <file>          Output path\n" ++
             "  --disassemble      Disassemble bytecode\n" ++
+            "  --diagnostics=<fmt> Diagnostic output format: text (default) or json\n" ++
             "  --no-ir-opt        Disable IR optimization passes (skips .sbc cache)\n" ++
             "  --sandbox          Restrict filesystem and process access\n" ++
             "  --gc-stats         Print GC statistics on exit\n" ++
@@ -278,6 +296,15 @@ fn handleCompletions(shell: []const u8) void {
     writeStderr("unknown shell: ");
     writeStderr(shell);
     writeStderr("\nSupported: bash, zsh, fish\n");
+    std.process.exit(USAGE_ERROR_EXIT);
+}
+
+fn parseDiagnosticsFormat(value: []const u8) DiagnosticsFormat {
+    if (std.mem.eql(u8, value, "text")) return .text;
+    if (std.mem.eql(u8, value, "json")) return .json;
+    writeStderr("--diagnostics: unknown format '");
+    writeStderr(value);
+    writeStderr("' (expected 'text' or 'json')\n");
     std.process.exit(USAGE_ERROR_EXIT);
 }
 
@@ -494,4 +521,36 @@ test "parse: flags after filename are script args" {
     try std.testing.expect(!opts.profile_mode);
     try std.testing.expectEqual(@as(usize, 3), opts.script_arg_count);
     try std.testing.expectEqualStrings("--gc-stats", opts.scriptArgs()[1]);
+}
+
+test "parse: --diagnostics=json sets json format" {
+    const argv = [_][*:0]const u8{ "kaappi", "--diagnostics=json", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expectEqual(DiagnosticsFormat.json, opts.diagnostics_format);
+    try std.testing.expectEqualStrings("test.scm", opts.file_path.?);
+}
+
+test "parse: --diagnostics=text is the explicit default" {
+    const argv = [_][*:0]const u8{ "kaappi", "--diagnostics=text", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expectEqual(DiagnosticsFormat.text, opts.diagnostics_format);
+}
+
+test "parse: diagnostics format defaults to text" {
+    const argv = [_][*:0]const u8{ "kaappi", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expectEqual(DiagnosticsFormat.text, opts.diagnostics_format);
+}
+
+test "parse: --diagnostics=json after filename is a script arg, not a format" {
+    const argv = [_][*:0]const u8{ "kaappi", "test.scm", "--diagnostics=json" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expectEqual(DiagnosticsFormat.text, opts.diagnostics_format);
+    try std.testing.expectEqual(@as(usize, 2), opts.script_arg_count);
+    try std.testing.expectEqualStrings("--diagnostics=json", opts.scriptArgs()[1]);
+}
+
+test "preScanSandbox: --diagnostics before --sandbox still detected" {
+    const argv = [_][*:0]const u8{ "kaappi", "--diagnostics=json", "--sandbox", "test.scm" };
+    try std.testing.expect(preScanSandbox(testArgs(&argv)));
 }

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -20,7 +20,7 @@ const kaappi_bash =
     \\    esac
     \\
     \\    if [[ "$cur" == -* ]]; then
-    \\        COMPREPLY=($(compgen -W "-h --help --version --lib-path --compile --emit-llvm -o --disassemble --sandbox --gc-stats --profile --profile-json --coverage --coverage-xml --timeout --max-memory --completions" -- "$cur"))
+    \\        COMPREPLY=($(compgen -W "-h --help --version --lib-path --compile --emit-llvm -o --disassemble --diagnostics=text --diagnostics=json --sandbox --gc-stats --profile --profile-json --coverage --coverage-xml --timeout --max-memory --completions" -- "$cur"))
     \\        return
     \\    fi
     \\
@@ -53,6 +53,7 @@ const kaappi_zsh =
     \\        '--emit-llvm[Emit LLVM IR text (.ll)]'
     \\        '-o[Output path]:file:_files'
     \\        '--disassemble[Disassemble bytecode]'
+    \\        '--diagnostics=[Diagnostic output format]:format:(text json)'
     \\        '--sandbox[Restrict filesystem and process access]'
     \\        '--gc-stats[Print GC statistics on exit]'
     \\        '--profile[Enable profiling]'
@@ -83,6 +84,7 @@ const kaappi_fish =
     \\complete -c kaappi -l emit-llvm -d 'Emit LLVM IR text (.ll)'
     \\complete -c kaappi -s o -r -F -d 'Output path'
     \\complete -c kaappi -l disassemble -d 'Disassemble bytecode'
+    \\complete -c kaappi -l diagnostics -x -a 'text json' -d 'Diagnostic output format'
     \\complete -c kaappi -l sandbox -d 'Restrict filesystem and process access'
     \\complete -c kaappi -l gc-stats -d 'Print GC statistics on exit'
     \\complete -c kaappi -l profile -d 'Enable profiling'

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -30,6 +30,8 @@ pub const ffi_callback = @import("ffi_callback.zig");
 pub const embedded_bytecode = @import("embedded_bytecode");
 pub const fiber_mod = @import("fiber.zig");
 pub const primitives_fiber = @import("primitives_fiber.zig");
+pub const diagnostics = @import("diagnostics.zig");
+pub const lsp_diagnostic = @import("lsp_diagnostic.zig");
 
 const version = "0.1.0";
 const initialize_result =
@@ -638,20 +640,20 @@ fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8,
     defer r.deinit();
 
     while (r.hasMore() catch false) {
-        const expr = r.readDatum() catch {
+        const expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
             if (has_diag) diag_buf.append(allocator, ',') catch {};
             has_diag = true;
-            addDiagnostic(&diag_buf, allocator, @intCast(lc.line -| 1), 0, 1, "read error");
+            addDiagnostic(&diag_buf, allocator, lc.line -| 1, diagnostics.readErrorCode(err));
             break;
         };
 
         // Compile phase
-        _ = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, 0, uri, false) catch {
+        _ = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, 0, uri, false) catch |err| {
             const lc = r.getLineCol();
             if (has_diag) diag_buf.append(allocator, ',') catch {};
             has_diag = true;
-            addDiagnostic(&diag_buf, allocator, @intCast(lc.line -| 1), 0, 1, "compile error");
+            addDiagnostic(&diag_buf, allocator, lc.line -| 1, diagnostics.compileErrorCode(err));
             break;
         };
     }
@@ -670,18 +672,26 @@ fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8,
     sendNotification(allocator, "textDocument/publishDiagnostics", params_buf.items);
 }
 
-fn addDiagnostic(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, line: u32, col: u32, severity: u8, message: []const u8) void {
-    buf.appendSlice(allocator, "{\"range\":{\"start\":{\"line\":") catch return;
-    jsonInt(buf, allocator, @intCast(line));
-    buf.appendSlice(allocator, ",\"character\":") catch return;
-    jsonInt(buf, allocator, @intCast(col));
-    buf.appendSlice(allocator, "},\"end\":{\"line\":") catch return;
-    jsonInt(buf, allocator, @intCast(line));
-    buf.appendSlice(allocator, ",\"character\":999}},\"severity\":") catch return;
-    jsonInt(buf, allocator, @intCast(severity));
-    buf.appendSlice(allocator, ",\"source\":\"kaappi\",\"message\":") catch return;
-    jsonString(buf, allocator, message);
-    buf.append(allocator, '}') catch return;
+// Serialize one diagnostic through the shared LSP `Diagnostic` writer
+// (src/lsp_diagnostic.zig) — the same code path `--diagnostics=json` uses, so
+// the CLI and the server can never drift (kaappi#1505). The range spans the
+// whole line (character 0..999) to highlight it in an editor; the `code` is the
+// stable KP code and `message` its registry template.
+fn addDiagnostic(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, line0: u32, code: diagnostics.Code) void {
+    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+    const diag: lsp_diagnostic.Diagnostic = .{
+        .range = .{
+            .start = .{ .line = line0, .character = 0 },
+            .end = .{ .line = line0, .character = 999 },
+        },
+        .severity = lsp_diagnostic.severityOf(code.info().severity),
+        .code = code.render(&cbuf),
+        .message = code.message(),
+    };
+    var tmp: [1024]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&tmp);
+    diag.writeJson(&w) catch return;
+    buf.appendSlice(allocator, w.buffered()) catch return;
 }
 
 // ---- Text position helpers ----

--- a/src/lsp_diagnostic.zig
+++ b/src/lsp_diagnostic.zig
@@ -1,0 +1,191 @@
+//! Shared LSP `Diagnostic` JSON serialization (kaappi#1505).
+//!
+//! One serializer, two surfaces. The `--diagnostics=json` CLI mode emits these
+//! objects as JSON Lines (one per line) on stderr; the language server embeds
+//! the same objects in a `textDocument/publishDiagnostics` array. Reusing the
+//! LSP `Diagnostic` shape means agents and editors need no Kaappi-specific
+//! schema — see docs/dev/diagnostics-json.md and the LSP specification
+//! (`Diagnostic` under Language Features → Diagnostics).
+//!
+//! Only the per-object serialization lives here; framing differs by surface and
+//! stays with each caller. This is the single implementation the acceptance
+//! criterion asks for — the LSP must not grow a second one to drift against.
+
+const std = @import("std");
+const diagnostics = @import("diagnostics.zig");
+
+/// A zero-based text position, as LSP defines it (both fields zero-based).
+pub const Position = struct { line: u32, character: u32 };
+
+/// A half-open `[start, end)` range in LSP zero-based coordinates.
+pub const Range = struct { start: Position, end: Position };
+
+/// LSP `DiagnosticSeverity`. The wire value is the enum's integer:
+/// 1 = Error, 2 = Warning, 3 = Information, 4 = Hint.
+pub const Severity = enum(u8) { err = 1, warning = 2, information = 3, hint = 4 };
+
+/// Map a registry severity onto the LSP severity scale.
+pub fn severityOf(sev: diagnostics.Severity) Severity {
+    return switch (sev) {
+        .err => .err,
+        .warning => .warning,
+    };
+}
+
+/// One suggested fix, serialized inside the diagnostic's `data.suggestions`
+/// array. `data` is a free-form LSP field; `kind`/`replacement` mirror the
+/// rename flavour of an LSP code action so a tool can apply the fix directly.
+pub const Suggestion = struct {
+    /// The kind of fix, e.g. "rename" for a "did you mean" correction.
+    kind: []const u8,
+    /// The text to substitute for the flagged token.
+    replacement: []const u8,
+};
+
+/// An LSP `Diagnostic`. Fields are serialized in the order below, matching the
+/// example in the issue and the field order the LSP spec lists.
+pub const Diagnostic = struct {
+    range: Range,
+    severity: Severity = .err,
+    /// The stable KP code (e.g. "KP3001"). `null` omits the field entirely.
+    code: ?[]const u8 = null,
+    /// Diagnostic origin; always "kaappi" for us. Lets an editor group ours
+    /// apart from other providers' diagnostics on the same document.
+    source: []const u8 = "kaappi",
+    message: []const u8,
+    /// Fix suggestions, emitted under `data.suggestions`. Empty omits `data`.
+    suggestions: []const Suggestion = &.{},
+
+    /// Append this diagnostic as one JSON object (no trailing newline) to `w`.
+    pub fn writeJson(self: Diagnostic, w: *std.Io.Writer) std.Io.Writer.Error!void {
+        try w.writeAll("{\"range\":{\"start\":{\"line\":");
+        try w.print("{d}", .{self.range.start.line});
+        try w.writeAll(",\"character\":");
+        try w.print("{d}", .{self.range.start.character});
+        try w.writeAll("},\"end\":{\"line\":");
+        try w.print("{d}", .{self.range.end.line});
+        try w.writeAll(",\"character\":");
+        try w.print("{d}", .{self.range.end.character});
+        try w.writeAll("}},\"severity\":");
+        try w.print("{d}", .{@intFromEnum(self.severity)});
+        if (self.code) |c| {
+            try w.writeAll(",\"code\":");
+            try writeJsonString(w, c);
+        }
+        try w.writeAll(",\"source\":");
+        try writeJsonString(w, self.source);
+        try w.writeAll(",\"message\":");
+        try writeJsonString(w, self.message);
+        if (self.suggestions.len > 0) {
+            try w.writeAll(",\"data\":{\"suggestions\":[");
+            for (self.suggestions, 0..) |s, i| {
+                if (i > 0) try w.writeByte(',');
+                try w.writeAll("{\"kind\":");
+                try writeJsonString(w, s.kind);
+                try w.writeAll(",\"replacement\":");
+                try writeJsonString(w, s.replacement);
+                try w.writeByte('}');
+            }
+            try w.writeAll("]}");
+        }
+        try w.writeByte('}');
+    }
+};
+
+/// Build a zero-width range at a position the reader reports as 1-based
+/// `(line, col)`, converting to LSP's zero-based coordinates. A zero (unknown)
+/// component maps to zero. Ranges stay points until span tracking lands
+/// (kaappi#1506); this is the honest "position known today".
+pub fn pointRange(line_1based: u32, col_1based: u32) Range {
+    const p: Position = .{
+        .line = if (line_1based > 0) line_1based - 1 else 0,
+        .character = if (col_1based > 0) col_1based - 1 else 0,
+    };
+    return .{ .start = p, .end = p };
+}
+
+/// Write `s` as a JSON string literal (surrounding quotes included), escaping
+/// the characters JSON requires. Control characters below 0x20 that lack a
+/// short escape are emitted as `\uXXXX`.
+fn writeJsonString(w: *std.Io.Writer, s: []const u8) std.Io.Writer.Error!void {
+    try w.writeByte('"');
+    for (s) |c| {
+        switch (c) {
+            '"' => try w.writeAll("\\\""),
+            '\\' => try w.writeAll("\\\\"),
+            '\n' => try w.writeAll("\\n"),
+            '\r' => try w.writeAll("\\r"),
+            '\t' => try w.writeAll("\\t"),
+            0x00...0x08, 0x0B, 0x0C, 0x0E...0x1F => try w.print("\\u{x:0>4}", .{c}),
+            else => try w.writeByte(c),
+        }
+    }
+    try w.writeByte('"');
+}
+
+// -- Tests ------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn renderToBuf(buf: []u8, diag: Diagnostic) []const u8 {
+    var w: std.Io.Writer = .fixed(buf);
+    diag.writeJson(&w) catch unreachable;
+    return w.buffered();
+}
+
+test "writeJson: minimal diagnostic omits code and data" {
+    var buf: [512]u8 = undefined;
+    const out = renderToBuf(&buf, .{
+        .range = pointRange(1, 1),
+        .message = "boom",
+    });
+    try testing.expectEqualStrings(
+        "{\"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":0,\"character\":0}}," ++
+            "\"severity\":1,\"source\":\"kaappi\",\"message\":\"boom\"}",
+        out,
+    );
+}
+
+test "writeJson: full diagnostic with code and a suggestion" {
+    var buf: [512]u8 = undefined;
+    const out = renderToBuf(&buf, .{
+        .range = pointRange(2, 10),
+        .code = "KP3001",
+        .message = "undefined variable 'countr'",
+        .suggestions = &.{.{ .kind = "rename", .replacement = "count" }},
+    });
+    try testing.expectEqualStrings(
+        "{\"range\":{\"start\":{\"line\":1,\"character\":9},\"end\":{\"line\":1,\"character\":9}}," ++
+            "\"severity\":1,\"code\":\"KP3001\",\"source\":\"kaappi\"," ++
+            "\"message\":\"undefined variable 'countr'\"," ++
+            "\"data\":{\"suggestions\":[{\"kind\":\"rename\",\"replacement\":\"count\"}]}}",
+        out,
+    );
+}
+
+test "writeJson: message is JSON-escaped" {
+    var buf: [512]u8 = undefined;
+    const out = renderToBuf(&buf, .{
+        .range = pointRange(1, 1),
+        .message = "bad \"quote\"\n\tand tab",
+    });
+    // The rendered object must parse back cleanly.
+    try testing.expect(std.mem.indexOf(u8, out, "\\\"quote\\\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\\n\\tand tab") != null);
+}
+
+test "pointRange: 1-based reader coordinates become 0-based, unknown clamps to 0" {
+    const r = pointRange(3, 5);
+    try testing.expectEqual(@as(u32, 2), r.start.line);
+    try testing.expectEqual(@as(u32, 4), r.start.character);
+    try testing.expectEqual(r.start, r.end);
+
+    const unknown = pointRange(0, 0);
+    try testing.expectEqual(@as(u32, 0), unknown.start.line);
+    try testing.expectEqual(@as(u32, 0), unknown.start.character);
+}
+
+test "severityOf: registry severities map onto LSP scale" {
+    try testing.expectEqual(Severity.err, severityOf(.err));
+    try testing.expectEqual(Severity.warning, severityOf(.warning));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -43,6 +43,7 @@ pub const llvm_emit = @import("llvm_emit.zig");
 pub const native_compiler = @import("native_compiler.zig");
 pub const toplevel_driver = @import("toplevel_driver.zig");
 pub const diagnostics = @import("diagnostics.zig");
+pub const lsp_diagnostic = @import("lsp_diagnostic.zig");
 pub const cli = @import("cli.zig");
 pub const config = @import("config.zig");
 
@@ -217,6 +218,10 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     if (opts.max_memory) |limit| gc.memory_limit = limit;
     if (opts.coverage_xml_path) |p| vm.coverage_xml_path = p;
     vm.command_line_args = opts.scriptArgs();
+    toplevel_driver.setDiagnosticFormat(switch (opts.diagnostics_format) {
+        .text => .text,
+        .json => .json,
+    });
 
     // Standalone mode: run embedded bytecode and exit
     if (embedded_bytecode.bytecode) |bytecode_data| {
@@ -959,6 +964,7 @@ test {
     _ = native_compiler;
     _ = toplevel_driver;
     _ = diagnostics;
+    _ = lsp_diagnostic;
     _ = repl_mod;
     _ = cli;
     _ = config;

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -3,6 +3,7 @@ const vm_mod = @import("vm.zig");
 const compiler_mod = @import("compiler.zig");
 const reporting = @import("reporting.zig");
 const diagnostics = @import("diagnostics.zig");
+const lsp_diagnostic = @import("lsp_diagnostic.zig");
 
 const writeStderr = reporting.writeStderr;
 
@@ -10,6 +11,45 @@ pub const Location = struct {
     source: []const u8,
     line: u32,
 };
+
+/// How top-level diagnostics are rendered. `text` is the default human format
+/// (unchanged); `json` emits one LSP `Diagnostic` object per line on stderr for
+/// agents and editors (`--diagnostics=json`, kaappi#1505). Both formats share
+/// the same codes, messages, and reporting funnel — only the rendering differs.
+pub const DiagnosticFormat = enum { text, json };
+
+// A process-wide setting (like `ir_mod.optimize_enabled`): set once from the
+// parsed CLI options before anything runs, then read by every report function.
+// The REPL, file runner, and stdin runner all funnel through here, so one
+// switch covers every surface.
+var diagnostic_format: DiagnosticFormat = .text;
+
+pub fn setDiagnosticFormat(fmt: DiagnosticFormat) void {
+    diagnostic_format = fmt;
+}
+
+pub fn diagnosticFormat() DiagnosticFormat {
+    return diagnostic_format;
+}
+
+/// Serialize one diagnostic and write it as a single line to stderr. On the
+/// rare overflow of the fixed buffer (a pathologically long detail message),
+/// emit a minimal valid object instead of a truncated one so the JSON Lines
+/// stream stays parseable end to end.
+fn emitJsonLine(diag: lsp_diagnostic.Diagnostic) void {
+    var buf: [2048]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    diag.writeJson(&w) catch {
+        writeStderr("{\"severity\":1,\"source\":\"kaappi\",\"message\":\"diagnostic too large to serialize\"}\n");
+        return;
+    };
+    writeStderr(w.buffered());
+    writeStderr("\n");
+}
+
+fn lspSeverity(code: diagnostics.Code) lsp_diagnostic.Severity {
+    return lsp_diagnostic.severityOf(code.info().severity);
+}
 
 // Every diagnostic Kaappi prints carries a stable KP code (KEP-0005, #1504).
 // The leading digit encodes the stage: KP1xxx read, KP2xxx compile, KP3xxx
@@ -21,6 +61,15 @@ pub const Location = struct {
 pub fn reportReadError(source_name: []const u8, line: u32, col: u32, err: anyerror) void {
     const code = diagnostics.readErrorCode(err);
     var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+    if (diagnostic_format == .json) {
+        emitJsonLine(.{
+            .range = lsp_diagnostic.pointRange(line, col),
+            .severity = lspSeverity(code),
+            .code = code.render(&cbuf),
+            .message = code.message(),
+        });
+        return;
+    }
     var buf: [256]u8 = undefined;
     const s = std.fmt.bufPrint(&buf, "{s}:{d}:{d}: read error[{s}]: {s}\n", .{
         source_name, line, col, code.render(&cbuf), code.message(),
@@ -31,8 +80,23 @@ pub fn reportReadError(source_name: []const u8, line: u32, col: u32, err: anyerr
 pub fn reportCompileError(source_name: []const u8, line: u32, err: anyerror) void {
     var cbuf: [diagnostics.Code.render_width]u8 = undefined;
     const detail = compiler_mod.getSyntaxErrorDetail();
+    // A macro/syntax-rules rejection carries a detail string and is the "expand"
+    // stage; a plain compile failure has none. Both are KP2xxx.
+    const code = if (detail.len > 0) diagnostics.Code.syntax_error else diagnostics.compileErrorCode(err);
+    const msg = if (detail.len > 0) detail else code.message();
+
+    if (diagnostic_format == .json) {
+        emitJsonLine(.{
+            .range = lsp_diagnostic.pointRange(line, 0),
+            .severity = lspSeverity(code),
+            .code = code.render(&cbuf),
+            .message = msg,
+        });
+        if (detail.len > 0) compiler_mod.syntax_error_detail_len = 0;
+        return;
+    }
+
     if (detail.len > 0) {
-        const code = diagnostics.Code.syntax_error;
         var buf: [256]u8 = undefined;
         const prefix = std.fmt.bufPrint(&buf, "{s}:{d}: syntax-error[{s}]: ", .{ source_name, line, code.render(&cbuf) }) catch "syntax-error: ";
         writeStderr(prefix);
@@ -40,7 +104,6 @@ pub fn reportCompileError(source_name: []const u8, line: u32, err: anyerror) voi
         writeStderr("\n");
         compiler_mod.syntax_error_detail_len = 0;
     } else {
-        const code = diagnostics.compileErrorCode(err);
         var buf: [256]u8 = undefined;
         const s = std.fmt.bufPrint(&buf, "{s}:{d}: compile error[{s}]: {s}\n", .{ source_name, line, code.render(&cbuf), code.message() }) catch "compile error\n";
         writeStderr(s);
@@ -56,6 +119,32 @@ pub fn reportRuntimeError(vm: *vm_mod.VM, err: anyerror, location: ?Location) vo
     const msg = if (detail.len > 0) detail else code.message();
     var cbuf: [diagnostics.Code.render_width]u8 = undefined;
     const code_str = code.render(&cbuf);
+
+    if (diagnostic_format == .json) {
+        // A "did you mean" hint is carried structurally (set at the raise site,
+        // kaappi#1505) so a tool can apply the rename directly; the message is
+        // then the clean form, with the redundant prose stripped.
+        var sug_buf: [1]lsp_diagnostic.Suggestion = undefined;
+        var suggestions: []const lsp_diagnostic.Suggestion = &.{};
+        var clean_msg = msg;
+        if (vm.last_error_suggestion) |replacement| {
+            sug_buf[0] = .{ .kind = "rename", .replacement = replacement };
+            suggestions = sug_buf[0..1];
+            clean_msg = messageWithoutSuggestion(msg, replacement);
+        }
+        emitJsonLine(.{
+            .range = lsp_diagnostic.pointRange(if (location) |loc| loc.line else 0, 0),
+            .severity = lspSeverity(code),
+            .code = code_str,
+            .message = clean_msg,
+            .suggestions = suggestions,
+        });
+        vm.last_error_detail_len = 0;
+        vm.last_error_code = .uncategorized;
+        vm.last_error_suggestion = null;
+        return;
+    }
+
     if (location) |loc| {
         var buf: [512]u8 = undefined;
         const s = if (loc.line > 0)
@@ -70,6 +159,19 @@ pub fn reportRuntimeError(vm: *vm_mod.VM, err: anyerror, location: ?Location) vo
     }
     vm.last_error_detail_len = 0;
     vm.last_error_code = .uncategorized;
+    vm.last_error_suggestion = null;
+}
+
+/// Return `detail` without the exact "did you mean" suffix that
+/// `raiseUndefinedVariable` appended for `replacement`. Deterministic: we rebuild
+/// the same suffix we produced and strip it only on an exact match, so this is
+/// not prose-scraping. Used to keep the JSON message clean when the hint is
+/// already present in `data.suggestions`.
+fn messageWithoutSuggestion(detail: []const u8, replacement: []const u8) []const u8 {
+    var buf: [80]u8 = undefined;
+    const suffix = std.fmt.bufPrint(&buf, ". Did you mean '{s}'?", .{replacement}) catch return detail;
+    if (std.mem.endsWith(u8, detail, suffix)) return detail[0 .. detail.len - suffix.len];
+    return detail;
 }
 
 /// The diagnostic code for a runtime error: the code carried on the raised
@@ -91,6 +193,10 @@ pub fn vmErrorLocation(vm: *vm_mod.VM, fallback_source: []const u8, fallback_lin
 }
 
 pub fn printStackTrace(vm: *vm_mod.VM) void {
+    // These human-oriented extras would corrupt the one-object-per-line JSON
+    // stream, so suppress them in JSON mode (a future phase may surface frames
+    // as LSP `relatedInformation`).
+    if (diagnostic_format == .json) return;
     const trace = vm.getLastStackTrace();
     if (trace.len > 1) {
         for (trace[1..]) |frame| {
@@ -107,6 +213,7 @@ pub fn printStackTrace(vm: *vm_mod.VM) void {
 }
 
 pub fn printSourceSnippet(source: []const u8, line: u32) void {
+    if (diagnostic_format == .json) return;
     if (line == 0 or source.len == 0) return;
     var current_line: u32 = 1;
     var line_start: usize = 0;

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -231,6 +231,13 @@ pub const VM = struct {
     // form in resetExecutionState. When `.uncategorized`, the reporting layer
     // derives a code from the Zig error instead.
     last_error_code: diagnostics.Code = .uncategorized,
+    // A structured fix suggestion for the escaping error (kaappi#1505): the
+    // nearest defined name for an undefined-variable error, surfaced as
+    // `data.suggestions` in `--diagnostics=json`. Borrowed from the globals
+    // key table (stable for the VM's lifetime), read by reportRuntimeError
+    // immediately after the error, and cleared alongside last_error_code (at
+    // execute() entry and after each report) so it never goes stale.
+    last_error_suggestion: ?[]const u8 = null,
     last_stack_trace: [16]StackFrame = undefined,
     last_stack_trace_len: usize = 0,
     // Debugger state

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -110,6 +110,7 @@ pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
     // runs on the error-exit path *after* noteUncaughtException has recorded the
     // escaping error's code — see the last_error_detail save/restore there).
     vm.last_error_code = .uncategorized;
+    vm.last_error_suggestion = null;
 
     // Each top-level form starts on the main fiber. A previous form may have
     // left the scheduler positioned on a spawned fiber, or the main fiber

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -1367,6 +1367,10 @@ noinline fn rejectImmutableEnv(self: *VM, func: *types.Function, name: []const u
 noinline fn raiseUndefinedVariable(self: *VM, name: []const u8) VMError {
     if (self.findSimilarName(name)) |suggestion| {
         self.setErrorDetail("undefined variable '{s}'. Did you mean '{s}'?", .{ name, suggestion });
+        // Carry the correction structurally so --diagnostics=json can emit it as
+        // a `data.suggestions` rename (kaappi#1505). `suggestion` is a globals
+        // key, stable for the VM's lifetime.
+        self.last_error_suggestion = suggestion;
     } else {
         self.setErrorDetail("undefined variable '{s}'", .{name});
     }

--- a/tests/scheme/errors/diagnostics-json.sh
+++ b/tests/scheme/errors/diagnostics-json.sh
@@ -45,8 +45,19 @@ def run(src, json_mode=True):
 
 def parse_lines(stderr):
     """Parse every non-empty stderr line as JSON. Raises if any line is not
-    valid JSON — that is exactly how a leaked snippet/backtrace line is caught."""
-    return [json.loads(l) for l in stderr.decode().splitlines() if l.strip()]
+    valid JSON — that is exactly how a leaked snippet/backtrace line is caught.
+
+    A Debug build's DebugAllocator appends "…leaked:" reports to stderr at
+    process teardown, *after* all diagnostics. That is a build-mode artifact,
+    not part of the product's stderr contract, so cut everything from the first
+    such report onward. Kaappi's own diagnostics are emitted during execution
+    (before teardown), so this preserves the strict check for a real text leak."""
+    text = stderr.decode()
+    for marker in ("error(DebugAllocator)", "error(gpa)"):
+        idx = text.find(marker)
+        if idx != -1:
+            text = text[:idx]
+    return [json.loads(l) for l in text.splitlines() if l.strip()]
 
 def assert_valid_diag(d):
     """Structural check of one LSP Diagnostic. Returns True or raises."""

--- a/tests/scheme/errors/diagnostics-json.sh
+++ b/tests/scheme/errors/diagnostics-json.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# --diagnostics=json structured output tests (kaappi#1505).
+#
+# Every diagnostic emitted under --diagnostics=json must be a valid LSP
+# Diagnostic object, one per line on stderr, covering all four pipeline stages
+# (read, expand, compile, runtime). We validate with a *real* JSON parser
+# (python3), not grep, so a malformed object or a leaked text line fails here.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "FAIL: python3 is required to validate JSON diagnostics output"
+    exit 1
+fi
+
+# The whole suite is a self-contained python driver: it runs the interpreter for
+# each case, parses stderr with json.loads, and asserts on the structured
+# fields. It prints PASS/FAIL per check and exits non-zero if any check fails.
+KAAPPI="$KAAPPI" python3 - <<'PY'
+import json, os, re, subprocess, sys
+
+KAAPPI = os.environ["KAAPPI"]
+CODE_RE = re.compile(r"^KP\d{4}$")
+ZIG_LEAK_RE = re.compile(r"error\.[A-Z][A-Za-z]+")
+
+passed = 0
+failed = 0
+
+def check(cond, label, detail=""):
+    global passed, failed
+    if cond:
+        print(f"PASS: {label}")
+        passed += 1
+    else:
+        print(f"FAIL: {label}  {detail}")
+        failed += 1
+
+def run(src, json_mode=True):
+    args = [KAAPPI]
+    if json_mode:
+        args.append("--diagnostics=json")
+    return subprocess.run(args, input=src.encode(), capture_output=True)
+
+def parse_lines(stderr):
+    """Parse every non-empty stderr line as JSON. Raises if any line is not
+    valid JSON — that is exactly how a leaked snippet/backtrace line is caught."""
+    return [json.loads(l) for l in stderr.decode().splitlines() if l.strip()]
+
+def assert_valid_diag(d):
+    """Structural check of one LSP Diagnostic. Returns True or raises."""
+    r = d["range"]
+    for pt in (r["start"], r["end"]):
+        assert isinstance(pt["line"], int) and pt["line"] >= 0, pt
+        assert isinstance(pt["character"], int) and pt["character"] >= 0, pt
+    assert d["severity"] == 1, d["severity"]
+    assert CODE_RE.match(d["code"]), d["code"]
+    assert d["source"] == "kaappi", d["source"]
+    assert isinstance(d["message"], str) and d["message"], d
+    assert not ZIG_LEAK_RE.search(d["message"]), d["message"]
+    return True
+
+def single_diag(label, src, expect_code_prefix, expect_msg_substr=None):
+    """Run src, assert exactly one valid diagnostic with the expected code
+    prefix (and optional message substring)."""
+    p = run(src)
+    try:
+        diags = parse_lines(p.stderr)
+    except Exception as e:
+        check(False, f"{label}: stderr is valid JSON Lines", f"{e!r}: {p.stderr!r}")
+        return None
+    if len(diags) != 1:
+        check(False, f"{label}: exactly one diagnostic", diags)
+        return None
+    d = diags[0]
+    try:
+        assert_valid_diag(d)
+    except AssertionError as e:
+        check(False, f"{label}: object is a valid LSP Diagnostic", repr(e))
+        return None
+    ok = d["code"].startswith(expect_code_prefix)
+    check(ok, f"{label}: code is {expect_code_prefix}xxx", d["code"])
+    if expect_msg_substr is not None:
+        check(expect_msg_substr in d["message"],
+              f"{label}: message mentions '{expect_msg_substr}'", d["message"])
+    check(p.returncode != 0, f"{label}: exits non-zero", p.returncode)
+    return d
+
+# --- All four stages produce a valid, coded diagnostic --------------------
+
+# Read / lexical (KP1xxx): unterminated string.
+single_diag("read stage", '(display "abc', "KP1", "unterminated string")
+
+# Expand stage (KP2002): a macro/syntax rejection carries its detail message.
+single_diag("expand stage", '(syntax-error "bad usage" 42)', "KP2", "bad usage")
+
+# Compile stage (KP2xxx): an if with no test.
+single_diag("compile stage", "(if)", "KP2")
+
+# Runtime stage (KP3xxx): car on a non-pair.
+single_diag("runtime stage", "(car 5)", "KP3", "car")
+
+# --- Suggestions map to data.suggestions ----------------------------------
+
+d = single_diag("undefined variable",
+                "(define count 1) (display countr)", "KP3", None)
+if d is not None:
+    check(d["code"] == "KP3001", "undefined variable is KP3001", d["code"])
+    # The message is the clean form; the fix is structured, not prose.
+    check(d["message"] == "undefined variable 'countr'",
+          "undefined-variable message is clean (no 'did you mean' prose)",
+          d["message"])
+    sugg = d.get("data", {}).get("suggestions")
+    check(sugg == [{"kind": "rename", "replacement": "count"}],
+          "data.suggestions offers the rename fix", sugg)
+
+# A diagnostic with no fix must omit data entirely.
+d = single_diag("no-suggestion diagnostic", "(car 5)", "KP3", None)
+if d is not None:
+    check("data" not in d, "diagnostic without a fix omits 'data'", d.get("data"))
+
+# --- Stream hygiene -------------------------------------------------------
+
+# A runtime error deep in a call chain must still emit exactly one JSON object;
+# the human backtrace/snippet must NOT leak onto stderr (it would break parsing).
+p = run("(define (a x) (b x))\n(define (b x) (car x))\n(a 42)\n")
+try:
+    diags = parse_lines(p.stderr)
+    check(len(diags) == 1 and diags[0]["code"] == "KP3002",
+          "backtrace suppressed: stderr stays one JSON object", diags)
+except Exception as e:
+    check(False, "backtrace case: stderr is valid JSON Lines", f"{e!r}: {p.stderr!r}")
+
+# Multiple top-level errors → one object per line, each independently valid.
+p = run("(car 5)\n(vector-ref (vector 1) 9)\n")
+try:
+    diags = parse_lines(p.stderr)
+    codes = [d["code"] for d in diags]
+    check(len(diags) == 2 and all(assert_valid_diag(d) for d in diags),
+          "multiple errors: one valid object per line", diags)
+    check(codes == ["KP3002", "KP3006"], "multiple errors keep their codes", codes)
+except Exception as e:
+    check(False, "multi-error case: stderr is valid JSON Lines", f"{e!r}: {p.stderr!r}")
+
+# Program stdout is not polluted by diagnostics on stderr.
+p = run('(display "hi") (newline) (car 5)')
+check(p.stdout == b"hi\n", "program stdout is clean in JSON mode", p.stdout)
+try:
+    diags = parse_lines(p.stderr)
+    check(len(diags) == 1 and diags[0]["code"] == "KP3002",
+          "stdout/stderr are cleanly separated", diags)
+except Exception as e:
+    check(False, "stdout-separation case: stderr is valid JSON", f"{e!r}: {p.stderr!r}")
+
+# --- Text mode remains the default ----------------------------------------
+
+p = run("(display countr)", json_mode=False)
+err = p.stderr.decode()
+check(not err.lstrip().startswith("{"), "default mode is not JSON", err)
+check("error[KP3001]" in err, "default mode keeps the human text format", err)
+
+# --- Summary --------------------------------------------------------------
+
+print()
+print(f"Passed: {passed}")
+print(f"Failed: {failed}")
+sys.exit(1 if failed else 0)
+PY
+
+echo "All --diagnostics=json tests pass."


### PR DESCRIPTION
## What

Adds `kaappi --diagnostics=json file.scm`, which emits every diagnostic as one **LSP `Diagnostic`** object per line (JSON Lines) on stderr, so agents and editors can consume errors structurally instead of scraping human text. Text mode remains the default and is unchanged.

```json
{"range":{"start":{"line":1,"character":9},"end":{"line":1,"character":9}},"severity":1,"code":"KP3001","source":"kaappi","message":"undefined variable 'countr'","data":{"suggestions":[{"kind":"rename","replacement":"count"}]}}
```

## Design

- **No invented schema.** Each line is an LSP [`Diagnostic`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic). The serializer lives in one place — `src/lsp_diagnostic.zig` — used by **both** the CLI reporting funnel (`src/toplevel_driver.zig`) and the language server (`src/kaappi_lsp.zig`), so the two can't drift. The LSP gains KP codes as a result.
- **`code`** is the stable `KP` code from the registry (#1504); `message` is free to be reworded.
- **Fix suggestions** ("did you mean") map to `data.suggestions` with `kind`/`replacement`, carried structurally on `VM.last_error_suggestion` (borrows an interned globals key; reset at `execute()` entry and after each report) so the JSON `message` stays clean while text mode keeps the inline hint.
- **Positions** are LSP zero-based; ranges are points until span tracking lands (#1506) — "positions known today".
- **Stream hygiene**: the source snippet and backtrace are suppressed in JSON mode so stderr stays one parseable object per line. (Frames as `relatedInformation` is future work.)

## Coverage — all four stages

| Stage | Code | Trigger |
|-------|------|---------|
| Read | `KP1xxx` | `(display "abc` |
| Expand | `KP2002` | `(syntax-error "bad" 42)` |
| Compile | `KP2xxx` | `(if)` |
| Runtime | `KP3xxx` | `(car 5)` |

## Acceptance criteria

- [x] `--diagnostics=json` covers all four stages
- [x] Schema documented — [`docs/dev/diagnostics-json.md`](docs/dev/diagnostics-json.md), referencing the LSP `Diagnostic` spec
- [x] Serialization shared with the LSP (no second implementation to drift)
- [x] Shell test in `tests/scheme/errors/` validating output with a real JSON parser (`diagnostics-json.sh`, `python3 json.loads`, 26 checks)

## Testing

`zig build test` green · `error-format.sh` 79/0 (text mode unchanged) · `diagnostics-json.sh` 26/0 · smoke suite · `zig build wasm` · LSP round-trip emits `KP1006` via the shared serializer · `zig fmt` clean.

## Notes

Depends on the KP code registry (#1504, merged). A standalone bundled binary still reports its own top-level errors as text; the flag governs the interpreter's read/expand/compile/runtime funnel that the file runner, stdin runner, and REPL share. Part of #1503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)