### PR TITLE
Windows: port thottam package installation (#1609)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
           mkdir -p win-stage
           cp zig-out/bin/kaappi.exe zig-out/bin/thottam.exe zig-out/bin/kaappi-lsp.exe win-stage/
           cp "$(ls -t .zig-cache/o/*/unit-tests.exe | head -1)" win-stage/
+          cp "$(ls -t .zig-cache/o/*/thottam-tests.exe | head -1)" win-stage/
 
       - name: Upload binaries for windows-arm-test
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -186,7 +187,8 @@ jobs:
 
   # Execute the suite on real Windows ARM64 via GitHub's hosted
   # windows-11-arm runners (free for public repos): the unit suite, the
-  # R7RS suite, and the .scm suites verified on the port's reference VM
+  # thottam suite + install/remove integration (#1609), the R7RS suite,
+  # and the .scm suites verified on the port's reference VM
   # (docs/dev/windows.md). The binaries come cross-compiled from
   # windows-cross — Zig 0.16.0 cannot compile natively on Windows ARM64
   # (zig build/build-exe access-violate on any project, #1613) — so this
@@ -235,6 +237,31 @@ jobs:
       - name: Unit tests
         shell: bash
         run: bin/unit-tests.exe
+
+      - name: thottam unit tests
+        shell: bash
+        run: bin/thottam-tests.exe
+
+      - name: thottam integration test
+        # Mirrors the POSIX test job's step: a real install of the
+        # pure-Scheme kaappi-json (Git for Windows is preinstalled on the
+        # runner), imported through the installed lib dir, then removed —
+        # which deletes a real git clone, whose read-only pack files are
+        # the Windows-specific removal hazard (#1609). KAAPPI_HOME is a
+        # C:/-style path (pwd -W): thottam hands paths straight to git.exe
+        # and the CRT, which never see git-bash's /d/... spellings.
+        shell: bash
+        run: |
+          export KAAPPI_HOME="$(pwd -W)/thottam-home"
+          bin/thottam.exe list
+          bin/thottam.exe install kaappi-json
+          bin/thottam.exe list | grep kaappi-json
+          bin/thottam.exe verify
+          echo '(import (kaappi json)) (display (json-write-string (list 1 2 3))) (newline)' > use-json.scm
+          bin/kaappi.exe --lib-path "$KAAPPI_HOME/lib" use-json.scm
+          bin/thottam.exe remove kaappi-json
+          ! bin/thottam.exe list | grep kaappi-json
+          rm -f use-json.scm
 
       - name: R7RS test suite
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,7 @@ jobs:
           export KAAPPI_HOME="$(pwd -W)/thottam-home"
           bin/thottam.exe list
           bin/thottam.exe install kaappi-json
+          bin/thottam.exe update kaappi-json
           bin/thottam.exe list | grep kaappi-json
           bin/thottam.exe verify
           echo '(import (kaappi json)) (display (json-write-string (list 1 2 3))) (newline)' > use-json.scm

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ powers the [playground](https://kaappi-lang.org/playground/).
 The Windows port (`zig build -Dtarget=aarch64-windows`) covers the full
 interpreter — REPL (plain line editing, no history/completion), fibers,
 channels, OS threads, FFI (`LoadLibrary`), and the `kaappi test` runner.
+thottam installs packages on Windows too (with Git for Windows on PATH);
+only manifests with a `build:` command are refused — the C-FFI packages'
+Makefiles target POSIX.
 Platform differences: ports never switch to non-blocking I/O (fiber I/O
 degrades to blocking reads, timers still work), and the POSIX-only slice
 of SRFI-170 (uid/gid, symlinks, chmod/umask, user/group info) raises a

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -75,10 +75,16 @@ and cross-thread SharedChannel promotion all work on top of this.
   C. `normalizeType` (ffi.zig) routes it through the 32-bit `.int`
   marshaling class there; `int64`/`uint64`/`size_t` use the 64-bit
   carrier (`i64`) everywhere.
-* **thottam** builds and runs (`list`, `verify`, `--help`); `install`/
-  `remove`/`update` print a clear unsupported error — the install
-  pipeline shells out to POSIX userland (`cp -R`, `find`, `sh -c`) that
-  needs reimplementing on the shim first.
+* **thottam `build:` commands are refused.** The package manager itself
+  is fully ported (#1609): install/remove/update/list/verify all work —
+  the install pipeline's file work (recursive copy/remove/walk,
+  `mkdir -p`, `touch`) runs on shim-based helpers (`thottam_fs.zig`)
+  instead of POSIX userland, on every platform. What remains
+  Windows-refused is a manifest's `build:` line: it ran via `/bin/sh -c`
+  and every ecosystem `build:` is a Makefile producing POSIX shared
+  libraries, so thottam errors clearly instead — pure-Scheme packages
+  (most of the ecosystem) have no `build:` line and install fine. Needs
+  Git for Windows on PATH, like every git operation.
 * **REPL** uses a plain prompt + line reader (linenoise is termios-only):
   the full REPL loop — debug commands, multi-line input, themes — works,
   without history/completion/editing.
@@ -98,8 +104,9 @@ Scheme tests that exercise POSIX-only functionality gate themselves:
 ## Testing on a Windows machine
 
 CI covers the target twice (ci.yml): `windows-cross` cross-compiles the
-binaries and the unit-test exe from Linux, guarding the path release.yml
-ships with, and `windows-arm-test` executes the unit suite, the R7RS
+binaries and the test exes from Linux, guarding the path release.yml
+ships with, and `windows-arm-test` executes the unit suite, the thottam
+suite plus a real package install/remove integration test, the R7RS
 suite, and the VM-verified `.scm` suites on GitHub's hosted
 `windows-11-arm` runners on every PR. The execution job installs no
 toolchain — it downloads the binaries `windows-cross` built as an
@@ -164,9 +171,10 @@ the github-release skill's Step 10.
 * The shell-based suites — errors, compile, test-runner, pipeline,
   doctor, fmt, cache, timings, the smoke `.sh` scripts, sandbox, and
   robustness — don't run on Windows (#1612).
-* thottam package installation (replace the POSIX userland calls with
-  shim-based recursive copy/remove/walk; git is already spawned via
-  CreateProcessW and works when Git for Windows is on PATH).
+* thottam refuses manifests with a `build:` command (#1609 ported
+  everything else — see Deliberate degradations above); lifting that
+  needs a Windows build story for the C-FFI packages, which today are
+  Makefiles producing `.dylib`/`.so` against POSIX headers.
 * `kaappi compile` links with `zig cc` when Zig is installed on the box;
   untested beyond the doctor's smoke-link probe.
 * Console reads are byte-oriented ANSI/UTF-8; typing non-ASCII at the

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -2,8 +2,10 @@ const std = @import("std");
 const platform = @import("platform.zig");
 
 /// Returns the kaappi home directory path written into `buf`.
-/// Checks `KAAPPI_HOME` env var first; falls back to `$HOME/.kaappi`.
-/// Returns null if neither env var is available or the path exceeds `buf`.
+/// Checks `KAAPPI_HOME` env var first; falls back to `$HOME/.kaappi`
+/// (`%USERPROFILE%/.kaappi` on Windows, whose shells don't set HOME —
+/// git-bash sets both). Returns null if no env var is available or the
+/// path exceeds `buf`.
 pub fn getHome(buf: []u8) ?[]const u8 {
     if (platform.getenv("KAAPPI_HOME")) |kh| {
         const home = std.mem.sliceTo(kh, 0);
@@ -12,7 +14,9 @@ pub fn getHome(buf: []u8) ?[]const u8 {
             return buf[0..home.len];
         }
     }
-    const home_ptr = platform.getenv("HOME") orelse return null;
+    const home_ptr = platform.getenv("HOME") orelse
+        (if (platform.is_windows) platform.getenv("USERPROFILE") else null) orelse
+        return null;
     const home = std.mem.sliceTo(home_ptr, 0);
     const suffix = "/.kaappi";
     const total = home.len + suffix.len;

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -68,6 +68,12 @@ pub const win = if (is_windows) struct {
     pub extern "c" fn _get_osfhandle(fd: c_int) isize;
     pub extern "c" fn _wfullpath(out: ?[*]u16, path: [*:0]const u16, size: usize) ?[*:0]u16;
     pub extern "c" fn _waccess(path: [*:0]const u16, mode: c_int) c_int;
+    pub extern "c" fn _wchmod(path: [*:0]const u16, mode: c_int) c_int;
+
+    // CRT _wchmod permission bits (sys/stat.h). Windows only honors the
+    // write bit — clearing it sets FILE_ATTRIBUTE_READONLY.
+    pub const S_IREAD: c_int = 0x0100;
+    pub const S_IWRITE: c_int = 0x0080;
 
     /// mingw ucrt `struct _stat64`. Field types (not manual offsets)
     /// reproduce the C layout: 2 bytes of tail padding after st_gid and 4
@@ -146,6 +152,7 @@ pub const win = if (is_windows) struct {
         alternate_file_name: [14]u16,
     };
     pub const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
+    pub const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
 
     pub const STD_OUTPUT_HANDLE: u32 = @bitCast(@as(i32, -11));
     pub const STD_ERROR_HANDLE: u32 = @bitCast(@as(i32, -12));
@@ -375,6 +382,10 @@ pub const StatInfo = struct {
     mtime_sec: i64,
     is_dir: bool,
     is_file: bool,
+    /// Only set by lstatPath. POSIX symlinks report neither is_dir nor
+    /// is_file; a Windows directory junction/symlink reports both
+    /// is_symlink and is_dir (remove it with rmdir, never by recursing).
+    is_symlink: bool = false,
 };
 
 pub fn statPath(path: [:0]const u8) ?StatInfo {
@@ -450,8 +461,91 @@ pub fn statFd(fd: fd_t) ?StatInfo {
     };
 }
 
+/// lstat(2) equivalent: like statPath but never follows a symlink (or, on
+/// Windows, a reparse point — junctions and directory symlinks report the
+/// link itself). The recursive walkers (thottam_fs.zig) depend on this to
+/// never traverse out of the tree they were pointed at. Windows uses
+/// FindFirstFileW on the literal path, which reports the reparse point's
+/// own attributes; drive roots ("C:/") are not queryable this way, and the
+/// walkers never ask. WASI has no symlink-aware path here; it degrades to
+/// statPath.
+pub fn lstatPath(path: [:0]const u8) ?StatInfo {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return null;
+        var data: win.Win32FindDataW = undefined;
+        const h = win.FindFirstFileW(wpath.ptr, &data);
+        if (h == win.INVALID_HANDLE_VALUE) return null;
+        _ = win.FindClose(h);
+        const is_dir = data.attributes & win.FILE_ATTRIBUTE_DIRECTORY != 0;
+        // FILETIME: 100ns ticks since 1601; Unix epoch offset as in realTime.
+        const ticks: i64 = (@as(i64, data.last_write_time.hi) << 32) | @as(i64, data.last_write_time.lo);
+        return .{
+            .size = (@as(u64, data.file_size_high) << 32) | @as(u64, data.file_size_low),
+            .mtime_sec = @divFloor(ticks - 116444736000000000, 10_000_000),
+            .is_dir = is_dir,
+            .is_file = !is_dir,
+            .is_symlink = data.attributes & win.FILE_ATTRIBUTE_REPARSE_POINT != 0,
+        };
+    }
+    if (comptime is_wasm) return statPath(path);
+    if (comptime builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var sx: linux.Statx = undefined;
+        const rc = linux.statx(@bitCast(@as(i32, std.posix.AT.FDCWD)), path, linux.AT.SYMLINK_NOFOLLOW, linux.STATX.BASIC_STATS, &sx);
+        if (rc > @as(usize, std.math.maxInt(isize))) return null;
+        return .{
+            .size = sx.size,
+            .mtime_sec = sx.mtime.sec,
+            .is_dir = sx.mode & std.posix.S.IFMT == std.posix.S.IFDIR,
+            .is_file = sx.mode & std.posix.S.IFMT == std.posix.S.IFREG,
+            .is_symlink = sx.mode & std.posix.S.IFMT == std.posix.S.IFLNK,
+        };
+    }
+    var st: std.c.Stat = undefined;
+    if (std.c.fstatat(std.posix.AT.FDCWD, path, &st, std.posix.AT.SYMLINK_NOFOLLOW) != 0) return null;
+    return .{
+        .size = @intCast(@max(st.size, 0)),
+        .mtime_sec = @intCast(st.mtime().sec),
+        .is_dir = st.mode & std.posix.S.IFMT == std.posix.S.IFDIR,
+        .is_file = st.mode & std.posix.S.IFMT == std.posix.S.IFREG,
+        .is_symlink = st.mode & std.posix.S.IFMT == std.posix.S.IFLNK,
+    };
+}
+
 pub fn pathExists(path: [:0]const u8) bool {
     return statPath(path) != null;
+}
+
+extern "c" fn chmod(path: [*:0]const u8, mode: std.c.mode_t) c_int;
+
+/// Best-effort "make deletable/traversable": clears the Windows read-only
+/// attribute (git marks pack/object files read-only, which makes _wunlink
+/// fail where POSIX unlink succeeds), chmod u+rwx on POSIX (covers
+/// unwritable directories, whose entries POSIX refuses to unlink). Used on
+/// the retry path of recursive removal; no-op on WASI.
+pub fn makeWritable(path: [:0]const u8) void {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return;
+        _ = win._wchmod(wpath.ptr, win.S_IREAD | win.S_IWRITE);
+        return;
+    }
+    if (comptime is_wasm) return;
+    _ = chmod(path, 0o700);
+}
+
+/// Inverse of makeWritable, for tests that reproduce git's read-only
+/// object files: sets the Windows read-only attribute / POSIX r-x mode.
+pub fn makeReadOnly(path: [:0]const u8) void {
+    if (comptime is_windows) {
+        var wbuf: WPathBuf = undefined;
+        const wpath = widen(&wbuf, path) orelse return;
+        _ = win._wchmod(wpath.ptr, win.S_IREAD);
+        return;
+    }
+    if (comptime is_wasm) return;
+    _ = chmod(path, 0o555);
 }
 
 /// access(path, W_OK) equivalent.

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -250,15 +250,21 @@ pub fn removeDir(allocator: std.mem.Allocator, path: []const u8) !void {
 }
 
 fn copyDylibsFromPkg(allocator: std.mem.Allocator, pkg_dir: []const u8, lib_dir: []const u8) !u32 {
+    // An unreadable/missing pkg_dir means "no native libraries", but a
+    // found library that fails to copy fails the install — recording a
+    // package whose FFI half is missing helps nobody.
     var names = tfs.collectFilesWithSuffix(allocator, pkg_dir, dylib_ext, false) catch return 0;
     defer tfs.freePathList(allocator, &names);
     var count: u32 = 0;
     for (names.items) |basename| {
-        const src = joinPath(allocator, pkg_dir, basename) catch continue;
+        const src = try joinPath(allocator, pkg_dir, basename);
         defer allocator.free(src);
-        const dst = joinPath(allocator, lib_dir, basename) catch continue;
+        const dst = try joinPath(allocator, lib_dir, basename);
         defer allocator.free(dst);
-        tfs.copyFile(allocator, src, dst) catch continue;
+        tfs.copyFile(allocator, src, dst) catch {
+            printErrColor(Color.red, "  Failed to install native library\n");
+            return error.CopyFailed;
+        };
         count += 1;
     }
     return count;
@@ -316,11 +322,13 @@ fn runBuildCommand(allocator: std.mem.Allocator, pkg: []const u8, build_cmd: []c
 
 /// Merge the contents of a package's lib/ into the shared lib dir — the
 /// `cp -R lib/. dst/` shape this replaced: existing files are overwritten
-/// (updates re-copy), unrelated files in dst survive. Non-fatal like the
-/// old ignored cp exit code, but say so when something goes wrong.
-fn installLibTree(allocator: std.mem.Allocator, lib_src: []const u8, lib_dir: []const u8) void {
+/// (updates re-copy), unrelated files in dst survive. Fatal on failure so
+/// a partial copy is never recorded as installed (the old pipeline
+/// ignored cp's exit code and could).
+fn installLibTree(allocator: std.mem.Allocator, lib_src: []const u8, lib_dir: []const u8) !void {
     tfs.copyTree(allocator, lib_src, lib_dir) catch {
-        printErrColor(Color.yellow, "  warning: failed to install some library files\n");
+        printErrColor(Color.red, "  Failed to install library files\n");
+        return error.CopyFailed;
     };
 }
 
@@ -497,7 +505,7 @@ fn doInstall(
     defer allocator.free(lib_src);
     if (dirExists(allocator, lib_src)) {
         writeStdout("  Installing libraries...\n");
-        installLibTree(allocator, lib_src, config.lib_dir);
+        try installLibTree(allocator, lib_src, config.lib_dir);
     }
 
     const dylib_count = try copyDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
@@ -646,7 +654,7 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
         const lib_src = try joinPath(allocator, pkg_dir, "lib");
         defer allocator.free(lib_src);
         if (dirExists(allocator, lib_src)) {
-            installLibTree(allocator, lib_src, config.lib_dir);
+            try installLibTree(allocator, lib_src, config.lib_dir);
         }
 
         _ = try copyDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
@@ -860,7 +868,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
         var visited = std.StringHashMap(void).init(allocator);
         defer freeVisited(allocator, &visited);
         doInstall(allocator, config, spec, locked_mode, &visited) catch |err| {
-            if (err == error.GitFailed or err == error.BuildFailed) std.process.exit(1);
+            if (err == error.GitFailed or err == error.BuildFailed or err == error.CopyFailed) std.process.exit(1);
             return err;
         };
     } else if (std.mem.eql(u8, cmd, "remove")) {
@@ -876,7 +884,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
         try doList(allocator, config);
     } else if (std.mem.eql(u8, cmd, "update")) {
         doUpdate(allocator, config, sub_arg) catch |err| {
-            if (err == error.NotInstalled or err == error.GitFailed) std.process.exit(1);
+            if (err == error.NotInstalled or err == error.GitFailed or err == error.CopyFailed) std.process.exit(1);
             return err;
         };
     } else if (std.mem.eql(u8, cmd, "verify")) {

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -2,7 +2,12 @@ const std = @import("std");
 const platform = @import("platform.zig");
 const builtin = @import("builtin");
 
-const dylib_ext = if (builtin.os.tag == .macos) ".dylib" else ".so";
+const dylib_ext = if (builtin.os.tag == .macos)
+    ".dylib"
+else if (builtin.os.tag == .windows)
+    ".dll"
+else
+    ".so";
 const version = @import("build_options").version;
 
 const crash = @import("crash.zig");
@@ -16,13 +21,13 @@ pub const panic = crash.PanicHandler("thottam");
 const semver = @import("thottam_semver.zig");
 const proc = @import("thottam_proc.zig");
 const state = @import("thottam_state.zig");
+const tfs = @import("thottam_fs.zig");
 
 const Semver = semver.Semver;
 const parseConstraints = semver.parseConstraints;
 const matchesAllConstraints = semver.matchesAllConstraints;
 const isConstraintSpec = semver.isConstraintSpec;
 
-const runCapture = proc.runCapture;
 const runPassthrough = proc.runPassthrough;
 const runGit = proc.runGit;
 const runGitCapture = proc.runGitCapture;
@@ -240,46 +245,29 @@ fn getPkgManifest(allocator: std.mem.Allocator, src_dir: []const u8, pkg: []cons
     return m;
 }
 
-fn copyDir(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
-    const exit_code = try runPassthrough(allocator, &.{ "/bin/cp", "-R", src, dst }, null);
-    if (exit_code != 0) return error.CopyFailed;
-}
-
 pub fn removeDir(allocator: std.mem.Allocator, path: []const u8) !void {
-    _ = try runPassthrough(allocator, &.{ "/bin/rm", "-rf", path }, null);
+    try tfs.removeTree(allocator, path);
 }
 
 fn copyDylibsFromPkg(allocator: std.mem.Allocator, pkg_dir: []const u8, lib_dir: []const u8) !u32 {
-    const pattern = try std.mem.concat(allocator, u8, &.{ "*", dylib_ext });
-    defer allocator.free(pattern);
-    const output = runCapture(allocator, &.{
-        "/usr/bin/find", pkg_dir, "-maxdepth", "1", "-name", pattern, "-print",
-    }, null) catch return 0;
-    defer allocator.free(output);
+    var names = tfs.collectFilesWithSuffix(allocator, pkg_dir, dylib_ext, false) catch return 0;
+    defer tfs.freePathList(allocator, &names);
     var count: u32 = 0;
-    var lines = std.mem.splitScalar(u8, output, '\n');
-    while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        const basename = std.fs.path.basename(line);
+    for (names.items) |basename| {
+        const src = joinPath(allocator, pkg_dir, basename) catch continue;
+        defer allocator.free(src);
         const dst = joinPath(allocator, lib_dir, basename) catch continue;
         defer allocator.free(dst);
-        _ = runPassthrough(allocator, &.{ "/bin/cp", line, dst }, null) catch continue;
+        tfs.copyFile(allocator, src, dst) catch continue;
         count += 1;
     }
     return count;
 }
 
 fn removeDylibsFromPkg(allocator: std.mem.Allocator, pkg_dir: []const u8, lib_dir: []const u8) !void {
-    const pattern = try std.mem.concat(allocator, u8, &.{ "*", dylib_ext });
-    defer allocator.free(pattern);
-    const output = runCapture(allocator, &.{
-        "/usr/bin/find", pkg_dir, "-maxdepth", "1", "-name", pattern, "-print",
-    }, null) catch return;
-    defer allocator.free(output);
-    var lines = std.mem.splitScalar(u8, output, '\n');
-    while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        const basename = std.fs.path.basename(line);
+    var names = tfs.collectFilesWithSuffix(allocator, pkg_dir, dylib_ext, false) catch return;
+    defer tfs.freePathList(allocator, &names);
+    for (names.items) |basename| {
         const target = joinPath(allocator, lib_dir, basename) catch continue;
         defer allocator.free(target);
         const target_z = allocator.dupeZ(u8, target) catch continue;
@@ -289,27 +277,51 @@ fn removeDylibsFromPkg(allocator: std.mem.Allocator, pkg_dir: []const u8, lib_di
 }
 
 fn removeSldFiles(allocator: std.mem.Allocator, pkg_lib_dir: []const u8, lib_dir: []const u8) !void {
-    const output = runCapture(allocator, &.{
-        "/usr/bin/find", pkg_lib_dir, "-name", "*.sld", "-print",
-    }, null) catch return;
-    defer allocator.free(output);
-    var lines = std.mem.splitScalar(u8, output, '\n');
-    while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        if (std.mem.startsWith(u8, line, pkg_lib_dir)) {
-            const rel = line[pkg_lib_dir.len..];
-            const target = std.mem.concat(allocator, u8, &.{ lib_dir, rel }) catch continue;
-            defer allocator.free(target);
-            const target_z = allocator.dupeZ(u8, target) catch continue;
-            defer allocator.free(target_z);
-            _ = platform.unlink(target_z);
-        }
+    var rels = tfs.collectFilesWithSuffix(allocator, pkg_lib_dir, ".sld", true) catch return;
+    defer tfs.freePathList(allocator, &rels);
+    for (rels.items) |rel| {
+        const target = joinPath(allocator, lib_dir, rel) catch continue;
+        defer allocator.free(target);
+        const target_z = allocator.dupeZ(u8, target) catch continue;
+        defer allocator.free(target_z);
+        _ = platform.unlink(target_z);
     }
 }
 
 fn printBuf(buf: []u8, comptime fmt: []const u8, args: anytype) void {
     const msg = std.fmt.bufPrint(buf, fmt, args) catch return;
     writeStdout(msg);
+}
+
+/// Run a package's `build:` line from kaappi.pkg. POSIX gets `/bin/sh -c`
+/// exactly as before. Windows has no /bin/sh, and every ecosystem `build:`
+/// is a Makefile producing POSIX shared libraries — refuse with a clear
+/// error rather than half-run something; pure-Scheme packages (no `build:`
+/// line, most of the ecosystem) never reach this.
+fn runBuildCommand(allocator: std.mem.Allocator, pkg: []const u8, build_cmd: []const u8, pkg_dir: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    if (comptime platform.is_windows) {
+        printErrColor(Color.red, "error: ");
+        const msg = std.fmt.bufPrint(&buf, "{s} has a 'build:' command in kaappi.pkg; building native packages is not supported on Windows (pure-Scheme packages install fine)\n", .{pkg}) catch "package 'build:' commands are not supported on Windows\n";
+        writeStderr(msg);
+        return error.BuildFailed;
+    }
+    printBuf(&buf, "  Building {s}...\n", .{pkg});
+    const exit_code = runPassthrough(allocator, &.{ "/bin/sh", "-c", build_cmd }, pkg_dir) catch 1;
+    if (exit_code != 0) {
+        printErrColor(Color.red, "  Build failed\n");
+        return error.BuildFailed;
+    }
+}
+
+/// Merge the contents of a package's lib/ into the shared lib dir — the
+/// `cp -R lib/. dst/` shape this replaced: existing files are overwritten
+/// (updates re-copy), unrelated files in dst survive. Non-fatal like the
+/// old ignored cp exit code, but say so when something goes wrong.
+fn installLibTree(allocator: std.mem.Allocator, lib_src: []const u8, lib_dir: []const u8) void {
+    tfs.copyTree(allocator, lib_src, lib_dir) catch {
+        printErrColor(Color.yellow, "  warning: failed to install some library files\n");
+    };
 }
 
 fn printColor(comptime color: []const u8, text: []const u8) void {
@@ -477,12 +489,7 @@ fn doInstall(
         }
 
         if (manifest.build_cmd) |build_cmd| {
-            printBuf(&buf, "  Building {s}...\n", .{pkg});
-            const exit_code = runPassthrough(allocator, &.{ "/bin/sh", "-c", build_cmd }, pkg_dir) catch 1;
-            if (exit_code != 0) {
-                printErrColor(Color.red, "  Build failed\n");
-                return error.BuildFailed;
-            }
+            try runBuildCommand(allocator, pkg, build_cmd, pkg_dir);
         }
     }
 
@@ -490,15 +497,7 @@ fn doInstall(
     defer allocator.free(lib_src);
     if (dirExists(allocator, lib_src)) {
         writeStdout("  Installing libraries...\n");
-        // "src/." copies the directory CONTENTS on both BSD and GNU cp.
-        // A trailing "/" only means that on BSD; GNU cp copies the directory
-        // itself, nesting libraries under lib/lib/ where the loader never
-        // finds them.
-        const src_glob = try std.mem.concat(allocator, u8, &.{ lib_src, "/." });
-        defer allocator.free(src_glob);
-        const dst_glob = try std.mem.concat(allocator, u8, &.{ config.lib_dir, "/" });
-        defer allocator.free(dst_glob);
-        _ = runPassthrough(allocator, &.{ "/bin/cp", "-R", src_glob, dst_glob }, null) catch {};
+        installLibTree(allocator, lib_src, config.lib_dir);
     }
 
     const dylib_count = try copyDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
@@ -640,25 +639,14 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
         if (getPkgManifest(allocator, config.src_dir, p)) |manifest| {
             defer manifest.deinit(allocator);
             if (manifest.build_cmd) |build_cmd| {
-                var build_buf: [256]u8 = undefined;
-                printBuf(&build_buf, "  Building {s}...\n", .{p});
-                const exit_code = runPassthrough(allocator, &.{ "/bin/sh", "-c", build_cmd }, pkg_dir) catch 1;
-                if (exit_code != 0) {
-                    printErrColor(Color.red, "  Build failed\n");
-                    return error.BuildFailed;
-                }
+                try runBuildCommand(allocator, p, build_cmd, pkg_dir);
             }
         }
 
         const lib_src = try joinPath(allocator, pkg_dir, "lib");
         defer allocator.free(lib_src);
         if (dirExists(allocator, lib_src)) {
-            // "src/." — see doInstall: portable contents-copy for BSD and GNU cp.
-            const src_glob = try std.mem.concat(allocator, u8, &.{ lib_src, "/." });
-            defer allocator.free(src_glob);
-            const dst_glob = try std.mem.concat(allocator, u8, &.{ config.lib_dir, "/" });
-            defer allocator.free(dst_glob);
-            _ = runPassthrough(allocator, &.{ "/bin/cp", "-R", src_glob, dst_glob }, null) catch {};
+            installLibTree(allocator, lib_src, config.lib_dir);
         }
 
         _ = try copyDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
@@ -785,7 +773,10 @@ pub fn getenv(name: [*:0]const u8) ?[]const u8 {
 
 fn buildConfig(allocator: std.mem.Allocator) !Config {
     const home = getenv("KAAPPI_HOME") orelse blk: {
-        const user_home = getenv("HOME") orelse fatal("HOME not set");
+        // Windows shells set USERPROFILE, not HOME (git-bash sets both).
+        const user_home = getenv("HOME") orelse
+            (if (platform.is_windows) getenv("USERPROFILE") else null) orelse
+            fatal(if (platform.is_windows) "neither HOME nor USERPROFILE is set" else "HOME not set");
         break :blk try std.mem.concat(allocator, u8, &.{ user_home, "/.kaappi" });
     };
     const org = getenv("KAAPPI_ORG") orelse "https://github.com/kaappi";
@@ -801,13 +792,10 @@ fn buildConfig(allocator: std.mem.Allocator) !Config {
 }
 
 fn ensureDirs(allocator: std.mem.Allocator, config: Config) void {
-    const lib_z = allocator.dupeZ(u8, config.lib_dir) catch return;
-    defer allocator.free(lib_z);
-    const src_z = allocator.dupeZ(u8, config.src_dir) catch return;
-    defer allocator.free(src_z);
-    _ = runPassthrough(allocator, &.{ "/bin/mkdir", "-p", config.lib_dir, config.src_dir }, null) catch {};
+    tfs.makeDirRecursive(allocator, config.lib_dir) catch {};
+    tfs.makeDirRecursive(allocator, config.src_dir) catch {};
     if (!fileExists(allocator, config.installed)) {
-        _ = runPassthrough(allocator, &.{ "/usr/bin/touch", config.installed }, null) catch {};
+        tfs.touchFile(allocator, config.installed) catch {};
     }
 }
 
@@ -864,19 +852,6 @@ pub fn main(init: std.process.Init.Minimal) !void {
         return;
     };
 
-    // Package installation shells out to POSIX userland (cp -R, find,
-    // sh -c for build commands) that Windows doesn't have; the read-only
-    // subcommands work everywhere. Gate the mutating ones until the
-    // install pipeline is reimplemented on the platform shim.
-    if (comptime platform.is_windows) {
-        const mutating = std.mem.eql(u8, cmd, "install") or
-            std.mem.eql(u8, cmd, "remove") or std.mem.eql(u8, cmd, "update");
-        if (mutating) {
-            writeStderr("thottam: package installation is not yet supported on Windows\n");
-            std.process.exit(1);
-        }
-    }
-
     if (std.mem.eql(u8, cmd, "install")) {
         const spec = sub_arg orelse {
             writeStderr("Usage: thottam install <package>[@<version>][::url]\n");
@@ -914,6 +889,15 @@ pub fn main(init: std.process.Init.Minimal) !void {
     }
 }
 
+// Pull in the sibling modules' tests: the test binary's root is this file,
+// and Zig only collects tests from files referenced by a test block.
+test {
+    _ = semver;
+    _ = proc;
+    _ = state;
+    _ = tfs;
+}
+
 test "markVisited copies keys so freed dependency names stay valid (issue #784)" {
     const allocator = std.testing.allocator;
     var visited = std.StringHashMap(void).init(allocator);
@@ -931,6 +915,8 @@ test "markVisited copies keys so freed dependency names stay valid (issue #784)"
 test "dylib_ext is correct for platform" {
     if (builtin.os.tag == .macos) {
         try std.testing.expectEqualStrings(".dylib", dylib_ext);
+    } else if (builtin.os.tag == .windows) {
+        try std.testing.expectEqualStrings(".dll", dylib_ext);
     } else {
         try std.testing.expectEqualStrings(".so", dylib_ext);
     }

--- a/src/thottam_fs.zig
+++ b/src/thottam_fs.zig
@@ -77,10 +77,13 @@ fn removeIfLink(z: [:0]const u8) !void {
     const st = platform.lstatPath(z) orelse return;
     if (!st.is_symlink) return;
     if (st.is_dir) {
-        // Windows directory junction/symlink: rmdir removes the link.
+        // Windows directory junction/symlink: rmdir removes the link
+        // (READONLY isn't honored on directory objects).
         if (platform.rmdir(z) != 0) return error.CopyFailed;
     } else {
-        if (platform.unlink(z) != 0) return error.CopyFailed;
+        // DeleteFile does honor READONLY on the link object itself, so
+        // retry through makeWritable like every other unlink here.
+        try unlinkRetry(z, null);
     }
 }
 
@@ -526,15 +529,21 @@ test "copyTree skips source symlinks and replaces destination symlinks (POSIX)" 
         const leak = try std.mem.concat(allocator, u8, &.{ base, "/src/leak.sld" });
         defer allocator.free(leak);
         try mklink(allocator, outside, leak);
+        const plain = try std.mem.concat(allocator, u8, &.{ base, "/src/plain.sld" });
+        defer allocator.free(plain);
+        try thottam.writeFile(allocator, plain, "P");
 
-        // Destination pre-planted with links: a file link where real.sld's
-        // parent dir will merge, and a dir link where kaappi/ will merge.
+        // Destination pre-planted with links: a file link where plain.sld
+        // will land, and a dir link where kaappi/ will merge.
         const dst = try std.mem.concat(allocator, u8, &.{ base, "/dst" });
         defer allocator.free(dst);
         try makeDirRecursive(allocator, dst);
         const dst_dirlink = try std.mem.concat(allocator, u8, &.{ dst, "/kaappi" });
         defer allocator.free(dst_dirlink);
         try mklink(allocator, outside_dir, dst_dirlink);
+        const dst_filelink = try std.mem.concat(allocator, u8, &.{ dst, "/plain.sld" });
+        defer allocator.free(dst_filelink);
+        try mklink(allocator, outside, dst_filelink);
         const src_root = try std.mem.concat(allocator, u8, &.{ base, "/src" });
         defer allocator.free(src_root);
 
@@ -544,6 +553,19 @@ test "copyTree skips source symlinks and replaces destination symlinks (POSIX)" 
         const leak_dst = try std.mem.concat(allocator, u8, &.{ dst, "/leak.sld" });
         defer allocator.free(leak_dst);
         try std.testing.expect(!thottam.fileExists(allocator, leak_dst));
+
+        // Destination file link replaced by a real file; the link's old
+        // target was not written through.
+        const dst_filelink_z = try allocator.dupeZ(u8, dst_filelink);
+        defer allocator.free(dst_filelink_z);
+        const plain_after = platform.lstatPath(dst_filelink_z) orelse return error.TestUnexpectedResult;
+        try std.testing.expect(!plain_after.is_symlink);
+        const plain_content = try thottam.readFile(allocator, dst_filelink);
+        defer allocator.free(plain_content);
+        try std.testing.expectEqualStrings("P", plain_content);
+        const outside_content = try thottam.readFile(allocator, outside);
+        defer allocator.free(outside_content);
+        try std.testing.expectEqualStrings("secret", outside_content);
 
         // Destination dir link replaced by a real directory; nothing
         // leaked into its old target.

--- a/src/thottam_fs.zig
+++ b/src/thottam_fs.zig
@@ -67,13 +67,19 @@ pub fn touchFile(allocator: std.mem.Allocator, path: []const u8) !void {
     platform.close(fd);
 }
 
-/// Byte-copy src over dst (created 0o644, truncated if present). Follows a
-/// src symlink — matching `cp`, which copies the target's content.
+/// Byte-copy src over dst (created 0o644, truncated if present). Opening
+/// src follows a symlink — `cp <link> dst` copies the target's content —
+/// but a dst that is itself a symlink is unlinked first: writing through
+/// it would land outside the tree the caller is installing into.
 pub fn copyFile(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
     const src_z = try allocator.dupeZ(u8, src);
     defer allocator.free(src_z);
     const dst_z = try allocator.dupeZ(u8, dst);
     defer allocator.free(dst_z);
+
+    if (platform.lstatPath(dst_z)) |dst_st| {
+        if (dst_st.is_symlink) _ = platform.unlink(dst_z);
+    }
 
     const in = platform.openRead(src_z) catch return error.CopyFailed;
     defer platform.close(in);
@@ -133,9 +139,10 @@ fn freeNames(allocator: std.mem.Allocator, names: *std.ArrayList([]u8)) void {
 /// `cp -R src/. dst/`: recursively merge the *contents* of src into dst,
 /// creating dst (and any missing parents) first. Existing files are
 /// overwritten, existing subdirectories merged into — `thottam update`
-/// relies on both. A symlink to a regular file is copied by content (the
-/// common `libfoo.so -> libfoo.so.1` shape); directory symlinks are
-/// skipped, never followed.
+/// relies on both. Symlinks in src are skipped, never followed: reading
+/// through a package-controlled link would copy content from outside the
+/// package tree (old `cp -R` duplicated links instead of following them,
+/// and ecosystem lib/ trees contain none).
 pub fn copyTree(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
     try makeDirRecursive(allocator, dst);
 
@@ -151,12 +158,8 @@ pub fn copyTree(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) 
         defer allocator.free(child_dst);
 
         const st = lstat(allocator, child_src) orelse continue;
-        if (st.is_symlink) {
-            const target_z = try allocator.dupeZ(u8, child_src);
-            defer allocator.free(target_z);
-            const target = platform.statPath(target_z) orelse continue;
-            if (target.is_file) try copyFile(allocator, child_src, child_dst);
-        } else if (st.is_dir) {
+        if (st.is_symlink) continue;
+        if (st.is_dir) {
             try copyTree(allocator, child_src, child_dst);
         } else if (st.is_file) {
             try copyFile(allocator, child_src, child_dst);
@@ -462,6 +465,48 @@ test "removeTree unlinks symlinks without following them (POSIX)" {
         defer allocator.free(tree_z);
         try std.testing.expect(!platform.pathExists(tree_z));
         try std.testing.expect(thottam.fileExists(allocator, precious));
+    } else return error.SkipZigTest;
+}
+
+test "copyTree skips symlinks instead of following them (POSIX)" {
+    if (comptime !platform.is_windows and builtin.os.tag != .wasi) {
+        const c = struct {
+            extern "c" fn symlink(target: [*:0]const u8, linkpath: [*:0]const u8) c_int;
+        };
+        const allocator = std.testing.allocator;
+        var buf: [512]u8 = undefined;
+        const base = try testBase(&buf, "cplink");
+        defer removeTree(allocator, base) catch {};
+
+        const outside = try std.mem.concat(allocator, u8, &.{ base, "/outside.txt" });
+        defer allocator.free(outside);
+        try makeDirRecursive(allocator, base);
+        try thottam.writeFile(allocator, outside, "secret");
+
+        const src = try std.mem.concat(allocator, u8, &.{ base, "/src" });
+        defer allocator.free(src);
+        try makeDirRecursive(allocator, src);
+        const real = try std.mem.concat(allocator, u8, &.{ src, "/real.sld" });
+        defer allocator.free(real);
+        try thottam.writeFile(allocator, real, "R");
+        const link = try std.mem.concat(allocator, u8, &.{ src, "/leak.sld" });
+        defer allocator.free(link);
+        const outside_z = try allocator.dupeZ(u8, outside);
+        defer allocator.free(outside_z);
+        const link_z = try allocator.dupeZ(u8, link);
+        defer allocator.free(link_z);
+        try std.testing.expect(c.symlink(outside_z, link_z) == 0);
+
+        const dst = try std.mem.concat(allocator, u8, &.{ base, "/dst" });
+        defer allocator.free(dst);
+        try copyTree(allocator, src, dst);
+
+        const real_dst = try std.mem.concat(allocator, u8, &.{ dst, "/real.sld" });
+        defer allocator.free(real_dst);
+        try std.testing.expect(thottam.fileExists(allocator, real_dst));
+        const leak_dst = try std.mem.concat(allocator, u8, &.{ dst, "/leak.sld" });
+        defer allocator.free(leak_dst);
+        try std.testing.expect(!thottam.fileExists(allocator, leak_dst));
     } else return error.SkipZigTest;
 }
 

--- a/src/thottam_fs.zig
+++ b/src/thottam_fs.zig
@@ -1,0 +1,502 @@
+//! Portable filesystem operations for thottam's install pipeline (#1609).
+//!
+//! Before the Windows port, install/remove/update shelled out to POSIX
+//! userland (`/bin/cp -R`, `/usr/bin/find`, `/bin/mkdir -p`, `/bin/rm -rf`,
+//! `/usr/bin/touch`). These helpers reimplement exactly that surface on the
+//! platform shim so the pipeline behaves identically on every target —
+//! Windows included — and spawns no processes for file work.
+//!
+//! Symlinks are never traversed (platform.lstatPath): a link inside a
+//! package tree can point anywhere, and following one during removal or
+//! copy would escape the tree. Removal retries once through
+//! platform.makeWritable — git marks object/pack files read-only, which
+//! blocks plain unlink on Windows (and unwritable directories block child
+//! unlinks on POSIX).
+
+const std = @import("std");
+const builtin = @import("builtin");
+const platform = @import("platform.zig");
+
+fn isSep(c: u8) bool {
+    return c == '/' or (platform.is_windows and c == '\\');
+}
+
+fn join(allocator: std.mem.Allocator, a: []const u8, b: []const u8) ![]u8 {
+    const result = try allocator.alloc(u8, a.len + 1 + b.len);
+    @memcpy(result[0..a.len], a);
+    result[a.len] = '/';
+    @memcpy(result[a.len + 1 ..], b);
+    return result;
+}
+
+fn lstat(allocator: std.mem.Allocator, path: []const u8) ?platform.StatInfo {
+    const z = allocator.dupeZ(u8, path) catch return null;
+    defer allocator.free(z);
+    return platform.lstatPath(z);
+}
+
+/// `mkdir -p`: creates every missing component, succeeds if the directory
+/// already exists. Intermediate mkdir failures are resolved by the final
+/// check — the path must be a directory when we're done.
+pub fn makeDirRecursive(allocator: std.mem.Allocator, path: []const u8) !void {
+    var p = path;
+    while (p.len > 1 and isSep(p[p.len - 1])) p = p[0 .. p.len - 1];
+    if (p.len == 0) return error.MkdirFailed;
+
+    var end: usize = 0;
+    while (end < p.len) {
+        while (end < p.len and !isSep(p[end])) end += 1;
+        if (end > 0) {
+            const prefix = try allocator.dupeZ(u8, p[0..end]);
+            defer allocator.free(prefix);
+            _ = platform.mkdir(prefix, 0o755);
+        }
+        while (end < p.len and isSep(p[end])) end += 1;
+    }
+
+    const z = try allocator.dupeZ(u8, p);
+    defer allocator.free(z);
+    if (!platform.isDir(z)) return error.MkdirFailed;
+}
+
+/// `touch`: creates the file if missing, never truncates existing content.
+pub fn touchFile(allocator: std.mem.Allocator, path: []const u8) !void {
+    const z = try allocator.dupeZ(u8, path);
+    defer allocator.free(z);
+    const fd = platform.openAppend(z, 0o644) catch return error.TouchFailed;
+    platform.close(fd);
+}
+
+/// Byte-copy src over dst (created 0o644, truncated if present). Follows a
+/// src symlink — matching `cp`, which copies the target's content.
+pub fn copyFile(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
+    const src_z = try allocator.dupeZ(u8, src);
+    defer allocator.free(src_z);
+    const dst_z = try allocator.dupeZ(u8, dst);
+    defer allocator.free(dst_z);
+
+    const in = platform.openRead(src_z) catch return error.CopyFailed;
+    defer platform.close(in);
+    const out = platform.openWriteTrunc(dst_z, 0o644) catch return error.CopyFailed;
+    defer platform.close(out);
+
+    var buf: [16384]u8 = undefined;
+    while (true) {
+        const raw = platform.read(in, &buf, buf.len);
+        if (raw < 0) {
+            if (platform.errno(raw) == .INTR) continue;
+            return error.CopyFailed;
+        }
+        const n: usize = @intCast(raw);
+        if (n == 0) return;
+        var total: usize = 0;
+        while (total < n) {
+            const w = platform.write(out, buf[total..].ptr, n - total);
+            if (w < 0) {
+                if (platform.errno(w) == .INTR) continue;
+                return error.CopyFailed;
+            }
+            if (w == 0) return error.CopyFailed;
+            total += @as(usize, @intCast(w));
+        }
+    }
+}
+
+/// Snapshot a directory's entry names (skipping "." and "..") so the
+/// caller can recurse or delete without a live iterator underneath —
+/// DirIter yields views into per-iterator state, and mutating a directory
+/// mid-iteration is undefined on both readdir and FindNextFileW.
+fn collectNames(allocator: std.mem.Allocator, dir_z: [:0]const u8) !?std.ArrayList([]u8) {
+    var it = platform.DirIter.open(dir_z) orelse return null;
+    defer it.close();
+    var names: std.ArrayList([]u8) = .empty;
+    errdefer {
+        for (names.items) |n| allocator.free(n);
+        names.deinit(allocator);
+    }
+    while (it.next()) |name| {
+        if (std.mem.eql(u8, name, ".") or std.mem.eql(u8, name, "..")) continue;
+        const copy = try allocator.dupe(u8, name);
+        names.append(allocator, copy) catch |err| {
+            allocator.free(copy);
+            return err;
+        };
+    }
+    return names;
+}
+
+fn freeNames(allocator: std.mem.Allocator, names: *std.ArrayList([]u8)) void {
+    for (names.items) |n| allocator.free(n);
+    names.deinit(allocator);
+}
+
+/// `cp -R src/. dst/`: recursively merge the *contents* of src into dst,
+/// creating dst (and any missing parents) first. Existing files are
+/// overwritten, existing subdirectories merged into — `thottam update`
+/// relies on both. A symlink to a regular file is copied by content (the
+/// common `libfoo.so -> libfoo.so.1` shape); directory symlinks are
+/// skipped, never followed.
+pub fn copyTree(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
+    try makeDirRecursive(allocator, dst);
+
+    const src_z = try allocator.dupeZ(u8, src);
+    defer allocator.free(src_z);
+    var names = (try collectNames(allocator, src_z)) orelse return error.CopyFailed;
+    defer freeNames(allocator, &names);
+
+    for (names.items) |name| {
+        const child_src = try join(allocator, src, name);
+        defer allocator.free(child_src);
+        const child_dst = try join(allocator, dst, name);
+        defer allocator.free(child_dst);
+
+        const st = lstat(allocator, child_src) orelse continue;
+        if (st.is_symlink) {
+            const target_z = try allocator.dupeZ(u8, child_src);
+            defer allocator.free(target_z);
+            const target = platform.statPath(target_z) orelse continue;
+            if (target.is_file) try copyFile(allocator, child_src, child_dst);
+        } else if (st.is_dir) {
+            try copyTree(allocator, child_src, child_dst);
+        } else if (st.is_file) {
+            try copyFile(allocator, child_src, child_dst);
+        }
+    }
+}
+
+/// Unlink with one retry after clearing write protection: the child's
+/// read-only attribute blocks unlink on Windows; on POSIX it's the parent
+/// directory's write bit that gates unlinking entries.
+fn unlinkRetry(child_z: [:0]const u8, parent_z: ?[:0]const u8) !void {
+    if (platform.unlink(child_z) == 0) return;
+    platform.makeWritable(child_z);
+    if (parent_z) |p| platform.makeWritable(p);
+    if (platform.unlink(child_z) != 0) return error.RemoveFailed;
+}
+
+fn rmdirRetry(dir_z: [:0]const u8) !void {
+    if (platform.rmdir(dir_z) == 0) return;
+    platform.makeWritable(dir_z);
+    if (platform.rmdir(dir_z) != 0) return error.RemoveFailed;
+}
+
+/// `rm -rf`: removes path and everything under it; succeeds silently when
+/// path doesn't exist. Symlinks are unlinked (POSIX) or rmdir'd (Windows
+/// directory junctions), never followed — a link out of the tree must not
+/// let removal escape it.
+pub fn removeTree(allocator: std.mem.Allocator, path: []const u8) !void {
+    const z = try allocator.dupeZ(u8, path);
+    defer allocator.free(z);
+    const st = platform.lstatPath(z) orelse return;
+    if (st.is_symlink) {
+        if (st.is_dir) return rmdirRetry(z);
+        return unlinkRetry(z, null);
+    }
+    if (!st.is_dir) return unlinkRetry(z, null);
+    return removeTreeInner(allocator, path, z);
+}
+
+fn removeTreeInner(allocator: std.mem.Allocator, dir: []const u8, dir_z: [:0]const u8) !void {
+    var names = (try collectNames(allocator, dir_z)) orelse blk: {
+        // An unreadable directory (POSIX --x or worse): make it
+        // traversable and retry once before giving up.
+        platform.makeWritable(dir_z);
+        break :blk (try collectNames(allocator, dir_z)) orelse return error.RemoveFailed;
+    };
+    defer freeNames(allocator, &names);
+
+    for (names.items) |name| {
+        const child = try join(allocator, dir, name);
+        defer allocator.free(child);
+        const child_z = try allocator.dupeZ(u8, child);
+        defer allocator.free(child_z);
+
+        const st = platform.lstatPath(child_z) orelse continue;
+        if (st.is_symlink) {
+            if (st.is_dir) {
+                try rmdirRetry(child_z);
+            } else {
+                try unlinkRetry(child_z, dir_z);
+            }
+        } else if (st.is_dir) {
+            try removeTreeInner(allocator, child, child_z);
+        } else {
+            try unlinkRetry(child_z, dir_z);
+        }
+    }
+
+    try rmdirRetry(dir_z);
+}
+
+/// `find root [-maxdepth 1] -name '*<suffix>'` for regular files: returns
+/// '/'-joined paths relative to root (a top-level match is just the file
+/// name). Symlinks to regular files count as matches (find matches names,
+/// and the install pipeline copies/removes their content counterpart);
+/// directory symlinks are never descended. A missing or unreadable root
+/// yields an empty list, like the old `find … | catch return` call sites;
+/// unreadable subdirectories are skipped.
+pub fn collectFilesWithSuffix(
+    allocator: std.mem.Allocator,
+    root: []const u8,
+    suffix: []const u8,
+    recursive: bool,
+) !std.ArrayList([]u8) {
+    var out: std.ArrayList([]u8) = .empty;
+    errdefer freePathList(allocator, &out);
+    try collectSuffixInner(allocator, root, "", suffix, recursive, &out);
+    return out;
+}
+
+pub fn freePathList(allocator: std.mem.Allocator, list: *std.ArrayList([]u8)) void {
+    for (list.items) |p| allocator.free(p);
+    list.deinit(allocator);
+}
+
+fn collectSuffixInner(
+    allocator: std.mem.Allocator,
+    dir: []const u8,
+    rel_prefix: []const u8,
+    suffix: []const u8,
+    recursive: bool,
+    out: *std.ArrayList([]u8),
+) !void {
+    const dir_z = try allocator.dupeZ(u8, dir);
+    defer allocator.free(dir_z);
+    var names = (try collectNames(allocator, dir_z)) orelse return;
+    defer freeNames(allocator, &names);
+
+    for (names.items) |name| {
+        const child = try join(allocator, dir, name);
+        defer allocator.free(child);
+
+        const st = lstat(allocator, child) orelse continue;
+        if (st.is_dir and !st.is_symlink) {
+            if (recursive) {
+                const child_prefix = try std.mem.concat(allocator, u8, &.{ rel_prefix, name, "/" });
+                defer allocator.free(child_prefix);
+                try collectSuffixInner(allocator, child, child_prefix, suffix, recursive, out);
+            }
+            continue;
+        }
+        if (!std.mem.endsWith(u8, name, suffix)) continue;
+
+        const is_match = st.is_file or (st.is_symlink and blk: {
+            const child_z = try allocator.dupeZ(u8, child);
+            defer allocator.free(child_z);
+            const target = platform.statPath(child_z) orelse break :blk false;
+            break :blk target.is_file;
+        });
+        if (!is_match) continue;
+
+        const rel = try std.mem.concat(allocator, u8, &.{ rel_prefix, name });
+        out.append(allocator, rel) catch |err| {
+            allocator.free(rel);
+            return err;
+        };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tests — each builds its tree under the platform temp dir and removes it
+// via removeTree (which is itself under test).
+// ---------------------------------------------------------------------------
+
+const thottam = @import("thottam.zig");
+
+fn testBase(buf: []u8, name: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}/kaappi-thottam-fs-{d}-{s}", .{ platform.tempDir(), platform.getPid(), name });
+}
+
+test "makeDirRecursive creates nested directories and is idempotent" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const base = try testBase(&buf, "mkdir");
+    defer removeTree(allocator, base) catch {};
+
+    const nested = try std.mem.concat(allocator, u8, &.{ base, "/a/b/c" });
+    defer allocator.free(nested);
+
+    try makeDirRecursive(allocator, nested);
+    const nested_z = try allocator.dupeZ(u8, nested);
+    defer allocator.free(nested_z);
+    try std.testing.expect(platform.isDir(nested_z));
+
+    // Idempotent on an existing tree.
+    try makeDirRecursive(allocator, nested);
+}
+
+test "touchFile creates an empty file and preserves existing content" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const base = try testBase(&buf, "touch");
+    defer removeTree(allocator, base) catch {};
+    try makeDirRecursive(allocator, base);
+
+    const file = try std.mem.concat(allocator, u8, &.{ base, "/installed.txt" });
+    defer allocator.free(file);
+
+    try touchFile(allocator, file);
+    try std.testing.expect(thottam.fileExists(allocator, file));
+
+    try thottam.writeFile(allocator, file, "kaappi-json\n");
+    try touchFile(allocator, file);
+    const content = try thottam.readFile(allocator, file);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings("kaappi-json\n", content);
+}
+
+test "copyTree merges nested trees and overwrites existing files" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const base = try testBase(&buf, "copytree");
+    defer removeTree(allocator, base) catch {};
+
+    const src = try std.mem.concat(allocator, u8, &.{ base, "/src" });
+    defer allocator.free(src);
+    const dst = try std.mem.concat(allocator, u8, &.{ base, "/dst" });
+    defer allocator.free(dst);
+
+    const src_sub = try std.mem.concat(allocator, u8, &.{ src, "/kaappi/deep" });
+    defer allocator.free(src_sub);
+    try makeDirRecursive(allocator, src_sub);
+    const a_src = try std.mem.concat(allocator, u8, &.{ src, "/kaappi/a.sld" });
+    defer allocator.free(a_src);
+    try thottam.writeFile(allocator, a_src, "A-new");
+    const b_src = try std.mem.concat(allocator, u8, &.{ src, "/kaappi/deep/b.sld" });
+    defer allocator.free(b_src);
+    try thottam.writeFile(allocator, b_src, "B");
+
+    // Pre-existing destination: a stale a.sld to overwrite and an
+    // unrelated file that must survive the merge.
+    const dst_sub = try std.mem.concat(allocator, u8, &.{ dst, "/kaappi" });
+    defer allocator.free(dst_sub);
+    try makeDirRecursive(allocator, dst_sub);
+    const a_dst = try std.mem.concat(allocator, u8, &.{ dst, "/kaappi/a.sld" });
+    defer allocator.free(a_dst);
+    try thottam.writeFile(allocator, a_dst, "A-old");
+    const keep = try std.mem.concat(allocator, u8, &.{ dst, "/keep.txt" });
+    defer allocator.free(keep);
+    try thottam.writeFile(allocator, keep, "keep");
+
+    try copyTree(allocator, src, dst);
+
+    const a_after = try thottam.readFile(allocator, a_dst);
+    defer allocator.free(a_after);
+    try std.testing.expectEqualStrings("A-new", a_after);
+
+    const b_dst = try std.mem.concat(allocator, u8, &.{ dst, "/kaappi/deep/b.sld" });
+    defer allocator.free(b_dst);
+    const b_after = try thottam.readFile(allocator, b_dst);
+    defer allocator.free(b_after);
+    try std.testing.expectEqualStrings("B", b_after);
+
+    const keep_after = try thottam.readFile(allocator, keep);
+    defer allocator.free(keep_after);
+    try std.testing.expectEqualStrings("keep", keep_after);
+}
+
+test "removeTree deletes read-only files inside read-only directories (git object shape)" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const base = try testBase(&buf, "rmro");
+
+    const pack_dir = try std.mem.concat(allocator, u8, &.{ base, "/.git/objects/pack" });
+    defer allocator.free(pack_dir);
+    try makeDirRecursive(allocator, pack_dir);
+    const pack_file = try std.mem.concat(allocator, u8, &.{ pack_dir, "/pack-abc.pack" });
+    defer allocator.free(pack_file);
+    try thottam.writeFile(allocator, pack_file, "P");
+
+    const pack_file_z = try allocator.dupeZ(u8, pack_file);
+    defer allocator.free(pack_file_z);
+    platform.makeReadOnly(pack_file_z);
+    const pack_dir_z = try allocator.dupeZ(u8, pack_dir);
+    defer allocator.free(pack_dir_z);
+    platform.makeReadOnly(pack_dir_z);
+
+    try removeTree(allocator, base);
+    const base_z = try allocator.dupeZ(u8, base);
+    defer allocator.free(base_z);
+    try std.testing.expect(!platform.pathExists(base_z));
+}
+
+test "removeTree on a missing path succeeds like rm -rf" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const base = try testBase(&buf, "rmmissing");
+    try removeTree(allocator, base);
+}
+
+test "removeTree unlinks symlinks without following them (POSIX)" {
+    if (comptime !platform.is_windows and builtin.os.tag != .wasi) {
+        const c = struct {
+            extern "c" fn symlink(target: [*:0]const u8, linkpath: [*:0]const u8) c_int;
+        };
+        const allocator = std.testing.allocator;
+        var buf: [512]u8 = undefined;
+        const base = try testBase(&buf, "rmlink");
+        defer removeTree(allocator, base) catch {};
+
+        const outside = try std.mem.concat(allocator, u8, &.{ base, "/outside" });
+        defer allocator.free(outside);
+        try makeDirRecursive(allocator, outside);
+        const precious = try std.mem.concat(allocator, u8, &.{ outside, "/precious.txt" });
+        defer allocator.free(precious);
+        try thottam.writeFile(allocator, precious, "keep me");
+
+        const tree = try std.mem.concat(allocator, u8, &.{ base, "/tree" });
+        defer allocator.free(tree);
+        try makeDirRecursive(allocator, tree);
+        const link = try std.mem.concat(allocator, u8, &.{ tree, "/escape" });
+        defer allocator.free(link);
+        const outside_z = try allocator.dupeZ(u8, outside);
+        defer allocator.free(outside_z);
+        const link_z = try allocator.dupeZ(u8, link);
+        defer allocator.free(link_z);
+        try std.testing.expect(c.symlink(outside_z, link_z) == 0);
+
+        try removeTree(allocator, tree);
+
+        // The link is gone with the tree; its target survived untouched.
+        const tree_z = try allocator.dupeZ(u8, tree);
+        defer allocator.free(tree_z);
+        try std.testing.expect(!platform.pathExists(tree_z));
+        try std.testing.expect(thottam.fileExists(allocator, precious));
+    } else return error.SkipZigTest;
+}
+
+test "collectFilesWithSuffix: recursive relative paths and top-level-only mode" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const base = try testBase(&buf, "collect");
+    defer removeTree(allocator, base) catch {};
+
+    const sub = try std.mem.concat(allocator, u8, &.{ base, "/kaappi/net" });
+    defer allocator.free(sub);
+    try makeDirRecursive(allocator, sub);
+    inline for (.{ "top.sld", "kaappi/json.sld", "kaappi/net/tls.sld", "kaappi/readme.txt" }) |rel| {
+        const p = try std.mem.concat(allocator, u8, &.{ base, "/", rel });
+        defer allocator.free(p);
+        try thottam.writeFile(allocator, p, "x");
+    }
+
+    var found = try collectFilesWithSuffix(allocator, base, ".sld", true);
+    defer freePathList(allocator, &found);
+    try std.testing.expectEqual(@as(usize, 3), found.items.len);
+    for ([_][]const u8{ "top.sld", "kaappi/json.sld", "kaappi/net/tls.sld" }) |want| {
+        var seen = false;
+        for (found.items) |got| {
+            if (std.mem.eql(u8, got, want)) seen = true;
+        }
+        try std.testing.expect(seen);
+    }
+
+    var top_only = try collectFilesWithSuffix(allocator, base, ".sld", false);
+    defer freePathList(allocator, &top_only);
+    try std.testing.expectEqual(@as(usize, 1), top_only.items.len);
+    try std.testing.expectEqualStrings("top.sld", top_only.items[0]);
+
+    var missing = try collectFilesWithSuffix(allocator, "/nonexistent/kaappi-fs-test", ".sld", true);
+    defer freePathList(allocator, &missing);
+    try std.testing.expectEqual(@as(usize, 0), missing.items.len);
+}

--- a/src/thottam_fs.zig
+++ b/src/thottam_fs.zig
@@ -67,9 +67,26 @@ pub fn touchFile(allocator: std.mem.Allocator, path: []const u8) !void {
     platform.close(fd);
 }
 
+/// If `path` is a symlink (or Windows reparse point), remove the link
+/// itself — never its target. The copy pipeline calls this on every
+/// destination it is about to write or recurse into: creating content
+/// through a pre-existing link would land outside the install tree.
+/// Errors when a link is present but can't be removed, so the caller
+/// never falls through to writing through it.
+fn removeIfLink(z: [:0]const u8) !void {
+    const st = platform.lstatPath(z) orelse return;
+    if (!st.is_symlink) return;
+    if (st.is_dir) {
+        // Windows directory junction/symlink: rmdir removes the link.
+        if (platform.rmdir(z) != 0) return error.CopyFailed;
+    } else {
+        if (platform.unlink(z) != 0) return error.CopyFailed;
+    }
+}
+
 /// Byte-copy src over dst (created 0o644, truncated if present). Opening
 /// src follows a symlink — `cp <link> dst` copies the target's content —
-/// but a dst that is itself a symlink is unlinked first: writing through
+/// but a dst that is itself a symlink is removed first: writing through
 /// it would land outside the tree the caller is installing into.
 pub fn copyFile(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
     const src_z = try allocator.dupeZ(u8, src);
@@ -77,9 +94,7 @@ pub fn copyFile(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) 
     const dst_z = try allocator.dupeZ(u8, dst);
     defer allocator.free(dst_z);
 
-    if (platform.lstatPath(dst_z)) |dst_st| {
-        if (dst_st.is_symlink) _ = platform.unlink(dst_z);
-    }
+    try removeIfLink(dst_z);
 
     const in = platform.openRead(src_z) catch return error.CopyFailed;
     defer platform.close(in);
@@ -160,6 +175,14 @@ pub fn copyTree(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) 
         const st = lstat(allocator, child_src) orelse continue;
         if (st.is_symlink) continue;
         if (st.is_dir) {
+            // A pre-existing link at the destination child would make the
+            // recursion (and makeDirRecursive) create content through it,
+            // outside the tree. Only the merge's *children* are guarded:
+            // the root dst may legitimately be a symlink the user set up
+            // (cp follows a symlinked destination directory too).
+            const child_dst_z = try allocator.dupeZ(u8, child_dst);
+            defer allocator.free(child_dst_z);
+            try removeIfLink(child_dst_z);
             try copyTree(allocator, child_src, child_dst);
         } else if (st.is_file) {
             try copyFile(allocator, child_src, child_dst);
@@ -468,11 +491,20 @@ test "removeTree unlinks symlinks without following them (POSIX)" {
     } else return error.SkipZigTest;
 }
 
-test "copyTree skips symlinks instead of following them (POSIX)" {
+test "copyTree skips source symlinks and replaces destination symlinks (POSIX)" {
     if (comptime !platform.is_windows and builtin.os.tag != .wasi) {
         const c = struct {
             extern "c" fn symlink(target: [*:0]const u8, linkpath: [*:0]const u8) c_int;
         };
+        const mklink = struct {
+            fn mk(allocator: std.mem.Allocator, target: []const u8, linkpath: []const u8) !void {
+                const target_z = try allocator.dupeZ(u8, target);
+                defer allocator.free(target_z);
+                const link_z = try allocator.dupeZ(u8, linkpath);
+                defer allocator.free(link_z);
+                try std.testing.expect(c.symlink(target_z, link_z) == 0);
+            }
+        }.mk;
         const allocator = std.testing.allocator;
         var buf: [512]u8 = undefined;
         const base = try testBase(&buf, "cplink");
@@ -480,33 +512,52 @@ test "copyTree skips symlinks instead of following them (POSIX)" {
 
         const outside = try std.mem.concat(allocator, u8, &.{ base, "/outside.txt" });
         defer allocator.free(outside);
-        try makeDirRecursive(allocator, base);
+        const outside_dir = try std.mem.concat(allocator, u8, &.{ base, "/outside-dir" });
+        defer allocator.free(outside_dir);
+        try makeDirRecursive(allocator, outside_dir);
         try thottam.writeFile(allocator, outside, "secret");
 
-        const src = try std.mem.concat(allocator, u8, &.{ base, "/src" });
+        const src = try std.mem.concat(allocator, u8, &.{ base, "/src/kaappi" });
         defer allocator.free(src);
         try makeDirRecursive(allocator, src);
         const real = try std.mem.concat(allocator, u8, &.{ src, "/real.sld" });
         defer allocator.free(real);
         try thottam.writeFile(allocator, real, "R");
-        const link = try std.mem.concat(allocator, u8, &.{ src, "/leak.sld" });
-        defer allocator.free(link);
-        const outside_z = try allocator.dupeZ(u8, outside);
-        defer allocator.free(outside_z);
-        const link_z = try allocator.dupeZ(u8, link);
-        defer allocator.free(link_z);
-        try std.testing.expect(c.symlink(outside_z, link_z) == 0);
+        const leak = try std.mem.concat(allocator, u8, &.{ base, "/src/leak.sld" });
+        defer allocator.free(leak);
+        try mklink(allocator, outside, leak);
 
+        // Destination pre-planted with links: a file link where real.sld's
+        // parent dir will merge, and a dir link where kaappi/ will merge.
         const dst = try std.mem.concat(allocator, u8, &.{ base, "/dst" });
         defer allocator.free(dst);
-        try copyTree(allocator, src, dst);
+        try makeDirRecursive(allocator, dst);
+        const dst_dirlink = try std.mem.concat(allocator, u8, &.{ dst, "/kaappi" });
+        defer allocator.free(dst_dirlink);
+        try mklink(allocator, outside_dir, dst_dirlink);
+        const src_root = try std.mem.concat(allocator, u8, &.{ base, "/src" });
+        defer allocator.free(src_root);
 
-        const real_dst = try std.mem.concat(allocator, u8, &.{ dst, "/real.sld" });
-        defer allocator.free(real_dst);
-        try std.testing.expect(thottam.fileExists(allocator, real_dst));
+        try copyTree(allocator, src_root, dst);
+
+        // Source file link skipped, not followed.
         const leak_dst = try std.mem.concat(allocator, u8, &.{ dst, "/leak.sld" });
         defer allocator.free(leak_dst);
         try std.testing.expect(!thottam.fileExists(allocator, leak_dst));
+
+        // Destination dir link replaced by a real directory; nothing
+        // leaked into its old target.
+        const dst_dirlink_z = try allocator.dupeZ(u8, dst_dirlink);
+        defer allocator.free(dst_dirlink_z);
+        const replaced = platform.lstatPath(dst_dirlink_z) orelse return error.TestUnexpectedResult;
+        try std.testing.expect(!replaced.is_symlink);
+        try std.testing.expect(replaced.is_dir);
+        const real_dst = try std.mem.concat(allocator, u8, &.{ dst, "/kaappi/real.sld" });
+        defer allocator.free(real_dst);
+        try std.testing.expect(thottam.fileExists(allocator, real_dst));
+        const escaped = try std.mem.concat(allocator, u8, &.{ outside_dir, "/real.sld" });
+        defer allocator.free(escaped);
+        try std.testing.expect(!thottam.fileExists(allocator, escaped));
     } else return error.SkipZigTest;
 }
 

--- a/src/thottam_proc.zig
+++ b/src/thottam_proc.zig
@@ -184,8 +184,7 @@ test "checkoutVersion resolves a pinned tag as a ref, not a pathspec (issue #780
 
     if (!thottam.fileExists(allocator, "/usr/bin/git")) return error.SkipZigTest;
 
-    const base = thottam.getenv("TMPDIR") orelse "/tmp";
-    const repo = try std.fmt.allocPrint(allocator, "{s}/kaappi-thottam-780-{d}", .{ base, std.c.getpid() });
+    const repo = try std.fmt.allocPrint(allocator, "{s}/kaappi-thottam-780-{d}", .{ platform.tempDir(), platform.getPid() });
     defer allocator.free(repo);
     defer thottam.removeDir(allocator, repo) catch {};
     thottam.removeDir(allocator, repo) catch {};


### PR DESCRIPTION
Closes #1609.

`thottam install`/`remove`/`update` were gated on Windows because the install pipeline shelled out to POSIX userland (`/bin/cp -R`, `/usr/bin/find`, `/bin/mkdir -p`, `/bin/rm -rf`, `/usr/bin/touch`, `/bin/sh -c`). This PR replaces the file work with shim-based helpers so the pipeline runs identically on every platform, and lifts the gate.

## What changed

- **`src/thottam_fs.zig` (new)** — portable replacements for the shell-outs: `makeDirRecursive`, `touchFile`, `copyFile`, `copyTree` (the `cp -R src/. dst/` merge shape: overwrite files, merge dirs, keep unrelated dst files), `removeTree` (`rm -rf` semantics: silent on missing paths, retries through `makeWritable` — git marks object/pack files read-only, which blocks `_wunlink` on Windows), and `collectFilesWithSuffix` (both `find` shapes: `-maxdepth 1` for dylibs, recursive for `.sld`). Symlinks are never traversed — a link out of the package tree cannot let removal or copy escape it.
- **`src/platform.zig`** — `lstatPath` (no-follow stat: `fstatat(SYMLINK_NOFOLLOW)` / `statx` / `FindFirstFileW`, which reports a reparse point's own attributes), `makeWritable`/`makeReadOnly` (`_wchmod` / `chmod`), `is_symlink` on `StatInfo`.
- **`src/thottam.zig`** — call sites rewired onto the helpers; the Windows gate in `main()` is gone; `dylib_ext` is `.dll` on Windows; `HOME` falls back to `USERPROFILE` (also in `kaappi_paths.getHome`, so `kaappi` finds `~/.kaappi/lib` from plain pwsh/cmd — without that, install would work but imports wouldn't resolve).
- **`build:` decision** (per the issue): a manifest with a `build:` line is **refused on Windows with a clear per-package error** — every ecosystem `build:` is a Makefile producing POSIX shared libraries, so `cmd /c` would only fail confusingly later. Pure-Scheme packages (most of the ecosystem) have no `build:` line and install fine.

## Test-discovery fix in passing

`thottam-tests`' root is `thottam.zig`, and Zig only collects tests from files referenced by a `test` block — the existing `thottam_proc`/`thottam_state`/`thottam_semver` tests were silently absent from the binary (it ran exactly 2 tests). An aggregator block now pulls them in (36 tests), which also surfaced that the proc test's `std.c.getpid` didn't compile for Windows; it now uses the platform shim.

## Verification

- Full unit suite + thottam suite green on macOS; `zig build test -Dtarget=aarch64-windows` and `-Dtarget=x86_64-linux` compile clean; `zig build wasm` unaffected.
- New unit tests cover mkdir -p, touch, merge-copy/overwrite, removal of read-only files inside read-only dirs (the git-clone shape), missing-path removal, symlink non-traversal, and both find shapes — they run on POSIX CI and on the `windows-11-arm` runner via the newly staged `thottam-tests.exe`.
- End-to-end on macOS against local git fixture packages: install (clone → deps → build → lib merge → dylib copy → lockfile) → import from `KAAPPI_HOME` → list/verify/update → remove (sld + dylib + clone tree incl. read-only git objects). Transitive `depends:` and `build:` exercised.
- CI: `windows-arm-test` now runs `thottam-tests.exe` and a real `install kaappi-json` → import → `remove` integration step (mirroring the POSIX job's step) — removal deletes a real git clone, exactly the Windows read-only hazard.

Docs: `docs/dev/windows.md` degradation/known-gaps updated; README Windows paragraph mentions the thottam status. The end-user Windows page (kaappi.github.io#17) can drop the "no package install" caveat once this ships in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)