### PR TITLE
Rendezvous semantics for (make-channel 0) on both representations (#1602, #1603)

### DIFF
--- a/src/bench_channel.zig
+++ b/src/bench_channel.zig
@@ -437,7 +437,7 @@ fn benchRealPromoted(workload: Workload, iters: u64) !f64 {
     var i: u64 = 0;
     while (i < iters) : (i += 1) {
         _ = try shared_channel.send(sc, payload, null);
-        _ = try shared_channel.receive(sc, &dest_gc, null);
+        _ = try shared_channel.receive(sc, &dest_gc, null, false);
         freeArena(&dest_gc); // bound the receiver heap, matching the matrix harness
     }
     const elapsed = nowNs() - start;

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -93,6 +93,18 @@ pub const Fiber = struct {
     /// accumulate duplicate ring entries; cleared when scheduleImpl consumes
     /// or discards the entry (#1477).
     queued: bool = false,
+    /// Rendezvous demand token (KEP-0002 §6 as amended, kaappi#1601/#1602):
+    /// the capacity-0 channel this fiber's parked receive has committed to,
+    /// or VOID. Set (with a write barrier) when the receive's park decision
+    /// increments the channel's `rv_demand`; makes that increment idempotent
+    /// across the yield_retry re-execution of the whole primitive. Released
+    /// — counter decrement + reset to VOID — on every terminal exit of the
+    /// wait (value, eof, timeout, error) and on fiber death
+    /// (releaseFiberRendezvousToken, the abandonFiberMutexes precedent).
+    /// Traced by markFiberState/referencesYoung like `waiting_on`; unlike
+    /// `waiting_on` it survives a wake (clear_waiting_on) until the retry
+    /// exits, which is exactly why it needs independent tracing.
+    rv_demand_on: Value = types.VOID,
     /// Mutexes this fiber currently owns (as `Value`s), maintained by
     /// mutex-lock! (#1458). `abandonFiberMutexes` walks this on fiber death
     /// instead of scanning a GC heap for owned mutexes — the mutex object may
@@ -229,6 +241,11 @@ pub const FiberScheduler = struct {
     /// once — a terminal fiber is never revived, so it can't be pushed twice)
     /// can't drift across call sites.
     pub fn retireSlot(self: *FiberScheduler, fiber: *Fiber, status: FiberStatus) void {
+        // Normally a no-op: the channel primitives release the rendezvous
+        // demand token on their own exits. Catches a fiber that died
+        // between a wake and its retry (e.g. dispatch-loop error paths), so
+        // its committed demand can't admit sends nobody will ever collect.
+        releaseFiberRendezvousToken(fiber);
         fiber.status = status;
         // Slot 0 is the main fiber; it can be transiently marked .completed at
         // top level (vm_calls.zig) but must never be recycled — ensureScheduler
@@ -964,6 +981,30 @@ pub fn abandonFiberMutexes(fiber: *Fiber, sched: ?*FiberScheduler) void {
     fiber.owned_mutexes.clearRetainingCapacity();
 }
 
+/// Release `fiber`'s rendezvous demand token, if it holds one (KEP-0002 §6
+/// as amended: every terminal exit of a rendezvous wait releases its token,
+/// and fiber death is the terminal exit of last resort — the
+/// abandonFiberMutexes precedent). Normally a no-op: the channel primitives
+/// release on their own value/eof/timeout/error exits; this catches a fiber
+/// killed between a wake and its retry (thread-terminate!, an errored
+/// dispatch). The channel stub is always in this thread's heap (the
+/// receive path's foreign-owner check gates acquisition), so the local
+/// decrement never touches another thread's memory; a promoted channel's
+/// counter lives in the SharedChannel and is withdrawn under its lock
+/// (#1603), safe from any thread.
+pub fn releaseFiberRendezvousToken(fiber: *Fiber) void {
+    if (fiber.rv_demand_on == types.VOID) return;
+    const ch = types.toObject(fiber.rv_demand_on).as(types.Channel);
+    if (ch.shared) |raw| {
+        const shared_channel = @import("shared_channel.zig");
+        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
+        shared_channel.withdrawRvDemand(sc);
+    } else {
+        ch.rv_demand -= 1;
+    }
+    fiber.rv_demand_on = types.VOID;
+}
+
 /// Wait for `target` fiber to finish. Shared by fiber-join and
 /// thread-join!'s fiber path — the exact same wait condition.
 pub const TargetWait = struct {
@@ -1236,6 +1277,7 @@ pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {
     gc.markValue(fiber.thunk);
     gc.markValue(fiber.result);
     gc.markValue(fiber.waiting_on);
+    gc.markValue(fiber.rv_demand_on);
     gc.markValue(fiber.name);
     gc.markValue(fiber.specific);
 

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -190,7 +190,8 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
             const fiber = obj.as(fiber_mod.Fiber);
             if (isYoungPointer(gc, fiber.thunk) or isYoungPointer(gc, fiber.result) or
                 isYoungPointer(gc, fiber.waiting_on) or isYoungPointer(gc, fiber.name) or
-                isYoungPointer(gc, fiber.specific) or isYoungPointer(gc, fiber.io_buffer)) return true;
+                isYoungPointer(gc, fiber.specific) or isYoungPointer(gc, fiber.io_buffer) or
+                isYoungPointer(gc, fiber.rv_demand_on)) return true;
             if (fiber.current_exception) |exc| {
                 if (isYoungPointer(gc, exc)) return true;
             }

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -243,6 +243,15 @@ fn releaseSharedRvToken(sc: *shared_channel.SharedChannel, ch_val: Value, me: *f
     shared_channel.withdrawRvDemand(sc);
 }
 
+/// Field-only clear, for exits where the counter was already adjusted
+/// under the channel lock — a pop with `holds_token` (§4 receive step 3 as
+/// amended: withdraw-at-pop, incl. its copy-failure raise) and
+/// tryTimeoutWithdraw's `.withdrawn`. Calling releaseSharedRvToken there
+/// would decrement a second time.
+fn clearSharedRvTokenField(ch_val: Value, me: *fiber_mod.Fiber) void {
+    if (me.rv_demand_on == ch_val) me.rv_demand_on = types.VOID;
+}
+
 /// Terminal-exit cleanup for a rendezvous flat park's preserved deadline
 /// (#1602): a dispatched fiber's timed wait keeps `me.deadline_ns` (and
 /// possibly a live reactor timer) across yield_retry re-executions — see
@@ -379,7 +388,16 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
         me.deadline_ns = null;
     }
     if (me.timed_out) {
+        // §6 delivery-wins (#1604 review): admission that opened together
+        // with the timer pop completes the send — the timeout applies to
+        // waiting, never to an already-satisfiable operation. Closed is
+        // checked first, matching the shared path's decide.
         me.timed_out = false;
+        if (ch.closed) return raiseFiberError("channel-send: send on closed channel");
+        if (ch.queue_len < localSendBound(ch, cap)) {
+            try enqueueChannel(gc, ch, ch_val, payload);
+            return types.VOID;
+        }
         return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID);
     }
 
@@ -621,9 +639,19 @@ fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: 
         ctx.sched.removeSharedWaiter(me);
 
         if (me.timed_out) {
+            // §6 delivery-wins, post-park mirror of the entry decide
+            // (#1604 review): a slot or rendezvous demand that materialized
+            // together with the timer pop completes the send; only a
+            // genuine would_park honors the timer.
             me.timed_out = false;
             me.deadline_ns = null;
-            return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID);
+            const decide = shared_channel.send(sc, payload, notifier) catch |err|
+                return translateSharedChannelError(err, "channel-send");
+            switch (decide) {
+                .sent => return types.VOID,
+                .closed => return raiseFiberError("channel-send: send on closed channel"),
+                .would_park => return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID),
+            }
         }
         // Loop back to 1: re-registers if still full, sends if a slot
         // opened (or the channel closed) while parked.
@@ -714,28 +742,37 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             // §6 delivery-wins (#1601): decide the timeout through one
             // actual receive() — a handoff that committed before the
             // deadline was processed is returned, never discarded; the
-            // timeout applies to waiting only. On a rendezvous channel one
-            // more case defers the decision: the §6 reservation-drain rule
-            // — an admitted send mid-copy against this receiver's demand
-            // (reserved > 0, queue empty) must land or abort before the
-            // receiver may leave, or the sender would report success into
-            // nowhere. Both resolutions ring recv_waiters (the push always
-            // did; the abort now does on a rendezvous channel — see
-            // shared_channel.send's failure path), so the drain is a park,
-            // not a spin: the dispatched flat park keeps timed_out set so
-            // the rung redispatch re-enters this branch, and the main
-            // fiber's in-place park restores it before looping back here.
-            const o = shared_channel.receive(sc, gc, notifier) catch |err| {
+            // timeout applies to waiting only. On a rendezvous channel the
+            // rest of the decision is tryTimeoutWithdraw, ONE mutex
+            // section over the queue re-check, the reservation check, and
+            // the demand decrement (§6 as amended — model finding 6: with
+            // the reservation check and the withdrawal in separate lock
+            // sections, a sender can reserve against the still-held token
+            // after the zero observation and push into demand that no
+            // longer exists). `.reservation_pending` is the §6
+            // reservation-drain rule — an admitted send mid-copy must land
+            // or abort before the receiver may leave; both resolutions
+            // ring recv_waiters (the push always did; the abort does on a
+            // rendezvous channel — see shared_channel.send's failure
+            // path), so the drain is a park, not a spin: the dispatched
+            // flat park keeps timed_out set so the rung redispatch
+            // re-enters this branch, and the main fiber's in-place park
+            // restores it before looping back here.
+            const holds = me.rv_demand_on == ch_val;
+            const o = shared_channel.receive(sc, gc, notifier, holds) catch |err| {
+                // receive() fails only in the post-pop copy-out, so a held
+                // token was already withdrawn with the pop: clear, never
+                // decrement again.
                 me.timed_out = false;
                 me.deadline_ns = null;
-                releaseSharedRvToken(sc, ch_val, me);
+                clearSharedRvTokenField(ch_val, me);
                 return translateSharedChannelError(err, "channel-receive");
             };
             switch (o) {
                 .value => |v| {
                     me.timed_out = false;
                     me.deadline_ns = null;
-                    releaseSharedRvToken(sc, ch_val, me);
+                    clearSharedRvTokenField(ch_val, me);
                     return v;
                 },
                 .eof => {
@@ -746,12 +783,24 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
                 },
                 .would_park => {},
             }
-            if (!rendezvous or shared_channel.reservedCount(sc) == 0) {
+            if (!rendezvous) {
                 me.timed_out = false;
                 me.deadline_ns = null;
-                releaseSharedRvToken(sc, ch_val, me);
                 return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
             }
+            switch (shared_channel.tryTimeoutWithdraw(sc, me.rv_demand_on == ch_val)) {
+                .withdrawn => {
+                    me.timed_out = false;
+                    me.deadline_ns = null;
+                    clearSharedRvTokenField(ch_val, me);
+                    return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
+                },
+                .value_ready => continue :outer, // raced in after the receive(): delivery wins
+                .reservation_pending => {},
+            }
+            // Error exits below are terminal for this wait: release the
+            // token (kaappi#1604 review — a leak here is phantom demand a
+            // main fiber never backstops) and drop the preserved deadline.
             if (is_dispatched) {
                 me.status = .waiting;
                 me.waiting_on = ch_val;
@@ -759,6 +808,9 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
                 ctx.sched.enrollSharedWaiter(me) catch |err| {
                     me.status = .running;
                     me.waiting_on = types.VOID;
+                    releaseSharedRvToken(sc, ch_val, me);
+                    me.timed_out = false;
+                    me.deadline_ns = null;
                     return err;
                 };
                 vm.yield_retry = true;
@@ -774,20 +826,27 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             ctx.sched.enrollSharedWaiter(me) catch |err| {
                 me.status = .running;
                 me.waiting_on = types.VOID;
+                releaseSharedRvToken(sc, ch_val, me);
+                me.deadline_ns = null;
                 return err;
             };
             _ = fiber_mod.runSchedulerStep(SharedChannelWait, .{ .me = me }, ctx.vm, ctx.sched, me) catch |err| {
                 ctx.sched.removeSharedWaiter(me);
                 me.status = .running;
                 me.waiting_on = types.VOID;
+                releaseSharedRvToken(sc, ch_val, me);
+                me.deadline_ns = null;
                 return err;
             };
             ctx.sched.removeSharedWaiter(me);
             me.timed_out = true;
             continue :outer;
         }
-        const outcome = shared_channel.receive(sc, gc, notifier) catch |err| {
-            releaseSharedRvToken(sc, ch_val, me);
+        const outcome = shared_channel.receive(sc, gc, notifier, me.rv_demand_on == ch_val) catch |err| {
+            // Fails only in the post-pop copy-out: a held token was already
+            // withdrawn with the pop (§4 step 3 as amended) — clear, never
+            // decrement again.
+            clearSharedRvTokenField(ch_val, me);
             return translateSharedChannelError(err, "channel-receive");
         };
         switch (outcome) {
@@ -796,7 +855,7 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
                     ctx.reactor.removeTimer(me);
                     me.deadline_ns = null;
                 }
-                releaseSharedRvToken(sc, ch_val, me);
+                clearSharedRvTokenField(ch_val, me);
                 return v;
             },
             .eof => {
@@ -845,8 +904,8 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         // whenever it returns .would_park, so the park below is always armed;
         // if the drive instead produced a value (or EOF), it is returned here
         // and the fiber never parks.
-        const redo = shared_channel.receive(sc, gc, notifier) catch |err| {
-            releaseSharedRvToken(sc, ch_val, me);
+        const redo = shared_channel.receive(sc, gc, notifier, me.rv_demand_on == ch_val) catch |err| {
+            clearSharedRvTokenField(ch_val, me);
             return translateSharedChannelError(err, "channel-receive");
         };
         switch (redo) {
@@ -855,7 +914,7 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
                     ctx.reactor.removeTimer(me);
                     me.deadline_ns = null;
                 }
-                releaseSharedRvToken(sc, ch_val, me);
+                clearSharedRvTokenField(ch_val, me);
                 return v;
             },
             .eof => {
@@ -878,17 +937,33 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         // promoteChannel seeded rv_demand with it.
         if (rendezvous) acquireSharedRvToken(vm, sc, ch_val, me);
 
+        // Every error exit from the park machinery below is terminal for
+        // this wait: release the token and detach any armed timer, matching
+        // the status/waiting_on cleanup these handlers already do
+        // (kaappi#1604 review). Only the deliberate Yielded park keeps the
+        // token — the retry re-enters the whole primitive.
         if (is_dispatched) {
             me.status = .waiting;
             me.waiting_on = ch_val;
             vm.gc.writeBarrier(&me.header, ch_val);
             if (me.deadline_ns orelse deadline_ns) |d| {
                 me.deadline_ns = d;
-                try ctx.reactor.addTimer(d, me);
+                ctx.reactor.addTimer(d, me) catch |err| {
+                    me.status = .running;
+                    me.waiting_on = types.VOID;
+                    releaseSharedRvToken(sc, ch_val, me);
+                    me.deadline_ns = null;
+                    return err;
+                };
             }
             ctx.sched.enrollSharedWaiter(me) catch |err| {
                 me.status = .running;
                 me.waiting_on = types.VOID;
+                releaseSharedRvToken(sc, ch_val, me);
+                if (me.deadline_ns != null) {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = null;
+                }
                 return err;
             };
             vm.yield_retry = true;
@@ -909,17 +984,33 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         // fibers).
         if (me.deadline_ns orelse deadline_ns) |d| {
             me.deadline_ns = d;
-            try ctx.reactor.addTimer(d, me);
+            ctx.reactor.addTimer(d, me) catch |err| {
+                me.status = .running;
+                me.waiting_on = types.VOID;
+                releaseSharedRvToken(sc, ch_val, me);
+                me.deadline_ns = null;
+                return err;
+            };
         }
         ctx.sched.enrollSharedWaiter(me) catch |err| {
             me.status = .running;
             me.waiting_on = types.VOID;
+            releaseSharedRvToken(sc, ch_val, me);
+            if (me.deadline_ns != null) {
+                ctx.reactor.removeTimer(me);
+                me.deadline_ns = null;
+            }
             return err;
         };
         _ = fiber_mod.runSchedulerStep(SharedChannelWait, .{ .me = me }, ctx.vm, ctx.sched, me) catch |err| {
             ctx.sched.removeSharedWaiter(me);
             me.status = .running;
             me.waiting_on = types.VOID;
+            releaseSharedRvToken(sc, ch_val, me);
+            if (me.deadline_ns != null) {
+                ctx.reactor.removeTimer(me);
+                me.deadline_ns = null;
+            }
             return err;
         };
         ctx.sched.removeSharedWaiter(me);
@@ -1043,7 +1134,15 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
                 if (me.deadline_ns orelse deadline_ns) |d| {
                     ctx.reactor.removeTimer(me);
                     me.deadline_ns = d;
-                    try ctx.reactor.addTimer(d, me);
+                    ctx.reactor.addTimer(d, me) catch |err| {
+                        // Terminal for this wait: don't leak the committed
+                        // demand or leave park state behind (#1604 review).
+                        me.status = .running;
+                        me.waiting_on = types.VOID;
+                        me.deadline_ns = null;
+                        releaseRvToken(ch, ch_val, me);
+                        return err;
+                    };
                 }
                 vm.yield_retry = true;
                 return PrimitiveError.Yielded;
@@ -1070,9 +1169,24 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         vm.gc.writeBarrier(&me.header, ch_val);
         ctx.sched.enrollWaiter(me); // #1530: O(1) wake on a channel send / close
         me.deadline_ns = d;
-        try ctx.reactor.addTimer(d, me);
+        ctx.reactor.addTimer(d, me) catch |err| {
+            me.status = .running;
+            me.waiting_on = types.VOID;
+            me.deadline_ns = null;
+            releaseRvToken(ch, ch_val, me);
+            return err;
+        };
     }
-    _ = try fiber_mod.runSchedulerStep(ChannelWait, .{ .ch = ch }, ctx.vm, ctx.sched, me);
+    _ = fiber_mod.runSchedulerStep(ChannelWait, .{ .ch = ch }, ctx.vm, ctx.sched, me) catch |err| {
+        // Terminal for this wait (the main fiber has no retireSlot backstop):
+        // release the committed demand and detach the timer (#1604 review).
+        releaseRvToken(ch, ch_val, me);
+        if (deadline_ns != null) {
+            ctx.reactor.removeTimer(me);
+            me.deadline_ns = null;
+        }
+        return err;
+    };
     if (deadline_ns != null) {
         ctx.reactor.removeTimer(me);
         me.deadline_ns = null;

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -180,14 +180,96 @@ fn enqueueChannel(gc: *memory.GC, ch: *types.Channel, ch_val: Value, payload: Va
     }
 }
 
+/// KEP-0002 §6 (amended, #1601/#1602): the send-admission bound for a local
+/// channel — its capacity, or, for a rendezvous channel (capacity 0), the
+/// current receiver demand. Callers pass the already-unwrapped capacity;
+/// unbounded channels never reach an admission check.
+fn localSendBound(ch: *types.Channel, cap: u32) u32 {
+    return if (cap == 0) ch.rv_demand else cap;
+}
+
+/// §4 receive step 7a (#1601): commit the current fiber as a receiver on a
+/// local rendezvous channel. Exactly once per logical wait — the Fiber
+/// field makes the increment idempotent across yield_retry re-execution of
+/// the whole primitive — and new demand is a send-side event: wake parked
+/// senders exactly like a freed slot would (model finding 4: without this
+/// wake, senders parked against bound 0 before any receiver committed are
+/// never woken). Allocates nothing.
+fn acquireRvToken(vm: *vm_mod.VM, ch: *types.Channel, ch_val: Value, me: *fiber_mod.Fiber) void {
+    if (me.rv_demand_on == ch_val) return;
+    ch.rv_demand += 1;
+    me.rv_demand_on = ch_val;
+    vm.gc.writeBarrier(&me.header, ch_val);
+    if (vm.scheduler) |sched| sched.wakeChannelWaiters(ch_val);
+}
+
+/// Terminal-exit half of step 7a: release the token if this wait holds one.
+/// Every exit of a rendezvous receive — value, eof, timeout, deadlock raise
+/// — must come through here; only the blockOrDeadlock park (yield_retry)
+/// deliberately keeps the token, because the retry re-enters the primitive
+/// and acquireRvToken's idempotence check picks it back up.
+fn releaseRvToken(ch: *types.Channel, ch_val: Value, me: *fiber_mod.Fiber) void {
+    if (me.rv_demand_on != ch_val) return;
+    ch.rv_demand -= 1;
+    me.rv_demand_on = types.VOID;
+}
+
+/// releaseRvToken for paths that may run before any scheduler exists (the
+/// fast-path dequeue, the closed short-circuit): a token can only be held
+/// by a fiber, so no scheduler means no token — a cheap no-op.
+fn releaseRvTokenCurrent(vm: *vm_mod.VM, ch: *types.Channel, ch_val: Value) void {
+    const sched = vm.scheduler orelse return;
+    const me = sched.fibers.items[sched.current_idx] orelse return;
+    releaseRvToken(ch, ch_val, me);
+}
+
+/// Shared-representation twin of acquireRvToken (#1603): commit the current
+/// fiber as a receiver on a promoted rendezvous channel. The token field is
+/// the same one the local path uses — a token acquired at a pre-promotion
+/// local park still names this channel's stub, so the idempotence check
+/// holds seamlessly across promotion (promoteChannel copied the count).
+/// commitRvDemand does the lock + send_waiters ring internally.
+fn acquireSharedRvToken(vm: *vm_mod.VM, sc: *shared_channel.SharedChannel, ch_val: Value, me: *fiber_mod.Fiber) void {
+    if (me.rv_demand_on == ch_val) return;
+    me.rv_demand_on = ch_val;
+    vm.gc.writeBarrier(&me.header, ch_val);
+    shared_channel.commitRvDemand(sc);
+}
+
+/// Terminal-exit half on the shared representation.
+fn releaseSharedRvToken(sc: *shared_channel.SharedChannel, ch_val: Value, me: *fiber_mod.Fiber) void {
+    if (me.rv_demand_on != ch_val) return;
+    me.rv_demand_on = types.VOID;
+    shared_channel.withdrawRvDemand(sc);
+}
+
+/// Terminal-exit cleanup for a rendezvous flat park's preserved deadline
+/// (#1602): a dispatched fiber's timed wait keeps `me.deadline_ns` (and
+/// possibly a live reactor timer) across yield_retry re-executions — see
+/// channelSendShared's discriminator comment for why the absolute deadline
+/// must survive the retry. Any exit that ends the logical wait (an admitted
+/// send, a delivered value, eof) must clear both, or the stale timer fires
+/// into whatever wait this fiber enters next. No-op without a scheduler.
+fn clearRvWaitDeadline(vm: *vm_mod.VM) void {
+    const sched = vm.scheduler orelse return;
+    const me = sched.fibers.items[sched.current_idx] orelse return;
+    if (me.deadline_ns != null) {
+        if (vm.reactor) |r| r.removeTimer(me);
+        me.deadline_ns = null;
+    }
+    me.timed_out = false;
+}
+
 /// A fiber parked waiting for room on a *local* bounded channel (KEP-0002
 /// §6). Mirrors ChannelWait's shape exactly; isDone is satisfied by either
-/// a freed slot or the channel becoming closed (channel-close! wakes both
-/// waiter roles via the same wakeChannelWaiters call).
+/// a freed slot (for a rendezvous channel: unmatched receiver demand) or
+/// the channel becoming closed (channel-close! wakes both waiter roles via
+/// the same wakeChannelWaiters call).
 const ChannelSendWait = struct {
     ch: *types.Channel,
     pub fn isDone(self: ChannelSendWait) bool {
-        return self.ch.closed or self.ch.capacity == null or self.ch.queue_len < self.ch.capacity.?;
+        const cap = self.ch.capacity orelse return true;
+        return self.ch.closed or self.ch.queue_len < localSendBound(self.ch, cap);
     }
 };
 
@@ -207,22 +289,71 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
         try enqueueChannel(gc, ch, ch_val, payload);
         return types.VOID;
     };
-    if (ch.queue_len < cap) {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    // §6 (amended, #1602): capacity 0 is a rendezvous channel — the bound is
+    // the committed receiver demand, so a send is admitted exactly when a
+    // receiver is parked waiting (and completes the handoff through the
+    // queue; the receiver's own exit collects it). Admission before the
+    // timeout redispatch check below: per the amendment, a timeout applies
+    // to waiting, never to an already-satisfiable operation, so a flat-park
+    // retry whose demand arrived together with (or before) its timer sends.
+    if (ch.queue_len < localSendBound(ch, cap)) {
+        // A rendezvous flat-park retry may still carry its preserved
+        // deadline/armed timer — the wait is over, clear them.
+        if (cap == 0) clearRvWaitDeadline(vm);
         try enqueueChannel(gc, ch, ch_val, payload);
         return types.VOID;
     }
 
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
     // See channelReceiveFn's matching check: a timeout resolves this wait
     // via the reactor timer alone, so "no fibers exist" is only a genuine
     // deadlock when there is also no deadline to bound the wait.
     if (vm.scheduler == null and deadline_ns == null) {
-        return raiseFiberError("channel-send: deadlock — channel is full and no fibers are running");
+        return raiseFiberError(if (cap == 0)
+            "channel-send: deadlock — rendezvous channel has no receiver and no fibers are running"
+        else
+            "channel-send: deadlock — channel is full and no fibers are running");
     }
 
     const ctx = try fiber_mod.ensureScheduler(vm);
     const my_idx = ctx.sched.current_idx;
     const me = ctx.sched.fibers.items[my_idx].?;
+
+    // Rendezvous + dispatched fiber: ALWAYS park via the flat yield_retry
+    // unwind, never the in-call drive below (#1602). Rendezvous is the one
+    // capacity where a parked sender and a parked receiver can exist
+    // simultaneously, and an in-call park makes this fiber a frozen
+    // *ancestor* whenever its drive transitively dispatches the fiber that
+    // eventually commits the matching demand: the waker can't dispatch a
+    // `driving` ancestor (#1487), the ancestor's own loop is buried under
+    // the waker's live frames, and a main-fiber counterparty at the top of
+    // that stack raises a spurious deadlock with a viable, satisfied sender
+    // frozen beneath it. The flat park keeps every rendezvous waiter
+    // dispatchable. Mirrors channelSendShared's is_dispatched branch,
+    // including the preserved-deadline discriminator: the retry re-executes
+    // this whole function, so the timer is armed once (me.deadline_ns null)
+    // and re-attached from the preserved absolute deadline on every
+    // re-park (a wake can race the timer pop, which wakeReadyFiber drops
+    // for non-waiting fibers — re-arming from the preserved value keeps the
+    // timeout live without ever extending it).
+    if (cap == 0 and my_idx != 0 and vm.dispatched_from_scheduler) {
+        if (me.deadline_ns != null and me.timed_out) {
+            me.timed_out = false;
+            me.deadline_ns = null;
+            return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID);
+        }
+        me.status = .waiting;
+        me.waiting_on = ch_val;
+        vm.gc.writeBarrier(&me.header, ch_val);
+        ctx.sched.enrollWaiter(me);
+        if (me.deadline_ns orelse deadline_ns) |d| {
+            ctx.reactor.removeTimer(me);
+            me.deadline_ns = d;
+            try ctx.reactor.addTimer(d, me);
+        }
+        vm.yield_retry = true;
+        return PrimitiveError.Yielded;
+    }
 
     // A local channel wait always resolves within this one call:
     // runSchedulerStep drives siblings and, if nothing else is runnable,
@@ -253,11 +384,14 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
     }
 
     if (ch.closed) return raiseFiberError("channel-send: send on closed channel");
-    if (ch.queue_len < cap) {
+    if (ch.queue_len < localSendBound(ch, cap)) {
         try enqueueChannel(gc, ch, ch_val, payload);
         return types.VOID;
     }
-    return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, "channel-send: deadlock — channel is full and no fibers can receive");
+    return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, if (cap == 0)
+        "channel-send: deadlock — rendezvous channel has no receiver and all fibers are blocked"
+    else
+        "channel-send: deadlock — channel is full and no fibers can receive");
 }
 
 const ChannelWait = struct {
@@ -350,9 +484,20 @@ fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: 
     const is_dispatched = my_idx != 0 and vm.dispatched_from_scheduler;
 
     if (me.deadline_ns != null and me.timed_out) {
+        // §6 delivery-wins (#1601): a timeout applies to waiting, never to
+        // an already-satisfiable operation — decide through one actual
+        // send(). Admission open (a receiver committed demand, or a slot
+        // freed, in the same instant the timer popped) completes the send;
+        // closed raises; only a genuine would_park honors the timer.
         me.timed_out = false;
         me.deadline_ns = null;
-        return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID);
+        const o = shared_channel.send(sc, payload, notifier) catch |err|
+            return translateSharedChannelError(err, "channel-send");
+        switch (o) {
+            .sent => return types.VOID,
+            .closed => return raiseFiberError("channel-send: send on closed channel"),
+            .would_park => return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-send: timed out", types.VOID),
+        }
     }
 
     while (true) {
@@ -560,22 +705,98 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
     const me = ctx.sched.fibers.items[my_idx].?;
     const notifier = ctx.reactor.notifyHandle();
     const is_dispatched = my_idx != 0 and vm.dispatched_from_scheduler;
+    // capacity is set once at promotion and never mutated, so the unlocked
+    // read is safe; 0 = rendezvous (§6 as amended, #1603).
+    const rendezvous = (sc.capacity orelse 1) == 0;
 
-    if (me.deadline_ns != null and me.timed_out) {
-        me.timed_out = false;
-        me.deadline_ns = null;
-        return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
-    }
-
-    while (true) {
-        const outcome = shared_channel.receive(sc, gc, notifier) catch |err|
+    outer: while (true) {
+        if (me.deadline_ns != null and me.timed_out) {
+            // §6 delivery-wins (#1601): decide the timeout through one
+            // actual receive() — a handoff that committed before the
+            // deadline was processed is returned, never discarded; the
+            // timeout applies to waiting only. On a rendezvous channel one
+            // more case defers the decision: the §6 reservation-drain rule
+            // — an admitted send mid-copy against this receiver's demand
+            // (reserved > 0, queue empty) must land or abort before the
+            // receiver may leave, or the sender would report success into
+            // nowhere. Both resolutions ring recv_waiters (the push always
+            // did; the abort now does on a rendezvous channel — see
+            // shared_channel.send's failure path), so the drain is a park,
+            // not a spin: the dispatched flat park keeps timed_out set so
+            // the rung redispatch re-enters this branch, and the main
+            // fiber's in-place park restores it before looping back here.
+            const o = shared_channel.receive(sc, gc, notifier) catch |err| {
+                me.timed_out = false;
+                me.deadline_ns = null;
+                releaseSharedRvToken(sc, ch_val, me);
+                return translateSharedChannelError(err, "channel-receive");
+            };
+            switch (o) {
+                .value => |v| {
+                    me.timed_out = false;
+                    me.deadline_ns = null;
+                    releaseSharedRvToken(sc, ch_val, me);
+                    return v;
+                },
+                .eof => {
+                    me.timed_out = false;
+                    me.deadline_ns = null;
+                    releaseSharedRvToken(sc, ch_val, me);
+                    return types.EOF;
+                },
+                .would_park => {},
+            }
+            if (!rendezvous or shared_channel.reservedCount(sc) == 0) {
+                me.timed_out = false;
+                me.deadline_ns = null;
+                releaseSharedRvToken(sc, ch_val, me);
+                return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
+            }
+            if (is_dispatched) {
+                me.status = .waiting;
+                me.waiting_on = ch_val;
+                vm.gc.writeBarrier(&me.header, ch_val);
+                ctx.sched.enrollSharedWaiter(me) catch |err| {
+                    me.status = .running;
+                    me.waiting_on = types.VOID;
+                    return err;
+                };
+                vm.yield_retry = true;
+                return PrimitiveError.Yielded;
+            }
+            // Main fiber drains in place: park (timed_out cleared so the
+            // drives inside runSchedulerStep work), restore decision mode,
+            // and re-decide at the top.
+            me.timed_out = false;
+            me.status = .waiting;
+            me.waiting_on = ch_val;
+            vm.gc.writeBarrier(&me.header, ch_val);
+            ctx.sched.enrollSharedWaiter(me) catch |err| {
+                me.status = .running;
+                me.waiting_on = types.VOID;
+                return err;
+            };
+            _ = fiber_mod.runSchedulerStep(SharedChannelWait, .{ .me = me }, ctx.vm, ctx.sched, me) catch |err| {
+                ctx.sched.removeSharedWaiter(me);
+                me.status = .running;
+                me.waiting_on = types.VOID;
+                return err;
+            };
+            ctx.sched.removeSharedWaiter(me);
+            me.timed_out = true;
+            continue :outer;
+        }
+        const outcome = shared_channel.receive(sc, gc, notifier) catch |err| {
+            releaseSharedRvToken(sc, ch_val, me);
             return translateSharedChannelError(err, "channel-receive");
+        };
         switch (outcome) {
             .value => |v| {
                 if (me.deadline_ns != null) {
                     ctx.reactor.removeTimer(me);
                     me.deadline_ns = null;
                 }
+                releaseSharedRvToken(sc, ch_val, me);
                 return v;
             },
             .eof => {
@@ -583,6 +804,7 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
                     ctx.reactor.removeTimer(me);
                     me.deadline_ns = null;
                 }
+                releaseSharedRvToken(sc, ch_val, me);
                 return types.EOF;
             },
             .would_park => {},
@@ -623,14 +845,17 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         // whenever it returns .would_park, so the park below is always armed;
         // if the drive instead produced a value (or EOF), it is returned here
         // and the fiber never parks.
-        const redo = shared_channel.receive(sc, gc, notifier) catch |err|
+        const redo = shared_channel.receive(sc, gc, notifier) catch |err| {
+            releaseSharedRvToken(sc, ch_val, me);
             return translateSharedChannelError(err, "channel-receive");
+        };
         switch (redo) {
             .value => |v| {
                 if (me.deadline_ns != null) {
                     ctx.reactor.removeTimer(me);
                     me.deadline_ns = null;
                 }
+                releaseSharedRvToken(sc, ch_val, me);
                 return v;
             },
             .eof => {
@@ -638,10 +863,20 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
                     ctx.reactor.removeTimer(me);
                     me.deadline_ns = null;
                 }
+                releaseSharedRvToken(sc, ch_val, me);
                 return types.EOF;
             },
             .would_park => {},
         }
+
+        // §4 receive step 7a (#1601/#1603): the park decision is the
+        // commitment point — commit the demand (and ring send_waiters,
+        // inside commitRvDemand) before either park below, so a remote
+        // sender's admission check sees it. Idempotent per logical wait via
+        // the fiber token field, which also survives promotion: a token
+        // acquired at a pre-promotion local park names this same stub, and
+        // promoteChannel seeded rv_demand with it.
+        if (rendezvous) acquireSharedRvToken(vm, sc, ch_val, me);
 
         if (is_dispatched) {
             me.status = .waiting;
@@ -660,8 +895,10 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
             return PrimitiveError.Yielded;
         }
 
-        if (!sharedWakeupPossible(sc) and deadline_ns == null)
+        if (!sharedWakeupPossible(sc) and deadline_ns == null) {
+            releaseSharedRvToken(sc, ch_val, me);
             return raiseFiberError("channel-receive: deadlock — channel is empty and no other thread can send");
+        }
 
         me.status = .waiting;
         me.waiting_on = ch_val;
@@ -687,13 +924,11 @@ fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_va
         };
         ctx.sched.removeSharedWaiter(me);
 
-        if (me.timed_out) {
-            me.timed_out = false;
-            me.deadline_ns = null;
-            return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
-        }
-        // Loop back to 1: re-registers if still empty, picks up a value if
-        // one arrived while parked.
+        // A fired timer routes through the decision head at the top of the
+        // loop (delivery-wins + the rendezvous reservation-drain rule) —
+        // me.timed_out stays set so the head recognizes it.
+        // Otherwise: loop back to 1 — re-registers if still empty, picks up
+        // a value if one arrived while parked.
     }
 }
 
@@ -718,21 +953,45 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         }
     }
 
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+
     if (ch.shared) |raw| {
         const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
+        // A token acquired at a pre-promotion local park stays valid across
+        // this dispatch (#1603): promoteChannel seeded sc.rv_demand with it,
+        // the fiber field still names this same stub, and the shared path's
+        // idempotent acquire/release keeps the accounting exact.
         return channelReceiveShared(sc, gc, args[0], deadline_ns, has_timeout_val, timeout_val);
     }
 
     if (ch.head != types.NIL and types.isPair(ch.head)) {
+        // A woken retry re-entering with a demand token finds its value
+        // here: terminal exit, release (a fresh receive holds none — no-op).
+        // §6 delivery-wins: this check runs before the timeout-redispatch
+        // discriminator below, so a value that arrived together with the
+        // timer pop is returned, never discarded; the preserved deadline is
+        // cleared with the wait.
+        if (ch.capacity) |c| {
+            if (c == 0) {
+                releaseRvTokenCurrent(vm, ch, args[0]);
+                clearRvWaitDeadline(vm);
+            }
+        }
         return dequeueChannel(ch, args[0]);
     }
 
     // Closed and drained is permanently terminal on the local
     // representation (no more sends can land once closed): short-circuit
     // before ever touching the scheduler.
