### PR TITLE
Add Windows x86_64 (x64) support

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -141,7 +141,7 @@ Note: `src/main.zig` and `src/thottam.zig` read the version from
 **STOP.** Ask the user for explicit confirmation before pushing. Explain:
 
 - Pushing the tag triggers the release workflow in CI
-- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, aarch64-windows (kaappi-aarch64-windows.exe, cross-compiled), x86_64-freebsd, aarch64-freebsd, x86_64-openbsd, aarch64-openbsd, x86_64-netbsd, aarch64-netbsd, plus kaappi.wasm (wasm32-wasi)
+- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, aarch64-windows and x86_64-windows (kaappi-{aarch64,x86_64}-windows.exe, cross-compiled), x86_64-freebsd, aarch64-freebsd, x86_64-openbsd, aarch64-openbsd, x86_64-netbsd, aarch64-netbsd, plus kaappi.wasm (wasm32-wasi)
 - macOS binaries are Developer ID signed and Apple notarized
 - It generates SHA256SUMS and creates a GitHub Release
 - This is irreversible
@@ -185,9 +185,11 @@ install script verification. If it fails, investigate before updating the
 docs site — a failure means the release artifacts have a problem (e.g.
 missing entitlement, broken binary, bad checksum).
 
-The Windows artifacts are covered by the checksum job (it verifies every
-released file) but have **no CI acceptance leg** — GitHub has no ARM64
-Windows runners. Smoke-test on the `ssh win11` UTM VM:
+The x86_64-windows artifact has its own post-release acceptance leg
+(`test-windows-x64`, on the windows-latest runners). The aarch64-windows
+artifact is covered by the checksum job (it verifies every released
+file) but has **no CI acceptance leg** — post-release.yml has no
+windows-11-arm job. Smoke-test it on the `ssh win11` UTM VM:
 
 ```bash
 # Download the release binary
@@ -200,7 +202,10 @@ ssh win11 "C:\tmp\kaappi-vX.Y.Z.exe features"
 ```
 
 Verify: version matches, script prints `3`, and `features` shows `windows`
-(not `posix`) with target `aarch64-windows-gnu`. See `docs/dev/windows.md`.
+(not `posix`) with target `aarch64-windows-gnu`. The same VM also runs
+the x86_64 artifact via Windows' built-in x64 emulation (target then
+reads `x86_64-windows-gnu`) if a manual cross-check is ever needed.
+See `docs/dev/windows.md`.
 
 The FreeBSD artifacts are likewise checksum-covered but have **no CI
 acceptance leg** — GitHub hosts no FreeBSD runners. Smoke-test the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,14 +353,19 @@ jobs:
             cc -shared -fPIC tests/scheme/ffi/fixtures/u64test.c -o tests/scheme/ffi/fixtures/libu64test.so
             bash tests/scheme/run-all.sh
 
-  # Cross-compile the Windows aarch64 binaries and the unit-test binary
-  # from Linux. Compile-only by design: this guards the cross-compilation
-  # path release.yml ships with, independent of the Windows runner image.
-  # Execution is covered by windows-arm-test below.
+  # Cross-compile the Windows binaries and the unit-test binary from
+  # Linux, once per arch. Compile-only by design: this guards the
+  # cross-compilation path release.yml ships with, independent of the
+  # Windows runner images. Execution is covered by windows-arm-test and
+  # windows-x64-test below.
   windows-cross:
     needs: format
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [aarch64, x86_64]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -370,38 +375,44 @@ jobs:
         uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
         with:
           version: 0.16.0
-          cache-key: windows-cross
+          cache-key: windows-cross-${{ matrix.arch }}
 
-      - name: Build (cross-compile for aarch64-windows)
-        run: zig build -Dtarget=aarch64-windows
+      - name: Build (cross-compile for ${{ matrix.arch }}-windows)
+        # `lib` builds kaappi_rt.lib — windows-x64-test links against it
+        # in the native-backend e2e step.
+        run: |
+          zig build -Dtarget=${{ matrix.arch }}-windows
+          zig build lib -Dtarget=${{ matrix.arch }}-windows
 
-      - name: Compile unit tests (aarch64-windows)
+      - name: Compile unit tests (${{ matrix.arch }}-windows)
         # The host can't execute the foreign test binaries; the build's
         # Run steps set skip_foreign_checks, so this compiles everything
         # and skips execution — a plain compile gate with normal error
         # propagation.
         run: |
-          zig build test -Dtarget=aarch64-windows
+          zig build test -Dtarget=${{ matrix.arch }}-windows
           ls .zig-cache/o/*/unit-tests.exe
 
-      - name: Stage binaries for windows-arm-test
+      - name: Stage binaries for the Windows test jobs
         # ls -t picks the exe this run compiled — the restored Zig cache
         # can hold stale unit-tests.exe from earlier runs.
         run: |
           mkdir -p win-stage
           cp zig-out/bin/kaappi.exe zig-out/bin/thottam.exe zig-out/bin/kaappi-lsp.exe win-stage/
+          cp zig-out/lib/kaappi_rt.lib win-stage/
           cp "$(ls -t .zig-cache/o/*/unit-tests.exe | head -1)" win-stage/
           cp "$(ls -t .zig-cache/o/*/thottam-tests.exe | head -1)" win-stage/
 
       - name: Cross-compile FFI test fixture
-        # uint64-range.scm dlopens this; windows-arm-test drops it into
-        # tests/scheme/ffi/fixtures/ — that job has no toolchain (#1613).
-        run: zig cc -target aarch64-windows-gnu -shared tests/scheme/ffi/fixtures/u64test.c -o win-stage/libu64test.dll
+        # uint64-range.scm dlopens this; the Windows test jobs drop it
+        # into tests/scheme/ffi/fixtures/ — the arm job has no toolchain
+        # (#1613).
+        run: zig cc -target ${{ matrix.arch }}-windows-gnu -shared tests/scheme/ffi/fixtures/u64test.c -o win-stage/libu64test.dll
 
-      - name: Upload binaries for windows-arm-test
+      - name: Upload binaries for the Windows test jobs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: windows-aarch64-binaries
+          name: windows-${{ matrix.arch }}-binaries
           path: win-stage/
           retention-days: 3
 
@@ -555,6 +566,175 @@ jobs:
             done
           done
           exit $fail
