### PR TITLE
Extend fuzzing beyond x86_64 to ARM64 and big-endian targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,13 +1,18 @@
 name: Fuzz
 
-# Scheduled bounded fuzzing of the targets in src/tests_fuzz.zig, plus the
-# offline differential batches: VM vs native backend
-# (tests/fuzz/native-diff.sh) and Kaappi vs Chibi Scheme
-# (tests/fuzz/oracle-diff.sh). See docs/dev/fuzzing.md for the runbook
-# (running locally, and turning a failure into a regression test + corpus
-# entry). Failures are auto-filed as GitHub issues labeled `fuzz-finding`
-# by the trailing `report` job — see that job's comment for the dedup and
-# token-isolation design.
+# Scheduled bounded fuzzing of the targets in src/tests_fuzz.zig — on both
+# native architectures, x86_64 and arm64 (Zig 0.16's fuzzer can't instrument
+# a cross-compiled target) — plus three offline differential batches: VM vs
+# native backend (tests/fuzz/native-diff.sh) and Kaappi vs Chibi Scheme
+# (tests/fuzz/oracle-diff.sh), both run per-arch on x86_64 + arm64; and the
+# cross-architecture batch (tests/fuzz/cross-diff.sh), which diffs the same
+# Kaappi build on the host vs a foreign arch under QEMU (s390x/riscv64/ppc64le)
+# to reach byte-order and codegen bugs the host-only fuzzer cannot. See
+# docs/dev/fuzzing.md for the runbook (running locally, cross-architecture
+# coverage, and turning a failure into a regression test + corpus entry).
+# Failures are auto-filed as GitHub issues labeled `fuzz-finding`, one per
+# platform/arch, by the trailing `report` job — see that job's comment for the
+# dedup, attribution, and token-isolation design.
 
 on:
   schedule:
@@ -35,24 +40,50 @@ on:
         description: 'First seed for the oracle batch (default: rotates per run).'
         required: false
         default: ''
+      cross-diff-count:
+        description: 'Number of programs for the cross-architecture (host vs QEMU target) batch.'
+        required: false
+        default: ''
+      cross-diff-base:
+        description: 'First seed for the cross-architecture batch (default: rotates per run).'
+        required: false
+        default: ''
 
 permissions:
   contents: read
 
 jobs:
   fuzz:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
+        # Zig 0.16's coverage-guided fuzzer instruments only the HOST arch —
+        # `zig build test --fuzz -Dtarget=…` fails with "no fuzz tests found" —
+        # so the in-process targets run NATIVELY, on both x86_64 and arm64. The
+        # aarch64 leg is not redundant: it re-exercises the NaN-box pointer
+        # assumptions and the GC write barriers on ARM's VA layout and memory
+        # model, and its full-VM eval paths cover ARM codegen the x86_64 leg
+        # cannot. Non-host architectures — above all the big-endian s390x
+        # canary — are unreachable by this fuzzer and are covered instead by
+        # the black-box `cross-diff` job below. See docs/dev/fuzzing.md
+        # ("Cross-architecture coverage").
         include:
           # The limit applies PER FUZZ TEST (7 targets currently). The eval,
           # token, and grammar targets build a full VM per input (~20-50 ms)
           # — and the differential target two of them — so they dominate the
           # wall time: locally 200 per target is a ~2 minute pass, so 2K per
           # target keeps a hosted runner well under the job timeout.
-          - variant: default
+          - platform: x86_64
+            runs-on: ubuntu-latest
+            variant: default
+            build-args: ''
+            limit: 2K
+            timeout: 55
+          - platform: arm64
+            runs-on: ubuntu-24.04-arm
+            variant: default
             build-args: ''
             limit: 2K
             timeout: 55
@@ -63,15 +94,25 @@ jobs:
           # collections (~35 min locally on M-series; budget more on a
           # hosted runner) — so the fuzz limit stays small and the timeout
           # generous. Throughput-sensitive fuzz targets skip themselves on
-          # stress builds (src/tests_fuzz.zig).
-          - variant: gc-stress
+          # stress builds (src/tests_fuzz.zig). Run on both arches: a rooting
+          # bug is arch-independent, but the pointer-tagging and write-barrier
+          # code it stresses is exactly where an ARM-specific fault would hide.
+          - platform: x86_64
+            runs-on: ubuntu-latest
+            variant: gc-stress
+            build-args: '-Dgc-stress=true'
+            limit: 100
+            timeout: 300
+          - platform: arm64
+            runs-on: ubuntu-24.04-arm
+            variant: gc-stress
             build-args: '-Dgc-stress=true'
             limit: 100
             timeout: 300
     steps:
-      # Both jobs in this workflow execute fuzzer-generated programs (and
-      # the native-diff job runs binaries compiled from them), so don't
-      # leave the GITHUB_TOKEN sitting in git config for the process tree.
+      # Every job in this workflow executes fuzzer-generated programs (and the
+      # native-diff job runs binaries compiled from them), so don't leave the
+      # GITHUB_TOKEN sitting in git config for the process tree.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -80,7 +121,7 @@ jobs:
         uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
         with:
           version: 0.16.0
-          cache-key: fuzz-${{ matrix.variant }}
+          cache-key: fuzz-${{ matrix.platform }}-${{ matrix.variant }}
 
       # Fuzzer state accumulates across runs when the cache is preserved:
       # f/ holds the discovered corpus, v/ the coverage bitmap. The rolling
@@ -93,9 +134,9 @@ jobs:
           path: |
             .zig-cache/f
             .zig-cache/v
-          key: fuzz-corpus-${{ matrix.variant }}-${{ github.run_id }}
+          key: fuzz-corpus-${{ matrix.platform }}-${{ matrix.variant }}-${{ github.run_id }}
           restore-keys: |
-            fuzz-corpus-${{ matrix.variant }}-
+            fuzz-corpus-${{ matrix.platform }}-${{ matrix.variant }}-
 
       # Zig 0.16's bounded fuzz mode does NOT propagate a fuzz-found crash
       # into the build's exit code — it saves the encoded crashing input to
