### PR TITLE
Detect mark-time use-after-free deterministically under gc-stress

### DIFF
--- a/.claude/rules/gc-safety.md
+++ b/.claude/rules/gc-safety.md
@@ -66,5 +66,10 @@ gc.popRoot();
 
 Stress-test with `-Dgc-stress=true` to force collection on every allocation.
 In Debug builds, freed objects are poisoned with `0xAA` to catch use-after-free.
+Debug and gc-stress builds additionally stamp freed headers with the
+`memory.FREED_OWNER` sentinel, and gc-stress builds quarantine freed slots
+across a collection — so marking a dangling value panics deterministically
+with `GC: marking freed object (use-after-free)` instead of segfaulting by
+luck or silently aliasing a recycled object (#1687).
 
 Rationale and full patterns: `docs/dev/gc-safety-and-error-handling.md`.

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -107,6 +107,20 @@ This turns "rare, timing-dependent" rooting and barrier bugs into
 deterministic failures. Every new allocation pattern in a loop should
 also get a stress test — see `tests/scheme/smoke/gc-rooting-stress.scm`.
 
+`-Dgc-stress=true` builds go further and make marking-time use-after-free
+itself deterministic (#1687). Freeing an object stamps its header with the
+reserved `memory.FREED_OWNER` owner id (in Debug builds too, after the
+`0xAA` poison), and the freed slot is held in a per-GC quarantine —
+released oldest-first, only past `GC.quarantine_max_bytes`, and only
+between a later collection's mark and sweep phases. A dangling value that
+reaches the mark phase then panics with
+`GC: marking freed object (use-after-free)` rather than being skipped as a
+foreign-owned object (the poisoned owner byte never matches the marking
+GC's id) or silently aliasing a live object recycled into the same slot —
+the two escape modes that let the #1682 dangling-local bug survive twelve
+nightly stress runs. Release builds compile out both the stamp/check and
+the quarantine.
+
 ### Where to look
 
 The `reverse` function in `primitives.zig` is a clean reference

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -99,6 +99,18 @@ scale their iteration count down via `@import("build_options").gc_stress`
 (see `tests_records.zig` for the pattern) so the stress suite stays
 tractable.
 
+Stress builds also detect marking-time use-after-free deterministically
+(#1687): freeing an object stamps its header's `owner` with the reserved
+`memory.FREED_OWNER` sentinel, and the freed slot is quarantined (withheld
+from the allocator, released only after a later collection's mark phase,
+capped at `GC.quarantine_max_bytes`). Marking a dangling value therefore
+panics with `GC: marking freed object (use-after-free)` on the first run —
+it can no longer be silently absorbed by the foreign-owner skip or hidden
+by the freed slot being recycled into a live same-size object, the two
+modes that let #1682 pass twelve nightly stress runs. Plain Debug builds
+stamp and check the sentinel too (best-effort, without the quarantine);
+release builds compile both features out.
+
 ---
 
 ## Scheme Integration Tests

--- a/src/bench_channel.zig
+++ b/src/bench_channel.zig
@@ -130,6 +130,9 @@ fn freeArena(gc: *memory.GC) void {
     gc.old_objects = null;
     gc.object_count = 0;
     gc.bytes_allocated = 0;
+    // In gc-stress builds freeObject quarantines each slot (#1687); this
+    // arena GC never collects, so nothing else would ever release them.
+    gc.quarantineDrain();
 }
 
 // --------------------------------------------------------------------------

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -67,6 +67,9 @@ fn minorCollect(gc: *GC) void {
         markObjectContents(gc, obj);
     }
     processWeakRefs(gc);
+    // #1687: between mark and sweep, so slots the sweep is about to
+    // quarantine can't be released before the next mark phase checks them.
+    gc.quarantineReleaseToCap();
     sweepYoung(gc);
     pruneRememberedSet(gc);
 }
@@ -313,6 +316,8 @@ fn fullCollect(gc: *GC) void {
     clearOldMarks(gc);
     markRoots(gc);
     processWeakRefs(gc);
+    // #1687: see minorCollect.
+    gc.quarantineReleaseToCap();
     sweep(gc);
     sweepOld(gc);
     gc.remembered_set.clearRetainingCapacity();
@@ -416,6 +421,13 @@ fn processWeakRefs(gc: *GC) void {
 fn weakReachable(gc: *GC, v: Value) bool {
     if (!types.isPointer(v)) return true;
     const obj = types.toObject(v);
+    // #1687: same freed-header trap as markValueInner — this probe runs in
+    // the same mark phase, and a dangling ephemeron key would otherwise be
+    // "not reachable", silently broken, and never marked (so never caught).
+    if (comptime memory_mod.uaf_detection) {
+        if (obj.owner == memory_mod.FREED_OWNER)
+            @panic("GC: marking freed object (use-after-free)");
+    }
     if (obj.owner != gc.id) return true;
     return obj.flags.marked;
 }
@@ -716,6 +728,16 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
     while (true) {
         if (!types.isPointer(cur)) return;
         const obj = types.toObject(cur);
+        // #1687: a freed header is stamped FREED_OWNER before its slot is
+        // released (and, under gc-stress, the slot is quarantined so this
+        // read stays defined). Marking one means a dangling value reached
+        // the mark phase — an unrooted-local bug like #1682. Panic here,
+        // deterministically, instead of letting the foreign-owner skip
+        // below absorb it silently.
+        if (comptime memory_mod.uaf_detection) {
+            if (obj.owner == memory_mod.FREED_OWNER)
+                @panic("GC: marking freed object (use-after-free)");
+        }
         // Never mark or trace an object owned by another GC. Its owner keeps
         // it alive (shared globals are marked by the parent, interned symbols
         // are never swept, a thread's thunk is extra-rooted until join), and
@@ -1050,7 +1072,23 @@ inline fn poisonAndDestroy(gc: *GC, comptime T: type, ptr: *T) void {
     if (builtin.mode == .Debug) {
         @memset(@as([*]u8, @ptrCast(ptr))[0..@sizeOf(T)], 0xAA);
     }
-    gc.allocator.destroy(ptr);
+    if (comptime memory_mod.uaf_detection) {
+        // Stamp AFTER the poison so the sentinel survives it. A later mark
+        // of this dead header then panics deterministically in
+        // markValueInner instead of being absorbed by the foreign-owner
+        // skip (#1687). Every heap type places its Object header in a
+        // `header` field.
+        ptr.header.owner = memory_mod.FREED_OWNER;
+    }
+    if (comptime memory_mod.free_quarantine) {
+        // Withhold the slot from the allocator so a dangling value marked
+        // after this sweep still reads the sentinel instead of a recycled
+        // live object. Released by quarantineReleaseToCap after a later
+        // mark phase.
+        gc.quarantinePut(@ptrCast(ptr), @sizeOf(T), .of(T));
+    } else {
+        gc.allocator.destroy(ptr);
+    }
 }
 
 pub fn freeObject(gc: *GC, obj: *Object) void {

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const platform = @import("platform.zig");
 const types = @import("types.zig");
 const diagnostics = @import("diagnostics.zig");
@@ -55,13 +56,37 @@ pub const GcStats = struct {
 
 pub var symbol_mutex: std.atomic.Mutex = .unlocked;
 
+/// Sentinel stamped into `Object.owner` when the object's header slot is
+/// freed (#1687). `nextGcId` never returns it, so a mark-phase read of this
+/// value is proof of use-after-free: the #958 foreign-owner skip would
+/// otherwise silently absorb the dangling reference (a Debug-poisoned owner
+/// byte reads as some other GC's id). Stamped and checked only when
+/// `uaf_detection` is set; release builds never see it.
+pub const FREED_OWNER: u32 = 0xFFFF_FFFF;
+
+/// Gate for the freed-owner sentinel (#1687): stamp freed headers and panic
+/// when marking reaches one. Debug and gc-stress builds only, so release
+/// builds pay nothing on the mark hot path.
+pub const uaf_detection: bool = builtin.mode == .Debug or build_options.gc_stress;
+
+/// Gate for the free-quarantine (#1687): under `-Dgc-stress=true`, freed
+/// header slots are withheld from the allocator until after a later
+/// collection's mark phase, so a dangling root marked one collection later
+/// still reads the FREED_OWNER sentinel instead of a recycled live object
+/// (the silent-aliasing mode that hid #1682 for twelve nightly runs).
+pub const free_quarantine: bool = build_options.gc_stress;
+
 /// Monotonic source of unique GC ids (see `GC.id`). Never reused, so a live
 /// GC can never collide with a dead thread's id. Starts at 1 so 0 is never a
-/// valid id.
+/// valid id, and skips FREED_OWNER so a freed header can never masquerade as
+/// a live GC's object.
 var next_gc_id: u32 = 0;
 
 fn nextGcId() u32 {
-    return @atomicRmw(u32, &next_gc_id, .Add, 1, .monotonic) + 1;
+    while (true) {
+        const id = @atomicRmw(u32, &next_gc_id, .Add, 1, .monotonic) +% 1;
+        if (id != 0 and id != FREED_OWNER) return id;
+    }
 }
 
 pub fn spinLock(m: *std.atomic.Mutex) void {
@@ -138,6 +163,25 @@ pub const GC = struct {
     /// Live only within a single collection.
     pending_ephemerons: std.ArrayList(Value) = .empty,
     pending_guardians: std.ArrayList(Value) = .empty,
+    /// #1687 free-quarantine (gc-stress builds only; see `free_quarantine`).
+    /// FIFO of freed header slots withheld from the allocator: entries before
+    /// `quarantine_head` are already released. Slots are appended by
+    /// gc_collect's poisonAndDestroy and released oldest-first — only once
+    /// the held bytes exceed `quarantine_max_bytes`, and only after a mark
+    /// phase — so every entry survives at least one full mark after its free
+    /// and a dangling value marked then still reads the FREED_OWNER sentinel.
+    quarantine: std.ArrayList(QuarantineEntry) = .empty,
+    quarantine_head: usize = 0,
+    quarantine_bytes: usize = 0,
+    /// Cap on withheld bytes. A field (not a const) so tests can shrink it to
+    /// exercise eviction without freeing megabytes.
+    quarantine_max_bytes: usize = 4 << 20,
+
+    pub const QuarantineEntry = struct {
+        ptr: [*]u8,
+        len: usize,
+        alignment: std.mem.Alignment,
+    };
 
     pub const INITIAL_ROOT_CAPACITY: usize = 1024;
     pub const MAX_ROOT_CAPACITY: usize = 65536;
@@ -189,6 +233,10 @@ pub const GC = struct {
         // could not track themselves (see `foreign_symbols`). No other thread
         // runs at deinit — every child has joined — so this needs no lock.
         for (self.foreign_symbols.items) |o| gc_collect.freeObject(self, o);
+        // The freeObject calls above append to the quarantine in gc-stress
+        // builds; give every slot back before the allocator is torn down.
+        self.quarantineDrain();
+        self.quarantine.deinit(self.allocator);
         self.foreign_symbols.deinit(self.allocator);
         self.symbols.deinit();
         self.allocator.free(self.root_buffer);
@@ -1410,6 +1458,59 @@ pub const GC = struct {
         self.root_count -= 1;
     }
 
+    // -- #1687 free-quarantine (see the `quarantine` field) --
+
+    /// Withhold a freed header slot from the allocator. Called by
+    /// poisonAndDestroy in place of `destroy` when `free_quarantine` is set;
+    /// the slot's Object.owner has already been stamped FREED_OWNER. If the
+    /// entry can't be recorded, release the slot immediately rather than
+    /// aborting the sweep — detection degrades, correctness doesn't.
+    pub fn quarantinePut(self: *GC, ptr: [*]u8, len: usize, alignment: std.mem.Alignment) void {
+        self.quarantine.append(self.allocator, .{ .ptr = ptr, .len = len, .alignment = alignment }) catch {
+            self.allocator.rawFree(ptr[0..len], alignment, @returnAddress());
+            return;
+        };
+        self.quarantine_bytes += len;
+    }
+
+    fn quarantineReleaseOldest(self: *GC) void {
+        const e = self.quarantine.items[self.quarantine_head];
+        self.quarantine_head += 1;
+        self.quarantine_bytes -= e.len;
+        self.allocator.rawFree(e.ptr[0..e.len], e.alignment, @returnAddress());
+        if (self.quarantine_head == self.quarantine.items.len) {
+            self.quarantine.clearRetainingCapacity();
+            self.quarantine_head = 0;
+        }
+    }
+
+    /// Release quarantined slots oldest-first until at most
+    /// `quarantine_max_bytes` remain. Called between a collection's mark and
+    /// sweep phases (gc_collect.zig), so slots freed by the upcoming sweep are
+    /// never eviction candidates before the *next* mark has had a chance to
+    /// trip the FREED_OWNER sentinel on them.
+    pub fn quarantineReleaseToCap(self: *GC) void {
+        if (comptime !free_quarantine) return;
+        while (self.quarantine_bytes > self.quarantine_max_bytes)
+            self.quarantineReleaseOldest();
+        // Compact once the released prefix dominates so the list doesn't
+        // grow by its own dead entries.
+        const items = self.quarantine.items;
+        if (self.quarantine_head > 0 and self.quarantine_head >= items.len / 2) {
+            const remaining = items.len - self.quarantine_head;
+            std.mem.copyForwards(QuarantineEntry, items[0..remaining], items[self.quarantine_head..]);
+            self.quarantine.shrinkRetainingCapacity(remaining);
+            self.quarantine_head = 0;
+        }
+    }
+
+    /// Release every quarantined slot. Used at GC teardown and by the arena
+    /// resets (shared_channel.zig, bench_channel.zig) that free objects on a
+    /// GC which never collects.
+    pub fn quarantineDrain(self: *GC) void {
+        while (self.quarantine.items.len > 0) self.quarantineReleaseOldest();
+    }
+
     pub const RootedSlot = struct {
         gc: *GC,
         idx: usize,
@@ -1581,6 +1682,66 @@ test "rootedScope release" {
     scope.release();
     try std.testing.expectEqual(@as(usize, 1), gc.extra_roots.items.len);
     try std.testing.expectEqual(types.makeFixnum(1), gc.extra_roots.items[0]);
+}
+
+// The #1687 tests read a freed object's header after the sweep. That read is
+// defined ONLY because the quarantine keeps the slot resident (withheld from
+// the allocator), which is why every one of them skips unless the
+// free-quarantine is compiled in.
+
+test "sweep stamps freed headers with the freed-owner sentinel (gc-stress)" {
+    if (comptime !free_quarantine) return error.SkipZigTest;
+    var gc = GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+
+    const v = try gc.allocPair(types.makeFixnum(1), types.NIL);
+    const obj = types.toObject(v);
+    try std.testing.expectEqual(gc.id, obj.owner);
+
+    gc.collect(); // unrooted → swept → slot quarantined, owner stamped
+    try std.testing.expectEqual(FREED_OWNER, obj.owner);
+    try std.testing.expectEqual(@as(usize, @sizeOf(Pair)), gc.quarantine_bytes);
+}
+
+test "quarantined slot survives a later mark phase un-recycled (gc-stress)" {
+    if (comptime !free_quarantine) return error.SkipZigTest;
+    var gc = GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+
+    const dead = try gc.allocPair(types.makeFixnum(1), types.NIL);
+    const dead_obj = types.toObject(dead);
+    gc.collect(); // frees `dead`, quarantines its slot
+
+    // A new allocation must not land in the withheld slot (the silent
+    // aliasing that hid #1682), and a second collection's release point
+    // (after mark, under the byte cap) must keep the sentinel readable.
+    var live = try gc.allocPair(types.makeFixnum(2), types.NIL);
+    gc.pushRoot(&live);
+    defer gc.popRoot();
+    try std.testing.expect(types.toObject(live) != dead_obj);
+    gc.collect();
+    try std.testing.expectEqual(FREED_OWNER, dead_obj.owner);
+}
+
+test "quarantine evicts oldest-first once over the byte cap (gc-stress)" {
+    if (comptime !free_quarantine) return error.SkipZigTest;
+    var gc = GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+    gc.quarantine_max_bytes = @sizeOf(Pair); // hold at most one pair slot
+
+    _ = try gc.allocPair(types.makeFixnum(1), types.NIL);
+    gc.collect(); // slot A quarantined; at the cap, not over it
+    try std.testing.expectEqual(@as(usize, @sizeOf(Pair)), gc.quarantine_bytes);
+
+    _ = try gc.allocPair(types.makeFixnum(2), types.NIL);
+    gc.collect(); // release point sees only A (≤ cap); sweep adds B
+    try std.testing.expectEqual(@as(usize, 2 * @sizeOf(Pair)), gc.quarantine_bytes);
+
+    gc.collect(); // now over the cap: A (oldest) is released, B stays
+    try std.testing.expectEqual(@as(usize, @sizeOf(Pair)), gc.quarantine_bytes);
 }
 
 test "mark worklist retains capacity across collections" {

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -226,6 +226,9 @@ fn resetForReuse(gc: *memory.GC) void {
     gc.bytes_allocated = 0;
     gc.symbols.clearRetainingCapacity();
     gc.remembered_set.clearRetainingCapacity();
+    // In gc-stress builds freeObject quarantines each slot (#1687); this GC
+    // never collects, so nothing else would ever release them.
+    gc.quarantineDrain();
 }
 
 pub const SharedChannel = struct {

--- a/src/types.zig
+++ b/src/types.zig
@@ -218,6 +218,9 @@ pub const Object = struct {
     /// closures being executed), and writing mark bits on those would corrupt
     /// the parent GC's mark state — under-marking sweeps live objects (#958).
     /// Fits in existing struct padding, so it adds no size.
+    /// In Debug/gc-stress builds, freeing the object stamps this field with
+    /// `memory.FREED_OWNER` so a later mark of the dead header panics
+    /// deterministically instead of being skipped as foreign (#1687).
     owner: u32 = 0,
     next: ?*Object = null,
     // Force 8-byte alignment so all heap objects satisfy the pointer tag


### PR DESCRIPTION
Closes #1687. Follow-up to #1682 (fixed in #1685; test-side audit in #1686).

That bug went undetected for twelve nightly gc-stress runs because both existing defenses structurally miss marking-time UAF: the Debug `0xAA` poison makes a freed header's `owner` read as some other GC's id, so `markValueInner`'s #958 foreign-owner skip **silently absorbs** the dangling reference; and when the freed slot is recycled by the next same-size allocation, the owner is valid again and the corruption is invisible except to exact-output assertions.

## What this adds

Both pieces comptime-gated (`memory.uaf_detection`, `memory.free_quarantine`) so release builds pay nothing:

**1. Freed-owner sentinel** (Debug or `-Dgc-stress=true`)
- `FREED_OWNER = 0xFFFF_FFFF` reserved; `nextGcId` can never return it.
- `poisonAndDestroy` stamps it into `Object.owner` *after* the poison memset so it survives.
- `markValueInner` (the funnel for all root/remembered-set/worklist marking) and `weakReachable` (the mark-phase probe for ephemeron keys / guardian watched objects, which never reach `markValueInner` when unreachable) panic on it: `GC: marking freed object (use-after-free)` — deterministic and attributable instead of a lucky segfault.

**2. Free-quarantine** (`-Dgc-stress=true` only)
- Freed header slots are withheld from the allocator in a per-GC FIFO (`quarantinePut` in place of `destroy`; payload frees stay immediate).
- Released oldest-first, only past a 4 MiB cap (`GC.quarantine_max_bytes`, a field so tests can shrink it), and only **between a later collection's mark and sweep phases** — so every slot survives at least one full mark after its free, and a dangling value marked later still reads the sentinel instead of aliasing a recycled live object.
- `GC.deinit` and the two arena resets that never collect (`shared_channel.resetForReuse`, `bench_channel.freeArena`) drain it; on entry-record OOM the slot is released immediately (detection degrades, correctness doesn't).

No false positives are possible: live objects always carry a real GC id, which `nextGcId` guarantees is never the sentinel — a sentinel read during marking is proof the Value was dangling.

## Acceptance (from the issue)

With the #1685 rooting fix temporarily reverted, `printer.test.prettyPrint clause form indentation` under `zig build test -Dgc-stress=true` panicked with the freed-object message on **8/8 runs** (previously: twelve silent nightly runs before one crash), via the slice-root mark path — the historically silent slot-reuse mode. The synthetic variant (unrooted heap local across an allocation, then into `makeList`) panics identically at the next collection. Both scenarios converge on the sentinel because the quarantine keeps the slot resident.

## Tests

- Three regression tests in `memory.zig` (skip unless the quarantine is compiled in, since they read freed headers — defined only while the slot is withheld): sentinel stamped on sweep; slot survives a later mark un-recycled; oldest-first eviction at the byte cap.
- Full unit suite green in normal, `-Doptimize=Debug`, and `-Dgc-stress=true` builds.
- Cross-compiles: `zig build wasm` (also with gc-stress), x86_64-linux, aarch64-windows, x86_64-freebsd.
- Stress binary end-to-end: `gc-rooting-stress.scm` (13k collections / 13.5k frees through the quarantine), smoke basic, SRFI-254 weak-ref suite 33/33 (exercises the `weakReachable` change).

Docs updated: `docs/dev/testing.md`, `docs/dev/gc-safety-and-error-handling.md`, `.claude/rules/gc-safety.md`, `Object.owner` doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)