### PR TITLE
Add `kaappi test` SRFI-64 runner with --json and --seed (#1509)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,11 @@ also skips the `.sbc` cache — useful for miscompilation triage and
 `--profile`, `--coverage`, `--diagnostics=<text|json>` (JSON Lines of LSP
 `Diagnostic` objects on stderr — see `docs/dev/diagnostics-json.md`),
 `--completions <shell>`.
-Subcommand: `kaappi compile <file> [-o output]`
-compiles to native binary via LLVM. Version is defined as `pub const version`
+Subcommands: `kaappi compile <file> [-o output]` compiles to a native binary
+via LLVM; `kaappi explain <code>` prints a diagnostic's reference entry;
+`kaappi test [paths...]` runs SRFI-64 suites (`--json`, `--seed <n>`,
+`--lib-path`) aggregating from the runner's own counters — see
+`docs/dev/test-runner.md`. Version is defined as `pub const version`
 in `main.zig`. Environment: `KAAPPI_LIB_DIR` overrides `libkaappi_rt.a` lookup.
 
 Build-time options: `-Dmax-frames=N` (initial frame capacity, default 480, grows to 32768),

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -24,6 +24,7 @@ investigation produced analysis worth keeping.
 | [llvm-backend.md](llvm-backend.md) | LLVM native backend: what LLVM provides vs what the runtime provides |
 | [adding-features.md](adding-features.md) | Step-by-step guides for the most common extension tasks |
 | [testing.md](testing.md) | The four test layers, how to run them, where new tests go |
+| [test-runner.md](test-runner.md) | `kaappi test`: the first-class SRFI-64 runner — discovery, worker subprocesses, `--json` schema, `--seed` |
 | [fuzzing.md](fuzzing.md) | Fuzzing runbook: the targets, the scheduled CI job, turning a failure into a regression test |
 | [github-actions.md](github-actions.md) | Workflow hardening rules: SHA-pinned actions, `persist-credentials: false`, least-privilege tokens |
 | [gc-safety-and-error-handling.md](gc-safety-and-error-handling.md) | Rooting, write barriers, and error propagation patterns contributors must follow |

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -1,0 +1,163 @@
+# `kaappi test` — first-class SRFI-64 runner
+
+The suite standardises on [SRFI-64](https://srfi.schemers.org/srfi-64/) as its
+test harness. `kaappi test` is the runner an agent or CI drives on top of it: it
+discovers SRFI-64 suites, runs each one, and aggregates pass/fail/skip counts
+**from the SRFI-64 runner's own counters** — never by scraping the
+`# of expected passes` lines. It is part of the machine-legibility epic
+(kaappi#1503, kaappi#1509); the guiding rule is that a caller can go from a
+failing suite to a fix using documented, structured output alone.
+
+```
+kaappi test [paths...]
+```
+
+- **Discovery.** With no paths, recurse `./tests` and keep files that use
+  SRFI-64 (a source substring check on `srfi 64`, which skips benchmarks, the
+  chibi-test R7RS suite, and coverage helpers). A named **file** is run as given
+  (no filter — you asked for it by name); a named **directory** is recursed with
+  the SRFI-64 filter. Discovered files run in sorted order.
+- **`--json`.** Emit JSON Lines: one `{"type":"file", …}` object per file, then
+  one `{"type":"summary", …}` object. See the schema below.
+- **`--seed <n>`.** Seed SRFI-27's default random source deterministically
+  (`random-source-pseudo-randomize! default-random-source 0 n`), so a run with
+  the same seed reproduces the same `random-integer`/`random-real` draws. The
+  effective seed — pinned or auto-chosen — is printed on **every** run (to
+  stderr, so `--json` stdout stays pure), so any failure can be replayed with
+  `--seed`.
+- **`--lib-path <path>`.** Repeatable; forwarded to every test file. This is
+  what makes the runner work unchanged on an ecosystem repo:
+  `kaappi test --lib-path ./lib`.
+- **Exit status** is nonzero iff a test failed, unexpectedly passed (`xpass`),
+  or a file errored.
+
+## How it works: one worker subprocess per file
+
+`kaappi test` is an **orchestrator**. For each file it forks a **worker** — an
+ordinary `kaappi <file>` invocation with `KAAPPI_TEST_EMIT` (and, when seeded,
+`KAAPPI_TEST_SEED`) set in its environment. The worker's presence of
+`KAAPPI_TEST_EMIT` is what puts it in worker mode; there is no user-facing worker
+flag.
+
+Subprocess isolation is deliberate. A test file may loop, segfault, leak an
+SRFI-18 thread, open sockets, or call `(exit 1)` in its failure epilogue. In a
+separate process, none of that can corrupt the run or bleed into another file's
+results, and a hung file is a `kill` away — the same robustness the legacy
+`tests/scheme/run-all.sh` gets from spawning per file, but with structured
+results instead of scraped text. It also mirrors the future parallel-execution
+story (kaappi#1509 stretch): files are already independent units.
+
+Inside the worker (`src/main.zig` `runWorkerFile` → `src/test_runner.zig`):
+
+1. **Install a collecting runner.** Before the file runs, the worker evaluates a
+   prelude that sets `test-runner-factory` to a factory built on
+   `test-runner-null` (so the SRFI-64 machinery prints nothing and writes no
+   `.log` file). Its `on-test-end` hook reads `test-result-kind` and the
+   result-alist and funnels every result into `%kt-*` accumulators; its
+   `on-group-begin` hook captures the outermost suite name. Because
+   `(import (srfi 64))` is idempotent, the file's own import doesn't reset the
+   factory. Multiple `test-begin`/`test-end` groups in one file each get a fresh
+   runner via the factory, and all funnel into the same accumulators.
+2. **Suppress `(exit)`.** The worker sets `vm.suppress_exit`, so a file's
+   `(exit 1)` failure epilogue becomes a *recorded* no-op (`vm.exit_requested`)
+   instead of terminating the worker before it can emit its result. A test
+   file's `(exit 1)` is redundant with the fail counts we already collected, so
+   it is **not** treated as a file error.
+3. **Run the file** via the normal `runFile` path (so the `.sbc` cache, imports,
+   and error diagnostics all behave exactly as a plain run).
+4. **Emit one JSON object** for the file to `KAAPPI_TEST_EMIT`, built by walking
+   the `(%kt-collect)` vector. Writing to a file (not stdout) keeps it separate
+   from the test file's own output, and is robust to the worker crashing.
+
+The orchestrator reads that file back, parses it with a real JSON parser
+(`std.json`), aggregates the counts, and — in `--json` mode — re-serializes each
+object so it can enrich an errored file with the diagnostic it captured from the
+worker's stdout/stderr (which the worker itself never sees, since that went to
+the pipe the orchestrator owns). A worker that writes no result (a crash) is
+reported as an errored file synthesised from the captured output.
+
+A **file-level error** (`"error": true`) means an *uncaught* read/compile/runtime
+error at top level. SRFI-64 catches ordinary test failures internally via
+`guard`, so those never set it — they show up in the counts and `failures`.
+
+## JSON schema
+
+One object per line (JSON Lines). Prose fields (`error_message`, failure
+`expected`/`actual`) are human-oriented and may be reworded; the structural
+fields (counts, `kind`, `error`) are the stable contract.
+
+Per-file object:
+
+```json
+{
+  "type": "file",
+  "file": "tests/scheme/smoke/numeric.scm",
+  "suite": "numeric",
+  "tests": 77,
+  "pass": 77, "fail": 0, "xpass": 0, "xfail": 0, "skip": 0,
+  "error": false,
+  "error_message": null,
+  "duration_ms": 203.4,
+  "failures": [
+    {
+      "name": "wrong sum",
+      "kind": "fail",
+      "expected": "5",
+      "actual": "4",
+      "source_file": null,
+      "source_line": null
+    }
+  ]
+}
+```
+
+- `suite` — the outermost `test-begin` name, or `null`.
+- `tests` — `pass + fail + xpass + xfail + skip`.
+- `kind` — `"fail"` (an expected pass that failed) or `"xpass"` (an
+  expected-fail that unexpectedly passed). `xfail` (expected fail) and `skip`
+  are counted but not listed as failures.
+- `expected` — present for comparison forms (`test-equal`/`test-eqv`/`test-eq`);
+  `null` for `test-assert`/`test-error`, which have no expected value. Rendered
+  with `write`.
+- `source_file`/`source_line` — populated when SRFI-64's result-alist carries
+  them (a forward-compatible slot; Kaappi's SRFI-64 does not currently set
+  them, so they are usually `null`).
+
+Summary object (always last):
+
+```json
+{
+  "type": "summary",
+  "files": 108, "files_failed": 1, "errors": 0,
+  "tests": 1611, "pass": 1610, "fail": 1, "xpass": 0, "xfail": 0, "skip": 0,
+  "seed": 543286,
+  "duration_ms": 15825.0
+}
+```
+
+## Relationship to `run-all.sh`
+
+[`tests/scheme/run-all.sh`](../../tests/scheme/run-all.sh) is the **legacy**
+runner and stays: it also drives the chibi-test R7RS suite and the shell-based
+error/compile suites, which are outside `kaappi test`'s SRFI-64 scope, and it
+runs `kaappi test`'s own acceptance shell tests
+(`tests/scheme/test-runner/*.sh`). Over time SRFI-64 suites can delegate to
+`kaappi test`; nothing forces the switch.
+
+`--changed` (affected-test selection over the import graph) is tracked
+separately in kaappi#1510 and is intentionally not part of this runner.
+
+## Tests
+
+- `src/test_runner.zig` unit tests — JSON serialization round-trips, the
+  SRFI-64 discovery gate, and the `suppress_exit` behaviour (the guard on the
+  `exitFn` change in `src/primitives_r7rs.zig`).
+- `tests/scheme/test-runner/json.sh` — the `--json` contract, validated with a
+  real JSON parser (python3): per-file + summary objects, counts, failure
+  detail, errored-file message, pure-JSON stdout, and exit status.
+- `tests/scheme/test-runner/seed.sh` — `--seed` reproducibility (same seed →
+  same draw, different seed → different draw, seed echoed on every run),
+  observed through the JSON.
+
+Both shell tests generate their fixtures in a temp dir so an intentionally
+failing suite never pollutes a plain `kaappi test ./tests` run of the repo.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -251,10 +251,12 @@ pub fn printUsage() void {
             "Usage: kaappi [options] [file] [script-args...]\n" ++
             "       kaappi compile <file.scm> [-o output]\n" ++
             "       kaappi explain <code>\n" ++
+            "       kaappi test [paths...]\n" ++
             "\n" ++
             "Commands:\n" ++
             "  compile <file>     Compile to native binary via LLVM\n" ++
             "  explain <code>     Explain a diagnostic code (e.g. KP3001); --json, --all\n" ++
+            "  test [paths...]    Run SRFI-64 suites; --json, --seed <n>, --lib-path\n" ++
             "\n" ++
             "Options:\n" ++
             "  -h, --help         Show this help message\n" ++

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -19,14 +19,20 @@ const kaappi_bash =
     \\            return ;;
     \\    esac
     \\
-    \\    local has_compile=false has_explain=false
+    \\    local has_compile=false has_explain=false has_test=false
     \\    for word in "${COMP_WORDS[@]}"; do
     \\        [[ "$word" == "compile" ]] && has_compile=true
     \\        [[ "$word" == "explain" ]] && has_explain=true
+    \\        [[ "$word" == "test" ]] && has_test=true
     \\    done
     \\
     \\    if $has_explain; then
     \\        COMPREPLY=($(compgen -W "--json --all" -- "$cur"))
+    \\        return
+    \\    fi
+    \\
+    \\    if $has_test; then
+    \\        COMPREPLY=($(compgen -W "--json --seed --lib-path" -- "$cur") $(compgen -f -- "$cur"))
     \\        return
     \\    fi
     \\
@@ -38,7 +44,7 @@ const kaappi_bash =
     \\    if $has_compile; then
     \\        COMPREPLY=($(compgen -f -X '!*.scm' -- "$cur") $(compgen -W "-o" -- "$cur"))
     \\    else
-    \\        COMPREPLY=($(compgen -W "compile explain" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
+    \\        COMPREPLY=($(compgen -W "compile explain test" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
     \\    fi
     \\}
     \\complete -o filenames -F _kaappi kaappi
@@ -73,7 +79,7 @@ const kaappi_zsh =
     \\
     \\    _arguments -s \
     \\        $flags \
-    \\        '1:command or file:_alternative "commands:command:(compile explain)" "files:file:_files -g \"*.scm\""' \
+    \\        '1:command or file:_alternative "commands:command:(compile explain test)" "files:file:_files -g \"*.scm\""' \
     \\        '*:script args:_files'
     \\}
     \\
@@ -102,6 +108,7 @@ const kaappi_fish =
     \\complete -c kaappi -l completions -r -x -a 'bash zsh fish' -d 'Output shell completion script'
     \\complete -c kaappi -a compile -d 'Compile to native binary via LLVM'
     \\complete -c kaappi -a explain -d 'Explain a diagnostic code (KP####)'
+    \\complete -c kaappi -a test -d 'Run SRFI-64 test suites (--json, --seed)'
     \\
 ;
 

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -65,45 +65,49 @@ fn siblingLibDir(exe_path: []const u8, buf: []u8) ?[]const u8 {
 /// Returns null if the platform has no self-exe-path lookup, the
 /// executable isn't nested at least two directories deep, or the resulting
 /// path doesn't fit `buf`. Does not check whether the directory exists.
-pub fn getExeRelativeLibDir(buf: []u8) ?[]const u8 {
-    var path_buf: [1024]u8 = undefined;
-    const exe_path: []const u8 = blk: {
-        if (comptime @import("builtin").os.tag == .linux) {
-            // /proc/self/exe is a kernel-resolved canonical path already —
-            // no realpath needed. Reject a result that fills the whole
-            // buffer: readlink doesn't NUL-terminate, and an exact-length
-            // return means the real target may have been truncated.
-            const n: isize = std.posix.system.readlink(
-                "/proc/self/exe",
-                &path_buf,
-                path_buf.len,
-            );
-            if (n > 0 and @as(usize, @intCast(n)) < path_buf.len) break :blk path_buf[0..@intCast(n)];
-        }
+/// Resolves the running executable's own absolute path into `buf`, returning
+/// the slice (or null if the platform has no self-exe lookup or the path
+/// doesn't fit). On Linux this reads `/proc/self/exe`; on macOS it resolves
+/// `_NSGetExecutablePath` through `realpath` so a symlinked launch (e.g. a
+/// Homebrew Cellar symlink) yields the real binary. Used both to derive the
+/// sibling `lib/` dir and, by the `kaappi test` orchestrator, to re-spawn the
+/// same binary as a worker regardless of how it was invoked.
+pub fn getExePath(buf: []u8) ?[]const u8 {
+    if (comptime @import("builtin").os.tag == .linux) {
+        // /proc/self/exe is a kernel-resolved canonical path already —
+        // no realpath needed. Reject a result that fills the whole
+        // buffer: readlink doesn't NUL-terminate, and an exact-length
+        // return means the real target may have been truncated.
+        const n: isize = std.posix.system.readlink("/proc/self/exe", buf.ptr, buf.len);
+        if (n > 0 and @as(usize, @intCast(n)) < buf.len) return buf[0..@intCast(n)];
+        return null;
+    }
 
-        if (comptime @import("builtin").os.tag == .macos) {
-            var size: u32 = path_buf.len;
-            const rc = std.c._NSGetExecutablePath(&path_buf, &size);
-            if (rc == 0) {
-                const len = std.mem.indexOfScalar(u8, &path_buf, 0) orelse path_buf.len;
-                // _NSGetExecutablePath may return a symlinked or relative
-                // path (e.g. a Homebrew Cellar symlink), which would derive
-                // ../lib from the wrong tree — resolve it to the real path
-                // first. Fall back to the raw path if realpath fails or the
-                // buffer wasn't NUL-terminated within bounds.
-                if (len < path_buf.len) {
-                    var resolved_buf: [std.posix.PATH_MAX]u8 = undefined;
-                    if (std.c.realpath(path_buf[0..len :0], &resolved_buf)) |resolved| {
-                        const rlen = std.mem.indexOfScalar(u8, resolved[0..resolved_buf.len], 0) orelse resolved_buf.len;
-                        break :blk resolved[0..rlen];
-                    }
-                }
-                break :blk path_buf[0..len];
+    if (comptime @import("builtin").os.tag == .macos) {
+        var size: u32 = @intCast(buf.len);
+        const rc = std.c._NSGetExecutablePath(buf.ptr, &size);
+        if (rc != 0) return null;
+        const len = std.mem.indexOfScalar(u8, buf[0..buf.len], 0) orelse return null;
+        // _NSGetExecutablePath may return a symlinked or relative path, which
+        // would derive ../lib from the wrong tree — resolve it to the real path
+        // first. Fall back to the raw path if realpath fails.
+        var resolved_buf: [std.posix.PATH_MAX]u8 = undefined;
+        if (std.c.realpath(buf[0..len :0], &resolved_buf)) |resolved| {
+            const rlen = std.mem.indexOfScalar(u8, resolved[0..resolved_buf.len], 0) orelse resolved_buf.len;
+            if (rlen <= buf.len) {
+                @memcpy(buf[0..rlen], resolved[0..rlen]);
+                return buf[0..rlen];
             }
         }
+        return buf[0..len];
+    }
 
-        break :blk "";
-    };
+    return null;
+}
+
+pub fn getExeRelativeLibDir(buf: []u8) ?[]const u8 {
+    var path_buf: [1024]u8 = undefined;
+    const exe_path: []const u8 = getExePath(&path_buf) orelse "";
     return siblingLibDir(exe_path, buf);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,6 +46,7 @@ pub const diagnostics = @import("diagnostics.zig");
 pub const lsp_diagnostic = @import("lsp_diagnostic.zig");
 pub const cli = @import("cli.zig");
 pub const explain = @import("explain.zig");
+pub const test_runner = @import("test_runner.zig");
 pub const config = @import("config.zig");
 
 pub const version = @import("build_options").version;
@@ -168,6 +169,13 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     // of that exists and exit. (Skipped on WASM, whose entry just runs a file.)
     if (comptime !is_wasm) {
         if (explain.maybeRun(allocator, init.args)) |exit_code| {
+            std.process.exit(exit_code);
+        }
+        // `kaappi test` is an orchestrator over worker subprocesses; like
+        // explain it needs no VM of its own, so dispatch it before any setup.
+        // (The worker children are ordinary `kaappi <file>` runs; they are
+        // recognized later by KAAPPI_TEST_EMIT in the file-run path.)
+        if (test_runner.maybeRun(allocator, init.args)) |exit_code| {
             std.process.exit(exit_code);
         }
     }
@@ -465,6 +473,12 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             usageError("Usage: kaappi --emit-llvm <file.scm> [-o output.ll]\n");
         }
     } else if (opts.file_path) |fp| {
+        if (comptime !is_wasm) {
+            if (test_runner.workerEmitPath()) |emit_path| {
+                try runWorkerFile(vm, fp, emit_path);
+                return;
+            }
+        }
         try runFile(vm, fp);
     } else {
         if (is_wasm) {
@@ -701,6 +715,38 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             bytecode_file.writeFileWithTopLevel(allocator, compiled_funcs.items, source_hash, sp) catch {};
         }
     }
+}
+
+/// `kaappi test` worker path: install the collecting SRFI-64 runner, run the
+/// file, then emit its one JSON result object. `suppress_exit` lets a file's
+/// `(exit 1)` epilogue be recorded instead of terminating the worker before it
+/// reports. The worker always exits 0 — the orchestrator reads pass/fail from
+/// the emitted JSON, not from this process's status (a missing/empty result is
+/// what signals a crash).
+fn runWorkerFile(vm: *vm_mod.VM, fp: []const u8, emit_path: []const u8) !void {
+    vm.suppress_exit = true;
+    test_runner.installCollector(vm) catch {
+        test_runner.emitResult(vm, emit_path, fp, true, "test collector setup failed", 0);
+        script_had_error = false;
+        return;
+    };
+
+    const start_ns = @import("vm_calls.zig").clockNs();
+    script_had_error = false;
+    runFile(vm, fp) catch {
+        script_had_error = true;
+    };
+    const duration_ms = @as(f64, @floatFromInt(@import("vm_calls.zig").clockNs() -| start_ns)) / 1_000_000.0;
+
+    // A file-level error is an *uncaught* read/compile/runtime error at top
+    // level — SRFI-64 catches test failures internally, so those never set
+    // this. A test file's `(exit 1)` failure epilogue is deliberately NOT an
+    // error: it is redundant with the fail counts we already collected.
+    const errored = script_had_error;
+    test_runner.emitResult(vm, emit_path, fp, errored, null, duration_ms);
+    // The result is emitted; don't let the file's error propagate to a nonzero
+    // worker exit — the orchestrator uses the JSON.
+    script_had_error = false;
 }
 
 fn runStdin(vm: *vm_mod.VM) !void {
@@ -978,5 +1024,6 @@ test {
     _ = repl_mod;
     _ = cli;
     _ = explain;
+    _ = test_runner;
     _ = config;
 }

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -110,6 +110,15 @@ fn exitCode(args: []const Value) u8 {
 fn exitFn(args: []const Value) PrimitiveError!Value {
     const code = exitCode(args);
     if (vm_mod.vm_instance) |vm| {
+        // `kaappi test` worker: record the request but don't terminate, so the
+        // worker still reaches its result-emission step. A test file's SRFI-64
+        // epilogue calls `(exit 1)` only on failure; suppressing it lets the
+        // worker report that failure structurally instead of losing the run.
+        if (vm.suppress_exit) {
+            vm.exit_requested = true;
+            vm.exit_code = code;
+            return types.VOID;
+        }
         var i = vm.wind_count;
         while (i > 0) {
             i -= 1;

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -1,0 +1,954 @@
+//! `kaappi test [paths...]` — first-class SRFI-64 test runner (kaappi#1509,
+//! part of the machine-legibility epic kaappi#1503).
+//!
+//! The suite already standardises on SRFI-64; what was missing is a runner an
+//! agent or CI can drive and parse without scraping the human report. This
+//! module is that runner, in two cooperating roles:
+//!
+//!  * **Orchestrator** (`maybeRun`) — the `kaappi test` process. It discovers
+//!    SRFI-64 suites, runs each in its own worker subprocess, aggregates the
+//!    counts the SRFI-64 runner itself reports (never by grepping the
+//!    "# of expected passes" lines), and prints a human summary or JSON Lines.
+//!    Exit status is nonzero iff a test failed, unexpectedly passed, or a file
+//!    errored.
+//!
+//!  * **Worker** (`workerEmitPath`, `installCollector`, `emitResult`) — a
+//!    child `kaappi <file>` invocation with `KAAPPI_TEST_EMIT` set in its
+//!    environment. Before the file runs it swaps in a quiet collecting
+//!    test-runner (built on `test-runner-null`, so no SRFI-64 chatter and no
+//!    `.log` files) whose per-test hook records structured results; afterwards
+//!    it writes exactly one JSON object describing the file.
+//!
+//! Subprocess isolation is deliberate, not incidental: a file that loops,
+//! segfaults, leaks a thread, or calls `(exit 1)` in its failure epilogue can
+//! neither corrupt the run nor bleed into another file's results. The worker
+//! sets `vm.suppress_exit` so that a file's `(exit)` cannot rob it of the
+//! chance to emit its result.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const reporting = @import("reporting.zig");
+const lsp_diagnostic = @import("lsp_diagnostic.zig");
+const types = @import("types.zig");
+const vm_mod = @import("vm.zig");
+const file_utils = @import("file_utils.zig");
+const kaappi_paths = @import("kaappi_paths.zig");
+
+const VM = vm_mod.VM;
+const Value = types.Value;
+const writeStdout = reporting.writeStdout;
+const writeStderr = reporting.writeStderr;
+const clockNs = @import("vm_calls.zig").clockNs;
+
+pub const USAGE_ERROR_EXIT: u8 = 2;
+
+/// Environment channel between orchestrator and worker. `EMIT_ENV` names the
+/// file the worker writes its one JSON result object to (per file, robust to
+/// the worker crashing or the test file calling `(exit)`); `SEED_ENV` carries
+/// the run-wide SRFI-27 seed.
+const EMIT_ENV = "KAAPPI_TEST_EMIT";
+const SEED_ENV = "KAAPPI_TEST_SEED";
+
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+
+fn getEnv(name: [*:0]const u8) ?[]const u8 {
+    const v = std.c.getenv(name) orelse return null;
+    return std.mem.span(v);
+}
+
+// ── Worker role ────────────────────────────────────────────────────────
+
+/// The Scheme prelude the worker evaluates before running a test file. It
+/// installs a collecting test-runner factory so every `test-begin` in the file
+/// (there may be several) produces a runner that funnels results into the
+/// `%kt-*` accumulators. Built on `test-runner-null`, so the SRFI-64 machinery
+/// prints nothing and writes no log file — this runner speaks only through the
+/// accumulators, which `%kt-collect` hands back to Zig as one vector.
+const collector_prelude =
+    \\(import (scheme base) (scheme write) (srfi 64))
+    \\(define %kt-pass 0)
+    \\(define %kt-fail 0)
+    \\(define %kt-xpass 0)
+    \\(define %kt-xfail 0)
+    \\(define %kt-skip 0)
+    \\(define %kt-suite #f)
+    \\(define %kt-failures '())
+    \\(define (%kt-render x)
+    \\  (let ((p (open-output-string)))
+    \\    (write x p)
+    \\    (get-output-string p)))
+    \\(define (%kt-name->string x)
+    \\  (cond ((eq? x #f) #f)
+    \\        ((string? x) x)
+    \\        (else (%kt-render x))))
+    \\(define (%kt-on-group-begin r name count)
+    \\  (if (and (not %kt-suite) (null? (test-runner-group-stack r)))
+    \\      (set! %kt-suite (%kt-name->string name))))
+    \\(define (%kt-on-test-end r)
+    \\  (let ((kind (test-result-kind r))
+    \\        (alist (test-result-alist r)))
+    \\    (cond
+    \\     ((eq? kind 'pass) (set! %kt-pass (+ %kt-pass 1)))
+    \\     ((eq? kind 'xfail) (set! %kt-xfail (+ %kt-xfail 1)))
+    \\     ((eq? kind 'skip) (set! %kt-skip (+ %kt-skip 1)))
+    \\     ((or (eq? kind 'fail) (eq? kind 'xpass))
+    \\      (if (eq? kind 'fail)
+    \\          (set! %kt-fail (+ %kt-fail 1))
+    \\          (set! %kt-xpass (+ %kt-xpass 1)))
+    \\      (let ((nm (assq 'test-name alist))
+    \\            (ev (assq 'expected-value alist))
+    \\            (av (assq 'actual-value alist))
+    \\            (sf (assq 'source-file alist))
+    \\            (sl (assq 'source-line alist)))
+    \\        (set! %kt-failures
+    \\              (cons (vector (if nm (%kt-name->string (cdr nm)) #f)
+    \\                            (symbol->string kind)
+    \\                            (if ev (%kt-render (cdr ev)) #f)
+    \\                            (if av (%kt-render (cdr av)) #f)
+    \\                            (if (and sf (string? (cdr sf))) (cdr sf) #f)
+    \\                            (if (and sl (exact-integer? (cdr sl))) (cdr sl) #f))
+    \\                    %kt-failures))))
+    \\     (else (set! %kt-skip (+ %kt-skip 1))))))
+    \\(define (%kt-factory)
+    \\  (let ((r (test-runner-null)))
+    \\    (test-runner-on-test-end! r %kt-on-test-end)
+    \\    (test-runner-on-group-begin! r %kt-on-group-begin)
+    \\    r))
+    \\(test-runner-factory %kt-factory)
+    \\(define (%kt-collect)
+    \\  (vector %kt-pass %kt-fail %kt-xpass %kt-xfail %kt-skip %kt-suite
+    \\          (reverse %kt-failures)))
+;
+
+/// The emit-file path if this process was launched as a `kaappi test` worker,
+/// else null. Presence of the env var is what puts a plain `kaappi <file>` run
+/// into worker mode.
+pub fn workerEmitPath() ?[]const u8 {
+    return getEnv(EMIT_ENV);
+}
+
+/// Install the collecting runner (and, when `SEED_ENV` is set, seed SRFI-27's
+/// default source deterministically). Must run after `vm.lib_paths` is set and
+/// before the test file runs. Returns an error only if the prelude itself fails
+/// to evaluate — a corrupt build, essentially.
+pub fn installCollector(vm: *VM) !void {
+    _ = vm.eval(collector_prelude) catch return error.CollectorInstallFailed;
+
+    if (getEnv(SEED_ENV)) |seed_str| {
+        const seed = std.fmt.parseInt(u64, seed_str, 10) catch return;
+        var buf: [256]u8 = undefined;
+        // `random-source-pseudo-randomize!` sets the source state as a pure
+        // function of (i, j), so the same seed reproduces the same draws. We
+        // seed the default source that `random-integer`/`random-real` use.
+        const prog = std.fmt.bufPrint(
+            &buf,
+            "(import (srfi 27)) (random-source-pseudo-randomize! default-random-source 0 {d})",
+            .{seed},
+        ) catch return;
+        _ = vm.eval(prog) catch {};
+    }
+}
+
+/// Write the file's one JSON result object to `emit_path`. Called after the
+/// test file has run (whether it completed, errored, or asked to exit). `errored`
+/// records a file-level failure — an uncaught top-level error or a nonzero
+/// `(exit)` — distinct from ordinary test failures, which live in the counts.
+pub fn emitResult(vm: *VM, emit_path: []const u8, file_path: []const u8, errored: bool, err_msg: ?[]const u8, duration_ms: f64) void {
+    const allocator = vm.gc.allocator;
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    buildFileJson(&aw.writer, vm, file_path, errored, err_msg, duration_ms) catch {
+        // Fall back to a minimal, always-valid error object so the orchestrator
+        // never has to treat a write we attempted as a missing result.
+        writeFile(emit_path, "{\"type\":\"file\",\"error\":true,\"error_message\":\"result serialization failed\"}\n");
+        return;
+    };
+    writeFile(emit_path, aw.written());
+}
+
+/// Serialize one `{"type":"file", ...}` object from the `%kt-collect` vector.
+fn buildFileJson(w: *std.Io.Writer, vm: *VM, file_path: []const u8, errored: bool, err_msg: ?[]const u8, duration_ms: f64) !void {
+    var collected: Value = vm.eval("(%kt-collect)") catch types.FALSE;
+    vm.gc.pushRoot(&collected);
+    defer vm.gc.popRoot();
+
+    var pass: i64 = 0;
+    var fail: i64 = 0;
+    var xpass: i64 = 0;
+    var xfail: i64 = 0;
+    var skip: i64 = 0;
+    var suite: Value = types.FALSE;
+    var failures: Value = types.NIL;
+
+    if (types.isVector(collected)) {
+        const vec = types.toObject(collected).as(types.Vector).data;
+        if (vec.len >= 7) {
+            pass = fixOr0(vec[0]);
+            fail = fixOr0(vec[1]);
+            xpass = fixOr0(vec[2]);
+            xfail = fixOr0(vec[3]);
+            skip = fixOr0(vec[4]);
+            suite = vec[5];
+            failures = vec[6];
+        }
+    }
+    const tests = pass + fail + xpass + xfail + skip;
+
+    try w.writeAll("{\"type\":\"file\",\"file\":");
+    try lsp_diagnostic.writeJsonString(w, file_path);
+    try w.writeAll(",\"suite\":");
+    try writeStrOrNull(w, suite);
+    try w.print(
+        ",\"tests\":{d},\"pass\":{d},\"fail\":{d},\"xpass\":{d},\"xfail\":{d},\"skip\":{d}",
+        .{ tests, pass, fail, xpass, xfail, skip },
+    );
+    try w.writeAll(",\"error\":");
+    try w.writeAll(if (errored) "true" else "false");
+    try w.writeAll(",\"error_message\":");
+    if (err_msg) |m| try lsp_diagnostic.writeJsonString(w, m) else try w.writeAll("null");
+    try w.print(",\"duration_ms\":{d:.3},\"failures\":[", .{duration_ms});
+
+    var first = true;
+    var cur = failures;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        const rec = types.car(cur);
+        if (!types.isVector(rec)) continue;
+        const rv = types.toObject(rec).as(types.Vector).data;
+        if (rv.len < 6) continue;
+        if (!first) try w.writeByte(',');
+        first = false;
+        try w.writeAll("{\"name\":");
+        try writeStrOrNull(w, rv[0]);
+        try w.writeAll(",\"kind\":");
+        try writeStrOrNull(w, rv[1]);
+        try w.writeAll(",\"expected\":");
+        try writeStrOrNull(w, rv[2]);
+        try w.writeAll(",\"actual\":");
+        try writeStrOrNull(w, rv[3]);
+        try w.writeAll(",\"source_file\":");
+        try writeStrOrNull(w, rv[4]);
+        try w.writeAll(",\"source_line\":");
+        try writeIntOrNull(w, rv[5]);
+        try w.writeByte('}');
+    }
+    try w.writeAll("]}\n");
+}
+
+fn fixOr0(v: Value) i64 {
+    return if (types.isFixnum(v)) types.toFixnum(v) else 0;
+}
+
+fn stringBytes(v: Value) ?[]const u8 {
+    if (!types.isString(v)) return null;
+    const s = types.toObject(v).as(types.SchemeString);
+    return s.data[0..s.len];
+}
+
+fn writeStrOrNull(w: *std.Io.Writer, v: Value) !void {
+    if (stringBytes(v)) |bytes| {
+        try lsp_diagnostic.writeJsonString(w, bytes);
+    } else {
+        try w.writeAll("null");
+    }
+}
+
+fn writeIntOrNull(w: *std.Io.Writer, v: Value) !void {
+    if (types.isFixnum(v)) {
+        try w.print("{d}", .{types.toFixnum(v)});
+    } else {
+        try w.writeAll("null");
+    }
+}
+
+fn writeFile(path: []const u8, bytes: []const u8) void {
+    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    if (path.len >= buf.len) return;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    const path_z: [*:0]const u8 = @ptrCast(&buf);
+    const fd = std.posix.openatZ(std.posix.AT.FDCWD, path_z, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, 0o644) catch return;
+    defer _ = std.posix.system.close(fd);
+    reporting.writeToFd(fd, bytes);
+}
+
+// ── Orchestrator role ──────────────────────────────────────────────────
+
+const ParentOpts = struct {
+    json: bool = false,
+    seed: ?u64 = null,
+    lib_paths: std.ArrayList([]const u8) = .empty,
+    paths: std.ArrayList([]const u8) = .empty,
+
+    fn deinit(self: *ParentOpts, allocator: std.mem.Allocator) void {
+        self.lib_paths.deinit(allocator);
+        self.paths.deinit(allocator);
+    }
+};
+
+/// Running totals across every file, plus the exit-relevant tallies.
+const Totals = struct {
+    files: u64 = 0,
+    files_failed: u64 = 0,
+    errors: u64 = 0,
+    pass: u64 = 0,
+    fail: u64 = 0,
+    xpass: u64 = 0,
+    xfail: u64 = 0,
+    skip: u64 = 0,
+};
+
+/// If `args` is a `kaappi test …` invocation, run it fully and return the
+/// process exit code; otherwise return null so normal CLI dispatch proceeds.
+/// Like `explain`, the orchestrator needs no VM of its own — it spawns workers
+/// — so main dispatches it before any VM/GC setup.
+pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
+    var it = args.iterate();
+    const argv0 = it.next() orelse return null;
+    const first = it.next() orelse return null;
+    if (!std.mem.eql(u8, first, "test")) return null;
+
+    var opts: ParentOpts = .{};
+    defer opts.deinit(allocator);
+
+    while (it.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--json")) {
+            opts.json = true;
+        } else if (std.mem.eql(u8, arg, "--seed")) {
+            const val = it.next() orelse {
+                writeStderr("kaappi test: --seed requires an integer argument\n");
+                return USAGE_ERROR_EXIT;
+            };
+            opts.seed = std.fmt.parseInt(u64, val, 10) catch {
+                writeStderr("kaappi test: --seed requires a non-negative integer\n");
+                return USAGE_ERROR_EXIT;
+            };
+        } else if (std.mem.eql(u8, arg, "--lib-path")) {
+            const val = it.next() orelse {
+                writeStderr("kaappi test: --lib-path requires a path argument\n");
+                return USAGE_ERROR_EXIT;
+            };
+            opts.lib_paths.append(allocator, val) catch return oom();
+        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            printUsage();
+            return 0;
+        } else if (arg.len > 1 and arg[0] == '-') {
+            writeStderr("kaappi test: unknown option '");
+            writeStderr(arg);
+            writeStderr("'\nRun 'kaappi test --help' for usage.\n");
+            return USAGE_ERROR_EXIT;
+        } else {
+            opts.paths.append(allocator, arg) catch return oom();
+        }
+    }
+
+    return run(allocator, argv0, &opts);
+}
+
+fn run(allocator: std.mem.Allocator, argv0: []const u8, opts: *ParentOpts) u8 {
+    // The exe to spawn as a worker: prefer the resolved self-path so it works
+    // regardless of how the parent was invoked, falling back to argv[0].
+    var exe_buf: [std.posix.PATH_MAX]u8 = undefined;
+    const exe_path = kaappi_paths.getExePath(&exe_buf) orelse argv0;
+
+    // One seed for the whole run; a random but human-typable value when the
+    // caller didn't pin one, so any failure is reproducible via --seed.
+    const seed = opts.seed orelse randomSeed();
+    {
+        var sbuf: [32]u8 = undefined;
+        const s = std.fmt.bufPrintZ(&sbuf, "{d}", .{seed}) catch return 1;
+        _ = setenv(SEED_ENV, s.ptr, 1);
+    }
+
+    var files: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (files.items) |f| allocator.free(f);
+        files.deinit(allocator);
+    }
+    discover(allocator, opts.paths.items, &files) catch {
+        writeStderr("kaappi test: out of memory during discovery\n");
+        return 1;
+    };
+
+    if (files.items.len == 0) {
+        if (opts.paths.items.len == 0) {
+            writeStderr("kaappi test: no SRFI-64 suites found under ./tests (pass paths explicitly, or run from a repo with a tests/ directory)\n");
+        } else {
+            writeStderr("kaappi test: no test files matched the given paths\n");
+        }
+        return 1;
+    }
+    std.mem.sort([]const u8, files.items, {}, lessThanStr);
+
+    // Seed note goes to stderr so JSON Lines on stdout stay pure, and is
+    // present on every run per the reproducibility requirement.
+    {
+        var nbuf: [128]u8 = undefined;
+        const note = std.fmt.bufPrint(&nbuf, "kaappi test: seed {d} (reproduce with: kaappi test --seed {d})\n", .{ seed, seed }) catch "";
+        writeStderr(note);
+    }
+
+    var totals: Totals = .{};
+    const start_ns = clockNs();
+
+    for (files.items, 0..) |file, i| {
+        runOneFile(allocator, exe_path, file, opts, i, &totals);
+    }
+
+    const total_ms = @as(f64, @floatFromInt(clockNs() -| start_ns)) / 1_000_000.0;
+    emitSummary(allocator, opts.json, &totals, seed, total_ms);
+
+    return if (totals.fail > 0 or totals.xpass > 0 or totals.errors > 0) 1 else 0;
+}
+
+fn runOneFile(allocator: std.mem.Allocator, exe_path: []const u8, file: []const u8, opts: *ParentOpts, index: usize, totals: *Totals) void {
+    const emit_path = std.fmt.allocPrint(allocator, "{s}/kaappi-test-{d}-{d}.json", .{ tmpDir(), std.c.getpid(), index }) catch {
+        writeStderr("kaappi test: out of memory\n");
+        return;
+    };
+    defer allocator.free(emit_path);
+
+    {
+        var pbuf: [std.posix.PATH_MAX]u8 = undefined;
+        if (emit_path.len < pbuf.len) {
+            @memcpy(pbuf[0..emit_path.len], emit_path);
+            pbuf[emit_path.len] = 0;
+            _ = setenv(EMIT_ENV, @ptrCast(&pbuf), 1);
+        }
+    }
+
+    const spawn = spawnWorker(allocator, exe_path, file, opts.lib_paths.items) catch {
+        reportSpawnFailure(file, totals, opts.json);
+        return;
+    };
+    defer allocator.free(spawn.output);
+
+    const result_json: ?[]u8 = file_utils.readWholeFile(allocator, emit_path, 8 * 1024 * 1024) catch null;
+    defer if (result_json) |rj| allocator.free(rj);
+    unlinkPath(emit_path);
+
+    accumulateAndReport(allocator, file, result_json, spawn, totals, opts.json);
+}
+
+const SpawnResult = struct {
+    output: []u8,
+    exit_code: u8,
+    signaled: bool,
+};
+
+/// Fork/exec `exe_path` on one file, capturing its combined stdout+stderr.
+/// `KAAPPI_TEST_EMIT` (set by the caller) is inherited via the environment, so
+/// the child runs as a worker and writes its JSON to that path. Output is
+/// capped so a runaway test can't exhaust memory here.
+fn spawnWorker(allocator: std.mem.Allocator, exe_path: []const u8, file: []const u8, lib_paths: []const []const u8) !SpawnResult {
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, exe_path);
+    for (lib_paths) |p| {
+        try argv.append(allocator, "--lib-path");
+        try argv.append(allocator, p);
+    }
+    try argv.append(allocator, file);
+
+    const argv_z = try allocator.alloc(?[*:0]const u8, argv.items.len + 1);
+    @memset(argv_z, null);
+    defer {
+        for (argv_z) |maybe_ptr| {
+            if (maybe_ptr) |p| {
+                const len = std.mem.len(p);
+                const ptr: [*]u8 = @constCast(p);
+                allocator.free(ptr[0 .. len + 1]);
+            }
+        }
+        allocator.free(argv_z);
+    }
+    for (argv.items, 0..) |arg, i| {
+        argv_z[i] = (try allocator.dupeZ(u8, arg)).ptr;
+    }
+
+    var pipe: [2]c_int = undefined;
+    if (std.c.pipe(&pipe) != 0) return error.PipeFailed;
+
+    const pid = std.posix.system.fork();
+    if (pid < 0) {
+        _ = std.c.close(pipe[0]);
+        _ = std.c.close(pipe[1]);
+        return error.ForkFailed;
+    }
+
+    if (pid == 0) {
+        // Child: both stdout and stderr go down the pipe, so the file's own
+        // chatter and any error diagnostics are captured together.
+        _ = std.c.close(pipe[0]);
+        _ = std.c.dup2(pipe[1], 1);
+        _ = std.c.dup2(pipe[1], 2);
+        _ = std.c.close(pipe[1]);
+        _ = std.posix.system.execve(
+            @ptrCast(argv_z[0].?),
+            @ptrCast(argv_z.ptr),
+            @ptrCast(std.c.environ),
+        );
+        std.process.exit(127);
+    }
+
+    _ = std.c.close(pipe[1]);
+    const cap: usize = 1024 * 1024;
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(allocator);
+    var tmp: [4096]u8 = undefined;
+    while (true) {
+        const n = std.posix.read(pipe[0], &tmp) catch break;
+        if (n == 0) break;
+        if (output.items.len < cap) {
+            const room = cap - output.items.len;
+            output.appendSlice(allocator, tmp[0..@min(n, room)]) catch break;
+        }
+    }
+    _ = std.c.close(pipe[0]);
+
+    var status: c_int = 0;
+    _ = std.c.waitpid(pid, &status, 0);
+    const raw: c_uint = @bitCast(status);
+    const wifexited = (raw & 0x7f) == 0;
+    const exit_code: u8 = @intCast((raw >> 8) & 0xff);
+
+    return .{
+        .output = output.toOwnedSlice(allocator) catch return error.OutOfMemory,
+        .exit_code = if (wifexited) exit_code else 1,
+        .signaled = !wifexited,
+    };
+}
+
+// ── Result shapes parsed back from a worker ────────────────────────────
+
+const FailureJson = struct {
+    name: ?[]const u8 = null,
+    kind: []const u8 = "fail",
+    expected: ?[]const u8 = null,
+    actual: ?[]const u8 = null,
+    source_file: ?[]const u8 = null,
+    source_line: ?i64 = null,
+};
+
+const FileResultJson = struct {
+    type: []const u8 = "file",
+    file: []const u8 = "",
+    suite: ?[]const u8 = null,
+    tests: u64 = 0,
+    pass: u64 = 0,
+    fail: u64 = 0,
+    xpass: u64 = 0,
+    xfail: u64 = 0,
+    skip: u64 = 0,
+    @"error": bool = false,
+    error_message: ?[]const u8 = null,
+    duration_ms: f64 = 0,
+    failures: []FailureJson = &.{},
+};
+
+fn accumulateAndReport(allocator: std.mem.Allocator, file: []const u8, result_json: ?[]u8, spawn: SpawnResult, totals: *Totals, json: bool) void {
+    const bytes = result_json orelse {
+        reportMissingResult(allocator, file, spawn, totals, json);
+        return;
+    };
+    if (std.mem.trim(u8, bytes, " \t\r\n").len == 0) {
+        reportMissingResult(allocator, file, spawn, totals, json);
+        return;
+    }
+
+    const parsed = std.json.parseFromSlice(FileResultJson, allocator, bytes, .{ .ignore_unknown_fields = true }) catch {
+        reportMissingResult(allocator, file, spawn, totals, json);
+        return;
+    };
+    defer parsed.deinit();
+    const r = parsed.value;
+
+    totals.files += 1;
+    totals.pass += r.pass;
+    totals.fail += r.fail;
+    totals.xpass += r.xpass;
+    totals.xfail += r.xfail;
+    totals.skip += r.skip;
+    const errored = r.@"error" or spawn.signaled;
+    if (errored) totals.errors += 1;
+    const failed = errored or r.fail > 0 or r.xpass > 0;
+    if (failed) totals.files_failed += 1;
+
+    if (json) {
+        // Re-serialize from the parsed object so the parent is the single
+        // producer of user-facing JSON and can enrich it: a killed worker gets
+        // error=true, and an errored file with no message of its own gets the
+        // diagnostic we captured from its output (which the worker itself never
+        // saw — it went to the pipe we own).
+        var enriched = r;
+        if (spawn.signaled) enriched.@"error" = true;
+        const override: ?[]const u8 = if (enriched.@"error" and enriched.error_message == null)
+            errorTail(if (spawn.signaled) "worker killed by signal" else spawn.output)
+        else
+            null;
+        emitFileObject(allocator, enriched, override);
+    } else {
+        reportFileText(file, r, errored, spawn);
+    }
+}
+
+fn reportFileText(file: []const u8, r: FileResultJson, errored: bool, spawn: SpawnResult) void {
+    var buf: [1024]u8 = undefined;
+    if (errored) {
+        const line = std.fmt.bufPrint(&buf, "  ERROR {s}\n", .{file}) catch "  ERROR (file)\n";
+        writeStdout(line);
+        printCapturedOutput(spawn.output);
+        return;
+    }
+    if (r.fail > 0 or r.xpass > 0) {
+        const line = std.fmt.bufPrint(&buf, "  FAIL  {s}  ({d}/{d} failed, {d:.0}ms)\n", .{ file, r.fail + r.xpass, r.tests, r.duration_ms }) catch "  FAIL\n";
+        writeStdout(line);
+        for (r.failures) |f| printFailure(f);
+    } else {
+        const line = std.fmt.bufPrint(&buf, "  PASS  {s}  ({d} tests, {d} skipped, {d:.0}ms)\n", .{ file, r.tests, r.skip, r.duration_ms }) catch "  PASS\n";
+        writeStdout(line);
+    }
+}
+
+fn printFailure(f: FailureJson) void {
+    var buf: [2048]u8 = undefined;
+    const name = f.name orelse "(unnamed)";
+    const line = if (f.expected != null and f.actual != null)
+        std.fmt.bufPrint(&buf, "        - {s}: expected {s}, got {s}\n", .{ name, f.expected.?, f.actual.? }) catch return
+    else if (f.actual != null)
+        std.fmt.bufPrint(&buf, "        - {s}: got {s}\n", .{ name, f.actual.? }) catch return
+    else
+        std.fmt.bufPrint(&buf, "        - {s}\n", .{name}) catch return;
+    writeStdout(line);
+}
+
+/// Show the tail of a failed/errored worker's captured output, indented, so the
+/// real diagnostic (a compile error, a stack trace) is visible inline.
+fn printCapturedOutput(output: []const u8) void {
+    const trimmed = std.mem.trim(u8, output, " \t\r\n");
+    if (trimmed.len == 0) return;
+    var lines = std.mem.splitScalar(u8, trimmed, '\n');
+    while (lines.next()) |ln| {
+        writeStdout("        | ");
+        writeStdout(ln);
+        writeStdout("\n");
+    }
+}
+
+fn reportMissingResult(allocator: std.mem.Allocator, file: []const u8, spawn: SpawnResult, totals: *Totals, json: bool) void {
+    totals.files += 1;
+    totals.errors += 1;
+    totals.files_failed += 1;
+    if (json) {
+        const r: FileResultJson = .{ .file = file, .@"error" = true };
+        const msg = if (spawn.signaled) "worker killed by signal" else errorTail(spawn.output) orelse "worker produced no result";
+        emitFileObject(allocator, r, msg);
+    } else {
+        var buf: [1024]u8 = undefined;
+        const line = std.fmt.bufPrint(&buf, "  ERROR {s}  (worker produced no result{s})\n", .{ file, if (spawn.signaled) ", killed by signal" else "" }) catch "  ERROR (no result)\n";
+        writeStdout(line);
+        printCapturedOutput(spawn.output);
+    }
+}
+
+fn reportSpawnFailure(file: []const u8, totals: *Totals, json: bool) void {
+    totals.files += 1;
+    totals.errors += 1;
+    totals.files_failed += 1;
+    if (json) {
+        emitFileObject(std.heap.page_allocator, .{ .file = file, .@"error" = true }, "failed to spawn worker");
+    } else {
+        var buf: [1024]u8 = undefined;
+        const line = std.fmt.bufPrint(&buf, "  ERROR {s}  (failed to spawn worker)\n", .{file}) catch "  ERROR (spawn failed)\n";
+        writeStdout(line);
+    }
+}
+
+/// Serialize one `{"type":"file", ...}` line from a parsed/synthesized result.
+/// `error_message_override` fills `error_message` when the result carries none
+/// of its own — used to surface a captured diagnostic for a file that errored.
+/// This is the parent's counterpart to the worker's `buildFileJson`; both must
+/// emit the same shape (covered by a round-trip parse test).
+fn emitFileObject(allocator: std.mem.Allocator, r: FileResultJson, error_message_override: ?[]const u8) void {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    writeFileObject(&aw.writer, r, error_message_override) catch return;
+    writeStdout(aw.written());
+}
+
+fn writeFileObject(w: *std.Io.Writer, r: FileResultJson, error_message_override: ?[]const u8) !void {
+    try w.writeAll("{\"type\":\"file\",\"file\":");
+    try lsp_diagnostic.writeJsonString(w, r.file);
+    try w.writeAll(",\"suite\":");
+    if (r.suite) |s| try lsp_diagnostic.writeJsonString(w, s) else try w.writeAll("null");
+    try w.print(",\"tests\":{d},\"pass\":{d},\"fail\":{d},\"xpass\":{d},\"xfail\":{d},\"skip\":{d}", .{ r.tests, r.pass, r.fail, r.xpass, r.xfail, r.skip });
+    try w.writeAll(",\"error\":");
+    try w.writeAll(if (r.@"error") "true" else "false");
+    try w.writeAll(",\"error_message\":");
+    const msg = r.error_message orelse error_message_override;
+    if (msg) |m| try lsp_diagnostic.writeJsonString(w, m) else try w.writeAll("null");
+    try w.print(",\"duration_ms\":{d:.3},\"failures\":[", .{r.duration_ms});
+    for (r.failures, 0..) |f, i| {
+        if (i > 0) try w.writeByte(',');
+        try w.writeAll("{\"name\":");
+        if (f.name) |n| try lsp_diagnostic.writeJsonString(w, n) else try w.writeAll("null");
+        try w.writeAll(",\"kind\":");
+        try lsp_diagnostic.writeJsonString(w, f.kind);
+        try w.writeAll(",\"expected\":");
+        if (f.expected) |e| try lsp_diagnostic.writeJsonString(w, e) else try w.writeAll("null");
+        try w.writeAll(",\"actual\":");
+        if (f.actual) |a| try lsp_diagnostic.writeJsonString(w, a) else try w.writeAll("null");
+        try w.writeAll(",\"source_file\":");
+        if (f.source_file) |sf| try lsp_diagnostic.writeJsonString(w, sf) else try w.writeAll("null");
+        try w.writeAll(",\"source_line\":");
+        if (f.source_line) |sl| try w.print("{d}", .{sl}) else try w.writeAll("null");
+        try w.writeByte('}');
+    }
+    try w.writeAll("]}\n");
+}
+
+/// The trailing slice of captured worker output to use as an error message —
+/// trimmed, and capped so a long stack trace doesn't bloat the JSON. Null when
+/// there is nothing useful to report.
+fn errorTail(output: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, output, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    const cap = 1024;
+    return if (trimmed.len > cap) trimmed[trimmed.len - cap ..] else trimmed;
+}
+
+fn emitSummary(allocator: std.mem.Allocator, json: bool, t: *Totals, seed: u64, total_ms: f64) void {
+    if (json) {
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        const w = &aw.writer;
+        (blk: {
+            w.print(
+                "{{\"type\":\"summary\",\"files\":{d},\"files_failed\":{d},\"errors\":{d},\"tests\":{d},\"pass\":{d},\"fail\":{d},\"xpass\":{d},\"xfail\":{d},\"skip\":{d},\"seed\":{d},\"duration_ms\":{d:.3}}}\n",
+                .{ t.files, t.files_failed, t.errors, t.pass + t.fail + t.xpass + t.xfail + t.skip, t.pass, t.fail, t.xpass, t.xfail, t.skip, seed, total_ms },
+            ) catch break :blk error.W;
+            break :blk {};
+        }) catch return;
+        writeStdout(aw.written());
+        return;
+    }
+
+    var buf: [512]u8 = undefined;
+    writeStdout("\n");
+    const s1 = std.fmt.bufPrint(&buf, "Summary: {d} passed, {d} failed, {d} unexpected-pass, {d} expected-fail, {d} skipped\n", .{ t.pass, t.fail, t.xpass, t.xfail, t.skip }) catch "";
+    writeStdout(s1);
+    const s2 = std.fmt.bufPrint(&buf, "Files:   {d} run, {d} failed, {d} errored ({d:.0}ms)\n", .{ t.files, t.files_failed, t.errors, total_ms }) catch "";
+    writeStdout(s2);
+    const s3 = std.fmt.bufPrint(&buf, "Seed:    {d}  (reproduce with: kaappi test --seed {d})\n", .{ seed, seed }) catch "";
+    writeStdout(s3);
+}
+
+// ── Discovery ──────────────────────────────────────────────────────────
+
+/// Fill `out` with the test files to run. With no explicit paths, recurse
+/// `./tests` and keep only files that use SRFI-64. An explicit file path is
+/// taken as-is (the caller asked for it by name); an explicit directory is
+/// recursed with the same SRFI-64 filter.
+fn discover(allocator: std.mem.Allocator, paths: []const []const u8, out: *std.ArrayList([]const u8)) !void {
+    if (paths.len == 0) {
+        if (isDirectory("tests")) try discoverDir(allocator, "tests", out, 0);
+        return;
+    }
+    for (paths) |p| {
+        if (isDirectory(p)) {
+            try discoverDir(allocator, p, out, 0);
+        } else {
+            // A named path that isn't a directory is taken as a file to run,
+            // whether or not it exists — a missing file surfaces as a worker
+            // error, which is more useful than silently dropping it.
+            try out.append(allocator, try allocator.dupe(u8, p));
+        }
+    }
+}
+
+const max_discover_depth = 32;
+
+fn discoverDir(allocator: std.mem.Allocator, dir_path: []const u8, out: *std.ArrayList([]const u8), depth: usize) !void {
+    if (depth > max_discover_depth) return;
+
+    const dir_z = allocator.dupeZ(u8, dir_path) catch return error.OutOfMemory;
+    defer allocator.free(dir_z);
+    const dir = std.c.opendir(dir_z) orelse return;
+    defer _ = std.c.closedir(dir);
+
+    while (std.c.readdir(dir)) |entry| {
+        const name_ptr: [*:0]const u8 = @ptrCast(&entry.name);
+        const name = std.mem.span(name_ptr);
+        if (name.len == 0 or name[0] == '.') continue; // skip . .. and dotfiles
+
+        const full = try std.fs.path.join(allocator, &.{ dir_path, name });
+        var keep = false;
+        defer if (!keep) allocator.free(full);
+
+        if (isDirectory(full)) {
+            try discoverDir(allocator, full, out, depth + 1);
+        } else if (std.mem.endsWith(u8, name, ".scm") and usesSrfi64(allocator, full)) {
+            try out.append(allocator, full);
+            keep = true;
+        }
+    }
+}
+
+/// True if `path` names a directory. Implemented by attempting to open it as
+/// one (opendir fails with ENOTDIR on a regular file) — no stat needed, matching
+/// the raw-libc filesystem style used elsewhere in the tree.
+fn isDirectory(path: []const u8) bool {
+    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    if (path.len >= buf.len) return false;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    const dir = std.c.opendir(@ptrCast(&buf)) orelse return false;
+    _ = std.c.closedir(dir);
+    return true;
+}
+
+/// A cheap gate so directory recursion runs only SRFI-64 suites — skipping
+/// benchmarks, the chibi-test R7RS suite, and coverage helpers. A false
+/// positive merely runs a file that reports no tests.
+fn usesSrfi64(allocator: std.mem.Allocator, path: []const u8) bool {
+    const src = file_utils.readWholeFile(allocator, path, 4 * 1024 * 1024) catch return false;
+    defer allocator.free(src);
+    return sourceUsesSrfi64(src);
+}
+
+fn sourceUsesSrfi64(src: []const u8) bool {
+    return std.mem.indexOf(u8, src, "srfi 64") != null;
+}
+
+// ── Small helpers ──────────────────────────────────────────────────────
+
+fn lessThanStr(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
+}
+
+fn tmpDir() []const u8 {
+    return getEnv("TMPDIR") orelse "/tmp";
+}
+
+fn randomSeed() u64 {
+    const entropy = clockNs() ^ (@as(u64, @intCast(std.c.getpid())) << 32);
+    var prng = std.Random.DefaultPrng.init(entropy);
+    return prng.random().intRangeLessThan(u64, 1, 1_000_000);
+}
+
+fn unlinkPath(path: []const u8) void {
+    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    if (path.len >= buf.len) return;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    _ = std.c.unlink(@ptrCast(&buf));
+}
+
+fn oom() u8 {
+    writeStderr("kaappi test: out of memory\n");
+    return 1;
+}
+
+fn printUsage() void {
+    writeStdout(
+        \\Usage: kaappi test [options] [paths...]
+        \\
+        \\Discover and run SRFI-64 test suites, aggregating results from the
+        \\test runner itself. With no paths, recurses ./tests for SRFI-64 files.
+        \\A named file is run as given; a named directory is recursed.
+        \\
+        \\Options:
+        \\  --json             Emit JSON Lines: one object per file, then a summary.
+        \\  --seed <n>         Seed SRFI-27's default random source (default: random,
+        \\                     printed on every run so failures are reproducible).
+        \\  --lib-path <path>  Add a library search path (repeatable), forwarded to
+        \\                     each test file — e.g. kaappi test --lib-path ./lib.
+        \\  -h, --help         Show this help.
+        \\
+        \\Exit status is nonzero iff a test failed, unexpectedly passed, or a file
+        \\errored.
+        \\
+    );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "FileResultJson parses a worker object" {
+    const bytes =
+        \\{"type":"file","file":"t.scm","suite":"s","tests":3,"pass":2,"fail":1,"xpass":0,"xfail":0,"skip":0,"error":false,"error_message":null,"duration_ms":1.5,"failures":[{"name":"n","kind":"fail","expected":"1","actual":"2","source_file":null,"source_line":null}]}
+    ;
+    const parsed = try std.json.parseFromSlice(FileResultJson, testing.allocator, bytes, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    try testing.expectEqualStrings("file", parsed.value.type);
+    try testing.expectEqualStrings("s", parsed.value.suite.?);
+    try testing.expectEqual(@as(u64, 2), parsed.value.pass);
+    try testing.expectEqual(@as(u64, 1), parsed.value.fail);
+    try testing.expect(!parsed.value.@"error");
+    try testing.expectEqual(@as(usize, 1), parsed.value.failures.len);
+    try testing.expectEqualStrings("2", parsed.value.failures[0].actual.?);
+}
+
+test "randomSeed is in the human-typable range" {
+    const s = randomSeed();
+    try testing.expect(s >= 1 and s < 1_000_000);
+}
+
+test "sourceUsesSrfi64 gates on the import substring" {
+    try testing.expect(sourceUsesSrfi64("(import (scheme base) (srfi 64))\n(test-begin \"a\")"));
+    try testing.expect(sourceUsesSrfi64("(import\n  (srfi 64))"));
+    try testing.expect(!sourceUsesSrfi64("(import (scheme base))\n(display \"no tests\")"));
+    try testing.expect(!sourceUsesSrfi64("(import (srfi 1) (srfi 128))"));
+}
+
+test "writeFileObject round-trips through the JSON parser" {
+    var failures = [_]FailureJson{.{ .name = "n", .kind = "fail", .expected = "1", .actual = "2" }};
+    const r: FileResultJson = .{
+        .file = "t.scm",
+        .suite = "s",
+        .tests = 2,
+        .pass = 1,
+        .fail = 1,
+        .duration_ms = 1.25,
+        .failures = &failures,
+    };
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeFileObject(&aw.writer, r, null);
+
+    const parsed = try std.json.parseFromSlice(FileResultJson, testing.allocator, aw.written(), .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    try testing.expectEqualStrings("t.scm", parsed.value.file);
+    try testing.expectEqual(@as(u64, 1), parsed.value.fail);
+    try testing.expectEqualStrings("2", parsed.value.failures[0].actual.?);
+}
+
+test "writeFileObject uses the error-message override only when none is present" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeFileObject(&aw.writer, .{ .file = "t.scm", .@"error" = true }, "captured diagnostic");
+    const parsed = try std.json.parseFromSlice(FileResultJson, testing.allocator, aw.written(), .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    try testing.expect(parsed.value.@"error");
+    try testing.expectEqualStrings("captured diagnostic", parsed.value.error_message.?);
+}
+
+// A test file's SRFI-64 failure epilogue often calls `(exit 1)`. The worker
+// sets `suppress_exit` so that becomes a recorded no-op instead of tearing the
+// worker down before it can emit its result — without which a failing suite
+// would report as a crash. Guards the exitFn change in primitives_r7rs.zig.
+test "suppress_exit turns (exit) into a recorded no-op, VM stays usable" {
+    const th = @import("testing_helpers.zig");
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    ctx.vm.suppress_exit = true;
+    const r = try ctx.vm.eval("(import (scheme process-context)) (exit 7)");
+    try testing.expectEqual(types.VOID, r);
+    try testing.expect(ctx.vm.exit_requested);
+    try testing.expectEqual(@as(u8, 7), ctx.vm.exit_code);
+
+    const after = try ctx.vm.eval("(+ 1 2)");
+    try testing.expectEqual(@as(i64, 3), types.toFixnum(after));
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -257,6 +257,14 @@ pub const VM = struct {
     profile_time_stack: [256]ProfileTimeEntry = undefined,
     profile_time_depth: usize = 0,
     sandbox_mode: bool = false,
+    /// Set by the `kaappi test` worker path: when true, `(exit code)` records
+    /// the request and returns instead of terminating the process, so the
+    /// worker always reaches its result-emission step even when a test file's
+    /// SRFI-64 epilogue calls `(exit 1)` on failure. `exit_requested`/
+    /// `exit_code` capture the last such request. No effect on normal runs.
+    suppress_exit: bool = false,
+    exit_requested: bool = false,
+    exit_code: u8 = 0,
     timeout_deadline_ns: ?u64 = null,
     instruction_counter: u64 = 0,
     /// Optional speed-independent execution bound: when set, `runUntil` aborts

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Run all Kaappi Scheme test suites.
 # Usage: bash tests/scheme/run-all.sh
+#
+# This is the legacy runner: it spawns `kaappi <file>` per suite and scrapes the
+# printed pass/fail counts. The first-class runner is `kaappi test` (kaappi#1509,
+# see docs/dev/test-runner.md), which aggregates results from the SRFI-64 runner
+# itself and offers `--json`/`--seed`. This script is kept for its broader reach
+# — it also drives the chibi-test R7RS suite and the shell-based error/compile
+# suites, which are outside `kaappi test`'s SRFI-64 scope.
 
 set -euo pipefail
 
@@ -148,6 +155,7 @@ run_suite "FFI tests" tests/scheme/ffi/*.scm
 run_suite "Audit tests" tests/scheme/audit/*.scm
 run_shell_suite "Error tests" tests/scheme/errors
 run_shell_suite "Compile tests" tests/scheme/compile
+run_shell_suite "Test runner" tests/scheme/test-runner
 
 echo "=== R7RS test suite ==="
 set +e

--- a/tests/scheme/test-runner/json.sh
+++ b/tests/scheme/test-runner/json.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# `kaappi test --json` structured-output tests (kaappi#1509).
+#
+# `kaappi test` discovers SRFI-64 suites, runs each in an isolated worker, and
+# aggregates results from the runner's own counters. `--json` emits JSON Lines:
+# one object per file plus a summary. We validate with a *real* JSON parser
+# (python3), not grep — a malformed object or any stray text leaking onto stdout
+# fails here.
+#
+# Fixtures are generated in a temp dir so an intentionally-failing suite never
+# pollutes a plain `kaappi test ./tests` run of the repo.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "FAIL: python3 is required to validate kaappi test --json output"
+    exit 1
+fi
+
+# Absolute path so the worker (spawned with an arbitrary cwd) resolves it.
+KAAPPI="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+
+cat > "$FIX/a-pass.scm" <<'EOF'
+(import (scheme base) (srfi 64))
+(test-begin "pass-suite")
+(test-equal "one plus one" 2 (+ 1 1))
+(test-assert "greater" (> 3 2))
+(test-end "pass-suite")
+EOF
+
+cat > "$FIX/b-fail.scm" <<'EOF'
+(import (scheme base) (scheme process-context) (srfi 64))
+(test-begin "fail-suite")
+(test-equal "wrong sum" 5 (+ 2 2))
+(test-equal "right sum" 4 (+ 2 2))
+(let ((r (test-runner-current)))
+  (test-end "fail-suite")
+  ;; A failure epilogue that exits nonzero — the runner must report this as a
+  ;; test failure, not lose the file, and not treat the (exit) as a file error.
+  (when (> (test-runner-fail-count r) 0) (exit 1)))
+EOF
+
+cat > "$FIX/c-error.scm" <<'EOF'
+(import (scheme base) (srfi 64))
+(test-begin "error-suite")
+(test-equal "before error" 1 1)
+(car '())            ; uncaught top-level error
+(test-end "error-suite")
+EOF
+
+cat > "$FIX/d-skip-xfail.scm" <<'EOF'
+(import (scheme base) (srfi 64))
+(test-begin "skip-xfail-suite")
+(test-skip "skipped")
+(test-assert "skipped" #f)
+(test-expect-fail "known-broken")
+(test-assert "known-broken" #f)
+(test-assert "ordinary pass" #t)
+(test-end "skip-xfail-suite")
+EOF
+
+status=0
+OUT="$("$KAAPPI" test --json "$FIX" 2>/dev/null)" || status=$?
+
+KT_OUT="$OUT" KT_STATUS="$status" python3 - <<'PY'
+import json, os, sys
+
+out = os.environ["KT_OUT"]
+status = int(os.environ["KT_STATUS"])
+
+passed = failed = 0
+def check(cond, label, detail=""):
+    global passed, failed
+    if cond:
+        print(f"PASS: {label}"); passed += 1
+    else:
+        print(f"FAIL: {label}  {detail}"); failed += 1
+
+lines = [l for l in out.splitlines() if l.strip()]
+
+# Every stdout line must be valid JSON — this is how a stray print leaking onto
+# stdout (which would corrupt a machine consumer's stream) is caught.
+objs = []
+ok = True
+for l in lines:
+    try:
+        objs.append(json.loads(l))
+    except json.JSONDecodeError as e:
+        ok = False
+        check(False, "every stdout line is valid JSON", f"{e}: {l!r}")
+        break
+if ok:
+    check(True, "every stdout line is valid JSON")
+
+files = {os.path.basename(o["file"]): o for o in objs if o.get("type") == "file"}
+summaries = [o for o in objs if o.get("type") == "summary"]
+
+check(len(files) == 4, "one object per discovered file", f"got {sorted(files)}")
+check(len(summaries) == 1, "exactly one summary object", f"got {len(summaries)}")
+
+a = files.get("a-pass.scm", {})
+check(a.get("pass") == 2 and a.get("fail") == 0 and a.get("error") is False,
+      "passing file: pass=2 fail=0 error=false", str(a))
+check(a.get("suite") == "pass-suite", "suite name captured from test-begin", str(a.get("suite")))
+check(a.get("tests") == 2, "tests count = pass+fail+...", str(a.get("tests")))
+check(isinstance(a.get("duration_ms"), (int, float)), "duration_ms is numeric", str(a.get("duration_ms")))
+
+b = files.get("b-fail.scm", {})
+check(b.get("fail") == 1 and b.get("pass") == 1, "failing file: fail=1 pass=1", str(b))
+check(b.get("error") is False, "an (exit 1) failure epilogue is NOT a file error", str(b.get("error")))
+fl = b.get("failures", [])
+check(len(fl) == 1, "one recorded failure", str(fl))
+if fl:
+    f0 = fl[0]
+    check(f0.get("name") == "wrong sum", "failure carries the test name", str(f0.get("name")))
+    check(f0.get("expected") == "5" and f0.get("actual") == "4",
+          "failure carries expected/actual", str(f0))
+
+c = files.get("c-error.scm", {})
+check(c.get("error") is True, "errored file: error=true", str(c.get("error")))
+check(bool(c.get("error_message")), "errored file surfaces a diagnostic message", str(c.get("error_message")))
+check(c.get("pass") == 1, "counts before the error are still reported", str(c.get("pass")))
+
+d = files.get("d-skip-xfail.scm", {})
+check(d.get("skip", 0) >= 1, "skipped test counted as skip", str(d))
+check(d.get("xfail", 0) >= 1, "expected-fail counted as xfail", str(d))
+check(d.get("pass", 0) >= 1, "ordinary pass still counted", str(d))
+
+if summaries:
+    s = summaries[0]
+    check(s.get("files") == 4, "summary files=4", str(s.get("files")))
+    check(s.get("errors") >= 1, "summary errors>=1", str(s.get("errors")))
+    check(s.get("fail") >= 1, "summary fail>=1", str(s.get("fail")))
+    check(isinstance(s.get("seed"), int), "summary carries an integer seed", str(s.get("seed")))
+    total = s["pass"] + s["fail"] + s["xpass"] + s["xfail"] + s["skip"]
+    check(s.get("tests") == total, "summary tests = sum of kinds", str(s))
+
+check(status != 0, "exit status nonzero when a test failed or a file errored", f"status={status}")
+
+print()
+print(f"Passed: {passed}")
+print(f"Failed: {failed}")
+sys.exit(1 if failed else 0)
+PY
+
+echo "All kaappi test --json tests pass."

--- a/tests/scheme/test-runner/lib-path.sh
+++ b/tests/scheme/test-runner/lib-path.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# `kaappi test --lib-path` forwarding (kaappi#1509).
+#
+# The ecosystem-repo criterion: `kaappi test --lib-path <dir>` must forward the
+# search path to each worker so a suite's `(import (some-lib))` resolves against
+# that dir, exactly as `kaappi --lib-path <dir> tests/x.scm` does. We put the lib
+# in a *non-standard* dir (`deps/`, not the cwd-relative `lib/` that kaappi
+# searches by default) so a pass here proves the forwarding, not ambient
+# resolution.
+
+set -u
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+KAAPPI="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "FAIL: python3 is required"
+    exit 1
+fi
+
+REPO="$(mktemp -d)"
+trap 'rm -rf "$REPO"' EXIT
+mkdir -p "$REPO/deps" "$REPO/tests"
+
+cat > "$REPO/deps/widget.sld" <<'EOF'
+(define-library (widget)
+  (import (scheme base))
+  (export widget-double)
+  (begin (define (widget-double x) (* 2 x))))
+EOF
+
+cat > "$REPO/tests/test-widget.scm" <<'EOF'
+(import (scheme base) (srfi 64) (widget))
+(test-begin "widget")
+(test-equal "double 21" 42 (widget-double 21))
+(test-end "widget")
+EOF
+
+PASS=0
+FAIL=0
+check() { if [[ "$1" == ok ]]; then echo "PASS: $2"; PASS=$((PASS+1)); else echo "FAIL: $2"; FAIL=$((FAIL+1)); fi; }
+
+field() { # json-stream -> "<pass> <error>" of the first file object
+    python3 -c '
+import json, sys
+for line in sys.stdin:
+    if not line.strip(): continue
+    o = json.loads(line)
+    if o.get("type") == "file":
+        print(o.get("pass"), o.get("error")); break
+'
+}
+
+cd "$REPO"
+
+# With forwarding: (widget) resolves from deps/, the suite passes, exit 0.
+OUT="$("$KAAPPI" test --lib-path ./deps --json 2>/dev/null)"; status=$?
+got="$(printf '%s\n' "$OUT" | field)"
+[[ "$got" == "1 False" ]] && check ok "forwarded --lib-path resolves the import (pass=1, no error)" \
+    || check no "forwarded --lib-path resolves the import (got: '$got')"
+[[ "$status" -eq 0 ]] && check ok "exit 0 when the forwarded suite passes" \
+    || check no "exit 0 when the forwarded suite passes (status=$status)"
+
+# Without forwarding: deps/ is not a default prefix, so (widget) is unresolved,
+# the file errors, and the run exits nonzero.
+OUT2="$("$KAAPPI" test ./tests --json 2>/dev/null)"; status2=$?
+got2="$(printf '%s\n' "$OUT2" | field)"
+[[ "$got2" == *"True" ]] && check ok "without --lib-path the import is unresolved (error=true)" \
+    || check no "without --lib-path the import is unresolved (got: '$got2')"
+[[ "$status2" -ne 0 ]] && check ok "exit nonzero when a file errors" \
+    || check no "exit nonzero when a file errors (status=$status2)"
+
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "All kaappi test --lib-path tests pass."

--- a/tests/scheme/test-runner/seed.sh
+++ b/tests/scheme/test-runner/seed.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# `kaappi test --seed` reproducibility tests (kaappi#1509).
+#
+# --seed N seeds SRFI-27's default random source deterministically, so the same
+# seed reproduces the same draws; the effective seed is printed on every run so
+# any failure can be replayed. We observe the drawn value *through the JSON*: a
+# fixture forces a failure whose `actual` field is the number it drew, so same
+# seed => same actual, different seed => (almost surely) different actual.
+
+# No `set -e`: the draw fixture fails on purpose, so `kaappi test` exits nonzero
+# by design — we read its JSON, we don't treat the exit as a script error.
+set -u
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "FAIL: python3 is required to validate kaappi test --seed output"
+    exit 1
+fi
+
+KAAPPI="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+
+# The test always fails; its `actual` value is the random number drawn, so the
+# JSON exposes the draw for comparison across runs.
+cat > "$FIX/draw.scm" <<'EOF'
+(import (scheme base) (srfi 27) (srfi 64))
+(test-begin "draw-suite")
+(test-equal "draw" 'sentinel (random-integer 1000000000))
+(test-end "draw-suite")
+EOF
+
+# actual-of SEED  ->  the drawn value from the single failure's `actual` field
+actual_of() {
+    local seed="$1"
+    "$KAAPPI" test --json --seed "$seed" "$FIX" 2>/dev/null | python3 -c '
+import json, sys
+for line in sys.stdin:
+    if not line.strip(): continue
+    o = json.loads(line)
+    if o.get("type") == "file" and o.get("failures"):
+        print(o["failures"][0]["actual"]); break
+'
+}
+
+PASS=0
+FAIL=0
+check() { # cond label
+    if [[ "$1" == "ok" ]]; then echo "PASS: $2"; PASS=$((PASS+1)); else echo "FAIL: $2"; FAIL=$((FAIL+1)); fi
+}
+
+A1="$(actual_of 12345)"
+A2="$(actual_of 12345)"
+B1="$(actual_of 67890)"
+
+[[ -n "$A1" ]] && check ok "seeded run produces a draw" || check no "seeded run produces a draw ($A1)"
+[[ "$A1" == "$A2" ]] && check ok "same seed => same draw ($A1)" || check no "same seed => same draw ($A1 vs $A2)"
+[[ "$A1" != "$B1" ]] && check ok "different seed => different draw ($A1 vs $B1)" || check no "different seed => different draw (both $A1)"
+
+# The effective seed must be printed on every run (to stderr), pinned or not.
+SEED_LINE="$("$KAAPPI" test --seed 12345 "$FIX" 2>&1 1>/dev/null | grep -c 'seed 12345' || true)"
+[[ "$SEED_LINE" -ge 1 ]] && check ok "pinned seed echoed on stderr" || check no "pinned seed echoed on stderr"
+
+DEFAULT_SEED="$("$KAAPPI" test "$FIX" 2>&1 1>/dev/null | grep -Ec 'seed [0-9]+' || true)"
+[[ "$DEFAULT_SEED" -ge 1 ]] && check ok "auto seed echoed on stderr (default run)" || check no "auto seed echoed on stderr"
+
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "All kaappi test --seed tests pass."


### PR DESCRIPTION
Closes #1509. Part of the machine-legibility epic #1503.

## What

A first-class `kaappi test [paths...]` runner an agent or CI can drive and parse, instead of scraping each SRFI-64 file's printed report:

- **Discovery** — no paths → recurse `./tests` keeping SRFI-64 files (skips benchmarks, the chibi R7RS suite, coverage helpers); a named file runs as-is, a named directory is recursed.
- **SRFI-64 aggregation from the runner itself** — a quiet collecting test-runner (built on `test-runner-null`, so no chatter / no `.log` files) funnels each result's kind/expected/actual into counters.
- **`--json`** — JSON Lines: one `{"type":"file",…}` per file + a `{"type":"summary",…}`; per-failure name/expected/actual, and `error_message` for errored files.
- **`--seed <n>`** — deterministically seeds SRFI-27's default source; the effective seed (pinned or auto) prints on **every** run so any failure replays.
- **`--lib-path`** — forwarded to every worker (ecosystem repos).
- **Exit** nonzero iff a test failed, unexpectedly passed, or a file errored.

## How

An orchestrator forks one worker (`kaappi <file>` with `KAAPPI_TEST_EMIT` set) per file. Subprocess isolation is deliberate — a file that loops, crashes, leaks a thread, or calls `(exit 1)` can't corrupt the run or bleed into another file's results (the robustness `run-all.sh` gets from spawning per file, but with structured results). A new `vm.suppress_exit` flag turns a test file's `(exit 1)` failure epilogue into a recorded no-op so the worker still emits its result; that exit is redundant with the fail counts and is not a file error. Only an *uncaught* top-level error is.

See [`docs/dev/test-runner.md`](https://github.com/kaappi/kaappi/blob/claude/github-issue-1509-bb7c42/docs/dev/test-runner.md) for the design, the worker protocol, and the JSON schema.

## Acceptance criteria

- [x] `kaappi test` discovers and runs SRFI-64 suites with an aggregated summary
- [x] `--json` documented + shell test using a real JSON parser (`tests/scheme/test-runner/json.sh`, python3)
- [x] `--seed` reproducibility test (`tests/scheme/test-runner/seed.sh` — same seed → same draw, observed through JSON)
- [x] `run-all.sh` documented as the legacy path; the three new shell tests are wired into it
- [x] Works unchanged on ecosystem repos via `--lib-path` (`tests/scheme/test-runner/lib-path.sh`, forwarding verified with a non-standard lib dir)

## Testing

- Zig unit suite passes, including new regression tests for `suppress_exit` and JSON round-tripping.
- Existing `errors/exit-code.sh` (48/0) and `errors/exit-wind.sh` (8/0) unchanged — default `(exit)` behavior preserved (`suppress_exit` defaults off).
- Full `tests/scheme` tree via `kaappi test`: **198 files, 5676 tests, 0 fail**, exit 0.
- `zig fmt` clean.

## Note

The current ecosystem repos (kaappi-json/-csv/…) use ad-hoc test frameworks rather than SRFI-64, so `kaappi test` reports "no suites found" there today; the `--lib-path` mechanism works on that layout (verified synthetically), and those repos would aggregate once they adopt SRFI-64. `--changed` (affected-test selection) is #1510 and intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)