### PR TITLE
Add /create-announcement skill for release announcements

### DIFF
--- a/.claude/skills/create-announcement/SKILL.md
+++ b/.claude/skills/create-announcement/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: create-announcement
+description: Post a release announcement to the kaappi org Announcements forum (github.com/orgs/kaappi/discussions). Use when the user asks to announce a release, post a release announcement, tell the community about a version, or share a release on the forum. Takes a release tag such as v0.22.0.
+argument-hint: "[tag]"
+---
+
+# Create Announcement
+
+Draft and post a release announcement to
+<https://github.com/orgs/kaappi/discussions/categories/announcements>.
+
+## Where this actually posts
+
+Org-level discussions at `github.com/orgs/kaappi/discussions` are **backed by
+the `kaappi/kaappi` repository** — there is no separate discussions repo. Create
+the discussion in `kaappi/kaappi`; GitHub serves it at the `orgs/kaappi` URL.
+
+| Thing | Value |
+|-------|-------|
+| Repo | `kaappi/kaappi` (id `R_kgDOS7a-eg`) |
+| Category | `Announcements` (id `DIC_kwDOS7a-es4C_rmH`) |
+| Other categories | `general`, `ideas`, `polls`, `q-a`, `show-and-tell` |
+
+Announcements is a **maintainer-restricted** category. A token without write
+access to `kaappi/kaappi` will fail at Step 6, not earlier.
+
+## Who this is for
+
+The release page already carries the exhaustive CHANGELOG. The announcement is
+**not** a second copy of it — it is the short, human version for people who
+use Kaappi rather than build it. Write for someone who wants to know, in
+thirty seconds, whether this release is worth upgrading for.
+
+## Step 0: Resolve the tag
+
+The argument is a release tag (`v0.22.0`). If none was given, use the latest
+release and **say which tag you resolved to** before doing any work:
+
+```bash
+gh release list -R kaappi/kaappi --limit 5
+```
+
+## Step 1: Preflight
+
+```bash
+gh auth status
+TAG=v0.22.0    # the resolved tag
+gh release view "$TAG" -R kaappi/kaappi --json tagName,publishedAt,url,isDraft,isPrerelease
+```
+
+Stop and ask the user if any of these hold:
+
+- The release does not exist — the tag may be pushed but the release workflow
+  still running. Check `gh run list --workflow=release.yml --limit=1`.
+- `isDraft` or `isPrerelease` is true. Announcing an unpublished or pre-release
+  build is almost always a mistake; confirm it is deliberate.
+- **The release is more than about a week old, or `CHANGELOG.md`'s
+  `[Unreleased]` section has substantial content.** Both are signs the next
+  release is near, and announcing the older one may not be what the user wants.
+  Do not decide this yourself — surface it and let them choose:
+
+  ```bash
+  sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | wc -l
+  ```
+
+## Step 2: Check for an existing announcement
+
+Re-running this skill must not double-post.
+
+```bash
+gh discussion list -R kaappi/kaappi --category "Announcements" \
+  --limit 30 --json number,title,url
+```
+
+If one already covers `$TAG`, do not create a second. Show it to the user and
+offer to edit it instead (see "Editing an already-posted announcement" below).
+
+## Step 3: Gather source material
+
+> **Authoring note — never write a dollar sign followed by a digit in a shell
+> snippet in this file.** Slash-command argument expansion rewrites those tokens
+> *before* the skill body is read, and the numbering is zero-indexed: a dollar
+> sign followed by zero becomes this invocation's **first** argument — the tag.
+> An `awk` field-variable comparison therefore arrives with the tag spliced in
+> where the field reference was and matches nothing: no error, just a silently
+> empty result. This skill always takes an argument, so that slot is live on
+> every run. (Described in prose deliberately — written literally, this note
+> would rewrite itself.) Named variables (`$TAG`, `$PREV`), `$@`, `$*`, and the
+> braced `${1}` form all pass through untouched. Prefer `git describe` or `grep`
+> over `awk` field variables, as below. Full measured rules:
+> [claude-code-harness.md](../../../docs/dev/claude-code-harness.md).
+
+```bash
+git fetch --tags --quiet
+PREV=$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null)
+echo "previous tag: $PREV"
+
+# Save the release body — it is long (v0.21.0's was 193 lines), and having it
+# on disk lets you re-read sections while drafting without refetching.
+gh release view "$TAG" -R kaappi/kaappi --json body --jq .body > /tmp/rel-body.md
+grep -n '^#\{2,4\} ' /tmp/rel-body.md    # section map, to orient before reading
+
+# Scale of the release, and which platforms shipped
+git log "$PREV..$TAG" --oneline --no-merges | wc -l
+gh release view "$TAG" -R kaappi/kaappi --json assets --jq '.assets[].name'
+```
+
+Read the release body **in full** before drafting — the section map alone is not
+enough to judge what matters, and the highest-impact item is often filed under
+"Fixed" rather than "Added". Cross-check anything ambiguous against
+`CHANGELOG.md` in the worktree; the release body is generated from it.
+
+## Step 4: Draft the announcement
+
+### Choosing highlights
+
+Pick **3–6**. The filter is *what can a user do now that they could not
+before*, not *what changed*.
+
+**Headline-worthy:**
+
+- New user-facing capability — a subcommand, a CLI flag, a language feature.
+- A new platform or architecture in the release assets.
+- A group of new SRFIs — collapse the family into **one** bullet naming them,
+  never one bullet each.
+- A fix for a bug that plausibly bit real users (wrong answers, crashes,
+  install failures), stated as the corrected behavior rather than the defect.
+- A performance change large enough to notice.
+
+**Not headline-worthy:** internal refactors, file splits, test or CI
+infrastructure, doc-only changes, harness changes, fixes to bugs that only
+existed on an unreleased branch.
+
+### Title
+
+```text
+Kaappi vX.Y.Z — <3–6 word theme>
+```
+
+Use `Kaappi vX.Y.Z released` when the release has no coherent theme. Do not
+stretch for one.
+
+### Body
+
+````markdown
+**Kaappi vX.Y.Z is out.** <One sentence on what this release is mostly about.>
+
+## Highlights
+
+- **<Capability>** — <one sentence on what it lets you do.>
+- **<Capability>** — <…>
+
+## Install or upgrade
+
+```bash
+curl -fsSL https://kaappi-lang.org/install.sh | bash
+```
+
+Binaries for every supported platform are on the
+[release page](<release URL>); see [Download](https://kaappi-lang.org/download/)
+for checksums and manual install.
+
+## Full notes
+
+[Complete changelog for vX.Y.Z](<release URL>)
+
+---
+
+Questions in [Q&A](https://github.com/orgs/kaappi/discussions/categories/q-a),
+feature ideas in [Ideas](https://github.com/orgs/kaappi/discussions/categories/ideas),
+and if you have built something with Kaappi we would like to see it in
+[Show and tell](https://github.com/orgs/kaappi/discussions/categories/show-and-tell).
+````
+
+### Accuracy rules
+
+This is public, permanent, and signed with the maintainer's name.
+
+- **Every claim traces to the release body or CHANGELOG.** Do not infer a
+  feature from a commit subject, and do not describe what a change "means for
+  users" beyond what the notes state.
+- **No invented numbers.** Benchmark figures, procedure counts, and SRFI counts
+  are quoted from the notes or omitted. Counting items the notes themselves list
+  ("seven new SRFIs") is fine; deriving a figure they do not state is not.
+- **Issue numbers belong in the changelog, not the announcement** — link the
+  release page instead.
+- Plain language. No superlatives the notes do not support.
+
+### Verify every link — before Step 5, not after
+
+A broken link is trivial to fix now and embarrassing once posted. The release
+URL comes from `gh release view --json url`, never from memory. Write the body
+to a file, then check every link in it actually resolves:
+
+```bash
+grep -oE 'https://[^)[:space:]]+' /path/to/announcement.md \
+  | sed 's/[.,;:]*$//' | sort -u | while read -r u; do
+  printf '%s  %s\n' "$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 20 "$u")" "$u"
+done
+```
+
+Every line must read `200`. Fix anything that does not before showing the draft.
+
+The character class must exclude whitespace as well as `)`, and trailing
+punctuation must be stripped: the body contains
+`curl -fsSL https://kaappi-lang.org/install.sh | bash` inside a fence, and a
+laxer pattern swallows the trailing `| bash` and reports a spurious `000` for a
+URL that is fine.
+
+## Step 5: Review with the user — STOP
+
+Show the full title and body and **wait for explicit approval**. This step is
+not optional: posting publishes public content under the user's account in a
+maintainer-only category, and it notifies every watcher of the org.
+
+Ask directly whether to post it. Revise and re-show as many times as needed.
+Do not proceed on silence or on an ambiguous reply.
+
+## Step 6: Post
+
+Only after an explicit yes. Write the body to a file first — passing multi-line
+markdown through `--body` mangles backticks and newlines:
+
+```bash
+gh discussion create -R kaappi/kaappi \
+  --category "Announcements" \
+  --title "Kaappi vX.Y.Z — <theme>" \
+  --body-file /path/to/announcement.md
+```
+
+`gh discussion` is a preview command. If it is missing or errors out, use the
+GraphQL mutation directly — the ids are fixed and listed at the top of this
+skill:
+
+```bash
+gh api graphql -F body=@/path/to/announcement.md \
+  -f title="Kaappi vX.Y.Z — <theme>" \
+  -f query='
+mutation($title: String!, $body: String!) {
+  createDiscussion(input: {
+    repositoryId: "R_kgDOS7a-eg",
+    categoryId: "DIC_kwDOS7a-es4C_rmH",
+    title: $title,
+    body: $body
+  }) { discussion { number url } }
+}'
+```
+
+## Step 7: Verify
+
+```bash
+gh discussion view <number> -R kaappi/kaappi
+```
+
+Report the `github.com/orgs/kaappi/discussions/<number>` URL to the user. Links
+were already checked in Step 4; what this pass catches is rendering — a fenced
+block that swallowed the text after it, or a heading that did not survive the
+round trip. Anything wrong is fixable in place via `gh discussion edit`.
+
+Pinning cannot be automated — there is no `gh discussion pin` and no
+`pinDiscussion` GraphQL mutation (verified against the live schema). If the
+user wants it pinned, point them at the "Pin discussion" control in the
+sidebar of the discussion page.
+
+## Editing an already-posted announcement
+
+```bash
+gh discussion edit <number> -R kaappi/kaappi --body-file /path/to/revised.md
+gh discussion edit <number> -R kaappi/kaappi --title "New title"
+```
+
+Editing is silent — watchers are not re-notified. For a correction that matters
+(a wrong version number, a broken install command), also add a comment so
+people who already read it see the fix:
+
+```bash
+gh discussion comment <number> -R kaappi/kaappi --body "Correction: …"
+```
+
+## Announcing something that is not a release
+
+The flow assumes a release tag. For anything else — a new ecosystem library, a
+docs milestone, a call for testing — skip Steps 0–3 and gather the material
+from whatever the subject actually is, then follow Steps 4–7 unchanged. Keep
+the same structure minus the "Install or upgrade" and "Full notes" sections.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---------|-------|
+| `Could not resolve to a Repository` | Token lacks access to `kaappi/kaappi`. |
+| `Category not found` | Slug is `announcements`; the display name is `Announcements`. Both work with `--category`. |
+| Discussion created but not at the `orgs/` URL | It will be — the org view and the repo view are the same discussion. |
+| Release body is empty | The release workflow generated notes from an empty `[Unreleased]` section. Fix the release, not the announcement. |
+| A shell snippet from this file behaves as if a variable were empty | A positional parameter (dollar sign plus digit, `@`, or `*`) in the snippet was replaced by the slash-command arguments before you read it. See the authoring note in Step 3. |

--- a/.claude/skills/create-announcement/SKILL.md
+++ b/.claude/skills/create-announcement/SKILL.md
@@ -21,8 +21,10 @@ the discussion in `kaappi/kaappi`; GitHub serves it at the `orgs/kaappi` URL.
 | Category | `Announcements` (id `DIC_kwDOS7a-es4C_rmH`) |
 | Other categories | `general`, `ideas`, `polls`, `q-a`, `show-and-tell` |
 
-Announcements is a **maintainer-restricted** category. A token without write
-access to `kaappi/kaappi` will fail at Step 6, not earlier.
+Announcements is a **maintainer-restricted** category, and `kaappi/kaappi` is
+public — so a read-only token sails through Steps 1 and 2 (both are public
+reads) and fails only at Step 6, on the write. A token that cannot authenticate
+at all fails earlier, at the `gh auth status` in Step 1.
 
 ## Who this is for
 
@@ -67,13 +69,19 @@ Stop and ask the user if any of these hold:
 
 Re-running this skill must not double-post.
 
+Search for the tag rather than listing the newest N. A plain `--limit 30` only
+inspects the 30 most recent announcements, which is exactly wrong for the case
+that needs the check most — announcing an *older* release, where any duplicate
+is by definition not among the newest:
+
 ```bash
 gh discussion list -R kaappi/kaappi --category "Announcements" \
-  --limit 30 --json number,title,url
+  --search "$TAG" --json number,title,url
 ```
 
-If one already covers `$TAG`, do not create a second. Show it to the user and
-offer to edit it instead (see "Editing an already-posted announcement" below).
+`totalCount: 0` means none exists. Any hit means one already covers `$TAG` — do
+not create a second. Show it to the user and offer to edit it instead (see
+"Editing an already-posted announcement" below).
 
 ## Step 3: Gather source material
 
@@ -193,7 +201,7 @@ URL comes from `gh release view --json url`, never from memory. Write the body
 to a file, then check every link in it actually resolves:
 
 ```bash
-grep -oE 'https://[^)[:space:]]+' /path/to/announcement.md \
+grep -oE 'https://[^)>"[:space:]]+' /path/to/announcement.md \
   | sed 's/[.,;:]*$//' | sort -u | while read -r u; do
   printf '%s  %s\n' "$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 20 "$u")" "$u"
 done
@@ -201,11 +209,14 @@ done
 
 Every line must read `200`. Fix anything that does not before showing the draft.
 
-The character class must exclude whitespace as well as `)`, and trailing
-punctuation must be stripped: the body contains
-`curl -fsSL https://kaappi-lang.org/install.sh | bash` inside a fence, and a
-laxer pattern swallows the trailing `| bash` and reports a spurious `000` for a
-URL that is fine.
+The character class is fussy for two measured reasons, so do not simplify it.
+Excluding whitespace and stripping trailing punctuation stops the body's
+`curl -fsSL https://kaappi-lang.org/install.sh | bash` fence from contributing a
+URL with the trailing `| bash` glued to it. Excluding `>` and `"` stops an
+angle-bracket
+autolink — `<https://kaappi-lang.org/download/>` — from contributing one with a
+trailing `>`. Both produce a spurious `000` for a URL that is perfectly fine,
+which is worse than useless: it blocks approval on a phantom defect.
 
 ## Step 5: Review with the user — STOP
 
@@ -228,9 +239,23 @@ gh discussion create -R kaappi/kaappi \
   --body-file /path/to/announcement.md
 ```
 
-`gh discussion` is a preview command. If it is missing or errors out, use the
-GraphQL mutation directly — the ids are fixed and listed at the top of this
-skill:
+`gh discussion` is a preview command. If it is missing or errors out, there is a
+GraphQL fallback below — but **re-check for the discussion before running it.**
+
+`createDiscussion` is a non-idempotent write. A non-zero exit from
+`gh discussion create` does not prove nothing was posted: a lost response (the
+mutation reached GitHub and succeeded, the reply did not make it back) looks
+identical to an outright failure from here. Firing the fallback blindly is how
+you get two public announcements and two rounds of watcher notifications.
+
+```bash
+gh discussion list -R kaappi/kaappi --category "Announcements" \
+  --search "$TAG" --json number,title,url
+```
+
+If that returns anything, the post *did* land — go to Step 7 with that number
+and do not run the mutation. Only on `totalCount: 0` use the fallback; the ids
+are fixed and listed at the top of this skill:
 
 ```bash
 gh api graphql -F body=@/path/to/announcement.md \
@@ -292,4 +317,4 @@ the same structure minus the "Install or upgrade" and "Full notes" sections.
 | `Category not found` | Slug is `announcements`; the display name is `Announcements`. Both work with `--category`. |
 | Discussion created but not at the `orgs/` URL | It will be — the org view and the repo view are the same discussion. |
 | Release body is empty | The release workflow generated notes from an empty `[Unreleased]` section. Fix the release, not the announcement. |
-| A shell snippet from this file behaves as if a variable were empty | A positional parameter (dollar sign plus digit, `@`, or `*`) in the snippet was replaced by the slash-command arguments before you read it. See the authoring note in Step 3. |
+| A shell snippet from this file produced a wrong or empty result | A dollar sign followed by a digit in the snippet was replaced by one of this invocation's arguments before you read it. Only that form is affected — `$@`, `$*`, and the braced form are not. See the authoring note in Step 3. |

--- a/.claude/skills/do-gate-benchmark/SKILL.md
+++ b/.claude/skills/do-gate-benchmark/SKILL.md
@@ -239,7 +239,7 @@ solely on the self-destruct timer.
 
 ## Notes
 
-- **Cost**: `s-8vcpu-16gb-intel` is ~$0.167/hr — even a generously
+- **Cost**: `s-8vcpu-16gb-intel` is ~USD 0.167/hr — even a generously
   over-budgeted 12–15 hour run is only a few dollars.
 - **Sequential execution**: `run-gate.py`'s invocation loop is strictly
   sequential (one subprocess at a time, each internally using up to `w`

--- a/.claude/skills/do-linux-test/SKILL.md
+++ b/.claude/skills/do-linux-test/SKILL.md
@@ -221,7 +221,7 @@ so they can destroy it manually via the DigitalOcean console.
 
 ## Notes
 
-- **Cost**: `s-2vcpu-4gb` is ~$0.03/hr. A full test run takes 10–15 minutes
+- **Cost**: `s-2vcpu-4gb` is ~USD 0.03/hr. A full test run takes 10–15 minutes
   (the compile tests rebuild the full binary, which is slow on 2 vCPUs).
 - **SSH key**: uses `~/.ssh/id_rsa`. The matching public key must be on the
   DigitalOcean account (upload via web console → Settings → Security).

--- a/.claude/skills/do-stress-test/SKILL.md
+++ b/.claude/skills/do-stress-test/SKILL.md
@@ -272,8 +272,8 @@ they can destroy it manually via the DigitalOcean console.
 
 ## Notes
 
-- **Cost**: `c5-4vcpu-8gb` is ~$0.185/hr → a full 3-hour window costs
-  ~$0.56. Faster per-core speed typically cuts the run to ~1–1.5h, so
+- **Cost**: `c5-4vcpu-8gb` is ~USD 0.185/hr → a full 3-hour window costs
+  ~USD 0.56. Faster per-core speed typically cuts the run to ~1–1.5h, so
   actual cost is comparable to the cheaper shared-CPU droplets.
 - **Why hours**: with a collection attempted on every allocation, each test's
   VM bootstrap alone performs tens of thousands of full collections. ~40 min

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1283,6 +1283,7 @@ detailed checklists for GC write barriers, rooting, and compiler form additions.
 | `/audit-primitives` | Audit a primitives file for R7RS correctness — writes tests, runs them, fixes bugs |
 | `/bytecode-isa` | Reference for the bytecode instruction set |
 | `/github-release` | Full release workflow (version bump, changelog, tag, push, CI verification) |
+| `/create-announcement` | Draft and post a release announcement to the org Announcements forum (takes a release tag) |
 | `/r7rs-reader` | R7RS lexical syntax reference for reader changes |
 | `/linux-test` | Build and test on Linux via podman (aarch64, x86_64, riscv64) |
 | `/do-linux-test` | Full test suite on real x86-64 Linux via DigitalOcean droplet |

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -246,6 +246,30 @@ Full release workflow with 10 steps and multiple confirmation gates:
 
 Includes error recovery procedures for both pre-push and post-push failures.
 
+### `/create-announcement`
+
+Drafts and posts a release announcement to the org Announcements forum at
+<https://github.com/orgs/kaappi/discussions/categories/announcements>. Takes a
+release tag (`/create-announcement v0.22.0`), defaulting to the latest release.
+
+The non-obvious fact the skill records: **org-level discussions are backed by
+the `kaappi/kaappi` repository** — the `.github` repo has discussions disabled,
+so the discussion is created in `kaappi/kaappi` and GitHub serves it at the
+`orgs/kaappi` URL. Repo and category ids are pinned in the skill for the
+GraphQL fallback, since `gh discussion` is still a preview command.
+
+Seven steps: resolve the tag, preflight (`gh auth`, release exists and is
+neither draft nor prerelease), check the category for an existing announcement
+so a re-run cannot double-post, gather material (release body, previous tag,
+commit count, shipped assets), draft, **stop for explicit approval**, post and
+verify. The approval gate is mandatory — posting publishes public content in a
+maintainer-restricted category and notifies every org watcher.
+
+Carries the editorial half too: how to pick 3–6 highlights (what a user can now
+*do*, not what changed — internal refactors and CI work are explicitly out), a
+title and body template, and accuracy rules requiring every claim to trace to
+the release notes.
+
 ### `/r7rs-reader`
 
 R7RS lexical syntax reference (Section 7.1). Documents implemented token types,
@@ -480,3 +504,42 @@ changes were made.
 Create a directory in `.claude/skills/<name>/` with a `SKILL.md` file.
 The directory name becomes the slash-command (`/name`). Skills are plain
 Markdown with step-by-step instructions.
+
+#### Argument expansion rewrites shell snippets before they are read
+
+A `SKILL.md` body is not delivered verbatim. Slash-command argument expansion
+rewrites positional tokens **before** the body reaches the model, so a shell
+snippet in the file is not necessarily the snippet that runs. Measured
+directly (three probe invocations at 0, 2, and 3 arguments):
+
+| Token in the file | What arrives |
+|-------------------|--------------|
+| `$0`, `$1`, `$2`, … | The **(N+1)-th** argument — the numbering is zero-indexed, so `$0` is the *first* argument |
+| `$0`, `$1`, … with no such argument | Left untouched — **not** replaced with an empty string |
+| `$ARGUMENTS` | The full argument string; empty when the skill is invoked with none |
+| `$@`, `$*`, `$#` | Never substituted |
+| `${1}` (braced) | Never substituted — the braced form is immune |
+| `$TAG` and other named variables | Never substituted |
+
+Position in the file is irrelevant: prose, inline code spans, and fenced code
+blocks are all rewritten alike. Fencing a snippet does **not** protect it.
+
+The failure mode is silent. `awk '$0==t{f=1}'` in a skill invoked as
+`/that-skill v0.21.0` arrives as `awk 'v0.21.0==t{f=1}'`, which matches nothing,
+exits 0, and yields an empty result far from the apparent cause — this is a real
+defect that shipped in `create-announcement` and was caught only by running it.
+
+Rules when authoring:
+
+- Prefer `git describe`, `cut -d' ' -f2`, or `sed -E` over `awk` field
+  variables. Where a field variable is unavoidable, `${2}` is safe.
+- Watch for `$` immediately before a digit in ordinary prose too — a cost note
+  reading `~$0.03/hr` renders as `~<first-argument>.03/hr`. Write `USD 0.03/hr`.
+- Before shipping, run `grep -nE '\$[0-9]' .claude/skills/<name>/SKILL.md` and
+  confirm every hit is deliberate.
+- When documenting this hazard *inside* a skill, describe it in prose ("a dollar
+  sign followed by a digit"). A warning containing the literal token rewrites
+  itself into an example of the bug.
+
+A no-argument skill is exposed only if someone passes arguments anyway; `$0` is
+the most fragile slot, since a single stray argument is enough to hit it.

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -258,12 +258,20 @@ so the discussion is created in `kaappi/kaappi` and GitHub serves it at the
 `orgs/kaappi` URL. Repo and category ids are pinned in the skill for the
 GraphQL fallback, since `gh discussion` is still a preview command.
 
-Seven steps: resolve the tag, preflight (`gh auth`, release exists and is
-neither draft nor prerelease), check the category for an existing announcement
-so a re-run cannot double-post, gather material (release body, previous tag,
-commit count, shipped assets), draft, **stop for explicit approval**, post and
+Eight steps, numbered 0 through 7: resolve the tag, preflight (`gh auth`,
+release exists and is neither draft nor prerelease, release not so old that the
+next one is imminent), search the category for an existing announcement of that
+tag so a re-run cannot double-post, gather material (release body, previous tag,
+commit count, shipped assets), draft, **stop for explicit approval**, post, and
 verify. The approval gate is mandatory — posting publishes public content in a
 maintainer-restricted category and notifies every org watcher.
+
+Both write paths guard against duplicating that notification. The duplicate
+check searches by tag rather than listing the newest N, since announcing an
+older release is precisely the case where a duplicate would not be among the
+newest. And because `createDiscussion` is a non-idempotent write whose lost
+response is indistinguishable from an outright failure, the GraphQL fallback
+re-runs that search before firing rather than trusting the CLI's exit code.
 
 Carries the editorial half too: how to pick 3–6 highlights (what a user can now
 *do*, not what changed — internal refactors and CI work are explicitly out), a


### PR DESCRIPTION
Adds a `/create-announcement <tag>` skill that drafts and posts a release announcement to the org Announcements forum, plus harness documentation for a skill-authoring hazard the work surfaced.

Used it for real: [Kaappi v0.21.0 — pattern matching and regular expressions](https://github.com/orgs/kaappi/discussions/1850).

## The non-obvious fact it depends on

Org-level discussions at `github.com/orgs/kaappi` are **backed by the `kaappi/kaappi` repository**. `kaappi/.github` has discussions disabled entirely, so a skill that guessed the obvious repo would fail on every run. The repo id (`R_kgDOS7a-eg`) and Announcements category id (`DIC_kwDOS7a-es4C_rmH`) are pinned in the file for the GraphQL fallback, since `gh discussion` is still a preview command.

## What the skill does

Seven steps: resolve the tag, preflight, check the category so a re-run cannot double-post, gather material, draft, **stop for explicit approval**, post and verify. The approval gate is mandatory — posting publishes public content in a maintainer-restricted category and notifies every org watcher.

It carries the editorial half too, which is the part that decides whether the output is any good. Release notes are exhaustive by design and an announcement is not a second copy of them, so the file specifies how to pick 3–6 highlights (what a user can now *do*, not what changed; internal refactors and CI work are explicitly out), a title and body template, and a rule that every claim trace back to the notes rather than to a commit subject.

## The argument-substitution hazard

Running the skill against `v0.21.0` broke it, in a way that generalizes to any skill:

> A dollar sign followed by a digit inside a `SKILL.md` is rewritten by slash-command argument expansion **before the body is read**, so a snippet in the file is not necessarily the snippet that runs.

Measured with a throwaway probe skill invoked at 0, 2, and 3 arguments rather than inferred:

| Token | Behavior |
|---|---|
| `$0` `$1` `$2` … | → the **(N+1)-th** argument — zero-indexed, so the zeroth takes the *first* argument |
| absent argument | token left **untouched** — not emptied |
| `$ARGUMENTS` | full argument string; empty when none |
| `$@` `$*` `$#` `${N}` | never substituted; the braced form is immune |
| location | irrelevant — prose, inline code, and fenced blocks all rewrite |

The failure is silent: the command still runs, still exits 0, and only the result is wrong. Full table now in `docs/dev/claude-code-harness.md` under "Extending the harness" → "Adding a skill", with a grep-before-shipping rule.

## Why the awk lines are untouched

`do-linux-test`, `do-stress-test`, and `do-gate-benchmark` all extract an SSH fingerprint with `awk '{print $2}'`. I initially inferred that expanded to empty and filed it as a bug. **That inference was wrong** — an absent argument leaves the token alone, `$2` is the *third* argument, and those skills take none. They were never broken, so they are left exactly as they were.

Their cost notes were the real exposure: a dollar sign followed by zero claims the *first* argument, so one stray argument garbles `~$0.03/hr` into `~<arg>.03/hr`. Reworded to `USD 0.03/hr` (4 occurrences, 3 files). Cosmetic impact, but it fires at one argument instead of three.

## Verification

- Every command in the skill run end-to-end against the real repo — `git describe` previous-tag resolution returns `v0.20.0` for `v0.21.0` and correctly returns empty at the oldest tag
- `gh discussion create/list/edit/comment/view` flags and the `createDiscussion` GraphQL input shape checked against the live API
- Confirmed there is no `pinDiscussion` mutation, so the skill says pinning is a web-UI action rather than suggesting a command that would fail
- The posted announcement's body diffs identical to the approved draft; all 6 links in it return `200`
- `npx markdownlint-cli2`: 0 issues across 82 files. `main` has not moved past this branch's base, so the merge commit CI lints matches the tree verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)