### PR TITLE
Batch fd reads in readOneByte (#1460)

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -137,6 +137,13 @@ fn currentErrorPortValue(vm: *vm_mod.VM) Value {
 /// buffer memory at roughly this plus the largest single write.
 const write_high_water: usize = 8192;
 
+/// Bytes a single fd read(2) fills into the port's read_buf. Byte-at-a-time
+/// consumers (read-char, read-u8, read-bytevector, read-string, read-line)
+/// then serve subsequent bytes from memory, paying one syscall per burst
+/// rather than one per byte (#1460). read(2) short-returns whatever is
+/// already available, so filling never blocks past the first available byte.
+const read_chunk_size: usize = 4096;
+
 /// Ports whose writes accumulate in `write_buf`: real-fd ports other than
 /// stdin/stdout/stderr. fd 0/1/2 keep the historical unbuffered
 /// direct-write behavior (REPL echo and diagnostic ordering depend on it);
@@ -618,10 +625,13 @@ fn closePort(args: []const Value) PrimitiveError!Value {
 /// peek_extra, read_buf, string data — before touching the fd, so buffered
 /// data costs zero syscalls. The fd path flushes this port's own pending
 /// writes first (a socket port's request must reach the peer before we
-/// wait on its response); on EAGAIN the calling fiber suspends on read
-/// readiness. Errors only with Yielded (parked; caller stashes partial
-/// progress via propagateReadErr), OutOfMemory, or ExceptionRaised (port
-/// closed mid-wait); `null` still means EOF.
+/// wait on its response), then reads a chunk (up to `read_chunk_size`) and
+/// buffers all but the first byte back into read_buf, so a run of
+/// byte-at-a-time reads costs one syscall per burst instead of one per byte
+/// (#1460); on EAGAIN the calling fiber suspends on read readiness. Errors
+/// only with Yielded (parked; caller stashes partial progress via
+/// propagateReadErr), OutOfMemory, or ExceptionRaised (port closed
+/// mid-wait); `null` still means EOF.
 pub fn readOneByte(port: *types.Port) PrimitiveError!?u8 {
     // Check peek buffer first
     if (port.peek_byte) |b| {
@@ -662,9 +672,9 @@ pub fn readOneByte(port: *types.Port) PrimitiveError!?u8 {
     }
     if (port.write_buf_len > port.write_buf_start) try drainWriteBuffer(port);
     maybeSetNonblocking(port);
-    var buf: [1]u8 = undefined;
+    var chunk: [read_chunk_size]u8 = undefined;
     while (true) {
-        const raw = std.posix.system.read(port.fd, &buf, buf.len);
+        const raw = std.posix.system.read(port.fd, &chunk, chunk.len);
         if (raw < 0) {
             const e = std.posix.errno(raw);
             if (e == .INTR) continue;
@@ -675,7 +685,24 @@ pub fn readOneByte(port: *types.Port) PrimitiveError!?u8 {
             return null;
         }
         if (raw == 0) return null;
-        return buf[0];
+        const n: usize = @intCast(raw);
+        // One read(2) per burst, not per byte (#1460): return the first byte
+        // and park the rest in read_buf for the consumption drain above to
+        // hand out on the next calls. read_buf is empty on this path — its
+        // drain only falls through once exhausted (and freed to null then) —
+        // so the fresh slice is entirely live (read_buf_len == len, so the
+        // "last read_buf_len bytes" cursor starts at 0). A caller that later
+        // parks does so on a subsequent call after this buffer drains, where
+        // stashPartialRead prepends onto an empty read_buf.
+        if (n > 1) {
+            std.debug.assert(port.read_buf == null);
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+            const rest = gc.allocator.alloc(u8, n - 1) catch return PrimitiveError.OutOfMemory;
+            @memcpy(rest, chunk[1..n]);
+            port.read_buf = rest;
+            port.read_buf_len = n - 1;
+        }
+        return chunk[0];
     }
 }
 
@@ -964,7 +991,7 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
         drainWriteBuffer(port) catch |err| return propagateReadErr(port, err, &.{buf.items});
     }
     maybeSetNonblocking(port);
-    var tmp: [4096]u8 = undefined;
+    var tmp: [read_chunk_size]u8 = undefined;
     while (true) {
         // Try to parse a datum from what we already have.
         if (buf.items.len > 0) {

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -429,3 +429,157 @@ test "#1478: fd->port rejects the standard streams and non-fixnums" {
     try std.testing.expectError(error.TypeError, vm.eval("(fd->port 1)"));
     try std.testing.expectError(error.TypeError, vm.eval("(fd->port \"nope\")"));
 }
+
+// #1460: readOneByte reads a chunk into read_buf and serves subsequent bytes
+// from memory, so byte-at-a-time consumers (read-u8, read-char,
+// read-bytevector, read-string, read-line) pay one read(2) per burst rather
+// than one per byte.
+
+test "readOneByte batches an available burst into read_buf, not one syscall per byte" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    const rport = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    defer _ = std.posix.system.close(pipe[1]);
+
+    // Stage a burst, then read a single byte. Batching pulls the whole burst
+    // in one read(2) and parks the tail in read_buf; without it every byte
+    // would cost its own read(2) and read_buf would stay empty -- this is the
+    // one assertion that fails on the pre-#1460 single-byte reader.
+    const burst = "ABCDEFGHIJ";
+    try std.testing.expectEqual(@as(isize, burst.len), std.posix.system.write(pipe[1], burst, burst.len));
+    const first = try vm.eval("(read-u8 rp)");
+    try std.testing.expectEqual(types.makeFixnum('A'), first);
+    try std.testing.expectEqual(@as(usize, burst.len - 1), rport.read_buf_len);
+
+    // The buffered tail is then served in order from memory.
+    const rest = try vm.eval("(read-string 9 rp)");
+    const s = types.toObject(rest).as(types.SchemeString);
+    try std.testing.expectEqualStrings("BCDEFGHIJ", s.data[0..s.len]);
+}
+
+test "read-bytevector over a large file preserves byte order across batched chunk boundaries" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    defer _ = std.posix.system.unlink("/tmp/kaappi-readbv-large.bin");
+    // 10000 bytes spans the 4096-byte read chunk twice. A deterministic,
+    // position-dependent pattern makes any dropped, duplicated, or reordered
+    // byte across a chunk boundary fail the equal? against the in-memory
+    // original (which never touched the fd).
+    const r = try vm.eval(
+        \\(let ((n 10000) (path "/tmp/kaappi-readbv-large.bin"))
+        \\  (define original (make-bytevector n 0))
+        \\  (let loop ((i 0))
+        \\    (when (< i n)
+        \\      (bytevector-u8-set! original i (modulo (* i 31) 256))
+        \\      (loop (+ i 1))))
+        \\  (let ((out (open-binary-output-file path)))
+        \\    (write-bytevector original out)
+        \\    (close-port out))
+        \\  (let ((in (open-binary-input-file path)))
+        \\    (let ((got (read-bytevector n in)))
+        \\      (close-port in)
+        \\      (and (= (bytevector-length got) n) (equal? got original)))))
+    );
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "read-bytevector composes read_buf left by a prior (read) with fresh fd reads" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    defer _ = std.posix.system.unlink("/tmp/kaappi-readbv-afterread.txt");
+    // (read) slurps a chunk, parses (a b c), and stashes that chunk's tail in
+    // read_buf; the 6000 trailing 'z' bytes overflow one chunk, so
+    // read-bytevector must drain the stash and then batch more from the fd,
+    // with byte 122 ('z') throughout.
+    const r = try vm.eval(
+        \\(let ((path "/tmp/kaappi-readbv-afterread.txt"))
+        \\  (let ((out (open-output-file path)))
+        \\    (write-string "(a b c)" out)
+        \\    (write-string (make-string 6000 #\z) out)
+        \\    (close-port out))
+        \\  (let ((in (open-input-file path)))
+        \\    (let ((datum (read in)))
+        \\      (let ((bv (read-bytevector 6000 in)))
+        \\        (close-port in)
+        \\        (and (equal? datum '(a b c))
+        \\             (= (bytevector-length bv) 6000)
+        \\             (let chk ((i 0))
+        \\               (if (= i 6000) #t
+        \\                   (and (= (bytevector-u8-ref bv i) 122) (chk (+ i 1))))))))))
+    );
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "read-bytevector after peek-char includes the peeked byte in order" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    defer _ = std.posix.system.unlink("/tmp/kaappi-readbv-afterpeek.txt");
+    // peek-char pulls a batched chunk: byte 0 goes back into peek_byte, the
+    // rest stays in read_buf. read-bytevector must then deliver the peeked
+    // byte first, the read_buf tail next, and the fd last -- all in order.
+    const r = try vm.eval(
+        \\(let ((path "/tmp/kaappi-readbv-afterpeek.txt"))
+        \\  (let ((out (open-output-file path)))
+        \\    (write-string "hello world" out)
+        \\    (close-port out))
+        \\  (let ((in (open-input-file path)))
+        \\    (let ((pc (peek-char in)))
+        \\      (let ((bv (read-bytevector 11 in)))
+        \\        (close-port in)
+        \\        (and (char=? pc #\h)
+        \\             (equal? bv (string->utf8 "hello world")))))))
+    );
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "a parked mid-read-bytevector retry over a pipe loses no bytes" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers) (srfi 18))");
+    // 10000 bytes, position-dependent. The writer sends it in two 5000-byte
+    // bursts with a sleep between: the reader consumes burst one (crossing a
+    // chunk boundary), finds the pipe dry, stashes its 5000-byte partial
+    // progress and parks. Its retry must re-serve that stash and then batch
+    // burst two -- any loss or reordering across the park fails equal?.
+    _ = try vm.eval(
+        \\(begin
+        \\  (define n 10000)
+        \\  (define half 5000)
+        \\  (define original (make-bytevector n 0))
+        \\  (let loop ((i 0))
+        \\    (when (< i n)
+        \\      (bytevector-u8-set! original i (modulo i 256))
+        \\      (loop (+ i 1)))))
+    );
+    _ = try vm.eval("(define reader (spawn (lambda () (read-bytevector n rp))))");
+    _ = try vm.eval(
+        \\(define writer (spawn (lambda ()
+        \\  (write-bytevector original wp 0 half) (flush-output-port wp)
+        \\  (thread-sleep! 0.05)
+        \\  (write-bytevector original wp half n) (flush-output-port wp)
+        \\  (close-port wp))))
+    );
+    _ = try vm.eval("(fiber-join writer)");
+    const r = try vm.eval("(equal? (fiber-join reader) original)");
+    try std.testing.expectEqual(types.TRUE, r);
+}


### PR DESCRIPTION
Closes #1460.

`readOneByte` in `src/primitives_io.zig` issued one `read(2)` syscall per byte on fd-backed ports, so every byte-at-a-time consumer — `read-bytevector`, `read-bytevector!`, `read-string`, `read-char`, `read-line`, `read-u8` — paid *k* syscalls to read *k* bytes from a file or socket. (Flagged by CodeRabbit on #1459 as a pre-existing perf gap; the dependency #1459 has since merged.)

## Change

The fd path now reads up to `read_chunk_size` (4096) bytes in a single `read(2)`, returns the first byte, and stashes the remainder into the port's existing `read_buf`. The consumption drain at the top of `readOneByte` hands those out on subsequent calls, so a run of byte reads costs **one syscall per burst instead of one per byte**.

### Constraints preserved (per the issue)

- **fd-loop semantics** unchanged: EINTR retry, EAGAIN → fiber `waitPortFd` (park/drive), EOF → `null`, WASI unaffected — same error structure, just a larger buffer.
- **Pending-write drain** before fd reads stays.
- **`read_buf` consumption model**: the fresh slice is allocated exactly `n-1` bytes so `rb.len == read_buf_len` and the "last `read_buf_len` bytes" cursor starts at 0.
- **Park/stash composition**: `read_buf` is always empty at the fd path (every park point sits past the peek/read_buf/string drains), so a caller that parks later prepends onto an empty `read_buf` via `stashPartialRead` — asserted in code.
- **No loop-to-fill**: a single `read(2)` short-returns whatever's available, so a 1-byte interactive read never blocks; an `n == 1` read allocates nothing (byte-identical to the old path).
- **`char-ready?` / `u8-ready?`** untouched (still always `#t`).
- **`readDatumFn`** already batched its own incremental-parse loop; it now shares the `read_chunk_size` constant and is otherwise unchanged (no #847 regression).

No GC-safety concern: `read_buf` uses `gc.allocator.alloc` (raw memory, not a GC object), which never triggers a collection — same pattern `readDatumFn`/`stashPartialRead` already use.

## Tests (`src/tests_port_io.zig`, 5 added)

1. **Batch-detection** — a single `read-u8` on a staged 10-byte burst leaves 9 bytes in `read_buf`. Verified **red** on the pre-#1460 single-byte reader (`expected 9, found 0`), green with the fix.
2. `read-bytevector` over a 10 KB file preserves byte order across the batched chunk boundaries.
3. `read-bytevector` composes `read_buf` left by a prior `(read)` with fresh fd reads.
4. `read-bytevector` after `peek-char` delivers the peeked byte first, in order.
5. A parked mid-`read-bytevector` retry over a pipe loses no bytes across the stash boundary.

## Verification

- `zig build test` ✓
- `zig build test -Dgc-stress=true` (port I/O tests) ✓
- `bash tests/scheme/run-all.sh` → **1847 pass, 0 fail** (R7RS 1395/0)
- `zig fmt --check` clean; manual sanity + piped-stdin reads ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)