### PR TITLE
Add SRFI 231 intervals + misc helpers (#1694 array family, phase 1a)

### DIFF
--- a/lib/srfi/231/intervals.sld
+++ b/lib/srfi/231/intervals.sld
@@ -1,0 +1,249 @@
+;;; SRFI 231 -- Intervals (phase 1a of #1694's SRFI 231 slice).
+;;;
+;;; SRFI 231 ("Intervals and Generalized Arrays") is 118 bindings total (101
+;;; procedures/parameters + 17 storage-class singletons) -- roughly 5-10x
+;;; any prior slice in this project, and structurally unrelated to SRFI
+;;; 25/164/63 already shipped for #1694: an interval is a genuinely new,
+;;; distinct opaque type (two parallel vectors of exact-integer lower/upper
+;;; bounds, arbitrary sign, not a vector of (lo . hi) pairs like 25's shape
+;;; nor plain zero-based sizes like 63's dims), and array?/array-set!'s
+;;; conventions (researched but not yet implemented -- later phases) turn
+;;; out to be their own hybrid of 25/164's and 63's rules, not identical to
+;;; either. Given the scale, SRFI 231 is being built across several slices:
+;;; this one covers only the interval layer (plus (srfi 231 misc)'s
+;;; permutation/translation helpers), which has zero dependency on arrays or
+;;; storage classes and is independently useful/testable. No bare
+;;; `(srfi 231)` library exists yet -- it will be assembled as a thin
+;;; re-export hub over these internal sub-libraries once every phase lands,
+;;; the same way `(srfi 160 base)` + per-tag files have no bare `(srfi 160)`
+;;; until a caller imports a specific typed sub-library.
+;;;
+;;; Every procedure's calling convention and error behavior below was
+;;; confirmed against the primary spec text (srfi.schemers.org/srfi-231)
+;;; and its official reference implementation before being written --
+;;; including two procedures (translation?, permutation?) whose exact
+;;; validation rule the spec states only in prose, not executable
+;;; pseudocode, and interval-fold-right's "all f evaluations before any
+;;; operator application" requirement, which is easy to implement as an
+;;; ordinary reverse fold without noticing that's insufficient (a naive
+;;; right-to-left walk interleaving f and operator calls would violate the
+;;; letter of the spec even though it 'looks' right for the common case
+;;; where f has no side effects).
+(define-library (srfi 231 intervals)
+  (import (scheme base) (srfi 1) (srfi 231 misc))
+  (export interval? make-interval interval-dimension
+          interval-lower-bound interval-upper-bound interval-width
+          interval-lower-bounds->list interval-upper-bounds->list
+          interval-lower-bounds->vector interval-upper-bounds->vector
+          interval-widths interval-volume interval-empty?
+          interval= interval-subset? interval-contains-multi-index?
+          interval-for-each interval-fold-left interval-fold-right
+          interval-dilate interval-translate interval-permute interval-scale
+          interval-intersect interval-cartesian-product interval-projections)
+  (begin
+
+    (define-record-type <interval>
+      (%make-interval lower upper)
+      interval?
+      (lower interval-lower-vec)
+      (upper interval-upper-vec))
+
+    (define (%validate-bounds! lower upper who)
+      (unless (= (vector-length lower) (vector-length upper))
+        (error (string-append who ": lower/upper bound vectors must have the same length") lower upper))
+      (let loop ((i 0))
+        (when (< i (vector-length lower))
+          (let ((lo (vector-ref lower i)) (hi (vector-ref upper i)))
+            (unless (and (integer? lo) (exact? lo) (integer? hi) (exact? hi))
+              (error (string-append who ": bounds must be exact integers") lo hi))
+            (unless (<= lo hi)
+              (error (string-append who ": lower bound must not exceed upper bound on axis") i lo hi)))
+          (loop (+ i 1)))))
+
+    ;; Deep-copies -- an interval must not retain a dependence on the
+    ;; caller's own (mutable, otherwise-visible) bound vectors, the same
+    ;; discipline as SRFI 25's shape (a CodeRabbit-caught bug there).
+    (define (%build-interval lower upper who)
+      (%validate-bounds! lower upper who)
+      (%make-interval (vector-copy lower) (vector-copy upper)))
+
+    (define (make-interval arg1 . rest)
+      (if (null? rest)
+          (begin
+            (unless (vector? arg1) (error "make-interval: argument must be a vector" arg1))
+            (%build-interval (make-vector (vector-length arg1) 0) arg1 "make-interval"))
+          (%build-interval arg1 (car rest) "make-interval")))
+
+    (define (interval-dimension interval) (vector-length (interval-lower-vec interval)))
+
+    (define (%check-axis! interval i who)
+      (unless (and (integer? i) (exact? i) (<= 0 i) (< i (interval-dimension interval)))
+        (error (string-append who ": axis index out of range") interval i)))
+
+    (define (interval-lower-bound interval i)
+      (%check-axis! interval i "interval-lower-bound")
+      (vector-ref (interval-lower-vec interval) i))
+
+    (define (interval-upper-bound interval i)
+      (%check-axis! interval i "interval-upper-bound")
+      (vector-ref (interval-upper-vec interval) i))
+
+    (define (interval-width interval i)
+      (%check-axis! interval i "interval-width")
+      (- (vector-ref (interval-upper-vec interval) i) (vector-ref (interval-lower-vec interval) i)))
+
+    (define (interval-lower-bounds->list interval) (vector->list (interval-lower-vec interval)))
+    (define (interval-upper-bounds->list interval) (vector->list (interval-upper-vec interval)))
+    (define (interval-lower-bounds->vector interval) (vector-copy (interval-lower-vec interval)))
+    (define (interval-upper-bounds->vector interval) (vector-copy (interval-upper-vec interval)))
+
+    (define (interval-widths interval)
+      (vector-map - (interval-upper-vec interval) (interval-lower-vec interval)))
+
+    (define (interval-volume interval)
+      (let ((w (interval-widths interval)))
+        (let loop ((i 0) (acc 1))
+          (if (= i (vector-length w)) acc (loop (+ i 1) (* acc (vector-ref w i)))))))
+
+    (define (interval-empty? interval) (zero? (interval-volume interval)))
+
+    (define (interval= i1 i2)
+      (and (equal? (interval-lower-vec i1) (interval-lower-vec i2))
+           (equal? (interval-upper-vec i1) (interval-upper-vec i2))))
+
+    (define (interval-subset? i1 i2)
+      (and (= (interval-dimension i1) (interval-dimension i2))
+           (let loop ((k 0))
+             (or (= k (interval-dimension i1))
+                 (and (<= (interval-lower-bound i2 k) (interval-lower-bound i1 k))
+                      (<= (interval-upper-bound i1 k) (interval-upper-bound i2 k))
+                      (loop (+ k 1)))))))
+
+    (define (interval-contains-multi-index? interval . multi-index)
+      (let ((lo (interval-lower-vec interval)) (up (interval-upper-vec interval)))
+        (and (= (length multi-index) (vector-length lo))
+             (let loop ((i 0) (xs multi-index))
+               (or (null? xs)
+                   (and (<= (vector-ref lo i) (car xs)) (< (car xs) (vector-ref up i))
+                        (loop (+ i 1) (cdr xs))))))))
+
+    ;; General d-dimensional nested traversal in lexicographic order. proc
+    ;; receives each multi-index as a LIST; public callers apply it to their
+    ;; own procedure via `apply` so f/operator see separate positional
+    ;; index arguments, matching the spec's convention everywhere. A
+    ;; zero-dimensional interval (both vectors empty) calls proc exactly
+    ;; once with '() -- a thunk call once `apply`-ed. Any axis with
+    ;; lo=hi contributes zero iterations, so an empty interval calls
+    ;; proc zero times overall, both matching spec exactly with no
+    ;; special-casing.
+    (define (%interval-for-each-indices lower upper proc)
+      (let ((d (vector-length lower)))
+        (define (go axis acc)
+          (if (= axis d)
+              (proc (reverse acc))
+              (let ((lo (vector-ref lower axis)) (hi (vector-ref upper axis)))
+                (let loop ((i lo))
+                  (when (< i hi)
+                    (go (+ axis 1) (cons i acc))
+                    (loop (+ i 1)))))))
+        (go 0 '())))
+
+    (define (interval-for-each f interval)
+      (%interval-for-each-indices (interval-lower-vec interval) (interval-upper-vec interval)
+                                   (lambda (indices) (apply f indices))))
+
+    (define (interval-fold-left f operator identity interval)
+      (let ((acc identity))
+        (%interval-for-each-indices (interval-lower-vec interval) (interval-upper-vec interval)
+                                     (lambda (indices) (set! acc (operator acc (apply f indices)))))
+        acc))
+
+    ;; Per spec, interval-fold-right must complete ALL f evaluations before
+    ;; applying operator to any of them -- not just visit indices in
+    ;; reverse order interleaved with operator, which looks equivalent only
+    ;; when f is pure. Collecting via cons during one lex-order traversal
+    ;; yields the results in REVERSE lex order for free; a plain left walk
+    ;; over that reversed list, applying (operator elem acc), is then
+    ;; algebraically identical to a true right fold over the lex-ordered
+    ;; results (verified by hand-expansion against the spec's own
+    ;; 0-dimensional formula, which falls out with no special-casing).
+    (define (interval-fold-right f operator identity interval)
+      (let ((results '()))
+        (%interval-for-each-indices (interval-lower-vec interval) (interval-upper-vec interval)
+                                     (lambda (indices) (set! results (cons (apply f indices) results))))
+        (let loop ((xs results) (acc identity))
+          (if (null? xs) acc (loop (cdr xs) (operator (car xs) acc))))))
+
+    (define (interval-dilate interval lower-diffs upper-diffs)
+      (%build-interval (vector-map + (interval-lower-vec interval) lower-diffs)
+                        (vector-map + (interval-upper-vec interval) upper-diffs)
+                        "interval-dilate"))
+
+    (define (interval-translate interval translation)
+      (unless (translation? translation)
+        (error "interval-translate: not a valid translation" translation))
+      (%build-interval (vector-map + (interval-lower-vec interval) translation)
+                        (vector-map + (interval-upper-vec interval) translation)
+                        "interval-translate"))
+
+    ;; If the permutation is (p0,...,pd-1), result axis i has bounds
+    ;; [l_{pi},u_{pi}) of the original interval -- per the spec's own
+    ;; exact convention statement.
+    (define (interval-permute interval permutation)
+      (unless (permutation? permutation)
+        (error "interval-permute: not a valid permutation" permutation))
+      (let* ((lo (interval-lower-vec interval)) (up (interval-upper-vec interval)) (d (vector-length lo))
+             (new-lo (make-vector d 0)) (new-up (make-vector d 0)))
+        (let loop ((i 0))
+          (when (< i d)
+            (let ((p (vector-ref permutation i)))
+              (vector-set! new-lo i (vector-ref lo p))
+              (vector-set! new-up i (vector-ref up p)))
+            (loop (+ i 1))))
+        (%build-interval new-lo new-up "interval-permute")))
+
+    (define (interval-scale interval scales)
+      (let* ((lo (interval-lower-vec interval)) (up (interval-upper-vec interval)) (d (vector-length lo)))
+        (let loop ((i 0))
+          (when (< i d)
+            (unless (zero? (vector-ref lo i))
+              (error "interval-scale: interval must have all-zero lower bounds" interval))
+            (loop (+ i 1))))
+        (%build-interval (make-vector d 0)
+                          (vector-map (lambda (u s) (ceiling (/ u s))) up scales)
+                          "interval-scale")))
+
+    ;; Returns #f (not an error) when no valid intersection exists -- an
+    ;; explicit, spec-sanctioned result, so this bypasses %build-interval's
+    ;; error-raising validation and checks componentwise itself.
+    (define (interval-intersect interval . intervals)
+      (let* ((all (cons interval intervals))
+             (d (interval-dimension interval))
+             (new-lo (make-vector d 0))
+             (new-up (make-vector d 0)))
+        (let loop ((i 0))
+          (when (< i d)
+            (vector-set! new-lo i (apply max (map (lambda (iv) (interval-lower-bound iv i)) all)))
+            (vector-set! new-up i (apply min (map (lambda (iv) (interval-upper-bound iv i)) all)))
+            (loop (+ i 1))))
+        (let check ((i 0))
+          (cond
+           ((= i d) (%make-interval new-lo new-up))
+           ((<= (vector-ref new-lo i) (vector-ref new-up i)) (check (+ i 1)))
+           (else #f)))))
+
+    (define (interval-cartesian-product . intervals)
+      (%make-interval (list->vector (apply append (map interval-lower-bounds->list intervals)))
+                       (list->vector (apply append (map interval-upper-bounds->list intervals)))))
+
+    (define (interval-projections interval right-dimension)
+      (let ((d (interval-dimension interval)))
+        (unless (and (integer? right-dimension) (exact? right-dimension)
+                     (<= 0 right-dimension) (<= right-dimension d))
+          (error "interval-projections: right-dimension out of range" interval right-dimension))
+        (let* ((left-dimension (- d right-dimension))
+               (lowers (interval-lower-bounds->list interval))
+               (uppers (interval-upper-bounds->list interval)))
+          (values
+           (%make-interval (list->vector (take lowers left-dimension)) (list->vector (take uppers left-dimension)))
+           (%make-interval (list->vector (drop lowers left-dimension)) (list->vector (drop uppers left-dimension)))))))))

--- a/lib/srfi/231/intervals.sld
+++ b/lib/srfi/231/intervals.sld
@@ -68,11 +68,13 @@
       (%make-interval (vector-copy lower) (vector-copy upper)))
 
     (define (make-interval arg1 . rest)
-      (if (null? rest)
-          (begin
-            (unless (vector? arg1) (error "make-interval: argument must be a vector" arg1))
-            (%build-interval (make-vector (vector-length arg1) 0) arg1 "make-interval"))
-          (%build-interval arg1 (car rest) "make-interval")))
+      (cond
+       ((null? rest)
+        (unless (vector? arg1) (error "make-interval: argument must be a vector" arg1))
+        (%build-interval (make-vector (vector-length arg1) 0) arg1 "make-interval"))
+       ((null? (cdr rest))
+        (%build-interval arg1 (car rest) "make-interval"))
+       (else (error "make-interval: too many arguments" arg1 rest))))
 
     (define (interval-dimension interval) (vector-length (interval-lower-vec interval)))
 
@@ -111,21 +113,28 @@
       (and (equal? (interval-lower-vec i1) (interval-lower-vec i2))
            (equal? (interval-upper-vec i1) (interval-upper-vec i2))))
 
+    ;; Per spec, this "assumes" i1 and i2 have the same dimension -- a
+    ;; mismatch is an error, not a normal #f comparison result (#f is
+    ;; reserved for same-dimension intervals that fail the bound check).
     (define (interval-subset? i1 i2)
-      (and (= (interval-dimension i1) (interval-dimension i2))
-           (let loop ((k 0))
-             (or (= k (interval-dimension i1))
-                 (and (<= (interval-lower-bound i2 k) (interval-lower-bound i1 k))
-                      (<= (interval-upper-bound i1 k) (interval-upper-bound i2 k))
-                      (loop (+ k 1)))))))
+      (unless (= (interval-dimension i1) (interval-dimension i2))
+        (error "interval-subset?: intervals must have the same dimension" i1 i2))
+      (let loop ((k 0))
+        (or (= k (interval-dimension i1))
+            (and (<= (interval-lower-bound i2 k) (interval-lower-bound i1 k))
+                 (<= (interval-upper-bound i1 k) (interval-upper-bound i2 k))
+                 (loop (+ k 1))))))
 
     (define (interval-contains-multi-index? interval . multi-index)
       (let ((lo (interval-lower-vec interval)) (up (interval-upper-vec interval)))
         (and (= (length multi-index) (vector-length lo))
              (let loop ((i 0) (xs multi-index))
                (or (null? xs)
-                   (and (<= (vector-ref lo i) (car xs)) (< (car xs) (vector-ref up i))
-                        (loop (+ i 1) (cdr xs))))))))
+                   (begin
+                     (unless (and (integer? (car xs)) (exact? (car xs)))
+                       (error "interval-contains-multi-index?: multi-index entries must be exact integers" (car xs)))
+                     (and (<= (vector-ref lo i) (car xs)) (< (car xs) (vector-ref up i))
+                          (loop (+ i 1) (cdr xs)))))))))
 
     ;; General d-dimensional nested traversal in lexicographic order. proc
     ;; receives each multi-index as a LIST; public callers apply it to their
@@ -174,7 +183,19 @@
         (let loop ((xs results) (acc identity))
           (if (null? xs) acc (loop (cdr xs) (operator (car xs) acc))))))
 
