### PR TITLE
Add SRFI 231 core array object (#1694 array family, phase 2)

### DIFF
--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -1,0 +1,178 @@
+;;; SRFI 231 -- Core array object (phase 2 of #1694's SRFI 231 slice).
+;;;
+;;; Builds on phase 1a (lib/srfi/231/intervals.sld) and phase 1b
+;;; (lib/srfi/231/storage-classes.sld). See intervals.sld's header for the
+;;; overall multi-slice roadmap; (srfi 231) itself is still not importable
+;;; as a bare library until every phase lands.
+;;;
+;;; An array is a domain (an interval) plus a getter (a procedure called
+;;; with SEPARATE positional index arguments, confirmed throughout the
+;;; primary spec text and its reference implementation -- never a packed
+;;; vector/list). A setter, if present, makes it mutable; array-set!'s
+;;; value argument is SECOND (right after the array), matching SRFI 63's
+;;; convention, not SRFI 25/164's value-last -- confirmed directly from
+;;; the spec's own formal signature, "array-set! array object . multi-index".
+;;; array? is disjoint from vector/string here (matching 25/164, NOT
+;;; 63's "vectors/strings are rank-1 arrays" rule) -- confirmed via direct
+;;; fetch specifically because getting this backwards was the single
+;;; biggest miss when implementing SRFI 63.
+;;;
+;;; specialized-array? => array? (spec: "A specialized-array is an
+;;; array."); mutable-array? => array? (entailed by make-array's own
+;;; contract). specialized-array? and mutable-array? are orthogonal --
+;;; array-freeze! can make a specialized array immutable in place, and a
+;;; plain closure-backed array can be mutable without being specialized
+;;; (e.g. a hash-table-backed sparse array, per the spec's own example).
+;;; One <array> record covers all four combinations: the specialized-only
+;;; fields (body/indexer/storage-class/safe?) are simply #f on a plain
+;;; array, and (not (array-setter-raw a)) means immutable.
+(define-library (srfi 231 arrays)
+  (import (scheme base)
+          (srfi 231 intervals) (srfi 231 storage-classes))
+  (export array? mutable-array? specialized-array?
+          make-array make-specialized-array make-specialized-array-from-data
+          array-domain array-getter array-setter array-dimension
+          array-ref array-set! array-freeze! array-empty?
+          array-body array-indexer array-storage-class array-safe? array-packed?
+          specialized-array-default-safe? specialized-array-default-mutable?)
+  (begin
+
+    (define-record-type <array>
+      (%make-array domain getter setter body indexer storage-class safe?)
+      array?
+      (domain array-domain)
+      (getter array-getter)
+      (setter %array-setter-raw %array-set-setter!)
+      (body %array-body-raw)
+      (indexer %array-indexer-raw)
+      (storage-class %array-storage-class-raw)
+      (safe? %array-safe?-raw))
+
+    (define (mutable-array? a) (and (array? a) (if (%array-setter-raw a) #t #f)))
+    (define (specialized-array? a) (and (array? a) (if (%array-body-raw a) #t #f)))
+
+    (define (array-setter a)
+      (unless (mutable-array? a) (error "array-setter: not a mutable array" a))
+      (%array-setter-raw a))
+
+    (define (array-body a)
+      (unless (specialized-array? a) (error "array-body: not a specialized array" a))
+      (%array-body-raw a))
+
+    (define (array-indexer a)
+      (unless (specialized-array? a) (error "array-indexer: not a specialized array" a))
+      (%array-indexer-raw a))
+
+    (define (array-storage-class a)
+      (unless (specialized-array? a) (error "array-storage-class: not a specialized array" a))
+      (%array-storage-class-raw a))
+
+    (define (array-safe? a)
+      (unless (specialized-array? a) (error "array-safe?: not a specialized array" a))
+      (%array-safe?-raw a))
+
+    (define (array-dimension a) (interval-dimension (array-domain a)))
+    (define (array-empty? a) (interval-empty? (array-domain a)))
+
+    (define (array-ref a . multi-index) (apply (array-getter a) multi-index))
+    ;; Value is the SECOND argument (right after array), matching SRFI
+    ;; 63's convention (opposite of SRFI 25/164's value-last).
+    (define (array-set! a object . multi-index) (apply (array-setter a) object multi-index))
+
+    (define (array-freeze! a)
+      (unless (array? a) (error "array-freeze!: not an array" a))
+      (%array-set-setter! a #f)
+      a)
+
+    (define (make-array interval getter . maybe-setter)
+      (unless (interval? interval) (error "make-array: not an interval" interval))
+      (unless (procedure? getter) (error "make-array: getter must be a procedure" getter))
+      (let ((setter (if (null? maybe-setter) #f (car maybe-setter))))
+        (%make-array interval getter setter #f #f #f #f)))
+
+    (define specialized-array-default-safe? (make-parameter #f))
+    (define specialized-array-default-mutable? (make-parameter #t))
+
+    ;; The lexicographical mapping of interval onto [0, interval-volume) --
+    ;; per spec, a specialized array's own indexer. Subtracts each axis's
+    ;; lower bound first to get a local 0-based index, then applies the
+    ;; standard row-major stride computation using the interval's own
+    ;; widths -- a direct generalization of SRFI 63's %row-major-offset to
+    ;; arbitrary (not just zero-based) lower bounds.
+    (define (%make-lex-indexer interval)
+      (let ((lo (interval-lower-bounds->vector interval))
+            (widths (interval-widths interval))
+            (d (interval-dimension interval)))
+        (lambda multi-index
+          (let loop ((i 0) (xs multi-index) (acc 0))
+            (if (= i d)
+                acc
+                (loop (+ i 1) (cdr xs)
+                      (+ (* acc (vector-ref widths i)) (- (car xs) (vector-ref lo i)))))))))
+
+    (define (%safe-getter interval raw-getter)
+      (lambda multi-index
+        (unless (apply interval-contains-multi-index? interval multi-index)
+          (error "array getter: multi-index not in domain" multi-index))
+        (apply raw-getter multi-index)))
+
+    (define (%safe-setter interval checker raw-setter)
+      (lambda (val . multi-index)
+        (unless (apply interval-contains-multi-index? interval multi-index)
+          (error "array setter: multi-index not in domain" multi-index))
+        (unless (checker val)
+          (error "array setter: value rejected by storage-class checker" val))
+        (apply raw-setter val multi-index)))
+
+    (define (%opt lst i default) (if (> (length lst) i) (list-ref lst i) default))
+
+    (define (make-specialized-array interval . opts)
+      (unless (interval? interval) (error "make-specialized-array: not an interval" interval))
+      (let* ((storage-class (%opt opts 0 generic-storage-class))
+             (initial-value (%opt opts 1 (storage-class-default storage-class)))
+             (safe? (%opt opts 2 (specialized-array-default-safe?)))
+             (body ((storage-class-maker storage-class) (interval-volume interval) initial-value))
+             (indexer (%make-lex-indexer interval))
+             (raw-getter (lambda multi-index
+                           ((storage-class-getter storage-class) body (apply indexer multi-index))))
+             (raw-setter (lambda (val . multi-index)
+                           ((storage-class-setter storage-class) body (apply indexer multi-index) val)))
+             (getter (if safe? (%safe-getter interval raw-getter) raw-getter))
+             (setter (if safe? (%safe-setter interval (storage-class-checker storage-class) raw-setter) raw-setter)))
+        (%make-array interval getter setter body indexer storage-class safe?)))
+
+    ;; Wraps EXTERNALLY supplied data (e.g. a plain vector or one of this
+    ;; codebase's own (srfi 160 <tag>) numeric vectors) as the body of a
+    ;; new 1-D array WITHOUT copying -- data must already be exactly
+    ;; body-shaped for storage-class (per storage-class-data?).
+    (define (make-specialized-array-from-data data . opts)
+      (let* ((storage-class (%opt opts 0 generic-storage-class))
+             (mutable? (%opt opts 1 (specialized-array-default-mutable?)))
+             (safe? (%opt opts 2 (specialized-array-default-safe?))))
+        (unless ((storage-class-data? storage-class) data)
+          (error "make-specialized-array-from-data: data is not compatible with storage-class" data storage-class))
+        (let* ((body ((storage-class-data->body storage-class) data))
+               (n ((storage-class-length storage-class) body))
+               (interval (make-interval (vector n)))
+               (indexer (lambda (i) i))
+               (raw-getter (lambda (i) ((storage-class-getter storage-class) body (indexer i))))
+               (raw-setter (lambda (val i) ((storage-class-setter storage-class) body (indexer i) val)))
+               (getter (if safe? (%safe-getter interval raw-getter) raw-getter))
+               (setter (and mutable?
+                            (if safe? (%safe-setter interval (storage-class-checker storage-class) raw-setter) raw-setter))))
+          (%make-array interval getter setter body indexer storage-class safe?))))
+
+    ;; #t iff lexicographic traversal order visits body positions
+    ;; 0,1,2,...,volume-1 consecutively -- always true immediately after
+    ;; make-specialized-array/make-specialized-array-from-data (their own
+    ;; indexer IS that exact lexicographic mapping); becomes meaningful
+    ;; once a later phase's view/share/reverse procedures install a
+    ;; different (non-consecutive) indexer over the same body.
+    (define (array-packed? a)
+      (unless (specialized-array? a) (error "array-packed?: not a specialized array" a))
+      (let ((expected 0) (ok #t) (indexer (array-indexer a)))
+        (interval-for-each (lambda multi-index
+                              (unless (= (apply indexer multi-index) expected) (set! ok #f))
+                              (set! expected (+ expected 1)))
+                            (array-domain a))
+        ok))))

--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -167,12 +167,17 @@
     ;; make-specialized-array/make-specialized-array-from-data (their own
     ;; indexer IS that exact lexicographic mapping); becomes meaningful
     ;; once a later phase's view/share/reverse procedures install a
-    ;; different (non-consecutive) indexer over the same body.
+    ;; different (non-consecutive) indexer over the same body. Escapes via
+    ;; call/cc on the first mismatch rather than scanning the full domain,
+    ;; since a later phase's non-packed arrays could otherwise pay a full
+    ;; interval-volume traversal just to report "not packed" at index 0.
     (define (array-packed? a)
       (unless (specialized-array? a) (error "array-packed?: not a specialized array" a))
-      (let ((expected 0) (ok #t) (indexer (array-indexer a)))
-        (interval-for-each (lambda multi-index
-                              (unless (= (apply indexer multi-index) expected) (set! ok #f))
-                              (set! expected (+ expected 1)))
-                            (array-domain a))
-        ok))))
+      (call/cc
+       (lambda (return)
+         (let ((expected 0) (indexer (array-indexer a)))
+           (interval-for-each (lambda multi-index
+                                 (unless (= (apply indexer multi-index) expected) (return #f))
+                                 (set! expected (+ expected 1)))
+                               (array-domain a))
+           #t))))))

--- a/tests/scheme/srfi/srfi231-arrays.scm
+++ b/tests/scheme/srfi/srfi231-arrays.scm
@@ -112,6 +112,35 @@
   (test-equal #t (guard (e (#t #t)) (array-safe? plain) #f))
   (test-equal #t (guard (e (#t #t)) (array-packed? plain) #f)))
 
+;;; --- zero-dimensional arrays: a single element, accessed with an empty
+;;; multi-index (a thunk call) ---
+(let ((z (make-array (make-interval (vector)) (lambda () 42))))
+  (test-equal 0 (array-dimension z))
+  (test-equal #f (array-empty? z))  ;; per spec, a 0-dim interval is never empty
+  (test-equal 42 (array-ref z)))
+
+(let ((zs (make-specialized-array (make-interval (vector)) s8-storage-class 7)))
+  (test-equal 0 (array-dimension zs))
+  (test-equal 7 (array-ref zs))
+  (array-set! zs 9)
+  (test-equal 9 (array-ref zs))
+  (test-equal #t (array-packed? zs)))
+
+;;; --- empty-domain arrays (some axis has lower = upper): array-empty? is
+;;; #t, and no multi-index can ever be valid since that axis's range is
+;;; unsatisfiable, so any access is rejected -- via the explicit domain
+;;; check in safe mode, and via the storage layer's own bounds check on
+;;; the resulting zero-length body in unsafe mode ---
+(let ((e (make-interval (vector 3 3) (vector 3 5))))
+  (test-equal #t (interval-empty? e))
+  (let ((ea (make-specialized-array e s8-storage-class)))
+    (test-equal #t (array-empty? ea))
+    (test-equal 0 (interval-volume (array-domain ea)))
+    (test-equal #t (guard (exn (#t #t)) (array-ref ea 3 3) #f))
+    (test-equal #t (guard (exn (#t #t)) (array-set! ea 1 3 3) #f)))
+  (let ((safe-ea (make-specialized-array e s8-storage-class 0 #t)))
+    (test-equal #t (guard (exn (#t #t)) (array-ref safe-ea 3 3) #f))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-arrays")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-arrays.scm
+++ b/tests/scheme/srfi/srfi231-arrays.scm
@@ -1,0 +1,117 @@
+;; SRFI 231 (Intervals and Generalized Arrays) tests -- phase 2: the core
+;; array object. Views/sharing, combinators, and multi-array assembly are
+;; later phases of this multi-slice SRFI, tracked under issue #1694;
+;; (srfi 231) itself is not yet an importable bare library.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi231-arrays.scm
+
+(import (scheme base) (scheme process-context) (srfi 64)
+        (srfi 231 intervals) (srfi 231 storage-classes) (srfi 231 arrays))
+
+(test-begin "srfi-231-arrays")
+
+;;; --- a plain (non-specialized) immutable array via closure ---
+(let ((ident (make-array (make-interval (vector 3 3))
+                          (lambda (i j) (if (= i j) 1 0)))))
+  (test-equal #t (array? ident))
+  (test-equal #f (mutable-array? ident))
+  (test-equal #f (specialized-array? ident))
+  (test-equal 1 (array-ref ident 0 0))
+  (test-equal 0 (array-ref ident 0 1))
+  (test-equal 1 (array-ref ident 1 1))
+  (test-equal 2 (array-dimension ident))
+  (test-equal #f (array-empty? ident))
+  (test-equal #t (guard (e (#t #t)) (array-setter ident) #f))
+  (test-equal #t (guard (e (#t #t)) (array-body ident) #f)))
+
+;;; --- make-array validates its arguments ---
+(test-equal #t (guard (e (#t #t)) (make-array "not an interval" (lambda () 1)) #f))
+(test-equal #t (guard (e (#t #t)) (make-array (make-interval (vector 1)) "not a procedure") #f))
+
+;;; --- a plain MUTABLE array via closures (sparse-style, matching the
+;;; spec's own illustrative example shape) -- mutable but not specialized ---
+(let* ((store (make-vector 9 0))
+       (sparse (make-array (make-interval (vector 3 3))
+                            (lambda (i j) (vector-ref store (+ (* i 3) j)))
+                            (lambda (v i j) (vector-set! store (+ (* i 3) j) v)))))
+  (test-equal #t (mutable-array? sparse))
+  (test-equal #f (specialized-array? sparse))
+  (array-set! sparse 'hello 1 2)
+  (test-equal 'hello (array-ref sparse 1 2))
+  ;; array-freeze! mutates the array in place, removing its setter
+  (test-equal sparse (array-freeze! sparse))
+  (test-equal #f (mutable-array? sparse))
+  (test-equal 'hello (array-ref sparse 1 2)))
+
+;;; --- array-freeze! rejects a non-array ---
+(test-equal #t (guard (e (#t #t)) (array-freeze! 42) #f))
+
+;;; --- make-specialized-array: arbitrary (including negative) lower
+;;; bounds, both array? and mutable-array? and specialized-array? true ---
+(let ((sa (make-specialized-array (make-interval (vector -2 -2) (vector 2 2)) s8-storage-class)))
+  (test-equal #t (array? sa))
+  (test-equal #t (mutable-array? sa))
+  (test-equal #t (specialized-array? sa))
+  (array-set! sa 42 -2 -2)
+  (array-set! sa -1 1 1)
+  (test-equal 42 (array-ref sa -2 -2))
+  (test-equal -1 (array-ref sa 1 1))
+  (test-equal 0 (array-ref sa 0 0))  ;; untouched cell reads the storage class's default
+  (test-equal #t (eq? (array-storage-class sa) s8-storage-class))
+  (test-equal #t (array-packed? sa))
+  (test-equal #f (array-safe? sa))  ;; specialized-array-default-safe? defaults to #f
+  ;; even in unsafe mode, the underlying storage class's own setter still
+  ;; enforces its element-type range (Kaappi's numeric vectors are always
+  ;; internally checked; "unsafe" only skips the array-level domain check)
+  (test-equal #t (guard (e (#t #t)) (array-set! sa 999 -2 -2) #f)))
+
+;;; --- make-specialized-array's optional arguments: storage-class,
+;;; initial-value, safe? ---
+(let ((safe-sa (make-specialized-array (make-interval (vector 3 3)) generic-storage-class 'x #t)))
+  (test-equal #t (array-safe? safe-sa))
+  (test-equal 'x (array-ref safe-sa 0 0))  ;; initial-value fills every cell
+  (test-equal #t (guard (e (#t #t)) (array-ref safe-sa 5 5) #f))  ;; out-of-domain rejected explicitly
+  (test-equal #t (guard (e (#t #t)) (array-set! safe-sa 'y 5 5) #f)))
+
+;;; --- make-specialized-array validates its interval argument ---
+(test-equal #t (guard (e (#t #t)) (make-specialized-array "not an interval") #f))
+
+;;; --- make-specialized-array-from-data: zero-copy wrap of existing data ---
+(let* ((existing (vector 'a 'b 'c 'd))
+       (wrapped (make-specialized-array-from-data existing generic-storage-class)))
+  (test-equal 1 (array-dimension wrapped))
+  (test-equal 'a (array-ref wrapped 0))
+  (test-equal 'd (array-ref wrapped 3))
+  (array-set! wrapped 'z 1)
+  ;; writing through the array mutates the ORIGINAL vector -- true sharing,
+  ;; not a copy
+  (test-equal 'z (vector-ref existing 1))
+  (test-equal #t (eq? (array-body wrapped) existing)))
+
+;; mutable? = #f produces an immutable wrapped array
+(test-equal #f (mutable-array? (make-specialized-array-from-data (vector 1 2 3) generic-storage-class #f)))
+
+;; data incompatible with the given storage-class is rejected
+(test-equal #t (guard (e (#t #t))
+                  (make-specialized-array-from-data "a string" s8-storage-class) #f))
+
+;;; --- specialized-array-default-safe?/mutable? are genuine SRFI 39
+;;; parameters, honored by make-specialized-array when safe?/... omitted ---
+(test-equal #f (specialized-array-default-safe?))
+(test-equal #t (specialized-array-default-mutable?))
+(parameterize ((specialized-array-default-safe? #t))
+  (test-equal #t (array-safe? (make-specialized-array (make-interval (vector 2 2))))))
+;; parameterize doesn't leak past its dynamic extent
+(test-equal #f (specialized-array-default-safe?))
+
+;;; --- array-body/indexer/storage-class/safe?/packed? all reject a
+;;; non-specialized array ---
+(let ((plain (make-array (make-interval (vector 2)) (lambda (i) i))))
+  (test-equal #t (guard (e (#t #t)) (array-body plain) #f))
+  (test-equal #t (guard (e (#t #t)) (array-indexer plain) #f))
+  (test-equal #t (guard (e (#t #t)) (array-storage-class plain) #f))
+  (test-equal #t (guard (e (#t #t)) (array-safe? plain) #f))
+  (test-equal #t (guard (e (#t #t)) (array-packed? plain) #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-231-arrays")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Third of several slices implementing SRFI 231 ("Intervals and Generalized Arrays") — see #1749 (phase 1a: intervals + misc) and #1750 (phase 1b: storage classes, both merged) for the overall roadmap.

This slice adds the array type itself: a domain (an interval) plus a getter, with an optional setter making it mutable, and an optional storage-class/body/indexer making it specialized.

- **One `<array>` record covers all four combinations** (plain immutable, plain mutable via closures, specialized mutable, specialized frozen-immutable) — specialized-only fields are simply `#f` on a plain array.
- **`array?`/`mutable-array?`/`specialized-array?` confirmed as a non-strict hierarchy**: `specialized-array? ⟹ array?` and `mutable-array? ⟹ array?`, but specialized and mutable are orthogonal — `array-freeze!` can make a specialized array immutable in place, and a closure-backed sparse array (per the spec's own illustrative example) can be mutable without being specialized at all.
- **Two conventions that don't match either prior array SRFI in this codebase exactly, both confirmed against the primary spec**: `array?` is disjoint from vector/string (matching 25/164, *not* 63's "vectors are rank-1 arrays" rule — getting this backwards was the single biggest miss when implementing 63), while `array-set!`'s value argument is *second* (matching 63, not 25/164's value-last). Getters/setters are always called with separate positional index arguments, never a packed vector/list.
- **`make-specialized-array`'s indexer** generalizes SRFI 63's 0-based-only row-major offset to arbitrary (including negative) lower bounds: shift each axis by its own lower bound first, then apply the standard row-major stride computation using the interval's own widths.
- **`make-specialized-array-from-data`** wraps externally supplied data (e.g. an existing `(srfi 160 <tag>)` vector) as a new array's body with zero copying — confirmed via a test that mutates through the array and checks the original vector changed.
- **`specialized-array-default-safe?`/`-mutable?`** are genuine SRFI 39 parameters, as the spec requires (a documented difference from the predecessor SRFI 179, where they were plain variables).

`(srfi 231)` itself remains not importable — still tracked under #1694. Remaining phases: views/sharing/reshaping, bulk combinators + conversions, multi-array assembly.

## Test plan

- [x] `kaappi check lib/srfi/231/arrays.sld` — clean
- [x] Manual smoke test covering plain immutable/mutable arrays, specialized arrays with arbitrary lower bounds, safe/unsafe access, `make-specialized-array-from-data` zero-copy sharing, `array-freeze!`, and every accessor's rejection of the wrong array kind
- [x] New `tests/scheme/srfi/srfi231-arrays.scm` (50 assertions) — all pass
- [x] `zig build test` — clean
- [x] `bash tests/scheme/run-all.sh` — 1977 pass, 1 known unrelated flake (#1748, confirmed passing standalone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)