### PR TITLE
Root internal-define slots in native let bodies (#1854)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native backend: an internal `define` in a `let` body could be collected**
+  (#1854). The LLVM backend gave the binding an `alloca` but never pushed it on
+  the GC shadow stack, so a collection triggered anywhere later in the body
+  freed the value it held and the memory was recycled into whatever the body
+  allocated next — a wrong answer in a compiled binary, with no crash and no
+  divergence in the interpreter. `emitLet` now mints and roots these slots
+  alongside the `let`'s own bindings; a `define` outside the head of the body
+  (where R7RS puts internal definitions) routes the whole form to the
+  interpreter rather than compile to something unrooted.
+
 ## [0.22.0] - 2026-07-30
 
 ### Added

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -178,10 +178,56 @@ The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
 | `define` | Function definitions compiled to a native LLVM function (see Lambda Strategy). A fixed-arity one's global value is a native closure over that entry (`kaappi_create_native_closure`, #1500); a variadic one's value stays `kaappi_eval_cached`. Non-lambda values: `call @kaappi_define_global(...)` (compound values via `kaappi_eval_cached`) |
 | `set!` | Store to the resolved lexical slot (local/param/upvalue) or `call @kaappi_set_global(...)` |
 | `lambda` | Compiled to a native LLVM function + closure, or cached eval fallback (see Lambda Strategy) |
-| `let`, `let*` | Native `alloca`s with shadow-stack rooting; falls back to `kaappi_eval_cached` for forms it cannot lower in scope (`src/llvm_emit_let.zig`) |
+| `let`, `let*` | Native `alloca`s with shadow-stack rooting, for the bindings and the body's head internal defines alike (see [Internal defines in a `let` body](#internal-defines-in-a-let-body)); falls back to `kaappi_eval_cached` for forms it cannot lower in scope (`src/llvm_emit_let.zig`) |
 | `cond`, `case`, `do` | Native `if`-style block/`phi` chains (`cond`/`case`) and a self-branching `alloca` loop (`do`) when every sub-form is emittable in the current lexical scope; otherwise a whole-form `kaappi_eval_cached` fallback (`src/llvm_emit_forms.zig`, kaappi#1496) |
 | `letrec`, `letrec*`, `guard`, quasiquote, named `let` | Serialize to source text, `call @kaappi_eval_cached(...)` (see [Cached eval fallback](#cached-eval-fallback)) |
 | `passthrough` | Serialize to source text, `call @kaappi_eval_cached(...)` |
+
+### Internal defines in a `let` body
+
+An internal `(define <symbol> <expr>)` in a natively emitted `let` body is a
+lexical binding, not a global (kaappi#819) — it lives in an `alloca` registered
+in the emitter's `locals` map, so it shadows any same-named global for the rest
+of the body. `emitLet` is the only tier that sets up such a scope; the closure
+and lambda tiers decline a body containing an internal define outright, so this
+path is reachable only from the top-level body and the lets nested inside it.
+
+The slots are **minted, rooted, and counted by `emitLet`, not by `emitDefine`**
+(kaappi#1854). Before emitting the body, `emitLet` walks the leading run of
+`(define <symbol> <expr>)` forms — R7RS's position for internal definitions —
+and for each mints an `alloca`, stores `VOID` into it, pushes it on the shadow
+stack, registers it in `locals`, and adds it to the same `binding_root_count`
+the bindings use. `emitDefine`'s internal path then only evaluates the
+initializer and stores into that slot; `LLVMEmitter.scope_define_names` is how
+it recognizes one.
+
+Two things make this the right owner:
+
+- **Rooting.** `emitDefine` used to mint the slot itself and never push it, so
+  the binding held the only reference to a freshly allocated value across every
+  later allocation in the body. A collection freed it and the memory was
+  recycled into whatever came next — a wrong answer with no crash:
+  `(let ((a 1)) (define xs (list 11 22 33)) <allocate> (car xs))` returned a
+  loop counter.
+- **A static push count.** The scope pops a fixed `n` at exit, so every push it
+  counts has to execute exactly once. Pushes emitted at the head of the body
+  dominate it; one emitted at a define nested inside an `if` would not. Those
+  defines are exactly the ones `scope_define_names` omits, and `emitDefine`
+  answers `error.UnsupportedNodeType` for them, so the enclosing `let` abandons
+  and the interpreter — which binds a non-head define correctly — takes the
+  whole form.
+
+Pre-creating every slot before any initializer runs is also letrec* semantics,
+which is what a body of internal definitions means: a forward or self reference
+reads `VOID` (bound but not yet assigned) rather than the uninitialized `alloca`
+it read before.
+
+Rooting these slots cannot interact with `musttail` (kaappi#1499): `mustTailSafe`
+already requires `self.locals == null`, which is never true inside a `let` body.
+
+The procedure shorthand `(define (f …) …)` is a different path — `ir.lowerDefine`
+turns it into a `passthrough`, so it never reaches `emitDefine` and still defines
+a global.
 
 ## Compile-Time Processing
 

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -193,6 +193,20 @@ pub const LLVMEmitter = struct {
     // shadows any same-named outer binding — including a boxed one: box-ness
     // is a per-binding attribute, never a name-level one (#1584).
     locals: ?std.StringHashMap(LocalBinding) = null,
+    // Names of the internal defines at the head of the CURRENT innermost native
+    // scope's body, whose slots that scope minted, rooted, and counted into its
+    // own pop before emitting the body (emitLet, #1854). emitDefine's internal
+    // path stores into one of these instead of minting a slot of its own, which
+    // it never rooted — so an allocation later in the body could collect the
+    // value the binding held, silently, in a compiled binary. A define whose
+    // name is absent here is one the scope's fixed pop count cannot account for
+    // (it is not at the head of the body — e.g. inside an `if` — so a root push
+    // emitted at it would run on only some paths): emitDefine declines it and
+    // the enclosing scope abandons to the interpreter, which binds it correctly.
+    // Scoped, never inherited: every scope that installs `locals` sets its own
+    // list (empty when it has no head defines) and restores the previous one on
+    // exit, so an inner body can never store into an outer scope's slot.
+    scope_define_names: []const []const u8 = &.{},
     // Frame-level boxed bindings (assignment conversion, #1497): boxed fixed
     // params and, inside a native closure, the mirrored boxed captures — name
     // -> the alloca that holds the box POINTER. Reads go through
@@ -260,6 +274,7 @@ pub const LLVMEmitter = struct {
         rest_param_alloca: ?[]const u8,
         rest_param_name: ?[]const u8,
         locals: ?std.StringHashMap(LocalBinding),
+        scope_define_names: []const []const u8,
         boxes: ?std.StringHashMap([]const u8),
         frame_entry_roots: usize,
         body_scope_roots: usize,
@@ -280,6 +295,7 @@ pub const LLVMEmitter = struct {
             .rest_param_alloca = self.rest_param_alloca,
             .rest_param_name = self.rest_param_name,
             .locals = self.locals,
+            .scope_define_names = self.scope_define_names,
             .boxes = self.boxes,
             .frame_entry_roots = self.frame_entry_roots,
             .body_scope_roots = self.body_scope_roots,
@@ -300,6 +316,7 @@ pub const LLVMEmitter = struct {
         self.rest_param_alloca = s.rest_param_alloca;
         self.rest_param_name = s.rest_param_name;
         self.locals = s.locals;
+        self.scope_define_names = s.scope_define_names;
         self.boxes = s.boxes;
         self.frame_entry_roots = s.frame_entry_roots;
         self.body_scope_roots = s.body_scope_roots;
@@ -811,6 +828,20 @@ pub const LLVMEmitter = struct {
     pub fn inLexicalScope(self: *LLVMEmitter) bool {
         return self.params != null or self.locals != null or
             self.rest_param_name != null or self.upvalues != null;
+    }
+
+    // The already-rooted slot the current scope minted for an internal define
+    // at the head of its body, or null when this scope never modelled `name`
+    // (#1854 — see scope_define_names). The name lookup goes through `locals`
+    // so the slot found is the one every read of that name resolves to.
+    pub fn definePreslot(self: *LLVMEmitter, name: []const u8) ?[]const u8 {
+        const locals = self.locals orelse return null;
+        for (self.scope_define_names) |n| {
+            if (!std.mem.eql(u8, n, name)) continue;
+            const binding = locals.get(name) orelse return null;
+            return binding.slot;
+        }
+        return null;
     }
 
     // Emit a value expression, resolving variable references against the

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -262,13 +262,21 @@ pub fn emitDo(self: *LLVMEmitter, args: Value, is_tail: bool) EmitError![]const 
 
     // Phase 2: bind all loop variables at once (parallel, not sequential).
     const saved_locals = self.locals;
+    const saved_define_names = self.scope_define_names;
     self.locals = if (saved_locals) |existing|
         existing.clone() catch return error.OutOfMemory
     else
         std.StringHashMap(llvm_emit.LocalBinding).init(self.allocator());
+    // A do body is its own scope, so it must not inherit the enclosing let's
+    // internal-define slots: those are rooted against that let's pop count, and
+    // a define reaching this body would otherwise store into one of them (#1854).
+    // `doArgsEmittable` rejects `define` outright, so nothing here can define at
+    // all — this keeps that from being load-bearing.
+    self.scope_define_names = &.{};
     defer {
         self.locals.?.deinit();
         self.locals = saved_locals;
+        self.scope_define_names = saved_define_names;
     }
     for (0..n) |i| self.locals.?.put(var_names[i], .{ .slot = allocas[i] }) catch return error.OutOfMemory;
 
@@ -1026,17 +1034,28 @@ pub fn emitDefine(self: *LLVMEmitter, data: ir.DefineData) EmitError![]const u8 
     // Internal define inside a natively compiled lexical scope (a `let`
     // body). self.locals is only populated while emitLet emits a body, so
     // top-level and lambda-body defines fall through to the global path.
-    // Create a fresh local binding so the define shadows any global of the
-    // same name for the rest of the body, instead of overwriting it (#819).
+    // The local binding shadows any global of the same name for the rest of the
+    // body instead of overwriting it (#819).
     if (self.locals != null) {
-        const alloca = try self.freshTemp();
-        try self.print("  {s} = alloca i64, align 8\n", .{alloca});
-        // Register before emitting the value so a self/mutual reference in
-        // the initializer resolves to this binding (letrec*-style).
-        self.locals.?.put(name, .{ .slot = alloca }) catch return error.OutOfMemory;
-        const val = try self.emitScopedValue(data.value);
-        try self.print("  store i64 {s}, ptr {s}\n", .{ val, alloca });
-        return self.emitVoid();
+        // emitLet minted this slot, stored VOID into it, pushed it on the shadow
+        // stack, and counted it into its own pop before emitting the body
+        // (#1854), so the value stored below survives a collection triggered
+        // anywhere later in that body — which the slot this path used to mint for
+        // itself, never rooted, did not. It is registered in `locals` from the
+        // same place, which is what makes a self/mutual reference in the
+        // initializer resolve here (letrec*-style) rather than to a global.
+        if (self.definePreslot(name)) |slot| {
+            const val = try self.emitScopedValue(data.value);
+            try self.print("  store i64 {s}, ptr {s}\n", .{ val, slot });
+            return self.emitVoid();
+        }
+        // A define the enclosing scope never modelled, i.e. not at the head of
+        // its body where R7RS requires internal definitions — inside an `if`
+        // branch, say. Minting a slot here leaves it unrooted, and rooting one
+        // would push on a path the scope's fixed pop count cannot match. Decline
+        // instead: the enclosing scope abandons to the interpreter, which binds
+        // it correctly.
+        return error.UnsupportedNodeType;
     }
 
     const sym_name = try self.internSymbol(name);

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -240,8 +240,11 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
         self.current_block = "entry";
         // The enclosing function's let-locals and rest parameter are not in
         // scope inside this closure's body; leaking them would misresolve
-        // names against the wrong frame's allocas.
+        // names against the wrong frame's allocas. The enclosing scope's
+        // internal-define slots go with them (#1854): they live in that frame's
+        // stack, and its pop count — not this one's — accounts for their roots.
         self.locals = null;
+        self.scope_define_names = &.{};
         self.rest_param_name = null;
         self.rest_param_alloca = null;
 
@@ -603,6 +606,9 @@ fn emitLambdaFunction(self: *LLVMEmitter, name: ?[]const u8, param_names: []cons
         self.tmp_counter = 0;
         self.label_counter = 0;
         self.locals = null;
+        // Likewise the enclosing scope's internal-define slots (#1854) — they
+        // are that frame's allocas, rooted against that frame's pop count.
+        self.scope_define_names = &.{};
         // This function is closed — it receives null for %upvalues at run
         // time — so an upvalue map inherited from the enclosing emission
         // scope must not leak into body emission or bindParamsAsGlobals.

--- a/src/llvm_emit_let.zig
+++ b/src/llvm_emit_let.zig
@@ -79,6 +79,7 @@ fn abandonLetForFallback(self: *LLVMEmitter, args: Value, sequential: bool, save
     self.buf.shrinkRetainingCapacity(checkpoint.buf_len);
     self.current_block = checkpoint.block;
     self.body_scope_roots = checkpoint.body_scope_roots;
+    self.scope_define_names = checkpoint.scope_define_names;
     self.locals.?.deinit();
     self.locals = saved_locals;
     return emitLetFallback(self, args, sequential);
@@ -91,7 +92,28 @@ const Checkpoint = struct {
     buf_len: usize,
     block: []const u8,
     body_scope_roots: usize,
+    scope_define_names: []const []const u8,
 };
+
+// The bound name of a `(define <symbol> <expr>)` body form, or null for
+// anything else — including `(define (f …) …)`, which `lowerDefine` turns into a
+// passthrough that defines a global and so never reaches emitDefine's internal
+// path (#1854).
+fn headDefineName(form: Value) ?[]const u8 {
+    if (!types.isPair(form)) return null;
+    const head = types.car(form);
+    if (!types.isSymbol(head) or !std.mem.eql(u8, types.symbolName(head), "define")) return null;
+    const rest = types.cdr(form);
+    if (!types.isPair(rest)) return null;
+    const target = types.car(rest);
+    if (!types.isSymbol(target)) return null;
+    if (!types.isPair(types.cdr(rest))) return null;
+    return types.symbolName(target);
+}
+
+// Same ceiling as this file's binding arrays: a body with more head defines than
+// this abandons to the interpreter rather than leaving the extras unrooted.
+const max_head_defines = 32;
 
 pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool) EmitError![]const u8 {
     const bindings = types.car(args);
@@ -105,6 +127,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
         .buf_len = self.buf.items.len,
         .block = self.current_block,
         .body_scope_roots = self.body_scope_roots,
+        .scope_define_names = self.scope_define_names,
     };
 
     // #827: If the let form (bindings or body) contains sub-expressions
@@ -262,6 +285,57 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
         }
     }
 
+    // R7RS internal defines at the head of the body are letrec* bindings, so
+    // mint and root every slot here — before any initializer runs — and hand the
+    // set to emitDefine, whose internal path then stores into an already-rooted
+    // slot instead of minting one of its own (#1854). The slot it used to mint
+    // was never pushed on the shadow stack, so an allocation later in the body
+    // could collect the value out from under the binding: `(let ((a 1)) (define
+    // xs (list 11 22 33)) <allocate a lot> (car xs))` returned whatever had been
+    // built in xs's recycled memory, silently, in a compiled binary.
+    //
+    // Rooting from this one place is also what keeps the push count static: these
+    // pushes dominate the whole body, unlike one emitted at a define nested
+    // inside an `if`, which would run on one path only while the pop count below
+    // is fixed. Those defines are exactly the ones absent from this set, and
+    // emitDefine declines them so the body loop's abandon hands the whole form to
+    // the interpreter (which binds a non-head define correctly).
+    var define_names: [max_head_defines][]const u8 = undefined;
+    var define_count: usize = 0;
+    {
+        var be = body_list;
+        head_defines: while (be != types.NIL and types.isPair(be)) : (be = types.cdr(be)) {
+            const dname = headDefineName(types.car(be)) orelse break;
+            if (define_count >= max_head_defines) {
+                return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
+            }
+            // A redefinition of the same name reuses the first slot: every store
+            // and every read resolves through `locals`, so one rooted slot per
+            // name is exactly right, and a second would only be dead weight.
+            for (define_names[0..define_count]) |n| {
+                if (std.mem.eql(u8, n, dname)) continue :head_defines;
+            }
+            const alloca = try self.freshTemp();
+            try self.print("  {s} = alloca i64, align 8\n", .{alloca});
+            // The slot is rooted before its own initializer runs, so it has to
+            // hold a scannable Value from the start. VOID is how this backend
+            // spells letrec*'s bound-but-not-yet-assigned, and it also replaces
+            // the uninitialized load a self-reference in the initializer used to
+            // get from the freshly minted alloca.
+            try self.print("  store i64 {d}, ptr {s}\n", .{ @as(i64, @bitCast(types.VOID)), alloca });
+            try self.emitRootPushAlloca(alloca);
+            binding_root_count += 1;
+            self.locals.?.put(dname, .{ .slot = alloca }) catch return error.OutOfMemory;
+            define_names[define_count] = dname;
+            define_count += 1;
+        }
+    }
+    // On the emitter's arena, not this frame's stack: the slice is read from
+    // arbitrarily deep inside body emission and is restored on both exits below,
+    // but an arena slice stays valid even if some future exit path forgets to.
+    self.scope_define_names = self.allocator().dupe([]const u8, define_names[0..define_count]) catch
+        return error.OutOfMemory;
+
     // #1585: while the body is lowered in tail position, the binding roots must
     // be released before every tail transfer — a `ret` through an in-body tail
     // call and a self-tail call's branch-back to the loop header alike.
@@ -292,6 +366,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
     }
 
     self.body_scope_roots = checkpoint.body_scope_roots;
+    self.scope_define_names = checkpoint.scope_define_names;
     try self.emitPopRoots(binding_root_count);
     self.locals.?.deinit();
     self.locals = saved_locals;

--- a/tests/scheme/compile/native-let-internal-define-root-1854.sh
+++ b/tests/scheme/compile/native-let-internal-define-root-1854.sh
@@ -41,9 +41,11 @@ KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
-    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
-fi
+# `kaappi compile` needs the native runtime archive. The helper freshens it with
+# zig when a toolchain is present and otherwise accepts a prebuilt one, so a box
+# running cross-compiled binaries still exercises the compile+link path — and it
+# knows the archive's per-platform name, which this script must not spell itself.
+ensure_runtime_lib "$REPO_DIR"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
@@ -93,9 +95,13 @@ check() {
     # Whether the top-level body kept the let native or handed it to the
     # interpreter: a natively emitted let leaves no kaappi_eval_cached in @main,
     # while emitLetFallback is exactly one such call.
-    (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1) || true
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1); then
+        echo "FAIL: $name — --emit-llvm failed, so native routing went unchecked" >&2
+        fail=1
+        return
+    fi
     local evals
-    evals=$(sed -n '/^define i32 @main/,/^}/p' "$DIR/$name.ll" 2>/dev/null | grep -c 'kaappi_eval_cached' || true)
+    evals=$(sed -n '/^define i32 @main/,/^}/p' "$DIR/$name.ll" | grep -c 'kaappi_eval_cached' || true)
     case "$native_expected" in
         native)
             if [[ "$evals" -ne 0 ]]; then

--- a/tests/scheme/compile/native-let-internal-define-root-1854.sh
+++ b/tests/scheme/compile/native-let-internal-define-root-1854.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+# Regression test for #1854: the native backend's internal-define path minted an
+# unrooted alloca for the binding, so a collection triggered later in the let
+# body freed the value out from under it.
+#
+# emitLet roots every let/let* binding alloca on the shadow stack, but the
+# internal-define branch in emitDefine (self.locals != null) created its slot,
+# stored the initializer, and never pushed it — so the slot held the ONLY
+# reference to a freshly allocated value across every later allocation in the
+# body. The value was collected and its memory recycled into whatever the body
+# allocated next, silently, with no crash:
+#
+#   (let ((a 1))
+#     (define xs (list 11 22 33))
+#     (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+#     (car xs))          ; => 198492, not 11
+#
+# Every case below printed recycled garbage — `(0.0 . 0.0)`, a loop counter's
+# list — from the pre-fix binary. The fix mints and roots these slots in emitLet
+# alongside the bindings, which is also what keeps the push count static: a
+# define nested inside an `if` would push on one path only while the scope's pop
+# count is fixed, so emitDefine declines those and the whole form goes to the
+# interpreter (cases 6 and 7 pin that down).
+#
+# Native codegen is NOT covered by -Dgc-stress (a VM/interpreter build option),
+# so this compile-and-run test is what guards the regression. Each case drives
+# enough allocation to force several collections while the binding is live.
+#
+# Usage: bash tests/scheme/compile/native-let-internal-define-root-1854.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
+    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
+fi
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+# Compile natively, run, and require the output to match the interpreter's —
+# which never had the bug, so it is the oracle. `native_expected` says whether
+# the let must still compile natively ("native") or is expected to route to the
+# interpreter ("fallback"); either way the answer must match, and asserting which
+# one happened keeps a silent fallback from making a "native" case pass
+# vacuously.
+check() {
+    local name="$1" src="$2" native_expected="$3"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    local want
+    if ! want=$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$DIR/$name.scm" 2>&1); then
+        echo "FAIL: $name — interpreter run failed: $want" >&2
+        fail=1
+        return
+    fi
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    local out status
+    set +e
+    out=$("$DIR/$name" 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 ]]; then
+        echo "FAIL: $name — binary aborted (exit $status): $out" >&2
+        fail=1
+        return
+    fi
+    if [[ "$out" != "$want" ]]; then
+        echo "FAIL: $name — native '$out' != interpreter '$want'" >&2
+        fail=1
+        return
+    fi
+
+    # Whether the top-level body kept the let native or handed it to the
+    # interpreter: a natively emitted let leaves no kaappi_eval_cached in @main,
+    # while emitLetFallback is exactly one such call.
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1) || true
+    local evals
+    evals=$(sed -n '/^define i32 @main/,/^}/p' "$DIR/$name.ll" 2>/dev/null | grep -c 'kaappi_eval_cached' || true)
+    case "$native_expected" in
+        native)
+            if [[ "$evals" -ne 0 ]]; then
+                echo "FAIL: $name — expected a natively emitted let, got $evals eval fallback(s) (test would be vacuous)" >&2
+                fail=1
+            fi
+            ;;
+        fallback)
+            if [[ "$evals" -eq 0 ]]; then
+                echo "FAIL: $name — expected the let to route to the interpreter, but none did" >&2
+                fail=1
+            fi
+            ;;
+        *)
+            echo "FAIL: $name — bad native_expected '$native_expected'" >&2
+            fail=1
+            ;;
+    esac
+}
+
+# 1. Issue reproducer: one internal define holding a fresh list across a loop
+#    that allocates hard. Pre-fix this printed the recycled contents of xs's
+#    freed memory (e.g. 198492 / (198472)).
+check internal-define-survives-gc \
+'(let ((a 1))
+  (define xs (list 11 22 33))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display (car xs)) (newline)
+  (display xs) (newline))' \
+native
+
+# 2. Several defines alongside a heap-valued let binding: every slot must be
+#    rooted, not just the binding's.
+check multiple-defines \
+'(let ((a (list 1 2)))
+  (define xs (list 11 22 33))
+  (define ys (list 44 55))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display (list a xs ys)) (newline))' \
+native
+
+# 3. Nested lets, each with its own define: the inner let owns its slot and pops
+#    exactly its own roots, leaving the outer let's define still rooted after it
+#    returns.
+check nested-let-defines \
+'(let ((a (list 1 2)))
+  (define xs (list 11 22))
+  (let ((b (list 3 4)))
+    (define ys (list 44 55))
+    (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+    (display (list a xs b ys)) (newline))
+  (display xs) (newline))' \
+native
+
+# 4. let* — its bindings are rooted one at a time as they are emitted, so the
+#    define slots have to be counted into the same pop.
+check letstar-define \
+'(let* ((a (list 1 2)) (b (cons 0 a)))
+  (define xs (list 11 22 33))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display (list a b xs)) (newline))' \
+native
+
+# 5. `(let () ...)`: zero bindings, so the define slots are the ONLY roots this
+#    scope pushes — the pop count comes entirely from them.
+check empty-bindings-define \
+'(let ()
+  (define xs (list 11 22 33))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display xs) (newline))' \
+native
+
+# 6. A define that is NOT at the head of the body (inside an `if`) is one the
+#    scope cannot root with a statically matched pop, so the whole let goes to
+#    the interpreter — which binds it correctly. R7RS puts internal definitions
+#    at the head of a body, so this shape is degenerate; it must still agree
+#    with the interpreter rather than compile to something unrooted.
+check non-head-define-falls-back \
+'(let ((a 1))
+  (if (> a 0) (define x (list 1 2)) #f)
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display x) (newline))' \
+fallback
+
+# 7. The head run ends at the first non-define form: a define after one is
+#    outside the modelled set, so this let falls back too.
+check define-after-expression-falls-back \
+'(let ((a 1))
+  (define xs (list 11 22))
+  (display a) (newline)
+  (define ys (list 33 44))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display (list xs ys)) (newline))' \
+fallback
+
+# 8. #819 still holds: an internal define shadows a same-named global for the
+#    rest of the body instead of overwriting it, and is still emitted natively.
+check shadows-global \
+'(define z 100)
+(let ((x (list 1)))
+  (define z x)
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display z) (newline))
+(display z) (newline)' \
+native
+
+# 9. A redefinition of the same name in one body reuses that name's single
+#    rooted slot — the second define must not strand a root or lose the value.
+check redefined-name \
+'(let ((a 1))
+  (define xs (list 1))
+  (define xs (list 11 22 33))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display xs) (newline))' \
+native
+
+# 10. letrec* ordering: a later define's initializer referencing an earlier one
+#     must see the earlier value, and the referenced list must survive the loop.
+check define-references-earlier-define \
+'(let ((a 1))
+  (define p (list 1 2))
+  (define q (cons 0 p))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display (list p q)) (newline))' \
+native
+
+# 11. A define whose value is a procedure. The unrooted slot held the closure,
+#     so pre-fix this did not merely print garbage — it died with
+#     "runtime error in call: not a procedure (NotAProcedure)" once the closure
+#     was collected and the slot was calling freed memory.
+check define-holding-a-procedure \
+'(let ((a (list 1)))
+  (define f (lambda (y) (+ y 1)))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i))
+  (display (list a (f 1))) (newline))' \
+native
+
+# 12. R7RS lets `begin` splice definitions at the head of a body. The head scan
+#     does not model that shape, so such a let goes to the interpreter — correct,
+#     just not native. Pinned so a future change that starts compiling it
+#     natively has to root those slots deliberately rather than by accident.
+check begin-spliced-define-falls-back \
+'(let ((a 1))
+  (begin (define x (list 1 2)))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display x) (newline))' \
+fallback
+
+# 13. Shadow-stack balance, asserted on the emitted IR rather than on output.
+#     A define slot now contributes a push that the scope's single trailing
+#     `kaappi_gc_pop_roots <n>` has to account for, so pushing without counting
+#     (or counting without pushing) desynchronises the two. Neither shows up as a
+#     wrong answer: an over-pop underflows GC.root_count (a ReleaseSafe panic,
+#     but only if the program happens to drive it below zero) and an under-pop
+#     just strands a slot. In a straight-line body every push and pop is
+#     textually reached exactly once, so summing them over @main is exact.
+#     Unlike the cases above this one balanced before the fix too — nothing was
+#     pushed and nothing counted; it guards the accounting from here on.
+check_root_balance() {
+    local name="$1" src="$2"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1); then
+        echo "FAIL: $name — --emit-llvm failed" >&2
+        fail=1
+        return
+    fi
+
+    local main_ir pushes pops
+    main_ir=$(sed -n '/^define i32 @main/,/^}/p' "$DIR/$name.ll")
+    pushes=$(printf '%s\n' "$main_ir" | grep -c 'call void @kaappi_gc_push_root' || true)
+    pops=$(printf '%s\n' "$main_ir" |
+        sed -n 's/.*call void @kaappi_gc_pop_roots(i64 \([0-9]*\)).*/\1/p' |
+        awk '{n += $1} END {print n + 0}')
+
+    if [[ "$pushes" -eq 0 ]]; then
+        echo "FAIL: $name — no root pushes in @main (test would be vacuous)" >&2
+        fail=1
+        return
+    fi
+    if [[ "$pushes" -ne "$pops" ]]; then
+        echo "FAIL: $name — @main pushes $pushes roots but pops $pops" >&2
+        fail=1
+    fi
+}
+
+check_root_balance define-slot-root-balance \
+'(let ((a (list 1 2)))
+  (define xs (list 11 22 33))
+  (define ys (list 44 55))
+  (let ((b (list 3 4)))
+    (define zs (list 66))
+    (display (list a xs ys b zs)) (newline)))'
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-let-internal-define-root-1854: all cases passed"


