### PR TITLE
Windows native backend: kaappi compile verified end-to-end (#1610)

### DIFF
--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -195,6 +195,41 @@ Scheme tests that exercise POSIX-only functionality gate themselves:
   (else #f))
 ```
 
+## Native backend (`kaappi compile`)
+
+The full pipeline — emit LLVM IR, discover the runtime archive, link with
+the first C compiler on PATH, run the native binary — works on the box
+and is exercised end-to-end by `tests/e2e/run-e2e.ps1` (the PowerShell
+port of run-e2e.sh's parity phase): all 37 `tests/e2e/programs` compile
+natively and match the interpreter's output, and `kaappi doctor`'s
+smoke-link passes. Verified on Windows 11 ARM64 (build 26100) with a Zig
+master toolchain as the linker (#1610); with the 0.16.0 toolchain,
+`zig cc` on the box access-violates like every native toolchain use
+(#1613), so end users get this at the 0.17.0 bump.
+
+Windows-specific pieces of the path (#1610):
+
+* The runtime archive is `kaappi_rt.lib` (Zig's COFF naming), not
+  `libkaappi_rt.a` — `platform.rt_lib_name` carries the platform
+  spelling, and the `findLibDir`/doctor probes and messages use it. The
+  search order is unchanged: `KAAPPI_LIB_DIR`, `<exe>/../lib`,
+  `zig-out/lib`, `/usr/local/lib`.
+* `kaappi compile foo.scm` derives `foo.exe` (PATH lookup and
+  double-click need the extension); an explicit `-o name` is used as
+  given.
+* The emitted module triple is `aarch64-pc-windows-gnu` — the gnu
+  (MinGW) ABI the runtime lib is built with and the ABI `zig cc` targets
+  on a box without MSVC.
+* The link line adds `-lws2_32` and drops `-lpthread`: the fd-readiness
+  backends call Winsock through `extern "ws2_32"` declarations, which
+  Zig links automatically only when it builds the final binary itself —
+  a foreign `zig cc` link of the static archive must name the import lib
+  explicitly. The equivalent manual link is:
+
+  ```
+  zig cc -w -O2 out.ll -o prog.exe -L<libdir> -lkaappi_rt -lc -lm -lws2_32
+  ```
+
 ## Testing on a Windows machine
 
 CI covers the target twice (ci.yml): `windows-cross` cross-compiles the
@@ -237,7 +272,9 @@ suites double as the socket-readiness backend's coverage, and their
 "#1608:" tests run the same park/wake patterns over real CRT `_pipe`
 pairs, covering the polled pipe backend (stage 2). The
 POSIX-permission/FIFO/uid tests and the dup2-based fd-recycle reactor
-test skip.
+test skip. With a fixed (master) toolchain on the box, the
+native-backend parity suite `tests/e2e/run-e2e.ps1` passes too (#1610,
+see "Native backend" above).
 
 ## Releasing
 
@@ -260,11 +297,12 @@ the github-release skill's Step 10.
 ## Known gaps / follow-ups
 
 * Native compilation on Windows ARM64 crashes in the Zig 0.16.0
-  toolchain (`zig build`/`zig build-exe` access-violate on any project,
-  #1613) — all builds must cross-compile, and `kaappi compile` on the
-  box (#1610) is blocked on the same upstream fix. Fixed upstream
-  (ziglang#31865; Zig master works on the box, verified 2026-07-17);
-  both unblock at the 0.17.0 toolchain bump.
+  toolchain (`zig build`/`zig build-exe`/`zig cc` access-violate on any
+  project, #1613) — all builds must cross-compile, and `kaappi compile`
+  needs a fixed toolchain on the box for its link step (verified
+  end-to-end with Zig master, see "Native backend" above). Fixed
+  upstream (ziglang#31865); everything unblocks at the 0.17.0 toolchain
+  bump.
 * The shell-based suites — errors, compile, test-runner, pipeline,
   doctor, fmt, cache, timings, the smoke `.sh` scripts, sandbox, and
   robustness — don't run on Windows (#1612).
@@ -272,8 +310,6 @@ the github-release skill's Step 10.
   everything else — see Deliberate degradations above); lifting that
   needs a Windows build story for the C-FFI packages, which today are
   Makefiles producing `.dylib`/`.so` against POSIX headers.
-* `kaappi compile` links with `zig cc` when Zig is installed on the box;
-  untested beyond the doctor's smoke-link probe.
 * Console reads are byte-oriented ANSI/UTF-8; typing non-ASCII at the
   plain REPL depends on the console's UTF-8 code page (set at startup).
 * Long paths (> 260 chars) need the system long-path opt-in.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -384,7 +384,7 @@ pub fn printUsage() void {
             "  --completions <sh> Output completion script (bash, zsh, fish)\n" ++
             "\n" ++
             "Environment variables:\n" ++
-            "  KAAPPI_LIB_DIR     Directory containing libkaappi_rt.a (for compile)\n" ++
+            "  KAAPPI_LIB_DIR     Directory containing " ++ platform.rt_lib_name ++ " (for compile)\n" ++
             "\n" ++
             "With no file argument, starts an interactive REPL.\n",
     );

--- a/src/doctor.zig
+++ b/src/doctor.zig
@@ -38,6 +38,11 @@ pub const USAGE_ERROR_EXIT: u8 = 2;
 /// The build's target triple and optimize mode are comptime-known, so they are
 /// module constants shared by the human table, the JSON meta, and the tests.
 const target_triple = @tagName(builtin.cpu.arch) ++ "-" ++ @tagName(builtin.os.tag) ++ "-" ++ @tagName(builtin.abi);
+
+/// Platform spelling of the native-backend runtime archive (`libkaappi_rt.a`;
+/// `kaappi_rt.lib` on Windows) — the messages below must name the file the
+/// user would actually see on disk (#1610).
+const rt_lib = platform.rt_lib_name;
 const build_mode = @tagName(builtin.mode);
 
 // ── Findings model ───────────────────────────────────────────────────────────
@@ -352,8 +357,8 @@ fn collectNativeBackend(r: *Report) void {
         r.add("native-backend", "c-compiler", .warn, "none of zig, cc, clang, gcc found on PATH", "install zig (recommended), clang, or gcc to compile native binaries");
     }
 
-    // `libkaappi_rt.a` lookup across the four documented locations, in the order
-    // native_compiler.findLibDir consults them.
+    // Runtime-archive lookup across the four documented locations, in the
+    // order native_compiler.findLibDir consults them.
     var archive_dir: ?[]const u8 = null;
 
     // An explicit KAAPPI_LIB_DIR that does not resolve is a definite
@@ -362,12 +367,12 @@ fn collectNativeBackend(r: *Report) void {
     if (platform.getenv("KAAPPI_LIB_DIR")) |env| {
         const dir = std.mem.sliceTo(env, 0);
         if (!dirExists(a, dir)) {
-            r.add("native-backend", "KAAPPI_LIB_DIR", .fail, r.fmt("{s} (directory does not exist)", .{dir}), "point KAAPPI_LIB_DIR at a directory containing libkaappi_rt.a, or unset it to use the default search");
+            r.add("native-backend", "KAAPPI_LIB_DIR", .fail, r.fmt("{s} (directory does not exist)", .{dir}), "point KAAPPI_LIB_DIR at a directory containing " ++ rt_lib ++ ", or unset it to use the default search");
         } else if (hasArchive(a, dir)) {
             archive_dir = dir;
-            r.add("native-backend", "KAAPPI_LIB_DIR", .pass, r.fmt("{s} (contains libkaappi_rt.a)", .{dir}), null);
+            r.add("native-backend", "KAAPPI_LIB_DIR", .pass, r.fmt("{s} (contains " ++ rt_lib ++ ")", .{dir}), null);
         } else {
-            r.add("native-backend", "KAAPPI_LIB_DIR", .fail, r.fmt("{s} (exists but has no libkaappi_rt.a)", .{dir}), "place libkaappi_rt.a in that directory, or unset KAAPPI_LIB_DIR to use the default search");
+            r.add("native-backend", "KAAPPI_LIB_DIR", .fail, r.fmt("{s} (exists but has no " ++ rt_lib ++ ")", .{dir}), "place " ++ rt_lib ++ " in that directory, or unset KAAPPI_LIB_DIR to use the default search");
         }
     }
 
@@ -388,9 +393,9 @@ fn collectNativeBackend(r: *Report) void {
     }
 
     if (archive_dir) |dir| {
-        r.add("native-backend", "libkaappi_rt.a", .pass, r.fmt("found in {s}", .{dir}), null);
+        r.add("native-backend", rt_lib, .pass, r.fmt("found in {s}", .{dir}), null);
     } else {
-        r.add("native-backend", "libkaappi_rt.a", .warn, "not found in KAAPPI_LIB_DIR, <exe>/../lib, zig-out/lib, or /usr/local/lib", "run 'zig build lib' in a source checkout, or install a release build that ships libkaappi_rt.a");
+        r.add("native-backend", rt_lib, .warn, "not found in KAAPPI_LIB_DIR, <exe>/../lib, zig-out/lib, or /usr/local/lib", "run 'zig build lib' in a source checkout, or install a release build that ships " ++ rt_lib);
     }
 
     // Smoke link: prove the discovered compiler can actually link a program
@@ -398,7 +403,7 @@ fn collectNativeBackend(r: *Report) void {
     if (found_cc and archive_dir != null) {
         smokeLink(r, archive_dir.?);
     } else {
-        r.add("native-backend", "smoke-link", .pass, "skipped (needs both a C compiler and libkaappi_rt.a)", null);
+        r.add("native-backend", "smoke-link", .pass, "skipped (needs both a C compiler and " ++ rt_lib ++ ")", null);
     }
 }
 
@@ -475,9 +480,9 @@ fn collectFfi(r: *Report) void {
 // ── Smoke link ───────────────────────────────────────────────────────────────
 
 /// Compile and link a tiny C program that references one leaf runtime export
-/// (`kaappi_fixnum_add`) against `libkaappi_rt.a`. A successful link proves the
-/// C compiler works and the archive is well-formed and resolvable — the exact
-/// path `kaappi compile` takes. The program is never executed.
+/// (`kaappi_fixnum_add`) against the runtime archive. A successful link proves
+/// the C compiler works and the archive is well-formed and resolvable — the
+/// exact path `kaappi compile` takes. The program is never executed.
 fn smokeLink(r: *Report, lib_dir: []const u8) void {
     // Never fork a compiler from within the unit-test binary: `probeAll` runs
     // this path, and tests must stay hermetic and fast. The shell test exercises
@@ -553,7 +558,9 @@ fn smokeLink(r: *Report, lib_dir: []const u8) void {
     push(&argv, &argc, a, "-lkaappi_rt");
     push(&argv, &argc, a, "-lc");
     push(&argv, &argc, a, "-lm");
-    if (comptime !platform.is_windows) push(&argv, &argc, a, "-lpthread");
+    // Windows: the runtime archive calls Winsock (#1608) and a foreign link
+    // must name the import lib itself — mirrors native_compiler.tryLink (#1610).
+    if (comptime platform.is_windows) push(&argv, &argc, a, "-lws2_32") else push(&argv, &argc, a, "-lpthread");
     argv[argc] = null;
 
     const link_ok = blk: {
@@ -591,9 +598,9 @@ fn smokeLink(r: *Report, lib_dir: []const u8) void {
         break :blk exited and code == 0;
     };
     if (link_ok) {
-        r.add("native-backend", "smoke-link", .pass, r.fmt("linked a test program against libkaappi_rt.a in {s}", .{lib_dir}), null);
+        r.add("native-backend", "smoke-link", .pass, r.fmt("linked a test program against " ++ rt_lib ++ " in {s}", .{lib_dir}), null);
     } else {
-        r.add("native-backend", "smoke-link", .warn, "link against libkaappi_rt.a failed", "run 'kaappi compile <file.scm>' to see the linker error");
+        r.add("native-backend", "smoke-link", .warn, "link against " ++ rt_lib ++ " failed", "run 'kaappi compile <file.scm>' to see the linker error");
     }
 }
 
@@ -617,7 +624,7 @@ fn fileExists(a: std.mem.Allocator, path: []const u8) bool {
 }
 
 fn hasArchive(a: std.mem.Allocator, dir: []const u8) bool {
-    const path = std.fmt.allocPrint(a, "{s}/libkaappi_rt.a", .{dir}) catch return false;
+    const path = std.fmt.allocPrint(a, "{s}/" ++ rt_lib, .{dir}) catch return false;
     return fileExists(a, path);
 }
 

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -64,8 +64,8 @@ fn siblingLibDir(exe_path: []const u8, buf: []u8) ?[]const u8 {
 /// the shared layout for both a `zig build` tree (`zig-out/bin/kaappi` +
 /// `zig-out/lib/`) and an installed release (`<prefix>/bin/kaappi` +
 /// `<prefix>/lib/`), so a from-source binary run from any directory can
-/// still find `libkaappi_rt.a` or the portable-library `.sld` sources it
-/// was built alongside.
+/// still find the runtime archive (`libkaappi_rt.a`; `kaappi_rt.lib` on
+/// Windows) or the portable-library `.sld` sources it was built alongside.
 ///
 /// Returns null if the platform has no self-exe-path lookup, the
 /// executable isn't nested at least two directories deep, or the resulting

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -1347,15 +1347,21 @@ pub const LLVMEmitter = struct {
     fn emitPreamble(self: *LLVMEmitter) EmitError!void {
         const arch = @import("builtin").cpu.arch;
         const os = @import("builtin").os.tag;
+        // The gnu (MinGW) Windows ABI matches how the runtime lib is built and
+        // how `zig cc` links on a box without MSVC (#1610). Clang would
+        // override a mismatched module triple with the driver's, but only
+        // with a warning that -w hides — emit the right one to begin with.
         const triple = switch (arch) {
             .aarch64 => switch (os) {
                 .macos => "aarch64-apple-macosx",
                 .linux => "aarch64-unknown-linux-gnu",
+                .windows => "aarch64-pc-windows-gnu",
                 else => "aarch64-unknown-unknown",
             },
             .x86_64 => switch (os) {
                 .macos => "x86_64-apple-macosx",
                 .linux => "x86_64-unknown-linux-gnu",
+                .windows => "x86_64-pc-windows-gnu",
                 else => "x86_64-unknown-unknown",
             },
             else => "unknown-unknown-unknown",

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -187,16 +187,13 @@ pub fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8)
     defer _ = platform.unlink(tmp_buf[0..ll_path.len :0]);
     try emitLlvmFile(vm, path, ll_path);
 
-    const out_path = output_path orelse blk: {
-        if (std.mem.endsWith(u8, path, ".scm")) {
-            break :blk path[0 .. path.len - 4];
-        }
-        break :blk path;
-    };
+    const out_path = output_path orelse try deriveOutputPath(allocator, path);
+    const should_free = output_path == null;
+    defer if (should_free) allocator.free(out_path);
     timings.setOutput(out_path); // kaappi#1515
 
     const lib_dir = findLibDir(allocator) orelse {
-        writeStderr("Cannot find libkaappi_rt.a. Build it with: zig build lib\n");
+        writeStderr("Cannot find " ++ platform.rt_lib_name ++ ". Build it with: zig build lib\n");
         return error.RuntimeLibraryNotFound;
     };
 
@@ -226,6 +223,15 @@ pub fn compileNative(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8)
     }
     writeStderr("No C compiler found. Install zig, clang, or gcc.\n");
     return error.NoCCompilerFound;
+}
+
+/// Default output path for `kaappi compile <path>` with no `-o`: the source
+/// name minus any `.scm` suffix, plus the platform executable suffix —
+/// `foo.scm` → `foo` on POSIX, `foo.exe` on Windows, where PATH lookup and
+/// double-click need the extension (#1610). Caller frees.
+fn deriveOutputPath(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
+    const base = if (std.mem.endsWith(u8, path, ".scm")) path[0 .. path.len - 4] else path;
+    return std.fmt.allocPrint(allocator, "{s}{s}", .{ base, platform.exe_suffix });
 }
 
 fn findInPath(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {
@@ -307,11 +313,41 @@ fn collectRedefinedNames(expr: types.Value, map: *std.StringHashMap(void)) void 
 }
 
 fn checkLibDir(allocator: std.mem.Allocator, dir: []const u8) bool {
-    const path = std.fmt.allocPrintSentinel(allocator, "{s}/libkaappi_rt.a", .{dir}, 0) catch return false;
+    const path = std.fmt.allocPrintSentinel(allocator, "{s}/" ++ platform.rt_lib_name, .{dir}, 0) catch return false;
     defer allocator.free(path);
     const fd = platform.openRead(path) catch return false;
     _ = platform.close(fd);
     return true;
+}
+
+test "deriveOutputPath strips .scm and appends the platform exe suffix" {
+    const a = std.testing.allocator;
+    const derived = try deriveOutputPath(a, "dir/foo.scm");
+    defer a.free(derived);
+    try std.testing.expectEqualStrings("dir/foo" ++ platform.exe_suffix, derived);
+
+    const noext = try deriveOutputPath(a, "prog");
+    defer a.free(noext);
+    try std.testing.expectEqualStrings("prog" ++ platform.exe_suffix, noext);
+}
+
+test "checkLibDir looks for the platform-named runtime archive" {
+    const a = std.testing.allocator;
+    const dir = try std.fmt.allocPrint(a, "{s}/kaappi-nctest-{d}", .{ platform.tempDir(), platform.getPid() });
+    defer a.free(dir);
+    const dir_z = try a.dupeZ(u8, dir);
+    defer a.free(dir_z);
+    try std.testing.expect(platform.mkdir(dir_z, 0o700) == 0);
+    defer _ = platform.rmdir(dir_z);
+
+    try std.testing.expect(!checkLibDir(a, dir));
+
+    const lib_path = try std.fmt.allocPrintSentinel(a, "{s}/" ++ platform.rt_lib_name, .{dir}, 0);
+    defer a.free(lib_path);
+    const fd = try platform.openWriteTrunc(lib_path, 0o600);
+    _ = platform.close(fd);
+    defer _ = platform.unlink(lib_path);
+    try std.testing.expect(checkLibDir(a, dir));
 }
 
 fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, out_path: []const u8, lib_flag: []const u8, is_zig: bool) bool {
@@ -366,7 +402,15 @@ fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, ou
     argc += 1;
     argv_buf[argc] = "-lm";
     argc += 1;
-    if (comptime !platform.is_windows) {
+    if (comptime platform.is_windows) {
+        // The runtime lib's fd-readiness backends (#1608) call Winsock via
+        // `extern "ws2_32"` declarations. Zig applies that link dependency
+        // only when it links the final binary itself; a foreign `zig cc`
+        // link of kaappi_rt.lib never sees it, so the import lib must be
+        // named explicitly (#1610).
+        argv_buf[argc] = "-lws2_32";
+        argc += 1;
+    } else {
         argv_buf[argc] = "-lpthread";
         argc += 1;
     }

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -679,6 +679,13 @@ pub const path_list_sep: u8 = if (is_windows) ';' else ':';
 /// Suffix an executable candidate needs on this platform ("" on POSIX).
 pub const exe_suffix: []const u8 = if (is_windows) ".exe" else "";
 
+/// File name `zig build lib` gives the native-backend runtime static
+/// library on this platform: Zig names COFF archives `<name>.lib`, all
+/// others `lib<name>.a`. `-lkaappi_rt` resolves either spelling, but the
+/// existence probes (native_compiler.checkLibDir, doctor) must look for
+/// the name that is actually on disk (#1610).
+pub const rt_lib_name: []const u8 = if (is_windows) "kaappi_rt.lib" else "libkaappi_rt.a";
+
 /// Longest path (bytes, incl. NUL) the canonicalization buffers hold.
 pub const PATH_MAX: usize = if (is_windows) 4096 else std.posix.PATH_MAX;
 

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -1,0 +1,86 @@
+# End-to-end tests for the LLVM native backend on Windows (kaappi#1610).
+# PowerShell port of run-e2e.sh's native-parity phase: `kaappi compile` every
+# program in programs/, run the native binary, and require its output to match
+# the interpreter's.
+#
+# Unlike run-e2e.sh this script does not build anything: native `zig build` is
+# broken in the 0.16.0 aarch64-windows toolchain (#1613), so kaappi.exe and
+# kaappi_rt.lib are cross-compiled and copied over — see "Testing on a Windows
+# machine" in docs/dev/windows.md. `kaappi compile` discovers kaappi_rt.lib by
+# itself (exe-relative ..\lib, or KAAPPI_LIB_DIR) and links with the first C
+# compiler found on PATH, so put a working zig on PATH first (Zig master /
+# >= 0.17.0 on ARM64 — the 0.16.0 toolchain access-violates, #1613).
+#
+# Usage: powershell -ExecutionPolicy Bypass -File tests\e2e\run-e2e.ps1 `
+#            [-Kaappi <path\to\kaappi.exe>]
+#        (default: $env:KAAPPI, then <repo>\zig-out\bin\kaappi.exe)
+
+param([string]$Kaappi = "")
+
+$ErrorActionPreference = "Continue"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoDir = (Resolve-Path (Join-Path $scriptDir "..\..")).Path
+if ($Kaappi -eq "") {
+    if ($env:KAAPPI) { $Kaappi = $env:KAAPPI }
+    else { $Kaappi = Join-Path $repoDir "zig-out\bin\kaappi.exe" }
+}
+if (-not (Test-Path $Kaappi)) {
+    Write-Output "kaappi.exe not found at $Kaappi (pass -Kaappi or set KAAPPI)"
+    exit 2
+}
+
+$outdir = Join-Path $env:TEMP ("kaappi-e2e-" + $PID)
+New-Item -ItemType Directory -Force -Path $outdir | Out-Null
+
+# Dirty builds at the same commit share bytecode-cache ids with different
+# code (docs/dev/windows.md) — never trust a warm cache on a test box.
+& $Kaappi cache clear 2>&1 | Out-Null
+
+$pass = 0
+$fail = 0
+$failed = @()
+
+# Default output naming must derive .exe on Windows (#1610).
+Copy-Item (Join-Path $scriptDir "programs\hello.scm") (Join-Path $outdir "naming.scm") -Force
+$null = (& $Kaappi compile (Join-Path $outdir "naming.scm") 2>&1)
+if (($LASTEXITCODE -eq 0) -and (Test-Path (Join-Path $outdir "naming.exe"))) {
+    Write-Output "PASS: default output naming (naming.scm -> naming.exe)"
+    $pass++
+} else {
+    Write-Output "FAIL: default output naming"
+    $fail++; $failed += "default-naming"
+}
+
+foreach ($p in (Get-ChildItem (Join-Path $scriptDir "programs\*.scm") | Sort-Object Name)) {
+    $name = $p.BaseName
+    $expected = (& $Kaappi $p.FullName 2>&1) -join "`n"
+    $exe = Join-Path $outdir "$name.exe"
+    $cc_out = (& $Kaappi compile $p.FullName -o $exe 2>&1) -join "`n"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Output "FAIL: $name - compile failed"
+        Write-Output $cc_out
+        $fail++; $failed += $name
+        continue
+    }
+    $actual = (& $exe 2>&1) -join "`n"
+    if ($actual -ceq $expected) {
+        Write-Output "PASS: $name"
+        $pass++
+    } else {
+        Write-Output "FAIL: $name"
+        Write-Output "  expected: $expected"
+        Write-Output "  actual:   $actual"
+        $fail++; $failed += $name
+    }
+}
+
+Remove-Item -Recurse -Force $outdir -ErrorAction SilentlyContinue
+
+Write-Output ""
+$total = $pass + $fail
+Write-Output "=== E2E Summary: $pass/$total passed ==="
+if ($fail -gt 0) {
+    Write-Output ("FAILED: " + ($failed -join ", "))
+    exit 1
+}
+exit 0


### PR DESCRIPTION
Closes #1610.

`kaappi compile` had never produced a running native binary on a Windows machine. Verifying it end-to-end on the Windows 11 ARM64 box surfaced four defects — the three the issue predicted, plus one new find:

## Fixes

- **Runtime-archive lookup** — `native_compiler.checkLibDir` and doctor's `hasArchive` probed for `libkaappi_rt.a`, but Zig names COFF archives `kaappi_rt.lib`, so discovery always failed on Windows. New `platform.rt_lib_name` carries the platform spelling; the probes, the compile error message, doctor's check names/messages, and `--help` use it. Search order unchanged.
- **Default output naming** — `kaappi compile foo.scm` derived `foo`; the derived name now appends `platform.exe_suffix` (`foo.exe` on Windows, unchanged elsewhere; explicit `-o` respected as given), via a new unit-tested `deriveOutputPath`.
- **Module triple** — the emitter fell to `aarch64-unknown-unknown` on Windows; now `aarch64/x86_64-pc-windows-gnu`, matching the gnu ABI the runtime lib is built with. (Clang's driver-triple override masked this, but only behind the `-w` the link line passes.)
- **New find: missing `-lws2_32`** — every link failed with undefined Winsock symbols. The fd-readiness backends (#1608) call ws2_32 via `extern "ws2_32"` declarations, which Zig links automatically only when it drives the final link itself; a foreign `zig cc` link of the static archive needs the import lib named explicitly. `tryLink` and doctor's `smokeLink` add it (in place of `-lpthread`) on Windows.

## Verification

On the Windows 11 ARM64 VM (build 26100), with a Zig master toolchain as the linker (0.16.0's `zig cc` access-violates natively on the box, #1613):

- **`tests/e2e/run-e2e.ps1`** (new in this PR: PowerShell port of run-e2e.sh's native-parity phase, kept for the post-0.17.0-bump retest): **38/38** — all 37 `tests/e2e/programs` compile natively and match the interpreter (closures, self/mutual tail calls, call/cc, macros, imports, eval/quote caches), plus the derived-`.exe` check.
- `kaappi doctor` native-backend: c-compiler, `kaappi_rt.lib` (via exe-relative `../lib`), and smoke-link all PASS (smoke-link failed before the ws2_32 fix — it caught the real defect).
- `KAAPPI_LIB_DIR` lookup, exe-relative discovery, and the `Cannot find kaappi_rt.lib` error path exercised individually.
- Emitted triple confirmed: `target triple = "aarch64-pc-windows-gnu"`.

No POSIX behavior change: macOS `tests/e2e/run-e2e.sh` stays 37/37; full unit suite green natively (1135/1135 + 25 thottam) and as the `-Dtarget=aarch64-windows` compile gate.

`docs/dev/windows.md` gains a "Native backend (`kaappi compile`)" section (fixes, the Windows manual link line, toolchain caveat) and drops the now-closed known-gap bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)