### PR TITLE
Add Windows aarch64 target

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -134,7 +134,7 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 **STOP.** Ask the user for explicit confirmation before pushing. Explain:
 
 - Pushing the tag triggers the release workflow in CI
-- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, plus kaappi.wasm (wasm32-wasi)
+- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, aarch64-windows (kaappi-aarch64-windows.exe, cross-compiled), plus kaappi.wasm (wasm32-wasi)
 - macOS binaries are Developer ID signed and Apple notarized
 - It generates SHA256SUMS and creates a GitHub Release
 - This is irreversible
@@ -177,6 +177,13 @@ and runs acceptance tests on macOS, Linux x86/ARM, WASM, plus checksum and
 install script verification. If it fails, investigate before updating the
 docs site — a failure means the release artifacts have a problem (e.g.
 missing entitlement, broken binary, bad checksum).
+
+The Windows artifacts are covered by the checksum job (it verifies every
+released file) but have **no CI acceptance leg** — GitHub has no ARM64
+Windows runners. To smoke-test them on a real Windows 11 ARM64 machine
+(e.g. the `ssh win11` UTM VM), download `kaappi-aarch64-windows.exe` there
+and run `--version`, a small script, and `kaappi features` (the feature
+list must show `windows`, not `posix`). See `docs/dev/windows.md`.
 
 ## Step 11: Update docs site (playground WASM + version)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,31 @@ jobs:
           zig build test -Dtarget=aarch64-windows
           ls .zig-cache/o/*/unit-tests.exe
 
+      - name: Stage binaries for windows-arm-test
+        # ls -t picks the exe this run compiled — the restored Zig cache
+        # can hold stale unit-tests.exe from earlier runs.
+        run: |
+          mkdir -p win-stage
+          cp zig-out/bin/kaappi.exe zig-out/bin/thottam.exe zig-out/bin/kaappi-lsp.exe win-stage/
+          cp "$(ls -t .zig-cache/o/*/unit-tests.exe | head -1)" win-stage/
+
+      - name: Upload binaries for windows-arm-test
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-aarch64-binaries
+          path: win-stage/
+          retention-days: 3
+
   # Execute the suite on real Windows ARM64 via GitHub's hosted
-  # windows-11-arm runners (free for public repos). Runs the unit suite,
-  # the R7RS suite, and the .scm suites verified on the port's reference
-  # VM (docs/dev/windows.md). The shell-based suites (#1612) and the FFI
-  # suite (#1611) are not runnable on Windows yet.
+  # windows-11-arm runners (free for public repos): the unit suite, the
+  # R7RS suite, and the .scm suites verified on the port's reference VM
+  # (docs/dev/windows.md). The binaries come cross-compiled from
+  # windows-cross — Zig 0.16.0 cannot compile natively on Windows ARM64
+  # (zig build/build-exe access-violate on any project, #1613) — so this
+  # job installs no toolchain and only executes. The shell-based suites
+  # (#1612) and the FFI suite (#1611) are not runnable on Windows yet.
   windows-arm-test:
-    needs: format
+    needs: windows-cross
     runs-on: windows-11-arm
     timeout-minutes: 40
     steps:
@@ -188,11 +206,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Zig
-        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+      - name: Download binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          version: 0.16.0
-          cache-key: windows-arm
+          name: windows-aarch64-binaries
+          path: bin
+
+      - name: Unwrap archived artifact
+        # upload-artifact v7 archives by default and download-artifact v8
+        # hands the wrapper zip back as a file (same dance as fuzz.yml's
+        # report job). Windows ships bsdtar, which extracts zip.
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for z in bin/*.zip; do tar -xf "$z" -C bin && rm -f "$z"; done
+          ls -l bin
 
       - name: Create tmp directories
         # Tests write scratch files under /tmp/..., which kaappi.exe
@@ -203,20 +232,13 @@ jobs:
           $drive = (Get-Location).Path.Substring(0, 2)
           New-Item -ItemType Directory -Force -Path "$drive\tmp" | Out-Null
 
-      - name: Build
-        # Explicit target = the gnu-ABI binaries windows-cross and
-        # release.yml build; native detection on the runner could pick
-        # the msvc ABI instead.
-        run: zig build -Dtarget=aarch64-windows
-
       - name: Unit tests
-        # Same command as windows-cross, but the host can execute the
-        # binary here, so the tests actually run.
-        run: zig build test -Dtarget=aarch64-windows
+        shell: bash
+        run: bin/unit-tests.exe
 
       - name: R7RS test suite
         shell: bash
-        run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
+        run: bin/kaappi.exe tests/scheme/r7rs/r7rs-tests.scm
 
       - name: Scheme suites (VM-verified subset)
         shell: bash
@@ -224,7 +246,7 @@ jobs:
           fail=0
           for dir in smoke compliance continuations hygiene srfi audit; do
             for f in tests/scheme/$dir/*.scm; do
-              if zig-out/bin/kaappi "$f" > out.log 2>&1; then
+              if bin/kaappi.exe "$f" > out.log 2>&1; then
                 echo "  PASS  $f"
               else
                 echo "  FAIL  $f"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,14 +161,12 @@ jobs:
         run: zig build -Dtarget=aarch64-windows
 
       - name: Compile unit tests (aarch64-windows)
-        # The run step cannot execute a foreign binary; compiling it is
-        # the regression gate. `|| true` is NOT used — a compile error
-        # must fail, so filter only the expected spawn failure.
+        # The host can't execute the foreign test binaries; the build's
+        # Run steps set skip_foreign_checks, so this compiles everything
+        # and skips execution — a plain compile gate with normal error
+        # propagation.
         run: |
-          zig build test -Dtarget=aarch64-windows 2>&1 | tee win-test-build.log || true
-          if grep -E "error:" win-test-build.log | grep -qvE "unable to spawn foreign binary|the following build command failed"; then
-            echo "unexpected compile errors" && exit 1
-          fi
+          zig build test -Dtarget=aarch64-windows
           ls .zig-cache/o/*/unit-tests.exe
 
   wasm:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,39 @@ jobs:
       - name: R7RS test suite (riscv64 via QEMU)
         run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
 
+  # Cross-compile the Windows aarch64 binaries and the unit-test binary.
+  # Compile-only: no Windows ARM64 runner exists on GitHub Actions, so
+  # execution is verified on a real Windows 11 ARM64 machine (see
+  # docs/dev/windows.md). This job keeps the target from bit-rotting.
+  windows-cross:
+    needs: format
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: windows-cross
+
+      - name: Build (cross-compile for aarch64-windows)
+        run: zig build -Dtarget=aarch64-windows
+
+      - name: Compile unit tests (aarch64-windows)
+        # The run step cannot execute a foreign binary; compiling it is
+        # the regression gate. `|| true` is NOT used — a compile error
+        # must fail, so filter only the expected spawn failure.
+        run: |
+          zig build test -Dtarget=aarch64-windows 2>&1 | tee win-test-build.log || true
+          if grep -E "error:" win-test-build.log | grep -qvE "unable to spawn foreign binary|the following build command failed"; then
+            echo "unexpected compile errors" && exit 1
+          fi
+          ls .zig-cache/o/*/unit-tests.exe
+
   wasm:
     needs: format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,10 @@ jobs:
       - name: R7RS test suite (riscv64 via QEMU)
         run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
 
-  # Cross-compile the Windows aarch64 binaries and the unit-test binary.
-  # Compile-only: no Windows ARM64 runner exists on GitHub Actions, so
-  # execution is verified on a real Windows 11 ARM64 machine (see
-  # docs/dev/windows.md). This job keeps the target from bit-rotting.
+  # Cross-compile the Windows aarch64 binaries and the unit-test binary
+  # from Linux. Compile-only by design: this guards the cross-compilation
+  # path release.yml ships with, independent of the Windows runner image.
+  # Execution is covered by windows-arm-test below.
   windows-cross:
     needs: format
     runs-on: ubuntu-latest
@@ -168,6 +168,73 @@ jobs:
         run: |
           zig build test -Dtarget=aarch64-windows
           ls .zig-cache/o/*/unit-tests.exe
