### PR TITLE
Unwind the GC root stack when an error escapes the pipeline

### DIFF
--- a/.claude/rules/gc-safety.md
+++ b/.claude/rules/gc-safety.md
@@ -108,6 +108,42 @@ const b = try gc.allocPair(a, z);
 gc.popRoot();
 ```
 
+- **The pattern above still leaks its root when the protected call is the one
+  that fails** — the `try` unwinds past `popRoot`, and nothing else ever
+  lowers `root_count`. You do **not** need an `errdefer` for that: the
+  pipeline boundaries snapshot `gc.root_count` on entry and call
+  `gc.truncateRoots(depth)` when an error escapes them (#1855). The
+  boundaries are the four `compileExpression*` entry points in
+  `compiler.zig`, `vm_eval.eval`, and `vm_calls.execute` — between them every
+  caller that keeps running after a pipeline error (REPL, `main`'s file loop,
+  `kaappi check`, the LSP, `pipeline`'s stage dumps, `native_compiler`, the
+  `eval`/`load` primitives, library-body compilation) is covered. Adding an
+  `errdefer gc.popRoot()` per site would be ~340 edits of exactly the LIFO
+  footgun above, which is why this is done once at the boundary instead.
+
+  Two consequences worth knowing. **Never `pushRoot` expecting a caller to
+  pop it across one of those boundaries** — roots do not outlive the boundary
+  that saw them pushed. And truncation only ever *shrinks*: a `root_count`
+  below the snapshot means an over-pop, which re-rooting cannot repair (the
+  slots would point into frames that have since returned), so the boundary
+  leaves it alone.
+
+  Recovery *within* a still-running form is not covered at primitive
+  granularity: a leak from a primitive whose error a Scheme `guard` catches
+  stays on the stack until the enclosing `execute` returns. No primitive with
+  that shape is known — the `oom_countdown` sweeps in
+  `src/tests_gc_root_boundary.zig` find leaks only in the expander — but a
+  new one would be a real hazard, so keep primitive error paths balanced.
+
+- **To test an OOM deep in the pipeline, use `gc.oom_countdown`**, not
+  `FailingAllocator` (documented deep-pipeline limitation) and not
+  `gc.memory_limit` (an absolute watermark that only trips once a form
+  *retains* more than the headroom, so it fails within the first few
+  allocations and never reaches the expander). Setting it to `n` lets the
+  next `n` heap allocations through and fails the one after. Sweeping `n`
+  over a range drives a failure at every allocation a form performs. It is
+  compiled out entirely outside test binaries (`builtin.is_test`).
+
 Stress-test with `-Dgc-stress=true` to force collection on every allocation.
 In Debug builds, freed objects are poisoned with `0xAA` to catch use-after-free.
 Debug and gc-stress builds additionally stamp freed headers with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The GC root stack is now unwound when an error escapes the compile/eval
+  pipeline (#1855). The canonical `pushRoot` / `try` / `popRoot` rooting
+  pattern leaks its root when the *protected* allocation is the one that
+  fails: the error unwinds past the `popRoot`, leaving the root stack holding
+  the address of a local in a frame that no longer exists for the next
+  collection to dereference — and shifting the stack so that every pending
+  `defer popRoot()` above it removes the wrong entry. The four
+  `compileExpression*` entry points, `vm_eval.eval`, and `vm_calls.execute`
+  now snapshot the root depth on entry and truncate back to it when an error
+  escapes, rather than adding an errdefer to each of ~340 push sites. Only
+  reachable under out-of-memory; the confirmed leak sites were in
+  `syntax-rules` ellipsis instantiation.
+
 ## [0.22.0] - 2026-07-30
 
 ### Added

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -34,7 +34,7 @@ not scan), it looks unreachable and gets freed.
 
 ```zig
 var val1 = try gc.allocString("hello");
