### PR TITLE
Fuzz report: file pre-fuzz unit-test failures per variant with the failing test names

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -528,38 +528,45 @@ jobs:
           oracle_marker=$(find artifacts -type f -name 'seed-*.kaappi.*' 2>/dev/null | sort | head -1 || true)
           oracle_dir=$(dirname "${oracle_marker:-artifacts/oracle-diff-divergences/absent}")
 
-          # The fuzz job routes three ways: crash marker → finding issue; no
-          # marker but a log whose test summary counts a failure ("N pass,
-          # M fail|crash|leak (T total)" step line or "N/M tests passed
-          # (K failed|crashed|leaked)" Build Summary line) → per-variant
-          # unit-test issue (#1688); anything else (no log at all, or a log
-          # without the signature: setup death, build failure, timeout) →
-          # the shared infrastructure issue.
+          # The fuzz job routes three ways: crash marker → finding issue; a
+          # log whose variant has no marker but whose test summary counts a
+          # failure ("N pass, M fail|crash|leak (T total)" step line or "N/M
+          # tests passed (K failed|crashed|leaked)" Build Summary line) →
+          # per-variant unit-test issue (#1688); anything else (no log at
+          # all, or a log without the signature: setup death, build failure,
+          # timeout) → the shared infrastructure issue. The buckets are not
+          # exclusive: both matrix variants can fail in the same run, and a
+          # crash in one variant must not swallow the other variant's
+          # independent failure, so every log is classified — only logs
+          # sitting next to a crash marker (that variant is the finding
+          # already filed) are skipped.
           if [ "$RESULT_FUZZ" = failure ]; then
             if [ -n "$crash" ]; then
               report_finding fuzz \
                 'Fuzz CI: bounded fuzzing found a crash' \
                 "$fuzz_dir" \
                 'A fuzz target found a crash. The encoded crashing input (a serialized Smith decision stream) is `.zig-cache/f/crash` inside the artifact; `fuzz-run.log` is the fuzzer transcript. Replay it per the runbook.'
-            else
-              fuzz_unexplained=""
-              fuzz_logs=$(find artifacts -type f -name 'fuzz-run.log' 2>/dev/null | sort || true)
-              if [ -z "$fuzz_logs" ]; then
-                fuzz_unexplained=1
-              else
-                # Both matrix variants can fail and upload a log each;
-                # classify every log independently.
-                while IFS= read -r flog; do
-                  if grep -qE '[0-9]+ pass, .*[0-9]+ (fail|crash|leak)|tests passed \([0-9]+ (failed|crashed|leaked)' "$flog"; then
-                    report_unit_test_failure "$flog"
-                  else
-                    fuzz_unexplained=1
-                    fuzz_dir=$(dirname "$flog") # infra excerpt shows this log
-                  fi
-                done <<< "$fuzz_logs"
-              fi
-              [ -z "$fuzz_unexplained" ] || infra_jobs="$infra_jobs fuzz"
             fi
+            fuzz_unexplained=""
+            fuzz_logs=$(find artifacts -type f -name 'fuzz-run.log' 2>/dev/null | sort || true)
+            if [ -z "$fuzz_logs" ]; then
+              # No log at all: setup death or job-level timeout — unless the
+              # crash marker already explains the job's failure.
+              [ -n "$crash" ] || fuzz_unexplained=1
+            else
+              while IFS= read -r flog; do
+                if [ -f "$(dirname "$flog")/.zig-cache/f/crash" ]; then
+                  continue # this variant IS the crash finding filed above
+                fi
+                if grep -qE '[0-9]+ pass, .*[0-9]+ (fail|crash|leak)|tests passed \([0-9]+ (failed|crashed|leaked)' "$flog"; then
+                  report_unit_test_failure "$flog"
+                else
+                  fuzz_unexplained=1
+                  fuzz_dir=$(dirname "$flog") # infra excerpt shows this log
+                fi
+              done <<< "$fuzz_logs"
+            fi
+            [ -z "$fuzz_unexplained" ] || infra_jobs="$infra_jobs fuzz"
           fi
 
           check_job "$RESULT_NATIVE" native-diff \

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -257,10 +257,13 @@ jobs:
   # To avoid false-positive finding issues, filing is gated on the finding
   # marker actually being present in the uploaded artifacts — the encoded
   # crash input for the fuzz job, per-seed divergence files for the diff
