### PR TITLE
Free the fiber scheduler when its setup allocation fails

### DIFF
--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -181,6 +181,34 @@ allocation a form performs. `FailingAllocator` cannot reach these sites, and
 and never reaches the expander. `oom_countdown` is compiled out entirely
 outside test binaries (`builtin.is_test`).
 
+### Raw-allocator ownership is still local (#1864)
+
+The boundary reset above unwinds the **GC root stack** and nothing else. A
+struct taken from `gc.allocator` is owned by whichever field is eventually
+assigned it, so every fallible step between the `create` and that assignment
+still needs its own local `errdefer`:
+
+```zig
+const sched = vm.gc.allocator.create(FiberScheduler) catch return VMError.OutOfMemory;
+sched.* = FiberScheduler.init(vm);
+errdefer {                       // nothing owns `sched` until vm.scheduler is set
+    sched.deinit(vm.gc.allocator);
+    vm.gc.allocator.destroy(sched);
+}
+```
+
+`fiber.ensureScheduler` was missing exactly this: an OOM in the main fiber's
+`allocFiber` or in `addFiber` returned with the scheduler neither destroyed
+nor stored, leaking both the struct and the managed `waiter_index` map inside
+it. This is not the LIFO footgun of rule 2 — an `errdefer` that undoes a
+*specific* allocation it names is always safe; only the shared, positional
+root stack makes `defer popRoot()` order-dependent.
+
+Note the scoping: an `errdefer` inside a block is discarded when that block
+exits normally, so the one above cannot fire for a later failure in the
+reactor block that follows it — which matters, because by then `vm.scheduler`
+owns the pointer and freeing it would be a double free.
+
 ### Where to look
 
 The `reverse` function in `primitives.zig` is a clean reference

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -966,6 +966,16 @@ pub fn ensureScheduler(vm: *VM) VMError!struct { vm: *VM, sched: *FiberScheduler
     if (vm.scheduler == null) {
         const sched = vm.gc.allocator.create(FiberScheduler) catch return VMError.OutOfMemory;
         sched.* = FiberScheduler.init(vm);
+        // Nothing owns `sched` until `vm.scheduler` is assigned below, so the
+        // two fallible steps in between have to give it back themselves —
+        // both the struct and the managed `waiter_index` map init() built
+        // inside it (#1864). Block-scoped, so a failure in the *reactor*
+        // block below — after this one has exited normally and stored the
+        // scheduler — never reaches it and cannot free a live scheduler.
+        errdefer {
+            sched.deinit(vm.gc.allocator);
+            vm.gc.allocator.destroy(sched);
+        }
         const main_fiber = vm.gc.allocFiber(types.VOID, sched.next_id) catch return VMError.OutOfMemory;
         sched.next_id += 1;
         main_fiber.status = .running;

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -3,6 +3,7 @@ const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const vm_mod = @import("vm.zig");
+const fiber_mod = @import("fiber.zig");
 
 // Regression tests for the fiber scheduler give-up path (#kaappi-book):
 // runSchedulerUntil used to silently return VOID when no fiber was runnable
@@ -395,4 +396,70 @@ test "rendezvous channel: parked timed senders pair under a nested main receive"
     const ok = std.mem.eql(u8, s, "(a sent-a tb empty)") or
         std.mem.eql(u8, s, "(b ta sent-b empty)");
     try std.testing.expect(ok);
+}
+
+// ---------------------------------------------------------------------------
+// ensureScheduler cleanup on a failed allocation (#1864)
+// ---------------------------------------------------------------------------
+//
+// ensureScheduler creates the FiberScheduler with the *raw* allocator and then
+// runs two more fallible steps — the main fiber's allocFiber, and addFiber's
+// append. Without an errdefer, a failure in either returns with `sched`
+// neither destroyed nor stored in `vm.scheduler`, so nothing owns it: the
+// struct and the managed `waiter_index` map inside it both leak. (The reactor
+// block immediately below it always cleaned up after itself; these tests pin
+// the scheduler block to the same contract.)
+//
+// The leak also blocked writing *any* OOM sweep that reaches a fiber path: the
+// leak check aborts the test before its own assertions run.
+
+test "ensureScheduler frees the scheduler when the main fiber allocation fails" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The scheduler struct comes from the raw allocator, which the injector
+    // does not count, so the main fiber is ensureScheduler's first *heap*
+    // allocation — countdown 0 fails exactly that one.
+    gc.oom_countdown = 0;
+    try std.testing.expectError(vm_mod.VMError.OutOfMemory, fiber_mod.ensureScheduler(vm));
+    gc.oom_countdown = null;
+    try std.testing.expect(vm.scheduler == null);
+    try std.testing.expect(vm.current_fiber == null);
+
+    // Not sticky: a later call still builds a usable scheduler, and the VM
+    // owns that one, so std.testing.allocator sees exactly one of each.
+    const ready = try fiber_mod.ensureScheduler(vm);
+    try std.testing.expect(vm.scheduler == ready.sched);
+    try std.testing.expect(vm.current_fiber != null);
+}
+
+test "spawning a fiber leaks nothing when an allocation fails" {
+    // End-to-end sweep over the whole first `spawn` — the one call that
+    // constructs the scheduler, and so the only point in the sweep that can
+    // reach the leaking path. Fails pre-fix with one leaked allocation
+    // attributed to spawnFn's `try ensureScheduler`.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    var failures: usize = 0;
+    var successes: usize = 0;
+    var n: usize = 0;
+    while (n <= 400) : (n += 1) {
+        ctx.gc.oom_countdown = n;
+        const result = ctx.vm.eval("(let ((f (spawn (lambda () (list 1 2 3))))) (fiber-join f))");
+        ctx.gc.oom_countdown = null;
+        if (result) |_| successes += 1 else |_| failures += 1;
+        ctx.gc.collect();
+    }
+    // Both halves matter. `failures` proves the injector fired at all;
+    // `successes` proves the bound ran past the *whole* allocation profile of
+    // the first spawn — the run that builds the scheduler. Without that second
+    // assertion a future spawn that allocates more would push the
+    // ensureScheduler window past 400 and quietly make this test vacuous
+    // instead of failing.
+    try std.testing.expect(failures > 0);
+    try std.testing.expect(successes > 0);
 }


