### PR TITLE
Fix dotted-tail usertext-marker matching gap in matchListPattern

### DIFF
--- a/src/expander.zig
+++ b/src/expander.zig
@@ -374,6 +374,24 @@ fn matchListPattern(pattern: Value, input: Value, literals: []const Value, bindi
     var inp = input;
 
     while (pat != types.NIL) {
+        // Unwrap a usertext marker BEFORE inspecting this iteration's shape.
+        // matchPattern's own top only unwraps its immediate pattern_in/
+        // input_in parameters; a marker pair spliced into a dotted-tail
+        // position by a generating macro's own template instantiation (a
+        // pattern-variable value that's a LIST, substituted into `. p`) is
+        // never wrapped in an extra cons cell of its own -- it becomes the
+        // literal cdr of the preceding pair, e.g. `(s . (marker . (%a)))` =
+        // `(s marker %a)` when walked. Without re-unwrapping here on every
+        // loop iteration (not just at entry), that marker pair surfaces as
+        // an ordinary-looking extra list element on a LATER iteration,
+        // shifting every remaining pattern/input position by one and
+        // breaking the match entirely (kaappi#1775's still-open companion
+        // bug: SRFI 148's em-syntax-rules generates exactly this shape for
+        // every rule, `(_ :prepare s . p)`). unwrapUsertext is a no-op on
+        // anything that isn't actually a marker pair, so this is safe to
+        // apply unconditionally.
+        pat = unwrapUsertext(pat);
+        inp = unwrapUsertext(inp);
         if (!types.isPair(pat)) {
             // Dotted pattern tail
             return matchPattern(pat, inp, literals, bindings, count, gc, literal_bound, use_check);

--- a/src/tests_macros_nested_sr.zig
+++ b/src/tests_macros_nested_sr.zig
@@ -102,6 +102,36 @@ test "hygiene: a custom ellipsis identifier substituted through a nested syntax-
     );
 }
 
+test "hygiene: a usertext marker spliced into a generated macro's dotted-tail pattern position is unwrapped mid-match, not just at pattern-matching entry" {
+    // A pattern variable bound to a LIST (here `p`, bound to the 2-element
+    // list `(a b)`) that a generating macro's own template splices into a
+    // NESTED syntax-rules pattern's dotted tail (`. p`) becomes, once
+    // flattened through the cons chain, structurally indistinguishable from
+    // a run of ordinary list elements: `(_ head . p)` with p=(a b) becomes
+    // `(_ head MARKER a b)` where MARKER is a real usertext-marker pair
+    // (car = the reserved __hyg-usertext symbol), not a literal token.
+    // matchPattern's own entry point unwraps its immediate pattern_in/
+    // input_in parameters, which is enough when the marker sits in the
+    // FIRST position (nothing consumed yet) -- but matchListPattern's own
+    // internal loop advances past `head` first without re-unwrapping, so a
+    // marker arriving at any LATER position (mid-match, after some
+    // elements are already consumed -- forced here by the leading `head`)
+    // surfaced as a bogus extra pattern element, shifting every subsequent
+    // position and failing the match outright. Found while porting SRFI
+    // 148's em-syntax-rules, whose generated pattern is always exactly
+    // this dotted-tail shape (`(_ :prepare s . p)`).
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax gen-dotted
+        \\    (syntax-rules ()
+        \\      ((_ p)
+        \\       (syntax-rules ()
+        \\         ((_ head . p) '(matched . p))))))
+        \\  (define-syntax use-it (gen-dotted (a b)))
+        \\  (equal? (use-it 99 10 20) '(matched 10 20)))
+    );
+}
+
 test "hygiene: a custom ellipsis substituted into an ORDINARY (non-quoted) template position is also recognized" {
     // Companion to the test above: the same NESTED_SR_FLAG usertext-marking
     // protocol only wraps a substituted value outside quote (QUOTE_FLAG


### PR DESCRIPTION
## Summary

- `matchPattern` unwraps its own `pattern_in`/`input_in` parameters once, at entry — but `matchListPattern`'s internal loop advances `pat`/`inp` on every iteration without re-unwrapping. A usertext marker pair spliced into a **dotted-tail** pattern position (e.g. a generated macro's pattern `(_ head . p)` where `p`'s substituted value is a list) is only caught by the entry-level unwrap when it sits in the very first position — anything preceding it in the pattern forces the marker to surface mid-loop as a bogus extra list element, shifting every subsequent position and failing the match ("bad arguments to macro call" even for well-formed calls).
- Fix: unwrap `pat`/`inp` at the top of `matchListPattern`'s loop body, before the dotted-tail check. `unwrapUsertext` is a pure, non-mutating accessor, so this carries none of the shared-structure-mutation risk of an earlier, reverted attempt at a different fix for a related symptom (see commit message / project memory for that history).

## Context

Found while resuming SRFI 148 (eager syntax-rules, tracked under #1699) after #1775 (a separate, unrelated performance cliff in `em-syntax-rules`-style generating macros) was fixed in #1784. SRFI 148's generated macro pattern is always exactly this dotted-tail shape (`(_ :prepare s . p)`), so every `em-syntax-rules`-defined macro hit this.

This fix is necessary but not sufficient to unblock SRFI 148 — a separate, deeper bug (`free-identifier=?`/`bound-identifier=?` failing when the compared identifier is a compound form, not a bare symbol) still blocks it. Filed as #1787 with full repro steps; that's a materially different investigation, not a quick follow-up to this PR.

## Test plan

- [x] New regression test in `tests_macros_nested_sr.zig`, mutation-tested (fails with the fix disabled via a manual toggle, passes with it enabled)
- [x] `zig build test` — full unit suite green
- [x] `bash tests/scheme/run-all.sh` — 1995/1995 pass
- [x] A/B verified `free-identifier=?`/`bound-identifier=?` scenarios (which regressed under an earlier, unrelated, reverted fix attempt for a related symptom) produce byte-for-byte identical output with this fix enabled vs. disabled — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)