### PR TITLE
Add a slowdown-investigation runbook; fix the cache's dirty-build-id claim

### DIFF
--- a/docs/dev/CLAUDE.md
+++ b/docs/dev/CLAUDE.md
@@ -23,6 +23,7 @@ belongs here.
 | LLVM native backend | `llvm-backend.md` |
 | GC safety | `gc-safety-and-error-handling.md` |
 | Tests | `testing.md`, `test-runner.md` |
+| A slowdown (compiler or generated code) | `performance.md` |
 | Fuzzing | `fuzzing.md`, `fuzzing-feasibility.md` |
 | Porting to a new OS/arch | `porting.md` + the OS-specific doc (`windows.md`, `freebsd.md`, `openbsd.md`, `netbsd.md`) |
 | CLI subcommands | `check.md`, `fmt.md`, `features.md`, `doctor.md`, `cache.md`, `timings.md` |

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -30,6 +30,7 @@ investigation produced analysis worth keeping.
 | [porting.md](porting.md) | Porting to a new OS or CPU architecture: the support matrix, where portability lives, the degradation ladder, staged checklists, what "supported" means |
 | [adding-features.md](adding-features.md) | Step-by-step guides for the most common extension tasks |
 | [testing.md](testing.md) | The four test layers, how to run them, where new tests go |
+| [performance.md](performance.md) | Investigating a slowdown: finding the stage vs. the caller, measuring before theorizing, trustworthy A/B protocol, benchmarking generated code |
 | [test-runner.md](test-runner.md) | `kaappi test`: the first-class SRFI-64 runner — discovery, worker subprocesses, `--json` schema, `--seed` |
 | [fmt.md](fmt.md) | `kaappi fmt`: the canonical comment-preserving formatter — the CST reader, the layout rules, the round-trip safety net, `--check` |
 | [fuzzing.md](fuzzing.md) | Fuzzing runbook: the targets, the scheduled CI job, turning a failure into a regression test |

--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -27,17 +27,45 @@ half hashed only the *version string*, which does not change between rebuilds
 during development — so a freshly rebuilt `kaappi` would silently execute
 bytecode compiled by the **previous** binary. The standing workaround was
 "delete the cache before testing compiler changes," which was tribal knowledge.
-Folding the build id into the key removes the footgun by construction:
+Folding the build id into the key covers the committed cases:
 
-- Rebuild after any edit → dirty tree → build id changes → **miss**.
 - A different commit → different `HEAD` hash → **miss**.
 - Clean vs. dirty tree at the same commit → different id → **miss**.
 - Two clean builds of the *same* commit → same id → a hit is safe (identical
   compiler), so CI builds and installed releases can share entries.
 
