### PR TITLE
Isolate record-type/define-values desugaring from vm.macros (#1718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A special-form-shadowing macro imported by one program could corrupt
+  `define-record-type`/`define-values` in a completely unrelated library
+  loaded afterward** — `define-record-type`'s and `define-values`'s
+  desugaring compiled their generated definitions against the
+  process-global macro table instead of an isolated one, so once any
+  program imported a macro shadowing a core special form (e.g. `lambda`),
+  every later library's own record types or `define-values` forms could
+  fail to compile, or — when the shadowed name was `define-record-type`
+  itself — be silently dropped with no error at all. Record-type/
+  define-values desugaring is now isolated from the importing program's
+  own macro scope, and the shadow-detection that lets a library define its
+  own `define-record-type` macro (SRFI 136/131/57) now checks that
+  library's own scope rather than the whole process's. Importing a special
+  form under a new name (`(rename (only (scheme base) let*) (let*
+  my-let*))`) now fails with a clear diagnostic at the `import` instead of
+  silently producing a binding that resolves to nothing (#1718).
+
 - **The installer now installs the native backend's runtime archive** —
   releases have published `libkaappi_rt-<target>.a` since 0.8.0, but the
   install script never downloaded it, so anyone who installed via

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -83,7 +83,7 @@ pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
     // same name); when one is in scope, fall through instead of returning
     // here so the form reaches ordinary macro-aware compilation below,
     // exactly like every other top-level form does.
-    if (std.mem.eql(u8, name, "define-record-type") and vm.macros.get("define-record-type") == null)
+    if (std.mem.eql(u8, name, "define-record-type") and !isMacroShadowed(vm, "define-record-type"))
         return vm_records.handleDefineRecordType(vm, types.cdr(expr));
     if (std.mem.eql(u8, name, "define-values")) return handleDefineValues(vm, types.cdr(expr));
     if (std.mem.eql(u8, name, "include")) return vm_library.handleTopLevelInclude(vm, types.cdr(expr), false);
@@ -100,6 +100,23 @@ pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
     return null;
 }
 
+// Whether `name` is shadowed by a macro in the currently-relevant scope: the
+// active library's own env when compiling a library body, else the
+// process-global macro table at true top level. Using vm.macros
+// unconditionally here would let one program's own special-form-shadowing
+// macro (imported into vm.globals, hence vm.macros) silently affect how a
+// completely unrelated library's top-level forms are dispatched later in
+// the same process (#1718) -- current_lib_env is what the library's own
+// define-syntax/import bindings actually land in (see compileLibExpr's
+// lib_macros), so it's the only scope that matters while compiling that
+// library's body.
+fn isMacroShadowed(vm: *VM, name: []const u8) bool {
+    if (vm.current_lib_env) |env| {
+        return if (env.get(name)) |v| types.isTransformer(v) else false;
+    }
+    return vm.macros.get(name) != null;
+}
+
 // Predicate mirror of the dispatch chain in handleTopLevelForm: true for the
 // top-level-only forms that eval() interprets specially rather than compiling
 // to a single reusable Function. compileCachedForm (#1494) consults this to
@@ -112,7 +129,7 @@ fn isSpecialTopLevelForm(vm: *VM, expr: Value) bool {
     const name = types.symbolName(head);
     return std.mem.eql(u8, name, "import") or
         std.mem.eql(u8, name, "define-library") or
-        (std.mem.eql(u8, name, "define-record-type") and vm.macros.get("define-record-type") == null) or
+        (std.mem.eql(u8, name, "define-record-type") and !isMacroShadowed(vm, "define-record-type")) or
         std.mem.eql(u8, name, "define-values") or
         std.mem.eql(u8, name, "include") or
         std.mem.eql(u8, name, "include-ci") or
@@ -255,7 +272,25 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
     if (!types.isPair(rest)) return VMError.CompileError;
     const expr = types.car(rest);
 
-    const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &vm.macros, vm.globals) catch return VMError.CompileError;
+    // Compile against a macro table scoped to the current library, not the
+    // process-global vm.macros: unlike define-record-type's desugaring,
+    // this initializer is user-authored code that legitimately needs to see
+    // whatever macros are in scope here -- but ONLY here, not an unrelated
+    // program's own special-form-shadowing macro sitting in vm.macros
+    // (#1718). Mirrors compileLibExpr's own lib_macros pattern (#877).
+    var scope_macros = if (vm.current_lib_env) |env| blk: {
+        var m = std.StringHashMap(Value).init(vm.gc.allocator);
+        var it = env.iterator();
+        while (it.next()) |entry| {
+            if (types.isTransformer(entry.value_ptr.*)) {
+                m.put(entry.key_ptr.*, entry.value_ptr.*) catch return VMError.OutOfMemory;
+            }
+        }
+        break :blk m;
+    } else vm.macros;
+    defer if (vm.current_lib_env != null) scope_macros.deinit();
+
+    const func = compiler_mod.compileExpressionWithMacros(vm.gc, expr, &scope_macros, vm.globals) catch return VMError.CompileError;
     var func_val = types.makePointer(&func.header);
     vm.gc.pushRoot(&func_val);
     defer vm.gc.popRoot();

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -1053,7 +1053,18 @@ fn processImportRename(vm: *VM, target: *std.StringHashMap(Value), args: Value) 
         const new_sym = types.car(new_rest);
         if (!types.isSymbol(old_sym) or !types.isSymbol(new_sym)) return error.InvalidSyntax;
         const old_name = types.symbolName(old_sym);
-        if (!source.contains(old_name) and !ir.isSpecialForm(old_name)) {
+        if (!source.contains(old_name)) {
+            // Special forms (lambda, let*, define, ...) have no runtime
+            // value -- they were never a real entry in `source` to begin
+            // with, so silently "passing" this check (the old behavior)
+            // left the new name bound to nothing: using it later fell
+            // through every special-form check and became a confusing
+            // "undefined variable" at the use site instead of a clear
+            // error here, at the actual mistake (#1718).
+            if (ir.isSpecialForm(old_name)) {
+                vm.setErrorDetail("import rename: cannot rename special form '{s}' -- special forms are not first-class bindings and cannot be rebound under a new name", .{old_name});
+                return error.UndefinedVariable;
+            }
             vm.setErrorDetail("import rename: identifier '{s}' not found in import set", .{old_name});
             return error.UndefinedVariable;
         }
@@ -1187,8 +1198,15 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
         defer vm.current_lib_env = saved_env;
         if (vm.handleTopLevelForm(expr)) |result| {
             _ = try result;
+            return;
         }
-        return;
+        // handleTopLevelForm deferred (e.g. define-record-type is shadowed
+        // by a macro in this library's own scope, per isMacroShadowed) --
+        // fall through to the macro-aware compileExpressionInEnv path below
+        // instead of silently dropping the form (#1718). Returning
+        // unconditionally here used to mean a null result was treated the
+        // same as "handled": the form was neither compiled as the builtin
+        // special form nor as an ordinary macro use.
     }
 
     // Compile against a per-library macro table seeded from lib_env rather

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -93,10 +93,17 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         vm.gc.pushRoot(&define_expr);
         defer vm.gc.popRoot();
 
+        // Compiled against an empty macro table, never vm.macros: this form
+        // is 100% compiler-synthesized (lambda/let/define plus internal
+        // primitive calls, no user subexpressions), so it must never be
+        // reinterpreted by a same- or cross-library macro that happens to
+        // shadow one of those keywords (#1718).
+        var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
+        defer no_macros.deinit();
         const func = if (vm.current_lib_env) |env|
-            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
+            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
         else
-            compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
+            compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
         define_expr = types.makePointer(&func.header);
         compiler_mod.Compiler.unrootFunction(vm.gc, func);
         _ = vm.execute(func) catch |err| return err;
@@ -127,10 +134,14 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         vm.gc.pushRoot(&define_expr);
         defer vm.gc.popRoot();
 
+        // See the constructor's compile call above (#1718): empty macro
+        // table, never vm.macros.
+        var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
+        defer no_macros.deinit();
         const func = if (vm.current_lib_env) |env|
-            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
+            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
         else
-            compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
+            compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
         define_expr = types.makePointer(&func.header);
         compiler_mod.Compiler.unrootFunction(vm.gc, func);
         _ = vm.execute(func) catch |err| return err;
@@ -163,10 +174,14 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             vm.gc.pushRoot(&define_expr);
             defer vm.gc.popRoot();
 
+            // See the constructor's compile call above (#1718): empty
+            // macro table, never vm.macros.
+            var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
+            defer no_macros.deinit();
             const func = if (vm.current_lib_env) |env|
-                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
+                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
             else
-                compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
+                compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(&func.header);
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = vm.execute(func) catch |err| return err;
@@ -198,10 +213,14 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             vm.gc.pushRoot(&define_expr);
             defer vm.gc.popRoot();
 
+            // See the constructor's compile call above (#1718): empty
+            // macro table, never vm.macros.
+            var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
+            defer no_macros.deinit();
             const func = if (vm.current_lib_env) |env|
-                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
+                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
             else
-                compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
+                compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(&func.header);
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
             _ = vm.execute(func) catch |err| return err;
@@ -295,10 +314,16 @@ fn compileAndRunDefine(vm: *VM, define_expr_in: Value) VMError!void {
     vm.gc.pushRoot(&define_expr);
     defer vm.gc.popRoot();
 
+    // Empty macro table, never vm.macros (#1718): every form reaching here
+    // is compiler-synthesized record-type boilerplate, never user code, so
+    // it must never be reinterpreted by a same- or cross-library macro that
+    // happens to shadow lambda/let/define/etc.
+    var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
+    defer no_macros.deinit();
     const func = if (vm.current_lib_env) |env|
-        compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &vm.macros, env, types.NIL, false) catch return VMError.CompileError
+        compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
     else
-        compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &vm.macros, vm.globals) catch return VMError.CompileError;
+        compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
     define_expr = types.makePointer(&func.header);
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
     _ = vm.execute(func) catch |err| return err;

