### PR TITLE
Promote expt to complex for negative base + non-integer exponent

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -433,23 +433,37 @@ fn exptFn(args: []const Value) PrimitiveError!Value {
             return gc.allocComplex(rr, ri) catch return PrimitiveError.OutOfMemory;
         }
         // General: z^w = e^(w * ln(z))
-        // ln(z) = ln|z| + i*arg(z)
-        const mag = @sqrt(zr * zr + zi * zi);
-        const arg = std.math.atan2(zi, zr);
-        const ln_r = @log(mag);
-        const ln_i = arg;
-        // w * ln(z)
-        const prod_r = wr * ln_r - wi * ln_i;
-        const prod_i = wr * ln_i + wi * ln_r;
-        // e^(prod_r + i*prod_i)
-        const exp_r = @exp(prod_r);
-        const result_r = exp_r * @cos(prod_i);
-        const result_i = exp_r * @sin(prod_i);
-        return gc.allocComplex(result_r, result_i) catch return PrimitiveError.OutOfMemory;
+        return complexPowGeneral(gc, zr, zi, wr, wi);
     }
     const base_f = try toF64Ext(args[0]);
     const exp_f = try toF64Ext(args[1]);
+    // A negative real base raised to a non-integer real exponent has no real
+    // result (e.g. (-8)^(1/3)) — promote to complex, matching sqrt's handling
+    // of negative reals. Integer exponents are excluded since std.math.pow
+    // already handles those correctly for a negative base.
+    if (std.math.isFinite(base_f) and base_f < 0.0 and
+        std.math.isFinite(exp_f) and exp_f != @trunc(exp_f))
+    {
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+        return complexPowGeneral(gc, base_f, 0.0, exp_f, 0.0);
+    }
     return makeFlonumVal(std.math.pow(f64, base_f, exp_f));
+}
+
+// z^w = e^(w * ln(z)), where ln(z) = ln|z| + i*arg(z).
+fn complexPowGeneral(gc: *memory.GC, zr: f64, zi: f64, wr: f64, wi: f64) PrimitiveError!Value {
+    const mag = @sqrt(zr * zr + zi * zi);
+    const arg = std.math.atan2(zi, zr);
+    const ln_r = @log(mag);
+    const ln_i = arg;
+    // w * ln(z)
+    const prod_r = wr * ln_r - wi * ln_i;
+    const prod_i = wr * ln_i + wi * ln_r;
+    // e^(prod_r + i*prod_i)
+    const exp_r = @exp(prod_r);
+    const result_r = exp_r * @cos(prod_i);
+    const result_i = exp_r * @sin(prod_i);
+    return gc.allocComplex(result_r, result_i) catch return PrimitiveError.OutOfMemory;
 }
 
 fn squareFn(args: []const Value) PrimitiveError!Value {

--- a/tests/scheme/smoke/expt-negative-base-1725.scm
+++ b/tests/scheme/smoke/expt-negative-base-1725.scm
@@ -1,0 +1,40 @@
+;; Regression test for #1725: expt doesn't promote to complex for a negative
+;; real base combined with a non-integer real exponent.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "expt-negative-base-1725")
+
+(define (close-enough? a b)
+  (< (magnitude (- a b)) 1e-9))
+
+;; (-8.0)^0.5 has no real value; principal branch is 2*sqrt(2)*i.
+(let ((r (expt -8.0 0.5)))
+  (test-assert "expt -8.0 0.5 is not real" (not (real? r)))
+  (test-assert "expt -8.0 0.5 is not nan"
+    (and (not (nan? (real-part r))) (not (nan? (imag-part r)))))
+  (test-assert "expt -8.0 0.5 value"
+    (close-enough? r (make-rectangular 0.0 (* 2 (sqrt 2))))))
+
+;; (-8)^(1/3) has no real value; principal branch is 1 + sqrt(3)*i.
+(let ((r (expt -8 1/3)))
+  (test-assert "expt -8 1/3 is not real" (not (real? r)))
+  (test-assert "expt -8 1/3 value"
+    (close-enough? r (make-rectangular 1.0 (sqrt 3)))))
+
+;; sqrt already got this right — expt should agree with it.
+(test-assert "expt -8.0 0.5 agrees with sqrt"
+  (close-enough? (expt -8.0 0.5) (sqrt -8.0)))
+
+;; Integer exponents (even via a flonum) must stay real for a negative base.
+(test-equal "expt -8.0 -2 stays real" 0.015625 (expt -8.0 -2))
+(test-equal "expt -8.0 2 stays real" 64.0 (expt -8.0 2))
+(test-equal "expt -8.0 3.0 stays real" -512.0 (expt -8.0 3.0))
+
+;; A non-negative base must never be promoted to complex.
+(test-equal "expt 2.0 0.5 stays real" (sqrt 2.0) (expt 2.0 0.5))
+(test-equal "expt 0.0 0.0 stays real" 1.0 (expt 0.0 0.0))
+
+(let ((runner (test-runner-current)))
+  (test-end "expt-negative-base-1725")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- `expt`'s real-number fallback called `std.math.pow` unconditionally, which returns `+nan.0` for a negative base combined with a non-integer real exponent (e.g. `(expt -8.0 0.5)`, `(expt -8 1/3)`) instead of the mathematically well-defined complex result — the same input shape `sqrt` already promotes correctly.
- Factored the existing `z^w = e^(w*ln(z))` formula out of the already-complex branch into a shared `complexPowGeneral` helper, and route a finite negative base with a finite non-integer exponent through it before falling back to `std.math.pow`.
- Integer exponents (even via a flonum, e.g. `(expt -8.0 3.0)`) are left untouched since `std.math.pow` already handles those correctly for a negative base.

Fixes #1725.

## Test plan

- [x] Added `tests/scheme/smoke/expt-negative-base-1725.scm`; confirmed it fails on the pre-fix binary (6 failures) and passes on the fixed one (11 passes)
- [x] `zig build test` (full unit suite)
- [x] Targeted SRFI suites that exercise `expt`: 94, 70, 143, 144, 270
- [x] Full `bash tests/scheme/run-all.sh`: 1987 pass, 0 fail (592 Scheme files + 1395 R7RS tests)
- [x] Verified against all repro cases from the issue plus regression guards (positive base, integer exponents, `0^0`) manually via the REPL

🤖 Generated with [Claude Code](https://claude.com/claude-code)