### PR TITLE
Root heap locals in prettyPrint tests against gc-stress sweeps

### DIFF
--- a/src/printer.zig
+++ b/src/printer.zig
@@ -1175,7 +1175,11 @@ test "prettyPrint body form indentation" {
     var plus_args: [11]Value = undefined;
     plus_args[0] = plus_sym;
     for (plus_args[1..], 0..) |*slot, i| slot.* = body_items[i];
-    const body = try gc.makeList(&plus_args);
+    var body = try gc.makeList(&plus_args);
+    // Root across the allocations below — unrooted locals are swept under
+    // -Dgc-stress=true (#1682).
+    gc.pushRoot(&body);
+    defer gc.popRoot();
 
     const define_sym = try gc.allocSymbol("define");
     const name_sym = try gc.allocSymbol("name");
@@ -1196,7 +1200,11 @@ test "prettyPrint clause form indentation" {
     // (cond (#t 1) (#f 2))
     const cond_sym = try gc.allocSymbol("cond");
     const clause1_items = [_]Value{ types.TRUE, types.makeFixnum(1) };
-    const clause1 = try gc.makeList(&clause1_items);
+    var clause1 = try gc.makeList(&clause1_items);
+    // clause1 must stay rooted while the next makeList allocates: under
+    // -Dgc-stress=true that collection sweeps unrooted locals (#1682).
+    gc.pushRoot(&clause1);
+    defer gc.popRoot();
     const clause2_items = [_]Value{ types.FALSE, types.makeFixnum(2) };
     const clause2 = try gc.makeList(&clause2_items);
     const cond_items = [_]Value{ cond_sym, clause1, clause2 };
@@ -1204,5 +1212,5 @@ test "prettyPrint clause form indentation" {
 
     const s = try prettyPrint(std.testing.allocator, form, 15);
     defer std.testing.allocator.free(s);
-    try std.testing.expect(std.mem.startsWith(u8, s, "(cond\n"));
+    try std.testing.expectEqualStrings("(cond\n  (#t 1)\n  (#f 2))", s);
 }


### PR DESCRIPTION
Fixes #1682 — the artifact-less fuzz failure in [run 29720271494](https://github.com/kaappi/kaappi/actions/runs/29720271494) was a real unit-test crash in the gc-stress variant, not infrastructure.

## Root cause

`test "prettyPrint clause form indentation"` (src/printer.zig) builds `(cond (#t 1) (#f 2))` and held `clause1` in an unrooted Zig local while the next `makeList` call allocated. Under `-Dgc-stress=true` every allocation collects, so that collection swept `clause1`'s pairs. The final `makeList(&cond_items)` then slice-rooted the dangling value, and `markValueInner` segfaulted reading the freed header — reproduced locally with a stack identical to the CI trace (`makeList → allocPair → collect → markRoots`).

## Why twelve prior scheduled runs passed

The use-after-free is usually **silent**: the freed `Pair` slot is normally reused by the very next same-size allocation, so the dangling `clause1` ends up aliasing `clause2` and the test prints `(cond (#f 2) (#f 2))` — which the old `startsWith(s, "(cond\n")` assertion happily accepted. Instrumented run showing the aliasing (clause2 reusing clause1's freed address):

```
DIAG clause1 obj @ 0x105aa0020
DIAG freeing pair @ 0x105aa0020
DIAG freeing pair @ 0x105aa0000
DIAG clause2 obj @ 0x105aa0020
DIAG clause-form output: [[(cond
  (#f 2)
  (#f 2))]]
```

Only when the freed slot is *not* reused does marking hit unmapped memory and segfault, which is what run #13 finally drew. This test predates the #1401 stress campaign (added in #1005), but that campaign could only catch crashing UAFs, not this silent mode.

## Fix

- Root `clause1` across the subsequent allocations (`gc.pushRoot`/`popRoot`), per the gc-safety rule that locals held across allocation calls must be rooted.
- Strengthen the assertion to an exact `expectEqualStrings("(cond\n  (#t 1)\n  (#f 2))")` — verified to fail under gc-stress without the rooting in **both** failure modes (content mismatch when the slot is reused, crash when it isn't), and to pass with it. This is the regression guard: the fuzz workflow's gc-stress variant runs this suite nightly.
- Also root `body` in the neighboring body-form test, which was safe only because `allocSymbol` never triggers a collection — too incidental a guarantee for a test to lean on.

## Verification

- `zig build test` — 1268/1268 pass (ReleaseSafe)
- `zig build test -Dgc-stress=true -Dtest-filter=prettyPrint` — 10/10 pass in both Debug and ReleaseSafe
- Rooting removed + new assertion → deterministic failure under gc-stress (mismatch), confirming the regression property

🤖 Generated with [Claude Code](https://claude.com/claude-code)