--- a/tests/scheme/errors/import-filter.sh
+++ b/tests/scheme/errors/import-filter.sh
@@ -90,10 +90,24 @@ echo '(import (rename (scheme base) (totally-bogus-name tbn)))' > "$TMPDIR_TESTS
 assert_exit_code "rename: unknown old name errors" 1 "$KAAPPI" "$TMPDIR_TESTS/rename-bogus.scm"
 assert_stderr_contains "rename: error names the identifier" "totally-bogus-name" "$KAAPPI" "$TMPDIR_TESTS/rename-bogus.scm"
 
-# --- rename: syntax keyword accepted ---
+# --- rename: special form errors clearly instead of silently binding nothing (#1718) ---
+# Special forms have no runtime value to move to a new name: `def` used to be
+# silently left unbound (a confusing "undefined variable" only at its use
+# site) rather than erroring here, at the actual mistake.
 echo '(import (rename (scheme base) (define def)))' > "$TMPDIR_TESTS/rename-syntax.scm"
 echo '(display "ok")' >> "$TMPDIR_TESTS/rename-syntax.scm"
-assert_exit_code "rename: syntax keyword accepted" 0 "$KAAPPI" "$TMPDIR_TESTS/rename-syntax.scm"
+assert_exit_code "rename: special form keyword errors" 1 "$KAAPPI" "$TMPDIR_TESTS/rename-syntax.scm"
+assert_stderr_contains "rename: error names the special form" "define" "$KAAPPI" "$TMPDIR_TESTS/rename-syntax.scm"
+
+echo '(import (rename (only (scheme base) let*) (let* my-let*)))' > "$TMPDIR_TESTS/rename-let-star.scm"
+echo '(display "ok")' >> "$TMPDIR_TESTS/rename-let-star.scm"
+assert_exit_code "rename: let* errors" 1 "$KAAPPI" "$TMPDIR_TESTS/rename-let-star.scm"
+assert_stderr_contains "rename: error names let*" "let\*" "$KAAPPI" "$TMPDIR_TESTS/rename-let-star.scm"
+
+echo '(import (rename (only (scheme base) lambda) (lambda my-lambda)))' > "$TMPDIR_TESTS/rename-lambda.scm"
+echo '(display "ok")' >> "$TMPDIR_TESTS/rename-lambda.scm"
+assert_exit_code "rename: lambda errors" 1 "$KAAPPI" "$TMPDIR_TESTS/rename-lambda.scm"
+assert_stderr_contains "rename: error names lambda" "lambda" "$KAAPPI" "$TMPDIR_TESTS/rename-lambda.scm"
 
 # --- rename: valid succeeds ---
 echo '(import (rename (scheme base) (car my-car)))' > "$TMPDIR_TESTS/rename-valid.scm"

