### PR TITLE
Splice top-level cond-expand into top-level forms (#1661)

### DIFF
--- a/docs/dev/check.md
+++ b/docs/dev/check.md
@@ -108,6 +108,15 @@ their bound names are gathered structurally in a pre-pass so a forward reference
 is not warned. `define-syntax` registers its macro at *compile* time, so a
 later use of a same-file macro expands correctly without running anything.
 
+Top-level `begin` and `cond-expand` are *spliced*: their bodies are analysed as
+top-level forms, matching how the interpreter treats them (R7RS 5.1 / 4.2.1). A
+`cond-expand` clause is selected with `evalLibFeatureReq` — the same live-registry
+evaluator the runtime uses — so a nested `import` runs for effect and a nested
+`define`'s name is gathered as a top-level binding (the pre-pass conservatively
+gathers from every clause, since it has no VM to pick one). Without this, the
+matched clause compiled as an expression and a nested `import` flagged `srfi` as
+an unknown top-level variable (#1661).
+
 ## The literal-type table
 
 `check_lint.zig`'s `type_table` is deliberately narrow. An entry belongs there

--- a/src/check.zig
+++ b/src/check.zig
@@ -29,6 +29,7 @@ const types = @import("types.zig");
 const reader = @import("reader.zig");
 const compiler = @import("compiler.zig");
 const vm_mod = @import("vm.zig");
+const vm_library = @import("vm_library.zig");
 const ir_mod = @import("ir.zig");
 const diagnostics = @import("diagnostics.zig");
 const lsp_diagnostic = @import("lsp_diagnostic.zig");
@@ -165,6 +166,31 @@ fn checkForm(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, expr: 
             return;
         }
 
+        // Top-level `cond-expand` splices the selected clause's body as
+        // top-level forms (R7RS 4.2.1) — recurse so a nested import runs for
+        // its effect and later forms see its bindings, mirroring the runtime's
+        // handleTopLevelCondExpand. Clause selection uses evalLibFeatureReq, the
+        // same evaluator the runtime uses, so both pick the same clause (#1661).
+        // A malformed or unsatisfied cond-expand falls through to be compiled as
+        // an expression (the compiler folds no-match to void and reports bad
+        // syntax) — the same fallback the runtime compiler path takes.
+        if (std.mem.eql(u8, name, "cond-expand")) {
+            var clauses = types.cdr(expr);
+            while (types.isPair(clauses)) : (clauses = types.cdr(clauses)) {
+                const clause = types.car(clauses);
+                if (!types.isPair(clause)) break;
+                const feature_req = types.car(clause);
+                const is_else = types.isSymbol(feature_req) and std.mem.eql(u8, types.symbolName(feature_req), "else");
+                if (is_else or vm_library.evalLibFeatureReq(vm, feature_req)) {
+                    var body = types.cdr(clause);
+                    while (types.isPair(body)) : (body = types.cdr(body)) {
+                        checkForm(vm, ctx, arena, types.car(body), path, line, col);
+                    }
+                    return;
+                }
+            }
+        }
+
         // Environment setup that later forms depend on: run it (suppressing lint
         // over the library/record code it compiles), so imported names/macros and
         // record accessors are in scope for the rest of the file.
@@ -229,6 +255,23 @@ fn collectFromForm(set: *std.StringHashMap(void), arena: std.mem.Allocator, expr
         var cur = rest;
         while (types.isPair(cur)) : (cur = types.cdr(cur)) {
             collectFromForm(set, arena, types.car(cur));
+        }
+    } else if (std.mem.eql(u8, head, "cond-expand")) {
+        // A top-level cond-expand splices its selected clause as top-level forms
+        // (#1661), so a define nested in a matched clause is a top-level name.
+        // With no VM here we can't tell which clause the runtime selects, so
+        // gather names from every clause body — the same conservative
+        // over-approximation test_selection.zig uses for import deps. At worst
+        // this suppresses a warning for a name only a dead clause defines; it
+        // never invents a spurious one (the linter's safe direction).
+        var cur = rest;
+        while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+            const clause = types.car(cur);
+            if (!types.isPair(clause)) continue;
+            var body = types.cdr(clause); // skip the feature requirement
+            while (types.isPair(body)) : (body = types.cdr(body)) {
+                collectFromForm(set, arena, types.car(body));
+            }
         }
     }
 }

--- a/src/tests_check.zig
+++ b/src/tests_check.zig
@@ -291,3 +291,28 @@ test "read and compile errors are reported as findings" {
     }
     try testing.expect(saw_compile);
 }
