### PR TITLE
Update gate/P3 benchmark docs to reflect completed Linux run + #1474 closure

### DIFF
--- a/benchmarks/gate/README.md
+++ b/benchmarks/gate/README.md
@@ -221,10 +221,16 @@ adopted **before** the frozen run starts (once it starts, the protocol freezes):
    raise, so it does not affect measurement, but it is a latent robustness bug
    worth a separate issue.
 
-## What is deferred
+## Status — campaign complete
 
-Lever D has now landed, so the gate's `C+D` cells are runnable. The frozen §4
-collection on **both** reference machines (macOS aarch64 + Linux x86_64, ≥ 8
-physical cores), the gate worksheet fill-in, and the KEP-0002 UQ 1 amendment are
-the campaign's remaining operational steps, to run once the harness is reviewed
-(ideally after kaappi#1489 is fixed — see limitation 2).
+The frozen §4 collection has run on **both** reference machines: macOS
+aarch64 (commit `b6d349c0`, 920 launches, 0 failures) and Linux x86_64
+(commit `807fd64a`, ~1000 launches, 0 failures; FO-DIGEST's 64 MiB cell
+excluded on Linux only, see `results/gate-linux-x86_64-metadata.txt`).
+Both machines independently classify **4 Between** — agreement, not just
+the cross-machine rule's fallback. The gate worksheet
+(`../../docs/dev/kep-0003-acceptance-gate-worksheet.md`) is fully filled;
+kaappi#1489 (limitation 2) was fixed before either frozen run started, and
+neither run hit a hang. kaappi#1474 (the gate decision issue) is closed;
+KEP-0003 stays Draft, gated, with its revisit trigger documented in the
+worksheet.

--- a/docs/dev/kep-0002-phase7-envelope-benchmarks.md
+++ b/docs/dev/kep-0002-phase7-envelope-benchmarks.md
@@ -257,34 +257,38 @@ Done in this pass:
   in the shipped build; still lever-selectable under `-Dchannel-instrument`
   so the gate's `none` baseline is preserved. Default-build regression test
   added ("lever C shipped default" in `tests_shared_channel.zig`).
-- **Lever B prototype landed and both P3 clauses met** — the reusable
-  per-channel arena, as a bounded single-slot recycled-GC cache behind
-  `-Dchannel-arena` (off in the shipped default). gc-stress + arena 77/77;
-  real-path small-message wins 51–63%; symbol-table reset contained in
-  `shared_channel.zig`. See the (B) section above. Remaining: the ship
-  decision (promote the flag to default, as C was).
+- **Lever B prototype landed, both P3 clauses met, and shipped as the
+  default** — the reusable per-channel arena, as a bounded single-slot
+  recycled-GC cache. `-Dchannel-arena` now defaults to `true` (pass
+  `-Dchannel-arena=false` to restore lever A); forced off under
+  `-Dchannel-instrument` so the frozen gate baseline stays lever A.
+  gc-stress + arena 77/77; real-path small-message wins 51–63%;
+  symbol-table reset contained in `shared_channel.zig`. See the (B) section
+  above.
 
 Still open for Phase 7 / #1472:
 
-1. **Second reference machine** — re-run on Linux x86_64 (≥ 8 physical
-   cores) and confirm the C and B verdicts agree. Only then is the P3
-   decision two-machine-solid.
-2. **Lever-B ship decision** — the second clause is now met (prototype
-   above); promoting the `-Dchannel-arena` cache to the shipped default is
-   a follow-up ship call, mirroring lever C's promotion.
-3. **The gate campaign** — the `parallel-map` IP-*/FO-* workloads, the
-   parent-side copy-overhead-share instrumentation, the Kalibera–Jones
-   statistics driver, the CSV + classification worksheet, and lever D
-   wired behind a flag in the real path. The larger, separate half of
-   #1472 that feeds #1474. **Landed and largely done**: the harness in
-   `benchmarks/gate/` (six workloads + controls, the real-path `share`
-   counters `src/channel_instrument.zig` → `src/shared_channel.zig`, levers
-   `none`/`c`/`cd`, the K–J driver emitting the §6 CSV), **lever D**
-   (`src/shared_buffer.zig`, zero-copy receive + copy-on-write behind
-   `-Dchannel-instrument`), the kaappi#1489 pool-hang fix, and the **macOS
-   aarch64 frozen run** (920 launches, 0 failures) → classified **Between**,
-   so KEP-0003 stays gated (worksheet
-   `docs/dev/kep-0003-acceptance-gate-worksheet.md`, dataset in
-   `benchmarks/gate/results/`). The only open piece is the Linux x86_64 run
-   (item 1); per §5 it cannot change the combined outcome (macOS=Between ⇒
-   combined=Between), so it is a publish-completeness follow-up.
+1. **Second reference machine for the P3 micro-benchmark** — re-run
+   `bench_channel.zig` itself on Linux x86_64 (≥ 8 physical cores) and
+   confirm the C and B verdicts agree there too. Only then is the P3
+   ship decision two-machine-solid. (Distinct from the gate campaign's
+   Linux run below, which is a different benchmark and is done.)
+
+The gate campaign (the `parallel-map` IP-*/FO-* workloads, the parent-side
+copy-overhead-share instrumentation, the Kalibera–Jones statistics driver,
+the CSV + classification worksheet, and lever D wired behind a flag in the
+real path — the larger, separate half of #1472 that fed #1474) is
+**complete on both reference machines**: the harness in `benchmarks/gate/`
+(six workloads + controls, the real-path `share` counters
+`src/channel_instrument.zig` → `src/shared_channel.zig`, levers
+`none`/`c`/`cd`, the K–J driver emitting the §6 CSV), lever D
+(`src/shared_buffer.zig`, zero-copy receive + copy-on-write behind
+`-Dchannel-instrument`), the kaappi#1489 pool-hang fix, the **macOS aarch64
+frozen run** (920 launches, 0 failures), and the **Linux x86_64 frozen run**
+(commit `807fd64a`, ~1000 launches, 0 failures) all landed. Both machines
+independently classified **Between** — agreement, not just the cross-machine
+rule's fallback — so KEP-0003 stays gated (worksheet
+`docs/dev/kep-0003-acceptance-gate-worksheet.md`, datasets in
+`benchmarks/gate/results/`). Issue #1474 is closed (maintainer decision,
+2026-07-16); the revisit trigger (real `kaappi-examples` traces with an
+`IP-*`-shaped hot loop) is documented in the worksheet.

