### PR TITLE
Resolve library globals identically in all three global-ref opcodes, fixing #1831

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,18 +430,24 @@ hygienically). SRFI 131 (ERR5RS Record Syntax, reduced) layers on the same
 substrate with by-*name* (not positional) constructor field resolution,
 including a subtype field shadowing an ancestor's same-named field per its
 own spec text. Two portability gotchas surfaced repeatedly while building
-these three: (1) calling a `%`-prefixed primitive from `(srfi 237
-primitives)` with no explicit import is *not* reliably ambiently visible
-the way some other primitives are elsewhere in this codebase — declare the
-import explicitly rather than assume it; (2) a genuine, unrooted-out
-compiler quirk was found (not fixed): calling one `%`-prefixed
+these three, and both turned out to be one engine bug, fixed in
+kaappi#1831: (1) calling a `%`-prefixed primitive from `(srfi 237
+primitives)` with no explicit import looked *unreliably* ambient — it
+worked in some positions and not others; (2) calling one `%`-prefixed
 forward-referenced global as a direct, non-tail-position argument
 expression to another (e.g. inside `if`/`list`, or as an argument nested
 one level deep) inside a closure passed to `map` raised a spurious
-"undefined variable" for the *inner* call, reliably fixed by routing
-through an extra wrapper function (any name) called in tail position —
-ordinary (non-`%`) names in the identical shape were unaffected; worth a
-dedicated investigation later.
+"undefined variable" for the *inner* call, reliably worked around at the
+time by routing through an extra wrapper function (any name) called in
+tail position. Both were the same thing: a library body's reference to a
+global that lives in vm.globals but not in its own lib_env resolved in
+tail position only, because `get_global` carried the vm.globals fallback
+and the `call_global` superinstruction the compiler emits for every
+non-tail call did not. Ordinary (non-`%`) names looked unaffected only
+because `(scheme base)` puts them in lib_env; all three global-reference
+opcodes now resolve through one helper in `vm_dispatch.zig`. Declaring
+the import explicitly is still the better style, but it is no longer
+load-bearing.
 SRFI 57 (Records, with inheritance via "schemes" -- a named, reusable field-
 label list a type or another scheme can extend, with multiple schemes
 mergeable at once via left-to-right append + delete-duplicates) is portable
@@ -535,16 +541,23 @@ engine represents every identifier as a plain, hygiene-renamed symbol,
 plain `equal?` on that raw symbol already implements both
 bound-identifier=? and free-identifier=? for SRFI 213's stored names —
 specific to this engine's rename-by-spelling hygiene representation, not
-a portable assumption. This design surfaced one more primitives quirk
-(kaappi#1831): `cadar` specifically — not `caar`/`cadr`/`cddr`/`cdddr`,
-and not its own semantically-identical unrolled spelling
-`(cadr (car x))` — fails silently when called from a helper function
-invoked during an `er-macro-transformer`'s expansion, worked around by
-spelling the one affected lookup as `(cadr (car alist))` in
-`lib/srfi/150.sld`. SRFI 150 ships with one documented, unfixed gap
-rather than blocking on an engine fix: 21 of 25 tests ported from the
-reference suite pass; the other 4 (two "Hygiene 1" assertions, one
-"Hygiene 2" assertion, and Alex Shinn's explicit-construction tuple
+a portable assumption. This design surfaced the library global-resolution
+bug fixed in kaappi#1831, which first presented as `cadar` specifically —
+not `caar`/`cadr`/`cddr`, and not its own unrolled spelling
+`(cadr (car x))` — failing when called from a helper function invoked
+during an `er-macro-transformer`'s expansion. The `cadar` framing was a
+red herring on two counts: `cadar` is a `(scheme cxr)` name
+`lib/srfi/150.sld` never imports while its apparent siblings there are
+`(scheme base)` names already in lib_env, and the file's one other
+cxr-only name (`cdddr`) sits inside the transformer's own lambda, which
+is evaluated at macro-definition time in the global environment and so
+never consults lib_env at all. The real rule was tail vs. non-tail
+position (see the SRFI 237 paragraph above); the idiomatic `cadar`
+spelling is back in `field-alist-ref`. SRFI 150 ships with one
+documented, unfixed gap rather than blocking on an engine fix: 21 of 25
+tests ported from the reference suite pass; the other 4 (two "Hygiene 1"
+assertions, one "Hygiene 2" assertion, and Alex Shinn's
+explicit-construction tuple
 example, marked `test-expect-fail`/annotated in
 `tests/scheme/srfi/srfi150.scm`) hit a precise, minimal, record-free
 reproduction (kaappi#1832) of the already-documented "a use-site

--- a/lib/srfi/150.sld
+++ b/lib/srfi/150.sld
@@ -78,24 +78,19 @@
 ;;;     implementation on a syntax-object-based Scheme could not assume
 ;;;     this and would need real bound-identifier=?/free-identifier=?.
 ;;;
-;;; `field-alist-ref` below deliberately spells its second-element lookup
-;;; as `(cadr (car alist))`, not the equivalent, more idiomatic `cadar`.
-;;; This works around a genuine, cleanly-isolated engine bug found during
-;;; this SRFI's own implementation: calling the composed accessor `cadar`
-;;; from inside a helper function that is itself invoked from a procedural
-;;; (er-macro-transformer) macro's expansion-time code silently fails --
-;;; the call never completes and the whole expansion is later reported as
-;;; a generic "invalid syntax" compile error with no other diagnostic.
-;;; Isolated to exactly `cadar` specifically (not cxr compositions
-;;; generally: `caar`, `cadr`, `cddr`, `cdddr` are all used elsewhere in
-;;; this very file with no issue) and exactly this call shape: `cadar`
-;;; called directly inline in a transformer body works fine; the same
-;;; `cadar` call moved one level down, into a separately-defined function
-;;; the transformer calls, fails; and both `(car (cdr (car x)))` and
-;;; `(cadr (car x))` -- semantically identical to `(cadar x)` -- work
-;;; correctly in that same nested position. Worth its own investigation
-;;; and engine issue later; sidestepped here since the unrolled spelling
-;;; is a one-line change with no semantic difference.
+;;; `field-alist-ref` below spelled its second-element lookup as the
+;;; unrolled `(cadr (car alist))` until kaappi#1831 was fixed. `cadar`
+;;; is a `(scheme cxr)` name this library does not import, and a library
+;;; body's reference to a global outside its own lib_env used to resolve
+;;; in tail position only (get_global carried the vm.globals fallback,
+;;; call_global did not), so the same call failed as a non-tail operand
+;;; and surfaced as a bare "invalid syntax" from the expansion. Two
+;;; near-misses made it look `cadar`-specific: `caar`/`cadr`/`cddr` here
+;;; are `(scheme base)` names, so they were in lib_env either way, and
+;;; the one other cxr-only name, `cdddr` on line 177, sits inside the
+;;; transformer's own lambda -- evaluated at macro-definition time in
+;;; the global environment, which never consults lib_env at all. The
+;;; idiomatic spelling is back.
 (define-library (srfi 150)
   (import (scheme base) (srfi 211 explicit-renaming) (srfi 213)
           (srfi 237) (srfi 237 primitives))
@@ -153,7 +148,7 @@
       (cond
         ((null? alist) #f)
         ((equal? field (caar alist)) (caar alist))
-        ((equal? field (cadr (car alist))) (caar alist))
+        ((equal? field (cadar alist)) (caar alist))
         (else (field-alist-ref field (cdr alist)))))
 
     (define (resolve-field-name field own-alist parent-alist)

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -1006,3 +1006,56 @@ test "top-level cond-expand malformed-form parity with the compiler (#1661)" {
     // silently splicing the proper prefix and dropping the tail.
     try std.testing.expectError(error.CompileError, vm.eval("(cond-expand (else 1 . junk))"));
 }
+
+// Regression for #1831: a library body referencing a global that is registered
+// in vm.globals but absent from its own lib_env resolved in tail position only.
+// The compiler picks a global-reference opcode purely by syntactic position —
+// get_global plus a plain tail_call for a tail call's operator, the call_global
+// superinstruction everywhere else — and only get_global carried the vm.globals
+// fallback library code needs (455f5cc2). So `(cadar x)` worked as a body's last
+// form and raised "undefined variable 'cadar'" one position over, which surfaced
+// as a bare `invalid syntax` when the caller ran at macro-expansion time.
+test "library resolves a non-imported global in every syntactic position (#1831)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // `cadar` belongs to (scheme cxr); this library imports only (scheme base),
+    // so the name lives in vm.globals and not in the library's own env.
+    _ = try vm.eval(
+        \\(define-library (test cxr-position)
+        \\  (import (scheme base))
+        \\  (export in-tail in-operand in-test in-nested)
+        \\  (begin
+        \\    (define (in-tail x) (cadar x))
+        \\    (define (in-operand x) (car (cadar x)))
+        \\    (define (in-test x) (if (cadar x) 1 0))
+        \\    (define (in-nested x) (begin (cadar x) 5))))
+    );
+    _ = try vm.eval("(import (test cxr-position))");
+
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(try vm.eval("(car (in-tail '((1 (7)))))")));
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(try vm.eval("(in-operand '((1 (7))))")));
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(try vm.eval("(in-test '((1 (7))))")));
+    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(try vm.eval("(in-nested '((1 (7))))")));
+}
+
+// Companion to the above: the vm.globals fallback call_global gained must stay
+// gated by restricted_globals, so a restricted (environment ...) is no leakier
+// for a non-tail call than the tail call #1253 already covers.
+test "restricted environment does not leak globals to a non-tail call (#1831)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // `car` is excluded from the environment; the call sits in operand position
+    // (inside `list`), so it compiles to call_global rather than a tail call.
+    const result = try vm.eval(
+        \\(guard (e (#t 'caught))
+        \\  (eval '(list (car '(1))) (environment '(only (scheme base) list))))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("caught", types.symbolName(result));
+}

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -201,7 +201,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const closure = frame.closure orelse return VMError.InvalidBytecode;
                 const func = closure.func;
                 const dst_idx = try registerIndex(self, frame.base, dst);
-                const env: *std.StringHashMap(Value) = func.env orelse self.globals;
                 if (func.env == null) {
                     if (func.global_cache) |cache| {
                         if (func.cache_version == self.global_version and
@@ -219,40 +218,14 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const sym = try constantAt(self, func, sym_idx);
                 if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                 const name = types.symbolName(sym);
-                // #1812: resolved once and reused below to also skip caching
-                // this reference — a def_env_binding_prefix name's resolution
-                // isn't invalidated by self.global_version (a library's own
-                // internal set! on its def_env doesn't bump it, since that
-                // mutation's func.env isn't null), so caching it under that
-                // version could go stale.
+                // #1812: skip caching a def_env_binding_prefix reference — its
+                // resolution isn't invalidated by self.global_version (a
+                // library's own internal set! on its def_env doesn't bump it,
+                // since that mutation's func.env isn't null), so caching it
+                // under that version could go stale.
                 const def_env_parts = vm_mod.globals_mod.parseDefEnvBindingSymbolName(name);
-                const found: ?Value = if (vm_mod.globals_mod.stripBaseBindingPrefix(name)) |base_name|
-                    resolveBaseBindingLocked(self, env, base_name)
-                else if (def_env_parts) |parts|
-                    vm_mod.globals_mod.lookupDefEnvBinding(parts.libname, parts.origname)
-                else blk: {
-                    // Map reads under the child-thread shared lock; the error
-                    // path runs after release (findSimilarName locks internally).
-                    self.lockGlobalsShared();
-                    defer self.unlockGlobalsShared();
-                    break :blk env.get(name) orelse blk2: {
-                        if (func.env != null and !func.restricted_globals) {
-                            if (self.globals.get(name)) |gval| break :blk2 gval;
-                        }
-                        // Hygienic-prefix fallback is intentionally ungated by
-                        // restricted_globals: macro-introduced references must
-                        // still resolve through globals even in restricted envs.
-                        const base = types.stripHygienicPrefix(name);
-                        if (base.len != name.len) {
-                            if (env.get(base)) |bval| break :blk2 bval;
-                            if (env != self.globals) {
-                                if (self.globals.get(base)) |gval| break :blk2 gval;
-                            }
-                        }
-                        break :blk2 null;
-                    };
-                };
-                const val = found orelse return raiseUndefinedVariable(self, name);
+                const val = lookupGlobalLocked(self, func, name) orelse
+                    return raiseUndefinedVariable(self, name);
                 self.registers[dst_idx] = val;
                 if (func.env == null and def_env_parts == null and (types.isClosure(val) or types.isNativeFn(val))) {
                     if (func.global_cache) |cache| {
@@ -926,7 +899,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const nargs = readU8(self, frame);
                 const the_closure = frame.closure orelse return VMError.InvalidBytecode;
                 const the_func = the_closure.func;
-                const env: *std.StringHashMap(Value) = the_func.env orelse self.globals;
                 const base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, base_wide, nargs);
                 const base: u32 = try toBase(base_wide);
@@ -945,7 +917,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             const sym = try constantAt(self, the_func, sym_idx);
                             if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                             const name = types.symbolName(sym);
-                            const val = lookupGlobalLocked(self, env, name) orelse return raiseUndefinedVariable(self, name);
+                            const val = lookupGlobalLocked(self, the_func, name) orelse return raiseUndefinedVariable(self, name);
                             self.registers[base] = val;
                             // #1812: don't cache a def_env_binding_prefix
                             // resolution — see the get_global handler's own
@@ -961,7 +933,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         const sym = try constantAt(self, the_func, sym_idx);
                         if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                         const name = types.symbolName(sym);
-                        const val = lookupGlobalLocked(self, env, name) orelse return raiseUndefinedVariable(self, name);
+                        const val = lookupGlobalLocked(self, the_func, name) orelse return raiseUndefinedVariable(self, name);
                         self.registers[base] = val;
                         if ((types.isClosure(val) or types.isNativeFn(val)) and
                             vm_mod.globals_mod.parseDefEnvBindingSymbolName(name) == null)
@@ -987,16 +959,8 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const sym = try constantAt(self, the_func, sym_idx);
                     if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                     const name = types.symbolName(sym);
-                    const found = if (vm_mod.globals_mod.stripBaseBindingPrefix(name)) |base_name|
-                        resolveBaseBindingLocked(self, env, base_name)
-                    else if (vm_mod.globals_mod.parseDefEnvBindingSymbolName(name)) |parts|
-                        vm_mod.globals_mod.lookupDefEnvBinding(parts.libname, parts.origname)
-                    else blk: {
-                        self.lockGlobalsShared();
-                        defer self.unlockGlobalsShared();
-                        break :blk env.get(name);
-                    };
-                    const val = found orelse return raiseUndefinedVariable(self, name);
+                    const val = lookupGlobalLocked(self, the_func, name) orelse
+                        return raiseUndefinedVariable(self, name);
                     self.registers[base] = val;
                 }
 
@@ -1047,7 +1011,6 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const nargs = readU8(self, frame);
                 const closure = frame.closure orelse return VMError.InvalidBytecode;
                 const func = closure.func;
-                const env: *std.StringHashMap(Value) = func.env orelse self.globals;
                 const abs_base_wide = @as(usize, frame.base) + @as(usize, base_reg);
                 try ensureCallWindow(self, abs_base_wide, nargs);
                 const abs_base: u32 = try toBase(abs_base_wide);
@@ -1066,7 +1029,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const sym = try constantAt(self, func, sym_idx);
                     if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
                     const name = types.symbolName(sym);
-                    callee = lookupGlobalLocked(self, env, name) orelse return raiseUndefinedVariable(self, name);
+                    callee = lookupGlobalLocked(self, func, name) orelse return raiseUndefinedVariable(self, name);
                     // #1812: don't cache a def_env_binding_prefix resolution
                     // — see get_global's own comment on why self.global_version
                     // can't be trusted to invalidate it.
@@ -1465,23 +1428,48 @@ noinline fn raiseUndefinedVariable(self: *VM, name: []const u8) VMError {
     return VMError.UndefinedVariable;
 }
 
-inline fn lookupGlobalLocked(self: *VM, env: *std.StringHashMap(Value), name: []const u8) ?Value {
+/// Resolve a global reference made by `func`: its own environment first, then
+/// the VM globals when `func` runs in a library (or `eval`) environment, then
+/// both again with any hygienic rename prefix stripped.
+///
+/// The three global-reference opcodes must all resolve through here.
+/// `get_global`, `call_global`, and `tail_call_global` describe the *same*
+/// reference — which one the compiler emits depends only on syntactic position
+/// (operand vs. operator, tail vs. non-tail) — so a name that resolves under
+/// one has to resolve under the others. They disagreed: only `get_global`
+/// carried the vm.globals fallback library code needs (455f5cc2), so a library
+/// body calling a global it hadn't imported (`cadar`, a `%`-prefixed internal
+/// primitive) worked in tail position, where the compiler emits get_global plus
+/// a plain tail_call, and raised "undefined variable" in every other position,
+/// where it emits call_global (kaappi#1831).
+inline fn lookupGlobalLocked(self: *VM, func: *types.Function, name: []const u8) ?Value {
+    const env: *std.StringHashMap(Value) = func.env orelse self.globals;
     if (vm_mod.globals_mod.stripBaseBindingPrefix(name)) |base_name| {
         return resolveBaseBindingLocked(self, env, base_name);
     }
     if (vm_mod.globals_mod.parseDefEnvBindingSymbolName(name)) |parts| {
         return vm_mod.globals_mod.lookupDefEnvBinding(parts.libname, parts.origname);
     }
+    // Map reads under the child-thread shared lock; the error path runs after
+    // release (findSimilarName locks internally).
     self.lockGlobalsShared();
-    const found: ?Value = env.get(name) orelse blk: {
-        const b = types.stripHygienicPrefix(name);
-        if (b.len != name.len) {
-            if (env.get(b)) |bval| break :blk bval;
+    defer self.unlockGlobalsShared();
+    return env.get(name) orelse blk: {
+        if (func.env != null and !func.restricted_globals) {
+            if (self.globals.get(name)) |gval| break :blk gval;
+        }
+        // Hygienic-prefix fallback is intentionally ungated by
+        // restricted_globals: macro-introduced references must still resolve
+        // through globals even in restricted envs.
+        const base = types.stripHygienicPrefix(name);
+        if (base.len != name.len) {
+            if (env.get(base)) |bval| break :blk bval;
+            if (env != self.globals) {
+                if (self.globals.get(base)) |gval| break :blk gval;
+            }
         }
         break :blk null;
     };
-    self.unlockGlobalsShared();
-    return found;
 }
 
 /// Resolve a `globals_mod.base_binding_prefix`-marked name (#1715): prefer


### PR DESCRIPTION
## Root cause

`cadar` was a red herring. The real rule is **tail vs. non-tail position inside a library body**.

The compiler picks a global-reference opcode purely by syntactic position:

| Position | Opcode(s) |
|---|---|
| operator of a **tail** call | `get_global` + a plain `tail_call` |
| everywhere else (operand, `if` test, non-tail operator) | the `call_global` superinstruction |

Only `get_global` carried the `vm.globals` fallback that library code has needed since 455f5cc2 ("Add vm.globals fallback to get_global for library contexts"); `call_global`'s `func.env != null` branch looked in `lib_env` and nowhere else. So a library that imports only `(scheme base)` resolved a `(scheme cxr)` name as its body's last form and raised `undefined variable 'cadar'` for the identical call one position over. Reduced, with no macros involved at all:

```scheme
(define-library (t r)
  (import (scheme base))
  (export h1 h2)
  (begin
    (define (h1 x) (cadar x))          ; worked
    (define (h2 x) (list (cadar x))))) ; undefined variable 'cadar'
