### PR TITLE
Iterate head-position macro chains instead of recursing (#1796)

### DIFF
--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -51,243 +51,370 @@ fn resolveSameFrameLocal(ctx: ?*const anyopaque, name: []const u8) bool {
     return false;
 }
 
+/// Undo record for one temporarily adjusted global (the hygiene "dance"
+/// below); restored LIFO when the expansion chain finishes.
+const TempGlobal = struct { name: []const u8, old_val: ?Value, was_present: bool };
+
+/// Undo record for one let-syntax sibling keyword swapped to its outer
+/// value (R7RS 4.3.1); restored LIFO when the expansion chain finishes.
+const PeerSave = struct { name: []const u8, old: ?Value };
+
+/// Does `form`'s head name a macro that compileForm would expand right
+/// back through expandAndCompileMacroUse, in the same position (same dst,
+/// same tail flag)? Mirrors compileForm's own macro-dispatch conditions
+/// exactly: the usertext-marker safety net, local/upvalue shadowing, and
+/// fixed-point suppression (a suppressed name must fall through to
+/// compileForm, which consumes the suppression). Non-null means the chain
+/// loop in expandAndCompileMacroUse can iterate instead of recursing.
+fn chainNextMacroUse(self: *Compiler, form: Value) CompileError!?struct { name: []const u8, transformer: Value } {
+    if (!types.isPair(form)) return null;
+    const head = types.car(form);
+    if (!types.isSymbol(head)) return null;
+    const hname = types.symbolName(head);
+    if (std.mem.eql(u8, hname, expander.USERTEXT_MARKER)) return null;
+    const effective_name = types.stripHygienicPrefix(hname);
+    const is_shadowed = std.mem.eql(u8, effective_name, hname) and
+        (self.resolveLocal(hname) != null or (try self.resolveUpvalue(hname)) != null);
+    if (is_shadowed) return null;
+    if (self.suppress_macro_name) |smn| {
+        if (std.mem.eql(u8, hname, smn)) return null;
+    }
+    const t = self.lookupMacro(hname) orelse return null;
+    if (self.resolveLocal(hname) != null or (try self.resolveUpvalue(hname)) != null) return null;
+    return .{ .name = hname, .transformer = t };
+}
+
 pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, transformer: Value, dst: u16, is_tail: bool) CompileError!void {
     if (self.macro_expansion_depth >= MAX_MACRO_EXPANSION_DEPTH or
         self.macro_expansion_steps >= MAX_MACRO_EXPANSION_STEPS)
     {
         return CompileError.MacroExpansionLimit;
     }
+    // Depth counts NESTED expansions only — a macro use compiled from
+    // inside another expansion's result recurses natively through
+    // compileExpr, so this cap is what keeps the native stack bounded.
+    // Head-position chains (an expansion that IS directly another macro
+    // use in the same position — SRFI 148's CK-machine steps, or a
+    // degenerate (loop) → (loop)) iterate in the loop below at O(1)
+    // native stack and are bounded by MAX_MACRO_EXPANSION_STEPS instead.
+    // The two must not be conflated: raising THIS constant to cover deep
+    // chains overflows the native stack — and in a Debug/test build the
+    // segfault then fires inside the DebugAllocator's own stack capture,
+    // whose SelfInfo lock the segfault handler needs, deadlocking the
+    // whole test run at 0% CPU (kaappi#1796).
     self.macro_expansion_depth += 1;
-    self.macro_expansion_steps += 1;
     defer self.macro_expansion_depth -= 1;
-    // Build merged macro view including parent scopes
-    var merged_macros = std.StringHashMap(Value).init(self.gc.allocator);
+
+    const gpa = self.gc.allocator;
+
+    // ---- Chain-accumulated bookkeeping -------------------------------
+    // Every link of the chain contributes temporary state that must stay
+    // active until the FINAL (non-macro) form finishes compiling —
+    // identifiers introduced by link k's template can survive into the
+    // final form, so link k's injected locals, adjusted globals, and peer
+    // swaps have to be live while it compiles. The old nested recursion
+    // kept all of that alive in per-level native frames; these heap-side
+    // accumulators keep the same lifetimes with per-link native cost
+    // zero, unwound LIFO by the defers below on success and error alike.
+
+    var merged_macros = std.StringHashMap(Value).init(gpa);
     defer merged_macros.deinit();
-    var p: ?*Compiler = self.parent;
-    while (p) |par| : (p = par.parent) {
-        var it = par.macros.iterator();
-        while (it.next()) |entry| {
-            try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
-        }
-    }
-    var it = self.macros.iterator();
-    while (it.next()) |entry| {
-        try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
-    }
-    const tx = types.toObject(transformer).as(types.Transformer);
-    // Temporarily add/modify globals so the expander doesn't
-    // rename template free references.
-    const TempGlobal = struct { name: []const u8, old_val: ?Value, was_present: bool };
-    var temp_globals: [128]TempGlobal = undefined;
-    var temp_global_count: usize = 0;
-    // Track non-procedure global free vars that need local injection
-    // to prevent shadowing by use-site locals (R7RS 4.3.1).
-    var global_free_names: [64][]const u8 = undefined;
-    var global_free_count: usize = 0;
-    if (self.globals) |g| {
-        // The sentinel puts below structurally mutate the globals
-        // map when g is the VM's shared one — exclude SRFI-18
-        // child-thread readers for the whole dance (#958). glk is
-        // non-null exactly when g is the current thread's shared
-        // globals map.
-        const glk = globals_mod.acquireGlobalsWrite(g);
-        defer globals_mod.releaseGlobalsWrite(glk);
-        for (tx.captured_locals) |cap| {
-            if (temp_global_count < 128) {
-                if (g.get(cap.name)) |gval| {
-                    temp_globals[temp_global_count] = .{ .name = cap.name, .old_val = gval, .was_present = true };
-                    temp_global_count += 1;
-                    _ = g.remove(cap.name);
-                }
-            }
-        }
-        if (tx.def_env) |env| {
-            var env_it = env.iterator();
-            while (env_it.next()) |entry| {
-                if (!g.contains(entry.key_ptr.*) and temp_global_count < 128) {
-                    temp_globals[temp_global_count] = .{ .name = entry.key_ptr.*, .old_val = null, .was_present = false };
-                    temp_global_count += 1;
-                    try g.put(entry.key_ptr.*, entry.value_ptr.*);
-                }
-            }
-        }
-        // Temporarily mark non-procedure free globals as VOID so
-        // renameForHygiene preserves them. Only mark identifiers that
-        // were bound at macro definition time (bound_free_refs) —
-        // template-introduced identifiers that coincidentally share a
-        // name with a later user define must still be renamed (#1208).
-        if (globals_mod.globals_ctx) |gctx| {
-            for (tx.bound_free_refs) |cname| {
-                const in_g = g.get(cname);
-                // glk != null means g IS the shared globals map
-                // and we already hold its exclusive lock; else
-                // this read needs its own child-thread lock.
-                const in_vm = if (glk != null)
-                    (if (gctx.globals.count() > 0) gctx.globals.get(cname) else null)
-                else in_vm_blk: {
-                    gctx.lockShared();
-                    defer gctx.unlockShared();
-                    break :in_vm_blk if (gctx.globals.count() > 0) gctx.globals.get(cname) else null;
-                };
-                const existing = in_g orelse in_vm;
-                if (existing) |val| {
-                    if (!types.isProcedure(val) and !types.isTransformer(val) and val != types.VOID) {
-                        if (temp_global_count < 128) {
-                            temp_globals[temp_global_count] = .{ .name = cname, .old_val = in_g, .was_present = in_g != null };
-                            temp_global_count += 1;
-                            try g.put(cname, types.VOID);
-                        }
-                        // Track for local injection after expansion
-                        if (global_free_count < 64) {
-                            global_free_names[global_free_count] = cname;
-                            global_free_count += 1;
-                        }
+
+    var temp_globals: std.ArrayList(TempGlobal) = .empty;
+    defer {
+        if (self.globals) |g| {
+            if (temp_globals.items.len > 0) {
+                const glk = globals_mod.acquireGlobalsWrite(g);
+                var tgi = temp_globals.items.len;
+                while (tgi > 0) {
+                    tgi -= 1;
+                    const tg = temp_globals.items[tgi];
+                    if (tg.was_present) {
+                        g.put(tg.name, tg.old_val.?) catch {};
+                    } else {
+                        _ = g.remove(tg.name);
                     }
                 }
+                globals_mod.releaseGlobalsWrite(glk);
             }
+        }
+        temp_globals.deinit(gpa);
+    }
+
+    // R7RS 4.3.1: let-syntax transformers resolve free macro references
+    // from the definition-site environment, not the use-site environment.
+    var peer_saves: std.ArrayList(PeerSave) = .empty;
+    defer {
+        var pi = peer_saves.items.len;
+        while (pi > 0) {
+            pi -= 1;
+            const ps = peer_saves.items[pi];
+            if (ps.old) |old| {
+                self.macros.put(ps.name, old) catch {};
+            } else {
+                _ = self.macros.remove(ps.name);
+            }
+        }
+        peer_saves.deinit(gpa);
+    }
+
+    // Injected locals (hygienic captured-local aliases plus non-procedure
+    // global aliases) accumulate across links. The chain's result lives in
+    // dst by the time this unwinds, so the aliases are dead, and
+    // compileExpr is register-balanced, making the LIFO rewind safe.
+    // Leaking an alias register would break the balanced-register contract
+    // expression compilation relies on — a call site allocates CONTIGUOUS
+    // argument registers, so a leak inside one argument shifts every later
+    // argument slot while the call still reads the original window (found
+    // by the Kaappi-vs-Chibi differential oracle, #1396).
+    const saved_locals_len = self.locals.items.len;
+    var injected_reg_count: u16 = 0;
+    defer {
+        while (self.locals.items.len > saved_locals_len) {
+            _ = self.locals.pop();
+        }
+        while (injected_reg_count > 0) : (injected_reg_count -= 1) {
+            self.freeReg();
         }
     }
-    defer if (self.globals) |g| {
-        const glk = globals_mod.acquireGlobalsWrite(g);
-        var tgi = temp_global_count;
-        while (tgi > 0) {
-            tgi -= 1;
-            const tg = temp_globals[tgi];
-            if (tg.was_present) {
-                g.put(tg.name, tg.old_val.?) catch {};
-            } else {
-                _ = g.remove(tg.name);
-            }
-        }
-        globals_mod.releaseGlobalsWrite(glk);
-    };
-    // Suppress GC during expansion: the expanded form isn't
-    // rooted until pushRoot below, so a collection triggered
-    // by allocPair inside expandMacro could free AST nodes
-    // that the partially-built result references.
-    self.gc.no_collect += 1;
+
+    const saved_suppress = self.suppress_macro_name;
+    defer self.suppress_macro_name = saved_suppress;
+
+    // `kaappi check`: a macro expansion is not the user's direct source, so
+    // suppress lint over everything compiled from it (kaappi#1511). Only calls
+    // the user wrote outside any macro use are "direct calls to a built-in".
+    var lint_enters: usize = 0;
+    defer while (lint_enters > 0) : (lint_enters -= 1) check_lint.exitMacroExpansion();
+
     const use_check = expander.UseSiteBindingCheck{
         .ctx = @ptrCast(self),
         .resolve_fn = &resolveLocalSkipAliases,
         .frame_resolve_fn = &resolveSameFrameLocal,
     };
-    const expanded = expander.expandMacro(self.gc, expr, transformer, self.globals, &merged_macros, use_check) catch |err| {
-        self.gc.no_collect -= 1;
-        return switch (err) {
-            error.OutOfMemory => CompileError.OutOfMemory,
-            error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
-            error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch => CompileError.InvalidSyntax,
-        };
-    };
-    var expanded_root = expanded;
-    self.gc.pushRoot(&expanded_root);
-    defer self.gc.popRoot();
-    self.gc.no_collect -= 1;
-    // Unwrap user-text provenance markers before compiling; specs of macros
-    // this expansion defines (syntax-rules subtrees) keep theirs.
-    if (expander.isUsertextPair(expanded_root)) {
-        expanded_root = expander.unwrapUsertext(expanded_root);
-    }
-    if (types.isPair(expanded_root) or types.isVector(expanded_root)) {
-        expander.stripUsertextMarkers(self.gc, expanded_root);
-    }
-    try self.scanSetTargets(expanded_root);
-    const saved_locals_len = self.locals.items.len;
-    try injectHygienicCapturedLocals(self, expanded_root, tx.captured_locals);
-    // Inject non-procedure global free vars as locals so
-    // use-site locals don't shadow the definition-site
-    // global binding (R7RS 4.3.1 referential transparency).
-    // Alias registers are freed after the expansion is compiled: leaking
-    // them breaks the balanced-register contract expression compilation
-    // relies on — a call site allocates CONTIGUOUS argument registers, so
-    // a leak inside one argument shifts every later argument slot while
-    // the call still reads the original window (found by the Kaappi-vs-
-    // Chibi differential oracle, #1396).
-    var injected_reg_count: u16 = 0;
-    for (global_free_names[0..global_free_count]) |gname| {
-        // Skip if already covered by captured_locals
-        var already_captured = false;
-        for (tx.captured_locals) |cap| {
-            if (std.mem.eql(u8, cap.name, gname)) {
-                already_captured = true;
-                break;
+
+    var cur_expr = expr;
+    var cur_name = name;
+    var cur_transformer = transformer;
+    var final_form = expr;
+
+    while (true) {
+        if (self.macro_expansion_steps >= MAX_MACRO_EXPANSION_STEPS) {
+            return CompileError.MacroExpansionLimit;
+        }
+        self.macro_expansion_steps += 1;
+
+        // Merged macro view including parent scopes, rebuilt per link so a
+        // peer swap made by an earlier link stays visible (matching the
+        // nested recursion, where each level built its own merged view
+        // after the enclosing level's swap).
+        merged_macros.clearRetainingCapacity();
+        {
+            var p: ?*Compiler = self.parent;
+            while (p) |par| : (p = par.parent) {
+                var it = par.macros.iterator();
+                while (it.next()) |entry| {
+                    try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
+                }
+            }
+            var it = self.macros.iterator();
+            while (it.next()) |entry| {
+                try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
             }
         }
-        if (already_captured) continue;
-        // Load the global value into a fresh register
-        const gslot = self.allocReg() catch continue;
-        injected_reg_count += 1;
-        const gsym = self.gc.allocSymbol(gname) catch continue;
-        const gsym_idx = self.addConstant(gsym) catch continue;
-        self.emitOp(.get_global) catch continue;
-        self.emitU16(gslot) catch continue;
-        self.emitU16(gsym_idx) catch continue;
-        try self.locals.append(self.gc.allocator, .{
-            .name = gname,
-            .depth = self.scope_depth,
-            .slot = gslot,
-            .binding_id = compiler_mod.freshBindingId(),
-            .is_global_alias = true,
-        });
-    }
-    // R7RS 4.3.1: let-syntax transformers resolve free macro references
-    // from the definition-site environment, not the use-site environment.
-    // Temporarily swap sibling keywords to their outer values.
-    const peer_names = tx.let_syntax_peer_names;
-    const peer_outer = tx.let_syntax_peer_vals;
-    std.debug.assert(peer_names.len == peer_outer.len);
-    const saved_peer = if (peer_names.len > 0)
-        self.gc.allocator.alloc(?Value, peer_names.len) catch return CompileError.OutOfMemory
-    else
-        null;
-    defer if (saved_peer) |sp| self.gc.allocator.free(sp);
-    if (saved_peer) |sp| {
-        for (peer_names, peer_outer, 0..) |pn, pv, i| {
-            sp[i] = self.macros.get(pn);
+
+        const tx = types.toObject(cur_transformer).as(types.Transformer);
+
+        // Track non-procedure global free vars that need local injection
+        // to prevent shadowing by use-site locals (R7RS 4.3.1). Per-link,
+        // consumed by the injection loop right after expansion.
+        var global_free_names: [64][]const u8 = undefined;
+        var global_free_count: usize = 0;
+
+        // Temporarily add/modify globals so the expander doesn't rename
+        // template free references. Undo records accumulate for the whole
+        // chain; the per-link cap of 128 preserves the old fixed-array
+        // behavior.
+        if (self.globals) |g| {
+            var level_count: usize = 0;
+            // The sentinel puts below structurally mutate the globals
+            // map when g is the VM's shared one — exclude SRFI-18
+            // child-thread readers for the whole dance (#958). glk is
+            // non-null exactly when g is the current thread's shared
+            // globals map.
+            const glk = globals_mod.acquireGlobalsWrite(g);
+            defer globals_mod.releaseGlobalsWrite(glk);
+            for (tx.captured_locals) |cap| {
+                if (level_count < 128) {
+                    if (g.get(cap.name)) |gval| {
+                        temp_globals.append(gpa, .{ .name = cap.name, .old_val = gval, .was_present = true }) catch return CompileError.OutOfMemory;
+                        level_count += 1;
+                        _ = g.remove(cap.name);
+                    }
+                }
+            }
+            if (tx.def_env) |env| {
+                var env_it = env.iterator();
+                while (env_it.next()) |entry| {
+                    if (!g.contains(entry.key_ptr.*) and level_count < 128) {
+                        temp_globals.append(gpa, .{ .name = entry.key_ptr.*, .old_val = null, .was_present = false }) catch return CompileError.OutOfMemory;
+                        level_count += 1;
+                        try g.put(entry.key_ptr.*, entry.value_ptr.*);
+                    }
+                }
+            }
+            // Temporarily mark non-procedure free globals as VOID so
+            // renameForHygiene preserves them. Only mark identifiers that
+            // were bound at macro definition time (bound_free_refs) —
+            // template-introduced identifiers that coincidentally share a
+            // name with a later user define must still be renamed (#1208).
+            if (globals_mod.globals_ctx) |gctx| {
+                for (tx.bound_free_refs) |cname| {
+                    const in_g = g.get(cname);
+                    // glk != null means g IS the shared globals map
+                    // and we already hold its exclusive lock; else
+                    // this read needs its own child-thread lock.
+                    const in_vm = if (glk != null)
+                        (if (gctx.globals.count() > 0) gctx.globals.get(cname) else null)
+                    else in_vm_blk: {
+                        gctx.lockShared();
+                        defer gctx.unlockShared();
+                        break :in_vm_blk if (gctx.globals.count() > 0) gctx.globals.get(cname) else null;
+                    };
+                    const existing = in_g orelse in_vm;
+                    if (existing) |val| {
+                        if (!types.isProcedure(val) and !types.isTransformer(val) and val != types.VOID) {
+                            if (level_count < 128) {
+                                temp_globals.append(gpa, .{ .name = cname, .old_val = in_g, .was_present = in_g != null }) catch return CompileError.OutOfMemory;
+                                level_count += 1;
+                                try g.put(cname, types.VOID);
+                            }
+                            // Track for local injection after expansion
+                            if (global_free_count < 64) {
+                                global_free_names[global_free_count] = cname;
+                                global_free_count += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Suppress GC during expansion: the expanded form isn't rooted
+        // until the extra_roots append below, so a collection triggered
+        // by allocPair inside expandMacro could free AST nodes that the
+        // partially-built result references.
+        self.gc.no_collect += 1;
+        const expanded = expander.expandMacro(self.gc, cur_expr, cur_transformer, self.globals, &merged_macros, use_check) catch |err| {
+            self.gc.no_collect -= 1;
+            return switch (err) {
+                error.OutOfMemory => CompileError.OutOfMemory,
+                error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
+                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch => CompileError.InvalidSyntax,
+            };
+        };
+        // Root for the rest of the enclosing compile scope via extra_roots
+        // (released by that scope's shrinkRetainingCapacity, exactly like
+        // compileDefineSyntax's transformers): the fixed root stack's 1024
+        // slots cannot hold one root per chain link, and material from
+        // EVERY link (injected local name slices, set!-target keys) must
+        // stay reachable until the final form finishes compiling.
+        self.gc.extra_roots.append(gpa, expanded) catch {
+            self.gc.no_collect -= 1;
+            return CompileError.OutOfMemory;
+        };
+        self.gc.no_collect -= 1;
+
+        var expanded_root = expanded;
+        // Unwrap user-text provenance markers before compiling; specs of
+        // macros this expansion defines (syntax-rules subtrees) keep
+        // theirs.
+        if (expander.isUsertextPair(expanded_root)) {
+            expanded_root = expander.unwrapUsertext(expanded_root);
+        }
+        if (types.isPair(expanded_root) or types.isVector(expanded_root)) {
+            expander.stripUsertextMarkers(self.gc, expanded_root);
+        }
+        try self.scanSetTargets(expanded_root);
+        try injectHygienicCapturedLocals(self, expanded_root, tx.captured_locals);
+        // Inject non-procedure global free vars as locals so use-site
+        // locals don't shadow the definition-site global binding
+        // (R7RS 4.3.1 referential transparency).
+        for (global_free_names[0..global_free_count]) |gname| {
+            // Skip if already covered by captured_locals
+            var already_captured = false;
+            for (tx.captured_locals) |cap| {
+                if (std.mem.eql(u8, cap.name, gname)) {
+                    already_captured = true;
+                    break;
+                }
+            }
+            if (already_captured) continue;
+            // Load the global value into a fresh register
+            const gslot = self.allocReg() catch continue;
+            injected_reg_count += 1;
+            const gsym = self.gc.allocSymbol(gname) catch continue;
+            const gsym_idx = self.addConstant(gsym) catch continue;
+            self.emitOp(.get_global) catch continue;
+            self.emitU16(gslot) catch continue;
+            self.emitU16(gsym_idx) catch continue;
+            try self.locals.append(gpa, .{
+                .name = gname,
+                .depth = self.scope_depth,
+                .slot = gslot,
+                .binding_id = compiler_mod.freshBindingId(),
+                .is_global_alias = true,
+            });
+        }
+        // Swap let-syntax sibling keywords to their outer values while
+        // material from this transformer is live; the undo record is
+        // appended before each swap so a mid-chain error restores
+        // everything applied so far.
+        std.debug.assert(tx.let_syntax_peer_names.len == tx.let_syntax_peer_vals.len);
+        for (tx.let_syntax_peer_names, tx.let_syntax_peer_vals) |pn, pv| {
+            peer_saves.append(gpa, .{ .name = pn, .old = self.macros.get(pn) }) catch return CompileError.OutOfMemory;
             if (pv != types.NIL) {
                 self.macros.put(pn, pv) catch {};
             } else {
                 _ = self.macros.remove(pn);
             }
         }
-    }
-    // Fixed-point detection: if the expansion is structurally identical to
-    // the input (e.g. SRFI-219 rule 3: (define x e) → (define x e)) AND the
-    // keyword is a built-in special form, suppress macro re-expansion so the
-    // built-in handler takes over.  For non-special-form macros (e.g. a
-    // degenerate (loop) → (loop)), let the expansion-limit catch it instead.
-    const is_fixed_point = valuesStructurallyEqual(expanded_root, expr, 128) and
-        ir_mod.isSpecialForm(types.stripHygienicPrefix(name));
-    const saved_suppress = self.suppress_macro_name;
-    if (is_fixed_point) self.suppress_macro_name = name;
-    defer self.suppress_macro_name = saved_suppress;
 
-    // `kaappi check`: a macro expansion is not the user's direct source, so
-    // suppress lint over everything compiled from it (kaappi#1511). Only calls
-    // the user wrote outside any macro use are "direct calls to a built-in".
-    check_lint.enterMacroExpansion();
-    defer check_lint.exitMacroExpansion();
+        check_lint.enterMacroExpansion();
+        lint_enters += 1;
 
-    const result_err = self.compileExpr(expanded_root, dst, is_tail);
-    if (saved_peer) |sp| {
-        for (peer_names, 0..) |pn, i| {
-            if (sp[i]) |old| {
-                self.macros.put(pn, old) catch {};
-            } else {
-                _ = self.macros.remove(pn);
-            }
+        // Fixed-point detection: if the expansion is structurally identical
+        // to the input (e.g. SRFI-219 rule 3: (define x e) → (define x e))
+        // AND the keyword is a built-in special form, suppress macro
+        // re-expansion so the built-in handler takes over — compileForm
+        // consumes the suppression, so the chain must break to it. For
+        // non-special-form macros (a degenerate (loop) → (loop)), keep
+        // chaining and let the step limit catch it.
+        if (valuesStructurallyEqual(expanded_root, cur_expr, 128) and
+            ir_mod.isSpecialForm(types.stripHygienicPrefix(cur_name)))
+        {
+            self.suppress_macro_name = cur_name;
+            final_form = expanded_root;
+            break;
         }
+
+        // Head-position chain: the expansion is itself directly a macro
+        // use that compileForm would route straight back here with the
+        // same dst and tail flag. Iterate instead of recursing so chain
+        // length costs no native stack (kaappi#1796) — the shape both
+        // SRFI 148's CK machine and runaway (loop)-style macros have.
+        if (try chainNextMacroUse(self, expanded_root)) |next| {
+            cur_expr = expanded_root;
+            cur_name = next.name;
+            cur_transformer = next.transformer;
+            continue;
+        }
+
+        final_form = expanded_root;
+        break;
     }
-    // Remove injected locals and rewind their alias registers: the
-    // expansion's result now lives in dst, so the aliases are dead, and
-    // compileExpr itself is register-balanced, making the LIFO rewind safe.
-    while (self.locals.items.len > saved_locals_len) {
-        _ = self.locals.pop();
-    }
-    while (injected_reg_count > 0) : (injected_reg_count -= 1) {
-        self.freeReg();
-    }
-    return result_err;
+
+    return self.compileExpr(final_form, dst, is_tail);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -197,6 +197,7 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
     var cur_name = name;
     var cur_transformer = transformer;
     var final_form = expr;
+    var merged_stale = true;
 
     while (true) {
         if (self.macro_expansion_steps >= MAX_MACRO_EXPANSION_STEPS) {
@@ -204,12 +205,14 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
         }
         self.macro_expansion_steps += 1;
 
-        // Merged macro view including parent scopes, rebuilt per link so a
-        // peer swap made by an earlier link stays visible (matching the
-        // nested recursion, where each level built its own merged view
-        // after the enclosing level's swap).
-        merged_macros.clearRetainingCapacity();
-        {
+        // Merged macro view including parent scopes. Nothing that runs
+        // between links can change any macro table except this function's
+        // own let-syntax peer swap below (no compilation happens inside
+        // the loop), so the view is rebuilt only after a link that
+        // actually swapped — keeping a runaway chain's per-link cost flat
+        // instead of O(links × macros in scope).
+        if (merged_stale) {
+            merged_macros.clearRetainingCapacity();
             var p: ?*Compiler = self.parent;
             while (p) |par| : (p = par.parent) {
                 var it = par.macros.iterator();
@@ -221,6 +224,7 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
             while (it.next()) |entry| {
                 try merged_macros.put(entry.key_ptr.*, entry.value_ptr.*);
             }
+            merged_stale = false;
         }
 
         const tx = types.toObject(cur_transformer).as(types.Transformer);
@@ -350,14 +354,18 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
                 }
             }
             if (already_captured) continue;
-            // Load the global value into a fresh register
+            // Load the global value into a fresh register. Register
+            // exhaustion skips the injection (non-fatal, as before), but a
+            // failure mid-emit must propagate: swallowing it after
+            // emitOp(.get_global) succeeded would leave a truncated
+            // instruction in the chunk for the VM to decode as garbage.
             const gslot = self.allocReg() catch continue;
             injected_reg_count += 1;
-            const gsym = self.gc.allocSymbol(gname) catch continue;
-            const gsym_idx = self.addConstant(gsym) catch continue;
-            self.emitOp(.get_global) catch continue;
-            self.emitU16(gslot) catch continue;
-            self.emitU16(gsym_idx) catch continue;
+            const gsym = try self.gc.allocSymbol(gname);
+            const gsym_idx = try self.addConstant(gsym);
+            try self.emitOp(.get_global);
+            try self.emitU16(gslot);
+            try self.emitU16(gsym_idx);
             try self.locals.append(gpa, .{
                 .name = gname,
                 .depth = self.scope_depth,
@@ -378,6 +386,7 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
             } else {
                 _ = self.macros.remove(pn);
             }
+            merged_stale = true;
         }
 
         check_lint.enterMacroExpansion();

--- a/src/tests_macro_chains.zig
+++ b/src/tests_macro_chains.zig
@@ -80,25 +80,33 @@ test "hygienic captured-local alias from an early chain link survives to the fin
 }
 
 test "divergent chain fails with a compile error and leaves the compiler usable" {
-    // (kick) → (bad-step 1 2 3): the second link's expansion has no
+    // (kick) → (bad-step gv 2 3): the second link's expansion has no
     // matching pattern. The chain must surface the same compile error the
     // nested recursion produced, and a mid-chain abort must restore all
-    // accumulated state (macro table, temp globals) — the same macros keep
-    // working afterwards.
+    // accumulated state. Two observables discriminate the chain-wide
+    // unwind: the macro table (bad-step still works afterwards) and the
+    // temp-globals hygiene dance — kick's template references `gv`, a
+    // non-procedure global, which expansion temporarily marks VOID in the
+    // globals map (#1208); a failed restore would leave gv VOID after the
+    // aborted compile.
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
     _ = try vm.eval(
+        \\(define gv 5)
         \\(define-syntax bad-step
         \\  (syntax-rules () ((_ ok) 'fine)))
         \\(define-syntax kick
-        \\  (syntax-rules () ((_) (bad-step 1 2 3))))
+        \\  (syntax-rules () ((_) (bad-step gv 2 3))))
     );
     const roots_before = gc.root_count;
     try std.testing.expectError(th.VMError.CompileError, vm.eval("(kick)"));
     try std.testing.expectEqual(roots_before, gc.root_count);
+
+    const gv_after = try vm.eval("gv");
+    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(gv_after));
 
     const after = try vm.eval("(bad-step 'x)");
     try std.testing.expect(types.isSymbol(after));

--- a/src/tests_macro_chains.zig
+++ b/src/tests_macro_chains.zig
@@ -1,0 +1,124 @@
+// Head-position macro expansion chains (kaappi#1796).
+//
+// A macro whose expansion IS directly another macro use in the same
+// position — SRFI 148's CK-machine steps, or a degenerate (loop) → (loop)
+// — used to compile by native recursion, one
+// expandAndCompileMacroUse → compileExpr → compileForm cycle per link, so
+// MAX_MACRO_EXPANSION_DEPTH was implicitly a native-stack guard: raising
+// it from 256 to 4096 made a runaway chain overflow the stack, and (in a
+// Debug/test build) the segfault fired inside the DebugAllocator's own
+// stack capture, whose SelfInfo lock the segfault handler then blocked
+// on — the whole test run deadlocked at 0% CPU. The fix iterates chains
+// inside expandAndCompileMacroUse at O(1) native stack, bounded by
+// MAX_MACRO_EXPANSION_STEPS; the depth cap keeps guarding only genuinely
+// nested expansions (which still recurse natively).
+//
+// These tests pin the two halves of that contract: chains longer than the
+// depth cap compile fine, and per-link bookkeeping (hygienic captured
+// locals, macro-table state) behaves exactly as the nested recursion did.
+
+const std = @import("std");
+const build_options = @import("build_options");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+
+test "head-position chain far deeper than the depth cap compiles at O(1) native stack" {
+    // Peano countdown: each link consumes one list element, so an
+    // N-element argument needs an N-link chain. N is well past
+    // MAX_MACRO_EXPANSION_DEPTH (256) — before kaappi#1796's fix this hit
+    // MacroExpansionLimit, and any constant large enough for it risked
+    // native stack overflow instead. Scaled down under gc-stress: the
+    // chain allocates a fresh (shrinking) list copy per link, and a
+    // collection per allocation makes the full-size run take minutes.
+    const n: usize = if (build_options.gc_stress) 300 else 2000;
+
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const gpa = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(gpa);
+    try src.appendSlice(gpa,
+        \\(define-syntax count-down
+        \\  (syntax-rules ()
+        \\    ((_ ()) 'done)
+        \\    ((_ (s . rest)) (count-down rest))))
+        \\(count-down (
+    );
+    for (0..n) |_| try src.appendSlice(gpa, " s");
+    try src.appendSlice(gpa, "))");
+
+    const roots_before = ctx.vm.gc.root_count;
+    const result = try ctx.vm.eval(src.items);
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("done", types.symbolName(result));
+    // The chain roots its links via extra_roots (released by the compile
+    // scope), never the fixed root stack — which would overflow its 1024
+    // slots at this length.
+    try std.testing.expectEqual(roots_before, ctx.vm.gc.root_count);
+}
+
+test "hygienic captured-local alias from an early chain link survives to the final form" {
+    // (starting) → (finishing (+ secret 1)) → (+ secret 1). The reference
+    // to `secret` is introduced by link 1's template and only compiled
+    // after link 2 has been processed, so link 1's injected captured-local
+    // alias must stay live until the final form compiles — the chain loop
+    // must accumulate per-link bookkeeping exactly as the old nested
+    // recursion's per-level frames did, not tear it down per link.
+    try th.expectEval(
+        \\(define (f)
+        \\  (define secret 41)
+        \\  (define-syntax finishing
+        \\    (syntax-rules () ((_ e) e)))
+        \\  (define-syntax starting
+        \\    (syntax-rules () ((_) (finishing (+ secret 1)))))
+        \\  (starting))
+        \\(f)
+    , 42);
+}
+
+test "divergent chain fails with a compile error and leaves the compiler usable" {
+    // (kick) → (bad-step 1 2 3): the second link's expansion has no
+    // matching pattern. The chain must surface the same compile error the
+    // nested recursion produced, and a mid-chain abort must restore all
+    // accumulated state (macro table, temp globals) — the same macros keep
+    // working afterwards.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-syntax bad-step
+        \\  (syntax-rules () ((_ ok) 'fine)))
+        \\(define-syntax kick
+        \\  (syntax-rules () ((_) (bad-step 1 2 3))))
+    );
+    const roots_before = gc.root_count;
+    try std.testing.expectError(th.VMError.CompileError, vm.eval("(kick)"));
+    try std.testing.expectEqual(roots_before, gc.root_count);
+
+    const after = try vm.eval("(bad-step 'x)");
+    try std.testing.expect(types.isSymbol(after));
+    try std.testing.expectEqualStrings("fine", types.symbolName(after));
+}
+
+test "runaway self-expansion is caught by the step limit, not native stack depth" {
+    // The tests_robustness twin of this asserts the error; this one pins
+    // the kaappi#1796 mechanism: the same runaway must ALSO fail when the
+    // chain runs from inside a lambda body (a nested compiler scope with
+    // its own locals), where per-link native recursion used to stack the
+    // deepest. Nothing here may crash or hang at any depth-cap value.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try std.testing.expectError(th.VMError.CompileError, ctx.vm.eval(
+        \\(define-syntax churn
+        \\  (syntax-rules ()
+        \\    ((_) (churn))))
+        \\(define (g) (churn))
+        \\(g)
+    ));
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -6,6 +6,7 @@ test {
     _ = @import("tests_numeric.zig");
     _ = @import("tests_macros.zig");
     _ = @import("tests_macros_nested_sr.zig");
+    _ = @import("tests_macro_chains.zig");
     _ = @import("tests_prescan.zig");
     _ = @import("tests_libraries.zig");
     _ = @import("tests_exceptions.zig");

--- a/tests/scheme/smoke/macro-chains.scm
+++ b/tests/scheme/smoke/macro-chains.scm
@@ -1,0 +1,68 @@
+;;; Head-position macro expansion chains (kaappi#1796): an expansion that
+;;; is directly another macro use in the same position is compiled
+;;; iteratively, so chain length is bounded by the expansion STEP limit
+;;; (10,000), not the nesting depth cap (256) that guards native stack.
+;;; Before the fix, the 400-link chain below failed with KP2003; the depth
+;;; cap could not simply be raised, because deep chains then overflowed
+;;; the native stack. Divergent-chain error cases live in the unit suite
+;;; (src/tests_macro_chains.zig) — a compile error would abort this file.
+(import (scheme base) (scheme process-context) (srfi 64))
+
+(define %test-fail-count 0)
+(test-begin "macro-chains")
+
+;; 1. Peano countdown: one chain link per list element, far past the
+;; nesting-depth cap of 256.
+(define-syntax count-down
+  (syntax-rules ()
+    ((_ ()) 'done)
+    ((_ (s . rest)) (count-down rest))))
+
+(test-eq "400-link head-position chain compiles and runs" 'done
+  (count-down
+    (s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s
+     s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s s)))
+
+;; 2. Hygiene across links: the reference to `secret` is introduced by the
+;; FIRST link's template but only compiled after the second link has been
+;; processed — early-link hygiene bookkeeping must survive to the final
+;; form.
+(define (chained-hygiene)
+  (define secret 41)
+  (define-syntax finishing
+    (syntax-rules () ((_ e) e)))
+  (define-syntax starting
+    (syntax-rules () ((_) (finishing (+ secret 1)))))
+  (starting))
+
+(test-eqv "captured local from an early chain link resolves in the final form" 42
+  (chained-hygiene))
+
+;; 3. Argument material threads through a chain of three distinct macros.
+(define-syntax hop3 (syntax-rules () ((_ v) (list 'c v))))
+(define-syntax hop2 (syntax-rules () ((_ v) (hop3 (+ v 1)))))
+(define-syntax hop1 (syntax-rules () ((_ v) (hop2 (* v 2)))))
+
+(test-equal "three-macro chain threads its argument" '(c 21)
+  (hop1 10))
+
+;; 4. A chain inside a tail position keeps the tail flag: deep recursion
+;; through a chained macro must not grow the VM stack either.
+(define-syntax go (syntax-rules () ((_ f n) (go-really f n))))
+(define-syntax go-really (syntax-rules () ((_ f n) (f n))))
+(define (spin k) (if (= k 0) 'spun (go spin (- k 1))))
+
+(test-eq "chained macro in tail position preserves tail calls" 'spun
+  (spin 100000))
+
+(set! %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "macro-chains")
+(if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
## Summary

Fixes #1796 by removing the mechanism that made `MAX_MACRO_EXPANSION_DEPTH`
unraisable — and with it, the need to raise the constant at all.

### What the profile actually showed (the #1775 hypothesis is refuted)

The issue's working hypothesis was that raising the depth cap re-triggers
the #1775 pre-scan cost. Profiling (`sample`, per the issue's own next-steps)
showed the pre-scan is innocent — its own `depth > 256` cap and 4096-expansion
budget are fully independent of `MAX_MACRO_EXPANSION_DEPTH`, exactly as the
declined CodeRabbit suggestion on #1784 documented.

The real chain of events at 4096, captured live in stack samples:

1. `tests_robustness.zig`'s deliberately-divergent `(loop)` → `(loop)` macro
   drives one **native** `compileForm → expandAndCompileMacroUse →
   compileExpr → compileForm` cycle per expansion level (~6–10 KB of frames
   per level, dominated by `expandAndCompileMacroUse`'s fixed
   `temp_globals[128]` array). The 256 limit was implicitly a *native stack*
   guard: 4096 levels needs tens of MB against an 8 MiB thread stack.
2. The segfault lands inside the Debug test allocator's own per-allocation
   stack capture (`Dwarf.SelfUnwinder.computeRules`), **while it holds the
   `std.debug` SelfInfo module lock**.
3. Zig's segfault handler then tries to symbolize the crash and blocks on
   that same lock: `handleSegfaultPosix → … → SelfInfo.MachO.findModule →
   futexWait` — a permanent 0%-CPU deadlock. `zig build test` waits on the
   deadlocked child forever. That is the "hang".

So the constant could never be raised safely by itself: any value large
enough for SRFI 148's CK chains is also large enough to overflow the native
stack on the same shape.

### The fix: iterate head-position chains instead of recursing

An expansion that is *directly another macro use in the same position* —
SRFI 148's CK-machine steps, and the degenerate `(loop)` → `(loop)` — is now
compiled by looping inside `expandAndCompileMacroUse` at O(1) native stack,
bounded by the existing `MAX_MACRO_EXPANSION_STEPS` (10,000) divergence
guard. `MAX_MACRO_EXPANSION_DEPTH` stays 256 and now guards only *genuinely
nested* expansions (a macro use inside an argument subform of another
expansion), which are the thing that actually recurses natively.

Per-link bookkeeping (the temp-globals hygiene dance, injected
captured-local aliases, let-syntax peer swaps, lint suppression) must stay
live until the final form finishes compiling — identifiers introduced by an
early link's template can survive into the final form. The loop accumulates
each link's undo records in heap-side stacks and unwinds them LIFO after the
final compile, on success and error alike — the exact lifetimes the nested
per-level frames used to provide. Chain links are rooted via `extra_roots`
(released by the enclosing compile scope, like `compileDefineSyntax`'s
transformers); the fixed 1024-slot root stack could not hold one root per
link anyway — a second latent cliff of the old nested design, since a
~1000-link chain would have panicked the root stack even before
overflowing the native stack.

Also, `chainNextMacroUse` mirrors `compileForm`'s macro-dispatch conditions
exactly (usertext marker, local/upvalue shadowing, fixed-point suppression),
so the loop only iterates cases that would have recursed straight back.

### Behavioral changes

- Head-position chains longer than 256 now compile (previously KP2003).
  This is precisely what SRFI 148 (#1699's final slice) needs: CK-machine
  compositions get up to 10,000 steps per top-level form with zero native
  stack growth.
- Runaway chains (`(loop)`) still fail with the same deterministic KP2003,
  now via the step limit — quickly, at any hypothetical depth-cap value.
- Genuinely nested expansion depth is unchanged (256).

### Verified

- `zig build test` green at 256 (the shipped value).
- `zig build test` green at 4096 as well — the issue's exact repro, run
  once with the constant temporarily raised to prove the cliff is gone,
  then reverted.
- `bash tests/scheme/run-all.sh` green.
- New unit tests (`src/tests_macro_chains.zig`), mutation-tested: with the
  chain loop disabled, the deep-chain test fails exactly as the old code
  did (MacroExpansionLimit at 256 nesting levels).
- New Scheme smoke suite `tests/scheme/smoke/macro-chains.scm` (positive
  cases; error cases live in the unit tests since a compile error aborts a
  Scheme test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
