### PR TITLE
Stop ReleaseSafe memsetting the expander's 1MB buffers on every expansion (#1802)

### DIFF
--- a/docs/dev/performance.md
+++ b/docs/dev/performance.md
@@ -75,6 +75,24 @@ Cheap ways to get a real number before committing to a hypothesis:
   a defensible limit in #1775 (p99.99 = 1649, and the pathological tier
   starting at 6299).
 
+### When the profile bottoms out in `memset`
+
+A `sample` whose hottest leaf is `_memset` filling `0xAA` is Zig's
+safety-checked-`undefined` fill: ReleaseSafe initializes every plain
+`var x: T = undefined;` local by memsetting it. For a large scratch buffer
+declared per call this can *be* the workload — in #1802 the expander's
+~1MB rule-matching buffers made three fills per macro expansion 96% of an
+80-second library compile. The only shape that suppresses the fill is
+`@setRuntimeSafety(false)` at the scope of the *declaration* (in practice:
+function scope, with the body wrapped in a `@setRuntimeSafety(true)` block
+so real checks stay on — see `expander.expandMacro`). Wrapping just the
+initializer — `b: { @setRuntimeSafety(false); break :b undefined; }` —
+does not work and is worse than nothing: it materializes a runtime
+undefined value whose store into the local gets the fill anyway.
+`objdump -d` on the suspect function, looking for `bl _memset` with a
+`#0xaa` fill byte, settles in seconds whether a given declaration is
+being filled.
+
 ## 3. A/B two binaries without fooling yourself
 
 This is where measurement most often goes wrong, because two hazards

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1111,10 +1111,28 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
                 {
                     // ((name <transformer-spec>) ...) bindings are compile-time
                     // data like define-syntax specs; the body is real code and
-                    // keeps the budgeted scan.
+                    // keeps the budgeted scan. Walk each spec individually,
+                    // skipping the binding NAME, so a binding pair is never
+                    // misread as a form: a macro bound under a special-form
+                    // name (R7RS lets a binding shadow `quote`, `set!`, ...)
+                    // would otherwise derail the walk — a binding literally
+                    // named `quote` early-returns before its own spec is
+                    // scanned. Verified unobservable end-to-end today (the
+                    // let-syntax body compiles via passthrough, where the
+                    // folder doesn't engage, and a late-discovered target is
+                    // still boxed via the box_local transition — pinned by
+                    // tests/scheme/hygiene/quote-shadow-boxing.scm), so this
+                    // is scan hygiene, not a bug fix.
                     const rest = types.cdr(cur);
                     if (!types.isPair(rest)) return;
-                    try collectSetTargets(self, types.car(rest), out, depth, null);
+                    var bindings_cur = types.car(rest);
+                    while (types.isPair(bindings_cur)) {
+                        const binding = types.car(bindings_cur);
+                        if (types.isPair(binding)) {
+                            try collectSetTargets(self, types.cdr(binding), out, depth, null);
+                        }
+                        bindings_cur = types.cdr(bindings_cur);
+                    }
                     cur = types.cdr(rest);
                     continue;
                 }

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1085,6 +1085,38 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
                     }
                     try collectSetTargets(self, expanded_root, out, depth + 1, budget);
                     return;
