### PR TITLE
Cover macro-generated top-level define read-back, fixing #1829

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,9 +518,18 @@ SRFI 237 — both used the same general shape (a child type's expansion
 queries a parent macro's own protocol for its record-type-descriptor via
 a nested macro call) and both broke once more than one such query
 relationship existed side by side in the same program, isolated to two
-distinct `em-syntax-rules` engine bugs along the way (kaappi#1828,
-kaappi#1829). The third, shipped design avoids the whole pattern: the
-type name is bound directly to an ordinary runtime record-type-
+distinct `em-syntax-rules` engine bugs along the way (kaappi#1828, still
+open; kaappi#1829, since fixed). kaappi#1829 turned out not to be an
+expander bug of its own at all: because the CK machine builds its output
+as plain data, a macro-generated top-level `define` lands under its BARE
+name, so the next expansion's own reference to it was a free reference to
+an already-bound non-procedure global — exactly the referential-
+transparency collision of kaappi#1832, which kaappi#1839's hygiene rename
+closed for both;
+`tests/scheme/hygiene/macro-fresh-global-readback-1829.scm` guards that
+shape directly. The third, shipped design avoids the whole pattern
+regardless (kaappi#1828 alone still rules the query-macro approach out):
+the type name is bound directly to an ordinary runtime record-type-
 descriptor exactly as in SRFI 131 (inheritance and field/accessor/
 mutator resolution, including multi-level shadowing, handled entirely at
 run time by SRFI 237's own by-name introspection), and the one piece

--- a/lib/srfi/150.sld
+++ b/lib/srfi/150.sld
@@ -11,13 +11,24 @@
 ;;; NOT a port of the reference implementation, and not this codebase's
 ;;; second implementation attempt either -- see issue #1810's own
 ;;; investigation notes for the two prior attempts and the general kaappi
-;;; engine bugs they surfaced (kaappi#1828, kaappi#1829): every design
-;;; built on a macro that answers a hygienic-metadata QUERY from a later,
-;;; separate define-record-type expansion (the reference's own SRFI 137
-;;; `make-subtype` closures; this codebase's first rewrite, a `:secret`
-;;; descriptor macro over SRFI 237) breaks once more than one such query
-;;; relationship exists side by side in the same program -- confirmed with
-;;; a minimal, record-free `em-syntax-rules` repro in kaappi#1829.
+;;; engine bugs they surfaced (kaappi#1828, still open; kaappi#1829, since
+;;; fixed): every design built on a macro that answers a hygienic-metadata
+;;; QUERY from a later, separate define-record-type expansion (the
+;;; reference's own SRFI 137 `make-subtype` closures; this codebase's first
+;;; rewrite, a `:secret` descriptor macro over SRFI 237) breaks once more
+;;; than one such query relationship exists side by side in the same
+;;; program.
+;;;
+;;; kaappi#1829's own minimal, record-free `em-syntax-rules` repro no
+;;; longer fails: it was not an expander bug at all but the referential-
+;;; transparency collision of kaappi#1832, reached because the CK machine
+;;; emits its output as plain data, so a macro-generated top-level define
+;;; lands under its BARE name and the next expansion's reference to it is
+;;; a free reference to an already-bound global. kaappi#1839's hygiene
+;;; rename closed it (see tests/scheme/hygiene/
+;;; macro-fresh-global-readback-1829.scm). kaappi#1828 is untouched by
+;;; that fix and on its own still rules the query-macro approach out, so
+;;; nothing below changes.
 ;;;
 ;;; This THIRD implementation avoids the whole pattern: it never threads
 ;;; anything across separate define-record-type expansions via a macro
@@ -43,11 +54,11 @@
 ;;;     parent's via `lookup`. SRFI 213's property table is a plain,
 ;;;     direct VM-level key-value store (`vm.syntax_properties`), entirely
 ;;;     bypassing the expander's own macro-to-macro call/argument-
-;;;     threading machinery that kaappi#1828/kaappi#1829 are bugs in --
-;;;     confirmed safe for repeated, independent inheritance chains during
-;;;     this SRFI's own investigation (a record-free prototype using this
-;;;     exact mechanism, mirroring kaappi#1829's own failing shape,
-;;;     produces correct results).
+;;;     threading machinery that kaappi#1828 is a bug in -- confirmed safe
+;;;     for repeated, independent inheritance chains during this SRFI's own
+;;;     investigation (a record-free prototype using this exact mechanism,
+;;;     mirroring kaappi#1829's own failing shape, produces correct
+;;;     results).
 ;;;
 ;;;   - `lookup` is only reachable from a procedural transformer (SRFI
 ;;;     211's `capture-lookup` convention; `em-syntax-rules`/plain

--- a/tests/scheme/hygiene/macro-fresh-global-readback-1829.scm
+++ b/tests/scheme/hygiene/macro-fresh-global-readback-1829.scm
@@ -1,0 +1,111 @@
+;; Regression test for #1829: an `em-syntax-rules` (SRFI 148) macro whose
+;; expansion defines a fresh top-level binding and reads it back in the
+;; same generated `begin` got the WRONG value back — it read a previous
+;; expansion's same-spelled binding instead of its own.
+;;
+;; Unlike a `syntax-rules` template (whose introduced top-level `define`
+;; is hygienically renamed), the CK machine builds its output as plain
+;; data, so `holder`/`slot` below land under their bare names and are real
+;; globals by the time the NEXT use expands. That made the template's own
+;; reference a free reference to an already-bound non-procedure global,
+;; which used to be deliberately left UNRENAMED so an injected alias could
+;; pierce use-site shadowing (R7RS 4.3.1 referential transparency). The
+;; bare reference was then indistinguishable from the parent's own
+;; same-spelled symbol that the `=>` query threads back in — the same
+;; collision as #1832 (see free-global-vs-arg-1832.scm), reached through a
+;; macro-generated top-level define instead of a pattern variable.
+;;
+;; Note both macros below share ONE global per spelling: every type's
+;; `:secret` hands back the same bare symbol, so "the parent's value" is
+;; whatever that single global holds at the moment of expansion. Each
+;; parent-having use therefore directly follows its intended parent, and
+;; the assertions say nothing about re-targeting an earlier one.
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 64) (srfi 148))
+
+(test-begin "macro-fresh-global-readback-1829")
+
+;; Read-backs are recorded through a PROCEDURE on purpose: procedures are
+;; excluded from the free-global alias mechanism under test, so the
+;; recorder itself cannot perturb what is being measured.
+(define collected '())
+(define (record! x) (set! collected (cons x collected)))
+(define (take-collected!)
+  (let ((r (reverse collected)))
+    (set! collected '())
+    r))
+
+(define-syntax :secret
+  (syntax-rules () ((_ . args) (syntax-error "misuse"))))
+
+;; Resolves a type-spec into (name parent-value-expr): with a parent,
+;; queries the parent's own :secret protocol for a reference to ITS OWN
+;; storage variable; with no parent, #f.
+(define-syntax parse-type
+  (em-syntax-rules ()
+    ((parse-type '(name parent))
+     ((parent ':secret) => 'parent-value)
+     `(name parent-value))
+    ((parse-type 'name) '(name #f))))
+
+;; --- Case 1: the storage name already exists as a user global ----------
+;; The tightest form of the bug: with `slot` bound before any use, the
+;; free-global path fires on the very FIRST parent-having use, so pre-fix
+;; `(defslot (childS parentS))` read back parentS's value instead of its
+;; own. (The macro-introduced `define slot` overwrites the user's binding
+;; in both builds — that is the pre-existing unhygienic-top-level-define
+;; behavior this test does not assert on.)
+(define slot '(user-slot))
+
+(define-syntax defslot
+  (em-syntax-rules ()
+    ((defslot type-spec)
+     ((parse-type 'type-spec) => '(name parent-expr))
+     `(begin
+        (define slot (list 'slot-named 'name 'with-parent parent-expr))
+        (record! slot)
+        (define-syntax name
+          (em-syntax-rules ::: ()
+            ((name ':secret) 'slot)
+            ((name 'arg :::) (em-error "bad"))))))))
+
+(defslot parentS)
+(defslot (childS parentS))
+
+(test-equal "storage name pre-bound: child reads back its own fresh define"
+  '((slot-named parentS with-parent #f)
+    (slot-named childS with-parent (slot-named parentS with-parent #f)))
+  (take-collected!))
+
+;; --- Case 2: the issue's reported sequence -----------------------------
+;; `holder` is NOT pre-bound here, so the first use creates it and the
+;; failure surfaces only on the parent-having branch's SECOND use, which
+;; queries a macro the branch's first use did not query. Pre-fix, the
+;; fourth read-back came back as parentB's own holder.
+(define-syntax deftype
+  (em-syntax-rules ()
+    ((deftype type-spec)
+     ((parse-type 'type-spec) => '(name parent-expr))
+     `(begin
+        (define holder (list 'type-named 'name 'with-parent parent-expr))
+        (record! holder)
+        (define-syntax name
+          (em-syntax-rules ::: ()
+            ((name ':secret) 'holder)
+            ((name 'arg :::) (em-error "bad"))))))))
+
+(deftype parentA)
+(deftype (childA parentA))
+(deftype parentB)
+(deftype (childB parentB))
+
+(test-equal "fresh top-level define reads back as itself, not a prior expansion's"
+  '((type-named parentA with-parent #f)
+    (type-named childA with-parent (type-named parentA with-parent #f))
+    (type-named parentB with-parent #f)
+    (type-named childB with-parent (type-named parentB with-parent #f)))
+  (take-collected!))
+
+(let ((runner (test-runner-current)))
+  (test-end "macro-fresh-global-readback-1829")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Status: #1829 is already fixed on `main`

The issue was filed before [#1839](https://github.com/kaappi/kaappi/pull/1839) (the fix for #1832) landed, and that fix closed it. Confirmed by A/B build, not inference:

| Build | 4th `deftype` read-back |
|---|---|
| `07adabaf` (pre-#1839) | `(type-named parentB with-parent #f)` — wrong |
| `70450499` (main) | `(type-named childB with-parent (type-named parentB …))` — correct |

So this PR adds the missing regression coverage and corrects two places that still describe #1829 as a live bug. No source changes.

## Root cause

The issue's own hypothesis — a global inline cache keyed more coarsely than binding identity, around `cache_version`/`global_version` — was **not** the cause.

- `em-syntax-rules` builds its output as **plain data** via the CK machine, so a macro-generated top-level `define holder` lands under its **bare** name. A `syntax-rules` template's introduced define does *not*: the plain-`syntax-rules` reduction fails with `undefined variable 'holder'` instead of reproducing.
- That makes bare `holder` a real global, so the *next* expansion's own `holder` is a free reference to an already-bound non-procedure global — which the pre-#1839 code deliberately left **unrenamed** so an injected alias could pierce use-site shadowing (R7RS 4.3.1 referential transparency).
- The bare reference was then indistinguishable from the parent's own `holder` symbol threaded back in by the `=>` query. That is exactly #1832's collision, reached through a generated top-level define instead of a pattern variable — which is why #1839's hygiene rename closed both.

Decisive probe: pre-binding the storage name makes the pre-fix build fail on the **first** parent-having use rather than the fourth. An `er-macro-transformer` version of the same shape does **not** reproduce on either build, pinning this to the `bound_free_refs` free-global path rather than to procedural transformers.

## What's in the PR

- **`tests/scheme/hygiene/macro-fresh-global-readback-1829.scm`** — the issue's reported four-use sequence plus the tighter pre-bound-name case. Read-backs are recorded through a *procedure*, which the alias mechanism excludes, so the recorder cannot perturb what it measures. Both assertions verified to fail on the pre-#1839 binary and pass on current `main`.
- **`CLAUDE.md`, `lib/srfi/150.sld`** — both read as if #1829 were still open. Now recorded as fixed, with the real mechanism.

#1828 was re-checked and still reproduces (`undefined variable ':prepare'`). It is untouched by #1839 and on its own still rules out the query-macro approach SRFI 150 rejected, so no design note changes.

## Verification

- `bash tests/scheme/run-all.sh` — **2011 pass, 0 fail** (616 Scheme files, up from 615, confirming the new file is picked up; 1395 R7RS)
- `zig build test` — clean
- `npx markdownlint-cli2` — clean
- `tests/scheme/srfi/srfi150.scm` unchanged at 21 pass / 4 expected failures (those belong to #1832's still-open broader limitation, not #1829)

Fixes #1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)