-try gc.pushRoot(&val1);
+gc.pushRoot(&val1);
 defer gc.popRoot();
 const pair = try gc.allocPair(val1, types.NIL);  // val1 is protected
 ```
@@ -49,15 +49,20 @@ keeps it alive.
    call two `alloc*` functions and the first result is used by or after
    the second, root it.
 
-2. **Always pair `pushRoot` with `defer popRoot()`.** This ensures
-   balanced rooting even on error returns.
+2. **Pair `pushRoot` with `defer popRoot()` where the whole scope is
+   `pushRoot`-free.** `popRoot` removes whatever is on top of the shared
+   stack, not "your" entry, so a deferred pop is only correct when nothing
+   between the push and the deferred call can push its own root. Inside a
+   loop body, or right before rooting a second value, pop explicitly
+   immediately after the specific call being protected instead. See the
+   `compileLetSyntax` incident in `.claude/rules/gc-safety.md`.
 
 3. **Root the accumulator in loops.** When building a list or vector
    via repeated `allocPair`/`allocVector`, root the accumulating result:
 
    ```zig
    var result: Value = types.NIL;
-   try gc.pushRoot(&result);
+   gc.pushRoot(&result);
    defer gc.popRoot();
    for (items) |item| {
        result = try gc.allocPair(item, result);
@@ -121,6 +126,60 @@ GC's id) or silently aliasing a live object recycled into the same slot —
 the two escape modes that let the #1682 dangling-local bug survive twelve
 nightly stress runs. Release builds compile out both the stamp/check and
 the quarantine.
+
+### Unwinding the root stack on error (#1855)
+
+Rooting around a fallible call has a hole the rules above cannot close:
+
+```zig
+var a = try gc.allocSomething(...);
+gc.pushRoot(&a);
+const result = try gc.allocOther(a, ...);  // if THIS fails...
+gc.popRoot();                              // ...this never runs
+```
+
+When the protected call is the one that fails, the error unwinds past the
+`popRoot`. `root_count` is only ever moved by `pushRoot`/`popRoot`, so
+nothing put it back: the root stack was left holding the address of a local
+in a frame that no longer exists, and the next collection dereferences it.
+Under NaN-boxing that usually reads as a garbage flonum (harmless by luck)
+and occasionally as a plausible heap pointer (UB). Worse, the extra entry
+shifts the whole stack, so every `defer popRoot()` still to fire on the way
+out removes the wrong entry.
+
+Switching to `errdefer` at each of the ~340 push sites is not the fix — a
+`defer`/`errdefer` near a loop is the LIFO footgun of rule 2, so the cure
+reintroduces the disease. Instead the **pipeline boundaries** snapshot
+`gc.root_count` on entry and call `gc.truncateRoots(depth)` when an error
+escapes:
+
+| Boundary | Covers |
+|----------|--------|
+| `compileExpression`, `compileExpressionWithMacrosAt`, `compileExpressionInEnv`, `compileProgram` (`compiler.zig`) | Reader, expander, IR and bytecode emission — for every caller: REPL, `main`'s file loop, `kaappi check`, the LSP, `pipeline`'s stage dumps, `native_compiler`, the `eval`/`load` primitives, library-body compilation |
+| `vm_eval.eval` | The top-level-only handlers that bypass the compiler (`import`, `define-library`, `define-record-type`, …) and the reader |
+| `vm_calls.execute` | The running program. Truncated inside the error branch, *before* it runs pending `dynamic-wind` after-thunks — those allocate, so a leaked root would otherwise still be live when they collect |
+
+Two invariants follow. Roots never outlive the boundary that saw them
+pushed, so nothing may `pushRoot` expecting a caller across a boundary to
+pop it. And truncation only ever shrinks: a depth *below* the snapshot is an
+over-pop, which re-rooting cannot repair — the resurrected slots may already
+belong to a returned frame — so the boundary leaves it alone.
+
+What is deliberately not covered: recovery *within* a running form. A root
+leaked by a primitive whose error a Scheme `guard` catches survives until
+the enclosing `execute` returns, because snapshotting per native call would
+put a load on the interpreter's hottest path for a hazard no primitive
+currently has. The sweeps in `src/tests_gc_root_boundary.zig` find leaks
+only in the expander; keep primitive error paths balanced so that stays
+true.
+
+To reproduce a failure this deep, use `gc.oom_countdown` — `n` allocations
+succeed, the next fails. Sweeping `n` walks the failure across every
+allocation a form performs. `FailingAllocator` cannot reach these sites, and
+`gc.memory_limit` is an absolute watermark that only trips once a form
+*retains* more than the headroom, so it fails in the first few allocations
+and never reaches the expander. `oom_countdown` is compiled out entirely
+outside test binaries (`builtin.is_test`).
 
 ### Where to look
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -111,6 +111,32 @@ modes that let #1682 pass twelve nightly stress runs. Plain Debug builds
 stamp and check the sentinel too (best-effort, without the quarantine);
 release builds compile both features out.
 
+### Injecting an out-of-memory failure
+
+`gc.oom_countdown` fails a chosen heap allocation: set it to `n` and the
+next `n` allocations succeed while the one after returns `OutOfMemory`.
+Sweeping `n` over a range therefore walks the failure across every
+allocation a form performs, which is how `tests_gc_root_boundary.zig`
+reaches error paths deep inside the expander and compiler (#1855):
+
+```zig
+var n: usize = 0;
+while (n <= 200) : (n += 1) {
+    ctx.gc.oom_countdown = n;
+    _ = ctx.vm.eval(source) catch {};
+    ctx.gc.oom_countdown = null;
+    // ...assert whatever must hold after a failed allocation
+}
+```
+
+Prefer it over the two alternatives for anything past the first few
+allocations. `std.testing.FailingAllocator` has a documented deep-pipeline
+limitation, and `gc.memory_limit` is an absolute watermark that only trips
+once one form *retains* more than its headroom — in practice it fails within
+the first handful of allocations and never reaches the expander at all.
+`oom_countdown` is gated on `builtin.is_test`, so it compiles out of every
+non-test build.
+
 ---
 
 ## Scheme Integration Tests

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1157,13 +1157,31 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
 // Convenience functions
 // ---------------------------------------------------------------------------
 
+// The `compileExpression*` entry points below are the pipeline's compile
+// boundary: every caller that keeps running after a compile error goes
+// through one of them (the REPL and `main`'s file loop, `kaappi check`, the
+// LSP, `pipeline`'s stage dumps, `native_compiler`, the `eval` and `load`
+// primitives, library-body compilation). Each snapshots the GC root-stack
+// depth alongside its existing `extra_roots` watermark and truncates back to
+// it when the compile fails (#1855).
+//
+// A failed compile unwinds through `try`s that sit between a `pushRoot` and
+// its `popRoot` — `expander_instantiate`'s ellipsis instantiation is the
+// confirmed case — so without this the root stack keeps pointing into frames
+// that no longer exist, and the leaked entry also misaligns every
+// `defer popRoot()` still to fire above it. Truncating here, once, is what
+// `GC.truncateRoots` documents; per-site errdefers would be ~340 edits of
+// exactly the pattern gc-safety.md warns about. Ordered first in the defer
+// block so nothing that runs after it can collect with dead roots live.
 pub fn compileExpression(gc: *memory.GC, expr: Value) CompileError!*types.Function {
     syntax_error_detail_len = 0;
     resetCompileErrorSpan();
     var c = try Compiler.init(gc);
     const roots_base = gc.extra_roots.items.len;
+    const root_depth = gc.root_count;
     var ok = false;
     defer {
+        if (!ok) gc.truncateRoots(root_depth);
         gc.extra_roots.shrinkRetainingCapacity(roots_base);
         if (!ok) Compiler.unrootFunction(gc, c.func);
         c.deinit();
@@ -1182,11 +1200,13 @@ pub fn compileExpressionWithMacrosAt(gc: *memory.GC, expr: Value, vm_macros: *st
     resetCompileErrorSpan();
     var c = try Compiler.init(gc);
     const roots_base = gc.extra_roots.items.len;
+    const root_depth = gc.root_count;
     c.globals = vm_globals;
     c.func.source_line = source_line;
     c.func.source_name = source_name;
     var ok = false;
     defer {
+        if (!ok) gc.truncateRoots(root_depth); // #1855, see compileExpression
         gc.extra_roots.shrinkRetainingCapacity(roots_base);
         if (!ok) Compiler.unrootFunction(gc, c.func);
         c.deinit();
@@ -1209,12 +1229,14 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
     resetCompileErrorSpan();
     var c = try Compiler.init(gc);
     const roots_base = gc.extra_roots.items.len;
+    const root_depth = gc.root_count;
     c.globals = env;
     c.lib_env = env;
     c.lib_env_val = env_val;
     c.restricted_env = true;
     var ok = false;
     defer {
+        if (!ok) gc.truncateRoots(root_depth); // #1855, see compileExpression
         gc.extra_roots.shrinkRetainingCapacity(roots_base);
         if (!ok) Compiler.unrootFunction(gc, c.func);
         c.deinit();
@@ -1237,8 +1259,10 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
 
 pub fn compileProgram(gc: *memory.GC, exprs: []const Value) CompileError!*types.Function {
     var c = try Compiler.init(gc);
+    const root_depth = gc.root_count;
     var ok = false;
     defer {
+        if (!ok) gc.truncateRoots(root_depth); // #1855, see compileExpression
         if (!ok) Compiler.unrootFunction(gc, c.func);
         c.deinit();
     }

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -196,6 +196,21 @@ pub const GC = struct {
     no_collect: u32 = 0,
     bytes_allocated: usize = 0,
     memory_limit: ?usize = null,
+    /// Test-only OOM injector: when set, the next `oom_countdown` heap
+    /// allocations succeed and the one after that fails with OutOfMemory.
+    /// Counted per `maybeCollect` call, so the few allocators that skip it
+    /// (`allocFunction`) are not injectable — which is also why a compile
+    /// with no macro use in it never fails here: bytecode, IR and constant
+    /// pools all use the raw allocator.
+    /// Sweeping it over 0..N drives a failure at every allocation the
+    /// pipeline performs, which is what reaches the deep expander/compiler
+    /// push/pop sites (#1855). `memory_limit` cannot: it is an absolute
+    /// watermark that only trips once one form *retains* more than the
+    /// headroom, so it only ever fails within the first few allocations, and
+    /// FailingAllocator has its own documented deep-pipeline limitation.
+    /// Compiled out entirely outside test binaries (`builtin.is_test` is
+    /// comptime), so the allocation path pays nothing for it.
+    oom_countdown: ?usize = null,
     profile_alloc_target: ?*u64 = null,
     root_marker: ?*const fn (*GC) void = null,
     source_spans: std.AutoHashMap(Value, types.Span) = undefined,
@@ -433,6 +448,12 @@ pub const GC = struct {
 
     // pub for gc_alloc.zig; not part of the public GC API.
     pub fn maybeCollect(self: *GC) !void {
+        if (comptime builtin.is_test) {
+            if (self.oom_countdown) |n| {
+                if (n == 0) return error.OutOfMemory;
+                self.oom_countdown = n - 1;
+            }
+        }
         // Stress mode only changes *when* a collection is due (every call
         // instead of at the threshold); the no_collect and memory_limit
         // semantics must match the normal path, or stress builds would
@@ -482,6 +503,34 @@ pub const GC = struct {
 
     pub fn popRoot(self: *GC) void {
         self.root_count -= 1;
+    }
+
+    /// Unwind the root stack back to a depth snapshotted from `root_count`
+    /// on entry to a pipeline boundary (#1855).
+    ///
+    /// The canonical `pushRoot` / `try` / `popRoot` pattern leaks its root
+    /// when the protected call fails: the error unwinds past the `popRoot`,
+    /// leaving the stack holding a pointer into a frame that no longer
+    /// exists. Nothing else ever lowers `root_count`, so the next collection
+    /// dereferences it, and the leaked entry also misaligns LIFO pairing for
+    /// every `defer popRoot()` still to fire above it. The boundaries that
+    /// hand a pipeline error back to a caller which keeps running — the
+    /// `compileExpression*` entry points (compiler.zig), `vm_eval.eval`, and
+    /// `vm_calls.execute` — therefore snapshot the depth and truncate to it,
+    /// instead of an errdefer at each of the ~340 push sites, where `defer`
+    /// near a loop is itself the LIFO footgun gc-safety.md warns about.
+    /// Recovery *within* a running form (a primitive error a Scheme `guard`
+    /// catches) is deliberately not covered at that granularity: see
+    /// docs/dev/gc-safety-and-error-handling.md.
+    ///
+    /// Only ever shrinks. `root_count` *below* the snapshot means an
+    /// over-pop, which re-rooting cannot repair: those slots may already
+    /// have been overwritten by an inner frame that has since returned, so
+    /// restoring them would re-root exactly the kind of dangling pointer
+    /// this is meant to eliminate. Leave the depth alone and let the
+    /// over-pop surface on its own terms.
+    pub fn truncateRoots(self: *GC, depth: u32) void {
+        if (self.root_count > depth) self.root_count = depth;
     }
 
     // -- #1687 free-quarantine (see the `quarantine` field) --

--- a/src/tests_gc_root_boundary.zig
+++ b/src/tests_gc_root_boundary.zig
@@ -1,0 +1,222 @@
+// Root-stack unwinding at the pipeline boundaries (#1855).
+//
+// The canonical rooting pattern documented in .claude/rules/gc-safety.md
+//
+//     var a = try gc.allocSomething(...);
+//     gc.pushRoot(&a);
+//     const result = try gc.allocOther(a, ...);
+//     gc.popRoot();
+//
+// leaks the pushed root when the *protected* call is the one that fails: the
+// error unwinds past `popRoot`. Nothing else ever lowers `root_count`, so the
+// root stack was left holding a pointer into a dead stack frame, which the
+// next collection dereferences (a garbage flonum under NaN-boxing, or a fake
+// heap pointer → UB). A leaked entry also breaks LIFO pairing for every
+// `defer popRoot()` still to fire above it on the unwind path, so those pops
+// start removing the wrong entries.
+//
+// Rather than an errdefer at each of the ~340 push sites, the boundaries
+// snapshot the depth on entry and truncate back to it: the
+// `compileExpression*` entry points, `vm.eval`, and `execute` (see
+// GC.truncateRoots). These tests sweep a real OutOfMemory across every
+// allocation the pipeline makes and assert the depth came back each time.
+//
+// The lever is `gc.oom_countdown`, not FailingAllocator (documented
+// deep-pipeline limitation) and not `gc.memory_limit`: the limit is an
+// absolute watermark that only trips once one form *retains* more than the
+// headroom, which in practice fails only within the first few allocations and
+// never reaches the expander. Pre-fix, the ellipsis sweeps below leaked on
+// 10 of 54 and 12 of 48 injected failures respectively.
+
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const compiler_mod = @import("compiler.zig");
+const reader_mod = @import("reader.zig");
+
+/// Fail the n-th heap allocation of `source`, for every n in 0..=upto, and
+/// assert the root stack is exactly as deep afterwards as it was before.
+/// Returns how many of the sweeps actually failed, so a caller can assert the
+/// sweep was not vacuous.
+fn sweepOom(ctx: *th.TestContext, source: []const u8, upto: usize) !usize {
+    const base = ctx.gc.root_count;
+    var failures: usize = 0;
+    var n: usize = 0;
+    while (n <= upto) : (n += 1) {
+        ctx.gc.oom_countdown = n;
+        const result = ctx.vm.eval(source);
+        ctx.gc.oom_countdown = null;
+        if (result) |_| {} else |_| failures += 1;
+        if (base != ctx.gc.root_count) {
+            std.debug.print(
+                "root depth {d} -> {d} after failing allocation #{d} of: {s}\n",
+                .{ base, ctx.gc.root_count, n, source },
+            );
+            // Put it back before failing so `ctx.deinit()`'s own teardown
+            // does not then collect through the dead entry and turn a clear
+            // assertion failure into a crash.
+            ctx.gc.root_count = base;
+            return error.RootStackNotUnwound;
+        }
+        // A collection with a dead root live is the actual failure mode; run
+        // one on every iteration so a leak that slipped through would also
+        // trip the use-after-free detection of a -Dgc-stress build.
+        ctx.gc.collect();
+    }
+    return failures;
+}
+
+// Macro expansion is where the leak was confirmed: instantiateEllipsis pushes
+// a root around the `try gc.allocPair` that builds each expansion element (and
+// around the synthetic `(elem ... ...)` template), both flagged in the PR
+// #1853 review.
+test "root depth is restored when macro expansion OOMs" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval(
+        \\(define-syntax m
+        \\  (syntax-rules ()
+        \\    ((_ x ...) (list (+ x 1) ...))))
+    );
+    const failures = try sweepOom(&ctx, "(m 1 2 3 4 5)", 200);
+    try std.testing.expect(failures > 0);
+}
+
+test "root depth is restored when nested-ellipsis expansion OOMs" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval(
+        \\(define-syntax n
+        \\  (syntax-rules ()
+        \\    ((_ (a b ...) ...) (list (list a b ...) ...))))
+    );
+    const failures = try sweepOom(&ctx, "(n (1 2 3) (4 5 6))", 200);
+    try std.testing.expect(failures > 0);
+}
+
+// The other pipeline shapes were balanced already; sweep them so a future
+// unbalanced push/pop anywhere under these boundaries is caught here rather
+// than by a mystery collection crash.
+test "root depth is restored when other pipeline stages OOM" {
+    const cases = [_][]const u8{
+        "(define-record-type <pt> (mk a b) pt? (a pa) (b pb))",
+        "(let-syntax ((f (syntax-rules () ((_ q) (* q q))))) (f 4))",
+        "(let ((y 5)) `(a b ,y ,@(list 1 2 3)))",
+        "(define-library (probe a) (import (scheme base)) (export z) (begin (define (z) 7)))",
+        "(guard (e (#t 'caught)) (vector-ref (vector 1 2) 9))",
+        "(guard (e (#t 'x)) (dynamic-wind (lambda () (list 1 2)) (lambda () (car 5)) (lambda () (list 3 4))))",
+        "(string-append (number->string 12345) (symbol->string 'abc))",
+        "(call-with-current-continuation (lambda (k) (map (lambda (v) (k (list v))) '(1 2 3))))",
+    };
+    for (cases) |src| {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+        const failures = try sweepOom(&ctx, src, 150);
+        try std.testing.expect(failures > 0);
+    }
+}
+
+// A failed form must not poison the ones after it: the whole point of putting
+// the depth back is that the next collection walks only live roots.
+test "eval keeps working after a failed allocation deep in expansion" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval(
+        \\(define-syntax m
+        \\  (syntax-rules ()
+        \\    ((_ x ...) (list (+ x 1) ...))))
+    );
+    var n: usize = 0;
+    while (n <= 60) : (n += 1) {
+        ctx.gc.oom_countdown = n;
+        _ = ctx.vm.eval("(m 1 2 3 4 5)") catch {};
+        ctx.gc.oom_countdown = null;
+        ctx.gc.collect();
+        const ok = try ctx.vm.eval("(apply + (m 1 2 3 4 5))");
+        try std.testing.expectEqual(@as(i64, 20), types.toFixnum(ok));
+    }
+}
+
+// The boundary must never truncate a root its *caller* still owns: a
+// successful compile has to leave the depth exactly where it found it, and a
+// caller-pushed root has to survive a failing one.
+test "compile boundary preserves caller roots across success and failure" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // A macro use, because that is what makes a *compile* allocate Scheme
+    // objects: bytecode, IR and constant pools all use the raw allocator, so
+    // only expansion goes through the GC — and only expansion can fail here.
+    _ = try ctx.vm.eval(
+        \\(define-syntax m
+        \\  (syntax-rules ()
+        \\    ((_ x ...) (list (+ x 1) ...))))
+    );
+
+    var held = try ctx.gc.allocPair(types.makeFixnum(1), types.NIL);
+    ctx.gc.pushRoot(&held);
+    defer ctx.gc.popRoot();
+
+    var reader = reader_mod.Reader.init(&ctx.gc, "(m 1 2 3)");
+    defer reader.deinit();
+    var expr = try reader.readDatum();
+    ctx.gc.pushRoot(&expr);
+    defer ctx.gc.popRoot();
+    const base = ctx.gc.root_count;
+
+    const func = try compiler_mod.compileExpressionWithMacros(&ctx.gc, expr, &ctx.vm.macros, ctx.vm.globals);
+    compiler_mod.Compiler.unrootFunction(&ctx.gc, func);
+    try std.testing.expectEqual(base, ctx.gc.root_count);
+
+    var failures: usize = 0;
+    var n: usize = 0;
+    while (n <= 60) : (n += 1) {
+        ctx.gc.oom_countdown = n;
+        const bad = compiler_mod.compileExpressionWithMacros(&ctx.gc, expr, &ctx.vm.macros, ctx.vm.globals);
+        ctx.gc.oom_countdown = null;
+        if (bad) |f| compiler_mod.Compiler.unrootFunction(&ctx.gc, f) else |_| failures += 1;
+        // Never below `base` either: truncating a root the caller still owns
+        // would be the same dangling-pointer bug with the blame reversed.
+        try std.testing.expectEqual(base, ctx.gc.root_count);
+    }
+    try std.testing.expect(failures > 0);
+
+    // The caller's roots are still there and still point at live data.
+    ctx.gc.collect();
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(types.car(held)));
+    try std.testing.expect(types.isPair(expr));
+}
+
+// truncateRoots only ever shrinks. `root_count` below the snapshot means an
+// over-pop, which re-rooting cannot repair: the slots it would resurrect may
+// already have been overwritten by an inner frame that has since returned,
+// which is exactly the dangling pointer this mechanism exists to remove.
+test "truncateRoots never grows the root stack" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var a: types.Value = types.NIL;
+    var b: types.Value = types.NIL;
+    gc.pushRoot(&a);
+    gc.pushRoot(&b);
+    try std.testing.expectEqual(@as(u32, 2), gc.root_count);
+
+    gc.truncateRoots(5);
+    try std.testing.expectEqual(@as(u32, 2), gc.root_count);
+
+    gc.truncateRoots(2);
+    try std.testing.expectEqual(@as(u32, 2), gc.root_count);
+
+    gc.truncateRoots(1);
+    try std.testing.expectEqual(@as(u32, 1), gc.root_count);
+    gc.popRoot();
+}

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -152,6 +152,15 @@ pub fn profileTailCall(vm: *VM, new_func: *types.Function) void {
 
 pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
     vm_mod.setVMInstance(vm);
+    // Runtime half of the #1855 boundary reset. The `run` error branch below
+    // truncates explicitly rather than relying on this errdefer, because that
+    // branch runs pending dynamic-wind after-thunks *before* returning: those
+    // allocate, so a root leaked deep in the failed run — `fiber.zig`'s spawn
+    // path pushes a root around a bare `try`, the runtime code with this
+    // shape — would otherwise still be live when they collect. The errdefer
+    // covers the other error returns out of this function.
+    const root_depth = vm.gc.root_count;
+    errdefer vm.gc.truncateRoots(root_depth);
     vm.resetExecutionState();
     // Clear the diagnostic code at entry (not in resetExecutionState, which also
     // runs on the error-exit path *after* noteUncaughtException has recorded the
@@ -196,6 +205,7 @@ pub fn execute(vm: *VM, func: *types.Function) VMError!Value {
     }
 
     const result = run(vm) catch |err| {
+        vm.gc.truncateRoots(root_depth);
         vm.last_stack_trace_len = vm.getStackTrace(&vm.last_stack_trace);
         if (vm.profile_mode) {
             vm.profile_time_depth = 0;

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -32,6 +32,16 @@ fn runTopLevelFunction(vm: *VM, func: *types.Function) VMError!Value {
 
 pub fn eval(vm: *VM, source: []const u8) VMError!Value {
     vm_mod.setVMInstance(vm);
+    // Outermost boundary for a source string (#1855): unwind the GC root
+    // stack if the error escapes. The compile boundary
+    // (compileExpression*) covers everything reached through the compiler;
+    // this covers the rest — the reader and the top-level-only handlers
+    // (import/define-library/define-record-type/...), which push roots of
+    // their own. Registered before the per-form `defer popRoot()`s below, so
+    // it fires last and has the final say on the depth even when an earlier
+    // leak made those pops remove the wrong entries.
+    const root_depth = vm.gc.root_count;
+    errdefer vm.gc.truncateRoots(root_depth);
     const reader_mod = @import("reader.zig");
     var reader = reader_mod.Reader.init(vm.gc, source);
     defer reader.deinit();

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -16,6 +16,7 @@ test {
     _ = @import("tests_advanced.zig");
     _ = @import("tests_filesystem.zig");
     _ = @import("tests_robustness.zig");
+    _ = @import("tests_gc_root_boundary.zig");
     _ = @import("tests_fuzz.zig");
     _ = @import("tests_deepcopy.zig");
     _ = @import("tests_shared_channel.zig");


### PR DESCRIPTION
Closes #1855. Implements the issue's option 2 (boundary reset).

## The bug

The canonical rooting pattern in `.claude/rules/gc-safety.md` leaks its root when the *protected* allocation is the one that fails:

```zig
gc.pushRoot(&a);
const result = try gc.allocOther(a, ...);  // if THIS fails…
gc.popRoot();                              // …never runs
```

Nothing else ever lowers `root_count`, so the root stack was left holding the address of a local in a frame that no longer exists — the next collection dereferences it (usually a garbage flonum under NaN-boxing, occasionally a plausible heap pointer → UB). The extra entry also shifts the stack, so every `defer popRoot()` still to fire on the unwind path removes the wrong entry.

## The fix

`GC.truncateRoots(depth)` (shrink-only), called from the boundaries that hand a pipeline error back to a caller which keeps running:

| Boundary | Covers |
|---|---|
| `compileExpression`, `compileExpressionWithMacrosAt`, `compileExpressionInEnv`, `compileProgram` | Reader, expander, IR, emission — for every caller: REPL, `main`'s file loop, `kaappi check`, LSP, `pipeline` dumps, `native_compiler`, the `eval`/`load` primitives, library-body compilation |
| `vm_eval.eval` | Top-level-only handlers that bypass the compiler (`import`, `define-library`, `define-record-type`, …) |
| `vm_calls.execute` | The running program |

`execute` truncates *inside* its error branch rather than by `errdefer` alone, because that branch runs pending `dynamic-wind` after-thunks — which allocate — before returning.

Per-site `errdefer`s (the issue's option 3) were rejected as the issue anticipated: ~340 edits of exactly the defer-near-a-loop LIFO footgun `gc-safety.md` warns about, which is how the `compileLetSyntax` bug fixed in #1853 happened.

Truncation only ever shrinks. A depth *below* the snapshot is an over-pop, and re-rooting those slots would resurrect pointers into frames that have since returned — the very bug this removes.

## Getting a test that fails pre-fix

The issue expected no direct regression test was possible. It turned out to be, with a new lever.

`gc.memory_limit` is an absolute watermark that only trips once a form *retains* more than its headroom, so it fails within the first few allocations and never reaches the expander — **46 failures over 12,500 tries, zero leaks**. `FailingAllocator` has its own documented deep-pipeline limitation. So this adds `gc.oom_countdown`: `n` allocations succeed, the next fails. Gated on `builtin.is_test`, so it compiles out of every non-test build.

Sweeping it located the leak in exactly the two `expander_instantiate.zig` ellipsis sites flagged in the #1853 review:

| shape | injected failures | leaks (pre-fix) | leaks (post-fix) |
|---|---|---|---|
| ellipsis macro | 54 | **10** | 0 |
| nested ellipsis | 48 | **12** | 0 |
| records, libraries, let-syntax, quasiquote, guard-caught primitive errors, dynamic-wind unwind, call/cc | 13–138 each | 0 | 0 |

3 of the 6 new tests in `src/tests_gc_root_boundary.zig` fail without the fix, with a precise diagnostic (`root depth 0 -> 1 after failing allocation #9 of: (m 1 2 3 4 5)`). The suite also asserts the inverse — that a caller-pushed root survives a failing compile, so the boundary can't over-truncate.

## Deliberate non-coverage

Recovery *within* a still-running form is not covered at primitive granularity: a root leaked by a primitive whose error a Scheme `guard` catches survives until the enclosing `execute` returns. Snapshotting per native call would load the interpreter's hottest path for a hazard no primitive currently has — the sweeps find leaks only in the expander. Documented in both `.claude/rules/gc-safety.md` and `docs/dev/gc-safety-and-error-handling.md` so a future unbalanced primitive is recognized as a real hazard rather than assumed covered.

The individual leak sites are left as they are, per the issue's preference for one boundary mechanism over per-site churn; the docs record that the boundary is what makes them safe.

## Verification

| Gate | Result |
|---|---|
| `zig build test` | 1427/1430 (3 pre-existing skips) |
| `bash tests/scheme/run-all.sh` | 2013 pass, 0 fail |
| `zig build test -Dgc-stress=true` | 1430/1430 |
| `markdownlint-cli2` | 0 issues |
| `zig fmt --check` | clean |

## Found in passing, not fixed here

An OOM during fiber `spawn` leaks a heap *allocation* (allocator-level, distinct from the root-stack issue) — reproducible with the new `oom_countdown` sweep, stack pointing through the `fiber.zig` spawn path. Left for its own change rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)