### PR TITLE
Lower `apply` natively in the LLVM backend (#1803)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,8 +175,11 @@ FFI-`dlopen` directory, so an archive placed there is invisible to
 **Features compiled natively:** arithmetic, comparisons, if/and/or/when/unless,
 let/let*, cond/case/do, lambda (with closures and variadic parameters),
 self-tail-call optimization (compiled as loops), tail calls to other native
-functions. Forms not yet compiled natively (letrec, named-let, guard,
-quasiquote, `apply`, `call/cc`, `call-with-values`, `eval`, …) run through
+functions, and `apply` (lowered to the argument-splicing `@kaappi_apply`
+runtime call, so an enclosing function keeps its native compilation —
+kaappi#1803; the dispatch mirrors the interpreter's tail/non-tail/shadowed
+cases exactly). Forms not yet compiled natively (letrec, named-let, guard,
+quasiquote, `call/cc`, `call-with-values`, `eval`, …) run through
 `kaappi_eval` at runtime — and because that eval resolves names in the *global*
 environment, any lexical scope containing one (the enclosing `define`/`lambda`
 frame or `let`) declines native compilation as a whole rather than splitting

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -394,14 +394,15 @@ past the fixed arity before branching, so variadic named functions loop too
 - contains an eval-fallback form (`letrec`, `guard`, named `let`, …), or a
   `cond`/`case`/`do` whose clauses themselves reach one (kaappi#1496);
 - contains a keyword-only special form that reaches the interpreter as a whole
-  `passthrough` — `apply`, `call/cc`,
-  `call-with-current-continuation`, `call-with-values`, `eval` (kaappi#1799);
+  `passthrough` — `call/cc`, `call-with-current-continuation`,
+  `call-with-values`, `eval` (kaappi#1799; `apply` left this set when it got
+  its own native lowering, kaappi#1803 — see below);
 - contains an internal `define` (the closure tier sets up no locals scope for
   it), or a rest parameter that is captured and mutated (no box model yet); or
 - captures an unmutated `let`-local, or a rest parameter, that has no copyable
   slot.
 
-### Why `apply` declines the whole enclosing scope (kaappi#1799)
+### Why `call/cc` & friends decline the whole enclosing scope (kaappi#1799)
 
 All four native-compilation gates — the two closure tiers,
 `tryCompileDefineFunction`, and `emitLet` — ask
@@ -414,16 +415,16 @@ compiles natively, its body's `passthrough` is serialized and run by
 `undefined variable 'xs'` — or, worse, silently read an unrelated global of the
 same name.
 
-The five keywords above were missing because the `passthrough` **node** is
-`.capability = .native` in `llvm_node_table`, which is right for the one shape
-`emitPassthrough` compiles (a `(define (f …) …)` shorthand) and wrong for every
-other. They are contributed instead by `ir.other_special_forms`, whose `bool`
-payload records exactly "an evaluated form headed by this keyword becomes a
-passthrough the interpreter runs". `else`, `=>`, `_`, `...`,
-`unquote`/`unquote-splicing` and the keywords `lowerFormWithMacros` intercepts
-earlier are deliberately `false`: `sexprNeedsEvalFallback` recurses blindly into
-sub-forms, so listing `else` would reject every natively lowered `cond`/`case`
-with an else clause.
+The five keywords (then including `apply`) were missing because the
+`passthrough` **node** is `.capability = .native` in `llvm_node_table`, which
+is right for the one shape `emitPassthrough` compiles (a `(define (f …) …)`
+shorthand) and wrong for every other. They are contributed instead by
+`ir.other_special_forms`, whose `bool` payload records exactly "an evaluated
+form headed by this keyword becomes a passthrough the interpreter runs".
+`else`, `=>`, `_`, `...`, `unquote`/`unquote-splicing` and the keywords
+`lowerFormWithMacros` intercepts earlier are deliberately `false`:
+`sexprNeedsEvalFallback` recurses blindly into sub-forms, so listing `else`
+would reject every natively lowered `cond`/`case` with an else clause.
 
 Publishing the frame's bindings as globals instead (`bindParamsAsGlobals`,
 the kaappi#1410 mechanism the `letrec`/`let` fallbacks use) is **not** an
@@ -431,9 +432,44 @@ alternative here: it aliases across activations, it cannot see `let`-locals at
 all, and it permanently clobbers a same-named global. Declining the frame is
 what keeps the interpreter's own lexical scope authoritative.
 
-The cost is that a function using `apply` is not natively compiled at all.
-`(apply + xs)` is idiomatic Scheme, so this is a real limitation of the current
-backend rather than a corner case.
+### Native `apply` (kaappi#1803)
+
+Declining is all-or-nothing for the enclosing function, and `(apply + xs)` is
+idiomatic Scheme: one `apply` that runs once de-optimized every other
+expression in the body (~19x on kaappi#1803's arithmetic-loop reproducer). So
+`apply` — alone among the passthrough keywords — is lowered natively.
+`emitPassthrough` routes an `(apply …)` head inside a lexical scope to
+`emitApplyForm` (`llvm_emit.zig`), which mirrors the interpreter's own dispatch
+(`compiler.zig`) case for case:
+
+- **tail + unshadowed + ≥2 operands** — structural apply with built-in
+  semantics: the callee and fixed arguments are emitted like `emitCallNode`'s,
+  and the final operand is passed as a Value to `@kaappi_apply`
+  (`runtime_exports.zig`), which splices it with `primitives.applyFn`'s exact
+  semantics — same `isProcedure` validation, same tortoise-and-hare
+  proper-list check (a circular list raises rather than hangs), same
+  `typeError` texts. The interpreter's `tail_apply` opcode ignores a top-level
+  rebinding of `apply`, so this path deliberately does too.
+- **tail + unshadowed + <2 operands** — the interpreter raises InvalidSyntax
+  at compile time; abandoning native compilation of the enclosing scope
+  (`error.UnsupportedNodeType`) routes the form to that exact error.
+- **everything else resolvable** — a lexically shadowed `apply`, or a non-tail
+  form that is rebound or has too few operands — is an ordinary indirect call
+  through whatever `apply` resolves to in scope, matching the interpreter's
+  plain `call_global`/local call.
+
+Two consequences worth knowing. First, the free-variable analyses
+(`nodeHasFreeVars`/`collectNodeFreeVars` in `llvm_emit_freevars.zig`) walk an
+apply `passthrough`'s raw operands — a capture inside one must become a closure
+upvalue, or it would be emitted as a global lookup (#1799's failure mode in a
+new spot). Second, a **tail `(apply f xs)` is not a real tail call across the
+runtime boundary**: `@kaappi_apply` re-enters the VM via `callWithArgs`, so a
+deep apply-driven self-recursion grows the native stack where the interpreter
+runs in constant space. This is the same pre-existing divergence class as any
+computed-operator tail call through `kaappi_call_scheme` (verified: both
+overflow around the same depth), not a new one — the emitter still balances
+the frame's GC roots before the `ret` so the shadow stack never leaks
+(#1498/#1585).
 
 The per-function analysis buffers (parameters, body nodes, captured free
 variables, bound names) grow on the emitter's arena, so the only size ceiling is

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -496,9 +496,9 @@ pub const sexpr_form_map = std.StaticStringMap(FormKind).initComptime(.{
 // failed at run time with "undefined variable 'xs'"). `isSpecialForm`, which every other caller
 // uses, ignores the payload entirely.
 //
-// `false` covers the two kinds of keyword that never reach `emitPassthrough` as
-// an evaluated head, and whose presence in the name set would wrongly reject
-// natively-lowered code wholesale:
+// `false` covers the three kinds of keyword that must stay OUT of the name
+// set, because their presence would wrongly reject natively-lowered code
+// wholesale:
 //
 //   - the ones `lowerFormWithMacros` intercepts before the `isSpecialForm`
 //     check — `if`, `lambda`, `let`, `define`, … (`letrec`/`letrec*` still
@@ -506,7 +506,11 @@ pub const sexpr_form_map = std.StaticStringMap(FormKind).initComptime(.{
 //   - syntax-position keywords that only ever appear *inside* another form:
 //     `else`/`=>` inside `cond`/`case` (both natively lowered, kaappi#1496),
 //     `_`/`...` inside `syntax-rules` patterns, and `unquote`/`unquote-splicing`
-//     inside `quasiquote` (already a fallback form in its own right).
+//     inside `quasiquote` (already a fallback form in its own right);
+//   - `apply`, which DOES reach `emitPassthrough` as an evaluated head but is
+//     lowered natively there inside a lexical scope (emitApplyForm →
+//     @kaappi_apply, kaappi#1803), so the enclosing frame keeps its native
+//     compilation instead of paying the whole-function fallback.
 const other_special_forms = std.StaticStringMap(bool).initComptime(.{
     .{ "quote", false },
     .{ "if", false },
@@ -524,7 +528,7 @@ const other_special_forms = std.StaticStringMap(bool).initComptime(.{
     .{ "letrec*", false },
     .{ "syntax-error", true },
     .{ "syntax-rules", true },
-    .{ "apply", true },
+    .{ "apply", false },
     .{ "call-with-values", true },
     .{ "call-with-current-continuation", true },
     .{ "call/cc", true },

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -440,7 +440,7 @@ pub const LLVMEmitter = struct {
             .let_star => try let_emit.emitLet(self, node.data.let_star.args, true, node.ann.is_tail),
             .letrec => try self.emitLetEvalFallback(node.data.letrec.args, "letrec"),
             .letrec_star => try self.emitLetEvalFallback(node.data.letrec_star.args, "letrec*"),
-            .passthrough => try self.emitPassthrough(node.data.passthrough),
+            .passthrough => try self.emitPassthrough(node.data.passthrough, node.ann.is_tail),
             .sexpr_form => try self.emitSexprEval(node),
         };
     }
@@ -1103,9 +1103,20 @@ pub const LLVMEmitter = struct {
         return self.emitCachedEval(source_buf.items);
     }
 
-    fn emitPassthrough(self: *LLVMEmitter, expr: Value) EmitError![]const u8 {
+    fn emitPassthrough(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![]const u8 {
         if (types.isPair(expr)) {
             const head = types.car(expr);
+            // (apply …) lowers natively inside a lexical scope (kaappi#1803):
+            // the pre-#1803 whole-form eval fallback runs in the GLOBAL
+            // environment and would lose the frame's bindings (#1799). At top
+            // level the eval fallback below stays the right choice — it is the
+            // global environment, and whole-form eval keeps macro uses in
+            // operand position expanding correctly.
+            if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "apply") and
+                self.inLexicalScope())
+            {
+                return self.emitApplyForm(expr, is_tail);
+            }
             if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "define")) {
                 const rest = types.cdr(expr);
                 if (rest != types.NIL and types.isPair(rest)) {
@@ -1139,6 +1150,144 @@ pub const LLVMEmitter = struct {
             }
         }
         return self.emitEvalExpr(expr);
+    }
+
+    // Native lowering of an `(apply f arg… lst)` passthrough inside a lexical
+    // scope (kaappi#1803), mirroring the interpreter's own dispatch
+    // (compiler.zig / compileApplyTail) case for case:
+    //
+    //   - tail + unshadowed + ≥2 operands → structural apply with built-in
+    //     semantics (the interpreter's tail_apply opcode ignores a top-level
+    //     rebinding of `apply`, so the fast path must too): @kaappi_apply
+    //     splices the final operand at run time.
+    //   - tail + unshadowed + <2 operands → the interpreter's compileApplyTail
+    //     raises InvalidSyntax at compile time; abandoning native compilation
+    //     routes the enclosing form to that exact error.
+    //   - everything else — lexically shadowed `apply` (any shape), or a
+    //     non-tail form that is rebound/natively redefined or has <2 operands
+    //     — is an ordinary indirect call through whatever `apply` resolves to
+    //     in scope (emitGlobalRef's lexical order), matching the interpreter's
+    //     plain call: a shadowed binding IS the callee, and the built-in's own
+    //     arity check raises the interpreter's exact runtime error for the
+    //     too-few-operands shapes.
+    //
+    // A malformed (improper) operand list abandons native compilation of the
+    // enclosing scope — the eval fallback would run in the global environment
+    // and lose the frame's bindings (#1799) — so the interpreter reports the
+    // syntax error for the whole enclosing form.
+    fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![]const u8 {
+        var operands: std.ArrayList(Value) = .empty;
+        defer operands.deinit(self.backing_alloc);
+        var cur = types.cdr(expr);
+        while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+            operands.append(self.backing_alloc, types.car(cur)) catch return error.OutOfMemory;
+        }
+        if (cur != types.NIL) return error.UnsupportedNodeType;
+
+        const shadowed = self.isNameShadowed("apply");
+        const rebound = self.rebound_globals.contains("apply") or
+            self.native_fns.contains("apply");
+
+        if (!shadowed and is_tail and operands.items.len < 2)
+            return error.UnsupportedNodeType;
+
+        const is_builtin_apply = !shadowed and (is_tail or !rebound);
+
+        if (is_builtin_apply and operands.items.len >= 2) {
+            const n_fixed = operands.items.len - 2;
+            const callee = try self.emitScopedOperand(operands.items[0]);
+            // Root the callee and every fixed argument across the remaining
+            // operand emissions (each can allocate). The final list operand
+            // needs no root: nothing allocates between its value and the call
+            // (emitCallNode's discipline for its own last argument).
+            var root_count: usize = 1;
+            try self.emitRootPush(callee);
+            const fixed_tmps = self.allocator().alloc([]const u8, n_fixed) catch return error.OutOfMemory;
+            for (0..n_fixed) |i| {
+                fixed_tmps[i] = try self.emitScopedOperand(operands.items[1 + i]);
+                try self.emitRootPush(fixed_tmps[i]);
+                root_count += 1;
+            }
+            const list_tmp = try self.emitScopedOperand(operands.items[operands.items.len - 1]);
+            try self.emitPopRoots(root_count);
+
+            const result = try self.freshTemp();
+            if (n_fixed == 0) {
+                const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
+                try self.print("  {s} = {s} i64 @kaappi_apply(ptr %vm, i64 {s}, ptr null, i64 0, i64 {s})\n", .{ result, call_prefix, callee, list_tmp });
+            } else {
+                const args_alloca = try self.freshTemp();
+                try self.print("  {s} = alloca [{d} x i64], align 8\n", .{ args_alloca, n_fixed });
+                for (0..n_fixed) |i| {
+                    const gep = try self.freshTemp();
+                    try self.print("  {s} = getelementptr [1 x i64], ptr {s}, i64 {d}\n", .{ gep, args_alloca, i });
+                    try self.print("  store i64 {s}, ptr {s}\n", .{ fixed_tmps[i], gep });
+                }
+                try self.print("  {s} = call i64 @kaappi_apply(ptr %vm, i64 {s}, ptr {s}, i64 {d}, i64 {s})\n", .{ result, callee, args_alloca, n_fixed, list_tmp });
+            }
+
+            if (is_tail) {
+                // Balance the frame-entry GC roots and any live let-binding
+                // roots before returning through this tail call, exactly as
+                // emitCallNode does (#1498/#1585) — a deep apply-driven loop
+                // must not leak one root set per iteration.
+                try self.emitPopRoots(self.frame_entry_roots + self.body_scope_roots);
+                try self.print("  ret i64 {s}\n", .{result});
+                try self.emitOrphanAfterTail();
+            }
+            return result;
+        }
+
+        // Generic path: resolve `apply` like any variable reference (a
+        // parameter, local, upvalue, or the current global binding) and call
+        // it with the operands — emitCallNode's indirect-call tail, inlined.
+        const callee = try self.emitGlobalRef(types.car(expr));
+        const nargs = operands.items.len;
+        var root_count: usize = 0;
+        if (nargs > 0) {
+            try self.emitRootPush(callee);
+            root_count += 1;
+        }
+        const arg_tmps = self.allocator().alloc([]const u8, nargs) catch return error.OutOfMemory;
+        for (operands.items, 0..) |operand, i| {
+            arg_tmps[i] = try self.emitScopedOperand(operand);
+            if (i + 1 < nargs) {
+                try self.emitRootPush(arg_tmps[i]);
+                root_count += 1;
+            }
+        }
+        try self.emitPopRoots(root_count);
+
+        const result = try self.freshTemp();
+        if (nargs == 0) {
+            const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
+            try self.print("  {s} = {s} i64 @kaappi_call_scheme(ptr %vm, i64 {s}, ptr null, i64 0)\n", .{ result, call_prefix, callee });
+        } else {
+            const args_alloca = try self.freshTemp();
+            try self.print("  {s} = alloca [{d} x i64], align 8\n", .{ args_alloca, nargs });
+            for (0..nargs) |i| {
+                const gep = try self.freshTemp();
+                try self.print("  {s} = getelementptr [1 x i64], ptr {s}, i64 {d}\n", .{ gep, args_alloca, i });
+                try self.print("  store i64 {s}, ptr {s}\n", .{ arg_tmps[i], gep });
+            }
+            try self.print("  {s} = call i64 @kaappi_call_scheme(ptr %vm, i64 {s}, ptr {s}, i64 {d})\n", .{ result, callee, args_alloca, nargs });
+        }
+        if (is_tail) {
+            try self.emitPopRoots(self.frame_entry_roots + self.body_scope_roots);
+            try self.print("  ret i64 {s}\n", .{result});
+            try self.emitOrphanAfterTail();
+        }
+        return result;
+    }
+
+    // Lower one raw apply operand to IR and emit it in the current lexical
+    // scope. Operands are never in tail position. A lowering failure (a
+    // resource limit or malformed leaf) abandons native compilation of the
+    // enclosing scope — emitScopedValue's emitEvalExpr fallback would run the
+    // operand in the global environment, the exact #1799 failure mode.
+    fn emitScopedOperand(self: *LLVMEmitter, operand: Value) EmitError![]const u8 {
+        const node = ir.lowerSingleExpr(self.allocator(), operand) catch return error.UnsupportedNodeType;
+        return self.emitNode(node);
     }
 
     // Build the runtime Value for a natively-compiled top-level function as a

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -12,10 +12,12 @@
 // native/interpreted boundary).
 //
 // The gate deliberately rejects `lambda`, `=>` clauses, and every eval-fallback
-// / passthrough special form (letrec, guard, apply, call/cc, …) and any macro
-// use. Rejecting lambdas also sidesteps do's fresh-binding-per-iteration
-// semantics: with no closure able to capture a loop variable, mutable allocas
-// updated in place are observably equivalent.
+// / passthrough special form (letrec, guard, call/cc, …) and any macro use —
+// but not `apply`, which the backend lowers natively inside a lexical scope
+// (emitApplyForm → @kaappi_apply, kaappi#1803). Rejecting lambdas also
+// sidesteps do's fresh-binding-per-iteration semantics: with no closure able
+// to capture a loop variable, mutable allocas updated in place are observably
+// equivalent.
 
 const std = @import("std");
 const ir = @import("ir.zig");
@@ -379,17 +381,17 @@ fn isKeyword(v: Value, name: []const u8) bool {
 // the interpreter as a whole.
 fn isRejectedFormHead(name: []const u8) bool {
     const rejected = [_][]const u8{
-        "lambda",           "letrec",                         "letrec*",
-        "guard",            "quasiquote",                     "delay",
-        "delay-force",      "parameterize",                   "define-values",
-        "let-values",       "let*-values",                    "define-syntax",
-        "let-syntax",       "letrec-syntax",                  "cond-expand",
-        "case-lambda",      "define",                         "define-record-type",
-        "apply",            "call-with-current-continuation", "call/cc",
-        "call-with-values", "eval",                           "import",
-        "include",          "include-ci",                     "define-library",
-        "syntax-rules",     "syntax-error",                   "unquote",
-        "unquote-splicing", "else",                           "=>",
+        "lambda",                         "letrec",         "letrec*",
+        "guard",                          "quasiquote",     "delay",
+        "delay-force",                    "parameterize",   "define-values",
+        "let-values",                     "let*-values",    "define-syntax",
+        "let-syntax",                     "letrec-syntax",  "cond-expand",
+        "case-lambda",                    "define",         "define-record-type",
+        "call-with-current-continuation", "call/cc",        "call-with-values",
+        "eval",                           "import",         "include",
+        "include-ci",                     "define-library", "syntax-rules",
+        "syntax-error",                   "unquote",        "unquote-splicing",
+        "else",                           "=>",
     };
     for (rejected) |r| {
         if (std.mem.eql(u8, name, r)) return true;

--- a/src/llvm_emit_freevars.zig
+++ b/src/llvm_emit_freevars.zig
@@ -351,9 +351,27 @@ fn nodeHasFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []c
             .cond, .case_form, .do_form => return sexprFormHasFreeVars(self, node.data.sexpr_form.form, node.data.sexpr_form.args, params),
             else => return false,
         },
-        .passthrough => return false,
+        // A natively lowered `(apply …)` keeps its operands as a raw
+        // S-expression (kaappi#1803); walk them like any other expression
+        // tree, or a capture inside one is invisible and the closure tiers
+        // emit the name as a global lookup — #1799's exact failure mode.
+        // Every other passthrough shape still declines the enclosing scope
+        // upstream (sexprNeedsEvalFallback), so it never reaches a native
+        // body and reports none.
+        .passthrough => {
+            if (isApplyForm(node.data.passthrough))
+                return sexprHasFreeVars(self, node.data.passthrough, params);
+            return false;
+        },
         .letrec, .letrec_star => return false,
     }
+}
+
+// True for a pair whose head is the symbol `apply` — the one passthrough
+// shape the backend lowers natively inside a lexical scope (kaappi#1803).
+fn isApplyForm(expr: Value) bool {
+    return types.isPair(expr) and types.isSymbol(types.car(expr)) and
+        std.mem.eql(u8, types.symbolName(types.car(expr)), "apply");
 }
 
 // Walk a raw S-expression (a set! target or value) with binder scoping,
@@ -446,7 +464,14 @@ fn collectNodeFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const
             .cond, .case_form, .do_form => return collectSexprFormFreeVars(self, node.data.sexpr_form.form, node.data.sexpr_form.args, params, list),
             else => return true,
         },
-        .constant, .define, .passthrough => return true,
+        // Collect captures inside a natively lowered `(apply …)` form's
+        // operands (kaappi#1803) — see the nodeHasFreeVars arm above.
+        .passthrough => {
+            if (isApplyForm(node.data.passthrough))
+                return collectSexprFreeVars(self, node.data.passthrough, params, list);
+            return true;
+        },
+        .constant, .define => return true,
         .letrec, .letrec_star => return true,
     }
 }

--- a/src/native_decls.zig
+++ b/src/native_decls.zig
@@ -30,6 +30,8 @@ pub const decls: []const Decl = &.{
     .{ .export_name = "kaappi_set_command_line_args", .scheme_name = null, .param_types = &.{ .ptr, .ptr }, .ret = .void_ty, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_global_lookup", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_call_scheme", .scheme_name = null, .param_types = &.{ .ptr, .i64, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
+    // Argument-splicing call for natively lowered `apply` (kaappi#1803).
+    .{ .export_name = "kaappi_apply", .scheme_name = null, .param_types = &.{ .ptr, .i64, .ptr, .i64, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_define_global", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64, .i64 }, .ret = .void_ty, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_set_global", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64, .i64 }, .ret = .void_ty, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_make_string", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -433,6 +433,56 @@ pub export fn kaappi_call_scheme(vm: ?*vm_mod.VM, callee: u64, args_ptr: ?[*]con
     return result;
 }
 
+// Argument-splicing call for natively lowered `apply` (kaappi#1803): call
+// `callee` with fixed_args[0..n_fixed] followed by the elements of `list`.
+// The body is primitives.applyFn minus the argument shuffling, and must stay
+// semantically in lockstep with it: the same isProcedure/isNativeFn
+// validation, the same tortoise-and-hare cycle detection (a circular list
+// raises instead of hanging), and the same typeError texts, so a compiled
+// binary's diagnostics match the interpreter's verbatim.
+pub export fn kaappi_apply(vm: ?*vm_mod.VM, callee: u64, fixed_args: ?[*]const u64, n_fixed: u64, list: u64) callconv(.c) u64 {
+    const v = vm orelse {
+        _ = platform.write(2, "apply: null vm\n", 15);
+        std.process.exit(1);
+    };
+    return applySpliced(v, callee, fixed_args, n_fixed, list) catch |err|
+        fatalVMError(v, "runtime error in apply", err);
+}
+
+fn applySpliced(v: *vm_mod.VM, callee: u64, fixed_args: ?[*]const u64, n_fixed: u64, list: u64) !u64 {
+    if (!types.isProcedure(callee) and !types.isNativeFn(callee))
+        return primitives.typeError("apply", "procedure", callee);
+
+    // Plain (non-GC) heap storage, same as applyFn's call_args: appending
+    // never allocates a heap object, so nothing here can trigger a collection
+    // before callWithArgs takes over (which roots the arguments in registers).
+    var call_args: std.ArrayList(Value) = .empty;
+    defer call_args.deinit(v.gc.allocator);
+
+    const n: usize = @intCast(n_fixed);
+    if (n > 0 and fixed_args != null) {
+        call_args.appendSlice(v.gc.allocator, fixed_args.?[0..n]) catch
+            return error.OutOfMemory;
+    }
+
+    // Flatten the last argument (must be a proper list).
+    var rest = list;
+    var slow = rest;
+    var step: bool = false;
+    while (rest != types.NIL) {
+        if (!types.isPair(rest)) return primitives.typeError("apply", "proper list", rest);
+        call_args.append(v.gc.allocator, types.car(rest)) catch return error.OutOfMemory;
+        rest = types.cdr(rest);
+        if (step) {
+            slow = types.cdr(slow);
+            if (slow == rest) return primitives.typeError("apply", "proper list", rest);
+        }
+        step = !step;
+    }
+
+    return v.callWithArgs(callee, call_args.items);
+}
+
 // Shadow-stack GC rooting for natively compiled code.
 // The LLVM emitter stores intermediate Values in alloca slots and registers
 // them here so the GC can see them during collection.

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -194,6 +194,7 @@ test "LLVM emit: preamble declares runtime functions" {
     try expectContains(ll, "declare void @kaappi_set_command_line_args(ptr, ptr)");
     try expectContains(ll, "declare i64 @kaappi_global_lookup(ptr, ptr, i64)");
     try expectContains(ll, "declare i64 @kaappi_call_scheme(ptr, i64, ptr, i64)");
+    try expectContains(ll, "declare i64 @kaappi_apply(ptr, i64, ptr, i64, i64)");
     try expectContains(ll, "declare i64 @kaappi_fixnum_add(i64, i64)");
     try expectContains(ll, "declare i64 @kaappi_cons(i64, i64)");
     try expectContains(ll, "declare i64 @kaappi_car(i64)");
@@ -739,7 +740,7 @@ test "native declare table covers all runtime exports in preamble" {
             return error.TestExpectedEqual;
         }
     }
-    try std.testing.expectEqual(@as(usize, 27), native_decls.decls.len);
+    try std.testing.expectEqual(@as(usize, 28), native_decls.decls.len);
 }
 
 // -- Compile-once eval-fallback cache (#1494) --
@@ -1222,21 +1223,22 @@ test "LLVM emit: a lambda capturing a param through a cond gets an upvalue (#149
     try std.testing.expect(std.mem.indexOf(u8, ll, "c\"base\"") == null);
 }
 
-test "LLVM emit: a cond containing apply falls back rather than mis-scoping (#1496)" {
-    // apply is a passthrough form the native path can't lower in a lexical
-    // scope; the whole enclosing function must fall back to the interpreter,
-    // not emit a native cond that evaluates apply in the global environment.
+test "LLVM emit: a cond containing apply lowers natively (#1496 → #1803)" {
+    // apply used to be a rejected form head that sent the whole enclosing
+    // function to the interpreter; emitApplyForm now lowers it inside the
+    // native cond arm, resolving `lst` against the parameter slot.
     var res = try emitMultiResult("(define (f lst) (cond ((null? lst) 0) (else (apply + lst))))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectNotContains(ll, "cond_merge_");
-    try std.testing.expect(countEvalFallbacks(ll) >= 1);
+    try expectContains(ll, "cond_merge_");
+    try expectContains(ll, "@kaappi_apply(ptr %vm");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
 // -- Passthrough forms must not be evaluated inside a native scope (#1799) --
 //
-// `emitPassthrough` hands an `apply` / `call/cc` / `call-with-values` / `eval`
-// form to the interpreter as source text, and `kaappi_eval` runs in the GLOBAL
+// `emitPassthrough` hands a `call/cc` / `call-with-values` / `eval` form to
+// the interpreter as source text, and `kaappi_eval` runs in the GLOBAL
 // environment. The keywords producing such a form therefore have to be in
 // `ir.eval_fallback_form_names`, the set `freevars.sexprNeedsEvalFallback`
 // consults, so all four native-compilation gates (the two closure tiers,
@@ -1247,45 +1249,117 @@ test "LLVM emit: a cond containing apply falls back rather than mis-scoping (#14
 // rest), and nothing else contributed their keywords. So a body using `apply`
 // compiled natively — `apply` is an `isKnownGlobal`, so it passed free-variable
 // analysis too — and the eval fallback raised "undefined variable 'xs'" at run
-// time. The three shapes below are the ones the bug report characterized.
+// time.
+//
+// `apply` has since left the fallback set (kaappi#1803): the same shapes now
+// stay native, with the form lowered to @kaappi_apply by emitApplyForm, so
+// these tests assert the native lowering instead of the decline. The
+// behavior-parity suite (tests/scheme/compile/native-apply-lexical-scope-1799.sh)
+// is unchanged — compiled output must still agree with the interpreter.
 
-test "LLVM emit: apply over a parameter declines native compilation (#1799)" {
+test "LLVM emit: apply over a parameter lowers natively (#1799 → #1803)" {
     var res = try emitMultiResult("(define (s xs) (apply + xs))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectNoNativeDef(ll, "s");
-    // The whole define crosses to the interpreter, which owns the lexical frame.
-    try expectContains(ll, "(define (s xs) (apply + xs))");
-    try std.testing.expect(countEvalFallbacks(ll) >= 1);
+    try expectNativeDef(ll, "s");
+    try expectContains(ll, "@kaappi_apply(ptr %vm");
+    // The whole program compiles natively: nothing crosses to the interpreter.
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
-test "LLVM emit: apply over a let-bound name declines native compilation (#1799)" {
+test "LLVM emit: apply over a let-bound name lowers natively (#1799 → #1803)" {
     var res = try emitMultiResult("(define (s) (let ((xs (list 1 2 3))) (apply + xs)))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectNoNativeDef(ll, "s");
-    try expectContains(ll, "(define (s) (let ((xs (list 1 2 3))) (apply + xs)))");
-    try std.testing.expect(countEvalFallbacks(ll) >= 1);
+    try expectNativeDef(ll, "s");
+    try expectContains(ll, "@kaappi_apply(ptr %vm");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
-test "LLVM emit: a bare let whose body applies falls back whole (#1799)" {
-    // emitLet's own #827 gate, with no enclosing define to decline first: the
-    // let must be evaluated as one form, not lowered to native allocas whose
-    // body then resolves `xs` in the global environment.
+test "LLVM emit: a bare let whose body applies lowers natively (#1799 → #1803)" {
+    // emitLet's #827 gate no longer rejects apply: the let lowers to native
+    // allocas and the body's apply resolves `xs` against them.
     var res = try emitMultiResult("(let ((xs (list 1 2 3))) (display (apply + xs)))");
     defer res.deinit();
     const ll = res.toSlice();
-    try expectContains(ll, "(let ((xs (list 1 2 3))) (display (apply + xs)))");
-    try std.testing.expect(countEvalFallbacks(ll) >= 1);
+    try expectNotContains(ll, "(let ((xs (list 1 2 3))) (display (apply + xs)))");
+    try expectContains(ll, "@kaappi_apply(ptr %vm");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
 }
 
-test "LLVM emit: apply with a computed operator declines native compilation (#1799)" {
-    // The operator position is as lexical as the argument list: `f` was named
-    // by the same "undefined variable" error before the fix.
+test "LLVM emit: apply with a computed operator lowers natively (#1799 → #1803)" {
+    // The operator position is as lexical as the argument list: `f` resolves
+    // to the parameter slot, not a global.
     var res = try emitMultiResult("(define (s f xs) (apply f xs))");
     defer res.deinit();
     const ll = res.toSlice();
+    try expectNativeDef(ll, "s");
+    try expectContains(ll, "@kaappi_apply(ptr %vm");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: apply with fixed arguments packs an argv alloca (#1803)" {
+    var res = try emitMultiResult("(define (s a b xs) (apply + a b xs))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "s");
+    // Two fixed arguments between the callee and the spliced list.
+    try expectContains(ll, "i64 2, i64 %");
+    try expectContains(ll, "@kaappi_apply(ptr %vm");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: a closure captures a variable used inside apply (#1803)" {
+    // collectFreeVars must walk the apply passthrough's operands: `xs` is the
+    // enclosing frame's parameter, captured as an upvalue. Before the
+    // freevars fix the capture was invisible and `xs` would have been emitted
+    // as a global lookup — #1799's failure mode in a new spot.
+    var res = try emitMultiResult("(define (mk xs) (lambda () (apply + xs)))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "mk");
+    try expectContains(ll, "define i64 @closure_");
+    try expectContains(ll, "@kaappi_apply(ptr %vm");
+    try expectContains(ll, "getelementptr i64, ptr %upvalues");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: a lexically shadowed apply is an ordinary call (#1803)" {
+    // `apply` here is the first parameter: the form must call IT (through
+    // kaappi_call_scheme), never the built-in @kaappi_apply.
+    var res = try emitMultiResult("(define (weird apply xs) (apply + xs))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "weird");
+    try expectNotContains(ll, "@kaappi_apply(ptr %vm");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: non-tail apply after a rebinding honors the rebinding (#1803)" {
+    // A top-level (define apply …) before the use: the interpreter's non-tail
+    // apply is an ordinary call through the current global binding, so the
+    // native code must look `apply` up instead of hardwiring the built-in.
+    // (In TAIL position the interpreter's tail_apply opcode ignores the
+    // rebinding, and emitApplyForm mirrors that too — see the parity suite.)
+    var res = try emitMultiResult(
+        "(define (myapply f lst) 99)" ++
+            "(define apply myapply)" ++
+            "(define (s xs) (+ 0 (apply + xs)))",
+    );
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNotContains(ll, "@kaappi_apply(ptr %vm");
+}
+
+test "LLVM emit: tail apply with too few operands declines the enclosing define (#1803)" {
+    // (apply f) in tail position is the interpreter's compile-time
+    // InvalidSyntax; the native path must rout the whole define to the
+    // interpreter so the program fails the same way, not emit a call.
+    var res = try emitMultiResult("(define (s f) (apply f))");
+    defer res.deinit();
+    const ll = res.toSlice();
     try expectNoNativeDef(ll, "s");
+    try expectNotContains(ll, "@kaappi_apply(ptr %vm");
     try std.testing.expect(countEvalFallbacks(ll) >= 1);
 }
 
@@ -1304,7 +1378,7 @@ test "eval-fallback name set covers the passthrough-evaluated special forms (#17
     // A direct check on the derived list, so a future edit to
     // `other_special_forms` that drops a payload fails here rather than as a
     // baffling run-time "undefined variable" in a compiled binary.
-    const must_have = [_][]const u8{ "apply", "call/cc", "call-with-current-continuation", "call-with-values", "eval" };
+    const must_have = [_][]const u8{ "call/cc", "call-with-current-continuation", "call-with-values", "eval" };
     for (must_have) |name| {
         var found = false;
         for (ir_mod.eval_fallback_form_names) |f| {
@@ -1317,8 +1391,11 @@ test "eval-fallback name set covers the passthrough-evaluated special forms (#17
     }
     // `else` and `=>` must stay OUT: sexprNeedsEvalFallback recurses blindly
     // into clause bodies, so listing them would reject every natively-lowered
-    // cond/case that has an else clause (#1496).
-    const must_not_have = [_][]const u8{ "else", "=>", "if", "lambda" };
+    // cond/case that has an else clause (#1496). `apply` must stay out too —
+    // emitApplyForm lowers it natively inside a lexical scope (kaappi#1803),
+    // and re-adding it would silently reinstate the whole-function fallback
+    // (a ~19x de-optimization for functions that merely contain one apply).
+    const must_not_have = [_][]const u8{ "else", "=>", "if", "lambda", "apply" };
     for (must_not_have) |name| {
         for (ir_mod.eval_fallback_form_names) |f| {
             if (std.mem.eql(u8, f, name)) {

--- a/tests/scheme/compile/native-apply-lowering-1803.sh
+++ b/tests/scheme/compile/native-apply-lowering-1803.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+# Regression test for #1803 (LLVM native backend): lower `apply` natively
+# instead of declining the whole enclosing function.
+#
+# #1799's fix put `apply` in ir.eval_fallback_form_names, which is correct but
+# blunt: ONE apply anywhere in a body sent every other expression in that body
+# to the interpreter too (~19x on the issue's arithmetic-loop reproducer).
+# emitApplyForm now emits the callee and fixed arguments natively and hands the
+# final operand to @kaappi_apply (runtime_exports.zig), which splices it with
+# primitives.applyFn's exact semantics. The dispatch mirrors the interpreter's
+# (compiler.zig): tail + unshadowed = structural built-in apply (tail_apply
+# ignores a top-level rebinding, so the fast path must too); everything else
+# resolvable is an ordinary call through whatever `apply` denotes in scope.
+#
+# Every functional case asserts the compiled binary agrees with the
+# interpreter; error cases assert both fail and the native diagnostic carries
+# applyFn's verbatim typeError detail. The structural case asserts the
+# convergence guarantee itself: a hot function containing one apply emits ZERO
+# eval fallbacks (that is what closed the 19x gap, and what a silent
+# reintroduction of the fallback would break first).
+#
+# Usage: bash tests/scheme/compile/native-apply-lowering-1803.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+FAILED=0
+
+compile_one() {
+    local label="$1"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+    local compile_out compile_status=0
+    compile_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" 2>&1)" || compile_status=$?
+    if [[ $compile_status -ne 0 ]]; then
+        echo "FAIL: $label — kaappi compile exited $compile_status: $compile_out" >&2
+        FAILED=1
+        return 1
+    fi
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — kaappi compile succeeded but produced no binary" >&2
+        FAILED=1
+        return 1
+    fi
+}
+
+# Run one program both ways and require identical output. The interpreter is
+# the oracle; `expected` documents intent without being what the comparison
+# rests on.
+check_both() {
+    local label="$1" expected="$2"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$src" 2>&1)" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        FAILED=1
+        return
+    fi
+
+    compile_one "$label" || return
+
+    local native_out native_status=0
+    native_out="$("$bin" 2>&1)" || native_status=$?
+    if [[ $native_status -ne 0 ]]; then
+        echo "FAIL: $label — compiled binary exited $native_status (output: '$native_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$native_out" != "$interp_out" ]]; then
+        echo "FAIL: $label — native '$native_out' != interpreted '$interp_out'" >&2
+        FAILED=1
+    fi
+}
+
+# Error-shape check: interpreter and compiled binary must BOTH fail (nonzero,
+# in bounded time — a circular list must raise, not hang), and the native
+# diagnostic must carry applyFn's typeError detail verbatim. Full-output
+# equality is impossible here: the interpreter prefixes file:line/excerpt
+# framing, and its tail-position apply reports through the tail_apply opcode's
+# own texts.
+check_both_fail() {
+    local label="$1" detail="$2"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$src" 2>&1)" || interp_status=$?
+    if [[ $interp_status -eq 0 ]]; then
+        echo "FAIL: $label — interpreter unexpectedly succeeded: '$interp_out'" >&2
+        FAILED=1
+        return
+    fi
+
+    compile_one "$label" || return
+
+    local native_out native_status=0
+    native_out="$("$bin" 2>&1)" || native_status=$?
+    if [[ $native_status -eq 0 ]]; then
+        echo "FAIL: $label — compiled binary unexpectedly succeeded: '$native_out'" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$native_out" != *"$detail"* ]]; then
+        echo "FAIL: $label — native diagnostic '$native_out' lacks '$detail'" >&2
+        FAILED=1
+    fi
+}
+
+# 1. The de-optimization shape from the issue: a hot self-tail arithmetic loop
+#    whose exit path holds the program's only apply. The loop total (3M
+#    iterations across 100 runs) matches the issue's reproducer; the operands
+#    keep every intermediate inside fixnum range.
+cat > "$DIR/heavy.scm" << 'SCHEME'
+(define (work n acc)
+  (if (= n 0) (apply + (list acc 0))
+      (work (- n 1) (+ acc (* n 3) (- n 1) (* n n)))))
+(define (bench k best)
+  (if (= k 0) best (bench (- k 1) (max best (work 30000 0)))))
+(display (bench 100 0))
+(newline)
+SCHEME
+check_both "heavy" "9002250035000"
+
+# 1b. The structural convergence guarantee behind the 19x fix: the emitted IR
+#     for that program routes NOTHING through the interpreter — `work` and
+#     `bench` compile natively and the apply is a @kaappi_apply call site.
+LL="$DIR/heavy.ll"
+if (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$LL" "$DIR/heavy.scm" > /dev/null 2>&1); then
+    evals=$(grep -c "call i64 @kaappi_eval" "$LL" || true)
+    if [[ "$evals" -ne 0 ]]; then
+        echo "FAIL: heavy — expected 0 eval fallbacks in emitted IR, found $evals" >&2
+        FAILED=1
+    fi
+    if ! grep -q "@kaappi_apply(ptr %vm" "$LL"; then
+        echo "FAIL: heavy — no native @kaappi_apply call site in emitted IR" >&2
+        FAILED=1
+    fi
+else
+    echo "FAIL: heavy — --emit-llvm failed" >&2
+    FAILED=1
+fi
+
+# 2. Tail apply driving a self-loop, with a let in the body so both
+#    frame-entry and body-scope GC roots are live at the tail transfer: a
+#    pop-before-ret miss leaks one root set per iteration and overflows the
+#    1024-slot shadow stack well before 2000 iterations.
+cat > "$DIR/tail-roots.scm" << 'SCHEME'
+(define (loop n acc)
+  (if (= n 0)
+      acc
+      (let ((next (cons n acc)))
+        (apply loop (list (- n 1) next)))))
+(display (length (loop 2000 '())))
+(newline)
+SCHEME
+check_both "tail-roots" "2000"
+
+# 3. Fixed arguments ahead of the list, under an adversarial GC (collection
+#    pressure on every few allocations): the callee and fixed-argument temps
+#    must be rooted across the allocating list-operand emission.
+cat > "$DIR/gc-fixed.scm" << 'SCHEME'
+(define (s a b xs) (apply + a b (list (car xs) (cadr xs))))
+(define (go n acc)
+  (if (= n 0) acc (go (- n 1) (+ acc (s 1 2 (list n (* n 2)))))))
+(display (go 2000 0))
+(newline)
+SCHEME
+KAAPPI_GC_THRESHOLD=1 check_both "gc-fixed" "6009000"
+
+# 4. A lexically shadowed `apply` is the callee, not the built-in.
+cat > "$DIR/shadowed.scm" << 'SCHEME'
+(define (weird apply xs) (apply + xs))
+(display (weird (lambda (f lst) (f 10 20)) (list 1 2 3)))
+(newline)
+SCHEME
+check_both "shadowed" "30"
+
+# 5. A top-level rebinding of `apply`: the interpreter honors it for a
+#    NON-tail apply (an ordinary call through the current global) but ignores
+#    it in TAIL position (the tail_apply opcode is structural). The native
+#    dispatch mirrors both halves.
+cat > "$DIR/rebound.scm" << 'SCHEME'
+(define (myapply f lst) 99)
+(define apply myapply)
+(define (nontail xs) (+ 0 (apply + xs)))
+(define (tail xs) (apply + xs))
+(display (nontail (list 1 2 3)))
+(newline)
+(display (tail (list 1 2 3)))
+(newline)
+SCHEME
+check_both "rebound" "$(printf '99\n6')"
+
+# 6. `apply` as a VALUE rather than a call head: resolves to the built-in
+#    procedure object and flows through map like any other argument.
+cat > "$DIR/as-value.scm" << 'SCHEME'
+(define (s) (map apply (list + *) (list (list 1 2) (list 3 4))))
+(display (s))
+(newline)
+SCHEME
+check_both "as-value" "(3 12)"
+
+# 7. Inside a natively lowered cond arm (#1496): apply no longer rejects the
+#    form, and the arm resolves the parameter correctly.
+cat > "$DIR/cond-arm.scm" << 'SCHEME'
+(define (f lst) (cond ((null? lst) 0) ((pair? lst) (apply + 100 lst)) (else -1)))
+(display (f (list 1 2 3)))
+(newline)
+(display (f '()))
+(newline)
+SCHEME
+check_both "cond-arm" "$(printf '106\n0')"
+
+# 8. Error shapes, non-tail so both runtimes report through applyFn's
+#    typeError texts. (Tail-position errors go through the interpreter's
+#    tail_apply opcode, whose texts differ — dispatch parity for those is
+#    covered by the rebound case above.)
+cat > "$DIR/err-not-proc.scm" << 'SCHEME'
+(define (s x) (+ 0 (apply x (list 1))))
+(display (s 5))
+SCHEME
+check_both_fail "err-not-proc" "type error in 'apply': expected procedure, got 5"
+
+cat > "$DIR/err-improper.scm" << 'SCHEME'
+(define (s xs) (+ 0 (apply + xs)))
+(display (s (cons 1 2)))
+SCHEME
+check_both_fail "err-improper" "type error in 'apply': expected proper list"
+
+# 9. A circular final list must raise in bounded time, never hang — the
+#    tortoise-and-hare check from applyFn, verbatim in @kaappi_apply.
+cat > "$DIR/err-circular.scm" << 'SCHEME'
+(define (s xs) (+ 0 (apply + xs)))
+(define l (list 1 2 3))
+(set-cdr! (cddr l) l)
+(display (s l))
+SCHEME
+check_both_fail "err-circular" "type error in 'apply': expected proper list"
+
+# 10. Too few operands, non-tail: the built-in's own arity check.
+cat > "$DIR/err-arity.scm" << 'SCHEME'
+(define (s f) (+ 0 (apply f)))
+(display (s +))
+SCHEME
+check_both_fail "err-arity" "expected at least 2 arguments, got 1"
+
+if [[ $FAILED -ne 0 ]]; then
+    exit 1
+fi
+
+echo "PASS"

--- a/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
+++ b/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
@@ -118,18 +118,24 @@ SCHEME
 check_native "$DIR/upvalue.scm" "(11 12 13)" "upvalue"
 
 # --- Case 8: bytecode tail positions calling a native callback ---
-# A do-loop forces the defined procedure onto the interpreter (eval
-# fallback), so (f i) / (apply f ...) / (g 14) execute as bytecode
-# tail_call / tail_apply / tail_call_global with a NativeClosure callee.
+# Each body is wrapped in a semantically transparent (letrec () ...) — an
+# eval-fallback form — to force the defined procedure onto the interpreter,
+# so (f i) / (apply f ...) / (g 14) execute as bytecode tail_call /
+# tail_apply / tail_call_global with a NativeClosure callee. The do-loop
+# alone stopped forcing this once `do` lowered natively (kaappi#1496), and
+# `apply` stopped forcing it too once it did (kaappi#1803) — without the
+# wrapper these run as native code and the bytecode opcodes go unexercised.
 cat > "$DIR/tail-calls.scm" << 'SCHEME'
 (define (tail-call-it f)
-  (do ((i 0 (+ i 1)))
-      ((= i 3) (f i))))
+  (letrec ()
+    (do ((i 0 (+ i 1)))
+        ((= i 3) (f i)))))
 (display (tail-call-it (lambda (x) (* x 100))))
 (newline)
 (define (tail-apply-it f)
-  (do ((i 0 (+ i 1)))
-      ((= i 1) (apply f (list 7 8)))))
+  (letrec ()
+    (do ((i 0 (+ i 1)))
+        ((= i 1) (apply f (list 7 8))))))
 (display (tail-apply-it (lambda (a b) (+ a b))))
 (newline)
 (define g #f)
@@ -137,8 +143,9 @@ cat > "$DIR/tail-calls.scm" << 'SCHEME'
   (set! g (lambda (x) (* x 3))))
 (setup!)
 (define (call-g)
-  (do ((i 0 (+ i 1)))
-      ((= i 1) (g 14))))
+  (letrec ()
+    (do ((i 0 (+ i 1)))
+        ((= i 1) (g 14)))))
 (display (call-g))
 (newline)
 SCHEME


### PR DESCRIPTION
Closes #1803. Follow-up to #1799/#1798.

## What

One `apply` anywhere in a body no longer de-optimizes the whole enclosing function. `emitPassthrough` routes an `(apply …)` head inside a lexical scope to a new `emitApplyForm`, which emits the callee and fixed arguments natively and hands the final operand to a new C-ABI entry point:

```zig
pub export fn kaappi_apply(vm: ?*vm_mod.VM, callee: u64,
                           fixed_args: ?[*]const u64, n_fixed: u64,
                           list: u64) callconv(.c) u64
```

`kaappi_apply` is `primitives.applyFn` minus the argument shuffling — same `isProcedure`/`isNativeFn` validation, same tortoise-and-hare cycle detection (a circular list raises, never hangs), same `typeError` texts verbatim.

## Dispatch mirrors the interpreter case for case

The interpreter's own `apply` handling is position-dependent (`compiler.zig`/`compileApplyTail`), and the native dispatch replicates it exactly — including its quirk:

| shape | interpreter | native |
|---|---|---|
| tail + unshadowed + ≥2 operands | `tail_apply` opcode (ignores a top-level rebinding of `apply`) | `@kaappi_apply`, builtin semantics |
| tail + unshadowed + <2 operands | compile-time `InvalidSyntax` | abandons native compilation → same error |
| shadowed / non-tail rebound / non-tail <2 operands | ordinary call through the current binding | indirect call via `emitGlobalRef`'s lexical order |

An earlier draft honored the rebinding in tail position too ("more correct" per R7RS) — parity testing caught it diverging from the interpreter (99 vs 6), so it was reverted to bug-compatible parity: **zero behavior change on every shape, only performance changes.**

## The latent free-variable trap

Both free-variable walks (`nodeHasFreeVars`/`collectNodeFreeVars`) treated every `.passthrough` node as capture-free — sound only while every passthrough keyword also declined the enclosing scope. With `apply` out of `eval_fallback_form_names`, `(lambda (x) (apply + base x))` would have compiled the closure with an incomplete upvalue set and read `base` as a global — #1799's failure mode in a new spot. Both arms now walk apply operands through the existing scope-aware `FreeNameWalk`.

## Results

The issue's heavy pair (fixnum-safe variant, 3M iterations), compiled, 3 runs each:

| program | before | after |
|---|---|---|
| heavy-pure | 0.12 s | 0.12 s |
| heavy-apply | ~19x slower (per issue) | **0.12 s** |

`(define (s xs) (apply + xs))` now emits 1 native define and 0 eval fallbacks (was 0 and 2).

## Verification

- `tests/scheme/compile/native-apply-lexical-scope-1799.sh` — **passes unchanged**, as the issue designed it to.
- New `tests/scheme/compile/native-apply-lowering-1803.sh` — 11 behavior-parity cases: the heavy reproducer + its structural convergence check (zero eval fallbacks in the emitted IR), tail-apply root balancing over 2000 iterations, fixed args under `KAAPPI_GC_THRESHOLD=1`, shadowed parameter, tail-vs-non-tail rebinding, apply-as-value, cond-arm, and four error shapes with verbatim `typeError` detail (not-a-procedure, improper, circular, arity).
- `src/tests_native.zig` — emit-level tests updated from assert-the-decline to assert-the-lowering; `must_have`/`must_not_have` name-set guards updated (`apply` now must stay OUT).
- `native-bootstrap-callbacks-1376.sh` case 8 relied on `apply` forcing the eval fallback to exercise bytecode `tail_apply` against a NativeClosure; a semantically transparent `(letrec ())` wrapper restores that documented coverage (`do` had already stopped forcing it in #1496).
- Full `zig build test` and `bash tests/scheme/run-all.sh`: **1998 pass, 0 fail**. Cross-compiles clean for x86_64-linux, aarch64-windows, and wasm.

## Notes

- `call/cc`/`call-with-values`/`eval` keep declining, per the issue's scope.
- A tail `(apply f xs)` is still not a real tail call across the runtime boundary (`callWithArgs` re-entry) — verified to be the same pre-existing divergence class as computed-operator tail calls through `kaappi_call_scheme`, which overflow at the same depths on unmodified main. Documented in `docs/dev/llvm-backend.md`.
- Two pre-existing bugs surfaced while validating against clean main (99dc2320), both reproduced without this change: macro uses inside natively-lowered `let` bodies miscompile to global lookups, and the issue's own `heavy-pure.scm` (no `apply` at all) segfaults at n=3M when the accumulator crosses into bignum range. Neither is touched here; both are being filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)