### PR TITLE
Extend SRFI 147 with begin-wrapped and bare-alias transformer specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,13 +567,23 @@ example, a `syntax-rules*` that auto-wraps multi-form templates in
 `resolveTransformerSpec`, which expands a non-literal spec via the same
 `expander.expandMacro` every ordinary macro call already goes through,
 looping (depth-bounded) until it bottoms out at a literal `syntax-rules`
-form. Two of the grammar's other new alternatives -- a bare keyword
-aliasing an existing one (including a builtin special form, which has no
-`Transformer`-shaped value to alias to, since builtins are recognized
-structurally rather than through the macro table) and a macro use
-expanding to `(begin <definition>... <transformer-spec>)` -- are
-deliberately not implemented, since neither is needed by SRFI 148 (the
-reason 147 was implemented in the first place).
+form. The grammar's other two new alternatives -- a bare keyword aliasing
+an existing one, and a macro use expanding to `(begin <definition>...
+<transformer-spec>)` -- were initially deferred as unneeded by SRFI 148
+(the reason 147 was implemented), then shipped in a same-week follow-up
+once tracing SRFI 148's actual reference implementation (not just its
+spec prose) showed its core `em-syntax-rules-aux1`/`em-syntax-rules-aux2`
+mechanism bottoms out through exactly `(begin (define-syntax a spec) a)`
+-- a helper definition followed by a bare reference to it, needing both
+alternatives together. `resolveTransformerSpecRec`'s contract changed
+accordingly: it now returns an already-parsed `Transformer` (not raw
+`syntax-rules` source), because the bare-symbol alias case has no source
+to hand back, only a `Transformer` an earlier step already parsed --
+looked up directly in the same `merged_macros` map the resolution loop
+already threads through. Aliasing a builtin special form still correctly
+falls through to `InvalidSyntax`: builtins are recognized structurally in
+`ir_mod.isSpecialForm`, never stored as `Transformer` values in that map,
+so there is nothing for a bare-symbol lookup to find.
 
 Verifying this against just its own worked example wasn't enough --
 `bash tests/scheme/run-all.sh` caught two real, generalizable bugs that no

--- a/lib/srfi/147.sld
+++ b/lib/srfi/147.sld
@@ -1,17 +1,22 @@
 ;;; SRFI 147 — Custom macro transformers.
 ;;;
 ;;; Extends R7RS's <transformer spec> grammar (previously only a literal
-;;; `(syntax-rules ...)` form) with two more alternatives: a bare keyword
-;;; (making the new name an alias for an existing one) and a macro use
-;;; that itself expands -- possibly through several steps -- to one of
-;;; the other alternatives. This lets a library define its own named
-;;; transformer-generating-transformer, e.g. the spec's own `syntax-rules*`
-;;; worked example, which automatically wraps multi-form templates in
-;;; `begin` so `((foo a b) (define a 1) (define b 2))` need not be written
-;;; as `((foo a b) (begin (define a 1) (define b 2)))`. SRFI 148's
-;;; `em-syntax-rules` -- the reason this SRFI was implemented -- is exactly
-;;; this pattern: its own transformer-spec use expands to a nested literal
-;;; `syntax-rules` form.
+;;; `(syntax-rules ...)` form) with three more alternatives: a bare
+;;; keyword (making the new name an alias for an existing one), a `(begin
+;;; <definition>... <transformer spec>)` form (letting a transformer-
+;;; generating-transformer introduce its own private helper macros while
+;;; building up the final spec), and a macro use that itself expands --
+;;; possibly through several steps -- to one of the other alternatives.
+;;; This lets a library define its own named transformer-generating-
+;;; transformer, e.g. the spec's own `syntax-rules*` worked example, which
+;;; automatically wraps multi-form templates in `begin` so `((foo a b)
+;;; (define a 1) (define b 2))` need not be written as `((foo a b) (begin
+;;; (define a 1) (define b 2)))`. SRFI 148's `em-syntax-rules` -- the
+;;; reason this SRFI was implemented -- needs the `begin` and bare-keyword
+;;; alternatives together: its own reference implementation's
+;;; `em-syntax-rules-aux1`/`em-syntax-rules-aux2` bottoms out through
+;;; exactly `(begin (define-syntax a spec) a)`, a private helper followed
+;;; by a bare reference to it.
 ;;;
 ;;; Kaappi's `define-syntax`/`let-syntax`/`letrec-syntax` are native
 ;;; compiler forms, not macros a portable library could redefine (the
@@ -24,20 +29,19 @@
 ;;; via the same `expander.expandMacro` every ordinary macro call already
 ;;; goes through, reusing the `NESTED_SR_FLAG`/`USERTEXT_MARKER`
 ;;; infrastructure built for SRFI 257's if-new-var idiom (a macro whose own
-;;; template constructs a nested `syntax-rules` form). So, like SRFI 46
-;;; and SRFI 149, this library is a conformance statement, not new
+;;; template constructs a nested `syntax-rules` form); a bare symbol is
+;;; resolved by direct lookup in the same macro table instead. So, like
+;;; SRFI 46 and SRFI 149, this library is a conformance statement, not new
 ;;; functionality on its own: it just re-exports the same
 ;;; `define-syntax`/`let-syntax`/`letrec-syntax`/`syntax-rules` already
 ;;; bound in `(scheme base)`.
 ;;;
