### PR TITLE
Inline fixnum fast paths for hot native primitives (#1493)

### DIFF
--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -119,9 +119,42 @@ opt -passes=verify -disable-output program.ll        # or: llvm-as -o /dev/null 
 The `-w` on the link commands only silences cosmetic warnings on generated IR
 for end users; a hard verifier **error** still fails the compile regardless.
 
-Cross-module inlining of the runtime primitives (`kaappi_fixnum_add`,
-`kaappi_car`, …) needs LTO and is tracked separately — `-O2` alone already
-cleans up the emitter's own IR substantially.
+### Inline primitive fast paths
+
+`-O2` cleans up the emitter's own scaffolding but cannot inline the runtime
+primitives (`kaappi_fixnum_add`, `kaappi_car`, …): they live in the static
+archive `libkaappi_rt.a`, on the far side of a compilation boundary `-O2` alone
+cannot cross. So the hottest primitives are emitted **as inline IR** instead of
+calls (#1493), removing the per-operation call in the common case:
+
+| Primitive | Inline fast path | Slow-path fallback |
+|-----------|------------------|--------------------|
+| `+` `-` `*` | fixnum-tag check on both operands → `llvm.sadd/ssub/smul.with.overflow.i64` on the sign-extended payloads → re-box if the result is in i48 range | `call @kaappi_fixnum_{add,sub,mul}` when an operand is not a fixnum, or the result overflows the i48 range (→ bignum) |
+| `<` `=` | fixnum-tag check → `icmp slt` (sign-extended) / `icmp eq` (raw) → boolean `select` | `call @kaappi_fixnum_{lt,eq}` for the full numeric tower |
+| `null?` | `icmp eq` against the nil immediate → `select` | none (pure) |
+
+The fast paths touch only the **NaN-boxed Value bits** (fixnum tag, payload,
+nil/boolean immediates), whose encoding is stable and is pulled from `types.zig`
+at emitter comptime (`nanbox` in `llvm_emit.zig`) — no magic numbers are
+hand-transcribed into the IR. `car`, `cdr`, and `cons` deliberately stay as
+direct specialized calls: `Pair`/`Object` are **auto-layout** (non-`extern`)
+structs whose field offsets Zig does not guarantee, so they cannot be encoded in
+hand-written IR, and `cons` allocates regardless.
+
+The inline binary path also **elides the shadow-stack rooting** (a
+`kaappi_gc_push_root`/`kaappi_gc_pop_roots` call pair) that keeps the first
+operand alive across the second's evaluation, whenever the second operand is a
+leaf that cannot allocate (a variable reference or an immediate constant —
+`nodeMayAllocate`). For a hot arithmetic loop this is the difference between a
+handful of runtime calls per operation and none: `fib(38)` runs ~3.3× faster
+than `-O2`-only.
+
+> **Why not LTO?** Building `libkaappi_rt.a` as bitcode and linking with `-flto`
+> would let LLVM inline every primitive, but Zig's toolchain cannot use LLD for
+> Mach-O (`using LLD to link macho files is unsupported`) and LTO requires LLD —
+> so `-flto` is unavailable on macOS, the primary dev platform, and would only
+> work when targeting Linux. Inline IR is portable across every target (it is
+> just text the emitter writes) and needs no cross-module inlining.
 
 ## LLVM IR Emission
 
@@ -132,7 +165,7 @@ The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
 |------|---------------|
 | `constant` | Literal `i64` for immediates; `kaappi_make_string` for strings; `kaappi_intern_symbol` for symbols; `(quote ...)` via `kaappi_eval` for other heap values |
 | `global_ref` | `call @kaappi_global_lookup(...)` |
-| `call` | Three paths: inlined primitive (`+ - * < = car cdr cons null?`); direct `call`/`tail call` to a known native function; otherwise stack-allocate args array and `call @kaappi_call_scheme(...)` |
+| `call` | Four paths: inline-IR fast path for `+ - * < = null?` (see [Inline primitive fast paths](#inline-primitive-fast-paths)); direct specialized call for `car cdr cons`; direct `call`/`tail call` to a known native function; otherwise stack-allocate args array and `call @kaappi_call_scheme(...)` |
 | `begin` | Emit each expression sequentially |
 | `if` | LLVM basic blocks with `br`/`phi` |
 | `and`/`or` | Short-circuit with basic blocks and `phi` |
@@ -287,6 +320,10 @@ environment variable controls the C compiler (defaults to `zig cc`).
 - Unicode strings, string ports, string mutation
 - Higher-order functions (`map`, `filter`, `fold`)
 - Tail-recursive loops (100k iterations)
+- Inline fixnum fast paths for `+ - * < = null?` with their runtime fallbacks —
+  overflow → bignum, non-fixnum (flonum/rational) operands, and sign-extended
+  negatives (`native-inline-primitives.scm`, all diffed against the interpreter,
+  including under a forced-collection `KAAPPI_GC_THRESHOLD=1` run)
 
 ## Related Documents
 

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -6,6 +6,50 @@ const native_decls = @import("native_decls.zig");
 
 const Value = types.Value;
 
+// NaN-box encoding constants for inline primitive emission. Derived at comptime
+// from types.zig so the emitted IR always matches the runtime's value
+// representation — no hand-transcribed magic numbers to drift out of sync.
+// These describe only the immediate Value bit layout (fixnum tag, payload, nil,
+// booleans), which is stable; heap-object field offsets (auto-layout structs)
+// are deliberately NOT encoded here, so car/cdr/cons stay as runtime calls.
+const nanbox = struct {
+    // High 16 bits (v >> 48) that mark a fixnum: 0xFFFD.
+    const fix_tag_hi: u64 = types.makeFixnum(0) >> 48;
+    // Base fixnum tag bits, OR'd with a 48-bit payload to box an integer.
+    const fix_base: i64 = @bitCast(types.makeFixnum(0));
+    // Mask selecting the 48-bit fixnum payload.
+    const payload_mask: i64 = std.math.maxInt(u48);
+    // Inclusive range of integers representable as a fixnum (i48).
+    const fix_min: i64 = std.math.minInt(i48);
+    const fix_max: i64 = std.math.maxInt(i48);
+    const nil: i64 = @bitCast(types.NIL);
+    const true_val: i64 = @bitCast(types.TRUE);
+    const false_val: i64 = @bitCast(types.FALSE);
+};
+
+const ArithOp = enum {
+    add,
+    sub,
+    mul,
+
+    // LLVM checked-arithmetic intrinsic that mirrors the runtime's
+    // @addWithOverflow / @subWithOverflow / @mulWithOverflow fast path.
+    fn overflowIntrinsic(self: ArithOp) []const u8 {
+        return switch (self) {
+            .add => "@llvm.sadd.with.overflow.i64",
+            .sub => "@llvm.ssub.with.overflow.i64",
+            .mul => "@llvm.smul.with.overflow.i64",
+        };
+    }
+
+    fn fromName(name: []const u8) ?ArithOp {
+        if (std.mem.eql(u8, name, "+")) return .add;
+        if (std.mem.eql(u8, name, "-")) return .sub;
+        if (std.mem.eql(u8, name, "*")) return .mul;
+        return null;
+    }
+};
+
 const NativeLambda = struct {
     llvm_name: []const u8,
     arity: u8,
@@ -17,6 +61,25 @@ fn nameInList(names: []const []const u8, name: []const u8) bool {
         if (std.mem.eql(u8, n, name)) return true;
     }
     return false;
+}
+
+// Conservative "evaluating this node might allocate (and therefore trigger a
+// GC)". Used to elide the shadow-stack rooting that only exists to keep an
+// already-computed operand alive while a *later* operand is evaluated: if the
+// later operand cannot allocate, nothing can collect, so the root push/pop pair
+// (two cross-module runtime calls) is pure overhead. Errs toward `true` — only
+// leaves whose emission is provably allocation-free return `false`:
+//   - immediate constants (fixnum/bool/char/nil) lower to a bare `add i64 0, K`;
+//     heap constants (string/symbol/pair) call make_string/intern_symbol/eval.
+//   - variable references (global_ref) always lower to a load or a
+//     non-allocating runtime call (global_lookup / box_ref).
+// Every compound form may allocate, so it stays `true`.
+fn nodeMayAllocate(node: *const ir.Node) bool {
+    return switch (node.tag) {
+        .constant => types.isPointer(node.data.constant),
+        .global_ref => false,
+        else => true,
+    };
 }
 
 pub const LLVMEmitter = struct {
@@ -1064,9 +1127,29 @@ pub const LLVMEmitter = struct {
     fn tryEmitInlineBinary(self: *LLVMEmitter, name: []const u8, args: []const *ir.Node) ?[]const u8 {
         const export_name = native_decls.findInline(.binary, name) orelse return null;
         const a = self.emitNode(args[0]) catch return null;
-        self.emitRootPush(a) catch return null;
+        // Root the first operand across the second's evaluation only when that
+        // evaluation could actually collect. For the common hot-loop shapes
+        // `(op var const)` and `(op var var)` the second operand is a leaf, so
+        // this drops two runtime calls (push_root/pop_roots) per operation.
+        const root_a = nodeMayAllocate(args[1]);
+        if (root_a) self.emitRootPush(a) catch return null;
         const b = self.emitNode(args[1]) catch return null;
-        self.emitPopRoots(1) catch return null;
+        if (root_a) self.emitPopRoots(1) catch return null;
+
+        // Arithmetic and comparison operate purely on NaN-boxed Value bits, so
+        // their fixnum fast paths lower to inline IR with a call to the runtime
+        // only on the slow path (non-fixnum operands, or overflow out of the
+        // i48 fixnum range → bignum promotion). This removes the per-operation
+        // cross-module call that -O2 alone cannot eliminate (#1493). cons falls
+        // through to a direct specialized call: it always allocates, so there is
+        // no call-free fast path, and its Pair layout is not encodable here.
+        if (ArithOp.fromName(name)) |op|
+            return self.emitInlineArith(op, a, b, export_name) catch return null;
+        if (std.mem.eql(u8, name, "<"))
+            return self.emitInlineCompare(.lt, a, b, export_name) catch return null;
+        if (std.mem.eql(u8, name, "="))
+            return self.emitInlineCompare(.eq, a, b, export_name) catch return null;
+
         const result = self.freshTemp() catch return null;
         self.print("  {s} = call i64 @{s}(i64 {s}, i64 {s})\n", .{ result, export_name, a, b }) catch return null;
         return result;
@@ -1075,8 +1158,148 @@ pub const LLVMEmitter = struct {
     fn tryEmitInlineUnary(self: *LLVMEmitter, name: []const u8, arg: *const ir.Node) ?[]const u8 {
         const export_name = native_decls.findInline(.unary, name) orelse return null;
         const v = self.emitNode(arg) catch return null;
+
+        // null? is a single Value comparison against the nil immediate — no
+        // heap access, no fallback needed. car/cdr touch the (auto-layout) Pair
+        // struct and raise on a non-pair, so they stay as direct runtime calls.
+        if (std.mem.eql(u8, name, "null?"))
+            return self.emitInlineNullCheck(v) catch return null;
+
         const result = self.freshTemp() catch return null;
         self.print("  {s} = call i64 @{s}(i64 {s})\n", .{ result, export_name, v }) catch return null;
+        return result;
+    }
+
+    // Emit `%dst = <sign-extended i48 payload of %boxed>`. Shifting the tag bits
+    // out to the left and arithmetic-shifting back sign-extends bit 47, matching
+    // types.toFixnum. Caller must have already checked %boxed is a fixnum.
+    fn emitUnboxFixnum(self: *LLVMEmitter, boxed: []const u8) EmitError![]const u8 {
+        const shifted = try self.freshTemp();
+        try self.print("  {s} = shl i64 {s}, 16\n", .{ shifted, boxed });
+        const val = try self.freshTemp();
+        try self.print("  {s} = ashr i64 {s}, 16\n", .{ val, shifted });
+        return val;
+    }
+
+    // Emit `%dst = i1` that is true iff %boxed carries the fixnum tag
+    // (`(boxed >> 48) == 0xFFFD`), matching types.isFixnum.
+    fn emitIsFixnum(self: *LLVMEmitter, boxed: []const u8) EmitError![]const u8 {
+        const hi = try self.freshTemp();
+        try self.print("  {s} = lshr i64 {s}, 48\n", .{ hi, boxed });
+        const is_fix = try self.freshTemp();
+        try self.print("  {s} = icmp eq i64 {s}, {d}\n", .{ is_fix, hi, nanbox.fix_tag_hi });
+        return is_fix;
+    }
+
+    // Compute `i1` = both operands are fixnums, then branch to the caller's
+    // fixnum fast-path block or its runtime slow-path block accordingly.
+    fn emitBothFixnumBranch(self: *LLVMEmitter, a: []const u8, b: []const u8, fast: []const u8, slow: []const u8) EmitError!void {
+        const a_fix = try self.emitIsFixnum(a);
+        const b_fix = try self.emitIsFixnum(b);
+        const both = try self.freshTemp();
+        try self.print("  {s} = and i1 {s}, {s}\n", .{ both, a_fix, b_fix });
+        try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ both, fast, slow });
+    }
+
+    // Fixnum fast path for +, -, *. On non-fixnum operands or a result outside
+    // the i48 fixnum range (overflow → bignum), fall back to the runtime.
+    fn emitInlineArith(self: *LLVMEmitter, op: ArithOp, a: []const u8, b: []const u8, export_name: []const u8) EmitError![]const u8 {
+        const id = self.label_counter;
+        self.label_counter += 1;
+        const fast = try std.fmt.allocPrint(self.allocator(), "arith_fast{d}", .{id});
+        const box = try std.fmt.allocPrint(self.allocator(), "arith_box{d}", .{id});
+        const slow = try std.fmt.allocPrint(self.allocator(), "arith_slow{d}", .{id});
+        const done = try std.fmt.allocPrint(self.allocator(), "arith_done{d}", .{id});
+
+        try self.emitBothFixnumBranch(a, b, fast, slow);
+
+        try self.startBlock(fast);
+        const va = try self.emitUnboxFixnum(a);
+        const vb = try self.emitUnboxFixnum(b);
+        const ov = try self.freshTemp();
+        try self.print("  {s} = call {{ i64, i1 }} {s}(i64 {s}, i64 {s})\n", .{ ov, op.overflowIntrinsic(), va, vb });
+        const raw = try self.freshTemp();
+        try self.print("  {s} = extractvalue {{ i64, i1 }} {s}, 0\n", .{ raw, ov });
+        const ovf = try self.freshTemp();
+        try self.print("  {s} = extractvalue {{ i64, i1 }} {s}, 1\n", .{ ovf, ov });
+        const ge = try self.freshTemp();
+        try self.print("  {s} = icmp sge i64 {s}, {d}\n", .{ ge, raw, nanbox.fix_min });
+        const le = try self.freshTemp();
+        try self.print("  {s} = icmp sle i64 {s}, {d}\n", .{ le, raw, nanbox.fix_max });
+        const in_range = try self.freshTemp();
+        try self.print("  {s} = and i1 {s}, {s}\n", .{ in_range, ge, le });
+        const not_ovf = try self.freshTemp();
+        try self.print("  {s} = xor i1 {s}, true\n", .{ not_ovf, ovf });
+        const ok = try self.freshTemp();
+        try self.print("  {s} = and i1 {s}, {s}\n", .{ ok, in_range, not_ovf });
+        try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ ok, box, slow });
+
+        try self.startBlock(box);
+        const masked = try self.freshTemp();
+        try self.print("  {s} = and i64 {s}, {d}\n", .{ masked, raw, nanbox.payload_mask });
+        const boxed = try self.freshTemp();
+        try self.print("  {s} = or i64 {s}, {d}\n", .{ boxed, masked, nanbox.fix_base });
+        try self.print("  br label %{s}\n", .{done});
+
+        try self.startBlock(slow);
+        const slow_res = try self.freshTemp();
+        try self.print("  {s} = call i64 @{s}(i64 {s}, i64 {s})\n", .{ slow_res, export_name, a, b });
+        try self.print("  br label %{s}\n", .{done});
+
+        try self.startBlock(done);
+        const result = try self.freshTemp();
+        try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {s}, %{s} ]\n", .{ result, boxed, box, slow_res, slow });
+        return result;
+    }
+
+    const CompareKind = enum { lt, eq };
+
+    // Fixnum fast path for < and =. Non-fixnum operands fall back to the
+    // runtime, which handles the full numeric tower.
+    fn emitInlineCompare(self: *LLVMEmitter, kind: CompareKind, a: []const u8, b: []const u8, export_name: []const u8) EmitError![]const u8 {
+        const id = self.label_counter;
+        self.label_counter += 1;
+        const fast = try std.fmt.allocPrint(self.allocator(), "cmp_fast{d}", .{id});
+        const slow = try std.fmt.allocPrint(self.allocator(), "cmp_slow{d}", .{id});
+        const done = try std.fmt.allocPrint(self.allocator(), "cmp_done{d}", .{id});
+
+        try self.emitBothFixnumBranch(a, b, fast, slow);
+
+        try self.startBlock(fast);
+        const cond = try self.freshTemp();
+        switch (kind) {
+            // Fixnums have a canonical encoding, so equal integers have equal
+            // bits — the raw compare matches the runtime's `a == b`.
+            .eq => try self.print("  {s} = icmp eq i64 {s}, {s}\n", .{ cond, a, b }),
+            // Ordering needs the sign-extended payloads (raw compare would
+            // mis-order negatives).
+            .lt => {
+                const va = try self.emitUnboxFixnum(a);
+                const vb = try self.emitUnboxFixnum(b);
+                try self.print("  {s} = icmp slt i64 {s}, {s}\n", .{ cond, va, vb });
+            },
+        }
+        const fast_res = try self.freshTemp();
+        try self.print("  {s} = select i1 {s}, i64 {d}, i64 {d}\n", .{ fast_res, cond, nanbox.true_val, nanbox.false_val });
+        try self.print("  br label %{s}\n", .{done});
+
+        try self.startBlock(slow);
+        const slow_res = try self.freshTemp();
+        try self.print("  {s} = call i64 @{s}(i64 {s}, i64 {s})\n", .{ slow_res, export_name, a, b });
+        try self.print("  br label %{s}\n", .{done});
+
+        try self.startBlock(done);
+        const result = try self.freshTemp();
+        try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {s}, %{s} ]\n", .{ result, fast_res, fast, slow_res, slow });
+        return result;
+    }
+
+    // null? — a single comparison against the nil immediate, no heap access.
+    fn emitInlineNullCheck(self: *LLVMEmitter, v: []const u8) EmitError![]const u8 {
+        const cond = try self.freshTemp();
+        try self.print("  {s} = icmp eq i64 {s}, {d}\n", .{ cond, v, nanbox.nil });
+        const result = try self.freshTemp();
+        try self.print("  {s} = select i1 {s}, i64 {d}, i64 {d}\n", .{ result, cond, nanbox.true_val, nanbox.false_val });
         return result;
     }
 
@@ -1198,6 +1421,11 @@ pub const LLVMEmitter = struct {
             }
             try self.write(")\n");
         }
+        // Checked-arithmetic intrinsics used by the inline fixnum fast paths
+        // for +, -, * (emitInlineArith).
+        try self.write("declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64)\n");
+        try self.write("declare { i64, i1 } @llvm.ssub.with.overflow.i64(i64, i64)\n");
+        try self.write("declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64)\n");
     }
 
     fn emitRootPush(self: *LLVMEmitter, tmp: []const u8) EmitError!void {

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -116,6 +116,13 @@ fn expectContains(haystack: []const u8, needle: []const u8) !void {
     }
 }
 
