### PR TITLE
Add `--timings`: per-stage pipeline timings + cache HIT/MISS visibility (#1515)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,11 @@ triage and `--disassemble` comparisons; note the cache key now folds in the
 git build id, so a rebuilt binary never serves the old binary's bytecode —
 the old "delete the cache before testing compiler changes" footgun is fixed,
 see `docs/dev/cache.md`), `--sandbox`, `--gc-stats`,
-`--profile`, `--coverage`, `--diagnostics=<text|json>` (JSON Lines of LSP
+`--profile`, `--timings[=text|json]` (per-stage pipeline wall time —
+read/expand/lower/optimize/emit/execute, plus native `llvm-emit`/`link` — and
+cache HIT/MISS + path, all on stderr; text or JSON; disjoint self-timed stages,
+zero overhead when absent — see `docs/dev/timings.md`),
+`--coverage`, `--diagnostics=<text|json>` (JSON Lines of LSP
 `Diagnostic` objects on stderr — see `docs/dev/diagnostics-json.md`),
 `--deny-warnings` (`check`-only: promote lint warnings to errors),
 `--completions <shell>`.

--- a/docs/dev/timings.md
+++ b/docs/dev/timings.md
@@ -1,0 +1,142 @@
+# `--timings`: per-stage pipeline timings + cache visibility
+
+`--profile` profiles the *user's program* — which of their procedures the VM
+spends time in. Nothing reported how long *kaappi's own* pipeline stages take,
+or whether a run was served from the `.sbc` bytecode cache. `--timings` fills
+that gap: `zig build`-style transparency for kaappi's own work, for humans
+chasing a slow startup and for CI to catch compiler-performance regressions.
+
+Part of the machine-legibility epic
+([#1503](https://github.com/kaappi/kaappi/issues/1503)); tracked in
+[#1515](https://github.com/kaappi/kaappi/issues/1515). Builds directly on the
+cache-transparency work in [#1516](https://github.com/kaappi/kaappi/issues/1516)
+— the headline of `--timings` is that every timed run states cache **HIT** or
+**MISS** and the path, so the invisible cache that
+[cost real debugging hours](cache.md) can never be a silent variable again.
+
+## Usage
+
+```
+kaappi --timings file.scm            # text summary on stderr
+kaappi --timings=json file.scm       # one JSON object on stderr
+kaappi --timings=text file.scm       # explicit text (the default)
+
+kaappi --timings --compile file.scm  # the --compile (bytecode) path
+kaappi --timings compile file.scm    # the native (LLVM) compile path
+```
+
+The output always goes to **stderr**, like `--diagnostics=json` — so the
+program's own stdout stays clean for piping:
+
+```
+$ kaappi --timings prog.scm 2>/dev/null   # program output only
+$ kaappi --timings prog.scm 1>/dev/null   # timing report only
+```
+
+## What it reports
+
+### Run path (`kaappi file.scm`)
+
+A cache **MISS** compiled from source, so every stage ran:
+
+```
+timings: read 1.2ms | expand 0.8ms | lower 0.4ms | optimize 0.3ms | emit 0.5ms | execute 12.1ms
+cache: MISS (wrote /Users/you/.kaappi/cache/1f8b6bdfcf8b707e.sbc)
+```
+
+A cache **HIT** skipped the whole read→compile pipeline, so only `execute`
+ran — the compile stages are omitted rather than printed as `0.0ms` noise:
+
+```
+timings: execute 11.9ms
+cache: HIT (/Users/you/.kaappi/cache/1f8b6bdfcf8b707e.sbc)
+```
+
+The cache line is never blank. When caching was not even attempted it says why:
+
+```
+cache: off (--no-ir-opt)     # or (sandbox), or (no home dir)
+cache: MISS (not cached: imports)   # imported programs are never cached (#1516)
+```
+
+### Stages
+
+| Stage      | What it measures |
+|------------|------------------|
+| `read`     | Tokenizing + parsing source into datums (`reader.zig`). |
+| `expand`   | `syntax-rules` macro expansion (`expander.expandMacro`). |
+| `lower`    | AST → IR lowering and tail-position analysis (`ir.lowerWithMacros` + `markTailPositions`). |
+| `optimize` | The five IR optimization passes (`ir.zig`). |
+| `emit`     | IR → register bytecode (`compiler_ir.compileFromNode`). |
+| `execute`  | VM execution of the top-level forms (`vm.execute`). |
+| `llvm-emit`| IR → LLVM IR text, native backend only (`llvm_emit.zig`). |
+| `link`     | Invoking the external C compiler to link the native binary. |
+
+The native `kaappi compile` path reports `read / lower / optimize / llvm-emit /
+link` plus the output binary, with no `execute` or cache line. `--compile`
+(bytecode) reports `read / expand / lower / optimize / emit` plus the `.sbc`
+output.
+
+### `--timings=json`
+
+A single object with a stable shape (all applicable stage keys always present,
+`0.000` when a stage didn't run), for regression tracking alongside the
+benchmark workflows:
+
+```json
+{"mode":"run","stages_ms":{"read":1.200,"expand":0.800,"lower":0.400,"optimize":0.300,"emit":0.500,"execute":12.100},"cache":{"status":"miss","path":"/Users/you/.kaappi/cache/1f8b6bdfcf8b707e.sbc","written":true}}
+```
+
+`mode` is `run` | `compile` | `native`. For a run, `cache.status` is `hit` |
+`miss` | `off`; `path` and `written` accompany a hit or miss, and a `reason`
+accompanies `off` (or a not-written miss). For compile/native, an `output` field
+names the artifact instead of a cache object.
+
+## Design — a self-time profiler stack
+
+The pipeline is **not** a flat sequence. Macro expansion is interleaved with
+emission: a macro use lowers to a *passthrough* IR node that is expanded, and
+then *re-compiled*, during `compileFromNode`. So `emit` legitimately contains
+nested `expand`, `lower`, `optimize`, and further `emit`. A single accumulator
+per stage would double-count those nested regions — `emit` would absorb the
+expansion time it triggered, and the numbers would sum to more than the wall
+clock.
+
+`src/timings.zig` avoids that with a **self-time stack**: every timed region is
+pushed, and elapsed wall time is always credited to the *innermost* active
+stage. Entering a nested stage freezes its parent; leaving resumes it. The
+buckets are therefore **disjoint** — they never overlap — regardless of nesting
+depth or which driver (run / `--compile` / native / imports) is on top. A
+macro-heavy compile makes this visible: `expand` can dwarf `emit` precisely
+because `emit` excludes the expansion it drove.
+
+Instrumentation lives at the shared chokepoints, so all callers are covered at
+once:
+
+- `ir.lowerAndOptimize` — `lower` and `optimize`.
+- `expander.expandMacro` — `expand` (the sole expansion entry point).
+- `compiler.compile` / `compileMultiple` — the outermost `emit` scope.
+- `native_compiler` — `read`, `llvm-emit`, `link`.
+- `main.zig` run/compile drivers — `read`, `execute`, and cache HIT/MISS.
+
+## Cost when absent, and threading
+
+Every `begin`/`end` is a single predicted branch (`if (!enabled) return`) when
+the flag is off, so there is no measurable overhead on an ordinary run — none of
+the instrumented functions sit in the bytecode dispatch loop.
+
+`enabled` is `threadlocal`, mirroring `ir.optimize_enabled`. Only the main
+thread — the one that parsed the CLI and drives the top-level pipeline — ever has
+it set. SRFI-18 child threads that compile via `eval` neither race on the shared
+buckets nor get counted, and since the whole program's pipeline runs on the main
+thread, nothing is lost.
+
+## Tests
+
+- `src/timings.zig` unit tests drive the self-time stack on a deterministic
+  clock (`test_clock`, gated on `builtin.is_test` so it compiles out of
+  production) and check the text/JSON rendering.
+- `tests/scheme/timings/timings-1515.sh` is the end-to-end shell test: it
+  validates the JSON shape (parsing it with `python3` when available), the
+  HIT/MISS transitions, the cache-off reasons, the compile-path shape, and that
+  timings never leak onto stdout.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -15,6 +15,11 @@ const writeStderr = reporting.writeStderr;
 // agree on the spelling.
 const diagnostics_prefix = "--diagnostics=";
 
+// `--timings[=fmt]` accepts a bare form (`--timings`, text) and the GNU `=`
+// value form (`--timings=json`), so — like `--diagnostics=` — it is matched
+// outside the value-flag table. Same spelling shared by parse + sandbox pre-scan.
+const timings_prefix = "--timings=";
+
 // ── Flag table ─────────────────────────────────────────────────────────
 
 const FlagId = enum {
@@ -115,6 +120,12 @@ pub const Options = struct {
     coverage_mode: bool = false,
     coverage_xml_path: ?[]const u8 = null,
 
+    // Per-stage pipeline timings + cache HIT/MISS (kaappi#1515). `--timings`
+    // (text) or `--timings=json`; parsed like `--diagnostics=` (GNU `=` syntax)
+    // but with a bare form too.
+    timings_enabled: bool = false,
+    timings_json: bool = false,
+
     timeout_ms: ?u64 = null,
     max_memory: ?usize = null,
 
@@ -156,6 +167,8 @@ pub fn preScanSandbox(args: std.process.Args) bool {
             // bare subcommand — keep scanning
         } else if (std.mem.startsWith(u8, arg, diagnostics_prefix)) {
             // `--diagnostics=…` carries its value inline — keep scanning.
+        } else if (std.mem.eql(u8, arg, "--timings") or std.mem.startsWith(u8, arg, timings_prefix)) {
+            // `--timings` / `--timings=…` — no separate value arg, keep scanning.
         } else {
             break;
         }
@@ -201,6 +214,16 @@ pub fn parse(args: std.process.Args) Options {
 
         if (std.mem.startsWith(u8, arg, diagnostics_prefix)) {
             opts.diagnostics_format = parseDiagnosticsFormat(arg[diagnostics_prefix.len..]);
+            continue;
+        }
+
+        if (std.mem.eql(u8, arg, "--timings")) {
+            opts.timings_enabled = true;
+            continue;
+        }
+        if (std.mem.startsWith(u8, arg, timings_prefix)) {
+            opts.timings_enabled = true;
+            opts.timings_json = parseTimingsFormat(arg[timings_prefix.len..]);
             continue;
         }
 
@@ -351,6 +374,8 @@ pub fn printUsage() void {
             "  --gc-stats         Print GC statistics on exit\n" ++
             "  --profile          Enable profiling\n" ++
             "  --profile-json <f> Write profile JSON to file\n" ++
+            "  --timings[=fmt]    Report per-stage pipeline timings + cache HIT/MISS\n" ++
+            "                     on stderr; fmt is text (default) or json\n" ++
             "  --coverage         Report library procedure coverage\n" ++
             "  --coverage-xml <f> Write Cobertura XML coverage to file\n" ++
             "  --timeout <ms>     Execution timeout in milliseconds\n" ++
@@ -386,6 +411,16 @@ fn parseDiagnosticsFormat(value: []const u8) DiagnosticsFormat {
     if (std.mem.eql(u8, value, "text")) return .text;
     if (std.mem.eql(u8, value, "json")) return .json;
     writeStderr("--diagnostics: unknown format '");
+    writeStderr(value);
+    writeStderr("' (expected 'text' or 'json')\n");
+    std.process.exit(USAGE_ERROR_EXIT);
+}
+
+/// Returns true for `json`, false for `text`; exits on anything else.
+fn parseTimingsFormat(value: []const u8) bool {
+    if (std.mem.eql(u8, value, "text")) return false;
+    if (std.mem.eql(u8, value, "json")) return true;
+    writeStderr("--timings: unknown format '");
     writeStderr(value);
     writeStderr("' (expected 'text' or 'json')\n");
     std.process.exit(USAGE_ERROR_EXIT);
@@ -560,6 +595,46 @@ test "parse: max-memory" {
     const argv = [_][*:0]const u8{ "kaappi", "--max-memory", "1000000", "test.scm" };
     const opts = parse(testArgs(&argv));
     try std.testing.expectEqual(@as(usize, 1000000), opts.max_memory.?);
+}
+
+test "parse: bare --timings enables text timings" {
+    const argv = [_][*:0]const u8{ "kaappi", "--timings", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expect(opts.timings_enabled);
+    try std.testing.expect(!opts.timings_json);
+    try std.testing.expectEqualStrings("test.scm", opts.file_path.?);
+}
+
+test "parse: --timings=json enables json timings" {
+    const argv = [_][*:0]const u8{ "kaappi", "--timings=json", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expect(opts.timings_enabled);
+    try std.testing.expect(opts.timings_json);
+}
+
+test "parse: --timings=text is the explicit text default" {
+    const argv = [_][*:0]const u8{ "kaappi", "--timings=text", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expect(opts.timings_enabled);
+    try std.testing.expect(!opts.timings_json);
+}
+
+test "parse: no --timings leaves it disabled" {
+    const argv = [_][*:0]const u8{ "kaappi", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expect(!opts.timings_enabled);
+}
+
+test "parse: --timings after filename is a script arg, not a flag" {
+    const argv = [_][*:0]const u8{ "kaappi", "test.scm", "--timings" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expect(!opts.timings_enabled);
+    try std.testing.expectEqualStrings("--timings", opts.scriptArgs()[1]);
+}
+
+test "preScanSandbox: --timings before --sandbox still detected" {
+    const argv = [_][*:0]const u8{ "kaappi", "--timings=json", "--sandbox", "test.scm" };
+    try std.testing.expect(preScanSandbox(testArgs(&argv)));
 }
 
 test "parse: no args → REPL (no file)" {

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -8,6 +8,7 @@ const passthrough = @import("compiler_passthrough.zig");
 const macro = @import("compiler_macro.zig");
 const ir_mod = @import("ir.zig");
 const compiler_ir = @import("compiler_ir.zig");
+const timings = @import("timings.zig");
 const globals_mod = @import("globals.zig");
 const printer = @import("printer.zig");
 const Value = types.Value;
@@ -483,7 +484,15 @@ pub const Compiler = struct {
         const root = try ir_mod.lowerAndOptimize(&ir, expr_root, &self.macros, is_tail);
 
         const dst = try self.allocReg();
-        try compiler_ir.compileFromNode(self, root, dst, is_tail);
+        // `--timings` (kaappi#1515): bytecode emission is the outermost `emit`
+        // scope. Passthrough macro uses re-enter the compiler from inside here;
+        // their nested expand/lower/optimize/emit are attributed correctly by
+        // the self-time stack. `defer` fires even on a `try` error path.
+        {
+            timings.begin(.emit);
+            defer timings.end();
+            try compiler_ir.compileFromNode(self, root, dst, is_tail);
+        }
         try self.emitOp(.@"return");
         try self.emitU16(dst);
 
@@ -517,7 +526,11 @@ pub const Compiler = struct {
             const root = try ir_mod.lowerAndOptimize(&ir, expr, &self.macros, false);
 
             dst = try self.allocReg();
-            try compiler_ir.compileFromNode(self, root, dst, false);
+            {
+                timings.begin(.emit); // see compile(): outermost emit scope (kaappi#1515)
+                defer timings.end();
+                try compiler_ir.compileFromNode(self, root, dst, false);
+            }
             if (i < exprs.len - 1) {
                 self.freeReg();
             }

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -73,7 +73,7 @@ const kaappi_bash =
     \\    fi
     \\
     \\    if [[ "$cur" == -* ]]; then
-    \\        COMPREPLY=($(compgen -W "-h --help --version --lib-path --compile --emit-llvm -o --disassemble --diagnostics=text --diagnostics=json --deny-warnings --sandbox --gc-stats --profile --profile-json --coverage --coverage-xml --timeout --max-memory --completions" -- "$cur"))
+    \\        COMPREPLY=($(compgen -W "-h --help --version --lib-path --compile --emit-llvm -o --disassemble --diagnostics=text --diagnostics=json --deny-warnings --sandbox --gc-stats --profile --profile-json --timings --timings=text --timings=json --coverage --coverage-xml --timeout --max-memory --completions" -- "$cur"))
     \\        return
     \\    fi
     \\
@@ -107,6 +107,7 @@ const kaappi_zsh =
     \\        '--gc-stats[Print GC statistics on exit]'
     \\        '--profile[Enable profiling]'
     \\        '--profile-json[Write profile JSON to file]:file:_files'
+    \\        '--timings=[Per-stage pipeline timings + cache HIT/MISS]:format:(text json)'
     \\        '--coverage[Report library procedure coverage]'
     \\        '--coverage-xml[Write Cobertura XML coverage to file]:file:_files'
     \\        '--timeout[Execution timeout in milliseconds]:ms:'
@@ -140,6 +141,7 @@ const kaappi_fish =
     \\complete -c kaappi -l gc-stats -d 'Print GC statistics on exit'
     \\complete -c kaappi -l profile -d 'Enable profiling'
     \\complete -c kaappi -l profile-json -r -F -d 'Write profile JSON to file'
+    \\complete -c kaappi -l timings -x -a 'text json' -d 'Per-stage pipeline timings + cache HIT/MISS'
     \\complete -c kaappi -l coverage -d 'Report library procedure coverage'
     \\complete -c kaappi -l coverage-xml -r -F -d 'Write Cobertura XML coverage to file'
     \\complete -c kaappi -l timeout -r -x -d 'Execution timeout in milliseconds'

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const timings = @import("timings.zig");
 const Value = types.Value;
 const GC = memory.GC;
 
@@ -139,6 +140,11 @@ pub const UseSiteBindingCheck = struct {
 };
 
 pub fn expandMacro(gc: *GC, expr: Value, transformer_val: Value, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value), use_check: UseSiteBindingCheck) !Value {
+    // `--timings` (kaappi#1515): the sole macro-expansion chokepoint, so timing
+    // it here covers every caller (compiler, pipeline dump, REPL). Expansion runs
+    // during emission; the self-time stack keeps it disjoint from the emit stage.
+    timings.begin(.expand);
+    defer timings.end();
     const transformer = types.toObject(transformer_val).as(types.Transformer);
     const saved_ellipsis = active_custom_ellipsis;
     active_custom_ellipsis = transformer.custom_ellipsis;

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const globals_mod = @import("globals.zig");
+const timings = @import("timings.zig");
 
 const Value = types.Value;
 const OpCode = types.OpCode;
@@ -612,13 +613,24 @@ pub fn lowerAndOptimize(
     macros: ?*std.StringHashMap(Value),
     is_tail: bool,
 ) CompileError!*Node {
-    var node = try lowerWithMacros(ir_instance, expr, macros);
+    // `--timings` (kaappi#1515): lowering (AST→IR, with macro uses deferred to
+    // passthrough nodes) and analysis are one self-timed stage; the five
+    // optimization passes are another. Nested lowering triggered later by macro
+    // expansion during emission is credited correctly by the self-time stack.
+    timings.begin(.lower);
+    var node = lowerWithMacros(ir_instance, expr, macros) catch |err| {
+        timings.end();
+        return err;
+    };
     markTailPositions(node, is_tail);
+    timings.end();
     // Lint hook for `kaappi check` (kaappi#1511). Inert (one null test) outside a
     // check run. Walked before the optimization passes so constant folding can't
     // hide a call the lint would flag.
     @import("check_lint.zig").maybeWalk(ir_instance, node);
     if (!optimize_enabled) return node;
+    timings.begin(.optimize);
+    defer timings.end();
     node = foldConstants(ir_instance, node);
     node = eliminateDeadBranches(ir_instance, node);
     node = simplifyBooleans(ir_instance, node);

--- a/src/main.zig
+++ b/src/main.zig
@@ -50,6 +50,7 @@ pub const features = @import("features.zig");
 pub const test_runner = @import("test_runner.zig");
 pub const doctor = @import("doctor.zig");
 pub const cache = @import("cache.zig");
+pub const timings = @import("timings.zig");
 pub const check = @import("check.zig");
 pub const pipeline = @import("pipeline.zig");
 pub const config = @import("config.zig");
@@ -261,6 +262,9 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
 
     // Apply parsed options to VM/GC
     if (opts.no_ir_opt) ir_mod.optimize_enabled = false;
+    // `--timings` (kaappi#1515): arm per-stage timing on this (main) thread
+    // before any pipeline work runs. A no-op elsewhere unless armed here.
+    if (opts.timings_enabled) timings.enable(if (opts.timings_json) .json else .text);
     if (opts.timeout_ms) |ms| {
         const clockNs = @import("vm_calls.zig").clockNs;
         vm.timeout_deadline_ns = clockNs() + ms * 1_000_000;
@@ -469,6 +473,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
 
     if (opts.native_compile_mode) {
         if (opts.file_path) |fp| {
+            defer timings.report(.native); // kaappi#1515 (no-op unless --timings)
             try native_compiler.compileNative(vm, fp, opts.compile_output);
         } else {
             usageError("Usage: kaappi compile <file.scm> [-o output]\n");
@@ -517,6 +522,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             // the auto-run cache, which lives in ~/.kaappi/cache keyed by a
             // hash of the source path (kaappi#1516). So `--no-ir-opt --compile`
             // can't poison a plain run's cache, and needs no output guard.
+            defer timings.report(.compile); // kaappi#1515 (no-op unless --timings)
             try compileFile(vm, fp, opts.compile_output);
         } else {
             usageError("Usage: kaappi --compile <file.scm> [-o output.sbc]\n");
@@ -534,6 +540,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 return;
             }
         }
+        defer timings.report(.run); // kaappi#1515 (no-op unless --timings)
         try runFile(vm, fp);
     } else {
         if (is_wasm) {
@@ -580,8 +587,21 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
     const sbc_path = if (vm.sandbox_mode or !ir_mod.optimize_enabled) null else cache.pathForSource(allocator, path);
     defer if (sbc_path) |p| allocator.free(p);
 
+    // `--timings` (kaappi#1515): record why caching was skipped entirely, so the
+    // report never leaves the cache line blank. HIT/MISS are recorded below.
+    if (sbc_path == null) {
+        if (vm.sandbox_mode) {
+            timings.cacheOff("sandbox");
+        } else if (!ir_mod.optimize_enabled) {
+            timings.cacheOff("--no-ir-opt");
+        } else {
+            timings.cacheOff("no home dir");
+        }
+    }
+
     if (sbc_path) |sp| {
         if (bytecode_file.readFileWithTopLevel(vm.gc, source_hash, sp) catch null) |loaded| {
+            timings.cacheHit(sp);
             defer allocator.free(loaded.funcs);
 
             var bundled_files_map = loaded.bundled_files orelse std.StringHashMap([]const u8).init(allocator);
@@ -610,7 +630,10 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                         var expr = pr.readDatum() catch break;
                         vm.gc.pushRoot(&expr);
                         defer vm.gc.popRoot();
-                        if (vm.handleTopLevelForm(expr)) |top_result| {
+                        timings.begin(.execute); // preamble replay re-runs imports (kaappi#1515)
+                        const top = vm.handleTopLevelForm(expr);
+                        timings.end();
+                        if (top) |top_result| {
                             _ = top_result catch {};
                         }
                     }
@@ -629,7 +652,10 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             for (loaded.funcs[0..top_count]) |func| {
                 var func_val = types.makePointer(@ptrCast(func));
                 vm.gc.pushRoot(&func_val);
-                const result = vm.execute(func) catch |err| {
+                timings.begin(.execute);
+                const exec_result = vm.execute(func);
+                timings.end();
+                const result = exec_result catch |err| {
                     vm.gc.popRoot();
                     script_had_error = true;
                     const loc = toplevel_driver.vmErrorLocation(vm, path, 0);
@@ -646,7 +672,10 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         }
     }
 
-    // No cache — compile from source
+    // No cache — compile from source. A non-null sbc_path here means the cache
+    // was consulted and missed (kaappi#1515); the write below marks it written.
+    if (sbc_path) |sp| timings.cacheMiss(sp);
+
     var compiled_funcs: std.ArrayList(*types.Function) = .empty;
     defer compiled_funcs.deinit(allocator);
     var has_imports = false;
@@ -663,7 +692,10 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
     }) {
         crash.noteStage(.reading);
         const datum_lc = r.getLineCol();
-        var expr = r.readDatum() catch |err| {
+        timings.begin(.read);
+        const read_result = r.readDatum();
+        timings.end();
+        var expr = read_result catch |err| {
             const lc = r.getLineCol();
             toplevel_driver.reportReadError(path, lc.line, lc.col, err);
             script_had_error = true;
@@ -675,7 +707,10 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
 
         // A top-level import/define-library/include runs library code here.
         crash.noteStage(.executing);
-        if (vm.handleTopLevelForm(expr)) |top_result| {
+        timings.begin(.execute);
+        const maybe_top = vm.handleTopLevelForm(expr);
+        timings.end();
+        if (maybe_top) |top_result| {
             has_imports = true;
             const result = top_result catch |err| {
                 script_had_error = true;
@@ -700,7 +735,10 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         vm.gc.pushRoot(&func_val);
 
         crash.noteStage(.executing);
-        const result = vm.execute(func) catch |err| {
+        timings.begin(.execute);
+        const exec_result = vm.execute(func);
+        timings.end();
+        const result = exec_result catch |err| {
             vm.gc.popRoot();
             script_had_error = true;
             const loc = toplevel_driver.vmErrorLocation(vm, path, datum_lc.line);
@@ -720,8 +758,13 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
     if (!has_imports and compiled_funcs.items.len > 0) {
         if (sbc_path) |sp| {
             cache.ensureDir();
-            bytecode_file.writeFileWithTopLevel(allocator, compiled_funcs.items, source_hash, path, sp) catch {};
+            if (bytecode_file.writeFileWithTopLevel(allocator, compiled_funcs.items, source_hash, path, sp)) |_| {
+                timings.cacheWrote(); // kaappi#1515: the miss's bytecode is now cached
+            } else |_| {}
         }
+    } else if (has_imports and sbc_path != null) {
+        // A miss was recorded, but imported programs are never cached — say so.
+        timings.cacheReason("imports");
     }
 }
 
@@ -925,7 +968,10 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         return;
     }) {
         const datum_lc = r.getLineCol();
-        var expr = r.readDatum() catch |err| {
+        timings.begin(.read); // kaappi#1515
+        const read_result = r.readDatum();
+        timings.end();
+        var expr = read_result catch |err| {
             const lc = r.getLineCol();
             toplevel_driver.reportReadError(path, lc.line, lc.col, err);
             script_had_error = true;
@@ -970,6 +1016,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
                 return;
             };
         defer allocator.free(sbc_path);
+        timings.setOutput(sbc_path); // kaappi#1515: the named .sbc artifact
 
         const has_bundle = collect_files.count() > 0 or preamble.items.len > 0;
         if (has_bundle) {
@@ -1055,4 +1102,6 @@ test {
     _ = fmt;
     _ = @import("fmt_print.zig");
     _ = crash;
+    _ = cache;
+    _ = timings;
 }

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -10,6 +10,7 @@ const reporting = @import("reporting.zig");
 const kaappi_paths = @import("kaappi_paths.zig");
 const diagnostics = @import("diagnostics.zig");
 const crash = @import("crash.zig");
+const timings = @import("timings.zig");
 
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
@@ -63,7 +64,10 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         writeStderr(s);
         return err;
     }) {
-        const expr = r.readDatum() catch |err| {
+        timings.begin(.read); // kaappi#1515
+        const read_result = r.readDatum();
+        timings.end();
+        const expr = read_result catch |err| {
             const lc = r.getLineCol();
             const code = diagnostics.readErrorCode(err);
             var cbuf: [diagnostics.Code.render_width]u8 = undefined;
@@ -121,7 +125,9 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     // sent to the interpreter (which expands it) instead of being mis-compiled
     // as a call to a same-named global (#1496).
     emitter.macros = &vm.macros;
+    timings.begin(.llvm_emit); // kaappi#1515: IR → LLVM IR text codegen
     emitter.emitProgram(ir_nodes.items) catch |err| {
+        timings.end();
         const code = diagnostics.Code.internal_error;
         var cbuf: [diagnostics.Code.render_width]u8 = undefined;
         var errbuf: [256]u8 = undefined;
@@ -129,6 +135,7 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         writeStderr(s);
         return err;
     };
+    timings.end(); // llvm_emit
 
     const out_path = output_path orelse blk: {
         if (std.mem.endsWith(u8, path, ".scm")) {
@@ -183,6 +190,7 @@ pub fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8)
         }
         break :blk path;
     };
+    timings.setOutput(out_path); // kaappi#1515
 
     const lib_dir = findLibDir(allocator) orelse {
         writeStderr("Cannot find libkaappi_rt.a. Build it with: zig build lib\n");
@@ -193,13 +201,19 @@ pub fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8)
     defer allocator.free(lib_flag);
 
     var found_compiler = false;
-    const compilers = [_][]const u8{ "zig", "cc", "clang", "gcc" };
-    for (compilers) |cc| {
-        const cc_path = findInPath(allocator, cc) orelse continue;
-        defer allocator.free(cc_path);
-        found_compiler = true;
-        if (tryLink(allocator, cc_path, ll_path, out_path, lib_flag, std.mem.eql(u8, cc, "zig"))) {
-            return;
+    {
+        // kaappi#1515: external C-compiler link step. `defer` fires on the
+        // success `return` inside the loop too, so the stage is always recorded.
+        timings.begin(.link);
+        defer timings.end();
+        const compilers = [_][]const u8{ "zig", "cc", "clang", "gcc" };
+        for (compilers) |cc| {
+            const cc_path = findInPath(allocator, cc) orelse continue;
+            defer allocator.free(cc_path);
+            found_compiler = true;
+            if (tryLink(allocator, cc_path, ll_path, out_path, lib_flag, std.mem.eql(u8, cc, "zig"))) {
+                return;
+            }
         }
     }
 

--- a/src/timings.zig
+++ b/src/timings.zig
@@ -1,0 +1,511 @@
+//! `--timings`: per-stage pipeline wall time + cache HIT/MISS visibility
+//! (kaappi#1515, part of the machine-legibility epic kaappi#1503).
+//!
+//! `--profile` profiles the *user's program*; nothing else reports how long
+//! kaappi's own pipeline stages take, or whether a run was served from the
+//! `.sbc` bytecode cache (kaappi#1516). This module gives `zig build`-style
+//! transparency for kaappi's own work — for humans chasing slow builds, and
+//! for CI to catch compiler-performance regressions (`--timings=json`).
+//!
+//! **Model — a self-time profiler stack.** The pipeline is not a flat sequence:
+//! macro expansion is interleaved with emission (a macro use becomes a
+//! passthrough IR node that is expanded, then *re-compiled*, during
+//! `compileFromNode`), so `emit` legitimately contains nested `expand`, `lower`,
+//! `optimize`, and further `emit`. A single accumulator per stage would
+//! double-count those nested regions. Instead, every timed region is pushed on
+//! a stack; wall time is always credited to the *innermost* active stage, so the
+//! buckets are disjoint (they never overlap) regardless of nesting or which
+//! caller drives them (run / `--compile` / native / imports). Each begin/end is
+//! one `clock_gettime`; when the flag is absent every entry point is a single
+//! predicted branch (`if (!enabled) return`), so there is no measurable overhead.
+//!
+//! **Threading.** `enabled` is `threadlocal` (like `ir.optimize_enabled`): only
+//! the main thread — the one that parsed the CLI and drives the top-level
+//! pipeline — ever has it set, so SRFI-18 child threads that compile via `eval`
+//! neither race on the shared buckets nor get counted. The whole program's
+//! pipeline runs on the main thread, so nothing is lost.
+//!
+//! Output goes to **stderr** (like `--diagnostics=json`), keeping the program's
+//! own stdout clean for piping. See `docs/dev/timings.md`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const is_wasm = builtin.os.tag == .wasi;
+
+pub const Format = enum { text, json };
+
+/// The invocation whose stages we are reporting. Selects which stages appear
+/// (and in which order) and whether a cache line is shown.
+pub const Mode = enum { run, compile, native };
+
+/// Pipeline stages. `read`→`execute` are the interpreter run/`--compile` path;
+/// `llvm_emit`/`link` are the extra native-backend stages under `kaappi compile`
+/// (which has no `execute`). Kept in one enum so a single bucket array indexes
+/// all of them.
+pub const Stage = enum { read, expand, lower, optimize, emit, llvm_emit, link, execute };
+
+const stage_count = @typeInfo(Stage).@"enum".fields.len;
+
+/// Fixed cap for the copied cache / output paths — comfortably above any real
+/// `PATH_MAX`, and platform-independent so this module compiles on WASM too
+/// (where timings are never armed anyway).
+const max_path = 4096;
+
+// ── State (threadlocal `enabled`; the rest is only ever touched by the main
+//    thread, which is the only thread that sets `enabled`) ─────────────────
+
+pub threadlocal var enabled: bool = false;
+var format: Format = .text;
+
+/// Nanosecond self-time per stage.
+var buckets: [stage_count]u64 = @splat(0);
+
+const Frame = struct { stage: Stage, resumed_ns: u64 };
+
+/// Deep enough for realistic macro-in-macro-output nesting (each level adds
+/// ~4 frames: emit→expand, then lower→optimize→emit of the expansion). Beyond
+/// this, credit degrades gracefully (frames past the cap aren't recorded) but
+/// `depth` still balances so begin/end never corrupt the stack or crash.
+var stack: [128]Frame = undefined;
+var depth: usize = 0;
+
+// ── Cache outcome (run path) ───────────────────────────────────────────────
+
+pub const CacheOutcome = enum { none, hit, miss, off };
+
+var cache_outcome: CacheOutcome = .none;
+var cache_written: bool = false;
+/// A static-lifetime reason ("sandbox", "--no-ir-opt", "imports", …) — safe to
+/// alias since callers pass string literals.
+var cache_reason: []const u8 = "";
+var cache_path_buf: [max_path]u8 = undefined;
+var cache_path_len: usize = 0;
+
+/// An explicit output artifact path (for `--compile` / native `compile`),
+/// copied because the caller's slice is freed before the report runs.
+var output_path_buf: [max_path]u8 = undefined;
+var output_path_len: usize = 0;
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+/// Turn timing on for this (main) thread and reset all accumulators. Called
+/// once, right after CLI parsing, only when `--timings` was given.
+pub fn enable(fmt: Format) void {
+    enabled = true;
+    format = fmt;
+    buckets = @splat(0);
+    depth = 0;
+    cache_outcome = .none;
+    cache_written = false;
+    cache_reason = "";
+    cache_path_len = 0;
+    output_path_len = 0;
+}
+
+// ── Timing primitives ──────────────────────────────────────────────────────
+
+/// Test-only clock override so the self-time accounting can be driven on a
+/// deterministic timeline (a real elapsed-wall test is flaky — the optimizer can
+/// collapse busy-work to nothing). Gated on `builtin.is_test`, so it compiles out
+/// of production builds entirely — no branch on the real hot path.
+var test_clock: ?u64 = null;
+
+fn nowNs() u64 {
+    if (builtin.is_test) {
+        if (test_clock) |t| return t;
+    }
+    if (comptime is_wasm) return 0;
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @intCast(@as(i128, ts.sec) * 1_000_000_000 + ts.nsec);
+}
+
+/// Enter `stage`. Credits any elapsed time to the (now-frozen) parent stage,
+/// then makes `stage` the innermost active one. Pair every `begin` with an
+/// `end`, ideally via `defer`.
+pub inline fn begin(stage: Stage) void {
+    if (!enabled) return;
+    beginSlow(stage);
+}
+
+fn beginSlow(stage: Stage) void {
+    const now = nowNs();
+    if (depth > 0 and depth - 1 < stack.len) {
+        const parent = &stack[depth - 1];
+        buckets[@intFromEnum(parent.stage)] +%= now -% parent.resumed_ns;
+    }
+    if (depth < stack.len) stack[depth] = .{ .stage = stage, .resumed_ns = now };
+    depth += 1;
+}
+
+/// Leave the innermost stage, crediting its remaining self-time, and resume its
+/// parent.
+pub inline fn end() void {
+    if (!enabled) return;
+    endSlow();
+}
+
+fn endSlow() void {
+    if (depth == 0) return;
+    depth -= 1;
+    const now = nowNs();
+    if (depth < stack.len) {
+        const cur = &stack[depth];
+        buckets[@intFromEnum(cur.stage)] +%= now -% cur.resumed_ns;
+    }
+    if (depth > 0 and depth - 1 < stack.len) stack[depth - 1].resumed_ns = now;
+}
+
+// ── Cache / output recording (run + compile paths) ─────────────────────────
+
+fn copyPath(dst: []u8, path: []const u8) usize {
+    const n = @min(dst.len, path.len);
+    @memcpy(dst[0..n], path[0..n]);
+    return n;
+}
+
+/// Bytecode served from the cache — the whole read→compile pipeline was skipped.
+pub fn cacheHit(path: []const u8) void {
+    if (!enabled) return;
+    cache_outcome = .hit;
+    cache_path_len = copyPath(&cache_path_buf, path);
+}
+
+/// Compiled from source; `path` is where the entry will be (best-effort)
+/// written. Call `cacheWrote` if the write succeeds, or `cacheReason` to note
+/// why it won't be cached (e.g. imports).
+pub fn cacheMiss(path: []const u8) void {
+    if (!enabled) return;
+    cache_outcome = .miss;
+    cache_path_len = copyPath(&cache_path_buf, path);
+}
+
+/// Record that the miss's bytecode was actually written to the cache.
+pub fn cacheWrote() void {
+    if (!enabled) return;
+    cache_written = true;
+}
+
+/// Caching was not attempted at all (sandbox, `--no-ir-opt`, no home dir, WASM).
+/// `reason` must be a static string.
+pub fn cacheOff(reason: []const u8) void {
+    if (!enabled) return;
+    cache_outcome = .off;
+    cache_reason = reason;
+}
+
+/// Annotate the current outcome (typically a miss) with a static-string reason,
+/// e.g. why a compiled program won't be cached.
+pub fn cacheReason(reason: []const u8) void {
+    if (!enabled) return;
+    cache_reason = reason;
+}
+
+/// Record the explicit output artifact for `--compile` / native `compile`.
+pub fn setOutput(path: []const u8) void {
+    if (!enabled) return;
+    output_path_len = copyPath(&output_path_buf, path);
+}
+
+// ── Reporting ──────────────────────────────────────────────────────────────
+
+const run_stages = [_]Stage{ .read, .expand, .lower, .optimize, .emit, .execute };
+const compile_stages = [_]Stage{ .read, .expand, .lower, .optimize, .emit };
+const native_stages = [_]Stage{ .read, .lower, .optimize, .llvm_emit, .link };
+
+fn stageName(s: Stage) []const u8 {
+    return switch (s) {
+        .read => "read",
+        .expand => "expand",
+        .lower => "lower",
+        .optimize => "optimize",
+        .emit => "emit",
+        .llvm_emit => "llvm-emit",
+        .link => "link",
+        .execute => "execute",
+    };
+}
+
+/// JSON keys use `_` (llvm-emit → llvm_emit) so they are valid identifiers.
+fn stageKey(s: Stage) []const u8 {
+    return switch (s) {
+        .llvm_emit => "llvm_emit",
+        else => stageName(s),
+    };
+}
+
+fn ms(stage: Stage) f64 {
+    return @as(f64, @floatFromInt(buckets[@intFromEnum(stage)])) / 1_000_000.0;
+}
+
+fn stagesFor(mode: Mode) []const Stage {
+    return switch (mode) {
+        .run => &run_stages,
+        .compile => &compile_stages,
+        .native => &native_stages,
+    };
+}
+
+/// Emit the timing report to stderr. Safe to call unconditionally — a no-op
+/// unless `--timings` enabled this thread.
+pub fn report(mode: Mode) void {
+    if (!enabled) return;
+    var buf: [4096]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    switch (format) {
+        .text => renderText(&w, mode),
+        .json => renderJson(&w, mode),
+    }
+    writeStderr(w.buffered());
+}
+
+fn renderText(w: *std.Io.Writer, mode: Mode) void {
+    // On a cache hit the read→emit stages never ran; show only what did.
+    const only_execute = mode == .run and cache_outcome == .hit;
+    const stages: []const Stage = if (only_execute) &.{.execute} else stagesFor(mode);
+
+    w.writeAll("timings:") catch {};
+    for (stages, 0..) |s, i| {
+        w.print("{s} {s} {d:.1}ms", .{ if (i == 0) "" else " |", stageName(s), ms(s) }) catch {};
+    }
+    w.writeByte('\n') catch {};
+
+    switch (mode) {
+        .run => renderCacheLine(w),
+        .compile, .native => if (output_path_len > 0) {
+            w.print("output: {s}\n", .{output_path_buf[0..output_path_len]}) catch {};
+        },
+    }
+}
+
+fn renderCacheLine(w: *std.Io.Writer) void {
+    const path = cache_path_buf[0..cache_path_len];
+    switch (cache_outcome) {
+        .hit => w.print("cache: HIT ({s})\n", .{path}) catch {},
+        .miss => {
+            if (cache_written) {
+                w.print("cache: MISS (wrote {s})\n", .{path}) catch {};
+            } else if (cache_reason.len > 0) {
+                w.print("cache: MISS (not cached: {s})\n", .{cache_reason}) catch {};
+            } else {
+                w.print("cache: MISS ({s})\n", .{path}) catch {};
+            }
+        },
+        .off => w.print("cache: off ({s})\n", .{cache_reason}) catch {},
+        .none => w.writeAll("cache: off\n") catch {},
+    }
+}
+
+fn renderJson(w: *std.Io.Writer, mode: Mode) void {
+    w.print("{{\"mode\":\"{s}\",\"stages_ms\":{{", .{@tagName(mode)}) catch {};
+    for (stagesFor(mode), 0..) |s, i| {
+        w.print("{s}\"{s}\":{d:.3}", .{ if (i == 0) "" else ",", stageKey(s), ms(s) }) catch {};
+    }
+    w.writeAll("}") catch {};
+    switch (mode) {
+        .run => renderCacheJson(w),
+        .compile, .native => if (output_path_len > 0) {
+            w.print(",\"output\":\"", .{}) catch {};
+            writeJsonString(w, output_path_buf[0..output_path_len]);
+            w.writeAll("\"") catch {};
+        },
+    }
+    w.writeAll("}\n") catch {};
+}
+
+fn renderCacheJson(w: *std.Io.Writer) void {
+    w.print(",\"cache\":{{\"status\":\"{s}\"", .{@tagName(cache_outcome)}) catch {};
+    if (cache_outcome == .hit or cache_outcome == .miss) {
+        w.writeAll(",\"path\":\"") catch {};
+        writeJsonString(w, cache_path_buf[0..cache_path_len]);
+        w.print("\",\"written\":{s}", .{if (cache_written) "true" else "false"}) catch {};
+    }
+    if (cache_reason.len > 0) {
+        w.writeAll(",\"reason\":\"") catch {};
+        writeJsonString(w, cache_reason);
+        w.writeAll("\"") catch {};
+    }
+    w.writeAll("}") catch {};
+}
+
+/// Minimal JSON string escaping (paths can contain backslashes/quotes on some
+/// platforms). Control characters are rare in paths; escape the two that matter.
+fn writeJsonString(w: *std.Io.Writer, s: []const u8) void {
+    for (s) |c| {
+        switch (c) {
+            '"' => w.writeAll("\\\"") catch {},
+            '\\' => w.writeAll("\\\\") catch {},
+            else => w.writeByte(c) catch {},
+        }
+    }
+}
+
+fn writeStderr(bytes: []const u8) void {
+    if (comptime is_wasm) {
+        _ = std.posix.write(2, bytes) catch 0;
+    } else {
+        _ = std.posix.system.write(2, bytes.ptr, bytes.len);
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+/// Reset to a known state for a test and force `enabled` on. `enabled` is
+/// threadlocal, so every enabling test must `defer testTeardown()` to keep it
+/// from leaking into unrelated tests that share this thread.
+fn testReset(fmt: Format) void {
+    enable(fmt);
+}
+
+fn testTeardown() void {
+    enabled = false;
+    depth = 0;
+}
+
+test "disabled: begin/end are no-ops and record nothing" {
+    enabled = false;
+    depth = 0;
+    buckets = @splat(0);
+    begin(.read);
+    end();
+    try testing.expectEqual(@as(usize, 0), depth);
+    try testing.expectEqual(@as(u64, 0), buckets[@intFromEnum(Stage.read)]);
+}
+
+test "self-time stack: a nested stage is not double-counted into its parent" {
+    testReset(.text);
+    defer testTeardown();
+    defer test_clock = null;
+    // emit contains a nested expand, on a deterministic timeline. The invariant
+    // is that emit's bucket EXCLUDES expand's span — were it double-counted,
+    // emit would read 55+45=100 instead of 55.
+    test_clock = 100;
+    begin(.emit); // emit resumes at 100
+    test_clock = 130; // 30ns of emit before the nested call
+    begin(.expand); // credits emit += 30; expand resumes at 130
+    test_clock = 175; // 45ns of expand
+    end(); // credits expand += 45; emit resumes at 175
+    test_clock = 200; // 25ns more emit after the nested call
+    end(); // credits emit += 25
+
+    try testing.expectEqual(@as(u64, 55), buckets[@intFromEnum(Stage.emit)]);
+    try testing.expectEqual(@as(u64, 45), buckets[@intFromEnum(Stage.expand)]);
+    try testing.expectEqual(@as(usize, 0), depth);
+}
+
+test "self-time stack: sibling stages accumulate independently" {
+    testReset(.text);
+    defer testTeardown();
+    defer test_clock = null;
+    // read, then lower, then optimize — three non-nested spans in a row.
+    test_clock = 0;
+    begin(.read);
+    test_clock = 10;
+    end(); // read = 10
+    begin(.lower);
+    test_clock = 40;
+    end(); // lower = 30
+    begin(.optimize);
+    test_clock = 45;
+    end(); // optimize = 5
+    try testing.expectEqual(@as(u64, 10), buckets[@intFromEnum(Stage.read)]);
+    try testing.expectEqual(@as(u64, 30), buckets[@intFromEnum(Stage.lower)]);
+    try testing.expectEqual(@as(u64, 5), buckets[@intFromEnum(Stage.optimize)]);
+}
+
+test "unbalanced end never underflows depth" {
+    testReset(.text);
+    defer testTeardown();
+    end();
+    end();
+    try testing.expectEqual(@as(usize, 0), depth);
+}
+
+test "overflow past the stack cap balances without crashing" {
+    testReset(.text);
+    defer testTeardown();
+    const over = stack.len + 5;
+    var i: usize = 0;
+    while (i < over) : (i += 1) begin(.read);
+    try testing.expectEqual(over, depth);
+    i = 0;
+    while (i < over) : (i += 1) end();
+    try testing.expectEqual(@as(usize, 0), depth);
+}
+
+test "text report: run miss shows all stages and a wrote cache line" {
+    testReset(.text);
+    defer testTeardown();
+    buckets[@intFromEnum(Stage.read)] = 1_200_000;
+    buckets[@intFromEnum(Stage.execute)] = 12_100_000;
+    cacheMiss("/home/u/.kaappi/cache/abcd.sbc");
+    cacheWrote();
+
+    var buf: [4096]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    renderText(&w, .run);
+    const out = w.buffered();
+    try testing.expect(std.mem.indexOf(u8, out, "read 1.2ms") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "execute 12.1ms") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "cache: MISS (wrote /home/u/.kaappi/cache/abcd.sbc)") != null);
+}
+
+test "text report: run hit shows only execute + a HIT line" {
+    testReset(.text);
+    defer testTeardown();
+    buckets[@intFromEnum(Stage.execute)] = 5_000_000;
+    cacheHit("/home/u/.kaappi/cache/abcd.sbc");
+
+    var buf: [4096]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    renderText(&w, .run);
+    const out = w.buffered();
+    try testing.expect(std.mem.indexOf(u8, out, "execute 5.0ms") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "read") == null); // compile stages hidden on a hit
+    try testing.expect(std.mem.indexOf(u8, out, "cache: HIT (") != null);
+}
+
+test "json report: run mode has stable shape with all keys" {
+    testReset(.json);
+    defer testTeardown();
+    buckets[@intFromEnum(Stage.read)] = 1_200_000;
+    cacheMiss("/tmp/x.sbc");
+    cacheWrote();
+
+    var buf: [4096]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    renderJson(&w, .run);
+    const out = w.buffered();
+    try testing.expect(std.mem.indexOf(u8, out, "\"mode\":\"run\"") != null);
+    inline for (.{ "read", "expand", "lower", "optimize", "emit", "execute" }) |k| {
+        try testing.expect(std.mem.indexOf(u8, out, "\"" ++ k ++ "\":") != null);
+    }
+    try testing.expect(std.mem.indexOf(u8, out, "\"cache\":{\"status\":\"miss\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"written\":true") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"read\":1.200") != null);
+}
+
+test "json report: native mode lists llvm_emit and link, no cache" {
+    testReset(.json);
+    defer testTeardown();
+    setOutput("/tmp/prog");
+    var buf: [4096]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    renderJson(&w, .native);
+    const out = w.buffered();
+    try testing.expect(std.mem.indexOf(u8, out, "\"mode\":\"native\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"llvm_emit\":") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"link\":") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"output\":\"/tmp/prog\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"cache\"") == null);
+}
+
+test "json string escaping for paths with quotes and backslashes" {
+    var buf: [128]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    writeJsonString(&w, "a\\b\"c");
+    try testing.expectEqualStrings("a\\\\b\\\"c", w.buffered());
+}

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -167,6 +167,7 @@ run_shell_suite "Pipeline dumps" tests/scheme/pipeline
 run_shell_suite "Doctor" tests/scheme/doctor
 run_shell_suite "Formatter" tests/scheme/fmt
 run_shell_suite "Cache" tests/scheme/cache
+run_shell_suite "Timings" tests/scheme/timings
 
 echo "=== R7RS test suite ==="
 set +e

--- a/tests/scheme/timings/timings-1515.sh
+++ b/tests/scheme/timings/timings-1515.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Regression test for #1515: `--timings` / `--timings=json` — per-stage pipeline
+# timings + cache HIT/MISS visibility on the run and compile paths.
+#
+# Hermetic: KAAPPI_HOME points at a throwaway dir so the real user cache is
+# never read or written. Timing output goes to stderr (like --diagnostics=json),
+# so stdout stays clean for piping — the tests assert both.
+#
+# Usage: bash tests/scheme/timings/timings-1515.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+
+HOMEDIR="$(mktemp -d)"
+PROGDIR="$(mktemp -d)"
+trap 'rm -rf "$HOMEDIR" "$PROGDIR"' EXIT
+export KAAPPI_HOME="$HOMEDIR"
+
+# Import-free program (the run-cache is, pre-existing, skipped for programs that
+# import — see #1516), so HIT/MISS is exercised.
+PROG="$PROGDIR/square.scm"
+cat > "$PROG" <<'SCM'
+(define (square x) (* x x))
+(display (square 9))
+(newline)
+SCM
+
+check() { # label expected-substring actual
+    if [[ "$3" == *"$2"* ]]; then
+        echo "PASS: $1"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: $1"; echo "  expected to contain: $2"; echo "  actual: $3"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_absent() { # label unexpected-substring actual
+    if [[ "$3" != *"$2"* ]]; then
+        echo "PASS: $1"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: $1"; echo "  expected NOT to contain: $2"; echo "  actual: $3"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_exit() { # label expected actual
+    if [[ "$3" -eq "$2" ]]; then
+        echo "PASS: $1"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: $1 — expected exit $2, got $3"; FAIL=$((FAIL + 1))
+    fi
+}
+
+# Capture only stderr (where timings are written); send stdout to /dev/null.
+stderr_of() { "$@" 2>&1 1>/dev/null; }
+# Capture only stdout (program output); discard stderr.
+stdout_of() { "$@" 2>/dev/null; }
+
+# Validate that a string is well-formed JSON when python3 is available; a no-op
+# (recorded as a skip note) otherwise, so the test never hard-depends on python.
+check_json_parses() { # label json
+    if command -v python3 >/dev/null 2>&1; then
+        if printf '%s' "$2" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
+            echo "PASS: $1 (valid JSON)"; PASS=$((PASS + 1))
+        else
+            echo "FAIL: $1 — not valid JSON"; echo "  actual: $2"; FAIL=$((FAIL + 1))
+        fi
+    else
+        echo "SKIP: $1 (python3 unavailable)"
+    fi
+}
+
+# ── 1. Run path, text, first run → cache MISS with all stages ───────────────
+out="$(stderr_of "$KAAPPI" --timings "$PROG")"
+check "run text: has a timings line" "timings:" "$out"
+for stage in read expand lower optimize emit execute; do
+    check "run text MISS: shows stage '$stage'" "$stage " "$out"
+done
+check "run text: first run is a MISS that wrote the cache" "cache: MISS (wrote " "$out"
+check "run text: MISS names the .sbc path" ".sbc" "$out"
+
+# Program stdout must be exactly its own output — no timing noise leaks in.
+prog_out="$(stdout_of "$KAAPPI" --timings "$PROG")"
+check "run: stdout carries only program output" "81" "$prog_out"
+check_absent "run: timings never pollute stdout" "timings:" "$prog_out"
+check_absent "run: cache line never pollutes stdout" "cache:" "$prog_out"
+
+# ── 2. Run path, text, second run → cache HIT (compile stages skipped) ──────
+out="$(stderr_of "$KAAPPI" --timings "$PROG")"
+check "run text: second run is a HIT" "cache: HIT (" "$out"
+check "run text HIT: still reports execute" "execute " "$out"
+check_absent "run text HIT: compile stages are hidden" "read " "$out"
+
+# ── 3. Run path, JSON → stable, well-formed shape ──────────────────────────
+json="$(stderr_of "$KAAPPI" --timings=json "$PROG")"
+check_json_parses "run json" "$json"
+check "run json: mode is run" '"mode":"run"' "$json"
+check "run json: has stages_ms object" '"stages_ms":{' "$json"
+for key in read expand lower optimize emit execute; do
+    check "run json: stages_ms has key '$key'" "\"$key\":" "$json"
+done
+check "run json: cache status present (hit on this run)" '"cache":{"status":"hit"' "$json"
+check "run json: cache path present" '"path":"' "$json"
+check "run json: cache written flag present" '"written":' "$json"
+
+# ── 4. Cache off: --no-ir-opt and --sandbox never leave the cache blank ─────
+out="$(stderr_of "$KAAPPI" --timings --no-ir-opt "$PROG")"
+check "run text: --no-ir-opt reports cache off with reason" "cache: off (--no-ir-opt)" "$out"
+out="$(stderr_of "$KAAPPI" --timings --sandbox "$PROG")"
+check "run text: --sandbox reports cache off with reason" "cache: off (sandbox)" "$out"
+
+# ── 5. Imported programs: a MISS that is honestly not cached ────────────────
+IMP="$PROGDIR/imp.scm"
+cat > "$IMP" <<'SCM'
+(import (scheme base) (scheme write))
+(display (+ 1 2))
+(newline)
+SCM
+json="$(stderr_of "$KAAPPI" --timings=json "$IMP")"
+check_json_parses "imports json" "$json"
+check "imports json: recorded as a miss" '"status":"miss"' "$json"
+check "imports json: not written to cache" '"written":false' "$json"
+check "imports json: reason names imports" '"reason":"imports"' "$json"
+
+# ── 6. Compile path (--compile): stages + output, no cache/execute ──────────
+json="$(stderr_of "$KAAPPI" --timings=json --compile "$PROG" -o "$PROGDIR/square.sbc")"
+check_json_parses "compile json" "$json"
+check "compile json: mode is compile" '"mode":"compile"' "$json"
+check "compile json: reports emit stage" '"emit":' "$json"
+check "compile json: names the output artifact" '"output":"' "$json"
+check_absent "compile json: no execute stage" '"execute":' "$json"
+check_absent "compile json: no cache object" '"cache"' "$json"
+
+# ── 7. No flag → no timing output at all ────────────────────────────────────
+out="$(stderr_of "$KAAPPI" "$PROG")"
+check_absent "no flag: no timings on stderr" "timings:" "$out"
+check_absent "no flag: no cache line on stderr" "cache:" "$out"
+
+# ── 8. Bad format is a usage error ──────────────────────────────────────────
+set +e
+"$KAAPPI" --timings=bogus "$PROG" >/dev/null 2>&1
+check_exit "invalid --timings format exits 2" 2 $?
+set -e
+
+echo ""
+echo "$PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #1515. Part of the machine-legibility epic #1503; builds on the cache-transparency work in #1516.

## Problem

`--profile` profiles the *user's program*. Nothing reported how long *kaappi's own* pipeline stages take, or whether a run was served from the invisible `.sbc` bytecode cache — the same cache whose staleness has repeatedly cost real debugging hours.

## What this adds

`kaappi --timings file.scm` (and `--timings=json`), on the run, `--compile`, and native `compile` paths. Output goes to **stderr** (like `--diagnostics=json`), so the program's own stdout stays clean for piping.

Run, cache **MISS** (everything compiled):
```
timings: read 1.2ms | expand 0.8ms | lower 0.4ms | optimize 0.3ms | emit 0.5ms | execute 12.1ms
cache: MISS (wrote /Users/you/.kaappi/cache/1f8b6bdfcf8b707e.sbc)
```

Run, cache **HIT** (pipeline skipped — only `execute` ran):
```
timings: execute 11.9ms
cache: HIT (/Users/you/.kaappi/cache/1f8b6bdfcf8b707e.sbc)
```

The cache line is never blank: `cache: off (--no-ir-opt)` / `(sandbox)`, or `cache: MISS (not cached: imports)`. `--timings=json` emits one stable-shaped object (`mode`, `stages_ms`, `cache`/`output`) for CI regression tracking.

## Design — self-time profiler stack

The pipeline isn't flat: macro expansion is interleaved with emission (a macro use lowers to a passthrough node that is expanded, then re-compiled, during `compileFromNode`), so `emit` legitimately contains nested `expand`/`lower`/`optimize`/`emit`. A naive per-stage accumulator would double-count those. `src/timings.zig` credits wall time only to the *innermost* active stage, so the buckets are **disjoint** regardless of nesting or driver. A macro-heavy compile shows this working — `expand` can dwarf `emit` precisely because `emit` excludes the expansion it drove.

Instrumentation lives at the shared chokepoints (`ir.lowerAndOptimize`, `expander.expandMacro`, `compiler.compile`/`compileMultiple`, `native_compiler`, the run/compile drivers), so all callers are covered at once.

## No overhead when absent / threading

Each `begin`/`end` is a single predicted branch (`if (!enabled) return`) when off — none sit in the bytecode dispatch loop. `enabled` is `threadlocal` (mirroring `ir.optimize_enabled`), so only the main thread is armed; SRFI-18 child threads compiling via `eval` neither race on nor pollute the buckets.

## Acceptance criteria

- [x] `--timings` and `--timings=json` on the run and compile paths
- [x] Cache HIT/MISS + path always included
- [x] No measurable overhead when the flag is absent
- [x] Shell test validating the JSON shape

## Tests

- `src/timings.zig` unit tests drive the self-time stack on a deterministic clock (`test_clock`, gated on `builtin.is_test` so it compiles out of production) and check text/JSON rendering; `src/cli.zig` parse tests for the flag + sandbox pre-scan.
- `tests/scheme/timings/timings-1515.sh` (42 checks): JSON shape (parsed with `python3` when available), HIT/MISS transitions, cache-off reasons, compile-path shape, stdout cleanliness, bad-format exit code. Registered in `run-all.sh`.
- Full unit suite green; Scheme suite **1866 pass / 0 fail** (incl. the still-passing #1516 cache suite); Linux x86_64 and WASM cross-builds green; `zig fmt` clean.

See `docs/dev/timings.md` for the full contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)