-;;; Two of the grammar's alternatives are deliberately NOT implemented
-;;; (documented scope reduction, matching this codebase's practice of
-;;; shipping an honest, reduced subset): a bare keyword aliasing an
-;;; existing one -- including a builtin special form, which has no
-;;; `Transformer`-shaped value in the compiler's macro table to alias to,
-;;; since builtins are recognized structurally rather than through that
-;;; table -- and a macro use expanding to `(begin <definition>...
-;;; <transformer-spec>)`. Neither is needed by SRFI 148.
+;;; One case is deliberately NOT implemented (documented scope reduction,
+;;; matching this codebase's practice of shipping an honest, reduced
+;;; subset): aliasing a builtin special form (`if`, `lambda`, etc.), which
+;;; has no `Transformer`-shaped value in the compiler's macro table to
+;;; alias to, since builtins are recognized structurally rather than
+;;; through that table. Aliasing any other, user-defined macro works.
 (define-library (srfi 147)
   (import (only (scheme base) define-syntax let-syntax letrec-syntax syntax-rules))
   (export define-syntax let-syntax letrec-syntax syntax-rules))

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -304,21 +304,13 @@ pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!
     if (rest == types.NIL) return CompileError.InvalidSyntax;
     const transformer_spec = types.car(rest);
 
-    // A resolved spec that required expansion (SRFI 147) is freshly
-    // allocated and otherwise unrooted; parseSyntaxRules itself allocates
-    // (its own Transformer object among other things), so root across the
-    // call to survive a collection triggered from within it (#1401
-    // pattern: a fresh, unrooted allocating-call result held across a
-    // second allocating call). Pop immediately after, NOT via defer --
-    // this push/pop pair must stay strictly nested with nothing else
-    // pushed to the same LIFO root stack in between, or an unrelated
-    // later pop (e.g. this function's own transformer rooting further
-    // down) would remove the wrong entry.
-    var resolved_spec = try resolveTransformerSpec(self, transformer_spec);
-    self.gc.pushRoot(&resolved_spec);
-    const parsed = parseSyntaxRules(self, resolved_spec, &.{});
-    self.gc.popRoot();
-    const transformer = parsed catch return CompileError.InvalidSyntax;
+    // resolveTransformerSpec resolves through SRFI 147's macro-use/alias/
+    // begin alternatives (if any), bottoming out at a parsed Transformer --
+    // freshly allocated and otherwise unrooted, exactly like a direct
+    // parseSyntaxRules call used to be here. Root it immediately below via
+    // extra_roots.append, with nothing able to allocate via the GC in
+    // between.
+    const transformer = try resolveTransformerSpec(self, transformer_spec);
 
     // Root the transformer for the rest of the enclosing compile scope: it
     // lives only in the compiler-local macro map, which the GC cannot see,
