### PR TITLE
Split tests_native.zig along subsystem seams

### DIFF
--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -5,22 +5,23 @@ const ir_mod = @import("ir.zig");
 const llvm_emit = @import("llvm_emit.zig");
 const reader_mod = @import("reader.zig");
 const native_decls = @import("native_decls.zig");
+const th = @import("testing_helpers.zig");
 
 // The LLVMEmitter stores lambda function defs via toOwnedSlice that aren't
 // individually freed on deinit (by design — production uses an arena).
 // Use page_allocator for the emitter to avoid false leak reports.
 const emitter_alloc = std.heap.page_allocator;
 
-const EmitResult = struct {
+pub const EmitResult = struct {
     gc: memory.GC,
     ir_instance: ir_mod.IR,
     emitter: llvm_emit.LLVMEmitter,
 
-    fn toSlice(self: *EmitResult) []const u8 {
+    pub fn toSlice(self: *EmitResult) []const u8 {
         return self.emitter.toSlice();
     }
 
-    fn deinit(self: *EmitResult) void {
+    pub fn deinit(self: *EmitResult) void {
         self.emitter.deinit();
         self.ir_instance.deinit();
         self.gc.deinit();
@@ -61,7 +62,7 @@ fn emitSourceResult(source: []const u8) !EmitResult {
     return .{ .gc = gc, .ir_instance = ir_instance, .emitter = emitter };
 }
 
-fn emitMultiResult(source: []const u8) !EmitResult {
+pub fn emitMultiResult(source: []const u8) !EmitResult {
     return emitMultiResultOpts(source, true);
 }
 
@@ -71,7 +72,7 @@ fn emitMultiResult(source: []const u8) !EmitResult {
 /// too. Used by the fuzz gate for exact eval accounting: dead-branch
 /// elimination legitimately deletes eval-fallback forms from constant-test
 /// branches, so exact counts only hold on unoptimized emission.
-fn emitMultiResultOpts(source: []const u8, optimize: bool) !EmitResult {
+pub fn emitMultiResultOpts(source: []const u8, optimize: bool) !EmitResult {
     var gc = memory.GC.init(emitter_alloc);
     errdefer gc.deinit();
 
@@ -128,7 +129,7 @@ fn expectNotContains(haystack: []const u8, needle: []const u8) !void {
 // define within max_fast_arity — or as a uniform array-ABI definition otherwise
 // (variadic, boxed, or over the arity bound). Both are tagged with a `; <name>`
 // header comment. This asserts one of the two forms is present for `name`.
-fn expectNativeDef(ll: []const u8, name: []const u8) !void {
+pub fn expectNativeDef(ll: []const u8, name: []const u8) !void {
     var fast_buf: [128]u8 = undefined;
     var uniform_buf: [128]u8 = undefined;
     const fast = try std.fmt.bufPrint(&fast_buf, "; {s} (fast entry)\ndefine tailcc i64 @", .{name});
@@ -149,7 +150,7 @@ fn expectNativeDef(ll: []const u8, name: []const u8) !void {
 // Quoted heap constants are deliberately NOT counted here: since #1495 they
 // route through @kaappi_quote_cached, a build-once *data* cache, not an eval
 // fallback — a separate concern with its own emit tests below.
-fn countEvalFallbacks(ll: []const u8) usize {
+pub fn countEvalFallbacks(ll: []const u8) usize {
     return std.mem.count(u8, ll, "call i64 @kaappi_eval(") +
         std.mem.count(u8, ll, "call i64 @kaappi_eval_cached(");
 }
@@ -1221,284 +1222,4 @@ test "LLVM emit: a cond containing letrec falls back to the interpreter (#1496)"
     // the correct choice is a whole-form eval, not a native block chain.
     try expectNotContains(ll, "cond_merge_");
     try std.testing.expect(countEvalFallbacks(ll) >= 1);
-}
-
-// -- NativeClosure dispatch tests (#1376) --
-// Since #1374 map/for-each/dynamic-wind/force are bytecode closures
-// (vm_bootstrap.zig), so bytecode must be able to invoke natively-compiled
-// callbacks (NativeClosure) from every call path in the dispatch loop.
-// These build a NativeClosure by hand (as kaappi_create_native_closure
-// would) and drive it through each opcode/helper.
-
-const th = @import("testing_helpers.zig");
-const Value = types.Value;
-
-fn ncDouble(_: ?*th.VM, args: [*]const Value, nargs: u64, _: [*]const Value) callconv(.c) u64 {
-    std.debug.assert(nargs == 1);
-    return types.makeFixnum(types.toFixnum(args[0]) * 2);
-}
-
-fn ncAddUpvalue(_: ?*th.VM, args: [*]const Value, nargs: u64, upvalues: [*]const Value) callconv(.c) u64 {
-    std.debug.assert(nargs == 1);
-    return types.makeFixnum(types.toFixnum(args[0]) + types.toFixnum(upvalues[0]));
-}
-
-fn ncFortyTwo(_: ?*th.VM, _: [*]const Value, _: u64, _: [*]const Value) callconv(.c) u64 {
-    return types.makeFixnum(42);
-}
-
-fn ncIgnoreArg(_: ?*th.VM, _: [*]const Value, nargs: u64, _: [*]const Value) callconv(.c) u64 {
-    std.debug.assert(nargs == 1);
-    return types.makeFixnum(7);
-}
-
-fn setupNativeClosures(ctx: *th.TestContext) !void {
-    try ctx.vm.defineGlobal("nc-double", try ctx.gc.allocNativeClosure(&ncDouble, &.{}, 1, "nc-double"));
-    try ctx.vm.defineGlobal("nc-42", try ctx.gc.allocNativeClosure(&ncFortyTwo, &.{}, 0, "nc-42"));
-    try ctx.vm.defineGlobal("nc-ignore", try ctx.gc.allocNativeClosure(&ncIgnoreArg, &.{}, 1, "nc-ignore"));
-}
-
-test "bootstrapped map calls a NativeClosure callback (call opcode)" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    try setupNativeClosures(&ctx);
-    const result = try ctx.vm.eval("(equal? (map nc-double (list 1 2 3)) (list 2 4 6))");
-    try std.testing.expectEqual(types.TRUE, result);
-}
-
-test "bootstrapped dynamic-wind calls NativeClosure thunks" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    try setupNativeClosures(&ctx);
-    const result = try ctx.vm.eval("(dynamic-wind nc-42 nc-42 nc-42)");
-    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
-}
-
-test "NativeClosure upvalues survive the dispatch-loop call path" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    const upvals = [_]Value{types.makeFixnum(100)};
-    try ctx.vm.defineGlobal("nc-add100", try ctx.gc.allocNativeClosure(&ncAddUpvalue, &upvals, 1, "nc-add100"));
-    const result = try ctx.vm.eval("(equal? (map nc-add100 (list 1 2)) (list 101 102))");
-    try std.testing.expectEqual(types.TRUE, result);
-}
-
-test "bytecode tail-calls a NativeClosure (tail_call opcode)" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    try setupNativeClosures(&ctx);
-    const result = try ctx.vm.eval("((lambda (f) (f 21)) nc-double)");
-    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
-}
-
-test "bytecode tail-applies a NativeClosure (tail_apply opcode)" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    try setupNativeClosures(&ctx);
-    const result = try ctx.vm.eval("((lambda (f) (apply f (list 21))) nc-double)");
-    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
-}
-
-test "bytecode tail-calls a NativeClosure global (tail_call_global opcode)" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    try setupNativeClosures(&ctx);
-    const result = try ctx.vm.eval("((lambda () (nc-double 21)))");
-    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
-}
-
-test "call/cc with a NativeClosure receiver (callHandler / tail_call_cc)" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    try setupNativeClosures(&ctx);
-    const non_tail = try ctx.vm.eval("(+ 0 (call-with-current-continuation nc-ignore))");
-    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(non_tail));
-    const tail = try ctx.vm.eval("((lambda () (call-with-current-continuation nc-ignore)))");
-    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(tail));
-}
-
-test "with-exception-handler NativeClosure thunk and handler (callThunk/callHandler)" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    try setupNativeClosures(&ctx);
-    const thunk_res = try ctx.vm.eval("(with-exception-handler (lambda (e) 0) nc-42)");
-    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(thunk_res));
-    const handler_res = try ctx.vm.eval("(with-exception-handler nc-ignore (lambda () (raise-continuable 1)))");
-    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(handler_res));
-}
-
-test "NativeClosure arity mismatch raises a catchable error" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-    try setupNativeClosures(&ctx);
-    const result = try ctx.vm.eval("(guard (e (#t 99)) (nc-double 1 2))");
-    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(result));
-}
-
-// -- Native-subset generator stays on the native path (#1395) --
-
-// The VM-vs-native differential oracle (tests/fuzz/native-diff.sh) is only
-// as strong as the generated programs' nativeness: every form that falls
-// back to the interpreter shrinks the diff to VM-vs-VM. This gate emits
-// fixed-seed native-subset programs through the LLVM emitter and counts
-// eval-fallback call sites in the IR (countEvalFallbacks spans both the plain
-// and the compile-once-cached spelling — #1494). Two shapes legitimately eval:
-//
-//   - a define emits ONE eval for its global binding when it is VARIADIC (a
-//     native closure value dispatches by exact arity, so a variadic entry can't
-//     be one) OR when its body reaches a code eval fallback (an inline variadic
-//     lambda, whose bindParamsAsGlobals would alias across activations if the
-//     value ran natively — the #1500 gate keeps the interpreter closure). A
-//     fixed-arity define with a fallback-free body emits ZERO: since #1500 its
-//     global binding is a native closure over the compiled entry (call sites
-//     already used the direct native path either way);
-//   - an inline VARIADIC lambda emits exactly ONE eval (#1420): no
-//     closure tier accepts a rest parameter, so it goes through
-//     emitLambdaViaEval, which first republishes the enclosing frame as
-//     globals — the #1410 codegen this shape exists to exercise. (This is the
-//     same code fallback that gates the enclosing define's value above, so a
-//     define with an inline variadic body contributes both evals.)
-//
-// The exact count is checked on UNOPTIMIZED emission: dead-branch
-// elimination legitimately deletes variadic lambdas from constant-test
-// branches (the generator emits constant tests as dead-branch fodder), so
-// under the production pass pipeline the count is only bounded — the
-// optimized emission is checked against that range instead, and anything
-// above it means a generated form silently fell back.
-test "native-subset generator emits no unexpected kaappi_eval fallbacks" {
-    const fuzz_gen = @import("fuzz_gen.zig");
-    const gpa = std.testing.allocator;
-
-    var seed: u64 = 0;
-    while (seed < 200) : (seed += 1) {
-        const src = try fuzz_gen.generateNativeSeeded(seed, gpa);
-        defer gpa.free(src);
-        errdefer std.debug.print("seed {d} program:\n{s}\n", .{ seed, src });
-
-        // The generator emits one top-level form per line, so define position
-        // is line-syntactic, and every parameter list is flat — a " . " in one
-        // (before its closing ')') marks a rest parameter.
-        //
-        // Per line we count two things:
-        //   value_evals: a define whose global binding evals — variadic, or a
-        //     fixed-arity define whose body reaches a code eval fallback. For a
-        //     generator body the only such fallback is an inline variadic
-        //     lambda, so "line has an inline variadic lambda" ⟺ the define's
-        //     body has a code fallback ⟺ #1500 keeps the interpreter value.
-        //   nvariadic: every inline variadic lambda (each one its own eval).
-        var value_evals: usize = 0;
-        var nvariadic: usize = 0;
-        var names: [8][]const u8 = undefined;
-        var name_count: usize = 0;
-        var lines = std.mem.splitScalar(u8, src, '\n');
-        while (lines.next()) |line| {
-            // Inline variadic lambdas: every "(lambda (" occurrence except the
-            // define-position one on a `(define name (lambda ...)` line. The
-            // parameter list is flat, so it ends at the first ')'; a " . "
-            // inside it marks a rest parameter.
-            var line_inline_variadic: usize = 0;
-            var from: usize = 0;
-            if (std.mem.startsWith(u8, line, "(define ") and !std.mem.startsWith(u8, line, "(define (")) {
-                if (std.mem.indexOf(u8, line, "(lambda (")) |pos| from = pos + "(lambda (".len;
-            }
-            while (std.mem.indexOfPos(u8, line, from, "(lambda (")) |pos| {
-                from = pos + "(lambda (".len;
-                const plist_end = std.mem.indexOfScalarPos(u8, line, from, ')') orelse line.len;
-                if (std.mem.indexOf(u8, line[from..plist_end], " . ") != null) line_inline_variadic += 1;
-            }
-            nvariadic += line_inline_variadic;
-
-            var name: ?[]const u8 = null;
-            var define_plist: ?[]const u8 = null; // the define's formal list
-            if (std.mem.startsWith(u8, line, "(define (")) {
-                const rest = line["(define (".len..];
-                const end = std.mem.indexOfAny(u8, rest, " )") orelse rest.len;
-                name = rest[0..end];
-                // Sugared `(define (f a . rest) ...)`: formals close at the
-                // first ')'.
-                const plist_end = std.mem.indexOfScalar(u8, rest, ')') orelse rest.len;
-                define_plist = rest[0..plist_end];
-            } else if (std.mem.startsWith(u8, line, "(define ") and
-                std.mem.indexOf(u8, line, "(lambda ") != null)
-            {
-                const rest = line["(define ".len..];
-                const end = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
-                name = rest[0..end];
-                // `(define f (lambda (a . rest) ...))`: the define-position
-                // lambda's formals close at the first ')' after "(lambda (".
-                if (std.mem.indexOf(u8, line, "(lambda (")) |pos| {
-                    const pos_from = pos + "(lambda (".len;
-                    const plist_end = std.mem.indexOfScalarPos(u8, line, pos_from, ')') orelse line.len;
-                    define_plist = line[pos_from..plist_end];
-                }
-            }
-            if (name) |n| {
-                names[name_count] = n;
-                name_count += 1;
-                // The define's value evals when it is variadic, or when its body
-                // has a code eval fallback (#1500 gate) — an inline variadic
-                // lambda on this line.
-                const define_variadic = if (define_plist) |pl|
-                    std.mem.indexOf(u8, pl, " . ") != null
-                else
-                    false;
-                if (define_variadic or line_inline_variadic > 0) value_evals += 1;
-            }
-        }
-        const expected = value_evals + nvariadic;
-
-        // Exact accounting on unoptimized emission: every source shape
-        // reaches the emitter, so any count mismatch is a shape that
-        // unexpectedly fell back (or unexpectedly stayed native).
-        var res_noopt = blk: {
-            ir_mod.optimize_enabled = false;
-            defer ir_mod.optimize_enabled = true;
-            break :blk try emitMultiResultOpts(src, false);
-        };
-        defer res_noopt.deinit();
-        // Count both eval spellings: define-time and inline-variadic-lambda
-        // fallbacks now route through @kaappi_eval_cached (#1494).
-        const actual_noopt = countEvalFallbacks(res_noopt.toSlice());
-        if (actual_noopt != expected) {
-            std.debug.print("seed {d}: expected {d} kaappi_eval calls unoptimized ({d} define-value evals + {d} inline variadic lambdas), found {d}\n", .{ seed, expected, value_evals, nvariadic, actual_noopt });
-            return error.NativeSubsetFellBackToEval;
-        }
-
-        // Production pass pipeline: elimination can only remove eval sites,
-        // never add them. A define's value eval is top-level (never in a dead
-        // branch), so it is the unremovable floor; inline variadic lambdas in
-        // constant-test branches may be eliminated above it.
-        var res = try emitMultiResult(src);
-        defer res.deinit();
-        const ll = res.toSlice();
-        const actual = countEvalFallbacks(ll);
-        if (actual < value_evals or actual > expected) {
-            std.debug.print("seed {d}: expected {d}..{d} kaappi_eval calls optimized, found {d}\n", .{ seed, value_evals, expected, actual });
-            return error.NativeSubsetFellBackToEval;
-        }
-
-        // The eval count alone cannot see a function whose native
-        // compilation was REJECTED (the define-time eval is emitted either
-        // way and call sites just degrade to global lookups), so also
-        // require the named native function definition that the emitter
-        // tags with a `; <name>` header comment.
-        for (names[0..name_count]) |n| {
-            // A named define is emitted as a tailcc fast entry (#1499) or, when
-            // not fast-eligible, a uniform definition — expectNativeDef accepts
-            // either. (A false return would mean the whole define fell back.)
-            expectNativeDef(ll, n) catch {
-                std.debug.print("seed {d}: no native definition for {s}\n", .{ seed, n });
-                return error.NativeSubsetFellBackToEval;
-            };
-        }
-    }
 }

