### PR TITLE
Correct the three "add a built-in procedure" docs (#1863)

### DIFF
--- a/.claude/skills/add-builtin/SKILL.md
+++ b/.claude/skills/add-builtin/SKILL.md
@@ -4,18 +4,28 @@ description: Pattern for adding a new built-in Scheme procedure to Kaappi
 
 # Add a Built-in Procedure
 
+Checklist. `docs/dev/adding-features.md` ("Adding a Built-in Procedure") is the
+detailed reference — read it for anything this doesn't cover.
+
 ## Steps
 
-1. **Define the function** in `src/primitives.zig`:
+1. **Define the function** in the `src/primitives_*.zig` file matching its
+   domain (arithmetic, string, vector, I/O, …). There are 31; `primitives.zig`
+   itself is the registration hub plus core list/pair ops, so a new procedure
+   rarely belongs there:
 
 ```zig
 fn myProc(args: []const Value) PrimitiveError!Value {
-    // Validate arg types
-    if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
+    // Validate arg types — typeError names the procedure and the bad value
+    if (!types.isFixnum(args[0]))
+        return primitives.typeError("my-proc", "exact integer", args[0]);
     // Compute result
     return types.makeFixnum(result);
 }
 ```
+
+The signature is always `fn([]const Value) PrimitiveError!Value`; arity is
+already checked by the dispatch layer.
 
 2. **Add a spec entry** to the file's `specs` table. One entry carries the
    name, function, arity, and the libraries that export it — `library.zig`
@@ -39,22 +49,24 @@ Two cases:
 Synthesize *references* to either with `Compiler.trueBuiltinRefOrSymbol` /
 `globals_mod.baseBindingSymbol`, never a bare `allocSymbol("%foo")` — that
 picks up a user binding of the same name.
-See `docs/dev/adding-features.md`.
 
-3. **Add a test** in `src/vm.zig` test section:
+3. **Add a test** in the matching `src/tests_*.zig` file (44 of them, one per
+   feature area — a new file only for a genuinely new area). Not in
+   `src/vm.zig`: its single `test` block only imports sibling modules into the
+   test build and holds no assertions. Use the `testing_helpers.zig` helpers:
 
 ```zig
-test "eval my-proc" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try makeTestVM(&gc);
-    defer vm.deinit();
-    const result = try vm.eval("(my-proc 42)");
-    try std.testing.expectEqual(@as(i64, expected), types.toFixnum(result));
+const th = @import("testing_helpers.zig");
+
+test "my-proc increments" {
+    try th.expectEval("(my-proc 42)", 43);
 }
 ```
 
-4. **Update STATUS.md** — add the procedure to the "Implemented" list.
+`th.expectEvalTrue` / `expectEvalBool` / `expectEvalVoid` cover other result
+shapes; `th.TestContext` is for multiple evals or inspecting the result value.
+Add a Scheme test under `tests/scheme/` when the behavior deserves an
+end-to-end check — and a bug fix always needs a regression test.
 
 ## Arity options
 
@@ -63,13 +75,39 @@ test "eval my-proc" {
 
 ## Heap allocation in primitives
 
-If the procedure needs to allocate (cons, list, string operations), use the global GC instance:
+To allocate (cons, list, string operations), take the threadlocal GC instance
+from `memory.zig` — `primitives.zig` does not re-export it:
 
 ```zig
-const gc = gc_instance orelse return PrimitiveError.OutOfMemory;
+const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 return gc.allocPair(a, b) catch return PrimitiveError.OutOfMemory;
 ```
 
+Read `.claude/rules/gc-safety.md` before allocating more than once: values held
+in Zig locals across a second allocation need rooting, and mutating a heap
+object's fields needs a write barrier.
+
+## Calling back into Scheme
+
+```zig
+const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+return vm.callWithArgs(proc, call_args);
+```
+
+Let the callee's error propagate — `PrimitiveError` and `VMError` are both
+aliases of `errors.KaappiError`, so a raise inside the Scheme procedure returns
+out of your primitive with its detail intact.
+
 ## Error handling
 
-Return `PrimitiveError.TypeError` for type errors, `PrimitiveError.DivisionByZero`, etc.
+Use `primitives.typeError(proc, expected, got)` for type checks — it produces
+`type error in 'my-proc': expected exact integer, got #t` instead of an
+anonymous `TypeError`. The `format` CI job ratchets against new bare
+`return PrimitiveError.TypeError`, so adding one fails the build; only
+infrastructure guards with no procedure context to report opt out, with
+`// bare-ok: <reason>`.
+
+`expectFixnum` / `expectString` / `expectChar` / `expectPair` / `expectVector` /
+`expectPort` validate and unwrap in one step, and `indexError(proc, index, len)`
+covers out-of-range access. Other error tags (`DivisionByZero`,
+`IndexOutOfBounds`, `OutOfMemory`, …) are returned directly.

--- a/.claude/skills/add-builtin/SKILL.md
+++ b/.claude/skills/add-builtin/SKILL.md
@@ -10,9 +10,9 @@ detailed reference — read it for anything this doesn't cover.
 ## Steps
 
 1. **Define the function** in the `src/primitives_*.zig` file matching its
-   domain (arithmetic, string, vector, I/O, …). There are 31; `primitives.zig`
-   itself is the registration hub plus core list/pair ops, so a new procedure
-   rarely belongs there:
+   domain (arithmetic, string, vector, I/O, …). There are 30 of those;
+   `primitives.zig` itself is the registration hub plus core list/pair ops, so
+   a new procedure rarely belongs there:
 
 ```zig
 fn myProc(args: []const Value) PrimitiveError!Value {
@@ -20,7 +20,8 @@ fn myProc(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0]))
         return primitives.typeError("my-proc", "exact integer", args[0]);
     // Compute result
-    return types.makeFixnum(result);
+    const n = types.toFixnum(args[0]);
+    return types.makeFixnum(n + 1);
 }
 ```
 
@@ -109,5 +110,6 @@ infrastructure guards with no procedure context to report opt out, with
 
 `expectFixnum` / `expectString` / `expectChar` / `expectPair` / `expectVector` /
 `expectPort` validate and unwrap in one step, and `indexError(proc, index, len)`
-covers out-of-range access. Other error tags (`DivisionByZero`,
-`IndexOutOfBounds`, `OutOfMemory`, …) are returned directly.
+covers out-of-range access — prefer it over returning `IndexOutOfBounds` bare,
+for the same reason. Error tags with no detail to attach (`DivisionByZero`,
+`OutOfMemory`, …) are returned directly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,14 @@ jobs:
       - name: Format check
         run: zig fmt --check src/
 
+      # Ratchet: lower the baseline whenever the count drops, so the guard keeps
+      # its bite. Was 91 when introduced; the remaining 20 are in
+      # primitives{,_hashtable,_parallel,_srfi18,_srfi237}.zig.
       - name: Check bare TypeError regression
         run: |
           count=$(grep -r 'return PrimitiveError\.TypeError' src/primitives*.zig | grep -v 'bare-ok' | wc -l | tr -d ' ')
-          echo "Unannotated bare TypeErrors: $count (baseline: 91)"
-          if [ "$count" -gt 91 ]; then
+          echo "Unannotated bare TypeErrors: $count (baseline: 20)"
+          if [ "$count" -gt 20 ]; then
             echo "::error::New bare PrimitiveError.TypeError without 'bare-ok' annotation."
             echo "Use primitives.typeError(proc, expected, got) for type checks."
             echo "Only add '// bare-ok: <reason>' for infrastructure guards."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -991,7 +991,7 @@ map.deinit();  // no allocator arg needed
 `docs/dev/adding-features.md` is the detailed reference; this is the checklist.
 
 1. Write the function in the appropriate `src/primitives_*.zig` file — one of
-   the 31 domain files, not `primitives.zig` itself (that's the registration
+   the 30 domain files, not `primitives.zig` itself (that's the registration
    hub plus core list/pair ops):
 
    ```zig

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `vm_continuations.zig` | captureContinuation, restoreContinuation, performWindTransition, callWithCC |
 | `vm_debug.zig` | Stepping debugger: breakpoints (with conditions), watch expressions, step/next/step-out/continue, up/down frame navigation, locals, backtrace |
 
-### Primitives (split into 26 files)
+### Primitives (split into 31 files)
 
 | File | Procedures |
 |------|-----------|
@@ -337,6 +337,15 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `primitives_srfi18.zig` | SRFI-18: threads, mutexes, condition variables, time objects |
 | `primitives_srfi258.zig` | SRFI-258: uninterned symbols (string->uninterned-symbol, symbol-interned?, generate-uninterned-symbol) |
 | `primitives_srfi260.zig` | SRFI-260: generated symbols (generate-symbol) |
+| `primitives_srfi160.zig` | SRFI-160: the 6 generic `%`-prefixed `NumericVector` primitives every per-type `.sld` builds on |
+| `primitives_srfi181.zig` | SRFI-181: custom ports (the 5 `make-custom-*-port` constructors) and `%transcoded-port` |
+| `primitives_srfi211.zig` | SRFI-211: `er-macro-transformer`, `lisp-transformer` procedural transformer constructors |
+| `primitives_srfi237.zig` | SRFI-237: R6RS record procedural layer (`(srfi 237 primitives)`) |
+| `primitives_srfi254.zig` | SRFI-254: ephemeron/guardian constructors, predicates, accessors (GC half lives in `gc_collect.zig`) |
+| `primitives_fiber.zig` | `(kaappi fibers)`: spawn, yield, fiber-join, channels |
+| `primitives_parallel.zig` | KEP-0002: the single native primitive backing `lib/kaappi/parallel.sld` |
+| `primitives_random_port.zig` | SRFI-271 random port `%`-prefixed internals |
+| `primitives_sysinfo.zig` | System inquiry shared by SRFI 59 (vicinity), 112 (environment), 193 (command line) |
 
 ### Other
 
@@ -979,14 +988,26 @@ map.deinit();  // no allocator arg needed
 
 ## How to add a new built-in procedure
 
-1. Write the function in the appropriate `src/primitives_*.zig` file:
+`docs/dev/adding-features.md` is the detailed reference; this is the checklist.
+
+1. Write the function in the appropriate `src/primitives_*.zig` file — one of
+   the 31 domain files, not `primitives.zig` itself (that's the registration
+   hub plus core list/pair ops):
 
    ```zig
    fn myProc(args: []const Value) PrimitiveError!Value {
-       if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
+       if (!types.isFixnum(args[0]))
+           return primitives.typeError("my-proc", "exact integer", args[0]);
        return types.makeFixnum(types.toFixnum(args[0]) + 1);
    }
    ```
+
+   Report type errors with `primitives.typeError(proc, expected, got)`, never a
+   bare `return PrimitiveError.TypeError` — it names the procedure and the
+   offending value in the message, and the `format` CI job ratchets against new
+   bare returns. `expectFixnum`/`expectString`/`expectPair`/… validate and
+   unwrap in one step. Infrastructure guards with no procedure context to
+   report opt out with `// bare-ok: <reason>`.
 
 2. Add one entry to the file's `specs` table — name, function, arity, and the
    libraries that export it. `registerAll` walks `all_specs` and
@@ -1012,8 +1033,21 @@ map.deinit();  // no allocator arg needed
    user binding of the same name silently wins. See
    `docs/dev/adding-features.md`.
 
-4. If the procedure needs heap allocation, use `primitives.gc_instance`.
-   If it needs to call Scheme procedures, use `primitives.vm_instance`.
+4. If the procedure needs heap allocation, use `memory.gc_instance` (a
+   threadlocal in `src/memory.zig`; `primitives.zig` does not re-export it).
+   If it needs to call Scheme procedures, use `vm_mod.vm_instance` and
+   `vm.callWithArgs(proc, args)`. Both are `orelse`-optional:
+
+   ```zig
+   const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+   ```
+
+5. Add a unit test in the matching `src/tests_*.zig` file (44 of them, one per
+   feature area) using the `testing_helpers.zig` helpers — `th.expectEval` for
+   the common case, `th.TestContext` when the test needs several evals. Not in
+   `src/vm.zig`: its one `test` block only imports sibling modules into the
+   test build. Add a Scheme test under `tests/scheme/` when the behavior is
+   worth an end-to-end check.
 
 ## How to add a new compiler form
 
@@ -1248,7 +1282,7 @@ independently and the child heap is freed after `thread-join!`.
 
 **Key implementation details:**
 
-- `vm_instance` and `gc_instance` are `threadlocal` (`src/vm.zig:37`, `src/primitives.zig:182`)
+- `vm_instance` and `gc_instance` are `threadlocal` (`src/vm.zig`, `src/memory.zig`)
 - `GC.initForThread` creates per-thread GC sharing parent's symbol table (`src/memory.zig`)
 - `GC.deepCopy` / `GC.deepCopyValue` deep-copies values between GC heaps (`src/memory.zig`)
 - `VM.initForThread` creates per-thread VM sharing parent's globals/libraries (`src/vm.zig`)

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -13,7 +13,7 @@ defer here. Follow these steps:
 ### 1. Write the function
 
 Choose the appropriate `src/primitives_*.zig` file based on domain (arithmetic,
-string, vector, I/O, etc.) and add your function. There are 31 of them;
+string, vector, I/O, etc.) and add your function. There are 30 of them;
 `primitives.zig` itself is the registration hub plus core list/pair ops, so a
 new procedure almost always belongs in one of the domain files, not there:
 

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -6,17 +6,22 @@ Step-by-step guides for the most common extension tasks in Kaappi.
 
 ## Adding a Built-in Procedure
 
-This is the most common change. Follow these steps:
+This is the most common change, and this section is the detailed reference for
+it. The root `CLAUDE.md` and the `/add-builtin` skill are short checklists that
+defer here. Follow these steps:
 
 ### 1. Write the function
 
 Choose the appropriate `src/primitives_*.zig` file based on domain (arithmetic,
-string, vector, I/O, etc.) and add your function:
+string, vector, I/O, etc.) and add your function. There are 31 of them;
+`primitives.zig` itself is the registration hub plus core list/pair ops, so a
+new procedure almost always belongs in one of the domain files, not there:
 
 ```zig
 fn myProc(args: []const Value) PrimitiveError!Value {
     // Validate argument types
-    if (!types.isFixnum(args[0])) return PrimitiveError.TypeError;
+    if (!types.isFixnum(args[0]))
+        return primitives.typeError("my-proc", "exact integer", args[0]);
 
     // Compute result
     const n = types.toFixnum(args[0]);
@@ -27,6 +32,22 @@ fn myProc(args: []const Value) PrimitiveError!Value {
 The function signature is always `fn([]const Value) PrimitiveError!Value`.
 Arguments are passed as a slice -- arity checking has already been done by the
 dispatch layer.
+
+**Report type errors through `primitives.typeError(proc, expected, got)`**, not
+a bare `return PrimitiveError.TypeError`. `typeError` attaches the procedure
+name, the expected type, and a description of what actually arrived to the
+error detail, so the user sees `type error in 'my-proc': expected exact
+integer, got #t` instead of an anonymous `TypeError`. The `format` CI job
+enforces this with a ratchet on the count of unannotated bare returns
+(`.github/workflows/ci.yml`), so adding one fails the build. Only
+infrastructure guards that have no procedure context to report -- the
+`vm_instance orelse` fallbacks, for example -- take a bare return, and those
+carry a `// bare-ok: <reason>` comment to opt out of the ratchet.
+
+For the common checks there are wrappers that validate and unwrap in one step,
+each taking the procedure name for the same error detail: `expectFixnum`,
+`expectString`, `expectChar`, `expectPair`, `expectVector`, `expectPort`, plus
+`indexError(proc, index, len)` for out-of-range access.
 
 ### 2. Register the procedure and its libraries
 
@@ -90,32 +111,68 @@ For SRFI procedures, tag with the corresponding `srfi_*` `Lib` value.
 ### 4. Handle heap allocation
 
 If your procedure allocates heap objects (strings, pairs, vectors, etc.), you
-need the GC instance:
+need the GC instance. It is a threadlocal declared in `src/memory.zig` as
+`memory.gc_instance` -- reach it through that module, since `primitives.zig`
+does not re-export it:
 
 ```zig
 fn myAllocProc(args: []const Value) PrimitiveError!Value {
-    const gc = primitives.gc_instance orelse return PrimitiveError.TypeError;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocPair(args[0], args[1]) catch return PrimitiveError.OutOfMemory;
 }
 ```
 
+Read `.claude/rules/gc-safety.md` before writing anything that allocates more
+than once: values held in Zig locals across a second allocation must be rooted,
+and mutating a heap object's fields needs a write barrier.
+
 ### 5. Handle calling Scheme procedures
 
 If your procedure needs to call back into Scheme code (like `map` or
-`for-each`), use the VM instance:
+`for-each`), use the VM instance -- likewise a threadlocal, declared in
+`src/vm.zig` and reached as `vm_mod.vm_instance` under the import name every
+primitives file already uses for that module:
 
 ```zig
 fn myHigherOrder(args: []const Value) PrimitiveError!Value {
-    const vm = primitives.vm_instance orelse return PrimitiveError.TypeError;
-    const result = vm.callValue(args[0], args[1..]) catch return PrimitiveError.TypeError;
-    return result;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    return vm.callWithArgs(args[0], args[1..]);
 }
 ```
 