@@ -392,15 +384,13 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         const binding_rest = types.cdr(binding);
         if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
         const transformer_spec = types.car(binding_rest);
-        // See compileDefineSyntax: root strictly around the parseSyntaxRules
-        // call, popping immediately (not via defer) -- this loop pushes
-        // tx_vals's own root for the result right after, and an
-        // out-of-order pop would remove that one instead of this one.
-        var resolved_spec = try resolveTransformerSpec(self, transformer_spec);
-        self.gc.pushRoot(&resolved_spec);
-        const parsed = parseSyntaxRules(self, resolved_spec, &.{});
-        self.gc.popRoot();
-        tx_vals.appendAssumeCapacity(parsed catch return CompileError.InvalidSyntax);
+        // resolveTransformerSpec returns an already-parsed, otherwise
+        // unrooted Transformer (see compileDefineSyntax) -- root it via
+        // tx_vals's own slot immediately after; appendAssumeCapacity
+        // doesn't allocate (capacity reserved above), so nothing can
+        // trigger a GC in between.
+        const transformer = try resolveTransformerSpec(self, transformer_spec);
+        tx_vals.appendAssumeCapacity(transformer);
         self.gc.pushRoot(&tx_vals.items[tx_vals.items.len - 1]);
         roots_pushed += 1;
         kw_names.appendAssumeCapacity(types.symbolName(keyword));
@@ -482,16 +472,11 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
         const binding_rest = types.cdr(binding);
         if (!types.isPair(binding_rest)) return CompileError.InvalidSyntax;
         const transformer_spec = types.car(binding_rest);
-        // See compileDefineSyntax: root strictly around the parseSyntaxRules
-        // call, popping immediately (not via defer) -- this loop later
-        // roots the transformer itself via extra_roots.append, and while
-        // that's a different (non-stack) mechanism, an immediate explicit
-        // pop keeps this pair safely self-contained regardless.
-        var resolved_spec = try resolveTransformerSpec(self, transformer_spec);
-        self.gc.pushRoot(&resolved_spec);
-        const parsed = parseSyntaxRules(self, resolved_spec, &.{});
-        self.gc.popRoot();
-        const transformer = parsed catch return CompileError.InvalidSyntax;
+        // resolveTransformerSpec returns an already-parsed, otherwise
+        // unrooted Transformer (see compileDefineSyntax) -- root it via
+        // extra_roots.append immediately below, nothing allocates via the
+        // GC in between.
+        const transformer = try resolveTransformerSpec(self, transformer_spec);
         const name = types.symbolName(keyword);
 
         // Root for the rest of the compile — see compileDefineSyntax (#1401).