--- a/src/tests_native_dispatch.zig
+++ b/src/tests_native_dispatch.zig
@@ -1,0 +1,122 @@
+const std = @import("std");
+const types = @import("types.zig");
+const th = @import("testing_helpers.zig");
+const Value = types.Value;
+
+// -- NativeClosure dispatch tests (#1376) --
+// Since #1374 map/for-each/dynamic-wind/force are bytecode closures
+// (vm_bootstrap.zig), so bytecode must be able to invoke natively-compiled
+// callbacks (NativeClosure) from every call path in the dispatch loop.
+// These build a NativeClosure by hand (as kaappi_create_native_closure
+// would) and drive it through each opcode/helper.
+
+fn ncDouble(_: ?*th.VM, args: [*]const Value, nargs: u64, _: [*]const Value) callconv(.c) u64 {
+    std.debug.assert(nargs == 1);
+    return types.makeFixnum(types.toFixnum(args[0]) * 2);
+}
+
+fn ncAddUpvalue(_: ?*th.VM, args: [*]const Value, nargs: u64, upvalues: [*]const Value) callconv(.c) u64 {
+    std.debug.assert(nargs == 1);
+    return types.makeFixnum(types.toFixnum(args[0]) + types.toFixnum(upvalues[0]));
+}
+
+fn ncFortyTwo(_: ?*th.VM, _: [*]const Value, _: u64, _: [*]const Value) callconv(.c) u64 {
+    return types.makeFixnum(42);
+}
+
+fn ncIgnoreArg(_: ?*th.VM, _: [*]const Value, nargs: u64, _: [*]const Value) callconv(.c) u64 {
+    std.debug.assert(nargs == 1);
+    return types.makeFixnum(7);
+}
+
+fn setupNativeClosures(ctx: *th.TestContext) !void {
+    try ctx.vm.defineGlobal("nc-double", try ctx.gc.allocNativeClosure(&ncDouble, &.{}, 1, "nc-double"));
+    try ctx.vm.defineGlobal("nc-42", try ctx.gc.allocNativeClosure(&ncFortyTwo, &.{}, 0, "nc-42"));
+    try ctx.vm.defineGlobal("nc-ignore", try ctx.gc.allocNativeClosure(&ncIgnoreArg, &.{}, 1, "nc-ignore"));
+}
+
+test "bootstrapped map calls a NativeClosure callback (call opcode)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("(equal? (map nc-double (list 1 2 3)) (list 2 4 6))");
+    try std.testing.expectEqual(types.TRUE, result);
+}
+
+test "bootstrapped dynamic-wind calls NativeClosure thunks" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("(dynamic-wind nc-42 nc-42 nc-42)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "NativeClosure upvalues survive the dispatch-loop call path" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const upvals = [_]Value{types.makeFixnum(100)};
+    try ctx.vm.defineGlobal("nc-add100", try ctx.gc.allocNativeClosure(&ncAddUpvalue, &upvals, 1, "nc-add100"));
+    const result = try ctx.vm.eval("(equal? (map nc-add100 (list 1 2)) (list 101 102))");
+    try std.testing.expectEqual(types.TRUE, result);
+}
+
+test "bytecode tail-calls a NativeClosure (tail_call opcode)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("((lambda (f) (f 21)) nc-double)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "bytecode tail-applies a NativeClosure (tail_apply opcode)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("((lambda (f) (apply f (list 21))) nc-double)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "bytecode tail-calls a NativeClosure global (tail_call_global opcode)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("((lambda () (nc-double 21)))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "call/cc with a NativeClosure receiver (callHandler / tail_call_cc)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const non_tail = try ctx.vm.eval("(+ 0 (call-with-current-continuation nc-ignore))");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(non_tail));
+    const tail = try ctx.vm.eval("((lambda () (call-with-current-continuation nc-ignore)))");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(tail));
+}
+
+test "with-exception-handler NativeClosure thunk and handler (callThunk/callHandler)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const thunk_res = try ctx.vm.eval("(with-exception-handler (lambda (e) 0) nc-42)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(thunk_res));
+    const handler_res = try ctx.vm.eval("(with-exception-handler nc-ignore (lambda () (raise-continuable 1)))");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(handler_res));
+}
+
+test "NativeClosure arity mismatch raises a catchable error" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try setupNativeClosures(&ctx);
+    const result = try ctx.vm.eval("(guard (e (#t 99)) (nc-double 1 2))");
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(result));
+}

