### PR TITLE
Isolate -Dbundle test builds from the shared kaappi binary

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -413,11 +413,19 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     // ~/.kaappi/lib, and the exe-relative fallback lib. Sized to hold them all;
     // the old fixed [16] silently dropped a 17th path (or an auto-discovered dir
     // once 16 explicit ones existed), same silent-drop shape as #1652 (#1653).
-    // Never freed: vm.lib_paths points in here and is read as late as the
-    // deferred coverage report, so it must live for the whole run — like the
-    // auto-discovered dir strings (klp/elp below) it aliases.
+    // These allocations (lib_paths itself, and the auto-discovered dir strings
+    // klp/elp below) must live for the whole run — vm.lib_paths is read as
+    // late as the deferred coverage report — so they come from a dedicated
+    // arena freed by one defer here, rather than the general allocator: a
+    // Debug build's leak-tracking allocator would otherwise report these
+    // intentionally-never-individually-freed strings as leaked on every exit
+    // (kaappi#1748).
+    var lib_paths_arena = std.heap.ArenaAllocator.init(allocator);
+    defer lib_paths_arena.deinit();
+    const lib_paths_alloc = lib_paths_arena.allocator();
+
     const auto_discovered_max = 3;
-    const lib_paths = try allocator.alloc([]const u8, opts.libPaths().len + auto_discovered_max);
+    const lib_paths = try lib_paths_alloc.alloc([]const u8, opts.libPaths().len + auto_discovered_max);
     var lib_path_count: usize = 0;
     for (opts.libPaths()) |lp| {
         lib_paths[lib_path_count] = lp;
@@ -438,7 +446,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             var home_buf: [512]u8 = undefined;
             const home = kaappi_paths.getHome(&home_buf) orelse break :blk null;
             const lib_suffix = "/lib";
-            const path = allocator.alloc(u8, home.len + lib_suffix.len) catch break :blk null;
+            const path = lib_paths_alloc.alloc(u8, home.len + lib_suffix.len) catch break :blk null;
             @memcpy(path[0..home.len], home);
             @memcpy(path[home.len..][0..lib_suffix.len], lib_suffix);
             break :blk path;
@@ -457,7 +465,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                 const existing = platform.getenv(env_name);
                 if (existing) |ex| {
                     const ex_len = std.mem.len(ex);
-                    const new = allocator.alloc(u8, klp.len + 1 + ex_len + 1) catch null;
+                    const new = lib_paths_alloc.alloc(u8, klp.len + 1 + ex_len + 1) catch null;
                     if (new) |n| {
                         @memcpy(n[0..klp.len], klp);
                         n[klp.len] = ':';
@@ -466,7 +474,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
                         _ = setenv(env_name, @ptrCast(n[0 .. klp.len + 1 + ex_len :0]), 1);
                     }
                 } else {
-                    const z = allocator.dupeZ(u8, klp) catch null;
+                    const z = lib_paths_alloc.dupeZ(u8, klp) catch null;
                     if (z) |zz| _ = setenv(env_name, zz, 1);
                 }
             }
