### PR TITLE
Set peers_computed only after the snapshot is durably stored

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -716,6 +716,16 @@ changes actually are, so any two different uncommitted edits at the same
 base commit alias to the identical id and share cache entries -- see
 `docs/dev/cache.md`.)
 
+CodeRabbit's review of that fix caught one more ordering bug: the first
+cut set `peers_computed = true` immediately, before the several fallible
+allocations (`peer_names_f`/`peer_vals_f` appends, both `dupe` calls) that
+actually build the snapshot. An OOM partway through would leave the flag
+permanently true with `let_syntax_peer_names`/`vals` still at their
+default-empty value -- every later reuse would then treat "no suppression
+needed" as the final, correct answer instead of retrying. Fixed by moving
+the flag assignment to strictly after both slices are durably stored,
+right before the `self.macros.put` that was already there.
+
 These differ from earlier Zig versions and are easy to get wrong:
 
 ```zig

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -434,7 +434,6 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
             self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
             continue;
         }
-        tx.peers_computed = true;
 
         // R7RS 4.3.1 suppresses sibling keywords only for references the
         // transformer's TEMPLATE makes (definition-site free references). A
@@ -468,6 +467,13 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         };
         tx.let_syntax_peer_names = new_peer_names;
         tx.let_syntax_peer_vals = new_peer_vals;
+        // Only NOW, once both slices are durably stored, mark this
+        // transformer's snapshot complete (CodeRabbit): setting the flag
+        // any earlier -- before the fallible appends/dupes above -- would
+        // let an OOM leave peers_computed true with the default-empty
+        // snapshot never actually filled in, and every later reuse would
+        // silently accept that empty snapshot as final instead of retrying.
+        tx.peers_computed = true;
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
     }
 


### PR DESCRIPTION
## Summary

- Follow-up to #1766, which had already auto-merged by the time
  CodeRabbit's review landed. Addresses that review directly:
  https://github.com/kaappi/kaappi/pull/1766#pullrequestreview-4782742562
- #1766 set `Transformer.peers_computed = true` immediately, before the
  several fallible allocations (`peer_names_f`/`peer_vals_f` appends,
  both `dupe` calls) that actually build the `let_syntax_peer_names`/
  `vals` snapshot. An OOM partway through would leave the flag
  permanently `true` with both fields still at their default-empty
  value — every later reuse of that transformer would then treat "no
  sibling suppression needed" as the final, correct answer instead of
  retrying the computation.
- Fixed by moving the flag assignment to strictly after both slices are
  durably stored, immediately before the `self.macros.put` that was
  already there — matching CodeRabbit's exact suggested diff.

## Test plan

- [x] Both discriminating reproductions from #1765/#1766 (macro
      redefined between two forms; nested reuse corrupting the outer
      binding) still resolve correctly
- [x] `tests/scheme/srfi/srfi147.scm`: 25/25 pass; `srfi257.scm`: 34/34
- [x] `zig build test` (full suite, incl. `-Dgc-stress=true` on
      `tests_macros`): no failures, no leaks
- [x] `bash tests/scheme/run-all.sh`: 591 Scheme files + 1395 R7RS
      tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)