### PR TITLE
Hand the whole enclosing scope to the interpreter when a nested let abandons (#1862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Native backend: a nested `let` that fell back to the interpreter lost the
+  enclosing `let`'s bindings** (#1862). When a `let` inside another `let` gave up
+  on native compilation mid-emission — more than 32 bindings, more head
+  `define`s than the scope roots, or any binding/body form the emitter could not
+  lower — the LLVM backend handed that inner form alone to `kaappi_eval`, which
+  resolves names in the global environment. The compiled binary then died with
+  `undefined variable` on the outer binding, or, with a same-named global in
+  scope, silently read that instead; the interpreter ran the same program
+  correctly. `bindParamsAsGlobals` republishes the frame's params, rest
+  parameter, and upvalues, but a `let`-local lives in an `alloca` it has no name
+  for, so it now declines when one is in scope. The error abandons the enclosing
+  `let` in turn, handing the interpreter that whole lexical scope in one piece —
+  the rule #827 already applied to everything an up-front syntactic scan can
+  see, now applied to the mid-emission escape hatch as well. A fallback inside a
+  plain lambda frame, where the params *are* publishable, still compiles the
+  lambda natively and is unaffected.
 - **Native backend: an internal `define` in a `let` body could be collected**
   (#1854). The LLVM backend gave the binding an `alloca` but never pushed it on
   the GC shadow stack, so a collection triggered anywhere later in the body

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -481,17 +481,21 @@ alternative here: it aliases across activations, and it permanently clobbers a
 same-named global. Declining the frame is what keeps the interpreter's own
 lexical scope authoritative.
 
-It also cannot reach a `let`-local, which lives in an alloca it has no name for
-— so it refuses outright when `self.locals != null` (kaappi#1862), rather than
-emitting an eval that silently cannot see one. Until that gate existed, the
-mid-emission escape hatch below violated the very rule it implements: an inner
-`let` that abandoned inside an enclosing one was evaluated in the global
-environment, dying with `undefined variable` on the outer binding, or — with a
-same-named global in scope — quietly reading that instead. Refusing sends the
-error up to the enclosing scope's own abandon path, which re-evaluates that whole
-scope as one unit and so keeps the bindings. Publishing the locals was the other
-option and is worse: a boxed local hits the same by-location problem as a boxed
-param (kaappi#1422), and both weaknesses above would extend to let-locals.
+`bindParamsAsGlobals` also cannot reach a `let`-local, which lives in an alloca
+it has no name for, so it refuses outright when `self.locals != null`
+(kaappi#1862) rather than emit an eval that silently cannot see one. Until that
+gate existed, `emitLet`'s own mid-emission escape hatch
+(`abandonLetForFallback`, reached on the triggers no up-front scan can pre-empt
+— more than 32 bindings, more head defines than the scope roots, an
+`ir.lowerSingleExpr`/`emitNode` failure) broke the very rule this section
+describes: an inner `let` abandoning inside an enclosing one was evaluated in
+the global environment, dying with `undefined variable` on the outer binding —
+or, with a same-named global in scope, quietly reading that instead. Refusing
+sends the error up to the enclosing scope's own abandon path, which
+re-evaluates that whole scope as one unit and so keeps the bindings. Publishing
+the locals was the other option and is worse: a boxed local hits the same
+by-location problem as a boxed param (kaappi#1422), and both weaknesses above
+would extend to let-locals.
 
 ### Native `apply` (kaappi#1803)
 

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -178,7 +178,7 @@ The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
 | `define` | Function definitions compiled to a native LLVM function (see Lambda Strategy). A fixed-arity one's global value is a native closure over that entry (`kaappi_create_native_closure`, #1500); a variadic one's value stays `kaappi_eval_cached`. Non-lambda values: `call @kaappi_define_global(...)` (compound values via `kaappi_eval_cached`) |
 | `set!` | Store to the resolved lexical slot (local/param/upvalue) or `call @kaappi_set_global(...)` |
 | `lambda` | Compiled to a native LLVM function + closure, or cached eval fallback (see Lambda Strategy) |
-| `let`, `let*` | Native `alloca`s with shadow-stack rooting, for the bindings and the body's head internal defines alike (see [Internal defines in a `let` body](#internal-defines-in-a-let-body)); falls back to `kaappi_eval_cached` for forms it cannot lower in scope (`src/llvm_emit_let.zig`) |
+| `let`, `let*` | Native `alloca`s with shadow-stack rooting, for the bindings and the body's head internal defines alike (see [Internal defines in a `let` body](#internal-defines-in-a-let-body)); falls back to `kaappi_eval_cached` for forms it cannot lower in scope — a nested one declines instead, so the whole enclosing scope goes to the interpreter as one unit (kaappi#1862, `src/llvm_emit_let.zig`) |
 | `cond`, `case`, `do` | Native `if`-style block/`phi` chains (`cond`/`case`) and a self-branching `alloca` loop (`do`) when every sub-form is emittable in the current lexical scope; otherwise a whole-form `kaappi_eval_cached` fallback (`src/llvm_emit_forms.zig`, kaappi#1496) |
 | `letrec`, `letrec*`, `guard`, quasiquote, named `let` | Serialize to source text, `call @kaappi_eval_cached(...)` (see [Cached eval fallback](#cached-eval-fallback)) |
 | `passthrough` | Serialize to source text, `call @kaappi_eval_cached(...)` |
@@ -477,9 +477,21 @@ would reject every natively lowered `cond`/`case` with an else clause.
 
 Publishing the frame's bindings as globals instead (`bindParamsAsGlobals`,
 the kaappi#1410 mechanism the `letrec`/`let` fallbacks use) is **not** an
-alternative here: it aliases across activations, it cannot see `let`-locals at
-all, and it permanently clobbers a same-named global. Declining the frame is
-what keeps the interpreter's own lexical scope authoritative.
+alternative here: it aliases across activations, and it permanently clobbers a
+same-named global. Declining the frame is what keeps the interpreter's own
+lexical scope authoritative.
+
+It also cannot reach a `let`-local, which lives in an alloca it has no name for
+— so it refuses outright when `self.locals != null` (kaappi#1862), rather than
+emitting an eval that silently cannot see one. Until that gate existed, the
+mid-emission escape hatch below violated the very rule it implements: an inner
+`let` that abandoned inside an enclosing one was evaluated in the global
+environment, dying with `undefined variable` on the outer binding, or — with a
+same-named global in scope — quietly reading that instead. Refusing sends the
+error up to the enclosing scope's own abandon path, which re-evaluates that whole
+scope as one unit and so keeps the bindings. Publishing the locals was the other
+option and is worse: a boxed local hits the same by-location problem as a boxed
+param (kaappi#1422), and both weaknesses above would extend to let-locals.
 
 ### Native `apply` (kaappi#1803)
 

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -365,6 +365,21 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
 // them. Leaving any of them out surfaces as "undefined variable" (or a
 // silently wrong value when a same-named global exists) at run time (#1410).
 pub fn bindParamsAsGlobals(self: *LLVMEmitter) EmitError!void {
+    // Params, rest, and upvalues are the whole of what this can reach: a
+    // `let`-local lives in an alloca this function has no name for, so there is
+    // nothing here to publish it from. Refuse rather than emit an eval that
+    // silently cannot see it (#1862) — a nested let/lambda that abandons
+    // mid-emission inside an enclosing let died with "undefined variable" on the
+    // outer binding in a compiled binary while the interpreter ran it fine.
+    // Declining sends the error up to the enclosing scope's own abandon path,
+    // which re-evaluates that whole scope as one unit and so keeps the bindings
+    // (#827's rule: never split one lexical scope across the boundary).
+    //
+    // Publishing the locals instead was the other option, and is worse: a boxed
+    // local hits the same #1422 by-value problem as a boxed param below, and both
+    // of this helper's documented weaknesses — it aliases across activations, and
+    // it permanently clobbers a same-named global — would extend to them.
+    if (self.locals != null) return error.UnsupportedNodeType;
     // A boxed captured variable cannot be republished as a global: a global
     // holds a by-value snapshot, and re-reading a boxed param/upvalue here
     // would capture the value *before* a later set!, reintroducing the exact
@@ -425,12 +440,11 @@ pub fn bindParamsAsGlobals(self: *LLVMEmitter) EmitError!void {
 }
 
 fn emitLambdaViaEval(self: *LLVMEmitter, data: ir.LambdaData) EmitError![]const u8 {
-    // #827: Inside a lexical scope with local bindings (a let body),
-    // evaluating the lambda in the global environment would lose those
-    // bindings.  Signal failure so the enclosing let falls back to the
-    // interpreter, which handles scoping correctly.
-    if (self.locals != null) return error.UnsupportedNodeType;
-
+    // #827: inside a lexical scope with local bindings (a let body), evaluating
+    // this lambda in the global environment would lose those bindings — the
+    // locals gate in bindParamsAsGlobals declines for exactly that reason, so the
+    // enclosing let abandons to the interpreter, which handles the scope
+    // correctly.
     try bindParamsAsGlobals(self);
 
     var source_buf: std.ArrayList(u8) = .empty;

--- a/src/llvm_emit_let.zig
+++ b/src/llvm_emit_let.zig
@@ -40,6 +40,9 @@ fn emitLetFallback(self: *LLVMEmitter, args: Value, sequential: bool) EmitError!
     // The let form is about to be evaluated in the global environment;
     // bind the enclosing frame's params/rest/upvalues as globals first
     // or references to them inside the form come up undefined (#1410).
+    // It declines outright when an enclosing let's locals are in scope, since
+    // those it cannot publish — the error then abandons that outer let too, so
+    // the interpreter gets the whole scope in one piece (#1862).
     try lambda.bindParamsAsGlobals(self);
     const keyword = if (sequential) "let*" else "let";
     // Build `(let bindings body ...)` by iterating the args list elements.

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -98,6 +98,15 @@ Conventions:
 - Don't bake POSIX-only spellings into assertions: kaappi prints native
   paths, the runtime archive name is per-platform, and a Windows abort
   exits 3 rather than dying by signal (see `errors/crash-handler.sh`).
+- **No GNU regex extensions in `grep`/`sed` patterns.** `\?`, `\|` and `\+`
+  are GNU additions to POSIX BRE. macOS, GNU, FreeBSD and NetBSD all accept
+  them, so a pattern using one passes locally and on 16 of 17 CI checks —
+  and then matches *nothing* on `openbsd-test`, the only leg whose grep is
+  strict (kaappi#1862). Use `grep -E` and write them as plain ERE `?`, `|`,
+  `+`, remembering that ERE makes `(`, `)`, `[` and `{` metacharacters that
+  a literal match has to escape. A suite whose *assertions* all fail
+  uniformly while its output comparisons stay clean is the signature of
+  this, not of a real regression.
 
 ## Quirks
 

--- a/tests/scheme/compile/native-nested-let-fallback-scope-1862.sh
+++ b/tests/scheme/compile/native-nested-let-fallback-scope-1862.sh
@@ -1,0 +1,342 @@
+#!/bin/bash
+# Regression test for #1862: a nested let that abandoned native compilation
+# mid-emission was handed to kaappi_eval without the ENCLOSING let's bindings in
+# scope, so the compiled binary diverged from the interpreter on code the
+# interpreter runs fine.
+#
+# `emitLetFallback` republishes the native frame's names as globals via
+# `bindParamsAsGlobals`, which reaches params, the rest param, and upvalues — but
+# a let-local lives in an alloca that helper has no name for, so it could not
+# publish one. An inner let that fell back therefore evaluated in the global
+# environment with the outer binding invisible:
+#
+#   (let ((outer 7))
+#     (let ((v0 0) ... (v32 32))     ; 33 bindings trips emitLet's ceiling
+#       (display (+ outer v0))))     ; "undefined variable 'outer'", exit 1
+#
+# Worse when a same-named global exists: the eval found the GLOBAL instead of
+# erroring, so the binary printed 999 where the interpreter printed 7, silently
+# (case shadows-global below).
+#
+# #827 fixed this class for anything a syntactic pre-scan can see, by declining
+# native compilation of the whole enclosing scope up front. The triggers here are
+# only discoverable mid-emission and no up-front scan can pre-empt them: more
+# than 32 bindings, more head defines than emitLet roots, an `ir.lowerSingleExpr`
+# or `emitNode` failure on a binding initializer or body form (#1854 added the
+# unmodelled-`define` case, which is what surfaced this).
+#
+# The fix gates `bindParamsAsGlobals` on `self.locals != null`: it declines
+# rather than emit an eval that cannot see them, which sends the error up to the
+# enclosing let's own abandon path, so the interpreter gets that whole lexical
+# scope in one piece — #827's rule, applied to the mid-emission escape hatch.
+# Publishing the locals instead would extend that helper's two documented
+# weaknesses (it aliases across activations, and it permanently clobbers a
+# same-named global) to let-locals, and could not represent a boxed one at all.
+#
+# 11 of the 13 cases below were verified to diverge against a pre-fix binary.
+# The two `native-frame` cases are the coverage guard for the opposite mistake:
+# the gate must not decline a fallback inside a plain lambda frame, where
+# publishing params/rest/upvalues is exactly the correct #1410 behavior.
+#
+# Usage: bash tests/scheme/compile/native-nested-let-fallback-scope-1862.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# `kaappi compile` needs the native runtime archive. The helper freshens it with
+# zig when a toolchain is present and otherwise accepts a prebuilt one, so a box
+# running cross-compiled binaries still exercises the compile+link path — and it
+# knows the archive's per-platform name, which this script must not spell itself.
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+# 33 bindings — one past emitLet's 32-binding ceiling, so the let abandons.
+BIG_BINDINGS=$(awk 'BEGIN { for (i = 0; i < 33; i++) printf "(v%d %d) ", i, i }')
+# 33 head defines — one past emitLet's max_head_defines, same effect.
+BIG_DEFINES=$(awk 'BEGIN { for (i = 0; i < 33; i++) printf "(define d%d %d) ", i, i }')
+
+# Compile natively, run, and require the output to match the interpreter's —
+# which never had the bug, so it is the oracle. `routing` then asserts HOW the
+# form was compiled, so a case cannot pass vacuously:
+#
+#   whole-scope:<name>  the eval'd form is the OUTER let, i.e. the enclosing
+#                       scope was handed to the interpreter as one unit. A bare
+#                       "did anything fall back?" count would NOT discriminate
+#                       here: pre-fix @main also held exactly one eval — of the
+#                       inner let alone, which is the bug.
+#   native-frame        a native function still exists and holds the eval, i.e.
+#                       the fallback stayed inside the natively compiled lambda.
+check() {
+    local name="$1" src="$2" routing="$3"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    local want
+    if ! want=$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$DIR/$name.scm" 2>&1); then
+        echo "FAIL: $name — interpreter run failed: $want" >&2
+        fail=1
+        return
+    fi
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    local out status
+    set +e
+    out=$("$DIR/$name" 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 ]]; then
+        echo "FAIL: $name — binary aborted (exit $status): $out" >&2
+        fail=1
+        return
+    fi
+    if [[ "$out" != "$want" ]]; then
+        echo "FAIL: $name — native '$out' != interpreter '$want'" >&2
+        fail=1
+        return
+    fi
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1); then
+        echo "FAIL: $name — --emit-llvm failed, so native routing went unchecked" >&2
+        fail=1
+        return
+    fi
+
+    case "$routing" in
+        whole-scope:*)
+            # The eval'd source strings are interned as private constants; one of
+            # them must open with the OUTER let, proving the abandon propagated
+            # out to it instead of stopping at the inner let. These sources hold
+            # no quote or backslash, so internString emits them verbatim.
+            local binder="${routing#whole-scope:}"
+            if ! grep -q "constant \[.*c\"(let\* \?((${binder} \|constant \[.*c\"(let \?((${binder} " "$DIR/$name.ll"; then
+                echo "FAIL: $name — no eval of the enclosing '($binder ...)' scope; the inner form fell back alone" >&2
+                fail=1
+            fi
+            ;;
+        native-frame)
+            # The lambda must still compile natively AND still carry the eval
+            # fallback inside its own body — the #1410 path the gate must leave
+            # alone. Its fast entry point is the natively emitted function.
+            local frame_evals
+            frame_evals=$(sed -n '/^define tailcc i64 @r[0-9]*\.fast/,/^}/p' "$DIR/$name.ll" |
+                grep -c 'kaappi_eval_cached' || true)
+            if [[ "$frame_evals" -eq 0 ]]; then
+                echo "FAIL: $name — no native frame carrying the eval fallback; the lambda declined too" >&2
+                fail=1
+            fi
+            ;;
+        *)
+            echo "FAIL: $name — bad routing '$routing'" >&2
+            fail=1
+            ;;
+    esac
+}
+
+# 1. Issue reproducer: the inner let trips the 32-binding ceiling and abandons
+#    mid-emission, so pre-fix the binary died with "undefined variable 'outer'".
+check over-32-bindings \
+"(let ((outer 7))
+  (let ($BIG_BINDINGS)
+    (display (+ outer v0))
+    (newline)))" \
+whole-scope:outer
+
+# 2. let* abandons on the same ceiling from its own binding loop, which roots
+#    each alloca as it goes rather than all at the end.
+check over-32-bindings-letstar \
+"(let ((outer 7))
+  (let* ($BIG_BINDINGS)
+    (display (+ outer v0))
+    (newline)))" \
+whole-scope:outer
+
+# 3. The silent case, and the worst symptom: with a same-named global in scope
+#    the eval resolved to it instead of erroring, so the binary printed 999
+#    where the interpreter printed 7 — no crash, no diagnostic. The trailing
+#    read pins that the let's binding never escapes to the global either.
+check shadows-global \
+"(define outer 999)
+(let ((outer 7))
+  (let ($BIG_BINDINGS)
+    (display (+ outer v0))
+    (newline)))
+(display outer)
+(newline)" \
+whole-scope:outer
+
+# 4. A set! of the outer binding from the abandoned inner let: the mutation has
+#    to land on the outer let's own location, which only holds if the whole
+#    scope is evaluated together.
+check set-through-outer-binding \
+"(let ((acc 0))
+  (let ($BIG_BINDINGS)
+    (set! acc (+ acc v32)))
+  (display acc)
+  (newline))" \
+whole-scope:acc
+
+# 5. More head defines than emitLet roots (#1854's max_head_defines) — a second
+#    mid-emission ceiling reaching the same escape hatch.
+check over-32-head-defines \
+"(let ((outer 7))
+  (let ((a 1))
+    $BIG_DEFINES
+    (display (list outer a d0 d32))
+    (newline)))" \
+whole-scope:outer
+
+# 6. #1854's trigger: a define inside an `if` is one the scope cannot root with a
+#    statically matched pop, so emitDefine declines and the inner let abandons
+#    from its body loop — an emitNode failure, not a ceiling.
+check unmodelled-define-in-if \
+"(let ((outer 7))
+  (let ((a 1))
+    (if (> a 0) (define x (list 1 2)) #f)
+    (display (list outer x))
+    (newline)))" \
+whole-scope:outer
+
+# 7. A define after a non-define body form is outside the modelled head run,
+#    reaching the same emitDefine decline from a different shape.
+check define-after-expression \
+"(let ((outer 7))
+  (let ((a 1))
+    (define xs (list 1))
+    (display a)
+    (newline)
+    (define ys (list 2))
+    (display (list outer xs ys))
+    (newline)))" \
+whole-scope:outer
+
+# 8. R7RS lets `begin` splice definitions at the head of a body; the head scan
+#    does not model that shape, so the inner let abandons there too.
+check begin-spliced-define \
+"(let ((outer 7))
+  (let ((a 1))
+    (begin (define x (list 1 2)))
+    (display (list outer x))
+    (newline)))" \
+whole-scope:outer
+
+# 9. #1497's up-front trigger, reached from a nested position: the inner let's
+#    body captures its own binding in an unmutated lambda, so the inner let falls
+#    back before emitting anything. The outer let cannot see this in its own
+#    capture analysis — the lambda references `a`, not `outer` — so it proceeds
+#    natively and the inner fallback is what has to decline.
+check captured-unmutated-inner-binding \
+"(let ((outer 7))
+  (let ((a 1))
+    (display (list outer ((lambda () a))))
+    (newline)))" \
+whole-scope:outer
+
+# 10. Two enclosing levels: the decline has to propagate through the middle let
+#     (which abandons and declines in turn) out to the outermost one, where
+#     locals are finally absent and the eval is correct.
+check triple-nested-lets \
+"(let ((o1 1))
+  (let ((o2 2))
+    (let ($BIG_BINDINGS)
+      (display (list o1 o2 v0))
+      (newline))))" \
+whole-scope:o1
+
+# 11. Coverage guard: a let that abandons directly inside a lambda frame, with no
+#     enclosing let. Params ARE publishable, so this must still compile the
+#     lambda natively and fall back only for the let (#1410). Verified against a
+#     pre-fix binary as the one case here whose emitted IR is unchanged — an
+#     over-broad gate (declining on params/upvalues too) would regress it.
+check let-fallback-in-lambda-frame \
+"(define (f p q)
+  (let ($BIG_BINDINGS)
+    (list p q v0 v32)))
+(display (f 1 2))
+(newline)" \
+native-frame
+
+# 12. The two rules together: inside a lambda, an inner let abandons and declines
+#     to the enclosing let, which then falls back with only the lambda's params
+#     in scope — publishable, so the lambda itself stays native.
+check nested-let-fallback-in-lambda-frame \
+"(define (f p)
+  (let ((o 7))
+    (let ($BIG_BINDINGS)
+      (list p o v0))))
+(display (f 5))
+(newline)" \
+native-frame
+
+# 13. Shadow-stack balance across the widened abandon, asserted on the emitted IR
+#     rather than on output. Declining now unwinds an extra level: the outer let
+#     had already emitted and rooted its own binding, and published it into the
+#     pop-before-tail accounting (#1585), before the inner let's decline made it
+#     abandon and roll all of that back. Leaving a push without its pop (or vice
+#     versa) desynchronises the shadow stack rather than printing a wrong answer —
+#     an over-pop underflows GC.root_count, an under-pop just strands a slot.
+#
+#     Since every let in the abandoning chain now falls back, its own pushes are
+#     truncated away entirely, so the count needs an independent baseline to not
+#     be vacuous: the leading sibling let stays native and contributes the pushes.
+#     In a straight-line @main every push and pop is textually reached exactly
+#     once, so summing them over the function is exact.
+check_root_balance() {
+    local name="$1" src="$2"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1); then
+        echo "FAIL: $name — --emit-llvm failed" >&2
+        fail=1
+        return
+    fi
+
+    local main_ir pushes pops
+    main_ir=$(sed -n '/^define i32 @main/,/^}/p' "$DIR/$name.ll")
+    pushes=$(printf '%s\n' "$main_ir" | grep -c 'call void @kaappi_gc_push_root' || true)
+    pops=$(printf '%s\n' "$main_ir" |
+        sed -n 's/.*call void @kaappi_gc_pop_roots(i64 \([0-9]*\)).*/\1/p' |
+        awk '{n += $1} END {print n + 0}')
+
+    if [[ "$pushes" -eq 0 ]]; then
+        echo "FAIL: $name — no root pushes in @main (test would be vacuous)" >&2
+        fail=1
+        return
+    fi
+    if [[ "$pushes" -ne "$pops" ]]; then
+        echo "FAIL: $name — @main pushes $pushes roots but pops $pops" >&2
+        fail=1
+    fi
+}
+
+check_root_balance abandon-rollback-root-balance \
+"(let ((sibling (list 1 2)))
+  (display sibling)
+  (newline))
+(let ((outer (list 3 4)))
+  (let ($BIG_BINDINGS)
+    (display (list outer v0))
+    (newline)))"
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-nested-let-fallback-scope-1862: all cases passed"