--- a/tests/scheme/smoke/lib1718/drt-shadow.sld
+++ b/tests/scheme/smoke/lib1718/drt-shadow.sld
@@ -1,0 +1,11 @@
+;; Fixture for #1718: exports its own define-record-type macro (the
+;; SRFI-136/131/57-style extended-record-syntax pattern), here a trivial
+;; passthrough. Importing this must not affect how an unrelated library's
+;; OWN plain define-record-type is compiled later in the same program.
+(define-library (lib1718 drt-shadow)
+  (import (scheme base))
+  (export define-record-type)
+  (begin
+    (define-syntax define-record-type
+      (syntax-rules ()
+        ((_ args ...) (define-record-type args ...))))))

--- a/tests/scheme/smoke/lib1718/drt-victim.sld
+++ b/tests/scheme/smoke/lib1718/drt-victim.sld
@@ -1,0 +1,13 @@
+;; Fixture for #1718: another unrelated library with its own plain
+;; define-record-type (not shadowed within its own scope). Must be
+;; compiled by the builtin handler, not silently dropped, regardless of
+;; whether some other library the program imported exports its own
+;; define-record-type macro.
+(define-library (lib1718 drt-victim)
+  (import (scheme base))
+  (export make-color color? color-r)
+  (begin
+    (define-record-type <color>
+      (make-color r)
+      color?
+      (r color-r))))

