### PR TITLE
Box mutable captured variables in the native backend (#1497)

### DIFF
--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -63,6 +63,7 @@ functions that native code calls:
 | `kaappi_define_global` | Define a global variable |
 | `kaappi_make_string` | Allocate a string on the GC heap |
 | `kaappi_intern_symbol` | Intern a symbol via the GC symbol table (ensures `eq?` identity) |
+| `kaappi_make_box` / `kaappi_box_ref` / `kaappi_box_set` | Allocate / read / write a one-slot heap box for a captured+mutated variable (assignment conversion, see [Mutable captured variables](#mutable-captured-variables-assignment-conversion)) |
 | `kaappi_eval` | Parse, compile, and evaluate a Scheme expression |
 
 All functions use `callconv(.c)` and pass Values as plain `u64` (the
@@ -195,7 +196,10 @@ The three tiers, tried in order:
    discovered by free-variable analysis (`collectFreeVars`) and **copied by
    value** into an `%upvalues` array at closure-creation time (sourced from the
    enclosing frame's `%args`, or, for a lambda nested in another native closure,
-   chained out of that closure's own `%upvalues` — #1410). The closure value is
+   chained out of that closure's own `%upvalues` — #1410). A free variable the
+   enclosing frame **boxed** (see [Mutable captured
+   variables](#mutable-captured-variables-assignment-conversion)) is captured as
+   the box **pointer** instead, so mutations are shared. The closure value is
    materialized with `kaappi_create_native_closure`.
 
 2. **Closed lambda / named function** (`tryCompilePureLambdaAsNativeClosure`,
@@ -220,15 +224,41 @@ label rather than recursing (non-variadic named functions only).
 **Falls back to `kaappi_eval` when the body:**
 - contains an eval-fallback form (`letrec`, `cond`, `case`, `do`, `guard`,
   named `let`, …);
-- mutates or internally defines a captured variable — the by-value upvalue
-  model cannot express mutation, and snapshotting at creation time would
-  diverge from the VM's by-**location** closure semantics (#819, #1422);
-- captures a `let`-local or rest parameter that has no copyable slot; or
+- contains an internal `define` (the closure tier sets up no locals scope for
+  it), or a rest parameter that is captured and mutated (no box model yet);
+- captures an unmutated `let`-local, or a rest parameter, that has no copyable
+  slot; or
 - exceeds a fixed analysis limit (parameter/body-node/name buffers).
 
 The resulting value (native closure or eval'd closure) is uniformly callable
 via `kaappi_call_scheme`, which dispatches through the VM's `callWithArgs`
 (closures, native functions, continuations, etc.).
+
+### Mutable captured variables (assignment conversion)
+
+The by-value `%upvalues` copy above is correct only while a captured binding is
+never mutated. A binding that is both **captured** by a nested lambda and
+**mutated** (by `set!`, or an internal `define` that re-binds it) is instead
+**assignment-converted to a heap box** (`llvm_emit_lambda.zig`, #1497):
+
+- At the binding's site in the enclosing native frame — a boxed **parameter**
+  (`emitBoxedParamSlots`) or a boxed **`let`-local** (`emitLet`) — the value is
+  wrapped in a box (`kaappi_make_box`) and the frame slot holds the box
+  **pointer**. The slot is GC-rooted for the frame's lifetime.
+- Every read of the boxed name compiles to `kaappi_box_ref`, every `set!` to
+  `kaappi_box_set` (`emitGlobalRef` / `emitStoreToVariable`, which consult the
+  emitter's `boxes` map before params/upvalues).
+- A nested closure captures the **box pointer** by value. Because the pointer is
+  immutable and the box's contents are shared, a `set!` through any closure over
+  the binding is visible to all of them — matching the interpreter's
+  by-**location** closure semantics and fixing the #1422 divergence.
+
+A box is a one-slot heap cell represented internally as a pair `(value . '())`;
+boxes never escape to Scheme, so reusing the pair type keeps GC marking, the
+write barrier, and sweeping correct with no new heap type. Only captured **and**
+mutated bindings are boxed — everything else keeps the by-value fast path. Boxed
+frames disable the self-tail-call loop and lower their body non-tail so the box
+roots are popped at a single `ret`.
 
 ## Testing
 
@@ -248,6 +278,8 @@ environment variable controls the C compiler (defaults to `zig cc`).
 ### What's been stress-tested
 
 - Closures with message dispatch (`eq?` on quoted symbols)
+- Mutable captured variables — counters, accumulators, and closures sharing a
+  boxed binding (`native-mutable-capture.scm`, `native-set-captured.scm`)
 - Recursive functions on quoted data (`flatten`, `my-len`)
 - Error handling with `guard`
 - User-defined macros (`define-syntax`)

--- a/src/fuzz_gen_native.zig
+++ b/src/fuzz_gen_native.zig
@@ -102,19 +102,18 @@ const Ctx = struct {
     /// string — a lambda nested there would be interpreted invisibly to
     /// the emitter and break the gate's eval accounting.
     no_lambda: bool = false,
-    /// True inside inline-lambda bodies: the capturing closure tier rejects
-    /// bodies containing set! ANYWHERE — even of a let-local — via the
-    /// blanket syntactic scan sexprContainsSetOrDefine (#819), so a set!
-    /// there would drop the lambda to emitLambdaViaEval. (Define-position
-    /// lambdas go through tryCompileDefineFunction, whose free-var check
-    /// does not descend into let forms, so set! inside their lets is fine.)
-    /// Also true inside inline-call ARGUMENT subtrees in function bodies:
-    /// arguments run between closure creation (which snapshots captured
-    /// params by value) and the call, so a set! of a captured param there
-    /// diverges from the VM's location-based capture (#1422).
+    /// True inside inline-lambda bodies and inline-call ARGUMENT subtrees.
+    /// A set! of a *captured* variable there triggers assignment conversion
+    /// (#1497): the enclosing frame boxes the binding, or — when the capturing
+    /// lambda cannot itself be a native closure — the whole function falls back
+    /// to eval. Either outcome shifts the gate's exact `kaappi_eval` accounting,
+    /// so the generator keeps these positions set!-free rather than model
+    /// boxing. (Define-position lambdas go through tryCompileDefineFunction,
+    /// whose free-var check does not descend into let forms, so set! inside
+    /// their lets is fine.) The closure tier itself now rejects only an
+    /// internal `define` (sexprContainsDefine), not set!.
     /// Note: set! of a define-position function's own params is prevented
-    /// separately by pushing those params with settable=false — the #1422
-    /// guard rejects functions whose params are both set! and captured.
+    /// separately by pushing those params with settable=false.
     no_set: bool = false,
 };
 

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -12,6 +12,13 @@ const NativeLambda = struct {
     is_variadic: bool,
 };
 
+fn nameInList(names: []const []const u8, name: []const u8) bool {
+    for (names) |n| {
+        if (std.mem.eql(u8, n, name)) return true;
+    }
+    return false;
+}
+
 pub const LLVMEmitter = struct {
     buf: std.ArrayList(u8),
     symbols: std.StringHashMap(u32),
@@ -34,6 +41,18 @@ pub const LLVMEmitter = struct {
     rest_param_alloca: ?[]const u8 = null,
     rest_param_name: ?[]const u8 = null,
     locals: ?std.StringHashMap([]const u8) = null,
+    // Boxed variables in the current frame (assignment conversion, #1497):
+    // name -> the alloca that holds the box POINTER. A boxed variable is both
+    // captured by a nested lambda and mutated; reads go through kaappi_box_ref
+    // and writes through kaappi_box_set, and nested closures capture the box
+    // pointer, restoring the interpreter's by-location semantics. Checked
+    // before params/upvalues in name resolution.
+    boxes: ?std.StringHashMap([]const u8) = null,
+    // Number of box-slot roots pushed at the current frame's entry that must be
+    // popped before the frame's `ret` (see emitLambdaFunction / the closure
+    // tier). Boxed frames disable tail-call emission so there is exactly one
+    // `ret` at which to pop.
+    frame_box_roots: usize = 0,
 
     pub const SavedScope = struct {
         buf: std.ArrayList(u8),
@@ -47,6 +66,8 @@ pub const LLVMEmitter = struct {
         rest_param_alloca: ?[]const u8,
         rest_param_name: ?[]const u8,
         locals: ?std.StringHashMap([]const u8),
+        boxes: ?std.StringHashMap([]const u8),
+        frame_box_roots: usize,
     };
 
     pub fn saveScope(self: *LLVMEmitter) SavedScope {
@@ -62,6 +83,8 @@ pub const LLVMEmitter = struct {
             .rest_param_alloca = self.rest_param_alloca,
             .rest_param_name = self.rest_param_name,
             .locals = self.locals,
+            .boxes = self.boxes,
+            .frame_box_roots = self.frame_box_roots,
         };
     }
 
@@ -77,6 +100,8 @@ pub const LLVMEmitter = struct {
         self.rest_param_alloca = s.rest_param_alloca;
         self.rest_param_name = s.rest_param_name;
         self.locals = s.locals;
+        self.boxes = s.boxes;
+        self.frame_box_roots = s.frame_box_roots;
     }
 
     pub fn init(backing: std.mem.Allocator) LLVMEmitter {
@@ -213,6 +238,9 @@ pub const LLVMEmitter = struct {
     // analysis in llvm_emit_lambda.zig: a shadowed name is a capture even
     // when a known global of the same name exists.
     pub fn isNameShadowed(self: *LLVMEmitter, name: []const u8) bool {
+        if (self.boxes) |bx| {
+            if (bx.get(name) != null) return true;
+        }
         if (self.locals) |loc| {
             if (loc.get(name) != null) return true;
         }
@@ -231,6 +259,18 @@ pub const LLVMEmitter = struct {
     fn emitGlobalRef(self: *LLVMEmitter, sym: Value) EmitError![]const u8 {
         if (!types.isSymbol(sym)) return error.UnsupportedNodeType;
         const name = types.symbolName(sym);
+
+        // A boxed variable's slot holds the box pointer; read through the box
+        // so a set! from any sibling closure over the same binding is visible.
+        if (self.boxes) |bx| {
+            if (bx.get(name)) |box_alloca| {
+                const boxptr = try self.freshTemp();
+                try self.print("  {s} = load i64, ptr {s}\n", .{ boxptr, box_alloca });
+                const tmp = try self.freshTemp();
+                try self.print("  {s} = call i64 @kaappi_box_ref(i64 {s})\n", .{ tmp, boxptr });
+                return tmp;
+            }
+        }
 
         if (self.locals) |loc| {
             if (loc.get(name)) |alloca_name| {
@@ -449,9 +489,14 @@ pub const LLVMEmitter = struct {
         if (lambda.sexprNeedsEvalFallback(args)) {
             return self.emitLetFallback(args, sequential);
         }
-        // #827: If the body contains a lambda that captures let-bound variable
-        // names, it cannot be compiled natively inside this scope (the lambda
-        // would be evaluated in the global environment, losing the bindings).
+        // #827/#1497: A body lambda that captures a let-bound variable cannot
+        // be compiled natively unless that variable is boxed — the native
+        // closure tier rejects by-value capture of let-locals. A captured var
+        // that is also mutated is assignment-converted to a heap box (#1497);
+        // a captured but unmutated var has no box, so the whole let falls back
+        // to the interpreter (which handles the scope correctly).
+        var box_names: [32][]const u8 = undefined;
+        var box_count: usize = 0;
         {
             var var_names: [32][]const u8 = undefined;
             var name_count: usize = 0;
@@ -464,9 +509,35 @@ pub const LLVMEmitter = struct {
                     name_count += 1;
                 }
             }
-            if (name_count > 0 and lambda.bodyHasCapturingLambda(body_list, var_names[0..name_count])) {
-                return self.emitLetFallback(args, sequential);
+            for (var_names[0..name_count]) |v| {
+                if (!lambda.bodyHasCapturingLambda(body_list, (&v)[0..1])) continue;
+                if (!lambda.sexprBodySetsName(body_list, v)) {
+                    return self.emitLetFallback(args, sequential);
+                }
+                box_names[box_count] = v;
+                box_count += 1;
             }
+        }
+        const any_boxed = box_count > 0;
+
+        // Boxed lets lower their body non-tail so the binding roots (which hold
+        // the box pointers) are always popped at the fall-through, never
+        // stranded past an in-body tail-call ret.
+        const body_tail = is_tail and !any_boxed;
+
+        // Box map scope for this let, extending any enclosing frame's boxes.
+        const saved_boxes = self.boxes;
+        var owns_boxes = false;
+        defer if (owns_boxes) {
+            if (self.boxes) |*b| b.deinit();
+            self.boxes = saved_boxes;
+        };
+        if (any_boxed) {
+            self.boxes = if (saved_boxes) |existing|
+                existing.clone() catch return error.OutOfMemory
+            else
+                std.StringHashMap([]const u8).init(self.allocator());
+            owns_boxes = true;
         }
 
         const saved_locals = self.locals;
@@ -504,7 +575,15 @@ pub const LLVMEmitter = struct {
                 const val = self.emitNode(node) catch {
                     return self.abandonLetForFallback(args, sequential, saved_locals, count);
                 };
-                try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
+                // A captured+mutated let-local is stored as a heap box; the
+                // alloca (rooted below) then holds the box pointer (#1497).
+                if (nameInList(box_names[0..box_count], types.symbolName(var_sym))) {
+                    const box = try self.freshTemp();
+                    try self.print("  {s} = call i64 @kaappi_make_box(ptr %vm, i64 {s})\n", .{ box, val });
+                    try self.print("  store i64 {s}, ptr {s}\n", .{ box, alloca });
+                } else {
+                    try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
+                }
                 try self.emitRootPushAlloca(alloca);
 
                 binding_allocas[count] = alloca;
@@ -514,7 +593,11 @@ pub const LLVMEmitter = struct {
             }
 
             for (0..count) |i| {
-                self.locals.?.put(var_names[i], binding_allocas[i]) catch return error.OutOfMemory;
+                if (nameInList(box_names[0..box_count], var_names[i])) {
+                    self.boxes.?.put(var_names[i], binding_allocas[i]) catch return error.OutOfMemory;
+                } else {
+                    self.locals.?.put(var_names[i], binding_allocas[i]) catch return error.OutOfMemory;
+                }
             }
             binding_root_count = count;
         } else {
@@ -535,10 +618,19 @@ pub const LLVMEmitter = struct {
                 };
                 const alloca = try self.freshTemp();
                 try self.print("  {s} = alloca i64, align 8\n", .{alloca});
-                try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
+                // Box a captured+mutated let*-local; later inits in this same
+                // let* then read it through the box (#1497).
+                if (nameInList(box_names[0..box_count], types.symbolName(var_sym))) {
+                    const box = try self.freshTemp();
+                    try self.print("  {s} = call i64 @kaappi_make_box(ptr %vm, i64 {s})\n", .{ box, val });
+                    try self.print("  store i64 {s}, ptr {s}\n", .{ box, alloca });
+                    self.boxes.?.put(types.symbolName(var_sym), alloca) catch return error.OutOfMemory;
+                } else {
+                    try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
+                    self.locals.?.put(types.symbolName(var_sym), alloca) catch return error.OutOfMemory;
+                }
                 try self.emitRootPushAlloca(alloca);
                 binding_root_count += 1;
-                self.locals.?.put(types.symbolName(var_sym), alloca) catch return error.OutOfMemory;
                 blist = types.cdr(blist);
             }
         }
@@ -547,7 +639,7 @@ pub const LLVMEmitter = struct {
         var body_expr = body_list;
         while (body_expr != types.NIL and types.isPair(body_expr)) {
             const rest = types.cdr(body_expr);
-            const expr_is_tail = is_tail and (rest == types.NIL or !types.isPair(rest));
+            const expr_is_tail = body_tail and (rest == types.NIL or !types.isPair(rest));
             const node = ir.lowerSingleExprTail(self.allocator(), types.car(body_expr), expr_is_tail) catch {
                 return self.abandonLetForFallback(args, sequential, saved_locals, binding_root_count);
             };
@@ -797,6 +889,16 @@ pub const LLVMEmitter = struct {
     // Resolution order mirrors emitGlobalRef's read path so writes and reads
     // reach the same binding.
     fn emitStoreToVariable(self: *LLVMEmitter, name: []const u8, val: []const u8) EmitError!void {
+        // A boxed variable is mutated through its heap cell so the new value is
+        // visible to every closure that captured the same box (#1497).
+        if (self.boxes) |bx| {
+            if (bx.get(name)) |box_alloca| {
+                const boxptr = try self.freshTemp();
+                try self.print("  {s} = load i64, ptr {s}\n", .{ boxptr, box_alloca });
+                try self.print("  call void @kaappi_box_set(i64 {s}, i64 {s})\n", .{ boxptr, val });
+                return;
+            }
+        }
         if (self.locals) |loc| {
             if (loc.get(name)) |alloca_name| {
                 try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca_name });

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -50,8 +50,10 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
 
     if (rest_name != null) return null;
 
-    // #1422: reject if a param is both set! and captured by a nested lambda.
-    if (bodyHasConflictingSetCapture(body_list, param_names[0..arity], null)) return null;
+    // #1497: a param that is both set! and captured by a nested lambda is
+    // assignment-converted to a heap box rather than rejected.
+    const boxed = analyzeBoxedParams(body_list, param_names[0..arity], null);
+    if (boxed.rest_conflict) return null;
 
     var body_ir = ir.IR.init(self.allocator());
     defer body_ir.deinit();
@@ -64,7 +66,10 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         if (body_count >= 64) return null;
         const expr = types.car(body_expr);
-        const opt = ir.lowerAndOptimize(&body_ir, expr, null, types.cdr(body_expr) == types.NIL) catch return null;
+        // Boxed frames are lowered non-tail so box roots can be popped at a
+        // single ret (see emitLambdaFunction).
+        const is_tail = !boxed.any and types.cdr(body_expr) == types.NIL;
+        const opt = ir.lowerAndOptimize(&body_ir, expr, null, is_tail) catch return null;
         body_nodes[body_count] = opt;
         body_count += 1;
         body_expr = types.cdr(body_expr);
@@ -75,7 +80,7 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
     @memcpy(allowed[0..arity], param_names[0..arity]);
     if (hasFreeVars(self, body_nodes[0..body_count], allowed[0..arity])) return null;
 
-    const fn_name = emitLambdaFunction(self, data.name, param_names[0..arity], body_nodes[0..body_count], rest_name) orelse return null;
+    const fn_name = emitLambdaFunction(self, data.name, param_names[0..arity], body_nodes[0..body_count], rest_name, boxed) orelse return null;
 
     const closure_name = data.name orelse "(lambda)";
     const name_str = self.internString(closure_name) catch return null;
@@ -90,14 +95,17 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     if (body_list == types.NIL) return null;
     if (!types.isPair(formals_val) and formals_val != types.NIL) return null;
 
-    // A closure copies its captured variables by value into an upvalue array,
-    // so a set! (or internal define) that mutates a captured binding cannot be
-    // represented natively. Reject any body containing set!/define and let the
-    // interpreter handle it (#819).
+    // An internal define in a closure body needs a locals scope the closure
+    // tier does not set up, so reject it (#819). A set! is now allowed: a
+    // captured binding it mutates is assignment-converted to a box by the
+    // enclosing frame (#1497), and a set! of the closure's own param/local
+    // resolves to that slot. The per-free-variable guard below refuses any
+    // set! of a captured variable that was NOT boxed, so a by-value upvalue is
+    // never mutated in place.
     {
         var be = body_list;
         while (be != types.NIL and types.isPair(be)) : (be = types.cdr(be)) {
-            if (sexprContainsSetOrDefine(types.car(be))) return null;
+            if (sexprContainsDefine(types.car(be))) return null;
         }
     }
 
@@ -122,6 +130,10 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
         plist = types.cdr(plist);
     }
 
+    // The closure's own params may themselves be captured+mutated by a lambda
+    // nested inside this closure (double nesting), needing their own boxes.
+    const own_boxed = analyzeBoxedParams(body_list, param_names[0..arity], null);
+
     var body_ir = ir.IR.init(self.allocator());
     defer body_ir.deinit();
     // Parameters shadow primitives of the same name; don't fold calls to them
@@ -133,7 +145,10 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         if (body_count >= 64) return null;
         const expr = types.car(body_expr);
-        const opt = ir.lowerAndOptimize(&body_ir, expr, null, types.cdr(body_expr) == types.NIL) catch return null;
+        // A closure with own boxed params lowers non-tail so its box roots pop
+        // at a single ret (see the closure body emission below).
+        const is_tail = !own_boxed.any and types.cdr(body_expr) == types.NIL;
+        const opt = ir.lowerAndOptimize(&body_ir, expr, null, is_tail) catch return null;
         body_nodes[body_count] = opt;
         body_count += 1;
         body_expr = types.cdr(body_expr);
@@ -147,14 +162,27 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
 
     const outer_params = self.params orelse return null;
     const outer_upvalues = self.upvalues;
-    for (free_vars[0..free_count]) |fv| {
-        // Captures are copied out of the enclosing frame at closure-creation
-        // time: params from its %args, and — when this lambda sits inside
-        // another native closure — chained captures from that closure's own
-        // %upvalues array (#1410). A name bound by an enclosing let-local or
-        // rest parameter (which outrank params in emitGlobalRef's resolution
-        // order) has no capturable slot, and any other name is unknown here;
-        // reject those and let the eval fallback handle the lambda.
+    const outer_boxes = self.boxes;
+    // Classify each capture: a variable the enclosing frame boxed is captured
+    // as the box POINTER (fv_boxed), so a set! from any sibling closure over
+    // the same binding is visible here; everything else is captured by value.
+    var fv_boxed: [16]bool = @splat(false);
+    for (free_vars[0..free_count], 0..) |fv, i| {
+        if (outer_boxes) |ob| {
+            if (ob.contains(fv)) {
+                fv_boxed[i] = true;
+                continue;
+            }
+        }
+        // A set! of a captured variable that was NOT boxed would mutate the
+        // by-value upvalue copy alone, diverging from the interpreter's
+        // by-location semantics (#1422). Refuse; the interpreter handles it.
+        if (sexprBodySetsName(body_list, fv)) return null;
+        // By-value captures are copied out of the enclosing frame at
+        // closure-creation time: params from its %args, and — when this lambda
+        // sits inside another native closure — chained captures from that
+        // closure's own %upvalues array (#1410). A name bound by an enclosing
+        // let-local or rest parameter has no capturable slot; reject those.
         if (localsOrRestShadows(self, fv)) return null;
         if (outer_params.contains(fv)) continue;
         if (outer_upvalues) |uv| {
@@ -202,15 +230,45 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
         self.params = p;
         self.upvalues = uv_map;
 
+        // Boxed captures and own boxed params get a fresh box map for this
+        // frame; reads/writes go through kaappi_box_ref / kaappi_box_set.
+        self.boxes = if (own_boxed.any or freeVarsAnyBoxed(fv_boxed[0..free_count]))
+            std.StringHashMap([]const u8).init(self.backing_alloc)
+        else
+            null;
+        defer if (self.boxes) |*b| b.deinit();
+        self.frame_box_roots = 0;
+
         const header = std.fmt.allocPrint(self.allocator(), "; closure: {s}\ndefine i64 {s}(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) {{\nentry:\n", .{ closure_name, fn_name }) catch return null;
         defer self.allocator().free(header);
         self.write(header) catch return null;
+
+        // A boxed captured variable's box pointer lives in its upvalue slot;
+        // mirror it into a local alloca so name resolution reads/writes it
+        // through the box. No GC root needed — the box stays reachable via the
+        // live closure's upvalue array for the whole call.
+        for (free_vars[0..free_count], 0..) |fv, i| {
+            if (!fv_boxed[i]) continue;
+            const box_alloca = self.freshTemp() catch return null;
+            self.print("  {s} = alloca i64, align 8\n", .{box_alloca}) catch return null;
+            const gep = self.freshTemp() catch return null;
+            self.print("  {s} = getelementptr i64, ptr %upvalues, i64 {d}\n", .{ gep, i }) catch return null;
+            const boxptr = self.freshTemp() catch return null;
+            self.print("  {s} = load i64, ptr {s}\n", .{ boxptr, gep }) catch return null;
+            self.print("  store i64 {s}, ptr {s}\n", .{ boxptr, box_alloca }) catch return null;
+            (self.boxes orelse return null).put(fv, box_alloca) catch return null;
+        }
+
+        if (own_boxed.any and !emitBoxedParamSlots(self, param_names[0..arity], own_boxed)) return null;
 
         var last_val: []const u8 = "";
         for (body_nodes[0..body_count]) |node| {
             last_val = self.emitNode(node) catch return null;
         }
 
+        if (self.frame_box_roots > 0) {
+            self.print("  call void @kaappi_gc_pop_roots(i64 {d})\n", .{self.frame_box_roots}) catch return null;
+        }
         self.print("  ret i64 {s}\n}}\n", .{last_val}) catch return null;
 
         fn_buf = self.buf;
@@ -223,6 +281,15 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     self.print("  {s} = alloca [{d} x i64], align 8\n", .{ uv_alloca, free_count }) catch return null;
     for (free_vars[0..free_count], 0..) |fv, i| {
         const val = blk: {
+            // A boxed capture is stored as its box POINTER, loaded from the
+            // enclosing frame's box slot; the box's contents (the live value)
+            // are shared, so a set! from any closure over it is visible (#1497).
+            if (fv_boxed[i]) {
+                const box_alloca = outer_boxes.?.get(fv).?;
+                const v = self.freshTemp() catch return null;
+                self.print("  {s} = load i64, ptr {s}\n", .{ v, box_alloca }) catch return null;
+                break :blk v;
+            }
             if (outer_params.get(fv)) |idx| {
                 const gep_src = self.freshTemp() catch return null;
                 self.print("  {s} = getelementptr i64, ptr %args, i64 {d}\n", .{ gep_src, idx }) catch return null;
@@ -256,6 +323,29 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
 // them. Leaving any of them out surfaces as "undefined variable" (or a
 // silently wrong value when a same-named global exists) at run time (#1410).
 pub fn bindParamsAsGlobals(self: *LLVMEmitter) EmitError!void {
+    // A boxed captured variable cannot be republished as a global: a global
+    // holds a by-value snapshot, and re-reading a boxed param/upvalue here
+    // would capture the value *before* a later set!, reintroducing the exact
+    // #1422 divergence (seen when a captured+mutated variable is captured by a
+    // lambda that itself falls back to eval — e.g. a variadic inner lambda).
+    // Signal failure so the whole enclosing native frame aborts and the
+    // interpreter, which honors by-location semantics, handles it (#1497).
+    if (self.boxes) |bx| {
+        if (bx.count() > 0) {
+            if (self.params) |p| {
+                var it = p.keyIterator();
+                while (it.next()) |k| {
+                    if (bx.contains(k.*)) return error.UnsupportedNodeType;
+                }
+            }
+            if (self.upvalues) |uv| {
+                var it = uv.keyIterator();
+                while (it.next()) |k| {
+                    if (bx.contains(k.*)) return error.UnsupportedNodeType;
+                }
+            }
+        }
+    }
     if (self.params) |p| {
         var iter = p.iterator();
         while (iter.next()) |entry| {
@@ -363,8 +453,11 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
         param_list = types.cdr(param_list);
     }
 
-    // #1422: reject if a param is both set! and captured by a nested lambda.
-    if (bodyHasConflictingSetCapture(body, param_names[0..arity], rest_name)) return null;
+    // #1497: params that are both set! and captured by a nested lambda are
+    // assignment-converted to heap boxes. A captured+mutated rest parameter
+    // has no box model yet — fall back to the interpreter for it.
+    const boxed = analyzeBoxedParams(body, param_names[0..arity], rest_name);
+    if (boxed.rest_conflict) return null;
 
     var body_ir = ir.IR.init(self.allocator());
     defer body_ir.deinit();
@@ -387,7 +480,9 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         if (body_count >= 64) return null;
         const expr = types.car(body_expr);
-        const opt = ir.lowerAndOptimize(&body_ir, expr, null, types.cdr(body_expr) == types.NIL) catch return null;
+        // Boxed frames lower non-tail so box roots pop at a single ret.
+        const is_tail = !boxed.any and types.cdr(body_expr) == types.NIL;
+        const opt = ir.lowerAndOptimize(&body_ir, expr, null, is_tail) catch return null;
         body_nodes[body_count] = opt;
         body_count += 1;
         body_expr = types.cdr(body_expr);
@@ -403,10 +498,10 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
     allowed[arity + extra] = name;
     if (hasFreeVars(self, body_nodes[0..body_count], allowed[0 .. arity + extra + 1])) return null;
 
-    return emitLambdaFunction(self, name, param_names[0..arity], body_nodes[0..body_count], rest_name);
+    return emitLambdaFunction(self, name, param_names[0..arity], body_nodes[0..body_count], rest_name, boxed);
 }
 
-fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []const []const u8, body_nodes: []const *ir.Node, rest_name: ?[]const u8) ?[]const u8 {
+fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []const []const u8, body_nodes: []const *ir.Node, rest_name: ?[]const u8, boxed: BoxAnalysis) ?[]const u8 {
     const id = self.lambda_counter;
     self.lambda_counter += 1;
     const fn_name = std.fmt.allocPrint(self.allocator(), "@lambda_{d}", .{id}) catch return null;
@@ -414,6 +509,16 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     if (name) |n| {
         self.native_fns.put(n, .{ .llvm_name = fn_name, .arity = @intCast(param_names.len), .is_variadic = rest_name != null }) catch {};
     }
+
+    // The native_fns entry is registered up front so a self-recursive tail call
+    // in the body can resolve to it, but body emission can still fail (e.g. an
+    // eval fallback that captures a boxed variable, #1497). If it does, remove
+    // the stale entry — otherwise a call site would emit a direct call to a
+    // @lambda_N that was never defined.
+    var success = false;
+    defer if (!success) {
+        if (name) |n| _ = self.native_fns.fetchRemove(n);
+    };
 
     var fn_buf: std.ArrayList(u8) = .empty;
     {
@@ -427,6 +532,12 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         // time — so an upvalue map inherited from the enclosing emission
         // scope must not leak into body emission or bindParamsAsGlobals.
         self.upvalues = null;
+        // A fresh box map for this frame's own boxed params (assignment
+        // conversion, #1497). The enclosing frame's boxes are out of scope in
+        // a closed function.
+        self.boxes = if (boxed.any) std.StringHashMap([]const u8).init(self.backing_alloc) else null;
+        defer if (self.boxes) |*b| b.deinit();
+        self.frame_box_roots = 0;
 
         var p = std.StringHashMap(u8).init(self.backing_alloc);
         defer p.deinit();
@@ -437,8 +548,11 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
 
         const body_lbl = std.fmt.allocPrint(self.allocator(), "body_{d}", .{id}) catch return null;
 
-        self.current_fn_name = if (rest_name == null) name else null;
-        self.body_label = if (rest_name == null) body_lbl else null;
+        // A boxed frame disables the self-tail-call loop: each activation needs
+        // its own fresh boxes, and the body is lowered non-tail so there is a
+        // single ret at which to pop the box roots.
+        self.current_fn_name = if (rest_name == null and !boxed.any) name else null;
+        self.body_label = if (rest_name == null and !boxed.any) body_lbl else null;
         self.current_block = body_lbl;
         self.rest_param_name = rest_name;
         self.rest_param_alloca = null;
@@ -451,11 +565,16 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
             emitRestListBuilder(self, param_names.len) catch return null;
         }
 
+        if (boxed.any and !emitBoxedParamSlots(self, param_names, boxed)) return null;
+
         var last_val: []const u8 = "";
         for (body_nodes) |node| {
             last_val = self.emitNode(node) catch return null;
         }
 
+        if (self.frame_box_roots > 0) {
+            self.print("  call void @kaappi_gc_pop_roots(i64 {d})\n", .{self.frame_box_roots}) catch return null;
+        }
         self.print("  ret i64 {s}\n}}\n", .{last_val}) catch return null;
 
         fn_buf = self.buf;
@@ -464,6 +583,7 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     const fn_def = fn_buf.toOwnedSlice(self.backing_alloc) catch return null;
     self.lambda_defs.append(self.backing_alloc, fn_def) catch return null;
 
+    success = true;
     return fn_name;
 }
 
@@ -649,63 +769,133 @@ fn localsOrRestShadows(self: *LLVMEmitter, name: []const u8) bool {
     return false;
 }
 
-// True if the raw S-expression contains a set! or define form anywhere (not
-// descending into quoted data). Used to reject closure bodies that mutate or
-// rebind captured state, which the native upvalue-copy model cannot express.
-fn sexprContainsSetOrDefine(expr: types.Value) bool {
-    if (!types.isPair(expr)) return false;
-    const head = types.car(expr);
-    if (types.isSymbol(head)) {
-        const h = types.symbolName(head);
-        if (std.mem.eql(u8, h, "set!") or std.mem.eql(u8, h, "define")) return true;
-        if (std.mem.eql(u8, h, "quote")) return false;
-    }
-    var cur = expr;
-    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
-        if (sexprContainsSetOrDefine(types.car(cur))) return true;
+// True if any of the parallel fv_boxed flags is set — i.e. this closure
+// captures at least one boxed variable and therefore needs a box map.
+fn freeVarsAnyBoxed(fv_boxed: []const bool) bool {
+    for (fv_boxed) |b| {
+        if (b) return true;
     }
     return false;
 }
 
-// True if the function body has a parameter that is both targeted by set!
-// and captured by a nested lambda.  The native upvalue-copy model snapshots
-// at closure creation, so a later set! of the same param is invisible to
-// the closure — diverging from the VM's by-location semantics (#1422).
-fn bodyHasConflictingSetCapture(body_list: Value, param_names: []const []const u8, rest_name: ?[]const u8) bool {
-    const total = param_names.len + @as(usize, if (rest_name != null) 1 else 0);
-    if (total == 0) return false;
-    var set_flags: [17]bool = @splat(false);
+// True if the raw S-expression contains an internal define anywhere (not
+// descending into quoted data). Used to reject closure bodies with an internal
+// define, which needs a locals scope the closure tier does not set up. A set!
+// is allowed — captured bindings it mutates are boxed by the enclosing frame
+// (#1497).
+fn sexprContainsDefine(expr: types.Value) bool {
+    if (!types.isPair(expr)) return false;
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const h = types.symbolName(head);
+        if (std.mem.eql(u8, h, "define")) return true;
+        if (std.mem.eql(u8, h, "quote")) return false;
+    }
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        if (sexprContainsDefine(types.car(cur))) return true;
+    }
+    return false;
+}
 
+// Per-frame assignment-conversion analysis (#1497). A native function's own
+// binding needs boxing when it is BOTH mutated (a set! target somewhere in the
+// body, including inside nested lambdas) AND captured by a nested lambda. Such
+// a binding is materialized as a heap box so a later set! is visible through
+// every closure that captured it — restoring the VM's by-location semantics.
+// Bindings that are only mutated, or only captured, keep the by-value fast path.
+pub const BoxAnalysis = struct {
+    // Parallel to the param_names passed to analyzeBoxedParams; flags[i] true
+    // means fixed parameter i needs a box.
+    flags: [16]bool = @splat(false),
+    // A captured+mutated rest parameter cannot be boxed by the current model;
+    // callers must reject native compilation (fall back to the interpreter).
+    rest_conflict: bool = false,
+    any: bool = false,
+};
+
+fn analyzeBoxedParams(body_list: Value, param_names: []const []const u8, rest_name: ?[]const u8) BoxAnalysis {
+    var result = BoxAnalysis{};
+    if (param_names.len == 0 and rest_name == null) return result;
+
+    // Which params / rest are assigned anywhere in the body.
+    var set_flags: [17]bool = @splat(false);
     var expr = body_list;
     while (expr != types.NIL and types.isPair(expr)) : (expr = types.cdr(expr)) {
         sexprCollectSetTargets(types.car(expr), param_names, rest_name, &set_flags);
     }
 
-    var any = false;
-    for (set_flags[0..total]) |f| {
-        if (f) {
-            any = true;
-            break;
-        }
-    }
-    if (!any) return false;
-
-    var flagged: [17][]const u8 = undefined;
-    var flagged_count: usize = 0;
+    // A binding needs boxing only if it is also captured by a nested lambda.
     for (param_names, 0..) |p, i| {
-        if (set_flags[i]) {
-            flagged[flagged_count] = p;
-            flagged_count += 1;
+        if (i >= 16) break;
+        if (set_flags[i] and bodyHasCapturingLambda(body_list, &.{p})) {
+            result.flags[i] = true;
+            result.any = true;
         }
     }
     if (rest_name) |rn| {
-        if (set_flags[param_names.len]) {
-            flagged[flagged_count] = rn;
-            flagged_count += 1;
+        if (set_flags[param_names.len] and bodyHasCapturingLambda(body_list, &.{rn})) {
+            result.rest_conflict = true;
         }
     }
+    return result;
+}
 
-    return bodyHasCapturingLambda(body_list, flagged[0..flagged_count]);
+// True if the body ever assigns `name` with (set! name ...), not descending
+// into quoted data. Used by the closure tier to verify that a captured
+// variable it mutates was actually boxed by the enclosing frame, and by
+// emitLet to decide which captured let-locals to box (#1497).
+pub fn sexprBodySetsName(body_list: Value, name: []const u8) bool {
+    var expr = body_list;
+    while (expr != types.NIL and types.isPair(expr)) : (expr = types.cdr(expr)) {
+        if (sexprSetsName(types.car(expr), name)) return true;
+    }
+    return false;
+}
+
+fn sexprSetsName(expr: Value, name: []const u8) bool {
+    if (!types.isPair(expr)) return false;
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const h = types.symbolName(head);
+        if (std.mem.eql(u8, h, "quote")) return false;
+        if (std.mem.eql(u8, h, "set!")) {
+            const rest = types.cdr(expr);
+            if (types.isPair(rest) and types.isSymbol(types.car(rest)) and
+                std.mem.eql(u8, types.symbolName(types.car(rest)), name)) return true;
+        }
+    }
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        if (sexprSetsName(types.car(cur), name)) return true;
+    }
+    return false;
+}
+
+// Materialize box slots for the boxed fixed params of the current frame. Runs
+// at function entry (params live in %args): loads each incoming value, boxes
+// it, stores the box pointer in a fresh alloca, GC-roots the alloca, and
+// registers the name in self.boxes. Increments self.frame_box_roots so the
+// caller pops the roots before the frame's ret. Returns false on OOM.
+fn emitBoxedParamSlots(self: *LLVMEmitter, param_names: []const []const u8, analysis: BoxAnalysis) bool {
+    var pushed: usize = 0;
+    for (param_names, 0..) |pname, i| {
+        if (i >= 16 or !analysis.flags[i]) continue;
+        const box_alloca = self.freshTemp() catch return false;
+        self.print("  {s} = alloca i64, align 8\n", .{box_alloca}) catch return false;
+        const gep = self.freshTemp() catch return false;
+        self.print("  {s} = getelementptr i64, ptr %args, i64 {d}\n", .{ gep, i }) catch return false;
+        const v = self.freshTemp() catch return false;
+        self.print("  {s} = load i64, ptr {s}\n", .{ v, gep }) catch return false;
+        const box = self.freshTemp() catch return false;
+        self.print("  {s} = call i64 @kaappi_make_box(ptr %vm, i64 {s})\n", .{ box, v }) catch return false;
+        self.print("  store i64 {s}, ptr {s}\n", .{ box, box_alloca }) catch return false;
+        self.print("  call void @kaappi_gc_push_root(ptr {s})\n", .{box_alloca}) catch return false;
+        (self.boxes orelse return false).put(pname, box_alloca) catch return false;
+        pushed += 1;
+    }
+    self.frame_box_roots += pushed;
+    return true;
 }
 
 fn sexprCollectSetTargets(expr: Value, param_names: []const []const u8, rest_name: ?[]const u8, flags: *[17]bool) void {
@@ -789,16 +979,12 @@ fn nodeHasFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []c
             return hasFreeVars(self, node.data.unless_form.body, params);
         },
         .set_form => {
-            // A set! is safe to compile in a body with no upvalues only when
-            // both the target and the value stay within our params/globals.
-            // Otherwise it mutates (or reads) a captured lexical variable that
-            // the native slot-store cannot reach, so disqualify and let the
-            // interpreter handle it. The value is a raw S-expr; a compound
-            // value is treated conservatively as possibly capturing (#819).
-            if (!types.isSymbol(node.data.set_form.name)) return true;
-            if (!valueIsBoundOrLiteral(self, node.data.set_form.name, params)) return true;
-            if (!valueIsBoundOrLiteral(self, node.data.set_form.value, params)) return true;
-            return false;
+            // The target and value are raw S-exprs; walk them with binder
+            // scoping. A set! of a captured variable is a genuine free
+            // reference — the enclosing frame boxes such variables so the
+            // closure tier can capture the box pointer (#1497).
+            if (sexprHasFreeVars(self, node.data.set_form.name, params)) return true;
+            return sexprHasFreeVars(self, node.data.set_form.value, params);
         },
         // An internal define introduces a binding that the native lambda-body
         // emitter cannot install (it has no locals map), so it would leak to a
@@ -817,22 +1003,19 @@ fn nodeHasFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []c
     }
 }
 
-// A raw S-expr value that is trivially safe to reference inside a natively
-// compiled body with no upvalues: a literal, or a symbol that names one of our
-// params or a known global. Anything else (a compound expression, or a symbol
-// naming a captured lexical variable) is treated as unsafe.
-fn valueIsBoundOrLiteral(self: *LLVMEmitter, value: types.Value, params: []const []const u8) bool {
-    if (types.isSymbol(value)) {
-        const name = types.symbolName(value);
-        for (params) |p| {
-            if (std.mem.eql(u8, name, p)) return true;
-        }
-        // A name shadowed by an enclosing lexical binding is a capture,
-        // not the known global it would otherwise resolve to.
-        if (self.isNameShadowed(name)) return false;
-        return ir.isKnownGlobal(name);
-    }
-    return !types.isPair(value);
+// Walk a raw S-expression (a set! target or value) with binder scoping,
+// reporting whether it references any free variable. Delegates to the shared
+// FreeNameWalk so nested let/lambda binders are handled correctly (#1497).
+fn sexprHasFreeVars(self: *LLVMEmitter, expr: types.Value, params: []const []const u8) bool {
+    var w = FreeNameWalk{ .emitter = self, .params = params };
+    walkSexpr(&w, expr);
+    return w.found or w.inexact;
+}
+
+fn collectSexprFreeVars(self: *LLVMEmitter, expr: types.Value, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
+    var w = FreeNameWalk{ .emitter = self, .params = params, .buf = buf, .count = count };
+    walkSexpr(&w, expr);
+    return !w.inexact;
 }
 
 // Both collectors return false when the analysis could not stay exact (a
@@ -898,7 +1081,13 @@ fn collectNodeFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const
         .let_form => return collectLetSexprFreeVars(self, node.data.let_form.args, false, params, buf, count),
         .let_star => return collectLetSexprFreeVars(self, node.data.let_star.args, true, params, buf, count),
         .lambda => return collectLambdaSexprFreeVars(self, node.data.lambda.args, params, buf, count),
-        .constant, .define, .set_form, .passthrough, .sexpr_form => return true,
+        // A set! of a captured variable must be captured too, or a closure
+        // that only writes (never reads) the binding would miss it (#1497).
+        .set_form => {
+            if (!collectSexprFreeVars(self, node.data.set_form.name, params, buf, count)) return false;
+            return collectSexprFreeVars(self, node.data.set_form.value, params, buf, count);
+        },
+        .constant, .define, .passthrough, .sexpr_form => return true,
         .letrec, .letrec_star => return true,
     }
 }

--- a/src/native_decls.zig
+++ b/src/native_decls.zig
@@ -42,6 +42,11 @@ pub const decls: []const Decl = &.{
     .{ .export_name = "kaappi_cdr", .scheme_name = "cdr", .param_types = &.{.i64}, .ret = .i64, .inline_kind = .unary },
     .{ .export_name = "kaappi_cons", .scheme_name = "cons", .param_types = &.{ .i64, .i64 }, .ret = .i64, .inline_kind = .binary },
     .{ .export_name = "kaappi_is_null", .scheme_name = "null?", .param_types = &.{.i64}, .ret = .i64, .inline_kind = .unary },
+    // Boxed mutable captures (#1497). Emitted directly by the closure tiers,
+    // never resolved as Scheme globals, so scheme_name stays null.
+    .{ .export_name = "kaappi_make_box", .scheme_name = null, .param_types = &.{ .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
+    .{ .export_name = "kaappi_box_ref", .scheme_name = null, .param_types = &.{.i64}, .ret = .i64, .inline_kind = .not_inlined },
+    .{ .export_name = "kaappi_box_set", .scheme_name = null, .param_types = &.{ .i64, .i64 }, .ret = .void_ty, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_create_native_closure", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .ptr, .i64, .i64, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_eval", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_gc_push_root", .scheme_name = null, .param_types = &.{.ptr}, .ret = .void_ty, .inline_kind = .not_inlined },

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -253,6 +253,43 @@ pub export fn kaappi_is_null(v: u64) callconv(.c) u64 {
     return if (v == types.NIL) types.TRUE else types.FALSE;
 }
 
+// --- Boxed mutable variables (assignment conversion, #1497) ---
+//
+// The native backend represents a captured-and-mutated variable as a heap
+// "box": closures capture the box POINTER by value, and every read/write goes
+// through the box, so a mutation is visible to all closures that share the
+// binding — matching the interpreter's by-location closure semantics.
+//
+// A box is a one-slot cell represented as a pair (value . '()). Boxes never
+// escape to Scheme code (they are an internal codegen artifact), so reusing the
+// pair type keeps the GC's existing marking, write barrier, and sweeping
+// correct for free.
+
+pub export fn kaappi_make_box(vm: ?*vm_mod.VM, init: u64) callconv(.c) u64 {
+    const v = vm orelse {
+        _ = std.posix.system.write(2, "make-box: null vm\n", 18);
+        std.process.exit(1);
+    };
+    // allocPair roots `init` internally before it may collect, so a young
+    // initial value survives a GC triggered by this very allocation.
+    return v.gc.allocPair(init, types.NIL) catch {
+        _ = std.posix.system.write(2, "OOM: failed to allocate box\n", 28);
+        std.process.exit(1);
+    };
+}
+
+pub export fn kaappi_box_ref(box: u64) callconv(.c) u64 {
+    return types.car(box);
+}
+
+pub export fn kaappi_box_set(box: u64, val: u64) callconv(.c) void {
+    // Write barrier before the store: a box promoted to the old generation
+    // that starts pointing at a young value must be recorded, or the young
+    // value is swept out from under it on the next minor collection.
+    if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(box), val);
+    types.setCar(box, val);
+}
+
 pub export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]const u64, nargs: u64) callconv(.c) u64 {
     const v = vm orelse {
         _ = std.posix.system.write(2, "null vm\n", 8);

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -498,6 +498,96 @@ test "LLVM emit: abandoned native let pops the binding roots it pushed (#1410)" 
     try expectContains(ll, "call void @kaappi_gc_pop_roots(i64 1)");
 }
 
+// -- Assignment conversion / boxing of captured+mutated variables (#1497) --
+
+test "LLVM emit: captured+mutated param is boxed and compiles natively (#1497)" {
+    // n is captured by the inner lambda and mutated by set!; it must become a
+    // heap box (make_box at make-acc's entry, box_ref/box_set in the closure)
+    // rather than being rejected to the interpreter.
+    var res = try emitSourceResult("(define (make-acc n) (lambda (amt) (set! n (+ n amt)) n))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_make_box("));
+    try expectContains(ll, "call i64 @kaappi_box_ref(");
+    try expectContains(ll, "call void @kaappi_box_set(");
+    // The closure captures the box POINTER, and the set! never degrades to a
+    // global rebind (which would be the by-value divergence).
+    try expectContains(ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_");
+    try std.testing.expect(std.mem.indexOf(u8, ll, "call void @kaappi_set_global") == null);
+}
+
+test "LLVM emit: captured+mutated let-local is boxed (#1497)" {
+    var res = try emitSourceResult("(define (make-counter) (let ((n 0)) (lambda () (set! n (+ n 1)) n)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_make_box("));
+    try expectContains(ll, "call i64 @kaappi_box_ref(");
+    try expectContains(ll, "call void @kaappi_box_set(");
+    try expectContains(ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_");
+}
+
+test "LLVM emit: #1422 shape boxes the param mutated after capture (#1497)" {
+    // The inner lambda captures u; a sibling argument set!s u before the call.
+    // Boxing makes the mutation visible through the closure (result 95, not 6).
+    var res = try emitSourceResult("(define (f0 u) ((lambda (a) (+ u a)) (let ((b 5)) (set! u 90) b)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_make_box("));
+    try expectContains(ll, "call void @kaappi_box_set(");
+    try expectContains(ll, "call i64 @kaappi_box_ref(");
+    try expectContains(ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_");
+}
+
+test "LLVM emit: two closures share one boxed binding (#1497)" {
+    // A single box is created; both the writer and the reader capture the same
+    // box pointer, so a mutation through one is visible to the other.
+    var res = try emitSourceResult("(define (mk) (let ((n 0)) (cons (lambda () (set! n (+ n 1)) n) (lambda () n))))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_make_box("));
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_"));
+}
+
+test "LLVM emit: a write-only closure still captures its boxed binding (#1497)" {
+    // The writer never reads v, only set!s it — it must still capture v (as a
+    // box) so the reader sees the write.
+    var res = try emitSourceResult("(define (mk v) (cons (lambda (x) (set! v x)) (lambda () v)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, ll, "call i64 @kaappi_make_box("));
+    try expectContains(ll, "call void @kaappi_box_set(");
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_"));
+}
+
+test "LLVM emit: a boxed frame roots the box and pops it before ret (#1497)" {
+    var res = try emitSourceResult("(define (make-acc n) (lambda (amt) (set! n (+ n amt)) n))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // The box slot is rooted at entry and popped at the single (non-tail) ret.
+    try expectContains(ll, "call void @kaappi_gc_push_root(");
+    try expectContains(ll, "call void @kaappi_gc_pop_roots(");
+}
+
+test "LLVM emit: a mutated but uncaptured param is NOT boxed (#1497)" {
+    // x is set! but no nested lambda captures it, so it keeps the fast path
+    // (a plain param slot) — no box.
+    var res = try emitSourceResult("(define (f x) (set! x (+ x 1)) x)");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expect(std.mem.indexOf(u8, ll, "call i64 @kaappi_make_box(") == null);
+    try std.testing.expect(std.mem.indexOf(u8, ll, "call i64 @kaappi_box_ref(") == null);
+}
+
+test "LLVM emit: a captured but unmutated param is NOT boxed (#1497)" {
+    // n is captured but never mutated, so the existing by-value upvalue copy
+    // is still correct — no box.
+    var res = try emitSourceResult("(define (make-adder n) (lambda (x) (+ n x)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try std.testing.expect(std.mem.indexOf(u8, ll, "call i64 @kaappi_make_box(") == null);
+    try expectContains(ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_");
+}
+
 // -- Begin --
 
 test "LLVM emit: begin sequence" {
@@ -537,7 +627,7 @@ test "native declare table covers all runtime exports in preamble" {
             return error.TestExpectedEqual;
         }
     }
-    try std.testing.expectEqual(@as(usize, 21), native_decls.decls.len);
+    try std.testing.expectEqual(@as(usize, 24), native_decls.decls.len);
 }
 
 // -- NativeClosure dispatch tests (#1376) --

--- a/tests/e2e/programs/native-mutable-capture.scm
+++ b/tests/e2e/programs/native-mutable-capture.scm
@@ -1,0 +1,35 @@
+; Assignment conversion / boxing of captured+mutated variables (#1497).
+; Each shape below compiles natively (the captured, mutated binding becomes a
+; heap box) and must match the interpreter's by-location closure semantics.
+
+; --- Counter via let: captured+mutated let-local ---
+(define (make-counter)
+  (let ((n 0))
+    (lambda () (set! n (+ n 1)) n)))
+(define c (make-counter))
+(display (c)) (display (c)) (display (c)) (newline)   ; 123
+
+; --- Accumulator: captured+mutated parameter ---
+(define (make-acc n)
+  (lambda (amt) (set! n (+ n amt)) n))
+(define a (make-acc 100))
+(display (a 10)) (display " ") (display (a 10)) (display " ") (display (a 5)) (newline)  ; 110 120 125
+
+; --- Two closures share one binding; a mutation through one is seen by both ---
+(define (make-pair)
+  (let ((n 0))
+    (cons (lambda () (set! n (+ n 1)) n)
+          (lambda () n))))              ; reader captures the same box
+(define p (make-pair))
+(display ((car p))) (display " ")       ; 1
+(display ((car p))) (display " ")       ; 2
+(display ((cdr p))) (newline)           ; 2  (reader sees the shared mutation)
+
+; --- Write-only closure + reader over the same binding ---
+(define (make-cell init)
+  (cons (lambda (v) (set! init v))      ; writer never reads init
+        (lambda () init)))
+(define b (make-cell 7))
+(display ((cdr b))) (display " ")       ; 7
+((car b) 42)
+(display ((cdr b))) (newline)           ; 42

--- a/tests/e2e/programs/native-set-captured.scm
+++ b/tests/e2e/programs/native-set-captured.scm
@@ -1,0 +1,25 @@
+; #1422 regression: a captured binding mutated AFTER the closure is created
+; must be visible through the closure (by-location semantics), not snapshotted
+; by value at closure-creation time.
+
+; The inner lambda captures u; the sibling argument set!s u before the call.
+(define (f0 u) ((lambda (a) (+ u a)) (let ((b 5)) (set! u 90) b)))
+(display (f0 1)) (newline)              ; 95  (reads u=90 through the box, + 5)
+
+; Retained-closure variant: set! the captured binding, then call the closure.
+(define (make u)
+  (let ((get (lambda () u)))
+    (set! u 90)
+    (get)))
+(display (make 1)) (newline)            ; 90
+
+; Double nesting: the box pointer threads through two closure layers.
+(define (outer u)
+  (lambda (v)
+    (set! u (+ u v))
+    (lambda () u)))
+(define step (outer 1))
+(define r1 (step 10))                    ; u := 11
+(display (r1)) (display " ")             ; 11
+(define r2 (step 100))                   ; u := 111 (same box)
+(display (r2)) (newline)                 ; 111

--- a/tests/scheme/compile/native-set-capture-divergence-1422.sh
+++ b/tests/scheme/compile/native-set-capture-divergence-1422.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
-# Regression test for #1422: the native closure tiers copy captured variables
-# by value, so a set! of the captured binding after closure creation is
-# invisible to the closure — diverging from the VM's by-location semantics.
+# Regression test for #1422 / #1497: the native closure tiers copy captured
+# variables by value, so a set! of the captured binding after closure creation
+# would be invisible to the closure — diverging from the VM's by-location
+# semantics.
 #
-# The fix rejects native compilation of a function whose body contains both
-# a set! of a parameter and a nested lambda that captures that parameter,
-# falling back to the interpreter.
+# The fix (#1497) applies assignment conversion: a variable that is both
+# captured by a nested lambda and mutated is boxed (a heap cell), closures
+# capture the box pointer, and reads/writes go through the box. Such functions
+# now compile NATIVELY and match the interpreter. The only remaining fallback
+# case is when the capturing lambda itself cannot be a native closure (e.g. a
+# variadic inner lambda) — a boxed variable cannot be republished as a global,
+# so the whole function falls back to the interpreter.
 #
 # Usage: bash tests/scheme/compile/native-set-capture-divergence-1422.sh [path-to-kaappi]
 
@@ -68,23 +73,24 @@ check() {
 }
 
 # 1. Issue reproducer (define-position): set! of param u in a sibling
-#    argument, lambda captures u.  Must fall back to interpreter.
+#    argument, lambda captures u.  u is boxed; compiles natively, matches VM.
 check set-capture-inline \
 '(define (f0 u) ((lambda (a) (+ u a)) (let ((b 5)) (set! u 90) b)))
 (write (f0 1))
 (newline)' \
-'95' no
+'95' yes
 
-# 2. Variadic inner lambda (falls to eval fallback, same divergence via
-#    bindParamsAsGlobals snapshot).  Must fall back.
+# 2. Variadic inner lambda captures the boxed u but cannot itself be a native
+#    closure; a boxed variable cannot be republished as a global, so the whole
+#    function falls back to the interpreter (still matches).
 check set-capture-variadic \
 '(define (f0 u) ((lambda (a . rest) (+ u a)) (let ((b 5)) (set! u 90) b) 7))
 (write (f0 1))
 (newline)' \
 '95' no
 
-# 3. Retained closure: set! runs between closure creation and call.
-#    Must fall back.
+# 3. Retained closure: set! runs between closure creation and call.  x is
+#    boxed, so the closure reads the mutated value — compiles natively.
 check set-capture-retained \
 '(define (f x)
   (let ((g (lambda () x)))
@@ -92,14 +98,14 @@ check set-capture-retained \
     (g)))
 (write (f 1))
 (newline)' \
-'42' no
+'42' yes
 
-# 4. Inline lambda (tier 2): same divergence through
-#    tryCompilePureLambdaAsNativeClosure.  Must fall back.
+# 4. Inline lambda (tier 2): boxed param u through
+#    tryCompilePureLambdaAsNativeClosure.  Compiles natively.
 check set-capture-inline-lambda \
 '(write ((lambda (u) ((lambda (a) (+ u a)) (let ((b 5)) (set! u 90) b))) 1))
 (newline)' \
-'95' no
+'95' yes
 
 # 5. Shadowed param: the lambda (x) shadows f's x, so it does NOT capture
 #    f's x.  The function should still compile natively.
@@ -116,6 +122,30 @@ check set-different-param \
 (write (f 1 99))
 (newline)' \
 '99' yes
+
+# 7. Mutual visibility (#1497 acceptance): two closures over one boxed binding;
+#    a set! through one is visible to the other. Compiles natively.
+check set-capture-shared \
+'(define (make-counter)
+  (let ((n 0))
+    (cons (lambda () (set! n (+ n 1)) n)
+          (lambda () n))))
+(define c (make-counter))
+(display ((car c)))
+(display ((car c)))
+(display ((cdr c)))
+(newline)' \
+'122' yes
+
+# 8. Accumulator over a boxed parameter, shared across calls. Native.
+check set-capture-accumulator \
+'(define (make-acc n) (lambda (amt) (set! n (+ n amt)) n))
+(define a (make-acc 100))
+(display (a 10))
+(display " ")
+(display (a 5))
+(newline)' \
+'110 115' yes
 
 if [[ "$fail" -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
Part of #1491. Closes #1497. Resolves the #1422 divergence.

## Problem

The LLVM native closure tiers copied captured variables **by value** into the
`%upvalues` array at closure-creation time. Two consequences:

1. Any closure body containing `set!` (or an internal `define`) of a captured
   variable was **rejected** and fell back to `kaappi_eval` — a whole class of
   counter/accumulator closures never compiled natively.
2. Even where accepted, a by-value snapshot **diverged** from the VM's
   by-location semantics: a later `set!` of a captured binding was invisible to
   a native closure that captured it (#1422).

## Change

Classic **assignment conversion / boxing**. A binding that is both **captured**
by a nested lambda and **mutated** (`set!`) becomes a heap **box**; closures
capture the box *pointer* by value, and reads/writes go through
`kaappi_box_ref` / `kaappi_box_set`. Because the pointer is immutable but the
contents are shared, a `set!` through any closure over the binding is visible to
all of them — matching the interpreter exactly. Only captured-**and**-mutated
bindings are boxed; everything else keeps the by-value fast path.

A box is a pair `(value . '())`, so the GC needs **no new heap type** (marking,
write barrier, and sweeping work unchanged). Backed by three C-ABI exports
(`kaappi_make_box` / `kaappi_box_ref` / `kaappi_box_set`).

### Where it lands
- `llvm_emit_lambda.zig` — `analyzeBoxedParams` (captured ∩ mutated); param box
  materialization; closure tier captures the box pointer; the blanket
  `set!`/`define` rejection is narrowed to `define`-only.
- `llvm_emit.zig` — a `boxes` map consulted first in name resolution; `emitLet`
  boxes captured+mutated let-locals (the idiomatic `(let ((n 0)) (lambda () (set! n …) n))`).
- `runtime_exports.zig` / `native_decls.zig` — the box primitives.

### Two latent bugs fixed along the way
1. `bindParamsAsGlobals` (the eval-fallback republish path) would republish a
   boxed param **by value** — reintroducing the exact #1422 snapshot when a
   boxed var is captured by a lambda that can't be a native closure (e.g. a
   **variadic** inner lambda). It now aborts native compilation so the whole
   function falls back correctly.
2. `emitLambdaFunction` registered `native_fns[name]` before body emission (for
   self-tail resolution) but didn't roll it back on failure — a call site could
   emit a direct call to a `@lambda_N` that was never defined.

Boxed frames disable the self-tail-call loop and lower non-tail so box roots pop
at a single `ret`.

## Acceptance criteria
- [x] Counter/accumulator closures (`set!` of a captured var, mutually visible
  across closures over the same binding) compile natively and match the
  interpreter.
- [x] `bodyHasConflictingSetCapture` removed; the set!-in-closure rejection
  narrowed to internal `define` only.
- [x] #1422 divergence resolved; `tests/e2e` + closure/hygiene Scheme suites green.

## Testing
- Unit suite green under normal **and** `-Dgc-stress=true`, incl. new boxing
  tests in `tests_native.zig`.
- e2e **26/26** (+ `native-mutable-capture.scm`, `native-set-captured.scm`,
  which build real native binaries and diff against the interpreter).
- Scheme suite **1845/0**; `native-set-capture-divergence-1422.sh` updated —
  the divergence cases now compile natively and match, plus new mutual-visibility
  and accumulator cases.
- Box rooting verified under `KAAPPI_GC_THRESHOLD=1` (GC on every allocation).

Still falls back **correctly** (via eval) for genuinely-unsupported shapes:
internal-define-in-function-body counters, and captured+mutated rest parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)