+`callWithArgs(proc, args)` is the entry point that takes a Value slice.
+(`vm_calls.callValue` is a different, register-based call used by the dispatch
+loop -- it takes a register base and an argument count, not a slice.) Let the
+callee's error propagate rather than rewriting it: `PrimitiveError` and
+`VMError` are both aliases of `errors.KaappiError`, so a raise from inside the
+Scheme procedure returns straight out of your primitive with its detail intact.
+
 ### 6. Test
 
-Add unit tests in the appropriate `src/tests_*.zig` file and/or a Scheme
-test in `tests/scheme/`.
+Add unit tests in the appropriate `src/tests_*.zig` file (there are 44, one per
+feature area -- pick the one matching your procedure's domain, and add a new
+file only for a genuinely new area). `src/vm.zig` is not a test file: its single
+`test` block only pulls sibling modules into the test build, and holds no
+assertions.
+
+Use the helpers in `src/testing_helpers.zig`, conventionally imported as `th`,
+rather than standing a GC and VM up by hand:
+
+```zig
+const th = @import("testing_helpers.zig");
+
+test "my-proc increments" {
+    try th.expectEval("(my-proc 42)", 43);
+}
+```
+
+`th.expectEvalTrue`, `th.expectEvalBool`, and `th.expectEvalVoid` cover the
+other result shapes; `th.TestContext` is for tests needing several evals or
+direct inspection of the result value. See `src/CLAUDE.md` for the full set.
+
+Add a Scheme-level test under `tests/scheme/` too when the behavior is worth
+checking end to end. A bug fix **must** come with a regression test that fails
+without the fix.
 
 ---
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -5,7 +5,7 @@ This file covers patterns specific to working in this directory.
 
 ## Test files (`tests_*.zig`)
 
