### PR TITLE
Fix two macro-expansion bugs found while investigating SRFI 148

### DIFF
--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -861,7 +861,16 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
 
     var custom_ellipsis: ?[]const u8 = null;
     var after_ellipsis = rest;
-    const first_arg = types.car(rest);
+    // A generating macro may splice a user/pattern-var-supplied ellipsis
+    // identifier into this position (mirrors the literals-list unwrap
+    // below): when a nested syntax-rules template substitutes an outer
+    // pattern variable here, NESTED_SR_FLAG's usertext-marking protocol
+    // wraps the value so the generating macro's own expansion doesn't
+    // re-walk it as template text. Unwrap it before checking whether this
+    // is a bare custom-ellipsis symbol, or it's still a usertext pair (not
+    // a symbol) and the ellipsis is silently missed, misparsing everything
+    // after it as part of the literals list.
+    const first_arg = expander.unwrapUsertext(types.car(rest));
     if (types.isSymbol(first_arg) and !types.isPair(first_arg)) {
         const name_str = types.symbolName(first_arg);
         if (!std.mem.eql(u8, name_str, "_")) {

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -759,20 +759,35 @@ fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_scop
 
     const in_escape = (intro_scope & ESCAPE_FLAG) != 0;
 
-    // Check for (quote ...) — substitute pattern vars but skip hygiene renaming
+    // Check for (quote <datum>) — substitute pattern vars but skip hygiene
+    // renaming. Must be a genuine, exactly-2-element quote form (R7RS quote
+    // is strictly unary): a template sub-list that merely STARTS with the
+    // symbol `quote` for an unrelated reason (e.g. passing the bare symbol
+    // `quote` as one argument among several to some other macro/procedure)
+    // is not a quote form at all, and treating it as one silently discarded
+    // every element after the second (e.g. `(op quote free-identifier=?
+    // more...)` instantiated as `(op (quote free-identifier=?))`, dropping
+    // `more...`).
     const tmpl_head = types.car(template);
     if (types.isSymbol(tmpl_head) and std.mem.eql(u8, types.symbolName(tmpl_head), "quote")) {
         const q_rest = types.cdr(template);
         if (q_rest != types.NIL and types.isPair(q_rest)) {
-            const quoted = types.car(q_rest);
-            const new_quoted = try instantiateTemplate(gc, quoted, bindings, intro_scope | QUOTE_FLAG, literals, macro_keyword, globals, macros);
-            var nq_root = new_quoted;
-            gc.pushRoot(&nq_root);
-            defer gc.popRoot();
-            const tail = try gc.allocPair(nq_root, types.NIL);
-            return gc.allocPair(tmpl_head, tail);
+            if (types.cdr(q_rest) == types.NIL) {
+                const quoted = types.car(q_rest);
+                const new_quoted = try instantiateTemplate(gc, quoted, bindings, intro_scope | QUOTE_FLAG, literals, macro_keyword, globals, macros);
+                var nq_root = new_quoted;
+                gc.pushRoot(&nq_root);
+                defer gc.popRoot();
+                const tail = try gc.allocPair(nq_root, types.NIL);
+                return gc.allocPair(tmpl_head, tail);
+            }
+            // More than 2 elements: `quote` is not forming a quote special
+            // form here, just an ordinary (possibly data) value in head
+            // position -- fall through to regular pair processing so the
+            // rest of the list survives instead of being silently dropped.
+        } else {
+            return template;
         }
-        return template;
     }
 
     // Quasiquote: its symbols are data (no renaming, like quote), but a

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -404,6 +404,56 @@ test "hygiene: genuinely inert quoted literal in a nested template is still not 
     );
 }
 
