### PR TITLE
Stamp cache_version in call_global/tail_call_global so the global cache can hit

### DIFF
--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -624,3 +624,57 @@ test "bootstrap stubs fail loudly without vm_bootstrap.install (#1375)" {
     try std.testing.expect(std.mem.indexOf(u8, detail, "vm_bootstrap.install") != null);
     try std.testing.expect(std.mem.indexOf(u8, detail, "'map'") != null);
 }
+
+// Regression test: `call_global`/`tail_call_global` populated the per-Function
+// inline cache but never stamped `cache_version`, leaving it at its default 0
+// while `global_version` had already been bumped past 0 by bootstrap
+// (vm_bootstrap.zig) and every library import (vm_library.zig). The fast-path
+// guard `cache_version == global_version` was therefore false forever, so every
+// call to a global fell through to a full hash-map lookup — measured ~1.4x
+// slower on call-dense code. `get_global` already self-healed (memset +
+// re-stamp); the two call opcodes did not.
+//
+// Asserting the stamp rather than timing keeps this deterministic. Child
+// SRFI-18 VMs masked the bug: initForThread leaves global_version at 0, which
+// happens to match the un-stamped default.
+test "call_global stamps cache_version so its inline cache can hit" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // `(>= i n)` and `(+ i 1)` both compile to call_global inside `tick`.
+    _ = try ctx.vm.eval("(define (tick i n) (if (>= i n) i (tick (+ i 1) n)))");
+    _ = try ctx.vm.eval("(tick 0 3)");
+
+    const tick = ctx.vm.globals.get("tick") orelse return error.TestUnexpectedResult;
+    const func = types.toObject(tick).as(types.Closure).func;
+
+    // The cache must exist and be valid for this VM, or it can never hit.
+    try std.testing.expect(func.global_cache != null);
+    try std.testing.expectEqual(ctx.vm.global_version, func.cache_version);
+    // global_version is non-zero in a real VM: that is precisely why an
+    // un-stamped (default 0) cache_version could never match.
+    try std.testing.expect(ctx.vm.global_version != 0);
+}
+
+// The heal must clear the whole cache before re-stamping (issue #812's rule),
+// never bless entries cached before the rebinding that bumped the version.
+// `(g)` compiles to call_global, so this exercises the call path specifically.
+test "call_global heal does not serve a stale callee after rebinding" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define (g) 1)");
+    _ = try ctx.vm.eval("(define counter 0)");
+    _ = try ctx.vm.eval("(define (redefine!) (set! g (lambda () 2)))");
+    _ = try ctx.vm.eval(
+        \\(define (h)
+        \\  (g)
+        \\  (redefine!)
+        \\  (set! counter 1)
+        \\  (g))
+    );
+    const result = try ctx.vm.eval("(h)");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
+}

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -913,6 +913,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         {
                             self.registers[base] = cache[sym_idx];
                         } else {
+                            if (the_func.cache_version != self.global_version) {
+                                @memset(cache, types.VOID);
+                                the_func.cache_version = self.global_version;
+                            }
                             const sym = try constantAt(self, the_func, sym_idx);
                             if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                             const name = types.symbolName(sym);
@@ -943,6 +947,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             @memset(cache, types.VOID);
                             cache[sym_idx] = val;
                             the_func.global_cache = cache;
+                            the_func.cache_version = self.global_version;
                         }
                     }
                 } else {
@@ -1029,6 +1034,10 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     callee = lookupGlobalLocked(self, env, name) orelse return raiseUndefinedVariable(self, name);
                     if (func.env == null and (types.isClosure(callee) or types.isNativeFn(callee))) {
                         if (func.global_cache) |cache| {
+                            if (func.cache_version != self.global_version) {
+                                @memset(cache, types.VOID);
+                                func.cache_version = self.global_version;
+                            }
                             if (sym_idx < cache.len) cache[sym_idx] = callee;
                         } else {
                             const cache = self.gc.allocator.alloc(Value, func.constants.items.len) catch {
@@ -1037,6 +1046,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             @memset(cache, types.VOID);
                             cache[sym_idx] = callee;
                             func.global_cache = cache;
+                            func.cache_version = self.global_version;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #1795. `call_global` and `tail_call_global` populated a `Function`'s global inline cache but never assigned `cache_version`, leaving it at its `types.zig` default of `0` while `global_version` is bumped past `0` before any user code runs (bootstrap + every library import). The fast-path guard `cache_version == global_version` was therefore false forever on the main VM — every global call fell through to a full hash-map lookup.

`get_global` already self-healed (memset the cache, then re-stamp) on a version mismatch; the two call opcodes were missed. This applies the same pattern to both:

- heal a stale cache (`@memset` + re-stamp) before refilling a slot
- stamp `cache_version` when the cache is first allocated

The memset-before-stamp preserves #812's rule that a version bump must not re-bless entries cached before the rebinding.

Child SRFI-18 threads masked this bug: `VM.initForThread` leaves a child's `global_version` at `0`, which accidentally matches the un-stamped default — so child threads hit the cache while the main thread never did. That discrepancy (a child OS thread running identical bytecode ~1.5x faster than main) is how it surfaced, during a parallelism audit.

Measured on x86_64 Linux, 20M-iteration call-dense loop: 2.45s → 1.72s (1.42x) on the main thread; the main-vs-child anomaly disappears (1.50x ratio → 1.00x).

## Test plan

- [x] Two new regression tests in `src/tests_core_eval.zig` assert the stamp directly (deterministic, not timing-based) and cover the heal path against #812's stale-callee rule. Verified to fail without the fix (`expected 694, found 0`) and pass with it.
- [x] `zig build test` — clean
- [x] `bash tests/scheme/run-all.sh` — 2005/2005 pass (610 Scheme files + 1395 R7RS suite), including the two flaky tests noted in the issue as environment-specific, which passed cleanly here

🤖 Generated with [Claude Code](https://claude.com/claude-code)