### PR TITLE
Stop (scheme base) from exporting %-prefixed internals

### DIFF
--- a/.claude/skills/add-builtin/SKILL.md
+++ b/.claude/skills/add-builtin/SKILL.md
@@ -25,13 +25,20 @@ fn myProc(args: []const Value) PrimitiveError!Value {
 .{ .name = "my-proc", .func = &myProc, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
 ```
 
-An **internal helper** — a `%`-prefixed name only compiler-generated code or
-a portable `.sld` calls — takes `.libs = primitives.INTERNAL` instead:
-registered in `vm.globals`, exported by nothing, so it doesn't reserve the
-name against every user library that imports `(scheme base)` (kaappi#1856; a
-comptime check rejects a `%` name tagged `scheme.*`). Synthesize *references*
-to one with `Compiler.trueBuiltinRefOrSymbol` /
-`globals_mod.baseBindingSymbol`, never a bare `allocSymbol("%foo")`.
+An **internal helper** — a `%`-prefixed name no user program should have to
+avoid — never takes a `scheme.*` tag, which reserves the name against every
+user library that imports it (kaappi#1856; a comptime check rejects this).
+Two cases:
+
+- Only compiler-generated code names it: `.libs = primitives.INTERNAL` —
+  registered in `vm.globals`, exported by nothing.
+- A portable `.sld` names it in its own Scheme source:
+  `.libs = primitives.INTERNAL_PUBLIC`, which adds `(kaappi primitives)` so
+  the `.sld` can import it (`lib/srfi/27.sld` and the record SRFIs do).
+
+Synthesize *references* to either with `Compiler.trueBuiltinRefOrSymbol` /
+`globals_mod.baseBindingSymbol`, never a bare `allocSymbol("%foo")` — that
+picks up a user binding of the same name.
 See `docs/dev/adding-features.md`.
 
 3. **Add a test** in `src/vm.zig` test section:

--- a/.claude/skills/add-builtin/SKILL.md
+++ b/.claude/skills/add-builtin/SKILL.md
@@ -17,11 +17,22 @@ fn myProc(args: []const Value) PrimitiveError!Value {
 }
 ```
 
-2. **Register it** in `registerAll()` in `src/primitives.zig`:
+2. **Add a spec entry** to the file's `specs` table. One entry carries the
+   name, function, arity, and the libraries that export it — `library.zig`
+   derives every export set from these tags, so there is no second list:
 
 ```zig
-try reg(vm, "my-proc", &myProc, .{ .exact = 1 });  // or .{ .variadic = N }
+.{ .name = "my-proc", .func = &myProc, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
 ```
+
+An **internal helper** — a `%`-prefixed name only compiler-generated code or
+a portable `.sld` calls — takes `.libs = primitives.INTERNAL` instead:
+registered in `vm.globals`, exported by nothing, so it doesn't reserve the
+name against every user library that imports `(scheme base)` (kaappi#1856; a
+comptime check rejects a `%` name tagged `scheme.*`). Synthesize *references*
+to one with `Compiler.trueBuiltinRefOrSymbol` /
+`globals_mod.baseBindingSymbol`, never a bare `allocSymbol("%foo")`.
+See `docs/dev/adding-features.md`.
 
 3. **Add a test** in `src/vm.zig` test section:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -988,17 +988,18 @@ map.deinit();  // no allocator arg needed
    }
    ```
 
-2. Register in the file's `registerXxx` function:
+2. Add one entry to the file's `specs` table — name, function, arity, and the
+   libraries that export it. `registerAll` walks `all_specs` and
+   `library.zig` derives every export set from the same tags, so this is the
+   whole registration; there is no second list and no manual `reg()` call:
 
    ```zig
-   try primitives.reg(vm, "my-proc", &myProc, .{ .exact = 1 });
+   .{ .name = "my-proc", .func = &myProc, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
    ```
 
    Arity: `.{ .exact = N }` for fixed, `.{ .variadic = N }` for N minimum args.
 
-3. Add to the file's `specs` table with the exporting libraries in `.libs`
-   (`library.zig` derives every export set from these tags — there is no
-   second list). An internal helper — a `%`-prefixed name only
+3. An internal helper — a `%`-prefixed name only
    compiler-generated code or a portable `.sld` calls — takes
    `primitives.INTERNAL` instead: registered in `vm.globals`, exported by
    nothing, so it doesn't reserve the name against user libraries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -996,7 +996,20 @@ map.deinit();  // no allocator arg needed
 
    Arity: `.{ .exact = N }` for fixed, `.{ .variadic = N }` for N minimum args.
 
-3. Add to library exports in `src/library.zig` (the `scheme.base` section).
+3. Add to the file's `specs` table with the exporting libraries in `.libs`
+   (`library.zig` derives every export set from these tags — there is no
+   second list). An internal helper — a `%`-prefixed name only
+   compiler-generated code or a portable `.sld` calls — takes
+   `primitives.INTERNAL` instead: registered in `vm.globals`, exported by
+   nothing, so it doesn't reserve the name against user libraries
+   (kaappi#1856; a comptime check rejects a `%` name tagged `scheme.*`).
+   `primitives.INTERNAL_PUBLIC` additionally exports it from
+   `(kaappi primitives)`, for helpers a portable `.sld` names in Scheme
+   source (SRFI 27/74/271 and the record SRFIs import it).
+   Synthesize *references* to one with `Compiler.trueBuiltinRefOrSymbol` /
+   `globals_mod.baseBindingSymbol`, never a bare `allocSymbol("%foo")`, or a
+   user binding of the same name silently wins. See
+   `docs/dev/adding-features.md`.
 
 4. If the procedure needs heap allocation, use `primitives.gc_instance`.
    If it needs to call Scheme procedures, use `primitives.vm_instance`.

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -28,12 +28,14 @@ The function signature is always `fn([]const Value) PrimitiveError!Value`.
 Arguments are passed as a slice -- arity checking has already been done by the
 dispatch layer.
 
-### 2. Register the procedure
+### 2. Register the procedure and its libraries
 
-In the same file's `registerXxx` function, add a registration call:
+Add an entry to the same file's `specs` table. One entry carries the name,
+implementation, arity, *and* the set of libraries that export it -- there is
+no second list to keep in sync:
 
 ```zig
-try reg(vm, "my-proc", &myProc, .{ .exact = 1 });
+.{ .name = "my-proc", .func = &myProc, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
 ```
 
 Arity options:
@@ -41,19 +43,49 @@ Arity options:
 - `.{ .exact = N }` -- exactly N arguments
 - `.{ .variadic = N }` -- N or more arguments
 
-### 3. Export from a library
+`.libs` takes a `LibSet` (`LS.initOne(.scheme_base)`,
+`LS.initMany(&.{ .scheme_base, .scheme_r5rs })`, or one of the shorthand
+aliases at the top of `src/primitives.zig`). `library.zig` derives every
+standard library's export set from these tables at startup, so the tag *is*
+the export. Two optional fields narrow that: `.sandbox = false` withholds the
+primitive under `--sandbox`, `.wasm = false` on WASM.
 
-Add the name to the appropriate library in `src/library.zig`. For most
-procedures, this means adding it to the `scheme_base_names` array:
+### 3. If the procedure is an internal helper, do not export it
+
+A primitive that only compiler-generated code or a portable `.sld` calls --
+conventionally named with a `%` prefix -- belongs in `.internal`, not in a
+standard library:
 
 ```zig
-const scheme_base_names = [_][]const u8{
-    // ... existing names ...
-    "my-proc",
-};
+.{ .name = "%my-helper", .func = &myHelper, .arity = .{ .exact = 1 }, .libs = primitives.INTERNAL },
 ```
 
-For SRFI procedures, add to the corresponding SRFI names array.
+`.internal` registers the primitive in `vm.globals` (so it resolves by name,
+including from a library body) while exporting it from nothing. Putting a `%`
+name in `(scheme base)` instead reserves it against every user library that
+imports `(scheme base)`, because R7RS 5.2 makes importing one identifier from
+two libraries with different bindings an error -- a user library that defined
+its own `%length` could not be imported at all (kaappi#1856). A comptime check
+in `primitives.zig` now rejects any `%` name tagged with a `scheme.*` library.
+
+If a *portable* `.sld` names the helper in its own Scheme source, tag it
+`primitives.INTERNAL_PUBLIC` instead: that is `.internal` plus
+`.kaappi_primitives`, which exports it from `(kaappi primitives)` so the
+`.sld` can declare the dependency (`lib/srfi/27.sld` and the record SRFIs do).
+A helper tied to one SRFI belongs in that SRFI's own `*_primitives`
+sub-library (`.srfi_237_primitives` and friends) rather than the general one.
+Either way the name stays out of `(scheme base)`.
+
+Compiler-synthesized *references* to an internal helper must go through
+`Compiler.trueBuiltinRefOrSymbol` / `globals_mod.baseBindingSymbol` rather
+than a bare `gc.allocSymbol("%my-helper")`: that marks the reference so it
+resolves against the pristine startup snapshot
+(`LibraryRegistry.internal_bindings`) instead of whatever the program being
+compiled has bound that name to. A bare symbol silently picks up a user's
+same-named binding -- which is how `define-record-type` inside a library that
+defined its own `%record-ref` started returning the wrong value.
+
+For SRFI procedures, tag with the corresponding `srfi_*` `Lib` value.
 
 ### 4. Handle heap allocation
 

--- a/lib/srfi/131.sld
+++ b/lib/srfi/131.sld
@@ -30,11 +30,13 @@
 ;;; same top-level-only limitation (library bodies not yet supported).
 (define-library (srfi 131)
   ;; (srfi 237 primitives) imported explicitly for %record-type-total-
-  ;; field-count/%make-record (used by %named-constructor/%absolute-index
-  ;; below) -- relying on their being ambiently visible without a
-  ;; declared import proved unreliable in testing for this file, unlike
-  ;; some other %-prefixed primitives elsewhere in this codebase.
-  (import (scheme base) (srfi 237) (srfi 237 primitives))
+  ;; field-count (used by %named-constructor/%absolute-index below) --
+  ;; relying on its being ambiently visible without a declared import
+  ;; proved unreliable in testing for this file. (kaappi primitives) is
+  ;; the same story for %make-record, and is now mandatory rather than
+  ;; merely good practice: it moved out of (scheme base), where it was
+  ;; reserving the name against every user library (kaappi#1856).
+  (import (scheme base) (srfi 237) (srfi 237 primitives) (kaappi primitives))
   (export define-record-type)
   (begin
 

--- a/lib/srfi/136.sld
+++ b/lib/srfi/136.sld
@@ -49,7 +49,9 @@
   ;; (srfi 237 primitives) imported explicitly for the same reason as
   ;; lib/srfi/131.sld: relying on ambient visibility of %-prefixed
   ;; primitives without a declared import proved unreliable in testing.
-  (import (scheme base) (srfi 237) (srfi 237 primitives))
+  ;; (kaappi primitives) supplies %make-record/%make-record-type/%record?,
+  ;; which used to arrive via (scheme base) and no longer do (kaappi#1856).
+  (import (scheme base) (srfi 237) (srfi 237 primitives) (kaappi primitives))
   (export define-record-type record? record-type-descriptor? record-type-descriptor
           record-type-predicate record-type-name record-type-parent record-type-fields
           make-record-type-descriptor make-record)

--- a/lib/srfi/150.sld
+++ b/lib/srfi/150.sld
@@ -114,8 +114,11 @@
 ;;; the global environment, which never consults lib_env at all. The
 ;;; idiomatic spelling is back.
 (define-library (srfi 150)
+  ;; (kaappi primitives): the internal %-prefixed helpers this file calls
+  ;; below. They used to arrive with (scheme base), which reserved their
+  ;; names against every user library (kaappi#1856).
   (import (scheme base) (srfi 211 explicit-renaming) (srfi 213)
-          (srfi 237) (srfi 237 primitives))
+          (srfi 237) (srfi 237 primitives) (kaappi primitives))
   (export define-record-type)
   (begin
 

--- a/lib/srfi/237.sld
+++ b/lib/srfi/237.sld
@@ -43,7 +43,10 @@
 ;;;     functionality) -- the base R6RS 2-form name-spec (bare symbol, or
 ;;;     `(<name> <ctor> <pred>)`) is fully supported.
 (define-library (srfi 237)
-  (import (scheme base) (srfi 237 primitives))
+  ;; (kaappi primitives): the internal %-prefixed helpers this file calls
+  ;; below. They used to arrive with (scheme base), which reserved their
+  ;; names against every user library (kaappi#1856).
+  (import (scheme base) (srfi 237 primitives) (kaappi primitives))
   (export
     ;; procedural
     make-record-type-descriptor record-type-descriptor?

--- a/lib/srfi/27.sld
+++ b/lib/srfi/27.sld
@@ -1,5 +1,8 @@
 (define-library (srfi 27)
-  (import (scheme base))
+  ;; (kaappi primitives): the internal %-prefixed helpers this file calls
+  ;; below. They used to arrive with (scheme base), which reserved their
+  ;; names against every user library (kaappi#1856).
+  (import (scheme base) (kaappi primitives))
   (export random-integer random-real
           default-random-source random-source?
           make-random-source

--- a/lib/srfi/271/determinized.sld
+++ b/lib/srfi/271/determinized.sld
@@ -6,8 +6,12 @@
 ;; suitable for reproducible testing. The port's state can be captured,
 ;; compared, and used to construct a fresh port at that same state.
 (define-library (srfi 271 determinized)
+  ;; (kaappi primitives): the internal %-prefixed helpers this file calls
+  ;; below. They used to arrive with (scheme base), which reserved their
+  ;; names against every user library (kaappi#1856).
   (import (scheme base)
-          (scheme case-lambda))
+          (scheme case-lambda)
+          (kaappi primitives))
   (export make-random-port
           random-port?
           random-port-state

--- a/lib/srfi/271/randomized.sld
+++ b/lib/srfi/271/randomized.sld
@@ -6,7 +6,10 @@
 ;; and not reproducible, and it exposes no inspectable state — hence this
 ;; library exports only make-random-port.
 (define-library (srfi 271 randomized)
-  (import (scheme base))
+  ;; (kaappi primitives): the internal %-prefixed helpers this file calls
+  ;; below. They used to arrive with (scheme base), which reserved their
+  ;; names against every user library (kaappi#1856).
+  (import (scheme base) (kaappi primitives))
   (export make-random-port)
   (begin
 

--- a/lib/srfi/57.sld
+++ b/lib/srfi/57.sld
@@ -90,7 +90,10 @@
 ;;; same as already noted for (srfi 237) -- this SRFI doesn't have those,
 ;;; nothing to note.
 (define-library (srfi 57)
-  (import (scheme base) (srfi 237) (srfi 237 primitives))
+  ;; (kaappi primitives): the internal %-prefixed helpers this file calls
+  ;; below. They used to arrive with (scheme base), which reserved their
+  ;; names against every user library (kaappi#1856).
+  (import (scheme base) (srfi 237) (srfi 237 primitives) (kaappi primitives))
   (export define-record-type define-record-scheme
           record-update record-update! record-compose)
   (begin

--- a/lib/srfi/74.sld
+++ b/lib/srfi/74.sld
@@ -10,7 +10,10 @@
 ;;; genuinely big-endian host (kaappi supports s390x/ppc64le as first-class
 ;;; targets, so this can't be assumed little-endian).
 (define-library (srfi 74)
-  (import (scheme base) (srfi 160 u8))
+  ;; (kaappi primitives): the internal %-prefixed helpers this file calls
+  ;; below. They used to arrive with (scheme base), which reserved their
+  ;; names against every user library (kaappi#1856).
+  (import (scheme base) (srfi 160 u8) (kaappi primitives))
   (export endianness
           blob? make-blob blob-length blob-copy blob-copy!
           blob->u8-list u8-list->blob blob=?

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -62,10 +62,17 @@ Then add the re-export in `compiler_forms.zig` (thin hub — don't add logic the
 
 ## Primitives files
 
-Each `primitives_*.zig` has a `registerXxx` function that calls `primitives.reg()`
-for every procedure. These files are intentionally broad (many independent
-functions) — don't split them further. See `.claude/rules/gc-safety.md` for
-write-barrier and rooting requirements when adding primitives that allocate.
+Each `primitives_*.zig` exports a `specs` table — one entry per procedure,
+carrying its name, function, arity, and the `.libs` set that exports it.
+`primitives.all_specs` concatenates them; `registerAll` and `library.zig`
+both walk that, so an entry is the whole registration. A `%`-prefixed
+internal helper takes `.libs = primitives.INTERNAL` (or `INTERNAL_PUBLIC`
+when a portable `.sld` names it) — never a `scheme.*` tag, which reserves
+the name against user libraries and is rejected at comptime (kaappi#1856).
+
+These files are intentionally broad (many independent functions) — don't
+split them further. See `.claude/rules/gc-safety.md` for write-barrier and
+rooting requirements when adding primitives that allocate.
 
 ## File size
 

--- a/src/check_lint.zig
+++ b/src/check_lint.zig
@@ -31,6 +31,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const ir_mod = @import("ir.zig");
+const globals_mod = @import("globals.zig");
 const diagnostics = @import("diagnostics.zig");
 
 const Value = types.Value;
@@ -139,6 +140,19 @@ fn walk(ctx: *Context, ir: *IR, node: *Node, fallback: types.Span) void {
     }
 }
 
+/// A reference a desugaring built, not one the user wrote: `let-values`'s
+/// `list`/`apply`/`call-with-values`, `case-lambda`'s `length`,
+/// `define-record-type`'s `%make-record`/`%record-ref`/…, marked with
+/// `globals_mod.base_binding_prefix` so they resolve against the pristine
+/// startup snapshot rather than vm.globals (#1715, #1856). They resolve by a
+/// path `ir.globals` cannot see, so judging them against it produced a
+/// spurious KP4001 on any file using one of those forms — and they are not
+/// the user's source text, exactly like the hygienic-prefix case above.
+fn isCompilerSynthesized(name: []const u8) bool {
+    return globals_mod.stripBaseBindingPrefix(name) != null or
+        globals_mod.parseDefEnvBindingSymbolName(name) != null;
+}
+
 // ── Unbound top-level variable (KP4001, warning) ───────────────────────────
 
 /// A free reference to a global that is neither a built-in, an imported binding,
@@ -151,6 +165,7 @@ fn checkGlobalRef(ctx: *Context, ir: *IR, node: *Node, fallback: types.Span) voi
 
     // Macro-introduced identifiers are not the user's source text.
     if (!std.mem.eql(u8, name, types.stripHygienicPrefix(name))) return;
+    if (isCompilerSynthesized(name)) return;
 
     // A lexical binding shadows the global — not a top-level reference at all.
     if (ir.compiler) |c| {
@@ -186,6 +201,7 @@ fn checkCall(ctx: *Context, ir: *IR, node: *Node) void {
     // Skip macro-introduced operators and any name the user rebinds: a lexical
     // shadow, a set! target, or a top-level (re)definition of the name.
     if (!std.mem.eql(u8, name, types.stripHygienicPrefix(name))) return;
+    if (isCompilerSynthesized(name)) return;
     if (ir.isRedefined(name)) return;
     if (ctx.user_defined.contains(name)) return;
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -290,9 +290,7 @@ pub const Compiler = struct {
     /// desugaring, which must always mean the standard procedures
     /// regardless of what the user's program does with those names.
     pub fn trueBuiltinRefOrSymbol(gc: *memory.GC, name: []const u8) CompileError!Value {
-        var buf: [96]u8 = undefined;
-        const prefixed = globals_mod.baseBindingSymbolName(&buf, name);
-        return gc.allocSymbol(prefixed) catch return CompileError.OutOfMemory;
+        return globals_mod.baseBindingSymbol(gc, name) catch return CompileError.OutOfMemory;
     }
 
     /// Emit code loading `name`'s pristine `(scheme base)` binding into

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const compiler_mod = @import("compiler.zig");
 const conditionals = @import("compiler_conditionals.zig");
 const expander = @import("expander.zig");
+const globals_mod = @import("globals.zig");
 const Value = types.Value;
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
@@ -787,7 +788,7 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
         //   (let* ((old0 (%pp0)) (new0 (%parameter-convert %pp0 %pv0))
         //          (old1 (%pp1)) (new1 (%parameter-convert %pp1 %pv1)) ...)
         //     (dynamic-wind ...))
-        const pconv_sym = gc.allocSymbol("%parameter-convert") catch return CompileError.OutOfMemory;
+        const pconv_sym = globals_mod.baseBindingSymbol(gc, "%parameter-convert") catch return CompileError.OutOfMemory;
         var inner_bindings: Value = types.NIL;
         i = binding_count;
         while (i > 0) {
@@ -805,7 +806,7 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
 
         const dw_sym = gc.allocSymbol("dynamic-wind") catch return CompileError.OutOfMemory;
         const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-        const pset_sym = gc.allocSymbol("%parameter-set!") catch return CompileError.OutOfMemory;
+        const pset_sym = globals_mod.baseBindingSymbol(gc, "%parameter-set!") catch return CompileError.OutOfMemory;
 
         // before-thunk: (%parameter-set! %pp_i new_i) — install pre-converted values
         var before_body: Value = types.NIL;
@@ -845,18 +846,24 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
 /// Desugars to (internal names %-prefixed so clause bodies referencing
 /// user variables named `args` or `n` are not captured):
 /// (lambda %cl-args
-///   (let ((%cl-n (%length %cl-args)))
+///   (let ((%cl-n (length %cl-args)))
 ///     (cond
 ///       ((= %cl-n arity1) (apply (lambda formals1 body1...) %cl-args))
 ///       ((= %cl-n arity2) (apply (lambda formals2 body2...) %cl-args))
 ///       ...
 ///       (else (error "wrong number of arguments")))))
 ///
-/// Uses the internal `%length` alias rather than `length` itself (kaappi#1714):
-/// a library legitimately shadowing `length` (e.g. to supply its own for a
-/// non-standard list-like type) must not break dispatch here, which needs
-/// the real list-length primitive regardless of what `length` currently
-/// resolves to in scope.
+/// `length` there is emitted as `length`'s pristine `(scheme base)` binding
+/// (`globals_mod.base_binding_prefix`, kaappi#1715), not as the name `length`
+/// means at the use site: a scope legitimately shadowing `length` — say, to
+/// supply its own for a non-standard list-like type — must not break dispatch
+/// here, which needs the real list-length primitive regardless (kaappi#1714).
+/// That used to be a dedicated `%length` primitive, but exporting it from
+/// `(scheme base)` made a user library defining its own `%length`
+/// un-importable outright (kaappi#1856), and being an ordinary global it lost
+/// to a top-level redefinition anyway. The prefixed reference has neither
+/// problem: it reserves no name and reads from the export table, which no
+/// user code can write.
 pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!void {
     const gc = self.gc;
 
@@ -873,7 +880,7 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
         const cond_sym = try gc.allocSymbol("cond");
         const eq_sym = try gc.allocSymbol("=");
         const ge_sym = try gc.allocSymbol(">=");
-        const length_sym = try gc.allocSymbol("%length");
+        const length_sym = try Compiler.trueBuiltinRefOrSymbol(gc, "length");
         const apply_sym = try gc.allocSymbol("apply");
         const else_sym = try gc.allocSymbol("else");
         const error_sym = try gc.allocSymbol("error");

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -647,7 +647,7 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
         while (fi > 0) {
             fi -= 1;
             if (spec.mutator_names[fi]) |mn| {
-                const rs = gc.allocSymbol("%record-set!") catch return CompileError.OutOfMemory;
+                const rs = globals_mod.baseBindingSymbol(gc, "%record-set!") catch return CompileError.OutOfMemory;
                 const p = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
                 const v = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
                 const idx = types.makeFixnum(@intCast(fi));
@@ -664,7 +664,7 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
         var fi = spec.field_count;
         while (fi > 0) {
             fi -= 1;
-            const rr = gc.allocSymbol("%record-ref") catch return CompileError.OutOfMemory;
+            const rr = globals_mod.baseBindingSymbol(gc, "%record-ref") catch return CompileError.OutOfMemory;
             const p = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
             const idx = types.makeFixnum(@intCast(fi));
             const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
@@ -676,7 +676,7 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
 
     // Predicate
     {
-        const rc = gc.allocSymbol("%record?") catch return CompileError.OutOfMemory;
+        const rc = globals_mod.baseBindingSymbol(gc, "%record?") catch return CompileError.OutOfMemory;
         const v = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
         const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
         const body = gc.makeList(&[_]Value{ rc, v, rt_ref }) catch return CompileError.OutOfMemory;
@@ -686,7 +686,7 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
 
     // Constructor
     {
-        const mr = gc.allocSymbol("%make-record") catch return CompileError.OutOfMemory;
+        const mr = globals_mod.baseBindingSymbol(gc, "%make-record") catch return CompileError.OutOfMemory;
         const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
         var body_elems: [258]Value = undefined;
         body_elems[0] = mr;
@@ -716,7 +716,7 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
 
     // Internal record type: (define __rt (%make-record-type "name" n))
     {
-        const mrt = gc.allocSymbol("%make-record-type") catch return CompileError.OutOfMemory;
+        const mrt = globals_mod.baseBindingSymbol(gc, "%make-record-type") catch return CompileError.OutOfMemory;
         const ns = gc.allocString(spec.type_name) catch return CompileError.OutOfMemory;
         const nf = types.makeFixnum(@intCast(spec.field_count));
         const init = gc.makeList(&[_]Value{ mrt, ns, nf }) catch return CompileError.OutOfMemory;
@@ -1050,7 +1050,7 @@ pub fn compileDelay(self: *Compiler, args: Value, dst: u16) CompileError!void {
     try emitClosureEpilogue(self, &child, thunk_reg);
 
     // Call %make-promise-lazy(thunk) — use fresh registers to avoid clobbering
-    const sym = self.gc.allocSymbol("%make-promise-lazy") catch return CompileError.OutOfMemory;
+    const sym = globals_mod.baseBindingSymbol(self.gc, "%make-promise-lazy") catch return CompileError.OutOfMemory;
     const sym_idx = try self.addConstant(sym);
     const call_base = try self.allocReg();
     try self.emitOp(.get_global);

--- a/src/globals.zig
+++ b/src/globals.zig
@@ -207,6 +207,21 @@ pub fn baseBindingSymbolName(buf: []u8, name: []const u8) []const u8 {
     return std.fmt.bufPrint(buf, "{s}{s}", .{ base_binding_prefix, name }) catch name;
 }
 
+/// Allocate the `base_binding_prefix`-marked symbol for `name`: a
+/// compiler-synthesized reference that must always mean the standard
+/// procedure, or the internal primitive (#1856), rather than whatever the
+/// program being compiled has bound that name to. Returns the plain symbol
+/// unprefixed only if the name is longer than the fixed buffer, matching
+/// `baseBindingSymbolName`'s own overflow behavior.
+///
+/// Lives here rather than on `Compiler` (which has
+/// `trueBuiltinRefOrSymbol`, a thin wrapper over this) so `vm_records.zig`'s
+/// `define-record-type` desugarer can use it from its `VMError` paths too.
+pub fn baseBindingSymbol(gc: *@import("memory.zig").GC, name: []const u8) !Value {
+    var buf: [96]u8 = undefined;
+    return gc.allocSymbol(baseBindingSymbolName(&buf, name));
+}
+
 /// If `name` carries `base_binding_prefix`, return the unprefixed suffix;
 /// otherwise return null.
 pub fn stripBaseBindingPrefix(name: []const u8) ?[]const u8 {

--- a/src/library.zig
+++ b/src/library.zig
@@ -56,11 +56,28 @@ pub const LibraryRegistry = struct {
     /// outlive the library (escaping via import into vm.globals), so a
     /// replaced env must stay alive until the registry is torn down (#820).
     retired_envs: std.ArrayList(*std.StringHashMap(Value)) = .empty,
+    /// Pristine values of the `.internal` primitives (`primitives.Lib.internal`),
+    /// captured at startup from vm.globals and never written again — the same
+    /// "snapshot before any user code runs" role `scheme.base`'s export table
+    /// plays for `lookupBaseBinding` (#1715). Compiler-synthesized references
+    /// resolve through it via `Compiler.trueBuiltinRefOrSymbol`, so
+    /// `define-record-type`, `case-lambda`, `parameterize`, and `delay` keep
+    /// working in a scope that binds `%record-ref` (or any other helper name)
+    /// to something of its own (#1856).
+    ///
+    /// A separate table rather than one more `Library` because the two answer
+    /// different questions: a `Library` is what `import` hands to a program,
+    /// this is what the compiler resolves against. Some of these names *are*
+    /// also exported, by `(kaappi primitives)`, for the portable `.sld`s that
+    /// call them from Scheme source — that export is the program-facing half
+    /// and has nothing to do with this snapshot.
+    internal_bindings: std.StringHashMap(Value),
 
     pub fn init(allocator: std.mem.Allocator) LibraryRegistry {
         return .{
             .allocator = allocator,
             .libraries = std.StringHashMap(Library).init(allocator),
+            .internal_bindings = std.StringHashMap(Value).init(allocator),
         };
     }
 
@@ -70,6 +87,7 @@ pub const LibraryRegistry = struct {
             lib.deinit();
         }
         self.libraries.deinit();
+        self.internal_bindings.deinit();
         for (self.retired_envs.items) |env| {
             env.deinit();
             self.allocator.destroy(env);
@@ -143,6 +161,20 @@ fn addExportsForLib(library: *Library, lib: Lib, globals: *std.StringHashMap(Val
 /// hence safe under `--sandbox` and on WASM.
 pub const extra_std_libraries = [_][]const u8{ "scheme.case-lambda", "srfi.9" };
 
+/// Snapshot the `.internal` primitives into `registry.internal_bindings` —
+/// see that field for why they live outside `libraries` (#1856). Runs from
+/// both registrars, since compiler-synthesized code needs these under
+/// `--sandbox` too; `registerSandboxed` only puts `spec.sandbox` primitives
+/// in globals, so a sandbox-excluded one is simply absent here as well.
+fn snapshotInternalBindings(registry: *LibraryRegistry, globals: *std.StringHashMap(Value)) !void {
+    for (&primitives_mod.all_specs) |spec| {
+        if (!spec.libs.contains(.internal)) continue;
+        if (globals.get(spec.name)) |val| {
+            try registry.internal_bindings.put(spec.name, val);
+        }
+    }
+}
+
 /// Register the standard R7RS libraries by deriving exports from spec tables.
 pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.StringHashMap(Value)) !void {
     const allocator = registry.allocator;
@@ -159,6 +191,8 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
     for (extra_std_libraries) |name| {
         try registry.register(Library.init(allocator, name));
     }
+
+    try snapshotInternalBindings(registry, globals);
 }
 
 pub fn registerSandboxedLibraries(registry: *LibraryRegistry, globals: *std.StringHashMap(Value)) !void {
@@ -177,6 +211,8 @@ pub fn registerSandboxedLibraries(registry: *LibraryRegistry, globals: *std.Stri
     for (extra_std_libraries) |name| {
         try registry.register(Library.init(allocator, name));
     }
+
+    try snapshotInternalBindings(registry, globals);
 }
 
 /// Convert a library name from an S-expression list like (scheme base) to

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -98,9 +98,43 @@ pub const Lib = enum {
     // (SRFI 211 is sub-library-only, so the sub-library names must stay
     // file-resolvable).
     srfi_211_primitives,
+    /// `(kaappi primitives)`: the internal helpers a *portable* `.sld` names
+    /// in its own Scheme source -- SRFI 27's random-source accessors, SRFI
+    /// 74's endianness probe, SRFI 271's random ports, the record substrate
+    /// SRFI 57/131/136/150/237 build on. They used to ride along in
+    /// `(scheme base)`, which reserved their names against every user library
+    /// (kaappi#1856); they are named here instead so each `.sld` declares the
+    /// dependency it actually has. Every spec tagged with this is *also*
+    /// tagged `.internal` (see `INTERNAL_PUBLIC`), so compiler-synthesized
+    /// references still resolve against the pristine snapshot.
+    ///
+    /// Not a stability promise: `(kaappi primitives)` is this implementation's
+    /// own substrate, and portable code should use the SRFIs layered over it.
+    kaappi_primitives,
     /// Internal-only tag for primitives that live in vm.globals but must
     /// not be exported by any standard library. No library is registered
     /// for this tag, so `addExportsForLib` never picks these specs up.
+    ///
+    /// Reachable anyway, by two routes that both bypass the import graph:
+    /// compiler-generated code (case-lambda's arity dispatch,
+    /// `define-record-type`'s desugaring, `delay`'s promise construction)
+    /// references them through `Compiler.trueBuiltinRefOrSymbol`, which
+    /// resolves against `LibraryRegistry.internal_bindings`; a portable
+    /// `.sld` that names one in Scheme source imports
+    /// `(kaappi primitives)` (see `kaappi_primitives` above).
+    ///
+    /// Exporting them from `(scheme base)` instead took the whole
+    /// `%`-prefixed namespace away from user libraries, since R7RS 5.2 makes
+    /// importing one name from two libraries with different bindings an
+    /// error — a user library defining its own `%length` could no longer be
+    /// imported at all (kaappi#1856). The comptime guard below keeps them
+    /// out of the `scheme.*` export sets.
+    ///
+    /// A subset of these are additionally *removed* from vm.globals once
+    /// `vm_bootstrap.install()` has captured them (its `internal_helpers`
+    /// list): `%push-wind` and the `%promise-*` mutators corrupt VM state
+    /// if called out of sequence, so they must be unreachable, not merely
+    /// unexported. Being `.internal` does not imply being purged.
     internal,
 
     pub fn canonicalName(self: Lib) []const u8 {
@@ -144,6 +178,7 @@ pub const Lib = enum {
             .srfi_237_primitives => "srfi.237.primitives",
             .srfi_160_primitives => "srfi.160.primitives",
             .srfi_211_primitives => "srfi.211.primitives",
+            .kaappi_primitives => "kaappi.primitives",
             .internal => "kaappi.internal",
         };
     }
@@ -204,6 +239,13 @@ pub const PrimSpec = struct {
 };
 
 const LS = LibSet;
+/// Registered in vm.globals, exported by nothing — see `Lib.internal`.
+pub const INTERNAL = LS.initOne(.internal);
+/// Same, plus exported by `(kaappi primitives)` for the portable `.sld`s that
+/// name it in Scheme source — see `Lib.kaappi_primitives`. The `.internal`
+/// half is not redundant: it is what puts the spec in the pristine snapshot
+/// `Compiler.trueBuiltinRefOrSymbol` resolves against.
+pub const INTERNAL_PUBLIC = LS.initMany(&.{ .internal, .kaappi_primitives });
 const BR = LS.initMany(&.{ .scheme_base, .scheme_r5rs });
 const BRS1 = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 });
 const BCRS1 = LS.initMany(&.{ .scheme_base, .scheme_cxr, .scheme_r5rs, .srfi_1 });
@@ -216,13 +258,15 @@ const core_specs = [_]PrimSpec{
     .{ .name = "set-cdr!", .func = &setCdr, .arity = .{ .exact = 2 }, .libs = BRS1 },
     .{ .name = "list", .func = &list, .arity = .{ .variadic = 0 }, .libs = BRS1 },
     .{ .name = "length", .func = &length, .arity = .{ .exact = 1 }, .libs = BRS1 },
-    // Internal alias for case-lambda's compiled arity dispatch (kaappi#1714):
-    // a library that legitimately shadows `length` (e.g. `except`s it and
-    // supplies its own) must not break case-lambda's dispatch, which needs
-    // the real list-length primitive regardless of what `length` currently
-    // means in scope. Same %-prefixed-internal-primitive convention as
-    // %record-set! etc. below.
-    .{ .name = "%length", .func = &length, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
+    // There is deliberately no `%length` alias here. case-lambda's arity
+    // dispatch needs the real list-length primitive regardless of what
+    // `length` means at its use site (kaappi#1714), but it gets that from
+    // `Compiler.trueBuiltinRefOrSymbol("length")` -- the pristine
+    // `(scheme base)` binding (kaappi#1715) -- rather than a second global.
+    // The alias, exported from `(scheme base)`, made a user library that
+    // defined its own `%length` un-importable (kaappi#1856); the prefixed
+    // reference is also strictly stronger, since a top-level redefinition
+    // could overwrite the alias but cannot touch the export table.
     .{ .name = "append", .func = &append, .arity = .{ .variadic = 0 }, .libs = BRS1 },
     .{ .name = "reverse", .func = &reverse, .arity = .{ .exact = 1 }, .libs = BRS1 },
     .{ .name = "caar", .func = &caarFn, .arity = .{ .exact = 1 }, .libs = BCRS1 },
@@ -249,11 +293,14 @@ const core_specs = [_]PrimSpec{
     .{ .name = "string-length", .func = &stringLength, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_13 }) },
     .{ .name = "string-append", .func = &stringAppend, .arity = .{ .variadic = 0 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_13 }) },
     .{ .name = "symbol->string", .func = &symbolToString, .arity = .{ .exact = 1 }, .libs = BR },
-    .{ .name = "%make-record-type", .func = &makeRecordTypeFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%make-record", .func = &makeRecordFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%record?", .func = &recordCheckFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%record-ref", .func = &recordRefFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%record-set!", .func = &recordSetFn, .arity = .{ .exact = 4 }, .libs = LS.initOne(.scheme_base) },
+    // The record substrate `define-record-type`'s desugarer emits and the
+    // portable record SRFIs (57/131/136/150/237) call directly. Internal,
+    // not `(scheme base)` exports (kaappi#1856).
+    .{ .name = "%make-record-type", .func = &makeRecordTypeFn, .arity = .{ .exact = 2 }, .libs = INTERNAL_PUBLIC },
+    .{ .name = "%make-record", .func = &makeRecordFn, .arity = .{ .variadic = 1 }, .libs = INTERNAL_PUBLIC },
+    .{ .name = "%record?", .func = &recordCheckFn, .arity = .{ .exact = 2 }, .libs = INTERNAL_PUBLIC },
+    .{ .name = "%record-ref", .func = &recordRefFn, .arity = .{ .exact = 3 }, .libs = INTERNAL_PUBLIC },
+    .{ .name = "%record-set!", .func = &recordSetFn, .arity = .{ .exact = 4 }, .libs = INTERNAL_PUBLIC },
     .{ .name = "apply", .func = &applyFn, .arity = .{ .variadic = 2 }, .libs = BR },
 };
 
@@ -306,6 +353,26 @@ comptime {
     for (all_specs) |spec| {
         if (spec.libs.count() == 0)
             @compileError("orphan spec (no libraries): " ++ spec.name);
+    }
+    // A `%`-prefixed name must never be exported by an R7RS standard
+    // library (kaappi#1856). `%` is this codebase's own "private helper"
+    // marker -- and the portable SRFI libraries' -- so user code has good
+    // reason to treat that namespace as its own; exporting `%length` from
+    // `(scheme base)` made a user library that defines its own `%length`
+    // un-importable outright, because R7RS 5.2 makes importing one
+    // identifier from two libraries with different bindings an error
+    // (enforced since kaappi#1726). Internal helpers belong in `.internal`,
+    // which keeps them in vm.globals and out of every export set; a
+    // deliberately public `%` name belongs in a `*_primitives`
+    // sub-library, which a `.sld` opts into by name.
+    for (all_specs) |spec| {
+        if (spec.name[0] != '%') continue;
+        for (std.enums.values(Lib)) |lib| {
+            if (!spec.libs.contains(lib)) continue;
+            if (std.mem.startsWith(u8, lib.canonicalName(), "scheme."))
+                @compileError("%-prefixed spec \"" ++ spec.name ++ "\" is exported by " ++
+                    lib.canonicalName() ++ "; use `.internal` (see Lib.internal) or a *_primitives sub-library");
+        }
     }
 }
 

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -14,7 +14,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "force", .func = primitives.bootstrapStub("force"), .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_lazy, .scheme_r5rs }) },
     .{ .name = "promise?", .func = &promiseP, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_lazy }) },
     .{ .name = "make-promise", .func = &makePromiseFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_lazy }) },
-    .{ .name = "%make-promise-lazy", .func = &makePromiseLazy, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%make-promise-lazy", .func = &makePromiseLazy, .arity = .{ .exact = 1 }, .libs = primitives.INTERNAL },
     .{ .name = "%promise-forced?", .func = &promiseForcedP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.internal) },
     .{ .name = "%promise-forcing?", .func = &promiseForcingP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.internal) },
     .{ .name = "%promise-value", .func = &promiseValue, .arity = .{ .exact = 1 }, .libs = LS.initOne(.internal) },

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -29,8 +29,8 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "get-environment-variable", .func = &getEnvVar, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_process_context), .sandbox = false },
     .{ .name = "get-environment-variables", .func = &getEnvVars, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_process_context), .sandbox = false },
     .{ .name = "make-parameter", .func = &makeParameterFn, .arity = .{ .variadic = 1 }, .libs = LS.initMany(&.{ .scheme_base, .srfi_39 }) },
-    .{ .name = "%parameter-set!", .func = &parameterSetDirectFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%parameter-convert", .func = &parameterConvertFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%parameter-set!", .func = &parameterSetDirectFn, .arity = .{ .exact = 2 }, .libs = primitives.INTERNAL },
+    .{ .name = "%parameter-convert", .func = &parameterConvertFn, .arity = .{ .exact = 2 }, .libs = primitives.INTERNAL },
     .{ .name = "eval", .func = &evalFn, .arity = .{ .variadic = 1 }, .libs = LS.initMany(&.{ .scheme_eval, .scheme_r5rs }), .sandbox = false },
     .{ .name = "environment", .func = &environmentFn, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.scheme_eval), .sandbox = false },
     .{ .name = "interaction-environment", .func = &interactionEnvironmentFn, .arity = .{ .exact = 0 }, .libs = LS.initMany(&.{ .scheme_eval, .scheme_r5rs, .scheme_repl }), .sandbox = false },
@@ -41,7 +41,7 @@ pub const specs = [_]primitives.PrimSpec{
     // Internal fact for portable libraries that need real hardware byte
     // order (e.g. SRFI 74's `(endianness native)`) -- not part of any
     // public R7RS/SRFI surface itself.
-    .{ .name = "%host-big-endian?", .func = &hostBigEndianFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%host-big-endian?", .func = &hostBigEndianFn, .arity = .{ .exact = 0 }, .libs = primitives.INTERNAL_PUBLIC },
 };
 
 fn hostBigEndianFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -17,15 +17,15 @@ fn freshSeed() u64 {
 pub const specs = [_]primitives.PrimSpec{
     .{ .name = "random-integer", .func = &randomIntegerFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "random-real", .func = &randomRealFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%default-random-source", .func = &defaultRandomSourceFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%default-random-source", .func = &defaultRandomSourceFn, .arity = .{ .exact = 0 }, .libs = primitives.INTERNAL_PUBLIC },
     .{ .name = "random-source?", .func = &randomSourcePFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "make-random-source", .func = &makeRandomSourceFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "random-source-randomize!", .func = &randomSourceRandomizeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "random-source-pseudo-randomize!", .func = &randomSourcePseudoRandomizeFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "random-source-state-ref", .func = &randomSourceStateRefFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "random-source-state-set!", .func = &randomSourceStateSetFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%rs-next-int", .func = &rsNextIntFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%rs-next-real", .func = &rsNextRealFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%rs-next-int", .func = &rsNextIntFn, .arity = .{ .exact = 2 }, .libs = primitives.INTERNAL_PUBLIC },
+    .{ .name = "%rs-next-real", .func = &rsNextRealFn, .arity = .{ .exact = 1 }, .libs = primitives.INTERNAL_PUBLIC },
 };
 
 // A fork(2)ed child inherits the parent's PRNG state, and the default source

--- a/src/primitives_random_port.zig
+++ b/src/primitives_random_port.zig
@@ -31,11 +31,11 @@ const version: u8 = 1;
 const seed_len = 32; // bytes consumed to seed the four state words
 
 pub const specs = [_]primitives.PrimSpec{
-    .{ .name = "%random-port-make-randomized", .func = &makeRandomizedFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%random-port-make-from-seed", .func = &makeFromSeedFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%random-port-make-from-state", .func = &makeFromStateFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%random-port-state", .func = &portStateFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "%random-port?", .func = &randomPortPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
+    .{ .name = "%random-port-make-randomized", .func = &makeRandomizedFn, .arity = .{ .exact = 0 }, .libs = primitives.INTERNAL_PUBLIC },
+    .{ .name = "%random-port-make-from-seed", .func = &makeFromSeedFn, .arity = .{ .exact = 1 }, .libs = primitives.INTERNAL_PUBLIC },
+    .{ .name = "%random-port-make-from-state", .func = &makeFromStateFn, .arity = .{ .exact = 1 }, .libs = primitives.INTERNAL_PUBLIC },
+    .{ .name = "%random-port-state", .func = &portStateFn, .arity = .{ .exact = 1 }, .libs = primitives.INTERNAL_PUBLIC },
+    .{ .name = "%random-port?", .func = &randomPortPredFn, .arity = .{ .exact = 1 }, .libs = primitives.INTERNAL_PUBLIC },
 };
 
 /// The determinized random port behind `v`, or a type error.

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -64,18 +64,21 @@ const SRFI237 = LS.initOne(.srfi_237_primitives);
 // %record-split-args are referenced directly by vm_records.zig's R6RS
 // desugarer's GENERATED code, exactly like the original R7RS %make-record/
 // %record?/%record-ref/%record-set! already are -- so they need the same
-// unconditional `.scheme_base` visibility those have (core_specs in
-// primitives.zig), not the `.srfi_237_primitives` sub-library tag, which
-// only gates what `lib/srfi/237/base.sld`'s own procedural-layer Scheme
-// code can `(import (srfi 237 primitives))`.
-const BASE = LS.initOne(.scheme_base);
+// import-free visibility those have (core_specs in primitives.zig), not the
+// `.srfi_237_primitives` sub-library tag, which only gates what
+// `lib/srfi/237/base.sld`'s own procedural-layer Scheme code can
+// `(import (srfi 237 primitives))`. That visibility is `.internal` --
+// registered in vm.globals, exported by no library -- and NOT
+// `.scheme_base`, which would reserve these names against every user
+// library that imports it (kaappi#1856).
+const INTERNAL = primitives.INTERNAL;
 
 pub const specs = [_]primitives.PrimSpec{
     .{ .name = "%make-record-type-descriptor", .func = &makeRecordTypeDescriptorFn, .arity = .{ .exact = 6 }, .libs = SRFI237 },
-    .{ .name = "%record?/inherit", .func = &recordCheckInheritFn, .arity = .{ .exact = 2 }, .libs = BASE },
-    .{ .name = "%record-ref/inherit", .func = &recordRefInheritFn, .arity = .{ .exact = 3 }, .libs = BASE },
-    .{ .name = "%record-set!/inherit", .func = &recordSetInheritFn, .arity = .{ .exact = 4 }, .libs = BASE },
-    .{ .name = "%record-split-args", .func = &recordSplitArgsFn, .arity = .{ .exact = 2 }, .libs = BASE },
+    .{ .name = "%record?/inherit", .func = &recordCheckInheritFn, .arity = .{ .exact = 2 }, .libs = INTERNAL },
+    .{ .name = "%record-ref/inherit", .func = &recordRefInheritFn, .arity = .{ .exact = 3 }, .libs = INTERNAL },
+    .{ .name = "%record-set!/inherit", .func = &recordSetInheritFn, .arity = .{ .exact = 4 }, .libs = INTERNAL },
+    .{ .name = "%record-split-args", .func = &recordSplitArgsFn, .arity = .{ .exact = 2 }, .libs = INTERNAL },
     .{ .name = "%record?/any", .func = &recordCheckAnyFn, .arity = .{ .exact = 1 }, .libs = SRFI237 },
     .{ .name = "%record-rtd", .func = &recordRtdFn, .arity = .{ .exact = 1 }, .libs = SRFI237 },
     .{ .name = "%record-type-name", .func = &recordTypeNameFn, .arity = .{ .exact = 1 }, .libs = SRFI237 },

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -254,13 +254,18 @@ test "case-lambda dispatch is unaffected by a shadowed global length" {
     // Regression (#1714): the desugaring called the global `length` directly
     // to count arguments, so a scope that legitimately shadows `length` (e.g.
     // a library providing its own for a non-standard list-like type) broke
-    // every case-lambda defined within it. Fixed by dispatching through an
-    // internal %length alias instead.
+    // every case-lambda defined within it. Dispatch now goes through
+    // `length`'s pristine (scheme base) binding (#1715's base_binding_prefix),
+    // which no rebinding of either `length` or the former `%length` alias can
+    // reach (#1856).
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
+    // Both names rebound, at top level (which the old alias could not
+    // survive: a top-level define overwrote it in vm.globals) and lexically.
+    _ = try vm.eval("(define (%length x) 'also-shadowed)");
     _ = try vm.eval(
         \\(define f
         \\  (let ()

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -7,6 +7,7 @@ const platform = @import("platform.zig");
 const library_mod = @import("library.zig");
 const primitives_mod = @import("primitives.zig");
 const vm_mod = @import("vm.zig");
+const vm_bootstrap = @import("vm_bootstrap.zig");
 const bytecode_file = @import("bytecode_file.zig");
 
 test "import scheme base" {
@@ -696,13 +697,17 @@ test "every spec name resolves in globals (drift guard)" {
     defer vm.deinit();
 
     for (&primitives_mod.all_specs) |spec| {
-        // .internal-only helpers are deliberately removed from globals by
-        // vm_bootstrap.install() after being captured by the bootstrapped
-        // closures (#1375) — they must NOT resolve.
-        const internal_only = spec.libs.eql(primitives_mod.LibSet.initOne(.internal));
-        if (internal_only) {
+        // The helpers vm_bootstrap.install() removes from globals after the
+        // bootstrapped closures capture them (#1375) must NOT resolve —
+        // calling %push-wind or a %promise-* mutator out of sequence
+        // corrupts VM state. Every other spec must, `.internal` included:
+        // being unexported is not being unreachable (#1856).
+        const purged = for (&vm_bootstrap.internal_helpers) |name| {
+            if (std.mem.eql(u8, name, spec.name)) break true;
+        } else false;
+        if (purged) {
             if (vm.globals.get(spec.name) != null) {
-                std.debug.print("DRIFT: internal spec \"{s}\" is still in globals\n", .{spec.name});
+                std.debug.print("DRIFT: purged spec \"{s}\" is still in globals\n", .{spec.name});
                 return error.TestUnexpectedResult;
             }
             continue;
@@ -712,6 +717,107 @@ test "every spec name resolves in globals (drift guard)" {
             return error.TestUnexpectedResult;
         }
     }
+}
+
+test "no standard library exports a %-prefixed internal (#1856)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The comptime guard in primitives.zig covers the spec tables; this
+    // covers the assembled export sets, which also draw on
+    // library.extra_exports and would not be caught there.
+    var it = vm.libraries.libraries.iterator();
+    while (it.next()) |entry| {
+        const lib_name = entry.key_ptr.*;
+        if (!std.mem.startsWith(u8, lib_name, "scheme.")) continue;
+        var exports = entry.value_ptr.exports.iterator();
+        while (exports.next()) |e| {
+            if (e.key_ptr.*[0] == '%') {
+                std.debug.print("DRIFT: {s} exports \"{s}\"\n", .{ lib_name, e.key_ptr.* });
+                return error.TestUnexpectedResult;
+            }
+        }
+    }
+}
+
+test "(kaappi primitives) exports what the portable .slds import (#1856)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // lib/srfi/{27,74,271/*,57,131,136,150,237}.sld name these in Scheme
+    // source and import (kaappi primitives) for them. A .sld cannot spell the
+    // base_binding_prefix compiler-synthesized references use, so this export
+    // is the only declared route — losing it breaks those libraries at load.
+    const lib = vm.libraries.get("kaappi.primitives") orelse {
+        std.debug.print("(kaappi primitives) is not registered\n", .{});
+        return error.TestUnexpectedResult;
+    };
+    for ([_][]const u8{
+        "%make-record",                 "%make-record-type",            "%record?",
+        "%record-ref",                  "%record-set!",                 "%host-big-endian?",
+        "%rs-next-int",                 "%rs-next-real",                "%default-random-source",
+        "%random-port?",                "%random-port-state",           "%random-port-make-from-seed",
+        "%random-port-make-from-state", "%random-port-make-randomized",
+    }) |name| {
+        if (lib.exports.get(name) == null) {
+            std.debug.print("(kaappi primitives) is missing \"{s}\"\n", .{name});
+            return error.TestUnexpectedResult;
+        }
+        // Same spec is `.internal` too, which is what puts it in the pristine
+        // snapshot the compiler resolves against — the two halves are
+        // independent and both load-bearing.
+        if (vm.libraries.internal_bindings.get(name) == null) {
+            std.debug.print("\"{s}\" is missing from internal_bindings\n", .{name});
+            return error.TestUnexpectedResult;
+        }
+    }
+}
+
+// A user library may define its own %-prefixed name and still import
+// (scheme base): #1856's exact failure was the R7RS 5.2 collision check
+// (#1726) firing between (scheme base)'s %length and the user's own.
+test "user library may define %length alongside (scheme base) (#1856)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-library (mylib ffi)
+        \\  (import (scheme base))
+        \\  (export %length)
+        \\  (begin (define (%length s) (string-length s))))
+    );
+    _ = try vm.eval(
+        \\(define-library (mylib)
+        \\  (import (scheme base) (mylib ffi))
+        \\  (export byte-length)
+        \\  (begin (define (byte-length s) (%length s))))
+    );
+    _ = try vm.eval("(import (mylib))");
+    const result = try vm.eval("(byte-length \"hi\")");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
+
+    // ... and case-lambda's arity dispatch still counts arguments with the
+    // real list-length inside that same library, rather than picking up the
+    // user's one-argument string-length (#1714 via #1715's pristine
+    // (scheme base) reference — the former %length alias, being an ordinary
+    // global, would have lost to the import here).
+    _ = try vm.eval(
+        \\(define-library (mylib cl)
+        \\  (import (scheme base) (mylib ffi))
+        \\  (export pick)
+        \\  (begin
+        \\    (define pick (case-lambda ((a) 'one) ((a b) 'two)))))
+    );
+    _ = try vm.eval("(import (mylib cl))");
+    const two = try vm.eval("(pick 1 2)");
+    try std.testing.expect(types.isSymbol(two));
+    try std.testing.expectEqualStrings("two", types.toObject(two).as(types.Symbol).name);
 }
 
 // ── SRFI 261 (#1645): portable SRFI library references ──────────────────────

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -127,10 +127,21 @@ fn checkSrfiFeature(name: []const u8) bool {
 /// startup from vm.globals and never touched again afterward — rather than
 /// vm.globals itself, which a later top-level `define` (or a library like
 /// SRFI 101 redefining `list`) freely overwrites (#1715).
+///
+/// Falls back to the `.internal` primitives' snapshot, which has the same
+/// write-once-at-startup property but hangs off no `(scheme …)` library
+/// (#1856). Compiler-synthesized code reaches
+/// `%make-record`/`%record-ref`/`%parameter-set!`/… through here, so a user
+/// program is free to bind those names itself without breaking
+/// `define-record-type`, `parameterize`, or `delay` in the same scope. The two
+/// tables have disjoint key sets — a `%`-prefixed name is never a `scheme.*`
+/// export (comptime-enforced in primitives.zig) — so the order is immaterial.
 fn lookupBaseBinding(name: []const u8) ?Value {
     const vm = vm_instance orelse return null;
-    const lib = vm.libraries.get("scheme.base") orelse return null;
-    return lib.exports.get(name);
+    if (vm.libraries.get("scheme.base")) |lib| {
+        if (lib.exports.get(name)) |val| return val;
+    }
+    return vm.libraries.internal_bindings.get(name);
 }
 
 /// The canonical name of the library currently being compiled, live for the
@@ -245,6 +256,11 @@ fn markVMRoots(gc: *memory.GC) void {
             var eit = env.valueIterator();
             while (eit.next()) |v| gc.markValue(v.*);
         }
+        // The pristine `.internal` primitives (#1856): only compiler-
+        // synthesized references reach them, so a user `define` of the same
+        // name is all it takes for globals to stop holding them.
+        var iit = vm.libraries.internal_bindings.valueIterator();
+        while (iit.next()) |v| gc.markValue(v.*);
     }
 
     // Mark library environments being built by handleDefineLibrary

--- a/src/vm_bootstrap.zig
+++ b/src/vm_bootstrap.zig
@@ -42,7 +42,13 @@ pub fn install(vm: *VM) VMError!void {
     vm.global_version +%= 1;
 }
 
-const internal_helpers = [_][]const u8{
+/// The `.internal` specs that must not merely be unexported but unreachable:
+/// removed from vm.globals by `install()` above. Every other `.internal`
+/// spec stays in globals on purpose — compiler-generated code and portable
+/// `.sld` bodies reach those by name (see `primitives.Lib.internal`). Public
+/// so `tests_libraries.zig`'s drift guard tests that distinction instead of
+/// assuming the two sets coincide.
+pub const internal_helpers = [_][]const u8{
     "%push-wind",
     "%pop-wind",
     "%promise-forced?",

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -11,6 +11,7 @@ const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
 
 const srfi237_prims = @import("primitives_srfi237.zig");
+const globals_mod = @import("globals.zig");
 
 /// Handle (define-record-type name (ctor field ...) pred (field accessor [mutator]) ...)
 /// Desugars into define forms using internal record primitives.
@@ -53,7 +54,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         const rt_local = vm.gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
 
         var body_args: [258]Value = undefined;
-        body_args[0] = vm.gc.allocSymbol("%make-record") catch return VMError.OutOfMemory;
+        body_args[0] = globals_mod.baseBindingSymbol(vm.gc, "%make-record") catch return VMError.OutOfMemory;
         body_args[1] = rt_local;
 
         for (0..all_field_count) |fi| {
@@ -118,7 +119,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         const define_sym = vm.gc.allocSymbol("define") catch return VMError.OutOfMemory;
         const v_sym = vm.gc.allocSymbol("v") catch return VMError.OutOfMemory;
         const pred_sym = vm.gc.allocSymbol(pred_name) catch return VMError.OutOfMemory;
-        const record_check_sym = vm.gc.allocSymbol("%record?") catch return VMError.OutOfMemory;
+        const record_check_sym = globals_mod.baseBindingSymbol(vm.gc, "%record?") catch return VMError.OutOfMemory;
 
         const body = vm.gc.makeList(&[_]Value{ record_check_sym, v_sym, rt_local }) catch return VMError.OutOfMemory;
         const params = vm.gc.makeList(&[_]Value{v_sym}) catch return VMError.OutOfMemory;
@@ -157,7 +158,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const define_sym = vm.gc.allocSymbol("define") catch return VMError.OutOfMemory;
             const p_sym = vm.gc.allocSymbol("p") catch return VMError.OutOfMemory;
             const acc_sym = vm.gc.allocSymbol(spec.accessor_names[fi]) catch return VMError.OutOfMemory;
-            const record_ref_sym = vm.gc.allocSymbol("%record-ref") catch return VMError.OutOfMemory;
+            const record_ref_sym = globals_mod.baseBindingSymbol(vm.gc, "%record-ref") catch return VMError.OutOfMemory;
             const idx_val = types.makeFixnum(@intCast(fi));
 
             const body = vm.gc.makeList(&[_]Value{ record_ref_sym, p_sym, idx_val, rt_local }) catch return VMError.OutOfMemory;
@@ -196,7 +197,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             const p_sym = vm.gc.allocSymbol("p") catch return VMError.OutOfMemory;
             const v_sym = vm.gc.allocSymbol("v") catch return VMError.OutOfMemory;
             const mut_sym = vm.gc.allocSymbol(mut_name) catch return VMError.OutOfMemory;
-            const record_set_sym = vm.gc.allocSymbol("%record-set!") catch return VMError.OutOfMemory;
+            const record_set_sym = globals_mod.baseBindingSymbol(vm.gc, "%record-set!") catch return VMError.OutOfMemory;
             const idx_val = types.makeFixnum(@intCast(fi));
 
             const body = vm.gc.makeList(&[_]Value{ record_set_sym, p_sym, idx_val, v_sym, rt_local }) catch return VMError.OutOfMemory;
@@ -619,7 +620,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
             extract_elems[0] = gc.allocSymbol("list") catch return VMError.OutOfMemory;
             const parent_inst_sym = gc.allocSymbol(" __parent-inst") catch return VMError.OutOfMemory;
             for (0..parent_total_fields) |fi| {
-                const rr_sym = gc.allocSymbol("%record-ref") catch return VMError.OutOfMemory;
+                const rr_sym = globals_mod.baseBindingSymbol(gc, "%record-ref") catch return VMError.OutOfMemory;
                 extract_elems[1 + fi] = gc.makeList(&[_]Value{ rr_sym, parent_inst_sym, types.makeFixnum(@intCast(fi)), parent_rt_ref }) catch return VMError.OutOfMemory;
             }
             const parent_fields_list = gc.makeList(extract_elems[0 .. 1 + parent_total_fields]) catch return VMError.OutOfMemory;
@@ -629,7 +630,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
                 const own_args_sym = gc.allocSymbol(" __own-args") catch return VMError.OutOfMemory;
                 const apply_sym = gc.allocSymbol("apply") catch return VMError.OutOfMemory;
                 const append_sym = gc.allocSymbol("append") catch return VMError.OutOfMemory;
-                const mr_sym = gc.allocSymbol("%make-record") catch return VMError.OutOfMemory;
+                const mr_sym = globals_mod.baseBindingSymbol(gc, "%make-record") catch return VMError.OutOfMemory;
                 const rt_local = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
                 const appended = gc.makeList(&[_]Value{ append_sym, parent_fields_list, own_args_sym }) catch return VMError.OutOfMemory;
                 const inner_body = gc.makeList(&[_]Value{ apply_sym, mr_sym, rt_local, appended }) catch return VMError.OutOfMemory;
@@ -652,7 +653,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
                 // (lambda call-args (let* ((__split (%record-split-args call-args own-count)) (__parent-inst (apply parent-ctor (car __split)))) (apply %make-record __rt (append (list ...parent fields...) (cdr __split)))))
                 const call_args_sym = gc.allocSymbol(" __call-args") catch return VMError.OutOfMemory;
                 const split_sym = gc.allocSymbol(" __split") catch return VMError.OutOfMemory;
-                const rss_sym = gc.allocSymbol("%record-split-args") catch return VMError.OutOfMemory;
+                const rss_sym = globals_mod.baseBindingSymbol(gc, "%record-split-args") catch return VMError.OutOfMemory;
                 const own_count_val = types.makeFixnum(@intCast(spec.field_count));
                 const split_call = gc.makeList(&[_]Value{ rss_sym, call_args_sym, own_count_val }) catch return VMError.OutOfMemory;
 
@@ -668,7 +669,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
 
                 const append_sym = gc.allocSymbol("append") catch return VMError.OutOfMemory;
                 const appended = gc.makeList(&[_]Value{ append_sym, parent_fields_list, own_args_expr }) catch return VMError.OutOfMemory;
-                const mr_sym = gc.allocSymbol("%make-record") catch return VMError.OutOfMemory;
+                const mr_sym = globals_mod.baseBindingSymbol(gc, "%make-record") catch return VMError.OutOfMemory;
                 const rt_local = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
                 const final_body = gc.makeList(&[_]Value{ apply_sym, mr_sym, rt_local, appended }) catch return VMError.OutOfMemory;
 
@@ -684,7 +685,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
         } else {
             // No parent: (lambda (f1 ... fn) (%make-record __rt f1 ... fn)), optionally wrapped in the protocol.
             var body_elems: [258]Value = undefined;
-            body_elems[0] = gc.allocSymbol("%make-record") catch return VMError.OutOfMemory;
+            body_elems[0] = globals_mod.baseBindingSymbol(gc, "%make-record") catch return VMError.OutOfMemory;
             body_elems[1] = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
             var param_syms: [256]Value = undefined;
             for (0..spec.field_count) |fi| {
@@ -727,7 +728,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
         const gc = vm.gc;
         const v_sym = gc.allocSymbol("v") catch return VMError.OutOfMemory;
         const rt_local = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
-        const rci_sym = gc.allocSymbol("%record?/inherit") catch return VMError.OutOfMemory;
+        const rci_sym = globals_mod.baseBindingSymbol(gc, "%record?/inherit") catch return VMError.OutOfMemory;
         const body = gc.makeList(&[_]Value{ rci_sym, v_sym, rt_local }) catch return VMError.OutOfMemory;
         const params = gc.makeList(&[_]Value{v_sym}) catch return VMError.OutOfMemory;
         const lambda_sym = gc.allocSymbol("lambda") catch return VMError.OutOfMemory;
@@ -750,7 +751,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
             const gc = vm.gc;
             const p_sym = gc.allocSymbol("p") catch return VMError.OutOfMemory;
             const rt_local = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
-            const rri_sym = gc.allocSymbol("%record-ref/inherit") catch return VMError.OutOfMemory;
+            const rri_sym = globals_mod.baseBindingSymbol(gc, "%record-ref/inherit") catch return VMError.OutOfMemory;
             const idx_val = types.makeFixnum(@intCast(abs_idx));
             const body = gc.makeList(&[_]Value{ rri_sym, p_sym, idx_val, rt_local }) catch return VMError.OutOfMemory;
             const params = gc.makeList(&[_]Value{p_sym}) catch return VMError.OutOfMemory;
@@ -770,7 +771,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
             const p_sym = gc.allocSymbol("p") catch return VMError.OutOfMemory;
             const v_sym = gc.allocSymbol("v") catch return VMError.OutOfMemory;
             const rt_local = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
-            const rsi_sym = gc.allocSymbol("%record-set!/inherit") catch return VMError.OutOfMemory;
+            const rsi_sym = globals_mod.baseBindingSymbol(gc, "%record-set!/inherit") catch return VMError.OutOfMemory;
             const idx_val = types.makeFixnum(@intCast(abs_idx));
             const body = gc.makeList(&[_]Value{ rsi_sym, p_sym, idx_val, v_sym, rt_local }) catch return VMError.OutOfMemory;
             const params = gc.makeList(&[_]Value{ p_sym, v_sym }) catch return VMError.OutOfMemory;
@@ -977,7 +978,7 @@ pub fn expandRecordTypeDefines(
 
     // 1. (define __rt (%make-record-type "name" num_fields))
     {
-        const mrt_sym = gc.allocSymbol("%make-record-type") catch return CompileError.OutOfMemory;
+        const mrt_sym = globals_mod.baseBindingSymbol(gc, "%make-record-type") catch return CompileError.OutOfMemory;
         const name_str = gc.allocString(spec.type_name) catch return CompileError.OutOfMemory;
         const nf_val = types.makeFixnum(@intCast(spec.field_count));
         def_inits[count.*] = gc.makeList(&[_]Value{ mrt_sym, name_str, nf_val }) catch return CompileError.OutOfMemory;
@@ -990,7 +991,7 @@ pub fn expandRecordTypeDefines(
     {
         const rt_local = gc.allocSymbol(" __rt") catch return CompileError.OutOfMemory;
         const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-        const mr_sym = gc.allocSymbol("%make-record") catch return CompileError.OutOfMemory;
+        const mr_sym = globals_mod.baseBindingSymbol(gc, "%make-record") catch return CompileError.OutOfMemory;
 
         var body_elems: [258]Value = undefined;
         body_elems[0] = mr_sym;
@@ -1032,7 +1033,7 @@ pub fn expandRecordTypeDefines(
     {
         const rt_local = gc.allocSymbol(" __rt") catch return CompileError.OutOfMemory;
         const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-        const rc_sym = gc.allocSymbol("%record?") catch return CompileError.OutOfMemory;
+        const rc_sym = globals_mod.baseBindingSymbol(gc, "%record?") catch return CompileError.OutOfMemory;
         const v_sym = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
 
         const body = gc.makeList(&[_]Value{ rc_sym, v_sym, rt_local }) catch return CompileError.OutOfMemory;
@@ -1052,7 +1053,7 @@ pub fn expandRecordTypeDefines(
     for (0..spec.field_count) |fi| {
         const rt_local = gc.allocSymbol(" __rt") catch return CompileError.OutOfMemory;
         const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-        const rr_sym = gc.allocSymbol("%record-ref") catch return CompileError.OutOfMemory;
+        const rr_sym = globals_mod.baseBindingSymbol(gc, "%record-ref") catch return CompileError.OutOfMemory;
         const p_sym = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
         const idx = types.makeFixnum(@intCast(fi));
 
@@ -1074,7 +1075,7 @@ pub fn expandRecordTypeDefines(
         if (spec.mutator_names[fi]) |mname| {
             const rt_local = gc.allocSymbol(" __rt") catch return CompileError.OutOfMemory;
             const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
-            const rs_sym = gc.allocSymbol("%record-set!") catch return CompileError.OutOfMemory;
+            const rs_sym = globals_mod.baseBindingSymbol(gc, "%record-set!") catch return CompileError.OutOfMemory;
             const p_sym = gc.allocSymbol("p") catch return CompileError.OutOfMemory;
             const v_sym = gc.allocSymbol("v") catch return CompileError.OutOfMemory;
             const idx = types.makeFixnum(@intCast(fi));

--- a/tests/scheme/smoke/lib1856/ffi.sld
+++ b/tests/scheme/smoke/lib1856/ffi.sld
@@ -1,0 +1,9 @@
+;; Fixture for percent-name-user-library-1856.scm: a user library that
+;; defines its own %-prefixed helpers and exports them.
+(define-library (lib1856 ffi)
+  (import (scheme base))
+  (export %length %record-ref %make-record)
+  (begin
+    (define (%length s) (string-length s))
+    (define (%record-ref . args) 'user-record-ref)
+    (define (%make-record . args) 'user-make-record)))

--- a/tests/scheme/smoke/lib1856/user.sld
+++ b/tests/scheme/smoke/lib1856/user.sld
@@ -1,0 +1,15 @@
+;; A library that imports both (scheme base) and the %-defining library above,
+;; and uses the forms whose desugarings reference the internal helpers those
+;; names used to collide with.
+(define-library (lib1856 user)
+  (import (scheme base) (lib1856 ffi))
+  (export byte-length pick point-x make-point user-helpers)
+  (begin
+    (define (byte-length s) (%length s))
+    ;; case-lambda's arity dispatch must count arguments with the real
+    ;; list-length, not the one-argument %length imported above (#1714).
+    (define pick (case-lambda ((a) 'one) ((a b) 'two) ((a b . r) 'many)))
+    ;; define-record-type's desugaring must use the real record primitives,
+    ;; not the imported %record-ref / %make-record.
+    (define-record-type point (make-point x y) point? (x point-x) (y point-y))
+    (define (user-helpers) (list (%record-ref 0 0 0) (%make-record)))))

--- a/tests/scheme/smoke/percent-name-user-library-1856.scm
+++ b/tests/scheme/smoke/percent-name-user-library-1856.scm
@@ -1,0 +1,42 @@
+;; Regression test for #1856: (scheme base) exported 22 %-prefixed internal
+;; primitives, so a user library defining any of those names and importing
+;; (scheme base) failed to load outright — R7RS 5.2 makes importing one
+;; identifier from two libraries with different bindings an error, which
+;; kaappi enforces since #1726. The internals moved to the .internal tag
+;; (registered in vm.globals, exported by no standard library), and the
+;; desugarings that reference them now go through the pristine (scheme base)
+;; snapshot, so a user binding of the same name cannot reach them either.
+;;
+;; The fixture libraries live in lib1856/ and are found via the script's own
+;; directory on the library search path.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64)
+        (lib1856 user) (lib1856 ffi))
+
+(test-begin "percent-name-user-library-1856")
+
+;; The whole library loads at all — this is the issue's own reproduction.
+(test-equal "user %length is the user's" 2 (byte-length "hi"))
+
+;; ... and the internal helpers the same library's desugarings need are
+;; unaffected by the user's same-named bindings.
+(test-equal "case-lambda dispatch: 1 arg" 'one (pick 1))
+(test-equal "case-lambda dispatch: 2 args" 'two (pick 1 2))
+(test-equal "case-lambda dispatch: rest" 'many (pick 1 2 3))
+(test-equal "define-record-type accessor" 3 (point-x (make-point 3 4)))
+(test-equal "the user's own %-helpers are still theirs"
+            '(user-record-ref user-make-record) (user-helpers))
+
+;; Same names, rebound at program top level this time: a top-level define
+;; overwrites vm.globals, which the old %length alias could not survive.
+(define (%length x) 'top-level-shadow)
+(define (%record-ref a b c) 'top-level-shadow)
+(define (%make-record . a) 'top-level-shadow)
+(define g (case-lambda ((a) 'one) ((a b) 'two)))
+(define-record-type pt (mk a) pt? (a pt-a))
+(test-equal "case-lambda under top-level %length" 'two (g 1 2))
+(test-equal "define-record-type under top-level %record-ref" 7 (pt-a (mk 7)))
+(test-equal "top-level %-bindings are still the user's" 'top-level-shadow (%length "x"))
+
+(let ((runner (test-runner-current)))
+  (test-end "percent-name-user-library-1856")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #1856.

## The bug

`(scheme base)` exported **22** `%`-prefixed internal primitives (the issue counted 18 — four more, `%record?/inherit` and friends, were tagged through a `BASE` alias in `primitives_srfi237.zig` and slipped the issue's grep). Because v0.22.0 also began enforcing R7RS 5.2 (#1726), a user library that defined any of those names and imported `(scheme base)` failed to load outright. `%` is this codebase's own private-helper marker, so user code has good reason to treat that namespace as its own — the documented C-extension walkthrough, whose example FFI library exported `%length`, was a real casualty.

## Answering the issue's question

The issue asked whether export-set membership was intended or incidental. **Incidental for all 22** — but they split into two groups by who names them, and the fix treats them differently:

| Who names it | Where it went |
|---|---|
| Only Zig-generated code — `%make-promise-lazy`, `%parameter-set!`, `%parameter-convert`, `%record?/inherit`, `%record-ref/inherit`, `%record-set!/inherit`, `%record-split-args` | `.internal`: registered in `vm.globals`, exported by nothing |
| A portable `.sld` names it in Scheme source — SRFI 27's random-source accessors, SRFI 74's endianness probe, SRFI 271's random ports, the record substrate SRFI 57/131/136/150/237 build on | `.internal` **plus** a new `(kaappi primitives)` library those `.sld`s now import |

A comptime check in `primitives.zig` now rejects any `%` name tagged with a `scheme.*` library, so this can't drift back.

`(kaappi primitives)` is deliberately importable and deliberately not a stability promise: it exposes exactly what `(scheme base)` already exposed, but namespaced and opt-in, and it lets each `.sld` declare the dependency it actually has instead of relying on ambient visibility.

## Unexporting alone would have been a silent regression

A library defining its own `%record-ref` would now load — and its `define-record-type` accessors would then call it:

```scheme
(define-library (u rec)
  (import (scheme base))
  (export get)
  (begin
    (define (%record-ref a b c) 'user-version)
    (define-record-type point (make-point x y) point? (x point-x) (y point-y))
    (define (get) (point-x (make-point 7 8)))))
;; without the second half of this PR: (get) => user-version
```

So compiler-synthesized references now go through `Compiler.trueBuiltinRefOrSymbol` / `globals_mod.baseBindingSymbol`, resolving against a pristine startup snapshot (`LibraryRegistry.internal_bindings`) instead of `vm.globals` — the same mechanism #1715 already used for `let-values`. The user's `%record-ref` stays theirs; `define-record-type` gets the real one. Same for `case-lambda`, `parameterize`, and `delay`.

`%length` is **deleted** rather than relocated: `case-lambda`'s arity dispatch references `length`'s pristine `(scheme base)` binding directly. That is what the alias existed to approximate (#1714) and is strictly stronger — a top-level `(define (%length x) ...)` could overwrite the alias but cannot touch the export table. The name is now entirely free for users.

## Two adjacent fixes

- **`kaappi check` KP4001 noise.** The lint judged base-binding-prefixed names against `ir.globals`, which cannot see them. Already wrong for `let-values`' synthesized `call-with-values`; `case-lambda`/`define-record-type`/`parameterize`/`delay` would have made it common. Now skipped, exactly like the hygienic-prefix case beside it.
- **Globals drift guard.** It assumed every `.internal` spec is purged from globals by `vm_bootstrap.install()`, which only held while the two sets happened to coincide. It now tests the real invariant against `vm_bootstrap.internal_helpers`.

## Found along the way, not fixed here

`kaappi check lib/srfi/27.sld` failing during development exposed a **pre-existing** gap: a library-body *top-level* reference to a global the library hasn't imported raises "undefined variable", while the identical reference inside a lambda in the same library resolves. It reproduces with `cadar` on `main` (nothing to do with this PR) — `compileExpressionInEnv` sets `restricted_globals` on the outer function of every library-body form, which gates off the `vm.globals` fallback #1831 added. Filed separately; this PR sidesteps it by giving the portable `.sld`s explicit imports, which is better style regardless.

## Testing

- New Scheme regression test `tests/scheme/smoke/percent-name-user-library-1856.scm` with `lib1856/` fixtures — the issue's own multi-file reproduction, plus the shadowing cases above at both library and program top level.
- New unit tests: no `scheme.*` library exports a `%` name; `(kaappi primitives)` exports what the `.sld`s import; a user library may define `%length` alongside `(scheme base)`.
- `tests_advanced.zig`'s #1714 test now also rebinds `%length` at top level, which the old alias could not survive.
- Full suite: **2014 Scheme tests pass, 0 fail** (was 2001 with 12 failing mid-refactor); `zig build test` green; `--sandbox`, `zig build wasm`, and `-Dtarget=x86_64-linux` all verified.

## Note for the docs repo

kaappi/kaappi.github.io@4d60e00 renamed the C-extension walkthrough's `%length` to `%strlen` to work around this. That workaround is no longer needed — `%length` is a free name again — though nothing breaks if it stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)