-    if (ch.closed) return types.EOF;
-
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    if (ch.closed) {
+        if (ch.capacity) |c| {
+            if (c == 0) {
+                releaseRvTokenCurrent(vm, ch, args[0]);
+                clearRvWaitDeadline(vm);
+            }
+        }
+        return types.EOF;
+    }
     // No timeout means a timer can never resolve this wait, so "no fibers
     // exist" really is unrecoverable; with a timeout, ensureScheduler below
     // lazily creates a scheduler+reactor and the wait resolves via the
@@ -750,6 +1009,47 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     const ctx = try fiber_mod.ensureScheduler(vm);
     const my_idx = ctx.sched.current_idx;
     const me = ctx.sched.fibers.items[my_idx].?;
+
+    // §4 receive step 7a (#1601): the park decision is the rendezvous
+    // commitment point — acquire the demand token before anything can run,
+    // so a parked sender's retry (woken inside acquireRvToken) and every
+    // sender a drive dispatches see this receiver's demand. Idempotent: a
+    // yield_retry re-execution already holds the token.
+    if (ch.capacity) |c| {
+        if (c == 0) {
+            // Post-timeout redispatch of a flat-parked wait (below): the
+            // head fast-path above already gave delivery priority, so a
+            // fired timer here really is a timeout — release and exit.
+            if (me.deadline_ns != null and me.timed_out) {
+                me.timed_out = false;
+                me.deadline_ns = null;
+                releaseRvToken(ch, ch_val, me);
+                return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
+            }
+            acquireRvToken(vm, ch, ch_val, me);
+            // Dispatched fiber: ALWAYS the flat yield_retry park, never the
+            // in-call drive below — see channelSendLocal's matching branch
+            // for why an in-call rendezvous park makes this fiber a frozen
+            // ancestor and deadlocks a stacked counterparty (#1602). The
+            // token is deliberately retained across the park; the retry's
+            // acquireRvToken is idempotent. Timer handling mirrors the send
+            // side: armed from the preserved absolute deadline on every
+            // re-park, never extended.
+            if (my_idx != 0 and vm.dispatched_from_scheduler) {
+                me.status = .waiting;
+                me.waiting_on = ch_val;
+                vm.gc.writeBarrier(&me.header, ch_val);
+                ctx.sched.enrollWaiter(me);
+                if (me.deadline_ns orelse deadline_ns) |d| {
+                    ctx.reactor.removeTimer(me);
+                    me.deadline_ns = d;
+                    try ctx.reactor.addTimer(d, me);
+                }
+                vm.yield_retry = true;
+                return PrimitiveError.Yielded;
+            }
+        }
+    }
 
     // A local channel wait always resolves within this one call -- see
     // channelSendLocal's doc comment for why no redispatch guard is needed.