+    ;; vector-map stops at the shortest input on a length mismatch (R7RS,
+    ;; matching `map`) rather than erroring, so a diffs/translation/scales/
+    ;; permutation vector shorter or longer than the interval's own
+    ;; dimension would otherwise silently produce a wrong-rank result
+    ;; instead of failing loudly -- validate lengths explicitly everywhere
+    ;; below rather than relying on vector-map to notice.
+    (define (%check-dimension-match! v interval who)
+      (unless (= (vector-length v) (interval-dimension interval))
+        (error (string-append who ": vector must match the interval's dimension") interval v)))
+
     (define (interval-dilate interval lower-diffs upper-diffs)
+      (%check-dimension-match! lower-diffs interval "interval-dilate")
+      (%check-dimension-match! upper-diffs interval "interval-dilate")
       (%build-interval (vector-map + (interval-lower-vec interval) lower-diffs)
                         (vector-map + (interval-upper-vec interval) upper-diffs)
                         "interval-dilate"))
@@ -182,6 +203,7 @@
     (define (interval-translate interval translation)
       (unless (translation? translation)
         (error "interval-translate: not a valid translation" translation))
+      (%check-dimension-match! translation interval "interval-translate")
       (%build-interval (vector-map + (interval-lower-vec interval) translation)
                         (vector-map + (interval-upper-vec interval) translation)
                         "interval-translate"))
