### PR TITLE
Port Kaappi to OpenBSD (x86_64, aarch64)

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -141,7 +141,7 @@ Note: `src/main.zig` and `src/thottam.zig` read the version from
 **STOP.** Ask the user for explicit confirmation before pushing. Explain:
 
 - Pushing the tag triggers the release workflow in CI
-- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, aarch64-windows (kaappi-aarch64-windows.exe, cross-compiled), x86_64-freebsd, aarch64-freebsd, plus kaappi.wasm (wasm32-wasi)
+- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, aarch64-windows (kaappi-aarch64-windows.exe, cross-compiled), x86_64-freebsd, aarch64-freebsd, x86_64-openbsd, aarch64-openbsd, plus kaappi.wasm (wasm32-wasi)
 - macOS binaries are Developer ID signed and Apple notarized
 - It generates SHA256SUMS and creates a GitHub Release
 - This is irreversible
@@ -217,6 +217,24 @@ ssh freebsd "/tmp/kaappi-$TAG features"
 Verify: version matches, script prints `3`, and `features` shows `posix`
 + `kaappi-threads` with target `aarch64-freebsd-none`. See
 `docs/dev/freebsd.md`.
+
+The OpenBSD artifacts also have **no CI acceptance leg** (GitHub hosts no
+OpenBSD runners; the `openbsd-test` CI job only runs on PRs, not the tag).
+Smoke-test the aarch64 binary on the `ssh openbsd` box (OpenBSD's base `ftp`
+does HTTPS):
+
+```bash
+TAG=vX.Y.Z
+ssh openbsd "ftp -o /tmp/kaappi-$TAG https://github.com/kaappi/kaappi/releases/download/$TAG/kaappi-aarch64-openbsd && chmod +x /tmp/kaappi-$TAG"
+ssh openbsd "/tmp/kaappi-$TAG --version"
+ssh openbsd "echo '(display (+ 1 2)) (newline)' | /tmp/kaappi-$TAG /dev/stdin"
+ssh openbsd "/tmp/kaappi-$TAG features"
+```
+
+Verify: it runs at all (a binary missing the `PT_OPENBSD_NOBTCFI` marker
+would `SIGILL` immediately under BTCFI), version matches, the script prints
+`3`, and `features` shows `posix` + `kaappi-threads` with target
+`aarch64-openbsd-none`. See `docs/dev/openbsd.md`.
 
 ## Step 11: Update docs site (playground WASM + version)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,9 @@ jobs:
           zig build test -Dtarget=x86_64-openbsd
           cp "$(ls -t .zig-cache/o/*/unit-tests | head -1)" ./unit-tests-openbsd
           cp "$(ls -t .zig-cache/o/*/thottam-tests | head -1)" ./thottam-tests-openbsd
-          zig run tools/openbsd_nobtcfi.zig -- ./unit-tests-openbsd ./thottam-tests-openbsd
+          # -lc: the tool uses libc I/O (std.c.pread/pwrite), which `zig run`
+          # links implicitly on macOS but not on this Linux host.
+          zig run tools/openbsd_nobtcfi.zig -lc -- ./unit-tests-openbsd ./thottam-tests-openbsd
 
       - name: Trim workspace for VM sync
         run: rm -rf .zig-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,73 @@ jobs:
             cc -shared -fPIC tests/scheme/ffi/fixtures/u64test.c -o tests/scheme/ffi/fixtures/libu64test.so
             bash tests/scheme/run-all.sh
 
+  # OpenBSD: cross-compile the x86_64 binaries + test executables on Linux,
+  # mark them PT_OPENBSD_NOBTCFI (Zig 0.16 emits no BTI landing pads, which
+  # OpenBSD's BTCFI enforcement requires — docs/dev/openbsd.md), then execute
+  # inside a KVM OpenBSD VM (GitHub hosts no OpenBSD runners). The VM tracks
+  # 7.9 to match the aarch64 reference machine; OpenBSD breaks ABI between
+  # releases, so the Zig-targeted release and the VM release must agree.
+  openbsd-test:
+    needs: format
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: openbsd
+
+      - name: Build (cross-compile for x86_64-openbsd)
+        # zig build marks the three installed binaries PT_OPENBSD_NOBTCFI via
+        # the host patcher (build.zig installExe). The runtime archive lets the
+        # VM's compile-suite scripts link `kaappi compile` output with base cc.
+        run: |
+          zig build -Dtarget=x86_64-openbsd
+          zig build lib -Dtarget=x86_64-openbsd
+
+      - name: Compile and mark unit tests (x86_64-openbsd)
+        # skip_foreign_checks makes this compile-and-skip on the Linux host;
+        # the binaries execute inside the VM below. ls -t picks the binaries
+        # this run compiled. Test executables are not installed artifacts, so
+        # the NOBTCFI marker is applied explicitly with the same host tool.
+        run: |
+          zig build test -Dtarget=x86_64-openbsd
+          cp "$(ls -t .zig-cache/o/*/unit-tests | head -1)" ./unit-tests-openbsd
+          cp "$(ls -t .zig-cache/o/*/thottam-tests | head -1)" ./thottam-tests-openbsd
+          zig run tools/openbsd_nobtcfi.zig -- ./unit-tests-openbsd ./thottam-tests-openbsd
+
+      - name: Trim workspace for VM sync
+        run: rm -rf .zig-cache
+
+      - name: Run test suites (OpenBSD VM)
+        uses: vmactions/openbsd-vm@c941015845c0f0c429676840963dc63b226d4f69 # v1
+        with:
+          release: "7.9"
+          usesh: true
+          sync: rsync
+          copyback: false
+          # bash: run-all.sh; python3 + git: the errors/ and test-runner/
+          # suites validate JSON output and build throwaway git repos.
+          prepare: pkg_add -I bash python%3 git
+          run: |
+            set -e
+            # OpenBSD's default login class caps the main-thread stack at 4 MiB
+            # and the data segment at 1.5 GiB. The test runner recurses on the
+            # main thread, and std.testing's DebugAllocator never reuses freed
+            # address space, so raise both to the hard limits before running the
+            # unit-test binary (docs/dev/openbsd.md).
+            ulimit -s $(ulimit -Hs)
+            ulimit -d $(ulimit -Hd)
+            ./unit-tests-openbsd
+            ./thottam-tests-openbsd
+            cc -shared -fPIC tests/scheme/ffi/fixtures/u64test.c -o tests/scheme/ffi/fixtures/libu64test.so
+            bash tests/scheme/run-all.sh
+
   # Cross-compile the Windows aarch64 binaries and the unit-test binary
   # from Linux. Compile-only by design: this guards the cross-compilation
   # path release.yml ships with, independent of the Windows runner image.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,26 @@ jobs:
             lib_src: libkaappi_rt.a
             lib_ext: .a
             strip: true
+          # Cross-compiled from Linux. `zig build` marks each binary
+          # PT_OPENBSD_NOBTCFI via the host patcher (build.zig) so it survives
+          # OpenBSD's BTCFI enforcement; the marker is a program header that
+          # stripping preserves. Execution is verified by CI's openbsd-test VM
+          # job (x86_64) and on the aarch64 reference machine
+          # (docs/dev/openbsd.md).
+          - os: ubuntu-latest
+            target: x86_64-openbsd
+            artifact: kaappi-x86_64-openbsd
+            exe_ext: ''
+            lib_src: libkaappi_rt.a
+            lib_ext: .a
+            strip: true
+          - os: ubuntu-latest
+            target: aarch64-openbsd
+            artifact: kaappi-aarch64-openbsd
+            exe_ext: ''
+            lib_src: libkaappi_rt.a
+            lib_ext: .a
+            strip: true
           # Cross-compiled via Zig's bundled mingw-w64; execution is
           # verified on real Windows 11 ARM64 hardware (docs/dev/windows.md)
           # since GitHub has no ARM64 Windows runners. The gnu-ABI static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 #### OpenBSD platform support
+
 - **OpenBSD target (x86_64, aarch64)** — `zig build -Dtarget=<arch>-openbsd` cross-compiles all three binaries (releases ship both arches). A full-POSIX kqueue port — fiber I/O (the macOS/FreeBSD reactor backend, shared), SRFI-18 OS threads, complete SRFI-170, FFI via `dlopen`, the full linenoise REPL, and thottam including `build:` manifests — with two automatic accommodations for OpenBSD's security hardening. **BTCFI:** OpenBSD enforces Branch Target CFI (an indirect branch must hit a `bti` landing pad or the kernel raises `SIGILL`), which Zig 0.16 can't emit, so each Zig-linked binary is marked `PT_OPENBSD_NOBTCFI` post-link (`tools/openbsd_nobtcfi.zig`, wired into `build.zig`) and `kaappi compile` links native output with `-z nobtcfi` — both opting out of enforcement. **Stack limit:** the interpreter raises its own soft stack limit to the hard limit at startup (`platform.raiseStackLimitBestEffort`) to clear OpenBSD's tight 4 MiB default. Self-exe lookup uses `sysctl KERN_PROC_ARGS`/argv[0] resolution (OpenBSD has no `KERN_PROC_PATHNAME`). Verified on real OpenBSD 7.9 aarch64 hardware: full unit suite (1141/1141), thottam, R7RS, and `run-all.sh` batteries, plus the native backend (`kaappi compile`) linking with the base system `cc` — no Zig toolchain on the box. CI runs the suites in a KVM OpenBSD VM. See `docs/dev/openbsd.md`
 
 ## [0.17.0] - 2026-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+#### OpenBSD platform support
