### PR TITLE
Hygiene-rename identifiers inside quote, fixing SRFI 148's em-gensym (#1801)

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const compiler_mod = @import("compiler.zig");
 const conditionals = @import("compiler_conditionals.zig");
+const expander = @import("expander.zig");
 const Value = types.Value;
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
@@ -312,8 +313,11 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
     }
 
     if (!types.isPair(tmpl)) {
-        // Atom: treat as quoted constant
-        const idx = try self.addConstant(tmpl);
+        // Atom: treat as quoted constant. Strip hygiene renames first, same
+        // as plain quote (#1801) -- a quasiquote template's literal atoms
+        // are quoted data exactly like `quote`'s.
+        const stripped = expander.stripHygieneFromDatum(self.gc, tmpl) catch return CompileError.OutOfMemory;
+        const idx = try self.addConstant(stripped);
         try self.emitOp(.load_const);
         try self.emitU16(dst);
         try self.emitU16(idx);

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -2,13 +2,17 @@ const std = @import("std");
 const types = @import("types.zig");
 const compiler_mod = @import("compiler.zig");
 const globals_mod = @import("globals.zig");
+const expander = @import("expander.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
 
 pub fn compileQuote(self: *Compiler, args: Value, dst: u16) CompileError!void {
     if (args == types.NIL) return CompileError.InvalidSyntax;
-    const datum = types.car(args);
+    // See ir.zig's lowerQuote: strip hygiene renames from a quoted datum's
+    // template-introduced identifiers now that it's becoming a real literal
+    // Value (#1801).
+    const datum = expander.stripHygieneFromDatum(self.gc, types.car(args)) catch return CompileError.OutOfMemory;
     const idx = try self.addConstant(datum);
     try self.emitOp(.load_const);
     try self.emitU16(dst);

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -800,10 +800,19 @@ fn collectPatternVars(pattern: Value, literals: []const Value, names: *[128][]co
 // renameForHygiene must mask off every flag that doesn't change renaming
 // behavior so scope-table entries stay consistent across contexts.
 const ESCAPE_FLAG: u32 = 0x80000000; // inside (... <template>) ellipsis escape
-const QUOTE_FLAG: u32 = 0x40000000; // inside (quote ...): substitute, don't rename
+const QUOTE_FLAG: u32 = 0x40000000; // inside (quote ...): substitute, hygiene-rename (#1801)
 const BINDING_FLAG: u32 = 0x20000000; // identifier is in binding position
 const NESTED_SR_FLAG: u32 = 0x10000000; // inside a nested syntax-rules template
 const LET_PAIR_FLAG: u32 = 0x08000000; // template is a single let-binding (var init) pair
+// Re-walking a usertext-marker-protected splice (an enclosing expansion's
+// pattern-var value, spliced verbatim into a nested syntax-rules template) in
+// substitute-only mode. Reuses QUOTE_FLAG's "substitute, expand ellipses"
+// walk shape, but MUST suppress renameForHygiene's QUOTE_FLAG rename (#1801):
+// unlike a literal identifier written directly in a quote form, this
+// identifier is use-site DATA from an enclosing expansion, never a
+// template-introduced identifier of the CURRENT one, so it must always pass
+// through unrenamed -- exactly the pre-#1801 QUOTE_FLAG behavior.
+const VERBATIM_FLAG: u32 = 0x00800000;
 // Quasiquote nesting depth (0-7, saturating). Symbols under `quasiquote` are
 // DATA — they must not be hygiene-renamed — but a depth-matching `unquote`
 // re-enters expression territory where renaming resumes. Three bits cover any
@@ -921,6 +930,98 @@ fn stripUsertextWalk(gc: *GC, expr: Value, depth: u16) void {
     }
 }
 
+/// Strip hygienic rename prefixes (`__hyg_N_`) from every symbol reachable
+/// from a fully-expanded `quote`/quasiquote-literal datum, returning the
+/// (possibly different) top-level value. renameForHygiene now hygiene-renames
+/// a template-introduced identifier inside `(quote ...)` exactly like any
+/// other, so that two separate macro expansions producing "the same" quoted
+/// identifier stay distinguishable via bound-identifier=?/free-identifier=?
+/// while still pure, uncompiled syntax (#1801). This function is the other
+/// half of that fix: called from every site that compiles a quoted datum
+/// into a literal runtime Value (plain quote, quasiquote's literal atoms),
+/// it removes those renames so the actual VALUE is unaffected -- ordinary
+/// macros that quote a fixed tag symbol still need `(eq? (macro) (macro))`
+/// to hold once the code runs. Mirrors stripUsertextWalk's in-place mutation
+/// and cycle/depth guards.
+pub fn stripHygieneFromDatum(gc: *GC, expr: Value) !Value {
+    if (types.isSymbol(expr)) return stripSymbolRename(gc, expr);
+    if (types.isPair(expr) or types.isVector(expr)) {
+        var root = expr;
+        gc.pushRoot(&root);
+        defer gc.popRoot();
+        try stripHygieneWalk(gc, expr, 4096);
+    }
+    return expr;
+}
+
+/// Rename a single symbol back to its base name if it carries a hygienic
+/// prefix, else return it unchanged. Factored out so stripHygieneWalk (which
+/// must recurse into itself for nested pairs/vectors) doesn't call back into
+/// stripHygieneFromDatum -- two functions with inferred error sets calling
+/// each other is a dependency loop Zig 0.16 rejects outright.
+fn stripSymbolRename(gc: *GC, sym: Value) !Value {
+    const name = types.symbolName(sym);
+    const stripped = types.stripHygienicPrefix(name);
+    if (stripped.len == name.len) return sym;
+    return gc.allocSymbol(stripped);
+}
+
+fn stripHygieneWalk(gc: *GC, expr: Value, depth: u16) !void {
+    if (depth == 0) return;
+    if (types.isVector(expr)) {
+        const vec = types.toObject(expr).as(types.Vector);
+        for (vec.data, 0..) |elem, i| {
+            if (types.isSymbol(elem)) {
+                const stripped = try stripSymbolRename(gc, elem);
+                if (stripped != elem) {
+                    gc.writeBarrier(types.toObject(expr), stripped);
+                    vec.data[i] = stripped;
+                }
+            } else {
+                try stripHygieneWalk(gc, elem, depth - 1);
+            }
+        }
+        return;
+    }
+    if (!types.isPair(expr)) return;
+    var cur = expr;
+    var hare = expr;
+    while (true) {
+        const car_v = types.car(cur);
+        if (types.isSymbol(car_v)) {
+            const stripped = try stripSymbolRename(gc, car_v);
+            if (stripped != car_v) {
+                gc.writeBarrier(types.toObject(cur), stripped);
+                types.setCar(cur, stripped);
+            }
+        } else {
+            try stripHygieneWalk(gc, car_v, depth - 1);
+        }
+        const cdr_v = types.cdr(cur);
+        if (types.isSymbol(cdr_v)) {
+            const stripped = try stripSymbolRename(gc, cdr_v);
+            if (stripped != cdr_v) {
+                gc.writeBarrier(types.toObject(cur), stripped);
+                types.setCdr(cur, stripped);
+            }
+            return;
+        }
+        if (types.isVector(cdr_v)) {
+            try stripHygieneWalk(gc, cdr_v, depth - 1);
+            return;
+        }
+        if (!types.isPair(cdr_v)) return;
+        cur = cdr_v;
+        // Tortoise-hare on the cdr spine, same as stripUsertextWalk: this
+        // walk only rewrites symbols in place, never restructures pairs, so
+        // advancing the hare over the (possibly rewritten-in-place) spine
+        // stays safe.
+        if (types.isPair(hare)) hare = types.cdr(hare);
+        if (types.isPair(hare)) hare = types.cdr(hare);
+        if (hare == cur) return;
+    }
+}
+
 /// Whether an ellipsis element template references any outer list binding —
 /// the condition under which instantiateEllipsis can find a repeat count.
 /// Inside a nested syntax-rules template, an ellipsis whose element
@@ -1013,7 +1114,32 @@ fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_scop
         const inner = unwrapUsertext(template);
         // A forged cyclic marker chain unwraps to itself: treat as opaque data.
         if (isUsertextPair(inner)) return inner;
-        const new_inner = try instantiateTemplate(gc, inner, bindings, (intro_scope | QUOTE_FLAG) & ~NESTED_SR_FLAG, literals, macro_keyword, globals, macros);
+        // A marker-protected chunk that is ITSELF, directly, a `(quote X)`
+        // form (e.g. em-gensym's own `'g` template text, captured wholesale
+        // as em-syntax-rules's own `template` pattern-var value and spliced,
+        // marker-protected, into the generated macro's stored transformer)
+        // is not opaque use-site data -- it's the ORIGINAL macro author's own
+        // literal template text, merely routed through em-syntax-rules's
+        // multi-step desugaring plumbing. Such an identifier must still get
+        // a fresh hygiene rename per invocation (#1801), so this case is
+        // excluded from VERBATIM_FLAG and falls through to the normal quote
+        // handling below. A chunk that merely CONTAINS a quote/quasiquote
+        // somewhere within a larger structure -- e.g. `(em `(let ((e ...))
+        // ...))`, where the let-bound `e` must stay verbatim to match a
+        // reference threaded through a completely separate expansion event
+        // (SRFI 148's own CK-machine, which compiles sub-pieces at different
+        // times) -- or a bare symbol (an ordinary pattern-var's actual
+        // use-site value, e.g. SRFI 257's accumulator rebinds) keeps the
+        // original, always-verbatim treatment: only the EXACT `(quote
+        // <datum>)` shape at the very top of the protected chunk counts,
+        // never one merely nested deeper inside.
+        const is_direct_quote = types.isPair(inner) and
+            types.isSymbol(types.car(inner)) and
+            std.mem.eql(u8, types.symbolName(types.car(inner)), "quote") and
+            types.isPair(types.cdr(inner)) and
+            types.cdr(types.cdr(inner)) == types.NIL;
+        const verbatim_bits: u32 = if (is_direct_quote) 0 else VERBATIM_FLAG;
+        const new_inner = try instantiateTemplate(gc, inner, bindings, (intro_scope | QUOTE_FLAG | verbatim_bits) & ~NESTED_SR_FLAG, literals, macro_keyword, globals, macros);
         if (isUsertextPair(new_inner)) return new_inner; // already protected
         if (!types.isSymbol(new_inner) and !types.isPair(new_inner)) return new_inner;
         var inner_root = new_inner;
@@ -1492,32 +1618,6 @@ fn scopeTableContains(scope: u32, name: []const u8) bool {
 }
 
 fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.StringHashMap(Value)) !Value {
-    if ((scope & QUOTE_FLAG) != 0) {
-        // Inside a nested syntax-rules template, a quoted identifier may be a
-        // reference to that inner macro's OWN pattern variable rather than
-        // inert literal data -- e.g. `((_ y) '(fixed y))`: the pattern's `y`
-        // is walked without QUOTE_FLAG and already claimed a hygienic rename
-        // in scope_table (case 5 below), but the template's `y` sits inside
-        // `quote` and used to always come back unrenamed, splitting the two
-        // occurrences (the inner macro's own matcher would then never bind
-        // its own template's `y` to anything, and the reference passed
-        // through literally). Reusing the SAME clean_scope lookup as the
-        // non-quoted path (QUOTE_FLAG stripped, so the two occurrences hash
-        // identically) restores that consistency when a same-scope rename
-        // already exists. Genuinely inert quoted data (no matching pattern-
-        // side rename, e.g. a literal symbol the inner template just quotes)
-        // keeps today's behavior: emitted verbatim, unrenamed.
-        if ((scope & NESTED_SR_FLAG) != 0) {
-            const clean_scope = scope & ~(BINDING_FLAG | NESTED_SR_FLAG | LET_PAIR_FLAG | QQ_DEPTH_MASK | QUOTE_FLAG);
-            for (scope_table[0..scope_table_count]) |entry| {
-                if (entry.scope == clean_scope and std.mem.eql(u8, entry.original_name, name)) {
-                    return gc.allocSymbol(entry.renamed_to);
-                }
-            }
-        }
-        return gc.allocSymbol(name);
-    }
-
     // Already renamed by an enclosing expansion: macro-generating macros
     // bake __hyg_ names into the inner macro's stored template. Gensyms are
     // globally unique, so renaming again cannot prevent any capture — it
@@ -1528,8 +1628,49 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
     // can flow back through a macro whose template re-emits it (e.g. SRFI 257's
     // ~etc, where the recursive (loop ...) call rides inside a submatch
     // argument). Re-renaming it splits the reference from the letrec binding.
+    // Checked before the quote branch below too, so a quoted occurrence of an
+    // already-renamed name is passed through rather than re-minted.
     if (std.mem.startsWith(u8, name, "__hyg_") or std.mem.startsWith(u8, name, "__nlet_"))
         return gc.allocSymbol(name);
+
+    // A usertext-marker splice being re-walked in substitute-only mode: this
+    // name is use-site data from an ENCLOSING expansion, not a template-
+    // introduced identifier of this one, so it must never be renamed --
+    // regardless of QUOTE_FLAG, which is also set here purely to get the
+    // rest of the quote-mode walk (substitute, expand ellipses). See
+    // VERBATIM_FLAG's own comment.
+    if ((scope & VERBATIM_FLAG) != 0) return gc.allocSymbol(name);
+
+    if ((scope & QUOTE_FLAG) != 0) {
+        // A template-introduced identifier inside `(quote ...)` is still an
+        // IDENTIFIER at the macro-expansion level, not yet inert data: two
+        // separate expansions of e.g. `(define-syntax gensym (syntax-rules ()
+        // ((gensym) 'g)))` must stay distinguishable via
+        // bound-identifier=?/free-identifier=?-style comparisons built out of
+        // further macro expansion (nested define-syntax/literal matching),
+        // even though `g` will eventually print/compare as the plain symbol
+        // `g` once actually compiled into a literal runtime value (#1801).
+        // So a quoted, template-introduced identifier is hygiene-renamed
+        // exactly like a non-quoted one -- deduped within THIS expansion via
+        // the same clean_scope lookup (needed so a nested syntax-rules
+        // template's quoted reference to its OWN pattern variable `y` in
+        // `((_ y) '(fixed y))` picks up the SAME rename the pattern side
+        // already claimed) -- and the compiler strips the `__hyg_` prefix
+        // back off wherever it compiles a REAL `(quote ...)` datum to a
+        // literal Value (stripHygieneFromDatum, called from quote and
+        // quasiquote compilation), so ordinary uses of `'sym` in a template
+        // still behave exactly as before once the code actually runs: two
+        // unrelated macro expansions that both quote the same literal tag
+        // still produce `eq?` symbols.
+        const clean_scope = scope & ~(BINDING_FLAG | NESTED_SR_FLAG | LET_PAIR_FLAG | QQ_DEPTH_MASK | QUOTE_FLAG);
+        for (scope_table[0..scope_table_count]) |entry| {
+            if (entry.scope == clean_scope and std.mem.eql(u8, entry.original_name, name)) {
+                return gc.allocSymbol(entry.renamed_to);
+            }
+        }
+        return mintHygienicRename(gc, name, clean_scope);
+    }
+
     const in_binding = (scope & BINDING_FLAG) != 0;
     // Strip context flags that don't change renaming, so the same template
     // identifier gets the same gensym inside and outside those contexts
@@ -1596,7 +1737,15 @@ fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.String
         }
     }
 
-    // Generate a fresh hygienic name for truly new identifiers
+    return mintHygienicRename(gc, name, clean_scope);
+}
+
+/// Generate a fresh hygienic name for a truly new template-introduced
+/// identifier and record it in scope_table (keyed by clean_scope) so later
+/// references to the same original name within this expansion, quoted or
+/// not, resolve to the same rename. Callers have already checked
+/// scope_table for an existing entry.
+fn mintHygienicRename(gc: *GC, name: []const u8, clean_scope: u32) !Value {
     const gensym_id = freshGensymId();
     var buf: [128]u8 = undefined;
     const len = std.fmt.bufPrint(&buf, "__hyg_{d}_{s}", .{ gensym_id, name }) catch

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -4,6 +4,7 @@ const memory = @import("memory.zig");
 const compiler_mod = @import("compiler.zig");
 const globals_mod = @import("globals.zig");
 const timings = @import("timings.zig");
+const expander = @import("expander.zig");
 
 const Value = types.Value;
 const OpCode = types.OpCode;
@@ -302,6 +303,16 @@ pub const IR = struct {
     // primitive's value at compile time no longer reflects its value at the
     // call site. Populated conservatively (whole-form scan) by the compiler.
     set_targets: ?*const std.StringHashMap(void) = null,
+    // GC that owns the Values being lowered, needed by lowerQuote to strip
+    // hygiene renames from a quoted datum (#1801). `compiler.gc` already
+    // supplies this for ordinary compilation; standalone lowering paths with
+    // no Compiler (the LLVM native backend, IR unit tests) set this
+    // explicitly when they have one. Deliberately NOT defaulted to the
+    // memory.gc_instance threadlocal: some standalone callers (e.g.
+    // tests_native.zig) construct their own short-lived GC without ever
+    // pointing that threadlocal at it, so trusting it here risked rooting
+    // onto a stale or unrelated GC.
+    gc: ?*memory.GC = null,
 
     pub fn init(allocator: std.mem.Allocator) IR {
         return .{
@@ -695,12 +706,13 @@ pub fn lowerAndOptimize(
     return node;
 }
 
-pub fn lowerSingleExpr(allocator: std.mem.Allocator, expr: Value) CompileError!*Node {
-    return lowerSingleExprTail(allocator, expr, false);
+pub fn lowerSingleExpr(allocator: std.mem.Allocator, gc: ?*memory.GC, expr: Value) CompileError!*Node {
+    return lowerSingleExprTail(allocator, gc, expr, false);
 }
 
-pub fn lowerSingleExprTail(allocator: std.mem.Allocator, expr: Value, is_tail: bool) CompileError!*Node {
+pub fn lowerSingleExprTail(allocator: std.mem.Allocator, gc: ?*memory.GC, expr: Value, is_tail: bool) CompileError!*Node {
     var scratch = IR.init(allocator);
+    scratch.gc = gc;
     return lowerAndOptimize(&scratch, expr, null, is_tail);
 }
 
@@ -724,7 +736,14 @@ fn lowerIf(ir: *IR, args: Value, macros: ?*std.StringHashMap(Value)) CompileErro
 
 fn lowerQuote(ir: *IR, args: Value) CompileError!*Node {
     if (args == types.NIL) return CompileError.InvalidSyntax;
-    return ir.makeConst(types.car(args));
+    const datum = types.car(args);
+    // A template-introduced identifier inside `(quote ...)` is hygiene-
+    // renamed like any other during expansion (#1801); strip it back to its
+    // base name now that this quote is being compiled into a real literal
+    // Value, so the rename never leaks into the running program.
+    const gc: ?*memory.GC = ir.gc orelse if (ir.compiler) |c| c.gc else null;
+    const stripped = if (gc) |g| expander.stripHygieneFromDatum(g, datum) catch return CompileError.OutOfMemory else datum;
+    return ir.makeConst(stripped);
 }
 
 fn lowerBegin(ir: *IR, args: Value, macros: ?*std.StringHashMap(Value)) CompileError!*Node {

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const ir = @import("ir.zig");
 const types = @import("types.zig");
+const memory = @import("memory.zig");
 const printer = @import("printer.zig");
 const native_decls = @import("native_decls.zig");
 // #1499 forward-reference reservation + finalization stubs (mutual tail calls).
@@ -156,6 +157,12 @@ pub const LLVMEmitter = struct {
     // VM (unit tests) — then no name is treated as a macro, which is correct
     // because those tests never exercise macros inside these forms.
     macros: ?*const std.StringHashMap(Value) = null,
+    // GC backing the Values being emitted, threaded into every scratch IR
+    // this emitter lowers (lowerSingleExpr/lowerSingleExprTail, and the
+    // per-lambda body_ir in llvm_emit_lambda.zig) so lowerQuote can strip
+    // hygiene renames from a macro-produced quoted datum (#1801). Null when
+    // driven without a VM (unit tests that never exercise such macros).
+    gc: ?*memory.GC = null,
     params: ?std.StringHashMap(u8),
     upvalues: ?std.StringHashMap(u8),
     tmp_counter: u32,
@@ -1010,7 +1017,7 @@ pub const LLVMEmitter = struct {
         // calls correctly; the standalone IR lowering below runs without a
         // macro table and would mis-lower a top-level (set! x (some-macro ...)).
         if (!self.inLexicalScope()) return self.emitEvalExpr(value);
-        const node = ir.lowerSingleExpr(self.allocator(), value) catch return self.emitEvalExpr(value);
+        const node = ir.lowerSingleExpr(self.allocator(), self.gc, value) catch return self.emitEvalExpr(value);
         return self.emitNode(node);
     }
 
@@ -1303,7 +1310,7 @@ pub const LLVMEmitter = struct {
     // enclosing scope — emitScopedValue's emitEvalExpr fallback would run the
     // operand in the global environment, the exact #1799 failure mode.
     fn emitScopedOperand(self: *LLVMEmitter, operand: Value) EmitError![]const u8 {
-        const node = ir.lowerSingleExpr(self.allocator(), operand) catch return error.UnsupportedNodeType;
+        const node = ir.lowerSingleExpr(self.allocator(), self.gc, operand) catch return error.UnsupportedNodeType;
         return self.emitNode(node);
     }
 

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -46,7 +46,7 @@ fn fmt(self: *LLVMEmitter, comptime f: []const u8, a: anytype) EmitError![]const
 // in-scope form to its enclosing form's abandon path (a top-level form has no
 // partial state to unwind at this point — the leaf lowers before any branch).
 fn lower(self: *LLVMEmitter, expr: Value, tail: bool) EmitError!*ir.Node {
-    return ir.lowerSingleExprTail(self.allocator(), expr, tail) catch return error.UnsupportedNodeType;
+    return ir.lowerSingleExprTail(self.allocator(), self.gc, expr, tail) catch return error.UnsupportedNodeType;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -67,6 +67,7 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
     if (boxed.rest_conflict) return null;
 
     var body_ir = ir.IR.init(self.allocator());
+    body_ir.gc = self.gc;
     defer body_ir.deinit();
     // Parameters shadow primitives of the same name; don't fold calls to them
     // using the built-in's semantics (issue #790).
@@ -139,6 +140,7 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     const own_boxed = freevars.analyzeBoxedParams(self, body_list, param_names.items, null) orelse return null;
 
     var body_ir = ir.IR.init(self.allocator());
+    body_ir.gc = self.gc;
     defer body_ir.deinit();
     // Parameters shadow primitives of the same name; don't fold calls to them
     // using the built-in's semantics (issue #790).
@@ -485,6 +487,7 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
     if (boxed.rest_conflict) return null;
 
     var body_ir = ir.IR.init(self.allocator());
+    body_ir.gc = self.gc;
     defer body_ir.deinit();
     // Parameters (including a rest parameter) shadow primitives of the same
     // name; don't fold calls to them using the built-in's semantics (#790).

--- a/src/llvm_emit_let.zig
+++ b/src/llvm_emit_let.zig
@@ -178,7 +178,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
                 return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             }
 
-            const node = ir.lowerSingleExpr(self.allocator(), init_expr) catch {
+            const node = ir.lowerSingleExpr(self.allocator(), self.gc, init_expr) catch {
                 return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             };
             const alloca = try self.freshTemp();
@@ -230,7 +230,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
                 return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             }
 
-            const node = ir.lowerSingleExpr(self.allocator(), init_expr) catch {
+            const node = ir.lowerSingleExpr(self.allocator(), self.gc, init_expr) catch {
                 return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             };
             const val = self.emitNode(node) catch {
@@ -276,7 +276,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         const rest = types.cdr(body_expr);
         const expr_is_tail = body_tail and (rest == types.NIL or !types.isPair(rest));
-        const node = ir.lowerSingleExprTail(self.allocator(), types.car(body_expr), expr_is_tail) catch {
+        const node = ir.lowerSingleExprTail(self.allocator(), self.gc, types.car(body_expr), expr_is_tail) catch {
             return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
         };
         // #827: if emitNode fails (e.g. a lambda that cannot be eval'd in

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -159,6 +159,10 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
 
     var ir_instance = ir_mod.IR.init(allocator);
     defer ir_instance.deinit();
+    // Lowered forms are already macro-expanded and may contain hygiene-
+    // renamed identifiers inside quoted data; lowerQuote needs the owning GC
+    // to strip those back to their base names (#1801).
+    ir_instance.gc = vm.gc;
 
     // Track names that are targets of define or set! in previous top-level
     // forms so constant folding does not inline primitive semantics for a
@@ -250,6 +254,9 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     // sent to the interpreter (which expands it) instead of being mis-compiled
     // as a call to a same-named global (#1496).
     emitter.macros = &vm.macros;
+    // Threaded into every scratch IR the emitter lowers, so lowerQuote can
+    // strip hygiene renames from a macro-produced quoted datum (#1801).
+    emitter.gc = vm.gc;
     timings.begin(.llvm_emit); // kaappi#1515: IR → LLVM IR text codegen
     emitter.emitProgram(ir_nodes.items) catch |err| {
         timings.end();

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -526,6 +526,10 @@ fn lowerAndPrint(vm: *VM, expr: Value, exit: *u8) void {
 
     var ir = ir_mod.IR.init(vm.gc.allocator);
     ir.globals = vm.globals;
+    // So the dumped tree matches what real compilation would build: lowerQuote
+    // strips hygiene renames from a quoted datum's template-introduced
+    // identifiers (#1801), which needs the owning GC.
+    ir.gc = vm.gc;
     defer ir.deinit();
 
     const node = ir_mod.lowerAndOptimize(&ir, expr, &vm.macros, false) catch |err| {
@@ -747,6 +751,7 @@ pub fn lowerFormToStringForTest(vm: *VM, a: std.mem.Allocator, expr: Value, no_o
 
     var ir = ir_mod.IR.init(a);
     ir.globals = vm.globals;
+    ir.gc = vm.gc;
     defer ir.deinit();
     const node = try ir_mod.lowerAndOptimize(&ir, expr, &vm.macros, false);
 

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -1021,6 +1021,55 @@ test "forged cyclic usertext-marker datum does not hang unwrap" {
     , 42);
 }
 
+test "quoted template symbol is eq? across separate macro invocations (#1801)" {
+    // #1801: renameForHygiene used to strip hygiene from a template-
+    // introduced identifier the instant it saw QUOTE_FLAG, which happened
+    // to make two separate expansions of `'g` collapse to the exact same
+    // bare symbol -- correct here, but for the wrong reason (an accident of
+    // never distinguishing them at all, rather than the compiler stripping
+    // a per-expansion hygienic rename back off). Guards against a fix that
+    // over-corrects and makes ordinary quoted-symbol macros stop producing
+    // eq? results; see tests_pipeline.zig for the complementary pre-compile
+    // check that the two expansions DO differ before this point.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax gen (syntax-rules () ((gen) 'g)))
+        \\  (eq? (gen) (gen)))
+    );
+}
+
+test "quoted template symbol still prints as the plain symbol (#1801)" {
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax gen (syntax-rules () ((gen) 'g)))
+        \\  (eq? 'g (gen)))
+    );
+}
+
+test "let-bound identifier and its quoted cross-macro reference stay consistent (#1801)" {
+    // A template-introduced identifier used both as a `let` binding (real
+    // code, inside quasiquote's literal structure) and, quoted, as an
+    // argument threaded to a SEPARATE macro (SRFI 148's simple-match /
+    // %compile-pattern shape, ported in tests/scheme/srfi/srfi148.scm) must
+    // resolve to the same base name once compiled. An earlier draft of the
+    // #1801 fix cleared VERBATIM_FLAG whenever entering ANY quote/quasiquote
+    // reached via a usertext-marker rewalk, which let the `let` binding's
+    // own hygienic rename diverge from a separately-compiled quoted
+    // reference to it -- desyncing the two.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax with-e-bound
+        \\    (syntax-rules ()
+        \\      ((_ helper)
+        \\       `(let ((e 42))
+        \\          ,(helper 'e)))))
+        \\  (define-syntax quote-arg
+        \\    (syntax-rules ()
+        \\      ((_ x) 'x)))
+        \\  (eq? 'e (eval (with-e-bound quote-arg) (interaction-environment))))
+    );
+}
+
 test "nested quasiquote template matches the directly written form" {
     // The template walk tracks quasiquote nesting (3 bits, 0-7, saturating);
     // a nested tower with depth-matching unquotes must expand to exactly what

--- a/src/tests_pipeline.zig
+++ b/src/tests_pipeline.zig
@@ -189,6 +189,32 @@ test "expand: recursive macro expands fully" {
     try testing.expect(contains(got, "if"));
 }
 
+test "expand: two separate expansions of a quoted template symbol get distinct hygienic renames (#1801)" {
+    // #1801: a template-introduced identifier written directly inside
+    // `(quote ...)` (e.g. `'g`) used to come back bare, unrenamed, from
+    // EVERY expansion -- so two separate uses of `(gen)` were structurally
+    // indistinguishable even before compilation, breaking any macro-level
+    // identity check built out of further syntax-rules expansion (SRFI
+    // 148's em-gensym/bound-identifier=?). Fixed by hygiene-renaming inside
+    // quote exactly like anywhere else during expansion; the compiler
+    // strips that rename back off once it turns the quoted datum into a
+    // literal runtime Value (see tests_macros.zig's "quoted template symbol
+    // is eq?" test for that complementary, post-compile behavior).
+    var h: Harness = .{};
+    try h.init();
+    defer h.deinit();
+    try h.setup("(define-syntax gen (syntax-rules () ((gen) 'g)))");
+
+    const first = try h.expand("(gen)");
+    defer testing.allocator.free(first);
+    const second = try h.expand("(gen)");
+    defer testing.allocator.free(second);
+
+    try testing.expect(contains(first, "__hyg_"));
+    try testing.expect(contains(second, "__hyg_"));
+    try testing.expect(!std.mem.eql(u8, first, second));
+}
+
 // ── ir: structure ────────────────────────────────────────────────────────────
 
 test "ir: if over a primitive comparison" {

--- a/tests/scheme/hygiene/quote-identifier-1801.scm
+++ b/tests/scheme/hygiene/quote-identifier-1801.scm
@@ -1,0 +1,119 @@
+;; Regression test for #1801: two separate expansions of a macro whose
+;; template introduces "the same" literal symbol inside `quote` were
+;; wrongly bound-identifier=? to each other. renameForHygiene stripped
+;; hygiene from a template-introduced identifier the instant it saw
+;; QUOTE_FLAG, before any per-expansion distinguishing information could
+;; ever be recorded -- so two macro-generated `'g`s always came out as the
+;; exact same bare symbol at the SYNTAX level, not just as data.
+;;
+;; Found via SRFI 148's em-gensym, which relies on hygiene ALONE (not a
+;; counter) for uniqueness: `(em-gensym)` is defined as `'g` and depends on
+;; each expansion's `g` being a fresh, distinguishable identifier when
+;; compared via bound-identifier=?. See tests/scheme/srfi/srfi148.scm's
+;; "em-gensym"/"em-generate-temporaries" cases, which exercise this
+;; directly through SRFI 148's own eager-syntax-rules machinery -- the
+;; cases here isolate the same property without depending on that library.
+;;
+;; Fixed by hygiene-renaming a template-introduced identifier inside
+;; `(quote ...)` exactly like any other during expansion (distinguishable
+;; per-expansion, deduped within one expansion via the same scope_table as
+;; everything else), then stripping that rename back off wherever the
+;; compiler turns a quoted datum into a literal runtime Value
+;; (expander.stripHygieneFromDatum, called from quote and quasiquote
+;; compilation) -- so the actual VALUE two unrelated expansions produce is
+;; still `eq?` once the code runs, even though the two are now
+;; distinguishable as SYNTAX before that point.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 148))
+
+(test-begin "quote-identifier-1801")
+
+;; --- The exact repro from #1801 ---
+
+(test-assert "SRFI 148: em-gensym produces distinguishable identifiers per expansion"
+  (em (em-not (em-bound-identifier=? (em-gensym) (em-gensym)))))
+
+(test-assert "SRFI 148: em-generate-temporaries relies on the same property"
+  (em (em-not (em-apply 'em-bound-identifier=? (em-generate-temporaries (em-2))))))
+
+;; --- The fix must not change ordinary, non-macro-generating-macro
+;;     behavior: a ordinary macro that quotes a fixed tag symbol must still
+;;     produce `eq?` results across separate invocations once the code
+;;     actually runs, exactly as before #1801. Only the SYNTAX-level
+;;     identity (visible through bound-identifier=?-style tricks) changes;
+;;     the runtime VALUE does not. ---
+
+(define-syntax gen
+  (syntax-rules ()
+    ((gen) 'g)))
+
+(test-assert "ordinary quoted-symbol macro: eq? across separate invocations"
+  (eq? (gen) (gen)))
+
+(test-equal "ordinary quoted-symbol macro: still prints as the plain symbol"
+  'g
+  (gen))
+
+;; A macro quoting a whole literal list, not just a bare symbol.
+(define-syntax gen-list
+  (syntax-rules ()
+    ((gen-list) '(a b c))))
+
+(test-equal "ordinary quoted-list macro: unaffected by the fix"
+  '(a b c)
+  (gen-list))
+
+(test-assert "ordinary quoted-list macro: equal? across separate invocations"
+  (equal? (gen-list) (gen-list)))
+
+;; --- A template-introduced identifier used consistently both as a `let`
+;;     binding (real, executable code) and, quoted, as data referencing
+;;     that same binding's name -- both occurrences must resolve to the
+;;     SAME rename within one expansion, and both must strip back to the
+;;     same base name once compiled, so the generated code still works.
+;;     (Regression guard: an earlier version of this fix made the `let`
+;;     binding hygiene-rename independently of a same-named quoted
+;;     reference threaded through a SEPARATE, later macro expansion,
+;;     desyncing the two -- see the "generated macro quoting user data"
+;;     case below for that specific shape.) ---
+
+(define-syntax with-e-bound
+  (syntax-rules ()
+    ((_ helper)
+     `(let ((e 42))
+        ,(helper 'e)))))
+
+;; Quotes its argument back: (quote-arg 'e) expands to ''e, so evaluating
+;; the assembled program yields the SYMBOL e, not the let-bound value 42.
+;; What matters is WHICH symbol comes out: if the let binding's `e` and
+;; this quoted reference to `e` ever get hygiene-renamed inconsistently
+;; (the regression this guards against), the result is some other,
+;; mismatched symbol instead of plain `e`.
+(define-syntax quote-arg
+  (syntax-rules ()
+    ((_ x) 'x)))
+
+(test-equal "let-bound identifier and its quoted, unquote-spliced reference agree"
+  'e
+  (eval (with-e-bound quote-arg) (interaction-environment)))
+
+;; --- A macro-generating-macro that splices USER-SUPPLIED data (not its own
+;;     template text) into a nested syntax-rules template must still treat
+;;     that data as opaque/verbatim, never hygiene-renaming it -- this is
+;;     the usertext-marker protection SRFI 257 relies on, and must survive
+;;     unchanged by #1801's fix (which only affects a macro's OWN literal
+;;     template text quoted directly, not pattern-variable values threaded
+;;     through from a use site). ---
+
+(define-syntax vb
+  (syntax-rules ()
+    ((_ e)
+     (let-syntax ((g (syntax-rules () ((_) (vector-ref #(e) 0)))))
+       (g)))))
+
+(test-equal "usertext splice into a nested template stays verbatim (not renamed)"
+  'foo
+  (vb foo))
+
+(let ((runner (test-runner-current)))
+  (test-end "quote-identifier-1801")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi148.scm
+++ b/tests/scheme/srfi/srfi148.scm
@@ -21,42 +21,42 @@
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi148.scm
 ;;
 ;; Deviations from the reference suite: none of the test logic itself was
-;; changed. 2 of the ~142 assertions are marked test-expect-fail below,
-;; citing a SEPARATE, general, pre-existing engine bug found while porting
-;; this suite -- not specific to SRFI 148 or to this library's own
-;; combinators, which are otherwise fully verified correct:
+;; changed. All ~142 assertions now pass -- the two general, pre-existing
+;; engine bugs found while porting this suite (neither specific to SRFI 148
+;; or to this library's own combinators) are both fixed:
+;;   - #1800: a macro that expands to a bare (define x v) in body position
+;;     didn't make x visible to later sibling forms in the same body.
+;;     Reproduced with a plain, non-eager syntax-rules macro -- nothing to
+;;     do with em-syntax-rules. Affected "Match quoted pattern with quoted
+;;     element", "Match quoted pattern with eager macro use", "Match
+;;     unquoted pattern with element", em-cons, em-list, em-append. Fixed:
+;;     expandAndCompileMacroUse's post-expansion cleanup popped every
+;;     compiler local added while compiling a macro's final expanded form
+;;     back off before returning, on the mistaken assumption that everything
+;;     added during a macro-use compile is transient chain bookkeeping
+;;     (hygienic aliases). A body-scope `define` reached through the
+;;     expansion adds a REAL, sibling-visible local, not an alias, and needs
+;;     to survive.
 ;;   - #1801: two separate expansions of a macro whose template introduces
-;;     "the same" literal symbol are wrongly bound-identifier=? to each
-;;     other. Breaks em-gensym/em-generate-temporaries, which deliberately
+;;     "the same" literal symbol were wrongly bound-identifier=? to each
+;;     other. Broke em-gensym/em-generate-temporaries, which deliberately
 ;;     rely on hygiene alone (not a counter) for uniqueness, per the
-;;     reference's own (em-gensym) => 'g definition.
-;;
-;; #1800 (a macro expanding to a bare (define x v) in body position didn't
-;; make x visible to later sibling forms -- affected "Match quoted pattern
-;; with quoted element", "Match quoted pattern with eager macro use",
-;; "Match unquoted pattern with element", em-cons, em-list, em-append) is
-;; FIXED: expandAndCompileMacroUse's post-expansion cleanup popped every
-;; compiler local added while compiling a macro's final expanded form back
-;; off before returning, on the mistaken assumption that everything added
-;; during a macro-use compile is transient chain bookkeeping (hygienic
-;; aliases). A body-scope `define` reached through the expansion adds a
-;; REAL, sibling-visible local, not an alias, and needs to survive.
+;;     reference's own (em-gensym) => 'g definition. Fixed:
+;;     renameForHygiene hygiene-renames a template-introduced identifier
+;;     inside `(quote ...)` exactly like any other during expansion, and the
+;;     compiler strips that rename back off wherever it compiles a quoted
+;;     datum to a literal Value (expander.stripHygieneFromDatum, called from
+;;     quote and quasiquote compilation) -- see src/expander.zig and the
+;;     regression tests in src/tests_macros.zig and
+;;     tests/scheme/hygiene/quote-identifier-1801.scm.
 ;; A third, more severe issue (#1802: importing this library alone costs
-;; ~80s, superlinearly in definition count, independent of test count) is
-;; NOT a per-assertion failure and has no test-expect-fail equivalent --
-;; see lib/srfi/148.sld's own header and issue #1802 for status; this file
-;; should not be wired into run-all.sh until that's resolved.
+;; ~80s, superlinearly in definition count, independent of test count) was
+;; ALSO fixed separately (see lib/srfi/148.sld's own header); with all three
+;; blockers resolved, this file is wired into run-all.sh.
 
 (import (scheme base) (scheme process-context) (srfi 2) (srfi 64) (srfi 148))
 
 (test-begin "SRFI 148")
-
-;; Each name needs its own test-expect-fail call: passing several
-;; specifiers to ONE call ANDs them together (test-match-all), so a
-;; single batched call here would require a test to simultaneously BE both
-;; names at once -- impossible, hence matching nothing.
-(test-expect-fail "em-gensym")
-(test-expect-fail "em-generate-temporaries")
 
 (test-equal "Match quoted pattern with quoted element"
   10

--- a/tests/scheme/srfi/srfi211.scm
+++ b/tests/scheme/srfi/srfi211.scm
@@ -59,12 +59,24 @@
            (eq? (rename 'fresh-name-xyz) (rename 'fresh-name-xyz))))))
 (test-equal #t (rename-same? ))
 
+;; Freshness is checked via symbol->string, not a bare quoted rename: #1801
+;; fixed renameForHygiene to hygiene-rename a template-introduced identifier
+;; inside `(quote ...)` like any other during expansion, then strip that
+;; rename back off wherever the compiler turns a quoted datum into a literal
+;; Value -- correct per R7RS quote semantics (quote always yields the plain
+;; datum, so `(rename-capture)` returning the SAME bare `fresh-name-uvw` both
+;; times, not a distinct gensym, is now the right answer for `(list (rename
+;; 'quote) (rename 'fresh-name-uvw))`). This test's original form relied on
+;; the pre-fix bug (quote never stripped hygiene at all) to observe
+;; distinctness; symbol->string sidesteps stripping (it only ever touches
+;; symbols) so the test can still verify that `rename` itself produces a
+;; genuinely fresh identifier per invocation.
 (define-syntax rename-capture
   (er-macro-transformer
    (lambda (form rename compare)
-     (list (rename 'quote) (rename 'fresh-name-uvw)))))
+     (list (rename 'quote) (symbol->string (rename 'fresh-name-uvw))))))
 (test-assert "two invocations rename to distinct gensyms"
-             (not (eq? (rename-capture) (rename-capture))))
+             (not (string=? (rename-capture) (rename-capture))))
 
 ;;; --- rename accepts a whole datum: leaves renamed, structure rebuilt ---
 (define-syntax tree-rename


### PR DESCRIPTION
## Summary

Fixes #1801: two separate expansions of a macro whose template introduces "the same" literal symbol inside `quote` were wrongly `bound-identifier=?` to each other.

- **Root cause**: `renameForHygiene` stripped hygiene from a template-introduced identifier the instant it saw `QUOTE_FLAG`, before any per-expansion distinguishing info could ever be recorded. Two separate expansions of e.g. `(define-syntax gensym (syntax-rules () ((gensym) 'g)))` were therefore structurally identical **as syntax**, not just as data — breaking any `bound-identifier=?`/`free-identifier=?`-style macro trick built out of further expansion, including SRFI 148's `em-gensym`, which relies on hygiene alone (no counter) for uniqueness per its own `(em-gensym) => 'g` definition.
- **Fix**: a quoted, template-introduced identifier is now hygiene-renamed exactly like a non-quoted one, consistently within one expansion. A new `expander.stripHygieneFromDatum` strips that rename back off wherever the compiler turns a quoted datum into a literal `Value` (`quote` and quasiquote's literal atoms) — so ordinary macros that quote a fixed tag symbol still produce `eq?` results once the code runs.
- **Gotcha #1**: a pre-existing, unrelated reuse of `QUOTE_FLAG` (re-walking a usertext-marker splice from a macro-generating-macro in substitute-only mode, e.g. SRFI 257's accumulator rebinds) needed a new `VERBATIM_FLAG` to keep its never-rename behavior — it used to be indistinguishable from the em-gensym case now that `QUOTE_FLAG` itself renames. Conflating the two regressed a real, passing SRFI 148 spec example (`simple-match`).
- **Gotcha #2**: `lowerQuote` needs a `*GC` to strip hygiene; threading it through the LLVM native backend's standalone IR lowering surfaced that the ambient `memory.gc_instance` threadlocal is unsafe there (a couple of `tests_native.zig` unit tests build their own short-lived GC without pointing the threadlocal at it — crashed with "GC root stack overflow" / segfault). `IR` and `LLVMEmitter` gained an explicit `gc` field instead, threaded from every real construction site.
- Removes the now-stale `em-gensym`/`em-generate-temporaries` `test-expect-fail` entries in `tests/scheme/srfi/srfi148.scm`.

**Update 1**: rebased onto `main` after #1815 (fixing #1800) merged and also touched `tests/scheme/srfi/srfi148.scm`'s `test-expect-fail` block, in the mirror-image direction. With both #1800 and #1801 now fixed, the file needs **zero** `test-expect-fail` entries left — all ~142 of SRFI 148's reference-suite assertions pass for real. Also corrects a stale comment claiming that file isn't wired into `run-all.sh` — it already is, via the `tests/scheme/srfi/*.scm` glob, and runs in well under a second now that #1802 is fixed.

**Update 2**: found (via CI, then reproduced locally) that `tests/scheme/srfi/srfi211.scm`'s "two invocations rename to distinct gensyms" test accidentally depended on the very bug this PR fixes: it built `(list (rename 'quote) (rename 'fresh-name-uvw))` and compared two invocations with `eq?`, which only "passed" before this PR because quote never stripped hygiene at all — with it correctly fixed, quote now strips both invocations to the same plain `fresh-name-uvw` (correct: quote always yields the plain datum, real Scheme quote never preserves syntax identity through evaluation). Fixed the test to check via `symbol->string` instead (untouched by `stripHygieneFromDatum`, which only ever touches symbols), which still correctly verifies `rename` produces a fresh identifier per invocation without relying on quote preserving it.

## Test plan

- [x] `zig build test` — full unit suite green (1341 tests), including 4 new regression tests (`tests_macros.zig` x3, `tests_pipeline.zig` x1)
- [x] `bash tests/scheme/run-all.sh` — full Scheme suite green (2006 assertions incl. R7RS suite), including the new `tests/scheme/hygiene/quote-identifier-1801.scm`
- [x] `tests/scheme/srfi/srfi148.scm` — **142 of 142 expected passes**, 0 failures, 0 `test-expect-fail` needed
- [x] `tests/scheme/srfi/srfi211.scm` — 29 of 29 expected passes (after the test fix above)
- [x] Verified each new/changed test fails on the pre-fix source and passes on the post-fix source (via `git checkout <base-sha> --detach` + rebuild)
- [x] Reviewed the auto-merged overlap with #1811's SRFI 211 procedural-macro mechanism (also touches `renameForHygiene`) — its `expandProceduralMacro` passes a bare `freshScope()` value with no flag bits set, so it never reaches the new `QUOTE_FLAG`/`VERBATIM_FLAG` paths added here; confirmed non-interacting, not just non-conflicting
- [x] `zig fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)