```

The issue reported it as an `er-macro-transformer` bug because the error is swallowed into a generic `invalid syntax` when the failing helper runs at macro-expansion time. Every isolation note in the issue falls out of this model, including "calling `cadar` directly inline in the transformer body works fine" — a transformer expression is evaluated at macro-definition time in the **global** environment, so its own lambda has `func.env == null` and never consults `lib_env`.

## Fix

All three global-reference opcodes now resolve through one `lookupGlobalLocked` helper that takes the `Function` rather than a pre-picked env, so `get_global`, `call_global`, and `tail_call_global` see the same chain: the function's own environment → `vm.globals` when it runs in a library (or `eval`) environment and isn't restricted → both again with any hygienic rename prefix stripped. Net -20 lines: the chain existed in three partial copies.

`tail_call_global` is currently unreachable from the compiler (both emit sites sit under `if (is_tail)` in functions only called with `is_tail == false`) but is exercised by hand-built bytecode in `tests_native_dispatch.zig`, so it moved with the others rather than being left as a fourth answer.

**Trade-off worth naming:** this makes the three opcodes agree in the *lenient* direction — a library body can reference any registered global without importing it. That leniency is pre-existing and deliberate (`get_global` has had it since 455f5cc2; `%parameter-set!` in `parameterize` desugaring depends on it), and `kaappi check`'s `KP4xxx` unknown-variable lint is the guard against genuinely wrong names. Tightening it instead would be a breaking change well beyond this issue.

## Also fixed by this

The "genuine, unrooted-out compiler quirk (not fixed)" documented in `CLAUDE.md` for the SRFI 237 primitives is the same bug: a `%`-prefixed internal primitive is a `vm.globals`-only name, so it looked *unreliably* ambient — fine in tail position, "undefined variable" as a nested argument, and the recorded workaround ("route through an extra wrapper function called in tail position") is exactly the shape that hits `get_global`. Both `CLAUDE.md` notes are corrected.

`lib/srfi/150.sld`'s `field-alist-ref` gets its idiomatic `cadar` back, replacing the `(cadr (car alist))` workaround. SRFI 150's suite is unchanged at 21 pass / 4 `test-expect-fail` (verified against the pre-change baseline, not assumed).

## Tests

Two regression tests in `src/tests_libraries.zig`, both mutation-verified:

- **`library resolves a non-imported global in every syntactic position (#1831)`** — one library, `cadar` in four positions (tail, operand, `if` test, non-final `begin`). Fails on `main` (three of the four raise `UndefinedVariable`).
- **`restricted environment does not leak globals to a non-tail call (#1831)`** — companion guard: the fallback `call_global` gained must stay gated by `restricted_globals`, so a restricted `(environment ...)` is no leakier for a non-tail call than #1253 already made it for a tail call. Fails when the `restricted_globals` gate is removed.

`zig build test` green; `bash tests/scheme/run-all.sh` green (2010 pass, 0 fail); `markdownlint-cli2` clean.

## Not in scope

A Scheme error raised inside a procedural transformer is still reported as a bare `compile error[KP2001]: invalid syntax`, discarding the real condition — that's what made this issue expensive to isolate. The reporting path already supports a detail string (`toplevel_driver.reportCompileError` prints `syntax-error[KP2002]` when `compiler.syntax_error_detail` is set); wiring the transformer's error into it is a separate change with its own test surface, so it's flagged as a follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)