### PR TITLE
Reject foreign thread handles in fiber primitives (#1484)

### DIFF
--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -261,6 +261,32 @@ pub fn raiseError(error_type: types.ErrorObject.ErrorType, msg: []const u8, reas
     return PrimitiveError.ExceptionRaised;
 }
 
+/// KEP-0002 §2 / invariant 4: a fiber (thread) value can only reach another OS
+/// thread through a shared global. Fibers sit on gc_deep_copy's uncopyable
+/// list, so they never ride a thread thunk or a channel message -- a thunk
+/// that captures a thread handle is rejected at thread-start! before any child
+/// spawns, and a child's own `(current-thread)` is a distinct fiber that
+/// ensureScheduler allocated on the child heap. So a fiber whose `owner` is not
+/// this GC is exactly the shared-global situation behind #1484: two threads
+/// clearing the same `os_thread` and double-`thread.join()`ing it (pthread-level
+/// UB), a losing joiner reading `target.result` before the winner has stored
+/// it, or a foreign thread-terminate! mutating another scheduler's fiber. Refuse
+/// it up front -- the same total treatment channel-send/-receive/-close!/-closed?
+/// give a foreign channel (only the `thread?` predicate is exempt, mirroring
+/// `channel?`) -- so the whole class is unreachable instead of patched case by
+/// case inside reapOsThread. The reason irritant is VOID, never the fiber
+/// itself: storing a foreign-heap object in an error the owner's GC may free
+/// would just re-open the dangling-pointer hazard this check exists to close.
+fn checkThreadOwner(fiber_val: Value, comptime proc: []const u8) PrimitiveError!void {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (types.toObject(fiber_val).owner == gc.id) return;
+    const msg = std.fmt.comptimePrint(
+        "{s}: thread belongs to another OS thread; a thread handle may only be used by the thread that created it",
+        .{proc},
+    );
+    _ = try raiseError(.general, msg, types.VOID);
+}
+
 // ---------------------------------------------------------------------------
 // Thread primitives
 // ---------------------------------------------------------------------------
@@ -300,6 +326,7 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
 fn threadNameFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFiber(args[0]))
         return primitives.typeError("thread-name", "thread", args[0]);
+    try checkThreadOwner(args[0], "thread-name");
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
     return fiber.name;
 }
@@ -307,6 +334,7 @@ fn threadNameFn(args: []const Value) PrimitiveError!Value {
 fn threadSpecificFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFiber(args[0]))
         return primitives.typeError("thread-specific", "thread", args[0]);
+    try checkThreadOwner(args[0], "thread-specific");
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
     return fiber.specific;
 }
@@ -314,6 +342,7 @@ fn threadSpecificFn(args: []const Value) PrimitiveError!Value {
 fn threadSpecificSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFiber(args[0]))
         return primitives.typeError("thread-specific-set!", "thread", args[0]);
