### PR TITLE
Run the #809 300-capture stress test again

### DIFF
--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -781,12 +781,12 @@ test "closure capturing more than 255 variables compiles and runs (#809)" {
     // upvalue_count field, panicking (compile-time) past 255 captures. The
     // field is now u16, matching the u16 upvalue index in the bytecode.
     //
-    // The u16-width property is orthogonal to GC rooting, and compiling the
-    // 300-capture program with a collection per allocation peaks around 7 GB
-    // RSS under the testing allocator — the full-suite stress run gets
-    // OOM-killed. Skip on stress builds; the 27-variable sibling test below
-    // keeps the capture path exercised there.
-    if (@import("build_options").gc_stress) return error.SkipZigTest;
+    // This was once skipped under -Dgc-stress=true: compiling the 300-capture
+    // program with a collection per allocation peaked ~7 GB RSS and OOM-killed
+    // the stress suite. The cause was markValue reallocating its mark worklist
+    // on every call, amplified by the testing allocator's metadata retention;
+    // #1436 made the worklist persistent and the peak dropped to a few tens of
+    // MB, so the test runs under stress again (#1451).
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);


### PR DESCRIPTION
## What

Removes the `-Dgc-stress=true` skip guard on `test "closure capturing more than 255 variables compiles and runs (#809)"` in `src/tests_advanced.zig`, so the 300-capture boundary is exercised under gc-stress again.

## Why

The test guards the `u8`→`u16` widening of `Function.upvalue_count` (`addUpvalue` used to `@intCast` the count into a `u8`, panicking past 255 captures). It was skipped on stress builds because compiling the 300-capture program once peaked ~7 GB RSS and OOM-killed the stress suite.

That blow-up was **not inherent to the test**. Tracing the history:

| Time (2026-07-11) | Event |
|---|---|
| 12:08 | `0abf3c34` (#1427) adds the skip, citing 7 GB RSS |
| 12:45 | Issue #1451 filed |
| 13:32 | `1f7f3e7c` (#1436) fixes the actual cause |

Per #1436, `markValue` reallocated a fresh 8 KB mark worklist on every call; the testing allocator's metadata retention amplified that churn into the multi-GB peak. Making the worklist persistent removed it. The skip was never lifted because #1436 targeted a different, deliberately-huge test.

Rather than the issue's fallback of lowering the capture count, `n = 300` is kept — the RSS problem is gone, so there's no reason to shrink the boundary margin.

## Verification (macOS ARM, gc-stress confirmed active)

- This test alone under `-Dgc-stress=true`: **~32 MB** peak RSS, passes (was claimed 7 GB).
- Full `tests_advanced.zig` (51 tests) under `-Dgc-stress=true`: **~539 MB** peak (from other, heavier tests), all pass.
- Full non-stress `zig build test`: green.

The nightly `fuzz.yml` gc-stress job runs the entire unit suite on `ubuntu-latest` (x86-64) and already passes for every other, far more allocation-heavy test — so the #1436 fix is proven on the CI stress platform. This change simply lets that job also cover the >255-upvalue boundary.

Fixes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)