### PR TITLE
Refuse kaappi compile when an import can't resolve at runtime (#1743)

### DIFF
--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -198,6 +198,25 @@ emit through `kaappi_eval_cached` like other passthrough forms, but as special
 top-level forms they are not cacheable — `kaappi_eval_cached` declines them and
 runs a plain `eval` each time (see [Cached eval fallback](#cached-eval-fallback)).
 
+**`import` only works at runtime for libraries built into the Zig binary**
+(#1743). `kaappi_runtime_init` (`runtime_exports.zig`) starts the compiled
+binary's own VM with no library search path, and the native backend does not
+bundle `.sld` sources into the binary the way the `--compile`/`-Dbundle-src`
+`.sbc` pathway does. So while the compiling VM resolves an `import` against
+its own `--lib-path`/auto-discovered directories just fine — including a
+third-party package or any of the 159 portable SRFIs — that exact resolution
+is unrepeatable inside the runtime binary's fresh VM, and re-running the
+serialized `import` form there raises "library not found". `emitLlvmFile`
+therefore refuses to emit anything (a compile-time error, not a broken
+binary) when it resolves any import from a `.sld` file rather than kaappi's
+built-in registry: it repurposes the `.sbc` bundler's own
+`vm.compile_collect_files` hook purely to detect this, since
+`processImportSet` (`vm_library.zig`) checks the built-in registry first and
+only records a file there when a library is resolved from disk. Both
+`kaappi compile` and `--emit-llvm` go through `emitLlvmFile`, so both refuse
+identically; the working alternatives are the interpreter or
+`zig build -Dbundle-src=<file>`.
+
 ## Heap-Allocated Constants
 
 Constants that are heap objects (pairs, vectors, symbols, strings) cannot

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -66,6 +66,38 @@ fn nativeUnsupportedMessage(buf: []u8, arch_name: []const u8, path: []const u8) 
     ) catch "error: native compilation is not supported on this architecture\n";
 }
 
+/// #1743 refuse-loudly diagnostic: `files` is the set of library .sld files
+/// this compile resolved from disk (see the call site's comment for why that
+/// makes them unusable from the compiled binary's own runtime). Lists each
+/// one and points at the two working alternatives instead of silently handing
+/// back a binary that fails at runtime with "library not found" despite
+/// compiling cleanly.
+fn reportUnresolvableLibraryImports(path: []const u8, files: *std.StringHashMap([]const u8)) void {
+    writeStderr("error: `kaappi compile` cannot produce a working binary for this program.\n\n");
+    writeStderr("It imports the following library file(s), which are not built into kaappi\n");
+    writeStderr("and were resolved from disk at compile time:\n");
+
+    var it = files.keyIterator();
+    while (it.next()) |key| {
+        var buf: [600]u8 = undefined;
+        const line = std.fmt.bufPrint(&buf, "    {s}\n", .{key.*}) catch continue;
+        writeStderr(line);
+    }
+
+    writeStderr(
+        "\nThe LLVM native backend does not embed library sources into the compiled\n" ++
+            "binary, and the binary's own runtime has no library search path -- so this\n" ++
+            "import fails with \"library not found\" at runtime even though compilation\n" ++
+            "reports success.\n\n" ++
+            "Run the program with the interpreter instead:\n",
+    );
+    var runbuf: [1088]u8 = undefined;
+    writeStderr(std.fmt.bufPrint(&runbuf, "    kaappi {s}\n", .{path}) catch "");
+    writeStderr("or produce a self-contained binary that embeds library sources:\n");
+    var bundlebuf: [1088]u8 = undefined;
+    writeStderr(std.fmt.bufPrint(&bundlebuf, "    zig build -Dbundle-src={s}\n", .{path}) catch "");
+}
+
 pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;
 
@@ -97,6 +129,30 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
 
     var r = reader_mod.Reader.initWithName(vm.gc, source, path);
     defer r.deinit();
+
+    // #1743: the compiled binary's own runtime (kaappi_runtime_init in
+    // runtime_exports.zig) starts a fresh VM with no library search path, and
+    // the native backend never bundles .sld sources into the binary the way
+    // the --compile/-Dbundle-src .sbc pathway does. So any import that this
+    // (compiling) VM resolves from a file — a third-party package or one of
+    // the 159 portable SRFIs, as opposed to a library built into the Zig
+    // binary — compiles cleanly here but reliably fails at runtime with
+    // "library not found", since the runtime's fresh VM can never find it.
+    // Reuse the .sbc bundler's own file-collection hook purely to detect this:
+    // processImportSet (vm_library.zig) checks the built-in registry first and
+    // only records a file here when a library is resolved from disk, so a
+    // built-in library never appears in this map.
+    var collect_files = std.StringHashMap([]const u8).init(allocator);
+    defer {
+        var cit = collect_files.iterator();
+        while (cit.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            allocator.free(entry.value_ptr.*);
+        }
+        collect_files.deinit();
+    }
+    vm.compile_collect_files = &collect_files;
+    defer vm.compile_collect_files = null;
 
     var ir_nodes: std.ArrayList(*ir_mod.Node) = .empty;
     defer ir_nodes.deinit(allocator);
@@ -181,6 +237,11 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         // Record any define/set! target from this form so that the next
         // form's constant folding does not assume the primitive is unmodified.
         collectRedefinedNames(expr, &redefined_names);
+    }
+
+    if (collect_files.count() > 0) {
+        reportUnresolvableLibraryImports(path, &collect_files);
+        return error.UnresolvableLibraryImport;
     }
 
     var emitter = llvm_emit.LLVMEmitter.init(allocator);

