### PR TITLE
Add Linux s390x and ppc64le support (interpreter tier)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,72 @@ jobs:
       - name: R7RS test suite (riscv64 via QEMU)
         run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
 
+  # s390x: interpreter tier like riscv64 (#1654), and the only big-endian
+  # target in the matrix — a permanent canary for byte-order bugs in the
+  # `.sbc` codec and any future serialization. Also validated on a
+  # real-kernel Alpine s390x VM (unit + thottam + R7RS + full Scheme
+  # suites; user VA stays below 2^42, inside the 48-bit NaN-box payload).
+  s390x-test:
+    needs: format
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: s390x
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: s390x
+
+      - name: Build (cross-compile for s390x)
+        run: zig build -Dtarget=s390x-linux
+
+      - name: Unit tests (s390x via QEMU)
+        run: zig build test -Dtarget=s390x-linux
+
+      - name: R7RS test suite (s390x via QEMU)
+        run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
+
+  # ppc64le: interpreter tier like riscv64 (#1654). Also validated on a
+  # real-kernel Alpine ppc64le VM (unit + thottam + R7RS + full Scheme
+  # suites; 128 TB = 2^47 default map window fits the NaN-box payload).
+  ppc64le-test:
+    needs: format
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: ppc64le
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: ppc64le
+
+      - name: Build (cross-compile for ppc64le)
+        run: zig build -Dtarget=powerpc64le-linux
+
+      - name: Unit tests (ppc64le via QEMU)
+        run: zig build test -Dtarget=powerpc64le-linux
+
+      - name: R7RS test suite (ppc64le via QEMU)
+        run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
+
   # FreeBSD: cross-compile the binaries and test executables from Linux
   # (guarding the cross-compilation path release.yml ships with), then
   # boot a FreeBSD VM via KVM on the same runner — GitHub hosts no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,25 @@ jobs:
             lib_src: libkaappi_rt.a
             lib_ext: .a
             strip: true
+          # Interpreter-tier Linux arches like riscv64 (no native
+          # backend). Cross-compiled; execution is verified by CI's
+          # s390x-test/ppc64le-test QEMU jobs and was validated on
+          # real-kernel Alpine VMs (#1654). s390x is the only big-endian
+          # target.
+          - os: ubuntu-latest
+            target: s390x-linux
+            artifact: kaappi-s390x-linux
+            exe_ext: ''
+            lib_src: libkaappi_rt.a
+            lib_ext: .a
+            strip: true
+          - os: ubuntu-latest
+            target: powerpc64le-linux
+            artifact: kaappi-powerpc64le-linux
+            exe_ext: ''
+            lib_src: libkaappi_rt.a
+            lib_ext: .a
+            strip: true
           # Cross-compiled from Linux (Zig bundles FreeBSD 14+ libc).
           # Execution is verified by CI's freebsd-test VM job (x86_64)
           # and on the port's aarch64 reference machine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ This runs `zig fmt --check` on staged `.zig` files before each commit.
 | Linux | x86_64 | yes | yes | CI tested (Ubuntu) |
 | Linux | aarch64 | yes | yes | CI tested (Ubuntu ARM) |
 | Linux | riscv64 | yes | yes | CI tested (QEMU) |
