### PR TITLE
Ship lib/kaappi/ in the release library tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,7 +270,11 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Bundle portable libraries
-        run: tar czf kaappi-lib.tar.gz lib/srfi/ lib/chibi/ LICENSE
+        # Pack the whole lib/ tree, never an enumerated subset: listing
+        # lib/srfi/ and lib/chibi/ here is how lib/kaappi/ was silently
+        # missing from every release tarball v0.18.0–v0.21.0, making the
+        # documented (kaappi parallel) unimportable on stock installs (#1741).
+        run: tar czf kaappi-lib.tar.gz lib/ LICENSE
 
       - name: Collect binaries, generate checksums, and sign
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   chain — archive present, `kaappi doctor` clean, and a compiled binary that
   runs — so this cannot silently regress.
 
+- **`(kaappi parallel)` now ships in the release library bundle** — the
+  release workflow packed `kaappi-lib.tar.gz` from an enumerated list
+  (`lib/srfi/`, `lib/chibi/`) that predates `lib/kaappi/`, so
+  `(import (kaappi parallel))` failed with "library not found" on every
+  installed release from v0.18.0 through v0.21.0 even though the library is
+  documented, correct in the source tree, and already embedded in the binary
+  for `--sandbox` and WASM. The bundle now packs the whole `lib/` tree, and
+  the post-release acceptance suite imports one disk-loaded library per
+  shipped `lib/` subdirectory — including a real `parallel-map` run — on
+  every platform leg, so omitting a library directory from the tarball can
+  no longer go unnoticed (#1741).
+
 #### SRFI 115 (regular expressions)
 
 - **`w/ascii` and `w/unicode` were no-ops** — both were accepted and ignored,

--- a/tests/acceptance/acceptance.sh
+++ b/tests/acceptance/acceptance.sh
@@ -133,6 +133,42 @@ assert_output "scheme write" '(import (scheme write)) (display "ok")' 'ok'
 assert_output "srfi 1" '(import (srfi 1)) (display (iota 5))' '(0 1 2 3 4)'
 assert_output "srfi 69" '(import (srfi 69)) (let ((h (make-hash-table))) (hash-table-set! h "k" 42) (display (hash-table-ref h "k")))' '42'
 
+# srfi 1/69 above are built into the binary and import even with no libraries
+# installed. The three tests below load .sld files from the installed
+# ~/.kaappi/lib tree — one per subdirectory the release tarball must ship
+# (srfi/, chibi/, kaappi/) — so each fails if kaappi-lib.tar.gz omits its
+# directory (#1741). They must not see the source checkout: from a checkout
+# cwd `./lib/<rel>` resolves before ~/.kaappi/lib, and a binary inside the
+# checkout (release/, zig-out/bin/) reaches the same tree via its
+# <exe>/../lib fallback — either would mask a broken tarball. So copy the
+# binary to a neutral directory and run these from there, where only the
+# installed libraries can satisfy the import.
+INSTALLED_TMP=$(mktemp -d)
+trap 'rm -rf "$INSTALLED_TMP"' EXIT
+mkdir -p "$INSTALLED_TMP/bin"
+KAAPPI_SRC=$(command -v "$KAAPPI" || echo "$KAAPPI")
+cp "$KAAPPI_SRC" "$INSTALLED_TMP/bin/$(basename "$KAAPPI_SRC")"
+KAAPPI_INSTALLED="$INSTALLED_TMP/bin/$(basename "$KAAPPI_SRC")"
+
+assert_installed_output() {
+    local label="$1"
+    local expr="$2"
+    local expected="$3"
+    local output
+    output=$(cd "$INSTALLED_TMP" && echo "$expr" | "$KAAPPI_INSTALLED" 2>&1 || true)
+    if echo "$output" | grep -qF "$expected"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected '$expected', got: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_installed_output "srfi 8 (disk-loaded)" '(import (srfi 8)) (receive (a b) (values 1 2) (display (+ a b)))' '3'
+assert_installed_output "chibi test (disk-loaded)" '(import (chibi test)) (display "ok")' 'ok'
+assert_installed_output "kaappi parallel (disk-loaded)" '(import (kaappi parallel)) (display (parallel-map (lambda (n) (* n n)) (list 1 2 3 4 5)))' '(1 4 9 16 25)'
+
 # --- File execution ---
 echo
 echo "-- File execution --"


### PR DESCRIPTION
Fixes #1741.

## Root cause

The release workflow's "Bundle portable libraries" step packed an enumerated list:

```
tar czf kaappi-lib.tar.gz lib/srfi/ lib/chibi/ LICENSE
```

The list dates to PR #3 and predates `lib/kaappi/`, so `lib/kaappi/parallel.sld` (the `(kaappi parallel)` pools library, KEP-0002 Phase 5) never shipped — every release from **v0.18.0 through v0.21.0** installs a `~/.kaappi/lib` with no `kaappi/` directory, and `(import (kaappi parallel))` fails with `library not found` on a stock install. The library itself is correct, documented on the docs site, and already embedded in the binary for `--sandbox`/WASM (so the playground was never affected) — only the native disk-load path on installed binaries was broken. `lib/` has exactly three tracked subdirectories (`srfi/`, `chibi/`, `kaappi/`); the other two were included, `kaappi/` was the only omission.

## Changes

- **`.github/workflows/release.yml`** — pack the whole `lib/` tree (`tar czf kaappi-lib.tar.gz lib/ LICENSE`) instead of an enumerated subset, so a future subdirectory cannot be silently dropped. Verified the only content delta vs. the old invocation is `lib/kaappi/parallel.sld` (+2.3 KB); the extraction layout is unchanged, so `install.sh` (which copies `libextract/lib/*` wholesale) and the post-release install steps need no changes.
- **`tests/acceptance/acceptance.sh`** — regression guard. The suite previously imported only built-in libraries (`srfi 1`/`69`), which resolve with *no* libraries installed; worse, it runs from the repo checkout, where cwd-relative `./lib` and the binary's `<exe>/../lib` fallback (#1523) both resolve the full source tree — so even a well-intended import test would have been masked. The new `assert_installed_output` helper copies the binary to a neutral temp dir and runs from there, so only the installed `~/.kaappi/lib` can satisfy the import; one disk-loaded import per shipped `lib/` subdirectory (`srfi 8`, `chibi test`, and `kaappi parallel` running a real `parallel-map`).
- **`CHANGELOG.md`** — Unreleased → Fixed entry.

## Verification

End-to-end A/B against a locally built binary at a neutral path, with tarballs built by the old and new invocations extracted into a fake `$HOME` exactly as `install.sh` does:

- old tarball: `(import (kaappi parallel))` → `error[KP2001]: library not found: (kaappi.parallel)` (the exact #1741 failure); `srfi 8`/`chibi test` pass
- new tarball: all pass, `parallel-map` yields `(1 4 9 16 25)` (the docs sample)

Full acceptance suite, CI-shaped (cwd = checkout, binary inside checkout):

- against the old tarball's install: **34 passed, 1 failed** — exactly the new `kaappi parallel (disk-loaded)` test, proving the guard binds despite the checkout's lib tree being reachable
- against the new tarball's install: **35 passed, 0 failed**

`release.yml` parses as valid YAML. No `.zig` files touched.

## Note for the next release

Since v0.21.0 is the latest release and its installs are missing a documented feature, a **v0.21.1 patch release** is worth considering — the fix only takes effect when a release runs the workflow. (Considered and rejected: making native non-sandbox loads fall back to the embedded copy — it would cover only the two embedded libraries, not the other ~200 shipped `.sld` files, and would mask install-layout problems like this one instead of surfacing them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)