### PR TITLE
Freeze R7RS 4.3.1 peer snapshot permanently, not per-call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -674,20 +674,47 @@ form's sibling set.
 
 That same review flagged a sixth spot the fifth's fix didn't close: the
 `tx_vals`-prefix scan only ever catches the same `Transformer` reappearing
-*within* one `let-syntax` form. It deliberately can't (and shouldn't) skip
-recomputation when that transformer is aliased into a *different*,
-unrelated `let-syntax` form later, since that form's own sibling set
-differs and genuinely needs its own snapshot -- but the recomputation
-itself still unconditionally overwrote whatever an earlier form's
-processing had already set, with no free. Fixed by freeing the previous
-`let_syntax_peer_names`/`vals` pair immediately before every overwrite,
-regardless of which of the two cases triggered it -- confirmed via a
-second mutation-tested reproduction (the same helper aliased into two
-separate, sequential top-level `let-syntax` forms, each with its own
-distinct sibling of the same name) that the recomputation itself still
-resolves correctly (the helper's template stays bound to whichever
-sibling was in scope at its true point of origin, not whichever form last
-recomputed the snapshot).
+*within* one `let-syntax` form, so a transformer aliased into a
+*different*, unrelated `let-syntax` form later still reached the
+recomputation code -- which still unconditionally overwrote whatever an
+earlier form's processing had set, with no free. The first fix for this
+(shipped, then reviewed) freed the old pair before every such overwrite
+and reasoned that recomputing was *correct*, since "a transformer aliased
+elsewhere genuinely needs its own peer snapshot against that different
+form's siblings." **That reasoning was wrong, not just the leak.** R7RS
+4.3.1's peer snapshot exists precisely to freeze a template's free
+references against whatever was in scope at the template's own true point
+of definition, so that *later* shadowing at some *other* use site can't
+reach in and change what a name resolves to -- recomputing it against a
+different form's outer bindings is exactly the kind of interference the
+mechanism exists to prevent, not a case it needs to additionally handle.
+Caught only by a properly discriminating reproduction: a plain top-level
+*procedure* as the shared free reference can't tell the two designs apart
+at all (a procedure binding was never captured by `let_syntax_peer_vals`
+in the first place, which reads `self.macros`, not `self.globals`) --
+only a *macro* redefined between the two forms exposes it, and did:
+recomputing silently changed a previously-correct answer from 11 to -10,
+using the second form's redefinition instead of the first form's binding
+where the helper was actually written. Nesting the reuse inside the
+defining form's own body (rather than two separate top-level forms) was
+worse: it corrupted the *outer* binding too, since the emptied snapshot
+let an outer sibling rebinding leak through unsuppressed for both calls.
+Fixed by replacing the per-call scan with a permanent, once-per-object
+`Transformer.peers_computed` flag (mirroring `finalized`'s own shape, but
+a distinct field -- peer suppression is `compileLetSyntax`-specific,
+unlike the finalization every macro-defining form needs): the snapshot is
+computed exactly once, at whichever form's processing the object is first
+encountered in, and every later encounter -- same form or a different
+one -- reuses it unchanged. (Verifying the fix took an unrelated detour:
+toggling the worktree between the old and new code via `git stash`/
+`git checkout <sha> -- <path>` without running `kaappi cache clear` after
+each rebuild made the same reproduction file answer differently across
+otherwise-identical rebuilds, looking exactly like nondeterminism until
+traced back to the `.sbc` bytecode cache's build-id half -- the git commit
+hash plus a binary `-dirty` flag, not a hash of what the uncommitted
+changes actually are, so any two different uncommitted edits at the same
+base commit alias to the identical id and share cache entries -- see
+`docs/dev/cache.md`.)
 
 These differ from earlier Zig versions and are easy to get wrong:
 

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -415,38 +415,26 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
     var saved_values: std.ArrayList(?Value) = .empty;
     defer saved_values.deinit(self.gc.allocator);
 
