### PR TITLE
Surface procedural macro transformer errors instead of bare "invalid syntax"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A procedural macro transformer's own raised condition was discarded and
+  reported as a bare `"invalid syntax"`.** A Scheme-level error inside a
+  SRFI 211 `er-macro-transformer`/`lisp-transformer` — the transformer's own
+  `(error ...)`, or a primitive type error inside it like `(car 7)` — was
+  computed and stored on the VM, then thrown away when the expander's
+  `TransformerFailed` collapsed to the compiler's generic
+  `CompileError.InvalidSyntax`: #1831 was a one-line resolution bug whose
+  real message was `undefined variable 'cadar'`, none of which reached the
+  user, so it was chased for days as a `cadar`-specific primitives bug
+  instead. The real condition now flows through the same
+  `syntax-error[KP2002]` channel `syntax-error` itself already reports
+  through — in the CLI's text output, `kaappi check`, and
+  `--diagnostics=json` alike — while an ordinary `syntax-rules` pattern-match
+  rejection, which has no VM-side condition to recover, keeps its existing
+  generic message (#1846).
+
 - **A `syntax-rules` template's own free reference to a pre-existing global
   could collapse into an unrelated, same-spelled argument at the use site.**
   R7RS 4.3.1 referential transparency for a template's free reference to a

--- a/docs/dev/diagnostics-json.md
+++ b/docs/dev/diagnostics-json.md
@@ -54,7 +54,7 @@ leading digit of the code identifies the stage (full taxonomy in
 | Stage | Codes | Example trigger |
 |-------|-------|-----------------|
 | Read / lexical | `KP1xxx` | `(display "abc` → `KP1006` unterminated string |
-| Expand (macros / `syntax-rules`) | `KP2002` | `(syntax-error "bad" 42)` → `KP2002` |
+| Expand (macros, `syntax-rules`, procedural transformers) | `KP2002` | `(syntax-error "bad" 42)` → `KP2002`; a raised condition inside an `er-macro-transformer`/`lisp-transformer` (SRFI 211) reports here too (#1846) |
 | Compile | `KP2xxx` | `(if)` → `KP2001` invalid syntax |
 | Runtime | `KP3xxx` | `(car 5)` → `KP3002` type error |
 

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -12,6 +12,29 @@ const Value = types.Value;
 const MAX_MACRO_EXPANSION_DEPTH: u16 = 256;
 const MAX_MACRO_EXPANSION_STEPS: u32 = 10_000;
 
+/// #1846: a procedural macro transformer (SRFI 211 er-macro-transformer /
+/// lisp-transformer) raised, returned a non-datum, or could not run.
+/// globals_mod.error_detail_for_macro carries the real Scheme-level condition
+/// when there is one (populated by vm.callProcForMacro for a raised exception,
+/// or directly by a failing primitive's own type-error call) -- copy it into
+/// the same syntax_error_detail channel `syntax-error` already reports
+/// through, so the top-level reporter and `kaappi check` show the real
+/// message instead of a bare "invalid syntax". Left empty (InvalidSyntax's
+/// generic message applies, exactly as before) when there is no VM-side
+/// detail -- e.g. no VM registered, or a transformer that returned a bare
+/// procedure with nothing left to SRFI 213 capture-lookup.
+fn recordTransformerFailure() CompileError {
+    if (globals_mod.error_detail_for_macro) |getter| {
+        const detail = getter();
+        if (detail.len > 0) {
+            const n = @min(detail.len, compiler_mod.syntax_error_detail.len);
+            @memcpy(compiler_mod.syntax_error_detail[0..n], detail[0..n]);
+            compiler_mod.syntax_error_detail_len = n;
+        }
+    }
+    return CompileError.InvalidSyntax;
+}
+
 /// 128 levels is safe because the expander shares pattern-variable subtrees
 /// (a == b short-circuits at the shared node), so only the short template
 /// spine is actually traversed.
@@ -370,7 +393,8 @@ pub fn expandAndCompileMacroUse(self: *Compiler, expr: Value, name: []const u8, 
             return switch (err) {
                 error.OutOfMemory => CompileError.OutOfMemory,
                 error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
-                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch, error.EllipsisNoPatternVariable, error.TransformerFailed => CompileError.InvalidSyntax,
+                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch, error.EllipsisNoPatternVariable => CompileError.InvalidSyntax,
+                error.TransformerFailed => recordTransformerFailure(),
             };
         };
         // Root for the rest of the enclosing compile scope via extra_roots
@@ -1113,7 +1137,8 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
             return switch (err) {
                 error.OutOfMemory => CompileError.OutOfMemory,
                 error.ScopeTableFull, error.PatternTooComplex => CompileError.InternalLimit,
-                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch, error.EllipsisNoPatternVariable, error.TransformerFailed => CompileError.InvalidSyntax,
+                error.NoMatchingPattern, error.EllipsisCountMismatch, error.EllipsisDepthMismatch, error.EllipsisNoPatternVariable => CompileError.InvalidSyntax,
+                error.TransformerFailed => recordTransformerFailure(),
             };
         };
         self.gc.no_collect -= 1;

--- a/src/globals.zig
+++ b/src/globals.zig
@@ -159,6 +159,18 @@ pub var eval_datum_for_macro: ?EvalDatumFn = null;
 pub const CallProcFn = *const fn (proc: Value, args: []const Value) anyerror!Value;
 pub var call_proc_for_macro: ?CallProcFn = null;
 
+/// #1846: retrieve the VM's last recorded error detail -- the message and
+/// irritants of whatever Scheme-level condition a procedural macro
+/// transformer raised (via call_proc_for_macro above), or the type-error text
+/// of a failing primitive call inside it (e.g. `(car 7)`). Registered by
+/// vm.setVMInstance alongside call_proc_for_macro. Read by
+/// compiler_macro.zig's error.TransformerFailed arms to populate
+/// compiler.syntax_error_detail -- the same channel `syntax-error` already
+/// reports through -- so the real condition reaches the user instead of a
+/// bare "invalid syntax".
+pub const ErrorDetailFn = *const fn () []const u8;
+pub var error_detail_for_macro: ?ErrorDetailFn = null;
+
 /// SRFI 213 (identifier properties): set/get on the VM-owned property
 /// table, keyed by the effective (hygiene-stripped) names of the property's
 /// identifier and key. Registered by vm.setVMInstance; the table's Values

--- a/src/tests_macros.zig
+++ b/src/tests_macros.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const compiler = @import("compiler.zig");
 
 test "define-syntax simple alias" {
     var gc = memory.GC.init(std.testing.allocator);
@@ -1833,6 +1834,58 @@ test "SRFI 211: transformer raising at expansion time is a compile error" {
     );
     const result = ctx.vm.eval("(boom)");
     try std.testing.expectError(error.CompileError, result);
+}
+
+// #1846: the condition a procedural transformer raises used to be computed,
+// stored on the VM, and then discarded -- CompileError.InvalidSyntax carried
+// no detail, so the top-level reporter fell back to a bare "invalid syntax"
+// with no hint of the real cause (see #1831, where this hid the actual
+// "undefined variable 'cadar'" message for days). It now reaches the same
+// compiler.syntax_error_detail channel `syntax-error` reports through, via
+// the globals.error_detail_for_macro hook vm.callProcForMacro/errorDetailForMacro
+// populate. `eval` returns CompileError directly without consuming that
+// buffer (unlike the CLI's reportCompileError/kaappi check paths), so it is
+// still readable here immediately after.
+test "SRFI 211: transformer's raised condition reaches syntax_error_detail (#1846)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    _ = try ctx.vm.eval(
+        \\(define-syntax boom
+        \\  (er-macro-transformer (lambda (f r c) (error "expansion refused" 'x 42))))
+    );
+    const result = ctx.vm.eval("(boom)");
+    try std.testing.expectError(error.CompileError, result);
+    try std.testing.expectEqualStrings("expansion refused x 42", compiler.getSyntaxErrorDetail());
+}
+
+test "SRFI 211: a failing primitive call inside a transformer reaches syntax_error_detail (#1846)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    _ = try ctx.vm.eval(
+        \\(define-syntax boom2
+        \\  (er-macro-transformer (lambda (f r c) (car 7))))
+    );
+    const result = ctx.vm.eval("(boom2)");
+    try std.testing.expectError(error.CompileError, result);
+    try std.testing.expectEqualStrings("type error in 'car': expected pair, got 7", compiler.getSyntaxErrorDetail());
+}
+
+test "SRFI 211: syntax-rules NoMatchingPattern still has no detail (#1846 scope note)" {
+    // TransformerFailed is the only ExpandError arm #1846 changes -- an
+    // ordinary syntax-rules rejection has no VM-side condition to recover
+    // (see the ExpandError.TransformerFailed doc comment in expander.zig)
+    // and must keep reporting the generic InvalidSyntax message.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    _ = try ctx.vm.eval(
+        \\(define-syntax only-one-arg (syntax-rules () ((_ x) x)))
+    );
+    const result = ctx.vm.eval("(only-one-arg 1 2 3)");
+    try std.testing.expectError(error.CompileError, result);
+    try std.testing.expectEqual(@as(usize, 0), compiler.getSyntaxErrorDetail().len);
 }
 
 test "SRFI 211: a global transformer value works as a bare-symbol spec" {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -40,6 +40,7 @@ pub fn setVMInstance(vm: *VM) void {
     globals_mod.def_env_binding_set = &setDefEnvBinding;
     globals_mod.eval_datum_for_macro = &evalDatumForMacro;
     globals_mod.call_proc_for_macro = &callProcForMacro;
+    globals_mod.error_detail_for_macro = &errorDetailForMacro;
     globals_mod.syntax_property_set = &syntaxPropertySet;
     globals_mod.syntax_property_get = &syntaxPropertyGet;
 }
@@ -63,10 +64,33 @@ fn evalDatumForMacro(expr: Value) anyerror!Value {
 }
 
 /// SRFI 211: invoke a procedural macro transformer (or a SRFI 213
-/// capture-lookup re-entry procedure) from inside the expander.
+/// capture-lookup re-entry procedure) from inside the expander. On failure,
+/// formats an escaping Scheme-level exception into last_error_detail exactly
+/// as a top-level form's own uncaught exception would (#1846): callReentrant
+/// (used here for a Closure transformer.proc) only preserves last_error_detail
+/// across its own cleanup, it doesn't populate it from current_exception the
+/// way execute()'s top-level boundary does via noteUncaughtException. Without
+/// this, `(error "msg" irritant)` raised inside a transformer leaves
+/// current_exception set but last_error_detail empty, and errorDetailForMacro
+/// below would have nothing to report. A primitive's own direct type error
+/// (e.g. `(car 7)`) already sets last_error_detail itself and is unaffected
+/// (noteUncaughtException no-ops for anything other than ExceptionRaised).
 fn callProcForMacro(proc: Value, args: []const Value) anyerror!Value {
     const vm = vm_instance orelse return VMError.TypeError; // bare-ok: no VM
-    return vm.callWithArgs(proc, args);
+    return vm.callWithArgs(proc, args) catch |err| {
+        vm.noteUncaughtException(err);
+        return err;
+    };
+}
+
+/// #1846: expose the VM's last recorded error detail to the expander/compiler
+/// (which cannot import vm.zig) so a procedural macro transformer's real
+/// failure -- the message above, or a primitive's own type-error text --
+/// reaches compiler_macro.zig's error.TransformerFailed arms instead of being
+/// discarded.
+fn errorDetailForMacro() []const u8 {
+    const vm = vm_instance orelse return "";
+    return vm.getErrorDetail();
 }
 
 /// SRFI 213: store a property value under the composite key

--- a/tests/scheme/errors/diagnostics-json.sh
+++ b/tests/scheme/errors/diagnostics-json.sh
@@ -106,6 +106,16 @@ single_diag("read stage", '(display "abc', "KP1", "unterminated string")
 # Expand stage (KP2002): a macro/syntax rejection carries its detail message.
 single_diag("expand stage", '(syntax-error "bad usage" 42)', "KP2", "bad usage")
 
+# Expand stage, procedural transformer (KP2002, kaappi#1846): a condition an
+# er-macro-transformer raises must carry its own message in JSON mode too,
+# not just the human-text CLI path -- same channel as syntax-error above.
+single_diag(
+    "expand stage: procedural transformer",
+    '(import (srfi 211 explicit-renaming)) '
+    '(define-syntax boom (er-macro-transformer (lambda (f r c) (error "field not found" (quote alpha) 42)))) '
+    '(boom)',
+    "KP2", "field not found alpha 42")
+
 # Compile stage (KP2xxx): an if with no test.
 single_diag("compile stage", "(if)", "KP2")
 

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -97,6 +97,32 @@ assert_output_contains "caught syntax-error does not leak into next compile erro
     '(import (scheme base)) (guard (e (#t #t)) (eval (quote (syntax-error "STALE" 999)) (environment (quote (scheme base))))) (if)' \
     'compile error'
 
+# --- Procedural macro transformer failures (SRFI 211, #1846) ---
+# A condition an er-macro-transformer/lisp-transformer raises used to be
+# computed, stored on the VM, and discarded -- the user only ever saw a bare
+# "invalid syntax". #1831 was a one-line resolution bug whose real message
+# was "undefined variable 'cadar'"; none of that reached the user, so it was
+# filed and chased as a cadar-specific bug for days. This must now match
+# syntax-error's own KP2002 path exactly.
+echo
+echo "-- Procedural macro transformer diagnostics (#1846) --"
+
+assert_output_contains "er-macro-transformer's raised condition reaches the user" \
+    '(import (srfi 211 explicit-renaming)) (define-syntax boom (er-macro-transformer (lambda (f r c) (error "field not found" (quote alpha) 42)))) (boom)' \
+    'syntax-error[KP2002]: field not found alpha 42'
+
+assert_output_contains "lisp-transformer's raised condition reaches the user" \
+    '(import (srfi 211 define-macro)) (define-syntax boom (lisp-transformer (lambda (f) (error "lisp boom" 7)))) (boom)' \
+    'syntax-error[KP2002]: lisp boom 7'
+
+assert_output_contains "a failing primitive inside a transformer names itself, not just 'invalid syntax'" \
+    '(import (srfi 211 explicit-renaming)) (define-syntax boom2 (er-macro-transformer (lambda (f r c) (car 7)))) (boom2)' \
+    "syntax-error[KP2002]: type error in 'car': expected pair, got 7"
+
+assert_output_contains "ordinary syntax-rules rejection keeps the generic message (scope note)" \
+    '(define-syntax only-one-arg (syntax-rules () ((_ x) x))) (only-one-arg 1 2 3)' \
+    'compile error[KP2001]: invalid syntax'
+
 # --- syntax-rules ellipsis with no driving pattern variable (#1791) ---
 # R7RS 4.3.2: a template subform followed by `...` whose element has no
 # pattern variable bound at that ellipsis depth is an error, not zero


### PR DESCRIPTION
## Summary

- A Scheme-level condition raised inside a SRFI 211 `er-macro-transformer`/`lisp-transformer` was computed, stored on the VM, and discarded before the compiler's `TransformerFailed` collapsed to a generic `invalid syntax[KP2001]`. #1831 was a one-line resolution bug whose real message was `undefined variable 'cadar'` — none of that reached the user, so it was chased for days as a `cadar`-specific primitives bug instead.
- `globals.error_detail_for_macro` exposes the VM's last error detail to the compiler (which cannot import `vm.zig`), and `compiler_macro.zig`'s two `TransformerFailed` arms copy it into the same `syntax_error_detail` channel `syntax-error` already reports through — so the CLI's text output, `kaappi check`, and `--diagnostics=json` all now show the real condition instead of a bare "invalid syntax".
- `vm.callProcForMacro` also now calls `noteUncaughtException` on failure. This wasn't in the issue's suggested shape, but is necessary for the issue's own primary repro case: `callReentrant` (used to invoke the transformer's own closure) preserves `last_error_detail` across its cleanup but never *populates* it from `current_exception` the way `execute()`'s top-level boundary does, so a plain `(error "msg" ...)` raised with no active handler left `last_error_detail` empty. Confirmed with a throwaway debug print before writing the real fix — see commit message for the trace. A primitive's own type error (e.g. `(car 7)`) already set the detail directly via `typeError()` and needed no VM change.
- An ordinary `syntax-rules` pattern-match rejection (`NoMatchingPattern` etc.) has no VM-side condition to recover and is explicitly out of scope (per the issue's own scope note) — it keeps its existing generic message, verified by a dedicated test.

## Test plan

- [x] 4 new Zig unit tests in `src/tests_macros.zig`: transformer's raised condition reaches `syntax_error_detail`, a failing primitive inside a transformer does too, and a scope-note test confirming ordinary `syntax-rules` rejections are unaffected.
- [x] 4 new assertions in `tests/scheme/errors/error-format.sh` (er-macro-transformer, lisp-transformer, primitive failure, and the unaffected-scope-note case), matching the issue's exact expected output.
- [x] 1 new case in `tests/scheme/errors/diagnostics-json.sh` confirming `--diagnostics=json` carries the message.
- [x] Verified no leakage: `kaappi check` with an early transformer failure followed by an unrelated `syntax-rules` error reports each independently.
- [x] Full `zig build test` (all unit tests) — pass.
- [x] Full `bash tests/scheme/run-all.sh` — 2012 pass, 0 fail.
- [x] `zig fmt --check` and `npx markdownlint-cli2` — clean.

Fixes #1846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)