+- **OpenBSD target (x86_64, aarch64)** — `zig build -Dtarget=<arch>-openbsd` cross-compiles all three binaries (releases ship both arches). A full-POSIX kqueue port — fiber I/O (the macOS/FreeBSD reactor backend, shared), SRFI-18 OS threads, complete SRFI-170, FFI via `dlopen`, the full linenoise REPL, and thottam including `build:` manifests — with two automatic accommodations for OpenBSD's security hardening. **BTCFI:** OpenBSD enforces Branch Target CFI (an indirect branch must hit a `bti` landing pad or the kernel raises `SIGILL`), which Zig 0.16 can't emit, so each Zig-linked binary is marked `PT_OPENBSD_NOBTCFI` post-link (`tools/openbsd_nobtcfi.zig`, wired into `build.zig`) and `kaappi compile` links native output with `-z nobtcfi` — both opting out of enforcement. **Stack limit:** the interpreter raises its own soft stack limit to the hard limit at startup (`platform.raiseStackLimitBestEffort`) to clear OpenBSD's tight 4 MiB default. Self-exe lookup uses `sysctl KERN_PROC_ARGS`/argv[0] resolution (OpenBSD has no `KERN_PROC_PATHNAME`). Verified on real OpenBSD 7.9 aarch64 hardware: full unit suite (1141/1141), thottam, R7RS, and `run-all.sh` batteries, plus the native backend (`kaappi compile`) linking with the base system `cc` — no Zig toolchain on the box. CI runs the suites in a KVM OpenBSD VM. See `docs/dev/openbsd.md`
+
 ## [0.17.0] - 2026-07-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ This runs `zig fmt --check` on staged `.zig` files before each commit.
 | Linux | riscv64 | yes | yes | CI tested (QEMU) |
 | Windows | aarch64 (ARM64) | yes | yes | `zig build -Dtarget=aarch64-windows`; see `docs/dev/windows.md` |
 | FreeBSD | x86_64, aarch64 | yes | yes | `zig build -Dtarget=<arch>-freebsd`; kqueue reactor; see `docs/dev/freebsd.md` |
+| OpenBSD | x86_64, aarch64 | yes | yes | `zig build -Dtarget=<arch>-openbsd`; kqueue reactor; binaries auto-marked `PT_OPENBSD_NOBTCFI`; see `docs/dev/openbsd.md` |
 | WebAssembly | wasm32-wasi | yes | — | `zig build wasm`, browser/WASI |
 
 **Cross-compilation:** `zig build -Dtarget=x86_64-linux` and
@@ -116,6 +117,11 @@ differences live in `src/platform.zig` (see `docs/dev/windows.md` for the
 port's architecture, degradations, and how to test on a Windows machine).
 `zig build -Dtarget=aarch64-freebsd` (or `x86_64-freebsd`) cross-compiles
 for FreeBSD — a full-POSIX port with no degradations (`docs/dev/freebsd.md`).
+`zig build -Dtarget=aarch64-openbsd` (or `x86_64-openbsd`) cross-compiles
+for OpenBSD — a kqueue port whose binaries are auto-marked
+`PT_OPENBSD_NOBTCFI` (a post-link patch, `tools/openbsd_nobtcfi.zig`, wired
+into `build.zig`) to survive BTCFI enforcement, since Zig 0.16 emits no BTI
+landing pads (`docs/dev/openbsd.md`).
 Porting to a new OS or CPU architecture: `docs/dev/porting.md` (porting
 surfaces, degradation ladder, staged checklists).
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ zig build test                       # run the unit tests
 | Linux | riscv64 | yes | yes | LLVM backend |
 | Windows | aarch64 (ARM64) | yes | yes | LLVM backend (needs a C toolchain) |
 | FreeBSD | x86_64, aarch64 | yes | yes | LLVM backend (base `cc` suffices) |
+| OpenBSD | x86_64, aarch64 | yes | yes | LLVM backend (base `cc` suffices) |
 | WebAssembly | wasm32-wasi | yes | — | interpreter only |
 
 The WASM build (`zig build wasm`) runs in browsers and WASI runtimes — it
@@ -109,6 +110,15 @@ The FreeBSD port (`zig build -Dtarget=x86_64-freebsd` or
 fiber I/O, OS threads, complete SRFI-170, the full linenoise REPL, and
 thottam with `build:` support. `kaappi compile` links native binaries
 with the base system's `cc` — no extra toolchain needed.
+
+The OpenBSD port (`zig build -Dtarget=x86_64-openbsd` or
+`aarch64-openbsd`) is the same full-POSIX kqueue platform — fiber I/O,
+threads, complete SRFI-170, the full REPL, `build:` support, and native
+compilation with base `cc`. Two accommodations for OpenBSD's hardening,
+both automatic: each binary is marked `PT_OPENBSD_NOBTCFI` at build time
+to opt out of BTCFI enforcement (Zig 0.16 emits no BTI landing pads), and
+the interpreter raises its own stack limit at startup to clear OpenBSD's
+tight 4 MiB default. See [`docs/dev/openbsd.md`](docs/dev/openbsd.md).
 
 ## A taste of Kaappi
 

--- a/build.zig
+++ b/build.zig
@@ -86,6 +86,23 @@ pub fn build(b: *std.Build) void {
     // stdin line loop instead (repl.zig).
     const use_linenoise = !is_wasm_target and target.result.os.tag != .windows;
 
+    // OpenBSD enforces BTCFI: an indirect branch must land on a `bti`
+    // instruction, but Zig 0.16 emits no landing pads, so every Zig-linked
+    // binary would SIGILL on its first function-pointer call. This host tool
+    // adds the PT_OPENBSD_NOBTCFI opt-out marker post-link; `installExe`
+    // below runs it on each installed executable for OpenBSD targets, so
+    // `zig build -Dtarget=<arch>-openbsd` produces working binaries directly.
+    // The `kaappi compile` native backend opts out honestly via `-z nobtcfi`
+    // (native_compiler.zig). See docs/dev/openbsd.md.
+    const nobtcfi_tool: ?*std.Build.Step.Compile = if (target.result.os.tag == .openbsd) b.addExecutable(.{
+        .name = "openbsd_nobtcfi",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tools/openbsd_nobtcfi.zig"),
+            .target = b.graph.host,
+            .optimize = .ReleaseSafe,
+        }),
+    }) else null;
+
     // Main module (embedded_bytecode added below based on bundle mode)
     const main_mod = kaappiModule(b, options_mod, .{
         .target = target,
@@ -156,7 +173,7 @@ pub fn build(b: *std.Build) void {
         .root_module = main_mod,
     });
     exe.stack_size = 64 * 1024 * 1024; // 64 MB — u16 register widening increases compiler frame sizes
-    b.installArtifact(exe);
+    installExe(b, exe, nobtcfi_tool);
 
     // Portable library sources (.sld/.scm), installed next to the exe so a
     // from-source build can resolve them via the exe-relative <exe_dir>/../lib
@@ -338,7 +355,7 @@ pub fn build(b: *std.Build) void {
         .root_module = thottam_mod,
     });
     thottam_exe.stack_size = 64 * 1024 * 1024;
-    b.installArtifact(thottam_exe);
+    installExe(b, thottam_exe, nobtcfi_tool);
 
     // Language server (kaappi-lsp)
     const lsp_mod = kaappiModule(b, options_mod, .{
@@ -353,7 +370,7 @@ pub fn build(b: *std.Build) void {
         .root_module = lsp_mod,
     });
     lsp_exe.stack_size = 64 * 1024 * 1024;
-    b.installArtifact(lsp_exe);
+    installExe(b, lsp_exe, nobtcfi_tool);
 
     // Fuzz program generator (driver for the offline differential harness,
     // tests/fuzz/native-diff.sh). Dev/CI tool: installed only by this step,
@@ -448,6 +465,25 @@ pub fn build(b: *std.Build) void {
 
     const cov_scheme_step = b.step("coverage-scheme", "Run a Scheme file with kcov code coverage");
     cov_scheme_step.dependOn(&run_kcov_scheme.step);
+}
+
+/// Installs `exe` to the bin dir, then — for OpenBSD targets — marks the
+/// installed binary PT_OPENBSD_NOBTCFI so it survives BTCFI enforcement
+/// (see the `nobtcfi_tool` comment in `build`). `has_side_effects` keeps the
+/// patch running on every build, since the install step re-copies the raw
+/// (unmarked) binary each time. A no-op wrapper around `installArtifact` on
+/// every other target.
+fn installExe(b: *std.Build, exe: *std.Build.Step.Compile, nobtcfi_tool: ?*std.Build.Step.Compile) void {
+    const tool = nobtcfi_tool orelse {
+        b.installArtifact(exe);
+        return;
+    };
+    const inst = b.addInstallArtifact(exe, .{});
+    const patch = b.addRunArtifact(tool);
+    patch.addArg(b.getInstallPath(.bin, exe.out_filename));
+    patch.has_side_effects = true;
+    patch.step.dependOn(&inst.step);
+    b.getInstallStep().dependOn(&patch.step);
 }
 
 fn kaappiModule(b: *std.Build, options_mod: *std.Build.Module, opts: struct {

--- a/build.zig
+++ b/build.zig
@@ -254,6 +254,16 @@ pub fn build(b: *std.Build) void {
         cc_run.step.dependOn(&emit_run.step);
 
         const native_install = b.addInstallBinFile(native_output, "program");
+        if (nobtcfi_tool) |tool| {
+            // `zig cc` rejects `-z nobtcfi`, so the native output — which calls
+            // into the no-landing-pad libkaappi_rt.a — must be marked the same
+            // way installExe marks the Zig-linked binaries, or it SIGILLs under
+            // BTCFI. Patch it in place before install. See docs/dev/openbsd.md.
+            const native_patch = b.addRunArtifact(tool);
+            native_patch.addFileArg(native_output);
+            native_patch.has_side_effects = true;
+            native_install.step.dependOn(&native_patch.step);
+        }
         native_step.dependOn(&native_install.step);
     }
 

--- a/build.zig
+++ b/build.zig
@@ -100,6 +100,9 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("tools/openbsd_nobtcfi.zig"),
             .target = b.graph.host,
             .optimize = .ReleaseSafe,
+            // pread/pwrite/close are libc externs; macOS links libc
+            // implicitly but Linux (the usual CI/build host) does not.
+            .link_libc = true,
         }),
     }) else null;
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -25,6 +25,7 @@ investigation produced analysis worth keeping.
 | [llvm-backend.md](llvm-backend.md) | LLVM native backend: what LLVM provides vs what the runtime provides |
 | [windows.md](windows.md) | Windows aarch64 port: the platform.zig shim, the two deliberate degradations, the `windows` feature identifier, how to test on a Windows machine |
 | [freebsd.md](freebsd.md) | FreeBSD port: kqueue backend reuse, the sysctl self-exe lookup, zero runtime degradations, cross-compile + copy testing, the CI VM job |
