### PR TITLE
Close #1828 as not-a-bug: unquoted em-syntax-rules template, not chaining

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,18 +524,26 @@ SRFI 237 — both used the same general shape (a child type's expansion
 queries a parent macro's own protocol for its record-type-descriptor via
 a nested macro call) and both broke once more than one such query
 relationship existed side by side in the same program, isolated to two
-distinct `em-syntax-rules` engine bugs along the way (kaappi#1828, still
-open; kaappi#1829, since fixed). kaappi#1829 turned out not to be an
-expander bug of its own at all: because the CK machine builds its output
-as plain data, a macro-generated top-level `define` lands under its BARE
-name, so the next expansion's own reference to it was a free reference to
-an already-bound non-procedure global — exactly the referential-
-transparency collision of kaappi#1832, which kaappi#1839's hygiene rename
-closed for both;
+apparent `em-syntax-rules` engine bugs along the way (kaappi#1828 and
+kaappi#1829 — both since determined NOT to be engine bugs). kaappi#1829
+turned out not to be an expander bug of its own at all: because the CK
+machine builds its output as plain data, a macro-generated top-level
+`define` lands under its BARE name, so the next expansion's own reference
+to it was a free reference to an already-bound non-procedure global —
+exactly the referential-transparency collision of kaappi#1832, which
+kaappi#1839's hygiene rename closed for both;
 `tests/scheme/hygiene/macro-fresh-global-readback-1829.scm` guards that
-shape directly. The third, shipped design avoids the whole pattern
-regardless (kaappi#1828 alone still rules the query-macro approach out):
-the type name is bound directly to an ordinary runtime record-type-
+shape directly. kaappi#1828 also turned out not to be an engine bug: its
+own repro's final (non-`=>`) template was left unquoted while calling an
+ordinary procedure, which SRFI 148's own spec documents as an error case,
+unrelated to the "bound variable as a later step's operator" framing it
+was filed under — `lib/srfi/148.sld`'s header and
+`tests/scheme/hygiene/em-syntax-rules-operator-chain-1828.scm` confirm the
+operator-position mechanism itself works correctly, including 3 levels of
+chaining. Whether the two rejected attempts above would have succeeded
+without this same misunderstanding is not re-tested. The third, shipped
+design avoids the whole query-macro pattern regardless, so it is unaffected
+either way: the type name is bound directly to an ordinary runtime record-type-
 descriptor exactly as in SRFI 131 (inheritance and field/accessor/
 mutator resolution, including multi-level shadowing, handled entirely at
 run time by SRFI 237's own by-name introspection), and the one piece

--- a/lib/srfi/148.sld
+++ b/lib/srfi/148.sld
@@ -60,6 +60,29 @@
 ;;         #t regardless of actual set equality. The reference's own
 ;;         test.sld has zero test cases for em-set=, unlike every sibling
 ;;         set operation -- presumably why this was never caught.
+;;
+;; A gotcha worth documenting explicitly (issue #1828, closed as not-a-bug):
+;; a rule's FINAL (non-`=>`) template, if left unquoted, is not free-form
+;; output -- the spec is explicit that "If the top-level template is an
+;; unquoted template <template>, the macro use is expanded as if it was a
+;; syntax-rules macro. It is an error if the expanded output is not an
+;; eager macro use (or a self-quoting syntax element)." Writing an unquoted
+;; final template that calls an ordinary procedure (e.g. `(display
+;; (list a b c))`, calling `display`, which is not an eager macro) is
+;; exactly that documented error case: `em-syntax-rules-aux2`'s generated
+;; `ck` dispatch (below) unconditionally treats an unquoted template's head
+;; as an eager-macro operator needing the `:prepare`/`:call` protocol, so a
+;; non-eager operator surfaces as a confusing `undefined variable
+;; ':prepare'` instead of a clear diagnostic -- easy to misread as a bug in
+;; chained `=>` step handling (issue #1828's own framing: "a variable bound
+;; by one => step can't be used as the operator of a later chained =>
+;; step"), especially since the failure looks identical whether or not any
+;; `=>` chaining is involved at all. Quoting the final template (or
+;; ensuring an unquoted one reduces to another eager macro use or a bare
+;; self-quoting atom) is the fix -- verified working, including a bound
+;; variable used as the OPERATOR of a later chained step, at both 2 and 3
+;; levels of nesting: see
+;; tests/scheme/hygiene/em-syntax-rules-operator-chain-1828.scm.
 (define-library (srfi 148)
   (export em-syntax-rules
 

--- a/lib/srfi/150.sld
+++ b/lib/srfi/150.sld
@@ -10,14 +10,14 @@
 ;;;
 ;;; NOT a port of the reference implementation, and not this codebase's
 ;;; second implementation attempt either -- see issue #1810's own
-;;; investigation notes for the two prior attempts and the general kaappi
-;;; engine bugs they surfaced (kaappi#1828, still open; kaappi#1829, since
-;;; fixed): every design built on a macro that answers a hygienic-metadata
-;;; QUERY from a later, separate define-record-type expansion (the
-;;; reference's own SRFI 137 `make-subtype` closures; this codebase's first
-;;; rewrite, a `:secret` descriptor macro over SRFI 237) breaks once more
-;;; than one such query relationship exists side by side in the same
-;;; program.
+;;; investigation notes for the two prior attempts and two apparent kaappi
+;;; engine bugs they surfaced along the way (kaappi#1828 and kaappi#1829 --
+;;; both since determined NOT to be engine bugs, see below): every design
+;;; built on a macro that answers a hygienic-metadata QUERY from a later,
+;;; separate define-record-type expansion (the reference's own SRFI 137
+;;; `make-subtype` closures; this codebase's first rewrite, a `:secret`
+;;; descriptor macro over SRFI 237) broke once more than one such query
+;;; relationship existed side by side in the same program.
 ;;;
 ;;; kaappi#1829's own minimal, record-free `em-syntax-rules` repro no
 ;;; longer fails: it was not an expander bug at all but the referential-
@@ -26,9 +26,19 @@
 ;;; lands under its BARE name and the next expansion's reference to it is
 ;;; a free reference to an already-bound global. kaappi#1839's hygiene
 ;;; rename closed it (see tests/scheme/hygiene/
-;;; macro-fresh-global-readback-1829.scm). kaappi#1828 is untouched by
-;;; that fix and on its own still rules the query-macro approach out, so
-;;; nothing below changes.
+;;; macro-fresh-global-readback-1829.scm).
+;;;
+;;; kaappi#1828 also turned out not to be an engine bug: its own repro's
+;;; final (non-`=>`) template was unquoted and called an ordinary
+;;; procedure, which SRFI 148's own spec documents as an error case
+;;; (unrelated to the reported "bound variable as a later step's operator"
+;;; framing -- see lib/srfi/148.sld's header and
+;;; tests/scheme/hygiene/em-syntax-rules-operator-chain-1828.scm, which
+;;; confirms the operator-position mechanism itself works correctly,
+;;; including at 3 levels of chaining). Whether the two rejected
+;;; implementation attempts above would have succeeded had they not tripped
+;;; over this same misunderstanding is not re-tested here -- this file's
+;;; own (third) design is unaffected either way, so nothing below changes.
 ;;;
 ;;; This THIRD implementation avoids the whole pattern: it never threads
 ;;; anything across separate define-record-type expansions via a macro
@@ -54,8 +64,9 @@
 ;;;     parent's via `lookup`. SRFI 213's property table is a plain,
 ;;;     direct VM-level key-value store (`vm.syntax_properties`), entirely
 ;;;     bypassing the expander's own macro-to-macro call/argument-
-;;;     threading machinery that kaappi#1828 is a bug in -- confirmed safe
-;;;     for repeated, independent inheritance chains during this SRFI's own
+;;;     threading machinery that kaappi#1828 was originally suspected of
+;;;     being a bug in (see above) -- confirmed safe for repeated,
+;;;     independent inheritance chains during this SRFI's own
 ;;;     investigation (a record-free prototype using this exact mechanism,
 ;;;     mirroring kaappi#1829's own failing shape, produces correct
 ;;;     results).

--- a/tests/scheme/hygiene/em-syntax-rules-operator-chain-1828.scm
+++ b/tests/scheme/hygiene/em-syntax-rules-operator-chain-1828.scm
@@ -1,0 +1,90 @@
+;; Regression test for #1828 -- NOT a bug, but locks in the (already
+;; correct) behavior the issue mistakenly reported as broken.
+;;
+;; Issue #1828 claimed that a variable bound by one `=>` step in an
+;; `em-syntax-rules` (SRFI 148) macro could not be used as the OPERATOR of
+;; a later chained `=>` step's expression -- e.g. binding `the-rtd` in step
+;; 1 and calling `(the-rtd ':secret)` in step 2. The reported repro failed
+;; with `undefined variable ':prepare'`.
+;;
+;; Root cause: the repro's own FINAL (non-`=>`) template was UNQUOTED --
+;; `(display (list a b c))` -- and called an ordinary procedure (`display`),
+;; not an eager macro. SRFI 148's own spec is explicit that an unquoted
+;; top-level template "is expanded as if it was a syntax-rules macro. It
+;; is an error if the expanded output is not an eager macro use (or a
+;; self-quoting syntax element)" -- so a compound call to a non-eager
+;; procedure is documented, spec-level invalid input, not an engine bug.
+;; `:prepare` leaking as an "undefined variable" is a confusing diagnostic
+;; for that documented error case (see lib/srfi/148.sld's header for the
+;; `ck`-dispatch mechanism this falls out of), but it is not the "operator
+;; position" bug the issue described.
+;;
+;; Confirmed by taking the issue's EXACT repro and changing ONLY the final
+;; template from `(display (list a b c))` to `'(list a b c)` (quoting it,
+;; per spec Case 1): it then runs correctly and evaluates to `(1 2 3)`,
+;; exactly the issue's own stated expectation. This file locks that in --
+;; both at the issue's own 2-level nesting and at a deeper 3-level chain,
+;; the shape closer to SRFI 150's actual `parse-type-spec` ->
+;; `parse-predicate-spec` -> `parent-rtd` usage that motivated the report
+;; (see lib/srfi/150.sld's header) -- as a permanent regression test.
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 64) (srfi 148))
+
+(test-begin "em-syntax-rules-operator-chain-1828")
+
+;; --- 2-level chain: the issue's own shape, final template quoted -------
+(define-syntax :secret
+  (syntax-rules () ((_ . args) (syntax-error "internal: :secret misused"))))
+
+(define-syntax descriptor
+  (em-syntax-rules ::: ()
+    ((descriptor ':secret) '(1 2 3))
+    ((descriptor 'arg :::) (em-error "invalid use"))))
+
+(define-syntax identity
+  (em-syntax-rules ()
+    ((identity 'x) 'x)))
+
+;; Two chained => steps: the first destructures `the-rtd` from an eager
+;; macro call; the second uses `the-rtd` (bound by the FIRST step) as the
+;; OPERATOR of its own step-expression -- exactly issue #1828's shape.
+(define-syntax test-chain
+  (em-syntax-rules ()
+    ((test-chain name)
+     ((identity 'name) => 'the-rtd)
+     ((the-rtd ':secret) => '(a b c))
+     '(list a b c))))
+
+(test-equal "operator-position chain (issue #1828's own shape, quoted template)"
+  '(1 2 3)
+  (test-chain descriptor))
+
+;; --- 3-level chain: each step's bound variable is the NEXT step's ------
+;; operator, one level deeper than the issue's repro.
+(define-syntax stage-a
+  (em-syntax-rules ()
+    ((stage-a ':secret) 'stage-b)))
+
+(define-syntax stage-b
+  (em-syntax-rules ()
+    ((stage-b ':secret) 'stage-c)))
+
+(define-syntax stage-c
+  (em-syntax-rules ()
+    ((stage-c ':secret) '42)))
+
+(define-syntax three-level-chain
+  (em-syntax-rules ()
+    ((three-level-chain start)
+     ((start ':secret) => 'next1)
+     ((next1 ':secret) => 'next2)
+     ((next2 ':secret) => 'result)
+     'result)))
+
+(test-equal "3-level operator-position chain"
+  42
+  (three-level-chain stage-a))
+
+(let ((runner (test-runner-current)))
+  (test-end "em-syntax-rules-operator-chain-1828")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Issue #1828 claimed a variable bound by one `=>` step in `em-syntax-rules` (SRFI 148) couldn't be used as the operator of a later chained `=>` step, citing `undefined variable ':prepare'`. This investigation found **no engine bug**: the repro's own final (non-`=>`) template was unquoted and called an ordinary procedure (`display`), which SRFI 148's own spec documents as an error case ("It is an error if the expanded output is not an eager macro use or a self-quoting syntax element"). The issue's exact repro, with only the final template quoted, runs correctly. See the closing comment on #1828 for the full evidence trail.

- Adds `tests/scheme/hygiene/em-syntax-rules-operator-chain-1828.scm`, locking in the correct (already-working) chained-operator-position behavior at 2 and 3 levels of nesting.
- Adds a note to `lib/srfi/148.sld`'s header documenting the unquoted-top-level-template constraint as a gotcha.
- Corrects three places (`lib/srfi/148.sld`, `lib/srfi/150.sld`, `CLAUDE.md`) that cited #1828 as a confirmed, still-open engine bug that ruled out a design approach for SRFI 150 — without asserting that approach would now work, since that's untested and out of scope here.

No changes to `em-syntax-rules-aux1`/`aux2`/`ck` — the mechanism is correct as written.

Closes #1828.

## Test plan

- [x] `zig build test` — clean
- [x] `bash tests/scheme/run-all.sh` — 2013 pass / 0 fail (up from 2011; new test file picked up)
- [x] New test run standalone: `./zig-out/bin/kaappi tests/scheme/hygiene/em-syntax-rules-operator-chain-1828.scm` — 2 pass
- [x] `npx markdownlint-cli2 CLAUDE.md` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)