### PR TITLE
Reclaim per-iteration alloca stack growth in native loops (#1808)

### DIFF
--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -223,6 +223,13 @@ pub const LLVMEmitter = struct {
     // `musttail call tailcc` only here — the uniform (ccc) entries, closures,
     // and the top-level body never can (calling-convention mismatch).
     in_fast_entry: bool = false,
+    // The `llvm.stacksave` result captured at the top of the current self-tail
+    // loop header (body_label), or null when no self-tail loop is active for
+    // this frame (kaappi#1808). emitSelfTailCall restores to this pointer
+    // right before branching back to the header, reclaiming every `alloca`
+    // made during the pass just completed — root-push slots and call-argument
+    // arrays alike — so the native stack does not grow per iteration.
+    loop_stack_save: ?[]const u8 = null,
     // Forward-reference plumbing (#1499): populated once by preScanReserve and
     // then read-only. reserved_fast maps a reserved top-level define name to its
     // stable @r{i}/@r{i}.fast names; fulfilled_fast records names whose real
@@ -250,6 +257,7 @@ pub const LLVMEmitter = struct {
         frame_entry_roots: usize,
         body_scope_roots: usize,
         in_fast_entry: bool,
+        loop_stack_save: ?[]const u8,
     };
 
     pub fn saveScope(self: *LLVMEmitter) SavedScope {
@@ -269,6 +277,7 @@ pub const LLVMEmitter = struct {
             .frame_entry_roots = self.frame_entry_roots,
             .body_scope_roots = self.body_scope_roots,
             .in_fast_entry = self.in_fast_entry,
+            .loop_stack_save = self.loop_stack_save,
         };
     }
 
@@ -288,6 +297,7 @@ pub const LLVMEmitter = struct {
         self.frame_entry_roots = s.frame_entry_roots;
         self.body_scope_roots = s.body_scope_roots;
         self.in_fast_entry = s.in_fast_entry;
+        self.loop_stack_save = s.loop_stack_save;
     }
 
     pub fn init(backing: std.mem.Allocator) LLVMEmitter {
@@ -754,6 +764,13 @@ pub const LLVMEmitter = struct {
         // rest-list slot) live BEFORE the header and are deliberately NOT popped
         // — they persist across iterations, overwritten in place above.
         try self.emitPopRoots(self.body_scope_roots);
+
+        // Reclaim every `alloca` made while computing this pass (root-push
+        // slots, call-argument arrays, let/do-variable slots) before starting
+        // the next one (#1808) — `alloca` frees only at function return, so
+        // without this the native stack grows by one pass's worth on every
+        // iteration and eventually overflows on a long-running loop.
+        if (self.loop_stack_save) |sp| try self.emitStackRestore(sp);
 
         try self.print("  br label %{s}\n", .{body_lbl});
 
@@ -1593,6 +1610,30 @@ pub const LLVMEmitter = struct {
         try self.write("declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64)\n");
         try self.write("declare { i64, i1 } @llvm.ssub.with.overflow.i64(i64, i64)\n");
         try self.write("declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64)\n");
+        // Reclaim per-iteration `alloca`s (root-push slots, call-argument
+        // arrays, let/do-variable slots) at the end of every native loop pass
+        // (kaappi#1808). `alloca` frees only at function *return*, never at
+        // "next loop iteration" — without this, a self-tail-call loop or a
+        // `do` loop that evaluates so much as one rooted call per pass grows
+        // the native stack by that call's alloca footprint on every pass,
+        // eventually overflowing the OS thread stack on a long-running loop
+        // regardless of whether the values involved are fixnums or bignums.
+        try self.write("declare ptr @llvm.stacksave()\n");
+        try self.write("declare void @llvm.stackrestore(ptr)\n");
+    }
+
+    // Capture the current native stack pointer (kaappi#1808). Call at the top
+    // of a loop pass and pass the result to emitStackRestore right before the
+    // back-edge that starts the next pass, to reclaim every `alloca` made
+    // during the pass just completed.
+    pub fn emitStackSave(self: *LLVMEmitter) EmitError![]const u8 {
+        const sp = try self.freshTemp();
+        try self.print("  {s} = call ptr @llvm.stacksave()\n", .{sp});
+        return sp;
+    }
+
+    pub fn emitStackRestore(self: *LLVMEmitter, sp: []const u8) EmitError!void {
+        try self.print("  call void @llvm.stackrestore(ptr {s})\n", .{sp});
     }
 
     pub fn emitRootPush(self: *LLVMEmitter, tmp: []const u8) EmitError!void {

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -276,6 +276,13 @@ pub fn emitDo(self: *LLVMEmitter, args: Value, is_tail: bool) EmitError![]const 
 
     try self.print("  br label %{s}\n", .{header});
     try self.startBlock(header);
+    // Capture the stack pointer at the top of every pass (both the initial
+    // entry and every iteration via the body's back-edge below) so it can be
+    // reclaimed before the next one starts (#1808): `alloca` frees only at
+    // function return, so a body/step that evaluates so much as one rooted
+    // call would otherwise grow the native stack by that call's footprint on
+    // every iteration, eventually overflowing it on a long-running loop.
+    const loop_sp = try self.emitStackSave();
     const test_node = try lower(self, test_expr, false);
     const tval = try self.emitNode(test_node);
     const cmp = try self.freshTemp();
@@ -315,6 +322,7 @@ pub fn emitDo(self: *LLVMEmitter, args: Value, is_tail: bool) EmitError![]const 
     for (0..ns) |k| {
         try self.print("  store i64 {s}, ptr {s}\n", .{ step_tmps[k], allocas[stepped[k]] });
     }
+    try self.emitStackRestore(loop_sp);
     try self.print("  br label %{s}\n", .{header});
 
     // Exit: evaluate the result expressions (or void), then drop the roots.

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -264,6 +264,10 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
         // A fresh frame starts with no let-binding roots (#1585); saveScope
         // restored the enclosing value on exit.
         self.body_scope_roots = 0;
+        // A closure never gets the self-tail-loop treatment (current_fn_name/
+        // body_label above are null), so nothing reads this — reset anyway so
+        // no stale enclosing-scope value could leak in (#1808).
+        self.loop_stack_save = null;
 
         const header = std.fmt.allocPrint(self.allocator(), "; closure: {s}\ndefine i64 {s}(ptr %vm, ptr %args, i64 %nargs, ptr %upvalues) {{\nentry:\n", .{ closure_name, fn_name }) catch return null;
         defer self.allocator().free(header);
@@ -599,6 +603,10 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         // A tail call in this body may be a guaranteed `musttail` only from a
         // `tailcc` fast entry (#1499).
         self.in_fast_entry = use_fast;
+        // No self-tail loop is active until the body_lbl header below sets
+        // this (#1808); a stale value from the enclosing scope must not leak
+        // into this frame's body.
+        self.loop_stack_save = null;
 
         var p = std.StringHashMap(u8).init(self.backing_alloc);
         defer p.deinit();
@@ -660,6 +668,14 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
 
         self.print("  br label %{s}\n{s}:\n", .{ body_lbl, body_lbl }) catch return null;
         self.current_block = body_lbl;
+
+        // Capture the stack pointer at the loop header so a self-tail call
+        // (emitSelfTailCall) can reclaim this pass's `alloca`s before
+        // branching back (#1808). Only when the self-tail loop is actually
+        // active (mirrors self.body_label's own !boxed.any condition) — a
+        // boxed frame's only `ret` is the trailing one, so there is no
+        // repeated pass to reclaim.
+        self.loop_stack_save = if (!boxed.any) (self.emitStackSave() catch return null) else null;
 
         if (boxed.any and !emitBoxedParamSlots(self, param_names, boxed)) return null;
 

--- a/tests/scheme/compile/native-loop-alloca-stack-growth-1808.sh
+++ b/tests/scheme/compile/native-loop-alloca-stack-growth-1808.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Regression test for #1808 (LLVM native backend): a compiled binary segfaults
+# with no diagnostic once a long-running native loop has executed enough
+# passes, regardless of whether the values involved ever become bignums.
+#
+# Root cause: `alloca` in LLVM frees only at function RETURN, never at "the
+# next loop iteration". emitRootPush's per-root shadow-stack slots and the
+# generic call path's argument-array `alloca`s (emitCallNode/emitDirectCall)
+# are emitted wherever the call site happens to be — which, for a call inside
+# a self-tail-call loop body or a `do` loop body, is a block reached via a
+# backward branch. Every pass through that block adds another `alloca`'s
+# worth of native stack that is never reclaimed until the function returns,
+# so a loop that runs long enough overflows the OS thread stack. The original
+# issue report suspected a GC-rooting gap around bignum promotion specifically
+# (the crash happened to land inside bignum code, since #1808's own reproducer
+# also grows into bignum range) — but the reproducer below with `(+ acc 0 0 0)`
+# never leaves fixnum range and crashes identically, proving the bug is the
+# stack growth itself, independent of bignum-ness.
+#
+# The fix (llvm_emit.zig's emitStackSave/emitStackRestore) captures the stack
+# pointer at the top of every loop pass (the self-tail-call body_lbl header in
+# emitLambdaFunction, and the `do`-loop header in llvm_emit_forms.emitDo) and
+# restores it right before the back-edge that starts the next pass, reclaiming
+# every alloca made during the pass just completed.
+#
+# Usage: bash tests/scheme/compile/native-loop-alloca-stack-growth-1808.sh [path-to-kaappi]
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+FAILED=0
+
+compile_one() {
+    local label="$1"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+    local compile_out compile_status=0
+    compile_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" 2>&1)" || compile_status=$?
+    if [[ $compile_status -ne 0 ]]; then
+        echo "FAIL: $label — kaappi compile exited $compile_status: $compile_out" >&2
+        FAILED=1
+        return 1
+    fi
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — kaappi compile succeeded but produced no binary" >&2
+        FAILED=1
+        return 1
+    fi
+}
+
+# Run one program both ways and require identical output. The interpreter is
+# the oracle; `expected` documents intent without being what the comparison
+# rests on.
+check_both() {
+    local label="$1" expected="$2"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$src" 2>&1)" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        FAILED=1
+        return
+    fi
+
+    compile_one "$label" || return
+
+    local native_out native_status=0
+    native_out="$("$bin" 2>&1)" || native_status=$?
+    if [[ $native_status -ne 0 ]]; then
+        echo "FAIL: $label — compiled binary exited $native_status (output: '$native_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$native_out" != "$interp_out" ]]; then
+        echo "FAIL: $label — native '$native_out' != interpreted '$interp_out'" >&2
+        FAILED=1
+    fi
+}
+
+# 1. The issue's own reproducer: a self-tail arithmetic loop whose accumulator
+#    grows past the i48 fixnum range into bignum territory.
+cat > "$DIR/heavy-pure.scm" << 'SCHEME'
+(define (work n acc)
+  (if (= n 0) acc
+      (work (- n 1) (+ acc (* n 3) (- n 1) (* n n)))))
+(display (work 3000000 0))
+SCHEME
+check_both "heavy-pure" "9000022500003500000"
+
+# 2. Fixnum-only self-tail loop: the accumulator NEVER leaves fixnum range
+#    (every term is 0), isolating the bug from bignum promotion entirely. This
+#    is the case that disproves the GC-rooting-around-bignum-promotion theory:
+#    the pre-fix binary crashed on this too, purely from `alloca` growth in
+#    the loop body's call to the 4-arg `+` (not inlined — inlining only
+#    applies to exactly 2 args, so this always takes the generic call path
+#    with its own argument-array alloca).
+cat > "$DIR/fixnum-only-loop.scm" << 'SCHEME'
+(define (loop n acc)
+  (if (= n 0) acc
+      (loop (- n 1) (+ acc 0 0 0))))
+(display (loop 3000000 0))
+SCHEME
+check_both "fixnum-only-loop" "0"
+
+# 3. Same class of bug in a `do` loop (a second, independent loop-establishing
+#    site in the LLVM emitter — do's own back-edge in emitDo, not
+#    emitSelfTailCall). Also fixnum-only.
+cat > "$DIR/do-loop.scm" << 'SCHEME'
+(define (run)
+  (do ((i 0 (+ i 1))
+       (acc 0 (+ acc 0 0 0)))
+      ((= i 3000000) acc)))
+(display (run))
+SCHEME
+check_both "do-loop" "0"
+
+# 4. The issue's other named suspect: a single crossing of the i48 fixnum
+#    boundary (in both directions) under forced GC pressure at the promotion
+#    site. This investigation found the real bug was loop-body stack growth,
+#    not a GC-rooting gap here — but the issue explicitly asked for this
+#    boundary case, and it is cheap insurance against a regression in the
+#    inline arithmetic overflow-to-bignum slow path (llvm_emit_inline.zig).
+cat > "$DIR/boundary-positive.scm" << 'SCHEME'
+(display (+ 140737488355327 1))
+SCHEME
+KAAPPI_GC_THRESHOLD=1 check_both "boundary-positive" "140737488355328"
+
+cat > "$DIR/boundary-negative.scm" << 'SCHEME'
+(display (- -140737488355328 1))
+SCHEME
+KAAPPI_GC_THRESHOLD=1 check_both "boundary-negative" "-140737488355329"
+
+if [[ $FAILED -ne 0 ]]; then
+    exit 1
+fi
+
+echo "PASS"


### PR DESCRIPTION
## Summary

Fixes #1808. The issue's own reproducer suspected a GC-rooting gap around
bignum promotion in the LLVM native backend, but the real bug is more
fundamental and independent of bignums entirely.

**Root cause:** LLVM's `alloca` instruction frees its stack space only when
the enclosing *function* returns — never when a loop body simply re-executes.
The native backend compiles self-tail-call loops (`emitLambdaFunction`) and
`do` loops (`emitDo`) as backward branches within a single function, not real
recursive calls. Several paths emit `alloca` instructions wherever they
happen to be textually positioned:

- `emitRootPush`'s per-call shadow-stack root slots
- the generic n-ary call path's argument-array `alloca` (used whenever a call
  isn't eligible for the 2-arg inline fast path or a direct/fast native
  call — e.g. any `+`/`-`/`*` call with more than 2 arguments, which is
  exactly what the issue's own `(+ acc (* n 3) (- n 1) (* n n))` is)
- `let`/`do`-bound variable slots

When any of these sit inside a loop body, every pass adds another `alloca`'s
worth of native stack that is never reclaimed, eventually overflowing the OS
thread stack on a long-running loop — regardless of whether the values
involved ever become bignums.

Confirmed via `lldb`: the crash is a real stack-guard-page hit (not a bad
pointer), and reproduces identically with:
- a purely fixnum-only self-tail loop (`(+ acc 0 0 0)`, always 0)
- a plain top-level `do`-loop with the same shape

both of which never leave fixnum range, disproving the original
GC-rooting-around-bignum-promotion hypothesis.

## Fix

Bracket each native loop's body with `llvm.stacksave`/`llvm.stackrestore`:
captured once at the loop header (the self-tail-call `body_lbl`, and the
`do`-loop's `header` block), restored right before the back-edge that starts
the next pass. This reclaims every `alloca` made during the completed pass
without needing to hunt down and rewrite each individual alloca-emitting call
site.

## Test plan

- [x] `zig build test` — unit suite green
- [x] `bash tests/scheme/run-all.sh` — 1999 pass (the one transient failure
      during development was a `native-rebind-stale-call-822.sh` flake from
      running two test drivers concurrently against the same runtime-lib
      rebuild; reruns alone pass cleanly)
- [x] All existing `tests/scheme/compile/*.sh` native-backend regression
      tests still pass
- [x] New `tests/scheme/compile/native-loop-alloca-stack-growth-1808.sh`:
      the issue's exact reproducer, a fixnum-only self-tail-loop variant, a
      `do`-loop variant, and the issue's explicitly-requested ±2^47 boundary
      crossing under `KAAPPI_GC_THRESHOLD=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)