@@ -107,12 +148,17 @@ jobs:
         env:
           FUZZ_LIMIT: ${{ inputs.limit || matrix.limit }}
           BUILD_ARGS: ${{ matrix.build-args }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
           set -o pipefail
+          # Written first, so the report job can attribute the platform even on
+          # a pre-fuzz unit-test failure (x86_64 and arm64 run identical build
+          # commands, so the log alone cannot tell them apart).
+          echo "$PLATFORM" > fuzz-platform.txt
           rm -f .zig-cache/f/crash
           zig build test "--fuzz=$FUZZ_LIMIT" $BUILD_ARGS 2>&1 | tee fuzz-run.log
           if [ -f .zig-cache/f/crash ]; then
-            echo "::error::Fuzzing found a crash; encoded input saved to .zig-cache/f/crash"
+            echo "::error::Fuzzing found a crash on $PLATFORM; encoded input saved to .zig-cache/f/crash"
             exit 1
           fi
 
@@ -126,10 +172,11 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: fuzz-artifacts-${{ matrix.variant }}
+          name: fuzz-artifacts-${{ matrix.platform }}-${{ matrix.variant }}
           path: |
             .zig-cache/f/crash
             fuzz-run.log
+            fuzz-platform.txt
             .zig-cache/tmp/libfuzzer.log
           include-hidden-files: true
           retention-days: 90
@@ -144,8 +191,21 @@ jobs:
   # workflow_dispatch or locally with
   # `bash tests/fuzz/native-diff.sh <count> <base>`.
   native-diff:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 55
+    strategy:
+      fail-fast: false
+      matrix:
+        # The LLVM native backend supports aarch64 and x86_64 only, so both
+        # sides of this VM-vs-native diff run natively, one job per arch. The
+        # arm64 leg is the ONLY fuzz coverage of aarch64 code generation:
+        # the x86_64 leg never exercises the ARM instruction emitter, calling
+        # convention, or register allocator.
+        include:
+          - arch: x86_64
+            runs-on: ubuntu-latest
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -155,7 +215,7 @@ jobs:
         uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
         with:
           version: 0.16.0
-          cache-key: fuzz-native-diff
+          cache-key: fuzz-native-diff-${{ matrix.arch }}
 
       - name: Build interpreter, runtime library, and generator
         run: |
@@ -168,9 +228,15 @@ jobs:
           COUNT: ${{ inputs.native-diff-count }}
           BASE: ${{ inputs.native-diff-base }}
           RUN_NUMBER: ${{ github.run_number }}
+          ARCH: ${{ matrix.arch }}
         run: |
           count="${COUNT:-300}"
           base="${BASE:-$((RUN_NUMBER * 300))}"
+          # arch.txt lets the report job attribute the divergence even when
+          # download-artifact collapses the single-artifact layout into
+          # artifacts/ (the #1584 misfiling bug — never anchor on dir names).
+          mkdir -p native-diff-results
+          echo "$ARCH" > native-diff-results/arch.txt
           bash tests/fuzz/native-diff.sh "$count" "$base"
 
       # Each divergence comes with the program and both sides' stdout/stderr;
@@ -179,7 +245,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: native-diff-divergences
+          name: native-diff-divergences-${{ matrix.arch }}
           path: native-diff-results/
           retention-days: 90
           if-no-files-found: warn
@@ -192,8 +258,20 @@ jobs:
   # noble's apt ships 0.9.1 which is too old for the generated programs
   # (#1429). Bump the tag and SHA below when a newer release is needed.
   oracle-diff:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Chibi builds from source on both arches, so the external-oracle diff
+        # runs natively on each. The arm64 leg would catch an ARM-specific
+        # conformance bug in the portable subset that both x86_64 evaluation
+        # paths share — the class the external oracle exists to find.
+        include:
+          - arch: x86_64
+            runs-on: ubuntu-latest
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       # This job executes fuzzer-generated programs; don't leave the
       # GITHUB_TOKEN sitting in git config for the process tree.
@@ -205,7 +283,7 @@ jobs:
         uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
         with:
           version: 0.16.0
-          cache-key: fuzz-oracle-diff
+          cache-key: fuzz-oracle-diff-${{ matrix.arch }}
 
       - name: Install Chibi Scheme (the oracle)
         run: |
@@ -226,9 +304,14 @@ jobs:
           COUNT: ${{ inputs.oracle-diff-count }}
           BASE: ${{ inputs.oracle-diff-base }}
           RUN_NUMBER: ${{ github.run_number }}
+          ARCH: ${{ matrix.arch }}
         run: |
           count="${COUNT:-1000}"
           base="${BASE:-$((RUN_NUMBER * 1000))}"
+          # arch.txt attributes the divergence in the report job regardless of
+          # download-artifact's single-artifact layout collapse (#1584).
+          mkdir -p oracle-diff-results
+          echo "$ARCH" > oracle-diff-results/arch.txt
           bash tests/fuzz/oracle-diff.sh "$count" "$base"
 
       # Each divergence comes with the program, both sides' stdout/stderr,
@@ -240,8 +323,82 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: oracle-diff-divergences
+          name: oracle-diff-divergences-${{ matrix.arch }}
           path: oracle-diff-results/
+          retention-days: 90
+          if-no-files-found: warn
+
+  # Cross-architecture differential: the SAME Kaappi build on the host arch vs
+  # a foreign arch under QEMU. Zig 0.16's fuzzer cannot instrument a
+  # cross-compiled target (`zig build test --fuzz -Dtarget=…` → "no fuzz tests
+  # found"), so the in-process `fuzz` targets never reach non-host arches. This
+  # black-box binary diff does: it generates portable-subset programs (whose
+  # output is deterministic and arch-independent by construction) and runs each
+  # through the native host kaappi and the cross-compiled target kaappi run via
+  # QEMU binfmt, flagging any stdout or exit-code difference. Because both sides
+  # are the same interpreter, a difference is definitively an arch bug —
+  # s390x is the big-endian canary; riscv64 and ppc64le add alignment/codegen
+  # breadth. See tests/fuzz/cross-diff.sh and docs/dev/fuzzing.md.
+  cross-diff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: s390x-linux
+            label: s390x # big-endian — the byte-order canary
+          - target: riscv64-linux
+            label: riscv64
+          - target: powerpc64le-linux
+            label: ppc64le
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: fuzz-cross-diff-${{ matrix.label }}
+
+      # binfmt registration so the cross-compiled target binary runs here; the
+      # host generator and host kaappi are built natively (no emulation).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: ${{ matrix.label }}
+
+      - name: Build host + target kaappi and the host generator
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          zig build fuzz-gen                 # host-arch generator
+          zig build                          # host kaappi → zig-out/bin/kaappi
+          cp zig-out/bin/kaappi zig-out/bin/kaappi-host
+          zig build -Dtarget="$TARGET"       # target kaappi OVERWRITES zig-out/bin/kaappi
+
+      - name: Cross-architecture differential (host vs target)
+        env:
+          COUNT: ${{ inputs.cross-diff-count }}
+          BASE: ${{ inputs.cross-diff-base }}
+          RUN_NUMBER: ${{ github.run_number }}
+          TARGET_LABEL: ${{ matrix.label }}
+        run: |
+          count="${COUNT:-500}"
+          base="${BASE:-$((RUN_NUMBER * 500))}"
+          HOST_KAAPPI=zig-out/bin/kaappi-host TARGET_KAAPPI=zig-out/bin/kaappi \
+            TARGET_LABEL="$TARGET_LABEL" bash tests/fuzz/cross-diff.sh "$count" "$base"
+
+      # Each divergence ships as seed-<N>.scm plus seed-<N>.{host,target}.{out,err}
+      # and arch.txt; see docs/dev/fuzzing.md for the (mostly endianness) triage.
+      - name: Upload divergences
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cross-diff-divergences-${{ matrix.label }}
+          path: cross-diff-results/
           retention-days: 90
           if-no-files-found: warn
 
@@ -257,22 +414,25 @@ jobs:
   # To avoid false-positive finding issues, filing is gated on the finding
   # marker actually being present in the uploaded artifacts — the encoded
   # crash input for the fuzz job, per-seed divergence files for the diff
-  # jobs. A fuzz job that failed without its marker but whose log shows the
-  # pre-fuzz unit-test phase failing is filed per variant as "Fuzz CI:
-  # unit-test failure (<variant> variant)" with the failing test names
-  # extracted from the log (#1688). Remaining marker-less failures
-  # (toolchain/apt flakes, build failures, job-level timeouts — a possible
-  # hang) are collected under a single "Fuzz CI: infrastructure or build
-  # failure" issue instead of wearing a divergence title.
+  # jobs (native/oracle/cross). Every finding is filed PER platform/arch,
+  # attributed from a file the job plants (fuzz-platform.txt / arch.txt), so
+  # a failure on one architecture never swallows another's. A fuzz leg that
+  # failed without a crash marker but whose log shows the pre-fuzz unit-test
+  # phase failing is filed as "Fuzz CI: unit-test failure (<platform>
+  # <variant>)" with the failing test names extracted from the log (#1688).
+  # Remaining marker-less failures (toolchain/apt flakes, build failures,
+  # job-level timeouts — a possible hang) are collected under a single
+  # "Fuzz CI: infrastructure or build failure" issue instead of wearing a
+  # divergence title.
   #
   # This is a SEPARATE job so the write-capable token never coexists with
-  # execution of fuzzer-generated programs — the three jobs above keep
+  # execution of fuzzer-generated programs — the four jobs above keep
   # contents:read tokens and persist-credentials: false; this one runs no
   # generated code (artifact contents are only copied into issue text).
   report:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [fuzz, native-diff, oracle-diff]
+    needs: [fuzz, native-diff, oracle-diff, cross-diff]
     if: failure()
     permissions:
       issues: write
@@ -315,6 +475,7 @@ jobs:
           RESULT_FUZZ: ${{ needs.fuzz.result }}
           RESULT_NATIVE: ${{ needs.native-diff.result }}
           RESULT_ORACLE: ${{ needs.oracle-diff.result }}
+          RESULT_CROSSDIFF: ${{ needs.cross-diff.result }}
         run: |
           set -euo pipefail
 
@@ -437,26 +598,36 @@ jobs:
             file_or_append "$title" finding-preamble.md "$fbody"
           }
 
