### PR TITLE
Reseed the default random source in fork(2)ed children

### DIFF
--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const platform = @import("platform.zig");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
@@ -27,20 +28,65 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "%rs-next-real", .func = &rsNextRealFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
 };
 
+// A fork(2)ed child inherits the parent's PRNG state, and the default source
+// is created eagerly at VM startup — so without intervention every forked
+// child (e.g. each http-listen-prefork worker, which forks via the FFI)
+// continues the parent's exact stream, and all workers draw identical
+// "random" values. The atfork child handler only flips a flag: it can run in
+// the forked child of a multithreaded parent, where anything beyond a plain
+// word write (libc locks, allocation, getrandom) is off-limits. getRS does
+// the actual reseed at the next touch.
+const has_fork = builtin.os.tag != .windows and builtin.os.tag != .wasi;
+
+var atfork_installed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+fn atforkChildMarkStale() callconv(.c) void {
+    if (vm_mod.vm_instance) |vm| vm.default_rs_needs_reseed = true;
+}
+
+fn installAtForkReseed() void {
+    if (atfork_installed.swap(true, .acq_rel)) return;
+    const c = struct {
+        extern fn pthread_atfork(
+            prepare: ?*const fn () callconv(.c) void,
+            parent: ?*const fn () callconv(.c) void,
+            child: ?*const fn () callconv(.c) void,
+        ) c_int;
+    };
+    _ = c.pthread_atfork(null, null, &atforkChildMarkStale);
+}
+
 pub fn initDefaultRS(vm: *vm_mod.VM) void {
+    if (comptime has_fork) installAtForkReseed();
     vm.default_random_source = vm.gc.allocRandomSource(freshSeed()) catch return;
+    vm.default_rs_needs_reseed = false;
 }
 
 pub fn ensureDefaultRS() void {
     const vm = vm_mod.vm_instance orelse return;
     if (vm.default_random_source == types.VOID) {
         vm.default_random_source = vm.gc.allocRandomSource(freshSeed()) catch return;
+        vm.default_rs_needs_reseed = false;
     }
 }
 
 fn getRS(proc: []const u8, v: Value) PrimitiveError!*types.RandomSource {
     if (!types.isRandomSource(v)) return primitives.typeError(proc, "random-source", v);
-    return types.toObject(v).as(types.RandomSource);
+    const rs = types.toObject(v).as(types.RandomSource);
+    if (vm_mod.vm_instance) |vm| {
+        if (vm.default_rs_needs_reseed and v == vm.default_random_source) {
+            // First default-source touch in a forked child: replace the
+            // inherited parent state with fresh OS entropy, in place — the
+            // same heap object stays valid for (srfi 27)'s load-time
+            // `default-random-source` snapshot binding. Clearing the flag
+            // before the caller runs also keeps an explicit randomize!/
+            // pseudo-randomize!/state-set! authoritative: their mutation
+            // lands after this one.
+            vm.default_rs_needs_reseed = false;
+            rs.prng = std.Random.DefaultPrng.init(freshSeed());
+        }
+    }
+    return rs;
 }
 
 fn randomIntegerFn(args: []const Value) PrimitiveError!Value {

--- a/src/tests_random_port.zig
+++ b/src/tests_random_port.zig
@@ -1,6 +1,8 @@
-//! Unit tests for the SRFI-271 random generator core (types.RandomGen) and
-//! the OS entropy fill (platform.osRandomBytes). End-to-end library semantics
-//! are covered by tests/scheme/srfi/srfi271.scm.
+//! Unit tests for the SRFI-271 random generator core (types.RandomGen), the
+//! OS entropy fill (platform.osRandomBytes), and the SRFI-27 default random
+//! source's after-fork reseed mechanism (primitives_random.zig). End-to-end
+//! library semantics are covered by tests/scheme/srfi/srfi271.scm; the real
+//! fork(2) wiring by tests/scheme/ffi/fork-reseed.scm.
 
 const std = @import("std");
 const types = @import("types.zig");
@@ -82,4 +84,33 @@ test "randomized RandomGen yields real entropy bytes (never null on a healthy ho
     var g = types.RandomGen{ .kind = .randomized };
     // Exercise the entropy-refill path many times over (~13 blocks).
     for (0..100) |_| try testing.expect(g.nextByte() != null);
+}
+
+test "stale default random source reseeds in place on next draw (fork child, #atfork)" {
+    const th = @import("testing_helpers.zig");
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(random-integer 1000000)");
+    const src_val = ctx.vm.default_random_source;
+    const rs = types.toObject(src_val).as(types.RandomSource);
+
+    // Learn where one draw takes the current state, then rewind.
+    const saved = rs.prng;
+    _ = try ctx.vm.eval("(random-integer 1000000)");
+    const advanced = rs.prng;
+    rs.prng = saved;
+
+    // What the pthread_atfork child handler does in a forked child.
+    ctx.vm.default_rs_needs_reseed = true;
+
+    _ = try ctx.vm.eval("(random-integer 1000000)");
+    try testing.expect(!ctx.vm.default_rs_needs_reseed);
+    // Same heap object: (srfi 27)'s load-time default-random-source
+    // snapshot must stay the live default.
+    try testing.expectEqual(src_val, ctx.vm.default_random_source);
+    // Without the reseed, replaying `saved` would land exactly on
+    // `advanced`; a fresh OS-entropy seed collides only with ~2^-64 odds.
+    try testing.expect(!std.meta.eql(rs.prng, advanced));
 }

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -319,6 +319,10 @@ pub const VM = struct {
     compile_collect_files: ?*std.StringHashMap([]const u8) = null,
     param_overrides: std.AutoHashMap(usize, Value) = undefined,
     default_random_source: Value = types.VOID,
+    /// Set by the pthread_atfork child handler (primitives_random.zig): this
+    /// process inherited the default source's PRNG state from its parent at
+    /// fork(2), and the next use must reseed it in place before drawing.
+    default_rs_needs_reseed: bool = false,
     scheduler: ?*@import("fiber.zig").FiberScheduler = null,
     current_fiber: ?*@import("fiber.zig").Fiber = null,
     /// Per-OS-thread I/O readiness/timer multiplexer (KEP-0001). Lazily

--- a/tests/scheme/ffi/fork-reseed.scm
+++ b/tests/scheme/ffi/fork-reseed.scm
@@ -1,0 +1,76 @@
+;; Regression test: a fork(2)ed child must not inherit the parent's default
+;; random source PRNG state. The default source is created eagerly at VM
+;; startup, so before this fix EVERY forked child (e.g. kaappi-http's
+;; http-listen-prefork workers) continued the parent's exact stream — all
+;; workers drew identical values, which meant identical kaappi-web session
+;; ids across workers. The pthread_atfork child handler marks the source
+;; stale and the next draw reseeds it in place from OS entropy.
+(import (scheme base) (scheme write) (scheme file) (scheme process-context))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(cond-expand
+  (posix
+
+   (define libc (ffi-open #f))
+   (define c-fork (ffi-fn libc "fork" '() 'int))
+   (define c-wait (ffi-fn libc "wait" '(pointer) 'int))
+
+   (define (draw-n n)
+     (let loop ((i 0) (acc '()))
+       (if (= i n)
+           (reverse acc)
+           (loop (+ i 1) (cons (random-integer 1000000000) acc)))))
+
+   ;; Advance the parent's default source so fork copies a mid-stream
+   ;; state, then agree on a scratch path before forking.
+   (define tmpfile
+     (string-append "/tmp/kaappi-fork-reseed-"
+                    (number->string (random-integer 1000000))
+                    ".tmp"))
+   (define warmup (draw-n 3))
+
+   (flush-output-port (current-output-port))
+   (let ((pid (c-fork)))
+     (cond
+       ((= pid 0)
+        ;; Child: draw and report back through the scratch file. Exit on
+        ;; every path so the child can never fall through into the
+        ;; parent's half of the test.
+        (guard (e (#t (exit 70)))
+          (call-with-output-file tmpfile
+            (lambda (p) (write (draw-n 8) p))))
+        (exit 0))
+       ((> pid 0)
+        (c-wait 0)
+        (let ((parent-draws (draw-n 8))
+              (child-draws (and (file-exists? tmpfile)
+                                (call-with-input-file tmpfile read))))
+          (check "child wrote 8 draws"
+                 (and (list? child-draws) (length child-draws)) 8)
+          ;; Before the fix these were equal element-for-element: the child
+          ;; continued the parent's PRNG stream. After it, the child's
+          ;; first draw reseeds from fresh OS entropy.
+          (check "child draws differ from parent's post-fork draws"
+                 (equal? child-draws parent-draws) #f)
+          (when (file-exists? tmpfile) (delete-file tmpfile))))
+       (else
+        (check "fork succeeded" (> pid 0) #t)))))
+
+  (else
+   (display "SKIP: fork-reseed needs POSIX fork") (newline)))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "fork-reseed tests failed" fail))


### PR DESCRIPTION
## Why

The default SRFI 27 random source is created **eagerly** at VM registration (`initDefaultRS` in `registerAll`/`registerSandboxed`), so a `fork(2)`ed child always inherits the parent's PRNG state. Every `http-listen-prefork` worker (kaappi-http forks via FFI `fork`) therefore continued the parent's exact stream: all workers drew identical "random" values — e.g. identical kaappi-web session IDs across workers (kaappi-web#1 fixed those IDs' *intra*-process collisions; this closes the *cross*-process hole). The new regression test demonstrates it directly: before this fix, a forked child's 8 draws are element-for-element identical to the parent's next 8 draws.

## How

- A `pthread_atfork` **child handler** marks the source stale. The handler only writes one word (`vm.default_rs_needs_reseed = true`): in the forked child of a multithreaded parent, anything that can take a libc lock or allocate is off-limits, so the handler defers the real work.
- The next touch of the default source reseeds it **in place** from OS entropy, in `getRS` — the single funnel every source-touching primitive goes through (`random-integer`, `random-real`, `%rs-next-int`/`-real` closures, `randomize!`, `state-ref`/`set!`).
  - *In place* because `lib/srfi/27.sld` snapshots `(%default-random-source)` into its `default-random-source` binding at load time — object identity must survive the reseed.
  - *Flag-cleared-first* so an explicit `random-source-randomize!`/`pseudo-randomize!`/`state-set!` in the child stays authoritative (its mutation lands after the automatic one).
- Windows and WASI have no `fork`; the handler is compiled out there. Installation is guarded by an atomic swap (`std.once` no longer exists in Zig 0.16).

## Testing

- `tests/scheme/ffi/fork-reseed.scm` — real `fork(2)` via FFI, child reports its draws through a scratch file; **fails before the fix** (child ≡ parent) and passes after. Skips via `cond-expand` on non-POSIX.
- State-replay unit test in `tests_random_port.zig`: rewind the source's state, set the flag as the atfork handler would, draw — the state must *not* land where a pure replay would (identity of the heap object also asserted).
- Full unit suite and full Scheme suite green (1986 pass, 0 fail).
- Cross-compiled `x86_64-linux`, `aarch64-windows`, `aarch64-netbsd`, and `wasm` to exercise the comptime gates on every OS class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)