### PR TITLE
Give kaappi compile binaries real argv via (command-line) (#1744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`kaappi compile` binaries could not see their own command-line
+  arguments** — the LLVM-emitted `main()` took no parameters at all, so
+  `(command-line)` always returned `()` in a compiled binary no matter what
+  arguments it was invoked with. `main` now takes the standard C
+  `(argc, argv)` pair and hands `argv` to the runtime right after init, so a
+  compiled binary's `(command-line)` reports its own path followed by its
+  real arguments, mirroring how the interpreter reports a script's name
+  followed by its arguments (#1744).
+
 - **A special-form-shadowing macro imported by one program could corrupt
   `define-record-type`/`define-values` in a completely unrelated library
   loaded afterward** — `define-record-type`'s and `define-values`'s

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -345,6 +345,9 @@ pub const LLVMEmitter = struct {
         self.buf = body;
 
         self.write("  %vm = call ptr @kaappi_runtime_init()\n") catch return error.OutOfMemory;
+        // Thread the real argv through so `(command-line)` works in compiled
+        // binaries (#1744) — %argc/%argv are @main's own parameters, set below.
+        self.write("  call void @kaappi_set_command_line_args(ptr %vm, ptr %argv)\n") catch return error.OutOfMemory;
         for (nodes) |node| {
             _ = self.emitNode(node) catch return error.OutOfMemory;
         }
@@ -405,7 +408,14 @@ pub const LLVMEmitter = struct {
             try self.write(def);
         }
 
-        try self.write("\ndefine i32 @main() {\nentry:\n");
+        // argc/argv match the standard C `main(int, char**)` ABI (kaappi#1744):
+        // the CRT startup call always passes argc in the first integer
+        // argument slot and argv in the second, so keeping %argc in the
+        // signature — even though the body never reads it — is required for
+        // %argv to bind to the real argv pointer rather than the argc value.
+        // kaappi_set_command_line_args scans argv to its NULL sentinel, so
+        // argc itself is never threaded any further.
+        try self.write("\ndefine i32 @main(i32 %argc, ptr %argv) {\nentry:\n");
         try self.write(body.items);
 
         try self.write("\n  call void @kaappi_runtime_deinit(ptr %vm)\n");

--- a/src/native_decls.zig
+++ b/src/native_decls.zig
@@ -27,6 +27,7 @@ pub const Decl = struct {
 pub const decls: []const Decl = &.{
     .{ .export_name = "kaappi_runtime_init", .scheme_name = null, .param_types = &.{}, .ret = .ptr, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_runtime_deinit", .scheme_name = null, .param_types = &.{.ptr}, .ret = .void_ty, .inline_kind = .not_inlined },
+    .{ .export_name = "kaappi_set_command_line_args", .scheme_name = null, .param_types = &.{ .ptr, .ptr }, .ret = .void_ty, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_global_lookup", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_call_scheme", .scheme_name = null, .param_types = &.{ .ptr, .i64, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_define_global", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64, .i64 }, .ret = .void_ty, .inline_kind = .not_inlined },

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -61,6 +61,32 @@ pub export fn kaappi_runtime_deinit(vm: ?*vm_mod.VM) callconv(.c) void {
     rt_gc.deinit();
 }
 
+// Populates vm.command_line_args from the process's real argv so
+// `(command-line)` sees a compiled binary's own arguments (kaappi#1744).
+// Threaded from the native `main(argc, argv)` entry point (llvm_emit.zig)
+// right after kaappi_runtime_init. argv is scanned to its NULL sentinel
+// instead of threading argc through: every native_backend_supported target
+// (glibc/musl/macOS libc, mingw-w64's CRT, *BSD libc) guarantees
+// argv[argc] == NULL.
+pub export fn kaappi_set_command_line_args(vm: ?*vm_mod.VM, argv: ?[*]const ?[*:0]const u8) callconv(.c) void {
+    const v = vm orelse return;
+    const av = argv orelse return;
+    v.command_line_args = collectArgv(av) catch {
+        const msg = "failed to collect command-line arguments\n";
+        _ = platform.write(2, msg, msg.len);
+        std.process.exit(1);
+    };
+}
+
+fn collectArgv(argv: [*]const ?[*:0]const u8) ![]const []const u8 {
+    var list: std.ArrayList([]const u8) = .empty;
+    var i: usize = 0;
+    while (argv[i]) |arg| : (i += 1) {
+        try list.append(std.heap.c_allocator, std.mem.span(arg));
+    }
+    return list.toOwnedSlice(std.heap.c_allocator);
+}
+
 pub export fn kaappi_global_lookup(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len: u64) callconv(.c) u64 {
     const v = vm orelse return 0;
     const len: usize = @intCast(name_len);

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -162,8 +162,11 @@ test "LLVM emit: preamble has target triple and runtime calls" {
     defer res.deinit();
     const ll = res.toSlice();
     try expectContains(ll, "target triple");
-    try expectContains(ll, "define i32 @main()");
+    // main takes argc/argv (kaappi#1744) so (command-line) works in compiled
+    // binaries — see kaappi_set_command_line_args below.
+    try expectContains(ll, "define i32 @main(i32 %argc, ptr %argv)");
     try expectContains(ll, "@kaappi_runtime_init");
+    try expectContains(ll, "call void @kaappi_set_command_line_args(ptr %vm, ptr %argv)");
     try expectContains(ll, "@kaappi_runtime_deinit");
     try expectContains(ll, "ret i32 0");
 }
@@ -173,6 +176,7 @@ test "LLVM emit: preamble declares runtime functions" {
     defer res.deinit();
     const ll = res.toSlice();
     try expectContains(ll, "declare ptr @kaappi_runtime_init()");
+    try expectContains(ll, "declare void @kaappi_set_command_line_args(ptr, ptr)");
     try expectContains(ll, "declare i64 @kaappi_global_lookup(ptr, ptr, i64)");
     try expectContains(ll, "declare i64 @kaappi_call_scheme(ptr, i64, ptr, i64)");
     try expectContains(ll, "declare i64 @kaappi_fixnum_add(i64, i64)");
@@ -720,7 +724,7 @@ test "native declare table covers all runtime exports in preamble" {
             return error.TestExpectedEqual;
         }
     }
-    try std.testing.expectEqual(@as(usize, 26), native_decls.decls.len);
+    try std.testing.expectEqual(@as(usize, 27), native_decls.decls.len);
 }
 
 // -- Compile-once eval-fallback cache (#1494) --

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -76,6 +76,30 @@ foreach ($p in (Get-ChildItem (Join-Path $scriptDir "programs\*.scm") | Sort-Obj
     }
 }
 
+# Command-line argument passthrough (kaappi#1744). Not part of the parity
+# loop above: (command-line)'s first element is the running binary's own
+# path, which legitimately differs between the interpreted and compiled
+# runs, so exact-output parity with the interpreter does not apply here.
+$argvExe = Join-Path $outdir "test-argv.exe"
+$cc_out = (& $Kaappi compile (Join-Path $scriptDir "test-argv.scm") -o $argvExe 2>&1) -join "`n"
+if ($LASTEXITCODE -ne 0) {
+    Write-Output "FAIL: command-line argument passthrough - compile failed"
+    Write-Output $cc_out
+    $fail++; $failed += "command-line-args"
+} else {
+    $actual = (& $argvExe a b c 2>&1) -join "`n"
+    $expected = '("a" "b" "c")'
+    if ($actual -ceq $expected) {
+        Write-Output "PASS: command-line argument passthrough"
+        $pass++
+    } else {
+        Write-Output "FAIL: command-line argument passthrough"
+        Write-Output "  expected: $expected"
+        Write-Output "  actual:   $actual"
+        $fail++; $failed += "command-line-args"
+    }
+}
+
 Remove-Item -Recurse -Force $outdir -ErrorAction SilentlyContinue
 
 Write-Output ""

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -133,6 +133,38 @@ for program in "$SCRIPT_DIR"/programs/*.scm; do
     assert_native_parity "$name" "$program"
 done
 
+# --- Phase 3: command-line argument passthrough (kaappi#1744) ---
+#
+# Not run through assert_native_parity: (command-line)'s first element is
+# the running binary's own path, which legitimately differs between the
+# interpreted and compiled runs, so exact-output parity does not apply.
+# This checks instead that real arguments passed to a compiled binary
+# survive the trip through main(argc, argv) -> (command-line).
+
+echo ""
+echo "=== Phase 3: command-line argument passthrough ==="
+
+argv_ll="$TMPDIR/test-argv.ll"
+argv_bin="$TMPDIR/test-argv"
+
+if "$KAAPPI" --emit-llvm -o "$argv_ll" "$SCRIPT_DIR/test-argv.scm" 2>/dev/null &&
+    $CC -O2 "$argv_ll" -o "$argv_bin" -L"$LIBDIR" -lkaappi_rt -lc -lm -lpthread 2>/dev/null; then
+    actual=$("$argv_bin" a b c 2>&1) || true
+    expected='("a" "b" "c")'
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: command-line argument passthrough"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: command-line argument passthrough"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+else
+    echo "FAIL: command-line argument passthrough — compile/link failed"
+    FAIL=$((FAIL + 1))
+fi
+
 # --- Summary ---
 
 echo ""

--- a/tests/e2e/test-argv.scm
+++ b/tests/e2e/test-argv.scm
@@ -1,0 +1,11 @@
+;; Verifies a `kaappi compile` binary sees its own argv via (command-line)
+;; (kaappi#1744). Run directly by run-e2e.sh's Phase 3, not through the
+;; generic per-program parity loop in programs/: the first (command-line)
+;; element is the running binary's own path, which legitimately differs
+;; between an interpreted run and a compiled run, so exact-output parity
+;; with the interpreter does not apply to this program. Only the tail of
+;; the list — the real arguments passed after the program name — is
+;; checked by the harness.
+(import (scheme base) (scheme write) (scheme process-context))
+(write (cdr (command-line)))
+(newline)


### PR DESCRIPTION
## Summary

Fixes #1744: `kaappi compile` binaries could not see their own command-line
arguments — `(command-line)` always returned `()`.

**Root cause**: the LLVM emitter generated every compiled binary's entry
point as `define i32 @main()` — zero parameters — so `argc`/`argv` never
reached the runtime.

**Fix**:
- `main` now takes the standard C `(i32 %argc, ptr %argv)` pair. `%argc`
  must stay in the signature even though it's never read, or `%argv` would
  bind to the wrong ABI register (the CRT startup call always passes argc
  first, argv second).
- A new runtime export, `kaappi_set_command_line_args(vm, argv)`, is called
  right after `kaappi_runtime_init` and scans `argv` to its NULL sentinel
  instead of threading `argc` through — every `native_backend_supported`
  target's libc/CRT guarantees `argv[argc] == NULL`.
- Registered in `native_decls.zig`'s comptime-checked declare table.

A compiled binary's `(command-line)` now returns `(own-binary-path arg1 arg2
...)` — the real argv — mirroring how the interpreter leads with the script
filename (R7RS: "the first string corresponds to the command name,
implementation-dependent").

Note: the issue also compared this against `zig build -Dbundle-src`, which
happens to omit a leading name. That turned out to be incidental (bundled
binaries still run through the normal CLI file-path parsing, unaware there's
no real script file, so the first extra argument accidentally gets consumed
as a `file_path` placeholder) rather than a designed contract, so it's left
untouched here — out of scope for an issue titled specifically about `kaappi
compile`.

## Test plan

- [x] `zig build` / `zig build test` — unit suite green, including two
      pre-existing tests updated for the new `main` signature and the
      declare-table count (26 → 27 entries)
- [x] New e2e phase (`tests/e2e/test-argv.scm` + `run-e2e.sh`/`run-e2e.ps1`)
      compiles a program, runs it with real arguments, and checks
      `(cdr (command-line))` — not run through the existing
      interpreter-vs-native parity loop, since the leading "command name"
      element legitimately differs between an interpreted and compiled run
      of the same program
- [x] Confirmed the new test fails pre-fix (`cdr: not a pair`, since
      `(command-line)` was `()`) and passes post-fix
- [x] Full e2e suite: 38/38 passed
- [x] Full Scheme suite (`bash tests/scheme/run-all.sh`): 1992/1992 passed
- [x] Manual repro from the issue verified: `./cl a b` → `("./cl" "a" "b")`
      (was `()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)