@@ -192,6 +214,7 @@
     (define (interval-permute interval permutation)
       (unless (permutation? permutation)
         (error "interval-permute: not a valid permutation" permutation))
+      (%check-dimension-match! permutation interval "interval-permute")
       (let* ((lo (interval-lower-vec interval)) (up (interval-upper-vec interval)) (d (vector-length lo))
              (new-lo (make-vector d 0)) (new-up (make-vector d 0)))
         (let loop ((i 0))
@@ -203,6 +226,7 @@
         (%build-interval new-lo new-up "interval-permute")))
 
     (define (interval-scale interval scales)
+      (%check-dimension-match! scales interval "interval-scale")
       (let* ((lo (interval-lower-vec interval)) (up (interval-upper-vec interval)) (d (vector-length lo)))
         (let loop ((i 0))
           (when (< i d)
@@ -215,22 +239,29 @@
 
     ;; Returns #f (not an error) when no valid intersection exists -- an
     ;; explicit, spec-sanctioned result, so this bypasses %build-interval's
-    ;; error-raising validation and checks componentwise itself.
+    ;; error-raising validation and checks componentwise itself. All
+    ;; intervals must share one dimension first, though -- otherwise a
+    ;; shorter first interval would silently limit the loop below to its
+    ;; own (smaller) axis count, never even looking at a later interval's
+    ;; extra axes rather than rejecting the mismatch.
     (define (interval-intersect interval . intervals)
       (let* ((all (cons interval intervals))
-             (d (interval-dimension interval))
-             (new-lo (make-vector d 0))
-             (new-up (make-vector d 0)))
-        (let loop ((i 0))
-          (when (< i d)
-            (vector-set! new-lo i (apply max (map (lambda (iv) (interval-lower-bound iv i)) all)))
-            (vector-set! new-up i (apply min (map (lambda (iv) (interval-upper-bound iv i)) all)))
-            (loop (+ i 1))))
-        (let check ((i 0))
-          (cond
-           ((= i d) (%make-interval new-lo new-up))
-           ((<= (vector-ref new-lo i) (vector-ref new-up i)) (check (+ i 1)))
-           (else #f)))))
+             (d (interval-dimension interval)))
+        (for-each (lambda (iv)
+                    (unless (= (interval-dimension iv) d)
+                      (error "interval-intersect: all intervals must have the same dimension" all)))
+                  all)
+        (let ((new-lo (make-vector d 0)) (new-up (make-vector d 0)))
+          (let loop ((i 0))
+            (when (< i d)
+              (vector-set! new-lo i (apply max (map (lambda (iv) (interval-lower-bound iv i)) all)))
+              (vector-set! new-up i (apply min (map (lambda (iv) (interval-upper-bound iv i)) all)))
+              (loop (+ i 1))))
+          (let check ((i 0))
+            (cond
+             ((= i d) (%make-interval new-lo new-up))
+             ((<= (vector-ref new-lo i) (vector-ref new-up i)) (check (+ i 1)))
+             (else #f))))))
 
     (define (interval-cartesian-product . intervals)
       (%make-interval (list->vector (apply append (map interval-lower-bounds->list intervals)))

--- a/lib/srfi/231/misc.sld
+++ b/lib/srfi/231/misc.sld
@@ -37,8 +37,23 @@
                           (not (vector-ref seen x))
                           (begin (vector-set! seen x #t) (loop (+ i 1))))))))))
 
-    ;; (index-rotate 5 3) => #(3 4 0 1 2)
+    (define (%check-nonneg-exact-integer! n who)
+      (unless (and (integer? n) (exact? n) (>= n 0))
+        (error (string-append who ": n must be a nonnegative exact integer") n)))
+
+    (define (%check-pos-exact-integer! n who)
+      (unless (and (integer? n) (exact? n) (> n 0))
+        (error (string-append who ": n must be a positive exact integer") n)))
+
+    (define (%check-in-range! k lo hi who)
+      (unless (and (integer? k) (exact? k) (<= lo k) (<= k hi))
+        (error (string-append who ": index out of range") k lo hi)))
+
+    ;; (index-rotate 5 3) => #(3 4 0 1 2). Per spec, k is inclusive of n
+    ;; itself (0 <= k <= n) -- (index-rotate n n) is the identity permutation.
     (define (index-rotate n k)
+      (%check-nonneg-exact-integer! n "index-rotate")
+      (%check-in-range! k 0 n "index-rotate")
       (let ((v (make-vector n 0)))
         (let loop ((i 0))
           (when (< i n)
@@ -48,6 +63,8 @@
 
     ;; (index-first 5 3) => #(3 0 1 2 4)
     (define (index-first n k)
+      (%check-pos-exact-integer! n "index-first")
+      (%check-in-range! k 0 (- n 1) "index-first")
       (let ((v (make-vector n 0)) (pos 1))
         (vector-set! v 0 k)
         (let loop ((i 0))
@@ -60,6 +77,8 @@
 
     ;; (index-last 5 3) => #(0 1 2 4 3)
     (define (index-last n k)
+      (%check-pos-exact-integer! n "index-last")
+      (%check-in-range! k 0 (- n 1) "index-last")
       (let ((v (make-vector n 0)) (pos 0))
         (let loop ((i 0))
           (when (< i n)
@@ -72,6 +91,9 @@
 
     ;; (index-swap 5 3 0) => #(3 1 2 0 4)
     (define (index-swap n i j)
+      (%check-pos-exact-integer! n "index-swap")
+      (%check-in-range! i 0 (- n 1) "index-swap")
+      (%check-in-range! j 0 (- n 1) "index-swap")
       (let ((v (make-vector n 0)))
         (let loop ((k 0))
           (when (< k n)

--- a/lib/srfi/231/misc.sld
+++ b/lib/srfi/231/misc.sld
@@ -1,0 +1,83 @@
+;;; SRFI 231 -- Miscellaneous procedures (permutation/translation vectors).
+;;;
+;;; Phase 1a of #1694's SRFI 231 slice (see lib/srfi/231/intervals.sld for
+;;; the overall roadmap note). These 6 procedures are pure vector utilities
+;;; with zero dependency on intervals -- kept as their own tiny library
+;;; since later array-transform phases (array-inner-product, array-block)
+;;; need index-rotate/index-first/index-last directly without pulling in
+;;; the whole interval layer, matching the spec's own "Miscellaneous
+;;; procedures" section which precedes "Intervals" in its own document
+;;; structure.
+;;;
+;;; translation?/permutation? per spec: a translation is "a vector of exact
+;;; integers" (any length, any sign); a permutation of dimension n is "a
+;;; vector whose entries are the exact integers 0,1,...,n-1, each occurring
+;;; once, in any order" -- confirmed via direct primary-source fetch since
+;;; neither is spelled out as executable pseudocode in the spec text itself.
+(define-library (srfi 231 misc)
+  (import (scheme base))
+  (export translation? permutation? index-rotate index-first index-last index-swap)
+  (begin
+
+    (define (%vector-every pred v)
+      (let loop ((i 0))
+        (or (= i (vector-length v))
+            (and (pred (vector-ref v i)) (loop (+ i 1))))))
+
+    (define (translation? object)
+      (and (vector? object) (%vector-every (lambda (x) (and (integer? x) (exact? x))) object)))
+
+    (define (permutation? object)
+      (and (vector? object)
+           (let* ((n (vector-length object)) (seen (make-vector n #f)))
+             (let loop ((i 0))
+               (or (= i n)
+                   (let ((x (vector-ref object i)))
+                     (and (integer? x) (exact? x) (<= 0 x) (< x n)
+                          (not (vector-ref seen x))
+                          (begin (vector-set! seen x #t) (loop (+ i 1))))))))))
+
+    ;; (index-rotate 5 3) => #(3 4 0 1 2)
+    (define (index-rotate n k)
+      (let ((v (make-vector n 0)))
+        (let loop ((i 0))
+          (when (< i n)
+            (vector-set! v i (modulo (+ i k) n))
+            (loop (+ i 1))))
+        v))
+
+    ;; (index-first 5 3) => #(3 0 1 2 4)
+    (define (index-first n k)
+      (let ((v (make-vector n 0)) (pos 1))
+        (vector-set! v 0 k)
+        (let loop ((i 0))
+          (when (< i n)
+            (unless (= i k)
+              (vector-set! v pos i)
+              (set! pos (+ pos 1)))
+            (loop (+ i 1))))
+        v))
+
+    ;; (index-last 5 3) => #(0 1 2 4 3)
+    (define (index-last n k)
+      (let ((v (make-vector n 0)) (pos 0))
+        (let loop ((i 0))
+          (when (< i n)
+            (unless (= i k)
+              (vector-set! v pos i)
+              (set! pos (+ pos 1)))
+            (loop (+ i 1))))
+        (vector-set! v (- n 1) k)
+        v))
+
+    ;; (index-swap 5 3 0) => #(3 1 2 0 4)
+    (define (index-swap n i j)
+      (let ((v (make-vector n 0)))
+        (let loop ((k 0))
+          (when (< k n)
+            (vector-set! v k k)
+            (loop (+ k 1))))
+        (let ((vi (vector-ref v i)))
+          (vector-set! v i (vector-ref v j))
+          (vector-set! v j vi))
+        v))))

--- a/tests/scheme/srfi/srfi231-intervals.scm
+++ b/tests/scheme/srfi/srfi231-intervals.scm
@@ -25,6 +25,19 @@
 (test-equal (vector 0 1 2 4 3) (index-last 5 3))
 (test-equal (vector 3 1 2 0 4) (index-swap 5 3 0))
 
+;;; --- index-* preconditions are validated, including the asymmetric
+;;; inclusive/exclusive boundary: index-rotate's k may equal n (identity
+;;; permutation), but index-first/-last/-swap's k/i/j must be strictly
+;;; less than n ---
+(test-equal (vector 0 1 2) (index-rotate 3 3))
+(test-equal #t (guard (e (#t #t)) (index-rotate 3 -1) #f))
+(test-equal #t (guard (e (#t #t)) (index-rotate 3 4) #f))
+(test-equal #t (guard (e (#t #t)) (index-first 3 -1) #f))
+(test-equal #t (guard (e (#t #t)) (index-first 3 3) #f))
+(test-equal #t (guard (e (#t #t)) (index-last 3 -1) #f))
+(test-equal #t (guard (e (#t #t)) (index-last 3 3) #f))
+(test-equal #t (guard (e (#t #t)) (index-swap 3 0 5) #f))
+
 ;;; --- construction: both 1-arg and 2-arg forms ---
 (test-equal 2 (interval-dimension (make-interval (vector 3 4))))
 (test-equal '(0 0) (interval-lower-bounds->list (make-interval (vector 3 4))))
@@ -43,6 +56,10 @@
 (test-equal #t (guard (e (#t #t)) (make-interval (vector 1.5)) #f))
 (test-equal #t (guard (e (#t #t))
                   (interval-lower-bound (make-interval (vector 3 4)) 5) #f))
+;; make-interval takes at most 2 arguments -- a 3rd is rejected, not
+;; silently discarded
+(test-equal #t (guard (e (#t #t))
+                  (make-interval (vector 0) (vector 1) (vector 2)) #f))
 
 ;;; --- an interval does not retain a dependence on the caller's vector ---
 (let* ((v (vector 5 5)) (c (make-interval v)))
@@ -66,12 +83,17 @@
       (inner (make-interval (vector 1 1) (vector 2 2))))
   (test-equal #t (interval-subset? inner outer))
   (test-equal #f (interval-subset? outer inner)))
+;; per spec, mismatched dimensions are an error, not a normal #f result
+(test-equal #t (guard (e (#t #t))
+                  (interval-subset? (make-interval (vector 2)) (make-interval (vector 2 3))) #f))
 
 ;;; --- interval-contains-multi-index? ---
 (let ((b (make-interval (vector -2 -2) (vector 2 2))))
   (test-equal #t (interval-contains-multi-index? b -2 -2))
   (test-equal #f (interval-contains-multi-index? b 2 0))
-  (test-equal #t (interval-contains-multi-index? b 0 0)))
+  (test-equal #t (interval-contains-multi-index? b 0 0))
+  ;; a multi-index must consist of exact integers
+  (test-equal #t (guard (e (#t #t)) (interval-contains-multi-index? b 1.5 0) #f)))
 
 ;;; --- interval-for-each: lexicographic order, separate positional args ---
 (let ((visits '()))
@@ -100,13 +122,18 @@
 (let* ((b (make-interval (vector -2 -2) (vector 2 2)))
        (dil (interval-dilate b (vector -1 -1) (vector 1 1))))
   (test-equal '(-3 -3) (interval-lower-bounds->list dil))
-  (test-equal '(3 3) (interval-upper-bounds->list dil)))
+  (test-equal '(3 3) (interval-upper-bounds->list dil))
+  ;; diff vectors of the wrong length are rejected, not silently truncated
+  ;; by vector-map's shortest-wins behavior
+  (test-equal #t (guard (e (#t #t)) (interval-dilate b (vector -1) (vector 1 1)) #f))
+  (test-equal #t (guard (e (#t #t)) (interval-dilate b (vector -1 -1) (vector 1 1 1)) #f)))
 
 (let* ((b (make-interval (vector -2 -2) (vector 2 2)))
        (tr (interval-translate b (vector 10 20))))
   (test-equal '(8 18) (interval-lower-bounds->list tr))
   (test-equal '(12 22) (interval-upper-bounds->list tr))
-  (test-equal #t (guard (e (#t #t)) (interval-translate b "not a translation") #f)))
+  (test-equal #t (guard (e (#t #t)) (interval-translate b "not a translation") #f))
+  (test-equal #t (guard (e (#t #t)) (interval-translate b (vector 1 2 3)) #f)))
 
 ;; matches the spec's own permutation convention: result axis i has bounds
 ;; of the original's axis permutation[i]
@@ -114,10 +141,14 @@
   (test-equal '(30 10 20) (interval-upper-bounds->list pm)))
 (test-equal #t (guard (e (#t #t))
                   (interval-permute (make-interval (vector 1 2)) (vector 5 5)) #f))
+(test-equal #t (guard (e (#t #t))
+                  (interval-permute (make-interval (vector 1 2 3)) (vector 1 0)) #f))
 
 (test-equal '(4) (interval-upper-bounds->list (interval-scale (make-interval (vector 10)) (vector 3))))
 (test-equal #t (guard (e (#t #t))
                   (interval-scale (make-interval (vector -2 -2) (vector 2 2)) (vector 1 1)) #f))
+(test-equal #t (guard (e (#t #t))
+                  (interval-scale (make-interval (vector 10 10)) (vector 2)) #f))
 
 ;;; --- interval-intersect ---
 (let ((i1 (make-interval (vector 0 0) (vector 5 5)))
@@ -126,7 +157,10 @@
   (let ((ix (interval-intersect i1 i2)))
     (test-equal '(3 3) (interval-lower-bounds->list ix))
     (test-equal '(5 5) (interval-upper-bounds->list ix)))
-  (test-equal #f (interval-intersect i1 i3)))
+  (test-equal #f (interval-intersect i1 i3))
+  ;; mismatched dimensions must be rejected, not silently limited to the
+  ;; first interval's own (possibly smaller) axis count
+  (test-equal #t (guard (e (#t #t)) (interval-intersect (make-interval (vector 5)) i1) #f)))
 
 ;;; --- interval-cartesian-product ---
 (let ((cp (interval-cartesian-product (make-interval (vector 2 3)) (make-interval (vector 5)))))

--- a/tests/scheme/srfi/srfi231-intervals.scm
+++ b/tests/scheme/srfi/srfi231-intervals.scm
@@ -1,0 +1,145 @@
+;; SRFI 231 (Intervals and Generalized Arrays) tests -- phase 1a: intervals
+;; and the (srfi 231 misc) permutation/translation helpers. Arrays and
+;; storage classes are later phases of this multi-slice SRFI, tracked under
+;; issue #1694; (srfi 231) itself is not yet an importable bare library.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi231-intervals.scm
+
+(import (scheme base) (scheme process-context) (srfi 64)
+        (srfi 231 misc) (srfi 231 intervals))
+
+(test-begin "srfi-231-intervals")
+
+;;; --- (srfi 231 misc): permutation/translation predicates and index constructors ---
+(test-equal #t (permutation? (vector 0 1 2)))
+(test-equal #t (permutation? (vector 1 0 2)))
+(test-equal #f (permutation? (vector 0 0 2)))
+(test-equal #f (permutation? (vector 0 1 3)))
+(test-equal #f (permutation? "not a vector"))
+(test-equal #t (translation? (vector 1 -2 3)))
+(test-equal #t (translation? (vector)))
+(test-equal #f (translation? (vector 1.5)))
+(test-equal #f (translation? "not a vector"))
+;; worked examples straight from the spec
+(test-equal (vector 3 4 0 1 2) (index-rotate 5 3))
+(test-equal (vector 3 0 1 2 4) (index-first 5 3))
+(test-equal (vector 0 1 2 4 3) (index-last 5 3))
+(test-equal (vector 3 1 2 0 4) (index-swap 5 3 0))
+
+;;; --- construction: both 1-arg and 2-arg forms ---
+(test-equal 2 (interval-dimension (make-interval (vector 3 4))))
+(test-equal '(0 0) (interval-lower-bounds->list (make-interval (vector 3 4))))
+(test-equal '(3 4) (interval-upper-bounds->list (make-interval (vector 3 4))))
+
+(let ((b (make-interval (vector -2 -2) (vector 2 2))))
+  (test-equal '(-2 -2) (interval-lower-bounds->list b))
+  (test-equal '(2 2) (interval-upper-bounds->list b))
+  (test-equal -2 (interval-lower-bound b 0))
+  (test-equal 2 (interval-upper-bound b 1))
+  (test-equal 4 (interval-width b 0)))
+
+;;; --- construction errors are catchable ---
+(test-equal #t (guard (e (#t #t)) (make-interval (vector -1 2)) #f))
+(test-equal #t (guard (e (#t #t)) (make-interval (vector 5 5) (vector 3 3)) #f))
+(test-equal #t (guard (e (#t #t)) (make-interval (vector 1.5)) #f))
+(test-equal #t (guard (e (#t #t))
+                  (interval-lower-bound (make-interval (vector 3 4)) 5) #f))
+
+;;; --- an interval does not retain a dependence on the caller's vector ---
+(let* ((v (vector 5 5)) (c (make-interval v)))
+  (vector-set! v 0 999)
+  (test-equal '(5 5) (interval-upper-bounds->list c)))
+
+;;; --- zero-dimensional and empty intervals ---
+(let ((z (make-interval (vector))))
+  (test-equal 0 (interval-dimension z))
+  (test-equal 1 (interval-volume z))
+  (test-equal #f (interval-empty? z)))
+
+(let ((e (make-interval (vector 3 3) (vector 3 5))))
+  (test-equal #t (interval-empty? e))
+  (test-equal 0 (interval-volume e)))
+
+;;; --- interval= / interval-subset? ---
+(test-equal #t (interval= (make-interval (vector 3 4)) (make-interval (vector 3 4))))
+(test-equal #f (interval= (make-interval (vector 3 4)) (make-interval (vector 4 3))))
+(let ((outer (make-interval (vector -2 -2) (vector 2 2)))
+      (inner (make-interval (vector 1 1) (vector 2 2))))
+  (test-equal #t (interval-subset? inner outer))
+  (test-equal #f (interval-subset? outer inner)))
+
+;;; --- interval-contains-multi-index? ---
+(let ((b (make-interval (vector -2 -2) (vector 2 2))))
+  (test-equal #t (interval-contains-multi-index? b -2 -2))
+  (test-equal #f (interval-contains-multi-index? b 2 0))
+  (test-equal #t (interval-contains-multi-index? b 0 0)))
+
+;;; --- interval-for-each: lexicographic order, separate positional args ---
+(let ((visits '()))
+  (interval-for-each (lambda (i j) (set! visits (cons (list i j) visits))) (make-interval (vector 2 2)))
+  (test-equal '((0 0) (0 1) (1 0) (1 1)) (reverse visits)))
+
+;;; --- interval-fold-left / interval-fold-right: order-sensitive (cons)
+;;; so a left/right mixup would be caught immediately ---
+(let ((d (make-interval (vector 3))))
+  (test-equal '(2 1 0) (interval-fold-left (lambda (i) i) (lambda (acc x) (cons x acc)) '() d))
+  (test-equal '(0 1 2) (interval-fold-right (lambda (i) i) (lambda (x acc) (cons x acc)) '() d)))
+
+;; 0-dimensional fold cases match the spec's own formulas exactly
+(let ((z (make-interval (vector))))
+  (test-equal '(id 42) (interval-fold-left (lambda () 42) (lambda (acc x) (list acc x)) 'id z))
+  (test-equal '(42 id) (interval-fold-right (lambda () 42) (lambda (x acc) (list x acc)) 'id z)))
+
+;; empty-interval fold cases: f must never be called, identity returned untouched
+(let ((e (make-interval (vector 3 3) (vector 3 5))))
+  (test-equal 'identity-value
+    (interval-fold-left (lambda (i j) (error "should not be called")) (lambda (acc x) x) 'identity-value e))
+  (test-equal 'identity-value
+    (interval-fold-right (lambda (i j) (error "should not be called")) (lambda (x acc) x) 'identity-value e)))
+
+;;; --- interval-dilate / interval-translate / interval-permute / interval-scale ---
+(let* ((b (make-interval (vector -2 -2) (vector 2 2)))
+       (dil (interval-dilate b (vector -1 -1) (vector 1 1))))
+  (test-equal '(-3 -3) (interval-lower-bounds->list dil))
+  (test-equal '(3 3) (interval-upper-bounds->list dil)))
+
+(let* ((b (make-interval (vector -2 -2) (vector 2 2)))
+       (tr (interval-translate b (vector 10 20))))
+  (test-equal '(8 18) (interval-lower-bounds->list tr))
+  (test-equal '(12 22) (interval-upper-bounds->list tr))
+  (test-equal #t (guard (e (#t #t)) (interval-translate b "not a translation") #f)))
+
+;; matches the spec's own permutation convention: result axis i has bounds
+;; of the original's axis permutation[i]
+(let ((pm (interval-permute (make-interval (vector 10 20 30)) (vector 2 0 1))))
+  (test-equal '(30 10 20) (interval-upper-bounds->list pm)))
+(test-equal #t (guard (e (#t #t))
+                  (interval-permute (make-interval (vector 1 2)) (vector 5 5)) #f))
+
+(test-equal '(4) (interval-upper-bounds->list (interval-scale (make-interval (vector 10)) (vector 3))))
+(test-equal #t (guard (e (#t #t))
+                  (interval-scale (make-interval (vector -2 -2) (vector 2 2)) (vector 1 1)) #f))
+
+;;; --- interval-intersect ---
+(let ((i1 (make-interval (vector 0 0) (vector 5 5)))
+      (i2 (make-interval (vector 3 3) (vector 8 8)))
+      (i3 (make-interval (vector 100 100) (vector 200 200))))
+  (let ((ix (interval-intersect i1 i2)))
+    (test-equal '(3 3) (interval-lower-bounds->list ix))
+    (test-equal '(5 5) (interval-upper-bounds->list ix)))
+  (test-equal #f (interval-intersect i1 i3)))
+
+;;; --- interval-cartesian-product ---
+(let ((cp (interval-cartesian-product (make-interval (vector 2 3)) (make-interval (vector 5)))))
+  (test-equal 3 (interval-dimension cp))
+  (test-equal '(2 3 5) (interval-upper-bounds->list cp)))
+
+;;; --- interval-projections: the spec's own worked example, verbatim ---
+(let-values (((left right) (interval-projections (make-interval (vector 2 3 1 5 4)) 2)))
+  (test-equal '(2 3 1) (interval-upper-bounds->list left))
+  (test-equal '(5 4) (interval-upper-bounds->list right)))
+(test-equal #t (guard (e (#t #t))
+                  (interval-projections (make-interval (vector 2 3)) 5) #f))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-231-intervals")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

First of several slices implementing SRFI 231 ("Intervals and Generalized Arrays") — the last remaining piece of issue #1694's array family, following SRFI 25 (#1739), SRFI 164 (#1740), and SRFI 63 (#1747).

**Scale note**: SRFI 231 is 118 bindings total (101 procedures/parameters + 17 storage-class singletons) — roughly 5-10x larger than any prior slice in this phase (SRFI 164 was the largest so far, at 23). Four parallel research passes against the primary spec text confirmed it's also structurally unrelated to SRFI 25/164/63: intervals are a genuinely new opaque type (two parallel vectors of exact-integer lower/upper bounds, arbitrary sign — not a shape-object or plain-size model), and `array?`/`array-set!` (later phases) turn out to be their own hybrid of the 25/164 and 63 conventions.

Given the scale, this is being split into several slices:

| Phase | Scope | ~Bindings |
|-------|-------|-----------|
| **1a (this PR)** | Intervals + misc permutation/translation helpers | 32 |
| 1b | Storage classes (`make-storage-class`, 17 singletons, accessors) | 28 |
| 2 | Core array object (array?/mutable-array?/specialized-array?, make-array, make-specialized-array, array-ref/set!, etc.) | ~19 |
| 3 | Views/sharing/reshaping (specialized-array-share, array-curry, array-tile, etc.) | ~12 |
| 4 | Bulk combinators + conversions (array-map/fold/reduce, outer/inner-product, list/vector conversions) | ~16 |
| 5 | Multi-array assembly (array-stack, array-append, array-block, array-decurry) | ~9 |
| final | Merge into public `lib/srfi/231.sld`, docs, SRFI count bump | — |

`(srfi 231)` is **not yet importable** as a bare library — same reasoning as `(srfi 160 base)` + per-tag files having no bare `(srfi 160)`. This PR does not touch the tracked SRFI counts (231 stays "tracked, in progress" under #1694 until the whole thing ships).

## This PR's scope

- `lib/srfi/231/misc.sld` (6 procedures): `translation?`, `permutation?`, `index-rotate`, `index-first`, `index-last`, `index-swap`.
- `lib/srfi/231/intervals.sld` (26 procedures): the `<interval>` record and all interval procedures — construction (both `make-interval` forms), accessors, `interval-for-each`/`fold-left`/`fold-right` (general d-dimensional lexicographic traversal), `interval-dilate`/`translate`/`permute`/`scale`, `interval-intersect` (returns `#f` on no overlap, not an error), `interval-cartesian-product`, `interval-projections` (returns two values).

Every calling convention was confirmed against the primary spec text and reference implementation before writing code, including two procedures (`translation?`/`permutation?`) whose exact validation rule the spec states only in prose, and `interval-fold-right`'s "all f evaluations before any operator application" requirement (a naive reverse-order fold interleaving f and operator would violate this even though it looks equivalent when f is pure).

## Also filed

#1748: `tests/scheme/compile/compile-import-error-703.sh` has now flaked 3 times in full `run-all.sh` runs across recent slices (never standalone), with a concrete root-cause theory (it rebuilds the shared `zig-out/bin/kaappi` binary in place, twice, as part of its own normal operation). Unrelated to this PR's diff — passed both standalone and on a clean full rerun here.

## Test plan

- [x] `kaappi check lib/srfi/231/misc.sld lib/srfi/231/intervals.sld` — clean
- [x] Manual smoke test covering both `make-interval` forms, negative bounds, 0-dim/empty edge cases, fold-left/fold-right order sensitivity (verified against the spec's own 0-dimensional formulas), dilate/translate/permute/scale, intersect, cartesian-product, and projections (matches the spec's own worked example verbatim)
- [x] New `tests/scheme/srfi/srfi231-intervals.scm` (62 assertions) — all pass
- [x] `zig build test` — clean
- [x] `bash tests/scheme/run-all.sh` — 1975 pass, 1 known flake (#1748, unrelated, confirmed passing standalone + on clean rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)