### PR TITLE
Mark #1480 resolved in the Phase 7 benchmark follow-ups

### DIFF
--- a/docs/dev/kep-0001-phase7-benchmarks.md
+++ b/docs/dev/kep-0001-phase7-benchmarks.md
@@ -413,4 +413,11 @@ discriminator exists to survive, not a real error to clean up after.
    (referring to the same bug as #1463) — now that the core fix has
    landed, those comments are stale and the workaround could be
    revisited (low priority, not urgent since the `yield`-based workaround
-   already works).
+   already works). **Resolved:** both comments were rewritten to record
+   that the core fix landed in #1463 — `threadSleepFn` now takes the same
+   `dispatched_from_scheduler`-aware yield-retry path `waitForFd` uses
+   (`src/primitives_srfi18.zig`), so `thread-sleep!` is no longer dangerous
+   in a retry loop. The `yield`-based loops were kept rather than reverted,
+   since `yield` plus a short poll timeout is just as reasonable a design
+   ([kaappi-net#4](https://github.com/kaappi/kaappi-net/pull/4),
+   [kaappi-pg#2](https://github.com/kaappi/kaappi-pg/pull/2)).


### PR DESCRIPTION
## Summary

Housekeeping close-out for [#1480](https://github.com/kaappi/kaappi/issues/1480).

The stale-comment cleanup #1480 tracked has already landed in both ecosystem
repos:

- **kaappi-net** ([kaappi-net#4](https://github.com/kaappi/kaappi-net/pull/4)) — `net.sld`'s TLS retry-loop comment
- **kaappi-pg** ([kaappi-pg#2](https://github.com/kaappi/kaappi-pg/pull/2)) — `pg.sld`'s async-plumbing retry-loop comment

Both comments now record that the core fix landed in #1463 — `threadSleepFn`
takes the same `dispatched_from_scheduler`-aware yield-retry path `waitForFd`
uses (`src/primitives_srfi18.zig:599`), so `thread-sleep!` is no longer
dangerous in a retry loop. The `yield`-based loops were kept rather than
reverted, since `yield` plus a short poll timeout is just as reasonable a
design.

This PR records the resolution on follow-up #4 in
`docs/dev/kep-0001-phase7-benchmarks.md`, mirroring the note added for #1478
in #1565. Docs-only change; no `.zig` files touched.

Closes #1480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)