### PR TITLE
Run the FFI Scheme suite on Windows (#1611)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,11 @@ jobs:
           cp zig-out/bin/kaappi.exe zig-out/bin/thottam.exe zig-out/bin/kaappi-lsp.exe win-stage/
           cp "$(ls -t .zig-cache/o/*/unit-tests.exe | head -1)" win-stage/
 
+      - name: Cross-compile FFI test fixture
+        # uint64-range.scm dlopens this; windows-arm-test drops it into
+        # tests/scheme/ffi/fixtures/ — that job has no toolchain (#1613).
+        run: zig cc -target aarch64-windows-gnu -shared tests/scheme/ffi/fixtures/u64test.c -o win-stage/libu64test.dll
+
       - name: Upload binaries for windows-arm-test
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -187,11 +192,12 @@ jobs:
   # Execute the suite on real Windows ARM64 via GitHub's hosted
   # windows-11-arm runners (free for public repos): the unit suite, the
   # R7RS suite, and the .scm suites verified on the port's reference VM
-  # (docs/dev/windows.md). The binaries come cross-compiled from
+  # (docs/dev/windows.md), including the FFI suite (#1611) against the
+  # cross-compiled fixture DLL. The binaries come cross-compiled from
   # windows-cross — Zig 0.16.0 cannot compile natively on Windows ARM64
   # (zig build/build-exe access-violate on any project, #1613) — so this
   # job installs no toolchain and only executes. The shell-based suites
-  # (#1612) and the FFI suite (#1611) are not runnable on Windows yet.
+  # (#1612) are not runnable on Windows yet.
   windows-arm-test:
     needs: windows-cross
     runs-on: windows-11-arm
@@ -223,6 +229,12 @@ jobs:
           for z in bin/*.zip; do tar -xf "$z" -C bin && rm -f "$z"; done
           ls -l bin
 
+      - name: Stage FFI test fixture
+        # uint64-range.scm opens tests/scheme/ffi/fixtures/libu64test
+        # relative to the repo root this job runs the suites from.
+        shell: bash
+        run: cp bin/libu64test.dll tests/scheme/ffi/fixtures/
+
       - name: Create tmp directories
         # Tests write scratch files under /tmp/..., which kaappi.exe
         # resolves to \tmp on the current drive (docs/dev/windows.md).
@@ -244,7 +256,7 @@ jobs:
         shell: bash
         run: |
           fail=0
-          for dir in smoke compliance continuations hygiene srfi audit; do
+          for dir in smoke compliance continuations hygiene srfi ffi audit; do
             for f in tests/scheme/$dir/*.scm; do
               if bin/kaappi.exe "$f" > out.log 2>&1; then
                 echo "  PASS  $f"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ zig-out/
 test_*.o
 *.dylib
 *.so
+# zig cc -shared for windows drops these next to the .dll
+*.dll
+*.pdb
+tests/scheme/ffi/fixtures/u64test.lib
 .claude/worktrees/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `(ffi-open #f)` on Windows now has POSIX `dlopen(NULL)` semantics: symbol lookup on the process handle searches every loaded module, so CRT functions (`abs`, `qsort`, `strlen`, …) resolve from `ucrtbase.dll` — previously it probed only the exe's (empty) export table. The FFI Scheme suite (`tests/scheme/ffi/`, incl. callbacks and a cross-compiled fixture DLL) now runs on Windows in CI and is part of the verified set (#1611)
 - FFI 64-bit integer marshaling now uses a platform-independent `i64` carrier: on LLP64 targets (Windows) C `long` is 32-bit and is routed through the 32-bit marshaling class, while `int64`/`uint64`/`size_t` keep full 64-bit range — previously all four assumed `c_long` was 64-bit (identical behavior on macOS/Linux, where it is)
 - macOS release binaries can now `ffi-open` user-compiled libraries: the hardened-runtime signing entitlements add `com.apple.security.cs.disable-library-validation`, without which dlopen refused every locally-built `.dylib` (kaappi-net, kaappi-pg, kaappi-sqlite, kaappi-crypto) on release binaries while source builds worked (#1587)
 

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -79,6 +79,16 @@ and cross-thread SharedChannel promotion all work on top of this.
   C. `normalizeType` (ffi.zig) routes it through the 32-bit `.int`
   marshaling class there; `int64`/`uint64`/`size_t` use the 64-bit
   carrier (`i64`) everywhere.
+* **`(ffi-open #f)` sees the whole process.** The process self-handle
+  gets POSIX `dlopen(NULL)` semantics: `dlSym` (platform.zig) probes
+  every loaded module in load order via `K32EnumProcessModules`, so CRT
+  symbols (`abs`, `qsort`, `strlen`, …) resolve even though they live in
+  `ucrtbase.dll` rather than the exe — `GetProcAddress` on the exe module
+  alone would find nothing (mingw exes export no symbols). Named opens
+  probe a `.dll` suffix (`dl_suffixes`); there is no `libm.dll`, so tests
+  that need the math functions `cond-expand` to `(ffi-open "ucrtbase")`
+  on Windows. FFI callbacks (comptime Zig trampolines, `callconv(.c)`)
+  work unchanged — the qsort-with-Scheme-comparator tests pass.
 * **thottam** builds and runs (`list`, `verify`, `--help`); `install`/
   `remove`/`update` print a clear unsupported error — the install
   pipeline shells out to POSIX userland (`cp -R`, `find`, `sh -c`) that
@@ -108,11 +118,13 @@ suite, and the VM-verified `.scm` suites on GitHub's hosted
 `windows-11-arm` runners on every PR. The execution job installs no
 toolchain — it downloads the binaries `windows-cross` built as an
 artifact, because native compilation on Windows ARM64 is broken in the
-Zig 0.16.0 toolchain itself (#1613). What CI can't run yet — the
-shell-based suites (#1612), the FFI suite (#1611), and interactive
-surfaces like the REPL — is verified against a real Windows 11 ARM64
-machine (e.g. a UTM VM with ssh). The unit-test binary compiles with the
-same target flag and runs on the box:
+Zig 0.16.0 toolchain itself (#1613). The FFI suite runs against a
+fixture DLL that `windows-cross` cross-compiles into the same artifact
+(`zig cc -target aarch64-windows-gnu -shared`). What CI can't run yet —
+the shell-based suites (#1612) and interactive surfaces like the REPL —
+is verified against a real Windows 11 ARM64 machine (e.g. a UTM VM with
+ssh). The unit-test binary compiles with the same target flag and runs
+on the box:
 
 ```bash
 zig build test -Dtarget=aarch64-windows       # compiles; foreign run steps skip cleanly
@@ -125,11 +137,11 @@ Two environment notes for the suite:
   `/tmp/...`, which Windows resolves to `\tmp` on the current drive.
 * Run from a writable directory; a few tests create files in the CWD.
 
-Verified on Windows 11 ARM64 (build 26100): full unit suite (1037 pass,
-14 skipped — the skips are POSIX-permission/FIFO/uid tests), the complete
+Verified on Windows 11 ARM64 (build 26100): full unit suite (1050 pass,
+10 skipped — the skips are POSIX-permission/FIFO/uid tests), the complete
 R7RS suite, and every `tests/scheme/{smoke,compliance,continuations,
-hygiene,srfi,audit}` file — the same set the `windows-arm-test` CI job
-now runs on every PR. The fd-readiness unit suites
+hygiene,srfi,ffi,audit}` file — the same set the `windows-arm-test` CI
+job now runs on every PR. The fd-readiness unit suites
 (`tests_reactor.zig`, `tests_scheduler.zig`, `tests_port_io.zig`) are
 excluded on Windows by `vm_tests.zig` — they test POSIX pipe readiness
 that cannot exist under the no-non-blocking design.
@@ -167,9 +179,6 @@ the github-release skill's Step 10.
   box (#1610) is blocked on the same upstream fix. Fixed upstream
   (ziglang#31865; Zig master works on the box, verified 2026-07-17);
   both unblock at the 0.17.0 toolchain bump.
-* The FFI Scheme suite (`tests/scheme/ffi/`) doesn't run on Windows:
-  POSIX library names (`"libm"`), unverified `(ffi-open #f)` semantics,
-  and a `.dylib`/`.so`-only fixture (#1611).
 * The shell-based suites — errors, compile, test-runner, pipeline,
   doctor, fmt, cache, timings, the smoke `.sh` scripts, sandbox, and
   robustness — don't run on Windows (#1612).

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -125,6 +125,10 @@ pub const win = if (is_windows) struct {
     pub extern "kernel32" fn GetModuleHandleW(name: ?[*:0]const u16) callconv(.winapi) ?HANDLE;
     pub extern "kernel32" fn GetProcAddress(mod: HANDLE, name: [*:0]const u8) callconv(.winapi) ?*anyopaque;
     pub extern "kernel32" fn FreeLibrary(mod: HANDLE) callconv(.winapi) c_int;
+    pub extern "kernel32" fn GetCurrentProcess() callconv(.winapi) HANDLE;
+    // Exported from kernel32 since Windows 7 (the psapi.dll re-export era
+    // predates every supported target).
+    pub extern "kernel32" fn K32EnumProcessModules(process: HANDLE, modules: [*]HANDLE, cb: u32, needed: *u32) callconv(.winapi) c_int;
     pub extern "kernel32" fn GetLastError() callconv(.winapi) u32;
     pub extern "kernel32" fn MoveFileExW(old: [*:0]const u16, new: [*:0]const u16, flags: u32) callconv(.winapi) c_int;
     pub const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
@@ -929,7 +933,10 @@ var dl_error_buf: [128]u8 = undefined;
 var dl_error_pending: bool = false;
 
 /// dlopen(3). A null path opens the running process (POSIX self-handle /
-/// GetModuleHandleW(null)); dlClose knows not to free that one.
+/// GetModuleHandleW(null)); dlClose knows not to free that one, and on
+/// Windows dlSym gives it dlopen(NULL) semantics by searching every
+/// loaded module — so CRT symbols resolve even though they live in
+/// ucrtbase.dll rather than the exe.
 pub fn dlOpen(path: ?[*:0]const u8) ?*anyopaque {
     if (comptime is_windows) {
         const p = path orelse return win.GetModuleHandleW(null);
@@ -944,6 +951,23 @@ pub fn dlOpen(path: ?[*:0]const u8) ?*anyopaque {
 
 pub fn dlSym(handle: *anyopaque, name: [*:0]const u8) ?*anyopaque {
     if (comptime is_windows) {
+        // The process self-handle from dlOpen(null): GetProcAddress on the
+        // exe module alone finds nothing useful — mingw exes export no
+        // symbols, and the CRT lives in ucrtbase.dll — so mirror POSIX
+        // dlsym on the dlopen(NULL) global handle by probing every loaded
+        // module in load order (exe first, like the ELF global scope).
+        if (handle == win.GetModuleHandleW(null)) {
+            var mods: [1024]win.HANDLE = undefined; // enough for any real process
+            var needed: u32 = 0;
+            if (win.K32EnumProcessModules(win.GetCurrentProcess(), &mods, @sizeOf(@TypeOf(mods)), &needed) != 0) {
+                const count = @min(mods.len, needed / @sizeOf(win.HANDLE));
+                for (mods[0..count]) |mod| {
+                    if (win.GetProcAddress(mod, name)) |sym| return sym;
+                }
+            }
+            dl_error_pending = true;
+            return null;
+        }
         const sym = win.GetProcAddress(handle, name);
         if (sym == null) dl_error_pending = true;
         return sym;
@@ -1268,4 +1292,20 @@ test "write to stdout-like sink via openNullSink" {
     const msg = "platform shim probe\n";
     const rc = write(fd, msg.ptr, msg.len);
     try std.testing.expect(rc == @as(isize, @intCast(msg.len)));
+}
+
+test "dlSym on the dlOpen(null) process handle finds CRT symbols (#1611)" {
+    // The (ffi-open #f) contract: the process handle resolves C runtime
+    // symbols — on Windows via the all-loaded-modules search (abs lives in
+    // ucrtbase.dll, never in the exe's export table), on POSIX via dlsym's
+    // global symbol scope.
+    if (comptime is_wasm) return error.SkipZigTest;
+    if (comptime builtin.target.abi.isMusl()) return error.SkipZigTest; // static libc: no dynamic loading
+    const proc = dlOpen(null) orelse return error.TestUnexpectedResult;
+    defer dlClose(proc);
+    try std.testing.expect(dlSym(proc, "abs") != null);
+    // A miss reports failure without poisoning later lookups.
+    try std.testing.expect(dlSym(proc, "kaappi_no_such_symbol_1611") == null);
+    _ = dlError();
+    try std.testing.expect(dlSym(proc, "abs") != null);
 }

--- a/tests/scheme/ffi/basic.scm
+++ b/tests/scheme/ffi/basic.scm
@@ -23,7 +23,9 @@
         (display " got ") (write got)
         (newline))))
 
-(define libm (ffi-open "libm"))
+;; The C math functions live in libm on POSIX; on Windows the CRT
+;; (ucrtbase.dll) hosts them — there is no libm.dll.
+(define libm (ffi-open (cond-expand (windows "ucrtbase") (else "libm"))))
 (define c-sqrt (ffi-fn libm "sqrt" '(double) 'double))
 (define c-ceil (ffi-fn libm "ceil" '(double) 'double))
 (define c-pow (ffi-fn libm "pow" '(double double) 'double))

--- a/tests/scheme/ffi/bignum-args.scm
+++ b/tests/scheme/ffi/bignum-args.scm
@@ -19,7 +19,13 @@
 
 (define libc (ffi-open #f))
 (define c-abs (ffi-fn libc "abs" '(int) 'int))
-(define c-labs (ffi-fn libc "labs" '(long) 'long))
+;; A 64-bit |x|: labs on LP64 POSIX where C long is 64-bit; Windows is
+;; LLP64 (long is 32-bit, and the FFI range-checks it as such), so the
+;; same coverage comes from llabs via the int64 type.
+(define c-labs
+  (cond-expand
+    (windows (ffi-fn libc "llabs" '(int64) 'int64))
+    (else (ffi-fn libc "labs" '(long) 'long))))
 
 ;; Fixnum args should still work
 (check "abs fixnum positive" (c-abs 42) 42)

--- a/tests/scheme/ffi/callback-error.scm
+++ b/tests/scheme/ffi/callback-error.scm
@@ -11,7 +11,9 @@
 (test-begin "ffi-callback-errors")
 
 (define lib (ffi-open #f))
-(define c-qsort (ffi-fn lib "qsort" '(pointer long long pointer) 'void))
+;; qsort's true signature: void qsort(void *, size_t, size_t, cmp).
+;; size_t (not long) matters on Windows, where long is only 32 bits.
+(define c-qsort (ffi-fn lib "qsort" '(pointer size_t size_t pointer) 'void))
 
 ;; --- (error ...) inside a callback is catchable at the FFI call site ---
 

--- a/tests/scheme/ffi/callback.scm
+++ b/tests/scheme/ffi/callback.scm
@@ -34,7 +34,9 @@
         (- va vb)))
     '(pointer pointer) 'int))
 
-(define c-qsort (ffi-fn lib "qsort" '(pointer long long pointer) 'void))
+;; qsort's true signature: void qsort(void *, size_t, size_t, cmp).
+;; size_t (not long) matters on Windows, where long is only 32 bits.
+(define c-qsort (ffi-fn lib "qsort" '(pointer size_t size_t pointer) 'void))
 (c-qsort base-ptr 5 4 int-cmp)
 
 ;; Verify sorted order

--- a/tests/scheme/ffi/int-range.scm
+++ b/tests/scheme/ffi/int-range.scm
@@ -23,7 +23,9 @@
     (display "FAIL: ") (display name) (display " should have raised error")
     (newline)))
 
-(define libm (ffi-open "libm"))
+;; abs resolves through libm's dependency chain on POSIX; on Windows the
+;; CRT (ucrtbase.dll) exports it directly — there is no libm.dll.
+(define libm (ffi-open (cond-expand (windows "ucrtbase") (else "libm"))))
 (define c-abs (ffi-fn libm "abs" '(int) 'int))
 
 ;; Valid in-range call

--- a/tests/scheme/ffi/narrow-range.scm
+++ b/tests/scheme/ffi/narrow-range.scm
@@ -6,7 +6,9 @@
 
 (test-begin "narrow-range")
 
-(define libm (ffi-open "libm"))
+;; libm on POSIX; on Windows the CRT (ucrtbase.dll) hosts abs — there is
+;; no libm.dll.
+(define libm (ffi-open (cond-expand (windows "ucrtbase") (else "libm"))))
 (define libc (ffi-open #f))
 
 ;; ---- uint8 [0, 255] ----
@@ -55,7 +57,13 @@
 (test-error "char reject: 300" (abs-char 300))
 
 ;; ---- uint32 [0, 4294967295] ----
-(define c-htonl (ffi-fn libc "htonl" '(uint32) 'uint32))
+;; Any uint32 -> uint32 function does here: htonl from the process's libc
+;; on POSIX; on Windows htonl lives in ws2_32.dll (not loaded), so use the
+;; CRT's byte-swap equivalent.
+(define c-htonl
+  (cond-expand
+    (windows (ffi-fn libc "_byteswap_ulong" '(uint32) 'uint32))
+    (else (ffi-fn libc "htonl" '(uint32) 'uint32))))
 (test-assert "uint32 valid: 0" (number? (c-htonl 0)))
 (test-assert "uint32 valid: 2^31" (number? (c-htonl 2147483648)))
 (test-assert "uint32 valid: 2^32-1" (number? (c-htonl 4294967295)))

--- a/tests/scheme/ffi/type-validation.scm
+++ b/tests/scheme/ffi/type-validation.scm
@@ -20,7 +20,9 @@
     (display "FAIL: ") (display name) (display " should have raised error")
     (newline)))
 
-(define libm (ffi-open "libm"))
+;; libm on POSIX; on Windows the CRT (ucrtbase.dll) hosts the math
+;; functions — there is no libm.dll.
+(define libm (ffi-open (cond-expand (windows "ucrtbase") (else "libm"))))
 (define c-sqrt (ffi-fn libm "sqrt" '(double) 'double))
 (define c-abs (ffi-fn libm "abs" '(int) 'int))
 

--- a/tests/scheme/ffi/uint32-range.scm
+++ b/tests/scheme/ffi/uint32-range.scm
@@ -18,7 +18,13 @@
 ;; to panic for values > 2^31-1.
 
 (define libc (ffi-open #f))
-(define c-htonl (ffi-fn libc "htonl" '(uint32) 'uint32))
+;; htonl from the process's libc on POSIX; on Windows htonl lives in
+;; ws2_32.dll (not loaded), so use the CRT's _byteswap_ulong — same
+;; uint32 -> uint32 byte swap on this little-endian target.
+(define c-htonl
+  (cond-expand
+    (windows (ffi-fn libc "_byteswap_ulong" '(uint32) 'uint32))
+    (else (ffi-fn libc "htonl" '(uint32) 'uint32))))
 
 ;; Values within i32 range should still work
 (check "htonl(0)" (c-htonl 0) 0)

--- a/tests/scheme/ffi/uint64-range.scm
+++ b/tests/scheme/ffi/uint64-range.scm
@@ -2,9 +2,14 @@
 ;; not be rejected.  The return direction already handled the full unsigned
 ;; range; the argument side was forcing values through a signed i64 path.
 ;;
-;; Requires fixtures/libu64test.{dylib,so} — compile with:
+;; Requires fixtures/libu64test.{dylib,so,dll} — compile with:
 ;;   zig cc -dynamiclib fixtures/u64test.c -o fixtures/libu64test.dylib  (macOS)
 ;;   zig cc -shared -fPIC fixtures/u64test.c -o fixtures/libu64test.so   (Linux)
+;;   zig cc -target aarch64-windows-gnu -shared fixtures/u64test.c \
+;;     -o fixtures/libu64test.dll   (Windows — cross-compiled, zig cannot
+;;                                   run natively on ARM64 Windows, #1613)
+;; run-all.sh builds the host fixture automatically when zig is on PATH;
+;; CI cross-compiles the .dll in the windows-cross job.
 
 (import (scheme base) (scheme write))
 
@@ -21,9 +26,15 @@
         (display " got ") (write got)
         (newline))))
 
-(define lib
+(define (try-open path)
   (guard (exn (#t #f))
-    (ffi-open "./fixtures/libu64test")))
+    (ffi-open path)))
+
+;; The fixture path depends on the working directory: ./fixtures when run
+;; from this directory, the repo-relative path when run via run-all.sh or CI.
+(define lib
+  (or (try-open "./fixtures/libu64test")
+      (try-open "tests/scheme/ffi/fixtures/libu64test")))
 
 (when (not lib)
   (display "SKIP: libu64test not found (compile fixtures/u64test.c first)")

--- a/tests/scheme/ffi/use-after-close.scm
+++ b/tests/scheme/ffi/use-after-close.scm
@@ -17,7 +17,9 @@
         (display " got ") (write got)
         (newline))))
 
-(define libm (ffi-open "libm"))
+;; libm on POSIX; on Windows the CRT (ucrtbase.dll) hosts the math
+;; functions — there is no libm.dll.
+(define libm (ffi-open (cond-expand (windows "ucrtbase") (else "libm"))))
 (define c-sqrt (ffi-fn libm "sqrt" '(double) 'double))
 
 ;; Verify the function works before close

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -158,6 +158,24 @@ run_suite "Compliance tests" tests/scheme/compliance/*.scm
 run_suite "Continuation tests" tests/scheme/continuations/*.scm
 run_suite "Hygiene tests" tests/scheme/hygiene/*.scm
 run_suite "SRFI tests" tests/scheme/srfi/*.scm
+
+# Build the FFI fixture library when a compiler is around so uint64-range.scm
+# exercises real code instead of skipping. Non-fatal: without a fixture the
+# test degrades to its documented SKIP.
+FIXTURE_SRC=tests/scheme/ffi/fixtures/u64test.c
+if command -v zig >/dev/null 2>&1; then
+    case "$(uname)" in
+        Darwin) FIXTURE_LIB=tests/scheme/ffi/fixtures/libu64test.dylib
+                FIXTURE_FLAGS="-dynamiclib" ;;
+        *)      FIXTURE_LIB=tests/scheme/ffi/fixtures/libu64test.so
+                FIXTURE_FLAGS="-shared -fPIC" ;;
+    esac
+    if [[ ! -e "$FIXTURE_LIB" || "$FIXTURE_SRC" -nt "$FIXTURE_LIB" ]]; then
+        # shellcheck disable=SC2086  # FIXTURE_FLAGS is a flag list
+        zig cc $FIXTURE_FLAGS "$FIXTURE_SRC" -o "$FIXTURE_LIB" \
+            || echo "  WARN  could not build $FIXTURE_LIB (uint64-range.scm will skip)"
+    fi
+fi
 run_suite "FFI tests" tests/scheme/ffi/*.scm
 run_suite "Audit tests" tests/scheme/audit/*.scm
 run_shell_suite "Error tests" tests/scheme/errors


### PR DESCRIPTION
Closes #1611.

The Windows aarch64 port (#1606) implemented the C FFI via `LoadLibraryW`/`GetProcAddress`, but no Scheme-level FFI test had ever executed on Windows — the suite couldn't run as written.

## What was broken

1. **`(ffi-open #f)` found nothing.** `dlSym` on the process self-handle did a plain `GetProcAddress` on the exe module, whose export table is empty (mingw exes export no symbols) — so `abs`, `qsort`, `strlen`, `tolower` were all unresolvable, unlike POSIX `dlopen(NULL)`.
2. **POSIX library names.** Five files open `"libm"`; there is no `libm.dll` — the C math functions live in `ucrtbase.dll`.
3. **LLP64 mismatches.** `labs` with the `long` type can't carry 64-bit values on Windows (long is 32-bit there), and `htonl` lives in ws2_32.dll, which isn't loaded.
4. **Fixture only built as `.dylib`/`.so`**, opened via a CWD-relative path — it turns out `uint64-range.scm` silently SKIPped in CI on *every* platform (nothing ever built the fixture, and the `./fixtures/...` path only resolves when run from the test's own directory).

## Changes

- **`src/platform.zig`** — the `dlOpen(null)` process handle now has POSIX `dlopen(NULL)` semantics: `dlSym` probes every loaded module in load order via `K32EnumProcessModules` (kernel32, Win7+), so CRT symbols resolve from `ucrtbase.dll`. New regression test, which runs on POSIX too (skips only on static-musl/wasm).
- **`tests/scheme/ffi/*.scm`** — `cond-expand` `(windows "ucrtbase")` for `"libm"`; `llabs`/`int64` in place of `labs`/`long` on Windows (same 64-bit marshaling coverage); the CRT's `_byteswap_ulong` in place of `htonl` (same uint32→uint32 byte swap); `qsort` declared with its true `size_t` signature on **all** platforms (`long` was wrong-but-harmless on LP64 and truncates on LLP64); `uint64-range.scm` tries the repo-relative fixture path too.
- **CI** — `windows-cross` cross-compiles `libu64test.dll` into the artifact (`zig cc -target aarch64-windows-gnu -shared`); `windows-arm-test` stages it into `fixtures/` and adds `ffi` to the suite loop. `run-all.sh` builds the host fixture when `zig` is on PATH (non-fatal), so `uint64-range.scm` now genuinely runs on Linux/macOS CI as well.
- **Docs** — `docs/dev/windows.md` documents the `(ffi-open #f)` semantics, moves the FFI suite into the verified list, and drops the known-gap entry. CHANGELOG entry under Unreleased → Fixed.

## Verification

- **Windows 11 ARM64 VM** (cross-compiled artifacts, same path as CI): all **14 FFI files pass**, including callbacks round-tripping through `qsort` and the fixture DLL loading via the repo-relative forward-slash path; unit suite **1050 pass / 0 fail** (10 skips) including the new dlSym test.
- **macOS**: full local suite **1871 pass / 0 fail** — `uint64-range.scm` now runs its 11 checks instead of skipping.
- Compile gates: `zig build -Dtarget=aarch64-windows`, `zig build test -Dtarget=aarch64-windows`, `zig build test -Dtarget=riscv64-linux`, `zig build wasm` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)