### PR TITLE
Lower cond/case/do natively in the LLVM backend (#1496)

### DIFF
--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -176,7 +176,8 @@ The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
 | `set!` | Store to the resolved lexical slot (local/param/upvalue) or `call @kaappi_set_global(...)` |
 | `lambda` | Compiled to a native LLVM function + closure, or cached eval fallback (see Lambda Strategy) |
 | `let`, `let*` | Native `alloca`s with shadow-stack rooting; falls back to `kaappi_eval_cached` for forms it cannot lower in scope |
-| `letrec`, `letrec*`, `cond`, `case`, `do`, `guard`, quasiquote, named `let` | Serialize to source text, `call @kaappi_eval_cached(...)` (see [Cached eval fallback](#cached-eval-fallback)) |
+| `cond`, `case`, `do` | Native `if`-style block/`phi` chains (`cond`/`case`) and a self-branching `alloca` loop (`do`) when every sub-form is emittable in the current lexical scope; otherwise a whole-form `kaappi_eval_cached` fallback (`src/llvm_emit_forms.zig`, kaappi#1496) |
+| `letrec`, `letrec*`, `guard`, quasiquote, named `let` | Serialize to source text, `call @kaappi_eval_cached(...)` (see [Cached eval fallback](#cached-eval-fallback)) |
 | `passthrough` | Serialize to source text, `call @kaappi_eval_cached(...)` |
 
 ## Compile-Time Processing
@@ -217,9 +218,10 @@ handled differently:
 
 ## Cached eval fallback
 
-Forms the backend cannot lower natively — `letrec`, `letrec*`, `cond`, `case`,
-`do`, `guard`, quasiquote, named `let`, `let`/`let*` it cannot scope, fallback
-lambdas, and general passthrough expressions — are serialized to a Scheme source
+Forms the backend cannot lower natively — `letrec`, `letrec*`, `guard`,
+quasiquote, named `let`, `let`/`let*` it cannot scope, a `cond`/`case`/`do` whose
+clauses reach an unlowerable sub-form (kaappi#1496), fallback lambdas, and
+general passthrough expressions — are serialized to a Scheme source
 string and executed by the interpreter. Plain `kaappi_eval` re-parses **and
 re-compiles** that string every time the enclosing native code runs it; inside a
 loop body or a frequently-called function that is a severe, easily-overlooked
@@ -360,8 +362,8 @@ in tail position stores the new arguments and `br`s back to the function's body
 label rather than recursing (non-variadic named functions only).
 
 **Falls back to the [cached eval](#cached-eval-fallback) when the body:**
-- contains an eval-fallback form (`letrec`, `cond`, `case`, `do`, `guard`,
-  named `let`, …);
+- contains an eval-fallback form (`letrec`, `guard`, named `let`, …), or a
+  `cond`/`case`/`do` whose clauses themselves reach one (kaappi#1496);
 - contains an internal `define` (the closure tier sets up no locals scope for
   it), or a rest parameter that is captured and mutated (no box model yet);
 - captures an unmutated `let`-local, or a rest parameter, that has no copyable

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -103,6 +103,20 @@ pub const llvm_node_table: [18]LLVMNodeEntry = .{
 
 const eval_fallback_name_count = countEvalFallbackNames();
 
+// FormKinds the LLVM native backend lowers directly rather than routing through
+// `kaappi_eval`, so they are NOT in `eval_fallback_form_names` and do not force
+// an enclosing native let/lambda body to fall back. `named_let` is excluded
+// because `lowerLet` handles it structurally (no keyword mapping); `cond`,
+// `case_form`, and `do_form` are excluded because the backend emits them
+// natively (kaappi#1496) — `llvm_emit_forms.zig` gates each on
+// `exprNativeEmittable` and only the ungated remainder reaches the interpreter.
+fn isNativeLoweredForm(fk: FormKind) bool {
+    return switch (fk) {
+        .named_let, .cond, .case_form, .do_form => true,
+        else => false,
+    };
+}
+
 fn countEvalFallbackNames() usize {
     var count: usize = 0;
     for (llvm_node_table) |entry| {
@@ -112,7 +126,7 @@ fn countEvalFallbackNames() usize {
     const form_fields = @typeInfo(FormKind).@"enum".fields;
     for (form_fields) |f| {
         const fk: FormKind = @enumFromInt(f.value);
-        if (fk == .named_let) continue;
+        if (isNativeLoweredForm(fk)) continue;
         count += 1;
     }
     return count;
@@ -132,7 +146,7 @@ pub const eval_fallback_form_names: [eval_fallback_name_count][]const u8 = blk: 
     const form_fields = @typeInfo(FormKind).@"enum".fields;
     for (form_fields) |f| {
         const fk: FormKind = @enumFromInt(f.value);
-        if (fk == .named_let) continue;
+        if (isNativeLoweredForm(fk)) continue;
         names[i] = fk.keyword();
         i += 1;
     }

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -89,6 +89,14 @@ pub const LLVMEmitter = struct {
     lambda_defs: std.ArrayList([]const u8),
     native_fns: std.StringHashMap(NativeLambda),
     rebound_globals: std.StringHashMap(void),
+    // The VM's macro table, borrowed for the lifetime of emission (never
+    // mutated here). Used only to keep native cond/case/do lowering (#1496)
+    // from mis-compiling a macro use as a call to a same-named global: a form
+    // that invokes a macro is not `exprNativeEmittable` and is sent to the
+    // interpreter, which expands it. Null when the emitter is driven without a
+    // VM (unit tests) — then no name is treated as a macro, which is correct
+    // because those tests never exercise macros inside these forms.
+    macros: ?*const std.StringHashMap(Value) = null,
     params: ?std.StringHashMap(u8),
     upvalues: ?std.StringHashMap(u8),
     tmp_counter: u32,
@@ -304,7 +312,7 @@ pub const LLVMEmitter = struct {
         };
     }
 
-    fn emitConstant(self: *LLVMEmitter, value: Value) EmitError![]const u8 {
+    pub fn emitConstant(self: *LLVMEmitter, value: Value) EmitError![]const u8 {
         if (types.isString(value)) {
             const str_data = types.toObject(value).as(types.SchemeString).data;
             const str_name = try self.internString(str_data);
@@ -954,7 +962,7 @@ pub const LLVMEmitter = struct {
         return self.emitVoid();
     }
 
-    fn inLexicalScope(self: *LLVMEmitter) bool {
+    pub fn inLexicalScope(self: *LLVMEmitter) bool {
         return self.params != null or self.locals != null or
             self.rest_param_name != null or self.upvalues != null;
     }
@@ -1027,9 +1035,30 @@ pub const LLVMEmitter = struct {
         return self.emitImm(@bitCast(types.VOID));
     }
 
+    const forms = @import("llvm_emit_forms.zig");
+
+    // True if `name` is bound as a syntax transformer in the VM's macro table.
+    // Guards native lowering of cond/case/do (#1496): a macro use must not be
+    // compiled as a call to a same-named global — it has to reach the
+    // interpreter, which expands it.
+    pub fn isMacroName(self: *LLVMEmitter, name: []const u8) bool {
+        const m = self.macros orelse return false;
+        return m.contains(name);
+    }
+
     fn emitSexprEval(self: *LLVMEmitter, node: *const ir.Node) EmitError![]const u8 {
         if (node.tag != .sexpr_form) return error.UnsupportedNodeType;
         const sf = node.data.sexpr_form;
+        // cond/case/do are lowered natively when every sub-form is emittable in
+        // the current lexical scope; otherwise they fall back like any other
+        // sexpr form (#1496). The dispatch is here so nested occurrences reached
+        // via emitNode take the same path.
+        switch (sf.form) {
+            .cond => return forms.emitCond(self, sf.args, node.ann.is_tail),
+            .case_form => return forms.emitCase(self, sf.args, node.ann.is_tail),
+            .do_form => return forms.emitDo(self, sf.args, node.ann.is_tail),
+            else => {},
+        }
         return self.emitFormEval(sf.args, sf.form.keyword());
     }
 
@@ -1037,7 +1066,7 @@ pub const LLVMEmitter = struct {
         return self.emitFormEval(args, form_name);
     }
 
-    fn emitFormEval(self: *LLVMEmitter, args: Value, form_name: []const u8) EmitError![]const u8 {
+    pub fn emitFormEval(self: *LLVMEmitter, args: Value, form_name: []const u8) EmitError![]const u8 {
         try lambda.bindParamsAsGlobals(self);
 
         var source_buf: std.ArrayList(u8) = .empty;
@@ -1487,18 +1516,18 @@ pub const LLVMEmitter = struct {
         try self.write("declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64)\n");
     }
 
-    fn emitRootPush(self: *LLVMEmitter, tmp: []const u8) EmitError!void {
+    pub fn emitRootPush(self: *LLVMEmitter, tmp: []const u8) EmitError!void {
         const slot = try self.freshTemp();
         try self.print("  {s} = alloca i64, align 8\n", .{slot});
         try self.print("  store i64 {s}, ptr {s}\n", .{ tmp, slot });
         try self.print("  call void @kaappi_gc_push_root(ptr {s})\n", .{slot});
     }
 
-    fn emitRootPushAlloca(self: *LLVMEmitter, alloca: []const u8) EmitError!void {
+    pub fn emitRootPushAlloca(self: *LLVMEmitter, alloca: []const u8) EmitError!void {
         try self.print("  call void @kaappi_gc_push_root(ptr {s})\n", .{alloca});
     }
 
-    fn emitPopRoots(self: *LLVMEmitter, n: usize) EmitError!void {
+    pub fn emitPopRoots(self: *LLVMEmitter, n: usize) EmitError!void {
         if (n > 0) {
             try self.print("  call void @kaappi_gc_pop_roots(i64 {d})\n", .{n});
         }

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -1,0 +1,541 @@
+// Native lowering of cond/case/do for the LLVM backend (kaappi#1496).
+//
+// These three forms desugar into machinery the emitter already lowers well —
+// `if`-style block/phi chains for cond and case, and a self-branching loop for
+// do — so routing them through `kaappi_eval` (as the generic sexpr-form
+// fallback does) is pure overhead. Each entry point first checks that every
+// sub-form is emittable in the current lexical scope (`exprNativeEmittable`);
+// if not, it either falls back to the interpreter at top level (where a
+// global-environment eval is correct) or, inside a native let/lambda body,
+// returns an error so the enclosing form abandons native compilation as a
+// whole (the #827 discipline — never split a lexical scope across the
+// native/interpreted boundary).
+//
+// The gate deliberately rejects `lambda`, `=>` clauses, and every eval-fallback
+// / passthrough special form (letrec, guard, apply, call/cc, …) and any macro
+// use. Rejecting lambdas also sidesteps do's fresh-binding-per-iteration
+// semantics: with no closure able to capture a loop variable, mutable allocas
+// updated in place are observably equivalent.
+
+const std = @import("std");
+const ir = @import("ir.zig");
+const types = @import("types.zig");
+
+const LLVMEmitter = @import("llvm_emit.zig").LLVMEmitter;
+const EmitError = @import("llvm_emit.zig").EmitError;
+
+const Value = types.Value;
+
+const false_bits: i64 = @bitCast(types.FALSE);
+const void_bits: i64 = @bitCast(types.VOID);
+
+// Cap on `do` loop variables — bounds the fixed-size scratch arrays below and
+// matches emitLet's 32-binding ceiling. A wider `do` falls back to eval.
+const MAX_DO_VARS = 32;
+
+fn fmt(self: *LLVMEmitter, comptime f: []const u8, a: anytype) EmitError![]const u8 {
+    return std.fmt.allocPrint(self.allocator(), f, a) catch return error.OutOfMemory;
+}
+
+// Lower a sub-expression to IR for native emission. The emittability gate has
+// already validated the surrounding structure, so a lowering failure here is a
+// resource limit or malformed leaf; mapping it to UnsupportedNodeType routes an
+// in-scope form to its enclosing form's abandon path (a top-level form has no
+// partial state to unwind at this point — the leaf lowers before any branch).
+fn lower(self: *LLVMEmitter, expr: Value, tail: bool) EmitError!*ir.Node {
+    return ir.lowerSingleExprTail(self.allocator(), expr, tail) catch return error.UnsupportedNodeType;
+}
+
+// ---------------------------------------------------------------------------
+// cond
+// ---------------------------------------------------------------------------
+
+pub fn emitCond(self: *LLVMEmitter, args: Value, is_tail: bool) EmitError![]const u8 {
+    if (!condArgsEmittable(self, args)) return fallback(self, args, "cond");
+    // (cond) with no clauses is unspecified — yield void.
+    if (!types.isPair(args)) return self.emitImm(void_bits);
+
+    const merge = try self.freshLabel("cond_merge_");
+    var incomings: std.ArrayList([]const u8) = .empty;
+    defer incomings.deinit(self.backing_alloc);
+
+    var clause_list = args;
+    var had_else = false;
+    while (types.isPair(clause_list)) : (clause_list = types.cdr(clause_list)) {
+        const clause = types.car(clause_list);
+        const test_expr = types.car(clause);
+        const body = types.cdr(clause);
+
+        if (isKeyword(test_expr, "else")) {
+            const v = try emitBody(self, body, is_tail);
+            try incomings.append(self.backing_alloc, try fmt(self, "[ {s}, %{s} ]", .{ v, self.current_block }));
+            try self.print("  br label %{s}\n", .{merge});
+            had_else = true;
+            break;
+        }
+
+        const test_node = try lower(self, test_expr, false);
+        const tval = try self.emitNode(test_node);
+        const cmp = try self.freshTemp();
+        try self.print("  {s} = icmp ne i64 {s}, {d}\n", .{ cmp, tval, false_bits });
+        const test_end = self.current_block;
+
+        if (body == types.NIL) {
+            // (test) with no body: the test value is the result when truthy.
+            const next = try self.freshLabel("cond_next_");
+            try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ cmp, merge, next });
+            try incomings.append(self.backing_alloc, try fmt(self, "[ {s}, %{s} ]", .{ tval, test_end }));
+            try self.startBlock(next);
+        } else {
+            const body_lbl = try self.freshLabel("cond_body_");
+            const next = try self.freshLabel("cond_next_");
+            try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ cmp, body_lbl, next });
+            try self.startBlock(body_lbl);
+            const v = try emitBody(self, body, is_tail);
+            try incomings.append(self.backing_alloc, try fmt(self, "[ {s}, %{s} ]", .{ v, self.current_block }));
+            try self.print("  br label %{s}\n", .{merge});
+            try self.startBlock(next);
+        }
+    }
+
+    // No clause matched and there was no else: the value is unspecified.
+    if (!had_else) {
+        try incomings.append(self.backing_alloc, try fmt(self, "[ {d}, %{s} ]", .{ void_bits, self.current_block }));
+        try self.print("  br label %{s}\n", .{merge});
+    }
+
+    return emitMergePhi(self, merge, incomings.items);
+}
+
+// ---------------------------------------------------------------------------
+// case
+// ---------------------------------------------------------------------------
+
+pub fn emitCase(self: *LLVMEmitter, args: Value, is_tail: bool) EmitError![]const u8 {
+    if (!caseArgsEmittable(self, args)) return fallback(self, args, "case");
+
+    const key_expr = types.car(args);
+    const clauses = types.cdr(args);
+
+    // Evaluate the key once and keep it rooted across every clause's eqv?
+    // comparisons (which may allocate while interning symbol/heap datums).
+    // A matched body pops this root at its own entry — the key is dead there
+    // (=> clauses, which would need it, are rejected by the gate) — so bodies
+    // stay in tail position.
+    const key_node = try lower(self, key_expr, false);
+    const key_val = try self.emitNode(key_node);
+    const key_slot = try self.freshTemp();
+    try self.print("  {s} = alloca i64, align 8\n", .{key_slot});
+    try self.print("  store i64 {s}, ptr {s}\n", .{ key_val, key_slot });
+    try self.emitRootPushAlloca(key_slot);
+
+    const merge = try self.freshLabel("case_merge_");
+    var incomings: std.ArrayList([]const u8) = .empty;
+    defer incomings.deinit(self.backing_alloc);
+
+    var clause_list = clauses;
+    var had_else = false;
+    while (types.isPair(clause_list)) : (clause_list = types.cdr(clause_list)) {
+        const clause = types.car(clause_list);
+        const datums = types.car(clause);
+        const body = types.cdr(clause);
+
+        if (isKeyword(datums, "else")) {
+            try self.emitPopRoots(1);
+            const v = try emitBody(self, body, is_tail);
+            try incomings.append(self.backing_alloc, try fmt(self, "[ {s}, %{s} ]", .{ v, self.current_block }));
+            try self.print("  br label %{s}\n", .{merge});
+            had_else = true;
+            break;
+        }
+
+        // An empty datum list is a dead clause (R7RS): emit no comparison.
+        if (datums == types.NIL) continue;
+
+        const body_lbl = try self.freshLabel("case_body_");
+        var datum_list = datums;
+        while (types.isPair(datum_list)) : (datum_list = types.cdr(datum_list)) {
+            const datum = types.car(datum_list);
+            const matched = try emitEqvMatch(self, key_slot, datum);
+            if (!types.isPair(types.cdr(datum_list))) {
+                const next = try self.freshLabel("case_next_");
+                try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ matched, body_lbl, next });
+                try self.startBlock(body_lbl);
+                try self.emitPopRoots(1);
+                const v = try emitBody(self, body, is_tail);
+                try incomings.append(self.backing_alloc, try fmt(self, "[ {s}, %{s} ]", .{ v, self.current_block }));
+                try self.print("  br label %{s}\n", .{merge});
+                try self.startBlock(next);
+            } else {
+                const check = try self.freshLabel("case_check_");
+                try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ matched, body_lbl, check });
+                try self.startBlock(check);
+            }
+        }
+    }
+
+    if (!had_else) {
+        try self.emitPopRoots(1);
+        try incomings.append(self.backing_alloc, try fmt(self, "[ {d}, %{s} ]", .{ void_bits, self.current_block }));
+        try self.print("  br label %{s}\n", .{merge});
+    }
+
+    return emitMergePhi(self, merge, incomings.items);
+}
+
+// Emit `(eqv? <key> <datum>)` and return an `i1` that is true when they match.
+// Mirrors the interpreter's per-datum eqv? dispatch (compiler_advanced.zig) so
+// symbol/number/char keys compare identically.
+fn emitEqvMatch(self: *LLVMEmitter, key_slot: []const u8, datum: Value) EmitError![]const u8 {
+    const sym = try self.internSymbol("eqv?");
+    const callee = try self.freshTemp();
+    try self.print("  {s} = call i64 @kaappi_global_lookup(ptr %vm, ptr {s}, i64 4)\n", .{ callee, sym });
+    try self.emitRootPush(callee);
+    const a = try self.freshTemp();
+    try self.print("  {s} = load i64, ptr {s}\n", .{ a, key_slot });
+    try self.emitRootPush(a);
+    const b = try self.emitConstant(datum);
+    try self.emitPopRoots(2);
+
+    const argv = try self.freshTemp();
+    try self.print("  {s} = alloca [2 x i64], align 8\n", .{argv});
+    const g0 = try self.freshTemp();
+    try self.print("  {s} = getelementptr [1 x i64], ptr {s}, i64 0\n", .{ g0, argv });
+    try self.print("  store i64 {s}, ptr {s}\n", .{ a, g0 });
+    const g1 = try self.freshTemp();
+    try self.print("  {s} = getelementptr [1 x i64], ptr {s}, i64 1\n", .{ g1, argv });
+    try self.print("  store i64 {s}, ptr {s}\n", .{ b, g1 });
+    const res = try self.freshTemp();
+    try self.print("  {s} = call i64 @kaappi_call_scheme(ptr %vm, i64 {s}, ptr {s}, i64 2)\n", .{ res, callee, argv });
+
+    const cmp = try self.freshTemp();
+    try self.print("  {s} = icmp ne i64 {s}, {d}\n", .{ cmp, res, false_bits });
+    return cmp;
+}
+
+// ---------------------------------------------------------------------------
+// do
+// ---------------------------------------------------------------------------
+
+pub fn emitDo(self: *LLVMEmitter, args: Value, is_tail: bool) EmitError![]const u8 {
+    // `do`'s result runs after the loop with the binding roots still live (it
+    // may reference the loop variables), so it is emitted non-tail regardless
+    // of the enclosing tail position — the roots pop after it computes.
+    _ = is_tail;
+    if (!doArgsEmittable(self, args)) return fallback(self, args, "do");
+
+    const specs = types.car(args);
+    const rest = types.cdr(args);
+    const test_clause = types.car(rest);
+    const commands = types.cdr(rest);
+    const test_expr = types.car(test_clause);
+    const result_exprs = types.cdr(test_clause);
+
+    var var_names: [MAX_DO_VARS][]const u8 = undefined;
+    var allocas: [MAX_DO_VARS][]const u8 = undefined;
+    var steps: [MAX_DO_VARS]Value = undefined;
+    var n: usize = 0;
+
+    // Phase 1: evaluate every init in the OUTER scope (do has let semantics —
+    // inits do not see the loop bindings), store into a fresh rooted alloca.
+    var s = specs;
+    while (types.isPair(s)) : (s = types.cdr(s)) {
+        const spec = types.car(s);
+        const init_expr = types.car(types.cdr(spec));
+        const init_node = try lower(self, init_expr, false);
+        const init_val = try self.emitNode(init_node);
+        const alloca = try self.freshTemp();
+        try self.print("  {s} = alloca i64, align 8\n", .{alloca});
+        try self.print("  store i64 {s}, ptr {s}\n", .{ init_val, alloca });
+        try self.emitRootPushAlloca(alloca);
+        var_names[n] = types.symbolName(types.car(spec));
+        const step_rest = types.cdr(types.cdr(spec));
+        steps[n] = if (types.isPair(step_rest)) types.car(step_rest) else types.VOID;
+        allocas[n] = alloca;
+        n += 1;
+    }
+
+    // Phase 2: bind all loop variables at once (parallel, not sequential).
+    const saved_locals = self.locals;
+    self.locals = if (saved_locals) |existing|
+        existing.clone() catch return error.OutOfMemory
+    else
+        std.StringHashMap([]const u8).init(self.allocator());
+    defer {
+        self.locals.?.deinit();
+        self.locals = saved_locals;
+    }
+    for (0..n) |i| self.locals.?.put(var_names[i], allocas[i]) catch return error.OutOfMemory;
+
+    const header = try self.freshLabel("do_header_");
+    const body_lbl = try self.freshLabel("do_body_");
+    const exit_lbl = try self.freshLabel("do_exit_");
+
+    try self.print("  br label %{s}\n", .{header});
+    try self.startBlock(header);
+    const test_node = try lower(self, test_expr, false);
+    const tval = try self.emitNode(test_node);
+    const cmp = try self.freshTemp();
+    try self.print("  {s} = icmp ne i64 {s}, {d}\n", .{ cmp, tval, false_bits });
+    try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ cmp, exit_lbl, body_lbl });
+
+    // Body: commands for effect, then all steps, then loop back.
+    try self.startBlock(body_lbl);
+    var c = commands;
+    while (types.isPair(c)) : (c = types.cdr(c)) {
+        const cnode = try lower(self, types.car(c), false);
+        _ = try self.emitNode(cnode);
+    }
+
+    // Evaluate every step into a temp (rooting each across the next's
+    // evaluation, à la emitSelfTailCall), then store them all back — do's
+    // steps see the *current* bindings, so no store may precede an evaluation.
+    var stepped: [MAX_DO_VARS]usize = undefined;
+    var ns: usize = 0;
+    for (0..n) |i| {
+        if (steps[i] != types.VOID) {
+            stepped[ns] = i;
+            ns += 1;
+        }
+    }
+    var step_tmps: [MAX_DO_VARS][]const u8 = undefined;
+    var roots: usize = 0;
+    for (0..ns) |k| {
+        const snode = try lower(self, steps[stepped[k]], false);
+        step_tmps[k] = try self.emitNode(snode);
+        if (k + 1 < ns) {
+            try self.emitRootPush(step_tmps[k]);
+            roots += 1;
+        }
+    }
+    try self.emitPopRoots(roots);
+    for (0..ns) |k| {
+        try self.print("  store i64 {s}, ptr {s}\n", .{ step_tmps[k], allocas[stepped[k]] });
+    }
+    try self.print("  br label %{s}\n", .{header});
+
+    // Exit: evaluate the result expressions (or void), then drop the roots.
+    try self.startBlock(exit_lbl);
+    const result_val = if (types.isPair(result_exprs))
+        try emitBody(self, result_exprs, false)
+    else
+        try self.emitImm(void_bits);
+    try self.emitPopRoots(n);
+    return result_val;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// A form that cannot be lowered natively: at top level a whole-form eval in the
+// global environment is correct; inside a native lexical scope, signal the
+// enclosing let/lambda to abandon native compilation (it re-evaluates the whole
+// enclosing form as one unit, preserving scope).
+fn fallback(self: *LLVMEmitter, args: Value, form_name: []const u8) EmitError![]const u8 {
+    if (self.inLexicalScope()) return error.UnsupportedNodeType;
+    return self.emitFormEval(args, form_name);
+}
+
+// Emit a body (a `begin` of expressions), returning the last value. The final
+// expression inherits the caller's tail position.
+fn emitBody(self: *LLVMEmitter, body: Value, is_tail: bool) EmitError![]const u8 {
+    if (!types.isPair(body)) return self.emitImm(void_bits);
+    var last: []const u8 = undefined;
+    var e = body;
+    while (types.isPair(e)) : (e = types.cdr(e)) {
+        const rest = types.cdr(e);
+        const tail = is_tail and !types.isPair(rest);
+        const node = try lower(self, types.car(e), tail);
+        last = try self.emitNode(node);
+    }
+    return last;
+}
+
+fn emitMergePhi(self: *LLVMEmitter, merge: []const u8, incomings: []const []const u8) EmitError![]const u8 {
+    try self.startBlock(merge);
+    const result = try self.freshTemp();
+    try self.print("  {s} = phi i64 ", .{result});
+    for (incomings, 0..) |inc, i| {
+        if (i != 0) try self.write(", ");
+        try self.write(inc);
+    }
+    try self.write("\n");
+    return result;
+}
+
+fn isKeyword(v: Value, name: []const u8) bool {
+    return types.isSymbol(v) and std.mem.eql(u8, types.symbolName(v), name);
+}
+
+// ---------------------------------------------------------------------------
+// Emittability gate
+// ---------------------------------------------------------------------------
+
+// Special-form heads the native backend cannot lower in the current lexical
+// scope (they route through eval / passthrough) or deliberately declines to
+// handle here (lambda, => markers). A form containing any of these is sent to
+// the interpreter as a whole.
+fn isRejectedFormHead(name: []const u8) bool {
+    const rejected = [_][]const u8{
+        "lambda",           "letrec",                         "letrec*",
+        "guard",            "quasiquote",                     "delay",
+        "delay-force",      "parameterize",                   "define-values",
+        "let-values",       "let*-values",                    "define-syntax",
+        "let-syntax",       "letrec-syntax",                  "cond-expand",
+        "case-lambda",      "define",                         "define-record-type",
+        "apply",            "call-with-current-continuation", "call/cc",
+        "call-with-values", "eval",                           "import",
+        "include",          "include-ci",                     "define-library",
+        "syntax-rules",     "syntax-error",                   "unquote",
+        "unquote-splicing", "else",                           "=>",
+    };
+    for (rejected) |r| {
+        if (std.mem.eql(u8, name, r)) return true;
+    }
+    return false;
+}
+
+// True if `expr` is an expression the emitter can lower natively while
+// respecting the current lexical scope. Conservative by design: anything not
+// on the allow-list (a macro use, a rejected special form, an improper list)
+// makes the whole enclosing cond/case/do fall back.
+fn exprNativeEmittable(self: *LLVMEmitter, expr: Value) bool {
+    if (types.isSymbol(expr)) return true; // variable reference
+    if (!types.isPair(expr)) return true; // self-evaluating datum
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const name = types.symbolName(head);
+        if (self.isMacroName(name)) return false;
+        if (std.mem.eql(u8, name, "quote")) return true; // opaque literal
+        if (isRejectedFormHead(name)) return false;
+        if (std.mem.eql(u8, name, "let")) return letArgsEmittable(self, types.cdr(expr));
+        if (std.mem.eql(u8, name, "let*")) return letArgsEmittable(self, types.cdr(expr));
+        if (std.mem.eql(u8, name, "cond")) return condArgsEmittable(self, types.cdr(expr));
+        if (std.mem.eql(u8, name, "case")) return caseArgsEmittable(self, types.cdr(expr));
+        if (std.mem.eql(u8, name, "do")) return doArgsEmittable(self, types.cdr(expr));
+        // if/begin/and/or/when/unless/set! and ordinary calls fall through:
+        // every list element is itself an expression (the keyword/operator is
+        // a harmless symbol), so validating them all covers these forms.
+    }
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        if (!exprNativeEmittable(self, types.car(cur))) return false;
+    }
+    return cur == types.NIL; // reject dotted/improper lists
+}
+
+// `(bindings body ...)` tail of a let/let*. Rejects named let (handled
+// elsewhere) and keeps the binding count within emitLet's native ceiling so a
+// let that passes here is one emitLet compiles natively rather than abandons.
+fn letArgsEmittable(self: *LLVMEmitter, args: Value) bool {
+    if (!types.isPair(args)) return false;
+    if (types.isSymbol(types.car(args))) return false; // named let
+    var count: usize = 0;
+    var b = types.car(args);
+    while (types.isPair(b)) : (b = types.cdr(b)) {
+        const binding = types.car(b);
+        if (!types.isPair(binding)) return false;
+        if (!types.isSymbol(types.car(binding))) return false;
+        const init_list = types.cdr(binding);
+        if (!types.isPair(init_list)) return false;
+        if (!exprNativeEmittable(self, types.car(init_list))) return false;
+        count += 1;
+        if (count > 32) return false;
+    }
+    if (b != types.NIL) return false;
+    var body = types.cdr(args);
+    if (!types.isPair(body)) return false; // a let needs a body
+    while (types.isPair(body)) : (body = types.cdr(body)) {
+        if (!exprNativeEmittable(self, types.car(body))) return false;
+    }
+    return body == types.NIL;
+}
+
+// Reject a clause whose body is a `=> proc` tail: native arrow clauses are not
+// implemented yet, so such a cond/case falls back to the interpreter.
+fn hasArrowBody(body: Value) bool {
+    return types.isPair(body) and isKeyword(types.car(body), "=>");
+}
+
+fn bodyEmittable(self: *LLVMEmitter, body: Value) bool {
+    var b = body;
+    while (types.isPair(b)) : (b = types.cdr(b)) {
+        if (!exprNativeEmittable(self, types.car(b))) return false;
+    }
+    return b == types.NIL;
+}
+
+fn condArgsEmittable(self: *LLVMEmitter, clauses: Value) bool {
+    var cl = clauses;
+    while (types.isPair(cl)) : (cl = types.cdr(cl)) {
+        const clause = types.car(cl);
+        if (!types.isPair(clause)) return false;
+        const test_expr = types.car(clause);
+        const body = types.cdr(clause);
+        if (isKeyword(test_expr, "else")) {
+            if (types.isPair(types.cdr(cl))) return false; // else must be last
+        } else if (!exprNativeEmittable(self, test_expr)) {
+            return false;
+        }
+        if (hasArrowBody(body)) return false;
+        if (!bodyEmittable(self, body)) return false;
+    }
+    return cl == types.NIL;
+}
+
+fn caseArgsEmittable(self: *LLVMEmitter, args: Value) bool {
+    if (!types.isPair(args)) return false; // need a key
+    if (!exprNativeEmittable(self, types.car(args))) return false;
+    var cl = types.cdr(args);
+    while (types.isPair(cl)) : (cl = types.cdr(cl)) {
+        const clause = types.car(cl);
+        if (!types.isPair(clause)) return false;
+        const datums = types.car(clause);
+        const body = types.cdr(clause);
+        if (isKeyword(datums, "else")) {
+            if (types.isPair(types.cdr(cl))) return false; // else must be last
+        } else {
+            // Datums are literals (never evaluated), but the list must be proper.
+            var d = datums;
+            while (types.isPair(d)) : (d = types.cdr(d)) {}
+            if (d != types.NIL) return false;
+        }
+        if (hasArrowBody(body)) return false;
+        if (!bodyEmittable(self, body)) return false;
+    }
+    return cl == types.NIL;
+}
+
+fn doArgsEmittable(self: *LLVMEmitter, args: Value) bool {
+    if (!types.isPair(args)) return false;
+    const rest = types.cdr(args);
+    if (!types.isPair(rest)) return false;
+    const test_clause = types.car(rest);
+    if (!types.isPair(test_clause)) return false;
+
+    var count: usize = 0;
+    var s = types.car(args);
+    while (types.isPair(s)) : (s = types.cdr(s)) {
+        const spec = types.car(s);
+        if (!types.isPair(spec)) return false;
+        if (!types.isSymbol(types.car(spec))) return false;
+        const init_list = types.cdr(spec);
+        if (!types.isPair(init_list)) return false;
+        if (!exprNativeEmittable(self, types.car(init_list))) return false;
+        const step_rest = types.cdr(init_list);
+        if (types.isPair(step_rest)) {
+            if (!exprNativeEmittable(self, types.car(step_rest))) return false;
+            if (types.cdr(step_rest) != types.NIL) return false; // one step only
+        } else if (step_rest != types.NIL) {
+            return false;
+        }
+        count += 1;
+        if (count > MAX_DO_VARS) return false;
+    }
+    if (s != types.NIL) return false;
+
+    if (!exprNativeEmittable(self, types.car(test_clause))) return false;
+    if (!bodyEmittable(self, types.cdr(test_clause))) return false; // result exprs
+    return bodyEmittable(self, types.cdr(rest)); // commands
+}

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -995,7 +995,15 @@ fn nodeHasFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []c
         .let_form => return letSexprHasFreeVars(self, node.data.let_form.args, false, params),
         .let_star => return letSexprHasFreeVars(self, node.data.let_star.args, true, params),
         .lambda => return lambdaSexprHasFreeVars(self, node.data.lambda.args, params),
-        .passthrough, .sexpr_form => return false,
+        // cond/case/do keep their clauses as a raw S-expression that the
+        // backend now lowers natively (#1496); scope them like let/lambda so a
+        // capture hidden in a clause is seen. Other sexpr forms are rejected
+        // upstream and never reach a native body, so they report none.
+        .sexpr_form => switch (node.data.sexpr_form.form) {
+            .cond, .case_form, .do_form => return sexprFormHasFreeVars(self, node.data.sexpr_form.form, node.data.sexpr_form.args, params),
+            else => return false,
+        },
+        .passthrough => return false,
         .letrec, .letrec_star => return false,
     }
 }
@@ -1084,7 +1092,14 @@ fn collectNodeFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const
             if (!collectSexprFreeVars(self, node.data.set_form.name, params, buf, count)) return false;
             return collectSexprFreeVars(self, node.data.set_form.value, params, buf, count);
         },
-        .constant, .define, .passthrough, .sexpr_form => return true,
+        // cond/case/do are lowered natively (#1496): collect captures hidden in
+        // their clauses so a closure over such a variable gets its upvalue.
+        // Other sexpr forms never reach a native body (rejected upstream).
+        .sexpr_form => switch (node.data.sexpr_form.form) {
+            .cond, .case_form, .do_form => return collectSexprFormFreeVars(self, node.data.sexpr_form.form, node.data.sexpr_form.args, params, buf, count),
+            else => return true,
+        },
+        .constant, .define, .passthrough => return true,
         .letrec, .letrec_star => return true,
     }
 }
@@ -1174,6 +1189,29 @@ fn collectLambdaSexprFreeVars(self: *LLVMEmitter, args: Value, params: []const [
     return !w.inexact;
 }
 
+// args is the raw form tail (ir.SexprFormData.args) of a natively lowered
+// cond/case/do (#1496). Walks it with the same binder scoping as let/lambda.
+fn sexprFormHasFreeVars(self: *LLVMEmitter, form: ir.FormKind, args: Value, params: []const []const u8) bool {
+    var w = FreeNameWalk{ .emitter = self, .params = params };
+    walkSexprForm(&w, form, args);
+    return w.found or w.inexact;
+}
+
+fn collectSexprFormFreeVars(self: *LLVMEmitter, form: ir.FormKind, args: Value, params: []const []const u8, buf: *[16][]const u8, count: *usize) bool {
+    var w = FreeNameWalk{ .emitter = self, .params = params, .buf = buf, .count = count };
+    walkSexprForm(&w, form, args);
+    return !w.inexact;
+}
+
+fn walkSexprForm(w: *FreeNameWalk, form: ir.FormKind, args: Value) void {
+    switch (form) {
+        .cond => walkCondSexpr(w, args),
+        .case_form => walkCaseSexpr(w, args),
+        .do_form => walkDoSexpr(w, args),
+        else => w.inexact = true,
+    }
+}
+
 // args is the raw `(bindings body ...)` tail of a let/let* form. For let the
 // init expressions see only the enclosing scope; for let* each init also sees
 // the binders before it. The binders are in scope for the body either way.
@@ -1250,6 +1288,107 @@ fn walkLambdaSexpr(w: *FreeNameWalk, rest: Value) void {
     }
 }
 
+// True if `v` is the symbol `name` — cond/case clause markers (else, =>) that
+// the walks below must skip rather than treat as variable references.
+fn sexprSymEql(v: Value, name: []const u8) bool {
+    return types.isSymbol(v) and std.mem.eql(u8, types.symbolName(v), name);
+}
+
+// clauses is the raw tail of a `cond`: each clause is `(test body ...)`, with a
+// leading `else` or `=> proc` handled structurally (the markers are not refs).
+fn walkCondSexpr(w: *FreeNameWalk, clauses: Value) void {
+    var cl = clauses;
+    while (types.isPair(cl)) : (cl = types.cdr(cl)) {
+        const clause = types.car(cl);
+        if (!types.isPair(clause)) {
+            w.inexact = true;
+            return;
+        }
+        const test_expr = types.car(clause);
+        if (!sexprSymEql(test_expr, "else")) walkSexpr(w, test_expr);
+        var body = types.cdr(clause);
+        if (types.isPair(body) and sexprSymEql(types.car(body), "=>")) body = types.cdr(body);
+        while (types.isPair(body)) : (body = types.cdr(body)) {
+            walkSexpr(w, types.car(body));
+        }
+    }
+}
+
+// args is the raw tail of a `case`: `(key clause ...)`. The datum list in each
+// clause is quoted data (never referenced); only the key and bodies are refs.
+fn walkCaseSexpr(w: *FreeNameWalk, args: Value) void {
+    if (!types.isPair(args)) {
+        w.inexact = true;
+        return;
+    }
+    walkSexpr(w, types.car(args)); // key
+    var cl = types.cdr(args);
+    while (types.isPair(cl)) : (cl = types.cdr(cl)) {
+        const clause = types.car(cl);
+        if (!types.isPair(clause)) {
+            w.inexact = true;
+            return;
+        }
+        var body = types.cdr(clause); // car is the (literal) datum list
+        if (types.isPair(body) and sexprSymEql(types.car(body), "=>")) body = types.cdr(body);
+        while (types.isPair(body)) : (body = types.cdr(body)) {
+            walkSexpr(w, types.car(body));
+        }
+    }
+}
+
+// args is the raw tail of a `do`: `(specs (test result ...) command ...)`. The
+// loop variables are bound for the steps, test, results, and commands, but the
+// init expressions are evaluated in the enclosing scope.
+fn walkDoSexpr(w: *FreeNameWalk, args: Value) void {
+    if (!types.isPair(args)) {
+        w.inexact = true;
+        return;
+    }
+    const specs = types.car(args);
+    const rest = types.cdr(args);
+    if (!types.isPair(rest) or !types.isPair(types.car(rest))) {
+        w.inexact = true;
+        return;
+    }
+    const test_clause = types.car(rest);
+    const commands = types.cdr(rest);
+
+    const saved = w.bound_count;
+    defer w.bound_count = saved;
+
+    // Inits are evaluated before the loop variables are bound.
+    var s = specs;
+    while (types.isPair(s)) : (s = types.cdr(s)) {
+        const spec = types.car(s);
+        if (!types.isPair(spec) or !types.isSymbol(types.car(spec)) or !types.isPair(types.cdr(spec))) {
+            w.inexact = true;
+            return;
+        }
+        walkSexpr(w, types.car(types.cdr(spec)));
+    }
+    if (s != types.NIL) {
+        w.inexact = true;
+        return;
+    }
+    // Bind the loop variables for the rest of the form.
+    s = specs;
+    while (types.isPair(s)) : (s = types.cdr(s)) {
+        w.pushBound(types.symbolName(types.car(types.car(s))));
+    }
+    // Steps see the loop bindings.
+    s = specs;
+    while (types.isPair(s)) : (s = types.cdr(s)) {
+        const step_rest = types.cdr(types.cdr(types.car(s)));
+        if (types.isPair(step_rest)) walkSexpr(w, types.car(step_rest));
+    }
+    walkSexpr(w, types.car(test_clause));
+    var r = types.cdr(test_clause);
+    while (types.isPair(r)) : (r = types.cdr(r)) walkSexpr(w, types.car(r));
+    var c = commands;
+    while (types.isPair(c)) : (c = types.cdr(c)) walkSexpr(w, types.car(c));
+}
+
 fn walkSexpr(w: *FreeNameWalk, expr: Value) void {
     if (w.inexact) return;
     if (types.isSymbol(expr)) {
@@ -1273,6 +1412,11 @@ fn walkSexpr(w: *FreeNameWalk, expr: Value) void {
             }
             return walkLetSexpr(w, rest, !is_let);
         }
+        // cond/case/do are natively lowered (#1496); scope their clauses so a
+        // capture inside one is seen. (They are no longer isEvalFallbackForm.)
+        if (std.mem.eql(u8, name, "cond")) return walkCondSexpr(w, types.cdr(expr));
+        if (std.mem.eql(u8, name, "case")) return walkCaseSexpr(w, types.cdr(expr));
+        if (std.mem.eql(u8, name, "do")) return walkDoSexpr(w, types.cdr(expr));
         // An internal define introduces a binding this walk does not model.
         if (std.mem.eql(u8, name, "define")) {
             w.inexact = true;

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -114,6 +114,10 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
 
     var emitter = llvm_emit.LLVMEmitter.init(allocator);
     defer emitter.deinit();
+    // Native cond/case/do lowering consults the macro table so a macro use is
+    // sent to the interpreter (which expands it) instead of being mis-compiled
+    // as a call to a same-named global (#1496).
+    emitter.macros = &vm.macros;
     emitter.emitProgram(ir_nodes.items) catch |err| {
         const code = diagnostics.Code.internal_error;
         var cbuf: [diagnostics.Code.render_width]u8 = undefined;

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -779,8 +779,9 @@ test "cached form compiles once and re-executes correctly (#1494)" {
     try ctx.init();
     defer ctx.deinit();
 
-    // A cond is one of the forms the native backend serializes to eval.
-    const fv = try ctx.vm.compileCachedForm("(cond (#f 1) (#t 42) (else 0))");
+    // guard is one of the forms the native backend still serializes to eval
+    // (cond/case/do now lower natively — #1496); the cache path is form-agnostic.
+    const fv = try ctx.vm.compileCachedForm("(guard (e (#t 0)) 42)");
     try std.testing.expect(types.isFunction(fv));
 
     // Re-running the one compiled Function is the cache fast path; it must yield
@@ -821,6 +822,106 @@ test "cached form declines non-cacheable sources (#1494)" {
     try std.testing.expectError(error.CompileError, ctx.vm.compileCachedForm("1 2"));
     // Empty source has nothing to compile.
     try std.testing.expectError(error.CompileError, ctx.vm.compileCachedForm("   "));
+}
+
+// -- cond / case / do native lowering (#1496) --
+// These forms used to be serialized and evaluated (kaappi_eval); they now lower
+// to native if-style block chains (cond/case) and a self-branching loop (do).
+// The gate falls back only for sub-forms that cannot be lowered in scope.
+
+test "LLVM emit: cond lowers to a native block chain, no eval" {
+    var res = try emitSourceResult("(cond ((< a 1) 10) ((< a 2) 20) (else 30))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "cond_merge_");
+    try expectContains(ll, "cond_body_");
+    try expectContains(ll, "phi i64");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: cond no-body clause yields the test value, no eval" {
+    // (test) with no body returns the test value when truthy — it must branch
+    // straight to the merge with that value, not re-evaluate anything.
+    var res = try emitSourceResult("(cond ((assv a b)) (else 0))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "cond_merge_");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: case lowers to eqv? dispatch, no eval" {
+    var res = try emitSourceResult("(case k ((1 2 3) 'lo) ((4 5 6) 'hi) (else 'other))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "case_merge_");
+    try expectContains(ll, "case_body_");
+    // Each datum is compared with the interpreter's eqv? via a runtime call.
+    try expectContains(ll, "call i64 @kaappi_call_scheme");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: do lowers to a native loop, no eval" {
+    var res = try emitSourceResult("(do ((i 0 (+ i 1)) (acc 0 (+ acc i))) ((= i 5) acc))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "do_header_");
+    try expectContains(ll, "do_body_");
+    try expectContains(ll, "do_exit_");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: a function whose body is a cond compiles natively (#1496)" {
+    // Previously the whole define fell back to eval because cond was an
+    // eval-fallback form; now only the define-time binding evals (1), and the
+    // body is a native @lambda with a cond block chain.
+    var res = try emitMultiResult("(define (sign n) (cond ((< n 0) -1) ((= n 0) 0) (else 1)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "; sign\ndefine i64 @lambda_");
+    try expectContains(ll, "cond_merge_");
+    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: do in a function body stays native (#1496)" {
+    var res = try emitMultiResult("(define (sumto n) (do ((i 0 (+ i 1)) (s 0 (+ s i))) ((= i n) s)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "; sumto\ndefine i64 @lambda_");
+    try expectContains(ll, "do_header_");
+    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: a lambda capturing a param through a cond gets an upvalue (#1496)" {
+    // The free-variable analysis must descend into the cond's clauses, or the
+    // capture of `base` degrades to a global lookup.
+    var res = try emitSourceResult("(define g (lambda (base) (lambda (n) (cond ((> n 0) (+ base n)) (else base)))))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_");
+    // base is read from the upvalue array, never interned for a global lookup.
+    try expectContains(ll, "ptr %upvalues, i64 0");
+    try std.testing.expect(std.mem.indexOf(u8, ll, "c\"base\"") == null);
+}
+
+test "LLVM emit: a cond containing apply falls back rather than mis-scoping (#1496)" {
+    // apply is a passthrough form the native path can't lower in a lexical
+    // scope; the whole enclosing function must fall back to the interpreter,
+    // not emit a native cond that evaluates apply in the global environment.
+    var res = try emitMultiResult("(define (f lst) (cond ((null? lst) 0) (else (apply + lst))))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNotContains(ll, "cond_merge_");
+    try std.testing.expect(countEvalFallbacks(ll) >= 1);
+}
+
+test "LLVM emit: a cond containing letrec falls back to the interpreter (#1496)" {
+    var res = try emitSourceResult("(cond (#t (letrec ((x 1)) x)) (else 0))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // A nested eval-fallback form makes the whole cond ineligible; at top level
+    // the correct choice is a whole-form eval, not a native block chain.
+    try expectNotContains(ll, "cond_merge_");
+    try std.testing.expect(countEvalFallbacks(ll) >= 1);
 }
 
 // -- NativeClosure dispatch tests (#1376) --

--- a/tests/e2e/programs/case-native.scm
+++ b/tests/e2e/programs/case-native.scm
@@ -1,0 +1,11 @@
+; case: multiple datums per clause, symbols, else
+(define (classify n)
+  (case n
+    ((0 2 4 6 8) 'even-digit)
+    ((1 3 5 7 9) 'odd-digit)
+    (else 'big)))
+(for-each (lambda (n) (display (classify n)) (display " ")) '(4 7 42))
+(newline)
+(display (case (string->symbol "b")
+          ((a) 1) ((b) 2) (else 0)))
+(newline)

--- a/tests/e2e/programs/cond-native.scm
+++ b/tests/e2e/programs/cond-native.scm
@@ -1,0 +1,12 @@
+; cond: else, ordinal dispatch, no-body clause, and => arrow
+(define (sign n)
+  (cond ((< n 0) 'neg)
+        ((= n 0) 'zero)
+        (else 'pos)))
+(for-each (lambda (n) (display (sign n)) (display " ")) '(-2 0 7))
+(newline)
+; no-body clause returns the test value; => applies proc to the test value
+(display (cond ((memv 3 '(1 2 3)) => car) (else 'none)))
+(newline)
+(display (cond ((assv 5 '((1 . a))) => cdr) (#f 1) (else 'fallthrough)))
+(newline)

--- a/tests/e2e/programs/do-native.scm
+++ b/tests/e2e/programs/do-native.scm
@@ -1,0 +1,9 @@
+; do: parallel step, a var without a step, a command body, and no result exprs
+(display (do ((i 0 (+ i 1)) (acc 0 (+ acc i))) ((= i 5) acc)))
+(newline)
+(display (do ((i 0 (+ i 1)) (s 0)) ((= i 5) s) (set! s (+ s (* i i)))))
+(newline)
+(define v (make-vector 4 0))
+(do ((i 0 (+ i 1))) ((= i 4)) (vector-set! v i (* i 10)))
+(display v)
+(newline)


### PR DESCRIPTION
Closes #1496 (part of the LLVM backend coverage epic #1491).

## Problem

`cond`, `case`, and `do` were routed through `kaappi_eval` like any other
unlowerable form, even though they desugar into machinery the emitter already
lowers well (`if`/`let` block chains and self-tail loops). A plain
`(define (f n) (cond …))` serialized the *whole function* to the interpreter.

## Change

New `src/llvm_emit_forms.zig` emits them natively:

- **cond** → `if`-style basic-block/`phi` chains — handles `else`, `(test)`
  no-body (returns the test value), and keeps TCO for tail arms.
- **case** → key evaluated once (rooted), per-datum `eqv?` dispatch matching
  the interpreter, `phi` merge.
- **do** → a self-branching `alloca` loop (header/body/exit; steps to temps
  then stored back).

An `exprNativeEmittable` gate decides eligibility. A form that reaches an
unlowerable sub-form (a macro use, a passthrough special form like `apply`/
`call/cc`, a nested eval-fallback form, a `lambda`, or a `=>` clause) still
falls back — at top level as a whole-form eval (correct in the global
environment), and inside a native `let`/lambda body by signalling the
enclosing form to abandon native compilation as a unit, so a lexical scope is
never split across the native/interpreted boundary (the #827 discipline).

Supporting changes:

- `src/ir.zig` — cond/case/do dropped from `eval_fallback_form_names`, so they
  no longer force an enclosing native body to fall back.
- `src/llvm_emit_lambda.zig` — the closure tiers' free-variable analysis now
  descends into cond/case/do clauses with correct binder scoping; without it a
  capture hidden in a clause degrades to a global lookup.
- `src/llvm_emit.zig` / `src/native_compiler.zig` — a borrowed macro-table
  reference so a macro use inside these forms reaches the interpreter that
  expands it.
- `docs/dev/llvm-backend.md` updated to match.

Rejecting lambdas inside `do` sidesteps its fresh-binding-per-iteration
semantics: with no closure able to capture a loop variable, in-place mutable
allocas are observably equivalent.

## Testing

- `zig build test` — full unit suite (10 new native emit tests)
- `tests/e2e/run-e2e.sh` — 32/32 parity (3 new: `cond/case/do-native.scm`)
- `bash tests/scheme/run-all.sh` — 1857 pass, 0 fail
- 110 randomised cond/case/do programs, interpreter vs native — 0 diffs
- Fallback paths (apply/letrec/call-cc/macros) and R7RS `do` fresh-binding
  verified for parity; tail-recursive cond keeps its self-tail-call loop

## Deliberate limits (both fall back correctly, so parity holds)

`=>` clauses and forms containing a nested `lambda`. Follow-up: teach
`fuzz_gen_native` to emit cond/case/do for VM-vs-native differential coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)