+| [openbsd.md](openbsd.md) | OpenBSD port: the `PT_OPENBSD_NOBTCFI` opt-out around BTCFI enforcement, the `KERN_PROC_ARGS` self-exe lookup, the tight default stack/data limits, cross-compile + patch + copy testing, the CI VM job |
 | [porting.md](porting.md) | Porting to a new OS or CPU architecture: the support matrix, where portability lives, the degradation ladder, staged checklists, what "supported" means |
 | [adding-features.md](adding-features.md) | Step-by-step guides for the most common extension tasks |
 | [testing.md](testing.md) | The four test layers, how to run them, where new tests go |

--- a/docs/dev/openbsd.md
+++ b/docs/dev/openbsd.md
@@ -141,7 +141,7 @@ zig build test -Dtarget=aarch64-openbsd       # compiles unit-tests / thottam-te
 UNIT=$(ls -t .zig-cache/o/*/unit-tests | head -1)
 THOTTAM=$(ls -t .zig-cache/o/*/thottam-tests | head -1)
 cp "$UNIT" ./unit-tests-openbsd; cp "$THOTTAM" ./thottam-tests-openbsd
-zig run tools/openbsd_nobtcfi.zig -- ./unit-tests-openbsd ./thottam-tests-openbsd
+zig run tools/openbsd_nobtcfi.zig -lc -- ./unit-tests-openbsd ./thottam-tests-openbsd  # -lc: the tool uses libc I/O
 
 # copy repo + binaries + lib + the two patched test binaries to the box, then:
 doas pkg_add -I bash          # run-all.sh needs bash; base system has cc

--- a/docs/dev/openbsd.md
+++ b/docs/dev/openbsd.md
@@ -1,0 +1,188 @@
+# OpenBSD port
+
+OpenBSD is the fifth completed OS port. Like FreeBSD it is a full-POSIX
+platform whose native readiness API is **kqueue** — the same backend macOS
+uses — so it sits on rung 1 of the degradation ladder ([porting.md](porting.md))
+with **no I/O degradation**: every port fd flips non-blocking and registers
+with the reactor. What makes OpenBSD different from FreeBSD is its security
+hardening, which forces two accommodations nothing else in the tree needs:
+
+1. **BTCFI** — the kernel enforces Branch Target CFI, and Zig 0.16 cannot emit
+   the landing pads it requires, so every Zig-linked binary must carry an
+   explicit opt-out marker (added post-link).
+2. **Small default resource limits** — the `default` login class caps the main
+   thread's stack at 4 MiB and the data segment at 1.5 GiB, both well under
+   what the interpreter and the unit-test binary use elsewhere.
+
+Everything else worked through the existing POSIX paths.
+
+## What the port touches
+
+| Surface | Change |
+|---------|--------|
+| `src/reactor.zig` | `.openbsd` added to the four per-OS switches (`Backend`, `NotifierBackend`, `ThreadNotifier.notify`, `releaseNotifier`), all resolving to the existing `KqueueBackend`. OpenBSD's `std.c` kqueue bindings are complete — `EVFILT.USER`, `NOTE.TRIGGER`, `EV.EOF` all present — so unlike FreeBSD no constant fallback was needed (the guarded `EV_EOF` stays for FreeBSD). |
+| `src/kaappi_paths.zig` | `getExePath` via `sysctl KERN_PROC_ARGS`/`KERN_PROC_ARGV` → argv[0] → `realpath`. OpenBSD has **no `KERN_PROC_PATHNAME`** (and no procfs), so there is no kernel-canonical exe path; argv[0] resolution is the portable route. |
+| `src/platform.zig` | `is_openbsd` const; `raiseStackLimitBestEffort()` — raises the soft stack limit to the hard limit at startup (OpenBSD-only, no-op elsewhere). |
+| `src/main.zig`, `src/kaappi_lsp.zig` | Call `raiseStackLimitBestEffort()` at startup. |
+| `src/native_compiler.zig` | `-z nobtcfi` added to the `kaappi compile` link line on OpenBSD. |
+| `src/llvm_emit.zig` | `aarch64-unknown-openbsd` / `x86_64-unknown-openbsd` module triples. |
+| `build.zig` + `tools/openbsd_nobtcfi.zig` | Post-link ELF patcher (host tool) that marks each installed Zig-linked binary `PT_OPENBSD_NOBTCFI`, so `zig build -Dtarget=<arch>-openbsd` yields working binaries directly. |
+| `src/testing_helpers.zig`, `src/cache.zig`, `src/tests_libraries.zig` | Resolve `std.testing.tmpDir` paths with a path-string `realpath` instead of `Io.Dir.realPathFile` (fd→path is `OperationUnsupported` on OpenBSD). |
+| CI + release | `openbsd-test` job in `ci.yml`; two `release.yml` matrix rows (`x86_64-openbsd`, `aarch64-openbsd`). |
+
+## BTCFI: the `PT_OPENBSD_NOBTCFI` opt-out
+
+The port's defining problem. OpenBSD on arm64 (and amd64, via IBT) enforces
+**BTCFI**: an indirect branch (`BLR`/`BR`) must land on a `bti` instruction, or
+the CPU raises `SIGILL` with `code=ILL_BTCFI`. OpenBSD's base clang emits those
+landing pads by default and rebuilds the entire base system with them; **Zig
+0.16 cannot** — it has no `-mbranch-protection` flag and no `bti` CPU feature,
+so a Zig-linked binary has no landing pads and traps on its very first
+function-pointer call (in practice, a thread entry trampoline right after
+`__tfork`). This is a young-toolchain limitation, the class the porting guide
+warns about — not a Kaappi bug.
+
+OpenBSD's own escape hatch for foreign toolchains is the linker flag
+`-z nobtcfi`, which emits a **`PT_OPENBSD_NOBTCFI`** program header — a pure
+marker (type only; zero offset/size) that tells `ld.so` and the kernel to skip
+BTCFI enforcement for that binary. Two paths use it:
+
+* **`kaappi compile` native output** takes the honest path: the system cc/ld
+  accepts `-z nobtcfi` directly, so `native_compiler.zig` adds it to the link
+  line on OpenBSD. (The native binary calls into the no-landing-pad
+  `libkaappi_rt.a`, so it needs the marker too.)
+* **Zig-linked binaries** (kaappi, thottam, kaappi-lsp, the unit-test
+  executables) can't use the flag — Zig's CLI rejects `-z nobtcfi` before it
+  reaches LLD. So `tools/openbsd_nobtcfi.zig` adds the marker **post-link**.
+  The program header table sits immediately before `.interp` with no room to
+  append an entry, so instead of growing the table the tool **repurposes the
+  `PT_GNU_STACK` entry in place**: OpenBSD ignores `PT_GNU_STACK` (it enforces
+  W^X independently and sizes the main stack from `RLIMIT_STACK`), so
+  overwriting its 56 bytes with the marker is a no-op for stack handling and
+  gains the opt-out. The tool is idempotent and arch-agnostic (same fix for
+  arm64 BTCFI and amd64 IBT).
+
+`build.zig` compiles this tool for the host and runs it on each installed
+executable for OpenBSD targets (`installExe`), so a plain
+`zig build -Dtarget=<arch>-openbsd` produces working binaries — no separate
+patch step, no footgun. It is a deliberate, documented security degradation
+(BTCFI off for our binaries), directly analogous to the Windows port shipping
+`strip: false` around its own toolchain bug; it lifts when Zig can emit
+aarch64 branch-protection landing pads.
+
+## Resource limits
+
+OpenBSD's `default` login class sets much lower limits than other platforms,
+and two of them bite:
+
+* **Stack (4 MiB soft / 32 MiB hard).** OpenBSD ignores the ELF `PT_GNU_STACK`
+  size hint (`build.zig`'s `--stack`) and sizes the main thread's stack from
+  `RLIMIT_STACK`; 4 MiB overflows on the interpreter's deep recursion (the
+  macro expander, nested compile). The **kaappi binary is unaffected** — it
+  already runs all work on a 64 MiB worker thread (`main.zig`), whose mmap'd
+  stack is not `RLIMIT_STACK`-bound. **kaappi-lsp** compiles user code on the
+  main thread, so it calls `platform.raiseStackLimitBestEffort()` at startup to
+  raise the soft limit to the 32 MiB hard limit. (kaappi calls it too, to
+  harden the rare worker-spawn-failure fallback.) 32 MiB is below the 64 MiB
+  other platforms get; a non-root process can't exceed the hard limit, so
+  extremely deep nesting in the LSP could still overflow — raise the login
+  class's `stacksize` in `login.conf` if so.
+* **Data (1.5 GiB soft / 64 GiB hard).** Only the **unit-test binary** hits
+  this. Zig's `std.testing.allocator` (a `DebugAllocator`) never reuses freed
+  virtual address space — by design, to catch use-after-free — so its
+  reservation grows monotonically across the 1141 tests and lands right at the
+  1.5 GiB soft limit, where allocation-heavy tests (deepCopy of a 200 K-element
+  list, #801) flakily fail with `OutOfMemory` and the thread-spawning channel
+  tests abort. The shipped binaries use the C allocator and never accumulate
+  this way. **Run the unit-test binary with the data limit raised to the hard
+  limit** (`ulimit -d $(ulimit -Hd)`), which the CI job and the recipe below
+  both do.
+
+## Self-exe path
+
+OpenBSD has neither `/proc/self/exe` nor `KERN_PROC_PATHNAME`, so there is no
+kernel-canonical executable path. `getExePath` reads the process's own argv[0]
+via `sysctl KERN_PROC_ARGS`/`KERN_PROC_ARGV` and resolves it with `realpath`:
+argv[0] with a `/` resolves directly (absolute or relative to cwd); a bare
+command name is searched on `$PATH`. This resolves the running binary for
+exe-relative library discovery and `kaappi test` worker respawn; it returns
+null (callers degrade) only for an argv[0] that cannot be found.
+
+## The `realPathFile` test-harness gap
+
+Three unit tests took the tmp dir's absolute path via
+`Io.Dir.realPathFile`, which resolves an **fd → path** — `OperationUnsupported`
+on OpenBSD (no `/proc/self/fd`, no `F_GETPATH`). The runtime never does this;
+only the tests did. They now resolve the tmp dir with a path-string `realpath`
+(`th.tmpDirRealPathAlloc`), which works on every platform — `std.testing`
+places tmp dirs at `.zig-cache/tmp/<sub_path>` relative to the cwd.
+
+## cond-expand / (features)
+
+OpenBSD builds expose `posix` — the project convention is exactly one OS-class
+identifier per build, and OpenBSD is a POSIX platform (there is no `openbsd`
+identifier, just as macOS exposes no `darwin`). The triple in `kaappi features`
+and the crash banner (`aarch64-openbsd-none`) distinguishes the OS when it
+matters. All capability identifiers (`kaappi-threads`, `kaappi-fibers`,
+`kaappi-reactor`, `kaappi-diagnostics`) are present — nothing is gated.
+
+## Testing on an OpenBSD machine
+
+No Zig toolchain is needed on the box — cross-compile everything, patch the
+Zig-linked test binaries, and copy it over (the build-anywhere / execute-on-
+target model). `zig build` already marks the three installed binaries; only the
+unit-test executables need the tool run on them explicitly.
+
+```bash
+# on the dev machine
+zig build -Dtarget=aarch64-openbsd            # or x86_64-openbsd (binaries auto-marked)
+zig build lib -Dtarget=aarch64-openbsd        # native-backend runtime lib
+zig build test -Dtarget=aarch64-openbsd       # compiles unit-tests / thottam-tests
+UNIT=$(ls -t .zig-cache/o/*/unit-tests | head -1)
+THOTTAM=$(ls -t .zig-cache/o/*/thottam-tests | head -1)
+cp "$UNIT" ./unit-tests-openbsd; cp "$THOTTAM" ./thottam-tests-openbsd
+zig run tools/openbsd_nobtcfi.zig -- ./unit-tests-openbsd ./thottam-tests-openbsd
+
+# copy repo + binaries + lib + the two patched test binaries to the box, then:
+doas pkg_add -I bash          # run-all.sh needs bash; base system has cc
+ulimit -s $(ulimit -Hs)       # 32 MiB — the test runner recurses on the main thread
+ulimit -d $(ulimit -Hd)       # 64 GiB — DebugAllocator virtual growth (see above)
+./unit-tests-openbsd && ./thottam-tests-openbsd
+cc -shared -fPIC tests/scheme/ffi/fixtures/u64test.c \
+   -o tests/scheme/ffi/fixtures/libu64test.so
+bash tests/scheme/run-all.sh
+```
+
+The native backend works with the base system `cc` (no Zig on the box):
+`kaappi compile` links its output against `libkaappi_rt.a` with `-z nobtcfi`;
+`kaappi doctor`'s smoke-link check confirms it per machine.
+
+Reference machine for this port: **OpenBSD 7.9 aarch64** (4-core / 4 GiB VM).
+
+## CI
+
+`openbsd-test` (ci.yml) cross-compiles the binaries, test executables, and
+`libkaappi_rt.a` for **x86_64-openbsd** on ubuntu-latest — the compile gate —
+runs `tools/openbsd_nobtcfi.zig` over the two test binaries, then boots an
+OpenBSD 7.9 VM (`vmactions/openbsd-vm`; GitHub hosts no OpenBSD runners) that
+shares the workspace and executes the unit suite, the thottam suite, and
+`run-all.sh` with the stack and data limits raised. One job, no artifact
+handoff, because the VM syncs the workspace directly. The VM tracks 7.9 to
+match the aarch64 reference machine (OpenBSD breaks ABI between releases, so the
+Zig-targeted release and the VM release should agree).
+
+## Known gaps
+
+* **BTCFI is disabled** for the Zig-linked binaries (the `PT_OPENBSD_NOBTCFI`
+  marker). This is a toolchain limitation, not a choice — it lifts when Zig can
+  emit aarch64 branch-protection landing pads. The `kaappi compile` native
+  backend is unaffected in principle (it could emit landing pads if Zig's C
+  toolchain did), but currently also opts out for the runtime archive's sake.
+* **kaappi-lsp's stack is capped at the 32 MiB hard limit** (vs 64 MiB
+  elsewhere); a non-root process cannot exceed it. Raise `login.conf` if deeply
+  nested LSP requests overflow.
+* Building natively with Zig **on** OpenBSD is expected to work (the target is
+  supported upstream) but hasn't been exercised — the cross-compile + copy flow
+  covers development, and the native backend needs only base `cc` at runtime.
+* `tests/e2e/run-e2e.sh` and the `compile/` suite need a Zig toolchain on the
+  box; they run wherever one exists.