--- a/src/tests_native_gate.zig
+++ b/src/tests_native_gate.zig
@@ -1,0 +1,170 @@
+const std = @import("std");
+const ir_mod = @import("ir.zig");
+
+// The LLVM-emit test infrastructure (EmitResult + the emit/count/assert
+// helpers) lives with the per-form emit tests in tests_native.zig; this gate
+// is a specialized consumer of the same infra.
+const native_tests = @import("tests_native.zig");
+const emitMultiResult = native_tests.emitMultiResult;
+const emitMultiResultOpts = native_tests.emitMultiResultOpts;
+const countEvalFallbacks = native_tests.countEvalFallbacks;
+const expectNativeDef = native_tests.expectNativeDef;
+
+// -- Native-subset generator stays on the native path (#1395) --
+
+// The VM-vs-native differential oracle (tests/fuzz/native-diff.sh) is only
+// as strong as the generated programs' nativeness: every form that falls
+// back to the interpreter shrinks the diff to VM-vs-VM. This gate emits
+// fixed-seed native-subset programs through the LLVM emitter and counts
+// eval-fallback call sites in the IR (countEvalFallbacks spans both the plain
+// and the compile-once-cached spelling — #1494). Two shapes legitimately eval:
+//
+//   - a define emits ONE eval for its global binding when it is VARIADIC (a
+//     native closure value dispatches by exact arity, so a variadic entry can't
+//     be one) OR when its body reaches a code eval fallback (an inline variadic
+//     lambda, whose bindParamsAsGlobals would alias across activations if the
+//     value ran natively — the #1500 gate keeps the interpreter closure). A
+//     fixed-arity define with a fallback-free body emits ZERO: since #1500 its
+//     global binding is a native closure over the compiled entry (call sites
+//     already used the direct native path either way);
+//   - an inline VARIADIC lambda emits exactly ONE eval (#1420): no
+//     closure tier accepts a rest parameter, so it goes through
+//     emitLambdaViaEval, which first republishes the enclosing frame as
+//     globals — the #1410 codegen this shape exists to exercise. (This is the
+//     same code fallback that gates the enclosing define's value above, so a
+//     define with an inline variadic body contributes both evals.)
+//
+// The exact count is checked on UNOPTIMIZED emission: dead-branch
+// elimination legitimately deletes variadic lambdas from constant-test
+// branches (the generator emits constant tests as dead-branch fodder), so
+// under the production pass pipeline the count is only bounded — the
+// optimized emission is checked against that range instead, and anything
+// above it means a generated form silently fell back.
+test "native-subset generator emits no unexpected kaappi_eval fallbacks" {
+    const fuzz_gen = @import("fuzz_gen.zig");
+    const gpa = std.testing.allocator;
+
+    var seed: u64 = 0;
+    while (seed < 200) : (seed += 1) {
+        const src = try fuzz_gen.generateNativeSeeded(seed, gpa);
+        defer gpa.free(src);
+        errdefer std.debug.print("seed {d} program:\n{s}\n", .{ seed, src });
+
+        // The generator emits one top-level form per line, so define position
+        // is line-syntactic, and every parameter list is flat — a " . " in one
+        // (before its closing ')') marks a rest parameter.
+        //
+        // Per line we count two things:
+        //   value_evals: a define whose global binding evals — variadic, or a
+        //     fixed-arity define whose body reaches a code eval fallback. For a
+        //     generator body the only such fallback is an inline variadic
+        //     lambda, so "line has an inline variadic lambda" ⟺ the define's
+        //     body has a code fallback ⟺ #1500 keeps the interpreter value.
+        //   nvariadic: every inline variadic lambda (each one its own eval).
+        var value_evals: usize = 0;
+        var nvariadic: usize = 0;
+        var names: [8][]const u8 = undefined;
+        var name_count: usize = 0;
+        var lines = std.mem.splitScalar(u8, src, '\n');
+        while (lines.next()) |line| {
+            // Inline variadic lambdas: every "(lambda (" occurrence except the
+            // define-position one on a `(define name (lambda ...)` line. The
+            // parameter list is flat, so it ends at the first ')'; a " . "
+            // inside it marks a rest parameter.
+            var line_inline_variadic: usize = 0;
+            var from: usize = 0;
+            if (std.mem.startsWith(u8, line, "(define ") and !std.mem.startsWith(u8, line, "(define (")) {
+                if (std.mem.indexOf(u8, line, "(lambda (")) |pos| from = pos + "(lambda (".len;
+            }
+            while (std.mem.indexOfPos(u8, line, from, "(lambda (")) |pos| {
+                from = pos + "(lambda (".len;
+                const plist_end = std.mem.indexOfScalarPos(u8, line, from, ')') orelse line.len;
+                if (std.mem.indexOf(u8, line[from..plist_end], " . ") != null) line_inline_variadic += 1;
+            }
+            nvariadic += line_inline_variadic;
+
+            var name: ?[]const u8 = null;
+            var define_plist: ?[]const u8 = null; // the define's formal list
+            if (std.mem.startsWith(u8, line, "(define (")) {
+                const rest = line["(define (".len..];
+                const end = std.mem.indexOfAny(u8, rest, " )") orelse rest.len;
+                name = rest[0..end];
+                // Sugared `(define (f a . rest) ...)`: formals close at the
+                // first ')'.
+                const plist_end = std.mem.indexOfScalar(u8, rest, ')') orelse rest.len;
+                define_plist = rest[0..plist_end];
+            } else if (std.mem.startsWith(u8, line, "(define ") and
+                std.mem.indexOf(u8, line, "(lambda ") != null)
+            {
+                const rest = line["(define ".len..];
+                const end = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
+                name = rest[0..end];
+                // `(define f (lambda (a . rest) ...))`: the define-position
+                // lambda's formals close at the first ')' after "(lambda (".
+                if (std.mem.indexOf(u8, line, "(lambda (")) |pos| {
+                    const pos_from = pos + "(lambda (".len;
+                    const plist_end = std.mem.indexOfScalarPos(u8, line, pos_from, ')') orelse line.len;
+                    define_plist = line[pos_from..plist_end];
+                }
+            }
+            if (name) |n| {
+                names[name_count] = n;
+                name_count += 1;
+                // The define's value evals when it is variadic, or when its body
+                // has a code eval fallback (#1500 gate) — an inline variadic
+                // lambda on this line.
+                const define_variadic = if (define_plist) |pl|
+                    std.mem.indexOf(u8, pl, " . ") != null
+                else
+                    false;
+                if (define_variadic or line_inline_variadic > 0) value_evals += 1;
+            }
+        }
+        const expected = value_evals + nvariadic;
+
+        // Exact accounting on unoptimized emission: every source shape
+        // reaches the emitter, so any count mismatch is a shape that
+        // unexpectedly fell back (or unexpectedly stayed native).
+        var res_noopt = blk: {
+            ir_mod.optimize_enabled = false;
+            defer ir_mod.optimize_enabled = true;
+            break :blk try emitMultiResultOpts(src, false);
+        };
+        defer res_noopt.deinit();
+        // Count both eval spellings: define-time and inline-variadic-lambda
+        // fallbacks now route through @kaappi_eval_cached (#1494).
+        const actual_noopt = countEvalFallbacks(res_noopt.toSlice());
+        if (actual_noopt != expected) {
+            std.debug.print("seed {d}: expected {d} kaappi_eval calls unoptimized ({d} define-value evals + {d} inline variadic lambdas), found {d}\n", .{ seed, expected, value_evals, nvariadic, actual_noopt });
+            return error.NativeSubsetFellBackToEval;
+        }
+
+        // Production pass pipeline: elimination can only remove eval sites,
+        // never add them. A define's value eval is top-level (never in a dead
+        // branch), so it is the unremovable floor; inline variadic lambdas in
+        // constant-test branches may be eliminated above it.
+        var res = try emitMultiResult(src);
+        defer res.deinit();
+        const ll = res.toSlice();
+        const actual = countEvalFallbacks(ll);
+        if (actual < value_evals or actual > expected) {
+            std.debug.print("seed {d}: expected {d}..{d} kaappi_eval calls optimized, found {d}\n", .{ seed, value_evals, expected, actual });
+            return error.NativeSubsetFellBackToEval;
+        }
+
+        // The eval count alone cannot see a function whose native
+        // compilation was REJECTED (the define-time eval is emitted either
+        // way and call sites just degrade to global lookups), so also
+        // require the named native function definition that the emitter
+        // tags with a `; <name>` header comment.
+        for (names[0..name_count]) |n| {
+            // A named define is emitted as a tailcc fast entry (#1499) or, when
+            // not fast-eligible, a uniform definition — expectNativeDef accepts
+            // either. (A false return would mean the whole define fell back.)
+            expectNativeDef(ll, n) catch {
+                std.debug.print("seed {d}: no native definition for {s}\n", .{ seed, n });
+                return error.NativeSubsetFellBackToEval;
+            };
+        }
+    }
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -22,6 +22,8 @@ test {
     _ = @import("tests_ffi.zig");
     _ = @import("tests_bytecode_cache.zig");
     _ = @import("tests_native.zig");
+    _ = @import("tests_native_dispatch.zig");
+    _ = @import("tests_native_gate.zig");
     _ = @import("tests_reactor.zig");
     _ = @import("tests_scheduler.zig");
     _ = @import("tests_port_io.zig");


### PR DESCRIPTION
## What

`src/tests_native.zig` had grown to 1504 lines, past the repo's 1500-line file-size policy. The LLVM native backend is an actively-growing area (#1407–#1500), so the file would keep re-crossing the limit. This splits it into three files along its natural, contiguous seams.

| File | Lines | Contents |
|------|------:|----------|
| `src/tests_native.zig` | 1225 | Emit-test helpers + all per-form LLVM-emit tests (assert on `llvm_emit.zig` text output) |
| `src/tests_native_dispatch.zig` | 122 | NativeClosure runtime-dispatch tests (#1376) |
| `src/tests_native_gate.zig` | 170 | Native-subset fuzz gate (#1395) |

## Why this split

The bulk of the file is per-form emit tests that share the same emit/count/assert infrastructure — that's breadth, not tangled coupling, so it stays together. The two extracted concerns are genuinely distinct:

- **Dispatch tests (#1376)** exercise the VM's opcode dispatch of hand-built native closures via `testing_helpers`, a different subsystem with *zero* coupling to the emit-test infrastructure. Moved verbatim.
- **Fuzz gate (#1395)** is a single differential-oracle test with its own `fuzz_gen` dependency. It reuses four emit helpers, so `EmitResult`, `emitMultiResult`, `emitMultiResultOpts`, `countEvalFallbacks`, and `expectNativeDef` are now `pub` in `tests_native.zig` and imported by the gate.

The main file drops to 1225 lines with headroom. Both new files are registered in `vm_tests.zig`.

## Notes

- The `const th` import previously lived in the dispatch section but was also used by three `#1494` "cached form" tests in the emit section (container-level decls are order-independent); re-added it to `tests_native.zig`.
- No test logic changed — this is a pure relocation plus visibility (`pub`) and import adjustments.

## Verification

- `zig fmt --check` clean on all changed files.
- Full `zig build test` suite passes.
- Emit tests and the fuzz gate re-verified green after rebasing onto the #1592 free-variable-analysis refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)