### PR TITLE
Keep a macro-expanded body-position define's local alive (#1800)

### DIFF
--- a/lib/srfi/251.sld
+++ b/lib/srfi/251.sld
@@ -53,22 +53,14 @@
 ;;;    step). An unrecognized macro call is treated as a command and
 ;;;    placed in whatever `mixed-lambda` segment it falls into; Kaappi's
 ;;;    own body compiler *does* independently recognize a macro-produced
-;;;    `define` reached that way, but only when the macro is invoked in
-;;;    the same lambda-body scope where it (or an enclosing macro that
-;;;    expands to it) was defined. SRFI 251's own `define-thunk` worked
-;;;    example nests the definition group containing `define-thunk`'s use
-;;;    one level deeper than the group defining `define-thunk` itself
-;;;    (there's a `display` command, hence a new group, in between) —
-;;;    confirmed empirically (not just asserted) to raise "undefined
-;;;    variable" here, rather than the spec's "the result is: 0": a
-;;;    body-local macro that expands to a `define`, invoked from a nested
-;;;    lambda scope different from the one where the macro itself was
-;;;    defined, isn't recognized as introducing a definition in that
-;;;    inner scope, regardless of how the body reached that shape (this
-;;;    reproduces with a hand-written pair of nested `(lambda () ...)`
-;;;    forms and no SRFI 251 macro involved at all). The test suite
-;;;    exercises and documents this precisely rather than asserting the
-;;;    spec's answer.
+;;;    `define` reached that way, including when the macro is invoked from
+;;;    a nested lambda scope different from the one where it (or an
+;;;    enclosing macro that expands to it) was defined — SRFI 251's own
+;;;    `define-thunk` worked example nests the definition group containing
+;;;    `define-thunk`'s use one level deeper than the group defining
+;;;    `define-thunk` itself (there's a `display` command, hence a new
+;;;    group, in between), and gives the spec's own "the result is: 0"
+;;;    (kaappi#1800; used to raise "undefined variable" here instead).
 ;;;  - The spec requires rejecting, as a static (compile-time) error, a
 ;;;    command or initializer that illegally references an identifier from
 ;;;    a *later* definition group. This is not enforced: Kaappi bodies

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -168,10 +168,42 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
     // argument slot while the call still reads the original window (found
     // by the Kaappi-vs-Chibi differential oracle, #1396).
     const saved_locals_len = self.locals.items.len;
+    // Set right before the final compileExpr(final_form, ...) call below
+    // (kaappi#1800). compileExpr(final_form) can itself append a REAL,
+    // sibling-visible local — a body-scope `define` reached through the
+    // macro's expansion relies on compileDefine's in_body_scope branch
+    // doing exactly that. Anything self.locals gains between
+    // saved_locals_len and pre_final_locals_len is still transient chain
+    // bookkeeping and must be discarded; anything gained AFTER
+    // pre_final_locals_len is final_form's own persistent state and must
+    // survive. The cleanup defer below removes only the former, shifting
+    // the latter down to close the gap (self.locals is compile-time
+    // bookkeeping with no bytecode encoding array position, only each
+    // Local's own .slot register — unlike registers, closing the gap here
+    // is safe).
+    var pre_final_locals_len = saved_locals_len;
     var injected_reg_count: u16 = 0;
     defer {
-        while (self.locals.items.len > saved_locals_len) {
-            _ = self.locals.pop();
+        const kept = self.locals.items.len -| pre_final_locals_len;
+        if (kept > 0) {
+            // final_form left real locals behind. Splice out just the
+            // transient block [saved_locals_len, pre_final_locals_len),
+            // keeping the kept tail's relative order and slots intact.
+            var i: usize = 0;
+            while (i < kept) : (i += 1) {
+                self.locals.items[saved_locals_len + i] = self.locals.items[pre_final_locals_len + i];
+            }
+            self.locals.shrinkRetainingCapacity(saved_locals_len + kept);
+            // The transient block's registers sit BELOW the kept locals'
+            // registers (allocated earlier); freeReg only reclaims from
+            // the top, so freeing them here would instead free the kept
+            // locals' registers out from under them. Leave them reserved
+            // — a bounded, rare register leak, not a correctness bug.
+            injected_reg_count = 0;
+        } else {
+            while (self.locals.items.len > saved_locals_len) {
+                _ = self.locals.pop();
+            }
         }
         while (injected_reg_count > 0) : (injected_reg_count -= 1) {
             self.freeReg();
@@ -423,6 +455,12 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
         break;
     }
 
+    // Everything appended to self.locals up to this point (across every
+    // link processed above) is transient chain bookkeeping and must still
+    // be discarded by the defer above; mark the boundary right before
+    // compiling final_form so it can tell that apart from whatever
+    // final_form's own compilation appends.
+    pre_final_locals_len = self.locals.items.len;
     return self.compileExpr(final_form, dst, is_tail);
 }
 

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -598,6 +598,36 @@ test "hygiene: template set! reaches the global past a use-site shadow" {
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(global));
 }
 
+test "hygiene: macro-expanded body-position define is visible to later siblings (#1800)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // form is a pattern variable, so substituting it preserves the
+    // use-site identifier x unrenamed -- expandAndCompileMacroUse used to
+    // pop the compiler local compileDefine's in_body_scope branch had just
+    // added for x, on the mistaken assumption that everything added while
+    // compiling a macro use is transient chain bookkeeping (hygienic
+    // aliases). A body-scope `define` reached through the expansion is a
+    // real, sibling-visible local, not an alias.
+    _ = try vm.eval("(define-syntax n800 (syntax-rules () ((n800 form) form)))");
+    const result = try vm.eval("(let () (n800 (define x 10)) x)");
+    try std.testing.expectEqual(@as(i64, 10), types.toFixnum(result));
+
+    // A local injected purely for R7RS 4.3.1 referential transparency
+    // (the sibling test above) must still be discarded after the macro
+    // use finishes, even when a LATER, separate macro use in the same
+    // body also leaves behind a real, surviving local.
+    _ = try vm.eval("(define counter 0)");
+    _ = try vm.eval("(define-syntax bump! (syntax-rules () ((bump!) (set! counter (+ counter 1)))))");
+    const combined = try vm.eval("(let ((counter 100)) (n800 (define z 5)) (bump!) (list counter z))");
+    try std.testing.expectEqual(@as(i64, 100), types.toFixnum(types.car(combined)));
+    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(types.car(types.cdr(combined))));
+    const global_counter = try vm.eval("counter");
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(global_counter));
+}
+
 test "hygiene: template binding shadows a builtin procedure of the same name" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/tests/scheme/hygiene/macro-body-define-visibility.scm
