### PR TITLE
Scope the procedure shorthand's internal define to its enclosing body (#1861)

### DIFF
--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -226,8 +226,27 @@ Rooting these slots cannot interact with `musttail` (kaappi#1499): `mustTailSafe
 already requires `self.locals == null`, which is never true inside a `let` body.
 
 The procedure shorthand `(define (f …) …)` is a different path — `ir.lowerDefine`
-turns it into a `passthrough`, so it never reaches `emitDefine` and still defines
-a global.
+turns it into a `passthrough`, so it never reaches `emitDefine` and none of the
+above applies to it. `emitPassthrough` **declines it whenever a lexical scope is
+active** (kaappi#1861), which is the only place that decision can be made: both
+of its paths define a global (`kaappi_define_global` when the body compiles
+natively, and otherwise an `emitEvalExpr` that runs in the global environment).
+The enclosing scope then goes to the interpreter whole — a `let` body abandons
+via `emitLet`, and a function body fails `emitLambdaFunction`, so the whole
+`define` falls back. Until that fix an internal `(define (g) …)` overwrote a
+same-named global (the interpreter merely shadows it), and one referencing an
+enclosing binding compiled to a global function whose body looked that binding
+up as a global — `(let ((a 3)) (define (h n) (* n a)) (h 5))` died with
+`undefined variable 'a'` in a binary the interpreter runs fine.
+
+Declining also **drops the name from `native_fns`/`rebound_globals` first**.
+This interpreter rebinds a body define that is *not* at the head of its body as
+a global, and a later call site that kept its direct call to the top-level
+function of the same name cannot observe that. Compiling the shorthand as a
+native local binding instead — the fuller fix — would need the closure value in
+a rooted slot (the kaappi#1854 machinery extended to a lambda-valued define)
+plus a way to keep the inner name out of the module-wide `native_fns` map, where
+it would capture direct call sites outside the scope that defined it.
 
 ## Compile-Time Processing
 

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -839,31 +839,70 @@ pub fn emitPassthrough(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError
             return self.emitApplyForm(expr, is_tail);
         }
         if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "define")) {
+            // The `(define (f …) …)` shorthand, split up, or null for any other
+            // define shape (a curried target, a malformed form).
+            const Shorthand = struct { name: []const u8, formals: Value, body: Value };
             const rest = types.cdr(expr);
-            if (rest != types.NIL and types.isPair(rest)) {
+            const shorthand: ?Shorthand = blk: {
+                if (rest == types.NIL or !types.isPair(rest)) break :blk null;
                 const target = types.car(rest);
-                if (types.isPair(target) and types.isSymbol(types.car(target))) {
-                    const fn_name = types.symbolName(types.car(target));
-                    const formals = types.cdr(target);
-                    const body = types.cdr(rest);
-                    _ = self.native_fns.fetchRemove(fn_name);
-                    self.rebound_globals.put(fn_name, {}) catch {};
-                    if (self.tryCompileDefineFunction(fn_name, formals, body) != null) {
-                        _ = self.rebound_globals.fetchRemove(fn_name);
-                        // #1500: bind the global to a native closure over the
-                        // compiled entry instead of eval'ing the whole define
-                        // form. Fixed-arity, and not when the body reaches a
-                        // code eval fallback (its bindParamsAsGlobals aliases
-                        // across activations — see NativeLambda.has_eval_fallback);
-                        // both keep the eval path, and `@f` still serves direct
-                        // call sites.
-                        if (self.native_fns.get(fn_name)) |info| {
-                            if (!info.is_variadic and !info.has_eval_fallback) {
-                                const val = try self.emitNativeFnClosureValue(info, fn_name);
-                                const sym = try self.internSymbol(fn_name);
-                                try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym, fn_name.len, val });
-                                return self.emitVoid();
-                            }
+                if (!types.isPair(target) or !types.isSymbol(types.car(target))) break :blk null;
+                break :blk .{
+                    .name = types.symbolName(types.car(target)),
+                    .formals = types.cdr(target),
+                    .body = types.cdr(rest),
+                };
+            };
+
+            // Whatever this name denoted, it does not any more — drop the
+            // direct-call binding before ANY path below returns. The decline
+            // just below returns without emitting, so doing this after it would
+            // leave a later call site bound to the top-level function of the
+            // same name (or to an inline primitive): the interpreter, running
+            // the abandoned scope, rebinds a body define that is not at the head
+            // of its body as a global, and a stale direct call cannot observe
+            // that (#1861). Costs nothing unless the name collides — the maps
+            // hold only natively compiled and reserved globals.
+            if (shorthand) |sh| {
+                _ = self.native_fns.fetchRemove(sh.name);
+                self.rebound_globals.put(sh.name, {}) catch {};
+            }
+
+            // An internal define inside a lexical scope is an R7RS letrec*
+            // binding of the enclosing body, never a global one — but both
+            // paths below define a global: the native one calls
+            // kaappi_define_global outright, and emitEvalExpr evaluates in the
+            // global environment. `lowerDefine` routes the `(define (f …) …)`
+            // shorthand here rather than to emitDefine, so this is the only
+            // place that can decline it, and #1854's slot machinery (which
+            // emitDefine uses for the symbol form) never sees it (#1861).
+            //
+            // Declining hands the whole enclosing scope to the interpreter,
+            // which scopes it correctly: a let body abandons via emitLet, and a
+            // function body fails emitLambdaFunction so the whole define falls
+            // back to eval. Compiling it as a native local binding instead would
+            // need the closure value in a rooted slot — #1854's machinery
+            // extended to a lambda-valued define — plus a way to keep the inner
+            // name out of the module-wide `native_fns` map, where it would
+            // capture direct call sites outside this scope.
+            if (self.inLexicalScope()) return error.UnsupportedNodeType;
+
+            if (shorthand) |sh| {
+                if (self.tryCompileDefineFunction(sh.name, sh.formals, sh.body) != null) {
+                    _ = self.rebound_globals.fetchRemove(sh.name);
+                    // #1500: bind the global to a native closure over the
+                    // compiled entry instead of eval'ing the whole define
+                    // form. Fixed-arity, and not when the body reaches a
+                    // code eval fallback (its bindParamsAsGlobals aliases
+                    // across activations — see NativeLambda.has_eval_fallback);
+                    // both keep the eval path, and `@f` still serves direct
+                    // call sites.
+                    if (self.native_fns.get(sh.name)) |info| {
+                        if (!info.is_variadic and !info.has_eval_fallback) {
+                            const val = try self.emitNativeFnClosureValue(info, sh.name);
+                            const sym = try self.internSymbol(sh.name);
+                            try self.print("  call void @kaappi_define_global(ptr %vm, ptr {s}, i64 {d}, i64 {s})\n", .{ sym, sh.name.len, val });
+                            return self.emitVoid();
                         }
                     }
                 }

--- a/src/llvm_emit_freevars.zig
+++ b/src/llvm_emit_freevars.zig
@@ -388,9 +388,13 @@ fn nodeHasFreeVars(self: *LLVMEmitter, node: *const ir.Node, params: []const []c
         // S-expression (kaappi#1803); walk them like any other expression
         // tree, or a capture inside one is invisible and the closure tiers
         // emit the name as a global lookup — #1799's exact failure mode.
-        // Every other passthrough shape still declines the enclosing scope
-        // upstream (sexprNeedsEvalFallback), so it never reaches a native
-        // body and reports none.
+        // A `(define (f …) …)` shorthand is the one other passthrough shape that
+        // reaches a native body — `define` is not an eval-fallback keyword — and
+        // it introduces no free reference of its own. It declines the enclosing
+        // scope from emitPassthrough instead, which is where the lexical scope
+        // is known (#1861); reporting it here as well changes nothing, and was
+        // measured to emit byte-identical IR. Every remaining shape declines
+        // upstream via sexprNeedsEvalFallback and never gets here.
         .passthrough => {
             if (isApplyForm(node.data.passthrough))
                 return sexprHasFreeVars(self, node.data.passthrough, params);

--- a/src/llvm_emit_let.zig
+++ b/src/llvm_emit_let.zig
@@ -100,8 +100,10 @@ const Checkpoint = struct {
 
 // The bound name of a `(define <symbol> <expr>)` body form, or null for
 // anything else — including `(define (f …) …)`, which `lowerDefine` turns into a
-// passthrough that defines a global and so never reaches emitDefine's internal
-// path (#1854).
+// passthrough that never reaches emitDefine's internal path (#1854). Returning
+// null for the shorthand is what makes `emitPassthrough` decline it in a lexical
+// scope, abandoning this let to the interpreter (#1861); modelling it here
+// instead would mean holding a closure value in one of these slots.
 fn headDefineName(form: Value) ?[]const u8 {
     if (!types.isPair(form)) return null;
     const head = types.car(form);

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -1560,13 +1560,35 @@ test "LLVM emit: a function body using a macro with no colliding global falls ba
 // -- Shorthand internal define (#1861) --
 
 // The IR of @main only. The direct-call assertions below are about the top-level
-// form sequence, so a fast-entry call inside some *other* function's body must
-// not satisfy (or defeat) them.
+// form sequence, so a call inside some *other* function's body must not satisfy
+// (or defeat) them.
 fn mainBody(ll: []const u8) []const u8 {
     const start = std.mem.indexOf(u8, ll, "define i32 @main") orelse return "";
     const rest = ll[start..];
     const end = std.mem.indexOf(u8, rest, "\n}\n") orelse return rest;
     return rest[0 .. end + 3];
+}
+
+// Does this stretch of IR call one of the module's own native entries directly,
+// rather than resolving the name at run time?
+//
+// Three spellings, and a test that checks only one is arch-specific: the
+// register-argument `tailcc` fast entry exists only where
+// `llvm_emit.fast_tailcalls_supported` (aarch64/x86_64), so on the QEMU-tier
+// arches every direct call is the uniform array ABI instead — where a reserved
+// name is `@r{i}` and an unreserved one `@lambda_{i}`. Matching the fast
+// spelling alone made the control below fail on ppc64le/riscv64/s390x while the
+// assertion it controls passed vacuously.
+//
+// Anchored on the callee position (right after `call [tailcc ]i64 `) so the
+// `ptr @r0` *argument* of a kaappi_create_native_closure — present either way —
+// is not mistaken for a call to it. Runtime imports are all `@kaappi_…`, so no
+// prefix here can match one.
+fn hasDirectNativeCall(ir_text: []const u8) bool {
+    for ([_][]const u8{ "call tailcc i64 @r", "call i64 @r", "call i64 @lambda_" }) |spelling| {
+        if (std.mem.indexOf(u8, ir_text, spelling) != null) return true;
+    }
+    return false;
 }
 
 test "LLVM emit: a shorthand internal define declines the enclosing let (#1861)" {
@@ -1609,11 +1631,11 @@ test "LLVM emit: an internal shorthand define drops the direct-call binding (#18
     // to the top-level function it used to denote.
     var res = try emitMultiResult("(define (g) 1) (let ((a 2)) (display a) (define (g) 3) (g)) (g)");
     defer res.deinit();
-    try expectNotContains(mainBody(res.toSlice()), "call tailcc i64 @");
+    try std.testing.expect(!hasDirectNativeCall(mainBody(res.toSlice())));
 
     // Positive control: without the internal define the same trailing call IS a
-    // direct fast-entry call, so the assertion above is not vacuous.
+    // direct call, so the assertion above is not vacuous.
     var ctl = try emitMultiResult("(define (g) 1) (let ((a 2)) (display a)) (g)");
     defer ctl.deinit();
-    try expectContains(mainBody(ctl.toSlice()), "call tailcc i64 @");
+    try std.testing.expect(hasDirectNativeCall(mainBody(ctl.toSlice())));
 }

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -1556,3 +1556,64 @@ test "LLVM emit: a function body using a macro with no colliding global falls ba
     const ll = res.toSlice();
     try expectNoNativeDef(ll, "f");
 }
+
+// -- Shorthand internal define (#1861) --
+
+// The IR of @main only. The direct-call assertions below are about the top-level
+// form sequence, so a fast-entry call inside some *other* function's body must
+// not satisfy (or defeat) them.
+fn mainBody(ll: []const u8) []const u8 {
+    const start = std.mem.indexOf(u8, ll, "define i32 @main") orelse return "";
+    const rest = ll[start..];
+    const end = std.mem.indexOf(u8, rest, "\n}\n") orelse return rest;
+    return rest[0 .. end + 3];
+}
+
+test "LLVM emit: a shorthand internal define declines the enclosing let (#1861)" {
+    // `lowerDefine` turns a pair target into a passthrough, so this never
+    // reaches emitDefine's #1854 internal path — emitPassthrough used to define
+    // a global for it, overwriting the top-level `g` the interpreter merely
+    // shadows. Declining sends the whole let to the interpreter.
+    var res = try emitMultiResult("(define (g) 1) (let ((a 2)) (define (g) 3) (g))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    // The top-level define still compiles; only the internal one declines.
+    try expectNativeDef(ll, "g");
+    try std.testing.expectEqual(@as(usize, 1), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: a shorthand internal define declines the enclosing function body (#1861)" {
+    // The same define in a lambda body, where `self.locals` is null and only
+    // the params make the frame lexical — a guard keyed on locals alone would
+    // let this one through.
+    var res = try emitMultiResult("(define (g) 1) (define (outer x) (define (g) 2) (g))");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNoNativeDef(ll, "outer");
+}
+
+test "LLVM emit: a top-level shorthand define still compiles natively (#1861 guard)" {
+    // The decline keys on "is a lexical scope active", so an over-broad version
+    // would take ordinary top-level defines with it.
+    var res = try emitMultiResult("(define (f n) (+ n 1)) (f 1)");
+    defer res.deinit();
+    const ll = res.toSlice();
+    try expectNativeDef(ll, "f");
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
+test "LLVM emit: an internal shorthand define drops the direct-call binding (#1861)" {
+    // Declining still has to invalidate the name in native_fns: this
+    // interpreter rebinds a body define that is not at the head of its body as
+    // a global, and the trailing (g) cannot observe that through a direct call
+    // to the top-level function it used to denote.
+    var res = try emitMultiResult("(define (g) 1) (let ((a 2)) (display a) (define (g) 3) (g)) (g)");
+    defer res.deinit();
+    try expectNotContains(mainBody(res.toSlice()), "call tailcc i64 @");
+
+    // Positive control: without the internal define the same trailing call IS a
+    // direct fast-entry call, so the assertion above is not vacuous.
+    var ctl = try emitMultiResult("(define (g) 1) (let ((a 2)) (display a)) (g)");
+    defer ctl.deinit();
+    try expectContains(mainBody(ctl.toSlice()), "call tailcc i64 @");
+}

--- a/tests/scheme/compile/native-shorthand-internal-define-scope-1861.sh
+++ b/tests/scheme/compile/native-shorthand-internal-define-scope-1861.sh
@@ -1,0 +1,370 @@
+#!/bin/bash
+# Regression test for #1861: the native backend compiled the procedure shorthand
+# `(define (f …) …)` in a let or lambda body to a GLOBAL define, so an internal
+# definition overwrote an outer one of the same name — or, when the helper
+# referenced an enclosing binding, killed the binary outright:
+#
+#   (define (g) 'global-g)
+#   (let ((a 1)) (define (g) 'inner-g) (display (g)) (newline))
+#   (display (g))                  ; interpreter: global-g, binary: inner-g
+#
+#   (let ((a 3)) (define (h n) (* n a)) (display (h 5)))
+#                                  ; interpreter: 15, binary: undefined variable 'a'
+#
+# #819 fixed this class for the symbol form `(define f <expr>)` and #1854 gave it
+# a rooted slot, both in `emitDefine` — but `lowerDefine` turns a pair target into
+# a `.passthrough` node, so the shorthand never reaches that path. It landed in
+# `emitPassthrough`'s define branch, which called kaappi_define_global when the
+# body compiled natively and otherwise fell through to an eval that runs in the
+# global environment. Neither looked at the enclosing lexical scope.
+#
+# The fix declines the form whenever a lexical scope is active, so the enclosing
+# scope goes to the interpreter whole — a let body abandons via emitLet (#1586's
+# transactional rollback, widened to the enclosing scope by #1862), and a function
+# body fails emitLambdaFunction so the whole define falls back. That is #827's
+# rule: never split one lexical scope across the native/interpreted boundary.
+#
+# Declining also has to drop the name's entry in `native_fns`/`rebound_globals`
+# BEFORE returning. Kaappi's interpreter rebinds a body define that is not at the
+# head of its body as a global, and a call site that kept its direct call to the
+# top-level function of the same name cannot observe that — a first cut of this
+# fix returned before the invalidation and regressed exactly the three
+# `non-head` cases below, which had agreed with the interpreter until then.
+#
+# Twelve of the fourteen cases below were verified to diverge against a pre-fix
+# binary: nine against the unfixed backend, and the three `non-head` ones against
+# the first cut. The other two are coverage guards that agreed all along —
+# `toplevel-define-stays-native` against an over-broad decline, and the root
+# balance check against a shadow stack the widened abandon leaves unbalanced.
+#
+# Usage: bash tests/scheme/compile/native-shorthand-internal-define-scope-1861.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# `kaappi compile` needs the native runtime archive. The helper freshens it with
+# zig when a toolchain is present and otherwise accepts a prebuilt one, so a box
+# running cross-compiled binaries still exercises the compile+link path — and it
+# knows the archive's per-platform name, which this script must not spell itself.
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+# Compile natively, run, and require the output to match the interpreter's —
+# which never had the bug, so it is the oracle. `routing` then asserts HOW the
+# form was compiled, so a case cannot pass vacuously by falling back for some
+# unrelated reason:
+#
+#   whole-scope:<binder>  the eval'd form is the enclosing let/let*, i.e. that
+#                         whole lexical scope went to the interpreter as one
+#                         unit rather than the define alone.
+#   whole-define:<name>   the eval'd form is the enclosing `(define (<name> …)`,
+#                         i.e. the function body declined native compilation.
+#   native                no eval fallback in @main at all: the form still
+#                         compiles natively. The guard must decline internal
+#                         defines, never top-level ones.
+#
+# ERE throughout, deliberately: `\?` and `\|` are GNU BRE extensions OpenBSD's
+# grep rejects, where they match nothing and every routing check passes
+# vacuously while the output comparisons stay clean (kaappi#1862). In ERE the
+# parens of the Scheme source are what need escaping instead.
+check() {
+    local name="$1" src="$2" routing="$3"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    local want
+    if ! want=$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$DIR/$name.scm" 2>&1); then
+        echo "FAIL: $name — interpreter run failed: $want" >&2
+        fail=1
+        return
+    fi
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    local out status
+    set +e
+    out=$("$DIR/$name" 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 ]]; then
+        echo "FAIL: $name — binary aborted (exit $status): $out" >&2
+        fail=1
+        return
+    fi
+    if [[ "$out" != "$want" ]]; then
+        echo "FAIL: $name — native '$out' != interpreter '$want'" >&2
+        fail=1
+        return
+    fi
+
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1); then
+        echo "FAIL: $name — --emit-llvm failed, so native routing went unchecked" >&2
+        fail=1
+        return
+    fi
+
+    case "$routing" in
+        whole-scope:*)
+            # The eval'd source strings are interned as private constants; one of
+            # them must open with the enclosing binder, proving the decline
+            # reached that scope. What gets interned is the form re-printed from
+            # the datum, so a source `'x` reads back as `(quote x)` and no case
+            # here yields a constant holding a quote or backslash for internString
+            # to escape. `let\*?` covers let and let* in one branch.
+            local binder="${routing#whole-scope:}"
+            if ! grep -Eq "constant \\[.*c\"\\(let\\*? ?\\(\\(${binder} " "$DIR/$name.ll"; then
+                echo "FAIL: $name — no eval of the enclosing '($binder ...)' scope; the define fell back alone" >&2
+                fail=1
+            fi
+            ;;
+        whole-define:*)
+            local fname="${routing#whole-define:}"
+            if ! grep -Eq "constant \\[.*c\"\\(define \\(${fname}[ )]" "$DIR/$name.ll"; then
+                echo "FAIL: $name — no eval of the enclosing '(define ($fname ...)'; the body stayed native" >&2
+                fail=1
+            fi
+            ;;
+        native)
+            local evals
+            evals=$(sed -n '/^define i32 @main/,/^}/p' "$DIR/$name.ll" | grep -c 'kaappi_eval_cached' || true)
+            if [[ "$evals" -ne 0 ]]; then
+                echo "FAIL: $name — expected a natively compiled define, got $evals eval fallback(s)" >&2
+                fail=1
+            fi
+            ;;
+        *)
+            echo "FAIL: $name — bad routing '$routing'" >&2
+            fail=1
+            ;;
+    esac
+}
+
+# 1. The issue's reproducer: the internal define replaced the global instead of
+#    shadowing it for the body. Pre-fix the binary printed inner-g twice.
+check shadows-global-in-let \
+"(define (g) 'global-g)
+(let ((a 1))
+  (define (g) 'inner-g)
+  (display (g))
+  (newline))
+(display (g))
+(newline)" \
+whole-scope:a
+
+# 2. With no global of that name to overwrite, the definition still escaped the
+#    let: pre-fix the trailing call found it and printed inner-g where the
+#    interpreter reports it unbound.
+check leaks-past-the-let \
+"(let ((a 1))
+  (define (g) 'inner-g)
+  (display (g))
+  (newline))
+(display (guard (e (#t 'unbound)) (g)))
+(newline)" \
+whole-scope:a
+
+# 3. The loud symptom: an internal helper referencing an enclosing binding
+#    compiled to a global function whose body looked `a` up as a global, so the
+#    binary died with "undefined variable 'a'" on code the interpreter runs.
+check helper-closes-over-binding \
+"(let ((a 3))
+  (define (h n) (* n a))
+  (display (h 5))
+  (newline))" \
+whole-scope:a
+
+# 4. Same, through a self-recursive helper: the recursive call resolves to the
+#    same binding, so the failure survives however many frames deep it recurses.
+check recursive-helper-closes-over-binding \
+"(let ((base 10))
+  (define (down k) (if (= k 0) base (down (- k 1))))
+  (display (down 3))
+  (newline))" \
+whole-scope:base
+
+# 5. A variadic shorthand takes a different route through emitPassthrough — the
+#    #1500 closure-value gate declines it, so it reached the trailing eval rather
+#    than kaappi_define_global. Both paths define a global; both must decline.
+check variadic-internal-helper \
+"(define (g . r) 'global-g)
+(let ((a 1))
+  (define (g . r) (cons a r))
+  (display (g 2 3))
+  (newline))
+(display (g))
+(newline)" \
+whole-scope:a
+
+# 6. let* reaches the same body loop from its own binding path, which roots each
+#    alloca as it goes rather than all at the end.
+check letstar-shadows-global \
+"(define (g) 'global-g)
+(let* ((a 1) (b 2))
+  (define (g) 'inner-g)
+  (display (list a b (g)))
+  (newline))
+(display (g))
+(newline)" \
+whole-scope:a
+
+# 7. Nested lets: the inner let's decline has to propagate out through the outer
+#    one (#1862), or the fallback eval loses `a`. Pre-fix this died with
+#    "undefined variable 'a'".
+check nested-let-shorthand-define \
+"(define (g) 'global-g)
+(let ((a 1))
+  (let ((b 2))
+    (define (g) (list a b))
+    (display (g))
+    (newline)))
+(display (g))
+(newline)" \
+whole-scope:a
+
+# 8. The silent one, and the reason output equality is the oracle here: a
+#    shorthand define alongside a symbol-form define of a name that also exists
+#    globally. The symbol form bound `z` locally (#819/#1854) while the shorthand
+#    compiled to a global function whose body read the GLOBAL z — so the binary
+#    printed (1 100) against the interpreter's (1 1), no crash, no diagnostic.
+check mixed-symbol-and-shorthand \
+"(define z 100)
+(let ((a 1))
+  (define z a)
+  (define (g) z)
+  (display (list z (g)))
+  (newline))
+(display z)
+(newline)" \
+whole-scope:a
+
+# 9. A lambda body, not a let: `self.locals` is null there, so a guard keyed on
+#    it alone would miss this — the frame is lexical because of its params. The
+#    whole define declines instead.
+check shadows-global-in-lambda \
+"(define (g) 'global-g)
+(define (outer x)
+  (define (g) 'inner-g)
+  (list x (g)))
+(display (outer 1))
+(newline)
+(display (g))
+(newline)" \
+whole-define:outer
+
+# 10-12. Non-head defines, which R7RS does not allow in a body and which this
+#    interpreter rebinds as globals. The decline must therefore still invalidate
+#    the name's direct-call binding: these three agreed with the interpreter
+#    before the fix, and a first cut that returned before invalidating regressed
+#    all three — the trailing (g) kept its direct call to the top-level function
+#    and printed global-g where the interpreter prints inner-g.
+check non-head-define-after-expression \
+"(define (g) 'global-g)
+(let ((a 1))
+  (display a)
+  (newline)
+  (define (g) 'inner-g)
+  (display (g))
+  (newline))
+(display (g))
+(newline)" \
+whole-scope:a
+
+check non-head-define-in-if-branch \
+"(define (g) 'global-g)
+(let ((a 1))
+  (if (> a 0) (define (g) 'inner-g) #f)
+  (display (g))
+  (newline))
+(display (g))
+(newline)" \
+whole-scope:a
+
+check non-head-define-spliced-by-begin \
+"(define (g) 'global-g)
+(let ((a 1))
+  (begin (define (g) 'inner-g))
+  (display (g))
+  (newline))
+(display (g))
+(newline)" \
+whole-scope:a
+
+# 13. Coverage guard for the opposite mistake. The guard keys on "is a lexical
+#     scope active", so an over-broad version would decline ordinary top-level
+#     defines too and quietly send the whole program to the interpreter. This
+#     one must still compile natively, with no eval fallback at all.
+check toplevel-define-stays-native \
+"(define (fib n) (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+(display (fib 20))
+(newline)" \
+native
+
+# 14. Shadow-stack balance across the widened abandon, asserted on the emitted IR
+#     rather than on output. A let that abandons from its body loop rolls back
+#     every push it had already emitted (#1586); leaving one without its pop (or
+#     vice versa) desynchronises the shadow stack rather than printing a wrong
+#     answer — an over-pop underflows GC.root_count, an under-pop strands a slot.
+#     The abandoning let contributes no pushes of its own once rolled back, so
+#     the leading sibling let is what keeps the count from being vacuously zero.
+#     In a straight-line @main every push and pop is textually reached exactly
+#     once, so summing them over the function is exact.
+check_root_balance() {
+    local name="$1" src="$2"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+    if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1); then
+        echo "FAIL: $name — --emit-llvm failed" >&2
+        fail=1
+        return
+    fi
+
+    local main_ir pushes pops
+    main_ir=$(sed -n '/^define i32 @main/,/^}/p' "$DIR/$name.ll")
+    pushes=$(printf '%s\n' "$main_ir" | grep -c 'call void @kaappi_gc_push_root' || true)
+    pops=$(printf '%s\n' "$main_ir" |
+        sed -n 's/.*call void @kaappi_gc_pop_roots(i64 \([0-9]*\)).*/\1/p' |
+        awk '{n += $1} END {print n + 0}')
+
+    if [[ "$pushes" -eq 0 ]]; then
+        echo "FAIL: $name — no root pushes in @main (test would be vacuous)" >&2
+        fail=1
+        return
+    fi
+    if [[ "$pushes" -ne "$pops" ]]; then
+        echo "FAIL: $name — @main pushes $pushes roots but pops $pops" >&2
+        fail=1
+    fi
+}
+
+check_root_balance shorthand-define-abandon-root-balance \
+"(let ((sibling (list 1 2)))
+  (display sibling)
+  (newline))
+(let ((outer (list 3 4)))
+  (define xs (list 5 6))
+  (define (h) (list outer xs))
+  (display (h))
+  (newline))"
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-shorthand-internal-define-scope-1861: all cases passed"

--- a/tests/scheme/compile/set-define-lexical-scope-819.sh
+++ b/tests/scheme/compile/set-define-lexical-scope-819.sh
@@ -99,6 +99,22 @@ check internal-define-local \
 '1
 100' 0
 
+# 5b. The procedure shorthand of case 5, which stayed broken for another six
+#     years of issue numbers (#1861): `ir.lowerDefine` turns a pair target into a
+#     passthrough, so it never reached the internal-define path case 5 exercises
+#     and defined a global instead. Reaching for the let-local in its body makes
+#     the pre-fix failure loud — the global function it compiled to looked `x` up
+#     as a global and the binary died with "undefined variable 'x'".
+#     tests/scheme/compile/native-shorthand-internal-define-scope-1861.sh covers
+#     the shape in depth; this is the direct pairing with case 5.
+check internal-define-shorthand-local \
+'(define (z) 100)
+(let ((x 1)) (define (z) x) (display (z)) (newline))
+(display (z))
+(newline)' \
+'1
+100' 0
+
 # 6. set! on a nested let-local inside a natively compiled function body.
 check set-nested-let \
 '(define (f x)


### PR DESCRIPTION
Fixes #1861.

## The bug

`(define (f …) …)` inside a natively compiled `let` or lambda body compiled to a
**global** define. Two symptoms:

| | interpreter | pre-fix binary |
|---|---|---|
| `(define (g) 'global-g)`<br>`(let ((a 1)) (define (g) 'inner-g) (g))`<br>`(g)` | `global-g` | `inner-g` |
| `(let ((a 3)) (define (h n) (* n a)) (h 5))` | `15` | `undefined variable 'a'` |

The second is the loud one the issue didn't mention: an internal helper
referencing an enclosing binding compiled to a global function whose body looked
that binding up as a global, so the binary died on code the interpreter runs.

#819 fixed this class for the symbol form `(define f <expr>)` and #1854 gave it a
rooted slot, both in `emitDefine`. `ir.lowerDefine` turns a pair target into a
`.passthrough`, so the shorthand never reaches that path — it landed in
`emitPassthrough`, whose two paths both define a global: `kaappi_define_global`
when the body compiles natively, and otherwise an `emitEvalExpr` that runs in the
global environment.

## The fix

Decline the form whenever a lexical scope is active, so the enclosing scope goes
to the interpreter whole (#827's rule: never split one lexical scope across the
native/interpreted boundary). A `let` body abandons via `emitLet` (#1586's
transactional rollback, widened by #1862, which is already merged); a function
body fails `emitLambdaFunction` so the whole `define` falls back.

Two things that differ from the issue's suggested fix, both found empirically:

1. **The gate is `inLexicalScope()`, not `locals != null`.** `self.locals` is
   populated only while `emitLet` emits a body, so the suggested guard misses a
   **lambda body**, which is lexical because of its params and had the identical
   bug. (This is deliberately *not* the same gate as `bindParamsAsGlobals`'s
   `locals != null` from #1862 — there, params/rest/upvalues genuinely are
   publishable.)

2. **Declining must invalidate `native_fns`/`rebound_globals` first.** This
   interpreter rebinds a body define that is *not* at the head of its body as a
   global, and a later call site that kept its direct `call tailcc @rN.fast` to
   the top-level function of the same name cannot observe that. A first cut
   returned before that bookkeeping and regressed three shapes that had been
   correct (define after an expression, inside an `if`, spliced by `begin`).

Compiling it as a native local binding is the fuller fix the issue describes, but
it needs the closure value in a rooted slot — #1854's machinery extended to a
lambda-valued define — plus a way to keep the inner name out of the module-wide
`native_fns` map, where it would capture direct call sites outside its own scope.

## Tests

- `tests/scheme/compile/native-shorthand-internal-define-scope-1861.sh` — 14
  cases diffing the native binary against the interpreter and asserting *how*
  each form was routed, so none can pass vacuously. Twelve were verified to
  diverge against a pre-fix binary (nine against the unfixed backend, three
  against the first cut); the other two are coverage guards — a top-level define
  that must stay native, and a shadow-stack balance check.
- Case 5b in `set-define-lexical-scope-819.sh` — the direct pairing with that
  file's symbol-form case 5, as the issue asked for.
- Four emit-level tests in `src/tests_native.zig`, so the decline is covered by
  `zig build test` on platforms where the compile suite is skipped. All three
  substantive ones fail without the guard; the fourth is the over-broad-decline
  guard.

`zig build test`, `zig build test -Dgc-stress=true` (filtered), and
`bash tests/scheme/run-all.sh` (2017 pass, 0 fail) are green.

## Note

`nodeHasFreeVars`'s `.passthrough` arm carried a comment claiming every non-apply
passthrough declines upstream via `sexprNeedsEvalFallback` — untrue for `define`,
which is not an eval-fallback keyword. An early decline there mirroring the
`.define => return true` arm was drafted and then dropped: it emits **byte-
identical IR** and no test can catch its removal. The comment is corrected to
state the real rule instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)