### PR TITLE
Add `kaappi explain <code>` diagnostic documentation command

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -29,6 +29,7 @@ investigation produced analysis worth keeping.
 | [gc-safety-and-error-handling.md](gc-safety-and-error-handling.md) | Rooting, write barriers, and error propagation patterns contributors must follow |
 | [diagnostics.md](diagnostics.md) | Diagnostic `KP` codes: the registry, the taxonomy, the stability policy, how to add a code |
 | [diagnostics-json.md](diagnostics-json.md) | `--diagnostics=json`: the LSP `Diagnostic` JSON Lines schema shared by the CLI and the language server |
+| [explain.md](explain.md) | `kaappi explain <code>`: the binary's own offline diagnostic reference (prose + example + fix), and the generator for the kaappi-lang.org page |
 | [claude-code-harness.md](claude-code-harness.md) | Hooks, permissions, path-scoped rules, and skills for AI-assisted development |
 
 ## Design decisions

--- a/docs/dev/diagnostics.md
+++ b/docs/dev/diagnostics.md
@@ -15,30 +15,36 @@ and `tests/scheme/errors/error-format.sh`
 This is the keystone of the "machine legibility" campaign
 ([kaappi#1503](https://github.com/kaappi/kaappi/issues/1503)); the design record
 is [KEP-0005](https://github.com/kaappi/keps/blob/main/keps/0005-diagnostic-contract.md).
-Later phases (`--diagnostics=json`, `kaappi explain`, `error-object-code`) all
-read from this one registry.
+Everything else in the campaign (`--diagnostics=json`, `kaappi explain`,
+`error-object-code`) reads from this one registry.
 
-For the structured JSON form of these same diagnostics (the LSP `Diagnostic`
-shape emitted by `--diagnostics=json`), see
-[diagnostics-json.md](diagnostics-json.md).
+Related surfaces built on the registry:
+
+- [diagnostics-json.md](diagnostics-json.md) — the structured JSON form of these
+  diagnostics (the LSP `Diagnostic` shape emitted by `--diagnostics=json`).
+- [explain.md](explain.md) — `kaappi explain <code>`, the binary's own offline
+  diagnostic reference (prose + example + fix for every code).
 
 ---
 
 ## The registry
 
 `src/diagnostics.zig` is the single source of truth. One comptime `table` binds
-together, per diagnostic, the three things that used to live apart:
+together, per diagnostic, the things that used to live apart:
 
 - **the code** — a `Code` enum value whose *integer is the KP number*, so
   `undefined_variable = 3001` renders as `"KP3001"`;
 - **the message template** — the human message (currently a complete sentence;
   it gains `{…}` placeholders as raise sites pass structured arguments);
-- **the explanation** — prose for `kaappi explain <code>` (surfaced in a later
-  phase; populated now so the registry is complete).
+- **the explanation** — prose surfaced by [`kaappi explain <code>`](explain.md),
+  which weaves in how to fix the diagnostic;
+- **the example** — a minimal snippet that triggers the code, also shown by
+  `kaappi explain`.
 
 A `comptime` block enforces registry integrity *at build time*: every `Code` has
 exactly one entry, no two entries collide, and every entry has a non-empty name,
-template, and explanation. A malformed registry fails `zig build`.
+template, explanation, and example. A malformed registry fails `zig build`; the
+runtime mirror of the same check lives in `src/tests_diagnostics.zig`.
 
 ## The taxonomy
 
@@ -130,8 +136,8 @@ in their stage range.
 ## Adding a new code
 
 1. Add a `Code` enum value in the right stage range with the next free ordinal,
-   and a matching `table` entry (name, template, explanation). The comptime gate
-   fails the build if you forget the entry or collide a number.
+   and a matching `table` entry (name, template, explanation, example). The
+   comptime gate fails the build if you forget the entry or collide a number.
 2. Route the raise site to it:
    - reader/compiler: add the `error.Xxx => .your_code` arm to
      `readErrorCode` / `compileErrorCode`;
@@ -140,5 +146,7 @@ in their stage range.
      `gc.allocErrorObjectCoded(msg, irritants, .your_code)`.
 3. Add assertions to `tests/scheme/errors/error-format.sh` (the code appears; no
    Zig name leaks) and, if useful, a unit test in `src/tests_diagnostics.zig`.
-4. Keep the explanation genuinely explanatory — it is what `kaappi explain` will
-   show.
+4. Keep the explanation genuinely explanatory and give a real triggering
+   `example` — they are what [`kaappi explain`](explain.md) shows, and
+   `tests/scheme/errors/explain.sh` runs every example to confirm it still
+   triggers its own code.

--- a/docs/dev/explain.md
+++ b/docs/dev/explain.md
@@ -1,0 +1,96 @@
+# `kaappi explain <code>` — the binary as its own diagnostic reference
+
+Every diagnostic Kaappi prints carries a stable `KP` code
+([diagnostics.md](diagnostics.md)). `kaappi explain` turns those codes into
+documentation that ships *inside the binary* — offline, version-matched, and
+identical for a human reading prose and an agent parsing JSON. The model is
+Rust's `rustc --explain E0308`.
+
+```
+kaappi explain KP3001
+```
+
+```
+KP3001  undefined-variable
+runtime · error
+
+undefined variable
+
+A variable was referenced that has no binding in scope. Check for a typo
+(Kaappi suggests the nearest defined name), a missing 'import', or a
+'define' that has not run yet because it appears after the reference.
+
+Example:
+    (display undefined-name)
+```
+
+The output has the three things an agent (or a human in a hurry) needs to go
+from a failing program to a fix: **prose** for what the diagnostic means, a
+minimal **example** that triggers it, and — woven into the prose — how to
+**fix** it.
+
+## Forms
+
+| Invocation | Output |
+|------------|--------|
+| `kaappi explain KP3001` | The entry for one code, as text. |
+| `kaappi explain undefined-variable` | Same — the code argument accepts the kebab **name**, a bare number (`3001`), or the rendered code in any case (`kp3001`). |
+| `kaappi explain --json KP3001` | The entry as one JSON object. |
+| `kaappi explain --all` | Every registered code, as text (the full reference). |
+| `kaappi explain --all --json` | Every code as a single JSON **array** — the source a docs generator consumes. |
+
+Output goes to **stdout**; it is requested content, not a diagnostic. An unknown
+code, a missing argument, or `--all` combined with a code is a usage error
+(exit `2`) reported on stderr with stdout left empty.
+
+## The JSON object
+
+`--json` emits the registry entry with the same stable-code / mutable-prose
+split as the [`--diagnostics=json`](diagnostics-json.md) contract: match on
+`code`/`name`/`stage`, treat `message`/`explanation`/`example` as prose that may
+be reworded release to release.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `code` | string | The stable `KP` code, e.g. `"KP3001"`. |
+| `name` | string | The stable kebab-case name, e.g. `"undefined-variable"`. |
+| `stage` | string | Pipeline stage from the leading digit: `read`, `compile`, `runtime`, `static-analysis`, `internal`. |
+| `severity` | string | `"error"` or `"warning"`. |
+| `message` | string | The one-line message template. |
+| `explanation` | string | Prose explanation (carries the fix). May contain newlines. |
+| `example` | string | A minimal triggering snippet. May contain newlines. |
+
+```json
+{"code":"KP3004","name":"division-by-zero","stage":"runtime","severity":"error","message":"division by zero","explanation":"An exact division, 'modulo', 'remainder', or 'quotient' had a zero\ndivisor. ...","example":"(/ 1 0)"}
+```
+
+The JSON string escaper is shared with `--diagnostics=json`
+(`lsp_diagnostic.writeJsonString`), so both machine surfaces escape identically.
+
+## The website page is generated, never hand-written
+
+`kaappi explain --all --json` is the single source a docs generator reads to
+build the diagnostics reference on kaappi-lang.org. Because the page is
+generated from the same registry the binary emits from, it **cannot drift** from
+what Kaappi actually prints — a stale reference page is a build artifact to
+regenerate, not prose to keep in sync by hand.
+
+## Examples are tested, not just present
+
+Each registry `example` is a real, minimal trigger (a handful — deeply nested
+input, internal invariants — are necessarily representative and say so in the
+snippet). `tests/scheme/errors/explain.sh` runs every runnable example back
+through the interpreter under `--diagnostics=json` and asserts it emits the code
+it is documented under. So an example that stops triggering its own code — or a
+code whose message moves — fails CI, not a user.
+
+## Where it lives
+
+| Piece | File |
+|-------|------|
+| Command parsing, text/JSON rendering | `src/explain.zig` |
+| Registry (codes, names, prose, examples) | `src/diagnostics.zig` |
+| Early dispatch (before VM/GC setup) | `src/main.zig` (`explain.maybeRun`) |
+| Shared JSON string escaper | `src/lsp_diagnostic.zig` |
+| Shell completions (`explain` subcommand) | `src/completions.zig` |
+| Tests | `src/explain.zig` (unit), `tests/scheme/errors/explain.sh` (end-to-end) |

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -250,9 +250,11 @@ pub fn printUsage() void {
             "\n" ++
             "Usage: kaappi [options] [file] [script-args...]\n" ++
             "       kaappi compile <file.scm> [-o output]\n" ++
+            "       kaappi explain <code>\n" ++
             "\n" ++
             "Commands:\n" ++
             "  compile <file>     Compile to native binary via LLVM\n" ++
+            "  explain <code>     Explain a diagnostic code (e.g. KP3001); --json, --all\n" ++
             "\n" ++
             "Options:\n" ++
             "  -h, --help         Show this help message\n" ++

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -19,20 +19,26 @@ const kaappi_bash =
     \\            return ;;
     \\    esac
     \\
+    \\    local has_compile=false has_explain=false
+    \\    for word in "${COMP_WORDS[@]}"; do
+    \\        [[ "$word" == "compile" ]] && has_compile=true
+    \\        [[ "$word" == "explain" ]] && has_explain=true
+    \\    done
+    \\
+    \\    if $has_explain; then
+    \\        COMPREPLY=($(compgen -W "--json --all" -- "$cur"))
+    \\        return
+    \\    fi
+    \\
     \\    if [[ "$cur" == -* ]]; then
     \\        COMPREPLY=($(compgen -W "-h --help --version --lib-path --compile --emit-llvm -o --disassemble --diagnostics=text --diagnostics=json --sandbox --gc-stats --profile --profile-json --coverage --coverage-xml --timeout --max-memory --completions" -- "$cur"))
     \\        return
     \\    fi
     \\
-    \\    local has_compile=false
-    \\    for word in "${COMP_WORDS[@]}"; do
-    \\        [[ "$word" == "compile" ]] && has_compile=true
-    \\    done
-    \\
     \\    if $has_compile; then
     \\        COMPREPLY=($(compgen -f -X '!*.scm' -- "$cur") $(compgen -W "-o" -- "$cur"))
     \\    else
-    \\        COMPREPLY=($(compgen -W "compile" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
+    \\        COMPREPLY=($(compgen -W "compile explain" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
     \\    fi
     \\}
     \\complete -o filenames -F _kaappi kaappi
@@ -67,7 +73,7 @@ const kaappi_zsh =
     \\
     \\    _arguments -s \
     \\        $flags \
-    \\        '1:command or file:_alternative "commands:command:(compile)" "files:file:_files -g \"*.scm\""' \
+    \\        '1:command or file:_alternative "commands:command:(compile explain)" "files:file:_files -g \"*.scm\""' \
     \\        '*:script args:_files'
     \\}
     \\
@@ -95,6 +101,7 @@ const kaappi_fish =
     \\complete -c kaappi -l max-memory -r -x -d 'Maximum heap memory in bytes'
     \\complete -c kaappi -l completions -r -x -a 'bash zsh fish' -d 'Output shell completion script'
     \\complete -c kaappi -a compile -d 'Compile to native binary via LLVM'
+    \\complete -c kaappi -a explain -d 'Explain a diagnostic code (KP####)'
     \\
 ;
 

--- a/src/diagnostics.zig
+++ b/src/diagnostics.zig
@@ -31,6 +31,35 @@ pub const Severity = enum {
     err,
     /// Advisory; does not by itself stop the program. Reserved for KP4xxx lint.
     warning,
+
+    /// Lower-case label used by `kaappi explain` and its JSON form.
+    pub fn label(self: Severity) []const u8 {
+        return switch (self) {
+            .err => "error",
+            .warning => "warning",
+        };
+    }
+};
+
+/// The pipeline stage a code belongs to, recovered from its leading digit. The
+/// taxonomy is documented in docs/dev/diagnostics.md; `kaappi explain` surfaces
+/// the label so an agent can see which stage failed without re-deriving it.
+pub const Stage = enum {
+    read,
+    compile,
+    runtime,
+    static_analysis,
+    internal,
+
+    pub fn label(self: Stage) []const u8 {
+        return switch (self) {
+            .read => "read",
+            .compile => "compile",
+            .runtime => "runtime",
+            .static_analysis => "static-analysis",
+            .internal => "internal",
+        };
+    }
 };
 
 /// A stable diagnostic code. The integer value IS the KP number, so
@@ -85,6 +114,47 @@ pub const Code = enum(u16) {
         return lookup(self);
     }
 
+    /// The pipeline stage this code came from, from its leading digit.
+    pub fn stage(self: Code) Stage {
+        return switch (@intFromEnum(self) / 1000) {
+            1 => .read,
+            2 => .compile,
+            3 => .runtime,
+            4 => .static_analysis,
+            else => .internal, // 9xxx
+        };
+    }
+
+    /// Resolve a user-supplied identifier to a registered code, for
+    /// `kaappi explain <code>`. Accepts the rendered code case-insensitively
+    /// with or without the "KP" prefix ("KP3001", "kp3001", "3001") as well as
+    /// the stable kebab-case name ("undefined-variable"). Returns null when
+    /// nothing matches so the caller can report an unknown-code usage error.
+    pub fn fromString(s: []const u8) ?Code {
+        if (s.len == 0) return null;
+
+        // Numeric form, with an optional "KP"/"kp" prefix.
+        var digits = s;
+        if (digits.len >= 2 and (digits[0] == 'K' or digits[0] == 'k') and
+            (digits[1] == 'P' or digits[1] == 'p'))
+        {
+            digits = digits[2..];
+        }
+        if (digits.len > 0 and isAllDigits(digits)) {
+            const n = std.fmt.parseInt(u16, digits, 10) catch return null;
+            inline for (std.enums.values(Code)) |c| {
+                if (@intFromEnum(c) == n) return c;
+            }
+            return null;
+        }
+
+        // Name form: match the kebab-case name case-insensitively.
+        for (table) |d| {
+            if (std.ascii.eqlIgnoreCase(d.name, s)) return d.code;
+        }
+        return null;
+    }
+
     /// The human-readable message template. In Phase 1 (kaappi#1504) most
     /// templates are complete sentences with no placeholders; a richer message
     /// supplied at the raise site (the VM/compiler "detail" buffers) overrides
@@ -104,6 +174,11 @@ pub const Diagnostic = struct {
     /// Prose explanation surfaced by `kaappi explain <code>` (kaappi#1507).
     /// Must be non-empty for every entry — enforced at compile time below.
     explanation: []const u8,
+    /// A minimal snippet that triggers this diagnostic, shown by
+    /// `kaappi explain <code>`. Where a genuine trigger cannot be an inline
+    /// one-liner (deeply nested input, an internal invariant) the snippet is
+    /// representative and says so. Must be non-empty — enforced at compile time.
+    example: []const u8,
     severity: Severity = .err,
 };
 
@@ -122,6 +197,7 @@ pub const table = [_]Diagnostic{
         \\most often an unclosed '(' or an unterminated string or block comment.
         \\Check that every '(' has a matching ')' and every '"' is closed.
         ,
+        .example = "(+ 1 2",
     },
     .{
         .code = .unexpected_char,
@@ -132,6 +208,7 @@ pub const table = [_]Diagnostic{
         \\at this position. A common cause is a malformed '#'-syntax such as an
         \\unknown '#\name' character literal or a stray '#'.
         ,
+        .example = "#z",
     },
     .{
         .code = .unexpected_right_paren,
@@ -141,6 +218,7 @@ pub const table = [_]Diagnostic{
         \\A ')' appeared with no matching '(' still open. Usually there is one
         \\closing parenthesis too many, or an earlier '(' was already closed.
         ,
+        .example = "(cons 1 2))",
     },
     .{
         .code = .invalid_number,
@@ -151,6 +229,7 @@ pub const table = [_]Diagnostic{
         \\example a malformed radix prefix (#x, #o, #b, #e, #i), a bad exponent,
         \\or a rational with a zero denominator.
         ,
+        .example = "1/0",
     },
     .{
         .code = .invalid_character_name,
@@ -161,6 +240,7 @@ pub const table = [_]Diagnostic{
         \\Valid forms are a single character (#\a), a named character
         \\(#\newline, #\space, #\tab, ...), or a hex escape (#\x41).
         ,
+        .example = "#\\foo",
     },
     .{
         .code = .unterminated_string,
@@ -170,6 +250,7 @@ pub const table = [_]Diagnostic{
         \\A string opened with '"' was never closed before end of input. Add the
         \\closing '"', or escape any literal '"' inside the string as '\"'.
         ,
+        .example = "(display \"abc",
     },
     .{
         .code = .invalid_escape,
@@ -180,6 +261,7 @@ pub const table = [_]Diagnostic{
         \\escape. R7RS allows \a \b \t \n \r \" \\ \x<hex>; and a line-continuation
         \\'\' followed by whitespace and a newline.
         ,
+        .example = "(display \"\\q\")",
     },
     .{
         .code = .dot_outside_list,
@@ -189,6 +271,7 @@ pub const table = [_]Diagnostic{
         \\A '.' (dotted-pair marker) appeared where it is not allowed. It is legal
         \\only before the final element inside a list, as in (a . b) or (a b . c).
         ,
+        .example = "(. 5)",
     },
     .{
         .code = .nesting_too_deep,
@@ -199,6 +282,9 @@ pub const table = [_]Diagnostic{
         \\means unbalanced parentheses producing runaway nesting rather than a
         \\genuinely deep literal.
         ,
+        // Representative: a real trigger needs more open parens than the
+        // reader's depth limit, too many to print inline.
+        .example = "((((( ...nested past the reader's depth limit... )))))",
     },
     .{
         .code = .token_too_long,
@@ -208,6 +294,9 @@ pub const table = [_]Diagnostic{
         \\A single token (identifier, number, or string) exceeded the reader's
         \\maximum token length. Split the input or shorten the token.
         ,
+        // Representative: a real trigger is one token longer than the reader's
+        // limit, too long to print inline.
+        .example = "aaaaaaaa...  ; a single token longer than the reader's limit",
     },
 
     // -- KP2xxx — Expand / compile ------------------------------------------
@@ -220,6 +309,7 @@ pub const table = [_]Diagnostic{
         \\test, a 'define' with no body, or a 'lambda' whose parameter list is not
         \\a proper list of identifiers. Check the form against its expected shape.
         ,
+        .example = "(if)",
     },
     .{
         .code = .syntax_error,
@@ -230,6 +320,7 @@ pub const table = [_]Diagnostic{
         \\because no 'syntax-rules' pattern matched the form. The accompanying
         \\message describes what the macro expected.
         ,
+        .example = "(syntax-error \"must be a pair\" 1)",
     },
     .{
         .code = .macro_expansion_limit,
@@ -239,6 +330,10 @@ pub const table = [_]Diagnostic{
         \\Macro expansion did not terminate within the implementation's step
         \\limit, which almost always indicates a macro that expands into itself
         \\without a base case.
+        ,
+        .example =
+        \\(define-syntax loop (syntax-rules () ((_ x) (loop x))))
+        \\(loop 1)
         ,
     },
 
@@ -253,6 +348,7 @@ pub const table = [_]Diagnostic{
         \\'with-exception-handler' to handle it. The message shown is the payload
         \\of the raised object.
         ,
+        .example = "(raise 'boom)",
     },
     .{
         .code = .undefined_variable,
@@ -263,6 +359,7 @@ pub const table = [_]Diagnostic{
         \\(Kaappi suggests the nearest defined name), a missing 'import', or a
         \\'define' that has not run yet because it appears after the reference.
         ,
+        .example = "(display undefined-name)",
     },
     .{
         .code = .type_error,
@@ -273,6 +370,7 @@ pub const table = [_]Diagnostic{
         \\'car' on a non-pair or '+' on a non-number. The message names the
         \\procedure, the type it expected, and the value it got.
         ,
+        .example = "(car 5)",
     },
     .{
         .code = .arity_mismatch,
@@ -283,6 +381,7 @@ pub const table = [_]Diagnostic{
         \\cannot accept. The message shows how many arguments were expected versus
         \\how many were supplied.
         ,
+        .example = "(cons 1)",
     },
     .{
         .code = .division_by_zero,
@@ -293,6 +392,7 @@ pub const table = [_]Diagnostic{
         \\divisor. Guard the divisor, or use inexact arithmetic where the result
         \\is a floating-point infinity or NaN instead of an error.
         ,
+        .example = "(/ 1 0)",
     },
     .{
         .code = .not_a_procedure,
@@ -303,6 +403,7 @@ pub const table = [_]Diagnostic{
         \\procedure, as in (5 6). Check for an extra pair of parentheses or a name
         \\that is bound to a value rather than a procedure.
         ,
+        .example = "(5 6)",
     },
     .{
         .code = .index_out_of_bounds,
@@ -313,6 +414,7 @@ pub const table = [_]Diagnostic{
         \\list-ref, bytevector-u8-ref, ...) was negative or not less than the
         \\length of the sequence.
         ,
+        .example = "(vector-ref (vector 1 2) 5)",
     },
     .{
         .code = .invalid_argument,
@@ -322,6 +424,10 @@ pub const table = [_]Diagnostic{
         \\An argument was of an acceptable type but outside the range or shape the
         \\procedure allows — for example a start index greater than an end index,
         \\or a value a procedure explicitly rejects.
+        ,
+        .example =
+        \\(import (srfi 13))
+        \\(string-join '() "," 'strict-infix)
         ,
     },
     .{
@@ -333,6 +439,10 @@ pub const table = [_]Diagnostic{
         \\non-tail recursion. Rewrite the recursion to be in tail position, or use
         \\an explicit accumulator or loop.
         ,
+        .example =
+        \\(define (sum n) (+ n (sum (+ n 1))))
+        \\(sum 0)
+        ,
     },
     .{
         .code = .execution_timeout,
@@ -342,6 +452,8 @@ pub const table = [_]Diagnostic{
         \\Execution exceeded a configured time budget and was interrupted. This is
         \\a sandbox / watchdog limit, not a fault in the program's logic per se.
         ,
+        // Surfaces only under a time budget: kaappi --timeout 500 prog.scm
+        .example = "(let loop () (loop))   ; run with --timeout 500",
     },
 
     // -- KP9xxx — Internal / resource exhaustion ----------------------------
@@ -354,6 +466,9 @@ pub const table = [_]Diagnostic{
         \\code is itself a gap worth reporting: the underlying condition should get
         \\its own registry entry.
         ,
+        // No dedicated trigger — this is the fallback for a condition that has
+        // not yet been given its own code.
+        .example = "(no specific trigger — a catch-all for uncoded conditions)",
     },
     .{
         .code = .internal_error,
@@ -364,6 +479,9 @@ pub const table = [_]Diagnostic{
         \\stream or an internal limit. This indicates a bug in Kaappi itself;
         \\please report it with the program that triggered it.
         ,
+        // No user-reachable trigger by design — correct input never produces
+        // this; it signals a bug in Kaappi.
+        .example = "(no trigger from correct input — signals a bug in Kaappi)",
     },
     .{
         .code = .out_of_memory,
@@ -373,6 +491,7 @@ pub const table = [_]Diagnostic{
         \\Memory allocation failed. The program (or a single datum, program text,
         \\or data structure within it) is too large for the available heap.
         ,
+        .example = "(make-bytevector 100000000000000)",
     },
 };
 
@@ -383,6 +502,13 @@ pub fn lookup(code: Code) Diagnostic {
         if (d.code == code) return d;
     }
     unreachable;
+}
+
+fn isAllDigits(s: []const u8) bool {
+    for (s) |c| {
+        if (!std.ascii.isDigit(c)) return false;
+    }
+    return true;
 }
 
 // -- Internal bridge: Zig error set -> curated code -------------------------
@@ -472,5 +598,6 @@ comptime {
         if (d.name.len == 0) @compileError("diagnostics registry: entry '" ++ @tagName(d.code) ++ "' has an empty name");
         if (d.template.len == 0) @compileError("diagnostics registry: entry '" ++ @tagName(d.code) ++ "' has an empty template");
         if (d.explanation.len == 0) @compileError("diagnostics registry: entry '" ++ @tagName(d.code) ++ "' has an empty explanation");
+        if (d.example.len == 0) @compileError("diagnostics registry: entry '" ++ @tagName(d.code) ++ "' has an empty example");
     }
 }

--- a/src/explain.zig
+++ b/src/explain.zig
@@ -1,0 +1,275 @@
+//! `kaappi explain <code>` — embedded documentation for every diagnostic code
+//! (kaappi#1507, part of the machine-legibility epic kaappi#1503).
+//!
+//! Modelled on `rustc --explain`: the binary is its own diagnostic reference —
+//! offline, version-matched, and identical for a human reading prose and an
+//! agent parsing JSON. Everything printed here comes from the single registry
+//! in `diagnostics.zig`, so `kaappi explain`, the `--diagnostics=json` stream,
+//! and the generated website page can never disagree about what a code means.
+//!
+//! Forms:
+//!   kaappi explain KP3001            prose + example + fix for one code
+//!   kaappi explain undefined-variable   (the kebab name works too)
+//!   kaappi explain --json KP3001     one JSON object for structured use
+//!   kaappi explain --all             the full reference, every code
+//!   kaappi explain --all --json      the full reference as a JSON array
+//!                                    (the source a docs generator consumes)
+
+const std = @import("std");
+const diagnostics = @import("diagnostics.zig");
+const lsp_diagnostic = @import("lsp_diagnostic.zig");
+const reporting = @import("reporting.zig");
+
+const writeStdout = reporting.writeStdout;
+const writeStderr = reporting.writeStderr;
+const Diagnostic = diagnostics.Diagnostic;
+
+pub const USAGE_ERROR_EXIT: u8 = 2;
+
+/// A parsed `kaappi explain …` invocation.
+pub const Request = struct {
+    /// The `<code>` argument (KP number or kebab name); null when `--all`.
+    query: ?[]const u8 = null,
+    json: bool = false,
+    all: bool = false,
+};
+
+/// If `args` is a `kaappi explain …` invocation, handle it fully and return the
+/// process exit code; otherwise return null so normal CLI dispatch proceeds.
+/// `explain` is a pure query over the static registry — it needs no VM, GC, or
+/// library setup, so main dispatches it before any of that is created.
+pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
+    var it = args.iterate();
+    _ = it.skip(); // argv[0]
+    const first = it.next() orelse return null;
+    if (!std.mem.eql(u8, first, "explain")) return null;
+
+    var req: Request = .{};
+    while (it.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--json")) {
+            req.json = true;
+        } else if (std.mem.eql(u8, arg, "--all")) {
+            req.all = true;
+        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            printUsage();
+            return 0;
+        } else if (arg.len > 1 and arg[0] == '-') {
+            writeStderr("kaappi explain: unknown option '");
+            writeStderr(arg);
+            writeStderr("'\nUsage: kaappi explain [--json] [--all] <code>\n");
+            return USAGE_ERROR_EXIT;
+        } else if (req.query == null) {
+            req.query = arg;
+        } else {
+            writeStderr("kaappi explain: unexpected extra argument '");
+            writeStderr(arg);
+            writeStderr("'\nUsage: kaappi explain [--json] [--all] <code>\n");
+            return USAGE_ERROR_EXIT;
+        }
+    }
+    return run(allocator, req);
+}
+
+/// Execute a parsed request; returns the process exit code.
+pub fn run(allocator: std.mem.Allocator, req: Request) u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
+
+    if (req.all) {
+        // `<code>` alongside `--all` is meaningless; flag it rather than
+        // silently ignore, so an agent's mistaken invocation is visible.
+        if (req.query) |q| {
+            writeStderr("kaappi explain: give a code or --all, not both (got '");
+            writeStderr(q);
+            writeStderr("')\n");
+            return USAGE_ERROR_EXIT;
+        }
+        (if (req.json) renderAllJson(w) else renderAllText(w)) catch return reportOom();
+        writeStdout(aw.written());
+        return 0;
+    }
+
+    const query = req.query orelse {
+        writeStderr("kaappi explain: missing <code> argument (e.g. 'kaappi explain KP3001')\n");
+        return USAGE_ERROR_EXIT;
+    };
+
+    const code = diagnostics.Code.fromString(query) orelse {
+        writeStderr("kaappi explain: unknown diagnostic code '");
+        writeStderr(query);
+        writeStderr("'\nRun 'kaappi explain --all' to list every code.\n");
+        return USAGE_ERROR_EXIT;
+    };
+
+    (if (req.json) renderJson(w, code.info()) else renderText(w, code.info())) catch return reportOom();
+    writeStdout(aw.written());
+    return 0;
+}
+
+fn reportOom() u8 {
+    writeStderr("kaappi explain: out of memory\n");
+    return 1;
+}
+
+// ── Rendering ──────────────────────────────────────────────────────────
+
+/// Human-readable form: header, one-line summary, prose (which carries the
+/// fix), then the triggering example.
+fn renderText(w: *std.Io.Writer, d: Diagnostic) std.Io.Writer.Error!void {
+    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+    try w.print("{s}  {s}\n", .{ d.code.render(&cbuf), d.name });
+    try w.print("{s} · {s}\n\n", .{ d.code.stage().label(), d.severity.label() });
+
+    try w.print("{s}\n\n", .{d.template});
+
+    try w.writeAll(d.explanation);
+    try w.writeByte('\n'); // registry prose has no trailing newline
+
+    try w.writeAll("\nExample:\n");
+    try writeIndented(w, d.example);
+}
+
+/// Structured form: one JSON object. `code`/`name`/`stage` are the stable
+/// machine handles; `message`/`explanation`/`example` are the human prose and
+/// are free to be reworded, exactly like the `--diagnostics=json` contract.
+fn renderJson(w: *std.Io.Writer, d: Diagnostic) std.Io.Writer.Error!void {
+    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+    try w.writeAll("{\"code\":");
+    try lsp_diagnostic.writeJsonString(w, d.code.render(&cbuf));
+    try w.writeAll(",\"name\":");
+    try lsp_diagnostic.writeJsonString(w, d.name);
+    try w.writeAll(",\"stage\":");
+    try lsp_diagnostic.writeJsonString(w, d.code.stage().label());
+    try w.writeAll(",\"severity\":");
+    try lsp_diagnostic.writeJsonString(w, d.severity.label());
+    try w.writeAll(",\"message\":");
+    try lsp_diagnostic.writeJsonString(w, d.template);
+    try w.writeAll(",\"explanation\":");
+    try lsp_diagnostic.writeJsonString(w, d.explanation);
+    try w.writeAll(",\"example\":");
+    try lsp_diagnostic.writeJsonString(w, d.example);
+    try w.writeByte('}');
+}
+
+fn renderAllText(w: *std.Io.Writer) std.Io.Writer.Error!void {
+    for (diagnostics.table, 0..) |d, i| {
+        if (i > 0) try w.writeAll("\n────────────────────────────────────────\n\n");
+        try renderText(w, d);
+    }
+}
+
+/// A single JSON array — one document a docs generator parses in one call.
+fn renderAllJson(w: *std.Io.Writer) std.Io.Writer.Error!void {
+    try w.writeByte('[');
+    for (diagnostics.table, 0..) |d, i| {
+        if (i > 0) try w.writeByte(',');
+        try renderJson(w, d);
+    }
+    try w.writeAll("]\n");
+}
+
+/// Write `text` with every line indented four spaces, always newline-terminated.
+fn writeIndented(w: *std.Io.Writer, text: []const u8) std.Io.Writer.Error!void {
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    while (lines.next()) |line| {
+        try w.writeAll("    ");
+        try w.writeAll(line);
+        try w.writeByte('\n');
+    }
+}
+
+fn printUsage() void {
+    writeStdout(
+        \\Usage: kaappi explain [--json] [--all] <code>
+        \\
+        \\Print the registry entry — meaning, example, and fix — for a diagnostic
+        \\code. <code> is a KP number ("KP3001", "3001") or its kebab name
+        \\("undefined-variable").
+        \\
+        \\  --json   Emit a JSON object (or a JSON array with --all).
+        \\  --all    Print every registered code (the full diagnostic reference).
+        \\
+    );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+fn renderTextToOwned(allocator: std.mem.Allocator, code: diagnostics.Code) ![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+    try renderText(&aw.writer, code.info());
+    return aw.toOwnedSlice();
+}
+
+fn renderJsonToOwned(allocator: std.mem.Allocator, code: diagnostics.Code) ![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+    try renderJson(&aw.writer, code.info());
+    return aw.toOwnedSlice();
+}
+
+test "text render carries code, name, message, explanation, and example" {
+    const out = try renderTextToOwned(testing.allocator, .undefined_variable);
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "KP3001") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "undefined-variable") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "runtime") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "undefined variable") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Example:") != null);
+    // the example snippet, indented
+    try testing.expect(std.mem.indexOf(u8, out, "    (display undefined-name)") != null);
+    // some of the explanation prose
+    try testing.expect(std.mem.indexOf(u8, out, "no binding in scope") != null);
+}
+
+test "json render is a single object with the expected fields" {
+    const out = try renderJsonToOwned(testing.allocator, .division_by_zero);
+    defer testing.allocator.free(out);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+
+    try testing.expectEqualStrings("KP3004", obj.get("code").?.string);
+    try testing.expectEqualStrings("division-by-zero", obj.get("name").?.string);
+    try testing.expectEqualStrings("runtime", obj.get("stage").?.string);
+    try testing.expectEqualStrings("error", obj.get("severity").?.string);
+    try testing.expect(obj.get("message") != null);
+    try testing.expect(obj.get("explanation") != null);
+    try testing.expectEqualStrings("(/ 1 0)", obj.get("example").?.string);
+}
+
+test "json escapes newlines in multi-line examples and explanations" {
+    // The stack-overflow example is a two-line snippet; a raw newline would be
+    // invalid JSON, so a successful parse proves it is escaped.
+    const out = try renderJsonToOwned(testing.allocator, .stack_overflow);
+    defer testing.allocator.free(out);
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+    try testing.expect(std.mem.indexOf(u8, parsed.value.object.get("example").?.string, "\n") != null);
+}
+
+test "--all json is one valid array covering every registered code" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try renderAllJson(&aw.writer);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    try testing.expectEqual(diagnostics.table.len, parsed.value.array.items.len);
+}
+
+test "fromString resolves KP number, bare number, and kebab name" {
+    try testing.expectEqual(diagnostics.Code.undefined_variable, diagnostics.Code.fromString("KP3001").?);
+    try testing.expectEqual(diagnostics.Code.undefined_variable, diagnostics.Code.fromString("kp3001").?);
+    try testing.expectEqual(diagnostics.Code.undefined_variable, diagnostics.Code.fromString("3001").?);
+    try testing.expectEqual(diagnostics.Code.undefined_variable, diagnostics.Code.fromString("undefined-variable").?);
+    try testing.expectEqual(diagnostics.Code.undefined_variable, diagnostics.Code.fromString("UNDEFINED-VARIABLE").?);
+    try testing.expect(diagnostics.Code.fromString("KP9999") == null);
+    try testing.expect(diagnostics.Code.fromString("nope") == null);
+    try testing.expect(diagnostics.Code.fromString("") == null);
+    try testing.expect(diagnostics.Code.fromString("kp") == null);
+}

--- a/src/lsp_diagnostic.zig
+++ b/src/lsp_diagnostic.zig
@@ -106,8 +106,9 @@ pub fn pointRange(line_1based: u32, col_1based: u32) Range {
 
 /// Write `s` as a JSON string literal (surrounding quotes included), escaping
 /// the characters JSON requires. Control characters below 0x20 that lack a
-/// short escape are emitted as `\uXXXX`.
-fn writeJsonString(w: *std.Io.Writer, s: []const u8) std.Io.Writer.Error!void {
+/// short escape are emitted as `\uXXXX`. Shared with `kaappi explain --json`
+/// (src/explain.zig) so both machine outputs escape identically.
+pub fn writeJsonString(w: *std.Io.Writer, s: []const u8) std.Io.Writer.Error!void {
     try w.writeByte('"');
     for (s) |c| {
         switch (c) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,6 +45,7 @@ pub const toplevel_driver = @import("toplevel_driver.zig");
 pub const diagnostics = @import("diagnostics.zig");
 pub const lsp_diagnostic = @import("lsp_diagnostic.zig");
 pub const cli = @import("cli.zig");
+pub const explain = @import("explain.zig");
 pub const config = @import("config.zig");
 
 pub const version = @import("build_options").version;
@@ -161,6 +162,15 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         _ = da.deinit();
     };
     const allocator = if (is_wasm) std.heap.wasm_allocator else if (is_debug) da.allocator() else std.heap.c_allocator;
+
+    // `kaappi explain <code>` is a pure query over the static diagnostic
+    // registry — no VM, GC, or library setup needed — so handle it before any
+    // of that exists and exit. (Skipped on WASM, whose entry just runs a file.)
+    if (comptime !is_wasm) {
+        if (explain.maybeRun(allocator, init.args)) |exit_code| {
+            std.process.exit(exit_code);
+        }
+    }
 
     var gc = memory.GC.init(allocator);
     defer gc.deinit();
@@ -967,5 +977,6 @@ test {
     _ = lsp_diagnostic;
     _ = repl_mod;
     _ = cli;
+    _ = explain;
     _ = config;
 }

--- a/src/tests_diagnostics.zig
+++ b/src/tests_diagnostics.zig
@@ -23,13 +23,38 @@ test "code renders as KPnnnn" {
 }
 
 test "every code resolves to a complete registry entry" {
+    // Registry completeness gate (kaappi#1507 acceptance): no registered code
+    // may lack a name, message, explanation, or example. The comptime block in
+    // diagnostics.zig enforces the same at build time; this is the runtime
+    // mirror that fails loudly if a new code is added without documentation.
     for (std.enums.values(Code)) |c| {
         const d = diagnostics.lookup(c);
         try std.testing.expectEqual(c, d.code);
         try std.testing.expect(d.name.len > 0);
         try std.testing.expect(d.template.len > 0);
         try std.testing.expect(d.explanation.len > 0);
+        try std.testing.expect(d.example.len > 0);
     }
+}
+
+test "code stage is recovered from the leading digit" {
+    try std.testing.expectEqual(diagnostics.Stage.read, Code.unexpected_eof.stage());
+    try std.testing.expectEqual(diagnostics.Stage.compile, Code.syntax_error.stage());
+    try std.testing.expectEqual(diagnostics.Stage.runtime, Code.undefined_variable.stage());
+    try std.testing.expectEqual(diagnostics.Stage.internal, Code.out_of_memory.stage());
+}
+
+test "fromString resolves codes and rejects unknowns" {
+    // Accepts the KP number (with or without prefix, any case) and the name.
+    try std.testing.expectEqual(Code.undefined_variable, Code.fromString("KP3001").?);
+    try std.testing.expectEqual(Code.undefined_variable, Code.fromString("kp3001").?);
+    try std.testing.expectEqual(Code.undefined_variable, Code.fromString("3001").?);
+    try std.testing.expectEqual(Code.undefined_variable, Code.fromString("undefined-variable").?);
+    // Unknown ordinals, unknown names, and empty/partial input resolve to null.
+    try std.testing.expect(Code.fromString("KP9999") == null);
+    try std.testing.expect(Code.fromString("not-a-code") == null);
+    try std.testing.expect(Code.fromString("") == null);
+    try std.testing.expect(Code.fromString("KP") == null);
 }
 
 test "no two registry entries share a code" {

--- a/tests/scheme/errors/explain.sh
+++ b/tests/scheme/errors/explain.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# `kaappi explain <code>` tests (kaappi#1507).
+#
+# `kaappi explain` turns the diagnostic registry into the binary's own offline
+# reference (like `rustc --explain`). These checks assert the text and JSON
+# surfaces, and — the load-bearing part — that every runnable example actually
+# triggers the code it is documented under, so the docs can never drift from
+# what the interpreter emits.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "FAIL: python3 is required to validate kaappi explain output"
+    exit 1
+fi
+
+KAAPPI="$KAAPPI" python3 - <<'PY'
+import json, os, re, subprocess, sys
+
+KAAPPI = os.environ["KAAPPI"]
+CODE_RE = re.compile(r'"code":"(KP\d{4})"')
+
+# Codes whose registry `example` is representative (an inline one-liner cannot
+# genuinely trigger them) — excluded from the self-consistency run only.
+ILLUSTRATIVE = {"KP1009", "KP1010", "KP9000", "KP9001"}
+
+passed = failed = 0
+
+def check(cond, label, detail=""):
+    global passed, failed
+    if cond:
+        print(f"PASS: {label}"); passed += 1
+    else:
+        print(f"FAIL: {label}  {detail}"); failed += 1
+
+def explain(*args):
+    return subprocess.run([KAAPPI, "explain", *args], capture_output=True, text=True)
+
+def emitted_code(src, timeout_ms=None):
+    """Run src through the interpreter, return the first KP code it emits."""
+    args = [KAAPPI, "--diagnostics=json"]
+    if timeout_ms is not None:
+        args += ["--timeout", str(timeout_ms)]
+    args.append("/dev/stdin")
+    p = subprocess.run(args, input=src, capture_output=True, text=True, timeout=30)
+    m = CODE_RE.search(p.stderr) or CODE_RE.search(p.stdout)
+    return m.group(1) if m else None
+
+# --- Text surface ---------------------------------------------------------
+
+p = explain("KP3001")
+check(p.returncode == 0, "explain KP3001 exits 0", p.returncode)
+for needle in ("KP3001", "undefined-variable", "runtime", "Example:",
+               "(display undefined-name)"):
+    check(needle in p.stdout, f"text output contains {needle!r}")
+
+# The code argument is accepted three ways.
+check(explain("undefined-variable").stdout == p.stdout, "kebab name == KP number output")
+check(explain("3001").stdout == p.stdout, "bare number == KP number output")
+check(explain("kp3001").stdout == p.stdout, "lowercase prefix == KP number output")
+
+# --- JSON surface ---------------------------------------------------------
+
+p = explain("--json", "KP3004")
+check(p.returncode == 0, "explain --json exits 0", p.returncode)
+obj = json.loads(p.stdout)  # raises (and fails the suite) if not valid JSON
+check(obj["code"] == "KP3004", "json code", obj.get("code"))
+check(obj["name"] == "division-by-zero", "json name", obj.get("name"))
+check(obj["stage"] == "runtime", "json stage", obj.get("stage"))
+check(obj["severity"] == "error", "json severity", obj.get("severity"))
+for field in ("message", "explanation", "example"):
+    check(isinstance(obj.get(field), str) and obj[field], f"json has non-empty {field}")
+
+# --- The full reference (--all) ------------------------------------------
+
+entries = json.loads(explain("--all", "--json").stdout)
+check(len(entries) >= 26, "explain --all --json lists every code", len(entries))
+seen = set()
+for e in entries:
+    seen.add(e["code"])
+    # Registry completeness at the CLI surface: no code may reach a user
+    # without prose AND a triggering example.
+    check(bool(e.get("explanation")), f"{e['code']} has an explanation")
+    check(bool(e.get("example")), f"{e['code']} has an example")
+check(len(seen) == len(entries), "every --all entry has a distinct code")
+
+all_text = explain("--all").stdout
+check("KP1001" in all_text and "KP9002" in all_text, "explain --all text spans the range")
+
+# --- Error handling -------------------------------------------------------
+
+p = explain("KP9999")
+check(p.returncode == 2, "unknown code exits 2", p.returncode)
+check(p.stdout == "", "unknown code prints nothing to stdout", p.stdout)
+check("KP9999" in p.stderr, "unknown code names it on stderr", p.stderr)
+
+p = explain()
+check(p.returncode == 2, "missing argument exits 2", p.returncode)
+
+p = explain("--all", "KP3001")
+check(p.returncode == 2, "code + --all is rejected", p.returncode)
+
+# --- Self-consistency: every runnable example triggers its own code -------
+
+inconsistent = []
+for e in entries:
+    code, ex = e["code"], e["example"]
+    if code in ILLUSTRATIVE:
+        continue
+    got = emitted_code(ex, timeout_ms=300 if code == "KP3009" else None)
+    if got != code:
+        inconsistent.append((code, got, ex.splitlines()[0]))
+check(not inconsistent, "every runnable example triggers its documented code",
+      inconsistent)
+
+# --- Summary --------------------------------------------------------------
+
+print()
+print(f"Passed: {passed}")
+print(f"Failed: {failed}")
+sys.exit(1 if failed else 0)
+PY
+
+echo "All kaappi explain tests pass."

--- a/tools/gen_diagnostics_reference.py
+++ b/tools/gen_diagnostics_reference.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Generate the kaappi-lang.org diagnostic reference page from the registry.
+
+The page can never drift from what the binary emits because it is generated
+*from the binary*: this script runs `kaappi explain --all --json` and renders
+the resulting entries as Markdown. Run it against a freshly built kaappi and
+commit the output into the kaappi.github.io repo (see docs/dev/explain.md).
+
+    zig build                                    # build zig-out/bin/kaappi
+    python3 tools/gen_diagnostics_reference.py   # -> stdout
+    python3 tools/gen_diagnostics_reference.py \\
+        --kaappi zig-out/bin/kaappi \\
+        -o ../kaappi.github.io/docs/guide/diagnostics.md
+
+Codes are grouped by pipeline stage, in registry order.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+# Human headings for each stage label emitted by `kaappi explain --json`.
+STAGE_HEADINGS = {
+    "read": "Read / lexical (`KP1xxx`)",
+    "compile": "Expand / compile (`KP2xxx`)",
+    "runtime": "Runtime (`KP3xxx`)",
+    "static-analysis": "Static analysis (`KP4xxx`)",
+    "internal": "Internal / resource (`KP9xxx`)",
+}
+STAGE_ORDER = ["read", "compile", "runtime", "static-analysis", "internal"]
+
+PREAMBLE = """\
+# Diagnostic reference
+
+Every diagnostic Kaappi prints carries a stable `KP` code. This page documents
+every registered code: what it means, a minimal example that triggers it, and
+how to fix it. The same content is available offline from the binary itself with
+[`kaappi explain <code>`](../guide/debugging.md) (e.g. `kaappi explain KP3001`).
+
+!!! note "Generated page"
+
+    This page is generated from the compiler's diagnostic registry by
+    `tools/gen_diagnostics_reference.py` in the core repo. Do not edit it by
+    hand — regenerate it after a release instead.
+"""
+
+
+def fetch_entries(kaappi: str) -> list[dict]:
+    proc = subprocess.run(
+        [kaappi, "explain", "--all", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"error: `{kaappi} explain --all --json` failed:\n{proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def render(entries: list[dict]) -> str:
+    by_stage: dict[str, list[dict]] = {}
+    for e in entries:
+        by_stage.setdefault(e["stage"], []).append(e)
+
+    out: list[str] = [PREAMBLE]
+    # Known stages first in taxonomy order, then any unrecognised stage so a
+    # future range can never be silently dropped from the page.
+    stages = [s for s in STAGE_ORDER if s in by_stage]
+    stages += [s for s in by_stage if s not in STAGE_ORDER]
+
+    for stage in stages:
+        out.append(f"\n## {STAGE_HEADINGS.get(stage, stage)}\n")
+        for e in by_stage[stage]:
+            out.append(f"### `{e['code']}` — {e['name']}\n")
+            out.append(f"_{e['message']}_\n")
+            out.append(e["explanation"] + "\n")
+            out.append("**Example**\n")
+            out.append("```scheme\n" + e["example"] + "\n```\n")
+    return "\n".join(out)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--kaappi", default="zig-out/bin/kaappi",
+                    help="path to the kaappi binary (default: zig-out/bin/kaappi)")
+    ap.add_argument("-o", "--output", help="write to this file instead of stdout")
+    args = ap.parse_args()
+
+    page = render(fetch_entries(args.kaappi))
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(page)
+        print(f"wrote {args.output}", file=sys.stderr)
+    else:
+        sys.stdout.write(page)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

`kaappi explain <code>` turns the KP diagnostic registry (#1504) into the binary's own offline reference — like `rustc --explain`. Everything is read from the one registry in `src/diagnostics.zig`, so this command, the `--diagnostics=json` stream, and the generated website page can never disagree about what a code means.

```
$ kaappi explain KP3001
KP3001  undefined-variable
runtime · error

undefined variable

A variable was referenced that has no binding in scope. Check for a typo
(Kaappi suggests the nearest defined name), a missing 'import', or a
'define' that has not run yet because it appears after the reference.

Example:
    (display undefined-name)
```

- **Code argument** accepts `KP3001`, `kp3001`, `3001`, or the kebab name `undefined-variable`.
- **`--json`** emits one JSON object; **`--all`** the full text reference; **`--all --json`** a JSON array (the drift-proof source a docs generator consumes).

## Acceptance criteria

- [x] `kaappi explain <code>` with prose + example + fix for every registered code (all 26)
- [x] `--json` variant
- [ ] Diagnostics reference page on kaappi-lang.org generated from the registry — **binary emitter + generator shipped here**; the page itself is a follow-up in the separate `kaappi.github.io` repo (mkdocs), produced by `tools/gen_diagnostics_reference.py`
- [x] A test that fails when any registered code lacks documentation (extended to require a non-empty `example` too)

## Notable design choices

- **`example` field** added to every registry entry — the "minimal example that triggers it." 22 of 26 are literal one-liners verified to emit their own code; the four that can't be inlined (deep nesting, oversized token, and the two internal catch-alls) are representative and say so in the snippet.
- **Examples are tested, not just present:** `tests/scheme/errors/explain.sh` reruns every runnable example back through `--diagnostics=json` and asserts it still triggers its documented code, so a drift fails CI rather than a user.
- `explain` is a pure query over the static registry, so `main` dispatches it **before any VM/GC/library setup** exists.
- The `--json` string escaper is shared with `--diagnostics=json` (`lsp_diagnostic.writeJsonString`), so both machine surfaces escape identically.
- Completeness is enforced at three layers: the build-time comptime gate, a runtime unit test, and the end-to-end shell test.

## Files

**New:** `src/explain.zig`, `tests/scheme/errors/explain.sh`, `docs/dev/explain.md`, `tools/gen_diagnostics_reference.py`
**Changed:** `src/diagnostics.zig` (`example` field + `Stage`/`stage()`/`fromString()` + gate), `src/main.zig` (early dispatch), `src/lsp_diagnostic.zig` (shared escaper made public), `src/cli.zig` / `src/completions.zig` (help + bash/zsh/fish completions), `src/tests_diagnostics.zig`, dev docs.

## Testing

Full `zig build test` green (including under `-Dgc-stress=true`), all `tests/scheme/errors/*.sh` pass (78 checks in `explain.sh`), smoke spot-checks pass, `zig fmt` clean. The `compile` subcommand and normal execution are unaffected.

Part of #1503. Closes #1507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)