### PR TITLE
Hygiene-rename free-global macro references to avoid arg collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A `syntax-rules` template's own free reference to a pre-existing global
+  could collapse into an unrelated, same-spelled argument at the use site.**
+  R7RS 4.3.1 referential transparency for a template's free reference to a
+  global that already existed when the macro was defined — e.g. `count` in
+  `(define-syntax inc! (syntax-rules () ((inc!) (set! count (+ count
+  1)))))` — was implemented by leaving the reference unrenamed and injecting
+  a register alias under that bare name, so it could pierce a same-named
+  local at the use site. But a bare, unrenamed reference is indistinguishable
+  from any other identifier of the same spelling introduced elsewhere in the
+  same expansion, including a pattern-variable argument the caller happened
+  to supply with that exact spelling. Calling such a macro with an argument
+  of the same name as its own free reference collapsed the two at that one
+  use site: `(let ((a 5)) (def a))`, where `def`'s own template referenced a
+  pre-existing global `a` while also taking `a` as an argument, resolved
+  both occurrences to the injected alias instead of the argument correctly
+  reading the `let`-bound local — silently producing a wrong value, or, for
+  a `set!`-based macro, overwriting the very use-site local the alias was
+  supposed to leave untouched. Such a reference is now hygiene-renamed like
+  any other template-introduced identifier, and its referential-transparency
+  alias is injected under that renamed name instead of the bare one (#1832).
+
 - **`thread-join!`'s default error report hid the child thread's real
   failure, and a local channel's deadlock message blamed only "fibers"
   even with another OS thread alive.** `thread-join!` has always wrapped an

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -80,6 +80,13 @@ const Local = struct {
     // template's free reference pierces use-site shadowing. set! through
     // the alias must write back to the global (see compileSet).
     is_global_alias: bool = false,
+    // The actual global's name, when is_global_alias is true. `name` itself
+    // is the reference's hygienic rename (e.g. __hyg_N_count), not the bare
+    // global name — kept distinct from any use-site identifier of the same
+    // spelling (kaappi#1832) — so compileSet's write-through must target
+    // THIS name instead of `name`. Unused (empty) when is_global_alias is
+    // false.
+    alias_global_name: []const u8 = "",
 };
 
 const Upvalue = struct {
@@ -383,15 +390,18 @@ pub const Compiler = struct {
         return false;
     }
 
-    pub fn isLocalGlobalAlias(self: *Compiler, name: []const u8) bool {
+    /// The real global name backing a global-alias local, or null if `name`
+    /// isn't a global-alias local. See Local.alias_global_name.
+    pub fn globalAliasTargetName(self: *Compiler, name: []const u8) ?[]const u8 {
         var i: usize = self.locals.items.len;
         while (i > 0) {
             i -= 1;
             if (std.mem.eql(u8, self.locals.items[i].name, name)) {
-                return self.locals.items[i].is_global_alias;
+                if (!self.locals.items[i].is_global_alias) return null;
+                return self.locals.items[i].alias_global_name;
             }
         }
-        return false;
+        return null;
     }
 
     pub fn isSlotBoxed(self: *Compiler, slot: u16) bool {

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -435,8 +435,11 @@ fn compileSetFromIR(self: *Compiler, data: ir_mod.SetData, dst: u16) CompileErro
     try compileFromNode(self, val_root, dst, false);
 
     if (self.resolveLocal(name)) |slot| {
-        if (self.isLocalGlobalAlias(name)) {
-            const sym_idx = try self.addConstant(data.name);
+        if (self.globalAliasTargetName(name)) |gname| {
+            // `data.name` is the reference's hygienic rename, not the bare
+            // global name (kaappi#1832) — write through to `gname` instead.
+            const target_sym = try self.gc.allocSymbol(gname);
+            const sym_idx = try self.addConstant(target_sym);
             try self.emitOp(.set_global);
             try self.emitU16(sym_idx);
             try self.emitU16(dst);

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -991,12 +991,16 @@ pub fn compileSet(self: *Compiler, args: Value, dst: u16) CompileError!void {
 
     const name = types.symbolName(target);
     if (self.resolveLocal(name)) |slot| {
-        if (self.isLocalGlobalAlias(name)) {
+        if (self.globalAliasTargetName(name)) |gname| {
             // The target is a register alias injected for a macro template's
             // free reference to a global: the variable itself lives in the
             // globals map, so write through to it, then refresh the alias
             // register for subsequent reads within the same expansion.
-            const sym_idx = try self.addConstant(target);
+            // `target` itself is the reference's hygienic rename, not the
+            // bare global name (kaappi#1832), so the write-through must use
+            // `gname` instead.
+            const target_sym = try self.gc.allocSymbol(gname);
+            const sym_idx = try self.addConstant(target_sym);
             try self.emitOp(.set_global);
             try self.emitU16(sym_idx);
             try self.emitU16(dst);

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -299,11 +299,25 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
                     }
                 }
             }
-            // Temporarily mark non-procedure free globals as VOID so
-            // renameForHygiene preserves them. Only mark identifiers that
-            // were bound at macro definition time (bound_free_refs) —
-            // template-introduced identifiers that coincidentally share a
-            // name with a later user define must still be renamed (#1208).
+            // Identify non-procedure free globals that were already bound at
+            // macro definition time (bound_free_refs): the template's own
+            // reference to one must resolve to THIS SAME variable at the use
+            // site regardless of what a use-site local shadows the name with
+            // (R7RS 4.3.1 referential transparency). This used to be done by
+            // temporarily marking the global VOID so renameForHygiene would
+            // preserve the reference's bare name — but a bare, unrenamed
+            // reference is textually indistinguishable from an unrelated
+            // identifier of the same spelling introduced elsewhere in the
+            // SAME expansion (e.g. a pattern-variable substitution of a
+            // same-named use-site argument), which is exactly the collision
+            // kaappi#1832 reported. So the reference is instead left to be
+            // hygiene-renamed like any other template-introduced identifier
+            // (#1208's own forward-reference concern still holds: only
+            // identifiers bound at macro definition time are collected
+            // here), and injectHygienicGlobalAliases (below, after
+            // expansion) finds the renamed occurrence(s) in the tree and
+            // aliases THEM to the global's current value instead of
+            // aliasing the bare name.
             if (globals_mod.globals_ctx) |gctx| {
                 for (tx.bound_free_refs) |cname| {
                     // #1812: a name resolvable through the transformer's own
@@ -334,12 +348,8 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
                     const existing = in_g orelse in_vm;
                     if (existing) |val| {
                         if (!types.isProcedure(val) and !types.isTransformer(val) and val != types.VOID) {
-                            if (level_count < 128) {
-                                temp_globals.append(gpa, .{ .name = cname, .old_val = in_g, .was_present = in_g != null }) catch return CompileError.OutOfMemory;
-                                level_count += 1;
-                                try g.put(cname, types.VOID);
-                            }
-                            // Track for local injection after expansion
+                            // Track for local injection after expansion —
+                            // the global itself is never touched now.
                             if (global_free_count < 64) {
                                 global_free_names[global_free_count] = cname;
                                 global_free_count += 1;
@@ -388,38 +398,16 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
         try self.scanSetTargets(expanded_root);
         try injectHygienicCapturedLocals(self, expanded_root, tx.captured_locals);
         // Inject non-procedure global free vars as locals so use-site
-        // locals don't shadow the definition-site global binding
-        // (R7RS 4.3.1 referential transparency).
-        for (global_free_names[0..global_free_count]) |gname| {
-            // Skip if already covered by captured_locals
-            var already_captured = false;
-            for (tx.captured_locals) |cap| {
-                if (std.mem.eql(u8, cap.name, gname)) {
-                    already_captured = true;
-                    break;
-                }
-            }
-            if (already_captured) continue;
-            // Load the global value into a fresh register. Register
-            // exhaustion skips the injection (non-fatal, as before), but a
-            // failure mid-emit must propagate: swallowing it after
-            // emitOp(.get_global) succeeded would leave a truncated
-            // instruction in the chunk for the VM to decode as garbage.
-            const gslot = self.allocReg() catch continue;
-            injected_reg_count += 1;
-            const gsym = try self.gc.allocSymbol(gname);
-            const gsym_idx = try self.addConstant(gsym);
-            try self.emitOp(.get_global);
-            try self.emitU16(gslot);
-            try self.emitU16(gsym_idx);
-            try self.locals.append(gpa, .{
-                .name = gname,
-                .depth = self.scope_depth,
-                .slot = gslot,
-                .binding_id = compiler_mod.freshBindingId(),
-                .is_global_alias = true,
-            });
-        }
+        // locals don't shadow the definition-site global binding (R7RS
+        // 4.3.1 referential transparency). The reference was hygienically
+        // renamed like any other template-introduced identifier (see the
+        // bound_free_refs scan above), so injectHygienicGlobalAliases finds
+        // whatever renamed name actually appears in the expansion instead
+        // of assuming the bare name — and, since injectHygienicCapturedLocals
+        // above already ran on this same tree, a name it already aliased is
+        // naturally skipped by the "already in self.locals" check, without
+        // needing a separate already-captured pre-filter.
+        try injectHygienicGlobalAliases(self, expanded_root, global_free_names[0..global_free_count], &injected_reg_count);
         // Swap let-syntax sibling keywords to their outer values while
         // material from this transformer is live; the undo record is
         // appended before each swap so a mid-chain error restores
@@ -1300,6 +1288,70 @@ fn injectHygCapturedWalk(self: *Compiler, expr: Value, captured: []const types.C
     if (types.isPair(expr)) {
         try injectHygCapturedWalk(self, types.car(expr), captured);
         try injectHygCapturedWalk(self, types.cdr(expr), captured);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hygienic global-alias injection
+// ---------------------------------------------------------------------------
+//
+// Companion to injectHygienicCapturedLocals above, for a template's free
+// reference to a non-procedure global that was already bound at the macro's
+// OWN definition time (bound_free_refs). Since kaappi#1832, such a reference
+// is hygiene-renamed like any other template-introduced identifier instead
+// of being preserved bare (a bare reference was indistinguishable from an
+// unrelated same-spelled identifier introduced elsewhere in the same
+// expansion — e.g. a pattern-variable substitution of a same-named use-site
+// argument). So, unlike the old bare-name injection, the alias here is
+// discovered by walking the expansion for the ACTUAL renamed name rather
+// than reconstructed from the pre-expansion candidate list, and it loads a
+// FRESH value from the global (there is no existing local slot to share, as
+// injectHygCapturedWalk has for a definition-site local).
+
+fn injectHygienicGlobalAliases(self: *Compiler, expr: Value, names: []const []const u8, injected_reg_count: *u16) CompileError!void {
+    if (names.len == 0) return;
+    try injectHygGlobalWalk(self, expr, names, injected_reg_count);
+}
+
+fn injectHygGlobalWalk(self: *Compiler, expr: Value, names: []const []const u8, injected_reg_count: *u16) CompileError!void {
+    if (types.isSymbol(expr)) {
+        const name = types.symbolName(expr);
+        if (!std.mem.startsWith(u8, name, "__hyg_")) return;
+        const base = types.stripHygienicPrefix(name);
+        if (base.len == name.len or !nameInSlice(names, base)) return;
+        // A __hyg_ name that is macro-bound is a renamed let-syntax KEYWORD,
+        // not a variable reference (see injectHygCapturedWalk's identical
+        // guard).
+        if (self.lookupMacro(name) != null) return;
+        for (self.locals.items) |loc| {
+            if (std.mem.eql(u8, loc.name, name)) return; // already injected
+        }
+        // Load the global's current value into a fresh register. Register
+        // exhaustion skips the injection (non-fatal, matching the old
+        // bare-name loop this replaces), but a failure mid-emit must still
+        // propagate: swallowing it after emitOp(.get_global) succeeded would
+        // leave a truncated instruction in the chunk for the VM to decode
+        // as garbage.
+        const gslot = self.allocReg() catch return;
+        injected_reg_count.* += 1;
+        const gsym = try self.gc.allocSymbol(base);
+        const gsym_idx = try self.addConstant(gsym);
+        try self.emitOp(.get_global);
+        try self.emitU16(gslot);
+        try self.emitU16(gsym_idx);
+        try self.locals.append(self.gc.allocator, .{
+            .name = name,
+            .depth = self.scope_depth,
+            .slot = gslot,
+            .binding_id = compiler_mod.freshBindingId(),
+            .is_global_alias = true,
+            .alias_global_name = base,
+        });
+        return;
+    }
+    if (types.isPair(expr)) {
+        try injectHygGlobalWalk(self, types.car(expr), names, injected_reg_count);
+        try injectHygGlobalWalk(self, types.cdr(expr), names, injected_reg_count);
     }
 }
 

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -672,6 +672,46 @@ test "hygiene: template set! reaches the global past a use-site shadow" {
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(global));
 }
 
+test "hygiene: template's free-global reference stays distinct from a same-spelled pattern-variable argument (#1832)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // `def2`'s template free-references the pre-existing global `a`
+    // while ALSO taking a pattern-variable argument. The compiler used to
+    // keep the template's own free reference to `a` unrenamed (so the
+    // referential-transparency alias it injects could pierce use-site
+    // shadowing by bare name) — but calling def2 with an argument of the
+    // SAME spelling from a scope that shadows `a` made the template's own
+    // reference and the pattern-variable-substituted argument collapse to
+    // the identical unrenamed symbol, so the injected alias intercepted
+    // BOTH instead of just the template's own reference.
+    _ = try vm.eval("(define a 999)");
+    _ = try vm.eval(
+        \\(define-syntax def2
+        \\  (syntax-rules ()
+        \\    ((def2 b) (list a b))))
+    );
+    const result = try vm.eval("(let ((a 5)) (def2 a))");
+    try std.testing.expectEqual(@as(i64, 999), types.toFixnum(types.car(result)));
+    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(types.car(types.cdr(result))));
+
+    // Same collision, but the template also set!s the global: the
+    // argument must still read the untouched use-site local, and the
+    // template's own set! must still reach the actual global.
+    _ = try vm.eval("(define counter2 0)");
+    _ = try vm.eval(
+        \\(define-syntax bump2!
+        \\  (syntax-rules ()
+        \\    ((bump2! x) (begin (set! counter2 (+ counter2 1)) x))))
+    );
+    const shadowed = try vm.eval("(let ((counter2 100)) (bump2! counter2))");
+    try std.testing.expectEqual(@as(i64, 100), types.toFixnum(shadowed));
+    const mutated_global = try vm.eval("counter2");
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(mutated_global));
+}
+
 test "hygiene: macro-expanded body-position define is visible to later siblings (#1800)" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/tests/scheme/hygiene/free-global-vs-arg-1832.scm
+++ b/tests/scheme/hygiene/free-global-vs-arg-1832.scm
@@ -1,0 +1,66 @@
+;; Regression test for #1832: a macro template's own free reference to a
+;; non-procedure global that was already bound at the macro's definition
+;; time (R7RS 4.3.1 referential transparency) used to be preserved
+;; UNRENAMED so it could pierce use-site shadowing. When a use site passed
+;; a pattern-variable argument of the SAME spelling, the two became
+;; textually indistinguishable, and whichever alias the compiler injected
+;; for the template's own reference silently intercepted the argument's
+;; occurrence too. This is the global counterpart of #1288's
+;; captured-local fix (see arg-vs-free.scm) — the reference is now
+;; hygiene-renamed like any other template-introduced identifier, and the
+;; referential-transparency alias is injected under that renamed name
+;; instead of the bare one.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "free-global-vs-arg-1832")
+
+;; Core bug: pattern-variable substitution carries the use-site `a` (the
+;; LET's own local, 5), but the template's free reference `a` must keep
+;; reading the pre-existing GLOBAL (999) regardless.
+(define a 999)
+(define-syntax def2
+  (syntax-rules ()
+    ((def2 b) (list a b))))
+
+(test-equal "arg same name as free global: template ref reads the global"
+  999
+  (car (let ((a 5)) (def2 a))))
+(test-equal "arg same name as free global: argument reads the use-site local"
+  5
+  (cadr (let ((a 5)) (def2 a))))
+
+;; No collision (baseline — should already work)
+(test-equal "no name collision"
+  (list 999 42)
+  (def2 42))
+
+;; set! combined with the same collision: the template's own set! must
+;; still mutate the GLOBAL, while the pattern-variable argument of the
+;; same spelling must still resolve to the use-site local, untouched.
+(define counter 0)
+(define-syntax bump2!
+  (syntax-rules ()
+    ((bump2! x) (begin (set! counter (+ counter 1)) x))))
+
+(test-equal "set!+collision: argument still reads the untouched use-site local"
+  100
+  (let ((counter 100)) (bump2! counter)))
+(test-equal "set!+collision: template's own set! still reached the global"
+  1
+  counter)
+
+;; Two free globals, one collides with the argument (mirrors arg-vs-free's
+;; "two captured locals" case).
+(define p 5)
+(define q 7)
+(define-syntax m2
+  (syntax-rules ()
+    ((_ x) (list x p q))))
+
+(test-equal "two free globals, arg collides with one"
+  (list 100 5 7)
+  (let ((q 100)) (m2 q)))
+
+(let ((runner (test-runner-current)))
+  (test-end "free-global-vs-arg-1832")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #1832.

`expandAndCompileMacroUse` implemented R7RS 4.3.1 referential transparency for a macro template's free reference to a global that already existed at the macro's *definition* time (e.g. `count` in `(define-syntax inc! (syntax-rules () ((inc!) (set! count (+ count 1)))))`) by temporarily marking that global `VOID`, signaling `renameForHygiene` to leave the reference **unrenamed** so an injected register alias could pierce use-site shadowing under that bare name.

A bare, unrenamed reference is indistinguishable from any other identifier of the same spelling introduced elsewhere in the *same* expansion — including a pattern-variable argument the caller happened to supply with that exact spelling. The issue's own reproduction demonstrates this via an `er-macro-transformer` observing the raw (corrupted) form. I traced it further and confirmed it's a real wrong-*value* bug, not just a syntax-introspection artifact:

```scheme
(define a 999)
(define-syntax def2 (syntax-rules () ((def2 b) (list a b))))
(let ((a 5)) (def2 a))   ; was (999 999), should be (999 5)
```

and a `set!`-based variant could overwrite an unrelated use-site local instead of leaving it untouched.

## Fix

The reference is now hygiene-renamed like any other template-introduced identifier — mirroring what the `set!`-target prescan (`collectSetTargets`) already did, and how `injectHygienicCapturedLocals` already handles the exact analogous case for a *captured local* (#1288, see `tests/scheme/hygiene/arg-vs-free.scm`). Its referential-transparency alias is now injected under that renamed name — found by walking the expansion tree in a new `injectHygienicGlobalAliases`, mirroring `injectHygCapturedWalk` — instead of the bare one.

`compileSet`'s write-through (both the legacy `compiler_lambda.zig` path and the IR `compiler_ir.zig` path) previously assumed the alias local's own name *was* the real global's name; it now reads a new `Local.alias_global_name` field instead, since the alias's `name` is a hygienic rename (e.g. `__hyg_N_count`), not the bare global name.

## Testing

- New Zig unit test in `tests_macros.zig` covering the core collision plus a `set!`+collision combination.
- New `tests/scheme/hygiene/free-global-vs-arg-1832.scm` (SRFI-64), including the two-free-globals case mirroring `arg-vs-free.scm`'s structure.
- Verified via `git stash`-based A/B testing that all new assertions genuinely fail pre-fix and pass post-fix.
- Confirmed the original issue reproduction now consistently hygiene-renames on *both* internal expansions (with different, fresh counters — the documented non-buggy shape).
- Confirmed SRFI 150's own `test-expect-fail` hygiene cases (the motivating context for filing #1832) are unaffected — still exactly the same 4 expected failures, same error, since that path goes through a different (ER-macro + `define-record-type` + SRFI 213) mechanism this fix doesn't touch. Not in scope here.
- Full test suite: `zig build test` (unit) and `bash tests/scheme/run-all.sh` (2010/2010: 615 Scheme files + 1395 R7RS suite) both pass clean.

## Test plan

- [x] `zig build test`
- [x] `bash tests/scheme/run-all.sh`
- [x] `zig fmt --check` on all touched files
- [x] Manual A/B verification (git stash) that new regression tests fail without the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)