### PR TITLE
Add CI guard that fails on non-final SRFIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,23 @@ jobs:
       - name: Build
         run: zig build -Doptimize=${{ matrix.optimize }}
 
+      # Kaappi ships only final SRFIs. Fail if the binary reports a SRFI whose
+      # status in the canonical registry is draft/withdrawn. Runs once (needs a
+      # binary; the enumeration comes from `kaappi features --json`). Exit 77 =
+      # SKIP (registry unreachable) so a network blip never reds the leg.
+      - name: SRFI final-status guard
+        if: matrix.os == 'ubuntu-latest' && matrix.optimize == 'ReleaseSafe'
+        run: |
+          set +e
+          bash tools/check-srfi-status.sh zig-out/bin/kaappi
+          code=$?
+          set -e
+          if [ "$code" -eq 77 ]; then
+            echo "::warning::SRFI final-status check skipped (registry unreachable)"
+            exit 0
+          fi
+          exit "$code"
+
       - name: Unit tests (leak detection via std.testing.allocator)
         run: zig build test -Doptimize=${{ matrix.optimize }}
 

--- a/docs/dev/features.md
+++ b/docs/dev/features.md
@@ -101,5 +101,8 @@ a `Lib` tag or a `.sld` file is enough.
   `cond-expand` identifiers for Scheme authors; it links here for the CLI view.
 - [observing-the-pipeline.md](observing-the-pipeline.md) — the `ast`/`expand`/`ir`
   read-only dumps, the other "understand the build" introspection commands.
+- [srfi-status-check.md](srfi-status-check.md) — the CI guard that reads
+  `srfis.builtin`/`srfis.portable` from `features --json` and fails if any
+  implemented SRFI is not `final` in the canonical registry.
 - [check.md](check.md), [test-runner.md](test-runner.md) — sibling
   machine-legibility subcommands.

--- a/docs/dev/srfi-status-check.md
+++ b/docs/dev/srfi-status-check.md
@@ -1,0 +1,58 @@
+# SRFI final-status guard
+
+Kaappi ships only SRFIs that have reached **final** status. This guard fails CI
+if the binary reports a SRFI whose status in the canonical registry is `draft`
+or `withdrawn` — catching an accidental `lib/srfi/<n>.sld` for a not-yet-final
+(or later-withdrawn) SRFI before it ships.
+
+## Running it
+
+```
+zig build                              # produce zig-out/bin/kaappi
+bash tools/check-srfi-status.sh        # checks zig-out/bin/kaappi by default
+bash tools/check-srfi-status.sh path/to/kaappi   # or a specific binary
+```
+
+Output is one `FAIL:` line per offender, or `OK: all N implemented SRFIs are
+final.`
+
+## How it works
+
+Two inputs, cross-referenced:
+
+1. **What we implement** — `kaappi features --json` (`srfis.builtin` +
+   `srfis.portable`), the derived source of truth described in
+   [features.md](features.md), plus SRFI 261 (a resolver-level naming
+   convention with no `.sld` file). Because the enumeration comes from the
+   binary, adding a portable `.sld` or a built-in `Lib` tag brings the new SRFI
+   under the check automatically — there is no second list to maintain.
+
+2. **Each SRFI's status** — [`admin/srfi-data.scm`][data] from the `srfi-common`
+   repository, the same data <https://srfi.schemers.org> renders. It is fetched
+   at check time (not vendored) so a *newly added* SRFI is validated against its
+   real, current status rather than a snapshot that a contributor could get
+   wrong.
+
+[data]: https://github.com/scheme-requests-for-implementation/srfi-common/blob/master/admin/srfi-data.scm
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Every implemented SRFI is final. |
+| `1`  | An implemented SRFI is non-final, or is absent from the registry. |
+| `77` | SKIP — no usable binary, or the registry could not be fetched. |
+
+`77` is the automake SKIP convention the shell suites already use. In CI the
+step maps `77` to a warning (`::warning::`) and passes, so a transient network
+failure fetching the registry never reds an unrelated change. A real non-final
+SRFI still exits `1` and fails the job.
+
+## In CI
+
+Wired into the `test` job in
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml), gated to a single
+matrix leg (`ubuntu-latest`, `ReleaseSafe`) so it runs once against that leg's
+already-built binary. It is intentionally **not** part of
+`tests/scheme/run-all.sh` — that runner executes in every matrix leg, and this
+check makes a network request.

