### PR TITLE
Surface the real cause behind cross-thread channel/thread failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`thread-join!`'s default error report hid the child thread's real
+  failure, and a local channel's deadlock message blamed only "fibers"
+  even with another OS thread alive.** `thread-join!` has always wrapped an
+  errored child's exception in a generic `"uncaught exception in thread"`
+  object, with the actual cause reachable only via `(error-object-message
+  (uncaught-exception-reason e))` inside a `guard` — the default, uncaught
+  top-level report never looked past the wrapper text. It now unwraps
+  `uncaught-exception-reason` automatically, so e.g. a channel reached
+  through a shared global instead of a thread's own thunk (a top-level
+  `define` is a shared pointer, never a lexical capture, so it is correctly
+  rejected rather than promoted) now reports `uncaught exception in
+  thread: channel belongs to another thread; pass it through the thread
+  thunk to share it` instead of stopping at the uninformative wrapper.
+  Separately, `channel-receive`/`channel-send`'s deadlock message for a
+  channel that was never shared with another thread — `"...and all fibers
+  are blocked"` — now names that thread explicitly when one is alive,
+  instead of reading as though fiber scheduling were the whole story
+  (#1742).
+
 - **Library import silently let colliding export names resolve to
   whichever import came last** — `(import (srfi 28) (srfi 29))`, which both
   export `format`, picked whichever library was written last in the

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -318,10 +318,11 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
     // via the reactor timer alone, so "no fibers exist" is only a genuine
     // deadlock when there is also no deadline to bound the wait.
     if (vm.scheduler == null and deadline_ns == null) {
-        return raiseFiberError(if (cap == 0)
+        var buf: [220]u8 = undefined;
+        return raiseFiberError(localChannelDeadlockMsg(&buf, if (cap == 0)
             "channel-send: deadlock — rendezvous channel has no receiver and no fibers are running"
         else
-            "channel-send: deadlock — channel is full and no fibers are running");
+            "channel-send: deadlock — channel is full and no fibers are running"));
     }
 
     const ctx = try fiber_mod.ensureScheduler(vm);
@@ -406,10 +407,11 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
         try enqueueChannel(gc, ch, ch_val, payload);
         return types.VOID;
     }
-    return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, if (cap == 0)
+    var buf: [220]u8 = undefined;
+    return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, localChannelDeadlockMsg(&buf, if (cap == 0)
         "channel-send: deadlock — rendezvous channel has no receiver and all fibers are blocked"
     else
-        "channel-send: deadlock — channel is full and no fibers can receive");
+        "channel-send: deadlock — channel is full and no fibers can receive"));
 }
 
 const ChannelWait = struct {
@@ -1088,7 +1090,8 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     // lazily creates a scheduler+reactor and the wait resolves via the
     // timer alone, with or without any other fiber ever existing.
     if (vm.scheduler == null and deadline_ns == null) {
-        return raiseFiberError("channel-receive: deadlock — channel is empty and no fibers are running");
+        var buf: [220]u8 = undefined;
+        return raiseFiberError(localChannelDeadlockMsg(&buf, "channel-receive: deadlock — channel is empty and no fibers are running"));
     }
 
     // Capture before the recursive dispatch below: args is a slice into
@@ -1218,7 +1221,8 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     // exit: release the token first. (A dispatched non-rendezvous fiber
     // parking here holds no token, so the release is a no-op for it.)
     releaseRvToken(ch, ch_val, me);
-    return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, "channel-receive: deadlock — channel is empty and all fibers are blocked");
+    var buf: [220]u8 = undefined;
+    return blockOrDeadlock(ctx.vm, me, my_idx, ch_val, localChannelDeadlockMsg(&buf, "channel-receive: deadlock — channel is empty and all fibers are blocked"));
 }
 
 /// Pops the head of a local (unpromoted) channel's queue. `ch.queue_len`
@@ -1239,6 +1243,29 @@ fn dequeueChannel(ch: *types.Channel, ch_val: Value) Value {
         }
     }
     return val;
