### PR TITLE
Name the library whose own import declaration collides

### DIFF
--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -231,6 +231,50 @@ test "import collision is detected regardless of order" {
     try std.testing.expect(std.mem.indexOf(u8, detail, "(test coll-lib-c)") != null);
 }
 
+test "collision inside a library's own import declaration names that library" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-library (test coll-inner-a)
+        \\  (import (scheme base))
+        \\  (export frob)
+        \\  (begin (define (frob) 'a)))
+    );
+    _ = try vm.eval(
+        \\(define-library (test coll-inner-b)
+        \\  (import (scheme base))
+        \\  (export frob)
+        \\  (begin (define (frob) 'b)))
+    );
+
+    // The colliding import declaration is *inside* coll-inner, but the
+    // error location cites the top-level form that triggered the load --
+    // so the message itself must say which library the declaration lives
+    // in (found the hard way via kaappi-mpl's sin.sld, kaappi-mpl#2).
+    const r = vm.eval(
+        \\(define-library (test coll-inner)
+        \\  (import (test coll-inner-a) (test coll-inner-b))
+        \\  (export frob)
+        \\  (begin (define unused 1)))
+    );
+    try std.testing.expectError(th.VMError.CompileError, r);
+    const detail = vm.getErrorDetail();
+    try std.testing.expect(std.mem.indexOf(u8, detail, "'frob'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, detail, "(test.coll-inner)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, detail, "own import declaration") != null);
+
+    // The failed load must restore the context: the same collision at top
+    // level stays attributed to the import form alone, not to any library.
+    const r2 = vm.eval("(import (test coll-inner-a) (test coll-inner-b))");
+    try std.testing.expectError(th.VMError.CompileError, r2);
+    const detail2 = vm.getErrorDetail();
+    try std.testing.expect(std.mem.indexOf(u8, detail2, "import declaration") == null);
+    try std.testing.expect(std.mem.indexOf(u8, detail2, "'frob'") != null);
+}
+
 test "import does not raise when the same binding is reachable two ways" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -274,6 +274,13 @@ pub const VM = struct {
     last_error_line: u32 = 0,
     last_error_col: u32 = 0,
     last_error_source: ?[]const u8 = null,
+    /// Dotted name of the library whose declarations are currently being
+    /// processed (nested loads save/restore it), or null at top level.
+    /// Error locations point at the top-level form that triggered the load,
+    /// so diagnostics raised from inside a library's own declarations — the
+    /// import-collision check especially — use this to name the library the
+    /// problem actually lives in.
+    loading_library_name: ?[]const u8 = null,
     // Diagnostic code of the escaping error (KEP-0005, #1504). Set by
     // noteUncaughtException from the raised error object; reset per top-level
     // form in resetExecutionState. When `.uncategorized`, the reporting layer

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -206,10 +206,22 @@ pub fn importSetChecked(
     while (it.next()) |entry| {
         if (tracker.map.get(entry.key_ptr.*)) |existing| {
             if (existing.value != entry.value_ptr.*) {
-                vm.setErrorDetail(
-                    "identifier '{s}' is imported with different bindings from both {s} and {s} -- R7RS 5.2: \"it is an error to import the same identifier more than once with different bindings\"; disambiguate with only/except/rename/prefix",
-                    .{ entry.key_ptr.*, existing.label, label },
-                );
+                // When the colliding import declaration is a library's own,
+                // the error location cites the top-level form that triggered
+                // the load — so name the library early in the message (the
+                // detail buffer truncates) or the reader hunts the wrong file
+                // (found the hard way via kaappi-mpl's sin.sld).
+                if (vm.loading_library_name) |loading| {
+                    vm.setErrorDetail(
+                        "identifier '{s}' is imported with different bindings inside library ({s})'s own import declaration, from both {s} and {s} -- R7RS 5.2: \"it is an error to import the same identifier more than once with different bindings\"; disambiguate with only/except/rename/prefix",
+                        .{ entry.key_ptr.*, loading, existing.label, label },
+                    );
+                } else {
+                    vm.setErrorDetail(
+                        "identifier '{s}' is imported with different bindings from both {s} and {s} -- R7RS 5.2: \"it is an error to import the same identifier more than once with different bindings\"; disambiguate with only/except/rename/prefix",
+                        .{ entry.key_ptr.*, existing.label, label },
+                    );
+                }
                 return error.UndefinedVariable;
             }
         }
@@ -1256,6 +1268,15 @@ pub fn handleDefineLibrary(vm: *VM, args: Value) VMError!Value {
         vm.gc.allocator.destroy(lib_env);
         vm.gc.allocator.free(lib_name);
     };
+
+    // Attribute diagnostics raised while processing this library's own
+    // declarations (e.g. an import collision) to this library, not to the
+    // top-level form whose file:line the error will cite. Registered after
+    // the lib_name-freeing defer above so the restore runs first (LIFO)
+    // and the name is never read after free.
+    const prev_loading_name = vm.loading_library_name;
+    vm.loading_library_name = lib_name;
+    defer vm.loading_library_name = prev_loading_name;
 
     // Root the library environment so GC can trace closures defined in
     // begin blocks before the library is registered. Push/pop for


### PR DESCRIPTION
Follow-up to #1781's R7RS 5.2 import-collision detection: the KP2001 diagnostic cites the file:line of the top-level form that triggered the library load, so a collision inside a library's **own** import declaration points the reader at the wrong file entirely.

Real-world case (this morning's nightly ecosystem triage): kaappi-mpl's `sin.sld` had a genuine `sqrt` collision, and it surfaced as

```
test-mpl.scm:8: error[KP2001]: identifier 'sqrt' is imported with different bindings from both (except (scheme base) + - * / numerator denominator) and (mpl sqrt) -- ...
```

— naming import-sets that appear nowhere near `test-mpl.scm:8`. It masqueraded as a core import-resolution regression and cost two wrong root-cause theories before the real one landed as kaappi-mpl#2.

## What changed

- `handleDefineLibrary` records the library's dotted name in a new save/restored `vm.loading_library_name` while its declarations are processed (nesting handled by the call stack; the restore-before-free ordering is guarded by defer LIFO).
- `importSetChecked`'s collision message names it when set:

```
demo-main.scm:1: error[KP2001]: identifier 'sqrt' is imported with different bindings inside library (mpl.sin)'s own import declaration, from both (except (scheme base) + - * / numerator denominator) and (mpl sqrt) -- ...
```

The library name sits early in the message because the 256-byte detail buffer truncates the tail. Top-level import forms keep the original message unchanged — behavior is identical, only attribution improves.

## Testing

- New unit test in `tests_libraries.zig`: a collision inside a library's own import declaration must name that library, and after the failed load a top-level collision must *not* carry library attribution (proves the restore path).
- Full suite: **1313 pass, 3 skip, 0 fail** + thottam 25/25.
- End-to-end: reproduced the exact pre-fix kaappi-mpl tree (`eea38d5^`) against this build — the message above is its real output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)