### PR TITLE
Harden fiber timed-mutex regression test against QEMU flake

### DIFF
--- a/tests/scheme/smoke/fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm
+++ b/tests/scheme/smoke/fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm
@@ -7,6 +7,18 @@
 ;; check: a 0.05s timeout fired only once the sibling finished (~0.74s in
 ;; the reviewer's repro) instead of at ~0.05s. schedule() now pops expired
 ;; reactor timers on every dispatch tick, not just when idle.
+;;
+;; The regression signal is an ORDERING, not an absolute duration: with the
+;; fix the timed lock resolves early in the sibling's run; without it, only
+;; once the sibling has finished. So the sibling timestamps its own
+;; completion, and the test asserts the timed lock resolved BEFORE that.
+;; Both samples come from one clock, so a slow/loaded QEMU VM (the netbsd CI
+;; runner) stretches them together and cannot invert their order — whereas
+;; the earlier absolute "< 0.3s" bound flaked there whenever a host
+;; deschedule near the 0.05s expiry pushed the single sample past 0.3s.
+;; (Widening that bound is not an option: the broken build resolves at
+;; ~0.7s, so any absolute bound loose enough to never flake would also let
+;; a genuinely-broken build pass.)
 
 (import (scheme base) (scheme write) (kaappi fibers) (srfi 18))
 
@@ -28,33 +40,66 @@
 
 (define (now) (time->seconds (current-time)))
 
+(define timeout 0.05)
+
 (define m (make-mutex))
 (mutex-lock! m)
 
+;; Single shared origin so the waiter's and sibling's elapsed samples are
+;; directly comparable.
+(define t0 (now))
+
 (define waiter
   (spawn (lambda ()
-           (let ((t0 (now)))
-             (let ((r (mutex-lock! m 0.05)))
-               (list r (- (now) t0)))))))
+           (let ((r (mutex-lock! m timeout)))
+             (list r (- (now) t0))))))
 
 ;; Busy sibling: yields repeatedly without ever parking, so the scheduler's
 ;; dispatch loop stays busy (never reaches the idle/parkOnReactor branch)
-;; for well over the waiter's 0.05s timeout.
+;; for well over the waiter's timeout. It timestamps its own completion so
+;; the test can compare the two fibers on one clock.
 (define busy
   (spawn (lambda ()
            (let loop ((i 0))
              (if (< i 8000000)
                  (begin (yield) (loop (+ i 1)))
-                 'done)))))
+                 (- (now) t0))))))
 
 (define result (fiber-join waiter))
+(define busy-elapsed (fiber-join busy))
+(define wait-elapsed (cadr result))
 
 (check "lock-timed-out" (car result) #f)
-;; Generous bound: must resolve well before the busy sibling's ~0.7s+
-;; runtime, not merely finish eventually.
-(check "resolved-near-timeout-not-after-sibling" (< (cadr result) 0.3) #t)
 
-(fiber-join busy)
+;; Premise: the busy sibling must genuinely outlast the timeout by a wide
+;; margin, otherwise "resolved before the sibling finished" proves little.
+;; This can only fail if the sibling ran too FAST (needs more iterations) —
+;; emulation slowdown makes busy-elapsed larger, never smaller.
+(if (> busy-elapsed (* timeout 4))
+    (set! pass (+ pass 1))
+    (begin
+      (set! fail (+ fail 1))
+      (display "FAIL: busy-sibling-outlasts-timeout busy-elapsed=")
+      (write busy-elapsed)
+      (display " (expected > ")
+      (write (* timeout 4))
+      (display "; bump the iteration count)")
+      (newline)))
+
+;; The regression signal: the timed lock must resolve BEFORE the busy
+;; sibling completes, not only once it has finished. With the fix
+;; wait-elapsed is sampled (~timeout) well before busy-elapsed (~0.7s+);
+;; without it, the lock resolves at busy-finish+e so this inverts.
+(if (< wait-elapsed busy-elapsed)
+    (set! pass (+ pass 1))
+    (begin
+      (set! fail (+ fail 1))
+      (display "FAIL: resolved-before-sibling-finished wait-elapsed=")
+      (write wait-elapsed)
+      (display " busy-elapsed=")
+      (write busy-elapsed)
+      (display " (timed lock did not resolve before the busy sibling finished)")
+      (newline)))
 
 ;; Summary
 (display pass)


### PR DESCRIPTION
## Problem

The `netbsd-test` CI job (a cross-compiled `x86_64-netbsd` binary in a resource-constrained QEMU VM) intermittently fails `tests/scheme/smoke/fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm` — the KEP-0001 Phase 2 / #1440 regression test. Example: PR #1663 CI, run 29680545987, assertion `resolved-near-timeout-not-after-sibling got=#f expected=#t`. It passes on every other platform in the same run and flakes intermittently on `main` too.

The old assertion is an **absolute wall-clock bound on a single sample**:

```scheme
(check "resolved-near-timeout-not-after-sibling" (< (cadr result) 0.3) #t)
```

When the host briefly deschedules the whole QEMU VM near the 0.05s timer expiry, the host-backed clock advances and that single sample balloons past 0.3s — even though the fix is present and working. This is the same class of QEMU wall-clock-gate flake already documented for the riscv64 fuzz job.

## Why not just widen the bound

The broken build resolves the timeout only once the busy sibling finishes (~0.7s). Any absolute bound loose enough to never flake under emulation (say `< 2.0`) would also let a **genuinely broken build pass** — it would delete the regression signal. So the magnitude sensitivity can't simply be relaxed.

## Fix

Assert the **ordering** the regression is actually about — *the timed lock resolves before the busy sibling completes* — instead of an absolute magnitude. The busy sibling now timestamps its own completion, both fibers share one `t0`, and the test checks `wait-elapsed < busy-elapsed`.

This is provably robust under emulation: with the fix the waiter records its time (~0.05s) **before** the sibling records its (~0.7s+), so any host deschedule or GC pause that inflates `wait-elapsed` necessarily happened before the sibling finished and inflates `busy-elapsed` by the same amount — the order can't invert. A slow/loaded VM stretches both samples together. A premise check (`busy-elapsed > timeout * 4`) keeps the sibling comfortably outlasting the timeout, and both timing checks print the measured values on failure instead of the undebuggable bare boolean.

The mutex-held / timed-waiter / busy-yielding-sibling structure that exercises the scheduler path (`schedule()` popping expired reactor timers on every dispatch tick, not only when idle) is unchanged — only the assertion form changed.

## Verification

- **Fixed build, native macOS:** 10/10 pass; 15/15 under saturated CPU load (24 hogs / 12 cores) — busy stretched 0.7s→2.1s while `wait-elapsed` held ~0.050s, so the margin *grew*.
- **Regression still caught:** temporarily neutered the per-tick timer pop in `runReactorTick` (`src/fiber.zig`) → test fails with `wait-elapsed=0.7594 busy-elapsed=0.7594` (waiter resolves ~40µs *after* the sibling), exactly the pre-#1440 behavior. Reverted byte-identical; the diff is the one `.scm` file.
- All 25 fiber/mutex smoke tests pass; full `zig build test` unit suite green.

The flake itself only reproduces on CI's oversubscribed QEMU VM — a healthy box has a crisp clock — and the test is platform-agnostic Scheme, so the definitive confirmation is the `netbsd-test` job staying green across repeated runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)