### PR TITLE
Reserve begin-internal define-syntax names during lowering, fixing #1772

### DIFF
--- a/src/ir.zig
+++ b/src/ir.zig
@@ -749,13 +749,87 @@ fn lowerQuote(ir: *IR, args: Value) CompileError!*Node {
 fn lowerBegin(ir: *IR, args: Value, macros: ?*std.StringHashMap(Value)) CompileError!*Node {
     var nodes: std.ArrayList(*Node) = .empty;
     defer nodes.deinit(ir.allocator);
+
+    // A literal `begin` lowers every child in one eager pass, all before any
+    // of them compile. A `define-syntax` sibling's real registration is a
+    // side effect of *compiling* its node (compiler_macro.compileDefineSyntax),
+    // not of lowering it, so without this, a later sibling lowered in this
+    // same pass never sees it via lookupMacro and its macro use lowers as a
+    // plain call instead of deferring to real expansion (kaappi#1772).
+    // Reserve each literal define-syntax sibling's name the moment it's
+    // reached, before lowering the next one — mirroring how
+    // compiler_lambda.scanBodyDefs resolves the identical problem for a
+    // body's own leading definitions. A name already visible via lookupMacro
+    // (a real transformer from this scope or an enclosing one) is left
+    // untouched, so this can never clobber a real value. The placeholder
+    // itself is never read as a transformer: begin's children compile in the
+    // same left-to-right order this loop lowers them in, so
+    // compileDefineSyntax overwrites it with the real transformer strictly
+    // before any later sibling compiles. If a later sibling fails to lower,
+    // roll back every reservation this call made, so the failure leaves the
+    // macro table exactly as it found it.
+    var reserved: std.ArrayList([]const u8) = .empty;
+    defer reserved.deinit(ir.allocator);
+    errdefer {
+        if (macros) |m| {
+            for (reserved.items) |rn| _ = m.remove(rn);
+        }
+    }
+
     var current = args;
     while (current != types.NIL) {
         if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        nodes.append(ir.allocator, try lowerWithMacros(ir, types.car(current), macros)) catch return CompileError.OutOfMemory;
+        const form = types.car(current);
+        try reserveLiteralDefineSyntax(ir, form, macros, &reserved);
+        nodes.append(ir.allocator, try lowerWithMacros(ir, form, macros)) catch return CompileError.OutOfMemory;
         current = types.cdr(current);
     }
     return ir.makeBegin(nodes.items);
+}
+
+/// If `form` is a literal, unshadowed `(define-syntax <name> <spec>)` — the
+/// same test `lowerFormWithMacros` applies a moment later when it actually
+/// lowers `form` — reserve `<name>` in the macro table backing this lowering
+/// pass, so a sibling lowered right after this call sees it via lookupMacro.
+/// No-op when there's no mutable macro table to reserve into, when `form`
+/// isn't really this special form (shadowed by a lexical binding, or
+/// `define-syntax` itself is shadowed by an enclosing macro), or when
+/// `<name>` is already visible — nothing to fix in that last case, and
+/// overwriting it would risk losing a real transformer if this define-syntax
+/// node is never actually compiled (e.g. a later sibling fails to lower).
+fn reserveLiteralDefineSyntax(
+    ir: *IR,
+    form: Value,
+    macros: ?*std.StringHashMap(Value),
+    reserved: *std.ArrayList([]const u8),
+) CompileError!void {
+    const target = macros orelse return;
+    if (!types.isPair(form)) return;
+    const head = types.car(form);
+    if (!types.isSymbol(head)) return;
+    const name = types.symbolName(head);
+    const effective_name = types.stripHygienicPrefix(name);
+    if (!std.mem.eql(u8, effective_name, "define-syntax")) return;
+
+    const is_shadowed = std.mem.eql(u8, effective_name, name) and
+        if (ir.compiler) |c| c.isLexicallyBound(name) else false;
+    if (is_shadowed) return;
+
+    const shadowed_by_macro = if (ir.compiler) |c|
+        c.lookupMacro(name) != null
+    else
+        target.get(name) != null;
+    if (shadowed_by_macro) return;
+
+    const ds_args = types.cdr(form);
+    if (!types.isPair(ds_args)) return;
+    const keyword = types.car(ds_args);
+    if (!types.isSymbol(keyword)) return;
+    const kw_name = types.symbolName(keyword);
+
+    if (target.contains(kw_name)) return;
+    target.put(kw_name, types.VOID) catch return CompileError.OutOfMemory;
+    reserved.append(ir.allocator, kw_name) catch return CompileError.OutOfMemory;
 }
 
 fn lowerLet(ir: *IR, expr: Value) CompileError!*Node {

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -495,6 +495,80 @@ test "top-level begin: define-syntax persists for later forms" {
     try std.testing.expectEqual(@as(i64, 7), types.toFixnum(result));
 }
 
+test "kaappi#1772: begin as a non-first body form sees its own internal define-syntax" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // A literal begin used as a non-first, non-whole-body form compiles via
+    // ir.lowerBegin (general IR lowering), not compiler_lambda's sequential
+    // compileBegin/scanBodyDefs. lowerBegin used to lower every child eagerly
+    // before any of them compiled, so a define-syntax sibling's registration
+    // — a side effect of *compiling* its node — wasn't visible yet when a
+    // later sibling in the same begin was lowered, and its use compiled as a
+    // plain call to an unbound global instead of expanding.
+    _ = try vm.eval(
+        \\(define (test-fn2)
+        \\  (+ 1 1)
+        \\  (begin
+        \\    (define-syntax inner-mid
+        \\      (syntax-rules ()
+        \\        ((_ y) (list 'fixed y))))
+        \\    (inner-mid 99)))
+    );
+    const result = try vm.eval("(test-fn2)");
+    try std.testing.expect(types.isPair(result));
+    try std.testing.expect(types.isSymbol(types.car(result)));
+    try std.testing.expectEqualStrings("fixed", types.symbolName(types.car(result)));
+    try std.testing.expectEqual(@as(i64, 99), types.toFixnum(types.car(types.cdr(result))));
+}
+
+test "kaappi#1772: begin inside an if branch sees its own internal define-syntax" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Same bug, reached through a different lowerWithMacros caller (lowerIf
+    // instead of a lambda body's compileExprSequence) — confirms the fix
+    // lives in lowerBegin itself, not in body-sequencing code.
+    _ = try vm.eval(
+        \\(define (test-fn3 flag)
+        \\  (if flag
+        \\      (begin
+        \\        (define-syntax inner-if
+        \\          (syntax-rules ()
+        \\            ((_ y) (list 'from-if y))))
+        \\        (inner-if 42))
+        \\      'other))
+    );
+    const result = try vm.eval("(test-fn3 #t)");
+    try std.testing.expect(types.isPair(result));
+    try std.testing.expectEqualStrings("from-if", types.symbolName(types.car(result)));
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(types.car(types.cdr(result))));
+}
+
+test "kaappi#1772: define-syntax use-before-def in a nested begin still errors, matching top level" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The reservation added for #1772 only reserves a define-syntax sibling's
+    // name once its OWN form is reached, so it must not hoist that name
+    // ahead of its textual position: a use compiled before its definition is
+    // still an unbound-global error, exactly like the same ordering would be
+    // at real top level (an earlier (m7 1), a later define-syntax m7).
+    _ = try vm.eval(
+        \\(define (test-fn7)
+        \\  (begin
+        \\    (begin (m7 1))
+        \\    (define-syntax m7 (syntax-rules () ((_ y) (list 'm7 y))))))
+    );
+    try std.testing.expectError(error.UndefinedVariable, vm.eval("(test-fn7)"));
+}
+
 test "syntax-rules nested ellipsis: depth-2 pattern variables" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();


### PR DESCRIPTION
## Summary

Fixes #1772. A literal `(begin ...)` used outside real top level or as the
direct result of a macro expansion — e.g. a non-first body form, or an `if`
branch — compiled an internal `define-syntax` + use incorrectly: the use
compiled as a plain call to an unbound global (or a wrong result) instead of
expanding.

## Root cause

`begin` has three independent compilation paths. Two already compile each
child sequentially (real top level, and a macro-expansion result routed
through `compiler_lambda.compileBegin`), so a `define-syntax` sibling's
registration is visible to later siblings. The third — a literal `begin`
reached through the general IR lowering path (`ir.lowerBegin`) — lowers
every child in one eager pass *before any of them compile*. A
`define-syntax` sibling's registration into the macro table is a side
effect of *compiling* its node (`compiler_macro.compileDefineSyntax`), not
of lowering it, so a later sibling lowered in the same pass never saw it via
`lookupMacro` — its macro use lowered as an ordinary call instead of
deferring to real expansion.

## Fix

`lowerBegin` now reserves a literal `define-syntax` sibling's name the
moment its form is reached, before lowering the next sibling — mirroring
how `compiler_lambda.scanBodyDefs` already resolves the identical problem
for a body's own leading definitions. A few care points:

- The reservation is skipped whenever the name is already visible via
  `lookupMacro` (a real transformer from this scope or an enclosing one),
  so it can never clobber a real value.
- The placeholder is never read as a transformer: `begin`'s children
  compile in the same left-to-right order this loop lowers them in, so
  `compileDefineSyntax` overwrites it with the real transformer strictly
  before any later sibling compiles.
- If a later sibling fails to lower, every reservation this call made is
  rolled back, so the failure leaves the macro table exactly as it found it.
- A use that textually precedes its `define-syntax` (in a nested `begin`)
  still errors as an unbound global, matching the same ordering at real top
  level — the fix does not hoist definitions ahead of their textual
  position.

## Test plan

- [x] `zig build test` — full unit suite passes, including 3 new regression
      tests in `tests_macros.zig` covering: `begin` as a non-first body
      form, `begin` inside an `if` branch, and use-before-def still erroring
- [x] `bash tests/scheme/run-all.sh` — 612/612 Scheme files pass, 1395/1395
      R7RS suite tests pass
- [x] Manually verified the issue's exact repro, plus nested-begin,
      redefinition-within-one-begin, and outer-macro-shadowing scenarios
- [x] Verified with `--no-ir-opt` and via `kaappi compile` (native/LLVM
      backend) and `kaappi check`/`kaappi ir` (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)