-    for (kw_names.items, tx_vals.items, 0..) |name, transformer, idx| {
+    for (kw_names.items, tx_vals.items) |name, transformer| {
         saved_names.append(self.gc.allocator, name) catch return CompileError.OutOfMemory;
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
         try finalizeTransformer(self, transformer);
         const tx = types.toObject(transformer).as(types.Transformer);
 
-        // SRFI 147 (bare-keyword alias / begin-wrapped helper reference) can
-        // resolve two DIFFERENT bindings in the SAME let-syntax form to the
-        // exact same Transformer Value (e.g. `((p (begin (define-syntax h
-        // ...) h)) (q h))` — CodeRabbit-caught reproduction on this PR).
-        // peer_snap_names/vals are identical for every binding in this one
-        // form, and collectTransformerFreeRefs depends only on the
-        // transformer's own (here, shared) template, so recomputing for a
-        // repeat is always redundant *within this loop* — unlike
-        // `finalized`, which must stay permanent (a transformer aliased
-        // into some OTHER, unrelated let-syntax form later genuinely needs
-        // its own peer snapshot against THAT form's different siblings, so
-        // this check is deliberately scoped to just this call's own
-        // tx_vals, not a Transformer-lifetime flag). Skipping the repeat
-        // avoids re-`dupe`ing and overwriting let_syntax_peer_names/vals
-        // with no free of the first pair.
-        var already_seen = false;
-        for (tx_vals.items[0..idx]) |seen| {
-            if (seen == transformer) {
-                already_seen = true;
-                break;
-            }
-        }
-        if (already_seen) {
+        // R7RS 4.3.1 sibling-suppression snapshot: computed exactly once
+        // per Transformer object, permanently, guarded by peers_computed
+        // (see its own doc comment in types.zig for why recomputing is a
+        // correctness bug, not just a wasted allocation -- a transformer's
+        // free references must resolve against its TRUE point of origin,
+        // not whatever OTHER let-syntax form later happens to alias it by
+        // bare keyword or begin-wrapped reference, SRFI 147). A binding
+        // that reaches an already-finalized peer snapshot here is exactly
+        // that kind of alias -- reuse it unchanged.
+        if (tx.peers_computed) {
             self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
             continue;
         }
+        tx.peers_computed = true;
 
         // R7RS 4.3.1 suppresses sibling keywords only for references the
         // transformer's TEMPLATE makes (definition-site free references). A
@@ -468,19 +456,18 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
                 peer_vals_f.append(self.gc.allocator, pv) catch return CompileError.OutOfMemory;
             }
         }
-        // CodeRabbit-caught follow-up: the already_seen guard above only
-        // covers the SAME Transformer reappearing within this one
-        // let-syntax form. It genuinely CAN'T cover the transformer being
-        // aliased into some OTHER, unrelated let-syntax form later --
-        // that form's own siblings differ, so its peer snapshot must be
-        // recomputed for real, not skipped. But that recomputation still
-        // unconditionally overwrites whatever an EARLIER form's own
-        // processing left here, with no free -- so free the previous
-        // pair first regardless of which case this is.
-        if (tx.let_syntax_peer_names.len > 0) self.gc.allocator.free(tx.let_syntax_peer_names);
-        if (tx.let_syntax_peer_vals.len > 0) self.gc.allocator.free(tx.let_syntax_peer_vals);
-        tx.let_syntax_peer_names = self.gc.allocator.dupe([]const u8, peer_names_f.items) catch return CompileError.OutOfMemory;
-        tx.let_syntax_peer_vals = self.gc.allocator.dupe(Value, peer_vals_f.items) catch return CompileError.OutOfMemory;
+        // Dupe both new slices before touching the (always default-empty
+        // here, since peers_computed guarantees this runs at most once
+        // per object) old fields, so a failure on the second dupe can't
+        // leave one field already overwritten and the other freed out
+        // from under it (CodeRabbit).
+        const new_peer_names = self.gc.allocator.dupe([]const u8, peer_names_f.items) catch return CompileError.OutOfMemory;
+        const new_peer_vals = self.gc.allocator.dupe(Value, peer_vals_f.items) catch {
+            self.gc.allocator.free(new_peer_names);
+            return CompileError.OutOfMemory;
+        };
+        tx.let_syntax_peer_names = new_peer_names;
+        tx.let_syntax_peer_vals = new_peer_vals;
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
     }
 

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -1329,20 +1329,19 @@ test "SRFI 147: two sibling let-syntax bindings resolving to the same Transforme
 }
 
 test "SRFI 147: reusing a persisted helper across two SEPARATE let-syntax forms doesn't leak" {
-    // CodeRabbit-caught follow-up: the already_seen guard above only
-    // covers the same Transformer reappearing WITHIN one let-syntax
-    // form. It genuinely can't cover this case -- a transformer aliased
-    // into some OTHER, unrelated let-syntax form later needs its own
-    // peer snapshot recomputed for real, since that form's own siblings
-    // differ. But the recomputation itself still unconditionally
-    // overwrote whatever the FIRST form's own processing had already set
-    // here, with no free -- leaking that first (non-empty, thanks to `r1`
-    // being a genuine free reference) pair of allocations. `r1` is a
-    // sibling of `p` in the FIRST let-syntax only; by the second,
-    // separate top-level form, `r1` has reverted to its outer procedure
-    // meaning, so a correct result for `(q 10)` (11, not 1000) also
-    // confirms h's own frozen peer snapshot from its true point of origin
-    // still works, unaffected by the later recomputation.
+    // CodeRabbit-caught follow-up to the sibling-reuse leak fix above: a
+    // transformer aliased into a DIFFERENT, later, unrelated let-syntax
+    // form reaches the SAME peer-computation code a second time.
+    // `r1` here is a plain top-level PROCEDURE, never a macro before
+    // either form, so let_syntax_peer_names/vals (built from
+    // self.macros.get, not self.globals) never captures anything for it
+    // either way -- this test only demonstrates the leak (a non-empty
+    // allocation from a genuine free reference, freed correctly whether
+    // or not the snapshot gets recomputed), not whether recomputing vs.
+    // reusing the snapshot changes the RESULT. See the next two tests for
+    // that: they use a macro (not a procedure) as the shared free
+    // reference specifically because only a macro's identity is
+    // captured by this mechanism at all.
     try th.expectEvalTrue(
         \\(begin
         \\  (define (r1 y) (+ y 1))
@@ -1350,6 +1349,69 @@ test "SRFI 147: reusing a persisted helper across two SEPARATE let-syntax forms 
         \\               (p (begin (define-syntax h (syntax-rules () ((_ x) (r1 x)))) h)))
         \\    (p 5))
         \\  (equal? (let-syntax ((q h)) (q 10)) 11))
