### PR TITLE
Sign macOS releases with disable-library-validation (#1587)

### DIFF
--- a/.github/kaappi.entitlements
+++ b/.github/kaappi.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- macOS release binaries can now `ffi-open` user-compiled libraries: the hardened-runtime signing entitlements add `com.apple.security.cs.disable-library-validation`, without which dlopen refused every locally-built `.dylib` (kaappi-net, kaappi-pg, kaappi-sqlite, kaappi-crypto) on release binaries while source builds worked (#1587)
+
 ## [0.15.0] - 2026-07-16
 
 ### Added


### PR DESCRIPTION
Fixes #1587.

The macOS release signing applies the hardened runtime (`--options runtime`) with entitlements granting only `com.apple.security.cs.allow-jit`. Library validation therefore stays enabled, and `dlopen` refuses any dylib not signed by the same Team ID or Apple — which is every user-compiled C FFI library. Result: `(ffi-open ...)` fails on release binaries for all locally-built ecosystem libraries (kaappi-net, kaappi-pg, kaappi-sqlite, kaappi-crypto), while unsigned source builds load the same file fine.

This adds `com.apple.security.cs.disable-library-validation` — the entitlement Apple provides for exactly this plugin-loading case — to `.github/kaappi.entitlements`, which the release workflow applies to both `kaappi` and `thottam`.

## Verification

On macOS arm64 (kaappi 0.15.0 source build, ad-hoc signed with the hardened runtime to emulate release signing):

| Entitlements | `(ffi-open "…/libcbtest.dylib")` |
|---|---|
| shipped (`allow-jit` only) | dlopen error — reproduces the release binary's behavior |
| this PR (`allow-jit` + `disable-library-validation`) | `#<ffi-library …>` — loads |

`plutil -lint` passes on the updated plist. Notarization accepts this entitlement (it is not in the restricted set that requires a provisioning profile).

After the next release, verify the shipped artifact directly: `cc -dynamiclib -o /tmp/libx.dylib x.c` then `(import (kaappi ffi)) (ffi-open "/tmp/libx.dylib")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)