### PR TITLE
Comptime-gate lever-D bytevector checks in gc_collect.zig

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -5,6 +5,7 @@ const types = @import("types.zig");
 const memory_mod = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
 const shared_buffer = @import("shared_buffer.zig");
+const instrument = @import("channel_instrument.zig");
 const GC = memory_mod.GC;
 
 const Value = types.Value;
@@ -1079,8 +1080,16 @@ fn objectSize(obj: *Object) usize {
         .flonum => @sizeOf(Flonum),
         .vector => @sizeOf(Vector) + obj.as(Vector).data.len * @sizeOf(Value),
         // A backed bytevector (lever D) borrows its bytes from a SharedBuffer,
-        // so only the struct counts against this heap.
-        .bytevector => @sizeOf(Bytevector) + if (obj.as(Bytevector).shared == null) obj.as(Bytevector).data.len else 0,
+        // so only the struct counts against this heap. Comptime-pruned in the
+        // shipped build (kaappi#1794): `shared` is always null there, so this
+        // always takes the "count the full data" branch.
+        .bytevector => blk: {
+            const bv = obj.as(Bytevector);
+            if (comptime instrument.enabled) {
+                break :blk @sizeOf(Bytevector) + (if (bv.shared == null) bv.data.len else 0);
+            }
+            break :blk @sizeOf(Bytevector) + bv.data.len;
+        },
         .numeric_vector => @sizeOf(NumericVector) + obj.as(NumericVector).data.len,
         .transformer => blk: {
             const t = obj.as(Transformer);
@@ -1270,10 +1279,16 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
             const bv = obj.as(Bytevector);
             // Lever D (kaappi#1472): a backed bytevector borrows its bytes from
             // a SharedBuffer -- release the reference (freeing the buffer at
-            // zero) instead of freeing bytes this heap never owned.
-            if (bv.shared) |raw| {
-                const sb: *shared_buffer.SharedBuffer = @ptrCast(@alignCast(raw));
-                sb.release();
+            // zero) instead of freeing bytes this heap never owned. Comptime-
+            // pruned in the shipped build (kaappi#1794): `shared` is always
+            // null there, so a shipped binary never loads the field at all.
+            if (comptime instrument.enabled) {
+                if (bv.shared) |raw| {
+                    const sb: *shared_buffer.SharedBuffer = @ptrCast(@alignCast(raw));
+                    sb.release();
+                } else {
+                    memory_mod.freeSliceNoFill(gc.allocator, u8, bv.data);
+                }
             } else {
                 memory_mod.freeSliceNoFill(gc.allocator, u8, bv.data);
             }


### PR DESCRIPTION
## Summary

- `Bytevector.shared` (KEP-0002 Phase 7 lever D, #1472) is only ever set by `allocBytevectorShared`, called solely from `gc_deep_copy.zig`'s `if (comptime instrument.enabled)` block — so it is provably always `null` in a shipped build (no `-Dchannel-instrument`).
- `gc_collect.zig`'s `freeObject` and `objectSize` still branched on `bv.shared` at plain runtime, unlike `gc_deep_copy.zig`'s own bytevector handling, which already gates the equivalent check with `if (comptime instrument.enabled)`.
- Wraps both consumer sites in the same comptime gate, mirroring `gc_deep_copy.zig`, so a shipped binary never loads the field and the dead branch is visible in the code rather than only in the reader's head.

No behavior change in either build mode — this is a code-generation/clarity fix, not a bug fix, so no new regression test is added (see commit message for the reasoning).

Fixes #1794.

## Test plan

- [x] `zig build` (default/shipped config) — compiles clean
- [x] `zig build -Dchannel-instrument=true` — compiles clean
- [x] `zig fmt --check src/gc_collect.zig` — clean
- [x] `zig build test` (default config) — pass
- [x] `zig build test -Dchannel-instrument=true` — pass, including `tests_shared_channel.zig`'s lever-D test which exercises both changed sites (`sb.release()` path in `freeObject` via envelope teardown, and `objectSize` accounting)
- [x] `bash tests/scheme/run-all.sh` (default build) — 2009 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)