### PR TITLE
Raise an error for a syntax-rules ellipsis with no driving pattern variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   instead of reading as though fiber scheduling were the whole story
   (#1742).
 
+- **A `syntax-rules` template ellipsis with no driving pattern variable
+  silently expanded to zero copies instead of erroring.** A template
+  subform followed by `...` whose element contains no pattern variable
+  bound under an ellipsis in the pattern — most often a typo'd bare `...`
+  where the literal-ellipsis escape `(... ...)` was meant — used to vanish
+  from the expansion with no diagnostic, e.g. `(syntax-rules () ((_)
+  '(head tok ... tail)))` expanded `(head tok ... tail)` to `(head tail)`
+  rather than reporting an error, per R7RS 4.3.2. `instantiateEllipsis` now
+  raises an error in this case instead of silently producing nothing,
+  proven not to fire for the legitimate case where such an ellipsis
+  belongs to a nested `syntax-rules` template's own grammar (the SRFI
+  147/148 macro-generating-macro pattern) — both call sites already gate on
+  the exact predicate that distinguishes the two. This also closes a
+  related gap `lib/srfi/149.sld` had documented and deliberately deferred:
+  a single pattern variable asked for more ellipsis nesting in the template
+  than its own matched depth, with no sibling variable to drive the extra
+  level, hits the same code path one recursion level down (#1791).
+
 - **SRFI 168 nstore prefixes could leak tuples across stores when one
   prefix was an initial subsequence of another** — `nstore-select`/
   `nstore-where` prefix-scan the packed key bytes directly (via SRFI 167's

--- a/lib/srfi/149.sld
+++ b/lib/srfi/149.sld
@@ -25,15 +25,19 @@
 ;;; tests/scheme/srfi/srfi149.scm and the "SRFI 149" tests in
 ;;; src/tests_macros.zig.
 ;;;
-;;; One PRE-EXISTING, unrelated gap found and deliberately left alone: a
-;;; template ellipsis with NO driving variable at all (e.g. a single
-;;; variable asked for MORE ellipses than its own maximum depth, with no
-;;; sibling reaching the requested depth either) silently produces an
-;;; empty result instead of erroring. This predates SRFI 149 entirely --
-;;; it is not a new case this SRFI introduces or one it needs to support,
-;;; and fixing the underlying error-detection leniency is a separate,
+;;; One PRE-EXISTING, unrelated gap found at the time and deliberately left
+;;; alone: a template ellipsis with NO driving variable at all (e.g. a
+;;; single variable asked for MORE ellipses than its own maximum depth,
+;;; with no sibling reaching the requested depth either) silently produced
+;;; an empty result instead of erroring. This predated SRFI 149 entirely --
+;;; it was not a new case this SRFI introduced or one it needed to support,
+;;; and fixing the underlying error-detection leniency was a separate,
 ;;; broader-blast-radius correctness project of its own, not part of
-;;; adding this SRFI's features.
+;;; adding this SRFI's features. FIXED by kaappi#1791: instantiateEllipsis
+;;; now raises EllipsisNoPatternVariable instead of silently producing zero
+;;; copies, proven safe against this SRFI's own legitimate mixed-depth
+;;; sibling case (both call sites already gate on the identical
+;;; ellipsisReferencesOuter predicate before reaching the raise site).
 ;;;
 ;;; Like SRFI 46 (a sibling "these R7RS extensions are already native"
 ;;; library), this is a conformance statement, not new functionality: it

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -346,7 +346,7 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
             return switch (err) {
                 error.OutOfMemory => CompileError.OutOfMemory,
                 error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
-                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch, error.TransformerFailed => CompileError.InvalidSyntax,
+                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch, error.EllipsisNoPatternVariable, error.TransformerFailed => CompileError.InvalidSyntax,
             };
         };
         // Root for the rest of the enclosing compile scope via extra_roots
@@ -1106,7 +1106,7 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
             return switch (err) {
                 error.OutOfMemory => CompileError.OutOfMemory,
                 error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
-                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch, error.TransformerFailed => CompileError.InvalidSyntax,
+                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch, error.EllipsisNoPatternVariable, error.TransformerFailed => CompileError.InvalidSyntax,
             };
         };
         self.gc.no_collect -= 1;

