### PR TITLE
LLVM backend: bind fixed-arity define values as native closures (#1500)

### DIFF
--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -172,7 +172,7 @@ The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
 | `if` | LLVM basic blocks with `br`/`phi` |
 | `and`/`or` | Short-circuit with basic blocks and `phi` |
 | `when`/`unless` | Conditional body execution |
-| `define` | Function definitions compiled to a native LLVM function (see Lambda Strategy); other values `call @kaappi_define_global(...)` (compound values via `kaappi_eval_cached`) |
+| `define` | Function definitions compiled to a native LLVM function (see Lambda Strategy). A fixed-arity one's global value is a native closure over that entry (`kaappi_create_native_closure`, #1500); a variadic one's value stays `kaappi_eval_cached`. Non-lambda values: `call @kaappi_define_global(...)` (compound values via `kaappi_eval_cached`) |
 | `set!` | Store to the resolved lexical slot (local/param/upvalue) or `call @kaappi_set_global(...)` |
 | `lambda` | Compiled to a native LLVM function + closure, or cached eval fallback (see Lambda Strategy) |
 | `let`, `let*` | Native `alloca`s with shadow-stack rooting; falls back to `kaappi_eval_cached` for forms it cannot lower in scope |
@@ -388,6 +388,81 @@ The resulting value (native closure or eval'd closure) is uniformly callable
 via `kaappi_call_scheme`, which dispatches through the VM's `callWithArgs`
 (closures, native functions, continuations, etc.).
 
+### Native closure values for compiled defines
+
+A top-level `(define (f …) …)` (or `(define f (lambda …))`) has two independent
+needs: **call sites** — `(f x)` — and **value uses** — passing `f` to `map`,
+`apply`, `(eq? f f)`, or returning it. The compiled `@f` entry (registered in
+`native_fns`) serves direct call sites. The value was, until #1500, a *separate*
+interpreter closure built by eval'ing the lambda/define source through the
+`kaappi_eval_cached` fallback — even though `@f` was already emitted natively.
+
+Since #1500 a **fixed-arity** define binds its global to a native closure over
+that same entry: `emitDefine` / `emitPassthrough` look up the just-registered
+`native_fns` record and emit
+`kaappi_create_native_closure(@f, null, 0, arity, …)` instead of the eval
+fallback (`emitNativeFnClosureValue` in `llvm_emit.zig`). This removes the
+per-program startup parse+compile for the value and makes value uses run native
+code, and — because taking `@f`'s address keeps the otherwise-`internal`
+fast-entry trampoline (#1499) alive — it also stops that trampoline being
+dropped. The value and the direct call sites now run the *same* native code
+(previously the value ran the interpreter), so the native backend's
+value-vs-call paths no longer diverge.
+
+**Re-entrant eval.** Making `@f` reachable as a value exposed a latent
+non-re-entrancy in the cached-eval fallback. When `@f`'s body itself reaches an
+eval or quote fallback and `f`'s *value* is invoked from inside an active
+`vm.execute` — e.g. `(define p (f 5))` eval'd at top level runs native `@f`
+under the VM's `CALL` dispatch, and `@f` calls `kaappi_eval_cached` /
+`kaappi_quote_cached` for its inner fallback — the nested run landed in
+`vm.execute`, which `resetExecutionState`s and runs from frame 0, corrupting the
+suspended outer form (it returned garbage or crashed with `car: not a pair`).
+`runTopLevelFunction` (`vm_eval.zig`) now guards this: at true top level
+(`frame_count == 0`) it stays `vm.execute`; when the VM is already executing it
+runs the compiled thunk through the same re-entrant path native callbacks use
+(`callWithArgs`, which pushes a frame *above* the current ones), leaving the
+outer execution intact. Both `eval` and `runCachedForm` route through it, so the
+quoted-constant and uncached fallbacks are covered too (before #1500 a native
+body only ran from native call sites, never from an outer `vm.execute`, so this
+nesting could not arise).
+
+Two kinds of define keep the eval-fallback value:
+
+- A **variadic** define: `callNativeClosure` dispatches native closures by
+  **exact** arity (`args.len != nc.arity` is an error), so a variadic entry
+  cannot be a native closure value.
+- A define whose body reaches a **code eval fallback** (a variadic inner lambda,
+  `letrec`, `guard`, a `let` it can't scope — anything that emits
+  `kaappi_eval_cached`, tracked as `NativeLambda.has_eval_fallback`). Such a
+  fallback republishes the enclosing frame's params as globals
+  (`bindParamsAsGlobals`), which **aliases across separate activations** — a
+  pre-existing native-backend limitation (two live closures from
+  `(f 1)` and `(f 2)` both read the last-published global). Direct call sites use
+  the closure immediately, so they don't expose it, but binding the value to a
+  native closure would run that body from new contexts and widen the aliasing to
+  the common `(define a (f 1)) (define b (f 2))` pattern. The gate keeps the
+  interpreter-closure value, which captures by location correctly. A **quoted
+  constant** (`kaappi_quote_cached`) is *not* a code fallback and does not gate:
+  quotes can't alias, and the re-entrant-eval fix above covers building them.
+
+In both cases `@f` still serves its direct call sites — a variadic entry passes
+the real argument count and builds the rest list itself — so only the value pays
+the eval fallback.
+
+(Native closure values are also why native closures now print as
+`#<procedure name>`, matching the interpreter's closures — see `printer.zig` —
+rather than a distinct `#<native-closure>` tag: a define'd function used as a
+written value is representation-identical across both backends.)
+
+Remaining eval-fallback lambda positions after #1500 (natural follow-ups): the
+value of a **variadic** define; the value of a define whose body has a **code
+eval fallback** (gated above — closing this needs the underlying
+`bindParamsAsGlobals` aliasing fixed, i.e. real by-location capture for
+eval-fallback closures, not just wider reach); a **bare variadic**
+`(lambda args …)` / `(lambda (a . rest) …)` expression (no closure tier builds a
+rest list for an anonymous lambda); and any lambda whose body still reaches an
+eval-fallback form (`letrec`, `guard`, named `let`, an internal `define`).
+
 ### Mutable captured variables (assignment conversion)
 
 The by-value `%upvalues` copy above is correct only while a captured binding is
@@ -505,6 +580,10 @@ environment variable controls the C compiler (defaults to `zig cc`).
   overflow → bignum, non-fixnum (flonum/rational) operands, and sign-extended
   negatives (`native-inline-primitives.scm`, all diffed against the interpreter,
   including under a forced-collection `KAAPPI_GC_THRESHOLD=1` run)
+- Native closure values for compiled defines (#1500) — a fixed-arity define used
+  as a *value* (`map`/`apply`/`eq?`/`procedure?`/returned from another function)
+  runs its native entry and prints as `#<procedure name>` exactly like the
+  interpreter's closure (`native-fn-value.scm`, diffed against the interpreter)
 
 ## Related Documents
 

--- a/src/fuzz_gen_native.zig
+++ b/src/fuzz_gen_native.zig
@@ -64,9 +64,11 @@
 //! here is void-valued (define / set! / when / unless / if-with-statement-
 //! arms / begin / let-ending-in-set! / write / newline) and all observable
 //! output is explicit: `(write ...)` of the final expressions plus of every
-//! non-procedure global (procedure values are never written — they print
-//! as `#<procedure name>` in the VM but `#<procedure>` natively, a
-//! representation difference by design, not a bug).
+//! non-procedure global. Procedure values are never written — nothing here
+//! produces an int-comparable result from one, and while the VM and native
+//! backends now print them identically (`#<procedure name>` both ways since
+//! #1500 made native closures print as procedures), keeping them out of the
+//! written output stays robust regardless of representation.
 //!
 //! Shares the Smith/PRNG Chooser, scope tracking, and byte-budget
 //! infrastructure with the full generator (fuzz_gen.zig).

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -76,6 +76,18 @@ const NativeLambda = struct {
     // uniform array-ABI entry. Direct call sites emit register-argument calls —
     // and `musttail` for guaranteed mutual TCO — when this is set (#1499).
     fast_name: ?[]const u8 = null,
+    // True when the function's native body reaches a *code* eval fallback
+    // (`kaappi_eval_cached` — a variadic inner lambda, letrec, guard, …). Such a
+    // fallback republishes the enclosing frame's params as globals
+    // (bindParamsAsGlobals), which aliases across separate activations — a
+    // pre-existing native-backend limitation. Direct call sites (immediate use)
+    // are unaffected, but binding the function's *value* to a native closure
+    // (#1500) would run that body from new contexts and widen the aliasing to
+    // the common `(define a (f 1)) (define b (f 2))` pattern, so a function with
+    // this set keeps its correctly-capturing interpreter-closure value. A quoted
+    // constant (`kaappi_quote_cached`) is NOT a code fallback and does not set
+    // this — quotes can't alias and the re-entrant-eval fix covers them.
+    has_eval_fallback: bool = false,
 };
 
 // A top-level define reserved by the pre-scan (preScanReserve) so a *forward*
@@ -1248,12 +1260,43 @@ pub const LLVMEmitter = struct {
                         self.rebound_globals.put(fn_name, {}) catch {};
                         if (self.tryCompileDefineFunction(fn_name, formals, body) != null) {
                             _ = self.rebound_globals.fetchRemove(fn_name);
+                            // #1500: bind the global to a native closure over the
+                            // compiled entry instead of eval'ing the whole define
+                            // form. Fixed-arity, and not when the body reaches a
+                            // code eval fallback (its bindParamsAsGlobals aliases
+                            // across activations — see NativeLambda.has_eval_fallback);
+                            // both keep the eval path, and `@f` still serves direct
+                            // call sites.
+                            if (self.native_fns.get(fn_name)) |info| {
+                                if (!info.is_variadic and !info.has_eval_fallback) {
+                                    const val = try self.emitNativeFnClosureValue(info, fn_name);
+                                    const sym = try self.internSymbol(fn_name);
+                                    try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym, fn_name.len, val });
+                                    return self.emitVoid();
+                                }
+                            }
                         }
                     }
                 }
             }
         }
         return self.emitEvalExpr(expr);