+| Linux | s390x (big-endian) | yes | yes | CI tested (QEMU); the byte-order canary (#1654) |
+| Linux | ppc64le | yes | yes | CI tested (QEMU) |
 | Windows | aarch64 (ARM64), x86_64 | yes | yes | `zig build -Dtarget=<arch>-windows`; see `docs/dev/windows.md` |
 | FreeBSD | x86_64, aarch64 | yes | yes | `zig build -Dtarget=<arch>-freebsd`; kqueue reactor; see `docs/dev/freebsd.md` |
 | OpenBSD | x86_64, aarch64 | yes | yes | `zig build -Dtarget=<arch>-openbsd`; kqueue reactor; binaries auto-marked `PT_OPENBSD_NOBTCFI`; see `docs/dev/openbsd.md` |
@@ -112,6 +114,11 @@ This runs `zig fmt --check` on staged `.zig` files before each commit.
 **Cross-compilation:** `zig build -Dtarget=x86_64-linux` and
 `zig build -Dtarget=riscv64-linux` cross-compile from macOS ARM. Binaries
 run in Linux containers via podman (x86_64 via Rosetta, riscv64 via QEMU).
+`zig build -Dtarget=s390x-linux` and `-Dtarget=powerpc64le-linux`
+cross-compile the interpreter-tier s390x/ppc64le ports (#1654) — zero
+runtime code changes; s390x is the only big-endian target and serves as
+the permanent byte-order canary in CI; both were validated end-to-end on
+real-kernel Alpine VMs (see `docs/dev/porting.md`).
 `zig build -Dtarget=aarch64-windows` (or `x86_64-windows`) cross-compiles
 the Windows binaries (kaappi.exe, thottam.exe, kaappi-lsp.exe);
 syscall-level platform differences live behind the `src/platform.zig`

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ zig build test                       # run the unit tests
 | macOS | aarch64 (Apple Silicon) | yes | yes | LLVM backend |
 | Linux | x86_64 | yes | yes | LLVM backend |
 | Linux | aarch64 | yes | yes | LLVM backend |
-| Linux | riscv64 | yes | yes | LLVM backend |
+| Linux | riscv64 | yes | yes | interpreter only |
 | Linux | s390x (big-endian) | yes | yes | interpreter only |
 | Linux | ppc64le | yes | yes | interpreter only |
 | Windows | aarch64 (ARM64), x86_64 | yes | yes | LLVM backend (needs a C toolchain) |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ zig build test                       # run the unit tests
 | Linux | x86_64 | yes | yes | LLVM backend |
 | Linux | aarch64 | yes | yes | LLVM backend |
 | Linux | riscv64 | yes | yes | LLVM backend |
+| Linux | s390x (big-endian) | yes | yes | interpreter only |
+| Linux | ppc64le | yes | yes | interpreter only |
 | Windows | aarch64 (ARM64), x86_64 | yes | yes | LLVM backend (needs a C toolchain) |
 | FreeBSD | x86_64, aarch64 | yes | yes | LLVM backend (base `cc` suffices) |
 | OpenBSD | x86_64, aarch64 | yes | yes | LLVM backend (base `cc` suffices) |

--- a/docs/dev/porting.md
+++ b/docs/dev/porting.md
@@ -1,12 +1,15 @@
 # Porting to a new OS or CPU architecture
 
 How Kaappi's existing platform support is structured, and staged checklists
-for bringing up a new operating system or a new CPU architecture. The six
+for bringing up a new operating system or a new CPU architecture. The
 completed ports are the reference material: **Windows aarch64**
 (#1606, #1608, #1609 — the OS-port exemplar, documented in
 [windows.md](windows.md)),
 **wasm32-wasi** (KEP-0001 Phase 4 — the capability-degradation exemplar),
 **riscv64-linux** (the CPU-architecture exemplar, tested under QEMU),
+**s390x-linux** (the big-endian exemplar — the first byte-order-flipped
+target, which the interpreter passed unmodified; #1654) with its
+little-endian sibling **ppc64le-linux**,
 **FreeBSD** (the POSIX-audit exemplar — a port where nearly everything
 already works and the job is verifying it, documented in
 [freebsd.md](freebsd.md)), **OpenBSD** (the toolchain-hardening exemplar
@@ -25,6 +28,8 @@ in [netbsd.md](netbsd.md)).
 | Linux | x86_64 | native | same as macOS, in Debug/ReleaseSafe/ReleaseFast | `test` (ubuntu-latest) | yes |
 | Linux | aarch64 | native | same | `test` (ubuntu-24.04-arm) | yes |
 | Linux | riscv64 | cross-compiled | unit + R7RS under QEMU user-mode | `riscv64-test` | yes |
+| Linux | s390x | cross-compiled | unit + R7RS under QEMU user-mode; full battery (unit + thottam + R7RS + `tests/scheme/`) on a real-kernel Alpine VM (#1654) | `s390x-test` | yes |
+| Linux | ppc64le | cross-compiled | unit + R7RS under QEMU user-mode; full battery on a real-kernel Alpine VM (#1654) | `ppc64le-test` | yes |
 | Windows | aarch64 | cross-compiled only (#1613) | unit + thottam + R7RS + VM-verified `.scm` suites on `windows-11-arm` runners | `windows-cross` + `windows-arm-test` | yes (unstripped, #1607) |
 | Windows | x86_64 | cross-compiled or native | same as aarch64 plus the native-backend e2e (`run-e2e.ps1`) on `windows-latest` runners | `windows-cross` + `windows-x64-test` | yes |
 | FreeBSD | x86_64, aarch64 | cross-compiled | unit + thottam + full `.scm` suites in a KVM FreeBSD VM (x86_64); verified on a real 15.1 aarch64 box | `freebsd-test` | yes (both arches) |
@@ -259,8 +264,8 @@ thottam → #1608 readiness), and it kept every intermediate PR shippable.
 ## Porting to a new CPU architecture
 
 A new architecture on an already-supported OS is much smaller than an OS
-port — riscv64 needed no runtime code changes at all, only build/CI work —
-*provided* the preconditions hold.
+port — riscv64, s390x, and ppc64le each needed no runtime code changes at
+all, only build/CI work — *provided* the preconditions hold.
 
 ### Preconditions (check before anything else)
 
@@ -278,13 +283,21 @@ port — riscv64 needed no runtime code changes at all, only build/CI work —
       that freely returns high addresses (or tags pointer high bits) is
       **blocked** until `makePointer`/`toObject` grow a masking scheme.
       Verify empirically: run the unit suite and check `--gc-stats` on a
-      heap-heavy program early.
-- [ ] **Little-endian.** `.sbc` files, and the NaN-box word itself in
-      memory, are handled through explicit conversions
-      (`littleToNative`), so a big-endian port is *plausible* — but no
-      big-endian target has ever been tested, and untested byte-order
-      code should be assumed broken. Treat big-endian as a real porting
-      project with its own audit, not a checkbox.
+      heap-heavy program early — and check `/proc/self/maps` on a *real*
+      kernel, since QEMU user-mode inherits the host's layout and proves
+      nothing. Verified this way: s390x keeps user VA below 4 TB = 2^42
+      (3-level page tables, upgraded only when a mapping demands more)
+      and ppc64le below its 128 TB = 2^47 default map window (#1654).
+- [ ] **Byte order goes through the codec helpers.** `.sbc` files are
+      canonically little-endian via explicit conversions
+      (`littleToNative`/`nativeToLittle`), and the NaN-box word is only
+      ever manipulated as a u64, never byte-punned. Big-endian is
+      **tested**: s390x passes the unit suite, the R7RS suite, and the
+      `.sbc` cache round-trip unchanged (#1654), and the `s390x-test` CI
+      job guards the invariant on every PR. The obligation this
+      precondition now expresses: new serialization or byte-punning code
+      must use the same explicit-conversion helpers — the s390x job is
+      the canary that catches it if it doesn't.
 - [ ] **f64 hardware or soft-float** with IEEE-754 semantics (flonums
       are NaN-boxed doubles; NaN canonicalization assumes IEEE bit
       patterns).
@@ -321,7 +334,7 @@ port — riscv64 needed no runtime code changes at all, only build/CI work —
 ### Native (LLVM) backend
 
 The interpreter ships without this; the native backend is a separate,
-optional tier (riscv64 ships interpreter-only today).
+optional tier (riscv64, s390x, and ppc64le ship interpreter-only today).
 
 - [ ] Add the triple to `llvm_emit.zig`'s `emitPreamble` switch
       (currently aarch64/x86_64 × macos/linux; everything else emits

--- a/tests/scheme/errors/crash-handler.sh
+++ b/tests/scheme/errors/crash-handler.sh
@@ -60,8 +60,16 @@ check "report URL line" $?
 grep -qF "panic: deliberate panic" <<<"$out"
 check "standard panic message retained" $?
 
-grep -qE "0x[0-9a-fA-F]+" <<<"$out"
-check "stack trace addresses retained" $?
+# Zig's panic unwinder can't walk frames on every target — ppc64le prints
+# "(empty stack trace)" (no frame-walk in Zig 0.16's std there). The banner
+# can't retain what std never produces, so assert addresses only when a
+# trace exists; the probe is the output itself, not an arch list (#1654).
+if grep -qF "(empty stack trace)" <<<"$out"; then
+    echo "SKIP: stack trace addresses (Zig prints no frames on this target)"
+else
+    grep -qE "0x[0-9a-fA-F]+" <<<"$out"
+    check "stack trace addresses retained" $?
+fi
 
 # Ordering: banner (identity) must come before the panic message + trace.
 banner_line=$(grep -n "internal error" <<<"$out" | head -1 | cut -d: -f1)


### PR DESCRIPTION
Closes #1654.

Adds Linux **s390x** and **ppc64le** as supported interpreter-tier architectures — the two remaining 64-bit Linux arches in the Debian 13 release set and the Fedora primary set. **Zero runtime code changes**: the diff is two CI jobs, two release rows, docs, and one test-portability gate.

s390x is the first big-endian target Kaappi has ever run on. The endian-explicit `.sbc` codec (#438), byte-composed bytecode operands, and u64-only NaN-box manipulation all held up unmodified — and the new `s390x-test` CI job now guards byte-order correctness on every PR permanently.

## What's in the diff

- **`ci.yml`**: `s390x-test` + `ppc64le-test` jobs, exact mirrors of `riscv64-test` (cross-compile, then unit tests + R7RS under QEMU user-mode binfmt). ~12 min each, parallel, off the critical path.
- **`release.yml`**: `kaappi-s390x-linux` + `kaappi-powerpc64le-linux` rows (schema identical to riscv64; `zig build` / `zig build lib` / `-Dstrip=true` verified locally for both targets).
- **`docs/dev/porting.md`**: support-matrix rows; the "little-endian" precondition rewritten — big-endian is now *tested*, and the precondition's real obligation (byte order goes through the codec helpers, with `s390x-test` as the canary) is stated as such; the 48-bit pointer precondition now records the real-kernel VA verification for both arches.
- **`CLAUDE.md` / `README.md`**: platform tables.
- **`tests/scheme/errors/crash-handler.sh`**: asserts stack-trace addresses only when Zig's unwinder produced a trace at all. ppc64le prints `(empty stack trace)` (no frame-walk in Zig 0.16's std there); the banner cannot retain what std never emits. The gate probes the output, not an arch list; still 13/13 on macOS, and s390x (which does unwind) keeps the full assertion.

## Validation

Cross-compiled from macOS ARM (static musl, same as the riscv64 release artifacts) and validated two independent ways.

**QEMU user-mode (the CI mechanism), via podman binfmt:**

| | s390x | ppc64le |
|---|---|---|
| `zig build test -Dtarget=…` | 1205/1211, 1 OOM-kill in a 4 GiB VM (dmesg-confirmed; GH runners have 16 GB) | clean exit 0 |
| R7RS suite | 1395/1395 | 1395/1395 |
| `.sbc` cache MISS→write→HIT | works | works |

**Real-kernel Alpine 3.24 VMs (UTM, kernel 6.18) — full battery:**

| | s390x | ppc64le |
|---|---|---|
| Unit suite | **1177 pass, 9 skip, 0 fail** | **1177 pass, 9 skip, 0 fail** |
| thottam suite | 25/25 | 25/25 |
| R7RS suite | 1395/1395 | 1395/1395 |
| `tests/scheme/` suites | **454 pass** · 22 env-fail · 6 skip | **454 pass** · 22 env-fail · 6 skip |
| `/proc` VA layout | user VA < 2^42 (3-level page tables) | user VA < 2^47 (128 TB window) |

Both VA layouts fit the 48-bit NaN-box pointer payload with wide margin — checked on real kernels because QEMU user-mode inherits the host's layout and proves nothing about it.

The 22 `tests/scheme/` failures are environmental, in exactly two classes, **identical on both arches** and unrelated to CPU architecture: (1) 16 FFI-class tests — the cross-compiled static-musl binaries cannot `dlopen` (inherent to static musl; the riscv64 release artifacts share this); (2) 6 `compile/*.sh` native-backend suites — no C toolchain on the boxes, and these arches are interpreter-tier anyway (their 6 SKIP siblings are the ones with `skip_without_zig` guards). Zero timeouts, zero unexplained failures.

Also fixes README's riscv64 "Native compilation" cell to "interpreter only" — it claimed "LLVM backend", contradicting porting.md ("riscv64 … ship interpreter-only today") and `llvm_emit.zig`, whose `emitPreamble` emits a real triple only for aarch64/x86_64. Verified empirically while resolving the contradiction: on a riscv64 box, `kaappi compile` links "successfully" (the `-w` on the zig cc link lets the driver override the `unknown-unknown-unknown` triple) but the binary **segfaults** — filed #1656 for making `kaappi compile` refuse loudly on unsupported arches instead.

## Not in scope

- Native LLVM backend for these arches (`llvm_emit.zig` stays aarch64/x86_64 — same tier as riscv64).
- IBM's free hosted runners (`power-z-gha-runner`) for native-hardware CI — possible follow-up if QEMU coverage ever proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
