### PR TITLE
Fuzz #1620: fix two generator leaks + report-job misclassification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,9 +221,10 @@ jobs:
           path: bin
 
       - name: Unwrap archived artifact
-        # upload-artifact v7 archives by default and download-artifact v8
-        # hands the wrapper zip back as a file (same dance as fuzz.yml's
-        # report job). Windows ships bsdtar, which extracts zip.
+        # Safety net only: named downloads extract the artifact contents
+        # into `path` directly (loose files, so this loop normally has
+        # nothing to do — the wrapper-zip belief was a misdiagnosis, #1620).
+        # Windows ships bsdtar, which extracts zip if one ever appears.
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -233,12 +233,9 @@ jobs:
 
       # Each divergence comes with the program, both sides' stdout/stderr,
       # and the oracle version; the triage protocol lives in the script
-      # header (Kaappi bug / oracle bug / generator leak).
-      #
-      # upload-artifact v7+ defaults `archive: true` (and archive: false
-      # only supports a single file), so the artifact arrives at the report
-      # job as one wrapper zip. The report job unwraps it before marker
-      # detection — see its "Unwrap archived artifacts" step (#1429, #1584).
+      # header (Kaappi bug / oracle bug / generator leak). The report job's
+      # marker detection must stay layout-agnostic about where these files
+      # land — see the layout note in its filing step (#1584, #1620).
       - name: Upload divergences
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -259,7 +256,7 @@ jobs:
   #
   # To avoid false-positive finding issues, filing is gated on the finding
   # marker actually being present in the uploaded artifacts — the encoded
-  # crash input for the fuzz job, seed-<N>.scm divergences for the diff
+  # crash input for the fuzz job, per-seed divergence files for the diff
   # jobs. Failed jobs without their marker (toolchain/apt flakes, build or
   # unit-test failures, job-level timeouts — a possible hang) are collected
   # under a single "Fuzz CI: infrastructure or build failure" issue instead
@@ -279,21 +276,21 @@ jobs:
       actions: read # download this run's failure artifacts for the excerpt
     steps:
       # No checkout: the job needs nothing from the repo, and gh targets it
-      # via -R. Each artifact lands in its own subdirectory of artifacts/.
+      # via -R. Artifacts usually land in per-name subdirectories of
+      # artifacts/ — but not always; see the layout note in the filing step.
       - name: Download failure artifacts
         continue-on-error: true # a job may have died before its upload step
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
-      # upload-artifact v7+ archives by default (`archive: true`; false only
-      # supports a single file), and download-artifact v8 hands the wrapper
-      # zip back as a file instead of extracting it. Left wrapped, the
-      # finding markers below never match and every real finding is
-      # misclassified as an infrastructure failure (#1429, #1584 — the
-      # seed-2788 divergence was filed as "infrastructure or build failure").
-      # Unwrap in place so marker detection sees loose files under either
-      # upload behavior. Extraction only ever writes files for the excerpt
+      # Safety net for archived uploads: should an artifact ever arrive as a
+      # wrapper zip instead of loose files, unwrap it in place so marker
+      # detection sees the files. (This was NOT the cause of the past
+      # misclassifications: the #1584 and #1620 artifact containers held
+      # loose files all along — the real cause was download-artifact v8's
+      # single-artifact layout, handled in the filing step's marker
+      # detection below.) Extraction only ever writes files for the excerpt
       # below — this job still executes nothing from the artifacts.
       - name: Unwrap archived artifacts
         shell: bash
@@ -421,20 +418,35 @@ jobs:
           }
 
           # Finding markers: a real finding always ships in the artifact — the
-          # encoded crash input for the fuzz job, seed-<N>.scm divergences for the
-          # diff jobs. A failed job without its marker is a toolchain/apt flake, a
-          # build or unit-test failure, or a job-level timeout (a possible hang) —
-          # those are reported below under an honest title instead of a finding one.
-          crash=$(find artifacts -type f -path '*fuzz-artifacts-*' -name crash 2>/dev/null | head -1 || true)
+          # encoded crash input for the fuzz job, per-seed divergence files for
+          # the diff jobs. A failed job without its marker is a toolchain/apt
+          # flake, a build or unit-test failure, or a job-level timeout (a
+          # possible hang) — those are reported below under an honest title
+          # instead of a finding one.
+          #
+          # Layout: download-artifact v8 normally extracts each artifact into
+          # artifacts/<artifact-name>/, but when the run produced exactly ONE
+          # artifact it extracts into artifacts/ itself (the action's
+          # `artifacts.length === 1` special case) — and one failed job is the
+          # common case. So never anchor on the artifact-name directory: search
+          # all of artifacts/ for filenames only the owning job can produce
+          # (seed-*.kaappi.* vs seed-*.{vm,nat}.* keeps the two diff jobs'
+          # files apart even without directories), and derive each excerpt
+          # directory from the file that matched. Anchoring on the directory
+          # name is exactly how the seed-2788 (#1584) and seed-10294 (#1620)
+          # divergences got misfiled as "infrastructure or build failure".
+          crash=$(find artifacts -type f -path '*/.zig-cache/f/crash' 2>/dev/null | sort | head -1 || true)
           if [ -n "$crash" ]; then
             fuzz_dir="${crash%/.zig-cache/f/crash}"
           else
             # No crash, but a test-phase failure still uploads fuzz-run.log.