-20 test files, one per feature area. Use helpers from `testing_helpers.zig`:
+44 test files, one per feature area. Use helpers from `testing_helpers.zig`:
 
 ```zig
 const th = @import("testing_helpers.zig");


### PR DESCRIPTION
Fixes #1863.

Three places documented how to add a built-in procedure and all three had drifted. Two taught code that cannot compile. Restructured per the issue's suggestion: `docs/dev/adding-features.md` is now the single detailed reference, and `CLAUDE.md` plus the `/add-builtin` skill are short checklists that defer to it.

## Verified, not assumed

Every claim in the issue was checked against the tree before editing (the issue asked for this explicitly). All held, with two refinements:

- **`src/vm.zig` has one `test` block, not zero** — but it only does `_ = @import("vm_tests.zig")` to pull sibling modules into the test build and holds no assertions. The substantive point stands, so the docs now say precisely that rather than "zero".
- **The higher-order sample was wrong in a way the issue did not catch.** `vm.callValue(proc, args_slice)` names no method on `VM`, and the free function `vm_calls.callValue` is register-based (`vm, callee, base, nargs`). The slice-taking entry point is `vm.callWithArgs`. Since `PrimitiveError` and `VMError` are both aliases of `errors.KaappiError`, the sample now propagates the callee's error instead of flattening it to `TypeError` and throwing the detail away.

## What changed

**Wrong symbols.** `primitives.gc_instance` / `primitives.vm_instance` do not exist. Real declarations: `memory.gc_instance` (`src/memory.zig`, 371 uses) and `vm_mod.vm_instance` (`src/vm.zig`, 112 uses) — the module names every primitives file already imports. The skill had a third spelling, bare `gc_instance`, which resolves nowhere.

**The pattern CI rejects.** The skill taught `return PrimitiveError.TypeError`; the `format` job exists to prevent exactly that, so following the docs broke the build. All three now teach `primitives.typeError(proc, expected, got)`, the `expect*` wrappers, and the `// bare-ok:` opt-out.