+    }
+
+    // Build the runtime Value for a natively-compiled top-level function as a
+    // native closure over its uniform C-ABI entry (#1500). A value use of the
+    // name — passing it to `map`/`apply`, `(eq? f f)`, returning it — then runs
+    // the native `@f` instead of an interpreter closure, and startup no longer
+    // parses and compiles the lambda through the eval fallback. Valid only for a
+    // fixed-arity function: `callNativeClosure` dispatches native closures by
+    // exact arity, so a variadic entry keeps the eval-fallback value. Referencing
+    // the entry here also takes its address, which keeps LLVM from dropping the
+    // `internal` fast-entry trampoline it would otherwise discard (#1499).
+    fn emitNativeFnClosureValue(self: *LLVMEmitter, info: NativeLambda, name: []const u8) EmitError![]const u8 {
+        const name_str = try self.internString(name);
+        const result = try self.freshTemp();
+        try self.print("  {s} = call i64 @kaappi_create_native_closure(ptr %vm, ptr {s}, ptr null, i64 0, i64 {d}, ptr {s}, i64 {d})\n", .{ result, info.llvm_name, info.arity, name_str, name.len });
+        return result;
     }
 
     fn emitDefine(self: *LLVMEmitter, data: ir.DefineData) EmitError![]const u8 {
@@ -1295,12 +1338,23 @@ pub const LLVMEmitter = struct {
             }
         }
 