-  # jobs. Failed jobs without their marker (toolchain/apt flakes, build or
-  # unit-test failures, job-level timeouts — a possible hang) are collected
-  # under a single "Fuzz CI: infrastructure or build failure" issue instead
-  # of wearing a divergence title.
+  # jobs. A fuzz job that failed without its marker but whose log shows the
+  # pre-fuzz unit-test phase failing is filed per variant as "Fuzz CI:
+  # unit-test failure (<variant> variant)" with the failing test names
+  # extracted from the log (#1688). Remaining marker-less failures
+  # (toolchain/apt flakes, build failures, job-level timeouts — a possible
+  # hang) are collected under a single "Fuzz CI: infrastructure or build
+  # failure" issue instead of wearing a divergence title.
   #
   # This is a SEPARATE job so the write-capable token never coexists with
   # execution of fuzzer-generated programs — the three jobs above keep
@@ -322,9 +325,41 @@ jobs:
             --color B60205 \
             --description "Automated report from the scheduled Fuzz workflow"
 
+          # log_excerpt LOG OUT — append the failure section of a zig build
+          # transcript to OUT: a few lines of context plus everything from
+          # the first failure anchor onward, bounded, with the raw tail as
+          # the fallback when no anchor appears. Excerpting by position
+          # (tail -c) only captured the #1682 crash trace because it
+          # happened to sit at the end of the log; anchoring on the failure
+          # pattern survives longer logs.
+          log_excerpt() {
+            lg="$1"; lout="$2"
+            # Anchors: a test-failure report ("error: '<test name>' ..."), a
+            # compile diagnostic ("src/x.zig:1:2: error: ..."), or the Build
+            # Summary — whichever comes first.
+            anchor=$(grep -nE -m1 "error: '|: error: |Build Summary:" "$lg" | cut -d: -f1 || true)
+            if [ -z "$anchor" ]; then
+              tail -c 2000 "$lg" >> "$lout"
+              return 0
+            fi
+            # Start 3 lines early: the "N pass, M crash (T total)" step line
+            # sits just above the first error line.
+            start=$((anchor - 3)); [ "$start" -ge 1 ] || start=1
+            tail -n "+$start" "$lg" > log-section.tmp
+            size=$(wc -c < log-section.tmp)
+            if [ "$size" -le 6000 ]; then
+              cat log-section.tmp >> "$lout"
+            else
+              head -c 4000 log-section.tmp >> "$lout"
+              printf '\n[... %s bytes omitted ...]\n' "$((size - 5500))" >> "$lout"
+              tail -c 1500 log-section.tmp >> "$lout"
+            fi
+          }
+
           # excerpt DIR OUT — append a bounded artifact listing plus the first
-          # divergence (or the fuzzer transcript tail) to OUT. Artifacts stay the
-          # authoritative copy; this is only enough to eyeball the finding.
+          # divergence (or the fuzzer transcript's failure section) to OUT.
+          # Artifacts stay the authoritative copy; this is only enough to
+          # eyeball the finding.
           excerpt() {
             dir="$1"; out="$2"
             if [ ! -d "$dir" ]; then
@@ -348,8 +383,8 @@ jobs:
             fi
             log=$(find "$dir" -name 'fuzz-run.log' | head -1 || true)
             if [ -n "$log" ]; then
-              printf '\nTail of `fuzz-run.log`:\n\n```\n' >> "$out"
-              tail -c 2000 "$log" >> "$out"
+              printf '\nExcerpt of `fuzz-run.log`:\n\n```\n' >> "$out"
+              log_excerpt "$log" "$out"
               printf '\n```\n' >> "$out"
             fi
             printf '</details>\n' >> "$out"
@@ -402,11 +437,55 @@ jobs:
             file_or_append "$title" finding-preamble.md "$fbody"
           }
 
