### PR TITLE
Fix VM-vs-native shadowed-boxed-name divergence + fuzz report misclassification

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -235,10 +235,10 @@ jobs:
       # and the oracle version; the triage protocol lives in the script
       # header (Kaappi bug / oracle bug / generator leak).
       #
-      # IMPORTANT: keep at v7.0.1 — later versions default to archive: true,
-      # which wraps the files in a zip that hides the seed-*.scm markers
-      # from the report job's `find`, silently misclassifying real findings
-      # as infrastructure failures (#1429).
+      # upload-artifact v7+ defaults `archive: true` (and archive: false
+      # only supports a single file), so the artifact arrives at the report
+      # job as one wrapper zip. The report job unwraps it before marker
+      # detection — see its "Unwrap archived artifacts" step (#1429, #1584).
       - name: Upload divergences
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -285,6 +285,28 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+
+      # upload-artifact v7+ archives by default (`archive: true`; false only
+      # supports a single file), and download-artifact v8 hands the wrapper
+      # zip back as a file instead of extracting it. Left wrapped, the
+      # finding markers below never match and every real finding is
+      # misclassified as an infrastructure failure (#1429, #1584 — the
+      # seed-2788 divergence was filed as "infrastructure or build failure").
+      # Unwrap in place so marker detection sees loose files under either
+      # upload behavior. Extraction only ever writes files for the excerpt
+      # below — this job still executes nothing from the artifacts.
+      - name: Unwrap archived artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -d artifacts ] || exit 0
+          find artifacts -type f -name '*.zip' -print0 | while IFS= read -r -d '' z; do
+            if unzip -o -q "$z" -d "$(dirname "$z")"; then
+              rm -f "$z"
+            else
+              echo "::warning::Could not unwrap $z; leaving it in place"
+            fi
+          done
 
       - name: File or update finding issues
         shell: bash

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -150,7 +150,11 @@ encoded crash input for the fuzz job, `seed-<N>.scm` divergences for the
 diff jobs); failed jobs without their marker — toolchain flakes, build or
 unit-test failures, job-level timeouts (a possible hang) — are collected
 under a single shared issue titled `Fuzz CI: infrastructure or build
-failure` instead. While an issue stays open, repeat failures append
+failure` instead. Because `upload-artifact` archives multi-file artifacts
+into a wrapper zip that `download-artifact` hands back un-extracted, the
+report job unwraps any `*.zip` under `artifacts/` before marker detection
+— skipping that step misclassifies every real finding as an
+infrastructure failure (#1429, #1584). While an issue stays open, repeat failures append
 comments to it instead of opening duplicates. Issues are never
 auto-closed: seed bases rotate nightly, so a later green run does not
 mean a finding is fixed — close the issue once the input is minimised

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -62,6 +62,15 @@ pub const ReservedFast = struct {
     consumed: bool = false, // a top-level define of this name has been emitted
 };
 
+// One `locals` entry: a binding introduced by let/let*, a do-loop variable, or
+// an internal define in a let body. When `boxed`, the slot alloca holds a box
+// POINTER (assignment conversion, #1497) and reads/writes go through
+// kaappi_box_ref / kaappi_box_set; otherwise the slot holds the value itself.
+pub const LocalBinding = struct {
+    slot: []const u8,
+    boxed: bool = false,
+};
+
 pub const LLVMEmitter = struct {
     buf: std.ArrayList(u8),
     symbols: std.StringHashMap(u32),
@@ -101,13 +110,22 @@ pub const LLVMEmitter = struct {
     current_block: []const u8 = "entry",
     rest_param_alloca: ?[]const u8 = null,
     rest_param_name: ?[]const u8 = null,
-    locals: ?std.StringHashMap([]const u8) = null,
-    // Boxed variables in the current frame (assignment conversion, #1497):
-    // name -> the alloca that holds the box POINTER. A boxed variable is both
-    // captured by a nested lambda and mutated; reads go through kaappi_box_ref
-    // and writes through kaappi_box_set, and nested closures capture the box
-    // pointer, restoring the interpreter's by-location semantics. Checked
-    // before params/upvalues in name resolution.
+    // Lexical bindings introduced inside the frame body: let/let* bindings,
+    // do-loop variables, and internal defines in a let body. Scope constructs
+    // clone this map on entry and restore it on exit, so `put` on a name
+    // shadows any same-named outer binding — including a boxed one: box-ness
+    // is a per-binding attribute, never a name-level one (#1584).
+    locals: ?std.StringHashMap(LocalBinding) = null,
+    // Frame-level boxed bindings (assignment conversion, #1497): boxed fixed
+    // params and, inside a native closure, the mirrored boxed captures — name
+    // -> the alloca that holds the box POINTER. Reads go through
+    // kaappi_box_ref and writes through kaappi_box_set, and nested closures
+    // capture the box pointer, restoring the interpreter's by-location
+    // semantics. Boxed let-locals do NOT live here — they are `locals`
+    // entries with `.boxed = true`, so inner scopes shadow correctly (#1584).
+    // bindParamsAsGlobals also reads this map as the frame-level "does this
+    // frame have boxed params/upvalues" fact, which must stay visible even
+    // while a let-local shadows the name.
     boxes: ?std.StringHashMap([]const u8) = null,
     // Number of GC roots pushed at the current frame's entry that must be popped
     // before every `ret` the frame emits: the boxed-param box slots (#1497) and,
@@ -157,7 +175,7 @@ pub const LLVMEmitter = struct {
         current_block: []const u8,
         rest_param_alloca: ?[]const u8,
         rest_param_name: ?[]const u8,
-        locals: ?std.StringHashMap([]const u8),
+        locals: ?std.StringHashMap(LocalBinding),
         boxes: ?std.StringHashMap([]const u8),
         frame_entry_roots: usize,
         body_scope_roots: usize,
@@ -368,16 +386,16 @@ pub const LLVMEmitter = struct {
         return self.emitImm(@bitCast(value));
     }
 
-    // Mirrors emitGlobalRef's lexical resolution order (locals, rest param,
-    // params, upvalues). Also consulted by the closure-tier free-variable
-    // analysis in llvm_emit_lambda.zig: a shadowed name is a capture even
-    // when a known global of the same name exists.
+    // Mirrors emitGlobalRef's lexical resolution order (locals, boxes, rest
+    // param, params, upvalues). Also consulted by the closure-tier
+    // free-variable analysis in llvm_emit_lambda.zig: a shadowed name is a
+    // capture even when a known global of the same name exists.
     pub fn isNameShadowed(self: *LLVMEmitter, name: []const u8) bool {
-        if (self.boxes) |bx| {
-            if (bx.get(name) != null) return true;
-        }
         if (self.locals) |loc| {
             if (loc.get(name) != null) return true;
+        }
+        if (self.boxes) |bx| {
+            if (bx.get(name) != null) return true;
         }
         if (self.rest_param_name) |rp_name| {
             if (std.mem.eql(u8, name, rp_name)) return true;
@@ -402,27 +420,46 @@ pub const LLVMEmitter = struct {
         return ir.isKnownGlobal(name) or self.reserved_fast.contains(name);
     }
 
+    // Read through a box: `slot` holds the box pointer, the result temp holds
+    // the box's current value.
+    fn emitBoxRead(self: *LLVMEmitter, slot: []const u8) EmitError![]const u8 {
+        const boxptr = try self.freshTemp();
+        try self.print("  {s} = load i64, ptr {s}\n", .{ boxptr, slot });
+        const tmp = try self.freshTemp();
+        try self.print("  {s} = call i64 @kaappi_box_ref(i64 {s})\n", .{ tmp, boxptr });
+        return tmp;
+    }
+
+    // Write through a box: `slot` holds the box pointer; the box's contents
+    // are replaced so every closure over the same binding sees the new value.
+    fn emitBoxWrite(self: *LLVMEmitter, slot: []const u8, val: []const u8) EmitError!void {
+        const boxptr = try self.freshTemp();
+        try self.print("  {s} = load i64, ptr {s}\n", .{ boxptr, slot });
+        try self.print("  call void @kaappi_box_set(i64 {s}, i64 {s})\n", .{ boxptr, val });
+    }
+
     fn emitGlobalRef(self: *LLVMEmitter, sym: Value) EmitError![]const u8 {
         if (!types.isSymbol(sym)) return error.UnsupportedNodeType;
         const name = types.symbolName(sym);
 
-        // A boxed variable's slot holds the box pointer; read through the box
-        // so a set! from any sibling closure over the same binding is visible.
-        if (self.boxes) |bx| {
-            if (bx.get(name)) |box_alloca| {
-                const boxptr = try self.freshTemp();
-                try self.print("  {s} = load i64, ptr {s}\n", .{ boxptr, box_alloca });
+        // Innermost lexical bindings first: a let-local/do-var shadows any
+        // same-named boxed param or boxed outer binding (#1584). A boxed
+        // local's slot holds the box pointer; read through the box so a set!
+        // from any closure over the same binding is visible (#1497).
+        if (self.locals) |loc| {
+            if (loc.get(name)) |b| {
+                if (b.boxed) return self.emitBoxRead(b.slot);
                 const tmp = try self.freshTemp();
-                try self.print("  {s} = call i64 @kaappi_box_ref(i64 {s})\n", .{ tmp, boxptr });
+                try self.print("  {s} = load i64, ptr {s}\n", .{ tmp, b.slot });
                 return tmp;
             }
         }
 
-        if (self.locals) |loc| {
-            if (loc.get(name)) |alloca_name| {
-                const tmp = try self.freshTemp();
-                try self.print("  {s} = load i64, ptr {s}\n", .{ tmp, alloca_name });
-                return tmp;
+        // Frame-level boxed bindings: assignment-converted params and, inside
+        // a native closure, mirrored boxed captures (#1497).
+        if (self.boxes) |bx| {
+            if (bx.get(name)) |box_alloca| {
+                return self.emitBoxRead(box_alloca);
             }
         }
 
@@ -882,22 +919,22 @@ pub const LLVMEmitter = struct {
 
     // Store `val` into the slot that `name` denotes in the current scope.
     // Resolution order mirrors emitGlobalRef's read path so writes and reads
-    // reach the same binding.
+    // reach the same binding — in particular a let-local shadowing a boxed
+    // name must receive the store, not the outer box (#1584).
     fn emitStoreToVariable(self: *LLVMEmitter, name: []const u8, val: []const u8) EmitError!void {
-        // A boxed variable is mutated through its heap cell so the new value is
-        // visible to every closure that captured the same box (#1497).
-        if (self.boxes) |bx| {
-            if (bx.get(name)) |box_alloca| {
-                const boxptr = try self.freshTemp();
-                try self.print("  {s} = load i64, ptr {s}\n", .{ boxptr, box_alloca });
-                try self.print("  call void @kaappi_box_set(i64 {s}, i64 {s})\n", .{ boxptr, val });
+        if (self.locals) |loc| {
+            if (loc.get(name)) |b| {
+                // A boxed binding is mutated through its heap cell so the new
+                // value is visible to every closure that captured the same
+                // box (#1497).
+                if (b.boxed) return self.emitBoxWrite(b.slot, val);
+                try self.print("  store i64 {s}, ptr {s}\n", .{ val, b.slot });
                 return;
             }
         }
-        if (self.locals) |loc| {
-            if (loc.get(name)) |alloca_name| {
-                try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca_name });
-                return;
+        if (self.boxes) |bx| {
+            if (bx.get(name)) |box_alloca| {
+                return self.emitBoxWrite(box_alloca, val);
             }
         }
         if (self.rest_param_name) |rp_name| {
@@ -1054,7 +1091,7 @@ pub const LLVMEmitter = struct {
             try self.print("  {s} = alloca i64, align 8\n", .{alloca});
             // Register before emitting the value so a self/mutual reference in
             // the initializer resolves to this binding (letrec*-style).
-            self.locals.?.put(name, alloca) catch return error.OutOfMemory;
+            self.locals.?.put(name, .{ .slot = alloca }) catch return error.OutOfMemory;
             const val = try self.emitScopedValue(data.value);
             try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
             return self.emitVoid();

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -21,8 +21,9 @@ const std = @import("std");
 const ir = @import("ir.zig");
 const types = @import("types.zig");
 
-const LLVMEmitter = @import("llvm_emit.zig").LLVMEmitter;
-const EmitError = @import("llvm_emit.zig").EmitError;
+const llvm_emit = @import("llvm_emit.zig");
+const LLVMEmitter = llvm_emit.LLVMEmitter;
+const EmitError = llvm_emit.EmitError;
 
 const Value = types.Value;
 
@@ -260,12 +261,12 @@ pub fn emitDo(self: *LLVMEmitter, args: Value, is_tail: bool) EmitError![]const 
     self.locals = if (saved_locals) |existing|
         existing.clone() catch return error.OutOfMemory
     else
-        std.StringHashMap([]const u8).init(self.allocator());
+        std.StringHashMap(llvm_emit.LocalBinding).init(self.allocator());
     defer {
         self.locals.?.deinit();
         self.locals = saved_locals;
     }
-    for (0..n) |i| self.locals.?.put(var_names[i], allocas[i]) catch return error.OutOfMemory;
+    for (0..n) |i| self.locals.?.put(var_names[i], .{ .slot = allocas[i] }) catch return error.OutOfMemory;
 
     const header = try self.freshLabel("do_header_");
     const body_lbl = try self.freshLabel("do_body_");

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -161,16 +161,33 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
 
     const outer_params = self.params orelse return null;
     const outer_upvalues = self.upvalues;
+    const outer_locals = self.locals;
     const outer_boxes = self.boxes;
-    // Classify each capture: a variable the enclosing frame boxed is captured
-    // as the box POINTER (fv_boxed), so a set! from any sibling closure over
+    // Classify each capture, resolving in emitGlobalRef's lexical order so the
+    // closure captures the same binding the enclosing body reads (#1584). A
+    // binding the enclosing frame boxed is captured as the box POINTER (its
+    // slot recorded in fv_box_slot), so a set! from any sibling closure over
     // the same binding is visible here; everything else is captured by value.
-    const fv_boxed = self.allocator().alloc(bool, free_vars.items.len) catch return null;
-    @memset(fv_boxed, false);
+    const fv_box_slot = self.allocator().alloc(?[]const u8, free_vars.items.len) catch return null;
+    @memset(fv_box_slot, null);
     for (free_vars.items, 0..) |fv, i| {
+        // Innermost first: a let-local/do-var of the enclosing scope. A boxed
+        // one is captured through its box; a plain one has no capturable slot
+        // (its stack alloca dies with the scope), so reject — the interpreter
+        // handles that shape.
+        if (outer_locals) |loc| {
+            if (loc.get(fv)) |b| {
+                if (b.boxed) {
+                    fv_box_slot[i] = b.slot;
+                    continue;
+                }
+                return null;
+            }
+        }
+        // Frame-level boxed params / mirrored boxed captures (#1497).
         if (outer_boxes) |ob| {
-            if (ob.contains(fv)) {
-                fv_boxed[i] = true;
+            if (ob.get(fv)) |slot| {
+                fv_box_slot[i] = slot;
                 continue;
             }
         }
@@ -181,9 +198,11 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
         // By-value captures are copied out of the enclosing frame at
         // closure-creation time: params from its %args, and — when this lambda
         // sits inside another native closure — chained captures from that
-        // closure's own %upvalues array (#1410). A name bound by an enclosing
-        // let-local or rest parameter has no capturable slot; reject those.
-        if (localsOrRestShadows(self, fv)) return null;
+        // closure's own %upvalues array (#1410). The rest parameter has no
+        // capturable slot; reject it.
+        if (self.rest_param_name) |rp| {
+            if (std.mem.eql(u8, fv, rp)) return null;
+        }
         if (outer_params.contains(fv)) continue;
         if (outer_upvalues) |uv| {
             if (uv.contains(fv)) continue;
@@ -232,7 +251,7 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
 
         // Boxed captures and own boxed params get a fresh box map for this
         // frame; reads/writes go through kaappi_box_ref / kaappi_box_set.
-        self.boxes = if (own_boxed.any or freeVarsAnyBoxed(fv_boxed))
+        self.boxes = if (own_boxed.any or freeVarsAnyBoxed(fv_box_slot))
             std.StringHashMap([]const u8).init(self.backing_alloc)
         else
             null;
@@ -251,7 +270,7 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
         // through the box. No GC root needed — the box stays reachable via the
         // live closure's upvalue array for the whole call.
         for (free_vars.items, 0..) |fv, i| {
-            if (!fv_boxed[i]) continue;
+            if (fv_box_slot[i] == null) continue;
             const box_alloca = self.freshTemp() catch return null;
             self.print("  {s} = alloca i64, align 8\n", .{box_alloca}) catch return null;
             const gep = self.freshTemp() catch return null;
@@ -285,10 +304,10 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     for (free_vars.items, 0..) |fv, i| {
         const val = blk: {
             // A boxed capture is stored as its box POINTER, loaded from the
-            // enclosing frame's box slot; the box's contents (the live value)
-            // are shared, so a set! from any closure over it is visible (#1497).
-            if (fv_boxed[i]) {
-                const box_alloca = outer_boxes.?.get(fv).?;
+            // enclosing binding's slot (a boxed let-local's alloca or a boxed
+            // param's frame slot); the box's contents (the live value) are
+            // shared, so a set! from any closure over it is visible (#1497).
+            if (fv_box_slot[i]) |box_alloca| {
                 const v = self.freshTemp() catch return null;
                 self.print("  {s} = load i64, ptr {s}\n", .{ v, box_alloca }) catch return null;
                 break :blk v;
@@ -890,23 +909,11 @@ fn sexprReferencesNames(expr: Value, target_names: []const []const u8, excluded_
 // of the same name exists — `car` inside (lambda (car) ...) is the parameter,
 // not the primitive. The shadow check must run before isKnownGlobal.
 
-// Enclosing bindings that outrank the params array in emitGlobalRef's
-// resolution order and cannot be copied out of %args into an upvalue buffer.
-fn localsOrRestShadows(self: *LLVMEmitter, name: []const u8) bool {
-    if (self.locals) |loc| {
-        if (loc.get(name) != null) return true;
-    }
-    if (self.rest_param_name) |rp| {
-        if (std.mem.eql(u8, name, rp)) return true;
-    }
-    return false;
-}
-
-// True if any of the parallel fv_boxed flags is set — i.e. this closure
+// True if any of the parallel fv_box_slot entries is set — i.e. this closure
 // captures at least one boxed variable and therefore needs a box map.
-fn freeVarsAnyBoxed(fv_boxed: []const bool) bool {
-    for (fv_boxed) |b| {
-        if (b) return true;
+fn freeVarsAnyBoxed(fv_box_slot: []const ?[]const u8) bool {
+    for (fv_box_slot) |s| {
+        if (s != null) return true;
     }
     return false;
 }

--- a/src/llvm_emit_let.zig
+++ b/src/llvm_emit_let.zig
@@ -74,7 +74,7 @@ fn emitLetFallback(self: *LLVMEmitter, args: Value, sequential: bool) EmitError!
 // (an `if`, say) may have split that block into terminated predecessors and a
 // fresh successor, all now truncated away, leaving the checkpoint block live
 // again for the fallback to emit into.
-fn abandonLetForFallback(self: *LLVMEmitter, args: Value, sequential: bool, saved_locals: ?std.StringHashMap([]const u8), checkpoint: Checkpoint) EmitError![]const u8 {
+fn abandonLetForFallback(self: *LLVMEmitter, args: Value, sequential: bool, saved_locals: ?std.StringHashMap(llvm_emit.LocalBinding), checkpoint: Checkpoint) EmitError![]const u8 {
     self.buf.shrinkRetainingCapacity(checkpoint.buf_len);
     self.current_block = checkpoint.block;
     self.body_scope_roots = checkpoint.body_scope_roots;
@@ -149,26 +149,15 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
     // stranded past an in-body tail-call ret.
     const body_tail = is_tail and !any_boxed;
 
-    // Box map scope for this let, extending any enclosing frame's boxes.
-    const saved_boxes = self.boxes;
-    var owns_boxes = false;
-    defer if (owns_boxes) {
-        if (self.boxes) |*b| b.deinit();
-        self.boxes = saved_boxes;
-    };
-    if (any_boxed) {
-        self.boxes = if (saved_boxes) |existing|
-            existing.clone() catch return error.OutOfMemory
-        else
-            std.StringHashMap([]const u8).init(self.allocator());
-        owns_boxes = true;
-    }
-
+    // Boxed let-locals are `locals` entries with `.boxed = true`, NOT
+    // additions to the frame-level `self.boxes` map: box-ness is an attribute
+    // of the individual binding, so an inner plain binding shadows an outer
+    // boxed one (and vice versa) through the ordinary locals clone (#1584).
     const saved_locals = self.locals;
     self.locals = if (saved_locals) |existing|
         existing.clone() catch return error.OutOfMemory
     else
-        std.StringHashMap([]const u8).init(self.allocator());
+        std.StringHashMap(llvm_emit.LocalBinding).init(self.allocator());
 
     var binding_root_count: usize = 0;
 
@@ -217,11 +206,10 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
         }
 
         for (0..count) |i| {
-            if (nameInList(box_names[0..box_count], var_names[i])) {
-                self.boxes.?.put(var_names[i], binding_allocas[i]) catch return error.OutOfMemory;
-            } else {
-                self.locals.?.put(var_names[i], binding_allocas[i]) catch return error.OutOfMemory;
-            }
+            self.locals.?.put(var_names[i], .{
+                .slot = binding_allocas[i],
+                .boxed = nameInList(box_names[0..box_count], var_names[i]),
+            }) catch return error.OutOfMemory;
         }
         binding_root_count = count;
     } else {
@@ -244,15 +232,18 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
             try self.print("  {s} = alloca i64, align 8\n", .{alloca});
             // Box a captured+mutated let*-local; later inits in this same
             // let* then read it through the box (#1497).
-            if (nameInList(box_names[0..box_count], types.symbolName(var_sym))) {
+            const is_boxed = nameInList(box_names[0..box_count], types.symbolName(var_sym));
+            if (is_boxed) {
                 const box = try self.freshTemp();
                 try self.print("  {s} = call i64 @kaappi_make_box(ptr %vm, i64 {s})\n", .{ box, val });
                 try self.print("  store i64 {s}, ptr {s}\n", .{ box, alloca });
-                self.boxes.?.put(types.symbolName(var_sym), alloca) catch return error.OutOfMemory;
             } else {
                 try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
-                self.locals.?.put(types.symbolName(var_sym), alloca) catch return error.OutOfMemory;
             }
+            self.locals.?.put(types.symbolName(var_sym), .{
+                .slot = alloca,
+                .boxed = is_boxed,
+            }) catch return error.OutOfMemory;
             try self.emitRootPushAlloca(alloca);
             binding_root_count += 1;
             blist = types.cdr(blist);

--- a/src/llvm_emit_let.zig
+++ b/src/llvm_emit_let.zig
@@ -214,7 +214,14 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
         binding_root_count = count;
     } else {
         var blist = bindings;
+        var count: usize = 0;
         while (blist != types.NIL and types.isPair(blist)) {
+            // Same 32-binding ceiling as the parallel-let path: the capture
+            // analysis above collects at most 32 names, so a binding past that
+            // would be registered unboxed even when captured+mutated.
+            if (count >= 32) {
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
+            }
             const binding = types.car(blist);
             const var_sym = types.car(binding);
             const init_expr = types.car(types.cdr(binding));
@@ -246,6 +253,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
             }) catch return error.OutOfMemory;
             try self.emitRootPushAlloca(alloca);
             binding_root_count += 1;
+            count += 1;
             blist = types.cdr(blist);
         }
     }

--- a/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
+++ b/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
@@ -15,9 +15,9 @@
 
 set -euo pipefail
 
-KAAPPI="${1:-zig-out/bin/kaappi}"
-KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 
 if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
     (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
@@ -26,9 +26,10 @@ fi
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 
-# GNU timeout when available (Linux/CI; guards case 5, which hangs on a buggy
-# build). On macOS without coreutils, run unbounded — the programs terminate
-# on a correct build.
+# Every binary run is bounded: case 5 hangs forever on a buggy build, and a
+# wedged test job is worse than a failed one. Prefer GNU timeout when
+# available (Linux/CI); otherwise (macOS without coreutils) a background
+# watchdog kills the process after the same deadline.
 RUN_TIMEOUT=""
 for c in timeout gtimeout; do
     if command -v "$c" >/dev/null 2>&1; then
@@ -36,6 +37,23 @@ for c in timeout gtimeout; do
         break
     fi
 done
+
+run_bounded() {
+    if [[ -n "$RUN_TIMEOUT" ]]; then
+        $RUN_TIMEOUT "$@"
+        return
+    fi
+    "$@" &
+    local pid=$!
+    # Redirect the watchdog's stdio away from the caller's command
+    # substitution, or its 10s sleep would hold the capture pipe open.
+    ( sleep 10; kill -9 "$pid" 2>/dev/null ) >/dev/null 2>&1 &
+    local watchdog=$!
+    local status=0
+    wait "$pid" || status=$?
+    kill "$watchdog" 2>/dev/null || true
+    return "$status"
+}
 
 fail=0
 
@@ -54,7 +72,7 @@ check() {
     fi
 
     local out
-    if ! out=$($RUN_TIMEOUT "$DIR/$name" 2>/dev/null); then
+    if ! out=$(run_bounded "$DIR/$name" 2>/dev/null); then
         echo "FAIL: $name — binary exited nonzero or timed out" >&2
         fail=1
         return
@@ -134,7 +152,7 @@ check shadow-do-var \
         ((lambda (h) a) 0)))
 (write (fd 1))
 (newline)' \
-'(3 . 7)'
+'(3 . 7)' yes
 
 # 6. Internal define in a let body shadowing a boxed param. This shape
 #    currently falls back to the interpreter as a whole (tier not pinned);
@@ -160,7 +178,7 @@ check seed-2788-f1 \
       (+ (car rest) (and (begin -76 v) (min 75 a)))))
 (write (f1 -68 -7))
 (newline)' \
-'-61'
+'-61' yes
 
 # 8. A lambda inside the let captures the PLAIN let-local that shadows the
 #    boxed param. There is no capturable slot for a plain let-local, so this

--- a/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
+++ b/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Regression test for #1584 (fuzz seed 2788): the native backend resolved
+# variable names against the frame-level box map BEFORE the lexical locals
+# map, so a let-local (or do-var, or internal define) that SHADOWED a boxed
+# binding of the same name resolved to the outer box instead of the inner
+# binding. A set! on the shadow then leaked into the boxed param that a
+# sibling closure had captured, and reads inside the shadowing scope saw the
+# box's value — both diverging from the VM.
+#
+# The fix makes box-ness a per-binding attribute: locals entries carry a
+# `boxed` flag, `self.boxes` holds only frame-level boxed params/captures,
+# and name resolution checks the innermost lexical binding first.
+#
+# Usage: bash tests/scheme/compile/native-boxed-shadow-divergence-1584.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
+    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+fi
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+# GNU timeout when available (Linux/CI; guards case 5, which hangs on a buggy
+# build). On macOS without coreutils, run unbounded — the programs terminate
+# on a correct build.
+RUN_TIMEOUT=""
+for c in timeout gtimeout; do
+    if command -v "$c" >/dev/null 2>&1; then
+        RUN_TIMEOUT="$c 10"
+        break
+    fi
+done
+
+fail=0
+
+# Compile natively and check output.  When expect_native is "yes", also
+# verify that at least one user-defined native function was emitted; when
+# "no", verify that none were (the whole program fell back to eval).
+check() {
+    local name="$1" src="$2" expect_out="$3" expect_native="${4:-}"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    local out
+    if ! out=$($RUN_TIMEOUT "$DIR/$name" 2>/dev/null); then
+        echo "FAIL: $name — binary exited nonzero or timed out" >&2
+        fail=1
+        return
+    fi
+
+    if [[ "$out" != "$expect_out" ]]; then
+        echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
+        fail=1
+    fi
+
+    if [[ -n "$expect_native" ]]; then
+        (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1) || true
+        local native_def_re='^define ([a-z]+ )*i64 @(lambda_|r[0-9])'
+        if [[ "$expect_native" == "yes" ]]; then
+            if ! grep -qE "$native_def_re" "$DIR/$name.ll" 2>/dev/null; then
+                echo "FAIL: $name — expected native fn definition in LLVM IR" >&2
+                fail=1
+            fi
+        elif [[ "$expect_native" == "no" ]]; then
+            if grep -qE "$native_def_re" "$DIR/$name.ll" 2>/dev/null; then
+                echo "FAIL: $name — expected NO native fn definition (should fall back)" >&2
+                fail=1
+            fi
+        fi
+    fi
+}
+
+# 1. Minimized seed-2788: param a is boxed (set! in body + captured by the
+#    lambda). The let binds its own a; the set! must hit the let-local, not
+#    the param's box, so the closure still reads -7. Buggy: 102.
+check shadow-set-leak \
+'(define (f a)
+  (- (let ((a 1)) (set! a -3) 99)
+     ((lambda (h) a) 0)))
+(write (f -7))
+(newline)' \
+'106' yes
+
+# 2. Reads inside the shadowing let must see the let-local (after its own
+#    set!), not the boxed param. Buggy: 66 (both sides read the box).
+check shadow-read \
+'(define (g a)
+  (+ (let ((a 5)) (set! a 6) (* a 10))
+     ((lambda (h) a) 0)))
+(write (g 2))
+(newline)' \
+'62' yes
+
+# 3. Reverse nesting: a boxed OUTER let-local shadowed by a plain inner
+#    let-local. The inner (+ x 1) must read 10, not the box. Buggy: #(2 3).
+check shadow-boxed-let-local \
+'(define (h)
+  (let ((x 1))
+    (vector ((lambda (k) (set! x 2) x) 0)
+            (let ((x 10)) (+ x 1)))))
+(write (h))
+(newline)' \
+'#(2 11)' yes
+
+# 4. let* whose later init reads the shadowing binding of a boxed param.
+#    Buggy: 7 (init reads the box, set! writes it, closure sees 5).
+check shadow-let-star-init \
+'(define (fs a)
+  (+ (let* ((a 10) (b (* a 2))) (set! a 5) b)
+     ((lambda (h) a) 0)))
+(write (fs 1))
+(newline)' \
+'21' yes
+
+# 5. do-loop variable shadowing a boxed param: the test and step expressions
+#    must read the loop variable. Buggy: infinite loop (test forever reads
+#    the box's 7).
+check shadow-do-var \
+'(define (fd a)
+  (set! a 7)
+  (cons (do ((a 0 (+ a 1))) ((= a 3) a))
+        ((lambda (h) a) 0)))
+(write (fd 1))
+(newline)' \
+'(3 . 7)'
+
+# 6. Internal define in a let body shadowing a boxed param. This shape
+#    currently falls back to the interpreter as a whole (tier not pinned);
+#    the output must stay correct if a later change compiles it natively.
+check shadow-internal-define \
+'(define (fi a)
+  (+ (let ((unused 0))
+       (define a 100)
+       (set! a (+ a 1))
+       a)
+     ((lambda (h) a) 0)))
+(write (fi 3))
+(newline)' \
+'104'
+
+# 7. Full seed-2788 f1 shape: variadic + shadowing let + capturing lambda in
+#    one function, exactly as the fuzzer generated it. Buggy: -65.
+check seed-2788-f1 \
+'(define (f1 v a . rest)
+  (if (null? rest)
+      (- (let ((a v)) (set! a -3) v)
+         ((lambda (h) a) v))
+      (+ (car rest) (and (begin -76 v) (min 75 a)))))
+(write (f1 -68 -7))
+(newline)' \
+'-61'
+
+# 8. A lambda inside the let captures the PLAIN let-local that shadows the
+#    boxed param. There is no capturable slot for a plain let-local, so this
+#    must reject to the interpreter — not capture the param box. Buggy: 2
+#    (both lambdas read the box). Tier not pinned: correctness is the point.
+check shadow-captured-by-lambda \
+'(define (f a)
+  (set! a 1)
+  (+ (let ((a 5)) ((lambda (h) a) 0))
+     ((lambda (h) a) 0)))
+(write (f 99))
+(newline)' \
+'6'
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-boxed-shadow-divergence-1584: all cases passed"


### PR DESCRIPTION
Fixes #1584.

The fuzz run behind #1584 was not an infrastructure failure — the `native-diff` job found a **real miscompilation** (seed 2788: `write` printed `-11` on the VM, `-19` natively) and uploaded its artifact, but the report job could not see the `seed-*.scm` marker inside the wrapper zip and filed it under the infrastructure title. This PR fixes both the compiler bug and the misclassification.

## 1. Native backend: shadowed boxed names resolved to the outer box

`emitGlobalRef` / `emitStoreToVariable` consulted the frame-level box map (`self.boxes`, #1497 assignment conversion) **before** the lexical locals map, and the closure-capture classifier did the same. Any `let`-local, `do`-var, or internal define shadowing a boxed name therefore resolved to the *outer* box:

```scheme
(define (f a)                        ; a is boxed: set! below + captured by the lambda
  (- (let ((a 1)) (set! a -3) 99)    ; set! must hit the let-local...
     ((lambda (h) a) 0)))            ; ...but leaked into a's box: closure read -3, not -7
