### PR TITLE
Fix CLAUDE.md: the 7 tracked macro/syntax SRFIs are issue #1699, not untriaged

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,8 +450,10 @@ SRFI 192 (port positioning) is built-in: `port-position`/`set-port-position!`/`p
 The library loader in `vm_library.zig` supports `cond-expand`, `include` (paths resolved relative to the .sld file), and `(export (rename ...))` in `define-library`. Macro transformers defined with `define-syntax` in library `begin` blocks are exported and imported correctly.
 
 Of the 208 final SRFIs in the registry, 171 are implemented, 7 are tracked
-for future implementation (72, 139, 147, 148, 149, 211, 213 — untriaged;
-no issue filed and no exclusion decision made yet), and 30 are excluded —
+for future implementation (72, 139, 147, 148, 149, 211, 213 — issue #1699,
+"Implement SRFI macro & syntax extension libraries": all 7 need expander
+or compiler changes, e.g. 72's explicit-renaming macros, 139's syntax
+parameters, 147/148's custom/eager macro transformers), and 30 are excluded —
 see `docs/dev/srfi-exclusions.md` for the full rationale. Issue #1694 (the
 numeric-vector and array family) is now fully closed: the vector-family
 subset — 4 (already shipped pre-Phase-4, just undocumented until Phase 4


### PR DESCRIPTION
## Summary

Small follow-up to #1755. That PR's SRFI-count reconciliation correctly identified `72, 139, 147, 148, 149, 211, 213` as the 7 genuinely-still-tracked final SRFIs, but described them as "untriaged; no issue filed" — checking `gh issue list` afterward turned up issue #1699 ("Implement SRFI macro & syntax extension libraries"), which already tracks exactly this set (filed and open, predating this session).

Fixes the one sentence in CLAUDE.md's "Of the 208 final SRFIs" paragraph to reference #1699 instead.

## Test plan

- [x] Doc-only change, no code/test impact
- [x] Confirmed via `gh issue view 1699` that its scope is exactly `72, 139, 147, 148, 149, 211, 213`
- [x] Confirmed via `gh issue list --search` that no other open issue duplicates or supersedes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)