**Re-tightened the ratchet** from 91 to the current count of 20, as the issue suggested — it had room for 71 regressions before firing. Added a comment so the next person lowers it too.

**Misdirected steps.** Tests go in one of the 44 `src/tests_*.zig` files using the `th.` helpers, not "the `src/vm.zig` test section". Dropped the `STATUS.md` step (file deleted in `cfe013ce`). Step 1 now points at the domain files rather than `primitives.zig`, the registration hub.

**Stale counts and citations.** Primitives table 26 → 31, plus the 9 files it never listed (`fiber`, `parallel`, `random_port`, `srfi160`, `srfi181`, `srfi211`, `srfi237`, `srfi254`, `sysinfo`) so the count and table now agree. `src/CLAUDE.md` 20 → 44 test files. Dropped the stale `src/vm.zig:37` / `src/primitives.zig:182` line numbers in favour of bare module names, which cannot rot the same way.

## Verification

Since the complaint is docs teaching non-compiling code, every sample was compiled rather than eyeballed — each added verbatim as a real primitive plus a `th.expectEval` test, built, run, then reverted:

- `zig build test -Dtest-filter=...` — 6/6 passed
- The documented error text is the observed output: `type error in 'my-proc': expected exact integer, got #t`
- Ratchet passes at the new baseline (20 = 20)
- `npx markdownlint-cli2` — 0 issues in 82 files; `zig fmt --check src/` clean; `ci.yml` parses

Docs and CI config only — no source changes (`src/CLAUDE.md` is documentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)