--- a/docs/dev/porting.md
+++ b/docs/dev/porting.md
@@ -1,14 +1,17 @@
 # Porting to a new OS or CPU architecture
 
 How Kaappi's existing platform support is structured, and staged checklists
-for bringing up a new operating system or a new CPU architecture. The four
+for bringing up a new operating system or a new CPU architecture. The five
 completed ports are the reference material: **Windows aarch64** (#1606,
 #1608, #1609 — the OS-port exemplar, documented in [windows.md](windows.md)),
 **wasm32-wasi** (KEP-0001 Phase 4 — the capability-degradation exemplar),
-**riscv64-linux** (the CPU-architecture exemplar, tested under QEMU), and
+**riscv64-linux** (the CPU-architecture exemplar, tested under QEMU),
 **FreeBSD** (the POSIX-audit exemplar — a port where nearly everything
 already works and the job is verifying it, documented in
-[freebsd.md](freebsd.md)).
+[freebsd.md](freebsd.md)), and **OpenBSD** (the toolchain-hardening exemplar
+— a POSIX/kqueue platform whose security mitigations, BTCFI enforcement and
+tight default resource limits, forced accommodations nothing else needs,
+documented in [openbsd.md](openbsd.md)).
 
 ## Current support matrix
 
@@ -20,6 +23,7 @@ already works and the job is verifying it, documented in
 | Linux | riscv64 | cross-compiled | unit + R7RS under QEMU user-mode | `riscv64-test` | yes |
 | Windows | aarch64 | cross-compiled only (#1613) | unit + thottam + R7RS + VM-verified `.scm` suites on `windows-11-arm` runners | `windows-cross` + `windows-arm-test` | yes (unstripped, #1607) |
 | FreeBSD | x86_64, aarch64 | cross-compiled | unit + thottam + full `.scm` suites in a KVM FreeBSD VM (x86_64); verified on a real 15.1 aarch64 box | `freebsd-test` | yes (both arches) |
+| OpenBSD | x86_64, aarch64 | cross-compiled | unit + thottam + full `.scm` suites in a KVM OpenBSD 7.9 VM (x86_64); verified on a real 7.9 aarch64 box | `openbsd-test` | yes (both arches, `PT_OPENBSD_NOBTCFI`-marked) |
 | WASI | wasm32 | cross-compiled (`zig build wasm`) | smoke + timer + parallel-pool under wasmtime | `wasm` | yes (`kaappi.wasm`) |
 
 Everything builds from any host — Zig cross-compiles all rows; no target
@@ -360,6 +364,26 @@ Hard-won specifics worth re-reading before starting (fuller detail in
   that also broke only-stripped binaries (#1607). Reduce with minimal
   probes before assuming the bug is in this repo, and document the
   workaround next to the release row (`strip: false`).
+* **A hardened OS can reject the whole toolchain's output.** OpenBSD/arm64
+  enforces BTCFI — every indirect branch must hit a `bti` landing pad or
+  the kernel raises `SIGILL`/`ILL_BTCFI` — and Zig 0.16 emits none, so the
+  binary trapped on its first function-pointer call before `main` ran. The
+  fix wasn't in our code: OpenBSD ships an opt-out (`-z nobtcfi` →
+  `PT_OPENBSD_NOBTCFI`), applied to the native-backend link directly and
+  to Zig-linked binaries by a post-link ELF patch (`tools/openbsd_nobtcfi.zig`,
+  wired into `build.zig`). `ktrace`/`kdump` on the box named the exact
+  `ILL_BTCFI` fault; a two-line C probe (function pointer with vs. without
+  `-mbranch-protection`) proved it was enforcement, not our bug. Watch for
+  the same class on any CFI-enforcing OS (amd64 IBT, future arm64 targets).
+* **A young target's default resource limits may be far tighter.** OpenBSD's
+  `default` login class caps the main stack at 4 MiB (deep interpreter
+  recursion overflowed it — the fix was the existing 64 MiB worker thread
+  plus a startup `setrlimit`) and the data segment at 1.5 GiB (the
+  DebugAllocator's unbounded virtual growth flakily OOM'd the *unit-test*
+  binary — the fix was raising `ulimit -d` for the test run, a harness
+  concern the shipped C-allocator binaries never hit). Check `ulimit -a`
+  early and separate "the runtime needs this" from "only the test binary
+  does."
 * **Probe capabilities at runtime, per object.** Comptime OS checks
   can't see host differences (WASI browser shim vs wasmtime; socket vs
   pipe fds behind the same CRT). One-time probes with remembered answers

--- a/docs/dev/porting.md
+++ b/docs/dev/porting.md
@@ -9,9 +9,9 @@ completed ports are the reference material: **Windows aarch64** (#1606,
 **FreeBSD** (the POSIX-audit exemplar — a port where nearly everything
 already works and the job is verifying it, documented in
 [freebsd.md](freebsd.md)), and **OpenBSD** (the toolchain-hardening exemplar
-— a POSIX/kqueue platform whose security mitigations, BTCFI enforcement and
-tight default resource limits, forced accommodations nothing else needs,
-documented in [openbsd.md](openbsd.md)).
+— a POSIX/kqueue platform whose BTCFI enforcement and tight default resource
+limits forced accommodations that nothing else needs, documented in
+[openbsd.md](openbsd.md)).
 
 ## Current support matrix
 

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,24 @@ set -euo pipefail
 REPO="kaappi/kaappi"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 
+# Download URL ($1) to file ($2). Prefers curl (macOS/Linux), then wget, then
+# the BSD base tools: fetch (FreeBSD) and ftp (OpenBSD) both fetch HTTPS from
+# the base system, where curl is not installed.
+download() {
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$2" "$1"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$2" "$1"
+    elif command -v fetch >/dev/null 2>&1; then
+        fetch -qo "$2" "$1"
+    elif command -v ftp >/dev/null 2>&1; then
+        ftp -o "$2" "$1"
+    else
+        echo "error: need curl, wget, fetch, or ftp to download files" >&2
+        return 1
+    fi
+}
+
 detect_platform() {
     local os arch
     os=$(uname -s)
@@ -41,10 +59,11 @@ detect_platform() {
 }
 
 get_latest_tag() {
-    curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
-        | grep '"tag_name"' \
-        | head -1 \
-        | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/'
+    local tmp
+    tmp=$(mktemp)
+    download "https://api.github.com/repos/$REPO/releases/latest" "$tmp" || { rm -f "$tmp"; return 1; }
+    grep '"tag_name"' "$tmp" | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/'
+    rm -f "$tmp"
 }
 
 main() {
@@ -74,10 +93,10 @@ main() {
     tmpdir=$(mktemp -d)
     trap "rm -rf '$tmpdir'" EXIT
 
-    curl -fsSL -o "$tmpdir/kaappi" "$base_url/$kaappi_artifact"
-    curl -fsSL -o "$tmpdir/thottam" "$base_url/$thottam_artifact"
-    curl -fsSL -o "$tmpdir/kaappi-lib.tar.gz" "$base_url/kaappi-lib.tar.gz"
-    curl -fsSL -o "$tmpdir/SHA256SUMS" "$base_url/SHA256SUMS"
+    download "$base_url/$kaappi_artifact" "$tmpdir/kaappi"
+    download "$base_url/$thottam_artifact" "$tmpdir/thottam"
+    download "$base_url/kaappi-lib.tar.gz" "$tmpdir/kaappi-lib.tar.gz"
+    download "$base_url/SHA256SUMS" "$tmpdir/SHA256SUMS"
 
     echo "Verifying checksums..."
     cd "$tmpdir"
@@ -89,8 +108,17 @@ main() {
         sha256sum -c --quiet check.txt
     elif command -v shasum >/dev/null 2>&1; then
         shasum -a 256 -c --quiet check.txt
+    elif command -v sha256 >/dev/null 2>&1; then
+        # OpenBSD/FreeBSD base: sha256 has no coreutils-style -c, so recompute
+        # each file's hash and confirm it appears in SHA256SUMS.
+        for f in kaappi thottam kaappi-lib.tar.gz; do
+            grep -q "$(sha256 -q "$f")" SHA256SUMS \
+                || { echo "error: checksum verification failed for $f" >&2; exit 1; }
+        done
     else
-        echo "warning: neither sha256sum nor shasum found, skipping verification"
+        echo "error: no checksum tool (sha256sum, shasum, or sha256) found;" >&2
+        echo "refusing to install unverified binaries" >&2
+        exit 1
     fi
 
     echo "Installing to $INSTALL_DIR/..."

--- a/install.sh
+++ b/install.sh
@@ -18,16 +18,17 @@ detect_platform() {
         Darwin)  os="macos" ;;
         Linux)   os="linux" ;;
         FreeBSD) os="freebsd" ;;
+        OpenBSD) os="openbsd" ;;
         *)
             echo "error: unsupported OS: $os"
-            echo "Kaappi supports macOS, Linux, and FreeBSD. See https://github.com/$REPO"
+            echo "Kaappi supports macOS, Linux, FreeBSD, and OpenBSD. See https://github.com/$REPO"
             exit 1
             ;;
     esac
 
     case "$arch" in
         arm64|aarch64) arch="aarch64" ;;
