### PR TITLE
Fix two macro-hygiene bugs in let-syntax and named-let expansion

### DIFF
--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -390,8 +390,28 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         try captureLocalsOnTransformer(self, transformer);
         try computeBoundFreeRefs(self, transformer);
         const tx = types.toObject(transformer).as(types.Transformer);
-        tx.let_syntax_peer_names = self.gc.allocator.dupe([]const u8, peer_snap_names) catch return CompileError.OutOfMemory;
-        tx.let_syntax_peer_vals = self.gc.allocator.dupe(Value, peer_snap_vals) catch return CompileError.OutOfMemory;
+        // R7RS 4.3.1 suppresses sibling keywords only for references the
+        // transformer's TEMPLATE makes (definition-site free references). A
+        // sibling handed to it as an argument is a use-site identifier — not a
+        // template free reference — and must stay resolvable (the
+        // `classify-nonellipsis-symbol` idiom `(b () k ...)` passes a sibling
+        // macro `k` through helper `b`). So keep only siblings this
+        // transformer free-references; on overflow, fall back to all siblings.
+        var free_names: [64][]const u8 = undefined;
+        var free_count: usize = 0;
+        const have_free = collectTransformerFreeRefs(transformer, &free_names, &free_count);
+        var peer_names_f: std.ArrayList([]const u8) = .empty;
+        defer peer_names_f.deinit(self.gc.allocator);
+        var peer_vals_f: std.ArrayList(Value) = .empty;
+        defer peer_vals_f.deinit(self.gc.allocator);
+        for (peer_snap_names, peer_snap_vals) |pn, pv| {
+            if (!have_free or nameInSlice(free_names[0..free_count], pn)) {
+                peer_names_f.append(self.gc.allocator, pn) catch return CompileError.OutOfMemory;
+                peer_vals_f.append(self.gc.allocator, pv) catch return CompileError.OutOfMemory;
+            }
+        }
+        tx.let_syntax_peer_names = self.gc.allocator.dupe([]const u8, peer_names_f.items) catch return CompileError.OutOfMemory;
+        tx.let_syntax_peer_vals = self.gc.allocator.dupe(Value, peer_vals_f.items) catch return CompileError.OutOfMemory;
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
     }
 
@@ -475,6 +495,27 @@ fn restoreMacros(self: *Compiler, names: [][]const u8, values: []?Value) void {
             _ = self.macros.remove(name);
         }
     }
