### PR TITLE
Report the real dlopen failure from ffi-open

### DIFF
--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -28,6 +28,75 @@ fn checkSandbox(comptime name: []const u8) PrimitiveError!void {
     }
 }
 
+/// dlopen(3) treats a name containing a slash as a pathname (relative or
+/// absolute) rather than a search key. The <home>/lib/ fallback in ffiOpen
+/// mirrors that distinction: prepending the fallback dir to a path would
+/// probe nonsense like "<home>/lib//opt/foo/libbar.dylib.so".
+fn hasPathSeparator(name: []const u8) bool {
+    if (std.mem.indexOfScalar(u8, name, '/') != null) return true;
+    return platform.is_windows and std.mem.indexOfScalar(u8, name, '\\') != null;
+}
+
+/// platform.dl_suffixes joined with "/" (e.g. ".dylib/.so/.so.6"), for the
+/// "also tried" note in ffiOpen's not-found diagnostic.
+const dl_suffix_list = blk: {
+    var s: []const u8 = "";
+    for (platform.dl_suffixes, 0..) |suffix, i| {
+        if (i > 0) s = s ++ "/";
+        s = s ++ suffix;
+    }
+    break :blk s;
+};
+
+/// Failure diagnostics for ffiOpen's candidate probing. dlerror(3) only
+/// remembers the most recent failure, so without snapshots the fallback
+/// probes would bury the interesting error under a "no such file" for a
+/// candidate path the user never asked for. Two snapshots are kept: the
+/// as-is attempt's error (the name the user actually passed), and the
+/// error of the first candidate that exists on disk but still failed to
+/// load — a code-signing, architecture, or file-format rejection is the
+/// failure that matters, wherever it fell in the probe order.
+const DlOpenDiag = struct {
+    first_buf: [256]u8 = undefined,
+    first_len: usize = 0,
+    real_buf: [256]u8 = undefined,
+    real_len: usize = 0,
+    real_cand_buf: [512]u8 = undefined,
+    real_cand_len: usize = 0,
+
+    fn noteFailure(self: *DlOpenDiag, candidate: [:0]const u8, is_first: bool) void {
+        // Read dlerror before the existence probe: reading consumes the
+        // pending error, and on Windows the text is rendered from
+        // GetLastError() at read time, which the probe's own syscalls
+        // would overwrite.
+        const err_msg = platform.dlError() orelse return;
+        const text = std.mem.span(err_msg);
+        if (is_first) self.first_len = copyInto(&self.first_buf, text);
+        if (self.real_len == 0 and platform.pathExists(candidate)) {
+            self.real_len = copyInto(&self.real_buf, text);
+            self.real_cand_len = copyInto(&self.real_cand_buf, candidate);
+        }
+    }
+
+    fn firstErr(self: *const DlOpenDiag) ?[]const u8 {
+        return if (self.first_len > 0) self.first_buf[0..self.first_len] else null;
+    }
+
+    fn realErr(self: *const DlOpenDiag) ?[]const u8 {
+        return if (self.real_len > 0) self.real_buf[0..self.real_len] else null;
+    }
+
+    fn realCand(self: *const DlOpenDiag) []const u8 {
+        return self.real_cand_buf[0..self.real_cand_len];
+    }
+
+    fn copyInto(dst: []u8, src: []const u8) usize {
+        const n = @min(dst.len, src.len);
+        @memcpy(dst[0..n], src[0..n]);
+        return n;
+    }
+};
+
 /// (ffi-open path-or-#f)
 /// Opens a shared library. Pass #f for the default process (all linked symbols).
 fn ffiOpen(args: []const Value) PrimitiveError!Value {
@@ -42,18 +111,22 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
 
     if (!types.isString(args[0])) return primitives.typeError("ffi-open", "string", args[0]);
     const str = types.toObject(args[0]).as(types.SchemeString);
+    const name = str.data[0..str.len];
 
     // Build null-terminated name
     var buf: [256]u8 = undefined;
     if (str.len >= buf.len) return primitives.typeError("ffi-open", "string shorter than 256 bytes", args[0]);
-    @memcpy(buf[0..str.len], str.data[0..str.len]);
+    @memcpy(buf[0..str.len], name);
     buf[str.len] = 0;
     const cname: [*:0]const u8 = @ptrCast(buf[0..str.len :0]);
 
+    var diag: DlOpenDiag = .{};
+
     // Try the name as-is
     if (platform.dlOpen(cname)) |handle| {
-        return gc.allocFfiLibrary(handle, str.data[0..str.len]) catch return PrimitiveError.OutOfMemory;
+        return gc.allocFfiLibrary(handle, name) catch return PrimitiveError.OutOfMemory;
     }
+    diag.noteFailure(buf[0..str.len :0], true);
 
     // Try platform library suffixes. ".so.6" covers glibc's core libraries
     // (libm, libc), where the unversioned .so is a linker script that
@@ -64,41 +137,80 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
             buf[str.len + suffix.len] = 0;
             const cname2: [*:0]const u8 = @ptrCast(buf[0 .. str.len + suffix.len :0]);
             if (platform.dlOpen(cname2)) |handle| {
-                return gc.allocFfiLibrary(handle, str.data[0..str.len]) catch return PrimitiveError.OutOfMemory;
+                return gc.allocFfiLibrary(handle, name) catch return PrimitiveError.OutOfMemory;
             }
+            diag.noteFailure(buf[0 .. str.len + suffix.len :0], false);
         }
     }
 