-            fuzz_dir=$(find artifacts -maxdepth 1 -type d -name 'fuzz-artifacts-*' 2>/dev/null | sort | head -1 || true)
-            fuzz_dir="${fuzz_dir:-artifacts/fuzz-artifacts-missing}"
+            fuzz_log=$(find artifacts -type f -name 'fuzz-run.log' 2>/dev/null | sort | head -1 || true)
+            fuzz_dir=$(dirname "${fuzz_log:-artifacts/fuzz-artifacts-missing/fuzz-run.log}")
           fi
-          native_marker=$(find artifacts/native-diff-divergences -name 'seed-*.scm' 2>/dev/null | head -1 || true)
-          oracle_marker=$(find artifacts/oracle-diff-divergences -name 'seed-*.scm' 2>/dev/null | head -1 || true)
+          native_marker=$(find artifacts -type f \( -name 'seed-*.vm.*' -o -name 'seed-*.nat.*' \) 2>/dev/null | sort | head -1 || true)
+          native_dir=$(dirname "${native_marker:-artifacts/native-diff-divergences/absent}")
+          oracle_marker=$(find artifacts -type f -name 'seed-*.kaappi.*' 2>/dev/null | sort | head -1 || true)
+          oracle_dir=$(dirname "${oracle_marker:-artifacts/oracle-diff-divergences/absent}")
 
           check_job "$RESULT_FUZZ" fuzz \
             'Fuzz CI: bounded fuzzing found a crash' \
@@ -443,12 +455,12 @@ jobs:
 
           check_job "$RESULT_NATIVE" native-diff \
             'Fuzz CI: VM vs native backend divergence' \
-            "$native_marker" artifacts/native-diff-divergences \
+            "$native_marker" "$native_dir" \
             'A generated program behaved differently on the bytecode VM vs the LLVM native backend. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{vm,nat}.{out,err}` and `seed-<N>.compile.log`. The seed base is printed near the top of the job log; the same seed always regenerates the same program: `bash tests/fuzz/native-diff.sh <count> <base>`.'
 
           check_job "$RESULT_ORACLE" oracle-diff \
             'Fuzz CI: Kaappi vs Chibi oracle divergence' \
