### PR TITLE
Fix --lib-path entries past the 16th being silently dropped (#1653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   input ports, so `read-u8`, `read-bytevector`, and `u8-ready?` operate on
   them directly. See `lib/srfi/271*.sld` and `tests/scheme/srfi/srfi271.scm`.
 
+### Fixed
+
+- **`--lib-path` entries past the 16th are no longer silently dropped**
+  (#1653) — two fixed `[16]` buffers (CLI storage in `cli.zig` and the
+  search-path assembly in `main.zig`) capped the library search path with
+  no diagnostic, so a 17th `--lib-path` — or the auto-discovered dirs
+  (script directory, `~/.kaappi/lib`, exe-relative `lib`) once 16 explicit
+  ones existed — vanished. Both now grow dynamically. Same silent-data-loss
+  shape as the CLI-argument cap fixed in #1652.
+
 ## [0.19.0] - 2026-07-18
 
 ### Added

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -133,8 +133,12 @@ pub const Options = struct {
     sandbox_mode: bool = false,
     no_ir_opt: bool = false,
 
-    lib_path_buf: [16][]const u8 = undefined,
-    lib_path_count: usize = 0,
+    /// Every `--lib-path <dir>` entry, in argv order. Allocated from the same
+    /// immortal c_allocator as script_args_slice: a fixed [16] cap here
+    /// silently dropped every path past the 16th, the same shape as #1652
+    /// (#1653). main.zig folds these into vm.lib_paths alongside the
+    /// auto-discovered dirs.
+    lib_paths_slice: []const []const u8 = &.{},
 
     /// The script path plus every argument after it, in argv order — what a
     /// script's `(command-line)` reports and what multi-file subcommands
@@ -149,7 +153,7 @@ pub const Options = struct {
     pub const Action = enum { run, exit_ok };
 
     pub fn libPaths(self: *const Options) []const []const u8 {
-        return self.lib_path_buf[0..self.lib_path_count];
+        return self.lib_paths_slice;
     }
 
     pub fn scriptArgs(self: *const Options) []const []const u8 {
@@ -186,6 +190,12 @@ pub fn parse(args: std.process.Args) Options {
     var opts: Options = .{};
     var iter = platform.argsIterate(args);
     _ = iter.skip();
+
+    // Grows dynamically (same immortal c_allocator convention as script args):
+    // the old fixed [16] silently dropped a 17th --lib-path (#1653). The
+    // exit_ok flags (--help/--version/--completions) return before the
+    // toOwnedSlice below, leaving lib_paths_slice empty — they never consult it.
+    var lib_paths: std.ArrayList([]const u8) = .empty;
 
     while (iter.next()) |arg| {
         if (std.mem.eql(u8, arg, "compile")) {
@@ -260,12 +270,7 @@ pub fn parse(args: std.process.Args) Options {
                     opts.action = .exit_ok;
                     return opts;
                 },
-                .lib_path => {
-                    if (opts.lib_path_count < 16) {
-                        opts.lib_path_buf[opts.lib_path_count] = value.?;
-                        opts.lib_path_count += 1;
-                    }
-                },
+                .lib_path => lib_paths.append(std.heap.c_allocator, value.?) catch oomCollectingArgs(),
                 .compile => opts.compile_mode = true,
                 .emit_llvm => opts.emit_llvm_mode = true,
                 .output => opts.compile_output = value.?,
@@ -299,6 +304,8 @@ pub fn parse(args: std.process.Args) Options {
             break;
         }
     }
+
+    opts.lib_paths_slice = lib_paths.toOwnedSlice(std.heap.c_allocator) catch oomCollectingArgs();
 
     // Collect remaining args after the file path for (command-line).
     // Also check for -o which is valid after the file path for compile modes.
@@ -370,7 +377,7 @@ pub fn printUsage() void {
             "Options:\n" ++
             "  -h, --help         Show this help message\n" ++
             "  --version          Show version\n" ++
-            "  --lib-path <path>  Add library search path (up to 16)\n" ++
+            "  --lib-path <path>  Add library search path (repeatable)\n" ++
             "  --compile          Compile file to bytecode (.sbc)\n" ++
             "  --emit-llvm        Emit LLVM IR text (.ll)\n" ++
             "  -o <file>          Output path\n" ++
@@ -560,7 +567,7 @@ test "parse: boolean flags" {
 test "parse: value flags" {
     const argv = [_][*:0]const u8{ "kaappi", "--lib-path", "/foo", "--timeout", "5000", "test.scm" };
     const opts = parse(testArgs(&argv));
-    try std.testing.expectEqual(@as(usize, 1), opts.lib_path_count);
+    try std.testing.expectEqual(@as(usize, 1), opts.libPaths().len);
     try std.testing.expectEqualStrings("/foo", opts.libPaths()[0]);
     try std.testing.expectEqual(@as(u64, 5000), opts.timeout_ms.?);
     try std.testing.expectEqualStrings("test.scm", opts.file_path.?);
@@ -690,9 +697,32 @@ test "parse: no args → REPL (no file)" {
 test "parse: multiple lib paths" {
     const argv = [_][*:0]const u8{ "kaappi", "--lib-path", "/a", "--lib-path", "/b", "test.scm" };
     const opts = parse(testArgs(&argv));
-    try std.testing.expectEqual(@as(usize, 2), opts.lib_path_count);
+    try std.testing.expectEqual(@as(usize, 2), opts.libPaths().len);
     try std.testing.expectEqualStrings("/a", opts.libPaths()[0]);
     try std.testing.expectEqualStrings("/b", opts.libPaths()[1]);
+}
+
+test "parse: lib paths past the 16th are kept (#1653)" {
+    // The old fixed [16] buffer silently dropped every --lib-path past it (same
+    // shape as #1652). Build 20 of them and require every one to survive.
+    const argv = comptime blk: {
+        @setEvalBranchQuota(200_000);
+        var a: [42][*:0]const u8 = undefined;
+        a[0] = "kaappi";
+        for (0..20) |i| {
+            a[1 + 2 * i] = "--lib-path";
+            a[2 + 2 * i] = std.fmt.comptimePrint("/lib{d}", .{i});
+        }
+        a[41] = "test.scm";
+        break :blk a;
+    };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expectEqual(@as(usize, 20), opts.libPaths().len);
+    try std.testing.expectEqualStrings("/lib0", opts.libPaths()[0]);
+    try std.testing.expectEqualStrings("/lib15", opts.libPaths()[15]);
+    try std.testing.expectEqualStrings("/lib16", opts.libPaths()[16]);
+    try std.testing.expectEqualStrings("/lib19", opts.libPaths()[19]);
+    try std.testing.expectEqualStrings("test.scm", opts.file_path.?);
 }
 
 test "parse: no-ir-opt" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -391,22 +391,26 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         return;
     }
 
-    // Library path auto-discovery: script dir + ~/.kaappi/lib
-    var lib_paths: [16][]const u8 = undefined;
+    // Library search path: the explicit --lib-path entries (any count) plus up
+    // to three auto-discovered dirs added below — the script's own directory,
+    // ~/.kaappi/lib, and the exe-relative fallback lib. Sized to hold them all;
+    // the old fixed [16] silently dropped a 17th path (or an auto-discovered dir
+    // once 16 explicit ones existed), same silent-drop shape as #1652 (#1653).
+    // Never freed: vm.lib_paths points in here and is read as late as the
+    // deferred coverage report, so it must live for the whole run — like the
+    // auto-discovered dir strings (klp/elp below) it aliases.
+    const auto_discovered_max = 3;
+    const lib_paths = try allocator.alloc([]const u8, opts.libPaths().len + auto_discovered_max);
     var lib_path_count: usize = 0;
     for (opts.libPaths()) |lp| {
-        if (lib_path_count < 16) {
-            lib_paths[lib_path_count] = lp;
-            lib_path_count += 1;
-        }
+        lib_paths[lib_path_count] = lp;
+        lib_path_count += 1;
     }
 
     if (opts.file_path) |fp| {
         if (std.mem.lastIndexOfScalar(u8, fp, '/')) |pos| {
-            if (lib_path_count < 16) {
-                lib_paths[lib_path_count] = if (pos == 0) fp[0..1] else fp[0..pos];
-                lib_path_count += 1;
-            }
+            lib_paths[lib_path_count] = if (pos == 0) fp[0..1] else fp[0..pos];
+            lib_path_count += 1;
         }
     }
 
@@ -423,10 +427,8 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             break :blk path;
         };
         if (kaappi_lib_path) |klp| {
-            if (lib_path_count < 16) {
-                lib_paths[lib_path_count] = klp;
-                lib_path_count += 1;
-            }
+            lib_paths[lib_path_count] = klp;
+            lib_path_count += 1;
             // The dynamic-linker search path is a POSIX concept; Windows
             // resolves DLLs via PATH and ffi-open's own explicit
             // ~/.kaappi/lib probe, so there is nothing to export there.
@@ -464,10 +466,8 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             break :blk allocator.dupe(u8, elp) catch null;
         };
         if (exe_lib_path) |elp| {
-            if (lib_path_count < 16) {
-                lib_paths[lib_path_count] = elp;
-                lib_path_count += 1;
-            }
+            lib_paths[lib_path_count] = elp;
+            lib_path_count += 1;
         }
     }
 

--- a/tests/scheme/smoke/lib-path-many-1653.sh
+++ b/tests/scheme/smoke/lib-path-many-1653.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Regression test for #1653: --lib-path entries past the 16th were silently
+# dropped. Two fixed [16] buffers had the bug — cli.zig's storage and main.zig's
+# search-path assembly (which also folds in the auto-discovered dirs: the
+# script's directory, ~/.kaappi/lib, and the exe-relative fallback lib). This
+# exercises the whole pipeline end-to-end (cli.parse → main assembly →
+# vm.lib_paths → resolveLibraryPath), which the cli.zig unit test can't reach.
+#
+# The two failure shapes the issue calls out:
+#   A. a 17th+ explicit --lib-path vanishes (here: library lives in the 20th).
+#   B. once 16 explicit paths exist, the auto-discovered dirs vanish too
+#      (here: 16 explicit empty paths + the library in the script's own dir).
+#
+# Isolation mirrors exe-relative-lib-1523.sh: resolveLibraryPath probes the
+# cwd-relative "" and "lib/" prefixes before any search path, so the run cwd
+# must not contain the library; an empty HOME keeps ~/.kaappi/lib from masking
+# a broken fix.
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/run" "$TMP/emptyhome" "$TMP/khome"
+
+# A library that is not a real SRFI, so the exe-relative lib/ fallback (which
+# ships the portable SRFI sources next to the binary) can never resolve it —
+# only an entry we pass can.
+make_lib() { # $1 = dir to hold the (mylib greet) library; $2 = greeting text
+    mkdir -p "$1/mylib"
+    cat > "$1/mylib/greet.sld" <<EOF
+(define-library (mylib greet)
+  (export greeting)
+  (import (scheme base))
+  (begin (define greeting "$2")))
+EOF
+}
+
+write_prog() { # $1 = .scm path
+    mkdir -p "$(dirname "$1")"
+    cat > "$1" <<'SCM'
+(import (scheme base) (scheme write) (mylib greet))
+(display greeting)
+(newline)
+SCM
+}
+
+# Runs kaappi from an isolated cwd/HOME with the given argv.
+run_isolated() {
+    (cd "$TMP/run" && \
+        env -u KAAPPI_LIB_DIR KAAPPI_HOME="$TMP/khome" HOME="$TMP/emptyhome" \
+        "$KAAPPI_ABS" "$@")
+}
+
+check() { # $1 = label; $2 = expected exit; $3 = expected stdout substring (or "")
+    local label="$1" want_exit="$2" want_out="$3"
+    shift 3
+    local status=0
+    run_isolated "$@" > "$TMP/out.txt" 2>&1 || status=$?
+    if [[ "$status" -ne "$want_exit" ]]; then
+        echo "FAIL: $label — expected exit $want_exit, got $status"
+        cat "$TMP/out.txt"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if [[ -n "$want_out" ]] && ! grep -q "$want_out" "$TMP/out.txt"; then
+        echo "FAIL: $label — output missing '$want_out'"
+        cat "$TMP/out.txt"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    echo "PASS: $label"
+    PASS=$((PASS + 1))
+}
+
+# ── Shape A: library in the 20th of 20 explicit --lib-path entries ──────────
+# 20 > 16, so under the old cap paths 17..20 (including the one that matters)
+# were dropped and the import failed.
+declare -a A_ARGS=()
+for i in $(seq 1 20); do
+    mkdir -p "$TMP/pA$i"
+    A_ARGS+=(--lib-path "$TMP/pA$i")
+done
+make_lib "$TMP/pA20" "greet-from-20th-path"
+write_prog "$TMP/progA/prog.scm"
+check "20 explicit --lib-path: library in the 20th resolves" 0 "greet-from-20th-path" \
+    "${A_ARGS[@]}" "$TMP/progA/prog.scm"
+
+# ── Negative control: the same 20 entries, but remove the library ───────────
+# Proves shape A actually resolves via the passed search path, not via cwd,
+# HOME, or the exe-relative fallback.
+rm -rf "$TMP/pA20/mylib"
+check "control: same 20 --lib-path but no library anywhere fails" 1 "" \
+    "${A_ARGS[@]}" "$TMP/progA/prog.scm"
+
+# ── Shape B: 16 explicit (empty) paths + library in the script's own dir ────
+# The auto-discovered script-dir entry is appended after the explicit ones, so
+# with 16 explicit paths filling the old [16] buffer it was dropped.
+declare -a B_ARGS=()
+for i in $(seq 1 16); do
+    mkdir -p "$TMP/pB$i"
+    B_ARGS+=(--lib-path "$TMP/pB$i")
+done
+write_prog "$TMP/progB/prog.scm"
+make_lib "$TMP/progB" "greet-from-script-dir"   # next to prog.scm
+check "16 explicit --lib-path: auto-discovered script dir still resolves" 0 "greet-from-script-dir" \
+    "${B_ARGS[@]}" "$TMP/progB/prog.scm"
+
+echo ""
+echo "$PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes #1653. Same silent-data-loss shape as #1652, in **two** fixed `[16]` buffers that capped the library search path with no diagnostic:

- **`src/cli.zig`** — `Options.lib_path_buf: [16][]const u8` guarded by `if (count < 16)`, storing the explicit `--lib-path` entries.
- **`src/main.zig`** — the search-path assembly copied those plus the auto-discovered dirs (script directory, `~/.kaappi/lib`, exe-relative `lib`) into a second fixed `[16]` local with the same guards.

So a 17th `--lib-path` — or the auto-discovered dirs once 16 explicit ones existed — vanished silently (exit 0, no error).

## Fix

- **cli.zig**: accumulate into a `c_allocator`-backed `ArrayList` + `toOwnedSlice`, the same immortal argv-lifetime convention already used for `script_args` (#1652). `libPaths()` now returns the grown slice.
- **main.zig**: size the assembly buffer to `opts.libPaths().len + 3` (the three possible auto-discovered dirs) and drop all four `< 16` guards.
- **Lifetime** (the issue's "mind the `vm.lib_paths` slice lifetime"): the assembly buffer is deliberately never freed — `vm.lib_paths` points into it and is read as late as the *deferred* coverage report (`reporting.zig`'s `resolveLibraryPath(…, vm.lib_paths)`), and it aliases the already-never-freed `klp`/`elp` path strings, so it must live for the whole run. Uses the `allocator` local (not `std.heap.c_allocator`) so the wasm build — which analyzes `mainImpl` but never reaches this code — still compiles.

## Verification

- **Regression tests fail without the fix, pass with it.** Stashed the source fix, rebuilt, and confirmed the e2e test fails 2/3 (both failure shapes); restored and confirmed 3/3 green.
  - `cli.zig` unit test: 20 `--lib-path` entries all survive.
  - `tests/scheme/smoke/lib-path-many-1653.sh` (end-to-end): library resolves from the 20th explicit path; the auto-discovered script dir still resolves with 16 explicit paths present; no-library negative control proves it exercises search-path resolution.
- Full `zig build test` green; smoke shell suite 11/11 (incl. the related `exe-relative-lib-1523` and `test-runner/lib-path`).
- Cross-compiles clean for **wasm**, **x86_64-windows**, **aarch64-windows**, **x86_64-linux**.
- CHANGELOG `### Fixed` entry added; `--lib-path` help text updated (`up to 16` → `repeatable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)