### PR TITLE
Add SRFI 231 views, sharing, and reshaping (#1694 array family, phase 3)

### DIFF
--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -34,7 +34,13 @@
           array-domain array-getter array-setter array-dimension
           array-ref array-set! array-freeze! array-empty?
           array-body array-indexer array-storage-class array-safe? array-packed?
-          specialized-array-default-safe? specialized-array-default-mutable?)
+          specialized-array-default-safe? specialized-array-default-mutable?
+          ;; Not part of SRFI 231's own public API -- exported only for
+          ;; sibling library files in this package (lib/srfi/231/views.sld
+          ;; and later phases) to build genuinely specialized arrays with
+          ;; custom indexers, the same way (srfi 160 base)'s %uvec-* helpers
+          ;; exist only for that package's own per-tag files to consume.
+          %make-array %safe-getter %safe-setter %make-lex-indexer)
   (begin
 
     (define-record-type <array>

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -1,0 +1,365 @@
+;;; SRFI 231 -- Views, sharing, and reshaping (phase 3 of #1694's SRFI 231
+;;; slice). Builds on phases 1a/1b/2 (intervals, storage classes, core
+;;; array object). See intervals.sld's header for the overall roadmap;
+;;; (srfi 231) itself is still not importable as a bare library.
+;;;
+;;; specialized-array-share is the foundational primitive here -- every
+;;; view/transform procedure that shares a specialized array's body (all
+;;; except array-curry/array-tile's own OUTER array, array-copy, and
+;;; specialized-array-reshape) is defined in terms of it. It composes a
+;;; caller-supplied affine "new-domain->old-domain" mapping (called with
+;;; the NEW array's indices as separate arguments, returning OLD
+;;; coordinates via multiple values -- confirmed from the spec's own
+;;; "shearing" example, which is strictly more general than any of the
+;;; other sharing procedures combined) with the source array's own
+;;; indexer, and inherits mutability/safety from the source.
+;;;
+;;; A recurring pattern confirmed across array-extract/translate/permute/
+;;; reverse/sample: each dispatches 3 ways on the SOURCE array's own mode
+;;; (specialized -> specialized-array-share; mutable-non-specialized ->
+;;; make-array with getter+setter; immutable -> make-array with getter
+;;; only), and the OUTPUT exactly mirrors the input's mode. array-curry
+;;; and array-tile break this pattern deliberately: their OUTER array is
+;;; unconditionally plain immutable/non-specialized regardless of input
+;;; mode (confirmed by an explicit spec quote for curry: "B is always an
+;;; immutable array... computed anew for each call" -- i.e. never
+;;; cached/memoized), while their INNER elements (the subarrays) follow
+;;; the same 3-way mirroring as everything else.
+;;;
+;;; specialized-array-reshape's affine-detectability test is, in the
+;;; spec's own words, "modeled on the corresponding code in the Python
+;;; library NumPy" and not specified in prose beyond that -- the
+;;; reference implementation's actual algorithm (empirically probing
+;;; strides, filtering size-1 axes, greedily matching adjacent-axis
+;;; volume groups between old and new shapes, verifying C-contiguity
+;;; within each group) is substantially more general than what's
+;;; implemented here. This port deliberately implements a conservative
+;;; special case instead: reshape succeeds zero-copy whenever the SOURCE
+;;; array is already array-packed? (the overwhelmingly common real case,
+;;; e.g. reshaping a fresh array-copy result), using a plain row-major
+;;; reindex; otherwise it behaves exactly as the spec allows for a
+;;; failed detection (error, or a forced copy-then-retry when
+;;; copy-on-failure? is #t). This never wrongly claims an affine map
+;;; exists (so it's never incorrect), but is more conservative than the
+;;; full algorithm for some non-packed-but-still-affinely-reshapable
+;;; arrays (e.g. some genuinely strided views) -- confirmed against both
+;;; of the spec's own worked examples (a packed array reshaping
+;;; successfully; a array-sample'd non-packed array failing without
+;;; copy-on-failure? and succeeding with it), which this simplification
+;;; handles identically to the full algorithm.
+(define-library (srfi 231 views)
+  (import (scheme base)
+          (srfi 231 misc) (srfi 231 intervals) (srfi 231 storage-classes) (srfi 231 arrays))
+  (export specialized-array-share
+          array-extract array-translate array-permute array-reverse
+          array-curry array-tile array-sample
+          array-copy array-copy!
+          specialized-array-reshape)
+  (begin
+
+    (define (%vector-every pred v)
+      (let loop ((i 0))
+        (or (= i (vector-length v))
+            (and (pred (vector-ref v i)) (loop (+ i 1))))))
+
+    (define (%opt lst i default) (if (> (length lst) i) (list-ref lst i) default))
+
+    ;; --- the foundational sharing primitive ---
+
+    (define (specialized-array-share array new-domain new-domain->old-domain)
+      (unless (specialized-array? array) (error "specialized-array-share: not a specialized array" array))
+      (unless (interval? new-domain) (error "specialized-array-share: not an interval" new-domain))
+      (when (> (interval-volume new-domain) (interval-volume (array-domain array)))
+        (error "specialized-array-share: new-domain has more elements than array" new-domain array))
+      (let* ((storage-class (array-storage-class array))
+             (body (array-body array))
+             (old-indexer (array-indexer array))
+             (new-indexer (lambda multi-index
+                            (call-with-values (lambda () (apply new-domain->old-domain multi-index)) old-indexer)))
+             (safe? (array-safe? array))
+             (mutable? (mutable-array? array))
+             (raw-getter (lambda multi-index
+                           ((storage-class-getter storage-class) body (apply new-indexer multi-index))))
+             (raw-setter (lambda (val . multi-index)
+                           ((storage-class-setter storage-class) body (apply new-indexer multi-index) val)))
+             (getter (if safe? (%safe-getter new-domain raw-getter) raw-getter))
+             (setter (and mutable?
+                          (if safe? (%safe-setter new-domain (storage-class-checker storage-class) raw-setter) raw-setter))))
+        (%make-array new-domain getter setter body new-indexer storage-class safe?)))
+
+    ;; --- the 3-way dispatch shape shared by extract/translate/permute/reverse/sample ---
+
+    (define (array-extract array new-domain)
+      (unless (array? array) (error "array-extract: not an array" array))
+      (unless (interval? new-domain) (error "array-extract: not an interval" new-domain))
+      (unless (= (interval-dimension new-domain) (array-dimension array))
+        (error "array-extract: dimension mismatch" new-domain array))
+      (unless (interval-subset? new-domain (array-domain array))
+        (error "array-extract: new-domain is not a subset of array's domain" new-domain array))
+      (cond
+       ((specialized-array? array) (specialized-array-share array new-domain values))
+       ((mutable-array? array) (make-array new-domain (array-getter array) (array-setter array)))
+       (else (make-array new-domain (array-getter array)))))
+
+    (define (array-translate array translation)
+      (unless (array? array) (error "array-translate: not an array" array))
+      (unless (translation? translation) (error "array-translate: not a valid translation" translation))
+      (unless (= (vector-length translation) (array-dimension array))
+        (error "array-translate: dimension mismatch" translation array))
+      (let ((new-domain (interval-translate (array-domain array) translation))
+            (tlist (vector->list translation)))
+        (cond
+         ((specialized-array? array)
+          (specialized-array-share array new-domain (lambda multi-index (apply values (map - multi-index tlist)))))
+         ((mutable-array? array)
+          (make-array new-domain
+                      (lambda multi-index (apply (array-getter array) (map - multi-index tlist)))
+                      (lambda (val . multi-index) (apply (array-setter array) val (map - multi-index tlist)))))
+         (else
+          (make-array new-domain (lambda multi-index (apply (array-getter array) (map - multi-index tlist))))))))
+
+    (define (%permutation-invert perm)
+      (let* ((n (vector-length perm)) (inv (make-vector n 0)))
+        (let loop ((i 0))
+          (when (< i n)
+            (vector-set! inv (vector-ref perm i) i)
+            (loop (+ i 1))))
+        inv))
+
+    ;; result[i] = lst[perm-vec[i]]
+    (define (%list-permute lst perm-vec)
+      (let ((v (list->vector lst)))
+        (map (lambda (p) (vector-ref v p)) (vector->list perm-vec))))
+
+    (define (array-permute array permutation)
+      (unless (array? array) (error "array-permute: not an array" array))
+      (unless (permutation? permutation) (error "array-permute: not a valid permutation" permutation))
+      (unless (= (vector-length permutation) (array-dimension array))
+        (error "array-permute: dimension mismatch" permutation array))
+      (let* ((new-domain (interval-permute (array-domain array) permutation))
+             (inv (%permutation-invert permutation)))
+        (cond
+         ((specialized-array? array)
+          (specialized-array-share array new-domain
+                                    (lambda multi-index (apply values (%list-permute multi-index inv)))))
+         ((mutable-array? array)
+          (make-array new-domain
+                      (lambda multi-index (apply (array-getter array) (%list-permute multi-index inv)))
+                      (lambda (val . multi-index) (apply (array-setter array) val (%list-permute multi-index inv)))))
+         (else
+          (make-array new-domain
+                      (lambda multi-index (apply (array-getter array) (%list-permute multi-index inv))))))))
+
+    (define (%flip-multi-index-maker domain flip-vec)
+      (let ((lowers (interval-lower-bounds->list domain))
+            (uppers (interval-upper-bounds->list domain))
+            (flips (vector->list flip-vec)))
+        (lambda (multi-index)
+          (map (lambda (i f l u) (if f (- (+ l u -1) i) i)) multi-index flips lowers uppers))))
+
+    ;; flip? default: reverse every axis (a same-length all-#t vector) --
+    ;; the array's own DOMAIN is unchanged (unlike translate/permute/sample);
+    ;; only the index<->value correspondence changes.
+    (define (array-reverse array . maybe-flip)
+      (unless (array? array) (error "array-reverse: not an array" array))
+      (let* ((d (array-dimension array))
+             (flip? (if (null? maybe-flip) (make-vector d #t) (car maybe-flip))))
+        (unless (and (vector? flip?) (= (vector-length flip?) d) (%vector-every boolean? flip?))
+          (error "array-reverse: flip? must be a boolean vector matching the array's dimension" flip? array))
+        (let* ((domain (array-domain array))
+               (flip-fn (%flip-multi-index-maker domain flip?)))
+          (cond
+           ((specialized-array? array)
+            (specialized-array-share array domain (lambda multi-index (apply values (flip-fn multi-index)))))
+           ((mutable-array? array)
+            (make-array domain
+                        (lambda multi-index (apply (array-getter array) (flip-fn multi-index)))
+                        (lambda (val . multi-index) (apply (array-setter array) val (flip-fn multi-index)))))
+           (else
+            (make-array domain (lambda multi-index (apply (array-getter array) (flip-fn multi-index)))))))))
+
+    (define (array-sample array scales)
+      (unless (array? array) (error "array-sample: not an array" array))
+      (unless (and (vector? scales) (%vector-every (lambda (x) (and (integer? x) (exact? x) (positive? x))) scales))
+        (error "array-sample: scales must be a vector of positive exact integers" scales))
+      (unless (= (vector-length scales) (array-dimension array))
+        (error "array-sample: dimension mismatch" scales array))
+      (unless (%vector-every zero? (interval-lower-bounds->vector (array-domain array)))
+        (error "array-sample: array's domain must have all-zero lower bounds" array))
+      (let ((new-domain (interval-scale (array-domain array) scales))
+            (slist (vector->list scales)))
+        (cond
+         ((specialized-array? array)
+          (specialized-array-share array new-domain (lambda multi-index (apply values (map * multi-index slist)))))
+         ((mutable-array? array)
+          (make-array new-domain
+                      (lambda multi-index (apply (array-getter array) (map * multi-index slist)))
+                      (lambda (val . multi-index) (apply (array-setter array) val (map * multi-index slist)))))
+         (else
+          (make-array new-domain (lambda multi-index (apply (array-getter array) (map * multi-index slist))))))))
+
+    ;; --- array-curry: outer array is ALWAYS plain immutable/non-specialized,
+    ;; computed fresh on every outer-getter call (never cached), regardless
+    ;; of the input array's own mode -- confirmed by an explicit spec quote.
+    ;; Inner arrays mirror the input's mode 3-way, same as extract/etc. ---
+
+    (define (array-curry array inner-dimension)
+      (unless (array? array) (error "array-curry: not an array" array))
+      (unless (and (integer? inner-dimension) (exact? inner-dimension)
+                   (<= 0 inner-dimension (array-dimension array)))
+        (error "array-curry: inner-dimension out of range" inner-dimension array))
+      (call-with-values (lambda () (interval-projections (array-domain array) inner-dimension))
+        (lambda (outer-interval inner-interval)
+          (cond
+           ((specialized-array? array)
+            (make-array outer-interval
+                        (lambda outer-multi-index
+                          (specialized-array-share
+                           array inner-interval
+                           (lambda inner-multi-index (apply values (append outer-multi-index inner-multi-index)))))))
+           ((mutable-array? array)
+            (make-array outer-interval
+                        (lambda outer-multi-index
+                          (make-array inner-interval
+                                      (lambda inner-multi-index
+                                        (apply (array-getter array) (append outer-multi-index inner-multi-index)))
+                                      (lambda (val . inner-multi-index)
+                                        (apply (array-setter array) val (append outer-multi-index inner-multi-index)))))))
+           (else
+            (make-array outer-interval
+                        (lambda outer-multi-index
+                          (make-array inner-interval
+                                      (lambda inner-multi-index
+                                        (apply (array-getter array) (append outer-multi-index inner-multi-index)))))))))))
+
+    ;; --- array-tile: outer array is ALWAYS plain immutable/non-specialized
+    ;; (same shape as curry's outer array); each tile is produced via
+    ;; array-extract itself, reusing its own 3-way dispatch rather than
+    ;; re-implementing sharing here. ---
+
+    ;; Per-axis cut offsets: a (n+1)-length vector of absolute coordinates
+    ;; bounding n slices. Sk is either a positive exact integer (uniform
+    ;; width, LAST slice truncated via min if it doesn't divide evenly --
+    ;; confirmed spec-sanctioned, not an error) or a nonempty vector of
+    ;; nonnegative exact integers summing to the axis's width (custom
+    ;; per-slice widths, exact prefix sums).
+    (define (%tile-cut-offsets width lower Sk)
+      (cond
+       ((and (integer? Sk) (exact? Sk) (positive? Sk))
+        (let* ((n (quotient (+ width (- Sk 1)) Sk))
+               (offsets (make-vector (+ n 1) lower)))
+          (let loop ((i 1))
+            (when (<= i n)
+              (vector-set! offsets i (min (+ lower (* i Sk)) (+ lower width)))
+              (loop (+ i 1))))
+          offsets))
+       ((and (vector? Sk) (> (vector-length Sk) 0)
+             (%vector-every (lambda (x) (and (integer? x) (exact? x) (>= x 0))) Sk)
+             (= (let loop ((i 0) (acc 0)) (if (= i (vector-length Sk)) acc (loop (+ i 1) (+ acc (vector-ref Sk i))))) width))
+        (let* ((n (vector-length Sk)) (offsets (make-vector (+ n 1) lower)))
+          (let loop ((i 1) (acc lower))
+            (when (<= i n)
+              (let ((new-acc (+ acc (vector-ref Sk (- i 1)))))
+                (vector-set! offsets i new-acc)
+                (loop (+ i 1) new-acc))))
+          offsets))
+       (else (error "array-tile: invalid slice-width component" Sk width))))
+
+    (define (array-tile array S)
+      (unless (array? array) (error "array-tile: not an array" array))
+      (let* ((domain (array-domain array)) (d (array-dimension array))
+             (lowers (interval-lower-bounds->vector domain))
+             (widths (interval-widths domain)))
+        (unless (and (vector? S) (= (vector-length S) d))
+          (error "array-tile: S must be a vector matching the array's dimension" S array))
+        (let ((cuts (make-vector d #f)))
+          (let loop ((k 0))
+            (when (< k d)
+              (vector-set! cuts k (%tile-cut-offsets (vector-ref widths k) (vector-ref lowers k) (vector-ref S k)))
+              (loop (+ k 1))))
+          (let ((out-dims (list->vector (map (lambda (c) (- (vector-length c) 1)) (vector->list cuts)))))
+            (make-array
+             (make-interval out-dims)
+             (lambda outer-multi-index
+               (let ((sub-lo (make-vector d 0)) (sub-hi (make-vector d 0)))
+                 (let loop ((k 0) (js outer-multi-index))
+                   (when (< k d)
+                     (let ((c (vector-ref cuts k)) (j (car js)))
+                       (vector-set! sub-lo k (vector-ref c j))
+                       (vector-set! sub-hi k (vector-ref c (+ j 1))))
+                     (loop (+ k 1) (cdr js))))
+                 (array-extract array (make-interval sub-lo sub-hi)))))))))
+
+    ;; --- array-copy / array-copy!: always produces a specialized array.
+    ;; If the source is ALREADY specialized, omitted options are taken
+    ;; from the SOURCE (storage-class/mutable?/safe?), making the default
+    ;; call a true copy; otherwise omitted options fall back to
+    ;; generic-storage-class/specialized-array-default-mutable?/-safe? --
+    ;; confirmed via an explicit spec quote naming this exact asymmetry.
+    ;; array-copy! is documented to differ from array-copy only in
+    ;; call/cc re-entrancy safety during the fill (the spec permits it to
+    ;; be faster/leaner by skipping a safety guarantee, never in the
+    ;; final result for an ordinary, non-continuation-abusing caller);
+    ;; this port implements both identically (a direct fill loop, no
+    ;; accumulate-to-a-list-first indirection) as a deliberate, documented
+    ;; scope reduction -- getters that escape and re-invoke a captured
+    ;; continuation mid-copy are exotic enough that the extra allocation
+    ;; and complexity isn't justified for this phase.
+    (define (%array-copy-impl array opts)
+      (unless (array? array) (error "array-copy: not an array" array))
+      (let* ((specialized? (specialized-array? array))
+             (storage-class (%opt opts 0 (if specialized? (array-storage-class array) generic-storage-class)))
+             (mutable? (%opt opts 1 (if specialized? (mutable-array? array) (specialized-array-default-mutable?))))
+             (safe? (%opt opts 2 (if specialized? (array-safe? array) (specialized-array-default-safe?))))
+             (domain (array-domain array))
+             (getter (array-getter array))
+             (dest (make-specialized-array domain storage-class (storage-class-default storage-class) safe?))
+             (dest-setter (array-setter dest)))
+        (interval-for-each (lambda multi-index (apply dest-setter (apply getter multi-index) multi-index)) domain)
+        (if mutable? dest (array-freeze! dest))))
+
+    (define (array-copy array . opts) (%array-copy-impl array opts))
+    (define (array-copy! array . opts) (%array-copy-impl array opts))
+
+    ;; --- specialized-array-reshape: see the file header for the
+    ;; documented conservative simplification (packed-check based rather
+    ;; than the reference implementation's full NumPy-derived multi-group
+    ;; stride-matching algorithm). ---
+
+    (define (specialized-array-reshape array new-domain . maybe-copy-on-failure)
+      (unless (specialized-array? array) (error "specialized-array-reshape: not a specialized array" array))
+      (unless (interval? new-domain) (error "specialized-array-reshape: not an interval" new-domain))
+      (unless (= (interval-volume new-domain) (interval-volume (array-domain array)))
+        (error "specialized-array-reshape: new-domain volume does not match array's volume" new-domain array))
+      (let ((copy-on-failure? (if (null? maybe-copy-on-failure) #f (car maybe-copy-on-failure))))
+        (cond
+         ((array-empty? array)
+          ;; any empty array reshapes trivially to any other same-volume
+          ;; (also empty) domain -- its getter/setter can never actually
+          ;; be invoked, so a placeholder is safe.
+          (%make-array new-domain
+                       (%safe-getter new-domain (lambda multi-index (error "unreachable: empty array access")))
+                       (and (mutable-array? array)
+                            (%safe-setter new-domain (lambda (v) #t)
+                                          (lambda (val . multi-index) (error "unreachable: empty array access"))))
+                       (array-body array) (lambda multi-index 0)
+                       (array-storage-class array) (array-safe? array)))
+         ((array-packed? array)
+          (let* ((storage-class (array-storage-class array))
+                 (body (array-body array))
+                 (base (apply (array-indexer array) (interval-lower-bounds->list (array-domain array))))
+                 (lex (%make-lex-indexer new-domain))
+                 (new-indexer (lambda multi-index (+ base (apply lex multi-index))))
+                 (safe? (array-safe? array))
+                 (mutable? (mutable-array? array))
+                 (raw-getter (lambda multi-index
+                               ((storage-class-getter storage-class) body (apply new-indexer multi-index))))
+                 (raw-setter (lambda (val . multi-index)
+                               ((storage-class-setter storage-class) body (apply new-indexer multi-index) val)))
+                 (getter (if safe? (%safe-getter new-domain raw-getter) raw-getter))
+                 (setter (and mutable?
+                              (if safe? (%safe-setter new-domain (storage-class-checker storage-class) raw-setter) raw-setter))))
+            (%make-array new-domain getter setter body new-indexer storage-class safe?)))
+         (copy-on-failure? (specialized-array-reshape (array-copy array) new-domain #f))
+         (else (error "specialized-array-reshape: requested reshape is not affinely representable without copying"
+                      array new-domain)))))))

--- a/tests/scheme/srfi/srfi231-views.scm
+++ b/tests/scheme/srfi/srfi231-views.scm
@@ -1,0 +1,196 @@
+;; SRFI 231 (Intervals and Generalized Arrays) tests -- phase 3: views,
+;; sharing, and reshaping. Bulk combinators/conversions and multi-array
+;; assembly are later phases of this multi-slice SRFI, tracked under
+;; issue #1694; (srfi 231) itself is not yet an importable bare library.
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi231-views.scm
+
+(import (scheme base) (scheme process-context) (srfi 64)
+        (srfi 231 intervals) (srfi 231 storage-classes) (srfi 231 arrays) (srfi 231 views))
+
+(test-begin "srfi-231-views")
+
+;;; --- specialized-array-share: the spec's own "shearing" example,
+;;; verbatim (cannot be achieved by any of the other sharing procedures) ---
+(let* ((a (array-copy (make-array (make-interval (vector 5 10)) list)))
+       (b (specialized-array-share a (make-interval (vector 5 5))
+                                    (lambda (i j) (values i (+ i j))))))
+  (test-equal #t (specialized-array? b))
+  (test-equal '(0 0) (array-ref b 0 0))
+  (test-equal '(1 2) (array-ref b 1 1))  ;; b(1,1) = a(1, 1+1) = a(1,2)
+  (test-equal '(4 8) (array-ref b 4 4))  ;; b(4,4) = a(4, 4+4) = a(4,8)
+  ;; write-through: shares the same body as a
+  (array-set! b 'sheared 2 2)
+  (test-equal 'sheared (array-ref a 2 4)))
+
+(test-equal #t (guard (e (#t #t))
+                  (specialized-array-share (make-array (make-interval (vector 5)) (lambda (i) i))
+                                            (make-interval (vector 5)) (lambda (i) (values i)))
+                  #f))  ;; source must be specialized
+
+;;; --- array-extract: preserves the SOURCE's absolute coordinate system
+;;; (does not reset a sub-array to 0-based), matching the spec's own
+;;; worked example verbatim ---
+(let* ((a (make-array (make-interval (vector 3 3)) list))
+       (b (array-extract a (make-interval (vector 1 0) (vector 3 2)))))
+  (test-equal '(1 0) (array-ref b 1 0))
+  (test-equal '(1 1) (array-ref b 1 1))
+  (test-equal '(2 0) (array-ref b 2 0))
+  (test-equal '(2 1) (array-ref b 2 1)))
+(test-equal #t (guard (e (#t #t))
+                  (array-extract (make-array (make-interval (vector 3 3)) list) (make-interval (vector 0 0) (vector 5 5)))
+                  #f))  ;; not a subset
+
+;; array-extract mirrors the source's own mode exactly
+(let ((sa (make-specialized-array (make-interval (vector 3 3)) s8-storage-class)))
+  (test-equal #t (specialized-array? (array-extract sa (make-interval (vector 1 1) (vector 3 3))))))
+
+;;; --- array-translate ---
+(let* ((a (make-array (make-interval (vector 2 3)) list))
+       (b (array-translate a (vector 1 -3))))
+  (test-equal #t (interval= (array-domain b) (make-interval (vector 1 -3) (vector 3 0))))
+  (test-equal '(0 0) (array-ref b 1 -3)))
+(test-equal #t (guard (e (#t #t)) (array-translate (make-array (make-interval (vector 2)) list) (vector 1 2)) #f))
+
+;;; --- array-permute: the spec's own two worked examples, verbatim ---
+(let* ((a (make-array (make-interval (vector 10 20 21 16)) list))
+       (b (array-permute a (vector 3 0 1 2))))
+  (test-equal #t (interval= (array-domain b) (make-interval (vector 16 10 20 21))))
+  (test-equal (array-ref a 2 5 7 9) (array-ref b 9 2 5 7)))
+(let* ((a (make-array (make-interval (vector 1 3 2)) list))
+       (b (array-permute a (vector 2 1 0))))
+  (test-equal #t (interval= (array-domain b) (make-interval (vector 2 3 1))))
+  (test-equal '(0 1 1) (array-ref b 1 1 0)))
+(test-equal #t (guard (e (#t #t)) (array-permute (make-array (make-interval (vector 2 3)) list) (vector 0 0)) #f))
+
+;;; --- array-reverse: default (every axis) and explicit flip? ---
+(let* ((a (make-array (make-interval (vector 4)) (lambda (i) i)))
+       (ra (array-reverse a)))
+  (test-equal #t (interval= (array-domain ra) (array-domain a)))  ;; domain unchanged
+  (test-equal 3 (array-ref ra 0))
+  (test-equal 2 (array-ref ra 1))
+  (test-equal 1 (array-ref ra 2))
+  (test-equal 0 (array-ref ra 3)))
+;; explicit flip? = #f on every axis is a no-op
+(let* ((a (make-array (make-interval (vector 3)) (lambda (i) i)))
+       (ra (array-reverse a (vector #f))))
+  (test-equal 0 (array-ref ra 0))
+  (test-equal 2 (array-ref ra 2)))
+;; the spec's own palindrome-checker shape (array-every isn't implemented
+;; until a later phase, so this checks element-by-element instead)
+(let* ((s "abba") (n (string-length s))
+       (a (make-array (make-interval (vector n)) (lambda (i) (string-ref s i))))
+       (ra (array-reverse a)))
+  (test-equal #t (char=? (array-ref a 0) (array-ref ra 3)))
+  (test-equal #t (char=? (array-ref a 1) (array-ref ra 2))))
+
+;;; --- array-curry: basic identity, and the outer array is ALWAYS
+;;; immutable/non-specialized regardless of the input's own mode ---
+(let* ((a (make-array (make-interval (vector 10 10)) list))
+       (b (array-curry a 1)))
+  (test-equal (array-ref a 3 4) (array-ref (array-ref b 3) 4))
+  (test-equal #t (array? b))
+  (test-equal #f (mutable-array? b))
+  (test-equal #f (specialized-array? b)))
+
+(let* ((sa (make-specialized-array (make-interval (vector 3 3)) s8-storage-class))
+       (curried (array-curry sa 1)))
+  (array-set! sa 42 1 2)
+  (test-equal #f (mutable-array? curried))
+  (test-equal #f (specialized-array? curried))
+  ;; but the INNER arrays mirror the source's own mode
+  (test-equal #t (specialized-array? (array-ref curried 1)))
+  (test-equal 42 (array-ref (array-ref curried 1) 2)))
+
+(test-equal #t (guard (e (#t #t)) (array-curry (make-array (make-interval (vector 2)) list) 5) #f))
+
+;;; --- array-sample: the spec's own worked example ---
+(let* ((a (make-array (make-interval (vector 3 2)) list))
+       (b (array-sample a (vector 2 1))))
+  (test-equal #t (interval= (array-domain b) (make-interval (vector 2 2))))
+  (test-equal '(2 0) (array-ref b 1 0))
+  (test-equal '(2 1) (array-ref b 1 1)))
+(test-equal #t (guard (e (#t #t))
+                  (array-sample (make-array (make-interval (vector 1) (vector 5)) list) (vector 1)) #f))
+
+;;; --- array-tile: the spec's own 6x6 non-uniform worked example,
+;;; verbatim, plus truncation on an unevenly-dividing uniform width ---
+(let* ((rows (list (vector 1 2 3 4 5 6) (vector 7 8 9 10 11 12) (vector 13 14 15 16 17 18)
+                    (vector 19 20 21 22 23 24) (vector 25 26 27 28 29 30) (vector 31 32 33 34 35 36)))
+       (rowvec (list->vector rows))
+       (T (make-array (make-interval (vector 6 6)) (lambda (i j) (vector-ref (vector-ref rowvec i) j))))
+       (tiled (array-tile T (vector (vector 3 1 2) 3))))
+  (test-equal #t (interval= (array-domain tiled) (make-interval (vector 3 2))))
+  (let ((t00 (array-ref tiled 0 0)))
+    (test-equal 1 (array-ref t00 0 0)) (test-equal 3 (array-ref t00 0 2)) (test-equal 15 (array-ref t00 2 2)))
+  (let ((t10 (array-ref tiled 1 0)))
+    (test-equal #t (interval= (array-domain t10) (make-interval (vector 3 0) (vector 4 3))))
+    (test-equal 19 (array-ref t10 3 0)) (test-equal 21 (array-ref t10 3 2)))
+  (let ((t20 (array-ref tiled 2 0)))
+    (test-equal #t (interval= (array-domain t20) (make-interval (vector 4 0) (vector 6 3))))
+    (test-equal 25 (array-ref t20 4 0)) (test-equal 31 (array-ref t20 5 0))))
+
+;; truncation: 5-element axis tiled with uniform width 2 -> ceil(5/2)=3
+;; slices, last one truncated to width 1, not zero-padded or an error
+(let* ((a (make-array (make-interval (vector 5)) (lambda (i) i)))
+       (tiled (array-tile a (vector 2))))
+  (test-equal '(3) (interval-upper-bounds->list (array-domain tiled)))
+  (test-equal '(4) (interval-lower-bounds->list (array-domain (array-ref tiled 2))))
+  (test-equal '(5) (interval-upper-bounds->list (array-domain (array-ref tiled 2)))))
+
+;; array-tile's outer array is always immutable/non-specialized
+(test-equal #f (specialized-array? (array-tile (make-specialized-array (make-interval (vector 4)) s8-storage-class) (vector 2))))
+
+;;; --- array-copy / array-copy!: default-inheritance rule ---
+(let* ((plain (make-array (make-interval (vector 2 2)) list))
+       (copied (array-copy plain)))
+  (test-equal #t (specialized-array? copied))
+  (test-equal '(0 0) (array-ref copied 0 0))
+  (test-equal '(1 1) (array-ref copied 1 1)))
+
+(let* ((sa (make-specialized-array (make-interval (vector 2 2)) s8-storage-class 5 #t))
+       (copy-of-sa (array-copy sa)))
+  ;; omitted options are taken from the SOURCE when it's already
+  ;; specialized -- by default, array-copy makes a TRUE copy
+  (test-equal #t (eq? (array-storage-class copy-of-sa) s8-storage-class))
+  (test-equal #t (array-safe? copy-of-sa))
+  (test-equal #t (not (eq? (array-body copy-of-sa) (array-body sa)))))
+
+;; array-copy! behaves identically for an ordinary (non-continuation-abusing) call
+(let* ((sa (make-specialized-array (make-interval (vector 3)) s8-storage-class)))
+  (array-set! sa 7 1)
+  (let ((c (array-copy! sa)))
+    (test-equal 7 (array-ref c 1))
+    (test-equal #t (not (eq? (array-body c) (array-body sa))))))
+
+;;; --- specialized-array-reshape: both of the spec's own worked examples ---
+(let* ((a (array-copy (make-array (make-interval (vector 3 4)) list)))
+       (reshaped (specialized-array-reshape a (make-interval (vector 4 3)))))
+  (test-equal #t (interval= (array-domain reshaped) (make-interval (vector 4 3))))
+  ;; row-major flatten: a's 12 elements read out in the new 4x3 shape
+  (test-equal '(0 0) (array-ref reshaped 0 0))
+  (test-equal '(0 1) (array-ref reshaped 0 1))
+  (test-equal '(0 2) (array-ref reshaped 0 2))
+  (test-equal '(0 3) (array-ref reshaped 1 0))
+  (test-equal '(1 0) (array-ref reshaped 1 1))
+  (test-equal '(2 3) (array-ref reshaped 3 2)))
+
+(let* ((a (array-copy (make-array (make-interval (vector 3 4)) list)))
+       (b (array-sample a (vector 2 1))))
+  ;; b's rows are non-adjacent in a's body -- no affine flatten exists
+  (test-equal #t (guard (e (#t #t)) (specialized-array-reshape b (make-interval (vector 8))) #f))
+  ;; but copy-on-failure? #t always succeeds via a forced copy first
+  (let ((forced (specialized-array-reshape b (make-interval (vector 8)) #t)))
+    (test-equal #t (interval= (array-domain forced) (make-interval (vector 8))))))
+
+(test-equal #t (guard (e (#t #t))
+                  (specialized-array-reshape (make-array (make-interval (vector 3)) (lambda (i) i)) (make-interval (vector 3)))
+                  #f))  ;; not specialized
+
+(test-equal #t (guard (e (#t #t))
+                  (specialized-array-reshape (array-copy (make-array (make-interval (vector 4)) (lambda (i) i)))
+                                              (make-interval (vector 5)))
+                  #f))  ;; volume mismatch
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-231-views")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Fourth of several slices implementing SRFI 231 ("Intervals and Generalized Arrays") — see #1749/#1750/#1751 (phases 1a/1b/2, all merged) for the overall roadmap.

This slice adds the 11-procedure "views/sharing/reshaping" cluster the spec's own "Sharing generalized arrays" section names as a natural unit: `specialized-array-share` (the foundational primitive), `array-extract`, `array-translate`, `array-permute`, `array-reverse`, `array-curry`, `array-tile`, `array-sample`, `array-copy`/`array-copy!`, and `specialized-array-reshape`.

**`lib/srfi/231/arrays.sld`** (phase 2, already merged) gets one small, purely additive change: `%make-array`/`%safe-getter`/`%safe-setter`/`%make-lex-indexer` are now exported for this and later phases' sibling library files to build genuinely specialized arrays with custom indexers — the same way `(srfi 160 base)`'s `%uvec-*` helpers exist only for that package's own per-tag files.

**`lib/srfi/231/views.sld`**:
- `array-extract`/`translate`/`permute`/`reverse`/`sample` all share one 3-way dispatch shape (specialized → `specialized-array-share`; mutable-non-specialized → `make-array` with getter+setter; immutable → `make-array` with getter only), with the output mirroring the input's mode exactly.
- `array-curry`/`array-tile` break this pattern deliberately — their **outer** array is unconditionally plain immutable/non-specialized regardless of input mode (confirmed by an explicit spec quote for curry: *"B is always an immutable array... computed anew for each call"*, i.e. never cached), while their **inner** elements/tiles mirror the input mode 3-way like everything else.
- `array-permute` needed real care to get the index-rearrangement direction right (apply the permutation's *inverse* to the new multi-index to recover old coordinates) — verified against both of the spec's own worked examples.
- `array-tile`'s last-slice truncation (when an axis width doesn't divide evenly by a uniform slice size) is spec-sanctioned via an explicit `min()`, not an error — verified against the spec's own 6×6 non-uniform worked example exactly, including the truncated case.
- **`specialized-array-reshape` deliberately implements a conservative simplification** of the reference implementation's full NumPy-derived multi-group stride-matching algorithm: it succeeds zero-copy whenever the source is already `array-packed?` (the overwhelmingly common case) via a plain row-major reindex, and otherwise behaves exactly as the spec allows for a failed detection (error, or forced-copy-then-retry when `copy-on-failure?` is `#t`). Never wrongly claims an affine map exists; verified identical to the full algorithm on both of the spec's own worked examples.
- `array-copy`/`array-copy!` are implemented identically (a direct fill loop) — a deliberate, documented scope reduction versus the spec's optional extra call/cc-safety guarantee for `array-copy` specifically.

`(srfi 231)` itself remains not importable — still tracked under #1694. Remaining phases: bulk combinators + conversions, multi-array assembly.

## Test plan

- [x] `kaappi check lib/srfi/231/views.sld` — clean
- [x] Extensive manual smoke test against the spec's own worked examples (shearing, permute rank-3/rank-4, palindrome-checker-shaped reverse, 6×6 non-uniform tile with truncation, sample, both reshape success/failure cases)
- [x] New `tests/scheme/srfi/srfi231-views.scm` (75 assertions) — all pass
- [x] `zig build test` — clean
- [x] `bash tests/scheme/run-all.sh` — 1978 pass, 1 known unrelated flake (#1748, confirmed passing standalone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)