### PR TITLE
Fix lost cross-thread wakeup in shared channel send/receive (#1489)

### DIFF
--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -403,7 +403,36 @@ fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: 
         // (channelReceiveShared) for why `me` must stay .running throughout.
         me.timed_out = false;
         _ = try fiber_mod.runSchedulerStep(SharedChannelSendPoll, .{ .sc = sc }, ctx.vm, ctx.sched, me);
-        if (sc.peekSendReady()) continue; // loop back to 1: re-derive via send()
+
+        // Re-derive readiness THROUGH send(), never a bare peekSendReady():
+        // symmetric to channelReceiveShared's re-receive (kaappi#1489). The
+        // drive can consume this fiber's one-shot send_waiters registration -- a
+        // sibling receive frees a slot, clearing+ringing it, and a sibling send
+        // refills it -- leaving the channel full AND this fiber unregistered, so
+        // peekSendReady() would fall through to a park no later remote receive
+        // can ring. Re-calling send() re-registers under the channel lock when
+        // the channel is still full (the full path enqueues nothing, so there is
+        // no double-send), and enqueues + returns .sent if the drive opened a
+        // slot.
+        const redo = shared_channel.send(sc, payload, notifier) catch |err|
+            return translateSharedChannelError(err, "channel-send");
+        switch (redo) {
+            .sent => {
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
+                return types.VOID;
+            },
+            .closed => {
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
+                return raiseFiberError("channel-send: send on closed channel");
+            },
+            .would_park => {},
+        }
 
         if (is_dispatched) {
             me.status = .waiting;
@@ -579,7 +608,39 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         // decision safe.
         me.timed_out = false;
         _ = try fiber_mod.runSchedulerStep(SharedChannelPoll, .{ .sc = sc }, ctx.vm, ctx.sched, me);
-        if (sc.peekReady()) continue; // loop back to 1: re-derive via receive()
+
+        // Re-derive readiness THROUGH receive(), never a bare peekReady(): the
+        // drive above can consume this fiber's one-shot recv_waiters
+        // registration -- a local sibling's channel-send clears+rings it and a
+        // sibling channel-receive drains the value -- leaving the channel empty
+        // AND this fiber unregistered. peekReady() sees "empty" and falls
+        // through to a park no later remote send can ever ring (kaappi#1489):
+        // the send finds recv_waiters empty and rings nothing, while the
+        // shared-waiter registry entry keeps hasRunnableFibers() true so the
+        // deadlock detector stays suppressed, and the fiber hangs forever. A
+        // second receive() re-registers the notifier under the channel lock
+        // whenever it returns .would_park, so the park below is always armed;
+        // if the drive instead produced a value (or EOF), it is returned here
+        // and the fiber never parks.
+        const redo = shared_channel.receive(sc, gc, notifier) catch |err|
+            return translateSharedChannelError(err, "channel-receive");
+        switch (redo) {
+            .value => |v| {
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
+                return v;
+            },
+            .eof => {
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
+                return types.EOF;
+            },
+            .would_park => {},
+        }
 
         if (is_dispatched) {
             me.status = .waiting;

--- a/tests/scheme/smoke/fiber-channel-lost-wakeup-1489.scm
+++ b/tests/scheme/smoke/fiber-channel-lost-wakeup-1489.scm
@@ -1,0 +1,40 @@
+;; Regression test for kaappi#1489: a lost cross-thread wakeup.
+;;
+;; A local sibling fiber's channel-send + channel-receive, executed during a
+;; receiver's SharedChannelPoll drive, used to consume the receiver's one-shot
+;; recv_waiters notifier registration and leave it parked-but-unregistered, so a
+;; later send from a real peer thread rang nothing and the receiver hung forever
+;; (the fix re-derives readiness through receive() after the drive, re-arming the
+;; registration under the channel lock before the park).
+;;
+;; Bounded by a receive timeout so a regression is a FAIL, not a hang (which
+;; tests/scheme/run-all.sh would SKIP and thereby hide): pre-fix, the parked
+;; receiver's notifier is disarmed, the remote send rings nothing, and only the
+;; 5 s timer fires (=> 'timed-out); post-fix, the remote send wakes it (=> 42).
+;; The remote sleep makes the receiver reach its park before the send arrives,
+;; so the send must travel the wakeup path this test guards.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (kaappi fibers) (srfi 18) (srfi 64))
+
+(test-begin "fiber-channel-lost-wakeup-1489")
+
+(define result
+  (let ((ch (make-channel)))            ; local => captured by the thunk => promoted
+    (define t (make-thread (lambda ()
+                             (thread-sleep! 0.5)   ; let the receiver park first
+                             (channel-send ch 42))))
+    (thread-start! t)
+    (spawn (lambda ()
+             (channel-send ch 'decoy)   ; snapshots-and-clears recv_waiters, rings
+             (channel-receive ch)))     ; drains its own value back
+    (let ((got (channel-receive ch 5 'timed-out)))  ; parks; must be woken by the remote send
+      (thread-join! t)
+      got)))
+
+(test-equal "remote send wakes a receiver whose notifier a local decoy disarmed"
+  42 result)
+
+(let ((runner (test-runner-current)))
+  (test-end "fiber-channel-lost-wakeup-1489")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #1489.

A fiber receiving on a promoted (shared) channel could park **permanently** even though a live peer thread later sends. During the receiver's `SharedChannelPoll` drive, a local sibling's `channel-send` + `channel-receive` consumes the receiver's one-shot `recv_waiters` notifier registration, and the fall-through readiness check — `peekReady()` — re-derives "empty" **without re-registering**. The later remote send finds `recv_waiters` empty and rings nothing; the parked fiber's `shared_waiters` registry entry keeps `hasRunnableFibers()` true, so the deadlock detector stays (by design) suppressed, and the process hangs silently forever.

This surfaced as the intermittent (~8%) pool hang that made the KEP-0002 Phase 7 gate campaign (#1472) lose invocations.

## Fix

Re-derive readiness after the drive **through `receive()` itself**, not a bare `peekReady()` (the fix direction from the issue): `receive()` re-registers the notifier under the channel lock whenever it returns `.would_park`, so the park below is always armed — and if the drive produced a value/EOF, it's returned immediately instead of parking.

`channelSendShared` had the identical latent bug for bounded channels (a sibling receive+send during the drive consuming its `send_waiters` registration), fixed symmetrically via `send()` — safe because `send()` on a full channel re-registers and enqueues nothing, so there's no double-send.

## Test

`tests/scheme/smoke/fiber-channel-lost-wakeup-1489.scm` is the issue's repro, **bounded by a receive timeout** so a regression is a FAIL rather than a hang (which `run-all.sh` would SKIP and hide): pre-fix the receiver is never woken and the timer fires (`'timed-out`); post-fix the remote send wakes it (`42`). Verified to fail without the fix and pass with it.

## Verification
- Repro: 20/20 runs, zero hangs (was exit-142 hang pre-fix).
- The three gate-campaign cells that hung ~8% of the time: **90/90 clean** post-fix.
- Full unit suite green on the normal build and under `-Dgc-stress=true` for fiber/channel/scheduler/srfi18.
- Bounded-channel, close, timeout, and parallel smoke tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)