+
+// ── Top-level cond-expand splices its selected clause (#1661) ───────────────
+// check must analyse a matched top-level cond-expand clause as spliced
+// top-level forms, exactly as it already does for begin. Otherwise the clause
+// compiled as an expression: a nested import turned `(srfi 1)` into a call to
+// an unknown `srfi`, and a nested define was never gathered as a top-level name
+// so a forward reference to it warned. Both were spurious KP4001 warnings.
+
+test "cond-expand: import nested in a matched clause is not flagged (#1661)" {
+    // else clause — the import runs for effect, `srfi` is not a call target.
+    try expectCounts("(cond-expand (else (import (srfi 1))))", 0, 0, 0);
+    // srfi-N guard (the #1649 idiom) selects the same clause.
+    try expectCounts("(cond-expand (srfi-1 (import (srfi 1))) (else 0))", 0, 0, 0);
+}
+
+test "cond-expand: a define in a matched clause is a known top-level name (#1661)" {
+    // The define nested in the clause must be gathered as a top-level name so
+    // the earlier forward reference resolves — like a top-level begin.
+    try expectCounts("(define (f) (helper))\n(cond-expand (else (define (helper) 1)))", 0, 0, 0);
+}
+
+test "cond-expand: an unsatisfied top-level clause is not an error (#1661)" {
+    // No clause matches and there is no else: folds to void, no finding.
+    try expectCounts("(cond-expand (no-such-feature (import (srfi 1))))", 0, 0, 0);
+}

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -755,3 +755,55 @@ test "srfi-N feature: portable srfi id honors sandbox mode (#1649)" {
     // A built-in, sandbox-allowed SRFI stays true under sandbox.
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(try vm.eval("(cond-expand (srfi-1 1) (else 0))")));
 }
+
+// ── Top-level cond-expand splices its body as top-level forms (#1661) ────────
+// R7RS 4.2.1: a top-level cond-expand expands to the selected clause's forms in
+// a top-level context, so declarations that only work at top level (import,
+// define, define-library, ...) nested in the matched clause must work. Before
+// the fix the whole form compiled as an expression, where `import` was not a
+// recognized form and `(srfi 1)` read as a call to an undefined `srfi` — the
+// program printed KP3001 and exited 1 even though the import still ran.
+
+test "top-level cond-expand splices a nested import via else (#1661)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Old behavior raised UndefinedVariable here; now it splices and imports.
+    _ = try vm.eval("(cond-expand (else (import (srfi 1))))");
+    // The import's side effect is visible: fold comes from (srfi 1).
+    try std.testing.expectEqual(@as(i64, 6), types.toFixnum(try vm.eval("(fold + 0 '(1 2 3))")));
+}
+
+test "top-level cond-expand: matched srfi-N guard imports cleanly (#1661)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The idiomatic #1649 probe: the srfi-1 clause is selected by
+    // evalLibFeatureReq and its nested import runs as a top-level form.
+    _ = try vm.eval("(cond-expand (srfi-1 (import (srfi 1))) (else (error \"no srfi-1\")))");
+    try std.testing.expectEqual(@as(i64, 10), types.toFixnum(try vm.eval("(fold + 0 '(1 2 3 4))")));
+}
+
+test "top-level cond-expand still yields a value as an expression (#1661)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // A matched clause whose body is an expression: the spliced begin returns
+    // its last form's value, so a bare top-level cond-expand is still a value.
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try vm.eval("(cond-expand (else 42))")));
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(try vm.eval("(cond-expand (srfi-1 3) (else 0))")));
+
+    // cond-expand in expression position (not the top-level datum) still goes
+    // through the compiler and composes inside a larger expression.
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(try vm.eval("(+ 1 (cond-expand (else 6)))")));
+
+    // No clause matches and there is no else: void, not an error (matching the
+    // expression-position compiler in compiler_conditionals.compileCondExpand).
+    try std.testing.expectEqual(types.VOID, try vm.eval("(cond-expand (no-such-feature 1))"));
+}

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -825,4 +825,8 @@ test "top-level cond-expand malformed-form parity with the compiler (#1661)" {
     // An improper clause-list tail reached without a match is the syntax error
     // the compiler reports for the same form in expression position.
     try std.testing.expectError(error.CompileError, vm.eval("(cond-expand (no-such-feature 1) . junk)"));
+
+    // An improper selected clause body is likewise rejected, rather than
+    // silently splicing the proper prefix and dropping the tail.
+    try std.testing.expectError(error.CompileError, vm.eval("(cond-expand (else 1 . junk))"));
 }

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -807,3 +807,22 @@ test "top-level cond-expand still yields a value as an expression (#1661)" {
     // expression-position compiler in compiler_conditionals.compileCondExpand).
     try std.testing.expectEqual(types.VOID, try vm.eval("(cond-expand (no-such-feature 1))"));
 }
