### PR TITLE
Add `kaappi doctor` installation and environment self-check (#1513)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,11 @@ closure changed, falling back to a loud full run when the graph can't be trusted
 pipeline-stage dumps: `ast` prints post-read datums (`read`+`write`), `expand`
 prints the program after full macro expansion (round-trips), `ir` prints the IR
 tree (`--no-opt` = before the optimization passes); none execute program code —
-see `docs/dev/observing-the-pipeline.md`. Version is defined as `pub const version`
+see `docs/dev/observing-the-pipeline.md`. `kaappi doctor [--json]` runs an
+installation/environment self-check (binary, library search path, thottam state,
+native backend + smoke link, REPL, FFI) printing `PASS`/`WARN`/`FAIL` per check
+with a fix for each failure; exit is nonzero only on `FAIL` — see
+`docs/dev/doctor.md`. Version is defined as `pub const version`
 in `main.zig`. Environment: `KAAPPI_LIB_DIR` overrides `libkaappi_rt.a` lookup.
 
 Build-time options: `-Dmax-frames=N` (initial frame capacity, default 480, grows to 32768),

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -32,6 +32,7 @@ investigation produced analysis worth keeping.
 | [diagnostics.md](diagnostics.md) | Diagnostic `KP` codes: the registry, the taxonomy, the stability policy, how to add a code |
 | [diagnostics-json.md](diagnostics-json.md) | `--diagnostics=json`: the LSP `Diagnostic` JSON Lines schema shared by the CLI and the language server |
 | [explain.md](explain.md) | `kaappi explain <code>`: the binary's own offline diagnostic reference (prose + example + fix), and the generator for the kaappi-lang.org page |
+| [doctor.md](doctor.md) | `kaappi doctor`: installation/environment self-check — the checks, the exit-code contract, the native-backend smoke link |
 | [claude-code-harness.md](claude-code-harness.md) | Hooks, permissions, path-scoped rules, and skills for AI-assisted development |
 
 ## Design decisions

--- a/docs/dev/doctor.md
+++ b/docs/dev/doctor.md
@@ -1,0 +1,75 @@
+# `kaappi doctor` — installation and environment self-check
+
+`kaappi doctor` answers "why doesn't my setup work?" without a human tracing it
+by hand. "Why doesn't `(import (kaappi json))` work?" has a fixed set of answers
+— library-path resolution, thottam state, a missing native library, the wrong
+binary on PATH — so the toolchain checks itself and prints, per check, a
+`PASS`/`WARN`/`FAIL` line with a concrete suggestion on every failure.
+
+Part of the machine-legibility epic ([#1503](https://github.com/kaappi/kaappi/issues/1503));
+tracked in [#1513](https://github.com/kaappi/kaappi/issues/1513). Like
+[`kaappi explain`](explain.md) and [`kaappi test`](test-runner.md), it is a
+meta-command: it inspects the environment and runs no user code, so `main`
+dispatches it (`doctor.maybeRun`) before any VM, GC, or library setup exists.
+
+## What it checks
+
+| Group | Checks |
+|-------|--------|
+| `binary` | version, target triple, build mode, the running binary's path, and the `kaappi` a shell would pick from PATH (so a mismatch — "wrong binary on PATH" — is visible). |
+| `library` | the effective `.sld` search path in order: each `--lib-path`, the script directory (added per-run), `~/.kaappi/lib`, and the exe-relative `../lib` fallback — with whether each exists. |
+| `package-manager` | `thottam` on PATH; every package in `~/.kaappi/thottam.lock` has a matching source tree in `~/.kaappi/src`. |
+| `native-backend` | C-compiler discovery (`zig`/`cc`/`clang`/`gcc`), `libkaappi_rt.a` across the four documented locations, and a **smoke link** if both are found. |
+| `repl` | `~/.kaappi` writable (where history is saved); terminal capabilities (`isatty`, `TERM`). |
+| `ffi` | every `.dylib`/`.so` in `~/.kaappi/lib` is `dlopen`-able (per-file result, with the `dlerror` on failure). |
+
+Two forms: `kaappi doctor` (a human table, one line per check) and
+`kaappi doctor --json` (one object — `version`/`target`/`build_mode` meta, an
+overall `status`, an `ok` boolean, and a `checks` array of
+`{group,label,status,detail,suggestion}`). Both are produced from the same
+findings list, so they can never disagree.
+
+## The exit-code contract
+
+> Exit status is nonzero **only** when a check is `FAIL`.
+
+`WARN` describes a degraded-but-usable environment — a missing `~/.kaappi/lib`
+(no libraries installed yet), no C compiler (native compile unavailable), an
+`.so` that won't load — and keeps the exit code 0. Those are common, legitimate
+states, not broken installs, so they must not fail scripts or CI.
+
+Only one condition is `FAIL`: an explicit **`KAAPPI_LIB_DIR` that does not
+resolve** — the directory is missing, or it exists but has no `libkaappi_rt.a`.
+`KAAPPI_LIB_DIR`'s sole purpose is to point the native backend at a runtime
+library, so a set-but-wrong value is an unambiguous misconfiguration (the user
+asked for a specific location and it is not there) — worth failing loudly, with
+the suggestion to fix or unset it. Everything absent-by-default degrades to
+`WARN` instead. The shell test (`tests/scheme/doctor/doctor.sh`) drives exactly
+this: a bogus `KAAPPI_LIB_DIR` must exit 1; the healthy environment must exit 0.
+
+## The smoke link
+
+When both a C compiler and `libkaappi_rt.a` are found, doctor compiles and links
+a tiny C program that references one leaf runtime export (`kaappi_fixnum_add`)
+against the archive — the exact final step `kaappi compile` performs. A
+successful link proves the compiler works *and* the archive is well-formed and
+resolvable; the program is never executed. The compiler's own diagnostics are
+sent to `/dev/null` (only the link's exit status matters), and the temp files
+are removed. Under the unit-test binary the fork is skipped (`builtin.is_test`)
+so tests stay hermetic; the shell test exercises the real link.
+
+## Code layout
+
+- `src/doctor.zig` — the whole command: `maybeRun` (arg parsing + dispatch), the
+  `collect*` probes (one per group), the `Report`/`Finding` model, the smoke
+  link, and the text/JSON renderers. Detail and suggestion strings live in one
+  arena freed in a single `deinit`.
+- `src/main.zig` — dispatches `doctor.maybeRun` alongside `explain` and `test`,
+  before VM setup.
+- `src/kaappi_paths.zig` — `getHome` and `getExeRelativeLibDir`, the shared path
+  logic doctor reflects so its reported search path matches a real run's.
+
+The findings model keeps rendering testable off synthetic data: `overall` (most
+severe finding wins) and `exitCode` (nonzero iff any `FAIL`) are pure functions,
+and the text/JSON renderers take a `Report`, so the unit tests assert on both
+without touching the real environment.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -296,6 +296,7 @@ pub fn printUsage() void {
             "       kaappi explain <code>\n" ++
             "       kaappi test [paths...]\n" ++
             "       kaappi ast|expand|ir <file.scm>\n" ++
+            "       kaappi doctor [--json]\n" ++
             "\n" ++
             "Commands:\n" ++
             "  compile <file>     Compile to native binary via LLVM\n" ++
@@ -309,6 +310,8 @@ pub fn printUsage() void {
             "  expand <file>      Print the program after full macro expansion\n" ++
             "  ir <file> [--no-opt]  Print the IR tree; --no-opt shows it before the\n" ++
             "                     optimization passes (default: after)\n" ++
+            "  doctor [--json]    Check the installation and environment; PASS/WARN/FAIL\n" ++
+            "                     per check with a fix for each failure\n" ++
             "\n" ++
             "Options:\n" ++
             "  -h, --help         Show this help message\n" ++

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -19,13 +19,14 @@ const kaappi_bash =
     \\            return ;;
     \\    esac
     \\
-    \\    local has_compile=false has_explain=false has_test=false has_check=false has_ir=false
+    \\    local has_compile=false has_explain=false has_test=false has_check=false has_ir=false has_doctor=false
     \\    for word in "${COMP_WORDS[@]}"; do
     \\        [[ "$word" == "compile" ]] && has_compile=true
     \\        [[ "$word" == "explain" ]] && has_explain=true
     \\        [[ "$word" == "test" ]] && has_test=true
     \\        [[ "$word" == "check" ]] && has_check=true
     \\        [[ "$word" == "ir" ]] && has_ir=true
+    \\        [[ "$word" == "doctor" ]] && has_doctor=true
     \\    done
     \\
     \\    if $has_explain; then
@@ -48,6 +49,11 @@ const kaappi_bash =
     \\        return
     \\    fi
     \\
+    \\    if $has_doctor; then
+    \\        COMPREPLY=($(compgen -W "--json --lib-path" -- "$cur"))
+    \\        return
+    \\    fi
+    \\
     \\    if [[ "$cur" == -* ]]; then
     \\        COMPREPLY=($(compgen -W "-h --help --version --lib-path --compile --emit-llvm -o --disassemble --diagnostics=text --diagnostics=json --deny-warnings --sandbox --gc-stats --profile --profile-json --coverage --coverage-xml --timeout --max-memory --completions" -- "$cur"))
     \\        return
@@ -56,7 +62,7 @@ const kaappi_bash =
     \\    if $has_compile; then
     \\        COMPREPLY=($(compgen -f -X '!*.scm' -- "$cur") $(compgen -W "-o" -- "$cur"))
     \\    else
-    \\        COMPREPLY=($(compgen -W "compile check explain test ast expand ir" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
+    \\        COMPREPLY=($(compgen -W "compile check explain test ast expand ir doctor" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
     \\    fi
     \\}
     \\complete -o filenames -F _kaappi kaappi
@@ -93,7 +99,7 @@ const kaappi_zsh =
     \\
     \\    _arguments -s \
     \\        $flags \
-    \\        '1:command or file:_alternative "commands:command:(compile check explain test ast expand ir)" "files:file:_files -g \"*.scm\""' \
+    \\        '1:command or file:_alternative "commands:command:(compile check explain test ast expand ir doctor)" "files:file:_files -g \"*.scm\""' \
     \\        '*:script args:_files'
     \\}
     \\
@@ -129,6 +135,7 @@ const kaappi_fish =
     \\complete -c kaappi -a ast -d 'Print post-read datums (read + write)'
     \\complete -c kaappi -a expand -d 'Print the program after full macro expansion'
     \\complete -c kaappi -a ir -d 'Print the IR tree (--no-opt for pre-optimization)'
+    \\complete -c kaappi -a doctor -d 'Check the installation and environment (--json)'
     \\
 ;
 

--- a/src/doctor.zig
+++ b/src/doctor.zig
@@ -1,0 +1,884 @@
+//! `kaappi doctor` — installation and environment self-check
+//! (kaappi#1513, part of the machine-legibility epic kaappi#1503).
+//!
+//! "Why doesn't `(import (kaappi json))` work?" has a fixed set of answers —
+//! library-path resolution, thottam state, a missing native library, the wrong
+//! binary on PATH — that were previously diagnosed by hand. `doctor` runs those
+//! checks itself and prints, per check, a `PASS`/`WARN`/`FAIL` line with a
+//! concrete, actionable suggestion on every failure.
+//!
+//! Like `kaappi explain` and `kaappi test`, this is a meta-command: it inspects
+//! the environment and never runs user code, so main dispatches it before any
+//! VM, GC, or library setup exists (`maybeRun`).
+//!
+//! Forms:
+//!   kaappi doctor            human-readable table, one line per check
+//!   kaappi doctor --json     one JSON object (meta + a `checks` array)
+//!
+//! Exit code is nonzero only when a check is `FAIL` — a genuinely broken
+//! configuration (e.g. `KAAPPI_LIB_DIR` set to a directory with no runtime
+//! library). `WARN`-level findings (a missing `~/.kaappi/lib`, no C compiler on
+//! PATH) describe a degraded-but-usable environment and keep the exit code 0.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const reporting = @import("reporting.zig");
+const lsp_diagnostic = @import("lsp_diagnostic.zig");
+const kaappi_paths = @import("kaappi_paths.zig");
+const file_utils = @import("file_utils.zig");
+
+pub const version = @import("build_options").version;
+
+const writeStdout = reporting.writeStdout;
+const writeStderr = reporting.writeStderr;
+
+pub const USAGE_ERROR_EXIT: u8 = 2;
+
+/// The build's target triple and optimize mode are comptime-known, so they are
+/// module constants shared by the human table, the JSON meta, and the tests.
+const target_triple = @tagName(builtin.cpu.arch) ++ "-" ++ @tagName(builtin.os.tag) ++ "-" ++ @tagName(builtin.abi);
+const build_mode = @tagName(builtin.mode);
+
+// ── Findings model ───────────────────────────────────────────────────────────
+
+pub const Status = enum {
+    pass,
+    warn,
+    fail,
+
+    /// Fixed-width human label, so the status column in the table aligns.
+    pub fn label(self: Status) []const u8 {
+        return switch (self) {
+            .pass => "PASS",
+            .warn => "WARN",
+            .fail => "FAIL",
+        };
+    }
+
+    /// Lowercase machine label for `--json` (mirrors the `explain` convention).
+    pub fn jsonLabel(self: Status) []const u8 {
+        return switch (self) {
+            .pass => "pass",
+            .warn => "warn",
+            .fail => "fail",
+        };
+    }
+};
+
+pub const Finding = struct {
+    /// Check category, e.g. "binary", "library", "native-backend".
+    group: []const u8,
+    /// Short name of the individual check within the group.
+    label: []const u8,
+    status: Status,
+    /// Human-readable one-line result.
+    detail: []const u8,
+    /// Actionable fix; present only when the check did not pass cleanly.
+    suggestion: ?[]const u8 = null,
+};
+
+/// The overall verdict is the most severe finding: `fail` beats `warn` beats
+/// `pass`.
+pub fn overall(findings: []const Finding) Status {
+    var result: Status = .pass;
+    for (findings) |f| {
+        if (f.status == .fail) return .fail;
+        if (f.status == .warn) result = .warn;
+    }
+    return result;
+}
+
+/// Exit code contract: nonzero only when at least one check is `FAIL`.
+pub fn exitCode(findings: []const Finding) u8 {
+    for (findings) |f| {
+        if (f.status == .fail) return 1;
+    }
+    return 0;
+}
+
+/// Accumulates findings. Every detail/suggestion string is allocated in the
+/// arena, so the whole report is freed in one `deinit`.
+pub const Report = struct {
+    arena: std.heap.ArenaAllocator,
+    findings: std.ArrayList(Finding) = .empty,
+
+    pub fn init(base: std.mem.Allocator) Report {
+        return .{ .arena = std.heap.ArenaAllocator.init(base) };
+    }
+
+    pub fn deinit(self: *Report) void {
+        self.arena.deinit();
+    }
+
+    fn allocator(self: *Report) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+
+    /// Arena-format a string; falls back to a fixed marker on OOM so a probe
+    /// never has to error out over a detail line.
+    fn fmt(self: *Report, comptime f: []const u8, args: anytype) []const u8 {
+        return std.fmt.allocPrint(self.allocator(), f, args) catch "(out of memory)";
+    }
+
+    fn add(self: *Report, group: []const u8, item: []const u8, status: Status, detail: []const u8, suggestion: ?[]const u8) void {
+        self.findings.append(self.allocator(), .{
+            .group = group,
+            .label = item,
+            .status = status,
+            .detail = detail,
+            .suggestion = suggestion,
+        }) catch {};
+    }
+
+    pub fn items(self: *const Report) []const Finding {
+        return self.findings.items;
+    }
+};
+
+// ── Public entry ─────────────────────────────────────────────────────────────
+
+/// A parsed `kaappi doctor …` invocation.
+pub const Request = struct {
+    json: bool = false,
+    /// `--lib-path` entries, surfaced in the library-resolution check exactly as
+    /// a real run would prepend them to the search path.
+    lib_paths: [][]const u8 = &.{},
+};
+
+/// If `args` is a `kaappi doctor …` invocation, handle it fully and return the
+/// process exit code; otherwise return null so normal CLI dispatch proceeds.
+pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
+    var it = args.iterate();
+    _ = it.skip(); // argv[0]
+    const first = it.next() orelse return null;
+    if (!std.mem.eql(u8, first, "doctor")) return null;
+
+    var lib_paths: std.ArrayList([]const u8) = .empty;
+    defer lib_paths.deinit(allocator);
+
+    var req: Request = .{};
+    while (it.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--json")) {
+            req.json = true;
+        } else if (std.mem.eql(u8, arg, "--lib-path")) {
+            const value = it.next() orelse {
+                writeStderr("kaappi doctor: --lib-path requires a path argument\n");
+                return USAGE_ERROR_EXIT;
+            };
+            lib_paths.append(allocator, value) catch return 1;
+        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            printUsage();
+            return 0;
+        } else if (arg.len > 1 and arg[0] == '-') {
+            writeStderr("kaappi doctor: unknown option '");
+            writeStderr(arg);
+            writeStderr("'\nUsage: kaappi doctor [--json] [--lib-path <path>]\n");
+            return USAGE_ERROR_EXIT;
+        } else {
+            writeStderr("kaappi doctor: unexpected argument '");
+            writeStderr(arg);
+            writeStderr("'\nUsage: kaappi doctor [--json] [--lib-path <path>]\n");
+            return USAGE_ERROR_EXIT;
+        }
+    }
+    req.lib_paths = lib_paths.items;
+    return run(allocator, req);
+}
+
+/// Run every check and render the report; returns the process exit code.
+pub fn run(allocator: std.mem.Allocator, req: Request) u8 {
+    var report = Report.init(allocator);
+    defer report.deinit();
+
+    probeAll(&report, req.lib_paths);
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    (if (req.json) renderJson(&aw.writer, &report) else renderText(&aw.writer, &report)) catch {
+        writeStderr("kaappi doctor: out of memory\n");
+        return 1;
+    };
+    writeStdout(aw.written());
+
+    return exitCode(report.items());
+}
+
+/// Runs each check group in the order they appear in the human table.
+fn probeAll(report: *Report, lib_paths: []const []const u8) void {
+    collectBinary(report);
+    collectLibrary(report, lib_paths);
+    collectPackageManager(report);
+    collectNativeBackend(report);
+    collectRepl(report);
+    collectFfi(report);
+}
+
+// ── Checks ───────────────────────────────────────────────────────────────────
+
+fn collectBinary(r: *Report) void {
+    r.add("binary", "version", .pass, r.fmt("v{s}", .{version}), null);
+    r.add("binary", "target", .pass, target_triple, null);
+    r.add("binary", "build-mode", .pass, build_mode, null);
+
+    // Surface the running binary and the `kaappi` a shell would pick from PATH.
+    // Both are shown (never a WARN): when they differ, that IS the "wrong binary
+    // on PATH" diagnosis, and showing both lets the reader see it directly
+    // without doctor guessing which one they meant.
+    var exe_buf: [4096]u8 = undefined;
+    const running = kaappi_paths.getExePath(&exe_buf);
+    if (running) |ep| {
+        r.add("binary", "running", .pass, r.fmt("{s}", .{ep}), null);
+    }
+    if (findInPath(r.allocator(), "kaappi")) |on_path| {
+        const resolved = realpath(r.allocator(), on_path) orelse on_path;
+        const same = if (running) |ep| std.mem.eql(u8, ep, resolved) else false;
+        const note = if (running == null)
+            ""
+        else if (same)
+            " (same as running binary)"
+        else
+            " (differs from running binary — a bare `kaappi` runs this one)";
+        r.add("binary", "on-PATH", .pass, r.fmt("{s}{s}", .{ on_path, note }), null);
+    } else {
+        r.add("binary", "on-PATH", .pass, "kaappi is not on PATH (invoked by explicit path)", null);
+    }
+}
+
+fn collectLibrary(r: *Report, lib_paths: []const []const u8) void {
+    const a = r.allocator();
+
+    // 1. `--lib-path` entries, in the order they would be prepended.
+    for (lib_paths) |lp| {
+        if (dirExists(a, lp)) {
+            r.add("library", r.fmt("--lib-path {s}", .{lp}), .pass, "directory exists", null);
+        } else {
+            r.add("library", r.fmt("--lib-path {s}", .{lp}), .warn, "directory does not exist", r.fmt("create '{s}', or correct the --lib-path argument", .{lp}));
+        }
+    }
+
+    // 2. The script's own directory is added per-run when a file is given;
+    //    `doctor` has no file, so state that rather than omit it silently.
+    r.add("library", "script directory", .pass, "added to the search path at runtime when a file argument is given", null);
+
+    // 3. ~/.kaappi/lib — where thottam installs libraries.
+    var home_buf: [512]u8 = undefined;
+    if (kaappi_paths.getHome(&home_buf)) |home| {
+        const klib = r.fmt("{s}/lib", .{home});
+        if (dirExists(a, klib)) {
+            r.add("library", "~/.kaappi/lib", .pass, klib, null);
+        } else {
+            r.add("library", "~/.kaappi/lib", .warn, r.fmt("{s} (missing)", .{klib}), "run 'thottam install <pkg>' to install libraries there");
+        }
+    } else {
+        r.add("library", "~/.kaappi/lib", .warn, "cannot resolve: neither KAAPPI_HOME nor HOME is set", "set HOME (or KAAPPI_HOME) so ~/.kaappi/lib can be located");
+    }
+
+    // 4. <exe>/../lib — the from-source / installed-prefix fallback. Absence is
+    //    normal (an installed layout uses ~/.kaappi/lib), so never a WARN.
+    var exe_lib_buf: [1024]u8 = undefined;
+    if (kaappi_paths.getExeRelativeLibDir(&exe_lib_buf)) |elib| {
+        const detail = if (dirExists(a, elib))
+            r.fmt("{s}", .{elib})
+        else
+            r.fmt("{s} (absent — fallback only)", .{elib});
+        r.add("library", "exe-relative ../lib", .pass, detail, null);
+    }
+}
+
+fn collectPackageManager(r: *Report) void {
+    const a = r.allocator();
+
+    if (findInPath(a, "thottam")) |tp| {
+        r.add("package-manager", "thottam", .pass, r.fmt("found: {s}", .{tp}), null);
+    } else {
+        r.add("package-manager", "thottam", .warn, "not found on PATH", "thottam ships alongside kaappi; add its directory to PATH to install libraries");
+    }
+
+    var home_buf: [512]u8 = undefined;
+    const home = kaappi_paths.getHome(&home_buf) orelse {
+        // Without a home dir there is no lockfile to reconcile; the library
+        // check already warned about the same root cause.
+        return;
+    };
+    const lockfile = r.fmt("{s}/thottam.lock", .{home});
+    const src_dir = r.fmt("{s}/src", .{home});
+
+    const content = file_utils.readWholeFile(a, lockfile, 1 << 20) catch {
+        r.add("package-manager", "lockfile", .pass, "no lockfile (no packages installed via thottam)", null);
+        return;
+    };
+
+    var total: usize = 0;
+    var missing: usize = 0;
+    var first_missing: ?[]const u8 = null;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        // Each line is "<pkg> <sha> [source]"; the package name is the first token.
+        const pkg = line[0 .. std.mem.indexOfScalar(u8, line, ' ') orelse line.len];
+        if (pkg.len == 0) continue;
+        total += 1;
+        const pkg_dir = r.fmt("{s}/{s}", .{ src_dir, pkg });
+        if (!dirExists(a, pkg_dir)) {
+            missing += 1;
+            if (first_missing == null) first_missing = r.fmt("{s}", .{pkg});
+        }
+    }
+
+    if (total == 0) {
+        r.add("package-manager", "lockfile", .pass, "lockfile present but empty", null);
+    } else if (missing == 0) {
+        r.add("package-manager", "lockfile", .pass, r.fmt("{d} locked package(s) present in ~/.kaappi/src", .{total}), null);
+    } else {
+        r.add("package-manager", "lockfile", .warn, r.fmt("{d} of {d} locked package(s) missing from ~/.kaappi/src (first: {s})", .{ missing, total, first_missing.? }), "run 'thottam update' to restore missing package sources");
+    }
+}
+
+fn collectNativeBackend(r: *Report) void {
+    const a = r.allocator();
+
+    // C compiler discovery mirrors native_compiler's search order.
+    const compilers = [_][]const u8{ "zig", "cc", "clang", "gcc" };
+    var found_cc = false;
+    for (compilers) |cc| {
+        const cc_path = findInPath(a, cc) orelse continue;
+        found_cc = true;
+        const note = if (std.mem.eql(u8, cc, "zig")) " (links via 'zig cc')" else "";
+        r.add("native-backend", "c-compiler", .pass, r.fmt("{s}: {s}{s}", .{ cc, cc_path, note }), null);
+        break;
+    }
+    if (!found_cc) {
+        r.add("native-backend", "c-compiler", .warn, "none of zig, cc, clang, gcc found on PATH", "install zig (recommended), clang, or gcc to compile native binaries");
+    }
+
+    // `libkaappi_rt.a` lookup across the four documented locations, in the order
+    // native_compiler.findLibDir consults them.
+    var archive_dir: ?[]const u8 = null;
+
+    // An explicit KAAPPI_LIB_DIR that does not resolve is a definite
+    // misconfiguration — the user asked for a specific runtime library and it
+    // is not there — so it is the one FAIL-level finding doctor emits.
+    if (std.c.getenv("KAAPPI_LIB_DIR")) |env| {
+        const dir = std.mem.sliceTo(env, 0);
+        if (!dirExists(a, dir)) {
+            r.add("native-backend", "KAAPPI_LIB_DIR", .fail, r.fmt("{s} (directory does not exist)", .{dir}), "point KAAPPI_LIB_DIR at a directory containing libkaappi_rt.a, or unset it to use the default search");
+        } else if (hasArchive(a, dir)) {
+            archive_dir = dir;
+            r.add("native-backend", "KAAPPI_LIB_DIR", .pass, r.fmt("{s} (contains libkaappi_rt.a)", .{dir}), null);
+        } else {
+            r.add("native-backend", "KAAPPI_LIB_DIR", .fail, r.fmt("{s} (exists but has no libkaappi_rt.a)", .{dir}), "place libkaappi_rt.a in that directory, or unset KAAPPI_LIB_DIR to use the default search");
+        }
+    }
+
+    if (archive_dir == null) {
+        var exe_lib_buf: [1024]u8 = undefined;
+        if (kaappi_paths.getExeRelativeLibDir(&exe_lib_buf)) |elib| {
+            if (hasArchive(a, elib)) archive_dir = r.fmt("{s}", .{elib});
+        }
+    }
+    if (archive_dir == null) {
+        const candidates = [_][]const u8{ "zig-out/lib", "/usr/local/lib" };
+        for (candidates) |dir| {
+            if (hasArchive(a, dir)) {
+                archive_dir = dir;
+                break;
+            }
+        }
+    }
+
+    if (archive_dir) |dir| {
+        r.add("native-backend", "libkaappi_rt.a", .pass, r.fmt("found in {s}", .{dir}), null);
+    } else {
+        r.add("native-backend", "libkaappi_rt.a", .warn, "not found in KAAPPI_LIB_DIR, <exe>/../lib, zig-out/lib, or /usr/local/lib", "run 'zig build lib' in a source checkout, or install a release build that ships libkaappi_rt.a");
+    }
+
+    // Smoke link: prove the discovered compiler can actually link a program
+    // against the discovered archive. Only meaningful when both were found.
+    if (found_cc and archive_dir != null) {
+        smokeLink(r, archive_dir.?);
+    } else {
+        r.add("native-backend", "smoke-link", .pass, "skipped (needs both a C compiler and libkaappi_rt.a)", null);
+    }
+}
+
+fn collectRepl(r: *Report) void {
+    const a = r.allocator();
+
+    var home_buf: [512]u8 = undefined;
+    if (kaappi_paths.getHome(&home_buf)) |home| {
+        const hist = r.fmt("{s}/history", .{home});
+        // Writability is a property of the containing ~/.kaappi directory: the
+        // history file is created on first REPL exit, so it need not exist yet.
+        if (!dirExists(a, home)) {
+            r.add("repl", "history", .pass, r.fmt("{s} (parent ~/.kaappi created on first REPL/thottam use)", .{hist}), null);
+        } else if (dirWritable(a, home)) {
+            r.add("repl", "history", .pass, r.fmt("{s} (writable)", .{hist}), null);
+        } else {
+            r.add("repl", "history", .warn, r.fmt("{s} (~/.kaappi is not writable)", .{home}), "make ~/.kaappi writable so REPL history can be saved");
+        }
+    } else {
+        r.add("repl", "history", .warn, "cannot resolve ~/.kaappi (neither KAAPPI_HOME nor HOME set)", "set HOME (or KAAPPI_HOME) so REPL history has a home");
+    }
+
+    const stdin_tty = std.c.isatty(0) != 0;
+    const stdout_tty = std.c.isatty(1) != 0;
+    const term = if (std.c.getenv("TERM")) |t| std.mem.sliceTo(t, 0) else "(unset)";
+    r.add("repl", "terminal", .pass, r.fmt("stdin tty={s}, stdout tty={s}, TERM={s}", .{ boolStr(stdin_tty), boolStr(stdout_tty), term }), null);
+}
+
+fn collectFfi(r: *Report) void {
+    const a = r.allocator();
+
+    var home_buf: [512]u8 = undefined;
+    const home = kaappi_paths.getHome(&home_buf) orelse {
+        r.add("ffi", "native-libraries", .pass, "skipped: cannot resolve ~/.kaappi/lib", null);
+        return;
+    };
+    const lib_dir = r.fmt("{s}/lib", .{home});
+
+    const lib_dir_z = a.dupeZ(u8, lib_dir) catch {
+        r.add("ffi", "native-libraries", .pass, "skipped: out of memory", null);
+        return;
+    };
+    const dir = std.c.opendir(lib_dir_z) orelse {
+        r.add("ffi", "native-libraries", .pass, r.fmt("no native libraries ({s} not present)", .{lib_dir}), null);
+        return;
+    };
+    defer _ = std.c.closedir(dir);
+
+    var checked: usize = 0;
+    var failed: usize = 0;
+    while (std.c.readdir(dir)) |entry| {
+        const name_ptr: [*:0]const u8 = @ptrCast(&entry.name);
+        const name = std.mem.span(name_ptr);
+        if (!isNativeLibrary(name)) continue;
+        checked += 1;
+
+        const full = r.fmt("{s}/{s}", .{ lib_dir, name });
+        const full_z = a.dupeZ(u8, full) catch continue;
+        if (std.c.dlopen(full_z, std.c.RTLD{ .LAZY = true })) |handle| {
+            _ = std.c.dlclose(handle);
+            r.add("ffi", r.fmt("{s}", .{name}), .pass, "dlopen succeeded", null);
+        } else {
+            failed += 1;
+            const err = if (std.c.dlerror()) |e| std.mem.span(e) else "dlopen failed";
+            r.add("ffi", r.fmt("{s}", .{name}), .warn, r.fmt("{s}", .{err}), "rebuild or reinstall the library (its dependencies may be missing)");
+        }
+    }
+
+    if (checked == 0) {
+        r.add("ffi", "native-libraries", .pass, r.fmt("no native libraries (.dylib/.so) in {s}", .{lib_dir}), null);
+    } else if (failed == 0) {
+        r.add("ffi", "native-libraries", .pass, r.fmt("{d} native library(ies) loadable", .{checked}), null);
+    }
+}
+
+// ── Smoke link ───────────────────────────────────────────────────────────────
+
+/// Compile and link a tiny C program that references one leaf runtime export
+/// (`kaappi_fixnum_add`) against `libkaappi_rt.a`. A successful link proves the
+/// C compiler works and the archive is well-formed and resolvable — the exact
+/// path `kaappi compile` takes. The program is never executed.
+fn smokeLink(r: *Report, lib_dir: []const u8) void {
+    // Never fork a compiler from within the unit-test binary: `probeAll` runs
+    // this path, and tests must stay hermetic and fast. The shell test exercises
+    // the real link end-to-end.
+    if (builtin.is_test) {
+        r.add("native-backend", "smoke-link", .pass, "skipped (test build)", null);
+        return;
+    }
+
+    const a = r.allocator();
+
+    const tmp = if (std.c.getenv("TMPDIR")) |t| std.mem.sliceTo(t, 0) else "/tmp";
+
+    // Work inside a private 0700 directory with a random name (mkdtemp-style).
+    // `mkdir` refuses to reuse an existing name, so a hostile pre-planted
+    // symlink in a shared TMPDIR cannot redirect the C input or the
+    // compiler-written output; both live inside this directory.
+    const hex = randomHex();
+    const dir_path = r.fmt("{s}/kaappi-doctor-{s}", .{ tmp, hex[0..] });
+    const dir_z = a.dupeZ(u8, dir_path) catch return;
+    if (std.c.mkdir(dir_z, 0o700) != 0) {
+        r.add("native-backend", "smoke-link", .pass, r.fmt("skipped (cannot create temp dir in {s})", .{tmp}), null);
+        return;
+    }
+    defer _ = std.c.rmdir(dir_z);
+
+    const c_path = r.fmt("{s}/smoke.c", .{dir_path});
+    const out_path = r.fmt("{s}/smoke.out", .{dir_path});
+    const c_path_z = a.dupeZ(u8, c_path) catch return;
+    const out_path_z = a.dupeZ(u8, out_path) catch return;
+    defer _ = std.c.unlink(c_path_z);
+    defer _ = std.c.unlink(out_path_z);
+
+    const c_source =
+        \\extern unsigned long long kaappi_fixnum_add(unsigned long long, unsigned long long);
+        \\int main(void) { return (int)kaappi_fixnum_add(0, 0); }
+        \\
+    ;
+    const cfd = std.posix.openatZ(std.posix.AT.FDCWD, c_path_z, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true, .EXCL = true }, 0o600) catch {
+        r.add("native-backend", "smoke-link", .pass, r.fmt("skipped (cannot write temp file in {s})", .{tmp}), null);
+        return;
+    };
+    reporting.writeToFd(cfd, c_source);
+    _ = std.posix.system.close(cfd);
+
+    // A C compiler capable of driving the linker is required; `zig` needs the
+    // `cc` subcommand. Prefer zig cc (per the repo's linking rule), then cc.
+    const use_zig = findInPath(a, "zig") != null;
+    const cc = if (use_zig) (findInPath(a, "zig").?) else (findInPath(a, "cc") orelse findInPath(a, "clang") orelse findInPath(a, "gcc") orelse {
+        r.add("native-backend", "smoke-link", .pass, "skipped (no C compiler)", null);
+        return;
+    });
+
+    const lib_flag = r.fmt("-L{s}", .{lib_dir});
+
+    var argv: [16]?[*:0]const u8 = .{null} ** 16;
+    var argc: usize = 0;
+    const push = struct {
+        fn f(buf: *[16]?[*:0]const u8, n: *usize, alloc: std.mem.Allocator, s: []const u8) void {
+            if (n.* >= buf.len - 1) return;
+            buf[n.*] = alloc.dupeZ(u8, s) catch return;
+            n.* += 1;
+        }
+    }.f;
+
+    push(&argv, &argc, a, cc);
+    if (use_zig) push(&argv, &argc, a, "cc");
+    push(&argv, &argc, a, "-w");
+    push(&argv, &argc, a, c_path);
+    push(&argv, &argc, a, "-o");
+    push(&argv, &argc, a, out_path);
+    push(&argv, &argc, a, lib_flag);
+    push(&argv, &argc, a, "-lkaappi_rt");
+    push(&argv, &argc, a, "-lc");
+    push(&argv, &argc, a, "-lm");
+    push(&argv, &argc, a, "-lpthread");
+    argv[argc] = null;
+
+    const child = std.posix.system.fork();
+    if (child < 0) {
+        r.add("native-backend", "smoke-link", .pass, "skipped (fork failed)", null);
+        return;
+    }
+    if (child == 0) {
+        // Silence the compiler's own diagnostics so they don't pollute doctor's
+        // output; the link's exit status is all we inspect.
+        const devnull = std.posix.openatZ(std.posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .WRONLY }, 0) catch -1;
+        if (devnull >= 0) {
+            _ = std.c.dup2(devnull, 1);
+            _ = std.c.dup2(devnull, 2);
+        }
+        _ = std.posix.system.execve(@ptrCast(argv[0].?), @ptrCast(&argv), @ptrCast(std.c.environ));
+        std.process.exit(127);
+    }
+
+    var status: c_int = 0;
+    _ = std.c.waitpid(child, &status, 0);
+    const raw: c_uint = @bitCast(status);
+    const exited = (raw & 0x7f) == 0;
+    const code = (raw >> 8) & 0xff;
+    if (exited and code == 0) {
+        r.add("native-backend", "smoke-link", .pass, r.fmt("linked a test program against libkaappi_rt.a in {s}", .{lib_dir}), null);
+    } else {
+        r.add("native-backend", "smoke-link", .warn, "link against libkaappi_rt.a failed", "run 'kaappi compile <file.scm>' to see the linker error");
+    }
+}
+
+// ── Filesystem / PATH helpers ────────────────────────────────────────────────
+
+fn dirExists(a: std.mem.Allocator, path: []const u8) bool {
+    const path_z = a.dupeZ(u8, path) catch return false;
+    const fd = std.posix.openatZ(std.posix.AT.FDCWD, path_z, .{ .DIRECTORY = true }, 0) catch return false;
+    _ = std.posix.system.close(fd);
+    return true;
+}
+
+fn dirWritable(a: std.mem.Allocator, path: []const u8) bool {
+    const path_z = a.dupeZ(u8, path) catch return false;
+    return std.c.access(path_z, std.posix.W_OK) == 0;
+}
+
+fn fileExists(a: std.mem.Allocator, path: []const u8) bool {
+    const path_z = a.dupeZ(u8, path) catch return false;
+    const fd = std.posix.openatZ(std.posix.AT.FDCWD, path_z, .{ .ACCMODE = .RDONLY }, 0) catch return false;
+    _ = std.posix.system.close(fd);
+    return true;
+}
+
+fn hasArchive(a: std.mem.Allocator, dir: []const u8) bool {
+    const path = std.fmt.allocPrint(a, "{s}/libkaappi_rt.a", .{dir}) catch return false;
+    return fileExists(a, path);
+}
+
+/// Returns the first `<dir>/name` on PATH that opens for reading, allocated in
+/// `a`. Mirrors native_compiler's discovery so doctor and compile agree.
+fn findInPath(a: std.mem.Allocator, name: []const u8) ?[]const u8 {
+    const path_env = std.c.getenv("PATH") orelse return null;
+    const path_str = std.mem.sliceTo(path_env, 0);
+    var iter = std.mem.splitScalar(u8, path_str, ':');
+    while (iter.next()) |raw_dir| {
+        if (raw_dir.len == 0) continue;
+        // Trim trailing slashes so a "…/bin/" PATH entry doesn't render as
+        // "…/bin//kaappi" — this string is shown to the user.
+        const dir = std.mem.trimEnd(u8, raw_dir, "/");
+        if (dir.len == 0) continue;
+        const full = std.fmt.allocPrint(a, "{s}/{s}", .{ dir, name }) catch continue;
+        const full_z = a.dupeZ(u8, full) catch continue;
+        const fd = std.posix.openatZ(std.posix.AT.FDCWD, full_z, .{ .ACCMODE = .RDONLY }, 0) catch continue;
+        _ = std.posix.system.close(fd);
+        return full;
+    }
+    return null;
+}
+
+/// Canonicalizes `path` via realpath into an arena copy (or null on failure).
+fn realpath(a: std.mem.Allocator, path: []const u8) ?[]const u8 {
+    const path_z = a.dupeZ(u8, path) catch return null;
+    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    const resolved = std.c.realpath(path_z, &buf) orelse return null;
+    const len = std.mem.indexOfScalar(u8, resolved[0..buf.len], 0) orelse return null;
+    return a.dupe(u8, resolved[0..len]) catch null;
+}
+
+/// 16 lowercase hex chars of entropy for a private temp-dir name. Reads
+/// `/dev/urandom` (portable across macOS and Linux); falls back to the
+/// monotonic clock only if that device is unavailable.
+fn randomHex() [16]u8 {
+    var raw: [8]u8 = undefined;
+    if (std.posix.openatZ(std.posix.AT.FDCWD, "/dev/urandom", .{ .ACCMODE = .RDONLY }, 0)) |fd| {
+        const n = std.posix.read(fd, &raw) catch 0;
+        _ = std.posix.system.close(fd);
+        if (n == raw.len) return std.fmt.bytesToHex(raw, .lower);
+    } else |_| {}
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    const seed = @as(u64, @bitCast(ts.sec)) ^ @as(u64, @bitCast(ts.nsec));
+    std.mem.writeInt(u64, raw[0..8], seed, .little);
+    return std.fmt.bytesToHex(raw, .lower);
+}
+
+fn isNativeLibrary(name: []const u8) bool {
+    return std.mem.endsWith(u8, name, ".dylib") or
+        std.mem.endsWith(u8, name, ".so") or
+        std.mem.indexOf(u8, name, ".so.") != null;
+}
+
+fn boolStr(b: bool) []const u8 {
+    return if (b) "yes" else "no";
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+fn renderText(w: *std.Io.Writer, report: *const Report) std.Io.Writer.Error!void {
+    const findings = report.items();
+
+    try w.writeAll("kaappi doctor\n\n");
+
+    var prev_group: ?[]const u8 = null;
+    for (findings) |f| {
+        if (prev_group == null or !std.mem.eql(u8, prev_group.?, f.group)) {
+            if (prev_group != null) try w.writeByte('\n');
+            try w.print("{s}\n", .{f.group});
+            prev_group = f.group;
+        }
+        try w.print("  {s}  {s}: {s}\n", .{ f.status.label(), f.label, f.detail });
+        if (f.suggestion) |s| {
+            try w.print("        \u{2192} {s}\n", .{s});
+        }
+    }
+
+    var n_pass: usize = 0;
+    var n_warn: usize = 0;
+    var n_fail: usize = 0;
+    for (findings) |f| switch (f.status) {
+        .pass => n_pass += 1,
+        .warn => n_warn += 1,
+        .fail => n_fail += 1,
+    };
+
+    try w.print("\nSummary: {d} pass, {d} warn, {d} fail — ", .{ n_pass, n_warn, n_fail });
+    try w.writeAll(switch (overall(findings)) {
+        .pass => "environment looks healthy.\n",
+        .warn => "usable, but some checks need attention.\n",
+        .fail => "problems found; see FAIL lines above.\n",
+    });
+}
+
+fn renderJson(w: *std.Io.Writer, report: *const Report) std.Io.Writer.Error!void {
+    const findings = report.items();
+
+    try w.writeAll("{\"version\":");
+    try lsp_diagnostic.writeJsonString(w, version);
+    try w.writeAll(",\"target\":");
+    try lsp_diagnostic.writeJsonString(w, target_triple);
+    try w.writeAll(",\"build_mode\":");
+    try lsp_diagnostic.writeJsonString(w, build_mode);
+    try w.writeAll(",\"status\":");
+    try lsp_diagnostic.writeJsonString(w, overall(findings).jsonLabel());
+    try w.print(",\"ok\":{s}", .{if (exitCode(findings) == 0) "true" else "false"});
+    try w.writeAll(",\"checks\":[");
+    for (findings, 0..) |f, i| {
+        if (i > 0) try w.writeByte(',');
+        try w.writeAll("{\"group\":");
+        try lsp_diagnostic.writeJsonString(w, f.group);
+        try w.writeAll(",\"label\":");
+        try lsp_diagnostic.writeJsonString(w, f.label);
+        try w.writeAll(",\"status\":");
+        try lsp_diagnostic.writeJsonString(w, f.status.jsonLabel());
+        try w.writeAll(",\"detail\":");
+        try lsp_diagnostic.writeJsonString(w, f.detail);
+        try w.writeAll(",\"suggestion\":");
+        if (f.suggestion) |s| {
+            try lsp_diagnostic.writeJsonString(w, s);
+        } else {
+            try w.writeAll("null");
+        }
+        try w.writeByte('}');
+    }
+    try w.writeAll("]}\n");
+}
+
+fn printUsage() void {
+    writeStdout(
+        \\Usage: kaappi doctor [--json] [--lib-path <path>]
+        \\
+        \\Check the installation and environment: binary, library search path,
+        \\package manager, native backend, REPL, and FFI. Prints PASS/WARN/FAIL
+        \\per check, each failure with a concrete suggestion.
+        \\
+        \\  --json              Emit one JSON object (meta + a "checks" array).
+        \\  --lib-path <path>   Include a path in the library-resolution check,
+        \\                      exactly as a real run would prepend it.
+        \\
+        \\Exit status is nonzero only when a check is FAIL.
+        \\
+    );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "overall verdict is the most severe finding" {
+    try testing.expectEqual(Status.pass, overall(&.{
+        .{ .group = "g", .label = "a", .status = .pass, .detail = "" },
+    }));
+    try testing.expectEqual(Status.warn, overall(&.{
+        .{ .group = "g", .label = "a", .status = .pass, .detail = "" },
+        .{ .group = "g", .label = "b", .status = .warn, .detail = "" },
+    }));
+    try testing.expectEqual(Status.fail, overall(&.{
+        .{ .group = "g", .label = "a", .status = .warn, .detail = "" },
+        .{ .group = "g", .label = "b", .status = .fail, .detail = "" },
+    }));
+    try testing.expectEqual(Status.pass, overall(&.{}));
+}
+
+test "exit code is nonzero only when a finding is FAIL" {
+    try testing.expectEqual(@as(u8, 0), exitCode(&.{
+        .{ .group = "g", .label = "a", .status = .pass, .detail = "" },
+        .{ .group = "g", .label = "b", .status = .warn, .detail = "" },
+    }));
+    try testing.expectEqual(@as(u8, 1), exitCode(&.{
+        .{ .group = "g", .label = "a", .status = .warn, .detail = "" },
+        .{ .group = "g", .label = "b", .status = .fail, .detail = "" },
+    }));
+}
+
+test "isNativeLibrary matches platform shared-library names" {
+    try testing.expect(isNativeLibrary("libfoo.dylib"));
+    try testing.expect(isNativeLibrary("libfoo.so"));
+    try testing.expect(isNativeLibrary("libfoo.so.6"));
+    try testing.expect(!isNativeLibrary("foo.sld"));
+    try testing.expect(!isNativeLibrary("README.md"));
+    try testing.expect(!isNativeLibrary("libfoo.a"));
+}
+
+test "text render groups findings and prints a summary" {
+    var report = Report.init(testing.allocator);
+    defer report.deinit();
+    report.add("binary", "version", .pass, "v9.9.9", null);
+    report.add("native-backend", "libkaappi_rt.a", .warn, "not found", "run 'zig build lib'");
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try renderText(&aw.writer, &report);
+    const out = aw.written();
+
+    try testing.expect(std.mem.indexOf(u8, out, "kaappi doctor") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "binary") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "PASS  version: v9.9.9") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "WARN  libkaappi_rt.a: not found") != null);
+    // suggestion arrow line
+    try testing.expect(std.mem.indexOf(u8, out, "run 'zig build lib'") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1 pass, 1 warn, 0 fail") != null);
+}
+
+test "json render is one object with meta and a checks array" {
+    var report = Report.init(testing.allocator);
+    defer report.deinit();
+    report.add("binary", "version", .pass, "v9.9.9", null);
+    report.add("native-backend", "KAAPPI_LIB_DIR", .fail, "missing", "unset it");
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try renderJson(&aw.writer, &report);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+
+    try testing.expect(obj.get("version") != null);
+    try testing.expect(obj.get("target") != null);
+    try testing.expect(obj.get("build_mode") != null);
+    // A FAIL finding drives status=fail and ok=false.
+    try testing.expectEqualStrings("fail", obj.get("status").?.string);
+    try testing.expectEqual(false, obj.get("ok").?.bool);
+
+    const checks = obj.get("checks").?.array;
+    try testing.expectEqual(@as(usize, 2), checks.items.len);
+    try testing.expectEqualStrings("binary", checks.items[0].object.get("group").?.string);
+    try testing.expectEqualStrings("version", checks.items[0].object.get("label").?.string);
+    // A pass finding with no suggestion serializes suggestion as JSON null.
+    switch (checks.items[0].object.get("suggestion").?) {
+        .null => {},
+        else => return error.TestExpectedNullSuggestion,
+    }
+    try testing.expectEqualStrings("unset it", checks.items[1].object.get("suggestion").?.string);
+}
+
+test "json render marks ok=true when no finding fails" {
+    var report = Report.init(testing.allocator);
+    defer report.deinit();
+    report.add("binary", "version", .pass, "v9.9.9", null);
+    report.add("library", "~/.kaappi/lib", .warn, "missing", "install");
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try renderJson(&aw.writer, &report);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("warn", parsed.value.object.get("status").?.string);
+    try testing.expectEqual(true, parsed.value.object.get("ok").?.bool);
+}
+
+test "probeAll produces findings for every check group" {
+    var report = Report.init(testing.allocator);
+    defer report.deinit();
+    probeAll(&report, &.{});
+
+    const groups = [_][]const u8{ "binary", "library", "package-manager", "native-backend", "repl", "ffi" };
+    for (groups) |g| {
+        var seen = false;
+        for (report.items()) |f| {
+            if (std.mem.eql(u8, f.group, g)) {
+                seen = true;
+                break;
+            }
+        }
+        try testing.expect(seen);
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -47,6 +47,7 @@ pub const lsp_diagnostic = @import("lsp_diagnostic.zig");
 pub const cli = @import("cli.zig");
 pub const explain = @import("explain.zig");
 pub const test_runner = @import("test_runner.zig");
+pub const doctor = @import("doctor.zig");
 pub const check = @import("check.zig");
 pub const pipeline = @import("pipeline.zig");
 pub const config = @import("config.zig");
@@ -178,6 +179,12 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         // (The worker children are ordinary `kaappi <file>` runs; they are
         // recognized later by KAAPPI_TEST_EMIT in the file-run path.)
         if (test_runner.maybeRun(allocator, init.args)) |exit_code| {
+            std.process.exit(exit_code);
+        }
+        // `kaappi doctor` inspects the environment (paths, PATH, native
+        // toolchain, FFI libraries) and runs no user code, so it likewise
+        // dispatches before any VM/GC/library setup exists.
+        if (doctor.maybeRun(allocator, init.args)) |exit_code| {
             std.process.exit(exit_code);
         }
     }
@@ -1053,6 +1060,7 @@ test {
     _ = cli;
     _ = explain;
     _ = test_runner;
+    _ = doctor;
     _ = check;
     _ = @import("check_lint.zig");
     _ = @import("tests_check.zig");

--- a/tests/scheme/doctor/doctor.sh
+++ b/tests/scheme/doctor/doctor.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# `kaappi doctor` — installation and environment self-check (kaappi#1513).
+#
+# Covers the exit-code contract (nonzero only on FAIL-level findings), the human
+# and --json output shapes, and a deliberately broken environment: an explicit
+# KAAPPI_LIB_DIR that does not resolve is the one FAIL doctor emits.
+
+set -uo pipefail
+
+KAAPPI="${1:-${KAAPPI:-zig-out/bin/kaappi}}"
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1 — $2"; FAIL=$((FAIL + 1)); }
+
+# assert_exit <label> <expected> <cmd...> — run cmd, compare its exit status.
+assert_exit() {
+    local label="$1" expected="$2"
+    shift 2
+    local status=0
+    "$@" > "$TMP/out" 2> "$TMP/err" || status=$?
+    if [[ "$status" -eq "$expected" ]]; then
+        pass "$label"
+    else
+        fail "$label" "expected exit $expected, got $status"
+        cat "$TMP/out" "$TMP/err"
+    fi
+}
+
+# assert_contains <label> <needle> <cmd...> — run cmd, grep combined output.
+assert_contains() {
+    local label="$1" needle="$2"
+    shift 2
+    "$@" > "$TMP/out" 2> "$TMP/err"
+    if grep -qF -- "$needle" "$TMP/out" "$TMP/err"; then
+        pass "$label"
+    else
+        fail "$label" "output missing: $needle"
+        cat "$TMP/out" "$TMP/err"
+    fi
+}
+
+# The healthy environment must never FAIL: WARN-level findings (a missing
+# ~/.kaappi/lib or libkaappi_rt.a) are usable-but-degraded and keep exit 0.
+# KAAPPI_LIB_DIR is unset so the one FAIL condition can't fire.
+assert_exit    "healthy env exits 0"           0 env -u KAAPPI_LIB_DIR "$KAAPPI" doctor
+assert_contains "human output has a header"    "kaappi doctor" env -u KAAPPI_LIB_DIR "$KAAPPI" doctor
+assert_contains "human output has a summary"   "Summary:"      env -u KAAPPI_LIB_DIR "$KAAPPI" doctor
+assert_contains "reports every check group"    "native-backend" env -u KAAPPI_LIB_DIR "$KAAPPI" doctor
+
+# --json output shape.
+assert_exit    "json healthy exits 0"          0 env -u KAAPPI_LIB_DIR "$KAAPPI" doctor --json
+assert_contains "json has meta version"        '"version":'  env -u KAAPPI_LIB_DIR "$KAAPPI" doctor --json
+assert_contains "json has target triple"       '"target":'   env -u KAAPPI_LIB_DIR "$KAAPPI" doctor --json
+assert_contains "json has checks array"        '"checks":['  env -u KAAPPI_LIB_DIR "$KAAPPI" doctor --json
+assert_contains "json healthy is ok:true"      '"ok":true'   env -u KAAPPI_LIB_DIR "$KAAPPI" doctor --json
+
+# Deliberately broken environment: KAAPPI_LIB_DIR pointing at a nonexistent
+# directory. This is a definite misconfiguration, so it is FAIL → exit 1.
+BOGUS="$TMP/nonexistent-lib-dir"
+assert_exit    "bogus KAAPPI_LIB_DIR exits 1"  1 env KAAPPI_LIB_DIR="$BOGUS" "$KAAPPI" doctor
+assert_contains "bogus dir names the check"    "KAAPPI_LIB_DIR" env KAAPPI_LIB_DIR="$BOGUS" "$KAAPPI" doctor
+assert_contains "bogus dir reports FAIL"       "FAIL" env KAAPPI_LIB_DIR="$BOGUS" "$KAAPPI" doctor
+assert_contains "bogus json is ok:false"       '"ok":false'      env KAAPPI_LIB_DIR="$BOGUS" "$KAAPPI" doctor --json
+assert_contains "bogus json status is fail"    '"status":"fail"' env KAAPPI_LIB_DIR="$BOGUS" "$KAAPPI" doctor --json
+
+# A directory that exists but has no libkaappi_rt.a is equally a FAIL: the
+# explicit override resolves to a place with no runtime library.
+EMPTY="$TMP/empty-lib-dir"
+mkdir -p "$EMPTY"
+assert_exit    "empty KAAPPI_LIB_DIR exits 1"  1 env KAAPPI_LIB_DIR="$EMPTY" "$KAAPPI" doctor
+assert_contains "empty dir suggests a fix"     "libkaappi_rt.a" env KAAPPI_LIB_DIR="$EMPTY" "$KAAPPI" doctor
+
+# Usage handling.
+assert_exit    "--help exits 0"                0 "$KAAPPI" doctor --help
+assert_contains "--help prints usage"          "Usage: kaappi doctor" "$KAAPPI" doctor --help
+assert_exit    "unknown option exits 2"        2 "$KAAPPI" doctor --bogus-flag
+assert_exit    "unexpected argument exits 2"   2 "$KAAPPI" doctor stray-arg
+
+echo ""
+echo "$PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -157,6 +157,7 @@ run_shell_suite "Error tests" tests/scheme/errors
 run_shell_suite "Compile tests" tests/scheme/compile
 run_shell_suite "Test runner" tests/scheme/test-runner
 run_shell_suite "Pipeline dumps" tests/scheme/pipeline
+run_shell_suite "Doctor" tests/scheme/doctor
 
 echo "=== R7RS test suite ==="
 set +e


### PR DESCRIPTION
Closes #1513. Part of the machine-legibility epic #1503.

## What

`kaappi doctor [--json]` — an environment self-check that runs the fixed set of
checks behind "why doesn't `(import (kaappi json))` work?" so a broken setup is
diagnosable from documented CLI output alone. Like `explain`/`test` it inspects
the environment and runs no user code, dispatching before any VM/GC/library
setup exists.

Each check prints `PASS`/`WARN`/`FAIL` with an actionable fix on failure, in a
human table or one `--json` object (`version`/`target`/`build_mode` meta,
overall `status`, `ok` boolean, and a `checks[]` array).

| Group | Coverage |
|---|---|
| **binary** | version, target triple, build mode, running-binary path vs the `kaappi` on PATH |
| **library** | effective `.sld` search path in order (`--lib-path`, script dir, `~/.kaappi/lib`, exe-relative `../lib`) and each entry's existence |
| **package-manager** | `thottam` on PATH; every `thottam.lock` package present in `~/.kaappi/src` |
| **native-backend** | C-compiler discovery, `libkaappi_rt.a` across the four documented locations, and a real smoke link when both are found |
| **repl** | `~/.kaappi` writable, terminal capabilities |
| **ffi** | per-file `dlopen` of every `.dylib`/`.so` in `~/.kaappi/lib` |

## Exit-code contract

Nonzero **only** on `FAIL`. `WARN` is degraded-but-usable (no libraries yet, no
C compiler) and keeps exit 0. The one FAIL is an explicit `KAAPPI_LIB_DIR` that
does not resolve — an unambiguous misconfiguration. `KAAPPI_LIB_DIR` is reported
in the native-backend group where it actually governs `libkaappi_rt.a` lookup,
not conflated with `.sld` resolution (transparency over the issue's simplified
grouping).

## Smoke link

When a compiler and `libkaappi_rt.a` are both found, doctor compiles+links a
tiny C program referencing one leaf runtime export against the archive — the
exact final step `kaappi compile` performs; the program is never executed.
Runs in a private `0700` temp dir with a random name (defeats the shared-`/tmp`
symlink race) and is skipped under the unit-test binary so tests stay hermetic.

## Acceptance criteria

- [x] `doctor` subcommand with human and `--json` output
- [x] Exit nonzero only on FAIL-level findings
- [x] Shell test with a deliberately broken environment (`tests/scheme/doctor/doctor.sh`, 20 assertions)

## Testing

- Full unit suite green; `doctor.zig` unit tests cover status rollup, exit-code, JSON/text rendering (JSON parsed by `std.json`), and group coverage.
- `tests/scheme/doctor/doctor.sh` (registered in `run-all.sh`): 20/20 — healthy exit 0, bogus/empty `KAAPPI_LIB_DIR` exit 1, `--json` shape, usage handling.
- `zig build wasm` clean (doctor's native-only code is lazily excluded on wasm32-wasi).
- `zig fmt` clean; smoke link verified end-to-end with no stale temp dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)