### PR TITLE
Fix hygiene rename split between a nested syntax-rules pattern and its quoted template

### DIFF
--- a/src/expander.zig
+++ b/src/expander.zig
@@ -1193,7 +1193,31 @@ fn scopeTableContains(scope: u32, name: []const u8) bool {
 }
 
 fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.StringHashMap(Value)) !Value {
-    if ((scope & QUOTE_FLAG) != 0) return gc.allocSymbol(name);
+    if ((scope & QUOTE_FLAG) != 0) {
+        // Inside a nested syntax-rules template, a quoted identifier may be a
+        // reference to that inner macro's OWN pattern variable rather than
+        // inert literal data -- e.g. `((_ y) '(fixed y))`: the pattern's `y`
+        // is walked without QUOTE_FLAG and already claimed a hygienic rename
+        // in scope_table (case 5 below), but the template's `y` sits inside
+        // `quote` and used to always come back unrenamed, splitting the two
+        // occurrences (the inner macro's own matcher would then never bind
+        // its own template's `y` to anything, and the reference passed
+        // through literally). Reusing the SAME clean_scope lookup as the
+        // non-quoted path (QUOTE_FLAG stripped, so the two occurrences hash
+        // identically) restores that consistency when a same-scope rename
+        // already exists. Genuinely inert quoted data (no matching pattern-
+        // side rename, e.g. a literal symbol the inner template just quotes)
+        // keeps today's behavior: emitted verbatim, unrenamed.
+        if ((scope & NESTED_SR_FLAG) != 0) {
+            const clean_scope = scope & ~(BINDING_FLAG | NESTED_SR_FLAG | LET_PAIR_FLAG | QQ_DEPTH_MASK | QUOTE_FLAG);
+            for (scope_table[0..scope_table_count]) |entry| {
+                if (entry.scope == clean_scope and std.mem.eql(u8, entry.original_name, name)) {
+                    return gc.allocSymbol(entry.renamed_to);
+                }
+            }
+        }
+        return gc.allocSymbol(name);
+    }
 
     // Already renamed by an enclosing expansion: macro-generating macros
     // bake __hyg_ names into the inner macro's stored template. Gensyms are

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -359,6 +359,51 @@ test "hygiene: macro-generating macro shares binding with inner macro" {
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
 }
 
+test "hygiene: nested syntax-rules pattern variable referenced inside its own quoted template" {
+    // The outer macro's template defines an inner macro via a NESTED
+    // syntax-rules. The inner macro's own pattern variable `y` is renamed
+    // for hygiene where it appears in the PATTERN `(_ y)` (walked without
+    // QUOTE_FLAG), but its template `'(fixed y)` wraps `y` in `quote`.
+    // renameForHygiene used to treat any quoted identifier as inert literal
+    // data and skip renaming it there unconditionally, splitting the
+    // pattern and template occurrences of the SAME inner pattern variable:
+    // the inner macro's own matcher then had nothing to bind to the
+    // template's unrenamed `y`, so it passed through literally instead of
+    // substituting the call's actual argument (99).
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax outer-qs
+        \\    (syntax-rules ()
+        \\      ((_)
+        \\       (begin
+        \\         (define-syntax inner-qs
+        \\           (syntax-rules ()
+        \\             ((_ y) '(fixed y))))
+        \\         (inner-qs 99)))))
+        \\  (equal? (outer-qs) '(fixed 99)))
+    );
+}
+
+test "hygiene: genuinely inert quoted literal in a nested template is still not renamed" {
+    // Companion to the test above: a symbol quoted inside a nested macro's
+    // template that is NOT one of the inner macro's own pattern variables
+    // must still come through unrenamed (the fix must not start renaming
+    // every quoted identifier in a nested syntax-rules template -- only
+    // ones that already have a same-scope pattern-side rename to match).
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax outer-qs2
+        \\    (syntax-rules ()
+        \\      ((_)
+        \\       (begin
+        \\         (define-syntax inner-qs2
+        \\           (syntax-rules ()
+        \\             ((_ y) (list 'literal-tag y))))
+        \\         (inner-qs2 99)))))
+        \\  (equal? (outer-qs2) '(literal-tag 99)))
+    );
+}
+
 test "hygiene: template references sibling define that appears later in body" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();


### PR DESCRIPTION
## Summary

Found while implementing SRFI 148 (issue #1699's final slice — task in
progress, not yet a PR): `em-syntax-rules` and most of `148.macros.scm`'s
combinators are macros that define helper macros via a NESTED
`syntax-rules`, and several of those nested templates are quoted (e.g.
`((_ y) '(fixed y))`). Porting the exact reference shape hit a
pre-existing, general hygiene bug — unrelated to SRFI 147/148 themselves —
that silently produces the wrong value.

## The bug

`renameForHygiene` (`src/expander.zig`) unconditionally treated any
identifier inside `(quote ...)` as inert literal data and skipped hygienic
renaming. That's correct for ordinary quoted data in a macro template, but
wrong for a nested `syntax-rules` being generated by an outer macro:

```scheme
(define-syntax outer-x
  (syntax-rules ()
    ((_)
     (begin
       (define-syntax inner-x
         (syntax-rules ()
           ((_ y) '(fixed y))))
       (inner-x 99)))))
(outer-x)  ; => (fixed y)  -- WRONG, should be (fixed 99)
```

`outer-x`'s expansion walks its own template once. The pattern `(_ y)` is
walked without `QUOTE_FLAG` and gets a hygienic rename for `y` (e.g.
`__hyg_4_y`), consistently applied everywhere else that occurrence of `y`
appears in the SAME walk — except the template `'(fixed y)`, which sits
inside `quote` and short-circuited straight to an unrenamed copy. The
pattern and template occurrences of `inner-x`'s own pattern variable end up
with different names, so when `inner-x` is later invoked, its own matcher
has nothing to substitute into the (unrenamed) template `y`, and it passes
through literally.

Confirmed via direct instrumentation of the actual expansion output:

```
expanded_root=(begin (define-syntax __hyg_3_inner-x
                        (syntax-rules () ((_ __hyg_4_y) (quote (fixed y)))))
                      (__hyg_3_inner-x 99))
```

Note `__hyg_4_y` in the pattern vs. bare `y` in the template.

## The fix

When a quoted identifier is reached while inside a nested `syntax-rules`
template (`NESTED_SR_FLAG` set), check `scope_table` first (using the same
`clean_scope` computation as the non-quoted path, with `QUOTE_FLAG`
additionally stripped so the two occurrences hash identically) for an
already-claimed rename under the same scope. If found, reuse it — matching
the pattern-side occurrence. If not found (genuinely inert quoted data,
never a pattern variable), fall back to the existing behavior: emitted
verbatim, unrenamed.

This is deliberately narrow: it only ever *reuses* an existing rename
created by the (already-correct) non-quoted path; it never invents a new
one for quoted content, so ordinary literal data quoted inside a nested
macro's template (a symbol that isn't any pattern variable) is untouched.

## Scope note

This fix unblocks the hygiene half of what SRFI 148 needs. A second,
independent, non-blocking bug was found and filed separately (#1772): a
*literally hand-written* `begin` containing internal `define-syntax` + use
compiles wrong outside real top level. It doesn't affect this fix or SRFI
148 (whose macros only ever produce such a `begin` via expansion, which
already routes through the correct path), so it's tracked separately rather
than folded into this PR.

## Testing

- New regression tests in `src/tests_macros.zig`:
  - the exact bug shape above (nested syntax-rules pattern variable
    referenced inside its own quoted template)
  - a companion test confirming a genuinely inert quoted literal in a
    nested template is still *not* renamed (guards against an
    over-eager fix)
- `zig build test`: full unit suite green
- `bash tests/scheme/run-all.sh`: 1986/1986 (591 Scheme files + 1395 R7RS
  suite), 0 fail

## Test plan

- [x] `zig build test`
- [x] `bash tests/scheme/run-all.sh`
- [x] Manual repro of the bug and confirmation of the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)