+test "hygiene: a template list starting with the symbol quote, but longer than 2 elements, is not treated as a quote form" {
+    // instantiateTemplate's (quote <datum>) fast path used to trigger for
+    // ANY template sub-list whose first element was literally the symbol
+    // `quote`, regardless of the list's actual length. R7RS quote is
+    // strictly unary, so a longer list starting with `quote` for an
+    // unrelated reason -- e.g. passing the bare symbol `quote` as one
+    // argument among several to some other macro -- was misinterpreted as
+    // `(quote <2nd-element>)`, silently discarding every element after the
+    // second. Found while porting SRFI 148's em-syntax-rules, whose own
+    // template literally begins `(em-syntax-rules-aux1 quote ...)`.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax sink
+        \\    (syntax-rules ()
+        \\      ((_ a b c) '(got a b c))))
+        \\  (define-syntax probe
+        \\    (syntax-rules ()
+        \\      ((_ (lit ...))
+        \\       (sink quote (lit ...) 42))))
+        \\  (equal? (probe ()) '(got quote () 42)))
+    );
+}
+
+test "hygiene: a custom ellipsis identifier substituted through a nested syntax-rules template is recognized, not misparsed as a literal" {
+    // parseSyntaxRules's custom-ellipsis detection (the optional symbol
+    // right after `syntax-rules`) requires a bare, unwrapped symbol. When a
+    // nested syntax-rules template substitutes an OUTER pattern variable
+    // into that exact position (NESTED_SR_FLAG's usertext-marking protocol
+    // wraps the value so the generating macro's own expansion doesn't
+    // re-walk it as template text), the wrapped value isn't a bare symbol,
+    // so the ellipsis position was silently missed and the wrapped pair
+    // was misparsed as the literals list instead -- corrupting everything
+    // that should have come after it. Found while porting SRFI 148's
+    // em-syntax-rules, whose custom-ellipsis branch generates exactly this
+    // shape. my-ellipsis is substituted (to the symbol :::) before this
+    // embedded syntax-rules is parsed, so both the declared ellipsis
+    // argument and its two uses (pattern and template) end up as the
+    // literal symbol :::, exercising the exact generated shape.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax gen-with-ellipsis
+        \\    (syntax-rules ()
+        \\      ((_ my-ellipsis)
+        \\       (syntax-rules my-ellipsis ()
+        \\         ((_ x my-ellipsis) '(x my-ellipsis))))))
+        \\  (define-syntax use-it (gen-with-ellipsis :::))
+        \\  (equal? (use-it 1 2 3) '(1 2 3)))
+    );
+}
+
 test "hygiene: template references sibling define that appears later in body" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();


### PR DESCRIPTION
## Summary

Found while implementing SRFI 148 (issue #1699's final tractable slice —
work paused, no feature PR yet, blocked on a separate, deeper performance
problem filed as #1775). Both are general, pre-existing bugs in the macro
expander, unrelated to any specific SRFI.

### Bug 1: `(quote ...)` fast path misfires on longer lists

`instantiateTemplate`'s quote-form detection (`src/expander.zig`) triggered
for any template sub-list whose first element was literally the symbol
`quote`, regardless of the list's actual length. R7RS `quote` is strictly
unary (`(quote <datum>)`, always exactly 2 elements), so a longer list that
merely *starts* with the symbol `quote` for an unrelated reason — e.g.
passing the bare symbol `quote` as one argument among several to some other
macro or procedure — was misparsed as a 2-element quote form, silently
discarding every element after the second.

```scheme
(define-syntax sink
  (syntax-rules () ((_ a b c) '(got a b c))))
(define-syntax probe
  (syntax-rules () ((_ (lit ...)) (sink quote (lit ...) 42))))
(probe ())
;; before: (sink quote) -- `(lit ...)` and `42` silently dropped
;; after:  (sink quote () 42) -- correct
```

SRFI 148's `em-syntax-rules` hits this directly: its own template literally
begins `(em-syntax-rules-aux1 quote free-identifier=? ...)`, passing the
bare symbol `quote` as a plain argument.

Fixed by requiring the quote-form fast path to match only when the sub-list
has exactly 2 elements; anything else falls through to regular pair
processing so the rest of the list survives.

### Bug 2: custom-ellipsis detection misses a usertext-wrapped value

`parseSyntaxRules`'s custom-ellipsis-argument detection (the optional
symbol right after `syntax-rules`) requires a bare, unwrapped symbol. When
a nested `syntax-rules` template substitutes an *outer* pattern variable
into that exact position, `NESTED_SR_FLAG`'s usertext-marking protocol
wraps the value (so the generating macro's own later expansion doesn't
re-walk it as template text) — but `parseSyntaxRules` never unwrapped it
before checking `isSymbol`, so the ellipsis position was silently missed
and the wrapped pair was misparsed as part of the literals list instead,
corrupting everything after it.

Fixed by unwrapping (mirroring the existing, analogous unwrap already done
for literals-list entries a few lines below) before the symbol check.

## Testing

- Two new regression tests in `src/tests_macros.zig`, each reproducing the
  bug in isolation with a minimal macro (not SRFI-148-specific).
- `zig build test`: full unit suite green.
- `bash tests/scheme/run-all.sh`: 1992/1992, 0 fail (post-rebase onto
  latest main).

## Scope note

SRFI 148 itself remains blocked on a separate, more serious problem: its
`em-syntax-rules` mechanism (a macro that generates a nested `syntax-rules`
transformer at expansion time) becomes severely, apparently
super-linearly slow as the generated macro's rule count grows — a 3-rule
macro compiles in under a second, an 8-rule one takes 40+ seconds. Filed
as #1775 with the investigation notes (including a reverted attempt at a
third, related correctness bug — a usertext marker surviving in a
generated pattern's dotted-tail position — that also regressed an
unrelated `bound-identifier=?` test, most likely from mutating structure
shared with a persistent, stored macro template). Not included here since
it needs its own dedicated investigation.

## Test plan

- [x] `zig build test`
- [x] `bash tests/scheme/run-all.sh`
- [x] Manual repro of both bugs and confirmation of the fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)