-        const val = if (types.isPair(data.value))
-            try self.emitEvalExpr(data.value)
-        else if (types.isSymbol(data.value))
-            try self.emitGlobalRef(data.value)
-        else
-            try self.emitConstant(data.value);
+        const val = blk: {
+            // #1500: the value compiled to a native function — bind the global
+            // to a native closure over its uniform entry instead of eval'ing the
+            // lambda source. Fixed-arity, and not when the body reaches a code
+            // eval fallback (its bindParamsAsGlobals aliases across activations;
+            // see NativeLambda.has_eval_fallback and emitNativeFnClosureValue).
+            if (self.native_fns.get(name)) |info| {
+                if (!info.is_variadic and !info.has_eval_fallback)
+                    break :blk try self.emitNativeFnClosureValue(info, name);
+            }
+            break :blk if (types.isPair(data.value))
+                try self.emitEvalExpr(data.value)
+            else if (types.isSymbol(data.value))
+                try self.emitGlobalRef(data.value)
+            else
+                try self.emitConstant(data.value);
+        };
 
         try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym_name, name.len, val });
 

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -495,6 +495,13 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
     const id = self.lambda_counter;
     self.lambda_counter += 1;
 
+    // Snapshot the module-monotonic code-eval-fallback counter so we can tell,
+    // after emitting this function's body, whether it reached one (its nested
+    // lambdas emit into lambda_defs but share this counter). Recorded on the
+    // native_fns entry as has_eval_fallback so the #1500 value materialization
+    // can decline a function whose body's bindParamsAsGlobals would alias.
+    const eval_cache_start = self.eval_cache_counter;
+
     // #1499: a fixed-arity, non-variadic, non-boxed *named* function within the
     // fast-arity bound gets a register-argument `tailcc` fast entry (holding the
     // body) plus a uniform C-ABI trampoline. Direct callers reach the fast entry
@@ -657,6 +664,15 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         // Record that this reserved name's @r{i}.fast got a real body, so no
         // forwarding stub is emitted for it at finalization.
         if (use_fast) self.fulfilled_fast.put(name.?, {}) catch {};