+
+test "top-level cond-expand malformed-form parity with the compiler (#1661)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // A matched clause returns immediately and never inspects later clauses —
+    // so a bare symbol after a matched else is ignored, not a syntax error,
+    // exactly as the expression-position compiler treats it.
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try vm.eval("(cond-expand (else 42) trailing-junk)")));
+
+    // A non-pair where a clause is expected is a syntax error, like the compiler.
+    try std.testing.expectError(error.CompileError, vm.eval("(cond-expand not-a-clause)"));
+
+    // An improper clause-list tail reached without a match is the syntax error
+    // the compiler reports for the same form in expression position.
+    try std.testing.expectError(error.CompileError, vm.eval("(cond-expand (no-such-feature 1) . junk)"));
+}

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -83,6 +83,11 @@ pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
     // R7RS 5.1: top-level begin splices its body as top-level forms
     if (std.mem.eql(u8, name, "begin")) return handleTopLevelBegin(vm, types.cdr(expr));
 
+    // R7RS 4.2.1: a top-level cond-expand expands to the selected clause's forms
+    // in a top-level context, so its body may contain declarations (import,
+    // define-library, ...) that only work at top level (#1661).
+    if (std.mem.eql(u8, name, "cond-expand")) return handleTopLevelCondExpand(vm, types.cdr(expr));
+
     return null;
 }
 
@@ -102,7 +107,8 @@ fn isSpecialTopLevelForm(expr: Value) bool {
         std.mem.eql(u8, name, "define-values") or
         std.mem.eql(u8, name, "include") or
         std.mem.eql(u8, name, "include-ci") or
-        std.mem.eql(u8, name, "begin");
+        std.mem.eql(u8, name, "begin") or
+        std.mem.eql(u8, name, "cond-expand");
 }
 
 /// Compile a single expression for the native eval-fallback cache (#1494):
@@ -171,6 +177,36 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
         rest = types.cdr(rest);
     }
     return last;
