### PR TITLE
Make FreeBSD installable: install.sh + release skill

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -141,7 +141,7 @@ Note: `src/main.zig` and `src/thottam.zig` read the version from
 **STOP.** Ask the user for explicit confirmation before pushing. Explain:
 
 - Pushing the tag triggers the release workflow in CI
-- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, aarch64-windows (kaappi-aarch64-windows.exe, cross-compiled), plus kaappi.wasm (wasm32-wasi)
+- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, aarch64-windows (kaappi-aarch64-windows.exe, cross-compiled), x86_64-freebsd, aarch64-freebsd, plus kaappi.wasm (wasm32-wasi)
 - macOS binaries are Developer ID signed and Apple notarized
 - It generates SHA256SUMS and creates a GitHub Release
 - This is irreversible
@@ -201,6 +201,22 @@ ssh win11 "C:\tmp\kaappi-vX.Y.Z.exe features"
 
 Verify: version matches, script prints `3`, and `features` shows `windows`
 (not `posix`) with target `aarch64-windows-gnu`. See `docs/dev/windows.md`.
+
+The FreeBSD artifacts are likewise checksum-covered but have **no CI
+acceptance leg** — GitHub hosts no FreeBSD runners. Smoke-test the
+aarch64 binary on the `ssh freebsd` box (the port's reference machine):
+
+```bash
+TAG=vX.Y.Z
+ssh freebsd "fetch -qo /tmp/kaappi-$TAG https://github.com/kaappi/kaappi/releases/download/$TAG/kaappi-aarch64-freebsd && chmod +x /tmp/kaappi-$TAG"
+ssh freebsd "/tmp/kaappi-$TAG --version"
+ssh freebsd "echo '(display (+ 1 2)) (newline)' | /tmp/kaappi-$TAG"
+ssh freebsd "/tmp/kaappi-$TAG features"
+```
+
+Verify: version matches, script prints `3`, and `features` shows `posix`
++ `kaappi-threads` with target `aarch64-freebsd-none`. See
+`docs/dev/freebsd.md`.
 
 ## Step 11: Update docs site (playground WASM + version)
 

--- a/install.sh
+++ b/install.sh
@@ -15,18 +15,20 @@ detect_platform() {
     arch=$(uname -m)
 
     case "$os" in
-        Darwin) os="macos" ;;
-        Linux)  os="linux" ;;
+        Darwin)  os="macos" ;;
+        Linux)   os="linux" ;;
+        FreeBSD) os="freebsd" ;;
         *)
             echo "error: unsupported OS: $os"
-            echo "Kaappi supports macOS and Linux. See https://github.com/$REPO"
+            echo "Kaappi supports macOS, Linux, and FreeBSD. See https://github.com/$REPO"
             exit 1
             ;;
     esac
 
     case "$arch" in
         arm64|aarch64) arch="aarch64" ;;
-        x86_64)        arch="x86_64" ;;
+        # FreeBSD reports x86_64 as amd64 (uname -m).
+        x86_64|amd64)  arch="x86_64" ;;
         riscv64)       arch="riscv64" ;;
         *)
             echo "error: unsupported architecture: $arch"


### PR DESCRIPTION
## Summary

Follow-up to the FreeBSD port ([#1631](https://github.com/kaappi/kaappi/pull/1631)). That PR shipped `release.yml` artifacts and CI, but the user-facing **install path** was still macOS/Linux/Windows-only. This closes the core-repo half of that gap.

- **`install.sh`** rejected `uname -s = FreeBSD` and never mapped FreeBSD's `amd64` (what x86_64 reports via `uname -m`) to the `x86_64` artifact name — so `curl | bash` failed on FreeBSD. Adds the `FreeBSD) os="freebsd"` case and the `amd64|x86_64 → x86_64` arch mapping. Verified `detect_platform` emits `aarch64-freebsd` on the reference box.
- **`/github-release` skill** — adds both FreeBSD targets to the Step-8 build list and a FreeBSD smoke-test leg in Step 10, on the `ssh freebsd` box (no hosted FreeBSD runner, so the artifacts are checksum-covered but not CI-acceptance-tested — same posture the skill already documents for Windows).

## Not in this PR
The end-user **download page** and the **served `install.sh`** live in the `kaappi.github.io` repo — companion PR: kaappi/kaappi.github.io#18. Release-workflow artifacts themselves were already complete in #1631.

## Verification
- `bash -n install.sh` clean; `detect_platform` → `aarch64-freebsd` on real FreeBSD 15.1 hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)