+          # report_unit_test_failure LOG — the fuzz job failed in its pre-fuzz
+          # unit-test phase: zig's test summary in LOG counts a failed/crashed
+          # test, and no fuzz crash marker exists. File it under a per-variant
+          # title with the failing test names pulled from LOG, so real test
+          # bugs and toolchain flakes stop appending to each other's threads
+          # and triage starts from the test name instead of guessing (#1688).
+          # The variant is read from the failed build command echoed at the
+          # end of the log — artifact directory names are unreliable (see the
+          # layout note below).
+          report_unit_test_failure() {
+            utlog="$1"
+            if grep -q -- '-Dgc-stress=true' "$utlog"; then
+              variant=gc-stress
+              hint='The unit-test phase of `zig build test --fuzz=… -Dgc-stress=true` reported a failed/crashed test; bounded fuzzing produced no crash marker. A test that fails only under gc-stress (collection attempted on every allocation) usually means a GC rooting bug — a heap value held in a Zig local across an allocation without rooting; see `.claude/rules/gc-safety.md`, #1401, #1682. Reproduce with `zig build test -Dgc-stress=true`.'
+            else
+              variant=default
+              hint='The unit-test phase of `zig build test --fuzz=…` reported a failed/crashed test on the default build; bounded fuzzing produced no crash marker. Plain `zig build test` is likely broken at this commit — expect regular CI to be red too.'
+            fi
+            utbody="body-unit-test-$variant.md"
+            body_start "fuzz ($variant variant)" "$hint" "$utbody"
+            # zig prints one "error: '<name>' failed:/terminated ..." line per
+            # failing test; panic-trace frames ("0x... in test.NAME (binary)")
+            # are the backup for truncated logs. Both normalize to test.<name>.
+            utnames=$(
+              { sed -n "s/^error: '\([^']*test\.[^']*\)'.*/\1/p" "$utlog"
+                grep -oE ' in [A-Za-z0-9_.]*test\.[^(]+' "$utlog" | sed 's/^ in //' || true; } \
+                | sed 's/.*test\./test./; s/[[:space:]]*$//' | sort -u | head -10
+            )
+            if [ -n "$utnames" ]; then
+              {
+                printf '**Failing/crashed test(s):**\n\n'
+                printf '%s\n' "$utnames" | sed 's/^/- `/; s/$/`/'
+                printf '\n'
+              } >> "$utbody"
+            fi
+            excerpt "$(dirname "$utlog")" "$utbody"
+            printf 'Automated report from the [Fuzz workflow](%s): the `%s`-variant fuzz job failed in its pre-fuzz unit-test phase — a unit test failed or crashed before bounded fuzzing was reached. This is a real test failure, not a fuzz finding; unlike toolchain or runner flakes it should reproduce locally.\n\n' \
+              "$run_url" "$variant" > unit-test-preamble.md
+            printf '> [!NOTE]\n> Close this issue once the failing test is fixed (or the failure is otherwise explained); until then, further unit-test failures of the same variant append comments here instead of opening new issues.\n\n' \
+              >> unit-test-preamble.md
+            file_or_append "Fuzz CI: unit-test failure ($variant variant)" unit-test-preamble.md "$utbody"
+          }
+
           infra_jobs=""
 
