### PR TITLE
Fix --profile dropping functions promoted to the old generation

### DIFF
--- a/src/reporting.zig
+++ b/src/reporting.zig
@@ -88,9 +88,33 @@ pub fn printGcStats(gc: *memory.GC) void {
     if (col > 0) writeStderr("\n");
 }
 
+/// Iterates every heap object: the young list, then the old list. Profile
+/// counters live on Function/NativeFn heap objects, and minor GC promotes
+/// long-lived objects onto `gc.old_objects` — a young-list-only walk
+/// silently drops exactly the oldest (hottest) functions from the report.
+pub const AllObjectsIter = struct {
+    lists: [2]?*types.Object,
+    idx: usize = 0,
+
+    pub fn next(self: *AllObjectsIter) ?*types.Object {
+        while (self.idx < self.lists.len) {
+            if (self.lists[self.idx]) |o| {
+                self.lists[self.idx] = o.next;
+                return o;
+            }
+            self.idx += 1;
+        }
+        return null;
+    }
+};
+
+pub fn allObjects(gc: *memory.GC) AllObjectsIter {
+    return .{ .lists = .{ gc.objects, gc.old_objects } };
+}
+
 pub fn resetProfileCounters(gc: *memory.GC) void {
-    var obj = gc.objects;
-    while (obj) |o| {
+    var it = allObjects(gc);
+    while (it.next()) |o| {
         if (o.tag == .function) {
             const func = o.as(types.Function);
             func.profile_instrs = 0;
@@ -104,7 +128,6 @@ pub fn resetProfileCounters(gc: *memory.GC) void {
             native.profile_time_ns = 0;
             native.profile_alloc_bytes = 0;
         }
-        obj = o.next;
     }
 }
 
@@ -141,8 +164,8 @@ pub fn printProfileReport(gc: *memory.GC) void {
     var total_instrs: u64 = 0;
     var total_calls: u64 = 0;
 
-    var obj = gc.objects;
-    while (obj) |o| {
+    var it = allObjects(gc);
+    while (it.next()) |o| {
         if (o.tag == .function) {
             const func = o.as(types.Function);
             if (func.profile_instrs > 0 or func.profile_calls > 0) {
@@ -181,7 +204,6 @@ pub fn printProfileReport(gc: *memory.GC) void {
                 }
             }
         }
-        obj = o.next;
     }
 
     if (count == 0) return;
@@ -603,8 +625,8 @@ pub fn writeProfileJson(gc: *memory.GC, path: []const u8) void {
 
     writeToFd(fd, "[");
     var first = true;
-    var obj = gc.objects;
-    while (obj) |o| {
+    var it = allObjects(gc);
+    while (it.next()) |o| {
         if (o.tag == .function) {
             const func = o.as(types.Function);
             if (func.profile_calls > 0) {
@@ -641,7 +663,6 @@ pub fn writeProfileJson(gc: *memory.GC, path: []const u8) void {
                 writeToFd(fd, s);
             }
         }
-        obj = o.next;
     }
     writeToFd(fd, "]\n");
 }

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -613,3 +613,80 @@ test "vm: instruction_limit does not trip a short program" {
     const result = try vm.eval("(let loop ((n 0) (acc 0)) (if (= n 100) acc (loop (+ n 1) (+ acc n))))");
     try std.testing.expectEqual(@as(i64, 4950), types.toFixnum(result));
 }
+
+// ---------------------------------------------------------------------------
+// Profile reporting vs. generational GC
+// ---------------------------------------------------------------------------
+// Functions that survive two minor collections are promoted from gc.objects
+// to gc.old_objects (sweepYoung). The profile walkers must traverse both
+// lists, or every long-lived (i.e. hottest) function silently vanishes from
+// the report — a long-running program printed no profile at all.
+
+const reporting = @import("reporting.zig");
+const file_utils = @import("file_utils.zig");
+
+fn findFunctionOnList(head: ?*types.Object, name: []const u8) ?*types.Function {
+    var obj = head;
+    while (obj) |o| {
+        if (o.tag == .function) {
+            const func = o.as(types.Function);
+            if (func.name) |n| {
+                if (std.mem.eql(u8, n, name)) return func;
+            }
+        }
+        obj = o.next;
+    }
+    return null;
+}
+
+/// Promote long-lived objects: full collections (every 8th cycle) don't
+/// promote, so 4 collects guarantee at least 3 minor ones — two survivals
+/// is the promotion threshold.
+fn forcePromotion(gc: *memory.GC) void {
+    var i: usize = 0;
+    while (i < 4) : (i += 1) gc.collect();
+}
+
+test "profile: resetProfileCounters reaches functions promoted to the old generation" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    ctx.vm.profile_mode = true;
+    _ = try ctx.vm.eval("(define (profile-oldgen-fn x) (+ x 1))");
+    _ = try ctx.vm.eval("(profile-oldgen-fn 41)");
+
+    forcePromotion(&ctx.gc);
+
+    // Setup validity: the function must really be on the old list with live
+    // counters, or this test cannot distinguish a young-list-only walk.
+    const func = findFunctionOnList(ctx.gc.old_objects, "profile-oldgen-fn") orelse
+        return error.TestSetupFunctionNotPromoted;
+    try std.testing.expect(func.profile_calls > 0);
+
+    reporting.resetProfileCounters(&ctx.gc);
+    try std.testing.expectEqual(@as(u64, 0), func.profile_calls);
+}
+
+test "profile: JSON report includes functions promoted to the old generation" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    ctx.vm.profile_mode = true;
+    _ = try ctx.vm.eval("(define (profile-oldgen-json-fn x) (* x 2))");
+    _ = try ctx.vm.eval("(profile-oldgen-json-fn 21)");
+
+    forcePromotion(&ctx.gc);
+
+    if (findFunctionOnList(ctx.gc.old_objects, "profile-oldgen-json-fn") == null)
+        return error.TestSetupFunctionNotPromoted;
+
+    const path = "/tmp/kaappi-test-profile-oldgen.json";
+    reporting.writeProfileJson(&ctx.gc, path);
+    defer _ = std.posix.system.unlink(path);
+
+    const contents = try file_utils.readWholeFile(std.testing.allocator, path, 1 << 20);
+    defer std.testing.allocator.free(contents);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "profile-oldgen-json-fn") != null);
+}


### PR DESCRIPTION
Closes #1598. Found while capturing `--profile` traces of `kaappi-examples` for the KEP-0003 revisit-trigger check (#1596).

## Bug

`printProfileReport`, `writeProfileJson`, and `resetProfileCounters` in `src/reporting.zig` walked only `gc.objects`, but `sweepYoung` promotes any function surviving two minor collections onto `gc.old_objects`. Consequences:

- **Long-running programs printed no profile at all** — every profiled function promoted ⇒ `count == 0` ⇒ silent return. Repro: `kaappi --profile parallel-primes/app.scm demo` printed nothing while `... count 50000` printed a report.
- Mid-length runs printed a report **silently missing the oldest (hottest) functions**.
- REPL profile resets left stale counters on promoted functions.

Coverage (`--coverage`/`--coverage-xml`) is unaffected — it reads counters via library export references, not a heap walk.

## Fix

A shared `allObjects` iterator over both generation lists, used by all three walkers.

## Tests

Two regression tests in `tests_robustness.zig` force promotion with explicit minor collections (4 collects ⇒ ≥ 3 minor ⇒ past the 2-survival threshold), assert the function really is on `gc.old_objects` (setup validity), then assert `resetProfileCounters` zeroes its counters and `writeProfileJson` output contains it. Verified both fail without the fix and pass with it; full `zig build test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)