### PR TITLE
KEP-0002 Phase 7 gate-campaign harness + lever D (#1472)

### DIFF
--- a/benchmarks/gate/README.md
+++ b/benchmarks/gate/README.md
@@ -1,0 +1,210 @@
+# KEP-0002 Phase 7 gate campaign (kaappi#1472)
+
+This directory holds the `parallel-map` gate-campaign harness: the half of
+Phase 7 that produces the **copy + reassembly overhead `share`** dataset the
+KEP-0003 acceptance gate (kaappi#1474) consumes. The other Phase 7 half — the
+P3 A/B/C/D envelope micro-benchmark — lives in `src/bench_channel.zig` and is
+decided independently (see `docs/dev/kep-0002-phase7-envelope-benchmarks.md`).
+
+**The pre-registered, frozen protocol is normative:**
+[keps `research/benchmarks/README.md`](https://github.com/kaappi/keps/blob/main/research/benchmarks/README.md).
+Everything here implements it; where this harness adds an operational
+definition the protocol left open, it is called out below and marked
+**PRE-FREEZE** — legal to change only until data collection for the frozen run
+starts. This harness has **not** started that frozen run; it is built and
+locally piloted so the protocol implementation can be reviewed first.
+
+## Files
+
+| File | What it is |
+|------|-----------|
+| `gate-harness.scm` | Runs ONE cell — `(workload, size, workers, lever)` — for warmup + measured iterations, printing one machine-readable `ITER` line per measured iteration. |
+| `run-gate.py` | Kalibera–Jones driver: launches the invocation level (fresh processes), randomizes order + env size, aggregates with bootstrap CIs, emits the §6 CSV + a table. |
+
+The counters and elision levers live in the interpreter:
+`src/channel_instrument.zig` (counters + lever flag), hooked into
+`src/shared_channel.zig` (the real `send`/`receive` path), exposed to Scheme as
+`%chan-instr-*` / `%elision-lever-set!` (`src/primitives_parallel.zig`, tagged
+`.internal`).
+
+## Build (required)
+
+The binary **must** be built with the instrumentation compiled in, or every
+copy counter reads 0 and the lever flag is inert (protocol §3 keeps them out of
+the shipped default):
+
+```
+zig build -Dchannel-instrument=true
+```
+
+`run-gate.py` warns if it detects all-zero copy counters (wrong binary).
+
+## Workloads (protocol §1)
+
+Three in-place-shaped (the gate counts these), three read-only fan-out, two
+controls. "Size" is always the envelope-side bytes of the dominant payload.
+
+| Id | Payload | Shape realized here |
+|----|---------|---------------------|
+| `ip-band` | RGBA image, `bytevector` of `size` bytes (W=256, H=size/1024) | each worker renders a disjoint row band (per-pixel arithmetic) → fresh bytevector; parent `bytevector-copy!`s into the image. Result copy dominates. |
+| `ip-map` | vector of `size/8` NaN-boxed flonums | task carries a pre-sliced chunk (copied in); worker computes `2.5·x+1`; parent `vector-copy!`s the transformed chunk into place. |
+| `ip-matmul` | two M×M f64 matrices, `M=isqrt(size/16)` | tasks carry **A and B whole** (fan-in copy) + a row-block spec; worker computes a disjoint C row block; parent assembles. |
+| `fo-digest` | `bytevector` of `size` bytes | task captures the **whole** payload (fan-out copy to every worker); worker checksums all of it; result is a fixnum pair. |
+| `fo-tree` | balanced binary tree of `size/40` nodes, symbol tags | task captures the **whole** tree; worker counts nodes tagged `gamma`; result a fixnum. Symbol-heavy (doubles as the §1 symbol-table probe). |
+| `fo-slice` | vector of `size/8` flonums | task captures the **whole** vector (the over-copying idiom) but sums only its own index range; result a flonum. |
+| `c-empty` | — | pool round trip, empty task → reply. Control-plane floor. |
+| `s:<id>` | — | single-thread, no-pool serial baseline `S` of each kernel. |
+
+NaN-boxed flonums: Kaappi has no flat f64 storage pre-KEP-0003, so a flonum
+vector of `size` bytes is `size/8` inline Values, and copying it walks all of
+them — that walk tax is deliberately part of what is measured (§1).
+
+### Self-containment rule
+
+Every worker **task thunk** captures only fixnums/flonums/payload objects and
+calls only built-in primitives — never a top-level procedure defined in the
+harness. A closure that crosses a worker boundary and then calls a
+separately-defined procedure can hang (kaappi#1520). Serial baselines never
+cross a thread, so they are free to call shared kernels.
+
+## Metrics (protocol §3)
+
+```
+share = (T_submit_copy + T_result_copy + T_reassembly) / E
+```
+
+- `T_submit_copy` — the parent's envelope build (`Envelope.create` → deepCopy)
+  on the send path, from the threadlocal counter. Worker-side builds land in a
+  worker threadlocal that is never read (§3's parent-side attribution).
+- `T_result_copy` — the parent's deepCopy of a result out of a reply envelope.
+- `T_reassembly` — bracketed explicitly around each parent-side
+  `bytevector-copy!` / `vector-copy!` into the output object.
+- `E` — wall time from the first `pool-submit` to the last reassembly copy;
+  pool creation/teardown and payload construction are excluded (per-cell setup,
+  amortized by reusing one pool + payload across a cell's iterations).
+- `S` — the `s:<id>` serial-kernel time; `speedup = S / E` (reported, not
+  gating).
+
+Secondary (non-gating): child peak RSS (from `wait4`), peak live envelope bytes.
+
+## Running
+
+Pilot (validates the harness; 5 invocations × 20 iterations by default):
+
+```
+zig build -Dchannel-instrument=true
+python3 benchmarks/gate/run-gate.py \
+    --bin zig-out/bin/kaappi --mode pilot \
+    --machine macos-aarch64 --cores 12 \
+    --sizes 65536,1048576 --workers 8 --levers none,c \
+    --out gate-pilot.csv
+```
+
+Full frozen run (per machine; floors 20 invocations × 10 iterations — set the
+counts from the pilot's CI half-widths to hit the protocol's ±2% target):
+
+```
+python3 benchmarks/gate/run-gate.py \
+    --bin zig-out/bin/kaappi --mode full \
+    --machine macos-aarch64 --cores 12 \
+    --sizes 65536,1048576,8388608,67108864 \
+    --workers 1,2,4,8,24 --levers none,cd \
+    --out gate-macos.csv
+```
+
+The driver shuffles the whole (cell × invocation) launch schedule under `--seed`
+and exports a random-length `KAAPPI_GATE_PAD` env var per process (§4.3), leaves
+ASLR on, and selects the lever at runtime on one binary (§4.4).
+
+## Output (protocol §6)
+
+`--out` is the §6 CSV:
+
+```
+machine, workload, size_bytes, workers, levers, invocations, iterations,
+E_mean_ms, E_ci95_lo, E_ci95_hi, share_mean, share_ci95_lo, share_ci95_hi,
+S_ms, speedup, rss_peak_mib, envelope_peak_mib
+```
+
+`share_*` are in **percent** (what the §5 rules and the kaappi#1474 worksheet
+compare against 25 % / 10 %). CIs are 95 % bootstrap percentiles over invocation
+means. Drop the `C+D` and `none` rows into
+`docs/dev/kep-0003-acceptance-gate-worksheet.md` and the classification reads
+out mechanically.
+
+## Local pilot (VALIDATION ONLY — not gate data)
+
+A bring-up pilot on macOS aarch64 (M-series, 12 cores), `w = 8`, levers
+`none`/`c` (not the gate's `C+D` — lever D is unimplemented), sizes 64 KiB and
+1 MiB (not up to 64 MiB), 3 invocations × 5 iterations (not the frozen
+20 × 10). **These numbers judge the harness, not the design; they must not be
+cited as the gate dataset.** They demonstrate the harness produces sensible,
+well-differentiated, statistically-summarized `share` values:
+
+| workload | share% @64 KiB | share% @1 MiB | shape |
+|----------|---------------:|--------------:|-------|
+| ip-band   | ~7  | ~4  | in-place, result copy modest at these sizes |
+| ip-map    | ~26 | ~22 | copy-bound (chunk in + out + reassemble) |
+| ip-matmul | ~2.6| ~0.7| compute-dominated (interpreted O(M³)) |
+| fo-digest | ~0.4| ~0.3| compute-dominated (whole-payload checksum) |
+| fo-tree   | ~67 | ~70 | symbol-heavy fan-out over-copy dominates |
+| fo-slice  | ~48 | ~55 | whole-vector fan-out over-copy dominates |
+
+Speedups came out sane (IP-* ≤ 8× with 8 workers; FO-* < 1× — the fan-out
+idiom does redundant whole-payload work per worker, by design). The pilot also
+exercised the driver's timeout handling: ~8 % of invocations hit the
+kaappi#1489 hang and were recorded as `TIMEOUT` failures (see limitation 2).
+
+## Levers (protocol §2)
+
+- `none` — per-message envelopes exactly as `shared_channel.zig` ships.
+- `c` — `none` + immediates (fixnum/boolean/char/flonum/nil) skip the envelope
+  heap. Implemented.
+- `cd` — `c` + a refcounted immutable side-heap for large bytevectors/strings.
+  **Not yet implemented in the real path** — a follow-up wires it behind this
+  flag. Until then `--levers cd` selects the `c` path. **The gate cannot be
+  evaluated until lever D exists** (§2): the gate cells are levers `C+D`.
+
+## Known limitations & PRE-FREEZE findings
+
+These surfaced during harness bring-up and must be resolved or explicitly
+adopted **before** the frozen run starts (once it starts, the protocol freezes):
+
+1. **Lever D is not in the real path yet.** The gate's cells are `C+D`; it is a
+   hard blocker for evaluating the gate (§2). Follow-up PR.
+
+2. **Intermittent pool hang (kaappi#1489).** The cross-thread wakeup path can
+   lose a wakeup and hang, at any submission count (probability grows with
+   count). The chunked idiom here uses only `w` tasks per iteration, so it is
+   rare, but it *does* occur. The driver bounds every invocation with
+   `--timeout` and records a `TIMEOUT` as a failed invocation (excluded, warned)
+   — a hang is not a "slow invocation is data" case. A clean frozen run wants
+   kaappi#1489 fixed first, or a documented retry policy.
+
+3. **FO-TREE uses vector nodes, not records.** §1 specifies
+   `define-record-type` nodes. Records cannot cross a Kaappi channel and remain
+   usable: `deepCopy` mints a fresh `RecordType` per envelope, so a copied
+   instance no longer matches the top-level record type an accessor closes over
+   (record-type identity is not interned the way symbols are). Nodes are 4-slot
+   vectors `#(left right tag count)` here — same shape, same symbol-heaviness.
+   Either adopt this deviation in a protocol PR, or preserve record-type
+   identity across `deepCopy`, before the frozen run.
+
+4. **IP-MATMUL compute cost.** The kernel is interpreted O(M³); at 64 MiB
+   (M=2048) that is ~8.6 G multiply-adds and dominates wall time, biasing
+   `ip-matmul`'s `share` down (honestly, but extremely). Confirm the top matmul
+   size is acceptable — or cap it — before freezing.
+
+5. **Exception-crossing fragility.** A worker task that *raises* sends the
+   condition back through the reply channel (`guard` in `parallel.sld`);
+   re-raising a cross-thread-copied error object was observed to panic
+   ("incorrect alignment") in one bring-up case. Well-formed workloads never
+   raise, so it does not affect measurement, but it is a latent robustness bug
+   worth a separate issue.
+
+## What is deferred
+
+The frozen §4 collection on **both** reference machines (macOS aarch64 + Linux
+x86_64, ≥ 8 physical cores), the A/B/C/D + gate worksheet fill-in, and the
+KEP-0002 UQ 1 amendment are the campaign's remaining operational steps, to run
+once lever D lands and the harness is reviewed.

--- a/benchmarks/gate/README.md
+++ b/benchmarks/gate/README.md
@@ -160,18 +160,37 @@ kaappi#1489 hang and were recorded as `TIMEOUT` failures (see limitation 2).
 - `none` — per-message envelopes exactly as `shared_channel.zig` ships.
 - `c` — `none` + immediates (fixnum/boolean/char/flonum/nil) skip the envelope
   heap. Implemented.
-- `cd` — `c` + a refcounted immutable side-heap for large bytevectors/strings.
-  **Not yet implemented in the real path** — a follow-up wires it behind this
-  flag. Until then `--levers cd` selects the `c` path. **The gate cannot be
-  evaluated until lever D exists** (§2): the gate cells are levers `C+D`.
+- `cd` — `c` + a refcounted immutable side-heap for large **bytevectors**
+  (kaappi#1472 lever D), implemented in the real path. A bytevector ≥ 4 KiB
+  crossing a channel is snapshotted once into a `SharedBuffer`
+  (`src/shared_buffer.zig`) and shared by refcount: zero-copy on receive,
+  copy-on-write on mutation. This is the lever the gate's `C+D` cells require
+  (§2). Two scope points to confirm before the frozen run:
+  - **Bytevectors only.** Strings are a follow-up; flonum *vectors*
+    (IP-MAP/IP-MATMUL/FO-SLICE) and the record/vector tree (FO-TREE) are
+    byte-opaque, so D does not apply to them — that "walk tax" is exactly the
+    pre-KEP-0003 reality §1 measures, and is what flat f64 storage (KEP-0003)
+    would address. So at `C+D`, D helps the bytevector workloads (IP-BAND,
+    FO-DIGEST) and correctly leaves the vector workloads at their `none` share.
+  - **No source promotion.** D elides the zero-copy *receive* of a distinct
+    payload and re-aliases an already-backed payload, but does not promote a
+    plain *source* bytevector to shared on first send — so a fan-out of the same
+    plain bytevector still snapshots per task envelope. This affects only
+    bytevector fan-out (FO-DIGEST), which is compute-dominated (share < 1 %), so
+    it does not change the gate classification. Add source promotion only if a
+    bytevector fan-out workload ever proves copy-bound.
 
 ## Known limitations & PRE-FREEZE findings
 
 These surfaced during harness bring-up and must be resolved or explicitly
 adopted **before** the frozen run starts (once it starts, the protocol freezes):
 
-1. **Lever D is not in the real path yet.** The gate's cells are `C+D`; it is a
-   hard blocker for evaluating the gate (§2). Follow-up PR.
+1. **Lever D scope (bytevectors; no source promotion; strings deferred).**
+   Lever D is implemented in the real path (see the Levers section), but two
+   scoping decisions — bytevectors only, and no plain-source promotion for
+   fan-out — should be explicitly adopted (or closed) before the frozen run.
+   Neither changes the gate classification (the only affected workload,
+   FO-DIGEST fan-out, is compute-dominated), but both are protocol-visible.
 
 2. **Intermittent pool hang (kaappi#1489).** The cross-thread wakeup path can
    lose a wakeup and hang, at any submission count (probability grows with
@@ -204,7 +223,8 @@ adopted **before** the frozen run starts (once it starts, the protocol freezes):
 
 ## What is deferred
 
-The frozen §4 collection on **both** reference machines (macOS aarch64 + Linux
-x86_64, ≥ 8 physical cores), the A/B/C/D + gate worksheet fill-in, and the
-KEP-0002 UQ 1 amendment are the campaign's remaining operational steps, to run
-once lever D lands and the harness is reviewed.
+Lever D has now landed, so the gate's `C+D` cells are runnable. The frozen §4
+collection on **both** reference machines (macOS aarch64 + Linux x86_64, ≥ 8
+physical cores), the gate worksheet fill-in, and the KEP-0002 UQ 1 amendment are
+the campaign's remaining operational steps, to run once the harness is reviewed
+(ideally after kaappi#1489 is fixed — see limitation 2).

--- a/benchmarks/gate/gate-harness.scm
+++ b/benchmarks/gate/gate-harness.scm
@@ -1,0 +1,506 @@
+;; KEP-0002 Phase 7 gate-campaign harness (kaappi#1472).
+;;
+;; Runs ONE benchmark cell -- (workload, size, workers, lever) -- for a given
+;; number of warmup + measured iterations, printing one machine-readable line
+;; per measured iteration for the Kalibera-Jones driver (run-gate.py) to
+;; aggregate. The frozen protocol is keps research/benchmarks/README.md; this
+;; file realizes its §1 workloads and §3 metrics.
+;;
+;; Usage:
+;;   kaappi gate-harness.scm <workload> <size-bytes> <workers> <lever> <warmup> <iters>
+;;
+;;   workload : ip-band ip-map ip-matmul fo-digest fo-tree fo-slice c-empty
+;;              | s:ip-band s:ip-map s:ip-matmul s:fo-digest s:fo-tree s:fo-slice
+;;              (an "s:" prefix runs the single-thread, no-pool serial baseline S)
+;;   lever    : none | c | cd   (envelope elision lever; §2)
+;;
+;; Output, one per measured iteration:
+;;   ITER <workload> <size> <workers> <lever> <iter> \
+;;        <e_ns> <submit_ns> <result_ns> <reassembly_ns> <peak_env_bytes> <checksum>
+;;
+;; DESIGN NOTES
+;;
+;;  * The §1 workloads are "in-place-shaped" (IP-*) and "read-only fan-out"
+;;    (FO-*). Each is realized with the chunked worker-pool idiom -- make-pool w;
+;;    submit exactly w disjoint tasks; task-wait each; reassemble -- NOT
+;;    parallel-map over a per-element list. This is what §1 actually describes
+;;    (disjoint bands / chunks / blocks) and is also lib/kaappi/parallel.sld's
+;;    documented recommendation for large inputs, sidestepping the kaappi#1489
+;;    many-submission wakeup hazard (w is small).
+;;
+;;  * Every worker task thunk is FULLY SELF-CONTAINED: it captures only fixnums,
+;;    flonums, and payload objects, and calls only built-in primitives -- never a
+;;    top-level procedure defined in this file. A closure that crosses a worker
+;;    boundary and then calls a separately-defined procedure can hang
+;;    (kaappi#1520); the serial baselines, which never cross a thread, are free to
+;;    call the shared top-level kernels.
+;;
+;;  * E (§3) is wall time from the first pool-submit to the last reassembly copy;
+;;    pool creation/teardown and payload construction are excluded (they are
+;;    per-cell setup, amortized across iterations by reusing one pool + payload).
+;;
+;;  * submit/result copy time comes from the real shared_channel path via the
+;;    threadlocal counters (%chan-instr-*); reassembly time is bracketed
+;;    explicitly around each parent-side output copy. All three are ns.
+
+(import (scheme base)
+        (scheme write)
+        (scheme process-context)
+        (scheme time)
+        (kaappi fibers)
+        (kaappi parallel))
+
+;; -------------------------------------------------------------------------
+;; small helpers
+;; -------------------------------------------------------------------------
+
+;; Trailing n elements of a list (robust to whether (command-line) prepends the
+;; interpreter and/or script name).
+(define (last-n lst n)
+  (let loop ((l lst) (len (length lst)))
+    (if (> len n) (loop (cdr l) (- len 1)) l)))
+
+;; Disjoint covering chunk for worker wi of `total` items across `workers`:
+;; returns (cons start len). The first (remainder) workers get one extra item.
+(define (chunk total workers wi)
+  (let* ((base (quotient total workers))
+         (rem (remainder total workers))
+         (start (+ (* wi base) (if (< wi rem) wi rem)))
+         (len (+ base (if (< wi rem) 1 0))))
+    (cons start len)))
+
+;; Integer square root (for the MxM matmul sizing).
+(define (isqrt n)
+  (if (< n 2)
+      n
+      (let loop ((x n) (y (quotient (+ n 1) 2)))
+        (if (< y x)
+            (loop y (quotient (+ y (quotient n y)) 2))
+            x))))
+
+;; -------------------------------------------------------------------------
+;; The measured parallel section (§3 E boundary). `make-task` maps a worker
+;; index to a self-contained 0-arg task thunk; `reassemble!` folds/copies one
+;; worker's result into the shared output on the parent, timed as reassembly.
+;; Returns (list e_ns submit_ns result_ns reassembly_ns peak_env_bytes).
+;; -------------------------------------------------------------------------
+(define (timed-parallel pool workers make-task reassemble!)
+  (%chan-instr-reset!)
+  (let* ((t0 (current-jiffy))
+         (replies (map (lambda (wi) (pool-submit pool (make-task wi)))
+                       (iota workers))))
+    (for-each (lambda (wi reply)
+                (let ((res (task-wait reply)))
+                  (%chan-instr-reassembly-begin!)
+                  (reassemble! wi res)
+                  (%chan-instr-reassembly-end!)))
+              (iota workers) replies)
+    (let ((e-ns (* (- (current-jiffy) t0) 1000)))
+      (list e-ns
+            (%chan-instr-submit-ns)
+            (%chan-instr-result-ns)
+            (%chan-instr-reassembly-ns)
+            (%chan-instr-envelope-peak-bytes)))))
+
+;; Serial baseline S (§1 C-SERIAL): same kernel, single thread, no pool, no
+;; channels. `body` runs the whole computation and returns a checksum. Returns
+;; (list e_ns 0 0 0 0) so the two paths share a print format.
+(define (timed-serial body)
+  (let ((t0 (current-jiffy)))
+    (let ((_ (body)))
+      (let ((e-ns (* (- (current-jiffy) t0) 1000)))
+        (list e-ns 0 0 0 0)))))
+
+;; NOTE ON SERIAL BASELINES (S): the serial body runs exactly the kernel's
+;; compute and returns the output object -- no extra verification pass inside
+;; the timed region, so S is comparable to the parallel section's E. (An earlier
+;; draft checksummed the whole output in the serial body only, which inflated S
+;; and produced spurious superlinear speedups.) The workloads write to a
+;; captured output vector/bytevector, so the interpreter cannot elide the work.
+
+;; =========================================================================
+;; IP-BAND -- RGBA image bytevector; each worker renders a disjoint row band
+;; (per-pixel arithmetic), returns its band; parent bytevector-copy!s into out.
+;; =========================================================================
+(define ip-band-width 256)
+
+(define (ip-band-height size) (quotient size (* 4 ip-band-width)))
+
+(define (make-ip-band size workers)
+  (let* ((width ip-band-width)
+         (height (ip-band-height size))
+         (out (make-bytevector (* 4 width height) 0)))
+    (lambda (pool)
+      (timed-parallel
+       pool workers
+       (lambda (wi)
+         (let* ((cb (chunk height workers wi))
+                (row0 (car cb)) (rows (cdr cb)) (w width))
+           ;; self-contained: captures w, row0, rows (fixnums); primitives only
+           (lambda ()
+             (let ((band (make-bytevector (* 4 w rows) 0)))
+               (let rloop ((r 0))
+                 (when (< r rows)
+                   (let ((y (+ row0 r)))
+                     (let xloop ((x 0))
+                       (when (< x w)
+                         (let ((base (* 4 (+ (* r w) x))))
+                           (bytevector-u8-set! band base (modulo (+ x y) 256))
+                           (bytevector-u8-set! band (+ base 1) (modulo (* x 2) 256))
+                           (bytevector-u8-set! band (+ base 2) (modulo (* y 3) 256))
+                           (bytevector-u8-set! band (+ base 3) 255))
+                         (xloop (+ x 1)))))
+                   (rloop (+ r 1))))
+               band))))
+       (lambda (wi band)
+         (let* ((cb (chunk height workers wi))
+                (row0 (car cb)))
+           (bytevector-copy! out (* 4 width row0) band)))))))
+
+;; serial baseline: render the whole image in one thread
+(define (make-ip-band-serial size workers)
+  (let* ((width ip-band-width)
+         (height (ip-band-height size))
+         (out (make-bytevector (* 4 width height) 0)))
+    (lambda (_pool)
+      (timed-serial
+       (lambda ()
+         (let rloop ((y 0))
+           (when (< y height)
+             (let xloop ((x 0))
+               (when (< x width)
+                 (let ((base (* 4 (+ (* y width) x))))
+                   (bytevector-u8-set! out base (modulo (+ x y) 256))
+                   (bytevector-u8-set! out (+ base 1) (modulo (* x 2) 256))
+                   (bytevector-u8-set! out (+ base 2) (modulo (* y 3) 256))
+                   (bytevector-u8-set! out (+ base 3) 255))
+                 (xloop (+ x 1))))
+             (rloop (+ y 1))))
+         out)))))
+
+;; =========================================================================
+;; IP-MAP -- vector of flonums; out[i] = a*x[i]+b over a disjoint chunk.
+;; Task carries the chunk (copied in); returns transformed chunk; parent
+;; vector-copy!s into out.
+;; =========================================================================
+(define (ip-map-n size) (quotient size 8))
+
+(define (make-ip-map size workers)
+  (let* ((n (ip-map-n size))
+         (xs (make-vector n 0.0))
+         (out (make-vector n 0.0))
+         (chunks (make-vector workers #f)))
+    (do ((i 0 (+ i 1))) ((= i n)) (vector-set! xs i (exact->inexact i)))
+    ;; Pre-slice the per-worker chunks ONCE, as setup outside the timed region:
+    ;; the task then just carries its chunk, so the only submit-time copy is the
+    ;; envelope deepCopy (T_submit_copy), matching §1's "carries the chunk
+    ;; (copied in)" -- slicing xs inside E would add parent copy work that no
+    ;; counter attributes, diluting `share`.
+    (do ((wi 0 (+ wi 1))) ((= wi workers))
+      (let* ((cb (chunk n workers wi)) (start (car cb)) (len (cdr cb))
+             (cv (make-vector len 0.0)))
+        (do ((i 0 (+ i 1))) ((= i len)) (vector-set! cv i (vector-ref xs (+ start i))))
+        (vector-set! chunks wi cv)))
+    (lambda (pool)
+      (timed-parallel
+       pool workers
+       (lambda (wi)
+         (let* ((cv (vector-ref chunks wi))
+                (len (vector-length cv)))
+           (lambda ()
+             (let ((r (make-vector len 0.0)))
+               (do ((i 0 (+ i 1))) ((= i len))
+                 (vector-set! r i (+ (* 2.5 (vector-ref cv i)) 1.0)))
+               r))))
+       (lambda (wi r)
+         (let* ((cb (chunk n workers wi))
+                (start (car cb)) (len (cdr cb)))
+           (vector-copy! out start r 0 len)))))))
+
+(define (make-ip-map-serial size workers)
+  (let* ((n (ip-map-n size))
+         (xs (make-vector n 0.0))
+         (out (make-vector n 0.0)))
+    (do ((i 0 (+ i 1))) ((= i n)) (vector-set! xs i (exact->inexact i)))
+    (lambda (_pool)
+      (timed-serial
+       (lambda ()
+         (do ((i 0 (+ i 1))) ((= i n))
+           (vector-set! out i (+ (* 2.5 (vector-ref xs i)) 1.0)))
+         out)))))
+
+;; =========================================================================
+;; IP-MATMUL -- two MxM f64 matrices (row-major flonum vectors). Each worker
+;; computes a disjoint row block of C, reading all of A and B. Tasks carry A
+;; and B whole (fan-in copy) plus the block spec; parent assembles C.
+;; =========================================================================
+(define (matmul-dim size) (isqrt (quotient size 16)))  ; 2 * M*M * 8 bytes = size
+
+(define (make-ip-matmul size workers)
+  (let* ((m (matmul-dim size))
+         (a (make-vector (* m m) 0.0))
+         (b (make-vector (* m m) 0.0))
+         (c (make-vector (* m m) 0.0)))
+    (do ((i 0 (+ i 1))) ((= i (* m m)))
+      (vector-set! a i (exact->inexact (modulo i 7)))
+      (vector-set! b i (exact->inexact (modulo i 5))))
+    (lambda (pool)
+      (timed-parallel
+       pool workers
+       (lambda (wi)
+         (let* ((cb (chunk m workers wi))
+                (r0 (car cb)) (rows (cdr cb)))
+           ;; captures a, b (whole, fan-in copy), m, r0, rows
+           (lambda ()
+             (let ((block (make-vector (* rows m) 0.0)))
+               (do ((ri 0 (+ ri 1))) ((= ri rows))
+                 (let ((arow (* (+ r0 ri) m)))
+                   (do ((j 0 (+ j 1))) ((= j m))
+                     (let loop ((k 0) (acc 0.0))
+                       (if (< k m)
+                           (loop (+ k 1)
+                                 (+ acc (* (vector-ref a (+ arow k))
+                                           (vector-ref b (+ (* k m) j)))))
+                           (vector-set! block (+ (* ri m) j) acc))))))
+               block))))
+       (lambda (wi block)
+         (let* ((cb (chunk m workers wi))
+                (r0 (car cb)) (rows (cdr cb)))
+           (vector-copy! c (* r0 m) block 0 (* rows m))))))))
+
+(define (make-ip-matmul-serial size workers)
+  (let* ((m (matmul-dim size))
+         (a (make-vector (* m m) 0.0))
+         (b (make-vector (* m m) 0.0))
+         (c (make-vector (* m m) 0.0)))
+    (do ((i 0 (+ i 1))) ((= i (* m m)))
+      (vector-set! a i (exact->inexact (modulo i 7)))
+      (vector-set! b i (exact->inexact (modulo i 5))))
+    (lambda (_pool)
+      (timed-serial
+       (lambda ()
+         (do ((i 0 (+ i 1))) ((= i m))
+           (let ((arow (* i m)))
+             (do ((j 0 (+ j 1))) ((= j m))
+               (let loop ((k 0) (acc 0.0))
+                 (if (< k m)
+                     (loop (+ k 1)
+                           (+ acc (* (vector-ref a (+ arow k))
+                                     (vector-ref b (+ (* k m) j)))))
+                     (vector-set! c (+ arow j) acc))))))
+         c)))))
+
+;; =========================================================================
+;; FO-DIGEST -- each worker computes an 8-byte checksum of the WHOLE payload
+;; (payload copied to every worker); result is a fixnum pair. Parent folds.
+;; =========================================================================
+(define (make-fo-digest size workers)
+  (let ((payload (make-bytevector size 0))
+        (acc (make-vector 1 0)))
+    (do ((i 0 (+ i 1))) ((= i size)) (bytevector-u8-set! payload i (modulo i 251)))
+    (lambda (pool)
+      (vector-set! acc 0 0)
+      (timed-parallel
+       pool workers
+       (lambda (wi)
+         ;; captures the WHOLE payload (fan-out copy) -- the point of FO-*
+         (lambda ()
+           (let ((n (bytevector-length payload)))
+             (let loop ((i 0) (lo 0) (hi 0))
+               (if (< i n)
+                   (let ((nlo (modulo (+ (* lo 31) (bytevector-u8-ref payload i)) 65521)))
+                     (loop (+ i 1) nlo (modulo (+ hi nlo) 65521)))
+                   (cons lo hi))))))
+       (lambda (wi r)
+         (vector-set! acc 0 (+ (vector-ref acc 0) (car r) (cdr r))))))))
+
+(define (make-fo-digest-serial size workers)
+  (let ((payload (make-bytevector size 0)))
+    (do ((i 0 (+ i 1))) ((= i size)) (bytevector-u8-set! payload i (modulo i 251)))
+    (lambda (_pool)
+      (timed-serial
+       (lambda ()
+         (let ((n (bytevector-length payload)))
+           (let loop ((i 0) (lo 0) (hi 0))
+             (if (< i n)
+                 (let ((nlo (modulo (+ (* lo 31) (bytevector-u8-ref payload i)) 65521)))
+                   (loop (+ i 1) nlo (modulo (+ hi nlo) 65521)))
+                 (+ lo hi)))))))))
+
+;; =========================================================================
+;; FO-SLICE -- vector of flonums; each worker sums only its index range but
+;; receives the WHOLE vector (the over-copying idiom). Result is a flonum.
+;; =========================================================================
+(define (make-fo-slice size workers)
+  (let* ((n (ip-map-n size))
+         (xs (make-vector n 0.0))
+         (acc (make-vector 1 0.0)))
+    (do ((i 0 (+ i 1))) ((= i n)) (vector-set! xs i (exact->inexact (modulo i 97))))
+    (lambda (pool)
+      (vector-set! acc 0 0.0)
+      (timed-parallel
+       pool workers
+       (lambda (wi)
+         (let* ((cb (chunk n workers wi))
+                (start (car cb)) (len (cdr cb)))
+           ;; captures the WHOLE xs (over-copy) + its own [start,len)
+           (lambda ()
+             (let loop ((i 0) (s 0.0))
+               (if (< i len)
+                   (loop (+ i 1) (+ s (vector-ref xs (+ start i))))
+                   s)))))
+       (lambda (wi r)
+         (vector-set! acc 0 (+ (vector-ref acc 0) r)))))))
+
+(define (make-fo-slice-serial size workers)
+  (let* ((n (ip-map-n size))
+         (xs (make-vector n 0.0)))
+    (do ((i 0 (+ i 1))) ((= i n)) (vector-set! xs i (exact->inexact (modulo i 97))))
+    (lambda (_pool)
+      (timed-serial
+       (lambda ()
+         (let loop ((i 0) (s 0.0))
+           (if (< i n) (loop (+ i 1) (+ s (vector-ref xs i))) s)))))))
+
+;; =========================================================================
+;; FO-TREE -- balanced binary tree of nodes (tag a symbol, symbol-heavy). Each
+;; worker counts nodes matching a tag over the WHOLE tree (copied to every
+;; worker). Result is a fixnum. Doubles as the §1 symbol-table probe.
+;;
+;; PROTOCOL DEVIATION (flagged pre-freeze): §1 specifies nodes as *records*
+;; via `define-record-type`. Records cannot cross a Kaappi channel and still be
+;; used by an accessor: deepCopy mints a fresh RecordType per envelope, so a
+;; copied instance no longer matches the top-level record type the accessor
+;; closes over (record-type identity is not preserved across the copy, unlike
+;; symbols, which are interned). A node is therefore a 4-slot vector
+;; #(left right tag count) here -- same shape and the same symbol-heaviness (the
+;; §1 point), but with a representation that survives the fan-out copy. The
+;; underlying limitation must be resolved (or this deviation adopted) before the
+;; frozen run; see benchmarks/gate/README.md.
+;; =========================================================================
+(define fo-tree-tags
+  (vector 'alpha 'beta 'gamma 'delta 'epsilon 'zeta 'eta 'theta
+          'iota 'kappa 'lambda 'mu 'nu 'xi 'omicron 'pi))
+
+;; ~40 bytes/node (vector header + 4 slots); build n = size/40 nodes.
+(define (fo-tree-count size) (max 1 (quotient size 40)))
+
+;; balanced tree of exactly `n` nodes, tags cycled from the pool
+(define (build-tree n)
+  (let ((counter (make-vector 1 0)))
+    (define (build k)
+      (if (<= k 0)
+          #f
+          (let* ((left-k (quotient (- k 1) 2))
+                 (right-k (- k 1 left-k))
+                 (l (build left-k))
+                 (tagi (modulo (vector-ref counter 0) (vector-length fo-tree-tags))))
+            (vector-set! counter 0 (+ (vector-ref counter 0) 1))
+            (vector l (build right-k)
+                    (vector-ref fo-tree-tags tagi)
+                    (vector-ref counter 0)))))
+    (build n)))
+
+(define (make-fo-tree size workers)
+  (let ((tree (build-tree (fo-tree-count size)))
+        (acc (make-vector 1 0)))
+    (lambda (pool)
+      (vector-set! acc 0 0)
+      (timed-parallel
+       pool workers
+       (lambda (wi)
+         ;; captures the WHOLE tree (fan-out copy of a symbol-heavy graph);
+         ;; counts nodes whose tag is 'gamma. Traversal uses an explicit stack
+         ;; list so the thunk calls no top-level helper (kaappi#1520).
+         (lambda ()
+           (let loop ((stack (list tree)) (cnt 0))
+             (if (null? stack)
+                 cnt
+                 (let ((nd (car stack)))
+                   (if nd
+                       (loop (cons (vector-ref nd 0)
+                                   (cons (vector-ref nd 1) (cdr stack)))
+                             (if (eq? (vector-ref nd 2) 'gamma) (+ cnt 1) cnt))
+                       (loop (cdr stack) cnt)))))))
+       (lambda (wi r)
+         (vector-set! acc 0 (+ (vector-ref acc 0) r)))))))
+
+(define (make-fo-tree-serial size workers)
+  (let ((tree (build-tree (fo-tree-count size))))
+    (lambda (_pool)
+      (timed-serial
+       (lambda ()
+         (let loop ((stack (list tree)) (cnt 0))
+           (if (null? stack)
+               cnt
+               (let ((nd (car stack)))
+                 (if nd
+                     (loop (cons (vector-ref nd 0) (cons (vector-ref nd 1) (cdr stack)))
+                           (if (eq? (vector-ref nd 2) 'gamma) (+ cnt 1) cnt))
+                     (loop (cdr stack) cnt))))))))))
+
+;; =========================================================================
+;; C-EMPTY -- control-plane floor: submit -> worker no-op -> reply.
+;; =========================================================================
+(define (make-c-empty size workers)
+  (let ((acc (make-vector 1 0)))
+    (lambda (pool)
+      (vector-set! acc 0 0)
+      (timed-parallel
+       pool workers
+       (lambda (wi) (lambda () 0))
+       (lambda (wi r) (vector-set! acc 0 (+ (vector-ref acc 0) r)))))))
+
+;; -------------------------------------------------------------------------
+;; dispatch
+;; -------------------------------------------------------------------------
+(define (workload->maker name)
+  (cond
+   ((string=? name "ip-band")     make-ip-band)
+   ((string=? name "ip-map")      make-ip-map)
+   ((string=? name "ip-matmul")   make-ip-matmul)
+   ((string=? name "fo-digest")   make-fo-digest)
+   ((string=? name "fo-slice")    make-fo-slice)
+   ((string=? name "fo-tree")     make-fo-tree)
+   ((string=? name "c-empty")     make-c-empty)
+   ((string=? name "s:ip-band")   make-ip-band-serial)
+   ((string=? name "s:ip-map")    make-ip-map-serial)
+   ((string=? name "s:ip-matmul") make-ip-matmul-serial)
+   ((string=? name "s:fo-digest") make-fo-digest-serial)
+   ((string=? name "s:fo-slice")  make-fo-slice-serial)
+   ((string=? name "s:fo-tree")   make-fo-tree-serial)
+   (else (error "unknown workload" name))))
+
+(define (serial-workload? name)
+  (and (> (string-length name) 2) (string=? (substring name 0 2) "s:")))
+
+;; -------------------------------------------------------------------------
+;; main
+;; -------------------------------------------------------------------------
+(define (run)
+  (let* ((argv (last-n (command-line) 6))
+         (workload (list-ref argv 0))
+         (size (string->number (list-ref argv 1)))
+         (workers (string->number (list-ref argv 2)))
+         (lever (list-ref argv 3))
+         (warmup (string->number (list-ref argv 4)))
+         (iters (string->number (list-ref argv 5)))
+         (serial? (serial-workload? workload)))
+    (%elision-lever-set! (string->symbol lever))
+    (let* ((maker (workload->maker workload))
+           (cell (maker size workers))
+           ;; serial baselines take no pool; parallel cells reuse one pool
+           (pool (if serial? #f (make-pool workers))))
+      (do ((i 0 (+ i 1))) ((= i warmup)) (cell pool))
+      (do ((i 0 (+ i 1))) ((= i iters))
+        (let ((r (cell pool)))
+          (display "ITER ") (display workload)
+          (display " ") (display size)
+          (display " ") (display workers)
+          (display " ") (display lever)
+          (display " ") (display i)
+          (for-each (lambda (x) (display " ") (display x)) r)
+          (newline)))
+      (unless serial? (pool-shutdown! pool)))))
+
+(run)

--- a/benchmarks/gate/run-gate.py
+++ b/benchmarks/gate/run-gate.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""KEP-0002 Phase 7 gate-campaign driver (kaappi#1472).
+
+Orchestrates the invocation level of the two-level statistics protocol
+(keps research/benchmarks/README.md §4): for every benchmark cell it launches
+N fresh `kaappi` processes (invocations), each running the in-process iteration
+loop in gate-harness.scm, then aggregates with bootstrap confidence intervals
+and emits the §6 CSV plus a rendered table.
+
+Protocol points implemented here:
+
+  * §4.1 two levels: invocations (fresh process) x iterations (in-process).
+  * §4.2 report mean + 95% bootstrap CI over invocation means; never best-of-N,
+    never discard outliers (a slow invocation is data). A *timed-out* invocation
+    (a hang, not a slow run) is recorded as a failure and excluded, with a
+    warning -- see the kaappi#1489 note in README.md.
+  * §4.3 randomization: the whole (cell x invocation) launch schedule is
+    shuffled under a seed, and a dummy env var of random length (0-4096 bytes)
+    is exported per process (the Mytkowicz environment-size effect). ASLR is
+    left on (nothing disables it).
+  * §4.4 one binary: the lever is a runtime arg to the same instrumented binary.
+  * §4.6 w = 8 needs >= 8 physical cores; the driver records the machine label
+    and core count but does not enforce it (the operator asserts it).
+
+Invocation model (an operational definition added pre-freeze, README.md): one
+invocation = one fresh process running exactly ONE cell for `iterations`
+iterations. This keeps per-cell RSS / peak-envelope clean and makes a single
+cell's hang cost only that cell's invocation, not a whole multi-cell process.
+The §4.3 cell-order shuffle is honored as the shuffle of the campaign-wide
+launch schedule.
+
+Usage:
+  run-gate.py --bin <kaappi-instrumented> [--mode pilot|full] [--out results.csv]
+              [--machine LABEL] [--cores N] [--sizes 65536,1048576,...]
+              [--workers 1,2,4,8] [--workloads ip-band,...] [--levers none,c,cd]
+              [--invocations N] [--iterations N] [--warmup N]
+              [--timeout SECS] [--seed N] [--bootstrap N]
+
+The binary MUST be built with `-Dchannel-instrument=true`, or every copy
+counter reads 0 (the driver warns if it detects all-zero copy time).
+"""
+
+import argparse
+import os
+import random
+import subprocess
+import sys
+import threading
+import time
+
+import numpy as np
+
+WORKLOADS = ["ip-band", "ip-map", "ip-matmul", "fo-digest", "fo-tree", "fo-slice"]
+GATE_IP = ["ip-band", "ip-map", "ip-matmul"]
+GATE_FO = ["fo-digest", "fo-tree", "fo-slice"]
+
+CSV_HEADER = (
+    "machine,workload,size_bytes,workers,levers,invocations,iterations,"
+    "E_mean_ms,E_ci95_lo,E_ci95_hi,share_mean,share_ci95_lo,share_ci95_hi,"
+    "S_ms,speedup,rss_peak_mib,envelope_peak_mib"
+)
+
+
+def maxrss_to_mib(ru_maxrss):
+    # darwin reports ru_maxrss in bytes; linux in KiB.
+    if sys.platform == "darwin":
+        return ru_maxrss / (1024.0 * 1024.0)
+    return ru_maxrss / 1024.0
+
+
+def run_once(bin_path, harness, workload, size, workers, lever, warmup, iters,
+             timeout, pad_len):
+    """Run one invocation (one fresh process). Returns a dict with parsed
+    per-iteration rows, child peak RSS (MiB), and a status string."""
+    env = os.environ.copy()
+    # Mytkowicz environment-size perturbation (§4.3): a padding var of random
+    # length. Random bytes as an ASCII-safe string.
+    env["KAAPPI_GATE_PAD"] = "x" * pad_len
+    cmd = [bin_path, harness, workload, str(size), str(workers), lever,
+           str(warmup), str(iters)]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            env=env, text=True)
+    timed_out = [False]
+
+    def _kill():
+        timed_out[0] = True
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+    timer = threading.Timer(timeout, _kill)
+    timer.start()
+    # Output is small (a handful of ITER lines); reading to EOF before reaping
+    # cannot deadlock. read() returns when the process exits or is killed.
+    out = proc.stdout.read()
+    err = proc.stderr.read()
+    try:
+        pid, status, rusage = os.wait4(proc.pid, 0)
+        proc.returncode = os.waitstatus_to_exitcode(status)  # keep Popen from re-reaping
+        rss_mib = maxrss_to_mib(rusage.ru_maxrss)
+    except ChildProcessError:
+        rss_mib = 0.0
+    timer.cancel()
+
+    rows = []
+    for line in out.splitlines():
+        f = line.split()
+        if len(f) >= 11 and f[0] == "ITER":
+            # ITER wl size workers lever iter e submit result reassembly peak
+            rows.append({
+                "e_ns": float(f[6]),
+                "submit_ns": float(f[7]),
+                "result_ns": float(f[8]),
+                "reassembly_ns": float(f[9]),
+                "peak_bytes": float(f[10]),
+            })
+    if timed_out[0]:
+        status_s = "TIMEOUT"
+    elif proc.returncode != 0:
+        status_s = f"EXIT{proc.returncode}"
+    elif not rows:
+        status_s = "NOOUTPUT"
+    else:
+        status_s = "OK"
+    return {"rows": rows, "rss_mib": rss_mib, "status": status_s, "stderr": err}
+
+
+def bootstrap_ci(invocation_means, n_boot, rng):
+    """95% CI as bootstrap percentiles over invocation-level means (§4.2)."""
+    a = np.asarray(invocation_means, dtype=float)
+    if len(a) == 0:
+        return (float("nan"), float("nan"), float("nan"))
+    if len(a) == 1:
+        return (float(a[0]), float(a[0]), float(a[0]))
+    idx = rng.integers(0, len(a), size=(n_boot, len(a)))
+    boot_means = a[idx].mean(axis=1)
+    return (float(a.mean()),
+            float(np.percentile(boot_means, 2.5)),
+            float(np.percentile(boot_means, 97.5)))
+
+
+class Cell:
+    """One (workload, size, workers, lever) measurement point."""
+
+    def __init__(self, workload, size, workers, lever):
+        self.workload = workload
+        self.size = size
+        self.workers = workers
+        self.lever = lever
+        self.invocations = []   # list of {"e": inv_mean_e_ns, "share": inv_mean_share, "peak": max_peak}
+        self.rss_peak_mib = 0.0
+        self.failures = []
+
+    def key(self):
+        return (self.workload, self.size, self.workers, self.lever)
+
+    def add_invocation(self, result):
+        if result["status"] != "OK":
+            self.failures.append(result["status"])
+            return
+        es = np.array([r["e_ns"] for r in result["rows"]])
+        # per-iteration share, then invocation mean (§3 quantity per section)
+        shares = np.array([
+            (r["submit_ns"] + r["result_ns"] + r["reassembly_ns"]) / r["e_ns"]
+            if r["e_ns"] > 0 else 0.0
+            for r in result["rows"]
+        ])
+        peak = max((r["peak_bytes"] for r in result["rows"]), default=0.0)
+        self.invocations.append({
+            "e": float(es.mean()),
+            "share": float(shares.mean()),
+            "peak": peak,
+        })
+        self.rss_peak_mib = max(self.rss_peak_mib, result["rss_mib"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bin", required=True, help="path to kaappi built with -Dchannel-instrument=true")
+    ap.add_argument("--harness", default=os.path.join(os.path.dirname(__file__), "gate-harness.scm"))
+    ap.add_argument("--out", default="gate-results.csv")
+    ap.add_argument("--mode", choices=["pilot", "full"], default="pilot")
+    ap.add_argument("--machine", default="unknown")
+    ap.add_argument("--cores", type=int, default=0)
+    ap.add_argument("--sizes", default="65536,1048576")
+    ap.add_argument("--workers", default="8")
+    ap.add_argument("--workloads", default=",".join(WORKLOADS))
+    ap.add_argument("--levers", default="none,c")
+    ap.add_argument("--invocations", type=int, default=0)
+    ap.add_argument("--iterations", type=int, default=0)
+    ap.add_argument("--warmup", type=int, default=3)
+    ap.add_argument("--timeout", type=float, default=120.0)
+    ap.add_argument("--seed", type=int, default=1472)
+    ap.add_argument("--bootstrap", type=int, default=10000)
+    args = ap.parse_args()
+
+    # Protocol §4.1 counts. Pilot: 5 x 20. Full: floors 20 x 10 (a real campaign
+    # sets these from the pilot's variance; the driver reports the CI half-width
+    # so the operator can confirm the +-2% target was met).
+    if args.mode == "pilot":
+        invocations = args.invocations or 5
+        iterations = args.iterations or 20
+    else:
+        invocations = args.invocations or 20
+        iterations = args.iterations or 10
+
+    sizes = [int(s) for s in args.sizes.split(",") if s]
+    workers = [int(w) for w in args.workers.split(",") if w]
+    workloads = [w for w in args.workloads.split(",") if w]
+    levers = [l for l in args.levers.split(",") if l]
+
+    rng = np.random.default_rng(args.seed)
+    pyrng = random.Random(args.seed)
+
+    # Build cells: the parallel matrix, plus serial baselines (S) for each
+    # (workload, size), plus c-empty at each worker count (control-plane floor).
+    cells = {}
+
+    def get_cell(wl, size, w, lever):
+        c = Cell(wl, size, w, lever)
+        if c.key() not in cells:
+            cells[c.key()] = c
+        return cells[c.key()]
+
+    for wl in workloads:
+        for size in sizes:
+            for w in workers:
+                for lever in levers:
+                    get_cell(wl, size, w, lever)
+    # serial baselines: workers=1, lever none (channels unused)
+    serial_cells = {}
+    for wl in workloads:
+        for size in sizes:
+            sc = Cell("s:" + wl, size, 1, "none")
+            serial_cells[sc.key()] = sc
+    # c-empty control at each worker count (size 0)
+    for w in workers:
+        get_cell("c-empty", 0, w, "none")
+
+    all_cells = list(cells.values()) + list(serial_cells.values())
+
+    # Launch schedule: (cell, invocation_index), shuffled campaign-wide (§4.3).
+    schedule = []
+    for c in all_cells:
+        for inv in range(invocations):
+            schedule.append(c)
+    pyrng.shuffle(schedule)
+
+    print(f"# gate campaign: mode={args.mode} machine={args.machine} "
+          f"cells={len(all_cells)} invocations={invocations} iterations={iterations} "
+          f"launches={len(schedule)}", file=sys.stderr)
+
+    t_start = time.time()
+    any_nonzero_copy = False
+    for i, c in enumerate(schedule):
+        pad_len = pyrng.randint(0, 4096)
+        res = run_once(args.bin, args.harness, c.workload, c.size, c.workers,
+                       c.lever, args.warmup, iterations, args.timeout, pad_len)
+        c.add_invocation(res)
+        if res["status"] == "OK":
+            if any(r["submit_ns"] + r["result_ns"] > 0 for r in res["rows"]):
+                any_nonzero_copy = True
+        else:
+            print(f"  ! {c.workload} size={c.size} w={c.workers} lever={c.lever}"
+                  f" -> {res['status']}", file=sys.stderr)
+            if res["stderr"].strip():
+                print("    stderr:", res["stderr"].strip().splitlines()[-1], file=sys.stderr)
+        if (i + 1) % 10 == 0 or i + 1 == len(schedule):
+            el = time.time() - t_start
+            print(f"  [{i+1}/{len(schedule)}] {el:.0f}s elapsed", file=sys.stderr)
+
+    if not any_nonzero_copy:
+        print("WARNING: all copy counters read 0 -- is --bin built with "
+              "-Dchannel-instrument=true?", file=sys.stderr)
+
+    # Serial S lookup by (workload, size).
+    serial_ms = {}
+    for sc in serial_cells.values():
+        if sc.invocations:
+            wl = sc.workload[2:]  # strip "s:"
+            serial_ms[(wl, sc.size)] = np.mean([iv["e"] for iv in sc.invocations]) / 1e6
+
+    # Emit CSV.
+    rows_out = [CSV_HEADER]
+    table = []
+    for c in cells.values():
+        if not c.invocations:
+            table.append((c, None))
+            continue
+        e_means = [iv["e"] for iv in c.invocations]
+        share_means = [iv["share"] * 100.0 for iv in c.invocations]  # percent
+        e_mean, e_lo, e_hi = bootstrap_ci(e_means, args.bootstrap, rng)
+        s_mean, s_lo, s_hi = bootstrap_ci(share_means, args.bootstrap, rng)
+        e_mean_ms, e_lo_ms, e_hi_ms = e_mean / 1e6, e_lo / 1e6, e_hi / 1e6
+        env_peak_mib = max((iv["peak"] for iv in c.invocations), default=0.0) / (1024.0 * 1024.0)
+        base_wl = c.workload
+        s_ms = serial_ms.get((base_wl, c.size), float("nan"))
+        speedup = (s_ms / e_mean_ms) if (s_ms == s_ms and e_mean_ms > 0) else float("nan")
+        rows_out.append(",".join(str(x) for x in [
+            args.machine, c.workload, c.size, c.workers, c.lever,
+            len(c.invocations), iterations,
+            f"{e_mean_ms:.4f}", f"{e_lo_ms:.4f}", f"{e_hi_ms:.4f}",
+            f"{s_mean:.3f}", f"{s_lo:.3f}", f"{s_hi:.3f}",
+            f"{s_ms:.4f}", f"{speedup:.3f}",
+            f"{c.rss_peak_mib:.2f}", f"{env_peak_mib:.4f}",
+        ]))
+        table.append((c, (e_mean_ms, s_mean, s_lo, s_hi, speedup)))
+
+    with open(args.out, "w") as fh:
+        fh.write("\n".join(rows_out) + "\n")
+
+    # Rendered table (share is the gate quantity; show its CI half-width).
+    print()
+    print(f"{'workload':<11}{'size':>10}{'w':>3}{'lever':>6}"
+          f"{'E_ms':>11}{'share%':>9}{'[lo,':>9}{'hi]':>8}{'ci+-%':>8}{'inv':>5}")
+    for c, agg in table:
+        if agg is None:
+            print(f"{c.workload:<11}{c.size:>10}{c.workers:>3}{c.lever:>6}"
+                  f"{'FAILED('+','.join(c.failures[:3])+')':>36}")
+            continue
+        e_ms, s_mean, s_lo, s_hi, speedup = agg
+        half = (s_hi - s_lo) / 2.0
+        pct = (half / s_mean * 100.0) if s_mean > 0 else float("nan")
+        print(f"{c.workload:<11}{c.size:>10}{c.workers:>3}{c.lever:>6}"
+              f"{e_ms:>11.3f}{s_mean:>9.2f}{s_lo:>9.2f}{s_hi:>8.2f}"
+              f"{pct:>8.1f}{len(c.invocations):>5}")
+
+    print(f"\nCSV written to {args.out}", file=sys.stderr)
+    if args.mode == "pilot":
+        print("# pilot: the ci+-% column is the bootstrap CI half-width as % of "
+              "the share mean; the frozen run raises invocation counts until it "
+              "meets the protocol's +-2% target (floors 20 inv x 10 iter).",
+              file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/build.zig
+++ b/build.zig
@@ -28,6 +28,14 @@ pub fn build(b: *std.Build) void {
     const gc_threshold = b.option(u32, "gc-threshold", "Initial GC object threshold (default: 8192)") orelse 8192;
     const gc_stress = b.option(bool, "gc-stress", "Force GC on every allocation (stress testing)") orelse false;
 
+    // KEP-0002 Phase 7 gate campaign (kaappi#1472): compile in the parent-side
+    // copy-time counters (T_submit_copy / T_result_copy / T_reassembly) and the
+    // runtime-selectable envelope elision levers (none / C / C+D). Off in the
+    // shipped default so release builds pay nothing (protocol §3: "compiled out
+    // in release builds"); the campaign builds ONE binary with this on and
+    // selects the lever at runtime (protocol §4.4, one binary for all modes).
+    const channel_instrument = b.option(bool, "channel-instrument", "Compile in KEP-0002 Phase 7 channel copy-time counters + elision levers (off in shipped builds)") orelse false;
+
     const test_filters = b.option([]const []const u8, "test-filter", "Only run unit tests whose names match the filter (repeatable)") orelse &.{};
 
     const options = b.addOptions();
@@ -35,6 +43,7 @@ pub fn build(b: *std.Build) void {
     options.addOption(u32, "max_registers", max_registers);
     options.addOption(u32, "gc_initial_threshold", gc_threshold);
     options.addOption(bool, "gc_stress", gc_stress);
+    options.addOption(bool, "channel_instrument", channel_instrument);
     options.addOption([]const u8, "version", zon.version);
     const options_mod = options.createModule();
 

--- a/docs/dev/kep-0002-phase7-envelope-benchmarks.md
+++ b/docs/dev/kep-0002-phase7-envelope-benchmarks.md
@@ -205,13 +205,23 @@ Still open for Phase 7 / #1472:
    suite, checking the lifetime rule stays contained. This is the P3 (B)
    second clause; without it the ≥30% result is necessary but not
    sufficient.
-3. **Lever-C ship** — the immediate fast path in the real
-   `send`/`receive`, with a regression test.
+3. **Lever-C ship** — the immediate fast path now exists in the real
+   `send`/`receive` (behind `-Dchannel-instrument`, as the gate lever
+   `c`; see the gate campaign below). Promoting it to the shipped default
+   (lever-invariant, no flag) with a regression test is the remaining
+   step.
 4. **KEP-0002 UQ 1 amendment** — record the A/B/C/D outcome (ship C; B
    pending clause 2; D deferred) into KEP-0002, per #1472's acceptance.
    Best done after (1).
 5. **The gate campaign** — the `parallel-map` IP-*/FO-* workloads, the
    parent-side copy-overhead-share instrumentation, the Kalibera–Jones
    statistics driver, the CSV + classification worksheet, and lever D
-   wired behind a flag in the real path. That is the larger, separate
-   half of #1472 that feeds #1474.
+   wired behind a flag in the real path. The larger, separate half of
+   #1472 that feeds #1474. **Harness landed** in `benchmarks/gate/` (see
+   `benchmarks/gate/README.md`): the six workloads + controls, the real-
+   path `share` counters (`src/channel_instrument.zig` →
+   `src/shared_channel.zig`), levers `none`/`c`, and the K–J driver
+   emitting the §6 CSV, all locally piloted on macOS aarch64. Still open
+   there: **lever D in the real path** (the gate cells are `C+D`, so the
+   gate is blocked until it lands), the frozen two-machine §4 collection,
+   and the worksheet fill-in.

--- a/docs/dev/kep-0002-phase7-envelope-benchmarks.md
+++ b/docs/dev/kep-0002-phase7-envelope-benchmarks.md
@@ -220,8 +220,11 @@ Still open for Phase 7 / #1472:
    #1472 that feeds #1474. **Harness landed** in `benchmarks/gate/` (see
    `benchmarks/gate/README.md`): the six workloads + controls, the real-
    path `share` counters (`src/channel_instrument.zig` →
-   `src/shared_channel.zig`), levers `none`/`c`, and the K–J driver
-   emitting the §6 CSV, all locally piloted on macOS aarch64. Still open
-   there: **lever D in the real path** (the gate cells are `C+D`, so the
-   gate is blocked until it lands), the frozen two-machine §4 collection,
-   and the worksheet fill-in.
+   `src/shared_channel.zig`), levers `none`/`c`/`cd`, and the K–J driver
+   emitting the §6 CSV, all locally piloted on macOS aarch64. **Lever D**
+   (refcounted immutable side-heap for large bytevectors,
+   `src/shared_buffer.zig`, zero-copy receive + copy-on-write) is wired
+   into the real deepCopy path behind `-Dchannel-instrument`, so the gate's
+   `C+D` cells are now runnable. Still open there: the frozen two-machine
+   §4 collection and the worksheet fill-in — ideally after kaappi#1489
+   (the intermittent pool hang) is fixed.

--- a/src/channel_instrument.zig
+++ b/src/channel_instrument.zig
@@ -1,0 +1,169 @@
+//! KEP-0002 Phase 7 gate-campaign instrumentation (kaappi#1472).
+//!
+//! The frozen protocol (keps `research/benchmarks/README.md`) gates the
+//! KEP-0003 acceptance decision on the *copy + reassembly overhead share* of a
+//! `parallel-map` section:
+//!
+//!     share = (T_submit_copy + T_result_copy + T_reassembly) / E
+//!
+//! This module owns the three parent-side counters and the runtime-selectable
+//! envelope elision lever (`none` / `C` / `C+D`) that the campaign sweeps.
+//!
+//! Two design rules from the protocol are baked in here:
+//!
+//!   * §3 "the counters ... are compiled out in release builds": the whole
+//!     module is a comptime no-op unless built with `-Dchannel-instrument=true`.
+//!     `enabled` is `false` in the shipped default and on WASM, and every hook
+//!     that touches a wall clock is unreferenced in that case, so the libc
+//!     `clock_gettime` never even compiles into a non-instrumented binary.
+//!
+//!   * §4.4 "one binary: all levers and modes selected by runtime flag, not
+//!     rebuild": the lever is a process-global read on every envelope build, set
+//!     once (from Scheme, via `%elision-lever-set!`) before a measured section.
+//!     The campaign builds a single instrumented binary and compares cells that
+//!     differ only in this runtime flag, so code layout is held constant.
+//!
+//! Attribution (§3): the copy counters are **per-thread**. `T_submit_copy` and
+//! `T_result_copy` are the parent's own envelope build (`Envelope.create`) and
+//! drain (receive-side `deepCopy`); a worker's build/drain of the *opposite*
+//! ends lands in that worker's own threadlocal, which nothing ever reads. Since
+//! the parent only ever sends tasks and receives results, every `Envelope.create`
+//! it runs is a submit copy and every receive `deepCopy` it runs is a result
+//! copy -- no per-call role tagging is needed, only the thread separation the
+//! threadlocals give for free.
+
+const std = @import("std");
+const build_options = @import("build_options");
+
+/// Compiled in only with `-Dchannel-instrument=true`. Everything below is a
+/// comptime no-op otherwise (protocol §3).
+pub const enabled: bool = build_options.channel_instrument;
+
+// --------------------------------------------------------------------------
+// Parent-side copy-time counters (protocol §3). Per-thread; the parent reads
+// its own after a measured section (see `%chan-instr-*` in
+// primitives_parallel.zig).
+// --------------------------------------------------------------------------
+pub threadlocal var t_submit_ns: u64 = 0;
+pub threadlocal var t_result_ns: u64 = 0;
+pub threadlocal var t_reassembly_ns: u64 = 0;
+
+/// Stashed start for the two-call reassembly bracket (`%chan-instr-reassembly-
+/// begin!` / `-end!`). The harness wraps each parent-side `bytevector-copy!` /
+/// `vector-copy!` into the output object; worker threads never call the bracket.
+threadlocal var reassembly_start: u64 = 0;
+
+/// A live timer handle. `void` when disabled so `begin()` compiles to nothing
+/// and the wall-clock read is unreferenced (keeps `clock_gettime` out of the
+/// shipped/WASM binary).
+pub const Timer = if (enabled) u64 else void;
+
+fn nowNs() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+/// Start a copy timer. Returns `{}` (and reads no clock) when disabled.
+pub inline fn begin() Timer {
+    if (comptime !enabled) return {};
+    return nowNs();
+}
+
+pub inline fn endSubmit(t: Timer) void {
+    if (comptime !enabled) return;
+    t_submit_ns += nowNs() -% t;
+}
+
+pub inline fn endResult(t: Timer) void {
+    if (comptime !enabled) return;
+    t_result_ns += nowNs() -% t;
+}
+
+pub fn reassemblyBegin() void {
+    if (comptime !enabled) return;
+    reassembly_start = nowNs();
+}
+
+pub fn reassemblyEnd() void {
+    if (comptime !enabled) return;
+    t_reassembly_ns += nowNs() -% reassembly_start;
+}
+
+/// Zero this thread's copy counters and the process-wide peak-envelope gauge.
+/// Called by the harness right before the timed parallel section.
+pub fn reset() void {
+    if (comptime !enabled) return;
+    t_submit_ns = 0;
+    t_result_ns = 0;
+    t_reassembly_ns = 0;
+    peak_envelope_bytes.store(live_envelope_bytes.load(.monotonic), .monotonic);
+}
+
+// --------------------------------------------------------------------------
+// Elision lever (protocol §2). Process-global: workers build result envelopes
+// and drain task envelopes, so every thread must agree on the active lever for
+// a cell. Set once before the measured section; a plain relaxed atomic suffices
+// (no ordering is piggybacked on it).
+// --------------------------------------------------------------------------
+pub const Lever = enum(u8) {
+    /// Per-message envelopes exactly as `shared_channel.zig` ships.
+    none = 0,
+    /// `none` + immediates (fixnums/booleans/chars/flonums/nil) skip the
+    /// envelope heap entirely.
+    c = 1,
+    /// `C` + a refcounted immutable side-heap for large bytevectors/strings
+    /// (implemented in a follow-up; selects like `C` until then).
+    cd = 2,
+};
+
+var active_lever: std.atomic.Value(u8) = std.atomic.Value(u8).init(@intFromEnum(Lever.none));
+
+pub fn setLever(l: Lever) void {
+    if (comptime !enabled) return;
+    active_lever.store(@intFromEnum(l), .monotonic);
+}
+
+pub inline fn lever() Lever {
+    if (comptime !enabled) return .none;
+    return @enumFromInt(active_lever.load(.monotonic));
+}
+
+/// True when the active lever elides immediates from the envelope heap
+/// (levers `C` and `C+D`).
+pub inline fn immediatesElided() bool {
+    if (comptime !enabled) return false;
+    return switch (lever()) {
+        .none => false,
+        .c, .cd => true,
+    };
+}
+
+// --------------------------------------------------------------------------
+// Peak live envelope bytes (protocol §3 secondary metric: the "invisible to
+// GC" footprint from KEP-0002's Drawbacks). Process-global, since envelopes are
+// created and destroyed across every thread. Non-gating; reported for context.
+// --------------------------------------------------------------------------
+var live_envelope_bytes: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+var peak_envelope_bytes: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+
+pub fn envelopeBytesAdd(n: usize) void {
+    if (comptime !enabled) return;
+    const now = live_envelope_bytes.fetchAdd(n, .monotonic) + n;
+    // Monotone-max update; a lost race only under-reports the peak slightly,
+    // which is acceptable for a non-gating secondary metric.
+    var prev = peak_envelope_bytes.load(.monotonic);
+    while (now > prev) {
+        prev = peak_envelope_bytes.cmpxchgWeak(prev, now, .monotonic, .monotonic) orelse break;
+    }
+}
+
+pub fn envelopeBytesSub(n: usize) void {
+    if (comptime !enabled) return;
+    _ = live_envelope_bytes.fetchSub(n, .monotonic);
+}
+
+pub fn peakEnvelopeBytes() usize {
+    if (comptime !enabled) return 0;
+    return peak_envelope_bytes.load(.monotonic);
+}

--- a/src/channel_instrument.zig
+++ b/src/channel_instrument.zig
@@ -112,8 +112,10 @@ pub const Lever = enum(u8) {
     /// `none` + immediates (fixnums/booleans/chars/flonums/nil) skip the
     /// envelope heap entirely.
     c = 1,
-    /// `C` + a refcounted immutable side-heap for large bytevectors/strings
-    /// (implemented in a follow-up; selects like `C` until then).
+    /// `C` + a refcounted immutable side-heap (`shared_buffer.SharedBuffer`)
+    /// for large bytevectors: snapshot once, share by refcount, copy-on-write.
+    /// Wired into the real deepCopy path (gc_deep_copy.zig); the gate's `C+D`
+    /// cells run on this lever.
     cd = 2,
 };
 
@@ -123,6 +125,20 @@ pub fn setLever(l: Lever) void {
     if (comptime !enabled) return;
     active_lever.store(@intFromEnum(l), .monotonic);
 }
+
+/// True only while `Envelope.create` is building an envelope under lever C+D,
+/// so `gc_deep_copy`'s bytevector arm knows to snapshot a large payload into a
+/// shared side-buffer (lever D) instead of copying it. Threadlocal: concurrent
+/// envelope builds on different threads must not see each other's mode. The
+/// receive side needs no such flag -- it aliases any already-backed bytevector
+/// unconditionally, since the immutable buffer already exists.
+pub threadlocal var envelope_build_d: bool = false;
+
+/// Lever D size gate. BEAM ships refcounted binaries above 64 bytes; the gate
+/// sweeps 64 KiB..64 MiB with per-worker chunks down to a few KiB, so a 4 KiB
+/// threshold keeps tiny control messages on the copy path while every gate
+/// payload (and its chunks) crosses by reference.
+pub const d_side_heap_threshold_bytes: usize = 4096;
 
 pub inline fn lever() Lever {
     if (comptime !enabled) return .none;

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const types = @import("types.zig");
 const memory_mod = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
+const shared_buffer = @import("shared_buffer.zig");
 const GC = memory_mod.GC;
 
 const Value = types.Value;
@@ -774,7 +775,9 @@ fn objectSize(obj: *Object) usize {
         .native_closure => @sizeOf(types.NativeClosure) + obj.as(types.NativeClosure).upvalues.len * @sizeOf(Value),
         .flonum => @sizeOf(Flonum),
         .vector => @sizeOf(Vector) + obj.as(Vector).data.len * @sizeOf(Value),
-        .bytevector => @sizeOf(Bytevector) + obj.as(Bytevector).data.len,
+        // A backed bytevector (lever D) borrows its bytes from a SharedBuffer,
+        // so only the struct counts against this heap.
+        .bytevector => @sizeOf(Bytevector) + if (obj.as(Bytevector).shared == null) obj.as(Bytevector).data.len else 0,
         .transformer => blk: {
             const t = obj.as(Transformer);
             break :blk @sizeOf(Transformer) + t.literals.len * @sizeOf(Value) +
@@ -920,7 +923,15 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
         },
         .bytevector => {
             const bv = obj.as(Bytevector);
-            gc.allocator.free(bv.data);
+            // Lever D (kaappi#1472): a backed bytevector borrows its bytes from
+            // a SharedBuffer -- release the reference (freeing the buffer at
+            // zero) instead of freeing bytes this heap never owned.
+            if (bv.shared) |raw| {
+                const sb: *shared_buffer.SharedBuffer = @ptrCast(@alignCast(raw));
+                sb.release();
+            } else {
+                gc.allocator.free(bv.data);
+            }
             poisonAndDestroy(gc, Bytevector, bv);
         },
         .promise => {

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -3,6 +3,8 @@ const types = @import("types.zig");
 const memory_mod = @import("memory.zig");
 const hashtable = @import("primitives_hashtable.zig");
 const shared_channel = @import("shared_channel.zig");
+const shared_buffer = @import("shared_buffer.zig");
+const instrument = @import("channel_instrument.zig");
 
 const GC = memory_mod.GC;
 const Value = types.Value;
@@ -94,7 +96,35 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             return new_val;
         },
         .bytevector => {
-            const new_val = try gc.allocBytevector(obj.as(types.Bytevector).data);
+            const bv = obj.as(types.Bytevector);
+            // Lever D (kaappi#1472). Comptime-pruned in the shipped build, where
+            // no bytevector is ever backed and the flag is never set.
+            if (comptime instrument.enabled) {
+                // Case 1 (receive side, and any re-copy of an already-backed
+                // bytevector): alias the existing immutable SharedBuffer by
+                // refcount -- zero byte copy. Unconditional on the lever, since
+                // the buffer already exists; a mutator later copies-on-write.
+                if (bv.shared) |raw| {
+                    const sb: *shared_buffer.SharedBuffer = @ptrCast(@alignCast(raw));
+                    const new_val = try gc.allocBytevectorShared(raw, sb.bytes);
+                    sb.retain(); // after the alloc: a failed alloc leaves the source's own ref intact
+                    try visited.put(src_ptr, new_val);
+                    return new_val;
+                }
+                // Case 2 (send side, lever C+D, large payload): snapshot the
+                // bytes into a fresh SharedBuffer once, then back the copy.
+                if (instrument.envelope_build_d and bv.data.len >= instrument.d_side_heap_threshold_bytes) {
+                    const sb = try shared_buffer.SharedBuffer.create(bv.data);
+                    const new_val = gc.allocBytevectorShared(@ptrCast(sb), sb.bytes) catch |err| {
+                        sb.release(); // drop create's rc=1 on alloc failure
+                        return err;
+                    };
+                    try visited.put(src_ptr, new_val);
+                    return new_val;
+                }
+            }
+            // Default (lever none, small payloads, shipped build): copy bytes.
+            const new_val = try gc.allocBytevector(bv.data);
             try visited.put(src_ptr, new_val);
             return new_val;
         },

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const types = @import("types.zig");
 const diagnostics = @import("diagnostics.zig");
+const shared_buffer = @import("shared_buffer.zig");
+const instrument = @import("channel_instrument.zig");
 const Value = types.Value;
 const Object = types.Object;
 const ObjectTag = types.ObjectTag;
@@ -612,6 +614,47 @@ pub const GC = struct {
         };
         self.finishAlloc(&bv.header, @sizeOf(Bytevector) + size);
         return types.makePointer(@ptrCast(bv));
+    }
+
+    /// Lever D (kaappi#1472): a bytevector whose bytes are BORROWED from a
+    /// refcounted immutable `shared_buffer.SharedBuffer` rather than owned.
+    /// `bytes` must be `shared`'s own slice; this object stores the pointer and
+    /// does not copy or free the bytes (freeObject releases the reference
+    /// instead). The caller owns the reference this object will hold
+    /// (SharedBuffer.create's rc=1, or a retain()) -- following allocChannelStub,
+    /// allocate first so a failure here leaves the caller's reference intact to
+    /// drop, rather than leaking it on a retain that precedes a failed alloc.
+    pub fn allocBytevectorShared(self: *GC, shared: *anyopaque, bytes: []u8) !Value {
+        try self.maybeCollect();
+        const bv = try self.allocator.create(Bytevector);
+        bv.* = .{
+            .header = .{ .tag = .bytevector },
+            .data = bytes,
+            .shared = shared,
+        };
+        // The bytes live in the SharedBuffer, not this heap: count only the
+        // struct, so the per-heap footprint reflects lever D's whole point.
+        self.finishAlloc(&bv.header, @sizeOf(Bytevector));
+        return types.makePointer(@ptrCast(bv));
+    }
+
+    /// Lever D copy-on-write (kaappi#1472): if `bv` borrows a shared immutable
+    /// buffer, give it private ownership of a copy and drop the shared reference
+    /// BEFORE it is mutated -- so a writer never touches shared bytes and
+    /// Scheme's copy semantics hold. No-op for an ordinary owned bytevector (and
+    /// comptime-pruned entirely in the shipped build, where none are ever
+    /// backed). Not under any collection here: the dupe is a raw allocator call
+    /// and callers run outside deepCopy's no_collect region.
+    pub fn unshareBytevector(self: *GC, bv: *Bytevector) !void {
+        if (comptime !instrument.enabled) return;
+        if (bv.shared) |raw| {
+            const owned = try self.allocator.dupe(u8, bv.data);
+            bv.data = owned;
+            bv.shared = null;
+            self.bytes_allocated += owned.len;
+            const sb: *shared_buffer.SharedBuffer = @ptrCast(@alignCast(raw));
+            sb.release();
+        }
     }
 
     pub fn allocPromise(self: *GC, forced: bool, value: Value) !Value {

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -94,6 +94,10 @@ fn bytevectorU8Set(args: []const Value) PrimitiveError!Value {
     const val = types.toFixnum(args[2]);
     if (idx < 0 or @as(usize, @intCast(idx)) >= bv.data.len) return primitives.typeError("bytevector-u8-set!", "valid index", args[1]);
     if (val < 0 or val > 255) return primitives.typeError("bytevector-u8-set!", "exact integer 0-255", args[2]);
+    // Lever D copy-on-write (kaappi#1472): if this bytevector borrows a shared
+    // immutable buffer, privatize it before writing. No-op otherwise.
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    gc.unshareBytevector(bv) catch return PrimitiveError.OutOfMemory;
     bv.data[@intCast(@as(u64, @bitCast(idx)))] = @intCast(@as(u64, @bitCast(val)));
     return types.VOID;
 }
@@ -127,6 +131,13 @@ fn bytevectorCopyBang(args: []const Value) PrimitiveError!Value {
     const end = range.end;
     const count = end - start;
     if (at + count > to.data.len) return primitives.typeError("bytevector-copy!", "valid range", args[0]);
+
+    // Lever D copy-on-write (kaappi#1472): privatize the destination before
+    // writing if it borrows a shared immutable buffer. `from` is read only, so
+    // it needs no COW even when `to` and `from` are the same object (after COW
+    // both refer to the new private buffer, preserving memmove semantics).
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    gc.unshareBytevector(to) catch return PrimitiveError.OutOfMemory;
 
     // Use memmove semantics for overlapping regions
     if (at <= start) {
@@ -344,6 +355,10 @@ fn readBytevectorMut(args: []const Value) PrimitiveError!Value {
     if (!types.isBytevector(args[0])) return primitives.typeError("read-bytevector!", "bytevector", args[0]);
     if (types.toObject(args[0]).flags.immutable) return primitives.typeError("read-bytevector!", "mutable bytevector", args[0]);
     const bv = types.toBytevector(args[0]);
+    // Lever D copy-on-write (kaappi#1472): privatize before the read loop writes
+    // into it; idempotent across the parked-retry protocol below.
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    gc.unshareBytevector(bv) catch return PrimitiveError.OutOfMemory;
     const port = try getInputPort(args, 1, "read-bytevector!");
     const len = bv.data.len;
 

--- a/src/primitives_parallel.zig
+++ b/src/primitives_parallel.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
 const is_wasm = @import("builtin").os.tag == .wasi;
+const build_options = @import("build_options");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const instrument = @import("channel_instrument.zig");
 const Value = types.Value;
 const PrimitiveError = primitives.PrimitiveError;
 const LS = primitives.LibSet;
@@ -19,9 +21,86 @@ const LS = primitives.LibSet;
 // re-exports it under `(kaappi parallel)` by naming it in `export` without
 // redefining it -- the same trick lib/srfi/27.sld uses for
 // random-integer/random-real (tagged .scheme_base there).
-pub const specs = [_]primitives.PrimSpec{
+const base_specs = [_]primitives.PrimSpec{
     .{ .name = "processor-count", .func = &processorCountFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
 };
+
+// KEP-0002 Phase 7 gate-campaign harness hooks (kaappi#1472). Compiled in ONLY
+// with `-Dchannel-instrument=true` (see the `specs` concat below), so the
+// shipped (kaappi fibers) never carries these `%`-prefixed benchmark
+// primitives. Tagged `.kaappi_fibers`, NOT `.internal`: `.internal` specs are
+// bootstrap-only helpers that vm_bootstrap.install removes from globals after
+// capture (#1375), but the harness calls these at runtime, so they must persist
+// as ordinary (kaappi fibers) globals.
+const instr_specs = [_]primitives.PrimSpec{
+    .{ .name = "%chan-instr-reset!", .func = &chanInstrReset, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "%chan-instr-submit-ns", .func = &chanInstrSubmitNs, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "%chan-instr-result-ns", .func = &chanInstrResultNs, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "%chan-instr-reassembly-begin!", .func = &chanInstrReassemblyBegin, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "%chan-instr-reassembly-end!", .func = &chanInstrReassemblyEnd, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "%chan-instr-reassembly-ns", .func = &chanInstrReassemblyNs, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "%chan-instr-envelope-peak-bytes", .func = &chanInstrEnvelopePeakBytes, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "%elision-lever-set!", .func = &elisionLeverSet, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
+};
+
+pub const specs = base_specs ++ (if (build_options.channel_instrument) instr_specs else [0]primitives.PrimSpec{});
+
+fn chanInstrReset(args: []const Value) PrimitiveError!Value {
+    _ = args;
+    instrument.reset();
+    return types.VOID;
+}
+
+fn chanInstrSubmitNs(args: []const Value) PrimitiveError!Value {
+    _ = args;
+    return types.makeFixnum(@intCast(instrument.t_submit_ns));
+}
+
+fn chanInstrResultNs(args: []const Value) PrimitiveError!Value {
+    _ = args;
+    return types.makeFixnum(@intCast(instrument.t_result_ns));
+}
+
+fn chanInstrReassemblyBegin(args: []const Value) PrimitiveError!Value {
+    _ = args;
+    instrument.reassemblyBegin();
+    return types.VOID;
+}
+
+fn chanInstrReassemblyEnd(args: []const Value) PrimitiveError!Value {
+    _ = args;
+    instrument.reassemblyEnd();
+    return types.VOID;
+}
+
+fn chanInstrReassemblyNs(args: []const Value) PrimitiveError!Value {
+    _ = args;
+    return types.makeFixnum(@intCast(instrument.t_reassembly_ns));
+}
+
+fn chanInstrEnvelopePeakBytes(args: []const Value) PrimitiveError!Value {
+    _ = args;
+    return types.makeFixnum(@intCast(instrument.peakEnvelopeBytes()));
+}
+
+/// `(%elision-lever-set! 'none|'c|'cd)` -- selects the envelope elision lever
+/// for subsequent sends/receives (protocol §2). Inert unless instrumented.
+fn elisionLeverSet(args: []const Value) PrimitiveError!Value {
+    if (!types.isPointer(args[0])) return PrimitiveError.TypeError;
+    const obj = types.toObject(args[0]);
+    if (obj.tag != .symbol) return PrimitiveError.TypeError;
+    const name = obj.as(types.Symbol).name;
+    const lever: instrument.Lever = if (std.mem.eql(u8, name, "none"))
+        .none
+    else if (std.mem.eql(u8, name, "c"))
+        .c
+    else if (std.mem.eql(u8, name, "cd"))
+        .cd
+    else
+        return PrimitiveError.TypeError;
+    instrument.setLever(lever);
+    return types.VOID;
+}
 
 /// Returns 1 under WASM (no real OS threads) or `--sandbox` (thread
 /// creation blocked) so pool-sizing code degrades to a single fiber worker

--- a/src/shared_buffer.zig
+++ b/src/shared_buffer.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const shared_object = @import("shared_object.zig");
+
+/// KEP-0002/KEP-0003 second shared-object type (the first is SharedChannel):
+/// a refcounted, immutable byte buffer allocated from the process-global
+/// allocator, outside every GC heap, so it can be shared across threads and
+/// outlive any single VM/GC.
+///
+/// Lever D of the Phase 7 elision matrix (kaappi#1472): a large bytevector
+/// crossing a channel is snapshotted into one of these ONCE, then shared by
+/// refcount on every subsequent hop instead of being re-copied. A GC-managed
+/// bytevector "backs onto" a SharedBuffer by borrowing its `bytes` slice and
+/// holding one refcount (see types.Bytevector.shared); the collector releases
+/// that refcount when the bytevector is swept (gc_collect.freeObject), and the
+/// buffer frees itself at the last release.
+///
+/// Immutable by contract: a backed bytevector that is about to be mutated first
+/// copies its bytes into private storage and drops its reference
+/// (GC.unshareBytevector), so no writer ever touches shared bytes. This is what
+/// makes sharing safe under Scheme's copy semantics -- the receiver still has a
+/// logically independent, mutable value; the copy is just deferred until (if
+/// ever) it is written.
+pub const SharedBuffer = struct {
+    header: shared_object.Header,
+    bytes: []u8,
+
+    /// Snapshot `src` into a fresh immutable buffer, refcount 1 (the creating
+    /// bytevector's reference). The one copy lever D pays.
+    pub fn create(src: []const u8) !*SharedBuffer {
+        const self = try std.heap.c_allocator.create(SharedBuffer);
+        errdefer std.heap.c_allocator.destroy(self);
+        const buf = try std.heap.c_allocator.alloc(u8, src.len);
+        @memcpy(buf, src);
+        self.* = .{ .header = undefined, .bytes = buf };
+        shared_object.init(&self.header, destroyHook);
+        return self;
+    }
+
+    /// +1: a new backing bytevector was created (deepCopy's alias arm).
+    pub fn retain(self: *SharedBuffer) void {
+        shared_object.retain(&self.header);
+    }
+
+    /// -1: a backing bytevector was freed or copied-on-write. Frees the buffer
+    /// at zero.
+    pub fn release(self: *SharedBuffer) void {
+        shared_object.release(&self.header);
+    }
+
+    fn destroyHook(header: *shared_object.Header) void {
+        const self: *SharedBuffer = @fieldParentPtr("header", header);
+        std.heap.c_allocator.free(self.bytes);
+        std.heap.c_allocator.destroy(self);
+    }
+};

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -5,6 +5,7 @@ const memory = @import("memory.zig");
 const reactor_mod = @import("reactor.zig");
 const vm_mod = @import("vm.zig");
 const pct_stress = @import("pct_stress.zig");
+const instrument = @import("channel_instrument.zig");
 const Value = types.Value;
 
 /// KEP-0002 Phase 3 (#1468) PCT stress hook: a no-op unless
@@ -36,7 +37,12 @@ const releaseNotifier = reactor_mod.releaseNotifier;
 /// fills it once, the receiver's deepCopy drains it once, then it is
 /// destroyed wholesale.
 pub const Envelope = struct {
-    gc: *memory.GC,
+    /// null only for a lever-C/C+D immediate envelope (KEP-0002 Phase 7,
+    /// kaappi#1472): a fixnum/boolean/char/flonum/nil payload is self-contained,
+    /// so no private heap is built and `value` holds the immediate directly.
+    /// Always non-null in the shipped default (lever `none`), where every
+    /// message gets its own heap exactly as originally specified.
+    gc: ?*memory.GC,
     value: Value = types.VOID,
     next: ?*Envelope = null,
 
@@ -60,6 +66,16 @@ pub const Envelope = struct {
     /// revisit only alongside a genuinely process-global (not per-thread
     /// chained) symbol table.
     pub fn create(payload: Value) !*Envelope {
+        // Lever C / C+D (kaappi#1472): a non-pointer immediate is self-contained
+        // -- deepCopy returns it unchanged -- so skip the per-message heap (and
+        // its GC struct + ~8 KiB root buffer) entirely. Comptime-pruned to the
+        // shipped path below whenever the instrument build flag is off.
+        if (instrument.immediatesElided() and !types.isPointer(payload)) {
+            const env = try std.heap.c_allocator.create(Envelope);
+            env.* = .{ .gc = null, .value = payload };
+            return env;
+        }
+
         const gc = try std.heap.c_allocator.create(memory.GC);
         gc.* = memory.GC.init(std.heap.c_allocator);
         // Defense in depth: deepCopy's own no_collect guard already
@@ -76,6 +92,9 @@ pub const Envelope = struct {
         errdefer std.heap.c_allocator.destroy(env);
         env.* = .{ .gc = gc };
         env.value = try gc.deepCopy(payload);
+        // Secondary metric (§3): the live per-message heap footprint invisible
+        // to any GC. No-op when the instrument flag is off.
+        instrument.envelopeBytesAdd(gc.bytes_allocated);
         return env;
     }
 
@@ -85,8 +104,11 @@ pub const Envelope = struct {
     /// self-send's aliased stub). No separate envelope-specific bookkeeping
     /// exists; this is the same teardown path a real GC uses.
     pub fn deinit(self: *Envelope) void {
-        self.gc.deinit();
-        std.heap.c_allocator.destroy(self.gc);
+        if (self.gc) |gc| {
+            instrument.envelopeBytesSub(gc.bytes_allocated);
+            gc.deinit();
+            std.heap.c_allocator.destroy(gc);
+        }
         std.heap.c_allocator.destroy(self);
     }
 };
@@ -431,6 +453,12 @@ pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !Sen
     // Built outside the lock: deepCopy allocates and must not hold the
     // channel mutex. A reservation was already taken, so the eventual push
     // (on success) is infallible.
+    //
+    // T_submit_copy (kaappi#1472 §3): time the parent's envelope build here on
+    // the send path only -- a worker returning a result accumulates into its
+    // own threadlocal, which the gate never reads. No-op when the instrument
+    // build flag is off.
+    const copy_timer = instrument.begin();
     const env = Envelope.create(payload) catch |err| {
         lockChannel(sc);
         sc.reserved -= 1;
@@ -447,6 +475,7 @@ pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !Sen
         // .create already tore itself down internally on failure.
         return err;
     };
+    instrument.endSubmit(copy_timer);
 
     lockChannel(sc);
     sc.reserved -= 1;
@@ -476,6 +505,10 @@ pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifi
         unlockChannel(sc);
         ring(snap.items);
 
+        // T_result_copy (kaappi#1472 §3): the parent copying a result out of a
+        // reply envelope, on its critical path. Same per-thread attribution as
+        // T_submit_copy; no-op when the instrument build flag is off.
+        const copy_timer = instrument.begin();
         const value = dest_gc.deepCopy(env.value) catch |err| {
             // "Receive fails ⇒ nothing received": the envelope is
             // untouched, its stubs keep their refcounts, the message stays
@@ -489,6 +522,7 @@ pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifi
             ring(recv_snap.items);
             return err;
         };
+        instrument.endResult(copy_timer);
         env.deinit();
         return .{ .value = value };
     }

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -91,7 +91,20 @@ pub const Envelope = struct {
         const env = try std.heap.c_allocator.create(Envelope);
         errdefer std.heap.c_allocator.destroy(env);
         env.* = .{ .gc = gc };
-        env.value = try gc.deepCopy(payload);
+        if (comptime instrument.enabled) {
+            // Lever C+D (kaappi#1472): signal deepCopy to snapshot a large
+            // bytevector into a shared immutable side-buffer (lever D) instead
+            // of copying it. Saved/restored so a nested build (a message
+            // carrying a channel whose queue drains via Envelope.create) can't
+            // clobber an outer build's mode. Comptime-pruned to the plain
+            // deepCopy below in the shipped build.
+            const prev_build_d = instrument.envelope_build_d;
+            instrument.envelope_build_d = (instrument.lever() == .cd);
+            defer instrument.envelope_build_d = prev_build_d;
+            env.value = try gc.deepCopy(payload);
+        } else {
+            env.value = try gc.deepCopy(payload);
+        }
         // Secondary metric (§3): the live per-message heap footprint invisible
         // to any GC. No-op when the instrument flag is off.
         instrument.envelopeBytesAdd(gc.bytes_allocated);

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -428,6 +428,50 @@ test "instrument lever C: an immediate payload skips the envelope heap (kaappi#1
     try std.testing.expectEqual(baseline, shared_object.liveCount());
 }
 
+test "instrument lever D: a large bytevector crosses by shared buffer, then copies on write (kaappi#1472)" {
+    if (comptime !instrument.enabled) return;
+    const baseline = shared_object.liveCount();
+    defer instrument.setLever(.none); // process-global; restore for other tests
+    instrument.setLever(.cd);
+
+    const sc = try shared_channel.SharedChannel.create();
+
+    var src_gc = memory.GC.init(std.testing.allocator);
+    defer src_gc.deinit();
+    var data: [8192]u8 = undefined; // >= the 4 KiB lever-D threshold
+    for (&data, 0..) |*b, i| b.* = @intCast(i % 256);
+    const bv = try src_gc.allocBytevector(&data);
+
+    _ = try shared_channel.send(sc, bv, null);
+    // Send side: the envelope's bytevector is backed by a SharedBuffer (one
+    // snapshot), not a plain byte copy.
+    const env_bv = types.toObject(sc.queue_head.?.value).as(types.Bytevector);
+    try std.testing.expect(env_bv.shared != null);
+    const shared_ptr = env_bv.shared.?;
+
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    defer dest_gc.deinit();
+    const recv = try shared_channel.receive(sc, &dest_gc, null);
+    const recv_bv = types.toObject(recv.value).as(types.Bytevector);
+    // Receive side: aliased the SAME buffer (no new snapshot), bytes intact.
+    try std.testing.expect(recv_bv.shared == shared_ptr);
+    try std.testing.expectEqualSlices(u8, &data, recv_bv.data);
+
+    // Copy-on-write: unshare privatizes the bytes and drops the reference, so
+    // the copy is byte-identical and then safe to mutate.
+    try dest_gc.unshareBytevector(recv_bv);
+    try std.testing.expect(recv_bv.shared == null);
+    try std.testing.expectEqualSlices(u8, &data, recv_bv.data);
+    recv_bv.data[0] = 0xFF;
+    try std.testing.expectEqual(@as(u8, 0xFF), recv_bv.data[0]);
+
+    sc.release();
+    // The SharedBuffer was freed when unshare dropped the last reference (the
+    // envelope's own reference went at receive-time env.deinit); the channel is
+    // freed by release. Both were shared_object.liveCount() entries.
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
 test "send: bounded-and-full channel registers a send waiter and would park" {
     // White-box: no Phase-1 Scheme API constructs a channel with a
     // non-null capacity yet (KEP-0002 Phase 4) -- direct construction only.

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
 const shared_object = @import("shared_object.zig");
+const instrument = @import("channel_instrument.zig");
 const reactor_mod = @import("reactor.zig");
 const th = @import("testing_helpers.zig");
 
@@ -383,6 +384,46 @@ test "send: build failure leaves the queue and reservation untouched (send fails
     try std.testing.expectEqual(@as(?*shared_channel.Envelope, null), sc.queue_head);
 
     src_gc.deinit();
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "instrument lever C: an immediate payload skips the envelope heap (kaappi#1472)" {
+    // Only meaningful in the gate-campaign build (-Dchannel-instrument=true);
+    // the default/shipped build compiles the elision branch out, so this is a
+    // trivial pass there. Run with -Dchannel-instrument=true to exercise it.
+    if (comptime !instrument.enabled) return;
+    const baseline = shared_object.liveCount();
+    defer instrument.setLever(.none); // process-global; restore for other tests
+
+    const sc = try shared_channel.SharedChannel.create();
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    defer dest_gc.deinit();
+
+    // Lever none: even a fixnum message gets its own private heap (the shipped
+    // per-message behavior).
+    instrument.setLever(.none);
+    _ = try shared_channel.send(sc, types.makeFixnum(42), null);
+    try std.testing.expect(sc.queue_head.?.gc != null);
+    const r0 = try shared_channel.receive(sc, &dest_gc, null);
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(r0.value));
+
+    // Lever C: the same immediate skips the heap entirely (gc == null) and
+    // still round-trips correctly.
+    instrument.setLever(.c);
+    _ = try shared_channel.send(sc, types.makeFixnum(7), null);
+    try std.testing.expect(sc.queue_head.?.gc == null);
+    const r1 = try shared_channel.receive(sc, &dest_gc, null);
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(r1.value));
+
+    // A pointer payload still takes the heap path under lever C.
+    var src_gc = memory.GC.init(std.testing.allocator);
+    defer src_gc.deinit();
+    const pair = try src_gc.allocPair(types.makeFixnum(1), types.NIL);
+    _ = try shared_channel.send(sc, pair, null);
+    try std.testing.expect(sc.queue_head.?.gc != null);
+    _ = try shared_channel.receive(sc, &dest_gc, null);
+
     sc.release();
     try std.testing.expectEqual(baseline, shared_object.liveCount());
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -439,6 +439,15 @@ pub const Vector = struct {
 pub const Bytevector = struct {
     header: Object,
     data: []u8,
+    /// Lever D (KEP-0002 Phase 7, kaappi#1472): when non-null, `data` is
+    /// borrowed from a refcounted immutable `shared_buffer.SharedBuffer` (this
+    /// bytevector holds one reference) rather than owned -- so a large payload
+    /// crossing a channel is shared, not re-copied. Kept opaque so types.zig,
+    /// the dependency-free base layer, doesn't import a feature module (the same
+    /// precedent as Channel.shared / FfiLibrary.handle). freeObject releases the
+    /// reference; a mutator first calls GC.unshareBytevector (copy-on-write).
+    /// Always null in the shipped default (lever `none`).
+    shared: ?*anyopaque = null,
 };
 
 pub const Promise = struct {


### PR DESCRIPTION
Builds the **`parallel-map` gate-campaign** half of KEP-0002 Phase 7 (#1472) — the harness that produces the copy+reassembly overhead `share` dataset the KEP-0003 acceptance gate (#1474) consumes, per the frozen protocol at [keps `research/benchmarks/README.md`](https://github.com/kaappi/keps/blob/main/research/benchmarks/README.md). Two coherent commits:

### 1. Harness + instrumentation + lever C (`b811d372`)
- **`src/channel_instrument.zig`** (behind a new `-Dchannel-instrument=true` build flag; compiled out of the shipped default per protocol §3): the parent-side `T_submit_copy` / `T_result_copy` / `T_reassembly` counters, the runtime elision-lever flag, and a peak-envelope gauge.
- **`shared_channel.zig`**: times the real `send`/`receive` copy path; **lever C** skips the envelope heap for immediate payloads (`Envelope.gc` is now optional).
- **`primitives_parallel.zig`**: `%chan-instr-*` / `%elision-lever-set!` harness hooks, registered only in the instrument build so the shipped `(kaappi fibers)` is unchanged.
- **`benchmarks/gate/`**: the six workloads + controls + serial baselines (`gate-harness.scm`), the Kalibera–Jones driver emitting the §6 CSV (`run-gate.py`), and a `README.md` mapping every piece to the protocol and recording the pre-freeze findings.

### 2. Lever D in the real path (`37b64f0e`)
The gate's `C+D` cells require it (§2). A bytevector ≥ 4 KiB crossing a channel is snapshotted **once** into a refcounted immutable `SharedBuffer` (`src/shared_buffer.zig`, the second `shared_object` after `SharedChannel`) and shared by refcount: **zero-copy on receive, copy-on-write on mutation**. `types.Bytevector.shared` borrows the bytes; `gc_deep_copy` handles send (snapshot) / receive (alias); `gc_collect` releases the reference; `unshareBytevector` does COW (wired into `bytevector-u8-set!` / `copy!` / `read-bytevector!`). All comptime-pruned in the shipped build.

**Scope** (documented, neither affects the classification): bytevectors only — flonum vectors and record trees are byte-opaque, so D correctly leaves them at their `none` share (the pre-KEP-0003 "walk tax" §1 measures); and no plain-source promotion, so a bytevector fan-out still snapshots per envelope (only affects the compute-dominated FO-DIGEST).

## Verification
- Full unit suite green on **normal and `-Dchannel-instrument=true`** builds (new lever-C and lever-D regression tests + the internal-spec drift guard); lever-D test also green under **`-Dgc-stress=true`**.
- Channel/fiber/parallel Scheme smoke tests green; shipped path byte-identical (`%chan-instr-*` undefined in a normal build).
- End-to-end pool test delivers correct bytes across a real thread and COW-mutates safely; local pilot on macOS aarch64 produced a §6 CSV with well-differentiated `share` (fo-tree ~68%, fo-slice ~50%, ip-map ~24%, ip-band/matmul/digest lower). At `C+D`, ip-band drops parent result-copy time ~10× and peak envelope bytes ~40× vs `none`.

## Not in this PR (deferred, operational)
The frozen §4 two-machine collection, the worksheet fill-in, and the KEP-0002 UQ 1 amendment. The pilot showed **#1489 (intermittent pool hang, ~8% of invocations)** is the practical blocker for a clean frozen run and is worth fixing first. See `benchmarks/gate/README.md` for the full pre-freeze findings (also: records don't survive channel copy → FO-TREE uses vector nodes; interpreted matmul cost at 64 MiB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)