+    }
+
+    // Record whether the body reached a code eval fallback, for #1500's value
+    // materialization gate. The entry was put before body emission (so a
+    // self-call resolves); update it in place now that the counter delta is known.
+    if (name) |n| {
+        if (self.native_fns.getPtr(n)) |e| {
+            e.has_eval_fallback = self.eval_cache_counter > eval_cache_start;
+        }
     }
 
     success = true;

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -526,8 +526,14 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                 try writer.print("#<builtin {s}>", .{nf.name});
             },
             .native_closure => {
+                // A native closure is the LLVM backend's representation of a
+                // Scheme procedure; print it exactly like an interpreter closure
+                // so native output matches the interpreter (#1500). Native
+                // closures never exist in interpreter mode, so this only affects
+                // native binaries — where a define'd function's value is now a
+                // native closure rather than an eval'd interpreter closure.
                 const nc = obj.as(types.NativeClosure);
-                try writer.print("#<native-closure {s}>", .{nc.name});
+                try writer.print("#<procedure {s}>", .{nc.name});
             },
             .function => {
                 try writer.writeAll("#<function>");

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -501,8 +501,9 @@ test "LLVM emit: capture through a nested lambda chains upvalues natively (#1410
     try expectContains(ll, "getelementptr i64, ptr %upvalues, i64 0");
     // u must never degrade to a global lookup / interned symbol...
     try std.testing.expect(std.mem.indexOf(u8, ll, "c\"u\"") == null);
-    // ...and nothing may fall back to eval beyond the define-time binding.
-    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+    // ...and nothing falls back to eval: g0 is fixed-arity, so since #1500 its
+    // global binding is a native closure over @g0, not an eval'd lambda.
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
 test "LLVM emit: depth-3 nested capture chains through every closure level (#1410)" {
@@ -511,7 +512,8 @@ test "LLVM emit: depth-3 nested capture chains through every closure level (#141
     const ll = res.toSlice();
     try std.testing.expectEqual(@as(usize, 3), std.mem.count(u8, ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_"));
     try std.testing.expect(std.mem.indexOf(u8, ll, "c\"u\"") == null);
-    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+    // g0 (fixed arity) binds a native closure, not an eval'd lambda (#1500).
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
 test "LLVM emit: capture through a let-wrapped nested lambda chains natively (#1410)" {
@@ -520,7 +522,8 @@ test "LLVM emit: capture through a let-wrapped nested lambda chains natively (#1
     const ll = res.toSlice();
     try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @closure_"));
     try std.testing.expect(std.mem.indexOf(u8, ll, "c\"u\"") == null);
-    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+    // g0 (fixed arity) binds a native closure, not an eval'd lambda (#1500).
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
 test "LLVM emit: eval fallback inside a native closure republishes upvalues (#1410)" {
@@ -534,6 +537,10 @@ test "LLVM emit: eval fallback inside a native closure republishes upvalues (#14
     try expectContains(ll, "c\"u\"");
     try expectContains(ll, "@kaappi_define_global");
     try expectContains(ll, "getelementptr i64, ptr %upvalues, i64 0");
+    // Two evals: the variadic inner lambda, plus g0's own value — its body
+    // reaches that code eval fallback, so the #1500 gate keeps g0's global an
+    // eval'd interpreter closure (not a native closure whose upvalue republish
+    // would alias across activations).
     try std.testing.expectEqual(@as(usize, 2), countEvalFallbacks(ll));
 }
 
@@ -557,6 +564,9 @@ test "LLVM emit: let eval fallback republishes enclosing params (#1410)" {
     const ll = res.toSlice();
     try expectContains(ll, "c\"u\"");
     try expectContains(ll, "@kaappi_define_global");
+    // Two evals: the let's whole-form fallback, plus f's own value — its body
+    // reaches that code eval fallback, so the #1500 gate keeps f's global an
+    // eval'd interpreter closure rather than a native closure over @f.
     try std.testing.expectEqual(@as(usize, 2), countEvalFallbacks(ll));
 }
 
@@ -890,14 +900,15 @@ test "LLVM emit: do lowers to a native loop, no eval" {
 
 test "LLVM emit: a function whose body is a cond compiles natively (#1496)" {
     // Previously the whole define fell back to eval because cond was an
-    // eval-fallback form; now only the define-time binding evals (1), and the
-    // body is a native @lambda with a cond block chain.
+    // eval-fallback form; now the body is a native @lambda with a cond block
+    // chain and (since #1500) the fixed-arity define binds a native closure
+    // over it, so nothing evals at all.
     var res = try emitMultiResult("(define (sign n) (cond ((< n 0) -1) ((= n 0) 0) (else 1)))");
     defer res.deinit();
     const ll = res.toSlice();
     try expectNativeDef(ll, "sign");
     try expectContains(ll, "cond_merge_");
-    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
 test "LLVM emit: do in a function body stays native (#1496)" {
@@ -906,7 +917,8 @@ test "LLVM emit: do in a function body stays native (#1496)" {
     const ll = res.toSlice();
     try expectNativeDef(ll, "sumto");
     try expectContains(ll, "do_header_");
-    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+    // Fixed-arity define binds a native closure over @sumto (#1500), no eval.
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
 // -- Removed fixed-size analysis buffers (#1498) --
@@ -1090,6 +1102,94 @@ test "LLVM emit: a forward-referenced non-native define gets a tailcc stub (#149
     try expectContains(ll, "call i64 @kaappi_call_scheme"); // the stub dispatches indirectly
 }
 
+// -- Native closure values for natively-compiled defines (#1500) --
+// A fixed-arity define whose function compiled natively binds its global to a
+// native closure over the compiled entry (kaappi_create_native_closure) rather
+// than eval'ing the lambda/define source. So a value use of the name runs
+// native code and startup skips the reader+compiler. A variadic entry keeps the
+// eval-fallback value: callNativeClosure dispatches native closures by exact
+// arity, so a variadic one cannot be a native closure value.
+
+test "LLVM emit: a sugared fixed-arity define binds a native closure value (#1500)" {
+    var res = try emitMultiResult("(define (sq x) (* x x))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "sq");
+    // The global binding is a native closure over the compiled entry...
+    try expectContains(ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @");
+    try expectContains(ll, "@kaappi_define_global");
+    // ...not an eval of the serialized define form.
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+    try expectNotContains(ll, "c\"(define (sq");
+}
+
+test "LLVM emit: an un-sugared lambda-valued define binds a native closure value (#1500)" {
+    var res = try emitMultiResult("(define double (lambda (x) (+ x x)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "double");
+    try expectContains(ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @");
+    // The lambda source is not serialized for eval anymore.
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+    try expectNotContains(ll, "c\"(lambda ");
+}
+
+test "LLVM emit: a variadic define keeps the eval-fallback value (#1500)" {
+    // A native closure value dispatches by exact arity (callNativeClosure), so a
+    // variadic entry cannot be one; its global binding stays the eval fallback,
+    // while @go still serves direct call sites natively.
+    var res = try emitMultiResult("(define (go a . rest) (cons a rest))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "go");
+    // Exactly the one define-time eval, and it is NOT a native closure value.
+    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+    try expectNotContains(ll, "call i64 @kaappi_create_native_closure");
+}
+
+test "LLVM emit: a define that falls back to eval keeps its interpreter value (#1500)" {
+    // guard is an eval-fallback form, so safe-div never compiles natively; the
+    // whole define form must still eval (no native_fns entry to build a closure
+    // over) — the #1500 native-closure path must not fire on a rejected define.
+    var res = try emitMultiResult("(define (safe-div a b) (guard (e (#t 0)) (/ a b)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNotContains(ll, "call i64 @kaappi_create_native_closure");
+    try std.testing.expect(countEvalFallbacks(ll) >= 1);
+}
+
+test "LLVM emit: a native define whose body has a code eval fallback keeps its value interpreted (#1500)" {
+    // mk compiles natively (its @mk serves direct calls), but its body reaches a
+    // code eval fallback (the variadic inner lambda). Binding mk's value to a
+    // native closure would run that body from new call contexts, widening the
+    // bindParamsAsGlobals aliasing to `(define a (mk 1)) (define b (mk 2))`, so
+    // the gate keeps the correctly-capturing interpreter closure value: the
+    // outer @mk exists, but mk's value is NOT a native closure over it.
+    var res = try emitMultiResult("(define (mk u) (lambda (c . r) u))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "mk");
+    // The inner variadic lambda still evals (its @mk body), and mk's value is
+    // eval'd too (the whole define form) — but no native closure value is built.
+    try expectNotContains(ll, "call i64 @kaappi_create_native_closure");
+    try std.testing.expect(countEvalFallbacks(ll) >= 2);
+}
+
+test "LLVM emit: a native define whose body only quotes still binds a native closure value (#1500)" {
+    // A quoted constant routes through kaappi_quote_cached, not a code eval
+    // fallback: it cannot alias, and the re-entrant-eval fix (runTopLevelFunction)
+    // covers its build when the value is invoked from inside an outer execute. So
+    // a quote-body define stays eligible for a native closure value.
+    var res = try emitMultiResult("(define (digits) (quote (1 2 3)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "digits");
+    try expectContains(ll, "call i64 @kaappi_create_native_closure(ptr %vm, ptr @");
+    // No CODE eval fallback (the quote uses the quote cache, counted separately).
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+    try expectContains(ll, "@kaappi_quote_cached");
+}
+
 test "LLVM emit: a lambda capturing a param through a cond gets an upvalue (#1496)" {
     // The free-variable analysis must descend into the cond's clauses, or the
     // capture of `base` degrades to a global lookup.
@@ -1253,13 +1353,20 @@ test "NativeClosure arity mismatch raises a catchable error" {
 // eval-fallback call sites in the IR (countEvalFallbacks spans both the plain
 // and the compile-once-cached spelling — #1494). Two shapes legitimately eval:
 //
-//   - defining a function/lambda emits exactly ONE eval
-//     (emitDefine/emitPassthrough create the global binding via the
-//     interpreter; call sites still use the direct native path);
+//   - a define emits ONE eval for its global binding when it is VARIADIC (a
+//     native closure value dispatches by exact arity, so a variadic entry can't
+//     be one) OR when its body reaches a code eval fallback (an inline variadic
+//     lambda, whose bindParamsAsGlobals would alias across activations if the
+//     value ran natively — the #1500 gate keeps the interpreter closure). A
+//     fixed-arity define with a fallback-free body emits ZERO: since #1500 its
+//     global binding is a native closure over the compiled entry (call sites
+//     already used the direct native path either way);
 //   - an inline VARIADIC lambda emits exactly ONE eval (#1420): no
 //     closure tier accepts a rest parameter, so it goes through
 //     emitLambdaViaEval, which first republishes the enclosing frame as
-//     globals — the #1410 codegen this shape exists to exercise.
+//     globals — the #1410 codegen this shape exists to exercise. (This is the
+//     same code fallback that gates the enclosing define's value above, so a
+//     define with an inline variadic body contributes both evals.)
 //
 // The exact count is checked on UNOPTIMIZED emission: dead-branch
 // elimination legitimately deletes variadic lambdas from constant-test
@@ -1277,36 +1384,28 @@ test "native-subset generator emits no unexpected kaappi_eval fallbacks" {
         defer gpa.free(src);
         errdefer std.debug.print("seed {d} program:\n{s}\n", .{ seed, src });
 
-        // One eval per function define and per lambda-valued global define,
-        // plus one per inline variadic lambda. The generator emits one
-        // top-level form per line, so define position is line-syntactic.
-        var ndefines: usize = 0;
+        // The generator emits one top-level form per line, so define position
+        // is line-syntactic, and every parameter list is flat — a " . " in one
+        // (before its closing ')') marks a rest parameter.
+        //
+        // Per line we count two things:
+        //   value_evals: a define whose global binding evals — variadic, or a
+        //     fixed-arity define whose body reaches a code eval fallback. For a
+        //     generator body the only such fallback is an inline variadic
+        //     lambda, so "line has an inline variadic lambda" ⟺ the define's
+        //     body has a code fallback ⟺ #1500 keeps the interpreter value.
+        //   nvariadic: every inline variadic lambda (each one its own eval).
+        var value_evals: usize = 0;
         var nvariadic: usize = 0;
         var names: [8][]const u8 = undefined;
         var name_count: usize = 0;
         var lines = std.mem.splitScalar(u8, src, '\n');
         while (lines.next()) |line| {
-            var name: ?[]const u8 = null;
-            if (std.mem.startsWith(u8, line, "(define (")) {
-                const rest = line["(define (".len..];
-                const end = std.mem.indexOfAny(u8, rest, " )") orelse rest.len;
-                name = rest[0..end];
-            } else if (std.mem.startsWith(u8, line, "(define ") and
-                std.mem.indexOf(u8, line, "(lambda ") != null)
-            {
-                const rest = line["(define ".len..];
-                const end = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
-                name = rest[0..end];
-            }
-            if (name) |n| {
-                ndefines += 1;
-                names[name_count] = n;
-                name_count += 1;
-            }
-            // Inline variadic lambdas: every "(lambda (" occurrence except
-            // the define-position one on a `(define name (lambda ...)` line.
-            // The parameter list is flat, so it ends at the first ')'; a
-            // " . " inside it marks a rest parameter.
+            // Inline variadic lambdas: every "(lambda (" occurrence except the
+            // define-position one on a `(define name (lambda ...)` line. The
+            // parameter list is flat, so it ends at the first ')'; a " . "
+            // inside it marks a rest parameter.
+            var line_inline_variadic: usize = 0;
             var from: usize = 0;
             if (std.mem.startsWith(u8, line, "(define ") and !std.mem.startsWith(u8, line, "(define (")) {
                 if (std.mem.indexOf(u8, line, "(lambda (")) |pos| from = pos + "(lambda (".len;
@@ -1314,10 +1413,48 @@ test "native-subset generator emits no unexpected kaappi_eval fallbacks" {
             while (std.mem.indexOfPos(u8, line, from, "(lambda (")) |pos| {
                 from = pos + "(lambda (".len;
                 const plist_end = std.mem.indexOfScalarPos(u8, line, from, ')') orelse line.len;
-                if (std.mem.indexOf(u8, line[from..plist_end], " . ") != null) nvariadic += 1;
+                if (std.mem.indexOf(u8, line[from..plist_end], " . ") != null) line_inline_variadic += 1;
+            }
+            nvariadic += line_inline_variadic;
+
+            var name: ?[]const u8 = null;
+            var define_plist: ?[]const u8 = null; // the define's formal list
+            if (std.mem.startsWith(u8, line, "(define (")) {
+                const rest = line["(define (".len..];
+                const end = std.mem.indexOfAny(u8, rest, " )") orelse rest.len;
+                name = rest[0..end];
+                // Sugared `(define (f a . rest) ...)`: formals close at the
+                // first ')'.
+                const plist_end = std.mem.indexOfScalar(u8, rest, ')') orelse rest.len;
+                define_plist = rest[0..plist_end];
+            } else if (std.mem.startsWith(u8, line, "(define ") and
+                std.mem.indexOf(u8, line, "(lambda ") != null)
+            {
+                const rest = line["(define ".len..];
+                const end = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
+                name = rest[0..end];
+                // `(define f (lambda (a . rest) ...))`: the define-position
+                // lambda's formals close at the first ')' after "(lambda (".
+                if (std.mem.indexOf(u8, line, "(lambda (")) |pos| {
+                    const pos_from = pos + "(lambda (".len;
+                    const plist_end = std.mem.indexOfScalarPos(u8, line, pos_from, ')') orelse line.len;
+                    define_plist = line[pos_from..plist_end];
+                }
+            }
+            if (name) |n| {
+                names[name_count] = n;
+                name_count += 1;
+                // The define's value evals when it is variadic, or when its body
+                // has a code eval fallback (#1500 gate) — an inline variadic
+                // lambda on this line.
+                const define_variadic = if (define_plist) |pl|
+                    std.mem.indexOf(u8, pl, " . ") != null
+                else
+                    false;
+                if (define_variadic or line_inline_variadic > 0) value_evals += 1;
             }
         }
-        const expected = ndefines + nvariadic;
+        const expected = value_evals + nvariadic;
 
         // Exact accounting on unoptimized emission: every source shape
         // reaches the emitter, so any count mismatch is a shape that
@@ -1332,18 +1469,20 @@ test "native-subset generator emits no unexpected kaappi_eval fallbacks" {
         // fallbacks now route through @kaappi_eval_cached (#1494).
         const actual_noopt = countEvalFallbacks(res_noopt.toSlice());
         if (actual_noopt != expected) {
-            std.debug.print("seed {d}: expected {d} kaappi_eval calls unoptimized ({d} defines + {d} inline variadic lambdas), found {d}\n", .{ seed, expected, ndefines, nvariadic, actual_noopt });
+            std.debug.print("seed {d}: expected {d} kaappi_eval calls unoptimized ({d} define-value evals + {d} inline variadic lambdas), found {d}\n", .{ seed, expected, value_evals, nvariadic, actual_noopt });
             return error.NativeSubsetFellBackToEval;
         }
 
         // Production pass pipeline: elimination can only remove eval sites,
-        // never add them.
+        // never add them. A define's value eval is top-level (never in a dead
+        // branch), so it is the unremovable floor; inline variadic lambdas in
+        // constant-test branches may be eliminated above it.
         var res = try emitMultiResult(src);
         defer res.deinit();
         const ll = res.toSlice();
         const actual = countEvalFallbacks(ll);
-        if (actual < ndefines or actual > expected) {
-            std.debug.print("seed {d}: expected {d}..{d} kaappi_eval calls optimized, found {d}\n", .{ seed, ndefines, expected, actual });
+        if (actual < value_evals or actual > expected) {
+            std.debug.print("seed {d}: expected {d}..{d} kaappi_eval calls optimized, found {d}\n", .{ seed, value_evals, expected, actual });
             return error.NativeSubsetFellBackToEval;
         }
 

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -8,6 +8,28 @@ const Value = types.Value;
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
 
+// Run a compiled top-level Function (an expression thunk), re-entrant-safely.
+//
+// At true top level (`frame_count == 0`) this is `vm.execute`, which resets the
+// execution state and runs the form from frame 0. But since #1500 a natively
+// compiled function is bound to a native closure *value*; when such a value is
+// itself invoked from inside an outer `vm.execute` (e.g. `(define p (g0 5))`
+// eval'd at top level runs the native `@g0` under the VM's CALL dispatch), and
+// `@g0`'s body reaches an eval/quote fallback, that fallback lands back here
+// with the outer form still suspended on frame 0. A nested `vm.execute` would
+// `resetExecutionState` and overwrite frame 0's registers, corrupting the outer
+// run. Detect the active execution and run the thunk through the same
+// re-entrant path native callbacks use (`callWithArgs` pushes a frame above the
+// current ones and returns when it unwinds), leaving the outer execution intact.
+//
+// `func` must already be GC-rooted by the caller (both call sites root it), so
+// the `allocClosure` here — which may collect — cannot free it.
+fn runTopLevelFunction(vm: *VM, func: *types.Function) VMError!Value {
+    if (vm.frame_count == 0) return vm.execute(func);
+    const closure_val = try vm.gc.allocClosure(func);
+    return vm.callWithArgs(closure_val, &.{});
+}
+
 pub fn eval(vm: *VM, source: []const u8) VMError!Value {
     vm_mod.setVMInstance(vm);
     const reader_mod = @import("reader.zig");
@@ -31,7 +53,7 @@ pub fn eval(vm: *VM, source: []const u8) VMError!Value {
             vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
-            last_result = vm.execute(func) catch |err| return err;
+            last_result = runTopLevelFunction(vm, func) catch |err| return err;
         }
     }
     return last_result;
@@ -128,7 +150,7 @@ pub fn compileCachedForm(vm: *VM, source: []const u8) VMError!Value {
 /// cache fast path: it runs the already-compiled form directly, skipping the
 /// reader and compiler that plain eval() re-runs on every call.
 pub fn runCachedForm(vm: *VM, func_val: Value) VMError!Value {
-    return vm.execute(types.toObject(func_val).as(types.Function));
+    return runTopLevelFunction(vm, types.toObject(func_val).as(types.Function));
 }
 
 fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {

--- a/tests/e2e/programs/native-fn-value.scm
+++ b/tests/e2e/programs/native-fn-value.scm
@@ -1,0 +1,65 @@
+; Native closure values for compiled defines (#1500).
+;
+; A fixed-arity define's global binding is now a native closure over the
+; compiled entry rather than an eval'd interpreter closure. Every use of the
+; NAME as a value — passing it to a higher-order procedure, apply, eq? identity,
+; procedure?, returning it from another function — must behave exactly like the
+; interpreter. The e2e harness diffs this program's native output against the
+; interpreter, so any divergence in native-closure-value semantics fails here.
+(import (scheme base) (scheme write))
+
+(define (sq x) (* x x))                 ; sugared fixed-arity define
+(define add (lambda (a b) (+ a b)))     ; un-sugared lambda-valued define
+
+; Used as a value: map / apply over the compiled entry.
+(display (map sq '(1 2 3 4 5))) (newline)
+(display (apply add '(30 12))) (newline)
+
+; eq? identity: one global binding, so the value is eq? to itself, and two
+; distinct functions are not eq?.
+(display (eq? sq sq)) (newline)
+(display (eq? sq add)) (newline)
+(display (procedure? sq)) (newline)
+
+; Written representation matches the interpreter (#<procedure name>).
+(write sq) (newline)
+
+; Returned as a value from another compiled function, then called.
+(define (pick which)
+  (if (eq? which 'sq) sq add))
+(display ((pick 'sq) 9)) (newline)
+(display ((pick 'add) 4 5)) (newline)
+
+; Fold using a compiled binary function as the accumulator.
+(define (fold-left f acc lst)
+  (if (null? lst) acc (fold-left f (f acc (car lst)) (cdr lst))))
+(display (fold-left add 0 '(1 2 3 4 5 6 7 8 9 10))) (newline)
+
+; A function whose body returns a quoted constant, used as a VALUE. Its value is
+; a native closure (a quote is not a code fallback), so invoking it from the
+; interpreter's eval runs the native body, whose kaappi_quote_cached re-enters
+; the evaluator — which must not clobber the suspended outer form. (Before the
+; #1500 re-entrancy fix this corrupted the outer form / crashed with "car: not a
+; pair".) The quote cache also makes every call return the SAME object (eq?),
+; matching the interpreter.
+(define (digits) '(1 2 3))
+(define ds (digits))
+(display (car ds)) (newline)
+(display (eq? (digits) (digits))) (newline)
+(display (map (lambda (_) (car (digits))) '(a b c))) (newline)
+
+; A function whose body reaches a CODE eval fallback (a variadic inner lambda)
+; keeps its correctly-capturing interpreter-closure value: separate activations
+; must NOT alias (this is the #1500 gate — a native closure value would share
+; the bindParamsAsGlobals republished binding and return 3 3 3 here).
+(define (make-const u) ((lambda (x) (lambda (c . r) x)) u))
+(define a (make-const 1))
+(define b (make-const 2))
+(define c (make-const 3))
+(display (list (a 0) (b 0) (c 0))) (newline)
+
+; Same, with a letrec body used as a value.
+(define (sumdown n)
+  (letrec ((go (lambda (k acc) (if (= k 0) acc (go (- k 1) (+ acc k))))))
+    (go n 0)))
+(display (map sumdown '(1 2 3 4))) (newline)


### PR DESCRIPTION
Closes #1500 (the last open child of the LLVM backend epic #1491).

## Problem

Measuring emitted IR across `tests/e2e/programs/*.scm` showed the dominant remaining lambda-position eval fallback was **the global value of a natively-compiled `define`** — `@f` was already emitted for direct call sites, but the value use of `f` (passing it to `map`/`apply`, `eq?`, returning it) was still built by eval'ing the lambda/define source through `kaappi_eval_cached`.

## Change

A fixed-arity native function's value is now materialized as `kaappi_create_native_closure(@f, …)` over the compiled entry (`emitNativeFnClosureValue`), reusing the `native_fns` registration and the #1499 trampoline. Value uses run native code, and startup no longer parses+compiles the lambda. Native closures also now print as `#<procedure name>` to match interpreter closures (they only exist in native binaries, so this is a pure fidelity win).

Running native `@f` bodies from these new contexts exposed two issues, both handled here:

1. **Re-entrancy** — `vm.execute` resets to frame 0, so a native value whose body reaches an eval/quote fallback, invoked from inside an outer `vm.execute`, corrupted the suspended outer form (`"car: not a pair"`). `runTopLevelFunction` (`vm_eval.zig`) runs the nested thunk via the re-entrant `callWithArgs` path when the VM is already executing. This is a genuine latent bug in the cached-eval fallback.
2. **`bindParamsAsGlobals` aliasing** — an eval-fallback closure republishes captured params as globals, which aliases across activations. This is **pre-existing** (reproducible via a direct call that stores escaping closures), but a native value would widen it to the common `(define a (f 1)) (define b (f 2))` pattern. Gated on `NativeLambda.has_eval_fallback`: a function whose body has a *code* eval fallback keeps its correctly-capturing interpreter-closure value. Quote-body functions stay eligible (quotes can't alias; the re-entrancy fix covers building them).

## Results

| Check | Result |
|---|---|
| Eval-fallback sites (36 e2e programs) | **59 → 27** (54%), 20/36 at zero |
| Unit suite (incl. 200-seed native fuzz oracle) | green |
| e2e (`run-e2e.sh`) | 37/37 |
| Scheme suites (incl. R7RS 1395) | 1863 pass, 0 fail |

New e2e program `native-fn-value.scm` covers the value-use path, quote re-entrancy, and the aliasing gate. `docs/dev/llvm-backend.md` documents the change and the remaining follow-ups (variadic define values, code-fallback-body values — which need the underlying `bindParamsAsGlobals` aliasing fixed — and bare variadic lambda expressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)