### PR TITLE
Fix the three usertext-marker spine gaps that actually blocked SRFI 148 (#1787)

### DIFF
--- a/src/expander.zig
+++ b/src/expander.zig
@@ -192,7 +192,10 @@ pub fn expandMacro(gc: *GC, expr: Value, transformer_val: Value, globals: ?*std.
     // back to the same macro.
     var macro_keyword: ?[]const u8 = null;
     if (transformer.num_rules > 0) {
-        const first_pat = transformer.patterns[0];
+        // Unwrap first: a generating macro that splices a WHOLE rule pattern
+        // from user text hands this transformer a marker-wrapped pattern,
+        // whose car is the marker symbol rather than the keyword.
+        const first_pat = unwrapUsertext(transformer.patterns[0]);
         if (types.isPair(first_pat)) {
             const kw = types.car(first_pat);
             if (types.isSymbol(kw)) {
@@ -231,8 +234,12 @@ pub fn expandMacro(gc: *GC, expr: Value, transformer_val: Value, globals: ?*std.
     for (0..transformer.num_rules) |i| {
         var bind_count: usize = 0;
 
-        // Skip the keyword in the pattern (first element of pattern)
-        const pattern_body = types.cdr(transformer.patterns[i]);
+        // Skip the keyword in the pattern (first element of pattern).
+        // Same whole-pattern unwrap as the keyword extraction above: without
+        // it this cdr strips the MARKER instead of the keyword, so every
+        // pattern position lines up one slot late against the input and the
+        // user's own `_` keyword placeholder swallows the first argument.
+        const pattern_body = types.cdr(unwrapUsertext(transformer.patterns[i]));
 
         if (matchPattern(pattern_body, input, transformer.literals[0..], &bindings, &bind_count, gc, literal_bound, use_check)) {
             return instantiateTemplate(gc, transformer.templates[i], bindings[0..bind_count], intro_scope, transformer.literals, macro_keyword, globals, macros);
@@ -385,11 +392,12 @@ fn matchListPattern(pattern: Value, input: Value, literals: []const Value, bindi
         // loop iteration (not just at entry), that marker pair surfaces as
         // an ordinary-looking extra list element on a LATER iteration,
         // shifting every remaining pattern/input position by one and
-        // breaking the match entirely (kaappi#1775's still-open companion
-        // bug: SRFI 148's em-syntax-rules generates exactly this shape for
-        // every rule, `(_ :prepare s . p)`). unwrapUsertext is a no-op on
-        // anything that isn't actually a marker pair, so this is safe to
-        // apply unconditionally.
+        // breaking the match entirely (#1787: SRFI 148's em-syntax-rules
+        // generates exactly this shape for every rule it emits,
+        // `(_ :prepare s . p)`). unwrapUsertext is a no-op on anything that
+        // isn't actually a marker pair, so this is safe to apply
+        // unconditionally. Two more spine walks need the same unwrap --
+        // expandMacro's keyword-skip and countPairs/matchEllipsis.
         pat = unwrapUsertext(pat);
         inp = unwrapUsertext(inp);
         if (!types.isPair(pat)) {
@@ -436,12 +444,22 @@ fn countPairs(v: Value) ?usize {
         if (slow == fast) return null;
     }
 
+    // Both callers (matchEllipsis, below) count a PATTERN or INPUT spine, so
+    // a usertext marker sitting in that spine — a chunk a generating macro
+    // spliced into a dotted-tail position — is a wrapper, not an element.
+    // Counting it makes the ellipsis reserve one element too many for the
+    // tail, so the split lands one position early: the trailing pattern
+    // still matches (the marker symbol binds the element the ellipsis
+    // should have taken), silently producing a SHORT ellipsis binding
+    // rather than an error. unwrapUsertext is a no-op on anything else; a
+    // forged cyclic marker chain still terminates on the MAX_ELLIPSIS_VALUES
+    // bound below.
     var n: usize = 0;
-    var cur = v;
+    var cur = unwrapUsertext(v);
     while (types.isPair(cur)) {
         n += 1;
         if (n > MAX_ELLIPSIS_VALUES) return null;
-        cur = types.cdr(cur);
+        cur = unwrapUsertext(types.cdr(cur));
     }
     return n;
 }
@@ -481,9 +499,12 @@ fn matchEllipsis(elem_pattern: Value, rest_pattern: Value, input: Value, literal
         @setRuntimeSafety(false);
         break :b undefined;
     };
-    var inp = input;
+    // Same spine unwrapping as countPairs: the repetition walk must step
+    // over marker cells rather than consume one as an element.
+    var inp = unwrapUsertext(input);
     for (0..repeat_count) |_| {
         var sub_count: usize = 0;
+        if (!types.isPair(inp)) return false;
         if (!matchPattern(elem_pattern, types.car(inp), literals, &sub_bindings, &sub_count, gc, literal_bound, use_check))
             return false;
 
@@ -515,11 +536,11 @@ fn matchEllipsis(elem_pattern: Value, rest_pattern: Value, input: Value, literal
             }
         }
 
-        inp = types.cdr(inp);
+        inp = unwrapUsertext(types.cdr(inp));
     }
 
     // Match remaining input against rest_pattern
-    if (rest_pattern == types.NIL) return inp == types.NIL;
+    if (unwrapUsertext(rest_pattern) == types.NIL) return inp == types.NIL;
     return matchListPattern(rest_pattern, inp, literals, bindings, count, gc, literal_bound, use_check);
 }
 

--- a/src/tests_macros_nested_sr.zig
+++ b/src/tests_macros_nested_sr.zig
@@ -159,3 +159,52 @@ test "hygiene: a custom ellipsis substituted into an ORDINARY (non-quoted) templ
         \\  (equal? (use-it2 1 2 3) '(1 2 3)))
     );
 }
+
+test "hygiene: a WHOLE generated rule pattern spliced from user text keeps its keyword slot" {
+    // Third site of the same usertext-marker-in-the-spine gap (#1787). When
+    // a generating macro splices an entire rule PATTERN (not just a tail),
+    // the marker wraps the whole thing: `(_ x y)` arrives as
+    // `(MARKER _ x y)`. expandMacro drops the pattern's first element to
+    // skip the macro keyword -- so it dropped the MARKER instead, leaving
+    // `(_ x y)` to line up against the argument list `(1 2)`. Every
+    // position then sat one slot late: the user's own `_` keyword
+    // placeholder swallowed the first argument, `x` took the second, and
+    // `y` had nothing left, so a perfectly well-formed call failed to match
+    // at all. (The keyword-name extraction a few lines above had the same
+    // gap, reading the marker symbol as the macro's own name.)
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax gen-rule
+        \\    (syntax-rules ()
+        \\      ((_ pat tmpl)
+        \\       (syntax-rules () (pat tmpl)))))
+        \\  (define-syntax use-rule (gen-rule (_ x y) (list 'ok x y)))
+        \\  (equal? (use-rule 1 2) '(ok 1 2)))
+    );
+}
+
+test "hygiene: an ellipsis followed by a spliced dotted tail reserves the right number of trailing elements" {
+    // Fourth site (#1787), and the only one that failed SILENTLY rather
+    // than erroring. matchEllipsis splits the input by counting how many
+    // elements the pattern after the ellipsis needs -- but a marker pair
+    // spliced into that trailing position is a wrapper, not an element, so
+    // the count came out one too high and the ellipsis stopped one element
+    // short. The trailing pattern still matched (the marker symbol behaved
+    // like an anonymous pattern variable and bound the element the ellipsis
+    // should have taken), so the expansion succeeded with a SHORT ellipsis
+    // binding: `(use-tail 1 2 99)` below yielded `(ok 1)` instead of
+    // `(ok 1 2)` with no diagnostic anywhere. The literal `99` in the
+    // spliced tail is what makes this observable -- a trailing pattern
+    // VARIABLE absorbs the off-by-one on both sides and gives the right
+    // answer for the wrong reason.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax gen-tail
+        \\    (syntax-rules ()
+        \\      ((_ tailpat)
+        \\       (syntax-rules ()
+        \\         ((_ a (... ...) . tailpat) (list 'ok a (... ...)))))))
+        \\  (define-syntax use-tail (gen-tail (99)))
+        \\  (equal? (use-tail 1 2 99) '(ok 1 2)))
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1787 — but not the bug it was filed for. **#1787's headline bug does not exist**; the real blocker was three instances of one marker-unwrapping gap, all fixed here. With them, every `em-syntax-rules`-defined macro in a full SRFI 148 port expands correctly end-to-end.

A pattern variable substituted into a **nested** `syntax-rules` template is wrapped as `(__hyg-usertext . value)` so the generated macro's own later expansion inserts it verbatim rather than re-walking it as template text. When the target is a list **position**, the wrapper gets its own cons cell and every consumer sees it. When the target is a **spine** position — a dotted tail, or the whole pattern — the wrapper becomes the cdr of an existing cell, so a naive walk reads the marker as one more ordinary element. `instantiateTemplate` and `stripUsertextWalk` already handled that shape; three matching-side walks did not.

| # | Site | Symptom |
|---|------|---------|
| 1 | `matchListPattern`'s loop (`(_ head . p)`) | `bad arguments to macro call` on well-formed calls — fixed in #1788, already on main |
| 2 | `expandMacro`'s keyword-skip (whole pattern spliced) | every position one slot late; user's own `_` swallows the first argument |
| 3 | `matchEllipsis`/`countPairs` (ellipsis, then spliced tail) | **silent** short ellipsis binding — no diagnostic at all |

Site 1 is #1788, which merged while this was in review; this branch is rebased on it, so the PR now carries only sites 2 and 3 (plus one stale-reference touch-up to #1788's own comment, pointing at the two sibling sites).

Site 3 is the nastiest: counting the marker makes the ellipsis reserve one element too many, and the trailing pattern *still matches* because the marker symbol behaves like an anonymous pattern variable and binds the element the ellipsis should have taken. It expands with a short binding and reports nothing.

## Why #1787's headline bug isn't real

#1787 reports `free-identifier=?` failing when the compared identifier is compound (e.g. `(quote t)`). Its repro passes the ellipsis identifier through a macro template as a bare `...`:

```scheme
((_) (free-identifier=? ... (quote t) 'yes 'no))
```

but a template `...` **is** the ellipsis. R7RS spells the pass-through `(... ...)`, which is exactly what SRFI 148's own `em-syntax-rules` writes. Kaappi expands a driver-less ellipsis to zero copies in silence, so that template quietly became `((quote t) 'yes 'no)` — the reported `not a procedure`, and nothing to do with identifier comparison. `chibi-scheme` rejects the same file at definition time with `too many ...'s`.

With the ellipsis escaped correctly, `free-identifier=?`/`bound-identifier=?` already answer every compound-vs-symbol case correctly — identically before and after this PR:

```
(free-identifier=? (... ...) (quote t) 'yes 'no)  =>  no    ; compound
(free-identifier=? (... ...) foo        'yes 'no)  =>  no    ; different symbol
(free-identifier=? (... ...) (... ...)  'yes 'no)  =>  yes   ; same identifier
```

The silent zero-expansion is a real diagnostic gap in its own right — filed as #1791.

## Test plan

- [x] 2 new regression tests in `tests_macros_nested_sr.zig` (one per new site), each **mutation-tested**: disabling site 2's fix fails exactly its test; disabling site 3's fails exactly its test; disabling site 1's (now on main) fails its own test plus site 3's, which routes through it.
- [x] `zig build test` — full unit suite green
- [x] `bash tests/scheme/run-all.sh` — 1995 pass, 0 fail
- [x] `zig fmt --check` clean
- [x] A/B against a pre-fix binary on a full SRFI 148 port: every combinator listed below goes from `bad arguments to macro call` to correct — `em-cons`, `em-cons*`, `em-car`/`em-cdr`, `em-fold`, `em-map`, `em-filter`, `em-append`, `em-append-map`, `em-quasiquote`, `em-take`, `em-assoc`, `em-vector->list`, `em-if`/`em-not`/`em-symbol?`/`em-equal?`, `em-free-identifier=?`/`em-bound-identifier=?`, and custom-ellipsis (`em-syntax-rules :::`) variants.

## Note for whoever resumes SRFI 148 (#1699)

Pattern matching is no longer the blocker. The next wall is `MAX_MACRO_EXPANSION_DEPTH` (256, `compiler_macro.zig`): the CK machine burns expansion steps fast, so `(em-member 'b '(b))` works while `(em-member 'b '(a b))` exceeds the limit, as do `em-fact` and `em-set-union`. That's a limit-tuning question, not a correctness one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

