### PR TITLE
Add regression test for cross-thread named-helper hang (#1520)

### DIFF
--- a/tests/scheme/smoke/lib1520/pool.sld
+++ b/tests/scheme/smoke/lib1520/pool.sld
@@ -1,0 +1,54 @@
+(define-library (lib1520 pool)
+  (export run-pool/helper run-pool/inlined)
+  (import (scheme base) (srfi 18) (kaappi fibers))
+  (begin
+    ;; worker-loop is a SEPARATELY-defined library top-level procedure. The
+    ;; #1520 bug: spawn-worker/helper's thread thunk *calls* it after crossing
+    ;; thread-start!. Deep-copying the thunk to the child OS thread used to
+    ;; drop the closure's lib_env (gc_deep_copy.zig set new_func.env = null),
+    ;; so the child couldn't resolve worker-loop, died silently, and the
+    ;; parent parked on (channel-receive reply) forever -- a pure hang, no
+    ;; error. Fixed in #1526 (new_func.env = func.env), same root cause as
+    ;; #1479's cross-library variant.
+    (define (worker-loop tasks)
+      (let loop ((msg (channel-receive tasks)))
+        (unless (eof-object? msg)
+          (let ((thunk (car msg)) (reply (cdr msg)))
+            (channel-send reply (thunk)))
+          (loop (channel-receive tasks)))))
+
+    ;; HELPER form: the thunk calls the separately-named worker-loop. Hung
+    ;; before #1526.
+    (define (spawn-worker/helper tasks)
+      (thread-start! (make-thread (lambda () (worker-loop tasks)))))
+
+    ;; INLINED form: the identical loop body, inlined into the thunk. The
+    ;; issue's contrast case -- this always worked, even before the fix.
+    (define (spawn-worker/inlined tasks)
+      (thread-start!
+        (make-thread
+          (lambda ()
+            (let loop ((msg (channel-receive tasks)))
+              (unless (eof-object? msg)
+                (let ((thunk (car msg)) (reply (cdr msg)))
+                  (channel-send reply (thunk)))
+                (loop (channel-receive tasks))))))))
+
+    ;; Drive one task through a freshly spawned worker, then shut it down
+    ;; deterministically (channel-close! ends the stream -- worker-loop's
+    ;; (eof-object? msg) guard sees the resulting eof -- then join) so the
+    ;; test never leaks a parked thread. `tasks` is a proper lexical channel
+    ;; throughout -- not a shared global -- so this is not the KEP-0002 Path 2
+    ;; case.
+    (define (drive spawn)
+      (let ((tasks (make-channel))
+            (reply (make-channel)))
+        (let ((worker (spawn tasks)))
+          (channel-send tasks (cons (lambda () (* 6 7)) reply))
+          (let ((result (channel-receive reply)))
+            (channel-close! tasks)
+            (thread-join! worker)
+            result))))
+
+    (define (run-pool/helper) (drive spawn-worker/helper))
+    (define (run-pool/inlined) (drive spawn-worker/inlined))))

--- a/tests/scheme/smoke/library-thread-named-helper-1520.scm
+++ b/tests/scheme/smoke/library-thread-named-helper-1520.scm
@@ -1,0 +1,100 @@
+;; Regression test for #1520: a closure that crosses a thread-start! boundary
+;; and then CALLS a separately-defined library top-level procedure used to
+;; hang forever.
+;;
+;; Root cause (shared with #1479): GC.deepCopy copied the thread thunk to the
+;; child OS thread's heap but set new_func.env = null, dropping the closure's
+;; defining lib_env. The child then resolved names through the shared globals
+;; map instead. A library top-level helper lives in the library's lib_env, not
+;; in globals, so the child could not find the helper it was supposed to call:
+;; it died silently and the parent, parked on (channel-receive reply), never
+;; woke -- a pure hang, no error surfaced. Fixed in #1526 (new_func.env =
+;; func.env).
+;;
+;; The identical logic INLINED into the thunk (no separate helper) always
+;; worked, even before the fix -- that inlined-vs-helper contrast is the tell,
+;; and both forms are asserted below.
+;;
+;; NAMING, DO NOT "SIMPLIFY": the library helper is named worker-loop and the
+;; program-level helper is named prog-worker-loop *on purpose*. Before the fix
+;; the child fell back to globals; if a program top-level (define (worker-loop
+;; ...)) existed there, the child would resolve THAT by coincidence and the
+;; library hang would be masked -- the guard would silently stop guarding.
+;; Keep the two helper names distinct.
+;;
+;; Distinct from #1479's regression test, which calls into ANOTHER library's
+;; export and reads the result back via thread-join!. Here the helper is
+;; same-library and the hang is the parent parking on a channel -- the exact
+;; shape reported in #1520.
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (kaappi fibers) (srfi 64) (lib1520 pool))
+
+;; Watchdog: if the library case regresses to a hang, fail fast (exit 1)
+;; instead of stalling run-all.sh for its full 60s per-file timeout. A passing
+;; run finishes in milliseconds and exits before this fires; kaappi tears the
+;; sleeping watchdog down on main-thread exit.
+(define _watchdog
+  (thread-start!
+    (make-thread
+      (lambda ()
+        (thread-sleep! 20)
+        (display "TIMEOUT: #1520 regression -- a cross-thread named-helper ")
+        (display "call hung (child could not resolve the helper)\n")
+        (exit 1)))))
+
+;; --- Program-level (bare-script) worker: helper and inlined forms ---
+;; prog-worker-loop is a program top-level define; the thunk calls it after
+;; crossing thread-start!. Program top-level defines DO land in globals, so the
+;; child's globals fallback resolved this even before the fix -- this form is
+;; documentation/contrast, not the regression trigger.
+(define (prog-worker-loop tasks)
+  (let loop ((msg (channel-receive tasks)))
+    (unless (eof-object? msg)
+      (let ((thunk (car msg)) (reply (cdr msg)))
+        (channel-send reply (thunk)))
+      (loop (channel-receive tasks)))))
+
+(define (prog-drive spawn)
+  (let ((tasks (make-channel))
+        (reply (make-channel)))
+    (let ((worker (spawn tasks)))
+      (channel-send tasks (cons (lambda () (* 6 7)) reply))
+      (let ((result (channel-receive reply)))
+        (channel-close! tasks)
+        (thread-join! worker)
+        result))))
+
+(define (prog-run/helper)
+  (prog-drive (lambda (tasks)
+                (thread-start!
+                  (make-thread (lambda () (prog-worker-loop tasks)))))))
+
+(define (prog-run/inlined)
+  (prog-drive (lambda (tasks)
+                (thread-start!
+                  (make-thread
+                    (lambda ()
+                      (let loop ((msg (channel-receive tasks)))
+                        (unless (eof-object? msg)
+                          (let ((thunk (car msg)) (reply (cdr msg)))
+                            (channel-send reply (thunk)))
+                          (loop (channel-receive tasks))))))))))
+
+(test-begin "library-thread-named-helper-1520")
+
+;; Library-level: the helper form HUNG before #1526 (the actual regression
+;; guard); the inlined form is the contrast that always worked.
+(test-equal "library thunk calling a named library helper returns the result"
+            42 (run-pool/helper))
+(test-equal "library thunk with the loop inlined returns the result"
+            42 (run-pool/inlined))
+
+;; Program-level: both worked before and after the fix (globals fallback).
+(test-equal "program-level thunk calling a named helper returns the result"
+            42 (prog-run/helper))
+(test-equal "program-level thunk with the loop inlined returns the result"
+            42 (prog-run/inlined))
+
+(let ((runner (test-runner-current)))
+  (test-end "library-thread-named-helper-1520")
+  (exit (if (> (test-runner-fail-count runner) 0) 1 0)))