--- a/src/diagnostics.zig
+++ b/src/diagnostics.zig
@@ -313,6 +313,9 @@ pub const table = [_]Diagnostic{
         \\A special form was written incorrectly — for example an 'if' with no
         \\test, a 'define' with no body, or a 'lambda' whose parameter list is not
         \\a proper list of identifiers. Check the form against its expected shape.
+        \\It can also mean a 'syntax-rules' template used '...' on a subform with
+        \\no pattern variable bound at that ellipsis depth — often a typo for the
+        \\literal-ellipsis escape '(... ...)'.
         ,
         .example = "(if)",
     },
@@ -600,6 +603,7 @@ pub fn compileErrorCode(err: anyerror) Code {
         error.NoMatchingPattern,
         error.EllipsisCountMismatch,
         error.EllipsisDepthMismatch,
+        error.EllipsisNoPatternVariable,
         error.PatternTooComplex,
         error.ScopeTableFull,
         => .syntax_error,

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -271,6 +271,13 @@ pub const ExpandError = error{
     PatternTooComplex,
     EllipsisCountMismatch,
     EllipsisDepthMismatch,
+    /// R7RS 4.3.2 (kaappi#1791): a template subform followed by `...` whose
+    /// element contains no pattern variable bound under an ellipsis in the
+    /// pattern — e.g. a typo'd bare `...` where `(... ...)` (the ellipsis
+    /// escape) was meant. See instantiateEllipsis's raise site for the proof
+    /// that this can never fire for the legitimate nested-syntax-rules
+    /// "belongs to the inner macro" case.
+    EllipsisNoPatternVariable,
     /// SRFI 211: a procedural transformer raised, returned a non-datum, or
     /// could not run (no VM registered). The VM's error state carries any
     /// Scheme-level condition the transformer raised.
@@ -1476,6 +1483,24 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
                 }
             }
         }
+
+        // R7RS 4.3.2 (kaappi#1791): no pattern variable at this ellipsis
+        // depth drove the repeat count, so this is not "zero repetitions" —
+        // it's a template bug (most often a typo'd bare `...` where the
+        // literal-ellipsis escape `(... ...)` was meant, kaappi#1787).
+        // Silently producing zero copies here previously let the malformed
+        // expansion continue and fail far away with a misleading error.
+        //
+        // This can never fire for the legitimate "ellipsis belongs to a
+        // nested syntax-rules template's own grammar" case: both call sites
+        // of this function (instantiateTemplate and instantiateLetBindings)
+        // already special-case `NESTED_SR_FLAG and !ellipsisReferencesOuter`
+        // *before* calling here, and `ellipsisReferencesOuter` is exactly
+        // the same predicate — over the same elem_template/bindings — as
+        // the `count_set` computation above. So `!count_set` here implies
+        // `ellipsisReferencesOuter` was false, which means the caller could
+        // only have reached this call with NESTED_SR_FLAG unset.
+        if (!count_set) return ExpandError.EllipsisNoPatternVariable;
 
         // Consecutive ellipses (R7RS 4.3.2): (x ... ...) flattens depth-2
         // bindings into a single list.  Count and strip leading ellipsis

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -1134,6 +1134,83 @@ test "SRFI 149: consecutive-ellipsis flatten composes with a following fixed tai
     );
 }
 