-          # report_unit_test_failure LOG — the fuzz job failed in its pre-fuzz
+          # platform_of DIR / arch_of DIR — the platform (x86_64/arm64) or arch
+          # (target label) a job wrote INTO its artifact, as fuzz-platform.txt /
+          # arch.txt. This is the ONLY reliable attribution: the x86_64 and
+          # arm64 fuzz legs run identical build commands (so the log can't tell
+          # them apart), and download-artifact collapses a lone artifact into
+          # artifacts/ itself, erasing the artifact-name directory. Anchoring
+          # platform on a directory name is exactly the #1584/#1620 misfiling
+          # bug — always read it from the file the job planted.
+          platform_of() { d="$1"; [ -f "$d/fuzz-platform.txt" ] && { tr -d '[:space:]' < "$d/fuzz-platform.txt"; return 0; }; echo unknown; }
+          arch_of()     { d="$1"; [ -f "$d/arch.txt" ]          && { tr -d '[:space:]' < "$d/arch.txt";          return 0; }; echo unknown; }
+
+          # report_unit_test_failure LOG — a fuzz leg failed in its pre-fuzz
           # unit-test phase: zig's test summary in LOG counts a failed/crashed
-          # test, and no fuzz crash marker exists. File it under a per-variant
-          # title with the failing test names pulled from LOG, so real test
-          # bugs and toolchain flakes stop appending to each other's threads
-          # and triage starts from the test name instead of guessing (#1688).
-          # The variant is read from the failed build command echoed at the
-          # end of the log — artifact directory names are unreliable (see the
-          # layout note below).
+          # test, and no crash marker exists. Filed under a per-platform+variant
+          # title with the failing test names pulled from LOG, so real test bugs
+          # and toolchain flakes stop appending to each other's threads and
+          # triage starts from the test name (#1688). Platform comes from the
+          # planted fuzz-platform.txt; the variant (default/gc-stress) from the
+          # build command echoed in the log.
           report_unit_test_failure() {
-            utlog="$1"
+            utlog="$1"; utdir=$(dirname "$utlog"); plat=$(platform_of "$utdir")
             if grep -q -- '-Dgc-stress=true' "$utlog"; then
               variant=gc-stress
               hint='The unit-test phase of `zig build test --fuzz=… -Dgc-stress=true` reported a failed/crashed test; bounded fuzzing produced no crash marker. A test that fails only under gc-stress (collection attempted on every allocation) usually means a GC rooting bug — a heap value held in a Zig local across an allocation without rooting; see `.claude/rules/gc-safety.md`, #1401, #1682. Reproduce with `zig build test -Dgc-stress=true`.'
             else
               variant=default
-              hint='The unit-test phase of `zig build test --fuzz=…` reported a failed/crashed test on the default build; bounded fuzzing produced no crash marker. Plain `zig build test` is likely broken at this commit — expect regular CI to be red too.'
+              hint='The unit-test phase of `zig build test --fuzz=…` reported a failed/crashed test; bounded fuzzing produced no crash marker. Plain `zig build test` is likely broken at this commit for this platform — expect regular CI to be red too. A failure on only one platform points at an architecture-specific bug.'
             fi
-            utbody="body-unit-test-$variant.md"
-            body_start "fuzz ($variant variant)" "$hint" "$utbody"
+            ut_label="$plat $variant"; utbody="body-unit-test-$plat-$variant.md"
+            body_start "fuzz ($ut_label)" "$hint" "$utbody"
             # zig prints one "error: '<name>' failed:/terminated ..." line per
             # failing test; panic-trace frames ("0x... in test.NAME (binary)")
             # are the backup for truncated logs. Both normalize to test.<name>.
@@ -472,115 +643,106 @@ jobs:
                 printf '\n'
               } >> "$utbody"
             fi
-            excerpt "$(dirname "$utlog")" "$utbody"
-            printf 'Automated report from the [Fuzz workflow](%s): the `%s`-variant fuzz job failed in its pre-fuzz unit-test phase — a unit test failed or crashed before bounded fuzzing was reached. This is a real test failure, not a fuzz finding; unlike toolchain or runner flakes it should reproduce locally.\n\n' \
-              "$run_url" "$variant" > unit-test-preamble.md
-            printf '> [!NOTE]\n> Close this issue once the failing test is fixed (or the failure is otherwise explained); until then, further unit-test failures of the same variant append comments here instead of opening new issues.\n\n' \
+            excerpt "$utdir" "$utbody"
+            printf 'Automated report from the [Fuzz workflow](%s): the `%s` fuzz job failed in its pre-fuzz unit-test phase — a unit test failed or crashed before bounded fuzzing was reached. This is a real test failure, not a fuzz finding; unlike toolchain or runner flakes it should reproduce locally on this platform.\n\n' \
+              "$run_url" "$ut_label" > unit-test-preamble.md
+            printf '> [!NOTE]\n> Close this issue once the failing test is fixed (or the failure is otherwise explained); until then, further unit-test failures of the same platform+variant append comments here instead of opening new issues.\n\n' \
               >> unit-test-preamble.md
-            file_or_append "Fuzz CI: unit-test failure ($variant variant)" unit-test-preamble.md "$utbody"
+            file_or_append "Fuzz CI: unit-test failure ($ut_label)" unit-test-preamble.md "$utbody"
           }
 
           infra_jobs=""
+          fuzz_dir="artifacts/fuzz-absent"
 
-          # check_job RESULT JOB TITLE MARKER DIR HINT — route a failed diff job
-          # to its finding issue when the finding marker is present, or collect
-          # it for the shared infrastructure issue when it is not. (The fuzz job
-          # routes through its own three-way classifier below.)
-          check_job() {
-            result="$1"; job="$2"; title="$3"; marker="$4"; dir="$5"; hint="$6"
-            [ "$result" = failure ] || return 0
-            if [ -n "$marker" ]; then
-              report_finding "$job" "$title" "$dir" "$hint"
-            else
-              infra_jobs="$infra_jobs $job"
-            fi
-          }
+          # Every finding is filed PER platform/arch: a crash on arm64 must not
+          # swallow a different crash on x86_64, nor an s390x divergence a
+          # riscv64 one. The routing is artifact-driven — it loops over every
+          # marker file rather than taking head -1 — so it scales to any number
+          # of platform legs without code changes. Markers stay per-job unique
+          # (fuzz: .zig-cache/f/crash; native: seed-*.{vm,nat}.*; oracle:
+          # seed-*.kaappi.*; cross: seed-*.host.*), so a whole-tree find never
+          # confuses one job's files for another's.
 
-          # Finding markers: a real finding always ships in the artifact — the
-          # encoded crash input for the fuzz job, per-seed divergence files for
-          # the diff jobs. A failed job without its marker is a toolchain/apt
-          # flake, a build or unit-test failure, or a job-level timeout (a
-          # possible hang) — those are reported below under honest titles
-          # instead of finding ones: fuzz-job unit-test failures per variant
-          # (#1688), everything else under the shared infrastructure issue.
-          #
-          # Layout: download-artifact v8 normally extracts each artifact into
-          # artifacts/<artifact-name>/, but when the run produced exactly ONE
-          # artifact it extracts into artifacts/ itself (the action's
-          # `artifacts.length === 1` special case) — and one failed job is the
-          # common case. So never anchor on the artifact-name directory: search
-          # all of artifacts/ for filenames only the owning job can produce
-          # (seed-*.kaappi.* vs seed-*.{vm,nat}.* keeps the two diff jobs'
-          # files apart even without directories), and derive each excerpt
-          # directory from the file that matched. Anchoring on the directory
-          # name is exactly how the seed-2788 (#1584) and seed-10294 (#1620)
-          # divergences got misfiled as "infrastructure or build failure".
-          crash=$(find artifacts -type f -path '*/.zig-cache/f/crash' 2>/dev/null | sort | head -1 || true)
-          if [ -n "$crash" ]; then
-            fuzz_dir="${crash%/.zig-cache/f/crash}"
-          else
-            # No crash, but a test-phase failure still uploads fuzz-run.log.
-            fuzz_log=$(find artifacts -type f -name 'fuzz-run.log' 2>/dev/null | sort | head -1 || true)
-            fuzz_dir=$(dirname "${fuzz_log:-artifacts/fuzz-artifacts-missing/fuzz-run.log}")
-          fi
-          native_marker=$(find artifacts -type f \( -name 'seed-*.vm.*' -o -name 'seed-*.nat.*' \) 2>/dev/null | sort | head -1 || true)
-          native_dir=$(dirname "${native_marker:-artifacts/native-diff-divergences/absent}")
-          oracle_marker=$(find artifacts -type f -name 'seed-*.kaappi.*' 2>/dev/null | sort | head -1 || true)
-          oracle_dir=$(dirname "${oracle_marker:-artifacts/oracle-diff-divergences/absent}")
-
-          # The fuzz job routes three ways: crash marker → finding issue; a
-          # log whose variant has no marker but whose test summary counts a
-          # failure ("N pass, M fail|crash|leak (T total)" step line or "N/M
-          # tests passed (K failed|crashed|leaked)" Build Summary line) →
-          # per-variant unit-test issue (#1688); anything else (no log at
-          # all, or a log without the signature: setup death, build failure,
-          # timeout) → the shared infrastructure issue. The buckets are not
-          # exclusive: both matrix variants can fail in the same run, and a
-          # crash in one variant must not swallow the other variant's
-          # independent failure, so every log is classified — only logs
-          # sitting next to a crash marker (that variant is the finding
-          # already filed) are skipped.
+          # ---- fuzz (native x86_64 + arm64 matrix) — three routes per leg ----
           if [ "$RESULT_FUZZ" = failure ]; then
