### PR TITLE
Guaranteed native mutual tail calls via tailcc + musttail (#1499)

### DIFF
--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -167,7 +167,7 @@ The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
 |------|---------------|
 | `constant` | Literal `i64` for immediates; `kaappi_make_string` for strings; `kaappi_intern_symbol` for symbols; `(quote ...)` via `kaappi_quote_cached` (built once per call site) for other heap values |
 | `global_ref` | `call @kaappi_global_lookup(...)` |
-| `call` | Four paths: inline-IR fast path for `+ - * < = null?` (see [Inline primitive fast paths](#inline-primitive-fast-paths)); direct specialized call for `car cdr cons`; direct `call`/`tail call` to a known native function; otherwise stack-allocate args array and `call @kaappi_call_scheme(...)` |
+| `call` | Five paths: inline-IR fast path for `+ - * < = null?` (see [Inline primitive fast paths](#inline-primitive-fast-paths)); direct specialized call for `car cdr cons`; a register-argument `call tailcc` (or guaranteed `musttail call tailcc` in tail position) to a known native **fast entry** (see [Guaranteed mutual tail calls](#guaranteed-mutual-tail-calls-tailcc--musttail)); a uniform-ABI `call`/`tail call` to a known native function without a fast entry (variadic / boxed / over the arity bound); otherwise stack-allocate args array and `call @kaappi_call_scheme(...)` |
 | `begin` | Emit each expression sequentially |
 | `if` | LLVM basic blocks with `br`/`phi` |
 | `and`/`or` | Short-circuit with basic blocks and `phi` |
@@ -326,6 +326,11 @@ define i64 @lambda_0(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) { ... }
 ```
 
 Fixed parameters are read from `%args`, captured variables from `%upvalues`.
+This is the signature `kaappi_create_native_closure` stores and
+`kaappi_call_scheme` invokes for indirect dispatch. A fixed-arity, non-variadic,
+non-boxed **named** function additionally gets a register-argument `tailcc`
+**fast entry** for direct calls and guaranteed mutual tail recursion — see
+[Guaranteed mutual tail calls](#guaranteed-mutual-tail-calls-tailcc--musttail).
 
 The three tiers, tried in order:
 
@@ -409,6 +414,62 @@ mutated bindings are boxed — everything else keeps the by-value fast path. Box
 frames disable the self-tail-call loop and lower their body non-tail so the box
 roots are popped at a single `ret`.
 
+### Guaranteed mutual tail calls (`tailcc` + `musttail`)
+
+Self-tail-recursion is constant-stack via the arg-overwrite loop above, but a
+tail call to *another* function cannot be: the uniform entry reads its parameters
+from a caller-frame `%args` array, and a real tail call tears that frame down, so
+the callee would read freed stack. `even?`/`odd?`-style **mutual** recursion
+therefore grew the stack. #1499 makes it constant-stack with LLVM's `tailcc`
+calling convention + `musttail` marker (which `tailcc` frees from the
+prototype-match rule, so functions of different arity may mutually tail-call).
+
+A fixed-arity, non-variadic, non-boxed **named** function (arity ≤
+`max_fast_arity`, currently 8) is emitted as **two** LLVM functions:
+
+- **`@name.fast`** — the body, `tailcc`, taking arguments **by value** in
+  registers. Its entry block copies those registers into a local `%args` array,
+  so the rest of the body — param resolution, the self-tail loop's in-place
+  overwrite, `bindParamsAsGlobals` — is byte-identical to the uniform entry. The
+  array is this frame's own; outgoing calls pass argument *values*, never a
+  pointer into it, so `musttail` stays sound.
+- **`@name`** — an `internal` uniform-ABI **trampoline** that unpacks `%args` and
+  `call tailcc @name.fast(...)`. This is what `kaappi_create_native_closure`
+  stores; indirect dispatch (`kaappi_call_scheme`) still goes through it. LLVM
+  drops it when a define's value is materialized via the interpreter and nothing
+  takes its address.
+
+Direct calls reach `@name.fast` with register arguments (no args array). A tail
+call from one fast entry to another emits `musttail call tailcc … ; ret` —
+LLVM-guaranteed constant stack. `mustTailSafe` gates this: the caller must be a
+fast entry, in tail position, with a balanced shadow stack — specifically **not
+inside a rooted `let`** (`self.locals == null`) and with the frame-entry roots
+(rest list / boxed params, always 0 in a fast entry) already popped, so the
+`musttail` immediately precedes its `ret` as LLVM requires. When those do not
+hold, it degrades to a best-effort `tail call tailcc` hint. Self-recursion keeps
+the loop (better than any call); variadic, boxed, over-arity, and closure
+functions keep the single uniform entry and are unchanged.
+
+**Forward references.** Mutual recursion needs the *forward* call (a callee
+defined later) to resolve to a direct `musttail` too, but `native_fns` is
+populated in emission order. A syntactic **pre-scan** (`preScanReserve`, run over
+all top-level nodes at the top of `emitProgram`) reserves a stable
+`@r{i}`/`@r{i}.fast` name pair for every top-level function define that is
+defined exactly once, never a top-level `set!` target, and has a proper list of
+symbol formals within the arity bound. A forward tail call to a reserved name
+emits `musttail call tailcc @r{i}.fast`; a reference to a reserved name in
+free-variable analysis counts as a **global**, not a capture
+(`isKnownOrReservedGlobal`), so the caller still compiles natively. When a
+reserved name's define turns out non-native (it falls back to the interpreter),
+finalization emits an `internal tailcc` **stub** `@r{i}.fast` that rebuilds an
+args array and dispatches through `kaappi_call_scheme` — so the `musttail` target
+always links, correct though not itself constant-stack for that one edge.
+
+**Per-target gate.** `fast_tailcalls_supported` (a comptime switch on the host
+arch) enables all of the above only on `aarch64` and `x86_64`, whose LLVM
+backends support `tailcc`/`musttail`. Other hosts keep the uniform-only ABI
+unchanged; RISC-V can be enabled once its `musttail` support is confirmed.
+
 ## Testing
 
 End-to-end tests live in `tests/e2e/`:
@@ -436,6 +497,10 @@ environment variable controls the C compiler (defaults to `zig cc`).
 - Unicode strings, string ports, string mutation
 - Higher-order functions (`map`, `filter`, `fold`)
 - Tail-recursive loops (100k iterations)
+- Guaranteed constant-stack **mutual** tail recursion via `tailcc`/`musttail`
+  (`even?`/`odd?` and a 3-function cycle at millions of alternating calls,
+  `native-mutual-tail.scm`) — a non-tail-calling native binary would overflow,
+  so the interpreter diff doubles as the constant-stack regression check
 - Inline fixnum fast paths for `+ - * < = null?` with their runtime fallbacks —
   overflow → bignum, non-fixnum (flonum/rational) operands, and sign-extended
   negatives (`native-inline-primitives.scm`, all diffed against the interpreter,

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -3,6 +3,8 @@ const ir = @import("ir.zig");
 const types = @import("types.zig");
 const printer = @import("printer.zig");
 const native_decls = @import("native_decls.zig");
+// #1499 forward-reference reservation + finalization stubs (mutual tail calls).
+const tailcall = @import("llvm_emit_tailcall.zig");
 
 const Value = types.Value;
 
@@ -50,10 +52,42 @@ const ArithOp = enum {
     }
 };
 
+// #1499: tailcc + musttail give guaranteed constant-stack mutual tail calls,
+// but only on backends whose LLVM target supports them. aarch64 and x86_64 both
+// do; other hosts keep the uniform array ABI (best-effort `tail call` hint).
+// RISC-V musttail is recent LLVM work and can be enabled here once verified.
+pub const fast_tailcalls_supported = switch (@import("builtin").cpu.arch) {
+    .aarch64, .x86_64 => true,
+    else => false,
+};
+
+// A named native function with at most this many fixed parameters gets a
+// register-argument `tailcc` fast entry (see emitLambdaFunction). Beyond it the
+// uniform array ABI is kept — the bound keeps register pressure and signature
+// width reasonable; it is not an ABI limit and can be raised.
+pub const max_fast_arity: usize = 8;
+
 const NativeLambda = struct {
     llvm_name: []const u8,
     arity: u8,
     is_variadic: bool,
+    // The `tailcc` register-argument entry (`@<name>.fast`) for a fixed-arity,
+    // non-variadic, non-boxed function, or null when the function has only the
+    // uniform array-ABI entry. Direct call sites emit register-argument calls —
+    // and `musttail` for guaranteed mutual TCO — when this is set (#1499).
+    fast_name: ?[]const u8 = null,
+};
+
+// A top-level define reserved by the pre-scan (preScanReserve) so a *forward*
+// tail call — a mutually-recursive callee defined later in the program — still
+// resolves to a direct `musttail` to a stable `@r{i}.fast` name. The real body
+// (when the define compiles natively) or a finalization stub (when it falls back
+// to the interpreter) defines that symbol, so the reference always links (#1499).
+pub const ReservedFast = struct {
+    base: []const u8, // "@r{i}" — the uniform trampoline name
+    fast: []const u8, // "@r{i}.fast" — the register-arg entry a musttail targets
+    arity: u8,
+    consumed: bool = false, // a top-level define of this name has been emitted
 };
 
 fn nameInList(names: []const []const u8, name: []const u8) bool {
@@ -136,6 +170,21 @@ pub const LLVMEmitter = struct {
     // self-tail loop keeps tail calls, so emitCallNode/emitDirectCall also pop
     // these before a tail-call `ret` (a no-op when the count is zero).
     frame_entry_roots: usize = 0,
+    // True only while emitting a `tailcc` register-argument fast-entry body
+    // (#1499). A tail call to another native fast entry may be a guaranteed
+    // `musttail call tailcc` only here — the uniform (ccc) entries, closures,
+    // and the top-level body never can (calling-convention mismatch).
+    in_fast_entry: bool = false,
+    // Forward-reference plumbing (#1499): populated once by preScanReserve and
+    // then read-only. reserved_fast maps a reserved top-level define name to its
+    // stable @r{i}/@r{i}.fast names; fulfilled_fast records names whose real
+    // @r{i}.fast body was emitted; forward_referenced records names a musttail
+    // was emitted to, so finalization can stub any that never got a real body.
+    reserved_fast: std.StringHashMap(ReservedFast),
+    fulfilled_fast: std.StringHashMap(void),
+    forward_referenced: std.StringHashMap(void),
+    // Monotonic counter naming the reserved @r{i} entries (see ReservedFast).
+    reserved_counter: u32,
 
     pub const SavedScope = struct {
         buf: std.ArrayList(u8),
@@ -151,6 +200,7 @@ pub const LLVMEmitter = struct {
         locals: ?std.StringHashMap([]const u8),
         boxes: ?std.StringHashMap([]const u8),
         frame_entry_roots: usize,
+        in_fast_entry: bool,
     };
 
     pub fn saveScope(self: *LLVMEmitter) SavedScope {
@@ -168,6 +218,7 @@ pub const LLVMEmitter = struct {
             .locals = self.locals,
             .boxes = self.boxes,
             .frame_entry_roots = self.frame_entry_roots,
+            .in_fast_entry = self.in_fast_entry,
         };
     }
 
@@ -185,6 +236,7 @@ pub const LLVMEmitter = struct {
         self.locals = s.locals;
         self.boxes = s.boxes;
         self.frame_entry_roots = s.frame_entry_roots;
+        self.in_fast_entry = s.in_fast_entry;
     }
 
     pub fn init(backing: std.mem.Allocator) LLVMEmitter {
@@ -195,6 +247,10 @@ pub const LLVMEmitter = struct {
             .lambda_defs = .empty,
             .native_fns = std.StringHashMap(NativeLambda).init(backing),
             .rebound_globals = std.StringHashMap(void).init(backing),
+            .reserved_fast = std.StringHashMap(ReservedFast).init(backing),
+            .fulfilled_fast = std.StringHashMap(void).init(backing),
+            .forward_referenced = std.StringHashMap(void).init(backing),
+            .reserved_counter = 0,
             .params = null,
             .upvalues = null,
             .tmp_counter = 0,
@@ -220,10 +276,17 @@ pub const LLVMEmitter = struct {
         self.lambda_defs.deinit(self.backing_alloc);
         self.native_fns.deinit();
         self.rebound_globals.deinit();
+        self.reserved_fast.deinit();
+        self.fulfilled_fast.deinit();
+        self.forward_referenced.deinit();
         self.arena.deinit();
     }
 
     pub fn emitProgram(self: *LLVMEmitter, nodes: []const *ir.Node) EmitError!void {
+        // Reserve stable @r{i}.fast names for top-level defines so a forward
+        // mutually-recursive tail call still lowers to a direct musttail (#1499).
+        try tailcall.preScanReserve(self, nodes);
+
         // Emit body into a separate buffer to collect string decls
         var body: std.ArrayList(u8) = .empty;
         defer body.deinit(self.backing_alloc);
@@ -234,6 +297,13 @@ pub const LLVMEmitter = struct {
         for (nodes) |node| {
             _ = self.emitNode(node) catch return error.OutOfMemory;
         }
+
+        // Any reserved name a musttail targeted but that never got a real native
+        // body (fell back to the interpreter) needs a forwarding stub so its
+        // @r{i}.fast symbol resolves at link time (#1499). Appended to
+        // lambda_defs — and its symbol interning done — before the symbol
+        // constants below are emitted.
+        try tailcall.emitForwardStubs(self);
 
         body = self.buf;
         self.buf = saved_buf;
@@ -358,6 +428,17 @@ pub const LLVMEmitter = struct {
         return false;
     }
 
+    // Whether `name` resolves to a top-level global rather than a lexical
+    // capture: a built-in / special form (ir.isKnownGlobal), or a name reserved
+    // for a top-level define emitted later in the program (#1499). The latter is
+    // what lets a *forward* mutual-recursion reference — a callee defined after
+    // its caller — count as a global call instead of a free variable that would
+    // wrongly reject native compilation of the caller. Callers must still check
+    // isNameShadowed first: a lexical binding of the same name outranks a global.
+    pub fn isKnownOrReservedGlobal(self: *LLVMEmitter, name: []const u8) bool {
+        return ir.isKnownGlobal(name) or self.reserved_fast.contains(name);
+    }
+
     fn emitGlobalRef(self: *LLVMEmitter, sym: Value) EmitError![]const u8 {
         if (!types.isSymbol(sym)) return error.UnsupportedNodeType;
         const name = types.symbolName(sym);
@@ -452,7 +533,27 @@ pub const LLVMEmitter = struct {
                     else
                         call.args.len == native.arity;
                     if (arity_ok) {
+                        // A fast-entry callee takes register arguments and, in
+                        // tail position from another fast entry, a guaranteed
+                        // `musttail` (#1499); otherwise the uniform array ABI.
+                        if (native.fast_name) |fast|
+                            return self.emitFastCall(fast, call.args, is_tail);
                         return self.emitDirectCall(native.llvm_name, call.args, is_tail);
+                    }
+                }
+                // Forward reference to a reserved mutually-recursive callee
+                // defined later in the program (#1499): only lowered to a direct
+                // musttail when it is provably safe (tail position, inside a fast
+                // entry, shadow stack balanced). Unsafe/non-tail forward refs
+                // fall through to the indirect path, which observes the runtime
+                // binding. The reserved @r{i}.fast is defined by the real body or
+                // a finalization stub, so the reference always links.
+                if (!self.rebound_globals.contains(op_name) and self.mustTailSafe(is_tail)) {
+                    if (self.reserved_fast.get(op_name)) |rf| {
+                        if (call.args.len == rf.arity) {
+                            self.forward_referenced.put(op_name, {}) catch return error.OutOfMemory;
+                            return self.emitFastCall(rf.fast, call.args, is_tail);
+                        }
                     }
                 }
             }
@@ -1396,6 +1497,61 @@ pub const LLVMEmitter = struct {
         try self.print("  {s} = icmp eq i64 {s}, {d}\n", .{ cond, v, nanbox.nil });
         const result = try self.freshTemp();
         try self.print("  {s} = select i1 {s}, i64 {d}, i64 {d}\n", .{ result, cond, nanbox.true_val, nanbox.false_val });
+        return result;
+    }
+
+    // Whether a tail call here can be a guaranteed `musttail call tailcc`
+    // (#1499). It must be in tail position, inside a `tailcc` fast-entry body
+    // (matching calling convention), and the shadow stack must hold no roots a
+    // torn-down frame would strand: not inside a rooted `let` (self.locals is
+    // non-null only there) and with the frame-entry roots — rest list / boxed
+    // params, always 0 in a fast entry — already balanced. LLVM also requires
+    // the musttail to immediately precede its `ret`, which these guarantee.
+    fn mustTailSafe(self: *LLVMEmitter, is_tail: bool) bool {
+        return is_tail and self.in_fast_entry and self.locals == null and self.frame_entry_roots == 0;
+    }
+
+    // Direct call to a native fast entry (#1499): arguments are passed by value
+    // in registers (no caller-frame args array), so a real `musttail` is sound.
+    // Emits `musttail call tailcc` when mustTailSafe, a `tail call tailcc` hint
+    // for a tail call from a non-fast caller, else a plain `call tailcc`.
+    fn emitFastCall(self: *LLVMEmitter, fast_name: []const u8, args: []const *ir.Node, is_tail: bool) EmitError![]const u8 {
+        const nargs = args.len;
+        const arg_tmps = self.allocator().alloc([]const u8, nargs) catch return error.OutOfMemory;
+        var root_count: usize = 0;
+        for (args, 0..) |arg, i| {
+            arg_tmps[i] = try self.emitNode(arg);
+            if (i + 1 < nargs) {
+                try self.emitRootPush(arg_tmps[i]);
+                root_count += 1;
+            }
+        }
+        try self.emitPopRoots(root_count);
+
+        const musttail = self.mustTailSafe(is_tail);
+        const prefix: []const u8 = if (musttail)
+            "musttail call tailcc"
+        else if (is_tail)
+            "tail call tailcc"
+        else
+            "call tailcc";
+
+        const result = try self.freshTemp();
+        // By-value args: (ptr %vm, i64 a0, …, ptr null). Fast entries are the
+        // direct-call targets — closed functions — so upvalues is always null.
+        try self.print("  {s} = {s} i64 {s}(ptr %vm", .{ result, prefix, fast_name });
+        for (arg_tmps) |a| try self.print(", i64 {s}", .{a});
+        try self.write(", ptr null)\n");
+
+        if (is_tail) {
+            // A fast entry has no frame-entry roots, so for musttail this is a
+            // no-op and the musttail immediately precedes ret as LLVM requires;
+            // a non-fast tail caller may still have some to balance (#1498).
+            if (!musttail) try self.emitPopRoots(self.frame_entry_roots);
+            try self.print("  ret i64 {s}\n", .{result});
+            try self.emitOrphanAfterTail();
+        }
+
         return result;
     }
 

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -3,8 +3,9 @@ const ir = @import("ir.zig");
 const types = @import("types.zig");
 const printer = @import("printer.zig");
 
-const LLVMEmitter = @import("llvm_emit.zig").LLVMEmitter;
-const EmitError = @import("llvm_emit.zig").EmitError;
+const llvm_emit = @import("llvm_emit.zig");
+const LLVMEmitter = llvm_emit.LLVMEmitter;
+const EmitError = llvm_emit.EmitError;
 
 const Value = types.Value;
 
@@ -493,17 +494,49 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
 fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []const []const u8, body_nodes: []const *ir.Node, rest_name: ?[]const u8, boxed: BoxAnalysis) ?[]const u8 {
     const id = self.lambda_counter;
     self.lambda_counter += 1;
-    const fn_name = std.fmt.allocPrint(self.allocator(), "@lambda_{d}", .{id}) catch return null;
 
-    if (name) |n| {
-        self.native_fns.put(n, .{ .llvm_name = fn_name, .arity = @intCast(param_names.len), .is_variadic = rest_name != null }) catch {};
+    // #1499: a fixed-arity, non-variadic, non-boxed *named* function within the
+    // fast-arity bound gets a register-argument `tailcc` fast entry (holding the
+    // body) plus a uniform C-ABI trampoline. Direct callers reach the fast entry
+    // — and, in tail position from another fast entry, via a guaranteed
+    // `musttail`. Everything else keeps the single uniform array-ABI entry.
+    const use_fast = llvm_emit.fast_tailcalls_supported and
+        name != null and
+        rest_name == null and
+        !boxed.any and
+        param_names.len <= llvm_emit.max_fast_arity;
+
+    // A reserved name (preScanReserve) gives forward mutual tail calls a stable
+    // @r{i}.fast target. Use the reserved name pair for the first (only) define
+    // of a reserved name; otherwise a fresh @lambda_{id} pair.
+    var reserved: ?*llvm_emit.ReservedFast = if (name) |n| self.reserved_fast.getPtr(n) else null;
+    if (reserved) |rp| {
+        if (rp.consumed) reserved = null;
     }
 
-    // The native_fns entry is registered up front so a self-recursive tail call
-    // in the body can resolve to it, but body emission can still fail (e.g. an
-    // eval fallback that captures a boxed variable, #1497). If it does, remove
-    // the stale entry — otherwise a call site would emit a direct call to a
-    // @lambda_N that was never defined.
+    const base_name = if (reserved) |rp|
+        rp.base
+    else
+        std.fmt.allocPrint(self.allocator(), "@lambda_{d}", .{id}) catch return null;
+    const fast_name = if (reserved) |rp|
+        rp.fast
+    else
+        std.fmt.allocPrint(self.allocator(), "@lambda_{d}.fast", .{id}) catch return null;
+
+    if (name) |n| {
+        self.native_fns.put(n, .{
+            .llvm_name = base_name,
+            .arity = @intCast(param_names.len),
+            .is_variadic = rest_name != null,
+            .fast_name = if (use_fast) fast_name else null,
+        }) catch {};
+    }
+
+    // native_fns is registered up front so a self-recursive tail call in the
+    // body can resolve to it, but body emission can still fail (e.g. an eval
+    // fallback that captures a boxed variable, #1497). If it does, remove the
+    // stale entry — otherwise a call site would emit a direct call to a function
+    // that was never defined.
     var success = false;
     defer if (!success) {
         if (name) |n| _ = self.native_fns.fetchRemove(n);
@@ -527,6 +560,9 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         self.boxes = if (boxed.any) std.StringHashMap([]const u8).init(self.backing_alloc) else null;
         defer if (self.boxes) |*b| b.deinit();
         self.frame_entry_roots = 0;
+        // A tail call in this body may be a guaranteed `musttail` only from a
+        // `tailcc` fast entry (#1499).
+        self.in_fast_entry = use_fast;
 
         var p = std.StringHashMap(u8).init(self.backing_alloc);
         defer p.deinit();
@@ -547,16 +583,41 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         self.rest_param_name = rest_name;
         self.rest_param_alloca = null;
 
-        const header = std.fmt.allocPrint(self.allocator(), "; {s}\ndefine i64 {s}(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) {{\nentry:\n", .{ name orelse "(lambda)", fn_name }) catch return null;
-        defer self.allocator().free(header);
-        self.write(header) catch return null;
+        // Function signature. The fast entry takes its arguments by value in
+        // registers; the uniform entry takes the caller's args array. Both make
+        // the body read parameters from `%args`, so body emission below is
+        // identical — the fast entry just materializes that `%args` locally.
+        if (use_fast) {
+            self.print("; {s} (fast entry)\ndefine tailcc i64 {s}(ptr %vm", .{ name orelse "(lambda)", fast_name }) catch return null;
+            for (0..param_names.len) |i| self.print(", i64 %a{d}", .{i}) catch return null;
+            self.write(", ptr %upvalues) {\nentry:\n") catch return null;
+        } else {
+            const header = std.fmt.allocPrint(self.allocator(), "; {s}\ndefine i64 {s}(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) {{\nentry:\n", .{ name orelse "(lambda)", base_name }) catch return null;
+            defer self.allocator().free(header);
+            self.write(header) catch return null;
+        }
         self.current_block = "entry";
+
+        // Fast-entry prologue: copy the register arguments into a local %args
+        // array so the rest of the body — param resolution, the self-tail loop's
+        // in-place overwrite, bindParamsAsGlobals — reads/writes `%args`
+        // unchanged. The array is this frame's own; outgoing tail calls pass
+        // argument *values*, never a pointer into it, so `musttail` stays sound.
+        if (use_fast and param_names.len > 0) {
+            self.print("  %args = alloca [{d} x i64], align 8\n", .{param_names.len}) catch return null;
+            for (0..param_names.len) |i| {
+                const gep = self.freshTemp() catch return null;
+                self.print("  {s} = getelementptr i64, ptr %args, i64 {d}\n", .{ gep, i }) catch return null;
+                self.print("  store i64 %a{d}, ptr {s}\n", .{ i, gep }) catch return null;
+            }
+        }
 
         // Build the rest list once, in the entry block, BEFORE branching to the
         // body label. The self-tail loop branches back to body_lbl, so keeping
         // the builder out of that block stops it re-running each iteration — its
         // allocas would otherwise grow the stack per iteration and it would
-        // clobber the rest list the self-call just rebuilt.
+        // clobber the rest list the self-call just rebuilt. (Never runs for a
+        // fast entry, which is non-variadic.)
         if (rest_name != null) {
             emitRestListBuilder(self, param_names.len) catch return null;
         }
@@ -582,8 +643,56 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     const fn_def = fn_buf.toOwnedSlice(self.backing_alloc) catch return null;
     self.lambda_defs.append(self.backing_alloc, fn_def) catch return null;
 
+    // Uniform C-ABI trampoline: unpacks the caller's args array and tail-calls
+    // the fast entry. This is what kaappi_create_native_closure stores for
+    // indirect dispatch (callNativeClosure invokes the uniform signature). It is
+    // `internal`, so LLVM drops it when a define's value is materialized via the
+    // interpreter and nothing takes its address (#1499).
+    if (use_fast) {
+        emitFastTrampoline(self, base_name, fast_name, param_names.len) catch return null;
+    }
+
+    if (reserved) |rp| {
+        rp.consumed = true;
+        // Record that this reserved name's @r{i}.fast got a real body, so no
+        // forwarding stub is emitted for it at finalization.
+        if (use_fast) self.fulfilled_fast.put(name.?, {}) catch {};
+    }
+
     success = true;
-    return fn_name;
+    return base_name;
+}
+
+// The uniform C-ABI shim (`@base`) around a fast entry (`@fast`): load each
+// argument from the caller's %args array and tail-call the register-argument
+// fast entry (#1499). Emitted into its own buffer and appended to lambda_defs.
+fn emitFastTrampoline(self: *LLVMEmitter, base_name: []const u8, fast_name: []const u8, arity: usize) EmitError!void {
+    const saved_buf = self.buf;
+    const saved_tmp = self.tmp_counter;
+    self.buf = .empty;
+    self.tmp_counter = 0;
+    defer {
+        self.buf = saved_buf;
+        self.tmp_counter = saved_tmp;
+    }
+
+    try self.print("; trampoline: {s}\ndefine internal i64 {s}(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) {{\nentry:\n", .{ base_name, base_name });
+    const arg_tmps = self.allocator().alloc([]const u8, arity) catch return error.OutOfMemory;
+    for (0..arity) |i| {
+        const gep = try self.freshTemp();
+        try self.print("  {s} = getelementptr i64, ptr %args, i64 {d}\n", .{ gep, i });
+        const v = try self.freshTemp();
+        try self.print("  {s} = load i64, ptr {s}\n", .{ v, gep });
+        arg_tmps[i] = v;
+    }
+    const result = try self.freshTemp();
+    try self.print("  {s} = call tailcc i64 {s}(ptr %vm", .{ result, fast_name });
+    for (arg_tmps) |a| try self.print(", i64 {s}", .{a});
+    try self.write(", ptr %upvalues)\n");
+    try self.print("  ret i64 {s}\n}}\n", .{result});
+
+    const def = self.buf.toOwnedSlice(self.backing_alloc) catch return error.OutOfMemory;
+    self.lambda_defs.append(self.backing_alloc, def) catch return error.OutOfMemory;
 }
 
 fn emitRestListBuilder(self: *LLVMEmitter, fixed_arity: usize) EmitError!void {
@@ -961,7 +1070,10 @@ fn nodeHasFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []c
             // An enclosing lexical binding outranks a known global of the
             // same name: this reference is a capture, not the primitive.
             if (self.isNameShadowed(name)) return true;
-            if (ir.isKnownGlobal(name)) return false;
+            // A built-in, or a name reserved for a later top-level define, is a
+            // global reference — not a free variable. The reserved case is what
+            // lets a forward mutual-recursion call compile natively (#1499).
+            if (self.isKnownOrReservedGlobal(name)) return false;
             return true;
         },
         .call => {
@@ -1058,8 +1170,9 @@ fn collectNodeFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const
                 if (std.mem.eql(u8, name, p)) return true;
             }
             // A shadowed known global is a capture; only an unshadowed one
-            // may be skipped as a genuine global reference.
-            if (ir.isKnownGlobal(name) and !self.isNameShadowed(name)) return true;
+            // may be skipped as a genuine global reference (incl. a name
+            // reserved for a later top-level define, #1499).
+            if (self.isKnownOrReservedGlobal(name) and !self.isNameShadowed(name)) return true;
             for (list.items) |existing| {
                 if (std.mem.eql(u8, name, existing)) return true;
             }
@@ -1155,8 +1268,9 @@ const FreeNameWalk = struct {
             if (std.mem.eql(u8, name, b)) return;
         }
         // A shadowed known global is a capture; only an unshadowed one is a
-        // genuine global reference (see the section comment above).
-        if (ir.isKnownGlobal(name) and !w.emitter.isNameShadowed(name)) return;
+        // genuine global reference (see the section comment above), including a
+        // name reserved for a later top-level define (#1499).
+        if (w.emitter.isKnownOrReservedGlobal(name) and !w.emitter.isNameShadowed(name)) return;
         w.found = true;
         if (w.buf) |buf| {
             for (buf.items) |existing| {

--- a/src/llvm_emit_tailcall.zig
+++ b/src/llvm_emit_tailcall.zig
@@ -1,0 +1,190 @@
+// Forward-reference plumbing for guaranteed mutual tail calls (#1499).
+//
+// Mutual recursion needs a *forward* tail call — a callee defined later in the
+// program — to lower to a direct `musttail`, but `native_fns` is populated in
+// emission order. `preScanReserve` runs once over all top-level nodes and
+// reserves a stable `@r{i}`/`@r{i}.fast` name pair for every top-level function
+// define that is fast-entry eligible, so a forward call can target `@r{i}.fast`
+// before the define is emitted. `emitForwardStubs` then defines any reserved
+// `@r{i}.fast` that never got a real native body (its define fell back to the
+// interpreter), so every `musttail` target links.
+//
+// The register-argument fast-call emission itself (`emitFastCall`) and the
+// fast-entry function emission (`emitLambdaFunction`, `emitFastTrampoline`) live
+// next to the call/lambda emitters they belong with, in llvm_emit.zig and
+// llvm_emit_lambda.zig respectively. This file is only the reservation +
+// finalization-stub half.
+
+const std = @import("std");
+const ir = @import("ir.zig");
+const types = @import("types.zig");
+
+const llvm_emit = @import("llvm_emit.zig");
+const LLVMEmitter = llvm_emit.LLVMEmitter;
+const EmitError = llvm_emit.EmitError;
+const ReservedFast = llvm_emit.ReservedFast;
+
+const Value = types.Value;
+
+// True if `expr` is a list whose head is the symbol `kw`.
+fn isFormNamed(expr: Value, kw: []const u8) bool {
+    if (!types.isPair(expr)) return false;
+    const head = types.car(expr);
+    return types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), kw);
+}
+
+// A top-level define seen by the pre-scan (#1499). `formals` is non-null only
+// for a *function* define — `(define (f . formals) …)` or
+// `(define f (lambda formals …))` — the only shape a fast entry can apply to.
+const TopDefine = struct { name: []const u8, formals: ?Value };
+
+// Recognize a top-level define node in any of its lowered shapes and extract the
+// defined name (+ formals, for function defines). `(define (f x) …)` lowers to a
+// `.passthrough` (ir.zig lowerDefine), `(define f v)` / `(define f (lambda …))`
+// to a `.define` node.
+fn topLevelDefine(node: *const ir.Node) ?TopDefine {
+    switch (node.tag) {
+        .define => {
+            if (!types.isSymbol(node.data.define.name)) return null;
+            const name = types.symbolName(node.data.define.name);
+            const value = node.data.define.value;
+            if (isFormNamed(value, "lambda")) {
+                const after = types.cdr(value);
+                if (types.isPair(after)) return .{ .name = name, .formals = types.car(after) };
+            }
+            return .{ .name = name, .formals = null };
+        },
+        .passthrough => {
+            const expr = node.data.passthrough;
+            if (!isFormNamed(expr, "define")) return null;
+            const rest = types.cdr(expr);
+            if (!types.isPair(rest)) return null;
+            const target = types.car(rest);
+            if (types.isPair(target) and types.isSymbol(types.car(target)))
+                return .{ .name = types.symbolName(types.car(target)), .formals = types.cdr(target) };
+            if (types.isSymbol(target))
+                return .{ .name = types.symbolName(target), .formals = null };
+            return null;
+        },
+        else => return null,
+    }
+}
+
+// A top-level `(set! name …)` target name, if any.
+fn topLevelSetName(node: *const ir.Node) ?[]const u8 {
+    if (node.tag != .set_form) return null;
+    if (!types.isSymbol(node.data.set_form.name)) return null;
+    return types.symbolName(node.data.set_form.name);
+}
+
+// Count of a proper list of symbol formals (fixed arity ≤ max_fast_arity), or
+// null for a dotted/variadic list, a non-symbol formal, or too many params —
+// none of which are fast-entry eligible.
+fn parseFixedArity(formals: Value) ?u8 {
+    var n: usize = 0;
+    var cur = formals;
+    while (cur != types.NIL) {
+        if (!types.isPair(cur)) return null; // dotted ⇒ variadic
+        if (!types.isSymbol(types.car(cur))) return null;
+        n += 1;
+        if (n > llvm_emit.max_fast_arity) return null;
+        cur = types.cdr(cur);
+    }
+    return @intCast(n);
+}
+
+// Reserve a stable @r{i}/@r{i}.fast name pair for each top-level function define
+// that is fast-entry eligible, so a *forward* mutual tail call (a callee defined
+// later in the program) still lowers to a direct `musttail`. Conservative,
+// syntactic, and sound: only names defined exactly once at top level, never a
+// top-level `set!` target, with a proper list of symbol formals within
+// max_fast_arity are reserved. The real body (if the define compiles natively)
+// or a finalization stub (if it falls back to the interpreter) defines the
+// @r{i}.fast symbol, so the musttail always links.
+pub fn preScanReserve(self: *LLVMEmitter, nodes: []const *ir.Node) EmitError!void {
+    if (!llvm_emit.fast_tailcalls_supported) return;
+
+    var def_count = std.StringHashMap(u32).init(self.allocator());
+    var set_targets = std.StringHashMap(void).init(self.allocator());
+    for (nodes) |node| {
+        if (topLevelDefine(node)) |td| {
+            const gop = def_count.getOrPut(td.name) catch return error.OutOfMemory;
+            gop.value_ptr.* = if (gop.found_existing) gop.value_ptr.* + 1 else 1;
+        }
+        if (topLevelSetName(node)) |sname| {
+            set_targets.put(sname, {}) catch return error.OutOfMemory;
+        }
+    }
+
+    for (nodes) |node| {
+        const td = topLevelDefine(node) orelse continue;
+        const formals = td.formals orelse continue;
+        const arity = parseFixedArity(formals) orelse continue;
+        if ((def_count.get(td.name) orelse 0) != 1) continue; // redefined
+        if (set_targets.contains(td.name)) continue; // rebound by set!
+        if (self.reserved_fast.contains(td.name)) continue;
+
+        const id = self.reserved_counter;
+        self.reserved_counter += 1;
+        const base = std.fmt.allocPrint(self.allocator(), "@r{d}", .{id}) catch return error.OutOfMemory;
+        const fast = std.fmt.allocPrint(self.allocator(), "@r{d}.fast", .{id}) catch return error.OutOfMemory;
+        self.reserved_fast.put(td.name, .{ .base = base, .fast = fast, .arity = arity }) catch return error.OutOfMemory;
+    }
+}
+
+// Emit a forwarding stub for every reserved name a `musttail` targeted that
+// never got a real native @r{i}.fast body (the define fell back to the
+// interpreter). The stub is a `tailcc` shell around the ordinary indirect call —
+// it looks the name up as a global and dispatches through kaappi_call_scheme —
+// so the symbol resolves at link time. Correct, though not itself constant-stack,
+// for that one non-native edge of a cycle.
+pub fn emitForwardStubs(self: *LLVMEmitter) EmitError!void {
+    var it = self.forward_referenced.keyIterator();
+    while (it.next()) |name_ptr| {
+        const name = name_ptr.*;
+        if (self.fulfilled_fast.contains(name)) continue;
+        const rf = self.reserved_fast.get(name) orelse continue;
+        try emitForwardStub(self, name, rf);
+    }
+}
+
+fn emitForwardStub(self: *LLVMEmitter, name: []const u8, rf: ReservedFast) EmitError!void {
+    // Intern the symbol now, while running before the module's symbol constants
+    // are emitted (see emitProgram), so @.sym.N exists for it.
+    const sym_name = try self.internSymbol(name);
+
+    const saved_buf = self.buf;
+    const saved_tmp = self.tmp_counter;
+    self.buf = .empty;
+    self.tmp_counter = 0;
+    defer {
+        self.buf = saved_buf;
+        self.tmp_counter = saved_tmp;
+    }
+
+    try self.print("; forward-ref stub: {s}\ndefine internal tailcc i64 {s}(ptr %vm", .{ name, rf.fast });
+    var i: usize = 0;
+    while (i < rf.arity) : (i += 1) try self.print(", i64 %a{d}", .{i});
+    try self.write(", ptr %upvalues) {\nentry:\n");
+
+    var args_ref: []const u8 = "null";
+    if (rf.arity > 0) {
+        const args_alloca = try self.freshTemp();
+        try self.print("  {s} = alloca [{d} x i64], align 8\n", .{ args_alloca, rf.arity });
+        i = 0;
+        while (i < rf.arity) : (i += 1) {
+            const gep = try self.freshTemp();
+            try self.print("  {s} = getelementptr i64, ptr {s}, i64 {d}\n", .{ gep, args_alloca, i });
+            try self.print("  store i64 %a{d}, ptr {s}\n", .{ i, gep });
+        }
+        args_ref = args_alloca;
+    }
+    const callee = try self.freshTemp();
+    try self.print("  {s} = call i64 @kaappi_global_lookup(ptr %vm, ptr {s}, i64 {d})\n", .{ callee, sym_name, name.len });
+    const result = try self.freshTemp();
+    try self.print("  {s} = call i64 @kaappi_call_scheme(ptr %vm, i64 {s}, ptr {s}, i64 {d})\n", .{ result, callee, args_ref, rf.arity });
+    try self.print("  ret i64 {s}\n}}\n", .{result});
+
+    const def = self.buf.toOwnedSlice(self.backing_alloc) catch return error.OutOfMemory;
+    self.lambda_defs.append(self.backing_alloc, def) catch return error.OutOfMemory;
+}

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -123,6 +123,22 @@ fn expectNotContains(haystack: []const u8, needle: []const u8) !void {
     }
 }
 
+// A named native function is emitted either as a `tailcc` register-argument fast
+// entry (#1499) — the case for a fixed-arity, non-variadic, non-boxed named
+// define within max_fast_arity — or as a uniform array-ABI definition otherwise
+// (variadic, boxed, or over the arity bound). Both are tagged with a `; <name>`
+// header comment. This asserts one of the two forms is present for `name`.
+fn expectNativeDef(ll: []const u8, name: []const u8) !void {
+    var fast_buf: [128]u8 = undefined;
+    var uniform_buf: [128]u8 = undefined;
+    const fast = try std.fmt.bufPrint(&fast_buf, "; {s} (fast entry)\ndefine tailcc i64 @", .{name});
+    const uniform = try std.fmt.bufPrint(&uniform_buf, "; {s}\ndefine i64 @", .{name});
+    if (std.mem.indexOf(u8, ll, fast) == null and std.mem.indexOf(u8, ll, uniform) == null) {
+        std.debug.print("\n--- no native definition (fast or uniform) for {s} ---\n", .{name});
+        return error.TestExpectedNativeDef;
+    }
+}
+
 // Total eval-fallback (code) call sites in emitted IR, regardless of caching:
 // a define-time binding, a general expression, or a lambda the closure tiers
 // can't express. These route through either plain @kaappi_eval or the
@@ -709,7 +725,9 @@ test "LLVM emit: eval fallback routes through the compile-once cache (#1494)" {
     var res = try emitMultiResult("(define (make-summer base) (lambda (a . rest) (+ base a)))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectContains(ll, "define i64 @lambda_0(ptr %vm");
+    // make-summer is a fixed-arity named define, so its body lives in a tailcc
+    // fast entry (#1499); the inner variadic lambda still takes the eval cache.
+    try expectNativeDef(ll, "make-summer");
     try expectContains(ll, "call i64 @kaappi_eval_cached(ptr %vm");
     try expectContains(ll, "@.eval_cache.0 = internal global i64 0");
     // The inner lambda must NOT go through the uncached kaappi_eval anymore.
@@ -877,7 +895,7 @@ test "LLVM emit: a function whose body is a cond compiles natively (#1496)" {
     var res = try emitMultiResult("(define (sign n) (cond ((< n 0) -1) ((= n 0) 0) (else 1)))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectContains(ll, "; sign\ndefine i64 @lambda_");
+    try expectNativeDef(ll, "sign");
     try expectContains(ll, "cond_merge_");
     try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
 }
@@ -886,7 +904,7 @@ test "LLVM emit: do in a function body stays native (#1496)" {
     var res = try emitMultiResult("(define (sumto n) (do ((i 0 (+ i 1)) (s 0 (+ s i))) ((= i n) s)))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectContains(ll, "; sumto\ndefine i64 @lambda_");
+    try expectNativeDef(ll, "sumto");
     try expectContains(ll, "do_header_");
     try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
 }
@@ -933,7 +951,7 @@ test "LLVM emit: a function body with more than 64 forms compiles natively (#149
     try src.appendSlice(std.testing.allocator, ")");
     var res = try emitMultiResult(src.items);
     defer res.deinit();
-    try expectContains(res.toSlice(), "; f\ndefine i64 @lambda_");
+    try expectNativeDef(res.toSlice(), "f");
 }
 
 // -- Variadic self-tail-call loop (#1498) --
@@ -961,6 +979,115 @@ test "LLVM emit: a variadic frame's rest list is GC-rooted for the frame (#1498)
     try expectContains(ll, "; f\ndefine i64 @lambda_");
     try expectContains(ll, "call void @kaappi_gc_push_root");
     try expectContains(ll, "call void @kaappi_gc_pop_roots");
+}
+
+// -- Guaranteed mutual tail calls via tailcc + musttail (#1499) --
+//
+// These positive tests assert that tailcc/musttail/fast-entry IR is emitted,
+// which only happens on hosts where `fast_tailcalls_supported` is true
+// (aarch64/x86_64). The test binary embeds its target arch, so on an unsupported
+// target (e.g. the riscv64-via-QEMU CI job) the feature is off and these skip;
+// the uniform-fallback behavior for those arches is covered by the
+// variadic/boxed/over-arity tests below, which pass on every target.
+
+test "LLVM emit: mutually recursive functions tail-call via musttail (#1499)" {
+    if (!llvm_emit.fast_tailcalls_supported) return error.SkipZigTest;
+    var res = try emitMultiResult("(define (ev? n) (if (= n 0) #t (od? (- n 1))))" ++
+        "(define (od? n) (if (= n 0) #f (ev? (- n 1))))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // Both functions get a tailcc register-argument fast entry ...
+    try expectContains(ll, "define tailcc i64 ");
+    try expectNativeDef(ll, "ev?");
+    try expectNativeDef(ll, "od?");
+    // ... and both directions of the cycle are guaranteed musttail tail calls:
+    // the backward call (od? -> ev?) resolves through native_fns, the forward
+    // call (ev? -> od?, defined later) through the pre-scan reservation.
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "musttail call tailcc"));
+}
+
+test "LLVM emit: a fast-entry function also emits a uniform trampoline (#1499)" {
+    if (!llvm_emit.fast_tailcalls_supported) return error.SkipZigTest;
+    var res = try emitMultiResult("(define (inc n) (+ n 1))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // The body lives in a tailcc register-argument fast entry ...
+    try expectContains(ll, "(fast entry)\ndefine tailcc i64 ");
+    // ... reached by a uniform C-ABI trampoline (internal, so LLVM drops it when
+    // unused) that unpacks %args and tail-calls it — the entry indirect dispatch
+    // stores via kaappi_create_native_closure.
+    try expectContains(ll, "; trampoline:");
+    try expectContains(ll, "define internal i64 ");
+    try expectContains(ll, "call tailcc i64 ");
+}
+
+test "LLVM emit: a non-tail direct call to a fast entry passes register args (#1499)" {
+    if (!llvm_emit.fast_tailcalls_supported) return error.SkipZigTest;
+    var res = try emitMultiResult("(define (sq x) (* x x))" ++
+        "(define (f a b) (+ (sq a) (sq b)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // f calls sq in operand (non-tail) position: a register-argument `call
+    // tailcc`, not a musttail and not the uniform kaappi_call_scheme dispatch.
+    try expectContains(ll, "call tailcc i64 ");
+    try expectNotContains(ll, "call i64 @kaappi_call_scheme");
+}
+
+test "LLVM emit: self-recursion stays a branch loop, not a musttail (#1499)" {
+    // A self-tail-call keeps the in-place arg-overwrite loop (#1498), which is
+    // strictly better than a call; musttail is only for tail calls to OTHERS.
+    var res = try emitMultiResult("(define (loop n) (if (= n 0) 'done (loop (- n 1))))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "br label %body_");
+    try expectNotContains(ll, "musttail");
+}
+
+test "LLVM emit: a variadic function keeps the uniform entry, no fast/musttail (#1499)" {
+    var res = try emitMultiResult("(define (v a . rest) (+ a (length rest)))" ++
+        "(define (t n) (if (= n 0) 0 (v n)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // v is variadic: uniform array-ABI entry only, and the tail call to it from
+    // t cannot be a musttail (v has no fast entry).
+    try expectContains(ll, "; v\ndefine i64 @");
+    try expectNotContains(ll, "; v (fast entry)");
+    try expectNotContains(ll, "musttail call tailcc i64 @r"); // no musttail targets v
+}
+
+test "LLVM emit: a boxed-parameter function has no fast entry (#1499)" {
+    // `n` is captured by the inner lambda and mutated, so make's frame is boxed
+    // (assignment conversion, #1497); boxed frames keep the uniform entry.
+    var res = try emitMultiResult("(define (make n) (lambda () (set! n (+ n 1)) n))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "; make\ndefine i64 @");
+    try expectNotContains(ll, "; make (fast entry)");
+}
+
+test "LLVM emit: a function over the fast-arity bound has no fast entry (#1499)" {
+    // 10 params > max_fast_arity (8): the uniform array ABI is kept.
+    var res = try emitMultiResult("(define (wide a b c d e g h i j k) (+ a b c d e g h i j k))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectContains(ll, "; wide\ndefine i64 @");
+    try expectNotContains(ll, "(fast entry)");
+}
+
+test "LLVM emit: a forward-referenced non-native define gets a tailcc stub (#1499)" {
+    if (!llvm_emit.fast_tailcalls_supported) return error.SkipZigTest;
+    var res = try emitMultiResult("(define (caller n) (if (= n 0) 0 (helper (- n 1))))" ++
+        "(define (helper n) (letrec ((loop (lambda (x) x))) (loop n)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // caller (a fast entry) tail-calls helper before it is defined: a musttail
+    // to the reserved @r{i}.fast.
+    try expectContains(ll, "musttail call tailcc");
+    // helper's body needs letrec (an eval fallback) so it has no real native
+    // fast body; finalization emits a forwarding stub so the musttail resolves.
+    try expectContains(ll, "forward-ref stub:");
+    try expectContains(ll, "define internal tailcc i64 ");
+    try expectContains(ll, "call i64 @kaappi_call_scheme"); // the stub dispatches indirectly
 }
 
 test "LLVM emit: a lambda capturing a param through a cond gets an upvalue (#1496)" {
@@ -1226,12 +1353,13 @@ test "native-subset generator emits no unexpected kaappi_eval fallbacks" {
         // require the named native function definition that the emitter
         // tags with a `; <name>` header comment.
         for (names[0..name_count]) |n| {
-            var needle_buf: [64]u8 = undefined;
-            const needle = try std.fmt.bufPrint(&needle_buf, "; {s}\ndefine i64 @lambda_", .{n});
-            if (std.mem.indexOf(u8, ll, needle) == null) {
+            // A named define is emitted as a tailcc fast entry (#1499) or, when
+            // not fast-eligible, a uniform definition — expectNativeDef accepts
+            // either. (A false return would mean the whole define fell back.)
+            expectNativeDef(ll, n) catch {
                 std.debug.print("seed {d}: no native definition for {s}\n", .{ seed, n });
                 return error.NativeSubsetFellBackToEval;
-            }
+            };
         }
     }
 }

--- a/tests/e2e/programs/native-mutual-tail.scm
+++ b/tests/e2e/programs/native-mutual-tail.scm
@@ -1,0 +1,35 @@
+; Guaranteed constant-stack mutual tail recursion via tailcc + musttail (#1499).
+;
+; even?/odd? exercise both directions of a 2-cycle: the forward call
+; (my-even? -> my-odd?, defined later) resolves through the pre-scan reservation,
+; the backward call (my-odd? -> my-even?) through native_fns. Both lower to
+; `musttail call tailcc`. The depth here (2,000,000) is far past what an 8 MB
+; stack holds as real frames, so a native binary that did NOT tail-call would
+; overflow and crash — the e2e diff against the (VM-TCO) interpreter is thus a
+; constant-stack regression test, not just an output check.
+(define (my-even? n) (if (= n 0) #t (my-odd? (- n 1))))
+(define (my-odd? n) (if (= n 0) #f (my-even? (- n 1))))
+
+(display (my-even? 2000000)) (newline) ; #t
+(display (my-odd? 2000001)) (newline)  ; #t
+(display (my-even? 2000001)) (newline) ; #f
+
+; A 3-function cycle — each call is in tail position, so all three are musttail.
+(define (count-a n) (if (= n 0) 'done-a (count-b (- n 1))))
+(define (count-b n) (if (= n 0) 'done-b (count-c (- n 1))))
+(define (count-c n) (if (= n 0) 'done-c (count-a (- n 1))))
+
+(display (count-a 1500000)) (newline)
+
+; A non-tail direct call to a fast entry: a register-argument `call tailcc`
+; (no args array), not a musttail. Verifies the fast entry is also the
+; ordinary direct-call target.
+(define (sq x) (* x x))
+(define (sum-of-squares a b) (+ (sq a) (sq b)))
+(display (sum-of-squares 3 4)) (newline) ; 25
+
+; A tail call nested inside an `if` inside a mutual cycle, mixed with a
+; self-tail loop (which stays a branch loop, not a musttail).
+(define (ping n acc) (if (= n 0) acc (pong (- n 1) (+ acc 1))))
+(define (pong n acc) (if (= n 0) acc (ping (- n 1) (+ acc 2))))
+(display (ping 1000000 0)) (newline)

--- a/tests/scheme/compile/native-set-capture-divergence-1422.sh
+++ b/tests/scheme/compile/native-set-capture-divergence-1422.sh
@@ -55,16 +55,19 @@ check() {
         fail=1
     fi
 
-    # Pin the compilation tier when requested.
+    # Pin the compilation tier when requested. A native user-function definition
+    # is `@lambda_N` (uniform) or, since #1499, a reserved `@rN` / `@rN.fast` /
+    # `@lambda_N.fast` fast entry — all tagged `define [internal|tailcc ...] i64`.
     if [[ -n "$expect_native" ]]; then
         (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1) || true
+        local native_def_re='^define ([a-z]+ )*i64 @(lambda_|r[0-9])'
         if [[ "$expect_native" == "yes" ]]; then
-            if ! grep -q '^define i64 @lambda_' "$DIR/$name.ll" 2>/dev/null; then
+            if ! grep -qE "$native_def_re" "$DIR/$name.ll" 2>/dev/null; then
                 echo "FAIL: $name — expected native fn definition in LLVM IR" >&2
                 fail=1
             fi
         elif [[ "$expect_native" == "no" ]]; then
-            if grep -q '^define i64 @lambda_' "$DIR/$name.ll" 2>/dev/null; then
+            if grep -qE "$native_def_re" "$DIR/$name.ll" 2>/dev/null; then
                 echo "FAIL: $name — expected NO native fn definition (should fall back)" >&2
                 fail=1
             fi


### PR DESCRIPTION
Closes #1499 (the structural / ABI-change item of epic #1491).

## Problem

Self-tail-recursion in the LLVM backend is constant-stack (an arg-overwrite branch loop), but a tail call to *another* function is not: the uniform entry `@lambda_N(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues)` reads its parameters from a **caller-frame `%args` array**, and a real tail call tears that frame down, so the callee would read freed stack. `even?`/`odd?`-style **mutual** recursion therefore grew the stack and eventually SIGSEGV'd. Guaranteed TCO needs arguments passed **by value** — an ABI change — which is what `tailcc` + `musttail` provide (`tailcc` frees `musttail` from the prototype-match rule, so different-arity mutual calls are legal).

## Approach

A fixed-arity, non-variadic, non-boxed **named** function (arity ≤ `max_fast_arity`, 8) now emits **two** functions:

- **`@name.fast`** — `tailcc`, arguments by value in registers. Its entry block copies them into a local `%args` array, so the entire existing body machinery (param resolution, the self-tail loop, boxed params, `bindParamsAsGlobals`) is reused byte-for-byte. Outgoing calls pass argument *values*, never a pointer into the frame, so `musttail` is sound.
- **`@name`** — an `internal` uniform-ABI **trampoline** unpacking `%args` and `call tailcc @name.fast`. This is what `kaappi_create_native_closure` stores for indirect dispatch; LLVM drops it when unused.

Direct tail calls between fast entries emit `musttail call tailcc … ; ret` (LLVM-guaranteed constant stack). Non-tail direct calls use register-argument `call tailcc` (no args array). Self-recursion keeps its branch loop (better than any call). **Variadic, boxed, over-arity, and closure functions are unchanged** — they keep the single uniform entry, so indirect dispatch is untouched.

**Forward references** (a mutually-recursive callee defined later) resolve through a syntactic pre-scan (`preScanReserve`, new `src/llvm_emit_tailcall.zig`) that reserves stable `@r{i}.fast` names for single-definition, non-`set!`, fixed-arity top-level functions; `emitForwardStubs` defines a `tailcc` forwarding stub for any reserved name that fell back to the interpreter, so every `musttail` target links. A reference to a reserved name counts as a **global** in free-variable analysis (`isKnownOrReservedGlobal`), so the caller still compiles natively (without this, a forward reference to a novel name looked like a free variable — `even?`/`odd?` only worked because they are built-ins).

**Safety.** `musttail` is gated (`mustTailSafe`) on being inside a `tailcc` fast entry, in tail position, and **outside any rooted `let`** (`self.locals == null`) with frame-entry roots balanced — so it never strands shadow-stack roots and always immediately precedes its `ret`. The whole feature is gated per target on `aarch64`/`x86_64` (`fast_tailcalls_supported`); other hosts keep the prior uniform ABI exactly.

## Acceptance criteria

- [x] Mutually-recursive native functions run in **constant stack** — 50M/30M-deep `even?`/`odd?` (and a 3-cycle, and an accumulator ping/pong) run native at ~3 MB flat RSS, exit 0; the old best-effort path would overflow.
- [x] **No regression for indirect calls;** `tests/e2e` + continuation suites green (36/36 e2e, full unit suite, `tests_native` under `-Dgc-stress=true`).
- [x] **Gated per-target** on backend `musttail` support (comptime `builtin.cpu.arch` switch; cross-compiles cleanly with the gate both on x86_64 and off riscv64).

## Testing

- New e2e program `tests/e2e/programs/native-mutual-tail.scm` — its native-vs-interpreter diff doubles as the constant-stack regression check (a non-tail-calling native binary would overflow and mismatch).
- 8 new emitter unit tests (`src/tests_native.zig`): musttail in both cycle directions, the uniform trampoline, register-arg non-tail calls, self-recursion staying a loop, variadic/boxed/over-arity staying uniform, and the forward-reference stub path.
- GC-safe verified under `KAAPPI_GC_THRESHOLD=1` with heap-allocating mutual recursion matching the interpreter.
- IR verifies under `opt -passes=verify`.
- `docs/dev/llvm-backend.md` documents the new mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)