-        # FreeBSD reports x86_64 as amd64 (uname -m).
+        # FreeBSD and OpenBSD report x86_64 as amd64 (uname -m).
         x86_64|amd64)  arch="x86_64" ;;
         riscv64)       arch="riscv64" ;;
         *)

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -438,7 +438,14 @@ test "renderStatus and clearDir over a temp cache dir" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const dir = try tmp.dir.realPathFileAlloc(std.testing.io, ".", allocator);
+    // Resolve the tmp dir with a path-string realpath, not Io.Dir's fd→path
+    // lookup: the latter is error.OperationUnsupported on OpenBSD (no
+    // /proc/self/fd, no F_GETPATH). std.testing places tmp dirs at
+    // .zig-cache/tmp/<sub_path> relative to the cwd.
+    var rel_buf: [platform.PATH_MAX]u8 = undefined;
+    const rel = try std.fmt.bufPrintZ(&rel_buf, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    var real_buf: [platform.PATH_MAX]u8 = undefined;
+    const dir = try allocator.dupe(u8, platform.realPath(rel, &real_buf) orelse return error.FileNotFound);
     defer allocator.free(dir);
 
     try writeTestCacheEntry(allocator, dir, "aaaa.sbc", "/home/u/one.scm");

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -766,6 +766,12 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // so CRT text-mode \n→\r\n rewriting on fd 1 would corrupt framing.
     platform.initStandardStreams();
 
+    // The LSP compiles user code on this (main) thread — unlike the kaappi
+    // binary, which runs on a 64 MB worker thread — so on OpenBSD it must
+    // raise its own 4 MiB default stack limit to avoid overflowing on deeply
+    // nested forms. No-op elsewhere. See docs/dev/openbsd.md.
+    platform.raiseStackLimitBestEffort();
+
     log("kaappi-lsp v" ++ version ++ " starting\n");
 
     documents = std.StringHashMap([]const u8).init(allocator);

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -185,7 +185,10 @@ fn openbsdExePath(buf: []u8) ?[]const u8 {
         @memcpy(cand[d.len + 1 ..][0..name.len], name);
         cand[total] = 0;
         const cpath = cand[0..total :0];
-        if (std.c.access(cpath.ptr, X_OK) != 0) continue;
+        // access(X_OK) also succeeds for a searchable directory, and realpath
+        // would then return that directory — require a regular file so a
+        // $PATH entry that is a directory named like the program is skipped.
+        if (std.c.access(cpath.ptr, X_OK) != 0 or platform.isDir(cpath)) continue;
         return realpathInto(cpath.ptr, &real, buf);
     }
     return null;

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -122,7 +122,85 @@ pub fn getExePath(buf: []u8) ?[]const u8 {
         return buf[0 .. len - 1]; // len counts the terminating NUL
     }
 
+    if (comptime @import("builtin").os.tag == .openbsd) {
+        return openbsdExePath(buf);
+    }
+
     return null;
+}
+
+/// OpenBSD self-exe resolution. Unlike FreeBSD/NetBSD, OpenBSD has no
+/// `KERN_PROC_PATHNAME` — and no procfs — so there is no kernel-canonical
+/// executable path to read. The portable route is the process's own
+/// argv[0] (via `sysctl KERN_PROC_ARGS / KERN_PROC_ARGV`), resolved to an
+/// absolute, canonical path with `realpath`:
+///   - argv[0] containing a '/'  → realpath resolves it (absolute, or
+///     relative to the cwd)
+///   - a bare command name       → search `$PATH` for the first executable
+///     match, then realpath it
+/// Returns null if argv[0] is unavailable or nothing resolves; callers
+/// (exe-relative lib discovery, `kaappi test` worker respawn) degrade to
+/// other lib paths / argv[0], exactly as on a platform with no self-exe
+/// lookup at all.
+fn openbsdExePath(buf: []u8) ?[]const u8 {
+    // KERN_PROC_ARGV returns an array of `char *` (relocated by the kernel
+    // to point within the buffer we pass, NUL-terminated) followed by the
+    // string data; the first pointer is argv[0]. A bounded scratch buffer
+    // covers an ordinary argv — an oversized one returns ENOMEM here and we
+    // degrade to null. Aligned so the pointer array can be read directly.
+    var scratch: [16 * 1024]u8 align(@alignOf(usize)) = undefined;
+    var mib = [4]c_int{
+        std.c.CTL.KERN,
+        std.c.KERN.PROC_ARGS,
+        @intCast(std.c.getpid()),
+        std.c.KERN.PROC_ARGV,
+    };
+    var len: usize = scratch.len;
+    if (std.c.sysctl(&mib, mib.len, &scratch, &len, null, 0) != 0) return null;
+
+    const argv: [*]const ?[*:0]const u8 = @ptrCast(&scratch);
+    const arg0 = argv[0] orelse return null;
+    if (std.mem.sliceTo(arg0, 0).len == 0) return null;
+
+    var real: [std.posix.PATH_MAX]u8 = undefined;
+
+    if (std.mem.indexOfScalar(u8, std.mem.sliceTo(arg0, 0), '/') != null) {
+        // Absolute, or relative to the cwd — realpath handles both.
+        return realpathInto(arg0, &real, buf);
+    }
+
+    // Bare command name: resolve against $PATH, first executable wins.
+    const path_env = platform.getenv("PATH") orelse return null;
+    const path = std.mem.sliceTo(path_env, 0);
+    const name = std.mem.sliceTo(arg0, 0);
+    const X_OK: c_int = 1; // execute permission (POSIX, universal)
+    var it = std.mem.splitScalar(u8, path, ':');
+    var cand: [std.posix.PATH_MAX]u8 = undefined;
+    while (it.next()) |dir| {
+        const d = if (dir.len == 0) "." else dir; // empty PATH entry == cwd
+        const total = d.len + 1 + name.len;
+        if (total + 1 > cand.len) continue;
+        @memcpy(cand[0..d.len], d);
+        cand[d.len] = '/';
+        @memcpy(cand[d.len + 1 ..][0..name.len], name);
+        cand[total] = 0;
+        const cpath = cand[0..total :0];
+        if (std.c.access(cpath.ptr, X_OK) != 0) continue;
+        return realpathInto(cpath.ptr, &real, buf);
+    }
+    return null;
+}
+
+/// Canonicalizes a NUL-terminated `path` with `realpath` into `real`, then
+/// copies the result into `buf`. Returns null if realpath fails or the
+/// result doesn't fit. Split out so both the argv[0] and the $PATH branch
+/// of `openbsdExePath` share one copy of the fit/NUL handling.
+fn realpathInto(path: [*:0]const u8, real: *[std.posix.PATH_MAX]u8, buf: []u8) ?[]const u8 {
+    const resolved = std.c.realpath(path, real) orelse return null;
+    const rlen = std.mem.sliceTo(resolved, 0).len;
+    if (rlen == 0 or rlen > buf.len) return null;
+    @memcpy(buf[0..rlen], resolved[0..rlen]);
+    return buf[0..rlen];
 }
 
 pub fn getExeRelativeLibDir(buf: []u8) ?[]const u8 {

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -1357,6 +1357,7 @@ pub const LLVMEmitter = struct {
                 .linux => "aarch64-unknown-linux-gnu",
                 .windows => "aarch64-pc-windows-gnu",
                 .freebsd => "aarch64-unknown-freebsd",
+                .openbsd => "aarch64-unknown-openbsd",
                 else => "aarch64-unknown-unknown",
             },
             .x86_64 => switch (os) {
@@ -1364,6 +1365,7 @@ pub const LLVMEmitter = struct {
                 .linux => "x86_64-unknown-linux-gnu",
                 .windows => "x86_64-pc-windows-gnu",
                 .freebsd => "x86_64-unknown-freebsd",
+                .openbsd => "x86_64-unknown-openbsd",
                 else => "x86_64-unknown-unknown",
             },
             else => "unknown-unknown-unknown",

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,6 +134,11 @@ const DESIRED_STACK: usize = 64 * 1024 * 1024; // 64 MB
 
 pub fn main(init: std.process.Init.Minimal) !void {
     platform.initStandardStreams();
+    // Hardens the fallback path below (and any OpenBSD build): if the worker
+    // thread can't be spawned we run mainInner on the main thread, whose stack
+    // is RLIMIT_STACK-bound — only 4 MiB by default on OpenBSD. No-op
+    // elsewhere. See docs/dev/openbsd.md.
+    platform.raiseStackLimitBestEffort();
     if (comptime !is_wasm) {
         // The compiler's recursive descent needs more than the default 8 MB
         // stack for deeply nested Scheme forms (e.g. cond chains that desugar

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -414,6 +414,18 @@ fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, ou
         argv_buf[argc] = "-lpthread";
         argc += 1;
     }
+    if (comptime platform.is_openbsd) {
+        // OpenBSD/arm64 enforces BTCFI: an indirect branch must land on a
+        // `bti` instruction. The Zig-built libkaappi_rt.a carries no landing
+        // pads (Zig 0.16 can't emit them), so the linked native binary opts
+        // out via the PT_OPENBSD_NOBTCFI marker that `-z nobtcfi` emits — the
+        // system cc/ld supports the flag natively. Kaappi's own binaries get
+        // the same marker post-link (build.zig). See docs/dev/openbsd.md.
+        argv_buf[argc] = "-z";
+        argc += 1;
+        argv_buf[argc] = "nobtcfi";
+        argc += 1;
+    }
     argv_buf[argc] = null;
 
     const link_ok = blk: {

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -23,6 +23,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 pub const is_windows = builtin.os.tag == .windows;
+pub const is_openbsd = builtin.os.tag == .openbsd;
 const is_wasm = builtin.os.tag == .wasi;
 
 /// CRT file descriptor on Windows; kernel fd elsewhere. i32 on every
@@ -822,6 +823,24 @@ pub fn sleepNs(ns: u64) void {
         if (ret == 0) break;
         if (errno(ret) != .INTR) break;
     }
+}
+
+/// Best-effort raise of the soft stack limit to the hard limit, called once
+/// at process startup. OpenBSD's `default` login class caps the soft stack
+/// at 4 MiB — under the 8 MiB macOS/Linux give a main thread, and far under
+/// the interpreter's deep-recursion needs (the macro expander and nested
+/// compile recurse on the machine stack). OpenBSD ignores the ELF
+/// `PT_GNU_STACK` size hint (`build.zig`'s `--stack`) and sizes the main
+/// stack from RLIMIT_STACK, so raising the soft limit to the hard limit
+/// (32 MiB on that class) before any deep recursion lets the on-demand stack
+/// grow that far. OpenBSD-only and best-effort: a no-op on every other
+/// platform — leaving their exact process setup untouched — and silent on any
+/// rlimit failure. See docs/dev/openbsd.md.
+pub fn raiseStackLimitBestEffort() void {
+    if (comptime builtin.os.tag != .openbsd) return;
+    const lim = std.posix.getrlimit(.STACK) catch return;
+    if (lim.cur >= lim.max) return;
+    std.posix.setrlimit(.STACK, .{ .cur = lim.max, .max = lim.max }) catch {};
 }
 
 // ---------------------------------------------------------------------------

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -29,7 +29,7 @@ pub const Interest = enum { read, write };
 const ReadyEvent = struct { fd: i32, readable: bool, writable: bool };
 
 const Backend = switch (builtin.os.tag) {
-    .macos, .ios, .tvos, .watchos, .visionos, .freebsd => KqueueBackend,
+    .macos, .ios, .tvos, .watchos, .visionos, .freebsd, .openbsd => KqueueBackend,
     .linux => EpollBackend,
     .wasi => WasiPollBackend,
     .windows => WindowsEventBackend,
@@ -91,7 +91,7 @@ pub const ThreadNotifier = struct {
         self.wake_pending.store(true, .release);
         if (!self.alive.load(.acquire)) return;
         switch (builtin.os.tag) {
-            .macos, .ios, .tvos, .watchos, .visionos, .freebsd => {
+            .macos, .ios, .tvos, .watchos, .visionos, .freebsd, .openbsd => {
                 var triggers = [1]std.c.Kevent{.{
                     .ident = 0,
                     .filter = std.c.EVFILT.USER,
@@ -132,7 +132,7 @@ pub const ThreadNotifier = struct {
 /// Reactor is constructed (see Reactor.init / each backend's
 /// `notifierBackend`).
 const NotifierBackend = switch (builtin.os.tag) {
-    .macos, .ios, .tvos, .watchos, .visionos, .freebsd => struct { kq: i32 },
+    .macos, .ios, .tvos, .watchos, .visionos, .freebsd, .openbsd => struct { kq: i32 },
     .linux => struct { fd: i32 },
     .wasi => struct {},
     .windows => struct { event: platform.win.HANDLE },
@@ -167,7 +167,7 @@ pub fn retainNotifier(n: *ThreadNotifier) void {
 pub fn releaseNotifier(n: *ThreadNotifier) void {
     if (n.refcount.fetchSub(1, .acq_rel) == 1) {
         switch (builtin.os.tag) {
-            .macos, .ios, .tvos, .watchos, .visionos, .freebsd => _ = platform.close(n.backend.kq),
+            .macos, .ios, .tvos, .watchos, .visionos, .freebsd, .openbsd => _ = platform.close(n.backend.kq),
             .linux => _ = platform.close(n.backend.fd),
             .wasi => {},
             // Shared with the backend's wait — closed only here, exactly
@@ -441,7 +441,7 @@ pub const Reactor = struct {
 };
 
 // ---------------------------------------------------------------------------
-// kqueue backend (macOS/Apple platforms, FreeBSD)
+// kqueue backend (macOS/Apple platforms, FreeBSD, OpenBSD)
 // ---------------------------------------------------------------------------
 
 const KqueueBackend = struct {

--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -9,6 +9,21 @@ pub const VM = vm_mod.VM;
 pub const VMError = vm_mod.VMError;
 pub const Value = types.Value;
 
+/// Absolute path of a `std.testing.tmpDir` result, resolved with a
+/// path-string `realpath` rather than `Io.Dir.realPathFile`'s fd→path
+/// lookup. That lookup is `error.OperationUnsupported` on OpenBSD (no
+/// `/proc/self/fd`, no `F_GETPATH`), whereas path-string realpath works on
+/// every platform. std.testing places tmp dirs at `.zig-cache/tmp/<sub_path>`
+/// relative to the cwd (see `std.testing.tmpDir`), which realpath
+/// canonicalizes. Caller owns the returned slice.
+pub fn tmpDirRealPathAlloc(tmp: *std.testing.TmpDir, allocator: std.mem.Allocator) ![]const u8 {
+    var rel_buf: [platform.PATH_MAX]u8 = undefined;
+    const rel = try std.fmt.bufPrintZ(&rel_buf, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    var out_buf: [platform.PATH_MAX]u8 = undefined;
+    const resolved = platform.realPath(rel, &out_buf) orelse return error.FileNotFound;
+    return allocator.dupe(u8, resolved);
+}
+
 /// Build a fully bootstrapped VM for a unit test. The VM is heap-allocated
 /// and returned by pointer: `vm_instance` and the GC root marker reach the
 /// VM by address, so it must never move. Returning the struct by value (as

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -307,7 +307,7 @@ test "cond-expand (library ...) detects an unloaded .sld on the lib path" {
         .sub_path = "condlib/feature.sld",
         .data = "(define-library (condlib feature) (export feature-value) (begin (define feature-value 7)))",
     });
-    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    const dir_path = try th.tmpDirRealPathAlloc(&tmp, std.testing.allocator);
     defer std.testing.allocator.free(dir_path);
 
     var gc = memory.GC.init(std.testing.allocator);
@@ -371,7 +371,7 @@ test "stale .sbc next to .sld must not drop include-library-declarations exports
         .sub_path = "cachedlib/decls.scm",
         .data = "(export answer)",
     });
-    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    const dir_path = try th.tmpDirRealPathAlloc(&tmp, std.testing.allocator);
     defer std.testing.allocator.free(dir_path);
 
     // Hand-build a valid .sbc with a matching source hash — exactly what the

--- a/tests/scheme/ffi/int-range.scm
+++ b/tests/scheme/ffi/int-range.scm
@@ -23,10 +23,12 @@
     (display "FAIL: ") (display name) (display " should have raised error")
     (newline)))
 
-;; abs resolves through libm's dependency chain on POSIX; on Windows the
-;; CRT (ucrtbase.dll) exports it directly — there is no libm.dll.
-(define libm (ffi-open (cond-expand (windows "ucrtbase") (else "libm"))))
-(define c-abs (ffi-fn libm "abs" '(int) 'int))
+;; abs is a libc function: resolve it from the process's own libc (the
+;; null/default handle) on POSIX — dlsym on an OpenBSD libm handle does not
+;; find abs — and from the CRT (ucrtbase.dll) on Windows, which has no
+;; libm.dll.
+(define abs-lib (ffi-open (cond-expand (windows "ucrtbase") (else #f))))
+(define c-abs (ffi-fn abs-lib "abs" '(int) 'int))
 
 ;; Valid in-range call
 (check "abs(-42)" (c-abs -42) 42)
@@ -39,7 +41,7 @@
 (check-error "abs(-5000000000) out of c_int range"
   (lambda () (c-abs -5000000000)))
 
-(ffi-close libm)
+(ffi-close abs-lib)
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "FFI int-range tests failed" fail))

--- a/tests/scheme/ffi/narrow-range.scm
+++ b/tests/scheme/ffi/narrow-range.scm
@@ -6,13 +6,15 @@
 
 (test-begin "narrow-range")
 
-;; libm on POSIX; on Windows the CRT (ucrtbase.dll) hosts abs — there is
-;; no libm.dll.
-(define libm (ffi-open (cond-expand (windows "ucrtbase") (else "libm"))))
+;; abs is a libc function, not libm: resolve it from the process's own libc
+;; (the null/default handle) on POSIX — dlsym on an OpenBSD libm handle does
+;; not find abs, and there is no libm.dll on Windows, where the CRT
+;; (ucrtbase.dll) hosts it.
+(define abs-lib (ffi-open (cond-expand (windows "ucrtbase") (else #f))))
 (define libc (ffi-open #f))
 
 ;; ---- uint8 [0, 255] ----
-(define abs-u8 (ffi-fn libm "abs" '(uint8) 'int))
+(define abs-u8 (ffi-fn abs-lib "abs" '(uint8) 'int))
 (test-equal "uint8 valid: 0" 0 (abs-u8 0))
 (test-equal "uint8 valid: 42" 42 (abs-u8 42))
 (test-equal "uint8 valid: 255" 255 (abs-u8 255))
@@ -21,7 +23,7 @@
 (test-error "uint8 reject: 300" (abs-u8 300))
 
 ;; ---- int8 [-128, 127] ----
-(define abs-i8 (ffi-fn libm "abs" '(int8) 'int))
+(define abs-i8 (ffi-fn abs-lib "abs" '(int8) 'int))
 (test-equal "int8 valid: 42" 42 (abs-i8 42))
 (test-equal "int8 valid: -42" 42 (abs-i8 -42))
 (test-equal "int8 valid: 127" 127 (abs-i8 127))
@@ -31,7 +33,7 @@
 (test-error "int8 reject: 200" (abs-i8 200))
 
 ;; ---- int16 [-32768, 32767] ----
-(define abs-i16 (ffi-fn libm "abs" '(int16) 'int))
+(define abs-i16 (ffi-fn abs-lib "abs" '(int16) 'int))
 (test-equal "int16 valid: 1000" 1000 (abs-i16 1000))
 (test-equal "int16 valid: 32767" 32767 (abs-i16 32767))
 (test-equal "int16 valid: -32768" 32768 (abs-i16 -32768))
@@ -40,7 +42,7 @@
 (test-error "int16 reject: 40000" (abs-i16 40000))
 
 ;; ---- uint16 [0, 65535] ----
-(define abs-u16 (ffi-fn libm "abs" '(uint16) 'int))
+(define abs-u16 (ffi-fn abs-lib "abs" '(uint16) 'int))
 (test-equal "uint16 valid: 1000" 1000 (abs-u16 1000))
 (test-equal "uint16 valid: 65535" 65535 (abs-u16 65535))
 (test-error "uint16 reject: 65536" (abs-u16 65536))
@@ -48,7 +50,7 @@
 (test-error "uint16 reject: 70000" (abs-u16 70000))
 
 ;; ---- char [0, 255] ----
-(define abs-char (ffi-fn libm "abs" '(char) 'int))
+(define abs-char (ffi-fn abs-lib "abs" '(char) 'int))
 (test-equal "char valid: 65" 65 (abs-char 65))
 (test-equal "char valid: 0" 0 (abs-char 0))
 (test-equal "char valid: 255" 255 (abs-char 255))
@@ -71,7 +73,7 @@
 (test-error "uint32 reject: 2^32" (c-htonl 4294967296))
 (test-error "uint32 reject: 2^35" (c-htonl (expt 2 35)))
 
-(ffi-close libm)
+(ffi-close abs-lib)
 (ffi-close libc)
 
 (let ((runner (test-runner-current)))

--- a/tests/scheme/ffi/type-validation.scm
+++ b/tests/scheme/ffi/type-validation.scm
@@ -20,11 +20,14 @@
     (display "FAIL: ") (display name) (display " should have raised error")
     (newline)))
 
-;; libm on POSIX; on Windows the CRT (ucrtbase.dll) hosts the math
-;; functions — there is no libm.dll.
+;; sqrt lives in libm on POSIX; on Windows the CRT (ucrtbase.dll) hosts the
+;; math functions — there is no libm.dll. abs is a libc function, resolved
+;; from the process's own libc (the null/default handle) on POSIX — dlsym on
+;; an OpenBSD libm handle does not find it — and from ucrtbase on Windows.
 (define libm (ffi-open (cond-expand (windows "ucrtbase") (else "libm"))))
+(define abs-lib (ffi-open (cond-expand (windows "ucrtbase") (else #f))))
 (define c-sqrt (ffi-fn libm "sqrt" '(double) 'double))
-(define c-abs (ffi-fn libm "abs" '(int) 'int))
+(define c-abs (ffi-fn abs-lib "abs" '(int) 'int))
 
 ;; --- Valid calls still work ---
 (let ((r (c-sqrt 4.0)))
@@ -57,6 +60,7 @@
   (check "fixnum->double coercion" (and (> r 1.99) (< r 2.01)) #t))
 
 (ffi-close libm)
+(ffi-close abs-lib)
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "FFI type validation tests failed" fail))

--- a/tools/openbsd_nobtcfi.zig
+++ b/tools/openbsd_nobtcfi.zig
@@ -1,0 +1,99 @@
+//! Post-link ELF patcher that marks a binary PT_OPENBSD_NOBTCFI so OpenBSD's
+//! `ld.so`/kernel skip Branch Target CFI (BTCFI) enforcement on it.
+//!
+//! Why this exists: OpenBSD on arm64 enforces BTCFI — an indirect branch
+//! (`BLR`/`BR`) must land on a `bti` instruction, or the CPU raises
+//! `SIGILL`/`ILL_BTCFI`. Its base clang emits those landing pads by default;
+//! Zig 0.16 cannot (no `-mbranch-protection`, no `bti` CPU feature), so a
+//! Zig-built binary traps on its first function-pointer call. OpenBSD's own
+//! opt-out is the linker flag `-z nobtcfi`, which emits a `PT_OPENBSD_NOBTCFI`
+//! program header — a pure marker (type only; zero offset/size). Zig's CLI
+//! rejects that `-z` flag, so we add the marker after the fact.
+//!
+//! How: the program header table sits immediately before `.interp` with no
+//! room to append an entry, so instead of growing the table we repurpose the
+//! `PT_GNU_STACK` entry in place. OpenBSD ignores `PT_GNU_STACK` (it enforces
+//! W^X independently and sizes the main stack from `RLIMIT_STACK`), so
+//! overwriting its 56 bytes with the NOBTCFI marker is a no-op for stack
+//! handling and gains the opt-out. Idempotent: a binary already carrying the
+//! marker is left untouched.
+//!
+//! The `kaappi compile` native backend takes the honest path instead — the
+//! system cc/ld accepts `-z nobtcfi` directly (native_compiler.zig). This
+//! tool is only for the Zig-linked binaries (kaappi, thottam, kaappi-lsp, and
+//! the unit-test executables). See docs/dev/openbsd.md.
+
+const std = @import("std");
+
+const PT_GNU_STACK: u32 = 0x6474e551;
+const PT_OPENBSD_NOBTCFI: u32 = 0x65a3dbe8;
+const PF_X: u32 = 1;
+
+pub fn main(init: std.process.Init.Minimal) !void {
+    var it = init.args.iterate();
+    _ = it.next(); // skip argv[0]
+    var any = false;
+    while (it.next()) |path| {
+        any = true;
+        patch(path) catch |err| {
+            std.debug.print("openbsd_nobtcfi: {s}: {s}\n", .{ path, @errorName(err) });
+            std.process.exit(1);
+        };
+    }
+    if (!any) {
+        std.debug.print("usage: openbsd_nobtcfi <elf-file> [<elf-file>...]\n", .{});
+        std.process.exit(2);
+    }
+}
+
+fn patch(path: [:0]const u8) !void {
+    const fd = try std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .RDWR }, 0);
+    defer _ = std.c.close(fd);
+
+    var ehdr: [64]u8 = undefined;
+    try preadExact(fd, &ehdr, 0);
+    if (!std.mem.eql(u8, ehdr[0..4], "\x7fELF")) return error.NotElf;
+    if (ehdr[4] != 2) return error.NotElf64; // EI_CLASS != ELFCLASS64
+    if (ehdr[5] != 1) return error.NotLittleEndian; // EI_DATA != ELFDATA2LSB — every openbsd target Kaappi builds is LE
+
+    const e_phoff = std.mem.readInt(u64, ehdr[0x20..0x28], .little);
+    const e_phentsize = std.mem.readInt(u16, ehdr[0x36..0x38], .little);
+    const e_phnum = std.mem.readInt(u16, ehdr[0x38..0x3a], .little);
+    if (e_phentsize < 56) return error.BadPhdrEntSize;
+
+    var i: u16 = 0;
+    while (i < e_phnum) : (i += 1) {
+        const off = e_phoff + @as(u64, i) * e_phentsize;
+        var ent: [56]u8 = undefined;
+        try preadExact(fd, &ent, off);
+        const p_type = std.mem.readInt(u32, ent[0..4], .little);
+        if (p_type == PT_OPENBSD_NOBTCFI) return; // idempotent — already marked
+        if (p_type == PT_GNU_STACK) {
+            var repl = [_]u8{0} ** 56;
+            std.mem.writeInt(u32, repl[0..4], PT_OPENBSD_NOBTCFI, .little); // p_type
+            std.mem.writeInt(u32, repl[4..8], PF_X, .little); // p_flags (marker only)
+            try pwriteExact(fd, &repl, off);
+            return;
+        }
+    }
+    return error.NoGnuStackPhdr;
+}
+
+fn preadExact(fd: std.posix.fd_t, buf: []u8, offset: u64) !void {
+    var n: usize = 0;
+    while (n < buf.len) {
+        const r = std.c.pread(fd, buf[n..].ptr, buf.len - n, @intCast(offset + n));
+        if (r < 0) return error.ReadFailed;
+        if (r == 0) return error.UnexpectedEof;
+        n += @intCast(r);
+    }
+}
+
+fn pwriteExact(fd: std.posix.fd_t, buf: []const u8, offset: u64) !void {
+    var n: usize = 0;
+    while (n < buf.len) {
+        const r = std.c.pwrite(fd, buf[n..].ptr, buf.len - n, @intCast(offset + n));
+        if (r < 0) return error.WriteFailed;
+        n += @intCast(r);
+    }
+}


### PR DESCRIPTION
Fifth OS port. OpenBSD (x86_64 + aarch64) is a full-POSIX kqueue platform like FreeBSD, but its security hardening forces two accommodations nothing else in the tree needs — and those were the real work.

## The defining problem: BTCFI

OpenBSD/arm64 enforces Branch Target CFI: every indirect branch must land on a `bti` instruction or the kernel kills the process with `SIGILL`/`ILL_BTCFI`. **Zig 0.16 emits no landing pads** (no `-mbranch-protection`, no `bti` CPU feature), so the binary trapped on its first function-pointer call, before `main` ran. `ktrace`/`kdump` on the box named the exact fault; a two-line C probe (a function-pointer call built with vs. without branch protection) proved it was enforcement, not our bug.

The fix is OpenBSD's own opt-out, `-z nobtcfi` (emits a `PT_OPENBSD_NOBTCFI` program header):

- **`kaappi compile`** adds `-z nobtcfi` to the base-`cc` link directly (`native_compiler.zig`).
- **Zig-linked binaries** — Zig's CLI rejects the flag, so `tools/openbsd_nobtcfi.zig` adds the marker **post-link** by repurposing the ignored `PT_GNU_STACK` header in place (the phdr table butts against `.interp`, so there's no room to append). `build.zig`'s `installExe` compiles that host tool and runs it on each installed executable for OpenBSD targets — so `zig build -Dtarget=<arch>-openbsd` produces **working binaries directly**, no separate patch step, no footgun. The marker survives `strip` (it's a program header), so release binaries get it too.

## Other accommodations

- **Stack** (4 MiB default): kaappi already runs work on a 64 MiB worker thread; kaappi-lsp compiles on the main thread, so both mains call `platform.raiseStackLimitBestEffort()` (setrlimit soft→hard, OpenBSD-only).
- **Data** (1.5 GiB default): only the *unit-test* binary hits it (Zig's `DebugAllocator` never reuses freed address space); CI and the recipe raise `ulimit -d`. Shipped C-allocator binaries never accumulate.
- **Self-exe**: `sysctl KERN_PROC_ARGS`/`KERN_PROC_ARGV` → argv[0] → `realpath` (OpenBSD has no `KERN_PROC_PATHNAME`).
- **3 shared FFI tests**: `abs` is a libc function; OpenBSD's `dlsym` doesn't chain a `dlopen`'d libm handle into libc like other platforms, so `(ffi-fn (ffi-open "libm") "abs" …)` returned `#f`. They now resolve `abs` from the libc/default handle (verified on macOS + OpenBSD; Windows path unchanged), keeping genuine libm functions like `sqrt` in libm.

## Validated on a real OpenBSD 7.9 aarch64 machine

| Suite | Result |
|---|---|
| Unit tests | **1141 / 1141** (deterministic, both hard limits raised) |
| thottam | 1 / 1 |
| R7RS | 1395 / 0 |
| `run-all.sh` | **1869 pass / 0 fail** / 2 skip (`compile/` self-skips without Zig) |
| FFI suite | 14 / 14 |
| `kaappi compile` → native binary | works (base `cc`, `-z nobtcfi`) |
| `kaappi doctor` | 14 pass, 2 warn, 0 fail (smoke-link PASS) |

Native macOS build + `zig build test` stay green (no regression); `zig fmt` clean.

## CI & release

- `openbsd-test` (ci.yml): cross-compiles x86_64-openbsd on ubuntu, marks the test binaries, then executes the suites in a KVM OpenBSD 7.9 VM (`vmactions/openbsd-vm`, SHA-pinned). 7.9 matches the aarch64 reference box — OpenBSD breaks ABI between releases, so the target release and VM release must agree. The first PR run validates the image string.
- `release.yml`: two rows (`x86_64-openbsd`, `aarch64-openbsd`, `strip: true`), auto-marked via `build.zig`.
- `/github-release` skill: platform list + an OpenBSD smoke-test leg on `ssh openbsd`; `install.sh`: `OpenBSD`→`openbsd`, `amd64`→`x86_64`.

New `docs/dev/openbsd.md`; support matrices updated in `porting.md`, `docs/dev/README.md`, `CLAUDE.md`, `README.md`; `CHANGELOG.md` entry.

## Follow-up (separate repo)

The kaappi.github.io download page needs OpenBSD rows in a follow-up (as FreeBSD's was, #18); the `releases/latest/download/*-openbsd` links 404 until the next release ships OpenBSD artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