-            if [ -n "$crash" ]; then
-              report_finding fuzz \
-                'Fuzz CI: bounded fuzzing found a crash' \
-                "$fuzz_dir" \
-                'A fuzz target found a crash. The encoded crashing input (a serialized Smith decision stream) is `.zig-cache/f/crash` inside the artifact; `fuzz-run.log` is the fuzzer transcript. Replay it per the runbook.'
+            crashes=$(find artifacts -type f -path '*/.zig-cache/f/crash' 2>/dev/null | sort || true)
+            crash_dirs=""
+            if [ -n "$crashes" ]; then
+              while IFS= read -r c; do
+                [ -n "$c" ] || continue
+                cdir="${c%/.zig-cache/f/crash}"; crash_dirs="$crash_dirs $cdir"; plat=$(platform_of "$cdir")
+                report_finding "fuzz-$plat" "Fuzz CI: bounded fuzzing found a crash ($plat)" "$cdir" \
+                  "A fuzz target found a crash on the \`$plat\` build. The encoded crashing input (a serialized Smith decision stream) is \`.zig-cache/f/crash\` inside the artifact; \`fuzz-run.log\` is the fuzzer transcript. Replay per the runbook, reproducing on $plat — a crash unique to one architecture usually points at endianness, alignment, or codegen rather than Scheme semantics."
+              done <<< "$crashes"
             fi
-            fuzz_unexplained=""
+            # Each fuzz-run.log NOT beside a crash we just filed: a unit-test
+            # phase failure (per platform+variant), or, lacking that signature,
+            # infra. No log at all AND no crash means the job died in setup.
+            fuzz_infra=""
             fuzz_logs=$(find artifacts -type f -name 'fuzz-run.log' 2>/dev/null | sort || true)
-            if [ -z "$fuzz_logs" ]; then
-              # No log at all: setup death or job-level timeout — unless the
-              # crash marker already explains the job's failure.
-              [ -n "$crash" ] || fuzz_unexplained=1
+            if [ -z "$fuzz_logs" ] && [ -z "$crashes" ]; then
+              fuzz_infra=1
             else
               while IFS= read -r flog; do
-                if [ -f "$(dirname "$flog")/.zig-cache/f/crash" ]; then
-                  continue # this variant IS the crash finding filed above
-                fi
+                [ -n "$flog" ] || continue
+                ldir=$(dirname "$flog"); skip=""
+                for cd in $crash_dirs; do [ "$cd" = "$ldir" ] && skip=1; done
+                [ -n "$skip" ] && continue
                 if grep -qE '[0-9]+ pass, .*[0-9]+ (fail|crash|leak)|tests passed \([0-9]+ (failed|crashed|leaked)' "$flog"; then
                   report_unit_test_failure "$flog"
                 else
-                  fuzz_unexplained=1
-                  fuzz_dir=$(dirname "$flog") # infra excerpt shows this log
+                  fuzz_infra=1; fuzz_dir="$ldir"
                 fi
               done <<< "$fuzz_logs"
             fi
-            [ -z "$fuzz_unexplained" ] || infra_jobs="$infra_jobs fuzz"
+            [ -z "$fuzz_infra" ] || infra_jobs="$infra_jobs fuzz"
           fi
 
-          check_job "$RESULT_NATIVE" native-diff \
-            'Fuzz CI: VM vs native backend divergence' \
-            "$native_marker" "$native_dir" \
-            'A generated program behaved differently on the bytecode VM vs the LLVM native backend. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{vm,nat}.{out,err}` and `seed-<N>.compile.log`. The seed base is printed near the top of the job log; the same seed always regenerates the same program: `bash tests/fuzz/native-diff.sh <count> <base>`.'
+          # ---- native-diff (one finding per arch that diverged) ----
+          if [ "$RESULT_NATIVE" = failure ]; then
+            ndirs=$(find artifacts -type f \( -name 'seed-*.vm.*' -o -name 'seed-*.nat.*' \) 2>/dev/null | sed 's#/[^/]*$##' | sort -u || true)
+            if [ -n "$ndirs" ]; then
+              while IFS= read -r nd; do
+                [ -n "$nd" ] || continue; arch=$(arch_of "$nd")
+                report_finding "native-diff-$arch" "Fuzz CI: VM vs native backend divergence ($arch)" "$nd" \
+                  "A generated program behaved differently on the bytecode VM vs the LLVM native backend on \`$arch\`. Each divergence ships as \`seed-<N>.scm\` plus \`seed-<N>.{vm,nat}.{out,err}\` and \`seed-<N>.compile.log\`. The seed base is printed near the top of the job log; the same seed always regenerates the same program: \`bash tests/fuzz/native-diff.sh <count> <base>\` on $arch. An aarch64-only divergence points at ARM code generation in the native backend."
+              done <<< "$ndirs"
+            else
+              infra_jobs="$infra_jobs native-diff"
+            fi
+          fi
 
-          check_job "$RESULT_ORACLE" oracle-diff \
-            'Fuzz CI: Kaappi vs Chibi oracle divergence' \
-            "$oracle_marker" "$oracle_dir" \
-            'Kaappi and Chibi Scheme disagreed on a portable-subset program. Each divergence ships as `seed-<N>.scm` plus `seed-<N>.{kaappi,chibi}.{out,err}`; `oracle-version.txt` records the oracle version. Triage protocol (Kaappi bug / oracle bug / generator leak) is in the header of `tests/fuzz/oracle-diff.sh`. Replay: `bash tests/fuzz/oracle-diff.sh <count> <base>`.'
+          # ---- oracle-diff (one finding per arch that diverged) ----
+          if [ "$RESULT_ORACLE" = failure ]; then
+            odirs=$(find artifacts -type f -name 'seed-*.kaappi.*' 2>/dev/null | sed 's#/[^/]*$##' | sort -u || true)
+            if [ -n "$odirs" ]; then
+              while IFS= read -r od; do
+                [ -n "$od" ] || continue; arch=$(arch_of "$od")
+                report_finding "oracle-diff-$arch" "Fuzz CI: Kaappi vs Chibi oracle divergence ($arch)" "$od" \
+                  "Kaappi and Chibi Scheme disagreed on a portable-subset program on \`$arch\`. Each divergence ships as \`seed-<N>.scm\` plus \`seed-<N>.{kaappi,chibi}.{out,err}\`; \`oracle-version.txt\` records the oracle version. Triage protocol (Kaappi bug / oracle bug / generator leak) is in the header of \`tests/fuzz/oracle-diff.sh\`. Replay: \`bash tests/fuzz/oracle-diff.sh <count> <base>\`."
+              done <<< "$odirs"
+            else
+              infra_jobs="$infra_jobs oracle-diff"
+            fi
+          fi
 