(write (f -7))                       ; VM: 106, native (before): 102
```

The inversion broke in both directions (a plain inner local shadowing a boxed outer let-local read the box too) and could even hang (a `do`-var shadowing a boxed param re-reads the box in its termination test forever).

**Fix:** box-ness becomes a per-binding attribute instead of a name-level one. `locals` entries carry a `boxed` flag (`LocalBinding`); `emitLet` registers boxed let-locals as tagged locals and no longer touches `self.boxes`, which shrinks to frame-level facts only (boxed params, a closure's mirrored boxed captures). Resolution and capture classification check the innermost lexical binding first, so shadowing works in both directions — while `bindParamsAsGlobals` keeps seeing the frame-level boxed-param fact (its eval-fallback abort, #1422/#1497) even when a local shadows the name.

## 2. Fuzz report job: unwrap archived artifacts before marker detection

`upload-artifact` v7+ defaults `archive: true` (`false` only supports a single file), and `download-artifact` v8 hands the wrapper zip back un-extracted — so the report job's `find` for `seed-*.scm`/`crash` markers never matched and every real finding was misclassified as infrastructure. This is the same failure mode as #1429; the fix back then pinned upload-artifact to v7.0.1 believing that version uploads loose files, but v7.0.1 archives too, so the pin never addressed the root cause. The report job now unwraps any `*.zip` under `artifacts/` before marker detection (correct under either upload layout, verified against the real #1584 artifact) and the stale comment is replaced. The report job still executes nothing from the artifacts.

## Verification

- New regression test `tests/scheme/compile/native-boxed-shadow-divergence-1584.sh`: 8 shadowing shapes (set!-leak, read-through, reverse nesting, `let*` init, `do`-var, internal define, the original seed-2788 function, capture-of-shadow). Pre-fix: cases 1–4 fail with the predicted wrong values, the `do` case hangs; post-fix: all pass.
- `bash tests/fuzz/native-diff.sh` over seeds 2700–2999 (the failing CI range) and 0–399: 700 compared, **0 divergent**.
- `zig build test` green; all `tests/scheme/compile/*.sh` pass (including the #1422 boxing suite and #819 internal-define suite).
- Report-job unwrap logic validated locally against the actual run-29473932606 artifact layout (both the native-diff wrapper and a simulated fuzz-crash wrapper with hidden `.zig-cache` paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)