### PR TITLE
Build Linux release binaries against glibc so dynamic loading works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,21 @@ jobs:
             lib_src: libkaappi_rt.a
             lib_ext: .a
             strip: true
+          # Mainstream Linux targets build against glibc (floor 2.28 —
+          # RHEL 8 / Debian 10 / Ubuntu 18.10 and newer) instead of Zig's
+          # default musl-static: static musl cannot dlopen, which made
+          # every released Linux binary reject (kaappi ffi) and with it
+          # the whole C-extension ecosystem (net/http/sqlite/pg/redis/
+          # crypto) — kaappi-lang.org's docs-samples CI caught it. The
+          # linux-ffi-smoke job below gates the release on dlopen working.
+          # `target` stays the artifact-naming key (install.sh matches
+          # libkaappi_rt-<target>.a); `zig_target` is what we compile for.
+          # Trade-off: glibc binaries don't run on musl distros (Alpine) —
+          # those users build from source until a musl-dynamic variant
+          # ships as an extra artifact.
           - os: ubuntu-latest
             target: x86_64-linux
+            zig_target: x86_64-linux-gnu.2.28
             artifact: kaappi-x86_64-linux
             exe_ext: ''
             lib_src: libkaappi_rt.a
@@ -29,6 +42,7 @@ jobs:
             strip: true
           - os: ubuntu-24.04-arm
             target: aarch64-linux
+            zig_target: aarch64-linux-gnu.2.28
             artifact: kaappi-aarch64-linux
             exe_ext: ''
             lib_src: libkaappi_rt.a
@@ -158,8 +172,8 @@ jobs:
 
       - name: Build release binaries and runtime library
         run: |
-          zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=${{ matrix.strip }}
-          zig build lib -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }}
+          zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.zig_target || matrix.target }} -Dstrip=${{ matrix.strip }}
+          zig build lib -Doptimize=ReleaseSafe -Dtarget=${{ matrix.zig_target || matrix.target }}
 
       - name: Sign and notarize macOS binaries
         if: matrix.target == 'aarch64-macos'
@@ -247,8 +261,37 @@ jobs:
           path: zig-out/bin/kaappi.wasm
           retention-days: 1
 
+  # The bug this guards against: a Linux artifact built without working
+  # dynamic loading (e.g. Zig's default musl-static target) passes every
+  # build step but cannot load a single C-extension library once
+  # installed. Run the actual release artifact and prove dlopen works
+  # before anything is published.
+  linux-ffi-smoke:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: kaappi-x86_64-linux
+          - os: ubuntu-24.04-arm
+            artifact: kaappi-aarch64-linux
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.artifact }}
+
+      - name: Smoke-test interpreter and dynamic loading
+        run: |
+          chmod +x ${{ matrix.artifact }}
+          echo '(display (+ 1 2)) (newline)' | ./${{ matrix.artifact }} /dev/stdin | grep -qx '3'
+          printf '(import (kaappi ffi))\n(define libm (ffi-open "libm.so.6"))\n(define c-sqrt (ffi-fn libm "sqrt" (quote (double)) (quote double)))\n(display (c-sqrt 4.0)) (newline)\n' \
+            | ./${{ matrix.artifact }} /dev/stdin | grep -qx '2.0'
+          echo "dynamic loading OK"
+
   release:
-    needs: [build, build-wasm]
+    needs: [build, build-wasm, linux-ffi-smoke]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Released Linux binaries are musl-static (Zig's default for bare `x86_64-linux`), and static musl cannot `dlopen` — so every Linux release install rejects `(import (kaappi ffi))` with **Dynamic loading not supported**, which kills the entire C-extension ecosystem (kaappi-net/http/sqlite/pg/redis/crypto). Found by the kaappi-lang.org docs-samples CI running the real release artifact on ubuntu-latest; the nightly ecosystem tests build kaappi natively and so never see release-artifact behavior.

**Changes**
- `x86_64-linux` and `aarch64-linux` release artifacts now compile with `-Dtarget=<arch>-linux-gnu.2.28` (glibc floor: RHEL 8 / Debian 10 / Ubuntu 18.10+). A new `zig_target` matrix field carries the compile triple so artifact names (`kaappi-x86_64-linux`, `thottam-x86_64-linux`, `libkaappi_rt-x86_64-linux.a`) are unchanged — install.sh keeps working as-is.
- Interpreter-tier arches (riscv64/s390x/ppc64le) stay musl-static, matching their documented Alpine-VM validation.
- New `linux-ffi-smoke` job: downloads the built x86_64/aarch64 artifacts, runs `(+ 1 2)` and an `ffi-open`/`ffi-fn` call against `libm.so.6`, and the `release` job now depends on it — an FFI-dead Linux artifact can never be published again.

**Trade-off:** glibc-linked binaries don't run on musl distros (Alpine). Those users build from source for now; a musl-dynamic variant could ship later as an additional artifact.

**Local verification (zig 0.16.0):** bare `x86_64-linux` builds `statically linked` (reproducing the bug); `x86_64-linux-gnu.2.28` and `aarch64-linux-gnu.2.28` build `dynamically linked` with interpreters `/lib64/ld-linux-x86-64.so.2` and `/lib/ld-linux-aarch64.so.1`; `zig build lib` produces the runtime library for the gnu targets. Runtime dlopen proof lands via the smoke job on the next tagged release.

Once released, the docs site's sweep re-activates its FFI checks on Linux automatically (`HAVE_FFI` probe in kaappi.github.io `scripts/sweep/_common.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)