--- a/tools/check-srfi-status.sh
+++ b/tools/check-srfi-status.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# check-srfi-status.sh — fail if Kaappi ships any SRFI that is not yet "final"
+# in the canonical SRFI registry.
+#
+# The set of implemented SRFIs comes from `kaappi features --json` — the derived
+# source of truth (built-in Zig SRFIs + the portable lib/srfi/*.sld files, see
+# docs/dev/features.md) — plus SRFI 261, a resolver-level naming convention with
+# no .sld file. Each number's status is checked against admin/srfi-data.scm from
+# the srfi-common repository, which is what https://srfi.schemers.org is built
+# from.
+#
+# Exit codes:
+#   0   all implemented SRFIs are final
+#   1   an implemented SRFI is non-final (draft/withdrawn) or absent from the
+#       registry — the failure this guard exists to catch
+#   77  SKIP (no usable kaappi binary, or the registry could not be fetched);
+#       the automake SKIP convention the rest of the suite uses. CI treats it as
+#       a warning so a network blip never reds an unrelated change.
+#
+# Usage: bash tools/check-srfi-status.sh [path-to-kaappi]
+#        KAAPPI=/path/to/kaappi bash tools/check-srfi-status.sh
+
+set -uo pipefail
+
+KAAPPI="${1:-${KAAPPI:-zig-out/bin/kaappi}}"
+DATA_URL="https://raw.githubusercontent.com/scheme-requests-for-implementation/srfi-common/master/admin/srfi-data.scm"
+
+if [ ! -x "$KAAPPI" ]; then
+    echo "SKIP: no kaappi binary at '$KAAPPI' (build it, or pass the path as \$1)"
+    exit 77
+fi
+
+# 1. Implemented SRFI numbers, straight from the binary's own registry. The
+#    builtin/portable values are flat integer arrays; flatten newlines first so
+#    the array regex matches whether or not the JSON is pretty-printed. SRFI 261
+#    has no .sld file (it is a resolver convention), so add it explicitly.
+json="$("$KAAPPI" features --json | tr '\n' ' ')" || {
+    echo "FAIL: 'kaappi features --json' failed"
+    exit 1
+}
+implemented="$(
+    {
+        printf '%s\n' "$json" |
+            grep -oE '"builtin"[[:space:]]*:[[:space:]]*\[[^]]*\]' | grep -oE '[0-9]+'
+        printf '%s\n' "$json" |
+            grep -oE '"portable"[[:space:]]*:[[:space:]]*\[[^]]*\]' | grep -oE '[0-9]+'
+        echo 261
+    } | sort -un
+)"
+if [ -z "$implemented" ]; then
+    echo "FAIL: could not extract SRFI numbers from 'kaappi features --json'"
+    exit 1
+fi
+
+# 2. Fetch the canonical registry (retry; soft-skip on hard network failure).
+data="$(mktemp)"
+trap 'rm -f "$data"' EXIT
+fetched=
+for attempt in 1 2 3; do
+    if curl -fsSL --max-time 30 "$DATA_URL" -o "$data" && [ -s "$data" ]; then
+        fetched=1
+        break
+    fi
+    sleep $((attempt * 2))
+done
+if [ -z "$fetched" ]; then
+    echo "SKIP: could not fetch srfi-data.scm from $DATA_URL"
+    exit 77
+fi
+
+# 3. Extract "<number> <status>" pairs. Each registry entry is an alist whose
+#    (number N) line precedes its (status X) line, e.g.
+#      ((number 1)
+#       (status final)
+#       (title "List Library") ...)
+statuses="$(
+    awk '
+      /^\(\(number [0-9]+\)/ {
+        num = $0; sub(/^\(\(number /, "", num); sub(/\).*/, "", num); have = 1
+      }
+      have && /^[[:space:]]*\(status [a-z-]+\)/ {
+        st = $0; sub(/^[[:space:]]*\(status /, "", st); sub(/\).*/, "", st)
+        print num, st; have = 0
+      }
+    ' "$data"
+)"
+if [ -z "$statuses" ]; then
+    echo "FAIL: could not parse any entries from srfi-data.scm"
+    exit 1
+fi
+
+# 4. Cross-reference: every implemented SRFI must be present and final.
+offenders=0
+count=0
+while IFS= read -r n; do
+    [ -n "$n" ] || continue
+    count=$((count + 1))
+    st="$(awk -v n="$n" '$1 == n { print $2; exit }' <<< "$statuses")"
+    if [ -z "$st" ]; then
+        echo "FAIL: SRFI $n is implemented but absent from srfi-data.scm"
+        offenders=$((offenders + 1))
+    elif [ "$st" != "final" ]; then
+        echo "FAIL: SRFI $n is implemented but its status is '$st' (expected 'final')"
+        offenders=$((offenders + 1))
+    fi
+done <<< "$implemented"
+
+if [ "$offenders" -ne 0 ]; then
+    echo
+    echo "$offenders non-final SRFI(s) implemented — Kaappi ships only final SRFIs."
+    echo "See https://srfi.schemers.org/?statuses=final for the authoritative list."
+    exit 1
+fi
+
+echo "OK: all $count implemented SRFIs are final."
+exit 0


### PR DESCRIPTION
## What

Adds a CI guard that fails if Kaappi ships any SRFI whose status in the canonical registry is **not `final`** (i.e. `draft` or `withdrawn`).

Prompted by an audit of the current SRFI implementations against <https://srfi.schemers.org/?statuses=final> — all **78** implemented SRFIs are final today, and this keeps it that way.

## How

`tools/check-srfi-status.sh` cross-references two *derived* sources, so there's no second list to maintain:

1. **What we implement** — `kaappi features --json` (`srfis.builtin` + `srfis.portable`, the source of truth from [features.md](docs/dev/features.md)), plus SRFI 261 (a resolver naming convention with no `.sld`). Add a `.sld` or a built-in `Lib` tag and the new SRFI is covered automatically.
2. **Each SRFI's status** — [`admin/srfi-data.scm`](https://github.com/scheme-requests-for-implementation/srfi-common/blob/master/admin/srfi-data.scm) from `srfi-common`, the same data the SRFI site renders. **Fetched, not vendored**, so a newly added SRFI is validated against its real current status rather than a snapshot a contributor could mismark.

Wired into the `test` job on a single matrix leg (`ubuntu-latest` / `ReleaseSafe`), reusing that leg's already-built binary. Intentionally **not** in `run-all.sh` (that runs in every leg and this makes a network request).

## Exit codes / flake-resistance

| Code | Meaning | In CI |
|------|---------|-------|
| `0` | all implemented SRFIs final | pass |
| `1` | a non-final (or unknown) SRFI is implemented | **fail** |
| `77` | SKIP — registry unreachable / no binary | `::warning::`, pass |

Exit 77 maps to a warning so a transient network failure never reds an unrelated change; a genuine non-final SRFI still exits 1.

## Testing

- `bash tools/check-srfi-status.sh` → `OK: all 78 implemented SRFIs are final.`
- Fault injection via a fake `features` output confirms it flags `withdrawn`, `draft`, and absent-from-registry SRFIs, and does **not** mistake `limits` integers (e.g. `480`) for SRFI numbers.
- No-binary and unreachable-registry paths both return `77`.
- `shellcheck` clean; `ci.yml` parses.

Run it locally:
```
zig build && bash tools/check-srfi-status.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)