### PR TITLE
Reclassify digit-led glued identifiers from KP1002 to KP1004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A digit-led token that wasn't a valid number was misreported as a bare
+  "unexpected character."** `3-state`, `5foo`, `1.2.3`, and similar tokens
+  are correctly rejected — R7RS identifiers can never begin with a digit, so
+  the reader commits to parsing a number on the leading digit — but the
+  generic `KP1002` ("unexpected character", whose explanation talks about
+  stray `#`-syntax) named the wrong category and gave no hint why, with the
+  caret pointing one character past the token's actual start. Such a token
+  now reports `KP1004` ("invalid number literal"), the accurate code since
+  the reader already committed to a number; the message echoes the
+  offending token and states the rule, and the caret points at the token's
+  start rather than wherever the number scan stopped:
+  `invalid number literal '3-state': identifiers cannot begin with a digit;
+  use |3-state| for a literal symbol`. Surfaced in the CLI's text output,
+  `kaappi check`, `kaappi compile`, and `--diagnostics=json` alike (#1723).
+
 - **A procedural macro transformer's own raised condition was discarded and
   reported as a bare `"invalid syntax"`.** A Scheme-level error inside a
   SRFI 211 `er-macro-transformer`/`lisp-transformer` — the transformer's own

--- a/src/check.zig
+++ b/src/check.zig
@@ -135,13 +135,13 @@ fn analyze(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, source: 
 
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
-        addReadError(ctx, err, lc.line, lc.col);
+        addReadError(ctx, arena, err, lc.line, lc.col);
         return;
     }) {
         const datum_lc = r.getLineCol();
         var expr = r.readDatum() catch |err| {
             const lc = r.getLineCol();
-            addReadError(ctx, err, lc.line, lc.col);
+            addReadError(ctx, arena, err, lc.line, lc.col);
             return;
         };
         vm.gc.pushRoot(&expr);
@@ -300,9 +300,16 @@ fn addName(set: *std.StringHashMap(void), arena: std.mem.Allocator, name: []cons
 
 // ── Error findings from read / compile / env-setup ─────────────────────────
 
-fn addReadError(ctx: *check_lint.Context, err: anyerror, line: u32, col: u32) void {
+fn addReadError(ctx: *check_lint.Context, arena: std.mem.Allocator, err: anyerror, line: u32, col: u32) void {
     const code = diagnostics.readErrorCode(err);
-    ctx.addFinding(code, .{ .line = line, .col = col }, code.message());
+    // A malformed-token error (e.g. a digit-led identifier, kaappi#1723) may
+    // carry a detail string; mirror addCompileError's detail-consumption
+    // pattern below, duping into the arena since the threadlocal buffer can
+    // be overwritten by a later read.
+    const detail = reader.getReadErrorDetail();
+    const msg: []const u8 = if (detail.len > 0) (arena.dupe(u8, detail) catch code.message()) else code.message();
+    ctx.addFinding(code, .{ .line = line, .col = col }, msg);
+    reader.resetReadErrorDetail();
 }
 
 fn addCompileError(ctx: *check_lint.Context, arena: std.mem.Allocator, err: anyerror, line: u32, col: u32) void {

--- a/src/diagnostics.zig
+++ b/src/diagnostics.zig
@@ -232,7 +232,13 @@ pub const table = [_]Diagnostic{
         .explanation =
         \\A token that looked like a number could not be parsed as one — for
         \\example a malformed radix prefix (#x, #o, #b, #e, #i), a bad exponent,
-        \\or a rational with a zero denominator.
+        \\or a rational with a zero denominator. It is also raised for a token
+        \\that starts with a digit but is not a valid number, such as '3-state'
+        \\or '5foo': R7RS identifiers can never begin with a digit, so once the
+        \\reader commits to parsing a number on the leading digit, anything left
+        \\glued onto it makes the whole token a malformed number rather than a
+        \\stray character. Rename the identifier, or write it inside '|...|' to
+        \\get a literal symbol instead.
         ,
         .example = "1/0",
     },

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -98,6 +98,23 @@ fn reportUnresolvableLibraryImports(path: []const u8, files: *std.StringHashMap(
     writeStderr(std.fmt.bufPrint(&bundlebuf, "    zig build -Dbundle-src={s}\n", .{path}) catch "");
 }
 
+/// Print a read error the way `toplevel_driver.reportReadError` does, detail
+/// channel included (kaappi#1723) -- kept as its own hand-rolled block since
+/// this native-compile path has no `--diagnostics=json` mode and predates that
+/// consolidation. Shared by both of `emitLlvmFile`'s read-loop error arms.
+fn reportNativeReadError(path: []const u8, line: u32, col: u32, err: anyerror) void {
+    const code = diagnostics.readErrorCode(err);
+    const detail = reader_mod.getReadErrorDetail();
+    const msg = if (detail.len > 0) detail else code.message();
+    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+    var errbuf: [256]u8 = undefined;
+    const prefix = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error[{s}]: ", .{ path, line, col, code.render(&cbuf) }) catch "read error: ";
+    writeStderr(prefix);
+    writeStderr(msg);
+    writeStderr("\n");
+    reader_mod.resetReadErrorDetail();
+}
+
 pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void {
     const allocator = vm.gc.allocator;
 
@@ -181,11 +198,7 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
 
     while (r.hasMore() catch |err| {
         const lc = r.getLineCol();
-        const code = diagnostics.readErrorCode(err);
-        var cbuf: [diagnostics.Code.render_width]u8 = undefined;
-        var errbuf: [256]u8 = undefined;
-        const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error[{s}]: {s}\n", .{ path, lc.line, lc.col, code.render(&cbuf), code.message() }) catch "read error\n";
-        writeStderr(s);
+        reportNativeReadError(path, lc.line, lc.col, err);
         return err;
     }) {
         timings.begin(.read); // kaappi#1515
@@ -193,11 +206,7 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         timings.end();
         const expr = read_result catch |err| {
             const lc = r.getLineCol();
-            const code = diagnostics.readErrorCode(err);
-            var cbuf: [diagnostics.Code.render_width]u8 = undefined;
-            var errbuf: [256]u8 = undefined;
-            const s = std.fmt.bufPrint(&errbuf, "{s}:{d}:{d}: read error[{s}]: {s}\n", .{ path, lc.line, lc.col, code.render(&cbuf), code.message() }) catch "read error\n";
-            writeStderr(s);
+            reportNativeReadError(path, lc.line, lc.col, err);
             return err;
         };
 

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -40,12 +40,17 @@ pub fn resetReadErrorDetail() void {
     read_error_detail_len = 0;
 }
 
+/// A token longer than the buffer overflows this on a pathologically long
+/// malformed identifier (the format string embeds it twice); rather than
+/// trusting `bufPrint`'s failure case to mean "the whole buffer holds valid
+/// output" (it doesn't specify how much of a partial write landed), build the
+/// writer directly and read back exactly how much it actually wrote -- same
+/// pattern as `compiler.formatSyntaxError`. The result is a cleanly truncated
+/// prefix of the intended message, never a partially-overwritten buffer.
 fn setReadErrorDetail(comptime fmt: []const u8, args: anytype) void {
-    const s = std.fmt.bufPrint(&read_error_detail, fmt, args) catch {
-        read_error_detail_len = read_error_detail.len;
-        return;
-    };
-    read_error_detail_len = s.len;
+    var w: std.Io.Writer = .fixed(&read_error_detail);
+    w.print(fmt, args) catch {};
+    read_error_detail_len = w.buffered().len;
 }
 
 pub const Token = union(enum) {
@@ -362,15 +367,23 @@ pub const Reader = struct {
         const start = self.pos;
         const tok = try reader_tokens.readNumber(self);
         if (self.pos < self.source.len and !isDelimiter(self.source[self.pos])) {
-            // The reader already committed to a number on the leading digit, so
-            // a non-delimiter character glued onto it -- `3-state`, `5foo`,
-            // `1.2.3` -- is a malformed *number* literal, not a stray character:
-            // R7RS identifiers can never begin with a digit, so there is no
-            // valid re-interpretation as an identifier either (kaappi#1723).
+            // Only reclassify when the character actually glued onto the number
+            // could continue an identifier (`<subsequent>`, ASCII or Unicode) --
+            // `3-state`, `5foo`, `1.2.3` are malformed number literals, since
+            // R7RS identifiers can never begin with a digit (kaappi#1723). A
+            // character that ISN'T a valid identifier continuation either --
+            // e.g. the backtick in `3\``, or a stray comma -- is unrelated to
+            // that rule and stays the original, accurate UnexpectedChar: an
+            // "identifiers cannot begin with a digit" hint would be nonsensical
+            // for it, and consumeGluedIdentifierChars would consume nothing
+            // anyway, leaving the message describing the number alone as if
+            // that were the problem.
+            const glued_start = self.pos;
+            consumeGluedIdentifierChars(self);
+            if (self.pos == glued_start) return ReadError.UnexpectedChar;
             // Consume the rest of the token so the message can echo it in full,
             // then rewind to the token's start so the reported position is the
             // start of the bad token, not wherever the number scan stopped.
-            consumeGluedIdentifierChars(self);
             setReadErrorDetail(
                 "invalid number literal '{s}': identifiers cannot begin with a digit; use |{s}| for a literal symbol",
                 .{ self.source[start..self.pos], self.source[start..self.pos] },

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -18,6 +18,36 @@ pub const ReadError = error{
     TokenTooLong,
 };
 
+/// Detail message for a read error that needs more than the diagnostics
+/// registry's bare template -- e.g. echoing the offending token. Mirrors the
+/// compiler's `syntax_error_detail` (compiler.zig, KEP-0005/#1504); threadlocal
+/// for the same reason (reading can happen on any thread). `Reader.nextToken`
+/// resets this at the start of every call -- the reader's single token-dispatch
+/// entry point, including the nested calls `skipWhitespaceAndCommentsChecked`
+/// makes for `#;`-datum comments -- so a stale detail from an earlier,
+/// unrelated token can never be misattributed to a later error (kaappi#1723).
+pub threadlocal var read_error_detail: [256]u8 = [_]u8{0} ** 256;
+pub threadlocal var read_error_detail_len: usize = 0;
+
+pub fn getReadErrorDetail() []const u8 {
+    return read_error_detail[0..read_error_detail_len];
+}
+
+/// Clear the channel. Called by a reporter after consuming a detail, mirroring
+/// `compiler.resetCompileErrorSpan` -- defensive belt-and-suspenders alongside
+/// the per-token reset in `nextToken`.
+pub fn resetReadErrorDetail() void {
+    read_error_detail_len = 0;
+}
+
+fn setReadErrorDetail(comptime fmt: []const u8, args: anytype) void {
+    const s = std.fmt.bufPrint(&read_error_detail, fmt, args) catch {
+        read_error_detail_len = read_error_detail.len;
+        return;
+    };
+    read_error_detail_len = s.len;
+}
+
 pub const Token = union(enum) {
     lparen,
     rparen,
@@ -241,6 +271,7 @@ pub const Reader = struct {
     }
 
     pub fn nextToken(self: *Reader) ReadError!Token {
+        read_error_detail_len = 0;
         try self.skipWhitespaceAndCommentsChecked();
         if (self.pos >= self.source.len) return .eof;
 
@@ -328,10 +359,53 @@ pub const Reader = struct {
     const reader_datum = @import("reader_datum.zig");
 
     fn readNumber(self: *Reader) ReadError!Token {
+        const start = self.pos;
         const tok = try reader_tokens.readNumber(self);
-        if (self.pos < self.source.len and !isDelimiter(self.source[self.pos]))
-            return ReadError.UnexpectedChar;
+        if (self.pos < self.source.len and !isDelimiter(self.source[self.pos])) {
+            // The reader already committed to a number on the leading digit, so
+            // a non-delimiter character glued onto it -- `3-state`, `5foo`,
+            // `1.2.3` -- is a malformed *number* literal, not a stray character:
+            // R7RS identifiers can never begin with a digit, so there is no
+            // valid re-interpretation as an identifier either (kaappi#1723).
+            // Consume the rest of the token so the message can echo it in full,
+            // then rewind to the token's start so the reported position is the
+            // start of the bad token, not wherever the number scan stopped.
+            consumeGluedIdentifierChars(self);
+            setReadErrorDetail(
+                "invalid number literal '{s}': identifiers cannot begin with a digit; use |{s}| for a literal symbol",
+                .{ self.source[start..self.pos], self.source[start..self.pos] },
+            );
+            self.pos = start;
+            return ReadError.InvalidNumber;
+        }
         return tok;
+    }
+
+    /// Consume the R7RS `<subsequent>` characters (ASCII or Unicode, matching
+    /// `readSymbol`'s identifier scan) glued onto an already-parsed number
+    /// token. Only called right before raising `InvalidNumber` for such a
+    /// token, purely so its full text can be echoed in the diagnostic
+    /// (kaappi#1723).
+    fn consumeGluedIdentifierChars(self: *Reader) void {
+        while (self.pos < self.source.len) {
+            const c = self.source[self.pos];
+            if (c < 0x80) {
+                if (isSubsequent(c)) {
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            } else {
+                const seq_len = std.unicode.utf8ByteSequenceLength(c) catch break;
+                if (self.pos + seq_len > self.source.len) break;
+                const cp = std.unicode.utf8Decode(self.source[self.pos .. self.pos + seq_len]) catch break;
+                if (isUnicodeSubsequent(cp)) {
+                    self.pos += seq_len;
+                } else {
+                    break;
+                }
+            }
+        }
     }
 
     fn foldAndReturnSymbol(self: *Reader, sym_text: []const u8) ReadError!Token {

--- a/src/tests_diagnostics.zig
+++ b/src/tests_diagnostics.zig
@@ -10,6 +10,8 @@ const std = @import("std");
 const diagnostics = @import("diagnostics.zig");
 const types = @import("types.zig");
 const th = @import("testing_helpers.zig");
+const memory = @import("memory.zig");
+const reader_mod = @import("reader.zig");
 const Code = diagnostics.Code;
 
 test "code renders as KPnnnn" {
@@ -74,6 +76,29 @@ test "reader errors map to read-stage codes with no leak fallback" {
     // An unrecognized reader error still resolves to a real read-stage code
     // rather than leaking the Zig error name.
     try std.testing.expectEqual(Code.unexpected_char, diagnostics.readErrorCode(error.SomeFutureReaderError));
+}
+
+test "digit-led glued identifier reclassifies from KP1002 to KP1004 (kaappi#1723)" {
+    // `3-state` looks like an identifier but R7RS forbids one starting with a
+    // digit, so the reader commits to a number on the leading digit and finds
+    // constituent characters glued onto it. This used to surface as the
+    // generic, miscoded `UnexpectedChar` (KP1002, "unexpected character" --
+    // whose explanation talks about stray '#'-syntax, irrelevant here); it
+    // must now resolve to `InvalidNumber` (KP1004, "invalid number literal").
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var reader = reader_mod.Reader.init(&gc, "3-state");
+    defer reader.deinit();
+    _ = reader.readDatum() catch |err| {
+        try std.testing.expectEqual(reader_mod.ReadError.InvalidNumber, err);
+        const code = diagnostics.readErrorCode(err);
+        try std.testing.expectEqual(Code.invalid_number, code);
+        try std.testing.expect(code != Code.unexpected_char);
+        var buf: [Code.render_width]u8 = undefined;
+        try std.testing.expectEqualStrings("KP1004", code.render(&buf));
+        return;
+    };
+    return error.TestExpectedError; // readDatum should have errored above
 }
 
 test "compile errors map to compile-stage codes" {

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -145,6 +145,82 @@ test "reader: rational with zero denominator" {
     defer reader.deinit();
     const result = reader.readDatum();
     try std.testing.expectError(reader_mod.ReadError.InvalidNumber, result);
+    // The zero-denominator rejection happens after a fully-formed token (no
+    // trailing constituent characters), so it never sets the digit-led-
+    // identifier detail below -- confirm no stale hint leaks in here.
+    try std.testing.expectEqual(@as(usize, 0), reader_mod.getReadErrorDetail().len);
+}
+
+// ---------------------------------------------------------------------------
+// Digit-led identifiers reclassify from KP1002 to KP1004 (kaappi#1723)
+// ---------------------------------------------------------------------------
+//
+// `3-state`, `5foo`, `1.2.3`, `9x` all look like identifiers but R7RS forbids
+// a bare identifier from beginning with a digit, so the reader commits to
+// parsing a number on the leading digit and then finds constituent
+// characters glued onto it. This used to surface as the generic, miscoded
+// `UnexpectedChar` (KP1002); it must now be `InvalidNumber` (KP1004), with
+// the reported position at the token's start and a detail message that
+// echoes the token and explains the rule.
+
+test "reader: digit-led glued identifier reclassifies to InvalidNumber, not UnexpectedChar" {
+    const cases = [_][]const u8{ "3-state", "5foo", "1.2.3", "9x", "-3state" };
+    for (cases) |src| {
+        var gc = memory.GC.init(std.testing.allocator);
+        defer gc.deinit();
+        var reader = reader_mod.Reader.init(&gc, src);
+        defer reader.deinit();
+        const result = reader.readDatum();
+        try std.testing.expectError(reader_mod.ReadError.InvalidNumber, result);
+    }
+}
+
+test "reader: digit-led glued identifier reports the token's start position" {
+    // "(define (3-state x) x)" -- the bad token starts at byte offset 9.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    const src = "(define (3-state x) x)";
+    var reader = reader_mod.Reader.init(&gc, src);
+    defer reader.deinit();
+    _ = reader.readDatum() catch {};
+    // Nothing else advances `pos` past the error: it must sit exactly on the
+    // '3', not on the '-' where the number scan actually stopped.
+    try std.testing.expectEqual(@as(usize, 9), reader.pos);
+    try std.testing.expectEqualStrings("3", src[reader.pos .. reader.pos + 1]);
+}
+
+test "reader: digit-led glued identifier detail echoes the token and the rule" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var reader = reader_mod.Reader.init(&gc, "3-state");
+    defer reader.deinit();
+    const result = reader.readDatum();
+    try std.testing.expectError(reader_mod.ReadError.InvalidNumber, result);
+    const detail = reader_mod.getReadErrorDetail();
+    try std.testing.expect(std.mem.indexOf(u8, detail, "3-state") != null);
+    try std.testing.expect(std.mem.indexOf(u8, detail, "cannot begin with a digit") != null);
+}
+
+test "reader: valid numbers and a piped digit-led symbol are unaffected" {
+    const cases = [_]struct { src: []const u8, is_symbol: bool }{
+        .{ .src = "3", .is_symbol = false },
+        .{ .src = "3-4i", .is_symbol = false },
+        .{ .src = "3e2", .is_symbol = false },
+        .{ .src = "1/2", .is_symbol = false },
+        .{ .src = "-.5", .is_symbol = false },
+        .{ .src = "|3-state|", .is_symbol = true },
+    };
+    for (cases) |c| {
+        var gc = memory.GC.init(std.testing.allocator);
+        defer gc.deinit();
+        var reader = reader_mod.Reader.init(&gc, c.src);
+        defer reader.deinit();
+        const result = try reader.readDatum();
+        if (c.is_symbol) {
+            try std.testing.expect(types.isSymbol(result));
+            try std.testing.expectEqualStrings("3-state", types.symbolName(result));
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -202,25 +202,111 @@ test "reader: digit-led glued identifier detail echoes the token and the rule" {
 }
 
 test "reader: valid numbers and a piped digit-led symbol are unaffected" {
-    const cases = [_]struct { src: []const u8, is_symbol: bool }{
-        .{ .src = "3", .is_symbol = false },
-        .{ .src = "3-4i", .is_symbol = false },
-        .{ .src = "3e2", .is_symbol = false },
-        .{ .src = "1/2", .is_symbol = false },
-        .{ .src = "-.5", .is_symbol = false },
-        .{ .src = "|3-state|", .is_symbol = true },
-    };
-    for (cases) |c| {
+    // Each case asserts the actual expected kind and value, not merely that
+    // reading succeeded -- a regression that read e.g. "3-4i" as some other
+    // datum type would otherwise pass silently.
+    {
         var gc = memory.GC.init(std.testing.allocator);
         defer gc.deinit();
-        var reader = reader_mod.Reader.init(&gc, c.src);
+        var reader = reader_mod.Reader.init(&gc, "3");
         defer reader.deinit();
         const result = try reader.readDatum();
-        if (c.is_symbol) {
-            try std.testing.expect(types.isSymbol(result));
-            try std.testing.expectEqualStrings("3-state", types.symbolName(result));
-        }
+        try std.testing.expect(types.isFixnum(result));
+        try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
     }
+    {
+        var gc = memory.GC.init(std.testing.allocator);
+        defer gc.deinit();
+        var reader = reader_mod.Reader.init(&gc, "3-4i");
+        defer reader.deinit();
+        const result = try reader.readDatum();
+        try std.testing.expect(types.isComplex(result));
+        const c = types.toComplex(result);
+        try std.testing.expectEqual(@as(f64, 3.0), c.real);
+        try std.testing.expectEqual(@as(f64, -4.0), c.imag);
+    }
+    {
+        var gc = memory.GC.init(std.testing.allocator);
+        defer gc.deinit();
+        var reader = reader_mod.Reader.init(&gc, "3e2");
+        defer reader.deinit();
+        const result = try reader.readDatum();
+        try std.testing.expect(types.isFlonum(result));
+        try std.testing.expectEqual(@as(f64, 300.0), types.toFlonum(result));
+    }
+    {
+        var gc = memory.GC.init(std.testing.allocator);
+        defer gc.deinit();
+        var reader = reader_mod.Reader.init(&gc, "1/2");
+        defer reader.deinit();
+        const result = try reader.readDatum();
+        try std.testing.expect(types.isRationalObj(result));
+        const r = types.toRational(result);
+        try std.testing.expectEqual(@as(i64, 1), types.toFixnum(r.numerator));
+        try std.testing.expectEqual(@as(i64, 2), types.toFixnum(r.denominator));
+    }
+    {
+        var gc = memory.GC.init(std.testing.allocator);
+        defer gc.deinit();
+        var reader = reader_mod.Reader.init(&gc, "-.5");
+        defer reader.deinit();
+        const result = try reader.readDatum();
+        try std.testing.expect(types.isFlonum(result));
+        try std.testing.expectEqual(@as(f64, -0.5), types.toFlonum(result));
+    }
+    {
+        var gc = memory.GC.init(std.testing.allocator);
+        defer gc.deinit();
+        var reader = reader_mod.Reader.init(&gc, "|3-state|");
+        defer reader.deinit();
+        const result = try reader.readDatum();
+        try std.testing.expect(types.isSymbol(result));
+        try std.testing.expectEqualStrings("3-state", types.symbolName(result));
+    }
+}
+
+test "reader: a number followed by a non-identifier stray character keeps UnexpectedChar" {
+    // A backtick or comma glued onto a number is not a digit-led-identifier
+    // typo -- consumeGluedIdentifierChars would consume nothing from it, so
+    // the original UnexpectedChar classification (KP1002) must survive, not
+    // a nonsensical "invalid number literal '3': ... cannot begin with a
+    // digit" that both mislabels a valid number and drops the actual
+    // offending character (kaappi#1723 review).
+    const cases = [_][]const u8{ "3`", "3,", "3'" };
+    for (cases) |src| {
+        var gc = memory.GC.init(std.testing.allocator);
+        defer gc.deinit();
+        var reader = reader_mod.Reader.init(&gc, src);
+        defer reader.deinit();
+        const result = reader.readDatum();
+        try std.testing.expectError(reader_mod.ReadError.UnexpectedChar, result);
+        try std.testing.expectEqual(@as(usize, 0), reader_mod.getReadErrorDetail().len);
+    }
+}
+
+test "reader: setReadErrorDetail truncates cleanly instead of leaking stale bytes" {
+    // A malformed token long enough to overflow the 256-byte detail buffer
+    // (the format string embeds the token twice) must truncate to a clean
+    // prefix of the intended message -- never pad the tail with leftover
+    // content from an earlier, unrelated message (kaappi#1723 review).
+    var long_src_buf: [300]u8 = undefined;
+    long_src_buf[0] = '3';
+    @memset(long_src_buf[1..], 'a');
+    const long_src = long_src_buf[0..];
+
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var reader = reader_mod.Reader.init(&gc, long_src);
+    defer reader.deinit();
+    const result = reader.readDatum();
+    try std.testing.expectError(reader_mod.ReadError.InvalidNumber, result);
+    const detail = reader_mod.getReadErrorDetail();
+    try std.testing.expectEqual(@as(usize, 256), detail.len);
+    // Every byte must be part of the intended, well-formed prefix -- the
+    // message starts with the expected literal text and the rest is only
+    // 'a' (from the token) with no embedded NUL or other stray byte.
+    try std.testing.expect(std.mem.startsWith(u8, detail, "invalid number literal '3aaa"));
+    for (detail) |b| try std.testing.expect(b == 'a' or std.ascii.isPrint(b));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const compiler_mod = @import("compiler.zig");
+const reader_mod = @import("reader.zig");
 const reporting = @import("reporting.zig");
 const diagnostics = @import("diagnostics.zig");
 const lsp_diagnostic = @import("lsp_diagnostic.zig");
@@ -65,21 +66,31 @@ fn lspSeverity(code: diagnostics.Code) lsp_diagnostic.Severity {
 
 pub fn reportReadError(source_name: []const u8, line: u32, col: u32, err: anyerror) void {
     const code = diagnostics.readErrorCode(err);
+    // A malformed-token error (e.g. a digit-led identifier, kaappi#1723) may
+    // carry a detail string that echoes the token and explains the rule; a
+    // plain reader failure has none. Prefer it over the bare registry
+    // template when present, same pattern as reportCompileError's `detail`.
+    const detail = reader_mod.getReadErrorDetail();
+    const msg = if (detail.len > 0) detail else code.message();
     var cbuf: [diagnostics.Code.render_width]u8 = undefined;
     if (diagnostic_format == .json) {
         emitJsonLine(.{
             .range = lsp_diagnostic.pointRange(line, col),
             .severity = lspSeverity(code),
             .code = code.render(&cbuf),
-            .message = code.message(),
+            .message = msg,
         });
+        reader_mod.resetReadErrorDetail();
         return;
     }
     var buf: [256]u8 = undefined;
-    const s = std.fmt.bufPrint(&buf, "{s}:{d}:{d}: read error[{s}]: {s}\n", .{
-        source_name, line, col, code.render(&cbuf), code.message(),
-    }) catch "read error\n";
-    writeStderr(s);
+    const prefix = std.fmt.bufPrint(&buf, "{s}:{d}:{d}: read error[{s}]: ", .{
+        source_name, line, col, code.render(&cbuf),
+    }) catch "read error: ";
+    writeStderr(prefix);
+    writeStderr(msg);
+    writeStderr("\n");
+    reader_mod.resetReadErrorDetail();
 }
 
 pub fn reportCompileError(source_name: []const u8, line: u32, col: u32, err: anyerror) void {

--- a/tests/scheme/errors/check.sh
+++ b/tests/scheme/errors/check.sh
@@ -85,6 +85,10 @@ echo "== read / compile errors still surface with KP codes =="
 assert_out "unclosed list is a read error"  'error\[KP1' '(car 1'
 assert_out "malformed if is a compile error" 'error\[KP2' '(if)'
 
+echo "== digit-led identifier reclassifies to KP1004 under check (kaappi#1723) =="
+assert_out "3-state is KP1004, not KP1002"       'error\[KP1004\]' '(define (3-state x) x) x'
+assert_out "3-state message echoes the token"    "invalid number literal '3-state'" '(define (3-state x) x) x'
+
 echo "== --diagnostics=json parity =="
 printf '(car 5)\n' > "$TMP/j.scm"
 JSON="$("$KAAPPI" check --diagnostics=json "$TMP/j.scm" 2>&1 || true)"

--- a/tests/scheme/errors/diagnostics-json.sh
+++ b/tests/scheme/errors/diagnostics-json.sh
@@ -157,6 +157,18 @@ if d is not None:
     check(d["range"]["start"]["line"] == 0 and d["range"]["start"]["character"] > 0,
           "reader error range carries a column", d["range"]["start"])
 
+# A digit-led identifier reclassifies from KP1002 to KP1004 in JSON mode too
+# (kaappi#1723), with the detail message echoing the token and the caret at
+# the token's start -- column 9 (0-based) of "(define (3-state x) x)".
+d = single_diag("digit-led identifier (kaappi#1723)",
+                "(define (3-state x) x)", "KP1", "3-state")
+if d is not None:
+    check(d["code"] == "KP1004", "digit-led identifier is exactly KP1004", d["code"])
+    check("cannot begin with a digit" in d["message"],
+          "digit-led identifier message states the rule", d["message"])
+    check(d["range"]["start"] == {"line": 0, "character": 9},
+          "digit-led identifier caret is at the token start", d["range"]["start"])
+
 # --- Suggestions map to data.suggestions ----------------------------------
 
 d = single_diag("undefined variable",

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -403,6 +403,39 @@ assert_output_contains "index out of bounds is KP3006" \
 assert_output_contains "uncaught user error is KP3000" \
     '(error "boom")' 'error[KP3000]: boom'
 
+# --- Digit-led identifiers reclassify from KP1002 to KP1004 (kaappi#1723) ---
+# `3-state`, `5foo`, `1.2.3`, `9x` all look like identifiers, but R7RS forbids
+# a bare identifier from starting with a digit: the reader commits to a
+# number on the leading digit, then finds characters glued onto it. This used
+# to surface as the generic, miscoded KP1002 "unexpected character" (whose
+# explanation talks about stray '#'-syntax, irrelevant here) with the caret
+# one column past the token's start. It must now be KP1004 "invalid number
+# literal", caret at the token's start, with a detail message that echoes the
+# token and explains the rule.
+echo
+echo "-- Digit-led identifier diagnostics (kaappi#1723) --"
+
+assert_output_contains "3-state is KP1004, not KP1002" \
+    '(define (3-state x) x)' 'read error[KP1004]'
+assert_output_contains "3-state message echoes the token" \
+    '(define (3-state x) x)' "invalid number literal '3-state'"
+assert_output_contains "3-state message states the identifier rule" \
+    '(define (3-state x) x)' 'cannot begin with a digit'
+assert_output_contains "3-state caret is at the token start, not the glued char" \
+    '(define (3-state x) x)' '<stdin>:1:10: read error[KP1004]'
+
+assert_output_contains "5foo is KP1004" '5foo' 'read error[KP1004]'
+assert_output_contains "1.2.3 is KP1004" '1.2.3' 'read error[KP1004]'
+assert_output_contains "9x is KP1004" '9x' 'read error[KP1004]'
+
+# A piped digit-led symbol and ordinary valid numbers are untouched.
+assert_output_contains "|3-state| reads as a symbol, not an error" \
+    "(display '|3-state|)" '3-state'
+assert_output_contains "3-4i still reads as a complex number" \
+    '(display 3-4i)' '3-4i'
+assert_output_contains "1/0 keeps the generic KP1004 message (no stray hint)" \
+    '1/0' 'read error[KP1004]: invalid number literal'
+
 # --- Full source columns: file:line:col (#1506) ---
 # Spans are threaded from the reader through IR into the bytecode line table, so
 # compile and runtime errors now carry a column, not just a line. The column
@@ -501,6 +534,7 @@ assert_no_zig_leak "uncaught user error"     '(error "boom" 1)'
 assert_no_zig_leak "raised non-error value"  '(raise 42)'
 assert_no_zig_leak "ellipsis with no pattern variable (#1791)" \
     '(define-syntax demo (syntax-rules () ((_) (quote (head tok ... tail))))) (demo)'
+assert_no_zig_leak "digit-led identifier (kaappi#1723)" '3-state'
 
 echo
 echo "=== Results ==="

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -436,6 +436,16 @@ assert_output_contains "3-4i still reads as a complex number" \
 assert_output_contains "1/0 keeps the generic KP1004 message (no stray hint)" \
     '1/0' 'read error[KP1004]: invalid number literal'
 
+# A non-identifier character glued onto a number (not an <subsequent> char) is
+# unrelated to the digit-led-identifier rule and must keep the original,
+# accurate KP1002 -- not a nonsensical "invalid number literal '3': ...
+# identifiers cannot begin with a digit" that both mislabels the valid number
+# '3' and drops the actual offending character (review fix).
+assert_output_contains "3 followed by a stray backtick keeps KP1002" \
+    '3`' 'read error[KP1002]'
+assert_output_contains "3 followed by a stray comma keeps KP1002" \
+    '3,' 'read error[KP1002]'
+
 # --- Full source columns: file:line:col (#1506) ---
 # Spans are threaded from the reader through IR into the bytecode line table, so
 # compile and runtime errors now carry a column, not just a line. The column


### PR DESCRIPTION
## Summary

- `3-state`, `5foo`, `1.2.3`, and similar tokens are correctly rejected by
  the reader — R7RS identifiers can never begin with a digit — but were
  miscategorized as the generic `KP1002` ("unexpected character") with no
  hint and the caret one column past the token's actual start.
- The `readNumber` wrapper in `src/reader.zig` now reclassifies this case as
  `KP1004` ("invalid number literal"), consumes the full glued token,
  rewinds to the token's start for accurate caret placement, and sets a new
  threadlocal detail-message channel (mirroring the compiler's
  `syntax_error_detail`) that echoes the offending token and states the
  rule, e.g.:
  `invalid number literal '3-state': identifiers cannot begin with a digit; use |3-state| for a literal symbol`
- Wired the detail through every surface that formats read errors:
  `toplevel_driver.reportReadError` (CLI text + `--diagnostics=json`),
  `kaappi check`, and `kaappi compile`.
- Extended the `KP1004` explanation in the diagnostics registry so `kaappi
  explain KP1004` teaches the new case.
- The detail channel resets at the top of every `nextToken()` call, so a
  stale hint from one read can never leak into a later, unrelated error —
  verified explicitly with an adversarial test (a caught `(read ...)`
  failure followed by an unrelated `1/0` error).

Fixes #1723.

## Test plan

- [x] `zig build test` — full Zig unit suite (1393 tests) passes.
- [x] `bash tests/scheme/run-all.sh` — all 617 Scheme test files and the
      full R7RS suite (1395 tests) pass.
- [x] New Zig unit tests in `src/tests_robustness.zig` and
      `src/tests_diagnostics.zig` cover the reclassification, token-start
      position, detail message content, and that valid numbers (`3`,
      `3-4i`, `3e2`, `1/2`, `-.5`) and a piped symbol (`|3-state|`) are
      unaffected.
- [x] New shell regression cases in `tests/scheme/errors/error-format.sh`,
      `tests/scheme/errors/diagnostics-json.sh`, and
      `tests/scheme/errors/check.sh` cover the CLI text, JSON, and `kaappi
      check` surfaces respectively.
- [x] Manually verified `kaappi`, `kaappi check`, `kaappi compile`, and
      `kaappi explain KP1004` against the issue's exact repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)