### PR TITLE
Fix .git write-permission rule to use Edit instead of Write

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,7 +36,7 @@
       "Bash(git push*--force*)",
       "Read(.env*)",
       "Read(~/.ssh/**)",
-      "Write(.git/**)"
+      "Edit(.git/**)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- The `deny` list in `.claude/settings.json` had `Write(.git/**)`, but Write-tool permission rules aren't matched by file permission checks — only `Edit(path)` rules cover all file-editing tools. The rule was silently unenforced.
- Changed to `Edit(.git/**)`.

## Test plan
- [x] Validated JSON syntax with `jq`
- [x] Startup warning no longer applies after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)