--- a/docs/dev/kep-0003-acceptance-gate-worksheet.md
+++ b/docs/dev/kep-0003-acceptance-gate-worksheet.md
@@ -260,9 +260,13 @@ rule regardless of what Linux showed (one machine reading Between makes
 agreement-or-disagreement both resolve to Between) — but the two machines
 turning out to *agree* is a stronger result than that logical fallback: it's
 a genuine cross-machine confirmation of the same demand shape, not just an
-unfalsifiable classification. KEP-0003 therefore **stays Draft (gated)**;
-#1474 stays open with the revisit trigger documented (real
-`kaappi-examples` traces with an `IP-*`-shaped hot loop).
+unfalsifiable classification. KEP-0003 therefore **stays Draft (gated)**.
+The protocol's default action for this outcome is to leave kaappi#1474 open
+as a placeholder for the revisit trigger; the maintainer closed it anyway on
+2026-07-16 as an explicit call (issuecomment-4987953896) once the dataset
+and this worksheet were complete. The trigger itself is unaffected by that
+housekeeping choice and remains the thing to watch for: real
+`kaappi-examples` traces with an `IP-*`-shaped hot loop.
 
 ### Reading (both machines) — what the numbers say beyond the verdict
 
@@ -310,6 +314,12 @@ status PR.
 | **2 Erlang** | KEP-0003 → **Rejected** (data linked) | open the Alternative-1 issue (refcounted immutable payloads) under KEP-0002 UQ 1; close #1475 unworked |
 | **3 Absent** | KEP-0003 → **Rejected** (data linked) | close both #1475 **and** the Alternative-1 line, with the data linked |
 | **4 Between** | KEP-0003 stays **Draft** (gated) | #1474 stays open; document the revisit trigger: real `kaappi-examples` traces with an `IP-*`-shaped hot loop |
+
+*(This run landed outcome 4. The "#1474 stays open" cell above is the
+protocol's default action; in practice the maintainer closed #1474 on
+2026-07-16 once this worksheet was complete, rather than leaving it open —
+see the note at the end of the Combined outcome section. The revisit
+trigger stands regardless of the issue's open/closed state.)*
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #1580 and the #1474/#1503 closures — three docs still described work as open/deferred that has since landed:

- `docs/dev/kep-0002-phase7-envelope-benchmarks.md`: lever B's shipped-default decision (PR #1560) and the gate campaign's Linux run (PR #1580) were both still listed as "remaining." Also un-conflates two different "Linux re-run" tasks that a stale cross-reference had blurred together: the P3 micro-benchmark's own Linux re-run of `bench_channel.zig` (still genuinely open, unrelated to #1472/#1474) vs. the gate campaign's Linux run (done).
- `benchmarks/gate/README.md`: "What is deferred" rewritten to "Status — campaign complete" now that both reference machines are collected.
- `docs/dev/kep-0003-acceptance-gate-worksheet.md`: updates the "#1474 stays open" language (written before the issue was actually closed) to note the real disposition — closed by explicit maintainer decision on 2026-07-16, a deliberate deviation from the protocol's own default action for a "Between" outcome, called out so it doesn't read as a protocol violation later. The revisit trigger is unchanged either way.

No code changes; docs-only.

## Test plan

- [x] Re-read all three files end-to-end after editing
- [x] Confirmed via `build.zig` that `-Dchannel-arena` genuinely defaults to `true` before claiming lever B ships as default
- [x] `grep`'d `docs/dev/` and `benchmarks/gate/` for other stale "pending"/"TBD"/"Linux x86_64" references — none remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)