-    // Try $KAAPPI_HOME/lib/ (or ~/.kaappi/lib/) as a fallback for installed packages
+    // Try $KAAPPI_HOME/lib/ (or ~/.kaappi/lib/) as a fallback for installed
+    // packages — but only for bare names: dlopen(3) treats a name with a
+    // path separator as a pathname, not something to re-search elsewhere.
     const kaappi_paths = @import("kaappi_paths.zig");
     var home_buf: [256]u8 = undefined;
-    if (kaappi_paths.getHome(&home_buf)) |kaappi_home| {
-        const lib_prefix = "/lib/";
-        const home_suffixes: []const []const u8 =
-            if (comptime platform.is_windows) &.{ "", ".dll" } else &.{ "", ".dylib", ".so" };
-        for (home_suffixes) |suffix| {
-            if (kaappi_home.len + lib_prefix.len + str.len + suffix.len < 512) {
-                var pbuf: [512]u8 = undefined;
-                @memcpy(pbuf[0..kaappi_home.len], kaappi_home);
-                @memcpy(pbuf[kaappi_home.len..][0..lib_prefix.len], lib_prefix);
-                @memcpy(pbuf[kaappi_home.len + lib_prefix.len ..][0..str.len], str.data[0..str.len]);
-                @memcpy(pbuf[kaappi_home.len + lib_prefix.len + str.len ..][0..suffix.len], suffix);
-                const total = kaappi_home.len + lib_prefix.len + str.len + suffix.len;
-                pbuf[total] = 0;
-                const pname: [*:0]const u8 = @ptrCast(pbuf[0..total :0]);
-                if (platform.dlOpen(pname)) |handle| {
-                    return gc.allocFfiLibrary(handle, str.data[0..str.len]) catch return PrimitiveError.OutOfMemory;
+    var searched_home: ?[]const u8 = null;
+    if (!hasPathSeparator(name)) {
+        if (kaappi_paths.getHome(&home_buf)) |kaappi_home| {
+            searched_home = kaappi_home;
+            const lib_prefix = "/lib/";
+            const home_suffixes: []const []const u8 =
+                if (comptime platform.is_windows) &.{ "", ".dll" } else &.{ "", ".dylib", ".so" };
+            for (home_suffixes) |suffix| {
+                if (kaappi_home.len + lib_prefix.len + str.len + suffix.len < 512) {
+                    var pbuf: [512]u8 = undefined;
+                    @memcpy(pbuf[0..kaappi_home.len], kaappi_home);
+                    @memcpy(pbuf[kaappi_home.len..][0..lib_prefix.len], lib_prefix);
+                    @memcpy(pbuf[kaappi_home.len + lib_prefix.len ..][0..str.len], name);
+                    @memcpy(pbuf[kaappi_home.len + lib_prefix.len + str.len ..][0..suffix.len], suffix);
+                    const total = kaappi_home.len + lib_prefix.len + str.len + suffix.len;
+                    pbuf[total] = 0;
+                    const pname: [*:0]const u8 = @ptrCast(pbuf[0..total :0]);
+                    if (platform.dlOpen(pname)) |handle| {
+                        return gc.allocFfiLibrary(handle, name) catch return PrimitiveError.OutOfMemory;
+                    }
+                    diag.noteFailure(pbuf[0..total :0], false);
                 }
             }
         }
     }
 
     const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
-    if (platform.dlError()) |err_msg| {
+    if (diag.realErr()) |err| {
+        // A candidate exists on disk but refused to load — report its
+        // error, prefixed with the path when the platform's dlerror text
+        // (e.g. Windows' bare "Win32 error N") doesn't already name it.
+        const cand = diag.realCand();
+        if (std.mem.indexOf(u8, err, cand) == null) {
+            vm.setErrorDetail("ffi-open: {s}: {s}", .{ cand, err });
+        } else {
+            vm.setErrorDetail("ffi-open: {s}", .{err});
+        }
+    } else if (diag.firstErr()) |err| {
+        // No candidate existed anywhere: report the as-is attempt's error
+        // — it is about the name the user actually asked for — plus a
+        // note about the other candidates probed.
+        const plain_note = " (also tried " ++ dl_suffix_list ++ " suffixes)";
+        var note_buf: [384]u8 = undefined;
+        const note: []const u8 = if (searched_home) |home|
+            std.fmt.bufPrint(&note_buf, " (also tried {s} suffixes and {s}/lib/)", .{ dl_suffix_list, home }) catch plain_note
+        else
+            plain_note;
+        // Clamp the dlerror text so the note survives the detail buffer:
+        // dyld's multi-path "tried:" list alone can overflow it, and the
+        // tail of that list is the least useful part of the message.
+        const overhead = "ffi-open: ".len + note.len + "cannot open '': ".len + name.len;
+        const room = vm.last_error_detail.len -| overhead;
+        const err_clamped = err[0..@min(err.len, room)];
+        if (std.mem.indexOf(u8, err_clamped, name) == null) {
+            vm.setErrorDetail("ffi-open: cannot open '{s}': {s}{s}", .{ name, err_clamped, note });
+        } else {
+            vm.setErrorDetail("ffi-open: {s}{s}", .{ err_clamped, note });
+        }
+    } else if (platform.dlError()) |err_msg| {
         const msg = std.mem.span(err_msg);
         vm.setErrorDetail("ffi-open: {s}", .{msg});
     } else {
-        vm.setErrorDetail("ffi-open: cannot open '{s}'", .{str.data[0..str.len]});
+        vm.setErrorDetail("ffi-open: cannot open '{s}'", .{name});
     }
     return PrimitiveError.TypeError; // bare-ok: detail set above
 }

--- a/src/tests_ffi.zig
+++ b/src/tests_ffi.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const memory = @import("memory.zig");
 const types = @import("types.zig");
 const ffi = @import("ffi.zig");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 
 // A C-ABI function with a real `_Bool` parameter. In safe builds (the default)
@@ -165,4 +166,111 @@ test "ffi callback error state is consumed by the failing call (#1185)" {
 
     _ = try ctx.vm.eval("(ffi-callback-release bad)");
     _ = try ctx.vm.eval("(ffi-callback-release good)");
+}
+
+// ---------------------------------------------------------------------------
+// ffi-open failure diagnostics: report the load error of the candidate that
+// exists (or the name the user asked for), never the "no such file" of
+// whichever fallback probe happened to run last
+// ---------------------------------------------------------------------------
+
+/// Evals `(ffi-open "<target>")` under a guard and returns the raised error
+/// message. The slice points into ctx's heap — assert on it before
+/// evaluating anything else.
+fn ffiOpenErrorMessage(ctx: *th.TestContext, target: []const u8) ![]const u8 {
+    var src_buf: [1400]u8 = undefined;
+    const src = try std.fmt.bufPrint(
+        &src_buf,
+        "(guard (e (#t (error-object-message e))) (ffi-open \"{s}\") 'no-error)",
+        .{target},
+    );
+    const caught = try ctx.vm.eval(src);
+    try std.testing.expect(types.isString(caught));
+    const s = types.toObject(caught).as(types.SchemeString);
+    return s.data[0..s.len];
+}
+
+test "ffi-open: existing unloadable file's own error is reported, not a probe's" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "garbage-lib", .data = "not a shared library" });
+    const dir_path = try th.tmpDirRealPathAlloc(&tmp, std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    var target_buf: [1200]u8 = undefined;
+    const target = try std.fmt.bufPrint(&target_buf, "{s}/garbage-lib", .{dir_path});
+    // Backslashes would be escape characters inside the Scheme string
+    // literal; Win32 accepts forward slashes.
+    std.mem.replaceScalar(u8, target, '\\', '/');
+
+    const msg = try ffiOpenErrorMessage(&ctx, target);
+    // The report is about the file that exists…
+    try std.testing.expect(std.mem.indexOf(u8, msg, "garbage-lib") != null);
+    // …not about a suffixed or home-prefixed candidate that never existed.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "garbage-lib.so") == null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "garbage-lib.dylib") == null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "garbage-lib.dll") == null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "lib//") == null);
+}
+
+test "ffi-open: bare name hitting an unloadable file under KAAPPI_HOME/lib reports that file's error" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "lib");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "lib/kaappi-test-home-garbage", .data = "not a shared library" });
+    const dir_path = try th.tmpDirRealPathAlloc(&tmp, std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    // Point getHome's KAAPPI_HOME override at the tmp dir for the duration.
+    var old_buf: [1024]u8 = undefined;
+    const old_home: ?[]const u8 = if (platform.getenv("KAAPPI_HOME")) |v| blk: {
+        const s = std.mem.sliceTo(v, 0);
+        if (s.len > old_buf.len) break :blk null;
+        @memcpy(old_buf[0..s.len], s);
+        break :blk old_buf[0..s.len];
+    } else null;
+    try platform.setEnv(std.testing.allocator, "KAAPPI_HOME", dir_path);
+    defer if (old_home) |v| {
+        platform.setEnv(std.testing.allocator, "KAAPPI_HOME", v) catch {};
+    } else {
+        platform.unsetEnv(std.testing.allocator, "KAAPPI_HOME") catch {};
+    };
+
+    const msg = try ffiOpenErrorMessage(&ctx, "kaappi-test-home-garbage");
+    // The middle-of-probe-order candidate that exists is the subject…
+    try std.testing.expect(std.mem.indexOf(u8, msg, "kaappi-test-home-garbage") != null);
+    // …not the .dylib/.so/.dll probes that ran (and missed) after it.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "kaappi-test-home-garbage.") == null);
+}
+
+test "ffi-open: name not found anywhere reports the requested name plus probe note" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const msg = try ffiOpenErrorMessage(&ctx, "kaappi-no-such-lib-zz");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "kaappi-no-such-lib-zz") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "also tried") != null);
+}
+
+test "ffi-open: a path with separators is not re-searched under home lib" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const msg = try ffiOpenErrorMessage(&ctx, "/kaappi-no-such-dir/libnope");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "libnope") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "also tried") != null);
+    // The note must not claim a home-dir probe, and no doubled
+    // "<home>/lib/<path>" mashup may appear anywhere in the message.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "/lib/)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "lib//") == null);
 }