+}
+
+/// kaappi#1742: a genuinely local (never-promoted, `ch.shared == null`)
+/// channel can only ever be satisfied by a fiber in this same OS thread's
+/// own scheduler -- promotion (via `Envelope.create` at `thread-start!`, or
+/// a message payload legitimately handed across) is the *only* way a
+/// channel crosses threads, so every call site below is only reachable when
+/// no other thread could EVER help this specific wait, no matter how long
+/// it lived. When another OS thread happens to be alive anyway
+/// (`crossThreadWaitPossible()`), the bare "no fibers"/"fibers are blocked"
+/// wording reads as if fibers were the only actor in the picture and erases
+/// that thread's existence entirely -- exactly the framing that turned
+/// kaappi#1742's repro (a channel reached through a shared global instead
+/// of the spawning thread's own thunk -- correctly rejected on the *other*
+/// end by the foreign-owner check) into a support question instead of a
+/// closed issue. Naming the other thread, and the one thing that would have
+/// shared this channel with it, turns the message itself into the fix.
+/// `buf` just needs to outlive the immediate `raiseFiberError`/
+/// `blockOrDeadlock` call the result is passed to -- that call copies the
+/// message into a fresh heap string before returning.
+fn localChannelDeadlockMsg(buf: []u8, base: []const u8) []const u8 {
+    if (!srfi18.crossThreadWaitPossible()) return base;
+    return std.fmt.bufPrint(buf, "{s} (another thread is running, but this channel was never shared with it — only a channel lexically captured by the thread's thunk crosses threads)", .{base}) catch base;
 }
 
 /// The scheduler ran out of runnable fibers while this fiber's blocking

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -96,6 +96,35 @@ test "channel-receive deadlock error is catchable by guard" {
     try std.testing.expectEqualStrings("deadlock-reported", s);
 }
 
+test "kaappi#1742: channel-receive deadlock names the other thread when one is alive but never shared this channel" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // `t` never touches `ch` -- it exists purely to make
+    // crossThreadWaitPossible() true while main's channel-receive on its
+    // own, never-promoted `ch` finds nothing runnable and nothing to wait
+    // for. Before this fix the raised message was the bare "...and all
+    // fibers are blocked", which reads as if fiber scheduling were the
+    // whole story and erases the fact that another OS thread exists but
+    // was simply never handed this channel.
+    const result = try ctx.vm.eval(
+        \\(define t (thread-start! (make-thread (lambda () (thread-sleep! 0.05)))))
+        \\(define ch (make-channel))
+        \\(guard (e (#t (if (and (string-contains (error-object-message e) "all fibers are blocked")
+        \\                       (string-contains (error-object-message e) "never shared with it"))
+        \\                  'deadlock-explained
+        \\                  (error-object-message e))))
+        \\  (channel-receive ch))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("deadlock-explained", s);
+
+    _ = try ctx.vm.eval("(thread-join! t)");
+}
+
 test "fiber-join on a permanently blocked fiber raises deadlock error" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -1158,6 +1158,31 @@ test "KEP-0002 Phase 2: uncopyable thunk is detected synchronously in thread-sta
     try std.testing.expectEqual(types.TRUE, caught);
 }
 
