### PR TITLE
Add `kaappi fmt` canonical comment-preserving formatter (#1518)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,13 @@ see `docs/dev/observing-the-pipeline.md`. `kaappi doctor [--json]` runs an
 installation/environment self-check (binary, library search path, thottam state,
 native backend + smoke link, REPL, FFI) printing `PASS`/`WARN`/`FAIL` per check
 with a fix for each failure; exit is nonzero only on `FAIL` — see
-`docs/dev/doctor.md`. Version is defined as `pub const version`
+`docs/dev/doctor.md`. `kaappi fmt [--check] files...` is the
+canonical, comment-preserving formatter (2-space R7RS indentation, single-space
+separators, closing parens gathered, reflowed to 80 cols): it rewrites files in
+place (or formats stdin to stdout), while `--check` writes nothing and exits
+nonzero listing paths that need formatting; every write is guarded by a
+real-reader `equal?` round-trip so it can never change a program — see
+`docs/dev/fmt.md`. Version is defined as `pub const version`
 in `main.zig`. Environment: `KAAPPI_LIB_DIR` overrides `libkaappi_rt.a` lookup.
 
 Build-time options: `-Dmax-frames=N` (initial frame capacity, default 480, grows to 32768),
@@ -246,6 +252,8 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 | `thottam.zig` | Package manager binary (thottam): install, remove, list, update, verify |
 | `llvm_emit.zig` | LLVM IR text emitter (walks IR nodes, produces `.ll` files) |
 | `runtime_exports.zig` | C-ABI bridge for LLVM native backend (21 exported functions) |
+| `fmt.zig` | `kaappi fmt`: comment-preserving CST reader (lexer + parser), CLI entry, real-reader `equal?` round-trip safety net |
+| `fmt_print.zig` | `kaappi fmt` layout engine: fits-or-breaks pretty-printer, special-form indentation rules |
 | `testing_helpers.zig` | Shared `makeTestVM` helper for unit tests |
 | `tests_ir.zig` | IR tests: bytecode parity, behavioral correctness, analysis, optimizations |
 | `tests_*.zig` | Unit tests by feature (core_eval, tail_calls, macros, io, etc.) |

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -26,6 +26,7 @@ investigation produced analysis worth keeping.
 | [adding-features.md](adding-features.md) | Step-by-step guides for the most common extension tasks |
 | [testing.md](testing.md) | The four test layers, how to run them, where new tests go |
 | [test-runner.md](test-runner.md) | `kaappi test`: the first-class SRFI-64 runner — discovery, worker subprocesses, `--json` schema, `--seed` |
+| [fmt.md](fmt.md) | `kaappi fmt`: the canonical comment-preserving formatter — the CST reader, the layout rules, the round-trip safety net, `--check` |
 | [fuzzing.md](fuzzing.md) | Fuzzing runbook: the targets, the scheduled CI job, turning a failure into a regression test |
 | [github-actions.md](github-actions.md) | Workflow hardening rules: SHA-pinned actions, `persist-credentials: false`, least-privilege tokens |
 | [gc-safety-and-error-handling.md](gc-safety-and-error-handling.md) | Rooting, write barriers, and error propagation patterns contributors must follow |

--- a/docs/dev/fmt.md
+++ b/docs/dev/fmt.md
@@ -1,0 +1,136 @@
+# `kaappi fmt` — the canonical formatter
+
+`kaappi fmt` lays Scheme source out in one canonical form. A canonical
+formatter makes diffs meaningful, ends style review, and gives agents
+format-on-save invariance — the same job `zig fmt` does for the compiler's own
+Zig. It is the final item of the machine-legibility epic (kaappi#1518, part of
+kaappi#1503).
+
+```
+kaappi fmt [--check] files...     # format each file in place
+kaappi fmt [--check]              # format stdin to stdout
+```
+
+* Without `--check`, each file is rewritten in place (only when its contents
+  actually change), and stdin is formatted to stdout.
+* With `--check`, nothing is written. Each path that is **not** already
+  formatted is printed, and the process exits non-zero if any file differs (or
+  fails to read/parse). This is the CI gate; the stdin form exits non-zero if
+  stdin is not already formatted.
+
+## What "canonical" means here
+
+* **2-space R7RS indentation.** Special forms indent their bodies two spaces
+  from the open paren; `define`/`lambda`/`let` bodies, `cond`/`case` clauses,
+  and the like follow the conventional Scheme shape (see *Layout rules*).
+* **Single-space separators.** Runs of spaces and tabs between elements collapse
+  to one space.
+* **Closing parens gathered.** A closing paren follows the last element on its
+  line — never dangling on a line of its own — unless a trailing line comment
+  forces it down.
+* **Reflowed to width.** A form that fits within `max_width` (80) columns is put
+  on one line; one that does not breaks. Layout depends only on the program's
+  content and its comments, **not** on the input's own line breaks, so two files
+  that differ only in whitespace format identically.
+* **Verbatim atoms.** Symbol, number, string, and character spellings are never
+  rewritten — `1.5e10`, `#xFF`, `#\newline`, `'x` vs `(quote x)` all pass
+  through untouched. The formatter rearranges whitespace *between* lexemes; it
+  never edits a lexeme.
+
+## Why it needs its own reader
+
+Comments are not datums, so the ordinary reader — which discards them — cannot
+drive a formatter. `fmt` has its own *concrete* syntax reader (`src/fmt.zig`):
+
+1. A **lexer** emits every lexeme, including the three comment kinds (`; line`,
+   `#| block |#`, `#;datum`) and the count of newlines before each lexeme (so
+   blank-line grouping and trailing-vs-leading comment placement survive).
+2. A **parser** builds a CST of `Node`s — lists/vectors, atoms, reader prefixes
+   (`'` `` ` `` `,` `,@` and datum labels `#3=`), datum comments, and line/block
+   comments — keeping every lexeme's text verbatim.
+3. The **printer** (`src/fmt_print.zig`) walks the CST and lays it out.
+
+The lexer mirrors the real reader's delimiter rules, and handles the awkward
+cases that make a naive tokenizer wrong: `#\(` / `#\;` / `#\ ` (a delimiter *is*
+the character), `#0#` and `#e#xFF` (interior `#`), strings and `|piped symbols|`
+that contain parens or semicolons, and nested `#| … |#`.
+
+## Layout rules
+
+When a list does not fit on one line it breaks in one of two shapes, chosen from
+its head:
+
+* **Body style** — `define`, `lambda`, `let`/`let*`/`letrec`, `when`, `unless`,
+  `begin`, `case`, `do`, `parameterize`, `guard`, `syntax-rules`,
+  `define-record-type`, `define-library`, and a few common macros
+  (`test-group`, `receive`): a fixed number of *distinguished* subforms stay on
+  the head line and the remaining **body** goes one item per line, indented two
+  spaces. `let` distinguishes its binding list; named `let` also distinguishes
+  the loop name.
+
+* **Call style** — function calls, `cond`, `and`/`or`, vectors, and any
+  unrecognised head: the first argument stays on the head line and the rest
+  align under it (the Emacs/`scmindent` default, the natural look for calls).
+
+The distinguished-subform table lives in `bodyDistinguished` in
+`src/fmt_print.zig`; unknown heads default to call style, so an unfamiliar macro
+formats predictably rather than wrongly.
+
+### Comments and blank lines
+
+A line comment forces its enclosing list to break and keeps the closing paren
+off its line. A comment on the same source line as the preceding datum stays
+*trailing*; on its own line it *leads* the next datum. A single blank line
+between body items or top-level forms is preserved (runs of blanks collapse to
+one); a blank before a subform that rides the head line is dropped. Everything
+else about layout is recomputed — that is what makes the output canonical.
+
+## The round-trip safety net
+
+Layout can only rearrange whitespace between lexemes, so the datums a program
+reads are invariant by construction. That invariant is *also checked at
+runtime*: before writing any file, `verifyRoundTrip` re-reads both the original
+and the formatted text **with the real reader** and compares the datum sequences
+with `equal?` (`primitives.deepEqual`). On any mismatch — or if either side
+fails to read — `fmt` refuses to write and reports an error. A bug in the
+lexer, parser, or printer can therefore never corrupt a source file; at worst a
+file is left unformatted.
+
+One consequence: a source whose datums cannot be compared this way — in
+practice, only a file containing a self-referential datum label the real reader
+builds into a cyclic structure that some readers cannot round-trip — is left
+untouched and reported, rather than reformatted. This is rare in hand-written
+program source.
+
+## Idempotence
+
+`fmt(fmt(x)) == fmt(x)`. This rests on two invariants, both under test:
+
+* `measure` (the fit predicate) and the inline emitter agree exactly on width.
+* Layout is a pure function of content and comments, never of the input's line
+  breaks. The one subtlety is blank lines: `hasBodyBlank` forces a break only
+  for a blank that layout will *preserve* (before an own-line item), so a
+  dropped blank never resurrects on the next pass and a preserved one always
+  re-forces the same break.
+
+## Tests
+
+* **`src/tests_fmt.zig`** — exact input→output cases, comment and blank-line
+  preservation, the idempotence property and semantics-preserving round-trip
+  over programs from the grammar fuzzer (`fuzz_gen`), and parser diagnostics.
+* **`tests/scheme/fmt/fmt.sh`** — CLI behaviour (write in place, `--check` exit
+  codes, stdin) plus two corpus-wide properties: formatting every `.scm`/`.sld`
+  under `tests/scheme/` and `lib/` has **zero semantic drift**, and the result
+  is **idempotent**.
+
+## CI adoption
+
+Ecosystem repos can gate formatting in CI with the check form:
+
+```yaml
+- name: Check formatting
+  run: kaappi fmt --check $(git ls-files '*.scm' '*.sld')
+```
+
+which exits non-zero (and prints the offending paths) when anything is
+unformatted.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -37,6 +37,7 @@ const FlagId = enum {
     max_memory,
     deny_warnings,
     no_opt,
+    check,
 };
 
 const FlagDesc = struct {
@@ -67,6 +68,7 @@ const flags = [_]FlagDesc{
     .{ .long = "--max-memory", .short = null, .takes_value = true, .id = .max_memory, .value_name = "bytes" },
     .{ .long = "--deny-warnings", .short = null, .takes_value = false, .id = .deny_warnings, .value_name = "" },
     .{ .long = "--no-opt", .short = null, .takes_value = false, .id = .no_opt, .value_name = "" },
+    .{ .long = "--check", .short = null, .takes_value = false, .id = .check, .value_name = "" },
 };
 
 fn lookupFlag(arg: []const u8) ?FlagDesc {
@@ -100,6 +102,10 @@ pub const Options = struct {
     expand_mode: bool = false,
     ir_mode: bool = false,
     ir_no_opt: bool = false,
+
+    // Canonical formatter (kaappi#1518): `kaappi fmt [--check] files...`.
+    fmt_mode: bool = false,
+    fmt_check: bool = false,
 
     compile_output: ?[]const u8 = null,
 
@@ -144,7 +150,8 @@ pub fn preScanSandbox(args: std.process.Args) bool {
         if (lookupFlag(arg)) |f| {
             if (f.takes_value) _ = iter.skip();
         } else if (std.mem.eql(u8, arg, "compile") or std.mem.eql(u8, arg, "check") or
-            std.mem.eql(u8, arg, "ast") or std.mem.eql(u8, arg, "expand") or std.mem.eql(u8, arg, "ir"))
+            std.mem.eql(u8, arg, "ast") or std.mem.eql(u8, arg, "expand") or
+            std.mem.eql(u8, arg, "ir") or std.mem.eql(u8, arg, "fmt"))
         {
             // bare subcommand — keep scanning
         } else if (std.mem.startsWith(u8, arg, diagnostics_prefix)) {
@@ -184,6 +191,11 @@ pub fn parse(args: std.process.Args) Options {
 
         if (std.mem.eql(u8, arg, "ir")) {
             opts.ir_mode = true;
+            continue;
+        }
+
+        if (std.mem.eql(u8, arg, "fmt")) {
+            opts.fmt_mode = true;
             continue;
         }
 
@@ -246,6 +258,7 @@ pub fn parse(args: std.process.Args) Options {
                 .max_memory => opts.max_memory = parsePositiveUsize(value.?, "--max-memory"),
                 .deny_warnings => opts.deny_warnings = true,
                 .no_opt => opts.ir_no_opt = true,
+                .check => opts.fmt_check = true,
             }
         } else if (arg.len > 1 and arg[0] == '-') {
             writeStderr("unknown option: ");
@@ -298,6 +311,7 @@ pub fn printUsage() void {
             "       kaappi test [paths...]\n" ++
             "       kaappi ast|expand|ir <file.scm>\n" ++
             "       kaappi doctor [--json]\n" ++
+            "       kaappi fmt [--check] [files...]\n" ++
             "\n" ++
             "Commands:\n" ++
             "  compile <file>     Compile to native binary via LLVM\n" ++
@@ -315,6 +329,9 @@ pub fn printUsage() void {
             "                     optimization passes (default: after)\n" ++
             "  doctor [--json]    Check the installation and environment; PASS/WARN/FAIL\n" ++
             "                     per check with a fix for each failure\n" ++
+            "  fmt [files...]     Canonically format Scheme in place; --check reports\n" ++
+            "                     paths needing formatting (exit 1) without writing.\n" ++
+            "                     With no files, formats stdin to stdout\n" ++
             "\n" ++
             "Options:\n" ++
             "  -h, --help         Show this help message\n" ++

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -19,7 +19,7 @@ const kaappi_bash =
     \\            return ;;
     \\    esac
     \\
-    \\    local has_compile=false has_explain=false has_test=false has_check=false has_ir=false has_doctor=false has_features=false
+    \\    local has_compile=false has_explain=false has_test=false has_check=false has_ir=false has_doctor=false has_features=false has_fmt=false
     \\    for word in "${COMP_WORDS[@]}"; do
     \\        [[ "$word" == "compile" ]] && has_compile=true
     \\        [[ "$word" == "explain" ]] && has_explain=true
@@ -28,6 +28,7 @@ const kaappi_bash =
     \\        [[ "$word" == "ir" ]] && has_ir=true
     \\        [[ "$word" == "doctor" ]] && has_doctor=true
     \\        [[ "$word" == "features" ]] && has_features=true
+    \\        [[ "$word" == "fmt" ]] && has_fmt=true
     \\    done
     \\
     \\    if $has_explain; then
@@ -60,6 +61,11 @@ const kaappi_bash =
     \\        return
     \\    fi
     \\
+    \\    if $has_fmt; then
+    \\        COMPREPLY=($(compgen -W "--check" -- "$cur") $(compgen -f -- "$cur"))
+    \\        return
+    \\    fi
+    \\
     \\    if [[ "$cur" == -* ]]; then
     \\        COMPREPLY=($(compgen -W "-h --help --version --lib-path --compile --emit-llvm -o --disassemble --diagnostics=text --diagnostics=json --deny-warnings --sandbox --gc-stats --profile --profile-json --coverage --coverage-xml --timeout --max-memory --completions" -- "$cur"))
     \\        return
@@ -68,7 +74,7 @@ const kaappi_bash =
     \\    if $has_compile; then
     \\        COMPREPLY=($(compgen -f -X '!*.scm' -- "$cur") $(compgen -W "-o" -- "$cur"))
     \\    else
-    \\        COMPREPLY=($(compgen -W "compile check explain features test ast expand ir doctor" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
+    \\        COMPREPLY=($(compgen -W "compile check explain features test ast expand ir doctor fmt" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
     \\    fi
     \\}
     \\complete -o filenames -F _kaappi kaappi
@@ -100,12 +106,13 @@ const kaappi_zsh =
     \\        '--timeout[Execution timeout in milliseconds]:ms:'
     \\        '--max-memory[Maximum heap memory in bytes]:bytes:'
     \\        '--no-opt[(ir) Show the IR before the optimization passes]'
+    \\        '--check[(fmt) Report files needing formatting without writing]'
     \\        '--completions[Output shell completion script]:shell:(bash zsh fish)'
     \\    )
     \\
     \\    _arguments -s \
     \\        $flags \
-    \\        '1:command or file:_alternative "commands:command:(compile check explain features test ast expand ir doctor)" "files:file:_files -g \"*.scm\""' \
+    \\        '1:command or file:_alternative "commands:command:(compile check explain features test ast expand ir doctor fmt)" "files:file:_files -g \"*.scm\""' \
     \\        '*:script args:_files'
     \\}
     \\
@@ -133,6 +140,7 @@ const kaappi_fish =
     \\complete -c kaappi -l max-memory -r -x -d 'Maximum heap memory in bytes'
     \\complete -c kaappi -l deny-warnings -d '(check) Treat lint warnings as errors'
     \\complete -c kaappi -l no-opt -d '(ir) Show the IR before the optimization passes'
+    \\complete -c kaappi -l check -d '(fmt) Report files needing formatting without writing'
     \\complete -c kaappi -l completions -r -x -a 'bash zsh fish' -d 'Output shell completion script'
     \\complete -c kaappi -a compile -d 'Compile to native binary via LLVM'
     \\complete -c kaappi -a check -d 'Compile-only static analysis (no execution)'
@@ -143,6 +151,7 @@ const kaappi_fish =
     \\complete -c kaappi -a expand -d 'Print the program after full macro expansion'
     \\complete -c kaappi -a ir -d 'Print the IR tree (--no-opt for pre-optimization)'
     \\complete -c kaappi -a doctor -d 'Check the installation and environment (--json)'
+    \\complete -c kaappi -a fmt -d 'Canonically format Scheme (--check for CI)'
     \\
 ;
 

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -1,0 +1,603 @@
+//! `kaappi fmt` — canonical, comment-preserving Scheme formatter (kaappi#1518,
+//! the final item of the machine-legibility epic kaappi#1503).
+//!
+//! A canonical formatter makes diffs meaningful, ends style review, and gives
+//! agents format-on-save invariance. `zig fmt` does this for the compiler's Zig;
+//! nothing did it for Scheme. `kaappi fmt` fills that gap:
+//!
+//!   kaappi fmt [--check] files...     # format in place, or check for CI
+//!   kaappi fmt [--check]              # read stdin, write stdout (or check)
+//!
+//! **Design.** Comments are not datums, so the ordinary reader (which discards
+//! them) cannot drive a formatter. This module has its own *concrete* syntax
+//! reader: a lexer (`Lexer`) that emits every lexeme — including line comments,
+//! block comments, `#;` datum comments, and the blank-line structure between
+//! them — and a parser (`Parser`) that builds a CST (`Node`) preserving all of
+//! it. Atom text is kept verbatim, so number/character/string spellings are
+//! never rewritten. `fmt_print.zig` walks the CST and lays it out canonically:
+//! 2-space R7RS indentation, single-space separators, closing parens gathered,
+//! forms reflowed to fit `max_width` columns.
+//!
+//! **Safety.** Layout can only rearrange whitespace *between* lexemes, never
+//! change them, so the datums a program reads are invariant. That invariant is
+//! also *checked at runtime*: before writing any file, `verifyRoundTrip` re-reads
+//! the original and the formatted text with the real reader and compares the
+//! datum sequences with `equal?`. On any mismatch — or if either side fails to
+//! read — `fmt` refuses to write and reports it, so a bug here can never corrupt
+//! a source file.
+
+const std = @import("std");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const reader_mod = @import("reader.zig");
+const primitives = @import("primitives.zig");
+const reporting = @import("reporting.zig");
+const file_utils = @import("file_utils.zig");
+const fmt_print = @import("fmt_print.zig");
+
+const Value = types.Value;
+const writeStdout = reporting.writeStdout;
+const writeStderr = reporting.writeStderr;
+
+const is_wasm = @import("builtin").os.tag == .wasi;
+
+/// Largest file `fmt` will touch. Formatting is whole-file, so an oversized
+/// source is rejected rather than partially processed.
+const max_file_bytes: usize = 8 * 1024 * 1024;
+
+// ── CST ───────────────────────────────────────────────────────────────────
+
+pub const NodeKind = enum {
+    /// A datum atom kept verbatim: symbol, number, string, character, boolean,
+    /// `|piped symbol|`, `#t`/`#f`, a datum-label reference `#3#`, or a lone `.`.
+    atom,
+    /// A parenthesised list `( … )` or a vector/bytevector `#( … )` / `#u8( … )`.
+    /// `text` is the opening delimiter; the close is always `)`.
+    list,
+    /// A reader prefix glued to exactly one following datum: `'`, `` ` ``, `,`,
+    /// `,@`, or a datum-label definition `#3=`. `children[0]` is the datum.
+    prefix,
+    /// `#;` datum comment: `children[0]` is the commented-out (but preserved)
+    /// datum. It contributes no datum to a read of the program.
+    datum_comment,
+    /// A `; …` line comment (text excludes the trailing newline).
+    line_comment,
+    /// A `#| … |#` block comment (text is verbatim, may span lines).
+    block_comment,
+};
+
+pub const Node = struct {
+    kind: NodeKind,
+    /// Verbatim source for atoms/comments; the opening delimiter for lists;
+    /// the prefix characters for prefixes; `"#;"` for datum comments.
+    text: []const u8 = "",
+    /// List elements (may include interspersed comments); the single target of
+    /// a prefix or datum comment; empty for atoms and comments.
+    children: []Node = &.{},
+    /// Number of newlines in the whitespace immediately preceding this node's
+    /// first lexeme. 0 = same line as the previous lexeme; ≥2 = a blank line
+    /// separated them. Drives trailing-vs-leading comment placement and
+    /// blank-line grouping; ordinary code layout is otherwise reflowed.
+    newlines_before: u32 = 0,
+    /// A `#(` / `#u8(` literal, whose first element is data, never an operator.
+    is_data: bool = false,
+    /// Memoised inline width (see `fmt_print`), so fit checks stay linear.
+    inline_width: ?usize = null,
+    width_computed: bool = false,
+};
+
+pub const ParseError = error{
+    UnterminatedList,
+    UnterminatedString,
+    UnterminatedBlockComment,
+    UnexpectedRightParen,
+    DanglingPrefix,
+    NestingTooDeep,
+    OutOfMemory,
+};
+
+const max_nesting: u32 = 1024;
+
+// ── Lexer ───────────────────────────────────────────────────────────────────
+
+const TokKind = enum {
+    lparen,
+    rparen,
+    list_open, // "#(" or "#u8("
+    atom,
+    prefix, // ' ` , ,@ #N=
+    datum_comment, // #;
+    line_comment,
+    block_comment,
+    eof,
+};
+
+const Tok = struct {
+    kind: TokKind,
+    text: []const u8,
+    newlines_before: u32,
+};
+
+const Lexer = struct {
+    src: []const u8,
+    pos: usize = 0,
+
+    fn isSpace(c: u8) bool {
+        return c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == 0x0c;
+    }
+
+    /// A boundary between atoms. Mirrors `reader.Reader.isDelimiter` so the
+    /// formatter carves the same lexemes the real reader does.
+    fn isDelimiter(c: u8) bool {
+        return isSpace(c) or c == '(' or c == ')' or c == '"' or c == ';' or c == '|';
+    }
+
+    /// Consume whitespace, returning the newline count. Whitespace-only runs and
+    /// blank lines are recovered from this count, not stored verbatim.
+    fn skipSpace(self: *Lexer) u32 {
+        var newlines: u32 = 0;
+        while (self.pos < self.src.len and isSpace(self.src[self.pos])) : (self.pos += 1) {
+            if (self.src[self.pos] == '\n') newlines += 1;
+        }
+        return newlines;
+    }
+
+    fn next(self: *Lexer) ParseError!Tok {
+        const nl = self.skipSpace();
+        if (self.pos >= self.src.len) return .{ .kind = .eof, .text = "", .newlines_before = nl };
+        const start = self.pos;
+        const c = self.src[self.pos];
+        const kind: TokKind = switch (c) {
+            '(' => blk: {
+                self.pos += 1;
+                break :blk .lparen;
+            },
+            ')' => blk: {
+                self.pos += 1;
+                break :blk .rparen;
+            },
+            '\'', '`' => blk: {
+                self.pos += 1;
+                break :blk .prefix;
+            },
+            ',' => blk: {
+                self.pos += 1;
+                if (self.pos < self.src.len and self.src[self.pos] == '@') self.pos += 1;
+                break :blk .prefix;
+            },
+            ';' => blk: {
+                while (self.pos < self.src.len and self.src[self.pos] != '\n') self.pos += 1;
+                break :blk .line_comment;
+            },
+            '"' => blk: {
+                try self.scanString();
+                break :blk .atom;
+            },
+            '|' => blk: {
+                try self.scanPipe();
+                break :blk .atom;
+            },
+            '#' => try self.scanHash(),
+            else => blk: {
+                self.scanAtom();
+                break :blk .atom;
+            },
+        };
+        return .{ .kind = kind, .text = self.src[start..self.pos], .newlines_before = nl };
+    }
+
+    /// A `#`-led lexeme: block comment, datum comment, vector/bytevector open,
+    /// character literal, datum-label prefix/reference, or a `#`-atom (`#t`,
+    /// `#xFF`, …). `self.pos` is at the `#`.
+    fn scanHash(self: *Lexer) ParseError!TokKind {
+        const rest = self.src[self.pos..];
+        if (rest.len >= 2 and rest[1] == '|') {
+            try self.scanBlockComment();
+            return .block_comment;
+        }
+        if (rest.len >= 2 and rest[1] == ';') {
+            self.pos += 2;
+            return .datum_comment;
+        }
+        if (rest.len >= 2 and rest[1] == '(') {
+            self.pos += 2;
+            return .list_open;
+        }
+        if (rest.len >= 4 and std.mem.eql(u8, rest[0..4], "#u8(")) {
+            self.pos += 4;
+            return .list_open;
+        }
+        if (rest.len >= 2 and rest[1] == '\\') {
+            self.scanChar();
+            return .atom;
+        }
+        // Datum-label definition `#N=` is a prefix on the following datum; a
+        // reference `#N#` is a standalone atom. Both are rare; anything else
+        // `#`-led is an ordinary atom (booleans, radix/exactness numbers).
+        if (rest.len >= 2 and std.ascii.isDigit(rest[1])) {
+            var i: usize = 1;
+            while (i < rest.len and std.ascii.isDigit(rest[i])) i += 1;
+            if (i < rest.len and rest[i] == '=') {
+                self.pos += i + 1;
+                return .prefix;
+            }
+        }
+        self.scanAtom();
+        return .atom;
+    }
+
+    fn scanAtom(self: *Lexer) void {
+        // `#` dispatches specially only at a token boundary (see `scanHash`), so
+        // as an interior constituent it is ordinary: this keeps `#0#` (a datum
+        // label reference) and `#e#xFF` (stacked prefixes) single atoms.
+        self.pos += 1;
+        while (self.pos < self.src.len and !isDelimiter(self.src[self.pos])) {
+            self.pos += 1;
+        }
+    }
+
+    fn scanString(self: *Lexer) ParseError!void {
+        self.pos += 1; // opening "
+        while (self.pos < self.src.len) {
+            const c = self.src[self.pos];
+            if (c == '\\') {
+                self.pos += 2; // escape: skip the escaped byte too
+                continue;
+            }
+            self.pos += 1;
+            if (c == '"') return;
+        }
+        return ParseError.UnterminatedString;
+    }
+
+    fn scanPipe(self: *Lexer) ParseError!void {
+        self.pos += 1; // opening |
+        while (self.pos < self.src.len) {
+            const c = self.src[self.pos];
+            if (c == '\\') {
+                self.pos += 2;
+                continue;
+            }
+            self.pos += 1;
+            if (c == '|') return;
+        }
+        return ParseError.UnterminatedString;
+    }
+
+    /// `#\…` — the escaped char may itself be a delimiter (`#\(`, `#\;`, `#\ `),
+    /// so consume it unconditionally; a *named* char (`#\space`, `#\x41`) then
+    /// continues over its alphanumeric tail.
+    fn scanChar(self: *Lexer) void {
+        self.pos += 2; // #\
+        if (self.pos >= self.src.len) return;
+        const first = self.src[self.pos];
+        if (first < 0x80) {
+            self.pos += 1;
+        } else {
+            const seq = std.unicode.utf8ByteSequenceLength(first) catch 1;
+            self.pos += @min(seq, self.src.len - self.pos);
+        }
+        if (std.ascii.isAlphabetic(first)) {
+            while (self.pos < self.src.len and std.ascii.isAlphanumeric(self.src[self.pos])) self.pos += 1;
+        }
+    }
+
+    fn scanBlockComment(self: *Lexer) ParseError!void {
+        self.pos += 2; // #|
+        var depth: usize = 1;
+        while (self.pos + 1 < self.src.len) {
+            if (self.src[self.pos] == '#' and self.src[self.pos + 1] == '|') {
+                depth += 1;
+                self.pos += 2;
+            } else if (self.src[self.pos] == '|' and self.src[self.pos + 1] == '#') {
+                depth -= 1;
+                self.pos += 2;
+                if (depth == 0) return;
+            } else {
+                self.pos += 1;
+            }
+        }
+        return ParseError.UnterminatedBlockComment;
+    }
+};
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+const Parser = struct {
+    lexer: Lexer,
+    arena: std.mem.Allocator,
+    depth: u32 = 0,
+
+    fn take(self: *Parser) ParseError!Tok {
+        return self.lexer.next();
+    }
+
+    /// Parse the whole program: a sequence of top-level nodes until EOF.
+    fn parseProgram(self: *Parser) ParseError![]Node {
+        var out: std.ArrayList(Node) = .empty;
+        while (true) {
+            const tok = try self.take();
+            if (tok.kind == .eof) break;
+            if (tok.kind == .rparen) return ParseError.UnexpectedRightParen;
+            const node = try self.nodeFromTok(tok);
+            try out.append(self.arena, node);
+        }
+        return out.toOwnedSlice(self.arena);
+    }
+
+    /// Parse list elements until the matching `)`.
+    fn parseList(self: *Parser, open: Tok, is_data: bool) ParseError!Node {
+        if (self.depth >= max_nesting) return ParseError.NestingTooDeep;
+        self.depth += 1;
+        defer self.depth -= 1;
+
+        var out: std.ArrayList(Node) = .empty;
+        while (true) {
+            const tok = try self.take();
+            switch (tok.kind) {
+                .eof => return ParseError.UnterminatedList,
+                .rparen => break,
+                else => try out.append(self.arena, try self.nodeFromTok(tok)),
+            }
+        }
+        return .{
+            .kind = .list,
+            .text = open.text,
+            .children = try out.toOwnedSlice(self.arena),
+            .newlines_before = open.newlines_before,
+            .is_data = is_data,
+        };
+    }
+
+    /// Build a node from an already-taken token, recursing for lists and for the
+    /// single datum a prefix / datum comment binds to.
+    fn nodeFromTok(self: *Parser, tok: Tok) ParseError!Node {
+        switch (tok.kind) {
+            .lparen => return self.parseList(tok, false),
+            .list_open => return self.parseList(tok, true),
+            .atom, .line_comment, .block_comment => return .{
+                .kind = switch (tok.kind) {
+                    .line_comment => .line_comment,
+                    .block_comment => .block_comment,
+                    else => .atom,
+                },
+                // Trailing whitespace inside a line comment is invisible and
+                // never part of a datum; strip it so the output has no trailing
+                // spaces. Block comment and atom text stays byte-for-byte.
+                .text = if (tok.kind == .line_comment)
+                    std.mem.trimEnd(u8, tok.text, " \t")
+                else
+                    tok.text,
+                .newlines_before = tok.newlines_before,
+            },
+            .prefix, .datum_comment => {
+                const target = try self.parsePrefixTarget();
+                const child = try self.arena.alloc(Node, 1);
+                child[0] = target;
+                return .{
+                    .kind = if (tok.kind == .prefix) .prefix else .datum_comment,
+                    .text = if (tok.kind == .datum_comment) "#;" else tok.text,
+                    .children = child,
+                    .newlines_before = tok.newlines_before,
+                };
+            },
+            .eof, .rparen => unreachable, // handled by callers
+        }
+    }
+
+    /// The datum a prefix binds to. A prefix immediately followed by a comment
+    /// (rather than a datum) is degenerate; binding to it verbatim keeps the CST
+    /// simple, and the round-trip check catches any resulting divergence.
+    fn parsePrefixTarget(self: *Parser) ParseError!Node {
+        const tok = try self.take();
+        return switch (tok.kind) {
+            .eof, .rparen => ParseError.DanglingPrefix,
+            else => self.nodeFromTok(tok),
+        };
+    }
+};
+
+/// Parse `source` into a top-level CST node sequence. Caller owns nothing —
+/// everything is arena-allocated.
+pub fn parse(arena: std.mem.Allocator, source: []const u8) ParseError![]Node {
+    var p = Parser{ .lexer = .{ .src = source }, .arena = arena };
+    return p.parseProgram();
+}
+
+// ── Public formatting API ────────────────────────────────────────────────────
+
+/// Format `source` into a fresh, canonical string (arena-allocated). Does *not*
+/// verify semantic preservation — callers that write to disk must go through
+/// `formatFile`, which does.
+pub fn formatSource(arena: std.mem.Allocator, source: []const u8) ParseError![]u8 {
+    const nodes = try parse(arena, source);
+    return fmt_print.print(arena, nodes);
+}
+
+/// True when `original` and `formatted` read to `equal?` datum sequences. This
+/// is the safety net: layout must never change the program a reader sees. Any
+/// read failure on either side (or a length/element mismatch) returns false, so
+/// the caller refuses to write.
+pub fn verifyRoundTrip(gc: *memory.GC, original: []const u8, formatted: []const u8) bool {
+    const roots_base = gc.extra_roots.items.len;
+    defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
+
+    var orig_list: std.ArrayList(Value) = .empty;
+    defer orig_list.deinit(gc.allocator);
+    if (!readAllRooted(gc, original, &orig_list)) return false;
+
+    var fmt_list: std.ArrayList(Value) = .empty;
+    defer fmt_list.deinit(gc.allocator);
+    if (!readAllRooted(gc, formatted, &fmt_list)) return false;
+
+    if (orig_list.items.len != fmt_list.items.len) return false;
+    for (orig_list.items, fmt_list.items) |a, b| {
+        if (!primitives.deepEqual(a, b)) return false;
+    }
+    return true;
+}
+
+/// Read every datum from `source`, appending to `out` and mirroring each into
+/// `gc.extra_roots` so a later read's allocations cannot collect earlier datums.
+/// Returns false on any read error.
+fn readAllRooted(gc: *memory.GC, source: []const u8, out: *std.ArrayList(Value)) bool {
+    var r = reader_mod.Reader.init(gc, source);
+    defer r.deinit();
+    while (r.hasMore() catch return false) {
+        const datum = r.readDatum() catch return false;
+        out.append(gc.allocator, datum) catch return false;
+        gc.extra_roots.append(gc.allocator, datum) catch return false;
+    }
+    return true;
+}
+
+// ── CLI entry ────────────────────────────────────────────────────────────────
+
+pub const Options = struct {
+    check: bool = false,
+    files: []const []const u8 = &.{},
+};
+
+/// `kaappi fmt [--check] [files...]`. With no files, reads stdin and writes the
+/// formatted result to stdout (`--check` instead exits nonzero if it differs).
+/// Returns the process exit code.
+pub fn run(gc: *memory.GC, opts: Options) u8 {
+    if (opts.files.len == 0) return runStdin(gc, opts.check);
+
+    var any_error = false;
+    var any_changed = false;
+    for (opts.files) |path| {
+        switch (formatFile(gc, path, opts.check)) {
+            .ok => {},
+            .changed => any_changed = true,
+            .failed => any_error = true,
+        }
+    }
+    if (any_error) return 1;
+    if (opts.check and any_changed) return 1;
+    return 0;
+}
+
+const FileOutcome = enum { ok, changed, failed };
+
+/// Format one file. In write mode, rewrites it only when the content changes and
+/// the round-trip check passes. In `--check` mode, never writes; reports the path
+/// if it is not already formatted.
+fn formatFile(gc: *memory.GC, path: []const u8, check: bool) FileOutcome {
+    const allocator = gc.allocator;
+
+    const source = file_utils.readWholeFile(allocator, path, max_file_bytes) catch {
+        reportFileError(path, "cannot read file");
+        return .failed;
+    };
+    defer allocator.free(source);
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+
+    const formatted = formatSource(arena_state.allocator(), source) catch |err| {
+        reportFileError(path, parseErrorMessage(err));
+        return .failed;
+    };
+
+    if (!verifyRoundTrip(gc, source, formatted)) {
+        reportFileError(path, "internal error: formatting would change the program; file left unchanged");
+        return .failed;
+    }
+
+    if (std.mem.eql(u8, formatted, source)) return .ok;
+
+    if (check) {
+        writeStdout(path);
+        writeStdout("\n");
+        return .changed;
+    }
+
+    writeWholeFile(path, formatted) catch {
+        reportFileError(path, "cannot write file");
+        return .failed;
+    };
+    return .changed;
+}
+
+fn runStdin(gc: *memory.GC, check: bool) u8 {
+    const allocator = gc.allocator;
+    const source = readAllStdin(allocator) catch {
+        writeStderr("kaappi fmt: cannot read stdin\n");
+        return 1;
+    };
+    defer allocator.free(source);
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+
+    const formatted = formatSource(arena_state.allocator(), source) catch |err| {
+        writeStderr("kaappi fmt: ");
+        writeStderr(parseErrorMessage(err));
+        writeStderr("\n");
+        return 1;
+    };
+
+    if (!verifyRoundTrip(gc, source, formatted)) {
+        writeStderr("kaappi fmt: internal error: formatting would change the program\n");
+        return 1;
+    }
+
+    if (check) return if (std.mem.eql(u8, formatted, source)) 0 else 1;
+    writeStdout(formatted);
+    return 0;
+}
+
+fn parseErrorMessage(err: ParseError) []const u8 {
+    return switch (err) {
+        ParseError.UnterminatedList => "syntax error: unterminated list",
+        ParseError.UnterminatedString => "syntax error: unterminated string or |symbol|",
+        ParseError.UnterminatedBlockComment => "syntax error: unterminated block comment",
+        ParseError.UnexpectedRightParen => "syntax error: unexpected ')'",
+        ParseError.DanglingPrefix => "syntax error: quote/unquote with no datum",
+        ParseError.NestingTooDeep => "syntax error: nesting too deep",
+        ParseError.OutOfMemory => "out of memory",
+    };
+}
+
+fn reportFileError(path: []const u8, msg: []const u8) void {
+    writeStderr("kaappi fmt: ");
+    writeStderr(path);
+    writeStderr(": ");
+    writeStderr(msg);
+    writeStderr("\n");
+}
+
+fn writeWholeFile(path: []const u8, bytes: []const u8) !void {
+    if (comptime is_wasm) return error.Unsupported;
+    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    if (path.len >= buf.len) return error.NameTooLong;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    const path_z: [*:0]const u8 = @ptrCast(&buf);
+    const fd = try std.posix.openatZ(std.posix.AT.FDCWD, path_z, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, 0o644);
+    defer _ = std.posix.system.close(fd);
+    reporting.writeToFd(fd, bytes);
+}
+
+fn readAllStdin(allocator: std.mem.Allocator) ![]u8 {
+    var result: std.ArrayList(u8) = .empty;
+    defer result.deinit(allocator);
+    var tmp: [4096]u8 = undefined;
+    while (true) {
+        const raw = std.c.read(0, &tmp, tmp.len);
+        if (raw == 0) break;
+        if (raw < 0) {
+            if (std.posix.errno(raw) == .INTR) continue;
+            return error.ReadFailed;
+        }
+        const n: usize = @intCast(raw);
+        if (result.items.len + n > max_file_bytes) return error.StreamTooLong;
+        try result.appendSlice(allocator, tmp[0..n]);
+    }
+    return result.toOwnedSlice(allocator);
+}
+
+test {
+    _ = @import("tests_fmt.zig");
+}

--- a/src/fmt_print.zig
+++ b/src/fmt_print.zig
@@ -1,0 +1,427 @@
+//! The layout engine for `kaappi fmt` (kaappi#1518). Walks the CST built by
+//! `fmt.zig` and emits canonical text: 2-space R7RS indentation, single spaces
+//! between elements, closing parens gathered, and forms reflowed to fit
+//! `max_width` columns.
+//!
+//! **Fits-or-breaks.** Every list is first measured; if it renders within the
+//! width on one line it is emitted inline (this is what gathers parens and
+//! collapses spacing). Otherwise it breaks, using one of two well-known Scheme
+//! layouts chosen from its operator:
+//!
+//!   * **body style** (`define`, `lambda`, `let`, `when`, `case`, …): a fixed
+//!     number of *distinguished* subforms stay on the operator's line; the rest
+//!     — the body — go one per line, indented two spaces from the open paren.
+//!   * **call style** (function calls, `cond`, `and`, vectors, unknown heads):
+//!     the first argument stays on the operator's line and the rest align under
+//!     it. This is the Emacs/`scmindent` default and the natural look for calls.
+//!
+//! **Comments and blank lines.** A line comment forces its list to break and
+//! keeps the closing paren off its line. A comment on the same source line as
+//! the preceding datum stays trailing; on its own line it leads the next datum.
+//! A single blank line between body items or top-level forms is preserved (runs
+//! collapse to one); everything else about layout is recomputed, which is what
+//! makes the output canonical.
+//!
+//! **Idempotence** rests on `measure` and the inline emitter agreeing exactly on
+//! width, and on layout depending only on content — never on the input's own line
+//! breaks (comments aside). Both are covered by tests in `tests_fmt.zig`.
+
+const std = @import("std");
+const fmt = @import("fmt.zig");
+
+const Node = fmt.Node;
+const NodeKind = fmt.NodeKind;
+
+/// Target line width. Forms whose one-line rendering would exceed this break.
+pub const max_width: usize = 80;
+const indent_step: usize = 2;
+
+/// Render a top-level node sequence to a canonical, arena-allocated string
+/// ending in exactly one newline (empty input yields an empty string).
+pub fn print(arena: std.mem.Allocator, nodes: []Node) error{OutOfMemory}![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(arena);
+    var p = Printer{ .out = &out, .a = arena };
+    try p.emitTopLevel(nodes);
+    if (out.items.len > 0 and out.items[out.items.len - 1] != '\n') try out.append(arena, '\n');
+    return out.toOwnedSlice(arena);
+}
+
+const Printer = struct {
+    out: *std.ArrayList(u8),
+    a: std.mem.Allocator,
+    /// Column (byte offset since the last newline) of the write cursor.
+    col: usize = 0,
+    /// The current line ends in a line comment, so nothing more may be appended
+    /// to it — the next token, and any closing paren, must start a new line.
+    line_comment_open: bool = false,
+
+    fn raw(self: *Printer, s: []const u8) error{OutOfMemory}!void {
+        try self.out.appendSlice(self.a, s);
+        if (std.mem.lastIndexOfScalar(u8, s, '\n')) |nl| {
+            self.col = s.len - nl - 1;
+        } else {
+            self.col += s.len;
+        }
+        self.line_comment_open = false;
+    }
+
+    fn spaces(self: *Printer, n: usize) error{OutOfMemory}!void {
+        try self.out.appendNTimes(self.a, ' ', n);
+        self.col += n;
+    }
+
+    fn newlineTo(self: *Printer, indent: usize) error{OutOfMemory}!void {
+        try self.out.append(self.a, '\n');
+        try self.out.appendNTimes(self.a, ' ', indent);
+        self.col = indent;
+        self.line_comment_open = false;
+    }
+
+    /// Emit an empty line (used to preserve a single blank line of grouping).
+    fn blankLine(self: *Printer) error{OutOfMemory}!void {
+        try self.out.append(self.a, '\n');
+    }
+
+    // ── Top level ────────────────────────────────────────────────────────────
+
+    fn emitTopLevel(self: *Printer, nodes: []Node) error{OutOfMemory}!void {
+        for (nodes, 0..) |*node, i| {
+            if (i > 0) {
+                if (isComment(node.kind) and node.newlines_before == 0 and !self.line_comment_open) {
+                    // A comment on the same line as the previous form's close.
+                    try self.spaces(1);
+                    try self.emitNode(node);
+                    continue;
+                }
+                if (node.newlines_before >= 2) try self.blankLine();
+                try self.newlineTo(0);
+            }
+            try self.emitNode(node);
+        }
+    }
+
+    // ── Node dispatch ────────────────────────────────────────────────────────
+
+    fn emitNode(self: *Printer, node: *Node) error{OutOfMemory}!void {
+        switch (node.kind) {
+            .atom, .block_comment => try self.raw(node.text),
+            .line_comment => {
+                try self.raw(node.text);
+                self.line_comment_open = true;
+            },
+            .prefix => {
+                try self.raw(node.text);
+                try self.emitNode(&node.children[0]);
+            },
+            .datum_comment => {
+                try self.raw("#;");
+                try self.emitNode(&node.children[0]);
+            },
+            .list => try self.emitList(node),
+        }
+    }
+
+    fn emitList(self: *Printer, node: *Node) error{OutOfMemory}!void {
+        const start_col = self.col;
+        // Inline only when it fits *and* holds no blank line that layout would
+        // preserve (see `hasBodyBlank`) — collapsing such a form would silently
+        // drop the author's grouping and, worse, break idempotence.
+        if (measure(node)) |w| {
+            if (start_col + w <= max_width and !hasBodyBlank(node)) return self.emitInline(node);
+        }
+        try self.emitBrokenList(node, start_col);
+    }
+
+    /// One-line rendering: `(` elements-joined-by-single-space `)`. Only called
+    /// when `measure` proved the node inline-able, so it must produce exactly
+    /// `measure(node)` bytes — the two are kept in lockstep for idempotence.
+    fn emitInline(self: *Printer, node: *Node) error{OutOfMemory}!void {
+        switch (node.kind) {
+            .atom, .block_comment, .line_comment => try self.raw(node.text),
+            .prefix => {
+                try self.raw(node.text);
+                try self.emitInline(&node.children[0]);
+            },
+            .datum_comment => {
+                try self.raw("#;");
+                try self.emitInline(&node.children[0]);
+            },
+            .list => {
+                try self.raw(node.text); // open delimiter
+                for (node.children, 0..) |*child, i| {
+                    if (i > 0) try self.spaces(1);
+                    try self.emitInline(child);
+                }
+                try self.raw(")");
+            },
+        }
+    }
+
+    // ── Broken (multi-line) lists ────────────────────────────────────────────
+
+    fn emitBrokenList(self: *Printer, node: *Node, start_col: usize) error{OutOfMemory}!void {
+        try self.raw(node.text); // open delimiter
+        const open_col = self.col; // column just inside the delimiter
+
+        const op_idx = firstCodeIndex(node.children);
+        if (op_idx == null or op_idx.? != 0 or node.is_data) {
+            // No operator to hug (empty-but-broken, a leading comment, or a data
+            // vector): lay every element out vertically under the open column.
+            try self.emitVertical(node.children, open_col);
+            return self.closeParen(node, start_col);
+        }
+
+        switch (styleOf(node)) {
+            .body => |n| try self.emitBodyStyle(node, start_col, n),
+            .call => try self.emitCallStyle(node, open_col),
+        }
+        try self.closeParen(node, start_col);
+    }
+
+    /// Body style: operator plus `n` distinguished subforms share the first line;
+    /// the remaining children are the body, one per line at `open+2`.
+    fn emitBodyStyle(self: *Printer, node: *Node, start_col: usize, n: usize) error{OutOfMemory}!void {
+        const children = node.children;
+        var placed: usize = 0; // code items on line 1 (operator counts as one)
+        var i: usize = 0;
+        while (i < children.len and placed <= n) {
+            if (isComment(children[i].kind)) break; // a leading comment starts the body
+            if (placed > 0) try self.spaces(1);
+            try self.emitNode(&children[i]);
+            placed += 1;
+            i += 1;
+            // Trailing same-line comments ride along on the first line.
+            while (i < children.len and isComment(children[i].kind) and children[i].newlines_before == 0) {
+                try self.spaces(1);
+                try self.emitNode(&children[i]);
+                const was_line = children[i].kind == .line_comment;
+                i += 1;
+                if (was_line) {
+                    try self.emitBody(children[i..], start_col + indent_step);
+                    return;
+                }
+            }
+        }
+        try self.emitBody(children[i..], start_col + indent_step);
+    }
+
+    /// Call style: the first argument stays on the operator's line; later
+    /// arguments align under it.
+    fn emitCallStyle(self: *Printer, node: *Node, open_col: usize) error{OutOfMemory}!void {
+        const children = node.children;
+        try self.emitNode(&children[0]); // operator, already at open_col
+        var i: usize = 1;
+
+        // Trailing same-line comments after the operator.
+        while (i < children.len and isComment(children[i].kind) and children[i].newlines_before == 0) {
+            try self.spaces(1);
+            try self.emitNode(&children[i]);
+            if (children[i].kind == .line_comment) {
+                i += 1;
+                return self.emitBody(children[i..], open_col);
+            }
+            i += 1;
+        }
+
+        if (i < children.len and !isComment(children[i].kind)) {
+            try self.spaces(1);
+            const align_col = self.col; // column where the first argument begins
+            try self.emitNode(&children[i]);
+            i += 1;
+            while (i < children.len and isComment(children[i].kind) and children[i].newlines_before == 0) {
+                try self.spaces(1);
+                try self.emitNode(&children[i]);
+                if (children[i].kind == .line_comment) {
+                    i += 1;
+                    return self.emitBody(children[i..], align_col);
+                }
+                i += 1;
+            }
+            return self.emitBody(children[i..], align_col);
+        }
+        // Operator with no argument on its line (only comments follow).
+        try self.emitBody(children[i..], open_col);
+    }
+
+    /// Every child on its own line at `indent` (used for vectors and the
+    /// leading-comment fallback).
+    fn emitVertical(self: *Printer, children: []Node, indent: usize) error{OutOfMemory}!void {
+        try self.emitBodyFrom(children, indent, true);
+    }
+
+    /// Body items each on their own line at `indent`, with a fresh line before
+    /// the first (it drops off the operator's line).
+    fn emitBody(self: *Printer, children: []Node, indent: usize) error{OutOfMemory}!void {
+        try self.emitBodyFrom(children, indent, false);
+    }
+
+    fn emitBodyFrom(self: *Printer, children: []Node, indent: usize, first_inline: bool) error{OutOfMemory}!void {
+        var started = false;
+        for (children) |*child| {
+            const on_own_line = !(first_inline and !started);
+            if (isComment(child.kind) and child.newlines_before == 0 and started and !self.line_comment_open) {
+                // Trailing comment on the previous item's line.
+                try self.spaces(1);
+                try self.emitNode(child);
+                continue;
+            }
+            if (on_own_line) {
+                // Preserve a single blank line of grouping before any own-line
+                // item, including the first (the item after the operator line).
+                if (child.newlines_before >= 2) try self.blankLine();
+                try self.newlineTo(indent);
+            }
+            try self.emitNode(child);
+            started = true;
+        }
+    }
+
+    /// Emit the closing paren, gathered onto the current line unless a trailing
+    /// line comment has closed it (then it drops to a fresh line under the open).
+    fn closeParen(self: *Printer, node: *Node, paren_col: usize) error{OutOfMemory}!void {
+        _ = node;
+        if (self.line_comment_open) try self.newlineTo(paren_col);
+        try self.raw(")");
+    }
+};
+
+// ── Measurement ──────────────────────────────────────────────────────────────
+
+/// Inline width of `node` in bytes, or null if it cannot be one line (contains a
+/// line comment, a multi-line block comment, or an atom with an embedded
+/// newline). Memoised on the node so repeated fit checks stay linear.
+fn measure(node: *Node) ?usize {
+    if (node.width_computed) return node.inline_width;
+    const w = computeMeasure(node);
+    node.width_computed = true;
+    node.inline_width = w;
+    return w;
+}
+
+fn computeMeasure(node: *Node) ?usize {
+    switch (node.kind) {
+        .line_comment => return null,
+        .atom, .block_comment => {
+            if (std.mem.indexOfScalar(u8, node.text, '\n') != null) return null;
+            return node.text.len;
+        },
+        .prefix => {
+            const child = measure(&node.children[0]) orelse return null;
+            return node.text.len + child;
+        },
+        .datum_comment => {
+            const child = measure(&node.children[0]) orelse return null;
+            return 2 + child; // "#;" glued to its datum
+        },
+        .list => {
+            var total: usize = node.text.len + 1; // open delimiter + ")"
+            for (node.children, 0..) |*child, i| {
+                const w = measure(child) orelse return null;
+                total += w;
+                if (i > 0) total += 1; // separating space
+            }
+            return total;
+        },
+    }
+}
+
+// ── Layout rules ─────────────────────────────────────────────────────────────
+
+const Style = union(enum) {
+    /// Function-call / data layout: first argument on the head line, rest aligned
+    /// under it.
+    call,
+    /// Special-form layout: `n` distinguished subforms on the head line, body at
+    /// open+2.
+    body: usize,
+};
+
+/// True when the list holds a blank line that layout will preserve — i.e. a
+/// blank before a child that lands on its own line (a body item, or a vector
+/// element past the first). Blanks before the operator or a distinguished
+/// subform sit on the head line and are dropped, so they do not count; keeping
+/// this in lockstep with what `emitBodyFrom` actually emits is what makes
+/// formatting idempotent (a preserved blank re-forces the break next time; a
+/// dropped one does not resurrect it).
+fn hasBodyBlank(node: *Node) bool {
+    if (node.kind != .list) return false;
+    const children = node.children;
+    const op_idx = firstCodeIndex(children);
+    const first_body: usize = if (op_idx == null or op_idx.? != 0 or node.is_data)
+        1 // vertical layout: only the first element shares the open line
+    else switch (styleOf(node)) {
+        .body => |n| n + 1, // operator + n distinguished subforms on the head line
+        .call => 2, // operator + first argument on the head line
+    };
+    if (first_body >= children.len) return false;
+    for (children[first_body..]) |child| {
+        if (child.newlines_before >= 2) return true;
+    }
+    return false;
+}
+
+fn styleOf(node: *Node) Style {
+    const op = node.children[0];
+    if (op.kind != .atom) return .call;
+    const name = op.text;
+
+    if (std.mem.eql(u8, name, "let")) {
+        // Named let — `(let loop ((…)) body)` — has an extra distinguished form.
+        if (node.children.len >= 2 and node.children[1].kind == .atom) return .{ .body = 2 };
+        return .{ .body = 1 };
+    }
+    if (bodyDistinguished(name)) |n| return .{ .body = n };
+    return .call;
+}
+
+/// Distinguished-subform count for the well-known body-style forms, or null for
+/// anything laid out as a call. Covers the R7RS special forms plus a few common
+/// macros (SRFI-64 `test-group`, SRFI-8 `receive`) whose bodies read as blocks.
+fn bodyDistinguished(name: []const u8) ?usize {
+    const table = [_]struct { name: []const u8, n: usize }{
+        .{ .name = "lambda", .n = 1 },
+        .{ .name = "define", .n = 1 },
+        .{ .name = "define-values", .n = 1 },
+        .{ .name = "define-syntax", .n = 1 },
+        .{ .name = "define-record-type", .n = 1 },
+        .{ .name = "define-library", .n = 1 },
+        .{ .name = "let*", .n = 1 },
+        .{ .name = "letrec", .n = 1 },
+        .{ .name = "letrec*", .n = 1 },
+        .{ .name = "let-values", .n = 1 },
+        .{ .name = "let*-values", .n = 1 },
+        .{ .name = "let-syntax", .n = 1 },
+        .{ .name = "letrec-syntax", .n = 1 },
+        .{ .name = "when", .n = 1 },
+        .{ .name = "unless", .n = 1 },
+        .{ .name = "begin", .n = 0 },
+        .{ .name = "case", .n = 1 },
+        .{ .name = "do", .n = 2 },
+        .{ .name = "parameterize", .n = 1 },
+        .{ .name = "guard", .n = 1 },
+        .{ .name = "syntax-rules", .n = 1 },
+        .{ .name = "case-lambda", .n = 0 },
+        .{ .name = "receive", .n = 2 },
+        .{ .name = "test-group", .n = 1 },
+        .{ .name = "test-group-with-cleanup", .n = 1 },
+    };
+    for (table) |e| {
+        if (std.mem.eql(u8, name, e.name)) return e.n;
+    }
+    return null;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn isComment(kind: NodeKind) bool {
+    return kind == .line_comment or kind == .block_comment;
+}
+
+/// Index of the first non-comment child, or null if there is none.
+fn firstCodeIndex(children: []Node) ?usize {
+    for (children, 0..) |c, i| {
+        if (!isComment(c.kind)) return i;
+    }
+    return null;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,6 +52,7 @@ pub const doctor = @import("doctor.zig");
 pub const check = @import("check.zig");
 pub const pipeline = @import("pipeline.zig");
 pub const config = @import("config.zig");
+pub const fmt = @import("fmt.zig");
 
 pub const version = @import("build_options").version;
 
@@ -477,6 +478,12 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     if (opts.ir_mode) {
         const fp = opts.file_path orelse usageError("Usage: kaappi ir <file.scm> [--no-opt]\n");
         std.process.exit(pipeline.runIr(vm, fp, opts.ir_no_opt));
+    }
+
+    // Canonical formatter (kaappi#1518). Reads and re-lays-out source; no
+    // program code runs. With no files it formats stdin to stdout.
+    if (opts.fmt_mode) {
+        std.process.exit(fmt.run(&gc, .{ .check = opts.fmt_check, .files = opts.scriptArgs() }));
     }
 
     if (opts.disassemble_mode) {
@@ -1075,4 +1082,6 @@ test {
     _ = pipeline;
     _ = @import("tests_pipeline.zig");
     _ = config;
+    _ = fmt;
+    _ = @import("fmt_print.zig");
 }

--- a/src/tests_fmt.zig
+++ b/src/tests_fmt.zig
@@ -1,0 +1,293 @@
+//! Tests for `kaappi fmt` (kaappi#1518): exact-output cases, comment and
+//! blank-line preservation, the idempotence property (`fmt(fmt(x)) == fmt(x)`)
+//! over generated programs, and the semantics-preserving round-trip guarantee.
+
+const std = @import("std");
+const testing = std.testing;
+const fmt = @import("fmt.zig");
+const fmt_print = @import("fmt_print.zig");
+const memory = @import("memory.zig");
+const fuzz_gen = @import("fuzz_gen.zig");
+
+/// Format `src` into an arena-backed string. Caller frees via the arena.
+fn fmtInto(arena: std.mem.Allocator, src: []const u8) ![]u8 {
+    return fmt.formatSource(arena, src);
+}
+
+/// Assert `src` formats to exactly `want`.
+fn expectFormat(src: []const u8, want: []const u8) !void {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const got = try fmtInto(arena.allocator(), src);
+    try testing.expectEqualStrings(want, got);
+}
+
+/// Assert formatting is idempotent for `src`: the first pass is a fixed point.
+fn expectIdempotent(src: []const u8) !void {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const once = try fmtInto(arena.allocator(), src);
+    const twice = try fmtInto(arena.allocator(), once);
+    try testing.expectEqualStrings(once, twice);
+}
+
+/// Assert formatting preserves the datums a reader sees.
+fn expectRoundTrips(src: []const u8) !void {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formatted = try fmtInto(arena.allocator(), src);
+
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+    try testing.expect(fmt.verifyRoundTrip(&gc, src, formatted));
+}
+
+// ── Spacing and gathering ─────────────────────────────────────────────────────
+
+test "collapses runs of whitespace to single spaces" {
+    try expectFormat("(+   1\t\t2    3)", "(+ 1 2 3)\n");
+}
+
+test "gathers trailing close parens" {
+    try expectFormat("(a (b (c)\n)\n)", "(a (b (c)))\n");
+}
+
+test "atoms are preserved verbatim" {
+    try expectFormat("(list 1.5e10 #xFF #\\newline \"a b\" 'x)", "(list 1.5e10 #xFF #\\newline \"a b\" 'x)\n");
+}
+
+test "quote and unquote glue to their datum" {
+    try expectFormat("( quote   x )", "(quote x)\n");
+    try expectFormat("`(a ,b ,@c)", "`(a ,b ,@c)\n");
+}
+
+test "empty list and single trailing newline" {
+    try expectFormat("()", "()\n");
+    try expectFormat("(a)\n\n\n", "(a)\n");
+}
+
+test "vector literals keep their prefix" {
+    try expectFormat("#(1 2 3)", "#(1 2 3)\n");
+    try expectFormat("#u8( 0 255 )", "#u8(0 255)\n");
+}
+
+// ── Special-form indentation ──────────────────────────────────────────────────
+
+test "define body breaks to two-space indent" {
+    const src = "(define (f x) (aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee ffffffffff))";
+    try expectFormat(src,
+        \\(define (f x)
+        \\  (aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee ffffffffff))
+        \\
+    );
+}
+
+test "when keeps test on head line, body indented two" {
+    const src = "(when some-condition (step-one arg) (step-two arg) (step-three arg) (step-four arg))";
+    try expectFormat(src,
+        \\(when some-condition
+        \\  (step-one arg)
+        \\  (step-two arg)
+        \\  (step-three arg)
+        \\  (step-four arg))
+        \\
+    );
+}
+
+test "let bindings and body" {
+    const src = "(let ((alpha 1) (beta 2) (gamma 3) (delta 4) (epsilon 5)) (+ alpha beta gamma delta epsilon))";
+    try expectFormat(src,
+        \\(let ((alpha 1) (beta 2) (gamma 3) (delta 4) (epsilon 5))
+        \\  (+ alpha beta gamma delta epsilon))
+        \\
+    );
+}
+
+test "named let gets an extra distinguished form" {
+    const src = "(let loop ((i 0) (acc (list))) (if (= i 100000) acc (loop (+ i 1) (cons i acc))))";
+    try expectFormat(src,
+        \\(let loop ((i 0) (acc (list)))
+        \\  (if (= i 100000) acc (loop (+ i 1) (cons i acc))))
+        \\
+    );
+}
+
+test "call style aligns arguments under the first" {
+    const src = "(some-procedure first-argument second-argument third-argument fourth-argument fifth-arg)";
+    try expectFormat(src,
+        \\(some-procedure first-argument
+        \\                second-argument
+        \\                third-argument
+        \\                fourth-argument
+        \\                fifth-arg)
+        \\
+    );
+}
+
+test "cond clauses align under the first clause" {
+    const src = "(cond ((= x 1) 'one) ((= x 2) 'two) ((= x 3) 'three) ((= x 4) 'four) (else 'many))";
+    try expectFormat(src,
+        \\(cond ((= x 1) 'one)
+        \\      ((= x 2) 'two)
+        \\      ((= x 3) 'three)
+        \\      ((= x 4) 'four)
+        \\      (else 'many))
+        \\
+    );
+}
+
+// ── Comments ──────────────────────────────────────────────────────────────────
+
+test "leading line comment stays on its own line" {
+    try expectFormat(";; a header\n(define x 1)", ";; a header\n(define x 1)\n");
+}
+
+test "trailing line comment stays on the datum's line" {
+    try expectFormat("(define x 1)   ; the answer", "(define x 1) ; the answer\n");
+}
+
+test "comment inside a body forces the break and is preserved" {
+    const src = "(begin ; start\n (a) ; first\n (b))";
+    try expectFormat(src,
+        \\(begin ; start
+        \\  (a) ; first
+        \\  (b))
+        \\
+    );
+}
+
+test "block comment is preserved verbatim inline" {
+    try expectFormat("(a #| note |# b)", "(a #| note |# b)\n");
+}
+
+test "trailing whitespace inside a line comment is stripped" {
+    // Invisible and never part of a datum — the output must carry no trailing
+    // spaces. (The literal string below ends the comment with two spaces.)
+    try expectFormat(";; note  \n(define x 1)", ";; note\n(define x 1)\n");
+}
+
+test "datum comment is preserved and glued" {
+    try expectFormat("(a #;(ignored) b)", "(a #;(ignored) b)\n");
+}
+
+// ── Blank lines ───────────────────────────────────────────────────────────────
+
+test "single blank line between top-level forms is preserved" {
+    try expectFormat("(a)\n\n(b)", "(a)\n\n(b)\n");
+}
+
+test "multiple blank lines collapse to one" {
+    try expectFormat("(a)\n\n\n\n(b)", "(a)\n\n(b)\n");
+}
+
+test "blank line inside a body is preserved" {
+    const src = "(define (f)\n  (first-step here)\n\n  (second-step here))";
+    try expectFormat(src,
+        \\(define (f)
+        \\  (first-step here)
+        \\
+        \\  (second-step here))
+        \\
+    );
+}
+
+test "blank before the first body item is preserved" {
+    // Regression: a blank line right after the head must survive, and re-parsing
+    // it (now a single blank) must reach the same fixed point — see the
+    // idempotence hazard fixed alongside hasBodyBlank.
+    try expectFormat("(begin\n\n  (a)\n  (b))",
+        \\(begin
+        \\
+        \\  (a)
+        \\  (b))
+        \\
+    );
+    try expectIdempotent("(begin\n\n\n  (a)\n  (b))");
+}
+
+test "blank before a distinguished subform collapses and stays idempotent" {
+    // The blank sits before the binding list, which rides on the `let` head
+    // line — so it is dropped, and the short form collapses to one line. If that
+    // drop were paired with a forced break the result would oscillate.
+    try expectFormat("(let\n\n  ((x 1))\n  x)", "(let ((x 1)) x)\n");
+    try expectIdempotent("(let\n\n  ((x 1))\n  x)");
+    try expectIdempotent("(define\n\n  x\n  1)");
+}
+
+// ── Idempotence ───────────────────────────────────────────────────────────────
+
+test "idempotent on a spread of forms" {
+    const cases = [_][]const u8{
+        "(define (fact n) (if (< n 2) 1 (* n (fact (- n 1)))))",
+        "(let loop ((i 0)) (when (< i 10) (display i) (loop (+ i 1))))",
+        "(cond ((assv x table) => cdr) (else (error \"missing\" x)))",
+        "(define-record-type point (make-point x y) point? (x point-x) (y point-y))",
+        ";; top comment\n(import (scheme base) (scheme write))\n\n(display \"hi\")",
+        "(when a (b) (c) (d) (e) (f) (g) (h) (i) (j) (k) (l) (m) (n) (o) (p) (q) (r))",
+        "#(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30)",
+    };
+    for (cases) |c| try expectIdempotent(c);
+}
+
+// ── Round-trip semantics ──────────────────────────────────────────────────────
+
+test "round-trips a spread of forms" {
+    const cases = [_][]const u8{
+        "(define (fact n) (if (< n 2) 1 (* n (fact (- n 1)))))",
+        "'(1 2 . 3)",
+        "`(a ,b ,@(c d) #(1 2))",
+        "(a #;(dropped) b #| block |# c)",
+        "#0=(1 2 . #0#)",
+        "(list #\\a #\\space #\\x3bb \"str\\ning\" |weird sym|)",
+        "(+ 1/2 3.5 #xFF #b101 +inf.0)",
+    };
+    for (cases) |c| try expectRoundTrips(c);
+}
+
+// ── Generated programs: idempotence + round-trip ──────────────────────────────
+
+test "idempotent and semantics-preserving over generated programs" {
+    const gc_stress = @import("build_options").gc_stress;
+    const iterations: u64 = if (gc_stress) 40 else 400;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var seed: u64 = 0;
+    while (seed < iterations) : (seed += 1) {
+        _ = arena.reset(.retain_capacity);
+        const a = arena.allocator();
+
+        const program = try fuzz_gen.generateSeeded(seed, a);
+
+        const once = try fmt.formatSource(a, program);
+        const twice = try fmt.formatSource(a, once);
+        try testing.expectEqualStrings(once, twice);
+
+        var gc = memory.GC.init(testing.allocator);
+        defer gc.deinit();
+        if (!fmt.verifyRoundTrip(&gc, program, once)) {
+            std.debug.print("round-trip drift on seed {d}:\n{s}\n---\n{s}\n", .{ seed, program, once });
+            return error.RoundTripDrift;
+        }
+    }
+}
+
+// ── Parser diagnostics ────────────────────────────────────────────────────────
+
+test "unterminated list is a format error, not a crash" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try testing.expectError(fmt.ParseError.UnterminatedList, fmt.formatSource(arena.allocator(), "(a b c"));
+}
+
+test "unexpected close paren is a format error" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try testing.expectError(fmt.ParseError.UnexpectedRightParen, fmt.formatSource(arena.allocator(), "a)"));
+}
+
+test "empty input yields empty output" {
+    try expectFormat("", "");
+    try expectFormat("   \n\n  ", "");
+}

--- a/tests/scheme/fmt/fmt.sh
+++ b/tests/scheme/fmt/fmt.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# `kaappi fmt` — canonical, comment-preserving formatter (kaappi#1518).
+#
+# Golden CLI behaviour (write in place, --check exit codes, stdin), plus two
+# tree-wide properties that are the issue's acceptance criteria:
+#
+#   * zero semantic drift — formatting every .scm/.sld under tests/scheme and
+#     lib must never change the datums a reader sees (fmt's built-in round-trip
+#     check reports any drift on stderr and refuses to write);
+#   * idempotence — formatting an already-formatted tree is a no-op.
+#
+# Exact input→output layout cases live in the Zig unit tests (src/tests_fmt.zig);
+# this suite exercises the CLI and the whole repo corpus.
+
+set -uo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+# Resolve to an absolute path: the tree checks format files in a temp mirror,
+# so a relative binary path would break once we reference it from elsewhere.
+case "$KAAPPI" in
+    /*) : ;;
+    *) KAAPPI="$PWD/$KAAPPI" ;;
+esac
+
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1 — $2"; FAIL=$((FAIL + 1)); }
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+    if [[ "$2" == "$3" ]]; then
+        pass "$1"
+    else
+        fail "$1" "expected [$2], got [$3]"
+    fi
+}
+
+# assert_exit <label> <expected> <cmd...>
+assert_exit() {
+    local label="$1" expected="$2"; shift 2
+    local status=0
+    "$@" > /dev/null 2>&1 || status=$?
+    if [[ "$status" -eq "$expected" ]]; then
+        pass "$label"
+    else
+        fail "$label" "expected exit $expected, got $status"
+    fi
+}
+
+# ── stdin formatting ─────────────────────────────────────────────────────────
+
+got="$(printf '(list   1  2\t3)' | "$KAAPPI" fmt)"
+assert_eq "stdin: collapses whitespace" "$(printf '(list 1 2 3)')" "$got"
+
+# `'x` (the reader abbreviation) glues to its datum; a written-out `(quote x)`
+# list stays a list — the formatter normalizes spacing, it does not rewrite one
+# spelling into the other.
+got="$(printf "'   x" | "$KAAPPI" fmt)"
+assert_eq "stdin: quote abbreviation glues" "$(printf "'x")" "$got"
+got="$(printf "( quote    x )" | "$KAAPPI" fmt)"
+assert_eq "stdin: quote list keeps its spelling" "$(printf '(quote x)')" "$got"
+
+# ── --check exit codes ───────────────────────────────────────────────────────
+
+printf '(list 1 2 3)\n' > "$TMP/ok.scm"
+assert_exit "check: formatted file exits 0" 0 "$KAAPPI" fmt --check "$TMP/ok.scm"
+
+printf '(list   1 2 3)\n' > "$TMP/bad.scm"
+assert_exit "check: unformatted file exits 1" 1 "$KAAPPI" fmt --check "$TMP/bad.scm"
+
+# --check must never modify the file it inspects.
+before="$(cat "$TMP/bad.scm")"
+"$KAAPPI" fmt --check "$TMP/bad.scm" > /dev/null 2>&1 || true
+assert_eq "check: leaves the file untouched" "$before" "$(cat "$TMP/bad.scm")"
+
+# ── write in place, then idempotent ──────────────────────────────────────────
+
+printf '(define    (f x)\n  (+ x    1))\n' > "$TMP/w.scm"
+"$KAAPPI" fmt "$TMP/w.scm" > /dev/null 2>&1
+assert_eq "write: reformats in place" "$(printf '(define (f x) (+ x 1))')" "$(cat "$TMP/w.scm")"
+assert_exit "write: result is already formatted" 0 "$KAAPPI" fmt --check "$TMP/w.scm"
+
+# ── Syntax errors are reported, not silently mangled ─────────────────────────
+
+printf '(a b c\n' > "$TMP/unterminated.scm"
+assert_exit "error: unterminated list exits 1" 1 "$KAAPPI" fmt --check "$TMP/unterminated.scm"
+
+# ── Corpus: zero semantic drift + idempotence over the repo tree ─────────────
+
+corpus_files() {
+    find tests/scheme lib \( -name '*.scm' -o -name '*.sld' \) -type f | sort
+}
+
+count="$(corpus_files | wc -l | tr -d ' ')"
+if [[ "$count" -eq 0 ]]; then
+    fail "corpus: found files" "no .scm/.sld under tests/scheme or lib"
+else
+    # (1) Zero drift on the original tree. --check exits 1 when files are merely
+    # unformatted; a genuine drift/parse failure instead prints to stderr, which
+    # is what we assert is empty.
+    corpus_files | xargs "$KAAPPI" fmt --check > /dev/null 2> "$TMP/drift.err" || true
+    if [[ -s "$TMP/drift.err" ]]; then
+        fail "corpus: zero semantic drift ($count files)" "fmt reported: $(cat "$TMP/drift.err")"
+    else
+        pass "corpus: zero semantic drift ($count files)"
+    fi
+
+    # (2) Idempotence: format a mirror of the tree, then re-check it. An
+    # already-formatted tree must need no changes (exit 0) and still not drift.
+    mkdir -p "$TMP/mirror"
+    tar cf - $(corpus_files) | (cd "$TMP/mirror" && tar xf -)
+    ( cd "$TMP/mirror" && corpus_files | xargs "$KAAPPI" fmt > /dev/null 2> "$TMP/fmt1.err" ) || true
+    if [[ -s "$TMP/fmt1.err" ]]; then
+        fail "corpus: idempotent ($count files)" "first pass reported: $(cat "$TMP/fmt1.err")"
+    else
+        recheck=0
+        ( cd "$TMP/mirror" && corpus_files | xargs "$KAAPPI" fmt --check > "$TMP/recheck.out" 2>&1 ) || recheck=$?
+        if [[ "$recheck" -eq 0 ]]; then
+            pass "corpus: idempotent ($count files)"
+        else
+            fail "corpus: idempotent ($count files)" "re-check flagged: $(cat "$TMP/recheck.out")"
+        fi
+    fi
+fi
+
+echo ""
+echo "fmt: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -158,6 +158,7 @@ run_shell_suite "Compile tests" tests/scheme/compile
 run_shell_suite "Test runner" tests/scheme/test-runner
 run_shell_suite "Pipeline dumps" tests/scheme/pipeline
 run_shell_suite "Doctor" tests/scheme/doctor
+run_shell_suite "Formatter" tests/scheme/fmt
 
 echo "=== R7RS test suite ==="
 set +e


### PR DESCRIPTION
Closes #1518 — the final item of the machine-legibility epic #1503.

## What

`kaappi fmt [--check] files...` — a canonical, comment-preserving Scheme formatter.

- **In place** by default; `kaappi fmt` with no files formats stdin → stdout.
- **`--check`** writes nothing, prints paths that need formatting, and exits nonzero — the CI gate.
- **Canonical layout:** 2-space R7RS indentation, single-space separators, closing parens gathered, forms reflowed to 80 columns. Body style for `define`/`lambda`/`let`/`when`/`case`/…; call style for calls, `cond`, vectors, and unknown heads.
- **Verbatim atoms:** number/character/string spellings and `(quote x)` vs `'x` pass through untouched.

## How

Comments aren't datums, so the ordinary reader can't drive a formatter. This adds its own concrete-syntax reader:

- [`src/fmt.zig`](src/fmt.zig) — lexer (every lexeme incl. line/block/`#;` comments + blank-line structure) + parser building a verbatim CST, plus the CLI entry.
- [`src/fmt_print.zig`](src/fmt_print.zig) — the fits-or-breaks layout engine.

**Safety net:** before writing any file, `verifyRoundTrip` re-reads the original and the formatted text with the **real reader** and compares datum sequences with `equal?`. On any mismatch it refuses to write — a bug here can never corrupt a source file.

## Acceptance criteria

- [x] **Zero semantic drift** formatting all 558 `.scm`/`.sld` under `tests/scheme/` + `lib/` (automated round-trip check).
- [x] **Comment & blank-line preservation** tests.
- [x] **Idempotence** property test over grammar-fuzzer programs (whole corpus is 558/558 idempotent too).
- [x] **`--check` mode**; ecosystem CI can adopt it (snippet in [`docs/dev/fmt.md`](docs/dev/fmt.md)).

## Tests & docs

- `src/tests_fmt.zig` — exact-output cases, comment/blank-line preservation, idempotence + round-trip over `fuzz_gen` programs, parser diagnostics.
- `tests/scheme/fmt/fmt.sh` — CLI behaviour + corpus zero-drift + corpus idempotence, wired into `run-all.sh`.
- `docs/dev/fmt.md`; completions (bash/zsh/fish), `--help`, and `CLAUDE.md` updated.

Full unit suite green; `zig fmt` clean; both new files well under the 1500-line policy.

## Notes / scope

- **Not included:** reformatting the ~61 tree files that aren't yet canonical — a large, separate diff with conflict risk against in-flight work. The criteria only require the round-trip *property* (tested here); a tree reformat can be a follow-up `kaappi fmt lib tests/scheme` run.
- **Known limitation:** a source with a self-referential datum label (e.g. `#0=(1 2 . #0#)`) is left untouched and reported rather than reformatted — the safety net can't confirm it. Essentially absent in real program source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)