--- a/tests/scheme/ffi/ffi-open-errors.scm
+++ b/tests/scheme/ffi/ffi-open-errors.scm
@@ -1,0 +1,55 @@
+;; Regression test: ffi-open failure diagnostics.
+;;   1. A name containing a path separator must not be re-searched under
+;;      <home>/lib/ (dlopen semantics), so the reported error can never be
+;;      about a "<home>/lib/<abs-path>" mashup the user never asked for.
+;;   2. When a candidate exists on disk but fails to load (bad format, code
+;;      signing, wrong architecture), that candidate's error is reported —
+;;      not the "no such file" of whichever fallback probe ran last.
+(import (scheme base)
+        (scheme write)
+        (scheme file)
+        (scheme process-context)
+        (srfi 64)
+        (srfi 170))
+
+(test-begin "ffi-open-errors")
+
+;; A file that exists but is not a loadable shared library.
+(define garbage-name "ffi-open-errors-garbage.tmp")
+(define garbage-path (string-append (current-directory) "/" garbage-name))
+(when (file-exists? garbage-path) (delete-file garbage-path))
+(call-with-output-file garbage-path
+                       (lambda (p)
+                         (write-string "definitely not a shared library" p)))
+
+(define (open-error-message target)
+  (guard (e (#t (error-object-message e))) (ffi-open target) #f))
+
+(test-assert "existing unloadable file: its own load error is reported"
+             (let ((msg (open-error-message garbage-path)))
+               (and (string? msg)
+                    (string-contains msg garbage-name)
+                    (not (string-contains msg
+                                          (string-append garbage-name ".so")))
+                    (not (string-contains msg
+                                          (string-append garbage-name ".dylib")))
+                    (not (string-contains msg
+                                          (string-append garbage-name ".dll"))))))
+
+(test-assert "missing library: requested name and probe note are reported"
+             (let ((msg (open-error-message "kaappi-ffi-no-such-lib")))
+               (and (string? msg)
+                    (string-contains msg "kaappi-ffi-no-such-lib")
+                    (string-contains msg "also tried"))))
+
+(test-assert "path input: no home-dir mashup path is reported"
+             (let ((msg (open-error-message "/kaappi-ffi-no-such-dir/libnope")))
+               (and (string? msg)
+                    (string-contains msg "libnope")
+                    (not (string-contains msg "lib//")))))
+
+(delete-file garbage-path)
+
+(let ((runner (test-runner-current)))
+  (test-end "ffi-open-errors")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

`ffi-open` probes several candidates (name as-is, platform suffixes, `<home>/lib/` with suffixes) but reported `dlerror()` only after the last probe — and dlerror only remembers the most recent failure. A library that **existed but refused to load** (macOS code-signing rejection, wrong architecture, corrupt file) was reported as `no such file` for a fallback path the user never asked for.

Motivating repro: with `libkaappi_math.dylib` present in `~/.kaappi/lib` but rejected by macOS library validation (v0.15.0 binary without the entitlement), `(import (kaappi math))` reported only `dlopen(~/.kaappi/lib/libkaappi_math.so): no such file` — never the validation error for the `.dylib` that exists.

## Changes

- **Snapshot per-candidate failures** (`DlOpenDiag`) and report, in order of preference:
  1. the error of the first candidate that **exists on disk but failed to load** — the signing/arch/format rejection that matters, wherever it fell in probe order (ecosystem libs pass bare names, so in the repro it's a mid-order candidate, not the as-is attempt);
  2. else the **as-is attempt's error** — about the name the user actually asked for — prefixed with the requested name when the platform's dlerror text doesn't contain it (Windows' bare `Win32 error N`), plus a `(also tried .dylib/.so/.so.6 suffixes and <home>/lib/)` note. The dlerror text is clamped so the note survives the 256-byte detail buffer (dyld's `tried:` list alone can overflow it).
- **Skip the `<home>/lib/` fallback for names containing a path separator**, matching dlopen(3) semantics (slash ⇒ pathname, not search key). Previously an absolute path produced nonsense probes like `<home>/lib//abs/path/libfoo.dylib.so`, whose `no such file` then masked the real error.
- On Windows, dlerror is snapshotted **before** the existence probe, since the text is rendered from `GetLastError()` at read time and the probe's own syscalls would clobber it.

Example (existing non-library file), before → after:

```
ffi-open: dlopen(/Users/x/.kaappi/lib//tmp/garbage.so, 0x0001): tried: '...' (no such file)
ffi-open: dlopen(/tmp/garbage, 0x0001): tried: '/tmp/garbage' (slice is not valid mach-o file), ...
```

## Compatibility

All ecosystem `ffi-open` call sites audited — every one passes a bare name, so the separator gate changes no working lookup. `primitives_ffi.specs` is comptime-excluded on wasm, so the new `pathExists` call never reaches that target.

## Tests

- 4 unit tests in `src/tests_ffi.zig`: existing-unloadable file via absolute path; the bare-name repro shape (garbage file under a temp `KAAPPI_HOME/lib`, asserting the mid-order candidate's error wins); not-found reporting the requested name + probe note; separator input never mentioning a home probe or `lib//` mashup. Each fails against the old code on POSIX and Windows.
- End-to-end SRFI-64 regression `tests/scheme/ffi/ffi-open-errors.scm`, self-contained (writes/deletes its own garbage fixture).

Verified: full `zig build test` green; `tests_ffi` green under `-Dgc-stress=true`; entire `tests/scheme/ffi/` suite green; cross-compiles clean for `aarch64-windows`, `x86_64-linux`, and wasm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)