+test "kaappi#1742: thread-join! surfaces the child's real failure reason in the default error detail" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // `ch` is a top-level define -- a shared global, not a lexical capture
+    // -- so the child's channel-send is correctly rejected by the
+    // foreign-owner check right above (primitives_fiber.zig's `ch_obj.owner
+    // != gc.id` check). Before this fix, thread-join!'s default (uncaught)
+    // report stopped at the generic "uncaught exception in thread" wrapper
+    // text and never showed this sentence -- reachable previously only via
+    // `(error-object-message (uncaught-exception-reason e))` inside a
+    // guard, as the test above does.
+    _ = try ctx.vm.eval(
+        \\(define ch (make-channel))
+        \\(define t (thread-start! (make-thread (lambda () (channel-send ch 42)))))
+    );
+    const result = ctx.vm.eval("(thread-join! t)");
+    try std.testing.expectError(th.VMError.ExceptionRaised, result);
+    try std.testing.expectEqualStrings(
+        "uncaught exception in thread: channel belongs to another thread; pass it through the thread thunk to share it",
+        ctx.vm.getErrorDetail(),
+    );
+}
+
 test "KEP-0002 Phase 2: thread churn -- repeated cross-thread channel round trips leave no refcount leak" {
     const baseline = shared_object.liveCount();
     {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -706,6 +706,28 @@ pub const VM = struct {
         return self.last_error_detail[0..self.last_error_detail_len];
     }
 
+    /// Writes `eo`'s own `message` + `irritants` (display mode for the
+    /// message, write mode for each irritant, matching R7RS `error`'s
+    /// display convention) to `w`. Shared by `noteUncaughtException`'s
+    /// top-level object and its `uncaught_reason` unwrap loop below.
+    fn writeErrorObjectMessage(w: *std.Io.Writer, allocator: std.mem.Allocator, eo: *types.ErrorObject) void {
+        const printer = @import("printer.zig");
+        if (printer.valueToString(allocator, eo.message, .display)) |msg| {
+            defer allocator.free(msg);
+            w.writeAll(msg) catch {};
+        } else |_| {}
+        var it = eo.irritants;
+        while (types.isPair(it)) {
+            const pair = types.toObject(it).as(types.Pair);
+            if (printer.valueToString(allocator, pair.car, .write)) |s| {
+                defer allocator.free(s);
+                w.writeAll(" ") catch {};
+                w.writeAll(s) catch {};
+            } else |_| {}
+            it = pair.cdr;
+        }
+    }
+
     /// Called from execute()'s error path, before resetExecutionState()
     /// discards the pending exception. If the escaping error is an uncaught
     /// Scheme exception and no native error detail was recorded, format the
@@ -729,20 +751,37 @@ pub const VM = struct {
         const allocator = self.gc.allocator;
         var w: std.Io.Writer = .fixed(&self.last_error_detail);
         if (types.isErrorObject(exc)) {
-            const eo = types.toObject(exc).as(types.ErrorObject);
-            if (printer.valueToString(allocator, eo.message, .display)) |msg| {
-                defer allocator.free(msg);
-                w.writeAll(msg) catch {};
-            } else |_| {}
-            var it = eo.irritants;
-            while (types.isPair(it)) {
-                const pair = types.toObject(it).as(types.Pair);
-                if (printer.valueToString(allocator, pair.car, .write)) |s| {
-                    defer allocator.free(s);
-                    w.writeAll(" ") catch {};
-                    w.writeAll(s) catch {};
-                } else |_| {}
-                it = pair.cdr;
+            var eo = types.toObject(exc).as(types.ErrorObject);
+            writeErrorObjectMessage(&w, allocator, eo);
+            // kaappi#1742: thread-join! wraps a child thread's failure in a
+            // generic "uncaught exception in thread" ErrorObject and
+            // stashes the real cause in uncaught_reason (see
+            // primitives_srfi18.zig's threadJoinResult) -- a field the
+            // message+irritants walk above never reaches, so the default
+            // report used to stop at that uninformative wrapper text and
+            // hide the one sentence that actually explains the failure,
+            // otherwise reachable only via `(error-object-message
+            // (uncaught-exception-reason e))` inside a guard. Unwrap it
+            // here instead. Bounded: a chain of nested thread-join!s can
+            // wrap this arbitrarily deep. Gated on this exact error_type --
+            // the only production site that ever sets it is
+            // threadJoinResult, so this never fires for the io_decoding/
+            // io_encoding error types that reuse the same uncaught_reason
+            // field slot for unrelated data (see types.ErrorObject's doc
+            // comment).
+            var depth: u8 = 0;
+            while (eo.error_type == .uncaught_exception and eo.uncaught_reason != types.VOID and depth < 8) : (depth += 1) {
+                w.writeAll(": ") catch {};
+                if (types.isErrorObject(eo.uncaught_reason)) {
+                    eo = types.toObject(eo.uncaught_reason).as(types.ErrorObject);
+                    writeErrorObjectMessage(&w, allocator, eo);
+                } else {
+                    if (printer.valueToString(allocator, eo.uncaught_reason, .write)) |s| {
+                        defer allocator.free(s);
+                        w.writeAll(s) catch {};
+                    } else |_| {}
+                    break;
+                }
             }
         } else {
             w.writeAll("uncaught exception: ") catch {};

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -402,6 +402,45 @@ assert_file_output_contains "runtime error column tracks the failing form" \
     "$COLDIR/rt-col2.scm" "rt-col2.scm:2:3: error"
 rm -rf "$COLDIR"
 
+# --- Thread exception diagnostics (kaappi#1742) ---
+# thread-join! used to wrap a child thread's failure in a generic "uncaught
+# exception in thread" message with no further detail, and a local (never-
+# shared) channel's deadlock message blamed "fibers" even when a live OS
+# thread was the actual, relevant context. Neither is a channel/thread bug —
+# see #1742's own investigation comment — but both hid the real cause.
+echo
+echo "-- Thread exception diagnostics (kaappi#1742) --"
+THREADDIR=$(mktemp -d)
+
+cat > "$THREADDIR/join-generic.scm" << 'SCHEME'
+(import (scheme base) (srfi 18))
+(define t (thread-start! (make-thread (lambda () (error "boom" 1)))))
+(thread-join! t)
+SCHEME
+assert_file_output_contains "thread-join! surfaces the child's (error ...) reason" \
+    "$THREADDIR/join-generic.scm" "uncaught exception in thread: boom 1"
+
+cat > "$THREADDIR/join-channel-repro.scm" << 'SCHEME'
+(import (scheme base) (srfi 18) (kaappi fibers))
+(define ch (make-channel))
+(define t (thread-start! (make-thread (lambda () (channel-send ch 42)))))
+(thread-join! t)
+SCHEME
+assert_file_output_contains "thread-join! surfaces a channel reached via a shared global (issue's own repro)" \
+    "$THREADDIR/join-channel-repro.scm" \
+    "uncaught exception in thread: channel belongs to another thread; pass it through the thread thunk to share it"
+
+cat > "$THREADDIR/receive-deadlock-other-thread.scm" << 'SCHEME'
+(import (scheme base) (srfi 18) (kaappi fibers))
+(define t (thread-start! (make-thread (lambda () (thread-sleep! 0.5)))))
+(define ch (make-channel))
+(channel-receive ch)
+SCHEME
+assert_file_output_contains "channel-receive deadlock names the other thread instead of blaming only fibers" \
+    "$THREADDIR/receive-deadlock-other-thread.scm" \
+    "never shared with it"
+rm -rf "$THREADDIR"
+
 # --- No leaked Zig error names on any path (KEP-0005, #1504) ---
 echo
 echo "-- No leaked Zig error names --"


### PR DESCRIPTION
## Summary

Closes #1742. The cross-thread channel mechanism is working exactly as designed — a channel only crosses a thread boundary when lexically captured by the thread's own thunk, and a top-level `define` (a shared, pointer-shared global) is correctly rejected rather than promoted. #1742's own investigation comment traced the report to two real, narrower diagnostics bugs rather than a channel/thread runtime bug:

- **`thread-join!`'s default report hid the real cause.** It wraps a child thread's failure in a generic `"uncaught exception in thread"` `ErrorObject`, stashing the actual reason in `uncaught_reason` — a field the default top-level reporter never looked at. `VM.noteUncaughtException` (`src/vm.zig`) now unwraps it (bounded, for nested `thread-join!` chains), gated strictly on `error_type == .uncaught_exception` so the unrelated `io_decoding`/`io_encoding` error types (which reuse the same field slot for different data) are untouched. The issue's exact repro now reports:
  ```
  error[KP3000]: uncaught exception in thread: channel belongs to another thread; pass it through the thread thunk to share it
  ```
- **`channel-receive`/`channel-send`'s deadlock message misattributed the cause.** For a channel that was never shared with another thread, the message read `"...and all fibers are blocked"` even when another OS thread was alive — implying fiber scheduling was the whole story. `src/primitives_fiber.zig`'s four local (unpromoted-channel) deadlock sites now name that thread explicitly via a new `localChannelDeadlockMsg` helper, reusing the existing `crossThreadWaitPossible()` predicate the sibling shared-channel path already relies on for the same distinction. This is a pure wording change — a local channel's deadlock decision was already immediate regardless of `crossThreadWaitPossible()` (traced through `fiber.zig`'s `parkOnReactor`/`runSchedulerStep`).

Out of scope for this PR (per discussion): the kaappi.github.io guide wording, `README.md`/`lib/kaappi/parallel.sld` (issue #1793's scope), and retitling the issue.

## Test plan

- [x] `zig build test` — 1381/1384 pass (3 pre-existing platform skips), 0 failures
- [x] `bash tests/scheme/run-all.sh` — 2006/2006 pass, 0 failures
- [x] `zig fmt --check` clean
- [x] New unit tests: `tests_shared_channel.zig` (thread-join! reason surfacing), `tests_fibers.zig` (deadlock wording, plus confirms the pre-existing single-threaded deadlock message is unchanged)
- [x] New shell regression assertions in `tests/scheme/errors/error-format.sh`, including the issue's exact repro
- [x] Manually re-ran the issue's exact repro script against a fresh build and confirmed both messages now show the real cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)