+++ b/tests/scheme/hygiene/macro-body-define-visibility.scm
@@ -1,0 +1,48 @@
+;; Regression test for #1800: a macro use in body position whose expansion
+;; is a bare (define x v) -- where x comes through as a pattern-variable
+;; substitution of a use-site identifier, not a template-literal name --
+;; must make x visible to later sibling forms in the same body, exactly as
+;; if the user had written (define x v) directly at that position.
+;;
+;; Root cause: expandAndCompileMacroUse's post-expansion cleanup popped
+;; every compiler local added while compiling the macro's final expanded
+;; form back off before returning, on the assumption that everything added
+;; during a macro-use compile is transient chain bookkeeping (hygienic
+;; captured-local aliases). A body-scope `define` reached through the
+;; expansion adds a REAL, sibling-visible local, not an alias, and must
+;; survive the call returning.
+;;
+;; Note: compile/runtime errors abort a top-level form without setting a
+;; non-zero exit code, so results are checked via flags in separate
+;; top-level forms (see forward-sibling-define-ref.scm for the same
+;; pattern).
+
+(define ok1 #f)
+
+;; let-syntax body: (m (define x 10)) expands (via pattern-variable
+;; substitution, preserving the use-site identifier x unrenamed) to
+;; (define x 10), which must bind x for the following (m2) reference.
+(let-syntax
+    ((m (syntax-rules () ((m form) form))))
+  (m (define x 10))
+  (if (equal? x 10)
+      (set! ok1 #t)
+      (begin (display "FAIL 1: expected 10, got ") (display x) (newline))))
+
+(define ok2 #f)
+
+;; Same pattern, but via a top-level define-syntax and a lambda/let body
+;; that goes through the leading-defines pre-scanner (scanBodyDefs), not
+;; let-syntax's own simpler body loop -- both paths route through the same
+;; expandAndCompileMacroUse and hit the same bug.
+(define-syntax n800 (syntax-rules () ((n800 form) form)))
+
+(let ()
+  (n800 (define y 20))
+  (if (equal? y 20)
+      (set! ok2 #t)
+      (begin (display "FAIL 2: expected 20, got ") (display y) (newline))))
+
+(if (and ok1 ok2)
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL: macro-expanded body-position define not visible to siblings") (newline) (exit 1)))

--- a/tests/scheme/srfi/srfi148.scm
+++ b/tests/scheme/srfi/srfi148.scm
@@ -21,21 +21,26 @@
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi148.scm
 ;;
 ;; Deviations from the reference suite: none of the test logic itself was
-;; changed. 8 of the ~142 assertions are marked test-expect-fail below,
-;; citing two SEPARATE, general, pre-existing engine bugs found while
-;; porting this suite -- neither is specific to SRFI 148 or to this
-;; library's own combinators, which are otherwise fully verified correct:
-;;   - #1800: a macro that expands to a bare (define x v) in body position
-;;     doesn't make x visible to later sibling forms in the same body.
-;;     Reproduced with a plain, non-eager syntax-rules macro -- nothing to
-;;     do with em-syntax-rules. Affects "Match quoted pattern with quoted
-;;     element", "Match quoted pattern with eager macro use", "Match
-;;     unquoted pattern with element", em-cons, em-list, em-append.
+;; changed. 2 of the ~142 assertions are marked test-expect-fail below,
+;; citing a SEPARATE, general, pre-existing engine bug found while porting
+;; this suite -- not specific to SRFI 148 or to this library's own
+;; combinators, which are otherwise fully verified correct:
 ;;   - #1801: two separate expansions of a macro whose template introduces
 ;;     "the same" literal symbol are wrongly bound-identifier=? to each
 ;;     other. Breaks em-gensym/em-generate-temporaries, which deliberately
 ;;     rely on hygiene alone (not a counter) for uniqueness, per the
 ;;     reference's own (em-gensym) => 'g definition.
+;;
+;; #1800 (a macro expanding to a bare (define x v) in body position didn't
+;; make x visible to later sibling forms -- affected "Match quoted pattern
+;; with quoted element", "Match quoted pattern with eager macro use",
+;; "Match unquoted pattern with element", em-cons, em-list, em-append) is
+;; FIXED: expandAndCompileMacroUse's post-expansion cleanup popped every
+;; compiler local added while compiling a macro's final expanded form back
+;; off before returning, on the mistaken assumption that everything added
+;; during a macro-use compile is transient chain bookkeeping (hygienic
+;; aliases). A body-scope `define` reached through the expansion adds a
+;; REAL, sibling-visible local, not an alias, and needs to survive.
 ;; A third, more severe issue (#1802: importing this library alone costs
 ;; ~80s, superlinearly in definition count, independent of test count) is
 ;; NOT a per-assertion failure and has no test-expect-fail equivalent --
@@ -48,14 +53,8 @@
 
 ;; Each name needs its own test-expect-fail call: passing several
 ;; specifiers to ONE call ANDs them together (test-match-all), so a
-;; single batched call here would require a test to simultaneously BE all
-;; 8 names at once -- impossible, hence matching nothing.
-(test-expect-fail "Match quoted pattern with quoted element")
-(test-expect-fail "Match quoted pattern with eager macro use")
-(test-expect-fail "Match unquoted pattern with element")
-(test-expect-fail "em-cons")
-(test-expect-fail "em-list")
-(test-expect-fail "em-append")
+;; single batched call here would require a test to simultaneously BE both
+;; names at once -- impossible, hence matching nothing.
 (test-expect-fail "em-gensym")
 (test-expect-fail "em-generate-temporaries")
 

--- a/tests/scheme/srfi/srfi251.scm
+++ b/tests/scheme/srfi/srfi251.scm
@@ -93,25 +93,27 @@
 ;; 0". This port's mixed-let nests define-thunk's *use* (define xx 42;
 ;; define-thunk foo x -- a new group, since a display command separates it
 ;; from the group that defines define-thunk) one lambda scope deeper than
-;; define-thunk's own definition. Confirmed (see lib/srfi/251.sld) that
-;; Kaappi does not recognize a body-local macro's produced `define` across
-;; that scope boundary, independent of SRFI 251 entirely -- so this port
-;; raises an "undefined variable" error here instead of computing the
-;; spec's answer. Documented as a known gap rather than silently wrong.
-(test-assert "known gap: macro-produced definition across a nested scope"
-  (guard (e (#t #t))
-    (captured
-     (lambda (port)
-       (mixed-let ((x 0))
-         (define-syntax define-thunk
-           (syntax-rules ()
-             ((_ i v) (define (i) v))))
-         (display "the result is" port)
-         (display ": " port)
-         (define xx 42)
-         (define-thunk foo x)
-         (display (foo) port))))
-    #f))
+;; define-thunk's own definition -- the same shape as "unrelated name in a
+;; later group" above, just with a macro-produced (define (foo) x) instead
+;; of a literal one. Used to raise "undefined variable" here instead of
+;; computing the spec's answer: independent of SRFI 251 entirely,
+;; expandAndCompileMacroUse's post-expansion cleanup popped the compiler
+;; local a macro's expanded `define` had just added, on the mistaken
+;; assumption that everything added while compiling a macro use is
+;; transient chain bookkeeping (fixed by kaappi#1800).
+(test-equal "macro-produced definition across a nested scope"
+  "the result is: 0"
+  (captured
+   (lambda (port)
+     (mixed-let ((x 0))
+       (define-syntax define-thunk
+         (syntax-rules ()
+           ((_ i v) (define (i) v))))
+       (display "the result is" port)
+       (display ": " port)
+       (define xx 42)
+       (define-thunk foo x)
+       (display (foo) port)))))
 
 ;; Example: illegal forward reference. The spec says this must be a
 ;; compile-time error. This port does not enforce the visibility


### PR DESCRIPTION
## Summary

Fixes #1800. A macro use whose expansion is a bare `(define x v)` in body position raised "undefined variable" for later references to `x` — e.g. `(let-syntax ((m (syntax-rules () ((m form) form)))) (m (define x 10)) x)` failed to compile, even though `x` here is a pattern-variable substitution of a use-site identifier (verified against chibi-scheme and guile: both correctly evaluate this to `10`).

Root cause: `expandAndCompileMacroUse`'s post-expansion cleanup unconditionally popped every compiler local added while compiling the macro's final expanded form, on the assumption that everything added during a macro-use compile is transient chain bookkeeping (hygienic captured-local aliases, or R7RS 4.3.1 referential-transparency global aliases). `compileDefine`'s `in_body_scope` branch adds a *real*, sibling-visible local when the macro's expansion is a definition, and that local must survive the call returning — only the aliases injected earlier in the chain are truly transient.

The fix distinguishes the two: everything added up to right before the final `compileExpr(final_form, ...)` call is discarded as before; anything `compileExpr` itself appends while compiling `final_form` is kept, by splicing out just the transient block from `self.locals` and leaving the kept tail's slots untouched. (Registers can't be renumbered the same way since bytecode already encodes concrete slot numbers, so if `final_form` left real locals behind, the transient block's registers are left reserved rather than freed — a small, bounded leak, never a correctness bug.)

Note: the issue's own minimal repro (a *template-literal* `x` in `(m) -> (define x 10)`, not a pattern-variable substitution) is **not** fixed and correctly still errors — that's genuine hygiene behavior, confirmed matching both chibi-scheme and guile.

## Additional fixes as a result

- 6 of SRFI 148's reference test suite assertions previously quarantined behind `test-expect-fail` (citing #1800) now pass for real: "Match quoted pattern with quoted element", "Match quoted pattern with eager macro use", "Match unquoted pattern with element", `em-cons`, `em-list`, `em-append`.
- SRFI 251's "known gap: macro-produced definition across a nested scope" test — the same underlying bug reached via a macro invoked from a nested lambda scope different from its own definition scope — now computes the spec's correct answer instead of raising. Converted from a documented gap to a real `test-equal`, with `lib/srfi/251.sld`'s header comment updated to match.

## Test plan

- [x] New regression test: `tests/scheme/hygiene/macro-body-define-visibility.scm` (fails without the fix, passes with it)
- [x] New Zig unit test: `tests_macros.zig` — covers the fix plus its interaction with the pre-existing global-alias-shadow mechanism in the same body
- [x] `zig build test` — full unit suite green
- [x] `bash tests/scheme/run-all.sh` — 2001/2001 pass (up from 2000/2001 pre-fix, after the SRFI 251 update)
- [x] `zig fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)