### PR DESCRIPTION
## Summary

Closes #1520 by adding the regression test it asks for. The reported hang was
**already fixed on `main` by #1526** (merged one day after #1520 was filed) —
it has the identical root cause as #1479 — so this PR is test-only.

## Root cause (confirmed by A/B bisect)

A library-defined procedure whose `thread-start!` thunk *calls* a
separately-defined library top-level helper hung forever. `GC.deepCopy` copied
the thunk to the child OS thread but set `new_func.env = null`, dropping the
closure's defining `lib_env`. The child then resolved names through the shared
`globals` map — where a library-scoped helper does not live — so it could not
find the helper, died silently, and the parent parked on `channel-receive`
forever. #1526 preserved `new_func.env = func.env`
([`gc_deep_copy.zig`](../blob/main/src/gc_deep_copy.zig#L171-L188)).

Clean bisect at the commit just before #1526 vs. current `main`:

| Form | pre-#1526 | post-#1526 |
|------|-----------|------------|
| **define-library** named helper | **hangs 12/12** | passes 20/20 |
| bare-script (program-level) helper | passes 20/20 | passes 20/20 |

Two clarifications vs. the issue's black-box narrative:

- **The bare-script form never reproduced.** Program top-level `define`s land
  in `globals`, exactly where the child's `env == null` fallback already looks,
  so they resolved before and after the fix. Only the *library* form (helper in
  `lib_env`) hung — matching the fix comment: the child "raised undefined
  variable for a name that worked at top level."
- **Masking hazard for cross-thread library tests.** Pre-fix the child resolves
  through `globals`, so a *same-named* program-level helper makes it resolve by
  coincidence and the library hang disappears. The test names the library
  helper `worker-loop` and the program-level one `prog-worker-loop` distinctly
  on purpose, with a header comment warning against unifying them.

## Test

- `tests/scheme/smoke/library-thread-named-helper-1520.scm` — SRFI-64, with a
  20 s watchdog thread so a regression **fails fast (exit 1)** instead of
  stalling `run-all.sh` for its full 60 s per-file timeout. Asserts the library
  helper form (the guard), the inlined contrast, and the program-level forms.
- `tests/scheme/smoke/lib1520/pool.sld` — fixture library.

Distinct from #1479's test, which calls into *another* library's export and
reads the result via `thread-join!`; here the helper is same-library and the
hang is the parent parking on a channel — the exact shape from the report.

## Verification

- **Fails on the pre-#1526 build** (watchdog fires, exit 1), **passes on current
  `main`**.
- Full Scheme suite green: 461 files + 1395 R7RS = **1856 pass, 0 fail, 0
  timeout**.
- Deep-copy path returns `42` under `-Dgc-stress=true` (collection on every
  allocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