--- a/tests/scheme/smoke/lib1718/dv-victim.sld
+++ b/tests/scheme/smoke/lib1718/dv-victim.sld
@@ -1,0 +1,10 @@
+;; Fixture for #1718: an ordinary, unrelated library with its own
+;; define-values whose initializer uses `lambda`. Must load correctly
+;; regardless of what other libraries the importing program has already
+;; loaded.
+(define-library (lib1718 dv-victim)
+  (import (scheme base))
+  (export dv-result)
+  (begin
+    (define-values (dv-result dv-extra)
+      (values ((lambda (x) (* x 2)) 21) 'unused))))

--- a/tests/scheme/smoke/lib1718/shadow.sld
+++ b/tests/scheme/smoke/lib1718/shadow.sld
@@ -1,0 +1,12 @@
+;; Fixture for #1718: exports a `lambda`-shadowing macro whose expansion
+;; does not reproduce its input unchanged (wraps the body in `begin`).
+;; Importing this must not corrupt compilation of unrelated libraries
+;; loaded afterward in the same program.
+(define-library (lib1718 shadow)
+  (import (scheme base))
+  (export lambda)
+  (begin
+    (define-syntax lambda
+      (syntax-rules ()
+        ((_ formals body1 body2 ...)
+         (lambda formals (begin body1 body2 ...)))))))

--- a/tests/scheme/smoke/lib1718/victim.sld
+++ b/tests/scheme/smoke/lib1718/victim.sld
@@ -1,0 +1,12 @@
+;; Fixture for #1718: an ordinary, unrelated library with its own
+;; define-record-type. Must load correctly regardless of what other
+;; libraries the importing program has already loaded.
+(define-library (lib1718 victim)
+  (import (scheme base))
+  (export make-point point? point-x point-y)
+  (begin
+    (define-record-type <point>
+      (make-point x y)
+      point?
+      (x point-x)
+      (y point-y))))

--- a/tests/scheme/smoke/record-macro-scope-1718.scm
+++ b/tests/scheme/smoke/record-macro-scope-1718.scm
@@ -1,0 +1,51 @@
+;; Regression test for #1718: a program that imports a library shadowing a
+;; core special form (here `lambda`, non-fixed-point expansion) must not
+;; corrupt compilation of unrelated libraries loaded afterward.
+;;
+;; Before the fix, define-record-type/define-values desugaring compiled its
+;; internally-synthesized (lambda ...) forms against the process-global
+;; vm.macros table instead of an isolated one. Once `lambda` was shadowed
+;; anywhere in the program, EVERY later define-record-type/define-values in
+;; ANY library -- not just the one doing the shadowing -- saw the shadow too,
+;; failing with a generic "CompileError while loading library" far from the
+;; actual cause. See lib1718/shadow.sld, lib1718/victim.sld,
+;; lib1718/dv-victim.sld.
+;;
+;; No SRFI-64 here (unlike most tests in this directory): test-assert/
+;; test-equal, and even a plain (define (f ...) ...) shorthand, expand
+;; through `lambda` themselves, so anything defined or asserted AFTER
+;; importing the shadow would legitimately fail too (a non-converging macro
+;; shadow breaks every use of the shadowed form in the *importing* program
+;; from that point on -- expected behavior, see lib1718/shadow.sld's
+;; header). The interesting property under test is that it does NOT also
+;; break unrelated *libraries*, so the checking helper is defined BEFORE
+;; the shadow import and only plain procedure calls (no lambda-desugaring
+;; syntax) appear after it, matching the convention in tests/scheme/hygiene/
+;; for the same reason.
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define failed #f)
+(define (check label ok)
+  (if ok
+      (begin (display "  PASS  ") (display label) (newline))
+      (begin (set! failed #t)
+             (display "  FAIL  ") (display label) (newline))))
+
+;; Import the shadow -- this puts a non-fixed-point `lambda` macro into the
+;; process-global vm.macros. Everything above this point is unaffected
+;; (already compiled); everything below must avoid writing new `lambda`- or
+;; `define`-shorthand-using source of its own.
+(import (lib1718 shadow))
+
+;; Now import unrelated libraries using define-record-type and
+;; define-values. Before the fix, loading these would fail.
+(import (lib1718 victim))
+(import (lib1718 dv-victim))
+
+(check "record constructor works" (procedure? make-point))
+(check "record predicate works" (point? (make-point 1 2)))
+(check "record accessor x" (= 1 (point-x (make-point 1 2))))
+(check "record accessor y" (= 2 (point-y (make-point 1 2))))
+(check "define-values initializer using lambda still works" (= 42 dv-result))
+
+(if failed (exit 1) (begin (display "PASS") (newline)))

--- a/tests/scheme/smoke/record-shadow-drop-1718.scm
+++ b/tests/scheme/smoke/record-shadow-drop-1718.scm
@@ -1,0 +1,33 @@
+;; Regression test for #1718: a program that imports a library exporting
+;; its own define-record-type macro (the SRFI-136/131/57-style extended
+;; record syntax pattern) must not silently drop define-record-type forms
+;; in unrelated libraries loaded afterward.
+;;
+;; Before the fix, vm_eval.zig's handleTopLevelForm/isSpecialTopLevelForm
+;; decided whether define-record-type was shadowed by checking the
+;; process-global vm.macros, and vm_library.zig's compileLibExpr
+;; unconditionally returned once it decided (correctly, per that check) to
+;; defer to macro-aware compilation -- but never actually performed that
+;; macro-aware compilation, so an unrelated library's own plain
+;; define-record-type was silently dropped: no error, its accessors just
+;; never got defined. See lib1718/drt-shadow.sld, lib1718/drt-victim.sld.
+(import (scheme base) (scheme write) (srfi 64))
+
+(test-begin "record-shadow-drop-1718")
+
+;; Import a library exporting its own define-record-type macro -- this
+;; puts a `define-record-type` macro into the process-global vm.macros.
+(import (lib1718 drt-shadow))
+
+;; Import an unrelated library with its own, un-shadowed define-record-type.
+;; Before the fix, this was silently dropped.
+(import (lib1718 drt-victim))
+
+(test-assert "record constructor defined" (procedure? make-color))
+(test-assert "record predicate defined" (procedure? color?))
+(test-assert "record accessor defined" (procedure? color-r))
+(test-equal "record works end-to-end" 42 (color-r (make-color 42)))
+
+(let ((runner (test-runner-current)))
+  (test-end "record-shadow-drop-1718")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #1718. That issue hypothesized special forms are dispatched by
literal source-name comparison, "bypassing import/rename/macro
resolution," and reported two symptoms. Investigation (repro scripts,
two independent research passes, and a validated implementation plan —
details below) found the actual, fixable mechanisms are narrower than
the issue's own theory:

- **Not a bug:** a macro shadowing `lambda` whose expansion never
  converges to a fixed point correctly hits the existing macro-expansion
  limit and cleanly errors — an *ordinary*, non-colliding macro name with
  the identical non-converging shape produces the byte-identical error.
  This is expected `letrec*`-style macro self-reference (the same
  mechanism that makes recursive macros like `my-or` work) applied to a
  macro with no base case.

- **The real bug:** `define-record-type`/`define-values` desugaring
  (`vm_records.zig`, `vm_eval.zig`) compiled their generated definitions
  against the process-global macro table (`vm.macros`) instead of an
  isolated one. Once *any* program imported a macro shadowing a core
  special form, *every later library's own* record types or
  `define-values` forms — completely unrelated to the shadowing macro —
  could fail to compile. Worse: when the shadowed name was
  `define-record-type` itself (the SRFI-136/131/57 pattern), an unrelated
  library's own plain `define-record-type` was **silently dropped, no
  error at all** — `vm_library.zig`'s `compileLibExpr` unconditionally
  returned after deciding to defer to macro-aware compilation, without
  ever actually performing it.

- **Renaming a special form on import** (`(rename (only (scheme base)
  let*) (let* my-let*))`) silently produced a binding that resolved to
  nothing — special forms have no runtime value to move to a new name.
  This now fails with a clear diagnostic at the `import` declaration.

The larger architectural ask in the issue — making every special-form
keyword a fully first-class, resolvable-through-normal-identifier
binding everywhere — is a much larger, riskier engine change
appropriately left tracked rather than attempted here.

## Changes

- `vm_records.zig`: `handleDefineRecordType` (4 sites) and
  `compileAndRunDefine` (covers all `handleDefineRecordTypeR6RS` call
  sites) now compile their compiler-synthesized ctor/predicate/accessor/
  mutator bodies against an empty macro table — these forms never
  contain user subexpressions, so they must never be reinterpreted by a
  same- or cross-library macro shadowing `lambda`/`let`/`define`/etc.
- `vm_eval.zig`: `handleDefineValues` now compiles its (user-authored)
  initializer expression against a macro table scoped to the current
  library, mirroring `compileLibExpr`'s existing `lib_macros` pattern
  (#877) instead of the global table.
- `vm_eval.zig`: the `define-record-type` shadow check
  (`handleTopLevelForm`/`isSpecialTopLevelForm`) now consults the active
  library's own scope (`current_lib_env`) first, falling back to the
  global table only at true top level.
- `vm_library.zig`: `compileLibExpr` now falls through to macro-aware
  compilation when `handleTopLevelForm` defers, instead of silently
  dropping the form.
- `vm_library.zig`: `processImportRename` now raises a clear diagnostic
  when asked to rename a special form.
- New regression tests: `tests/scheme/smoke/record-macro-scope-1718.scm`,
  `tests/scheme/smoke/record-shadow-drop-1718.scm` (+ `lib1718/`
  fixtures), and three new cases in
  `tests/scheme/errors/import-filter.sh` (plus an update to its
  pre-existing `rename-syntax` case, which only asserted exit 0 without
  checking the renamed binding actually worked — precisely the blind
  spot that let this ship).

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — unit suite passes
- [x] `bash tests/scheme/run-all.sh` — 1988 pass, 0 fail (593 Scheme
      files + 1395 R7RS suite), including the new regression tests
- [x] Verified all new tests fail on the pre-fix code (via `git stash`)
      and pass post-fix
- [x] Manually confirmed the issue's exact repros (cross-library
      corruption via real SRFI 35/64, and the `let*`/`lambda` rename
      cases) now behave correctly
- [x] Confirmed no regression in SRFI 136/131/57/237/219 (all pass in
      the full suite; each's own shadowing mechanism is untouched or
      made more correctly scoped by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)