+                } else if (std.mem.eql(u8, hname, "define-syntax")) {
+                    // (define-syntax name <transformer-spec>): the spec is
+                    // compile-time data — it resolves to a transformer object
+                    // and never contributes a runtime `set!` to THIS form —
+                    // so walk it for literal `set!`s in templates but never
+                    // macro-expand inside it. Speculatively running a
+                    // SRFI 147 spec like SRFI 148's `(em-syntax-rules ...)`
+                    // drove the whole CK machine per definition, burning the
+                    // entire budget (and with it set_targets_all boxing) on
+                    // forms with no runtime code at all (kaappi#1802). A
+                    // `set!` that only materializes when the spec's own
+                    // macros run is caught at the macro's real use site —
+                    // its own form's pre-scan, or Part B — the same
+                    // correct-late path every divergent best-effort
+                    // expansion above already takes.
+                    const rest = types.cdr(cur);
+                    if (types.isPair(rest)) {
+                        // Skip the macro name; walk the spec without a budget.
+                        try collectSetTargets(self, types.cdr(rest), out, depth, null);
+                    }
+                    return;
+                } else if (std.mem.eql(u8, hname, "let-syntax") or
+                    std.mem.eql(u8, hname, "letrec-syntax"))
+                {
+                    // ((name <transformer-spec>) ...) bindings are compile-time
+                    // data like define-syntax specs; the body is real code and
+                    // keeps the budgeted scan.
+                    const rest = types.cdr(cur);
+                    if (!types.isPair(rest)) return;
+                    try collectSetTargets(self, types.car(rest), out, depth, null);
+                    cur = types.cdr(rest);
+                    continue;
                 }
             }
         }

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -166,87 +166,98 @@ threadlocal var active_def_local_refs: []const []const u8 = &.{};
 threadlocal var active_use_check: UseSiteBindingCheck = .{};
 
 pub fn expandMacro(gc: *GC, expr: Value, transformer_val: Value, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value), use_check: UseSiteBindingCheck) !Value {
-    // `--timings` (kaappi#1515): the sole macro-expansion chokepoint, so timing
-    // it here covers every caller (compiler, pipeline dump, REPL). Expansion runs
-    // during emission; the self-time stack keeps it disjoint from the emit stage.
-    timings.begin(.expand);
-    defer timings.end();
-    const transformer = types.toObject(transformer_val).as(types.Transformer);
-    const saved_ellipsis = active_custom_ellipsis;
-    active_custom_ellipsis = transformer.custom_ellipsis;
-    defer active_custom_ellipsis = saved_ellipsis;
-    const saved_literals = active_literals;
-    active_literals = transformer.literals;
-    defer active_literals = saved_literals;
-    const saved_def_local_refs = active_def_local_refs;
-    active_def_local_refs = transformer.def_site_local_refs;
-    defer active_def_local_refs = saved_def_local_refs;
-    const saved_use_check = active_use_check;
-    active_use_check = use_check;
-    defer active_use_check = saved_use_check;
-    const input = types.cdr(expr); // skip the keyword
+    // The rule-matching bindings buffer is ~1MB and only entries below
+    // bind_count are ever read, so it must not be filled per call: Zig 0.16
+    // ReleaseSafe 0xAA-fills every plain `= undefined` local, and this fill
+    // (here and in matchEllipsis/instantiateEllipsis) was ~96% of an
+    // 80-second SRFI 148 library compile (kaappi#1802). The only shape that
+    // suppresses the fill is declaring the buffer under a safety-off
+    // *function* scope; the entire body then runs in the safety-on block
+    // below, so index/overflow checks are unaffected. (The previous
+    // `b: { @setRuntimeSafety(false); break :b undefined; }` initializer
+    // does NOT work: it materializes a runtime undefined value whose store
+    // into the local gets the fill anyway.)
+    @setRuntimeSafety(false);
+    var bindings: [MAX_BINDINGS]Binding = undefined;
+    {
+        @setRuntimeSafety(true);
+        // `--timings` (kaappi#1515): the sole macro-expansion chokepoint, so timing
+        // it here covers every caller (compiler, pipeline dump, REPL). Expansion runs
+        // during emission; the self-time stack keeps it disjoint from the emit stage.
+        timings.begin(.expand);
+        defer timings.end();
+        const transformer = types.toObject(transformer_val).as(types.Transformer);
+        const saved_ellipsis = active_custom_ellipsis;
+        active_custom_ellipsis = transformer.custom_ellipsis;
+        defer active_custom_ellipsis = saved_ellipsis;
+        const saved_literals = active_literals;
+        active_literals = transformer.literals;
+        defer active_literals = saved_literals;
+        const saved_def_local_refs = active_def_local_refs;
+        active_def_local_refs = transformer.def_site_local_refs;
+        defer active_def_local_refs = saved_def_local_refs;
+        const saved_use_check = active_use_check;
+        active_use_check = use_check;
+        defer active_use_check = saved_use_check;
+        const input = types.cdr(expr); // skip the keyword
 
-    // Extract the macro keyword name from the first pattern (car of the
-    // full pattern list). This identifier must not be renamed during
-    // hygiene: recursive macro calls in the template need to resolve
-    // back to the same macro.
-    var macro_keyword: ?[]const u8 = null;
-    if (transformer.num_rules > 0) {
-        // Unwrap first: a generating macro that splices a WHOLE rule pattern
-        // from user text hands this transformer a marker-wrapped pattern,
-        // whose car is the marker symbol rather than the keyword.
-        const first_pat = unwrapUsertext(transformer.patterns[0]);
-        if (types.isPair(first_pat)) {
-            const kw = types.car(first_pat);
-            if (types.isSymbol(kw)) {
-                macro_keyword = types.symbolName(kw);
+        // Extract the macro keyword name from the first pattern (car of the
+        // full pattern list). This identifier must not be renamed during
+        // hygiene: recursive macro calls in the template need to resolve
+        // back to the same macro.
+        var macro_keyword: ?[]const u8 = null;
+        if (transformer.num_rules > 0) {
+            // Unwrap first: a generating macro that splices a WHOLE rule pattern
+            // from user text hands this transformer a marker-wrapped pattern,
+            // whose car is the marker symbol rather than the keyword.
+            const first_pat = unwrapUsertext(transformer.patterns[0]);
+            if (types.isPair(first_pat)) {
+                const kw = types.car(first_pat);
+                if (types.isSymbol(kw)) {
+                    macro_keyword = types.symbolName(kw);
+                }
             }
         }
-    }
 
-    // Create a fresh scope for this macro invocation. All template-
-    // introduced identifiers within this expansion share this scope,
-    // so they get consistent renaming (the same name maps to the same
-    // gensym) while differing from user identifiers.
-    const intro_scope = freshScope();
+        // Create a fresh scope for this macro invocation. All template-
+        // introduced identifiers within this expansion share this scope,
+        // so they get consistent renaming (the same name maps to the same
+        // gensym) while differing from user identifiers.
+        const intro_scope = freshScope();
 
-    // The scope table is only a dedup cache for renames *within* this
-    // expansion: each expansion has a globally-unique scope id, so entries
-    // from prior expansions are never matched again. Release them on return
-    // so the fixed-size table doesn't fill up over many expansions. (Once it
-    // was full, new renames went unrecorded, so repeated references to the
-    // same template identifier got *different* gensyms — splitting a binding
-    // from its uses, e.g. `__hyg_N_res` undefined.) Save/restore rather than
-    // zeroing keeps this correct even if expansion ever becomes re-entrant.
-    const saved_scope_count = scope_table_count;
-    defer scope_table_count = saved_scope_count;
+        // The scope table is only a dedup cache for renames *within* this
+        // expansion: each expansion has a globally-unique scope id, so entries
+        // from prior expansions are never matched again. Release them on return
+        // so the fixed-size table doesn't fill up over many expansions. (Once it
+        // was full, new renames went unrecorded, so repeated references to the
+        // same template identifier got *different* gensyms — splitting a binding
+        // from its uses, e.g. `__hyg_N_res` undefined.) Save/restore rather than
+        // zeroing keeps this correct even if expansion ever becomes re-entrant.
+        const saved_scope_count = scope_table_count;
+        defer scope_table_count = saved_scope_count;
 
-    const literal_bound = transformer.literal_bound;
+        const literal_bound = transformer.literal_bound;
 
-    // Try each rule in order. The bindings buffer is hoisted and left
-    // uninitialized (entries below bind_count are always written before
-    // being read) — a safety fill of the ~1MB array per rule attempt is
-    // prohibitively slow for macro-heavy code.
-    var bindings: [MAX_BINDINGS]Binding = b: {
-        @setRuntimeSafety(false);
-        break :b undefined;
-    };
-    for (0..transformer.num_rules) |i| {
-        var bind_count: usize = 0;
+        // Try each rule in order. The bindings buffer is hoisted to the top of
+        // the function and left uninitialized (entries below bind_count are
+        // always written before being read).
+        for (0..transformer.num_rules) |i| {
+            var bind_count: usize = 0;
 
-        // Skip the keyword in the pattern (first element of pattern).
-        // Same whole-pattern unwrap as the keyword extraction above: without
-        // it this cdr strips the MARKER instead of the keyword, so every
-        // pattern position lines up one slot late against the input and the
-        // user's own `_` keyword placeholder swallows the first argument.
-        const pattern_body = types.cdr(unwrapUsertext(transformer.patterns[i]));
+            // Skip the keyword in the pattern (first element of pattern).
+            // Same whole-pattern unwrap as the keyword extraction above: without
+            // it this cdr strips the MARKER instead of the keyword, so every
+            // pattern position lines up one slot late against the input and the
+            // user's own `_` keyword placeholder swallows the first argument.
+            const pattern_body = types.cdr(unwrapUsertext(transformer.patterns[i]));
 
-        if (matchPattern(pattern_body, input, transformer.literals[0..], &bindings, &bind_count, gc, literal_bound, use_check)) {
-            return instantiateTemplate(gc, transformer.templates[i], bindings[0..bind_count], intro_scope, transformer.literals, macro_keyword, globals, macros);
+            if (matchPattern(pattern_body, input, transformer.literals[0..], &bindings, &bind_count, gc, literal_bound, use_check)) {
+                return instantiateTemplate(gc, transformer.templates[i], bindings[0..bind_count], intro_scope, transformer.literals, macro_keyword, globals, macros);
+            }
         }
-    }
 
-    return error.NoMatchingPattern;
+        return error.NoMatchingPattern;
+    }
 }
 
 pub const ExpandError = error{
@@ -465,83 +476,87 @@ fn countPairs(v: Value) ?usize {
 }
 
 fn matchEllipsis(elem_pattern: Value, rest_pattern: Value, input: Value, literals: []const Value, bindings: *[MAX_BINDINGS]Binding, count: *usize, gc: ?*GC, literal_bound: []const u32, use_check: UseSiteBindingCheck) bool {
-    // Count how many elements the rest_pattern needs (handles improper lists)
-    const rest_len = countPairs(rest_pattern) orelse return false;
-    const input_len = countPairs(input) orelse return false;
-
-    if (input_len < rest_len) return false;
-    const repeat_count = input_len - rest_len;
-
+    // Scratch buffers, hoisted out of the repetition loop and left
+    // uninitialized: matchPattern only writes entries below sub_count, and a
+    // safety fill of the ~1MB array per repetition is what made match-style
+    // macros unusably slow. Declared under a safety-off function scope so
+    // ReleaseSafe's 0xAA fill of `= undefined` locals is not emitted; the
+    // whole body runs in the safety-on block below (see expandMacro;
+    // kaappi#1802).
+    @setRuntimeSafety(false);
+    var sub_bindings: [MAX_BINDINGS]Binding = undefined;
     var elem_var_names: [128][]const u8 = undefined;
-    var elem_var_count: usize = 0;
-    var var_overflow = false;
-    collectPatternVars(elem_pattern, literals, &elem_var_names, &elem_var_count, &var_overflow);
-    if (var_overflow) return false;
+    {
+        @setRuntimeSafety(true);
+        // Count how many elements the rest_pattern needs (handles improper lists)
+        const rest_len = countPairs(rest_pattern) orelse return false;
+        const input_len = countPairs(input) orelse return false;
 
-    // Create list bindings for each pattern variable found in the ellipsis
-    // sub-pattern. Field-wise assignment: see matchPattern.
-    const base_count = count.*;
-    for (0..elem_var_count) |vi| {
-        if (count.* >= MAX_BINDINGS) return false;
-        bindings[count.*].name = elem_var_names[vi];
-        bindings[count.*].value = types.NIL;
-        bindings[count.*].depth = 1;
-        bindings[count.*].is_list = true;
-        bindings[count.*].ellipsis_count = 0;
-        count.* += 1;
-    }
+        if (input_len < rest_len) return false;
+        const repeat_count = input_len - rest_len;
 
-    // Match each repetition. The sub-binding buffer is hoisted out of the
-    // loop and left uninitialized: matchPattern only writes entries below
-    // sub_count, and a safety fill of the ~1MB array per repetition is
-    // what made match-style macros unusably slow.
-    var sub_bindings: [MAX_BINDINGS]Binding = b: {
-        @setRuntimeSafety(false);
-        break :b undefined;
-    };
-    // Same spine unwrapping as countPairs: the repetition walk must step
-    // over marker cells rather than consume one as an element.
-    var inp = unwrapUsertext(input);
-    for (0..repeat_count) |_| {
-        var sub_count: usize = 0;
-        if (!types.isPair(inp)) return false;
-        if (!matchPattern(elem_pattern, types.car(inp), literals, &sub_bindings, &sub_count, gc, literal_bound, use_check))
-            return false;
+        var elem_var_count: usize = 0;
+        var var_overflow = false;
+        collectPatternVars(elem_pattern, literals, &elem_var_names, &elem_var_count, &var_overflow);
+        if (var_overflow) return false;
 
-        // Append each sub-binding value to the corresponding list binding
-        for (0..sub_count) |si| {
-            for (base_count..count.*) |bi| {
-                if (std.mem.eql(u8, bindings[bi].name, sub_bindings[si].name)) {
-                    if (bindings[bi].ellipsis_count >= MAX_ELLIPSIS_VALUES) return false;
-                    if (sub_bindings[si].is_list) {
-                        // Nested ellipsis: build list from inner values
-                        if (gc) |g| {
-                            var inner_list: Value = types.NIL;
-                            var k = sub_bindings[si].ellipsis_count;
-                            while (k > 0) {
-                                k -= 1;
-                                inner_list = g.allocPair(sub_bindings[si].ellipsis_values[k], inner_list) catch return false;
+        // Create list bindings for each pattern variable found in the ellipsis
+        // sub-pattern. Field-wise assignment: see matchPattern.
+        const base_count = count.*;
+        for (0..elem_var_count) |vi| {
+            if (count.* >= MAX_BINDINGS) return false;
+            bindings[count.*].name = elem_var_names[vi];
+            bindings[count.*].value = types.NIL;
+            bindings[count.*].depth = 1;
+            bindings[count.*].is_list = true;
+            bindings[count.*].ellipsis_count = 0;
+            count.* += 1;
+        }
+
+        // Same spine unwrapping as countPairs: the repetition walk must step
+        // over marker cells rather than consume one as an element.
+        var inp = unwrapUsertext(input);
+        for (0..repeat_count) |_| {
+            var sub_count: usize = 0;
+            if (!types.isPair(inp)) return false;
+            if (!matchPattern(elem_pattern, types.car(inp), literals, &sub_bindings, &sub_count, gc, literal_bound, use_check))
+                return false;
+
+            // Append each sub-binding value to the corresponding list binding
+            for (0..sub_count) |si| {
+                for (base_count..count.*) |bi| {
+                    if (std.mem.eql(u8, bindings[bi].name, sub_bindings[si].name)) {
+                        if (bindings[bi].ellipsis_count >= MAX_ELLIPSIS_VALUES) return false;
+                        if (sub_bindings[si].is_list) {
+                            // Nested ellipsis: build list from inner values
+                            if (gc) |g| {
+                                var inner_list: Value = types.NIL;
+                                var k = sub_bindings[si].ellipsis_count;
+                                while (k > 0) {
+                                    k -= 1;
+                                    inner_list = g.allocPair(sub_bindings[si].ellipsis_values[k], inner_list) catch return false;
+                                }
+                                bindings[bi].ellipsis_values[bindings[bi].ellipsis_count] = inner_list;
+                                bindings[bi].depth = sub_bindings[si].depth + 1;
+                            } else {
+                                bindings[bi].ellipsis_values[bindings[bi].ellipsis_count] = sub_bindings[si].value;
                             }
-                            bindings[bi].ellipsis_values[bindings[bi].ellipsis_count] = inner_list;
-                            bindings[bi].depth = sub_bindings[si].depth + 1;
                         } else {
                             bindings[bi].ellipsis_values[bindings[bi].ellipsis_count] = sub_bindings[si].value;
                         }
-                    } else {
-                        bindings[bi].ellipsis_values[bindings[bi].ellipsis_count] = sub_bindings[si].value;
+                        bindings[bi].ellipsis_count += 1;
+                        break;
                     }
-                    bindings[bi].ellipsis_count += 1;
-                    break;
                 }
             }
+
+            inp = unwrapUsertext(types.cdr(inp));
         }
 
-        inp = unwrapUsertext(types.cdr(inp));
+        // Match remaining input against rest_pattern
+        if (unwrapUsertext(rest_pattern) == types.NIL) return inp == types.NIL;
+        return matchListPattern(rest_pattern, inp, literals, bindings, count, gc, literal_bound, use_check);
     }
-
-    // Match remaining input against rest_pattern
-    if (unwrapUsertext(rest_pattern) == types.NIL) return inp == types.NIL;
-    return matchListPattern(rest_pattern, inp, literals, bindings, count, gc, literal_bound, use_check);
 }
 
 fn collectPatternVars(pattern: Value, literals: []const Value, names: *[128][]const u8, count: *usize, overflowed: *bool) void {
@@ -1103,139 +1118,143 @@ fn templateReferencesVar(template: Value, name: []const u8) bool {
 }
 
 fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bindings: []Binding, intro_scope: u32, literals: []const Value, macro_keyword: ?[]const u8, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value)) (std.mem.Allocator.Error || ExpandError)!Value {
-    // Find the repeat count from ellipsis bindings referenced in elem_template.
-    // All referenced list bindings must have equal counts (R7RS). Bindings
-    // with depth > 1 (nested ellipses) participate too: their ellipsis_count
-    // at this level is the outer repetition count, and each iteration below
-    // unpacks them one level for the inner ellipsis to consume.
-    var repeat_count: usize = 0;
-    var count_set = false;
-    var referenced: [MAX_BINDINGS]bool = @splat(false);
-    for (bindings, 0..) |b, bi| {
-        if (b.is_list and templateReferencesVar(elem_template, b.name)) {
-            referenced[bi] = true;
-            if (!count_set) {
-                repeat_count = b.ellipsis_count;
-                count_set = true;
-            } else if (b.ellipsis_count != repeat_count) {
-                return ExpandError.EllipsisCountMismatch;
+    // Per-iteration sub-binding scratch, hoisted out of the loop and written
+    // field-by-field there: whole-struct assignment re-initializes or copies
+    // the 8KB ellipsis_values field each time, which dominated expansion time
+    // on macro-heavy code (ellipsis_values is only read when is_list).
+    // Declared under a safety-off function scope so ReleaseSafe's 0xAA fill
+    // of `= undefined` locals is not emitted; the whole body runs in the
+    // safety-on block below (see expandMacro; kaappi#1802).
+    @setRuntimeSafety(false);
+    var sub_bindings: [MAX_BINDINGS]Binding = undefined;
+    {
+        @setRuntimeSafety(true);
+        // Find the repeat count from ellipsis bindings referenced in elem_template.
+        // All referenced list bindings must have equal counts (R7RS). Bindings
+        // with depth > 1 (nested ellipses) participate too: their ellipsis_count
+        // at this level is the outer repetition count, and each iteration below
+        // unpacks them one level for the inner ellipsis to consume.
+        var repeat_count: usize = 0;
+        var count_set = false;
+        var referenced: [MAX_BINDINGS]bool = @splat(false);
+        for (bindings, 0..) |b, bi| {
+            if (b.is_list and templateReferencesVar(elem_template, b.name)) {
+                referenced[bi] = true;
+                if (!count_set) {
+                    repeat_count = b.ellipsis_count;
+                    count_set = true;
+                } else if (b.ellipsis_count != repeat_count) {
+                    return ExpandError.EllipsisCountMismatch;
+                }
             }
         }
-    }
 
-    // Consecutive ellipses (R7RS 4.3.2): (x ... ...) flattens depth-2
-    // bindings into a single list.  Count and strip leading ellipsis
-    // tokens from rest_template so the tail instantiation sees only the
-    // non-ellipsis remainder.
-    var extra_ellipsis: u32 = 0;
-    var true_rest = rest_template;
-    while (types.isPair(true_rest)) {
-        const head = types.car(true_rest);
-        if (types.isSymbol(head) and isEllipsis(types.symbolName(head))) {
-            extra_ellipsis += 1;
-            true_rest = types.cdr(true_rest);
-        } else {
-            break;
+        // Consecutive ellipses (R7RS 4.3.2): (x ... ...) flattens depth-2
+        // bindings into a single list.  Count and strip leading ellipsis
+        // tokens from rest_template so the tail instantiation sees only the
+        // non-ellipsis remainder.
+        var extra_ellipsis: u32 = 0;
+        var true_rest = rest_template;
+        while (types.isPair(true_rest)) {
+            const head = types.car(true_rest);
+            if (types.isSymbol(head) and isEllipsis(types.symbolName(head))) {
+                extra_ellipsis += 1;
+                true_rest = types.cdr(true_rest);
+            } else {
+                break;
+            }
         }
-    }
 
-    // First instantiate the rest (after all consumed ellipses)
-    const result = try instantiateTemplate(gc, true_rest, bindings, intro_scope, literals, macro_keyword, globals, macros);
-    var result_root = result;
-    gc.pushRoot(&result_root);
-    defer gc.popRoot();
+        // First instantiate the rest (after all consumed ellipses)
+        const result = try instantiateTemplate(gc, true_rest, bindings, intro_scope, literals, macro_keyword, globals, macros);
+        var result_root = result;
+        gc.pushRoot(&result_root);
+        defer gc.popRoot();
 
-    // When extra ellipses are present, build the synthetic template
-    // (elem_template ... ...) once outside the loop — it is invariant
-    // across iterations and instantiateTemplate only reads it.
-    var synth = types.NIL;
-    if (extra_ellipsis > 0) {
-        gc.pushRoot(&synth);
-        const ellipsis_name = active_custom_ellipsis orelse "...";
-        var ei: u32 = 0;
-        while (ei < extra_ellipsis) : (ei += 1) {
-            const dots = try gc.allocSymbol(ellipsis_name);
-            synth = try gc.allocPair(dots, synth);
+        // When extra ellipses are present, build the synthetic template
+        // (elem_template ... ...) once outside the loop — it is invariant
+        // across iterations and instantiateTemplate only reads it.
+        var synth = types.NIL;
+        if (extra_ellipsis > 0) {
+            gc.pushRoot(&synth);
+            const ellipsis_name = active_custom_ellipsis orelse "...";
+            var ei: u32 = 0;
+            while (ei < extra_ellipsis) : (ei += 1) {
+                const dots = try gc.allocSymbol(ellipsis_name);
+                synth = try gc.allocPair(dots, synth);
+            }
+            synth = try gc.allocPair(elem_template, synth);
         }
-        synth = try gc.allocPair(elem_template, synth);
-    }
-    defer if (extra_ellipsis > 0) gc.popRoot();
+        defer if (extra_ellipsis > 0) gc.popRoot();
 
-    // Generate copies in reverse so we build the list from right to left.
-    // The sub-binding buffer is hoisted out of the loop and written
-    // field-by-field: whole-struct assignment re-initializes or copies the
-    // 8KB ellipsis_values field each time, which dominated expansion time
-    // on macro-heavy code (ellipsis_values is only read when is_list).
-    var sub_bindings: [MAX_BINDINGS]Binding = b: {
-        @setRuntimeSafety(false);
-        break :b undefined;
-    };
-    var i = repeat_count;
-    while (i > 0) {
-        i -= 1;
-        // Create sub-bindings with the i-th value for each referenced list
-        // binding. Unreferenced list bindings are skipped: their
-        // ellipsis_count can be smaller than repeat_count (e.g. two
-        // ellipsis groups of different lengths in one template), so
-        // indexing ellipsis_values[i] would read uninitialized data.
-        var sub_count: usize = 0;
-        for (bindings, 0..) |b, bi| {
-            if (b.is_list) {
-                if (!referenced[bi]) continue;
-                if (b.depth > 1) {
-                    // Nested ellipsis: unpack list into sub-binding
-                    sub_bindings[sub_count].name = b.name;
-                    sub_bindings[sub_count].value = types.NIL;
-                    sub_bindings[sub_count].depth = b.depth - 1;
-                    sub_bindings[sub_count].is_list = true;
-                    var list_val = b.ellipsis_values[i];
-                    var ev_count: usize = 0;
-                    while (types.isPair(list_val) and ev_count < MAX_ELLIPSIS_VALUES) {
-                        sub_bindings[sub_count].ellipsis_values[ev_count] = types.car(list_val);
-                        ev_count += 1;
-                        list_val = types.cdr(list_val);
+        // Generate copies in reverse so we build the list from right to left.
+        var i = repeat_count;
+        while (i > 0) {
+            i -= 1;
+            // Create sub-bindings with the i-th value for each referenced list
+            // binding. Unreferenced list bindings are skipped: their
+            // ellipsis_count can be smaller than repeat_count (e.g. two
+            // ellipsis groups of different lengths in one template), so
+            // indexing ellipsis_values[i] would read uninitialized data.
+            var sub_count: usize = 0;
+            for (bindings, 0..) |b, bi| {
+                if (b.is_list) {
+                    if (!referenced[bi]) continue;
+                    if (b.depth > 1) {
+                        // Nested ellipsis: unpack list into sub-binding
+                        sub_bindings[sub_count].name = b.name;
+                        sub_bindings[sub_count].value = types.NIL;
+                        sub_bindings[sub_count].depth = b.depth - 1;
+                        sub_bindings[sub_count].is_list = true;
+                        var list_val = b.ellipsis_values[i];
+                        var ev_count: usize = 0;
+                        while (types.isPair(list_val) and ev_count < MAX_ELLIPSIS_VALUES) {
+                            sub_bindings[sub_count].ellipsis_values[ev_count] = types.car(list_val);
+                            ev_count += 1;
+                            list_val = types.cdr(list_val);
+                        }
+                        sub_bindings[sub_count].ellipsis_count = ev_count;
+                    } else {
+                        sub_bindings[sub_count].name = b.name;
+                        sub_bindings[sub_count].value = b.ellipsis_values[i];
+                        sub_bindings[sub_count].depth = 0;
+                        sub_bindings[sub_count].is_list = false;
+                        sub_bindings[sub_count].ellipsis_count = 0;
                     }
-                    sub_bindings[sub_count].ellipsis_count = ev_count;
                 } else {
                     sub_bindings[sub_count].name = b.name;
-                    sub_bindings[sub_count].value = b.ellipsis_values[i];
-                    sub_bindings[sub_count].depth = 0;
+                    sub_bindings[sub_count].value = b.value;
+                    sub_bindings[sub_count].depth = b.depth;
                     sub_bindings[sub_count].is_list = false;
                     sub_bindings[sub_count].ellipsis_count = 0;
                 }
+                sub_count += 1;
+            }
+
+            if (extra_ellipsis == 0) {
+                const expanded = try instantiateTemplate(gc, elem_template, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
+                var expanded_root = expanded;
+                gc.pushRoot(&expanded_root);
+                result_root = try gc.allocPair(expanded_root, result_root);
+                gc.popRoot();
             } else {
-                sub_bindings[sub_count].name = b.name;
-                sub_bindings[sub_count].value = b.value;
-                sub_bindings[sub_count].depth = b.depth;
-                sub_bindings[sub_count].is_list = false;
-                sub_bindings[sub_count].ellipsis_count = 0;
-            }
-            sub_count += 1;
-        }
+                const expanded_list = try instantiateTemplate(gc, synth, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
 
-        if (extra_ellipsis == 0) {
-            const expanded = try instantiateTemplate(gc, elem_template, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
-            var expanded_root = expanded;
-            gc.pushRoot(&expanded_root);
-            result_root = try gc.allocPair(expanded_root, result_root);
-            gc.popRoot();
-        } else {
-            const expanded_list = try instantiateTemplate(gc, synth, sub_bindings[0..sub_count], intro_scope, literals, macro_keyword, globals, macros);
-
-            // Splice expanded_list (a proper list) into result_root.
-            if (expanded_list != types.NIL and types.isPair(expanded_list)) {
-                var tail = expanded_list;
-                while (types.isPair(types.cdr(tail))) {
-                    tail = types.cdr(tail);
+                // Splice expanded_list (a proper list) into result_root.
+                if (expanded_list != types.NIL and types.isPair(expanded_list)) {
+                    var tail = expanded_list;
+                    while (types.isPair(types.cdr(tail))) {
+                        tail = types.cdr(tail);
+                    }
+                    gc.writeBarrier(types.toObject(tail), result_root);
+                    types.setCdr(tail, result_root);
+                    result_root = expanded_list;
                 }
-                gc.writeBarrier(types.toObject(tail), result_root);
-                types.setCdr(tail, result_root);
-                result_root = expanded_list;
             }
         }
-    }
 
-    return result_root;
+        return result_root;
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_prescan.zig
+++ b/src/tests_prescan.zig
@@ -128,6 +128,77 @@ test "#1775: a fixed-point macro does not exhaust the pre-scan budget" {
     try std.testing.expectEqual(@as(u64, 0), truncations);
 }
 
+test "#1802: a macro use in transformer-spec position does not consume the pre-scan budget" {
+    // SRFI 147/148 shape: the transformer spec is itself a macro use that
+    // resolveTransformerSpec expands to a literal syntax-rules at real
+    // compile time. The pre-scan used to treat the spec as ordinary code and
+    // speculatively expand it too — for SRFI 148's `em-syntax-rules` that ran
+    // the whole CK machine once per *definition*, burning the entire budget
+    // (and, via truncation, boxing every local) on forms with no runtime
+    // code at all (kaappi#1802). A spec never contributes a runtime `set!`
+    // to its own form, so the scan must walk it without expanding.
+    //
+    // With the limit at 0, ANY spec expansion truncates, so this fails
+    // without the fix.
+    const saved = compiler.prescan_expansion_limit;
+    defer compiler.prescan_expansion_limit = saved;
+
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // Defined at the default limit; its own spec is a literal syntax-rules.
+    _ = try ctx.vm.eval(
+        \\(define-syntax gen (syntax-rules () ((_) (syntax-rules () ((_ x) x)))))
+    );
+
+    compiler.prescan_expansion_limit = 0;
+    const before = compiler.prescan_truncations;
+    _ = try ctx.vm.eval("(define-syntax my-id (gen))");
+    try std.testing.expectEqual(@as(u64, 0), compiler.prescan_truncations - before);
+    compiler.prescan_expansion_limit = saved;
+
+    // The real SRFI 147 resolution must be unaffected by the pre-scan skip.
+    const result = try ctx.vm.eval("(my-id 42)");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+test "#1802: let-syntax specs are skipped but the body keeps the budgeted scan" {
+    // Three failure modes distinguished by one form, compiled with a budget
+    // of exactly 1:
+    //   - spec still consumes budget (no fix): `(gen)` eats the single
+    //     expansion, `rebind` then truncates the scan => truncations 1.
+    //   - body wrongly walked without the budget (over-broad fix): `rebind`
+    //     is never expanded, `+` never enters set_targets, `(+ 5 2)` folds
+    //     to 7 before the reassignment runs => result 7.
+    //   - correct: the one expansion goes to the body's `rebind`, `+` is a
+    //     known target, the fold is suppressed => result 3, truncations 0.
+    const saved = compiler.prescan_expansion_limit;
+    defer compiler.prescan_expansion_limit = saved;
+
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval(
+        \\(define-syntax gen (syntax-rules () ((_) (syntax-rules () ((_ x) x)))))
+    );
+    _ = try ctx.vm.eval(
+        \\(define-syntax rebind (syntax-rules () ((_ a b) (set! a b))))
+    );
+
+    compiler.prescan_expansion_limit = 1;
+    const before = compiler.prescan_truncations;
+    const result = try ctx.vm.eval(
+        \\(let-syntax ((local-id (gen)))
+        \\  (define (f) (+ 5 2))
+        \\  (rebind + -)
+        \\  (local-id (f)))
+    );
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+    try std.testing.expectEqual(@as(u64, 0), compiler.prescan_truncations - before);
+}
+
 test "#1775: ordinary code does not trigger the pre-scan fallback" {
     // The default limit must leave normal programs alone: truncation costs
     // ~2x runtime (every local boxed, nothing folded), so it has to stay a

--- a/tests/scheme/hygiene/quote-shadow-boxing.scm
+++ b/tests/scheme/hygiene/quote-shadow-boxing.scm
@@ -1,0 +1,39 @@
+;; A let-syntax macro bound under the name `quote` (R7RS lets a binding
+;; shadow any keyword) whose template mutates an enclosing local, driven
+;; through a re-entrant continuation (#1168's shape).
+;;
+;; The set! pre-scan cannot see this target early: the binding's name
+;; derails a naive walk (kaappi#1802's let-syntax scan handles the spec
+;; positions individually for exactly that reason), and at pre-scan time
+;; the macro isn't registered yet, so the use site can't be expanded
+;; either. Termination therefore depends on the late path: Part B
+;; (scanSetTargets at real expansion) discovering the target and the
+;; box_local transition boxing the already-bound local after the fact.
+;; If that late-boxing self-heal ever regresses, this test hangs rather
+;; than terminating at 3.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "quote-shadow-boxing")
+
+(test-equal "quote-named macro's set! target is boxed late"
+  3
+  (let ((n 0) (k* #f))
+    (let-syntax ((quote (syntax-rules () ((_) (set! n (+ n 1))))))
+      (call/cc (lambda (k) (set! k* k)))
+      (quote)
+      (if (< n 3) (k* #f))
+      n)))
+
+;; Same shape but the shadowing macro also fires in result position, and
+;; the template target is a literal global — exercises the spec-position
+;; walk (the binding pair must not be misread as a quote form).
+(test-equal "quote-named macro rebinding a global"
+  3
+  (let-syntax ((quote (syntax-rules () ((_) (set! + -)))))
+    (define (f) (+ 5 2))
+    (quote)
+    (f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "quote-shadow-boxing")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #1802.

## What was actually superlinear

`(import (srfi 148))` on the drafted 134-definition library took **86.6s** (17/34/67/100/134 truncation points: 0.4s / 6.7s / 13.1s / 63.5s / 86.6s). A `sample` profile — per the #1775 discipline of profiling the caller, not guessing from the stage — put ~96% of wall time under `compiler.collectSetTargets`, and the hottest leaf (19,078 of 19,489 samples) was **`_memset`**, called from `expandMacro`, `matchListPattern` (inlined `matchEllipsis`), and `instantiateEllipsis`.

Neither of the issue's two candidate hypotheses was the driver. Two compounding causes:

### 1. Zig 0.16 ReleaseSafe fills `= undefined` locals — and the old suppression idiom now *causes* the fill

The expander declares three ~1MB `[MAX_BINDINGS]Binding` scratch buffers (128 bindings × 8,232 bytes, dominated by the inline `ellipsis_values: [1024]Value` field), one per call of `expandMacro` / `matchEllipsis` / `instantiateEllipsis`. Disassembly showed each call executing `memset(buf, 0xAA, 0x101400)` — exactly the fill the existing `b: { @setRuntimeSafety(false); break :b undefined; }` initializer was written to prevent. Under Zig 0.16 that block materializes a runtime undefined value whose **store** into the local gets the safety fill anyway; minimal-repro objects confirmed the only working shape is `@setRuntimeSafety(false)` at the **declaration's scope**. Each function now declares its buffers under a safety-off function scope and runs its entire body inside a `@setRuntimeSafety(true)` block, so index/overflow checks are unaffected. Confirmed by disassembly: no 0xAA memset remains in any of the three functions.

This half alone: 86.6s → 0.28s, and it speeds up every macro-heavy compile (SRFI 257, match-style macros), not just SRFI 148.

### 2. The `set!` pre-scan speculatively ran the CK machine inside transformer specs

The budgeted pre-scan (#1775) treats a transformer spec as ordinary code, so `(define-syntax em-cadr (em-syntax-rules ...))` speculatively expanded the whole SRFI 147/148 resolution chain once per definition — burning the full 4096-expansion budget, and with it the truncation fallback (`set_targets_all` ⇒ box every local), on forms that produce **no runtime code at all**. A spec only ever resolves to a compile-time transformer object; it cannot contribute a runtime `set!` to its own form. `collectSetTargets` now walks `define-syntax` / `let-syntax` / `letrec-syntax` spec positions with the null budget (no macro expansion — literal `set!`s in templates are still found by the plain walk, exactly what Part B mode does); `let-syntax`/`letrec-syntax` **bodies** keep the budgeted scan. The macro-shadowing precedence (SRFI 219-style) is preserved: the check sits after the macro lookup, so a macro literally named `define-syntax` still expands. A `set!` that only materializes when the spec's own macros run is caught at the macro's real use site — the same correct-late Part B path every divergent best-effort expansion already takes (empty `UseSiteBindingCheck`, budget truncation).

This also stops a real pessimization: previously any form mixing an `em-syntax-rules`-style definition with real code truncated its scan and boxed every local in the form. And it keeps Debug builds (where the fill is by-design) from paying the CK-machine cost in the pre-scan.

## Results

| | before | after |
|---|---|---|
| `(import (srfi 148))`, 134 definitions | 86.6s | **0.07s** |
| `--timings` expand stage | 185ms (after fix 1 alone) | 10.5ms |
| Full upstream SRFI 148 reference suite | blocked (import alone exceeded the 60s per-file timeout) | **0.85s**, 134 expected passes / 8 known xfails (#1800/#1801) |
| Truncation-point curve 17/34/67/100/134 | 0.4 / 6.7 / 13.1 / 63.5 / 86.6s | flat: 0.01 / 0.03 / 0.05 / 0.20 / 0.06s (user) |

## Tests

- Two new regression tests in `tests_prescan.zig`, both **verified to fail with the `collectSetTargets` change reverted** (mutation-tested): a spec-position macro use must consume zero budget at limit 0; and a limit-1 `let-syntax` form distinguishes spec-burns-budget (truncation), body-loses-scan (wrong fold ⇒ result 7), and correct (result 3, zero truncations).
- The buffer-fill half can't be unit-tested from Zig (Debug test builds fill by design); it is pinned by disassembly, loud comments at all three sites, and a new "When the profile bottoms out in `memset`" entry in `docs/dev/performance.md`. The real-world guard is the SRFI 148 suite itself, which lands with #1699's final slice now that this unblocks it.
- `zig build test` (full unit suite), gc-stress spot check (`tests_prescan`, `tests_macros`), and the full Scheme suite all green: **602 files pass, 0 fail, 0 timeout; R7RS 1395/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)