### PR TITLE
Bound the set! pre-scan so macro-generating macros stop compiling exponentially (#1775)

### DIFF
--- a/docs/dev/timings.md
+++ b/docs/dev/timings.md
@@ -119,6 +119,41 @@ once:
 - `native_compiler` — `read`, `llvm-emit`, `link`.
 - `main.zig` run/compile drivers — `read`, `execute`, and cache HIT/MISS.
 
+## What `--timings` cannot tell you: who the caller is
+
+`--timings` attributes wall time to a *stage*, never to a *caller*. When one
+stage dominates, that is the end of what it can say — and the stage is often
+not where the fix is.
+
+[#1775](https://github.com/kaappi/kaappi/issues/1775) is the worked example. A
+macro-generating macro compiled in 41s, and `--timings` reported:
+
+```
+timings: read 1.4ms | expand 2765.8ms | lower 0.0ms | optimize 0.0ms | ...
+```
+
+Correct, and misleading: the time really was inside `expander.expandMacro`, but
+nothing in `expander.zig` was wrong. The expansions were being driven by
+`compiler.collectSetTargets` — a `set!` pre-scan that explored branches the real
+compiler never takes. Two sessions read the `expand` number as "the expander is
+slow" and profiled `instantiateTemplate` and `stripUsertextMarkers` by hand,
+ruling out theories one at a time.
+
+A stack profiler answers the caller question directly and needs no
+instrumentation — ReleaseSafe binaries keep frame pointers, so this works on the
+ordinary `zig build` output:
+
+```bash
+kaappi slow.scm & sample $! 8 -f /tmp/prof.txt
+```
+
+On Linux use `perf record -g -- kaappi slow.scm && perf report`. The #1775
+profile put 99% of samples under `collectSetTargets` in the first run.
+
+**Rule of thumb: `--timings` to find out *which stage*, `sample`/`perf` to find
+out *which caller*.** Reach for the profiler as soon as a stage number is
+surprising, before forming a theory about the code inside that stage.
+
 ## Cost when absent, and threading
 
 Every `begin`/`end` is a single predicted branch (`if (!enabled) return`) when

--- a/docs/dev/timings.md
+++ b/docs/dev/timings.md
@@ -128,7 +128,7 @@ not where the fix is.
 [#1775](https://github.com/kaappi/kaappi/issues/1775) is the worked example. A
 macro-generating macro compiled in 41s, and `--timings` reported:
 
-```
+```text
 timings: read 1.4ms | expand 2765.8ms | lower 0.0ms | optimize 0.0ms | ...
 ```
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -111,6 +111,13 @@ pub const Compiler = struct {
     // constant folders (IR and legacy) to avoid folding calls to a name that
     // may be reassigned before the call executes.
     set_targets: ?*std.StringHashMap(void) = null,
+    // True when the pre-scan that built `set_targets` had to stop early (see
+    // SetScanBudget), making that map an under-approximation. Both consumers
+    // then behave as if *every* name were a `set!` target: box every local and
+    // fold nothing. Costs optimization, never correctness — the opposite bias
+    // from a silently-truncated scan, which would leave a mutated local
+    // unboxed and reintroduce #1168/#1250 (kaappi#1775).
+    set_targets_all: bool = false,
     scope_depth: u16 = 0,
     next_register: u16 = 0,
     parent: ?*Compiler = null,
@@ -177,6 +184,7 @@ pub const Compiler = struct {
             .lib_env_val = parent.lib_env_val,
             .restricted_env = parent.restricted_env,
             .set_targets = parent.set_targets,
+            .set_targets_all = parent.set_targets_all,
             .parent = parent,
         };
     }
@@ -424,7 +432,7 @@ pub const Compiler = struct {
     /// pattern matchers) quadratic — every level re-expanded its whole subtree.
     pub fn scanSetTargets(self: *Compiler, expr: Value) CompileError!void {
         if (self.set_targets) |st| {
-            try collectSetTargets(self, expr, st, 0, false);
+            try collectSetTargets(self, expr, st, 0, null);
         }
     }
 
@@ -436,7 +444,7 @@ pub const Compiler = struct {
     /// whose car survives restore. (#1168)
     pub fn boxIfSetTarget(self: *Compiler, name: []const u8, slot: u16) CompileError!void {
         const targets = self.set_targets orelse return;
-        if (targets.contains(name)) {
+        if (self.set_targets_all or targets.contains(name)) {
             try self.markLocalBoxedBySlot(slot);
         }
     }
@@ -509,9 +517,15 @@ pub const Compiler = struct {
         // (including in nested lambda bodies, which inherit this set).
         var set_targets = std.StringHashMap(void).init(self.gc.allocator);
         defer set_targets.deinit();
-        try collectSetTargets(self, expr_root, &set_targets, 0, true);
+        var budget = SetScanBudget{ .expansions_left = prescan_expansion_limit };
+        try collectSetTargets(self, expr_root, &set_targets, 0, &budget);
         self.set_targets = &set_targets;
-        defer self.set_targets = null;
+        self.set_targets_all = budget.truncated;
+        if (budget.truncated) prescan_truncations += 1;
+        defer {
+            self.set_targets = null;
+            self.set_targets_all = false;
+        }
 
         // Lower AST to IR, run analysis and optimizations, then emit bytecode.
         var ir = ir_mod.IR.init(self.gc.allocator);
@@ -948,17 +962,61 @@ fn formatSyntaxError(args: Value) void {
     syntax_error_detail_len = w.buffered().len;
 }
 
+/// Work limit for one top-level `set!` pre-scan (kaappi#1775).
+///
+/// The pre-scan expands macros so it can see a `set!` a template introduces
+/// (#1250). That makes it a speculative *evaluator* of compile-time macro
+/// code, and it explores branches the real compiler never takes: at
+/// `(m kt kf)`, where `m` is a helper the enclosing expansion defined with
+/// `define-syntax`, the scan has no binding for `m`, so it treats `kt` and
+/// `kf` as ordinary sub-forms and expands macros inside *both*. The real
+/// compiler registers `m`, expands it, and follows exactly one. Every such
+/// fork doubles the work, so macros that generate macros — SRFI 148's
+/// `em-syntax-rules`, SRFI 257's CK-machine combinators — cost time
+/// exponential in the number of forks.
+///
+/// Exceeding the limit is safe by construction: the scan sets `truncated`,
+/// and Compiler.set_targets_all makes both consumers assume every name is a
+/// `set!` target. A truncated scan therefore loses optimization, never
+/// correctness.
+///
+/// 4096 is ~2.5x the highest count any non-pathological top-level form in
+/// this repo's Scheme suites reaches (p99.99 = 1649 expansions; 87% of forms
+/// need none at all) and well under the 6299+ the macro-generating cases
+/// start at. That headroom matters: a truncated scan boxes every local in the
+/// form, measured at ~2x runtime on compute-heavy code, so ordinary programs
+/// must never reach the limit.
+///
+/// A `var` only so tests can lower it and exercise the truncation path
+/// without a multi-second pathological program; nothing in the compiler
+/// writes it.
+pub var prescan_expansion_limit: u32 = 4096;
+
+/// Number of top-level forms whose `set!` pre-scan truncated. Diagnostic
+/// only — read by tests to assert the guard did (or did not) engage.
+pub threadlocal var prescan_truncations: u64 = 0;
+
+const SetScanBudget = struct {
+    expansions_left: u32,
+    /// Set when the scan stopped early (budget exhausted or depth cap hit),
+    /// meaning `out` is an under-approximation of the real target set.
+    truncated: bool = false,
+};
+
 /// Recursively collect the symbol names that appear as the target of a
 /// `(set! <name> ...)` anywhere in `expr` into `out`. Used to suppress
 /// constant folding of those names within the enclosing form (see
 /// Compiler.set_targets) and to box locals for correct continuation
 /// semantics (R7RS §3.4). Conservative: it scans every sub-form except
-/// the interior of `quote`d data. When `expand_macros` is set and a known
+/// the interior of `quote`d data. When `budget` is non-null and a known
 /// macro is encountered, it is expanded and the expansion is scanned
 /// (#1250). Only the top-level pre-scan expands; the per-expansion Part B
-/// scan passes false (see scanSetTargets).
-fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void), depth: u16, expand_macros: bool) CompileError!void {
-    if (depth > 256) return;
+/// scan passes null (see scanSetTargets).
+fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void), depth: u16, budget: ?*SetScanBudget) CompileError!void {
+    if (depth > 256) {
+        if (budget) |b| b.truncated = true;
+        return;
+    }
     var cur = expr;
     while (types.isPair(cur)) {
         const head = types.car(cur);
@@ -973,8 +1031,13 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
                         out.put(types.symbolName(target), {}) catch return CompileError.OutOfMemory;
                     }
                 }
-            } else if (expand_macros) {
+            } else if (budget) |b| {
                 if (self.lookupMacro(types.symbolName(head))) |transformer| {
+                    if (b.expansions_left == 0) {
+                        b.truncated = true;
+                        return;
+                    }
+                    b.expansions_left -= 1;
                     // Best-effort expansion: uses an empty UseSiteBindingCheck
                     // (no locals exist at pre-scan time), so patterns with
                     // literals may diverge from the real expansion.  Part B
@@ -997,12 +1060,24 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
                     self.gc.pushRoot(&expanded_root);
                     defer self.gc.popRoot();
                     self.gc.no_collect -= 1;
-                    try collectSetTargets(self, expanded_root, out, depth + 1, expand_macros);
+                    // Fixed point (e.g. SRFI-219 rule 3: (define x e) →
+                    // (define x e)): the expansion is the input, so scanning
+                    // it again can only repeat what this pass already did.
+                    // expandAndCompileMacroUse detects the same case to hand
+                    // the form to its built-in handler; here it just stops the
+                    // scan from re-expanding until the depth cap (kaappi#1775).
+                    // Fall through to the sub-form walk below, which is what
+                    // compiling the built-in form will visit anyway.
+                    if (macro.valuesStructurallyEqual(expanded_root, cur, 128)) {
+                        cur = types.cdr(cur);
+                        continue;
+                    }
+                    try collectSetTargets(self, expanded_root, out, depth + 1, budget);
                     return;
                 }
             }
         }
-        try collectSetTargets(self, head, out, depth, expand_macros);
+        try collectSetTargets(self, head, out, depth, budget);
         cur = types.cdr(cur);
     }
 }

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -989,8 +989,10 @@ fn formatSyntaxError(args: Value) void {
 ///
 /// A `var` only so tests can lower it and exercise the truncation path
 /// without a multi-second pathological program; nothing in the compiler
-/// writes it.
-pub var prescan_expansion_limit: u32 = 4096;
+/// writes it. Threadlocal for the same reason as `ir.optimize_enabled`: an
+/// SRFI-18 child thread compiling concurrently keeps the default rather than
+/// racing on whatever a test left in a shared global.
+pub threadlocal var prescan_expansion_limit: u32 = 4096;
 
 /// Number of top-level forms whose `set!` pre-scan truncated. Diagnostic
 /// only — read by tests to assert the guard did (or did not) engage.
@@ -1013,6 +1015,15 @@ const SetScanBudget = struct {
 /// (#1250). Only the top-level pre-scan expands; the per-expansion Part B
 /// scan passes null (see scanSetTargets).
 fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void), depth: u16, budget: ?*SetScanBudget) CompileError!void {
+    // This is the scan's *own* recursion cap, deliberately not shared with
+    // compiler_macro.MAX_MACRO_EXPANSION_DEPTH despite both being 256: they
+    // count different things. That one bounds the real expansion of code that
+    // will be compiled, and exceeding it is a user-visible error (KP2003).
+    // This one bounds a speculative walk that also descends into branches the
+    // compiler discards, so it is reached by programs whose real expansion
+    // depth never comes close — measured: every SRFI 257 suite trips this cap
+    // several times per run while compiling and passing normally. Tying the
+    // two together would assert an equivalence the measurements contradict.
     if (depth > 256) {
         if (budget) |b| b.truncated = true;
         return;

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -15,7 +15,7 @@ const MAX_MACRO_EXPANSION_STEPS: u32 = 10_000;
 /// 128 levels is safe because the expander shares pattern-variable subtrees
 /// (a == b short-circuits at the shared node), so only the short template
 /// spine is actually traversed.
-fn valuesStructurallyEqual(a: Value, b: Value, depth: u16) bool {
+pub fn valuesStructurallyEqual(a: Value, b: Value, depth: u16) bool {
     if (a == b) return true;
     if (depth == 0) return false;
     if (types.isPair(a) and types.isPair(b))

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -148,7 +148,9 @@ fn tryConstantFold(self: *Compiler, expr: Value, dst: u16) bool {
     // A `set!` to this name in the enclosing form may run before this call,
     // so folding would use a stale primitive value. Suppress it.
     if (self.set_targets) |st| {
-        if (st.contains(name)) return false;
+        // set_targets_all: the pre-scan was truncated, so treat every name as
+        // possibly reassigned (kaappi#1775).
+        if (self.set_targets_all or st.contains(name)) return false;
     }
 
     if (self.resolveLocal(name) != null) return false;

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -296,6 +296,15 @@ pub const IR = struct {
         // The globals map never sees these, so consult the compiler's scope.
         if (self.compiler) |c| {
             if (c.isLexicallyBound(name)) return true;
+            // A truncated `set!` pre-scan means "any name may be reassigned"
+            // (kaappi#1775); suppress every fold rather than trust a partial
+            // set_targets map. Every caller of isRedefined is an optimization
+            // or lint gate (folding here and in tryFoldFromAST/simplifyBooleans,
+            // the KP4xxx built-in-call lint in check_lint), so the only effects
+            // are: no constant folding in this form, and `kaappi check` stays
+            // quiet about its direct built-in calls. Nothing here decides
+            // special-form-vs-call lowering.
+            if (c.set_targets_all) return true;
         }
         if (self.bound_names) |names| {
             for (names) |n| {

--- a/src/tests_prescan.zig
+++ b/src/tests_prescan.zig
@@ -1,0 +1,151 @@
+// Regressions for the top-level `set!` pre-scan (compiler.collectSetTargets)
+// and its work limit (kaappi#1775).
+//
+// The pre-scan expands macros so it can see a `set!` a macro template
+// introduces, which is what makes #1250's macro-introduced-set! cases box
+// correctly. That makes it a speculative evaluator of compile-time macro
+// code, and it can explore exponentially many branches the real compiler
+// never takes. It is therefore bounded (compiler.prescan_expansion_limit),
+// and hitting the bound must fall back to "assume every name is a `set!`
+// target" rather than silently returning a partial answer — the tests here
+// pin both halves of that contract.
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const compiler = @import("compiler.zig");
+
+/// Evaluate `body` with the pre-scan limit lowered, assert it yields
+/// `expected`, and report how many top-level forms truncated meanwhile.
+/// The limit is restored even on failure. The result is checked here rather
+/// than returned because the VM (and any heap value it produced) is gone
+/// once this returns.
+fn evalWithPrescanLimit(limit: u32, expected: i64, body: []const u8) !u64 {
+    const saved = compiler.prescan_expansion_limit;
+    defer compiler.prescan_expansion_limit = saved;
+    compiler.prescan_expansion_limit = limit;
+
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const before = compiler.prescan_truncations;
+    const value = try ctx.vm.eval(body);
+    try std.testing.expectEqual(expected, types.toFixnum(value));
+    return compiler.prescan_truncations - before;
+}
+
+test "#1775: a truncated set! pre-scan still boxes a macro-introduced set! target" {
+    // #1250's shape: `inc!` introduces the `set!`, and a continuation
+    // captured before it re-enters the `let`. `n` must be boxed, or the
+    // register snapshot rolls the mutation back on every resume and the loop
+    // never terminates (#1168).
+    //
+    // With the limit at 0 the pre-scan cannot expand `inc!`, so it never sees
+    // that `set!` at all. The only thing that keeps this correct is the
+    // truncation fallback marking *every* name a target. Before #1775 the
+    // scan just stopped and returned what it had, so an over-budget form
+    // silently reintroduced the #1250 bug.
+    const truncations = try evalWithPrescanLimit(0, 3,
+        \\(begin
+        \\  (define-syntax inc! (syntax-rules () ((_ v) (set! v (+ v 1)))))
+        \\  (let ((n 0) (k* #f))
+        \\    (call/cc (lambda (k) (set! k* k)))
+        \\    (inc! n)
+        \\    (if (< n 3) (k* #f))
+        \\    n))
+    );
+    // The test is only meaningful if the guard actually engaged.
+    try std.testing.expect(truncations > 0);
+}
+
+test "#1775: truncated pre-scan boxes a lambda parameter that a macro set!s" {
+    // Same contract for a parameter rather than a `let` binding — a separate
+    // boxing path (boxIfSetTarget is called per binding site).
+    const truncations = try evalWithPrescanLimit(0, 3,
+        \\(begin
+        \\  (define-syntax inc! (syntax-rules () ((_ v) (set! v (+ v 1)))))
+        \\  ((lambda (n)
+        \\     (let ((k* #f))
+        \\       (call/cc (lambda (k) (set! k* k)))
+        \\       (inc! n)
+        \\       (if (< n 3) (k* #f))
+        \\       n))
+        \\   0))
+    );
+    try std.testing.expect(truncations > 0);
+}
+
+test "#1775: truncated pre-scan suppresses constant folding of a set! primitive" {
+    // The other consumer of set_targets: folding `(+ 5 2)` to 7 is unsound
+    // once `+` has been reassigned before the call runs. A truncated scan has
+    // no list of reassigned names, so it must suppress every fold.
+    //
+    // `f` is compiled — and its body folded or not — before `rebind` is ever
+    // expanded, so Part B (scanSetTargets, which records the target when the
+    // macro is really expanded) is too late here. Only the pre-scan can catch
+    // it, and at limit 0 only its truncation fallback can.
+    const truncations = try evalWithPrescanLimit(0, 3,
+        \\(begin
+        \\  (define-syntax rebind (syntax-rules () ((_ a b) (set! a b))))
+        \\  ((lambda ()
+        \\     (define (f) (+ 5 2))
+        \\     (rebind + -)
+        \\     (f))))
+    );
+    try std.testing.expect(truncations > 0);
+}
+
+test "#1775: a fixed-point macro does not exhaust the pre-scan budget" {
+    // SRFI 219 rule 3 is `(define name expr)` → `(define name expr)`: the
+    // expansion IS the input. expandAndCompileMacroUse detects that and hands
+    // the form to the built-in `define`; the pre-scan did not, so it
+    // re-expanded the same form until the 256-level depth cap — 257 wasted
+    // expansions for every plain `define` in a program importing SRFI 219,
+    // and (once truncation became meaningful) a spurious fall back to boxing
+    // everything.
+    //
+    // The macro must shadow `define` itself, exactly as SRFI 219 does: the
+    // fixed point only terminates because the keyword is also a built-in
+    // special form, which is what expandAndCompileMacroUse falls back to. A
+    // fixed point on any other name is a diverging macro the expansion-step
+    // limit rejects outright.
+    //
+    // A budget of 8 is far below the depth cap, so without the fixed-point
+    // check this truncates; with it, one expansion settles the form.
+    const truncations = try evalWithPrescanLimit(8, 42,
+        \\(begin
+        \\  (define-syntax define
+        \\    (syntax-rules ()
+        \\      ((define ((name . outer) . args) . body)
+        \\       (define (name . outer) (lambda args . body)))
+        \\      ((define (name . args) . body)
+        \\       (define name (lambda args . body)))
+        \\      ((define name expr)
+        \\       (define name expr))))
+        \\  (define answer 42)
+        \\  answer)
+    );
+    try std.testing.expectEqual(@as(u64, 0), truncations);
+}
+
+test "#1775: ordinary code does not trigger the pre-scan fallback" {
+    // The default limit must leave normal programs alone: truncation costs
+    // ~2x runtime (every local boxed, nothing folded), so it has to stay a
+    // pathological-input backstop, not something ordinary macro use reaches.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const before = compiler.prescan_truncations;
+    const result = try ctx.vm.eval(
+        \\(begin
+        \\  (define-syntax swap!
+        \\    (syntax-rules () ((_ a b) (let ((tmp a)) (set! a b) (set! b tmp)))))
+        \\  (define-syntax twice (syntax-rules () ((_ e) (begin e e))))
+        \\  (let ((x 1) (y 2))
+        \\    (twice (swap! x y))
+        \\    (+ (* 10 x) y)))
+    );
+    try std.testing.expectEqual(@as(i64, 12), types.toFixnum(result));
+    try std.testing.expectEqual(@as(u64, 0), compiler.prescan_truncations - before);
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -6,6 +6,7 @@ test {
     _ = @import("tests_numeric.zig");
     _ = @import("tests_macros.zig");
     _ = @import("tests_macros_nested_sr.zig");
+    _ = @import("tests_prescan.zig");
     _ = @import("tests_libraries.zig");
     _ = @import("tests_exceptions.zig");
     _ = @import("tests_records.zig");


### PR DESCRIPTION
Fixes #1775.

## Root cause — it was not the expander

`--timings` reports `expand 2765.8ms` on the pathological case, which is true
and misleading: the time really is inside `expander.expandMacro`, but nothing
in `expander.zig` is wrong. Two earlier sessions read that number as "the
expander is slow" and ruled out theories one at a time
(`instantiateTemplate`, `instantiateEllipsis`, `stripUsertextMarkers`
memoization).

`sample` put 99% of stack samples under **`compiler.collectSetTargets`** on
the first run.

That function is the top-level `set!` pre-scan. It expands macros so it can
see a `set!` a macro template introduces (#1250) — which makes it a
speculative *evaluator* of compile-time macro code, and it explores branches
the real compiler never takes:

```scheme
;; em-syntax-rules-aux2 emits this per pattern element
(c e maybe-ellipsis KT KF)
;; -> (begin (define-syntax m (syntax-rules ...)) (m kt kf))
```

The real compiler registers `m`, expands it, and follows exactly one of
`KT`/`KF`. The pre-scan never processes that inner `define-syntax`, so `m` is
an unknown operator and both continuations are just sub-forms — it expands
macros inside **both**. Every pattern element doubles the work: ~2.2x per
added rule, measured.

## Fix

1. **Budget** — `SetScanBudget` caps the pre-scan at 4096 macro expansions
   per top-level form.
2. **Sound fallback** — on truncation, `Compiler.set_targets_all` makes both
   consumers assume *every* name is a `set!` target: box every local, fold
   nothing. A truncated scan loses optimization, never correctness. The
   pre-existing `depth > 256` cutoff now feeds the same flag; until now it
   silently returned a partial answer, which is precisely the
   under-approximation #1168/#1250 are about.
3. **Fixed-point check** — the pre-scan lacked the one
   `expandAndCompileMacroUse` already has, so SRFI 219's rule 3
   (`(define name expr)` -> `(define name expr)`) re-expanded 257 times for
   every plain `define`.

### Why 4096

Measured across all 176,651 top-level forms in this repo's Scheme suites: 87%
need zero pre-scan expansions, p99 = 7, p99.9 = 45, p99.99 = 1649 — then the
macro-generating tier jumps to 6,299–773,241. 4096 sits in that gap.

The headroom is deliberate: truncation costs **~2x runtime** (tak 9.3s →
21.5s, const-prop 1.12s → 2.36s with the fallback forced on), so ordinary
code must never reach the limit. Lower budgets compile the pathological cases
faster (srfi257-full: 1024 → 10.7s, 256 → 8.3s vs the 7.7s floor) at the cost
of widening that penalty's blast radius.

## Results

| case | before | after |
|---|--:|--:|
| issue's 8-rule quasiquote benchmark | 31.6s | 4.6s |
| `srfi257-full.scm` | 280.8s | 16.2s |
| `srfi257-rx-full.scm` | 102.1s | 23.5s |
| 7-rule generating macro | 14.9s | 4.8s |
| 9-rule generating macro | 71.9s | 4.9s |

Growth is now flat past the budget (7/9/11/13 rules all ~4.6-4.9s) instead of
exponential.

No regression under the budget (qq4, plain5 identical over 5 interleaved
runs) and none at runtime (fib/tak/ack/heavy-arith/const-prop unchanged).

## Tests

`src/tests_prescan.zig`, all four mutation-tested — two of the first drafts
did **not** discriminate and were rewritten:

- The fold test only fails if the fold is decided *before* the macro is
  expanded; otherwise Part B (`scanSetTargets`) records the target in time.
- The fixed-point test needs the macro to shadow **`define` itself**, as SRFI
  219 does — a fixed point on any other name is a diverging macro the
  expansion-step limit rejects, so it never reaches the path.
- The two boxing tests fail as a *hang* under mutation, the authentic
  #1168/#1250 failure mode.

`zig build test`, `zig build test -Dgc-stress=true`, and
`bash tests/scheme/run-all.sh` (1994 pass, 0 fail) all green.

## Docs

`docs/dev/timings.md` gains a section on the trap this bug is a worked
example of: `--timings` tells you *which stage*, `sample`/`perf` tells you
*which caller*. Note that adding a `prescan` timing stage would **not** have
helped — with disjoint self-timed stages the nested `expandMacro` time still
lands under `expand`.

## Note on SRFI 148

This removes the performance blocker from #1775, but the separate
dotted-tail usertext-marker correctness bug documented in that issue is
still unfixed, so SRFI 148 is not yet unblocked end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)