+    );
+}
+
+test "SRFI 147: a helper's peer snapshot is frozen at its TRUE point of origin, never recomputed" {
+    // CodeRabbit-caught: an EARLIER draft of this fix let a transformer's
+    // R7RS 4.3.1 sibling-suppression snapshot be recomputed every time it
+    // reached a NEW let-syntax form (guarded only by a scan of that one
+    // call's own tx_vals, matching the leak-only concern above) --
+    // reasoning that a transformer aliased elsewhere "genuinely needs its
+    // own peer snapshot against that different form's siblings". That
+    // reasoning was WRONG: recomputing doesn't just waste an allocation,
+    // it can silently change which binding a macro's free reference
+    // resolves to, since the "peer snapshot" is precisely what freezes a
+    // template's own references against outer shadowing (R7RS 4.3.1) --
+    // recomputing it against a DIFFERENT form's outer bindings defeats
+    // the entire mechanism. Confirmed via direct reproduction: redefining
+    // the top-level MACRO meaning of a shared sibling name between two
+    // forms changed a previously shipped answer from 11 to -10 (using
+    // the SECOND form's redefinition instead of the first's, where h1
+    // was actually defined) before this fix's peers_computed flag made
+    // the snapshot permanent instead of per-call. Using a macro (not a
+    // procedure, as the leak test above does) is essential here: a plain
+    // procedure reference isn't captured by let_syntax_peer_vals at all
+    // (it comes from self.macros, not self.globals), so a test built on
+    // one can't distinguish "recomputed" from "reused" -- only a shared
+    // sibling that is itself a macro can.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax r1 (syntax-rules () ((_ y) (+ y 1))))
+        \\  (define result1
+        \\    (let-syntax ((r1 (syntax-rules () ((_ y) (* y 100))))
+        \\                 (p (begin (define-syntax h1 (syntax-rules () ((_ x) (r1 x)))) h1)))
+        \\      (p 5)))
+        \\  (define-syntax r1 (syntax-rules () ((_ y) (- y))))
+        \\  (define result2
+        \\    (let-syntax ((r1 (syntax-rules () ((_ y) (* y 9999))))
+        \\                 (q1 h1))
+        \\      (q1 10)))
+        \\  (equal? (list result1 result2) (list 6 11)))
+    );
+}
+
+test "SRFI 147: nesting a reuse inside the defining form's own body doesn't corrupt the outer binding" {
+    // CodeRabbit-caught: the reproduction above uses two SEPARATE,
+    // sequential top-level forms. This one nests the reuse INSIDE the
+    // very same let-syntax body that first defines the helper, then
+    // checks the OUTER binding (`p`) still resolves correctly
+    // AFTERWARD -- confirming the corruption isn't specific to top-level
+    // sequencing. Before this fix, the nested `q1`'s own peer
+    // recomputation used ONLY that inner let-syntax's own sibling set
+    // (just `q1` itself, no `r1`), silently emptying h1's peer snapshot
+    // -- which let the OUTER let-syntax's own `r1` sibling rebinding
+    // (`* y 100`) leak through unsuppressed for BOTH the nested call and
+    // the later outer one: `(q1 20)` wrongly returned 2000 instead of 21,
+    // and `(p 5)` -- called AFTER, unrelated to the nested reuse except
+    // for sharing h1's object -- wrongly returned 500 instead of 6.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax r1 (syntax-rules () ((_ y) (+ y 1))))
+        \\  (let-syntax ((r1 (syntax-rules () ((_ y) (* y 100))))
+        \\               (p (begin (define-syntax h1 (syntax-rules () ((_ x) (r1 x)))) h1)))
+        \\    (and (equal? (let-syntax ((q1 h1)) (q1 20)) 21)
+        \\         (equal? (p 5) 6))))
     );
 }
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -471,6 +471,20 @@ pub const Transformer = struct {
     // and unconditionally overwrites a slice field with no free of the old
     // one -- a second call on top of the first leaks the first allocation.
     finalized: bool = false,
+    // Guards compileLetSyntax's R7RS 4.3.1 sibling-suppression snapshot
+    // (let_syntax_peer_names/vals below) the same way `finalized` guards
+    // captured_locals/bound_free_refs, and for a stronger reason than just
+    // avoiding a leak: recomputing it a second time is not merely
+    // redundant, it's WRONG. A transformer's free references must resolve
+    // according to its own true point of origin (the one let-syntax/
+    // letrec-syntax/define-syntax that actually created it), not whatever
+    // OTHER, unrelated let-syntax form later happens to alias it by name
+    // or by begin-wrapped reference (SRFI 147) -- confirmed via direct
+    // reproduction: redefining an outer binding between two such forms
+    // changed a shared helper's already-resolved answer, proving a second
+    // computation silently overwrote the first with a different, wrong
+    // snapshot rather than just wasting an allocation.
+    peers_computed: bool = false,
     captured_locals: []CapturedLocal = &.{},
     def_env: ?*std.StringHashMap(Value) = null,
     def_env_val: Value = NIL,

--- a/tests/scheme/srfi/srfi147.scm
+++ b/tests/scheme/srfi/srfi147.scm
@@ -198,22 +198,59 @@
 
 ;;; --- CodeRabbit-caught follow-up: reusing a persisted helper across two
 ;;; SEPARATE let-syntax forms (not siblings in the same one) must not leak
-;;; either. The already_seen guard above only covers a repeat WITHIN one
-;;; form -- a transformer aliased into some OTHER, later, unrelated form
-;;; genuinely needs its own peer snapshot recomputed (that form's own
-;;; siblings differ), but the recomputation itself must free whatever an
-;;; earlier form's processing already set here first. `r1` is a sibling
-;;; of `p` in the FIRST let-syntax only; by the second, separate form,
-;;; `r1` has reverted to its outer procedure meaning, so a correct result
-;;; for `(q 10)` (11, not 1000) also confirms h's own frozen peer snapshot
-;;; from its true point of origin still works, unaffected by the later
-;;; recomputation ---
+;;; either. `r1` here is a plain top-level PROCEDURE, never a macro before
+;;; either form, so let_syntax_peer_names/vals (built from self.macros,
+;;; not self.globals) never captures anything for it either way -- this
+;;; only demonstrates the leak (a genuine, non-empty allocation, freed
+;;; correctly), not whether recomputing vs. reusing the snapshot changes
+;;; the RESULT. See the next two tests for that ---
 (define (r1 y) (+ y 1))
 (begin
   (let-syntax ((r1 (syntax-rules () ((_ y) (* y 100))))
                (p (begin (define-syntax h1 (syntax-rules () ((_ x) (r1 x)))) h1)))
     (p 5))
   (test-equal 11 (let-syntax ((q1 h1)) (q1 10))))
+
+;;; --- CodeRabbit-caught: a helper's R7RS 4.3.1 peer snapshot must be
+;;; frozen at its TRUE point of origin, never recomputed. An earlier draft
+;;; of this fix let it be recomputed every time a transformer reached a
+;;; NEW let-syntax form -- reasoning that an alias elsewhere "genuinely
+;;; needs its own snapshot against that form's different siblings". That
+;;; reasoning was WRONG: recomputing doesn't just waste an allocation, it
+;;; can silently change which binding a macro's free reference resolves
+;;; to. Confirmed via direct reproduction: redefining the top-level MACRO
+;;; meaning of a shared sibling name between two forms changed a
+;;; previously shipped answer from 11 to -10 before this fix. Using a
+;;; macro (not a procedure, as above) for the shared sibling is essential:
+;;; a plain procedure reference isn't captured by let_syntax_peer_vals at
+;;; all (self.macros, not self.globals), so a test built on one can't
+;;; distinguish "recomputed" from "reused" ---
+(define-syntax r2 (syntax-rules () ((_ y) (+ y 1))))
+(define result-a
+  (let-syntax ((r2 (syntax-rules () ((_ y) (* y 100))))
+               (p2 (begin (define-syntax h2 (syntax-rules () ((_ x) (r2 x)))) h2)))
+    (p2 5)))
+(define-syntax r2 (syntax-rules () ((_ y) (- y))))
+(define result-b
+  (let-syntax ((r2 (syntax-rules () ((_ y) (* y 9999))))
+               (q2 h2))
+    (q2 10)))
+(test-equal '(6 11) (list result-a result-b))
+
+;;; --- CodeRabbit-caught: nesting a reuse inside the DEFINING form's own
+;;; body (not two separate top-level forms) must not corrupt the OUTER
+;;; binding either. Before this fix, the nested `q3`'s own peer
+;;; recomputation used ONLY that inner let-syntax's own sibling set (just
+;;; `q3` itself, no `r3`), silently emptying h3's peer snapshot -- which
+;;; let the OUTER let-syntax's own `r3` sibling rebinding leak through
+;;; unsuppressed for BOTH the nested call and the later outer one ---
+(define-syntax r3 (syntax-rules () ((_ y) (+ y 1))))
+(test-equal
+ '(21 6)
+ (let-syntax ((r3 (syntax-rules () ((_ y) (* y 100))))
+              (p3 (begin (define-syntax h3 (syntax-rules () ((_ x) (r3 x)))) h3)))
+   (list (let-syntax ((q3 h3)) (q3 20))
+         (p3 5))))
 
 ;;; --- persistent registration inside a NESTED body scope (not top level):
 ;;; the cross-referencing shape works the same way inside a lambda body,


### PR DESCRIPTION
## Summary

- Follow-up to #1765, which had already auto-merged by the time
  CodeRabbit's review landed. Addresses that review directly:
  https://github.com/kaappi/kaappi/pull/1765#pullrequestreview-4782578486
- #1765 fixed a leak (free the old `let_syntax_peer_names`/`vals` pair
  before every cross-form overwrite), but treated *recomputing* the
  sibling-suppression snapshot against a different `let-syntax` form's
  own bindings as necessary and correct. **It isn't** — this is a real
  hygiene correctness bug, not just a wasted allocation. R7RS 4.3.1's
  peer snapshot exists to freeze a template's free references against
  whatever was in scope at the template's own true point of definition,
  specifically so later shadowing at some *other* use site can't reach
  in and change what a name resolves to. Recomputing it against a
  different form's outer bindings is exactly the interference the
  mechanism exists to prevent.
