### PR TITLE
Route case-lambda's arity dispatch through an internal %length alias

### DIFF
--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -845,12 +845,18 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
 /// Desugars to (internal names %-prefixed so clause bodies referencing
 /// user variables named `args` or `n` are not captured):
 /// (lambda %cl-args
-///   (let ((%cl-n (length %cl-args)))
+///   (let ((%cl-n (%length %cl-args)))
 ///     (cond
 ///       ((= %cl-n arity1) (apply (lambda formals1 body1...) %cl-args))
 ///       ((= %cl-n arity2) (apply (lambda formals2 body2...) %cl-args))
 ///       ...
 ///       (else (error "wrong number of arguments")))))
+///
+/// Uses the internal `%length` alias rather than `length` itself (kaappi#1714):
+/// a library legitimately shadowing `length` (e.g. to supply its own for a
+/// non-standard list-like type) must not break dispatch here, which needs
+/// the real list-length primitive regardless of what `length` currently
+/// resolves to in scope.
 pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!void {
     const gc = self.gc;
 
@@ -867,7 +873,7 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
         const cond_sym = try gc.allocSymbol("cond");
         const eq_sym = try gc.allocSymbol("=");
         const ge_sym = try gc.allocSymbol(">=");
-        const length_sym = try gc.allocSymbol("length");
+        const length_sym = try gc.allocSymbol("%length");
         const apply_sym = try gc.allocSymbol("apply");
         const else_sym = try gc.allocSymbol("else");
         const error_sym = try gc.allocSymbol("error");

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -216,6 +216,13 @@ const core_specs = [_]PrimSpec{
     .{ .name = "set-cdr!", .func = &setCdr, .arity = .{ .exact = 2 }, .libs = BRS1 },
     .{ .name = "list", .func = &list, .arity = .{ .variadic = 0 }, .libs = BRS1 },
     .{ .name = "length", .func = &length, .arity = .{ .exact = 1 }, .libs = BRS1 },
+    // Internal alias for case-lambda's compiled arity dispatch (kaappi#1714):
+    // a library that legitimately shadows `length` (e.g. `except`s it and
+    // supplies its own) must not break case-lambda's dispatch, which needs
+    // the real list-length primitive regardless of what `length` currently
+    // means in scope. Same %-prefixed-internal-primitive convention as
+    // %record-set! etc. below.
+    .{ .name = "%length", .func = &length, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "append", .func = &append, .arity = .{ .variadic = 0 }, .libs = BRS1 },
     .{ .name = "reverse", .func = &reverse, .arity = .{ .exact = 1 }, .libs = BRS1 },
     .{ .name = "caar", .func = &caarFn, .arity = .{ .exact = 1 }, .libs = BCRS1 },

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -250,6 +250,35 @@ test "case-lambda does not capture user variables named n or args" {
     try std.testing.expectEqual(@as(i64, 143), types.toFixnum(r3));
 }
 
+test "case-lambda dispatch is unaffected by a shadowed global length" {
+    // Regression (#1714): the desugaring called the global `length` directly
+    // to count arguments, so a scope that legitimately shadows `length` (e.g.
+    // a library providing its own for a non-standard list-like type) broke
+    // every case-lambda defined within it. Fixed by dispatching through an
+    // internal %length alias instead.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define f
+        \\  (let ()
+        \\    (define (length x) 'shadowed)
+        \\    (case-lambda
+        \\      ((a) (list 'one a))
+        \\      ((a b) (list 'two a b)))))
+    );
+
+    const r1 = try vm.eval("(f 1)");
+    try std.testing.expect(types.isPair(r1));
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(types.car(types.cdr(r1))));
+
+    const r2 = try vm.eval("(f 1 2)");
+    try std.testing.expect(types.isPair(r2));
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(types.car(types.cdr(types.cdr(r2)))));
+}
+
 test "case-lambda dispatches to clauses beyond the 32nd" {
     // Regression: a fixed 32-entry buffer silently dropped later clauses, so
     // calls matching them fell through to the wrong-number-of-arguments error.

--- a/tests/scheme/smoke/case-lambda-fixes.scm
+++ b/tests/scheme/smoke/case-lambda-fixes.scm
@@ -1,6 +1,7 @@
 ;; Regression tests for case-lambda and case fixes:
 ;; #854: case rejects empty datum list (() body)
 ;; #836: case-lambda desugaring captured user variables named n or args
+;; #1714: case-lambda's arity dispatch called global `length` non-hygienically
 ;;
 ;; Checks are manual (not SRFI-64) and every risky expression runs inside
 ;; guard: an uncaught top-level error does not fail the process exit code,
@@ -42,3 +43,19 @@
 (define h (case-lambda ((x . rest) (+ x n args))))
 (check "case-lambda rest clause sees outer n and args" 143
   (lambda () (h 1 2 3)))
+
+;; #1714: a scope that shadows `length` (e.g. a library providing its own
+;; for a non-standard list-like type) must not break arity dispatch for a
+;; case-lambda defined within it.
+(define shadowed-length-case-lambda
+  (let ()
+    (define (length x) 'shadowed)
+    (case-lambda
+      ((a) (list 'one a))
+      ((a b) (list 'two a b)))))
+(check "case-lambda dispatch ignores a shadowed global length (1 arg)"
+       '(one 1)
+  (lambda () (shadowed-length-case-lambda 1)))
+(check "case-lambda dispatch ignores a shadowed global length (2 args)"
+       '(two 1 2)
+  (lambda () (shadowed-length-case-lambda 1 2)))


### PR DESCRIPTION
## Summary
- `case-lambda`'s compiled arity-dispatch code called the global `length` procedure by name to count arguments, so a scope that legitimately shadows `length` (e.g. a library providing its own for a non-standard list-like type, as SRFI 101 needs) resolved to the *shadowed* version instead of the real list-length primitive, breaking every `case-lambda` defined within that scope.
- Adds an internal `%length` primitive (same underlying implementation as `length`) using the same `%`-prefixed internal-primitive convention already used for `%record-set!`, `%make-record`, `%parameter-set!`, etc. — names ordinary user code has no reason to shadow.
- `compileCaseLambda`'s desugared dispatch now references `%length` instead of `length`.

Fixes #1714

## Test plan
- [x] New Zig unit test in `src/tests_advanced.zig`: `case-lambda dispatch is unaffected by a shadowed global length` (both a 1-arg and 2-arg clause, dispatched from within a scope with a local `(define (length x) ...)` shadow).
- [x] New Scheme smoke checks in `tests/scheme/smoke/case-lambda-fixes.scm` reproducing the exact failure mode and confirming the fix.
- [x] `zig build test` — full unit suite green.
- [x] `bash tests/scheme/run-all.sh` — 2007 pass, 0 fail (612 Scheme files + 1395 R7RS suite), both before and after rebasing onto `origin/main`.
- [x] Manually confirmed the original repro (`(import (except (scheme base) length)) (define (length x) ...) (case-lambda ...)`) now returns correct results instead of a type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)