@@ -777,13 +1077,33 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         ctx.reactor.removeTimer(me);
         me.deadline_ns = null;
     }
+    // §6 delivery-wins (#1601): a value already in the queue outranks a
+    // fired timer — the timeout applies to waiting, never to an already-
+    // satisfiable receive. On a rendezvous channel the sender has already
+    // returned believing the handoff committed; honoring the timer here
+    // would silently discard a delivered value. Clear the stale flag so a
+    // later wait can't inherit it.
+    if (ch.head != types.NIL) {
+        me.timed_out = false;
+        releaseRvToken(ch, ch_val, me);
+        return dequeueChannel(ch, ch_val);
+    }
     if (me.timed_out) {
         me.timed_out = false;
+        releaseRvToken(ch, ch_val, me);
         return if (has_timeout_val) timeout_val else srfi18.raiseError(.channel_timeout, "channel-receive: timed out", types.VOID);
     }
-
-    if (ch.head != types.NIL) return dequeueChannel(ch, ch_val);
-    if (ch.closed) return types.EOF;
+    if (ch.closed) {
+        releaseRvToken(ch, ch_val, me);
+        return types.EOF;
+    }
+    // A rendezvous receive only reaches this point on the main fiber or
+    // under re-entrant native frames — a dispatched one flat-parked above,
+    // token retained, and its retry re-enters the whole primitive. For
+    // exactly these callers blockOrDeadlock raises, which is a terminal
+    // exit: release the token first. (A dispatched non-rendezvous fiber
+    // parking here holds no token, so the release is a no-op for it.)
+    releaseRvToken(ch, ch_val, me);
     return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, "channel-receive: deadlock — channel is empty and all fibers are blocked");
 }
 

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -645,7 +645,15 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
     // and unwinds (threadEntryFn's self-abandon) — its owned-mutexes list is
     // maintained on *its* thread, so the parent must not touch it from here
     // (#1458).
-    if (fiber.os_thread == null) fiber_mod.abandonFiberMutexes(fiber, ctx.sched);
+    if (fiber.os_thread == null) {
+        fiber_mod.abandonFiberMutexes(fiber, ctx.sched);
+        // Same ownership reasoning for a held rendezvous demand token
+        // (KEP-0002 §6 amended, #1602): this path flips the victim's status
+        // directly, bypassing retireSlot, and the victim never runs again
+        // to release it itself. An OS thread's fiber lives in the child's
+        // heap — its own unwind releases the token there.
+        fiber_mod.releaseFiberRendezvousToken(fiber);
+    }
 
     const status = @atomicLoad(fiber_mod.FiberStatus, &fiber.status, .acquire);
     if (status != .completed and status != .errored) {

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -482,7 +482,18 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
     };
 
     const result = child_vm.callWithArgs(child_thunk, &.{}) catch {
-        if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(cf, child_vm.scheduler);
+        if (child_vm.current_fiber) |cf| {
+            fiber_mod.abandonFiberMutexes(cf, child_vm.scheduler);
+            // A terminated/errored child parked in a rendezvous receive
+            // unwinds through here holding its demand token (#1604 review):
+            // the parent-side terminate path deliberately never touches an
+            // OS thread's fiber, so this child-side release is the only
+            // thing standing between thread-terminate! and permanently
+            // phantom demand on a channel other threads still use. Runs on
+            // the child thread; a promoted channel withdraws under the
+            // SharedChannel lock, safe from here.
+            fiber_mod.releaseFiberRendezvousToken(cf);
+        }
         // Built on this (owning) thread, mirroring thread-start!'s thunk
         // copy: this is the only place a channel raised in the exception
         // can legally promote (gc_instance == child_gc here, not the
@@ -502,7 +513,13 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
         return;
     };
 