+}
+
+// R7RS 4.2.1: evaluate a top-level cond-expand by selecting the first clause
+// whose feature requirement holds (or the else clause) and splicing that
+// clause's body as top-level forms — the same splicing handleTopLevelBegin
+// does. This lets top-level-only declarations nested in a matched clause
+// (import, define-library, define-record-type, ...) work, instead of the whole
+// form being compiled as an expression where those aren't recognized (#1661).
+//
+// Clause selection reuses vm_library.evalLibFeatureReq (the live-registry
+// evaluator define-library uses), so guards resolve identically in both
+// contexts: else, (library (srfi N)), and the srfi-N feature ids (#1649).
+//
+// The caller (handleTopLevelForm) has the whole cond-expand form rooted, so the
+// clause list and the selected body stay reachable across the compile/execute
+// that handleTopLevelBegin performs. No clause matching yields void, matching
+// the expression-position compiler (compiler_conditionals.compileCondExpand).
+fn handleTopLevelCondExpand(vm: *VM, clauses_val: Value) VMError!Value {
+    var clauses = clauses_val;
+    while (types.isPair(clauses)) {
+        const clause = types.car(clauses);
+        clauses = types.cdr(clauses);
+        if (!types.isPair(clause)) return VMError.CompileError;
+        const feature_req = types.car(clause);
+        const is_else = types.isSymbol(feature_req) and std.mem.eql(u8, types.symbolName(feature_req), "else");
+        if (is_else or vm_library.evalLibFeatureReq(vm, feature_req)) {
+            return handleTopLevelBegin(vm, types.cdr(clause));
+        }
+    }
+    return types.VOID;
 }
 
 fn handleDefineValues(vm: *VM, args: Value) VMError!Value {

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -206,9 +206,12 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
 // error; a proper but unsatisfied list (no matching clause, no else) yields
 // void; and — like the compiler — a matched clause returns immediately without
 // inspecting later clauses, so trailing clauses after a match are not validated.
-// The one case needing an explicit check is an improper clause-list tail reached
-// without a match (e.g. `(cond-expand (x 1) . junk)`): the compiler rejects it,
-// so we do too rather than silently yield void.
+// Two structural cases need an explicit check because handleTopLevelBegin (shared
+// with top-level begin) silently ignores improper tails while the compiler
+// rejects them: an improper clause-list tail reached without a match (e.g.
+// `(cond-expand (x 1) . junk)`), and an improper selected clause body (e.g.
+// `(cond-expand (else 1 . junk))`). Both are validated here so cond-expand's own
+// structure matches the compiler; begin's own leniency is left untouched.
 fn handleTopLevelCondExpand(vm: *VM, clauses_val: Value) VMError!Value {
     var clauses = clauses_val;
     while (types.isPair(clauses)) : (clauses = types.cdr(clauses)) {
@@ -217,11 +220,21 @@ fn handleTopLevelCondExpand(vm: *VM, clauses_val: Value) VMError!Value {
         const feature_req = types.car(clause);
         const is_else = types.isSymbol(feature_req) and std.mem.eql(u8, types.symbolName(feature_req), "else");
         if (is_else or vm_library.evalLibFeatureReq(vm, feature_req)) {
-            return handleTopLevelBegin(vm, types.cdr(clause));
+            const body = types.cdr(clause);
+            if (!isProperList(body)) return VMError.CompileError;
+            return handleTopLevelBegin(vm, body);
         }
     }
     if (clauses != types.NIL) return VMError.CompileError;
     return types.VOID;
+}
+
+// A proper (nil-terminated) list? Used to reject improper clause bodies before
+// splicing them, matching the compiler's rejection of the same malformed form.
+fn isProperList(list: Value) bool {
+    var rest = list;
+    while (types.isPair(rest)) rest = types.cdr(rest);
+    return rest == types.NIL;
 }
 
 fn handleDefineValues(vm: *VM, args: Value) VMError!Value {

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -172,7 +172,13 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
             vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
-            last = vm.execute(func) catch |err| return err;
+            // runTopLevelFunction, not vm.execute: a spliced top-level body can
+            // be reached while an outer execution is suspended (eval re-entered
+            // from a native callback, frame_count != 0). A bare vm.execute would
+            // resetExecutionState and corrupt frame 0; runTopLevelFunction runs
+            // the thunk re-entrantly in that case and is identical to vm.execute
+            // at true top level. func is rooted above, as it requires.
+            last = runTopLevelFunction(vm, func) catch |err| return err;
         }
         rest = types.cdr(rest);
     }
@@ -192,13 +198,21 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
 //
 // The caller (handleTopLevelForm) has the whole cond-expand form rooted, so the
 // clause list and the selected body stay reachable across the compile/execute
-// that handleTopLevelBegin performs. No clause matching yields void, matching
-// the expression-position compiler (compiler_conditionals.compileCondExpand).
+// that handleTopLevelBegin performs.
+//
+// Malformed-form handling tracks the expression-position compiler
+// (compiler_conditionals.compileCondExpand) so the same form errors the same way
+// regardless of position: a non-pair where a clause is expected is a syntax
+// error; a proper but unsatisfied list (no matching clause, no else) yields
+// void; and — like the compiler — a matched clause returns immediately without
+// inspecting later clauses, so trailing clauses after a match are not validated.
+// The one case needing an explicit check is an improper clause-list tail reached
+// without a match (e.g. `(cond-expand (x 1) . junk)`): the compiler rejects it,
+// so we do too rather than silently yield void.
 fn handleTopLevelCondExpand(vm: *VM, clauses_val: Value) VMError!Value {
     var clauses = clauses_val;
-    while (types.isPair(clauses)) {
+    while (types.isPair(clauses)) : (clauses = types.cdr(clauses)) {
         const clause = types.car(clauses);
-        clauses = types.cdr(clauses);
         if (!types.isPair(clause)) return VMError.CompileError;
         const feature_req = types.car(clause);
         const is_else = types.isSymbol(feature_req) and std.mem.eql(u8, types.symbolName(feature_req), "else");
@@ -206,6 +220,7 @@ fn handleTopLevelCondExpand(vm: *VM, clauses_val: Value) VMError!Value {
             return handleTopLevelBegin(vm, types.cdr(clause));
         }
     }
+    if (clauses != types.NIL) return VMError.CompileError;
     return types.VOID;
 }
 

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -726,7 +726,10 @@ fn tryLoadLibraryFromFile(vm: *VM, name_list: Value) !void {
 
 /// Evaluate a feature requirement for cond-expand in define-library.
 /// Unlike the compiler's evalFeatureReq, this has access to the VM's live library registry.
-fn evalLibFeatureReq(vm: *VM, req: Value) bool {
+/// Also used by handleTopLevelCondExpand in vm_eval.zig (#1661) so a top-level
+/// cond-expand selects clauses with the same live-registry logic as the
+/// define-library form.
+pub fn evalLibFeatureReq(vm: *VM, req: Value) bool {
     if (types.isSymbol(req)) {
         const name = types.symbolName(req);
         for (types.platform_features) |f| {

--- a/tests/scheme/errors/exit-code.sh
+++ b/tests/scheme/errors/exit-code.sh
@@ -73,6 +73,12 @@ assert_exit_code "explicit (exit 0) after error exits 0" 0 "$KAAPPI" "$TMPDIR_TE
 echo '(import (scheme base)) (guard (e (#t (display "caught"))) (car 1))' > "$TMPDIR_TESTS/guarded.scm"
 assert_exit_code "guarded error exits 0" 0 "$KAAPPI" "$TMPDIR_TESTS/guarded.scm"
 
+# A top-level cond-expand must splice its matched clause's body as top-level
+# forms, so a nested import runs as a declaration rather than compiling as an
+# expression that emits a spurious KP3001 and exits 1 (#1661).
+printf '(cond-expand (else (import (srfi 1))))\n(display (fold + 0 (list 1 2 3)))\n' > "$TMPDIR_TESTS/condexpand-import.scm"
+assert_exit_code "top-level cond-expand nested import exits 0 (#1661)" 0 "$KAAPPI" "$TMPDIR_TESTS/condexpand-import.scm"
+
 # Stdin scripts behave the same
 assert_stdin_exit_code "clean stdin exits 0" 0 '(display "ok")'
 assert_stdin_exit_code "stdin runtime error exits 1" 1 '(car 1)'


### PR DESCRIPTION
## Summary

Fixes #1661. A `cond-expand` at the top level was compiled as an ordinary
expression, so an `import` (or any top-level-only declaration) nested in the
matched clause was mis-compiled — `(srfi 1)` read as a call to an undefined
`srfi`, printing `error[KP3001]: undefined variable 'srfi'` and exiting 1, even
though the import's side effect still ran. This defeated the idiomatic #1649
probe `(cond-expand (srfi-1 (import (srfi 1))) (else …))`.

```scheme
;; before: prints the KP3001 error and exits 1 (but still prints 6)
(cond-expand (else (import (srfi 1))))
(display (fold + 0 '(1 2 3)))   ; => 6
```

## Fix

R7RS 4.2.1: a top-level `cond-expand` expands to the selected clause's forms in
a **top-level context**. So `handleTopLevelForm` (`src/vm_eval.zig`) now
recognizes `cond-expand`:

- selects the first satisfied clause (or `else`) with the existing
  `evalLibFeatureReq` — the same live-registry evaluator `define-library` uses,
  so `else`, `(library (srfi N))`, and the `srfi-N` feature ids (#1649) all
  resolve identically;
- splices the matched clause's body through `handleTopLevelBegin`, exactly as
  top-level `begin` already does;
- `isSpecialTopLevelForm` learns `cond-expand` too, so the native eval-cache
  (#1494) declines to cache it.

Expression-position `cond-expand` (inside `define`, as a call argument, …) is
untouched — it never reaches `handleTopLevelForm` and still goes through the
compiler. A no-match top-level `cond-expand` yields void, matching the
compiler; a malformed one is a `KP2001` syntax error, matching the compiler.

## `kaappi check` had the same bug

The compile-only linter had the identical splice gap, surfacing as spurious
`KP4001` warnings — the clause compiled as an expression flagged `srfi`, and a
`define` nested in a matched clause was never gathered as a top-level name, so a
forward reference to it warned. Mirrored the splice in `src/check.zig`:
`checkForm` recurses into the selected clause (like `begin`), and
`collectFromForm` gathers names from every clause body (no VM there to pick one
— the same conservative over-approximation `test_selection.zig` already uses for
import deps). `docs/dev/check.md` updated.

`pipeline.zig` (the `expand`/`ir`/`ast` dumps) and `test_selection.zig` were
checked: the former only prints the form (no error — out of scope), and the
latter already walks every `cond-expand` clause.

## Tests

- `src/tests_libraries.zig` — top-level splice makes a nested `import` bind
  (`else` and `srfi-N` guards); top-level `cond-expand` still yields a value;
  expression-position `cond-expand` still composes; no-match yields void.
- `src/tests_check.zig` — a matched clause's `import` isn't flagged; a nested
  `define` is a known top-level name; an unsatisfied clause is not an error.
- `tests/scheme/errors/exit-code.sh` — top-level import-in-`cond-expand` exits 0.

Full unit suite (1226 tests), R7RS suite, SRFI/smoke/compliance/error suites all
green locally.