@@ -480,7 +488,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         const exe_lib_path = blk: {
             var exe_lib_buf: [1024]u8 = undefined;
             const elp = kaappi_paths.getExeRelativeLibDir(&exe_lib_buf) orelse break :blk null;
-            break :blk allocator.dupe(u8, elp) catch null;
+            break :blk lib_paths_alloc.dupe(u8, elp) catch null;
         };
         if (exe_lib_path) |elp| {
             lib_paths[lib_path_count] = elp;

--- a/tests/scheme/compile/compile-import-error-703.sh
+++ b/tests/scheme/compile/compile-import-error-703.sh
@@ -73,14 +73,15 @@ if [[ ! -f "$DIR/main.sbc" ]]; then
     exit 1
 fi
 
-# Build bundled binary
+# Build bundled binary into an isolated --prefix so the shared zig-out/bin/kaappi
+# binary -- which run-all.sh and every other test read from a fixed path -- is
+# never touched. Rebuilding it in place here raced the next sequential test's
+# exec of that same path (kaappi#1748).
 BUNDLE_BIN="$DIR/main-standalone"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
-(cd "$REPO_DIR" && zig build -Dbundle="$DIR/main.sbc" -Doptimize=ReleaseSafe 2>/dev/null)
-cp "$REPO_DIR/zig-out/bin/kaappi" "$BUNDLE_BIN"
-
-# Rebuild regular binary
-(cd "$REPO_DIR" && zig build 2>/dev/null)
+BUNDLE_PREFIX="$DIR/bundle-out"
+(cd "$REPO_DIR" && zig build -Dbundle="$DIR/main.sbc" -Doptimize=ReleaseSafe --prefix "$BUNDLE_PREFIX" 2>/dev/null)
+cp "$BUNDLE_PREFIX/bin/kaappi" "$BUNDLE_BIN"
 
 # Run bundled binary — the begin block must have executed (hash table initialized)
 OUTPUT=$("$BUNDLE_BIN" 2>/dev/null)

--- a/tests/scheme/compile/compile-preamble-gc-700.sh
+++ b/tests/scheme/compile/compile-preamble-gc-700.sh
@@ -71,14 +71,15 @@ if [[ ! -f "$DIR/main.sbc" ]]; then
     exit 1
 fi
 
-# Build bundled binary
+# Build bundled binary into an isolated --prefix so the shared zig-out/bin/kaappi
+# binary -- which run-all.sh and every other test read from a fixed path -- is
+# never touched. Rebuilding it in place here raced the next sequential test's
+# exec of that same path (kaappi#1748).
 BUNDLE_BIN="$DIR/main-standalone"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
-(cd "$REPO_DIR" && zig build -Dbundle="$DIR/main.sbc" -Doptimize=ReleaseSafe 2>/dev/null)
-cp "$REPO_DIR/zig-out/bin/kaappi" "$BUNDLE_BIN"
-
-# Rebuild regular binary
-(cd "$REPO_DIR" && zig build 2>/dev/null)
+BUNDLE_PREFIX="$DIR/bundle-out"
+(cd "$REPO_DIR" && zig build -Dbundle="$DIR/main.sbc" -Doptimize=ReleaseSafe --prefix "$BUNDLE_PREFIX" 2>/dev/null)
+cp "$BUNDLE_PREFIX/bin/kaappi" "$BUNDLE_BIN"
 
 # Run the bundled binary — must not crash or show preamble errors
 OUTPUT=$("$BUNDLE_BIN" 2>&1)

--- a/tests/scheme/compile/native-loop-alloca-stack-growth-1808.sh
+++ b/tests/scheme/compile/native-loop-alloca-stack-growth-1808.sh
@@ -34,6 +34,15 @@ REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 
+# Each reproducer below drives the interpreter through 3,000,000 iterations
+# as its correctness oracle before native-compiling the same program; under a
+# Debug build's un-optimized, leak-tracking allocator that oracle run alone
+# takes minutes rather than milliseconds (kaappi#1748). The regression this
+# test guards (native loop alloca stack growth) is independent of how the
+# *driver* was built, so ReleaseSafe/ReleaseFast/other-platform CI legs
+# already cover it at full rigor.
+skip_on_debug_build "$KAAPPI_ABS" "3M-iteration interpreter oracle is impractically slow under Debug (kaappi#1748); covered by other CI legs"
+
 ensure_runtime_lib "$REPO_DIR"
 
 DIR=$(mktemp -d)

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -30,6 +30,13 @@ TMPSTDERR=$(mktemp /tmp/kaappi-r7rs-stderr-XXXXXX)
 trap 'rm -f "$TMPOUT" "$TMPSTDOUT" "$TMPSTDERR"; rm -rf "$KAAPPI_HOME_TMP"' EXIT
 
 TIMEOUT="${KAAPPI_TEST_TIMEOUT:-60}"
+# Shell-suite tests do real work (native compiles, sometimes a `zig build`) so
+# they legitimately run longer than a single .scm file — a few minutes, not
+# seconds — but with no bound at all a genuine hang silently burns the whole
+# job's timeout with no indication of which file was stuck (kaappi#1748: a
+# 3M-iteration test took 7+ minutes under a Debug build and ate the rest of a
+# 40-minute CI job before anyone could tell which file was responsible).
+SHELL_TIMEOUT="${KAAPPI_SHELL_TEST_TIMEOUT:-300}"
 PASS=0
 FAIL=0
 TIMEDOUT=0
@@ -123,7 +130,7 @@ run_suite() {
 
 run_shell_suite() {
     local title="$1" dir="$2"
-    local matched=0
+    local matched=0 pid status
     echo "=== $title ==="
     for test_script in "$dir"/*.sh; do
         [[ -e "$test_script" ]] || continue
@@ -133,16 +140,25 @@ run_shell_suite() {
             continue
         fi
         matched=1
-        set +e
-        KAAPPI="$KAAPPI" bash "$test_script" "$KAAPPI" > "$TMPOUT" 2>&1
-        status=$?
-        set -e
+        KAAPPI="$KAAPPI" bash "$test_script" "$KAAPPI" > "$TMPOUT" 2>&1 &
+        pid=$!
+        if wait_with_timeout "$pid" "$SHELL_TIMEOUT"; then
+            status=0
+            wait "$pid" || status=$?
+        else
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            echo "  TIMEOUT  $test_script  (killed after ${SHELL_TIMEOUT}s)"
+            cat "$TMPOUT"
+            TIMEDOUT=$((TIMEDOUT + 1))
+            continue
+        fi
         if [[ $status -eq 0 ]]; then
             echo "  PASS  $test_script"
             PASS=$((PASS + 1))
         elif [[ $status -eq 77 ]]; then
-            # Exit 77 = SKIP (shell-common.sh skip_on_windows): the script's
-            # premise cannot hold on this platform.
+            # Exit 77 = SKIP (shell-common.sh skip_on_windows/skip_without_zig/
+            # skip_on_debug_build): the script's premise cannot hold here.
             echo "  SKIP  $test_script"
             SKIPPED=$((SKIPPED + 1))
         else

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -54,6 +54,24 @@ skip_without_zig() {
     fi
 }
 
+# skip_on_debug_build <kaappi-binary> <reason>: exit 77 (SKIP) when the given
+# binary reports build_mode "Debug" in `kaappi features --json`. For tests
+# whose regression coverage needs a large iteration/allocation count to be
+# meaningful (e.g. a native-compile stack-growth stress loop): a Debug
+# build's un-optimized, leak-tracking allocator makes that scale of work
+# impractically slow (10-20x, kaappi#1748) without adding any coverage a
+# ReleaseSafe/ReleaseFast/other-platform CI leg doesn't already provide at
+# full rigor, so skip rather than shrink (which risks silently dropping
+# below the iteration count actually needed to reproduce the regression) or
+# race a timeout.
+skip_on_debug_build() {
+    local kaappi="$1" reason="$2"
+    if "$kaappi" features --json 2>/dev/null | grep -q '"build_mode":"Debug"'; then
+        echo "SKIP: $reason"
+        exit 77
+    fi
+}
+
 # ensure_runtime_lib <repo-dir>: freshen the native runtime archive via
 # `zig build lib` when a toolchain is present. Without one, accept an
 # already-built archive (cross-compiled and copied to the box) so the


### PR DESCRIPTION
## Summary

- `compile-import-error-703.sh` and `compile-preamble-gc-700.sh` both build a
  standalone binary via `zig build -Dbundle=...`, which rewrites the shared
  `zig-out/bin/kaappi` in place, then rebuild it a second time (plain
  `zig build`) to restore the ordinary interpreter for the rest of the suite.
  `run-all.sh` and every other sequential test read that same fixed path, so a
  test executed right after either of these could race the restoring rebuild
  and observe a not-yet-settled binary — matching the flake reported in #1748.
- Both scripts now pass `--prefix <tmpdir>/bundle-out` to the `-Dbundle=`
  build, so it installs into an isolated location instead of `zig-out/bin/`.
  The shared binary is therefore never mutated, and the second "rebuild
  regular binary" step is no longer needed (dropped entirely) since there's
  nothing left to restore.

### Follow-up: fixing the Debug CI leg's own fallout

The plain-`zig build` "restore" step above defaults to `-Doptimize=ReleaseSafe`
regardless of the CI leg's actual mode. That meant the **Debug** leg was
silently running everything from partway through the `compile/` suite onward
— including the 1,391-test R7RS suite — against a **ReleaseSafe** binary, not
Debug. Removing the clobber fixed that masking, which surfaced two real,
previously-untested problems on a genuine Debug run:

- `main.zig`'s `mainImpl` intentionally never frees a few CLI-lifetime
  allocations (`lib_paths` and the auto-discovered library dirs) since they
  must live for the whole process. A Debug build's leak-tracking allocator
  reports these as leaked on every exit (to stderr), and several `compile/`
  tests merge stderr into stdout (`2>&1`) for exact-match/last-line
  comparisons — so the leak report corrupted otherwise-correct results.
  Fixed at the source: these allocations now come from a dedicated arena
  freed by one `defer`, so nothing is ever reported as outstanding.
- `native-loop-alloca-stack-growth-1808.sh` runs the interpreter through
  3,000,000 iterations per case as its correctness oracle before
  native-compiling. Under Debug's un-optimized, leak-tracked allocator that
  alone takes minutes instead of milliseconds (confirmed locally: 7+ minutes,
  still incomplete). `run_shell_suite` had no per-file timeout, so this
  silently burned the rest of the 40-minute CI job with no indication of the
  culprit. Skipped under Debug specifically (new `skip_on_debug_build`
  helper) — the regression it guards is independent of how the driver was
  built, so ReleaseSafe/ReleaseFast/other CI legs already cover it at full
  rigor; shrinking the iteration count instead risked silently dropping below
  what's needed to actually reproduce the regression.

Also hardened `run_shell_suite` with a per-file timeout (mirroring
`run_file`'s existing `wait_with_timeout`), so a future hang in any shell
test fails fast and names the culprit instead of quietly consuming the whole
job budget.

## Test plan

- [x] `bash tests/scheme/compile/compile-import-error-703.sh` — pass
- [x] `bash tests/scheme/compile/compile-preamble-gc-700.sh` — pass
- [x] Full `tests/scheme/compile/*.sh` suite (19 files), ReleaseSafe — all
      pass, `zig-out/bin/kaappi` hash unchanged before/after
- [x] Full `bash tests/scheme/run-all.sh`, ReleaseSafe — 2008 pass, 0 fail, 0
      timeout, 0 skipped (613 Scheme files + 1395 R7RS suite)
- [x] Full `tests/scheme/compile/*.sh` suite, **Debug** — all pass (1
      SKIP: `native-loop-alloca-stack-growth-1808.sh`), confirmed no leak
      noise, no hang
- [x] All shell-based suites (`errors/`, `compile/`, `test-runner/`,
      `pipeline/`, `doctor/`, `fmt/`, `cache/`, `timings/`), **Debug** — 42
      pass, 0 fail, 0 timeout, 1 skipped, ~11 min total (previously hung for
      the full 40-minute CI timeout)
- [x] `native-loop-alloca-stack-growth-1808.sh` under **ReleaseSafe** — still
      runs at full rigor (not skipped), passes in ~11s

Fixes #1748