-    if (child_vm.current_fiber) |cf| fiber_mod.abandonFiberMutexes(cf, child_vm.scheduler);
+    if (child_vm.current_fiber) |cf| {
+        fiber_mod.abandonFiberMutexes(cf, child_vm.scheduler);
+        // Normal completion cannot hold a token (the primitives release on
+        // their own exits) — symmetric no-op guard, mirroring the unwind
+        // path above.
+        fiber_mod.releaseFiberRendezvousToken(cf);
+    }
 
     // Store the result in child_resources (not on the fiber) so the parent
     // GC never traverses a child-heap pointer (Race C) -- and, since Phase

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -605,15 +605,32 @@ pub fn withdrawRvDemand(sc: *SharedChannel) void {
     unlockChannel(sc);
 }
 
-/// Lock-protected read of the in-flight reservation count, for the §6
-/// reservation-drain rule: a timed-out rendezvous receiver that observes
-/// reserved > 0 with an empty queue keeps waiting (the push — or the
-/// abort's ring, see send's failure path — redecides it) instead of
-/// stranding a send already past its point of no return.
-pub fn reservedCount(sc: *SharedChannel) u32 {
+pub const TimeoutWithdrawOutcome = enum {
+    /// The demand token (when held) was withdrawn — the timeout stands.
+    withdrawn,
+    /// A value is queued: delivery wins, the caller must receive it.
+    value_ready,
+    /// An admitted send is mid-copy (§6 reservation-drain): the caller
+    /// keeps waiting — the push or the abort rings it — and re-decides.
+    reservation_pending,
+};
+
+/// §6's timeout withdraw as ONE mutex section (model finding 6,
+/// kaappi#1604 review): the queue check (delivery-wins), the reservation
+/// check (drain), and the demand decrement must not be separate lock
+/// acquisitions — a sender could otherwise reserve against the still-held
+/// token after a separate `reserved == 0` observation and push into demand
+/// that no longer exists, reporting success into nowhere. With this
+/// operation the sender's §4 step-3/7 admission and the receiver's
+/// withdrawal serialize on the same lock: after `.withdrawn`, no send is
+/// ever admitted against the departed receiver.
+pub fn tryTimeoutWithdraw(sc: *SharedChannel, holds_token: bool) TimeoutWithdrawOutcome {
     lockChannel(sc);
     defer unlockChannel(sc);
-    return sc.reserved;
+    if (sc.queue_len > 0) return .value_ready;
+    if (sc.reserved > 0) return .reservation_pending;
+    if (holds_token) sc.rv_demand -= 1;
+    return .withdrawn;
 }
 
 pub const SendOutcome = union(enum) {
@@ -706,9 +723,21 @@ pub const RecvOutcome = union(enum) {
 
 /// KEP-0002 §4 receive, on the shared representation, verbatim. `notifier`
 /// follows send()'s same null-is-safe convention on the park branch.
-pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifier) !RecvOutcome {
+///
+/// `holds_token` (§4 receive step 3 as amended — model finding 5,
+/// kaappi#1604 review): true when the calling fiber holds this channel's
+/// rendezvous demand token. A pop then withdraws that demand in the SAME
+/// mutex section as the pop — the receiver is satisfied the moment it owns
+/// an envelope, and the freed-slot ring below must not be able to wake a
+/// sender into demand whose owner already has a value. The caller clears
+/// its fiber token field (never decrements again) on both the `.value`
+/// outcome AND the copy-failure error: the pop consumed the token either
+/// way (the raise is a terminal exit; the re-queued envelope falls under
+/// §6's abnormal-exit rule). Always false for non-rendezvous callers.
+pub fn receive(sc: *SharedChannel, dest_gc: *memory.GC, notifier: ?*ThreadNotifier, holds_token: bool) !RecvOutcome {
     lockChannel(sc);
     if (sc.popFront()) |env| {
+        if (holds_token) sc.rv_demand -= 1;
         var snap: std.ArrayList(*ThreadNotifier) = .empty;
         defer snap.deinit(std.heap.c_allocator);
         sc.snapshotAndClearSendWaiters(&snap); // a slot opened

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -243,9 +243,19 @@ pub const SharedChannel = struct {
     /// call in progress.
     reserved: u32 = 0,
     /// null = unbounded (KEP-0002 §6, `make-channel`'s optional capacity
-    /// argument). Set once, by promoteChannel, from the local
-    /// representation's own `capacity` field -- never mutated after.
+    /// argument). 0 = rendezvous (§6 as amended, kaappi#1601/#1603): the
+    /// admission bound is `rv_demand` instead. Set once, by promoteChannel,
+    /// from the local representation's own `capacity` field -- never
+    /// mutated after (which is what makes unlocked reads of it safe).
     capacity: ?u32 = null,
+    /// Rendezvous demand (capacity == 0 only; §4 receive step 7a as
+    /// amended): the number of receivers currently committed to this
+    /// channel. Guarded by `lock`. Seeded by promoteChannel from the local
+    /// rv_demand (a token acquired at a pre-promotion local park stays
+    /// counted); grown by commitRvDemand, shrunk by withdrawRvDemand --
+    /// both driven by the per-fiber token field, so the count is exactly
+    /// the outstanding tokens.
+    rv_demand: u32 = 0,
     /// KEP-0002 §6, `channel-close!`. Set once (true), by promoteChannel
     /// (carried over from an already-closed local channel) or by close().
     closed: bool = false,
@@ -316,7 +326,8 @@ pub const SharedChannel = struct {
         defer unlockChannel(self);
         if (self.closed) return true;
         const cap = self.capacity orelse return true;
-        return self.queue_len + self.reserved < cap;
+        const bound = if (cap == 0) self.rv_demand else cap;
+        return self.queue_len + self.reserved < bound;
     }
 
     /// KEP-0002 §6's `channel-closed?`, lock-protected like peekReady --
@@ -477,9 +488,14 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
     // KEP-0002 §6: carried over from the local representation before
     // publishing -- safe either way, since nothing can observe `sc` until
     // `ch.shared` is set below. `sc.queue_len` needs no equivalent copy: the
-    // drain loop below derives it correctly via pushBack.
+    // drain loop below derives it correctly via pushBack. rv_demand carries
+    // the tokens of receivers parked locally before promotion (§6 as
+    // amended, kaappi#1603): their per-fiber token fields still name this
+    // channel, so their post-migration retries release against this
+    // counter -- the copy is what keeps that accounting exact.
     sc.capacity = ch.capacity;
     sc.closed = ch.closed;
+    sc.rv_demand = ch.rv_demand;
     // Publish before draining (§2 step 2): a queued local message may
     // contain this very channel (e.g. (channel-send ch (list ch))). With
     // `shared` already set, the drain's own Envelope.create -> deepCopy
@@ -564,6 +580,42 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
     return sc;
 }
 
+/// §4 receive step 7a (KEP-0002 as amended, kaappi#1601/#1603), shared
+/// representation: commit a receiver — grow the demand and ring
+/// send_waiters exactly like a freed slot would (model finding 4: without
+/// this ring, senders parked against bound 0 before any receiver committed
+/// are never woken). Snapshot under the lock, rung after release, like
+/// every other ring. Called once per logical wait (the caller's per-fiber
+/// token field provides the idempotence).
+pub fn commitRvDemand(sc: *SharedChannel) void {
+    lockChannel(sc);
+    sc.rv_demand += 1;
+    var snap: std.ArrayList(*ThreadNotifier) = .empty;
+    defer snap.deinit(std.heap.c_allocator);
+    sc.snapshotAndClearSendWaiters(&snap);
+    unlockChannel(sc);
+    ring(snap.items);
+}
+
+/// Terminal-exit half of step 7a on the shared representation: a receiver's
+/// wait ended (value, eof, timeout, error, death) — withdraw its demand.
+pub fn withdrawRvDemand(sc: *SharedChannel) void {
+    lockChannel(sc);
+    sc.rv_demand -= 1;
+    unlockChannel(sc);
+}
+
+/// Lock-protected read of the in-flight reservation count, for the §6
+/// reservation-drain rule: a timed-out rendezvous receiver that observes
+/// reserved > 0 with an empty queue keeps waiting (the push — or the
+/// abort's ring, see send's failure path — redecides it) instead of
+/// stranding a send already past its point of no return.
+pub fn reservedCount(sc: *SharedChannel) u32 {
+    lockChannel(sc);
+    defer unlockChannel(sc);
+    return sc.reserved;
+}
+
 pub const SendOutcome = union(enum) {
     sent,
     would_park,
@@ -582,7 +634,11 @@ pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !Sen
         return .closed;
     }
     if (sc.capacity) |cap| {
-        if (sc.queue_len + sc.reserved >= cap) {
+        // §4 step 3 as amended (kaappi#1601): the admission bound is the
+        // capacity, or -- rendezvous (capacity 0) -- the committed receiver
+        // demand, so a send is admitted exactly when a receiver is waiting.
+        const bound = if (cap == 0) sc.rv_demand else cap;
+        if (sc.queue_len + sc.reserved >= bound) {
             if (notifier) |n| sc.registerSendWaiter(n);
             unlockChannel(sc);
             return .would_park;
@@ -615,10 +671,14 @@ pub fn send(sc: *SharedChannel, payload: Value, notifier: ?*ThreadNotifier) !Sen
         var snap: std.ArrayList(*ThreadNotifier) = .empty;
         defer snap.deinit(std.heap.c_allocator);
         sc.snapshotAndClearSendWaiters(&snap);
-        // A receiver may be parked waiting out this very reservation
-        // (receive step 6's reserved==0 eof guard) if the channel closed
-        // while this send was in flight.
-        if (sc.closed) sc.snapshotAndClearRecvWaiters(&snap);
+        // A receiver may be parked waiting out this very reservation: when
+        // the channel closed while this send was in flight (receive step
+        // 6's reserved==0 eof guard), and -- rendezvous, §6 as amended --
+        // always: a timed-out rendezvous receiver draining a reservation
+        // (the §6 reservation-drain rule) must be rung by the abort as
+        // well as the push, or its wait would outlive the timeout it was
+        // given.
+        if (sc.closed or (sc.capacity orelse 1) == 0) sc.snapshotAndClearRecvWaiters(&snap);
         unlockChannel(sc);
         ring(snap.items);
         // Nothing was enqueued ("send fails ⇒ nothing sent"); Envelope

--- a/src/stress_channel.zig
+++ b/src/stress_channel.zig
@@ -86,7 +86,7 @@ const Consumer = struct {
         defer local_gc.deinit();
 
         while (self.count.load(.monotonic) < self.target_total) {
-            const outcome = shared_channel.receive(self.sc, &local_gc, notifier) catch |err|
+            const outcome = shared_channel.receive(self.sc, &local_gc, notifier, false) catch |err|
                 fail("consumer: receive failed: {t} (seed={d})\n", .{ err, seed });
             switch (outcome) {
                 .value => |v| {

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -346,13 +346,24 @@ test "rendezvous channel: parked timed senders pair under a nested main receive"
     defer vm.deinit();
 
     _ = try vm.eval("(define ch (make-channel 0))");
-    _ = try vm.eval("(define s1 (spawn (lambda () (channel-send ch 'a 0.5 'ta))))");
-    _ = try vm.eval("(define s2 (spawn (lambda () (channel-send ch 'b 0.5 'tb))))");
+    _ = try vm.eval("(define s1 (spawn (lambda () (if (eq? (channel-send ch 'a 0.4 'ta) 'ta) 'ta 'sent-a))))");
+    _ = try vm.eval("(define s2 (spawn (lambda () (if (eq? (channel-send ch 'b 0.4 'tb) 'tb) 'tb 'sent-b))))");
     _ = try vm.eval("(yield)");
-    const got = try vm.eval("(channel-receive ch)");
+    // One-demand/one-send admission (#1604 review): joining both senders
+    // pins EXACTLY one delivery and one timeout, and the final probe pins
+    // that no second value was admitted and stranded — the two ways
+    // findings 5/6 would have manifested here.
+    const summary = try vm.eval(
+        \\(let* ((got (channel-receive ch))
+        \\       (r1 (fiber-join s1))
+        \\       (r2 (fiber-join s2))
+        \\       (rest (channel-receive ch 0.05 'empty)))
+        \\  (list got r1 r2 rest))
+    );
     const printer = @import("printer.zig");
-    const s = try printer.valueToString(std.testing.allocator, got, .write);
+    const s = try printer.valueToString(std.testing.allocator, summary, .write);
     defer std.testing.allocator.free(s);
-    const one_of = std.mem.eql(u8, s, "a") or std.mem.eql(u8, s, "b");
-    try std.testing.expect(one_of);
+    const ok = std.mem.eql(u8, s, "(a sent-a tb empty)") or
+        std.mem.eql(u8, s, "(b ta sent-b empty)");
+    try std.testing.expect(ok);
 }

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -251,3 +251,108 @@ test "processor-count returns a positive fixnum" {
     // import needed, same as any other registered primitive.
     try th.expectEvalTrue("(and (integer? (processor-count)) (exact? (processor-count)) (> (processor-count) 0))");
 }
+
+// Rendezvous channels (KEP-0002 §6 as amended; #1600/#1601/#1602):
+// (make-channel 0) pairs a sender with a committed receiver instead of the
+// pre-amendment "permanently full" degenerate behavior.
+
+test "rendezvous channel: fiber sender pairs with main receiver (#1600 repro)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define ch (make-channel 0))");
+    _ = try vm.eval("(spawn (lambda () (channel-send ch 41)))");
+    const result = try vm.eval("(+ 1 (channel-receive ch))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "rendezvous channel: main sender pairs with fiber receiver" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define ch (make-channel 0))");
+    _ = try vm.eval("(define f (spawn (lambda () (channel-receive ch))))");
+    _ = try vm.eval("(channel-send ch 7)");
+    const result = try vm.eval("(fiber-join f)");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(result));
+}
+
+test "rendezvous channel: demand token accounting stays balanced" {
+    // The §4 step 7a token discipline: every terminal exit of a receive —
+    // timeout, guarded deadlock raise, delivered value — must leave
+    // rv_demand at zero once no receiver is committed. A leak here admits
+    // sends nobody will ever collect.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define ch (make-channel 0))");
+    const ch_val = try vm.eval("ch");
+    const ch = types.toObject(ch_val).as(types.Channel);
+
+    // timed-out receive releases its token
+    _ = try vm.eval("(channel-receive ch 0.02 'to)");
+    try std.testing.expectEqual(@as(u32, 0), ch.rv_demand);
+
+    // a guarded deadlock raise releases too
+    _ = try vm.eval("(guard (e (#t 'dead)) (channel-receive ch))");
+    try std.testing.expectEqual(@as(u32, 0), ch.rv_demand);
+
+    // a completed handoff releases the receiver's token
+    _ = try vm.eval("(spawn (lambda () (channel-send ch 'v)))");
+    _ = try vm.eval("(channel-receive ch)");
+    try std.testing.expectEqual(@as(u32, 0), ch.rv_demand);
+    try std.testing.expectEqual(@as(u32, 0), ch.queue_len);
+}
+
+test "rendezvous channel: timed-out receive leaves no phantom demand for senders" {
+    // Pure-behavior twin of the accounting test: if the timed-out
+    // receiver's token leaked, the later timed send would be admitted and
+    // strand its value; if a value were stranded, the final receive would
+    // return it instead of timing out.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(let ((ch (make-channel 0)))
+        \\  (list (channel-receive ch 0.02 'rto)
+        \\        (channel-send ch 'v 0.02 'sto)
+        \\        (channel-receive ch 0.02 'empty)))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(rto sto empty)", s);
+}
+
+test "rendezvous channel: parked timed senders pair under a nested main receive" {
+    // Regression for the frozen-ancestor interleaving found while testing
+    // #1602: two *timed* sends used to park in-call (driving), the main
+    // fiber's receive was dispatched as the innermost nested frame, and its
+    // demand-wake could never reach the driving ancestors (#1487) — the
+    // receive raised a spurious KP3000 deadlock with two viable senders
+    // frozen beneath it. The flat yield_retry park keeps every rendezvous
+    // waiter dispatchable.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define ch (make-channel 0))");
+    _ = try vm.eval("(define s1 (spawn (lambda () (channel-send ch 'a 0.5 'ta))))");
+    _ = try vm.eval("(define s2 (spawn (lambda () (channel-send ch 'b 0.5 'tb))))");
+    _ = try vm.eval("(yield)");
+    const got = try vm.eval("(channel-receive ch)");
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, got, .write);
+    defer std.testing.allocator.free(s);
+    const one_of = std.mem.eql(u8, s, "a") or std.mem.eql(u8, s, "b");
+    try std.testing.expect(one_of);
+}

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -1569,3 +1569,114 @@ test "KEP-0002 Phase 3 (#1468): main thread receives values sent concurrently by
     try std.testing.expectEqual(baseline, shared_object.liveCount());
     try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
 }
+
+// Rendezvous on the shared representation (KEP-0002 §6 as amended;
+// #1600/#1601/#1603): capacity 0 admits a send exactly when a receiver has
+// committed demand.
+
+test "shared rendezvous: raw protocol admits only against committed demand" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+    sc.capacity = 0;
+
+    // no demand: would_park, nothing enqueued
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(1), null));
+
+    // one committed receiver: exactly one send admitted
+    shared_channel.commitRvDemand(sc);
+    try std.testing.expectEqual(shared_channel.SendOutcome.sent, try shared_channel.send(sc, types.makeFixnum(2), null));
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(3), null));
+
+    // the committed receiver collects the handoff and withdraws
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    const got = try shared_channel.receive(sc, &gc, null);
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(got.value));
+    shared_channel.withdrawRvDemand(sc);
+
+    // demand gone again: back to would_park
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(4), null));
+
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "shared rendezvous: promotion seeds rv_demand from the local counter" {
+    // A receiver parked on the local representation before promotion holds
+    // a demand token counted in ch.rv_demand; promoteChannel must carry it
+    // so a remote sender's admission sees the migrated receiver (§2 step 4
+    // + §6 as amended).
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define ch (make-channel 0))");
+    const ch_val = try ctx.vm.eval("ch");
+    const ch = types.toObject(ch_val).as(types.Channel);
+
+    // Park a fiber receiver locally: it commits a demand token.
+    _ = try ctx.vm.eval("(define r (spawn (lambda () (channel-receive ch))))");
+    _ = try ctx.vm.eval("(yield)");
+    try std.testing.expectEqual(@as(u32, 1), ch.rv_demand);
+
+    const sc = try shared_channel.promoteChannel(&ctx.gc, ch);
+    try std.testing.expectEqual(@as(u32, 1), sc.rv_demand);
+
+    // A raw remote-style send is admitted against the migrated demand and
+    // the parked receiver collects it through the normal primitive path.
+    try std.testing.expectEqual(shared_channel.SendOutcome.sent, try shared_channel.send(sc, types.makeFixnum(9), null));
+    const joined = try ctx.vm.eval("(fiber-join r)");
+    try std.testing.expectEqual(@as(i64, 9), types.toFixnum(joined));
+    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
+}
+
+test "shared rendezvous: timed-out receive withdraws demand on the promoted channel" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define ch (make-channel 0))");
+    const ch_val = try ctx.vm.eval("ch");
+    const ch = types.toObject(ch_val).as(types.Channel);
+    const sc = try shared_channel.promoteChannel(&ctx.gc, ch);
+
+    const result = try ctx.vm.eval("(channel-receive ch 0.02 'rto)");
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("rto", s);
+    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
+
+    // and the send side still refuses admission afterwards
+    const sres = try ctx.vm.eval("(channel-send ch 'v 0.02 'sto)");
+    const s2 = try printer.valueToString(std.testing.allocator, sres, .write);
+    defer std.testing.allocator.free(s2);
+    try std.testing.expectEqualStrings("sto", s2);
+    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
+}
+
+test "shared rendezvous: cross-thread handoff both directions" {
+    // The #1600 scenario on real OS threads, channel captured by the thunk
+    // (the KEP-0002 §2 legal sharing path — a top-level global would fail
+    // the foreign-owner check instead of promoting).
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const got = try ctx.vm.eval(
+        \\(let* ((ch (make-channel 0))
+        \\       (t (thread-start! (make-thread (lambda () (channel-send ch 41))))))
+        \\  (let ((v (+ 1 (channel-receive ch))))
+        \\    (thread-join! t) ; join releases the child VM/GC (child_resources)
+        \\    v))
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(got));
+
+    const got2 = try ctx.vm.eval(
+        \\(let* ((ch (make-channel 0))
+        \\       (t (thread-start! (make-thread (lambda () (channel-receive ch))))))
+        \\  (channel-send ch 7)
+        \\  (thread-join! t))
+    );
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(got2));
+}

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -281,7 +281,7 @@ test "reply-to worked example (§1): the received half, with the rc 1->2->3->2 p
     // against an envelope-owned stub (obj.owner = the envelope GC's id, not
     // memory.gc_instance) -- exactly why the alias path deliberately skips
     // the ownership check.
-    const recv_outcome = try shared_channel.receive(tasks_sc, &dest_gc, null);
+    const recv_outcome = try shared_channel.receive(tasks_sc, &dest_gc, null, false);
     const received_val = switch (recv_outcome) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
@@ -407,7 +407,7 @@ test "instrument lever C: an immediate payload skips the envelope heap (kaappi#1
     instrument.setLever(.none);
     _ = try shared_channel.send(sc, types.makeFixnum(42), null);
     try std.testing.expect(sc.queue_head.?.gc != null);
-    const r0 = try shared_channel.receive(sc, &dest_gc, null);
+    const r0 = try shared_channel.receive(sc, &dest_gc, null, false);
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(r0.value));
 
     // Lever C: the same immediate skips the heap entirely (gc == null) and
