### PR TITLE
Unwind an idle in-place I/O drive pinned over a resolved wait (#1625)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,7 +498,11 @@ would block (`EAGAIN`) suspend the calling fiber instead of the thread
 (`.io_waiting` + the yield-retry re-execution protocol — callers stash
 partial progress into `port.read_buf` first via
 `primitives_io.propagateReadErr`); the main fiber or one under re-entrant
-native frames drives the scheduler in place instead. Port fds (never 0/1/2)
+native frames drives the scheduler in place instead. An in-place drive that
+goes idle while an *enclosing* drive's wait already resolved or timed out
+(`FiberScheduler.driving_waits`) unwinds with a catchable "port I/O
+abandoned" error rather than blocking unboundedly — the pinned ancestor can
+only proceed once this fiber's native frames unwind (#1625). Port fds (never 0/1/2)
 flip to `O_NONBLOCK` lazily, only once a scheduler exists — sequential
 programs keep blocking fds and their exact syscall profile. On WASI the
 flip is the host-capability probe: `fd_fdstat_set_flags(NONBLOCK)` failing

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -233,8 +233,8 @@ pub const FiberScheduler = struct {
     /// descendant about to block unboundedly must check this first, or it
     /// wedges the whole thread on an event that may never come while the
     /// ancestor sits ready to proceed (#1625). Matching by fiber identity
-    /// (not "skip the top entry") keeps the answer right even if the
-    /// caller's own push was dropped by OOM.
+    /// (not "skip the top entry") keeps the check independent of the
+    /// list's push/pop bookkeeping.
     pub fn anyAncestorWaitResolved(self: *FiberScheduler, me: *Fiber) bool {
         for (self.driving_waits.items) |w| {
             if (w.fiber != me and (w.fiber.timed_out or w.is_done(w.ctx))) return true;
@@ -1298,26 +1298,24 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
     // Publish this drive's wait so nested drives can evaluate it (#1625) —
     // see driving_waits' doc comment. `ctx` is this frame's parameter, so
     // the pointer stays valid for exactly the extent the entry is stacked.
-    // An OOM here just leaves the entry out: descendants lose the ancestor
-    // check for this drive (worst case the pre-#1625 behavior), which is
-    // strictly better than failing the wait itself.
+    // Unlike the ready ring or waiter_index, this list is a correctness
+    // registry with no fallback: an entry silently dropped on OOM would
+    // re-open the #1625 wedge for this drive's descendants. Fail the wait
+    // loudly instead — callers already handle OutOfMemory from inside the
+    // loop (saveCurrentFiber's growth, parkOnReactor's poll), and a clean
+    // error beats a silent hang at death's door.
     const erased = struct {
         fn isDone(p: *const anyopaque) bool {
             const c: *const Ctx = @ptrCast(@alignCast(p));
             return c.isDone();
         }
     };
-    const enrolled = blk: {
-        sched.driving_waits.append(vm.gc.allocator, .{
-            .fiber = me,
-            .ctx = @ptrCast(&ctx),
-            .is_done = &erased.isDone,
-        }) catch break :blk false;
-        break :blk true;
-    };
-    defer if (enrolled) {
-        _ = sched.driving_waits.pop();
-    };
+    sched.driving_waits.append(vm.gc.allocator, .{
+        .fiber = me,
+        .ctx = @ptrCast(&ctx),
+        .is_done = &erased.isDone,
+    }) catch return VMError.OutOfMemory;
+    defer _ = sched.driving_waits.pop();
 
     while (!ctx.isDone() and !me.timed_out) {
         const next_idx = sched.scheduleForDispatch() orelse {

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -173,6 +173,26 @@ pub const FiberScheduler = struct {
     /// giving up the accelerator forever (rather than trying to recover it) is
     /// the responsible trade: worst case is exactly the old behavior.
     waiter_index_degraded: bool,
+    /// #1625: the stack of runSchedulerStep drives currently live on this OS
+    /// thread's Zig call stack, outermost first (each drive pushes on entry,
+    /// pops on exit — strict LIFO). Every entry except the innermost belongs
+    /// to an *ancestor*: a fiber frozen mid-dispatch whose own wait condition
+    /// nothing announces — no wake path fires when a TargetWait's target
+    /// completes for a fiber that is `driving` rather than `.waiting` — so
+    /// the only way a descendant can learn "the wait pinned beneath me has
+    /// resolved and only my unwinding can deliver it" is to evaluate the
+    /// ancestor's own isDone through this type-erased view. Entries reference
+    /// the drive's stack frame (`ctx` points into it) and are only ever read
+    /// while that frame is alive, which the LIFO discipline guarantees.
+    driving_waits: std.ArrayList(DrivingWait),
+
+    /// One live runSchedulerStep drive, with its comptime-typed wait context
+    /// erased so drives over different Ctx types can share one stack.
+    const DrivingWait = struct {
+        fiber: *Fiber,
+        ctx: *const anyopaque,
+        is_done: *const fn (*const anyopaque) bool,
+    };
 
     pub fn init(vm: *VM) FiberScheduler {
         return .{
@@ -187,6 +207,7 @@ pub const FiberScheduler = struct {
             .free_head = 0,
             .waiter_index = std.AutoHashMap(Value, std.ArrayList(usize)).init(vm.gc.allocator),
             .waiter_index_degraded = false,
+            .driving_waits = .empty,
         };
     }
 
@@ -198,6 +219,27 @@ pub const FiberScheduler = struct {
         var it = self.waiter_index.valueIterator();
         while (it.next()) |list| list.deinit(allocator);
         self.waiter_index.deinit();
+        self.driving_waits.deinit(allocator);
+    }
+
+    /// True iff some *other* live drive on this OS thread — always an
+    /// ancestor of the caller's, since drives nest strictly (#1487's
+    /// reasoning) — would exit its loop if control returned to it: its wait
+    /// condition is satisfied, or its timed wait expired (`timed_out` —
+    /// a pure sleep resolves *only* this way, its isDone is constant
+    /// false). Such an ancestor can consume its resolution only when the
+    /// callers above it unwind: it is excluded from dispatch (`driving`),
+    /// its loop is frozen mid-dispatch, and no wake path targets it. A
+    /// descendant about to block unboundedly must check this first, or it
+    /// wedges the whole thread on an event that may never come while the
+    /// ancestor sits ready to proceed (#1625). Matching by fiber identity
+    /// (not "skip the top entry") keeps the answer right even if the
+    /// caller's own push was dropped by OOM.
+    pub fn anyAncestorWaitResolved(self: *FiberScheduler, me: *Fiber) bool {
+        for (self.driving_waits.items) |w| {
+            if (w.fiber != me and (w.fiber.timed_out or w.is_done(w.ctx))) return true;
+        }
+        return false;
     }
 
     /// Shared lazy-compaction for the FIFO rings (`ready`, `free_slots`):
@@ -1056,6 +1098,18 @@ const IoWait = struct {
     pub fn isDone(self: IoWait) bool {
         return self.me.status != .io_waiting;
     }
+    /// #1625: an fd wait is the one drive whose *own* registration defeats
+    /// the generic idle escape — hasRunnableFibers counts this fiber's
+    /// `.io_waiting` and the fd keeps the reactor non-empty, so
+    /// parkOnReactor never returns false and the poll is unbounded. When an
+    /// ancestor drive has already resolved, blocking anyway wedges it
+    /// forever on an event that may never come; unwinding (waitForFd turns
+    /// the broken-off drive into a catchable error) is the only exit that
+    /// lets the thread proceed. Waits that resolve through in-thread wakes
+    /// (join/channel/mutex/condvar) don't need this: with no fd of their
+    /// own, the same idle state already falls out via parkOnReactor's
+    /// deadlock check, and timed sleeps must run their full duration.
+    pub const unwind_on_resolved_ancestor = true;
 };
 
 /// Blocks the current fiber until `fd` is ready for `interest` (KEP-0001
@@ -1073,7 +1127,12 @@ const IoWait = struct {
 ///   in place — exactly the thread-sleep! pattern — until the reactor
 ///   reports the fd ready or a close-port wake intervenes, then returns so
 ///   the caller retries its syscall. Blocking main on I/O this way keeps
-///   sibling fibers running while preserving blocking-read semantics.
+///   sibling fibers running while preserving blocking-read semantics. One
+///   exception (#1625): if the drive goes idle while an *enclosing* drive's
+///   wait has already resolved (IoWait.unwind_on_resolved_ancestor), it
+///   raises a catchable "port I/O abandoned" error instead of blocking,
+///   because only this fiber's unwinding can let that enclosing wait
+///   proceed.
 pub fn waitForFd(vm: *VM, fd: platform.fd_t, interest: reactor_mod.Interest) VMError!void {
     const ctx = try ensureScheduler(vm);
     const me = vm.current_fiber orelse return VMError.InvalidArgument;
@@ -1115,7 +1174,32 @@ pub fn waitForFd(vm: *VM, fd: platform.fd_t, interest: reactor_mod.Interest) VME
         me.io_fd = null;
         me.status = .running;
     }
-    _ = try runSchedulerStep(IoWait, .{ .me = me }, vm, ctx.sched, me);
+    const done = try runSchedulerStep(IoWait, .{ .me = me }, vm, ctx.sched, me);
+    // The drive broke off unresolved: IoWait's unwind_on_resolved_ancestor
+    // fired (#1625) — an enclosing dispatch's wait has completed and only
+    // this fiber's unwinding lets it proceed. Returning normally would
+    // retry the syscall, EAGAIN again, and re-enter the same drive: an
+    // unbreakable spin. Raise a catchable error instead; the defer above
+    // has already pulled `me` off the reactor, and the re-entrant frames
+    // that made parking impossible (guard, dynamic-wind) are exception
+    // plumbing — an ordinary raise is exactly the unwind they handle.
+    if (!done) return raiseIoWaitAbandoned(vm);
+}
+
+/// The catchable error a broken-off in-place I/O drive surfaces as (#1625).
+/// A plain ErrorObject like blockOrDeadlock's deadlock errors — this is the
+/// I/O drive's analogue of those: "this wait can no longer be serviced
+/// without wedging the scheduler."
+fn raiseIoWaitAbandoned(vm: *VM) VMError {
+    var msg = vm.gc.allocString(
+        "port I/O abandoned: fiber cannot suspend under re-entrant native frames " ++
+            "(guard, dynamic-wind, callbacks) while an enclosing completed wait needs this thread",
+    ) catch return VMError.OutOfMemory;
+    vm.gc.pushRoot(&msg);
+    defer vm.gc.popRoot();
+    const err_obj = vm.gc.allocErrorObject(msg, types.NIL) catch return VMError.OutOfMemory;
+    vm.current_exception = err_obj;
+    return VMError.ExceptionRaised;
 }
 
 /// Called when sched.schedule() finds nothing immediately runnable. Blocks
@@ -1211,8 +1295,45 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
     me.driving = true;
     defer me.driving = false;
 
+    // Publish this drive's wait so nested drives can evaluate it (#1625) —
+    // see driving_waits' doc comment. `ctx` is this frame's parameter, so
+    // the pointer stays valid for exactly the extent the entry is stacked.
+    // An OOM here just leaves the entry out: descendants lose the ancestor
+    // check for this drive (worst case the pre-#1625 behavior), which is
+    // strictly better than failing the wait itself.
+    const erased = struct {
+        fn isDone(p: *const anyopaque) bool {
+            const c: *const Ctx = @ptrCast(@alignCast(p));
+            return c.isDone();
+        }
+    };
+    const enrolled = blk: {
+        sched.driving_waits.append(vm.gc.allocator, .{
+            .fiber = me,
+            .ctx = @ptrCast(&ctx),
+            .is_done = &erased.isDone,
+        }) catch break :blk false;
+        break :blk true;
+    };
+    defer if (enrolled) {
+        _ = sched.driving_waits.pop();
+    };
+
     while (!ctx.isDone() and !me.timed_out) {
         const next_idx = sched.scheduleForDispatch() orelse {
+            // Nothing dispatchable. Before blocking in the reactor, a wait
+            // that opted in gives up instead when an ancestor drive's
+            // condition has already resolved: that ancestor can only
+            // proceed once we unwind, and blocking here — for I/O waits,
+            // on this fiber's own fd with no bound — would pin it forever
+            // (#1625: a guard-wrapped reader's in-place drive vs. the
+            // enclosing fiber-join whose target already completed). Checked
+            // only at the idle point so runnable siblings still get
+            // dispatched first — one of them may resolve *this* wait, which
+            // is always the better outcome.
+            if (comptime @hasDecl(Ctx, "unwind_on_resolved_ancestor")) {
+                if (sched.anyAncestorWaitResolved(me)) break;
+            }
             if (!(try parkOnReactor(vm, sched, poll_cap_ns))) break;
             continue;
         };

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -169,6 +169,105 @@ test "closing a port with a parked reader raises a clean error in that fiber" {
     try std.testing.expectEqual(types.TRUE, r);
 }
 
+test "#1625: guard reader's idle drive unwinds instead of wedging a resolved join" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pair = th.makeBidiFdPair();
+    _ = try definePortGlobal(vm, "rp", pair[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pair[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    _ = try vm.eval(
+        \\(define f (spawn (lambda ()
+        \\  (guard (e (#t (list 'caught (error-object? e) (error-object-message e))))
+        \\    (read-char rp)
+        \\    'not-reached))))
+    );
+    // The #1625 hang: this join's dispatch runs f first (FIFO). Under
+    // guard's re-entrant native frames f cannot park-and-retry, so its
+    // EAGAIN drives the scheduler in place; that drive dispatches the
+    // trivial fiber — resolving THIS join — and then went idle in an
+    // unbounded reactor poll on f's own never-ready fd, pinning the
+    // resolved join beneath f's native frames forever. Fixed, the idle
+    // drive notices the resolved enclosing wait, unwinds f's read with the
+    // catchable "port I/O abandoned" error (guard is exactly the plumbing
+    // that handles it), and the join returns.
+    const joined = try vm.eval("(fiber-join (spawn (lambda () 1)))");
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(joined));
+
+    const f_val = try vm.eval("f");
+    try std.testing.expectEqual(fiber_mod.FiberStatus.completed, types.toObject(f_val).as(fiber_mod.Fiber).status);
+    const caught = try vm.eval("(and (equal? (car (fiber-join f)) 'caught) (cadr (fiber-join f)))");
+    try std.testing.expectEqual(types.TRUE, caught);
+    // Pin which error unwound the read: the deliberate #1625 abandonment,
+    // not #1184's contentless generic conversion of a stray Yielded.
+    const msg_val = try vm.eval("(caddr (fiber-join f))");
+    const msg = types.toObject(msg_val).as(types.SchemeString);
+    try std.testing.expect(std.mem.startsWith(u8, msg.data[0..msg.len], "port I/O abandoned"));
+
+    // The port survived f's unwinding: still open, still closable.
+    _ = try vm.eval("(fiber-join (spawn (lambda () (close-port rp))))");
+    const closed = try vm.eval("(not (input-port-open? rp))");
+    try std.testing.expectEqual(types.TRUE, closed);
+}
+
+test "#1625: guard reader pinned under an expired thread-sleep! unwinds too" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pair = th.makeBidiFdPair();
+    _ = try definePortGlobal(vm, "rp", pair[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pair[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers) (srfi 18))");
+    _ = try vm.eval(
+        \\(define f (spawn (lambda ()
+        \\  (guard (e (#t 'caught))
+        \\    (read-char rp)
+        \\    'not-reached))))
+    );
+    // The timed-out flavor of the same wedge: main's sleep drive dispatches
+    // f, whose EAGAIN drive is then pinned beneath the sleep. The sleep's
+    // timer bounds the reactor poll, so the deadline fires inside f's
+    // drive and flips main to timed_out — a resolution SleepWait's isDone
+    // (constant false) never reports. The ancestor check must read
+    // `timed_out` too, or f's next idle poll is unbounded (no timers left,
+    // only f's own fd) and the sleep never returns.
+    _ = try vm.eval("(thread-sleep! 0.05)");
+    const f_val = try vm.eval("f");
+    try std.testing.expectEqual(fiber_mod.FiberStatus.completed, types.toObject(f_val).as(fiber_mod.Fiber).status);
+    const r = try vm.eval("(eq? (fiber-join f) 'caught)");
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
+test "#1625: same ordering over an OS pipe unwinds identically" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = th.makePipeFdPair();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    _ = try vm.eval(
+        \\(define f (spawn (lambda ()
+        \\  (guard (e (#t (list 'caught (error-object? e))))
+        \\    (read-char rp)
+        \\    'not-reached))))
+    );
+    const joined = try vm.eval("(fiber-join (spawn (lambda () 1)))");
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(joined));
+    const r = try vm.eval("(equal? (fiber-join f) '(caught #t))");
+    try std.testing.expectEqual(types.TRUE, r);
+}
+
 test "thread-terminate! pulls a parked reader off the reactor; the fd stays usable" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -717,15 +816,13 @@ test "#1608: closing an OS-pipe port with a parked reader raises a clean error i
         \\    (read-char rp)
         \\    'not-reached))))
     );
-    // Deliberately NOT pre-parked with a dispatch tick before spawning the
-    // closer (unlike the interleave test above): f's guard means its read
-    // runs under re-entrant native frames, and a pre-parked f redispatched
-    // by the later join drives the scheduler into an unbounded poll with
-    // the runnable closer never dispatched — a pre-existing interaction
-    // independent of the pipe backend (repros with socket pairs; #1625).
-    // The FIFO dispatch order below still exercises the parked path
-    // deterministically: at the join, f is dispatched first, parks on the
-    // empty pipe, and only then does its in-place drive dispatch closer.
+    // Closer spawned before the join so both are pending at dispatch time:
+    // FIFO runs f first, its guard means the read blocks under re-entrant
+    // native frames (drive-in-place, not park-and-retry), and the drive
+    // dispatches closer, whose close-port wakes f into the clean "port
+    // closed" raise. The other ordering — f's drive going idle with no
+    // closer yet — used to wedge in an unbounded poll; that path now
+    // unwinds with "port I/O abandoned" and has its own tests (#1625).
     _ = try vm.eval("(define closer (spawn (lambda () (close-port rp))))");
     // The join completing at all is the "nothing hangs" half of the
     // acceptance criterion; the guard result is the "clean error" half.


### PR DESCRIPTION
Closes #1625.

## The hang

The repro's stack is real, but it belongs to the **first** join — `(fiber-join (spawn (lambda () 1)))` — not the last one. A guard-wrapped blocking read can never park: `guard` desugars to `call/ec` + `with-exception-handler`, whose thunk runs under `callReentrant`'s nested `runUntil`, which clears `dispatched_from_scheduler`. So the reader's EAGAIN takes `waitForFd`'s **drive** mode. That drive dispatches the trivial fiber (resolving the enclosing join), then goes idle — and `parkOnReactor` polls **unbounded** on the reader's own fd: `hasRunnableFibers` counts the reader's `.io_waiting` and its registration keeps the reactor non-empty, so the generic deadlock escape never fires. The enclosing join, already resolved, is pinned beneath the reader's native frames on the one OS stack; `kevent` blocks forever.

The issue's observation 1 ("previously parked `.io_waiting`, redispatched by the later join") was a misread of an identical-looking stack: a guard-wrapped reader never survives in a parked state past the eval that dispatches it, so the final-join framing can't occur. Verified by running the repro before the fix — it hangs at the pre-park join (`sample` shows the same stack as the issue's, at that eval).

## The fix

A resolution of a *driving* fiber's wait is announced by nothing: a driver is never `.waiting`, so no wake path targets it, and its loop is frozen mid-dispatch until the fiber it dispatched unwinds. So:

- Every `runSchedulerStep` drive now publishes its wait in a type-erased per-scheduler stack (`FiberScheduler.driving_waits`, strict LIFO, popped on exit). A nested drive can evaluate whether any ancestor's `isDone()` is satisfied **or its timed wait expired** (`timed_out` — a pure `thread-sleep!` resolves only that way).
- At a drive's idle point (runnable siblings always dispatch first — one of them may resolve the wait properly, e.g. a `close-port`), a wait that opts in via `unwind_on_resolved_ancestor` breaks off instead of blocking. Only `IoWait` opts in: it is the one drive whose own fd registration defeats the existing `parkOnReactor` deadlock escape. Join/channel/mutex/condvar drives already fall out through that escape, and sleeps must run their full duration.
- `waitForFd` turns the broken-off drive into a catchable **"port I/O abandoned"** error (a plain `ErrorObject`, like `blockOrDeadlock`'s deadlock errors). The re-entrant frames that made parking impossible are exception plumbing — `guard` catches it, the fiber completes, and the pinned ancestor proceeds. Returning without raising would EAGAIN-retry into the same drive: an unbreakable spin.

## Tests

- `#1625: guard reader's idle drive unwinds instead of wedging a resolved join` — the issue's repro (socketpair); asserts the join returns, the reader completed via the specific abandonment error (message prefix pinned, so #1184's contentless generic conversion can't fake a pass), and the port is still open and closable afterward.
- `#1625: guard reader pinned under an expired thread-sleep! unwinds too` — the `timed_out` half of the detector; hangs without the `w.fiber.timed_out` clause (verified by temporarily removing it).
- `#1625: same ordering over an OS pipe unwinds identically` — pipe-pair variant (covers the Windows polled pipe backend path).
- Updated the #1623 close-wake pipe test's comment: the dodged ordering now has its own tests.

Full unit suite green; `bash tests/scheme/run-all.sh` green (no SKIPs); the 72 port/fiber/scheduler tests green under `-Dgc-stress=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)