### PR TITLE
Add SRFI 263 (Prototype Object System)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,7 +291,7 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 | `tests_*.zig` | Unit tests by feature (core_eval, tail_calls, macros, io, etc.) |
 
 ### SRFI libraries (in `lib/srfi/`)
-72 SRFIs supported. 8 built-in (Zig primitives in `library.zig`): 1, 9, 13, 18, 39, 69, 133, 170. 64 portable R7RS .sld files loaded on demand via `(import (srfi N))`: 0, 2, 4, 6, 8, 11, 14, 16, 17, 19, 23, 26, 27, 28, 31, 34, 35, 36, 37, 38, 41, 42, 43, 45, 48, 60, 61, 64, 78, 87, 98, 111, 113, 115, 116, 117, 125, 127, 128, 130, 132, 134, 141, 143, 144, 145, 146, 151, 152, 158, 166, 174, 175, 189, 195, 196, 197, 210, 219, 222, 227, 232, 233, 235. Sub-libraries: (srfi 146 hash), (srfi 166 pretty), (srfi 166 columnar), (srfi 166 unicode), (srfi 166 color).
+73 SRFIs supported. 8 built-in (Zig primitives in `library.zig`): 1, 9, 13, 18, 39, 69, 133, 170. 65 portable R7RS .sld files loaded on demand via `(import (srfi N))`: 0, 2, 4, 6, 8, 11, 14, 16, 17, 19, 23, 26, 27, 28, 31, 34, 35, 36, 37, 38, 41, 42, 43, 45, 48, 60, 61, 64, 78, 87, 98, 111, 113, 115, 116, 117, 125, 127, 128, 130, 132, 134, 141, 143, 144, 145, 146, 151, 152, 158, 166, 174, 175, 189, 195, 196, 197, 210, 219, 222, 227, 232, 233, 235, 263. Sub-libraries: (srfi 146 hash), (srfi 166 pretty), (srfi 166 columnar), (srfi 166 unicode), (srfi 166 color), (srfi 263 syntax).
 
 The library loader in `vm_library.zig` supports `cond-expand`, `include` (paths resolved relative to the .sld file), and `(export (rename ...))` in `define-library`. Macro transformers defined with `define-syntax` in library `begin` blocks are exported and imported correctly.
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -79,7 +79,7 @@ Uses real OS threads via `std.Thread.spawn`. Each child thread gets its own VM a
 
 ### Portable SRFIs (65 libraries)
 
-Loaded on demand from `.sld` files via `(import (srfi N))`. Sub-libraries: (srfi 146 hash), (srfi 166 pretty), (srfi 166 columnar), (srfi 166 unicode), (srfi 166 color).
+Loaded on demand from `.sld` files via `(import (srfi N))`. Sub-libraries: (srfi 146 hash), (srfi 166 pretty), (srfi 166 columnar), (srfi 166 unicode), (srfi 166 color), (srfi 263 syntax).
 
 | SRFI | Title |
 |------|-------|
