### PR TITLE
Free let_syntax_peer_names/vals before cross-form recomputation too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -672,6 +672,23 @@ a transformer aliased into some OTHER, unrelated `let-syntax` form later
 genuinely needs its own peer snapshot computed against that different
 form's sibling set.
 
+That same review flagged a sixth spot the fifth's fix didn't close: the
+`tx_vals`-prefix scan only ever catches the same `Transformer` reappearing
+*within* one `let-syntax` form. It deliberately can't (and shouldn't) skip
+recomputation when that transformer is aliased into a *different*,
+unrelated `let-syntax` form later, since that form's own sibling set
+differs and genuinely needs its own snapshot -- but the recomputation
+itself still unconditionally overwrote whatever an earlier form's
+processing had already set, with no free. Fixed by freeing the previous
+`let_syntax_peer_names`/`vals` pair immediately before every overwrite,
+regardless of which of the two cases triggered it -- confirmed via a
+second mutation-tested reproduction (the same helper aliased into two
+separate, sequential top-level `let-syntax` forms, each with its own
+distinct sibling of the same name) that the recomputation itself still
+resolves correctly (the helper's template stays bound to whichever
+sibling was in scope at its true point of origin, not whichever form last
+recomputed the snapshot).
+
 These differ from earlier Zig versions and are easy to get wrong:
 
 ```zig

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -468,6 +468,17 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
                 peer_vals_f.append(self.gc.allocator, pv) catch return CompileError.OutOfMemory;
             }
         }
+        // CodeRabbit-caught follow-up: the already_seen guard above only
+        // covers the SAME Transformer reappearing within this one
+        // let-syntax form. It genuinely CAN'T cover the transformer being
+        // aliased into some OTHER, unrelated let-syntax form later --
+        // that form's own siblings differ, so its peer snapshot must be
+        // recomputed for real, not skipped. But that recomputation still
+        // unconditionally overwrites whatever an EARLIER form's own
+        // processing left here, with no free -- so free the previous
+        // pair first regardless of which case this is.
+        if (tx.let_syntax_peer_names.len > 0) self.gc.allocator.free(tx.let_syntax_peer_names);
+        if (tx.let_syntax_peer_vals.len > 0) self.gc.allocator.free(tx.let_syntax_peer_vals);
         tx.let_syntax_peer_names = self.gc.allocator.dupe([]const u8, peer_names_f.items) catch return CompileError.OutOfMemory;
         tx.let_syntax_peer_vals = self.gc.allocator.dupe(Value, peer_vals_f.items) catch return CompileError.OutOfMemory;
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -1328,6 +1328,31 @@ test "SRFI 147: two sibling let-syntax bindings resolving to the same Transforme
     );
 }
 
+test "SRFI 147: reusing a persisted helper across two SEPARATE let-syntax forms doesn't leak" {
+    // CodeRabbit-caught follow-up: the already_seen guard above only
+    // covers the same Transformer reappearing WITHIN one let-syntax
+    // form. It genuinely can't cover this case -- a transformer aliased
+    // into some OTHER, unrelated let-syntax form later needs its own
+    // peer snapshot recomputed for real, since that form's own siblings
+    // differ. But the recomputation itself still unconditionally
+    // overwrote whatever the FIRST form's own processing had already set
+    // here, with no free -- leaking that first (non-empty, thanks to `r1`
+    // being a genuine free reference) pair of allocations. `r1` is a
+    // sibling of `p` in the FIRST let-syntax only; by the second,
+    // separate top-level form, `r1` has reverted to its outer procedure
+    // meaning, so a correct result for `(q 10)` (11, not 1000) also
+    // confirms h's own frozen peer snapshot from its true point of origin
+    // still works, unaffected by the later recomputation.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define (r1 y) (+ y 1))
+        \\  (let-syntax ((r1 (syntax-rules () ((_ y) (* y 100))))
+        \\               (p (begin (define-syntax h (syntax-rules () ((_ x) (r1 x)))) h)))
+        \\    (p 5))
+        \\  (equal? (let-syntax ((q h)) (q 10)) 11))
+    );
+}
+
 test "SRFI 147: zero-definition begin resolves directly to the final element" {
     try th.expectEvalTrue(
         \\(begin

--- a/tests/scheme/srfi/srfi147.scm
+++ b/tests/scheme/srfi/srfi147.scm
@@ -196,6 +196,25 @@
               (q h))
    (q 42)))
 
+;;; --- CodeRabbit-caught follow-up: reusing a persisted helper across two
+;;; SEPARATE let-syntax forms (not siblings in the same one) must not leak
+;;; either. The already_seen guard above only covers a repeat WITHIN one
+;;; form -- a transformer aliased into some OTHER, later, unrelated form
+;;; genuinely needs its own peer snapshot recomputed (that form's own
+;;; siblings differ), but the recomputation itself must free whatever an
+;;; earlier form's processing already set here first. `r1` is a sibling
+;;; of `p` in the FIRST let-syntax only; by the second, separate form,
+;;; `r1` has reverted to its outer procedure meaning, so a correct result
+;;; for `(q 10)` (11, not 1000) also confirms h's own frozen peer snapshot
+;;; from its true point of origin still works, unaffected by the later
+;;; recomputation ---
+(define (r1 y) (+ y 1))
+(begin
+  (let-syntax ((r1 (syntax-rules () ((_ y) (* y 100))))
+               (p (begin (define-syntax h1 (syntax-rules () ((_ x) (r1 x)))) h1)))
+    (p 5))
+  (test-equal 11 (let-syntax ((q1 h1)) (q1 10))))
+
 ;;; --- persistent registration inside a NESTED body scope (not top level):
 ;;; the cross-referencing shape works the same way inside a lambda body,
 ;;; and two separate invocations of the same generator in two separate


### PR DESCRIPTION
## Summary

- Follow-up to #1764 (itself a follow-up to #1763), which had already
  auto-merged by the time CodeRabbit's review landed. Addresses that
  review directly: https://github.com/kaappi/kaappi/pull/1764#pullrequestreview-4782423142
- #1764 fixed a leak reachable when two *sibling* `let-syntax` bindings
  in one form resolve to the same `Transformer` object, guarded by a
  scan of that call's own `tx_vals` prefix. CodeRabbit correctly pointed
  out that guard deliberately can't (and shouldn't) cover a *different*
  case: the same transformer aliased into a **separate, unrelated**
  `let-syntax` form later. That form's own sibling set genuinely differs
  and needs its own peer snapshot recomputed — but the recomputation
  itself still unconditionally overwrote whatever an earlier form's
  processing had already set on the shared object, with no free.
- Fixed by freeing the previous `let_syntax_peer_names`/`let_syntax_peer_vals`
  pair immediately before every overwrite, regardless of which of the
  two cases (within-form repeat vs. cross-form reuse) triggered it.
- Mutation-tested: a second reproduction (the same persisted helper
  aliased into two separate, sequential top-level `let-syntax` forms,
  each introducing its own distinct sibling of the same name) leaks 2
  allocations without this fix, confirmed via the debug allocator, and
  passes cleanly with it. The reproduction also confirms the
  recomputation itself is still *correct*, not just leak-free: the
  helper's template stays bound to whichever sibling was in scope at
  its true point of origin, unaffected by the later form's recomputation.
- 1 new Zig unit test + 1 new SRFI-64 test in `tests/scheme/srfi/srfi147.scm`.

## Test plan

- [x] Mutation-tested: reverted the fix, confirmed the new unit test
      fails with 2 leaked allocations at the exact `dupe` call sites;
      restored the fix, confirmed it passes cleanly
- [x] `tests/scheme/srfi/srfi147.scm`: 23/23 pass
- [x] `zig build test` (full suite): no failures, no leaks
- [x] `bash tests/scheme/run-all.sh`: 591 Scheme files + 1395 R7RS
      tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)