### PR TITLE
Root test locals held across never-collecting allocations (#1682 follow-up)

### DIFF
--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -927,7 +927,12 @@ test "bignum compare" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
-    const a = try parseBignumString(&gc, "99999999999999999999999999999999", 10);
+    // Root a across the second parse: it stays valid today only because
+    // parseBignumString builds its Bignum without maybeCollect, and this
+    // must not silently break if that path ever collects (#1682).
+    var a = try parseBignumString(&gc, "99999999999999999999999999999999", 10);
+    gc.pushRoot(&a);
+    defer gc.popRoot();
     const b = try parseBignumString(&gc, "99999999999999999999999999999998", 10);
     try std.testing.expectEqual(@as(i8, 1), compare(a, b));
     try std.testing.expectEqual(@as(i8, -1), compare(b, a));

--- a/src/tests_bytecode_cache.zig
+++ b/src/tests_bytecode_cache.zig
@@ -65,9 +65,18 @@ test "bytecode cache: deserialized top-level functions survive a mid-run GC" {
     defer vm.deinit();
 
     // Three independent top-level thunks, each returning a distinct fixnum —
-    // standing in for a program's sequence of top-level forms.
+    // standing in for a program's sequence of top-level forms. Root each
+    // across the next helper call: they stay valid today only because
+    // allocFunction happens never to collect, and this must not silently
+    // break if that changes (#1682).
     const f0 = try makeReturnConstFunc(&gc, 111);
+    var f0_root = types.makePointer(&f0.header);
+    gc.pushRoot(&f0_root);
+    defer gc.popRoot();
     const f1 = try makeReturnConstFunc(&gc, 222);
+    var f1_root = types.makePointer(&f1.header);
+    gc.pushRoot(&f1_root);
+    defer gc.popRoot();
     const f2 = try makeReturnConstFunc(&gc, 333);
 
     var funcs_arr = [_]*Function{ f0, f1, f2 };


### PR DESCRIPTION
## Summary

Follow-up to #1682 / #1685: an exhaustive audit of every unit-test file for the **silent** variant of that bug — an unrooted heap local swept under `-Dgc-stress=true`, then aliased by the next same-size allocation so shape-only assertions still pass.

**Result: zero live instances.** The #1401 campaign plus the rooting discipline in the newer test files (tests_shared_channel, tests_deepcopy, tests_srfi18, tests_robustness, tests_pipeline, tests_native, tests_port_io all carry explicit rooting with comments) already cover every collecting-call site. The remaining structural safety comes from: allocator arguments/slices being auto-rooted, interned symbols being immortal roots, compiled/deserialized top-level functions being pinned in `gc.extra_roots`, and cross-GC allocations never sweeping another heap.

Two suspects survived to the fix stage and both proved to be false positives worth documenting:

- tests_srfi254 guardian/transport-cell tests look like textbook hits but set `gc.enabled = false`, which fully gates `maybeCollect`.
- `"bignum compare"` holds `a` unrooted across a second `parseBignumString` — but that function builds its Bignum via raw `create`+`trackObject` and never calls `maybeCollect`. Confirmed empirically: the unmodified test passes under `-Doptimize=Debug -Dgc-stress=true`, where a genuinely swept local trips the 0xAA freed-object poison.

## Changes (test-only)

Both changed sites hold a heap value across an allocating call that merely *happens* never to collect — exactly the situation #1685 roots `body` for ("stayed safe only because allocSymbol happens never to collect"). Applied the same convention:

- `src/bignum.zig` — root `a` in `"bignum compare"` across the second `parseBignumString`.
- `src/tests_bytecode_cache.zig` — root `f0`/`f1` in the mid-run-GC survival test across the subsequent `makeReturnConstFunc` calls (interposed `allocFunction`).

The two printer.zig tests from the original report are deliberately untouched — open PR #1685 fixes those, and duplicating it here would conflict.

## Testing

- `zig build test` — 1268/1268 pass
- `zig build test -Dgc-stress=true -Dtest-filter=bignum -Dtest-filter=bytecode` — 66/66 pass
- `zig build test -Doptimize=Debug -Dgc-stress=true` filtered to the touched tests — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)