--- a/tests/scheme/compile/native-external-library-import-1743.sh
+++ b/tests/scheme/compile/native-external-library-import-1743.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Regression test for #1743: `kaappi compile` reported success and produced a
+# binary for a program that imports a library resolved from a .sld file (a
+# third-party package, or any of the 159 portable SRFIs) — then the binary
+# died at runtime with "library not found", because the compiled binary's own
+# runtime (kaappi_runtime_init in runtime_exports.zig) starts a fresh VM with
+# no library search path, and the native backend does not bundle library
+# sources into the binary the way the --compile/-Dbundle-src .sbc pathway
+# does.
+#
+# The fix makes `kaappi compile` (and --emit-llvm, which it calls internally)
+# detect at compile time when the program resolved any import from a .sld
+# file rather than kaappi's built-in registry, and refuse to produce a binary
+# — a loud compile-time diagnostic instead of a silently broken executable
+# that exits 0.
+#
+# Usage: bash tests/scheme/compile/native-external-library-import-1743.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# Freshen the runtime library (prebuilt archive suffices without zig)
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+# A program importing a library kaappi cannot resolve at runtime must be
+# REFUSED at compile time: nonzero exit, no binary produced, and a stderr
+# diagnostic that names the problem instead of a silent false "success".
+expect_refused() {
+    local name="$1" src="$2"; shift 2
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    local status=0
+    local err
+    err=$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$@" compile "$DIR/$name.scm" -o "$DIR/$name" 2>&1 >/dev/null) || status=$?
+
+    if [[ "$status" -eq 0 ]]; then
+        echo "FAIL: $name — kaappi compile exited 0 for an unresolvable import" >&2
+        fail=1
+        return
+    fi
+    if [[ -e "$DIR/$name" ]]; then
+        echo "FAIL: $name — a binary was produced despite the refusal" >&2
+        fail=1
+        return
+    fi
+    if [[ "$err" != *"cannot produce a working binary"* ]]; then
+        echo "FAIL: $name — stderr did not explain the refusal: $err" >&2
+        fail=1
+        return
+    fi
+}
+
+# A program using only built-in libraries, or a self-contained
+# define-library, must keep compiling and running exactly as before.
+expect_compiles_and_runs() {
+    local name="$1" src="$2" expect_out="$3"; shift 3
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" "$@" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+    local out
+    if ! out=$("$DIR/$name" 2>/dev/null); then
+        echo "FAIL: $name — binary exited nonzero" >&2
+        fail=1
+        return
+    fi
+    if [[ "$out" != "$expect_out" ]]; then
+        echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
+        fail=1
+    fi
+}
+
+# --- Case 1: third-party-style library, resolved via --lib-path, mirrors
+#     the original bug report (kaappi-json) without depending on any
+#     sibling repo. ---
+mkdir -p "$DIR/thirdparty"
+cat > "$DIR/thirdparty/greet.sld" << 'SCHEME'
+(define-library (thirdparty greet)
+  (export greet)
+  (import (scheme base))
+  (begin
+    (define (greet) "hello")))
+SCHEME
+
+expect_refused thirdparty-import \
+'(import (scheme base) (scheme write) (thirdparty greet))
+(write (greet))
+(newline)' \
+--lib-path "$DIR"
+
+# --- Case 2: a portable SRFI (not one of the 12 built into the Zig binary)
+#     resolved from this repo's own lib/srfi/*.sld — no --lib-path needed,
+#     since main() adds the exe-relative lib dir automatically. ---
+expect_refused portable-srfi-import \
+'(import (scheme base) (scheme write) (srfi 2))
+(and-let* ((x 1)) (write x))
+(newline)'
+
+# --- Case 3: nested import inside the user's own define-library must also
+#     be caught — the whole form (including its internal import) is replayed
+#     verbatim in the binary's runtime. ---
+expect_refused nested-define-library-import \
+'(define-library (my-wrapper)
+  (export my-greet)
+  (import (scheme base) (thirdparty greet))
+  (begin
+    (define (my-greet) (greet))))
+
+(import (scheme base) (scheme write) (my-wrapper))
+(write (my-greet))
+(newline)' \
+--lib-path "$DIR"
+
+# --- Case 4: --emit-llvm shares the same guard (kaappi compile calls it
+#     internally, but the flag is also reachable directly, e.g. via
+#     `zig build native`). ---
+status=0
+err=$(cd "$REPO_DIR" && "$KAAPPI_ABS" --lib-path "$DIR" --emit-llvm -o "$DIR/emit.ll" "$DIR/thirdparty-import.scm" 2>&1 >/dev/null) || status=$?
+if [[ "$status" -eq 0 ]]; then
+    echo "FAIL: emit-llvm-refused — --emit-llvm exited 0 for an unresolvable import" >&2
+    fail=1
+elif [[ -e "$DIR/emit.ll" ]]; then
+    echo "FAIL: emit-llvm-refused — a .ll file was produced despite the refusal" >&2
+    fail=1
+elif [[ "$err" != *"cannot produce a working binary"* ]]; then
+    echo "FAIL: emit-llvm-refused — stderr did not explain the refusal: $err" >&2
+    fail=1
+fi
+
+# --- Case 5 (no false positives): built-in SRFI 1 needs no file resolution
+#     at all, so it must keep compiling and running natively. ---
+expect_compiles_and_runs builtin-srfi-still-works \
+'(import (scheme base) (scheme write) (srfi 1))
+(write (filter odd? (list 1 2 3 4 5)))
+(newline)' \
+'(1 3 5)'
+
+# --- Case 6 (no false positives): a library defined AND used in the same
+#     file needs no file resolution either. ---
+expect_compiles_and_runs self-contained-library-still-works \
+'(define-library (my-math)
+  (export square)
+  (import (scheme base))
+  (begin
+    (define (square x) (* x x))))
+
+(import (scheme base) (scheme write) (my-math))
+(write (square 7))
+(newline)' \
+'49'
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-external-library-import-1743: all cases passed"


