### PR TITLE
Add Markdown linting to CI, fixing #1837

### DIFF
--- a/.claude/rules/compiler-forms.md
+++ b/.claude/rules/compiler-forms.md
@@ -18,6 +18,7 @@ Most new forms use this path — ~4 edits:
 
 3. **Dispatch** in the `.sexpr_form` arm of `compileFromNode()` in
    `src/compiler_ir.zig`:
+
    ```zig
    .my_form => try forms.compileMyForm(self, sf.args, dst, tail),
    ```

--- a/.claude/rules/gc-safety.md
+++ b/.claude/rules/gc-safety.md
@@ -92,11 +92,14 @@ gc.popRoot();                // pops `a`'s root right away, strictly nested
   reference (#1401).
 
 Dangerous pattern:
+
 ```zig
 const a = try gc.allocPair(x, y);
 const b = try gc.allocPair(a, z);  // GC may invalidate a
 ```
+
 Safe:
+
 ```zig
 var a = try gc.allocPair(x, y);
 gc.pushRoot(&a);

--- a/.claude/skills/add-builtin/SKILL.md
+++ b/.claude/skills/add-builtin/SKILL.md
@@ -7,6 +7,7 @@ description: Pattern for adding a new built-in Scheme procedure to Kaappi
 ## Steps
 
 1. **Define the function** in `src/primitives.zig`:
+
 ```zig
 fn myProc(args: []const Value) PrimitiveError!Value {
     // Validate arg types
@@ -17,11 +18,13 @@ fn myProc(args: []const Value) PrimitiveError!Value {
 ```
 
 2. **Register it** in `registerAll()` in `src/primitives.zig`:
+
 ```zig
 try reg(vm, "my-proc", &myProc, .{ .exact = 1 });  // or .{ .variadic = N }
 ```
 
 3. **Add a test** in `src/vm.zig` test section:
+
 ```zig
 test "eval my-proc" {
     var gc = memory.GC.init(std.testing.allocator);
@@ -36,15 +39,19 @@ test "eval my-proc" {
 4. **Update STATUS.md** — add the procedure to the "Implemented" list.
 
 ## Arity options
+
 - `.{ .exact = N }` — exactly N arguments
 - `.{ .variadic = N }` — at least N arguments
 
 ## Heap allocation in primitives
+
 If the procedure needs to allocate (cons, list, string operations), use the global GC instance:
+
 ```zig
 const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
 return gc.allocPair(a, b) catch return PrimitiveError.OutOfMemory;
 ```
 
 ## Error handling
+
 Return `PrimitiveError.TypeError` for type errors, `PrimitiveError.DivisionByZero`, etc.

--- a/.claude/skills/audit-primitives/SKILL.md
+++ b/.claude/skills/audit-primitives/SKILL.md
@@ -11,6 +11,7 @@ Systematically audit one `src/primitives_*.zig` file at a time. The argument is 
 ### Step 1: Extract procedures
 
 Read `src/<file>` and list every procedure registered with `try reg(vm, ...)`:
+
 - Scheme name, Zig function name, arity (exact N or variadic N)
 - Note which procedures call back into the VM (use `callWithArgs`, `callVM`)
 
@@ -23,6 +24,7 @@ For each procedure, check these categories against the R7RS spec:
 **Type errors** — what happens when given the wrong type? Every primitive should raise a catchable error, not crash. Test with: fixnum where string expected, string where pair expected, `#f` where procedure expected, etc.
 
 **Boundary conditions:**
+
 - Empty inputs: `'()`, `""`, `#()`, `#u8()`, `0`
 - Single-element: `'(x)`, `"a"`, `#(1)`
 - Large values: bignums `(expt 2 100)`, long strings, deep lists
@@ -31,12 +33,14 @@ For each procedure, check these categories against the R7RS spec:
 - Mixed exact/inexact, fixnum/bignum/rational/complex combinations
 
 **Higher-order functions** — if the procedure takes a callback:
+
 - Does error propagation work? `(guard (e (#t 'caught)) (proc (lambda (x) (error "e")) ...))`
 - Are continuations handled? What if the callback invokes `call/cc`?
 
 **Optional arguments** — if variadic, does each optional arg actually work?
 
 **GC safety** — does the procedure root values before allocating? Look for patterns like:
+
 ```zig
 const a = try gc.allocPair(...);
 // BUG: a may be invalidated by the next allocation
@@ -76,6 +80,7 @@ zig build run -- tests/scheme/audit/<basename>-audit.scm
 ```
 
 For each failure:
+
 1. Read the Zig source for the failing procedure
 2. Identify the bug (wrong logic, missing branch, type coercion error)
 3. Fix the source
@@ -91,7 +96,9 @@ Summarize: how many procedures audited, tests written, bugs found, bugs fixed.
 These patterns were found during coverage testing and are likely to recur:
 
 ### 1. Thunk not called
+
 Functions accepting an optional callback that return the procedure object instead of calling it:
+
 ```zig
 // BUG: returns the thunk instead of calling it
 if (args.len > 2) return args[2];
@@ -100,7 +107,9 @@ if (types.isProcedure(args[2])) return vm.callWithArgs(args[2], &[_]Value{});
 ```
 
 ### 2. Missing overwrite semantics
+
 Merge/update operations that skip existing entries instead of overwriting:
+
 ```zig
 // BUG: skips existing keys
 if (findKey(ht, key) == null) { ... }
@@ -109,7 +118,9 @@ if (findKey(ht, key)) |idx| { entries[idx].value = new_val; } else { ... }
 ```
 
 ### 3. Truncation instead of exact conversion
+
 Numeric operations that truncate floats where exact conversion is needed:
+
 ```zig
 // BUG: #e1.5 becomes 1
 .fixnum = @intFromFloat(f)
@@ -117,7 +128,9 @@ Numeric operations that truncate floats where exact conversion is needed:
 ```
 
 ### 4. Ignored optional arguments
+
 Variadic functions that accept but never inspect extra arguments:
+
 ```zig
 // BUG: trim ignores predicate
 while (isWhitespace(data[start])) ...
@@ -126,7 +139,9 @@ if (args.len > 1) { ... call pred ... } else { isWhitespace(...) }
 ```
 
 ### 5. Resource leaks
+
 Heap allocations in primitives or VM without corresponding cleanup:
+
 ```zig
 // BUG: allocated but never freed
 const sched = allocator.create(Scheduler);
@@ -136,7 +151,9 @@ if (self.scheduler) |s| { allocator.destroy(s); }
 ```
 
 ### 6. Missing type dispatch
+
 Arithmetic/comparison functions that handle fixnum and flonum but miss bignum, rational, or complex:
+
 ```zig
 // BUG: (even? (expt 2 100)) → TypeError
 if (types.isFixnum(args[0])) { ... }
@@ -170,6 +187,7 @@ return PrimitiveError.TypeError; // misses bignum!
 ## Audit Priority
 
 Start with files that have the highest bug density risk (complex type dispatch, many optional args):
+
 1. `primitives_arithmetic.zig` — most complex type dispatch
 2. `primitives_numeric.zig` — exact/inexact conversion edge cases
 3. `primitives_string.zig` — UTF-8 + mutation

--- a/.claude/skills/bytecode-isa/SKILL.md
+++ b/.claude/skills/bytecode-isa/SKILL.md
@@ -10,6 +10,7 @@ encoding, and disassembler output format. Do not duplicate the table here;
 that doc is the single source of truth.
 
 Quick orientation:
+
 - Opcodes are defined in the `OpCode` enum in `src/types.zig`
 - Executed by the dispatch loop `runUntil` in `src/vm_dispatch.zig`
 - Emitted by `src/compiler.zig` (and the `compiler_*.zig` form modules)

--- a/.claude/skills/do-gate-benchmark/SKILL.md
+++ b/.claude/skills/do-gate-benchmark/SKILL.md
@@ -87,6 +87,7 @@ safe, and each one wastes a debugging cycle if you don't recognize it fast:
 
 Mirror `/do-stress-test`'s provisioning (Zig 0.16, `git make gcc
 libc6-dev`, unprivileged `tester` user, `git fetch --depth 1 <exact-commit>`
+
 + checkout) — plus `python3-numpy`, which `run-gate.py` imports:
 
 ```bash

--- a/.claude/skills/do-linux-test/SKILL.md
+++ b/.claude/skills/do-linux-test/SKILL.md
@@ -38,6 +38,7 @@ Save this fingerprint for the droplet creation step.
 ## Create the droplet
 
 Use `mcp__digitalocean-droplets__droplet-create`:
+
 - **Name**: `kaappi-test-<branch>` (replace `/` with `-` in branch name, truncate to 60 chars)
 - **Size**: `s-2vcpu-4gb`
 - **Region**: `nyc3`
@@ -55,6 +56,7 @@ Record the **droplet ID** immediately — it is needed for cleanup.
 
 2. Scan the host key and pin it (TOFU — trust on first contact, then verify
    all subsequent connections against this pinned key):
+
    ```bash
    IP=<droplet-ip>
    for i in $(seq 1 24); do
@@ -65,6 +67,7 @@ Record the **droplet ID** immediately — it is needed for cleanup.
    ```
 
 3. Verify SSH is ready using the pinned host key:
+
    ```bash
    ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=yes \
      -o UserKnownHostsFile=/tmp/kaappi-test-hostkeys \
@@ -193,6 +196,7 @@ droplet — reconnect and fetch it.
 ## Report results
 
 Parse the test output and summarize:
+
 - **Build**: OK / FAIL
 - **Unit tests**: pass/fail counts
 - **Scheme tests**: per-suite results from `run-all.sh` output (look for

--- a/.claude/skills/do-stress-test/SKILL.md
+++ b/.claude/skills/do-stress-test/SKILL.md
@@ -11,6 +11,7 @@ droplet. The droplet self-destructs after **3 hours** and is **always**
 destroyed when done.
 
 Key differences from `/do-linux-test`:
+
 - The stress suite is CPU-bound for **1.5–3 hours** (every test VM bootstrap
   performs tens of thousands of collections; ~40 min on an M-series Mac).
 - It runs detached (`nohup`) on the droplet and is **polled**, never awaited
@@ -45,6 +46,7 @@ ssh-keygen -l -E md5 -f ~/.ssh/id_rsa.pub | awk '{print $2}' | sed 's/MD5://'
 ## Create the droplet
 
 Use `mcp__digitalocean-droplets__droplet-create`:
+
 - **Name**: `kaappi-stress-<branch>` (replace `/` with `-`, truncate to 60 chars)
 - **Size**: `c5-4vcpu-8gb` (CPU-optimized gen 5 — the suite is single-core-bound,
   so dedicated per-core speed matters; fall back to `c2-4vcpu-8gb`, then `c-4`,
@@ -64,6 +66,7 @@ Record the **droplet ID** immediately — it is needed for cleanup.
 
 2. Scan the host key and pin it (TOFU — trust on first contact, then verify
    all subsequent connections against this pinned key):
+
    ```bash
    IP=<droplet-ip>
    for i in $(seq 1 24); do
@@ -74,6 +77,7 @@ Record the **droplet ID** immediately — it is needed for cleanup.
    ```
 
 3. Verify SSH is ready using the pinned host key:
+
    ```bash
    ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=yes \
      -o UserKnownHostsFile=/tmp/kaappi-test-hostkeys \

--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -73,6 +73,7 @@ The file uses Keep a Changelog format. After editing, it should look like:
 One file — `build.zig.zon` is the single source of truth (no `v` prefix):
 
 **`build.zig.zon` line 3:**
+
 ```zig
 .version = "X.Y.Z",
 ```
@@ -220,6 +221,7 @@ ssh freebsd "/tmp/kaappi-$TAG features"
 ```
 
 Verify: version matches, script prints `3`, and `features` shows `posix`
+
 + `kaappi-threads` with target `aarch64-freebsd-none`. See
 `docs/dev/freebsd.md`.
 
@@ -256,6 +258,7 @@ ssh netbsd "echo '(import (scheme base)(scheme write)(srfi 144)) (write (> fl-le
 ```
 
 Verify: version matches, the script prints `3`, `features` shows `posix`
+
 + `kaappi-threads` with target `aarch64-netbsd-none`, and the SRFI-144
 probe prints `#t` (denormal arithmetic — guards the startup FPCR
 flush-to-zero fix on NetBSD/aarch64). See `docs/dev/netbsd.md`.

--- a/.claude/skills/parallel-issues/SKILL.md
+++ b/.claude/skills/parallel-issues/SKILL.md
@@ -94,7 +94,7 @@ Before grouping, determine which issues depend on which others:
 For each set, output only the issue numbers as a comma-separated list on one
 line:
 
-```
+```text
 Set 1: NNN, NNN, NNN, ...
 Set 2: NNN, NNN, ...
 ```

--- a/.claude/skills/r7rs-reader/SKILL.md
+++ b/.claude/skills/r7rs-reader/SKILL.md
@@ -7,6 +7,7 @@ description: R7RS lexical syntax reference for implementing/modifying the Kaappi
 Reader implementation: `src/reader.zig`
 
 ## Token types (currently implemented)
+
 - `(` `)` — list delimiters
 - `.` — dotted pair separator
 - `'` — quote abbreviation → `(quote datum)`
@@ -21,23 +22,28 @@ Reader implementation: `src/reader.zig`
 - identifiers — standard R7RS rules
 
 ## Identifier rules
+
 - **Initial**: letter or `! $ % & * / : < = > ? @ ^ _ ~`
 - **Subsequent**: initial or digit or `+ - . @`
 - **Peculiar**: `+`, `-`, `...`, or identifiers starting with `+`/`-` followed by sign subsequent
 - **Quoted**: `|...|` with `\|` and `\\` escapes
 
 ## String escape sequences
+
 `\"` `\\` `\n` `\r` `\t` `\a` `\b` `\|` `\x<hex>;`
 
 ## Character names
+
 `alarm` `backspace` `delete` `escape` `newline` `null` `return` `space` `tab`
 
 ## Comment forms
+
 - `;` line comment
 - `#;` datum comment (skips next datum)
 - `#| ... |#` nested block comment
 
 ## Not yet implemented
+
 - Floating point numbers
 - Number prefixes: `#b` `#o` `#d` `#x` `#e` `#i`
 - Complex numbers

--- a/.claude/skills/vm-test/SKILL.md
+++ b/.claude/skills/vm-test/SKILL.md
@@ -251,11 +251,13 @@ reference-machine quirks are in the `reference-win11-vm` memory.
 3. **Ship** into `C:\tmp` (must exist — tests write `/tmp/...` → `\tmp`).
    Create the staging subdir first (`tar -C` won't make it), keep PowerShell
    off the binary stdin with a `cmd` wrapper, and suppress AppleDouble files:
+
    ```bash
    ssh win11 'cmd /c "if not exist C:\tmp\kaappi-vm mkdir C:\tmp\kaappi-vm"'
    COPYFILE_DISABLE=1 tar czf - <files> \
      | ssh win11 'cmd /c "tar -xzf - -C C:\tmp\kaappi-vm"'
    ```
+
 4. **Run** unit-tests.exe + R7RS + the VM-verified `.scm` suites. Shell
    (`run-all.sh`) suites run under the box's Git Bash
    (`C:\tmp\PortableGit\bin\bash.exe`) via a scp'd runner script — quoting

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,6 +17,7 @@ labels: bug
 <!-- What happened? What did you expect? -->
 
 **Minimal reproduction**
+
 ```scheme
 ;; Paste the smallest program that triggers the bug
 ```
@@ -26,5 +27,6 @@ labels: bug
      a wrong Scheme error. If unsure, paste the full output. -->
 
 **Full output**
-```
+
+```text
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
             exit 1
           fi
 
+      # Globs, ignores, and the rule set all live in .markdownlint-cli2.jsonc,
+      # so `npx markdownlint-cli2` locally lints exactly what this step does.
+      - name: Markdown lint
+        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
+
   test:
     needs: format
     # Explicit name, deliberately NOT including matrix.timeout: this job's

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,31 @@
+// Markdown linting for this repo, enforced by the `format` job in
+// .github/workflows/ci.yml. Run `npx markdownlint-cli2` locally to get the
+// same answer CI gets; `npx markdownlint-cli2 --fix` fixes most of it.
+//
+// Globs and ignores live here rather than in the workflow so the bare local
+// command and the CI action lint exactly the same set of files.
+{
+  "globs": ["**/*.md"],
+
+  // AGENTS.md is a symlink to CLAUDE.md — linting both double-reports every
+  // violation and would show every fix twice in a diff.
+  "ignores": ["vendor/**", ".zig-cache/**", "zig-out/**", "AGENTS.md"],
+
+  // Only cosmetic rules are disabled. Everything structural stays on: MD018
+  // (line-initial `#NNNN`, the #1836 bug), MD022/MD031/MD032/MD058 (blank
+  // lines around headings, fences, lists, tables), MD040 (fence language),
+  // MD025/MD026/MD001 (heading sanity), MD009, MD037, MD038.
+  "config": {
+    "MD013": false, // line-length: prose is hand-wrapped ~76-80, not uniformly
+    "MD060": false, // table-column-style: cosmetic pipe padding
+    "MD024": false, // no-duplicate-heading: Keep a Changelog repeats "### Added"
+    "MD033": false, // no-inline-html: README's centered banner block
+    "MD041": false, // first-line-heading: README banner, issue templates
+    "MD004": false, // ul-style: porting.md uses `*` for prose, `-` for task lists
+    "MD036": false, // no-emphasis-as-heading
+    "MD014": false, // commands-show-output
+    "MD029": false, // ol-prefix
+    "MD034": false, // no-bare-urls
+    "MD049": false  // emphasis-style
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -559,9 +559,11 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Added
 
 #### FreeBSD platform support
+
 - **FreeBSD target (x86_64, aarch64)** — `zig build -Dtarget=<arch>-freebsd` cross-compiles all three binaries (releases ship both arches). A full-POSIX port with no runtime degradations: kqueue-backed fiber I/O (the macOS reactor backend, shared), SRFI-18 OS threads, complete SRFI-170, FFI via `dlopen`, the full linenoise REPL, and thottam including `build:` manifests. Self-exe lookup uses `sysctl kern.proc.pathname`. Verified on real FreeBSD 15.1 aarch64 hardware: full unit, R7RS, and `run-all.sh` suites, plus the native backend (`kaappi compile`) linking with the base system `cc` — no Zig toolchain needed on the box. CI runs the suites in a KVM FreeBSD VM. See `docs/dev/freebsd.md`
 
 ### Fixed
+
 - **Out-of-memory errors are now deterministic across kernels** — a single vector/bytevector/string payload allocation is capped at 1 TiB (`GC.max_payload_bytes`) and raises the catchable out-of-memory error before asking the OS. Previously the graceful error relied on `malloc` refusing absurd requests, which overcommitting kernels (FreeBSD's default) don't do — `(make-bytevector 100000000000000)` was OOM-killed by the kernel instead of raising
 
 ## [0.16.0] - 2026-07-17
@@ -569,6 +571,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Added
 
 #### Windows platform support
+
 - **Windows aarch64 target** — `zig build -Dtarget=aarch64-windows` cross-compiles `kaappi.exe`, `thottam.exe`, and `kaappi-lsp.exe` (via Zig's bundled mingw-w64; releases ship `kaappi-aarch64-windows.exe`). The full interpreter works on Windows 11 ARM64 — REPL (plain line editing), fibers, channels (incl. capacity-0 rendezvous), SRFI-18 OS threads, FFI via `LoadLibrary`, and the `kaappi test` runner — verified with the complete unit and R7RS suites on real hardware. The POSIX-only slice of SRFI-170 (uid/gid, symlinks, chmod/umask, user/group info) raises a catchable file error, and `cond-expand`/`(features)` expose a `windows` identifier in place of `posix`. See `docs/dev/windows.md` (#1606)
 - **Windows fd readiness** — fiber I/O suspension now works on Windows: socket-backed ports get reactor-driven non-blocking I/O via `WSAEventSelect` (#1608 stage 1), and pipe-backed ports get emulated non-blocking mode via a polled peek/write-quota backend (#1608 stage 2). File ports keep blocking reads (the POSIX baseline — no OS has regular-file readiness). The fd-readiness unit suites (`tests_reactor`, `tests_scheduler`, `tests_port_io`) run on Windows over loopback TCP socket pairs
 - **Windows native backend** — `kaappi compile` verified end-to-end on Windows: `rt_lib_name` probes `kaappi_rt.lib`, emits a derived `.exe` output, and uses the `windows-gnu` triple; 38/38 tests pass via `run-e2e.ps1` (#1610)
@@ -576,6 +579,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **Windows CI** — the shell-based test suites (`tests/scheme/run-all.sh` and sub-suites) run on Windows via Git Bash, and the FFI Scheme suite (`tests/scheme/ffi/`) runs with a cross-compiled fixture DLL (#1611, #1612)
 
 #### Other
+
 - **Rendezvous channels** — `(make-channel 0)` creates a capacity-0 channel with true rendezvous semantics (sender blocks until a receiver is ready) on both fiber-local and cross-thread (`SharedChannel`) representations (#1604)
 - **Heap-type layout guard** — a comptime check in `types.zig` asserts every heap struct keeps its `header: Object` at byte offset 0, catching layout drift at compile time instead of silent memory corruption (#1618, #1622)
 - **Porting guide** — `docs/dev/porting.md` documents porting surfaces, the degradation ladder, and staged checklists for adding a new OS or CPU architecture (#1624)
@@ -583,19 +587,23 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Fixed
 
 #### Windows
+
 - `(ffi-open #f)` on Windows now has POSIX `dlopen(NULL)` semantics: symbol lookup on the process handle searches every loaded module, so CRT functions resolve from `ucrtbase.dll` (#1611)
 - FFI 64-bit integer marshaling now uses a platform-independent `i64` carrier: on LLP64 targets (Windows) C `long` is 32-bit and is routed through the 32-bit marshaling class, while `int64`/`uint64`/`size_t` keep full 64-bit range
 
 #### Concurrency
+
 - An idle in-place I/O drive pinned over a resolved ancestor's wait now unwinds with a catchable "port I/O abandoned" error instead of blocking unboundedly (#1625)
 - GC `referencesYoung` now traces `owned_mutexes` in the fiber arm, preventing young-generation mutexes shared with a fiber from being collected during minor GC (#1605)
 
 #### LLVM native backend
+
 - Fix native `let` root leak: body-scope roots were not popped on early return (#1585)
 - Fix duplicated fallback effects in transactional `emitLet` (#1586)
 - Fix VM-vs-native divergence for shadowed boxed names (#1590)
 
 #### Other
+
 - macOS release binaries can now `ffi-open` user-compiled libraries: signing entitlements add `com.apple.security.cs.disable-library-validation` (#1587)
 - `--profile` no longer drops functions promoted to the old GC generation (#1599)
 - Fuzz generator coverage leaks in `genLetMut` ordering and string length (#1620)
@@ -606,6 +614,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Added
 
 #### Machine legibility: CLI diagnostics & tooling (epic #1503)
+
 - **`kaappi check <file>`** — compile-only static analysis: reads, expands, and compiles without executing, reporting read/compile diagnostics plus `KP4xxx` lint findings (unknown top-level variable, wrong arity or wrong-type literal on a direct built-in call). Never rejects a program R7RS permits (#1511)
 - **`kaappi ast` / `expand` / `ir`** — read-only pipeline-stage dumps: post-read datums, fully macro-expanded source (round-trips), and the IR tree before/after the five optimization passes (#1512)
 - **Full source spans in diagnostics** — the reader records `(line, col, end_line, end_col)` per datum; compile and runtime errors report `file:line:col` instead of `file:line`, down to the exact offending sub-form. `.sbc` cache format bumped to v9 (#1506)
@@ -622,6 +631,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **`--timings[=json]`** — per-stage pipeline wall time (read/expand/lower/optimize/emit/execute, plus native `llvm-emit`/`link`) and an always-present cache HIT/MISS line with path, using a self-time profiler stack so nested stages stay disjoint (#1515)
 
 #### Concurrency: fiber I/O reactor (KEP-0001)
+
 - **Reactor core** — per-OS-thread event loop with kqueue/epoll backends and a userspace timer heap (#1446)
 - **Scheduler integration** — blocking fiber operations (channel/join/mutex/condvar waits, `thread-sleep!`) now park on the reactor instead of blocking the OS thread or busy-polling (#1453)
 - **Non-blocking port I/O** — reads/writes that would block suspend the calling fiber instead of the thread, so fibers serving different connections interleave; ports buffer writes (8 KiB high water) with real `flush-output-port` semantics (#1459)
@@ -630,6 +640,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **O(1) fiber scheduling** — a ready ring + free-slot list replace the old O(n) scan on every dispatch and spawn (154x faster dispatch at 5,000 concurrent fibers) (#1477); wake paths are further indexed by waited-on object for O(1) wakes instead of scanning every fiber (~8x at 10,000 fibers) (#1530)
 
 #### Concurrency: cross-thread channels (KEP-0002)
+
 - **`SharedChannel`** — a channel now promotes automatically for use across `thread-start!`ed OS threads; reaching one through a shared global instead of a legitimate handoff raises a descriptive error instead of corrupting memory (#1482)
 - **Envelope-based `thread-start!`/`thread-join!`** — thunks, results, and exceptions cross threads via a copy-once envelope, closing a concurrent-copy race and enabling channels created inside a thunk to promote correctly (#1483)
 - **Cross-thread wakeup** — a reactor-backed `ThreadNotifier` (kqueue/epoll/WASI) replaces the placeholder panic left by earlier phases (#1485)
@@ -638,6 +649,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **Envelope-cost elision shipped as default** — immediate payloads (fixnums, booleans, chars) skip the per-message envelope heap entirely (28–120x faster sends), and pointer payloads reuse a recycled per-channel buffer (~50–63% lower round-trip latency for small messages) (#1472)
 
 #### Other
+
 - **Configurable REPL syntax highlighting** — dark/light presets, `NO_COLOR` support, per-token overrides, and configurable prompts via a new `~/.kaappi/config` file (#1456)
 - **`cond-expand`/`(features)`** gain `kaappi-fibers`, `kaappi-reactor`, and `kaappi-threads` subsystem identifiers (KEP-0004 Phase 0/1) (#1488)
 - **KEP-0003 access-semantics research experiment** — measures the cost of `unordered`-atomic element access for shared flat buffers ahead of building them; resolves KEP-0003's Unresolved Question 2 to a hybrid design. Docs/benchmarks only, no source changes (#1473)
@@ -645,6 +657,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Changed
 
 #### Native (LLVM) backend
+
 - **Guaranteed native mutual tail calls** — a fixed-arity direct tail call between natively-compiled functions now emits `musttail call tailcc`, giving mutual recursion (not just self-recursion) LLVM-guaranteed constant stack (#1499)
 - **Native `cond`/`case`/`do` lowering** — emitted directly instead of falling back to a whole-function `kaappi_eval` (#1564)
 - **Cached eval-fallback compilation** — a form the native backend can't lower (`letrec`, `guard`, quasiquote, named `let`, …) is parsed and compiled once per call site instead of on every execution (#1494)
@@ -656,11 +669,13 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **Native lambda analysis buffers grow instead of bailing out** at fixed size limits, and variadic self-tail-calls now loop instead of recursing (#1498)
 
 #### Performance
+
 - **Batched fd reads** in `readOneByte` — up to 4096 bytes per syscall instead of one syscall per byte for byte-at-a-time port consumers (#1460)
 
 ### Fixed
 
 #### Concurrency
+
 - Lost cross-thread wakeup in shared channel send/receive that could park a receiver permanently (#1489)
 - Dirty-snapshot dispatch hazard in `mutex-lock!`, `condition-variable-wait`, `thread-join!`, and timed channel ops, via a generic `driving` guard that excludes an in-flight fiber from re-dispatch (#1487)
 - `mutex-lock!`/`mutex-unlock!`+condvar giving up instantly across OS threads instead of polling shared state, which could silently corrupt lock ownership (#1454)
@@ -671,15 +686,18 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Closures losing their library environment when deep-copied across threads, which hung or raised "undefined variable" for any library-defined procedure called from a `thread-start!` thunk (#1479)
 
 #### GC and memory
+
 - Stale "gap" registers (dead slots between live frame windows) copied verbatim into `call/cc` continuation snapshots (#1464) and fiber suspension snapshots (#1529) — both use-after-free hazards under `-Dgc-stress=true`
 
 #### Compiler and tooling
+
 - Portable SRFI libraries now resolve via an exe-relative `lib/` fallback, so a `zig build`-produced binary run from any directory (with no prior `thottam` setup) can still find them (#1523)
 - Fuzz generator-coverage gates bounded by instruction count instead of wall clock, so they measure generator correctness rather than timing out under `-Dgc-stress=true` or on emulated (QEMU riscv64) CI targets (#1447)
 
 ## [0.14.1] - 2026-07-11
 
 ### Added
+
 - **Persistent GC mark worklist** on the GC struct, eliminating per-collection heap allocation (#1436)
 - **Bignum rational literals** — the reader now accepts rational literals with bignum numerators or denominators (#1423)
 - **Chained nested-lambda captures** in the native closure tiers (#1419)
@@ -687,6 +705,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **Fuzzing infrastructure** (Phases 1–3): seed corpora, Smith-driven grammar generator, three differential oracles (IR opt-vs-no-opt, VM-vs-native backend, Kaappi-vs-Chibi), scheduled CI job, and auto-filed GitHub issues for findings (#1388, #1398, #1403, #1405, #1408, #1418, #1424, #1426, #1434)
 
 ### Fixed
+
 - Root bignum intermediates in rational arithmetic and `string->number` (#1421)
 - Fix nested `syntax-rules` substitution and template-let ellipsis bindings (#1411)
 - Descend into `let`/`let*` in the native closure free-variable analysis (#1409)
@@ -696,6 +715,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Harden the `--no-ir-opt` compile guard (#1406)
 
 ### Changed
+
 - Pin GitHub Actions by SHA and disable persisted checkout credentials (#1413)
 - Build chibi-scheme from source in oracle-diff CI (#1434)
 - Security-harden the DigitalOcean test skills (#1435)
@@ -703,6 +723,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.14.0] - 2026-07-10
 
 ### Added
+
 - **SRFI-17 generalized `set!`** with pre-defined setters for `car`, `cdr`, `vector-ref`, `string-ref`, `hashtable-ref`, and `slot-ref` (#1349)
 - **SRFI-61 general `cond` clause** (`generator guard => receiver`) (#1357)
 - **SRFI-132 complete sort library** — 22 procedures: `list-sort`, `list-stable-sort`, `list-sort!`, `vector-sort`, `vector-stable-sort`, `vector-sort!`, merge operations, selection, and deletion (#1339)
@@ -715,6 +736,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **SRFI completions:** 15 missing SRFI-41 stream procedures (#1330), 9 missing SRFI-133 vector procedures (#1308), 27 missing SRFI-235 combinators (#1338), 21 missing SRFI-125 hash table exports (#1337), 16 missing SRFI-175 ASCII procedures (#1325), SRFI-33 aliases from SRFI-60 (#1328), SRFI-174 `timespec-hash`/`timespec->inexact`/`inexact->timespec` (#1352), SRFI-197 `nest`/`nest-reverse` (#1345), SRFI-78 `check-set-mode!`/`check-ec` (#1342), SRFI-69 `hash-table-update!` (#1315), SRFI-45 `lazy`/`eager` exports (#1353), SRFI-170 `owner/unchanged`/`group/unchanged` constants (#1363), SRFI-210 `box`/`mv` exports (#1318), SRFI-13 `string-join` grammar argument (#1312)
 
 ### Changed
+
 - **Trampoline rewrite:** `map`, `for-each`, `dynamic-wind`, and `force` are now Scheme closures bootstrapped at VM init, eliminating native VM re-entrancy for the callback family. ~460 lines of native code retired. Callbacks that `call/cc` out of `map` now park correctly instead of corrupting the native call stack (#1374, #1378)
 - **Native backend NativeClosure dispatch:** all VM call sites (call, tail-call, tail-apply, `call/cc` receiver, exception handler, dynamic-wind thunks) now handle NativeClosure, fixing native-compiled programs calling bootstrapped procedures (#1376, #1379)
 - **Test framework migration:** 55 test files migrated from `(chibi test)` to SRFI-64 — the R7RS suite remains on `(chibi test)` (#1382)
@@ -725,12 +747,14 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Fixed
 
 #### GC and memory
+
 - Fix GC crash on stale VM registers after thread start/join cycles (#1254)
 - Add GC write barriers to `readListTail` `set-cdr!` calls (#1292)
 - Root hash-table-walk/fold snapshot entries to prevent use-after-free (#1294)
 - Clear stale registers in tail-call window extension (#1293)
 
 #### Compiler and macros
+
 - Fix hygiene: use-site argument no longer captured by same-name def-site local (#1301)
 - Capture `let`/`lambda` locals in `define-syntax` transformers (#1287)
 - Expand macros during `set!` target pre-scan (#1291)
@@ -749,6 +773,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Rewrite SRFI-26 `cut`/`cute` with recursive helper macros to fix expander bug (#1344)
 
 #### Control flow
+
 - Fix spurious wind unwind on return into native-callback frames (#1380)
 - Make advisory yield a no-op under re-entrant native frames (#1384)
 - Fix yield raising inside `with-exception-handler` after `spawn` (#1369)
@@ -759,6 +784,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix `parameterize` to evaluate all values before binding (#1260)
 
 #### R7RS conformance
+
 - Enforce immutability on literal vectors, pairs, and bytevectors (#1285)
 - Signal error on `define`/`set!` in immutable environments (#1275)
 - Reject non-environment second argument to `eval` (#1282)
@@ -771,6 +797,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Patch datum-label references inside vectors (#1257)
 
 #### SRFIs
+
 - Fix SRFI-1 `take-right`/`drop-right` to accept dotted lists (#1354)
 - Fix SRFI-4 integer vector kinds to be disjoint types with range validation (#1336)
 - Fix SRFI-9 record-type redefinition retargeting old procedures (#1371)
@@ -807,12 +834,14 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Honor timeout deadlines when no fibers are runnable (#1300)
 
 #### FFI
+
 - Fix FFI `char` type to accept Scheme characters and return characters (#1309)
 - Fix `group-info` by name returning gid 0 (#1307)
 
 ## [0.13.0] - 2026-07-05
 
 ### Added
+
 - **REPL parenthesis highlighting:** matching parentheses are highlighted as you type (#1228)
 - **`KAAPPI_HOME` environment variable:** override the default `~/.kaappi/` directory for libraries, packages, and REPL history (#1031, #1084)
 - **Native backend shadow-stack GC rooting:** native-compiled binaries now use a shadow stack for precise GC root tracking (#1034, #1082)
@@ -822,6 +851,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **Comprehensive R7RS conformance audit** (Phases 0–3.4): gap tests for R7RS sections 4.1–6.14, primitives audit tests for all 21 files, SRFI conformance tests for 40+ SRFIs (#1137)
 
 ### Changed
+
 - **All compilation routed through the IR pipeline** — the legacy `compileExpr` direct-emit path is retired; every form now lowers to IR before bytecode emission (#1038, #1136)
 - **Comptime spec tables replace runtime registration** — primitive procedure metadata is now a single comptime array with compile-time duplicate and orphan detection (#1053, #1133)
 - **Unified error type:** `VMError` and `PrimitiveError` collapsed into a single error set, eliminating 8 inline error-mapping switches (#1046, #1128)
@@ -840,6 +870,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **Replaced hand-rolled JSON** in LSP with `std.json` (#1066, #1091)
 
 ### Fixed
+
 - Fix `current-input-port` corruption under extreme GC pressure (#1013, #1015)
 - Root SRFI-1 `filter-map`/`append-map`/`unfold` callback results across allocations (#1027, #1085)
 - Root `callWithArgs` return values in `map`, `fold`, and `unfold` primitives (#1098)
@@ -860,6 +891,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.12.0] - 2026-07-04
 
 ### Added
+
 - **Width-aware pretty-printing for REPL output:** large results are formatted with indentation and line wrapping instead of a single long line (#1005)
 - **Multiple-values display at top level:** `(values 1 2 3)` now prints all values, not just the first (#973)
 - **Uncaught error detail:** show message and irritants for uncaught user-raised errors (#976)
@@ -868,6 +900,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Fixed
 
 #### GC and memory
+
 - Fix GC corruption during library `include`-load: fresh s-expressions in Zig locals were not rooted during include processing (#1010, #1012)
 - Root top-level forms before compilation to prevent collection (#1011)
 - Root `vector-partition` yes/no accumulators across allocation (#810, #944)
@@ -883,12 +916,14 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Deep-copy `native_fn`/`native_closure` instead of aliasing across thread heaps (#975)
 
 #### Continuations
+
 - Fix `call/cc` escapes lost inside re-entrant native calls (`map`, `for-each`) — frame birth IDs now prevent incorrect escape detection (#934)
 - Raise error on continuation resume across a returned native call frame instead of silently corrupting state (#1009)
 - Fix continuation restore escape misdetection and `dynamic-wind` double-run (#870, #875, #905)
 - Fix use-after-free of frame pointer after re-entrant natives grow the frames array (#927)
 
 #### Threading (SRFI-18)
+
 - Share globals map by pointer with SRFI-18 child threads, lock rehashes (#958, #971)
 - Fix heap corruption from child threads touching shared parent state (#958, #968)
 - Fix `thread-terminate!` never stopping OS threads, hanging `thread-join!` (#933)
@@ -899,6 +934,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix top-level `thread-yield!` scheduler interaction and pre-scheduler parameter loss (#940)
 
 #### Compiler and IR
+
 - Replace fixed 256-node buffers with growable lists in IR lowering — removes hard limit on form complexity (#791, #1003)
 - Honor lexical shadowing of keywords in IR lowering (#788, #967)
 - Suppress constant folding of `set!`-reassigned globals in the same form (#962)
@@ -918,11 +954,13 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix `car`/`cdr` type errors in LLVM native backend (#834, #892)
 
 #### Macro system
+
 - Fix nested-ellipsis expansion rejecting depth-2 pattern variables (#931)
 - Fix double hygiene renaming in macro-generating macros (#923)
 - Fix two R7RS suite forms aborted by hygiene and macro-shadowing bugs (#926)
 
 #### Arithmetic
+
 - Compare rationals exactly instead of falling back to f64 (#844, #949)
 - Fix bignum `toF64` double-rounding by using u128 top-two-limb combination (#833, #907)
 - Fix `exact-integer-sqrt` to use scale-aware initial guess for large bignums (#851, #906)
@@ -936,6 +974,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix `numerator`/`denominator` on flonums to use exact dyadic fraction (#858, #903)
 
 #### I/O
+
 - Fix `read` after `peek-char` reordering stream bytes (#804, #997)
 - Fix `peek-char` returning raw lead byte for multi-byte UTF-8 on fd ports (#798, #1001)
 - Check `peek_byte` before returning EOF in string-port read (#799, #1006)
@@ -945,21 +984,25 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Signal `read-error?` when `read` hits EOF mid-datum per R7RS 6.13.2 (#977)
 
 #### Reader
+
 - Fix Unicode reader gaps and fold-case for non-ASCII identifiers (#920, #1004)
 - Fix char literal semicolon parsing and `string-prefix?`/`suffix?` argument order (#891)
 
 #### Strings
+
 - Fix `string-titlecase` word boundaries and Unicode case mapping (#824, #1002)
 - Fix `string-join` default delimiter from empty string to single space (#825, #909)
 - Fix `string-replace` index clamping and bignum parse error propagation (#830, #893)
 
 #### FFI
+
 - Handle bignums in `types.toF64` to fix FFI `double`/`float` marshaling (#792, #793, #998, #999)
 - Accept full unsigned 64-bit range for `uint64`/`size_t` FFI arguments (#794, #992)
 - Range-check FFI args against declared narrow int types (#795, #980)
 - Coerce FFI bool args to 0/1 before the C `_Bool` trampoline (#796, #963)
 
 #### Libraries
+
 - Handle `cond-expand` and nested `include-library-declarations` in library bodies (#874, #982)
 - Fix `cond-expand (library ...)` and `include` in library bodies (#917)
 - Search the script's directory for libraries; unify `cond-expand` library checks (#930)
@@ -968,19 +1011,23 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Add missing exports to SRFI-133 and SRFI-1 library definitions (#816, #818)
 
 #### SRFIs
+
 - Fix SRFI-158 `gtake` crash, SRFI-189 `nothing` procedure, SRFI-115 unknown char class (#1008)
 - Mark hash-table entries occupied on insert via `update!`/`default` and `alist->hash-table` (#939)
 - Guard `vector-unfold`/`unfold-right` against empty multiple values (#806, #986)
 - Fix `alist->hash-table` arity check (#1011)
 
 #### Quasiquote
+
 - Fix quasiquote nesting for `unquote-splicing`, vectors, and dotted tails (#849, #850, #852)
 
 #### Fibers
+
 - Fix `channel-receive` silently returning an unspecified value when the value had to flow through two or more intermediate fiber stages: a fiber blocked with no runnable siblings now parks on the channel and is woken by the next `channel-send`, so multi-stage pipelines deliver values correctly. A receive (or `fiber-join`) that can never be satisfied now raises a catchable deadlock error instead of returning void (#978)
 - `apply`-forwarded `channel-receive` propagates the park signal instead of collapsing it into a type error
 
 #### REPL and CLI
+
 - Stop `--sandbox` pre-scan at filename boundary (#783, #1007)
 - Skip `.sbc` bytecode cache in sandbox mode (#785, #995)
 - Include compiler version in `.sbc` cache validity check (#925, #993)
@@ -994,14 +1041,17 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Add missing separator before dotted tail in pretty-printer (#863, #883)
 
 #### LSP
+
 - Fix `positionEncoding` rejection and `jsonUnescape` `\uXXXX` (#866, #872, #901)
 - Fix `MethodNotFound` response, hover newlines, dotted define crash (#873, #871, #869, #895)
 
 #### Package manager (thottam)
+
 - Fix version-pinned installs: use `--end-of-options` instead of `--` so the ref resolves as a revision, not a pathspec (#780, #960)
 - Copy visited-set keys to fix use-after-free on transitive deps (#947)
 
 #### Other
+
 - Evaluate `parameterize` param expressions exactly once (#860, #887)
 - Allow empty datum list in `case` clauses (#854, #889)
 - Use `raise-continuable` for unmatched `guard` clauses per R7RS (#845, #897)
@@ -1019,12 +1069,14 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Fixed
 
 #### GC and memory
+
 - Fix GC safety in vm_library: root AST before `handleImport`, write barrier in cond-expand splicing, root parsed declarations before compilation (#754, #757, #759)
 - Add GC write barrier in vector constant deserialization (#738)
 - Fix GC safety violations in rational arithmetic paths — root intermediate heap values across allocating calls (#747)
 - Fix data race in symbol table marking during SRFI-18 threading — use blocking lock instead of tryLock (#750)
 
 #### Arithmetic
+
 - Fix exact rational + bignum arithmetic to preserve exactness instead of falling back to inexact float (#746)
 - Fix two-argument `log` to return complex for negative first argument (#752)
 - Fix `angle` to return pi for -0.0 using `atan2` (#748)
@@ -1034,18 +1086,22 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Apply exactness prefix to complex number parsing in `string->number` (#751)
 
 #### Compiler
+
 - Fix off-by-one in `addConstant`: allow 65536 constants (#756)
 - Check `resolveUpvalue` before applying `apply` tail-call optimization when `apply` is shadowed by a closure variable (#760)
 - Decrement `no_collect` before propagating pushRoot OOM after macro expansion, preventing permanent GC suppression (#761)
 - Validate `let-syntax` bindings have transformer spec (#758)
 
 #### Deep copy
+
 - Fix deep copy of promise, parameter, and error_object: register in visited map before recursing to prevent infinite recursion on circular structures (#753, #755)
 
 #### Bytecode serialization
+
 - Handle EOF and UNDEFINED values in writeConstant/readConstant (#743, #745)
 
 #### Package manager (thottam)
+
 - Add `.git` suffix to `resolveVersion` URL (#733)
 - Check build exit code in `doUpdate` (#734)
 - Track update failures and exit 1 if any failed (#735)
@@ -1053,15 +1109,18 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Validate package name in `doRemove` before path construction (#737)
 
 #### CLI and REPL
+
 - Make REPL Ctrl-C show fresh prompt instead of exiting (#742)
 - Report missing arguments for CLI flags (`--lib-path`, `-o`, etc.) (#740)
 
 ### Changed
+
 - Split `main.zig`, `ir.zig`, and `memory.zig` into smaller files per 1500-line policy (#732)
 
 ## [0.11.0] - 2026-07-02
 
 ### Added
+
 - **R7RS eval environments:** `eval` now honors its second argument; added `environment`, `null-environment`, `scheme-report-environment`, and `interaction-environment` procedures (#691)
 - **Vector patterns in syntax-rules:** pattern matching and template instantiation for vector literals in `syntax-rules`
 - **Ellipsis-depth validation:** syntax-rules templates validate that pattern variables are used at correct ellipsis nesting depth
@@ -1074,46 +1133,56 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Fixed
 
 #### GC and memory
+
 - Fix generational GC: mark `Closure.func` in minor collections — unmarked closures could be collected prematurely
 - Fix generational GC: mark `RecordInstance.record_type` in minor collections
 - Fix `hash-table-walk`/`hash-table-fold` use-after-free when callback triggers rehash
 - Fix GC roots in `loadLibrarySource`, `compileFile` preamble replay, and `handleTopLevelForm` (#699, #700)
 
 #### Macro system
+
 - Fix `let-syntax` referential transparency: free variables in transformer output now resolve in the definition environment
 - Fix macro hygiene for template-introduced bindings whose names shadow built-in procedures
 
 #### Compiler
+
 - Fix internal-define pre-scan: use dynamic list instead of fixed 64-entry buffer — more than 64 internal defines no longer crashes
 - Fix passthrough constant folding: check globals for redefined primitives before folding (#600 follow-up)
 - Fix `define-values` register corruption with 2+ names in lambda body
 
 #### LLVM native backend
+
 - Fix native closure compilation: bail out for variadic lambdas instead of generating incorrect code
 - Fix local parameter shadowing in call position — shadowed parameters now use the correct binding
 
 #### Reader
+
 - Require delimiter after numeric tokens per R7RS (e.g., `1a` is now an error, not parsed as `1`)
 - Fix `char-alphabetic?` misclassifying non-letter Unicode codepoints (e.g., digits, symbols)
 
 #### Hash tables
+
 - Fix hash-table sentinel collision: `eof-object` and `void` are no longer confused with empty/deleted slots
 
 #### I/O
+
 - Fix `read-bytevector!` returning wrong value for zero-length target at EOF
 - Fix `writeJsonEscaped`: properly escape backspace (`\b`) and form feed (`\f`)
 
 #### Library loading
+
 - Fix `handleDefineLibrary` aborting on import errors instead of propagating; fix bundled file paths (#703)
 - Fix `compileFile` preamble skip and GC safety (#699)
 
 #### CLI and REPL
+
 - Fix `(command-line)` removing hardcoded "kaappi" prefix from output
 - Fix REPL tab completion for Scheme identifiers containing `-`, `?`, `!`, `->` (#676)
 
 ## [0.10.0] - 2026-07-01
 
 ### Added
+
 - Abandon mutexes held by terminated fibers, per SRFI-18 spec (#642)
 - Detect `thread-join!` on current thread and raise error, per SRFI-18 spec (#643)
 - Remove 256-argument cap from `apply` by using heap-allocated ArrayList (#649)
@@ -1122,37 +1191,46 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Fixed
 
 #### GC and threading
+
 - Fix `referencesYoung` .fiber case missing `handler_stack`, `wind_stack`, `param_overrides`, and `frame.native` — could cause premature remembered-set eviction (#646)
 - Fix `markVMRoots` iterating shared libraries map in child threads without synchronization (#634)
 - Fix `VM.initForThread` sharing parent's Port objects by raw pointer instead of allocating fresh ports per thread (#635)
 - Fix `equal?` exponential blowup on shared DAGs deeper than 128 nodes (#648)
 
 #### LLVM native backend
+
 - Fix tail call passing pointer to caller's stack alloca — LLVM may reuse the frame, corrupting arguments (#639)
 - Fix `emitDirectCall` skipping arity validation, causing silent wrong results on over/under-application (#636)
 
 #### Reader and compiler
+
 - Fix reader truncating peculiar identifiers like `->foo` to just the sign character (#647)
 - Fix internal `define-syntax` inside `let`/`letrec` body leaking macro binding into enclosing scope (#651)
 
 #### Strings
+
 - Fix `string-for-each`/`string-map` byte cursor desync when callback mutates the string via `string-set!` (#645)
 - Fix SRFI-13 `parseStartEnd` and `string-take`/`-drop` silently clamping out-of-range indices instead of raising errors (#640)
 
 #### Arithmetic
+
 - Fix `parseBignumString` CHUNK_DIGITS overflow for radix 12–36 (#631)
 - Fix complex number printing dropping `-0.0` components (#637)
 
 #### I/O
+
 - Fix `read-bytevector` allocating full k-byte buffer upfront — a large k caused hangs; exploitable under `--sandbox` (#638)
 
 #### FFI
+
 - Fix `toCString` silently truncating strings with embedded NUL bytes (#630)
 
 #### LSP
+
 - Fix LSP crash on negative or oversized line/character position values (#641)
 
 #### Other
+
 - Fix `create-temp-file` raising uninformative bare TypeError on long prefix (#632)
 - Fix REPL `highlightCallback` misparsing character literals like `#\;` and `#\(` (#633)
 
@@ -1161,13 +1239,16 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Fixed
 
 #### Security
+
 - Fix git argument injection in thottam package manager — custom source URLs starting with `-` parsed as git options (#614)
 
 #### Compiler
+
 - Fix bare lambda internal define register clobbering (#601)
 - Fix constant folding ignoring redefined primitives (#600)
 
 #### Arithmetic and numeric
+
 - Fix exact division with bignums returning flonum instead of rational (#612)
 - Fix `makeRationalFromReader` using unchecked `makeFixnum`, truncating large rational literals (#610)
 - Fix `toRationalParts` calling `toFixnum` on bignum fields (#611)
@@ -1175,25 +1256,31 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix `string->number` `"#e<large>"` process abort from unchecked `@intFromFloat` (#604)
 
 #### GC and memory
+
 - Fix `deepCopyValue` dropping transformer fields on cross-thread copy (#605)
 - Fix `deepCopyValue` record_instance missing cycle guard, causing stack overflow on cyclic records (#606)
 
 #### Bytecode
+
 - Fix bytecode symbol name length write/read mismatch, panic on names > 4096 bytes (#609)
 - Reject denormalized bignum in bytecode reader (#607)
 
 #### Macro system
+
 - Fix macro import leaking entire `def_env` into importer (#608)
 
 #### CLI
+
 - Fix `-o` flag stripped from `(command-line)` in normal runs (#602)
 
 #### Package manager
+
 - Fix `isConstraintSpec` panic on empty-after-trim version string (#613)
 
 ## [0.9.0] - 2026-06-30
 
 ### Added
+
 - **Growable frame stack and register array:** frame stack starts at 480 and doubles on overflow up to 32,768; register file starts at 2,048 and grows to 65,536 — eliminates fixed-size stack overflow for deeply recursive programs
 - **R7RS 5.3.2 compliance:** internal `define` forms desugared to `letrec*` per spec, enabling correct scoping in procedure bodies
 - **Benchmark infrastructure:** 13 benchmarks covering continuations, tail calls, closures, bignum, GC pressure, plus trend visualization with regression detection and PR-level comparison workflow
@@ -1206,6 +1293,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ### Fixed
 
 #### GC safety
+
 - Root closure during upvalue capture to prevent collection
 - Fix `markObjectContents` missing types causing use-after-free
 - Clear old marks before full collection (corruption fix)
@@ -1222,6 +1310,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Unroot accessor/mutator functions in `vm_records`
 
 #### Compiler
+
 - Fix `case =>` proc clause clobbering live local registers
 - Guard `apply` tail-call optimization against local variable shadowing
 - Fix panic on calls with >255 arguments
@@ -1237,6 +1326,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix `define-values` to reject arity mismatches
 
 #### FFI
+
 - Fix unsigned return types marshaled as signed
 - Fix `uint32` params panic for values > 2^31
 - Fix integer args crashing on out-of-range values
@@ -1249,6 +1339,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Make `(pointer, long, long, pointer)->void` handler generic
 
 #### Arithmetic and numeric
+
 - Fix `inexact->exact` to return true IEEE-754 value for non-integer flonums
 - Fix `floor`/`ceiling`/`truncate`/`round` on exact rationals to use exact arithmetic
 - Fix `exact` returning flonum instead of bignum for large values
@@ -1262,6 +1353,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Reject non-integer flonums in `even?` and `odd?`
 
 #### Reader and I/O
+
 - Fix token validation for codepoints, delimiters, and booleans
 - Fix `readConstant` accepting malformed numeric constants from `.sbc`
 - Fix `#e` on complex numbers and `#i` on bignums
@@ -1275,6 +1367,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix bytevector port primitives: `u8-ready?`, `read-bytevector`, `get-output-bytevector`
 
 #### LLVM native backend
+
 - Mark tail position in `let`/`let*` body expressions
 - Fix symbol escaping and LSP document text memory leak
 - Update `current_block` in `and`/`or`, handle symbol refs in `define`/`set!`
@@ -1282,6 +1375,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix arithmetic for non-fixnum operands and overflow
 
 #### VM and runtime
+
 - Handle `ContinuationInvoked` in `call_global` and `tail_call_global` fast paths
 - Fix `pending_lib_envs` unconditional pop causing use-after-free on deep nesting
 - Fix `callWithArgs` register bounds check and >255 args panic
@@ -1292,6 +1386,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Detect re-entrant promise forcing per SRFI-45
 
 #### Fibers and threading
+
 - Fix fiber error handling: proper limit error, error propagation, native proc rejection
 - Fix fiber scheduling starvation with round-robin dispatch
 - Reclaim completed fiber slots in scheduler
@@ -1299,6 +1394,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Store `default-random-source` on VM instead of thread-local
 
 #### Strings and characters
+
 - Fix character write format and `string-every`/`string-any` char criterion
 - Handle `start`/`end` arguments in `string-pad` and `string-pad-right`
 - Escape control characters in write mode for strings and symbols
@@ -1309,11 +1405,13 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Reject surrogate codepoints in `integer->char`
 
 #### Vectors
+
 - Fix `vector-count`, `vector-index-right`, and `vector-partition` SRFI-133 bugs
 - Process vector unquotes in quasiquote splicing context
 - Validate `vector-append-subvectors` indices are non-negative and in bounds
 
 #### R7RS library compliance
+
 - Fix `export (rename ...)` to use R7RS flat syntax
 - Add `exact-integer-sqrt` to `(scheme base)` exports
 - Remove `open-binary-input-file` and `open-binary-output-file` from `(scheme base)`
@@ -1323,6 +1421,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Replace fixed-size arrays with dynamic lists in import `except`/`rename`
 
 #### Package manager (thottam)
+
 - Fix semver resolution to use `KAAPPI_ORG`
 - Fix caret (`^`) semver constraint for major version 0
 - Validate package names and use cwd to prevent shell injection
@@ -1331,24 +1430,28 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix `doVerify` SHA parsing to exclude source URL from lockfile
 
 #### Filesystem
+
 - Fix error handling: descriptive errno, `getgroups` cap, `readlink` truncation
 - Validate `mode`/`uid`/`gid` range instead of panicking
 - Validate `user-info` and `group-info` reject negative integer arguments
 - Distinguish `char-special` and `block-special` in `file-info-type`
 
 #### Bytecode serialization
+
 - Fix cached bytecode path to handle bundled files and preamble
 - Fix f64 read/write to use little-endian byte order
 - Add fixnum range validation during deserialization
 - Fix memory leaks in deserialization error paths
 
 #### LSP
+
 - Support string request IDs
 - Fix three JSON handling bugs
 - Fix document text memory leak
 - Fix `safeValueDescription` `native_closure` tag
 
 #### Debugger
+
 - Fix break line number and up/down navigation
 - Free breakpoint name/condition strings on delete, cap overflow, and VM teardown
 - Add bounds check on register access
@@ -1356,14 +1459,17 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Fix dangling pointer in watch command
 
 #### Expander
+
 - Fix flonum datum patterns and ellipsis escape hygiene
 - Fix infinite loop when `cond-expand` clause has empty body
 
 #### SRFI-27
+
 - Fix `make-random-source` seeding and unit validation
 - Fix lossless state roundtrip, negative arg guard, zero-state rejection
 
 #### Other
+
 - Fix record field spec validation and REPL datum comment handling
 - Fix crashes in record primitives, `read-bytevector!`, and `hash-table-merge!`
 - Fix printer freeing string literal on bignum `toString` failure
@@ -1371,12 +1477,14 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Use PID-unique temp path for native compilation LLVM IR
 
 ### Changed
+
 - Split four files that exceeded the 1500-line policy
 - Use descriptive `typeError` calls instead of bare `PrimitiveError.TypeError`
 
 ## [0.8.0] - 2026-06-28
 
 ### Added
+
 - **Generational GC:** young/old generations with minor and full collections; young objects surviving 2 minor cycles are promoted; write barrier tracks old→young references
 - **Native compilation CLI:** `kaappi compile program.scm -o binary` bundles LLVM IR emission and linking in one command; finds `libkaappi_rt.a` via `KAAPPI_LIB_DIR`, exe-relative path, or `zig-out/lib/`
 - **LLVM backend — tail call optimization:** self-tail-calls compiled as loops; cross-function tail calls use LLVM `tail call` annotation
@@ -1393,12 +1501,14 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **Fuzz testing:** compiler and eval fuzz targets (in addition to existing reader and bytecode loader targets)
 
 ### Fixed
+
 - `kaappi compile` finds `libkaappi_rt.a` relative to the binary using `_NSGetExecutablePath` (macOS) / `/proc/self/exe` (Linux); release artifacts now include `libkaappi_rt.a`
 - Unit test false failure from disassembler stderr writes corrupting Zig test runner IPC
 
 ## [0.7.0] - 2026-06-28
 
 ### Added
+
 - **LLVM native backend:** compile Scheme programs to native executables via `zig build native -Dnative-src=program.scm` or `kaappi --emit-llvm`
 - **Native lambda compilation:** simple functions compile as separate LLVM function definitions with direct calls; self-recursive calls bypass runtime dispatch
 - **Closure support in native backend:** inner lambdas capturing outer parameters work in native binaries
@@ -1416,14 +1526,17 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **Benchmarks:** string, list, vector, hashtable benchmarks (suite grows from 4 to 8)
 
 ### Changed
+
 - **Compiler:** all expressions route through IR pipeline (`lowerWithMacros` → analysis → optimization → `compileFromNode`)
 - **IR lowering:** `lower()` is now a thin wrapper over `lowerWithMacros(null)`; macros threaded through all recursive lowering helpers
 
 ### Removed
+
 - **JIT backends:** removed 5,215 lines of hand-written AArch64 and x86_64 JIT code; replaced by LLVM native backend
 - **`--no-jit` flag:** no longer needed
 
 ### Fixed
+
 - **IR lowering:** nested calls inside `if`/`begin`/`and`/`or` produced `passthrough` nodes instead of proper `call` nodes
 - **Native backend:** symbol constants not interned at runtime, breaking `eq?` identity in closures
 - **Native backend:** quoted list constants (`'(1 2 3)`) emitted as dangling pointers
@@ -1432,6 +1545,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.6.6] - 2026-06-27
 
 ### Fixed
+
 - **Expander:** Mismatched-length ellipsis template variables read uninitialized memory; now returns clean error
 - **Reader:** Datum-label placeholder (`#N=`/`#N#`) not GC-rooted — use-after-free during nested read
 - **Reader:** Malformed `#`-prefixed numeric literals (`#d` at EOF, `#e1e19`) panicked instead of clean error
@@ -1445,15 +1559,18 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - **SRFI-18:** Child thread data races — globals marking wrote cross-heap mark bits, `markRoots` deadlocked on symbol mutex, fiber result stored child-heap pointers visible to parent GC
 
 ### Changed
+
 - **Build:** Release binaries now stripped (`-Dstrip` option) — Linux x86_64 drops from 9.6 MB to 1.7 MB
 
 ## [0.6.5] - 2026-06-27
 
 ### Changed
+
 - **Bytecode:** Register operands widened from u8 to u16 (format version 3→4), raising the per-function register limit from 250 to 2048 for large library modules
 - **Runtime:** Main entry point runs on a worker thread with 64 MB stack to prevent stack overflow from deeply nested `cond`/`if` chains in the compiler's recursive descent
 
 ### Fixed
+
 - **FFI:** 64-bit integer returns (c_long) silently truncated to 48-bit fixnums; now promotes to bignum for values exceeding ±2^47
 - **FFI:** Pointer returns promote to bignum for addresses ≥ 2^47; `marshalToPointer` handles bignum round-trips
 - **FFI:** qsort-shaped handler `(pointer, long, long, pointer) -> void` panicked on negative count/size
@@ -1474,9 +1591,11 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.6.4] - 2026-06-26
 
 ### Added
+
 - Nested/composed import sets: `(prefix (only (scheme base) car cdr) s:)` now works per R7RS §5.6
 
 ### Fixed
+
 - **GC safety:** Root accumulators in SRFI-1 `circular-list`, `lset-adjoin`, `lset-union`, `lset-xor`, `append-reverse`, `concatenate`, `cons*`, `unfold`
 - **GC safety:** Root return value across dynamic-wind after-thunks in `.return` handler
 - **GC safety:** Root vector elements during bytecode cache deserialization
@@ -1502,17 +1621,20 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.6.3] - 2026-06-26
 
 ### Fixed
+
 - macOS signed binaries crashing on JIT due to missing `allow-jit` entitlement for hardened runtime
 
 ## [0.6.2] - 2026-06-26
 
 ### Fixed
+
 - JIT NaN-boxing encoding mismatch causing arithmetic crashes on both AArch64 and x86_64 backends
 - Verification link in README now points to download page
 
 ## [0.6.1] - 2026-06-25
 
 ### Fixed
+
 - Root intermediate heap values in multi-allocation GC loops
 - Root remaining unrooted heap intermediates across the runtime
 - Propagate errors from silent `catch {}` discards instead of swallowing them
@@ -1521,6 +1643,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Add FFI argument type validation and sandbox defense-in-depth
 
 ### Added
+
 - Vision and philosophy document for contributors (`docs/dev/vision.md`)
 - Developer guide for GC safety and error handling (`docs/dev/gc-safety-and-error-handling.md`)
 - Downloads page at kaappi-lang.org/download/
@@ -1529,6 +1652,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.6.0] - 2026-06-25
 
 ### Added
+
 - 5 new REPL commands: `,quit`/`,exit`, `,version`, `,load <file>`,
   `,import <lib>`, `,dis <expr>`
 - Grouped `,help` output with section headers (Evaluation, Inspection,
@@ -1544,6 +1668,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - REPL banner shows `,help` hint for discovering commands
 
 ### Changed
+
 - **NaN-boxing**: values are now NaN-boxed 64-bit words — flonums are packed
   directly into the Value without heap allocation, improving floating-point
   performance and reducing GC pressure
@@ -1551,6 +1676,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
   (`echo '(+ 1 2)' | kaappi` prints only `3`)
 
 ### Fixed
+
 - FFI parameter limit raised from 4 to 5
 - Library import errors now report the actual missing dependency instead of
   blaming the top-level library (e.g. "library not found: (srfi 132)"
@@ -1562,12 +1688,14 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.5.0] - 2026-06-25
 
 ### Added
+
 - `--timeout` and `--max-memory` CLI flags for resource limits (time and
   memory caps for script execution)
 - REPL history moved to `~/.kaappi/history` with comma command tab completion
 - Sandbox mode blocks SRFI-18 OS threads
 
 ### Fixed
+
 - Type error messages now include expected-vs-actual context across all
   primitives (21 files)
 - Improved error messages for failed imports and arity mismatches
@@ -1575,6 +1703,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.4.0] - 2026-06-24
 
 ### Added
+
 - WebAssembly (wasm32-wasi) build target: `zig build wasm` produces
   `kaappi.wasm` for browser and WASI runtimes
 - WASM binary included in GitHub Release artifacts
@@ -1586,6 +1715,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Codecov integration in CI for Zig source coverage
 
 ### Fixed
+
 - JIT tail_call and self-call bugs causing data corruption on recursive
   closures
 - JIT `emitStoreHalfAtOffset` slow path stored address instead of value
@@ -1594,6 +1724,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - Thread deep copy hardened: proper error handling and memory leak fixes
 
 ### Changed
+
 - JIT compiler handles `closure`, `close_upvalue`, and closure tail calls
   natively (fewer side-exits to interpreter)
 - Split `vm.zig` into `vm_dispatch.zig` and `vm_calls.zig` for
@@ -1606,6 +1737,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.3.0] - 2026-06-23
 
 ### Added
+
 - Language Server Protocol (LSP) server (`kaappi-lsp`) with diagnostics,
   completions, and hover — works with VS Code, Neovim, Emacs, Helix
 - REPL: Ctrl+R reverse history search, `,type`, `,describe`, `,apropos`
@@ -1618,6 +1750,7 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 - SRFI 19 test suite (112 tests)
 
 ### Fixed
+
 - x86_64 JIT crash: `readU16` used wrong byte order (little-endian vs
   VM's big-endian), causing misread jump offsets and SIGABRT on Linux
 - JIT branch-target pre-scan: added bounds checking for jump targets
@@ -1627,21 +1760,25 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.2.1] - 2026-06-23
 
 ### Added
+
 - Colored output for thottam (green/red/cyan, TTY-gated — no escape codes
   when piped)
 - Thottam integration test in CI (install/remove cycle against kaappi-json)
 
 ### Removed
+
 - Old `scripts/thottam` shell script (replaced by the Zig binary in v0.2.0)
 
 ## [0.2.0] - 2026-06-23
 
 ### Added
+
 - `thottam` package manager rewritten in Zig as a compiled binary, replacing
   the shell script (`scripts/thottam`). Ships alongside `kaappi` in release
   artifacts for all 4 platforms. Adds dependency cycle detection.
 
 ### Changed
+
 - Release workflow now builds and uploads `thottam` binaries for all platforms
 - `install.sh` now downloads and installs both `kaappi` and `thottam`
 - macOS binaries (both `kaappi` and `thottam`) are Developer ID signed and
@@ -1650,12 +1787,14 @@ Found by the SRFI 257 `rx` conformance suite, which drove every one of these
 ## [0.1.2] - 2026-06-23
 
 ### Changed
+
 - macOS binary is now signed with Developer ID and notarized by Apple,
   eliminating the Gatekeeper "malware" warning for downloaded binaries
 
 ## [0.1.1] - 2026-06-23
 
 ### Fixed
+
 - Release binaries printed `DebugAllocator` leak warnings to stderr when stdin
   was piped — now use `c_allocator` in release builds, `DebugAllocator` only in
   Debug mode
@@ -1669,6 +1808,7 @@ forms, 14 standard libraries, 51 SRFIs, C FFI, JIT compiler, green threads,
 profiler, stepping debugger, bytecode caching, and standalone binary bundling.
 
 ### Added
+
 - x86_64 JIT backend with full feature parity to AArch64 (all opcodes,
   specialized arithmetic, function calls, self-tail-call)
 - Register allocation for x86_64 JIT via lazy-store cache
@@ -1690,6 +1830,7 @@ profiler, stepping debugger, bytecode caching, and standalone binary bundling.
 - Versioning policy (`VERSIONING.md`)
 
 ### Fixed
+
 - JIT W^X violation on Linux: pages were mapped RWX, now properly use
   RW-then-RX via mprotect
 - JIT icache flush on Linux aarch64
@@ -1698,6 +1839,7 @@ profiler, stepping debugger, bytecode caching, and standalone binary bundling.
   (it auto-promotes to bignum)
 
 ### Changed
+
 - `thread-start!` now requires `--experimental-threads` flag (was silently
   unsafe)
 - Applied `zig fmt` to all 22 source files that had drifted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Complete R7RS-small Scheme implementation. Zig 0.16, ~80k lines, 641 built-in pr
 
 ## Build
 
-```
+```bash
 zig build                          # build executable (zig-out/bin/kaappi)
 zig build run                      # launch REPL (linenoise: arrow keys, history, tab completion)
 zig build run -- f.scm             # run a Scheme file
@@ -89,7 +89,7 @@ Requires Zig 0.16+ and libc (for linenoise terminal handling).
 
 After cloning, enable the pre-commit format check:
 
-```
+```bash
 git config core.hooksPath .githooks
 ```
 
@@ -195,7 +195,7 @@ cannot resolve. `zig cc` includes these automatically.
 
 ## Architecture
 
-```
+```text
 Source → Reader → Expander → IR → Analysis → Optimization → Bytecode Emission → VM
          (UTF-8    (syntax-    (33 node  (tail pos,    (const fold,     (register-   (generational
           lexer)    rules)      types)    primitives,   dead branch,      based)       GC)
@@ -217,6 +217,7 @@ Source → Reader → Expander → IR → Analysis → Optimization → Bytecode
 
 NaN-boxed u64 — flonums, fixnums, booleans, characters, and nil all fit in a
 single word with zero heap allocation:
+
 - **Any non-NaN f64**: flonum (stored directly, no heap allocation)
 - **0xFFFC | 48-bit pointer**: heap `Object` (8-byte aligned)
 - **0xFFFD | 48-bit integer**: fixnum (signed, up to ±2^47; auto-promotes to bignum)
@@ -240,6 +241,7 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 ## File organization
 
 ### Core runtime
+
 | File | Lines | Responsibility |
 |------|-------|---------------|
 | `types.zig` | ~1200 | Value type, `Object`/`ObjectTag`, opcodes, type predicates, hygiene helpers, re-export hub for the `types_*.zig` heap-type domain files below |
@@ -277,6 +279,7 @@ domain-mate (`Pair`, `Symbol`, `SchemeString`, `Closure`, `Function`,
 its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 
 ### Compiler & IR (9 files)
+
 | File | Responsibility |
 |------|---------------|
 | `ir.zig` | IR node types (33), AST→IR lowering, 3 analysis passes, 5 optimization passes |
@@ -291,6 +294,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `compiler_forms.zig` | Re-export hub (thin file, don't edit directly) |
 
 ### VM (split into 8 files)
+
 | File | Responsibility |
 |------|---------------|
 | `vm.zig` | VM struct, init/deinit, error handling, delegation wrappers |
@@ -303,6 +307,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `vm_debug.zig` | Stepping debugger: breakpoints (with conditions), watch expressions, step/next/step-out/continue, up/down frame navigation, locals, backtrace |
 
 ### Primitives (split into 26 files)
+
 | File | Procedures |
 |------|-----------|
 | `primitives.zig` | Registration hub, core list/pair ops, type predicates, equivalence, map, for-each, apply |
@@ -329,6 +334,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `primitives_srfi260.zig` | SRFI-260: generated symbols (generate-symbol) |
 
 ### Other
+
 | File | Responsibility |
 |------|---------------|
 | `library.zig` | Library registry, standard library registration ((scheme base), etc.) |
@@ -352,6 +358,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `tests_*.zig` | Unit tests by feature (core_eval, tail_calls, macros, io, etc.) |
 
 ### SRFI libraries (in `lib/srfi/`)
+
 178 SRFIs supported. 12 built-in (Zig primitives): 1, 9, 13, 18, 39, 69, 133, 170, 192, 254, 258, 260. 162 portable R7RS .sld files loaded on demand via `(import (srfi N))`, plus SRFI 261 (Portable SRFI Library References) as an import-resolver convention with no library file, and SRFI 226, SRFI 160, and SRFI 211 (see below) as sub-libraries only with no bare `(srfi 226)`/`(srfi 160)`/`(srfi 211)` file (so none appears as a bare number in `kaappi features`' scan): 0, 2, 4, 5, 6, 7, 8, 11, 14, 16, 17, 19, 23, 25, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 45, 46, 48, 51, 54, 57, 59, 60, 61, 62, 63, 64, 66, 67, 70, 71, 74, 78, 86, 87, 90, 94, 95, 98, 101, 111, 112, 113, 115, 116, 117, 118, 120, 123, 125, 126, 127, 128, 129, 130, 131, 132, 134, 135, 136, 137, 139, 140, 141, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 156, 158, 161, 162, 164, 165, 166, 167, 168, 169, 171, 173, 174, 175, 178, 180, 181, 185, 188, 189, 190, 193, 194, 195, 196, 197, 201, 202, 203, 207, 209, 210, 213, 214, 215, 216, 217, 219, 221, 222, 223, 224, 225, 227, 228, 229, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 244, 247, 248, 250, 251, 252, 253, 255, 257, 259, 263, 264, 267, 270, 271. Sub-libraries: (srfi 146 hash), (srfi 171 meta), (srfi 166 pretty), (srfi 166 columnar), (srfi 166 unicode), (srfi 166 color), (srfi 211 explicit-renaming), (srfi 211 define-macro), (srfi 211 syntax-parameter), (srfi 226 control prompts), (srfi 226 control continuations), (srfi 226 control times), (srfi 254 ephemerons), (srfi 254 guardians), (srfi 254 transport-cell-guardians), (srfi 254 ephemerons-and-guardians), (srfi 257 misc), (srfi 257 box), (srfi 257 rx), (srfi 263 syntax), (srfi 271 randomized), (srfi 271 determinized), (srfi 248 primitives). SRFI 226 (Control Features) is a 12-sub-library spec with no default/main library of its own (every feature lives under a named sub-library per its own spec); only the three `control` sub-libraries listed above (a reduced, escape-only continuation-prompt subset) are implemented — see the header of `lib/srfi/226/control/prompts.sld` for what's out of scope and why — so unlike every other portable SRFI it never appears as a bare number in `kaappi features`' scan (kaappi#1517 scans `lib/srfi/*.sld` non-recursively, matching what actually ships). SRFI 257's `rx` sublibrary layers regexp match patterns over SRFI 115 and SRFI 264 (`(~/ "([a-z]*):([0-9]*)" s name num)`); it is a verbatim port apart from the reference's missing `regexp-search-all`, which `~/all+` calls (see the header of `lib/srfi/257/rx.sld`). Its reference suite is what drove SRFI 115's matcher to a backtracking CPS engine (#1679): `%run` now offers each way a node can match to a continuation instead of returning one possessive answer, so `(regexp-matches (rx (* any) "b") "ab")` succeeds, `*?`/`??`/`**?` work, and a single-character repetition body still scans iteratively (`%run-rep1`) so `(* any)` over a long string costs no stack. #1681 then closed the remaining SRE gaps: look-behind (`%run-behind` scans backwards, floored at the search `start` that `%run` now threads alongside `end`), `grapheme`/`bog`/`eog` (UAX #29 clusters via `%gcb`/`%gcb-join?`/`%grapheme-end`), the `title-case` and `symbol` char sets, `&`/`-` set operators (every `<cset-sre>` compiles to a node `%match-one` decides, so `~`/`&`/`-` never re-enter the backtracking matcher), a real `w/ascii`/`w/unicode` context (a compile-time flag in the `%make-ctx` box, not a runtime one — SRFI 115 scopes it to char sets, so `%cm` is untouched), `w/nocapture`, submatch lookup by `(-> name …)` symbol, and bare `word` as a whole word rather than one word-constituent character. The three Unicode properties `(scheme char)` cannot answer — Lt, S\*, and the UAX #29 break classes — ship as range tables *inside* the portable `.sld`, generated by `tools/gen_srfi115_charsets.py`; regenerate them on a Unicode version bump and keep the version in step with `tools/gen_unicode_tables.py`. SRFI-254 (ephemerons and guardians) needs GC integration — its weak-reference marking/resurrection lives in `gc_collect.processWeakRefs`, its heap types (`Ephemeron`, `Guardian`, `TransportCell`) in `types.zig`, its primitives in `primitives_srfi254.zig`, and guardian invocation (a guardian is callable) in `vm_calls.invokeGuardian`. On this non-moving collector `current-hash` is a stable identity hash and transport cell guardians are degenerate (keys never move, so `(tg)` always yields #f). SRFI 258 (uninterned symbols) is built-in: `string->uninterned-symbol` and `generate-uninterned-symbol` allocate via `GC.allocUninternedSymbol` (memory.zig), which bypasses the intern table so the result is an ordinary collectable object never `eqv?` to any other symbol; the `Symbol.interned` flag (types.zig) drives `symbol-interned?` and the unreadable `#<uninterned-symbol …>` printer form that `read` rejects. Equality needs no special code (symbols already compare by identity), and `gc_deep_copy` preserves uninterned-ness across SRFI-18 thread boundaries. SRFI 260 (generated symbols) is built-in but needs no engine integration beyond one primitive (`generate-symbol` in `primitives_srfi260.zig`): because Kaappi interns every symbol by name (no uninterned symbols), write/read invariance is automatic, so the primitive just interns a fresh `"<pretty>.<counter>.<128-bit-OS-entropy-hex>"` name — a process-global atomic counter guarantees in-process uniqueness and `platform.osRandomBytes` supplies the unpredictability. SRFI 120 (Timer APIs) is portable (`lib/srfi/120.sld`) with no engine
 changes: each `make-timer` spawns one dedicated SRFI-18 thread owning its
 task list entirely in its own heap, coordinated purely through a `(kaappi
@@ -563,10 +570,11 @@ fully shipped too, leaving only SRFI 58's reader/writer array-literal
 syntax excluded (its stated blocker — no typed array infrastructure to
 build on — no longer holds at all now that SRFI 4/160/25/164/63/231 exist,
 worth re-examining if 58 is ever picked up). #1695 was fully closed
-earlier in Phase 4: 57/131/136/137/237/240 shipped, 99/100/150 excluded.
-#1699 (minus what Phases 1–3 closed) and #1729, which completed SRFI 181's
-transcoded-port half — custom ports landed separately in Phase 3, #1727 —
-plus issues #1703 and #1702, were all closed in full in Phase 4 as well.
+earlier in Phase 4: 57/131/136/137/237/240 shipped, 99/100/150
+excluded. #1699 (minus what Phases 1–3 closed) and #1729, which completed
+SRFI 181's transcoded-port half — custom ports landed separately in
+Phase 3, #1727 — plus issues #1703 and #1702, were all closed in full in
+Phase 4 as well.
 `docs/dev/srfi-exclusions.md`'s 30 excluded break down as: 7 meta/ecosystem SRFIs
 already covered by existing features, 11 non-standard reader syntax SRFIs
 that would fundamentally alter the parser, reinterpret already-valid syntax,
@@ -937,6 +945,7 @@ map.deinit();  // no allocator arg needed
 ## How to add a new built-in procedure
 
 1. Write the function in the appropriate `src/primitives_*.zig` file:
+
    ```zig
    fn myProc(args: []const Value) PrimitiveError!Value {
        if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
@@ -945,9 +954,11 @@ map.deinit();  // no allocator arg needed
    ```
 
 2. Register in the file's `registerXxx` function:
+
    ```zig
    try primitives.reg(vm, "my-proc", &myProc, .{ .exact = 1 });
    ```
+
    Arity: `.{ .exact = N }` for fixed, `.{ .variadic = N }` for N minimum args.
 
 3. Add to library exports in `src/library.zig` (the `scheme.base` section).
@@ -998,6 +1009,7 @@ mutating heap object fields, root `Function*` before `vm.execute()`.
 
 **Every bug fix MUST include a regression test** that fails without the fix and
 passes with it. Place it in the appropriate location:
+
 - Zig unit test → `src/tests_*.zig` (for VM, compiler, GC internals)
 - Scheme test → `tests/scheme/smoke/` or a dedicated file under `tests/scheme/`
   (for end-to-end behavior visible from Scheme)
@@ -1027,7 +1039,7 @@ iteration should scale their counts down via
 
 Uses [kcov](https://simonkagstrom.github.io/kcov/) to track which Zig source lines execute during tests. Install with `brew install kcov`. Both steps build in Debug mode (regardless of `-Doptimize`) since kcov needs DWARF line info.
 
-```
+```bash
 zig build coverage                                        # unit tests only
 zig build coverage-scheme -- tests/scheme/r7rs/r7rs-tests.scm  # R7RS test suite
 open coverage/index.html                                  # view HTML report
@@ -1069,7 +1081,7 @@ and its `rt_artifact` case — `docs/dev/porting.md` Stage 6.
 `src/thottam.zig` is a Zig binary that installs Kaappi ecosystem libraries.
 Built alongside kaappi via `zig build`, ships in release artifacts for all platforms.
 
-```
+```bash
 thottam install kaappi-web                                    # from default org
 thottam install kaappi-auth::https://github.com/bob/kaappi-auth  # from custom URL
 thottam install kaappi-web@v1.0.0                             # pinned version
@@ -1080,6 +1092,7 @@ thottam remove kaappi-web                                     # uninstall
 ```
 
 **How it works:**
+
 - Clones from `github.com/kaappi/<package>` (or a custom `::url`) to `~/.kaappi/src/`
 - Reads `kaappi.pkg` for dependencies and build commands
 - Copies `.sld` files to `~/.kaappi/lib/` (preserving directory structure)
@@ -1093,7 +1106,8 @@ native libraries. No `--lib-path` or `DYLD_LIBRARY_PATH` needed after
 install.
 
 **Package manifest** (`kaappi.pkg`):
-```
+
+```text
 name: kaappi-web
 depends: kaappi-http kaappi-json
 build: make
@@ -1121,6 +1135,7 @@ The lockfile (`~/.kaappi/thottam.lock`) records source URLs for provenance.
 | kaappi-web | Pure Scheme | kaappi-http, kaappi-json | Web framework (routing, middleware) |
 
 **Library pattern** (for creating new kaappi-* packages):
+
 - `csrc/` — C helper for FFI (if needed)
 - `lib/kaappi/<name>.sld` — main library with re-exports
 - `lib/kaappi/<name>/` — sub-libraries (ffi.sld, parse.sld, etc.)
@@ -1182,6 +1197,7 @@ This means threads cannot share mutable heap state. The child GC collects
 independently and the child heap is freed after `thread-join!`.
 
 **Key implementation details:**
+
 - `vm_instance` and `gc_instance` are `threadlocal` (`src/vm.zig:37`, `src/primitives.zig:182`)
 - `GC.initForThread` creates per-thread GC sharing parent's symbol table (`src/memory.zig`)
 - `GC.deepCopy` / `GC.deepCopyValue` deep-copies values between GC heaps (`src/memory.zig`)
@@ -1258,6 +1274,7 @@ workspace-level `.claude/settings.json` when working from the multi-repo workspa
 |------|------------|-------|
 | Session context | SessionStart hook | `.claude/hooks/session-start.sh` |
 | Zig formatting | PostToolUse hook + git pre-commit | `.claude/hooks/zig-fmt-post.sh`, `.githooks/pre-commit` |
+| Markdown structure | CI `format` job (markdownlint) | `.markdownlint-cli2.jsonc`, `.github/workflows/ci.yml` |
 | No destructive commands | Deny permissions + PreToolUse hook | `.claude/settings.json`, `.claude/hooks/bash-guard-pre.sh` |
 | Tests pass before stop | Stop hook | `.claude/hooks/test-on-stop.sh` |
 | GC safety checklist | Path-scoped rule (auto-loaded) | `.claude/rules/gc-safety.md` |

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -15,6 +15,7 @@ Kaappi implements every identifier from [R7RS Appendix A](https://small.r7rs.org
 Implemented: `cons*`, `xcons`, `list-tabulate`, `circular-list`, `iota`, `proper-list?`, `dotted-list?`, `circular-list?`, `not-pair?`, `null-list?`, `list=`, `first`–`tenth`, `car+cdr`, `take`, `drop`, `take-right`, `drop-right`, `take-while`, `drop-while`, `split-at`, `last`, `last-pair`, `zip`, `unzip1`, `unzip2`, `count`, `fold`, `fold-right`, `pair-fold`, `pair-fold-right`, `reduce`, `reduce-right`, `unfold`, `unfold-right`, `map-in-order`, `append-map`, `filter-map`, `pair-for-each`, `filter`, `partition`, `remove`, `find`, `find-tail`, `any`, `every`, `list-index`, `span`, `break`, `delete`, `delete-duplicates`, `alist-cons`, `alist-copy`, `alist-delete`, `lset=`, `lset-adjoin`, `lset-union`, `lset-intersection`, `lset-difference`, `lset-xor`, `append-reverse`, `length+`, `concatenate`.
 
 **Not implemented:**
+
 - `unzip3`–`unzip5` — rarely used
 - Linear-update (`!`) variants — SRFI 1 permits non-mutating implementations
 - `lset-diff+intersection` — composite operation; use `lset-difference` + `lset-intersection`
@@ -32,6 +33,7 @@ Implemented: `string-contains`, `string-prefix?`, `string-suffix?`, `string-trim
 All predicate-accepting procedures accept SRFI-14 char-set objects directly in addition to predicate procedures. Optional `start`/`end` index parameters are supported on all searching, filtering, and transformation functions.
 
 **Not implemented:**
+
 - `string-xcopy!` — mutation variant
 
 ### SRFI 27 — Random Numbers
@@ -47,6 +49,7 @@ All predicate-accepting procedures accept SRFI-14 char-set objects directly in a
 **Coverage: 91%** (21 of 23 spec procedures). `hash-table-ref` correctly calls default thunk. `hash-table-merge!` overwrites existing keys. `string-ci-hash` uses Unicode case folding.
 
 **Not implemented:**
+
 - `hash-table-equivalence-function`, `hash-table-hash-function` — `make-hash-table` accepts but ignores custom comparator/hash arguments
 
 ### SRFI 133 — Vector Library
@@ -56,6 +59,7 @@ All predicate-accepting procedures accept SRFI-14 char-set objects directly in a
 Implemented: All SRFI-133 procedures including `vector-unfold`, `vector-unfold-right`, `vector-binary-search`, `vector-concatenate`, `vector-cumulate`, `vector-partition`, `vector-swap!`, `vector-reverse!`, `vector-reverse-copy`, `vector-skip`, `vector-skip-right`.
 
 **Not implemented:**
+
 - `vector-append-subvectors` — composite append with subranges
 
 ### SRFI 170 — POSIX API
@@ -65,6 +69,7 @@ Implemented: All SRFI-133 procedures including `vector-unfold`, `vector-unfold-r
 Implemented: File info (`file-info`, `file-info?`, `file-info-type`, all `file-info:*` accessors, type predicates), file operations (`create-directory`, `delete-directory`, `rename-file`, `create-symlink`, `read-symlink`, `create-hard-link`, `real-path`, `set-file-mode`, `truncate-file`, `create-fifo`, `set-file-owner`, `set-file-times`), process state (`pid`, `umask`, `set-umask!`, `current-directory`, `set-current-directory!`, `user-uid`, `user-gid`, `user-effective-uid`, `user-effective-gid`, `user-supplementary-gids`, `nice`), environment (`set-environment-variable!`, `delete-environment-variable!`), terminal (`terminal?`), user/group database, directory traversal (`open-directory`, `read-directory`, `close-directory`, `directory-files`), time (`posix-time`, `monotonic-time`), temp files (`temp-file-prefix`, `create-temp-file`).
 
 **Not implemented (by design):**
+
 - Process management (`fork`, `exec*`, `waitpid`, `_exit`) — unsafe in GC'd bytecode VM
 - Signal handling — requires async-safe VM interrupt mechanism
 - Pipes, I/O multiplexing — not exposed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ zig build run
 
 The codebase is organized into clear subsystems:
 
-```
+```text
 src/
   types.zig              Value type, heap objects, opcodes
   memory.zig             Mark-and-sweep GC
@@ -150,6 +150,33 @@ To catch formatting issues locally before commit, enable the pre-commit hook:
 git config core.hooksPath .githooks
 ```
 
+### Markdown
+
+Markdown is linted too — CI runs markdownlint over every `.md` file in the
+repo. The rule set, globs, and ignores all live in `.markdownlint-cli2.jsonc`,
+so a bare local run lints exactly what CI lints:
+
+```bash
+npx markdownlint-cli2
+```
+
+Most findings are blank lines around headings, lists, and fences, which
+`npx markdownlint-cli2 --fix` inserts for you. Only cosmetic rules are
+disabled (line length, table padding, and similar) — the structural ones are
+on, including **MD018**, which catches the silent failure that motivated the
+check: prose wrapping that puts `#1573),` at the start of a line, where
+Markdown reads it as a malformed heading.
+
+Two rules must **never** be autofixed blindly, which is why the repo is kept
+at zero findings rather than relying on `--fix` after the fact:
+
+- **MD018** "fixes" a line-initial `#1699` by inserting a space — turning
+  prose into a real `# 1699` heading. Rewrap the line instead so the issue
+  reference isn't line-initial.
+- **MD038** strips the space from `` `#\ ` `` — corrupting a Scheme character
+  literal. `docs/dev/fmt.md` disables it around the one paragraph that
+  documents that literal.
+
 ## CI
 
 GitHub Actions (`.github/workflows/ci.yml`) runs on every push and PR.
@@ -157,7 +184,7 @@ All jobs must pass before merging.
 
 | Job | Runner | What it does |
 |-----|--------|--------------|
-| **format** | ubuntu-latest | `zig fmt --check src/`, bare TypeError regression check |
+| **format** | ubuntu-latest | `zig fmt --check src/`, bare TypeError regression check, markdownlint over every `.md` |
 | **test** (matrix) | ubuntu-latest (x86_64), ubuntu-24.04-arm (aarch64), macos-latest (aarch64) | Build, unit tests, Scheme suites, sandbox/robustness tests, thottam integration. Runs in Debug, ReleaseSafe, and ReleaseFast optimize modes on x86_64; ReleaseSafe only on ARM and macOS. |
 | **riscv64-test** | ubuntu-latest + QEMU | Cross-compiles with `-Dtarget=riscv64-linux` and runs unit tests + R7RS suite under QEMU emulation. Separate from the matrix because it needs QEMU setup. |
 | **coverage** | ubuntu-22.04 | Unit test + R7RS suite coverage via kcov (push only). Pinned to 22.04 because kcov is not in Ubuntu 24.04 apt repos. |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ which can't consume LLVM IR. See [`docs/dev/netbsd.md`](docs/dev/netbsd.md).
 
 ## A taste of Kaappi
 
-```
+```console
 $ kaappi
 kaappi> (define (fib n)
   ...     (if (< n 2) n
@@ -327,7 +327,7 @@ true parallel I/O (e.g., thread-per-connection servers):
 
 ## Architecture
 
-```
+```text
 Source → Reader → Expander → IR → Bytecode emission → VM
          (UTF-8    (syntax-   (analysis +   (register-    (generational GC,
           lexer)    rules)     optimization   based)        stack-copied
@@ -346,7 +346,7 @@ Source → Reader → Expander → IR → Bytecode emission → VM
 Values are **NaN-boxed 64-bit words** — flonums, fixnums, booleans, characters,
 and nil all fit in a single u64 with zero heap allocation:
 
-```
+```text
 Flonum:    any f64 that is not a NaN     ← stored directly
 Pointer:   0xFFFC | 48-bit pointer       ← heap object
 Fixnum:    0xFFFD | 48-bit signed int    ← up to ±2^47, auto-promotes to bignum

--- a/benchmarks/gate/README.md
+++ b/benchmarks/gate/README.md
@@ -33,7 +33,7 @@ The binary **must** be built with the instrumentation compiled in, or every
 copy counter reads 0 and the lever flag is inert (protocol §3 keeps them out of
 the shipped default):
 
-```
+```bash
 zig build -Dchannel-instrument=true
 ```
 
@@ -72,7 +72,7 @@ are free to call shared kernels.
 
 ## Metrics (protocol §3)
 
-```
+```text
 share = (T_submit_copy + T_result_copy + T_reassembly) / E
 ```
 
@@ -94,7 +94,7 @@ Secondary (non-gating): child peak RSS (from `wait4`), peak live envelope bytes.
 
 Pilot (validates the harness; 5 invocations × 20 iterations by default):
 
-```
+```bash
 zig build -Dchannel-instrument=true
 python3 benchmarks/gate/run-gate.py \
     --bin zig-out/bin/kaappi --mode pilot \
@@ -106,7 +106,7 @@ python3 benchmarks/gate/run-gate.py \
 Full frozen run (per machine; floors 20 invocations × 10 iterations — set the
 counts from the pilot's CI half-widths to hit the protocol's ±2% target):
 
-```
+```bash
 python3 benchmarks/gate/run-gate.py \
     --bin zig-out/bin/kaappi --mode full \
     --machine macos-aarch64 --cores 12 \
@@ -123,7 +123,7 @@ ASLR on, and selects the lever at runtime on one binary (§4.4).
 
 `--out` is the §6 CSV:
 
-```
+```text
 machine, workload, size_bytes, workers, levers, invocations, iterations,
 E_mean_ms, E_ci95_lo, E_ci95_hi, share_mean, share_ci95_lo, share_ci95_hi,
 S_ms, speedup, rss_peak_mib, envelope_peak_mib
@@ -153,7 +153,7 @@ well-differentiated, statistically-summarized `share` values:
 | fo-tree   | ~67 | ~70 | symbol-heavy fan-out over-copy dominates |
 | fo-slice  | ~48 | ~55 | whole-vector fan-out over-copy dominates |
 
-Speedups came out sane (IP-* ≤ 8× with 8 workers; FO-* < 1× — the fan-out
+Speedups came out sane (`IP-*` ≤ 8× with 8 workers; `FO-*` < 1× — the fan-out
 idiom does redundant whole-payload work per worker, by design). The pilot also
 exercised the driver's timeout handling: ~8 % of invocations hit the
 kaappi#1489 hang and were recorded as `TIMEOUT` failures (see limitation 2).

--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -111,15 +111,18 @@ Check off each unit when its PR is open and issues are filed. Add the date
 and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 
 **Phase 0 — Baseline**
+
 - [x] 0: Baseline run, tracking issue, labels created, `audit-baseline.sh` committed (2026-07-05, #1137; baseline fully green at b2317e8 — 0 failures across all suites, no issues filed)
 
 **Phase 1 — R7RS spec gap analysis** (independent; run in parallel)
+
 - [x] 1A: Expressions & syntax (4.1–4.3) + Libraries (5.6–5.7) (2026-07-05, #1139–#1142; 34 new gap tests, 3 disabled pending fixes; libraries 5.6 fully green)
 - [x] 1B: Equivalence, numbers, booleans, lists, symbols (6.1–6.5) (2026-07-05, no bugs found — 40 gap tests all pass, incl. circular equal? termination and numeric I/O round-trips)
 - [x] 1C: Characters, strings, vectors, bytevectors (6.6–6.9) (2026-07-05, #1145; 43 gap tests, 4 disabled — char classification derives from case mappings; full string casing, UTF-8 slicing, overlap copies all conform)
 - [x] 1D: Control, exceptions, eval, I/O, system (6.10–6.14) (2026-07-05, #1147; 30 gap tests, 2 disabled — immutable environments don't signal on define/set!; cyclic write, CRLF read-line, raise-continuable all conform)
 
 **Phase 2 — Primitives audit** (independent; run in parallel; order = risk)
+
 - [x] 2.1: `primitives_srfi18.zig` (threads) (2026-07-05, #1153–#1156; 73 audit tests + 4 disabled — mutex timeout lock-steal, #f-thread owner, native thunks rejected, gc-stress SIGSEGV)
 - [x] 2.2: `primitives_string_ext.zig` (SRFI-13) (2026-07-05, #825/#826 reopened + #1158–#1159; 84 audit tests + 6 disabled — join grammar, Unicode trim, s2 ranges, ignored optional args)
 - [x] 2.3: `primitives_char.zig` (Unicode) (2026-07-05, no new bugs — 59 audit tests; final-sigma, ligatures, Cherokee all conform; classification pending #1145)
@@ -140,6 +143,7 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 - [x] 2.18: `primitives.zig` (core) (2026-07-05, #1198–#1199; 196 audit tests + 4 disabled — reverse/append/apply(non-tail) hang on circular lists while length/list?/tail_apply detect or bound them; record accessors/mutators skip the type check, cross-type reads/writes silently succeed; eqv?/equal?/predicates/apply otherwise fully conform incl. circular equal? and width-changing string mutations)
 
 **Phase 3 — SRFI conformance**
+
 - [x] 3.0: Run all 35 existing SRFI test files, capture failures (2026-07-05, no failures — all 35 files pass individually under timeout 30 at 96ce73b: chibi-test files all print 0 fail, SRFI-64 files report 0 unexpected failures (srfi64.scm's 1 "expected failure" is an intentional test-expect-fail), exit-code files all print their OK markers; no hangs, no escaped errors)
 - [x] 3.1: Built-in SRFIs without adequate tests (9, 39, 170) (2026-07-05, #1202–#1203 + #560 reopened; 68 tests + 6 disabled — parameterize installs bindings sequentially (SRFI-39 "1010" example fails), record redefinition retargets old ctors/predicates via call-time __record_type_ lookup, define-record-type still broken in lambda/let bodies (begin was fixed); constructors map fields by name, converters, disjointness, escape-restore all conform; 170 covered by 2.5)
 - [x] 3a: SRFIs 0, 6, 17, 23, 26 (syntax extensions) (2026-07-05, #1205 + #1208; 54 tests + 9 disabled — SRFI-17 is a stub (no generalized set!, no predefined setters), cut/cute hardcoded patterns (cute re-evaluates per call, later slots swallowed, no operator slots, arity cap); cond-expand/string ports/error all conform)
@@ -150,11 +154,13 @@ and issue numbers, e.g. `[x] ... (2026-07-06, #1101–#1105)`.
 - [x] 3.4: Upgrade smoke-only SRFIs to behavioral tests (98, 125, 128, 132, 141, 151, 152, 174, 175, 195, 219, 232) (2026-07-05, #1229–#1238; 402 tests + ~60 disabled — SRFI-219 dead on arrival (imported define macro can't shadow the built-in special form, #1237 is a core expander bug), SRFI-232 currying is strictly unary chains, balanced/ aliased to round/, default comparator not a total order (pairs/vectors/cross-type unordered) + eq/eqv comparators unhashable, hash-table-ref/find ignore success/proc-result (125), string-every drops last value (152), ascii-digit-value treats letters as digits (175), copy-bit rejects spec booleans + eqv/bits->list arity (151, beyond #1214), 14 of 22 SRFI-132 exports missing, timespec conversions missing (174); SRFI-98 and 195 fully conform)
 
 **Phase 4 — Compiler & VM edge cases**
+
 - [x] 4A: Tail positions in derived forms + thin-coverage forms (2026-07-05, #1240–#1242; 54 tests + 6 disabled — call-with-values consumer, call/cc receiver, and eval are NOT tail-called (§3.5 requires; native re-entry panics at ~1024 via #1191's mechanism), let*-values body is not a tail context (even 1 clause; let-values is fine), force caps promise chains at 100k iterations and mislabels longer legit delay-force chains as circular; apply/cond=>/case-lambda/do/let-syntax and all other §3.5 contexts verified at 1e5–1e6 depth; parameterize/define-values/letrec*/letrec-syntax thin coverage conforms except sequential-binding #1202)
 - [x] 4B: Continuation interactions (2026-07-05, no new issues; 22 tests + 1 disabled (#1169) — R7RS 6.10 connect/talk/disconnect re-entry example exact, multi-shot segments, parameterize captured+restored across re-entry, escape/afters inner-to-outer, guard =>/else/re-raise, raise-continuable resume, handler-return secondary exception, mv through dynamic-wind all conform; state kept global to dodge #1168)
 - [x] 4C: Macro hygiene + define-library import sets (2026-07-05, #1243; 23 tests + 1 disabled — doubled-ellipsis template (x ... ...) produces garbage with a literal ... instead of flattening; be-like-begin/(... ...) escape, custom ellipsis, vector patterns, tail patterns after ellipsis, =>-shadowing (p.24 example!), macro exports through prefix/only/rename/except and only-of-rename, cond-expand library declarations all conform; circular imports cleanly detected with nonzero exit)
 
 **Phase 5 — Synthesis**
+
 - [x] 5: Deduplicate, group by root cause, prioritize, update tracking issue (2026-07-05 — 87 findings filed over the campaign, 81 still open, 6 already fixed (#1176 #1178 #1180 #1184 #1185 #1188 — their FAIL markers still need re-enabling); no duplicates found (dedup enforced at filing time); grouped into 9 root-cause clusters with 2 epics filed (native re-entrancy, portable-SRFI quality); priority order + 197-marker inventory posted on #1137; run-all.sh hardened to parse chibi-test/SRFI-64 fail counts so exit-0 failures no longer pass silently)
 
 ---
@@ -189,9 +195,9 @@ coverage/ (gap-fillers), deferred/ (known-deferred .sbc files), phase1–5/
 
 Most Scheme test files use **no formal framework** — they succeed on exit
 code 0 and fail on non-zero. Audit, SRFI, and compliance tests use
-`(srfi 64)` with an exit-on-fail epilogue (migrated from `(chibi test)` in
-#1313); only the R7RS suite still uses the chibi-test shim, and its output
-is parsed specially by `run-all.sh`. See Footguns above.
+`(srfi 64)` with an exit-on-fail epilogue (migrated from `(chibi test)`
+in #1313); only the R7RS suite still uses the chibi-test shim, and its
+output is parsed specially by `run-all.sh`. See Footguns above.
 
 ### Primitives audit status
 
@@ -301,7 +307,7 @@ Sessions 1A–1D are independent — run them in parallel.
 
 ### Session prompt (Phase 1)
 
-```
+```text
 Read docs/audit-strategy.md — follow the Session protocol. Your unit is
 Phase 1, session 1X (domains listed in the Domain map).
 
@@ -365,7 +371,7 @@ Small files can be batched: 2.15–2.17 (random, lazy, cxr) fit in one session.
 
 ### Session prompt (Phase 2)
 
-```
+```text
 Read docs/audit-strategy.md — follow the Session protocol. Your unit is
 Phase 2.N: src/primitives_XXX.zig.
 
@@ -433,7 +439,7 @@ SRFIs — see Progress tracker for exact groupings). Adapt tests from
 
 ### Session prompt (Phase 3)
 
-```
+```text
 Read docs/audit-strategy.md — follow the Session protocol. Your unit is
 Phase 3X: SRFIs N1, N2, ... (see the Progress tracker grouping).
 
@@ -506,7 +512,7 @@ Existing: `tests/scheme/hygiene/` (12 files), `src/tests_macros.zig`
 
 ### Session prompt (Phase 4)
 
-```
+```text
 Read docs/audit-strategy.md — follow the Session protocol. Your unit is
 Phase 4X (see the focus list for your unit).
 
@@ -529,7 +535,7 @@ Deliverables: PR with test files, issues filed, tracker updated.
 **Goal:** Review all issues filed, deduplicate, identify root causes,
 prioritize. Runs after all other phases.
 
-```
+```text
 Read all open GitHub issues with labels "audit", "r7rs-conformance", or "srfi".
 1. Group by root cause (e.g., "bignum dispatch missing in 5 procedures") —
    close duplicates, link related issues, create epics for systemic problems.
@@ -548,7 +554,7 @@ so future chibi-test failures actually fail the run.
 
 ## Parallelization Plan
 
-```
+```text
         Phase 0 (baseline)
               │
     ┌─────────┼─────────┐
@@ -619,7 +625,7 @@ If a match exists, comment on it instead of filing a new issue.
 
 ### Issue title conventions
 
-```
+```text
 [R7RS 6.2] exact->inexact: returns wrong value for rationals
 [SRFI-1] filter: does not preserve order for improper lists
 [R7RS 4.2] named-let: not in tail position

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -37,6 +37,7 @@ try reg(vm, "my-proc", &myProc, .{ .exact = 1 });
 ```
 
 Arity options:
+
 - `.{ .exact = N }` -- exactly N arguments
 - `.{ .variadic = N }` -- N or more arguments
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -8,7 +8,7 @@ fit together.
 
 ## Pipeline
 
-```
+```text
 Source code
     |
     v
@@ -126,7 +126,7 @@ Source code
 All Scheme values fit in a single **NaN-boxed 64-bit word**. Flonums, fixnums,
 booleans, characters, and nil all fit in a u64 with zero heap allocation:
 
-```
+```text
 Flonum:    any f64 that is not a NaN             -- stored directly
 Pointer:   0xFFFC | 48-bit pointer               -- heap object
 Fixnum:    0xFFFD | 48-bit signed integer         -- up to ±2^47
@@ -279,6 +279,7 @@ enum value followed by operands.
 ### Function objects
 
 A compiled `Function` contains:
+
 - Bytecode array (opcodes + operands)
 - Constant pool (values referenced by `load_const`)
 - Upvalue descriptors (for closure creation)

--- a/docs/dev/bytecode.md
+++ b/docs/dev/bytecode.md
@@ -83,7 +83,7 @@ Implemented in `src/disassembler.zig`. Three entry points:
 
 ### Output format
 
-```
+```text
 ; Function: fib
 ; Source: fib.scm:1
 ; Arity: 1, Locals: 6, Upvalues: 0
@@ -101,6 +101,7 @@ Implemented in `src/disassembler.zig`. Three entry points:
 ```
 
 Formatting choices:
+
 - Hex offsets for jump target calculation
 - Register names (`r0`, `r1`, ...) with `debug_locals` annotations where available
 - Symbol names resolved from constant pool (not raw indices)

--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -76,7 +76,7 @@ a version mismatch reads back as a miss.
 
 Entries live in a single directory:
 
-```
+```text
 $KAAPPI_HOME/cache        # if KAAPPI_HOME is set
 ~/.kaappi/cache           # otherwise
 ```
@@ -106,7 +106,7 @@ to* the source as `file.sbc`. A central store is what makes `cache status` /
 
 ## Inspect, clear, bypass
 
-```
+```bash
 kaappi cache status    # location, entry count, total size, and per entry:
                        #   size, producing build id, current/stale, source path
 kaappi cache clear     # remove every entry (the supported way to wipe it)

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -86,7 +86,7 @@ permission deny rules — the hook also catches `git tag -d` and
 4. Runs `zig build test` with a 120-second timeout (`timeout` on Linux,
    `gtimeout` on macOS, bare if neither available).
 5. If tests pass, exits 0.
-6. If tests fail, emits `{"decision":"block","reason":"Unit tests failed:\n..."}` 
+6. If tests fail, emits `{"decision":"block","reason":"Unit tests failed:\n..."}`
    with the last 30 lines of test output, preventing Claude from finishing
    until it fixes the failures.
 
@@ -400,7 +400,7 @@ The `infra/` repo also contains non-plugin resources:
 
 The harness has three layers that reinforce each other:
 
-```
+```text
 Permissions (settings.json)     ← first gate: allow / deny
     ↓
 Pre-tool hooks (bash-guard)     ← second gate: block dangerous patterns
@@ -435,6 +435,7 @@ changes were made.
 
 1. Write a shell script in `.claude/hooks/`.
 2. Add a hook entry in `.claude/settings.json` under the appropriate event key:
+
    ```json
    {
      "hooks": {
@@ -453,6 +454,7 @@ changes were made.
      }
    }
    ```
+
 3. The script receives the tool payload as JSON on stdin.
 4. To block: emit `{"decision":"block","reason":"..."}` on stdout.
 5. To permit: exit 0 with no blocking output.
@@ -460,6 +462,7 @@ changes were made.
 ### Adding a rule
 
 1. Write a Markdown file in `.claude/rules/` with YAML front matter:
+
    ```markdown
    ---
    globs: ["src/my_*.zig"]
@@ -468,6 +471,7 @@ changes were made.
    
    Rule content here...
    ```
+
 2. The rule loads automatically when editing files matching the globs.
    No `settings.json` change needed.
 

--- a/docs/dev/decisions/continuation-strategy.md
+++ b/docs/dev/decisions/continuation-strategy.md
@@ -65,6 +65,7 @@ no overhead. Only the small fraction of code that reaches `call/cc` falls
 back to the VM.
 
 **Pros:**
+
 - Zero overhead for continuation-free code (the common case)
 - No changes to the bytecode VM — it keeps working as-is
 - The direct-style IR serves both backends without conversion
@@ -72,6 +73,7 @@ back to the VM.
   `setjmp`/`longjmp` — they're single-shot by definition
 
 **Cons:**
+
 - Code that uses `call/cc` in hot loops does not benefit from native
   compilation. This is acceptable: such code is rare, and the bytecode
   the bytecode VM already handles it well.
@@ -87,6 +89,7 @@ stays, native is an additional backend) and avoids penalizing the common case.
 
 The semantic analysis pass (Stage 3) determines which functions may reach
 `call/cc` — conservatively, any function that:
+
 - Directly calls `call-with-current-continuation` or `call/cc`
 - Calls a function that is not provably continuation-free
 - Receives a closure argument that might invoke a continuation

--- a/docs/dev/decisions/native-backend-architecture-scope.md
+++ b/docs/dev/decisions/native-backend-architecture-scope.md
@@ -48,7 +48,7 @@ Verified 2026-07-19 on riscv64 (Alpine container under QEMU, riscv64 Zig
 squarely inside the natively-compiled feature set (self-tail-call loop +
 closure):
 
-```
+```console
 $ kaappi compile hello.scm -o hello
 Compiled hello              # ~29 s under TCG, warm caches
 $ ./hello

--- a/docs/dev/decisions/self-tail-call-optimization.md
+++ b/docs/dev/decisions/self-tail-call-optimization.md
@@ -49,6 +49,7 @@ The compiler has two code paths for function calls:
 
 **Critical:** The compiler at line 845 of `compiler.zig` explicitly
 **excludes tail calls** from the `call_global` path:
+
 ```zig
 if (!is_tail and types.isSymbol(operator) and ...)
     return self.compileCallGlobal(expr, operator, dst, is_tail);
@@ -72,7 +73,7 @@ for the tail position, not in the VM handler.
 
 The `tail_call_global` handler works as follows:
 
-```
+```text
 ; Before:  frame.base = 0, args computed at abs_base = frame.base + base_reg
 ; abs_base might be at offset 3 (base_reg = 3)
 ;
@@ -119,6 +120,7 @@ In `tak`:
 
 The outer `(tak ...)` is a tail call to the same function. For a
 self-tail-call, we can skip:
+
 1. Global cache lookup (the callee is the current closure)
 2. Type check (`isClosure`)
 3. Arity check (same function, same arity)
@@ -148,7 +150,8 @@ if (is_tail and types.isSymbol(head) and self.func.name != null and
 ```
 
 `compileSelfTailCall` emits:
-```
+
+```text
 self_tail_call nargs
 ; args are at consecutive registers starting at some base
 ```
@@ -184,6 +187,7 @@ tail calls.
 **Change in `compiler.zig`:**
 
 Remove the `!is_tail` guard at line 845:
+
 ```zig
 if (types.isSymbol(operator) and self.resolveLocal(...) == null) {
     // ... same exclusion list ...
@@ -226,12 +230,14 @@ speed improvement).
 ### Expected impact
 
 **`self_tail_call`** eliminates per-tail-call overhead:
+
 - Current: cache lookup (3 comparisons + potential hash) + `isClosure`
   (2 checks) + arity check (1 comparison) + argument copy + closure/code/ip
   assignment = ~15 operations
 - After: argument copy + IP reset = ~5 operations
 
 For `tak(33,22,11)` with ~880M calls (1/4 are tail calls = ~220M tail calls):
+
 - Saving ~10 operations × 220M = ~2.2 billion operations
 - At ~1ns per operation: ~2.2s savings → ~40s → ~38s (estimated ~12% gain)
 
@@ -268,25 +274,31 @@ call — estimated ~3% additional gain.
 ## Disassembly comparison
 
 ### Current `tak` bytecode (outer tail call)
-```
+
+```text
   0026  get_global      r3, tak      ; 4 bytes, hash lookup
   ...
   0099  tail_call       r3, 3        ; 3 bytes, full dispatch
 ```
+
 Two instructions, two bytecode dispatches.
 
 ### With `self_tail_call`
-```
+
+```text
   ...
   0076  self_tail_call  r3, 3        ; 3 bytes, arg copy + ip=0
 ```
+
 One instruction, one dispatch, no global lookup or type check.
 
 ### With `tail_call_global` enabled
-```
+
+```text
   ...
   0076  tail_call_global r3, tak, 3  ; 5 bytes, cache + inline tail
 ```
+
 One instruction, one dispatch, cache lookup + inline tail-call logic.
 
 ## Recommendation

--- a/docs/dev/diagnostics-json.md
+++ b/docs/dev/diagnostics-json.md
@@ -5,14 +5,14 @@ By default Kaappi prints diagnostics as human-oriented text
 output to **JSON Lines** so an agent, CI gate, or editor can consume errors
 structurally instead of scraping prose:
 
-```
+```bash
 kaappi --diagnostics=json file.scm
 ```
 
 Each diagnostic is emitted as **one JSON object per line on stderr**. Program
 output on stdout is unaffected, so redirect the two apart:
 
-```
+```bash
 kaappi --diagnostics=json file.scm 2>diagnostics.jsonl
 ```
 

--- a/docs/dev/diagnostics.md
+++ b/docs/dev/diagnostics.md
@@ -2,7 +2,7 @@
 
 Every user-facing diagnostic Kaappi prints carries a stable `KP`-prefixed code:
 
-```
+```text
 err.scm:2: error[KP3001]: undefined variable 'countr'. Did you mean 'count'?
 ```
 
@@ -74,7 +74,7 @@ The stage word is kept for the human reader; the bracketed code is inserted
 before the colon. Every stage reports `file:line:col`, the column pointing at
 the offending form's opening paren ([full source spans](#source-spans), #1506):
 
-```
+```text
 <stdin>:1:12: read error[KP1002]: unexpected character
 <stdin>:1:1: compile error[KP2001]: invalid syntax
 <stdin>:1:1: syntax-error[KP2002]: bad usage 1

--- a/docs/dev/ecosystem-library-bar.md
+++ b/docs/dev/ecosystem-library-bar.md
@@ -40,6 +40,7 @@ The following `kaappi-*` repos have been identified as having committed
 - `kaappi-http` — `libkaappi_http.dylib`
 
 When cleaning these up:
+
 1. Add `*.dylib` and `*.so` to `.gitignore`
 2. `git rm --cached` the artifact
 3. Ensure `make` rebuilds it

--- a/docs/dev/explain.md
+++ b/docs/dev/explain.md
@@ -6,11 +6,11 @@ documentation that ships *inside the binary* — offline, version-matched, and
 identical for a human reading prose and an agent parsing JSON. The model is
 Rust's `rustc --explain E0308`.
 
-```
+```bash
 kaappi explain KP3001
 ```
 
-```
+```text
 KP3001  undefined-variable
 runtime · error
 

--- a/docs/dev/features.md
+++ b/docs/dev/features.md
@@ -18,7 +18,7 @@ discovery *inside* Scheme via `cond-expand`. Part of the machine-legibility epic
 
 ## Forms
 
-```
+```text
 kaappi features            human-readable capability table
 kaappi features --json     one JSON object for structured / agent use
 ```

--- a/docs/dev/fmt.md
+++ b/docs/dev/fmt.md
@@ -6,7 +6,7 @@ format-on-save invariance — the same job `zig fmt` does for the compiler's own
 Zig. It is the final item of the machine-legibility epic (kaappi#1518, part of
 kaappi#1503).
 
-```
+```text
 kaappi fmt [--check] files...     # format each file in place
 kaappi fmt [--check]              # format stdin to stdout
 ```
@@ -50,10 +50,14 @@ drive a formatter. `fmt` has its own *concrete* syntax reader (`src/fmt.zig`):
    comments — keeping every lexeme's text verbatim.
 3. The **printer** (`src/fmt_print.zig`) walks the CST and lays it out.
 
+<!-- The space inside `#\ ` is the space character literal being documented,
+     not stray padding — MD038's autofix would delete it. -->
+<!-- markdownlint-disable MD038 -->
 The lexer mirrors the real reader's delimiter rules, and handles the awkward
 cases that make a naive tokenizer wrong: `#\(` / `#\;` / `#\ ` (a delimiter *is*
 the character), `#0#` and `#e#xFF` (interior `#`), strings and `|piped symbols|`
 that contain parens or semicolons, and nested `#| … |#`.
+<!-- markdownlint-enable MD038 -->
 
 ## Layout rules
 

--- a/docs/dev/fuzzing-feasibility.md
+++ b/docs/dev/fuzzing-feasibility.md
@@ -90,7 +90,7 @@ fast persistent harness — already exist here:
   `vm_mod`, [`vm.zig`](../../src/vm.zig) imports `vm_tests.zig`, which imports
   `tests_fuzz.zig`. Run them with:
 
-  ```
+  ```bash
   zig build test --fuzz
   ```
 
@@ -116,7 +116,7 @@ inputs. The current four targets each make exactly one
 `smith.sliceWithHash(&buf, 0)` call. Consequently, a seed for a Scheme source
 `s` must be encoded as:
 
-```
+```text
 <4-byte little-endian length of s><bytes of s>
 ```
 

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -64,8 +64,8 @@ wall-clock time stops tracking how much work a program does, by a
 speed-independent instruction-count budget instead. Three modes take the
 instruction-count bound (`speed_independent` in `src/tests_fuzz.zig`):
 `-Dgc-stress=true` (a full collection on every allocation, #1447), a
-cross-compiled target running under an emulator (riscv64 under QEMU in CI,
-#1573), and `-Doptimize=Debug` (the whole pipeline unoptimized, #1835).
+cross-compiled target running under an emulator (riscv64 under QEMU in
+CI, #1573), and `-Doptimize=Debug` (the whole pipeline unoptimized, #1835).
 
 The Debug case is worth understanding before touching the 100 ms number,
 because the deadline is only *checked* inside `runUntil`: time spent

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -54,6 +54,7 @@ keeps it alive.
 
 3. **Root the accumulator in loops.** When building a list or vector
    via repeated `allocPair`/`allocVector`, root the accumulating result:
+
    ```zig
    var result: Value = types.NIL;
    try gc.pushRoot(&result);

--- a/docs/dev/ir.md
+++ b/docs/dev/ir.md
@@ -14,7 +14,7 @@ provides a clean lowering target for a future native backend.
 
 The `compile()` function in `compiler.zig` orchestrates the full pipeline:
 
-```
+```text
 S-expression (post-expansion)
     |
     v  lowerWithMacros()
@@ -163,6 +163,7 @@ position sets `ann.is_tail = true`, which `compileFromNode()` uses to emit
 `tail_call` instead of `call`.
 
 Propagation rules:
+
 - `if`: test is non-tail; consequent and alternate inherit parent's tail status
 - `begin`, `and`, `or`: last expression inherits; all others are non-tail
 - `when`, `unless`: test is non-tail; last body expression inherits
@@ -181,6 +182,7 @@ Recognized primitives include: `+`, `-`, `*`, `/`, `=`, `<`, `>`, `cons`,
 ### markConstants(node)
 
 Identifies compile-time constant expressions:
+
 - `constant` nodes are always constant
 - `call` nodes are constant if the operator is a primitive and all arguments
   are constant
@@ -197,6 +199,7 @@ this order:
 ### 1. foldConstants
 
 Evaluates constant primitive calls at compile time. Handles:
+
 - Unary: `not`, `zero?`, `-` (negation)
 - Binary: `+`, `-`, `*`, `<`, `>`, `<=`, `>=`, `=`
 
@@ -206,6 +209,7 @@ skipped and the call is left for runtime.
 ### 2. eliminateDeadBranches
 
 Removes unreachable branches from `if` when the test is a constant:
+
 - `(if #t A B)` → `A`
 - `(if #f A B)` → `B`
 - `(if #f A)` → `#void`
@@ -213,12 +217,14 @@ Removes unreachable branches from `if` when the test is a constant:
 ### 3. simplifyBooleans
 
 Pattern-based boolean rewrites:
+
 - `(not (not X))` → `X`
 - `(if (not X) A B)` → `(if X B A)`
 
 ### 4. eliminateIdentity
 
 Removes algebraic identity operations:
+
 - `(+ x 0)` or `(+ 0 x)` → `x`
 - `(* x 1)` or `(* 1 x)` → `x`
 - `(* x 0)` or `(* 0 x)` → `0`
@@ -227,6 +233,7 @@ Removes algebraic identity operations:
 ### 5. simplifyBegin
 
 Structural cleanup:
+
 - `(begin X)` → `X` (single-expression begin)
 - Recursively simplifies nested begins
 

--- a/docs/dev/kep-0002-phase7-envelope-benchmarks.md
+++ b/docs/dev/kep-0002-phase7-envelope-benchmarks.md
@@ -18,7 +18,7 @@ x86_64 publish-half open (see [Status](#status--what-remains)).
 
 ## Running it
 
-```
+```bash
 zig build bench-channel                        # ReleaseSafe: the shipped default
 zig build bench-channel -Doptimize=ReleaseFast # faster build, for contrast
 zig build bench-channel -Dchannel-arena=true   # section 3 exercises the lever-B arena prototype

--- a/docs/dev/kep-0003-acceptance-gate-worksheet.md
+++ b/docs/dev/kep-0003-acceptance-gate-worksheet.md
@@ -221,7 +221,7 @@ When both could read true, **Absent wins** — it is the stronger claim
 Alternative 1 as well. Rule 1 (Racket) excludes both by the same
 monotonicity. Hence the fixed precedence:
 
-```
+```text
 outcome(machine) =
     Rule1 (Racket)  if  ≥ 2 of 3 IP-* pass the C+D lower-bound test
   else Rule3 (Absent) if  all 24 none cells have ci95_hi < 10 %
@@ -241,7 +241,7 @@ outcome(machine) =
 > demand shape on one microarchitecture only is not enough to carve out
 > the GC model (§5 cross-machine rule).
 
-```
+```text
 combined =
     outcome(macOS)  if  outcome(macOS) == outcome(Linux)
   else Between (4)          # disagreement ⇒ stays gated, publish both

--- a/docs/dev/lessons-learned.md
+++ b/docs/dev/lessons-learned.md
@@ -53,6 +53,7 @@ The same cache had a second, independent problem — it wasn't traced by the GC,
 **Symptom:** Opening a second file after reading and closing a first file caused `read-line` type errors.
 
 **Root cause:** Two interacting issues:
+
 1. Named let closures captured ports via upvalues. The first call's closure was stored as a global. On the second call, a new closure was created but the global cache returned the OLD closure (with the closed port's upvalue).
 2. The global cache invalidation bug (#3 above) prevented the new closure from being seen.
 
@@ -101,12 +102,14 @@ The same cache had a second, independent problem — it wasn't traced by the GC,
 **Symptom:** Various use-after-free crashes during library loading and multi-file I/O.
 
 **Root causes found:**
+
 - `vm_instance` not set in `main()`, so `markVMRoots` did nothing during early GC cycles
 - Library export values not rooted — heap objects in the library registry weren't traced during GC
 - Flonum cache entries not rooted — cached flonums could be freed between GC cycles
 - Exception handler closures not rooted between `popHandler` and `callHandler`
 
 **Fixes:**
+
 - Set `vm_instance` early in `main()` before any allocations
 - Mark library export values in `markVMRoots`
 - Mark flonum cache entries in `markRoots`
@@ -145,6 +148,7 @@ Full investigation: [postmortems/2026-06-17-gc-reachability-bug.md](postmortems/
 ## 11. Performance: what worked and what didn't
 
 **What worked:**
+
 - **Global variable cache** (+10%): Cache resolved procedure values in Function objects. Avoids hash table lookups on repeated `get_global` instructions.
 - **Flonum cache** (+10%): 16-entry cache for frequently-used float values. Reduces GC pressure from temporary flonum allocations.
 - **Closure-first type dispatch** (+5%): Reorder `callValue` to check closures before native fns, FFI, parameters, continuations. Closures are the common case in Scheme.
@@ -152,10 +156,12 @@ Full investigation: [postmortems/2026-06-17-gc-reachability-bug.md](postmortems/
 - **Bypass the ReleaseSafe allocator fill on hot, size-proportional buffers** (#1809; continuations -60%, bignum -56%, string -40%, nqueens -9.5%, no regressions on the benchmark suite): `std.mem.Allocator`'s `.alloc`/`.free`/`.dupe` unconditionally `@memset(..., 0xAA)` in ReleaseSafe, inside their own generic bodies rather than the vtable — so no backing allocator swap or `@setRuntimeSafety(false)` can suppress it. `memory.allocSliceNoFill`/`freeSliceNoFill`/`dupeSliceNoFill` call `rawAlloc`/`rawFree` directly, skipping the fill, applied at ~80 call sites (GC object payloads, bignum scratch buffers, register/frame growth, continuation capture, string/vector/bytevector builders). Debug/gc-stress poisoning is untouched since it's independently implemented (`gc_collect.poisonAndDestroy`). See [performance.md](performance.md#when-the-profile-bottoms-out-in-memset).
 
 **What didn't work:**
+
 - **`tail_call_global` superinstruction**: Attempted and reverted — the real blocker was callee-type dispatch, not register layout. The shipped alternative, `self_tail_call` (~23% on tak), covers the hot self-recursion case. Full analysis: [decisions/self-tail-call-optimization.md](decisions/self-tail-call-optimization.md).
 - **Per-entry cache versioning**: Considered for the global cache, but full-cache clearing on version mismatch is simpler and just as effective.
 
 **Rejected, then shipped anyway:**
+
 - **NaN-boxing**: Rejected at the time over fixnum-range fears (a naive scheme would cut fixnums from i63 to i51). Shipped 2026-06-25 with a 48-bit fixnum payload and automatic bignum promotion, which preserves R7RS integer semantics — and made flonums allocation-free. The lesson: a rejected design can become viable when one blocking assumption (here, that range loss breaks semantics) is removed by another mechanism (bignum auto-promotion).
 
 **Total improvement (pre-NaN-boxing):** fib(35) from 2.69s to ~2.0s (26% faster).

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -11,6 +11,7 @@ the second of two execution backends:
 LLVM replaces the machine-code backend, not the Scheme runtime.
 
 **LLVM provides:**
+
 - Optimization passes (constant propagation, inlining, loop optimization, etc.)
 - Code generation for many architectures (x86_64, AArch64, RISC-V, etc.)
 - Mature debugging support (DWARF)
@@ -19,6 +20,7 @@ LLVM replaces the machine-code backend, not the Scheme runtime.
 - Platform portability
 
 **The Kaappi runtime provides (unchanged):**
+
 - Garbage collector (mark-and-sweep, `memory.zig`)
 - Closure representation (Function + upvalues)
 - NaN-boxed value scheme (tagged u64)
@@ -32,7 +34,7 @@ runtime that the bytecode VM uses. The native binary links against
 
 ## Architecture
 
-```
+```text
 Source → Reader → Expander → IR → Analysis → Optimization
                                                     |
                               +---------------------+---------------------+
@@ -391,6 +393,7 @@ past the fixed arity before branching, so variadic named functions loop too
 (kaappi#1498). (Boxed frames still disable the loop; see below.)
 
 **Falls back to the [cached eval](#cached-eval-fallback) when the body:**
+
 - contains an eval-fallback form (`letrec`, `guard`, named `let`, …), or a
   `cond`/`case`/`do` whose clauses themselves reach one (kaappi#1496);
 - contains a keyword-only special form that reaches the interpreter as a whole

--- a/docs/dev/observing-the-pipeline.md
+++ b/docs/dev/observing-the-pipeline.md
@@ -2,7 +2,7 @@
 
 Kaappi compiles a program through a fixed sequence of stages:
 
-```
+```text
 Source → Reader → Expander → IR → (optimization) → Bytecode → VM
          ast       expand      ir      ir            --disassemble
 ```

--- a/docs/dev/postmortems/2026-06-17-deep-recursion-register-overflow.md
+++ b/docs/dev/postmortems/2026-06-17-deep-recursion-register-overflow.md
@@ -14,11 +14,12 @@ frames, 65536 registers).
 
 A hard Zig panic instead of a catchable Scheme error:
 
-```
+```text
 thread … panic: index out of bounds: index 1201, len 1024
 ```
 
 Reproducers:
+
 ```bash
 zig build run -- tests/scheme/r7rs/combined-tests.scm
 zig build run -- tests/scheme/r7rs/r7rs-tests.scm

--- a/docs/dev/postmortems/2026-06-17-gc-reachability-bug.md
+++ b/docs/dev/postmortems/2026-06-17-gc-reachability-bug.md
@@ -23,9 +23,11 @@ zig build run -- scripts/large-files.scm
 ```
 
 Output before the fix:
-```
+
+```text
    1243██src/vm.zig    ##############################
 ```
+
 The `██` are bytes `0xAA 0xAA` — the literal `"  "` (two spaces) freed by GC and
 its data buffer overwritten by the poison pattern.
 

--- a/docs/dev/postmortems/2026-06-18-fixnum-overflow-promotion.md
+++ b/docs/dev/postmortems/2026-06-18-fixnum-overflow-promotion.md
@@ -28,7 +28,8 @@ stored as `i64` internally via `toFixnum()`, and results are packed back with
 ```
 
 This causes 2 of the 4 remaining R7RS test failures:
-```
+
+```text
 FAIL [6.2 Numbers]: expected 4611686018427387904 got -4611686018427387904  (division)
 FAIL [6.2 Numbers]: expected 4611686018427387904 got -4611686018427387904  (quotient)
 ```
@@ -88,6 +89,7 @@ fn makeFixnumOrBignum(gc: *memory.GC, n: i64) !Value {
 **Multiplication** (line ~447): Same pattern.
 
 **Division/quotient**: Add an explicit check after `@divTrunc`:
+
 ```zig
 const result = @divTrunc(a, b);
 if (!fitsFixnum(result)) return bignum_mod.fromI64(gc, result);
@@ -137,6 +139,7 @@ of wrapping with `makeFixnum`.
 ## Verification
 
 After fixing:
+
 ```scheme
 (+ 4611686018427387903 1)       ;=> 4611686018427387904 (bignum)
 (* 2305843009213693952 2)       ;=> 4611686018427387904 (bignum)
@@ -148,9 +151,11 @@ After fixing:
 ```
 
 Run `zig build test` and then:
+
 ```bash
 zig build run -- tests/scheme/r7rs/r7rs-tests.scm
 ```
+
 The two "expected 4611686018427387904" failures should resolve.
 
 ## Complexity

--- a/docs/dev/srfi-status-check.md
+++ b/docs/dev/srfi-status-check.md
@@ -7,7 +7,7 @@ or `withdrawn` — catching an accidental `lib/srfi/<n>.sld` for a not-yet-final
 
 ## Running it
 
-```
+```bash
 zig build                              # produce zig-out/bin/kaappi
 bash tools/check-srfi-status.sh        # checks zig-out/bin/kaappi by default
 bash tools/check-srfi-status.sh path/to/kaappi   # or a specific binary

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -8,7 +8,7 @@ discovers SRFI-64 suites, runs each one, and aggregates pass/fail/skip counts
 (kaappi#1503, kaappi#1509); the guiding rule is that a caller can go from a
 failing suite to a fix using documented, structured output alone.
 
-```
+```text
 kaappi test [paths...]
 ```
 
@@ -143,7 +143,7 @@ closure is derivable by *reading library declarations* — no build-system
 integration, no compiler instrumentation. `kaappi test` exploits this to run
 only the suites a change actually touches (kaappi#1510).
 
-```
+```text
 kaappi test --changed [--since <rev>]     # run only affected suites
 kaappi test --list-affected [--since <rev>]  # print them, run nothing
 ```

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -119,7 +119,7 @@ release builds compile both features out.
 
 Scheme tests live in `tests/scheme/`, organized by purpose:
 
-```
+```text
 tests/scheme/
   r7rs/             R7RS test suite (1,391 tests via chibi test)
     r7rs-tests.scm  Canonical suite — imports (chibi test)
@@ -350,7 +350,7 @@ regression).
 After the benchmark job has run at least once on `main`, a trend chart is
 published to GitHub Pages. Access it at:
 
-```
+```text
 https://kaappi-lang.org/kaappi/dev/bench/
 ```
 
@@ -375,6 +375,7 @@ slow drift over many commits is usually runner variance.
 ### Adding a new benchmark
 
 1. Create `benchmarks/<name>.scm` using the harness:
+
    ```scheme
    (include "benchmarks/common.scm")
 
@@ -389,6 +390,7 @@ slow drift over many commits is usually runner variance.
       (lambda () (my-bench input))
       (lambda (result) (= result expected))))
    ```
+
 2. Create `benchmarks/<name>.input` with `count input expected` (one per line).
    Calibrate so each iteration runs 0.5–3 seconds.
 3. Add the entry to the `BENCHMARKS` array in `benchmarks/run-benchmarks.sh`.
@@ -463,7 +465,7 @@ A pull request will not be merged if CI fails.
 E2e tests verify that the LLVM native backend produces binaries with
 identical output to the interpreter. They live in `tests/e2e/`:
 
-```
+```text
 tests/e2e/
   run-e2e.sh              Shell runner (BDD specs + native parity tests)
   test-llvm-backend.scm   BDD specs using kaappi-bdd
@@ -492,6 +494,7 @@ bash tests/e2e/run-e2e.sh
 ```
 
 The script:
+
 1. Builds `kaappi` and `libkaappi_rt.a`
 2. Runs BDD specs via the interpreter
 3. For each program in `programs/`: runs via interpreter, compiles to

--- a/docs/dev/timings.md
+++ b/docs/dev/timings.md
@@ -16,7 +16,7 @@ cache-transparency work in [#1516](https://github.com/kaappi/kaappi/issues/1516)
 
 ## Usage
 
-```
+```bash
 kaappi --timings file.scm            # text summary on stderr
 kaappi --timings=json file.scm       # one JSON object on stderr
 kaappi --timings=text file.scm       # explicit text (the default)
@@ -28,7 +28,7 @@ kaappi --timings compile file.scm    # the native (LLVM) compile path
 The output always goes to **stderr**, like `--diagnostics=json` — so the
 program's own stdout stays clean for piping:
 
-```
+```console
 $ kaappi --timings prog.scm 2>/dev/null   # program output only
 $ kaappi --timings prog.scm 1>/dev/null   # timing report only
 ```
@@ -39,7 +39,7 @@ $ kaappi --timings prog.scm 1>/dev/null   # timing report only
 
 A cache **MISS** compiled from source, so every stage ran:
 
-```
+```text
 timings: read 1.2ms | expand 0.8ms | lower 0.4ms | optimize 0.3ms | emit 0.5ms | execute 12.1ms
 cache: MISS (wrote /Users/you/.kaappi/cache/1f8b6bdfcf8b707e.sbc)
 ```
@@ -47,14 +47,14 @@ cache: MISS (wrote /Users/you/.kaappi/cache/1f8b6bdfcf8b707e.sbc)
 A cache **HIT** skipped the whole read→compile pipeline, so only `execute`
 ran — the compile stages are omitted rather than printed as `0.0ms` noise:
 
-```
+```text
 timings: execute 11.9ms
 cache: HIT (/Users/you/.kaappi/cache/1f8b6bdfcf8b707e.sbc)
 ```
 
 The cache line is never blank. When caching was not even attempted it says why:
 
-```
+```text
 cache: off (--no-ir-opt)     # or (sandbox), or (no home dir)
 cache: MISS (not cached: imports)   # imported programs are never cached (#1516)
 ```

--- a/docs/dev/unicode-case-mapping.md
+++ b/docs/dev/unicode-case-mapping.md
@@ -39,6 +39,7 @@ covered by the case tables (upcase/downcase work) but is a historical script
 and not explicitly listed in the reader's fast path.
 
 String operations also handle multi-codepoint expansions:
+
 - `string-upcase`: ß→SS, ǰ→J+caron, ΐ/ΰ→decomposed, ff/fi/fl ligatures
 - `string-downcase`: İ→i+dot, Σ→ς (final sigma context)
 - `string-foldcase`: ß→ss, İ→i+dot, ſ→s, ǰ→j+caron

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -74,8 +74,8 @@ fd 1 would corrupt `Content-Length` framing. Paths are normalized to
 `GetModuleFileNameW`, `getcwd`, `_wfullpath`): Win32 accepts forward
 slashes everywhere the runtime passes paths, and every internal path
 split/join is written for `/` (a `std.fs.path.join`, which uses `\` on
-Windows, is a bug — it broke `kaappi test --changed` suite discovery,
-#1612).
+Windows, is a bug — it broke `kaappi test --changed` suite
+discovery, #1612).
 
 ## Fd readiness: sockets and pipes (#1608)
 
@@ -257,7 +257,7 @@ Windows-specific pieces of the path (#1610):
   a foreign `zig cc` link of the static archive must name the import lib
   explicitly. The equivalent manual link is:
 
-  ```
+  ```bash
   zig cc -w -O2 out.ll -o prog.exe -L<libdir> -lkaappi_rt -lc -lm -lws2_32
   ```
 

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -23,6 +23,7 @@
 
 1. Pick the right directory (smoke/ for bug regressions, compliance/ for spec conformance).
 2. Use SRFI-64 for assertions:
+
    ```scheme
    (import (scheme base) (scheme write) (scheme process-context) (srfi 64))
 
@@ -35,6 +36,7 @@
      (test-end "descriptive-name")
      (when (> (test-runner-fail-count runner) 0) (exit 1)))
    ```
+
 3. The `(exit 1)` on failure is required — `run-all.sh` uses exit codes.
    Grab the runner **before** `(test-end ...)`: the outermost `test-end`
    resets the current runner, so `(test-runner-current)` afterwards no
@@ -42,9 +44,11 @@
    error.
 4. No registration needed — `run-all.sh` picks up `*.scm` files automatically.
 5. For bug regressions, name the file after the bug and add a comment:
+
    ```scheme
    ;; Regression test for #123: describe the bug
    ```
+
 6. Fixture files (`.sld` libraries, included sources, data) must go in a
    subdirectory (e.g. `fixtures/`, `lib868/`), never as loose `.scm` files
    next to the tests — `run-all.sh` executes every top-level `.scm` file


### PR DESCRIPTION
## Summary

Adds a `markdownlint` step to the existing `format` job and clears the repo to
zero findings. Closes the gap where `.zig` is enforced three ways and Markdown
had nothing — the gap that let the **MD018** violation in #1836 reach `main`,
where only CodeRabbit caught it.

**Measuring the fallout first changed the approach.** The issue expected to
start from a deliberately narrow rule set and widen over time. But of the 2792
default violations, MD013 (line-length, 1032) and MD060 (table pipe padding,
997) alone are 73% of the noise:

| Stage | Violations |
|-------|-----------:|
| markdownlint defaults | 2792 |
| after disabling 11 cosmetic rules | 507 |
| after `--fix` (34 files, blank lines only) | 67 |
| after 67 fence language tags + 5 hand fixes | **0** |

That was few enough to clear in one pass, so **every structural rule is on** —
MD018, MD022, MD031, MD032, MD040, MD058, MD009, MD025, MD026, MD001, MD037,
MD038. Only cosmetic rules are disabled, each with a one-line reason in the
config.

## Two autofix hazards — do not run `--fix` blind on this repo

Both reproduced on a scratch copy, and both silently corrupt content. This is
why the five affected sites were fixed **by hand before** the `--fix` pass:

| Rule | What blind `--fix` does |
|------|-------------------------|
| **MD018** | "Fixes" a line-initial `#1699` by inserting a space — promoting prose to a real `# 1699` heading, making the #1836 bug *worse*. It newly surfaced 3 MD025, 1 MD026, and 1 MD001 as the phantom headings took effect. |
| **MD038** | Strips the space from the space-character literal in `docs/dev/fmt.md` — corrupting the Scheme literal that paragraph exists to document. |

Both are now written down in `CONTRIBUTING.md` so a later `--fix` can't quietly
reintroduce them, and `fmt.md` carries a narrowly scoped `disable`/`enable` pair
around the one paragraph.

## Notes on the choices

- **Config**: globs, ignores, and rules live together in
  `.markdownlint-cli2.jsonc`, so a bare local `npx markdownlint-cli2` lints
  exactly what CI lints. `AGENTS.md` is ignored — it is a symlink to
  `CLAUDE.md` and would double-report every finding.
- **Action pin**: SHA resolved per `docs/dev/github-actions.md` — the `v24.1.0`
  ref is an *annotated* tag, peeled to its commit. Dependabot's existing
  `github-actions` ecosystem keeps it fresh.
- **`CHANGELOG.md` is included**, not excluded: it is hand-maintained by the
  release skill, not generator output, and all 284 of its findings were
  auto-fixable blank lines in historical entries. No entry text changed.
- **No `CHANGELOG` entry for this PR** — CI-infrastructure changes (e.g. #1671)
  don't get one, matching the issue's "no user-visible impact".
- **CI-only**, per the issue's scope. A pre-commit hook would make every
  contributor's commit depend on `npx` and a network fetch, a cost `zig fmt`
  doesn't impose since Zig is already required to build.

## Verification

Beyond the linter being green (0 issues across 81 files):

- **Word-sequence diff, HEAD vs branch, all 52 changed `.md` files** — 48 are
  byte-identical; the 4 that differ are exactly the intentional edits. The
  three prose rewraps preserved their wording exactly.
- **All 277 code-fence interiors byte-identical** — the only delta is the one
  block added to `CONTRIBUTING.md`. (The word check drops blank lines, so it
  could not have seen a blank line inserted *inside* a fence; this closes that
  gap.)
- **Negative test** — injecting `#1837),` at the start of a line fails the
  check with MD018; removing it returns to clean. The motivating bug class is
  genuinely caught.
- **MD038 suppression is scoped** — verified it fires immediately after the
  `enable` directive and stays silent inside the disabled paragraph.

## Checklist

- [x] `zig build test` passes
- [x] `zig fmt --check src/` passes
- [ ] Scheme test suites — **not run, and cannot be affected**: no `.zig` or
      `.scm` file changed, and nothing in the build or test scripts consumes
      Markdown (the only `.md` mentions in shell scripts are comments). The
      markdown-specific verification above stands in its place.
- [x] New tests added for new behavior — the check itself is the test; its
      negative test is described above
- [x] Documentation updated — `CONTRIBUTING.md` (local command + both autofix
      hazards + CI job table) and `CLAUDE.md` (enforcement map)

Fixes #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