+// Issue #1791: a syntax-rules template subform followed by `...` whose
+// element contains no pattern variable bound under an ellipsis in the
+// pattern previously expanded silently to zero copies (R7RS 4.3.2 makes
+// this an error). The common trigger is a typo'd bare `...` where the
+// literal-ellipsis escape `(... ...)` was meant (kaappi#1787's root cause).
+// Fixed in instantiateEllipsis (expander.zig): raises
+// error.EllipsisNoPatternVariable instead of silently producing nothing.
+// Proven safe against the nested-syntax-rules "belongs to the inner macro"
+// carve-out (both call sites already gate on the identical
+// ellipsisReferencesOuter predicate before reaching the raise site) — the
+// third test below exercises that carve-out directly.
+
+test "syntax-rules: ellipsis subform with no driving pattern variable is an error (#1791)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The issue's own example: `tok` is not a pattern variable at all.
+    _ = try vm.eval(
+        \\(define-syntax demo
+        \\  (syntax-rules ()
+        \\    ((_) '(head tok ... tail))))
+    );
+    const result = vm.eval("(demo)");
+    try std.testing.expectError(error.CompileError, result);
+}
+
+test "syntax-rules: ordinary ellipsis broadcast still works (#1791 regression guard)" {
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax my-list
+        \\    (syntax-rules () ((_ x ...) (list x ...))))
+        \\  (equal? (my-list 1 2 3) '(1 2 3)))
+    );
+}
+
+test "syntax-rules: macro-generating-macro's own ellipsis is preserved, not flagged (#1791 carve-out guard)" {
+    // define-listify's own pattern var is `name` (the generated macro's
+    // name); the NESTED syntax-rules template's `x ...` belongs entirely to
+    // the generated macro's own grammar and must be preserved literally
+    // during define-listify's expansion, not routed through
+    // instantiateEllipsis at all. It only becomes a real, correctly-driven
+    // ellipsis later, when the generated macro (my-list2) is itself used.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax define-listify
+        \\    (syntax-rules ()
+        \\      ((_ name)
+        \\       (define-syntax name
+        \\         (syntax-rules () ((_ x ...) (list x ...)))))))
+        \\  (define-listify my-list2)
+        \\  (equal? (my-list2 1 2 3) '(1 2 3)))
+    );
+}
+
+test "syntax-rules: excess ellipsis depth with no sibling now errors (#1791, closes SRFI 149-documented gap)" {
+    // lib/srfi/149.sld documented this exact case as a pre-existing,
+    // deliberately-deferred gap: `a` has pattern depth 1, but the template
+    // asks for 2 ellipses with no sibling variable to drive the extra
+    // level. Hits the same !count_set path one recursion level down (via
+    // the consecutive-ellipsis "extra_ellipsis" unwrap), so it's fixed as a
+    // side effect of the same change.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-syntax over-deep
+        \\  (syntax-rules ()
+        \\    ((_ a ...) (list a ... ...))))
+    );
+    const result = vm.eval("(over-deep 1 2 3)");
+    try std.testing.expectError(error.CompileError, result);
+}
+
 // SRFI 147 (Custom Macro Transformers) regression coverage. Unlike SRFI
 // 139/149, this genuinely needed an engine change: compileDefineSyntax/
 // compileLetSyntax/compileLetrecSyntax (compiler_macro.zig) now resolve a

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -97,6 +97,23 @@ assert_output_contains "caught syntax-error does not leak into next compile erro
     '(import (scheme base)) (guard (e (#t #t)) (eval (quote (syntax-error "STALE" 999)) (environment (quote (scheme base))))) (if)' \
     'compile error'
 
+# --- syntax-rules ellipsis with no driving pattern variable (#1791) ---
+# R7RS 4.3.2: a template subform followed by `...` whose element has no
+# pattern variable bound at that ellipsis depth is an error, not zero
+# copies. `tok` here is not a pattern variable at all — a stand-in for the
+# common typo'd bare `...` where the literal-ellipsis escape `(... ...)`
+# was meant (kaappi#1787's root cause).
+echo
+echo "-- syntax-rules ellipsis diagnostics (#1791) --"
+
+assert_output_contains "ellipsis with no pattern variable is a compile error" \
+    '(define-syntax demo (syntax-rules () ((_) (quote (head tok ... tail))))) (demo)' \
+    'compile error[KP2001]'
+
+assert_output_contains "ellipsis with no pattern variable has location" \
+    '(define-syntax demo (syntax-rules () ((_) (quote (head tok ... tail))))) (demo)' \
+    '<stdin>:1:'
+
 # --- Runtime errors include file:line ---
 echo
 echo "-- Runtime errors from files --"
