### PR TITLE
Index parked fibers by waited-on object for O(1) wakes (#1530)

### DIFF
--- a/docs/dev/kep-0001-phase7-benchmarks.md
+++ b/docs/dev/kep-0001-phase7-benchmarks.md
@@ -379,7 +379,12 @@ discriminator exists to survive, not a real error to clean up after.
    `FiberScheduler.schedule()`/`addFiber()` O(fiber count) scans don't
    scale past ~1,000 concurrently-live fibers — replace with an O(1)/O(log
    n) ready-queue design. Directly explains the `http-listen-fiber` p99
-   regression above.
+   regression above. **Resolved:** the dispatch/spawn hot path became O(1)
+   in [#1525](https://github.com/kaappi/kaappi/pull/1525) (ready ring +
+   free-slot list); the residual O(fiber count) *wake* scans
+   (`wakeWaiters`/`wakeChannelWaiters`/mutex+condvar wakes) were the
+   follow-up [#1530](https://github.com/kaappi/kaappi/issues/1530), fixed
+   with a by-object waiter index (each wake now O(waiters-on-that-object)).
 2. [#1478](https://github.com/kaappi/kaappi/issues/1478) — wire
    `kaappi-net`'s raw TCP sockets into `Reactor.register`/`waitForFd`
    properly, so `http-listen-fiber` gets genuine event-driven wakeup

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -137,6 +137,31 @@ pub const FiberScheduler = struct {
     /// order) via free_head, compacted lazily. Slot 0 (main) is never pushed.
     free_slots: std.ArrayList(usize),
     free_head: usize,
+    /// #1530: O(waiters-on-object) wakes. Secondary index mapping a waited-on
+    /// Value (a fiber to join, a channel, a mutex, a condition variable) to the
+    /// slot indices of the fibers currently parked (`.waiting`) on it, so the
+    /// wake paths (wakeWaiters/wakeChannelWaiters/wakeMutexWaiters/
+    /// wakeOneCondVarWaiter/wakeAllCondVarWaiters) touch only the relevant
+    /// waiters instead of rescanning every slot. Slot indices (not `*Fiber`)
+    /// so a since-reused or since-terminated slot is caught by validation at
+    /// wake time (like the ready ring's popReady) rather than dangling — a
+    /// terminated waiter therefore needs no explicit de-index, unlike the
+    /// pointer-holding shared_waiters registry. Enrolled by enrollWaiter at
+    /// every local park site; consulted authoritatively (no fallback scan) by
+    /// the wake paths, EXCEPT when degraded (see below). Only ever holds local
+    /// waiters: a fiber parked on a *promoted* channel is woken through
+    /// sweepSharedWaiters instead and is deliberately never enrolled here.
+    waiter_index: std.AutoHashMap(Value, std.ArrayList(usize)),
+    /// Sticky fallback switch (#1530). enrollWaiter allocates (a map entry and
+    /// a list slot); if that ever OOMs, the just-parked fiber would be absent
+    /// from `waiter_index` and an index-only wake could never find it — a
+    /// lost-wakeup hang. Rather than fail the park (which would need per-site
+    /// rollback of the timer/deadline state), enrollWaiter sets this flag and
+    /// the wake paths permanently fall back to the pre-#1530 authoritative
+    /// O(fiber count) scan. Post-OOM the VM is usually about to die anyway, so
+    /// giving up the accelerator forever (rather than trying to recover it) is
+    /// the responsible trade: worst case is exactly the old behavior.
+    waiter_index_degraded: bool,
 
     pub fn init(vm: *VM) FiberScheduler {
         return .{
@@ -149,6 +174,8 @@ pub const FiberScheduler = struct {
             .ready_head = 0,
             .free_slots = .empty,
             .free_head = 0,
+            .waiter_index = std.AutoHashMap(Value, std.ArrayList(usize)).init(vm.gc.allocator),
+            .waiter_index_degraded = false,
         };
     }
 
@@ -157,6 +184,9 @@ pub const FiberScheduler = struct {
         self.shared_waiters.deinit(allocator);
         self.ready.deinit(allocator);
         self.free_slots.deinit(allocator);
+        var it = self.waiter_index.valueIterator();
+        while (it.next()) |list| list.deinit(allocator);
+        self.waiter_index.deinit();
     }
 
     /// Shared lazy-compaction for the FIFO rings (`ready`, `free_slots`):
@@ -649,35 +679,142 @@ pub const FiberScheduler = struct {
         if (self.vm.reactor) |r| r.removeTimer(fiber);
     }
 
-    pub fn wakeWaiters(self: *FiberScheduler, completed_fiber: *Fiber) void {
-        const completed_val = types.makePointer(@ptrCast(&completed_fiber.header));
+    /// What doWake should do to each matched waiter beyond the common
+    /// suspend + cancel-timer + markRunnable. `all` distinguishes a broadcast
+    /// (wake every matching waiter) from a hand-off (wake the first, leave the
+    /// rest parked). `result`, when set, is stored into each woken fiber (the
+    /// fiber-join hand-off). `clear_waiting_on` blanks the woken fiber's
+    /// `waiting_on` (the channel retry contract; the join/mutex/condvar paths
+    /// leave it, matching their pre-#1530 behavior exactly).
+    const WakeSpec = struct {
+        all: bool,
+        result: ?Value = null,
+        clear_waiting_on: bool = false,
+    };
+
+    /// Enroll `fiber` (already flipped to `.waiting` with its `waiting_on`
+    /// set) into waiter_index so the matching wake path finds it without
+    /// scanning every slot (#1530). Call at every LOCAL park site; a park on a
+    /// promoted channel must NOT call this — it is woken via sweepSharedWaiters
+    /// (a stale local-index entry for it would merely be validated away).
+    /// A `waiting_on` of VOID (thread-sleep!'s pure timed wait) is never a
+    /// wake target, so it is skipped. The tail check makes a re-park on the
+    /// same object idempotent: the mutex/condvar retry loops re-enter
+    /// `.waiting` without an intervening wake, and dropping the duplicate keeps
+    /// the list length ~= concurrent waiters rather than growing with spins.
+    /// An allocation failure degrades the whole index to the fallback scan
+    /// (waiter_index_degraded) rather than leaving this fiber unfindable.
+    pub fn enrollWaiter(self: *FiberScheduler, fiber: *Fiber) void {
+        if (self.waiter_index_degraded) return;
+        const key = fiber.waiting_on;
+        if (key == types.VOID) return;
+        const gop = self.waiter_index.getOrPut(key) catch {
+            self.waiter_index_degraded = true;
+            return;
+        };
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+        const list = gop.value_ptr;
+        // Tail dedup: a re-park on the same object would otherwise append a
+        // second copy of this slot every spin. The prior entry is still valid
+        // (this fiber is `.waiting` on `key` again), so skipping keeps the
+        // list bounded by concurrent waiters, not iterations.
+        if (list.items.len != 0 and list.items[list.items.len - 1] == fiber.sched_idx) return;
+        list.append(self.vm.gc.allocator, fiber.sched_idx) catch {
+            // A brand-new key whose first append failed left an empty list in
+            // the map; drop it so an empty entry can't linger.
+            if (!gop.found_existing) _ = self.waiter_index.remove(key);
+            self.waiter_index_degraded = true;
+        };
+    }
+
+    /// The common tail of every wake path: move `fiber` from `.waiting` back
+    /// to `.suspended`, hand off any join result, cancel a pending timeout
+    /// timer, and enqueue it on the ready ring. Factored out so the index and
+    /// fallback-scan paths apply byte-identical semantics.
+    fn doWake(self: *FiberScheduler, fiber: *Fiber, spec: WakeSpec) void {
+        if (spec.result) |r| {
+            fiber.result = r;
+            self.vm.gc.writeBarrier(&fiber.header, r);
+        }
+        fiber.status = .suspended;
+        if (spec.clear_waiting_on) fiber.waiting_on = types.VOID;
+        self.cancelPendingTimer(fiber);
+        self.markRunnable(fiber);
+    }
+
+    /// Wake fibers parked on `key`, per `spec`. Uses waiter_index when healthy
+    /// (O(waiters-on-key)); falls back to the pre-#1530 O(fiber count) scan
+    /// only after an enroll OOM degraded the index. The single choke point
+    /// behind all five public wake entry points.
+    fn wakeOn(self: *FiberScheduler, key: Value, spec: WakeSpec) void {
+        if (self.waiter_index_degraded) return self.scanWakeOn(key, spec);
+        self.indexWakeOn(key, spec);
+    }
+
+    /// Index-driven wake. Walks only the slot indices enrolled under `key`,
+    /// validating each exactly as popReady validates a ready-ring entry (slot
+    /// still owns its index, still `.waiting`, still on `key`) so a
+    /// since-reused or since-woken slot can never wake the wrong fiber. Stale
+    /// entries and the woken one are compacted out; a broadcast empties the
+    /// list, a hand-off keeps the still-parked tail. An emptied list frees its
+    /// key so the map stays bounded by currently-contended objects — essential
+    /// for fiber-join keys, which are one-shot (one per completed fiber).
+    fn indexWakeOn(self: *FiberScheduler, key: Value, spec: WakeSpec) void {
+        const entry = self.waiter_index.getEntry(key) orelse return;
+        const list = entry.value_ptr;
+        var w: usize = 0; // write cursor: entries to keep, compacted in place
+        var woke_one = false;
+        for (list.items) |idx| {
+            // Hand-off: once the single waiter is woken, keep the rest verbatim
+            // (they stay parked; their validity is rechecked at the next wake).
+            if (!spec.all and woke_one) {
+                list.items[w] = idx;
+                w += 1;
+                continue;
+            }
+            const occ: ?*Fiber = if (idx < self.fibers.items.len) self.fibers.items[idx] else null;
+            if (occ) |fiber| {
+                if (fiber.sched_idx == idx and fiber.status == .waiting and fiber.waiting_on == key) {
+                    self.doWake(fiber, spec);
+                    woke_one = true;
+                    continue; // drop the woken entry
+                }
+            }
+            // stale (reused/absent slot, or no longer waiting on `key`): drop
+        }
+        if (w == 0) {
+            list.deinit(self.vm.gc.allocator);
+            _ = self.waiter_index.remove(key);
+        } else {
+            list.shrinkRetainingCapacity(w);
+        }
+    }
+
+    /// Pre-#1530 authoritative scan, retained as the enroll-OOM fallback
+    /// (waiter_index_degraded). Behaviorally identical to the original wake
+    /// loops: every `.waiting` fiber on `key` for a broadcast, the first for a
+    /// hand-off.
+    fn scanWakeOn(self: *FiberScheduler, key: Value, spec: WakeSpec) void {
         for (self.fibers.items) |f| {
             if (f) |fiber| {
-                if (fiber.status == .waiting and fiber.waiting_on == completed_val) {
-                    fiber.status = .suspended;
-                    fiber.result = completed_fiber.result;
-                    self.vm.gc.writeBarrier(&fiber.header, completed_fiber.result);
-                    self.cancelPendingTimer(fiber);
-                    self.markRunnable(fiber);
+                if (fiber.status == .waiting and fiber.waiting_on == key) {
+                    self.doWake(fiber, spec);
+                    if (!spec.all) return;
                 }
             }
         }
+    }
+
+    pub fn wakeWaiters(self: *FiberScheduler, completed_fiber: *Fiber) void {
+        const completed_val = types.makePointer(@ptrCast(&completed_fiber.header));
+        self.wakeOn(completed_val, .{ .all = true, .result = completed_fiber.result });
     }
 
     /// Wake every fiber parked on this channel (status .waiting via the
     /// channel-receive retry protocol). Waking all is safe: each re-executes
     /// channel-receive and re-parks if the channel is empty again.
     pub fn wakeChannelWaiters(self: *FiberScheduler, ch_val: Value) void {
-        for (self.fibers.items) |f| {
-            if (f) |fiber| {
-                if (fiber.status == .waiting and fiber.waiting_on == ch_val) {
-                    fiber.status = .suspended;
-                    fiber.waiting_on = types.VOID;
-                    self.cancelPendingTimer(fiber);
-                    self.markRunnable(fiber);
-                }
-            }
-        }
+        self.wakeOn(ch_val, .{ .all = true, .clear_waiting_on = true });
     }
 
     /// KEP-0002 §5's per-scheduler shared-waiter registry: a fiber joins
@@ -735,42 +872,21 @@ pub const FiberScheduler = struct {
         self.shared_waiters.clearRetainingCapacity();
     }
 
+    /// Hand the mutex to one parked waiter (mutex unlock / abandonment). The
+    /// woken fiber re-races the claim and re-parks on failure, so waking
+    /// exactly one is the correct SRFI-18 hand-off.
     pub fn wakeMutexWaiters(self: *FiberScheduler, mutex_val: Value) void {
-        for (self.fibers.items) |f| {
-            if (f) |fiber| {
-                if (fiber.status == .waiting and fiber.waiting_on == mutex_val) {
-                    fiber.status = .suspended;
-                    self.cancelPendingTimer(fiber);
-                    self.markRunnable(fiber);
-                    return;
-                }
-            }
-        }
+        self.wakeOn(mutex_val, .{ .all = false });
     }
 
+    /// condition-variable-signal!: wake exactly one waiter.
     pub fn wakeOneCondVarWaiter(self: *FiberScheduler, cv_val: Value) void {
-        for (self.fibers.items) |f| {
-            if (f) |fiber| {
-                if (fiber.status == .waiting and fiber.waiting_on == cv_val) {
-                    fiber.status = .suspended;
-                    self.cancelPendingTimer(fiber);
-                    self.markRunnable(fiber);
-                    return;
-                }
-            }
-        }
+        self.wakeOn(cv_val, .{ .all = false });
     }
 
+    /// condition-variable-broadcast!: wake every waiter.
     pub fn wakeAllCondVarWaiters(self: *FiberScheduler, cv_val: Value) void {
-        for (self.fibers.items) |f| {
-            if (f) |fiber| {
-                if (fiber.status == .waiting and fiber.waiting_on == cv_val) {
-                    fiber.status = .suspended;
-                    self.cancelPendingTimer(fiber);
-                    self.markRunnable(fiber);
-                }
-            }
-        }
+        self.wakeOn(cv_val, .{ .all = true });
     }
 
     pub fn markRoots(self: *FiberScheduler, gc: *memory.GC) void {

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -238,6 +238,7 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
         me.status = .waiting;
         me.waiting_on = ch_val;
         vm.gc.writeBarrier(&me.header, ch_val);
+        ctx.sched.enrollWaiter(me); // #1530: O(1) wake on a freed slot / close
         me.deadline_ns = d;
         try ctx.reactor.addTimer(d, me);
     }
@@ -767,6 +768,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         me.status = .waiting;
         me.waiting_on = ch_val;
         vm.gc.writeBarrier(&me.header, ch_val);
+        ctx.sched.enrollWaiter(me); // #1530: O(1) wake on a channel send / close
         me.deadline_ns = d;
         try ctx.reactor.addTimer(d, me);
     }
@@ -818,6 +820,9 @@ fn blockOrDeadlock(vm: *vm_mod.VM, me: *fiber_mod.Fiber, my_idx: usize, wait_on:
         me.status = .waiting;
         me.waiting_on = wait_on;
         vm.gc.writeBarrier(&me.header, wait_on);
+        // Index this park so fiber completion (wakeWaiters) or a channel
+        // send/close (wakeChannelWaiters) finds it in O(1) (#1530).
+        if (vm.scheduler) |sched| sched.enrollWaiter(me);
         vm.yield_retry = true;
         return PrimitiveError.Yielded;
     }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -726,6 +726,7 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
         me.waiting_on = args[0];
         me.status = .waiting;
         me.timed_out = false;
+        ctx.sched.enrollWaiter(me); // #1530: O(1) wake when the joined fiber completes
         if (deadline_ns) |d| {
             me.deadline_ns = d;
             try ctx.reactor.addTimer(d, me);
@@ -1026,6 +1027,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     me.waiting_on = mutex_val;
     me.status = .waiting;
     me.timed_out = false;
+    ctx.sched.enrollWaiter(me); // #1530: O(1) wake on mutex unlock / abandonment
     if (deadline) |d| {
         me.deadline_ns = d;
         try ctx.reactor.addTimer(d, me);
@@ -1061,6 +1063,10 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
                 try ctx.reactor.addTimer(d, me);
             }
             me.status = .waiting;
+            // A local wake dropped me's index entry; re-enroll so the next
+            // unlock finds me again (#1530). No-op via the tail check when a
+            // cross-thread resolution left the entry in place.
+            ctx.sched.enrollWaiter(me);
             continue;
         }
         if (!crossThreadWaitPossible()) {
@@ -1077,6 +1083,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
             try ctx.reactor.addTimer(d, me);
         }
         me.status = .waiting;
+        ctx.sched.enrollWaiter(me); // #1530: re-index after this spin (see above)
     }
     // A cross-thread resolution never runs local wake bookkeeping (the
     // unlocking thread's scheduler/reactor doesn't even know `me` exists),
@@ -1151,6 +1158,7 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
         me.waiting_on = args[1];
         me.status = .waiting;
         me.timed_out = false;
+        ctx.sched.enrollWaiter(me); // #1530: O(1) wake on signal / broadcast
         if (deadline) |d| {
             me.deadline_ns = d;
             try ctx.reactor.addTimer(d, me);
@@ -1179,6 +1187,7 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
             }
             sleepNs(CROSS_THREAD_POLL_NS);
             me.status = .waiting;
+            ctx.sched.enrollWaiter(me); // #1530: re-index after this spin (see mutexLockFn)
         }
         // See the matching comment in mutexLockFn: a cross-thread signal
         // never runs local wake bookkeeping, so any timer registered above

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -150,7 +150,7 @@ test "enrollSharedWaiter dedups by pointer; removeSharedWaiter is a no-op if abs
     defer ctx.deinit();
 
     _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = ctx.vm.scheduler.?;
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
     const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
@@ -170,7 +170,7 @@ test "sweepSharedWaiters unconditionally flips every enrolled .waiting fiber and
     defer ctx.deinit();
 
     _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = ctx.vm.scheduler.?;
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
     const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
@@ -191,7 +191,7 @@ test "sweepSharedWaiters does not clobber a fiber no longer .waiting" {
     defer ctx.deinit();
 
     _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = ctx.vm.scheduler.?;
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
     const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
@@ -219,7 +219,7 @@ test "scheduleForDispatch() does not select a .suspended fiber whose own nested 
     defer ctx.deinit();
 
     _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = ctx.vm.scheduler.?;
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
     const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
@@ -251,7 +251,7 @@ test "hasRunnableFibers does not count a .suspended fiber whose own nested drive
     defer ctx.deinit();
 
     _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = ctx.vm.scheduler.?;
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
     const f_val = try ctx.vm.eval("f");
     const f = types.toObject(f_val).as(fiber_mod.Fiber);
 
@@ -274,7 +274,7 @@ test "runSchedulerStep sets driving for its whole extent and clears it on return
     defer ctx.deinit();
 
     _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = ctx.vm.scheduler.?;
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
     const main_fiber = sched.fibers.items[0].?;
     const f = types.toObject(try ctx.vm.eval("f")).as(fiber_mod.Fiber);
     try std.testing.expect(!main_fiber.driving);
@@ -367,7 +367,7 @@ test "#1477: addFiber assigns each fiber its stable slot index" {
     defer ctx.deinit();
 
     _ = try ctx.vm.eval("(import (kaappi fibers)) (define f (spawn (lambda () 1)))");
-    const sched = ctx.vm.scheduler.?;
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
     const f = types.toObject(try ctx.vm.eval("f")).as(fiber_mod.Fiber);
 
     // f lives at exactly the slot addFiber recorded on it, and that slot is
@@ -466,4 +466,183 @@ test "fiber suspend does not save stale gap registers (#1529)" {
         \\out
     );
     try std.testing.expectEqual(@as(i64, 16), types.toFixnum(result));
+}
+
+// #1530: the by-object waiter index (waiter_index / enrollWaiter). These
+// drive the index directly — parking a spawned fiber is simulated by setting
+// its status/waiting_on and calling enrollWaiter, exactly as the real park
+// sites do — so the wake mechanics are checked in isolation from the full
+// scheduler loop the Scheme-level tests already cover.
+
+fn parkOn(sched: *fiber_mod.FiberScheduler, f: *fiber_mod.Fiber, key: types.Value) void {
+    f.status = .waiting;
+    f.waiting_on = key;
+    sched.enrollWaiter(f);
+}
+
+test "#1530: a broadcast wakes every enrolled waiter on the object and frees the key" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(import (kaappi fibers))");
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
+    // A rooted channel Value is the wake key (any non-VOID Value keys the index).
+    const key = try ctx.vm.eval("(define k (make-channel)) k");
+    _ = try ctx.vm.eval("(define a (spawn (lambda () 1)))");
+    _ = try ctx.vm.eval("(define b (spawn (lambda () 2)))");
+    _ = try ctx.vm.eval("(define c (spawn (lambda () 3)))");
+    const fa = types.toObject(try ctx.vm.eval("a")).as(fiber_mod.Fiber);
+    const fb = types.toObject(try ctx.vm.eval("b")).as(fiber_mod.Fiber);
+    const fc = types.toObject(try ctx.vm.eval("c")).as(fiber_mod.Fiber);
+
+    for ([_]*fiber_mod.Fiber{ fa, fb, fc }) |f| parkOn(sched, f, key);
+    try std.testing.expect(sched.waiter_index.count() == 1); // one object contended
+    try std.testing.expectEqual(@as(usize, 3), sched.waiter_index.get(key).?.items.len);
+
+    sched.wakeChannelWaiters(key); // broadcast
+
+    for ([_]*fiber_mod.Fiber{ fa, fb, fc }) |f| {
+        try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, f.status);
+        try std.testing.expectEqual(types.VOID, f.waiting_on); // channel path clears it
+    }
+    // The emptied list is dropped so the map stays bounded by live contention.
+    try std.testing.expect(sched.waiter_index.count() == 0);
+}
+
+test "#1530: a hand-off wakes exactly one waiter and leaves the rest enrolled" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(import (srfi 18) (kaappi fibers))");
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
+    const key = try ctx.vm.eval("(define m (make-mutex)) m");
+    _ = try ctx.vm.eval("(define a (spawn (lambda () 1)))");
+    _ = try ctx.vm.eval("(define b (spawn (lambda () 2)))");
+    _ = try ctx.vm.eval("(define c (spawn (lambda () 3)))");
+    const fa = types.toObject(try ctx.vm.eval("a")).as(fiber_mod.Fiber);
+    const fb = types.toObject(try ctx.vm.eval("b")).as(fiber_mod.Fiber);
+    const fc = types.toObject(try ctx.vm.eval("c")).as(fiber_mod.Fiber);
+
+    for ([_]*fiber_mod.Fiber{ fa, fb, fc }) |f| parkOn(sched, f, key);
+
+    sched.wakeMutexWaiters(key); // hand-off: first enrolled (a) only
+
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, fa.status);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.waiting, fb.status);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.waiting, fc.status);
+    // a's entry is consumed; b and c stay enrolled for the next unlock.
+    try std.testing.expectEqual(@as(usize, 2), sched.waiter_index.get(key).?.items.len);
+}
+
+test "#1530: a terminated (.errored) waiter still in the index is skipped, not resurrected" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(import (kaappi fibers))");
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
+    const key = try ctx.vm.eval("(define k (make-channel)) k");
+    _ = try ctx.vm.eval("(define a (spawn (lambda () 1)))");
+    _ = try ctx.vm.eval("(define b (spawn (lambda () 2)))");
+    const fa = types.toObject(try ctx.vm.eval("a")).as(fiber_mod.Fiber);
+    const fb = types.toObject(try ctx.vm.eval("b")).as(fiber_mod.Fiber);
+
+    parkOn(sched, fa, key);
+    parkOn(sched, fb, key);
+    // thread-terminate! flips a directly to .errored without de-indexing it
+    // (the index holds slot indices, not pointers, so validation catches it).
+    fa.status = .errored;
+
+    sched.wakeChannelWaiters(key);
+
+    try std.testing.expectEqual(fiber_mod.FiberStatus.errored, fa.status); // not woken
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, fb.status); // woken
+    try std.testing.expect(sched.waiter_index.count() == 0);
+}
+
+test "#1530: tail dedup bounds a same-object re-park; a wake+re-park re-indexes" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(import (srfi 18) (kaappi fibers))");
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
+    const key = try ctx.vm.eval("(define m (make-mutex)) m");
+    _ = try ctx.vm.eval("(define a (spawn (lambda () 1)))");
+    const fa = types.toObject(try ctx.vm.eval("a")).as(fiber_mod.Fiber);
+
+    parkOn(sched, fa, key);
+    // Re-parking on the SAME object with no intervening wake must not grow the
+    // list (the mutex/condvar spin loops re-enter .waiting repeatedly).
+    sched.enrollWaiter(fa);
+    sched.enrollWaiter(fa);
+    try std.testing.expectEqual(@as(usize, 1), sched.waiter_index.get(key).?.items.len);
+
+    // A hand-off consumes a's entry and drops the now-empty key.
+    sched.wakeMutexWaiters(key);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, fa.status);
+    try std.testing.expect(sched.waiter_index.get(key) == null);
+
+    // The retry loop re-parks: enrollWaiter must re-add it (waiting_on is still
+    // the mutex on the mutex path), and the next unlock must find it again.
+    fa.status = .waiting;
+    sched.enrollWaiter(fa);
+    try std.testing.expectEqual(@as(usize, 1), sched.waiter_index.get(key).?.items.len);
+    sched.wakeMutexWaiters(key);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, fa.status);
+}
+
+test "#1530: wakeWaiters hands the completed fiber's result to an indexed joiner" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(import (kaappi fibers))");
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
+    _ = try ctx.vm.eval("(define t (spawn (lambda () 1)))");
+    _ = try ctx.vm.eval("(define j (spawn (lambda () 2)))");
+    const t_val = try ctx.vm.eval("t");
+    const ft = types.toObject(t_val).as(fiber_mod.Fiber);
+    const fj = types.toObject(try ctx.vm.eval("j")).as(fiber_mod.Fiber);
+
+    // j joins t (keyed on t's own Value, exactly what blockOrDeadlock sets).
+    parkOn(sched, fj, t_val);
+
+    ft.status = .completed;
+    ft.result = types.makeFixnum(99);
+    sched.wakeWaiters(ft);
+
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, fj.status);
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(fj.result));
+    try std.testing.expect(sched.waiter_index.count() == 0);
+}
+
+test "#1530: a degraded index falls back to the full scan and still wakes" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(import (kaappi fibers))");
+    const sched = (try fiber_mod.ensureScheduler(ctx.vm)).sched;
+    const key = try ctx.vm.eval("(define k (make-channel)) k");
+    _ = try ctx.vm.eval("(define a (spawn (lambda () 1)))");
+    _ = try ctx.vm.eval("(define b (spawn (lambda () 2)))");
+    const fa = types.toObject(try ctx.vm.eval("a")).as(fiber_mod.Fiber);
+    const fb = types.toObject(try ctx.vm.eval("b")).as(fiber_mod.Fiber);
+
+    // Simulate a prior enroll OOM: the index is abandoned and enroll no-ops.
+    sched.waiter_index_degraded = true;
+    fa.status = .waiting;
+    fa.waiting_on = key;
+    fb.status = .waiting;
+    fb.waiting_on = key;
+    sched.enrollWaiter(fa); // no-op while degraded
+    try std.testing.expect(sched.waiter_index.count() == 0);
+
+    // The wake must still find both by scanning fibers.items (pre-#1530 path).
+    sched.wakeChannelWaiters(key);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, fa.status);
+    try std.testing.expectEqual(fiber_mod.FiberStatus.suspended, fb.status);
 }