-          # check_job RESULT JOB TITLE MARKER DIR HINT — route a failed job to its
-          # finding issue when the finding marker is present, or collect it for the
-          # shared infrastructure issue when it is not.
+          # check_job RESULT JOB TITLE MARKER DIR HINT — route a failed diff job
+          # to its finding issue when the finding marker is present, or collect
+          # it for the shared infrastructure issue when it is not. (The fuzz job
+          # routes through its own three-way classifier below.)
           check_job() {
             result="$1"; job="$2"; title="$3"; marker="$4"; dir="$5"; hint="$6"
             [ "$result" = failure ] || return 0
@@ -421,8 +500,9 @@ jobs:
           # encoded crash input for the fuzz job, per-seed divergence files for
           # the diff jobs. A failed job without its marker is a toolchain/apt
           # flake, a build or unit-test failure, or a job-level timeout (a
-          # possible hang) — those are reported below under an honest title
-          # instead of a finding one.
+          # possible hang) — those are reported below under honest titles
+          # instead of finding ones: fuzz-job unit-test failures per variant
+          # (#1688), everything else under the shared infrastructure issue.
           #
           # Layout: download-artifact v8 normally extracts each artifact into
           # artifacts/<artifact-name>/, but when the run produced exactly ONE
@@ -448,10 +528,39 @@ jobs:
           oracle_marker=$(find artifacts -type f -name 'seed-*.kaappi.*' 2>/dev/null | sort | head -1 || true)
           oracle_dir=$(dirname "${oracle_marker:-artifacts/oracle-diff-divergences/absent}")
 
-          check_job "$RESULT_FUZZ" fuzz \
-            'Fuzz CI: bounded fuzzing found a crash' \
-            "$crash" "$fuzz_dir" \
-            'A fuzz target found a crash. The encoded crashing input (a serialized Smith decision stream) is `.zig-cache/f/crash` inside the artifact; `fuzz-run.log` is the fuzzer transcript. Replay it per the runbook.'
+          # The fuzz job routes three ways: crash marker → finding issue; no
+          # marker but a log whose test summary counts a failure ("N pass,
+          # M fail|crash|leak (T total)" step line or "N/M tests passed
+          # (K failed|crashed|leaked)" Build Summary line) → per-variant
+          # unit-test issue (#1688); anything else (no log at all, or a log
+          # without the signature: setup death, build failure, timeout) →
+          # the shared infrastructure issue.
+          if [ "$RESULT_FUZZ" = failure ]; then
+            if [ -n "$crash" ]; then
+              report_finding fuzz \
+                'Fuzz CI: bounded fuzzing found a crash' \
+                "$fuzz_dir" \
+                'A fuzz target found a crash. The encoded crashing input (a serialized Smith decision stream) is `.zig-cache/f/crash` inside the artifact; `fuzz-run.log` is the fuzzer transcript. Replay it per the runbook.'
+            else
+              fuzz_unexplained=""
+              fuzz_logs=$(find artifacts -type f -name 'fuzz-run.log' 2>/dev/null | sort || true)
+              if [ -z "$fuzz_logs" ]; then
+                fuzz_unexplained=1
+              else
+                # Both matrix variants can fail and upload a log each;
+                # classify every log independently.
+                while IFS= read -r flog; do
+                  if grep -qE '[0-9]+ pass, .*[0-9]+ (fail|crash|leak)|tests passed \([0-9]+ (failed|crashed|leaked)' "$flog"; then
+                    report_unit_test_failure "$flog"
+                  else
+                    fuzz_unexplained=1
+                    fuzz_dir=$(dirname "$flog") # infra excerpt shows this log
+                  fi
+                done <<< "$fuzz_logs"
+              fi
+              [ -z "$fuzz_unexplained" ] || infra_jobs="$infra_jobs fuzz"
+            fi
+          fi
 
           check_job "$RESULT_NATIVE" native-diff \
             'Fuzz CI: VM vs native backend divergence' \
@@ -464,12 +573,12 @@ jobs:
             'Kaappi and Chibi Scheme disagreed on a portable-subset program. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{kaappi,chibi}.{out,err}`; `oracle-version.txt` records the oracle version. Triage protocol (Kaappi bug / oracle bug / generator leak) is in the header of `tests/fuzz/oracle-diff.sh`. Replay: `bash tests/fuzz/oracle-diff.sh <count> <base>`.'
 
           if [ -n "$infra_jobs" ]; then
-            printf 'Automated report from the [Fuzz workflow](%s): a job failed WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM), a build or unit-test failure unrelated to fuzzing, or a job-level timeout. A timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious.\n\n' \
+            printf 'Automated report from the [Fuzz workflow](%s): a job failed WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM), a build failure, or a job-level timeout. (A fuzz-job unit-test failure is recognized from its log and filed separately as `Fuzz CI: unit-test failure (<variant> variant)`.) A timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious.\n\n' \
               "$run_url" > infra-preamble.md
             printf '> [!NOTE]\n> Close this issue once the failed run is explained (or the underlying breakage is fixed); further artifact-less failures append comments here.\n\n' \
               >> infra-preamble.md
             body_start "${infra_jobs# }" \
-              'The failed job(s) uploaded no finding artifact, so this is not (necessarily) a fuzz finding. Check the run log for a setup or build step failure, a unit-test failure, or a job cancelled at its timeout.' \
+              'The failed job(s) uploaded no finding artifact, so this is not (necessarily) a fuzz finding. Check the run log for a setup or build step failure, a test failure the classifier did not recognize, or a job cancelled at its timeout.' \
               body-infra.md
             case " $infra_jobs " in
               *' fuzz '*) excerpt "$fuzz_dir" body-infra.md ;;

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -154,6 +154,8 @@ phase failing (zig's `N pass, M fail|crash` test summary) is filed per
 variant as `Fuzz CI: unit-test failure (<variant> variant)` with the
 failing test names extracted from the log — under gc-stress that usually
 means a GC rooting bug (`.claude/rules/gc-safety.md`, #1401, #1682).
+Both matrix variants are classified independently: a crash in one
+variant does not swallow the other variant's failure.
 Remaining marker-less failures — toolchain flakes, build failures,
 job-level timeouts (a possible hang) — are collected under a single
 shared issue titled `Fuzz CI: infrastructure or build

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -143,13 +143,20 @@ on success, so crash state never leaks into the next run.
 fuzz pass, `native-diff`, or `oracle-diff`) is auto-filed as a GitHub
 issue by the trailing `report` job — one open issue per job, labeled
 `fuzz-finding`, containing the run link, a bounded artifact excerpt (the
-first divergent program plus both sides' output, or the fuzzer transcript
-tail), and replay instructions. A finding-titled issue is only filed when
-the finding marker is actually present in the uploaded artifacts (the
-encoded crash input for the fuzz job, per-seed divergence files for the
-diff jobs); failed jobs without their marker — toolchain flakes, build or
-unit-test failures, job-level timeouts (a possible hang) — are collected
-under a single shared issue titled `Fuzz CI: infrastructure or build
+first divergent program plus both sides' output, or the failure section
+of the run log, pattern-anchored on the first `error:`/Build Summary line
+rather than the raw tail — #1688), and replay instructions. A
+finding-titled issue is only filed when the finding marker is actually
+present in the uploaded artifacts (the encoded crash input for the fuzz
+job, per-seed divergence files for the diff jobs). A fuzz job that fails
+without its marker but whose `fuzz-run.log` shows the pre-fuzz unit-test
+phase failing (zig's `N pass, M fail|crash` test summary) is filed per
+variant as `Fuzz CI: unit-test failure (<variant> variant)` with the
+failing test names extracted from the log — under gc-stress that usually
+means a GC rooting bug (`.claude/rules/gc-safety.md`, #1401, #1682).
+Remaining marker-less failures — toolchain flakes, build failures,
+job-level timeouts (a possible hang) — are collected under a single
+shared issue titled `Fuzz CI: infrastructure or build
 failure` instead. Marker detection must not assume where inside
 `artifacts/` a file lands: `download-artifact` normally extracts each
 artifact into its own named subdirectory, but a run with exactly one


### PR DESCRIPTION
Closes #1688 (follow-up to #1682).

## Problem

When the fuzz job failed **without** a crash marker, the `report` job filed it under the shared **"Fuzz CI: infrastructure or build failure"** issue with five candidate explanations — while `fuzz-run.log`, already downloaded by the job, contained the phase, the counts, the exact crashing test, and the variant. #1682's triage started from "toolchain download, apt flake, runner OOM?" when the log said `in test.prettyPrint clause form indentation`. The `tail -c 2000` excerpt also only included that crash trace because it happened to sit at the end of the log.

## Changes (`.github/workflows/fuzz.yml`, report job only)

1. **Three-way fuzz routing.** Crash marker → finding issue (unchanged). No marker but the log's test summary counts a failure (`N pass, M fail|crash|leak (T total)` step line or `N/M tests passed (K failed|crashed|leaked)` Build Summary line) → a dedicated deduped issue **per variant**: `Fuzz CI: unit-test failure (gc-stress variant)`. Anything else (no log, setup death, build failure, timeout) → the shared infra issue, as before. Keeping titles separate stops toolchain flakes and real test bugs from appending to each other's threads.
   - **Failing test names in the body**, extracted from zig's `error: '<name>' failed:/terminated …` lines with panic-trace frames (`0x… in test.NAME (unit-tests)`) as backup, normalized to `test.<name>` and deduped. The fuzz-target name in the FUZZING REPORT section is not picked up.
   - **Targeted hint**: a test failing only under `-Dgc-stress=true` usually means a GC rooting bug (`.claude/rules/gc-safety.md`, #1401, #1682), with the local repro command.
   - **Variant from the failed build command** echoed at the log's end (`… test --fuzz=100 -Dgc-stress=true`) — artifact directory names are unreliable under download-artifact v8's single-artifact layout (#1584, #1620). Both matrix variants classify independently when both fail; a log the classifier doesn't recognize still lands in the infra issue (and its excerpt shows that log).
2. **Pattern-anchored excerpt.** `log_excerpt` starts at the first test-failure report (`error: '`), compile diagnostic (`: error: `), or `Build Summary:` line — 3 lines early to catch the counts line — bounded to 6 KB (head + `[... N bytes omitted ...]` + tail for long sections), with the old `tail -c 2000` as fallback when no anchor matches. Benefits all three issue kinds.

`docs/dev/fuzzing.md`'s "How findings reach you" paragraph is updated to match.

## Validation

Zig 0.16 output shapes were reproduced locally for both a failing (`error: '…' failed:` / `1 pass, 1 fail`) and a crashing (`error: '…' terminated with signal …` / `1 pass, 1 crash`) test, matching the real #1682 log. The filing script (extracted from the YAML so tested bytes = shipped bytes) ran against a stubbed `gh` in nine scenarios — 44 assertions, all passing:

| Scenario | Expectation |
|---|---|
| Flattened single artifact, gc-stress unit-test crash (#1682 replay) | per-variant issue; test name listed once; rooting hint; error line in excerpt (old tail missed it — failure section is 3.6 KB) |
| Compile-error log (no test signature) | infra issue; excerpt now includes the compile diagnostic |
| Both variants fail with unit-test failures | two issues, correct variants, both test names on default |
| Crash marker present | crash finding only, no unit-test issue (unchanged path) |
| No artifacts at all | infra issue with "No artifact was uploaded" |
| native-diff divergence | finding issue with seed program (untouched path regression) |
| Open same-title issue exists | comment appended, nothing created |
| gc-stress unit-test failure + default-variant flake | unit-test issue **and** infra issue, infra excerpt shows the unexplained log |
| Failure section > 6 KB | bounded excerpt with omission marker, error line and Build Summary both present |

`shellcheck -S warning` is clean on the extracted script; YAML parses.

True infra failures (no log, setup-step death, job-level timeout) keep the existing shared-issue behavior, and dedup/token-isolation are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)