+
+  # Execute the same suite set on x86_64 Windows via the standard
+  # windows-latest runners, from the cross-compiled x86_64 artifacts
+  # (guarding the binaries release.yml ships), plus the native-backend
+  # e2e suite (tests/e2e/run-e2e.ps1, #1610) — possible only on this
+  # arch: Zig 0.16.0 works natively on x86_64 Windows, while the
+  # aarch64 toolchain access-violates compiling anything (#1613, an
+  # aarch64-only LLVM COFF bug). Zig is installed only after the shell
+  # suites so both Windows jobs run them under identical no-toolchain
+  # conditions (the bundle-rebuild scripts gate on a toolchain being
+  # present).
+  windows-x64-test:
+    needs: windows-cross
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      # The Windows runner images set core.autocrlf=true; the Scheme
+      # suites compare exact output, so check out files as committed.
+      - name: Disable autocrlf
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-x86_64-binaries
+          path: bin
+
+      - name: Unwrap archived artifact
+        # Safety net only: named downloads extract the artifact contents
+        # into `path` directly (loose files, so this loop normally has
+        # nothing to do — the wrapper-zip belief was a misdiagnosis, #1620).
+        # Windows ships bsdtar, which extracts zip if one ever appears.
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for z in bin/*.zip; do tar -xf "$z" -C bin && rm -f "$z"; done
+          ls -l bin
+
+      - name: Stage FFI test fixture
+        # uint64-range.scm opens tests/scheme/ffi/fixtures/libu64test
+        # relative to the repo root this job runs the suites from.
+        shell: bash
+        run: cp bin/libu64test.dll tests/scheme/ffi/fixtures/
+
+      - name: Create tmp directories
+        # Tests write scratch files under /tmp/..., which kaappi.exe
+        # resolves to \tmp on the current drive (docs/dev/windows.md).
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path C:\tmp | Out-Null
+          $drive = (Get-Location).Path.Substring(0, 2)
+          New-Item -ItemType Directory -Force -Path "$drive\tmp" | Out-Null
+
+      - name: Unit tests
+        shell: bash
+        run: bin/unit-tests.exe
+
+      - name: thottam unit tests
+        shell: bash
+        run: bin/thottam-tests.exe
+
+      - name: thottam integration test
+        # Mirrors the POSIX test job's step: a real install of the
+        # pure-Scheme kaappi-json, imported through the installed lib
+        # dir, then removed — which deletes a real git clone, whose
+        # read-only pack files are the Windows-specific removal hazard
+        # (#1609). KAAPPI_HOME is a C:/-style path (pwd -W): thottam
+        # hands paths straight to git.exe and the CRT, which never see
+        # git-bash's /d/... spellings.
+        shell: bash
+        run: |
+          export KAAPPI_HOME="$(pwd -W)/thottam-home"
+          bin/thottam.exe list
+          bin/thottam.exe install kaappi-json
+          bin/thottam.exe update kaappi-json
+          bin/thottam.exe list | grep kaappi-json
+          bin/thottam.exe verify
+          echo '(import (kaappi json)) (display (json-write-string (list 1 2 3))) (newline)' > use-json.scm
+          bin/kaappi.exe --lib-path "$KAAPPI_HOME/lib" use-json.scm
+          bin/thottam.exe remove kaappi-json
+          ! bin/thottam.exe list | grep kaappi-json
+          rm -f use-json.scm
+
+      - name: R7RS test suite
+        shell: bash
+        run: bin/kaappi.exe tests/scheme/r7rs/r7rs-tests.scm
+
+      - name: Scheme suites (VM-verified subset)
+        shell: bash
+        run: |
+          fail=0
+          for dir in smoke compliance continuations hygiene srfi ffi audit; do
+            for f in tests/scheme/$dir/*.scm; do
+              if bin/kaappi.exe "$f" > out.log 2>&1; then
+                echo "  PASS  $f"
+              else
+                echo "  FAIL  $f"
+                cat out.log
+                fail=1
+              fi
+            done
+          done
+          rm -f out.log
+          exit $fail
+
+      - name: Shell suites (#1612)
+        # The bash-driven drivers, under the runner's Git Bash. Exit 77 =
+        # SKIP (tests/scheme/shell-common.sh): a script whose premise cannot
+        # hold on Windows — the compile/ suite hard-skips on the OS — reports
+        # itself instead of failing. KAAPPI_HOME is isolated like run-all.sh
+        # does, so suites never touch a real cache.
+        shell: bash
+        run: |
+          # Some drivers validate JSON with python3; shim python3 when the
+          # name is missing. ($HOME, not $RUNNER_TEMP: a Windows-spelled dir
+          # in bash's PATH would not resolve for bash's own lookup.)
+          if ! command -v python3 >/dev/null 2>&1; then
+            mkdir -p "$HOME/.pyshim"
+            printf '#!/bin/sh\nexec python "$@"\n' > "$HOME/.pyshim/python3"
+            chmod +x "$HOME/.pyshim/python3"
+            export PATH="$HOME/.pyshim:$PATH"
+          fi
+          export KAAPPI=bin/kaappi.exe
+          export KAAPPI_HOME="$RUNNER_TEMP/kaappi-test-home"
+          fail=0
+          for dir in smoke errors compile test-runner pipeline doctor fmt cache timings sandbox robustness; do
+            for s in tests/scheme/$dir/*.sh; do
+              [ -e "$s" ] || continue
+              # `|| status=$?`: the runner's `shell: bash` implies -e, which
+              # would otherwise abort the whole step on the first SKIP (77).
+              status=0
+              out=$(KAAPPI="$KAAPPI" bash "$s" "$KAAPPI" 2>&1) || status=$?
+              if [ "$status" -eq 0 ]; then
+                echo "  PASS  $s"
+              elif [ "$status" -eq 77 ]; then
+                echo "  SKIP  $s"
+              else
+                echo "  FAIL  $s (exit $status)"
+                printf '%s\n' "$out"
+                fail=1
+              fi
+            done
+          done
+          exit $fail
+
+      - name: Install Zig
+        # After the suites (see the job comment). Native x86_64 Windows
+        # Zig — the C compiler + linker `kaappi compile` picks up.
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: windows-x64-test
+
+      - name: Native backend e2e (#1610)
+        # `kaappi compile` end-to-end on x86_64 Windows: emits LLVM IR,
+        # links against the cross-compiled kaappi_rt.lib (KAAPPI_LIB_DIR
+        # — the artifact drops it next to the exe, not at the
+        # exe-relative ..\lib), and requires every native binary's
+        # output to match the interpreter's.
+        shell: pwsh
+        run: |
+          $env:KAAPPI_LIB_DIR = Join-Path $PWD "bin"
+          & .\tests\e2e\run-e2e.ps1 -Kaappi (Join-Path $PWD "bin\kaappi.exe")
+          exit $LASTEXITCODE
 
   wasm:
     needs: format

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -308,11 +308,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check results
+        # Every leg must be exactly `success` — a cancelled or skipped
+        # job is not an acceptance pass.
         run: |
           results="${{ needs.test-checksums.result }} ${{ needs.test-macos.result }} ${{ needs.test-linux-x86.result }} ${{ needs.test-linux-arm.result }} ${{ needs.test-windows-x64.result }} ${{ needs.test-wasm.result }} ${{ needs.test-install-script.result }}"
           echo "Job results: $results"
-          if echo "$results" | grep -q "failure"; then
-            echo "One or more acceptance tests failed"
-            exit 1
-          fi
+          for r in $results; do
+            if [ "$r" != "success" ]; then
+              echo "One or more acceptance tests did not succeed"
+              exit 1
+            fi
+          done
           echo "All acceptance tests passed"

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -303,13 +303,13 @@ jobs:
           echo '(display (+ 1 2))' | kaappi | grep -F '3'
 
   summary:
-    needs: [test-checksums, test-macos, test-linux-x86, test-linux-arm, test-wasm, test-install-script]
+    needs: [test-checksums, test-macos, test-linux-x86, test-linux-arm, test-windows-x64, test-wasm, test-install-script]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          results="${{ needs.test-checksums.result }} ${{ needs.test-macos.result }} ${{ needs.test-linux-x86.result }} ${{ needs.test-linux-arm.result }} ${{ needs.test-wasm.result }} ${{ needs.test-install-script.result }}"
+          results="${{ needs.test-checksums.result }} ${{ needs.test-macos.result }} ${{ needs.test-linux-x86.result }} ${{ needs.test-linux-arm.result }} ${{ needs.test-windows-x64.result }} ${{ needs.test-wasm.result }} ${{ needs.test-install-script.result }}"
           echo "Job results: $results"
           if echo "$results" | grep -q "failure"; then
             echo "One or more acceptance tests failed"

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -184,6 +184,63 @@ jobs:
           THOTTAM=release/thottam-aarch64-linux \
           bash tests/acceptance/acceptance.sh "${TAG#v}"
 
+  # x86_64 Windows acceptance on the standard windows-latest runners,
+  # under the runner's Git Bash (acceptance.sh is plain bash driving the
+  # binary; verified 34/34 against the cross-compiled x86_64 binaries on
+  # the Windows reference VM). The aarch64-windows artifact has no such
+  # leg — smoke-test it on the reference VM per the release skill.
+  test-windows-x64:
+    runs-on: windows-latest
+    steps:
+      - name: Disable autocrlf
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Determine tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download release assets
+        shell: bash
+        run: |
+          gh release download "${{ steps.tag.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'kaappi-x86_64-windows.exe' \
+            --pattern 'thottam-x86_64-windows.exe' \
+            --pattern 'kaappi-lib.tar.gz' \
+            --pattern 'SHA256SUMS' \
+            --dir release
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Verify checksum
+        shell: bash
+        run: cd release && grep 'kaappi-x86_64-windows.exe' SHA256SUMS | sha256sum -c
+
+      - name: Install libraries
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.kaappi/lib" /tmp/libextract
+          tar xzf release/kaappi-lib.tar.gz -C /tmp/libextract
+          cp -r /tmp/libextract/lib/* "$HOME/.kaappi/lib/"
+
+      - name: Run acceptance tests
+        shell: bash
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          KAAPPI=release/kaappi-x86_64-windows.exe \
+          THOTTAM=release/thottam-x86_64-windows.exe \
+          bash tests/acceptance/acceptance.sh "${TAG#v}"
+
   test-wasm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,19 @@ jobs:
             lib_src: kaappi_rt.lib
             lib_ext: .lib
             strip: false
+          # Same cross-compiled mingw-w64 path; execution is verified by
+          # CI's windows-x64-test job on the x86_64 windows-latest
+          # runners and under x64 emulation on the Windows 11 ARM64
+          # reference machine (docs/dev/windows.md). strip: true — the
+          # #1607 threadlocal miscompile is aarch64-COFF-specific; a
+          # stripped x86_64 kaappi.exe runs correctly (VM-verified).
+          - os: ubuntu-latest
+            target: x86_64-windows
+            artifact: kaappi-x86_64-windows.exe
+            exe_ext: .exe
+            lib_src: kaappi_rt.lib
+            lib_ext: .lib
+            strip: true
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+#### Windows x86_64 support
+
+- **Windows x86_64 (x64) target** — `zig build -Dtarget=x86_64-windows`
+  cross-compiles kaappi.exe, thottam.exe, and kaappi-lsp.exe for x64
+  Windows; the platform layer was already OS-gated, so both Windows
+  architectures share the same code and degradation profile
+  (`docs/dev/windows.md`). Verified on Windows 11 (ARM64 reference VM
+  via the built-in x64 emulation layer): full unit suite, R7RS, all
+  `.scm` and shell suites, thottam, the post-release acceptance script,
+  and the native-backend e2e (`kaappi compile`, 38/38) — the stock Zig
+  0.16.0 x86_64-windows toolchain works natively (the #1613
+  access-violation is aarch64-only), so `kaappi compile` needs no
+  master-toolchain workaround on x64. CI gains a `windows-cross`
+  aarch64/x86_64 matrix and a `windows-x64-test` job (windows-latest)
+  running the same suites as `windows-arm-test` plus the native-backend
+  e2e; releases ship `kaappi-x86_64-windows.exe`,
+  `thottam-x86_64-windows.exe`, and `libkaappi_rt-x86_64-windows.lib`
+  (stripped — the #1607 strip crash is aarch64-only), with a
+  post-release acceptance leg on windows-latest.
+
 #### SRFI 271 (Random port libraries)
 
 - **SRFI 271 (Random port libraries)** — `(import (srfi 271))` gives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,12 @@ This runs `zig fmt --check` on staged `.zig` files before each commit.
 run in Linux containers via podman (x86_64 via Rosetta, riscv64 via QEMU).
 `zig build -Dtarget=aarch64-windows` (or `x86_64-windows`) cross-compiles
 the Windows binaries (kaappi.exe, thottam.exe, kaappi-lsp.exe);
-syscall-level platform differences live in `src/platform.zig` — both
-arches share the same OS-gated code (see `docs/dev/windows.md` for the
-port's architecture, degradations, and how to test on a Windows machine;
-x86_64 also builds natively with the stock Zig toolchain, and x64
-binaries run on the ARM64 reference VM via Windows' x64 emulation).
+syscall-level platform differences live behind the `src/platform.zig`
+facade (Windows ABI/socket/pipe helpers in `src/platform_win*.zig`) —
+both arches share the same OS-gated code (see `docs/dev/windows.md` for
+the port's architecture, degradations, and how to test on a Windows
+machine; x86_64 also builds natively with the stock Zig toolchain, and
+x64 binaries run on the ARM64 reference VM via Windows' x64 emulation).
 `zig build -Dtarget=aarch64-freebsd` (or `x86_64-freebsd`) cross-compiles
 for FreeBSD — a full-POSIX port with no degradations (`docs/dev/freebsd.md`).
 `zig build -Dtarget=aarch64-openbsd` (or `x86_64-openbsd`) cross-compiles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ This runs `zig fmt --check` on staged `.zig` files before each commit.
 | Linux | x86_64 | yes | yes | CI tested (Ubuntu) |
 | Linux | aarch64 | yes | yes | CI tested (Ubuntu ARM) |
 | Linux | riscv64 | yes | yes | CI tested (QEMU) |
-| Windows | aarch64 (ARM64) | yes | yes | `zig build -Dtarget=aarch64-windows`; see `docs/dev/windows.md` |
+| Windows | aarch64 (ARM64), x86_64 | yes | yes | `zig build -Dtarget=<arch>-windows`; see `docs/dev/windows.md` |
 | FreeBSD | x86_64, aarch64 | yes | yes | `zig build -Dtarget=<arch>-freebsd`; kqueue reactor; see `docs/dev/freebsd.md` |
 | OpenBSD | x86_64, aarch64 | yes | yes | `zig build -Dtarget=<arch>-openbsd`; kqueue reactor; binaries auto-marked `PT_OPENBSD_NOBTCFI`; see `docs/dev/openbsd.md` |
 | NetBSD | x86_64, aarch64 | yes | yes | `zig build -Dtarget=<arch>-netbsd`; kqueue reactor; versioned libc symbols bound explicitly; aarch64 FPCR reset at startup; see `docs/dev/netbsd.md` |
@@ -112,10 +112,13 @@ This runs `zig fmt --check` on staged `.zig` files before each commit.
 **Cross-compilation:** `zig build -Dtarget=x86_64-linux` and
 `zig build -Dtarget=riscv64-linux` cross-compile from macOS ARM. Binaries
 run in Linux containers via podman (x86_64 via Rosetta, riscv64 via QEMU).
-`zig build -Dtarget=aarch64-windows` cross-compiles the Windows binaries
-(kaappi.exe, thottam.exe, kaappi-lsp.exe); syscall-level platform
-differences live in `src/platform.zig` (see `docs/dev/windows.md` for the
-port's architecture, degradations, and how to test on a Windows machine).
+`zig build -Dtarget=aarch64-windows` (or `x86_64-windows`) cross-compiles
+the Windows binaries (kaappi.exe, thottam.exe, kaappi-lsp.exe);
+syscall-level platform differences live in `src/platform.zig` — both
+arches share the same OS-gated code (see `docs/dev/windows.md` for the
+port's architecture, degradations, and how to test on a Windows machine;
+x86_64 also builds natively with the stock Zig toolchain, and x64
+binaries run on the ARM64 reference VM via Windows' x64 emulation).
 `zig build -Dtarget=aarch64-freebsd` (or `x86_64-freebsd`) cross-compiles
 for FreeBSD — a full-POSIX port with no degradations (`docs/dev/freebsd.md`).
 `zig build -Dtarget=aarch64-openbsd` (or `x86_64-openbsd`) cross-compiles

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ zig build test                       # run the unit tests
 | Linux | x86_64 | yes | yes | LLVM backend |
 | Linux | aarch64 | yes | yes | LLVM backend |
 | Linux | riscv64 | yes | yes | LLVM backend |
-| Windows | aarch64 (ARM64) | yes | yes | LLVM backend (needs a C toolchain) |
+| Windows | aarch64 (ARM64), x86_64 | yes | yes | LLVM backend (needs a C toolchain) |
 | FreeBSD | x86_64, aarch64 | yes | yes | LLVM backend (base `cc` suffices) |
 | OpenBSD | x86_64, aarch64 | yes | yes | LLVM backend (base `cc` suffices) |
 | NetBSD | x86_64, aarch64 | yes | yes | LLVM backend (needs pkgsrc `clang`; base `cc` is GCC) |
@@ -95,19 +95,20 @@ zig build test                       # run the unit tests
 The WASM build (`zig build wasm`) runs in browsers and WASI runtimes — it
 powers the [playground](https://kaappi-lang.org/playground/).
 
-The Windows port (`zig build -Dtarget=aarch64-windows`) covers the full
+The Windows port (`zig build -Dtarget=aarch64-windows` or
+`-Dtarget=x86_64-windows`) covers the full
 interpreter — REPL (plain line editing, no history/completion), fibers,
 channels, OS threads, FFI (`LoadLibrary`), and the `kaappi test` runner.
 thottam installs packages on Windows too (with Git for Windows on PATH);
 only manifests with a `build:` command are refused — the C-FFI packages'
 Makefiles target POSIX.
-Platform differences: fd readiness is socket-only — socket-backed ports
-get reactor-driven non-blocking fiber I/O (WSAEventSelect), while pipe
-and file ports keep blocking reads (timers and cross-thread wakeups
-always work) — and the POSIX-only slice of SRFI-170 (uid/gid, symlinks,
-chmod/umask, user/group info) raises a catchable file error.
-`cond-expand` distinguishes the platforms: Windows builds expose the
-`windows` feature identifier instead of `posix`.
+Platform differences: fd readiness covers sockets (event-driven,
+WSAEventSelect) and pipes (polled) — file ports keep blocking reads
+(timers and cross-thread wakeups always work) — and the POSIX-only
+slice of SRFI-170 (uid/gid, symlinks, chmod/umask, user/group info)
+raises a catchable file error. `cond-expand` distinguishes the
+platforms: Windows builds expose the `windows` feature identifier
+instead of `posix`.
 
 The FreeBSD port (`zig build -Dtarget=x86_64-freebsd` or
 `aarch64-freebsd`) is full POSIX with no degradations: kqueue-backed

--- a/build.zig
+++ b/build.zig
@@ -413,10 +413,11 @@ pub fn build(b: *std.Build) void {
     });
     const run_unit_tests = b.addRunArtifact(unit_tests);
     // Cross-compiled test binaries the host can't execute (no emulator
-    // registered — e.g. aarch64-windows) skip cleanly instead of failing,
-    // so `zig build test -Dtarget=aarch64-windows` is a compile gate CI
-    // can run anywhere. Native runs and QEMU-backed riscv64 are
-    // unaffected (the binary is executable there, so it still runs).
+    // registered — e.g. aarch64- or x86_64-windows) skip cleanly instead
+    // of failing, so `zig build test -Dtarget=<arch>-windows` is a
+    // compile gate CI can run anywhere. Native runs and QEMU-backed
+    // riscv64 are unaffected (the binary is executable there, so it
+    // still runs).
     run_unit_tests.skip_foreign_checks = true;
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);

--- a/docs/dev/porting.md
+++ b/docs/dev/porting.md
@@ -26,14 +26,16 @@ in [netbsd.md](netbsd.md)).
 | Linux | aarch64 | native | same | `test` (ubuntu-24.04-arm) | yes |
 | Linux | riscv64 | cross-compiled | unit + R7RS under QEMU user-mode | `riscv64-test` | yes |
 | Windows | aarch64 | cross-compiled only (#1613) | unit + thottam + R7RS + VM-verified `.scm` suites on `windows-11-arm` runners | `windows-cross` + `windows-arm-test` | yes (unstripped, #1607) |
+| Windows | x86_64 | cross-compiled or native | same as aarch64 plus the native-backend e2e (`run-e2e.ps1`) on `windows-latest` runners | `windows-cross` + `windows-x64-test` | yes |
 | FreeBSD | x86_64, aarch64 | cross-compiled | unit + thottam + full `.scm` suites in a KVM FreeBSD VM (x86_64); verified on a real 15.1 aarch64 box | `freebsd-test` | yes (both arches) |
 | OpenBSD | x86_64, aarch64 | cross-compiled | unit + thottam + full `.scm` suites in a KVM OpenBSD 7.9 VM (x86_64); verified on a real 7.9 aarch64 box | `openbsd-test` | yes (both arches, `PT_OPENBSD_NOBTCFI`-marked) |
 | NetBSD | x86_64, aarch64 | cross-compiled | unit + thottam + full `.scm` suites in a KVM NetBSD 10.1 VM (x86_64); verified on a real 10.1 aarch64 box | `netbsd-test` | yes (both arches) |
 | WASI | wasm32 | cross-compiled (`zig build wasm`) | smoke + timer + parallel-pool under wasmtime | `wasm` | yes (`kaappi.wasm`) |
 
 Everything builds from any host — Zig cross-compiles all rows; no target
-needs its own build machine (Windows currently *requires* cross-compilation
-because the 0.16.0 toolchain is itself miscompiled on that target, #1613).
+needs its own build machine (Windows **aarch64** currently *requires*
+cross-compilation because the 0.16.0 toolchain is itself miscompiled on
+that target, #1613; Windows x86_64 is unaffected and builds natively).
 
 ## Where portability lives
 

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -3,9 +3,12 @@
 Kaappi builds and runs on Windows 11, on both ARM64 and x86_64. The port
 keeps the runtime's integer-fd POSIX-shaped I/O layer intact by mapping
 it onto the C runtime's low-level io functions, and concentrates every
-syscall-level platform difference in one file. Everything below is
-OS-gated, not arch-gated — both architectures run the same platform
-code; only the toolchain caveats differ.
+syscall-level platform difference behind one facade — `src/platform.zig`,
+whose Windows ABI declarations and socket/pipe helpers live in
+`src/platform_win.zig`, `src/platform_win_sock.zig`, and
+`src/platform_win_pipe.zig`. Everything below is OS-gated, not
+arch-gated — both architectures run the same platform code; only the
+toolchain caveats differ.
 
 ```bash
 zig build -Dtarget=aarch64-windows        # kaappi.exe, thottam.exe, kaappi-lsp.exe

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -1,27 +1,38 @@
-# Windows port (aarch64)
+# Windows port (aarch64 + x86_64)
 
-Kaappi builds and runs on Windows 11 ARM64. The port keeps the runtime's
-integer-fd POSIX-shaped I/O layer intact by mapping it onto the C
-runtime's low-level io functions, and concentrates every syscall-level
-platform difference in one file.
+Kaappi builds and runs on Windows 11, on both ARM64 and x86_64. The port
+keeps the runtime's integer-fd POSIX-shaped I/O layer intact by mapping
+it onto the C runtime's low-level io functions, and concentrates every
+syscall-level platform difference in one file. Everything below is
+OS-gated, not arch-gated — both architectures run the same platform
+code; only the toolchain caveats differ.
 
 ```bash
 zig build -Dtarget=aarch64-windows        # kaappi.exe, thottam.exe, kaappi-lsp.exe
+zig build -Dtarget=x86_64-windows         # same three, x64
 zig build test -Dtarget=aarch64-windows   # compiles unit-tests.exe (run it on Windows)
+zig build test -Dtarget=x86_64-windows
 ```
 
 Builds use Zig's bundled mingw-w64, so no Windows SDK or MSVC install is
 needed on the build machine.
 
-Cross-compilation is currently the **only** way to build: the official
-Zig 0.16.0 aarch64-windows toolchain access-violates compiling anything
-natively on Windows ARM64 (`zig build` and `zig build-exe` alike, on any
-project — #1613). Root cause: LLVM miscompiled `private thread_local`
-access on aarch64-windows (ziglang#31865 on Codeberg), and the shipped
-zig.exe — itself a stripped, LLVM-built aarch64-windows binary — carries
-the miscompile. The LLVM fix landed ~2026-06 and Zig master nightlies
-compile natively on the box; kaappi native builds unblock when the first
-fixed release (0.17.0) ships and the pinned toolchain moves to it.
+On **aarch64**, cross-compilation is currently the **only** way to
+build: the official Zig 0.16.0 aarch64-windows toolchain
+access-violates compiling anything natively on Windows ARM64
+(`zig build` and `zig build-exe` alike, on any project — #1613). Root
+cause: LLVM miscompiled `private thread_local` access on
+aarch64-windows (ziglang#31865 on Codeberg), and the shipped zig.exe —
+itself a stripped, LLVM-built aarch64-windows binary — carries the
+miscompile. The LLVM fix landed ~2026-06 and Zig master nightlies
+compile natively on the box; kaappi native builds unblock when the
+first fixed release (0.17.0) ships and the pinned toolchain moves to
+it.
+
+On **x86_64**, none of that applies: #1613 is a bug in LLVM's aarch64
+COFF backend, and the standard Zig 0.16.0 x86_64-windows toolchain
+compiles natively. Cross-compiling from macOS/Linux and building
+natively on an x64 Windows box both work today.
 
 ## Architecture: src/platform.zig
 
@@ -218,7 +229,11 @@ natively and match the interpreter's output, and `kaappi doctor`'s
 smoke-link passes. Verified on Windows 11 ARM64 (build 26100) with a Zig
 master toolchain as the linker (#1610); with the 0.16.0 toolchain,
 `zig cc` on the box access-violates like every native toolchain use
-(#1613), so end users get this at the 0.17.0 bump.
+(#1613), so aarch64 end users get this at the 0.17.0 bump. On x86_64
+the stock 0.16.0 toolchain already works as the linker: the same e2e
+suite passes on the reference VM under x64 emulation with
+zig-x86_64-windows-0.16.0 on PATH, and the `windows-x64-test` CI job
+runs it on every PR.
 
 Windows-specific pieces of the path (#1610):
 
@@ -230,9 +245,9 @@ Windows-specific pieces of the path (#1610):
 * `kaappi compile foo.scm` derives `foo.exe` (PATH lookup and
   double-click need the extension); an explicit `-o name` is used as
   given.
-* The emitted module triple is `aarch64-pc-windows-gnu` — the gnu
-  (MinGW) ABI the runtime lib is built with and the ABI `zig cc` targets
-  on a box without MSVC.
+* The emitted module triple is `aarch64-pc-windows-gnu` /
+  `x86_64-pc-windows-gnu` per arch — the gnu (MinGW) ABI the runtime
+  lib is built with and the ABI `zig cc` targets on a box without MSVC.
 * The link line adds `-lws2_32` and drops `-lpthread`: the fd-readiness
   backends call Winsock through `extern "ws2_32"` declarations, which
   Zig links automatically only when it builds the final binary itself —
@@ -245,17 +260,24 @@ Windows-specific pieces of the path (#1610):
 
 ## Testing on a Windows machine
 
-CI covers the target twice (ci.yml): `windows-cross` cross-compiles the
-binaries and the test exes from Linux, guarding the path release.yml
-ships with, and `windows-arm-test` executes the unit suite, the thottam
+CI covers the target three ways (ci.yml): `windows-cross`
+cross-compiles the binaries and the test exes from Linux for **both**
+arches (a matrix over aarch64/x86_64), guarding the path release.yml
+ships with, and two execution jobs run the unit suite, the thottam
 suite plus a real package install/remove integration test, the R7RS
-suite, the VM-verified `.scm` suites, and the shell-based suites (#1612)
-on GitHub's hosted `windows-11-arm` runners on every PR. The execution
-job installs no toolchain — it downloads the binaries `windows-cross`
-built as an artifact, because native compilation on Windows ARM64 is
-broken in the Zig 0.16.0 toolchain itself (#1613). The FFI suite runs
-against a fixture DLL that `windows-cross` cross-compiles into the same
-artifact (`zig cc -target aarch64-windows-gnu -shared`).
+suite, the VM-verified `.scm` suites, and the shell-based suites
+(#1612) on every PR: `windows-arm-test` on GitHub's hosted
+`windows-11-arm` runners and `windows-x64-test` on the standard
+x86_64 `windows-latest` runners. Both execution jobs run the suites
+from the cross-compiled artifacts with no toolchain installed — on
+aarch64 because native compilation is broken in the Zig 0.16.0
+toolchain itself (#1613), on x64 so both jobs exercise identical
+no-toolchain conditions. The x64 job then installs the (natively
+working) x86_64 Zig and runs the native-backend e2e suite
+(`tests/e2e/run-e2e.ps1`, #1610) — the one leg the arm job cannot
+have until the 0.17.0 bump. The FFI suite runs against a fixture DLL
+that `windows-cross` cross-compiles into each artifact
+(`zig cc -target <arch>-windows-gnu -shared`).
 
 The shell-based drivers (errors, test-runner, pipeline, doctor, fmt,
 cache, timings, the smoke `.sh` scripts, sandbox, robustness) run under
@@ -298,7 +320,22 @@ complete R7RS suite, every `tests/scheme/{smoke,compliance,
 continuations,hygiene,srfi,ffi,audit}` file, and the shell-based
 suites under Git Bash (34 pass, 15 skip: the 14 `compile/` gates plus
 `profile-json-escaping.sh`) — the same set the `windows-arm-test` CI
-job now runs on every PR. The fd-readiness unit
+job now runs on every PR.
+
+The **x86_64** build was verified on the same reference machine via
+Windows 11's built-in x64 emulation layer (x64 binaries run
+transparently on ARM64 Windows), which is also how to re-test it
+there: cross-compile with `-Dtarget=x86_64-windows`, ship, run. The
+full set passed under emulation — unit suite (1166/0, 15 skips),
+thottam suite, R7RS, all 436 `.scm` suite files, the shell suites
+(same 34/15/0 profile as aarch64), the post-release acceptance script
+(34/34), and the native-backend e2e (see above). A stripped x86_64
+kaappi.exe starts and runs correctly — the #1607 strip crash does not
+exist on this arch. Emulation is a fidelity compromise (it validates
+the port's logic, not x64 silicon); the `windows-x64-test` CI job runs
+the same suites on real x86_64 runners on every PR, so the VM is only
+needed for what CI can't reach (interactive REPL, release smoke
+tests). The fd-readiness unit
 suites (`tests_reactor.zig`, `tests_scheduler.zig`, `tests_port_io.zig`)
 run on Windows too: testing_helpers' cross-platform fd pairs substitute
 loopback TCP socket pairs for the POSIX pipes/socketpairs, so those
@@ -312,36 +349,46 @@ see "Native backend" above).
 
 ## Releasing
 
-`release.yml` cross-compiles the Windows row from an ubuntu runner and
-ships `kaappi-aarch64-windows.exe`, `thottam-aarch64-windows.exe`, and
-`libkaappi_rt-aarch64-windows.lib` (the gnu-ABI static lib is emitted as
-`kaappi_rt.lib`). The row builds with `-Dstrip=false`: a **stripped**
-kaappi.exe access-violates at startup on ARM64 Windows (0xC0000005
-before any output — #1607). Root cause: under strip, Zig demotes
-threadlocals to `private` linkage and LLVM emits a broken +64 KB TLS
-offset for them on aarch64-windows (ziglang#31865) — kaappi reaches
-`vm_instance`/`gc_instance` at startup, while thottam and small probes
-have no affected threadlocal access, which is why only kaappi.exe
-crashed. Fixed in LLVM/Zig master; re-enable strip for the row and
-retest after the toolchain bump (#1613). The post-release acceptance workflow checksums the Windows
-artifacts but does not yet execute them (wiring it to the hosted
-`windows-11-arm` runners is open) — smoke-test a release manually per
-the github-release skill's Step 10.
+`release.yml` cross-compiles both Windows rows from ubuntu runners and
+ships `kaappi-{aarch64,x86_64}-windows.exe`,
+`thottam-{aarch64,x86_64}-windows.exe`, and
+`libkaappi_rt-{aarch64,x86_64}-windows.lib` (the gnu-ABI static lib is
+emitted as `kaappi_rt.lib`). The **aarch64** row builds with
+`-Dstrip=false`: a **stripped** kaappi.exe access-violates at startup
+on ARM64 Windows (0xC0000005 before any output — #1607). Root cause:
+under strip, Zig demotes threadlocals to `private` linkage and LLVM
+emits a broken +64 KB TLS offset for them on aarch64-windows
+(ziglang#31865) — kaappi reaches `vm_instance`/`gc_instance` at
+startup, while thottam and small probes have no affected threadlocal
+access, which is why only kaappi.exe crashed. Fixed in LLVM/Zig
+master; re-enable strip for the row and retest after the toolchain
+bump (#1613). The **x86_64** row strips like every other platform —
+the miscompile lives in LLVM's aarch64 COFF backend, and a stripped
+x64 kaappi.exe was verified working on the reference VM. Post-release,
+the x86_64 artifact has a real acceptance leg (`test-windows-x64` in
+post-release.yml, on windows-latest); the aarch64 artifact is
+checksummed but not executed (a `windows-11-arm` leg is still open) —
+smoke-test it manually per the github-release skill's Step 10.
 
 ## Known gaps / follow-ups
 
-* Native compilation on Windows ARM64 crashes in the Zig 0.16.0
+* Native compilation on Windows **ARM64** crashes in the Zig 0.16.0
   toolchain (`zig build`/`zig build-exe`/`zig cc` access-violate on any
-  project, #1613) — all builds must cross-compile, and `kaappi compile`
-  needs a fixed toolchain on the box for its link step (verified
-  end-to-end with Zig master, see "Native backend" above). Fixed
-  upstream (ziglang#31865); everything unblocks at the 0.17.0 toolchain
-  bump.
+  project, #1613) — aarch64 builds must cross-compile, and `kaappi
+  compile` needs a fixed toolchain on the box for its link step
+  (verified end-to-end with Zig master, see "Native backend" above).
+  Fixed upstream (ziglang#31865); everything unblocks at the 0.17.0
+  toolchain bump. x86_64 Windows is unaffected.
 * The `compile/` shell suite self-skips on Windows: every script
   rebuilds the runtime archive or the interpreter with a native `zig`
-  on the box, which #1613 breaks. The `skip_on_windows` gates
-  (tests/scheme/shell-common.sh) lift work at the 0.17.0 toolchain
-  bump. (The rest of the shell-based suites run in CI — #1612.)
+  on the box, which #1613 breaks on aarch64. The `skip_on_windows`
+  gates (tests/scheme/shell-common.sh) are OS-level, so they also skip
+  on x86_64 where a native zig would actually work — the scripts
+  themselves have never been ported to Windows path/exe-suffix
+  conventions. Lifting the gates (per-arch or wholesale at the 0.17.0
+  bump) is open; the native-compile path on x64 is covered by
+  run-e2e.ps1 in `windows-x64-test` meanwhile. (The rest of the
+  shell-based suites run in CI — #1612.)
 * thottam refuses manifests with a `build:` command (#1609 ported
   everything else — see Deliberate degradations above); lifting that
   needs a Windows build story for the C-FFI packages, which today are
@@ -350,5 +397,6 @@ the github-release skill's Step 10.
   plain REPL depends on the console's UTF-8 code page (set at startup).
 * Long paths (> 260 chars) need the system long-path opt-in.
 * `-Dstrip=true` produces a kaappi.exe that access-violates at startup
-  on ARM64 Windows (#1607, see Releasing above) — releases ship it
-  unstripped until the toolchain bump lands the LLVM TLS fix.
+  on ARM64 Windows (#1607, see Releasing above) — the aarch64 release
+  row ships unstripped until the toolchain bump lands the LLVM TLS
+  fix. The x86_64 row is unaffected and ships stripped.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -136,8 +136,13 @@ pub const Options = struct {
     lib_path_buf: [16][]const u8 = undefined,
     lib_path_count: usize = 0,
 
-    script_arg_buf: [64][]const u8 = undefined,
-    script_arg_count: usize = 0,
+    /// The script path plus every argument after it, in argv order — what a
+    /// script's `(command-line)` reports and what multi-file subcommands
+    /// (`fmt`, `test`) iterate. Allocated from the same immortal c_allocator
+    /// argv itself lives in (platform.argsIterate): a fixed cap here
+    /// silently dropped every argument past the 64th, so `kaappi fmt` over
+    /// the 573-file corpus only ever touched the first 64 files (#1652).
+    script_args_slice: []const []const u8 = &.{},
 
     action: Action = .run,
 
@@ -148,7 +153,7 @@ pub const Options = struct {
     }
 
     pub fn scriptArgs(self: *const Options) []const []const u8 {
-        return self.script_arg_buf[0..self.script_arg_count];
+        return self.script_args_slice;
     }
 };
 
@@ -298,8 +303,8 @@ pub fn parse(args: std.process.Args) Options {
     // Collect remaining args after the file path for (command-line).
     // Also check for -o which is valid after the file path for compile modes.
     if (opts.file_path) |fp| {
-        opts.script_arg_buf[0] = fp;
-        opts.script_arg_count = 1;
+        var script_args: std.ArrayList([]const u8) = .empty;
+        script_args.append(std.heap.c_allocator, fp) catch oomCollectingArgs();
         const consumes_output = opts.compile_mode or opts.native_compile_mode or
             opts.disassemble_mode or opts.emit_llvm_mode;
         while (iter.next()) |extra| {
@@ -313,14 +318,16 @@ pub fn parse(args: std.process.Args) Options {
                 opts.ir_no_opt = true;
                 continue;
             }
-            if (opts.script_arg_count < 64) {
-                opts.script_arg_buf[opts.script_arg_count] = extra;
-                opts.script_arg_count += 1;
-            }
+            script_args.append(std.heap.c_allocator, extra) catch oomCollectingArgs();
         }
+        opts.script_args_slice = script_args.toOwnedSlice(std.heap.c_allocator) catch oomCollectingArgs();
     }
 
     return opts;
+}
+
+fn oomCollectingArgs() noreturn {
+    usageError("kaappi: out of memory collecting command-line arguments\n");
 }
 
 pub fn printUsage() void {
@@ -562,10 +569,32 @@ test "parse: value flags" {
 test "parse: script args after filename" {
     const argv = [_][*:0]const u8{ "kaappi", "test.scm", "arg1", "arg2" };
     const opts = parse(testArgs(&argv));
-    try std.testing.expectEqual(@as(usize, 3), opts.script_arg_count);
+    try std.testing.expectEqual(@as(usize, 3), opts.scriptArgs().len);
     try std.testing.expectEqualStrings("test.scm", opts.scriptArgs()[0]);
     try std.testing.expectEqualStrings("arg1", opts.scriptArgs()[1]);
     try std.testing.expectEqualStrings("arg2", opts.scriptArgs()[2]);
+}
+
+test "parse: script args past the 64th are kept (#1652)" {
+    // The old fixed [64] buffer silently dropped everything past it — the
+    // fmt corpus (573 files in one xargs invocation) only ever touched the
+    // first 64 files. Build 129 args and require every one to survive.
+    const argv = comptime blk: {
+        @setEvalBranchQuota(200_000);
+        var a: [131][*:0]const u8 = undefined;
+        a[0] = "kaappi";
+        a[1] = "test.scm";
+        for (0..129) |i| {
+            a[2 + i] = std.fmt.comptimePrint("arg{d}", .{i});
+        }
+        break :blk a;
+    };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expectEqual(@as(usize, 130), opts.scriptArgs().len);
+    try std.testing.expectEqualStrings("test.scm", opts.scriptArgs()[0]);
+    try std.testing.expectEqualStrings("arg63", opts.scriptArgs()[64]);
+    try std.testing.expectEqualStrings("arg64", opts.scriptArgs()[65]);
+    try std.testing.expectEqualStrings("arg128", opts.scriptArgs()[129]);
 }
 
 test "parse: compile subcommand" {
@@ -691,7 +720,7 @@ test "parse: flags after filename are script args" {
     const opts = parse(testArgs(&argv));
     try std.testing.expect(!opts.gc_stats_mode);
     try std.testing.expect(!opts.profile_mode);
-    try std.testing.expectEqual(@as(usize, 3), opts.script_arg_count);
+    try std.testing.expectEqual(@as(usize, 3), opts.scriptArgs().len);
     try std.testing.expectEqualStrings("--gc-stats", opts.scriptArgs()[1]);
 }
 
@@ -718,7 +747,7 @@ test "parse: --diagnostics=json after filename is a script arg, not a format" {
     const argv = [_][*:0]const u8{ "kaappi", "test.scm", "--diagnostics=json" };
     const opts = parse(testArgs(&argv));
     try std.testing.expectEqual(DiagnosticsFormat.text, opts.diagnostics_format);
-    try std.testing.expectEqual(@as(usize, 2), opts.script_arg_count);
+    try std.testing.expectEqual(@as(usize, 2), opts.scriptArgs().len);
     try std.testing.expectEqualStrings("--diagnostics=json", opts.scriptArgs()[1]);
 }
 

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -208,6 +208,10 @@ const Lexer = struct {
             self.pos += 4;
             return .list_open;
         }
+        if (rest.len >= 2 and rest[1] == '"') {
+            try self.scanRawString();
+            return .atom;
+        }
         if (rest.len >= 2 and rest[1] == '\\') {
             self.scanChar();
             return .atom;
@@ -225,6 +229,31 @@ const Lexer = struct {
         }
         self.scanAtom();
         return .atom;
+    }
+
+    /// SRFI 267 raw string `#"X" content "X"` — one verbatim lexeme, kept
+    /// byte-for-byte (newlines included; a multiline atom never inlines, see
+    /// `computeMeasure`). Mirrors reader_tokens.readRawString: the delimiter X
+    /// is the bytes up to the next `"`, the terminator is `"` X `"`, and no
+    /// escape sequences exist. `self.pos` is at the `#`.
+    fn scanRawString(self: *Lexer) ParseError!void {
+        self.pos += 2; // consume `#"`
+        const delim_start = self.pos;
+        while (self.pos < self.src.len and self.src[self.pos] != '"') self.pos += 1;
+        if (self.pos >= self.src.len) return ParseError.UnterminatedString;
+        const delim = self.src[delim_start..self.pos];
+        self.pos += 1; // the `"` closing the delimiter / opening the content
+        while (self.pos < self.src.len) : (self.pos += 1) {
+            if (self.src[self.pos] == '"' and
+                self.pos + delim.len + 2 <= self.src.len and
+                std.mem.eql(u8, self.src[self.pos + 1 .. self.pos + 1 + delim.len], delim) and
+                self.src[self.pos + 1 + delim.len] == '"')
+            {
+                self.pos += delim.len + 2; // consume the whole terminator
+                return;
+            }
+        }
+        return ParseError.UnterminatedString;
     }
 
     fn scanAtom(self: *Lexer) void {

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -10,14 +10,19 @@
 //! and calls the wide CRT entry points so non-ASCII paths work regardless
 //! of the active ANSI code page.
 //!
-//! Fd readiness on Windows is socket-only (#1608 stage 1): ports whose
-//! CRT fd wraps a SOCKET (isSocketFd probe) flip to non-blocking via
-//! FIONBIO and get reactor-driven fiber suspension through WSAEventSelect
-//! (reactor.zig's WindowsEventBackend), reading/writing through
-//! sockRecv/sockSend. Pipes and files have no would-block mode at the CRT
-//! layer, so their fiber I/O still degrades to blocking reads — the same
-//! shape as a WASI host whose NONBLOCK probe fails. Sequential programs
-//! and timer-driven fibers are unaffected either way.
+//! Fd readiness on Windows (#1608): ports whose CRT fd wraps a SOCKET
+//! (isSocketFd probe) flip to non-blocking via FIONBIO and get
+//! event-driven fiber suspension through WSAEventSelect (reactor.zig's
+//! WindowsEventBackend), reading/writing through sockRecv/sockSend.
+//! Pipe ports have no OS-level would-block mode, so they enter *emulated*
+//! non-blocking mode under a scheduler: pipeRead/pipeWrite's
+//! non-destructive pre-checks synthesize EAGAIN and the reactor re-polls
+//! the same checks on a 10 ms quantum (platform_win_pipe.zig). File
+//! ports keep blocking reads — the POSIX baseline too, since no OS has
+//! regular-file readiness. Sequential programs and timer-driven fibers
+//! are unaffected either way. This file is the public facade; the
+//! Windows ABI declarations and the socket/pipe helpers live in
+//! platform_win.zig, platform_win_sock.zig, and platform_win_pipe.zig.
 
 const std = @import("std");
 const builtin = @import("builtin");

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -1,4 +1,4 @@
-//! Cross-platform syscall shim (Windows aarch64 target).
+//! Cross-platform syscall shim (Windows targets, aarch64 + x86_64).
 //!
 //! The runtime's I/O layer is built on integer file descriptors with
 //! POSIX read/write/open/close semantics. POSIX targets forward straight

--- a/src/tests_fmt.zig
+++ b/src/tests_fmt.zig
@@ -291,3 +291,29 @@ test "empty input yields empty output" {
     try expectFormat("", "");
     try expectFormat("   \n\n  ", "");
 }
+
+// ── SRFI 267 raw strings (#1652 corpus fallout) ──────────────────────────────
+// The CST lexer must carve `#"X" content "X"` exactly like the real reader
+// (reader_tokens.readRawString), or the round-trip guard refuses the file —
+// srfi267.scm surfaced this the first time the corpus actually reached it.
+
+test "raw string is one verbatim lexeme" {
+    try expectFormat("(display   #\"\"no escapes \\n here\"\")", "(display #\"\"no escapes \\n here\"\")\n");
+    try expectFormat("(a  #\"X\"quotes \" inside\"X\"  b)", "(a #\"X\"quotes \" inside\"X\" b)\n");
+}
+
+test "multiline raw string never inlines and stays byte-identical" {
+    const src = "(define text #\"\"line one\nline two\"\")\n";
+    try expectIdempotent(src);
+    try expectRoundTrips(src);
+}
+
+test "raw strings round-trip through the real reader" {
+    try expectRoundTrips("(list #\"\"plain\"\" #\"q\"with \" quote\"q\")");
+}
+
+test "unterminated raw string is a format error" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try testing.expectError(fmt.ParseError.UnterminatedString, fmt.formatSource(arena.allocator(), "(a #\"X\"never closed"));
+}

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -8,8 +8,10 @@
 # kaappi_rt.lib are cross-compiled and copied over — see "Testing on a Windows
 # machine" in docs/dev/windows.md. `kaappi compile` discovers kaappi_rt.lib by
 # itself (exe-relative ..\lib, or KAAPPI_LIB_DIR) and links with the first C
-# compiler found on PATH, so put a working zig on PATH first (Zig master /
-# >= 0.17.0 on ARM64 — the 0.16.0 toolchain access-violates, #1613).
+# compiler found on PATH, so put a working zig on PATH first: on ARM64 that
+# means Zig master / >= 0.17.0 (the 0.16.0 toolchain access-violates, #1613);
+# on x86_64 the stock 0.16.0 toolchain works (#1613 is aarch64-only) and the
+# windows-x64-test CI job runs this script with it on every PR.
 #
 # Usage: powershell -ExecutionPolicy Bypass -File tests\e2e\run-e2e.ps1 `
 #            [-Kaappi <path\to\kaappi.exe>]

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -68,8 +68,9 @@ KAAPPI_TEST_SKIP="callcc-bench.scm" bash tests/scheme/run-all.sh
 ## Shell test scripts (`*.sh`)
 
 Suite directories may also hold bash drivers; `run-all.sh` runs them via
-`run_shell_suite` (and the `windows-arm-test` CI job runs them under Git
-Bash on Windows — see `docs/dev/windows.md`). Conventions:
+`run_shell_suite` (and the `windows-arm-test`/`windows-x64-test` CI jobs
+run them under Git Bash on Windows — see `docs/dev/windows.md`).
+Conventions:
 
 - Accept the binary as `${KAAPPI:-zig-out/bin/kaappi}` or `${1:-...}` —
   runners pass both.

--- a/tests/scheme/fmt/fmt.sh
+++ b/tests/scheme/fmt/fmt.sh
@@ -89,6 +89,26 @@ assert_exit "write: result is already formatted" 0 "$KAAPPI" fmt --check "$TMP/w
 printf '(a b c\n' > "$TMP/unterminated.scm"
 assert_exit "error: unterminated list exits 1" 1 "$KAAPPI" fmt --check "$TMP/unterminated.scm"
 
+# ── Regression #1652: arguments past the 64th must not be dropped ────────────
+# The CLI once collected script args into a fixed [64] buffer and silently
+# discarded the rest, so a single fmt/--check invocation over a big file list
+# (exactly how xargs drives the corpus below) never touched files 65+.
+
+mkdir -p "$TMP/argcliff"
+cliff_files=()
+for i in $(seq 1 70); do
+    printf '(define x %d)\n' "$i" > "$TMP/argcliff/f$i.scm"
+    cliff_files+=("$TMP/argcliff/f$i.scm")
+done
+printf '(define    y   70)\n' > "$TMP/argcliff/f70.scm" # only unformatted file
+status=0
+"$KAAPPI" fmt --check "${cliff_files[@]}" > "$TMP/argcliff.out" 2>&1 || status=$?
+if [[ "$status" -eq 1 ]] && grep -q "f70.scm" "$TMP/argcliff.out"; then
+    pass "check: file #70 of 70 still checked (#1652)"
+else
+    fail "check: file #70 of 70 still checked (#1652)" "exit $status, output: $(cat "$TMP/argcliff.out")"
+fi
+
 # ── Corpus: zero semantic drift + idempotence over the repo tree ─────────────
 
 corpus_files() {

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -4,7 +4,7 @@
 # On Windows the suites run under Git Bash (MSYS) — see docs/dev/windows.md.
 # A script whose premise cannot hold there calls skip_on_windows with a
 # reason and exits 77, the conventional SKIP status (automake's) that
-# run-all.sh and the windows-arm-test CI driver both recognize. This is the
+# run-all.sh and the Windows CI test drivers recognize. This is the
 # shell analogue of the `cond-expand (windows ...)` gate the .scm tests use.
 
 # is_windows: true under Git Bash / MSYS / Cygwin on Windows.


### PR DESCRIPTION
## Summary

Extends the Windows port (aarch64, #1606) to **x86_64**. The platform layer (`src/platform.zig`) was already OS-gated rather than arch-gated, so both architectures share the same code and degradation profile — this PR is the CI/release/docs wiring plus full verification, with two arch-specific findings that make x64 *stronger* than the ARM64 port:

- **#1613 does not apply on x64**: the stock Zig 0.16.0 x86_64-windows toolchain compiles natively (the access-violation is an aarch64-only LLVM COFF bug). Verified by building kaappi from clean source on the box — the resulting binary reports `x86_64-windows-gnu`. This also means `kaappi compile` works for end users today with the stock toolchain (no master-toolchain workaround).
- **#1607 does not apply on x64**: a stripped x64 kaappi.exe starts and runs correctly, so the release row ships `strip: true` like every other platform (the aarch64 row stays unstripped until the 0.17.0 bump).

## Also fixes #1652 (pre-existing, exposed by this PR's CI run)

The first `windows-arm-test` run went red on fmt.sh while x64/macOS/Linux stayed green. Root cause was nothing Windows-specific: **the CLI silently dropped every argument past the 64th** (fixed `[64]` buffer in `cli.zig`), so `kaappi fmt` over the 573-file corpus only ever touched the first 64 files — on POSIX, xargs fits all 573 paths in one invocation, so the corpus phases have never actually validated files 65+. GitHub's large job environment makes MSYS xargs split the list, `fmt` vs `fmt --check` split at different boundaries, and the gap files got flagged; the branch-name length shifts the boundary, which is why main and earlier PRs were green by luck.

Fixed by growing script args dynamically (same immortal c_allocator convention as `platform.argsIterate`), with regression tests at the `cli.parse` level (129 args) and in fmt.sh (70-file `--check` whose 70th file is the only unformatted one). Running the corpus in full for the first time then surfaced a second latent bug, also fixed here: the fmt CST lexer didn't know **SRFI 267 raw strings**, so the round-trip guard refused `srfi267.scm`; `scanRawString` now mirrors `reader_tokens.readRawString` (new tests_fmt.zig cases). The same silent-drop shape exists for `--lib-path` (cap 16) and is tracked as #1653.

## Verification

x86_64 Windows (Windows 11 reference VM, `ssh win11`, via the built-in x64 emulation layer):

| Suite | Result |
|-------|--------|
| Unit suite (cross-compiled unit-tests.exe) | 1166 passed, 15 skipped, 0 failed |
| thottam suite | 22 passed, 3 skipped, 0 failed |
| R7RS suite | green |
| `.scm` suites (smoke/compliance/continuations/hygiene/srfi/ffi/audit) | 436 passed, 0 failed |
| Shell suites (Git Bash) | 34 pass, 15 skip, 0 fail — same profile as aarch64 |
| `tests/acceptance/acceptance.sh` (post-release dry-run) | 34/34 |
| Native-backend e2e `tests/e2e/run-e2e.ps1` (stock x64 zig 0.16.0 as linker) | 38/38 |
| Native `zig build` from clean source + run | works |
| Stripped kaappi.exe | works |

Local (macOS, after the #1652 fix): full unit suite green; `run-all.sh` **1877 pass, 0 fail** — including the fmt corpus genuinely covering all 573 files for the first time.

## Changes

- **ci.yml**: `windows-cross` becomes an aarch64/x86_64 matrix (also stages `kaappi_rt.lib` in the artifacts); new `windows-x64-test` job on `windows-latest` executes the same suites as `windows-arm-test`, then installs Zig and runs the native-backend e2e — the `kaappi compile` leg the arm job can't have until the 0.17.0 bump. Zig installs only *after* the shell suites so both Windows jobs run them under identical no-toolchain conditions.
- **release.yml**: `x86_64-windows` row (stripped); ships `kaappi-x86_64-windows.exe`, `thottam-x86_64-windows.exe`, `libkaappi_rt-x86_64-windows.lib`.
- **post-release.yml**: new `test-windows-x64` acceptance leg (checksum verify + `acceptance.sh` under Git Bash on windows-latest) — the first executed post-release coverage for any Windows artifact; wired into the `summary` gate.
- **cli.zig / fmt.zig / tests_fmt.zig / fmt.sh**: the #1652 fix, SRFI-267 raw-string support in the fmt lexer, and their regression tests.
- **Docs**: `docs/dev/windows.md` reworked for both arches (toolchain caveats scoped to aarch64, x64 testing-via-emulation notes), `docs/dev/porting.md` support matrix, README/CLAUDE.md platform tables, CHANGELOG, github-release skill (platform list + Step 10), `run-e2e.ps1` header, comment touch-ups. Also corrected README's stale "fd readiness is socket-only" claim (pipes have polled readiness since #1623).

🤖 Generated with [Claude Code](https://claude.com/claude-code)