--- a/tests/scheme/smoke/fiber-many-waiters-one-object-1530.scm
+++ b/tests/scheme/smoke/fiber-many-waiters-one-object-1530.scm
@@ -1,0 +1,48 @@
+;; Regression test for #1530: the wake paths index parked fibers by the object
+;; they wait on (waiter_index / enrollWaiter), so a wake touches only the
+;; waiters on that object instead of scanning every fiber. This drives the
+;; broadcast wake with many concurrent waiters on ONE channel: N fibers all
+;; block on channel-receive, then channel-close! must wake every one of them
+;; (each observes EOF) — no lost wakeup, no hang, regardless of N. It also
+;; guards the single-object hand-off shape the mutex/condvar wakes share.
+(import (scheme base) (scheme write) (srfi 64) (kaappi fibers))
+
+(test-begin "fiber-many-waiters-one-object-1530")
+
+(define n 500)
+(define ch (make-channel))
+(define got-eof 0)
+
+;; Spawn N fibers that all park on the same empty channel, so they are all
+;; concurrently enrolled under one key at once — the case #1530 makes O(N)
+;; instead of O(N^2) across the N wakes.
+(define fibers
+  (let loop ((i 0) (acc '()))
+    (if (= i n)
+        acc
+        (loop (+ i 1)
+              (cons (spawn (lambda ()
+                             (if (eof-object? (channel-receive ch))
+                                 (begin (set! got-eof (+ got-eof 1)) 'eof)
+                                 'value)))
+                    acc)))))
+
+;; Give every fiber a turn to reach channel-receive and park, then wake them
+;; all with a single close. A lost wakeup here would strand a fiber and make
+;; its fiber-join below hang (run-all.sh's per-file timeout catches that).
+(yield)
+(channel-close! ch)
+
+(define results (map fiber-join fibers))
+
+(test-equal "all N fibers completed" n (length results))
+(test-equal "every waiter woke on close and saw EOF" n got-eof)
+(test-assert "and each returned the EOF marker"
+  (let loop ((rs results))
+    (cond ((null? rs) #t)
+          ((eq? (car rs) 'eof) (loop (cdr rs)))
+          (else #f))))
+
+(let ((runner (test-runner-current)))
+  (test-end "fiber-many-waiters-one-object-1530")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #1530.

## Problem

After #1525 made fiber **dispatch/spawn** O(1) (ready ring + free-slot list), the five **wake** paths still linearly scanned every slot in `sched.fibers.items` on each call:

| fn | called on |
|----|-----------|
| `wakeWaiters` | every fiber completion (fiber-join) |
| `wakeChannelWaiters` | every local channel send / dequeue / close |
| `wakeMutexWaiters` | mutex unlock / abandonment |
| `wakeOneCondVarWaiter` | `condition-variable-signal!` |
| `wakeAllCondVarWaiters` | `condition-variable-broadcast!` |

On a workload holding thousands of live fibers, each op paid an O(fiber count) scan — the residual super-linearity #1477 flagged once dispatch was O(1). `wakeWaiters` alone runs on **every** completion and scanned all N fibers even with zero joiners, so spawn+join was O(N²).

## Fix — a by-object waiter index

A per-scheduler `waiter_index: AutoHashMap(Value, ArrayList(usize))` maps a waited-on Value (a fiber to join, a channel, a mutex, a condvar) → the **slot indices** of the fibers parked on it. `enrollWaiter` feeds it at every local park site; `wakeOn` is the single choke point behind all five entry points. Each wake is now O(waiters-on-that-object).

Key design choices:
- **Slot indices, not `*Fiber`.** A since-reused/terminated slot is caught by the same validation the ready ring uses at pop (slot still owns its index, still `.waiting`, still on the key), so a terminated waiter needs no explicit de-index — unlike the pointer-holding `shared_waiters` registry.
- **Enrollment is complete** for the broadcast wakes (a "wake all" can't fall back on an empty index the way #1525's lossy ready ring can). All 9 local park sites enroll; the 4 shared-channel parks (woken via `sweepSharedWaiters`) and `thread-sleep!`'s VOID-keyed timed wait are deliberately excluded, and the mutex/condvar retry spins re-enroll.
- **OOM → sticky `waiter_index_degraded` → falls back to the exact pre-#1530 scan**, so an allocation failure degrades to old behavior instead of a lost-wakeup hang, with no per-site park rollback.
- **Tail-check dedup** bounds the retry spins without a per-fiber flag (which would carry an address-reuse ABA hazard).

## Results

Same-machine `bench-fibers` A/B (`git stash`):

| fibers | baseline ns/(spawn+join) | with fix |
|---|---|---|
| 100 | 2,170 | 2,260 |
| 1,000 | 2,439 | 1,285 |
| 10,000 | **18,606** | **2,309** |

~8× at 10k, and **flat** across 100/1k/10k instead of super-linear.

## Testing

- Full unit suite **918/918**; targeted gc-stress on the concurrency tests **132/132** (no UAF in the index under collect-on-every-alloc).
- Full Scheme suite **456 files + 1395 R7RS = 1851 pass, 0 fail**, including the lost-wakeup (#1489), nested-dispatch (#1487), starvation, cross-thread, and abandoned-mutex regressions.
- New: 6 unit tests in `tests_scheduler.zig` + `tests/scheme/smoke/fiber-many-waiters-one-object-1530.scm` (500 fibers block on one channel; close wakes all).

## Out of scope

`hasRunnableFibers` (early-exits on the first runnable fiber; O(n) only in the genuine no-progress case, and its deadlock-detection invariants make an O(1) rewrite risky) and `wakeIoWaitersOnFd` (keyed by fd, not `waiting_on`) — matching the issue's suggested-fix scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)