### PR TITLE
Use list? instead of pair? for user-supplementary-gids audit test

### DIFF
--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -121,7 +121,7 @@
 (test-equal #t (number? (nice 0)))
 (test-equal #t (and (number? (user-uid)) (number? (user-gid))
                     (number? (user-effective-uid)) (number? (user-effective-gid))))
-(test-equal #t (pair? (user-supplementary-gids)))
+(test-equal #t (list? (user-supplementary-gids)))
 
 ;;; --- environment variables (write side) ---
 (set-environment-variable! "KAAPPI_AUDIT_VAR" "v1")


### PR DESCRIPTION
## Summary
- `tests/scheme/audit/primitives_filesystem-audit.scm` asserted `(pair? (user-supplementary-gids))`, which requires a *non-empty* list — a property of the environment (having at least one supplementary group), not of the procedure. SRFI 170 only promises an exact-integer list.
- Fails for any process with no supplementary groups, most commonly root in a minimal container image.
- The other two tests of this primitive (`src/tests_filesystem.zig`, `tests/scheme/coverage/filesystem-coverage.scm`) already use `list?`; this brings the audit test in line with them.

Fixes #1844

## Test plan
- [x] `zig build` succeeds
- [x] `zig-out/bin/kaappi tests/scheme/audit/primitives_filesystem-audit.scm` — 69 passes (was 68 pass / 1 fail conceptually reproducible only in a no-supplementary-groups environment; this dev machine has supplementary groups so it exercises the non-empty path)
- [x] `bash tests/scheme/run-all.sh` — full suite green: 2011 pass, 0 fail (616 Scheme files + 1395 R7RS suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)