- Confirmed via a properly discriminating reproduction — a plain
  top-level *procedure* as the shared free reference can't distinguish
  "recomputed" from "reused" at all, since procedure bindings were never
  captured by `let_syntax_peer_vals` in the first place (it reads
  `self.macros`, not `self.globals`); only a *macro*, redefined between
  two forms, exposes it:
  ```scheme
  (define-syntax r1 (syntax-rules () ((_ y) (+ y 1))))
  (let-syntax ((r1 (syntax-rules () ((_ y) (* y 100))))
               (p (begin (define-syntax h (syntax-rules () ((_ x) (r1 x)))) h)))
    (p 5))                          ; => 6, correct
  (define-syntax r1 (syntax-rules () ((_ y) (- y))))
  (let-syntax ((r1 (syntax-rules () ((_ y) (* y 9999))))
               (q h))
    (q 10))                         ; => -10 (WRONG, used r1's redefinition)
                                     ;    should be 11 (h's true origin binding)
  ```
  Nesting the reuse inside the *defining* form's own body (rather than
  two separate top-level forms) is worse: it corrupts the *outer*
  binding too, since the emptied/recomputed snapshot lets an outer
  sibling rebinding leak through unsuppressed for both calls.
- Fixed by replacing the per-call `tx_vals`-prefix scan with a
  permanent, once-per-object `Transformer.peers_computed` flag
  (mirroring `finalized`'s own shape, kept as a separate field since
  peer suppression is `compileLetSyntax`-specific, not something every
  macro-defining form needs): the snapshot is computed exactly once, at
  whichever form's processing first encounters the object, and every
  later encounter — same form or a different one — reuses it unchanged.
- Also applies CodeRabbit's suggested atomic-dupe pattern: dupe both new
  slices before touching the old ones, so a second-dupe OOM can't leave
  one field freed and the other stale.
- 2 new Zig unit tests + 2 new SRFI-64 tests, plus corrected comments on
  the existing leak-only test (which used a plain procedure and
  therefore couldn't have caught this) to stop overclaiming what it
  proves.

## Test plan

- [x] Direct reproduction of the exact discriminating scenario above:
      fails (-10) on #1765's code, passes (11) with this fix
- [x] Nested-reuse-corrupts-outer-binding reproduction: fails (2000/500)
      on #1765's code, passes (21/6) with this fix
- [x] `tests/scheme/srfi/srfi147.scm`: 25/25 pass; `srfi257.scm`: 34/34
- [x] `zig build test` (full suite, incl. `-Dgc-stress=true` on
      `tests_macros`): no failures, no leaks
- [x] `bash tests/scheme/run-all.sh`: 591 Scheme files + 1395 R7RS
      tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)