@@ -415,7 +415,7 @@ test "instrument lever C: an immediate payload skips the envelope heap (kaappi#1
     instrument.setLever(.c);
     _ = try shared_channel.send(sc, types.makeFixnum(7), null);
     try std.testing.expect(sc.queue_head.?.gc == null);
-    const r1 = try shared_channel.receive(sc, &dest_gc, null);
+    const r1 = try shared_channel.receive(sc, &dest_gc, null, false);
     try std.testing.expectEqual(@as(i64, 7), types.toFixnum(r1.value));
 
     // A pointer payload still takes the heap path under lever C.
@@ -424,7 +424,7 @@ test "instrument lever C: an immediate payload skips the envelope heap (kaappi#1
     const pair = try src_gc.allocPair(types.makeFixnum(1), types.NIL);
     _ = try shared_channel.send(sc, pair, null);
     try std.testing.expect(sc.queue_head.?.gc != null);
-    _ = try shared_channel.receive(sc, &dest_gc, null);
+    _ = try shared_channel.receive(sc, &dest_gc, null, false);
 
     sc.release();
     try std.testing.expectEqual(baseline, shared_object.liveCount());
@@ -454,7 +454,7 @@ test "lever C shipped default: immediates skip the envelope heap, pointers keep 
     for (immediates) |imm| {
         _ = try shared_channel.send(sc, imm, null);
         try std.testing.expect(sc.queue_head.?.gc == null);
-        const r = try shared_channel.receive(sc, &dest_gc, null);
+        const r = try shared_channel.receive(sc, &dest_gc, null, false);
         try std.testing.expectEqual(imm, r.value);
     }
 
@@ -464,7 +464,7 @@ test "lever C shipped default: immediates skip the envelope heap, pointers keep 
     const pair = try src_gc.allocPair(types.makeFixnum(1), types.NIL);
     _ = try shared_channel.send(sc, pair, null);
     try std.testing.expect(sc.queue_head.?.gc != null);
-    _ = try shared_channel.receive(sc, &dest_gc, null);
+    _ = try shared_channel.receive(sc, &dest_gc, null, false);
 
     sc.release();
     // No envelope heap leaks (an immediate envelope owns no GC to destroy).
@@ -494,7 +494,7 @@ test "instrument lever D: a large bytevector crosses by shared buffer, then copi
 
     var dest_gc = memory.GC.init(std.testing.allocator);
     defer dest_gc.deinit();
-    const recv = try shared_channel.receive(sc, &dest_gc, null);
+    const recv = try shared_channel.receive(sc, &dest_gc, null, false);
     const recv_bv = types.toObject(recv.value).as(types.Bytevector);
     // Receive side: aliased the SAME buffer (no new snapshot), bytes intact.
     try std.testing.expect(recv_bv.shared == shared_ptr);
@@ -548,7 +548,7 @@ test "lever B arena: a receive parks its GC, the next send reuses it, symbol-bea
     try std.testing.expect(sc.cached_gc.load(.acquire) == null);
     const g1 = sc.queue_head.?.gc.?; // the envelope's freshly-allocated arena GC
 
-    const r1 = try shared_channel.receive(sc, &dest_gc, null);
+    const r1 = try shared_channel.receive(sc, &dest_gc, null, false);
     try expectSymbolNamed(types.car(r1.value), "foo");
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(types.cdr(r1.value)));
     // receive reset g1 and parked it in the cache for reuse.
@@ -563,7 +563,7 @@ test "lever B arena: a receive parks its GC, the next send reuses it, symbol-bea
     try std.testing.expect(sc.queue_head.?.gc.? == g1); // REUSE: same arena GC
     try std.testing.expect(sc.cached_gc.load(.acquire) == null); // taken by the send
 
-    const r2 = try shared_channel.receive(sc, &dest_gc, null);
+    const r2 = try shared_channel.receive(sc, &dest_gc, null, false);
     try expectSymbolNamed(types.car(r2.value), "bar");
     try std.testing.expectEqual(@as(i64, 2), types.toFixnum(types.cdr(r2.value)));
 
@@ -571,7 +571,7 @@ test "lever B arena: a receive parks its GC, the next send reuses it, symbol-bea
     // gone, so this interns a fresh live symbol rather than aliasing the first.
     const msg3 = try src_gc.allocPair(try src_gc.allocSymbol("foo"), types.makeFixnum(3));
     _ = try shared_channel.send(sc, msg3, null);
-    const r3 = try shared_channel.receive(sc, &dest_gc, null);
+    const r3 = try shared_channel.receive(sc, &dest_gc, null, false);
     try expectSymbolNamed(types.car(r3.value), "foo");
     try std.testing.expectEqual(@as(i64, 3), types.toFixnum(types.cdr(r3.value)));
 
