### PR TITLE
Ship envelope elision lever C (immediate fast path) as the default (#1472)

### DIFF
--- a/docs/dev/kep-0002-phase7-envelope-benchmarks.md
+++ b/docs/dev/kep-0002-phase7-envelope-benchmarks.md
@@ -12,7 +12,9 @@ The other Phase 7 half — the `parallel-map` scaling curve that feeds the
 KEP-0003 acceptance gate ([kaappi#1474](https://github.com/kaappi/kaappi/issues/1474)),
 under the full Kalibera–Jones statistics of
 [keps `research/benchmarks/README.md`](https://github.com/kaappi/keps/blob/main/research/benchmarks/README.md)
-— is separate and still to do (see [Status](#status--what-remains)).
+— is separate; its harness, lever D, and the macOS aarch64 frozen run have
+landed (classified **Between**, KEP-0003 stays gated), with only the Linux
+x86_64 publish-half open (see [Status](#status--what-remains)).
 
 ## Running it
 
@@ -120,9 +122,15 @@ block mechanically.
 Fixnum A/C = **107.9×** (ReleaseSafe), **27.8×** (ReleaseFast). Both
 build modes clear 2× by more than an order of magnitude, and C erases
 the two fixed allocations. This is the near-certain outcome P3
-predicted. **Recommend shipping C** — a `!isPointer(payload)` fast path
-in `shared_channel.send`/`receive` that carries the raw value instead of
-building an envelope.
+predicted. **Shipped as the default** — `Envelope.create` in
+`shared_channel.zig` now carries a `!isPointer(payload)` immediate inline
+(no private heap) unconditionally in the shipped build. `deepCopy` of a
+non-pointer returns it unchanged, so the fast path is provably identical
+to the full envelope path for immediates (the full path would only build
+an empty heap and store the same value). Under `-Dchannel-instrument` the
+elision stays lever-selectable so the gate's `none` lever keeps forcing
+the pre-C baseline; the default-build regression test is in
+`tests_shared_channel.zig` ("lever C shipped default").
 
 ### (B) reusable arena — **ship candidate under ReleaseSafe, pending the second clause**
 
@@ -194,6 +202,11 @@ Done in this pass:
   into the full A/B/C/D matrix, with a counting allocator and the
   mechanical P3 decision printer. Unit suite green; the file is a
   standalone bench executable, outside the `test` graph.
+- **Lever C shipped as the default** — `Envelope.create` carries a
+  `!isPointer(payload)` immediate inline (no private heap) unconditionally
+  in the shipped build; still lever-selectable under `-Dchannel-instrument`
+  so the gate's `none` baseline is preserved. Default-build regression test
+  added ("lever C shipped default" in `tests_shared_channel.zig`).
 
 Still open for Phase 7 / #1472:
 
@@ -205,26 +218,19 @@ Still open for Phase 7 / #1472:
    suite, checking the lifetime rule stays contained. This is the P3 (B)
    second clause; without it the ≥30% result is necessary but not
    sufficient.
-3. **Lever-C ship** — the immediate fast path now exists in the real
-   `send`/`receive` (behind `-Dchannel-instrument`, as the gate lever
-   `c`; see the gate campaign below). Promoting it to the shipped default
-   (lever-invariant, no flag) with a regression test is the remaining
-   step.
-4. **KEP-0002 UQ 1 amendment** — record the A/B/C/D outcome (ship C; B
-   pending clause 2; D deferred) into KEP-0002, per #1472's acceptance.
-   Best done after (1).
-5. **The gate campaign** — the `parallel-map` IP-*/FO-* workloads, the
+3. **The gate campaign** — the `parallel-map` IP-*/FO-* workloads, the
    parent-side copy-overhead-share instrumentation, the Kalibera–Jones
    statistics driver, the CSV + classification worksheet, and lever D
    wired behind a flag in the real path. The larger, separate half of
-   #1472 that feeds #1474. **Harness landed** in `benchmarks/gate/` (see
-   `benchmarks/gate/README.md`): the six workloads + controls, the real-
-   path `share` counters (`src/channel_instrument.zig` →
-   `src/shared_channel.zig`), levers `none`/`c`/`cd`, and the K–J driver
-   emitting the §6 CSV, all locally piloted on macOS aarch64. **Lever D**
-   (refcounted immutable side-heap for large bytevectors,
-   `src/shared_buffer.zig`, zero-copy receive + copy-on-write) is wired
-   into the real deepCopy path behind `-Dchannel-instrument`, so the gate's
-   `C+D` cells are now runnable. Still open there: the frozen two-machine
-   §4 collection and the worksheet fill-in — ideally after kaappi#1489
-   (the intermittent pool hang) is fixed.
+   #1472 that feeds #1474. **Landed and largely done**: the harness in
+   `benchmarks/gate/` (six workloads + controls, the real-path `share`
+   counters `src/channel_instrument.zig` → `src/shared_channel.zig`, levers
+   `none`/`c`/`cd`, the K–J driver emitting the §6 CSV), **lever D**
+   (`src/shared_buffer.zig`, zero-copy receive + copy-on-write behind
+   `-Dchannel-instrument`), the kaappi#1489 pool-hang fix, and the **macOS
+   aarch64 frozen run** (920 launches, 0 failures) → classified **Between**,
+   so KEP-0003 stays gated (worksheet
+   `docs/dev/kep-0003-acceptance-gate-worksheet.md`, dataset in
+   `benchmarks/gate/results/`). The only open piece is the Linux x86_64 run
+   (item 1); per §5 it cannot change the combined outcome (macOS=Between ⇒
+   combined=Between), so it is a publish-completeness follow-up.

--- a/src/channel_instrument.zig
+++ b/src/channel_instrument.zig
@@ -107,7 +107,10 @@ pub fn reset() void {
 // (no ordering is piggybacked on it).
 // --------------------------------------------------------------------------
 pub const Lever = enum(u8) {
-    /// Per-message envelopes exactly as `shared_channel.zig` ships.
+    /// The pre-C baseline: every message gets its own private heap, immediates
+    /// included. This was the shipped behavior before lever C shipped as the
+    /// default (kaappi#1472); the gate keeps it selectable so the frozen
+    /// protocol's baseline (lever A) stays reproducible under this build flag.
     none = 0,
     /// `none` + immediates (fixnums/booleans/chars/flonums/nil) skip the
     /// envelope heap entirely.

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -37,11 +37,13 @@ const releaseNotifier = reactor_mod.releaseNotifier;
 /// fills it once, the receiver's deepCopy drains it once, then it is
 /// destroyed wholesale.
 pub const Envelope = struct {
-    /// null only for a lever-C/C+D immediate envelope (KEP-0002 Phase 7,
-    /// kaappi#1472): a fixnum/boolean/char/flonum/nil payload is self-contained,
-    /// so no private heap is built and `value` holds the immediate directly.
-    /// Always non-null in the shipped default (lever `none`), where every
-    /// message gets its own heap exactly as originally specified.
+    /// null for an immediate envelope (lever C, KEP-0002 Phase 7, kaappi#1472):
+    /// a fixnum/boolean/char/flonum/nil payload is self-contained, so no private
+    /// heap is built and `value` holds the immediate directly. This is the
+    /// shipped default. Non-null for a pointer payload (which needs its own
+    /// deep-copied heap), and for every payload -- immediates included -- under
+    /// the gate's `none` lever (-Dchannel-instrument), which forces the pre-C
+    /// full-envelope baseline so the frozen protocol stays reproducible.
     gc: ?*memory.GC,
     value: Value = types.VOID,
     next: ?*Envelope = null,
@@ -66,11 +68,25 @@ pub const Envelope = struct {
     /// revisit only alongside a genuinely process-global (not per-thread
     /// chained) symbol table.
     pub fn create(payload: Value) !*Envelope {
-        // Lever C / C+D (kaappi#1472): a non-pointer immediate is self-contained
-        // -- deepCopy returns it unchanged -- so skip the per-message heap (and
-        // its GC struct + ~8 KiB root buffer) entirely. Comptime-pruned to the
-        // shipped path below whenever the instrument build flag is off.
-        if (instrument.immediatesElided() and !types.isPointer(payload)) {
+        // Lever C (kaappi#1472) -- shipped as the default. A non-pointer
+        // immediate (fixnum/boolean/char/flonum/nil) is self-contained:
+        // deepCopy returns it unchanged (gc_deep_copy.zig, `if (!isPointer)
+        // return src`), so the full path below would only build an empty private
+        // heap and store the same value back. Skip that heap (its GC struct +
+        // ~8 KiB root buffer) and carry the immediate inline instead. The P3
+        // micro-benchmark measured 28-108x on fixnum messages and the KEP-0002
+        // UQ-1 amendment recorded C as ship (immediates >= 2x lever A).
+        //
+        // Always on in the shipped default (the `else true` arm below compiles
+        // to an unconditional fast path referencing no instrument state). Under
+        // -Dchannel-instrument the gate keeps it lever-selectable: the frozen
+        // protocol's pre-C baseline (`none`) forces the full-envelope path even
+        // for immediates so it stays reproducible; `c`/`cd` enable elision.
+        const elide_immediates = if (comptime instrument.enabled)
+            instrument.immediatesElided()
+        else
+            true;
+        if (elide_immediates and !types.isPointer(payload)) {
             const env = try std.heap.c_allocator.create(Envelope);
             env.* = .{ .gc = null, .value = payload };
             return env;

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -389,9 +389,10 @@ test "send: build failure leaves the queue and reservation untouched (send fails
 }
 
 test "instrument lever C: an immediate payload skips the envelope heap (kaappi#1472)" {
-    // Only meaningful in the gate-campaign build (-Dchannel-instrument=true);
-    // the default/shipped build compiles the elision branch out, so this is a
-    // trivial pass there. Run with -Dchannel-instrument=true to exercise it.
+    // The lever is only selectable in the gate-campaign build
+    // (-Dchannel-instrument=true); the shipped build has C always on (covered by
+    // the default-build test below), so this lever-sweep test is a trivial pass
+    // there. Run with -Dchannel-instrument=true to exercise it.
     if (comptime !instrument.enabled) return;
     const baseline = shared_object.liveCount();
     defer instrument.setLever(.none); // process-global; restore for other tests
@@ -425,6 +426,47 @@ test "instrument lever C: an immediate payload skips the envelope heap (kaappi#1
     _ = try shared_channel.receive(sc, &dest_gc, null);
 
     sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "lever C shipped default: immediates skip the envelope heap, pointers keep it (kaappi#1472)" {
+    // Mirror of the lever-sweep test above, for the shipped/default build: with
+    // no -Dchannel-instrument, lever C is unconditionally on. An instrument
+    // build defaults to lever `none` (the pre-C baseline), where immediates
+    // would take the heap path, so restrict this to the non-instrument build.
+    if (comptime instrument.enabled) return;
+    const baseline = shared_object.liveCount();
+
+    const sc = try shared_channel.SharedChannel.create();
+    var dest_gc = memory.GC.init(std.testing.allocator);
+    defer dest_gc.deinit();
+
+    // Every immediate encoding is self-contained, so each skips the private
+    // heap (gc == null) and still round-trips through the destination gc.
+    const immediates = [_]types.Value{
+        types.makeFixnum(42),
+        types.TRUE,
+        types.makeChar('λ'),
+        types.NIL,
+        types.makeFlonum(3.14), // direct f64 bit pattern -- a non-pointer
+    };
+    for (immediates) |imm| {
+        _ = try shared_channel.send(sc, imm, null);
+        try std.testing.expect(sc.queue_head.?.gc == null);
+        const r = try shared_channel.receive(sc, &dest_gc, null);
+        try std.testing.expectEqual(imm, r.value);
+    }
+
+    // A pointer payload still gets its own deep-copied heap (gc != null).
+    var src_gc = memory.GC.init(std.testing.allocator);
+    defer src_gc.deinit();
+    const pair = try src_gc.allocPair(types.makeFixnum(1), types.NIL);
+    _ = try shared_channel.send(sc, pair, null);
+    try std.testing.expect(sc.queue_head.?.gc != null);
+    _ = try shared_channel.receive(sc, &dest_gc, null);
+
+    sc.release();
+    // No envelope heap leaks (an immediate envelope owns no GC to destroy).
     try std.testing.expectEqual(baseline, shared_object.liveCount());
 }
 


### PR DESCRIPTION
## What

Makes **lever C** — cross-thread immediate messages skip the per-message envelope heap — the **shipped default**, instead of a benchmark-only lever behind `-Dchannel-instrument`.

Part of KEP-0002 Phase 7 ([#1472](https://github.com/kaappi/kaappi/issues/1472)). The P3 A/B/C/D micro-benchmark decided C ships (pre-registered criterion: immediates ≥ 2× lever A on fixnums — measured **28× ReleaseFast / 108× ReleaseSafe**), and the KEP-0002 UQ-1 amendment recorded that decision. This turns the recorded decision into product code.

## Why it's safe

For any non-pointer payload (fixnum / boolean / char / flonum / nil), `deepCopy` returns the value **unchanged** (`gc_deep_copy.zig`: `if (!isPointer(src)) return src`). So the full envelope path only ever built an empty private mini-heap and stored the same value back. The fast path carries that value inline and skips the GC struct + ~8 KiB root buffer — **provably identical observable behavior**, minus two allocations per immediate message. `receive()` (`deepCopy` of an immediate is a no-op) and `deinit()` (`if (self.gc)`) already handle the null-heap envelope.

## Frozen-protocol preservation

Under `-Dchannel-instrument` the elision stays **lever-selectable**: the gate's `none` lever still forces the pre-C full-envelope path even for immediates, so the frozen KEP-0003 acceptance-gate baseline (lever A) stays reproducible. Only the shipped (non-instrument) build changes behavior. The existing instrument lever-sweep test still asserts `none` ⇒ full envelope and passes.

## Tests

- New default-build regression test `"lever C shipped default"` in `tests_shared_channel.zig`: every immediate encoding (fixnum, boolean, char, nil, flonum) yields a null-`gc` envelope that round-trips; a pointer payload still gets a heap; no envelope-heap leak. Proven to actually execute via a flip-and-revert (broke the assertion → suite failed → restored).
- `zig build test` (default) ✅ · `zig build test -Dchannel-instrument=true` ✅ · `zig build test -Dgc-stress=true` (shared/lever-C filter) 52/52 ✅
- All channel/fiber/parallel/thread Scheme smoke tests ✅
- E2E: every immediate encoding round-trips across a **real OS-thread** channel under the shipped default ✅
- `bench-channel` still compiles/runs ✅ · `zig fmt` clean ✅

## Docs

`docs/dev/kep-0002-phase7-envelope-benchmarks.md` updated: (C) section marked shipped, status list reconciled (lever-C ship done; gate campaign macOS run landed as "Between").

🤖 Generated with [Claude Code](https://claude.com/claude-code)