+          # ---- cross-diff (host vs foreign arch under QEMU; one per target) ----
+          if [ "$RESULT_CROSSDIFF" = failure ]; then
+            tdirs=$(find artifacts -type f -name 'seed-*.host.*' 2>/dev/null | sed 's#/[^/]*$##' | sort -u || true)
+            if [ -n "$tdirs" ]; then
+              while IFS= read -r td; do
+                [ -n "$td" ] || continue; arch=$(arch_of "$td")
+                report_finding "cross-diff-$arch" "Fuzz CI: cross-architecture divergence ($arch vs host)" "$td" \
+                  "The SAME Kaappi build produced different output on \`$arch\` than on the host arch for a portable-subset program — an architecture-specific bug (on s390x, almost always endianness in the \`.sbc\` codec or other multi-byte serialization/hashing). Each divergence ships as \`seed-<N>.scm\` plus \`seed-<N>.{host,target}.{out,err}\`; \`arch.txt\` records the target. Replay: build both arches, then \`HOST_KAAPPI=… TARGET_KAAPPI=… TARGET_LABEL=$arch bash tests/fuzz/cross-diff.sh <count> <base>\`."
+              done <<< "$tdirs"
+            else
+              infra_jobs="$infra_jobs cross-diff"
+            fi
+          fi
+
+          # ---- shared infrastructure issue for marker-less failures ----
           if [ -n "$infra_jobs" ]; then
-            printf 'Automated report from the [Fuzz workflow](%s): a job failed WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM), a build failure, or a job-level timeout. (A fuzz-job unit-test failure is recognized from its log and filed separately as `Fuzz CI: unit-test failure (<variant> variant)`.) A timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious.\n\n' \
+            printf 'Automated report from the [Fuzz workflow](%s): a job failed WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM), a build failure, or a job-level timeout. (A fuzz-job unit-test failure is recognized from its log and filed separately as `Fuzz CI: unit-test failure (<platform> <variant>)`.) A timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious.\n\n' \
               "$run_url" > infra-preamble.md
             printf '> [!NOTE]\n> Close this issue once the failed run is explained (or the underlying breakage is fixed); further artifact-less failures append comments here.\n\n' \
               >> infra-preamble.md

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -149,12 +149,16 @@ jobs:
           FUZZ_LIMIT: ${{ inputs.limit || matrix.limit }}
           BUILD_ARGS: ${{ matrix.build-args }}
           PLATFORM: ${{ matrix.platform }}
+          VARIANT: ${{ matrix.variant }}
         run: |
           set -o pipefail
-          # Written first, so the report job can attribute the platform even on
-          # a pre-fuzz unit-test failure (x86_64 and arm64 run identical build
-          # commands, so the log alone cannot tell them apart).
+          # Platform AND variant are written up front, so the report job can
+          # attribute a finding without parsing the log: x86_64 and arm64 run
+          # identical build commands (platform is otherwise invisible), and a
+          # default-vs-gc-stress crash on the same platform must stay two
+          # distinct issues rather than collapsing on a platform-only title.
           echo "$PLATFORM" > fuzz-platform.txt
+          echo "$VARIANT" > fuzz-variant.txt
           rm -f .zig-cache/f/crash
           zig build test "--fuzz=$FUZZ_LIMIT" $BUILD_ARGS 2>&1 | tee fuzz-run.log
           if [ -f .zig-cache/f/crash ]; then
@@ -177,6 +181,7 @@ jobs:
             .zig-cache/f/crash
             fuzz-run.log
             fuzz-platform.txt
+            fuzz-variant.txt
             .zig-cache/tmp/libfuzzer.log
           include-hidden-files: true
           retention-days: 90
@@ -598,32 +603,40 @@ jobs:
             file_or_append "$title" finding-preamble.md "$fbody"
           }
 
-          # platform_of DIR / arch_of DIR — the platform (x86_64/arm64) or arch
-          # (target label) a job wrote INTO its artifact, as fuzz-platform.txt /
+          # platform_of DIR / variant_of DIR / arch_of DIR — the platform
+          # (x86_64/arm64), variant (default/gc-stress), or target arch a job
+          # wrote INTO its artifact, as fuzz-platform.txt / fuzz-variant.txt /
           # arch.txt. This is the ONLY reliable attribution: the x86_64 and
           # arm64 fuzz legs run identical build commands (so the log can't tell
           # them apart), and download-artifact collapses a lone artifact into
-          # artifacts/ itself, erasing the artifact-name directory. Anchoring
-          # platform on a directory name is exactly the #1584/#1620 misfiling
-          # bug — always read it from the file the job planted.
+          # artifacts/ itself, erasing the artifact-name directory. Anchoring on
+          # a directory name is exactly the #1584/#1620 misfiling bug — always
+          # read it from the file the job planted. variant_of also keeps a log
+          # fallback (zig echoes the failing build command, which carries
+          # -Dgc-stress=true) for any artifact predating the planted file.
           platform_of() { d="$1"; [ -f "$d/fuzz-platform.txt" ] && { tr -d '[:space:]' < "$d/fuzz-platform.txt"; return 0; }; echo unknown; }
           arch_of()     { d="$1"; [ -f "$d/arch.txt" ]          && { tr -d '[:space:]' < "$d/arch.txt";          return 0; }; echo unknown; }
+          variant_of() {
+            d="$1"
+            [ -f "$d/fuzz-variant.txt" ] && { tr -d '[:space:]' < "$d/fuzz-variant.txt"; return 0; }
+            [ -f "$d/fuzz-run.log" ] && grep -q -- '-Dgc-stress=true' "$d/fuzz-run.log" && { echo gc-stress; return 0; }
+            echo default
+          }
 
           # report_unit_test_failure LOG — a fuzz leg failed in its pre-fuzz
           # unit-test phase: zig's test summary in LOG counts a failed/crashed
           # test, and no crash marker exists. Filed under a per-platform+variant
           # title with the failing test names pulled from LOG, so real test bugs
           # and toolchain flakes stop appending to each other's threads and