@@ -640,7 +640,7 @@ test "receive: pops a non-empty queue and deep-copies into the destination gc" {
     src_gc.deinit();
 
     var dest_gc = memory.GC.init(std.testing.allocator);
-    const outcome = try shared_channel.receive(sc, &dest_gc, null);
+    const outcome = try shared_channel.receive(sc, &dest_gc, null, false);
     const value = switch (outcome) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
@@ -666,7 +666,7 @@ test "receive: copy-out failure re-queues the envelope at the head (receive fail
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
     dest_gc.allocator = failing.allocator();
 
-    try std.testing.expectError(error.OutOfMemory, shared_channel.receive(sc, &dest_gc, null));
+    try std.testing.expectError(error.OutOfMemory, shared_channel.receive(sc, &dest_gc, null, false));
     try std.testing.expectEqual(@as(u32, 1), sc.queue_len); // FIFO preserved: still queued
 
     dest_gc.allocator = std.testing.allocator; // restore before deinit (matches how it was built)
@@ -674,7 +674,7 @@ test "receive: copy-out failure re-queues the envelope at the head (receive fail
 
     // The message is still deliverable, in order, on a subsequent receive.
     var dest_gc2 = memory.GC.init(std.testing.allocator);
-    const outcome = try shared_channel.receive(sc, &dest_gc2, null);
+    const outcome = try shared_channel.receive(sc, &dest_gc2, null, false);
     const value = switch (outcome) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
@@ -693,7 +693,7 @@ test "receive: empty and closed with reserved==0 returns eof" {
     var dest_gc = memory.GC.init(std.testing.allocator);
     defer dest_gc.deinit();
 
-    const outcome = try shared_channel.receive(sc, &dest_gc, null);
+    const outcome = try shared_channel.receive(sc, &dest_gc, null, false);
     try std.testing.expectEqual(shared_channel.RecvOutcome.eof, outcome);
 
     sc.release();
@@ -708,7 +708,7 @@ test "receive: empty and open registers a recv waiter and would park" {
     defer reactor.deinit();
     const notifier = reactor.notifyHandle();
 
-    const outcome = try shared_channel.receive(sc, &dest_gc, notifier);
+    const outcome = try shared_channel.receive(sc, &dest_gc, notifier, false);
     try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, outcome);
     try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
     try std.testing.expectEqual(@as(u32, 2), notifier.refcount.load(.monotonic));
@@ -729,13 +729,13 @@ test "receive: copy-out failure re-queues at the head under a bounded channel to
     var dest_gc = memory.GC.init(std.testing.allocator);
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
     dest_gc.allocator = failing.allocator();
-    try std.testing.expectError(error.OutOfMemory, shared_channel.receive(sc, &dest_gc, null));
+    try std.testing.expectError(error.OutOfMemory, shared_channel.receive(sc, &dest_gc, null, false));
     dest_gc.allocator = std.testing.allocator;
     dest_gc.deinit();
     try std.testing.expectEqual(@as(u32, 1), sc.queue_len); // FIFO preserved: still at capacity, not over
 
     var dest_gc2 = memory.GC.init(std.testing.allocator);
-    const value = switch (try shared_channel.receive(sc, &dest_gc2, null)) {
+    const value = switch (try shared_channel.receive(sc, &dest_gc2, null, false)) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
     };
@@ -781,14 +781,14 @@ test "required regression: bounded channel tolerates the documented transient ca
 
     // The overshoot drains with ordinary receives, FIFO order intact.
     var dest_gc = memory.GC.init(std.testing.allocator);
-    const first = switch (try shared_channel.receive(sc, &dest_gc, null)) {
+    const first = switch (try shared_channel.receive(sc, &dest_gc, null, false)) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
     };
     try std.testing.expectEqual(@as(i64, 11), types.toFixnum(types.car(first)));
     try std.testing.expectEqual(@as(u32, 1), sc.queue_len); // exactly at capacity now
 
-    const second = switch (try shared_channel.receive(sc, &dest_gc, null)) {
+    const second = switch (try shared_channel.receive(sc, &dest_gc, null, false)) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
     };
@@ -810,7 +810,7 @@ test "close: idempotent and wakes both waiter lists" {
 
     var dest_gc = memory.GC.init(std.testing.allocator);
     defer dest_gc.deinit();
-    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, try shared_channel.receive(sc, &dest_gc, notifier));
+    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, try shared_channel.receive(sc, &dest_gc, notifier, false));
     try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(1), notifier));
     try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
     try std.testing.expectEqual(@as(usize, 1), sc.send_waiters.items.len);
@@ -905,14 +905,14 @@ test "required regression: reserve, concurrent close, and the admitted push stil
     // eof: reserved is now 0, but the message is sitting in the queue and
     // is checked first.
     var dest_gc = memory.GC.init(std.testing.allocator);
-    const value = switch (try shared_channel.receive(sc, &dest_gc, null)) {
+    const value = switch (try shared_channel.receive(sc, &dest_gc, null, false)) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
     };
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(types.car(value)));
 
     // Only now, with the queue drained and reserved == 0, does eof appear.
-    try std.testing.expectEqual(shared_channel.RecvOutcome.eof, try shared_channel.receive(sc, &dest_gc, null));
+    try std.testing.expectEqual(shared_channel.RecvOutcome.eof, try shared_channel.receive(sc, &dest_gc, null, false));
 
     dest_gc.deinit();
     sc.release();
@@ -942,7 +942,7 @@ test "required regression: workers looping until eof all see the admitted messag
     var eof_count: u32 = 0;
     var i: u32 = 0;
     while (i < 4) : (i += 1) {
-        switch (try shared_channel.receive(sc, &dest_gc, null)) {
+        switch (try shared_channel.receive(sc, &dest_gc, null, false)) {
             .value => |v| {
                 try std.testing.expectEqual(@as(i64, 7), types.toFixnum(types.car(v)));
                 value_count += 1;
@@ -977,7 +977,7 @@ test "required regression: copy failure of the last reserved send on a closed ch
     // reserved==0 guard, exercised the ordinary way here).
     var dest_gc = memory.GC.init(std.testing.allocator);
     defer dest_gc.deinit();
-    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, try shared_channel.receive(sc, &dest_gc, notifier));
+    try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, try shared_channel.receive(sc, &dest_gc, notifier, false));
     try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
 
     // The in-flight send's own copy now fails. send()'s real failure path
@@ -996,7 +996,7 @@ test "required regression: copy failure of the last reserved send on a closed ch
 
     // Retrying now, as the woken receiver would, observes reserved == 0
     // and returns eof -- not a hang.
-    try std.testing.expectEqual(shared_channel.RecvOutcome.eof, try shared_channel.receive(sc, &dest_gc, null));
+    try std.testing.expectEqual(shared_channel.RecvOutcome.eof, try shared_channel.receive(sc, &dest_gc, null, false));
 
     sc.release();
     // Explicit, not deferred -- must run before the leak-count checks
@@ -1236,7 +1236,7 @@ test "KEP-0002 Phase 2: an exception raised in the child carrying a channel prom
         // different code path than the "channel created and returned"
         // test above (whose channel is empty until inside the envelope).
         const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(inner_ch.shared.?));
-        const recv_outcome = try shared_channel.receive(sc, &ctx.gc, null);
+        const recv_outcome = try shared_channel.receive(sc, &ctx.gc, null, false);
         const drained = switch (recv_outcome) {
             .value => |v| v,
             else => return error.TestUnexpectedResult,
@@ -1387,7 +1387,7 @@ test "required regression: a rung receiver that loses the pop race re-parks and 
     var dest_gc_a = memory.GC.init(std.testing.allocator);
 
     // Receiver A finds the queue empty and registers.
-    const outcome1 = try shared_channel.receive(sc, &dest_gc_a, notifier);
+    const outcome1 = try shared_channel.receive(sc, &dest_gc_a, notifier, false);
     try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, outcome1);
     try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
 
@@ -1401,7 +1401,7 @@ test "required regression: a rung receiver that loses the pop race re-parks and 
     // first. This is exactly what "loses the pop race" means: A was rung,
     // but by the time it gets to retry, nothing is left.
     var dest_gc_fast = memory.GC.init(std.testing.allocator);
-    const fast_outcome = try shared_channel.receive(sc, &dest_gc_fast, null);
+    const fast_outcome = try shared_channel.receive(sc, &dest_gc_fast, null, false);
     const fast_value = switch (fast_outcome) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
@@ -1411,13 +1411,13 @@ test "required regression: a rung receiver that loses the pop race re-parks and 
     // A retries -- exactly what channelReceiveShared's loop does after
     // runSchedulerStep returns: the queue is empty again, so it must
     // re-register, not treat "I was woken" as "a value is waiting for me".
-    const outcome2 = try shared_channel.receive(sc, &dest_gc_a, notifier);
+    const outcome2 = try shared_channel.receive(sc, &dest_gc_a, notifier, false);
     try std.testing.expectEqual(shared_channel.RecvOutcome.would_park, outcome2);
     try std.testing.expectEqual(@as(usize, 1), sc.recv_waiters.items.len);
 
     // A subsequent send correctly wakes A again -- no lost wakeup.
     _ = try shared_channel.send(sc, types.makeFixnum(9), null);
-    const outcome3 = try shared_channel.receive(sc, &dest_gc_a, notifier);
+    const outcome3 = try shared_channel.receive(sc, &dest_gc_a, notifier, false);
     const final_value = switch (outcome3) {
         .value => |v| v,
         else => return error.TestUnexpectedResult,
@@ -1481,7 +1481,7 @@ test "N producers / M consumers stress on the raw SharedChannel/ThreadNotifier p
             defer local_gc.deinit();
 
             while (count.load(.monotonic) < target_total) {
-                const outcome = shared_channel.receive(s, &local_gc, local_notifier) catch unreachable;
+                const outcome = shared_channel.receive(s, &local_gc, local_notifier, false) catch unreachable;
                 switch (outcome) {
                     .value => |v| {
                         const val = types.toFixnum(v);
@@ -1568,115 +1568,4 @@ test "KEP-0002 Phase 3 (#1468): main thread receives values sent concurrently by
     }
     try std.testing.expectEqual(baseline, shared_object.liveCount());
     try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
-}
-
-// Rendezvous on the shared representation (KEP-0002 §6 as amended;
-// #1600/#1601/#1603): capacity 0 admits a send exactly when a receiver has
-// committed demand.
-
-test "shared rendezvous: raw protocol admits only against committed demand" {
-    const baseline = shared_object.liveCount();
-    const sc = try shared_channel.SharedChannel.create();
-    sc.capacity = 0;
-
-    // no demand: would_park, nothing enqueued
-    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(1), null));
-
-    // one committed receiver: exactly one send admitted
-    shared_channel.commitRvDemand(sc);
-    try std.testing.expectEqual(shared_channel.SendOutcome.sent, try shared_channel.send(sc, types.makeFixnum(2), null));
-    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(3), null));
-
-    // the committed receiver collects the handoff and withdraws
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    const got = try shared_channel.receive(sc, &gc, null);
-    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(got.value));
-    shared_channel.withdrawRvDemand(sc);
-
-    // demand gone again: back to would_park
-    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(4), null));
-
-    sc.release();
-    try std.testing.expectEqual(baseline, shared_object.liveCount());
-}
-
-test "shared rendezvous: promotion seeds rv_demand from the local counter" {
-    // A receiver parked on the local representation before promotion holds
-    // a demand token counted in ch.rv_demand; promoteChannel must carry it
-    // so a remote sender's admission sees the migrated receiver (§2 step 4
-    // + §6 as amended).
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-
-    _ = try ctx.vm.eval("(define ch (make-channel 0))");
-    const ch_val = try ctx.vm.eval("ch");
-    const ch = types.toObject(ch_val).as(types.Channel);
-
-    // Park a fiber receiver locally: it commits a demand token.
-    _ = try ctx.vm.eval("(define r (spawn (lambda () (channel-receive ch))))");
-    _ = try ctx.vm.eval("(yield)");
-    try std.testing.expectEqual(@as(u32, 1), ch.rv_demand);
-
-    const sc = try shared_channel.promoteChannel(&ctx.gc, ch);
-    try std.testing.expectEqual(@as(u32, 1), sc.rv_demand);
-
-    // A raw remote-style send is admitted against the migrated demand and
-    // the parked receiver collects it through the normal primitive path.
-    try std.testing.expectEqual(shared_channel.SendOutcome.sent, try shared_channel.send(sc, types.makeFixnum(9), null));
-    const joined = try ctx.vm.eval("(fiber-join r)");
-    try std.testing.expectEqual(@as(i64, 9), types.toFixnum(joined));
-    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
-}
-
-test "shared rendezvous: timed-out receive withdraws demand on the promoted channel" {
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-
-    _ = try ctx.vm.eval("(define ch (make-channel 0))");
-    const ch_val = try ctx.vm.eval("ch");
-    const ch = types.toObject(ch_val).as(types.Channel);
-    const sc = try shared_channel.promoteChannel(&ctx.gc, ch);
-
-    const result = try ctx.vm.eval("(channel-receive ch 0.02 'rto)");
-    const printer = @import("printer.zig");
-    const s = try printer.valueToString(std.testing.allocator, result, .write);
-    defer std.testing.allocator.free(s);
-    try std.testing.expectEqualStrings("rto", s);
-    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
-
-    // and the send side still refuses admission afterwards
-    const sres = try ctx.vm.eval("(channel-send ch 'v 0.02 'sto)");
-    const s2 = try printer.valueToString(std.testing.allocator, sres, .write);
-    defer std.testing.allocator.free(s2);
-    try std.testing.expectEqualStrings("sto", s2);
-    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
-}
-
-test "shared rendezvous: cross-thread handoff both directions" {
-    // The #1600 scenario on real OS threads, channel captured by the thunk
-    // (the KEP-0002 §2 legal sharing path — a top-level global would fail
-    // the foreign-owner check instead of promoting).
-    var ctx: th.TestContext = undefined;
-    try ctx.init();
-    defer ctx.deinit();
-
-    const got = try ctx.vm.eval(
-        \\(let* ((ch (make-channel 0))
-        \\       (t (thread-start! (make-thread (lambda () (channel-send ch 41))))))
-        \\  (let ((v (+ 1 (channel-receive ch))))
-        \\    (thread-join! t) ; join releases the child VM/GC (child_resources)
-        \\    v))
-    );
-    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(got));
-
-    const got2 = try ctx.vm.eval(
-        \\(let* ((ch (make-channel 0))
-        \\       (t (thread-start! (make-thread (lambda () (channel-receive ch))))))
-        \\  (channel-send ch 7)
-        \\  (thread-join! t))
-    );
-    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(got2));
 }

