### PR TITLE
referencesYoung: trace owned_mutexes in the fiber arm (hygiene)

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -220,6 +220,19 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
             while (pit.next()) |v| {
                 if (isYoungPointer(gc, v.*)) return true;
             }
+            // Keeps this arm in lockstep with markFiberState (the
+            // waiting_on/rv_demand_on pairing convention). For fibers the
+            // whole remembered-set path is belt-and-braces, not
+            // load-bearing: every scheduler-resident fiber is marked as an
+            // unconditional root each collection (markVMRoots ->
+            // FiberScheduler.markRoots), minor collections included, so
+            // markFiberState re-traces owned_mutexes every cycle whether or
+            // not this prune keeps the fiber. Checked here anyway so the
+            // safety of pruning never silently starts depending on that
+            // root-marking invariant.
+            for (fiber.owned_mutexes.items) |m_val| {
+                if (isYoungPointer(gc, m_val)) return true;
+            }
         },
         .channel => {
             const ch = obj.as(types.Channel);


### PR DESCRIPTION
Closes out the side-question flagged during the rendezvous work (#1602): `referencesYoung`'s fiber arm omitted `owned_mutexes` while `markFiberState` traces it.

**Verified false alarm for correctness** — every scheduler-resident fiber is marked as an unconditional root on every collection (`markVMRoots` → `FiberScheduler.markRoots`), minor collections included, so `markFiberState` re-traces `owned_mutexes` each cycle regardless of remembered-set pruning; the same invariant covers the barrier-less `owned_mutexes.append` in `mutex-lock!`. No reachable use-after-free.

This adds the loop anyway, with a comment recording that safety argument in the code: it restores the `markFiberState`/`referencesYoung` pairing convention (`waiting_on`, `rv_demand_on`) and keeps pruning correct even if the root-marking invariant ever changes. No behavior change; full unit suite + gc-stress SRFI-18 filter green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)