### PR TITLE
Abandon cross-heap mutexes on fiber death (#1458)

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -93,6 +93,16 @@ pub const Fiber = struct {
     /// accumulate duplicate ring entries; cleared when scheduleImpl consumes
     /// or discards the entry (#1477).
     queued: bool = false,
+    /// Mutexes this fiber currently owns (as `Value`s), maintained by
+    /// mutex-lock! (#1458). `abandonFiberMutexes` walks this on fiber death
+    /// instead of scanning a GC heap for owned mutexes — the mutex object may
+    /// live in *another* thread's heap (shared via a top-level global), where
+    /// a heap scan of the dying fiber's own heap would never find it. Only
+    /// ever mutated on this fiber's owning thread; traced by markFiberState so
+    /// a same-heap mutex held solely through this list stays alive (a foreign
+    /// mutex is skipped by markValue's owner check and kept alive by its own
+    /// heap's roots). Freed in freeObject's `.fiber` arm.
+    owned_mutexes: std.ArrayList(Value) = .empty,
 };
 
 pub const FiberScheduler = struct {
@@ -805,28 +815,37 @@ pub fn ensureScheduler(vm: *VM) VMError!struct { vm: *VM, sched: *FiberScheduler
 /// mid-turn, so a lock it held doesn't hang every other fiber waiting on it
 /// forever. Fiber 0 (main) is exempt at call sites: finishing or aborting
 /// one top-level form is not thread death, so its mutexes stay valid.
-pub fn abandonFiberMutexes(gc: *memory.GC, fiber: *Fiber, sched: ?*FiberScheduler) void {
+///
+/// Walks `fiber.owned_mutexes` (maintained by mutex-lock!) rather than
+/// scanning a GC heap for owned mutexes: a mutex shared across OS threads
+/// via a top-level global lives in whichever heap allocated it — typically
+/// the parent's, not the dying child's — so a scan of the child's own heap
+/// would never find it (#1458). The list is only ever mutated on `fiber`'s
+/// owning thread, and every call site invokes this on that same thread, so
+/// the walk/clear here races nothing.
+///
+/// The `m.locked and m.owner == fiber_val` guard is still required: the list
+/// may hold stale entries (a mutex unlocked by another thread, or re-locked
+/// by a different owner, is only pruned lazily on the next mutex-lock!), and
+/// abandoning one of those would corrupt a lock a live fiber legitimately
+/// holds.
+pub fn abandonFiberMutexes(fiber: *Fiber, sched: ?*FiberScheduler) void {
     const fiber_val = types.makePointer(@ptrCast(&fiber.header));
-    var lists = [_]?*types.Object{ gc.objects, gc.old_objects };
-    for (&lists) |*head| {
-        var obj = head.*;
-        while (obj) |o| : (obj = o.next) {
-            if (o.tag == .mutex) {
-                const m = o.as(types.Mutex);
-                if (@atomicLoad(bool, &m.locked, .acquire) and m.owner == fiber_val) {
-                    // Order matters: abandoned and owner must both be
-                    // published *before* the release-store below, so a
-                    // cross-thread acquirer that wins the locked CAS is
-                    // guaranteed to see them already updated (not stomp a
-                    // fresh owner write with VOID, or miss the abandonment).
-                    @atomicStore(bool, &m.abandoned, true, .release);
-                    m.owner = types.VOID;
-                    @atomicStore(bool, &m.locked, false, .release);
-                    if (sched) |s| s.wakeMutexWaiters(types.makePointer(@ptrCast(o)));
-                }
-            }
+    for (fiber.owned_mutexes.items) |m_val| {
+        const m = types.toMutex(m_val);
+        if (@atomicLoad(bool, &m.locked, .acquire) and m.owner == fiber_val) {
+            // Order matters: abandoned and owner must both be published
+            // *before* the release-store below, so a cross-thread acquirer
+            // that wins the locked CAS is guaranteed to see them already
+            // updated (not stomp a fresh owner write with VOID, or miss the
+            // abandonment).
+            @atomicStore(bool, &m.abandoned, true, .release);
+            m.owner = types.VOID;
+            @atomicStore(bool, &m.locked, false, .release);
+            if (sched) |s| s.wakeMutexWaiters(m_val);
         }
     }
+    fiber.owned_mutexes.clearRetainingCapacity();
 }
 
 /// Wait for `target` fiber to finish. Shared by fiber-join and
@@ -1072,7 +1091,7 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
             // valid. retireSlot returns the vacated slot to the free list
             // (a no-op for slot 0), keeping addFiber's fast path fed.
             sched.retireSlot(fiber, .errored);
-            if (next_idx != 0) abandonFiberMutexes(vm.gc, fiber, sched);
+            if (next_idx != 0) abandonFiberMutexes(fiber, sched);
             try sched.saveCurrentFiber();
             sched.wakeWaiters(fiber);
             continue;
@@ -1080,7 +1099,7 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
         sched.retireSlot(fiber, .completed);
         fiber.result = result;
         vm.gc.writeBarrier(&fiber.header, result);
-        if (next_idx != 0) abandonFiberMutexes(vm.gc, fiber, sched);
+        if (next_idx != 0) abandonFiberMutexes(fiber, sched);
         try sched.saveCurrentFiber();
         sched.wakeWaiters(fiber);
     }
@@ -1124,4 +1143,9 @@ pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {
     if (fiber.current_exception) |exc| gc.markValue(exc);
     gc.markValue(fiber.continuation_value);
     gc.markValue(fiber.io_buffer);
+
+    // Keep held mutexes alive while the fiber owns them (#1458). markValue
+    // skips any mutex owned by another GC, so a foreign (parent-heap) mutex
+    // this child locked is a no-op here — its own heap's roots keep it alive.
+    for (fiber.owned_mutexes.items) |m_val| gc.markValue(m_val);
 }

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -1051,6 +1051,7 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
         .fiber => {
             const fiber = obj.as(@import("fiber.zig").Fiber);
             fiber.param_overrides.deinit();
+            fiber.owned_mutexes.deinit(gc.allocator);
             gc.allocator.free(fiber.frames);
             gc.allocator.free(fiber.registers);
             poisonAndDestroy(gc, @import("fiber.zig").Fiber, fiber);

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -452,7 +452,7 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
     };
 
     const result = child_vm.callWithArgs(child_thunk, &.{}) catch {
-        if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
+        if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(cf, child_vm.scheduler);
         // Built on this (owning) thread, mirroring thread-start!'s thunk
         // copy: this is the only place a channel raised in the exception
         // can legally promote (gc_instance == child_gc here, not the
@@ -472,7 +472,7 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
         return;
     };
 
-    if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(child_gc, cf, child_vm.scheduler);
+    if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(cf, child_vm.scheduler);
 
     // Store the result in child_resources (not on the fiber) so the parent
     // GC never traverses a child-heap pointer (Race C) -- and, since Phase
@@ -607,7 +607,14 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
     // Atomic: for OS threads the child VM polls this flag concurrently.
     @atomicStore(bool, &fiber.terminated, true, .monotonic);
 
-    if (memory.gc_instance) |gc| fiber_mod.abandonFiberMutexes(gc, fiber, ctx.sched);
+    // Abandon a *local* fiber's held mutexes here: it lives in this
+    // scheduler on this thread, so walking its owned-mutexes list is
+    // race-free, and it will never run again to abandon them itself. An OS
+    // thread instead abandons its own mutexes when it observes `terminated`
+    // and unwinds (threadEntryFn's self-abandon) — its owned-mutexes list is
+    // maintained on *its* thread, so the parent must not touch it from here
+    // (#1458).
+    if (fiber.os_thread == null) fiber_mod.abandonFiberMutexes(fiber, ctx.sched);
 
     const status = @atomicLoad(fiber_mod.FiberStatus, &fiber.status, .acquire);
     if (status != .completed and status != .errored) {
@@ -940,6 +947,43 @@ fn tryClaimAbandoned(m: *types.Mutex) bool {
     return @cmpxchgStrong(bool, &m.abandoned, true, false, .acq_rel, .acquire) == null;
 }
 
+// Records `m_val` on the fiber that just took ownership so
+// abandonFiberMutexes can release it if the fiber dies still holding it
+// (#1458) — including a mutex from another thread's heap, which the old
+// heap-scan could never find. Only ever touches `fiber`'s own list, and is
+// only called with the current fiber (the acquirer), so it never races
+// another thread mutating this list.
+//
+// Before appending it first drops entries whose mutex is no longer locked:
+// an unlocked mutex is never owned, so this can't drop one we'd need to
+// abandon, and it keeps the list bounded to currently-held mutexes even
+// when a lock/unlock pair repeats or another thread unlocked one of ours.
+// The `== m_val` pass dedups: a mutex we still hold (unlock-then-relock with
+// no intervening prune) survives the sweep, so appending again would double
+// it.
+fn trackOwnedMutex(fiber: *fiber_mod.Fiber, m_val: Value) void {
+    const gc = memory.gc_instance orelse return;
+    var already = false;
+    var i: usize = 0;
+    while (i < fiber.owned_mutexes.items.len) {
+        const v = fiber.owned_mutexes.items[i];
+        if (v == m_val) {
+            already = true;
+            i += 1;
+        } else if (!@atomicLoad(bool, &types.toMutex(v).locked, .acquire)) {
+            _ = fiber.owned_mutexes.swapRemove(i);
+        } else {
+            i += 1;
+        }
+    }
+    if (already) return;
+    // Best-effort: an OOM here only means this one mutex won't be abandoned
+    // if the fiber dies holding it (reverting to the pre-#1458 gap for it).
+    // The lock itself already succeeded, so failing the primitive now would
+    // be worse — the caller would believe the lock failed while it is held.
+    fiber.owned_mutexes.append(gc.allocator, m_val) catch {};
+}
+
 fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     if (!types.isMutex(args[0]))
         return primitives.typeError("mutex-lock!", "mutex", args[0]);
@@ -948,8 +992,17 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
 
     if (tryClaimMutex(m)) {
         const ctx = try ensureScheduler();
-        m.owner = resolveMutexOwner(args, if (ctx.vm.current_fiber) |cf| types.makePointer(@ptrCast(&cf.header)) else types.VOID);
-        if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
+        if (ctx.vm.current_fiber) |cf| {
+            m.owner = resolveMutexOwner(args, types.makePointer(@ptrCast(&cf.header)));
+            if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
+            // Only track when *this* fiber became the owner: an explicit
+            // owner arg naming another fiber (possibly on another thread)
+            // must not append to this fiber's list.
+            if (m.owner == types.makePointer(@ptrCast(&cf.header))) trackOwnedMutex(cf, args[0]);
+        } else {
+            m.owner = resolveMutexOwner(args, types.VOID);
+            if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
+        }
         if (tryClaimAbandoned(m)) return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
         return types.TRUE;
     }
@@ -1039,6 +1092,8 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     else
         types.makePointer(@ptrCast(&me.header));
     if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
+    // Track only when `me` itself became the owner (see the fast path).
+    if (m.owner == types.makePointer(@ptrCast(&me.header))) trackOwnedMutex(me, mutex_val);
 
     if (tryClaimAbandoned(m)) return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
     return types.TRUE;

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -119,21 +119,32 @@ test "abandonFiberMutexes marks owned mutex abandoned" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
+    // Root across allocations: abandonFiberMutexes now dereferences the
+    // fiber's owned-mutexes list, so under -Dgc-stress=true the fiber and
+    // mutex must survive allocMutex's collection.
     const fiber = try gc.allocFiber(types.VOID, 0);
-    const fiber_val = types.makePointer(@ptrCast(&fiber.header));
-    const m_val = try gc.allocMutex(types.VOID);
+    var fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    gc.pushRoot(&fiber_val);
+    defer gc.popRoot();
+    var m_val = try gc.allocMutex(types.VOID);
+    gc.pushRoot(&m_val);
+    defer gc.popRoot();
     const m = types.toMutex(m_val);
 
     m.locked = true;
     m.owner = fiber_val;
+    try fiber.owned_mutexes.append(gc.allocator, m_val);
 
-    fiber_mod.abandonFiberMutexes(&gc, fiber, null);
+    fiber_mod.abandonFiberMutexes(fiber, null);
 
     try std.testing.expect(m.abandoned);
     try std.testing.expect(!m.locked);
     try std.testing.expectEqual(types.VOID, m.owner);
 }
 
+// A stale list entry — a mutex still locked but owned by a *different* fiber
+// (it was re-acquired after this fiber released it) — must be left alone by
+// the defensive `m.owner == fiber_val` guard, not stomped.
 test "abandonFiberMutexes skips mutex owned by different fiber" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -141,21 +152,32 @@ test "abandonFiberMutexes skips mutex owned by different fiber" {
     defer vm.deinit();
 
     const fiber_a = try gc.allocFiber(types.VOID, 0);
+    var fiber_a_val = types.makePointer(@ptrCast(&fiber_a.header));
+    gc.pushRoot(&fiber_a_val);
+    defer gc.popRoot();
     const fiber_b = try gc.allocFiber(types.VOID, 1);
-    const fiber_a_val = types.makePointer(@ptrCast(&fiber_a.header));
-    const m_val = try gc.allocMutex(types.VOID);
+    var fiber_b_val = types.makePointer(@ptrCast(&fiber_b.header));
+    gc.pushRoot(&fiber_b_val);
+    defer gc.popRoot();
+    var m_val = try gc.allocMutex(types.VOID);
+    gc.pushRoot(&m_val);
+    defer gc.popRoot();
     const m = types.toMutex(m_val);
 
     m.locked = true;
     m.owner = fiber_a_val;
+    // Stale entry lingering in fiber_b's list (owner is now fiber_a).
+    try fiber_b.owned_mutexes.append(gc.allocator, m_val);
 
-    fiber_mod.abandonFiberMutexes(&gc, fiber_b, null);
+    fiber_mod.abandonFiberMutexes(fiber_b, null);
 
     try std.testing.expect(!m.abandoned);
     try std.testing.expect(m.locked);
     try std.testing.expectEqual(fiber_a_val, m.owner);
 }
 
+// A stale list entry for a mutex this fiber has since unlocked must be
+// skipped by the `m.locked` guard.
 test "abandonFiberMutexes skips unlocked mutex" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -163,13 +185,19 @@ test "abandonFiberMutexes skips unlocked mutex" {
     defer vm.deinit();
 
     const fiber = try gc.allocFiber(types.VOID, 0);
-    const m_val = try gc.allocMutex(types.VOID);
+    var fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    gc.pushRoot(&fiber_val);
+    defer gc.popRoot();
+    var m_val = try gc.allocMutex(types.VOID);
+    gc.pushRoot(&m_val);
+    defer gc.popRoot();
     const m = types.toMutex(m_val);
 
     m.locked = false;
     m.owner = types.VOID;
+    try fiber.owned_mutexes.append(gc.allocator, m_val);
 
-    fiber_mod.abandonFiberMutexes(&gc, fiber, null);
+    fiber_mod.abandonFiberMutexes(fiber, null);
 
     try std.testing.expect(!m.abandoned);
 }
@@ -204,14 +232,61 @@ test "abandonFiberMutexes handles multiple mutexes" {
     m2.owner = types.VOID;
     m3.locked = true;
     m3.owner = fiber_val;
+    // m2 is a stale entry (unlocked) — the defensive guard must skip it while
+    // still abandoning the two genuinely-held mutexes around it.
+    try fiber.owned_mutexes.append(gc.allocator, m1_val);
+    try fiber.owned_mutexes.append(gc.allocator, m2_val);
+    try fiber.owned_mutexes.append(gc.allocator, m3_val);
 
-    fiber_mod.abandonFiberMutexes(&gc, fiber, null);
+    fiber_mod.abandonFiberMutexes(fiber, null);
 
     try std.testing.expect(m1.abandoned);
     try std.testing.expect(!m1.locked);
     try std.testing.expect(!m2.abandoned);
     try std.testing.expect(m3.abandoned);
     try std.testing.expect(!m3.locked);
+}
+
+// Core #1458 fix: a mutex living in *another* thread's heap (the shared,
+// top-level-global case) is abandoned when a fiber that locked it dies,
+// even though it is not on the dying fiber's own GC object lists. The old
+// heap-scanning abandonFiberMutexes scanned only the passed GC's heap and
+// so never found a parent-heap mutex from a child fiber's death; walking the
+// fiber's owned-mutexes list finds it regardless of which heap owns it.
+test "abandonFiberMutexes abandons a mutex from another GC heap (#1458)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Child heap shares the parent's symbol table, like a real SRFI-18 thread.
+    var child_gc = memory.GC.initForThread(std.testing.allocator, &gc);
+    defer child_gc.deinit();
+
+    // Mutex lives in the parent heap; the fiber that holds it in the child.
+    var m_val = try gc.allocMutex(types.VOID);
+    gc.pushRoot(&m_val);
+    defer gc.popRoot();
+    const m = types.toMutex(m_val);
+
+    const fiber = try child_gc.allocFiber(types.VOID, 0);
+    var fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    child_gc.pushRoot(&fiber_val);
+    defer child_gc.popRoot();
+
+    m.locked = true;
+    m.owner = fiber_val;
+    try fiber.owned_mutexes.append(child_gc.allocator, m_val);
+
+    // Sanity: the parent-heap mutex is not on the child heap's object lists,
+    // so the old heap-scan of child_gc would have missed it entirely.
+    try std.testing.expect(m.header.owner != child_gc.id);
+
+    fiber_mod.abandonFiberMutexes(fiber, null);
+
+    try std.testing.expect(m.abandoned);
+    try std.testing.expect(!m.locked);
+    try std.testing.expectEqual(types.VOID, m.owner);
 }
 
 test "thread-terminate! on current thread abandons held mutex" {
@@ -261,7 +336,7 @@ test "mutex-lock! on abandoned mutex raises abandoned-mutex-exception" {
     const m_val = try vm.eval("m");
     const m = types.toMutex(m_val);
     const sched_fiber = vm.current_fiber.?;
-    fiber_mod.abandonFiberMutexes(&gc, sched_fiber, vm.scheduler);
+    fiber_mod.abandonFiberMutexes(sched_fiber, vm.scheduler);
 
     try std.testing.expect(m.abandoned);
 

--- a/tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm
+++ b/tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm
@@ -1,0 +1,91 @@
+;; Regression test for #1458: a child OS thread that dies while holding a
+;; mutex allocated in the *parent's* heap (shared via a top-level global)
+;; must abandon that mutex.
+;;
+;; Each SRFI-18 OS thread has its own GC heap. A mutex created before any
+;; thread is spawned lives in the parent heap. The old abandonFiberMutexes
+;; scanned only the dying child's own heap for mutexes it owned, so it never
+;; found the parent-heap mutex: mutex-state stayed 'not-abandoned, m.owner
+;; kept dangling at the (soon-freed) dead child fiber, and a subsequent
+;; mutex-lock! from the parent raised the generic deadlock error or hung
+;; instead of abandoned-mutex-exception. Tracking held mutexes on the fiber
+;; itself lets the child abandon the mutex regardless of which heap owns it.
+;;
+;; The shared mutexes are top-level globals and the thunks reference them by
+;; name: sync primitives are deep-copy-rejected when *captured* by a thread
+;; thunk's closure, so globals (shared by reference across threads) are the
+;; only supported way to share one — see srfi18-cross-thread-wait.scm.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (check-true name val)
+  (if val
+      (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1)) (display "FAIL: ") (display name) (newline))))
+
+;; Spawn `thunk` in a child thread and join it, swallowing the uncaught
+;; exception a dying thunk surfaces. Joining guarantees the child fully
+;; finished — i.e. it already ran its self-abandon — before we inspect the
+;; mutex. Wrapped so the top-level call's value is discarded (no stray print).
+(define (spawn-and-join thunk)
+  (let ((t (make-thread thunk)))
+    (thread-start! t)
+    (guard (e (#t #t)) (thread-join! t))
+    (if #f #f)))
+
+(define m (make-mutex 'shared))
+(define m2 (make-mutex 'shared-2))
+
+(define (die-holding-m) (mutex-lock! m) (error "boom"))
+(define (die-holding-m2) (mutex-lock! m2) (error "boom"))
+
+;; ---- child errors out while holding a parent-heap mutex ----
+(let ()
+  (spawn-and-join die-holding-m)
+  (check "mutex-state is 'abandoned after child dies holding it"
+         (mutex-state m) 'abandoned)
+  ;; Per SRFI-18, re-locking an abandoned mutex raises
+  ;; abandoned-mutex-exception (and leaves the mutex held by this thread).
+  (check-true "mutex-lock! on the abandoned mutex raises abandoned-mutex-exception"
+    (guard (e ((abandoned-mutex-exception? e) #t) (#t #f))
+      (mutex-lock! m)
+      #f)))
+
+;; ---- a second, independently shared mutex is abandoned the same way ----
+;; Guards against a fix that only works for the first mutex a thread touches.
+(let ()
+  (spawn-and-join die-holding-m2)
+  (check "second parent-heap mutex also abandoned across heaps"
+         (mutex-state m2) 'abandoned))
+
+;; ---- thread-terminate! on a thread holding a parent-heap mutex ----
+;; thread-terminate! on an OS thread does NOT abandon the mutex from the
+;; parent (its owned-mutexes list is maintained on the child's own thread);
+;; the child abandons it itself when it observes the terminate flag and
+;; unwinds. Joining after terminating waits for that to happen.
+(define mt (make-mutex 'terminated))
+(define (hold-mt-forever) (mutex-lock! mt) (let loop () (loop)))
+(let ((t (make-thread hold-mt-forever)))
+  (thread-start! t)
+  (thread-sleep! 0.1)                   ; let it acquire mt
+  (thread-terminate! t)
+  (guard (e (#t #t)) (thread-join! t))
+  (check "parent-heap mutex abandoned after thread-terminate!"
+         (mutex-state mt) 'abandoned))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

Fixes #1458. A child OS thread that died while holding a mutex allocated in the **parent's heap** (shared via a top-level global) never abandoned it.

`abandonFiberMutexes` located a dying fiber's held mutexes by **scanning that fiber's own GC heap**. But each SRFI-18 OS thread has its own heap, and a mutex created before any thread spawns lives in the parent's heap. Scanning the *child's* heap never found it, so:

- `mutex-state` stayed `'not-abandoned`
- `m.owner` kept dangling at the (soon-freed) dead child fiber
- a subsequent `mutex-lock!` from another thread hung or raised the generic deadlock error instead of `abandoned-mutex-exception`

This was flagged as a pre-existing gap during the #1455 review.

## Approach

Track held mutexes on the fiber itself (the issue's preferred direction) so abandonment no longer depends on which heap owns the mutex object.

- **`Fiber.owned_mutexes: ArrayList(Value)`** — maintained by `mutex-lock!`. Entries are pruned-on-lock (drop no-longer-locked) and deduped, rather than removed at unlock. That bounds the list **without touching the unlock path**, which deliberately avoids the cross-thread list-mutation race a remove-on-cross-thread-unlock would hit. The defensive `m.locked and m.owner == fiber` guard still skips stale entries.
- **`abandonFiberMutexes(fiber, sched)`** walks that list. It is only ever mutated and walked on the fiber's own thread, so it races nothing.
- **`thread-terminate!`** abandons a *local* fiber's mutexes in place (same thread) and lets an *OS-thread* target self-abandon when it observes the terminate flag and unwinds — its held mutexes are on the child's own thread.
- **GC**: `markFiberState` keeps held mutexes alive (foreign ones skipped by `markValue`'s owner check; fibers are always scheduler roots so no write barrier is needed); `freeObject` frees the list.

## Tests

- `tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm` — end-to-end: child errors holding a shared mutex → `'abandoned` + `abandoned-mutex-exception`; a second independent mutex; and the `thread-terminate!` path. Verified it **fails against the pre-fix binary** (returned the dead fiber from `mutex-state`, the exact issue symptom) and passes after.
- 5 unit tests in `src/tests_srfi18.zig`, including a new one that allocates the mutex in a *parent* GC and the fiber in a *child* GC.

## Verification

- Full unit suite: pass
- Full Scheme suite: **453 pass, 0 fail** · R7RS: **1395 pass, 0 fail**
- SRFI-18 / mutex / abandon filters under `-Dgc-stress=true`: pass
- `zig fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)