### PR TITLE
LLVM backend: fix native let root leak (#1585) + duplicated fallback effects (#1586)

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -114,8 +114,22 @@ pub const LLVMEmitter = struct {
     // for a variadic frame, the rest-list slot (#1498). Boxed frames disable
     // tail-call emission, so their only `ret` is the trailing one; a variadic
     // self-tail loop keeps tail calls, so emitCallNode/emitDirectCall also pop
-    // these before a tail-call `ret` (a no-op when the count is zero).
+    // these before a tail-call `ret` (a no-op when the count is zero). These are
+    // pushed BEFORE the frame's loop header (body_label), so a self-tail call's
+    // branch-back to that header does NOT pop them — they persist across
+    // iterations (the rest-list slot is overwritten in place).
     frame_entry_roots: usize = 0,
+    // Number of GC roots pushed by let/let* bindings AFTER the frame's loop
+    // header that are live at the current tail position and must be released
+    // before EVERY tail transfer: both a `ret` through an in-body tail call and
+    // a self-tail call's branch-back to the header (which re-enters the let and
+    // re-pushes them, so leaving them would leak one root set per iteration —
+    // #1585). Distinct from frame_entry_roots precisely because the branch-back
+    // must pop these but not those. emitLet publishes its binding_root_count
+    // here while lowering its body in tail position and restores the prior value
+    // afterwards; nested lets accumulate. Always 0 unless self.locals != null
+    // (inside a rooted let), which keeps musttail disabled while it is nonzero.
+    body_scope_roots: usize = 0,
     // True only while emitting a `tailcc` register-argument fast-entry body
     // (#1499). A tail call to another native fast entry may be a guaranteed
     // `musttail call tailcc` only here — the uniform (ccc) entries, closures,
@@ -146,6 +160,7 @@ pub const LLVMEmitter = struct {
         locals: ?std.StringHashMap([]const u8),
         boxes: ?std.StringHashMap([]const u8),
         frame_entry_roots: usize,
+        body_scope_roots: usize,
         in_fast_entry: bool,
     };
 
@@ -164,6 +179,7 @@ pub const LLVMEmitter = struct {
             .locals = self.locals,
             .boxes = self.boxes,
             .frame_entry_roots = self.frame_entry_roots,
+            .body_scope_roots = self.body_scope_roots,
             .in_fast_entry = self.in_fast_entry,
         };
     }
@@ -182,6 +198,7 @@ pub const LLVMEmitter = struct {
         self.locals = s.locals;
         self.boxes = s.boxes;
         self.frame_entry_roots = s.frame_entry_roots;
+        self.body_scope_roots = s.body_scope_roots;
         self.in_fast_entry = s.in_fast_entry;
     }
 
@@ -553,9 +570,9 @@ pub const LLVMEmitter = struct {
 
         if (is_tail) {
             // Balance the frame-entry GC roots (variadic rest list, boxed
-            // params) before returning through this tail call (#1498). A no-op
-            // when the frame pushed none.
-            try self.emitPopRoots(self.frame_entry_roots);
+            // params) AND any let-binding roots live in the body (#1585) before
+            // returning through this tail call (#1498). A no-op when both are 0.
+            try self.emitPopRoots(self.frame_entry_roots + self.body_scope_roots);
             try self.print("  ret i64 {s}\n", .{result});
             try self.emitOrphanAfterTail();
         }
@@ -612,6 +629,14 @@ pub const LLVMEmitter = struct {
                 try self.print("  store i64 {s}, ptr {s}\n", .{ rest_tmp, alloca });
             }
         }
+
+        // Release the let-binding roots pushed since the loop header before
+        // branching back to it (#1585): the loop re-enters those lets and
+        // re-pushes fresh roots, so leaving them stacked leaks one set per
+        // iteration until the shadow stack overflows. frame_entry_roots (the
+        // rest-list slot) live BEFORE the header and are deliberately NOT popped
+        // — they persist across iterations, overwritten in place above.
+        try self.emitPopRoots(self.body_scope_roots);
 
         try self.print("  br label %{s}\n", .{body_lbl});
 
@@ -1095,11 +1120,13 @@ pub const LLVMEmitter = struct {
     // (#1499). It must be in tail position, inside a `tailcc` fast-entry body
     // (matching calling convention), and the shadow stack must hold no roots a
     // torn-down frame would strand: not inside a rooted `let` (self.locals is
-    // non-null only there) and with the frame-entry roots — rest list / boxed
-    // params, always 0 in a fast entry — already balanced. LLVM also requires
-    // the musttail to immediately precede its `ret`, which these guarantee.
+    // non-null only there, and body_scope_roots is likewise nonzero only there —
+    // #1585) and with the frame-entry roots — rest list / boxed params, always 0
+    // in a fast entry — already balanced. LLVM also requires the musttail to
+    // immediately precede its `ret`, which these guarantee.
     fn mustTailSafe(self: *LLVMEmitter, is_tail: bool) bool {
-        return is_tail and self.in_fast_entry and self.locals == null and self.frame_entry_roots == 0;
+        return is_tail and self.in_fast_entry and self.locals == null and
+            self.frame_entry_roots == 0 and self.body_scope_roots == 0;
     }
 
     // Direct call to a native fast entry (#1499): arguments are passed by value
@@ -1137,8 +1164,10 @@ pub const LLVMEmitter = struct {
         if (is_tail) {
             // A fast entry has no frame-entry roots, so for musttail this is a
             // no-op and the musttail immediately precedes ret as LLVM requires;
-            // a non-fast tail caller may still have some to balance (#1498).
-            if (!musttail) try self.emitPopRoots(self.frame_entry_roots);
+            // a non-fast tail caller may still have frame-entry roots and, inside
+            // a let, body-scope roots to balance (#1498, #1585). musttail is only
+            // chosen when both counts are 0 (see mustTailSafe).
+            if (!musttail) try self.emitPopRoots(self.frame_entry_roots + self.body_scope_roots);
             try self.print("  ret i64 {s}\n", .{result});
             try self.emitOrphanAfterTail();
         }
@@ -1179,9 +1208,9 @@ pub const LLVMEmitter = struct {
 
         if (is_tail) {
             // Balance the frame-entry GC roots (variadic rest list, boxed
-            // params) before returning through this tail call (#1498). A no-op
-            // when the frame pushed none.
-            try self.emitPopRoots(self.frame_entry_roots);
+            // params) AND any let-binding roots live in the body (#1585) before
+            // returning through this tail call (#1498). A no-op when both are 0.
+            try self.emitPopRoots(self.frame_entry_roots + self.body_scope_roots);
             try self.print("  ret i64 {s}\n", .{result});
             try self.emitOrphanAfterTail();
         }

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -238,6 +238,9 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
             null;
         defer if (self.boxes) |*b| b.deinit();
         self.frame_entry_roots = 0;
+        // A fresh frame starts with no let-binding roots (#1585); saveScope
+        // restored the enclosing value on exit.
+        self.body_scope_roots = 0;
 
         const header = std.fmt.allocPrint(self.allocator(), "; closure: {s}\ndefine i64 {s}(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) {{\nentry:\n", .{ closure_name, fn_name }) catch return null;
         defer self.allocator().free(header);
@@ -567,6 +570,9 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         self.boxes = if (boxed.any) std.StringHashMap([]const u8).init(self.backing_alloc) else null;
         defer if (self.boxes) |*b| b.deinit();
         self.frame_entry_roots = 0;
+        // A fresh frame starts with no let-binding roots (#1585); saveScope
+        // restored the enclosing value on exit.
+        self.body_scope_roots = 0;
         // A tail call in this body may be a guaranteed `musttail` only from a
         // `tailcc` fast entry (#1499).
         self.in_fast_entry = use_fast;

--- a/src/llvm_emit_let.zig
+++ b/src/llvm_emit_let.zig
@@ -61,21 +61,50 @@ fn emitLetFallback(self: *LLVMEmitter, args: Value, sequential: bool) EmitError!
     return self.emitCachedEval(source_buf.items);
 }
 
-// Abandon a partially emitted native let and compile the whole form via
-// the interpreter instead. Pops the GC roots already pushed for emitted
-// bindings (the natively computed values are dead once the interpreter
-// re-evaluates the form; leaving their roots pushed would leak stack
-// slots into the GC root set on every execution of this code path).
-fn abandonLetForFallback(self: *LLVMEmitter, args: Value, sequential: bool, saved_locals: ?std.StringHashMap([]const u8), roots_pushed: usize) EmitError![]const u8 {
-    try self.emitPopRoots(roots_pushed);
+// Abandon a partially emitted native let and compile the whole form via the
+// interpreter instead. Native let lowering is transactional (#1586): binding
+// initializers are written into self.buf as they are lowered, but the
+// interpreter fallback re-evaluates the WHOLE form, so any already-emitted init
+// with side effects would run once natively and again from the fallback.
+// Truncating self.buf back to the pre-let checkpoint discards every stranded
+// instruction — allocas, initializer side effects, box creation, and the GC
+// root pushes alike — so there is exactly one evaluation and nothing to pop
+// (the push_root calls were discarded with the rest). Restoring current_block
+// reopens the block the let began in: an initializer's in-scope control flow
+// (an `if`, say) may have split that block into terminated predecessors and a
+// fresh successor, all now truncated away, leaving the checkpoint block live
+// again for the fallback to emit into.
+fn abandonLetForFallback(self: *LLVMEmitter, args: Value, sequential: bool, saved_locals: ?std.StringHashMap([]const u8), checkpoint: Checkpoint) EmitError![]const u8 {
+    self.buf.shrinkRetainingCapacity(checkpoint.buf_len);
+    self.current_block = checkpoint.block;
+    self.body_scope_roots = checkpoint.body_scope_roots;
     self.locals.?.deinit();
     self.locals = saved_locals;
     return emitLetFallback(self, args, sequential);
 }
 
+// The emitter state emitLet must be able to roll back to when it abandons a
+// partially lowered form to the interpreter (#1586). Captured before any of the
+// let's own IR is written.
+const Checkpoint = struct {
+    buf_len: usize,
+    block: []const u8,
+    body_scope_roots: usize,
+};
+
 pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool) EmitError![]const u8 {
     const bindings = types.car(args);
     const body_list = types.cdr(args);
+
+    // Snapshot the emitter state before writing any of this let's IR, so an
+    // abandon partway through can roll back to exactly here (#1586). Captured up
+    // front — the upfront fallbacks below emit nothing before returning, so they
+    // never need it, but capturing here keeps the pre-let block/position exact.
+    const checkpoint: Checkpoint = .{
+        .buf_len = self.buf.items.len,
+        .block = self.current_block,
+        .body_scope_roots = self.body_scope_roots,
+    };
 
     // #827: If the let form (bindings or body) contains sub-expressions
     // that need interpreter eval fallback (cond, do, letrec, etc.),
@@ -150,17 +179,17 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
         var blist = bindings;
         while (blist != types.NIL and types.isPair(blist)) {
             if (count >= 32) {
-                return abandonLetForFallback(self, args, sequential, saved_locals, count);
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             }
             const binding = types.car(blist);
             const var_sym = types.car(binding);
             const init_expr = types.car(types.cdr(binding));
             if (!types.isSymbol(var_sym)) {
-                return abandonLetForFallback(self, args, sequential, saved_locals, count);
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             }
 
             const node = ir.lowerSingleExpr(self.allocator(), init_expr) catch {
-                return abandonLetForFallback(self, args, sequential, saved_locals, count);
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             };
             const alloca = try self.freshTemp();
             try self.print("  {s} = alloca i64, align 8\n", .{alloca});
@@ -168,7 +197,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
             // (e.g. a lambda) sends the whole let to the interpreter,
             // like the body path below.
             const val = self.emitNode(node) catch {
-                return abandonLetForFallback(self, args, sequential, saved_locals, count);
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             };
             // A captured+mutated let-local is stored as a heap box; the
             // alloca (rooted below) then holds the box pointer (#1497).
@@ -202,14 +231,14 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
             const var_sym = types.car(binding);
             const init_expr = types.car(types.cdr(binding));
             if (!types.isSymbol(var_sym)) {
-                return abandonLetForFallback(self, args, sequential, saved_locals, binding_root_count);
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             }
 
             const node = ir.lowerSingleExpr(self.allocator(), init_expr) catch {
-                return abandonLetForFallback(self, args, sequential, saved_locals, binding_root_count);
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             };
             const val = self.emitNode(node) catch {
-                return abandonLetForFallback(self, args, sequential, saved_locals, binding_root_count);
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             };
             const alloca = try self.freshTemp();
             try self.print("  {s} = alloca i64, align 8\n", .{alloca});
@@ -230,23 +259,36 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
         }
     }
 
+    // #1585: while the body is lowered in tail position, the binding roots must
+    // be released before every tail transfer — a `ret` through an in-body tail
+    // call and a self-tail call's branch-back to the loop header alike.
+    // Publishing them into body_scope_roots threads them into the same
+    // pop-before-tail accounting the tail-call emitters already apply, so the
+    // roots are dropped on those paths instead of being stranded past the `ret`
+    // (or re-pushed unbounded each loop iteration). The trailing emitPopRoots
+    // below still covers the ordinary fall-through (non-tail) exit; on a
+    // tail-transfer path it lands in the dead orphan block after the `ret`.
+    // Boxed lets set body_tail = false and pop only at fall-through.
+    if (body_tail) self.body_scope_roots += binding_root_count;
+
     var last: []const u8 = "";
     var body_expr = body_list;
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         const rest = types.cdr(body_expr);
         const expr_is_tail = body_tail and (rest == types.NIL or !types.isPair(rest));
         const node = ir.lowerSingleExprTail(self.allocator(), types.car(body_expr), expr_is_tail) catch {
-            return abandonLetForFallback(self, args, sequential, saved_locals, binding_root_count);
+            return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
         };
         // #827: if emitNode fails (e.g. a lambda that cannot be eval'd in
         // this lexical scope), fall back to evaluating the entire let form
         // via the interpreter.
         last = self.emitNode(node) catch {
-            return abandonLetForFallback(self, args, sequential, saved_locals, binding_root_count);
+            return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
         };
         body_expr = rest;
     }
 
+    self.body_scope_roots = checkpoint.body_scope_roots;
     try self.emitPopRoots(binding_root_count);
     self.locals.?.deinit();
     self.locals = saved_locals;

--- a/tests/scheme/compile/native-let-partial-emit-dup-1586.sh
+++ b/tests/scheme/compile/native-let-partial-emit-dup-1586.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Regression test for #1586: the native `let`/`let*` emitter duplicated side
+# effects when a partially-emitted let abandoned to the interpreter fallback.
+#
+# emitLet writes binding initializers into the output IR incrementally, but bails
+# to a whole-form `kaappi_eval_cached` fallback when a later binding or body form
+# cannot be lowered natively (over the 32-binding ceiling, a non-symbol binding
+# var, an init/body that needs interpreter eval in this lexical scope). The
+# abandon path could not unwind the IR already written, so any side-effecting
+# initializer that had already been emitted ran once from the stranded native
+# code AND again when the interpreter re-evaluated the whole form.
+#
+# The fix makes native let lowering transactional: emitLet snapshots the output
+# position (and current block) before writing any of its IR, and the abandon path
+# truncates back to that snapshot — discarding the partial initializers, their
+# side effects, and their GC root pushes — before emitting the interpreter
+# fallback. Each side effect then runs exactly once, matching the interpreter.
+#
+# NOTE: the incremental-emit path is only reached for a BARE top-level `let`
+# (a `let` that is a top-level form). A `let` that is a define initializer or a
+# function body takes a different route that does not duplicate — so these
+# reproducers must be bare top-level lets, exactly as in the issue. The
+# interpreter, run in file mode, echoes the value of each bare top-level form;
+# the natively-compiled binary does not. We therefore assert the native output
+# against the known-correct constant, and cross-check that the interpreter's
+# final (non-echo) line agrees.
+#
+# Usage: bash tests/scheme/compile/native-let-partial-emit-dup-1586.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
+    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+fi
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+# Each program ends with an explicit `(display ...)` of the observable side
+# effect state on its own final line. `expect` is that final line — the correct
+# result when the side effect runs exactly once. Before the fix the native
+# binary printed the doubled state; after it, it matches the interpreter.
+check() {
+    local name="$1" src="$2" expect="$3"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    # Oracle: the interpreter never had the bug. Its last output line is the
+    # explicit display (earlier lines may be the echoed bare-let values).
+    local interp_last
+    interp_last=$("$KAAPPI_ABS" "$DIR/$name.scm" 2>&1 | tail -1) || {
+        echo "FAIL: $name — interpreter run failed" >&2
+        fail=1
+        return
+    }
+    if [[ "$interp_last" != "$expect" ]]; then
+        echo "FAIL: $name — interpreter final line '$interp_last', expected '$expect'" >&2
+        fail=1
+        return
+    fi
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    local out status
+    set +e
+    out=$("$DIR/$name" 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 ]]; then
+        echo "FAIL: $name — binary aborted (exit $status): $out" >&2
+        fail=1
+        return
+    fi
+    if [[ "$out" != "$expect" ]]; then
+        echo "FAIL: $name — native gave '$out', expected '$expect' (side effect duplicated?)" >&2
+        fail=1
+    fi
+}
+
+# 1. Issue reproducer: a 33-binding let exceeds the 32-binding native ceiling, so
+#    emission bails after the first 32 inits are already written. The first init
+#    has a side effect (bump). It must run once — n=1, not n=2.
+check dup-33-bindings \
+'(define n 0)
+(define (bump) (set! n (+ n 1)) 0)
+(let ((b0 (bump)) (b1 0) (b2 0) (b3 0) (b4 0) (b5 0) (b6 0) (b7 0) (b8 0)
+      (b9 0) (b10 0) (b11 0) (b12 0) (b13 0) (b14 0) (b15 0) (b16 0) (b17 0)
+      (b18 0) (b19 0) (b20 0) (b21 0) (b22 0) (b23 0) (b24 0) (b25 0) (b26 0)
+      (b27 0) (b28 0) (b29 0) (b30 0) (b31 0) (b32 0))
+  n)
+(display "n=") (display n) (newline)' \
+'n=1'
+
+# 2. A side-effecting first init that also contains control flow (an `if`),
+#    followed by the 33-binding overflow. The `if` splits the current basic block
+#    before the abandon; the fix must restore the block so the fallback emits into
+#    a live block AND discard the init so the effect runs once.
+check dup-init-control-flow \
+'(define n 0)
+(define (bump) (set! n (+ n 1)) 7)
+(let ((b0 (if (> (bump) 0) 1 2)) (b1 0) (b2 0) (b3 0) (b4 0) (b5 0) (b6 0)
+      (b7 0) (b8 0) (b9 0) (b10 0) (b11 0) (b12 0) (b13 0) (b14 0) (b15 0)
+      (b16 0) (b17 0) (b18 0) (b19 0) (b20 0) (b21 0) (b22 0) (b23 0) (b24 0)
+      (b25 0) (b26 0) (b27 0) (b28 0) (b29 0) (b30 0) (b31 0) (b32 0))
+  (+ b0 n))
+(display "n=") (display n) (newline)' \
+'n=1'
+
+# 3. Mid-body abandon: an earlier body expression runs for effect, then a later
+#    body form (a `cond` with a `=>` clause, not natively emittable inside a let
+#    scope) abandons the whole let. The earlier effect must not be duplicated.
+check dup-body-abandon \
+'(define log (quote ()))
+(define (note x) (set! log (cons x log)) x)
+(let ((a 2))
+  (if (> a 0) (note (quote pos)) (note (quote neg)))
+  (cond ((assv a (quote ((2 . two) (3 . three)))) => cdr)
+        (else (quote other))))
+(display "log=") (display (reverse log)) (newline)' \
+'log=(pos)'
+
+# 4. let* variant: a side-effecting first init, then a second init that is not
+#    natively emittable (cond with =>), forcing abandon after the first init.
+check dup-letstar \
+'(define cnt 0)
+(define (tick) (set! cnt (+ cnt 1)) cnt)
+(let* ((a (if (> (tick) 0) 10 20))
+       (b (cond ((assv a (quote ((10 . ten)))) => cdr) (else (quote no)))))
+  (list a b))
+(display "cnt=") (display cnt) (newline)' \
+'cnt=1'
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-let-partial-emit-dup-1586: all cases passed"

--- a/tests/scheme/compile/native-let-tail-root-leak-1585.sh
+++ b/tests/scheme/compile/native-let-tail-root-leak-1585.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Regression test for #1585: the native `let`/`let*` emitter leaked GC
+# shadow-stack roots on tail calls through a let body.
+#
+# An unboxed let lowers its last body expr in tail position, but the tail-call
+# emitters used to pop only the frame-entry roots before `ret` — never the let's
+# binding roots. The trailing `kaappi_gc_pop_roots` landed in the dead orphan
+# block after the `ret`, so every execution leaked one shadow-stack slot per
+# binding. `GC.pushRoot` grows the root buffer to MAX_ROOT_CAPACITY (65536) and
+# then panics ("GC root stack overflow"), so any loop that drives such a pattern
+# past ~65k iterations crashed a natively-compiled binary while the interpreter
+# ran fine.
+#
+# The self-tail-call path (a loop through a let) leaked the same way: the
+# branch-back to the loop header re-entered the let and re-pushed its roots
+# without popping the previous iteration's.
+#
+# Native codegen is NOT covered by -Dgc-stress (a VM/interpreter build option),
+# so this compile-and-run test is what guards the regression. Each loop below
+# runs well past MAX_ROOT_CAPACITY, so a leak of even one root per iteration
+# overflows the buffer and aborts.
+#
+# Usage: bash tests/scheme/compile/native-let-tail-root-leak-1585.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
+    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+fi
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+# Compile natively, run, and compare output. Also assert a native user function
+# was actually emitted, so a silent fallback to the interpreter (which never had
+# the bug) can never make this test pass vacuously.
+check() {
+    local name="$1" src="$2" expect_out="$3"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    local out status
+    set +e
+    out=$("$DIR/$name" 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 ]]; then
+        echo "FAIL: $name — binary aborted (exit $status): $out" >&2
+        fail=1
+        return
+    fi
+    if [[ "$out" != "$expect_out" ]]; then
+        echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
+        fail=1
+        return
+    fi
+
+    # Confirm this exercised native codegen rather than a fallback.
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1) || true
+    if ! grep -qE '^define ([a-z]+ )*i64 @(lambda_|r[0-9])' "$DIR/$name.ll" 2>/dev/null; then
+        echo "FAIL: $name — expected a native fn definition (test would be vacuous otherwise)" >&2
+        fail=1
+    fi
+}
+
+# 1. Issue reproducer: an ordinary tail call in a non-boxed let body, driven
+#    100000 times (> MAX_ROOT_CAPACITY). Before the fix this panicked with
+#    "GC root stack overflow"; the interpreter printed "done".
+check tail-through-let \
+'(define (g x) x)
+(define (f n) (let ((a (+ n 1))) (g a)))
+(define (drive i)
+  (if (= i 0) (quote done) (begin (f i) (drive (- i 1)))))
+(display (drive 100000)) (newline)' \
+'done'
+
+# 2. Self-tail loop through a let: the branch-back path (emitSelfTailCall) must
+#    pop the binding roots too, or every iteration leaks one.
+check self-tail-loop-let \
+'(define (loop i acc)
+  (let ((j (+ i 1)))
+    (if (= i 300000) acc (loop j (+ acc 1)))))
+(display (loop 0 0)) (newline)' \
+'300000'
+
+# 3. Self-tail loop through a let* (two bindings — leak of two roots/iteration
+#    without the fix).
+check self-tail-loop-letstar \
+'(define (loop i acc)
+  (let* ((j (+ i 1)) (k (+ acc 1)))
+    (if (= i 300000) acc (loop j k))))
+(display (loop 0 0)) (newline)' \
+'300000'
+
+# 4. Two nested lets, both in tail position: a tail call through them must pop
+#    BOTH binding roots. Driven past the cap via a non-tail outer driver.
+check nested-let-tail \
+'(define (g a b) (+ a b))
+(define (f n) (let ((a (+ n 1))) (let ((b (+ a 1))) (g a b))))
+(define (drive i)
+  (if (= i 0) (quote done) (begin (f i) (drive (- i 1)))))
+(display (drive 100000)) (newline)' \
+'done'
+
+# 5. Variadic self-tail loop through a let: the frame-entry rest-list root lives
+#    before the loop header and must persist across iterations, while the let
+#    binding root inside the body must be popped on every branch-back.
+check variadic-self-tail-let \
+'(define (loop i . rest)
+  (let ((j (+ i 1)))
+    (if (= i 300000) (length rest) (loop j (quote x)))))
+(display (loop 0)) (newline)' \
+'1'
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-let-tail-root-leak-1585: all cases passed"