@@ -619,23 +604,34 @@ fn computeBoundFreeRefs(self: *Compiler, transformer: Value) CompileError!void {
 // ---------------------------------------------------------------------------
 
 /// SRFI 147 (custom macro transformers): R7RS's <transformer spec> only
-/// accepts a literal `(syntax-rules ...)` form. This SRFI extends it to
-/// also accept a macro use that itself expands (possibly through several
-/// steps) to a literal `(syntax-rules ...)` form -- letting a library
-/// define its own named transformer-generating-transformer, e.g. a
-/// `syntax-rules*` that automatically wraps multi-form templates in
-/// `begin` (the SRFI's own worked example, and what SRFI 148's
-/// `em-syntax-rules` needs this for).
+/// accepts a literal `(syntax-rules ...)` form. This SRFI extends it with
+/// three more alternatives, all implemented here:
 ///
-/// Deliberately NOT implemented (documented scope reduction, matching
-/// this codebase's practice of shipping an honest, reduced subset): the
-/// grammar's other two new alternatives, a bare keyword making the new
-/// name an alias for an existing one (including a builtin special form,
-/// which has no `Transformer`-shaped value in `self.macros` to alias to
-/// -- builtins are recognized structurally in `ir_mod.isSpecialForm`, not
-/// via this map), and a macro use expanding to `(begin <definition>...
-/// <transformer-spec>)`. Neither is needed by SRFI 148, the reason this
-/// SRFI was implemented.
+///  1. A macro use that itself expands (possibly through several steps)
+///     to a literal `(syntax-rules ...)` form -- letting a library define
+///     its own named transformer-generating-transformer, e.g. a
+///     `syntax-rules*` that automatically wraps multi-form templates in
+///     `begin` (the SRFI's own worked example).
+///  2. A bare keyword making the new name an alias for an existing
+///     *user-defined* one (resolved via a direct `merged_macros` lookup).
+///     A builtin special form is NOT aliasable this way: builtins are
+///     recognized structurally in `ir_mod.isSpecialForm`, never stored as
+///     `Transformer` values in `merged_macros`, so aliasing one correctly
+///     falls through to `InvalidSyntax` -- there's nothing to find.
+///  3. A macro use expanding to `(begin <definition>... <transformer
+///     spec>)`, letting a transformer-generating-transformer introduce
+///     its own private helper macros while building up the final spec.
+///
+/// SRFI 148's `em-syntax-rules` -- the reason this SRFI was implemented --
+/// needs alternatives 2 and 3 together, not just 1: tracing its reference
+/// implementation's own `em-syntax-rules-aux1`/`em-syntax-rules-aux2`
+/// shows its core expansion mechanism bottoms out through exactly
+/// `(begin (define-syntax a spec) a)` -- a begin-wrapped form whose FINAL
+/// element is a bare reference to the helper just defined, not a fresh
+/// macro use or literal `syntax-rules` form. An initial, shallower
+/// research pass wrongly concluded alternatives 2 and 3 weren't needed;
+/// this correction shipped once the actual reference implementation
+/// (not just the spec prose) was traced through.
 fn resolveTransformerSpec(self: *Compiler, spec_in: Value) CompileError!Value {
     // A transformer-spec can be compiled inside a nested child Compiler
     // scope (e.g. a let-syntax whose own body sits inside `guard`'s
@@ -680,25 +676,88 @@ fn resolveTransformerSpec(self: *Compiler, spec_in: Value) CompileError!Value {
         merged_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return CompileError.OutOfMemory;
     }
 
+    var steps: u32 = 0;
+    return resolveTransformerSpecRec(self, spec_in, &merged_macros, &steps);
+}
+
+/// The actual resolution loop, factored out so a `(begin (define-syntax
+/// NAME spec) ...)` alternative can recurse into itself to resolve each
+/// internal helper's own spec, sharing the same `merged_macros` (so a
+/// later helper, or the final transformer-spec, can reference an earlier
+/// one) and the same expansion-step budget (so a pathological chain of
+/// nested begins can't bypass MAX_MACRO_EXPANSION_DEPTH). Returns an
+/// already-parsed Transformer, not raw `syntax-rules` source -- required
+/// because the bare-symbol alias case (below) has no source to hand back,
+/// only a Transformer some earlier step already parsed.
+fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *std.StringHashMap(Value), steps: *u32) CompileError!Value {
     var spec = spec_in;
     self.gc.pushRoot(&spec);
     defer self.gc.popRoot();
-    var steps: u32 = 0;
     while (true) {
+        // Alternative 2: a bare identifier aliases whatever transformer
+        // that name already resolves to -- either a helper this same
+        // begin-unwrap just registered (the shape SRFI 148 needs:
+        // `(begin (define-syntax a spec) a)`) or any other macro already
+        // visible here. A name absent from merged_macros (including any
+        // builtin special form, never stored there) correctly falls
+        // through to InvalidSyntax: there is no Transformer to alias.
+        if (types.isSymbol(spec)) {
+            return merged_macros.get(types.symbolName(spec)) orelse CompileError.InvalidSyntax;
+        }
         if (!types.isPair(spec)) return CompileError.InvalidSyntax;
         const head = types.car(spec);
         if (!types.isSymbol(head)) return CompileError.InvalidSyntax;
-        if (std.mem.eql(u8, types.symbolName(head), "syntax-rules")) return spec;
-        const transformer = merged_macros.get(types.symbolName(head)) orelse return CompileError.InvalidSyntax;
-        steps += 1;
-        if (steps > MAX_MACRO_EXPANSION_DEPTH) return CompileError.InvalidSyntax;
+        const head_name = types.symbolName(head);
+        if (std.mem.eql(u8, head_name, "syntax-rules")) return parseSyntaxRules(self, spec, &.{});
+        if (std.mem.eql(u8, head_name, "begin")) {
+            // spec = (begin def1 def2 ... final-spec). Each def must be a
+            // literal (define-syntax NAME SPEC); SPEC may itself need
+            // further resolution (another macro-use, alias, or nested
+            // begin), so it recurses through this same function --
+            // yielding an already-parsed Transformer directly, with no
+            // separate parse step needed here -- before being registered
+            // transiently into `merged_macros`, visible to later defs and
+            // the final spec within THIS resolution but never leaking
+            // into the enclosing scope.
+            var rest = types.cdr(spec);
+            if (!types.isPair(rest)) return CompileError.InvalidSyntax;
+            while (types.isPair(types.cdr(rest))) {
+                const def = types.car(rest);
+                if (!types.isPair(def)) return CompileError.InvalidSyntax;
+                const def_head = types.car(def);
+                if (!types.isSymbol(def_head) or !std.mem.eql(u8, types.symbolName(def_head), "define-syntax"))
+                    return CompileError.InvalidSyntax;
+                const def_rest1 = types.cdr(def);
+                if (!types.isPair(def_rest1)) return CompileError.InvalidSyntax;
+                const def_name_sym = types.car(def_rest1);
+                if (!types.isSymbol(def_name_sym)) return CompileError.InvalidSyntax;
+                const def_rest2 = types.cdr(def_rest1);
+                if (!types.isPair(def_rest2)) return CompileError.InvalidSyntax;
+                const def_spec_raw = types.car(def_rest2);
+                const def_transformer = try resolveTransformerSpecRec(self, def_spec_raw, merged_macros, steps);
+                // Root for the rest of this compile scope immediately --
+                // it lives only in merged_macros (a local Zig hashmap,
+                // not GC-scanned), matching compileDefineSyntax's own
+                // top-level transformer rooting (#1401 pattern). Nothing
+                // between the recursive call's return and this line
+                // allocates via the GC.
+                self.gc.extra_roots.append(self.gc.allocator, def_transformer) catch return CompileError.OutOfMemory;
+                merged_macros.put(types.symbolName(def_name_sym), def_transformer) catch return CompileError.OutOfMemory;
+                rest = types.cdr(rest);
+            }
+            spec = types.car(rest);
+            continue;
+        }
+        const transformer = merged_macros.get(head_name) orelse return CompileError.InvalidSyntax;
+        steps.* += 1;
+        if (steps.* > MAX_MACRO_EXPANSION_DEPTH) return CompileError.InvalidSyntax;
         const use_check = expander.UseSiteBindingCheck{
             .ctx = @ptrCast(self),
             .resolve_fn = &resolveLocalSkipAliases,
             .frame_resolve_fn = &resolveSameFrameLocal,
         };
         self.gc.no_collect += 1;
-        spec = expander.expandMacro(self.gc, spec, transformer, self.globals, &merged_macros, use_check) catch |err| {
+        spec = expander.expandMacro(self.gc, spec, transformer, self.globals, merged_macros, use_check) catch |err| {
             self.gc.no_collect -= 1;
             return switch (err) {
                 error.OutOfMemory => CompileError.OutOfMemory,

--- a/tests/scheme/srfi/srfi147.scm
+++ b/tests/scheme/srfi/srfi147.scm
@@ -2,10 +2,11 @@
 ;; genuinely needed an engine change: compileDefineSyntax/compileLetSyntax/
 ;; compileLetrecSyntax (src/compiler_macro.zig) now resolve a
 ;; transformer-spec through resolveTransformerSpec before parsing it, so a
-;; macro use that itself expands to a literal (syntax-rules ...) form is
-;; accepted anywhere a transformer-spec is expected. See lib/srfi/147.sld's
-;; header for the full rationale and the deliberately-deferred grammar
-;; alternatives (bare-keyword aliasing, begin-wrapped definitions). Part of
+;; macro use that itself expands (possibly through a bare-keyword alias or
+;; a begin-wrapped helper definition) to a literal (syntax-rules ...) form
+;; is accepted anywhere a transformer-spec is expected. See
+;; lib/srfi/147.sld's header for the full rationale and the one
+;; deliberately-deferred case (aliasing a builtin special form). Part of
 ;; issue #1699 (SRFI macro & syntax extension libraries).
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi147.scm
 
@@ -50,18 +51,106 @@
  (let-syntax ((multi (alias-of-syntax-rules* (((multi a b) (+ a b) (* a b))))))
    (multi 1 2)))
 
-;;; --- deliberately deferred: a bare keyword aliasing an existing one
-;;; (including a builtin special form) is not supported ---
+;;; --- deliberately deferred: a bare keyword aliasing a BUILTIN special
+;;; form is not supported (builtins have no Transformer value to alias to) ---
 (test-equal #t (guard (e (#t #t)) (eval '(let-syntax ((my-if if)) (my-if #t 1 2)) (interaction-environment)) #f))
 
-;;; --- deliberately deferred: a macro use expanding to
-;;; (begin <definition>... <transformer-spec>) is not supported ---
+;;; --- a bare keyword aliasing an existing, non-builtin macro IS supported ---
+(test-equal
+ 7
+ (let-syntax ((original (syntax-rules () ((_ a) (+ a 3)))))
+   (let-syntax ((alias original))
+     (alias 4))))
+
+;;; --- the em-syntax-rules-aux1/aux2 shape SRFI 148 actually needs: a
+;;; macro use expands to (begin (define-syntax NAME spec) NAME) -- a
+;;; private helper followed by a bare reference to it ---
+(define-syntax gen-adder
+  (syntax-rules ()
+    ((_ n)
+     (begin
+       (define-syntax adder
+         (syntax-rules ()
+           ((_ x) (+ x n))))
+       adder))))
+
+(test-equal
+ 15
+ (let-syntax ((add10 (gen-adder 10)))
+   (add10 5)))
+
+;;; --- begin-wrapped form works in define-syntax and letrec-syntax too,
+;;; not just let-syntax ---
+(define-syntax add100 (gen-adder 100))
+(test-equal 105 (add100 5))
+
+(test-equal
+ 106
+ (letrec-syntax ((add101 (gen-adder 101)))
+   (add101 5)))
+
+;;; --- multiple internal definitions in one begin, the LAST of which is
+;;; the bare-symbol tail (not the first) ---
+(define-syntax gen-two
+  (syntax-rules ()
+    ((_ n)
+     (begin
+       (define-syntax unused-helper
+         (syntax-rules () ((_ x) (- x))))
+       (define-syntax real-helper
+         (syntax-rules () ((_ x) (* x n))))
+       real-helper))))
+
+(test-equal 24 (let-syntax ((triple (gen-two 3))) (triple 8)))
+
+;;; --- chained resolution: a begin-wrapped alias whose own helper's spec
+;;; is ANOTHER macro use that resolves to a further begin-wrapped alias
+;;; (simulating em-syntax-rules's own multi-stage aux1 -> aux2 chaining) ---
+(define-syntax stage-inner
+  (syntax-rules ()
+    ((_ n)
+     (begin
+       (define-syntax inner-helper
+         (syntax-rules () ((_ x) (* x n))))
+       inner-helper))))
+
+(define-syntax stage-outer
+  (syntax-rules ()
+    ((_ n)
+     (begin
+       (define-syntax outer-helper
+         (stage-inner n))
+       outer-helper))))
+
+(test-equal 42 (let-syntax ((chained (stage-outer 7))) (chained 6)))
+
+;;; --- zero internal definitions: (begin <transformer-spec>) with nothing
+;;; to define first is the degenerate case of the same grammar rule ---
+(define-syntax gen-plain
+  (syntax-rules ()
+    ((_ n)
+     (begin
+       (syntax-rules () ((_ x) (- x n)))))))
+
+(test-equal 8 (let-syntax ((sub2 (gen-plain 2))) (sub2 10)))
+
+;;; --- malformed begin body (something other than define-syntax before
+;;; the final spec) is a compile error, not a silent success ---
 (test-equal
  #t
  (guard (e (#t #t))
-   (eval '(let-syntax ((foo (begin (define-syntax helper (syntax-rules () ((_ x) x)))
-                                    (syntax-rules () ((foo a) (helper a))))))
-            (foo 1))
+   (eval '(let-syntax ((oops (begin (define x 1) (syntax-rules () ((_ y) y)))))
+            (oops 1))
+         (interaction-environment))
+   #f))
+
+;;; --- a bare symbol that resolves to nothing (not a helper just defined,
+;;; not any other visible macro) is a compile error ---
+(test-equal
+ #t
+ (guard (e (#t #t))
+   (eval '(let-syntax ((oops (begin (define-syntax a (syntax-rules () ((_ x) x))) b)))
+            (oops 1))
          (interaction-environment))
    #f))
 


### PR DESCRIPTION
## Summary

- Follow-up to #1760 (SRFI 147). Deeper research for SRFI 148 (the actual
  reference implementation, not just spec prose) found that
  `em-syntax-rules`'s core mechanism (`em-syntax-rules-aux1`/`aux2`)
  bottoms out through exactly `(begin (define-syntax a spec) a)` — a
  private helper definition followed by a bare reference to it. #1760
  deferred both grammar alternatives this needs based on an earlier,
  shallower research pass that concluded neither was needed.
- `resolveTransformerSpec`/`resolveTransformerSpecRec` (`src/compiler_macro.zig`)
  now handle:
  - A `(begin <definition>... <transformer-spec>)` spec: each internal
    `define-syntax` is resolved (recursively, so chained/nested begins
    work) and registered transiently, visible to later defs and the
    final spec within that resolution only.
  - A bare symbol as a terminal case: aliases whatever transformer that
    name already resolves to. This also implements SRFI 147's
    "bare keyword aliases an existing macro" alternative for any
    non-builtin target. Aliasing a builtin special form still correctly
    fails — builtins are recognized structurally and are never stored as
    `Transformer` values in the macro table a bare symbol resolves
    against.
  - The function's contract changed to return an already-parsed
    `Transformer` rather than raw `syntax-rules` source, since the
    bare-symbol case has nothing else to hand back.
- Updated `lib/srfi/147.sld`'s header and `CLAUDE.md`'s SRFI 147 section
  to reflect what's now implemented; only builtin-special-form aliasing
  remains a documented, deliberate scope reduction.
- 8 new SRFI-64 tests in `tests/scheme/srfi/srfi147.scm`: the exact
  `em-syntax-rules-aux1` shape, multi-definition begins, chained/nested
  begin resolution (simulating `aux1` → `aux2` staging), the
  zero-definition degenerate case, non-builtin bare-keyword aliasing, and
  two negative cases (malformed begin body, dangling bare-symbol alias).

## Test plan

- [x] `kaappi check` on the modified test file
- [x] Manual reproduction of the exact `em-syntax-rules-aux1`/`aux2`
      shape plus a multi-stage chained-alias variant, both correct
- [x] `tests/scheme/srfi/srfi147.scm`: 16/16 pass (8 original + 8 new)
- [x] `tests/scheme/srfi/srfi257.scm` and `srfi149.scm`/`srfi139.scm`
      (macro-heavy libraries that caught real bugs in #1760): all pass
- [x] `zig build test`: full unit suite green
- [x] `bash tests/scheme/run-all.sh`: 590 Scheme files + 1395 R7RS tests,
      0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)