### PR TITLE
Harden tests_check against silent import-resolution failures (#1627)

### DIFF
--- a/src/tests_check.zig
+++ b/src/tests_check.zig
@@ -57,12 +57,28 @@ const Harness = struct {
         }
         return null;
     }
+
+    /// Print every collected finding. Wired into failures so an unexpected
+    /// finding (a failed import, a stray compile error) identifies itself
+    /// instead of surfacing as a bare lint miscount (#1627).
+    fn dump(self: *Harness, source: []const u8) void {
+        std.debug.print("collected findings for: {s}\n", .{source});
+        if (self.ctx.findings.items.len == 0) {
+            std.debug.print("  (none)\n", .{});
+            return;
+        }
+        for (self.ctx.findings.items) |f| {
+            var cbuf: [Code.render_width]u8 = undefined;
+            std.debug.print("  {s} at {d}:{d}: {s}\n", .{ f.code.render(&cbuf), f.span.line, f.span.col, f.message });
+        }
+    }
 };
 
 fn expectCounts(source: []const u8, arity: usize, type_mismatch: usize, unbound: usize) !void {
     var h: Harness = .{};
     try h.run(source);
     defer h.deinit();
+    errdefer h.dump(source);
     testing.expectEqual(arity, h.count(.primitive_arity_mismatch)) catch |e| {
         std.debug.print("arity mismatch count wrong for: {s}\n", .{source});
         return e;
@@ -73,6 +89,13 @@ fn expectCounts(source: []const u8, arity: usize, type_mismatch: usize, unbound:
     };
     testing.expectEqual(unbound, h.count(.unknown_toplevel_variable)) catch |e| {
         std.debug.print("unbound count wrong for: {s}\n", .{source});
+        return e;
+    };
+    // Nothing beyond the expected lint findings: an extra finding here is a
+    // broken precondition (a failed import, a stray compile error), which must
+    // fail as itself — not hide until it perturbs a lint count (#1627).
+    testing.expectEqual(arity + type_mismatch + unbound, h.total()) catch |e| {
+        std.debug.print("unexpected extra findings for: {s}\n", .{source});
         return e;
     };
 }
@@ -175,12 +198,47 @@ test "invariant: calls synthesized by a macro are not linted" {
 }
 
 test "invariant: an imported macro use is not linted as a call" {
-    // `test-error`'s argument is a deliberate error the guard catches; the
-    // program is valid, so `check` must not reject it.
+    // `swallow`'s argument is a deliberate error the macro discards; the
+    // program is valid, so `check` must not reject it. The macro arrives
+    // through `import` — registered by importBinding at import time, a
+    // different path from the in-file `define-syntax` test above. The library
+    // is defined in-source so the import resolves from the registry and the
+    // test never touches the filesystem (#1627); the on-disk `.sld` variant
+    // follows below.
     try expectCounts(
+        \\(define-library (t macros)
+        \\  (export swallow)
+        \\  (begin (define-syntax swallow (syntax-rules () ((_ e) 'ok)))))
+        \\(import (t macros))
+        \\(swallow (car 1 2))
+    , 0, 0, 0);
+}
+
+test "invariant: a macro imported from an .sld file is not linted as a call" {
+    // The on-disk variant of the test above: `(chibi test)` goes through the
+    // real .sld search + load path, and `test-error`'s argument is a
+    // deliberate error the guard catches. CWD-DEPENDENT: unit-test VMs have
+    // no lib_paths, so resolution probes "" and "lib/" relative to the
+    // process cwd — this test needs the repo root (lib/chibi/test.sld) as
+    // cwd. The macro probe turns any resolution/load hiccup into a loud
+    // import failure instead of a baffling lint miscount (#1627).
+    const source =
         \\(import (chibi test))
         \\(test-error (apply +))
-    , 0, 0, 0);
+    ;
+    var h: Harness = .{};
+    try h.run(source);
+    defer h.deinit();
+    errdefer h.dump(source);
+    if (!h.tc.vm.macros.contains("test-error")) {
+        std.debug.print(
+            "import failed: (chibi test) did not provide the test-error macro — " ++
+                ".sld resolution is cwd-relative and needs lib/chibi/test.sld under the cwd (#1627)\n",
+            .{},
+        );
+        return error.ImportFailed;
+    }
+    try testing.expectEqual(@as(usize, 0), h.total());
 }
 
 // ── Recursion into bodies (calls inside standard forms still checked) ───────


### PR DESCRIPTION
## Summary

`tests_check.test."invariant: an imported macro use is not linted as a call"` flaked on macOS ARM (#1627) with the baffling signature `unbound count wrong … expected 0, found 1`. The test silently depended on the unit-test process cwd containing `lib/chibi/test.sld` — test VMs have no `lib_paths`, so `(import (chibi test))` resolves cwd-relative only — and any resolution/load failure degraded to a miscounted lint because `expectCounts` never looked at findings outside the three `KP4xxx` codes it counts.

This implements both hardenings the issue suggests (independent of the still-unconfirmed trigger):

- **Loud harness.** `expectCounts` now also asserts there are *no findings beyond* the expected lint counts, and every failure path (via `errdefer`) dumps the full findings list with rendered `KP` codes. A failed import — which `check` already records as a `KP2001 "library not found: …"` finding — now identifies itself instead of hiding until it perturbs a lint count.
- **Hermetic invariant test.** The imported-macro invariant test now defines its library in-source via `define-library`, so the `import` resolves from the in-memory registry through the same `importBinding` path — zero filesystem involvement, while still covering the import-time macro registration path (distinct from the in-file `define-syntax` test).
- **Clearly-marked cwd-dependent `.sld` variant.** The real on-disk search+load path keeps its own test with `(chibi test)`, explicitly commented as CWD-DEPENDENT, which probes `vm.macros.contains("test-error")` after analysis and fails as `error.ImportFailed` with an explanatory message when the import didn't actually resolve.

## Failure-mode verification (simulated resolution failure)

Renaming the imported library to a nonexistent one now produces, instead of the old bare miscount:

```
import failed: (chibi test) did not provide the test-error macro — .sld resolution is cwd-relative and needs lib/chibi/test.sld under the cwd (#1627)
collected findings for: (import (chibi test-simulated-resolution-failure))
(test-error (apply +))
  KP2001 at 1:1: library not found: (chibi.test-simulated-resolution-failure)
  KP4001 at 2:1: unknown variable 'test-error' at top level
```

and the `expectCounts` guard likewise dumps the `KP2001` finding when the hermetic variant's import is broken.

## Testing

- `zig build test -Dtest-filter=tests_check` — 32/32 pass
- `zig build test` — full suite 1139/1139 pass
- Both negative paths exercised via temporary simulated import failures (outputs above), then reverted

Closes #1627

🤖 Generated with [Claude Code](https://claude.com/claude-code)