### PR DESCRIPTION
Closes #1585
Closes #1586

## Summary

Fixes two pre-existing bugs in the LLVM native backend's `let`/`let*` emitter, both surfaced by CodeRabbit while reviewing the mechanical file split in #1583 (not introduced by it). Native codegen is not covered by `-Dgc-stress`, which is why the unit suite never caught them.

### #1585 — GC root leak on tail calls through a let body

An unboxed `let` lowers its last body expr in tail position, but the tail-call emitters popped only `frame_entry_roots` before `ret` — never the let's binding roots. The trailing `kaappi_gc_pop_roots` landed in the dead orphan block after the `ret`, leaking one shadow-stack slot per binding on every execution; `GC.pushRoot` overflows at `MAX_ROOT_CAPACITY` (65536), so any loop driving such a pattern past ~65k iterations crashed a natively-compiled binary while the interpreter ran fine. The self-tail-call branch-back to the loop header leaked the same way (re-entering the let and re-pushing its roots each iteration).

**Fix:** a new `body_scope_roots` emitter counter (a sibling to `frame_entry_roots`) holds the let-binding roots that must be released before *every* tail transfer. `emitCallNode`/`emitFastCall`/`emitDirectCall` now pop `frame_entry_roots + body_scope_roots` before `ret`; `emitSelfTailCall` pops only `body_scope_roots` before the loop back-edge — the rest-list / boxed-param roots live *before* the loop header and correctly persist across iterations (the rest slot is overwritten in place). `emitLet` publishes its `binding_root_count` into the counter while lowering its body in tail position. This preserves R7RS proper tail calls — unlike forcing lets-with-bindings non-tail, which the issue explicitly rejected (it breaks TCO of `(let ((m …)) (loop m …))`).