### PR DESCRIPTION
## Summary
- `kaappi compile` reported success (exit 0) and produced a binary for a program importing any library resolved from a `.sld` file — a third-party package (e.g. `kaappi-json`) or one of the 159 portable SRFIs — then the binary died at runtime with `library not found`, because the compiled binary's own runtime (`kaappi_runtime_init`) starts a fresh VM with no library search path and the native backend never bundles `.sld` sources the way `--compile`/`-Dbundle-src` does.
- `emitLlvmFile` now detects this by reusing the `.sbc` bundler's own file-collection hook (populated only when a library is resolved from disk, never for a built-in) and refuses to emit anything — a compile-time error naming the unresolvable library file(s) and pointing at the interpreter or `zig build -Dbundle-src` as working alternatives — instead of a silently broken binary. Covers both `kaappi compile` and `--emit-llvm` (and transitively `zig build native`).
- No false positives: built-in libraries (e.g. `(srfi 1)`) and self-contained `define-library` forms still compile and run exactly as before.
- Updated `docs/dev/llvm-backend.md`'s "Compile-Time Processing" section to document the restriction.

Fixes #1743

## Test plan
- [x] Added `tests/scheme/compile/native-external-library-import-1743.sh`, covering: a third-party-style library via `--lib-path`, a portable SRFI with no built-in registration, a nested `define-library` import, `--emit-llvm` sharing the guard, and two no-false-positive cases (built-in SRFI, self-contained library)
- [x] Verified the new test fails on the pre-fix code and passes with the fix (`git stash`/`git stash pop` A-B check)
- [x] `zig build test` — all unit tests pass
- [x] `bash tests/scheme/run-all.sh` — 592/592 Scheme files, 1395/1395 R7RS suite tests pass
- [x] `zig fmt --check src/native_compiler.zig` — clean