+
+  # Execute the suite on real Windows ARM64 via GitHub's hosted
+  # windows-11-arm runners (free for public repos). Runs the unit suite,
+  # the R7RS suite, and the .scm suites verified on the port's reference
+  # VM (docs/dev/windows.md). The shell-based suites (#1612) and the FFI
+  # suite (#1611) are not runnable on Windows yet.
+  windows-arm-test:
+    needs: format
+    runs-on: windows-11-arm
+    timeout-minutes: 40
+    steps:
+      # The Windows runner images set core.autocrlf=true; the Scheme
+      # suites compare exact output, so check out files as committed.
+      - name: Disable autocrlf
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: windows-arm
+
+      - name: Create tmp directories
+        # Tests write scratch files under /tmp/..., which kaappi.exe
+        # resolves to \tmp on the current drive (docs/dev/windows.md).
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path C:\tmp | Out-Null
+          $drive = (Get-Location).Path.Substring(0, 2)
+          New-Item -ItemType Directory -Force -Path "$drive\tmp" | Out-Null
+
+      - name: Build
+        # Explicit target = the gnu-ABI binaries windows-cross and
+        # release.yml build; native detection on the runner could pick
+        # the msvc ABI instead.
+        run: zig build -Dtarget=aarch64-windows
+
+      - name: Unit tests
+        # Same command as windows-cross, but the host can execute the
+        # binary here, so the tests actually run.
+        run: zig build test -Dtarget=aarch64-windows
+
+      - name: R7RS test suite
+        shell: bash
+        run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
+
+      - name: Scheme suites (VM-verified subset)
+        shell: bash
+        run: |
+          fail=0
+          for dir in smoke compliance continuations hygiene srfi audit; do
+            for f in tests/scheme/$dir/*.scm; do
+              if zig-out/bin/kaappi "$f" > out.log 2>&1; then
+                echo "  PASS  $f"
+              else
+                echo "  FAIL  $f"
+                cat out.log
+                fail=1
+              fi
+            done
+          done
+          rm -f out.log
+          exit $fail
 
   wasm:
     needs: format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,45 @@ jobs:
           - os: macos-latest
             target: aarch64-macos
             artifact: kaappi-aarch64-macos
+            exe_ext: ''
+            lib_src: libkaappi_rt.a
+            lib_ext: .a
+            strip: true
           - os: ubuntu-latest
             target: x86_64-linux
             artifact: kaappi-x86_64-linux
+            exe_ext: ''
+            lib_src: libkaappi_rt.a
+            lib_ext: .a
+            strip: true
           - os: ubuntu-24.04-arm
             target: aarch64-linux
             artifact: kaappi-aarch64-linux
+            exe_ext: ''
+            lib_src: libkaappi_rt.a
+            lib_ext: .a
+            strip: true
           - os: ubuntu-latest
             target: riscv64-linux
             artifact: kaappi-riscv64-linux
+            exe_ext: ''
+            lib_src: libkaappi_rt.a
+            lib_ext: .a
+            strip: true
+          # Cross-compiled via Zig's bundled mingw-w64; execution is
+          # verified on real Windows 11 ARM64 hardware (docs/dev/windows.md)
+          # since GitHub has no ARM64 Windows runners. The gnu-ABI static
+          # lib is emitted as kaappi_rt.lib on this target. strip: false —
+          # a stripped kaappi.exe access-violates at startup on ARM64
+          # Windows (toolchain issue, see docs/dev/windows.md); thottam is
+          # unaffected but the row ships both unstripped for consistency.
+          - os: ubuntu-latest
+            target: aarch64-windows
+            artifact: kaappi-aarch64-windows.exe
+            exe_ext: .exe
+            lib_src: kaappi_rt.lib
+            lib_ext: .lib
+            strip: false
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -38,7 +68,7 @@ jobs:
 
       - name: Build release binaries and runtime library
         run: |
-          zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=true
+          zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=${{ matrix.strip }}
           zig build lib -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }}
 
       - name: Sign and notarize macOS binaries
@@ -80,9 +110,9 @@ jobs:
 
       - name: Rename binaries
         run: |
-          cp zig-out/bin/kaappi ${{ matrix.artifact }}
-          cp zig-out/bin/thottam thottam-${{ matrix.target }}
-          cp zig-out/lib/libkaappi_rt.a libkaappi_rt-${{ matrix.target }}.a
+          cp zig-out/bin/kaappi${{ matrix.exe_ext }} ${{ matrix.artifact }}
+          cp zig-out/bin/thottam${{ matrix.exe_ext }} thottam-${{ matrix.target }}${{ matrix.exe_ext }}
+          cp zig-out/lib/${{ matrix.lib_src }} libkaappi_rt-${{ matrix.target }}${{ matrix.lib_ext }}
 
       - name: Upload kaappi artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -94,15 +124,15 @@ jobs:
       - name: Upload thottam artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: thottam-${{ matrix.target }}
-          path: thottam-${{ matrix.target }}
+          name: thottam-${{ matrix.target }}${{ matrix.exe_ext }}
+          path: thottam-${{ matrix.target }}${{ matrix.exe_ext }}
           retention-days: 1
 
       - name: Upload libkaappi_rt artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: libkaappi_rt-${{ matrix.target }}
-          path: libkaappi_rt-${{ matrix.target }}.a
+          path: libkaappi_rt-${{ matrix.target }}${{ matrix.lib_ext }}
           retention-days: 1
 
   build-wasm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+
 - **Windows aarch64 target** — `zig build -Dtarget=aarch64-windows` cross-compiles `kaappi.exe`, `thottam.exe`, and `kaappi-lsp.exe` (via Zig's bundled mingw-w64; releases ship `kaappi-aarch64-windows.exe`). The full interpreter works on Windows 11 ARM64 — REPL (plain line editing), fibers, channels (incl. capacity-0 rendezvous), SRFI-18 OS threads, FFI via `LoadLibrary`, and the `kaappi test` runner — verified with the complete unit and R7RS suites on real hardware. Platform notes: ports never switch to non-blocking I/O (fiber I/O degrades to blocking reads; timers and cross-thread wakeups still work), the POSIX-only slice of SRFI-170 (uid/gid, symlinks, chmod/umask, user/group info) raises a catchable file error, and `cond-expand`/`(features)` expose a `windows` identifier in place of `posix`. thottam runs read-only subcommands; `install`/`remove`/`update` are not yet supported on Windows. See `docs/dev/windows.md`
 
 ### Fixed
+
 - FFI 64-bit integer marshaling now uses a platform-independent `i64` carrier: on LLP64 targets (Windows) C `long` is 32-bit and is routed through the 32-bit marshaling class, while `int64`/`uint64`/`size_t` keep full 64-bit range — previously all four assumed `c_long` was 64-bit (identical behavior on macOS/Linux, where it is)
 - macOS release binaries can now `ffi-open` user-compiled libraries: the hardened-runtime signing entitlements add `com.apple.security.cs.disable-library-validation`, without which dlopen refused every locally-built `.dylib` (kaappi-net, kaappi-pg, kaappi-sqlite, kaappi-crypto) on release binaries while source builds worked (#1587)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Windows aarch64 target** — `zig build -Dtarget=aarch64-windows` cross-compiles `kaappi.exe`, `thottam.exe`, and `kaappi-lsp.exe` (via Zig's bundled mingw-w64; releases ship `kaappi-aarch64-windows.exe`). The full interpreter works on Windows 11 ARM64 — REPL (plain line editing), fibers, channels (incl. capacity-0 rendezvous), SRFI-18 OS threads, FFI via `LoadLibrary`, and the `kaappi test` runner — verified with the complete unit and R7RS suites on real hardware. Platform notes: ports never switch to non-blocking I/O (fiber I/O degrades to blocking reads; timers and cross-thread wakeups still work), the POSIX-only slice of SRFI-170 (uid/gid, symlinks, chmod/umask, user/group info) raises a catchable file error, and `cond-expand`/`(features)` expose a `windows` identifier in place of `posix`. thottam runs read-only subcommands; `install`/`remove`/`update` are not yet supported on Windows. See `docs/dev/windows.md`
+
 ### Fixed
+- FFI 64-bit integer marshaling now uses a platform-independent `i64` carrier: on LLP64 targets (Windows) C `long` is 32-bit and is routed through the 32-bit marshaling class, while `int64`/`uint64`/`size_t` keep full 64-bit range — previously all four assumed `c_long` was 64-bit (identical behavior on macOS/Linux, where it is)
 - macOS release binaries can now `ffi-open` user-compiled libraries: the hardened-runtime signing entitlements add `com.apple.security.cs.disable-library-validation`, without which dlopen refused every locally-built `.dylib` (kaappi-net, kaappi-pg, kaappi-sqlite, kaappi-crypto) on release binaries while source builds worked (#1587)
 
 ## [0.15.0] - 2026-07-16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,11 +103,16 @@ This runs `zig fmt --check` on staged `.zig` files before each commit.
 | Linux | x86_64 | yes | yes | CI tested (Ubuntu) |
 | Linux | aarch64 | yes | yes | CI tested (Ubuntu ARM) |
 | Linux | riscv64 | yes | yes | CI tested (QEMU) |
+| Windows | aarch64 (ARM64) | yes | yes | `zig build -Dtarget=aarch64-windows`; see `docs/dev/windows.md` |
 | WebAssembly | wasm32-wasi | yes | — | `zig build wasm`, browser/WASI |
 
 **Cross-compilation:** `zig build -Dtarget=x86_64-linux` and
 `zig build -Dtarget=riscv64-linux` cross-compile from macOS ARM. Binaries
 run in Linux containers via podman (x86_64 via Rosetta, riscv64 via QEMU).
+`zig build -Dtarget=aarch64-windows` cross-compiles the Windows binaries
+(kaappi.exe, thottam.exe, kaappi-lsp.exe); syscall-level platform
+differences live in `src/platform.zig` (see `docs/dev/windows.md` for the
+port's architecture, degradations, and how to test on a Windows machine).
 
 Builds default to **ReleaseSafe** (fast, with bounds/safety checks retained;
 fixnum overflow auto-promotes to bignum). Debug is ~500x slower for allocation-

--- a/README.md
+++ b/README.md
@@ -83,13 +83,20 @@ zig build test                       # run the unit tests
 | Linux | x86_64 | yes | yes | LLVM backend |
 | Linux | aarch64 | yes | yes | LLVM backend |
 | Linux | riscv64 | yes | yes | LLVM backend |
+| Windows | aarch64 (ARM64) | yes | yes | LLVM backend (needs a C toolchain) |
 | WebAssembly | wasm32-wasi | yes | — | interpreter only |
 
 The WASM build (`zig build wasm`) runs in browsers and WASI runtimes — it
 powers the [playground](https://kaappi-lang.org/playground/).
 
-Windows is not supported: Kaappi depends on POSIX APIs (mmap, signals) and
-linenoise (terminal I/O).
+The Windows port (`zig build -Dtarget=aarch64-windows`) covers the full
+interpreter — REPL (plain line editing, no history/completion), fibers,
+channels, OS threads, FFI (`LoadLibrary`), and the `kaappi test` runner.
+Platform differences: ports never switch to non-blocking I/O (fiber I/O
+degrades to blocking reads, timers still work), and the POSIX-only slice
+of SRFI-170 (uid/gid, symlinks, chmod/umask, user/group info) raises a
+catchable file error. `cond-expand` distinguishes the platforms: Windows
+builds expose the `windows` feature identifier instead of `posix`.
 
 ## A taste of Kaappi
 

--- a/build.zig
+++ b/build.zig
@@ -375,6 +375,12 @@ pub fn build(b: *std.Build) void {
         .filters = test_filters,
     });
     const run_unit_tests = b.addRunArtifact(unit_tests);
+    // Cross-compiled test binaries the host can't execute (no emulator
+    // registered — e.g. aarch64-windows) skip cleanly instead of failing,
+    // so `zig build test -Dtarget=aarch64-windows` is a compile gate CI
+    // can run anywhere. Native runs and QEMU-backed riscv64 are
+    // unaffected (the binary is executable there, so it still runs).
+    run_unit_tests.skip_foreign_checks = true;
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
 
@@ -389,6 +395,7 @@ pub fn build(b: *std.Build) void {
         .filters = test_filters,
     });
     const run_thottam_tests = b.addRunArtifact(thottam_tests);
+    run_thottam_tests.skip_foreign_checks = true;
     test_step.dependOn(&run_thottam_tests.step);
 
     // Code coverage via kcov (always Debug for DWARF line info)

--- a/build.zig
+++ b/build.zig
@@ -82,12 +82,15 @@ pub fn build(b: *std.Build) void {
     const null_embed = wf.add("embedded_bytecode.zig", "pub const bytecode: ?[]const u8 = null;\n");
 
     const is_wasm_target = target.result.os.tag == .wasi;
+    // linenoise is POSIX-only (termios); the Windows REPL uses a plain
+    // stdin line loop instead (repl.zig).
+    const use_linenoise = !is_wasm_target and target.result.os.tag != .windows;
 
     // Main module (embedded_bytecode added below based on bundle mode)
     const main_mod = kaappiModule(b, options_mod, .{
         .target = target,
         .optimize = optimize,
-        .linenoise = !is_wasm_target,
+        .linenoise = use_linenoise,
         .strip = strip,
         .single_threaded = if (is_wasm_target) true else null,
     });
@@ -113,7 +116,7 @@ pub fn build(b: *std.Build) void {
         const compiler_mod = kaappiModule(b, options_mod, .{
             .target = target,
             .optimize = optimize,
-            .linenoise = !is_wasm_target,
+            .linenoise = use_linenoise,
             .embed = compiler_null_embed,
         });
 
@@ -181,7 +184,7 @@ pub fn build(b: *std.Build) void {
         .root = "src/runtime_exports.zig",
         .target = target,
         .optimize = optimize,
-        .linenoise = !is_wasm_target,
+        .linenoise = use_linenoise,
         .embed = null_embed,
     });
     const lib = b.addLibrary(.{
@@ -413,7 +416,7 @@ pub fn build(b: *std.Build) void {
     const cov_main_mod = kaappiModule(b, options_mod, .{
         .target = target,
         .optimize = .Debug,
-        .linenoise = !is_wasm_target,
+        .linenoise = use_linenoise,
         .embed = null_embed,
     });
     const cov_exe = b.addExecutable(.{

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -23,6 +23,7 @@ investigation produced analysis worth keeping.
 | [ir.md](ir.md) | Compiler IR: 33 node types, analysis passes, optimization passes |
 | [observing-the-pipeline.md](observing-the-pipeline.md) | `kaappi ast` / `expand` / `ir` / `--disassemble`: read-only dumps of every stage between source and bytecode |
 | [llvm-backend.md](llvm-backend.md) | LLVM native backend: what LLVM provides vs what the runtime provides |
+| [windows.md](windows.md) | Windows aarch64 port: the platform.zig shim, the two deliberate degradations, the `windows` feature identifier, how to test on a Windows machine |
 | [adding-features.md](adding-features.md) | Step-by-step guides for the most common extension tasks |
 | [testing.md](testing.md) | The four test layers, how to run them, where new tests go |
 | [test-runner.md](test-runner.md) | `kaappi test`: the first-class SRFI-64 runner — discovery, worker subprocesses, `--json` schema, `--seed` |

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -1,0 +1,128 @@
+# Windows port (aarch64)
+
+Kaappi builds and runs on Windows 11 ARM64. The port keeps the runtime's
+integer-fd POSIX-shaped I/O layer intact by mapping it onto the C
+runtime's low-level io functions, and concentrates every syscall-level
+platform difference in one file.
+
+```bash
+zig build -Dtarget=aarch64-windows        # kaappi.exe, thottam.exe, kaappi-lsp.exe
+zig build test -Dtarget=aarch64-windows   # compiles unit-tests.exe (run it on Windows)
+```
+
+Builds use Zig's bundled mingw-w64, so no Windows SDK or MSVC install is
+needed on the build machine.
+
+## Architecture: src/platform.zig
+
+The runtime is written against integer file descriptors with POSIX
+`read`/`write`/`open`/`close` semantics. `src/platform.zig` is the single
+shim behind that surface:
+
+* **POSIX targets** forward to `std.posix` / `std.c` — the exact calls the
+  code made before the port; zero behavior change.
+* **Windows** maps the same calls onto the CRT's low-level io layer
+  (`_open`/`_read`/`_write`/`_close`: integer fds with 0/1/2 preopened),
+  with wide-char path entry points (`_wopen`, `_wstat64`, …) so UTF-8
+  paths survive regardless of the ANSI code page, plus a handful of Win32
+  calls for what the CRT lacks: `QueryPerformanceCounter` (monotonic
+  clock), console UTF-8 + VT mode, `GetModuleFileNameW` (self-exe path),
+  `CreateProcessW` (process spawning with correct argument quoting),
+  `LoadLibraryW`/`GetProcAddress` (FFI), `FindFirstFileW` (directory
+  iteration), and an auto-reset event for the reactor.
+
+Files are always opened `O_BINARY` — the CRT's default text mode would
+rewrite `\n`/`\r\n` and treat `^Z` as EOF, which R7RS ports must never
+see. Paths are normalized to `/` at the boundaries that produce them
+(argv script path, `GetModuleFileNameW`, `getcwd`, `_wfullpath`): Win32
+accepts forward slashes everywhere the runtime passes paths, and every
+internal path split/join is written for `/`.
+
+## Deliberate degradations
+
+Both mirror the WASI port's established shape:
+
+* **No non-blocking ports.** CRT fds have no `O_NONBLOCK`, so
+  `maybeSetNonblocking` (primitives_io.zig) is a comptime no-op — the
+  permanent analogue of the WASI probe-fail path. No read ever EAGAINs,
+  nothing registers an fd with the reactor, and fiber I/O degrades to
+  single-fiber blocking exactly as on a WASI host without
+  `fd_fdstat_set_flags`.
+* **Timer/notify-only reactor.** `WindowsEventBackend` (reactor.zig) is
+  one auto-reset Win32 event: `WaitForSingleObject` bounded by the
+  nearest timer deadline serves `thread-sleep!` and timed channel/mutex
+  waits, and `SetEvent` is the KEP-0002 cross-thread notify ring. The
+  fd-`arm` path returns an error — unreachable by construction since no
+  port ever goes non-blocking. Timer granularity is the OS scheduler's
+  (~15 ms), coarser than kqueue/epoll.
+
+Fibers, channels (including capacity-0 rendezvous), SRFI-18 OS threads,
+and cross-thread SharedChannel promotion all work on top of this.
+
+* **POSIX-only SRFI-170 raises.** uid/gid, `user-info`/`group-info`,
+  symlinks, hard links, FIFOs, `set-file-mode`, `umask`, `nice`,
+  `truncate-file`, and `set-file-times` raise a catchable file error
+  ("… not supported on Windows") — the names stay bound so portable code
+  can probe with `guard`. `file-info` works; inode, blksize, and blocks
+  report 0 (Windows has no such concepts at the CRT layer).
+* **`long` FFI type is 32-bit** on Windows (LLP64), faithfully matching
+  C. `normalizeType` (ffi.zig) routes it through the 32-bit `.int`
+  marshaling class there; `int64`/`uint64`/`size_t` use the 64-bit
+  carrier (`i64`) everywhere.
+* **thottam** builds and runs (`list`, `verify`, `--help`); `install`/
+  `remove`/`update` print a clear unsupported error — the install
+  pipeline shells out to POSIX userland (`cp -R`, `find`, `sh -c`) that
+  needs reimplementing on the shim first.
+* **REPL** uses a plain prompt + line reader (linenoise is termios-only):
+  the full REPL loop — debug commands, multi-line input, themes — works,
+  without history/completion/editing.
+
+## cond-expand / (features)
+
+Windows builds expose the `windows` feature identifier and omit `posix`
+(exactly one OS-class identifier per build — `types.platform_features`).
+Scheme tests that exercise POSIX-only functionality gate themselves:
+
+```scheme
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
+```
+
+## Testing on a Windows machine
+
+There is no Windows CI runner yet; the port is verified against a real
+Windows 11 ARM64 machine (e.g. a UTM VM with ssh). The unit-test binary
+compiles with the same target flag and runs on the box:
+
+```bash
+zig build test -Dtarget=aarch64-windows       # compiles; "unable to spawn" is expected
+scp .zig-cache/o/*/unit-tests.exe win11:...   # run it there
+```
+
+Two environment notes for the suite:
+
+* Create `C:\tmp` first — the Scheme/Zig tests write scratch files under
+  `/tmp/...`, which Windows resolves to `\tmp` on the current drive.
+* Run from a writable directory; a few tests create files in the CWD.
+
+Verified on Windows 11 ARM64 (build 26100): full unit suite (1037 pass,
+14 skipped — the skips are POSIX-permission/FIFO/uid tests), the complete
+R7RS suite, and every `tests/scheme/{smoke,compliance,continuations,
+hygiene,srfi,audit}` file. The fd-readiness unit suites
+(`tests_reactor.zig`, `tests_scheduler.zig`, `tests_port_io.zig`) are
+excluded on Windows by `vm_tests.zig` — they test POSIX pipe readiness
+that cannot exist under the no-non-blocking design.
+
+## Known gaps / follow-ups
+
+* Fiber I/O suspension needs a real Windows readiness backend (IOCP or
+  overlapped I/O) to lift the blocking-port degradation.
+* thottam package installation (replace the POSIX userland calls with
+  shim-based recursive copy/remove/walk; git is already spawned via
+  CreateProcessW and works when Git for Windows is on PATH).
+* `kaappi compile` links with `zig cc` when Zig is installed on the box;
+  untested beyond the doctor's smoke-link probe.
+* Console reads are byte-oriented ANSI/UTF-8; typing non-ASCII at the
+  plain REPL depends on the console's UTF-8 code page (set at startup).
+* Long paths (> 260 chars) need the system long-path opt-in.

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -13,6 +13,12 @@ zig build test -Dtarget=aarch64-windows   # compiles unit-tests.exe (run it on W
 Builds use Zig's bundled mingw-w64, so no Windows SDK or MSVC install is
 needed on the build machine.
 
+Cross-compilation is currently the **only** way to build: the official
+Zig 0.16.0 aarch64-windows toolchain access-violates compiling anything
+natively on Windows ARM64 (`zig build` and `zig build-exe` alike, on any
+project — #1613), so kaappi cannot be built on the machine it runs on
+until the upstream fix lands.
+
 ## Architecture: src/platform.zig
 
 The runtime is written against integer file descriptors with POSIX
@@ -95,7 +101,10 @@ CI covers the target twice (ci.yml): `windows-cross` cross-compiles the
 binaries and the unit-test exe from Linux, guarding the path release.yml
 ships with, and `windows-arm-test` executes the unit suite, the R7RS
 suite, and the VM-verified `.scm` suites on GitHub's hosted
-`windows-11-arm` runners on every PR. What CI can't run yet — the
+`windows-11-arm` runners on every PR. The execution job installs no
+toolchain — it downloads the binaries `windows-cross` built as an
+artifact, because native compilation on Windows ARM64 is broken in the
+Zig 0.16.0 toolchain itself (#1613). What CI can't run yet — the
 shell-based suites (#1612), the FFI suite (#1611), and interactive
 surfaces like the REPL — is verified against a real Windows 11 ARM64
 machine (e.g. a UTM VM with ssh). The unit-test binary compiles with the
@@ -145,6 +154,10 @@ the github-release skill's Step 10.
   files. Splitting the portable timer/notify tests out so they run on
   Windows is tracked with the readiness-backend work; runtime coverage
   today comes via the SRFI-18/fiber suites and the VM verification.
+* Native compilation on Windows ARM64 crashes in the Zig 0.16.0
+  toolchain (`zig build`/`zig build-exe` access-violate on any project,
+  #1613) — all builds must cross-compile, and `kaappi compile` on the
+  box (#1610) is blocked on the same upstream fix.
 * The FFI Scheme suite (`tests/scheme/ffi/`) doesn't run on Windows:
   POSIX library names (`"libm"`), unverified `(ffi-open #f)` semantics,
   and a `.dylib`/`.so`-only fixture (#1611).

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -91,12 +91,14 @@ Scheme tests that exercise POSIX-only functionality gate themselves:
 
 ## Testing on a Windows machine
 
-There is no Windows CI runner yet; the port is verified against a real
-Windows 11 ARM64 machine (e.g. a UTM VM with ssh). The unit-test binary
-compiles with the same target flag and runs on the box:
+CI has a compile-only `windows-cross` job (ci.yml) that keeps the target
+building, but GitHub has no ARM64 Windows runners, so nothing executes
+there; runtime behavior is verified against a real Windows 11 ARM64
+machine (e.g. a UTM VM with ssh). The unit-test binary compiles with the
+same target flag and runs on the box:
 
 ```bash
-zig build test -Dtarget=aarch64-windows       # compiles; "unable to spawn" is expected
+zig build test -Dtarget=aarch64-windows       # compiles; foreign run steps skip cleanly
 scp .zig-cache/o/*/unit-tests.exe win11:...   # run it there
 ```
 
@@ -132,6 +134,11 @@ smoke-test a release manually per the github-release skill's Step 10.
 
 * Fiber I/O suspension needs a real Windows readiness backend (IOCP or
   overlapped I/O) to lift the blocking-port degradation.
+* The reactor's timer/notify paths have no Windows unit coverage: the
+  suites that exercise them directly sit in the excluded fd-readiness
+  files. Splitting the portable timer/notify tests out so they run on
+  Windows is tracked with the readiness-backend work; runtime coverage
+  today comes via the SRFI-18/fiber suites and the VM verification.
 * thottam package installation (replace the POSIX userland calls with
   shim-based recursive copy/remove/walk; git is already spawned via
   CreateProcessW and works when Git for Windows is on PATH).

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -91,9 +91,13 @@ Scheme tests that exercise POSIX-only functionality gate themselves:
 
 ## Testing on a Windows machine
 
-CI has a compile-only `windows-cross` job (ci.yml) that keeps the target
-building, but GitHub has no ARM64 Windows runners, so nothing executes
-there; runtime behavior is verified against a real Windows 11 ARM64
+CI covers the target twice (ci.yml): `windows-cross` cross-compiles the
+binaries and the unit-test exe from Linux, guarding the path release.yml
+ships with, and `windows-arm-test` executes the unit suite, the R7RS
+suite, and the VM-verified `.scm` suites on GitHub's hosted
+`windows-11-arm` runners on every PR. What CI can't run yet — the
+shell-based suites (#1612), the FFI suite (#1611), and interactive
+surfaces like the REPL — is verified against a real Windows 11 ARM64
 machine (e.g. a UTM VM with ssh). The unit-test binary compiles with the
 same target flag and runs on the box:
 
@@ -111,7 +115,8 @@ Two environment notes for the suite:
 Verified on Windows 11 ARM64 (build 26100): full unit suite (1037 pass,
 14 skipped — the skips are POSIX-permission/FIFO/uid tests), the complete
 R7RS suite, and every `tests/scheme/{smoke,compliance,continuations,
-hygiene,srfi,audit}` file. The fd-readiness unit suites
+hygiene,srfi,audit}` file — the same set the `windows-arm-test` CI job
+now runs on every PR. The fd-readiness unit suites
 (`tests_reactor.zig`, `tests_scheduler.zig`, `tests_port_io.zig`) are
 excluded on Windows by `vm_tests.zig` — they test POSIX pipe readiness
 that cannot exist under the no-non-blocking design.
@@ -127,8 +132,9 @@ before any output; a stripped thottam.exe and small stripped test
 programs — including one spawning a 64 MB-stack thread — run fine, so
 it's specific to the large kaappi image; toolchain investigation
 pending). The post-release acceptance workflow checksums the Windows
-artifacts but cannot execute them (no GitHub ARM64 Windows runners) —
-smoke-test a release manually per the github-release skill's Step 10.
+artifacts but does not yet execute them (wiring it to the hosted
+`windows-11-arm` runners is open) — smoke-test a release manually per
+the github-release skill's Step 10.
 
 ## Known gaps / follow-ups
 
@@ -139,6 +145,12 @@ smoke-test a release manually per the github-release skill's Step 10.
   files. Splitting the portable timer/notify tests out so they run on
   Windows is tracked with the readiness-backend work; runtime coverage
   today comes via the SRFI-18/fiber suites and the VM verification.
+* The FFI Scheme suite (`tests/scheme/ffi/`) doesn't run on Windows:
+  POSIX library names (`"libm"`), unverified `(ffi-open #f)` semantics,
+  and a `.dylib`/`.so`-only fixture (#1611).
+* The shell-based suites — errors, compile, test-runner, pipeline,
+  doctor, fmt, cache, timings, the smoke `.sh` scripts, sandbox, and
+  robustness — don't run on Windows (#1612).
 * thottam package installation (replace the POSIX userland calls with
   shim-based recursive copy/remove/walk; git is already spawned via
   CreateProcessW and works when Git for Windows is on PATH).

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -114,6 +114,20 @@ hygiene,srfi,audit}` file. The fd-readiness unit suites
 excluded on Windows by `vm_tests.zig` — they test POSIX pipe readiness
 that cannot exist under the no-non-blocking design.
 
+## Releasing
+
+`release.yml` cross-compiles the Windows row from an ubuntu runner and
+ships `kaappi-aarch64-windows.exe`, `thottam-aarch64-windows.exe`, and
+`libkaappi_rt-aarch64-windows.lib` (the gnu-ABI static lib is emitted as
+`kaappi_rt.lib`). The row builds with `-Dstrip=false`: a **stripped**
+kaappi.exe access-violates at startup on ARM64 Windows (0xC0000005
+before any output; a stripped thottam.exe and small stripped test
+programs — including one spawning a 64 MB-stack thread — run fine, so
+it's specific to the large kaappi image; toolchain investigation
+pending). The post-release acceptance workflow checksums the Windows
+artifacts but cannot execute them (no GitHub ARM64 Windows runners) —
+smoke-test a release manually per the github-release skill's Step 10.
+
 ## Known gaps / follow-ups
 
 * Fiber I/O suspension needs a real Windows readiness backend (IOCP or
@@ -126,3 +140,6 @@ that cannot exist under the no-non-blocking design.
 * Console reads are byte-oriented ANSI/UTF-8; typing non-ASCII at the
   plain REPL depends on the console's UTF-8 code page (set at startup).
 * Long paths (> 260 chars) need the system long-path opt-in.
+* `-Dstrip=true` produces a kaappi.exe that access-violates at startup
+  on ARM64 Windows (see Releasing above) — releases ship it unstripped
+  until the toolchain issue is understood.

--- a/src/bench_reactor.zig
+++ b/src/bench_reactor.zig
@@ -19,6 +19,7 @@
 // Build/run:  zig build bench-reactor
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const reactor_mod = @import("reactor.zig");
 const fiber_mod = @import("fiber.zig");
 const Reactor = reactor_mod.Reactor;
@@ -37,7 +38,7 @@ fn makePipe() [2]std.c.fd_t {
 }
 
 fn closeFd(fd: std.c.fd_t) void {
-    _ = std.posix.system.close(fd);
+    _ = platform.close(fd);
 }
 
 const RearmResult = struct { arm_ns: f64, io_ns: f64 };
@@ -70,9 +71,9 @@ fn benchRearmVsIo(iters: u32) !RearmResult {
     const io_start = nowNs();
     i = 0;
     while (i < iters) : (i += 1) {
-        const wrote = std.posix.system.write(pipe[1], &buf, 1);
+        const wrote = platform.write(pipe[1], &buf, 1);
         if (wrote != 1) return error.ShortWrite;
-        const bytes_read = std.posix.system.read(pipe[0], &buf, 1);
+        const bytes_read = platform.read(pipe[0], &buf, 1);
         if (bytes_read != 1) return error.ShortRead;
     }
     const io_elapsed = nowNs() - io_start;
@@ -105,7 +106,7 @@ fn benchWakeAllFanout(allocator: std.mem.Allocator, n: u32) !FanoutResult {
     }
 
     var buf: [1]u8 = .{'x'};
-    const wrote = std.posix.system.write(pipe[1], &buf, 1);
+    const wrote = platform.write(pipe[1], &buf, 1);
     if (wrote != 1) return error.ShortWrite;
 
     var ready: std.ArrayList(*Fiber) = .empty;

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const build_options = @import("build_options");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
@@ -172,7 +173,7 @@ test "bytecode round-trip: simple function" {
     try writeFileWithTopLevel(allocator, &funcs_arr, hash, "test.scm", path);
     defer {
         // Clean up test file
-        _ = std.posix.system.unlink(@ptrCast(path));
+        _ = platform.unlink(path);
     }
 
     // Deserialize
@@ -212,7 +213,7 @@ test "bytecode round-trip: hash mismatch returns null" {
 
     try writeFileWithTopLevel(allocator, &funcs_arr, 12345, "test.scm", path);
     defer {
-        _ = std.posix.system.unlink(@ptrCast(path));
+        _ = platform.unlink(path);
     }
 
     // Try reading with different hash
@@ -268,7 +269,7 @@ test "bytecode round-trip: various constant types" {
 
     try writeFileWithTopLevel(allocator, &funcs_arr, hash, "test.scm", path);
     defer {
-        _ = std.posix.system.unlink(@ptrCast(path));
+        _ = platform.unlink(path);
     }
 
     const result = try readFileWithTopLevel(&gc, hash, path);
@@ -335,7 +336,7 @@ test "bytecode round-trip: nested functions" {
 
     try writeFileWithTopLevel(allocator, &funcs_arr, hash, "test.scm", path);
     defer {
-        _ = std.posix.system.unlink(@ptrCast(path));
+        _ = platform.unlink(path);
     }
 
     const result = try readFileWithTopLevel(&gc, hash, path);
@@ -478,19 +479,15 @@ test "bytecode validation rejects oversized function count header" {
     try w.writeU32(allocator, 1);
 
     const path = "/tmp/kaappi_test_bad_func_count.sbc";
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .TRUNC = true,
-    }, 0o644) catch unreachable;
-    defer _ = std.posix.system.close(fd);
-    defer _ = std.posix.system.unlink(@ptrCast(path));
+    const fd = platform.openWriteTrunc(path, 0o644) catch unreachable;
+    defer _ = platform.close(fd);
+    defer _ = platform.unlink(path);
 
     var total: usize = 0;
     while (total < w.buf.items.len) {
-        const wrote = std.posix.system.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
+        const wrote = platform.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
         if (wrote < 0) {
-            if (std.posix.errno(wrote) == .INTR) continue;
+            if (platform.errno(wrote) == .INTR) continue;
             break;
         }
         if (wrote == 0) break;
@@ -547,7 +544,7 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
 
     try writeFileWithTopLevel(allocator, &funcs_arr, hash, "test.scm", path);
     defer {
-        _ = std.posix.system.unlink(@ptrCast(path));
+        _ = platform.unlink(path);
     }
 
     const result = try readFileWithTopLevel(&gc, hash, path);
@@ -604,7 +601,7 @@ test "bytecode round-trip: line table and source_line preserved" {
     const path = "/tmp/kaappi_test_linetable.sbc";
 
     try writeFileWithTopLevel(allocator, &funcs_arr, hash, "test.scm", path);
-    defer _ = std.posix.system.unlink(@ptrCast(path));
+    defer _ = platform.unlink(path);
 
     const result = try readFileWithTopLevel(&gc, hash, path);
     try std.testing.expect(result != null);
@@ -660,19 +657,15 @@ test "bytecode validation rejects invalid opcode" {
     try w.writeU32(allocator, 0); // line_table count
 
     const path = "/tmp/kaappi_test_invalid_opcode.sbc";
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .TRUNC = true,
-    }, 0o644) catch unreachable;
-    defer _ = std.posix.system.close(fd);
-    defer _ = std.posix.system.unlink(@ptrCast(path));
+    const fd = platform.openWriteTrunc(path, 0o644) catch unreachable;
+    defer _ = platform.close(fd);
+    defer _ = platform.unlink(path);
 
     var total: usize = 0;
     while (total < w.buf.items.len) {
-        const wrote = std.posix.system.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
+        const wrote = platform.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
         if (wrote < 0) {
-            if (std.posix.errno(wrote) == .INTR) continue;
+            if (platform.errno(wrote) == .INTR) continue;
             break;
         }
         if (wrote == 0) break;

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -8,6 +8,7 @@
 //! the inverse.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const file_utils = @import("file_utils.zig");
@@ -411,7 +412,7 @@ pub fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?D
             var w: std.Io.Writer = .fixed(&buf);
             w.print("error: bytecode too large ({d} bytes, max {d})\n", .{ code_len, bf.MAX_CODE_BYTES }) catch {};
             const msg = w.buffered();
-            _ = std.posix.system.write(2, msg.ptr, msg.len);
+            _ = platform.write(2, msg.ptr, msg.len);
             return null;
         }
         const code_bytes = r.readBytes(code_len) catch return null;

--- a/src/bytecode_file_write.zig
+++ b/src/bytecode_file_write.zig
@@ -5,6 +5,7 @@
 //! via `bytecode_file.zig`; see `bytecode_file_read.zig` for the inverse.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const is_wasm = @import("builtin").os.tag == .wasi;
 const build_options = @import("build_options");
 const types = @import("types.zig");
@@ -317,18 +318,18 @@ fn writeFunctionsToBuffer(w: *Writer, allocator: std.mem.Allocator, top_level_fu
 
 fn writeBufferToFile(w: *Writer, path: []const u8) !void {
     if (comptime is_wasm) return BytecodeError.WriteError;
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .TRUNC = true,
-    }, 0o644) catch return BytecodeError.WriteError;
-    defer _ = std.posix.system.close(fd);
+    var path_buf: [platform.PATH_MAX]u8 = undefined;
+    if (path.len >= path_buf.len) return BytecodeError.WriteError;
+    @memcpy(path_buf[0..path.len], path);
+    path_buf[path.len] = 0;
+    const fd = platform.openWriteTrunc(path_buf[0..path.len :0], 0o644) catch return BytecodeError.WriteError;
+    defer _ = platform.close(fd);
 
     var total: usize = 0;
     while (total < w.buf.items.len) {
-        const result = std.posix.system.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
+        const result = platform.write(fd, w.buf.items.ptr + total, w.buf.items.len - total);
         if (result < 0) {
-            if (std.posix.errno(result) == .INTR) continue;
+            if (platform.errno(result) == .INTR) continue;
             return BytecodeError.WriteError;
         }
         if (result == 0) return BytecodeError.WriteError;

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -26,6 +26,7 @@
 //! caching entirely.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 const bytecode_file = @import("bytecode_file.zig");
 const kaappi_paths = @import("kaappi_paths.zig");
@@ -77,7 +78,7 @@ pub fn pathForSource(allocator: std.mem.Allocator, source_path: []const u8) ?[]u
     var dir_buf: [1024]u8 = undefined;
     const dir = cacheDir(&dir_buf) orelse return null;
 
-    var abs_buf: [std.posix.PATH_MAX]u8 = undefined;
+    var abs_buf: [platform.PATH_MAX]u8 = undefined;
     const key_path = absPath(source_path, &abs_buf) orelse source_path;
     const key = std.hash.Wyhash.hash(0, key_path);
 
@@ -88,13 +89,11 @@ pub fn pathForSource(allocator: std.mem.Allocator, source_path: []const u8) ?[]u
 /// which it does on both the cache read and write paths), returning the slice
 /// or null on failure so the caller falls back to the raw path.
 fn absPath(path: []const u8, buf: []u8) ?[]const u8 {
-    if (path.len == 0 or path.len >= std.posix.PATH_MAX or buf.len < std.posix.PATH_MAX) return null;
-    var z: [std.posix.PATH_MAX]u8 = undefined;
+    if (path.len == 0 or path.len >= platform.PATH_MAX or buf.len < platform.PATH_MAX) return null;
+    var z: [platform.PATH_MAX]u8 = undefined;
     @memcpy(z[0..path.len], path);
     z[path.len] = 0;
-    if (std.c.realpath(z[0..path.len :0], buf.ptr) == null) return null;
-    const len = std.mem.indexOfScalar(u8, buf[0..std.posix.PATH_MAX], 0) orelse return null;
-    return buf[0..len];
+    return platform.realPath(z[0..path.len :0], buf);
 }
 
 /// Best-effort creation of `~/.kaappi` and `~/.kaappi/cache`. Failures are
@@ -112,7 +111,7 @@ pub fn ensureDir() void {
 fn mkdirBestEffort(path: []const u8) void {
     var z: [1024]u8 = undefined;
     const zpath = zPath(&z, path) orelse return;
-    _ = std.c.mkdir(zpath, 0o755);
+    _ = platform.mkdir(zpath, 0o755);
 }
 
 /// Copies `path` into `buf` with a NUL terminator, returning a sentinel slice
@@ -129,7 +128,7 @@ fn zPath(buf: []u8, path: []const u8) ?[:0]const u8 {
 /// If `args` is a `kaappi cache …` invocation, handle it fully and return the
 /// process exit code; otherwise return null so normal CLI dispatch proceeds.
 pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
-    var it = args.iterate();
+    var it = platform.argsIterate(args);
     _ = it.skip(); // argv[0]
     const first = it.next() orelse return null;
     if (!std.mem.eql(u8, first, "cache")) return null;
@@ -255,15 +254,13 @@ pub fn renderStatus(allocator: std.mem.Allocator, dir: []const u8, w: *std.Io.Wr
         try w.writeAll("  (path too long)\n0 entries, 0 B\n");
         return;
     };
-    const dh = std.c.opendir(dir_z) orelse {
+    var dh = platform.DirIter.open(dir_z) orelse {
         try w.writeAll("  (empty — no cache directory yet)\n0 entries, 0 B\n");
         return;
     };
-    defer _ = std.c.closedir(dh);
+    defer dh.close();
 
-    while (std.c.readdir(dh)) |ent| {
-        const name_ptr: [*:0]const u8 = @ptrCast(&ent.name);
-        const name = std.mem.span(name_ptr);
+    while (dh.next()) |name| {
         if (!std.mem.endsWith(u8, name, ".sbc")) continue;
 
         const full = std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir, name }) catch continue;
@@ -350,7 +347,7 @@ pub fn clearDir(allocator: std.mem.Allocator, dir: []const u8) ClearResult {
 
     var z: [1024]u8 = undefined;
     const dir_z = zPath(&z, dir) orelse return res;
-    const dh = std.c.opendir(dir_z) orelse return res;
+    var dh = platform.DirIter.open(dir_z) orelse return res;
 
     var names: std.ArrayList([]u8) = .empty;
     defer {
@@ -358,9 +355,7 @@ pub fn clearDir(allocator: std.mem.Allocator, dir: []const u8) ClearResult {
         names.deinit(allocator);
     }
 
-    while (std.c.readdir(dh)) |ent| {
-        const name_ptr: [*:0]const u8 = @ptrCast(&ent.name);
-        const name = std.mem.span(name_ptr);
+    while (dh.next()) |name| {
         if (!std.mem.endsWith(u8, name, ".sbc")) continue;
         const dup = allocator.dupe(u8, name) catch continue;
         names.append(allocator, dup) catch {
@@ -368,7 +363,7 @@ pub fn clearDir(allocator: std.mem.Allocator, dir: []const u8) ClearResult {
             continue;
         };
     }
-    _ = std.c.closedir(dh);
+    dh.close();
 
     for (names.items) |name| {
         const full = std.fmt.allocPrintSentinel(allocator, "{s}/{s}", .{ dir, name }, 0) catch continue;
@@ -382,7 +377,7 @@ pub fn clearDir(allocator: std.mem.Allocator, dir: []const u8) ClearResult {
             defer allocator.free(d);
             break :blk d.len;
         } else |_| 0;
-        if (std.c.unlink(full) != 0) continue;
+        if (platform.unlink(full) != 0) continue;
         res.removed += 1;
         res.bytes += size;
     }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const completions = @import("completions.zig");
 const reporting = @import("reporting.zig");
 
@@ -154,7 +155,7 @@ pub const Options = struct {
 // ── Public API ─────────────────────────────────────────────────────────
 
 pub fn preScanSandbox(args: std.process.Args) bool {
-    var iter = args.iterate();
+    var iter = platform.argsIterate(args);
     _ = iter.skip();
     while (iter.next()) |arg| {
         if (std.mem.eql(u8, arg, "--sandbox")) return true;
@@ -178,7 +179,7 @@ pub fn preScanSandbox(args: std.process.Args) bool {
 
 pub fn parse(args: std.process.Args) Options {
     var opts: Options = .{};
-    var iter = args.iterate();
+    var iter = platform.argsIterate(args);
     _ = iter.skip();
 
     while (iter.next()) |arg| {
@@ -456,7 +457,20 @@ fn parsePositiveUsize(str: []const u8, flag_name: []const u8) usize {
 
 // ── Tests ──────────────────────────────────────────────────────────────
 
-fn testArgs(argv: []const [*:0]const u8) std.process.Args {
+fn testArgs(comptime argv: []const [*:0]const u8) std.process.Args {
+    if (comptime platform.is_windows) {
+        // Windows argv is one WTF-16 command line; join the (simple,
+        // quote-free) test arguments so the parse tests exercise the real
+        // Windows command-line iterator.
+        comptime var line: []const u8 = "";
+        inline for (argv, 0..) |arg, i| {
+            const s = comptime std.mem.span(arg);
+            comptime std.debug.assert(std.mem.indexOfAny(u8, s, " \t\"") == null);
+            if (i > 0) line = line ++ " ";
+            line = line ++ s;
+        }
+        return .{ .vector = comptime std.unicode.wtf8ToWtf16LeStringLiteral(line) };
+    }
     return .{ .vector = argv };
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 const kaappi_paths = @import("kaappi_paths.zig");
 const file_utils = @import("file_utils.zig");
@@ -65,7 +66,7 @@ pub const Config = struct {
 
 pub fn load() Config {
     var cfg: Config = .{};
-    const nc = std.c.getenv("NO_COLOR");
+    const nc = platform.getenv("NO_COLOR");
     const no_color = nc != null and std.mem.sliceTo(nc.?, 0).len > 0;
     if (no_color) {
         cfg.theme = Theme.no_color;
@@ -267,21 +268,21 @@ fn warnLine(line_num: usize, msg: []const u8) void {
     if (comptime builtin.is_test) return;
     var buf: [128]u8 = undefined;
     const out = std.fmt.bufPrint(&buf, "config: {s} (line {d})\n", .{ msg, line_num }) catch return;
-    _ = std.posix.system.write(2, out.ptr, out.len);
+    _ = platform.write(2, out.ptr, out.len);
 }
 
 fn warnColor(line_num: usize, key: []const u8, value: []const u8) void {
     if (comptime builtin.is_test) return;
     var buf: [192]u8 = undefined;
     const out = std.fmt.bufPrint(&buf, "config: unknown color '{s}' for {s} (line {d})\n", .{ value, key, line_num }) catch return;
-    _ = std.posix.system.write(2, out.ptr, out.len);
+    _ = platform.write(2, out.ptr, out.len);
 }
 
 fn warnKey(line_num: usize, key: []const u8) void {
     if (comptime builtin.is_test) return;
     var buf: [128]u8 = undefined;
     const out = std.fmt.bufPrint(&buf, "config: unknown key '{s}' (line {d})\n", .{ key, line_num }) catch return;
-    _ = std.posix.system.write(2, out.ptr, out.len);
+    _ = platform.write(2, out.ptr, out.len);
 }
 
 // --- Tests ---

--- a/src/crash.zig
+++ b/src/crash.zig
@@ -39,6 +39,7 @@
 //! never dangle at panic time.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 
@@ -108,9 +109,9 @@ pub fn reset() void {
 fn writeStderr(bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
-        const rc = std.posix.system.write(2, bytes.ptr + total, bytes.len - total);
+        const rc = platform.write(2, bytes.ptr + total, bytes.len - total);
         if (rc < 0) {
-            if (std.posix.errno(rc) == .INTR) continue;
+            if (platform.errno(rc) == .INTR) continue;
             return;
         }
         if (rc == 0) return;
@@ -170,7 +171,7 @@ pub fn PanicHandler(comptime binary_name: []const u8) type {
 /// normal dispatch.
 pub fn maybePanicTest(args: std.process.Args) void {
     const flag = "--panic-test";
-    var it = args.iterate();
+    var it = platform.argsIterate(args);
     _ = it.skip(); // argv[0]
     while (it.next()) |arg| {
         if (!std.mem.startsWith(u8, arg, flag)) continue;

--- a/src/doctor.zig
+++ b/src/doctor.zig
@@ -489,7 +489,7 @@ fn smokeLink(r: *Report, lib_dir: []const u8) void {
 
     const a = r.allocator();
 
-    const tmp = if (platform.getenv("TMPDIR")) |t| std.mem.sliceTo(t, 0) else "/tmp";
+    const tmp = platform.tempDir();
 
     // Work inside a private 0700 directory with a random name (mkdtemp-style).
     // `mkdir` refuses to reuse an existing name, so a hostile pre-planted
@@ -670,7 +670,8 @@ fn randomHex() [16]u8 {
 fn isNativeLibrary(name: []const u8) bool {
     return std.mem.endsWith(u8, name, ".dylib") or
         std.mem.endsWith(u8, name, ".so") or
-        std.mem.indexOf(u8, name, ".so.") != null;
+        std.mem.indexOf(u8, name, ".so.") != null or
+        std.mem.endsWith(u8, name, ".dll");
 }
 
 fn boolStr(b: bool) []const u8 {

--- a/src/doctor.zig
+++ b/src/doctor.zig
@@ -21,6 +21,7 @@
 //! PATH) describe a degraded-but-usable environment and keep the exit code 0.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 const reporting = @import("reporting.zig");
 const lsp_diagnostic = @import("lsp_diagnostic.zig");
@@ -148,7 +149,7 @@ pub const Request = struct {
 /// If `args` is a `kaappi doctor …` invocation, handle it fully and return the
 /// process exit code; otherwise return null so normal CLI dispatch proceeds.
 pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
-    var it = args.iterate();
+    var it = platform.argsIterate(args);
     _ = it.skip(); // argv[0]
     const first = it.next() orelse return null;
     if (!std.mem.eql(u8, first, "doctor")) return null;
@@ -358,7 +359,7 @@ fn collectNativeBackend(r: *Report) void {
     // An explicit KAAPPI_LIB_DIR that does not resolve is a definite
     // misconfiguration — the user asked for a specific runtime library and it
     // is not there — so it is the one FAIL-level finding doctor emits.
-    if (std.c.getenv("KAAPPI_LIB_DIR")) |env| {
+    if (platform.getenv("KAAPPI_LIB_DIR")) |env| {
         const dir = std.mem.sliceTo(env, 0);
         if (!dirExists(a, dir)) {
             r.add("native-backend", "KAAPPI_LIB_DIR", .fail, r.fmt("{s} (directory does not exist)", .{dir}), "point KAAPPI_LIB_DIR at a directory containing libkaappi_rt.a, or unset it to use the default search");
@@ -420,9 +421,9 @@ fn collectRepl(r: *Report) void {
         r.add("repl", "history", .warn, "cannot resolve ~/.kaappi (neither KAAPPI_HOME nor HOME set)", "set HOME (or KAAPPI_HOME) so REPL history has a home");
     }
 
-    const stdin_tty = std.c.isatty(0) != 0;
-    const stdout_tty = std.c.isatty(1) != 0;
-    const term = if (std.c.getenv("TERM")) |t| std.mem.sliceTo(t, 0) else "(unset)";
+    const stdin_tty = platform.isatty(0);
+    const stdout_tty = platform.isatty(1);
+    const term = if (platform.getenv("TERM")) |t| std.mem.sliceTo(t, 0) else "(unset)";
     r.add("repl", "terminal", .pass, r.fmt("stdin tty={s}, stdout tty={s}, TERM={s}", .{ boolStr(stdin_tty), boolStr(stdout_tty), term }), null);
 }
 
@@ -440,28 +441,26 @@ fn collectFfi(r: *Report) void {
         r.add("ffi", "native-libraries", .pass, "skipped: out of memory", null);
         return;
     };
-    const dir = std.c.opendir(lib_dir_z) orelse {
+    var dir = platform.DirIter.open(lib_dir_z) orelse {
         r.add("ffi", "native-libraries", .pass, r.fmt("no native libraries ({s} not present)", .{lib_dir}), null);
         return;
     };
-    defer _ = std.c.closedir(dir);
+    defer dir.close();
 
     var checked: usize = 0;
     var failed: usize = 0;
-    while (std.c.readdir(dir)) |entry| {
-        const name_ptr: [*:0]const u8 = @ptrCast(&entry.name);
-        const name = std.mem.span(name_ptr);
+    while (dir.next()) |name| {
         if (!isNativeLibrary(name)) continue;
         checked += 1;
 
         const full = r.fmt("{s}/{s}", .{ lib_dir, name });
         const full_z = a.dupeZ(u8, full) catch continue;
-        if (std.c.dlopen(full_z, std.c.RTLD{ .LAZY = true })) |handle| {
-            _ = std.c.dlclose(handle);
+        if (platform.dlOpen(full_z)) |handle| {
+            platform.dlClose(handle);
             r.add("ffi", r.fmt("{s}", .{name}), .pass, "dlopen succeeded", null);
         } else {
             failed += 1;
-            const err = if (std.c.dlerror()) |e| std.mem.span(e) else "dlopen failed";
+            const err = if (platform.dlError()) |e| std.mem.span(e) else "dlopen failed";
             r.add("ffi", r.fmt("{s}", .{name}), .warn, r.fmt("{s}", .{err}), "rebuild or reinstall the library (its dependencies may be missing)");
         }
     }
@@ -490,7 +489,7 @@ fn smokeLink(r: *Report, lib_dir: []const u8) void {
 
     const a = r.allocator();
 
-    const tmp = if (std.c.getenv("TMPDIR")) |t| std.mem.sliceTo(t, 0) else "/tmp";
+    const tmp = if (platform.getenv("TMPDIR")) |t| std.mem.sliceTo(t, 0) else "/tmp";
 
     // Work inside a private 0700 directory with a random name (mkdtemp-style).
     // `mkdir` refuses to reuse an existing name, so a hostile pre-planted
@@ -499,30 +498,30 @@ fn smokeLink(r: *Report, lib_dir: []const u8) void {
     const hex = randomHex();
     const dir_path = r.fmt("{s}/kaappi-doctor-{s}", .{ tmp, hex[0..] });
     const dir_z = a.dupeZ(u8, dir_path) catch return;
-    if (std.c.mkdir(dir_z, 0o700) != 0) {
+    if (platform.mkdir(dir_z, 0o700) != 0) {
         r.add("native-backend", "smoke-link", .pass, r.fmt("skipped (cannot create temp dir in {s})", .{tmp}), null);
         return;
     }
-    defer _ = std.c.rmdir(dir_z);
+    defer _ = platform.rmdir(dir_z);
 
     const c_path = r.fmt("{s}/smoke.c", .{dir_path});
     const out_path = r.fmt("{s}/smoke.out", .{dir_path});
     const c_path_z = a.dupeZ(u8, c_path) catch return;
     const out_path_z = a.dupeZ(u8, out_path) catch return;
-    defer _ = std.c.unlink(c_path_z);
-    defer _ = std.c.unlink(out_path_z);
+    defer _ = platform.unlink(c_path_z);
+    defer _ = platform.unlink(out_path_z);
 
     const c_source =
         \\extern unsigned long long kaappi_fixnum_add(unsigned long long, unsigned long long);
         \\int main(void) { return (int)kaappi_fixnum_add(0, 0); }
         \\
     ;
-    const cfd = std.posix.openatZ(std.posix.AT.FDCWD, c_path_z, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true, .EXCL = true }, 0o600) catch {
+    const cfd = platform.openWriteTruncExcl(c_path_z, 0o600) catch {
         r.add("native-backend", "smoke-link", .pass, r.fmt("skipped (cannot write temp file in {s})", .{tmp}), null);
         return;
     };
     reporting.writeToFd(cfd, c_source);
-    _ = std.posix.system.close(cfd);
+    _ = platform.close(cfd);
 
     // A C compiler capable of driving the linker is required; `zig` needs the
     // `cc` subcommand. Prefer zig cc (per the repo's linking rule), then cc.
@@ -554,32 +553,44 @@ fn smokeLink(r: *Report, lib_dir: []const u8) void {
     push(&argv, &argc, a, "-lkaappi_rt");
     push(&argv, &argc, a, "-lc");
     push(&argv, &argc, a, "-lm");
-    push(&argv, &argc, a, "-lpthread");
+    if (comptime !platform.is_windows) push(&argv, &argc, a, "-lpthread");
     argv[argc] = null;
 
-    const child = std.posix.system.fork();
-    if (child < 0) {
-        r.add("native-backend", "smoke-link", .pass, "skipped (fork failed)", null);
-        return;
-    }
-    if (child == 0) {
-        // Silence the compiler's own diagnostics so they don't pollute doctor's
-        // output; the link's exit status is all we inspect.
-        const devnull = std.posix.openatZ(std.posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .WRONLY }, 0) catch -1;
-        if (devnull >= 0) {
-            _ = std.c.dup2(devnull, 1);
-            _ = std.c.dup2(devnull, 2);
+    const link_ok = blk: {
+        if (comptime platform.is_windows) {
+            // winSpawnCapture already silences the compiler (stdout captured,
+            // stderr → NUL); only the exit status matters here.
+            var argv_slices: [16][]const u8 = undefined;
+            for (argv[0..argc], 0..) |arg, i| argv_slices[i] = std.mem.sliceTo(arg.?, 0);
+            const out = platform.winSpawnCapture(a, argv_slices[0..argc], null) catch break :blk false;
+            a.free(out);
+            break :blk true;
         }
-        _ = std.posix.system.execve(@ptrCast(argv[0].?), @ptrCast(&argv), @ptrCast(std.c.environ));
-        std.process.exit(127);
-    }
+        const child = std.posix.system.fork();
+        if (child < 0) {
+            r.add("native-backend", "smoke-link", .pass, "skipped (fork failed)", null);
+            return;
+        }
+        if (child == 0) {
+            // Silence the compiler's own diagnostics so they don't pollute doctor's
+            // output; the link's exit status is all we inspect.
+            const devnull = platform.openNullSink() catch -1;
+            if (devnull >= 0) {
+                _ = std.c.dup2(devnull, 1);
+                _ = std.c.dup2(devnull, 2);
+            }
+            _ = std.posix.system.execve(@ptrCast(argv[0].?), @ptrCast(&argv), @ptrCast(std.c.environ));
+            std.process.exit(127);
+        }
 
-    var status: c_int = 0;
-    _ = std.c.waitpid(child, &status, 0);
-    const raw: c_uint = @bitCast(status);
-    const exited = (raw & 0x7f) == 0;
-    const code = (raw >> 8) & 0xff;
-    if (exited and code == 0) {
+        var status: c_int = 0;
+        _ = std.c.waitpid(child, &status, 0);
+        const raw: c_uint = @bitCast(status);
+        const exited = (raw & 0x7f) == 0;
+        const code = (raw >> 8) & 0xff;
+        break :blk exited and code == 0;
+    };
+    if (link_ok) {
         r.add("native-backend", "smoke-link", .pass, r.fmt("linked a test program against libkaappi_rt.a in {s}", .{lib_dir}), null);
     } else {
         r.add("native-backend", "smoke-link", .warn, "link against libkaappi_rt.a failed", "run 'kaappi compile <file.scm>' to see the linker error");
@@ -590,20 +601,18 @@ fn smokeLink(r: *Report, lib_dir: []const u8) void {
 
 fn dirExists(a: std.mem.Allocator, path: []const u8) bool {
     const path_z = a.dupeZ(u8, path) catch return false;
-    const fd = std.posix.openatZ(std.posix.AT.FDCWD, path_z, .{ .DIRECTORY = true }, 0) catch return false;
-    _ = std.posix.system.close(fd);
-    return true;
+    return platform.isDir(path_z);
 }
 
 fn dirWritable(a: std.mem.Allocator, path: []const u8) bool {
     const path_z = a.dupeZ(u8, path) catch return false;
-    return std.c.access(path_z, std.posix.W_OK) == 0;
+    return platform.accessWritable(path_z);
 }
 
 fn fileExists(a: std.mem.Allocator, path: []const u8) bool {
     const path_z = a.dupeZ(u8, path) catch return false;
-    const fd = std.posix.openatZ(std.posix.AT.FDCWD, path_z, .{ .ACCMODE = .RDONLY }, 0) catch return false;
-    _ = std.posix.system.close(fd);
+    const fd = platform.openRead(path_z) catch return false;
+    _ = platform.close(fd);
     return true;
 }
 
@@ -615,19 +624,19 @@ fn hasArchive(a: std.mem.Allocator, dir: []const u8) bool {
 /// Returns the first `<dir>/name` on PATH that opens for reading, allocated in
 /// `a`. Mirrors native_compiler's discovery so doctor and compile agree.
 fn findInPath(a: std.mem.Allocator, name: []const u8) ?[]const u8 {
-    const path_env = std.c.getenv("PATH") orelse return null;
+    const path_env = platform.getenv("PATH") orelse return null;
     const path_str = std.mem.sliceTo(path_env, 0);
-    var iter = std.mem.splitScalar(u8, path_str, ':');
+    var iter = std.mem.splitScalar(u8, path_str, platform.path_list_sep);
     while (iter.next()) |raw_dir| {
         if (raw_dir.len == 0) continue;
         // Trim trailing slashes so a "…/bin/" PATH entry doesn't render as
         // "…/bin//kaappi" — this string is shown to the user.
-        const dir = std.mem.trimEnd(u8, raw_dir, "/");
+        const dir = std.mem.trimEnd(u8, raw_dir, if (platform.is_windows) "/\\" else "/");
         if (dir.len == 0) continue;
-        const full = std.fmt.allocPrint(a, "{s}/{s}", .{ dir, name }) catch continue;
+        const full = std.fmt.allocPrint(a, "{s}/{s}{s}", .{ dir, name, platform.exe_suffix }) catch continue;
         const full_z = a.dupeZ(u8, full) catch continue;
-        const fd = std.posix.openatZ(std.posix.AT.FDCWD, full_z, .{ .ACCMODE = .RDONLY }, 0) catch continue;
-        _ = std.posix.system.close(fd);
+        const fd = platform.openRead(full_z) catch continue;
+        _ = platform.close(fd);
         return full;
     }
     return null;
@@ -636,10 +645,9 @@ fn findInPath(a: std.mem.Allocator, name: []const u8) ?[]const u8 {
 /// Canonicalizes `path` via realpath into an arena copy (or null on failure).
 fn realpath(a: std.mem.Allocator, path: []const u8) ?[]const u8 {
     const path_z = a.dupeZ(u8, path) catch return null;
-    var buf: [std.posix.PATH_MAX]u8 = undefined;
-    const resolved = std.c.realpath(path_z, &buf) orelse return null;
-    const len = std.mem.indexOfScalar(u8, resolved[0..buf.len], 0) orelse return null;
-    return a.dupe(u8, resolved[0..len]) catch null;
+    var buf: [platform.PATH_MAX]u8 = undefined;
+    const resolved = platform.realPath(path_z, &buf) orelse return null;
+    return a.dupe(u8, resolved) catch null;
 }
 
 /// 16 lowercase hex chars of entropy for a private temp-dir name. Reads
@@ -647,14 +655,14 @@ fn realpath(a: std.mem.Allocator, path: []const u8) ?[]const u8 {
 /// monotonic clock only if that device is unavailable.
 fn randomHex() [16]u8 {
     var raw: [8]u8 = undefined;
-    if (std.posix.openatZ(std.posix.AT.FDCWD, "/dev/urandom", .{ .ACCMODE = .RDONLY }, 0)) |fd| {
-        const n = std.posix.read(fd, &raw) catch 0;
-        _ = std.posix.system.close(fd);
-        if (n == raw.len) return std.fmt.bytesToHex(raw, .lower);
-    } else |_| {}
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    const seed = @as(u64, @bitCast(ts.sec)) ^ @as(u64, @bitCast(ts.nsec));
+    if (comptime !platform.is_windows) {
+        if (platform.openRead("/dev/urandom")) |fd| {
+            const n = platform.read(fd, &raw, raw.len);
+            _ = platform.close(fd);
+            if (n == raw.len) return std.fmt.bytesToHex(raw, .lower);
+        } else |_| {}
+    }
+    const seed = platform.monotonicNs() ^ (@as(u64, @intCast(@abs(platform.realTime().nsec))) << 17);
     std.mem.writeInt(u64, raw[0..8], seed, .little);
     return std.fmt.bytesToHex(raw, .lower);
 }

--- a/src/explain.zig
+++ b/src/explain.zig
@@ -16,6 +16,7 @@
 //!                                    (the source a docs generator consumes)
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const diagnostics = @import("diagnostics.zig");
 const lsp_diagnostic = @import("lsp_diagnostic.zig");
 const reporting = @import("reporting.zig");
@@ -39,7 +40,7 @@ pub const Request = struct {
 /// `explain` is a pure query over the static registry — it needs no VM, GC, or
 /// library setup, so main dispatches it before any of that is created.
 pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
-    var it = args.iterate();
+    var it = platform.argsIterate(args);
     _ = it.skip(); // argv[0]
     const first = it.next() orelse return null;
     if (!std.mem.eql(u8, first, "explain")) return null;

--- a/src/features.zig
+++ b/src/features.zig
@@ -26,6 +26,7 @@
 //! (WASM's entry point just runs a file).
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 const types = @import("types.zig");
@@ -57,7 +58,7 @@ const max_builtin_srfis = 32;
 /// the process exit code; otherwise return null so normal CLI dispatch
 /// proceeds.
 pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
-    var it = args.iterate();
+    var it = platform.argsIterate(args);
     _ = it.skip(); // argv[0]
     const first = it.next() orelse return null;
     if (!std.mem.eql(u8, first, "features")) return null;

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const VM = @import("vm.zig").VM;
@@ -95,13 +96,13 @@ fn toUnsignedArgOpt(v: Value) ?u64 {
     return @intCast(fixnum);
 }
 
-fn toLongArg(v: Value, declared: FfiType) error{TypeError}!c_long {
+fn toLongArg(v: Value, declared: FfiType) error{TypeError}!i64 {
     if (declared == .uint64 or declared == .size_type) {
         const unsigned = toUnsignedArgOpt(v) orelse return error.TypeError;
-        const narrowed = std.math.cast(c_ulong, unsigned) orelse return error.TypeError;
+        const narrowed = std.math.cast(u64, unsigned) orelse return error.TypeError;
         return @bitCast(narrowed);
     }
-    return toCheckedInt(c_long, v);
+    return toCheckedInt(i64, v);
 }
 
 /// C-truthiness of a value bound to a `bool` FFI parameter. `validateArg`
@@ -130,13 +131,13 @@ fn toCString(v: Value, buf: *[4096]u8) ?[*:0]const u8 {
 const MAX_FIXNUM: i64 = 0x7FFF_FFFF_FFFF; // 2^47 - 1
 const MIN_FIXNUM: i64 = -0x8000_0000_0000; // -2^47
 
-fn marshalLongReturn(result: c_long, gc: *memory.GC) !Value {
+fn marshalLongReturn(result: i64, gc: *memory.GC) !Value {
     if (result >= MIN_FIXNUM and result <= MAX_FIXNUM)
         return types.makeFixnum(@intCast(result));
     return gc.allocBignumFromI64(result) catch return error.OutOfMemory;
 }
 
-fn marshalLongOrUlong(result: c_long, orig_type: FfiType, gc: *memory.GC) !Value {
+fn marshalLongOrUlong(result: i64, orig_type: FfiType, gc: *memory.GC) !Value {
     if (orig_type == .uint32 or orig_type == .uint64 or orig_type == .size_type) {
         const unsigned: u64 = @bitCast(@as(i64, result));
         if (orig_type == .uint32) {
@@ -157,7 +158,7 @@ fn marshalReturn(comptime T: type, result: T, rt: FfiType, gc: *memory.GC) !Valu
         return types.makeFlonum(result);
     } else if (T == c_int) {
         return types.makeFixnum(@intCast(result));
-    } else if (T == c_long) {
+    } else if (T == i64) {
         return marshalLongOrUlong(result, rt, gc);
     } else if (T == void) {
         return types.VOID;
@@ -212,6 +213,12 @@ fn normalizeType(t: FfiType) FfiType {
     return switch (t) {
         .int8, .int16, .int32, .char_type, .bool_type, .uint8, .uint16 => .int,
         .int64, .uint32, .uint64, .size_type => .long,
+        // LLP64 (Windows): C `long` is 32-bit — route it through the .int
+        // (c_int) class so arguments are range-checked to 32 bits and a
+        // returned value reads the correct register half. Everywhere else
+        // C long is 64-bit and stays in the .long class, whose carrier
+        // type is i64 (== c_long on LP64).
+        .long => if (platform.is_windows) .int else .long,
         else => t,
     };
 }
@@ -335,7 +342,7 @@ const canonical_types = [_]FfiType{ .int, .long, .double, .float, .string, .poin
 fn CParamType(comptime t: FfiType) type {
     return switch (t) {
         .int => c_int,
-        .long => c_long,
+        .long => i64,
         .double => f64,
         .float => f32,
         .string => [*:0]const u8,
@@ -347,7 +354,7 @@ fn CParamType(comptime t: FfiType) type {
 fn CReturnType(comptime t: FfiType) type {
     return switch (t) {
         .int => c_int,
-        .long => c_long,
+        .long => i64,
         .double => f64,
         .float => f32,
         .string => ?[*:0]const u8,
@@ -514,13 +521,13 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     var bufs: [4][4096]u8 = undefined;
 
     if (p0 == .pointer and p1 == .long and p2 == .long and p3 == .pointer and rt == .void_type) {
-        const f: *const fn (?*anyopaque, c_long, c_long, ?*anyopaque) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
+        const f: *const fn (?*anyopaque, i64, i64, ?*anyopaque) callconv(.c) void = @ptrCast(@alignCast(ffi_fn.symbol));
         f(try marshalArg(.pointer, args[0], &bufs[0], ffi_fn.param_types[0]), try marshalArg(.long, args[1], &bufs[1], ffi_fn.param_types[1]), try marshalArg(.long, args[2], &bufs[2], ffi_fn.param_types[2]), try marshalArg(.pointer, args[3], &bufs[3], ffi_fn.param_types[3]));
         return types.VOID;
     }
 
     if (p0 == .pointer and p1 == .long and p2 == .long and p3 == .pointer and rt == .int) {
-        const f: *const fn (?*anyopaque, c_long, c_long, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
+        const f: *const fn (?*anyopaque, i64, i64, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
         const result = f(try marshalArg(.pointer, args[0], &bufs[0], ffi_fn.param_types[0]), try marshalArg(.long, args[1], &bufs[1], ffi_fn.param_types[1]), try marshalArg(.long, args[2], &bufs[2], ffi_fn.param_types[2]), try marshalArg(.pointer, args[3], &bufs[3], ffi_fn.param_types[3]));
         return marshalRetValue(.int, result, ffi_fn.return_type, gc);
     }
@@ -532,13 +539,13 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     }
 
     if (p0 == .pointer and p1 == .pointer and p2 == .long and p3 == .long and rt == .pointer) {
-        const f: *const fn (?*anyopaque, ?*anyopaque, c_long, c_long) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
+        const f: *const fn (?*anyopaque, ?*anyopaque, i64, i64) callconv(.c) ?*anyopaque = @ptrCast(@alignCast(ffi_fn.symbol));
         const result = f(try marshalArg(.pointer, args[0], &bufs[0], ffi_fn.param_types[0]), try marshalArg(.pointer, args[1], &bufs[1], ffi_fn.param_types[1]), try marshalArg(.long, args[2], &bufs[2], ffi_fn.param_types[2]), try marshalArg(.long, args[3], &bufs[3], ffi_fn.param_types[3]));
         return marshalRetValue(.pointer, result, ffi_fn.return_type, gc);
     }
 
     if (p0 == .pointer and p1 == .long and p2 == .long and p3 == .long and rt == .int) {
-        const f: *const fn (?*anyopaque, c_long, c_long, c_long) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
+        const f: *const fn (?*anyopaque, i64, i64, i64) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
         const result = f(try marshalArg(.pointer, args[0], &bufs[0], ffi_fn.param_types[0]), try marshalArg(.long, args[1], &bufs[1], ffi_fn.param_types[1]), try marshalArg(.long, args[2], &bufs[2], ffi_fn.param_types[2]), try marshalArg(.long, args[3], &bufs[3], ffi_fn.param_types[3]));
         return marshalRetValue(.int, result, ffi_fn.return_type, gc);
     }
@@ -603,7 +610,7 @@ fn callFfi5(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
     }
 
     if (p0 == .pointer and p1 == .pointer and p2 == .long and p3 == .int and p4 == .pointer and rt == .int) {
-        const f: *const fn (?*anyopaque, ?*anyopaque, c_long, c_int, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
+        const f: *const fn (?*anyopaque, ?*anyopaque, i64, c_int, ?*anyopaque) callconv(.c) c_int = @ptrCast(@alignCast(ffi_fn.symbol));
         const result = f(try marshalArg(.pointer, args[0], &bufs[0], ffi_fn.param_types[0]), try marshalArg(.pointer, args[1], &bufs[1], ffi_fn.param_types[1]), try marshalArg(.long, args[2], &bufs[2], ffi_fn.param_types[2]), try marshalArg(.int, args[3], &bufs[3], ffi_fn.param_types[3]), try marshalArg(.pointer, args[4], &bufs[4], ffi_fn.param_types[4]));
         return marshalRetValue(.int, result, ffi_fn.return_type, gc);
     }
@@ -714,7 +721,7 @@ test "marshalLongReturn: large positive 64-bit value" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
-    const large: c_long = std.math.maxInt(i64);
+    const large: i64 = std.math.maxInt(i64);
     const val = try marshalLongReturn(large, &gc);
     try std.testing.expect(types.isBignum(val));
     const bn = types.toBignum(val);
@@ -726,7 +733,7 @@ test "marshalLongReturn: large negative 64-bit value" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
-    const large: c_long = std.math.minInt(i64);
+    const large: i64 = std.math.minInt(i64);
     const val = try marshalLongReturn(large, &gc);
     try std.testing.expect(types.isBignum(val));
     const bn = types.toBignum(val);
@@ -965,8 +972,8 @@ test "toUnsignedArgOpt: rejects negative and multi-limb bignums" {
 
 test "toLongArg: signed types use signed path" {
     const v = types.makeFixnum(42);
-    try std.testing.expectEqual(@as(c_long, 42), try toLongArg(v, .long));
-    try std.testing.expectEqual(@as(c_long, 42), try toLongArg(v, .int64));
+    try std.testing.expectEqual(@as(i64, 42), try toLongArg(v, .long));
+    try std.testing.expectEqual(@as(i64, 42), try toLongArg(v, .int64));
 }
 
 test "toLongArg: uint64 accepts values >= 2^63" {

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const memory = @import("memory.zig");
@@ -10,9 +11,7 @@ const VMError = vm_mod.VMError;
 const CallFrame = types.CallFrame;
 
 pub fn clockNs() u64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return @as(u64, @intCast(ts.sec)) * 1_000_000_000 + @as(u64, @intCast(ts.nsec));
+    return platform.monotonicNs();
 }
 
 pub const FiberStatus = enum(u8) {
@@ -75,7 +74,7 @@ pub const Fiber = struct {
     /// on the reactor (KEP-0001 Phase 3). Unused by anything shipped in
     /// Phase 2, but the fields must exist now so the scheduler/GC plumbing
     /// can be built and tested ahead of the port-layer primitives.
-    io_fd: ?std.posix.fd_t = null,
+    io_fd: ?platform.fd_t = null,
     io_interest: reactor_mod.Interest = .read,
     /// Pins an in-flight read/write buffer across GC while a primitive is
     /// parked on the reactor. Traced by markFiberState/referencesYoung.
@@ -1038,7 +1037,7 @@ fn wakeReadyFiber(f: *Fiber) void {
 /// clean "port closed" error instead of sleeping on an fd that will never
 /// fire (the caller unregisters it from the reactor right after this).
 /// Mirrors wakeChannelWaiters' iterate-and-flip discipline.
-pub fn wakeIoWaitersOnFd(sched: *FiberScheduler, fd: std.posix.fd_t) void {
+pub fn wakeIoWaitersOnFd(sched: *FiberScheduler, fd: platform.fd_t) void {
     for (sched.fibers.items) |f| {
         if (f) |fiber| {
             if (fiber.status == .io_waiting and fiber.io_fd == fd) {
@@ -1075,7 +1074,7 @@ const IoWait = struct {
 ///   reports the fd ready or a close-port wake intervenes, then returns so
 ///   the caller retries its syscall. Blocking main on I/O this way keeps
 ///   sibling fibers running while preserving blocking-read semantics.
-pub fn waitForFd(vm: *VM, fd: std.posix.fd_t, interest: reactor_mod.Interest) VMError!void {
+pub fn waitForFd(vm: *VM, fd: platform.fd_t, interest: reactor_mod.Interest) VMError!void {
     const ctx = try ensureScheduler(vm);
     const me = vm.current_fiber orelse return VMError.InvalidArgument;
     const my_idx = ctx.sched.current_idx;

--- a/src/file_utils.zig
+++ b/src/file_utils.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin_os = @import("builtin").os;
 const is_wasm = builtin_os.tag == .wasi;
 
@@ -11,21 +12,19 @@ pub fn readWholeFile(allocator: std.mem.Allocator, path: []const u8, max_size: u
     } else blk: {
         const path_z = allocator.dupeZ(u8, path) catch return error.OutOfMemory;
         defer allocator.free(path_z);
-        const raw_fd = std.c.open(path_z, .{});
-        if (raw_fd < 0) return error.FileNotFound;
-        break :blk raw_fd;
+        break :blk platform.openRead(path_z) catch return error.FileNotFound;
     };
-    defer _ = std.c.close(fd);
+    defer platform.close(fd);
 
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(allocator);
 
     var tmp: [4096]u8 = undefined;
     while (true) {
-        const raw = std.c.read(fd, &tmp, tmp.len);
+        const raw = platform.read(fd, &tmp, tmp.len);
         if (raw == 0) break;
         if (raw < 0) {
-            if (std.posix.errno(raw) == .INTR) continue;
+            if (platform.errno(raw) == .INTR) continue;
             return error.InputOutput;
         }
         const bytes_read: usize = @intCast(raw);

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -27,6 +27,7 @@
 //! a source file.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const reader_mod = @import("reader.zig");
@@ -574,9 +575,8 @@ fn writeWholeFile(path: []const u8, bytes: []const u8) !void {
     if (path.len >= buf.len) return error.NameTooLong;
     @memcpy(buf[0..path.len], path);
     buf[path.len] = 0;
-    const path_z: [*:0]const u8 = @ptrCast(&buf);
-    const fd = try std.posix.openatZ(std.posix.AT.FDCWD, path_z, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, 0o644);
-    defer _ = std.posix.system.close(fd);
+    const fd = platform.openWriteTrunc(buf[0..path.len :0], 0o644) catch |err| return err;
+    defer _ = platform.close(fd);
     reporting.writeToFd(fd, bytes);
 }
 
@@ -585,10 +585,10 @@ fn readAllStdin(allocator: std.mem.Allocator) ![]u8 {
     defer result.deinit(allocator);
     var tmp: [4096]u8 = undefined;
     while (true) {
-        const raw = std.c.read(0, &tmp, tmp.len);
+        const raw = platform.read(0, &tmp, tmp.len);
         if (raw == 0) break;
         if (raw < 0) {
-            if (std.posix.errno(raw) == .INTR) continue;
+            if (platform.errno(raw) == .INTR) continue;
             return error.ReadFailed;
         }
         const n: usize = @intCast(raw);

--- a/src/fuzz_gen_main.zig
+++ b/src/fuzz_gen_main.zig
@@ -6,10 +6,11 @@
 //! releases.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const fuzz_gen = @import("fuzz_gen.zig");
 
 fn fail(msg: []const u8) noreturn {
-    _ = std.posix.system.write(2, msg.ptr, msg.len);
+    _ = platform.write(2, msg.ptr, msg.len);
     std.process.exit(2);
 }
 
@@ -59,9 +60,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // program would be diffed as if it were the real seed.
     var off: usize = 0;
     while (off < src.len) {
-        const rc = std.posix.system.write(1, src.ptr + off, src.len - off);
+        const rc = platform.write(1, src.ptr + off, src.len - off);
         if (rc < 0) {
-            if (std.posix.errno(rc) == .INTR) continue;
+            if (platform.errno(rc) == .INTR) continue;
             std.process.exit(1);
         }
         if (rc == 0) std.process.exit(1);

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 const types = @import("types.zig");
 const memory_mod = @import("memory.zig");
@@ -36,9 +37,7 @@ const build_options = @import("build_options");
 const GC_THRESHOLD: usize = build_options.gc_initial_threshold;
 
 fn clockNs() u64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return @intCast(@as(i128, ts.sec) * 1_000_000_000 + ts.nsec);
+    return platform.monotonicNs();
 }
 
 pub fn collect(gc: *GC) void {
@@ -951,13 +950,13 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                 if (port.write_buf) |wb| {
                     var start = port.write_buf_start;
                     while (start < port.write_buf_len) {
-                        const rc = std.posix.system.write(port.fd, wb.ptr + start, port.write_buf_len - start);
-                        if (rc < 0 and std.posix.errno(rc) == .INTR) continue;
+                        const rc = platform.write(port.fd, wb.ptr + start, port.write_buf_len - start);
+                        if (rc < 0 and platform.errno(rc) == .INTR) continue;
                         if (rc <= 0) break;
                         start += @as(usize, @intCast(rc));
                     }
                 }
-                _ = std.posix.system.close(port.fd);
+                _ = platform.close(port.fd);
             }
             if (port.write_buf) |wb| {
                 gc.allocator.free(wb);
@@ -1052,7 +1051,7 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
         .directory_object => {
             const d = obj.as(types.DirectoryObject);
             if (d.dir) |dir| {
-                _ = std.c.closedir(@ptrCast(@alignCast(dir)));
+                platform.dirIterDestroy(@ptrCast(@alignCast(dir)));
                 d.dir = null;
             }
             poisonAndDestroy(gc, types.DirectoryObject, d);

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -174,11 +174,28 @@ fn readMessage(allocator: std.mem.Allocator) ?[]u8 {
     return body;
 }
 
+/// Writes the whole slice, retrying short writes and EINTR: a partial
+/// LSP header or payload desynchronizes the JSON-RPC framing for every
+/// later message, so give up on the frame only on a hard write error.
+fn writeAll(fd: platform.fd_t, bytes: []const u8) bool {
+    var offset: usize = 0;
+    while (offset < bytes.len) {
+        const n = platform.write(fd, bytes.ptr + offset, bytes.len - offset);
+        if (n < 0) {
+            if (platform.errno(n) == .INTR) continue;
+            return false;
+        }
+        if (n == 0) return false;
+        offset += @intCast(n);
+    }
+    return true;
+}
+
 fn writeMessage(allocator: std.mem.Allocator, json: []const u8) void {
     var header: [64]u8 = undefined;
     const h = std.fmt.bufPrint(&header, "Content-Length: {d}\r\n\r\n", .{json.len}) catch return;
-    _ = platform.write(1, h.ptr, h.len);
-    _ = platform.write(1, json.ptr, json.len);
+    if (!writeAll(1, h)) return;
+    _ = writeAll(1, json);
     _ = allocator;
 }
 

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 pub const types = @import("types.zig");
 pub const memory = @import("memory.zig");
@@ -38,7 +39,7 @@ const initialize_result =
     "{\"capabilities\":{\"textDocumentSync\":1,\"completionProvider\":{\"resolveProvider\":false,\"triggerCharacters\":[]},\"hoverProvider\":true,\"documentSymbolProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true},\"serverInfo\":{\"name\":\"kaappi-lsp\",\"version\":\"" ++ version ++ "\"}}";
 
 fn log(msg: []const u8) void {
-    _ = std.posix.system.write(2, msg.ptr, msg.len);
+    _ = platform.write(2, msg.ptr, msg.len);
 }
 
 fn logFmt(buf: []u8, comptime fmt: []const u8, args: anytype) void {
@@ -124,7 +125,11 @@ fn readMessage(allocator: std.mem.Allocator) ?[]u8 {
     // Read headers until blank line
     while (true) {
         var byte: [1]u8 = undefined;
-        const n = std.posix.read(0, &byte) catch return null;
+        const n = platform.read(0, &byte, 1);
+        if (n < 0) {
+            if (platform.errno(n) == .INTR) continue;
+            return null;
+        }
         if (n == 0) return null;
         if (header_len < header_buf.len) {
             header_buf[header_len] = byte[0];
@@ -154,15 +159,17 @@ fn readMessage(allocator: std.mem.Allocator) ?[]u8 {
     const body = allocator.alloc(u8, content_length) catch return null;
     var total: usize = 0;
     while (total < content_length) {
-        const n = std.posix.read(0, body[total..]) catch {
+        const n = platform.read(0, body.ptr + total, content_length - total);
+        if (n < 0) {
+            if (platform.errno(n) == .INTR) continue;
             allocator.free(body);
             return null;
-        };
+        }
         if (n == 0) {
             allocator.free(body);
             return null;
         }
-        total += n;
+        total += @intCast(n);
     }
     return body;
 }
@@ -170,8 +177,8 @@ fn readMessage(allocator: std.mem.Allocator) ?[]u8 {
 fn writeMessage(allocator: std.mem.Allocator, json: []const u8) void {
     var header: [64]u8 = undefined;
     const h = std.fmt.bufPrint(&header, "Content-Length: {d}\r\n\r\n", .{json.len}) catch return;
-    _ = std.posix.system.write(1, h.ptr, h.len);
-    _ = std.posix.system.write(1, json.ptr, json.len);
+    _ = platform.write(1, h.ptr, h.len);
+    _ = platform.write(1, json.ptr, json.len);
     _ = allocator;
 }
 

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -1,17 +1,18 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 
 /// Returns the kaappi home directory path written into `buf`.
 /// Checks `KAAPPI_HOME` env var first; falls back to `$HOME/.kaappi`.
 /// Returns null if neither env var is available or the path exceeds `buf`.
 pub fn getHome(buf: []u8) ?[]const u8 {
-    if (std.c.getenv("KAAPPI_HOME")) |kh| {
+    if (platform.getenv("KAAPPI_HOME")) |kh| {
         const home = std.mem.sliceTo(kh, 0);
         if (home.len > 0 and home.len <= buf.len) {
             @memcpy(buf[0..home.len], home);
             return buf[0..home.len];
         }
     }
-    const home_ptr = std.c.getenv("HOME") orelse return null;
+    const home_ptr = platform.getenv("HOME") orelse return null;
     const home = std.mem.sliceTo(home_ptr, 0);
     const suffix = "/.kaappi";
     const total = home.len + suffix.len;
@@ -26,7 +27,7 @@ test "getHome falls back to HOME/.kaappi" {
     if (getHome(&buf)) |home| {
         try std.testing.expect(home.len > 0);
         try std.testing.expect(std.mem.endsWith(u8, home, "/.kaappi") or
-            std.c.getenv("KAAPPI_HOME") != null);
+            platform.getenv("KAAPPI_HOME") != null);
     }
 }
 
@@ -73,6 +74,10 @@ fn siblingLibDir(exe_path: []const u8, buf: []u8) ?[]const u8 {
 /// sibling `lib/` dir and, by the `kaappi test` orchestrator, to re-spawn the
 /// same binary as a worker regardless of how it was invoked.
 pub fn getExePath(buf: []u8) ?[]const u8 {
+    if (comptime @import("builtin").os.tag == .windows) {
+        return platform.getExePathWindows(buf);
+    }
+
     if (comptime @import("builtin").os.tag == .linux) {
         // /proc/self/exe is a kernel-resolved canonical path already —
         // no realpath needed. Reject a result that fills the whole

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin_os = @import("builtin").os;
 const is_wasm = builtin_os.tag == .wasi;
 const is_linux = builtin_os.tag == .linux;
@@ -24,7 +25,7 @@ pub const primitives_r7rs = @import("primitives_r7rs.zig");
 pub const printer = @import("printer.zig");
 pub const expander = @import("expander.zig");
 pub const library = @import("library.zig");
-pub const ln = if (is_wasm) struct {} else @import("linenoise.zig");
+pub const ln = if (is_wasm or builtin_os.tag == .windows) struct {} else @import("linenoise.zig");
 pub const ffi = @import("ffi.zig");
 pub const primitives_ffi = @import("primitives_ffi.zig");
 pub const primitives_srfi1 = @import("primitives_srfi1.zig");
@@ -92,22 +93,9 @@ fn readFileContents(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     if (comptime !is_wasm) {
         const path_z = allocator.dupeZ(u8, path) catch return error.OutOfMemory;
         defer allocator.free(path_z);
-        const probe_fd = std.c.open(path_z, .{});
-        if (probe_fd >= 0) {
-            defer _ = std.c.close(probe_fd);
-            const is_dir = if (comptime is_linux) blk: {
-                const linux = std.os.linux;
-                var sx: linux.Statx = undefined;
-                const rc = linux.statx(probe_fd, "", 0x1000, .{ .TYPE = true }, &sx);
-                break :blk rc <= @as(usize, std.math.maxInt(isize)) and (sx.mode & std.posix.S.IFMT == std.posix.S.IFDIR);
-            } else blk: {
-                var stat_buf: std.c.Stat = undefined;
-                break :blk std.c.fstat(probe_fd, &stat_buf) == 0 and (stat_buf.mode & std.posix.S.IFMT == std.posix.S.IFDIR);
-            };
-            if (is_dir) {
-                std.debug.print("Error: '{s}' is a directory\n", .{path});
-                return error.IsDir;
-            }
+        if (platform.isDir(path_z)) {
+            std.debug.print("Error: '{s}' is a directory\n", .{path});
+            return error.IsDir;
         }
     }
 
@@ -129,10 +117,10 @@ fn readAllStdin(allocator: std.mem.Allocator) ![]u8 {
 
     var tmp: [4096]u8 = undefined;
     while (true) {
-        const raw = std.c.read(0, &tmp, tmp.len);
+        const raw = platform.read(0, &tmp, tmp.len);
         if (raw == 0) break;
         if (raw < 0) {
-            if (std.posix.errno(raw) == .INTR) continue;
+            if (platform.errno(raw) == .INTR) continue;
             break;
         }
         const bytes_read: usize = @intCast(raw);
@@ -257,8 +245,25 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         try library.registerStandardLibraries(&vm.libraries, vm.globals);
     }
 
-    const opts = cli.parse(init.args);
+    var opts = cli.parse(init.args);
     if (opts.action == .exit_ok) return;
+
+    // Windows argv paths arrive with backslashes, but every internal path
+    // operation — script-relative includes, sibling-library resolution,
+    // cache keys — splits and joins on '/'. Win32 accepts '/' everywhere,
+    // so normalize the script path once at the boundary.
+    if (comptime platform.is_windows) {
+        if (opts.file_path) |fp| {
+            const dup = allocator.dupe(u8, fp) catch fp;
+            if (dup.ptr != fp.ptr) {
+                const mutable = @constCast(dup);
+                for (mutable) |*ch| {
+                    if (ch.* == '\\') ch.* = '/';
+                }
+                opts.file_path = dup;
+            }
+        }
+    }
 
     // Apply parsed options to VM/GC
     if (opts.no_ir_opt) ir_mod.optimize_enabled = false;
@@ -413,24 +418,29 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 lib_paths[lib_path_count] = klp;
                 lib_path_count += 1;
             }
-            const env_name = if (@import("builtin").os.tag == .macos)
-                "DYLD_LIBRARY_PATH"
-            else
-                "LD_LIBRARY_PATH";
-            const existing = std.c.getenv(env_name);
-            if (existing) |ex| {
-                const ex_len = std.mem.len(ex);
-                const new = allocator.alloc(u8, klp.len + 1 + ex_len + 1) catch null;
-                if (new) |n| {
-                    @memcpy(n[0..klp.len], klp);
-                    n[klp.len] = ':';
-                    @memcpy(n[klp.len + 1 .. klp.len + 1 + ex_len], ex[0..ex_len]);
-                    n[klp.len + 1 + ex_len] = 0;
-                    _ = setenv(env_name, @ptrCast(n[0 .. klp.len + 1 + ex_len :0]), 1);
+            // The dynamic-linker search path is a POSIX concept; Windows
+            // resolves DLLs via PATH and ffi-open's own explicit
+            // ~/.kaappi/lib probe, so there is nothing to export there.
+            if (comptime !platform.is_windows) {
+                const env_name = if (@import("builtin").os.tag == .macos)
+                    "DYLD_LIBRARY_PATH"
+                else
+                    "LD_LIBRARY_PATH";
+                const existing = platform.getenv(env_name);
+                if (existing) |ex| {
+                    const ex_len = std.mem.len(ex);
+                    const new = allocator.alloc(u8, klp.len + 1 + ex_len + 1) catch null;
+                    if (new) |n| {
+                        @memcpy(n[0..klp.len], klp);
+                        n[klp.len] = ':';
+                        @memcpy(n[klp.len + 1 .. klp.len + 1 + ex_len], ex[0..ex_len]);
+                        n[klp.len + 1 + ex_len] = 0;
+                        _ = setenv(env_name, @ptrCast(n[0 .. klp.len + 1 + ex_len :0]), 1);
+                    }
+                } else {
+                    const z = allocator.dupeZ(u8, klp) catch null;
+                    if (z) |zz| _ = setenv(env_name, zz, 1);
                 }
-            } else {
-                const z = allocator.dupeZ(u8, klp) catch null;
-                if (z) |zz| _ = setenv(env_name, zz, 1);
             }
         }
 
@@ -547,7 +557,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             writeStderr("kaappi-wasm: no file specified\n");
             return;
         }
-        if (!is_wasm and std.c.isatty(0) == 0) {
+        if (!is_wasm and !platform.isatty(0)) {
             try runStdin(vm);
         } else {
             try repl_mod.repl(vm);
@@ -1050,6 +1060,7 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
 }
 
 test {
+    _ = platform;
     _ = types;
     _ = memory;
     _ = reader;

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const diagnostics = @import("diagnostics.zig");
 const shared_buffer = @import("shared_buffer.zig");
@@ -518,7 +519,7 @@ pub const GC = struct {
         return types.makePointer(@ptrCast(ri));
     }
 
-    pub fn allocPort(self: *GC, fd: std.posix.fd_t, is_input: bool, is_output: bool, name: []const u8, owns_name: bool) !Value {
+    pub fn allocPort(self: *GC, fd: platform.fd_t, is_input: bool, is_output: bool, name: []const u8, owns_name: bool) !Value {
         try self.maybeCollect();
         const port = try self.allocator.create(Port);
         port.* = .{

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const reader_mod = @import("reader.zig");
 const compiler = @import("compiler.zig");
@@ -147,19 +148,17 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     const should_free = output_path == null;
     defer if (should_free) allocator.free(out_path);
 
-    const fd = std.posix.openat(std.posix.AT.FDCWD, out_path, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .TRUNC = true,
-    }, 0o644) catch |err| {
+    const out_path_z = try allocator.dupeZ(u8, out_path);
+    defer allocator.free(out_path_z);
+    const fd = platform.openWriteTrunc(out_path_z, 0o644) catch |err| {
         writeStderr("Failed to create output file\n");
         return err;
     };
-    defer _ = std.posix.system.close(fd);
+    defer _ = platform.close(fd);
     const data = emitter.toSlice();
     var total: usize = 0;
     while (total < data.len) {
-        const result = std.posix.system.write(fd, data.ptr + total, data.len - total);
+        const result = platform.write(fd, data.ptr + total, data.len - total);
         if (result <= 0) {
             writeStderr("Failed to write output\n");
             return error.WriteFailed;
@@ -175,13 +174,17 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
 pub fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;
 
-    const pid = std.c.getpid();
-    var ll_buf: [64]u8 = undefined;
-    var ll_w: std.Io.Writer = .fixed(&ll_buf);
-    try ll_w.print("/tmp/kaappi_native_{d}.ll", .{pid});
+    const pid = platform.getPid();
+    var tmp_buf: [512]u8 = undefined;
+    const tmp_dir: []const u8 = if (comptime platform.is_windows)
+        (if (platform.getenv("TEMP")) |t| std.mem.sliceTo(t, 0) else "C:/Windows/Temp")
+    else
+        "/tmp";
+    var ll_w: std.Io.Writer = .fixed(&tmp_buf);
+    try ll_w.print("{s}/kaappi_native_{d}.ll", .{ tmp_dir, pid });
     const ll_path = ll_w.buffered();
-    ll_buf[ll_path.len] = 0;
-    defer _ = std.posix.system.unlink(@ptrCast(ll_path.ptr));
+    tmp_buf[ll_path.len] = 0;
+    defer _ = platform.unlink(tmp_buf[0..ll_path.len :0]);
     try emitLlvmFile(vm, path, ll_path);
 
     const out_path = output_path orelse blk: {
@@ -226,28 +229,28 @@ pub fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8)
 }
 
 fn findInPath(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {
-    const path_env = std.c.getenv("PATH") orelse return null;
+    const path_env = platform.getenv("PATH") orelse return null;
     const path_str = std.mem.span(path_env);
-    var iter = std.mem.splitScalar(u8, path_str, ':');
+    var iter = std.mem.splitScalar(u8, path_str, platform.path_list_sep);
     while (iter.next()) |dir| {
-        const full = std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir, name }) catch continue;
+        const full = std.fmt.allocPrint(allocator, "{s}/{s}{s}", .{ dir, name, platform.exe_suffix }) catch continue;
         const full_z = allocator.dupeZ(u8, full) catch {
             allocator.free(full);
             continue;
         };
         allocator.free(full);
-        const fd = std.posix.openat(std.posix.AT.FDCWD, full_z, .{ .ACCMODE = .RDONLY }, 0) catch {
+        const fd = platform.openRead(full_z) catch {
             allocator.free(full_z);
             continue;
         };
-        _ = std.posix.system.close(fd);
+        _ = platform.close(fd);
         return full_z;
     }
     return null;
 }
 
 fn findLibDir(allocator: std.mem.Allocator) ?[]const u8 {
-    if (std.c.getenv("KAAPPI_LIB_DIR")) |env| {
+    if (platform.getenv("KAAPPI_LIB_DIR")) |env| {
         const dir = std.mem.span(env);
         if (checkLibDir(allocator, dir)) return dir;
     }
@@ -304,10 +307,10 @@ fn collectRedefinedNames(expr: types.Value, map: *std.StringHashMap(void)) void 
 }
 
 fn checkLibDir(allocator: std.mem.Allocator, dir: []const u8) bool {
-    const path = std.fmt.allocPrint(allocator, "{s}/libkaappi_rt.a", .{dir}) catch return false;
+    const path = std.fmt.allocPrintSentinel(allocator, "{s}/libkaappi_rt.a", .{dir}, 0) catch return false;
     defer allocator.free(path);
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{ .ACCMODE = .RDONLY }, 0) catch return false;
-    _ = std.posix.system.close(fd);
+    const fd = platform.openRead(path) catch return false;
+    _ = platform.close(fd);
     return true;
 }
 
@@ -363,29 +366,40 @@ fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, ou
     argc += 1;
     argv_buf[argc] = "-lm";
     argc += 1;
-    argv_buf[argc] = "-lpthread";
-    argc += 1;
+    if (comptime !platform.is_windows) {
+        argv_buf[argc] = "-lpthread";
+        argc += 1;
+    }
     argv_buf[argc] = null;
 
-    const pid = std.posix.system.fork();
-    if (pid < 0) return false;
+    const link_ok = blk: {
+        if (comptime platform.is_windows) {
+            var argv_slices: [16][]const u8 = undefined;
+            for (argv_buf[0..argc], 0..) |arg, i| argv_slices[i] = std.mem.sliceTo(arg.?, 0);
+            const code = platform.winSpawnPassthrough(allocator, argv_slices[0..argc], null) catch break :blk false;
+            break :blk code == 0;
+        }
+        const pid = std.posix.system.fork();
+        if (pid < 0) return false;
 
-    if (pid == 0) {
-        _ = std.posix.system.execve(
-            @ptrCast(argv_buf[0].?),
-            @ptrCast(&argv_buf),
-            @ptrCast(std.c.environ),
-        );
-        std.process.exit(127);
-    }
+        if (pid == 0) {
+            _ = std.posix.system.execve(
+                @ptrCast(argv_buf[0].?),
+                @ptrCast(&argv_buf),
+                @ptrCast(std.c.environ),
+            );
+            std.process.exit(127);
+        }
 
-    var status: c_int = 0;
-    _ = std.c.waitpid(pid, &status, 0);
-    const raw: c_uint = @bitCast(status);
-    const exited = (raw & 0x7f) == 0;
-    if (!exited) return false;
-    const exit_code = (raw >> 8) & 0xff;
-    if (exit_code == 0) {
+        var status: c_int = 0;
+        _ = std.c.waitpid(pid, &status, 0);
+        const raw: c_uint = @bitCast(status);
+        const exited = (raw & 0x7f) == 0;
+        if (!exited) break :blk false;
+        const exit_code = (raw >> 8) & 0xff;
+        break :blk exit_code == 0;
+    };
+    if (link_ok) {
         var msgbuf: [512]u8 = undefined;
         const msg = std.fmt.bufPrint(&msgbuf, "Compiled {s}\n", .{out_path}) catch return true;
         writeStdout(msg);

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -126,6 +126,8 @@ pub const win = if (is_windows) struct {
     pub extern "kernel32" fn GetProcAddress(mod: HANDLE, name: [*:0]const u8) callconv(.winapi) ?*anyopaque;
     pub extern "kernel32" fn FreeLibrary(mod: HANDLE) callconv(.winapi) c_int;
     pub extern "kernel32" fn GetLastError() callconv(.winapi) u32;
+    pub extern "kernel32" fn MoveFileExW(old: [*:0]const u16, new: [*:0]const u16, flags: u32) callconv(.winapi) c_int;
+    pub const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
     pub extern "kernel32" fn FindFirstFileW(path: [*:0]const u16, data: *Win32FindDataW) callconv(.winapi) HANDLE;
     pub extern "kernel32" fn FindNextFileW(h: HANDLE, data: *Win32FindDataW) callconv(.winapi) c_int;
     pub extern "kernel32" fn FindClose(h: HANDLE) callconv(.winapi) c_int;
@@ -346,12 +348,14 @@ pub fn rename(old: [:0]const u8, new: [:0]const u8) c_int {
         var wbuf_new: WPathBuf = undefined;
         const wold = widen(&wbuf_old, old) orelse return -1;
         const wnew = widen(&wbuf_new, new) orelse return -1;
-        // POSIX rename replaces an existing target atomically; _wrename
-        // fails with EEXIST instead. Match POSIX by removing a stale
-        // target first (best effort — the subsequent rename reports any
-        // real failure).
-        _ = win._wunlink(wnew.ptr);
-        return win._wrename(wold.ptr, wnew.ptr);
+        // POSIX rename replaces an existing target and never destroys it
+        // on failure. _wrename fails with EEXIST on an existing target,
+        // and unlinking the target first would delete it even when the
+        // rename then fails (worst case rename(x, x), which POSIX defines
+        // as a successful no-op but unlink-first would turn into data
+        // loss). MoveFileExW with REPLACE_EXISTING has the POSIX shape:
+        // the destination is only replaced when the whole move succeeds.
+        return if (win.MoveFileExW(wold.ptr, wnew.ptr, win.MOVEFILE_REPLACE_EXISTING) != 0) 0 else -1;
     }
     return @intCast(std.posix.system.rename(old, new));
 }
@@ -482,8 +486,11 @@ pub fn realPath(path: [:0]const u8, buf: []u8) ?[]const u8 {
         var wout: WPathBuf = undefined;
         if (win._wfullpath(&wout, wpath.ptr, wpath_max) == null) return null;
         const wlen = std.mem.indexOfScalar(u16, &wout, 0) orelse return null;
+        // wtf16LeToWtf8 assumes the destination fits (it does not bounds
+        // check); each u16 code unit expands to at most 3 WTF-8 bytes, so
+        // preflight on that worst case.
+        if (wlen * 3 > buf.len) return null;
         const n = std.unicode.wtf16LeToWtf8(buf, wout[0..wlen]);
-        if (n > buf.len) return null;
         const out = buf[0..n];
         for (out) |*ch| {
             if (ch.* == '\\') ch.* = '/';
@@ -704,6 +711,11 @@ pub const EnvIter = struct {
                 while (block[end] != 0) end += 1;
                 if (end == start) return null; // double NUL: done
                 st.offset = end + 1;
+                // Preflight: wtf16LeToWtf8 does not bounds check (<= 3
+                // bytes per u16 code unit); a pathologically long entry
+                // (vars can reach 32 KiB) is skipped rather than
+                // overflowing the fixed decode buffer.
+                if ((end - start) * 3 > st.buf.len) continue;
                 const n = std.unicode.wtf16LeToWtf8(&st.buf, block[start..end]);
                 const entry = st.buf[0..n];
                 // The block's first entries can be drive-letter cruft
@@ -740,8 +752,10 @@ pub fn getCwd(buf: []u8) ?[]const u8 {
         var wbuf: WPathBuf = undefined;
         if (win._wgetcwd(&wbuf, wpath_max) == null) return null;
         const wlen = std.mem.indexOfScalar(u16, &wbuf, 0) orelse return null;
+        // Preflight: wtf16LeToWtf8 does not bounds check (<= 3 bytes per
+        // u16 code unit).
+        if (wlen * 3 > buf.len) return null;
         const n = std.unicode.wtf16LeToWtf8(buf, wbuf[0..wlen]);
-        if (n > buf.len) return null;
         const out = buf[0..n];
         for (out) |*ch| {
             if (ch.* == '\\') ch.* = '/';
@@ -750,6 +764,25 @@ pub fn getCwd(buf: []u8) ?[]const u8 {
     }
     const result = std.c.getcwd(buf.ptr, buf.len) orelse return null;
     return std.mem.sliceTo(@as([*:0]const u8, @ptrCast(result)), 0);
+}
+
+/// The platform scratch directory: $TMPDIR / /tmp on POSIX, $TEMP (with
+/// $TMP and a fixed last resort) on Windows — which has no TMPDIR.
+pub fn tempDir() []const u8 {
+    if (comptime is_windows) {
+        inline for (.{ "TEMP", "TMP" }) |name| {
+            if (getenv(name)) |t| {
+                const s = std.mem.sliceTo(t, 0);
+                if (s.len > 0) return s;
+            }
+        }
+        return "C:/Windows/Temp";
+    }
+    if (getenv("TMPDIR")) |t| {
+        const s = std.mem.sliceTo(t, 0);
+        if (s.len > 0) return s;
+    }
+    return "/tmp";
 }
 
 /// The platform temp-file *prefix* (directory + name stem) used by
@@ -869,8 +902,10 @@ pub fn getExePathWindows(buf: []u8) ?[]const u8 {
     var wbuf: [wpath_max]u16 = undefined;
     const wlen = win.GetModuleFileNameW(null, &wbuf, wpath_max);
     if (wlen == 0 or wlen >= wpath_max) return null;
+    // Preflight: wtf16LeToWtf8 does not bounds check (<= 3 bytes per u16
+    // code unit), and callers pass buffers as small as 1024 bytes.
+    if (wlen * 3 > buf.len) return null;
     const n = std.unicode.wtf16LeToWtf8(buf, wbuf[0..wlen]);
-    if (n > buf.len) return null;
     const path = buf[0..n];
     for (path) |*ch| {
         if (ch.* == '\\') ch.* = '/';
@@ -1018,13 +1053,20 @@ pub fn winSpawnPassthrough(allocator: std.mem.Allocator, argv: []const []const u
     return winSpawnInner(allocator, argv, cwd, null, false);
 }
 
+const WinCapture = struct {
+    list: *std.ArrayList(u8),
+    /// Bytes kept; the read loop drains the pipe past this so the child
+    /// never stalls on a full pipe.
+    cap: usize = std.math.maxInt(usize),
+};
+
 /// Runs argv with stdout captured into the returned buffer (caller
 /// frees); stderr is discarded. error.CommandFailed on nonzero exit.
 pub fn winSpawnCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) SpawnError![]u8 {
     if (comptime !is_windows) unreachable;
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
-    const code = try winSpawnInner(allocator, argv, cwd, &out, false);
+    const code = try winSpawnInner(allocator, argv, cwd, .{ .list = &out }, false);
     if (code != 0) return error.CommandFailed;
     return out.toOwnedSlice(allocator);
 }
@@ -1033,16 +1075,18 @@ pub const WinSpawnResult = struct { output: []u8, exit_code: u8 };
 
 /// Runs argv capturing combined stdout+stderr (the fork/dup2-both shape
 /// test_runner's worker spawn uses); never errors on a nonzero exit —
-/// the caller inspects the code.
-pub fn winSpawnCaptureMerged(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) SpawnError!WinSpawnResult {
+/// the caller inspects the code. Output is capped at `cap` bytes (the
+/// pipe keeps draining past it, so the child never blocks on a full
+/// pipe), mirroring the POSIX call sites' in-loop caps.
+pub fn winSpawnCaptureMerged(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, cap: usize) SpawnError!WinSpawnResult {
     if (comptime !is_windows) unreachable;
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
-    const code = try winSpawnInner(allocator, argv, cwd, &out, true);
+    const code = try winSpawnInner(allocator, argv, cwd, .{ .list = &out, .cap = cap }, true);
     return .{ .output = try out.toOwnedSlice(allocator), .exit_code = code };
 }
 
-fn winSpawnInner(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, capture: ?*std.ArrayList(u8), merge_stderr: bool) SpawnError!u8 {
+fn winSpawnInner(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, capture: ?WinCapture, merge_stderr: bool) SpawnError!u8 {
     if (comptime !is_windows) unreachable;
     const cmdline = buildCommandLineW(allocator, argv) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
@@ -1101,14 +1145,36 @@ fn winSpawnInner(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[
         return error.SpawnFailed;
     }
 
-    if (capture) |out| {
+    if (capture) |cap| {
         var tmp: [4096]u8 = undefined;
+        var read_err: ?SpawnError = null;
         while (true) {
             const n = win._read(read_fd, &tmp, tmp.len);
             if (n <= 0) break;
-            out.appendSlice(allocator, tmp[0..@intCast(n)]) catch break;
+            const got: usize = @intCast(n);
+            if (cap.list.items.len < cap.cap) {
+                const room = cap.cap - cap.list.items.len;
+                cap.list.appendSlice(allocator, tmp[0..@min(got, room)]) catch {
+                    // Keep draining so the child can exit, but report the
+                    // failure instead of returning truncated output as
+                    // success.
+                    read_err = error.OutOfMemory;
+                    break;
+                };
+            }
+        }
+        if (read_err != null) {
+            // Drain the remainder without buffering, then reap the child
+            // before propagating.
+            while (win._read(read_fd, &tmp, tmp.len) > 0) {}
         }
         _ = win._close(read_fd);
+        if (read_err) |e| {
+            _ = win.WaitForSingleObject(pi.process, win.INFINITE);
+            _ = win.CloseHandle(pi.thread);
+            _ = win.CloseHandle(pi.process);
+            return e;
+        }
     }
 
     _ = win.WaitForSingleObject(pi.process, win.INFINITE);
@@ -1123,6 +1189,57 @@ fn winSpawnInner(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[
 // tests (run on the host platform; the Windows arms are exercised by the
 // cross-compiled unit-test binary on a Windows machine)
 // ---------------------------------------------------------------------------
+
+fn expectQuoted(expected: []const u8, arg: []const u8) !void {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try appendQuotedArg(&list, std.testing.allocator, arg);
+    try std.testing.expectEqualStrings(expected, list.items);
+}
+
+// CommandLineToArgvW-inverse quoting: these are the canonical cases from
+// the Windows command-line parsing rules; the child's CRT must parse each
+// quoted form back to the original argument.
+test "appendQuotedArg: plain arg unquoted" {
+    try expectQuoted("abc", "abc");
+}
+
+test "appendQuotedArg: spaces force quotes" {
+    try expectQuoted("\"two words\"", "two words");
+}
+
+test "appendQuotedArg: empty arg becomes empty quotes" {
+    try expectQuoted("\"\"", "");
+}
+
+test "appendQuotedArg: embedded quote gets a backslash" {
+    try expectQuoted("\"say \\\" it\"", "say \" it");
+}
+
+test "appendQuotedArg: backslashes before a quote double" {
+    // arg: a\"b  →  "a\\\"b" (the two backslashes encode one literal \,
+    // the third escapes the quote)
+    try expectQuoted("\"a\\\\\\\"b\"", "a\\\"b");
+}
+
+test "appendQuotedArg: trailing backslashes double before the closing quote" {
+    // arg: dir\ with a space → "dir \\" so the closing quote isn't eaten
+    try expectQuoted("\"dir \\\\\"", "dir \\");
+}
+
+test "appendQuotedArg: backslashes not before a quote stay literal" {
+    // Windows paths with spaces: no doubling mid-string
+    try expectQuoted("\"C:\\Program Files\\kaappi\"", "C:\\Program Files\\kaappi");
+}
+
+test "buildCommandLineW joins and round-trips through WTF-16" {
+    const argv = [_][]const u8{ "git", "-C", "C:\\repo dir", "checkout", "v1.0.0", "--" };
+    const wline = try buildCommandLineW(std.testing.allocator, &argv);
+    defer std.testing.allocator.free(wline);
+    var narrow: [256]u8 = undefined;
+    const n = std.unicode.wtf16LeToWtf8(&narrow, wline);
+    try std.testing.expectEqualStrings("git -C \"C:\\repo dir\" checkout v1.0.0 --", narrow[0..n]);
+}
 
 test "monotonicNs advances" {
     const a = monotonicNs();

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -1,0 +1,1154 @@
+//! Cross-platform syscall shim (Windows aarch64 target).
+//!
+//! The runtime's I/O layer is built on integer file descriptors with
+//! POSIX read/write/open/close semantics. POSIX targets forward straight
+//! to std.posix/std.c. Windows maps the same surface onto the C runtime's
+//! low-level io layer (`_open`/`_read`/`_write`: integer fds, 0/1/2
+//! preopened by the CRT) plus Win32 for what the CRT lacks (monotonic
+//! clock, console modes, self-exe path, process spawning). Paths are
+//! UTF-8 at every public boundary; Windows converts to UTF-16 internally
+//! and calls the wide CRT entry points so non-ASCII paths work regardless
+//! of the active ANSI code page.
+//!
+//! Two deliberate degradations on Windows (mirroring the WASI port):
+//! ports never flip to O_NONBLOCK (no fcntl), so fiber I/O suspension
+//! degrades to blocking reads exactly like the WASI probe-fail path; and
+//! the reactor uses a timer+event backend (reactor.zig) instead of fd
+//! readiness. Sequential programs and timer-driven fibers are unaffected.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const is_windows = builtin.os.tag == .windows;
+const is_wasm = builtin.os.tag == .wasi;
+
+/// CRT file descriptor on Windows; kernel fd elsewhere. i32 on every
+/// supported target (std.posix.fd_t is i32 on all POSIX platforms).
+pub const fd_t = i32;
+
+/// Classic errno values — std.c.E defines the CRT's set for Windows
+/// (INTR=4, AGAIN=11, ...), matching POSIX names for everything the
+/// runtime checks.
+pub const E = std.c.E;
+
+// ---------------------------------------------------------------------------
+// Windows externs: CRT low-level io + the handful of Win32 calls we need.
+// Public so reactor.zig (event backend) and repl.zig can reach the raw
+// primitives without re-declaring them.
+// ---------------------------------------------------------------------------
+
+pub const win = if (is_windows) struct {
+    pub const HANDLE = *anyopaque;
+    pub const INVALID_HANDLE_VALUE: HANDLE = @ptrFromInt(std.math.maxInt(usize));
+    pub const INFINITE: u32 = 0xFFFF_FFFF;
+    pub const WAIT_OBJECT_0: u32 = 0;
+    pub const WAIT_TIMEOUT: u32 = 0x102;
+
+    // --- CRT (ucrt via zig's bundled mingw-w64) ---
+    pub extern "c" fn _write(fd: c_int, buf: [*]const u8, count: c_uint) c_int;
+    pub extern "c" fn _read(fd: c_int, buf: [*]u8, count: c_uint) c_int;
+    pub extern "c" fn _close(fd: c_int) c_int;
+    pub extern "c" fn _isatty(fd: c_int) c_int;
+    pub extern "c" fn _wopen(path: [*:0]const u16, oflag: c_int, ...) c_int;
+    pub extern "c" fn _pipe(fds: *[2]c_int, size: c_uint, mode: c_int) c_int;
+    pub extern "c" fn _dup(fd: c_int) c_int;
+    pub extern "c" fn _dup2(old: c_int, new: c_int) c_int;
+    pub extern "c" fn _errno() *c_int;
+    pub extern "c" fn _wunlink(path: [*:0]const u16) c_int;
+    pub extern "c" fn _wmkdir(path: [*:0]const u16) c_int;
+    pub extern "c" fn _wrmdir(path: [*:0]const u16) c_int;
+    pub extern "c" fn _wrename(old: [*:0]const u16, new: [*:0]const u16) c_int;
+    pub extern "c" fn _wchdir(path: [*:0]const u16) c_int;
+    pub extern "c" fn _wgetcwd(buf: [*]u16, size: c_int) ?[*:0]u16;
+    pub extern "c" fn _wstat64(path: [*:0]const u16, st: *Stat64) c_int;
+    pub extern "c" fn _fstat64(fd: c_int, st: *Stat64) c_int;
+    pub extern "c" fn _lseeki64(fd: c_int, offset: i64, whence: c_int) i64;
+    pub extern "c" fn _putenv(pair: [*:0]const u8) c_int;
+    pub extern "c" fn _open_osfhandle(h: isize, flags: c_int) c_int;
+    pub extern "c" fn _get_osfhandle(fd: c_int) isize;
+    pub extern "c" fn _wfullpath(out: ?[*]u16, path: [*:0]const u16, size: usize) ?[*:0]u16;
+    pub extern "c" fn _waccess(path: [*:0]const u16, mode: c_int) c_int;
+
+    /// mingw ucrt `struct _stat64`. Field types (not manual offsets)
+    /// reproduce the C layout: 2 bytes of tail padding after st_gid and 4
+    /// before st_size fall out of natural alignment in an extern struct.
+    pub const Stat64 = extern struct {
+        st_dev: c_uint,
+        st_ino: c_ushort,
+        st_mode: c_ushort,
+        st_nlink: c_short,
+        st_uid: c_short,
+        st_gid: c_short,
+        st_rdev: c_uint,
+        st_size: i64,
+        st_atime: i64,
+        st_mtime: i64,
+        st_ctime: i64,
+    };
+
+    // CRT _open flags (io.h). O_BINARY everywhere: the CRT defaults to
+    // text mode, which silently rewrites \n <-> \r\n and treats ^Z as EOF
+    // — R7RS ports must see raw bytes.
+    pub const O_RDONLY: c_int = 0x0000;
+    pub const O_WRONLY: c_int = 0x0001;
+    pub const O_RDWR: c_int = 0x0002;
+    pub const O_APPEND: c_int = 0x0008;
+    pub const O_CREAT: c_int = 0x0100;
+    pub const O_TRUNC: c_int = 0x0200;
+    pub const O_EXCL: c_int = 0x0400;
+    pub const O_BINARY: c_int = 0x8000;
+    pub const O_NOINHERIT: c_int = 0x0080;
+
+    pub const S_IFMT: c_ushort = 0xF000;
+    pub const S_IFDIR: c_ushort = 0x4000;
+    pub const S_IFREG: c_ushort = 0x8000;
+
+    // --- kernel32 ---
+    pub extern "kernel32" fn CreateEventW(attrs: ?*anyopaque, manual_reset: c_int, initial_state: c_int, name: ?[*:0]const u16) callconv(.winapi) ?HANDLE;
+    pub extern "kernel32" fn SetEvent(h: HANDLE) callconv(.winapi) c_int;
+    pub extern "kernel32" fn WaitForSingleObject(h: HANDLE, ms: u32) callconv(.winapi) u32;
+    pub extern "kernel32" fn CloseHandle(h: HANDLE) callconv(.winapi) c_int;
+    pub extern "kernel32" fn QueryPerformanceCounter(count: *i64) callconv(.winapi) c_int;
+    pub extern "kernel32" fn QueryPerformanceFrequency(freq: *i64) callconv(.winapi) c_int;
+    pub extern "kernel32" fn Sleep(ms: u32) callconv(.winapi) void;
+    pub extern "kernel32" fn GetSystemTimePreciseAsFileTime(ft: *u64) callconv(.winapi) void;
+    pub extern "kernel32" fn SetConsoleOutputCP(cp: u32) callconv(.winapi) c_int;
+    pub extern "kernel32" fn SetConsoleCP(cp: u32) callconv(.winapi) c_int;
+    pub extern "kernel32" fn GetStdHandle(which: u32) callconv(.winapi) ?HANDLE;
+    pub extern "kernel32" fn GetConsoleMode(h: HANDLE, mode: *u32) callconv(.winapi) c_int;
+    pub extern "kernel32" fn SetConsoleMode(h: HANDLE, mode: u32) callconv(.winapi) c_int;
+    pub extern "kernel32" fn GetConsoleScreenBufferInfo(h: HANDLE, info: *ConsoleScreenBufferInfo) callconv(.winapi) c_int;
+    pub extern "kernel32" fn GetModuleFileNameW(mod: ?*anyopaque, buf: [*]u16, size: u32) callconv(.winapi) u32;
+    pub extern "kernel32" fn CreateProcessW(app: ?[*:0]const u16, cmdline: ?[*:0]u16, pattrs: ?*anyopaque, tattrs: ?*anyopaque, inherit: c_int, flags: u32, env: ?*anyopaque, cwd: ?[*:0]const u16, si: *StartupInfoW, pi: *ProcessInformation) callconv(.winapi) c_int;
+    pub extern "kernel32" fn GetExitCodeProcess(h: HANDLE, code: *u32) callconv(.winapi) c_int;
+    pub extern "kernel32" fn LoadLibraryW(name: [*:0]const u16) callconv(.winapi) ?HANDLE;
+    pub extern "kernel32" fn GetModuleHandleW(name: ?[*:0]const u16) callconv(.winapi) ?HANDLE;
+    pub extern "kernel32" fn GetProcAddress(mod: HANDLE, name: [*:0]const u8) callconv(.winapi) ?*anyopaque;
+    pub extern "kernel32" fn FreeLibrary(mod: HANDLE) callconv(.winapi) c_int;
+    pub extern "kernel32" fn GetLastError() callconv(.winapi) u32;
+    pub extern "kernel32" fn FindFirstFileW(path: [*:0]const u16, data: *Win32FindDataW) callconv(.winapi) HANDLE;
+    pub extern "kernel32" fn FindNextFileW(h: HANDLE, data: *Win32FindDataW) callconv(.winapi) c_int;
+    pub extern "kernel32" fn FindClose(h: HANDLE) callconv(.winapi) c_int;
+
+    pub const FileTime = extern struct { lo: u32, hi: u32 };
+    pub const Win32FindDataW = extern struct {
+        attributes: u32,
+        creation_time: FileTime,
+        last_access_time: FileTime,
+        last_write_time: FileTime,
+        file_size_high: u32,
+        file_size_low: u32,
+        reserved0: u32,
+        reserved1: u32,
+        file_name: [260]u16,
+        alternate_file_name: [14]u16,
+    };
+    pub const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
+
+    pub const STD_OUTPUT_HANDLE: u32 = @bitCast(@as(i32, -11));
+    pub const STD_ERROR_HANDLE: u32 = @bitCast(@as(i32, -12));
+    pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
+
+    pub const Coord = extern struct { x: i16, y: i16 };
+    pub const SmallRect = extern struct { left: i16, top: i16, right: i16, bottom: i16 };
+    pub const ConsoleScreenBufferInfo = extern struct {
+        size: Coord,
+        cursor_position: Coord,
+        attributes: u16,
+        window: SmallRect,
+        maximum_window_size: Coord,
+    };
+
+    pub const StartupInfoW = extern struct {
+        cb: u32,
+        reserved: ?[*:0]u16 = null,
+        desktop: ?[*:0]u16 = null,
+        title: ?[*:0]u16 = null,
+        x: u32 = 0,
+        y: u32 = 0,
+        x_size: u32 = 0,
+        y_size: u32 = 0,
+        x_count_chars: u32 = 0,
+        y_count_chars: u32 = 0,
+        fill_attribute: u32 = 0,
+        flags: u32 = 0,
+        show_window: u16 = 0,
+        reserved2: u16 = 0,
+        reserved3: ?*anyopaque = null,
+        std_input: ?HANDLE = null,
+        std_output: ?HANDLE = null,
+        std_error: ?HANDLE = null,
+    };
+    pub const STARTF_USESTDHANDLES: u32 = 0x0100;
+
+    pub const ProcessInformation = extern struct {
+        process: HANDLE,
+        thread: HANDLE,
+        process_id: u32,
+        thread_id: u32,
+    };
+} else struct {};
+
+/// Max path length for the UTF-16 conversion buffers. Windows' classic
+/// limit is 260; longer works only with the registry long-path opt-in.
+/// The buffer is sized generously — a conversion that doesn't fit fails
+/// cleanly (error return) rather than truncating.
+pub const wpath_max = 2048;
+pub const WPathBuf = [wpath_max]u16;
+
+/// UTF-8 → NUL-terminated UTF-16 for a wide CRT call. Null on invalid
+/// UTF-8 or overflow.
+pub fn widen(buf: *WPathBuf, path: []const u8) ?[:0]const u16 {
+    if (!is_windows) return null;
+    if (path.len >= wpath_max) return null;
+    const n = std.unicode.wtf8ToWtf16Le(buf[0 .. wpath_max - 1], path) catch return null;
+    buf[n] = 0;
+    return buf[0..n :0];
+}
+
+// ---------------------------------------------------------------------------
+// errno
+// ---------------------------------------------------------------------------
+
+/// std.posix.errno equivalent that also works on Windows (CRT errno).
+/// CRT calls return exactly -1 on failure.
+pub fn errno(rc: anytype) E {
+    if (comptime is_windows) {
+        return if (rc == -1) @enumFromInt(win._errno().*) else .SUCCESS;
+    }
+    return std.posix.errno(rc);
+}
+
+// ---------------------------------------------------------------------------
+// read / write / close / isatty / pipe / dup2
+// ---------------------------------------------------------------------------
+
+pub fn write(fd: fd_t, buf: [*]const u8, len: usize) isize {
+    if (comptime is_windows) {
+        const n: c_uint = @intCast(@min(len, std.math.maxInt(c_int)));
+        return @intCast(win._write(fd, buf, n));
+    }
+    return std.posix.system.write(fd, buf, len);
+}
+
+pub fn read(fd: fd_t, buf: [*]u8, len: usize) isize {
+    if (comptime is_windows) {
+        const n: c_uint = @intCast(@min(len, std.math.maxInt(c_int)));
+        return @intCast(win._read(fd, buf, n));
+    }
+    return std.posix.system.read(fd, buf, len);
+}
+
+pub fn close(fd: fd_t) void {
+    if (comptime is_windows) {
+        _ = win._close(fd);
+        return;
+    }
+    _ = std.posix.system.close(fd);
+}
+
+pub fn isatty(fd: fd_t) bool {
+    if (comptime is_windows) return win._isatty(fd) != 0;
+    return std.c.isatty(fd) != 0;
+}
+
+pub fn pipe(fds: *[2]fd_t) c_int {
+    if (comptime is_windows) return win._pipe(fds, 65536, win.O_BINARY | win.O_NOINHERIT);
+    if (comptime is_wasm) return -1;
+    return std.c.pipe(fds);
+}
+
+pub fn dup2(old: fd_t, new: fd_t) c_int {
+    if (comptime is_windows) return win._dup2(old, new);
+    return std.c.dup2(old, new);
+}
+
+pub fn dup(fd: fd_t) fd_t {
+    if (comptime is_windows) return win._dup(fd);
+    return std.c.dup(fd);
+}
+
+// ---------------------------------------------------------------------------
+// open — semantic wrappers instead of a flags struct: std.posix.O's layout
+// is platform-specific and the runtime only ever uses these five shapes.
+// ---------------------------------------------------------------------------
+
+pub const OpenError = error{OpenFailed};
+
+fn winOpen(path: []const u8, oflag: c_int, pmode: c_int) OpenError!fd_t {
+    var wbuf: WPathBuf = undefined;
+    const wpath = widen(&wbuf, path) orelse return error.OpenFailed;
+    const fd = win._wopen(wpath.ptr, oflag | win.O_BINARY, pmode);
+    if (fd < 0) return error.OpenFailed;
+    return fd;
+}
+
+pub fn openRead(path: [:0]const u8) OpenError!fd_t {
+    if (comptime is_windows) return winOpen(path, win.O_RDONLY, 0);
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{}, 0) catch error.OpenFailed;
+}
+
+pub fn openWriteTrunc(path: [:0]const u8, mode: u16) OpenError!fd_t {
+    if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_TRUNC, 0o600);
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, mode) catch error.OpenFailed;
+}
+
+pub fn openWriteTruncExcl(path: [:0]const u8, mode: u16) OpenError!fd_t {
+    if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_TRUNC | win.O_EXCL, 0o600);
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true, .EXCL = true }, mode) catch error.OpenFailed;
+}
+
+pub fn openAppend(path: [:0]const u8, mode: u16) OpenError!fd_t {
+    if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_APPEND, 0o600);
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true }, mode) catch error.OpenFailed;
+}
+
+/// Write-only sink for discarding output (/dev/null, NUL).
+pub fn openNullSink() OpenError!fd_t {
+    if (comptime is_windows) return winOpen("NUL", win.O_WRONLY, 0);
+    return std.posix.openatZ(std.posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .WRONLY }, 0) catch error.OpenFailed;
+}
+
+// ---------------------------------------------------------------------------
+// filesystem metadata / manipulation
+// ---------------------------------------------------------------------------
+
+pub fn unlink(path: [:0]const u8) c_int {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return -1;
+        return win._wunlink(wpath.ptr);
+    }
+    return @intCast(std.posix.system.unlink(path));
+}
+
+pub fn mkdir(path: [:0]const u8, mode: u16) c_int {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return -1;
+        return win._wmkdir(wpath.ptr);
+    }
+    return std.c.mkdir(path, mode);
+}
+
+pub fn rmdir(path: [:0]const u8) c_int {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return -1;
+        return win._wrmdir(wpath.ptr);
+    }
+    return @intCast(std.posix.system.rmdir(path));
+}
+
+pub fn rename(old: [:0]const u8, new: [:0]const u8) c_int {
+    if (comptime is_windows) {
+        var wbuf_old: WPathBuf = undefined;
+        var wbuf_new: WPathBuf = undefined;
+        const wold = widen(&wbuf_old, old) orelse return -1;
+        const wnew = widen(&wbuf_new, new) orelse return -1;
+        // POSIX rename replaces an existing target atomically; _wrename
+        // fails with EEXIST instead. Match POSIX by removing a stale
+        // target first (best effort — the subsequent rename reports any
+        // real failure).
+        _ = win._wunlink(wnew.ptr);
+        return win._wrename(wold.ptr, wnew.ptr);
+    }
+    return @intCast(std.posix.system.rename(old, new));
+}
+
+pub fn chdir(path: [:0]const u8) c_int {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return -1;
+        return win._wchdir(wpath.ptr);
+    }
+    return @intCast(std.posix.system.chdir(path));
+}
+
+/// Portable stat result — only the fields the runtime consumes.
+pub const StatInfo = struct {
+    size: u64,
+    mtime_sec: i64,
+    is_dir: bool,
+    is_file: bool,
+};
+
+pub fn statPath(path: [:0]const u8) ?StatInfo {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return null;
+        var st: win.Stat64 = undefined;
+        if (win._wstat64(wpath.ptr, &st) != 0) return null;
+        const fmt = st.st_mode & win.S_IFMT;
+        return .{
+            .size = @intCast(@max(st.st_size, 0)),
+            .mtime_sec = st.st_mtime,
+            .is_dir = fmt == win.S_IFDIR,
+            .is_file = fmt == win.S_IFREG,
+        };
+    }
+    // This Zig's std.c has no plain stat(); the codebase's established
+    // pattern (primitives_io.fileExistsP) is statx on Linux, fstatat
+    // elsewhere.
+    if (comptime builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var sx: linux.Statx = undefined;
+        const rc = linux.statx(@bitCast(@as(i32, std.posix.AT.FDCWD)), path, 0, linux.STATX.BASIC_STATS, &sx);
+        if (rc > @as(usize, std.math.maxInt(isize))) return null;
+        return .{
+            .size = sx.size,
+            .mtime_sec = sx.mtime.sec,
+            .is_dir = sx.mode & std.posix.S.IFMT == std.posix.S.IFDIR,
+            .is_file = sx.mode & std.posix.S.IFMT == std.posix.S.IFREG,
+        };
+    }
+    var st: std.c.Stat = undefined;
+    if (std.c.fstatat(std.posix.AT.FDCWD, path, &st, 0) != 0) return null;
+    return .{
+        .size = @intCast(@max(st.size, 0)),
+        .mtime_sec = @intCast(st.mtime().sec),
+        .is_dir = st.mode & std.posix.S.IFMT == std.posix.S.IFDIR,
+        .is_file = st.mode & std.posix.S.IFMT == std.posix.S.IFREG,
+    };
+}
+
+pub fn statFd(fd: fd_t) ?StatInfo {
+    if (comptime is_windows) {
+        var st: win.Stat64 = undefined;
+        if (win._fstat64(fd, &st) != 0) return null;
+        const fmt = st.st_mode & win.S_IFMT;
+        return .{
+            .size = @intCast(@max(st.st_size, 0)),
+            .mtime_sec = st.st_mtime,
+            .is_dir = fmt == win.S_IFDIR,
+            .is_file = fmt == win.S_IFREG,
+        };
+    }
+    if (comptime builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var sx: linux.Statx = undefined;
+        const rc = linux.statx(fd, "", linux.AT.EMPTY_PATH, linux.STATX.BASIC_STATS, &sx);
+        if (rc > @as(usize, std.math.maxInt(isize))) return null;
+        return .{
+            .size = sx.size,
+            .mtime_sec = sx.mtime.sec,
+            .is_dir = sx.mode & std.posix.S.IFMT == std.posix.S.IFDIR,
+            .is_file = sx.mode & std.posix.S.IFMT == std.posix.S.IFREG,
+        };
+    }
+    var st: std.c.Stat = undefined;
+    if (std.c.fstat(fd, &st) != 0) return null;
+    return .{
+        .size = @intCast(@max(st.size, 0)),
+        .mtime_sec = @intCast(st.mtime().sec),
+        .is_dir = st.mode & std.posix.S.IFMT == std.posix.S.IFDIR,
+        .is_file = st.mode & std.posix.S.IFMT == std.posix.S.IFREG,
+    };
+}
+
+pub fn pathExists(path: [:0]const u8) bool {
+    return statPath(path) != null;
+}
+
+/// access(path, W_OK) equivalent.
+pub fn accessWritable(path: [:0]const u8) bool {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return false;
+        return win._waccess(wpath.ptr, 2) == 0;
+    }
+    return std.c.access(path, std.posix.W_OK) == 0;
+}
+
+/// Separator between entries of $PATH-style lists.
+pub const path_list_sep: u8 = if (is_windows) ';' else ':';
+
+/// Suffix an executable candidate needs on this platform ("" on POSIX).
+pub const exe_suffix: []const u8 = if (is_windows) ".exe" else "";
+
+/// Longest path (bytes, incl. NUL) the canonicalization buffers hold.
+pub const PATH_MAX: usize = if (is_windows) 4096 else std.posix.PATH_MAX;
+
+/// Canonicalizes `path` into `buf` (which must hold PATH_MAX bytes).
+/// POSIX realpath resolves symlinks and requires the file to exist;
+/// Windows _wfullpath only normalizes lexically — both are stable
+/// canonical keys for the same existing file, which is all the caller
+/// (the bytecode cache) needs. Backslashes are normalized to '/' so keys
+/// match however the path was spelled.
+pub fn realPath(path: [:0]const u8, buf: []u8) ?[]const u8 {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return null;
+        var wout: WPathBuf = undefined;
+        if (win._wfullpath(&wout, wpath.ptr, wpath_max) == null) return null;
+        const wlen = std.mem.indexOfScalar(u16, &wout, 0) orelse return null;
+        const n = std.unicode.wtf16LeToWtf8(buf, wout[0..wlen]);
+        if (n > buf.len) return null;
+        const out = buf[0..n];
+        for (out) |*ch| {
+            if (ch.* == '\\') ch.* = '/';
+        }
+        return out;
+    }
+    if (buf.len < PATH_MAX) return null;
+    if (std.c.realpath(path, buf.ptr) == null) return null;
+    const len = std.mem.indexOfScalar(u8, buf[0..PATH_MAX], 0) orelse return null;
+    return buf[0..len];
+}
+
+pub fn isDir(path: [:0]const u8) bool {
+    const st = statPath(path) orelse return false;
+    return st.is_dir;
+}
+
+// ---------------------------------------------------------------------------
+// directory iteration — CRT has no opendir; Windows uses FindFirstFileW.
+// ---------------------------------------------------------------------------
+
+/// Minimal readdir-shaped iterator. Yields every entry including "." and
+/// ".." (exactly like readdir) as UTF-8 names valid until the next call.
+pub const DirIter = struct {
+    const WinState = struct {
+        handle: win.HANDLE,
+        data: win.Win32FindDataW,
+        /// First entry is produced by FindFirstFileW itself.
+        first_pending: bool,
+        name_buf: [1024]u8,
+    };
+    state: if (is_windows) WinState else *std.c.DIR,
+
+    pub fn open(path: [:0]const u8) ?DirIter {
+        if (comptime is_windows) {
+            var pattern_buf: [wpath_max]u8 = undefined;
+            const pattern = std.fmt.bufPrint(&pattern_buf, "{s}/*", .{path}) catch return null;
+            var wbuf: WPathBuf = undefined;
+            const wpattern = widen(&wbuf, pattern) orelse return null;
+            var st: WinState = undefined;
+            st.handle = win.FindFirstFileW(wpattern.ptr, &st.data);
+            if (st.handle == win.INVALID_HANDLE_VALUE) return null;
+            st.first_pending = true;
+            return .{ .state = st };
+        }
+        const dh = std.c.opendir(path) orelse return null;
+        return .{ .state = dh };
+    }
+
+    pub fn next(self: *DirIter) ?[]const u8 {
+        if (comptime is_windows) {
+            const st = &self.state;
+            if (!st.first_pending) {
+                if (win.FindNextFileW(st.handle, &st.data) == 0) return null;
+            }
+            st.first_pending = false;
+            const wname = std.mem.sliceTo(&st.data.file_name, 0);
+            const n = std.unicode.wtf16LeToWtf8(&st.name_buf, wname);
+            return st.name_buf[0..n];
+        }
+        const ent = std.c.readdir(self.state) orelse return null;
+        const name_ptr: [*:0]const u8 = @ptrCast(&ent.name);
+        return std.mem.span(name_ptr);
+    }
+
+    pub fn close(self: *DirIter) void {
+        if (comptime is_windows) {
+            _ = win.FindClose(self.state.handle);
+            return;
+        }
+        _ = std.c.closedir(self.state);
+    }
+};
+
+/// Heap-allocated DirIter for callers that hand the iterator to a
+/// GC-managed object (SRFI-170 directory streams): allocated from the
+/// c allocator so the GC finalizer can destroy it without allocator
+/// plumbing.
+pub fn dirIterCreate(path: [:0]const u8) ?*DirIter {
+    const it = std.heap.c_allocator.create(DirIter) catch return null;
+    it.* = DirIter.open(path) orelse {
+        std.heap.c_allocator.destroy(it);
+        return null;
+    };
+    return it;
+}
+
+pub fn dirIterDestroy(it: *DirIter) void {
+    it.close();
+    std.heap.c_allocator.destroy(it);
+}
+
+// ---------------------------------------------------------------------------
+// sleep
+// ---------------------------------------------------------------------------
+
+/// Blocking whole-thread sleep. The fiber layer never calls this (its
+/// sleeps go through the reactor's bounded waits); only genuinely
+/// synchronous paths do.
+pub fn sleepNs(ns: u64) void {
+    if (comptime is_windows) {
+        const ms = (ns +| 999_999) / 1_000_000;
+        win.Sleep(@intCast(@min(ms, win.INFINITE - 1)));
+        return;
+    }
+    var ts: std.c.timespec = .{
+        .sec = @intCast(ns / 1_000_000_000),
+        .nsec = @intCast(ns % 1_000_000_000),
+    };
+    while (true) {
+        const ret = std.c.nanosleep(&ts, &ts);
+        if (ret == 0) break;
+        if (errno(ret) != .INTR) break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// environment
+// ---------------------------------------------------------------------------
+
+/// CRT getenv — works on Windows too (mingw ucrt). Values are in the
+/// active code page on Windows; ASCII-safe for the variables the runtime
+/// reads (KAAPPI_HOME and friends may contain non-ASCII paths — those
+/// round-trip correctly only when the system UTF-8 code page is enabled,
+/// a documented Windows limitation for now).
+pub fn getenv(name: [*:0]const u8) ?[*:0]const u8 {
+    return std.c.getenv(name);
+}
+
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+
+/// setenv(3) equivalent. Windows CRT has no setenv; _putenv takes a
+/// single "NAME=VALUE" string (which it copies).
+pub fn setEnv(allocator: std.mem.Allocator, name: []const u8, value: []const u8) !void {
+    if (comptime is_windows) {
+        const pair = try std.fmt.allocPrintSentinel(allocator, "{s}={s}", .{ name, value }, 0);
+        defer allocator.free(pair);
+        _ = win._putenv(pair.ptr);
+        return;
+    }
+    const name_z = try allocator.dupeZ(u8, name);
+    defer allocator.free(name_z);
+    const value_z = try allocator.dupeZ(u8, value);
+    defer allocator.free(value_z);
+    _ = setenv(name_z, value_z, 1);
+}
+
+/// unsetenv(3) equivalent ("NAME=" removes the variable via _putenv).
+pub fn unsetEnv(allocator: std.mem.Allocator, name: []const u8) !void {
+    if (comptime is_windows) {
+        const pair = try std.fmt.allocPrintSentinel(allocator, "{s}=", .{name}, 0);
+        defer allocator.free(pair);
+        _ = win._putenv(pair.ptr);
+        return;
+    }
+    const name_z = try allocator.dupeZ(u8, name);
+    defer allocator.free(name_z);
+    _ = unsetenv(name_z);
+}
+
+extern "c" fn _getpid() c_int;
+
+/// RtlGenRandom — the classic stable alias for cryptographic entropy on
+/// Windows, avoiding the bcrypt DLL dance.
+extern "advapi32" fn SystemFunction036(buf: [*]u8, len: u32) callconv(.winapi) u8;
+
+/// 64 bits of OS entropy: getrandom on Linux, arc4random elsewhere,
+/// RtlGenRandom on Windows. Falls back to the monotonic clock only if
+/// the OS source fails.
+pub fn randomSeed64() u64 {
+    if (comptime is_windows) {
+        var buf: [8]u8 = undefined;
+        if (SystemFunction036(&buf, buf.len) != 0) return @bitCast(buf);
+        return monotonicNs();
+    }
+    if (comptime builtin.os.tag == .linux) {
+        var buf: [8]u8 = undefined;
+        const rc = std.os.linux.getrandom(&buf, buf.len, 0);
+        if (rc == buf.len) return @bitCast(buf);
+        return monotonicNs();
+    }
+    if (comptime is_wasm) return monotonicNs();
+    const arc4 = @extern(*const fn () callconv(.c) u32, .{ .name = "arc4random" });
+    const lo: u64 = arc4();
+    const hi: u64 = arc4();
+    return (hi << 32) | lo;
+}
+
+/// Iterates "NAME=VALUE" environment entries as UTF-8 (each valid until
+/// the next call). POSIX walks `environ`; Windows walks the wide
+/// environment block.
+pub const EnvIter = struct {
+    const WinState = struct {
+        block: ?[*]u16,
+        offset: usize,
+        buf: [8192]u8,
+    };
+    state: if (is_windows) WinState else usize,
+
+    pub fn init() EnvIter {
+        if (comptime is_windows) {
+            const k32 = struct {
+                extern "kernel32" fn GetEnvironmentStringsW() callconv(.winapi) ?[*]u16;
+            };
+            return .{ .state = .{ .block = k32.GetEnvironmentStringsW(), .offset = 0, .buf = undefined } };
+        }
+        return .{ .state = 0 };
+    }
+
+    pub fn next(self: *EnvIter) ?[]const u8 {
+        if (comptime is_windows) {
+            const st = &self.state;
+            const block = st.block orelse return null;
+            while (true) {
+                const start = st.offset;
+                var end = start;
+                while (block[end] != 0) end += 1;
+                if (end == start) return null; // double NUL: done
+                st.offset = end + 1;
+                const n = std.unicode.wtf16LeToWtf8(&st.buf, block[start..end]);
+                const entry = st.buf[0..n];
+                // The block's first entries can be drive-letter cruft
+                // starting with '='; skip those like every environ walker.
+                if (entry.len > 0 and entry[0] == '=') continue;
+                return entry;
+            }
+        }
+        const environ_ptr = @extern(*[*:null]?[*:0]const u8, .{ .name = "environ" });
+        const entry = environ_ptr.*[self.state] orelse return null;
+        self.state += 1;
+        return std.mem.sliceTo(entry, 0);
+    }
+
+    pub fn deinit(self: *EnvIter) void {
+        if (comptime is_windows) {
+            const k32 = struct {
+                extern "kernel32" fn FreeEnvironmentStringsW(block: [*]u16) callconv(.winapi) c_int;
+            };
+            if (self.state.block) |b| _ = k32.FreeEnvironmentStringsW(b);
+            self.state.block = null;
+        }
+    }
+};
+
+pub fn getPid() i64 {
+    if (comptime is_windows) return @intCast(_getpid());
+    return @intCast(std.c.getpid());
+}
+
+/// getcwd into `buf` (UTF-8; Windows result normalized to '/').
+pub fn getCwd(buf: []u8) ?[]const u8 {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        if (win._wgetcwd(&wbuf, wpath_max) == null) return null;
+        const wlen = std.mem.indexOfScalar(u16, &wbuf, 0) orelse return null;
+        const n = std.unicode.wtf16LeToWtf8(buf, wbuf[0..wlen]);
+        if (n > buf.len) return null;
+        const out = buf[0..n];
+        for (out) |*ch| {
+            if (ch.* == '\\') ch.* = '/';
+        }
+        return out;
+    }
+    const result = std.c.getcwd(buf.ptr, buf.len) orelse return null;
+    return std.mem.sliceTo(@as([*:0]const u8, @ptrCast(result)), 0);
+}
+
+/// The platform temp-file *prefix* (directory + name stem) used by
+/// SRFI-170's temp-file-prefix / create-temp-file. Written into `buf`
+/// on Windows (where the temp dir is an env var); static elsewhere.
+pub fn tempFilePrefix(buf: []u8) []const u8 {
+    if (comptime is_windows) {
+        const dir: []const u8 = blk: {
+            if (getenv("TEMP")) |t| {
+                const s = std.mem.sliceTo(t, 0);
+                if (s.len > 0) break :blk s;
+            }
+            break :blk "C:/Windows/Temp";
+        };
+        return std.fmt.bufPrint(buf, "{s}/kaappi-", .{dir}) catch "kaappi-tmp-";
+    }
+    return "/tmp/kaappi-";
+}
+
+// ---------------------------------------------------------------------------
+// clocks
+// ---------------------------------------------------------------------------
+
+var qpc_freq: std.atomic.Value(i64) = std.atomic.Value(i64).init(0);
+
+/// Monotonic clock in nanoseconds. QueryPerformanceCounter on Windows,
+/// CLOCK_MONOTONIC elsewhere.
+pub fn monotonicNs() u64 {
+    if (comptime is_windows) {
+        var freq = qpc_freq.load(.monotonic);
+        if (freq == 0) {
+            _ = win.QueryPerformanceFrequency(&freq);
+            if (freq <= 0) freq = 1;
+            qpc_freq.store(freq, .monotonic);
+        }
+        var counter: i64 = 0;
+        _ = win.QueryPerformanceCounter(&counter);
+        return @intCast(@divTrunc(@as(i128, counter) * std.time.ns_per_s, @as(i128, freq)));
+    }
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+/// Wall clock as (seconds, nanoseconds) since the Unix epoch.
+pub const RealTime = struct { sec: i64, nsec: i64 };
+
+pub fn realTime() RealTime {
+    if (comptime is_windows) {
+        // FILETIME: 100ns ticks since 1601-01-01; the offset to the Unix
+        // epoch is 11644473600 seconds.
+        var ft: u64 = 0;
+        win.GetSystemTimePreciseAsFileTime(&ft);
+        const unix_ticks: i64 = @as(i64, @intCast(ft)) - 116444736000000000;
+        return .{
+            .sec = @divFloor(unix_ticks, 10_000_000),
+            .nsec = @mod(unix_ticks, 10_000_000) * 100,
+        };
+    }
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.REALTIME, &ts);
+    return .{ .sec = @intCast(ts.sec), .nsec = @intCast(ts.nsec) };
+}
+
+// ---------------------------------------------------------------------------
+// console / terminal
+// ---------------------------------------------------------------------------
+
+/// One-time console setup. Windows: switch the console to UTF-8 in both
+/// directions and enable VT (ANSI escape) processing so colored
+/// diagnostics and the REPL prompt render. No-op elsewhere.
+pub fn initConsole() void {
+    if (comptime !is_windows) return;
+    _ = win.SetConsoleOutputCP(65001);
+    _ = win.SetConsoleCP(65001);
+    inline for (.{ win.STD_OUTPUT_HANDLE, win.STD_ERROR_HANDLE }) |which| {
+        if (win.GetStdHandle(which)) |h| {
+            if (h != win.INVALID_HANDLE_VALUE) {
+                var mode: u32 = 0;
+                if (win.GetConsoleMode(h, &mode) != 0) {
+                    _ = win.SetConsoleMode(h, mode | win.ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+                }
+            }
+        }
+    }
+}
+
+/// Terminal width in columns, or null when stdout isn't a terminal (or
+/// the platform can't say).
+pub fn terminalWidth() ?u16 {
+    if (comptime is_windows) {
+        const h = win.GetStdHandle(win.STD_OUTPUT_HANDLE) orelse return null;
+        if (h == win.INVALID_HANDLE_VALUE) return null;
+        var info: win.ConsoleScreenBufferInfo = undefined;
+        if (win.GetConsoleScreenBufferInfo(h, &info) == 0) return null;
+        const width = info.window.right - info.window.left + 1;
+        if (width <= 0) return null;
+        return @intCast(width);
+    }
+    if (comptime is_wasm) return null;
+    var ws: std.posix.winsize = .{ .row = 0, .col = 0, .xpixel = 0, .ypixel = 0 };
+    const ret = std.c.ioctl(1, std.c.T.IOCGWINSZ, @intFromPtr(&ws));
+    if (ret != 0 or ws.col == 0) return null;
+    return ws.col;
+}
+
+// ---------------------------------------------------------------------------
+// self-exe path
+// ---------------------------------------------------------------------------
+
+/// The running executable's absolute path, UTF-8, written into `buf`.
+/// Windows: GetModuleFileNameW, with backslashes normalized to '/' so
+/// every downstream path split/join (all written for '/') keeps working —
+/// Win32 accepts forward slashes everywhere the runtime passes paths.
+pub fn getExePathWindows(buf: []u8) ?[]const u8 {
+    if (comptime !is_windows) return null;
+    var wbuf: [wpath_max]u16 = undefined;
+    const wlen = win.GetModuleFileNameW(null, &wbuf, wpath_max);
+    if (wlen == 0 or wlen >= wpath_max) return null;
+    const n = std.unicode.wtf16LeToWtf8(buf, wbuf[0..wlen]);
+    if (n > buf.len) return null;
+    const path = buf[0..n];
+    for (path) |*ch| {
+        if (ch.* == '\\') ch.* = '/';
+    }
+    return path;
+}
+
+// ---------------------------------------------------------------------------
+// dynamic library loading (C FFI)
+// ---------------------------------------------------------------------------
+
+/// Shared-library suffixes to probe, most specific first. ".so.6" covers
+/// glibc's core libraries, where the unversioned .so is a linker script
+/// dlopen cannot load.
+pub const dl_suffixes: []const []const u8 = if (is_windows)
+    &.{".dll"}
+else
+    &.{ ".dylib", ".so", ".so.6" };
+
+var dl_error_buf: [128]u8 = undefined;
+var dl_error_pending: bool = false;
+
+/// dlopen(3). A null path opens the running process (POSIX self-handle /
+/// GetModuleHandleW(null)); dlClose knows not to free that one.
+pub fn dlOpen(path: ?[*:0]const u8) ?*anyopaque {
+    if (comptime is_windows) {
+        const p = path orelse return win.GetModuleHandleW(null);
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, std.mem.sliceTo(p, 0)) orelse return null;
+        const handle = win.LoadLibraryW(wpath.ptr);
+        if (handle == null) dl_error_pending = true;
+        return handle;
+    }
+    return std.c.dlopen(path, .{ .LAZY = true });
+}
+
+pub fn dlSym(handle: *anyopaque, name: [*:0]const u8) ?*anyopaque {
+    if (comptime is_windows) {
+        const sym = win.GetProcAddress(handle, name);
+        if (sym == null) dl_error_pending = true;
+        return sym;
+    }
+    return std.c.dlsym(handle, name);
+}
+
+pub fn dlClose(handle: *anyopaque) void {
+    if (comptime is_windows) {
+        // The process self-handle (dlOpen(null)) takes no reference on
+        // Windows; FreeLibrary on it would corrupt the exe module count.
+        if (handle == win.GetModuleHandleW(null)) return;
+        _ = win.FreeLibrary(handle);
+        return;
+    }
+    _ = std.c.dlclose(handle);
+}
+
+/// dlerror(3): the last dlOpen/dlSym failure message, or null. Windows
+/// reports the numeric GetLastError code (single-threaded consumer, same
+/// as dlerror's own contract).
+pub fn dlError() ?[*:0]const u8 {
+    if (comptime is_windows) {
+        if (!dl_error_pending) return null;
+        dl_error_pending = false;
+        const msg = std.fmt.bufPrintZ(&dl_error_buf, "Win32 error {d}", .{win.GetLastError()}) catch return null;
+        return msg.ptr;
+    }
+    return std.c.dlerror();
+}
+
+// ---------------------------------------------------------------------------
+// command-line args
+// ---------------------------------------------------------------------------
+
+/// Uniform argv iteration. POSIX/WASI iterate the raw argv block;
+/// Windows must parse the process command line, which allocates. That
+/// decode is process-lifetime by nature (yielded slices escape into
+/// Options and library paths that live as long as argv would), so it
+/// comes from the c allocator and is deliberately never freed — each
+/// call site parses once per process, so nothing accumulates, and
+/// leak-tracking test allocators never see it.
+pub fn argsIterate(args: std.process.Args) std.process.Args.Iterator {
+    if (comptime is_windows) {
+        return args.iterateAllocator(std.heap.c_allocator) catch @panic("out of memory parsing command line");
+    }
+    return args.iterate();
+}
+
+// ---------------------------------------------------------------------------
+// process spawning (Windows). POSIX keeps its fork/exec paths in
+// thottam_proc.zig / native_compiler.zig / test_runner.zig — this is the
+// CreateProcessW analogue those files call on Windows.
+// ---------------------------------------------------------------------------
+
+/// Quotes one argument per CommandLineToArgvW's rules (the inverse parse
+/// every C runtime uses): wrap in quotes when it contains whitespace/
+/// quotes or is empty; backslashes immediately before a quote (or the
+/// closing quote) are doubled; embedded quotes get a backslash.
+fn appendQuotedArg(list: *std.ArrayList(u8), allocator: std.mem.Allocator, arg: []const u8) !void {
+    const needs_quotes = arg.len == 0 or std.mem.indexOfAny(u8, arg, " \t\"") != null;
+    if (!needs_quotes) {
+        try list.appendSlice(allocator, arg);
+        return;
+    }
+    try list.append(allocator, '"');
+    var backslashes: usize = 0;
+    for (arg) |ch| {
+        switch (ch) {
+            '\\' => backslashes += 1,
+            '"' => {
+                try list.appendNTimes(allocator, '\\', backslashes * 2 + 1);
+                backslashes = 0;
+                try list.append(allocator, '"');
+            },
+            else => {
+                try list.appendNTimes(allocator, '\\', backslashes);
+                backslashes = 0;
+                try list.append(allocator, ch);
+            },
+        }
+    }
+    try list.appendNTimes(allocator, '\\', backslashes * 2);
+    try list.append(allocator, '"');
+}
+
+fn buildCommandLineW(allocator: std.mem.Allocator, argv: []const []const u8) ![:0]u16 {
+    var line: std.ArrayList(u8) = .empty;
+    defer line.deinit(allocator);
+    for (argv, 0..) |arg, i| {
+        if (i > 0) try line.append(allocator, ' ');
+        try appendQuotedArg(&line, allocator, arg);
+    }
+    const wlen = std.unicode.calcWtf16LeLen(line.items) catch return error.InvalidName;
+    const wline = try allocator.allocSentinel(u16, wlen, 0);
+    errdefer allocator.free(wline);
+    _ = std.unicode.wtf8ToWtf16Le(wline, line.items) catch return error.InvalidName;
+    return wline;
+}
+
+pub const SpawnError = error{ SpawnFailed, CommandFailed, OutOfMemory, InvalidName };
+
+/// Runs argv (argv[0] searched on PATH, .exe implied), waits, and returns
+/// the exit code. Child inherits stdin/stdout/stderr.
+pub fn winSpawnPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) SpawnError!u8 {
+    if (comptime !is_windows) unreachable;
+    return winSpawnInner(allocator, argv, cwd, null, false);
+}
+
+/// Runs argv with stdout captured into the returned buffer (caller
+/// frees); stderr is discarded. error.CommandFailed on nonzero exit.
+pub fn winSpawnCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) SpawnError![]u8 {
+    if (comptime !is_windows) unreachable;
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    const code = try winSpawnInner(allocator, argv, cwd, &out, false);
+    if (code != 0) return error.CommandFailed;
+    return out.toOwnedSlice(allocator);
+}
+
+pub const WinSpawnResult = struct { output: []u8, exit_code: u8 };
+
+/// Runs argv capturing combined stdout+stderr (the fork/dup2-both shape
+/// test_runner's worker spawn uses); never errors on a nonzero exit —
+/// the caller inspects the code.
+pub fn winSpawnCaptureMerged(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) SpawnError!WinSpawnResult {
+    if (comptime !is_windows) unreachable;
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    const code = try winSpawnInner(allocator, argv, cwd, &out, true);
+    return .{ .output = try out.toOwnedSlice(allocator), .exit_code = code };
+}
+
+fn winSpawnInner(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, capture: ?*std.ArrayList(u8), merge_stderr: bool) SpawnError!u8 {
+    if (comptime !is_windows) unreachable;
+    const cmdline = buildCommandLineW(allocator, argv) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidName,
+    };
+    defer allocator.free(cmdline);
+
+    var wcwd_buf: WPathBuf = undefined;
+    const wcwd: ?[*:0]const u16 = if (cwd) |c|
+        (widen(&wcwd_buf, c) orelse return error.InvalidName).ptr
+    else
+        null;
+
+    var si: win.StartupInfoW = .{ .cb = @sizeOf(win.StartupInfoW) };
+    var pi: win.ProcessInformation = undefined;
+
+    // Capture mode routes the child's stdout through a CRT pipe: the
+    // write end is made inheritable via a dup (CRT pipes are created
+    // NOINHERIT so the read end never leaks). stderr merges into the
+    // same pipe or goes to NUL, per `merge_stderr`.
+    var pipe_fds: [2]fd_t = undefined;
+    var read_fd: fd_t = -1;
+    var inherit: c_int = 0;
+    var write_dup: fd_t = -1;
+    var null_fd: fd_t = -1;
+    if (capture != null) {
+        if (win._pipe(&pipe_fds, 65536, win.O_BINARY | win.O_NOINHERIT) != 0) return error.SpawnFailed;
+        read_fd = pipe_fds[0];
+        write_dup = win._dup(pipe_fds[1]);
+        _ = win._close(pipe_fds[1]);
+        if (write_dup < 0) {
+            _ = win._close(read_fd);
+            return error.SpawnFailed;
+        }
+        si.flags = win.STARTF_USESTDHANDLES;
+        si.std_input = @ptrFromInt(@as(usize, @bitCast(win._get_osfhandle(0))));
+        si.std_output = @ptrFromInt(@as(usize, @bitCast(win._get_osfhandle(write_dup))));
+        if (merge_stderr) {
+            si.std_error = si.std_output;
+        } else {
+            null_fd = win._wopen(std.unicode.wtf8ToWtf16LeStringLiteral("NUL"), win.O_WRONLY, @as(c_int, 0));
+            si.std_error = if (null_fd >= 0) @ptrFromInt(@as(usize, @bitCast(win._get_osfhandle(null_fd)))) else si.std_output;
+        }
+        inherit = 1;
+    }
+
+    const created = win.CreateProcessW(null, cmdline.ptr, null, null, inherit, 0, null, wcwd, &si, &pi);
+    if (capture != null) {
+        // Parent must drop its write end (and NUL) or the read loop
+        // below never sees EOF.
+        _ = win._close(write_dup);
+        if (null_fd >= 0) _ = win._close(null_fd);
+    }
+    if (created == 0) {
+        if (read_fd >= 0) _ = win._close(read_fd);
+        return error.SpawnFailed;
+    }
+
+    if (capture) |out| {
+        var tmp: [4096]u8 = undefined;
+        while (true) {
+            const n = win._read(read_fd, &tmp, tmp.len);
+            if (n <= 0) break;
+            out.appendSlice(allocator, tmp[0..@intCast(n)]) catch break;
+        }
+        _ = win._close(read_fd);
+    }
+
+    _ = win.WaitForSingleObject(pi.process, win.INFINITE);
+    var code: u32 = 0;
+    _ = win.GetExitCodeProcess(pi.process, &code);
+    _ = win.CloseHandle(pi.thread);
+    _ = win.CloseHandle(pi.process);
+    return @truncate(code);
+}
+
+// ---------------------------------------------------------------------------
+// tests (run on the host platform; the Windows arms are exercised by the
+// cross-compiled unit-test binary on a Windows machine)
+// ---------------------------------------------------------------------------
+
+test "monotonicNs advances" {
+    const a = monotonicNs();
+    const b = monotonicNs();
+    try std.testing.expect(b >= a);
+}
+
+test "realTime is after 2020" {
+    const rt = realTime();
+    try std.testing.expect(rt.sec > 1577836800); // 2020-01-01
+    try std.testing.expect(rt.nsec >= 0 and rt.nsec < 1_000_000_000);
+}
+
+test "statPath reports a directory" {
+    if (comptime is_wasm) return error.SkipZigTest;
+    const cwd_path = if (is_windows) "." else "/tmp";
+    const st = statPath(cwd_path) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(st.is_dir);
+    try std.testing.expect(!st.is_file);
+}
+
+test "write to stdout-like sink via openNullSink" {
+    if (comptime is_wasm) return error.SkipZigTest;
+    const fd = try openNullSink();
+    defer close(fd);
+    const msg = "platform shim probe\n";
+    const rc = write(fd, msg.ptr, msg.len);
+    try std.testing.expect(rc == @as(isize, @intCast(msg.len)));
+}

--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const primitives = @import("primitives.zig");
 const memory = @import("memory.zig");
@@ -35,7 +36,7 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
 
     if (args[0] == types.FALSE) {
         // Open default process (all linked symbols including libc)
-        const handle = std.c.dlopen(null, std.c.RTLD{ .LAZY = true }) orelse return primitives.typeError("ffi-open", "openable library", args[0]);
+        const handle = platform.dlOpen(null) orelse return primitives.typeError("ffi-open", "openable library", args[0]);
         return gc.allocFfiLibrary(handle, "default") catch return PrimitiveError.OutOfMemory;
     }
 
@@ -50,20 +51,19 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
     const cname: [*:0]const u8 = @ptrCast(buf[0..str.len :0]);
 
     // Try the name as-is
-    if (std.c.dlopen(cname, std.c.RTLD{ .LAZY = true })) |handle| {
+    if (platform.dlOpen(cname)) |handle| {
         return gc.allocFfiLibrary(handle, str.data[0..str.len]) catch return PrimitiveError.OutOfMemory;
     }
 
     // Try platform library suffixes. ".so.6" covers glibc's core libraries
     // (libm, libc), where the unversioned .so is a linker script that
     // dlopen cannot load.
-    const platform_suffixes = [_][]const u8{ ".dylib", ".so", ".so.6" };
-    for (platform_suffixes) |suffix| {
+    for (platform.dl_suffixes) |suffix| {
         if (str.len + suffix.len < buf.len) {
             @memcpy(buf[str.len..][0..suffix.len], suffix);
             buf[str.len + suffix.len] = 0;
             const cname2: [*:0]const u8 = @ptrCast(buf[0 .. str.len + suffix.len :0]);
-            if (std.c.dlopen(cname2, std.c.RTLD{ .LAZY = true })) |handle| {
+            if (platform.dlOpen(cname2)) |handle| {
                 return gc.allocFfiLibrary(handle, str.data[0..str.len]) catch return PrimitiveError.OutOfMemory;
             }
         }
@@ -74,8 +74,9 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
     var home_buf: [256]u8 = undefined;
     if (kaappi_paths.getHome(&home_buf)) |kaappi_home| {
         const lib_prefix = "/lib/";
-        const suffixes = [_][]const u8{ "", ".dylib", ".so" };
-        for (suffixes) |suffix| {
+        const home_suffixes: []const []const u8 =
+            if (comptime platform.is_windows) &.{ "", ".dll" } else &.{ "", ".dylib", ".so" };
+        for (home_suffixes) |suffix| {
             if (kaappi_home.len + lib_prefix.len + str.len + suffix.len < 512) {
                 var pbuf: [512]u8 = undefined;
                 @memcpy(pbuf[0..kaappi_home.len], kaappi_home);
@@ -85,7 +86,7 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
                 const total = kaappi_home.len + lib_prefix.len + str.len + suffix.len;
                 pbuf[total] = 0;
                 const pname: [*:0]const u8 = @ptrCast(pbuf[0..total :0]);
-                if (std.c.dlopen(pname, std.c.RTLD{ .LAZY = true })) |handle| {
+                if (platform.dlOpen(pname)) |handle| {
                     return gc.allocFfiLibrary(handle, str.data[0..str.len]) catch return PrimitiveError.OutOfMemory;
                 }
             }
@@ -93,7 +94,7 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
     }
 
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    if (std.c.dlerror()) |err_msg| {
+    if (platform.dlError()) |err_msg| {
         const msg = std.mem.span(err_msg);
         vm.setErrorDetail("ffi-open: {s}", .{msg});
     } else {
@@ -124,9 +125,9 @@ fn ffiFn(args: []const Value) PrimitiveError!Value {
     name_buf[name_str.len] = 0;
     const cname: [*:0]const u8 = @ptrCast(name_buf[0..name_str.len :0]);
 
-    const symbol = std.c.dlsym(handle, cname) orelse {
+    const symbol = platform.dlSym(handle, cname) orelse {
         const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-        if (std.c.dlerror()) |err_msg| {
+        if (platform.dlError()) |err_msg| {
             const msg = std.mem.span(err_msg);
             vm.setErrorDetail("ffi-fn: {s}", .{msg});
         } else {
@@ -171,7 +172,7 @@ fn ffiClose(args: []const Value) PrimitiveError!Value {
     if (!types.isFfiLibrary(args[0])) return primitives.typeError("ffi-close", "ffi-library", args[0]);
     const lib = types.toObject(args[0]).as(types.FfiLibrary);
     if (lib.handle) |handle| {
-        _ = std.c.dlclose(handle);
+        _ = platform.dlClose(handle);
         lib.handle = null;
     }
     return types.VOID;

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const primitives = @import("primitives.zig");
 const vm_mod = @import("vm.zig");
@@ -68,6 +69,30 @@ fn makedev(major: u64, minor: u64) u64 {
 }
 
 fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
+    if (comptime platform.is_windows) {
+        // _wstat64 always follows reparse points (`follow` has no effect)
+        // and Windows has no POSIX uid/gid/blocks; absent concepts report
+        // as zero, exactly like SRFI-170 suggests for hosts without them.
+        var wbuf: platform.WPathBuf = undefined;
+        const wpath = platform.widen(&wbuf, std.mem.sliceTo(path, 0)) orelse return null;
+        var st: platform.win.Stat64 = undefined;
+        if (platform.win._wstat64(wpath.ptr, &st) != 0) return null;
+        return .{
+            .mode = @intCast(st.st_mode),
+            .size = st.st_size,
+            .mtime_sec = st.st_mtime,
+            .atime_sec = st.st_atime,
+            .ctime_sec = st.st_ctime,
+            .dev = @intCast(st.st_dev),
+            .ino = @intCast(st.st_ino),
+            .nlinks = @intCast(@max(st.st_nlink, 0)),
+            .rdev = @intCast(st.st_rdev),
+            .blksize = 0,
+            .blocks = 0,
+            .uid = 0,
+            .gid = 0,
+        };
+    }
     if (is_linux) {
         const linux = std.os.linux;
         var sx: linux.Statx = undefined;
@@ -199,6 +224,14 @@ fn raiseFileError(gc: *GC, msg_text: []const u8, irritant: Value) PrimitiveError
     return PrimitiveError.ExceptionRaised;
 }
 
+/// POSIX-only operations raise a clean, catchable file error on Windows
+/// instead of being silently absent — the name stays bound, so portable
+/// code can probe with guard/with-exception-handler.
+fn raiseUnsupportedOnWindows(comptime name: []const u8) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    return raiseFileError(gc, name ++ ": not supported on Windows", types.FALSE);
+}
+
 fn extractPath(val: Value) ?[]const u8 {
     if (!types.isString(val)) return null;
     const str = types.toObject(val).as(types.SchemeString);
@@ -225,10 +258,10 @@ fn directoryFiles(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const dir = std.c.opendir(path_z) orelse {
+    var dir = platform.DirIter.open(path_z) orelse {
         return raiseFileError(gc, "cannot open directory", args[0]);
     };
-    defer _ = std.c.closedir(dir);
+    defer dir.close();
 
     var str_val: Value = types.NIL;
     gc.pushRoot(&str_val);
@@ -237,10 +270,7 @@ fn directoryFiles(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&result);
     defer gc.popRoot();
 
-    while (std.c.readdir(dir)) |entry| {
-        const name_ptr: [*:0]const u8 = @ptrCast(&entry.name);
-        const name = std.mem.span(name_ptr);
-
+    while (dir.next()) |name| {
         if (std.mem.eql(u8, name, ".") or std.mem.eql(u8, name, "..")) continue;
         if (!include_dotfiles and name.len > 0 and name[0] == '.') continue;
 
@@ -268,7 +298,18 @@ fn fileInfoFn(args: []const Value) PrimitiveError!Value {
         return raiseFileError(gc, "cannot stat file", args[0]);
     };
 
-    const S = std.c.S;
+    // std.c.S doesn't exist on Windows; these mode bits are identical
+    // across every target we build (the CRT uses the classic values).
+    const S = if (platform.is_windows) struct {
+        const IFMT: u32 = 0xF000;
+        const IFDIR: u32 = 0x4000;
+        const IFREG: u32 = 0x8000;
+        const IFLNK: u32 = 0xA000;
+        const IFIFO: u32 = 0x1000;
+        const IFSOCK: u32 = 0xC000;
+        const IFCHR: u32 = 0x2000;
+        const IFBLK: u32 = 0x6000;
+    } else std.c.S;
     const file_type: types.FileInfo.FileType = blk: {
         const masked = sr.mode & S.IFMT;
         if (masked == S.IFDIR) break :blk .directory;
@@ -425,7 +466,7 @@ fn createDirectoryFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    if (std.c.mkdir(path_z, mode) != 0) {
+    if (platform.mkdir(path_z, @intCast(mode)) != 0) {
         return raiseFileError(gc, "cannot create directory", args[0]);
     }
     return types.VOID;
@@ -439,7 +480,7 @@ fn deleteDirectoryFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    if (std.c.rmdir(path_z) != 0) {
+    if (platform.rmdir(path_z) != 0) {
         return raiseFileError(gc, "cannot delete directory", args[0]);
     }
     return types.VOID;
@@ -461,13 +502,14 @@ fn renameFileFn(args: []const Value) PrimitiveError!Value {
     const new_z = gc.allocator.dupeZ(u8, new) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(new_z);
 
-    if (std.c.rename(old_z, new_z) != 0) {
+    if (platform.rename(old_z, new_z) != 0) {
         return raiseFileError(gc, "cannot rename file", args[0]);
     }
     return types.VOID;
 }
 
 fn createSymlinkFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("create-symlink");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const old = extractPath(args[0]) orelse return primitives.typeError("create-symlink", "string", args[0]);
     const new = extractPath(args[1]) orelse return primitives.typeError("create-symlink", "string", args[1]);
@@ -486,6 +528,7 @@ fn createSymlinkFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn readSymlinkFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("read-symlink");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("read-symlink", "string", args[0]);
     try validatePathNoNul(path, args[0]);
@@ -505,6 +548,7 @@ fn readSymlinkFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn createHardLinkFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("create-hard-link");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const old = extractPath(args[0]) orelse return primitives.typeError("create-hard-link", "string", args[0]);
     const new = extractPath(args[1]) orelse return primitives.typeError("create-hard-link", "string", args[1]);
@@ -530,15 +574,15 @@ fn realPathFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    var resolved_buf: [std.posix.PATH_MAX]u8 = undefined;
-    const resolved = std.c.realpath(path_z, &resolved_buf) orelse {
+    var resolved_buf: [platform.PATH_MAX]u8 = undefined;
+    const resolved = platform.realPath(path_z, &resolved_buf) orelse {
         return raiseFileError(gc, "cannot resolve path", args[0]);
     };
-    const len = std.mem.indexOfScalar(u8, resolved[0..resolved_buf.len], 0) orelse resolved_buf.len;
-    return gc.allocString(resolved[0..len]) catch return PrimitiveError.OutOfMemory;
+    return gc.allocString(resolved) catch return PrimitiveError.OutOfMemory;
 }
 
 fn setFileModeFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("set-file-mode");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("set-file-mode", "string", args[0]);
     try validatePathNoNul(path, args[0]);
@@ -555,6 +599,7 @@ fn setFileModeFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn truncateFileFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("truncate-file");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("truncate-file", "string", args[0]);
     try validatePathNoNul(path, args[0]);
@@ -571,6 +616,7 @@ fn truncateFileFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn createFifoFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("create-fifo");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("create-fifo", "string", args[0]);
     try validatePathNoNul(path, args[0]);
@@ -590,6 +636,7 @@ fn createFifoFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn setFileOwnerFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("set-file-owner");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("set-file-owner", "string", args[0]);
     try validatePathNoNul(path, args[0]);
@@ -628,6 +675,7 @@ fn timeArgToTimespec(args: []const Value, idx: usize) std.c.timespec {
 }
 
 fn setFileTimesFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("set-file-times");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = extractPath(args[0]) orelse return primitives.typeError("set-file-times", "string", args[0]);
     try validatePathNoNul(path, args[0]);
@@ -652,10 +700,11 @@ fn setFileTimesFn(args: []const Value) PrimitiveError!Value {
 
 fn pidFn(args: []const Value) PrimitiveError!Value {
     _ = args;
-    return types.makeFixnum(@as(i64, @intCast(std.c.getpid())));
+    return types.makeFixnum(platform.getPid());
 }
 
 fn umaskFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("umask");
     _ = args;
     const cur = std.c.umask(0);
     _ = std.c.umask(cur);
@@ -663,6 +712,7 @@ fn umaskFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn setUmaskFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("set-umask!");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[0])) return primitives.typeError("set-umask!", "integer", args[0]);
     const mask = try validateMode(gc, args[0]);
@@ -673,12 +723,11 @@ fn setUmaskFn(args: []const Value) PrimitiveError!Value {
 fn currentDirectoryFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    var buf: [std.posix.PATH_MAX]u8 = undefined;
-    const result = std.c.getcwd(&buf, buf.len) orelse {
+    var buf: [platform.PATH_MAX]u8 = undefined;
+    const result = platform.getCwd(&buf) orelse {
         return raiseFileError(gc, "cannot get current directory", types.FALSE);
     };
-    const len = std.mem.indexOfScalar(u8, result[0..buf.len], 0) orelse buf.len;
-    return gc.allocString(result[0..len]) catch return PrimitiveError.OutOfMemory;
+    return gc.allocString(result) catch return PrimitiveError.OutOfMemory;
 }
 
 fn setCurrentDirectoryFn(args: []const Value) PrimitiveError!Value {
@@ -689,33 +738,38 @@ fn setCurrentDirectoryFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    if (std.c.chdir(path_z) != 0) {
+    if (platform.chdir(path_z) != 0) {
         return raiseFileError(gc, "cannot change directory", args[0]);
     }
     return types.VOID;
 }
 
 fn userUidFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("user-uid");
     _ = args;
     return types.makeFixnum(@as(i64, @intCast(std.c.getuid())));
 }
 
 fn userGidFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("user-gid");
     _ = args;
     return types.makeFixnum(@as(i64, @intCast(std.c.getgid())));
 }
 
 fn userEffectiveUidFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("user-effective-uid");
     _ = args;
     return types.makeFixnum(@as(i64, @intCast(std.c.geteuid())));
 }
 
 fn userEffectiveGidFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("user-effective-gid");
     _ = args;
     return types.makeFixnum(@as(i64, @intCast(std.c.getegid())));
 }
 
 fn userSupplementaryGidsFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("user-supplementary-gids");
     _ = args;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
@@ -740,6 +794,7 @@ fn userSupplementaryGidsFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn niceFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("nice");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var delta: c_int = 1;
     if (args.len > 0 and types.isFixnum(args[0])) {
@@ -773,14 +828,9 @@ fn setEnvVarFn(args: []const Value) PrimitiveError!Value {
     try validatePathNoNul(name, args[0]);
     try validatePathNoNul(value, args[1]);
 
-    const name_z = gc.allocator.dupeZ(u8, name) catch return PrimitiveError.OutOfMemory;
-    defer gc.allocator.free(name_z);
-    const value_z = gc.allocator.dupeZ(u8, value) catch return PrimitiveError.OutOfMemory;
-    defer gc.allocator.free(value_z);
-
-    if (setenv(name_z, value_z, 1) != 0) {
+    platform.setEnv(gc.allocator, name, value) catch {
         return raiseFileError(gc, "cannot set environment variable", args[0]);
-    }
+    };
     return types.VOID;
 }
 
@@ -789,10 +839,7 @@ fn deleteEnvVarFn(args: []const Value) PrimitiveError!Value {
     const name = extractPath(args[0]) orelse return primitives.typeError("delete-environment-variable!", "string", args[0]);
     try validatePathNoNul(name, args[0]);
 
-    const name_z = gc.allocator.dupeZ(u8, name) catch return PrimitiveError.OutOfMemory;
-    defer gc.allocator.free(name_z);
-
-    _ = unsetenv(name_z);
+    platform.unsetEnv(gc.allocator, name) catch return PrimitiveError.OutOfMemory;
     return types.VOID;
 }
 
@@ -803,7 +850,7 @@ fn deleteEnvVarFn(args: []const Value) PrimitiveError!Value {
 fn terminalP(args: []const Value) PrimitiveError!Value {
     if (!types.isPort(args[0])) return primitives.typeError("terminal?", "port", args[0]);
     const port = types.toObject(args[0]).as(types.Port);
-    return if (std.c.isatty(port.fd) != 0) types.TRUE else types.FALSE;
+    return if (platform.isatty(port.fd)) types.TRUE else types.FALSE;
 }
 
 // -------------------------------------------------------------------------
@@ -811,6 +858,7 @@ fn terminalP(args: []const Value) PrimitiveError!Value {
 // -------------------------------------------------------------------------
 
 fn userInfoFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("user-info");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     const pw = if (types.isFixnum(args[0])) blk: {
@@ -874,6 +922,7 @@ fn userInfoFullName(args: []const Value) PrimitiveError!Value {
 }
 
 fn groupInfoFn(args: []const Value) PrimitiveError!Value {
+    if (comptime platform.is_windows) return raiseUnsupportedOnWindows("group-info");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     if (types.isFixnum(args[0])) {
@@ -922,12 +971,12 @@ fn openDirectoryFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const dir = std.c.opendir(path_z) orelse {
+    const dir = platform.dirIterCreate(path_z) orelse {
         return raiseFileError(gc, "cannot open directory", args[0]);
     };
 
     return gc.allocDirectoryObject(@ptrCast(dir), include_dotfiles) catch {
-        _ = std.c.closedir(dir);
+        platform.dirIterDestroy(dir);
         return PrimitiveError.OutOfMemory;
     };
 }
@@ -938,17 +987,15 @@ fn readDirectoryFn(args: []const Value) PrimitiveError!Value {
     const d = types.toDirectoryObject(args[0]);
 
     const dir_ptr = d.dir orelse return types.EOF;
-    const dir: *std.c.DIR = @ptrCast(@alignCast(dir_ptr));
+    const dir: *platform.DirIter = @ptrCast(@alignCast(dir_ptr));
 
-    while (std.c.readdir(dir)) |entry| {
-        const name_ptr: [*:0]const u8 = @ptrCast(&entry.name);
-        const name = std.mem.span(name_ptr);
+    while (dir.next()) |name| {
         if (std.mem.eql(u8, name, ".") or std.mem.eql(u8, name, "..")) continue;
         if (!d.include_dotfiles and name.len > 0 and name[0] == '.') continue;
         return gc.allocString(name) catch return PrimitiveError.OutOfMemory;
     }
 
-    _ = std.c.closedir(dir);
+    platform.dirIterDestroy(dir);
     d.dir = null;
     return types.EOF;
 }
@@ -957,7 +1004,7 @@ fn closeDirectoryFn(args: []const Value) PrimitiveError!Value {
     if (!types.isDirectoryObject(args[0])) return primitives.typeError("close-directory", "directory-object", args[0]);
     const d = types.toDirectoryObject(args[0]);
     if (d.dir) |dir| {
-        _ = std.c.closedir(@ptrCast(@alignCast(dir)));
+        platform.dirIterDestroy(@ptrCast(@alignCast(dir)));
         d.dir = null;
     }
     return types.VOID;
@@ -970,17 +1017,15 @@ fn closeDirectoryFn(args: []const Value) PrimitiveError!Value {
 fn posixTimeFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.REALTIME, &ts);
-    return gc.allocSrfi18Time(@intCast(ts.sec), @intCast(ts.nsec), .utc) catch return PrimitiveError.OutOfMemory;
+    const rt = platform.realTime();
+    return gc.allocSrfi18Time(@intCast(rt.sec), @intCast(rt.nsec), .utc) catch return PrimitiveError.OutOfMemory;
 }
 
 fn monotonicTimeFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return gc.allocSrfi18Time(@intCast(ts.sec), @intCast(ts.nsec), .monotonic) catch return PrimitiveError.OutOfMemory;
+    const mono = platform.monotonicNs();
+    return gc.allocSrfi18Time(@intCast(mono / 1_000_000_000), @intCast(mono % 1_000_000_000), .monotonic) catch return PrimitiveError.OutOfMemory;
 }
 
 // (file-info-type fi) — return type as symbol
@@ -1005,14 +1050,16 @@ fn fileInfoTypeFn(args: []const Value) PrimitiveError!Value {
 fn tempFilePrefixFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    return gc.allocString("/tmp/kaappi-") catch return PrimitiveError.OutOfMemory;
+    var buf: [512]u8 = undefined;
+    return gc.allocString(platform.tempFilePrefix(&buf)) catch return PrimitiveError.OutOfMemory;
 }
 
 // (create-temp-file [prefix]) — create a temp file and return its path
 fn createTempFileFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
-    var prefix: []const u8 = "/tmp/kaappi-";
+    var prefix_buf: [512]u8 = undefined;
+    var prefix: []const u8 = platform.tempFilePrefix(&prefix_buf);
     if (args.len > 0 and types.isString(args[0])) {
         const s = types.toObject(args[0]).as(types.SchemeString);
         prefix = s.data[0..s.len];
@@ -1021,14 +1068,34 @@ fn createTempFileFn(args: []const Value) PrimitiveError!Value {
 
     // Build template: prefix + XXXXXX + null
     var template_buf: [256]u8 = undefined;
-    if (prefix.len + 7 > template_buf.len) return raiseFileError(gc, "temp file prefix too long", args[0]);
+    if (prefix.len + 7 > template_buf.len) return raiseFileError(gc, "temp file prefix too long", if (args.len > 0) args[0] else types.FALSE);
     @memcpy(template_buf[0..prefix.len], prefix);
     @memcpy(template_buf[prefix.len..][0..6], "XXXXXX");
     template_buf[prefix.len + 6] = 0;
 
+    if (comptime platform.is_windows) {
+        // No mkstemp in the CRT: fill the template with entropy ourselves
+        // and rely on O_EXCL to make creation race-free, retrying on
+        // collision exactly as mkstemp does.
+        var attempt: u32 = 0;
+        while (attempt < 100) : (attempt += 1) {
+            var seed = platform.monotonicNs() ^ (@as(u64, @intCast(platform.getPid())) << 32) ^ (@as(u64, attempt) << 56);
+            const letters = "abcdefghijklmnopqrstuvwxyz0123456789";
+            for (template_buf[prefix.len..][0..6]) |*ch| {
+                ch.* = letters[@intCast(seed % letters.len)];
+                seed /= letters.len;
+            }
+            const path_z: [:0]const u8 = template_buf[0 .. prefix.len + 6 :0];
+            const wfd = platform.openWriteTruncExcl(path_z, 0o600) catch continue;
+            _ = platform.close(wfd);
+            return gc.allocString(path_z) catch return PrimitiveError.OutOfMemory;
+        }
+        return raiseFileError(gc, "cannot create temp file", types.FALSE);
+    }
+
     const fd = mkstemp(@ptrCast(template_buf[0 .. prefix.len + 6 :0]));
     if (fd < 0) return raiseFileError(gc, "cannot create temp file", types.FALSE);
-    _ = std.posix.system.close(fd);
+    _ = platform.close(fd);
 
     // Find actual path length (null-terminated)
     var path_len: usize = 0;

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
@@ -166,7 +167,13 @@ fn isBufferedFdPort(port: *types.Port) bool {
 /// keeps the port on a blocking fd, so no read ever EAGAINs, nothing
 /// registers with the reactor, and I/O degrades to single-fiber blocking
 /// exactly where the host can't support better.
+///
+/// Windows is a permanent probe-fail: CRT fds have no O_NONBLOCK, so
+/// ports always stay blocking — same degradation as a WASI host without
+/// fd_fdstat_set_flags, and the reactor there is timer/notify-only by
+/// construction (reactor.zig's WindowsEventBackend).
 pub fn maybeSetNonblocking(port: *types.Port) void {
+    if (comptime platform.is_windows) return;
     if (port.nonblocking or port.is_string_port or port.fd <= 2) return;
     const vm = vm_mod.vm_instance orelse return;
     if (vm.scheduler == null) return;
@@ -275,9 +282,9 @@ fn drainWriteBuffer(port: *types.Port) PrimitiveError!void {
         // buffer (or a concurrent close-port drains it for us).
         const buf = port.write_buf orelse break;
         maybeSetNonblocking(port);
-        const rc = std.posix.system.write(port.fd, buf.ptr + port.write_buf_start, port.write_buf_len - port.write_buf_start);
+        const rc = platform.write(port.fd, buf.ptr + port.write_buf_start, port.write_buf_len - port.write_buf_start);
         if (rc < 0) {
-            const e = std.posix.errno(rc);
+            const e = platform.errno(rc);
             if (e == .INTR) continue;
             if (e == .AGAIN) {
                 try waitPortFd(port, .write);
@@ -336,8 +343,8 @@ pub fn flushAllOpenPorts(gc: *memory.GC) void {
             if (!port.is_open or port.is_string_port or port.fd <= 2) continue;
             const wb = port.write_buf orelse continue;
             while (port.write_buf_start < port.write_buf_len) {
-                const rc = std.posix.system.write(port.fd, wb.ptr + port.write_buf_start, port.write_buf_len - port.write_buf_start);
-                if (rc < 0 and std.posix.errno(rc) == .INTR) continue;
+                const rc = platform.write(port.fd, wb.ptr + port.write_buf_start, port.write_buf_len - port.write_buf_start);
+                if (rc < 0 and platform.errno(rc) == .INTR) continue;
                 if (rc <= 0) break;
                 port.write_buf_start += @as(usize, @intCast(rc));
             }
@@ -504,10 +511,10 @@ fn openInputFile(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{}, 0) catch {
+    const fd = platform.openRead(path_z) catch {
         return raiseFileError(gc, "cannot open input file", args[0]);
     };
-    errdefer _ = std.posix.system.close(fd);
+    errdefer _ = platform.close(fd);
 
     const owned_name = gc.allocator.dupe(u8, path) catch return PrimitiveError.OutOfMemory;
     return gc.allocPort(fd, true, false, owned_name, true) catch {
@@ -526,14 +533,10 @@ fn openOutputFile(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .TRUNC = true,
-    }, 0o644) catch {
+    const fd = platform.openWriteTrunc(path_z, 0o644) catch {
         return raiseFileError(gc, "cannot open output file", args[0]);
     };
-    errdefer _ = std.posix.system.close(fd);
+    errdefer _ = platform.close(fd);
 
     const owned_name = gc.allocator.dupe(u8, path) catch return PrimitiveError.OutOfMemory;
     return gc.allocPort(fd, false, true, owned_name, true) catch {
@@ -613,7 +616,7 @@ fn closePort(args: []const Value) PrimitiveError!Value {
             if (vm.scheduler) |sched| fiber_mod.wakeIoWaitersOnFd(sched, port.fd);
             if (vm.reactor) |r| r.unregister(port.fd);
         }
-        if (port.fd > 2) _ = std.posix.system.close(port.fd);
+        if (port.fd > 2) _ = platform.close(port.fd);
     }
     port.is_open = false;
     return types.VOID;
@@ -674,9 +677,9 @@ pub fn readOneByte(port: *types.Port) PrimitiveError!?u8 {
     maybeSetNonblocking(port);
     var chunk: [read_chunk_size]u8 = undefined;
     while (true) {
-        const raw = std.posix.system.read(port.fd, &chunk, chunk.len);
+        const raw = platform.read(port.fd, &chunk, chunk.len);
         if (raw < 0) {
-            const e = std.posix.errno(raw);
+            const e = platform.errno(raw);
             if (e == .INTR) continue;
             if (e == .AGAIN) {
                 try waitPortFd(port, .read);
@@ -1020,9 +1023,9 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
             }
         }
 
-        const raw_n = std.posix.system.read(port.fd, &tmp, tmp.len);
+        const raw_n = platform.read(port.fd, &tmp, tmp.len);
         if (raw_n < 0) {
-            const e = std.posix.errno(raw_n);
+            const e = platform.errno(raw_n);
             if (e == .INTR) continue;
             if (e == .AGAIN) {
                 // Mid-datum would-block: a parked retry re-executes this
@@ -1074,17 +1077,7 @@ fn fileExistsP(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    if (comptime @import("builtin").os.tag == .linux) {
-        const linux = std.os.linux;
-        var sx: linux.Statx = undefined;
-        const rc = linux.statx(@bitCast(@as(i32, std.posix.AT.FDCWD)), path_z, 0, linux.STATX.BASIC_STATS, &sx);
-        if (rc > @as(usize, std.math.maxInt(isize))) return types.FALSE;
-    } else {
-        var stat_buf: std.c.Stat = undefined;
-        if (std.c.fstatat(std.posix.AT.FDCWD, path_z, &stat_buf, 0) != 0)
-            return types.FALSE;
-    }
-    return types.TRUE;
+    return if (platform.pathExists(path_z)) types.TRUE else types.FALSE;
 }
 
 fn eofObjectP(args: []const Value) PrimitiveError!Value {
@@ -1177,7 +1170,7 @@ fn deleteFile(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const result = std.posix.system.unlink(path_z);
+    const result = platform.unlink(path_z);
     if (result < 0) {
         var msg = gc.allocString("cannot delete file") catch return PrimitiveError.OutOfMemory;
         gc.pushRoot(&msg);

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
@@ -53,18 +54,16 @@ fn disassembleFn(args: []const Value) PrimitiveError!Value {
 fn currentSecond(args: []const Value) PrimitiveError!Value {
     _ = args;
 
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.REALTIME, &ts);
-    const secs: f64 = @as(f64, @floatFromInt(ts.sec)) +
-        @as(f64, @floatFromInt(ts.nsec)) / 1e9;
+    const rt = platform.realTime();
+    const secs: f64 = @as(f64, @floatFromInt(rt.sec)) +
+        @as(f64, @floatFromInt(rt.nsec)) / 1e9;
     return types.makeFlonum(secs);
 }
 
 fn currentJiffy(args: []const Value) PrimitiveError!Value {
     _ = args;
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    const us: i64 = @as(i64, @intCast(ts.sec)) * 1000000 + @divFloor(@as(i64, @intCast(ts.nsec)), 1000);
+    const ns = platform.monotonicNs();
+    const us: i64 = @intCast(ns / 1000);
     return types.makeFixnum(us);
 }
 
@@ -153,15 +152,13 @@ fn getEnvVar(args: []const Value) PrimitiveError!Value {
     const name_z = gc.allocator.dupeZ(u8, name) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(name_z);
 
-    const env = std.c.getenv(name_z);
+    const env = platform.getenv(name_z);
     if (env) |val| {
         const val_slice = std.mem.span(val);
         return gc.allocString(val_slice) catch return PrimitiveError.OutOfMemory;
     }
     return types.FALSE;
 }
-
-extern var environ: [*:null]?[*:0]const u8;
 
 fn getEnvVars(args: []const Value) PrimitiveError!Value {
     _ = args;
@@ -179,9 +176,9 @@ fn getEnvVars(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&key_val);
     defer gc.popRoot();
 
-    var i: usize = 0;
-    while (environ[i]) |entry| : (i += 1) {
-        const s = std.mem.span(entry);
+    var env_it = platform.EnvIter.init();
+    defer env_it.deinit();
+    while (env_it.next()) |s| {
         if (std.mem.indexOfScalar(u8, s, '=')) |eq_pos| {
             key_val = gc.allocString(s[0..eq_pos]) catch return PrimitiveError.OutOfMemory;
             const val_str = gc.allocString(s[eq_pos + 1 ..]) catch return PrimitiveError.OutOfMemory;
@@ -286,7 +283,7 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
     defer gc.allocator.free(path_z);
 
     // Open and read the file
-    const fd = std.c.open(path_z, .{});
+    const fd = platform.openRead(path_z) catch -1;
     if (fd < 0) {
         var msg = gc.allocString("cannot open file") catch return PrimitiveError.OutOfMemory;
         gc.pushRoot(&msg);
@@ -301,14 +298,14 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
         vm.current_exception = err_obj;
         return PrimitiveError.ExceptionRaised;
     }
-    defer _ = std.c.close(fd);
+    defer if (fd >= 0) platform.close(fd);
 
     var contents: std.ArrayList(u8) = .empty;
     defer contents.deinit(gc.allocator);
 
     var tmp: [4096]u8 = undefined;
     while (true) {
-        const raw = std.c.read(fd, &tmp, tmp.len);
+        const raw = platform.read(fd, &tmp, tmp.len);
         if (raw <= 0) break;
         const n: usize = @intCast(raw);
         contents.appendSlice(gc.allocator, tmp[0..n]) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
@@ -9,19 +10,7 @@ const PrimitiveError = primitives.PrimitiveError;
 const LS = primitives.LibSet;
 
 fn freshSeed() u64 {
-    if (@import("builtin").os.tag == .linux) {
-        var buf: [8]u8 = undefined;
-        const rc = std.os.linux.getrandom(&buf, buf.len, 0);
-        if (rc == buf.len) return @bitCast(buf);
-    } else {
-        const arc4 = @extern(*const fn () callconv(.c) u32, .{ .name = "arc4random" });
-        const lo: u64 = arc4();
-        const hi: u64 = arc4();
-        return (hi << 32) | lo;
-    }
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return @as(u64, @bitCast(ts.sec)) ^ @as(u64, @bitCast(ts.nsec));
+    return platform.randomSeed64();
 }
 
 pub const specs = [_]primitives.PrimSpec{

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
@@ -221,9 +222,8 @@ pub fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
         if (t.seconds < 0) return 0;
         const ns_clamped: u64 = if (t.nanoseconds > 0) @intCast(t.nanoseconds) else 0;
         const sec_ns: u64 = @as(u64, @intCast(t.seconds)) * 1_000_000_000 + ns_clamped;
-        var now_ts: std.c.timespec = undefined;
-        _ = std.c.clock_gettime(.REALTIME, &now_ts);
-        const now_ns = @as(u64, @intCast(now_ts.sec)) * 1_000_000_000 + @as(u64, @intCast(now_ts.nsec));
+        const now_rt = platform.realTime();
+        const now_ns = @as(u64, @intCast(now_rt.sec)) * 1_000_000_000 + @as(u64, @intCast(now_rt.nsec));
         if (sec_ns <= now_ns) return 0;
         const mono_now = fiber_mod.clockNs();
         return mono_now + (sec_ns - now_ns);
@@ -635,9 +635,8 @@ fn getSleepSeconds(v: Value) PrimitiveError!f64 {
     }
     if (types.isPointer(v) and types.toObject(v).tag == .srfi18_time) {
         const t = types.toObject(v).as(types.Srfi18Time);
-        var ts: std.c.timespec = undefined;
-        _ = std.c.clock_gettime(.REALTIME, &ts);
-        const now: f64 = @as(f64, @floatFromInt(ts.sec)) + @as(f64, @floatFromInt(ts.nsec)) / 1e9;
+        const rt = platform.realTime();
+        const now: f64 = @as(f64, @floatFromInt(rt.sec)) + @as(f64, @floatFromInt(rt.nsec)) / 1e9;
         const target: f64 = @as(f64, @floatFromInt(t.seconds)) + @as(f64, @floatFromInt(t.nanoseconds)) / 1e9;
         return target - now;
     }
@@ -702,15 +701,7 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn sleepNs(ns: u64) void {
-    var ts: std.c.timespec = .{
-        .sec = @intCast(ns / 1_000_000_000),
-        .nsec = @intCast(ns % 1_000_000_000),
-    };
-    while (true) {
-        const ret = std.c.nanosleep(&ts, &ts);
-        if (ret == 0) break;
-        if (std.posix.errno(ret) != .INTR) break;
-    }
+    platform.sleepNs(ns);
 }
 
 fn threadJoinFn(args: []const Value) PrimitiveError!Value {
@@ -1359,9 +1350,8 @@ fn condvarBroadcastFn(args: []const Value) PrimitiveError!Value {
 
 fn currentTimeFn(_: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.REALTIME, &ts);
-    return gc.allocSrfi18Time(@intCast(ts.sec), @intCast(ts.nsec), .utc) catch return PrimitiveError.OutOfMemory;
+    const rt = platform.realTime();
+    return gc.allocSrfi18Time(@intCast(rt.sec), @intCast(rt.nsec), .utc) catch return PrimitiveError.OutOfMemory;
 }
 
 fn timeToSecondsFn(args: []const Value) PrimitiveError!Value {

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -8,6 +8,7 @@
 //! kqueue (macOS/BSD), epoll (Linux), poll_oneoff (WASI, Phase 4). See
 //! https://github.com/kaappi/keps/blob/main/keps/0001-event-loop-reactor.md
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 const fiber_mod = @import("fiber.zig");
 const memory = @import("memory.zig");
@@ -30,7 +31,8 @@ const Backend = switch (builtin.os.tag) {
     .macos, .ios, .tvos, .watchos, .visionos => KqueueBackend,
     .linux => EpollBackend,
     .wasi => WasiPollBackend,
-    else => @compileError("reactor: unsupported OS (kqueue/epoll/wasi only)"),
+    .windows => WindowsEventBackend,
+    else => @compileError("reactor: unsupported OS (kqueue/epoll/wasi/windows only)"),
 };
 
 const TimerEntry = struct {
@@ -104,16 +106,20 @@ pub const ThreadNotifier = struct {
                 // way to learn a notify happened.
                 while (true) {
                     const rc = std.c.kevent(self.backend.kq, &triggers, 1, triggers[0..0].ptr, 0, &zero_ts);
-                    if (rc >= 0 or std.posix.errno(rc) != .INTR) break;
+                    if (rc >= 0 or platform.errno(rc) != .INTR) break;
                 }
             },
             .linux => {
                 const one: u64 = 1;
                 while (true) {
-                    const rc = std.posix.system.write(self.backend.fd, @ptrCast(&one), @sizeOf(u64));
-                    if (rc >= 0 or std.posix.errno(rc) != .INTR) break;
+                    const rc = platform.write(self.backend.fd, @ptrCast(&one), @sizeOf(u64));
+                    if (rc >= 0 or platform.errno(rc) != .INTR) break;
                 }
             },
+            // Auto-reset event: signaling is idempotent while pending and
+            // the next WaitForSingleObject consumes it atomically — the
+            // same self-clearing wake the EVFILT.USER/eventfd paths give.
+            .windows => _ = platform.win.SetEvent(self.backend.event),
             .wasi => {},
             else => unreachable,
         }
@@ -128,7 +134,8 @@ const NotifierBackend = switch (builtin.os.tag) {
     .macos, .ios, .tvos, .watchos, .visionos => struct { kq: i32 },
     .linux => struct { fd: i32 },
     .wasi => struct {},
-    else => @compileError("reactor: unsupported OS (kqueue/epoll/wasi only)"),
+    .windows => struct { event: platform.win.HANDLE },
+    else => @compileError("reactor: unsupported OS (kqueue/epoll/wasi/windows only)"),
 };
 
 /// KEP-0002 §7 leak-check hook, mirrors shared_object.liveCount() --
@@ -159,9 +166,12 @@ pub fn retainNotifier(n: *ThreadNotifier) void {
 pub fn releaseNotifier(n: *ThreadNotifier) void {
     if (n.refcount.fetchSub(1, .acq_rel) == 1) {
         switch (builtin.os.tag) {
-            .macos, .ios, .tvos, .watchos, .visionos => _ = std.posix.system.close(n.backend.kq),
-            .linux => _ = std.posix.system.close(n.backend.fd),
+            .macos, .ios, .tvos, .watchos, .visionos => _ = platform.close(n.backend.kq),
+            .linux => _ = platform.close(n.backend.fd),
             .wasi => {},
+            // Shared with the backend's wait — closed only here, exactly
+            // like kqueue's shared kq (see KqueueBackend.deinit).
+            .windows => _ = platform.win.CloseHandle(n.backend.event),
             else => unreachable,
         }
         std.heap.c_allocator.destroy(n);
@@ -456,7 +466,7 @@ const KqueueBackend = struct {
             .udata = 0,
         };
         self.apply((&reg)[0..1]) catch {
-            _ = std.posix.system.close(kq);
+            _ = platform.close(kq);
             return error.Unexpected;
         };
         return self;
@@ -540,7 +550,7 @@ const KqueueBackend = struct {
         }
         const rc = std.c.kevent(self.kq, self.raw[0..0].ptr, 0, &self.raw, self.raw.len, ts_ptr);
         if (rc < 0) {
-            if (std.posix.errno(rc) == .INTR) return self.ready[0..0];
+            if (platform.errno(rc) == .INTR) return self.ready[0..0];
             return error.Unexpected;
         }
 
@@ -673,7 +683,7 @@ const EpollBackend = struct {
                 // slot itself is inert (Reactor.poll's regs lookup never
                 // finds an entry for notify_fd).
                 var drain_buf: [8]u8 = undefined;
-                _ = std.posix.system.read(self.notify_fd, &drain_buf, drain_buf.len);
+                _ = platform.read(self.notify_fd, &drain_buf, drain_buf.len);
                 self.ready[i] = .{ .fd = self.notify_fd, .readable = false, .writable = false };
                 continue;
             }
@@ -876,5 +886,65 @@ const WasiPollBackend = struct {
         if (readable) dirs.read = false;
         if (writable) dirs.write = false;
         if (!dirs.read and !dirs.write) _ = self.interests.swapRemove(fd);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Windows event backend
+//
+// Windows has no fd-readiness support here by construction: CRT fds have
+// no O_NONBLOCK, so maybeSetNonblocking (primitives_io.zig) is a comptime
+// no-op, no read/write ever EAGAINs, and register() is never reached —
+// the same shape as a WASI host whose NONBLOCK probe fails, except made
+// permanent. What remains is exactly what the reactor still owes the
+// scheduler on such a platform: bounded timer waits (thread-sleep!, timed
+// channel/mutex waits) and the KEP-0002 cross-thread notify. One
+// auto-reset Win32 event serves both — WaitForSingleObject bounded by the
+// nearest deadline, SetEvent as the notify ring.
+// ---------------------------------------------------------------------------
+
+const WindowsEventBackend = struct {
+    /// Shared with the ThreadNotifier (same handle), so — like kqueue's
+    /// `kq` — exactly one place may close it: releaseNotifier's zero
+    /// transition. deinit here is a no-op.
+    event: platform.win.HANDLE,
+
+    /// The allocator is part of the uniform backend init signature
+    /// (WasiPollBackend needs it); this backend owns no allocations.
+    fn init(_: std.mem.Allocator) !WindowsEventBackend {
+        const ev = platform.win.CreateEventW(null, 0, 0, null) orelse return error.Unexpected;
+        return .{ .event = ev };
+    }
+
+    fn notifierBackend(self: *const WindowsEventBackend) NotifierBackend {
+        return .{ .event = self.event };
+    }
+
+    fn deinit(self: *WindowsEventBackend) void {
+        _ = self;
+    }
+
+    /// Unreachable by construction (see the header comment): ports never
+    /// go non-blocking on Windows, so nothing ever registers an fd. A
+    /// clean error rather than `unreachable` so a future caller bug
+    /// surfaces as a failed wait-registration, not UB.
+    fn arm(_: *WindowsEventBackend, _: i32, _: bool, _: bool, _: bool) !void {
+        return error.Unexpected;
+    }
+
+    fn disarmAll(_: *WindowsEventBackend, _: i32) void {}
+
+    fn wait(self: *WindowsEventBackend, timeout_ns: ?u64) ![]const ReadyEvent {
+        const ms: u32 = if (timeout_ns) |ns| blk: {
+            // Ceil so a timer may fire slightly late but never early
+            // (resolved KEP-0001 question 2, epoll's msFromNs discipline).
+            const ceil_ms = (ns +| 999_999) / 1_000_000;
+            break :blk @intCast(@min(ceil_ms, platform.win.INFINITE - 1));
+        } else platform.win.INFINITE;
+        _ = platform.win.WaitForSingleObject(self.event, ms);
+        // Timer expiry is decided by the reactor against clockNs()
+        // (popExpiredTimers); a notify set wake_pending before SetEvent.
+        // There are never fd events to report.
+        return &[_]ReadyEvent{};
     }
 };

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
@@ -10,7 +11,11 @@ const reporting = @import("reporting.zig");
 const expander = @import("expander.zig");
 const toplevel_driver = @import("toplevel_driver.zig");
 const crash = @import("crash.zig");
-const ln = if (is_wasm) struct {} else @import("linenoise.zig");
+/// linenoise is POSIX-only (termios). The Windows REPL keeps the whole
+/// eval/print/debug-command loop and swaps only the line source: a plain
+/// prompt + buffered stdin read (no editing/history/completion).
+const use_linenoise = !is_wasm and !platform.is_windows;
+const ln = if (use_linenoise) @import("linenoise.zig") else struct {};
 
 const config_mod = @import("config.zig");
 const version = @import("main.zig").version;
@@ -23,10 +28,53 @@ var highlight_enabled: bool = true;
 
 fn getTerminalWidth() u16 {
     if (comptime is_wasm) return 80;
-    var ws: std.posix.winsize = .{ .row = 0, .col = 0, .xpixel = 0, .ypixel = 0 };
-    const ret = std.c.ioctl(1, std.c.T.IOCGWINSZ, @intFromPtr(&ws));
-    if (ret == 0 and ws.col > 0) return ws.col;
-    return 80;
+    return platform.terminalWidth() orelse 80;
+}
+
+/// One REPL line. linenoise where available; otherwise write the prompt
+/// and read a plain line from fd 0 (Windows). Returns a malloc'd
+/// NUL-terminated line without its trailing newline — the linenoise
+/// return contract — freed by `freeReplLine`. Null on EOF.
+fn readReplLine(prompt: [*:0]const u8) ?[*:0]u8 {
+    if (comptime use_linenoise) return @ptrCast(ln.linenoise(prompt));
+
+    const prompt_s = std.mem.span(prompt);
+    _ = platform.write(1, prompt_s.ptr, prompt_s.len);
+
+    const allocator = std.heap.c_allocator;
+    var line: std.ArrayList(u8) = .empty;
+    defer line.deinit(allocator);
+    while (true) {
+        var byte: [1]u8 = undefined;
+        const n = platform.read(0, &byte, 1);
+        if (n < 0) {
+            if (platform.errno(n) == .INTR) continue;
+            return null;
+        }
+        if (n == 0) {
+            if (line.items.len == 0) return null; // EOF at line start
+            break; // EOF terminates a final unterminated line
+        }
+        if (byte[0] == '\n') break;
+        line.append(allocator, byte[0]) catch return null;
+    }
+    if (line.items.len > 0 and line.items[line.items.len - 1] == '\r') {
+        _ = line.pop();
+    }
+    line.append(allocator, 0) catch return null;
+    const owned = line.toOwnedSlice(allocator) catch return null;
+    return @ptrCast(owned.ptr);
+}
+
+fn freeReplLine(line_ptr: [*:0]u8) void {
+    if (comptime use_linenoise) {
+        ln.free(@ptrCast(line_ptr));
+        return;
+    }
+    // Mirror of readReplLine's raw_c_allocator ownership: reconstruct the
+    // allocation (bytes incl. the NUL) and free it.
+    const len = std.mem.len(line_ptr);
+    std.heap.c_allocator.free(line_ptr[0 .. len + 1]);
 }
 
 const writeStdout = reporting.writeStdout;
@@ -619,24 +667,25 @@ pub fn repl(vm: *vm_mod.VM) !void {
 
     terminal_width = getTerminalWidth();
     repl_vm = vm;
-    ln.setMultiLine(true);
-    ln.historySetMaxLen(cfg.history_length);
 
     var hist_path_buf: [512]u8 = undefined;
-    const hist_path: ?[*:0]const u8 = blk: {
+    const hist_path: ?[*:0]const u8 = if (comptime use_linenoise) blk: {
+        ln.setMultiLine(true);
+        ln.historySetMaxLen(cfg.history_length);
         const kaappi_paths = @import("kaappi_paths.zig");
         var home_buf: [256]u8 = undefined;
         const kaappi_home = kaappi_paths.getHome(&home_buf) orelse break :blk null;
         const dir = std.fmt.bufPrintZ(hist_path_buf[0..500], "{s}", .{kaappi_home}) catch break :blk null;
-        _ = std.c.mkdir(dir.ptr, 0o755);
+        _ = platform.mkdir(dir, 0o755);
         const path = std.fmt.bufPrintZ(&hist_path_buf, "{s}/history", .{kaappi_home}) catch break :blk null;
         break :blk path;
-    };
-    if (hist_path) |p| ln.historyLoad(p);
-
-    ln.setCompletionCallback(&completionCallback);
-    if (highlight_enabled) {
-        ln.setHighlightCallback(&highlightCallback);
+    } else null;
+    if (comptime use_linenoise) {
+        if (hist_path) |p| ln.historyLoad(p);
+        ln.setCompletionCallback(&completionCallback);
+        if (highlight_enabled) {
+            ln.setHighlightCallback(&highlightCallback);
+        }
     }
 
     // Build colored prompt strings: <color>text<reset>\0
@@ -673,14 +722,18 @@ pub fn repl(vm: *vm_mod.VM) !void {
     while (true) {
         const prompt: [*:0]const u8 = if (input_buf.items.len > 0) continuation_prompt else primary_prompt;
         accumulated_input = input_buf.items;
-        const line_ptr = ln.linenoise(prompt) orelse {
-            const err = std.c._errno().*;
-            if (err == @intFromEnum(std.posix.E.AGAIN)) {
-                if (input_buf.items.len > 0) {
-                    input_buf.clearRetainingCapacity();
+        const line_ptr = readReplLine(prompt) orelse {
+            if (comptime use_linenoise) {
+                // linenoise signals ctrl-C via EAGAIN: reset any pending
+                // multi-line input instead of exiting.
+                const err = std.c._errno().*;
+                if (err == @intFromEnum(std.posix.E.AGAIN)) {
+                    if (input_buf.items.len > 0) {
+                        input_buf.clearRetainingCapacity();
+                    }
+                    writeStdout("\n");
+                    continue;
                 }
-                writeStdout("\n");
-                continue;
             }
             if (input_buf.items.len > 0) {
                 input_buf.clearRetainingCapacity();
@@ -689,7 +742,7 @@ pub fn repl(vm: *vm_mod.VM) !void {
             }
             break;
         };
-        defer ln.free(@ptrCast(line_ptr));
+        defer freeReplLine(line_ptr);
 
         const line = std.mem.span(line_ptr);
         const trimmed = std.mem.trim(u8, line, " \t\r");
@@ -800,13 +853,10 @@ pub fn repl(vm: *vm_mod.VM) !void {
         }
         if (std.mem.startsWith(u8, debug_trimmed, ",time ")) {
             const time_expr = debug_trimmed[6..];
-            var ts: std.c.timespec = undefined;
-            _ = std.c.clock_gettime(.MONOTONIC, &ts);
+            const t0 = platform.monotonicNs();
             evalInput(vm, allocator, time_expr);
-            var te: std.c.timespec = undefined;
-            _ = std.c.clock_gettime(.MONOTONIC, &te);
-            const secs = @as(f64, @floatFromInt(te.sec - ts.sec)) +
-                @as(f64, @floatFromInt(te.nsec - ts.nsec)) / 1_000_000_000.0;
+            const t1 = platform.monotonicNs();
+            const secs = @as(f64, @floatFromInt(t1 - t0)) / 1_000_000_000.0;
             var tbuf: [64]u8 = undefined;
             const ts_str = std.fmt.bufPrint(&tbuf, "; {d:.3} seconds\n", .{secs}) catch "; ? seconds\n";
             writeStdout(ts_str);
@@ -1044,18 +1094,22 @@ pub fn repl(vm: *vm_mod.VM) !void {
             continue;
         }
 
-        var hist_buf: std.ArrayList(u8) = .empty;
-        defer hist_buf.deinit(allocator);
-        hist_buf.appendSlice(allocator, full_input) catch {};
-        hist_buf.append(allocator, 0) catch {};
-        ln.historyAdd(@ptrCast(hist_buf.items.ptr));
+        if (comptime use_linenoise) {
+            var hist_buf: std.ArrayList(u8) = .empty;
+            defer hist_buf.deinit(allocator);
+            hist_buf.appendSlice(allocator, full_input) catch {};
+            hist_buf.append(allocator, 0) catch {};
+            ln.historyAdd(@ptrCast(hist_buf.items.ptr));
+        }
 
         evalInputTyped(vm, allocator, full_input, .store_last);
 
         input_buf.clearRetainingCapacity();
     }
 
-    if (hist_path) |p| ln.historySave(p);
+    if (comptime use_linenoise) {
+        if (hist_path) |p| ln.historySave(p);
+    }
     repl_vm = null;
 }
 

--- a/src/reporting.zig
+++ b/src/reporting.zig
@@ -1,16 +1,17 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 pub const types = @import("types.zig");
 pub const memory = @import("memory.zig");
 pub const vm_mod = @import("vm.zig");
 pub const library_mod = @import("library.zig");
 const file_utils = @import("file_utils.zig");
 
-pub fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
+pub fn writeToFd(fd: platform.fd_t, bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
+        const result = platform.write(fd, bytes.ptr + total, bytes.len - total);
         if (result < 0) {
-            if (std.posix.errno(result) == .INTR) continue;
+            if (platform.errno(result) == .INTR) continue;
             break;
         }
         if (result == 0) break;
@@ -464,11 +465,18 @@ pub fn writeCoverageXml(vm: *vm_mod.VM, path: []const u8) void {
     xml.appendSlice(allocator, "</coverage>\n") catch {};
 
     // Write to file
-    const fd = std.posix.openat(std.posix.AT.FDCWD, @ptrCast(path), .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, 0o644) catch {
+    var path_buf: [platform.PATH_MAX]u8 = undefined;
+    if (path.len >= path_buf.len) {
+        writeStderr("error: could not open coverage XML output file\n");
+        return;
+    }
+    @memcpy(path_buf[0..path.len], path);
+    path_buf[path.len] = 0;
+    const fd = platform.openWriteTrunc(path_buf[0..path.len :0], 0o644) catch {
         writeStderr("error: could not open coverage XML output file\n");
         return;
     };
-    defer _ = std.posix.system.close(fd);
+    defer _ = platform.close(fd);
 
     writeToFd(fd, xml.items);
 }
@@ -595,7 +603,7 @@ pub fn printCoverageReport(vm: *vm_mod.VM) void {
     }
 }
 
-fn writeJsonEscaped(fd: std.posix.fd_t, s: []const u8) void {
+fn writeJsonEscaped(fd: platform.fd_t, s: []const u8) void {
     for (s) |c| {
         switch (c) {
             '"' => writeToFd(fd, "\\\""),
@@ -616,12 +624,12 @@ fn writeJsonEscaped(fd: std.posix.fd_t, s: []const u8) void {
 }
 
 pub fn writeProfileJson(gc: *memory.GC, path: []const u8) void {
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .TRUNC = true,
-    }, 0o644) catch return;
-    defer _ = std.posix.system.close(fd);
+    var path_buf: [platform.PATH_MAX]u8 = undefined;
+    if (path.len >= path_buf.len) return;
+    @memcpy(path_buf[0..path.len], path);
+    path_buf[path.len] = 0;
+    const fd = platform.openWriteTrunc(path_buf[0..path.len :0], 0o644) catch return;
+    defer _ = platform.close(fd);
 
     writeToFd(fd, "[");
     var first = true;

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const vm_mod = @import("vm.zig");
@@ -14,7 +15,7 @@ pub export fn kaappi_runtime_init() callconv(.c) ?*vm_mod.VM {
 
     rt_gc = memory.GC.init(allocator);
 
-    if (std.c.getenv("KAAPPI_GC_THRESHOLD")) |env_ptr| {
+    if (platform.getenv("KAAPPI_GC_THRESHOLD")) |env_ptr| {
         const env = std.mem.span(env_ptr);
         if (std.fmt.parseInt(usize, env, 10)) |threshold| {
             rt_gc.gc_threshold = threshold;
@@ -61,9 +62,9 @@ pub export fn kaappi_global_lookup(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_
     const len: usize = @intCast(name_len);
     const name = name_ptr[0..len];
     return v.globals.get(name) orelse {
-        _ = std.posix.system.write(2, "undefined variable: ", 20);
-        _ = std.posix.system.write(2, name_ptr, len);
-        _ = std.posix.system.write(2, "\n", 1);
+        _ = platform.write(2, "undefined variable: ", 20);
+        _ = platform.write(2, name_ptr, len);
+        _ = platform.write(2, "\n", 1);
         std.process.exit(1);
     };
 }
@@ -73,7 +74,7 @@ pub export fn kaappi_define_global(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_
     const len: usize = @intCast(name_len);
     const name = name_ptr[0..len];
     v.defineGlobal(name, val) catch {
-        _ = std.posix.system.write(2, "failed to define global\n", 24);
+        _ = platform.write(2, "failed to define global\n", 24);
         std.process.exit(1);
     };
 }
@@ -88,9 +89,9 @@ pub export fn kaappi_set_global(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len
     if (v.globals.getPtr(name)) |ptr| {
         ptr.* = val;
     } else {
-        _ = std.posix.system.write(2, "set!: unbound variable '", 24);
-        _ = std.posix.system.write(2, name_ptr, len);
-        _ = std.posix.system.write(2, "'\n", 2);
+        _ = platform.write(2, "set!: unbound variable '", 24);
+        _ = platform.write(2, name_ptr, len);
+        _ = platform.write(2, "'\n", 2);
         std.process.exit(1);
     }
 }
@@ -100,7 +101,7 @@ pub export fn kaappi_make_string(vm: ?*vm_mod.VM, str_ptr: [*]const u8, str_len:
     const len: usize = @intCast(str_len);
     const data = str_ptr[0..len];
     const result = v.gc.allocString(data) catch {
-        _ = std.posix.system.write(2, "failed to allocate string\n", 26);
+        _ = platform.write(2, "failed to allocate string\n", 26);
         std.process.exit(1);
     };
     return result;
@@ -111,7 +112,7 @@ pub export fn kaappi_intern_symbol(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_
     const len: usize = @intCast(name_len);
     const name = name_ptr[0..len];
     const result = v.gc.allocSymbol(name) catch {
-        _ = std.posix.system.write(2, "failed to intern symbol\n", 24);
+        _ = platform.write(2, "failed to intern symbol\n", 24);
         std.process.exit(1);
     };
     return result;
@@ -125,7 +126,7 @@ pub export fn kaappi_create_native_closure(vm: ?*vm_mod.VM, fn_ptr: ?*anyopaque,
     const name = name_ptr[0..@as(usize, @intCast(name_len))];
     const nc_fn: types.NativeClosureFnType = @ptrCast(@alignCast(fn_ptr));
     const result = v.gc.allocNativeClosure(nc_fn, uv, a, name) catch {
-        _ = std.posix.system.write(2, "OOM: failed to allocate native closure\n", 39);
+        _ = platform.write(2, "OOM: failed to allocate native closure\n", 39);
         std.process.exit(1);
     };
     return result;
@@ -137,15 +138,15 @@ pub export fn kaappi_create_native_closure(vm: ?*vm_mod.VM, fn_ptr: ?*anyopaque,
 fn fatalVMError(vm: *vm_mod.VM, context: []const u8, err: anyerror) noreturn {
     vm.noteUncaughtException(err);
     const detail = vm.getErrorDetail();
-    _ = std.posix.system.write(2, context.ptr, context.len);
+    _ = platform.write(2, context.ptr, context.len);
     if (detail.len > 0) {
-        _ = std.posix.system.write(2, ": ", 2);
-        _ = std.posix.system.write(2, detail.ptr, detail.len);
+        _ = platform.write(2, ": ", 2);
+        _ = platform.write(2, detail.ptr, detail.len);
     }
     const name = @errorName(err);
-    _ = std.posix.system.write(2, " (", 2);
-    _ = std.posix.system.write(2, name.ptr, name.len);
-    _ = std.posix.system.write(2, ")\n", 2);
+    _ = platform.write(2, " (", 2);
+    _ = platform.write(2, name.ptr, name.len);
+    _ = platform.write(2, ")\n", 2);
     std.process.exit(1);
 }
 
@@ -250,7 +251,7 @@ pub export fn kaappi_quote_cached(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len
     // is the right anchor.
     const val = v.eval(source) catch |err| fatalVMError(v, "eval error", err);
     _ = v.gc.rootedSlot(val) catch {
-        _ = std.posix.system.write(2, "OOM: failed to root quoted constant\n", 36);
+        _ = platform.write(2, "OOM: failed to root quoted constant\n", 36);
         std.process.exit(1);
     };
     slot.* = val;
@@ -259,11 +260,11 @@ pub export fn kaappi_quote_cached(vm: ?*vm_mod.VM, src_ptr: [*]const u8, src_len
 
 fn callPrimitive(name: []const u8, a: u64, b: u64) u64 {
     const vm = vm_mod.vm_instance orelse {
-        _ = std.posix.system.write(2, "runtime: no VM instance\n", 24);
+        _ = platform.write(2, "runtime: no VM instance\n", 24);
         std.process.exit(1);
     };
     const proc = vm.globals.get(name) orelse {
-        _ = std.posix.system.write(2, "runtime: undefined primitive\n", 29);
+        _ = platform.write(2, "runtime: undefined primitive\n", 29);
         std.process.exit(1);
     };
     const args = [_]u64{ a, b };
@@ -321,19 +322,19 @@ pub export fn kaappi_fixnum_eq(a: u64, b: u64) callconv(.c) u64 {
 
 pub export fn kaappi_car(v: u64) callconv(.c) u64 {
     if (types.isPair(v)) return types.car(v);
-    _ = std.posix.system.write(2, "car: not a pair\n", 16);
+    _ = platform.write(2, "car: not a pair\n", 16);
     std.process.exit(1);
 }
 
 pub export fn kaappi_cdr(v: u64) callconv(.c) u64 {
     if (types.isPair(v)) return types.cdr(v);
-    _ = std.posix.system.write(2, "cdr: not a pair\n", 16);
+    _ = platform.write(2, "cdr: not a pair\n", 16);
     std.process.exit(1);
 }
 
 pub export fn kaappi_cons(a: u64, b: u64) callconv(.c) u64 {
     const gc = memory.gc_instance orelse {
-        _ = std.posix.system.write(2, "cons: no GC instance\n", 21);
+        _ = platform.write(2, "cons: no GC instance\n", 21);
         std.process.exit(1);
     };
     var val_a = a;
@@ -341,7 +342,7 @@ pub export fn kaappi_cons(a: u64, b: u64) callconv(.c) u64 {
     gc.pushRoot(&val_a);
     gc.pushRoot(&val_b);
     const result = gc.allocPair(val_a, val_b) catch {
-        _ = std.posix.system.write(2, "OOM: failed to allocate pair\n", 29);
+        _ = platform.write(2, "OOM: failed to allocate pair\n", 29);
         std.process.exit(1);
     };
     gc.popRoot();
@@ -367,13 +368,13 @@ pub export fn kaappi_is_null(v: u64) callconv(.c) u64 {
 
 pub export fn kaappi_make_box(vm: ?*vm_mod.VM, init: u64) callconv(.c) u64 {
     const v = vm orelse {
-        _ = std.posix.system.write(2, "make-box: null vm\n", 18);
+        _ = platform.write(2, "make-box: null vm\n", 18);
         std.process.exit(1);
     };
     // allocPair roots `init` internally before it may collect, so a young
     // initial value survives a GC triggered by this very allocation.
     return v.gc.allocPair(init, types.NIL) catch {
-        _ = std.posix.system.write(2, "OOM: failed to allocate box\n", 28);
+        _ = platform.write(2, "OOM: failed to allocate box\n", 28);
         std.process.exit(1);
     };
 }
@@ -392,7 +393,7 @@ pub export fn kaappi_box_set(box: u64, val: u64) callconv(.c) void {
 
 pub export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]const u64, nargs: u64) callconv(.c) u64 {
     const v = vm orelse {
-        _ = std.posix.system.write(2, "null vm\n", 8);
+        _ = platform.write(2, "null vm\n", 8);
         std.process.exit(1);
     };
     const n: usize = @intCast(nargs);

--- a/src/stress_channel.zig
+++ b/src/stress_channel.zig
@@ -12,6 +12,7 @@
 //!             zig build stress-channel -- <seed> <producers> <consumers> <per-producer>
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
@@ -22,7 +23,7 @@ const pct_stress = @import("pct_stress.zig");
 fn fail(comptime fmt: []const u8, args: anytype) noreturn {
     var buf: [512]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch fmt;
-    _ = std.posix.system.write(2, msg.ptr, msg.len);
+    _ = platform.write(2, msg.ptr, msg.len);
     std.process.exit(1);
 }
 
@@ -139,7 +140,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     var buf: [256]u8 = undefined;
     const banner = try std.fmt.bufPrint(&buf, "stress-channel: seed={d} producers={d} consumers={d} per_producer={d}\n", .{ seed, n_producers, m_consumers, per_producer });
-    _ = std.posix.system.write(1, banner.ptr, banner.len);
+    _ = platform.write(1, banner.ptr, banner.len);
 
     pct_stress.enabled = true;
     last_progress_ns.store(nowNs(), .monotonic);
@@ -199,5 +200,5 @@ pub fn main(init: std.process.Init.Minimal) !void {
         fail("FAIL: notifier leak: baseline={d} now={d} (seed={d})\n", .{ notifier_baseline, reactor_mod.notifierLiveCount(), seed });
 
     const ok_msg = "stress-channel: PASS\n";
-    _ = std.posix.system.write(1, ok_msg.ptr, ok_msg.len);
+    _ = platform.write(1, ok_msg.ptr, ok_msg.len);
 }

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -26,6 +26,7 @@
 //! chance to emit its result.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 const reporting = @import("reporting.zig");
 const lsp_diagnostic = @import("lsp_diagnostic.zig");
@@ -50,10 +51,8 @@ pub const USAGE_ERROR_EXIT: u8 = 2;
 const EMIT_ENV = "KAAPPI_TEST_EMIT";
 const SEED_ENV = "KAAPPI_TEST_SEED";
 
-extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
-
 fn getEnv(name: [*:0]const u8) ?[]const u8 {
-    const v = std.c.getenv(name) orelse return null;
+    const v = platform.getenv(name) orelse return null;
     return std.mem.span(v);
 }
 
@@ -262,13 +261,13 @@ fn writeIntOrNull(w: *std.Io.Writer, v: Value) !void {
 }
 
 fn writeFile(path: []const u8, bytes: []const u8) void {
-    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    var buf: [platform.PATH_MAX]u8 = undefined;
     if (path.len >= buf.len) return;
     @memcpy(buf[0..path.len], path);
     buf[path.len] = 0;
-    const path_z: [*:0]const u8 = @ptrCast(&buf);
-    const fd = std.posix.openatZ(std.posix.AT.FDCWD, path_z, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, 0o644) catch return;
-    defer _ = std.posix.system.close(fd);
+    const path_z: [:0]const u8 = buf[0..path.len :0];
+    const fd = platform.openWriteTrunc(path_z, 0o644) catch return;
+    defer _ = platform.close(fd);
     reporting.writeToFd(fd, bytes);
 }
 
@@ -315,7 +314,7 @@ const Totals = struct {
 /// Like `explain`, the orchestrator needs no VM of its own — it spawns workers
 /// — so main dispatches it before any VM/GC setup.
 pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
-    var it = args.iterate();
+    var it = platform.argsIterate(args);
     const argv0 = it.next() orelse return null;
     const first = it.next() orelse return null;
     if (!std.mem.eql(u8, first, "test")) return null;
@@ -376,7 +375,7 @@ pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
 fn run(allocator: std.mem.Allocator, argv0: []const u8, opts: *ParentOpts) u8 {
     // The exe to spawn as a worker: prefer the resolved self-path so it works
     // regardless of how the parent was invoked, falling back to argv[0].
-    var exe_buf: [std.posix.PATH_MAX]u8 = undefined;
+    var exe_buf: [platform.PATH_MAX]u8 = undefined;
     const exe_path = kaappi_paths.getExePath(&exe_buf) orelse argv0;
 
     // One seed for the whole run; a random but human-typable value when the
@@ -385,7 +384,7 @@ fn run(allocator: std.mem.Allocator, argv0: []const u8, opts: *ParentOpts) u8 {
     {
         var sbuf: [32]u8 = undefined;
         const s = std.fmt.bufPrintZ(&sbuf, "{d}", .{seed}) catch return 1;
-        _ = setenv(SEED_ENV, s.ptr, 1);
+        platform.setEnv(allocator, SEED_ENV, std.mem.sliceTo(s.ptr, 0)) catch return 1;
     }
 
     var files: std.ArrayList([]const u8) = .empty;
@@ -447,19 +446,14 @@ fn run(allocator: std.mem.Allocator, argv0: []const u8, opts: *ParentOpts) u8 {
 }
 
 fn runOneFile(allocator: std.mem.Allocator, exe_path: []const u8, file: []const u8, opts: *ParentOpts, index: usize, totals: *Totals) void {
-    const emit_path = std.fmt.allocPrint(allocator, "{s}/kaappi-test-{d}-{d}.json", .{ tmpDir(), std.c.getpid(), index }) catch {
+    const emit_path = std.fmt.allocPrint(allocator, "{s}/kaappi-test-{d}-{d}.json", .{ tmpDir(), platform.getPid(), index }) catch {
         writeStderr("kaappi test: out of memory\n");
         return;
     };
     defer allocator.free(emit_path);
 
     {
-        var pbuf: [std.posix.PATH_MAX]u8 = undefined;
-        if (emit_path.len < pbuf.len) {
-            @memcpy(pbuf[0..emit_path.len], emit_path);
-            pbuf[emit_path.len] = 0;
-            _ = setenv(EMIT_ENV, @ptrCast(&pbuf), 1);
-        }
+        platform.setEnv(allocator, EMIT_ENV, emit_path) catch {};
     }
 
     const spawn = spawnWorker(allocator, exe_path, file, opts.lib_paths.items) catch {
@@ -494,6 +488,22 @@ fn spawnWorker(allocator: std.mem.Allocator, exe_path: []const u8, file: []const
         try argv.append(allocator, p);
     }
     try argv.append(allocator, file);
+
+    if (comptime platform.is_windows) {
+        const res = platform.winSpawnCaptureMerged(allocator, argv.items, null) catch return error.ForkFailed;
+        // Cap after the fact (the POSIX path caps during the read loop);
+        // a runaway worker is bounded either way before parsing.
+        const cap: usize = 1024 * 1024;
+        if (res.output.len > cap) {
+            const trimmed = allocator.dupe(u8, res.output[0..cap]) catch {
+                allocator.free(res.output);
+                return error.OutOfMemory;
+            };
+            allocator.free(res.output);
+            return .{ .output = trimmed, .exit_code = res.exit_code, .signaled = false };
+        }
+        return .{ .output = res.output, .exit_code = res.exit_code, .signaled = false };
+    }
 
     const argv_z = try allocator.alloc(?[*:0]const u8, argv.items.len + 1);
     @memset(argv_z, null);
@@ -850,12 +860,10 @@ fn discoverDir(allocator: std.mem.Allocator, dir_path: []const u8, out: *std.Arr
 
     const dir_z = allocator.dupeZ(u8, dir_path) catch return error.OutOfMemory;
     defer allocator.free(dir_z);
-    const dir = std.c.opendir(dir_z) orelse return;
-    defer _ = std.c.closedir(dir);
+    var dir = platform.DirIter.open(dir_z) orelse return;
+    defer dir.close();
 
-    while (std.c.readdir(dir)) |entry| {
-        const name_ptr: [*:0]const u8 = @ptrCast(&entry.name);
-        const name = std.mem.span(name_ptr);
+    while (dir.next()) |name| {
         if (name.len == 0 or name[0] == '.') continue; // skip . .. and dotfiles
 
         const full = try std.fs.path.join(allocator, &.{ dir_path, name });
@@ -871,17 +879,13 @@ fn discoverDir(allocator: std.mem.Allocator, dir_path: []const u8, out: *std.Arr
     }
 }
 
-/// True if `path` names a directory. Implemented by attempting to open it as
-/// one (opendir fails with ENOTDIR on a regular file) — no stat needed, matching
-/// the raw-libc filesystem style used elsewhere in the tree.
+/// True if `path` names a directory.
 fn isDirectory(path: []const u8) bool {
-    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    var buf: [platform.PATH_MAX]u8 = undefined;
     if (path.len >= buf.len) return false;
     @memcpy(buf[0..path.len], path);
     buf[path.len] = 0;
-    const dir = std.c.opendir(@ptrCast(&buf)) orelse return false;
-    _ = std.c.closedir(dir);
-    return true;
+    return platform.isDir(buf[0..path.len :0]);
 }
 
 /// A cheap gate so directory recursion runs only SRFI-64 suites — skipping
@@ -904,21 +908,22 @@ fn lessThanStr(_: void, a: []const u8, b: []const u8) bool {
 }
 
 fn tmpDir() []const u8 {
+    if (comptime platform.is_windows) return getEnv("TEMP") orelse "C:/Windows/Temp";
     return getEnv("TMPDIR") orelse "/tmp";
 }
 
 fn randomSeed() u64 {
-    const entropy = clockNs() ^ (@as(u64, @intCast(std.c.getpid())) << 32);
+    const entropy = clockNs() ^ (@as(u64, @intCast(platform.getPid())) << 32);
     var prng = std.Random.DefaultPrng.init(entropy);
     return prng.random().intRangeLessThan(u64, 1, 1_000_000);
 }
 
 fn unlinkPath(path: []const u8) void {
-    var buf: [std.posix.PATH_MAX]u8 = undefined;
+    var buf: [platform.PATH_MAX]u8 = undefined;
     if (path.len >= buf.len) return;
     @memcpy(buf[0..path.len], path);
     buf[path.len] = 0;
-    _ = std.c.unlink(@ptrCast(&buf));
+    _ = platform.unlink(buf[0..path.len :0]);
 }
 
 fn oom() u8 {

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -490,18 +490,13 @@ fn spawnWorker(allocator: std.mem.Allocator, exe_path: []const u8, file: []const
     try argv.append(allocator, file);
 
     if (comptime platform.is_windows) {
-        const res = platform.winSpawnCaptureMerged(allocator, argv.items, null) catch return error.ForkFailed;
-        // Cap after the fact (the POSIX path caps during the read loop);
-        // a runaway worker is bounded either way before parsing.
-        const cap: usize = 1024 * 1024;
-        if (res.output.len > cap) {
-            const trimmed = allocator.dupe(u8, res.output[0..cap]) catch {
-                allocator.free(res.output);
-                return error.OutOfMemory;
-            };
-            allocator.free(res.output);
-            return .{ .output = trimmed, .exit_code = res.exit_code, .signaled = false };
-        }
+        // Same 1 MiB in-loop cap as the POSIX read loop below: the pipe
+        // keeps draining past it, so a runaway worker can neither exhaust
+        // memory here nor block on a full pipe.
+        const res = platform.winSpawnCaptureMerged(allocator, argv.items, null, 1024 * 1024) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.ForkFailed,
+        };
         return .{ .output = res.output, .exit_code = res.exit_code, .signaled = false };
     }
 

--- a/src/test_selection.zig
+++ b/src/test_selection.zig
@@ -442,8 +442,14 @@ fn runCapture(arena: std.mem.Allocator, argv: []const []const u8) ?CaptureResult
         if (argv.len > argv_slices_buf.len) return null;
         argv_slices_buf[0] = exe;
         for (argv[1..], 1..) |arg, i| argv_slices_buf[i] = arg;
-        const res = platform.winSpawnCaptureMerged(arena, argv_slices_buf[0..argv.len], null) catch return null;
-        return .{ .stdout = res.output, .ok = res.exit_code == 0 };
+        // stdout only — the POSIX arm routes stderr to /dev/null because
+        // this output is machine-parsed (git -z path lists); a warning on
+        // stderr must never leak into the path stream.
+        const stdout = platform.winSpawnCapture(arena, argv_slices_buf[0..argv.len], null) catch |err| switch (err) {
+            error.CommandFailed => return .{ .stdout = arena.alloc(u8, 0) catch return null, .ok = false },
+            else => return null,
+        };
+        return .{ .stdout = stdout, .ok = true };
     }
 
     var pipe: [2]c_int = undefined;

--- a/src/test_selection.zig
+++ b/src/test_selection.zig
@@ -29,6 +29,7 @@
 //! `docs/dev/test-runner.md` for the full contract.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const reader_mod = @import("reader.zig");
@@ -436,6 +437,15 @@ fn runCapture(arena: std.mem.Allocator, argv: []const []const u8) ?CaptureResult
     }
     argv_z[argv.len] = null;
 
+    if (comptime platform.is_windows) {
+        var argv_slices_buf: [32][]const u8 = undefined;
+        if (argv.len > argv_slices_buf.len) return null;
+        argv_slices_buf[0] = exe;
+        for (argv[1..], 1..) |arg, i| argv_slices_buf[i] = arg;
+        const res = platform.winSpawnCaptureMerged(arena, argv_slices_buf[0..argv.len], null) catch return null;
+        return .{ .stdout = res.output, .ok = res.exit_code == 0 };
+    }
+
     var pipe: [2]c_int = undefined;
     if (std.c.pipe(&pipe) != 0) return null;
 
@@ -488,15 +498,15 @@ fn runCapture(arena: std.mem.Allocator, argv: []const []const u8) ?CaptureResult
 fn findInPath(arena: std.mem.Allocator, name: []const u8) ?[]const u8 {
     // An explicit path (contains '/') is used as-is.
     if (std.mem.indexOfScalar(u8, name, '/') != null) return name;
-    const path_env = std.c.getenv("PATH") orelse return null;
+    const path_env = platform.getenv("PATH") orelse return null;
     const path_str = std.mem.span(path_env);
-    var iter = std.mem.splitScalar(u8, path_str, ':');
+    var iter = std.mem.splitScalar(u8, path_str, platform.path_list_sep);
     while (iter.next()) |dir| {
         if (dir.len == 0) continue;
-        const full = std.fmt.allocPrint(arena, "{s}/{s}", .{ dir, name }) catch continue;
+        const full = std.fmt.allocPrint(arena, "{s}/{s}{s}", .{ dir, name, platform.exe_suffix }) catch continue;
         const full_z = arena.dupeZ(u8, full) catch continue;
-        const fd = std.posix.openat(std.posix.AT.FDCWD, full_z, .{ .ACCMODE = .RDONLY }, 0) catch continue;
-        _ = std.posix.system.close(fd);
+        const fd = platform.openRead(full_z) catch continue;
+        _ = platform.close(fd);
         return full;
     }
     return null;
@@ -508,10 +518,20 @@ fn findInPath(arena: std.mem.Allocator, name: []const u8) ?[]const u8 {
 /// access, so it works for deleted files too). Relative paths resolve against
 /// `base`, which must itself be absolute.
 fn toAbs(arena: std.mem.Allocator, base: []const u8, path: []const u8) ?[]const u8 {
-    if (path.len > 0 and path[0] == '/') {
-        return std.fs.path.resolve(arena, &.{path}) catch null;
+    const resolved = if (path.len > 0 and path[0] == '/')
+        std.fs.path.resolve(arena, &.{path}) catch return null
+    else
+        std.fs.path.resolve(arena, &.{ base, path }) catch return null;
+    // std.fs.path.resolve emits backslashes on Windows; the import graph
+    // (and every path the runtime builds) uses '/', so normalize to keep
+    // graph keys and git-diff paths comparable.
+    if (comptime platform.is_windows) {
+        const mutable = @constCast(resolved);
+        for (mutable) |*ch| {
+            if (ch.* == '\\') ch.* = '/';
+        }
     }
-    return std.fs.path.resolve(arena, &.{ base, path }) catch null;
+    return resolved;
 }
 
 fn stringBytes(v: Value) ?[]const u8 {

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -1,5 +1,6 @@
 // Phase 11: Deferred features
 const std = @import("std");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
@@ -588,7 +589,7 @@ test "cond-expand kaappi-threads feature" {
 // probe this test is gating.
 test "cond-expand library check honors sandbox mode" {
     // Skip when source tree isn't available (cross-compiled binary in container)
-    _ = std.posix.openat(std.posix.AT.FDCWD, "lib/srfi/41.sld", .{}, 0) catch return error.SkipZigTest;
+    if (!platform.pathExists("lib/srfi/41.sld")) return error.SkipZigTest;
 
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -617,7 +618,7 @@ test "cond-expand library check honors sandbox mode" {
 
 test "load library from .sld file" {
     // Skip when source tree isn't available (cross-compiled binary in container)
-    _ = std.posix.openat(std.posix.AT.FDCWD, "testlib/helper.sld", .{}, 0) catch return error.SkipZigTest;
+    if (!platform.pathExists("testlib/helper.sld")) return error.SkipZigTest;
 
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -635,7 +636,7 @@ test "load library from .sld file" {
 }
 
 test "load library with include declaration" {
-    _ = std.posix.openat(std.posix.AT.FDCWD, "testlib/with-include.sld", .{}, 0) catch return error.SkipZigTest;
+    if (!platform.pathExists("testlib/with-include.sld")) return error.SkipZigTest;
 
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/tests_bytecode_cache.zig
+++ b/src/tests_bytecode_cache.zig
@@ -13,6 +13,7 @@
 // gc.extra_roots for the whole run (see main.zig comment near compiled_funcs).
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");

--- a/src/tests_filesystem.zig
+++ b/src/tests_filesystem.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
@@ -27,7 +28,12 @@ test "file-info:inode returns positive fixnum" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    try std.testing.expectEqual(types.TRUE, try vm.eval("(> (file-info:inode (file-info \".\" #t)) 0)"));
+    // Windows has no inode concept; _wstat64 reports 0 (documented degradation).
+    const inode_expr = if (comptime platform.is_windows)
+        "(>= (file-info:inode (file-info \".\" #t)) 0)"
+    else
+        "(> (file-info:inode (file-info \".\" #t)) 0)";
+    try std.testing.expectEqual(types.TRUE, try vm.eval(inode_expr));
 }
 
 test "file-info:nlinks returns positive fixnum" {
@@ -74,7 +80,12 @@ test "file-info:blksize and :blocks" {
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
-    try std.testing.expectEqual(types.TRUE, try vm.eval("(> (file-info:blksize (file-info \".\" #t)) 0)"));
+    // Windows reports no block geometry (documented degradation: 0).
+    const blksize_expr = if (comptime platform.is_windows)
+        "(>= (file-info:blksize (file-info \".\" #t)) 0)"
+    else
+        "(> (file-info:blksize (file-info \".\" #t)) 0)";
+    try std.testing.expectEqual(types.TRUE, try vm.eval(blksize_expr));
     try std.testing.expectEqual(types.TRUE, try vm.eval("(>= (file-info:blocks (file-info \".\" #t)) 0)"));
 }
 
@@ -93,7 +104,7 @@ test "file-info predicates on directory" {
 }
 
 test "file-info on regular file" {
-    _ = std.posix.openat(std.posix.AT.FDCWD, "build.zig", .{}, 0) catch return error.SkipZigTest;
+    if (!platform.pathExists("build.zig")) return error.SkipZigTest;
 
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -124,6 +135,7 @@ test "current-directory returns non-empty string" {
 }
 
 test "umask returns non-negative integer" {
+    if (comptime platform.is_windows) return error.SkipZigTest; // POSIX identity/umask
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -133,6 +145,7 @@ test "umask returns non-negative integer" {
 }
 
 test "user-uid and user-gid return fixnums" {
+    if (comptime platform.is_windows) return error.SkipZigTest; // POSIX identity/umask
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -143,6 +156,7 @@ test "user-uid and user-gid return fixnums" {
 }
 
 test "user-effective-uid and user-effective-gid" {
+    if (comptime platform.is_windows) return error.SkipZigTest; // POSIX identity/umask
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -153,6 +167,7 @@ test "user-effective-uid and user-effective-gid" {
 }
 
 test "user-supplementary-gids returns list" {
+    if (comptime platform.is_windows) return error.SkipZigTest; // POSIX identity/umask
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -172,6 +187,7 @@ test "real-path resolves current directory" {
 }
 
 test "user-info for current user" {
+    if (comptime platform.is_windows) return error.SkipZigTest; // POSIX-only, raises on Windows
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -186,6 +202,7 @@ test "user-info for current user" {
 }
 
 test "user-info by name" {
+    if (comptime platform.is_windows) return error.SkipZigTest; // POSIX-only, raises on Windows
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -208,6 +225,7 @@ test "user-info? predicate" {
 }
 
 test "group-info for current group" {
+    if (comptime platform.is_windows) return error.SkipZigTest; // POSIX-only, raises on Windows
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -252,7 +270,7 @@ test "open-directory read-directory close-directory cycle" {
 }
 
 test "terminal? on file port returns #f" {
-    _ = std.posix.openat(std.posix.AT.FDCWD, "build.zig", .{}, 0) catch return error.SkipZigTest;
+    if (!platform.pathExists("build.zig")) return error.SkipZigTest;
 
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -343,6 +361,7 @@ test "rename-file works" {
 }
 
 test "set-file-mode changes permissions" {
+    if (comptime platform.is_windows) return error.SkipZigTest; // POSIX-only, raises on Windows
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const memory = @import("memory.zig");
 const reader_mod = @import("reader.zig");
 const bytecode_file = @import("bytecode_file.zig");
@@ -268,18 +269,16 @@ fn evalNormalized(input: []const u8, optimize: bool, gpa: std.mem.Allocator) Nor
     // Redirect fd 1 to /dev/null for the duration: generated programs can
     // call (display ...), and the test binary's stdout is the build-runner
     // IPC pipe — a stray write there deadlocks the run.
-    const c = std.posix.system;
-    const saved_stdout = c.dup(1);
+    const saved_stdout = platform.dup(1);
     if (saved_stdout < 0) return .harness_unavailable;
-    defer _ = c.close(saved_stdout);
-    const devnull = c.open("/dev/null", .{ .ACCMODE = .WRONLY });
-    if (devnull < 0) return .harness_unavailable;
-    if (c.dup2(devnull, 1) < 0) {
-        _ = c.close(devnull);
+    defer _ = platform.close(saved_stdout);
+    const devnull = platform.openNullSink() catch return .harness_unavailable;
+    if (platform.dup2(devnull, 1) < 0) {
+        _ = platform.close(devnull);
         return .harness_unavailable;
     }
-    _ = c.close(devnull);
-    defer _ = c.dup2(saved_stdout, 1);
+    _ = platform.close(devnull);
+    defer _ = platform.dup2(saved_stdout, 1);
 
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/tests_io.zig
+++ b/src/tests_io.zig
@@ -1,5 +1,6 @@
 // Phase 9: Ports and I/O (R7RS 6.13)
 const std = @import("std");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
@@ -217,6 +218,8 @@ test "file-exists?" {
 }
 
 test "file-exists? returns #t for unreadable files" {
+    // POSIX permission bits; Windows ACLs don't map to chmod(0o000).
+    if (comptime platform.is_windows) return error.SkipZigTest;
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -238,6 +241,7 @@ test "file-exists? returns #t for unreadable files" {
 
 test "file-exists? returns #t for FIFOs" {
     if (comptime @import("builtin").os.tag == .wasi) return error.SkipZigTest;
+    if (comptime platform.is_windows) return error.SkipZigTest; // no mkfifo
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -6,6 +6,7 @@
 // while it waits, write buffering with real flush, and the close-port
 // wake discipline.
 const std = @import("std");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
@@ -191,7 +192,7 @@ test "thread-terminate! pulls a parked reader off the reactor; the fd stays usab
     const f_val = try vm.eval("f");
     try std.testing.expectEqual(fiber_mod.FiberStatus.io_waiting, types.toObject(f_val).as(fiber_mod.Fiber).status);
     _ = try vm.eval("(thread-terminate! f)");
-    try std.testing.expectEqual(@as(?std.posix.fd_t, null), types.toObject(f_val).as(fiber_mod.Fiber).io_fd);
+    try std.testing.expectEqual(@as(?platform.fd_t, null), types.toObject(f_val).as(fiber_mod.Fiber).io_fd);
 
     _ = try vm.eval("(define g (spawn (lambda () (read-char rp))))");
     _ = try vm.eval("(define w (spawn (lambda () (write-char #\\k wp) (flush-output-port wp))))");
@@ -208,19 +209,19 @@ test "port write buffer holds bytes until flush; close-port flushes the remainde
     const pipe = makePipe();
     setNonblockingFd(pipe[0]); // test-side reads must not block on an empty pipe
     _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
-    defer _ = std.posix.system.close(pipe[0]); // read end stays Zig-owned
+    defer _ = platform.close(pipe[0]); // read end stays Zig-owned
 
     _ = try vm.eval("(write-char #\\z wp)");
     var buf: [8]u8 = undefined;
     // Buffered: nothing reaches the pipe before the flush.
-    try std.testing.expect(std.posix.system.read(pipe[0], &buf, buf.len) < 0);
+    try std.testing.expect(platform.read(pipe[0], &buf, buf.len) < 0);
     _ = try vm.eval("(flush-output-port wp)");
-    try std.testing.expectEqual(@as(isize, 1), std.posix.system.read(pipe[0], &buf, buf.len));
+    try std.testing.expectEqual(@as(isize, 1), platform.read(pipe[0], &buf, buf.len));
     try std.testing.expectEqual(@as(u8, 'z'), buf[0]);
 
     _ = try vm.eval("(write-char #\\q wp)");
     _ = try vm.eval("(close-port wp)");
-    try std.testing.expectEqual(@as(isize, 1), std.posix.system.read(pipe[0], &buf, buf.len));
+    try std.testing.expectEqual(@as(isize, 1), platform.read(pipe[0], &buf, buf.len));
     try std.testing.expectEqual(@as(u8, 'q'), buf[0]);
 }
 
@@ -236,18 +237,18 @@ test "a read on the same port flushes its pending writes first" {
     var fds: [2]std.c.fd_t = undefined;
     try std.testing.expectEqual(@as(c_int, 0), std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds));
     _ = try definePortGlobal(vm, "sp", fds[0], true, true);
-    defer _ = std.posix.system.close(fds[1]); // peer end stays Zig-owned
+    defer _ = platform.close(fds[1]); // peer end stays Zig-owned
 
     // Stage the peer's response up front so the read completes immediately
     // once the flush-before-read has happened.
-    _ = std.posix.system.write(fds[1], "y", 1);
+    _ = platform.write(fds[1], "y", 1);
 
     _ = try vm.eval("(write-char #\\x sp)"); // buffered request
     const r = try vm.eval("(read-char sp)");
     try std.testing.expectEqual(types.makeChar('y'), r);
 
     var buf: [8]u8 = undefined;
-    try std.testing.expectEqual(@as(isize, 1), std.posix.system.read(fds[1], &buf, buf.len));
+    try std.testing.expectEqual(@as(isize, 1), platform.read(fds[1], &buf, buf.len));
     try std.testing.expectEqual(@as(u8, 'x'), buf[0]);
 }
 
@@ -268,7 +269,7 @@ test "(read) must not lose read_buf when its write drain parks" {
     _ = try definePortGlobal(vm, "peer", fds[1], true, true);
 
     // The first (read sp) consumes (a) and stashes " (b)" into port.read_buf.
-    _ = std.posix.system.write(fds[1], "(a) (b)", 7);
+    _ = platform.write(fds[1], "(a) (b)", 7);
     const first = try vm.eval("(equal? (read sp) '(a))");
     try std.testing.expectEqual(types.TRUE, first);
 
@@ -303,12 +304,12 @@ test "binary read-u8 drains bytes a prior (read) left in the port buffer" {
 
     const pipe = makePipe();
     _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
-    defer _ = std.posix.system.close(pipe[1]);
+    defer _ = platform.close(pipe[1]);
 
     // (read) slurps a 4 KiB chunk, consumes "(a)", and stashes " 7" in
     // port.read_buf. The old binary-side byte reader had its own copy that
     // skipped read_buf entirely, silently losing these bytes.
-    _ = std.posix.system.write(pipe[1], "(a) 7", 5);
+    _ = platform.write(pipe[1], "(a) 7", 5);
     const datum_ok = try vm.eval("(equal? (read rp) '(a))");
     try std.testing.expectEqual(types.TRUE, datum_ok);
     const b = try vm.eval("(read-u8 rp)");
@@ -325,11 +326,11 @@ test "lazy O_NONBLOCK: set only for fd > 2 and only once a scheduler exists" {
 
     const pipe = makePipe();
     const rport = try definePortGlobal(vm, "rp", pipe[0], true, false);
-    defer _ = std.posix.system.close(pipe[1]);
+    defer _ = platform.close(pipe[1]);
 
     // Sequential program: reads never flip the fd, so blocking semantics
     // and the syscall profile are untouched.
-    _ = std.posix.system.write(pipe[1], "a", 1);
+    _ = platform.write(pipe[1], "a", 1);
     _ = try vm.eval("(read-char rp)");
     try std.testing.expect(!rport.nonblocking);
 
@@ -340,7 +341,7 @@ test "lazy O_NONBLOCK: set only for fd > 2 and only once a scheduler exists" {
     try std.testing.expect(!stdin_port.nonblocking);
 
     // A real-fd port does flip on its next use now that fibers exist.
-    _ = std.posix.system.write(pipe[1], "b", 1);
+    _ = platform.write(pipe[1], "b", 1);
     _ = try vm.eval("(read-char rp)");
     try std.testing.expect(rport.nonblocking);
 }
@@ -443,14 +444,14 @@ test "readOneByte batches an available burst into read_buf, not one syscall per 
 
     const pipe = makePipe();
     const rport = try definePortGlobal(vm, "rp", pipe[0], true, false);
-    defer _ = std.posix.system.close(pipe[1]);
+    defer _ = platform.close(pipe[1]);
 
     // Stage a burst, then read a single byte. Batching pulls the whole burst
     // in one read(2) and parks the tail in read_buf; without it every byte
     // would cost its own read(2) and read_buf would stay empty -- this is the
     // one assertion that fails on the pre-#1460 single-byte reader.
     const burst = "ABCDEFGHIJ";
-    try std.testing.expectEqual(@as(isize, burst.len), std.posix.system.write(pipe[1], burst, burst.len));
+    try std.testing.expectEqual(@as(isize, burst.len), platform.write(pipe[1], burst, burst.len));
     const first = try vm.eval("(read-u8 rp)");
     try std.testing.expectEqual(types.makeFixnum('A'), first);
     try std.testing.expectEqual(@as(usize, burst.len - 1), rport.read_buf_len);

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -6,6 +6,7 @@
 // but register()'s Debug-build staleness assertion reads the status of
 // every already-listed waiter (Phase 3).
 const std = @import("std");
+const platform = @import("platform.zig");
 const reactor_mod = @import("reactor.zig");
 const fiber_mod = @import("fiber.zig");
 const Reactor = reactor_mod.Reactor;
@@ -18,7 +19,7 @@ fn makePipe() [2]std.c.fd_t {
 }
 
 fn closeFd(fd: std.c.fd_t) void {
-    _ = std.posix.system.close(fd);
+    _ = platform.close(fd);
 }
 
 fn newReady() std.ArrayList(*Fiber) {
@@ -30,7 +31,7 @@ fn newReady() std.ArrayList(*Fiber) {
 /// unrelated assertion mismatch or poll() timeout.
 fn writeByte(fd: std.c.fd_t, byte: u8) void {
     const buf = [1]u8{byte};
-    const n = std.posix.system.write(fd, &buf, 1);
+    const n = platform.write(fd, &buf, 1);
     std.testing.expectEqual(@as(isize, 1), n) catch unreachable;
 }
 
@@ -440,9 +441,9 @@ fn fillSendBuffer(fd: std.c.fd_t) void {
     var buf: [4096]u8 = [_]u8{0} ** 4096;
     var iterations: usize = 0;
     while (iterations < 4096) : (iterations += 1) {
-        const n = std.posix.system.write(fd, &buf, buf.len);
+        const n = platform.write(fd, &buf, buf.len);
         if (n < 0) {
-            std.testing.expectEqual(std.posix.E.AGAIN, std.posix.errno(n)) catch unreachable;
+            std.testing.expectEqual(std.posix.E.AGAIN, platform.errno(n)) catch unreachable;
             return;
         }
     }
@@ -454,9 +455,9 @@ fn fillSendBuffer(fd: std.c.fd_t) void {
 fn drainSocket(fd: std.c.fd_t) void {
     var buf: [4096]u8 = undefined;
     while (true) {
-        const n = std.posix.system.read(fd, &buf, buf.len);
+        const n = platform.read(fd, &buf, buf.len);
         if (n < 0) {
-            std.testing.expectEqual(std.posix.E.AGAIN, std.posix.errno(n)) catch unreachable;
+            std.testing.expectEqual(std.posix.E.AGAIN, platform.errno(n)) catch unreachable;
             return;
         }
         if (n == 0) return;

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -5,6 +5,7 @@
 // parkOnReactor's ready-list handling against a real fd, and the
 // live-window bound on per-fiber save/restore storage.
 const std = @import("std");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
@@ -18,12 +19,12 @@ fn makePipe() [2]std.c.fd_t {
 }
 
 fn closeFd(fd: std.c.fd_t) void {
-    _ = std.posix.system.close(fd);
+    _ = platform.close(fd);
 }
 
 fn writeByte(fd: std.c.fd_t, byte: u8) void {
     const buf = [1]u8{byte};
-    const n = std.posix.system.write(fd, &buf, 1);
+    const n = platform.write(fd, &buf, 1);
     std.testing.expectEqual(@as(isize, 1), n) catch unreachable;
 }
 

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
@@ -33,9 +34,7 @@ fn testDestroyHook(_: *shared_object.Header) void {
 }
 
 fn nowNsForStressTest() u64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+    return platform.monotonicNs();
 }
 
 test "shared_object: init/retain/release destroys exactly at zero" {

--- a/src/tests_shared_channel_rendezvous.zig
+++ b/src/tests_shared_channel_rendezvous.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
@@ -221,8 +222,7 @@ test "shared rendezvous: close wakes a parked child-thread receiver (determinist
         const demand = sc.rv_demand;
         memory.spinUnlock(&sc.lock);
         if (demand > 0) break;
-        var ts: std.c.timespec = .{ .sec = 0, .nsec = 1 * std.time.ns_per_ms };
-        _ = std.c.nanosleep(&ts, &ts);
+        platform.sleepNs(1 * std.time.ns_per_ms);
     }
     try std.testing.expect(spins < 2000);
 

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 
 const dylib_ext = if (builtin.os.tag == .macos) ".dylib" else ".so";
@@ -54,7 +55,7 @@ const Color = struct {
 };
 
 fn initColor() void {
-    use_color = std.c.isatty(1) != 0;
+    use_color = platform.isatty(1);
 }
 
 const Config = struct {
@@ -66,12 +67,12 @@ const Config = struct {
     lockfile: []const u8,
 };
 
-fn writeToFd(fd: std.posix.fd_t, bytes: []const u8) void {
+fn writeToFd(fd: platform.fd_t, bytes: []const u8) void {
     var total: usize = 0;
     while (total < bytes.len) {
-        const result = std.posix.system.write(fd, bytes.ptr + total, bytes.len - total);
+        const result = platform.write(fd, bytes.ptr + total, bytes.len - total);
         if (result < 0) {
-            if (std.posix.errno(result) == .INTR) continue;
+            if (platform.errno(result) == .INTR) continue;
             break;
         }
         if (result == 0) break;
@@ -100,15 +101,18 @@ fn fatal(msg: []const u8) noreturn {
 pub fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     const path_z = try allocator.dupeZ(u8, path);
     defer allocator.free(path_z);
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{}, 0) catch return error.FileNotFound;
-    defer _ = std.posix.system.close(fd);
+    const fd = platform.openRead(path_z) catch return error.FileNotFound;
+    defer _ = platform.close(fd);
     var buf: std.ArrayList(u8) = .empty;
     var tmp: [4096]u8 = undefined;
     while (true) {
-        const n = std.posix.read(fd, &tmp) catch {
+        const raw = platform.read(fd, &tmp, tmp.len);
+        if (raw < 0) {
+            if (platform.errno(raw) == .INTR) continue;
             buf.deinit(allocator);
             return error.ReadFailed;
-        };
+        }
+        const n: usize = @intCast(raw);
         if (n == 0) break;
         buf.appendSlice(allocator, tmp[0..n]) catch return error.OutOfMemory;
     }
@@ -118,15 +122,11 @@ pub fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
 pub fn writeFile(allocator: std.mem.Allocator, path: []const u8, content: []const u8) !void {
     const path_z = try allocator.dupeZ(u8, path);
     defer allocator.free(path_z);
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .TRUNC = true,
-    }, 0o644) catch return error.CannotOpen;
-    defer _ = std.posix.system.close(fd);
+    const fd = platform.openWriteTrunc(path_z, 0o644) catch return error.CannotOpen;
+    defer _ = platform.close(fd);
     var total: usize = 0;
     while (total < content.len) {
-        const result = std.posix.system.write(fd, content.ptr + total, content.len - total);
+        const result = platform.write(fd, content.ptr + total, content.len - total);
         if (result <= 0) return error.WriteFailed;
         total += @as(usize, @intCast(result));
     }
@@ -135,30 +135,24 @@ pub fn writeFile(allocator: std.mem.Allocator, path: []const u8, content: []cons
 fn appendFile(allocator: std.mem.Allocator, path: []const u8, line: []const u8) !void {
     const path_z = try allocator.dupeZ(u8, path);
     defer allocator.free(path_z);
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .APPEND = true,
-    }, 0o644) catch return error.CannotOpen;
-    defer _ = std.posix.system.close(fd);
-    _ = std.posix.system.write(fd, line.ptr, line.len);
-    _ = std.posix.system.write(fd, "\n", 1);
+    const fd = platform.openAppend(path_z, 0o644) catch return error.CannotOpen;
+    defer _ = platform.close(fd);
+    _ = platform.write(fd, line.ptr, line.len);
+    _ = platform.write(fd, "\n", 1);
 }
 
 pub fn fileExists(allocator: std.mem.Allocator, path: []const u8) bool {
     const path_z = allocator.dupeZ(u8, path) catch return false;
     defer allocator.free(path_z);
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{}, 0) catch return false;
-    _ = std.posix.system.close(fd);
+    const fd = platform.openRead(path_z) catch return false;
+    _ = platform.close(fd);
     return true;
 }
 
 fn dirExists(allocator: std.mem.Allocator, path: []const u8) bool {
     const path_z = allocator.dupeZ(u8, path) catch return false;
     defer allocator.free(path_z);
-    const fd = std.posix.openat(std.posix.AT.FDCWD, path_z, .{ .DIRECTORY = true }, 0) catch return false;
-    _ = std.posix.system.close(fd);
-    return true;
+    return platform.isDir(path_z);
 }
 
 fn joinPath(allocator: std.mem.Allocator, a: []const u8, b: []const u8) ![]u8 {
@@ -290,7 +284,7 @@ fn removeDylibsFromPkg(allocator: std.mem.Allocator, pkg_dir: []const u8, lib_di
         defer allocator.free(target);
         const target_z = allocator.dupeZ(u8, target) catch continue;
         defer allocator.free(target_z);
-        _ = std.posix.system.unlink(target_z);
+        _ = platform.unlink(target_z);
     }
 }
 
@@ -308,7 +302,7 @@ fn removeSldFiles(allocator: std.mem.Allocator, pkg_lib_dir: []const u8, lib_dir
             defer allocator.free(target);
             const target_z = allocator.dupeZ(u8, target) catch continue;
             defer allocator.free(target_z);
-            _ = std.posix.system.unlink(target_z);
+            _ = platform.unlink(target_z);
         }
     }
 }
@@ -785,7 +779,7 @@ fn printUsage() void {
 }
 
 pub fn getenv(name: [*:0]const u8) ?[]const u8 {
-    const val = std.c.getenv(name) orelse return null;
+    const val = platform.getenv(name) orelse return null;
     return std.mem.sliceTo(val, 0);
 }
 
@@ -826,7 +820,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     initColor();
 
-    var args = init.args.iterate();
+    var args = platform.argsIterate(init.args);
     _ = args.skip();
 
     var locked_mode = false;
@@ -869,6 +863,19 @@ pub fn main(init: std.process.Init.Minimal) !void {
         printUsage();
         return;
     };
+
+    // Package installation shells out to POSIX userland (cp -R, find,
+    // sh -c for build commands) that Windows doesn't have; the read-only
+    // subcommands work everywhere. Gate the mutating ones until the
+    // install pipeline is reimplemented on the platform shim.
+    if (comptime platform.is_windows) {
+        const mutating = std.mem.eql(u8, cmd, "install") or
+            std.mem.eql(u8, cmd, "remove") or std.mem.eql(u8, cmd, "update");
+        if (mutating) {
+            writeStderr("thottam: package installation is not yet supported on Windows\n");
+            std.process.exit(1);
+        }
+    }
 
     if (std.mem.eql(u8, cmd, "install")) {
         const spec = sub_arg orelse {

--- a/src/thottam_proc.zig
+++ b/src/thottam_proc.zig
@@ -1,6 +1,18 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 
 pub fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) ![]u8 {
+    if (comptime platform.is_windows) {
+        const raw = platform.winSpawnCapture(allocator, argv, cwd) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.CommandFailed => return error.CommandFailed,
+            else => return error.ForkFailed,
+        };
+        defer allocator.free(raw);
+        const trimmed = std.mem.trim(u8, raw, "\n\r");
+        return allocator.dupe(u8, trimmed) catch return error.OutOfMemory;
+    }
+
     const argv_z = try allocator.alloc(?[*:0]const u8, argv.len + 1);
     @memset(argv_z, null);
     defer {
@@ -78,6 +90,13 @@ pub fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?
 }
 
 pub fn runPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) !u8 {
+    if (comptime platform.is_windows) {
+        return platform.winSpawnPassthrough(allocator, argv, cwd) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.ForkFailed,
+        };
+    }
+
     const argv_z = try allocator.alloc(?[*:0]const u8, argv.len + 1);
     @memset(argv_z, null);
     defer {
@@ -125,7 +144,8 @@ pub fn runPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cw
 pub fn runGit(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(allocator);
-    argv.append(allocator, "/usr/bin/git") catch return error.OutOfMemory;
+    // Windows: no fixed install path; CreateProcessW searches PATH.
+    argv.append(allocator, if (platform.is_windows) "git" else "/usr/bin/git") catch return error.OutOfMemory;
     for (args) |a| {
         argv.append(allocator, a) catch return error.OutOfMemory;
     }
@@ -136,7 +156,7 @@ pub fn runGit(allocator: std.mem.Allocator, args: []const []const u8) !void {
 pub fn runGitCapture(allocator: std.mem.Allocator, args: []const []const u8) ![]u8 {
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(allocator);
-    argv.append(allocator, "/usr/bin/git") catch return error.OutOfMemory;
+    argv.append(allocator, if (platform.is_windows) "git" else "/usr/bin/git") catch return error.OutOfMemory;
     for (args) |a| {
         argv.append(allocator, a) catch return error.OutOfMemory;
     }

--- a/src/timings.zig
+++ b/src/timings.zig
@@ -29,6 +29,7 @@
 //! own stdout clean for piping. See `docs/dev/timings.md`.
 
 const std = @import("std");
+const platform = @import("platform.zig");
 const builtin = @import("builtin");
 
 const is_wasm = builtin.os.tag == .wasi;
@@ -116,9 +117,7 @@ fn nowNs() u64 {
         if (test_clock) |t| return t;
     }
     if (comptime is_wasm) return 0;
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return @intCast(@as(i128, ts.sec) * 1_000_000_000 + ts.nsec);
+    return platform.monotonicNs();
 }
 
 /// Enter `stage`. Credits any elapsed time to the (now-frozen) parent stage,
@@ -345,7 +344,7 @@ fn writeStderr(bytes: []const u8) void {
     if (comptime is_wasm) {
         _ = std.posix.write(2, bytes) catch 0;
     } else {
-        _ = std.posix.system.write(2, bytes.ptr, bytes.len);
+        _ = platform.write(2, bytes.ptr, bytes.len);
     }
 }
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+const platform = @import("platform.zig");
 const build_options = @import("build_options");
 const diagnostics = @import("diagnostics.zig");
 
@@ -503,7 +504,7 @@ pub const Promise = struct {
 
 pub const Port = struct {
     header: Object,
-    fd: std.posix.fd_t,
+    fd: platform.fd_t,
     is_input: bool,
     is_output: bool,
     is_open: bool,
@@ -1348,8 +1349,16 @@ const is_wasm_target = builtin.os.tag == .wasi;
 /// carve-out. `kaappi-threads` is omitted on wasm, matching
 /// Lib.wasmAvailable()'s `srfi_18 => false` gate (primitives.zig) — no OS
 /// threads there. (KEP-0004)
-const base_platform_features = [_][]const u8{ "r7rs", "kaappi", "ieee-float", "posix", "exact-closed", "exact-complex", "kaappi-fibers", "kaappi-reactor", "kaappi-diagnostics" };
-pub const platform_features = if (is_wasm_target) base_platform_features else base_platform_features ++ [_][]const u8{"kaappi-threads"};
+const is_windows_target = builtin.os.tag == .windows;
+const base_platform_features = [_][]const u8{ "r7rs", "kaappi", "ieee-float", "exact-closed", "exact-complex", "kaappi-fibers", "kaappi-reactor", "kaappi-diagnostics" };
+// R7RS appendix B feature identifiers: exactly one OS-class identifier —
+// `windows` on Windows, `posix` everywhere else (WASI hosts are POSIX-ish
+// enough for the subset the runtime exposes there).
+const os_feature = [_][]const u8{if (is_windows_target) "windows" else "posix"};
+pub const platform_features = if (is_wasm_target)
+    base_platform_features ++ os_feature
+else
+    base_platform_features ++ os_feature ++ [_][]const u8{"kaappi-threads"};
 
 test "nil is not a pointer" {
     try std.testing.expect(!isPointer(NIL));

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const Value = types.Value;
 
@@ -29,9 +30,7 @@ pub fn continuationArgValue(gc: *memory.GC, args: []const Value) VMError!Value {
 }
 
 pub fn clockNs() u64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return @intCast(@as(i128, ts.sec) * 1_000_000_000 + ts.nsec);
+    return platform.monotonicNs();
 }
 
 pub fn profileCreditSelf(vm: *VM) void {

--- a/src/vm_debug.zig
+++ b/src/vm_debug.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const VM = vm_mod.VM;
@@ -90,9 +91,9 @@ pub fn debugPause(vm: *VM, frame: *CallFrame) !void {
         writeStderr("debug> ");
         var i: usize = 0;
         while (i < cmd_buf.len) {
-            const result = std.posix.system.read(0, cmd_buf[i .. i + 1].ptr, 1);
+            const result = platform.read(0, cmd_buf[i .. i + 1].ptr, 1);
             if (result < 0) {
-                if (std.posix.errno(result) == .INTR) continue;
+                if (platform.errno(result) == .INTR) continue;
                 vm.debug_mode = false;
                 vm.step_mode = .none;
                 return;

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const memory = @import("memory.zig");
@@ -329,9 +330,8 @@ pub fn resolveLibraryPath(allocator: std.mem.Allocator, rel_path: []const u8, li
         // Check if file exists by trying to open it
         const probe_z = allocator.dupeZ(u8, full_path) catch continue;
         defer allocator.free(probe_z);
-        const probe_fd = std.c.open(probe_z, .{});
-        if (probe_fd < 0) continue;
-        _ = std.c.close(probe_fd);
+        const probe_fd = platform.openRead(probe_z) catch continue;
+        _ = platform.close(probe_fd);
 
         // File exists — return heap-allocated copy
         return allocator.dupe(u8, full_path) catch null;

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -25,9 +25,15 @@ test {
     _ = @import("tests_native.zig");
     _ = @import("tests_native_dispatch.zig");
     _ = @import("tests_native_gate.zig");
-    _ = @import("tests_reactor.zig");
-    _ = @import("tests_scheduler.zig");
-    _ = @import("tests_port_io.zig");
+    // fd-readiness suites are POSIX-only by design: Windows ports never
+    // flip to non-blocking (platform.zig), so the reactor there is
+    // timer/notify-only and these suites' pipe plumbing has nothing to
+    // exercise.
+    if (comptime @import("platform.zig").is_windows == false) {
+        _ = @import("tests_reactor.zig");
+        _ = @import("tests_scheduler.zig");
+        _ = @import("tests_port_io.zig");
+    }
     _ = @import("tests_diagnostics.zig");
     _ = @import("tests_spans.zig");
 }

--- a/tests/scheme/audit/primitives_ffi-audit.scm
+++ b/tests/scheme/audit/primitives_ffi-audit.scm
@@ -9,6 +9,11 @@
 (import (scheme base) (scheme write))
 (import (scheme process-context) (srfi 64))
 
+;; the self-handle (ffi-open #f) does not expose libc on Windows — skip there.
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
+
 (test-begin "primitives_ffi audit")
 
 ;;; --- ffi-open ---

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -4,12 +4,13 @@
 ;; Run directly and read the printed counts — run-all.sh only sees exit codes.
 
 (import (scheme base) (scheme write) (scheme file) (srfi 170) (srfi 60))
+(import (scheme process-context) (srfi 64))
 
-;; symlinks/FIFOs/uid-gid are POSIX-only — skip there.
+;; symlinks/FIFOs/uid-gid are POSIX-only — skip there. (After the imports:
+;; the skip branch calls exit, which (scheme process-context) provides.)
 (cond-expand
   (windows (display "skipped on windows\n") (exit 0))
   (else #f))
-(import (scheme process-context) (srfi 64))
 
 (test-begin "primitives_filesystem audit")
 

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -4,6 +4,11 @@
 ;; Run directly and read the printed counts — run-all.sh only sees exit codes.
 
 (import (scheme base) (scheme write) (scheme file) (srfi 170) (srfi 60))
+
+;; symlinks/FIFOs/uid-gid are POSIX-only — skip there.
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
 (import (scheme process-context) (srfi 64))
 
 (test-begin "primitives_filesystem audit")

--- a/tests/scheme/audit/primitives_r7rs-audit.scm
+++ b/tests/scheme/audit/primitives_r7rs-audit.scm
@@ -40,7 +40,12 @@
                       (pair? (car env))
                       (string? (caar env))
                       (string? (cdar env))
-                      (and (assoc "PATH" env) #t))))
+                      ;; Windows preserves case but names are
+                      ;; case-insensitive ("Path"), so compare ci there.
+                      (and (cond-expand
+                             (windows (assoc "PATH" env string-ci=?))
+                             (else (assoc "PATH" env)))
+                           #t))))
 ;; exit/emergency-exit semantics (afters run for exit, skipped for
 ;; emergency-exit; #f→1, #t→0, default→0) are covered by
 ;; tests/scheme/errors/exit-wind.sh since they terminate the process.

--- a/tests/scheme/compliance/r7rs-control-io-gaps.scm
+++ b/tests/scheme/compliance/r7rs-control-io-gaps.scm
@@ -8,6 +8,13 @@
 (import (scheme base) (scheme write) (scheme read) (scheme eval) (scheme file)
         (scheme time) (scheme char) (scheme process-context) (srfi 64))
 
+;; Windows preserves case but names are case-insensitive ("Path"), so
+;; the alist lookup must compare case-insensitively there.
+(define (env-assoc name env)
+  (cond-expand
+    (windows (assoc name env string-ci=?))
+    (else (assoc name env))))
+
 (test-begin "r7rs-control-io-gaps")
 
 ;; --- 6.10 map and friends (p. 51) ---
@@ -134,7 +141,7 @@
 (test-equal "get-environment-variable returns string" #t
   (string? (get-environment-variable "PATH")))
 (test-equal "get-environment-variables alist" #t
-  (pair? (assoc "PATH" (get-environment-variables))))
+  (pair? (env-assoc "PATH" (get-environment-variables))))
 ;; delete-file on a missing file signals a file-error (p. 60)
 (test-equal "delete-file missing signals file-error" 'fe
   (guard (e ((file-error? e) 'fe) (#t 'other))

--- a/tests/scheme/smoke/bignum-rational-ffi-793.scm
+++ b/tests/scheme/smoke/bignum-rational-ffi-793.scm
@@ -2,6 +2,11 @@
 ;; causing bignum-backed rationals to marshal as 0.0 or +inf.0 in FFI.
 (import (scheme base) (scheme write) (scheme process-context) (srfi 64))
 
+;; no libm on Windows — skip there.
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
+
 (test-begin "bignum-rational-ffi-793")
 
 (define libm (ffi-open "libm"))

--- a/tests/scheme/smoke/features-consistency.scm
+++ b/tests/scheme/smoke/features-consistency.scm
@@ -8,7 +8,11 @@
 (test-assert "r7rs in features" (and (memq 'r7rs (features)) #t))
 (test-assert "kaappi in features" (and (memq 'kaappi (features)) #t))
 (test-assert "ieee-float in features" (and (memq 'ieee-float (features)) #t))
-(test-assert "posix in features" (and (memq 'posix (features)) #t))
+;; Exactly one OS-class identifier: windows on Windows, posix elsewhere.
+(test-assert "os feature in features"
+  (cond-expand
+    (windows (and (memq 'windows (features)) (not (memq 'posix (features))) #t))
+    (else (and (memq 'posix (features)) (not (memq 'windows (features))) #t))))
 (test-assert "exact-closed in features" (and (memq 'exact-closed (features)) #t))
 (test-assert "exact-complex in features" (and (memq 'exact-complex (features)) #t))
 

--- a/tests/scheme/smoke/ffi-nul-string.scm
+++ b/tests/scheme/smoke/ffi-nul-string.scm
@@ -3,6 +3,11 @@
 
 (import (scheme base) (scheme write))
 
+;; self-dlopen does not expose libc on Windows — skip there.
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
+
 (define libc (ffi-open #f))
 (define c-strlen (ffi-fn libc "strlen" '(string) 'long))
 

--- a/tests/scheme/smoke/ffi-nul-string.scm
+++ b/tests/scheme/smoke/ffi-nul-string.scm
@@ -1,7 +1,7 @@
 ;;; Regression test for issue #630: toCString must reject strings with
 ;;; embedded NUL bytes instead of silently truncating them.
 
-(import (scheme base) (scheme write))
+(import (scheme base) (scheme write) (scheme process-context))
 
 ;; self-dlopen does not expose libc on Windows — skip there.
 (cond-expand

--- a/tests/scheme/smoke/file-info-blocks.scm
+++ b/tests/scheme/smoke/file-info-blocks.scm
@@ -1,4 +1,4 @@
-(import (scheme base) (scheme write) (srfi 170))
+(import (scheme base) (scheme write) (scheme process-context) (srfi 170))
 
 ;; Windows reports no block geometry (documented degradation) — skip there.
 (cond-expand

--- a/tests/scheme/smoke/file-info-blocks.scm
+++ b/tests/scheme/smoke/file-info-blocks.scm
@@ -1,5 +1,10 @@
 (import (scheme base) (scheme write) (srfi 170))
 
+;; Windows reports no block geometry (documented degradation) — skip there.
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
+
 (define pass 0)
 (define fail 0)
 

--- a/tests/scheme/smoke/filesystem-intcast.scm
+++ b/tests/scheme/smoke/filesystem-intcast.scm
@@ -1,5 +1,10 @@
 (import (scheme base) (scheme write) (srfi 170))
 
+;; set-file-mode/umask are POSIX-only — skip there.
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
+
 (define pass 0)
 (define fail 0)
 

--- a/tests/scheme/smoke/filesystem-intcast.scm
+++ b/tests/scheme/smoke/filesystem-intcast.scm
@@ -1,4 +1,4 @@
-(import (scheme base) (scheme write) (srfi 170))
+(import (scheme base) (scheme write) (scheme process-context) (srfi 170))
 
 ;; set-file-mode/umask are POSIX-only — skip there.
 (cond-expand

--- a/tests/scheme/smoke/group-info-by-name-1161.scm
+++ b/tests/scheme/smoke/group-info-by-name-1161.scm
@@ -3,6 +3,11 @@
 
 (import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 170))
 
+;; user-gid/group-info are POSIX-only — skip there.
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
+
 (test-begin "group-info-by-name")
 
 (let* ((gid (user-gid))

--- a/tests/scheme/srfi/srfi-170-chown-constants.scm
+++ b/tests/scheme/srfi/srfi-170-chown-constants.scm
@@ -1,6 +1,11 @@
 ;; Regression test for #1163: owner/unchanged and group/unchanged constants
 (import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 170))
 
+;; set-file-owner is POSIX-only — skip there.
+(cond-expand
+  (windows (display "skipped on windows\n") (exit 0))
+  (else #f))
+
 (test-begin "srfi-170-chown-constants")
 
 ;; Constants must be exported and equal to -1 (POSIX "unchanged" sentinel)

--- a/tests/scheme/srfi/srfi98.scm
+++ b/tests/scheme/srfi/srfi98.scm
@@ -2,6 +2,12 @@
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi98.scm
 
 (import (scheme base) (srfi 98) (scheme process-context) (srfi 64))
+;; Windows preserves case but names are case-insensitive ("Path"), so
+;; the alist lookup must compare case-insensitively there.
+(define (env-assoc name env)
+  (cond-expand
+    (windows (assoc name env string-ci=?))
+    (else (assoc name env))))
 
 (test-begin "srfi-98")
 
@@ -11,8 +17,8 @@
 
 (define env (get-environment-variables))
 (test-equal #t (list? env))
-(test-equal #t (pair? (assoc "PATH" env)))
-(test-equal #t (string? (cdr (assoc "PATH" env))))
+(test-equal #t (pair? (env-assoc "PATH" env)))
+(test-equal #t (string? (cdr (env-assoc "PATH" env))))
 
 ;; every entry is a (string . string) pair
 (test-equal #t
@@ -24,7 +30,7 @@
              (loop (cdr e))))))
 
 ;; the alist agrees with single-variable lookup
-(test-equal (get-environment-variable "PATH") (cdr (assoc "PATH" env)))
+(test-equal (get-environment-variable "PATH") (cdr (env-assoc "PATH" env)))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-98")


### PR DESCRIPTION
## Summary

`zig build -Dtarget=aarch64-windows` now cross-compiles kaappi.exe, thottam.exe, and kaappi-lsp.exe (via Zig's bundled mingw-w64 — no Windows SDK needed on the build machine), and releases ship `kaappi-aarch64-windows.exe`. The port is documented in `docs/dev/windows.md`.

**Architecture.** The runtime's I/O layer is written against integer fds with POSIX read/write/open/close semantics. Rather than fork it, the new `src/platform.zig` maps that surface per-OS: POSIX targets forward to the exact `std.posix`/`std.c` calls the code made before (zero behavior change), while Windows maps onto the CRT's low-level io layer (`_open`/`_read`/`_write`: integer fds, 0/1/2 preopened, always `O_BINARY`) with wide-char path entry points so UTF-8 paths survive any ANSI code page, plus Win32 for what the CRT lacks: QPC monotonic clock, console UTF-8 + VT modes, self-exe path, `CreateProcessW` spawning with CommandLineToArgvW-inverse quoting, `LoadLibraryW` FFI, `FindFirstFileW` directory iteration, and an auto-reset event for the reactor.

**Two deliberate degradations**, both mirroring the WASI port's shape:

- CRT fds have no `O_NONBLOCK`, so `maybeSetNonblocking` is a comptime no-op — the permanent analogue of the WASI probe-fail path. Ports stay blocking; fiber I/O degrades to blocking reads.
- The reactor backend (`WindowsEventBackend`) is one auto-reset event: `WaitForSingleObject` bounded by the nearest timer deadline serves `thread-sleep!`/timed waits, `SetEvent` is the KEP-0002 cross-thread notify ring. Fibers, channels (incl. capacity-0 rendezvous), SRFI-18 threads, and SharedChannel promotion all work on top.

**Other platform decisions**

- SRFI-170's POSIX-only slice (uid/gid, user/group-info, symlinks, chmod/umask, fifos, nice) raises a catchable file error; `file-info` works with inode/blksize/blocks reporting 0.
- `cond-expand`/`(features)` expose exactly one OS-class identifier: `windows` on Windows, `posix` elsewhere; POSIX-only Scheme tests gate themselves on it.
- The FFI's 64-bit integer carrier changes from `c_long` to `i64` (identical on LP64); LLP64 Windows routes the 32-bit C `long` through the `.int` marshaling class — previously all 64-bit FFI marshaling silently assumed `c_long` was 64-bit.
- linenoise is termios-only: the Windows REPL keeps the full eval/print/debug-command loop and swaps only the line source for a plain prompt + buffered reader.
- thottam builds and runs read-only subcommands; `install`/`remove`/`update` print a clear unsupported error (POSIX-userland install pipeline).
- `kaappi test`'s worker orchestration runs on `CreateProcessW` with merged stdout+stderr capture.
- The fd-readiness unit suites (tests_reactor/scheduler/port_io) are excluded on Windows by `vm_tests.zig` — they test POSIX pipe readiness that cannot exist under the no-non-blocking design.

**Release + CI wiring**

- `release.yml` gains the aarch64-windows matrix row with per-row artifact naming (the gnu-ABI static lib is emitted as `kaappi_rt.lib`). The row builds with `-Dstrip=false`: a stripped kaappi.exe access-violates at startup on ARM64 Windows (stripped thottam and small stripped probes are fine — toolchain issue, documented).
- `ci.yml` gains a compile-only `windows-cross` job so the target cannot bit-rot (GitHub has no ARM64 Windows runners for execution).
- The `/github-release` skill's platform list and post-release notes now cover the Windows artifacts.

## Test evidence

Verified on a real Windows 11 ARM64 machine (build 26100, UTM VM):

- Full Zig unit suite: **1037 passed, 14 skipped, 0 failed** (skips are POSIX-permission/FIFO/uid tests); thottam tests pass
- Complete R7RS suite: **1395 pass, 0 fail**
- Every `tests/scheme/{smoke,compliance,continuations,hygiene,srfi,audit}` file passes
- `kaappi test` (worker spawning), `doctor`, `cache status|clear`, piped REPL, fibers/channels/rendezvous, SRFI-18 threads + `thread-sleep!`, FFI (`LoadLibraryW`), Unicode paths/console all exercised end-to-end
- The exact release-row commands were rehearsed locally and the resulting binary re-verified on the VM

No POSIX regression: macOS unit suite green, and the full Scheme suite (`run-all.sh`) is **1871 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up issues

- #1607 — stripped kaappi.exe access-violates at startup on ARM64 Windows (release row ships unstripped until understood)
- #1608 — fd readiness backend (IOCP/WSAEventSelect) to lift the blocking-port degradation
- #1609 — thottam package installation on Windows (install pipeline still shells out to POSIX userland)
- #1610 — verify `kaappi compile` (LLVM native backend) end-to-end on a Windows machine
- kaappi/kaappi.github.io#17 — downloads page Windows row after the next release