### PR TITLE
Normalize heap-Value creation to makePointer(&x.header) (#1618)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,14 +346,13 @@ re-export, IR tests, and tail position handling.
 ## How to add a new heap type
 
 1. Add tag to `ObjectTag` enum in `src/types.zig` (slots 35+ available, enum is u6 with 64 slots).
-2. Add the struct with `header: Object` as first field, and add it to the
-   heap-type layout guard (comptime block at the bottom of `types.zig`).
-   Declaring `header` first does NOT guarantee it lands at byte offset 0 —
-   Zig may reorder auto-struct fields, and most `makePointer` sites cast
-   the struct pointer, so a displaced header silently corrupts every Value
-   of that type. The guard turns that into a compile error; if it fires
-   (also when merely adding fields to an existing heap type), rearrange or
-   repack the new fields until the offset is 0 again (see `Port.sock_state`).
+2. Add the struct with `header: Object` as the first-declared field
+   (convention only — Zig's auto layout may still place it at a nonzero
+   byte offset, and that's fine). Heap Values always carry the address of
+   the `header` field: build them with `makePointer(&x.header)` — the
+   `*Object` parameter type makes passing the struct pointer a compile
+   error — and recover the struct with `Object.as()`/`@fieldParentPtr`,
+   never a direct cast.
 3. Add `allocXxx` in `src/memory.zig`.
 4. Handle in `markValue` (trace contained Values) and `freeObject` (free owned memory).
 5. Add display in `src/printer.zig`.

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -62,8 +62,7 @@ need the GC instance:
 ```zig
 fn myAllocProc(args: []const Value) PrimitiveError!Value {
     const gc = primitives.gc_instance orelse return PrimitiveError.TypeError;
-    const result = gc.allocPair(args[0], args[1]) catch return PrimitiveError.OutOfMemory;
-    return types.makePointer(@ptrCast(result));
+    return gc.allocPair(args[0], args[1]) catch return PrimitiveError.OutOfMemory;
 }
 ```
 
@@ -195,8 +194,8 @@ Slots 35-63 are available.
 
 ### 2. Define the struct
 
-In `src/types.zig`, define the struct. The first field **must** be the `Object`
-header:
+In `src/types.zig`, define the struct with an `Object` header, declared
+first by convention:
 
 ```zig
 pub const MyType = struct {
@@ -205,6 +204,12 @@ pub const MyType = struct {
     name: []const u8,
 };
 ```
+
+Layout is otherwise free — Zig's auto layout may place `header` at a
+nonzero byte offset, and that's fine. Heap Values always carry the address
+of the `header` field: build them with `types.makePointer(&x.header)` (its
+`*Object` parameter makes passing the struct pointer a compile error) and
+recover the struct with `Object.as()`, never a direct cast (#1618).
 
 ### 3. Add the allocator
 
@@ -278,7 +283,7 @@ var second = try gc.allocPair(c, d);  // GC might run here!
 // `first` might now be a dangling pointer
 
 // SAFE: root `first` before the second allocation
-var first_val = types.makePointer(@ptrCast(try gc.allocPair(a, b)));
+var first_val = try gc.allocPair(a, b);
 gc.pushRoot(&first_val);
 var second = try gc.allocPair(c, d);  // GC runs, but first_val is rooted
 gc.popRoot();
@@ -298,7 +303,7 @@ gc.popRoot();
    function in a closure internally, which allocates:
 
    ```zig
-   var func_val = types.makePointer(@ptrCast(func));
+   var func_val = types.makePointer(&func.header);
    gc.pushRoot(&func_val);
    const result = vm.execute(func) catch |err| {
        gc.popRoot();

--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -755,7 +755,7 @@ pub fn parseBignumString(gc: *memory.GC, digits: []const u8, radix: u8) !Value {
     };
     gc.trackObject(&bn.header);
     gc.bytes_allocated += @sizeOf(Bignum) + limbs.len * @sizeOf(u64);
-    return types.makePointer(@ptrCast(bn));
+    return types.makePointer(&bn.header);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -229,7 +229,7 @@ test "bytecode round-trip: various constant types" {
     const func = try gc.allocFunction();
     // Root the function: the constant allocations below can collect, and an
     // unrooted func would be swept while we are still appending into it.
-    var func_root = types.makePointer(@ptrCast(func));
+    var func_root = types.makePointer(&func.header);
     gc.pushRoot(&func_root);
     defer gc.popRoot();
     func.code.append(allocator, @intFromEnum(types.OpCode.load_void)) catch unreachable;
@@ -326,7 +326,7 @@ test "bytecode round-trip: nested functions" {
     parent_func.code.append(allocator, @intFromEnum(types.OpCode.@"return")) catch unreachable;
     parent_func.code.append(allocator, 0) catch unreachable; // src high
     parent_func.code.append(allocator, 0) catch unreachable; // src low
-    parent_func.constants.append(allocator, types.makePointer(@ptrCast(child_func))) catch unreachable;
+    parent_func.constants.append(allocator, types.makePointer(&child_func.header)) catch unreachable;
     parent_func.arity = 0;
     parent_func.locals_count = 1;
 
@@ -506,7 +506,7 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
     const func = try gc.allocFunction();
     // Root the function: the constant allocations below can collect, and an
     // unrooted func would be swept while we are still appending into it.
-    var func_root = types.makePointer(@ptrCast(func));
+    var func_root = types.makePointer(&func.header);
     gc.pushRoot(&func_root);
     defer gc.popRoot();
     func.code.append(allocator, @intFromEnum(types.OpCode.load_void)) catch unreachable;

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -149,7 +149,7 @@ fn readConstant(r: *Reader, gc: *GC, all_funcs: []*Function, depth: u32) !Value 
         bf.TAG_FUNCTION => {
             const idx = try r.readU32();
             if (idx >= all_funcs.len) return BytecodeError.CorruptedFile;
-            return types.makePointer(@ptrCast(all_funcs[idx]));
+            return types.makePointer(&all_funcs[idx].header);
         },
         bf.TAG_PAIR => {
             const car_val = try readConstant(r, gc, all_funcs, depth + 1);
@@ -386,7 +386,7 @@ pub fn deserializeFromBuffer(gc: *GC, data: []const u8, expected_hash: ?u64) !?D
     defer if (!keep_roots) gc.extra_roots.shrinkRetainingCapacity(roots_base);
     for (0..func_count) |i| {
         all_funcs[i] = gc.allocFunction() catch return BytecodeError.OutOfMemory;
-        gc.extra_roots.append(allocator, types.makePointer(@ptrCast(all_funcs[i]))) catch return BytecodeError.OutOfMemory;
+        gc.extra_roots.append(allocator, types.makePointer(&all_funcs[i].header)) catch return BytecodeError.OutOfMemory;
     }
 
     for (0..func_count) |i| {

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -132,7 +132,7 @@ pub const Compiler = struct {
 
     pub fn init(gc: *memory.GC) CompileError!Compiler {
         const func = gc.allocFunction() catch return CompileError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, types.makePointer(@ptrCast(func))) catch return CompileError.OutOfMemory;
+        gc.extra_roots.append(gc.allocator, types.makePointer(&func.header)) catch return CompileError.OutOfMemory;
         return .{
             .gc = gc,
             .func = func,
@@ -150,7 +150,7 @@ pub const Compiler = struct {
     }
 
     pub fn unrootFunction(gc: *memory.GC, func: *types.Function) void {
-        const func_val = types.makePointer(@ptrCast(func));
+        const func_val = types.makePointer(&func.header);
         for (gc.extra_roots.items, 0..) |v, i| {
             if (v == func_val) {
                 _ = gc.extra_roots.orderedRemove(i);
@@ -165,7 +165,7 @@ pub const Compiler = struct {
         func.env_val = parent.lib_env_val;
         func.source_line = parent.func.source_line;
         func.source_name = parent.func.source_name;
-        parent.gc.extra_roots.append(parent.gc.allocator, types.makePointer(@ptrCast(func))) catch return CompileError.OutOfMemory;
+        parent.gc.extra_roots.append(parent.gc.allocator, types.makePointer(&func.header)) catch return CompileError.OutOfMemory;
         return .{
             .gc = parent.gc,
             .func = func,

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -14,7 +14,7 @@ pub fn emitClosureEpilogue(self: *Compiler, child: *Compiler, target_reg: u16) C
             try self.markLocalBoxedBySlot(uv.index);
         }
     }
-    const func_val = types.makePointer(@ptrCast(child.func));
+    const func_val = types.makePointer(&child.func.header);
     const idx = try self.addConstant(func_val);
     try self.emitOp(.closure);
     try self.emitU16(target_reg);

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -116,13 +116,6 @@ pub const Fiber = struct {
     owned_mutexes: std.ArrayList(Value) = .empty,
 };
 
-// Fiber is exempt from types.zig's heap-type layout guard: its auto layout
-// already places `header` at a nonzero offset, which is safe here — and
-// only here — because every Fiber-to-Value conversion in the codebase
-// spells `makePointer(@ptrCast(&fiber.header))` (never the struct pointer),
-// matching Object.as()'s @fieldParentPtr. Keep that discipline for any new
-// conversion site.
-
 pub const FiberScheduler = struct {
     /// Growable — no fiber-count ceiling (KEP-0001 Phase 2). Slots are
     /// reused before growing (see addFiber), so long-running spawn/join
@@ -358,7 +351,7 @@ pub const FiberScheduler = struct {
         if (types.isClosure(thunk_val)) {
             closure = types.toObject(thunk_val).as(types.Closure);
         } else {
-            var fiber_root = types.makePointer(@ptrCast(&fiber.header));
+            var fiber_root = types.makePointer(&fiber.header);
             self.vm.gc.pushRoot(&fiber_root);
             const trampoline = try wrapInTrampoline(self.vm.gc, thunk_val);
             self.vm.gc.popRoot();
@@ -368,7 +361,7 @@ pub const FiberScheduler = struct {
         }
 
         @memset(fiber.registers, types.UNDEFINED);
-        fiber.registers[0] = types.makePointer(@ptrCast(closure));
+        fiber.registers[0] = types.makePointer(&closure.header);
         fiber.frames[0] = .{
             .closure = closure,
             .code = closure.func.code.items,
@@ -829,7 +822,7 @@ pub const FiberScheduler = struct {
     }
 
     pub fn wakeWaiters(self: *FiberScheduler, completed_fiber: *Fiber) void {
-        const completed_val = types.makePointer(@ptrCast(&completed_fiber.header));
+        const completed_val = types.makePointer(&completed_fiber.header);
         self.wakeOn(completed_val, .{ .all = true, .result = completed_fiber.result });
     }
 
@@ -915,7 +908,7 @@ pub const FiberScheduler = struct {
     pub fn markRoots(self: *FiberScheduler, gc: *memory.GC) void {
         for (self.fibers.items) |f| {
             if (f) |fiber| {
-                gc.markValue(types.makePointer(@ptrCast(&fiber.header)));
+                gc.markValue(types.makePointer(&fiber.header));
                 if (fiber.status == .running) continue;
                 markFiberState(gc, fiber);
             }
@@ -969,7 +962,7 @@ pub fn ensureScheduler(vm: *VM) VMError!struct { vm: *VM, sched: *FiberScheduler
 /// abandoning one of those would corrupt a lock a live fiber legitimately
 /// holds.
 pub fn abandonFiberMutexes(fiber: *Fiber, sched: ?*FiberScheduler) void {
-    const fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    const fiber_val = types.makePointer(&fiber.header);
     for (fiber.owned_mutexes.items) |m_val| {
         const m = types.toMutex(m_val);
         if (@atomicLoad(bool, &m.locked, .acquire) and m.owner == fiber_val) {
@@ -1288,8 +1281,8 @@ pub fn markFiberState(gc: *memory.GC, fiber: *Fiber) void {
     gc.markValue(fiber.specific);
 
     for (fiber.frames[0..fiber.frame_count]) |f| {
-        if (f.closure) |cls| gc.markValue(types.makePointer(@ptrCast(cls)));
-        if (f.native) |nf| gc.markValue(types.makePointer(@ptrCast(nf)));
+        if (f.closure) |cls| gc.markValue(types.makePointer(&cls.header));
+        if (f.native) |nf| gc.markValue(types.makePointer(&nf.header));
     }
     const span = FiberScheduler.liveRegisterSpan(fiber.frames[0..fiber.frame_count], fiber.registers.len);
     for (fiber.registers[0..span]) |r| gc.markValue(r);

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -100,7 +100,7 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
         },
         .record_instance => {
             const ri = obj.as(RecordInstance);
-            if (isYoungPointer(gc, types.makePointer(@ptrCast(ri.record_type)))) return true;
+            if (isYoungPointer(gc, types.makePointer(&ri.record_type.header))) return true;
             for (ri.fields) |field| {
                 if (isYoungPointer(gc, field)) return true;
             }
@@ -116,7 +116,7 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
         },
         .closure => {
             const cls = obj.as(Closure);
-            if (isYoungPointer(gc, types.makePointer(@ptrCast(cls.func)))) return true;
+            if (isYoungPointer(gc, types.makePointer(&cls.func.header))) return true;
             for (cls.upvalues) |uv| {
                 if (isYoungPointer(gc, uv)) return true;
             }
@@ -155,10 +155,10 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
             }
             for (cont.frames[0..cont.frame_count]) |frame| {
                 if (frame.closure) |cls| {
-                    if (isYoungPointer(gc, types.makePointer(@ptrCast(cls)))) return true;
+                    if (isYoungPointer(gc, types.makePointer(&cls.header))) return true;
                 }
                 if (frame.native) |nf| {
-                    if (isYoungPointer(gc, types.makePointer(@ptrCast(nf)))) return true;
+                    if (isYoungPointer(gc, types.makePointer(&nf.header))) return true;
                 }
             }
             for (cont.handlers[0..cont.handler_count]) |handler| {
@@ -197,10 +197,10 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
             if (isYoungPointer(gc, fiber.continuation_value)) return true;
             for (fiber.frames[0..fiber.frame_count]) |f| {
                 if (f.closure) |cls| {
-                    if (isYoungPointer(gc, types.makePointer(@ptrCast(cls)))) return true;
+                    if (isYoungPointer(gc, types.makePointer(&cls.header))) return true;
                 }
                 if (f.native) |nf| {
-                    if (isYoungPointer(gc, types.makePointer(@ptrCast(nf)))) return true;
+                    if (isYoungPointer(gc, types.makePointer(&nf.header))) return true;
                 }
                 const window = f.frameWindow();
                 const end: usize = @min(@as(usize, f.base) + window, fiber.registers.len);
@@ -375,7 +375,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
         },
         .closure => {
             const cls = obj.as(Closure);
-            markValue(gc, types.makePointer(@ptrCast(cls.func)));
+            markValue(gc, types.makePointer(&cls.func.header));
             for (cls.upvalues) |uv| markValue(gc, uv);
         },
         .hash_table => {
@@ -391,7 +391,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
         },
         .record_instance => {
             const ri = obj.as(RecordInstance);
-            markValue(gc, types.makePointer(@ptrCast(ri.record_type)));
+            markValue(gc, types.makePointer(&ri.record_type.header));
             for (ri.fields) |field| markValue(gc, field);
         },
         .promise => {
@@ -421,8 +421,8 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
             const cont = obj.as(Continuation);
             for (cont.registers) |reg| markValue(gc, reg);
             for (cont.frames[0..cont.frame_count]) |frame| {
-                if (frame.closure) |cls| markValue(gc, types.makePointer(@ptrCast(cls)));
-                if (frame.native) |nf| markValue(gc, types.makePointer(@ptrCast(nf)));
+                if (frame.closure) |cls| markValue(gc, types.makePointer(&cls.header));
+                if (frame.native) |nf| markValue(gc, types.makePointer(&nf.header));
             }
             for (cont.handlers[0..cont.handler_count]) |handler| markValue(gc, handler.handler);
             for (cont.wind_records[0..cont.wind_count]) |wr| {
@@ -592,7 +592,7 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         .pair => unreachable,
         .closure => {
             const cls = obj.as(Closure);
-            worklist.append(gc.allocator, types.makePointer(@ptrCast(cls.func))) catch @panic("GC mark: worklist OOM");
+            worklist.append(gc.allocator, types.makePointer(&cls.func.header)) catch @panic("GC mark: worklist OOM");
             for (cls.upvalues) |uv| {
                 worklist.append(gc.allocator, uv) catch @panic("GC mark: worklist OOM");
             }
@@ -632,7 +632,7 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         .record_type => {},
         .record_instance => {
             const ri = obj.as(RecordInstance);
-            worklist.append(gc.allocator, types.makePointer(@ptrCast(ri.record_type))) catch @panic("GC mark: worklist OOM");
+            worklist.append(gc.allocator, types.makePointer(&ri.record_type.header)) catch @panic("GC mark: worklist OOM");
             for (ri.fields) |field| {
                 worklist.append(gc.allocator, field) catch @panic("GC mark: worklist OOM");
             }
@@ -644,10 +644,10 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
             }
             for (cont.frames[0..cont.frame_count]) |frame| {
                 if (frame.closure) |cls| {
-                    worklist.append(gc.allocator, types.makePointer(@ptrCast(cls))) catch @panic("GC mark: worklist OOM");
+                    worklist.append(gc.allocator, types.makePointer(&cls.header)) catch @panic("GC mark: worklist OOM");
                 }
                 if (frame.native) |nf| {
-                    worklist.append(gc.allocator, types.makePointer(@ptrCast(nf))) catch @panic("GC mark: worklist OOM");
+                    worklist.append(gc.allocator, types.makePointer(&nf.header)) catch @panic("GC mark: worklist OOM");
                 }
             }
             for (cont.handlers[0..cont.handler_count]) |handler| {

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -145,7 +145,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         },
         .closure => {
             const cl = obj.as(types.Closure);
-            const func_val = types.makePointer(@ptrCast(cl.func));
+            const func_val = types.makePointer(&cl.func.header);
             const new_func_val = try deepCopyValue(gc, func_val, visited);
             const new_func = types.toObject(new_func_val).as(types.Function);
             const new_val = try gc.allocClosure(new_func);
@@ -159,7 +159,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         .function => {
             const func = obj.as(types.Function);
             const new_func = try gc.allocFunction();
-            const new_val = types.makePointer(@ptrCast(new_func));
+            const new_val = types.makePointer(&new_func.header);
             try visited.put(src_ptr, new_val);
             new_func.arity = func.arity;
             new_func.locals_count = func.locals_count;
@@ -287,7 +287,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         },
         .record_instance => {
             const ri = obj.as(types.RecordInstance);
-            const rt_val = types.makePointer(@ptrCast(ri.record_type));
+            const rt_val = types.makePointer(&ri.record_type.header);
             const new_rt_val = try deepCopyValue(gc, rt_val, visited);
             const new_rt = types.toObject(new_rt_val).as(types.RecordType);
             const new_val = try gc.allocRecordInstance(new_rt, &.{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -359,7 +359,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
 
         const top_count = @min(loaded.top_level_count, @as(u32, @intCast(loaded.funcs.len)));
         for (loaded.funcs[0..top_count]) |func| {
-            var func_val = types.makePointer(@ptrCast(func));
+            var func_val = types.makePointer(&func.header);
             vm.gc.pushRoot(&func_val);
             const result = vm.execute(func) catch |err| {
                 vm.gc.popRoot();
@@ -660,7 +660,7 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             const top_count = @min(loaded.top_level_count, @as(u32, @intCast(loaded.funcs.len)));
             crash.noteStage(.executing);
             for (loaded.funcs[0..top_count]) |func| {
-                var func_val = types.makePointer(@ptrCast(func));
+                var func_val = types.makePointer(&func.header);
                 vm.gc.pushRoot(&func_val);
                 timings.begin(.execute);
                 const exec_result = vm.execute(func);
@@ -739,9 +739,9 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         };
 
         compiled_funcs.append(allocator, func) catch return error.OutOfMemory;
-        vm.gc.extra_roots.append(allocator, types.makePointer(@ptrCast(func))) catch return error.OutOfMemory;
+        vm.gc.extra_roots.append(allocator, types.makePointer(&func.header)) catch return error.OutOfMemory;
 
-        var func_val = types.makePointer(@ptrCast(func));
+        var func_val = types.makePointer(&func.header);
         vm.gc.pushRoot(&func_val);
 
         crash.noteStage(.executing);
@@ -863,7 +863,7 @@ fn runStdin(vm: *vm_mod.VM) !void {
             return;
         };
 
-        var func_val = types.makePointer(@ptrCast(func));
+        var func_val = types.makePointer(&func.header);
         vm.gc.pushRoot(&func_val);
 
         crash.noteStage(.executing);

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -252,7 +252,7 @@ pub const GC = struct {
             .cdr = cdr_val,
         };
         self.finishAlloc(&pair.header, @sizeOf(Pair));
-        return types.makePointer(@ptrCast(pair));
+        return types.makePointer(&pair.header);
     }
 
     pub fn allocSymbol(self: *GC, name: []const u8) !Value {
@@ -304,7 +304,7 @@ pub const GC = struct {
             self.trackObject(&sym.header);
         }
 
-        const val = types.makePointer(@ptrCast(sym));
+        const val = types.makePointer(&sym.header);
         try sym_table.put(owned_name, val);
         return val;
     }
@@ -322,7 +322,7 @@ pub const GC = struct {
             .len = data.len,
         };
         self.finishAlloc(&str.header, @sizeOf(SchemeString) + data.len);
-        return types.makePointer(@ptrCast(str));
+        return types.makePointer(&str.header);
     }
 
     pub fn allocFunction(self: *GC) !*Function {
@@ -338,7 +338,7 @@ pub const GC = struct {
     }
 
     pub fn allocClosure(self: *GC, func: *Function) !Value {
-        self.rootArgs1(types.makePointer(@ptrCast(func)));
+        self.rootArgs1(types.makePointer(&func.header));
         try self.maybeCollect();
         self.clearArgRoots();
         const upvalue_count = func.upvalue_count;
@@ -353,7 +353,7 @@ pub const GC = struct {
             .upvalues = upvalues,
         };
         self.finishAlloc(&cls.header, @sizeOf(Closure) + @as(usize, upvalue_count) * @sizeOf(Value));
-        return types.makePointer(@ptrCast(cls));
+        return types.makePointer(&cls.header);
     }
 
     pub fn allocNativeFn(self: *GC, name: []const u8, func: types.NativeFnType, arity: NativeFn.Arity) !Value {
@@ -365,7 +365,7 @@ pub const GC = struct {
             .arity = arity,
         };
         self.finishAlloc(&nf.header, @sizeOf(NativeFn));
-        return types.makePointer(@ptrCast(nf));
+        return types.makePointer(&nf.header);
     }
 
     pub fn allocNativeClosure(self: *GC, fn_ptr: types.NativeClosureFnType, upvalues: []const Value, arity: u8, name: []const u8) !Value {
@@ -387,7 +387,7 @@ pub const GC = struct {
             .name = name,
         };
         self.finishAlloc(&nc.header, @sizeOf(types.NativeClosure) + upvalues.len * @sizeOf(Value));
-        return types.makePointer(@ptrCast(nc));
+        return types.makePointer(&nc.header);
     }
 
     pub fn allocFlonum(self: *GC, value: f64) !Value {
@@ -412,7 +412,7 @@ pub const GC = struct {
             .data = owned,
         };
         self.finishAlloc(&vec.header, @sizeOf(Vector) + data.len * @sizeOf(Value));
-        return types.makePointer(@ptrCast(vec));
+        return types.makePointer(&vec.header);
     }
 
     pub fn allocVectorFill(self: *GC, size: usize, fill: Value) !Value {
@@ -428,7 +428,7 @@ pub const GC = struct {
             .data = data,
         };
         self.finishAlloc(&vec.header, @sizeOf(Vector) + size * @sizeOf(Value));
-        return types.makePointer(@ptrCast(vec));
+        return types.makePointer(&vec.header);
     }
 
     pub fn allocErrorObject(self: *GC, message: Value, irritants: Value) !Value {
@@ -452,7 +452,7 @@ pub const GC = struct {
             .code = code,
         };
         self.finishAlloc(&err.header, @sizeOf(types.ErrorObject));
-        return types.makePointer(@ptrCast(err));
+        return types.makePointer(&err.header);
     }
 
     pub fn allocTransformer(self: *GC, literals: []const Value, patterns: []const Value, templates: []const Value) !Value {
@@ -473,7 +473,7 @@ pub const GC = struct {
             .num_rules = num_rules,
         };
         self.finishAlloc(&tx.header, @sizeOf(Transformer) + (literals.len + patterns.len + templates.len) * @sizeOf(Value));
-        return types.makePointer(@ptrCast(tx));
+        return types.makePointer(&tx.header);
     }
 
     pub fn allocRecordType(self: *GC, name: []const u8, num_fields: u8) !Value {
@@ -488,7 +488,7 @@ pub const GC = struct {
             .num_fields = num_fields,
         };
         self.finishAlloc(&rt.header, @sizeOf(RecordType) + name.len);
-        return types.makePointer(@ptrCast(rt));
+        return types.makePointer(&rt.header);
     }
 
     pub fn allocRecordInstance(self: *GC, record_type: *RecordType, field_values: []const Value) !Value {
@@ -503,7 +503,7 @@ pub const GC = struct {
                 fields[i] = types.UNDEFINED;
             }
         }
-        self.rootArgs1(types.makePointer(@ptrCast(record_type)));
+        self.rootArgs1(types.makePointer(&record_type.header));
         const saved_slice_roots = self.slice_roots;
         self.slice_roots = fields;
         defer self.slice_roots = saved_slice_roots;
@@ -516,7 +516,7 @@ pub const GC = struct {
             .fields = fields,
         };
         self.finishAlloc(&ri.header, @sizeOf(RecordInstance) + record_type.num_fields * @sizeOf(Value));
-        return types.makePointer(@ptrCast(ri));
+        return types.makePointer(&ri.header);
     }
 
     pub fn allocPort(self: *GC, fd: platform.fd_t, is_input: bool, is_output: bool, name: []const u8, owns_name: bool) !Value {
@@ -539,7 +539,7 @@ pub const GC = struct {
             .string_out_cap = 0,
         };
         self.finishAlloc(&port.header, @sizeOf(Port));
-        return types.makePointer(@ptrCast(port));
+        return types.makePointer(&port.header);
     }
 
     pub fn allocStringInputPort(self: *GC, data: []const u8) !Value {
@@ -562,7 +562,7 @@ pub const GC = struct {
             .string_pos = 0,
         };
         self.finishAlloc(&port.header, @sizeOf(Port) + data.len);
-        return types.makePointer(@ptrCast(port));
+        return types.makePointer(&port.header);
     }
 
     pub fn allocStringOutputPort(self: *GC) !Value {
@@ -586,7 +586,7 @@ pub const GC = struct {
             .string_out_cap = initial_cap,
         };
         self.finishAlloc(&port.header, @sizeOf(Port) + initial_cap);
-        return types.makePointer(@ptrCast(port));
+        return types.makePointer(&port.header);
     }
 
     pub fn allocBytevector(self: *GC, data: []const u8) !Value {
@@ -600,7 +600,7 @@ pub const GC = struct {
             .data = owned,
         };
         self.finishAlloc(&bv.header, @sizeOf(Bytevector) + data.len);
-        return types.makePointer(@ptrCast(bv));
+        return types.makePointer(&bv.header);
     }
 
     pub fn allocBytevectorFill(self: *GC, size: usize, fill: u8) !Value {
@@ -614,7 +614,7 @@ pub const GC = struct {
             .data = data,
         };
         self.finishAlloc(&bv.header, @sizeOf(Bytevector) + size);
-        return types.makePointer(@ptrCast(bv));
+        return types.makePointer(&bv.header);
     }
 
     /// Lever D (kaappi#1472): a bytevector whose bytes are BORROWED from a
@@ -636,7 +636,7 @@ pub const GC = struct {
         // The bytes live in the SharedBuffer, not this heap: count only the
         // struct, so the per-heap footprint reflects lever D's whole point.
         self.finishAlloc(&bv.header, @sizeOf(Bytevector));
-        return types.makePointer(@ptrCast(bv));
+        return types.makePointer(&bv.header);
     }
 
     /// Lever D copy-on-write (kaappi#1472): if `bv` borrows a shared immutable
@@ -669,7 +669,7 @@ pub const GC = struct {
             .value = value,
         };
         self.finishAlloc(&p.header, @sizeOf(Promise));
-        return types.makePointer(@ptrCast(p));
+        return types.makePointer(&p.header);
     }
 
     pub fn allocContinuation(
@@ -742,7 +742,7 @@ pub const GC = struct {
             frames.len * @sizeOf(SavedFrame) +
             handlers.len * @sizeOf(SavedHandler) +
             wind_records.len * @sizeOf(WindRecord));
-        return types.makePointer(@ptrCast(cont));
+        return types.makePointer(&cont.header);
     }
 
     /// Allocate an escape continuation (call/ec). Unlike a full continuation,
@@ -778,7 +778,7 @@ pub const GC = struct {
             .target_handler_count = target_handler_count,
         };
         self.finishAlloc(&cont.header, @sizeOf(Continuation));
-        return types.makePointer(@ptrCast(cont));
+        return types.makePointer(&cont.header);
     }
 
     pub fn allocComplex(self: *GC, real: f64, imag: f64) !Value {
@@ -796,7 +796,7 @@ pub const GC = struct {
             .exact_imag = exact_imag,
         };
         self.finishAlloc(&c.header, @sizeOf(types.Complex));
-        return types.makePointer(@ptrCast(c));
+        return types.makePointer(&c.header);
     }
 
     pub fn allocParameter(self: *GC, init_value: Value, converter: Value) !Value {
@@ -810,7 +810,7 @@ pub const GC = struct {
             .converter = converter,
         };
         self.finishAlloc(&p.header, @sizeOf(types.ParameterObject));
-        return types.makePointer(@ptrCast(p));
+        return types.makePointer(&p.header);
     }
 
     pub fn allocFfiLibrary(self: *GC, handle: ?*anyopaque, name: []const u8) !Value {
@@ -825,7 +825,7 @@ pub const GC = struct {
             .name = owned_name,
         };
         self.finishAlloc(&lib.header, @sizeOf(FfiLibrary) + name.len);
-        return types.makePointer(@ptrCast(lib));
+        return types.makePointer(&lib.header);
     }
 
     pub fn allocFfiFunction(self: *GC, symbol: *anyopaque, library: Value, name: []const u8, param_types: []const FfiType, return_type: FfiType) !Value {
@@ -848,7 +848,7 @@ pub const GC = struct {
             .param_count = @intCast(param_types.len),
         };
         self.finishAlloc(&ffi_fn.header, @sizeOf(FfiFunction) + name.len + param_types.len * @sizeOf(FfiType));
-        return types.makePointer(@ptrCast(ffi_fn));
+        return types.makePointer(&ffi_fn.header);
     }
 
     pub fn allocFfiCallback(self: *GC, closure: Value, slot_index: u8, fn_ptr: *anyopaque) !Value {
@@ -864,7 +864,7 @@ pub const GC = struct {
             .active = true,
         };
         self.finishAlloc(&cb.header, @sizeOf(FfiCallback));
-        return types.makePointer(@ptrCast(cb));
+        return types.makePointer(&cb.header);
     }
 
     pub fn allocRandomSource(self: *GC, seed: u64) !Value {
@@ -875,7 +875,7 @@ pub const GC = struct {
             .prng = std.Random.DefaultPrng.init(seed),
         };
         self.finishAlloc(&rs.header, @sizeOf(RandomSource));
-        return types.makePointer(@ptrCast(rs));
+        return types.makePointer(&rs.header);
     }
 
     pub fn allocFiber(self: *GC, thunk: Value, id: u32) !*@import("fiber.zig").Fiber {
@@ -928,7 +928,7 @@ pub const GC = struct {
             .tail = types.NIL,
         };
         self.finishAlloc(&ch.header, @sizeOf(types.Channel));
-        return types.makePointer(@ptrCast(ch));
+        return types.makePointer(&ch.header);
     }
 
     /// KEP-0002 §6: a bounded channel, `(make-channel capacity)`. Separate
@@ -945,7 +945,7 @@ pub const GC = struct {
             .capacity = capacity,
         };
         self.finishAlloc(&ch.header, @sizeOf(types.Channel));
-        return types.makePointer(@ptrCast(ch));
+        return types.makePointer(&ch.header);
     }
 
     /// A promoted-channel stub: a new counted reference to an existing
@@ -962,7 +962,7 @@ pub const GC = struct {
             .shared = shared,
         };
         self.finishAlloc(&ch.header, @sizeOf(types.Channel));
-        return types.makePointer(@ptrCast(ch));
+        return types.makePointer(&ch.header);
     }
 
     pub fn allocMutex(self: *GC, name: Value) !Value {
@@ -979,7 +979,7 @@ pub const GC = struct {
             .specific = types.VOID,
         };
         self.finishAlloc(&m.header, @sizeOf(types.Mutex));
-        return types.makePointer(@ptrCast(m));
+        return types.makePointer(&m.header);
     }
 
     pub fn allocConditionVariable(self: *GC, name: Value) !Value {
@@ -993,7 +993,7 @@ pub const GC = struct {
             .specific = types.VOID,
         };
         self.finishAlloc(&cv.header, @sizeOf(types.ConditionVariable));
-        return types.makePointer(@ptrCast(cv));
+        return types.makePointer(&cv.header);
     }
 
     pub fn allocSrfi18Time(self: *GC, seconds: i64, nanoseconds: i64, time_type: types.TimeType) !Value {
@@ -1006,7 +1006,7 @@ pub const GC = struct {
             .time_type = time_type,
         };
         self.finishAlloc(&t.header, @sizeOf(types.Srfi18Time));
-        return types.makePointer(@ptrCast(t));
+        return types.makePointer(&t.header);
     }
 
     pub fn allocHashTable(self: *GC, initial_capacity: usize) !Value {
@@ -1032,7 +1032,7 @@ pub const GC = struct {
             .hash_fn = 0,
         };
         self.finishAlloc(&ht.header, @sizeOf(HashTable) + cap * @sizeOf(HashEntry));
-        return types.makePointer(@ptrCast(ht));
+        return types.makePointer(&ht.header);
     }
 
     pub fn allocBignumFromI64(self: *GC, n: i64) !Value {
@@ -1049,7 +1049,7 @@ pub const GC = struct {
             .positive = n >= 0,
         };
         self.finishAlloc(&bn.header, @sizeOf(Bignum) + @sizeOf(u64));
-        return types.makePointer(@ptrCast(bn));
+        return types.makePointer(&bn.header);
     }
 
     pub fn allocBignumFromLimbs(self: *GC, limbs: []const u64, len: usize, positive: bool) !Value {
@@ -1070,7 +1070,7 @@ pub const GC = struct {
             .positive = positive,
         };
         self.finishAlloc(&bn.header, @sizeOf(Bignum) + limbs.len * @sizeOf(u64));
-        return types.makePointer(@ptrCast(bn));
+        return types.makePointer(&bn.header);
     }
 
     pub fn allocRational(self: *GC, num: Value, den: Value) !Value {
@@ -1084,7 +1084,7 @@ pub const GC = struct {
             .denominator = den,
         };
         self.finishAlloc(&rat.header, @sizeOf(Rational));
-        return types.makePointer(@ptrCast(rat));
+        return types.makePointer(&rat.header);
     }
 
     pub fn allocFileInfo(self: *GC, info: struct {
@@ -1123,7 +1123,7 @@ pub const GC = struct {
             .file_type = info.file_type,
         };
         self.finishAlloc(&fi.header, @sizeOf(types.FileInfo));
-        return types.makePointer(@ptrCast(fi));
+        return types.makePointer(&fi.header);
     }
 
     pub fn allocUserInfo(self: *GC, name: []const u8, uid: u32, gid: u32, home_dir: []const u8, shell: []const u8, full_name: []const u8) !Value {
@@ -1148,7 +1148,7 @@ pub const GC = struct {
             .full_name = gecos_copy,
         };
         self.finishAlloc(&ui.header, @sizeOf(types.UserInfo) + name.len + home_dir.len + shell.len + full_name.len);
-        return types.makePointer(@ptrCast(ui));
+        return types.makePointer(&ui.header);
     }
 
     pub fn allocGroupInfo(self: *GC, name: []const u8, gid: u32) !Value {
@@ -1163,7 +1163,7 @@ pub const GC = struct {
             .gid = gid,
         };
         self.finishAlloc(&gi.header, @sizeOf(types.GroupInfo) + name.len);
-        return types.makePointer(@ptrCast(gi));
+        return types.makePointer(&gi.header);
     }
 
     pub fn allocEnvironment(self: *GC, env_map: *std.StringHashMap(Value), owned: bool, immutable: bool) !Value {
@@ -1176,7 +1176,7 @@ pub const GC = struct {
             .immutable = immutable,
         };
         self.finishAlloc(&se.header, @sizeOf(types.SchemeEnvironment));
-        return types.makePointer(@ptrCast(se));
+        return types.makePointer(&se.header);
     }
 
     pub fn allocDirectoryObject(self: *GC, dir: *anyopaque, include_dotfiles: bool) !Value {
@@ -1188,7 +1188,7 @@ pub const GC = struct {
             .include_dotfiles = include_dotfiles,
         };
         self.finishAlloc(&d.header, @sizeOf(types.DirectoryObject));
-        return types.makePointer(@ptrCast(d));
+        return types.makePointer(&d.header);
     }
 
     pub fn allocMultipleValues(self: *GC, values: []const Value) !Value {
@@ -1206,7 +1206,7 @@ pub const GC = struct {
             .values = owned,
         };
         self.finishAlloc(&mv.header, @sizeOf(MultipleValues) + values.len * @sizeOf(Value));
-        return types.makePointer(@ptrCast(mv));
+        return types.makePointer(&mv.header);
     }
 
     // -- Convenience: build a proper list from a slice

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -41,7 +41,7 @@ fn spawnFn(args: []const Value) PrimitiveError!Value {
     const ctx = try fiber_mod.ensureScheduler(vm);
 
     const fiber = ctx.sched.spawnFiber(proc) catch return PrimitiveError.OutOfMemory;
-    return types.makePointer(@ptrCast(&fiber.header));
+    return types.makePointer(&fiber.header);
 }
 
 fn yieldFn(_: []const Value) PrimitiveError!Value {

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -79,8 +79,8 @@ fn promiseMerge(args: []const Value) PrimitiveError!Value {
     outer.value = inner.value;
     gc.writeBarrier(&outer.header, inner.value);
     inner.forced = true;
-    inner.value = types.makePointer(@ptrCast(outer));
-    gc.writeBarrier(&inner.header, types.makePointer(@ptrCast(outer)));
+    inner.value = types.makePointer(&outer.header);
+    gc.writeBarrier(&inner.header, types.makePointer(&outer.header));
     outer.forcing = false;
     return types.VOID;
 }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -294,7 +294,7 @@ fn checkThreadOwner(fiber_val: Value, comptime proc: []const u8) PrimitiveError!
 fn currentThreadFn(_: []const Value) PrimitiveError!Value {
     const ctx = try ensureScheduler();
     const fiber = ctx.vm.current_fiber orelse return types.VOID;
-    return types.makePointer(@ptrCast(&fiber.header));
+    return types.makePointer(&fiber.header);
 }
 
 fn threadPredFn(args: []const Value) PrimitiveError!Value {
@@ -320,7 +320,7 @@ fn makeThreadFn(args: []const Value) PrimitiveError!Value {
         gc.writeBarrier(&fiber.header, args[1]);
     }
 
-    return types.makePointer(@ptrCast(&fiber.header));
+    return types.makePointer(&fiber.header);
 }
 
 fn threadNameFn(args: []const Value) PrimitiveError!Value {
@@ -1047,12 +1047,12 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     if (tryClaimMutex(m)) {
         const ctx = try ensureScheduler();
         if (ctx.vm.current_fiber) |cf| {
-            m.owner = resolveMutexOwner(args, types.makePointer(@ptrCast(&cf.header)));
+            m.owner = resolveMutexOwner(args, types.makePointer(&cf.header));
             if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
             // Only track when *this* fiber became the owner: an explicit
             // owner arg naming another fiber (possibly on another thread)
             // must not append to this fiber's list.
-            if (m.owner == types.makePointer(@ptrCast(&cf.header))) trackOwnedMutex(cf, args[0]);
+            if (m.owner == types.makePointer(&cf.header)) trackOwnedMutex(cf, args[0]);
         } else {
             m.owner = resolveMutexOwner(args, types.VOID);
             if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
@@ -1148,12 +1148,12 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     me.deadline_ns = null;
 
     m.owner = if (owner_arg) |oa|
-        (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else types.makePointer(@ptrCast(&me.header)))
+        (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else types.makePointer(&me.header))
     else
-        types.makePointer(@ptrCast(&me.header));
+        types.makePointer(&me.header);
     if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
     // Track only when `me` itself became the owner (see the fast path).
-    if (m.owner == types.makePointer(@ptrCast(&me.header))) trackOwnedMutex(me, mutex_val);
+    if (m.owner == types.makePointer(&me.header)) trackOwnedMutex(me, mutex_val);
 
     if (tryClaimAbandoned(m)) return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
     return types.TRUE;

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -351,10 +351,10 @@ pub const Reactor = struct {
     pub fn markRoots(self: *Reactor, gc: *memory.GC) void {
         var it = self.regs.valueIterator();
         while (it.next()) |reg| {
-            for (reg.read_waiters.items) |f| gc.markValue(types.makePointer(@ptrCast(&f.header)));
-            for (reg.write_waiters.items) |f| gc.markValue(types.makePointer(@ptrCast(&f.header)));
+            for (reg.read_waiters.items) |f| gc.markValue(types.makePointer(&f.header));
+            for (reg.write_waiters.items) |f| gc.markValue(types.makePointer(&f.header));
         }
-        for (self.timers.items) |entry| gc.markValue(types.makePointer(@ptrCast(&entry.fiber.header)));
+        for (self.timers.items) |entry| gc.markValue(types.makePointer(&entry.fiber.header));
     }
 
     /// Blocks up to `timeout_ns` (or the nearest timer deadline, whichever

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1441,7 +1441,7 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
             break;
         };
 
-        var func_val = types.makePointer(@ptrCast(func));
+        var func_val = types.makePointer(&func.header);
         vm.gc.pushRoot(&func_val);
 
         crash.noteStage(.executing);

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -544,7 +544,7 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
     // by a remote receive freeing a slot).
     if (vm_mod.vm_instance) |vm| {
         if (vm.scheduler) |sched| {
-            const ch_val = types.makePointer(@ptrCast(&ch.header));
+            const ch_val = types.makePointer(&ch.header);
             // Registers the notifier once, only if something actually
             // matched -- register{Recv,Send}Waiter's own dedup makes
             // calling them once per matching fiber idempotent, but hoisting

--- a/src/tests_bytecode_cache.zig
+++ b/src/tests_bytecode_cache.zig
@@ -85,7 +85,7 @@ test "bytecode cache: deserialized top-level functions survive a mid-run GC" {
 
     // The round-tripped bytecode executes and returns each constant.
     for (loaded.funcs[0..loaded.top_level_count], want) |func, w| {
-        var fv = types.makePointer(@ptrCast(func));
+        var fv = types.makePointer(&func.header);
         gc.pushRoot(&fv);
         defer gc.popRoot();
         const r = try vm.execute(func);
@@ -103,7 +103,7 @@ test "bytecode cache: deserialized top-level functions survive a mid-run GC" {
 
     // ...and they remain executable after the collection.
     for (loaded.funcs[0..loaded.top_level_count], want) |func, w| {
-        var fv = types.makePointer(@ptrCast(func));
+        var fv = types.makePointer(&func.header);
         gc.pushRoot(&fv);
         defer gc.popRoot();
         const r = try vm.execute(func);
@@ -158,7 +158,7 @@ fn expectSbcEquivalence(source: []const u8) !void {
     // Phase 4: execute deserialized functions and compare final result
     var result: types.Value = types.VOID;
     for (loaded.funcs[0..loaded.top_level_count]) |func| {
-        var fv = types.makePointer(@ptrCast(func));
+        var fv = types.makePointer(&func.header);
         gc2.pushRoot(&fv);
         defer gc2.popRoot();
         result = try vm2.execute(func);

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -123,7 +123,7 @@ test "abandonFiberMutexes marks owned mutex abandoned" {
     // fiber's owned-mutexes list, so under -Dgc-stress=true the fiber and
     // mutex must survive allocMutex's collection.
     const fiber = try gc.allocFiber(types.VOID, 0);
-    var fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    var fiber_val = types.makePointer(&fiber.header);
     gc.pushRoot(&fiber_val);
     defer gc.popRoot();
     var m_val = try gc.allocMutex(types.VOID);
@@ -152,11 +152,11 @@ test "abandonFiberMutexes skips mutex owned by different fiber" {
     defer vm.deinit();
 
     const fiber_a = try gc.allocFiber(types.VOID, 0);
-    var fiber_a_val = types.makePointer(@ptrCast(&fiber_a.header));
+    var fiber_a_val = types.makePointer(&fiber_a.header);
     gc.pushRoot(&fiber_a_val);
     defer gc.popRoot();
     const fiber_b = try gc.allocFiber(types.VOID, 1);
-    var fiber_b_val = types.makePointer(@ptrCast(&fiber_b.header));
+    var fiber_b_val = types.makePointer(&fiber_b.header);
     gc.pushRoot(&fiber_b_val);
     defer gc.popRoot();
     var m_val = try gc.allocMutex(types.VOID);
@@ -185,7 +185,7 @@ test "abandonFiberMutexes skips unlocked mutex" {
     defer vm.deinit();
 
     const fiber = try gc.allocFiber(types.VOID, 0);
-    var fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    var fiber_val = types.makePointer(&fiber.header);
     gc.pushRoot(&fiber_val);
     defer gc.popRoot();
     var m_val = try gc.allocMutex(types.VOID);
@@ -209,7 +209,7 @@ test "abandonFiberMutexes handles multiple mutexes" {
     defer vm.deinit();
 
     const fiber = try gc.allocFiber(types.VOID, 0);
-    var fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    var fiber_val = types.makePointer(&fiber.header);
     // Root everything across the following allocations: under -Dgc-stress=true
     // each allocMutex collects, and an unrooted fiber/mutex local is swept.
     gc.pushRoot(&fiber_val);
@@ -270,7 +270,7 @@ test "abandonFiberMutexes abandons a mutex from another GC heap (#1458)" {
     const m = types.toMutex(m_val);
 
     const fiber = try child_gc.allocFiber(types.VOID, 0);
-    var fiber_val = types.makePointer(@ptrCast(&fiber.header));
+    var fiber_val = types.makePointer(&fiber.header);
     child_gc.pushRoot(&fiber_val);
     defer child_gc.popRoot();
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -60,7 +60,15 @@ pub fn isPointer(v: Value) bool {
     return (v >> 48) == 0xFFFC;
 }
 
-pub fn makePointer(ptr: *anyopaque) Value {
+/// Build a heap Value from the address of a heap struct's `header` field:
+/// `makePointer(&x.header)`. The payload is always the header address —
+/// `toObject` reads it back as `*Object` and `Object.as()` recovers the
+/// enclosing struct via @fieldParentPtr — so heap structs stay free to
+/// gain or reorder fields (Zig's auto layout does not keep `header` at
+/// byte offset 0; it once silently moved Port's to offset 48, #1618).
+/// Taking `*Object` rather than `*anyopaque` makes passing the struct
+/// pointer itself a compile error instead of latent Value corruption.
+pub fn makePointer(ptr: *Object) Value {
     return NANBOX_PTR | @as(u64, @intFromPtr(ptr));
 }
 
@@ -268,8 +276,8 @@ pub const Object = struct {
         // Not a plain @ptrCast: "auto"-layout structs (every T here — none
         // are extern) give Zig no guarantee that `header: Object` sits at
         // byte offset 0, only that it's declared first. @fieldParentPtr
-        // computes the real offset regardless (see makePointer(&x.header)
-        // call sites, which is what self actually points at).
+        // computes the real offset regardless — the inverse of
+        // makePointer(&x.header), which is what self actually points at.
         return @fieldParentPtr("header", self);
     }
 };
@@ -535,10 +543,6 @@ pub const Port = struct {
     write_buf_start: usize = 0,
     write_buf_len: usize = 0,
     /// Windows-only socket-port state (#1608); always defaults elsewhere.
-    /// One u8-backed field rather than two bools: this struct's auto
-    /// layout keeps `header` at offset 0 with a single byte added here,
-    /// but reorders `header` away from 0 with two — see the heap-type
-    /// layout guard at the bottom of this file.
     sock_state: packed struct(u8) {
         /// maybeSetNonblocking's socket probe already ran for this port,
         /// whatever its outcome — the probe is a getsockopt syscall and
@@ -1382,39 +1386,25 @@ test "nil is not a pointer" {
     try std.testing.expect(isNil(NIL));
 }
 
-// ---------------------------------------------------------------------------
-// Heap-type layout guard.
-//
-// A heap Value's 48-bit payload is produced by `makePointer(@ptrCast(x))`
-// at most allocation sites — the *struct* address — while `toObject(v)`
-// reads it as a `*Object` and `Object.as()` treats it as the address of
-// the `header` *field*. Those three agree only while `header` sits at
-// byte offset 0, and Zig's auto struct layout does NOT promise that for
-// any field, first-declared or not: adding two `bool`s to Port once moved
-// its header to offset 48 with no other change, silently turning every
-// port Value into garbage (#1608 review). This guard turns any such
-// layout shift into a compile error; if it fires for a type you just
-// edited, rearrange or repack the new fields (e.g. Port.sock_state packs
-// two flags into one u8 precisely for this) until the offset is 0 again.
-// Fiber (fiber.zig) is deliberately absent: its header already sits at a
-// nonzero offset, which is safe because every Fiber-to-Value site spells
-// makePointer(@ptrCast(&fiber.header)) — the convention Object.as()
-// documents. Migrating the remaining struct-pointer call sites to that
-// convention (making this guard unnecessary) is tracked as a follow-up.
-comptime {
-    const heap_types = [_]type{
-        Pair,              Symbol,         SchemeString, Closure,           NativeFn,
-        NativeClosure,     Vector,         Bytevector,   Port,              RecordType,
-        Function,          Flonum,         Transformer,  ErrorObject,       RecordInstance,
-        Continuation,      MultipleValues, Complex,      Promise,           ParameterObject,
-        FfiLibrary,        FfiFunction,    FfiCallback,  HashTable,         Bignum,
-        Rational,          FileInfo,       UserInfo,     GroupInfo,         DirectoryObject,
-        RandomSource,      Channel,        Mutex,        ConditionVariable, Srfi18Time,
-        SchemeEnvironment,
+test "heap Value round-trip is layout-independent" {
+    // Every heap Value's payload is the address of the struct's `header`
+    // field (makePointer(&x.header)), never the struct address, so heap
+    // structs may gain or reorder fields freely: Zig's auto layout keeps
+    // no field at a fixed offset, and it once moved Port's header to byte
+    // offset 48 just from adding two bools, silently corrupting every port
+    // Value under the old struct-pointer convention (#1618). This test
+    // pins the round-trip on a struct shaped to invite reordering; it must
+    // hold whether or not the header lands at offset 0.
+    const Skewed = struct {
+        flag: bool = false,
+        header: Object,
+        wide: u64 = 0,
     };
-    for (heap_types) |T| {
-        if (@offsetOf(T, "header") != 0) {
-            @compileError("heap type " ++ @typeName(T) ++ ": auto layout moved `header` off byte offset 0; rearrange/repack its fields (see the layout-guard comment in types.zig)");
-        }
-    }
+    var x = Skewed{ .header = .{ .tag = .pair } };
+    const v = makePointer(&x.header);
+    try std.testing.expect(isPointer(v));
+    const obj = toObject(v);
+    try std.testing.expect(obj == &x.header);
+    try std.testing.expect(obj.tag == .pair);
+    try std.testing.expect(obj.as(Skewed) == &x);
 }

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -59,8 +59,8 @@ fn markVMRoots(gc: *memory.GC) void {
     if (vm.gc != gc) return; // only mark the VM that owns this GC
 
     for (vm.frames[0..vm.frame_count]) |f| {
-        if (f.closure) |cls| gc.markValue(types.makePointer(@ptrCast(cls)));
-        if (f.native) |nf| gc.markValue(types.makePointer(@ptrCast(nf)));
+        if (f.closure) |cls| gc.markValue(types.makePointer(&cls.header));
+        if (f.native) |nf| gc.markValue(types.makePointer(&nf.header));
         const window = f.frameWindow();
         const end: usize = @min(@as(usize, f.base) + window, vm.registers.len);
         var r: usize = f.base;

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -49,7 +49,7 @@ pub fn eval(vm: *VM, source: []const u8) VMError!Value {
         }
         const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return VMError.CompileError;
         {
-            var func_val = types.makePointer(@ptrCast(func));
+            var func_val = types.makePointer(&func.header);
             vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
@@ -132,7 +132,7 @@ pub fn compileCachedForm(vm: *VM, source: []const u8) VMError!Value {
     if (reader.hasMore() catch return VMError.CompileError) return VMError.CompileError;
 
     const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return VMError.CompileError;
-    const func_val = types.makePointer(@ptrCast(func));
+    const func_val = types.makePointer(&func.header);
     // No GC-triggering allocation runs between the compile above and the
     // rootedSlot below (unrootFunction and rootedSlot only touch the
     // C-allocated extra_roots list), so `func` needs no interim shadow root.
@@ -162,7 +162,7 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
             last = result catch |err| return err;
         } else {
             const func = compiler_mod.compileExpressionWithMacros(vm.gc, form, &vm.macros, vm.globals) catch return VMError.CompileError;
-            var func_val = types.makePointer(@ptrCast(func));
+            var func_val = types.makePointer(&func.header);
             vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
@@ -183,7 +183,7 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
     const expr = types.car(rest);
 
     const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return VMError.CompileError;
-    var func_val = types.makePointer(@ptrCast(func));
+    var func_val = types.makePointer(&func.header);
     vm.gc.pushRoot(&func_val);
     defer vm.gc.popRoot();
     compiler_mod.Compiler.unrootFunction(vm.gc, func);

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -285,7 +285,7 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
                 }
                 return error.InvalidSyntax;
             };
-            var func_val = types.makePointer(@ptrCast(func));
+            var func_val = types.makePointer(&func.header);
             vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
@@ -721,7 +721,7 @@ fn evalIncludedForm(vm: *VM, expr: Value, path: []const u8, line: u32) void {
     if (vm.lib_compile_collect) |collect| {
         collect.append(vm.gc.allocator, func) catch {};
     }
-    var func_val = types.makePointer(@ptrCast(func));
+    var func_val = types.makePointer(&func.header);
     vm.gc.pushRoot(&func_val);
     defer vm.gc.popRoot();
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
@@ -1044,7 +1044,7 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
     if (vm.lib_compile_collect) |collect| {
         collect.append(vm.gc.allocator, func) catch return VMError.OutOfMemory;
     }
-    var func_val = types.makePointer(@ptrCast(func));
+    var func_val = types.makePointer(&func.header);
     vm.gc.pushRoot(&func_val);
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
     defer vm.gc.popRoot();

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -95,7 +95,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
         else
             compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
-        define_expr = types.makePointer(@ptrCast(func));
+        define_expr = types.makePointer(&func.header);
         compiler_mod.Compiler.unrootFunction(vm.gc, func);
         _ = vm.execute(func) catch |err| return err;
     }
@@ -130,7 +130,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
         else
             compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
-        define_expr = types.makePointer(@ptrCast(func));
+        define_expr = types.makePointer(&func.header);
         compiler_mod.Compiler.unrootFunction(vm.gc, func);
         _ = vm.execute(func) catch |err| return err;
     }
@@ -167,7 +167,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
                 compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
             else
                 compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
-            define_expr = types.makePointer(@ptrCast(func));
+            define_expr = types.makePointer(&func.header);
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = vm.execute(func) catch |err| return err;
         }
@@ -203,7 +203,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
                 compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
             else
                 compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
-            define_expr = types.makePointer(@ptrCast(func));
+            define_expr = types.makePointer(&func.header);
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = vm.execute(func) catch |err| return err;
         }


### PR DESCRIPTION
Closes #1618.

## What

Every heap Value's 48-bit payload is now the address of the struct's `header` field, never the struct address, and the compiler enforces it: `makePointer` takes `*Object` instead of `*anyopaque`.

- **99 struct-pointer sites** (`makePointer(@ptrCast(x))` in memory.zig allocators, gc_collect, gc_deep_copy, bytecode_file*, compiler*, vm*, main, repl, bignum, primitives_lazy, tests) migrated to `makePointer(&x.header)`.
- **23 already-correct sites** (fiber, reactor, primitives_srfi18, shared_channel, primitives_fiber, tests_srfi18) lose their now-redundant `@ptrCast`.
- **The #1608 stopgap comptime layout guard is deleted** (`@offsetOf(T, "header") == 0` assert over the 36 types.zig heap types), along with `Port.sock_state`'s "one u8, not two bools" packing constraint comment. Heap structs can now gain/reorder fields freely — as `Fiber`, whose header already sits at a nonzero offset, always could.
- Docs updated (CLAUDE.md heap-type how-to, docs/dev/adding-features.md — which also had two examples wrapping `allocPair`'s already-`Value` result in `makePointer(@ptrCast(...))`, invalid code even under the old convention).

## Why the signature change

The issue prescribed keeping `*anyopaque` and spelling sites `makePointer(@ptrCast(&x.header))`. Taking `*Object` is the same convention but stronger and terser: `&x.header` needs no cast, passing the struct pointer is a **type error** (with `*anyopaque`, any pointer coerces — no `@ptrCast` even needed — so nothing stops a new site from regressing), and that permanent enforcement is what makes deleting the guard safe rather than hopeful.

## Round-trip contract

`makePointer(&x.header)` → payload = header address → `toObject(v)` reads it as `*Object` → `Object.as(T)` recovers the struct via `@fieldParentPtr("header", ...)`. GC internals (object list threaded through `Object.next`, `finishAlloc(&x.header, ...)`, sweep/free via `obj.as(T)`, remembered set of `*Object`, `writeBarrier(toObject(v)|&x.header, ...)`) were already header-centric — audited, no change needed. No direct `@ptrCast` from `toObject` bypassing `as()` exists.

Behavior today is bit-identical (the guard held before deletion, so every migrated type currently has `header` at offset 0; Fiber was already header-convention); the change removes the layout constraint going forward.

## Testing

- New `types.zig` test: heap-Value round-trip on a deliberately reorder-prone struct (must hold whether or not `header` lands at offset 0), exercising `makePointer`/`toObject`/`as()`.
- `zig build test` — all unit tests pass.
- `bash tests/scheme/run-all.sh` — 476 Scheme files + 1395 R7RS tests, 0 failures.
- Cross-compiles clean for x86_64-linux, aarch64-windows, and wasm32-wasi (Zig analyzes lazily, so platform-gated makePointer sites in the reactor backends type-check only under their targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)