@@ -148,3 +148,8 @@ Loaded on demand from `.sld` files via `(import (srfi N))`. Sub-libraries: (srfi
 | 233 | INI files |
 | 235 | Combinators |
 | 263 | Prototype Object System |
+
+SRFI 263 note: `(resend #f ...)` from a method inherited from a *non-immediate*
+ancestor loops, because `resend` restarts the lookup skipping only the original
+receiver — a distinct-origin lookup the finalized SRFI never specified. Resending
+to an explicit target, and resend from a directly-overriding method, both work.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -6,7 +6,7 @@ Kaappi implements every identifier from [R7RS Appendix A](https://small.r7rs.org
 
 ## SRFI conformance
 
-72 SRFIs supported. 8 built-in (native Zig), 64 portable (.sld files). Coverage details for the built-in SRFIs follow.
+73 SRFIs supported. 8 built-in (native Zig), 65 portable (.sld files). Coverage details for the built-in SRFIs follow.
 
 ### SRFI 1 — List Library
 
@@ -77,7 +77,7 @@ Implemented: **Threads** — `current-thread`, `thread?`, `make-thread`, `thread
 
 Uses real OS threads via `std.Thread.spawn`. Each child thread gets its own VM and GC with an independent heap. Values are deep-copied across thread boundaries at start and join.
 
-### Portable SRFIs (64 libraries)
+### Portable SRFIs (65 libraries)
 
 Loaded on demand from `.sld` files via `(import (srfi N))`. Sub-libraries: (srfi 146 hash), (srfi 166 pretty), (srfi 166 columnar), (srfi 166 unicode), (srfi 166 color).
 
@@ -147,3 +147,4 @@ Loaded on demand from `.sld` files via `(import (srfi N))`. Sub-libraries: (srfi
 | 232 | Flexible curried procedures |
 | 233 | INI files |
 | 235 | Combinators |
+| 263 | Prototype Object System |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 Kaappi implements every identifier from [R7RS Appendix A](https://small.r7rs.org/)
 — 614 built-in procedures, 32 syntax forms, and all 14 standard libraries — plus
-72 SRFIs, a C FFI, OS threads and fibers, an LLVM native-code backend, a package
+73 SRFIs, a C FFI, OS threads and fibers, an LLVM native-code backend, a package
 manager, and a stepping debugger. The runtime is a register-based bytecode VM
 with generational garbage collection and stack-copying first-class continuations.
 
@@ -199,7 +199,7 @@ symbols, and **multi-line input** with automatic paren balancing.
 
 ### Beyond the standard
 
-- **72 SRFIs** — 8 built-in, 64 as portable `.sld` libraries (full list in [CONFORMANCE.md](CONFORMANCE.md))
+- **73 SRFIs** — 8 built-in, 65 as portable `.sld` libraries (full list in [CONFORMANCE.md](CONFORMANCE.md))
 - **Native binaries** — `kaappi compile program.scm -o program` compiles Scheme to a native executable via LLVM, with self-tail-calls compiled as loops ([details](docs/dev/llvm-backend.md))
 - **Standalone bundles** — `zig build -Dbundle-src=program.scm` embeds bytecode + libraries in a single executable
 - **C FFI** — call shared libraries from Scheme via `(kaappi ffi)`; 18 marshalled types, callbacks for passing Scheme procedures to C
@@ -453,7 +453,7 @@ R7RS-small and is not implemented.
 
 ### SRFI coverage
 
-72 SRFIs are supported. Some built-in SRFIs have minor coverage gaps (e.g.,
+73 SRFIs are supported. Some built-in SRFIs have minor coverage gaps (e.g.,
 linear-update variants in SRFI-1, `string-xcopy!` in SRFI-13). See
 [CONFORMANCE.md](CONFORMANCE.md) for per-SRFI details.
 

--- a/lib/srfi/263.sld
+++ b/lib/srfi/263.sld
@@ -1,0 +1,342 @@
+;;; SRFI 263: Prototype Object System
+;;;
+;;; A prototype-based object system inspired by Self. Objects are
+;;; represented as closures and communicate through message passing,
+;;; with value slots, method slots, and parent slots for inheritance,
+;;; plus a mirror interface for reflection.
+;;;
+;;; Ported to Kaappi from the reference implementation by Daniel Ziltener.
+;;; Deviations from the reference, each marked "Kaappi:" at its call site:
+;;;
+;;;   Portability
+;;;   * The CHICKEN-style private symbol `##srfi-263#obj-data` is written
+;;;     with R7RS bar-quoting as |##srfi-263#obj-data|.
+;;;   * The duplicate (dead) definition of `recursive-lookup` is dropped;
+;;;     only the second, deduplicating one is kept.
+;;;   * The root 'derive method returns a single value instead of relying on
+;;;     CHICKEN truncating (values obj data) in a single-value context.
+;;;
+;;;   Spec-conformance bug fixes (untested by the reference test suite)
+;;;   * copy: use the mirror's real 'immediate-* reflection messages (the
+;;;     reference sends nonexistent 'get-* messages and crashes), and
+;;;     re-install 'mirror over the copy's own data so it is independent of
+;;;     the original (the reference copy's methods captured the original).
+;;;   * message-not-understood / ambiguous-message-send: re-dispatch as a
+;;;     message to the receiver so custom handler slots can intercept, per
+;;;     the SRFI; the reference applies the bare symbol and cannot override.
+;;;
+;;; SPDX-FileCopyrightText: 2026 Daniel Ziltener
+;;; SPDX-License-Identifier: MIT
+
+(define-library (srfi 263)
+  (import (scheme base)
+          (scheme case-lambda)
+          (scheme cxr)
+          (srfi 1))
+  (export *the-root-object*
+          slot?
+          slot-getter
+          slot-setter
+          slot-type)
+  (begin
+
+    ;;; Core system
+
+    (define-record-type slot
+      (make-slot getter setter type)
+      slot?
+      (getter slot-getter)
+      (setter slot-setter)
+      (type slot-type))
+
+    (define (delete-slot! obj-data slot)
+      (let* ((message-alist (get-message-alist obj-data))
+             (slot-list (get-slot-list obj-data))
+             (parent-list (get-parent-list obj-data))
+             (setter-predicate (lambda (item) (eq? (slot-setter item) slot)))
+             (is-setter? (find setter-predicate slot-list))
+             (slot-predicate (lambda (item)
+                               (or (eq? (slot-getter item) slot)
+                                  (eq? (slot-setter item) slot))))
+             (slots (filter slot-predicate slot-list)))
+        (if (= 1 (length slots))
+            (let ((slot (car slots)))
+              (if (eq? 'parent (slot-type slot))
+                  (set-parent-list! obj-data
+                                    (delete
+                                     ((cdr (assq (slot-getter slot) message-alist)) #f #f)
+                                     parent-list)))
+              (set-message-alist!
+               obj-data
+               (if is-setter?
+                   (alist-delete (slot-setter slot) message-alist)
+                   (alist-delete (slot-getter slot)
+                                 (alist-delete (slot-setter slot) message-alist))))
+              (set-slot-list!
+               obj-data
+               (if is-setter?
+                   (map (lambda (item)
+                          (if (setter-predicate item)
+                              (make-slot (slot-getter item) #f (slot-type item))
+                              item))
+                        slot-list)
+                   (remove slot-predicate slot-list)))))))
+
+    (define (slot-add-message-name type)
+      (case type
+        ((value) 'set-value-slot!)
+        ((method) 'set-method-slot!)
+        ((parent) 'set-parent-slot!)))
+
+    (define (gen-accessors type getter-name setter-name value)
+      (values
+       (case type
+         ((value) (lambda (self resend) value))
+         ((method) value)
+         ((parent) (lambda (self resend) value)))
+       (if setter-name
+           (lambda (self resend value)
+             (apply self (slot-add-message-name type) getter-name
+                    (if setter-name (list setter-name value) value)))
+           #f)))
+
+    (define (set-object-data-slots! obj-data type getter-name getter setter-name setter)
+      (let ((new-messages (if setter
+                              `((,getter-name . ,getter)
+                                (,setter-name . ,setter))
+                              `((,getter-name . ,getter)))))
+        (set-message-alist!
+         obj-data (append new-messages (get-message-alist obj-data)))
+        (set-slot-list!
+         obj-data (cons (make-slot getter-name setter-name type) (get-slot-list obj-data)))))
+
+    (define (set-slot! obj-data type getter-name . args)
+      (let* ((setter? (< 1 (length args)))
+             (setter-name (and setter? (car args)))
+             (value (if setter? (cadr args) (car args))))
+        (let-values (((getter setter)
+                      (gen-accessors type getter-name setter-name value)))
+          (delete-slot! obj-data getter-name)
+          (set-object-data-slots! obj-data type getter-name getter setter-name setter)
+          (when (eq? type 'parent)
+            (set-parent-list!
+             obj-data (cons value (get-parent-list obj-data)))))))
+
+    (define (method-finder name message-alist)
+      (letrec ((mfinder
+                (lambda (self)
+                  (cond ((or
+                          (assq name message-alist)
+                          (assq name (get-message-alist ((self 'mirror) '|##srfi-263#obj-data|))))
+                         => cdr)
+                        (else #f)))))
+        mfinder))
+
+    (define (recursive-lookup self checker skip?)
+      (cond
+       ((and (not skip?) (checker self))
+        => (lambda (alist-entry)
+             (values alist-entry #t)))
+       (else
+        (let ((obj-data ((self 'mirror) '|##srfi-263#obj-data|)))
+          (let loop ((parents (get-parent-list obj-data))
+                     (handlers '())
+                     (handler #f)
+                     (found #f))
+            (cond
+             ((not (null? parents))
+              (let-values (((new-handler new-found)
+                            (recursive-lookup (car parents) checker #f)))
+                (loop (cdr parents)
+                      (if new-found (lset-adjoin eq? handlers new-handler) handlers)
+                      (if new-found new-handler handler)
+                      (or new-found found))))
+             (else
+              (if handler
+                  (if (= 1 (length handlers))
+                      (values handler found)
+                      (values 'ambiguous-message-send #f))
+                  (values 'message-not-understood #f)))))))))
+
+    (define (recursive-ancestor-collector self)
+      (let ((parents (get-parent-list ((self 'mirror) '|##srfi-263#obj-data|))))
+        (if (null? parents)
+            (list self)
+            (apply lset-union
+                   eq?
+                   parents
+                   (map recursive-ancestor-collector parents)))))
+
+    (define (recursive-slot-collector self)
+      (let ((parents (recursive-ancestor-collector self)))
+        (apply lset-union
+               (lambda (a b)
+                 (eq? (car a) (car b)))
+               (list)
+               (map (lambda (class)
+                      (get-slot-list ((class 'mirror) '|##srfi-263#obj-data|)))
+                    parents))))
+
+    ;;;; Method running
+
+    (define (send-with-error-handling caller method-lookup method-name message-alist parents-only args)
+      (let-values (((method found?)
+                    (recursive-lookup
+                     method-lookup
+                     (method-finder method-name message-alist)
+                     parents-only)))
+        (if found?
+            (apply method caller (make-resender caller method-name) args)
+            ;; Kaappi: when the message is not found, `method` is the symbol
+            ;; 'message-not-understood or 'ambiguous-message-send. Per SRFI 263,
+            ;; "the original message receiving object is sent a
+            ;; message-not-understood message" — so re-dispatch it as a message
+            ;; to `caller`, letting a custom handler slot intercept it. The
+            ;; reference applies the bare symbol instead (an error only by
+            ;; accident of it not being a procedure), which defeats overriding.
+            (caller method method-name args))))
+
+    (define (make-resender caller handler-name)
+      (lambda (target-override . args)
+        (let ((target (cond
+                       ((eq? #f target-override)
+                        caller)
+                       (else target-override))))
+          (send-with-error-handling caller target handler-name '() (eq? target-override #f) args))))
+
+    ;;;; Root object
+
+    (define-record-type object-data
+      (make-object-data* message-alist slot-list parent-list)
+      object-data?
+      (message-alist get-message-alist set-message-alist!)
+      (slot-list get-slot-list set-slot-list!)
+      (parent-list get-parent-list set-parent-list!))
+
+    (define (make-object-data)
+      (make-object-data* '() '() '()))
+
+    (define (*object* obj-data)
+      (letrec
+          ((obj-handler
+            (lambda (message . args)
+              (send-with-error-handling
+               obj-handler obj-handler message (get-message-alist obj-data) #f args))))
+        obj-handler))
+
+    (define (set-method-slot! obj-data name . args)
+      (apply set-slot! obj-data 'method name args))
+
+    (define (derive-object obj mirror?)
+      (let* ((obj-data (make-object-data))
+             (derived-object (*object* obj-data)))
+        (set-slot! obj-data 'parent 'parent obj)
+        (set-method-slot!
+         obj-data 'mirror
+         (lambda (self resend)
+           (let-values (((new-mirror new-mirror-data)
+                         (derive-object (obj 'mirror) #t)))
+             (populate-mirror new-mirror new-mirror-data obj-data))))
+        (when mirror?
+          (set-method-slot! obj-data 'derive
+                            (lambda (self resend)
+                              (let-values (((new-obj new-data)
+                                            (derive-object self #t)))
+                                new-obj))))
+        (values derived-object obj-data)))
+
+    (define (populate-mirror mirror mirror-data obj-data)
+      (map
+       (lambda (name proc)
+         (set-method-slot! mirror-data name proc))
+       '(|##srfi-263#obj-data| immediate-message-alist
+                    immediate-ancestor-list full-ancestor-list
+                    immediate-slot-list full-slot-list)
+       (list (lambda (self resend) obj-data)
+             (lambda (self resend) (list-copy (get-message-alist obj-data)))
+             (lambda (self resend) (list-copy (get-parent-list obj-data)))
+             (lambda (self resend) (recursive-ancestor-collector self))
+             (lambda (self resend) (list-copy (get-slot-list obj-data)))
+             (lambda (self resend) (recursive-slot-collector self))))
+      mirror)
+
+    (define *the-root-object*
+      (let* ((obj-data (make-object-data))
+             (object (*object* obj-data)))
+        (set-message-alist!
+         obj-data
+         (alist-cons 'set-method-slot!
+                     (lambda (self resend name . args)
+                       (apply set-method-slot! ((self 'mirror) '|##srfi-263#obj-data|)
+                              name args))
+                     (get-message-alist obj-data)))
+        (set-slot-list!
+         obj-data
+         (append (list (make-slot set-method-slot! #f 'method)) (get-slot-list obj-data)))
+        (set-method-slot!
+         obj-data 'mirror
+         (lambda (self resend)
+           (let-values (((root-mirror mirror-data) (derive-object *the-root-object* #t)))
+             (populate-mirror root-mirror mirror-data obj-data))))
+        (set-method-slot!
+         obj-data 'derive
+         (lambda (self resend)
+           ;; Kaappi: return a single value. The reference returns
+           ;; (derive-object self #f) directly (two values) and relies on
+           ;; CHICKEN truncating to the first in a single-value context;
+           ;; R7RS leaves that unspecified, so match the single-value
+           ;; pattern the derived-object 'derive method already uses.
+           (let-values (((new-obj new-data) (derive-object self #f)))
+             new-obj)))
+        (set-method-slot!
+         obj-data 'copy
+         (lambda (self resend)
+           ;; Kaappi: the reference sends the mirror 'get-message-alist,
+           ;; 'get-slot-list and 'get-parent-list — messages no mirror
+           ;; understands (they crash with "message not understood"), which is
+           ;; why the reference test suite never exercises copy. The mirror
+           ;; actually exposes the receiver's own definitions as
+           ;; 'immediate-message-alist / 'immediate-slot-list /
+           ;; 'immediate-ancestor-list, so use those to duplicate them.
+           (let ((mirror (self 'mirror))
+                 (new-data (make-object-data)))
+             (set-message-alist! new-data (list-copy (mirror 'immediate-message-alist)))
+             (set-slot-list! new-data (list-copy (mirror 'immediate-slot-list)))
+             (set-parent-list! new-data (list-copy (mirror 'immediate-ancestor-list)))
+             ;; Kaappi: the copied 'mirror method still closes over the
+             ;; ORIGINAL's object-data, so set-value-slot!/set-parent-slot! on
+             ;; the copy would mutate the original (copies were never
+             ;; independent in the reference). Re-install 'mirror over the
+             ;; copy's own object-data, mirroring derive-object's setup and
+             ;; chaining through the primary parent's mirror.
+             (let ((parents (get-parent-list new-data)))
+               (unless (null? parents)
+                 (let ((primary-parent (car parents)))
+                   (set-method-slot!
+                    new-data 'mirror
+                    (lambda (self resend)
+                      (let-values (((new-mirror new-mirror-data)
+                                    (derive-object (primary-parent 'mirror) #t)))
+                        (populate-mirror new-mirror new-mirror-data new-data)))))))
+             (*object* new-data))))
+        (set-method-slot!
+         obj-data 'delete-slot!
+         (lambda (self resend name)
+           (delete-slot! ((self 'mirror) '|##srfi-263#obj-data|) name)))
+        (set-method-slot!
+         obj-data 'set-value-slot!
+         (lambda (self resend name . args)
+           (apply set-slot! ((self 'mirror) '|##srfi-263#obj-data|) 'value name args)))
+        (set-method-slot!
+         obj-data 'set-parent-slot!
+         (lambda (self resend name . args)
+           (apply set-slot! ((self 'mirror) '|##srfi-263#obj-data|) 'parent name args)))
+        (set-method-slot!
+         obj-data 'message-not-understood
+         (lambda (self resend message args)
+           (error "Message not understood" self message args)))
+        (set-method-slot!
+         obj-data 'ambiguous-message-send
+         (lambda (self resend message args)
+           (error "Message ambiguous" self message args)))
+        object))))

--- a/lib/srfi/263.sld
+++ b/lib/srfi/263.sld
@@ -18,12 +18,27 @@
 ;;;
 ;;;   Spec-conformance bug fixes (untested by the reference test suite)
 ;;;   * copy: use the mirror's real 'immediate-* reflection messages (the
-;;;     reference sends nonexistent 'get-* messages and crashes), and
+;;;     reference sends nonexistent 'get-* messages and crashes), and always
 ;;;     re-install 'mirror over the copy's own data so it is independent of
-;;;     the original (the reference copy's methods captured the original).
+;;;     the original — including a copy of the parentless root object.
 ;;;   * message-not-understood / ambiguous-message-send: re-dispatch as a
 ;;;     message to the receiver so custom handler slots can intercept, per
 ;;;     the SRFI; the reference applies the bare symbol and cannot override.
+;;;   * Reflection: the mirror's full-ancestor-list / full-slot-list are
+;;;     driven from the mirrored object, not the mirror receiver, so they
+;;;     return the real ancestors/slots (and the receiver's own slots);
+;;;     full-slot-list dedups by getter name (slot is a record, not a pair);
+;;;     the root's set-method-slot! slot records the message name, not the
+;;;     procedure; and the SRFI's has-ancestor mirror message is provided.
+;;;
+;;;   Known limitation (a gap in the finalized SRFI itself, not fixed here)
+;;;   * (resend #f ...) from a method inherited from a non-immediate ancestor
+;;;     loops: resend restarts the lookup skipping only the original receiver,
+;;;     so it re-finds the same ancestor method. A correct fix needs a
+;;;     distinct-origin lookup the SRFI never specified. Resending to an
+;;;     explicit target, and resend from a directly-overriding method, both
+;;;     work. Likewise, ambiguity is detected per distinct procedure, so two
+;;;     parents sharing one procedure object are not flagged ambiguous.
 ;;;
 ;;; SPDX-FileCopyrightText: 2026 Daniel Ziltener
 ;;; SPDX-License-Identifier: MIT
@@ -158,24 +173,30 @@
                       (values 'ambiguous-message-send #f))
                   (values 'message-not-understood #f)))))))))
 
+    ;; Kaappi: collect self plus every ancestor, deduplicated. The reference
+    ;; only includes `self` in the no-parents base case, so full-ancestor-list
+    ;; on a non-root object dropped the object itself; folding (list self) into
+    ;; the union restores the self+ancestors result the reference test expects.
     (define (recursive-ancestor-collector self)
       (let ((parents (get-parent-list ((self 'mirror) '|##srfi-263#obj-data|))))
-        (if (null? parents)
-            (list self)
-            (apply lset-union
-                   eq?
-                   parents
-                   (map recursive-ancestor-collector parents)))))
+        (apply lset-union
+               eq?
+               (list self)
+               (map recursive-ancestor-collector parents))))
 
     (define (recursive-slot-collector self)
-      (let ((parents (recursive-ancestor-collector self)))
+      (let ((classes (recursive-ancestor-collector self)))
         (apply lset-union
+               ;; Kaappi: dedup by getter name. `slot` is a record, not a
+               ;; pair — the reference's (car a) errors once two slot lists
+               ;; are unioned. recursive-ancestor-collector now includes self,
+               ;; so the receiver's own slots are part of full-slot-list.
                (lambda (a b)
-                 (eq? (car a) (car b)))
+                 (eq? (slot-getter a) (slot-getter b)))
                (list)
                (map (lambda (class)
                       (get-slot-list ((class 'mirror) '|##srfi-263#obj-data|)))
-                    parents))))
+                    classes))))
 
     ;;;; Method running
 
@@ -236,7 +257,7 @@
          (lambda (self resend)
            (let-values (((new-mirror new-mirror-data)
                          (derive-object (obj 'mirror) #t)))
-             (populate-mirror new-mirror new-mirror-data obj-data))))
+             (populate-mirror new-mirror new-mirror-data self obj-data))))
         (when mirror?
           (set-method-slot! obj-data 'derive
                             (lambda (self resend)
@@ -245,19 +266,28 @@
                                 new-obj))))
         (values derived-object obj-data)))
 
-    (define (populate-mirror mirror mirror-data obj-data)
+    ;; Kaappi: `owner` is the object being mirrored. The reference passes the
+    ;; mirror receiver (`self`) to the recursive collectors, so full-ancestor-
+    ;; list / full-slot-list walked the parallel mirror hierarchy and returned
+    ;; mirror objects instead of the real ancestors; drive them from `owner`
+    ;; instead. Also installs `has-ancestor`, a mirror message the SRFI lists
+    ;; but the reference omits.
+    (define (populate-mirror mirror mirror-data owner obj-data)
       (map
        (lambda (name proc)
          (set-method-slot! mirror-data name proc))
        '(|##srfi-263#obj-data| immediate-message-alist
                     immediate-ancestor-list full-ancestor-list
-                    immediate-slot-list full-slot-list)
+                    immediate-slot-list full-slot-list has-ancestor)
        (list (lambda (self resend) obj-data)
              (lambda (self resend) (list-copy (get-message-alist obj-data)))
              (lambda (self resend) (list-copy (get-parent-list obj-data)))
-             (lambda (self resend) (recursive-ancestor-collector self))
+             (lambda (self resend) (recursive-ancestor-collector owner))
              (lambda (self resend) (list-copy (get-slot-list obj-data)))
-             (lambda (self resend) (recursive-slot-collector self))))
+             (lambda (self resend) (recursive-slot-collector owner))
+             (lambda (self resend candidate)
+               (and (not (eq? candidate owner))
+                    (and (memq candidate (recursive-ancestor-collector owner)) #t)))))
       mirror)
 
     (define *the-root-object*
@@ -272,12 +302,16 @@
                      (get-message-alist obj-data)))
         (set-slot-list!
          obj-data
-         (append (list (make-slot set-method-slot! #f 'method)) (get-slot-list obj-data)))
+         ;; Kaappi: quote the getter name. The reference stores the
+         ;; set-method-slot! procedure here, so reflection returned a
+         ;; procedure instead of the 'set-method-slot! message name and
+         ;; deletion by that name could not match it.
+         (append (list (make-slot 'set-method-slot! #f 'method)) (get-slot-list obj-data)))
         (set-method-slot!
          obj-data 'mirror
          (lambda (self resend)
            (let-values (((root-mirror mirror-data) (derive-object *the-root-object* #t)))
-             (populate-mirror root-mirror mirror-data obj-data))))
+             (populate-mirror root-mirror mirror-data self obj-data))))
         (set-method-slot!
          obj-data 'derive
          (lambda (self resend)
@@ -306,18 +340,20 @@
              ;; Kaappi: the copied 'mirror method still closes over the
              ;; ORIGINAL's object-data, so set-value-slot!/set-parent-slot! on
              ;; the copy would mutate the original (copies were never
-             ;; independent in the reference). Re-install 'mirror over the
-             ;; copy's own object-data, mirroring derive-object's setup and
-             ;; chaining through the primary parent's mirror.
-             (let ((parents (get-parent-list new-data)))
-               (unless (null? parents)
-                 (let ((primary-parent (car parents)))
-                   (set-method-slot!
-                    new-data 'mirror
-                    (lambda (self resend)
-                      (let-values (((new-mirror new-mirror-data)
-                                    (derive-object (primary-parent 'mirror) #t)))
-                        (populate-mirror new-mirror new-mirror-data new-data)))))))
+             ;; independent in the reference). Always re-install 'mirror over
+             ;; the copy's own object-data — including when the copy has no
+             ;; parents (a copy of *the-root-object*), which otherwise keeps
+             ;; the original's mirror and mutates the global root. Chain the
+             ;; mirror through the primary parent, or the root object itself
+             ;; when the copy is parentless.
+             (let* ((parents (get-parent-list new-data))
+                    (mirror-base (if (null? parents) *the-root-object* (car parents))))
+               (set-method-slot!
+                new-data 'mirror
+                (lambda (self resend)
+                  (let-values (((new-mirror new-mirror-data)
+                                (derive-object (mirror-base 'mirror) #t)))
+                    (populate-mirror new-mirror new-mirror-data self new-data)))))
              (*object* new-data))))
         (set-method-slot!
          obj-data 'delete-slot!

--- a/lib/srfi/263/syntax.sld
+++ b/lib/srfi/263/syntax.sld
@@ -1,11 +1,15 @@
 ;;; SRFI 263: Prototype Object System — syntactic sugar
 ;;;
 ;;; Convenience macros over the (srfi 263) message-passing protocol:
-;;; set-method!, derive-object, copy-object, and define-object.
+;;; define-method, derive-object, copy-object, and define-object.
 ;;;
 ;;; Ported to Kaappi from the reference implementation by Daniel Ziltener.
-;;; Kaappi change: the CHICKEN `(void)` in the empty-slots base case is
-;;; written as the R7RS unspecified value (if #f #f).
+;;; Kaappi changes:
+;;;   * The method macro is exported as `define-method`, the name the SRFI 263
+;;;     document specifies. The reference implementation names it `set-method!`;
+;;;     that name is kept as an alias for reference-implementation compatibility.
+;;;   * The CHICKEN `(void)` in the empty-slots base case is written as the
+;;;     R7RS unspecified value (if #f #f).
 ;;;
 ;;; SPDX-FileCopyrightText: 2026 Daniel Ziltener
 ;;; SPDX-License-Identifier: MIT
@@ -13,19 +17,28 @@
 (define-library (srfi 263 syntax)
   (import (scheme base)
           (srfi 263))
-  (export set-method!
+  (export define-method
+          set-method!
           derive-object
           copy-object
           define-object)
   (begin
 
-    (define-syntax set-method!
+    (define-syntax define-method
       (syntax-rules ()
         ((_ (obj message self resend args ...)
             body1 body ...)
          (obj 'set-method-slot! `message
               (lambda (self resend args ...)
                 body1 body ...)))))
+
+    ;; Reference-implementation alias for define-method.
+    (define-syntax set-method!
+      (syntax-rules ()
+        ((_ (obj message self resend args ...)
+            body1 body ...)
+         (define-method (obj message self resend args ...)
+           body1 body ...))))
 
     (define-syntax derive-object
       (syntax-rules ()

--- a/lib/srfi/263/syntax.sld
+++ b/lib/srfi/263/syntax.sld
@@ -1,0 +1,75 @@
+;;; SRFI 263: Prototype Object System — syntactic sugar
+;;;
+;;; Convenience macros over the (srfi 263) message-passing protocol:
+;;; set-method!, derive-object, copy-object, and define-object.
+;;;
+;;; Ported to Kaappi from the reference implementation by Daniel Ziltener.
+;;; Kaappi change: the CHICKEN `(void)` in the empty-slots base case is
+;;; written as the R7RS unspecified value (if #f #f).
+;;;
+;;; SPDX-FileCopyrightText: 2026 Daniel Ziltener
+;;; SPDX-License-Identifier: MIT
+
+(define-library (srfi 263 syntax)
+  (import (scheme base)
+          (srfi 263))
+  (export set-method!
+          derive-object
+          copy-object
+          define-object)
+  (begin
+
+    (define-syntax set-method!
+      (syntax-rules ()
+        ((_ (obj message self resend args ...)
+            body1 body ...)
+         (obj 'set-method-slot! `message
+              (lambda (self resend args ...)
+                body1 body ...)))))
+
+    (define-syntax derive-object
+      (syntax-rules ()
+        ((_ (creation-parent (parent-name parent-object) ...)
+            slots ...)
+         (let ((o (creation-parent 'derive)))
+           (o 'set-parent-slot! 'parent-name parent-object)
+           ...
+           (derive-object/add-slots! o slots ...)
+           o))))
+
+    (define-syntax copy-object
+      (syntax-rules ()
+        ((_ (creation-parent (parent-name parent-object) ...)
+            slots ...)
+         (let ((o (creation-parent 'copy)))
+           (o 'set-parent-slot! 'parent-name parent-object)
+           ...
+           (derive-object/add-slots! o slots ...)
+           o))))
+
+    (define-syntax derive-object/add-slots!
+      (syntax-rules ()
+        ((_ o)
+         (if #f #f))
+        ((_ o ((method-name . method-args) body ...)
+            slots ...)
+         (begin
+           (o 'set-method-slot! `method-name (lambda method-args
+                                               body ...))
+           (derive-object/add-slots! o slots ...)))
+        ((_ o (slot-getter slot-setter slot-value)
+            slots ...)
+         (begin
+           (o 'set-value-slot! `slot-getter `slot-setter slot-value)
+           (derive-object/add-slots! o slots ...)))
+        ((_ o (slot-getter slot-value)
+            slots ...)
+         (begin
+           (o 'set-value-slot! `slot-getter slot-value)
+           (derive-object/add-slots! o slots ...)))))
+
+    (define-syntax define-object
+      (syntax-rules ()
+        ((_ name body ...)
+         (define name
+           (derive-object body ...)))))))

--- a/tests/scheme/srfi/srfi263.scm
+++ b/tests/scheme/srfi/srfi263.scm
@@ -1,29 +1,19 @@
 ;;; SRFI 263 (Prototype Object System) conformance tests.
 ;;;
-;;; Ports the reference implementation's test suite and adds coverage for
-;;; the reflection procedures, working copy/copy-object, custom
-;;; message-not-understood handlers, and the (srfi 263 syntax) macros.
+;;; Ports the reference implementation's test suite and adds coverage for the
+;;; reflection procedures and mirror messages, working copy/copy-object,
+;;; custom message-not-understood handlers, resend, private (non-symbol)
+;;; selectors, and the (srfi 263 syntax) macros.
 
 (import (scheme base)
+        (scheme process-context)
         (scheme write)
         (srfi 1)
+        (srfi 64)
         (srfi 263)
         (srfi 263 syntax))
 
-(define pass 0)
-(define fail 0)
-
-(define (check name got expected)
-  (if (equal? got expected)
-      (set! pass (+ pass 1))
-      (begin
-        (set! fail (+ fail 1))
-        (display "FAIL: ") (display name)
-        (display " expected ") (write expected)
-        (display " got ") (write got)
-        (newline))))
-
-(define (check-true name got) (check name (and got #t) #t))
+(test-begin "srfi-263")
 
 ;; #t if THUNK raises (used for message-not-understood / ambiguity).
 (define (raises? thunk)
@@ -37,42 +27,42 @@
 ;;; Basic functionality (ported from the reference test suite)
 ;;; --------------------------------------------------------------------
 
-(check-true "root has no ancestors"
-            (null? ((*the-root-object* 'mirror) 'immediate-ancestor-list)))
-(check "root exposes 9 messages"
-       (length ((*the-root-object* 'mirror) 'immediate-message-alist)) 9)
+(test-assert "root has no ancestors"
+             (null? ((*the-root-object* 'mirror) 'immediate-ancestor-list)))
+(test-equal "root exposes 9 messages"
+            9 (length ((*the-root-object* 'mirror) 'immediate-message-alist)))
 
 (let ((class (*the-root-object* 'derive)))
-  (check-true "derived object's ancestor is the root"
-              (eq? *the-root-object*
-                   (car ((class 'mirror) 'immediate-ancestor-list))))
+  (test-assert "derived object's ancestor is the root"
+               (eq? *the-root-object*
+                    (car ((class 'mirror) 'immediate-ancestor-list))))
 
   (class 'set-method-slot! 'testmethod (lambda (self resend) 'success))
-  (check "method slot returns its value" (class 'testmethod) 'success)
+  (test-equal "method slot returns its value" 'success (class 'testmethod))
 
   (class 'set-value-slot! 'val 'set-val! 10)
-  (check "value slot getter" (class 'val) 10)
+  (test-equal "value slot getter" 10 (class 'val))
   (class 'set-val! 20)
-  (check "value slot after setter" (class 'val) 20)
-  (check "getter+setter add two messages"
-         (length ((class 'mirror) 'immediate-message-alist)) 5)
+  (test-equal "value slot after setter" 20 (class 'val))
+  (test-equal "getter+setter add two messages"
+              5 (length ((class 'mirror) 'immediate-message-alist)))
 
   (class 'set-value-slot! 'val 40)
-  (check "value slot with no setter" (class 'val) 40)
-  (check "redefining as getter-only drops the old setter"
-         (length ((class 'mirror) 'immediate-message-alist)) 4)
+  (test-equal "value slot with no setter" 40 (class 'val))
+  (test-equal "redefining as getter-only drops the old setter"
+              4 (length ((class 'mirror) 'immediate-message-alist)))
 
   ;; Deleting the setter keeps the getter.
   (class 'set-value-slot! 'val 'set-val! 10)
   (class 'delete-slot! 'set-val!)
-  (check "deleting the setter keeps the getter"
-         (length ((class 'mirror) 'immediate-message-alist)) 4)
+  (test-equal "deleting the setter keeps the getter"
+              4 (length ((class 'mirror) 'immediate-message-alist)))
 
   ;; Deleting the getter also deletes the setter.
   (class 'set-value-slot! 'val 'set-val! 10)
   (class 'delete-slot! 'val)
-  (check "deleting the getter also deletes the setter"
-         (length ((class 'mirror) 'immediate-message-alist)) 3))
+  (test-equal "deleting the getter also deletes the setter"
+              3 (length ((class 'mirror) 'immediate-message-alist))))
 
 ;;; --------------------------------------------------------------------
 ;;; Inheritance
@@ -81,24 +71,47 @@
 (let* ((firstlevel (*the-root-object* 'derive))
        (secondlevel (firstlevel 'derive)))
   (firstlevel 'set-method-slot! 'testmethod (lambda (self resend) 'success))
-  (check "method is inherited" (secondlevel 'testmethod) 'success)
+  (test-equal "method is inherited" 'success (secondlevel 'testmethod))
 
   (firstlevel 'set-value-slot! 'val 'set-val! 10)
-  (check "value is inherited" (secondlevel 'val) 10)
+  (test-equal "value is inherited" 10 (secondlevel 'val))
 
   ;; Setting through an inherited setter copies the slot onto the child.
   (secondlevel 'set-val! 20)
-  (check "parent value unchanged after child set" (firstlevel 'val) 10)
-  (check "child gets its own value" (secondlevel 'val) 20)
+  (test-equal "parent value unchanged after child set" 10 (firstlevel 'val))
+  (test-equal "child gets its own value" 20 (secondlevel 'val))
 
   (firstlevel 'set-value-slot! 'val #f 30)
-  (check "parent value can be changed independently" (firstlevel 'val) 30)
-  (check "child keeps its own value" (secondlevel 'val) 20)
+  (test-equal "parent value can be changed independently" 30 (firstlevel 'val))
+  (test-equal "child keeps its own value" 20 (secondlevel 'val))
 
-  (check "firstlevel full ancestry (self + root)"
-         (length ((firstlevel 'mirror) 'full-ancestor-list)) 2)
-  (check "secondlevel full ancestry (self + parent + root)"
-         (length ((secondlevel 'mirror) 'full-ancestor-list)) 3))
+  (test-equal "firstlevel full ancestry (self + root)"
+              2 (length ((firstlevel 'mirror) 'full-ancestor-list)))
+  (test-equal "secondlevel full ancestry (self + parent + root)"
+              3 (length ((secondlevel 'mirror) 'full-ancestor-list)))
+
+  ;; full-ancestor-list and has-ancestor return / test the real objects.
+  (test-assert "full-ancestor-list contains the real parent"
+               (and (memq firstlevel
+                          ((secondlevel 'mirror) 'full-ancestor-list)) #t))
+  (test-assert "has-ancestor is true for a real ancestor"
+               ((secondlevel 'mirror) 'has-ancestor firstlevel))
+  (test-assert "has-ancestor is false for self"
+               (not ((secondlevel 'mirror) 'has-ancestor secondlevel)))
+  (test-assert "has-ancestor is false for an unrelated object"
+               (not ((secondlevel 'mirror) 'has-ancestor
+                     (*the-root-object* 'derive)))))
+
+;;; --------------------------------------------------------------------
+;;; resend: to super from an overriding method, and to an explicit target
+;;; --------------------------------------------------------------------
+
+(let* ((base (*the-root-object* 'derive))
+       (sub (base 'derive)))
+  (base 'set-method-slot! 'name (lambda (self resend) 'base))
+  (sub 'set-method-slot! 'name (lambda (self resend) (list 'sub (resend #f))))
+  (test-equal "resend #f from an overriding method reaches the parent"
+              '(sub base) (sub 'name)))
 
 ;;; --------------------------------------------------------------------
 ;;; Multiple inheritance, message-not-understood and ambiguity
@@ -113,24 +126,24 @@
                (lambda (self resend val) (* val val)))
   (mathclass 'set-parent-slot! 'adder adderclass)
 
-  (check "adder method" (adderclass 'inc 9) 10)
-  (check "square method" (squareclass 'square 3) 9)
-  (check "method inherited across a second parent" (mathclass 'inc 8) 9)
+  (test-equal "adder method" 10 (adderclass 'inc 9))
+  (test-equal "square method" 9 (squareclass 'square 3))
+  (test-equal "method inherited across a second parent" 9 (mathclass 'inc 8))
 
-  (check-true "unknown message signals an error"
-              (raises? (lambda () (adderclass 'nope 10))))
+  (test-assert "unknown message signals an error"
+               (raises? (lambda () (adderclass 'nope 10))))
 
   ;; Both parents define 'reset -> ambiguous.
   (adderclass 'set-method-slot! 'reset (lambda (self resend x) 5))
   (squareclass 'set-method-slot! 'reset (lambda (self resend x) 5))
-  (check-true "ambiguous message signals an error"
-              (raises? (lambda () (mathclass 'reset 1))))
+  (test-assert "ambiguous message signals an error"
+               (raises? (lambda () (mathclass 'reset 1))))
 
-  (check "two immediate parents"
-         (length ((mathclass 'mirror) 'immediate-ancestor-list)) 2)
+  (test-equal "two immediate parents"
+              2 (length ((mathclass 'mirror) 'immediate-ancestor-list)))
   (mathclass 'delete-slot! 'adder)
-  (check "deleting a parent slot removes the ancestor"
-         (length ((mathclass 'mirror) 'immediate-ancestor-list)) 1))
+  (test-equal "deleting a parent slot removes the ancestor"
+              1 (length ((mathclass 'mirror) 'immediate-ancestor-list))))
 
 ;;; --------------------------------------------------------------------
 ;;; Custom message-not-understood handler (SRFI-mandated, overridable)
@@ -139,11 +152,23 @@
 (let ((obj (*the-root-object* 'derive)))
   (obj 'set-method-slot! 'message-not-understood
        (lambda (self resend message args) (list 'dnu message args)))
-  (check "custom message-not-understood intercepts unknown messages"
-         (obj 'whatever 1 2) '(dnu whatever (1 2))))
+  (test-equal "custom message-not-understood intercepts unknown messages"
+              '(dnu whatever (1 2)) (obj 'whatever 1 2)))
 
 ;;; --------------------------------------------------------------------
-;;; Slot reflection: slot?, slot-getter, slot-setter, slot-type
+;;; Private messages: unforgeable non-symbol selectors
+;;; --------------------------------------------------------------------
+
+(let ((obj (*the-root-object* 'derive))
+      (secret (list 'unforgeable)))
+  (obj 'set-method-slot! secret (lambda (self resend) 'private-hit))
+  (test-equal "dispatch on a non-symbol (unforgeable) selector"
+              'private-hit (obj secret))
+  (test-assert "the private selector is not reachable as a symbol"
+               (raises? (lambda () (obj 'unforgeable)))))
+
+;;; --------------------------------------------------------------------
+;;; Slot reflection: slot?, slot-getter, slot-setter, slot-type; full-slot-list
 ;;; --------------------------------------------------------------------
 
 (let ((cls (*the-root-object* 'derive)))
@@ -153,35 +178,49 @@
          (foo (find (lambda (s) (eq? (slot-getter s) 'foo)) slots))
          (bar (find (lambda (s) (eq? (slot-getter s) 'bar)) slots))
          (par (find (lambda (s) (eq? (slot-type s) 'parent)) slots)))
-    (check-true "slot? recognises a slot" (slot? foo))
-    (check-true "slot? rejects a non-slot" (not (slot? 'foo)))
-    (check "value slot getter name" (slot-getter foo) 'foo)
-    (check "value slot setter name" (slot-setter foo) 'set-foo!)
-    (check "value slot type" (slot-type foo) 'value)
-    (check "method slot type" (slot-type bar) 'method)
-    (check "method slot has no setter" (slot-setter bar) #f)
-    (check-true "parent slot present" (slot? par))
-    (check "parent slot type" (slot-type par) 'parent)))
+    (test-assert "slot? recognises a slot" (slot? foo))
+    (test-assert "slot? rejects a non-slot" (not (slot? 'foo)))
+    (test-equal "value slot getter name" 'foo (slot-getter foo))
+    (test-equal "value slot setter name" 'set-foo! (slot-setter foo))
+    (test-equal "value slot type" 'value (slot-type foo))
+    (test-equal "method slot type" 'method (slot-type bar))
+    (test-equal "method slot has no setter" #f (slot-setter bar))
+    (test-assert "parent slot present" (slot? par))
+    (test-equal "parent slot type" 'parent (slot-type par))
+    ;; full-slot-list includes the receiver's own slots (foo, bar) and does
+    ;; not crash unioning slot records.
+    (test-assert "full-slot-list includes the object's own slots"
+                 (let ((getters (map slot-getter
+                                     ((cls 'mirror) 'full-slot-list))))
+                   (and (memq 'foo getters) (memq 'bar getters) #t)))))
 
 ;;; --------------------------------------------------------------------
-;;; copy / copy-object: an independent duplicate
+;;; copy / copy-object: an independent duplicate (incl. the root object)
 ;;; --------------------------------------------------------------------
 
 (let ((orig (*the-root-object* 'derive)))
   (orig 'set-value-slot! 'x 'set-x! 99)
   (orig 'set-method-slot! 'greet (lambda (self resend) 'hi))
   (let ((dup (orig 'copy)))
-    (check "copy duplicates value slots" (dup 'x) 99)
-    (check "copy duplicates method slots" (dup 'greet) 'hi)
+    (test-equal "copy duplicates value slots" 99 (dup 'x))
+    (test-equal "copy duplicates method slots" 'hi (dup 'greet))
     (dup 'set-x! 5)
-    (check "mutating the copy leaves the original alone" (orig 'x) 99)
-    (check "the copy has its own value" (dup 'x) 5)
+    (test-equal "mutating the copy leaves the original alone" 99 (orig 'x))
+    (test-equal "the copy has its own value" 5 (dup 'x))
     (orig 'set-x! 77)
-    (check "mutating the original leaves the copy alone" (dup 'x) 5)
-    (check "the original has its own value" (orig 'x) 77)))
+    (test-equal "mutating the original leaves the copy alone" 5 (dup 'x))
+    (test-equal "the original has its own value" 77 (orig 'x))))
+
+;; A copy of the parentless root object must not alias the global root.
+(let ((rootcopy (*the-root-object* 'copy)))
+  (rootcopy 'set-value-slot! 'copied-marker 123)
+  (test-equal "root copy sees its own slot" 123 (rootcopy 'copied-marker))
+  (test-assert "root copy does not pollute the global root object"
+               (raises? (lambda () (*the-root-object* 'copied-marker)))))
 
 ;;; --------------------------------------------------------------------
-;;; (srfi 263 syntax): define-object, set-method!, derive-object, copy-object
+;;; (srfi 263 syntax): define-object, define-method / set-method!,
+;;; derive-object, copy-object
 ;;; --------------------------------------------------------------------
 
 (define-object testobject (*the-root-object*)
@@ -189,26 +228,36 @@
   (val 10)                              ; value slot
   (testval set-testval! 50))            ; value slot with a setter
 
-(check "define-object method slot" (testobject 'compute 3 4) 7)
-(check "define-object value slot" (testobject 'val) 10)
-(check "define-object value+setter slot" (testobject 'testval) 50)
+(test-equal "define-object method slot" 7 (testobject 'compute 3 4))
+(test-equal "define-object value slot" 10 (testobject 'val))
+(test-equal "define-object value+setter slot" 50 (testobject 'testval))
 (testobject 'set-testval! 20)
-(check "define-object setter works" (testobject 'testval) 20)
+(test-equal "define-object setter works" 20 (testobject 'testval))
 
-(set-method! (testobject methodslot self resend a b) (* a b))
-(check "set-method! adds a method" (testobject 'methodslot 6 7) 42)
+;; define-method is SRFI 263's documented name; set-method! is the alias.
+(define-method (testobject methodslot self resend a b) (* a b))
+(test-equal "define-method adds a method" 42 (testobject 'methodslot 6 7))
+(set-method! (testobject aliased self resend a) (- a 1))
+(test-equal "set-method! alias adds a method" 4 (testobject 'aliased 5))
 
-(let ((d (derive-object (testobject) (extra 999))))
-  (check "derive-object adds a slot" (d 'extra) 999)
-  (check "derive-object inherits parent slots" (d 'val) 10))
+;; A secondary named parent exercises the repeated set-parent-slot! branch
+;; of derive-object / copy-object.
+(define helper (*the-root-object* 'derive))
+(helper 'set-method-slot! 'help (lambda (self resend) 'helped))
 
-(let ((cp (copy-object (testobject))))
-  (check "copy-object duplicates the object" (cp 'val) 10)
+(let ((d (derive-object (testobject (aux helper)) (extra 999))))
+  (test-equal "derive-object adds a slot" 999 (d 'extra))
+  (test-equal "derive-object inherits creation-parent slots" 10 (d 'val))
+  (test-equal "derive-object inherits named-parent methods" 'helped (d 'help)))
+
+(let ((cp (copy-object (testobject (aux helper)))))
+  (test-equal "copy-object duplicates the object" 10 (cp 'val))
+  (test-equal "copy-object inherits named-parent methods" 'helped (cp 'help))
   (cp 'set-testval! 1)
-  (check "copy-object is independent" (testobject 'testval) 20))
+  (test-equal "copy-object is independent" 20 (testobject 'testval)))
 
 ;;; --------------------------------------------------------------------
 
-(display pass) (display " passed, ") (display fail) (display " failed")
-(newline)
-(if (> fail 0) (error "SRFI 263 tests failed" fail))
+(let ((runner (test-runner-current)))
+  (test-end "srfi-263")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi263.scm
+++ b/tests/scheme/srfi/srfi263.scm
@@ -1,0 +1,214 @@
+;;; SRFI 263 (Prototype Object System) conformance tests.
+;;;
+;;; Ports the reference implementation's test suite and adds coverage for
+;;; the reflection procedures, working copy/copy-object, custom
+;;; message-not-understood handlers, and the (srfi 263 syntax) macros.
+
+(import (scheme base)
+        (scheme write)
+        (srfi 1)
+        (srfi 263)
+        (srfi 263 syntax))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define (check-true name got) (check name (and got #t) #t))
+
+;; #t if THUNK raises (used for message-not-understood / ambiguity).
+(define (raises? thunk)
+  (call-with-current-continuation
+   (lambda (k)
+     (with-exception-handler
+         (lambda (e) (k #t))
+       (lambda () (thunk) #f)))))
+
+;;; --------------------------------------------------------------------
+;;; Basic functionality (ported from the reference test suite)
+;;; --------------------------------------------------------------------
+
+(check-true "root has no ancestors"
+            (null? ((*the-root-object* 'mirror) 'immediate-ancestor-list)))
+(check "root exposes 9 messages"
+       (length ((*the-root-object* 'mirror) 'immediate-message-alist)) 9)
+
+(let ((class (*the-root-object* 'derive)))
+  (check-true "derived object's ancestor is the root"
+              (eq? *the-root-object*
+                   (car ((class 'mirror) 'immediate-ancestor-list))))
+
+  (class 'set-method-slot! 'testmethod (lambda (self resend) 'success))
+  (check "method slot returns its value" (class 'testmethod) 'success)
+
+  (class 'set-value-slot! 'val 'set-val! 10)
+  (check "value slot getter" (class 'val) 10)
+  (class 'set-val! 20)
+  (check "value slot after setter" (class 'val) 20)
+  (check "getter+setter add two messages"
+         (length ((class 'mirror) 'immediate-message-alist)) 5)
+
+  (class 'set-value-slot! 'val 40)
+  (check "value slot with no setter" (class 'val) 40)
+  (check "redefining as getter-only drops the old setter"
+         (length ((class 'mirror) 'immediate-message-alist)) 4)
+
+  ;; Deleting the setter keeps the getter.
+  (class 'set-value-slot! 'val 'set-val! 10)
+  (class 'delete-slot! 'set-val!)
+  (check "deleting the setter keeps the getter"
+         (length ((class 'mirror) 'immediate-message-alist)) 4)
+
+  ;; Deleting the getter also deletes the setter.
+  (class 'set-value-slot! 'val 'set-val! 10)
+  (class 'delete-slot! 'val)
+  (check "deleting the getter also deletes the setter"
+         (length ((class 'mirror) 'immediate-message-alist)) 3))
+
+;;; --------------------------------------------------------------------
+;;; Inheritance
+;;; --------------------------------------------------------------------
+
+(let* ((firstlevel (*the-root-object* 'derive))
+       (secondlevel (firstlevel 'derive)))
+  (firstlevel 'set-method-slot! 'testmethod (lambda (self resend) 'success))
+  (check "method is inherited" (secondlevel 'testmethod) 'success)
+
+  (firstlevel 'set-value-slot! 'val 'set-val! 10)
+  (check "value is inherited" (secondlevel 'val) 10)
+
+  ;; Setting through an inherited setter copies the slot onto the child.
+  (secondlevel 'set-val! 20)
+  (check "parent value unchanged after child set" (firstlevel 'val) 10)
+  (check "child gets its own value" (secondlevel 'val) 20)
+
+  (firstlevel 'set-value-slot! 'val #f 30)
+  (check "parent value can be changed independently" (firstlevel 'val) 30)
+  (check "child keeps its own value" (secondlevel 'val) 20)
+
+  (check "firstlevel full ancestry (self + root)"
+         (length ((firstlevel 'mirror) 'full-ancestor-list)) 2)
+  (check "secondlevel full ancestry (self + parent + root)"
+         (length ((secondlevel 'mirror) 'full-ancestor-list)) 3))
+
+;;; --------------------------------------------------------------------
+;;; Multiple inheritance, message-not-understood and ambiguity
+;;; --------------------------------------------------------------------
+
+(let* ((adderclass (*the-root-object* 'derive))
+       (squareclass (*the-root-object* 'derive))
+       (mathclass (squareclass 'derive)))
+  (adderclass 'set-method-slot! 'inc
+              (lambda (self resend val) (+ val 1)))
+  (squareclass 'set-method-slot! 'square
+               (lambda (self resend val) (* val val)))
+  (mathclass 'set-parent-slot! 'adder adderclass)
+
+  (check "adder method" (adderclass 'inc 9) 10)
+  (check "square method" (squareclass 'square 3) 9)
+  (check "method inherited across a second parent" (mathclass 'inc 8) 9)
+
+  (check-true "unknown message signals an error"
+              (raises? (lambda () (adderclass 'nope 10))))
+
+  ;; Both parents define 'reset -> ambiguous.
+  (adderclass 'set-method-slot! 'reset (lambda (self resend x) 5))
+  (squareclass 'set-method-slot! 'reset (lambda (self resend x) 5))
+  (check-true "ambiguous message signals an error"
+              (raises? (lambda () (mathclass 'reset 1))))
+
+  (check "two immediate parents"
+         (length ((mathclass 'mirror) 'immediate-ancestor-list)) 2)
+  (mathclass 'delete-slot! 'adder)
+  (check "deleting a parent slot removes the ancestor"
+         (length ((mathclass 'mirror) 'immediate-ancestor-list)) 1))
+
+;;; --------------------------------------------------------------------
+;;; Custom message-not-understood handler (SRFI-mandated, overridable)
+;;; --------------------------------------------------------------------
+
+(let ((obj (*the-root-object* 'derive)))
+  (obj 'set-method-slot! 'message-not-understood
+       (lambda (self resend message args) (list 'dnu message args)))
+  (check "custom message-not-understood intercepts unknown messages"
+         (obj 'whatever 1 2) '(dnu whatever (1 2))))
+
+;;; --------------------------------------------------------------------
+;;; Slot reflection: slot?, slot-getter, slot-setter, slot-type
+;;; --------------------------------------------------------------------
+
+(let ((cls (*the-root-object* 'derive)))
+  (cls 'set-value-slot! 'foo 'set-foo! 1)
+  (cls 'set-method-slot! 'bar (lambda (self resend) 'b))
+  (let* ((slots ((cls 'mirror) 'immediate-slot-list))
+         (foo (find (lambda (s) (eq? (slot-getter s) 'foo)) slots))
+         (bar (find (lambda (s) (eq? (slot-getter s) 'bar)) slots))
+         (par (find (lambda (s) (eq? (slot-type s) 'parent)) slots)))
+    (check-true "slot? recognises a slot" (slot? foo))
+    (check-true "slot? rejects a non-slot" (not (slot? 'foo)))
+    (check "value slot getter name" (slot-getter foo) 'foo)
+    (check "value slot setter name" (slot-setter foo) 'set-foo!)
+    (check "value slot type" (slot-type foo) 'value)
+    (check "method slot type" (slot-type bar) 'method)
+    (check "method slot has no setter" (slot-setter bar) #f)
+    (check-true "parent slot present" (slot? par))
+    (check "parent slot type" (slot-type par) 'parent)))
+
+;;; --------------------------------------------------------------------
+;;; copy / copy-object: an independent duplicate
+;;; --------------------------------------------------------------------
+
+(let ((orig (*the-root-object* 'derive)))
+  (orig 'set-value-slot! 'x 'set-x! 99)
+  (orig 'set-method-slot! 'greet (lambda (self resend) 'hi))
+  (let ((dup (orig 'copy)))
+    (check "copy duplicates value slots" (dup 'x) 99)
+    (check "copy duplicates method slots" (dup 'greet) 'hi)
+    (dup 'set-x! 5)
+    (check "mutating the copy leaves the original alone" (orig 'x) 99)
+    (check "the copy has its own value" (dup 'x) 5)
+    (orig 'set-x! 77)
+    (check "mutating the original leaves the copy alone" (dup 'x) 5)
+    (check "the original has its own value" (orig 'x) 77)))
+
+;;; --------------------------------------------------------------------
+;;; (srfi 263 syntax): define-object, set-method!, derive-object, copy-object
+;;; --------------------------------------------------------------------
+
+(define-object testobject (*the-root-object*)
+  ((compute self resend a b) (+ a b))   ; method slot
+  (val 10)                              ; value slot
+  (testval set-testval! 50))            ; value slot with a setter
+
+(check "define-object method slot" (testobject 'compute 3 4) 7)
+(check "define-object value slot" (testobject 'val) 10)
+(check "define-object value+setter slot" (testobject 'testval) 50)
+(testobject 'set-testval! 20)
+(check "define-object setter works" (testobject 'testval) 20)
+
+(set-method! (testobject methodslot self resend a b) (* a b))
+(check "set-method! adds a method" (testobject 'methodslot 6 7) 42)
+
+(let ((d (derive-object (testobject) (extra 999))))
+  (check "derive-object adds a slot" (d 'extra) 999)
+  (check "derive-object inherits parent slots" (d 'val) 10))
+
+(let ((cp (copy-object (testobject))))
+  (check "copy-object duplicates the object" (cp 'val) 10)
+  (cp 'set-testval! 1)
+  (check "copy-object is independent" (testobject 'testval) 20))
+
+;;; --------------------------------------------------------------------
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "SRFI 263 tests failed" fail))


### PR DESCRIPTION
Implements [SRFI 263: Prototype Object System](https://srfi.schemers.org/srfi-263/srfi-263.html) (Final, 2026-05-22; Daniel Ziltener) as two portable libraries loaded on demand, like the other portable SRFIs. Closes #1638.

- **`(srfi 263)`** — core message-passing protocol + reflection: `*the-root-object*`, `slot?`, `slot-getter`, `slot-setter`, `slot-type`.
- **`(srfi 263 syntax)`** — sugar: `define-object`, `derive-object`, `copy-object`, `set-method!`.

## Approach

Ported from the reference implementation. It targets CHICKEN and relies on a few things R7RS leaves unspecified, so the port makes them portable and — where the reference is simply broken (its own `test.scm` never exercises those paths) — matches the SRFI's **documented** behavior. Every deviation is marked `Kaappi:` at its call site and summarized in the file header.

| Site | Reference | This port | Why |
|------|-----------|-----------|-----|
| private symbol | `##srfi-263#obj-data` (CHICKEN `##` reader) | `\|##srfi-263#obj-data\|` (R7RS bar-quote) | strict reader |
| `recursive-lookup` | defined twice (first dead) | keep only the second, deduplicating one | portability |
| root `'derive` | returns `(values obj data)` | returns a single value | R7RS doesn't truncate MV in single-value context; **basic derivation fails otherwise** |
| `copy` / `copy-object` | sends nonexistent mirror `'get-*` messages → crashes; copied methods capture the original's data | uses real `'immediate-*` messages + re-installs `'mirror` over the copy's own data | make a copy actually work and be independent |
| unknown message | applies the bare symbol `'message-not-understood` (an error only by accident) | re-dispatches the message to the receiver | SRFI says the handler slot is overridable |

## Docs / discovery

The portable-SRFI list is generated by scanning `lib/srfi/*.sld`, so `kaappi features` picks up 263 automatically. Counts updated to **73 SRFIs (65 portable)** in `CLAUDE.md`, `CONFORMANCE.md`, and `README.md`.

## Tests

`tests/scheme/srfi/srfi263.scm` (auto-discovered by `run-all.sh`) ports the reference suite and adds coverage for slot reflection, working `copy`/`copy-object`, custom `message-not-understood` handlers, and all four macros — **51 checks, 0 failures**.

- `zig build test` — green (includes the features portable-SRFI count test, now 65)
- full `tests/scheme/srfi/*.scm` suite — 85 passed, 0 failed

## Follow-up (separate repo)

An end-user docs entry on the [kaappi.github.io](https://github.com/kaappi/kaappi.github.io) ecosystem/SRFI page — not included here since that's a different repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)