### PR TITLE
Drop stale cross-thread concurrency limitation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,32 +455,20 @@ refcounted shared channel outside every GC heap, and every message crosses by
 copy (KEP-0002). `(kaappi parallel)` builds worker pools and `parallel-map`/
 `parallel-for-each` on top of this — see the [Concurrency
 guide](https://kaappi-lang.org/guide/concurrency/) for the higher-level API.
-A channel reached through a shared global instead (not captured by a thunk or
-message) still raises a descriptive error rather than corrupting memory. Two
-narrow correctness issues are open in the cross-thread wakeup path
-([#1487](https://github.com/kaappi/kaappi/issues/1487),
-[#1489](https://github.com/kaappi/kaappi/issues/1489)) — not yet recommended
-for production concurrent workloads. See [Standards
+A channel must reach the other thread through **lexical capture** in the
+thunk (or in a message sent over an already-promoted channel) — a channel
+reached instead through a shared top-level `define` is never promoted, and
+raises a descriptive error rather than corrupting memory
+([#1742](https://github.com/kaappi/kaappi/issues/1742) is exactly this
+trap). See [Standards
 Conformance](https://kaappi-lang.org/conformance/#extensions-beyond-r7rs-smalls-scope)
 for current status.
 
-A closure that crosses a `thread-start!` boundary must not, once running on
-the other thread, *call* a separately-defined top-level procedure from a
-library — doing so hangs
-([#1520](https://github.com/kaappi/kaappi/issues/1520)). The identical logic
-inlined directly into the closure works correctly; `(kaappi parallel)`'s own
-worker loop is written this way for exactly this reason.
-
-`parallel-map`/`parallel-for-each` submit one task per list element, so a
-large list means many concurrent `pool-submit`/`task-wait` round trips —
-which, given #1487/#1489 above, means an intermittent hang becomes
-increasingly likely somewhere past a few hundred concurrent submissions
-rather than a hard cutoff. Reliable in testing through list sizes in the
-low hundreds. For larger inputs, chunk manually with
-`make-pool`/`pool-submit`/`task-wait` (one task per processor, each
-covering a slice of the input with an ordinary sequential loop) instead of
-one task per element — see `kaappi-examples/parallel-primes` for a worked
-example.
+`parallel-map`/`parallel-for-each` submit one task per list element. For
+very large inputs, chunking manually with `make-pool`/`pool-submit`/
+`task-wait` (one task per processor, each covering a slice of the input with
+an ordinary sequential loop) reduces per-task submission overhead — see
+`kaappi-examples/parallel-primes` for a worked example.
 
 ### Macros
 

--- a/benchmarks/gate/README.md
+++ b/benchmarks/gate/README.md
@@ -63,9 +63,12 @@ them — that walk tax is deliberately part of what is measured (§1).
 
 Every worker **task thunk** captures only fixnums/flonums/payload objects and
 calls only built-in primitives — never a top-level procedure defined in the
-harness. A closure that crosses a worker boundary and then calls a
-separately-defined procedure can hang (kaappi#1520). Serial baselines never
-cross a thread, so they are free to call shared kernels.
+harness. This is a protocol constraint of the frozen run, not a live engine
+limitation: at the time data collection ran, a closure that crossed a worker
+boundary and then called a separately-defined procedure could hang
+(kaappi#1520, fixed 2026-07-15), so self-contained thunks kept the frozen
+dataset free of that risk. Serial baselines never cross a thread, so they
+are free to call shared kernels.
 
 ## Metrics (protocol §3)
 

--- a/benchmarks/gate/gate-harness.scm
+++ b/benchmarks/gate/gate-harness.scm
@@ -25,15 +25,19 @@
 ;;    submit exactly w disjoint tasks; task-wait each; reassemble -- NOT
 ;;    parallel-map over a per-element list. This is what §1 actually describes
 ;;    (disjoint bands / chunks / blocks) and is also lib/kaappi/parallel.sld's
-;;    documented recommendation for large inputs, sidestepping the kaappi#1489
-;;    many-submission wakeup hazard (w is small).
+;;    documented recommendation for large inputs; keeping submission counts
+;;    small (w is small) also incidentally sidestepped what was, at the time
+;;    data collection ran, an open many-submission wakeup hazard (kaappi#1489,
+;;    fixed 2026-07-14).
 ;;
 ;;  * Every worker task thunk is FULLY SELF-CONTAINED: it captures only fixnums,
 ;;    flonums, and payload objects, and calls only built-in primitives -- never a
-;;    top-level procedure defined in this file. A closure that crosses a worker
-;;    boundary and then calls a separately-defined procedure can hang
-;;    (kaappi#1520); the serial baselines, which never cross a thread, are free to
-;;    call the shared top-level kernels.
+;;    top-level procedure defined in this file. This was a protocol constraint
+;;    of the frozen run, not a live engine limitation: at the time data
+;;    collection ran, a closure that crossed a worker boundary and then called
+;;    a separately-defined procedure could hang (kaappi#1520, fixed
+;;    2026-07-15); the serial baselines, which never cross a thread, were free
+;;    to call the shared top-level kernels regardless.
 ;;
 ;;  * E (§3) is wall time from the first pool-submit to the last reassembly copy;
 ;;    pool creation/teardown and payload construction are excluded (they are

--- a/lib/kaappi/parallel.sld
+++ b/lib/kaappi/parallel.sld
@@ -11,27 +11,15 @@
 ;; degrades to spawning fiber workers on the calling thread's scheduler
 ;; instead: structurally the same pool, cooperative instead of parallel.
 ;;
-;; Known limitation (kaappi#1520): a closure that crosses a thread-start!
-;; boundary and then CALLS a separately-defined library-top-level procedure
-;; hangs (the identical logic inlined directly into the closure works) --
-;; so a pool must only be used from the thread that created it (or one that
-;; received it some other way that doesn't route through a fresh
-;; thread-start! thunk); do not thread-start! your own worker whose thunk
-;; calls pool-submit/task-wait/pool-shutdown!. This is why the worker loop
-;; below is inlined into each spawned thunk rather than factored into a
-;; shared procedure -- see the comment at %spawn-worker.
-;;
-;; Known limitation (kaappi#1487, kaappi#1489): parallel-map/parallel-for-each
-;; submit one task per list element, so a large list means many concurrent
-;; pool-submit/task-wait round trips on the shared task/reply channels --
-;; and the cross-thread wakeup path has open correctness issues that surface
-;; as an intermittent hang somewhere past a few hundred concurrent
-;; submissions (probability grows with count, not a hard cutoff). Reliable
-;; in testing through list sizes in the low hundreds. For larger inputs,
-;; chunk manually with make-pool/pool-submit/task-wait -- one task per
-;; processor, each covering a slice of the input with an ordinary
-;; sequential loop -- which is also simply more efficient for this shape of
-;; work. See kaappi-examples/parallel-primes for a worked chunking example.
+;; A pool crosses a thread-start! boundary the same way any (kaappi fibers)
+;; channel does: only via lexical capture (kaappi#1742) -- a pool reached
+;; instead through a shared top-level define is never promoted and raises a
+;; descriptive error rather than corrupting memory. parallel-map and
+;; parallel-for-each submit one task per list element; for very large
+;; inputs, chunking manually with make-pool/pool-submit/task-wait -- one
+;; task per processor, each covering a slice of the input with an ordinary
+;; sequential loop -- reduces per-task submission overhead. See
+;; kaappi-examples/parallel-primes for a worked chunking example.
 
 (define-library (kaappi parallel)
   (import (scheme base) (srfi 1) (kaappi fibers))
@@ -49,12 +37,9 @@
       (tasks %pool-tasks) (workers %pool-workers))
 
     ;; The worker loop is inlined directly into each spawned thunk below,
-    ;; not factored into a shared named procedure called from within it.
-    ;; A library-level procedure *called* (not just referenced) from inside
-    ;; a closure that crosses thread-start!'s thread boundary hangs -- the
-    ;; identical logic inlined into the thunk itself works correctly. Fully
-    ;; inlining also matches the KEP-0002 §8 reference pseudocode, which
-    ;; never factors this loop out.
+    ;; not factored into a shared named procedure called from within it --
+    ;; matching the KEP-0002 §8 reference pseudocode, which never factors
+    ;; this loop out either.
     ;;
     ;; Parks on the tasks channel's notifier; closed => drain queue, then
     ;; exit on eof. A task's exception is caught here (not left to escape)


### PR DESCRIPTION
## Summary
- README.md, `lib/kaappi/parallel.sld`, and `benchmarks/gate/` (README + `gate-harness.scm`) still described #1487, #1489, and #1520 as open correctness issues / live engine limitations. All three were closed as `completed` on 2026-07-13/14/15, each has a regression test in the tree, and all of those tests pass.
- Dropped the stale "not yet recommended for production" caveat and the `parallel-map` "reliable only through low hundreds" scale caveat, replacing them with the constraint that's actually still true: a channel (or a pool containing one) must reach the other thread through **lexical capture** in the thunk — a shared top-level `define` is never promoted (#1742, closed 2026-07-28, is exactly this trap).
- Reworded `benchmarks/gate/README.md`'s self-containment rule and the matching design notes in `gate-harness.scm` as protocol constraints of the already-completed, frozen benchmark run, not live engine limitations — the code/rules themselves are unchanged (the worker loop stays inlined; that's independently justified by matching the KEP-0002 §8 reference pseudocode).
- Left `benchmarks/gate/README.md`'s "Known limitations & PRE-FREEZE findings" section and its `kaappi#1489` mention at line ~159 untouched — those are already correctly self-contained historical records (the immediately-following "Status — campaign complete" section already clarifies the fix landed before the frozen runs started), matching what the issue itself called out as fine to leave alone.

## Test plan
- [x] Smoke-tested the edited `lib/kaappi/parallel.sld` with `kaappi --lib-path ./lib` — `parallel-map` and `make-pool`/`pool-submit`/`task-wait`/`pool-shutdown!` all still work correctly (comment-only changes, no code touched).
- [x] `git diff` reviewed in full; only comments/prose changed in `README.md`, `lib/kaappi/parallel.sld`, `benchmarks/gate/README.md`, `benchmarks/gate/gate-harness.scm`.
- [x] Repo-wide grep confirms no other stale `#1487`/`#1489`/`#1520` "live limitation" claims remain outside regression-test filenames and already-correct historical mentions in `docs/dev/`.

Fixes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)