### PR TITLE
Fix let_syntax_peer_names/vals leak when siblings share a Transformer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -649,6 +649,29 @@ leaked the first allocation. Fixed by merging both calls into one
 every transformer is finalized exactly once regardless of how many names
 end up pointing at it.
 
+CodeRabbit caught a fifth, adjacent instance of the exact same hazard in
+review of that fix, after CI had already auto-merged it -- shipped as its
+own immediate follow-up: `compileLetSyntax`'s sibling-suppression
+bookkeeping (`let_syntax_peer_names`/`let_syntax_peer_vals`, R7RS 4.3.1)
+lives in a separate code block in the SAME per-binding loop, outside
+`finalizeTransformer`'s reach, and has the identical "unconditionally
+`dupe` and overwrite" shape -- reachable as soon as two sibling bindings
+in one `let-syntax` form resolve to the same `Transformer` (a begin-
+wrapped helper reference for one, a bare alias of that same helper for
+the other). Verified as a real, non-hypothetical leak (not just a
+theoretical overwrite) by confirming the shared transformer's template
+has a genuinely non-empty free-reference set first -- an earlier draft's
+reproduction used a template with zero free references, where `dupe`ing
+an empty slice doesn't actually allocate, so the mutation-tested unit
+test silently failed to catch anything until the reproduction was
+corrected to reference a true sibling. Fixed with a narrower, deliberately
+non-permanent guard: a linear scan of this call's own `tx_vals` prefix for
+an identical `Value` already processed earlier in the SAME loop -- unlike
+`Transformer.finalized`, this can't be a permanent per-object flag, since
+a transformer aliased into some OTHER, unrelated `let-syntax` form later
+genuinely needs its own peer snapshot computed against that different
+form's sibling set.
+
 These differ from earlier Zig versions and are easy to get wrong:
 
 ```zig

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -415,11 +415,39 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
     var saved_values: std.ArrayList(?Value) = .empty;
     defer saved_values.deinit(self.gc.allocator);
 
-    for (kw_names.items, tx_vals.items) |name, transformer| {
+    for (kw_names.items, tx_vals.items, 0..) |name, transformer, idx| {
         saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
         try finalizeTransformer(self, transformer);
         const tx = types.toObject(transformer).as(types.Transformer);
+
+        // SRFI 147 (bare-keyword alias / begin-wrapped helper reference) can
+        // resolve two DIFFERENT bindings in the SAME let-syntax form to the
+        // exact same Transformer Value (e.g. `((p (begin (define-syntax h
+        // ...) h)) (q h))` — CodeRabbit-caught reproduction on this PR).
+        // peer_snap_names/vals are identical for every binding in this one
+        // form, and collectTransformerFreeRefs depends only on the
+        // transformer's own (here, shared) template, so recomputing for a
+        // repeat is always redundant *within this loop* — unlike
+        // `finalized`, which must stay permanent (a transformer aliased
+        // into some OTHER, unrelated let-syntax form later genuinely needs
+        // its own peer snapshot against THAT form's different siblings, so
+        // this check is deliberately scoped to just this call's own
+        // tx_vals, not a Transformer-lifetime flag). Skipping the repeat
+        // avoids re-`dupe`ing and overwriting let_syntax_peer_names/vals
+        // with no free of the first pair.
+        var already_seen = false;
+        for (tx_vals.items[0..idx]) |seen| {
+            if (seen == transformer) {
+                already_seen = true;
+                break;
+            }
+        }
+        if (already_seen) {
+            self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
+            continue;
+        }
+
         // R7RS 4.3.1 suppresses sibling keywords only for references the
         // transformer's TEMPLATE makes (definition-site free references). A
         // sibling handed to it as an argument is a use-site identifier — not a

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -1292,6 +1292,42 @@ test "SRFI 147: chained resolution through nested begin-wrapped aliases" {
     );
 }
 
+test "SRFI 147: two sibling let-syntax bindings resolving to the same Transformer don't leak" {
+    // CodeRabbit-caught on this PR: `p`'s spec is a begin-wrapped helper
+    // reference and `q`'s spec is a bare alias of the SAME helper name --
+    // compileLetSyntax's per-binding loop then holds the exact same
+    // Transformer Value in tx_vals twice. finalizeTransformer already
+    // guards captured_locals/bound_free_refs against a second pass, but
+    // let_syntax_peer_names/vals are set in a separate block in this same
+    // loop with no such guard, and unconditionally `dupe`s+overwrites on
+    // every iteration -- the second iteration (`q`) leaked the first pair
+    // of allocations (`p`'s) before this test's fix. `h`'s own template
+    // references sibling `r` (also bound by this same let-syntax) so
+    // peer_names_f/vals are genuinely non-empty for both iterations --
+    // with an EMPTY peer set the dupe of a zero-length slice doesn't
+    // actually allocate, which would make this test pass even without
+    // the fix (confirmed: the first draft of this test used a peer-free
+    // template and did not catch the leak on a mutation-test revert of
+    // the fix). Also exercises that R7RS 4.3.1 sibling suppression itself
+    // still works through the shared-Transformer path: `r`'s outer
+    // (pre-let-syntax) binding is a procedure, unrelated to the sibling
+    // macro of the same name, so `(q 42)` = `(+ 42 1)` = 43, not the
+    // sibling macro's `(* 42 100)`. Run under the Debug allocator (zig
+    // build test, no -Doptimize=ReleaseFast), which is what actually
+    // catches the leak; the returned value alone wouldn't distinguish a
+    // leak from correct behavior.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define (r y) (+ y 1))
+        \\  (equal?
+        \\   (let-syntax ((r (syntax-rules () ((_ y) (* y 100))))
+        \\                (p (begin (define-syntax h (syntax-rules () ((_ x) (r x)))) h))
+        \\                (q h))
+        \\     (q 42))
+        \\   43))
+    );
+}
+
 test "SRFI 147: zero-definition begin resolves directly to the final element" {
     try th.expectEvalTrue(
         \\(begin

--- a/tests/scheme/srfi/srfi147.scm
+++ b/tests/scheme/srfi/srfi147.scm
@@ -178,6 +178,24 @@
 (define-syntax use-minus (gen-minus 1))
 (test-equal '(11 9) (list (use-plus 10) (use-minus 10)))
 
+;;; --- two sibling let-syntax bindings resolving to the exact same
+;;; Transformer (a begin-wrapped helper reference, and a bare alias of
+;;; that same helper) must not corrupt R7RS 4.3.1 sibling suppression --
+;;; CodeRabbit-caught: this shape leaked let_syntax_peer_names/vals
+;;; before the fix, since that bookkeeping was computed unconditionally
+;;; per binding rather than once per underlying Transformer object. `r`'s
+;;; outer (pre-let-syntax) meaning is a plain procedure, unrelated to the
+;;; sibling macro of the same name that this let-syntax also introduces,
+;;; so a correct result (43, not 4200) also confirms the peer snapshot
+;;; itself is still right, not just leak-free ---
+(define (r y) (+ y 1))
+(test-equal
+ 43
+ (let-syntax ((r (syntax-rules () ((_ y) (* y 100))))
+              (p (begin (define-syntax h (syntax-rules () ((_ x) (r x)))) h))
+              (q h))
+   (q 42)))
+
 ;;; --- persistent registration inside a NESTED body scope (not top level):
 ;;; the cross-referencing shape works the same way inside a lambda body,
 ;;; and two separate invocations of the same generator in two separate


### PR DESCRIPTION
## Summary

- Follow-up to #1763, which had already auto-merged (CI passed) by the
  time CodeRabbit's review landed on it. Addresses that review's finding
  directly: https://github.com/kaappi/kaappi/pull/1763#pullrequestreview-4782288661
- CodeRabbit found the exact same overwrite-without-free hazard #1763
  had just fixed for `captured_locals`/`bound_free_refs` (via
  `finalizeTransformer`) also applies to `compileLetSyntax`'s own
  `let_syntax_peer_names`/`let_syntax_peer_vals` bookkeeping (R7RS
  4.3.1 sibling suppression), which lives in a separate code block in
  the same per-binding loop, outside `finalizeTransformer`'s reach.
  Reachable as soon as two sibling `let-syntax` bindings resolve to the
  same `Transformer` object — e.g. a begin-wrapped helper reference for
  one binding, a bare alias of that same helper for another:
  ```scheme
  (let-syntax ((p (begin (define-syntax h (syntax-rules () ((_ x) x))) h))
               (q h))
    (q 42))
  ```
- Fixed with a narrower guard than `Transformer.finalized`: a linear
  scan of this call's own `tx_vals` prefix for an identical `Value`
  already processed earlier in the *same* loop. This can't be a
  permanent per-object flag like `finalized` — a transformer aliased
  into some *other*, unrelated `let-syntax` form later genuinely needs
  its own peer snapshot computed against that different form's sibling
  set, so the check is deliberately scoped to just this one call.
- Verified the leak is real (not just a theoretical overwrite) before
  fixing: an initial reproduction using a template with zero free
  references didn't actually leak, since duping a zero-length slice
  doesn't allocate — the mutation-tested unit test only caught it once
  the reproduction was corrected to have the shared transformer
  reference a genuine sibling.
- 1 new Zig unit test (mutation-tested: confirmed it fails with the
  fix reverted, reporting 2 leaked allocations at the exact
  `let_syntax_peer_names`/`vals` `dupe` call sites) and 1 new SRFI-64
  test covering the same scenario, which also confirms R7RS 4.3.1
  sibling suppression itself still resolves correctly through the
  shared-Transformer path (the outer, pre-`let-syntax` meaning of the
  shared sibling name wins, not the sibling macro rebinding).

## Test plan

- [x] Mutation-tested: reverted the fix, confirmed the new unit test
      fails with 2 leaked allocations at the exact `dupe` call sites;
      restored the fix, confirmed it passes cleanly
- [x] `tests/scheme/srfi/srfi147.scm`: 22/22 pass; `srfi257.scm`: 34/34
- [x] `zig build test` (full suite, including `-Dtest-filter=tests_macros`):
      no failures, no leaks
- [x] `bash tests/scheme/run-all.sh`: 591 Scheme files + 1395 R7RS
      tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)