--- a/src/tests_shared_channel_rendezvous.zig
+++ b/src/tests_shared_channel_rendezvous.zig
@@ -1,0 +1,240 @@
+const std = @import("std");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const shared_channel = @import("shared_channel.zig");
+const shared_object = @import("shared_object.zig");
+const th = @import("testing_helpers.zig");
+
+// Rendezvous on the shared representation (KEP-0002 §6 as amended;
+// #1600/#1601/#1603, review findings 5-6 from #1604): capacity 0 admits a
+// send exactly when a receiver has committed demand. Split out of
+// tests_shared_channel.zig along the rendezvous seam (1500-line policy;
+// the tests_native.zig split, #1595, is the precedent). Follows the same
+// conventions: bare-GC tests for the raw protocol, th.TestContext where a
+// VM drives the primitives, and every SharedChannel balanced against a
+// liveCount baseline.
+
+test "shared rendezvous: raw protocol admits only against committed demand" {
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+    sc.capacity = 0;
+
+    // no demand: would_park, nothing enqueued
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(1), null));
+
+    // one committed receiver: exactly one send admitted
+    shared_channel.commitRvDemand(sc);
+    try std.testing.expectEqual(shared_channel.SendOutcome.sent, try shared_channel.send(sc, types.makeFixnum(2), null));
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(3), null));
+
+    // the committed receiver collects the handoff and withdraws
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    const got = try shared_channel.receive(sc, &gc, null, false);
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(got.value));
+    shared_channel.withdrawRvDemand(sc);
+
+    // demand gone again: back to would_park
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(4), null));
+
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "shared rendezvous: promotion seeds rv_demand from the local counter" {
+    // A receiver parked on the local representation before promotion holds
+    // a demand token counted in ch.rv_demand; promoteChannel must carry it
+    // so a remote sender's admission sees the migrated receiver (§2 step 4
+    // + §6 as amended).
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define ch (make-channel 0))");
+    const ch_val = try ctx.vm.eval("ch");
+    const ch = types.toObject(ch_val).as(types.Channel);
+
+    // Park a fiber receiver locally: it commits a demand token.
+    _ = try ctx.vm.eval("(define r (spawn (lambda () (channel-receive ch))))");
+    _ = try ctx.vm.eval("(yield)");
+    try std.testing.expectEqual(@as(u32, 1), ch.rv_demand);
+
+    const sc = try shared_channel.promoteChannel(&ctx.gc, ch);
+    try std.testing.expectEqual(@as(u32, 1), sc.rv_demand);
+
+    // A raw remote-style send is admitted against the migrated demand and
+    // the parked receiver collects it through the normal primitive path.
+    try std.testing.expectEqual(shared_channel.SendOutcome.sent, try shared_channel.send(sc, types.makeFixnum(9), null));
+    const joined = try ctx.vm.eval("(fiber-join r)");
+    try std.testing.expectEqual(@as(i64, 9), types.toFixnum(joined));
+    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
+}
+
+test "shared rendezvous: timed-out receive withdraws demand on the promoted channel" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define ch (make-channel 0))");
+    const ch_val = try ctx.vm.eval("ch");
+    const ch = types.toObject(ch_val).as(types.Channel);
+    const sc = try shared_channel.promoteChannel(&ctx.gc, ch);
+
+    const result = try ctx.vm.eval("(channel-receive ch 0.02 'rto)");
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("rto", s);
+    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
+
+    // and the send side still refuses admission afterwards
+    const sres = try ctx.vm.eval("(channel-send ch 'v 0.02 'sto)");
+    const s2 = try printer.valueToString(std.testing.allocator, sres, .write);
+    defer std.testing.allocator.free(s2);
+    try std.testing.expectEqualStrings("sto", s2);
+    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
+}
+
+test "shared rendezvous: cross-thread handoff both directions" {
+    // The #1600 scenario on real OS threads, channel captured by the thunk
+    // (the KEP-0002 §2 legal sharing path — a top-level global would fail
+    // the foreign-owner check instead of promoting).
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const got = try ctx.vm.eval(
+        \\(let* ((ch (make-channel 0))
+        \\       (t (thread-start! (make-thread (lambda () (channel-send ch 41))))))
+        \\  (let ((v (+ 1 (channel-receive ch))))
+        \\    (thread-join! t) ; join releases the child VM/GC (child_resources)
+        \\    v))
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(got));
+
+    const got2 = try ctx.vm.eval(
+        \\(let* ((ch (make-channel 0))
+        \\       (t (thread-start! (make-thread (lambda () (channel-receive ch))))))
+        \\  (channel-send ch 7)
+        \\  (thread-join! t))
+    );
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(got2));
+}
+
+test "shared rendezvous: a token-holding pop withdraws demand with the pop (finding 5)" {
+    // Model finding 5 (rv2_popwindow): with the withdraw deferred to the
+    // receiver's own exit, the window between the pop and the withdraw kept
+    // the token counted and admitted a second send against an
+    // already-satisfied receiver. receive(holds_token = true) must close
+    // the window inside the pop's mutex section.
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+    sc.capacity = 0;
+
+    shared_channel.commitRvDemand(sc);
+    try std.testing.expectEqual(shared_channel.SendOutcome.sent, try shared_channel.send(sc, types.makeFixnum(1), null));
+
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    const got = try shared_channel.receive(sc, &gc, null, true);
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(got.value));
+    // The pop consumed the token: demand is already zero, and a second
+    // send is NOT admitted — pre-fix it was, and its value stranded.
+    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
+    try std.testing.expectEqual(shared_channel.SendOutcome.would_park, try shared_channel.send(sc, types.makeFixnum(2), null));
+    try std.testing.expectEqual(@as(u32, 0), sc.queue_len);
+
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "shared rendezvous: tryTimeoutWithdraw is one lock section (finding 6)" {
+    // Model finding 6 (rva_naive): a reservedCount() peek followed by a
+    // separate withdraw let a sender reserve against the still-held token
+    // in between. The single operation decides queue / reservation /
+    // withdraw under one lock; this exercises its three outcomes.
+    const baseline = shared_object.liveCount();
+    const sc = try shared_channel.SharedChannel.create();
+    sc.capacity = 0;
+
+    // (1) idle: withdraws the held token.
+    shared_channel.commitRvDemand(sc);
+    try std.testing.expectEqual(shared_channel.TimeoutWithdrawOutcome.withdrawn, shared_channel.tryTimeoutWithdraw(sc, true));
+    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
+
+    // (2) a committed handoff outranks the timer: delivery wins, token kept.
+    shared_channel.commitRvDemand(sc);
+    try std.testing.expectEqual(shared_channel.SendOutcome.sent, try shared_channel.send(sc, types.makeFixnum(7), null));
+    try std.testing.expectEqual(shared_channel.TimeoutWithdrawOutcome.value_ready, shared_channel.tryTimeoutWithdraw(sc, true));
+    try std.testing.expectEqual(@as(u32, 1), sc.rv_demand);
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    _ = try shared_channel.receive(sc, &gc, null, true);
+    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
+
+    // (3) an in-flight reservation defers the decision (the drain rule).
+    shared_channel.commitRvDemand(sc);
+    memory.spinLock(&sc.lock);
+    sc.reserved += 1; // simulate §4 step 7 mid-copy
+    memory.spinUnlock(&sc.lock);
+    try std.testing.expectEqual(shared_channel.TimeoutWithdrawOutcome.reservation_pending, shared_channel.tryTimeoutWithdraw(sc, true));
+    try std.testing.expectEqual(@as(u32, 1), sc.rv_demand); // token retained
+    memory.spinLock(&sc.lock);
+    sc.reserved -= 1;
+    memory.spinUnlock(&sc.lock);
+    try std.testing.expectEqual(shared_channel.TimeoutWithdrawOutcome.withdrawn, shared_channel.tryTimeoutWithdraw(sc, true));
+    try std.testing.expectEqual(@as(u32, 0), sc.rv_demand);
+
+    sc.release();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
+test "shared rendezvous: close wakes a parked child-thread receiver (deterministic)" {
+    // #1604 review: the Scheme twin of this test synchronizes with
+    // thread-sleep!, which cannot prove the child parked before the close.
+    // Here the parent polls sc.rv_demand — the child's commitment is
+    // exactly the observable the demand counter provides — so the close is
+    // guaranteed to exercise waking an already-parked cross-thread
+    // receiver, not just a later receive seeing `closed`.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define ch (make-channel 0))");
+    // Capture a let-bound alias so the thunk's deepCopy promotes the
+    // channel (a top-level global would fail the child's foreign-owner
+    // check instead).
+    _ = try ctx.vm.eval(
+        \\(define t (thread-start!
+        \\  (make-thread (let ((c ch))
+        \\                 (lambda () (if (eof-object? (channel-receive c)) 'eof 'val))))))
+    );
+    const ch_val = try ctx.vm.eval("ch");
+    const ch = types.toObject(ch_val).as(types.Channel);
+    try std.testing.expect(ch.shared != null);
+    const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(ch.shared.?));
+
+    // Wait until the child has committed its demand (i.e. is parked).
+    var spins: usize = 0;
+    while (spins < 2000) : (spins += 1) {
+        memory.spinLock(&sc.lock);
+        const demand = sc.rv_demand;
+        memory.spinUnlock(&sc.lock);
+        if (demand > 0) break;
+        var ts: std.c.timespec = .{ .sec = 0, .nsec = 1 * std.time.ns_per_ms };
+        _ = std.c.nanosleep(&ts, &ts);
+    }
+    try std.testing.expect(spins < 2000);
+
+    _ = try ctx.vm.eval("(channel-close! ch)");
+    const joined = try ctx.vm.eval("(thread-join! t)");
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, joined, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("eof", s);
+    // The woken receiver's eof exit released its token.
+    memory.spinLock(&sc.lock);
+    const final_demand = sc.rv_demand;
+    memory.spinUnlock(&sc.lock);
+    try std.testing.expectEqual(@as(u32, 0), final_demand);
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -722,9 +722,17 @@ pub const Channel = struct {
     /// instead of walking the head/tail pair list. Unused once `shared` is
     /// set (the SharedChannel tracks its own queue_len).
     queue_len: u32 = 0,
-    /// null = unbounded (today's semantics). Local-representation only;
-    /// carried into the SharedChannel by promoteChannel on promotion.
+    /// null = unbounded (today's semantics). 0 = rendezvous (KEP-0002 §6
+    /// as amended, kaappi#1601): send admission is bounded by `rv_demand`
+    /// instead of a static capacity. Local-representation only; carried
+    /// into the SharedChannel by promoteChannel on promotion.
     capacity: ?u32 = null,
+    /// Rendezvous demand (capacity == 0 only): the number of receivers
+    /// currently committed to this channel — each parked receive holds one
+    /// demand token (Fiber.rv_demand_on), acquired at its park decision and
+    /// released on every terminal exit. The send-admission bound for a
+    /// rendezvous channel. Meaningless (always 0) for capacity != 0.
+    rv_demand: u32 = 0,
     /// KEP-0002 §6: end-of-stream. Local-representation only; carried into
     /// the SharedChannel by promoteChannel on promotion.
     closed: bool = false,

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -16,6 +16,7 @@ test {
     _ = @import("tests_fuzz.zig");
     _ = @import("tests_deepcopy.zig");
     _ = @import("tests_shared_channel.zig");
+    _ = @import("tests_shared_channel_rendezvous.zig");
     _ = @import("tests_ir.zig");
     _ = @import("tests_srfi18.zig");
     _ = @import("tests_fibers.zig");

--- a/tests/scheme/smoke/fiber-channel-capacity.scm
+++ b/tests/scheme/smoke/fiber-channel-capacity.scm
@@ -22,10 +22,10 @@
     (set! order (cons (channel-receive ch) order))
     (reverse order)))
 
-;; --- capacity 0: every send is permanently full (no rendezvous handoff;
-;; the reservation-based protocol has no direct sender/receiver pairing),
-;; so a timed send on it always times out ---
-(test-equal "capacity-0 channel: send always times out (degenerate, documented)"
+;; --- capacity 0: a rendezvous channel (KEP-0002 §6 as amended, #1602) —
+;; a timed send with no receiver committed parks and times out; the full
+;; pairing semantics live in fiber-channel-rendezvous.scm ---
+(test-equal "capacity-0 channel: unpaired send times out"
   'timed-out
   (let ((ch (make-channel 0)))
     (channel-send ch 1 0.05 'timed-out)))

--- a/tests/scheme/smoke/fiber-channel-close.scm
+++ b/tests/scheme/smoke/fiber-channel-close.scm
@@ -52,12 +52,13 @@
     (channel-close! ch)
     (fiber-join f))) ; drives the scheduler until f completes -- no hang
 
-;; --- close wakes a parked sender on a full bounded channel too ---
+;; --- close wakes a parked sender too (capacity 0 = rendezvous: with no
+;; receiver committed the sender parks, exactly like a full bounded queue) ---
 (test-assert "channel-close! wakes a fiber parked on channel-send (raises, not hangs)"
   (let* ((ch (make-channel 0))
          (f (spawn (lambda ()
                      (guard (e (#t 'raised)) (channel-send ch 1) 'not-raised)))))
-    (yield) ; let the sender run and park (capacity 0: always full)
+    (yield) ; let the sender run and park (no receiver committed)
     (channel-close! ch)
     (eq? 'raised (fiber-join f))))
 

--- a/tests/scheme/smoke/fiber-channel-rendezvous-thread.scm
+++ b/tests/scheme/smoke/fiber-channel-rendezvous-thread.scm
@@ -1,0 +1,74 @@
+;; Regression tests for #1600/#1603: rendezvous channels (capacity 0)
+;; across real OS threads — the promoted SharedChannel representation
+;; (KEP-0002 §6 as amended, kaappi/keps#28). The channel must be CAPTURED
+;; by the thunk (let-bound): that is the §2 legal sharing path that
+;; promotes it; a top-level global would fail the foreign-owner check on
+;; the child instead.
+(import (scheme base) (scheme write) (scheme process-context)
+        (kaappi fibers) (srfi 18) (srfi 64))
+
+(test-begin "fiber-channel-rendezvous-thread")
+
+;; --- child thread sends, parent receives (the #1600 cross-thread shape) ---
+(test-equal "child-thread sender pairs with parent receiver"
+  'x
+  (let* ((ch (make-channel 0))
+         (t (thread-start! (make-thread (lambda () (channel-send ch 'x) 'sent)))))
+    (let ((v (channel-receive ch)))
+      (thread-join! t)
+      v)))
+
+;; --- parent sends, child thread receives ---
+(test-equal "parent sender pairs with child-thread receiver"
+  'hello
+  (let* ((ch (make-channel 0))
+         (t (thread-start! (make-thread (lambda () (channel-receive ch))))))
+    (channel-send ch 'hello)
+    (thread-join! t)))
+
+;; --- several values, one at a time (each send waits for its receive) ---
+(test-equal "sequential rendezvous handoffs across the thread boundary"
+  '(1 2 3)
+  (let* ((ch (make-channel 0))
+         (t (thread-start!
+             (make-thread (lambda ()
+                            (channel-send ch 1)
+                            (channel-send ch 2)
+                            (channel-send ch 3)
+                            'done)))))
+    (let ((vs (list (channel-receive ch)
+                    (channel-receive ch)
+                    (channel-receive ch))))
+      (thread-join! t)
+      vs)))
+
+;; --- timeouts stay the unpaired escape hatch on the promoted path ---
+(test-equal "promoted rendezvous: unpaired timed send times out"
+  'sto
+  (let ((ch (make-channel 0)))
+    ;; promote by round-tripping through a thread that ignores the channel
+    (let ((t (thread-start! (make-thread (lambda () (channel-closed? ch))))))
+      (thread-join! t)
+      (channel-send ch 'v 0.05 'sto))))
+
+(test-equal "promoted rendezvous: unpaired timed receive times out"
+  'rto
+  (let ((ch (make-channel 0)))
+    (let ((t (thread-start! (make-thread (lambda () (channel-closed? ch))))))
+      (thread-join! t)
+      (channel-receive ch 0.05 'rto))))
+
+;; --- close crosses the boundary: parent closes, parked child receiver eofs ---
+(test-equal "channel-close! wakes a child-thread rendezvous receiver with eof"
+  'eof
+  (let* ((ch (make-channel 0))
+         (t (thread-start!
+             (make-thread (lambda ()
+                            (if (eof-object? (channel-receive ch)) 'eof 'val))))))
+    (thread-sleep! 0.05) ; let the child park
+    (channel-close! ch)
+    (thread-join! t)))
+
+(let ((runner (test-runner-current)))
+  (test-end "fiber-channel-rendezvous-thread")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/fiber-channel-rendezvous.scm
+++ b/tests/scheme/smoke/fiber-channel-rendezvous.scm
@@ -1,0 +1,148 @@
+;; Regression tests for #1600/#1602: (make-channel 0) is a rendezvous
+;; channel (KEP-0002 §6 as amended, kaappi/keps#28) — channel-send completes
+;; only against a committed receiver, channel-receive only when a sender
+;; provides a value; whichever side arrives first waits. Before the fix,
+;; capacity 0 was "permanently full" and every untimed pairing deadlocked.
+(import (scheme base) (scheme write) (scheme process-context)
+        (kaappi fibers) (srfi 64))
+
+(test-begin "fiber-channel-rendezvous")
+
+;; --- the #1600 repro, verbatim shape: spawned sender, main receiver ---
+(test-equal "sender-first handoff (the #1600 repro)"
+  'x
+  (let ((ch (make-channel 0)))
+    (spawn (lambda () (channel-send ch 'x)))
+    (channel-receive ch)))
+
+;; --- receiver first, main sender ---
+(test-equal "receiver-first handoff"
+  'hello
+  (let* ((ch (make-channel 0))
+         (f (spawn (lambda () (channel-receive ch)))))
+    (channel-send ch 'hello)
+    (fiber-join f)))
+
+;; --- the synchronous guarantee: a send cannot complete unpaired ---
+(test-equal "send completes only after a receiver commits"
+  '(not-sent-yet v sent)
+  (let* ((ch (make-channel 0))
+         (state 'not-sent-yet)
+         (f (spawn (lambda () (channel-send ch 'v) (set! state 'sent)))))
+    (yield) ; the sender runs and parks — a buffered channel would complete it
+    (let ((pre state)
+          (got (channel-receive ch)))
+      (fiber-join f)
+      (list pre got state))))
+
+;; --- unpaired operations still deadlock cleanly (fail-loud preserved) ---
+(test-assert "unpaired untimed send raises a deadlock error"
+  (guard (e (#t #t)) (channel-send (make-channel 0) 1) #f))
+
+(test-assert "unpaired untimed receive raises a deadlock error"
+  (guard (e (#t #t)) (channel-receive (make-channel 0)) #f))
+
+;; --- timeouts stay the unpaired escape hatch ---
+(test-equal "unpaired send times out with timeout-val"
+  'sto
+  (channel-send (make-channel 0) 'v 0.05 'sto))
+
+(test-equal "unpaired receive times out with timeout-val"
+  'rto
+  (channel-receive (make-channel 0) 0.05 'rto))
+
+(test-assert "unpaired send timeout without timeout-val raises channel-timeout"
+  (let ((ch (make-channel 0)))
+    (guard (e (#t (channel-timeout-exception? e)))
+      (channel-send ch 1 0.05)
+      #f)))
+
+;; --- a timed operation paired with a waiting counterparty never waits out ---
+(test-equal "timed receive with a parked sender returns the value immediately"
+  'fast
+  (let ((ch (make-channel 0)))
+    (spawn (lambda () (channel-send ch 'fast)))
+    (yield) ; let the sender park
+    (channel-receive ch 5 'never)))
+
+(test-equal "timed send with a parked receiver completes immediately"
+  'got-it
+  (let* ((ch (make-channel 0))
+         (f (spawn (lambda () (channel-receive ch)))))
+    (yield) ; let the receiver park (commit demand)
+    (channel-send ch 'got-it 5)
+    (fiber-join f)))
+
+;; --- a timed-out receive withdraws its demand and strands nothing ---
+(test-equal "timed-out receive leaves no phantom demand and no stranded value"
+  '(rto sto empty)
+  (let ((ch (make-channel 0)))
+    (list (channel-receive ch 0.05 'rto)
+          (channel-send ch 'v 0.05 'sto)
+          (channel-receive ch 0.05 'empty))))
+
+;; --- close wakes both sides ---
+(test-equal "channel-close! wakes a parked rendezvous receiver with eof"
+  'eof
+  (let* ((ch (make-channel 0))
+         (f (spawn (lambda () (if (eof-object? (channel-receive ch)) 'eof 'val)))))
+    (yield)
+    (channel-close! ch)
+    (fiber-join f)))
+
+(test-equal "channel-close! wakes a parked rendezvous sender with a raise"
+  'raised
+  (let* ((ch (make-channel 0))
+         (f (spawn (lambda () (guard (e (#t 'raised)) (channel-send ch 1) 'sent)))))
+    (yield)
+    (channel-close! ch)
+    (fiber-join f)))
+
+;; --- two parked timed senders, one receiver: exactly one handoff ---
+;; (regression for the frozen-ancestor interleaving found in #1602: this
+;; raised a spurious deadlock when timed senders parked in-call)
+(test-assert "one of two parked timed senders pairs; the other times out"
+  (let* ((ch (make-channel 0))
+         (s1 (spawn (lambda () (channel-send ch 'a 0.3 'ta))))
+         (s2 (spawn (lambda () (channel-send ch 'b 0.3 'tb)))))
+    (yield)
+    (let ((got (channel-receive ch)))
+      (fiber-join s1)
+      (fiber-join s2)
+      (memq got '(a b)))))
+
+;; --- two parked receivers, two sends: both delivered ---
+(test-assert "two parked receivers each collect one of two sends"
+  (let* ((ch (make-channel 0))
+         (r1 (spawn (lambda () (channel-receive ch))))
+         (r2 (spawn (lambda () (channel-receive ch)))))
+    (yield)
+    (channel-send ch 'one)
+    (channel-send ch 'two)
+    (let ((got (list (fiber-join r1) (fiber-join r2))))
+      (and (memq 'one got) (memq 'two got) #t))))
+
+;; --- rendezvous ping-pong: repeated pairing over two channels ---
+(test-equal "ping-pong across two rendezvous channels"
+  '(10 20 30)
+  (let ((ping (make-channel 0))
+        (pong (make-channel 0)))
+    (spawn (lambda ()
+             (let loop ((n 0))
+               (unless (= n 3)
+                 (channel-send pong (* 10 (channel-receive ping)))
+                 (loop (+ n 1))))))
+    (list (begin (channel-send ping 1) (channel-receive pong))
+          (begin (channel-send ping 2) (channel-receive pong))
+          (begin (channel-send ping 3) (channel-receive pong)))))
+
+;; --- eof-objects stay rejected on rendezvous channels too ---
+(test-assert "channel-send rejects an eof-object on a rendezvous channel"
+  (let* ((ch (make-channel 0))
+         (f (spawn (lambda () (channel-receive ch 0.2 'nothing)))))
+    (yield)
+    (guard (e (#t #t)) (channel-send ch (eof-object)) #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "fiber-channel-rendezvous")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/fiber-channel-rendezvous.scm
+++ b/tests/scheme/smoke/fiber-channel-rendezvous.scm
@@ -99,17 +99,24 @@
     (fiber-join f)))
 
 ;; --- two parked timed senders, one receiver: exactly one handoff ---
-;; (regression for the frozen-ancestor interleaving found in #1602: this
-;; raised a spurious deadlock when timed senders parked in-call)
-(test-assert "one of two parked timed senders pairs; the other times out"
+;; (regression for the frozen-ancestor interleaving found in #1602 — a
+;; spurious deadlock when timed senders parked in-call — strengthened per
+;; the #1604 review to pin one-demand/one-send admission: exactly one
+;; sender delivers, the other times out, and no second value strands)
+(test-assert "exactly one of two parked timed senders pairs; nothing strands"
   (let* ((ch (make-channel 0))
-         (s1 (spawn (lambda () (channel-send ch 'a 0.3 'ta))))
-         (s2 (spawn (lambda () (channel-send ch 'b 0.3 'tb)))))
+         (s1 (spawn (lambda () (if (eq? (channel-send ch 'a 0.3 'ta) 'ta) 'ta 'sent-a))))
+         (s2 (spawn (lambda () (if (eq? (channel-send ch 'b 0.3 'tb) 'tb) 'tb 'sent-b)))))
     (yield)
-    (let ((got (channel-receive ch)))
-      (fiber-join s1)
-      (fiber-join s2)
-      (memq got '(a b)))))
+    (let* ((got (channel-receive ch))
+           (r1 (fiber-join s1))
+           (r2 (fiber-join s2))
+           (rest (channel-receive ch 0.05 'empty)))
+      (and (eq? rest 'empty)
+           (case got
+             ((a) (and (eq? r1 'sent-a) (eq? r2 'tb)))
+             ((b) (and (eq? r1 'ta) (eq? r2 'sent-b)))
+             (else #f))))))
 
 ;; --- two parked receivers, two sends: both delivered ---
 (test-assert "two parked receivers each collect one of two sends"

--- a/tests/scheme/smoke/fiber-channel-timeout.scm
+++ b/tests/scheme/smoke/fiber-channel-timeout.scm
@@ -31,15 +31,17 @@
     (channel-send ch 42)
     (channel-receive ch 5)))
 
-;; --- send: no timeout-val -> raises on a permanently-full channel ---
-(test-assert "channel-send on a full channel times out and raises"
+;; --- send: no timeout-val -> raises when no receiver ever commits
+;; (capacity 0 = rendezvous, KEP-0002 §6 as amended: an unpaired send
+;; parks; the timeout is the escape hatch) ---
+(test-assert "channel-send with no receiver times out and raises"
   (let ((ch (make-channel 0)))
     (guard (e (#t (channel-timeout-exception? e)))
       (channel-send ch 1 0.05)
       #f)))
 
 ;; --- send: with timeout-val -> returns it instead of raising ---
-(test-equal "channel-send on a full channel times out and returns timeout-val"
+(test-equal "channel-send with no receiver times out and returns timeout-val"
   'gave-up
   (let ((ch (make-channel 0)))
     (channel-send ch 1 0.05 'gave-up)))


### PR DESCRIPTION
Implements rendezvous semantics for `(make-channel 0)` on **both representations**, per the KEP-0002 §4/§6 amendment (kaappi/keps#28, model-checked first). Closes #1602, closes #1603; tracking issue #1600. Before this change, capacity 0 was the documented degenerate "permanently full" channel: construction succeeded but no value could ever transfer — the #1600 repro now prints `x`.

## Semantics

`(make-channel 0)` is a synchronous channel: `channel-send` completes only against a committed receiver, `channel-receive` only when a sender provides a value; whichever side arrives first waits. Unpaired untimed operations still raise KP3000; timeouts stay the escape hatch; close wakes both sides; eof-send stays rejected.

## Design — demand-bounded admission (no pairing machinery)

Per the amendment, rendezvous is the dynamic-capacity generalization of the existing reservation/wake-all-retry protocol: the send-admission bound for capacity 0 is `rv_demand` — the count of receivers currently committed — instead of a static capacity. The value still transfers through the queue.

- **Demand tokens**: a receiver commits at its park decision (increment + `Fiber.rv_demand_on`, idempotent across `yield_retry` re-execution) and releases on every terminal exit (value, eof, timeout, error, deadlock raise) plus the death paths (`retireSlot`, `thread-terminate!` — the `abandonFiberMutexes` precedent). New demand wakes parked senders exactly like a freed slot (model finding 4: without that ring, senders parked against bound 0 before any receiver commits hang forever).
- **Local path** (`channelSendLocal`/`channelReceiveFn`): bound-aware admission + token protocol. One non-obvious rule found by testing, now regression-tested: **dispatched fibers must flat-park (`yield_retry`) on rendezvous waits, never in-call park.** Rendezvous is the only capacity where a parked sender and parked receiver can exist simultaneously, and an in-call park makes the fiber a frozen *ancestor* when its drive transitively dispatches the counterparty (#1487: driving ancestors are undispatchable) — a main-fiber receiver stacked on top raised a spurious KP3000 with two viable timed senders frozen beneath it. Flat parks keep every rendezvous waiter dispatchable; timers survive re-parks via the preserved-`me.deadline_ns` discriminator (`channelSendShared`'s established pattern).
- **Shared path** (`SharedChannel`): `rv_demand` under the existing spinlock; `commitRvDemand` (lock + snapshot-and-ring `send_waiters`) / `withdrawRvDemand`; `promoteChannel` seeds the counter from the local one, so tokens acquired at pre-promotion local parks stay counted across migration (the token field names the same stub on both representations — no re-dispatch bookkeeping needed).
- **Timeout rules** (§6): *delivery-wins* — both operations' timeout redispatch decides through one actual `send()`/`receive()`, so a handoff/slot that materialized with the timer pop is honored, never discarded; *reservation-drain* — a timed-out rendezvous receiver observing `reserved > 0` with an empty queue re-parks until the in-flight send pushes or aborts, so a send past its point of no return is never silently stranded. The abort path now rings `recv_waiters` on rendezvous channels even while open (mirrored in the TLA+ model, kaappi/keps@fe166f2).
- **GC**: `Fiber.rv_demand_on` traced by `markFiberState` and `referencesYoung` (the `waiting_on` precedent — it must trace independently because the token survives a wake's `clear_waiting_on`).

## Verification

- `zig build test` green (full suite), including new tests: token accounting stays balanced across timeout/deadlock/handoff exits; the frozen-ancestor regression; raw shared-protocol admission against demand; promotion seeding; cross-thread handoff both directions (leak-checked).
- `-Dgc-stress=true` green for `tests_fibers` + `tests_shared_channel`.
- New Scheme suites: `tests/scheme/smoke/fiber-channel-rendezvous.scm` (17 assertions: both directions, ordering witness, deadlocks, timeouts, delivery-priority, close, multi-party, ping-pong, no-phantom-demand) and `fiber-channel-rendezvous-thread.scm` (6 assertions on the promoted path across real OS threads, including sequential lockstep handoffs and cross-thread close).
- The three existing capacity-0 fixtures pass unchanged (their assertions — unpaired timed sends time out, close wakes parked senders, untimed unpaired sends deadlock — are all still true under rendezvous); only their stale "permanently full / no rendezvous handoff" comments were updated.
- Full `tests/scheme/run-all.sh` green.

Docs follow-up: kaappi/kaappi.github.io#16 (merges when this ships in a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