--- a/tests/scheme/compile/native-nested-let-fallback-scope-1862.sh
+++ b/tests/scheme/compile/native-nested-let-fallback-scope-1862.sh
@@ -126,8 +126,15 @@ check() {
             # them must open with the OUTER let, proving the abandon propagated
             # out to it instead of stopping at the inner let. These sources hold
             # no quote or backslash, so internString emits them verbatim.
+            #
+            # ERE, deliberately: `\?` and `\|` are GNU BRE extensions that
+            # OpenBSD's grep does not accept, and there they matched nothing at
+            # all — every case here failed its routing check while still agreeing
+            # with the interpreter on output. In ERE `?` needs no backslash, and
+            # `let\*?` (an optional literal `*`) covers `let` and `let*` in one
+            # branch, so the alternation goes away too.
             local binder="${routing#whole-scope:}"
-            if ! grep -q "constant \[.*c\"(let\* \?((${binder} \|constant \[.*c\"(let \?((${binder} " "$DIR/$name.ll"; then
+            if ! grep -Eq "constant \\[.*c\"\\(let\\*? ?\\(\\(${binder} " "$DIR/$name.ll"; then
                 echo "FAIL: $name — no eval of the enclosing '($binder ...)' scope; the inner form fell back alone" >&2
                 fail=1
             fi


### PR DESCRIPTION
Fixes #1862.

## The bug

A `let` nested inside another `let` that gives up on native compilation *mid-emission* was handed to `kaappi_eval` on its own. That eval resolves names in the global environment, so the outer `let`'s bindings were invisible:

```scheme
(let ((outer 7))
  (let ((v0 0) (v1 1) ... (v32 32))   ; 33 bindings trips emitLet's ceiling
    (display (+ outer v0))))
```

| | output |
|---|---|
| `kaappi t.scm` | `7` |
| `kaappi compile t.scm -o t && ./t` | `eval error: undefined variable 'outer' … (UndefinedVariable)`, exit 1 |

Worse when a same-named global is in scope — no error at all, just a wrong answer:

```scheme
(define outer 999)
(let ((outer 7)) (let (<33 bindings>) (display (+ outer v0))))
```

Interpreter prints `7`; the pre-fix binary printed `999`, silently.

[#827](https://github.com/kaappi/kaappi/issues/827) already fixed this class for anything an up-front syntactic scan can see, by declining native compilation of the whole enclosing scope. The triggers here are only discoverable mid-emission, so no scan can pre-empt them: more than 32 bindings, more head `define`s than the scope roots, or an `ir.lowerSingleExpr`/`emitNode` failure on a binding initializer or body form. [#1854](https://github.com/kaappi/kaappi/issues/1854) added the last of those, which is what surfaced this.

## The fix

`bindParamsAsGlobals` is the single chokepoint every whole-form eval fallback goes through, and params, the rest parameter, and upvalues are the whole of what it can reach — a `let`-local lives in an `alloca` it has no name for. It now refuses when `self.locals != null`, the way it already refuses a boxed param it cannot honestly publish. The error abandons the enclosing `let` in turn, so the interpreter gets that whole lexical scope in one piece.

This is the issue's **option 2**. Option 1 (publish the locals) is worse: a boxed local hits the same by-location problem as a boxed param ([#1422](https://github.com/kaappi/kaappi/issues/1422)), and both of that helper's documented weaknesses — it aliases across activations, and it permanently clobbers a same-named global — would extend to let-locals.

`emitLambdaViaEval`'s own `self.locals != null` check is now that same gate one line later, so it is dropped rather than duplicated.

## Verification

**A/B against a pre-fix binary** (built to an isolated `--prefix`, cache cleared between): 11 of the new test's 13 cases diverge without the fix and pass with it. The two that pass either way are deliberate guards, not filler:

- `let-fallback-in-lambda-frame` — a fallback inside a plain lambda frame, where params *are* publishable, must still compile the lambda natively. Its emitted IR is byte-identical pre/post, so an over-broad gate (declining on params/upvalues too) would regress it.
- `abandon-rollback-root-balance` — shadow-stack push/pop accounting across the now-wider abandon.

The `whole-scope:<binder>` routing assertion was mutation-tested separately: a bare "did anything fall back?" count does **not** discriminate here, since pre-fix `@main` also held exactly one eval — of the inner `let` alone, which *is* the bug. The assertion requires the eval'd source to open with the *outer* `let`.

**34-program adversarial sweep** over the shapes this touches (nested lets, `do`/`cond`/`case` bodies, rest params, upvalues, boxed captures, internal defines, tail position, at-the-ceiling lets), pre vs post:

- 7 cases moved from diverging to agreeing with the interpreter
- 0 regressed
- **0 change in any program's eval-fallback count or native-function count** — the eval widens from the inner `let` to the enclosing scope rather than replacing native code

The one case that diverges in both is a pre-existing, unrelated artifact: the interpreter echoes a bare top-level expression's value and a compiled binary does not (confirmed by removing the bare expression, after which it agrees).

**Suites:** `zig build test` clean; full Scheme suite 2016 pass / 0 fail; all 21 native-compile shell suites pass; `zig fmt --check` and `markdownlint-cli2` clean.

## Docs

`docs/dev/llvm-backend.md` stated the gap as a live hazard ("it cannot see `let`-locals at all") — updated to describe the gate, why declining beats publishing, and what the pre-fix symptom was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)