### PR DESCRIPTION
Closes #1854.

## The bug

The LLVM backend gave an internal `define` in a `let` body its own `alloca` but never pushed it on the GC shadow stack, so the binding held the **only** reference to a freshly allocated value across every later allocation in that body. A collection freed it and the memory was recycled into whatever the body allocated next — a wrong answer in a compiled binary, with no crash and no divergence in the interpreter:

```scheme
(let ((a 1))
  (define xs (list 11 22 33))
  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
  (car xs))            ; => 198492, not 11
```

Reproduces at plain ReleaseSafe — no `-Dgc-stress` needed, and it wouldn't have helped anyway (that's a VM/interpreter build option, not a native-codegen one). When the define held a procedure it was worse: calling the collected closure died with `not a procedure`.

## Why the fix isn't the one the issue proposed

The issue suggested mirroring `emitLet` — `emitRootPushAlloca` at the define site, counted into `binding_root_count`. That is unsound. `emitDefine`'s internal path is reachable from inside an `if` branch (verified: a `.define` node emits into a `then0` block), so a push emitted there runs on one path while the scope's pop is a fixed `n`.

Ownership therefore moves to `emitLet`, which already owns the scope's root accounting. Before emitting the body it walks the leading run of `(define <symbol> <expr>)` forms — R7RS's position for internal definitions — and for each mints an `alloca`, stores `VOID`, pushes it, and counts it into the same `binding_root_count` the let's own bindings use. `emitDefine`'s internal path now only evaluates the initializer and stores into that slot, recognizing it through the new `LLVMEmitter.scope_define_names`.

