### PR TITLE
Fix string->number to reject misplaced digit-separator underscores

### DIFF
--- a/lib/srfi/169.sld
+++ b/lib/srfi/169.sld
@@ -24,19 +24,18 @@
 ;;; there is nothing to export.
 ;;;
 ;;; Scope note: this port makes no deliberate `string->number` change for
-;;; SRFI 169 (the spec doesn't ask for it). In practice `string->number`
-;;; already tolerates *some* underscore placements today, for two
-;;; unrelated, pre-existing reasons: its small-integer fast path calls
-;;; Zig's std.fmt.parseInt directly, which has its own (more permissive
-;;; than SRFI 169) underscore convenience -- e.g. it wrongly accepts a
-;;; doubled underscore ("1__2" -> 12) that SRFI 169 requires rejecting,
-;;; a pre-existing gap unrelated to this port, filed as #1724 rather than
-;;; silently left -- and its hex-float path shares `parseHexFloat` with
-;;; the reader (added for SRFI 270, which *does* require `string->number`
-;;; support), which does apply this library's own stricter validation.
-;;; Bottom line: do not rely on `string->number` for SRFI-169-correct
-;;; underscore handling; only the reader syntax itself is validated to
-;;; spec.
+;;; SRFI 169 (the spec doesn't ask for it), but `string->number` does
+;;; validate underscore placement to the same rule: `stringToNumber`
+;;; (src/primitives_numeric.zig) calls `bignum.stripUnderscores` once, up
+;;; front on the whole numeric body, before any shape-specific parsing --
+;;; so the plain-integer, rational numerator/denominator, hex-float,
+;;; bignum-overflow, decimal-float, and complex-parts paths all see
+;;; already-validated, already-stripped digits. This closed a real gap
+;;; (#1724): the small-integer and rational fast paths used to call Zig's
+;;; std.fmt.parseInt directly on unvalidated input, which has its own,
+;;; more permissive underscore convenience (mirroring Zig's own integer
+;;; literal syntax) that wrongly accepted a doubled underscore
+;;; ("1__2" -> 12) SRFI 169 requires rejecting.
 
 (define-library (srfi 169)
   (export)

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1102,7 +1102,7 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string->number", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
-    var s = str.data[0..str.len];
+    var s: []const u8 = str.data[0..str.len];
 
     var radix: u8 = 10;
     if (args.len > 1) {
@@ -1147,6 +1147,21 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
         }
     }
     if (s.len == 0) return types.FALSE;
+
+    // SRFI 169: `s` may still carry embedded digit-separator underscores at
+    // this point. Validate their placement -- strictly between two valid
+    // digits of `radix`, matching the reader's own rule (bignum.zig's
+    // stripUnderscores doc comment) -- and strip them up front, once, for
+    // every shape below (plain integer, rational numerator/denominator,
+    // decimal float, complex parts). Without this, the small-integer and
+    // rational fast paths call std.fmt.parseInt directly, which has its own
+    // more permissive underscore convenience (mirroring Zig's own integer
+    // literal syntax) that wrongly accepts e.g. a doubled underscore
+    // ("1__2" -> 12) SRFI 169 requires rejecting (#1724). The hex-float and
+    // bignum-overflow paths already call stripUnderscores internally, so
+    // this is a harmless no-op for them once `s` is already clean.
+    var underscore_buf: [4096]u8 = undefined;
+    s = bignum_mod.stripUnderscores(s, radix, &underscore_buf) orelse return types.FALSE;
 
     if (std.mem.eql(u8, s, "+inf.0") or std.mem.eql(u8, s, "-inf.0") or
         std.mem.eql(u8, s, "+nan.0") or std.mem.eql(u8, s, "-nan.0"))

--- a/tests/scheme/smoke/string-to-number-underscores-1724.scm
+++ b/tests/scheme/smoke/string-to-number-underscores-1724.scm
@@ -1,0 +1,51 @@
+;; Regression test for #1724: string->number wrongly accepted misplaced
+;; SRFI-169-style digit-separator underscores ("1__2" -> 12 instead of #f).
+;;
+;; Root cause: the small-integer fast path (and the rational
+;; numerator/denominator parse) called Zig's std.fmt.parseInt directly on
+;; unvalidated input. That function has its own, more permissive underscore
+;; convenience (mirroring Zig's own integer-literal syntax) that only
+;; rejects a leading/trailing underscore, not a doubled one -- unlike
+;; bignum.stripUnderscores, which the reader and the hex-float/bignum-
+;; overflow paths already used. The fix validates+strips underscores once,
+;; up front in string->number, before any shape-specific parsing.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "string-to-number-underscores-1724")
+
+;;; --- exact repro from the issue ---
+
+(test-equal "doubled underscore rejected, not silently collapsed" #f (string->number "1__2"))
+(test-equal "trailing underscore rejected" #f (string->number "123_"))
+(test-equal "leading underscore rejected" #f (string->number "_123"))
+(test-equal "single well-placed underscores accepted" 123 (string->number "1_2_3"))
+(test-equal "single underscore, single digit each side" 12 (string->number "1_2"))
+
+;;; --- same root cause, other numeric shapes reachable from string->number ---
+
+(test-equal "doubled underscore in rational numerator rejected" #f (string->number "1__2/3"))
+(test-equal "doubled underscore in rational denominator rejected" #f (string->number "1/3__4"))
+(test-equal "valid underscores in rational numerator and denominator" 6/17 (string->number "1_2/3_4"))
+
+(test-equal "doubled underscore in hex integer rejected" #f (string->number "#xFF__FF"))
+(test-equal "valid underscore in hex integer" 65535 (string->number "#xFF_FF"))
+
+(test-equal "doubled underscore in complex real part rejected" #f (string->number "1__2+3i"))
+(let ((z (string->number "1_2+3_4i")))
+  (test-assert "valid underscores in complex real and imaginary parts"
+    (and z (= (real-part z) 12) (= (imag-part z) 34))))
+
+(test-equal "doubled underscore in decimal float rejected" #f (string->number "1__2.5"))
+(test-equal "doubled underscore rejected under #e prefix" #f (string->number "#e1__2.5"))
+
+;; Already correct before the fix (i64 overflow routes to parseBignumString,
+;; which validates internally) -- kept here to pin the boundary alongside
+;; the previously-buggy small-integer case above.
+(test-equal "doubled underscore rejected in a bignum-sized literal" #f
+  (string->number "99999999999999999999__999999999999999999"))
+(test-equal "valid underscores throughout a bignum-sized literal" 12345678901234567890
+  (string->number "12_34_56_78_90_12_34_56_78_90"))
+
+(let ((runner (test-runner-current)))
+  (test-end "string-to-number-underscores-1724")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

- `string->number`'s small-integer fast path and rational numerator/denominator parsing called Zig's `std.fmt.parseInt` directly on unvalidated input. That function tolerates a doubled underscore (mirroring Zig's own integer-literal syntax), so `(string->number "1__2")` silently returned `12` instead of `#f`.
- The hex-float and bignum-overflow paths were already correct, since they route through `bignum.stripUnderscores` — the same SRFI-169 placement validator the reader uses.
- Fix: validate + strip underscores once, up front in `stringToNumber`, right after prefix handling and before any shape-specific parsing (plain integer, rational, hex float, bignum overflow, decimal float, complex parts). This makes every path consistent and is a zero-copy no-op for inputs with no underscore at all.
- Updated `lib/srfi/169.sld`'s header comment, which explicitly documented this as an open gap ("filed as #1724... do not rely on `string->number`...") — it now describes the fixed behavior.

Fixes #1724.

## Test plan

- [x] New regression test `tests/scheme/smoke/string-to-number-underscores-1724.scm` (SRFI-64): exact repro from the issue, plus the same root cause in rational, hex, and complex shapes.
- [x] `zig build test` — unit suite passes.
- [x] `bash tests/scheme/run-all.sh` — full suite passes (1993/1993, 0 failures).
- [x] `zig fmt --check` clean.
- [x] Manually verified against the issue's exact repro cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)