-A collision is self-correcting, never a wrong result: even if two different
-source paths hashed to the same cache filename, the stored source hash would not
-match, so the load misses and recompiles.
+### The one case it does *not* cover: two dirty builds
+
+`-dirty` is a **flag, not a hash of the working tree** (`gitBuildId` in
+`build.zig` appends the literal suffix whenever `git status --porcelain`
+prints anything). So every uncommitted state at the same commit shares one
+build id:
+
+```text
+edit A, uncommitted, at 370d8e85  →  370d8e85-dirty
+edit B, uncommitted, at 370d8e85  →  370d8e85-dirty   ← identical
+```
+
+The id changes on the first clean→dirty transition and then stays put no
+matter how many further edits you make. Two rebuilds of *different*
+uncommitted compiler changes therefore **share cache entries**, and the
+second one can execute bytecode the first one produced.
+
+This is the original footgun surviving in the case contributors hit most —
+iterating on uncommitted changes — and it is worst during A/B work, where
+toggling between two versions (`git stash`, `git checkout <sha> -- <path>`)
+makes the same input file answer differently across otherwise-identical
+rebuilds. It reads exactly like nondeterminism in the code under test.
+
+**Run `kaappi cache clear` after every rebuild when A/B-testing compiler
+changes, or measure with `--no-ir-opt`, which bypasses the cache in both
+directions.** See [performance.md](performance.md) for the full A/B protocol.
+
+A *filename* collision is self-correcting, never a wrong result: even if two
+different source paths hashed to the same cache filename, the stored source
+hash would not match, so the load misses and recompiles. The dirty-build-id
+case above is different in kind — the key genuinely matches — which is why it
+needs the manual step.
 
 The header also records, purely for `cache status` to display, the **producing
 build id** and the **source path** (see `src/bytecode_file.zig`, format

--- a/docs/dev/performance.md
+++ b/docs/dev/performance.md
@@ -1,0 +1,176 @@
+# Investigating a slowdown
+
+A runbook for the question "this is slower than it should be — now what?"
+It covers **finding** the cause and **measuring** trustworthily. It
+deliberately holds no numbers: current performance figures live in the
+benchmark suite and its dashboard, past optimization results in
+[lessons-learned.md](lessons-learned.md) §11, and point-in-time campaign
+data in the KEP benchmark documents. Numbers copied into a guide rot.
+
+Two kinds of slowdown share this page because the tools overlap but the
+first moves differ:
+
+- **The compiler is slow** — `kaappi` takes too long to *compile* a
+  program. Start at step 1.
+- **Compiled code is slow** — the program itself runs too long. Skip to
+  [Benchmarking generated code](#benchmarking-generated-code).
+
+## 1. Find the stage, then find the caller
+
+`--timings` reports per-stage pipeline wall time and cache HIT/MISS
+([timings.md](timings.md)):
+
+```bash
+kaappi --timings slow.scm
+```
+
+That names the **stage**. It cannot name the **caller**, and the caller is
+usually where the fix is. Do not form a theory about the code inside a
+stage from the stage number alone — go straight to a stack profiler:
+
+```bash
+# macOS
+kaappi slow.scm & sample $! 8 -f /tmp/prof.txt
+
+# Linux
+perf record -g -- kaappi slow.scm && perf report
+```
+
+Neither needs a special build: the ordinary `zig build` output (ReleaseSafe)
+profiles with full symbolized stacks. Reach for the profiler as soon as a
+stage number is surprising — before forming a theory about the code inside
+that stage.
+
+**Worked example — [#1775](https://github.com/kaappi/kaappi/issues/1775).**
+A macro-generating macro compiled in 41s. `--timings` said
+`expand 2765.8ms`, which was true: the time really was inside
+`expander.expandMacro`. Two sessions read that as "the expander is slow"
+and hand-eliminated theories in `instantiateTemplate` and
+`stripUsertextMarkers`. Nothing in `expander.zig` was wrong — the
+expansions were being driven by `compiler.collectSetTargets`, a `set!`
+pre-scan exploring branches the real compiler never takes. One `sample`
+run put 99% of samples under `collectSetTargets`.
+
+Note what would *not* have helped: adding a `prescan` stage to
+`--timings`. Stages are disjoint and self-timed, so the nested
+`expandMacro` time still lands under `expand`. More stage instrumentation
+does not answer a caller question — only a profiler does.
+
+## 2. Measure before you theorize
+
+The expensive failure mode in every slowdown investigation on record is
+plausible reasoning that measurement then refutes. #1775 lost two sessions
+to two such theories (exponential re-visiting of shared subtrees; O(n²)
+list accumulation) before either was tested; a third — identity
+memoization of the walk — sounded compelling and delivered 8%.
+
+Cheap ways to get a real number before committing to a hypothesis:
+
+- A counter in the suspect function, printed once per top-level form.
+  Crude, decisive, and thrown away afterwards.
+- Disable the suspect path entirely and re-time. If the time doesn't move,
+  the theory is dead in one build.
+- Distribution over the real corpus, not one input: running the whole
+  `tests/scheme/` tree with a counter is what turned "4096 feels safe" into
+  a defensible limit in #1775 (p99.99 = 1649, and the pathological tier
+  starting at 6299).
+
+## 3. A/B two binaries without fooling yourself
+
+This is where measurement most often goes wrong, because two hazards
+conspire.
+
+### Clear the bytecode cache between rebuilds
+
+The `.sbc` cache key folds in the git build id — but `-dirty` is a **flag,
+not a hash of the working tree**. Every uncommitted state at the same
+commit produces the identical id, so rebuilds of *different* uncommitted
+changes share cache entries and one can execute bytecode the other
+produced. Full explanation in [cache.md](cache.md).
+
+Toggling between two versions with `git stash` or
+`git checkout <sha> -- <path>` and rebuilding is exactly the shape that
+triggers it, and the symptom is the same input file answering differently
+across otherwise-identical rebuilds — indistinguishable from
+nondeterminism in the code under test.
+
+```bash
+kaappi cache clear     # after every rebuild, when A/B-ing compiler changes
+```
+
+`--no-ir-opt` also bypasses the cache in both directions, which makes it a
+convenient measurement flag — at the cost of disabling the IR optimization
+passes, so it answers a different question than a default-configuration
+run.
+
+### Keep the two binaries as separate files
+
+Rebuilding over `zig-out/bin/kaappi` leaves no way to check *which* binary
+just ran, and a failed or partial build silently re-measures the previous
+one. Copy each build somewhere private and verify by checksum before any
+run whose result you intend to act on:
+
+```bash
+zig build && cp zig-out/bin/kaappi /tmp/kaappi-base      # baseline
+# ... apply the change ...
+zig build && cp zig-out/bin/kaappi /tmp/kaappi-fixed     # candidate
+shasum /tmp/kaappi-base /tmp/kaappi-fixed                # must differ
+```
+
+Then interleave the runs rather than running all of A followed by all of
+B, so thermal and load drift hits both arms equally:
+
+```bash
+for i in 1 2 3 4 5; do
+  /usr/bin/time -p /tmp/kaappi-base  --no-ir-opt case.scm 2>&1 >/dev/null | awk '/real/{print "base ", $2}'
+  /usr/bin/time -p /tmp/kaappi-fixed --no-ir-opt case.scm 2>&1 >/dev/null | awk '/real/{print "fixed", $2}'
+done
+```
+
+A single pair of runs is not a result. In #1775 one such pair showed a 45%
+regression on a case that five interleaved runs then showed as identical.
+
+## 4. Check the shape, not just the magnitude
+
+Growth rate identifies the bug class faster than any absolute number.
+Generate the same input at several sizes and time each: a constant ratio
+per step is exponential, a constant increment is linear. #1775 read as
+"~2.2x per added rule" from six data points, which ruled out the O(n²)
+theory before any code was read.
+
+The same technique verifies a fix. After bounding the work, the series
+went flat (7, 9, 11 and 13 rules all landing within noise of each other) —
+evidence a single before/after pair cannot give.
+
+## Benchmarking generated code
+
+For the runtime cost of compiled Scheme rather than the compiler, the
+benchmark suite is the tool — see
+[testing.md § Benchmarks](testing.md#benchmarks) for the suite, the
+harness, reading results, and adding a case:
+
+```bash
+bash benchmarks/run-benchmarks.sh
+bash benchmarks/compare-benchmarks.sh baseline.json current.json
+```
+
+Subsystem micro-benchmarks live behind their own build steps:
+`zig build bench` (call/cc vs call/ec), `bench-fibers`, `bench-reactor`,
+`bench-channel`.
+
+CI runs the suite on every push to main and posts a per-benchmark
+comparison on PRs touching `src/`, `benchmarks/`, `lib/`, or build files.
+Treat ±10% on shared runners as noise.
+
+## Where the rest of the performance material lives
+
+| Topic | Document |
+|-------|----------|
+| Benchmark suite, harness, CI integration, trend dashboard | [testing.md](testing.md) |
+| `--timings` output, JSON schema, where the instrumentation sits | [timings.md](timings.md) |
+| `.sbc` cache key, invalidation, `cache status` / `cache clear` | [cache.md](cache.md) |
+| IR optimization passes | [ir.md](ir.md) |
+| Native backend optimization | [llvm-backend.md](llvm-backend.md) |
+| Optimizations that worked, that didn't, and that were revisited | [lessons-learned.md](lessons-learned.md) §11 |
+| Self-tail-call design (Option A shipped, B reverted) | [decisions/self-tail-call-optimization.md](decisions/self-tail-call-optimization.md) |
+| KEP acceptance-gate campaigns and their datasets | `kep-0001-phase7-benchmarks.md`, `kep-0002-phase7-envelope-benchmarks.md`, `kep-0003-acceptance-gate-worksheet.md` |

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -27,7 +27,8 @@ pub const MAGIC = [4]u8{ 'K', 'P', 'B', 'C' };
 // path after the compiler hash, so `kaappi cache status` can report which
 // source and which binary produced each cache entry. The compiler hash itself
 // now folds in the git build id (see `compilerHash`), so a dev rebuild at the
-// same version string — different commit or a dirty tree — no longer collides.
+// same version string — different commit, or clean vs. dirty — no longer
+// collides. Two *dirty* builds at the same commit still do; see compilerHashFor.
 // v9 (kaappi#1506): line-table entries carry a column alongside the line so
 // runtime errors can report `file:line:col`. A version mismatch makes
 // `readFileWithTopLevel` return null, so older `.sbc` caches are ignored and
@@ -106,11 +107,17 @@ pub fn sourceHash(source: []const u8) u64 {
 /// version string with the git build id (short HEAD hash, `-dirty` when the
 /// tree had uncommitted changes; "unknown" when git is unavailable at build
 /// time). Two binaries built from the same commit with a clean tree share a
-/// key and may reuse each other's cache; any other pair — a dev rebuild after
-/// an edit, a different commit, a dirty vs. clean tree — differs, so a stale
-/// entry is rejected on load and recompiled. This closes the long-standing
-/// footgun where same-version rebuilds silently ran the previous binary's
-/// bytecode (kaappi#1516). Pure in its inputs so the keying is unit-testable.
+/// key and may reuse each other's cache; a different commit, or a dirty vs.
+/// clean tree, differs — so a stale entry is rejected on load and recompiled.
+/// This closes most of the long-standing footgun where same-version rebuilds
+/// silently ran the previous binary's bytecode (kaappi#1516).
+///
+/// It does NOT separate two *dirty* builds at the same commit: `-dirty` is a
+/// flag, not a hash of the working tree, so every uncommitted state shares one
+/// build id and rebuilds of different uncommitted changes reuse each other's
+/// entries. `kaappi cache clear` between rebuilds is still required when
+/// A/B-testing compiler changes — see docs/dev/cache.md and
+/// docs/dev/performance.md. Pure in its inputs so the keying is unit-testable.
 pub fn compilerHashFor(version_str: []const u8, build_id: []const u8) u64 {
     var h = std.hash.Wyhash.init(0);
     h.update(version_str);


### PR DESCRIPTION
Two related changes: a missing entry point for performance work, and a
documented guarantee that turned out to be false — found while checking
what the new doc would need to say.

## `docs/dev/performance.md` — "Investigating a slowdown"

Performance material was spread across eight documents, organized by tool or
subsystem rather than by question. Someone holding *"this compiles too slowly,
where do I start?"* had no entry point: the answer spanned `timings.md` (which
stage), an undocumented profiler step (which caller), and `testing.md` (is it a
regression?).

That gap has a measured cost. #1775 lost two sessions to plausible theories
about `expander.zig` because `--timings` reported `expand 2765.8ms` — true, and
misleading, since the driver was `compiler.collectSetTargets`. One `sample` run
settled it.

The doc is a runbook, the same genre as `fuzzing.md` and `porting.md`:

1. **Find the stage, then the caller.** `--timings` names the stage and
   structurally cannot name the caller. Includes why *more* stage
   instrumentation wouldn't have helped on #1775 — stages are disjoint and
   self-timed, so nested `expandMacro` time lands under `expand` regardless.
2. **Measure before theorizing.** With the cheap ways to get a real number.
3. **A/B two binaries without fooling yourself.** Cache clearing, separate
   binary files verified by checksum, interleaved runs. (In #1775 a single
   pair of runs showed a 45% regression that five interleaved runs showed as
   noise.)
4. **Check the shape, not just the magnitude.** Growth rate identifies the bug
   class faster than any absolute number, and verifies the fix in a way a
   before/after pair cannot.

Plus a section routing runtime-performance questions to the benchmark suite,
and a table pointing at every existing home.

**It carries no numbers** — current figures belong to the benchmark dashboard,
past results to `lessons-learned.md` §11, campaign data to the KEP documents.
The only figures are the #1775 case study, which is history and won't rot.
Everything already documented elsewhere is linked, not restated.

## The `cache.md` fix

While checking what content would be genuinely new, found `cache.md` asserting
the opposite of the truth about the one thing A/B measurement depends on:

> Rebuild after any edit → dirty tree → build id changes → **miss**.

`-dirty` is a **flag, not a hash of the working tree** — `gitBuildId`
(`build.zig:584`) appends the literal suffix whenever `git status --porcelain`
prints anything. The id changes on the first clean→dirty transition and then
never again.

Verified rather than reasoned, by building two *different* uncommitted edits at
the same commit:

```text
edit A (src/types.zig)      → 370d8e85-dirty
edit B (src/primitives.zig) → 370d8e85-dirty   ← identical
```

They therefore share `.sbc` cache entries, and one rebuild can execute bytecode
the other produced. This is the original #1516 footgun surviving in the case
contributors hit most — iterating on uncommitted changes — and it reads exactly
like nondeterminism in the code under test. I hit it during the SRFI-147 work,
where `git stash` toggling made the same file answer differently across
otherwise-identical rebuilds.

`cache.md` now documents the case the build id does not cover, why it is worst
during A/B work, and the `kaappi cache clear` remedy. `bytecode_file.zig`'s two
comments that overstated the same guarantee are corrected.

**No code change.** `compilerHashFor` is correct and its unit test asserts
nothing false — the aliasing is upstream in `build.zig` — so neither is
touched. Adding a test here would be tautological (`compilerHashFor` is pure in
its inputs; identical build-id strings *should* hash equal), which is why the
limitation is recorded in the doc comment directly above the function instead.

## Verification

- Every relative link and the one `#benchmarks` anchor resolves.
- All four `zig build bench*` steps and both benchmark scripts referenced
  actually exist; `lessons-learned.md` really has a §11.
- Fences labeled (the MD040 finding from #1784).
- `zig fmt --check`, `zig build`, and the cache-key tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)