### PR TITLE
Windows pipe readiness: polled backend lifts the blocking-pipe degradation (#1608 stage 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,11 +504,15 @@ flip is the host-capability probe: `fd_fdstat_set_flags(NONBLOCK)` failing
 registers an fd and the reactor degrades to CLOCK-only `poll_oneoff` waits —
 timers and `thread-sleep!` (the one SRFI-18 primitive registered on WASM,
 as a global; the `(srfi 18)` library itself stays native-only) always work.
-On Windows the probe is `isSocketFd` (#1608): socket-backed ports (CRT fds
+On Windows the probe is `fdKind` (#1608): socket-backed ports (CRT fds
 wrapping a SOCKET via `_open_osfhandle`) flip via `FIONBIO` and read/write
 through `platform.sockRecv/sockSend`, with WSAEventSelect readiness in the
-reactor; pipe/file ports stay blocking (no would-block mode at the CRT
-layer — IOCP rework is #1608 stage 2).
+reactor; pipe ports enter *emulated* non-blocking mode (no OS flip exists) —
+`platform.pipeRead/pipeWrite`'s peek/write-quota pre-checks synthesize the
+EAGAIN and the reactor re-polls the same checks on a 10 ms quantum, paid
+only while a pipe waiter exists; file ports stay blocking, which is the
+POSIX baseline too (no OS has regular-file readiness — see
+`docs/dev/windows.md` for why IOCP was rejected).
 Ports on fd > 2 buffer writes in `port.write_buf` until
 `flush-output-port`, `close-port`, a read on the same port, or the 8 KiB
 high-water mark; `close-port` flushes, wakes fibers parked on the fd

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -50,17 +50,20 @@ see. Paths are normalized to `/` at the boundaries that produce them
 accepts forward slashes everywhere the runtime passes paths, and every
 internal path split/join is written for `/`.
 
-## Fd readiness: sockets only (#1608 stage 1)
+## Fd readiness: sockets and pipes (#1608)
 
-Fiber I/O suspension works on **sockets**; pipes and files keep blocking
-reads. Win32 has no unified readiness API for arbitrary handles, so the
-split follows what the platform can express:
+Fiber I/O suspension works on **sockets** (stage 1, event-driven) and
+**pipes** (stage 2, polled); files keep blocking reads — which is not a
+degradation at all, see below. Win32 has no unified readiness API for
+arbitrary handles, so each kind uses what the platform can express. The
+one-time `fdKind` probe (platform_win_pipe.zig) classifies a port's fd on
+first touch: `GetFileType` separates disk files out, and `isSocketFd`'s
+kernel-verified gates split PIPE-typed handles into sockets and pipes.
 
 * **Socket ports.** A socket enters the port layer as a CRT fd created
   with `_open_osfhandle((intptr_t)sock, 0)` — the bridge contract for
-  kaappi-net-style FFI code and `fd->port`. `maybeSetNonblocking`'s
-  one-time `isSocketFd` probe (platform_win_sock.zig) marks the port
-  `sock_state.is_socket` on first touch, so reads/writes route through
+  kaappi-net-style FFI code and `fd->port`. The probe marks the port
+  `fd_state.is_socket`, so reads/writes route through
   `platform.sockRecv`/`sockSend` from the start — CRT `_read`/`_write`
   cannot operate on (overlapped) SOCKET handles at all — and once a
   scheduler exists the port also flips non-blocking via `FIONBIO`, whose
@@ -80,11 +83,36 @@ split follows what the platform can express:
   a kernel-verified `ioctlsocket(FIONREAD)` round-trip, so a file or
   pipe recycling a dead socket's handle value can never be
   misclassified as a socket.
-* **Pipe and file ports.** CRT fds for pipes/files have no would-block
-  mode, so these ports never flip non-blocking, never EAGAIN, and never
-  reach the reactor — single-fiber blocking I/O, the WASI probe-fail
-  shape. Lifting this needs a completion-based (IOCP/overlapped) rework
-  of the retry protocol, deliberately deferred (#1608 stage 2).
+* **Pipe ports** (anonymous or named, e.g. an fd from CRT `_pipe` bridged
+  via `fd->port`) get *polled* readiness (platform_win_pipe.zig). Pipe
+  fds have no would-block mode, so under a scheduler the port enters
+  emulated non-blocking mode: `nonblocking` is set with no OS-level flip,
+  and reads/writes route through `pipeRead`/`pipeWrite`, whose
+  non-destructive pre-checks synthesize the EAGAIN the shared protocol
+  expects — `PeekNamedPipe` gates reads, and
+  `NtQueryInformationFile(FilePipeLocalInformation).WriteQuotaAvailable`
+  (the same query libuv uses for non-overlapped pipe writes) gates
+  writes, clamping each write to the space known to be free so the
+  blocking CRT write underneath can never actually block. The reactor
+  answers "when is it ready again" by re-running the same checks: while
+  any pipe interest is armed, the backend bounds its wait at a 10 ms poll
+  quantum and sweeps `pipePollReady` — the same latency order as the
+  ~15 ms OS timer granularity that already bounds this backend, paid only
+  while a fiber is actually parked on a pipe. Any check failure (broken
+  pipe, wrong-direction end) reports ready so the retried syscall
+  surfaces the real EOF/error; a failed write-quota query falls back to
+  the plain blocking write (the pre-stage-2 behavior, never a wrong
+  result). Sequential programs never set the flag: their pipe ports keep
+  plain blocking `_read`/`_write` and the exact pre-stage-2 syscall
+  profile.
+* **File ports** stay fully blocking — deliberately and permanently,
+  because that is the cross-platform baseline, not a Windows gap: POSIX
+  has no readiness for regular files either (`O_NONBLOCK` is a no-op on
+  them; epoll rejects them with EPERM, kqueue reports them always-ready),
+  so the kqueue/epoll builds also block the OS thread for the duration of
+  a disk read. Only a true async-file-I/O model (io_uring-class) would
+  change this, on every platform alike — out of scope for the KEP-0001
+  readiness model.
 * **Timers and cross-thread wakeups** are unaffected either way: the
   same backend serves `thread-sleep!` and timed channel/mutex waits
   (`WaitForMultipleObjects` bounded by the nearest deadline) and the
@@ -94,6 +122,30 @@ split follows what the platform can express:
 
 Fibers, channels (including capacity-0 rendezvous), SRFI-18 OS threads,
 and cross-thread SharedChannel promotion all work on top of this.
+
+### Why polling, not IOCP (#1608 stage 2 evaluation)
+
+The issue's stage-2 question — do pipes/files justify a completion-based
+(IOCP/overlapped) rework of the park-and-retry protocol? — resolved to
+**no**, on three grounds:
+
+1. **IOCP cannot serve the fds the port layer actually sees.** Overlapped
+   I/O requires `FILE_FLAG_OVERLAPPED` at handle creation, and the pipe
+   fds that reach the runtime — CRT `_pipe`, inherited descriptors,
+   foreign FFI code wrapping `CreatePipe` handles — are synchronous
+   handles without it. The only general completion design is a blocking
+   worker-thread pool (libuv's fallback for non-overlapped pipes), a new
+   subsystem whose issued-read semantics also break the retry protocol's
+   guarantees: a worker that has consumed bytes when the waiting fiber is
+   terminated or the port closed loses data that the park-and-retry
+   model, which never reads until readiness is known, cannot lose.
+2. **Files gain nothing from any of it** — POSIX offers no regular-file
+   readiness either (see above), so there is no behavior gap to close.
+3. **Pipes don't need completion.** The polled design above keeps the
+   protocol byte-for-byte, reuses the backend's existing per-wait sweep
+   shape, and its 10 ms worst-case wake latency sits inside the latency
+   envelope the platform's own timer granularity already imposes — and
+   the quantum is paid only while a pipe waiter exists.
 
 ## Other deliberate degradations
 
@@ -158,8 +210,10 @@ fixture DLL that `windows-cross` cross-compiles into the same artifact
 (`zig cc -target aarch64-windows-gnu -shared`). What CI can't run yet —
 the shell-based suites (#1612) and interactive surfaces like the REPL —
 is verified against a real Windows 11 ARM64 machine (e.g. a UTM VM with
-ssh). The unit-test binary compiles with the same target flag and runs
-on the box:
+ssh). Before any decisive run on the box, `kaappi cache clear` — dirty
+builds at the same commit share bytecode-cache ids with different code.
+The unit-test binary compiles with the same target flag and runs on the
+box:
 
 ```bash
 zig build test -Dtarget=aarch64-windows       # compiles; foreign run steps skip cleanly
@@ -179,7 +233,9 @@ continuations,hygiene,srfi,ffi,audit}` file — the same set the
 suites (`tests_reactor.zig`, `tests_scheduler.zig`, `tests_port_io.zig`)
 run on Windows too: testing_helpers' cross-platform fd pairs substitute
 loopback TCP socket pairs for the POSIX pipes/socketpairs, so those
-suites double as the socket-readiness backend's coverage (#1608). The
+suites double as the socket-readiness backend's coverage, and their
+"#1608:" tests run the same park/wake patterns over real CRT `_pipe`
+pairs, covering the polled pipe backend (stage 2). The
 POSIX-permission/FIFO/uid tests and the dup2-based fd-recycle reactor
 test skip.
 
@@ -203,10 +259,6 @@ the github-release skill's Step 10.
 
 ## Known gaps / follow-ups
 
-* Fiber I/O suspension on **pipes and files** still blocks the OS thread
-  (#1608 stage 2): CRT fds for those have no would-block mode, so lifting
-  it means a completion-based (IOCP/overlapped) rework of the
-  park-and-retry protocol. Sockets are done (stage 1, above).
 * Native compilation on Windows ARM64 crashes in the Zig 0.16.0
   toolchain (`zig build`/`zig build-exe` access-violate on any project,
   #1613) — all builds must cross-compile, and `kaappi compile` on the

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -964,10 +964,16 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                     var start = port.write_buf_start;
                     while (start < port.write_buf_len) {
                         // A Windows socket port must send() — CRT _write
-                        // cannot operate on a SOCKET handle (#1608).
+                        // cannot operate on a SOCKET handle — and a pipe
+                        // port in emulated non-blocking mode must keep its
+                        // quota gate: plain _write on a full pipe would
+                        // block this sweep forever, exactly the would-block
+                        // this loop promises to drop (#1608).
                         const remaining = port.write_buf_len - start;
                         const rc = if (platform.is_windows and port.fd_state.is_socket)
                             platform.sockSend(port.fd, wb.ptr + start, remaining)
+                        else if (platform.is_windows and port.fd_state.is_pipe and port.nonblocking)
+                            platform.pipeWrite(port.fd, wb.ptr + start, remaining)
                         else
                             platform.write(port.fd, wb.ptr + start, remaining);
                         if (rc < 0 and platform.errno(rc) == .INTR) continue;

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -966,7 +966,7 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                         // A Windows socket port must send() — CRT _write
                         // cannot operate on a SOCKET handle (#1608).
                         const remaining = port.write_buf_len - start;
-                        const rc = if (platform.is_windows and port.sock_state.is_socket)
+                        const rc = if (platform.is_windows and port.fd_state.is_socket)
                             platform.sockSend(port.fd, wb.ptr + start, remaining)
                         else
                             platform.write(port.fd, wb.ptr + start, remaining);

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -198,40 +198,6 @@ pub const win = if (is_windows) struct {
     pub const FILE_TYPE_PIPE: u32 = 0x3;
     pub extern "kernel32" fn GetFileType(h: HANDLE) callconv(.winapi) u32;
 
-    // --- Pipe readiness (#1608 stage 2). Anonymous/CRT pipe handles have
-    // no would-block mode and no FILE_FLAG_OVERLAPPED, so pipe readiness is
-    // *polled*: PeekNamedPipe answers "how many bytes could a read return
-    // right now", and NtQueryInformationFile(FilePipeLocalInformation)
-    // answers "how much buffer space could a write consume right now"
-    // (WriteQuotaAvailable — the same query libuv uses for its
-    // non-overlapped pipe writes; stable ntdll ABI since NT4, ntifs.h). ---
-    pub extern "kernel32" fn PeekNamedPipe(h: HANDLE, buf: ?*anyopaque, buf_size: u32, bytes_read: ?*u32, total_avail: ?*u32, bytes_left_msg: ?*u32) callconv(.winapi) c_int;
-    pub extern "ntdll" fn NtQueryInformationFile(h: HANDLE, iosb: *IoStatusBlock, info: *anyopaque, len: u32, class: c_int) callconv(.winapi) i32;
-    pub const IoStatusBlock = extern struct { status_or_pointer: usize, information: usize };
-    /// FILE_INFORMATION_CLASS value for FILE_PIPE_LOCAL_INFORMATION.
-    pub const FilePipeLocalInformation: c_int = 24;
-    /// ntifs.h FILE_PIPE_LOCAL_INFORMATION (all ULONGs).
-    pub const FilePipeLocalInfo = extern struct {
-        named_pipe_type: u32,
-        named_pipe_configuration: u32,
-        maximum_instances: u32,
-        current_instances: u32,
-        inbound_quota: u32,
-        read_data_available: u32,
-        outbound_quota: u32,
-        write_quota_available: u32,
-        named_pipe_state: u32,
-        named_pipe_end: u32,
-    };
-    // named_pipe_configuration values (data-flow direction is fixed at
-    // creation; which end may write follows from it + named_pipe_end).
-    pub const FILE_PIPE_INBOUND: u32 = 0;
-    pub const FILE_PIPE_OUTBOUND: u32 = 1;
-    pub const FILE_PIPE_FULL_DUPLEX: u32 = 2;
-    // named_pipe_end values.
-    pub const FILE_PIPE_CLIENT_END: u32 = 0;
-    pub const FILE_PIPE_SERVER_END: u32 = 1;
-
     pub extern "ws2_32" fn WSAStartup(version: u16, data: *WSAData) callconv(.winapi) c_int;
     pub extern "ws2_32" fn closesocket(s: SOCKET) callconv(.winapi) c_int;
     pub extern "ws2_32" fn WSAGetLastError() callconv(.winapi) c_int;
@@ -1266,7 +1232,8 @@ pub fn argsIterate(args: std.process.Args) std.process.Args.Iterator {
 /// every C runtime uses): wrap in quotes when it contains whitespace/
 /// quotes or is empty; backslashes immediately before a quote (or the
 /// closing quote) are doubled; embedded quotes get a backslash.
-fn appendQuotedArg(list: *std.ArrayList(u8), allocator: std.mem.Allocator, arg: []const u8) !void {
+/// Pub (with buildCommandLineW) only for tests_platform.zig.
+pub fn appendQuotedArg(list: *std.ArrayList(u8), allocator: std.mem.Allocator, arg: []const u8) !void {
     const needs_quotes = arg.len == 0 or std.mem.indexOfAny(u8, arg, " \t\"") != null;
     if (!needs_quotes) {
         try list.appendSlice(allocator, arg);
@@ -1293,7 +1260,7 @@ fn appendQuotedArg(list: *std.ArrayList(u8), allocator: std.mem.Allocator, arg: 
     try list.append(allocator, '"');
 }
 
-fn buildCommandLineW(allocator: std.mem.Allocator, argv: []const []const u8) ![:0]u16 {
+pub fn buildCommandLineW(allocator: std.mem.Allocator, argv: []const []const u8) ![:0]u16 {
     var line: std.ArrayList(u8) = .empty;
     defer line.deinit(allocator);
     for (argv, 0..) |arg, i| {
@@ -1448,103 +1415,5 @@ fn winSpawnInner(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[
     return @truncate(code);
 }
 
-// ---------------------------------------------------------------------------
-// tests (run on the host platform; the Windows arms are exercised by the
-// cross-compiled unit-test binary on a Windows machine)
-// ---------------------------------------------------------------------------
-
-fn expectQuoted(expected: []const u8, arg: []const u8) !void {
-    var list: std.ArrayList(u8) = .empty;
-    defer list.deinit(std.testing.allocator);
-    try appendQuotedArg(&list, std.testing.allocator, arg);
-    try std.testing.expectEqualStrings(expected, list.items);
-}
-
-// CommandLineToArgvW-inverse quoting: these are the canonical cases from
-// the Windows command-line parsing rules; the child's CRT must parse each
-// quoted form back to the original argument.
-test "appendQuotedArg: plain arg unquoted" {
-    try expectQuoted("abc", "abc");
-}
-
-test "appendQuotedArg: spaces force quotes" {
-    try expectQuoted("\"two words\"", "two words");
-}
-
-test "appendQuotedArg: empty arg becomes empty quotes" {
-    try expectQuoted("\"\"", "");
-}
-
-test "appendQuotedArg: embedded quote gets a backslash" {
-    try expectQuoted("\"say \\\" it\"", "say \" it");
-}
-
-test "appendQuotedArg: backslashes before a quote double" {
-    // arg: a\"b  →  "a\\\"b" (the two backslashes encode one literal \,
-    // the third escapes the quote)
-    try expectQuoted("\"a\\\\\\\"b\"", "a\\\"b");
-}
-
-test "appendQuotedArg: trailing backslashes double before the closing quote" {
-    // arg: dir\ with a space → "dir \\" so the closing quote isn't eaten
-    try expectQuoted("\"dir \\\\\"", "dir \\");
-}
-
-test "appendQuotedArg: backslashes not before a quote stay literal" {
-    // Windows paths with spaces: no doubling mid-string
-    try expectQuoted("\"C:\\Program Files\\kaappi\"", "C:\\Program Files\\kaappi");
-}
-
-test "buildCommandLineW joins and round-trips through WTF-16" {
-    const argv = [_][]const u8{ "git", "-C", "C:\\repo dir", "checkout", "v1.0.0", "--" };
-    const wline = try buildCommandLineW(std.testing.allocator, &argv);
-    defer std.testing.allocator.free(wline);
-    var narrow: [256]u8 = undefined;
-    const n = std.unicode.wtf16LeToWtf8(&narrow, wline);
-    try std.testing.expectEqualStrings("git -C \"C:\\repo dir\" checkout v1.0.0 --", narrow[0..n]);
-}
-
-test "monotonicNs advances" {
-    const a = monotonicNs();
-    const b = monotonicNs();
-    try std.testing.expect(b >= a);
-}
-
-test "realTime is after 2020" {
-    const rt = realTime();
-    try std.testing.expect(rt.sec > 1577836800); // 2020-01-01
-    try std.testing.expect(rt.nsec >= 0 and rt.nsec < 1_000_000_000);
-}
-
-test "statPath reports a directory" {
-    if (comptime is_wasm) return error.SkipZigTest;
-    const cwd_path = if (is_windows) "." else "/tmp";
-    const st = statPath(cwd_path) orelse return error.TestUnexpectedResult;
-    try std.testing.expect(st.is_dir);
-    try std.testing.expect(!st.is_file);
-}
-
-test "write to stdout-like sink via openNullSink" {
-    if (comptime is_wasm) return error.SkipZigTest;
-    const fd = try openNullSink();
-    defer close(fd);
-    const msg = "platform shim probe\n";
-    const rc = write(fd, msg.ptr, msg.len);
-    try std.testing.expect(rc == @as(isize, @intCast(msg.len)));
-}
-
-test "dlSym on the dlOpen(null) process handle finds CRT symbols (#1611)" {
-    // The (ffi-open #f) contract: the process handle resolves C runtime
-    // symbols — on Windows via the all-loaded-modules search (abs lives in
-    // ucrtbase.dll, never in the exe's export table), on POSIX via dlsym's
-    // global symbol scope.
-    if (comptime is_wasm) return error.SkipZigTest;
-    if (comptime builtin.target.abi.isMusl()) return error.SkipZigTest; // static libc: no dynamic loading
-    const proc = dlOpen(null) orelse return error.TestUnexpectedResult;
-    defer dlClose(proc);
-    try std.testing.expect(dlSym(proc, "abs") != null);
-    // A miss reports failure without poisoning later lookups.
-    try std.testing.expect(dlSym(proc, "kaappi_no_such_symbol_1611") == null);
-    _ = dlError();
-    try std.testing.expect(dlSym(proc, "abs") != null);
-}
+// Tests live in tests_platform.zig (extracted when this file outgrew the
+// 1500-line policy); appendQuotedArg/buildCommandLineW are pub for them.

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -198,6 +198,40 @@ pub const win = if (is_windows) struct {
     pub const FILE_TYPE_PIPE: u32 = 0x3;
     pub extern "kernel32" fn GetFileType(h: HANDLE) callconv(.winapi) u32;
 
+    // --- Pipe readiness (#1608 stage 2). Anonymous/CRT pipe handles have
+    // no would-block mode and no FILE_FLAG_OVERLAPPED, so pipe readiness is
+    // *polled*: PeekNamedPipe answers "how many bytes could a read return
+    // right now", and NtQueryInformationFile(FilePipeLocalInformation)
+    // answers "how much buffer space could a write consume right now"
+    // (WriteQuotaAvailable — the same query libuv uses for its
+    // non-overlapped pipe writes; stable ntdll ABI since NT4, ntifs.h). ---
+    pub extern "kernel32" fn PeekNamedPipe(h: HANDLE, buf: ?*anyopaque, buf_size: u32, bytes_read: ?*u32, total_avail: ?*u32, bytes_left_msg: ?*u32) callconv(.winapi) c_int;
+    pub extern "ntdll" fn NtQueryInformationFile(h: HANDLE, iosb: *IoStatusBlock, info: *anyopaque, len: u32, class: c_int) callconv(.winapi) i32;
+    pub const IoStatusBlock = extern struct { status_or_pointer: usize, information: usize };
+    /// FILE_INFORMATION_CLASS value for FILE_PIPE_LOCAL_INFORMATION.
+    pub const FilePipeLocalInformation: c_int = 24;
+    /// ntifs.h FILE_PIPE_LOCAL_INFORMATION (all ULONGs).
+    pub const FilePipeLocalInfo = extern struct {
+        named_pipe_type: u32,
+        named_pipe_configuration: u32,
+        maximum_instances: u32,
+        current_instances: u32,
+        inbound_quota: u32,
+        read_data_available: u32,
+        outbound_quota: u32,
+        write_quota_available: u32,
+        named_pipe_state: u32,
+        named_pipe_end: u32,
+    };
+    // named_pipe_configuration values (data-flow direction is fixed at
+    // creation; which end may write follows from it + named_pipe_end).
+    pub const FILE_PIPE_INBOUND: u32 = 0;
+    pub const FILE_PIPE_OUTBOUND: u32 = 1;
+    pub const FILE_PIPE_FULL_DUPLEX: u32 = 2;
+    // named_pipe_end values.
+    pub const FILE_PIPE_CLIENT_END: u32 = 0;
+    pub const FILE_PIPE_SERVER_END: u32 = 1;
+
     pub extern "ws2_32" fn WSAStartup(version: u16, data: *WSAData) callconv(.winapi) c_int;
     pub extern "ws2_32" fn closesocket(s: SOCKET) callconv(.winapi) c_int;
     pub extern "ws2_32" fn WSAGetLastError() callconv(.winapi) c_int;
@@ -378,6 +412,17 @@ pub const isSocketFd = win_sock.isSocketFd;
 pub const setSockNonblockingFd = win_sock.setSockNonblockingFd;
 pub const sockRecv = win_sock.sockRecv;
 pub const sockSend = win_sock.sockSend;
+
+// Windows pipes (#1608 stage 2: polled pipe readiness) live in
+// platform_win_pipe.zig, the same seam. fdKind is the port layer's
+// first-touch classification (socket / pipe / other).
+const win_pipe = @import("platform_win_pipe.zig");
+pub const FdKind = win_pipe.FdKind;
+pub const fdKind = win_pipe.fdKind;
+pub const pipeHandleFromFd = win_pipe.pipeHandleFromFd;
+pub const pipeRead = win_pipe.pipeRead;
+pub const pipeWrite = win_pipe.pipeWrite;
+pub const pipePollReady = win_pipe.pipePollReady;
 pub const SockReadiness = win_sock.SockReadiness;
 pub const sockPollReady = win_sock.sockPollReady;
 

--- a/src/platform_win_pipe.zig
+++ b/src/platform_win_pipe.zig
@@ -21,10 +21,26 @@
 //! flag, so their pipe I/O keeps the plain blocking CRT calls and syscall
 //! profile.
 //!
+//! One documented caveat rules the threading story: MSDN warns that
+//! PeekNamedPipe "can block thread execution the same way any I/O function
+//! can when called on a synchronous handle in a multi-threaded
+//! application" — synchronous file objects serialize their I/O, so a peek
+//! races a *concurrent blocking read on the same handle from another
+//! thread*. That situation is outside this runtime's model: ports never
+//! cross OS threads (SRFI-18 threads deep-copy, each owns its VM/GC), so
+//! every peek, quota query, and read/write on a pipe handle issues from
+//! the one thread that owns the port — and the only *blocking* pipe reads
+//! that thread ever makes are sequential-mode (no scheduler, so nothing
+//! else runs) or post-peek (bytes known present, returns immediately).
+//! Foreign FFI code sharing a pipe handle across threads accepts the same
+//! caveat POSIX code sharing an fd across threads always has.
+//!
 //! Everything here is a comptime no-op off Windows. Split placed beside
 //! platform_win_sock.zig (file size policy); platform.zig re-exports the
-//! public symbols, and the raw kernel32/ntdll externs stay in
-//! `platform.win`.
+//! public symbols. Unlike the ws2_32 slice — whose externs live in
+//! `platform.win` because reactor.zig and testing_helpers share them —
+//! the kernel32/ntdll pipe externs below have this file as their only
+//! consumer, so they stay private to it.
 
 const std = @import("std");
 const platform = @import("platform.zig");
@@ -32,6 +48,42 @@ const win = platform.win;
 const E = platform.E;
 const fd_t = platform.fd_t;
 const is_windows = platform.is_windows;
+
+/// Pipe-readiness syscall surface (#1608 stage 2). PeekNamedPipe answers
+/// "how many bytes could a read return right now";
+/// NtQueryInformationFile(FilePipeLocalInformation) answers "how much
+/// buffer space could a write consume right now" (WriteQuotaAvailable —
+/// the same query libuv uses for its non-overlapped pipe writes; stable
+/// ntdll ABI since NT4, ntifs.h). Wrapped in the same comptime guard as
+/// `platform.win` so nothing Windows-flavored is ever analyzed elsewhere.
+const winp = if (is_windows) struct {
+    pub extern "kernel32" fn PeekNamedPipe(h: win.HANDLE, buf: ?*anyopaque, buf_size: u32, bytes_read: ?*u32, total_avail: ?*u32, bytes_left_msg: ?*u32) callconv(.winapi) c_int;
+    pub extern "ntdll" fn NtQueryInformationFile(h: win.HANDLE, iosb: *IoStatusBlock, info: *anyopaque, len: u32, class: c_int) callconv(.winapi) i32;
+    pub const IoStatusBlock = extern struct { status_or_pointer: usize, information: usize };
+    /// FILE_INFORMATION_CLASS value for FILE_PIPE_LOCAL_INFORMATION.
+    pub const FilePipeLocalInformation: c_int = 24;
+    /// ntifs.h FILE_PIPE_LOCAL_INFORMATION (all ULONGs).
+    pub const FilePipeLocalInfo = extern struct {
+        named_pipe_type: u32,
+        named_pipe_configuration: u32,
+        maximum_instances: u32,
+        current_instances: u32,
+        inbound_quota: u32,
+        read_data_available: u32,
+        outbound_quota: u32,
+        write_quota_available: u32,
+        named_pipe_state: u32,
+        named_pipe_end: u32,
+    };
+    // named_pipe_configuration values (data-flow direction is fixed at
+    // creation; which end may write follows from it + named_pipe_end).
+    pub const FILE_PIPE_INBOUND: u32 = 0;
+    pub const FILE_PIPE_OUTBOUND: u32 = 1;
+    pub const FILE_PIPE_FULL_DUPLEX: u32 = 2;
+    // named_pipe_end values.
+    pub const FILE_PIPE_CLIENT_END: u32 = 0;
+    pub const FILE_PIPE_SERVER_END: u32 = 1;
+} else struct {};
 
 /// What a CRT fd wraps, as far as fd readiness is concerned. `.socket`
 /// gets event-driven readiness (WSAEventSelect, stage 1), `.pipe` gets
@@ -62,10 +114,10 @@ pub fn pipeHandleFromFd(fd: fd_t) ?win.HANDLE {
     return @ptrFromInt(@as(usize, @bitCast(raw)));
 }
 
-fn queryPipeInfo(h: win.HANDLE) ?win.FilePipeLocalInfo {
-    var iosb: win.IoStatusBlock = undefined;
-    var info: win.FilePipeLocalInfo = undefined;
-    const status = win.NtQueryInformationFile(h, &iosb, &info, @sizeOf(win.FilePipeLocalInfo), win.FilePipeLocalInformation);
+fn queryPipeInfo(h: win.HANDLE) ?winp.FilePipeLocalInfo {
+    var iosb: winp.IoStatusBlock = undefined;
+    var info: winp.FilePipeLocalInfo = undefined;
+    const status = winp.NtQueryInformationFile(h, &iosb, &info, @sizeOf(winp.FilePipeLocalInfo), winp.FilePipeLocalInformation);
     if (status < 0) return null;
     return info;
 }
@@ -77,11 +129,11 @@ fn queryPipeInfo(h: win.HANDLE) ?win.FilePipeLocalInfo {
 /// Load-bearing for pipeWrite: quota == 0 on a writable end means "full,
 /// park until the reader drains", but on a non-writable end it would mean
 /// "park forever" — that case must surface the real write error instead.
-fn isWritableEnd(info: win.FilePipeLocalInfo) bool {
+fn isWritableEnd(info: winp.FilePipeLocalInfo) bool {
     return switch (info.named_pipe_configuration) {
-        win.FILE_PIPE_FULL_DUPLEX => true,
-        win.FILE_PIPE_INBOUND => info.named_pipe_end == win.FILE_PIPE_CLIENT_END,
-        win.FILE_PIPE_OUTBOUND => info.named_pipe_end == win.FILE_PIPE_SERVER_END,
+        winp.FILE_PIPE_FULL_DUPLEX => true,
+        winp.FILE_PIPE_INBOUND => info.named_pipe_end == winp.FILE_PIPE_CLIENT_END,
+        winp.FILE_PIPE_OUTBOUND => info.named_pipe_end == winp.FILE_PIPE_SERVER_END,
         // Unknown layout: claim writable and let the write surface the truth.
         else => true,
     };
@@ -100,7 +152,7 @@ pub fn pipeRead(fd: fd_t, buf: [*]u8, len: usize) isize {
         return -1;
     };
     var avail: u32 = 0;
-    if (win.PeekNamedPipe(h, null, 0, null, &avail, null) != 0 and avail == 0) {
+    if (winp.PeekNamedPipe(h, null, 0, null, &avail, null) != 0 and avail == 0) {
         win._errno().* = @intFromEnum(E.AGAIN);
         return -1;
     }
@@ -146,7 +198,7 @@ pub fn pipePollReady(fd: fd_t, want_read: bool, want_write: bool) PipeReadiness 
     var result: PipeReadiness = .{};
     if (want_read) {
         var avail: u32 = 0;
-        if (win.PeekNamedPipe(h, null, 0, null, &avail, null) == 0) {
+        if (winp.PeekNamedPipe(h, null, 0, null, &avail, null) == 0) {
             result.readable = true;
         } else {
             result.readable = avail > 0;

--- a/src/platform_win_pipe.zig
+++ b/src/platform_win_pipe.zig
@@ -1,0 +1,163 @@
+//! Windows pipe substrate (#1608 stage 2: pipe readiness).
+//!
+//! Pipe fds on Windows have no would-block mode: the CRT layer offers no
+//! O_NONBLOCK, anonymous/CRT pipe handles are created without
+//! FILE_FLAG_OVERLAPPED (so completion-based I/O — IOCP — is impossible on
+//! the handles that actually reach the port layer), and a pipe HANDLE is
+//! not a waitable readiness object. What the platform *does* offer is
+//! non-destructive state queries: PeekNamedPipe answers "how many bytes
+//! could a read return right now", and
+//! NtQueryInformationFile(FilePipeLocalInformation) answers "how much
+//! buffer space could a write consume right now" (the same query libuv
+//! uses for its non-overlapped pipe writes).
+//!
+//! Those two queries carry the whole design. A pipe port in emulated
+//! non-blocking mode (port.nonblocking set with no OS-level flip —
+//! maybeSetNonblocking) reads/writes through pipeRead/pipeWrite below,
+//! whose pre-checks synthesize the EAGAIN that drives the shared
+//! park-and-retry protocol unchanged; the reactor's WindowsEventBackend
+//! answers "when is it ready again" by re-running the same checks on a
+//! bounded poll cadence (pipePollReady). Sequential programs never set the
+//! flag, so their pipe I/O keeps the plain blocking CRT calls and syscall
+//! profile.
+//!
+//! Everything here is a comptime no-op off Windows. Split placed beside
+//! platform_win_sock.zig (file size policy); platform.zig re-exports the
+//! public symbols, and the raw kernel32/ntdll externs stay in
+//! `platform.win`.
+
+const std = @import("std");
+const platform = @import("platform.zig");
+const win = platform.win;
+const E = platform.E;
+const fd_t = platform.fd_t;
+const is_windows = platform.is_windows;
+
+/// What a CRT fd wraps, as far as fd readiness is concerned. `.socket`
+/// gets event-driven readiness (WSAEventSelect, stage 1), `.pipe` gets
+/// polled readiness (this file, stage 2), `.other` — disk files, console,
+/// character devices — stays fully blocking, which for regular files is
+/// exactly the POSIX baseline (O_NONBLOCK is a no-op on regular files
+/// everywhere; epoll rejects them outright).
+pub const FdKind = enum { socket, pipe, other };
+
+/// One-shot fd classification for the port layer's first-touch probe and
+/// the reactor's arm routing. GetFileType returns PIPE for both sockets
+/// and pipes; isSocketFd's kernel-verified gates split those (and defeat
+/// stale ws2_32 entries left by handle-value recycling — see its comment).
+pub fn fdKind(fd: fd_t) FdKind {
+    if (comptime !is_windows) return .other;
+    const h = pipeHandleFromFd(fd) orelse return .other;
+    if (win.GetFileType(h) != win.FILE_TYPE_PIPE) return .other;
+    return if (platform.isSocketFd(fd)) .socket else .pipe;
+}
+
+/// The HANDLE behind a CRT fd, or null if the fd is invalid/unassociated
+/// (sockFromFd's shape, minus the SOCKET cast).
+pub fn pipeHandleFromFd(fd: fd_t) ?win.HANDLE {
+    const raw = win._get_osfhandle(fd);
+    // -1 is INVALID_HANDLE_VALUE (bad fd), -2 the CRT's "fd has no
+    // associated stream" marker.
+    if (raw == -1 or raw == -2) return null;
+    return @ptrFromInt(@as(usize, @bitCast(raw)));
+}
+
+fn queryPipeInfo(h: win.HANDLE) ?win.FilePipeLocalInfo {
+    var iosb: win.IoStatusBlock = undefined;
+    var info: win.FilePipeLocalInfo = undefined;
+    const status = win.NtQueryInformationFile(h, &iosb, &info, @sizeOf(win.FilePipeLocalInfo), win.FilePipeLocalInformation);
+    if (status < 0) return null;
+    return info;
+}
+
+/// Whether this end of the pipe is one data can be written *into*. A pipe's
+/// data-flow direction is fixed at creation (named_pipe_configuration) and
+/// each handle knows which end it holds (named_pipe_end); CreatePipe's
+/// anonymous pipes are INBOUND with the write handle on the client end.
+/// Load-bearing for pipeWrite: quota == 0 on a writable end means "full,
+/// park until the reader drains", but on a non-writable end it would mean
+/// "park forever" — that case must surface the real write error instead.
+fn isWritableEnd(info: win.FilePipeLocalInfo) bool {
+    return switch (info.named_pipe_configuration) {
+        win.FILE_PIPE_FULL_DUPLEX => true,
+        win.FILE_PIPE_INBOUND => info.named_pipe_end == win.FILE_PIPE_CLIENT_END,
+        win.FILE_PIPE_OUTBOUND => info.named_pipe_end == win.FILE_PIPE_SERVER_END,
+        // Unknown layout: claim writable and let the write surface the truth.
+        else => true,
+    };
+}
+
+/// read(2)-shaped, peek-gated read on a pipe fd in emulated non-blocking
+/// mode: no data pending synthesizes EAGAIN (the CRT read would block);
+/// otherwise the plain blocking CRT read runs and cannot block — a pipe
+/// read short-returns whatever is buffered, and a failed peek (broken or
+/// non-readable end) means the read itself returns 0/EOF or the real error
+/// immediately.
+pub fn pipeRead(fd: fd_t, buf: [*]u8, len: usize) isize {
+    if (comptime !is_windows) return -1;
+    const h = pipeHandleFromFd(fd) orelse {
+        win._errno().* = @intFromEnum(E.BADF);
+        return -1;
+    };
+    var avail: u32 = 0;
+    if (win.PeekNamedPipe(h, null, 0, null, &avail, null) != 0 and avail == 0) {
+        win._errno().* = @intFromEnum(E.AGAIN);
+        return -1;
+    }
+    return platform.read(fd, buf, len);
+}
+
+/// write(2)-shaped, quota-gated write on a pipe fd in emulated non-blocking
+/// mode. Byte-mode pipe writes block until *every* requested byte fits, so
+/// the request is clamped to the space known to be free — the caller's
+/// short-write loop (drainWriteBuffer) handles the remainder. Zero free
+/// space on a writable end synthesizes EAGAIN; a failed query or a
+/// non-writable end falls through to the plain CRT write, which surfaces
+/// the real error (or blocks, exactly as before stage 2 — the graceful
+/// degradation, never a wrong result).
+pub fn pipeWrite(fd: fd_t, buf: [*]const u8, len: usize) isize {
+    if (comptime !is_windows) return -1;
+    const h = pipeHandleFromFd(fd) orelse {
+        win._errno().* = @intFromEnum(E.BADF);
+        return -1;
+    };
+    const info = queryPipeInfo(h) orelse return platform.write(fd, buf, len);
+    if (!isWritableEnd(info)) return platform.write(fd, buf, len);
+    if (info.write_quota_available == 0) {
+        win._errno().* = @intFromEnum(E.AGAIN);
+        return -1;
+    }
+    return platform.write(fd, buf, @min(len, info.write_quota_available));
+}
+
+pub const PipeReadiness = struct { readable: bool = false, writable: bool = false };
+
+/// Snapshot of the pipe's current readiness in the requested directions —
+/// the reactor's poll-cadence re-check (level-triggered by construction, so
+/// none of WSAEventSelect's edge-record races apply). Any query failure —
+/// bad fd, broken pipe, non-readable/non-writable end — reports the
+/// requested direction ready: a spurious wake is always safe under the
+/// park-and-retry protocol (the retried syscall surfaces the real outcome),
+/// a missed one parks the fiber forever.
+pub fn pipePollReady(fd: fd_t, want_read: bool, want_write: bool) PipeReadiness {
+    if (comptime !is_windows) return .{};
+    const h = pipeHandleFromFd(fd) orelse
+        return .{ .readable = want_read, .writable = want_write };
+    var result: PipeReadiness = .{};
+    if (want_read) {
+        var avail: u32 = 0;
+        if (win.PeekNamedPipe(h, null, 0, null, &avail, null) == 0) {
+            result.readable = true;
+        } else {
+            result.readable = avail > 0;
+        }
+    }
+    if (want_write) {
+        if (queryPipeInfo(h)) |info| {
+            result.writable = !isWritableEnd(info) or info.write_quota_available > 0;
+        } else {
+            result.writable = true;
+        }
+    }
+    return result;
+}

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -168,35 +168,47 @@ fn isBufferedFdPort(port: *types.Port) bool {
 /// registers with the reactor, and I/O degrades to single-fiber blocking
 /// exactly where the host can't support better.
 ///
-/// On Windows the probe is isSocketFd (#1608 stage 1): a port whose CRT
-/// fd wraps a SOCKET is marked `sock_state.is_socket` — unconditionally,
-/// on first touch — routing its I/O through sockRecv/sockSend (portFdRead/
+/// On Windows the probe is fdKind (#1608): a port whose CRT fd wraps a
+/// SOCKET is marked `fd_state.is_socket` — unconditionally, on first
+/// touch — routing its I/O through sockRecv/sockSend (portFdRead/
 /// portFdWrite); once a scheduler exists it additionally flips
 /// non-blocking via FIONBIO, so would-block surfaces as the EAGAIN the
 /// shared paths expect and the WSAEventSelect reactor backend supplies
-/// the wakeup. Pipe and file fds have no would-block mode at the CRT
-/// layer, so those ports stay blocking — for them the degradation is the
-/// same shape as a WASI host without fd_fdstat_set_flags. The probe
-/// result is remembered per port (sock_state.probe_done) so file ports
-/// don't pay a getsockopt per read.
+/// the wakeup (stage 1). A non-socket pipe fd is marked
+/// `fd_state.is_pipe`; once a scheduler exists the port enters *emulated*
+/// non-blocking mode — `nonblocking` set with no OS-level flip (pipe fds
+/// have no would-block mode) — routing its I/O through pipeRead/pipeWrite,
+/// whose peek/quota pre-checks synthesize the EAGAIN, and the reactor
+/// re-runs those checks on a poll cadence for the wakeup (stage 2). File
+/// fds stay fully blocking, which is the POSIX baseline too (O_NONBLOCK
+/// is a no-op on regular files; epoll rejects them). The probe result is
+/// remembered per port (fd_state.probe_done) so file ports don't pay the
+/// probe syscalls per read.
 pub fn maybeSetNonblocking(port: *types.Port) void {
     if (port.nonblocking or port.is_string_port or port.fd <= 2) return;
     if (comptime platform.is_windows) {
-        // The socket probe is NOT scheduler-gated, unlike the flip below:
+        // The fd-kind probe is NOT scheduler-gated, unlike the flips below:
         // sockets are OVERLAPPED handles by default on Windows, which CRT
         // _read/_write (plain ReadFile/WriteFile) cannot operate on at
         // all — so a socket port must route through recv/send (portFdRead/
         // portFdWrite) from its very first touch, scheduler or not. A
         // still-blocking socket keeps blocking recv/send semantics, so
         // sequential programs behave exactly like POSIX blocking reads.
-        if (!port.sock_state.probe_done) {
-            port.sock_state.probe_done = true;
-            if (platform.isSocketFd(port.fd)) port.sock_state.is_socket = true;
+        if (!port.fd_state.probe_done) {
+            port.fd_state.probe_done = true;
+            switch (platform.fdKind(port.fd)) {
+                .socket => port.fd_state.is_socket = true,
+                .pipe => port.fd_state.is_pipe = true,
+                .other => {},
+            }
         }
-        if (!port.sock_state.is_socket) return; // pipes/files: no would-block mode
         const wvm = vm_mod.vm_instance orelse return;
         if (wvm.scheduler == null) return;
-        if (platform.setSockNonblockingFd(port.fd)) port.nonblocking = true;
+        if (port.fd_state.is_socket) {
+            if (platform.setSockNonblockingFd(port.fd)) port.nonblocking = true;
+        } else if (port.fd_state.is_pipe) {
+            port.nonblocking = true;
+        }
         return;
     }
     const vm = vm_mod.vm_instance orelse return;
@@ -217,21 +229,27 @@ pub fn maybeSetNonblocking(port: *types.Port) void {
     port.nonblocking = true;
 }
 
-/// The port's fd byte source: read(2) everywhere except a Windows socket
-/// port, which must recv() on the underlying SOCKET — CRT _read cannot
-/// operate on (overlapped) SOCKET handles at all (platform_win_sock.zig).
-/// Same return/errno contract as platform.read.
+/// The port's fd byte source: read(2) everywhere except on Windows, where
+/// a socket port must recv() on the underlying SOCKET — CRT _read cannot
+/// operate on (overlapped) SOCKET handles at all (platform_win_sock.zig) —
+/// and a pipe port in emulated non-blocking mode reads through the
+/// PeekNamedPipe gate that synthesizes EAGAIN (platform_win_pipe.zig; a
+/// sequential program's pipe port keeps plain blocking _read and its exact
+/// syscall profile). Same return/errno contract as platform.read.
 fn portFdRead(port: *types.Port, buf: [*]u8, len: usize) isize {
     if (comptime platform.is_windows) {
-        if (port.sock_state.is_socket) return platform.sockRecv(port.fd, buf, len);
+        if (port.fd_state.is_socket) return platform.sockRecv(port.fd, buf, len);
+        if (port.fd_state.is_pipe and port.nonblocking) return platform.pipeRead(port.fd, buf, len);
     }
     return platform.read(port.fd, buf, len);
 }
 
-/// The port's fd byte sink; portFdRead's write-side twin.
+/// The port's fd byte sink; portFdRead's write-side twin (pipe ports gate
+/// on the write-quota query instead of the peek).
 fn portFdWrite(port: *types.Port, buf: [*]const u8, len: usize) isize {
     if (comptime platform.is_windows) {
-        if (port.sock_state.is_socket) return platform.sockSend(port.fd, buf, len);
+        if (port.fd_state.is_socket) return platform.sockSend(port.fd, buf, len);
+        if (port.fd_state.is_pipe and port.nonblocking) return platform.pipeWrite(port.fd, buf, len);
     }
     return platform.write(port.fd, buf, len);
 }
@@ -385,7 +403,7 @@ pub fn flushAllOpenPorts(gc: *memory.GC) void {
             const port = o.as(types.Port);
             if (!port.is_open or port.is_string_port or port.fd <= 2) continue;
             const wb = port.write_buf orelse continue;
-            // Ensure the Windows socket probe ran: a below-high-water
+            // Ensure the Windows fd-kind probe ran: a below-high-water
             // append never drains, so this may be the port's first fd
             // touch, and CRT _write cannot operate on a SOCKET handle.
             maybeSetNonblocking(port);

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -6,7 +6,7 @@
 //! became runnable (fd readiness or timer expiry). Wired into the
 //! scheduler in KEP-0001 Phase 2 (fiber.zig's runSchedulerStep). Backends:
 //! kqueue (macOS/BSD), epoll (Linux), poll_oneoff (WASI, Phase 4),
-//! WSAEventSelect (Windows, sockets only — #1608). See
+//! WSAEventSelect + polled pipes (Windows — #1608). See
 //! https://github.com/kaappi/keps/blob/main/keps/0001-event-loop-reactor.md
 const std = @import("std");
 const platform = @import("platform.zig");
@@ -891,35 +891,50 @@ const WasiPollBackend = struct {
 };
 
 // ---------------------------------------------------------------------------
-// Windows event backend (#1608 stage 1: socket readiness)
+// Windows event backend (#1608: socket + pipe readiness)
 //
-// Fd readiness on Windows is socket-only. Win32 has no unified readiness
-// API for arbitrary handles — pipes and files have no would-block mode at
-// the CRT layer, so their ports never flip non-blocking, never EAGAIN,
-// and never reach register() (single-fiber blocking I/O, the WASI
-// probe-fail shape). Sockets do: maybeSetNonblocking's isSocketFd probe
-// flips them via FIONBIO, their reads/writes EAGAIN through
-// sockRecv/sockSend, and this backend supplies the wakeup.
+// Win32 has no unified readiness API for arbitrary handles, so this
+// backend is two mechanisms behind one wait:
 //
-// The wakeup is WSAEventSelect wired into the pre-existing event wait:
-// every armed socket posts its network-event records to one shared
-// manual-reset event (`sock_event`), and wait() blocks on exactly two
-// handles — the auto-reset notify event (KEP-0002 cross-thread ring,
-// unchanged) and `sock_event` — bounded by the nearest timer deadline.
-// After any wakeup a sweep WSAEnumNetworkEvents-es every armed socket and
-// maps the records onto ReadyEvents (FD_READ/FD_ACCEPT → readable,
-// FD_WRITE/FD_CONNECT → writable, FD_CLOSE → both, the epoll HUP
-// policy). Sharing one event avoids the 64-handle
-// WaitForMultipleObjects ceiling outright; the O(armed) sweep mirrors
-// WasiPollBackend's per-wait rebuild.
+// * Sockets (stage 1) get event-driven readiness. maybeSetNonblocking's
+//   fdKind probe flips them via FIONBIO, their reads/writes EAGAIN
+//   through sockRecv/sockSend, and every armed socket posts its
+//   network-event records via WSAEventSelect to one shared manual-reset
+//   event (`sock_event`). wait() blocks on exactly two handles — the
+//   auto-reset notify event (KEP-0002 cross-thread ring, unchanged) and
+//   `sock_event` — bounded by the nearest timer deadline; after any
+//   wakeup a sweep WSAEnumNetworkEvents-es every armed socket and maps
+//   the records onto ReadyEvents (FD_READ/FD_ACCEPT → readable,
+//   FD_WRITE/FD_CONNECT → writable, FD_CLOSE → both, the epoll HUP
+//   policy). Sharing one event avoids the 64-handle
+//   WaitForMultipleObjects ceiling outright; the O(armed) sweep mirrors
+//   WasiPollBackend's per-wait rebuild.
 //
-// FD_WRITE and FD_CLOSE are edge-recorded, and (re)issuing WSAEventSelect
-// clears the socket's pending records — so a condition that became true
-// before arm() would be missed entirely (the classic WSAEventSelect
-// races: send hit WSAEWOULDBLOCK, the peer drained the buffer, *then* the
-// fiber parked). arm() therefore takes a 0-timeout select() snapshot
-// right after arming and stashes it as pre-ready state that the next
-// wait() reports without blocking.
+//   FD_WRITE and FD_CLOSE are edge-recorded, and (re)issuing
+//   WSAEventSelect clears the socket's pending records — so a condition
+//   that became true before arm() would be missed entirely (the classic
+//   WSAEventSelect races: send hit WSAEWOULDBLOCK, the peer drained the
+//   buffer, *then* the fiber parked). arm() therefore takes a 0-timeout
+//   select() snapshot right after arming and stashes it as pre-ready
+//   state that the next wait() reports without blocking.
+//
+// * Pipes (stage 2) get *polled* readiness. Pipe handles are not
+//   waitable readiness objects and carry no would-block mode; completion
+//   I/O is off the table too (CRT/inherited anonymous pipes lack
+//   FILE_FLAG_OVERLAPPED — see platform_win_pipe.zig). What they do
+//   offer is non-destructive state queries, so a pipe port EAGAINs
+//   through pipeRead/pipeWrite's peek/quota pre-checks, and while any
+//   pipe interest is armed wait() bounds its block at
+//   `pipe_poll_quantum_ns` and re-runs the same checks (pipePollReady)
+//   in its sweep — level-triggered by construction, so none of the
+//   edge-record races above apply and no pre-ready snapshot is needed.
+//   The quantum is the same order as the ~15 ms OS timer granularity
+//   that already bounds this backend's timers, and it is paid only
+//   while a fiber is actually parked on a pipe.
+//
+// Files stay fully blocking — which is the POSIX baseline as well
+// (O_NONBLOCK is a no-op on regular files; epoll rejects them), so
+// there is no cross-platform behavior gap to lift for them.
 // ---------------------------------------------------------------------------
 
 const WindowsEventBackend = struct {
@@ -935,8 +950,16 @@ const WindowsEventBackend = struct {
     /// fd → armed socket state; the userspace registry the sweep walks
     /// (kernel knotes' stand-in, like WasiPollBackend.interests).
     sockets: std.AutoHashMap(i32, SockReg),
+    /// fd → armed pipe interest (#1608 stage 2). No kernel object backs
+    /// these; while non-empty, wait() bounds its block at the poll
+    /// quantum and re-checks each entry (pipePollReady) in its sweep. A
+    /// reported direction disarms itself (the WasiPollBackend ONESHOT
+    /// emulation), so entries exist only while a fiber is parked and the
+    /// quantum is never paid otherwise.
+    pipes: std.AutoHashMap(i32, PipeReg),
     ready: std.ArrayList(ReadyEvent) = .empty,
-    /// Sweep scratch: fds whose socket died under the registration.
+    /// Sweep scratch: fds whose socket died under the registration, and
+    /// pipe fds whose armed interest was fully consumed this sweep.
     dead: std.ArrayList(i32) = .empty,
     /// Whether any armed socket carries an unreported pre-ready snapshot;
     /// makes the next wait() a 0-timeout collect instead of a block.
@@ -951,6 +974,15 @@ const WindowsEventBackend = struct {
         pre_write: bool = false,
     };
 
+    const PipeReg = struct { want_read: bool, want_write: bool };
+
+    /// Wait-timeout cap while any pipe interest is armed. Pipe readiness
+    /// on Windows is polled (header comment); this is the cadence — the
+    /// same order as the OS scheduler's ~15 ms timer granularity that
+    /// already bounds this backend, so pipe waits join the platform's
+    /// existing latency envelope rather than adding a new one.
+    const pipe_poll_quantum_ms: u32 = 10;
+
     fn init(allocator: std.mem.Allocator) !WindowsEventBackend {
         const ev = platform.win.CreateEventW(null, 0, 0, null) orelse return error.Unexpected;
         const sock_ev = platform.win.CreateEventW(null, 1, 0, null) orelse {
@@ -962,6 +994,7 @@ const WindowsEventBackend = struct {
             .sock_event = sock_ev,
             .allocator = allocator,
             .sockets = std.AutoHashMap(i32, SockReg).init(allocator),
+            .pipes = std.AutoHashMap(i32, PipeReg).init(allocator),
         };
     }
 
@@ -982,21 +1015,31 @@ const WindowsEventBackend = struct {
         }
         _ = platform.win.CloseHandle(self.sock_event);
         self.sockets.deinit();
+        self.pipes.deinit();
         self.ready.deinit(self.allocator);
         self.dead.deinit(self.allocator);
     }
 
-    /// Arms readiness interest for the socket behind `fd`. Both reactor
-    /// call sites pass the fd's complete desired state, and WSAEventSelect
-    /// replaces the previous mask wholesale — epoll's CTL_MOD shape, so
-    /// `first_time` is irrelevant. The SOCKET is re-derived from the fd on
-    /// every arm, which also self-heals fd-number recycling over a stale
-    /// registration (the epoll ENOENT-retry concern). Fails cleanly on a
-    /// non-socket fd (WSAEventSelect: WSAENOTSOCK) — waitForFd turns that
-    /// into a diagnosable registration error; port-layer callers never get
-    /// here for non-sockets because only sockets ever EAGAIN.
+    /// Arms readiness interest for the socket or pipe behind `fd`. Both
+    /// reactor call sites pass the fd's complete desired state, and both
+    /// mechanisms replace the previous interest wholesale — epoll's
+    /// CTL_MOD shape, so `first_time` is irrelevant. The fd's kind and
+    /// its SOCKET are re-derived on every arm, which also self-heals
+    /// fd-number recycling over a stale registration (the epoll
+    /// ENOENT-retry concern), including a recycle that changes the fd's
+    /// kind — each path drops the other registry's entry. Fails cleanly
+    /// on a non-socket, non-pipe fd (WSAEventSelect: WSAENOTSOCK) —
+    /// waitForFd turns that into a diagnosable registration error;
+    /// port-layer callers never get here for files because file ports
+    /// never EAGAIN.
     fn arm(self: *WindowsEventBackend, fd: i32, wants_read: bool, wants_write: bool, _: bool) !void {
         platform.ensureWinsock();
+        if (platform.fdKind(fd) == .pipe) {
+            _ = self.sockets.remove(fd);
+            try self.pipes.put(fd, .{ .want_read = wants_read, .want_write = wants_write });
+            return;
+        }
+        _ = self.pipes.remove(fd);
         const sock = platform.sockFromFd(fd) orelse return error.Unexpected;
 
         // Reserve the map slot before touching the kernel so an OOM can't
@@ -1026,6 +1069,9 @@ const WindowsEventBackend = struct {
             // are irrelevant since the registry entry is dropped either way.
             _ = platform.win.WSAEventSelect(kv.value.sock, null, 0);
         }
+        // Pipes have no kernel arming to cancel — dropping the entry is
+        // the whole disarm.
+        _ = self.pipes.remove(fd);
     }
 
     fn wait(self: *WindowsEventBackend, timeout_ns: ?u64) ![]const ReadyEvent {
@@ -1035,6 +1081,9 @@ const WindowsEventBackend = struct {
             const ceil_ms = (ns +| 999_999) / 1_000_000;
             break :blk @intCast(@min(ceil_ms, platform.win.INFINITE - 1));
         } else platform.win.INFINITE;
+        // Armed pipe interest has no kernel wakeup — bound the block at
+        // the poll quantum so the sweep below re-checks it (#1608 stage 2).
+        if (self.pipes.count() > 0) ms = @min(ms, pipe_poll_quantum_ms);
         // Unreported pre-ready state turns the block into a collect pass.
         if (self.any_pre_ready) ms = 0;
 
@@ -1055,8 +1104,9 @@ const WindowsEventBackend = struct {
         // WasiPollBackend guard with their own ensure-capacity calls.
         self.ready.clearRetainingCapacity();
         self.dead.clearRetainingCapacity();
-        try self.ready.ensureTotalCapacity(self.allocator, self.sockets.count());
-        try self.dead.ensureTotalCapacity(self.allocator, self.sockets.count());
+        const max_events = self.sockets.count() + self.pipes.count();
+        try self.ready.ensureTotalCapacity(self.allocator, max_events);
+        try self.dead.ensureTotalCapacity(self.allocator, max_events);
         self.any_pre_ready = false;
 
         var it = self.sockets.iterator();
@@ -1089,6 +1139,26 @@ const WindowsEventBackend = struct {
             }
         }
         for (self.dead.items) |fd| _ = self.sockets.remove(fd);
+
+        // Pipe sweep (#1608 stage 2): polled, level-triggered readiness —
+        // each pass re-derives the fd's current state, so there are no
+        // event records to lose and no pre-ready snapshots to keep. A
+        // reported direction disarms itself (the WasiPollBackend ONESHOT
+        // emulation: armed ⇔ a fiber is parked holds by construction);
+        // Reactor.poll re-arms for whatever waiters remain after a fire.
+        self.dead.clearRetainingCapacity();
+        var pit = self.pipes.iterator();
+        while (pit.next()) |entry| {
+            const fd = entry.key_ptr.*;
+            const reg = entry.value_ptr;
+            const r = platform.pipePollReady(fd, reg.want_read, reg.want_write);
+            if (!r.readable and !r.writable) continue;
+            self.ready.appendAssumeCapacity(.{ .fd = fd, .readable = r.readable, .writable = r.writable });
+            if (r.readable) reg.want_read = false;
+            if (r.writable) reg.want_write = false;
+            if (!reg.want_read and !reg.want_write) self.dead.appendAssumeCapacity(fd);
+        }
+        for (self.dead.items) |fd| _ = self.pipes.remove(fd);
         // Timer expiry is decided by the reactor against clockNs()
         // (popExpiredTimers); a notify set wake_pending before SetEvent.
         return self.ready.items;

--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -136,6 +136,20 @@ pub fn makeBidiFdPair() [2]platform.fd_t {
     return fds;
 }
 
+/// A unidirectional OS *pipe* pair on every platform ([0] read end, [1]
+/// write end): pipe(2) on POSIX, CRT _pipe (64 KiB, binary) on Windows.
+/// Unlike makeFdPair — which substitutes loopback TCP on Windows because
+/// the readiness suites predate pipe readiness there — this is for tests
+/// that exercise the pipe kind itself (#1608 stage 2: polled readiness;
+/// on POSIX the same tests re-cover native pipe readiness). Raw test-side
+/// I/O on these fds must use platform.read/platform.write, not
+/// fdRead/fdWrite (whose Windows routing is socket-only).
+pub fn makePipeFdPair() [2]platform.fd_t {
+    var fds: [2]platform.fd_t = undefined;
+    std.debug.assert(platform.pipe(&fds) == 0);
+    return fds;
+}
+
 fn makeWinLoopbackPair() [2]platform.fd_t {
     platform.ensureWinsock();
     const ws = winsock_test;

--- a/src/tests_platform.zig
+++ b/src/tests_platform.zig
@@ -1,0 +1,107 @@
+// Platform shim tests (src/platform.zig), extracted from that file's tail
+// when it outgrew the 1500-line policy. They run on the host platform; the
+// Windows arms are exercised by the cross-compiled unit-test binary on a
+// Windows machine. appendQuotedArg/buildCommandLineW are pub solely for
+// this file.
+const std = @import("std");
+const builtin = @import("builtin");
+const platform = @import("platform.zig");
+
+const is_windows = platform.is_windows;
+const is_wasm = builtin.target.cpu.arch.isWasm();
+
+fn expectQuoted(expected: []const u8, arg: []const u8) !void {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try platform.appendQuotedArg(&list, std.testing.allocator, arg);
+    try std.testing.expectEqualStrings(expected, list.items);
+}
+
+// CommandLineToArgvW-inverse quoting: these are the canonical cases from
+// the Windows command-line parsing rules; the child's CRT must parse each
+// quoted form back to the original argument.
+test "appendQuotedArg: plain arg unquoted" {
+    try expectQuoted("abc", "abc");
+}
+
+test "appendQuotedArg: spaces force quotes" {
+    try expectQuoted("\"two words\"", "two words");
+}
+
+test "appendQuotedArg: empty arg becomes empty quotes" {
+    try expectQuoted("\"\"", "");
+}
+
+test "appendQuotedArg: embedded quote gets a backslash" {
+    try expectQuoted("\"say \\\" it\"", "say \" it");
+}
+
+test "appendQuotedArg: backslashes before a quote double" {
+    // arg: a\"b  →  "a\\\"b" (the two backslashes encode one literal \,
+    // the third escapes the quote)
+    try expectQuoted("\"a\\\\\\\"b\"", "a\\\"b");
+}
+
+test "appendQuotedArg: trailing backslashes double before the closing quote" {
+    // arg: dir\ with a space → "dir \\" so the closing quote isn't eaten
+    try expectQuoted("\"dir \\\\\"", "dir \\");
+}
+
+test "appendQuotedArg: backslashes not before a quote stay literal" {
+    // Windows paths with spaces: no doubling mid-string
+    try expectQuoted("\"C:\\Program Files\\kaappi\"", "C:\\Program Files\\kaappi");
+}
+
+test "buildCommandLineW joins and round-trips through WTF-16" {
+    const argv = [_][]const u8{ "git", "-C", "C:\\repo dir", "checkout", "v1.0.0", "--" };
+    const wline = try platform.buildCommandLineW(std.testing.allocator, &argv);
+    defer std.testing.allocator.free(wline);
+    var narrow: [256]u8 = undefined;
+    const n = std.unicode.wtf16LeToWtf8(&narrow, wline);
+    try std.testing.expectEqualStrings("git -C \"C:\\repo dir\" checkout v1.0.0 --", narrow[0..n]);
+}
+
+test "monotonicNs advances" {
+    const a = platform.monotonicNs();
+    const b = platform.monotonicNs();
+    try std.testing.expect(b >= a);
+}
+
+test "realTime is after 2020" {
+    const rt = platform.realTime();
+    try std.testing.expect(rt.sec > 1577836800); // 2020-01-01
+    try std.testing.expect(rt.nsec >= 0 and rt.nsec < 1_000_000_000);
+}
+
+test "statPath reports a directory" {
+    if (comptime is_wasm) return error.SkipZigTest;
+    const cwd_path = if (is_windows) "." else "/tmp";
+    const st = platform.statPath(cwd_path) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(st.is_dir);
+    try std.testing.expect(!st.is_file);
+}
+
+test "write to stdout-like sink via openNullSink" {
+    if (comptime is_wasm) return error.SkipZigTest;
+    const fd = try platform.openNullSink();
+    defer platform.close(fd);
+    const msg = "platform shim probe\n";
+    const rc = platform.write(fd, msg.ptr, msg.len);
+    try std.testing.expect(rc == @as(isize, @intCast(msg.len)));
+}
+
+test "dlSym on the dlOpen(null) process handle finds CRT symbols (#1611)" {
+    // The (ffi-open #f) contract: the process handle resolves C runtime
+    // symbols — on Windows via the all-loaded-modules search (abs lives in
+    // ucrtbase.dll, never in the exe's export table), on POSIX via dlsym's
+    // global symbol scope.
+    if (comptime is_wasm) return error.SkipZigTest;
+    if (comptime builtin.target.abi.isMusl()) return error.SkipZigTest; // static libc: no dynamic loading
+    const proc = platform.dlOpen(null) orelse return error.TestUnexpectedResult;
+    defer platform.dlClose(proc);
+    try std.testing.expect(platform.dlSym(proc, "abs") != null);
+    // A miss reports failure without poisoning later lookups.
+    try std.testing.expect(platform.dlSym(proc, "kaappi_no_such_symbol_1611") == null);
+    _ = platform.dlError();
+    try std.testing.expect(platform.dlSym(proc, "abs") != null);
+}

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -610,6 +610,15 @@ test "#1608: two fibers reading two OS-pipe ports park and interleave" {
     // ever running and deadlock the test.
     _ = try vm.eval("(define f1 (spawn (lambda () (read-char rp1))))");
     _ = try vm.eval("(define f2 (spawn (lambda () (read-char rp2))))");
+    // Dispatch both readers and prove they *parked* on the reactor —
+    // .io_waiting is the load-bearing stage-2 claim on Windows — before
+    // the writer is even spawned, so a lucky writer-first schedule can't
+    // pass this test without the parked-pipe path.
+    _ = try vm.eval("(fiber-join (spawn (lambda () 1)))");
+    for ([_][]const u8{ "f1", "f2" }) |name| {
+        const f_val = try vm.eval(name);
+        try std.testing.expectEqual(fiber_mod.FiberStatus.io_waiting, types.toObject(f_val).as(fiber_mod.Fiber).status);
+    }
     _ = try vm.eval(
         \\(define w (spawn (lambda ()
         \\  (write-char #\b wp2) (flush-output-port wp2)
@@ -669,8 +678,10 @@ test "#1608: OS-pipe port stays blocking sequentially; enters non-blocking mode 
     defer platform.close(pipe[1]);
 
     // Sequential program: the fd-kind probe may run, but nothing flips —
-    // blocking semantics and the syscall profile are untouched.
-    _ = platform.write(pipe[1], "a", 1);
+    // blocking semantics and the syscall profile are untouched. Each raw
+    // write is asserted so a setup failure fails loudly here instead of
+    // hanging the blocking read below.
+    try std.testing.expectEqual(@as(isize, 1), platform.write(pipe[1], "a", 1));
     _ = try vm.eval("(read-char rp)");
     try std.testing.expect(!rport.nonblocking);
     if (comptime platform.is_windows) {
@@ -684,7 +695,7 @@ test "#1608: OS-pipe port stays blocking sequentially; enters non-blocking mode 
     // real O_NONBLOCK flip on POSIX, the emulated flag (no OS-level flip
     // exists for pipe fds) on Windows.
     _ = try vm.eval("(import (kaappi fibers)) (fiber-join (spawn (lambda () 1)))");
-    _ = platform.write(pipe[1], "b", 1);
+    try std.testing.expectEqual(@as(isize, 1), platform.write(pipe[1], "b", 1));
     _ = try vm.eval("(read-char rp)");
     try std.testing.expect(rport.nonblocking);
 }
@@ -706,9 +717,76 @@ test "#1608: closing an OS-pipe port with a parked reader raises a clean error i
         \\    (read-char rp)
         \\    'not-reached))))
     );
+    // Deliberately NOT pre-parked with a dispatch tick before spawning the
+    // closer (unlike the interleave test above): f's guard means its read
+    // runs under re-entrant native frames, and a pre-parked f redispatched
+    // by the later join drives the scheduler into an unbounded poll with
+    // the runnable closer never dispatched — a pre-existing interaction
+    // independent of the pipe backend (repros with socket pairs; #1625).
+    // The FIFO dispatch order below still exercises the parked path
+    // deterministically: at the join, f is dispatched first, parks on the
+    // empty pipe, and only then does its in-place drive dispatch closer.
     _ = try vm.eval("(define closer (spawn (lambda () (close-port rp))))");
     // The join completing at all is the "nothing hangs" half of the
     // acceptance criterion; the guard result is the "clean error" half.
     const r = try vm.eval("(equal? (fiber-join f) '(caught #t))");
     try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "#1608: GC finalization of an abandoned pipe port with a full pipe drops the remainder instead of blocking" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = th.makePipeFdPair();
+    defer platform.close(pipe[0]);
+
+    // Fill the pipe to exactly-full without ever blocking: quota-gated
+    // raw writes on Windows, O_NONBLOCK raw writes on POSIX. Reaching
+    // EAGAIN is the test's precondition — a plain blocking write in the
+    // sweep below would then hang forever.
+    if (comptime !platform.is_windows) th.setFdNonblocking(pipe[1]);
+    var chunk: [4096]u8 = undefined;
+    @memset(&chunk, 'f');
+    var filled = false;
+    var guard: usize = 0;
+    while (guard < 10_000) : (guard += 1) {
+        const rc = if (comptime platform.is_windows)
+            platform.pipeWrite(pipe[1], &chunk, chunk.len)
+        else
+            platform.write(pipe[1], &chunk, chunk.len);
+        if (rc < 0) {
+            try std.testing.expectEqual(platform.E.AGAIN, platform.errno(rc));
+            filled = true;
+            break;
+        }
+        try std.testing.expect(rc > 0);
+    }
+    try std.testing.expect(filled);
+
+    // An abandoned port owning the write end, with pending buffered
+    // output, in emulated non-blocking mode — exactly what a fiber
+    // terminated mid-park can leave for the collector. Rooted only while
+    // its fields are populated (the alloc below may collect under
+    // -Dgc-stress), then dropped so the next collection must sweep it.
+    var port_val = try gc.allocPort(pipe[1], false, true, "gcflush", false);
+    gc.pushRoot(&port_val);
+    const port = types.toObject(port_val).as(types.Port);
+    const pending = try gc.allocator.alloc(u8, 64);
+    @memset(pending, 'p');
+    port.write_buf = pending;
+    port.write_buf_start = 0;
+    port.write_buf_len = pending.len;
+    port.nonblocking = true;
+    if (comptime platform.is_windows) {
+        port.fd_state = .{ .probe_done = true, .is_socket = false, .is_pipe = true };
+    }
+    gc.popRoot();
+
+    // freeObject's best-effort flush hits the full pipe. The quota gate
+    // (Windows) / O_NONBLOCK (POSIX) turns that into an EAGAIN that drops
+    // the remainder, per the flush's own contract; a blocking write here
+    // would hang this collection — and the whole OS thread — forever.
+    gc.collect();
 }

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -6,9 +6,11 @@
 // while it waits, write buffering with real flush, and the close-port
 // wake discipline. The fds are testing_helpers' cross-platform pairs —
 // pipes/socketpairs on POSIX, loopback socket pairs on Windows, where
-// this suite is the end-to-end coverage of the socket-only readiness
-// bridge (#1608: isSocketFd probe → FIONBIO → sockRecv/sockSend EAGAIN →
-// WSAEventSelect wakeup).
+// this suite is the end-to-end coverage of the socket readiness bridge
+// (#1608 stage 1: fdKind probe → FIONBIO → sockRecv/sockSend EAGAIN →
+// WSAEventSelect wakeup). The "#1608:" tests at the bottom run the same
+// patterns over real OS-pipe pairs, covering the polled pipe backend
+// (stage 2) on Windows.
 const std = @import("std");
 const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
@@ -576,5 +578,137 @@ test "a parked mid-read-bytevector retry over a pipe loses no bytes" {
     );
     _ = try vm.eval("(fiber-join writer)");
     const r = try vm.eval("(equal? (fiber-join reader) original)");
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+// ---------------------------------------------------------------------------
+// #1608 stage 2: OS-pipe pairs (makePipeFdPair). On POSIX these re-cover
+// native pipe readiness with real pipe fds; on Windows they are the
+// end-to-end coverage of the polled pipe backend — fd-kind probe →
+// emulated non-blocking (no OS flip) → pipeRead/pipeWrite EAGAIN →
+// pipePollReady wakeup. Before stage 2, every parked-fiber test below
+// would deadlock on Windows: the read blocked the OS thread and the
+// writer fiber never ran.
+// ---------------------------------------------------------------------------
+
+test "#1608: two fibers reading two OS-pipe ports park and interleave" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe1 = th.makePipeFdPair();
+    const pipe2 = th.makePipeFdPair();
+    _ = try definePortGlobal(vm, "rp1", pipe1[0], true, false);
+    _ = try definePortGlobal(vm, "wp1", pipe1[1], false, true);
+    _ = try definePortGlobal(vm, "rp2", pipe2[0], true, false);
+    _ = try definePortGlobal(vm, "wp2", pipe2[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    // Both readers park on empty pipes before the writer runs; a read that
+    // blocked the OS thread instead of parking would keep the writer from
+    // ever running and deadlock the test.
+    _ = try vm.eval("(define f1 (spawn (lambda () (read-char rp1))))");
+    _ = try vm.eval("(define f2 (spawn (lambda () (read-char rp2))))");
+    _ = try vm.eval(
+        \\(define w (spawn (lambda ()
+        \\  (write-char #\b wp2) (flush-output-port wp2)
+        \\  (write-char #\a wp1) (flush-output-port wp1))))
+    );
+    const r1 = try vm.eval("(fiber-join f1)");
+    const r2 = try vm.eval("(fiber-join f2)");
+    try std.testing.expectEqual(types.makeChar('a'), r1);
+    try std.testing.expectEqual(types.makeChar('b'), r2);
+}
+
+test "#1608: OS-pipe write beyond the pipe buffer parks the writer; a reader fiber drains it" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = th.makePipeFdPair();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    // 100000 bytes exceeds every platform's pipe capacity (16-64 KiB, and
+    // the 64 KiB CRT _pipe buffer on Windows), so the flush hits
+    // would-block mid-buffer — on Windows that is pipeWrite's quota gate,
+    // whose clamp must also keep each retry's blocking CRT write inside
+    // the known-free space. The final count and content check prove no
+    // byte was lost or duplicated across the park/retry cycles.
+    _ = try vm.eval("(define n 100000)");
+    _ = try vm.eval(
+        \\(define writer (spawn (lambda ()
+        \\  (write-string (make-string n #\x) wp)
+        \\  (flush-output-port wp)
+        \\  (close-port wp))))
+    );
+    _ = try vm.eval(
+        \\(define reader (spawn (lambda ()
+        \\  (let loop ((total 0) (ok #t))
+        \\    (let ((s (read-string 4096 rp)))
+        \\      (if (eof-object? s)
+        \\          (and ok (= total n))
+        \\          (loop (+ total (string-length s))
+        \\                (and ok (string=? s (make-string (string-length s) #\x))))))))))
+    );
+    const r = try vm.eval("(fiber-join reader)");
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "#1608: OS-pipe port stays blocking sequentially; enters non-blocking mode under a scheduler" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = th.makePipeFdPair();
+    const rport = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    defer platform.close(pipe[1]);
+
+    // Sequential program: the fd-kind probe may run, but nothing flips —
+    // blocking semantics and the syscall profile are untouched.
+    _ = platform.write(pipe[1], "a", 1);
+    _ = try vm.eval("(read-char rp)");
+    try std.testing.expect(!rport.nonblocking);
+    if (comptime platform.is_windows) {
+        // The probe classified the fd correctly on first touch.
+        try std.testing.expect(rport.fd_state.probe_done);
+        try std.testing.expect(rport.fd_state.is_pipe);
+        try std.testing.expect(!rport.fd_state.is_socket);
+    }
+
+    // Once a scheduler exists the next use enters non-blocking mode: a
+    // real O_NONBLOCK flip on POSIX, the emulated flag (no OS-level flip
+    // exists for pipe fds) on Windows.
+    _ = try vm.eval("(import (kaappi fibers)) (fiber-join (spawn (lambda () 1)))");
+    _ = platform.write(pipe[1], "b", 1);
+    _ = try vm.eval("(read-char rp)");
+    try std.testing.expect(rport.nonblocking);
+}
+
+test "#1608: closing an OS-pipe port with a parked reader raises a clean error in that fiber" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = th.makePipeFdPair();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    _ = try vm.eval(
+        \\(define f (spawn (lambda ()
+        \\  (guard (e (#t (list 'caught (error-object? e))))
+        \\    (read-char rp)
+        \\    'not-reached))))
+    );
+    _ = try vm.eval("(define closer (spawn (lambda () (close-port rp))))");
+    // The join completing at all is the "nothing hangs" half of the
+    // acceptance criterion; the guard result is the "clean error" half.
+    const r = try vm.eval("(equal? (fiber-join f) '(caught #t))");
     try std.testing.expectEqual(types.TRUE, r);
 }

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -7,9 +7,10 @@
 // every already-listed waiter (Phase 3).
 //
 // The fds come from testing_helpers' cross-platform pairs: pipes and
-// AF_UNIX socketpairs on POSIX, loopback TCP pairs on Windows — where fd
-// readiness is socket-only (#1608), so this suite doubles as the
-// WSAEventSelect backend's coverage there.
+// AF_UNIX socketpairs on POSIX, loopback TCP pairs on Windows — where this
+// suite doubles as the WSAEventSelect socket backend's coverage (#1608
+// stage 1). The "#1608:" tests at the bottom use real OS-pipe pairs on
+// every platform, covering the polled pipe backend (stage 2) on Windows.
 const std = @import("std");
 const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
@@ -625,4 +626,84 @@ test "notify() from another OS thread interrupts a blocking poll()" {
     try std.testing.expectEqual(@as(usize, 0), ready.items.len);
     try std.testing.expect(reactor.notifier.wake_pending.load(.acquire));
     try std.testing.expect(elapsed_ns < 1_000_000_000);
+}
+
+// ---------------------------------------------------------------------------
+// #1608 stage 2: reactor-level coverage over real OS-pipe pairs. On POSIX
+// these re-cover the kqueue/epoll pipe paths; on Windows they exercise the
+// WindowsEventBackend pipe registry — arm routing via fdKind, the
+// poll-quantum-bounded wait, and the pipePollReady sweep.
+// ---------------------------------------------------------------------------
+
+test "#1608: pipe pair — register + poll wakes the fiber when the pipe becomes readable" {
+    var reactor = try Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+
+    const pipe = th.makePipeFdPair();
+    defer closeFd(pipe[0]);
+    defer closeFd(pipe[1]);
+
+    var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
+    try reactor.register(pipe[0], .read, &fiber_a);
+
+    // Raw pipe write (CRT _write works on pipe fds; fdWrite's Windows
+    // routing is socket-only).
+    try std.testing.expectEqual(@as(isize, 1), platform.write(pipe[1], "x", 1));
+
+    var ready = newReady();
+    defer ready.deinit(std.testing.allocator);
+    // One poll call may time out at the pipe quantum before the sweep sees
+    // the byte; bound the loop generously instead of assuming one pass.
+    var waited_ns: u64 = 0;
+    while (ready.items.len == 0 and waited_ns < 5_000_000_000) : (waited_ns += 100_000_000) {
+        try reactor.poll(100_000_000, &ready);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), ready.items.len);
+    try std.testing.expectEqual(&fiber_a, ready.items[0]);
+}
+
+test "#1608: pipe pair — poll times out empty while the pipe is silent" {
+    var reactor = try Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+
+    const pipe = th.makePipeFdPair();
+    defer closeFd(pipe[0]);
+    defer closeFd(pipe[1]);
+
+    var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
+    try reactor.register(pipe[0], .read, &fiber_a); // never written to
+
+    var ready = newReady();
+    defer ready.deinit(std.testing.allocator);
+    // 50ms cap spans several pipe-poll quanta on Windows: every sweep must
+    // report the silent pipe not-ready, not just the first.
+    try reactor.poll(50_000_000, &ready);
+
+    try std.testing.expectEqual(@as(usize, 0), ready.items.len);
+}
+
+test "#1608: pipe pair — a write end with buffer space is ready for write interest" {
+    var reactor = try Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+
+    const pipe = th.makePipeFdPair();
+    defer closeFd(pipe[0]);
+    defer closeFd(pipe[1]);
+
+    var fiber_a: Fiber = undefined;
+    fiber_a.status = .io_waiting;
+    try reactor.register(pipe[1], .write, &fiber_a);
+
+    var ready = newReady();
+    defer ready.deinit(std.testing.allocator);
+    var waited_ns: u64 = 0;
+    while (ready.items.len == 0 and waited_ns < 5_000_000_000) : (waited_ns += 100_000_000) {
+        try reactor.poll(100_000_000, &ready);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), ready.items.len);
+    try std.testing.expectEqual(&fiber_a, ready.items[0]);
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -542,18 +542,26 @@ pub const Port = struct {
     write_buf: ?[]u8 = null,
     write_buf_start: usize = 0,
     write_buf_len: usize = 0,
-    /// Windows-only socket-port state (#1608); always defaults elsewhere.
-    sock_state: packed struct(u8) {
-        /// maybeSetNonblocking's socket probe already ran for this port,
-        /// whatever its outcome — the probe is a getsockopt syscall and
+    /// Windows-only fd-kind state (#1608); always defaults elsewhere.
+    fd_state: packed struct(u8) {
+        /// maybeSetNonblocking's fd-kind probe already ran for this port,
+        /// whatever its outcome — the probe is a handful of syscalls and
         /// must not repeat on every read of an ordinary file port.
         probe_done: bool = false,
-        /// `fd` wraps a SOCKET (established by the isSocketFd probe), so
+        /// `fd` wraps a SOCKET (fdKind probe, #1608 stage 1), so
         /// reads/writes must route through platform.sockRecv/sockSend —
         /// CRT _read/_write cannot operate on (overlapped) SOCKET handles
         /// at all, blocking or not.
         is_socket: bool = false,
-        _pad: u6 = 0,
+        /// `fd` wraps a non-socket pipe end (#1608 stage 2). Under a
+        /// scheduler the port enters *emulated* non-blocking mode
+        /// (`nonblocking` set with no OS-level flip): reads/writes route
+        /// through platform.pipeRead/pipeWrite, whose peek/quota
+        /// pre-checks synthesize the EAGAIN that parks the fiber, and the
+        /// reactor re-runs the same checks on a poll cadence for the
+        /// wakeup.
+        is_pipe: bool = false,
+        _pad: u5 = 0,
     } = .{},
 };
 

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -27,11 +27,13 @@ test {
     _ = @import("tests_native_gate.zig");
     // The fd-readiness suites run everywhere: their fds come from
     // testing_helpers' cross-platform pairs — pipes/socketpairs on POSIX,
-    // loopback socket pairs on Windows, where fd readiness is socket-only
-    // (#1608) and these suites are the WSAEventSelect backend's coverage.
+    // loopback socket pairs on Windows, where these suites cover the
+    // WSAEventSelect socket backend, and their "#1608:" pipe-pair tests
+    // cover the polled pipe backend (stage 2).
     _ = @import("tests_reactor.zig");
     _ = @import("tests_scheduler.zig");
     _ = @import("tests_port_io.zig");
     _ = @import("tests_diagnostics.zig");
     _ = @import("tests_spans.zig");
+    _ = @import("tests_platform.zig");
 }


### PR DESCRIPTION
Closes #1608 (stage 2 — the issue's remaining half after the WSAEventSelect socket backend, #1619).

## The stage-2 evaluation, answered

The issue asked: *do pipes/files justify a completion-based (IOCP/overlapped) rework of the retry protocol?* The answer is **no** — and not just on cost/benefit grounds:

1. **IOCP cannot serve the fds the port layer actually sees.** Overlapped I/O requires `FILE_FLAG_OVERLAPPED` at handle creation, and the pipe fds that reach the runtime — CRT `_pipe`, inherited descriptors, FFI code wrapping `CreatePipe` handles via `_open_osfhandle` — are synchronous handles without it. The only general completion design is a blocking worker-thread pool (libuv's fallback for non-overlapped pipes): a new subsystem whose *issued-read* semantics can lose consumed bytes when the waiting fiber is terminated or the port closed mid-read — a failure mode the park-and-retry model, which never reads until readiness is known, structurally cannot have.
2. **Files gain nothing from any of it.** POSIX has no regular-file readiness either: `O_NONBLOCK` is a no-op on regular files, epoll rejects them with EPERM, kqueue reports them always-ready — so the kqueue/epoll builds also block the OS thread for the duration of a disk read. Blocking file I/O is the cross-platform baseline, not a Windows degradation. (Only an io_uring-class async-file model would change this, on every platform alike — out of scope for the KEP-0001 readiness model.)
3. **Pipes need only readiness, and Windows can express it by polling.** `PeekNamedPipe` answers read-readiness and `NtQueryInformationFile(FilePipeLocalInformation).WriteQuotaAvailable` answers write-readiness (the same query libuv uses for its non-overlapped pipe writes; stable ntdll ABI since NT4).

## What ships

- **`platform_win_pipe.zig`** (new, mirroring the stage-1 sock split): `fdKind` one-shot fd classification (socket / pipe / other), `pipeRead` (peek-gated read: no pending data ⇒ synthesized EAGAIN; otherwise the blocking CRT read cannot block — pipe reads short-return), `pipeWrite` (quota-gated write, clamped to the known-free space so the blocking CRT write underneath can never block; byte-mode pipe writes otherwise block until *every* byte fits), `pipePollReady` (the reactor's sweep check; any query failure reports ready so the retried syscall surfaces the real EOF/error — spurious wakes are safe under the protocol, missed ones park forever). A quota probe on a non-writable end is detected via `named_pipe_configuration`/`named_pipe_end` and falls through to the plain write so it surfaces its real error instead of parking forever.
- **Port layer**: `Port.sock_state` becomes `fd_state` (`probe_done` / `is_socket` / `is_pipe`, still one packed u8 — the heap-layout-guard-safe shape). Pipe ports under a scheduler enter *emulated* non-blocking mode: `nonblocking` set with no OS-level flip, routing through `pipeRead`/`pipeWrite`. Sequential programs never set the flag — their pipe ports keep plain blocking `_read`/`_write` and the exact pre-change syscall profile.
- **`WindowsEventBackend`**: a second registry for armed pipe interest. `arm()` routes by `fdKind` on every arm (self-healing across fd recycling, including kind changes). While any pipe interest is armed, `wait()` bounds its block at a **10 ms poll quantum** — the same order as the ~15 ms OS timer granularity that already bounds this backend — and sweeps `pipePollReady`; a reported direction disarms itself (the WasiPollBackend ONESHOT emulation), so the quantum is paid only while a fiber is actually parked on a pipe. Level-triggered by construction: none of WSAEventSelect's edge-record races apply and no pre-ready snapshot is needed.
- **Tests**: `testing_helpers.makePipeFdPair` (real OS pipes on every platform — POSIX `pipe(2)`, CRT `_pipe`) + seven new tests. Four in `tests_port_io.zig` (two-readers park/interleave, write-beyond-pipe-buffer parks the writer and drains losslessly, sequential port stays blocking / flips under a scheduler with fd-kind asserts, close-port wakes a parked reader cleanly) and three reactor-level in `tests_reactor.zig` (readable wake, silent timeout across several quanta, write-space readiness). On POSIX these re-cover native pipe readiness; on Windows they are the new backend's coverage — **every parked-fiber one of them deadlocked on Windows before this change**.
- **Docs**: `docs/dev/windows.md` fd-readiness section rewritten (sockets + pipes + the files-parity note) with a "Why polling, not IOCP" record of this evaluation; stage-2 entry removed from Known gaps; core `CLAUDE.md` reactor paragraph updated.

## Verification

| Where | What | Result |
|---|---|---|
| macOS (dev) | full unit suite | pass |
| macOS | `tests_port_io` + `tests_reactor` under `-Dgc-stress=true` | pass |
| macOS | R7RS suite | 0 fail |
| cross | `zig build` + `zig build test` `-Dtarget=aarch64-windows`, `zig build wasm`, `-Dtarget=x86_64-linux` | all compile |
| Windows 11 ARM64 VM | full unit suite (`unit-tests.exe`, cache cleared first) | **1115 passed / 0 failed** (15 skips), all seven `#1608:` tests OK |
| Windows 11 ARM64 VM | R7RS suite | 0 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)