@@ -456,6 +473,8 @@ assert_no_zig_leak "not a procedure"         '(5 6)'
 assert_no_zig_leak "stack overflow"          '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 50000)'
 assert_no_zig_leak "uncaught user error"     '(error "boom" 1)'
 assert_no_zig_leak "raised non-error value"  '(raise 42)'
+assert_no_zig_leak "ellipsis with no pattern variable (#1791)" \
+    '(define-syntax demo (syntax-rules () ((_) (quote (head tok ... tail))))) (demo)'
 
 echo
 echo "=== Results ==="


### PR DESCRIPTION
## Summary

Fixes #1791. A `syntax-rules` template subform followed by `...` whose element contains no pattern variable bound under an ellipsis in the pattern previously expanded silently to zero copies instead of erroring (R7RS 4.3.2):

```scheme
(define-syntax demo
  (syntax-rules ()
    ((_) '(head tok ... tail))))
(demo)  ; => (head tail), silently -- tok ... just vanished
```

The most common trigger is a typo'd bare `...` where the literal-ellipsis escape `(... ...)` was meant. This is exactly what happened in #1787: a stray `...` silently ate part of a template, and the resulting malformed expansion failed far away with a misleading `not a procedure` error instead of pointing at the real problem.

## Approach

The issue's own filed recommendation was definition-time detection (mirroring chibi-scheme, which reports this at `define-syntax` time). After tracing the code, I went with a simpler **expansion-time** fix instead, inside `instantiateEllipsis` itself:

Both call sites of `instantiateEllipsis` (`instantiateTemplate` and `instantiateLetBindings`) already gate on `NESTED_SR_FLAG and !ellipsisReferencesOuter` before calling it — the carve-out for a driver-less ellipsis that legitimately belongs to a *nested* `syntax-rules` template's own grammar (the SRFI 147/148 macro-generating-macro pattern). `ellipsisReferencesOuter` is exactly the same predicate, over the same `elem_template`/`bindings`, as the `count_set` computation already inside `instantiateEllipsis`. So `!count_set` inside `instantiateEllipsis` can only happen when that carve-out does **not** apply — reaching it already proves this is the genuine bug, never the legitimate nested-macro case. That makes raising an error there safe without building a second, parallel static template-walker that would need to mirror `instantiateTemplate`/`instantiateLetBindings`'s full dispatch (quote, quasiquote, escape, nested-syntax-rules, let-bindings, usertext-marker unwrapping) forever.

Bonus: this also closes a related gap `lib/srfi/149.sld`'s header had documented and deliberately deferred — a single pattern variable asked for more ellipsis nesting in the template than its own matched depth, with no sibling variable to drive the extra level, hits the same `!count_set` path one recursion level down. A definition-time check without full depth-tracking would not have caught that variant.

## Testing

- New unit tests in `src/tests_macros.zig`: the issue's exact example now errors; ordinary ellipsis usage still works (regression guard); the nested-syntax-rules-generates-a-macro carve-out still works (guards the safety argument above directly); the SRFI-149-adjacent degenerate case now errors too.
- New shell assertions in `tests/scheme/errors/error-format.sh`: CLI-level diagnostic format and no raw Zig-error-name leak.
- Full measurement pass per the issue's own request (run twice — before and after rebasing onto the latest `main`): `bash tests/scheme/run-all.sh` — **2007 pass, 0 fail** (612 Scheme files including all ~199 SRFI test files covering effectively every `.sld` library's `define-syntax` forms, plus the 1395-test R7RS suite). No library anywhere in the ecosystem depended on the old silent-swallow behavior.
- `zig build test` — full unit suite green.

## Test plan

- [x] `zig build test` passes
- [x] `bash tests/scheme/run-all.sh` passes (2007/2007, run both pre- and post-rebase)
- [x] Manually verified the issue's exact repro now fails to compile with a diagnostic instead of silently returning `(head tail)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)