+}
+
+/// Collect the free-reference identifier names in a transformer's templates —
+/// identifiers that are neither the rule's pattern variables nor literals.
+/// Returns false on overflow (caller should then treat the set as unknown).
+fn collectTransformerFreeRefs(transformer: Value, out: *[64][]const u8, count: *usize) bool {
+    const tx = types.toObject(transformer).as(types.Transformer);
+    var pv_names: [64][]const u8 = undefined;
+    var pv_count: usize = 0;
+    for (tx.patterns[0..tx.num_rules]) |pat| {
+        if (!collectSymbols(pat, &pv_names, &pv_count)) return false;
+    }
+    for (tx.templates[0..tx.num_rules]) |tmpl| {
+        if (!collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, out, count)) return false;
+    }
+    return true;
+}
+
+fn nameInSlice(names: []const []const u8, name: []const u8) bool {
+    for (names) |n| if (std.mem.eql(u8, n, name)) return true;
+    return false;
 }
 
 fn computeBoundFreeRefs(self: *Compiler, transformer: Value) CompileError!void {

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -948,8 +948,14 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
     // bake __hyg_ names into the inner macro's stored template. Gensyms are
     // globally unique, so renaming again cannot prevent any capture — it
     // only severs the reference from the binding created by the generating
-    // expansion (issue #919: __hyg_N___hyg_M_march-hare undefined).
-    if (std.mem.startsWith(u8, name, "__hyg_")) return gc.allocSymbol(name);
+    // expansion (issue #919: __hyg_N___hyg_M_march-hare undefined). The same
+    // holds for the named-let loop gensym (__nlet_N_name): named-let desugars
+    // during compilation, interleaved with macro expansion, so its loop name
+    // can flow back through a macro whose template re-emits it (e.g. SRFI 257's
+    // ~etc, where the recursive (loop ...) call rides inside a submatch
+    // argument). Re-renaming it splits the reference from the letrec binding.
+    if (std.mem.startsWith(u8, name, "__hyg_") or std.mem.startsWith(u8, name, "__nlet_"))
+        return gc.allocSymbol(name);
     const in_binding = (scope & BINDING_FLAG) != 0;
     // Strip context flags that don't change renaming, so the same template
     // identifier gets the same gensym inside and outside those contexts

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -753,3 +753,42 @@ test "macro-with-global expansion keeps later argument slots intact (#1396)" {
         \\  (equal? (list (m0) 1 2) '(41 1 2)))
     );
 }
+
+test "let-syntax sibling macro passed as an argument stays resolvable" {
+    // R7RS 4.3.1 says a let-syntax transformer's *template* free references
+    // resolve at the definition site, where sibling keywords aren't visible.
+    // Kaappi suppressed ALL siblings during an expansion's compilation, so a
+    // sibling handed to a helper as an *argument* (a use-site identifier, not
+    // a template reference) vanished: `id` was reported undefined. Now only
+    // siblings a transformer actually free-references in its template are
+    // suppressed. This `(helper macro)` idiom underlies SRFI 257's `classify`
+    // (`classify-nonellipsis-symbol`'s `(b () k ...)`).
+    try th.expectEval(
+        \\(let-syntax ((apply1 (syntax-rules () ((_ m v) (m v))))
+        \\             (id     (syntax-rules () ((_ x) x))))
+        \\  (apply1 id 42))
+    , 42);
+}
+
+test "named-let loop gensym survives re-expansion through a macro" {
+    // A named let desugars during compilation to a __nlet_N_loop gensym,
+    // interleaved with macro expansion. When the (loop ...) call rides through
+    // another macro whose template re-emits it, the hygiene renamer used to
+    // re-rename the already-gensym'd name (__hyg_M___nlet_N_loop), splitting
+    // the recursive call from its letrec binding. renameForHygiene now leaves
+    // __nlet_ gensyms alone, as it already does for __hyg_ ones (issue #919).
+    // Exercised by SRFI 257's ~etc, which loops with the recursive call nested
+    // inside a submatch argument.
+    try th.expectEval(
+        \\(begin
+        \\  (define-syntax again
+        \\    (syntax-rules ()
+        \\      ((_ call) (let-syntax ((go (syntax-rules () ((_) call)))) (go)))))
+        \\  (define-syntax build
+        \\    (syntax-rules ()
+        \\      ((_ base)
+        \\       (let loop ((n base) (acc 0))
+        \\         (if (= n 0) acc (again (loop (- n 1) (+ acc 1))))))))
+        \\  (build 4))
+    , 4);
+}


### PR DESCRIPTION
## Summary

Two general macro-expander bugs, both uncovered while investigating SRFI 257's
matcher (#1644) — whose deeply macrological reference implementation exercises
corners of `syntax-rules` most programs never reach. The fixes are independent
of that SRFI and improve hygiene for all Kaappi macros.

### 1. `let-syntax` sibling passed as an argument went undefined

R7RS 4.3.1 resolves a transformer's *template* free references at its
definition site, where sibling `let-syntax` keywords aren't visible — so
`compileLetSyntax` swapped **every** sibling out of the macro environment while
compiling an expansion's output. But a sibling handed to a helper macro as an
**argument** is a use-site identifier, not a template free reference, and must
stay resolvable:

```scheme
(let-syntax ((apply1 (syntax-rules () ((_ m v) (m v))))
             (id     (syntax-rules () ((_ x) x))))
  (apply1 id 42))   ; was: undefined variable 'id' — now: 42
```

Now only siblings a transformer actually free-references in its template are
suppressed (`collectTransformerFreeRefs`, reusing the existing `collectFreeRefs`).

### 2. Named-let loop gensym re-renamed by hygiene

A named `let` desugars to a `__nlet_N_loop` gensym during compilation,
interleaved with macro expansion. When the recursive `(loop ...)` call rides
through another macro whose template re-emits it, `renameForHygiene` renamed the
already-gensym'd name (`__hyg_M___nlet_N_loop`), splitting the recursive call
from its `letrec` binding. It now leaves `__nlet_` names alone, exactly as it
already does for `__hyg_` ones (issue #919).

## Testing

- Two regression tests added to `tests_macros.zig`, each verified to fail
  without its fix and pass with it (confirmed via single-fix A/B binaries).
- Full suite green: `zig build test` + `tests/scheme/run-all.sh` → **1875 pass,
  0 fail** (480 Scheme files + 1395 R7RS).

## Dropped: a third (nested-`syntax-rules`) fix, proven unnecessary

Mid-investigation I also wrote a ~230-line change to isolate a nested
`syntax-rules`' own pattern variables (renaming them to fresh gensyms so they
couldn't fuse with same-named identifiers in the outer template). It was **not**
needed: with only fixes 1 and 2 applied, single-fix A/B binaries showed the full
matcher regression set already passing. So it was removed to keep this PR small
and low-risk — this diff intentionally does **not** touch nested-`syntax-rules`
instantiation. Noting it here so it isn't re-introduced as "missing."

## Note on #1644 (SRFI 257)

These two fixes make SRFI 257's *core* matcher work (destructuring, quasiquote,
non-linear patterns, `~and`/`~or`/`~not`/`~etc`/`~append`, the `box` sublibrary,
`define-match-pattern`, `(=> next)` guards). Full SRFI 257 additionally needs
working backtracking invocation (`(=> next back)` + `(back)`) and the `misc`
sublibrary (`cm-match`/`sr-match`), which each surface further deep expander
issues. #1644 stays open to track that larger, separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)