### PR TITLE
Add understanding map and /quiz comprehension skill

### DIFF
--- a/.claude/skills/quiz/SKILL.md
+++ b/.claude/skills/quiz/SKILL.md
@@ -1,0 +1,143 @@
+---
+description: Prediction-with-commitment comprehension quiz on a core Kaappi subsystem — writes questions from the current code, waits for committed answers, verifies against code and live runs, and logs results to a per-user ledger. Use when the user asks to be quizzed, to test or calibrate their understanding of a subsystem, or to measure comprehension coverage / pay down cognitive debt.
+---
+
+# Comprehension Quiz
+
+Measures and repairs the gap between the code and the maintainer's mental
+model of it. One principle governs everything here: **prediction with
+commitment before revelation**. A committed wrong answer, corrected with
+evidence, builds more model than any explainer (the hypercorrection
+effect). This is a calibration instrument, not an exam.
+
+The argument is a subsystem: one of the core-tier names in
+`docs/dev/understanding-map.md` (values, gc, ir, continuations, hygiene,
+fibers, threads) or a `src/` file. Only core-tier subsystems are quizzed
+by default — not knowing fenced-tier internals is the point of the fence;
+quiz one only if explicitly asked. With no argument: read the ledger,
+list the core-tier subsystems least recently quizzed, let the user pick.
+
+## Workflow
+
+### Step 1: Prepare (silently)
+
+1. Read the subsystem's section in `docs/dev/understanding-map.md` — its
+   "Theory" list is the syllabus.
+2. Read the actual sources. Questions and answers are grounded in the
+   code as it is **today**, never in docs or your memory of them.
+3. Read the relevant `docs/dev/` pages *last*, looking for drift: if doc
+   and code disagree, that is a finding — and prime quiz material.
+4. Check `~/.kaappi/quiz-ledger.md` for this subsystem's previous `Gaps:`
+   lines — if any exist, re-test exactly one (spaced repetition).
+
+Do not narrate this phase, and do not quote code that leaks answers.
+
+### Step 2: Ask
+
+Write 3–5 questions, numbered, all in one message. Mix these types:
+
+- **Prediction** — "what happens if …" for a concrete input or sequence;
+  must be demonstrable by running something.
+- **Invariant** — "what must remain true across …, and what breaks when
+  it doesn't?"
+- **Design** — "why this way; what alternative was rejected, and why?"
+- **Debugging** — "given this symptom, where do you look first, and why
+  there?"
+
+Then state the rules and **end the turn**:
+
+> Commit answers to all questions before I reveal anything. Guessing is
+> fine — a confident wrong answer is the most valuable outcome. One or
+> two sentences each.
+
+No hints, no code excerpts that give answers away, no continuing until
+the user replies. Grade only what they commit; unanswered questions are
+recorded as not attempted.
+
+### Step 3: Verify with evidence
+
+Ground truth comes **by demonstration, not recall**:
+
+- Behavior questions: run it — a scratch `.scm` through
+  `zig-out/bin/kaappi` (build first if needed), the REPL, `kaappi ir` /
+  `kaappi expand`, `--disassemble`; `-Dgc-stress=true` for GC claims.
+  Show the actual output.
+- Invariant/design questions: cite the exact `file:line` and quote the
+  decisive lines.
+- If a question can't be demonstrated or cited, it was a bad question —
+  void it and say so rather than grading from belief.
+
+### Step 4: Grade
+
+Per question: ✓ correct / ◐ partial / ✗ wrong — evidence first, then at
+most one short paragraph of correction. A confident ✗ is the jackpot:
+show the disproof cleanly and plainly; don't soften it, don't pile on.
+
+Two special verdicts:
+
+- **User right, code wrong** — their model beats the implementation.
+  That's a bug finding: offer to file it.
+- **User matches the docs, code disagrees** — doc drift: offer to fix the
+  doc or file it.
+
+### Step 5: Ledger
+
+Append to `~/.kaappi/quiz-ledger.md` (create with a
+`# Kaappi comprehension ledger` header if missing). It lives outside the
+repo deliberately: it survives worktrees and stays out of the public
+repo. Format:
+
+```markdown
+## 2026-07-19 — gc (3/5)
+1. ✓ root-before-allocate across two allocations
+2. ✗ write-barrier direction — answered young→old; it's old→young (memory.zig:NNN)
+3. ◐ copy-before-collect — knew the rule, not why slices alias
+4. ✓ vm_instance as root (#1401)
+5. — survive-count promotion (not attempted)
+Gaps: barrier direction; promotion rule.
+Drift: none.
+```
+
+One `##` entry per quiz; a verdict plus a few-word gist per question; a
+`Gaps:` line (it seeds the next quiz's re-test); a `Drift:` line.
+
+### Step 6: Close the loop
+
+- **≥80%** — model is healthy; note which subsystem the ledger says is
+  most stale.
+- **≤50% on a core subsystem** — suggest a retrieval session: the user
+  writes the subsystem's theory from memory (ten lines), then you diff it
+  against the code together.
+- **Any confident ✗ on an invariant** — flag it in `Gaps:` so the next
+  quiz re-tests it.
+- Findings (bugs, drift) get filed or fixed, not just noted.
+
+## Question quality bar
+
+Good questions probe theory; bad ones probe text.
+
+**Good** — "A primitive holds the Value returned by `allocPair` in a Zig
+local, calls `allocVector`, then uses the local. What can happen, and
+which build flag makes the failure deterministic?" (runnable, plausible
+wrong answers, tests a load-bearing rule)
+
+**Good** — "`close-port` on an fd with fibers parked on it: what happens
+to those fibers, and why was 'leave them parked' not an option?"
+
+**Bad** — "How many optimization passes does the IR run?" (grep-able
+trivia — a number, not a model)
+
+**Bad** — "Which file implements dynamic-wind transitions?" (naming;
+knowing it's `vm_continuations.zig` is not knowing the wind invariant)
+
+The test for keeping a question: could a wrong answer to it ever cause a
+bad merge decision, a wrong review, or a misdiagnosis? If not, cut it.
+
+## Anti-patterns
+
+- Explaining anything before answers are committed — the commitment *is*
+  the mechanism.
+- Grading from docs or memory instead of demonstration.
+- Padding to five questions with trivia — three sharp beat five soft.
+- Turning the reveal into a lecture — evidence, one paragraph, move on.
+- Quizzing fenced-tier internals unprompted.

--- a/.claude/skills/quiz/SKILL.md
+++ b/.claude/skills/quiz/SKILL.md
@@ -10,19 +10,26 @@ commitment before revelation**. A committed wrong answer, corrected with
 evidence, builds more model than any explainer (the hypercorrection
 effect). This is a calibration instrument, not an exam.
 
-The argument is a subsystem: one of the core-tier names in
-`docs/dev/understanding-map.md` (values, gc, ir, continuations, hygiene,
-fibers, threads) or a `src/` file. Only core-tier subsystems are quizzed
-by default — not knowing fenced-tier internals is the point of the fence;
-quiz one only if explicitly asked. With no argument: read the ledger,
-list the core-tier subsystems least recently quizzed, let the user pick.
+The argument is a subsystem alias or a `src/` file. Aliases are the
+canonical ledger keys, one per core-tier section of
+`docs/dev/understanding-map.md`: `values` (§1), `gc` (§2), `ir` (§3),
+`continuations` (§4), `hygiene` (§5), `fibers` (§6), `threads` (§7).
+A `src/` file argument resolves to the core-tier section whose
+**Where** line lists it and is quizzed under that section's alias; a
+file listed by no core section is fenced-tier — quizzed only if
+explicitly asked, with the file itself as the syllabus and its path as
+the ledger key. Only core-tier subsystems are quizzed by default: not
+knowing fenced-tier internals is the point of the fence. With no
+argument: read the ledger, list the aliases least recently quizzed,
+let the user pick.
 
 ## Workflow
 
 ### Step 1: Prepare (silently)
 
-1. Read the subsystem's section in `docs/dev/understanding-map.md` — its
-   "Theory" list is the syllabus.
+1. Read the resolved core-tier section in `docs/dev/understanding-map.md`
+   — its "Theory" list is the syllabus. (For an explicitly requested
+   fenced-tier file, the file itself is the syllabus.)
 2. Read the actual sources. Questions and answers are grounded in the
    code as it is **today**, never in docs or your memory of them.
 3. Read the relevant `docs/dev/` pages *last*, looking for drift: if doc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -628,6 +628,8 @@ detailed checklists for GC write barriers, rooting, and compiler form additions.
 | `/do-linux-test` | Full test suite on real x86-64 Linux via DigitalOcean droplet |
 | `/do-stress-test` | Unit suite under `-Dgc-stress=true` on a DigitalOcean droplet (3-hour lifetime) |
 | `/do-gate-benchmark` | KEP gate-campaign statistical benchmark (`benchmarks/gate/`) on a Linux x86_64 reference machine via DigitalOcean droplet |
+| `/parallel-issues` | Group open GitHub issues into parallel sets for concurrent Claude Code sessions |
+| `/quiz` | Prediction-with-commitment comprehension quiz on a core-tier subsystem (`docs/dev/understanding-map.md`); answers verified against code and live runs, results logged to `~/.kaappi/quiz-ledger.md` |
 
 ### Ecosystem plugin (`kaappi-dev`)
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -79,6 +79,7 @@ investigations.
 | Document | Contents |
 |----------|----------|
 | [ecosystem-library-bar.md](ecosystem-library-bar.md) | Quality bar for `kaappi-*` packages (applies ecosystem-wide, not just this repo) |
+| [understanding-map.md](understanding-map.md) | Where theory must live in a maintainer's head (core tier) vs. where a contract fences deliberate shallowness (fenced tier); the reification ladder; comprehension practices incl. `/quiz` |
 
 ## Adding a new document
 

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -316,10 +316,12 @@ are considered, and a comma-separated list of issue numbers to skip.
 
 Prediction-with-commitment comprehension quiz on a core-tier subsystem
 from [understanding-map.md](understanding-map.md) — the practice half of
-the cognitive-debt policy that document defines. Protocol: silently read
-the current sources (not the docs), ask 3–5
+the cognitive-debt policy that document defines. Protocol: silently
+prepare — the map section is the syllabus, the current sources are
+ground truth, and the relevant `docs/dev/` pages are read last, purely
+to detect doc/code drift — then ask 3–5
 prediction/invariant/design/debugging questions, require committed
-answers before revealing anything, then grade with evidence — live runs
+answers before revealing anything, and grade with evidence — live runs
 and `file:line` citations, never recall. Results append to a per-user
 ledger at `~/.kaappi/quiz-ledger.md`, kept outside the repo deliberately
 (survives worktrees, stays private). Doc-vs-code drift and

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -305,6 +305,26 @@ dataset (PR #1580); see the skill file for the full lesson set (droplet
 tier-restriction gotcha, three bash-guard string-match footguns, splitting a
 run around a per-machine workload cap).
 
+### `/parallel-issues`
+
+Groups open GitHub issues into sets that can be worked concurrently by
+separate Claude Code sessions without file-level conflicts. Optional
+arguments: a label (or comma-separated labels) restricting which issues
+are considered, and a comma-separated list of issue numbers to skip.
+
+### `/quiz`
+
+Prediction-with-commitment comprehension quiz on a core-tier subsystem
+from [understanding-map.md](understanding-map.md) — the practice half of
+the cognitive-debt policy that document defines. Protocol: silently read
+the current sources (not the docs), ask 3–5
+prediction/invariant/design/debugging questions, require committed
+answers before revealing anything, then grade with evidence — live runs
+and `file:line` citations, never recall. Results append to a per-user
+ledger at `~/.kaappi/quiz-ledger.md`, kept outside the repo deliberately
+(survives worktrees, stays private). Doc-vs-code drift and
+user-beats-code disagreements surface as findings to file or fix.
+
 ## Ecosystem Plugin (`kaappi-dev`)
 
 The `infra/` repo hosts a Claude Code plugin called `kaappi-dev` that provides

--- a/docs/dev/understanding-map.md
+++ b/docs/dev/understanding-map.md
@@ -30,7 +30,7 @@ and you re-serialize yourself as the bottleneck the tooling removed.
 
 ## The decision rule
 
-```
+```text
 understanding priority ≈ expected touches × boundary leakiness × centrality
 ```
 

--- a/docs/dev/understanding-map.md
+++ b/docs/dev/understanding-map.md
@@ -1,0 +1,250 @@
+# Understanding Map
+
+Where theory must live in a maintainer's head (**core tier**), and where a
+contract makes shallow understanding a deliberate, safe choice (**fenced
+tier**). This is the policy that turns "do I understand this codebase?"
+from a source of anxiety into a portfolio decision.
+
+## Why this exists
+
+Most of this codebase is written in AI-assisted sessions. Code is generated
+faster than a human forms a theory of it, and the gap is **cognitive
+debt**: code you are responsible for without holding its model. (Naur,
+*Programming as Theory Building*, 1985: the program is not the text — it is
+the theory in the programmers' heads, and the text is a lossy projection.
+AI-generated code is born without a theory-holder unless the human builds
+one alongside.)
+
+Not all of the gap needs paying down. We already run on oceans of code
+nobody here understands (LLVM, libc, the kernel) — safely, because someone
+else holds the theory and a contract fences the interface. Debt is only
+un-understood code **on our side of the responsibility boundary**. So every
+subsystem gets one of two legitimate treatments:
+
+1. **Hold the theory** — invest in a real mental model (core tier).
+2. **Build the fence** — put a contract (spec + tests) around it and
+   deliberately stay shallow (fenced tier).
+
+Trying to hold the theory of everything is also a failure mode: you drown,
+and you re-serialize yourself as the bottleneck the tooling removed.
+
+## The decision rule
+
+```
+understanding priority ≈ expected touches × boundary leakiness × centrality
+```
+
+- **Touches** — how often changes land there.
+- **Leakiness** — whether its obligations bind code *outside* it (the GC's
+  rooting rules bind every primitives file; a SRFI `.sld` binds nothing).
+- **Centrality** — how much else breaks when its invariants do.
+
+Pay down understanding where change is coming, not where anxiety is.
+
+## What each tier obligates
+
+|  | Core | Fenced |
+|--|------|--------|
+| Mental model | The theory: invariants, failure modes, design rationale | The contract: what it promises and how that's verified |
+| PR review | Slow; predict the approach before reading the diff | Contract-first: does the fence (tests) still hold? |
+| `/quiz` | Quizzed periodically | Not quizzed — not knowing is the point |
+| AI sessions | End with a ≤3-line **theory delta** (what changed in the system's theory, not the repo) | Normal |
+
+## Core tier
+
+Seven subsystems. For each: where it lives, the theory to hold, and the
+bug history that earned it core status — the recurring bug classes *are*
+the leakiness measurement.
+
+### 1. Value representation & heap-object layout
+
+- **Where:** `src/types.zig`
+- **Theory:** the NaN-boxing scheme (which payloads are immediate and why
+  any non-NaN f64 is a flonum), fixnum range and bignum promotion, and the
+  heap-Value convention: a heap Value carries the address of the `header`
+  field — built with `makePointer(&x.header)`, recovered via
+  `Object.as()`, never a direct cast.
+- **Why core:** everything touches it, and layout mistakes corrupt
+  silently and surface far away. #1618 (Value built from a struct pointer
+  instead of its header) was fixed and then reified into a compile error
+  (the `*Object` parameter, PR #1622). s390x is kept in CI purely as the
+  byte-order canary for this layer (#1654).
+
+### 2. GC: rooting, write barrier, generations
+
+- **Where:** `src/memory.zig`, `src/gc_collect.zig`; rules in
+  `.claude/rules/gc-safety.md`
+- **Theory:** root-before-allocate, and why an unrooted fresh result dies
+  between two allocations (#1414: every bignum/bignum division returned 1
+  by aliasing); the write barrier's direction (old→young) and what a minor
+  collection misses without it; copy-before-collect ordering inside
+  allocators; why `vm_instance` is itself effectively a root (#1401);
+  ephemeron/guardian processing during collection (SRFI-254).
+- **Why core:** maximal leakiness — these rules bind every primitives file
+  and every VM file, permanently. The gc-stress campaign (#1401) and the
+  unrooted-desugar bug class exist because these obligations were held
+  shallowly.
+
+### 3. IR pipeline & the register/frame contract
+
+- **Where:** `src/ir.zig`, `src/compiler_ir.zig`, `src/compiler.zig`
+- **Theory:** the lowering shape (structured nodes vs. `sexpr_form`
+  passthrough), what the 3 analysis passes establish (tail positions above
+  all), what the 5 optimization passes are allowed to assume, and the
+  contract emitted bytecode relies on from the VM: register file, frames,
+  gap registers.
+- **Why core:** every new form passes through it, and tail-position
+  mistakes are semantic bugs, not slowdowns. The gap-register capture
+  class (#1464, fixed by PR #1528 + `clearGapRegisters` #1529) came from
+  holding the register contract shallowly.
+
+### 4. Continuations & dynamic-wind
+
+- **Where:** `src/vm_continuations.zig`
+- **Theory:** stack-copying capture (what exactly is copied and when),
+  wind-stack transitions, the invariant that a callee's return never
+  unwinds the caller's winds, and the native-frame limit (a continuation
+  captured under a native frame cannot be resumed after that frame
+  returns).
+- **Why core:** it interacts with everything — errors, fibers, the native
+  backend — and wind bugs corrupt control flow in ways tests rarely catch
+  on first contact.
+
+### 5. Expander hygiene
+
+- **Where:** `src/expander.zig`, `src/compiler_macro.zig`
+- **Theory:** syntax-rules matching and template instantiation, free-ref
+  collection (`computeBoundFreeRefs`, PR #1344), why renaming is the hard
+  part, and where the current model's edges are.
+- **Why core:** the one subsystem where bugs proved effectively unbounded —
+  SRFI-257 was dropped (#1644) because each expander fix uncovered more.
+  Judging which macro bugs are fixable vs. structural requires a real
+  model, not pattern-matching on past fixes.
+
+### 6. Fibers & the I/O reactor (KEP-0001)
+
+- **Where:** `src/fiber.zig`, `src/reactor.zig`, `src/primitives_fiber.zig`
+- **Theory:** park vs. drive-in-place (who is allowed to block and when),
+  the yield-retry re-execution protocol and why partial progress must be
+  stashed in `port.read_buf` first, the `driving_waits` abandonment rule
+  (#1625), the lazy `O_NONBLOCK` flip as a capability probe, and the
+  per-platform readiness models (kqueue / epoll / WASI `poll_oneoff` /
+  `WSAEventSelect`).
+- **Why core:** a distributed protocol across the scheduler, the reactor,
+  and every port primitive; its failure mode is a hang — the least
+  debuggable symptom there is. Even *stating* #1625's "port I/O abandoned"
+  rule required holding the whole protocol at once.
+
+### 7. Cross-thread ownership (SRFI-18)
+
+- **Where:** `src/primitives_srfi18.zig`, deep copy in `src/memory.zig` /
+  `src/gc_deep_copy.zig`
+- **Theory:** per-thread VM+GC with deep copy at the boundaries (start and
+  join) and why no heap value may cross otherwise; `Object.owner` and why
+  a child's marking must skip parent-owned objects (#958); foreign-owner
+  checks on fiber/channel primitives (#1484); the symbol-interning lock.
+- **Why core:** violations are use-after-free across heaps — the
+  worst-case debugging experience. The cross-thread named-helper hang
+  (#1520) showed this model must be held, not rediscovered per incident.
+
+## Fenced tier
+
+| Area | The fence | Notes |
+|------|-----------|-------|
+| 68 portable SRFI `.sld`s | The SRFI documents (external spec) + `tests/scheme/srfi/` conformance suites | The ideal fence: a spec someone else wrote, mechanically checked |
+| Primitive bodies (`src/primitives_*.zig`) | R7RS spec + audit suites (`tests/scheme/audit/`) + procedure coverage | The GC rules *inside* them stay core — see below |
+| LLVM emitter mechanics (`src/llvm_emit.zig`) | Differential fence: native output must agree with the interpreter (parity tests) | The *strategy* layer is borderline — see below |
+| Platform ports (`src/platform*.zig`) | The `platform.zig` facade + real-VM CI jobs per OS/arch | Per-OS theory lives in `docs/dev/<os>.md` |
+| `.sbc` bytecode codec (`src/bytecode_file*.zig`) | Format contract + build-id cache keys (#1516) + round-trip | Build-id keys retired the stale-cache footgun class outright |
+| `kaappi fmt` layout engine (`src/fmt_print.zig`) | Real-reader `equal?` round-trip: a formatter bug cannot change a program | A fence so strong even its author needn't trust the layout code |
+| thottam (`src/thottam.zig`) | CLI contract + end-to-end install flows; blast radius contained to `~/.kaappi` | |
+| Reader lexical syntax (`src/reader*.zig`) | R7RS §7.1 formal grammar + compliance tests | Borderline — see below |
+| Bignum arithmetic (`src/bignum.zig`) | Audit tests against mathematical ground truth | #1414 lived here, but it was a GC-rule violation, not an arithmetic one |
+| Vendored + generated (`vendor/linenoise/`, `src/unicode_tables.zig`) | Upstream project / the generator | Never hand-edit |
+
+Anything unlisted defaults to fenced-if-tested. Being repeatedly surprised
+by an unlisted area is evidence for promotion — change this map in the
+same PR.
+
+## Core rules run through fenced code
+
+Fencing a *file* does not fence the cross-cutting rules that run through
+it. The GC discipline (rooting, barriers, copy-before-collect) is core
+even inside individually-fenced `primitives_*.zig` bodies — #1414 was a
+GC-rule violation inside fenced bignum code. When a core rule and a fenced
+file intersect, the rule sets the review depth.
+
+## Fence integrity
+
+A fence is only as strong as its enforcement:
+
+- **Weakening or skipping tests silently promotes code to core.** A
+  disabled conformance suite means someone must now hold that theory — and
+  nobody decided to.
+- **Edit fenced code contract-first**: write the failing test (the
+  contract's missing clause), then change the code. Editing fenced code
+  from "understanding" nobody holds, without strengthening the fence, is
+  how debt compounds.
+- **Tier changes are explicit.** Promote when a bug class recurs or
+  obligations start leaking past the fence; demote when a machine-checked
+  contract lands (see the ladder). Either way, edit this file in the same
+  PR.
+
+## The reification ladder
+
+Every hard-won piece of theory should climb as high as it can:
+
+| Rung | Form | Examples in this repo |
+|------|------|-----------------------|
+| 1. Tacit | In a head | Where all theory starts — and all debt |
+| 2. Documented | Postmortems, `docs/dev/` | `gc-safety-and-error-handling.md`, `lessons-learned.md` |
+| 3. Checklisted | Auto-loaded rules | `.claude/rules/gc-safety.md`, `compiler-forms.md` |
+| 4. Machine-checked | Compile errors, stress builds, differential tests | The `*Object` param (#1618→#1622), `-Dgc-stress`, fmt's `equal?` round-trip, native/interpreter parity tests, build-id cache keys (#1516), the `(features)`-vs-table equality check (#1517) |
+
+Rungs 2–3 are still consumed by trust; rung 4 no longer needs to be held
+by anyone. **Every postmortem should end by asking: which rung did this
+lesson reach, and can it go one higher?**
+
+## Practices
+
+The map is the *what*; these are the *how*. All four are prediction-first,
+because understanding is built by generating answers, not by reading them.
+
+1. **`/quiz <subsystem>`** — periodic prediction-with-commitment quiz on a
+   core-tier subsystem, graded against the code and live runs, logged to
+   `~/.kaappi/quiz-ledger.md`. The ledger is comprehension coverage.
+2. **PR prediction line** — before reading an AI-authored diff that
+   touches core tier, write one sentence: how do you think it solved it?
+   The delta between guess and diff is the signal.
+3. **Theory delta** — an AI session that touched core-tier files ends with
+   ≤3 lines on what changed in the *system's theory* (new invariant,
+   changed contract, retired assumption) — distinct from the changelog.
+4. **Per-release retrieval note** — once per release, pick one core
+   subsystem and write its theory from memory, ten lines, no peeking; then
+   diff against `docs/dev/` and fix whichever side is wrong.
+
+## Borderline calls
+
+Classifications the maintainer should adjudicate (initial lean in
+parentheses):
+
+- **LLVM backend strategy** — the what-compiles-natively line, the boxing
+  rule (#1497), the tailcc trampoline (#1499): core-adjacent theory even
+  though emitter mechanics stay fenced by parity. (Lean: split exactly
+  there — strategy core, mechanics fenced.)
+- **Reader** — spec'd and conformance-tested like a fenced area, but
+  hygiene's raw material (datum identity) originates here. (Lean: fenced;
+  revisit if reader bugs ever leak into the expander.)
+- **VM debugger (`src/vm_debug.zig`)** — low centrality, self-contained.
+  (Lean: fenced.)
+- **Bytecode ISA** — the opcode set vs. the dispatch loop. (Lean: the ISA
+  contract is core-lite via `bytecode.md` + `/bytecode-isa`; the dispatch
+  loop is fenced by the Scheme suites.)
+
+## Status
+
+Drafted 2026-07-19 by Claude (Opus 4.8) as part of the cognitive-debt
+work; awaiting the maintainer's correction pass. Corrections to this map
+are themselves retrieval practice — a wrong tier here is a bug, and the
+map only becomes authoritative once a human has disagreed with it at
+least once.


### PR DESCRIPTION
## Why

AI-assisted development generates code faster than a human forms a theory of it (Naur: the program *is* the theory; the text is a lossy projection). The existing harness — CLAUDE.md, path-scoped rules, session memory — solves the **machine** side of that gap: every session cold-starts into full context. Nothing maintained the **human** side. This PR adds the policy and the practice for it.

## What

- **`docs/dev/understanding-map.md`** — classifies subsystems into:
  - **Core tier** (maintainer holds the theory): values/heap layout, GC, IR + register/frame contract, continuations/dynamic-wind, expander hygiene, fibers/reactor, cross-thread ownership. Each entry names the theory to hold and the bug history that earned the tier (#1618, #1414/#1401, #1464, #1644, #1625, #958/#1520 …).
  - **Fenced tier** (contract + tests make shallow understanding a deliberate choice): portable SRFI `.sld`s, primitive bodies, LLVM emitter mechanics (parity fence), platform ports, `.sbc` codec, `fmt` layout engine, etc.
  - Plus: the decision rule (touches × leakiness × centrality), per-tier obligations, fence-integrity rules ("skipping tests silently promotes code to core"), and the reification ladder (tacit → documented → checklisted → machine-checked).
- **`.claude/skills/quiz/`** — `/quiz <subsystem>`: prediction-with-commitment comprehension quiz on a core-tier subsystem. Questions come from the current code; answers are committed before any reveal; grading is by demonstration (live runs, `file:line` citations — never recall); results append to a per-user ledger at `~/.kaappi/quiz-ledger.md` (outside the repo: survives worktrees, stays private). Doc-vs-code drift surfaces as findings.
- **Index wiring** — CLAUDE.md skills table, `claude-code-harness.md`, `docs/dev/README.md` (Policy section). In passing, adds the missing `/parallel-issues` entries to both skill tables.

## Review notes

The map's **Borderline calls** section (LLVM strategy split, reader, vm_debug, bytecode ISA) lists classifications awaiting the maintainer's adjudication, each with a stated lean — this PR review is a fine place to overrule them. Per the map's own status note, it becomes authoritative once a human has disagreed with it at least once.

No `.zig` changes; docs and harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)