### PR TITLE
Let a library body reference an unimported global from its top level (#1860)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A library body could not reference a global it had not imported from its
+  own top level** (#1860) — the identical reference from inside a `lambda` in
+  the same body worked, so a name like `cadar` or a `%`-prefixed internal
+  primitive resolved or raised `undefined variable` depending only on where in
+  the body it was written. #1831 gave the three global-reference opcodes one
+  resolver with a `vm.globals` fallback for library code, but gated it on a
+  flag derived per-function: it landed on the outer function of each
+  library-body form and on none of the closures inside it. The flag is now a
+  property of the environment, set from a `library`-vs-`restricted` distinction
+  at the one compile entry point that has it and inherited by every nested
+  function. This also closes the same gap in the other direction: a restricted
+  `(environment ...)` withheld a name from the expression's own top level and
+  handed it over through a `lambda`, and now withholds it from both.
+
 - **Native backend: an internal `define` in a `let` body could be collected**
   (#1854). The LLVM backend gave the binding an `alloca` but never pushed it on
   the GC shadow stack, so a collection triggered anywhere later in the body

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,9 +450,17 @@ tail position only, because `get_global` carried the vm.globals fallback
 and the `call_global` superinstruction the compiler emits for every
 non-tail call did not. Ordinary (non-`%`) names looked unaffected only
 because `(scheme base)` puts them in lib_env; all three global-reference
-opcodes now resolve through one helper in `vm_dispatch.zig`. Declaring
-the import explicitly is still the better style, but it is no longer
-load-bearing.
+opcodes now resolve through one helper in `vm_dispatch.zig`. That fix left
+one residual, closed in kaappi#1860: the fallback is gated on
+`Function.restricted_globals`, which was derived per-function, so it was
+off for the outer function of each library-body form and on for every
+closure inside it — the same reference resolved from inside a `lambda` and
+raised `undefined variable` as a library-body *top-level* `define`'s
+initializer. It is now a property of the environment
+(`compiler.EnvKind`, inherited by `Compiler.initChild`), which also stops
+a restricted `(environment ...)` from leaking vm.globals through a
+closure. Declaring the import explicitly is still the better style, but it
+is no longer load-bearing.
 SRFI 57 (Records, with inheritance via "schemes" -- a named, reusable field-
 label list a type or another scheme can extend, with multiple schemes
 mergeable at once via left-to-right append + delete-duplicates) is portable

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -111,7 +111,16 @@ pub const Compiler = struct {
     globals: ?*std.StringHashMap(Value) = null,
     lib_env: ?*std.StringHashMap(Value) = null,
     lib_env_val: Value = types.NIL,
-    restricted_env: bool = false, // true for restricted environments (null-environment, environment)
+    // True whenever `globals` is a partial environment map rather than
+    // vm.globals — a library's lib_env, or a restricted (environment ...) —
+    // so a name's *absence* from it proves nothing about what that name will
+    // resolve to at run time. Read only by IR.isRedefined, which then declines
+    // to treat the name as a known primitive: a compile-time optimization
+    // gate, nothing more. Whether the run-time lookup may fall back to
+    // vm.globals is the separate Function.restricted_globals, which
+    // compileExpressionInEnv sets from its EnvKind and not from this
+    // (kaappi#1860).
+    restricted_env: bool = false,
     // Names that are `set!` somewhere in the top-level form being compiled.
     // Owned by the top-level compile() frame and inherited by child compilers
     // so nested lambda bodies see the same suppression set. Consulted by the
@@ -177,6 +186,10 @@ pub const Compiler = struct {
         const func = parent.gc.allocFunction() catch return CompileError.OutOfMemory;
         func.env = parent.lib_env;
         func.env_val = parent.lib_env_val;
+        // Inherited with `env`, which it qualifies: whether a name missing
+        // from that env may fall back to vm.globals is a property of the
+        // environment, not of how deeply nested the reference happens to be.
+        func.restricted_globals = parent.func.restricted_globals;
         func.source_line = parent.func.source_line;
         func.source_name = parent.func.source_name;
         parent.gc.extra_roots.append(parent.gc.allocator, types.makePointer(&func.header)) catch return CompileError.OutOfMemory;
@@ -1222,7 +1235,26 @@ pub fn compileExpressionWithMacrosAt(gc: *memory.GC, expr: Value, vm_macros: *st
     return c.func;
 }
 
-pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.StringHashMap(Value), env: *std.StringHashMap(Value), env_val: Value, is_tail: bool) CompileError!*types.Function {
+/// Which kind of non-vm.globals environment `compileExpressionInEnv` is
+/// compiling against. Its two callers hand it structurally identical `env`
+/// maps and want opposite things from a name the map doesn't hold, so the
+/// distinction cannot be recovered from the map itself (kaappi#1860).
+pub const EnvKind = enum {
+    /// A `define-library` body — its `begin` blocks, and the
+    /// `define-record-type` boilerplate they expand to. `lib_env` holds only
+    /// what this library imported or defined, so a reference to anything else
+    /// (a `(scheme cxr)` name, a `%`-prefixed internal primitive) has to keep
+    /// reaching vm.globals, exactly as it does from inside a closure in the
+    /// same body.
+    library,
+    /// An R7RS restricted environment: `(environment ...)`,
+    /// `null-environment`, or the env argument of `eval`/`load`. Withholding
+    /// vm.globals is the entire point — only what the environment imported may
+    /// resolve (kaappi#1253).
+    restricted,
+};
+
+pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.StringHashMap(Value), env: *std.StringHashMap(Value), env_val: Value, is_tail: bool, kind: EnvKind) CompileError!*types.Function {
     syntax_error_detail_len = 0;
     resetCompileErrorSpan();
     var c = try Compiler.init(gc);
@@ -1232,6 +1264,10 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
     c.lib_env = env;
     c.lib_env_val = env_val;
     c.restricted_env = true;
+    // Before compile(), not after: initChild copies it onto every nested
+    // function as that compile runs. Nothing in the compiler reads it — only
+    // vm_dispatch.lookupGlobalLocked does, at run time.
+    c.func.restricted_globals = kind == .restricted;
     var ok = false;
     defer {
         if (!ok) gc.truncateRoots(root_depth); // #1855, see compileExpression
@@ -1246,7 +1282,6 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
     try c.compile(expr, is_tail);
     c.func.env = env;
     c.func.env_val = env_val;
-    c.func.restricted_globals = c.restricted_env;
     var out_it = c.macros.iterator();
     while (out_it.next()) |entry| {
         vm_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return CompileError.OutOfMemory;

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -198,6 +198,10 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             // library-scoped imports don't live, so the child raised
             // "undefined variable" for a name that worked at top level.
             new_func.env = func.env;
+            // Carried with `env`, which it qualifies: a copy that kept the
+            // env but dropped the restriction would resolve names in the
+            // child thread that the original refuses in the parent.
+            new_func.restricted_globals = func.restricted_globals;
             // env_val (the eval/immutability Environment *object*) is a GC
             // Value; leave it NIL rather than share a parent-heap object into
             // the child heap. Runtime name resolution uses `env` (above), not

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -228,7 +228,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
         defer if (use_local) local_macros.deinit();
 
         const macro_target: *std.StringHashMap(Value) = if (use_local) &local_macros else &vm.macros;
-        const func = compiler_mod.compileExpressionInEnv(gc, expr, macro_target, se.env, args[1], false) catch return PrimitiveError.TypeError; // bare-ok: compile error
+        const func = compiler_mod.compileExpressionInEnv(gc, expr, macro_target, se.env, args[1], false, .restricted) catch return PrimitiveError.TypeError; // bare-ok: compile error
         var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
         compiler_mod.Compiler.unrootFunction(gc, func);
         gc.pushRoot(&closure_val);
@@ -359,7 +359,7 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
         const expr = reader.readDatum() catch return primitives.typeError("load", "valid datum", args[0]);
 
         if (env) |e| {
-            const func = compiler_mod.compileExpressionInEnv(gc, expr, macro_target, e, env_val, false) catch return primitives.typeError("load", "valid expression", args[0]);
+            const func = compiler_mod.compileExpressionInEnv(gc, expr, macro_target, e, env_val, false, .restricted) catch return primitives.typeError("load", "valid expression", args[0]);
             var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
             compiler_mod.Compiler.unrootFunction(gc, func);
             gc.pushRoot(&closure_val);

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -1165,3 +1165,77 @@ test "restricted environment does not leak globals to a non-tail call (#1831)" {
     try std.testing.expect(types.isSymbol(result));
     try std.testing.expectEqualStrings("caught", types.symbolName(result));
 }
+
+// Regression for #1860, #1831's residual: the vm.globals fallback above was
+// gated on a flag every library-body form's *outer* function carried and no
+// closure inside it did, because compileExpressionInEnv derived it from the
+// compile-time restricted_env. So the fallback was off exactly at a library
+// body's own top level: the same reference resolved from inside a lambda and
+// raised "undefined variable" as a top-level define's initializer — the
+// position-dependence #1831 set out to remove, one level up.
+test "library resolves a non-imported global at its own top level (#1860)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Same premise as the #1831 test: `cadar` is (scheme cxr), so it lives in
+    // vm.globals and not in this library's lib_env. Every form here is
+    // evaluated as the library body loads, not inside a procedure.
+    _ = try vm.eval(
+        \\(define-library (test cxr-toplevel)
+        \\  (import (scheme base))
+        \\  (export from-define from-begin from-nested-let in-lambda)
+        \\  (begin
+        \\    (define from-define (cadar '((1 2) 3)))
+        \\    (define from-begin 0)
+        \\    (set! from-begin (car (cadar '((1 (9)) 3))))
+        \\    (define from-nested-let (let ((v '((4 5) 6))) (cadar v)))
+        \\    (define (in-lambda) (cadar '((7 8) 9)))))
+    );
+    _ = try vm.eval("(import (test cxr-toplevel))");
+
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(try vm.eval("from-define")));
+    try std.testing.expectEqual(@as(i64, 9), types.toFixnum(try vm.eval("from-begin")));
+    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(try vm.eval("from-nested-let")));
+    // The case that already worked, kept alongside: both must agree.
+    try std.testing.expectEqual(@as(i64, 8), types.toFixnum(try vm.eval("(in-lambda)")));
+}
+
+// The mirror of the above, and why #1860 could not be fixed by flipping the
+// flag: the same per-function derivation left restricted_globals *off* for
+// closures compiled inside a restricted environment, so `(environment ...)`
+// withheld a name from its top level and handed it over through one lambda.
+// Both directions now follow the environment rather than the nesting depth.
+test "restricted environment does not leak globals into a closure (#1860)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // `car` is not in the environment; the reference sits in the body of a
+    // lambda the eval'd expression immediately applies.
+    const from_closure = try vm.eval(
+        \\(guard (e (#t 'caught))
+        \\  (eval '((lambda () (car '(1)))) (environment '(only (scheme base) list))))
+    );
+    try std.testing.expect(types.isSymbol(from_closure));
+    try std.testing.expectEqualStrings("caught", types.symbolName(from_closure));
+
+    // Two levels deep, and via a named local procedure, to pin that the
+    // restriction is inherited down the whole chain rather than one level.
+    const from_nested = try vm.eval(
+        \\(guard (e (#t 'caught))
+        \\  (eval '(let ((f (lambda () (lambda () (car '(1))))))
+        \\           ((f)))
+        \\        (environment '(only (scheme base) list))))
+    );
+    try std.testing.expect(types.isSymbol(from_nested));
+    try std.testing.expectEqualStrings("caught", types.symbolName(from_nested));
+
+    // The environment's own imports still resolve from inside a closure —
+    // the restriction withholds vm.globals, it does not break the env.
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(try vm.eval(
+        \\(car (eval '((lambda () (list 3))) (environment '(only (scheme base) list))))
+    )));
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -406,6 +406,13 @@ pub const Function = struct {
     cache_version: u32 = 0,
     env: ?*std.StringHashMap(Value) = null,
     env_val: Value = NIL,
+    // `env` is authoritative: a name missing from it must not fall back to
+    // vm.globals. Set for an R7RS restricted environment ((environment ...),
+    // null-environment, (eval expr env)) and *not* for a library body, whose
+    // env is only what it imported — see compiler.EnvKind. A property of the
+    // environment, so every function compiled inside one inherits it
+    // (Compiler.initChild); deriving it per-function made the same reference
+    // resolve or not by syntactic position (kaappi#1860).
     restricted_globals: bool = false,
     profile_instrs: u64 = 0,
     profile_calls: u64 = 0,

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -1331,7 +1331,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             use_local_macros = true;
                             break :mt &local_macros;
                         };
-                        break :blk compiler_mod.compileExpressionInEnv(self.gc, expr_val, macro_target, se.env, self.registers[abs_base + 1], true) catch return VMError.CompileError;
+                        break :blk compiler_mod.compileExpressionInEnv(self.gc, expr_val, macro_target, se.env, self.registers[abs_base + 1], true, .restricted) catch return VMError.CompileError;
                     }
                     break :blk compiler_mod.compileExpressionWithMacrosAt(self.gc, expr_val, &self.macros, self.globals, 0, null, true) catch return VMError.CompileError;
                 };
@@ -1442,6 +1442,14 @@ noinline fn raiseUndefinedVariable(self: *VM, name: []const u8) VMError {
 /// primitive) worked in tail position, where the compiler emits get_global plus
 /// a plain tail_call, and raised "undefined variable" in every other position,
 /// where it emits call_global (kaappi#1831).
+///
+/// `restricted_globals` had the same defect one level up: it was derived
+/// per-function, so it landed on the outer function of a form and on none of
+/// the closures inside it. A library body — which must *not* be restricted —
+/// therefore failed at its own top level and worked inside a lambda, while a
+/// restricted environment — which must be — blocked its top level and leaked
+/// through one. It is now a property of the environment, set by
+/// compiler.EnvKind and inherited by every nested function (kaappi#1860).
 inline fn lookupGlobalLocked(self: *VM, func: *types.Function, name: []const u8) ?Value {
     const env: *std.StringHashMap(Value) = func.env orelse self.globals;
     if (vm_mod.globals_mod.stripBaseBindingPrefix(name)) |base_name| {

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -873,7 +873,7 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
             lib_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return VMError.OutOfMemory;
         }
     }
-    const func = compiler_mod.compileExpressionInEnv(vm.gc, expr, &lib_macros, lib_env, types.NIL, false) catch |err| {
+    const func = compiler_mod.compileExpressionInEnv(vm.gc, expr, &lib_macros, lib_env, types.NIL, false, .library) catch |err| {
         // Name the failing form so a broken library body surfaces as itself
         // instead of being masked as "library not found" upstream (#1010).
         if (vm.last_error_detail_len == 0) {

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -102,7 +102,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
         defer no_macros.deinit();
         const func = if (vm.current_lib_env) |env|
-            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
+            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false, .library) catch return VMError.CompileError
         else
             compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
         define_expr = types.makePointer(&func.header);
@@ -140,7 +140,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
         var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
         defer no_macros.deinit();
         const func = if (vm.current_lib_env) |env|
-            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
+            compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false, .library) catch return VMError.CompileError
         else
             compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
         define_expr = types.makePointer(&func.header);
@@ -180,7 +180,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
             defer no_macros.deinit();
             const func = if (vm.current_lib_env) |env|
-                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
+                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false, .library) catch return VMError.CompileError
             else
                 compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(&func.header);
@@ -219,7 +219,7 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
             defer no_macros.deinit();
             const func = if (vm.current_lib_env) |env|
-                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
+                compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false, .library) catch return VMError.CompileError
             else
                 compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(&func.header);
@@ -322,7 +322,7 @@ fn compileAndRunDefine(vm: *VM, define_expr_in: Value) VMError!void {
     var no_macros = std.StringHashMap(Value).init(vm.gc.allocator);
     defer no_macros.deinit();
     const func = if (vm.current_lib_env) |env|
-        compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false) catch return VMError.CompileError
+        compiler_mod.compileExpressionInEnv(vm.gc, define_expr, &no_macros, env, types.NIL, false, .library) catch return VMError.CompileError
     else
         compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
     define_expr = types.makePointer(&func.header);

--- a/tests/scheme/smoke/libraries.scm
+++ b/tests/scheme/smoke/libraries.scm
@@ -49,6 +49,31 @@
 (import (my utils))
 (test-eqv "dotted name lib" 15 (add5 10))
 
+;; A library body may reference a global it did not import -- `cadar` is
+;; (scheme cxr), so it lives in vm.globals and not in this library's own env.
+;; It used to resolve only from inside a procedure: as a top-level define's
+;; initializer it raised "undefined variable", taking the whole library with
+;; it (kaappi#1860, the residual of kaappi#1831). Both positions here, so the
+;; two must agree.
+(define-library (unimported-global)
+  (import (scheme base))
+  (export at-top-level from-procedure)
+  (begin
+    (define at-top-level (cadar '((1 2) 3)))
+    (define (from-procedure) (cadar '((1 2) 3)))))
+
+(import (unimported-global))
+(test-eqv "unimported global at library top level" 2 at-top-level)
+(test-eqv "unimported global inside a procedure" 2 (from-procedure))
+
+;; The mirror: a restricted (environment ...) withholds vm.globals from a
+;; closure too, not just from the expression's own top level. `car` is not in
+;; the environment, so this must raise rather than resolve (kaappi#1860).
+(import (scheme eval))
+(test-eqv "restricted env withholds globals from a closure" 'blocked
+  (guard (e (#t 'blocked))
+    (eval '((lambda () (car '(1 2)))) (environment '(only (scheme base) list)))))
+
 (set! %test-fail-count (test-runner-fail-count (test-runner-current)))
 (test-end "libraries")
 (if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
Closes #1860.

## The bug

#1831 gave `get_global`, `call_global`, and `tail_call_global` one resolver
carrying a `vm.globals` fallback, so a library body can reach a global that
lives there but not in its own `lib_env`. That fallback is gated on
`Function.restricted_globals`, which `compileExpressionInEnv` derived from the
compile-time `restricted_env` flag it sets for *both* of its callers — and it
set it on the outer function of the form only. Every closure inside that form
got the field's `false` default.

So the same reference resolved or not by syntactic position, one level up from
what #1831 fixed:

```scheme
(define-library (probe a) (import (scheme base)) (export v)
  (begin (define v (cadar '((1 2) 3)))))            ; KP3001 undefined variable

(define-library (probe b) (import (scheme base)) (export f)
  (begin (define f (lambda () (cadar '((1 2) 3)))))) ; 2
```

Probing it turned up the **mirror hole**, which is also why #1860 could not be
fixed by flipping the flag: for a restricted `(environment ...)`, where
withholding `vm.globals` is the whole point, those same nested closures got
`false` too — so the restriction held at the eval'd expression's top level and
leaked through a `lambda`:

```
direct tail:    BLOCKED
direct operand: BLOCKED
inside lambda:  1        <-- `car` was not in the environment
inside let:     BLOCKED
```

(`let` was fine only because it compiles inline into the same function.)

## The fix

`restricted_globals` becomes a property of the *environment* rather than of one
function. `compileExpressionInEnv` takes a new `EnvKind` naming which of its two
callers it is serving — `.library` (a `define-library` body and the
`define-record-type` boilerplate it expands to, which must keep the fallback) or
`.restricted` (`(environment ...)` / `null-environment` / `eval`'s and `load`'s
env argument, which must not). The two hand it structurally identical `env`
maps, so the distinction is not recoverable from the map itself. The flag is set
before `compile()` runs, and `Compiler.initChild` copies it onto every nested
function alongside the `env` it qualifies. `gc_deep_copy` carries it too, so a
closure crossing an SRFI-18 thread boundary does not become leakier than the
original.

`Compiler.restricted_env` keeps its separate, compile-time-only meaning —
`globals` is a partial map, so `IR.isRedefined` must not treat a missing name as
a known primitive — and stays true for both kinds. Its comment said
"restricted environments (null-environment, environment)", which had been wrong
since library bodies started setting it.

## Tests

Two Zig regressions in `tests_libraries.zig` (one per direction) plus an
end-to-end pair in `tests/scheme/smoke/libraries.scm`. Mutation-tested
individually:

| Mutation | Fails |
|---|---|
| library bodies restricted again | new #1860 library test **and** the existing #1831 test |
| `initChild` inheritance removed | new #1860 restricted-closure test |

`zig build test` and `bash tests/scheme/run-all.sh` are green.

## Note for review

The restricted-environment half is a behavior *tightening*: code doing
`(eval '(lambda () ...) (environment ...))` that reached a name the environment
never imported now raises, as R7RS says it should and as the same reference
already did outside a lambda. No portable library in `lib/` uses R7RS
`environment` (SRFI 165's "computation environment" is unrelated), and the full
suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
