### PR TITLE
Name the expected type, and the right argument, in every type error (#1868)

### DIFF
--- a/.claude/skills/add-builtin/SKILL.md
+++ b/.claude/skills/add-builtin/SKILL.md
@@ -102,14 +102,33 @@ out of your primitive with its detail intact.
 ## Error handling
 
 Use `primitives.typeError(proc, expected, got)` for type checks — it produces
-`type error in 'my-proc': expected exact integer, got #t` instead of an
-anonymous `TypeError`. The `format` CI job ratchets against new bare
-`return PrimitiveError.TypeError`, so adding one fails the build; only
-infrastructure guards with no procedure context to report opt out, with
-`// bare-ok: <reason>`.
+`type error in 'my-proc': expected exact integer, got #t`. The `format` CI job
+rejects **any** bare `return PrimitiveError.TypeError` that lacks a
+`// bare-ok: <reason>` comment, so adding one fails the build; the annotation is
+only for infrastructure guards with no procedure context to report (a
+`vm_instance orelse` with no VM, say).
+
+A bare return is not silent — `vm_calls.mapNativeError` fills in
+`type error in '<primitive>': got <args[0]>` — so it looks deliberate while
+dropping the expected type and, when the bad value is not `args[0]`, naming the
+wrong argument. That is the trap, not the missing name.
 
 `expectFixnum` / `expectString` / `expectChar` / `expectPair` / `expectVector` /
-`expectPort` validate and unwrap in one step, and `indexError(proc, index, len)`
-covers out-of-range access — prefer it over returning `IndexOutOfBounds` bare,
-for the same reason. Error tags with no detail to attach (`DivisionByZero`,
-`OutOfMemory`, …) are returned directly.
+`expectPort` validate and unwrap in one step. Pick the helper that matches the
+failure rather than routing everything through `typeError`:
+
+| Helper | Tag | Use for |
+|--------|-----|---------|
+| `typeError(proc, expected, got)` | `TypeError` (KP3002) | wrong type |
+| `indexError(proc, index, len)` | `IndexOutOfBounds` (KP3006) | index outside `0..len` |
+| `argError(proc, fmt, args)` | `InvalidArgument` (KP3007) | right type, rejected anyway |
+
+`argError` takes a comptime format string and prefixes the procedure name
+itself — reach for it when "expected X, got Y" would misdescribe the failure
+(a symbol outside an accepted set, a sealed rtd, an already-claimed uid). It is
+also how you name an offending *symbol*: `typeError`'s `safeValueDescription`
+never dereferences heap payloads, so its `got` renders every symbol as a bare
+`#<symbol>`, while `argError`'s format string can print the name.
+
+Error tags with no detail to attach (`DivisionByZero`, `OutOfMemory`, …) are
+returned directly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,22 @@ jobs:
       - name: Format check
         run: zig fmt --check src/
 
-      # Ratchet: lower the baseline whenever the count drops, so the guard keeps
-      # its bite. Was 91 when introduced; the remaining 20 are in
-      # primitives{,_hashtable,_parallel,_srfi18,_srfi237}.zig.
+      # This was a ratchet (91 at introduction, then 20) while a backlog of
+      # anonymous TypeErrors was worked off. kaappi#1868 cleared the last of
+      # them, so the baseline is now 0 and there is no number to keep in step
+      # with the source -- every bare return must carry a `bare-ok` reason.
       - name: Check bare TypeError regression
         run: |
-          count=$(grep -r 'return PrimitiveError\.TypeError' src/primitives*.zig | grep -v 'bare-ok' | wc -l | tr -d ' ')
-          echo "Unannotated bare TypeErrors: $count (baseline: 20)"
-          if [ "$count" -gt 20 ]; then
-            echo "::error::New bare PrimitiveError.TypeError without 'bare-ok' annotation."
-            echo "Use primitives.typeError(proc, expected, got) for type checks."
-            echo "Only add '// bare-ok: <reason>' for infrastructure guards."
-            grep -rn 'return PrimitiveError\.TypeError' src/primitives*.zig | grep -v 'bare-ok'
+          if grep -rn 'return PrimitiveError\.TypeError' src/primitives*.zig | grep -v 'bare-ok'; then
+            echo "::error::Bare PrimitiveError.TypeError without a 'bare-ok' annotation (listed above)."
+            echo "Use primitives.typeError(proc, expected, got) for type checks --"
+            echo "a bare return reaches the user as vm_calls.mapNativeError's fallback,"
+            echo "which names the primitive but reports args[0] as the offending value."
+            echo "Only add '// bare-ok: <reason>' for infrastructure guards that have no"
+            echo "procedure context to report (e.g. a 'vm_instance orelse' with no VM)."
             exit 1
           fi
+          echo "No unannotated bare TypeErrors."
 
       # Globs, ignores, and the rule set all live in .markdownlint-cli2.jsonc,
       # so `npx markdownlint-cli2` locally lints exactly what this step does.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1011,11 +1011,25 @@ map.deinit();  // no allocator arg needed
    ```
 
    Report type errors with `primitives.typeError(proc, expected, got)`, never a
-   bare `return PrimitiveError.TypeError` — it names the procedure and the
-   offending value in the message, and the `format` CI job ratchets against new
-   bare returns. `expectFixnum`/`expectString`/`expectPair`/… validate and
-   unwrap in one step. Infrastructure guards with no procedure context to
-   report opt out with `// bare-ok: <reason>`.
+   bare `return PrimitiveError.TypeError` — it names the expected type and the
+   offending value, and the `format` CI job rejects any unannotated bare return
+   (the count-based ratchet was retired at 0 by kaappi#1868).
+   `expectFixnum`/`expectString`/`expectPair`/… validate and unwrap in one step.
+   Infrastructure guards with no procedure context to report opt out with
+   `// bare-ok: <reason>`.
+
+   A bare return is not silent — `vm_calls.mapNativeError` synthesizes
+   `type error in '<primitive>': got <args[0]>` when no detail was set — which
+   is exactly what makes it dangerous: the procedure name survives, so the
+   message looks deliberate while omitting the expected type and, when the
+   offending value is not the first argument, naming the wrong one.
+
+   Use the sibling helpers for failures that are not type errors, rather than
+   stretching `typeError` over them: `indexError(proc, index, len)`
+   (`IndexOutOfBounds`, KP3006) and `argError(proc, fmt, args)`
+   (`InvalidArgument`, KP3007 — for a value of acceptable type that the
+   procedure rejects anyway, e.g. a sealed parent rtd). See
+   `docs/dev/adding-features.md`.
 
 2. Add one entry to the file's `specs` table — name, function, arity, and the
    libraries that export it. `registerAll` walks `all_specs` and
@@ -1368,6 +1382,7 @@ workspace-level `.claude/settings.json` when working from the multi-repo workspa
 | Session context | SessionStart hook | `.claude/hooks/session-start.sh` |
 | Zig formatting | PostToolUse hook + git pre-commit | `.claude/hooks/zig-fmt-post.sh`, `.githooks/pre-commit` |
 | Markdown structure | CI `format` job (markdownlint) | `.markdownlint-cli2.jsonc`, `.github/workflows/ci.yml` |
+| No bare `PrimitiveError.TypeError` | CI `format` job (grep, zero allowed) | `.github/workflows/ci.yml` |
 | No destructive commands | Deny permissions + PreToolUse hook | `.claude/settings.json`, `.claude/hooks/bash-guard-pre.sh` |
 | Tests pass before stop | Stop hook | `.claude/hooks/test-on-stop.sh` |
 | GC safety checklist | Path-scoped rule (auto-loaded) | `.claude/rules/gc-safety.md` |

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -37,17 +37,40 @@ dispatch layer.
 a bare `return PrimitiveError.TypeError`. `typeError` attaches the procedure
 name, the expected type, and a description of what actually arrived to the
 error detail, so the user sees `type error in 'my-proc': expected exact
-integer, got #t` instead of an anonymous `TypeError`. The `format` CI job
-enforces this with a ratchet on the count of unannotated bare returns
+integer, got #t`. The `format` CI job rejects any unannotated bare return
 (`.github/workflows/ci.yml`), so adding one fails the build. Only
 infrastructure guards that have no procedure context to report -- the
 `vm_instance orelse` fallbacks, for example -- take a bare return, and those
-carry a `// bare-ok: <reason>` comment to opt out of the ratchet.
+carry a `// bare-ok: <reason>` comment to opt out.
+
+A bare return is not silent, which is what made the backlog kaappi#1868 cleared
+easy to underestimate: `vm_calls.mapNativeError` synthesizes `type error in
+'<primitive>': got <args[0]>` for any primitive that set no detail. So the
+procedure name survives -- what is lost is the *expected* type, and, whenever
+the offending value is not the first argument, the report names the wrong one.
+A string-keyed hash table given a bad key used to blame the table itself.
 
 For the common checks there are wrappers that validate and unwrap in one step,
 each taking the procedure name for the same error detail: `expectFixnum`,
-`expectString`, `expectChar`, `expectPair`, `expectVector`, `expectPort`, plus
-`indexError(proc, index, len)` for out-of-range access.
+`expectString`, `expectChar`, `expectPair`, `expectVector`, `expectPort`.
+
+`typeError` has two siblings for the conditions that are not type errors, so
+that reaching for it never becomes the reflex for every rejection:
+
+| Helper | Tag | Use for |
+|--------|-----|---------|
+| `typeError(proc, expected, got)` | `TypeError` (KP3002) | the value is of the wrong type |
+| `indexError(proc, index, len)` | `IndexOutOfBounds` (KP3006) | an index outside `0..len` |
+| `argError(proc, fmt, args)` | `InvalidArgument` (KP3007) | the type is fine and the procedure rejects the value anyway |
+
+`argError` takes a comptime format string and its arguments, and prefixes the
+procedure name itself: `argError("%make-record-type-descriptor", "record type
+'{s}' is sealed and cannot be a parent", .{p.name})`. Prefer it whenever
+"expected X, got Y" would misdescribe the failure -- a symbol that is not one of
+three accepted symbols, an rtd that refuses to be extended, a uid already
+claimed. It also sidesteps a limit of `typeError`: `safeValueDescription`
+deliberately does not dereference heap payloads, so `got` renders every symbol
+as a bare `#<symbol>`, and `argError`'s own format string can name it.
 
 ### 2. Register the procedure and its libraries
 

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -411,7 +411,7 @@ pub fn bootstrapStub(comptime name: []const u8) types.NativeFnType {
             _ = args;
             const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             vm.setErrorDetail("'{s}' is implemented in Scheme (src/vm_bootstrap.zig) but vm_bootstrap.install() has not run for this VM", .{name});
-            return PrimitiveError.TypeError;
+            return PrimitiveError.TypeError; // bare-ok: detail set on the line above
         }
     };
     return &S.call;
@@ -473,7 +473,7 @@ pub fn typeError(proc: []const u8, expected: []const u8, got: Value) PrimitiveEr
     var buf: [128]u8 = undefined;
     const s = safeValueDescription(&buf, got);
     vm.setErrorDetail("type error in '{s}': expected {s}, got {s}", .{ proc, expected, s });
-    return PrimitiveError.TypeError;
+    return PrimitiveError.TypeError; // bare-ok: this is typeError itself
 }
 
 pub fn expectPair(proc: []const u8, v: Value) PrimitiveError!*types.Pair {
@@ -511,6 +511,16 @@ pub fn indexError(proc: []const u8, index: i64, len: usize) PrimitiveError {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.IndexOutOfBounds;
     vm.setErrorDetail("{s}: index {d} out of range for length {d}", .{ proc, index, len });
     return PrimitiveError.IndexOutOfBounds;
+}
+
+/// The `typeError`/`indexError` sibling for a constraint that is about neither
+/// type nor range: the argument's type is acceptable and the procedure still
+/// rejects it (R6RS's "parent is sealed", a uid whose field specs disagree).
+/// `explanation` says what the procedure requires, in the caller's own words.
+pub fn argError(proc: []const u8, comptime explanation: []const u8, fmt_args: anytype) PrimitiveError {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidArgument;
+    vm.setErrorDetail("{s}: " ++ explanation, .{proc} ++ fmt_args);
+    return PrimitiveError.InvalidArgument;
 }
 
 pub const Range = struct { start: usize, end: usize };

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -155,23 +155,30 @@ fn stringBytesOrNull(v: Value) ?[]const u8 {
     return s.data[0..s.len];
 }
 
-fn equalForTable(ht: *HashTable, a: Value, b: Value) PrimitiveError!bool {
+// A string-keyed table rejects a non-string key, but "expected string" alone
+// leaves the caller guessing why: nothing about `(hash-table-set! h 1 'x)` says
+// the table's own equivalence function is what makes 1 wrong. Naming the
+// compare mode puts the reason in the message.
+const STRING_EQ_KEY = "string key (this table compares with string=?)";
+const STRING_CI_KEY = "string key (this table compares with string-ci=?)";
+
+fn equalForTable(proc: []const u8, ht: *HashTable, a: Value, b: Value) PrimitiveError!bool {
     return switch (ht.compare_mode) {
         .equal => primitives.deepEqual(a, b),
         .eq => a == b,
         .eqv => eqvEqual(a, b),
         .string_eq => blk: {
-            const sa = stringBytesOrNull(a) orelse return PrimitiveError.TypeError;
-            const sb = stringBytesOrNull(b) orelse return PrimitiveError.TypeError;
+            const sa = stringBytesOrNull(a) orelse return primitives.typeError(proc, STRING_EQ_KEY, a);
+            const sb = stringBytesOrNull(b) orelse return primitives.typeError(proc, STRING_EQ_KEY, b);
             break :blk std.mem.eql(u8, sa, sb);
         },
         .string_ci => blk: {
-            const sa = stringBytesOrNull(a) orelse return PrimitiveError.TypeError;
-            const sb = stringBytesOrNull(b) orelse return PrimitiveError.TypeError;
+            const sa = stringBytesOrNull(a) orelse return primitives.typeError(proc, STRING_CI_KEY, a);
+            const sb = stringBytesOrNull(b) orelse return primitives.typeError(proc, STRING_CI_KEY, b);
             break :blk char_mod.foldCompareStrings(sa, sb) == .eq;
         },
         .custom => blk: {
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             const call_args = [2]Value{ a, b };
             const result = vm.callWithArgs(ht.equiv_fn, &call_args) catch |err| {
                 return err;
@@ -215,20 +222,20 @@ fn stringCiContentHash(data: []const u8) usize {
     return h;
 }
 
-fn hashForTable(ht: *HashTable, key: Value) PrimitiveError!usize {
+fn hashForTable(proc: []const u8, ht: *HashTable, key: Value) PrimitiveError!usize {
     return switch (ht.compare_mode) {
         .equal, .eqv => valueHash(key),
         .eq => identityHash(key),
         .string_eq => blk: {
-            const data = stringBytesOrNull(key) orelse return PrimitiveError.TypeError;
+            const data = stringBytesOrNull(key) orelse return primitives.typeError(proc, STRING_EQ_KEY, key);
             break :blk stringContentHash(data);
         },
         .string_ci => blk: {
-            const data = stringBytesOrNull(key) orelse return PrimitiveError.TypeError;
+            const data = stringBytesOrNull(key) orelse return primitives.typeError(proc, STRING_CI_KEY, key);
             break :blk stringCiContentHash(data);
         },
         .custom => blk: {
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
             const call_args = [1]Value{key};
             const result = vm.callWithArgs(ht.hash_fn, &call_args) catch |err| {
                 return err;
@@ -345,7 +352,7 @@ fn valueHashDepth(key: Value, depth: usize) usize {
     return @truncate(key *% 2654435761);
 }
 
-fn findKey(ht: *HashTable, key: Value) PrimitiveError!?usize {
+fn findKey(proc: []const u8, ht: *HashTable, key: Value) PrimitiveError!?usize {
     if (ht.capacity == 0) return null;
     const mask = ht.capacity - 1;
     if (ht.compare_mode == .equal) {
@@ -360,12 +367,12 @@ fn findKey(ht: *HashTable, key: Value) PrimitiveError!?usize {
         }
         return null;
     }
-    var idx = (try hashForTable(ht, key)) & mask;
+    var idx = (try hashForTable(proc, ht, key)) & mask;
     var probes: usize = 0;
     while (probes < ht.capacity) {
         const entry = &ht.entries[idx];
         if (entry.state == .empty) return null;
-        if (entry.state == .occupied and try equalForTable(ht, entry.key, key)) return idx;
+        if (entry.state == .occupied and try equalForTable(proc, ht, entry.key, key)) return idx;
         idx = (idx + 1) & mask;
         probes += 1;
     }
@@ -374,7 +381,7 @@ fn findKey(ht: *HashTable, key: Value) PrimitiveError!?usize {
 
 const FindSlotResult = struct { idx: usize, found: bool };
 
-fn findSlot(ht: *HashTable, key: Value) PrimitiveError!FindSlotResult {
+fn findSlot(proc: []const u8, ht: *HashTable, key: Value) PrimitiveError!FindSlotResult {
     const mask = ht.capacity - 1;
     if (ht.compare_mode == .equal) {
         var idx = valueHash(key) & mask;
@@ -395,7 +402,7 @@ fn findSlot(ht: *HashTable, key: Value) PrimitiveError!FindSlotResult {
         }
         return .{ .idx = first_tombstone orelse 0, .found = false };
     }
-    var idx = (try hashForTable(ht, key)) & mask;
+    var idx = (try hashForTable(proc, ht, key)) & mask;
     var first_tombstone: ?usize = null;
     var probes: usize = 0;
     while (probes < ht.capacity) {
@@ -405,7 +412,7 @@ fn findSlot(ht: *HashTable, key: Value) PrimitiveError!FindSlotResult {
         }
         if (entry.state == .tombstone) {
             if (first_tombstone == null) first_tombstone = idx;
-        } else if (try equalForTable(ht, entry.key, key)) {
+        } else if (try equalForTable(proc, ht, entry.key, key)) {
             return .{ .idx = idx, .found = true };
         }
         idx = (idx + 1) & mask;
@@ -414,7 +421,7 @@ fn findSlot(ht: *HashTable, key: Value) PrimitiveError!FindSlotResult {
     return .{ .idx = first_tombstone orelse 0, .found = false };
 }
 
-fn rehash(ht: *HashTable) PrimitiveError!void {
+fn rehash(proc: []const u8, ht: *HashTable) PrimitiveError!void {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const new_cap = if (ht.capacity == 0) 8 else ht.capacity * 2;
     const new_entries = memory.allocSliceNoFill(gc.allocator, HashEntry, new_cap) catch return PrimitiveError.OutOfMemory;
@@ -429,7 +436,7 @@ fn rehash(ht: *HashTable) PrimitiveError!void {
     var new_count: usize = 0;
     for (old_entries[0..old_cap]) |entry| {
         if (entry.state == .occupied) {
-            const h = hashForTable(ht, entry.key) catch |err| {
+            const h = hashForTable(proc, ht, entry.key) catch |err| {
                 memory.freeSliceNoFill(gc.allocator, HashEntry, new_entries);
                 return err;
             };
@@ -447,10 +454,10 @@ fn rehash(ht: *HashTable) PrimitiveError!void {
     memory.freeSliceNoFill(gc.allocator, HashEntry, old_entries);
 }
 
-fn growIfNeeded(ht: *HashTable) PrimitiveError!void {
+fn growIfNeeded(proc: []const u8, ht: *HashTable) PrimitiveError!void {
     // Grow when load factor > 75% (count uses > 3/4 of capacity)
     if (ht.capacity == 0 or ht.count * 4 >= ht.capacity * 3) {
-        try rehash(ht);
+        try rehash(proc, ht);
     }
 }
 
@@ -461,7 +468,7 @@ fn growIfNeeded(ht: *HashTable) PrimitiveError!void {
 // (make-hash-table) or (make-hash-table equal-proc [hash-proc])
 fn makeHashTableFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     const ht_val = gc.allocHashTable(8) catch return PrimitiveError.OutOfMemory;
     const ht = types.toHashTable(ht_val);
     configureHashTable(ht, ht_val, gc, vm, args);
@@ -476,7 +483,7 @@ fn hashTablePFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-ref ht key) or (hash-table-ref ht key default)
 fn hashTableRefFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-ref", args[0]);
-    if (try findKey(ht, args[1])) |idx| {
+    if (try findKey("hash-table-ref", ht, args[1])) |idx| {
         return ht.entries[idx].value;
     }
     // Key not found — call thunk if provided
@@ -495,8 +502,8 @@ fn hashTableRefFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-set! ht key value)
 fn hashTableSetFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-set!", args[0]);
-    try growIfNeeded(ht);
-    const slot = try findSlot(ht, args[1]);
+    try growIfNeeded("hash-table-set!", ht);
+    const slot = try findSlot("hash-table-set!", ht, args[1]);
     if (memory.gc_instance) |gc| {
         gc.writeBarrier(types.toObject(args[0]), args[1]);
         gc.writeBarrier(types.toObject(args[0]), args[2]);
@@ -513,7 +520,7 @@ fn hashTableSetFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-delete! ht key)
 fn hashTableDeleteFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-delete!", args[0]);
-    if (try findKey(ht, args[1])) |idx| {
+    if (try findKey("hash-table-delete!", ht, args[1])) |idx| {
         ht.entries[idx].state = .tombstone;
         ht.entries[idx].key = 0;
         ht.entries[idx].value = 0;
@@ -525,7 +532,7 @@ fn hashTableDeleteFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-exists? ht key)
 fn hashTableExistsFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-exists?", args[0]);
-    return if ((try findKey(ht, args[1])) != null) types.TRUE else types.FALSE;
+    return if ((try findKey("hash-table-exists?", ht, args[1])) != null) types.TRUE else types.FALSE;
 }
 
 // (hash-table-size ht)
@@ -616,7 +623,7 @@ fn hashTableToAlistFn(args: []const Value) PrimitiveError!Value {
 // (alist->hash-table alist) or (alist->hash-table alist equal-proc [hash-proc])
 fn alistToHashTableFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     var current = args[0];
 
     // Count entries first
@@ -642,7 +649,7 @@ fn alistToHashTableFn(args: []const Value) PrimitiveError!Value {
         const value = types.cdr(entry_pair);
 
         // Only add if key not already present (first occurrence wins)
-        const slot = try findSlot(ht, key);
+        const slot = try findSlot("alist->hash-table", ht, key);
         if (!slot.found) {
             ht.entries[slot.idx] = .{ .key = key, .value = value, .state = .occupied };
             ht.count += 1;
@@ -675,7 +682,7 @@ fn hashTableUpdateFn(args: []const Value) PrimitiveError!Value {
     const key = args[1];
     const proc = args[2];
 
-    const old_val = if (try findKey(ht, key)) |idx|
+    const old_val = if (try findKey("hash-table-update!", ht, key)) |idx|
         ht.entries[idx].value
     else if (args.len > 3) blk: {
         break :blk vm.callWithArgs(args[3], &[_]Value{}) catch |err| {
@@ -690,8 +697,8 @@ fn hashTableUpdateFn(args: []const Value) PrimitiveError!Value {
         return err;
     };
 
-    try growIfNeeded(ht);
-    const slot = try findSlot(ht, key);
+    try growIfNeeded("hash-table-update!", ht);
+    const slot = try findSlot("hash-table-update!", ht, key);
     if (memory.gc_instance) |gc| {
         gc.writeBarrier(types.toObject(args[0]), key);
         gc.writeBarrier(types.toObject(args[0]), new_val);
@@ -713,7 +720,7 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
     const proc = args[2];
     const default_val = args[3];
 
-    const old_val = if (try findKey(ht, key)) |idx|
+    const old_val = if (try findKey("hash-table-update!/default", ht, key)) |idx|
         ht.entries[idx].value
     else
         default_val;
@@ -723,8 +730,8 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
         return err;
     };
 
-    try growIfNeeded(ht);
-    const slot = try findSlot(ht, key);
+    try growIfNeeded("hash-table-update!/default", ht);
+    const slot = try findSlot("hash-table-update!/default", ht, key);
     if (memory.gc_instance) |gc| {
         gc.writeBarrier(types.toObject(args[0]), key);
         gc.writeBarrier(types.toObject(args[0]), new_val);
@@ -815,7 +822,7 @@ fn hashByIdentityFn(args: []const Value) PrimitiveError!Value {
 // (hash-table-ref/default ht key default)
 fn hashTableRefDefaultFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-ref/default", args[0]);
-    if (try findKey(ht, args[1])) |idx| {
+    if (try findKey("hash-table-ref/default", ht, args[1])) |idx| {
         return ht.entries[idx].value;
     }
     return args[2];
@@ -862,7 +869,7 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance;
     for (ht2.entries[0..ht2.capacity]) |entry| {
         if (entry.state != .occupied) continue;
-        const slot = try findSlot(ht1, entry.key);
+        const slot = try findSlot("hash-table-merge!", ht1, entry.key);
         if (gc) |g| {
             g.writeBarrier(types.toObject(args[0]), entry.key);
             g.writeBarrier(types.toObject(args[0]), entry.value);
@@ -870,8 +877,8 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
         if (slot.found) {
             ht1.entries[slot.idx].value = entry.value;
         } else {
-            try growIfNeeded(ht1);
-            const new_slot = try findSlot(ht1, entry.key);
+            try growIfNeeded("hash-table-merge!", ht1);
+            const new_slot = try findSlot("hash-table-merge!", ht1, entry.key);
             ht1.entries[new_slot.idx] = entry;
             ht1.count += 1;
         }
@@ -882,13 +889,13 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
 fn hashTableEquivFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-equivalence-function", args[0]);
     if (ht.equiv_fn != 0) return ht.equiv_fn;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     return lookupGlobal(vm, "equal?");
 }
 
 fn hashTableHashFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-hash-function", args[0]);
     if (ht.hash_fn != 0) return ht.hash_fn;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
     return lookupGlobal(vm, "hash");
 }

--- a/src/primitives_parallel.zig
+++ b/src/primitives_parallel.zig
@@ -40,8 +40,12 @@ const instr_specs = [_]primitives.PrimSpec{
     .{ .name = "%chan-instr-reassembly-end!", .func = &chanInstrReassemblyEnd, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
     .{ .name = "%chan-instr-reassembly-ns", .func = &chanInstrReassemblyNs, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
     .{ .name = "%chan-instr-envelope-peak-bytes", .func = &chanInstrEnvelopePeakBytes, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
-    .{ .name = "%elision-lever-set!", .func = &elisionLeverSet, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = LEVER_SET, .func = &elisionLeverSet, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
 };
+
+/// Shared by the spec entry and `elisionLeverSet`'s own error messages, so the
+/// name a caller sees reported can never drift from the name it called.
+const LEVER_SET = "%elision-lever-set!";
 
 pub const specs = base_specs ++ (if (build_options.channel_instrument) instr_specs else [0]primitives.PrimSpec{});
 
@@ -86,10 +90,8 @@ fn chanInstrEnvelopePeakBytes(args: []const Value) PrimitiveError!Value {
 /// `(%elision-lever-set! 'none|'c|'cd)` -- selects the envelope elision lever
 /// for subsequent sends/receives (protocol §2). Inert unless instrumented.
 fn elisionLeverSet(args: []const Value) PrimitiveError!Value {
-    if (!types.isPointer(args[0])) return PrimitiveError.TypeError;
-    const obj = types.toObject(args[0]);
-    if (obj.tag != .symbol) return PrimitiveError.TypeError;
-    const name = obj.as(types.Symbol).name;
+    if (!types.isSymbol(args[0])) return primitives.typeError(LEVER_SET, "symbol", args[0]);
+    const name = types.toObject(args[0]).as(types.Symbol).name;
     const lever: instrument.Lever = if (std.mem.eql(u8, name, "none"))
         .none
     else if (std.mem.eql(u8, name, "c"))
@@ -97,7 +99,10 @@ fn elisionLeverSet(args: []const Value) PrimitiveError!Value {
     else if (std.mem.eql(u8, name, "cd"))
         .cd
     else
-        return PrimitiveError.TypeError;
+        // Not a type error: args[0] IS a symbol, just not one of the three this
+        // lever accepts -- and `safeValueDescription` renders every symbol as a
+        // bare `#<symbol>`, so typeError could not name the one passed.
+        return primitives.argError(LEVER_SET, "expected lever none, c, or cd, got '{s}'", .{name});
     instrument.setLever(lever);
     return types.VOID;
 }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -362,11 +362,16 @@ fn threadSpecificSetFn(args: []const Value) PrimitiveError!Value {
 fn threadStartFn(args: []const Value) PrimitiveError!Value {
     // Unregistered on WASM (spec .wasm = false) but the body must still
     // compile there: the comptime spec-table filter (wasm_specs) evaluates
-    // the full `specs` array, which analyzes every referenced function.
-    // The else-branch is what keeps std.Thread.spawn out of the
-    // single-threaded wasm32 build — only the taken branch of a
-    // comptime-known if is analyzed.
-    if (comptime is_wasm) return PrimitiveError.TypeError else return threadStartImpl(args);
+    // the full `specs` array, which analyzes every referenced function --
+    // this one included (a `@compileError` here does fire on `zig build wasm`).
+    // What keeps threadStartImpl's std.Thread.spawn out of that build is the
+    // comptime-true branch returning unconditionally, so nothing after it is
+    // analyzed. Measured, because the `else` looks load-bearing and is not:
+    // a `@compileError` in threadStartImpl fires on neither `if/else` nor a
+    // plain early return. Keep the guard; the spelling is free (kaappi#1868).
+    if (comptime is_wasm) {
+        return PrimitiveError.TypeError; // bare-ok: unregistered on WASM, so unreachable
+    } else return threadStartImpl(args);
 }
 
 fn threadStartImpl(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -55,11 +55,17 @@ const RecordInstance = types.RecordInstance;
 const PrimitiveError = primitives.PrimitiveError;
 const typeError = primitives.typeError;
 const indexError = primitives.indexError;
+const argError = primitives.argError;
 const expectString = primitives.expectString;
 const expectFixnum = primitives.expectFixnum;
 const LS = primitives.LibSet;
 
 const SRFI237 = LS.initOne(.srfi_237_primitives);
+
+/// Shared by the spec entry and every error this primitive reports, so the name
+/// a caller sees can never drift from the name it called.
+const MAKE_RTD = "%make-record-type-descriptor";
+
 // %record?/inherit, %record-ref/inherit, %record-set!/inherit, and
 // %record-split-args are referenced directly by vm_records.zig's R6RS
 // desugarer's GENERATED code, exactly like the original R7RS %make-record/
@@ -74,7 +80,7 @@ const SRFI237 = LS.initOne(.srfi_237_primitives);
 const INTERNAL = primitives.INTERNAL;
 
 pub const specs = [_]primitives.PrimSpec{
-    .{ .name = "%make-record-type-descriptor", .func = &makeRecordTypeDescriptorFn, .arity = .{ .exact = 6 }, .libs = SRFI237 },
+    .{ .name = MAKE_RTD, .func = &makeRecordTypeDescriptorFn, .arity = .{ .exact = 6 }, .libs = SRFI237 },
     .{ .name = "%record?/inherit", .func = &recordCheckInheritFn, .arity = .{ .exact = 2 }, .libs = INTERNAL },
     .{ .name = "%record-ref/inherit", .func = &recordRefInheritFn, .arity = .{ .exact = 3 }, .libs = INTERNAL },
     .{ .name = "%record-set!/inherit", .func = &recordSetInheritFn, .arity = .{ .exact = 4 }, .libs = INTERNAL },
@@ -123,21 +129,24 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     // args: name(string), parent(record-type-or-#f), uid(string-or-#f),
     // sealed?(bool), opaque?(bool), field-specs(list of (name-string . mutable?))
-    const name = try expectString("%make-record-type-descriptor", args[0]);
+    const name = try expectString(MAKE_RTD, args[0]);
 
     const parent: ?*RecordType = if (args[1] == types.FALSE)
         null
     else blk: {
-        if (!types.isRecordType(args[1])) return typeError("%make-record-type-descriptor", "record-type", args[1]);
+        if (!types.isRecordType(args[1])) return typeError(MAKE_RTD, "record-type", args[1]);
         break :blk asRecordType(args[1]);
     };
-    // R6RS: "An exception ... is raised if parent is sealed".
-    if (parent) |p| if (p.sealed) return PrimitiveError.TypeError;
+    // R6RS: "An exception ... is raised if parent is sealed". Not a type error:
+    // a sealed rtd is a perfectly good record type, it just refuses to be
+    // extended -- so this reports as `invalid-argument` (KP3007).
+    if (parent) |p| if (p.sealed)
+        return argError(MAKE_RTD, "record type '{s}' is sealed and cannot be a parent", .{p.name});
 
     const uid: ?[]const u8 = if (args[2] == types.FALSE)
         null
     else
-        try expectString("%make-record-type-descriptor", args[2]);
+        try expectString(MAKE_RTD, args[2]);
 
     const sealed = args[3] != types.FALSE;
     const is_opaque = args[4] != types.FALSE;
@@ -147,11 +156,11 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
     var field_count: usize = 0;
     var specs_cur = args[5];
     while (specs_cur != types.NIL) {
-        if (!types.isPair(specs_cur)) return typeError("%make-record-type-descriptor", "list", args[5]);
+        if (!types.isPair(specs_cur)) return typeError(MAKE_RTD, "list", args[5]);
         const entry = types.car(specs_cur);
-        if (!types.isPair(entry)) return typeError("%make-record-type-descriptor", "(name . mutable?) pair", entry);
+        if (!types.isPair(entry)) return typeError(MAKE_RTD, "(name . mutable?) pair", entry);
         if (field_count >= 255) return PrimitiveError.TypeError; // bare-ok: internal record primitive; own_field_count is u8
-        field_names_buf[field_count] = try expectString("%make-record-type-descriptor", types.car(entry));
+        field_names_buf[field_count] = try expectString(MAKE_RTD, types.car(entry));
         field_mutable_buf[field_count] = types.cdr(entry) != types.FALSE;
         field_count += 1;
         specs_cur = types.cdr(specs_cur);
@@ -176,7 +185,10 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
             {
                 return existing;
             }
-            return PrimitiveError.TypeError;
+            // Also not a type error: the uid is a fine string, it is just
+            // already claimed by a type this call does not match.
+            return argError(MAKE_RTD, "uid \"{s}\" is already bound to a record type with a " ++
+                "different parent, sealed/opaque flag, or field set", .{u});
         }
     }
 

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -23,6 +23,21 @@ assert_output_contains() {
     fi
 }
 
+assert_output_lacks() {
+    local label="$1"
+    local input="$2"
+    local forbidden="$3"
+    local output
+    output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
+    if echo "$output" | grep -qF "$forbidden"; then
+        echo "FAIL: $label — output still contains '$forbidden'"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
 assert_file_output_contains() {
     local label="$1"
     local file="$2"
@@ -527,6 +542,68 @@ assert_file_output_contains "channel-receive deadlock names the other thread ins
     "never shared with it"
 rm -rf "$THREADDIR"
 
+# --- Retired bare TypeError returns (kaappi#1868) ---
+# These conditions used to return an anonymous PrimitiveError.TypeError. Note
+# what that did and did NOT cost: vm_calls.mapNativeError already synthesized
+# "type error in '<primitive>': got <args[0]>" for any primitive that set no
+# detail, so the procedure name was never the missing piece. What was missing is
+# the *expected* type — and for the hash-table cases args[0] is the table, so
+# the fallback actively blamed the wrong argument ("got #<hash-table size=0>"
+# for a bad key). Assert the message; asserting only "an error was raised", or
+# only that the procedure is named, passes against the pre-fix build too.
+echo
+echo "-- Retired bare TypeErrors (kaappi#1868) --"
+
+# A string-keyed table rejecting a non-string key. This pair is deliberately
+# both halves of the same claim: the negative pins the old wrong answer (the
+# table) and the positive pins the new right one (the key) -- a "lacks" check
+# alone would also pass if the call stopped erroring altogether.
+assert_output_lacks "string-keyed table blames the key, not the table itself" \
+    '(import (scheme base) (srfi 69)) (hash-table-set! (make-hash-table string=?) 1 2)' \
+    'got #<hash-table'
+
+assert_output_contains "string-keyed table names the compare mode, not just 'string'" \
+    '(import (scheme base) (srfi 69)) (hash-table-set! (make-hash-table string=?) 1 2)' \
+    'expected string key (this table compares with string=?), got 1'
+
+# Each entry point must name ITSELF, not a shared "hash-table" label: the proc
+# name is threaded through findKey/findSlot/growIfNeeded, so a regression shows
+# up as the wrong procedure in the message rather than as a missing one.
+assert_output_contains "string-keyed hash-table-ref names itself, not hash-table-set!" \
+    '(import (scheme base) (srfi 69)) (hash-table-ref (make-hash-table string=?) 42)' \
+    "type error in 'hash-table-ref': expected string key"
+
+assert_output_contains "a string-ci=? table names string-ci=?, not string=?" \
+    '(import (scheme base) (srfi 69)) (hash-table-delete! (make-hash-table string-ci=?) 42)' \
+    "type error in 'hash-table-delete!': expected string key (this table compares with string-ci=?), got 42"
+
+# R6RS "parent is sealed" and a uid collision are not type errors at all: both
+# arguments are of an acceptable type and the procedure rejects them anyway, so
+# they now report as invalid-argument (KP3007), not KP3002.
+assert_output_contains "sealed parent rtd is KP3007, not a type error" \
+    "(import (scheme base) (srfi 237)) (define l (make-record-type-descriptor 'l #f #f #t #f '#())) (make-record-type-descriptor 'c l #f #f #f '#())" \
+    "error[KP3007]: %make-record-type-descriptor: record type 'l' is sealed and cannot be a parent"
+
+assert_output_contains "non-equivalent uid collision is KP3007 and echoes the uid" \
+    "(import (scheme base) (srfi 237)) (make-record-type-descriptor 'a #f 'dup #f #f '#((mutable x))) (make-record-type-descriptor 'a #f 'dup #f #f '#((mutable y)))" \
+    'error[KP3007]: %make-record-type-descriptor: uid "dup" is already bound to a record type'
+
+# %elision-lever-set! is a KEP-0002 gate-harness hook compiled in only with
+# -Dchannel-instrument=true, so it is absent from ordinary builds (including
+# the one CI runs this suite against). Probe for it rather than assuming.
+if echo '(import (scheme base) (kaappi fibers)) (%elision-lever-set! (quote none))' \
+    | "$KAAPPI" >/dev/null 2>&1; then
+    echo "-- %elision-lever-set! (instrumented build) --"
+    assert_output_contains "a non-symbol lever is a type error naming the primitive" \
+        "(import (scheme base) (kaappi fibers)) (%elision-lever-set! 42)" \
+        "type error in '%elision-lever-set!': expected symbol, got 42"
+    assert_output_contains "an unknown lever symbol is KP3007 and echoes the symbol" \
+        "(import (scheme base) (kaappi fibers)) (%elision-lever-set! 'bogus)" \
+        "error[KP3007]: %elision-lever-set!: expected lever none, c, or cd, got 'bogus'"
+else
+    echo "SKIP: %elision-lever-set! lever diagnostics (needs -Dchannel-instrument=true)"
+fi
+
 # --- No leaked Zig error names on any path (KEP-0005, #1504) ---
 echo
 echo "-- No leaked Zig error names --"
@@ -545,6 +622,10 @@ assert_no_zig_leak "raised non-error value"  '(raise 42)'
 assert_no_zig_leak "ellipsis with no pattern variable (#1791)" \
     '(define-syntax demo (syntax-rules () ((_) (quote (head tok ... tail))))) (demo)'
 assert_no_zig_leak "digit-led identifier (kaappi#1723)" '3-state'
+assert_no_zig_leak "string-keyed table, non-string key (kaappi#1868)" \
+    '(import (scheme base) (srfi 69)) (hash-table-set! (make-hash-table string=?) 1 2)'
+assert_no_zig_leak "sealed parent rtd (kaappi#1868)" \
+    "(import (scheme base) (srfi 237)) (define l (make-record-type-descriptor 'l #f #f #t #f '#())) (make-record-type-descriptor 'c l #f #f #f '#())"
 
 echo
 echo "=== Results ==="


### PR DESCRIPTION
Closes #1868.

The `format` job's bare-`TypeError` ratchet stood at 20. Those 20 were not one
thing, so this works through them in the four groups the issue identified — 9
infrastructure guards gain a `// bare-ok:` reason, 11 become real diagnostics —
and then retires the ratchet itself: with none left there is no baseline to keep
in step with the source, so the CI step becomes a plain grep-and-fail.

| Group | Action | Count |
|---|---|---|
| A | annotate `// bare-ok:` (no behavior change) | 9 |
| B | thread `proc` through the hash-table key path | 6 |
| C | `%elision-lever-set!` | 3 |
| D | srfi237 sealed-parent / uid-collision → `InvalidArgument` | 2 |

Counts reconcile exactly: 102 matching lines before (82 annotated + 20 not) → 91
after, all annotated. 11 genuinely converted, 9 annotated.

## A bare return was never as anonymous as it looked

This is what made the backlog easy to leave alone, and it is worth stating
because the issue's own framing ("no procedure name, no expected type, no
offending value") is wrong on two of three. `vm_calls.mapNativeError` already
fills in `type error in '<primitive>': got <args[0]>` for any primitive that set
no detail. The procedure name survives. What is lost is the *expected* type —
and whenever the offending value is not the first argument, the report
confidently names the wrong one. A string-keyed hash table handed a bad key
blamed the table itself:

```diff
-  type error in 'hash-table-set!': got #<hash-table size=0>
+  type error in 'hash-table-set!': expected string key (this table compares with string=?), got 1
```

Reporting the key instead of the table means the key path has to know which
procedure it is serving, so `proc` is threaded through `equalForTable` /
`hashForTable` / `findKey` / `findSlot` / `rehash` / `growIfNeeded`. This was
the issue's one flagged design question; the alternative — a fixed
`"hash-table"` label — would have been cheaper and nearly worthless, since
every call site already holds the exact literal one line above in its own
`getHashTable` call. Each entry point now names itself:

```
type error in 'hash-table-ref':      expected string key (this table compares with string=?), got 42
type error in 'hash-table-delete!':  expected string key (this table compares with string-ci=?), got 42
```

## Not everything rejected is a type error

Two of the 20 reject an argument whose type is perfectly good. That is what
`invalid-argument` (KP3007) already describes — "a value a procedure explicitly
rejects", per its own registry entry — so they now report that, through a new
`primitives.argError(proc, fmt, args)` sitting alongside `typeError` and
`indexError`:

```
error[KP3007]: %make-record-type-descriptor: record type 'locked' is sealed and cannot be a parent
error[KP3007]: %make-record-type-descriptor: uid "dup" is already bound to a record type with a different parent, sealed/opaque flag, or field set
```

The unknown-elision-lever check joins them, which **deviates from the issue's
suggestion** of `typeError` there. Two reasons: `args[0]` *is* a symbol, so it is
not a type error; and `typeError` routes its value through
`safeValueDescription`, which deliberately never dereferences heap payloads, so
it renders every symbol as a bare `#<symbol>` and could not have named the one
passed. `argError`'s own format string can:

```
error[KP3007]: %elision-lever-set!: expected lever none, c, or cd, got 'bogus'
```

## Tests assert the message, and were mutation-tested

Asserting that an error was raised — or even that it names the procedure —
passes against the pre-fix build too. That is not hypothetical: the first
version of the hash-table assertion did exactly that, because
`mapNativeError`'s fallback already emitted `type error in 'hash-table-set!'`.
It is replaced by a pair that pins both the old wrong answer
(`assert_output_lacks 'got #<hash-table'`) and the new right one.

All 8 new assertions were checked against a binary built from `main` and fail
there; all 8 pass here. `%elision-lever-set!` exists only under
`-Dchannel-instrument=true`, so its two assertions sit behind a runtime probe of
the binary — verified in both states (116 assertions on an ordinary build, 118
on an instrumented one), since a probe that always skips is worthless.

## Incidental finding

While placing a `bare-ok` marker on `threadStartFn`'s WASM branch, its comment
claimed the `else` was what kept `std.Thread.spawn` out of the wasm32 build. It
is not. A `@compileError` canary in `threadStartImpl` fires under **neither**
`if/else` **nor** a plain early return, while one in `threadStartFn` itself does
fire — so the function is analyzed, and the pruning comes from the comptime-true
branch returning unconditionally, not from the branch structure. Comment
corrected; `else` kept (it costs nothing and keeps the diff minimal).

## Verification

- `zig build test` clean; `zig fmt --check` clean; markdownlint clean
- Scheme suite **2016 pass / 0 fail** (621 files + 1395 R7RS)
- `error-format.sh` 116/116 default, 118/118 instrumented; `exit-code.sh` 49/49
- Builds: native, `zig build wasm`, `-Dtarget=x86_64-linux`, `-Dchannel-instrument=true`
- The new CI gate tested in both directions with an injected offender
- `-Dgc-stress` deliberately skipped: nothing here allocates or roots

Docs updated in all four places that described the ratchet — `CLAUDE.md` (plus a
new Enforcement-map row), `docs/dev/adding-features.md`, and the `/add-builtin`
skill.

## Left out

The issue's aside about the `vm_instance orelse` guard returning `TypeError` in
41 places and `OutOfMemory` in 34 — including twice within two lines of each
other in `primitives_hashtable.zig` — is **not** addressed here. Annotating those
guards is zero-behavior-change; re-tagging them is not, and it is tree-wide.
Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
