### PR TITLE
Add crash-reporting panic handler with context breadcrumb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,8 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 | `bytecode_file.zig` | Bytecode serialization/deserialization (.sbc cache format) |
 | `disassembler.zig` | Bytecode disassembler for `(disassemble proc)` |
 | `linenoise.zig` | Zig FFI wrapper for vendored linenoise C library |
-| `main.zig` | Entry point, REPL loop with linenoise, file execution, CLI flags, `pub const version` |
+| `main.zig` | Entry point, REPL loop with linenoise, file execution, CLI flags, `pub const version`, `pub const panic` |
+| `crash.zig` | Custom panic handler (`PanicHandler(name)`) + pipeline breadcrumb (`noteStage`/`noteFile`); prints version/target/build-mode + stage + report URL before the trace. See `docs/dev/crash-reporting.md` |
 | `native_compiler.zig` | LLVM IR emission, native binary compilation, C compiler discovery, linker invocation |
 | `thottam.zig` | Package manager binary (thottam): install, remove, list, update, verify |
 | `llvm_emit.zig` | LLVM IR text emitter (walks IR nodes, produces `.ll` files) |

--- a/docs/dev/crash-reporting.md
+++ b/docs/dev/crash-reporting.md
@@ -1,0 +1,118 @@
+# Crash reporting — the panic handler
+
+When a bug is *in Kaappi itself* (not in the user's program), the ReleaseSafe
+binary dies with a Zig panic and a stack trace. The trace is the valuable part
+and is kept verbatim. What the custom panic handler adds in front of it is the
+context that turns an unreproducible report into an actionable one:
+
+```text
+kaappi internal error — this is a bug in kaappi, not in your program.
+  version: v0.14.1 (aarch64-macos, ReleaseSafe)
+  while:   compiling /path/to/file.scm
+  report:  https://github.com/kaappi/kaappi/issues/new — include everything below.
+
+thread 12345 panic: <message>
+<stack trace>
+```
+
+Part of the machine-legibility epic
+([#1503](https://github.com/kaappi/kaappi/issues/1503)); tracked in
+[#1514](https://github.com/kaappi/kaappi/issues/1514). A raw panic is already
+better than a silent segfault, but it gives the user no guidance, no version
+context, and lands as a report we often can't reproduce. The banner fixes all
+three: it says *whose* bug it is, names the exact build, and says where to send
+it — while the trace below it stays intact.
+
+## The four banner lines
+
+| Line | Source | Why |
+|------|--------|-----|
+| identity | comptime `binary_name` | Distinguishes an interpreter bug from a bug in the user's Scheme, and names which binary (`kaappi` / `thottam`). |
+| `version:` | `build_options.version`, `builtin.cpu.arch`/`os.tag`, `builtin.mode` | A report that doesn't name the build wastes a round-trip. All three are comptime — free at runtime. The target is the short `arch-os` form; `kaappi features` prints the full `arch-os-abi` triple. |
+| `while:` | the breadcrumb (below) | The single most useful field for reproduction: which pipeline stage, and which file, was in flight. |
+| `report:` | constant | Removes the "where do I file this?" step. |
+
+The `while:` line is **omitted** when the breadcrumb is still `idle` — a
+pre-pipeline crash, or a binary like `thottam` that runs no Scheme pipeline —
+rather than inventing a stage. The other three lines always print.
+
+## The breadcrumb
+
+`src/crash.zig` holds a process-wide breadcrumb: a coarse `Stage`
+(`reading` / `expanding` / `compiling` / `executing`) plus the file in flight.
+The top-level driver updates it at each stage boundary with a single store:
+
+```zig
+crash.noteFile(path);      // once per file/stream
+crash.noteStage(.compiling); // per top-level form, at each boundary
+```
+
+It is deliberately trivial — a plain enum store and a slice store, no
+allocation, no locking — matching the other process-wide flags in this codebase
+(`ir.optimize_enabled`, `main.script_had_error`,
+`toplevel_driver.diagnostic_format`). The design constraints that make plain
+globals safe here:
+
+- **Read only at panic.** Live execution never consults the breadcrumb, so a
+  stale value can only mislabel a crash; it can never misdirect a running
+  program.
+- **Single writer.** Only the main pipeline thread writes it, and only before
+  any SRFI-18 worker exists for a given file, so there is no torn write to worry
+  about. An SRFI-18 worker that panics reads whatever stage was last set
+  (`executing`), which is correct for it anyway.
+- **Never dangles.** The stored file slice is always a long-lived path (from
+  argv) or a string literal (`<stdin>`, `<repl>`, `<bundled program>`,
+  `<panic-test>`), so it is valid when the handler reads it.
+
+### Where it's wired
+
+| Path | File | Stages set |
+|------|------|-----------|
+| file runner (fresh + cached) | `main.zig` `runFile` | reading → executing (imports) → compiling → executing |
+| stdin runner | `main.zig` `runStdin` | reading → executing → compiling → executing |
+| standalone (embedded bytecode) | `main.zig` | executing |
+| REPL | `repl.zig` `evalInputInner` | reading → executing → compiling → executing, `reset()` on return to prompt |
+| `kaappi ast` / `expand` / `ir` | `pipeline.zig` | reading, expanding, compiling |
+| `kaappi compile` (native) | `native_compiler.zig` `emitLlvmFile` | compiling |
+
+Macro expansion happens *inside* the compiler on the normal run path, so
+`expanding` as a distinct breadcrumb is set by `kaappi expand` (where it is the
+literal activity); on a normal run the compiler stage covers expansion.
+
+## Installation
+
+Each user-facing binary's root file sets the Zig root `panic` namespace to a
+handler built for its name:
+
+```zig
+// src/main.zig
+pub const panic = crash.PanicHandler("kaappi");
+// src/thottam.zig
+pub const panic = crash.PanicHandler("thottam");
+```
+
+`PanicHandler(name)` returns a `std.debug.FullPanic` whose `call` prints the
+banner and then delegates to `std.debug.defaultPanic`, so **every** safety-check
+panic, `unreachable`, and `@panic` funnels through it with the standard message
+and full stack trace preserved. The handler writes straight to fd 2 with a raw
+syscall — a panic handler must not depend on allocation or any subsystem that may
+itself be in the broken state that triggered the panic.
+
+## The deliberate-panic test hook
+
+`crash.maybePanicTest` recognizes `--panic-test[=<stage>]`, sets a
+representative breadcrumb, and deliberately `@panic`s. `main` dispatches it
+before any setup, so it never touches the VM. It is undocumented (not in
+`--help`) and not part of normal option parsing.
+
+It is intentionally **available in every build mode, not Debug-gated**: the whole
+point is to verify the banner the *shipped* ReleaseSafe binary prints (the mode
+the example names), and the Scheme error suite runs against exactly that build. A
+Debug-only hook could never test the path a real user hits.
+
+`tests/scheme/errors/crash-handler.sh` drives it: it asserts the identity line,
+the version/target/build-mode line, the breadcrumb (and that it tracks the
+`=<stage>` selector), the report URL, that the standard panic message + trace
+addresses survive in front of the banner, and that the process dies by signal
+(abort) rather than exiting cleanly. `src/crash.zig` also carries unit tests for
+the stage verbs, the breadcrumb state machine, and the target-string shape.

--- a/src/crash.zig
+++ b/src/crash.zig
@@ -1,0 +1,243 @@
+//! Custom panic handler for the user-facing binaries (`kaappi`, `thottam`) —
+//! kaappi#1514, part of the machine-legibility epic kaappi#1503.
+//!
+//! In ReleaseSafe (the shipped default) a bug *in the interpreter* dies with a
+//! raw Zig panic and stack trace. The trace is the valuable part and is kept
+//! verbatim; what this adds in front of it is the context that turns an
+//! unreproducible report into an actionable one:
+//!
+//!   * which binary, and the fact that this is *our* bug, not the user's program;
+//!   * version, target triple, and build mode (so a report names the exact build);
+//!   * a breadcrumb naming the pipeline stage and file in flight when it died;
+//!   * where to report it.
+//!
+//! Example:
+//!
+//!   kaappi internal error — this is a bug in kaappi, not in your program.
+//!     version: v0.14.1 (aarch64-macos, ReleaseSafe)
+//!     while:   compiling /path/to/file.scm
+//!     report:  https://github.com/kaappi/kaappi/issues/new — include everything below.
+//!
+//!   thread 12345 panic: <message>
+//!   <stack trace>
+//!
+//! **Installation.** Each binary's root file sets
+//! `pub const panic = crash.PanicHandler("<name>")`. `PanicHandler` returns a
+//! `std.debug.FullPanic` namespace whose `call` prints the banner and then
+//! delegates to `std.debug.defaultPanic`, so every safety check, `unreachable`,
+//! and `@panic` funnels through it with the standard message + trace intact.
+//!
+//! **The breadcrumb** (`noteStage` / `noteFile`) is updated by the top-level
+//! driver at each pipeline stage boundary. It is deliberately trivial — a plain
+//! enum store and a slice store, no allocation, no locking — matching the other
+//! process-wide flags in this codebase (`ir.optimize_enabled`,
+//! `main.script_had_error`, `toplevel_driver.diagnostic_format`). It is only ever
+//! *read* from the panic handler, and only written on the single main pipeline
+//! thread before any SRFI-18 worker exists for a given file, so a stale value at
+//! worst mislabels a crash; it can never misdirect live execution. The stored
+//! file slice is always a long-lived path (argv) or a string literal, so it can
+//! never dangle at panic time.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
+
+/// Arch and OS of this build, e.g. "aarch64-macos" — no ABI suffix, matching the
+/// banner format. (`kaappi features` reports the full `arch-os-abi` triple; this
+/// is the shorter human form for the crash line.) Comptime, so free at runtime.
+const target = @tagName(builtin.cpu.arch) ++ "-" ++ @tagName(builtin.os.tag);
+
+// ── Breadcrumb ───────────────────────────────────────────────────────────
+
+/// The coarse pipeline stage in flight, updated at stage boundaries by the
+/// top-level driver. Read only by the panic handler to render the `while:` line.
+pub const Stage = enum {
+    idle,
+    reading,
+    expanding,
+    compiling,
+    executing,
+
+    /// Present-participle verb for the `while:` line.
+    fn verb(self: Stage) []const u8 {
+        return switch (self) {
+            .idle => "starting up",
+            .reading => "reading",
+            .expanding => "expanding",
+            .compiling => "compiling",
+            .executing => "executing",
+        };
+    }
+};
+
+// Process-wide, single-writer (the main pipeline thread), read only at panic.
+// Plain globals — no atomics — for the reasons in the module doc comment.
+var current_stage: Stage = .idle;
+var current_file: []const u8 = "";
+
+/// Record the pipeline stage now in flight. Near-zero cost: a single store.
+pub fn noteStage(stage: Stage) void {
+    current_stage = stage;
+}
+
+/// Record the file (or a `<stdin>` / `<repl>` label) now being processed. The
+/// slice must outlive the run; every caller passes a long-lived path or a string
+/// literal, so the breadcrumb can never dangle when the panic handler reads it.
+pub fn noteFile(path: []const u8) void {
+    current_file = path;
+}
+
+/// Set stage and file together at a boundary that also names a new file.
+pub fn note(stage: Stage, path: []const u8) void {
+    current_file = path;
+    current_stage = stage;
+}
+
+/// Reset to idle — e.g. the REPL returning to the prompt between inputs, so a
+/// crash while idle at the prompt is not mislabeled as the last evaluation.
+pub fn reset() void {
+    current_stage = .idle;
+    current_file = "";
+}
+
+// ── Panic handler ────────────────────────────────────────────────────────
+
+/// Write straight to stderr with a raw syscall — a panic handler must not depend
+/// on allocation or any subsystem that may itself be in the broken state that
+/// triggered the panic. Mirrors `reporting.writeToFd` but is self-contained.
+fn writeStderr(bytes: []const u8) void {
+    var total: usize = 0;
+    while (total < bytes.len) {
+        const rc = std.posix.system.write(2, bytes.ptr + total, bytes.len - total);
+        if (rc < 0) {
+            if (std.posix.errno(rc) == .INTR) continue;
+            return;
+        }
+        if (rc == 0) return;
+        total += @intCast(rc);
+    }
+}
+
+/// Print the crash banner: identity + build, the stage/file breadcrumb, and the
+/// report URL. Everything but the breadcrumb is comptime-constant text. The
+/// `while:` line is omitted entirely when the breadcrumb is still `idle` (a
+/// pre-pipeline crash, or a binary like `thottam` with no Scheme pipeline) —
+/// more honest than inventing a stage.
+fn printBanner(comptime binary_name: []const u8) void {
+    writeStderr("\n" ++ binary_name ++ " internal error — this is a bug in " ++
+        binary_name ++ ", not in your program.\n" ++
+        "  version: v" ++ build_options.version ++ " (" ++ target ++ ", " ++ @tagName(builtin.mode) ++ ")\n");
+
+    if (current_stage != .idle) {
+        writeStderr("  while:   ");
+        writeStderr(current_stage.verb());
+        if (current_file.len > 0) {
+            writeStderr(" ");
+            writeStderr(current_file);
+        }
+        writeStderr("\n");
+    }
+
+    writeStderr("  report:  https://github.com/kaappi/kaappi/issues/new — include everything below.\n\n");
+}
+
+/// Build the `pub const panic` namespace for a binary. The returned
+/// `std.debug.FullPanic` prints our banner, then hands off to the standard panic
+/// path so the message and full stack trace are preserved unchanged.
+pub fn PanicHandler(comptime binary_name: []const u8) type {
+    const Impl = struct {
+        fn call(msg: []const u8, first_trace_addr: ?usize) noreturn {
+            printBanner(binary_name);
+            std.debug.defaultPanic(msg, first_trace_addr);
+        }
+    };
+    return std.debug.FullPanic(Impl.call);
+}
+
+// ── Deliberate-panic test hook ───────────────────────────────────────────
+
+/// Internal, undocumented hook that lets CI exercise the panic handler against a
+/// real build (kaappi#1514 acceptance criterion). It is intentionally available
+/// in *every* build mode — not gated to Debug — because the whole point is to
+/// verify the banner the shipped **ReleaseSafe** binary prints (the mode the
+/// example names); a Debug-only hook could never test that path. It is kept out
+/// of `--help` and normal option parsing, and dispatched before any setup, so it
+/// is never a user-facing surface.
+///
+/// `--panic-test[=<stage>]`: set a representative breadcrumb (the named stage, or
+/// `executing` by default, with a synthetic file) and deliberately panic. Does
+/// nothing and returns if the argument is absent, so the caller falls through to
+/// normal dispatch.
+pub fn maybePanicTest(args: std.process.Args) void {
+    const flag = "--panic-test";
+    var it = args.iterate();
+    _ = it.skip(); // argv[0]
+    while (it.next()) |arg| {
+        if (!std.mem.startsWith(u8, arg, flag)) continue;
+        // Optional "=<stage>" selector so a test can assert the while: line
+        // tracks the breadcrumb the pipeline set.
+        const rest = arg[flag.len..];
+        const stage: Stage = if (rest.len > 1 and rest[0] == '=')
+            stageFromName(rest[1..]) orelse .executing
+        else
+            .executing;
+        note(stage, "<panic-test>");
+        @panic("deliberate panic: --panic-test crash-handler hook");
+    }
+}
+
+/// The `Stage` whose tag is `name`, or null. Used only by the test hook.
+fn stageFromName(name: []const u8) ?Stage {
+    for (std.enums.values(Stage)) |s| {
+        if (std.mem.eql(u8, name, @tagName(s))) return s;
+    }
+    return null;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "stage verbs are present-participle and total" {
+    try testing.expectEqualStrings("reading", Stage.reading.verb());
+    try testing.expectEqualStrings("expanding", Stage.expanding.verb());
+    try testing.expectEqualStrings("compiling", Stage.compiling.verb());
+    try testing.expectEqualStrings("executing", Stage.executing.verb());
+    try testing.expectEqualStrings("starting up", Stage.idle.verb());
+}
+
+test "stageFromName round-trips every tag and rejects unknowns" {
+    for (std.enums.values(Stage)) |s| {
+        try testing.expectEqual(@as(?Stage, s), stageFromName(@tagName(s)));
+    }
+    try testing.expect(stageFromName("nonsense") == null);
+    try testing.expect(stageFromName("") == null);
+}
+
+test "breadcrumb note/noteStage/noteFile/reset update the globals" {
+    defer reset();
+
+    note(.compiling, "/tmp/foo.scm");
+    try testing.expectEqual(Stage.compiling, current_stage);
+    try testing.expectEqualStrings("/tmp/foo.scm", current_file);
+
+    noteStage(.executing);
+    try testing.expectEqual(Stage.executing, current_stage);
+    try testing.expectEqualStrings("/tmp/foo.scm", current_file); // file unchanged
+
+    noteFile("<stdin>");
+    try testing.expectEqualStrings("<stdin>", current_file);
+    try testing.expectEqual(Stage.executing, current_stage); // stage unchanged
+
+    reset();
+    try testing.expectEqual(Stage.idle, current_stage);
+    try testing.expectEqualStrings("", current_file);
+}
+
+test "target string is arch-os with no abi suffix" {
+    // Two components, exactly one '-' separating them (arch names never contain
+    // one; "-none"/"-gnu" would add a second). Guards the banner's shorter form.
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, target, "-"));
+    try testing.expect(std.mem.startsWith(u8, target, @tagName(builtin.cpu.arch)));
+    try testing.expect(std.mem.endsWith(u8, target, @tagName(builtin.os.tag)));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -53,8 +53,14 @@ pub const check = @import("check.zig");
 pub const pipeline = @import("pipeline.zig");
 pub const config = @import("config.zig");
 pub const fmt = @import("fmt.zig");
+pub const crash = @import("crash.zig");
 
 pub const version = @import("build_options").version;
+
+/// Custom panic handler (kaappi#1514): prints version/target/build-mode, the
+/// pipeline breadcrumb, and a report URL before the standard message + trace.
+/// Picked up by the Zig compiler as the root `panic` namespace.
+pub const panic = crash.PanicHandler("kaappi");
 
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
@@ -173,6 +179,10 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     // registry — no VM, GC, or library setup needed — so handle it before any
     // of that exists and exit. (Skipped on WASM, whose entry just runs a file.)
     if (comptime !is_wasm) {
+        // Internal, undocumented hook (kaappi#1514): `--panic-test` deliberately
+        // panics so CI can verify the crash banner on a real build. Dispatched
+        // first, before any setup, and never returns when the flag is present.
+        crash.maybePanicTest(init.args);
         if (explain.maybeRun(allocator, init.args)) |exit_code| {
             std.process.exit(exit_code);
         }
@@ -296,6 +306,9 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             vm.bundled_files = &bundled_files_map;
         }
         defer vm.bundled_files = null;
+
+        // Everything from here runs the bundled program (kaappi#1514 breadcrumb).
+        crash.note(.executing, "<bundled program>");
 
         // Replay preamble (import, include, define-library forms)
         if (loaded.preamble) |preamble| {
@@ -611,6 +624,9 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
     vm.current_lib_dir = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[0 .. pos + 1] else "";
     defer vm.current_lib_dir = saved_lib_dir;
 
+    // Crash breadcrumb (kaappi#1514): name the file once; stages update per-form.
+    crash.noteFile(path);
+
     const source = readFileContents(allocator, path) catch {
         script_had_error = true;
         return;
@@ -671,6 +687,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             }
 
             const top_count = @min(loaded.top_level_count, @as(u32, @intCast(loaded.funcs.len)));
+            crash.noteStage(.executing);
             for (loaded.funcs[0..top_count]) |func| {
                 var func_val = types.makePointer(@ptrCast(func));
                 vm.gc.pushRoot(&func_val);
@@ -699,12 +716,14 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
     var r = reader.Reader.initWithName(vm.gc, source, path);
     defer r.deinit();
 
+    crash.noteStage(.reading);
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
         toplevel_driver.reportReadError(path, lc.line, lc.col, err);
         script_had_error = true;
         return;
     }) {
+        crash.noteStage(.reading);
         const datum_lc = r.getLineCol();
         var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
@@ -716,6 +735,8 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
+        // A top-level import/define-library/include runs library code here.
+        crash.noteStage(.executing);
         if (vm.handleTopLevelForm(expr)) |top_result| {
             has_imports = true;
             const result = top_result catch |err| {
@@ -727,6 +748,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             continue;
         }
 
+        crash.noteStage(.compiling);
         const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path, false) catch |err| {
             toplevel_driver.reportCompileError(path, datum_lc.line, datum_lc.col, err);
             script_had_error = true;
@@ -739,6 +761,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         var func_val = types.makePointer(@ptrCast(func));
         vm.gc.pushRoot(&func_val);
 
+        crash.noteStage(.executing);
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();
             script_had_error = true;
@@ -803,6 +826,8 @@ fn runStdin(vm: *vm_mod.VM) !void {
     };
     defer allocator.free(source);
 
+    crash.note(.reading, "<stdin>");
+
     var r = reader.Reader.initWithName(vm.gc, source, "<stdin>");
     defer r.deinit();
 
@@ -812,6 +837,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
         script_had_error = true;
         return;
     }) {
+        crash.noteStage(.reading);
         // Capture the datum's start position before reading it, so a compile
         // error with no recorded span still falls back to the form's start
         // column (not the post-datum position) — kaappi#1506.
@@ -826,6 +852,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
+        crash.noteStage(.executing);
         if (vm.handleTopLevelForm(expr)) |top_result| {
             const result = top_result catch |err| {
                 script_had_error = true;
@@ -836,6 +863,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
             continue;
         }
 
+        crash.noteStage(.compiling);
         const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, "<stdin>", false) catch |err| {
             toplevel_driver.reportCompileError("<stdin>", datum_lc.line, datum_lc.col, err);
             script_had_error = true;
@@ -845,6 +873,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
         var func_val = types.makePointer(@ptrCast(func));
         vm.gc.pushRoot(&func_val);
 
+        crash.noteStage(.executing);
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();
             script_had_error = true;
@@ -1084,4 +1113,5 @@ test {
     _ = config;
     _ = fmt;
     _ = @import("fmt_print.zig");
+    _ = crash;
 }

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -9,6 +9,7 @@ const file_utils = @import("file_utils.zig");
 const reporting = @import("reporting.zig");
 const kaappi_paths = @import("kaappi_paths.zig");
 const diagnostics = @import("diagnostics.zig");
+const crash = @import("crash.zig");
 
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
@@ -26,6 +27,8 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     const saved_lib_dir = vm.current_lib_dir;
     vm.current_lib_dir = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[0 .. pos + 1] else "";
     defer vm.current_lib_dir = saved_lib_dir;
+
+    crash.note(.compiling, path); // native backend: read → lower → emit LLVM IR
 
     var r = reader_mod.Reader.initWithName(vm.gc, source, path);
     defer r.deinit();

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -34,6 +34,7 @@ const ir_mod = @import("ir.zig");
 const reporting = @import("reporting.zig");
 const file_utils = @import("file_utils.zig");
 const toplevel_driver = @import("toplevel_driver.zig");
+const crash = @import("crash.zig");
 
 const VM = vm_mod.VM;
 const Value = types.Value;
@@ -54,6 +55,8 @@ pub fn runAst(vm: *VM, path: []const u8) u8 {
     const allocator = vm.gc.allocator;
     const source = readSource(allocator, path) orelse return 1;
     defer allocator.free(source);
+
+    crash.note(.reading, path); // pure read + write
 
     var r = reader.Reader.initWithName(vm.gc, source, path);
     defer r.deinit();
@@ -81,13 +84,17 @@ pub fn runExpand(vm: *VM, path: []const u8) u8 {
     vm.current_lib_dir = dirOf(path);
     defer vm.current_lib_dir = saved_lib_dir;
 
+    crash.noteFile(path);
+
     var r = reader.Reader.initWithName(vm.gc, source, path);
     defer r.deinit();
 
     while (r.hasMore() catch |err| return reportRead(&r, path, err)) {
+        crash.noteStage(.reading);
         var expr = r.readDatum() catch |err| return reportRead(&r, path, err);
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
+        crash.noteStage(.expanding);
         expandTopLevel(vm, expr, path);
     }
     return 0;
@@ -451,14 +458,18 @@ pub fn runIr(vm: *VM, path: []const u8, no_opt: bool) u8 {
     ir_mod.optimize_enabled = !no_opt;
     defer ir_mod.optimize_enabled = saved_opt;
 
+    crash.noteFile(path);
+
     var r = reader.Reader.initWithName(vm.gc, source, path);
     defer r.deinit();
 
     var exit: u8 = 0;
     while (r.hasMore() catch |err| return reportRead(&r, path, err)) {
+        crash.noteStage(.reading);
         var expr = r.readDatum() catch |err| return reportRead(&r, path, err);
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
+        crash.noteStage(.compiling); // lowering to IR
         irTopLevel(vm, expr, path, &exit);
     }
     return exit;

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -9,6 +9,7 @@ const vm_library = @import("vm_library.zig");
 const reporting = @import("reporting.zig");
 const expander = @import("expander.zig");
 const toplevel_driver = @import("toplevel_driver.zig");
+const crash = @import("crash.zig");
 const ln = if (is_wasm) struct {} else @import("linenoise.zig");
 
 const config_mod = @import("config.zig");
@@ -1317,6 +1318,11 @@ test "highlightCallback — +inf.0 gets number color" {
 }
 
 fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u8, mode: EvalMode) void {
+    // Crash breadcrumb (kaappi#1514); reset on return so a crash at the idle
+    // prompt is not mislabeled as this input's last stage.
+    crash.note(.reading, "<repl>");
+    defer crash.reset();
+
     var r = reader.Reader.initWithName(vm.gc, input, "<repl>");
     defer r.deinit();
 
@@ -1325,6 +1331,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
         toplevel_driver.reportReadError("<repl>", lc.line, lc.col, err);
         break :blk false;
     }) {
+        crash.noteStage(.reading);
         // Datum start position, for a compile error's fallback column when no
         // precise span was recorded (kaappi#1506).
         const datum_lc = r.getLineCol();
@@ -1337,6 +1344,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
+        crash.noteStage(.executing);
         if (vm.handleTopLevelForm(expr)) |top_result| {
             const result = top_result catch |err| {
                 toplevel_driver.reportRuntimeError(vm, err, null);
@@ -1373,6 +1381,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
             continue;
         }
 
+        crash.noteStage(.compiling);
         const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, "<repl>", false) catch |err| {
             toplevel_driver.reportCompileError("<repl>", datum_lc.line, datum_lc.col, err);
             break;
@@ -1381,6 +1390,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
         var func_val = types.makePointer(@ptrCast(func));
         vm.gc.pushRoot(&func_val);
 
+        crash.noteStage(.executing);
         const result = vm.execute(func) catch |err| {
             vm.gc.popRoot();
             toplevel_driver.reportRuntimeError(vm, err, null);

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -4,6 +4,14 @@ const builtin = @import("builtin");
 const dylib_ext = if (builtin.os.tag == .macos) ".dylib" else ".so";
 const version = @import("build_options").version;
 
+const crash = @import("crash.zig");
+
+/// Custom panic handler (kaappi#1514): the package manager gets the same
+/// identity/version/report banner as `kaappi`. thottam runs no Scheme pipeline,
+/// so the breadcrumb stays idle and the `while:` line is omitted — the banner
+/// still names the build and where to report.
+pub const panic = crash.PanicHandler("thottam");
+
 const semver = @import("thottam_semver.zig");
 const proc = @import("thottam_proc.zig");
 const state = @import("thottam_state.zig");

--- a/tests/scheme/errors/crash-handler.sh
+++ b/tests/scheme/errors/crash-handler.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Crash-reporting panic handler tests (kaappi#1514, part of epic #1503).
+#
+# `--panic-test[=<stage>]` is an internal, undocumented hook that deliberately
+# panics. It exists so CI can verify the crash banner the *shipped* build prints
+# in front of the standard Zig panic — the whole reason it is not Debug-gated is
+# that this suite runs against the default ReleaseSafe binary (the build mode the
+# banner names), which is exactly the path a real user hits.
+#
+# We assert: the identity line, the version/target/build-mode line, the pipeline
+# breadcrumb (and that it tracks the stage), the report URL, that the standard
+# panic message + stack trace still follow the banner, and that the process dies
+# by signal (abort), not a clean exit.
+
+set -uo pipefail   # NOT -e: --panic-test aborts (nonzero) by design.
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+
+pass=0
+fail=0
+# check "label" <0-if-ok-else-nonzero>
+check() {
+    if [[ "$2" -eq 0 ]]; then
+        echo "PASS: $1"; pass=$((pass + 1))
+    else
+        echo "FAIL: $1"; fail=$((fail + 1))
+    fi
+}
+ok() { [[ "$1" -eq 0 ]] && echo 0 || echo 1; }
+
+# ── Default (executing) stage ────────────────────────────────────────────
+out="$("$KAAPPI" --panic-test 2>&1)"
+status=$?
+
+# abort() dies by signal → shell status is 128+signo (134 for SIGABRT). Assert
+# "died by signal" rather than a specific number so it stays portable.
+check "aborts (died by signal, not a clean exit)" "$(ok "$([[ $status -ge 128 ]] && echo 0 || echo 1)")"
+
+grep -qF "kaappi internal error — this is a bug in kaappi, not in your program." <<<"$out"
+check "banner identity line" $?
+
+grep -qE "^  version: v[0-9]+\.[0-9]+\.[0-9]+ \(.+-.+, (Debug|ReleaseSafe|ReleaseFast|ReleaseSmall)\)$" <<<"$out"
+check "version/target/build-mode line" $?
+
+grep -qE "^  while:   executing <panic-test>$" <<<"$out"
+check "breadcrumb while line (default = executing)" $?
+
+grep -qF "report:  https://github.com/kaappi/kaappi/issues/new" <<<"$out"
+check "report URL line" $?
+
+# The standard panic message + trace must survive in front of which the banner is
+# printed — the trace is the valuable part and must not be swallowed.
+grep -qF "panic: deliberate panic" <<<"$out"
+check "standard panic message retained" $?
+
+grep -qE "0x[0-9a-fA-F]+" <<<"$out"
+check "stack trace addresses retained" $?
+
+# Ordering: banner (identity) must come before the panic message + trace.
+banner_line=$(grep -n "internal error" <<<"$out" | head -1 | cut -d: -f1)
+trace_line=$(grep -n "panic: deliberate" <<<"$out" | head -1 | cut -d: -f1)
+check "banner precedes the stack trace" \
+    "$(ok "$([[ -n $banner_line && -n $trace_line && $banner_line -lt $trace_line ]] && echo 0 || echo 1)")"
+
+# ── The breadcrumb tracks the stage selector ─────────────────────────────
+# Proves the while: line renders from the live breadcrumb, not a fixed string —
+# the same mechanism the pipeline drives at reading/expanding/compiling/executing.
+for stage in reading expanding compiling executing; do
+    out="$("$KAAPPI" --panic-test="$stage" 2>&1)"
+    grep -qE "^  while:   $stage <panic-test>$" <<<"$out"
+    check "breadcrumb reflects stage=$stage" $?
+done
+
+# An unknown stage selector falls back to executing (never crashes the parser).
+out="$("$KAAPPI" --panic-test=bogus 2>&1)"
+grep -qE "^  while:   executing <panic-test>$" <<<"$out"
+check "unknown stage falls back to executing" $?
+
+# ── Summary ──────────────────────────────────────────────────────────────
+echo
+echo "Passed: $pass"
+echo "Failed: $fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Closes #1514 (part of the machine-legibility epic #1503).

## What

When a bug is in kaappi itself, ReleaseSafe currently dies with a raw Zig panic and trace — no guidance, no version context, and reports that arrive unreproducible. This adds a custom panic handler for the user-facing binaries (`kaappi`, `thottam`) that prefixes the **retained** trace with actionable context:

```
kaappi internal error — this is a bug in kaappi, not in your program.
  version: v0.14.1 (aarch64-macos, ReleaseSafe)
  while:   compiling /path/to/file.scm
  report:  https://github.com/kaappi/kaappi/issues/new — include everything below.

thread 12345 panic: <message>
<stack trace>
```

## How

- **`src/crash.zig`** — `PanicHandler(name)` returns a `std.debug.FullPanic` that prints the banner then delegates to `std.debug.defaultPanic`, so every safety check / `unreachable` / `@panic` funnels through it with the standard message + full trace intact. Each root file sets `pub const panic = crash.PanicHandler("kaappi"|"thottam")`. The handler writes straight to fd 2 — no allocation on the panic path.
- **Breadcrumb** — a near-zero-cost `Stage` enum + file slice (`noteStage`/`noteFile`), read only from the handler, updated at reading/expanding/compiling/executing boundaries in `runFile`, `runStdin`, the embedded path, the REPL, the pipeline dumps, and the native compiler. The `while:` line is omitted when idle, so `thottam` (no Scheme pipeline) shows only the build + report lines.
- **`--panic-test[=<stage>]`** — internal, undocumented deliberate-panic hook so CI can verify the banner. **Intentionally not Debug-gated**: the error suite runs against the shipped ReleaseSafe build (the mode the banner names and the path a real user hits); a Debug-only hook could never test it. Kept out of `--help` and cli parsing; dispatched before any setup.

## Acceptance criteria

- [x] Panic handler prints version/target/build-mode, stage breadcrumb, and report URL before the trace
- [x] Breadcrumb updated at pipeline stage boundaries
- [x] A deliberate-panic test hook exercising the handler in CI

The stretch `--crash-bundle` is deliberately left for a separate PR per the issue (must never auto-upload — bundles contain user source).

## Tests

- `tests/scheme/errors/crash-handler.sh` — 13 checks (banner lines, breadcrumb tracks the `=<stage>` selector, report URL, trace retained in front of the banner, died-by-signal), in the run-all errors suite.
- 4 unit tests in `src/crash.zig` (stage verbs, breadcrumb state machine, target-string shape).
- `docs/dev/crash-reporting.md` written; `CLAUDE.md` file-org table updated.

Verified end-to-end: full `zig build test` green, all 14 error shell tests pass, smoke tests (incl. imports) pass, `zig fmt --check` clean. A temporary real panic injected into the execute path showed `while: executing /tmp/E2EPANIC.scm` (real file + stage); a temporary env-gated panic in thottam showed the `thottam internal error` banner with no `while:` line (idle) — both reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)