### #1586 — duplicated side effects on partial-emit fallback

`emitLet` writes binding initializers into the output buffer incrementally but bails to a whole-form `kaappi_eval_cached` fallback when a later binding/body can't be lowered natively (over the 32-binding ceiling, a non-symbol var, an init/body needing interpreter eval in this lexical scope). The abandon path could not unwind the IR already written, so an already-emitted side-effecting init ran once natively **and** again from the fallback.

**Fix:** make `emitLet` transactional — snapshot `{buf_len, current_block, body_scope_roots}` before writing any of the let's IR, and on abandon truncate the buffer back to it (`shrinkRetainingCapacity`), discarding the stranded inits, their side effects, and their GC root pushes, before emitting the fallback. Restoring `current_block` is essential: an init's in-scope control flow (an `if`) may have split the block into terminated predecessors and a fresh successor, all truncated away, so the fallback must re-open the checkpoint block.

## Tests

Two compile-and-run regression tests under `tests/scheme/compile/`:

- **`native-let-tail-root-leak-1585.sh`** — drives tail-through-let and self-tail loops (plain, `let*`, nested, variadic) well past `MAX_ROOT_CAPACITY`, and asserts a native fn was actually emitted so the test can't pass vacuously via fallback.
- **`native-let-partial-emit-dup-1586.sh`** — 33-binding overflow, control-flow first init, mid-body abandon, and `let*` abandon, asserting each side effect runs exactly once (bare top-level lets — the only shape that reaches the incremental-emit path).

Both fail on `main` (GC root stack overflow / `n=2` / `log=(pos pos)` / `cnt=2`) and pass with the fix.

## Verification

- Both regression tests fail without the fix, pass with it
- Full unit suite green (`zig build test`)
- All 13 existing native compile tests pass
- ~14 native-vs-interpreter differential cases pass (nested lets, `let*`, boxed lets, variadic self-tail, mid-body abandon, closure-operator tail calls)
- `zig fmt` clean

## Note (out of scope)

Found a **pre-existing, unrelated** native-backend bug in passing (confirmed on `main`): `(define (f v) (apply <param> (list v)))` compiles the `apply` eval-fallback in a fast entry via `kaappi_eval_cached` but doesn't republish `v` as a global, giving a native `undefined variable 'v'` — no `let` involved. Surfaced by `tests/scheme/smoke/tail-calls.scm:90`. Left for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)