### PR TITLE
Build quoted heap constants once instead of per-execution eval (#1495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - **LLVM backend: cache eval-fallback compilation per call site** — forms the native backend cannot lower (`letrec`, `cond`, `case`, `do`, `guard`, quasiquote, named `let`, and fallback lambdas) are compiled at most once per call site via `kaappi_eval_cached` instead of being re-parsed and re-compiled on every execution, removing a severe cliff inside loops and hot functions (#1494)
+- **LLVM backend: build quoted heap constants once per call site** — quoted pairs/vectors and other non-immediate literals are built once via `kaappi_quote_cached` and memoized in a per-site global slot, instead of being re-consed by `kaappi_eval` on every execution. This also fixes a correctness divergence: every evaluation of one quoted literal now returns the same object, so `(eq? …)` identity for quoted literals matches the interpreter's constant-pool sharing (#1495)
 
 ### Fixed
 - Run the fuzz generator-coverage gates (grammar/native/portable evaluate-rate and the differential oracle) under `-Dgc-stress=true` by bounding evaluation with an instruction budget instead of the wall-clock deadline a stress build makes meaningless (#1447)

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -64,8 +64,9 @@ functions that native code calls:
 | `kaappi_make_string` | Allocate a string on the GC heap |
 | `kaappi_intern_symbol` | Intern a symbol via the GC symbol table (ensures `eq?` identity) |
 | `kaappi_make_box` / `kaappi_box_ref` / `kaappi_box_set` | Allocate / read / write a one-slot heap box for a captured+mutated variable (assignment conversion, see [Mutable captured variables](#mutable-captured-variables-assignment-conversion)) |
-| `kaappi_eval` | Parse, compile, and evaluate a Scheme expression (used only for quoted heap constants now) |
+| `kaappi_eval` | Parse, compile, and evaluate a Scheme expression (now only the uncached fallback path inside the two caching entry points below, and the child-thread path) |
 | `kaappi_eval_cached` | Like `kaappi_eval`, but compiles the source once per call site and caches the resulting `Function` in a per-site global slot (see [Cached eval fallback](#cached-eval-fallback)) |
+| `kaappi_quote_cached` | Build a quoted heap constant once per call site and memoize the built value in a per-site global slot (see [Cached quoted constants](#cached-quoted-constants)) |
 
 All functions use `callconv(.c)` and pass Values as plain `u64` (the
 NaN-boxed representation crosses C ABI trivially).
@@ -164,7 +165,7 @@ The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
 
 | Node | LLVM IR output |
 |------|---------------|
-| `constant` | Literal `i64` for immediates; `kaappi_make_string` for strings; `kaappi_intern_symbol` for symbols; `(quote ...)` via `kaappi_eval` for other heap values |
+| `constant` | Literal `i64` for immediates; `kaappi_make_string` for strings; `kaappi_intern_symbol` for symbols; `(quote ...)` via `kaappi_quote_cached` (built once per call site) for other heap values |
 | `global_ref` | `call @kaappi_global_lookup(...)` |
 | `call` | Four paths: inline-IR fast path for `+ - * < = null?` (see [Inline primitive fast paths](#inline-primitive-fast-paths)); direct specialized call for `car cdr cons`; direct `call`/`tail call` to a known native function; otherwise stack-allocate args array and `call @kaappi_call_scheme(...)` |
 | `begin` | Emit each expression sequentially |
@@ -205,9 +206,12 @@ handled differently:
 - **Strings**: `kaappi_make_string(vm, data_ptr, len)` — allocated at runtime
 - **Symbols**: `kaappi_intern_symbol(vm, name_ptr, len)` — interned at runtime,
   ensuring `eq?` identity matches between native code and interpreter closures
-- **Pairs, vectors, other heap values**: Serialized via `(quote ...)` and
-  evaluated at runtime via `kaappi_eval` (building these once rather than
-  re-consing per execution is a separate optimization, tracked as #1495)
+- **Pairs, vectors, other heap values**: Serialized via `(quote ...)` and built
+  at runtime via `kaappi_quote_cached`, which builds the constant once per call
+  site and memoizes it in a global slot (#1495) — so a literal in a hot path is
+  no longer re-consed per execution, and every evaluation returns the same object
+  (`eq?`), matching the interpreter's constant-pool sharing. See
+  [Cached quoted constants](#cached-quoted-constants).
 - **Fixnums, booleans, characters, nil, void**: Embedded directly as `i64`
   literals (these are NaN-boxed immediates with no heap allocation)
 
@@ -243,9 +247,9 @@ fallback that first republishes the enclosing frame's params/upvalues as globals
 The compile-once split point is code vs. data:
 
 - **Code fallbacks** → `kaappi_eval_cached` (compile the form once; #1494).
-- **Quoted heap constants** → plain `kaappi_eval` still, because caching the
-  *compiled form* would only avoid the re-parse, not the per-execution
-  re-consing; building the constant once is the distinct #1495 optimization.
+- **Quoted heap constants** → `kaappi_quote_cached`, which caches the *built
+  value* rather than a compiled form (#1495). See
+  [Cached quoted constants](#cached-quoted-constants).
 
 Two safety properties:
 
@@ -260,6 +264,51 @@ Two safety properties:
   be cross-heap hazards; child threads always take the plain, uncached path.
   Non-cacheable sources (a special top-level form, multiple data) also fall back
   to a plain `eval`.
+
+## Cached quoted constants
+
+A quoted heap constant — a pair, vector, or other literal with no immediate
+representation — is serialized to a `(quote …)` source string (see
+[Heap-Allocated Constants](#heap-allocated-constants)). Plain `kaappi_eval`
+rebuilds that constant on **every** execution, which is both a hot-path cliff
+and a correctness divergence: the interpreter compiles a `quote` to a single
+constant-pool entry (`compileQuote` in `src/compiler_passthrough.zig`), so every
+evaluation of one literal returns the **same** object — `(eq? (f) (f))` is `#t`
+when `f` returns a quoted literal — whereas a fresh rebuild is `eq?` to nothing.
+
+`kaappi_quote_cached` (`src/runtime_exports.zig`) closes both gaps. The emitter
+(`emitQuotedEvalExpr` in `src/llvm_emit.zig`) allocates one global slot per
+quoted-literal call site:
+
+```llvm
+@.quote_cache.0 = internal global i64 0
+...
+  %t0 = call i64 @kaappi_quote_cached(ptr %vm, ptr @.str.1, i64 15, ptr @.quote_cache.0)
+```
+
+The first execution builds the constant, permanently GC-roots it (via
+`extra_roots`, exactly as the eval cache roots its `Function`), and stores it in
+the slot; every later execution returns the cached object directly. This is the
+**data** analogue of `kaappi_eval_cached`: that caches a compiled `Function`,
+this caches the built value itself.
+
+Two properties fall out of the per-call-site slot, both matching the interpreter:
+
+- **`eq?` identity across evaluations.** One literal at one call site returns the
+  same object every time. Before #1495 the native backend rebuilt it per
+  execution, so `(eq? (f) (f))` was `#f` natively but `#t` in the interpreter.
+- **Distinct literals stay distinct.** Two textually separate occurrences of the
+  same datum get **separate** slots, so they are not `eq?` to each other — the
+  interpreter likewise gives them separate constant-pool entries.
+
+The **threads** carve-out mirrors the eval cache: only the main runtime thread
+touches a slot (the check precedes both the read and the write). A spawned
+SRFI-18 thread has its own VM and GC, so caching a child-heap constant (freed at
+thread-join) or returning a main-heap one under a child VM would be cross-heap
+hazards; child threads build the constant fresh on every execution — exactly the
+pre-caching behavior. The build-once guarantee (and the `eq?` identity that
+follows from it) therefore holds on the main thread, where all AOT-compiled
+top-level code runs.
 
 ## Lambda Strategy
 

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -101,6 +101,11 @@ pub const LLVMEmitter = struct {
     // counters (string/sym/lambda) it is monotonic across the whole module and
     // deliberately NOT part of SavedScope.
     eval_cache_counter: u32,
+    // One global cache slot per quoted-heap-constant call site (#1495), naming
+    // each `@.quote_cache.N`. Distinct from eval_cache: it memoizes the built
+    // constant itself (a pair/vector value), not a compiled Function. Same
+    // module-monotonic, non-SavedScope discipline as the counters above.
+    quote_cache_counter: u32,
     arena: std.heap.ArenaAllocator,
     backing_alloc: std.mem.Allocator,
     current_fn_name: ?[]const u8 = null,
@@ -188,6 +193,7 @@ pub const LLVMEmitter = struct {
             .sym_counter = 0,
             .lambda_counter = 0,
             .eval_cache_counter = 0,
+            .quote_cache_counter = 0,
             .arena = std.heap.ArenaAllocator.init(backing),
             .backing_alloc = backing,
         };
@@ -253,6 +259,14 @@ pub const LLVMEmitter = struct {
         var cache_slot: u32 = 0;
         while (cache_slot < self.eval_cache_counter) : (cache_slot += 1) {
             try self.print("@.eval_cache.{d} = internal global i64 0\n", .{cache_slot});
+        }
+
+        // One mutable global per quoted-heap-constant call site (#1495): 0 until
+        // the literal is first built, then the cached pair/vector value. Emitted
+        // at module scope for the same reason as the eval-cache slots above.
+        var quote_slot: u32 = 0;
+        while (quote_slot < self.quote_cache_counter) : (quote_slot += 1) {
+            try self.print("@.quote_cache.{d} = internal global i64 0\n", .{quote_slot});
         }
 
         for (self.lambda_defs.items) |def| {
@@ -1357,15 +1371,32 @@ pub const LLVMEmitter = struct {
         return self.emitCachedEval(source);
     }
 
+    // A quoted heap constant (pair/vector/… — anything with no immediate
+    // representation) is serialized to a `(quote …)` source string and built
+    // once via the caching runtime entry point (#1495). Plain @kaappi_eval
+    // re-reads and re-builds the constant on every execution, which is both a
+    // hot-path cliff and a correctness divergence: the interpreter compiles a
+    // quote to a single constant-pool entry, so every evaluation of one literal
+    // returns the SAME object (`eq?`). @kaappi_quote_cached memoizes the built
+    // constant in a per-call-site global slot, reproducing that per-site sharing
+    // in native code. Distinct source occurrences get distinct slots, so two
+    // textually separate literals stay non-`eq?`, again matching the interpreter.
     fn emitQuotedEvalExpr(self: *LLVMEmitter, value: Value) EmitError![]const u8 {
         const printed = printer.valueToString(self.backing_alloc, value, .write) catch return error.OutOfMemory;
         defer self.backing_alloc.free(printed);
         const source = std.fmt.allocPrint(self.backing_alloc, "(quote {s})", .{printed}) catch return error.OutOfMemory;
         defer self.backing_alloc.free(source);
         const str_name = try self.internString(source);
+        const slot_name = try self.nextQuoteCacheSlot();
         const tmp = try self.freshTemp();
-        try self.print("  {s} = call i64 @kaappi_eval(ptr %vm, ptr {s}, i64 {d})\n", .{ tmp, str_name, source.len });
+        try self.print("  {s} = call i64 @kaappi_quote_cached(ptr %vm, ptr {s}, i64 {d}, ptr {s})\n", .{ tmp, str_name, source.len, slot_name });
         return tmp;
+    }
+
+    fn nextQuoteCacheSlot(self: *LLVMEmitter) EmitError![]const u8 {
+        const id = self.quote_cache_counter;
+        self.quote_cache_counter += 1;
+        return std.fmt.allocPrint(self.allocator(), "@.quote_cache.{d}", .{id}) catch return error.OutOfMemory;
     }
 
     pub fn internSymbol(self: *LLVMEmitter, name: []const u8) EmitError![]const u8 {

--- a/src/native_decls.zig
+++ b/src/native_decls.zig
@@ -52,6 +52,10 @@ pub const decls: []const Decl = &.{
     // Compile-once caching eval for the backend's per-call-site eval fallbacks
     // (#1494). The trailing ptr is the call site's global cache slot.
     .{ .export_name = "kaappi_eval_cached", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64, .ptr }, .ret = .i64, .inline_kind = .not_inlined },
+    // Build-once cache for quoted heap constants (#1495). Same slot-passing
+    // shape as kaappi_eval_cached, but the slot memoizes the built pair/vector
+    // value itself rather than a compiled Function.
+    .{ .export_name = "kaappi_quote_cached", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64, .ptr }, .ret = .i64, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_gc_push_root", .scheme_name = null, .param_types = &.{.ptr}, .ret = .void_ty, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_gc_pop_roots", .scheme_name = null, .param_types = &.{.i64}, .ret = .void_ty, .inline_kind = .not_inlined },
 };

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -206,6 +206,57 @@ pub export fn kaappi_eval_cached(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len:
     return v.runCachedForm(func_val) catch |err| fatalVMError(v, "eval error", err);
 }
 
+// Build-once cache for the LLVM backend's quoted heap constants (#1495). A
+// quoted pair/vector literal has no immediate representation, so the emitter
+// serializes it to a `(quote …)` source string. Plain kaappi_eval re-reads and
+// re-builds that constant on every execution — both a hot-path cliff and a
+// correctness divergence: the interpreter compiles a quote to a single
+// constant-pool entry, so every evaluation of one literal returns the SAME
+// object (`eq?`), whereas a fresh rebuild is `eq?` to nothing.
+//
+// The emitter allocates one `slot` global per quoted-literal call site. The
+// first execution builds the constant, permanently roots it, and stashes it in
+// `slot`; every later execution returns the cached object directly — matching
+// the interpreter's per-call-site constant sharing. This is the data analogue
+// of kaappi_eval_cached: that caches a compiled Function, this caches the built
+// value itself.
+pub export fn kaappi_quote_cached(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len: u64, slot: *u64) callconv(.c) u64 {
+    const v = vm orelse return 0;
+    const len: usize = @intCast(src_len);
+    const source = src_ptr[0..len];
+
+    // Only the main runtime thread touches the shared slot — the guard precedes
+    // both the read and the write, exactly as in kaappi_eval_cached. A natively
+    // compiled body that evaluates a quoted literal can run on a spawned SRFI-18
+    // thread, which has its own VM and GC; caching a child-heap constant (freed
+    // at join) or returning a main-heap one under a child VM are cross-heap
+    // hazards. Child threads therefore build the constant fresh on every
+    // execution — exactly the pre-caching behavior — so the slot stays
+    // main-thread-only and race-free.
+    if (v.gc != &rt_gc) {
+        return v.eval(source) catch |err| fatalVMError(v, "eval error", err);
+    }
+
+    // Fast path: already built. `slot` holds the cached constant, kept alive by
+    // a permanent GC root created on first build.
+    if (slot.* != 0) return slot.*;
+
+    // Slow path (first execution at this call site): build once, permanently
+    // root, and cache. rootedSlot only appends to the C-allocated extra_roots
+    // list, so no Scheme-heap allocation runs between eval returning the fresh
+    // constant and it becoming rooted — the young constant cannot be swept in
+    // the gap. The root lives for the whole program (the slot is a module global
+    // the collector never scans), so extra_roots — not the LIFO shadow stack —
+    // is the right anchor.
+    const val = v.eval(source) catch |err| fatalVMError(v, "eval error", err);
+    _ = v.gc.rootedSlot(val) catch {
+        _ = std.posix.system.write(2, "OOM: failed to root quoted constant\n", 36);
+        std.process.exit(1);
+    };
+    slot.* = val;
+    return val;
+}
+
 fn callPrimitive(name: []const u8, a: u64, b: u64) u64 {
     const vm = vm_mod.vm_instance orelse {
         _ = std.posix.system.write(2, "runtime: no VM instance\n", 24);

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -123,11 +123,16 @@ fn expectNotContains(haystack: []const u8, needle: []const u8) !void {
     }
 }
 
-// Total eval-fallback call sites in emitted IR, regardless of caching. Code
-// fallbacks route through @kaappi_eval_cached (#1494) while quoted heap
-// constants stay on plain @kaappi_eval; a test that only cares "how many forms
-// crossed to the interpreter" counts both. The trailing "(" keeps the plain
-// count from also matching the "_cached(" spelling.
+// Total eval-fallback (code) call sites in emitted IR, regardless of caching:
+// a define-time binding, a general expression, or a lambda the closure tiers
+// can't express. These route through either plain @kaappi_eval or the
+// compile-once @kaappi_eval_cached (#1494); a test that only cares "how many
+// forms crossed to the interpreter as code" counts both. The trailing "("
+// keeps the plain count from also matching the "_cached(" spelling.
+//
+// Quoted heap constants are deliberately NOT counted here: since #1495 they
+// route through @kaappi_quote_cached, a build-once *data* cache, not an eval
+// fallback — a separate concern with its own emit tests below.
 fn countEvalFallbacks(ll: []const u8) usize {
     return std.mem.count(u8, ll, "call i64 @kaappi_eval(") +
         std.mem.count(u8, ll, "call i64 @kaappi_eval_cached(");
@@ -688,7 +693,7 @@ test "native declare table covers all runtime exports in preamble" {
             return error.TestExpectedEqual;
         }
     }
-    try std.testing.expectEqual(@as(usize, 25), native_decls.decls.len);
+    try std.testing.expectEqual(@as(usize, 26), native_decls.decls.len);
 }
 
 // -- Compile-once eval-fallback cache (#1494) --
@@ -716,15 +721,57 @@ test "LLVM emit: eval fallback routes through the compile-once cache (#1494)" {
     try std.testing.expectEqual(sites, slots);
 }
 
-test "LLVM emit: quoted heap constants stay on the uncached eval (#1494/#1495)" {
-    // Building quoted data once is a separate optimization (#1495); the caching
-    // eval is only for code fallbacks, so a quoted list keeps plain kaappi_eval.
+// -- Build-once quoted-constant cache (#1495) --
+// A quoted pair/vector literal has no immediate form, so it is serialized to a
+// (quote …) source and built via @kaappi_quote_cached, which memoizes the built
+// constant in a per-call-site global slot. Before #1495 it was rebuilt by plain
+// @kaappi_eval on every execution — wasteful, and non-eq? to the interpreter's
+// shared constant-pool entry. These verify the emitter side; the runtime side
+// (build once, eq? identity) is covered by tests/e2e/programs/native-quote-cache.scm.
+
+test "LLVM emit: quoted heap constant builds once via the quote cache (#1495)" {
     var res = try emitSourceResult("(quote (1 2 3))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectContains(ll, "call i64 @kaappi_eval(ptr %vm");
+    // The literal routes through the build-once cache with a per-site slot...
+    try expectContains(ll, "call i64 @kaappi_quote_cached(ptr %vm");
+    try expectContains(ll, "@.quote_cache.0 = internal global i64 0");
+    // ...and no longer through the plain, rebuild-every-time eval. (The eval
+    // *declaration* stays in the preamble; only a `call` would be the fallback.)
+    try expectNotContains(ll, "call i64 @kaappi_eval(");
     try expectNotContains(ll, "call i64 @kaappi_eval_cached(");
-    try expectNotContains(ll, "@.eval_cache.0");
+    // Data caching is not an eval fallback, so it must not inflate that count.
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: distinct quoted literals get distinct cache slots (#1495)" {
+    // Two textually separate literals are independent constants (the interpreter
+    // gives them separate constant-pool entries and they are not eq?), so each
+    // must get its own slot; a shared slot would alias them into eq?.
+    var res = try emitSourceResult("(cons (quote (1 2)) (quote (3 4)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    const calls = std.mem.count(u8, ll, "call i64 @kaappi_quote_cached(");
+    const slots = std.mem.count(u8, ll, "@.quote_cache.");
+    try std.testing.expectEqual(@as(usize, 2), calls);
+    // Two slot definitions + two references (one per call) = four mentions.
+    try expectContains(ll, "@.quote_cache.0 = internal global i64 0");
+    try expectContains(ll, "@.quote_cache.1 = internal global i64 0");
+    try expectNotContains(ll, "@.quote_cache.2");
+    // Each call names a slot, so mentions are strictly more than the two defs.
+    try std.testing.expect(slots > calls);
+}
+
+test "LLVM emit: quoted symbols and immediates skip the quote cache (#1495)" {
+    // Only heap constants need building. A quoted symbol interns directly and a
+    // quoted fixnum is an immediate — neither touches @kaappi_quote_cached.
+    var res = try emitSourceResult("(cons (quote sym) 7)");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "call i64 @kaappi_intern_symbol");
+    // Only a `call` is the build path; the preamble `declare` is unconditional.
+    try expectNotContains(ll, "call i64 @kaappi_quote_cached(");
+    try expectNotContains(ll, "@.quote_cache.");
 }
 
 test "cached form compiles once and re-executes correctly (#1494)" {

--- a/tests/e2e/programs/native-quote-cache.scm
+++ b/tests/e2e/programs/native-quote-cache.scm
@@ -1,0 +1,43 @@
+; Build-once cache for quoted heap constants (#1495).
+;
+; A quoted pair/vector literal has no immediate representation, so the native
+; backend serializes it to a (quote …) form. Before #1495 that form was rebuilt
+; by kaappi_eval on every evaluation, so a literal read twice was never eq? to
+; itself — a divergence from the interpreter, which compiles a quote to a single
+; constant-pool entry and returns the SAME object each time. The cache restores
+; per-call-site sharing: build once, memoize, return the cached object.
+(import (scheme base) (scheme write))
+
+; Same literal, same call site, two evaluations: eq? in the interpreter, and now
+; eq? natively too. This printed #f before the cache (a fresh rebuild each call).
+(define (lst) '(1 2 3))
+(display (eq? (lst) (lst)))
+(newline)
+
+; eqv? on the same literal follows eq? for heap objects (identity) — also #t.
+(display (eqv? (lst) (lst)))
+(newline)
+
+; Quoted vector literals share the same path.
+(define (vec) '#(4 5 6))
+(display (eq? (vec) (vec)))
+(newline)
+
+; Two textually distinct occurrences are independent constants — distinct cache
+; slots, so NOT eq?, matching the interpreter's separate constant-pool entries.
+(display (eq? '(7 8) '(7 8)))
+(newline)
+
+; Build-once under load: every iteration of a hot self-tail loop sees the SAME
+; object. A per-iteration rebuild would make some (eq? (lst) (lst)) return #f and
+; flip the accumulator, so a #t here means the fast path stayed cached.
+(define (hot n acc)
+  (if (= n 0)
+      acc
+      (hot (- n 1) (and acc (eq? (lst) (lst))))))
+(display (hot 10000 #t))
+(newline)
+
+; The cached value is structurally correct, not merely stable.
+(display (lst))
+(newline)


### PR DESCRIPTION
Closes #1495 (epic #1491).

## Problem

Quoted heap constants (pairs, vectors, other non-immediate literals) were emitted as `(quote …)` source strings passed to `@kaappi_eval` on **every execution** (`emitQuotedEvalExpr` in `src/llvm_emit.zig`). A quoted literal in a hot path was re-parsed and re-consed each time it was evaluated — strings and symbols already avoided this (`kaappi_make_string` / `kaappi_intern_symbol`), but pairs/vectors did not.

Beyond the cost, this was a **correctness divergence**. The interpreter compiles a `quote` to a single constant-pool entry (`compileQuote` → `addConstant` → `load_const`), so every evaluation of one literal returns the **same** object. The native backend rebuilt a fresh copy each time, so for a function `f` returning `'(1 2 3)`:

| | interpreter | native (before) | native (after) |
|---|---|---|---|
| `(eq? (f) (f))` | `#t` | **`#f`** | `#t` |

## Change

Add `kaappi_quote_cached(vm, str, len, *slot)` in `src/runtime_exports.zig`. The emitter allocates **one global slot per quoted-literal call site** (`@.quote_cache.N`); the first execution builds the constant, permanently GC-roots it, and stashes it in the slot, and every later execution returns the cached object directly.

This is the **data analogue** of the #1494 eval cache: that caches a compiled `Function`, this caches the built value itself. Per-call-site slots reproduce the interpreter's identity in both directions — one literal read twice is `eq?`; two textually distinct occurrences get separate slots and stay non-`eq?`, matching the interpreter's separate constant-pool entries.

### Design notes

- **GC rooting** — the slot is a module global the collector never scans, so the built constant is kept alive via `extra_roots` (a program-lifetime root, unlike the LIFO shadow stack). No Scheme-heap allocation runs between `eval` returning the fresh constant and it becoming rooted, so it cannot be swept in the gap. Verified under `-Dgc-stress=true`.
- **Threads** — only the main runtime thread touches a slot, and the guard precedes both the slot read and write. A spawned SRFI-18 thread has its own VM+GC, so caching a child-heap constant (freed at join) or returning a main-heap one under a child VM would be cross-heap hazards; child threads build the constant fresh each execution — the same carve-out as #1494.
- **Scope** — only heap constants route through the cache. Quoted symbols still intern directly (`kaappi_intern_symbol`) and quoted immediates stay `i64` literals.

## Acceptance criteria

- ✅ A given quoted literal is constructed at most once per program run — one slot per call site; runtime builds only when `slot == 0`.
- ✅ `eq?`/`eqv?` identity for quoted literals matches the interpreter — verified in both directions (same-site `eq?`, distinct-site not `eq?`).
- ✅ `tests/e2e` green — **29/29**, including the new `native-quote-cache.scm`.

## Tests

- `src/tests_native.zig`: replaced the #1494 "quoted-stays-plain" placeholder with 3 emit tests (builds-once + per-site slot; distinct literals → distinct slots; symbols/immediates skip the cache). `countEvalFallbacks` is unchanged — quote caching is a build-once *data* cache, not an eval fallback — with its comment updated.
- `tests/e2e/programs/native-quote-cache.scm`: `eq?`/`eqv?` identity across calls, quoted vectors, distinct-literal non-identity, and a hot self-tail loop.
- Verified: unit **936/936**, native **76/76**, e2e **29/29**, and the quote-cache programs under `zig build lib -Dgc-stress=true` + `KAAPPI_GC_THRESHOLD=1` (collection on every allocation).
- Docs: `docs/dev/llvm-backend.md` (new "Cached quoted constants" section), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)