+fn expectNotContains(haystack: []const u8, needle: []const u8) !void {
+    if (std.mem.indexOf(u8, haystack, needle) != null) {
+        std.debug.print("\n--- Expected NOT to find ---\n{s}\n--- but it appears in output (len={d}) ---\n", .{ needle, haystack.len });
+        return error.TestUnexpectedResult;
+    }
+}
+
 // -- Preamble and structure --
 
 test "LLVM emit: preamble has target triple and runtime calls" {
@@ -188,46 +195,90 @@ test "LLVM emit: general call emits kaappi_call_scheme" {
     try expectContains(res.toSlice(), "@kaappi_call_scheme");
 }
 
-test "LLVM emit: inline add" {
+// Arithmetic + comparison + null? lower to inline fixnum fast paths (#1493).
+// Each emits the fixnum-fast-path IR *and* keeps a call to the runtime for the
+// slow path (non-fixnum operands, or overflow out of the i48 range → bignum).
+// car/cdr/cons keep a direct specialized call: their Pair layout is an
+// auto-layout struct that cannot be encoded in hand-written IR, and cons always
+// allocates.
+
+test "LLVM emit: inline add uses fixnum fast path + runtime fallback" {
     var res = try emitSourceResult("(+ a b)");
     defer res.deinit();
-    try expectContains(res.toSlice(), "@kaappi_fixnum_add");
+    try expectContains(res.toSlice(), "@llvm.sadd.with.overflow.i64");
+    try expectContains(res.toSlice(), "call i64 @kaappi_fixnum_add"); // slow-path call
 }
 
-test "LLVM emit: inline sub" {
+test "LLVM emit: inline sub uses fixnum fast path + runtime fallback" {
     var res = try emitSourceResult("(- a b)");
     defer res.deinit();
-    try expectContains(res.toSlice(), "@kaappi_fixnum_sub");
+    try expectContains(res.toSlice(), "@llvm.ssub.with.overflow.i64");
+    try expectContains(res.toSlice(), "call i64 @kaappi_fixnum_sub");
 }
 
-test "LLVM emit: inline mul" {
+test "LLVM emit: inline mul uses fixnum fast path + runtime fallback" {
     var res = try emitSourceResult("(* a b)");
     defer res.deinit();
-    try expectContains(res.toSlice(), "@kaappi_fixnum_mul");
+    try expectContains(res.toSlice(), "@llvm.smul.with.overflow.i64");
+    try expectContains(res.toSlice(), "call i64 @kaappi_fixnum_mul");
 }
 
-test "LLVM emit: inline car" {
+test "LLVM emit: inline < uses inline compare + runtime fallback" {
+    var res = try emitSourceResult("(< a b)");
+    defer res.deinit();
+    try expectContains(res.toSlice(), "icmp slt i64");
+    try expectContains(res.toSlice(), "call i64 @kaappi_fixnum_lt");
+}
+
+test "LLVM emit: inline = uses inline compare + runtime fallback" {
+    var res = try emitSourceResult("(= a b)");
+    defer res.deinit();
+    try expectContains(res.toSlice(), "select i1");
+    try expectContains(res.toSlice(), "call i64 @kaappi_fixnum_eq");
+}
+
+test "LLVM emit: inline car keeps a direct specialized call" {
     var res = try emitSourceResult("(car x)");
     defer res.deinit();
-    try expectContains(res.toSlice(), "@kaappi_car");
+    try expectContains(res.toSlice(), "call i64 @kaappi_car");
 }
 
-test "LLVM emit: inline cdr" {
+test "LLVM emit: inline cdr keeps a direct specialized call" {
     var res = try emitSourceResult("(cdr x)");
     defer res.deinit();
-    try expectContains(res.toSlice(), "@kaappi_cdr");
+    try expectContains(res.toSlice(), "call i64 @kaappi_cdr");
 }
 
-test "LLVM emit: inline cons" {
+test "LLVM emit: inline cons keeps a direct specialized call" {
     var res = try emitSourceResult("(cons a b)");
     defer res.deinit();
-    try expectContains(res.toSlice(), "@kaappi_cons");
+    try expectContains(res.toSlice(), "call i64 @kaappi_cons");
 }
 
-test "LLVM emit: inline null?" {
+test "LLVM emit: null? inlines to a nil comparison with no runtime call" {
     var res = try emitSourceResult("(null? x)");
     defer res.deinit();
-    try expectContains(res.toSlice(), "@kaappi_is_null");
+    // Inlined: a single comparison + boolean select, and crucially NO call to
+    // the runtime (only the always-present preamble `declare` mentions it).
+    try expectContains(res.toSlice(), "select i1");
+    try expectNotContains(res.toSlice(), "call i64 @kaappi_is_null");
+}
+
+test "LLVM emit: inline binary skips rooting when operands cannot allocate (#1493)" {
+    // Both operands are leaves (variable ref + immediate), so nothing can
+    // collect while the second is evaluated — the shadow-stack push/pop pair is
+    // pure call overhead and must be elided.
+    var res = try emitSourceResult("(+ a 1)");
+    defer res.deinit();
+    try expectNotContains(res.toSlice(), "call void @kaappi_gc_push_root");
+}
+
+test "LLVM emit: inline binary still roots when a later operand may allocate (#1493)" {
+    // The second operand is a call, which may allocate and trigger a GC, so the
+    // first operand's result must stay rooted across it.
+    var res = try emitSourceResult("(+ a (f b))");
+    defer res.deinit();
+    try expectContains(res.toSlice(), "call void @kaappi_gc_push_root");
 }
 
 // -- Control flow --

--- a/tests/e2e/programs/native-inline-primitives.scm
+++ b/tests/e2e/programs/native-inline-primitives.scm
@@ -1,0 +1,39 @@
+; Inline fixnum fast paths for + - * < = null? (#1493), plus the runtime
+; slow-path fallbacks they must defer to: overflow out of the i48 fixnum range
+; (bignum promotion), non-fixnum operands (flonum, rational), and negative
+; values (which exercise sign-extension in the < ordering path). The native
+; binary's output must match the interpreter exactly.
+
+; Fixnum fast paths
+(display (+ 3 4)) (newline)            ; 7
+(display (- 10 3)) (newline)           ; 7
+(display (* 6 7)) (newline)            ; 42
+(display (+ -5 2)) (newline)           ; -3
+(display (* -4 -3)) (newline)          ; 12
+
+; Comparisons, including negatives (sign-extension)
+(display (< 2 5)) (newline)            ; #t
+(display (< -3 -1)) (newline)          ; #t
+(display (< -1 -3)) (newline)          ; #f
+(display (= 7 7)) (newline)            ; #t
+(display (= -4 -4)) (newline)          ; #t
+
+; null?
+(display (null? '())) (newline)        ; #t
+(display (null? '(1))) (newline)       ; #f
+(display (null? 5)) (newline)          ; #f
+
+; Overflow → bignum promotion (i48 max is 140737488355327)
+(display (* 1000000000 1000000000)) (newline)   ; 1000000000000000000
+(display (+ 140737488355327 1)) (newline)       ; 140737488355328
+
+; Non-fixnum operands → runtime fallback
+(display (+ 1.5 2.5)) (newline)        ; 4.0
+(display (< 1.5 2.5)) (newline)        ; #t
+(display (= 2.0 2)) (newline)          ; #t
+(display (+ 1/3 1/6)) (newline)        ; 1/2
+
+; Recursion that leans on the inline fast paths in a hot loop
+(define (fib n)
+  (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+(display (fib 20)) (newline)           ; 6765


### PR DESCRIPTION
Closes #1493. Part of the LLVM native backend performance epic (#1491), follow-up to the -O2 change (#1492).

## Problem

Inlined primitives emit a cross-module call per operation (`@kaappi_fixnum_add`, `@kaappi_car`, …) into the static archive `libkaappi_rt.a`. Plain `-O2` cannot inline across that boundary, so trivial arithmetic in a hot loop pays a real call every iteration.

## Why not LTO (the issue's primary proposal)

LTO is **infeasible on macOS**, the primary dev platform: Zig 0.16 cannot use LLD for Mach-O (`error: using LLD to link macho files is unsupported`) and `-flto` requires LLD, so both `zig build-lib -flto` and `zig cc -flto` fail on macOS (even compile-only, even with `-flld`). It works *only* when targeting Linux. Rather than ship a per-platform-inconsistent optimization that silently degrades on Mac, this PR takes the issue's **explicitly-sanctioned alternative**: emit the hottest primitives as inline IR — portable across all 5 targets (it is just text the emitter writes) and needing no cross-module inlining.

## What changed (`src/llvm_emit.zig` only — no build/link/flag changes)

- **`+ - * < = null?`** lower to inline fixnum fast paths with a runtime slow-path fallback (non-fixnum operands, or overflow past the i48 range → bignum promotion). Arithmetic uses `llvm.s{add,sub,mul}.with.overflow.i64`; `<`/`=` use `icmp`+`select`; `null?` is a pure nil comparison.
- All NaN-box constants are derived from `types.zig` at **emitter comptime** (`nanbox` struct) — no hand-transcribed magic numbers.
- **`car`/`cdr`/`cons` stay as direct specialized calls**: `Pair`/`Object` are auto-layout (non-`extern`) structs whose field offsets Zig does not guarantee, so heap layout is deliberately not encoded in hand-written IR, and `cons` allocates regardless.
- **Rooting elision (the larger win):** the inline path emitted a `kaappi_gc_push_root`/`pop_roots` call pair around every op to keep the first operand alive across the second's evaluation. That is pointless when the second operand cannot allocate. A conservative `nodeMayAllocate` predicate (only immediate constants and variable references are alloc-free) drops both calls for the common `(op var const)` / `(op var var)` shapes.

## Results

| benchmark | -O2 only | this PR | speedup |
|-----------|:---:|:---:|:---:|
| **fib(38)** | 1.45s | 0.44s | **3.30×** |

Inline arithmetic *alone* was only ~1.2×; the rooting-elision unlocked the 3.3×. Alloc-bound loops (cons/car/cdr-heavy) are unchanged, as expected.

## Verification

- **e2e 27/27** — new `native-inline-primitives.scm` diffs overflow→bignum, non-fixnum (flonum/rational), and sign-extended-negative paths against the interpreter
- **Unit suite 897/897** (10 new/updated emitter tests incl. rooting-elision assertions; also green under `-Dgc-stress=true`)
- **GC-safety:** native binaries stay correct under forced-collection `KAAPPI_GC_THRESHOLD=1`, including the `(+ (car lst) (allocating-call))` case where rooting must be *kept*
- `kaappi compile` end-to-end output identical to the interpreter

## Acceptance criteria

- [x] Hot arithmetic loops show reduced call overhead vs `-O2`-only (fib 3.30×)
- [x] `tests/e2e/run-e2e.sh` green (27/27)
- [x] Gated behind the IR-verify + e2e safety net (unchanged)
- [ ] ~LTO build path documented and wired in~ — LTO is infeasible on macOS (see above); the rationale is documented in `docs/dev/llvm-backend.md` and the inline-IR alternative delivered instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)