### PR TITLE
End a timed wait whose deadline the dispatch tick already popped (#1870)

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -1364,8 +1364,19 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
 
     while (!ctx.isDone() and !me.timed_out) {
         const next_idx = sched.scheduleForDispatch() orelse {
-            // Nothing dispatchable. Before blocking in the reactor, a wait
-            // that opted in gives up instead when an ancestor drive's
+            // Nothing dispatchable — but scheduleForDispatch's own per-tick
+            // runReactorTick may have just resolved *this* wait, after the
+            // loop guard above already read the pre-tick state. A popped
+            // timer is the dangerous case (#1870): wakeReadyFiber sets
+            // `me.timed_out` and the entry is gone from the timer heap, so
+            // the park below has nothing left to bound it — with this
+            // fiber's own shared_waiters entry keeping hasRunnableFibers()
+            // true, parkOnReactor blocks in an unbounded reactor.poll()
+            // that only an unrelated cross-thread notify can release. Re-
+            // check here rather than one `continue` later: the loop guard
+            // never gets its turn because the park never returns.
+            if (me.timed_out or ctx.isDone()) break;
+            // A wait that opted in gives up instead when an ancestor drive's
             // condition has already resolved: that ancestor can only
             // proceed once we unwind, and blocking here — for I/O waits,
             // on this fiber's own fd with no bound — would pin it forever

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -4,6 +4,8 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 const vm_mod = @import("vm.zig");
 const fiber_mod = @import("fiber.zig");
+const reactor_mod = @import("reactor.zig");
+const platform = @import("platform.zig");
 
 // Regression tests for the fiber scheduler give-up path (#kaappi-book):
 // runSchedulerUntil used to silently return VOID when no fiber was runnable
@@ -462,4 +464,73 @@ test "spawning a fiber leaks nothing when an allocation fails" {
     // instead of failing.
     try std.testing.expect(failures > 0);
     try std.testing.expect(successes > 0);
+}
+
+// ---------------------------------------------------------------------------
+// A timeout popped by the dispatch tick must not be followed by an unbounded
+// park (#1870)
+// ---------------------------------------------------------------------------
+//
+// runSchedulerStep's loop guard reads `me.timed_out` *before* calling
+// scheduleForDispatch(), whose own runReactorTick() then pops expired timers.
+// When that tick pops this fiber's own deadline, wakeReadyFiber sets
+// `timed_out` and the entry leaves the timer heap — and the pre-tick guard is
+// already spent. Pre-fix the idle branch went straight into parkOnReactor with
+// nothing left to bound reactor.poll(): the fiber's own shared_waiters entry
+// keeps hasRunnableFibers() true, so the "nothing can ever happen" early
+// return is skipped and the poll blocks until an unrelated cross-thread notify
+// arrives. That is the SRFI-120 flake: a 30 ms timer task that never ran until
+// the caller's own timer-cancel! message woke the thread seconds later.
+//
+// The watchdog is a safety net, not the mechanism under test: it rings the
+// notifier so a pre-fix build finishes the wait instead of hanging the suite
+// forever, and the elapsed-time assertion is what actually fails there.
+
+const WaitForever = struct {
+    pub fn isDone(_: WaitForever) bool {
+        return false;
+    }
+};
+
+fn ringAfter(flag: *std.atomic.Value(bool), n: *reactor_mod.ThreadNotifier) void {
+    var waited: u64 = 0;
+    while (!flag.load(.acquire) and waited < 3_000_000_000) : (waited += 5_000_000) {
+        platform.sleepNs(5_000_000);
+    }
+    n.notify();
+}
+
+test "an expired timer popped by the dispatch tick ends the wait instead of parking unbounded" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    const me = ctx.sched.fibers.items[ctx.sched.current_idx].?;
+
+    // The state a timed channel-receive on a promoted channel parks in, with
+    // the deadline already past so scheduleForDispatch()'s tick — not
+    // parkOnReactor's own poll — is what pops it.
+    me.status = .waiting;
+    me.timed_out = false;
+    me.deadline_ns = fiber_mod.clockNs();
+    try ctx.reactor.addTimer(me.deadline_ns.?, me);
+    try ctx.sched.enrollSharedWaiter(me);
+    defer ctx.sched.removeSharedWaiter(me);
+
+    var done = std.atomic.Value(bool).init(false);
+    const watchdog = try std.Thread.spawn(.{}, ringAfter, .{ &done, ctx.reactor.notifier });
+
+    const started = fiber_mod.clockNs();
+    _ = try fiber_mod.runSchedulerStep(WaitForever, .{}, vm, ctx.sched, me);
+    const elapsed = fiber_mod.clockNs() - started;
+
+    done.store(true, .release);
+    watchdog.join();
+
+    // The wait must come back on its own timeout, promptly. Pre-fix it comes
+    // back only when the watchdog rings, ~3 s later.
+    try std.testing.expect(me.timed_out);
+    try std.testing.expect(elapsed < 1_000_000_000);
 }


### PR DESCRIPTION
Fixes #1870.

## The flake is not timeout headroom

The issue's first hypothesis — a loaded runner missing a 30 ms deadline by
more than the 1–2 s `channel-receive` bound — is refuted by the CI logs'
own per-line timestamps. `tests/scheme/srfi/srfi120.scm` runs for 2.834 s on
a healthy `windows-x64-test`. The two red runs:

| run | duration | delta | failing wait's bound |
|---|---|---|---|
| [`ed5255ec` on main](https://github.com/kaappi/kaappi/actions/runs/30531306447/job/90835482950) | 3.792 s | **+0.958 s** | 1.0 s (`:133`) |
| [#1867 branch attempt 1](https://github.com/kaappi/kaappi/actions/runs/30546868857) | 4.819 s | **+1.985 s** | 2.0 s (`:178`) |

Each overshoot is the failing wait's *own bound minus the ~30 ms it should
have taken*, and the neighbouring suite files ran at their normal 0.07–0.10 s
on both sides of the failure. The process was not stalled; the wait ran to
its full deadline and the value never arrived. Widening the bounds would only
have made the run longer. (A wall-clock step was also excluded — the runner's
own timestamps are monotonic across both windows, and a backward step would
have *shortened* the measured window, not lengthened it.)

`:179` failing as well in the second run pins which side broke: had the
handler run and re-raised, `timer-cancel!` would have raised its preserved
condition and `:179` would have passed. It didn't, so the scheduled task
never ran at all.

## What actually happens

`runSchedulerStep` evaluates `!ctx.isDone() and !me.timed_out`, then calls
`scheduleForDispatch()`, whose own per-tick `runReactorTick()` pops expired
timers. When that tick pops *this* fiber's deadline, `wakeReadyFiber` sets
`me.timed_out` and the entry leaves the timer heap — but the loop guard was
already evaluated against the pre-tick state, so the idle branch goes
straight into `parkOnReactor` with nothing left to bound `reactor.poll()`.
The fiber's own `shared_waiters` entry keeps `hasRunnableFibers()` true, so
the "nothing can ever happen" early return is skipped too, and the poll
blocks until an unrelated cross-thread notify arrives. The loop guard never
gets its turn, because the park never returns.

For SRFI 120 that means the timer thread, parked on its control channel
waiting out a 30 ms task, sleeps indefinitely — and only wakes when the
caller's own `timer-cancel!` rings its notifier seconds later, at which point
delivery-wins hands it the `stop` message and the task never runs. That
matches every observed symptom: no tick is ever queued, so `:136`'s "no
further firings" assertion still passes, and `timer-cancel!` has no preserved
condition to raise.

Windows is where it surfaces because `WaitForMultipleObjects` returns
spuriously often enough (an auto-reset notify event left signalled by an
earlier `SetEvent`) to land a loop iteration exactly where it needs to be:
past the guard, with the deadline expiring during the tick.

## The fix

One pre-park re-check of the loop's own two exit conditions, at the single
`parkOnReactor` call site in the tree.

## Evidence

Captured with temporary instrumentation in `parkOnReactor` (reverted; not in
this diff) on the Windows ARM64 reference VM:

```
[#1870] LONG POLL 6003ms cap=null timers_before=0 timers_now=0 shared_waiters=1
        ctx=primitives_fiber.SharedChannelWait fibers=[0:st=2,dl=1,to=1,drv=1;]
MISS iter=2006 recv-at=1015ms drain=none task-still-pending=#t
```

`st=2` is `.suspended`, `to=1` is `timed_out` — the deadline had already
fired — with an empty timer heap and a 6-second unbounded poll. A probe
asking the timer `timer-task-exists?` after the miss confirms the task was
still queued, never run.

A `(srfi 120)` timer per iteration, Windows ARM64:

| | before | after |
|---|---|---|
| wedges | 4 / 13,500 | **0 / 9,000** |
| `srfi120.scm` end to end | — | 0 failures / 60 |

macOS never reproduced it in 7,000 iterations.

## Testing

- New unit test in `src/tests_fibers.zig` builds the state directly (a fiber
  `.waiting` with an already-past deadline plus a `shared_waiters` entry) and
  asserts the wait returns on its own timeout promptly. Mutation-tested:
  reverting the one-line guard makes it fail. A watchdog thread rings the
  notifier after 3 s so a pre-fix build fails on elapsed time rather than
  hanging the suite.
- `zig build test` — green; `-Dgc-stress=true -Dtest-filter=tests_fibers` — green.
- `bash tests/scheme/run-all.sh` — 621 Scheme files pass, R7RS 1395 pass, 0 fail.

## Not changed

`doWake`'s `cancelPendingTimer` similarly drops a reactor timer while leaving
`deadline_ns` set; `mutex-lock!` already re-arms explicitly for that reason
(`primitives_srfi18.zig:1130-1141`). No channel path reaches that state, and
it is not what this bug was, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)