+    try checkThreadOwner(args[0], "thread-specific-set!");
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
     fiber.specific = args[1];
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
@@ -333,6 +362,7 @@ fn threadStartFn(args: []const Value) PrimitiveError!Value {
 fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     if (!types.isFiber(args[0]))
         return primitives.typeError("thread-start!", "thread", args[0]);
+    try checkThreadOwner(args[0], "thread-start!");
 
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
 
@@ -600,6 +630,7 @@ fn getSleepSeconds(v: Value) PrimitiveError!f64 {
 fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFiber(args[0]))
         return primitives.typeError("thread-terminate!", "thread", args[0]);
+    try checkThreadOwner(args[0], "thread-terminate!");
 
     const ctx = try ensureScheduler();
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
@@ -660,6 +691,12 @@ fn sleepNs(ns: u64) void {
 fn threadJoinFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFiber(args[0]))
         return primitives.typeError("thread-join!", "thread", args[0]);
+    // Before anything reads target.os_thread/status/result: a foreign fiber
+    // (reached only via a shared global) is the double-join UB and
+    // loser-reads-VOID race from #1484. Self-join stays a distinct, friendlier
+    // error below -- the current fiber is always this GC's own, so it passes
+    // here first.
+    try checkThreadOwner(args[0], "thread-join!");
 
     const target = types.toObject(args[0]).as(fiber_mod.Fiber);
 

--- a/tests/scheme/smoke/thread-foreign-owner-1484.scm
+++ b/tests/scheme/smoke/thread-foreign-owner-1484.scm
@@ -1,0 +1,139 @@
+;; Regression test for #1484: fiber (thread) primitives reject a *foreign*
+;; thread handle -- one reached from another OS thread through a shared global
+;; -- the same way channel-send/channel-receive reject a foreign channel.
+;;
+;; Part 1 (the safety fix): a fiber can only be shared across OS threads via a
+;; global. Fibers are uncopyable (gc_deep_copy's `.fiber` arm), so they never
+;; ride a thread thunk or a channel message; and a child thread's own
+;; (current-thread) is a distinct fiber that ensureScheduler allocated on the
+;; child heap. So `owner != gc.id` is exactly the concurrent-thread-join!
+;; hazard: two threads both clearing the same os_thread and double-
+;; `thread.join()`ing it (pthread UB), or the loser reading target.result
+;; before the winner stored it. It is now a clean, catchable diagnostic.
+;;
+;; Part 2 (the design decision, KEP-0002 invariant 4): a channel reached
+;; through a shared global and then *raised or returned* by a child thread is
+;; refused, not silently voided. The exception/result copy runs on the child,
+;; which does not own the channel, so Envelope.create rejects it and
+;; thread-join! surfaces a descriptive error. This is the principled reading of
+;; invariant 4 (the only legal cross-thread handle is a locally owned stub made
+;; by deepCopy through a thunk or a message) -- restoring the old owner-, and
+;; order-, dependent parity would reopen exactly the sharing this model forbids.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (kaappi fibers) (srfi 64))
+
+(test-begin "thread-foreign-owner-1484")
+
+;; `worker` is a genuine top-level define -> a real global resolved through
+;; vm.globals, so a child thread's thunk that names it does NOT capture it as
+;; an upvalue (which, being a fiber, would be rejected as uncopyable right at
+;; thread-start! and exercise the wrong path). The child reads the shared
+;; global at run time and gets the parent-owned fiber -- foreign to it. The
+;; owner check is state-independent, so whether `worker` is still sleeping or
+;; already finished when a child reaches it, the rejection is identical.
+(define worker (make-thread (lambda () (thread-sleep! 0.2) 'worker-done)))
+;; test-assert (not a bare top-level expression) so the fiber thread-start!
+;; returns is not echoed by the file runner as stray stdout.
+(test-assert "worker thread starts on its owning thread"
+  (thread? (thread-start! worker)))
+
+;; Runs `body-thunk` on a fresh child thread and returns whatever the child
+;; reports back through `report` -- a channel captured (and so legally
+;; promoted) into the child. The child guards its body so a foreign-owner
+;; rejection comes back as the error's message string instead of crashing the
+;; child. `body-thunk` closes over nothing but the `worker` global, so it
+;; deep-copies into the child cleanly.
+(define (observe-on-child body-thunk)
+  (let ((report (make-channel)))
+    (let ((child (make-thread
+                   (lambda ()
+                     (guard (e (#t (channel-send report
+                                     (if (error-object? e)
+                                         (error-object-message e)
+                                         'non-error-condition))))
+                       (body-thunk)
+                       (channel-send report 'no-error-raised))))))
+      (thread-start! child)
+      (thread-join! child)
+      (channel-receive report))))
+
+(define (foreign-thread-error? msg)
+  (and (string? msg) (string-contains msg "another OS thread")))
+
+;; --- Part 1: foreign fiber handles are refused across OS threads ---
+
+(test-assert "cross-thread thread-join! on a foreign handle is refused"
+  (foreign-thread-error? (observe-on-child (lambda () (thread-join! worker)))))
+
+(test-assert "cross-thread thread-terminate! on a foreign handle is refused"
+  (foreign-thread-error? (observe-on-child (lambda () (thread-terminate! worker)))))
+
+(test-assert "cross-thread thread-start! on a foreign handle is refused"
+  (foreign-thread-error? (observe-on-child (lambda () (thread-start! worker)))))
+
+(test-assert "cross-thread thread-specific on a foreign handle is refused"
+  (foreign-thread-error? (observe-on-child (lambda () (thread-specific worker)))))
+
+(test-assert "cross-thread thread-specific-set! on a foreign handle is refused"
+  (foreign-thread-error?
+    (observe-on-child (lambda () (thread-specific-set! worker 'x)))))
+
+(test-assert "cross-thread thread-name on a foreign handle is refused"
+  (foreign-thread-error? (observe-on-child (lambda () (thread-name worker)))))
+
+;; --- Part 1 positive controls: same-thread use is completely unaffected ---
+
+;; The terminate/start attempts above were all refused, so `worker` was never
+;; touched by another thread and still runs to completion; its owner reaps it
+;; normally.
+(test-equal "the owning thread can still join its own thread"
+  'worker-done
+  (thread-join! worker))
+
+(test-equal "the owning thread can still set and read thread-specific"
+  'payload
+  (let ((t (make-thread (lambda () #t))))
+    (thread-specific-set! t 'payload)
+    (thread-specific t)))
+
+;; --- Part 2: shared-global channel refused at the exception/result boundary ---
+
+;; Raised: threadEntryFn builds the exception envelope on the child, which does
+;; not own `raised-ch`, so the copy fails and thread-join! reports an
+;; uncaught-exception whose reason names the foreign-channel cause -- never a
+;; silently voided join reason (the pre-#1483 wart this locks shut).
+(define raised-ch (make-channel))
+(test-assert "child raising a shared-global channel surfaces a descriptive error at join"
+  (guard (e ((uncaught-exception? e)
+             (let ((reason (uncaught-exception-reason e)))
+               (and (error-object? reason)
+                    (string-contains (error-object-message reason) "another thread")))))
+    (thread-join! (thread-start! (make-thread (lambda () (raise raised-ch)))))
+    #f))
+
+;; Returned: the join-result copy likewise runs on the non-owning child, so
+;; thread-join! raises "result contains ... a channel owned by another thread"
+;; rather than handing back a corrupt cross-heap alias.
+(define returned-ch (make-channel))
+(test-assert "child returning a shared-global channel surfaces a descriptive error at join"
+  (guard (e ((error-object? e)
+             (string-contains (error-object-message e) "another thread")))
+    (thread-join! (thread-start! (make-thread (lambda () returned-ch))))
+    #f))
+
+;; A channel legally shared through the thunk (captured, hence promoted) still
+;; crosses back as a result untouched -- Part 2 refuses only the shared-global
+;; path, not the sanctioned one.
+(test-equal "a channel captured by the thunk still returns across the join"
+  'ok
+  (let* ((t (make-thread (lambda ()
+                           (let ((inner (make-channel)))
+                             (channel-send inner 'ok)
+                             inner)))))
+    (thread-start! t)
+    (channel-receive (thread-join! t))))
+
+(let ((runner (test-runner-current)))
+  (test-end "thread-foreign-owner-1484")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #1484 — the follow-up from #1483 (KEP-0002 Phase 2). Both parts.

## Part 1 — concurrent `thread-join!` races (the safety fix)

A fiber (thread) value can only reach another OS thread through a **shared global**: fibers are on `gc_deep_copy`'s uncopyable list (`.fiber => UncopyableType`), so they never ride a thread thunk or a channel message, and a thunk that captures a thread handle is rejected at `thread-start!` before any child spawns. That single fact is what makes the two residual `thread-join!` hazards from #1483 reachable at all:

- two threads both passing `threadJoinFn`'s `target.os_thread != null` check and both calling `thread.join()` on the one `std.Thread` handle — pthread-level UB, plus an unsynchronized `target.os_thread = null` store;
- the loser of the `takeResult` race reading `target.result` / `target.current_exception` before the winner has stored them.

`thread-terminate!` on a foreign handle could likewise mutate another scheduler's fiber.

Rather than patch `reapOsThread` point by point, this gives the fiber primitives that dereference a thread handle the **same foreign-owner check** `channel-send`/`-receive`/`-close!`/`-closed?` already have — one `checkThreadOwner` helper, called from `thread-start!`, `thread-terminate!`, `thread-join!`, `thread-specific`, `thread-specific-set!`, and `thread-name`. Only the `thread?` predicate stays exempt, mirroring `channel?`. A foreign handle is now a clean, catchable diagnostic instead of a data race, so the whole class is unreachable.

**Why guarding the accessors (including reads) breaks nothing:** a child OS thread's own `(current-thread)` is a *distinct* fiber that `ensureScheduler` allocates on the child heap — never the parent-owned handle passed to `threadEntryFn` — and same-thread cooperative fibers all share one GC id. So `owner == gc.id` holds for every legitimate use; only a genuinely foreign (shared-global) handle fails. No library or test operates on a thread handle cross-thread.

## Part 2 — shared-global channel parity (the design decision)

#1483 left open whether a channel reached through a shared global and then *raised or returned* by a child thread should regain exact main-branch parity, or whether refusing it is the more principled reading of KEP-0002 invariant 4 (the only legal cross-thread handle is a locally owned stub made by `deepCopy` through a thunk or a message).

**Decision: keep the refusal.** The exception/result copy runs on the non-owning child, so `Envelope.create` rejects it and `thread-join!` surfaces a descriptive error (already correct since #1483's response commit) rather than the old owner- and order-dependent parity or a silently voided join reason. Restoring parity would reopen exactly the cross-thread sharing this model forbids. No code change — locked in with tests.

## Tests

New `tests/scheme/smoke/thread-foreign-owner-1484.scm` (12 SRFI-64 assertions):

- **Part 1:** a child reaching a top-level-global `worker` fiber is refused for join / terminate / start / specific / specific-set! / name (the child guards and reports the message back through a *captured* — hence legally promoted — channel), plus positive controls that the owner still joins and inspects its own thread.
- **Part 2:** a child raising and a child returning a shared-global channel each surface a descriptive error, plus a control that a legally captured channel still returns across the join.

Without the fix, all six Part-1 assertions **and** "the owning thread can still join its own thread" fail (the last proving the double-reap actually corrupts the owner's join); the Part-2 assertions pass either way.

`zig build test` green, `zig fmt` clean, all 45 thread/channel/fiber Scheme tests + `srfi18-coverage` (54) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)