-          # triage starts from the test name (#1688). Platform comes from the
-          # planted fuzz-platform.txt; the variant (default/gc-stress) from the
-          # build command echoed in the log.
+          # triage starts from the test name (#1688). Platform and variant both
+          # come from the files the job planted (fuzz-platform.txt /
+          # fuzz-variant.txt), so a gc-stress unit-test failure is never
+          # mislabeled default.
           report_unit_test_failure() {
-            utlog="$1"; utdir=$(dirname "$utlog"); plat=$(platform_of "$utdir")
-            if grep -q -- '-Dgc-stress=true' "$utlog"; then
-              variant=gc-stress
+            utlog="$1"; utdir=$(dirname "$utlog"); plat=$(platform_of "$utdir"); variant=$(variant_of "$utdir")
+            if [ "$variant" = gc-stress ]; then
               hint='The unit-test phase of `zig build test --fuzz=… -Dgc-stress=true` reported a failed/crashed test; bounded fuzzing produced no crash marker. A test that fails only under gc-stress (collection attempted on every allocation) usually means a GC rooting bug — a heap value held in a Zig local across an allocation without rooting; see `.claude/rules/gc-safety.md`, #1401, #1682. Reproduce with `zig build test -Dgc-stress=true`.'
             else
-              variant=default
               hint='The unit-test phase of `zig build test --fuzz=…` reported a failed/crashed test; bounded fuzzing produced no crash marker. Plain `zig build test` is likely broken at this commit for this platform — expect regular CI to be red too. A failure on only one platform points at an architecture-specific bug.'
             fi
             ut_label="$plat $variant"; utbody="body-unit-test-$plat-$variant.md"
@@ -670,9 +683,10 @@ jobs:
             if [ -n "$crashes" ]; then
               while IFS= read -r c; do
                 [ -n "$c" ] || continue
-                cdir="${c%/.zig-cache/f/crash}"; crash_dirs="$crash_dirs $cdir"; plat=$(platform_of "$cdir")
-                report_finding "fuzz-$plat" "Fuzz CI: bounded fuzzing found a crash ($plat)" "$cdir" \
-                  "A fuzz target found a crash on the \`$plat\` build. The encoded crashing input (a serialized Smith decision stream) is \`.zig-cache/f/crash\` inside the artifact; \`fuzz-run.log\` is the fuzzer transcript. Replay per the runbook, reproducing on $plat — a crash unique to one architecture usually points at endianness, alignment, or codegen rather than Scheme semantics."
+                cdir="${c%/.zig-cache/f/crash}"; crash_dirs="$crash_dirs $cdir"
+                plat=$(platform_of "$cdir"); variant=$(variant_of "$cdir")
+                report_finding "fuzz-$plat-$variant" "Fuzz CI: bounded fuzzing found a crash ($plat $variant)" "$cdir" \
+                  "A fuzz target found a crash on the \`$plat $variant\` build. The encoded crashing input (a serialized Smith decision stream) is \`.zig-cache/f/crash\` inside the artifact; \`fuzz-run.log\` is the fuzzer transcript. Replay per the runbook, reproducing on $plat — a crash unique to one architecture usually points at endianness, alignment, or codegen rather than Scheme semantics; a gc-stress-only crash points at a GC rooting bug."
               done <<< "$crashes"
             fi
             # Each fuzz-run.log NOT beside a crash we just filed: a unit-test

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -149,26 +149,28 @@ on success, so crash state never leaks into the next run.
 **How findings reach you:** any failed job in the workflow (the bounded
 fuzz pass, `native-diff`, `oracle-diff`, or `cross-diff`) is auto-filed as
 a GitHub issue by the trailing `report` job — one open issue **per
-platform/arch**, labeled `fuzz-finding`, containing the run link, a bounded
-artifact excerpt (the first divergent program plus both sides' output, or
-the failure section of the run log, pattern-anchored on the first
-`error:`/Build Summary line rather than the raw tail — #1688), and replay
-instructions. Because every leg is classified independently — the routing
-loops over every marker file rather than taking the first — a crash on
-`arm64` and a different crash on `x86_64`, or an `s390x` divergence and a
-`riscv64` one, each get their own attributed issue rather than one
-swallowing the others. Platform/arch is read from a file the job plants in
-its artifact (`fuzz-platform.txt` / `arch.txt`), never from the artifact
-directory name (which `download-artifact` erases when a run has a single
-artifact — the #1584/#1620 misfiling bug). A
+platform+variant** (fuzz) or **per arch** (the diff jobs), labeled
+`fuzz-finding`, containing the run link, a bounded artifact excerpt (the
+first divergent program plus both sides' output, or the failure section of
+the run log, pattern-anchored on the first `error:`/Build Summary line
+rather than the raw tail — #1688), and replay instructions. Because every
+leg is classified independently — the routing loops over every marker file
+rather than taking the first — a crash on `arm64` and a different crash on
+`x86_64`, a `default`-variant crash and a `gc-stress` crash on the *same*
+platform, or an `s390x` divergence and a `riscv64` one, each get their own
+attributed issue rather than one swallowing the others. Platform, variant,
+and arch are each read from a file the job plants in its artifact
+(`fuzz-platform.txt` / `fuzz-variant.txt` / `arch.txt`), never from the
+artifact directory name (which `download-artifact` erases when a run has a
+single artifact — the #1584/#1620 misfiling bug). A
 finding-titled issue is only filed when the finding marker is actually
 present in the uploaded artifacts (the encoded crash input for the fuzz
 job, per-seed divergence files for the diff jobs). A fuzz job that fails
 without its marker but whose `fuzz-run.log` shows the pre-fuzz unit-test
-phase failing (zig's `N pass, M fail|crash` test summary) is filed per
-variant as `Fuzz CI: unit-test failure (<variant> variant)` with the
-failing test names extracted from the log — under gc-stress that usually
-means a GC rooting bug (`.claude/rules/gc-safety.md`, #1401, #1682).
+phase failing (zig's `N pass, M fail|crash` test summary) is filed as
+`Fuzz CI: unit-test failure (<platform> <variant>)` with the failing test
+names extracted from the log — under gc-stress that usually means a GC
+rooting bug (`.claude/rules/gc-safety.md`, #1401, #1682).
 Both matrix variants are classified independently: a crash in one
 variant does not swallow the other variant's failure.
 Remaining marker-less failures — toolchain flakes, build failures,

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -101,12 +101,19 @@ allocate per iteration to scale their counts down via
 
 [`.github/workflows/fuzz.yml`](../../.github/workflows/fuzz.yml) runs a
 bounded fuzz pass daily at 02:47 UTC (scheduled away from the 05:17 UTC
-ecosystem nightly), in two variants:
+ecosystem nightly). The in-process `fuzz` targets run on **two native
+architectures** — `x86_64` (`ubuntu-latest`) and `arm64`
+(`ubuntu-24.04-arm`) — in two build variants each:
 
-| Variant | Build | Limit (per fuzz test) | Job timeout |
-|---------|-------|-----------------------|-------------|
-| `default` | standard `ReleaseSafe` test build | 2K runs | 55 min |
-| `gc-stress` | `-Dgc-stress=true` | 100 runs | 300 min |
+| Platform | Variant | Build | Limit (per fuzz test) | Job timeout |
+|----------|---------|-------|-----------------------|-------------|
+| x86_64 / arm64 | `default` | standard `ReleaseSafe` test build | 2K runs | 55 min |
+| x86_64 / arm64 | `gc-stress` | `-Dgc-stress=true` | 100 runs | 300 min |
+
+Both arches run natively because Zig 0.16's fuzzer only instruments the host
+(see [Cross-architecture coverage](#cross-architecture-coverage)). The `arm64`
+legs are not redundant: they exercise the NaN-box pointer assumptions, GC
+write barriers, and full-VM eval codegen on ARM's memory model and VA layout.
 
 The `gc-stress` variant runs the whole unit suite with a collection on
 every allocation before fuzzing, so its wall time is dominated by the test
@@ -140,12 +147,20 @@ accumulates instead of restarting from the seeds; the cache is only saved
 on success, so crash state never leaks into the next run.
 
 **How findings reach you:** any failed job in the workflow (the bounded
-fuzz pass, `native-diff`, or `oracle-diff`) is auto-filed as a GitHub
-issue by the trailing `report` job — one open issue per job, labeled
-`fuzz-finding`, containing the run link, a bounded artifact excerpt (the
-first divergent program plus both sides' output, or the failure section
-of the run log, pattern-anchored on the first `error:`/Build Summary line
-rather than the raw tail — #1688), and replay instructions. A
+fuzz pass, `native-diff`, `oracle-diff`, or `cross-diff`) is auto-filed as
+a GitHub issue by the trailing `report` job — one open issue **per
+platform/arch**, labeled `fuzz-finding`, containing the run link, a bounded
+artifact excerpt (the first divergent program plus both sides' output, or
+the failure section of the run log, pattern-anchored on the first
+`error:`/Build Summary line rather than the raw tail — #1688), and replay
+instructions. Because every leg is classified independently — the routing
+loops over every marker file rather than taking the first — a crash on
+`arm64` and a different crash on `x86_64`, or an `s390x` divergence and a
+`riscv64` one, each get their own attributed issue rather than one
+swallowing the others. Platform/arch is read from a file the job plants in
+its artifact (`fuzz-platform.txt` / `arch.txt`), never from the artifact
+directory name (which `download-artifact` erases when a run has a single
+artifact — the #1584/#1620 misfiling bug). A
 finding-titled issue is only filed when the finding marker is actually
 present in the uploaded artifacts (the encoded crash input for the fuzz
 job, per-seed divergence files for the diff jobs). A fuzz job that fails
@@ -323,6 +338,67 @@ source at a pinned tag+SHA (0.12 as of #1429 — Ubuntu noble's apt has 0.9.1
 which lacks features the generated programs use); the recorded version makes
 any divergence reproducible against the exact oracle. Gauche can be added
 later as a second, separately pinned opinion.
+
+## Cross-architecture coverage
+
+Bugs come in two classes, and only one is architecture-sensitive. Logic bugs
+in the reader, compiler, VM, and GC — and the miscompilations the opt-vs-no-opt
+and Chibi oracles catch — are the *same* defect on every CPU, so the host-arch
+targets find them once. The other class only appears off the host: **byte
+order** (the `.sbc` codec's `littleToNative` conversions are no-ops on
+little-endian x86_64, so an endian bug there is invisible until a big-endian
+machine runs it), **alignment**, **pointer width**, and **target-specific code
+generation** in the LLVM native backend. The fuzz workflow reaches those three
+ways:
+
+| Coverage | Where | Reaches |
+|----------|-------|---------|
+| In-process `fuzz` targets | `x86_64` + `arm64` (native) | ARM memory model, GC barriers, ARM eval codegen |
+| `native-diff`, `oracle-diff` | `x86_64` + `arm64` (native) | **aarch64 code generation** in the native backend; ARM conformance |
+| `cross-diff` | `s390x`, `riscv64`, `ppc64le` (QEMU) | **big-endian** (s390x) + alignment/codegen breadth |
+
+**Why the QEMU arches use a binary differential and not `--fuzz`.** Zig 0.16's
+coverage-guided fuzzer cannot instrument a cross-compiled target:
+`zig build test --fuzz -Dtarget=s390x-linux` fails with `no fuzz tests found`
+(reproduced with and without a `-Dtest-filter`), so the in-process targets in
+`src/tests_fuzz.zig` only ever run on the host arch. The corpus *seeds* still
+run on these arches — `ci.yml`'s `s390x-test` / `riscv64-test` / `ppc64le-test`
+jobs execute the whole unit suite, which replays each target's corpus once — so
+seed-level coverage exists; what cross-compiled fuzzing can't add is *mutation*
+beyond the seeds.
+
+[`tests/fuzz/cross-diff.sh`](../../tests/fuzz/cross-diff.sh) supplies the
+missing exploration a different way: for each seed it generates a
+portable-subset program (the same `kaappi-fuzz-gen --portable` used by the
+Chibi oracle) and runs it through the **native host `kaappi`** and the
+**cross-compiled target `kaappi` under QEMU binfmt**, comparing exit code and
+stdout. Because both sides are the *same interpreter* on a deterministic,
+fully-specified program, they must agree byte-for-byte — so any difference is
+definitively an architecture bug, never unspecified behavior. This is strictly
+tighter than the Chibi oracle (which must tolerate dialect differences) and is
+the ideal big-endian oracle: an endian bug anywhere in the VM, reader, printer,
+bignum, or hashing shows up as an s390x-vs-host stdout mismatch.
+
+```bash
+# Locally you need a target binary that runs here (QEMU binfmt, or a real box).
+zig build fuzz-gen                                   # host generator
+zig build && cp zig-out/bin/kaappi zig-out/bin/kaappi-host   # host kaappi
+zig build -Dtarget=s390x-linux                       # target kaappi (overwrites zig-out/bin/kaappi)
+HOST_KAAPPI=zig-out/bin/kaappi-host TARGET_KAAPPI=zig-out/bin/kaappi \
+  TARGET_LABEL=s390x bash tests/fuzz/cross-diff.sh 500 0
+```
+
+The `cross-diff` job runs 500 programs per target nightly with a rotating seed
+base (replayable via `workflow_dispatch` inputs `cross-diff-count` /
+`cross-diff-base`), and uploads divergences as
+`cross-diff-divergences-<target>`. A divergence is almost always (a) an
+architecture-specific Kaappi bug — on s390x, almost always endianness — or (b)
+the portable generator leaking non-portable behavior, fixed in
+`src/fuzz_gen_portable.zig`. Minimise it as ordinary Scheme, re-checking both
+arches at each shrink step, then add the minimised program as a `seed()` corpus
+entry on the **eval** target so the host suite guards it too. The native backend
+covers only aarch64/x86_64, so `cross-diff` uses the interpreter on the target;
+there is no native-backend differential on the QEMU arches.
 
 ## Turning a failure into a regression test
 

--- a/tests/fuzz/cross-diff.sh
+++ b/tests/fuzz/cross-diff.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Cross-architecture differential harness: the SAME Kaappi build on two CPU
+# architectures.
+#
+# For each seed this generates a portable-subset program (kaappi-fuzz-gen
+# --portable; see src/fuzz_gen_portable.zig for the fully-specified-subset
+# rules), runs it through a HOST kaappi (native) and a TARGET kaappi (a
+# different CPU arch, executed transparently via QEMU binfmt), and compares
+# exit code and stdout. Divergent programs are copied into RESULTS_DIR and the
+# script exits non-zero.
+#
+# WHY A BINARY DIFFERENTIAL AND NOT `--fuzz`: Zig 0.16's coverage-guided fuzzer
+# cannot instrument a cross-compiled target — `zig build test --fuzz
+# -Dtarget=s390x-linux` fails with "no fuzz tests found" — so the in-process
+# targets in src/tests_fuzz.zig only ever run on the host arch (see
+# docs/dev/fuzzing.md, "Cross-architecture coverage"). This harness needs only
+# the `kaappi` binary to run under QEMU, which it does, so it is the portable
+# way to reach non-host architectures — above all the big-endian s390x canary.
+#
+# WHY THIS IS A CLEAN ORACLE: both sides are the same interpreter, and the
+# portable subset is deterministic and fully specified (no time/random/IO
+# ordering, `eq?` only on interned symbols, no identity- or address-dependent
+# output). So the two runs MUST agree byte-for-byte on stdout and agree on exit
+# code; any difference is an architecture-specific bug — endianness, alignment,
+# pointer width, or codegen — never unspecified behavior. This is strictly
+# tighter than oracle-diff.sh's Kaappi-vs-Chibi comparison, which must tolerate
+# dialect differences; here there are none to tolerate.
+#
+# Usage: bash tests/fuzz/cross-diff.sh [N] [SEED_BASE]
+#   N          number of programs (default 100)
+#   SEED_BASE  first seed (default 0); seeds are BASE..BASE+N-1, and the same
+#              seed always yields the same program
+#
+# Environment:
+#   HOST_KAAPPI    native kaappi binary  (default: zig-out/bin/kaappi-host)
+#   TARGET_KAAPPI  foreign-arch kaappi   (default: zig-out/bin/kaappi; run via binfmt)
+#   GEN            portable generator    (default: zig-out/bin/kaappi-fuzz-gen; HOST arch)
+#   TARGET_LABEL   arch name for logs + arch.txt  (default: target)
+#   RESULTS_DIR    where divergences are written (default: ./cross-diff-results)
+#
+# Comparison rules (both sides are the same interpreter, so this is strict):
+#   any exit >= 128 on either side -> divergence: 128+N is death by signal N
+#                                     (segfault, abort, ...) — an arch crash
+#   exit codes differ              -> divergence (same program, same interpreter)
+#   exit codes equal               -> stdout must match byte-for-byte
+#   either side timed out          -> pair skipped (incomparable); the target
+#                                     runs under emulation and is much slower,
+#                                     so it gets a longer bound than the host
+#
+# Triage: a divergence is (a) an architecture-specific Kaappi bug — the common
+# case, and on s390x almost always endianness (the `.sbc` codec and any
+# serialization/hashing that reads multi-byte values); minimise the program
+# (re-check both arches at each step), then file it with the program and both
+# outputs; or (b) the generator leaking non-portable behavior — fix
+# src/fuzz_gen_portable.zig. Two self-consistent-but-different arches is (a):
+# the same code produced different observable output, which is the bug.
+
+set -u
+
+N="${1:-100}"
+BASE="${2:-0}"
+RESULTS_DIR="${RESULTS_DIR:-cross-diff-results}"
+TARGET_LABEL="${TARGET_LABEL:-target}"
+
+cd "$(dirname "$0")/../.." || exit 1
+
+HOST_KAAPPI="${HOST_KAAPPI:-zig-out/bin/kaappi-host}"
+TARGET_KAAPPI="${TARGET_KAAPPI:-zig-out/bin/kaappi}"
+GEN="${GEN:-zig-out/bin/kaappi-fuzz-gen}"
+
+# The generator is a host tool; build it if absent. The two kaappi binaries are
+# built by the caller (the target one needs -Dtarget=, which only the workflow
+# knows), so a missing binary is a setup error, not something to auto-build.
+[ -x "$GEN" ] || zig build fuzz-gen || exit 1
+if [ ! -x "$HOST_KAAPPI" ]; then
+  echo "cross-diff: host kaappi '$HOST_KAAPPI' not found or not executable" >&2
+  echo "cross-diff: build it first: zig build && cp zig-out/bin/kaappi zig-out/bin/kaappi-host" >&2
+  exit 2
+fi
+if [ ! -x "$TARGET_KAAPPI" ]; then
+  echo "cross-diff: target kaappi '$TARGET_KAAPPI' not found or not executable" >&2
+  echo "cross-diff: build it first: zig build -Dtarget=<arch>-linux (and register QEMU binfmt)" >&2
+  exit 2
+fi
+
+# Smoke-check that the target binary actually runs here (binfmt registered): a
+# trivial program whose output is known. A target that cannot execute would
+# make every seed a false "divergence", so fail loudly and early instead.
+probe="$(mktemp "${TMPDIR:-/tmp}/cross-diff-probe.XXXXXX.scm")"
+printf '(write (+ 1 2))(newline)\n' > "$probe"
+probe_out="$("$TARGET_KAAPPI" "$probe" 2>/dev/null)"
+rm -f "$probe" "${probe%.scm}.sbc"
+if [ "$probe_out" != "3" ]; then
+  echo "cross-diff: target kaappi '$TARGET_KAAPPI' did not run (probe printed '$probe_out', expected '3')" >&2
+  echo "cross-diff: is QEMU binfmt registered for $TARGET_LABEL? (docker/setup-qemu-action)" >&2
+  exit 2
+fi
+echo "cross-diff: host=$HOST_KAAPPI target=$TARGET_KAAPPI ($TARGET_LABEL)"
+
+# GNU timeout when available (Linux/CI). The target runs under emulation, so it
+# gets a much longer bound than the host; the portable programs are bounded by
+# construction, so running without `timeout` at all is acceptable too.
+TIMEOUT_BIN=""
+for c in timeout gtimeout; do
+  if command -v "$c" >/dev/null 2>&1; then TIMEOUT_BIN="$c"; break; fi
+done
+HOST_TIMEOUT="${TIMEOUT_BIN:+$TIMEOUT_BIN 10}"
+TARGET_TIMEOUT="${TIMEOUT_BIN:+$TIMEOUT_BIN 120}"
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/cross-diff.XXXXXX") || exit 1
+trap 'rm -rf "$WORK"' EXIT
+
+divergent=0
+skipped=0
+compared=0
+
+echo "cross-diff: seeds $BASE..$((BASE + N - 1))"
+
+save_divergence() {
+  mkdir -p "$RESULTS_DIR"
+  printf '%s\n' "$TARGET_LABEL" > "$RESULTS_DIR/arch.txt"
+  cp "$prog" "$RESULTS_DIR/"
+  for f in host.out host.err target.out target.err; do
+    [ -f "$WORK/$f" ] && cp "$WORK/$f" "$RESULTS_DIR/seed-$seed.$f"
+  done
+}
+
+i=0
+while [ "$i" -lt "$N" ]; do
+  seed=$((BASE + i))
+  i=$((i + 1))
+  prog="$WORK/seed-$seed.scm"
+  # Clear per-seed transients so save_divergence can never attach a stale file.
+  rm -f "$WORK/host.out" "$WORK/host.err" "$WORK/target.out" "$WORK/target.err"
+  "$GEN" "$seed" --portable > "$prog" || {
+    echo "cross-diff: generator failed for seed $seed" >&2
+    exit 1
+  }
+
+  $HOST_TIMEOUT "$HOST_KAAPPI" "$prog" > "$WORK/host.out" 2> "$WORK/host.err"
+  h_exit=$?
+  $TARGET_TIMEOUT "$TARGET_KAAPPI" "$prog" > "$WORK/target.out" 2> "$WORK/target.err"
+  t_exit=$?
+
+  # 124 = timeout(1) expiry, 137 = SIGKILL after expiry: incomparable pair.
+  if [ -n "$TIMEOUT_BIN" ] && { [ "$h_exit" -eq 124 ] || [ "$h_exit" -eq 137 ] ||
+    [ "$t_exit" -eq 124 ] || [ "$t_exit" -eq 137 ]; }; then
+    skipped=$((skipped + 1))
+    rm -f "$prog" "${prog%.scm}.sbc"
+    continue
+  fi
+
+  mismatch=""
+  if [ "$h_exit" -ge 128 ] || [ "$t_exit" -ge 128 ]; then
+    # 128+N = killed by signal N. A segfault/abort on one arch is the finding.
+    mismatch="signal-terminated exit (host=$h_exit target=$t_exit)"
+  elif [ "$h_exit" -ne "$t_exit" ]; then
+    mismatch="exit code differs (host=$h_exit target=$t_exit)"
+  else
+    cmp -s "$WORK/host.out" "$WORK/target.out" || mismatch="stdout differs (exit $h_exit on both)"
+  fi
+  compared=$((compared + 1))
+
+  if [ -n "$mismatch" ]; then
+    echo "seed $seed: DIVERGENCE — $mismatch" >&2
+    save_divergence
+    divergent=$((divergent + 1))
+  fi
+  rm -f "$prog" "${prog%.scm}.sbc"
+done
+
+echo "cross-diff: $compared compared, $skipped skipped, $divergent divergent"
+if [ "$divergent" -gt 0 ]; then
+  echo "cross-diff: divergent programs saved in $RESULTS_DIR/ ($TARGET_LABEL vs host)" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

The scheduled Fuzz workflow ran only on **x86_64 Linux**, leaving two bug classes with no fuzz coverage:

- **aarch64 code generation** in the LLVM native backend — the primary dev platform (macOS ARM) shares this backend, yet it was 0% fuzz-tested.
- **Byte-order bugs** — the `.sbc` codec's `littleToNative` conversions are no-ops on little-endian, so an endian bug there is invisible by construction until a big-endian machine runs it.

## What changed

| Job | Before | After |
|-----|--------|-------|
| `fuzz` (in-process) | x86_64 | x86_64 **+ arm64**, both variants |
| `native-diff` | x86_64 | x86_64 **+ arm64** (aarch64 codegen) |
| `oracle-diff` | x86_64 | x86_64 **+ arm64** |
| `cross-diff` | — | **new**: s390x / riscv64 / ppc64le via QEMU |

### The Zig limitation that shaped the design

`zig build test --fuzz -Dtarget=<t>-linux` fails with **`no fuzz tests found`** — Zig 0.16's coverage-guided fuzzer cannot instrument a cross-compiled target (verified with and without a `-Dtest-filter`; the native filtered form works). So the in-process targets are host-only.

The substitute is arguably a *stronger* oracle: **`tests/fuzz/cross-diff.sh`** runs the same generated portable-subset program through the native host `kaappi` and the cross-compiled target `kaappi` under QEMU binfmt, and diffs exit code + stdout. Both sides are the same interpreter on a deterministic program, so **any difference is definitively an architecture bug** — never unspecified behavior. **s390x is the big-endian canary.**

### Report job

Now files **one finding issue per platform/arch**, looping over every marker (a crash on arm64 never swallows a different crash on x86_64). Platform/arch is read from a file each job plants in its artifact (`fuzz-platform.txt` / `arch.txt`), never the artifact directory name — which `download-artifact` erases for single-artifact runs (the #1584/#1620 misfiling bug).

## Testing

- **Report classifier**: extracted the actual bash from the YAML and ran it through 11 synthetic-failure scenarios (single/multi-platform crashes, per-arch divergences, unit-test failures, single-artifact-collapse layout, "everything fails → 9 attributed issues") — all pass.
- **`cross-diff.sh`**: verified positive (identical binaries → 0 divergent, exit 0) and negative (perturbed target → divergences, exit 1, correct artifacts); shellcheck-clean.
- **Cross-compile**: s390x, riscv64, ppc64le all build on this branch.
- **YAML**: parses; all `matrix.*` references resolve; artifact names collision-free.

## CI budget

All `timeout-minutes` are under GitHub's 6-hour per-job cap. Observed x86_64 runtimes are 4–17 min against 30–300-min budgets. `cross-diff` is the only unbenchmarked job — estimated ~25–35 min against its 90-min budget; the first scheduled run will confirm. riscv64/ppc64le are little-endian (lower marginal value than s390x/arm64) and are the cheap lever if runner time needs trimming.

See `docs/dev/fuzzing.md` → **Cross-architecture coverage** for the full rationale and local-run instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)