### PR DESCRIPTION
Fixes #1864.

## The bug

`fiber.ensureScheduler` (`src/fiber.zig:967`) takes the `FiberScheduler` from the raw allocator, then runs two more fallible steps — the main fiber's `allocFiber` and `addFiber` — before `vm.scheduler` is assigned. Until that assignment nothing owns the struct, so a failure in either step returned with it neither destroyed nor stored, leaking both the struct and the managed `waiter_index` map `init()` built inside it.

The `Reactor` block directly below already cleaned up after itself; this makes the scheduler block symmetric with its own neighbour.

## Why the errdefer is block-scoped

Deliberately, and it is the non-obvious part of the patch. An `errdefer` is discarded when its block exits normally, so this one cannot fire for a later failure in the *reactor* block — by then `vm.scheduler` owns the pointer and freeing it would be a double free rather than a leak. Verified against a standalone Zig program before applying, rather than assumed.

## Severity

Low on its own: it needs a real OOM during the first `spawn` in a VM, leaks one struct, and the process is usually about to die anyway. Worth fixing because the correct pattern was already three lines away, and because the leak blocked writing *any* OOM-sweep test that reaches a fiber path — the leak check aborts the test before its own assertions run.

## Tests

Two regression tests in `src/tests_fibers.zig`, both confirmed to fail pre-fix and pass post-fix:

1. **Deterministic.** The scheduler comes from the raw allocator, which the injector does not count, so `oom_countdown = 0` lands exactly on the main fiber's `allocFiber`. This pins the bug in every build config, independent of any sweep bound.
2. **End-to-end sweep** over the first `spawn` (the issue's own repro). It asserts `successes > 0` as well as `failures > 0`, so a future `spawn` that allocates more fails the test loudly instead of quietly sweeping past the `ensureScheduler` window and going vacuous.

Pre-fix, the sweep's leak trace pointed at `primitives_fiber.zig:41` in `spawnFn` — exactly what the issue reported.

## Scope check

Scanned the sibling raw `allocator.create` sites in `reactor.zig` and `primitives_srfi18.zig`; all already unwind their error paths explicitly. This was the only gap, so there is nothing to spin off.

## Docs

Added a short subsection to `docs/dev/gc-safety-and-error-handling.md`. The existing #1855 section can read as though the pipeline boundary reset covers this case, when it only unwinds the GC root stack — raw-allocator ownership between a `create` and the field that owns it still needs a local `errdefer`.

## Verification

- Unit suite: 1432/1435 passed, 3 skipped, no leaks
- Scheme suites: 2015 pass, 0 fail
- `zig fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)