### PR TITLE
Address PR #1733 second-round review: Windows paths, stale sandbox docs

### DIFF
--- a/lib/srfi/59.sld
+++ b/lib/srfi/59.sld
@@ -58,11 +58,12 @@
 ;;;   itself -- that native library is reachable directly under `--sandbox`
 ;;;   (unlike SRFI 170/192, which -- being built-in, not `.sld` files --
 ;;;   are excluded by their own `Lib.sandboxAllowed` entry instead), and
-;;;   three of its four procedures (`%implementation-version`, `%os-name`,
-;;;   `%cpu-architecture`) stay reachable there; only the filesystem-path-
-;;;   revealing ones this library itself needs (`%script-path`,
-;;;   `%current-lib-dir`, `%kaappi-lib-dir`, `%implementation-dir`) opt out
-;;;   per-primitive (`src/primitives_sysinfo.zig`).
+;;;   its three static build-info procedures (`%implementation-version`,
+;;;   `%os-name`, `%cpu-architecture`) stay reachable there; only the
+;;;   filesystem-path-revealing ones this library itself needs
+;;;   (`%script-path`, `%current-lib-dir`, `%kaappi-lib-dir`,
+;;;   `%implementation-dir`) opt out per-primitive
+;;;   (`src/primitives_sysinfo.zig`).
 (define-library (srfi 59)
   (import (scheme base) (scheme process-context) (kaappi sysinfo))
   (export program-vicinity

--- a/lib/srfi/59.sld
+++ b/lib/srfi/59.sld
@@ -50,9 +50,19 @@
 ;;;   prints "/"-separated paths natively on every supported platform,
 ;;;   Windows included.
 ;;;
-;;; - (kaappi sysinfo) is not sandbox-available, so program-vicinity --
-;;;   and therefore this whole library -- is unavailable under `--sandbox`,
-;;;   the same restriction SRFI 170 and SRFI 192 already have.
+;;; - This whole library is unavailable under `--sandbox`: it is a portable
+;;;   `.sld` file, and `--sandbox` blocks every file-backed library load
+;;;   (`vm_library.libraryIsAvailable`) unless the library is specifically
+;;;   embedded in the binary, which this one is not. That blanket file-load
+;;;   block is why this library is unreachable, not `(kaappi sysinfo)`
+;;;   itself -- that native library is reachable directly under `--sandbox`
+;;;   (unlike SRFI 170/192, which -- being built-in, not `.sld` files --
+;;;   are excluded by their own `Lib.sandboxAllowed` entry instead), and
+;;;   three of its four procedures (`%implementation-version`, `%os-name`,
+;;;   `%cpu-architecture`) stay reachable there; only the filesystem-path-
+;;;   revealing ones this library itself needs (`%script-path`,
+;;;   `%current-lib-dir`, `%kaappi-lib-dir`, `%implementation-dir`) opt out
+;;;   per-primitive (`src/primitives_sysinfo.zig`).
 (define-library (srfi 59)
   (import (scheme base) (scheme process-context) (kaappi sysinfo))
   (export program-vicinity

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -143,9 +143,15 @@ pub const Lib = enum {
             => false,
             // Mixed: %implementation-version/%os-name/%cpu-architecture are
             // harmless (static build info) and stay sandbox = true on their
-            // own specs; only %script-path (host filesystem path) opts out
-            // per-spec below. Blocking the whole library here would make
-            // that per-spec flag moot for the other three.
+            // own specs; the filesystem-path-revealing ones (%script-path,
+            // %current-lib-dir, %kaappi-lib-dir, %implementation-dir) opt
+            // out per-spec instead (primitives_sysinfo.zig). Blocking the
+            // whole library here would make those per-spec flags moot for
+            // the harmless three. This only governs direct `(import (kaappi
+            // sysinfo))`; every portable SRFI layered on it (59, 112, 193)
+            // is still unreachable under --sandbox regardless, since it's a
+            // `.sld` file and file-backed loads are blocked wholesale
+            // (vm_library.libraryIsAvailable) unless embedded.
             .kaappi_sysinfo => true,
             else => true,
         };

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -920,11 +920,20 @@ fn reportIncludeError(vm: *VM, path: []const u8, line: u32, detail: ?[]const u8,
     vm_mod.writeStderr(s);
 }
 
+/// Directory portion of `path` (trailing separator included), or "" if it
+/// has none. `\` is only recognized as a separator on Windows -- matching
+/// `vicinity:suffix?`'s own platform split (lib/srfi/59.sld) -- since on
+/// POSIX a backslash is just an ordinary, if unusual, filename character
+/// (kaappi#1733 review: a Windows `(load "dir\file.scm")` was reporting
+/// program-vicinity as "" instead of "dir\" while loading).
 pub fn extractDir(path: []const u8) []const u8 {
-    if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| {
-        return path[0 .. pos + 1];
-    }
-    return "";
+    const slash = std.mem.lastIndexOfScalar(u8, path, '/');
+    const backslash = if (platform.is_windows) std.mem.lastIndexOfScalar(u8, path, '\\') else null;
+    const last = if (slash != null and backslash != null)
+        @max(slash.?, backslash.?)
+    else
+        slash orelse backslash orelse return "";
+    return path[0 .. last + 1];
 }
 
 fn resolveImportBindings(vm: *VM, import_set: Value) anyerror!std.StringHashMap(Value) {

--- a/tests/scheme/srfi/srfi59-nested-load-vicinity.scm
+++ b/tests/scheme/srfi/srfi59-nested-load-vicinity.scm
@@ -1,0 +1,29 @@
+;; Regression test: SRFI 59's program-vicinity tracks whatever file is
+;; *currently loading*, not just the top-level script. Previously it only
+;; ever reported the top-level script's path (backed by the static
+;; %script-path), even from inside a nested `load` -- so a loaded file's own
+;; call to program-vicinity incorrectly saw the outer script's directory
+;; instead of its own. Found via PR #1733 review; fixed by tracking
+;; vm.current_lib_dir (the same "currently loading file" state .sld/include
+;; resolution already maintains) instead.
+
+(import (scheme base) (scheme process-context) (srfi 64) (srfi 59))
+
+(test-begin "srfi-59-nested-load-vicinity")
+
+;; Both the direct `kaappi ... srfi59-nested-load-vicinity.scm` invocation
+;; and run-all.sh run this file as the top-level script, so program-vicinity
+;; must see this file's own directory before any load happens.
+(let* ((outer-vicinity (program-vicinity))
+       (fixture (string-append outer-vicinity "fixtures/srfi59-nested-vicinity.scm")))
+  (load fixture)
+  (test-equal "program-vicinity: reports the loaded file's own directory while loading"
+              (string-append outer-vicinity "fixtures/")
+              %srfi59-nested-vicinity-result)
+  (test-equal "program-vicinity: reverts to the outer script's directory after load returns"
+              outer-vicinity
+              (program-vicinity)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-59-nested-load-vicinity")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi59.scm
+++ b/tests/scheme/srfi/srfi59.scm
@@ -129,20 +129,8 @@
                (and (string? combined)
                     (string=? combined (string-append vicinity "srfi59.scm")))))
 
-;; program-vicinity tracks whatever file is *currently loading*, not just the
-;; top-level script: while `load` is on the stack it reports the loaded
-;; file's own directory, and reverts to this script's directory once `load`
-;; returns (kaappi#1703 review -- previously it only ever reported the
-;; top-level script's path, even from inside a nested load).
-(let* ((outer-vicinity (program-vicinity))
-       (fixture (string-append outer-vicinity "fixtures/srfi59-nested-vicinity.scm")))
-  (load fixture)
-  (test-equal "program-vicinity: reports the loaded file's own directory while loading"
-              (string-append outer-vicinity "fixtures/")
-              %srfi59-nested-vicinity-result)
-  (test-equal "program-vicinity: reverts to the outer script's directory after load returns"
-              outer-vicinity
-              (program-vicinity)))
+;; program-vicinity's nested-load tracking (kaappi#1733 review) has its own
+;; dedicated regression file: srfi59-nested-load-vicinity.scm.
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-59")


### PR DESCRIPTION
## Summary

PR #1733 (SRFI Phase 4 slice 1) merged, but CodeRabbit's review of my fix
commits there surfaced 4 more findings after the merge. This addresses 3 of
them with code/doc changes, extracts one regression test into its own file
per project convention, and documents why the remaining suggestion wasn't
applied.

- `extractDir` (`vm_library.zig`): now recognizes `\` as a separator on
  Windows too (matching `vicinity:suffix?`'s own platform split). A Windows
  `(load "dir\file.scm")` was reporting `program-vicinity` as `""` instead
  of `"dir\"` while loading, since `extractDir` only searched for `/`.
- Fixed stale sandbox documentation in `lib/srfi/59.sld` and
  `primitives.zig`, left over from PR #1733's fix that stopped blocking the
  whole `(kaappi sysinfo)` library under `--sandbox`. SRFI 59 is still
  unavailable under `--sandbox` — but because it's a non-embedded `.sld`
  file (blocked wholesale by `vm_library.libraryIsAvailable`), not because
  of `kaappi_sysinfo`'s own gate, which no longer blocks it.
- Moved the nested-load `program-vicinity` regression out of `srfi59.scm`
  into its own file (`srfi59-nested-load-vicinity.scm`), per this project's
  "name bug regressions after the bug" convention.
- **Not applied**: using `shell-common.sh`'s `native_path` helper in
  `script-path-normalization.sh`. `native_path` converts via `cygpath -m`
  (forward-slash mixed style), but `%script-path`'s actual Windows output
  is backslash-separated and `write`-escaped — a format `native_path`
  wouldn't produce, so it can't build a matching expected value. The test's
  existing self-referential comparison (clean path vs. a `"../"`-laden path
  to the same file) sidesteps needing to predict the exact spelling at all,
  and is already verified passing on both `windows-arm-test` and
  `windows-x64-test` in PR #1733's CI run.

## Test plan

- [x] `zig build test` and `zig build test -Dgc-stress=true` green
- [x] `bash tests/scheme/run-all.sh` green (1962 pass, 0 fail)
- [x] `zig fmt --check` clean
- [x] Windows cross-compile (`-Dtarget=x86_64-windows`) and `zig build wasm` succeed
- [x] `tests/scheme/srfi/srfi59.scm` and the new
      `tests/scheme/srfi/srfi59-nested-load-vicinity.scm` pass standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)