### PR TITLE
Detect cycles through record instances in the printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   every platform leg, so omitting a library directory from the tarball can
   no longer go unnoticed (#1741).
 
+- **The generic printer no longer hangs on cyclic record structures** —
+  `write`/`display`/`write-shared` already detected and datum-labeled
+  cycles through pairs and vectors, but record instances were invisible to
+  that machinery, so printing a cyclic record fell through to the plain
+  depth-limited recursive printer instead. A direct self-reference merely
+  recursed until hitting the depth cap, but a record field that's a vector
+  of records which each reference it back (e.g. two mutually-referencing
+  record types — the shape that motivated this issue) fans out
+  combinatorially at every level of that recursion, hanging the process
+  long before the cap is reached. Record instances now join pairs and
+  vectors in both cycle-detection passes, so a cyclic web of records prints
+  with the same `#N=`/`#N#` datum-label markers instead of looping forever
+  (#1713).
+
 #### SRFI 115 (regular expressions)
 
 - **`w/ascii` and `w/unicode` were no-ops** — both were accepted and ignored,

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -74,7 +74,7 @@ fn markShared(value: Value, state: *SharedState) void {
     defer state.depth -= 1;
     const obj = types.toObject(value);
     switch (obj.tag) {
-        .pair, .vector => {
+        .pair, .vector, .record_instance => {
             // Check if already seen
             for (state.seen[0..state.seen_count]) |s| {
                 if (s == value) {
@@ -98,9 +98,14 @@ fn markShared(value: Value, state: *SharedState) void {
             if (obj.tag == .pair) {
                 markShared(types.car(value), state);
                 markShared(types.cdr(value), state);
-            } else {
+            } else if (obj.tag == .vector) {
                 const vec = obj.as(types.Vector);
                 for (vec.data) |elem| {
+                    markShared(elem, state);
+                }
+            } else if (obj.tag == .record_instance) {
+                const ri = obj.as(types.RecordInstance);
+                for (ri.fields) |elem| {
                     markShared(elem, state);
                 }
             }
@@ -142,6 +147,14 @@ fn printValueShared(writer: anytype, value: Value, state: *SharedState, atom_mod
             try printValueShared(writer, elem, state, atom_mode);
         }
         try writer.writeByte(')');
+    } else if (types.isPointer(value) and types.toObject(value).tag == .record_instance) {
+        const ri = types.toObject(value).as(types.RecordInstance);
+        try writer.print("#<{s}", .{ri.record_type.name});
+        for (ri.fields) |field| {
+            try writer.writeByte(' ');
+            try printValueShared(writer, field, state, atom_mode);
+        }
+        try writer.writeByte('>');
     } else {
         try printValue(writer, value, atom_mode);
     }
@@ -197,6 +210,24 @@ fn markCycles(allocator: std.mem.Allocator, value: Value, state: *SharedState) v
     markCyclesRec(allocator, value, state, &on_stack, &done, 0);
 }
 
+/// Elements/fields to walk for a heap type whose cycle-detection treatment is
+/// otherwise identical to a vector's: visit each child once, flag a back-edge
+/// as shared. Record instances join vectors here so a cyclic web of records
+/// (e.g. two record types referencing each other, kaappi#1713) gets a datum
+/// label instead of recursing forever -- without this, such a cycle is
+/// invisible to this pre-pass, `state.shared_count` stays 0, and printing
+/// falls through to the plain depth-limited recursion, which merely bounds
+/// depth rather than detecting the cycle: a record type whose field is a
+/// vector of records that each reference it back fans out combinatorially
+/// long before the depth cap is reached.
+fn vectorLikeChildren(obj: *types.Object) ?[]const Value {
+    return switch (obj.tag) {
+        .vector => obj.as(types.Vector).data,
+        .record_instance => obj.as(types.RecordInstance).fields,
+        else => null,
+    };
+}
+
 fn markCyclesRec(
     allocator: std.mem.Allocator,
     value: Value,
@@ -209,12 +240,11 @@ fn markCyclesRec(
     if (!types.isPointer(value)) return;
     const obj = types.toObject(value);
 
-    if (obj.tag == .vector) {
+    if (vectorLikeChildren(obj)) |children| {
         if (on_stack.contains(value)) return recordSharedNode(state, value);
         if (done.contains(value)) return;
         on_stack.put(value, {}) catch return;
-        const vec = obj.as(types.Vector);
-        for (vec.data) |elem| markCyclesRec(allocator, elem, state, on_stack, done, depth + 1);
+        for (children) |elem| markCyclesRec(allocator, elem, state, on_stack, done, depth + 1);
         _ = on_stack.remove(value);
         done.put(value, {}) catch {};
         return;
@@ -1169,6 +1199,49 @@ test "write-shared shared substructure" {
     const s = try valueToString(std.testing.allocator, outer, .shared);
     defer std.testing.allocator.free(s);
     try std.testing.expectEqualStrings("(#0=(1) #0#)", s);
+}
+
+// Regression tests for #1713: record instances were invisible to both the
+// `write`/`display` cycle-detection pre-pass and the `write-shared`
+// shared-structure pre-pass, so a self-referential record fell through to
+// the plain depth-limited recursive printer instead of getting a datum
+// label. A single direct self-reference "only" recurses ~1024 times before
+// hitting the depth cap, but a fan-out cycle (a record field that's a
+// vector of records each pointing back) blows up combinatorially at every
+// level of that recursion -- see the Scheme-level regression test
+// tests/scheme/smoke/cyclic-record-printer-1713.scm for that shape.
+
+test "write circular record instance" {
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    // Build a "cell" record whose only field points back to itself.
+    const rt_val = try gc.allocRecordType("cell", 1);
+    const rt = types.toObject(rt_val).as(types.RecordType);
+    const placeholder = [_]Value{types.NIL};
+    const ri = try gc.allocRecordInstance(rt, &placeholder);
+    types.toObject(ri).as(types.RecordInstance).fields[0] = ri;
+
+    const s = try valueToString(std.testing.allocator, ri, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("#0=#<cell #0#>", s);
+}
+
+test "write-shared circular record instance" {
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const rt_val = try gc.allocRecordType("cell", 1);
+    const rt = types.toObject(rt_val).as(types.RecordType);
+    const placeholder = [_]Value{types.NIL};
+    const ri = try gc.allocRecordInstance(rt, &placeholder);
+    types.toObject(ri).as(types.RecordInstance).fields[0] = ri;
+
+    const s = try valueToString(std.testing.allocator, ri, .shared);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("#0=#<cell #0#>", s);
 }
 
 test "prettyPrint short list stays single-line" {

--- a/tests/scheme/smoke/cyclic-record-printer-1713.scm
+++ b/tests/scheme/smoke/cyclic-record-printer-1713.scm
@@ -1,0 +1,76 @@
+;; Regression test for #1713: the generic record printer recursed into
+;; record fields with no cycle detection. A directly self-referential
+;; record eventually hit the printer's depth cap, but a *fan-out* cycle
+;; (a record whose field is a vector of records that each reference it
+;; back -- the shape SRFI 209's enum/enum-type design hit) branches at
+;; every level of that recursion, blowing up combinatorially long before
+;; the depth cap is reached. write/display/write-shared must instead
+;; detect the cycle and print a datum-label marker, exactly as they
+;; already do for pairs and vectors.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "cyclic-record-printer-1713")
+
+(define (print->string proc x)
+  (let ((port (open-output-string)))
+    (proc x port)
+    (get-output-string port)))
+
+;; --- Directly self-referential record ----------------------------------
+
+(define-record-type cell
+  (make-cell val next)
+  cell?
+  (val cell-val)
+  (next cell-next set-cell-next!))
+
+(define c (make-cell 42 #f))
+(set-cell-next! c c)
+
+(test-equal "self-referential record: write"
+  "#0=#<cell 42 #0#>"
+  (print->string write c))
+
+(test-equal "self-referential record: display"
+  "#0=#<cell 42 #0#>"
+  (print->string display c))
+
+(test-equal "self-referential record: write-shared"
+  "#0=#<cell 42 #0#>"
+  (print->string write-shared c))
+
+;; --- Fan-out cycle: two mutually-referencing record types ---------------
+;; Mirrors the SRFI 209 enum/enum-type design that motivated this issue:
+;; enum-type -> (vector of enums) -> each enum -> back to enum-type.
+;; Without real cycle detection this fans out by the vector's width at
+;; every trip around the cycle instead of just looping once.
+
+(define-record-type enum-type
+  (make-etype enums)
+  etype?
+  (enums etype-enums set-etype-enums!))
+
+(define-record-type enum
+  (make-enum etype)
+  enum?
+  (etype enum-etype))
+
+(define et (make-etype #f))
+(define enums (vector (make-enum et) (make-enum et) (make-enum et)))
+(set-etype-enums! et enums)
+
+(test-equal "fan-out record cycle: write"
+  "#0=#<enum-type #(#<enum #0#> #<enum #0#> #<enum #0#>)>"
+  (print->string write et))
+
+;; --- Non-cyclic records still print in full, unlabeled ------------------
+
+(define plain (make-cell 1 (make-cell 2 #f)))
+
+(test-equal "non-cyclic record printing is unaffected"
+  "#<cell 1 #<cell 2 #f>>"
+  (print->string write plain))
+
+(let ((runner (test-runner-current)))
+  (test-end "cyclic-record-printer-1713")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- `write`/`display`/`write-shared` already detect and datum-label cycles through pairs and vectors via `markCyclesRec`/`markShared`, but record instances were invisible to both pre-passes — a cyclic record structure fell through to the plain depth-limited recursive printer instead.
- A single direct self-reference merely recurses to the 1024-level depth cap and stops, but a fan-out cycle (a record field that's a vector of records which each reference it back — the SRFI 209 `enum`/`enum-type` shape that motivated this issue) branches at every level of that recursion and blows up combinatorially long before the depth cap is reached — that's the observed hang.
- Fix: record instances now join pairs/vectors in `markCyclesRec` (via a shared `vectorLikeChildren` helper), in `markShared`, and in `printValueShared`'s print path, so a cyclic web of records prints with the same `#N=`/`#N#` datum-label markers instead of looping forever.

Fixes #1713.

## Test plan

- [x] New Zig unit tests in `src/printer.zig`: `write circular record instance`, `write-shared circular record instance` (self-referential record, mirroring the existing pair/vector cycle tests)
- [x] New Scheme end-to-end test `tests/scheme/smoke/cyclic-record-printer-1713.scm`: direct self-reference under `write`/`display`/`write-shared`, the fan-out shape via two mutually-referencing record types (reproducing the original SRFI 209 report), and a check that ordinary non-cyclic records still print unlabeled and byte-identical to before
- [x] `zig build test` — full unit suite passes (1318/1321, 3 pre-existing unrelated skips)
- [x] `bash tests/scheme/run-all.sh` — full suite passes (592 Scheme files + 1395 R7RS tests, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)