### PR TITLE
Run the shell-based test suites on Windows (#1612)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,10 @@ jobs:
           for dir in smoke errors compile test-runner pipeline doctor fmt cache timings sandbox robustness; do
             for s in tests/scheme/$dir/*.sh; do
               [ -e "$s" ] || continue
-              out=$(KAAPPI="$KAAPPI" bash "$s" "$KAAPPI" 2>&1); status=$?
+              # `|| status=$?`: the runner's `shell: bash` implies -e, which
+              # would otherwise abort the whole step on the first SKIP (77).
+              status=0
+              out=$(KAAPPI="$KAAPPI" bash "$s" "$KAAPPI" 2>&1) || status=$?
               if [ "$status" -eq 0 ]; then
                 echo "  PASS  $s"
               elif [ "$status" -eq 77 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,13 +193,14 @@ jobs:
   # Execute the suite on real Windows ARM64 via GitHub's hosted
   # windows-11-arm runners (free for public repos): the unit suite, the
   # thottam suite + install/remove integration (#1609), the R7RS suite,
-  # and the .scm suites verified on the port's reference VM
+  # the .scm suites verified on the port's reference VM
   # (docs/dev/windows.md), including the FFI suite (#1611) against the
-  # cross-compiled fixture DLL. The binaries come cross-compiled from
+  # cross-compiled fixture DLL, and the shell-based suites (#1612) under
+  # the runner's Git Bash. The binaries come cross-compiled from
   # windows-cross — Zig 0.16.0 cannot compile natively on Windows ARM64
   # (zig build/build-exe access-violate on any project, #1613) — so this
-  # job installs no toolchain and only executes. The shell-based suites
-  # (#1612) are not runnable on Windows yet.
+  # job installs no toolchain and only executes; the compile/ suite
+  # (which rebuilds with zig on the box) self-skips for the same reason.
   windows-arm-test:
     needs: windows-cross
     runs-on: windows-11-arm
@@ -297,6 +298,44 @@ jobs:
             done
           done
           rm -f out.log
+          exit $fail
+
+      - name: Shell suites (#1612)
+        # The bash-driven drivers, under the runner's Git Bash. Exit 77 =
+        # SKIP (tests/scheme/shell-common.sh): a script whose premise cannot
+        # hold on Windows — the compile/ suite needs a native Zig toolchain
+        # (#1613) — reports itself instead of failing. KAAPPI_HOME is
+        # isolated like run-all.sh does, so suites never touch a real cache.
+        shell: bash
+        run: |
+          # Some drivers validate JSON with python3; the arm image ships
+          # Python as `python`, so shim python3 when the name is missing.
+          # ($HOME, not $RUNNER_TEMP: a Windows-spelled dir in bash's PATH
+          # would not resolve for bash's own lookup.)
+          if ! command -v python3 >/dev/null 2>&1; then
+            mkdir -p "$HOME/.pyshim"
+            printf '#!/bin/sh\nexec python "$@"\n' > "$HOME/.pyshim/python3"
+            chmod +x "$HOME/.pyshim/python3"
+            export PATH="$HOME/.pyshim:$PATH"
+          fi
+          export KAAPPI=bin/kaappi.exe
+          export KAAPPI_HOME="$RUNNER_TEMP/kaappi-test-home"
+          fail=0
+          for dir in smoke errors compile test-runner pipeline doctor fmt cache timings sandbox robustness; do
+            for s in tests/scheme/$dir/*.sh; do
+              [ -e "$s" ] || continue
+              out=$(KAAPPI="$KAAPPI" bash "$s" "$KAAPPI" 2>&1); status=$?
+              if [ "$status" -eq 0 ]; then
+                echo "  PASS  $s"
+              elif [ "$status" -eq 77 ]; then
+                echo "  SKIP  $s"
+              else
+                echo "  FAIL  $s (exit $status)"
+                printf '%s\n' "$out"
+                fail=1
+              fi
+            done
+          done
           exit $fail
 
   wasm:

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -45,10 +45,23 @@ shim behind that surface:
 
 Files are always opened `O_BINARY` — the CRT's default text mode would
 rewrite `\n`/`\r\n` and treat `^Z` as EOF, which R7RS ports must never
-see. Paths are normalized to `/` at the boundaries that produce them
-(argv script path, `GetModuleFileNameW`, `getcwd`, `_wfullpath`): Win32
-accepts forward slashes everywhere the runtime passes paths, and every
-internal path split/join is written for `/`.
+see. The preopened standard fds get the same treatment at startup
+(`platform.initStandardStreams`, called first thing in every binary's
+main): stdout/stderr flip to binary unconditionally — piped output is
+byte-identical to POSIX, and the console still renders bare `\n`
+correctly (newline auto-return is independent of the CRT fd mode) —
+while stdin flips only when it is *not* the interactive console, whose
+line input relies on text mode (`\r\n` → `\n`, ^Z+Enter = EOF) for the
+plain REPL. The same call switches the console to UTF-8 both ways and
+enables VT processing. In kaappi-lsp this is also what keeps the
+length-framed wire format intact: text-mode `\n`→`\r\n` rewriting on
+fd 1 would corrupt `Content-Length` framing. Paths are normalized to
+`/` at the boundaries that produce them (argv script path,
+`GetModuleFileNameW`, `getcwd`, `_wfullpath`): Win32 accepts forward
+slashes everywhere the runtime passes paths, and every internal path
+split/join is written for `/` (a `std.fs.path.join`, which uses `\` on
+Windows, is a bug — it broke `kaappi test --changed` suite discovery,
+#1612).
 
 ## Fd readiness: sockets and pipes (#1608)
 
@@ -236,14 +249,33 @@ CI covers the target twice (ci.yml): `windows-cross` cross-compiles the
 binaries and the test exes from Linux, guarding the path release.yml
 ships with, and `windows-arm-test` executes the unit suite, the thottam
 suite plus a real package install/remove integration test, the R7RS
-suite, and the VM-verified `.scm` suites on GitHub's hosted
-`windows-11-arm` runners on every PR. The execution job installs no
-toolchain — it downloads the binaries `windows-cross` built as an
-artifact, because native compilation on Windows ARM64 is broken in the
-Zig 0.16.0 toolchain itself (#1613). The FFI suite runs against a
-fixture DLL that `windows-cross` cross-compiles into the same artifact
-(`zig cc -target aarch64-windows-gnu -shared`). What CI can't run yet —
-the shell-based suites (#1612) and interactive surfaces like the REPL —
+suite, the VM-verified `.scm` suites, and the shell-based suites (#1612)
+on GitHub's hosted `windows-11-arm` runners on every PR. The execution
+job installs no toolchain — it downloads the binaries `windows-cross`
+built as an artifact, because native compilation on Windows ARM64 is
+broken in the Zig 0.16.0 toolchain itself (#1613). The FFI suite runs
+against a fixture DLL that `windows-cross` cross-compiles into the same
+artifact (`zig cc -target aarch64-windows-gnu -shared`).
+
+The shell-based drivers (errors, test-runner, pipeline, doctor, fmt,
+cache, timings, the smoke `.sh` scripts, sandbox, robustness) run under
+the runner's Git Bash, whose MSYS userland supplies bash, coreutils,
+git, and — via a CI shim when the image only exposes `python` — python3.
+A driver whose premise cannot hold on Windows sources
+`tests/scheme/shell-common.sh` and calls `skip_on_windows <reason>`,
+exiting 77 (the shell analogue of the `cond-expand (windows ...)` gate
+the `.scm` tests use); run-all.sh and the CI loop report those as SKIP.
+Today that is the `compile/` suite (each script rebuilds the runtime
+archive or interpreter with a native `zig` on the box — #1613, so the
+gates lift work at the 0.17.0 toolchain bump) and
+`profile-json-escaping.sh` (it plants `"`/`\` in a real directory name,
+which Windows filenames cannot contain). shell-common.sh also carries
+the portability helpers the drivers need on Windows: `native_path` (the
+C:/-style spelling the binary itself prints, via `cygpath -m` — MSYS
+`/tmp/...` paths never appear in kaappi's own output) and `rt_lib_name`
+(`kaappi_rt.lib` vs `libkaappi_rt.a`).
+
+What CI still can't run — interactive surfaces like the console REPL —
 is verified against a real Windows 11 ARM64 machine (e.g. a UTM VM with
 ssh). Before any decisive run on the box, `kaappi cache clear` — dirty
 builds at the same commit share bytecode-cache ids with different code.
@@ -262,9 +294,11 @@ Two environment notes for the suite:
 * Run from a writable directory; a few tests create files in the CWD.
 
 Verified on Windows 11 ARM64 (build 26100): full unit suite, the
-complete R7RS suite, and every `tests/scheme/{smoke,compliance,
-continuations,hygiene,srfi,ffi,audit}` file — the same set the
-`windows-arm-test` CI job now runs on every PR. The fd-readiness unit
+complete R7RS suite, every `tests/scheme/{smoke,compliance,
+continuations,hygiene,srfi,ffi,audit}` file, and the shell-based
+suites under Git Bash (34 pass, 15 skip: the 14 `compile/` gates plus
+`profile-json-escaping.sh`) — the same set the `windows-arm-test` CI
+job now runs on every PR. The fd-readiness unit
 suites (`tests_reactor.zig`, `tests_scheduler.zig`, `tests_port_io.zig`)
 run on Windows too: testing_helpers' cross-platform fd pairs substitute
 loopback TCP socket pairs for the POSIX pipes/socketpairs, so those
@@ -303,9 +337,11 @@ the github-release skill's Step 10.
   end-to-end with Zig master, see "Native backend" above). Fixed
   upstream (ziglang#31865); everything unblocks at the 0.17.0 toolchain
   bump.
-* The shell-based suites — errors, compile, test-runner, pipeline,
-  doctor, fmt, cache, timings, the smoke `.sh` scripts, sandbox, and
-  robustness — don't run on Windows (#1612).
+* The `compile/` shell suite self-skips on Windows: every script
+  rebuilds the runtime archive or the interpreter with a native `zig`
+  on the box, which #1613 breaks. The `skip_on_windows` gates
+  (tests/scheme/shell-common.sh) lift work at the 0.17.0 toolchain
+  bump. (The rest of the shell-based suites run in CI — #1612.)
 * thottam refuses manifests with a `build:` command (#1609 ported
   everything else — see Deliberate degradations above); lifting that
   needs a Windows build story for the C-FFI packages, which today are

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -762,6 +762,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
     _ = init;
     const allocator = std.heap.c_allocator;
 
+    // Byte-faithful stdio (Windows): the LSP wire format is length-framed,
+    // so CRT text-mode \n→\r\n rewriting on fd 1 would corrupt framing.
+    platform.initStandardStreams();
+
     log("kaappi-lsp v" ++ version ++ " starting\n");
 
     documents = std.StringHashMap([]const u8).init(allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -133,6 +133,7 @@ fn readAllStdin(allocator: std.mem.Allocator) ![]u8 {
 const DESIRED_STACK: usize = 64 * 1024 * 1024; // 64 MB
 
 pub fn main(init: std.process.Init.Minimal) !void {
+    platform.initStandardStreams();
     if (comptime !is_wasm) {
         // The compiler's recursive descent needs more than the default 8 MB
         // stack for deeply nested Scheme forms (e.g. cond chains that desugar

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -52,6 +52,7 @@ pub const win = if (is_windows) struct {
     pub extern "c" fn _read(fd: c_int, buf: [*]u8, count: c_uint) c_int;
     pub extern "c" fn _close(fd: c_int) c_int;
     pub extern "c" fn _isatty(fd: c_int) c_int;
+    pub extern "c" fn _setmode(fd: c_int, mode: c_int) c_int;
     pub extern "c" fn _wopen(path: [*:0]const u16, oflag: c_int, ...) c_int;
     pub extern "c" fn _pipe(fds: *[2]c_int, size: c_uint, mode: c_int) c_int;
     pub extern "c" fn _dup(fd: c_int) c_int;
@@ -1067,11 +1068,26 @@ pub fn realTime() RealTime {
 // console / terminal
 // ---------------------------------------------------------------------------
 
-/// One-time console setup. Windows: switch the console to UTF-8 in both
-/// directions and enable VT (ANSI escape) processing so colored
-/// diagnostics and the REPL prompt render. No-op elsewhere.
-pub fn initConsole() void {
+/// One-time standard-stream setup, called at the top of every binary's
+/// main. Windows only (no-op elsewhere):
+///
+/// * Put the CRT's preopened fds in binary mode. They default to text
+///   mode, which rewrites `\n` to `\r\n` on write and strips `\r` /
+///   treats ^Z as EOF on read — translations R7RS ports must never see
+///   (files already open O_BINARY for the same reason, kaappi#1612).
+///   The interactive console keeps rendering bare `\n` correctly (the
+///   console's newline auto-return is independent of the CRT fd mode).
+///   stdin is flipped only when it is NOT the interactive console: the
+///   plain REPL's line reader relies on console text-mode input
+///   (`\r\n` → `\n`, ^Z+Enter = EOF), while piped/redirected stdin gets
+///   the byte-faithful POSIX behavior tests observe.
+/// * Switch the console to UTF-8 in both directions and enable VT (ANSI
+///   escape) processing so colored diagnostics and the REPL prompt render.
+pub fn initStandardStreams() void {
     if (comptime !is_windows) return;
+    _ = win._setmode(1, win.O_BINARY);
+    _ = win._setmode(2, win.O_BINARY);
+    if (!isatty(0)) _ = win._setmode(0, win.O_BINARY);
     _ = win.SetConsoleOutputCP(65001);
     _ = win.SetConsoleCP(65001);
     inline for (.{ win.STD_OUTPUT_HANDLE, win.STD_ERROR_HANDLE }) |which| {

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -861,7 +861,11 @@ fn discoverDir(allocator: std.mem.Allocator, dir_path: []const u8, out: *std.Arr
     while (dir.next()) |name| {
         if (name.len == 0 or name[0] == '.') continue; // skip . .. and dotfiles
 
-        const full = try std.fs.path.join(allocator, &.{ dir_path, name });
+        // '/' join, not std.fs.path.join: every internal path in the runtime
+        // (and the git-diff paths the affected-test graph compares against)
+        // uses '/', which Win32 accepts everywhere — a '\' here would make
+        // discovered paths miss the graph on Windows (kaappi#1612).
+        const full = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir_path, name });
         var keep = false;
         defer if (!keep) allocator.free(full);
 

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -814,6 +814,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     };
     const allocator = if (@import("builtin").mode == .Debug) da.allocator() else std.heap.c_allocator;
 
+    platform.initStandardStreams();
     initColor();
 
     var args = platform.argsIterate(init.args);

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -65,6 +65,30 @@ KAAPPI_TEST_TIMEOUT=120 bash tests/scheme/run-all.sh
 KAAPPI_TEST_SKIP="callcc-bench.scm" bash tests/scheme/run-all.sh
 ```
 
+## Shell test scripts (`*.sh`)
+
+Suite directories may also hold bash drivers; `run-all.sh` runs them via
+`run_shell_suite` (and the `windows-arm-test` CI job runs them under Git
+Bash on Windows — see `docs/dev/windows.md`). Conventions:
+
+- Accept the binary as `${KAAPPI:-zig-out/bin/kaappi}` or `${1:-...}` —
+  runners pass both.
+- Exit 0 = pass, anything else = fail, **exit 77 = skip** (the automake
+  convention). To skip on Windows, source the shared helper and gate:
+
+  ```bash
+  . "$(dirname "$0")/../shell-common.sh"
+  skip_on_windows "why the premise cannot hold on Windows"
+  ```
+
+  This is the shell analogue of the `cond-expand (windows ...)` gate
+  above. `shell-common.sh` also provides `is_windows`, `native_path`
+  (the C:/-style path spelling kaappi itself prints, for output
+  assertions), and `rt_lib_name` (`libkaappi_rt.a` / `kaappi_rt.lib`).
+- Don't bake POSIX-only spellings into assertions: kaappi prints native
+  paths, the runtime archive name is per-platform, and a Windows abort
+  exits 3 rather than dying by signal (see `errors/crash-handler.sh`).
+
 ## Quirks
 
 - `run-all.sh` parses R7RS suite output with awk — don't change its output format.

--- a/tests/scheme/cache/cache-transparency-1516.sh
+++ b/tests/scheme/cache/cache-transparency-1516.sh
@@ -10,6 +10,8 @@
 
 set -euo pipefail
 
+. "$(dirname "$0")/../shell-common.sh"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 PASS=0
 FAIL=0
@@ -57,10 +59,11 @@ check "status on empty cache reports 0 entries" "0 entries" "$out"
 run1="$("$KAAPPI" "$PROG")"
 check "program runs (MISS)" "81" "$run1"
 
-# 3. status now lists one current entry naming the source.
+# 3. status now lists one current entry naming the source. The recorded
+# path is the native spelling (on Windows C:/..., not the shell's /tmp/...).
 out="$("$KAAPPI" cache status)"
 check "status lists 1 entry" "1 entry" "$out"
-check "status names the source path" "$PROG" "$out"
+check "status names the source path" "$(native_path "$PROG")" "$out"
 check "status marks the entry current" "current" "$out"
 
 # 4. Re-run (HIT) — identical result, no crash.

--- a/tests/scheme/compile/compile-import-error-703.sh
+++ b/tests/scheme/compile/compile-import-error-703.sh
@@ -10,6 +10,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 
 DIR=$(mktemp -d)

--- a/tests/scheme/compile/compile-preamble-699.sh
+++ b/tests/scheme/compile/compile-preamble-699.sh
@@ -14,6 +14,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 
 COMPILE_DIR=$(mktemp -d)

--- a/tests/scheme/compile/compile-preamble-gc-700.sh
+++ b/tests/scheme/compile/compile-preamble-gc-700.sh
@@ -8,6 +8,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 
 DIR=$(mktemp -d)

--- a/tests/scheme/compile/define-library-many-exports-862.sh
+++ b/tests/scheme/compile/define-library-many-exports-862.sh
@@ -3,6 +3,13 @@
 # Creates a library with 200 exports, verifies all are importable.
 
 set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
 KAAPPI="${1:-zig-out/bin/kaappi}"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
+++ b/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
@@ -16,6 +16,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
+++ b/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
@@ -15,6 +15,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"

--- a/tests/scheme/compile/native-gc-roots-1034.sh
+++ b/tests/scheme/compile/native-gc-roots-1034.sh
@@ -13,6 +13,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/compile/native-let-partial-emit-dup-1586.sh
+++ b/tests/scheme/compile/native-let-partial-emit-dup-1586.sh
@@ -29,6 +29,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/compile/native-let-tail-root-leak-1585.sh
+++ b/tests/scheme/compile/native-let-tail-root-leak-1585.sh
@@ -24,6 +24,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/compile/native-nested-closure-1410.sh
+++ b/tests/scheme/compile/native-nested-closure-1410.sh
@@ -17,6 +17,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/compile/native-param-shadow-fold-790.sh
+++ b/tests/scheme/compile/native-param-shadow-fold-790.sh
@@ -11,6 +11,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/compile/native-rebind-stale-call-822.sh
+++ b/tests/scheme/compile/native-rebind-stale-call-822.sh
@@ -14,6 +14,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/compile/native-set-capture-divergence-1422.sh
+++ b/tests/scheme/compile/native-set-capture-divergence-1422.sh
@@ -16,6 +16,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/compile/set-define-lexical-scope-819.sh
+++ b/tests/scheme/compile/set-define-lexical-scope-819.sh
@@ -12,6 +12,13 @@
 
 set -euo pipefail
 
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
 KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/scheme/doctor/doctor.sh
+++ b/tests/scheme/doctor/doctor.sh
@@ -7,9 +7,12 @@
 
 set -uo pipefail
 
+. "$(dirname "$0")/../shell-common.sh"
+
 KAAPPI="${1:-${KAAPPI:-zig-out/bin/kaappi}}"
 PASS=0
 FAIL=0
+RTLIB="$(rt_lib_name)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -67,12 +70,13 @@ assert_contains "bogus dir reports FAIL"       "FAIL" env KAAPPI_LIB_DIR="$BOGUS
 assert_contains "bogus json is ok:false"       '"ok":false'      env KAAPPI_LIB_DIR="$BOGUS" "$KAAPPI" doctor --json
 assert_contains "bogus json status is fail"    '"status":"fail"' env KAAPPI_LIB_DIR="$BOGUS" "$KAAPPI" doctor --json
 
-# A directory that exists but has no libkaappi_rt.a is equally a FAIL: the
-# explicit override resolves to a place with no runtime library.
+# A directory that exists but has no runtime archive is equally a FAIL: the
+# explicit override resolves to a place with no runtime library. The archive's
+# name is the platform spelling (libkaappi_rt.a / kaappi_rt.lib).
 EMPTY="$TMP/empty-lib-dir"
 mkdir -p "$EMPTY"
 assert_exit    "empty KAAPPI_LIB_DIR exits 1"  1 env KAAPPI_LIB_DIR="$EMPTY" "$KAAPPI" doctor
-assert_contains "empty dir suggests a fix"     "libkaappi_rt.a" env KAAPPI_LIB_DIR="$EMPTY" "$KAAPPI" doctor
+assert_contains "empty dir suggests a fix"     "$RTLIB" env KAAPPI_LIB_DIR="$EMPTY" "$KAAPPI" doctor
 
 # Usage handling.
 assert_exit    "--help exits 0"                0 "$KAAPPI" doctor --help

--- a/tests/scheme/errors/crash-handler.sh
+++ b/tests/scheme/errors/crash-handler.sh
@@ -14,6 +14,8 @@
 
 set -uo pipefail   # NOT -e: --panic-test aborts (nonzero) by design.
 
+. "$(dirname "$0")/../shell-common.sh"
+
 KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
 
 pass=0
@@ -32,9 +34,14 @@ ok() { [[ "$1" -eq 0 ]] && echo 0 || echo 1; }
 out="$("$KAAPPI" --panic-test 2>&1)"
 status=$?
 
-# abort() dies by signal → shell status is 128+signo (134 for SIGABRT). Assert
-# "died by signal" rather than a specific number so it stays portable.
-check "aborts (died by signal, not a clean exit)" "$(ok "$([[ $status -ge 128 ]] && echo 0 || echo 1)")"
+# abort() dies by signal → shell status is 128+signo (134 for SIGABRT) on
+# POSIX; the Windows CRT maps abort() to exit code 3. Assert "the abort path,
+# not a clean exit" per platform rather than a specific signal number.
+if is_windows; then
+    check "aborts (Windows CRT abort exit code 3)" "$(ok "$([[ $status -eq 3 ]] && echo 0 || echo 1)")"
+else
+    check "aborts (died by signal, not a clean exit)" "$(ok "$([[ $status -ge 128 ]] && echo 0 || echo 1)")"
+fi
 
 grep -qF "kaappi internal error — this is a bug in kaappi, not in your program." <<<"$out"
 check "banner identity line" $?

--- a/tests/scheme/errors/exit-code.sh
+++ b/tests/scheme/errors/exit-code.sh
@@ -141,10 +141,12 @@ else
     fi
 fi
 
-# Missing C compiler / failing linker: a dummy libkaappi_rt.a satisfies the
+# Missing C compiler / failing linker: a dummy runtime archive satisfies the
 # library lookup, and PATH controls what compiler the link step can find.
+# Both platform spellings are written so the lookup succeeds everywhere
+# (libkaappi_rt.a on POSIX, kaappi_rt.lib on Windows — platform.rt_lib_name).
 mkdir -p "$TMPDIR_TESTS/fakelib" "$TMPDIR_TESTS/emptypath" "$TMPDIR_TESTS/fakecc"
-touch "$TMPDIR_TESTS/fakelib/libkaappi_rt.a"
+touch "$TMPDIR_TESTS/fakelib/libkaappi_rt.a" "$TMPDIR_TESTS/fakelib/kaappi_rt.lib"
 printf '#!/bin/sh\nexit 1\n' > "$TMPDIR_TESTS/fakecc/cc"
 chmod +x "$TMPDIR_TESTS/fakecc/cc"
 assert_exit_code "compile without C compiler exits 1" 1 \

--- a/tests/scheme/errors/explain.sh
+++ b/tests/scheme/errors/explain.sh
@@ -39,11 +39,11 @@ def explain(*args):
     return subprocess.run([KAAPPI, "explain", *args], capture_output=True, text=True)
 
 def emitted_code(src, timeout_ms=None):
-    """Run src through the interpreter, return the first KP code it emits."""
+    """Run src through the interpreter (program fed on stdin — portable,
+    unlike a /dev/stdin pseudo-file argument), return the first KP code."""
     args = [KAAPPI, "--diagnostics=json"]
     if timeout_ms is not None:
         args += ["--timeout", str(timeout_ms)]
-    args.append("/dev/stdin")
     p = subprocess.run(args, input=src, capture_output=True, text=True, timeout=30)
     m = CODE_RE.search(p.stderr) or CODE_RE.search(p.stdout)
     return m.group(1) if m else None

--- a/tests/scheme/errors/features.sh
+++ b/tests/scheme/errors/features.sh
@@ -77,7 +77,9 @@ for k in ("initial_frame_capacity", "initial_register_capacity", "gc_initial_thr
 
 prog = ('(import (scheme base)) '
         '(for-each (lambda (f) (display f) (newline)) (features))')
-lang = subprocess.run([KAAPPI, "/dev/stdin"], input=prog, capture_output=True, text=True)
+# Program fed on stdin with no file argument (the runStdin path): works on
+# every platform, unlike a /dev/stdin pseudo-file argument.
+lang = subprocess.run([KAAPPI], input=prog, capture_output=True, text=True)
 lang_features = [ln for ln in lang.stdout.splitlines() if ln]
 # Same members (cond-expand resolves against this exact set) AND same order
 # (both iterate the one `types.platform_features` array).
@@ -88,7 +90,7 @@ check(feats == lang_features,
 # Every advertised feature is genuinely recognized by cond-expand.
 for f in feats:
     src = f'(import (scheme base) (scheme write)) (cond-expand ({f} (display "y")) (else (display "n")))'
-    r = subprocess.run([KAAPPI, "/dev/stdin"], input=src, capture_output=True, text=True)
+    r = subprocess.run([KAAPPI], input=src, capture_output=True, text=True)
     check(r.stdout.strip() == "y", f"cond-expand recognizes {f!r}", r.stdout)
 
 # --- Error handling -------------------------------------------------------

--- a/tests/scheme/robustness/robustness.sh
+++ b/tests/scheme/robustness/robustness.sh
@@ -5,6 +5,8 @@
 
 set -euo pipefail
 
+. "$(dirname "$0")/../shell-common.sh"
+
 KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
 PASS=0
 FAIL=0
@@ -113,11 +115,14 @@ assert_no_crash "splicing" "(display \`(a ,@(list 1 2 3) b))"
 # --- Corrupted .sbc file ---
 echo
 echo "-- Corrupted .sbc --"
+# The path is embedded in Scheme source, so it must be the spelling the
+# binary can open (on Windows the shell's /tmp/... is not).
 TMPFILE=$(mktemp /tmp/kaappi-corrupt-XXXXXX.sbc)
+TMPFILE_NATIVE=$(native_path "$TMPFILE")
 echo "NOT_A_VALID_SBC_FILE" > "$TMPFILE"
-assert_error "corrupted .sbc (text)" "(load \"$TMPFILE\")"
+assert_error "corrupted .sbc (text)" "(load \"$TMPFILE_NATIVE\")"
 printf '\x00\x01\x02\x03\x80\x81\xff\xfe\x00\x00\x00\x00\x00\x00\x00\x00' > "$TMPFILE"
-assert_error "corrupted .sbc (binary)" "(load \"$TMPFILE\")"
+assert_error "corrupted .sbc (binary)" "(load \"$TMPFILE_NATIVE\")"
 rm -f "$TMPFILE"
 
 echo

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -140,6 +140,11 @@ run_shell_suite() {
         if [[ $status -eq 0 ]]; then
             echo "  PASS  $test_script"
             PASS=$((PASS + 1))
+        elif [[ $status -eq 77 ]]; then
+            # Exit 77 = SKIP (shell-common.sh skip_on_windows): the script's
+            # premise cannot hold on this platform.
+            echo "  SKIP  $test_script"
+            SKIPPED=$((SKIPPED + 1))
         else
             echo "  FAIL  $test_script"
             cat "$TMPOUT"

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -1,0 +1,42 @@
+# Shared helpers for the shell-based test suites. Sourced, never executed:
+#   . "$(dirname "$0")/../shell-common.sh"
+#
+# On Windows the suites run under Git Bash (MSYS) — see docs/dev/windows.md.
+# A script whose premise cannot hold there calls skip_on_windows with a
+# reason and exits 77, the conventional SKIP status (automake's) that
+# run-all.sh and the windows-arm-test CI driver both recognize. This is the
+# shell analogue of the `cond-expand (windows ...)` gate the .scm tests use.
+
+# is_windows: true under Git Bash / MSYS / Cygwin on Windows.
+is_windows() {
+    case "$(uname -s)" in
+        MINGW* | MSYS* | CYGWIN*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# skip_on_windows <reason>: exit 77 (SKIP) on Windows, no-op elsewhere.
+skip_on_windows() {
+    if is_windows; then
+        echo "SKIP: $1"
+        exit 77
+    fi
+}
+
+# native_path <abs-path>: the spelling of an absolute path as the kaappi
+# binary itself sees and prints it. Git Bash hands out MSYS paths
+# (/tmp/...), while kaappi records and prints native C:/... paths; cygpath
+# -m (mixed: drive letter + forward slashes) converts. Identity elsewhere.
+native_path() {
+    if is_windows && command -v cygpath > /dev/null 2>&1; then
+        cygpath -m "$1"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
+# rt_lib_name: the runtime archive's platform file name — must match
+# platform.rt_lib_name in src/platform.zig.
+rt_lib_name() {
+    if is_windows; then echo "kaappi_rt.lib"; else echo "libkaappi_rt.a"; fi
+}

--- a/tests/scheme/smoke/profile-json-escaping.sh
+++ b/tests/scheme/smoke/profile-json-escaping.sh
@@ -2,6 +2,12 @@
 # Regression test for issue #292: profile JSON output must escape string values
 set -e
 
+. "$(dirname "$0")/../shell-common.sh"
+
+# The test plants JSON-special characters ('"', '\') in a real directory
+# name; Windows forbids both in filenames, so the premise cannot hold there.
+skip_on_windows "profile-json-escaping: Windows filenames cannot contain JSON-special characters"
+
 KAAPPI="${KAAPPI:-./zig-out/bin/kaappi}"
 TMPDIR_TEST="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_TEST"' EXIT

--- a/tests/scheme/test-runner/changed.sh
+++ b/tests/scheme/test-runner/changed.sh
@@ -99,6 +99,10 @@ EOF
 git -C "$FIX" init -q
 git -C "$FIX" config user.email test@example.com
 git -C "$FIX" config user.name test
+# Hermetic line endings: a host git with core.autocrlf=true (the Git for
+# Windows default) would rewrite the fixtures on checkout and leave every
+# file permanently diff-dirty, breaking the "nothing changed" steps.
+git -C "$FIX" config core.autocrlf false
 git -C "$FIX" add -A
 git -C "$FIX" commit -qm init
 


### PR DESCRIPTION
Closes #1612.

The bash-driven suites now run on Windows under Git Bash — verified end-to-end on the port's reference Windows 11 ARM64 VM (**34 pass, 0 fail, 15 skip** across `smoke/*.sh`, `errors`, `compile`, `test-runner`, `pipeline`, `doctor`, `fmt`, `cache`, `timings`, `sandbox`, `robustness`) and wired into the `windows-arm-test` CI job so every PR runs them.

## Runtime bugs the suites caught (both fixed here)

Exactly the surface the issue predicted — and it found two real bugs on the first sweep:

1. **Standard streams were in CRT text mode** — every `(newline)` reached pipes as `\r\n`, so piped output differed byte-for-byte from POSIX (caught by `repl-multiple-values.sh`; the earlier `.scm`/R7RS runs never byte-compare stdout, so it went unseen). Files already open `O_BINARY` for exactly this reason, but the preopened fds 0/1/2 were missed — and `platform.initConsole` (console UTF-8 + VT mode) turned out to be dead code, never called since the port landed. The new `platform.initStandardStreams`, called first thing in all three binaries' mains, flips stdout/stderr to binary unconditionally, flips stdin only when it is not the interactive console (the plain REPL's line reader relies on console text mode: `\r\n`→`\n`, ^Z+Enter = EOF), and performs the console UTF-8/VT setup for real. In kaappi-lsp this also protects `Content-Length` framing from `\n`→`\r\n` rewriting.
2. **`kaappi test --changed`/`--list-affected` was broken on Windows**: suite discovery used `std.fs.path.join` (the one place in the runtime), so discovered paths carried `\` separators and never matched the `/`-spelled import-graph and git-diff paths (caught by `test-runner/changed.sh`).

Both fixes' regression tests are the shell suites themselves, now running in CI on Windows: `repl-multiple-values.sh` and `test-runner/changed.sh` each fail without the corresponding fix (demonstrated during triage on the VM).

## Skip mechanism (the shell analogue of the `cond-expand (windows ...)` gate)

New `tests/scheme/shell-common.sh`, sourced by drivers that need it:

- `skip_on_windows <reason>` — prints the reason and exits **77** (automake's SKIP status). `run-all.sh` and the CI loop report these as SKIP instead of PASS/FAIL.
- `native_path` — the `C:/...` spelling kaappi itself prints (via `cygpath -m`), for output assertions against MSYS `/tmp/...` paths.
- `rt_lib_name` — `kaappi_rt.lib` vs `libkaappi_rt.a` (matches `platform.rt_lib_name`).
- `is_windows` — for per-assertion gates.

Gated scripts and why:

- all 14 `tests/scheme/compile/*.sh`: each rebuilds the runtime archive or interpreter with a native `zig` on the box — no working native toolchain on Windows ARM64 until the 0.17.0 bump (#1613), and the CI execution job deliberately installs none. The gates lift then.
- `smoke/profile-json-escaping.sh`: it plants `"` and `\` in a real directory name; Windows filenames cannot contain either, so the premise is untestable there.

Notably, none of the REPL scripts turned out to be pty-based — they all drive kaappi through pipes, so they run as-is (no skips needed).

## Per-script portability fixes (behavior identical on POSIX)

- `errors/features.sh`, `errors/explain.sh`: fed programs via a literal `/dev/stdin` file argument, which doesn't exist on Windows — now feed actual stdin (the same `runStdin` path, on every platform).
- `errors/crash-handler.sh`: "died by signal (status ≥ 128)" holds only on POSIX; the Windows CRT maps `abort()` to exit code 3. The assertion is now per-platform; the other 12 checks (banner, breadcrumb, trace) pass on Windows unchanged.
- `errors/exit-code.sh`: the fake runtime-archive fixture now writes both platform spellings so the missing-compiler/failing-linker tests reach the compiler stage everywhere.
- `test-runner/changed.sh`: the fixture repo pins `core.autocrlf false` — a host git defaulting to `true` (the Git for Windows default) rewrites the fixtures on checkout and leaves every file permanently diff-dirty, breaking the "nothing changed" steps.
- `cache/cache-transparency-1516.sh`, `robustness/robustness.sh`: path assertions/embedded `(load ...)` paths use `native_path`.
- `doctor/doctor.sh`: expects the platform runtime-archive name.

## CI

`windows-arm-test` gains one "Shell suites" step: the same loop shape as the `.scm` step, honoring exit 77 as SKIP, with an isolated `KAAPPI_HOME` (mirroring `run-all.sh`) and a conditional `python3` shim (several drivers validate JSON with python3; the arm image ships Python as `python`).

## Docs

`docs/dev/windows.md` (testing section, stream semantics, known-gaps list — the #1612 entry is replaced by the narrower #1613-gated `compile/` entry) and `tests/scheme/CLAUDE.md` (shell-script conventions: exit 77, `shell-common.sh`, platform-spelling pitfalls).

## Verification

- Windows 11 ARM64 VM (build 26100), Git Bash: full sweep of all 11 shell-suite dirs — 34 pass, 0 fail, 15 skip.
- POSIX (macOS ARM): `zig build test` green; full `bash tests/scheme/run-all.sh` green; each edited driver also run individually.
- `zig build -Dtarget=aarch64-windows`, `zig build test -Dtarget=aarch64-windows` (compile gate), and `zig build wasm` all build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