-            "$oracle_marker" artifacts/oracle-diff-divergences \
+            "$oracle_marker" "$oracle_dir" \
             'Kaappi and Chibi Scheme disagreed on a portable-subset program. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{kaappi,chibi}.{out,err}`; `oracle-version.txt` records the oracle version. Triage protocol (Kaappi bug / oracle bug / generator leak) is in the header of `tests/fuzz/oracle-diff.sh`. Replay: `bash tests/fuzz/oracle-diff.sh <count> <base>`.'
 
           if [ -n "$infra_jobs" ]; then

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -146,15 +146,19 @@ issue by the trailing `report` job — one open issue per job, labeled
 first divergent program plus both sides' output, or the fuzzer transcript
 tail), and replay instructions. A finding-titled issue is only filed when
 the finding marker is actually present in the uploaded artifacts (the
-encoded crash input for the fuzz job, `seed-<N>.scm` divergences for the
+encoded crash input for the fuzz job, per-seed divergence files for the
 diff jobs); failed jobs without their marker — toolchain flakes, build or
 unit-test failures, job-level timeouts (a possible hang) — are collected
 under a single shared issue titled `Fuzz CI: infrastructure or build
-failure` instead. Because `upload-artifact` archives multi-file artifacts
-into a wrapper zip that `download-artifact` hands back un-extracted, the
-report job unwraps any `*.zip` under `artifacts/` before marker detection
-— skipping that step misclassifies every real finding as an
-infrastructure failure (#1429, #1584). While an issue stays open, repeat failures append
+failure` instead. Marker detection must not assume where inside
+`artifacts/` a file lands: `download-artifact` normally extracts each
+artifact into its own named subdirectory, but a run with exactly one
+artifact (one failed job — the common case) is extracted into `artifacts/`
+itself, so the report job searches the whole tree for filenames only the
+owning job can produce (`seed-*.kaappi.*` vs `seed-*.{vm,nat}.*`) —
+anchoring on the directory name is how the seed-2788 and seed-10294
+divergences were misfiled as infrastructure failures (#1584, #1620). While
+an issue stays open, repeat failures append
 comments to it instead of opening duplicates. Issues are never
 auto-closed: seed bases rotate nightly, so a later green run does not
 mean a finding is fixed — close the issue once the input is minimised

--- a/src/fuzz_gen.zig
+++ b/src/fuzz_gen.zig
@@ -68,6 +68,28 @@ const pattern_names = [_][]const u8{ "p", "q", "r" };
 
 pub const symbol_names = [_][]const u8{ "alpha", "beta", "boom", "zed" };
 
+/// String literal pool entry: the source text (with quotes) plus its length
+/// in codepoints — the unit every string index and length primitive uses.
+pub const StrLit = struct { text: []const u8, len: u16 };
+
+/// Build a pool entry with the length derived from the text at comptime. A
+/// hand-maintained count is a generator leak waiting to happen: "x y!" was
+/// recorded as len 5 (actually 4), so every index the generators derived
+/// from it — `(string-ref s 4)`, `(modulo i 5)` — could land out of range,
+/// making erroneous programs the oracle can't flag because both sides raise
+/// identically (#1620).
+pub fn strLit(comptime text: []const u8) StrLit {
+    comptime {
+        std.debug.assert(text.len >= 2 and text[0] == '"' and text[text.len - 1] == '"');
+        const inner = text[1 .. text.len - 1];
+        // Escape sequences would need their own length rules; the pools are
+        // escape-free, so reject rather than miscount.
+        std.debug.assert(std.mem.indexOfScalar(u8, inner, '\\') == null);
+        const n = std.unicode.utf8CountCodepoints(inner) catch unreachable;
+        return .{ .text = text, .len = n };
+    }
+}
+
 // Public: also referenced by the expression generators in fuzz_gen_expr.zig.
 pub const arith_ops = [_][]const u8{ "+", "-", "*", "min", "max" };
 pub const div_ops = [_][]const u8{ "quotient", "remainder", "modulo" };

--- a/src/fuzz_gen_data.zig
+++ b/src/fuzz_gen_data.zig
@@ -35,12 +35,12 @@ const real_round_ops = gen_mod.real_round_ops;
 const acc_modulus = gen_mod.acc_modulus;
 
 const char_lits = [_][]const u8{ "#\\a", "#\\b", "#\\z", "#\\0", "#\\space", "#\\newline", "#\\x3BB" };
-const string_lits = [_]struct { text: []const u8, len: u16 }{
-    .{ .text = "\"\"", .len = 0 },
-    .{ .text = "\"abc\"", .len = 3 },
-    .{ .text = "\"fuzz\"", .len = 4 },
-    .{ .text = "\"aλb\"", .len = 3 }, // multi-byte codepoint: UTF-8 index paths
-    .{ .text = "\"x y!\"", .len = 5 },
+const string_lits = [_]gen_mod.StrLit{
+    gen_mod.strLit("\"\""),
+    gen_mod.strLit("\"abc\""),
+    gen_mod.strLit("\"fuzz\""),
+    gen_mod.strLit("\"aλb\""), // multi-byte codepoint: UTF-8 index paths
+    gen_mod.strLit("\"x y!\""),
 };
 const flonum_lits = [_][]const u8{ "0.5", "-1.5", "2.25", "3.5", "-0.25", "100.0", "0.0" };
 const flonum_divisors = [_][]const u8{ "2.0", "4.0", "-8.0", "0.5" };

--- a/src/fuzz_gen_portable.zig
+++ b/src/fuzz_gen_portable.zig
@@ -810,6 +810,16 @@ fn genLetInt(g: *Gen, d: u32) Error!void {
 /// never a reference to an outer binding), mutates it, and computes an int
 /// from it — no sibling expression can observe the mutation. This is the
 /// only structure mutation allowed in expression position.
+///
+/// Ordering invariant (#1620): the constructor's sub-expressions sit in the
+/// let INIT (outer scope — generate them before registering the binding),
+/// but the mutation statement's index/value sub-expressions sit in the let
+/// BODY, where `name` shadows any outer binding. Reserve `name` before
+/// generating those, or the picker can reference an outer same-named int
+/// that now resolves to the fresh object (seed 10294 emitted
+/// `(bytevector-u8-set! c (modulo c 1) ...)` — a type error). The kind is
+/// upgraded from .reserved once the mutation statement is complete, so the
+/// body result may reference the mutated object.
 fn genLetMut(g: *Gen, d: u32) Error!void {
     var nb: [4][]const u8 = undefined;
     const names = g.pickNames(1, &nb);
@@ -827,22 +837,24 @@ fn genLetMut(g: *Gen, d: u32) Error!void {
             try g.emitf("(let (({s} (make-vector {d} ", .{ name, len });
             try genInt(g, d);
             try g.emitf("))) (vector-set! {s} ", .{name});
+            try g.pushBinding(name, .reserved);
             try genIndex(g, d, len);
             try g.emit(" ");
             try genInt(g, d);
             try g.emit(") ");
-            try g.pushBinding(name, .{ .vector = .{ .len = len, .boxed = false } });
+            g.scope.items[mark].kind = .{ .vector = .{ .len = len, .boxed = false } };
         },
         .str => {
             const len: u16 = @intCast(g.ch.range(.len_pick, 1, 6));
             try g.emitf("(let (({s} (make-string {d} ", .{ name, len });
             try genChar(g, d);
             try g.emitf("))) (string-set! {s} ", .{name});
+            try g.pushBinding(name, .reserved);
             try genIndex(g, d, len);
             try g.emit(" ");
             try genChar(g, d);
             try g.emit(") ");
-            try g.pushBinding(name, .{ .string = .{ .len = len, .mutable = true } });
+            g.scope.items[mark].kind = .{ .string = .{ .len = len, .mutable = true } };
         },
         .list => {
             const len: u16 = @intCast(g.ch.range(.len_pick, 1, 4));
@@ -852,20 +864,22 @@ fn genLetMut(g: *Gen, d: u32) Error!void {
                 try genInt(g, d);
             }
             try g.emitf("))) (set-car! {s} ", .{name});
+            try g.pushBinding(name, .reserved);
             try genInt(g, d);
             try g.emit(") ");
-            try g.pushBinding(name, .{ .list = .{ .len = .{ .exact = len }, .mut = .all, .ints = true } });
+            g.scope.items[mark].kind = .{ .list = .{ .len = .{ .exact = len }, .mut = .all, .ints = true } };
         },
         .bv => {
             const len: u16 = @intCast(g.ch.range(.len_pick, 1, 6));
             try g.emitf("(let (({s} (make-bytevector {d} {d}))) (bytevector-u8-set! {s} ", .{
                 name, len, g.ch.range(.lit_pick, 0, 255), name,
             });
+            try g.pushBinding(name, .reserved);
             try genIndex(g, d, len);
             try g.emit(" (modulo ");
             try genInt(g, d);
             try g.emit(" 256)) ");
-            try g.pushBinding(name, .{ .bytevector = len });
+            g.scope.items[mark].kind = .{ .bytevector = len };
         },
     }
     try genInt(g, d);

--- a/src/fuzz_gen_portable_data.zig
+++ b/src/fuzz_gen_portable_data.zig
@@ -31,11 +31,11 @@ const pickBindKind = portable.pickBindKind;
 const litInt = portable.litInt;
 
 const char_lits = [_][]const u8{ "#\\a", "#\\b", "#\\z", "#\\0", "#\\space", "#\\newline" };
-const string_lits = [_]struct { text: []const u8, len: u16 }{
-    .{ .text = "\"\"", .len = 0 },
-    .{ .text = "\"abc\"", .len = 3 },
-    .{ .text = "\"fuzz\"", .len = 4 },
-    .{ .text = "\"x y!\"", .len = 5 },
+const string_lits = [_]gen_mod.StrLit{
+    gen_mod.strLit("\"\""),
+    gen_mod.strLit("\"abc\""),
+    gen_mod.strLit("\"fuzz\""),
+    gen_mod.strLit("\"x y!\""),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -594,6 +594,39 @@ test "portable-subset generator: programs evaluate without error" {
     try std.testing.expect(ok * 100 >= total * 90);
 }
 
+// Pinned finding seeds (#1620): each reproduced a generator leak outside
+// the total-by-construction subset — a program that raises. Reverting the
+// fix restores the seed's decision-stream mapping and with it the erroneous
+// program, so each seed re-detects its specific bug. Add future oracle-diff
+// finding seeds here after fixing them.
+//
+//   10294 — genLetMut emitted the mutation statement's index/value
+//     sub-expressions before registering the fresh binding, so the picker
+//     could reference an outer same-named int that the new binding shadows:
+//     (let ((c (make-bytevector 1 92))) (bytevector-u8-set! c (modulo c 1) ...) ...)
+//     where the index's `c` is the bytevector — a type error, caught by the
+//     Chibi oracle as an exit-class divergence.
+//   216, 10104 — the "x y!" pool literal recorded len 5 (actually 4), so
+//     derived indices (string-set! at 4, (modulo i 15) on an appended
+//     length-12 string) landed out of range. Invisible to the oracle: both
+//     sides raise identically. Found by a post-fix 4000-seed totality scan.
+test "portable-subset generator: pinned finding seeds stay total (#1620)" {
+    for ([_]u64{ 10294, 216, 10104 }) |seed_n| {
+        const src = try fuzz_gen.generatePortableSeeded(seed_n, std.testing.allocator);
+        defer std.testing.allocator.free(src);
+        errdefer std.debug.print("seed {d} program:\n{s}\n", .{ seed_n, src });
+        var out = evalNormalized(src, true, std.testing.allocator);
+        defer out.deinit(std.testing.allocator);
+        switch (out) {
+            .value => {},
+            .compile_error, .runtime_error => return error.PortableProgramRaised,
+            // Deadline/heap pressure on a loaded machine is not a generator
+            // leak; the 60-seed gate above carries the throughput signal.
+            .resource_limit, .harness_unavailable => return error.SkipZigTest,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Differential oracle: optimized vs unoptimized evaluation (Tier 3, #1394)
 //


### PR DESCRIPTION
Closes #1620.

The run behind #1620 was **not** an infrastructure failure — the `oracle-diff` job found a real divergence (seed 10294) and uploaded its artifact, but the report job misclassified it. This PR fixes both the finding and the misclassification.

## The finding: two portable-generator leaks (commit 1)

Seed 10294 generated an **erroneous program** (triage category c, generator leak):

```scheme
(let ((c (make-bytevector 1 92))) (bytevector-u8-set! c (modulo c 1) (modulo 40 256)) d)
```

`genLetMut` generated the mutation statement's index/value sub-expressions **before** registering the fresh binding, so the picker referenced the outer int `c` (the enclosing named-let counter) — which the new bytevector binding shadows at the emitted position. Kaappi raises `KP3002`, Chibi silently returns: an exit-class divergence on a program that is "an error" per R7RS, so neither implementation is wrong. Fixed by registering the binding as `.reserved` before the mutation statement (the `letrec_rec` precedent) and upgrading it to its real kind for the body result.

A post-fix 4000-seed totality scan surfaced a **second, older leak**: the `"x y!"` pool literal recorded `len = 5` (actually 4), so derived indices could land out of range. Invisible to the oracle — both sides raise identically on out-of-range indices. Pool lengths are now derived from the text at comptime (`strLit`), removing the bug class.

Verification:
- the exact failed CI batch (seeds 10000–10999) reruns **0 divergent** against the same Chibi 0.12.0 oracle
- 4000-seed totality scan (0–2999, 10000–10999): **0 failures** (was 10)
- pinned regression seeds `{10294, 216, 10104}` in `tests_fuzz.zig` fail without each fix, pass with it
- full `zig build test` green

## The misclassification: report job assumed a fixed artifact layout (commit 2)

`download-artifact` v8 extracts each artifact into `artifacts/<name>/` **except** when the run produced exactly one artifact — the action's [`artifacts.length === 1` special case](https://github.com/actions/download-artifact/blob/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c/src/download-artifact.ts#L185-L198) extracts into `artifacts/` itself. One failed job is the common case, so the `find artifacts/oracle-diff-divergences -name 'seed-*.scm'` marker check found nothing and the finding was filed under the infra title.

This is also what actually misfiled seed 2788 (#1584): both runs' artifact containers hold **loose files** (verified via the artifacts API), so the wrapper-zip theory behind the "Unwrap archived artifacts" step was a misdiagnosis — that step never had anything to unwrap. It stays as a cheap safety net, reframed.

Marker detection now searches all of `artifacts/` for filenames only the owning job can produce (`seed-*.kaappi.*` vs `seed-*.{vm,nat}.*`, the `.zig-cache/f/crash` path suffix) and derives each excerpt directory from the matched file. Tested offline against 8 layout scenarios (flattened/nested × oracle/native/fuzz-crash/fuzz-log, plus no-artifact): 21/21 assertions pass, and the excerpt body renders the full finding under the flattened layout that previously produced "_No artifact was uploaded_".

🤖 Generated with [Claude Code](https://claude.com/claude-code)