### PR TITLE
Make nstore prefixes byte-prefix-free, fixing tuple leaks across stores (#1717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Every nstore's prefix is now wrapped in a self-delimiting length header —
   the packed prefix's own byte length, itself packed via `engine-pack`,
   which is prefix-free across distinct non-negative integers — so one
-  nstore's scan can no longer pull in a different nstore's tuples
-  regardless of how their logical prefixes relate (#1717).
+  nstore's scan can no longer pull in a different nstore's tuples for any
+  two *distinct* prefixes, including one being an initial subsequence of
+  another. Two nstores given the exact same prefix remain
+  indistinguishable, which was never a supported way to tell them apart
+  (#1717).
 
 - **Library import silently let colliding export names resolve to
   whichever import came last** — `(import (srfi 28) (srfi 29))`, which both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   instead of reading as though fiber scheduling were the whole story
   (#1742).
 
+- **SRFI 168 nstore prefixes could leak tuples across stores when one
+  prefix was an initial subsequence of another** — `nstore-select`/
+  `nstore-where` prefix-scan the packed key bytes directly (via SRFI 167's
+  `engine-prefix-range`), and `engine-pack` concatenates each item's
+  encoding with no marker for "prefix ends here." Two nstores sharing an
+  engine/store, e.g. one keyed by `(list 0)` and another by `(list 0 0)`,
+  had the shorter prefix's scan also match the longer prefix's tuples.
+  Every nstore's prefix is now wrapped in a self-delimiting length header —
+  the packed prefix's own byte length, itself packed via `engine-pack`,
+  which is prefix-free across distinct non-negative integers — so one
+  nstore's scan can no longer pull in a different nstore's tuples
+  regardless of how their logical prefixes relate (#1717).
+
 - **Library import silently let colliding export names resolve to
   whichever import came last** — `(import (srfi 28) (srfi 29))`, which both
   export `format`, picked whichever library was written last in the

--- a/lib/srfi/168.sld
+++ b/lib/srfi/168.sld
@@ -39,14 +39,21 @@
 ;;;    internally, no laziness is actually lost.
 ;;;  - Hooks reuse SRFI 167's minimal hook object directly (`make-okvs-hook`
 ;;;    et al.) instead of defining a second one.
-;;;  - Prefixes must be pairwise non-prefixing across nstores sharing an
-;;;    engine/store: `%all-tuples` prefix-scans the packed bytes directly,
-;;;    so an nstore whose prefix is an initial subsequence of another's
-;;;    (e.g. `(list 0)` vs `(list 0 0)`) would have its scan pull in the
-;;;    other nstore's tuples too. Not an issue for the spec's own worked
-;;;    example (a single nstore), but real if multiple nstores are meant to
-;;;    coexist — give each a prefix no other nstore's prefix extends,
-;;;    e.g. by starting every nstore's prefix with its own unique tag.
+;;;  - Every nstore's packed prefix is wrapped in a self-delimiting length
+;;;    header before it is used as a key prefix or a prefix-range scan key
+;;;    (`%prefix-tag`, used by both `%tuple-key` and `%all-tuples`): the
+;;;    header is the packed prefix's own byte length, itself packed via
+;;;    `engine-pack`, which is prefix-free across distinct non-negative
+;;;    integers (differing magnitude-byte-lengths diverge at the length
+;;;    byte itself; equal magnitude-byte-lengths produce equal-length
+;;;    encodings, which can only be a "prefix" of one another by being
+;;;    identical — see `%pack-integer` in lib/srfi/167.sld). This means one
+;;;    nstore's prefix-range scan can never pull in a different nstore's
+;;;    tuples sharing the same engine/store, even when one nstore's
+;;;    logical prefix is an initial subsequence of another's (e.g.
+;;;    `(list 0)` vs `(list 0 0)`) — fixed as kaappi#1717. Two nstores
+;;;    given the exact same prefix are still indistinguishable, which was
+;;;    never a supported way to tell them apart.
 ;;;
 ;;; Bindings are represented as SRFI 146 hash-mappings (`(srfi 146 hash)`,
 ;;; i.e. `hashmap`), matching the spec's text ("a mapping of bindings")
@@ -109,8 +116,17 @@
           (error (string-append who ": wrong number of items for this nstore")
                  items (%nstore-items ns))))
 
+    ;; See the header comment (kaappi#1717) for why this length header is
+    ;; needed: it makes each nstore's prefix tag prefix-free with respect to
+    ;; every other nstore's, even when one's logical prefix is an initial
+    ;; subsequence of another's.
+    (define (%prefix-tag ns)
+      (let* ((eng (%nstore-engine ns))
+             (packed (apply engine-pack eng (%nstore-prefix ns))))
+        (bytevector-append (engine-pack eng (bytevector-length packed)) packed)))
+
     (define (%tuple-key ns items)
-      (apply engine-pack (%nstore-engine ns) (append (%nstore-prefix ns) items)))
+      (bytevector-append (%prefix-tag ns) (apply engine-pack (%nstore-engine ns) items)))
 
     ;;; --- mutation ---
 
@@ -132,14 +148,12 @@
 
     ;;; --- pattern matching ---
 
-    (define (%drop lst n) (if (<= n 0) lst (%drop (cdr lst) (- n 1))))
-
     (define (%all-tuples transaction ns)
       (let* ((eng (%nstore-engine ns))
-             (prefix-key (apply engine-pack eng (%nstore-prefix ns)))
-             (gen (engine-prefix-range eng transaction prefix-key))
-             (plen (length (%nstore-prefix ns))))
-        (map (lambda (pair) (%drop (engine-unpack eng (car pair)) plen))
+             (tag (%prefix-tag ns))
+             (tag-len (bytevector-length tag))
+             (gen (engine-prefix-range eng transaction tag)))
+        (map (lambda (pair) (engine-unpack eng (bytevector-copy (car pair) tag-len)))
              (generator->list gen))))
 
     ;; Matches a pattern (a list where each position is a literal or an

--- a/tests/scheme/srfi/srfi168.scm
+++ b/tests/scheme/srfi/srfi168.scm
@@ -108,6 +108,48 @@
 (test-equal 1 (length friends-of-carol-via-alice))
 (test-equal "bob" (hashmap-ref (car friends-of-carol-via-alice) 'whom))
 
+;;; --- regression test for kaappi#1717 ---
+;;; Two nstores sharing one engine/store whose prefixes are initial
+;;; subsequences of each other (e.g. (list 0) vs (list 0 0)) must not leak
+;;; tuples across stores when one nstore's prefix-range scan runs.
+
+(define overlap-engine (make-default-engine))
+(define overlap-db (okvs-open "test-nstore-prefix-overlap"))
+;; short-store's prefix (list 0) is a byte-level initial subsequence of
+;; long-store's prefix (list 0 0) once both are packed with engine-pack.
+(define short-store (nstore overlap-engine (list 0) '(x y)))
+(define long-store (nstore overlap-engine (list 0 0) '(z)))
+
+;; Only long-store gets a tuple. Before the fix, short-store's prefix scan
+;; (using the raw packed bytes of (list 0) as its scan prefix) also matched
+;; long-store's key, since packing (list 0 0) starts with the same bytes as
+;; packing (list 0). Dropping short-store's 1-item prefix length from the
+;; unpacked (0 0 "long-val") left (0 "long-val") -- 2 elements, matching
+;; short-store's own 2-field arity -- so it was misread as belonging to
+;; short-store, x=0 y="long-val", even though short-store never got it.
+(nstore-add! overlap-db long-store (list "long-val"))
+
+(test-equal 0
+  (length (generator->pairs
+            (nstore-select overlap-db short-store (list (nstore-var 'x) (nstore-var 'y))))))
+(test-equal '("long-val")
+  (map (lambda (hm) (hashmap-ref hm 'z))
+       (generator->pairs (nstore-select overlap-db long-store (list (nstore-var 'z))))))
+
+;; Adding a genuine short-store tuple must be visible only there, and must
+;; not disturb long-store's own (still-correct) view.
+(nstore-add! overlap-db short-store (list "sx" "sy"))
+
+(define short-results
+  (generator->pairs (nstore-select overlap-db short-store (list (nstore-var 'x) (nstore-var 'y)))))
+(test-equal 1 (length short-results))
+(test-equal "sx" (hashmap-ref (car short-results) 'x))
+(test-equal "sy" (hashmap-ref (car short-results) 'y))
+
+(test-equal '("long-val")
+  (map (lambda (hm) (hashmap-ref hm 'z))
+       (generator->pairs (nstore-select overlap-db long-store (list (nstore-var 'z))))))
+
 ;;; --- worked example from the SRFI 168 document: a blog triplestore ---
 
 (define blog-engine (make-default-engine))


### PR DESCRIPTION
## Summary

Fixes #1717. SRFI 168's `%all-tuples` prefix-scanned the packed key bytes
directly (via SRFI 167's `engine-prefix-range`), and `engine-pack`
concatenates each item's encoding with no marker for "prefix ends here."
Two nstores sharing an engine/store whose prefixes were initial
subsequences of each other — e.g. `(list 0)` vs `(list 0 0)` — had the
shorter prefix's scan also match the longer prefix's tuples.

- Every nstore's packed prefix is now wrapped in a self-delimiting length
  header (`%prefix-tag`, `lib/srfi/168.sld`) — the packed prefix's own
  byte length, itself packed via `engine-pack` — before use as a key
  prefix (`%tuple-key`) or a prefix-range scan key (`%all-tuples`).
- `engine-pack`'s integer encoding is prefix-free across distinct
  non-negative integers: differing magnitude-byte-lengths diverge at the
  length byte itself, and equal magnitude-byte-lengths produce
  equal-length encodings that can only be a "prefix" of each other by
  being identical (see `%pack-integer` in `lib/srfi/167.sld`). This
  guarantees one nstore's prefix-range scan can never pull in a different
  nstore's tuples, regardless of how their logical prefixes relate.
- Entirely contained in `168.sld`; `167.sld`'s `engine-pack`/`engine-unpack`
  are unchanged.

## Test plan

- [x] Added a regression test to `tests/scheme/srfi/srfi168.scm`: two
      nstores share an engine, with prefix/arity combinations chosen so
      the leak (if present) surfaces as a concrete wrong row rather than
      being silently filtered by an arity mismatch.
- [x] Confirmed the new test **fails** (4 assertions) against the pre-fix
      code (via `git stash` on just `lib/srfi/168.sld`), then **passes**
      (32/32) with the fix — proving it's a valid regression test.
- [x] `tests/scheme/srfi/srfi167.scm` and `tests/scheme/srfi/srfi168.scm`
      pass in full.
- [x] `bash tests/scheme/run-all.sh`: 2005/2006 pass. The one failure
      (`compile-import-error-703.sh`) is unrelated (native-compile test)
      and passes when run standalone — a pre-existing flake from
      concurrent rebuilds in `run-all.sh`, not caused by this change.
- [x] `kaappi check lib/srfi/168.sld`: no issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)