A define the scan didn't model gets `error.UnsupportedNodeType`, so the enclosing let abandons and the interpreter — which binds a non-head define correctly — takes the whole form.

Two things fall out:

- Pre-creating every slot before any initializer runs **is** letrec\* semantics, which is what a body of internal definitions means. A forward or self reference now reads `VOID` (bound but not yet assigned) instead of the uninitialized `alloca` it read before.
- No `musttail` interaction (#1499): `mustTailSafe` already requires `self.locals == null`, which is never true inside a `let` body.

## Reachability, for the record

- The internal-define path is reachable only from the top-level body and the lets nested in it. A lambda body containing a let with an internal define never compiles natively — `walkSexpr` sets `w.inexact = true` on `define`, and `letSexprHasFreeVars` returns `found or inexact`.
- So `body_tail` is always false for a define-bearing let (top-level forms lower with `is_tail = false`), making the `body_scope_roots` publish defensive rather than exercised. It is still the correct accounting if that ever changes.
- `"define"` is in `isRejectedFormHead`, so `cond`/`case`/`do` bodies reject defines up front; only `if`/`when`/`unless`/`and`/`or`/`begin` can carry one into the internal path.

## Tests

`tests/scheme/compile/native-let-internal-define-root-1854.sh` — 13 cases, each diffed against the interpreter (the oracle), each asserting whether the let stayed native or routed to the interpreter so a silent fallback can't make a case pass vacuously:

- head defines under GC pressure: single, multiple, nested lets, `let*`, `(let () ...)`, a procedure-valued define, redefinition of one name, letrec\* ordering
- fallback shapes pinned: a define inside `if`, a define after an expression, a `begin`-spliced define
- #819's shadowing guard kept
- a structural assertion that the root pushes and pops in `@main` balance

**Nine of the eleven behavioural cases fail against the pre-fix binary** (A/B'd against a stashed build). The balance assertion was mutation-tested: dropping the `binding_root_count += 1` makes it report `@main pushes 21 roots but pops 18`.

Full suite: 2014 pass / 0 fail (619 Scheme files + 1395 R7RS assertions). E2E native backend: 38/38. `zig build test` green.

## Found on the way, filed separately

Two **pre-existing** bugs surfaced while reproducing; neither is touched here:

1. `(define (f) ...)` shorthand in a native let body defines a **global** — `ir.lowerDefine` routes a pair target to `.passthrough`, bypassing `emitDefine` entirely. Native prints `inner-g`/`inner-g` where the interpreter prints `inner-g`/`global-g`. This is #819 still open for that one spelling.
2. A nested let that abandons to the interpreter loses the **outer** let's bindings — `bindParamsAsGlobals` publishes params/rest/upvalues but not `locals`. Repro: an outer let plus an inner let with 33 bindings (tripping the 32-binding ceiling) referencing the outer local → `undefined variable` in the compiled binary. `docs/dev/llvm-backend.md` already notes "it cannot see `let`-locals at all".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
