### PR TITLE
Refuse native compilation on unsupported arches (#1656)

### DIFF
--- a/docs/dev/decisions/native-backend-architecture-scope.md
+++ b/docs/dev/decisions/native-backend-architecture-scope.md
@@ -12,6 +12,11 @@ riscv64 is the designated pathfinder if that happens.
 Prerequisite shipped independently of any port: #1656 — `kaappi compile`
 on an unsupported architecture must refuse loudly instead of linking a
 binary that crashes (see "The failure mode that forced this decision").
+**Done:** `llvm_emit.native_backend_supported` (the single source of truth
+derived from `targetTriple`, so a future arch arm flips it automatically)
+now gates both `emitLlvmFile` — which exits nonzero naming the arch and
+pointing at the interpreter, before any codegen — and `kaappi doctor`,
+which reports one honest `arch` WARN instead of a misleading PASS trio.
 
 ## Problem
 

--- a/docs/dev/doctor.md
+++ b/docs/dev/doctor.md
@@ -19,7 +19,7 @@ dispatches it (`doctor.maybeRun`) before any VM, GC, or library setup exists.
 | `binary` | version, target triple, build mode, the running binary's path, and the `kaappi` a shell would pick from PATH (so a mismatch — "wrong binary on PATH" — is visible). |
 | `library` | the effective `.sld` search path in order: each `--lib-path`, the script directory (added per-run), `~/.kaappi/lib`, and the exe-relative `../lib` fallback — with whether each exists. |
 | `package-manager` | `thottam` on PATH; every package in `~/.kaappi/thottam.lock` has a matching source tree in `~/.kaappi/src`. |
-| `native-backend` | C-compiler discovery (`zig`/`cc`/`clang`/`gcc`), `libkaappi_rt.a` across the four documented locations, and a **smoke link** if both are found. |
+| `native-backend` | On an interpreter-tier arch (riscv64, s390x, ppc64le — where `kaappi compile` refuses, #1656) a single `arch` WARN says native compilation is unavailable and stops; otherwise C-compiler discovery (`zig`/`cc`/`clang`/`gcc`), `libkaappi_rt.a` across the four documented locations, and a **smoke link** if both are found. |
 | `repl` | `~/.kaappi` writable (where history is saved); terminal capabilities (`isatty`, `TERM`). |
 | `ffi` | every `.dylib`/`.so` in `~/.kaappi/lib` is `dlopen`-able (per-file result, with the `dlerror` on failure). |
 

--- a/docs/dev/doctor.md
+++ b/docs/dev/doctor.md
@@ -19,7 +19,7 @@ dispatches it (`doctor.maybeRun`) before any VM, GC, or library setup exists.
 | `binary` | version, target triple, build mode, the running binary's path, and the `kaappi` a shell would pick from PATH (so a mismatch — "wrong binary on PATH" — is visible). |
 | `library` | the effective `.sld` search path in order: each `--lib-path`, the script directory (added per-run), `~/.kaappi/lib`, and the exe-relative `../lib` fallback — with whether each exists. |
 | `package-manager` | `thottam` on PATH; every package in `~/.kaappi/thottam.lock` has a matching source tree in `~/.kaappi/src`. |
-| `native-backend` | On an interpreter-tier arch (riscv64, s390x, ppc64le — where `kaappi compile` refuses, #1656) a single `arch` WARN says native compilation is unavailable and stops; otherwise C-compiler discovery (`zig`/`cc`/`clang`/`gcc`), `libkaappi_rt.a` across the four documented locations, and a **smoke link** if both are found. |
+| `native-backend` | On an interpreter-tier arch (riscv64, s390x, ppc64le — where `kaappi compile` refuses, #1656) a single `arch` WARN says native compilation is unavailable and stops; otherwise C-compiler discovery (`zig`/`cc`/`clang`/`gcc`), the runtime archive (`libkaappi_rt.a`, or `kaappi_rt.lib` on Windows) across the four documented locations, and a **smoke link** if both are found. |
 | `repl` | `~/.kaappi` writable (where history is saved); terminal capabilities (`isatty`, `TERM`). |
 | `ffi` | every `.dylib`/`.so` in `~/.kaappi/lib` is `dlopen`-able (per-file result, with the `dlerror` on failure). |
 

--- a/src/doctor.zig
+++ b/src/doctor.zig
@@ -28,6 +28,7 @@ const lsp_diagnostic = @import("lsp_diagnostic.zig");
 const kaappi_paths = @import("kaappi_paths.zig");
 const file_utils = @import("file_utils.zig");
 const native_compiler = @import("native_compiler.zig");
+const llvm_emit = @import("llvm_emit.zig");
 
 pub const version = @import("build_options").version;
 
@@ -343,6 +344,23 @@ fn collectPackageManager(r: *Report) void {
 
 fn collectNativeBackend(r: *Report) void {
     const a = r.allocator();
+
+    // #1656: on an arch the LLVM backend can't target (riscv64, s390x, ppc64le),
+    // `kaappi compile` refuses — native compilation is unavailable, by design.
+    // Report that once, honestly, instead of running the c-compiler / archive /
+    // smoke-link probes below, which would all PASS and falsely imply native
+    // builds work here. WARN keeps exit 0: the install is healthy for the
+    // interpreter tier, which is fully supported on every arch.
+    if (!llvm_emit.native_backend_supported) {
+        r.add(
+            "native-backend",
+            "arch",
+            .warn,
+            r.fmt("native compilation unavailable on {s} — the LLVM backend targets aarch64 and x86_64 only; the interpreter tier is fully supported", .{@tagName(builtin.cpu.arch)}),
+            "run programs with the interpreter: kaappi <file.scm>",
+        );
+        return;
+    }
 
     // C compiler discovery uses native_compiler's own search order, so the
     // finding names the driver `kaappi compile` will actually pick.

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -21,6 +21,69 @@ pub const fast_tailcalls_supported = switch (@import("builtin").cpu.arch) {
     else => false,
 };
 
+/// The LLVM `target triple` for a host `(arch, os)`, or null on an architecture
+/// the native backend cannot target. A real triple exists only for aarch64 and
+/// x86_64 (× the six supported OSes); every other arch would otherwise be
+/// emitted as `unknown-unknown-unknown`, which the `-w` on the `zig cc` link
+/// lets the driver silently override with the host default — so the link
+/// *succeeds* and the user gets a binary that segfaults (#1656). This is the
+/// single source of truth for both the emitted triple (emitPreamble) and
+/// `native_backend_supported`, so a future port that adds an arch arm here
+/// flips both at once. The `windows` arms use the gnu (MinGW) ABI: it matches
+/// how the runtime lib is built and how `zig cc` links on a box without MSVC
+/// (#1610).
+pub fn targetTriple(arch: std.Target.Cpu.Arch, os: std.Target.Os.Tag) ?[]const u8 {
+    return switch (arch) {
+        .aarch64 => switch (os) {
+            .macos => "aarch64-apple-macosx",
+            .linux => "aarch64-unknown-linux-gnu",
+            .windows => "aarch64-pc-windows-gnu",
+            .freebsd => "aarch64-unknown-freebsd",
+            .openbsd => "aarch64-unknown-openbsd",
+            .netbsd => "aarch64-unknown-netbsd",
+            else => "aarch64-unknown-unknown",
+        },
+        .x86_64 => switch (os) {
+            .macos => "x86_64-apple-macosx",
+            .linux => "x86_64-unknown-linux-gnu",
+            .windows => "x86_64-pc-windows-gnu",
+            .freebsd => "x86_64-unknown-freebsd",
+            .openbsd => "x86_64-unknown-openbsd",
+            .netbsd => "x86_64-unknown-netbsd",
+            else => "x86_64-unknown-unknown",
+        },
+        else => null,
+    };
+}
+
+/// Whether the LLVM native backend can target this host. False on the
+/// interpreter-tier arches (riscv64, s390x, ppc64le, …) — `kaappi compile`,
+/// `--emit-llvm`, and `kaappi doctor` consult this to refuse native compilation
+/// *loudly* instead of emitting an unknown-triple module that links to a
+/// crashing binary (#1656). The interpreter tier runs on every arch regardless.
+/// See docs/dev/decisions/native-backend-architecture-scope.md.
+pub const native_backend_supported = targetTriple(@import("builtin").cpu.arch, @import("builtin").os.tag) != null;
+
+test "targetTriple: only aarch64/x86_64 are native-compilable; others refuse (#1656)" {
+    // Supported hosts get a concrete triple for every supported OS.
+    try std.testing.expect(targetTriple(.aarch64, .linux) != null);
+    try std.testing.expect(targetTriple(.aarch64, .macos) != null);
+    try std.testing.expect(targetTriple(.x86_64, .linux) != null);
+    try std.testing.expect(targetTriple(.x86_64, .windows) != null);
+    // The interpreter-tier arches have no triple, so native_backend_supported
+    // is false there and `kaappi compile` refuses instead of linking a
+    // segfaulting binary. A future port that adds one of these arms flips this
+    // assertion and native_backend_supported together (single source of truth).
+    try std.testing.expect(targetTriple(.riscv64, .linux) == null);
+    try std.testing.expect(targetTriple(.s390x, .linux) == null);
+    try std.testing.expect(targetTriple(.powerpc64le, .linux) == null);
+    // native_backend_supported is exactly "the host has a triple".
+    try std.testing.expectEqual(
+        targetTriple(@import("builtin").cpu.arch, @import("builtin").os.tag) != null,
+        native_backend_supported,
+    );
+}
+
 // A named native function with at most this many fixed parameters gets a
 // register-argument `tailcc` fast entry (see emitLambdaFunction). Beyond it the
 // uniform array ABI is kept — the bound keeps register pressure and signature
@@ -1345,34 +1408,11 @@ pub const LLVMEmitter = struct {
     }
 
     fn emitPreamble(self: *LLVMEmitter) EmitError!void {
-        const arch = @import("builtin").cpu.arch;
-        const os = @import("builtin").os.tag;
-        // The gnu (MinGW) Windows ABI matches how the runtime lib is built and
-        // how `zig cc` links on a box without MSVC (#1610). Clang would
-        // override a mismatched module triple with the driver's, but only
-        // with a warning that -w hides — emit the right one to begin with.
-        const triple = switch (arch) {
-            .aarch64 => switch (os) {
-                .macos => "aarch64-apple-macosx",
-                .linux => "aarch64-unknown-linux-gnu",
-                .windows => "aarch64-pc-windows-gnu",
-                .freebsd => "aarch64-unknown-freebsd",
-                .openbsd => "aarch64-unknown-openbsd",
-                .netbsd => "aarch64-unknown-netbsd",
-                else => "aarch64-unknown-unknown",
-            },
-            .x86_64 => switch (os) {
-                .macos => "x86_64-apple-macosx",
-                .linux => "x86_64-unknown-linux-gnu",
-                .windows => "x86_64-pc-windows-gnu",
-                .freebsd => "x86_64-unknown-freebsd",
-                .openbsd => "x86_64-unknown-openbsd",
-                .netbsd => "x86_64-unknown-netbsd",
-                else => "x86_64-unknown-unknown",
-            },
-            else => "unknown-unknown-unknown",
-        };
-
+        // native_compiler refuses on unsupported arches before reaching here
+        // (#1656), so targetTriple is non-null in every real compile; the
+        // `orelse` is a defensive fallback so a stray direct call still emits
+        // *something* rather than crashing the compiler.
+        const triple = targetTriple(@import("builtin").cpu.arch, @import("builtin").os.tag) orelse "unknown-unknown-unknown";
         try self.print("; Generated by Kaappi Scheme LLVM backend\ntarget triple = \"{s}\"\n\n", .{triple});
         for (native_decls.decls) |d| {
             try self.print("declare {s} @{s}(", .{ d.ret.toLLVM(), d.export_name });

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -21,17 +21,18 @@ pub const fast_tailcalls_supported = switch (@import("builtin").cpu.arch) {
     else => false,
 };
 
-/// The LLVM `target triple` for a host `(arch, os)`, or null on an architecture
-/// the native backend cannot target. A real triple exists only for aarch64 and
-/// x86_64 (× the six supported OSes); every other arch would otherwise be
-/// emitted as `unknown-unknown-unknown`, which the `-w` on the `zig cc` link
-/// lets the driver silently override with the host default — so the link
-/// *succeeds* and the user gets a binary that segfaults (#1656). This is the
-/// single source of truth for both the emitted triple (emitPreamble) and
-/// `native_backend_supported`, so a future port that adds an arch arm here
-/// flips both at once. The `windows` arms use the gnu (MinGW) ABI: it matches
-/// how the runtime lib is built and how `zig cc` links on a box without MSVC
-/// (#1610).
+/// The LLVM `target triple` for a host `(arch, os)`, or null when the native
+/// backend cannot emit a *concrete* triple for it. That is exactly aarch64 and
+/// x86_64 × the six supported OSes; every other arch — and any other OS on
+/// those two arches — returns null. A non-concrete triple would come out as
+/// `*-unknown-unknown`, which the `-w` on the `zig cc` link lets the driver
+/// silently override with the host default — so the link *succeeds* and the
+/// user gets a binary that segfaults (#1656). Returning null instead routes
+/// every such host through the loud refusal, not just unsupported arches. This
+/// is the single source of truth for both the emitted triple (emitPreamble) and
+/// `native_backend_supported`, so a future port that adds an arm here flips both
+/// at once. The `windows` arms use the gnu (MinGW) ABI: it matches how the
+/// runtime lib is built and how `zig cc` links on a box without MSVC (#1610).
 pub fn targetTriple(arch: std.Target.Cpu.Arch, os: std.Target.Os.Tag) ?[]const u8 {
     return switch (arch) {
         .aarch64 => switch (os) {
@@ -41,7 +42,7 @@ pub fn targetTriple(arch: std.Target.Cpu.Arch, os: std.Target.Os.Tag) ?[]const u
             .freebsd => "aarch64-unknown-freebsd",
             .openbsd => "aarch64-unknown-openbsd",
             .netbsd => "aarch64-unknown-netbsd",
-            else => "aarch64-unknown-unknown",
+            else => null,
         },
         .x86_64 => switch (os) {
             .macos => "x86_64-apple-macosx",
@@ -50,7 +51,7 @@ pub fn targetTriple(arch: std.Target.Cpu.Arch, os: std.Target.Os.Tag) ?[]const u
             .freebsd => "x86_64-unknown-freebsd",
             .openbsd => "x86_64-unknown-openbsd",
             .netbsd => "x86_64-unknown-netbsd",
-            else => "x86_64-unknown-unknown",
+            else => null,
         },
         else => null,
     };
@@ -77,6 +78,12 @@ test "targetTriple: only aarch64/x86_64 are native-compilable; others refuse (#1
     try std.testing.expect(targetTriple(.riscv64, .linux) == null);
     try std.testing.expect(targetTriple(.s390x, .linux) == null);
     try std.testing.expect(targetTriple(.powerpc64le, .linux) == null);
+    // A supported arch on an *unsupported OS* has no concrete triple either, so
+    // it refuses too: native_backend_supported means "we can emit a correct
+    // triple", not merely "the arch is one we know". Without this, such a host
+    // would emit `aarch64-unknown-unknown` and hit the same -w link/crash path.
+    try std.testing.expect(targetTriple(.aarch64, .dragonfly) == null);
+    try std.testing.expect(targetTriple(.x86_64, .illumos) == null);
     // native_backend_supported is exactly "the host has a triple".
     try std.testing.expectEqual(
         targetTriple(@import("builtin").cpu.arch, @import("builtin").os.tag) != null,

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -52,8 +52,35 @@ test "cc_search_order: zig first, gcc last, clang before NetBSD's base GCC" {
     }
 }
 
+/// Builds the #1656 refuse-loudly diagnostic naming the host arch and pointing
+/// at the interpreter, into `buf`. Split out so a test can assert its content
+/// without having to run on an interpreter-tier arch. Returns the written slice
+/// (or a static fallback if `buf` cannot hold even the arch-less form).
+fn nativeUnsupportedMessage(buf: []u8, arch_name: []const u8, path: []const u8) []const u8 {
+    return std.fmt.bufPrint(
+        buf,
+        "error: native compilation is not supported on this architecture ({s}).\n" ++
+            "The LLVM native backend targets aarch64 and x86_64 only; run the program with the interpreter instead:\n" ++
+            "    kaappi {s}\n",
+        .{ arch_name, path },
+    ) catch "error: native compilation is not supported on this architecture\n";
+}
+
 pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;
+
+    // #1656: refuse loudly on an arch the LLVM backend can't target, before any
+    // file I/O. Otherwise emitPreamble emits an unknown-triple module and the
+    // `-w` link silently overrides it with the host default, handing the user a
+    // binary that segfaults. Both entry points — `kaappi compile` (compileNative
+    // calls this first) and `--emit-llvm` — funnel through here, so one guard
+    // covers both. See docs/dev/decisions/native-backend-architecture-scope.md.
+    if (!llvm_emit.native_backend_supported) {
+        var errbuf: [2048]u8 = undefined;
+        writeStderr(nativeUnsupportedMessage(&errbuf, @tagName(@import("builtin").cpu.arch), path));
+        return error.NativeBackendUnsupported;
+    }
+
     const source = file_utils.readWholeFile(allocator, path, 1024 * 1024) catch |err| {
         var errbuf: [1088]u8 = undefined;
         const s = std.fmt.bufPrint(&errbuf, "Error opening file '{s}'\n", .{path}) catch "Error opening file\n";
@@ -364,6 +391,25 @@ test "deriveOutputPath strips .scm and appends the platform exe suffix" {
     const noext = try deriveOutputPath(a, "prog");
     defer a.free(noext);
     try std.testing.expectEqualStrings("prog" ++ platform.exe_suffix, noext);
+}
+
+test "nativeUnsupportedMessage names the arch and points at the interpreter (#1656)" {
+    var buf: [512]u8 = undefined;
+    const msg = nativeUnsupportedMessage(&buf, "riscv64", "hello.scm");
+    // Names the offending arch and the interpreter fallback command...
+    try std.testing.expect(std.mem.indexOf(u8, msg, "riscv64") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "not supported") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "kaappi hello.scm") != null);
+    // ...and the two arches that *are* supported, so the user sees the boundary.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "aarch64") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "x86_64") != null);
+}
+
+test "nativeUnsupportedMessage falls back safely when the buffer is tiny" {
+    var buf: [8]u8 = undefined;
+    const msg = nativeUnsupportedMessage(&buf, "riscv64", "hello.scm");
+    // Too small for the formatted form, but still a non-empty honest message.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "not supported") != null);
 }
 
 test "checkLibDir looks for the platform-named runtime archive" {


### PR DESCRIPTION
## Summary

Fixes #1656. `kaappi compile` on any architecture but aarch64/x86_64 emitted an `unknown-unknown-unknown` LLVM triple; the `-w` on the `zig cc` link then let the driver silently override it with the host default, so the link **succeeded** and the user got a **segfaulting binary** instead of an error — strictly worse than a plain failure, since nothing hinted the target was never supported.

This is the "refuse loudly" prerequisite already blessed by the [native-backend scope decision](docs/dev/decisions/native-backend-architecture-scope.md) (#1658): the backend stays aarch64/x86_64-only; interpreter-tier arches (riscv64, s390x, ppc64le) ship without `kaappi compile` deliberately.

## What changed

- **`llvm_emit.zig`** — extract the per-`(arch, os)` triple switch out of `emitPreamble` into a single-source-of-truth `pub fn targetTriple(arch, os) ?[]const u8` (null on an unsupported arch), and derive `pub const native_backend_supported` from it. A future port that adds an arch arm flips both the emitted triple and the support flag at once.
- **`native_compiler.zig`** — `emitLlvmFile` (the chokepoint for **both** `kaappi compile` and `--emit-llvm`) now refuses before any file I/O when `!native_backend_supported`: it prints a message naming the host arch and pointing at the interpreter, and returns `error.NativeBackendUnsupported` (→ exit 1).
- **`doctor.zig`** — `collectNativeBackend` reports one honest `arch` **WARN** on an unsupported arch instead of the misleading c-compiler/archive/smoke-link **PASS** trio that implied native builds work. WARN keeps exit 0 (the install is healthy for the interpreter tier).
- **docs** — `doctor.md` native-backend row; decision doc marked shipped.

## Tests

New unit tests (run on every arch, including the riscv64/s390x/ppc64le QEMU CI legs):
- `targetTriple`: aarch64/x86_64 classified native-compilable, riscv64/s390x/ppc64le not; `native_backend_supported` == "host has a triple".
- `nativeUnsupportedMessage`: names the arch + both supported arches + the interpreter fallback; safe tiny-buffer fallback.

Full suite: **1215/1215 pass**; `zig fmt --check` clean.

## End-to-end verification (riscv64 under QEMU via podman)

| Command | Before | After |
|---|---|---|
| `kaappi hello.scm` | `500510` (ok) | `500510`, exit 0 — unchanged |
| `kaappi compile hello.scm -o hello` | `Compiled` then **segfault** | **exit 1**, clear message, no binary written |
| `kaappi doctor` | c-compiler/smoke-link **PASS** (misleading) | `WARN  arch: native compilation unavailable on riscv64 …` |

Supported host (aarch64) native compile re-verified: still produces a working binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)