### PR TITLE
Settle the vm_instance/gc_instance guard tag, and write the rule down (#1874)

### DIFF
--- a/.claude/rules/gc-safety.md
+++ b/.claude/rules/gc-safety.md
@@ -135,6 +135,19 @@ gc.popRoot();
   `src/tests_gc_root_boundary.zig` find leaks only in the expander — but a
   new one would be a real hazard, so keep primitive error paths balanced.
 
+- **Tag a `gc_instance`/`vm_instance` guard by what the function was going to
+  return anyway** (#1874). A guard in an allocating function returns
+  `OutOfMemory` — no GC means the allocation cannot happen, so that *is* its
+  error. A guard in an error-message helper returns that helper's own tag
+  (`typeError` → `TypeError`, `indexError` → `IndexOutOfBounds`,
+  `argError` → `InvalidArgument`): losing the VM costs the detail, not the
+  diagnosis. Everything else — most `vm_instance` guards — returns
+  `PrimitiveError.InvalidBytecode` (→ KP9001 "internal error", i.e. "report
+  this"), never `OutOfMemory` (not an allocation failure) and never a bare
+  `TypeError`, which `mapNativeError` dresses up as `type error in '<proc>':
+  got <args[0]>` and so blames a real argument. Full rationale in
+  `docs/dev/gc-safety-and-error-handling.md`.
+
 - **To test an OOM deep in the pipeline, use `gc.oom_countdown`**, not
   `FailingAllocator` (documented deep-pipeline limitation) and not
   `gc.memory_limit` (an absolute watermark that only trips once a form

--- a/.claude/skills/add-builtin/SKILL.md
+++ b/.claude/skills/add-builtin/SKILL.md
@@ -91,9 +91,16 @@ object's fields needs a write barrier.
 ## Calling back into Scheme
 
 ```zig
-const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
 return vm.callWithArgs(proc, call_args);
 ```
+
+`InvalidBytecode` (→ KP9001 "internal error") is the settled tag for a
+threadlocal guard whose function has no natural error of its own — a null
+`vm_instance` is an implementation-invariant violation, not an allocation
+failure. The `gc_instance` guard above keeps `OutOfMemory` because for an
+allocating function that *is* its natural error. See
+`docs/dev/gc-safety-and-error-handling.md`.
 
 Let the callee's error propagate — `PrimitiveError` and `VMError` are both
 aliases of `errors.KaappiError`, so a raise inside the Scheme procedure returns
@@ -105,8 +112,8 @@ Use `primitives.typeError(proc, expected, got)` for type checks — it produces
 `type error in 'my-proc': expected exact integer, got #t`. The `format` CI job
 rejects **any** bare `return PrimitiveError.TypeError` that lacks a
 `// bare-ok: <reason>` comment, so adding one fails the build; the annotation is
-only for infrastructure guards with no procedure context to report (a
-`vm_instance orelse` with no VM, say).
+only for infrastructure guards with no procedure context to report *and* whose
+function returns `TypeError` anyway (`typeError` itself, `bootstrapStub`).
 
 A bare return is not silent — `vm_calls.mapNativeError` fills in
 `type error in '<primitive>': got <args[0]>` — so it looks deliberate while

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
             echo "a bare return reaches the user as vm_calls.mapNativeError's fallback,"
             echo "which names the primitive but reports args[0] as the offending value."
             echo "Only add '// bare-ok: <reason>' for infrastructure guards that have no"
-            echo "procedure context to report (e.g. a 'vm_instance orelse' with no VM)."
+            echo "procedure context to report, and only when TypeError is the tag the"
+            echo "function returns anyway -- a 'vm_instance orelse' whose function has no"
+            echo "natural tag is InvalidBytecode (kaappi#1874), not an annotated TypeError."
             exit 1
           fi
           echo "No unannotated bare TypeErrors."

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -39,9 +39,13 @@ name, the expected type, and a description of what actually arrived to the
 error detail, so the user sees `type error in 'my-proc': expected exact
 integer, got #t`. The `format` CI job rejects any unannotated bare return
 (`.github/workflows/ci.yml`), so adding one fails the build. Only
-infrastructure guards that have no procedure context to report -- the
-`vm_instance orelse` fallbacks, for example -- take a bare return, and those
-carry a `// bare-ok: <reason>` comment to opt out.
+infrastructure guards that have no procedure context to report take a bare
+return, and those carry a `// bare-ok: <reason>` comment to opt out -- and
+only when `TypeError` is the tag the function returns anyway (`typeError`
+itself, for instance). A `vm_instance`/`gc_instance` guard in a function with
+no natural tag is `InvalidBytecode`, not an annotated `TypeError`; see
+"Tagging the `vm_instance` / `gc_instance` guards" in
+`gc-safety-and-error-handling.md`.
 
 A bare return is not silent, which is what made the backlog kaappi#1868 cleared
 easy to underestimate: `vm_calls.mapNativeError` synthesizes `type error in
@@ -158,10 +162,18 @@ primitives file already uses for that module:
 
 ```zig
 fn myHigherOrder(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return vm.callWithArgs(args[0], args[1..]);
 }
 ```
+
+`InvalidBytecode` is the settled tag for a threadlocal guard whose function
+has no natural error of its own: a null `vm_instance` is an
+implementation-invariant violation, and that is the one `KaappiError` variant
+that means so (it reports as KP9001 "internal error", which tells the user to
+file a bug rather than to shrink their heap). The `gc_instance` guard above
+keeps `OutOfMemory` because for an allocating function that *is* its natural
+error. Both rules are spelled out in `gc-safety-and-error-handling.md`.
 
 `callWithArgs(proc, args)` is the entry point that takes a Value slice.
 (`vm_calls.callValue` is a different, register-based call used by the dispatch

--- a/docs/dev/diagnostics.md
+++ b/docs/dev/diagnostics.md
@@ -59,7 +59,7 @@ The leading digit tells an agent which pipeline stage a diagnostic came from:
 | `KP2xxx` | Expand / compile | `expander.zig`, `compiler*.zig`, `ir.zig` |
 | `KP3xxx` | Runtime | `vm*.zig`, `primitives*.zig` |
 | `KP4xxx` | Static analysis / lint | `kaappi check` — see [check.md](check.md) ([#1511](https://github.com/kaappi/kaappi/issues/1511)) |
-| `KP9xxx` | Internal / resource | internal-compiler-error and out-of-memory paths |
+| `KP9xxx` | Internal / resource | internal-error and out-of-memory paths |
 
 Ranges are deliberately sparse (1000 codes per stage). Granularity target: **one
 code per user-distinguishable condition** — finer than the internal `KaappiError`

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -261,6 +261,77 @@ Primitives return `PrimitiveError!Value`. The VM translates these to
    - Debug info (source line tracking, line tables)
    - Error-path recovery where the primary error takes precedence
 
+### Tagging the `vm_instance` / `gc_instance` guards (#1874)
+
+Roughly 450 sites open with one of:
+
+```zig
+const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode;
+```
+
+Both threadlocals are set during VM init (`vm_mod.setVMInstance` runs before
+`registerAll`), so neither guard fires in a working build. That makes the tag
+a *readability* decision, not a behavioral one — and left undecided it drifted
+into a 46/34 `TypeError`/`OutOfMemory` split with nothing explaining either
+side. Two rules settle it.
+
+**Rule 1 — a guard returns the tag the function was going to return anyway,
+just without the formatted detail.** These helpers fetch the VM only to
+*attach a message* to an error they were already committed to raising, so
+losing the VM costs the message, not the diagnosis:
+
+| Helper | Tag |
+|---|---|
+| `primitives.typeError` | `TypeError` |
+| `primitives.indexError` | `IndexOutOfBounds` |
+| `primitives.argError`, `primitives_string_ext`'s cursor guard | `InvalidArgument` |
+| `primitives_arithmetic.raiseDivByZero` | `DivisionByZero` |
+| the `overApplied`-style arity helpers (SRFI 181/254/258/260) | `ArityMismatch` |
+| `primitives_fiber.reraiseFiberError` | `ExceptionRaised` |
+| `primitives_io`'s `waitPortFd` / `raisePortClosedDuringIo` | `InvalidArgument` |
+| `primitives.bootstrapStub` (its own tag is `TypeError`) | `TypeError` |
+
+A `gc_instance` guard in an allocating function is the same rule at scale: no
+GC means the allocation the function exists to perform cannot happen, so
+`OutOfMemory` *is* what it was going to return. That is 348 of the 354
+`gc_instance` sites and stays as it is.
+
+**Rule 2 — with no natural tag, use `InvalidBytecode`.** A null threadlocal is
+an implementation-invariant violation, and `InvalidBytecode` is the only
+`KaappiError` variant that means that. `diagnostics.runtimeErrorCode` maps it
+to `.internal_error` (KP9001), whose registry template — the message the user
+actually sees, since these guards set no detail — is "internal error" plus
+"please report it with the program that triggered it". That is the correct
+instruction for a condition no program can cause.
+
+The two rejected alternatives are worth naming, because both are what the
+drifted sites had:
+
+- `OutOfMemory` prints "out of memory" and sends the reader after heap size
+  for something that is not an allocation failure.
+- `TypeError` is worse still: `vm_calls.mapNativeError` fills in a detail when
+  none was set, so a bare `TypeError` surfaces as `type error in '<proc>': got
+  <args[0]>` — a message that names a real argument as the culprit and reads
+  as deliberate. That synthesized-detail trap is the whole reason the CI
+  `format` job rejects an unannotated bare `return PrimitiveError.TypeError`
+  (kaappi#1868/#1871); `// bare-ok: <reason>` is for Rule 1 sites only.
+
+Guards in functions that do not return an error union (`orelse return 0`,
+`null`, `false`, or a bare `return`) have no tag to settle and are outside
+both rules.
+
+One seam the two rules leave visible, so it does not read as fresh drift: the
+`raise*` helpers that build a condition object and end in `return
+PrimitiveError.ExceptionRaised` split across both. `reraiseFiberError` and
+`raisePortClosedDuringIo` already carried a tag of their own and keep it under
+Rule 1; `raiseFiberError`, `raiseWrappedPortClosed` and
+`raiseEntropyUnavailable` carried `OutOfMemory`, which is not what they return,
+so Rule 2 moved them to `InvalidBytecode`. Reading Rule 1 strictly would send
+all five the same way — but `ExceptionRaised` is the one tag a guard cannot
+honestly borrow, since it promises `vm.current_exception` was set and the guard
+fired precisely because there is no VM to set it on.
+
 ### Sandbox enforcement
 
 Sandbox restrictions operate at two levels:

--- a/src/diagnostics.zig
+++ b/src/diagnostics.zig
@@ -533,11 +533,15 @@ pub const table = [_]Diagnostic{
     .{
         .code = .internal_error,
         .name = "internal-error",
-        .template = "internal compiler error",
+        // Not "internal compiler error": KP9xxx is stage `.internal`, and this
+        // code is reachable from the runtime too (an uninitialized VM or GC —
+        // kaappi#1874), not only from the compiler.
+        .template = "internal error",
         .explanation =
         \\Kaappi hit a condition that should not be reachable — a corrupt bytecode
-        \\stream or an internal limit. This indicates a bug in Kaappi itself;
-        \\please report it with the program that triggered it.
+        \\stream, an internal limit, or a runtime whose VM/GC was never
+        \\initialized. This indicates a bug in Kaappi itself; please report it
+        \\with the program that triggered it.
         ,
         // No user-reachable trigger by design — correct input never produces
         // this; it signals a bug in Kaappi.

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -430,7 +430,7 @@ fn mapProcCallError(err: anyerror) ExpandError {
 /// their renamings"): symbols rename, pairs/vectors rebuild with renamed
 /// leaves, everything else passes through.
 fn erRenameFn(args: []const Value) anyerror!Value {
-    const gc = memory.gc_instance orelse return error.TypeError;
+    const gc = memory.gc_instance orelse return error.InvalidBytecode; // no GC: internal invariant
     return erRenameDatum(gc, args[0]);
 }
 

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -214,7 +214,7 @@ fn getInputPort(args: []const Value, arg_idx: usize, proc_name: []const u8) Prim
         if (!port.is_open) return primitives.typeError(proc_name, "open port", args[arg_idx]);
         return port;
     }
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const port_val = if (vm.current_input_port_param != types.VOID)
         vm.getParameterValue(types.toParameter(vm.current_input_port_param))
     else
@@ -231,7 +231,7 @@ fn getOutputPort(args: []const Value, arg_idx: usize, proc_name: []const u8) Pri
         if (!port.is_open) return primitives.typeError(proc_name, "open port", args[arg_idx]);
         return port;
     }
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const port_val = if (vm.current_output_port_param != types.VOID)
         vm.getParameterValue(types.toParameter(vm.current_output_port_param))
     else

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -47,14 +47,18 @@ pub const specs = [_]primitives.PrimSpec{
 // ---------------------------------------------------------------------------
 
 pub fn raiseFn(args: []const Value) PrimitiveError!Value {
+    // No VM means there is no handler stack to raise into: print what we can
+    // and give up. Every exit from this block reports the same condition, so
+    // they all carry the internal-invariant tag — including the print failure,
+    // which changes what we could say, not what went wrong.
     const vm = vm_mod.vm_instance orelse {
-        const gc = memory.gc_instance orelse return PrimitiveError.TypeError; // bare-ok: no GC
+        const gc = memory.gc_instance orelse return PrimitiveError.InvalidBytecode;
         primitives_io.writeStderr("Error: unhandled exception: ");
-        const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.TypeError; // bare-ok: print failed
+        const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.InvalidBytecode;
         defer gc.allocator.free(s);
         primitives_io.writeStderr(s);
         primitives_io.writeStderr("\n");
-        return PrimitiveError.TypeError; // bare-ok: no VM for raise
+        return PrimitiveError.InvalidBytecode;
     };
     // SRFI 248: a sticky (unwind) handler catches raise the same way it
     // catches raise-continuable — invoked in place so the handler can capture
@@ -101,14 +105,15 @@ fn dispatchStickyUnwind(vm: *vm_mod.VM, obj: Value, continuable: bool) Primitive
 }
 
 fn raiseContinuableFn(args: []const Value) PrimitiveError!Value {
+    // Same no-VM fallback as raiseFn — see the note there.
     const vm = vm_mod.vm_instance orelse {
-        const gc = memory.gc_instance orelse return PrimitiveError.TypeError; // bare-ok: no GC
+        const gc = memory.gc_instance orelse return PrimitiveError.InvalidBytecode;
         primitives_io.writeStderr("Error: unhandled exception: ");
-        const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.TypeError; // bare-ok: print failed
+        const s = printer.valueToString(gc.allocator, args[0], .write) catch return PrimitiveError.InvalidBytecode;
         defer gc.allocator.free(s);
         primitives_io.writeStderr(s);
         primitives_io.writeStderr("\n");
-        return PrimitiveError.TypeError; // bare-ok: no VM for raise
+        return PrimitiveError.InvalidBytecode;
     };
     return raiseContinuable(vm, args[0]);
 }
@@ -163,7 +168,7 @@ fn nativeErrorToErrorObject(vm: *vm_mod.VM, gc: *memory.GC, err: anyerror) Primi
 }
 
 fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const handler = args[0];
     const thunk = args[1];
 
@@ -232,7 +237,7 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
 /// we catch it here, turn it into a coded error object, and hand it to the
 /// handler with an empty delimited continuation (the stack has already unwound).
 fn callWithUnwindHandlerFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const handler = args[0];
     const thunk = args[1];
 
@@ -281,7 +286,7 @@ fn callWithUnwindHandlerFn(args: []const Value) PrimitiveError!Value {
 /// is empty (the raise was in tail context of the guarded thunk). Backs
 /// empty-continuation?.
 fn unwindRaiseEmptyFn(_: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return if (vm.pending_raise_empty) types.TRUE else types.FALSE;
 }
 
@@ -293,7 +298,7 @@ fn unwindRaiseEmptyFn(_: []const Value) PrimitiveError!Value {
 /// re-enter the same sticky handler and loop. No-op if the top handler is not
 /// sticky, so it can never disturb an ordinary handler.
 fn popUnwindHandlerFn(_: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     if (vm.handler_count > 0 and vm.handler_stack[vm.handler_count - 1].sticky) {
         vm.handler_count -= 1;
     }
@@ -383,7 +388,7 @@ fn errorFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn callWithCurrentContinuation(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const proc = args[0];
     if (!types.isProcedure(proc)) return primitives.typeError("call/cc", "procedure", args[0]);
 
@@ -419,7 +424,7 @@ fn callWithCurrentContinuation(args: []const Value) PrimitiveError!Value {
 /// is O(1): no register/frame snapshot is taken. Invoking the continuation
 /// outside its extent raises an error.
 fn callWithEscapeContinuation(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const proc = args[0];
     if (!types.isProcedure(proc)) return primitives.typeError("call/ec", "procedure", args[0]);
 
@@ -456,7 +461,7 @@ fn valuesFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const producer = args[0];
     const consumer = args[1];
 
@@ -490,7 +495,7 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn pushWindFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     if (!types.isProcedure(args[0])) return primitives.typeError("%push-wind", "procedure", args[0]);
     if (!types.isProcedure(args[1])) return primitives.typeError("%push-wind", "procedure", args[1]);
     if (vm.wind_count >= vm_mod.MAX_WINDS) return PrimitiveError.OutOfMemory;
@@ -500,7 +505,7 @@ fn pushWindFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn popWindFn(_: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     if (vm.wind_count == 0) return PrimitiveError.TypeError; // bare-ok: underflow
     vm.wind_count -= 1;
     return types.VOID;

--- a/src/primitives_ffi.zig
+++ b/src/primitives_ffi.zig
@@ -174,7 +174,7 @@ fn ffiOpen(args: []const Value) PrimitiveError!Value {
         }
     }
 
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     if (diag.realErr()) |err| {
         // A candidate exists on disk but refused to load — report its
         // error, prefixed with the path when the platform's dlerror text
@@ -238,7 +238,7 @@ fn ffiFn(args: []const Value) PrimitiveError!Value {
     const cname: [*:0]const u8 = @ptrCast(name_buf[0..name_str.len :0]);
 
     const symbol = platform.dlSym(handle, cname) orelse {
-        const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+        const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
         if (platform.dlError()) |err_msg| {
             const msg = std.mem.span(err_msg);
             vm.setErrorDetail("ffi-fn: {s}", .{msg});
@@ -255,7 +255,7 @@ fn ffiFn(args: []const Value) PrimitiveError!Value {
     while (param_list != types.NIL) {
         if (!types.isPair(param_list)) return primitives.typeError("ffi-fn", "proper list of types", args[2]);
         if (param_count >= 16) {
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
             vm.setErrorDetail("ffi-fn: too many parameters (max 16)", .{});
             return PrimitiveError.TypeError; // bare-ok: detail set above
         }
@@ -312,13 +312,13 @@ fn ffiCallbackFn(args: []const Value) PrimitiveError!Value {
     const ret_type = parseType(args[2]) orelse return primitives.typeError("ffi-callback", "valid FFI type symbol", args[2]);
 
     const sig = matchCallbackSig(param_types[0..param_count], ret_type) orelse {
-        const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+        const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
         vm.setErrorDetail("ffi-callback: unsupported callback signature", .{});
         return PrimitiveError.TypeError; // bare-ok: detail set above
     };
 
     const slot = ffi_callback.allocSlot(proc, sig) orelse {
-        const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+        const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
         vm.setErrorDetail("ffi-callback: no free callback slots (max 32)", .{});
         return PrimitiveError.OutOfMemory;
     };

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -37,7 +37,7 @@ fn spawnFn(args: []const Value) PrimitiveError!Value {
     if (!types.isProcedure(proc))
         return primitives.typeError("spawn", "procedure", proc);
 
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const ctx = try fiber_mod.ensureScheduler(vm);
 
     const fiber = ctx.sched.spawnFiber(proc) catch return PrimitiveError.OutOfMemory;
@@ -45,7 +45,7 @@ fn spawnFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn yieldFn(_: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const sched = vm.scheduler orelse return types.VOID;
     // Yield is advisory: it may only arm the Yielded unwind when the signal
     // can reach a scheduler dispatch loop. Under a re-entrant native frame
@@ -78,7 +78,7 @@ fn fiberJoinFn(args: []const Value) PrimitiveError!Value {
     // args[0] after that point would be a use-after-free.
     const target_val = args[0];
 
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const ctx = try fiber_mod.ensureScheduler(vm);
     const my_idx = ctx.sched.current_idx;
     const me = ctx.sched.fibers.items[my_idx].?;
@@ -298,7 +298,7 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
         try enqueueChannel(gc, ch, ch_val, payload);
         return types.VOID;
     };
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     // §6 (amended, #1602): capacity 0 is a rendezvous channel — the bound is
     // the committed receiver demand, so a send is admitted exactly when a
     // receiver is parked waiting (and completes the handoff through the
@@ -496,7 +496,7 @@ fn sharedWakeupPossible(sc: *shared_channel.SharedChannel) bool {
 /// `me.deadline_ns == null`), never re-armed on a later loop iteration or
 /// redispatch of the same call.
 fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: Value, deadline_ns: ?u64, has_timeout_val: bool, timeout_val: Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const ctx = try fiber_mod.ensureScheduler(vm);
     const my_idx = ctx.sched.current_idx;
     const me = ctx.sched.fibers.items[my_idx].?;
@@ -729,7 +729,7 @@ fn channelSendShared(sc: *shared_channel.SharedChannel, payload: Value, ch_val: 
 /// fiber's redispatch cannot simply re-parse `deadline_ns` from Scheme
 /// arguments.
 fn channelReceiveShared(sc: *shared_channel.SharedChannel, gc: *memory.GC, ch_val: Value, deadline_ns: ?u64, has_timeout_val: bool, timeout_val: Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const ctx = try fiber_mod.ensureScheduler(vm);
     const my_idx = ctx.sched.current_idx;
     const me = ctx.sched.fibers.items[my_idx].?;
@@ -1046,7 +1046,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         }
     }
 
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
 
     if (ch.shared) |raw| {
         const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
@@ -1297,7 +1297,7 @@ fn blockOrDeadlock(vm: *vm_mod.VM, me: *fiber_mod.Fiber, my_idx: usize, wait_on:
 /// function name never reaches the user, only `msg` does.
 fn raiseFiberError(msg: []const u8) PrimitiveError {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
     var msg_root = message;
     gc.pushRoot(&msg_root);

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -215,7 +215,7 @@ pub const specs = [_]primitives.PrimSpec{
 };
 
 fn raiseFileError(gc: *GC, msg_text: []const u8, irritant: Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     var msg = gc.allocString(msg_text) catch return PrimitiveError.OutOfMemory;
     gc.pushRoot(&msg);
     defer gc.popRoot();

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -178,7 +178,7 @@ fn equalForTable(proc: []const u8, ht: *HashTable, a: Value, b: Value) Primitive
             break :blk char_mod.foldCompareStrings(sa, sb) == .eq;
         },
         .custom => blk: {
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
             const call_args = [2]Value{ a, b };
             const result = vm.callWithArgs(ht.equiv_fn, &call_args) catch |err| {
                 return err;
@@ -235,7 +235,7 @@ fn hashForTable(proc: []const u8, ht: *HashTable, key: Value) PrimitiveError!usi
             break :blk stringCiContentHash(data);
         },
         .custom => blk: {
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
             const call_args = [1]Value{key};
             const result = vm.callWithArgs(ht.hash_fn, &call_args) catch |err| {
                 return err;
@@ -468,7 +468,7 @@ fn growIfNeeded(proc: []const u8, ht: *HashTable) PrimitiveError!void {
 // (make-hash-table) or (make-hash-table equal-proc [hash-proc])
 fn makeHashTableFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const ht_val = gc.allocHashTable(8) catch return PrimitiveError.OutOfMemory;
     const ht = types.toHashTable(ht_val);
     configureHashTable(ht, ht_val, gc, vm, args);
@@ -489,7 +489,7 @@ fn hashTableRefFn(args: []const Value) PrimitiveError!Value {
     // Key not found — call thunk if provided
     if (args.len > 2) {
         if (types.isProcedure(args[2])) {
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
             return vm.callWithArgs(args[2], &[_]Value{}) catch |err| {
                 return err;
             };
@@ -573,7 +573,7 @@ fn hashTableValuesFn(args: []const Value) PrimitiveError!Value {
 
 // (hash-table-walk ht proc) — call (proc key value) for each entry
 fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-walk", args[0]);
     const proc = args[1];
@@ -623,7 +623,7 @@ fn hashTableToAlistFn(args: []const Value) PrimitiveError!Value {
 // (alist->hash-table alist) or (alist->hash-table alist equal-proc [hash-proc])
 fn alistToHashTableFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     var current = args[0];
 
     // Count entries first
@@ -677,7 +677,7 @@ fn hashTableCopyFn(args: []const Value) PrimitiveError!Value {
 
 // (hash-table-update! ht key function [thunk])
 fn hashTableUpdateFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const ht = try getHashTable("hash-table-update!", args[0]);
     const key = args[1];
     const proc = args[2];
@@ -714,7 +714,7 @@ fn hashTableUpdateFn(args: []const Value) PrimitiveError!Value {
 
 // (hash-table-update!/default ht key proc default)
 fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const ht = try getHashTable("hash-table-update!/default", args[0]);
     const key = args[1];
     const proc = args[2];
@@ -830,7 +830,7 @@ fn hashTableRefDefaultFn(args: []const Value) PrimitiveError!Value {
 
 // (hash-table-fold ht f init) — fold over hash table entries
 fn hashTableFoldFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const ht = try getHashTable("hash-table-fold", args[0]);
     const proc = args[1];
@@ -889,13 +889,13 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
 fn hashTableEquivFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-equivalence-function", args[0]);
     if (ht.equiv_fn != 0) return ht.equiv_fn;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return lookupGlobal(vm, "equal?");
 }
 
 fn hashTableHashFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-hash-function", args[0]);
     if (ht.hash_fn != 0) return ht.hash_fn;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return lookupGlobal(vm, "hash");
 }

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -86,7 +86,7 @@ fn getOutputPort(args: []const Value, arg_idx: usize, proc: []const u8) Primitiv
         if (!port.is_open) return primitives.typeError(proc, "open output port", args[arg_idx]);
         return port;
     }
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const port_val = currentOutputPortValue(vm);
     if (!types.isPort(port_val)) return primitives.typeError(proc, "port", port_val);
     return types.toObject(port_val).as(types.Port);
@@ -101,7 +101,7 @@ fn getInputPort(args: []const Value, arg_idx: usize, proc: []const u8) Primitive
         if (!port.is_open) return primitives.typeError(proc, "open input port", args[arg_idx]);
         return port;
     }
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const port_val = currentInputPortValue(vm);
     if (!types.isPort(port_val)) return primitives.typeError(proc, "port", port_val);
     return types.toObject(port_val).as(types.Port);
@@ -499,7 +499,7 @@ fn stringPortWrite(port: *types.Port, bytes: []const u8) void {
 /// codepoint count and converts the returned character count back to a
 /// byte offset to advance by.
 fn writeBytesToCustomPort(port: *types.Port, cb: *types.CustomBacking, bytes: []const u8) PrimitiveError!void {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     // Shouldn't normally happen: an input-only custom port's write_proc is
     // #f, but portWriteBytes is only ever reached via getOutputPort's own
     // is_output check first. Reject explicitly rather than silently
@@ -688,7 +688,7 @@ fn outputPortOpenP(args: []const Value) PrimitiveError!Value {
 }
 
 fn raiseFileError(gc: *@import("memory.zig").GC, msg_text: []const u8, irritant: Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     var msg = gc.allocString(msg_text) catch return PrimitiveError.OutOfMemory;
     gc.pushRoot(&msg);
     defer gc.popRoot();
@@ -985,7 +985,7 @@ fn setPortPositionBang(args: []const Value) PrimitiveError!Value {
 /// object" case is available directly from get-position for code that
 /// calls it itself; it just isn't threaded through port-position.
 fn portPositionFromCustomPort(cb: *types.CustomBacking) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     if (cb.get_position_proc == types.FALSE) {
         vm.setErrorDetail("port-position: port does not support positioning", .{});
         return PrimitiveError.InvalidArgument;
@@ -1002,7 +1002,7 @@ fn portPositionFromCustomPort(cb: *types.CustomBacking) PrimitiveError!Value {
 /// describes bytes at the old position, meaningless once set-position!
 /// jumps elsewhere.
 fn setPortPositionOnCustomPort(port: *types.Port, cb: *types.CustomBacking, pos: i64) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     if (cb.set_position_proc == types.FALSE) {
         vm.setErrorDetail("set-port-position!: port does not support positioning", .{});
         return PrimitiveError.InvalidArgument;
@@ -1171,7 +1171,7 @@ fn raiseCustomPortBadReturn(vm: *vm_mod.VM, proc: []const u8) PrimitiveError {
 
 fn readOneByteFromCustomPort(port: *types.Port, cb: *types.CustomBacking) PrimitiveError!?u8 {
     if (cb.read_proc == types.FALSE) return null; // output-only custom port
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     var buf: Value = if (port.is_binary) blk: {
@@ -1223,7 +1223,7 @@ fn readOneByteFromCustomPort(port: *types.Port, cb: *types.CustomBacking) Primit
 /// wrapped_port) calls bypass that boundary entirely.
 fn raiseWrappedPortClosed() PrimitiveError {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     var msg = gc.allocString("transcoded port: the underlying port has been closed") catch return PrimitiveError.OutOfMemory;
     gc.pushRoot(&msg);
     defer gc.popRoot();
@@ -1249,7 +1249,7 @@ fn raiseWrappedPortClosed() PrimitiveError {
 /// push/pop pair.
 fn handleInvalidUtf8(ts: *types.TranscodeState, msg: []const u8) PrimitiveError!?u21 {
     if (ts.error_mode == .replace) return 0xFFFD;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const srfi18 = @import("primitives_srfi18.zig");
     var condition = try srfi18.makeErrorWithType(.io_decoding, msg, types.NIL);
@@ -1818,7 +1818,7 @@ fn readStringFn(args: []const Value) PrimitiveError!Value {
 fn flushOutputPort(args: []const Value) PrimitiveError!Value {
     const port = try getOutputPort(args, 0, "flush-output-port");
     if (port.custom_backend) |cb| {
-        const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+        const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
         try flushCustomPortIfNeeded(vm, cb);
         return types.VOID;
     }
@@ -1864,7 +1864,7 @@ fn deleteFile(args: []const Value) PrimitiveError!Value {
 
 /// (call-with-input-file string proc)
 fn callWithInputFile(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     // Open file
     const port_val = try openInputFile(&[_]Value{args[0]});
     // Call proc with port
@@ -1880,7 +1880,7 @@ fn callWithInputFile(args: []const Value) PrimitiveError!Value {
 
 /// (call-with-output-file string proc)
 fn callWithOutputFile(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const port_val = try openOutputFile(&[_]Value{args[0]});
     const result = vm.callWithArgs(args[1], &[_]Value{port_val}) catch |err| {
         _ = closePort(&[_]Value{port_val}) catch {};
@@ -1893,7 +1893,7 @@ fn callWithOutputFile(args: []const Value) PrimitiveError!Value {
 /// (call-with-port port proc)
 fn callWithPort(args: []const Value) PrimitiveError!Value {
     if (!types.isPort(args[0])) return primitives.typeError("call-with-port", "port", args[0]);
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const result = vm.callWithArgs(args[1], &[_]Value{args[0]}) catch |err| {
         _ = closePort(&[_]Value{args[0]}) catch {};
         return err;
@@ -1904,7 +1904,7 @@ fn callWithPort(args: []const Value) PrimitiveError!Value {
 
 /// (with-input-from-file string thunk)
 fn withInputFromFile(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const port_val = try openInputFile(&[_]Value{args[0]});
     const saved = currentInputPortValue(vm);
     setCurrentPort(vm, vm.current_input_port_param, port_val);
@@ -1920,7 +1920,7 @@ fn withInputFromFile(args: []const Value) PrimitiveError!Value {
 
 /// (with-output-to-file string thunk)
 fn withOutputToFile(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const port_val = try openOutputFile(&[_]Value{args[0]});
     const saved = currentOutputPortValue(vm);
     setCurrentPort(vm, vm.current_output_port_param, port_val);

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -150,7 +150,7 @@ fn memberFn(args: []const Value) PrimitiveError!Value {
     while (current != types.NIL) {
         if (!types.isPair(current)) return primitives.typeError("member", "proper list", current);
         if (has_compare) {
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
             const call_args = [2]Value{ args[0], types.car(current) };
             const result = vm.callWithArgs(compare, &call_args) catch |err| {
                 return err;
@@ -259,7 +259,7 @@ fn assocFn(args: []const Value) PrimitiveError!Value {
         const pair = types.car(current);
         if (!types.isPair(pair)) return primitives.typeError("assoc", "pair", pair);
         if (has_compare) {
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
             const call_args = [2]Value{ args[0], types.car(pair) };
             const result = vm.callWithArgs(compare, &call_args) catch |err| {
                 return err;

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -90,7 +90,7 @@ fn jiffiesPerSecond(args: []const Value) PrimitiveError!Value {
 fn commandLine(args: []const Value) PrimitiveError!Value {
     _ = args;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
 
     var result: Value = types.NIL;
     gc.pushRoot(&result);
@@ -205,7 +205,7 @@ fn getEnvVars(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn evalFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const expr = args[0];
 
@@ -255,7 +255,7 @@ fn evalFn(args: []const Value) PrimitiveError!Value {
 fn environmentFn(args: []const Value) PrimitiveError!Value {
     // (environment import-set ...) — R7RS 6.12
     // Create a new environment containing bindings from the given import sets.
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;
@@ -279,7 +279,7 @@ fn environmentFn(args: []const Value) PrimitiveError!Value {
 
 fn loadFn(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("load", "string", args[0]);
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
@@ -395,7 +395,7 @@ fn makeParameterFn(args: []const Value) PrimitiveError!Value {
     gc.pushRoot(&val);
     defer gc.popRoot();
     if (converter != types.NIL) {
-        const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+        const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
         val = vm.callWithArgs(converter, &[_]Value{init}) catch |err| {
             return err;
         };
@@ -419,7 +419,7 @@ fn parameterConvertFn(args: []const Value) PrimitiveError!Value {
     if (!types.isParameter(args[0])) return primitives.typeError("%parameter-convert", "parameter", args[0]);
     const param = types.toObject(args[0]).as(types.ParameterObject);
     if (param.converter == types.NIL) return args[1];
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return vm.callWithArgs(param.converter, &[_]Value{args[1]}) catch |err| return err;
 }
 
@@ -429,7 +429,7 @@ fn parameterConvertFn(args: []const Value) PrimitiveError!Value {
 
 fn interactionEnvironmentFn(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocEnvironment(vm.globals, false, false) catch return PrimitiveError.OutOfMemory;
 }
@@ -449,7 +449,7 @@ fn schemeReportEnvironmentFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("scheme-report-environment", "integer", args[0]);
     const version = types.toFixnum(args[0]);
     if (version != 5 and version != 7) return primitives.typeError("scheme-report-environment", "5 or 7", args[0]);
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     const env_map = gc.allocator.create(std.StringHashMap(Value)) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_random.zig
+++ b/src/primitives_random.zig
@@ -91,7 +91,7 @@ fn getRS(proc: []const u8, v: Value) PrimitiveError!*types.RandomSource {
 
 fn randomIntegerFn(args: []const Value) PrimitiveError!Value {
     ensureDefaultRS();
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const rs = try getRS("random-integer", vm.default_random_source);
     return randomBelow("random-integer", rs, args[0]);
 }
@@ -99,7 +99,7 @@ fn randomIntegerFn(args: []const Value) PrimitiveError!Value {
 fn randomRealFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     ensureDefaultRS();
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const rs = try getRS("random-real", vm.default_random_source);
     return types.makeFlonum(openUnitReal(rs));
 }
@@ -107,7 +107,7 @@ fn randomRealFn(args: []const Value) PrimitiveError!Value {
 fn defaultRandomSourceFn(args: []const Value) PrimitiveError!Value {
     _ = args;
     ensureDefaultRS();
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return vm.default_random_source;
 }
 

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -87,7 +87,7 @@ pub const specs = [_]primitives.PrimSpec{
 // ---------------------------------------------------------------------------
 
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return vm.callWithArgs(proc, call_args) catch |err| {
         return err;
     };

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -168,7 +168,7 @@ var child_registry: ChildRegistry = .{
 /// the scheduler (KEP-0001 Phase 2) — the actual setup logic lives in one
 /// place instead of being duplicated per call site.
 fn ensureScheduler() @TypeOf(fiber_mod.ensureScheduler(undefined)) {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return fiber_mod.ensureScheduler(vm);
 }
 
@@ -266,7 +266,7 @@ pub fn makeErrorWithType(error_type: types.ErrorObject.ErrorType, msg: []const u
 /// typed-error-object construction.
 pub fn raiseError(error_type: types.ErrorObject.ErrorType, msg: []const u8, reason: Value) PrimitiveError!Value {
     const err_val = try makeErrorWithType(error_type, msg, reason);
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     vm.current_exception = err_val;
     return PrimitiveError.ExceptionRaised;
 }
@@ -385,7 +385,7 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("thread-start!", "new thread", args[0]);
 
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
 
     // KEP-0002 Phase 2: copy the thunk into an envelope on THIS (the owning)
     // thread, before ever spawning the child. This closes the old
@@ -552,7 +552,7 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
 }
 
 fn threadYieldFn(_: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const sched = vm.scheduler orelse {
         std.Thread.yield() catch {};
         return types.VOID;

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -175,7 +175,7 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
     // resolves to the same RTD object for a given uid, so pointer equality
     // already captures parent equivalence.
     if (uid) |u| {
-        const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+        const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
         if (vm.record_uid_registry.get(u)) |existing| {
             const existing_rt = asRecordType(existing);
             if (existing_rt.parent == parent and
@@ -206,7 +206,7 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
     };
 
     if (uid) |u| {
-        const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+        const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
         // Root across put(): a Value reachable only from this local isn't
         // yet visible to markVMRoots' registry scan until the insert lands.
         gc.pushRoot(&new_val);
@@ -383,7 +383,7 @@ fn recordTypeTotalFieldCountFn(args: []const Value) PrimitiveError!Value {
 
 fn recordUidToRtdFn(args: []const Value) PrimitiveError!Value {
     const uid = try expectString("%record-uid->rtd", args[0]);
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     if (vm.record_uid_registry.get(uid)) |rt_val| return rt_val;
     return types.FALSE;
 }

--- a/src/primitives_srfi260.zig
+++ b/src/primitives_srfi260.zig
@@ -94,7 +94,7 @@ fn generateSymbol(args: []const Value) PrimitiveError!Value {
 /// The OS CSPRNG failed, so an unpredictable name cannot be produced. Raise a
 /// catchable general error rather than hand back a predictable symbol.
 fn raiseEntropyUnavailable(gc: *memory.GC) PrimitiveError {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     var msg = gc.allocString("generate-symbol: OS entropy source unavailable") catch return PrimitiveError.OutOfMemory;
     gc.pushRoot(&msg);
     defer gc.popRoot();

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -101,7 +101,7 @@ fn callPredOrCharset(pred: Value, cp: u21) PrimitiveError!bool {
         return types.toChar(pred) == cp;
     }
 
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const char_val = types.makeChar(cp);
 
     // If pred is a procedure, call it directly
@@ -453,7 +453,7 @@ fn stringConcatenateFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return vm.callWithArgs(proc, call_args) catch |err| return err;
 }
 

--- a/src/primitives_sysinfo.zig
+++ b/src/primitives_sysinfo.zig
@@ -36,7 +36,7 @@ pub const specs = [_]primitives.PrimSpec{
 /// `load`ed/imported file).
 fn scriptPath(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const path = vm.script_path orelse return types.FALSE;
     return gc.allocString(path) catch return PrimitiveError.OutOfMemory;
@@ -52,7 +52,7 @@ fn scriptPath(args: []const Value) PrimitiveError!Value {
 /// this library's established #f-for-inapplicable convention.
 fn currentLibDir(args: []const Value) PrimitiveError!Value {
     _ = args;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const dir = vm.current_lib_dir orelse return types.FALSE;
     return gc.allocString(dir) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -327,7 +327,7 @@ fn vectorToStringFn(args: []const Value) PrimitiveError!Value {
 // ---------------------------------------------------------------------------
 
 fn callVM(proc: Value, call_args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     return vm.callWithArgs(proc, call_args) catch |err| {
         return err;
     };

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -16,7 +16,7 @@ var eval_depth_observed: usize = 0;
 // count reflects the depth accumulated by the surrounding recursion.
 fn recordEvalDepth(args: []const Value) primitives.PrimitiveError!Value {
     _ = args;
-    const vm = vm_mod.vm_instance orelse return primitives.PrimitiveError.TypeError;
+    const vm = vm_mod.vm_instance orelse return primitives.PrimitiveError.InvalidBytecode; // no VM: internal invariant
     eval_depth_observed = vm.frame_count;
     return types.VOID;
 }

--- a/src/tests_diagnostics.zig
+++ b/src/tests_diagnostics.zig
@@ -116,6 +116,12 @@ test "runtime errors map to runtime-stage codes" {
     try std.testing.expectEqual(Code.not_a_procedure, diagnostics.runtimeErrorCode(error.NotAProcedure));
     try std.testing.expectEqual(Code.index_out_of_bounds, diagnostics.runtimeErrorCode(error.IndexOutOfBounds));
     try std.testing.expectEqual(Code.uncaught_exception, diagnostics.runtimeErrorCode(error.ExceptionRaised));
+    // The settled tag for a `vm_instance`/`gc_instance` guard whose function has
+    // no natural error of its own (kaappi#1874). ~80 sites report through this
+    // mapping and set no detail, so KP9001's registry template is the entire
+    // message the user sees — losing this arm would silently downgrade all of
+    // them to the `uncategorized` catch-all.
+    try std.testing.expectEqual(Code.internal_error, diagnostics.runtimeErrorCode(error.InvalidBytecode));
     // Control-flow signals are not diagnostics — they must never surface a
     // stage-specific code.
     try std.testing.expectEqual(Code.uncategorized, diagnostics.runtimeErrorCode(error.Yielded));


### PR DESCRIPTION
Closes #1874.

## The decision

For the residue with no natural tag: **`InvalidBytecode`** — the issue's option 2.

It is the only `KaappiError` variant that means "an implementation invariant was violated," which is exactly what a null threadlocal is. `diagnostics.runtimeErrorCode` already maps it to `.internal_error` (KP9001), and since these guards set no detail, that registry template is the *entire* message the user sees:

```
error[KP9001]: internal error
```

with `kaappi explain KP9001` saying "please report it with the program that triggered it" — the correct instruction for a condition no program can cause.

The two alternatives are what the drifted sites actually had, and both mislead:

- **`OutOfMemory`** prints "out of memory" and sends the reader after heap size for something that is not an allocation failure.
- **`TypeError`** is worse: `vm_calls.mapNativeError` fills in a detail when none was set, so a bare return surfaces as `type error in '<proc>': got <args[0]>` — it names a real argument as the culprit and reads as deliberate. That is the #1868 trap.

## What moved (82 sites)

| | |
|---|---:|
| `vm_instance orelse return TypeError` (the `// bare-ok: no VM` family) | 44 |
| `vm_instance orelse return OutOfMemory` | 34 |
| `primitives_control.zig` — the two no-VM fallback blocks in `raiseFn`/`raiseContinuableFn` | 3 + 3 |
| `expander.zig:433` | 1 |
| one test-only observer in `tests_core_eval.zig` | 1 |

Two notes on the one-offs. The `primitives_control` blocks were retagged **whole**, not just the `gc_instance` guard the issue named — every exit from those nine lines reports the same "there is no VM to raise into," and changing one of four would have left the function speaking in two tags. And `expander.zig`'s odd `error.TypeError` spelling becomes `error.InvalidBytecode` rather than `PrimitiveError.TypeError`: `erRenameFn` returns `anyerror!Value` and dispatches through `mapNativeError`'s existing `error.InvalidBytecode` arm, so this fixes the spelling complaint with a tag the file can use honestly.

## What did not move

Every site in the issue's table, all 348 `gc_instance` → `OutOfMemory` (no GC means the allocation the function exists to perform cannot happen — that *is* its error), and the `orelse return 0 / null / false` guards, which have no tag to settle.

Including `primitives.zig:412`/`415` (`bootstrapStub`), whose guard mirrors its function's own `TypeError` and so follows Rule 1. Worth a separate look though: "`vm_bootstrap.install()` has not run" is itself an internal-invariant violation, so the *function's* tag is arguably wrong — a different decision from this one.

## Reporting

`.internal_error`'s template said "internal compiler error". KP9xxx is stage `.internal`, and the code is now reached from the runtime as well, so it is **"internal error"**, with the uninitialized-runtime path named in the explanation. Verified via `kaappi explain KP9001` in text and JSON; `tests/scheme/errors/explain.sh` passes (84/84).

One assertion added to `tests_diagnostics.zig` pinning `runtimeErrorCode(error.InvalidBytecode) → .internal_error`. Roughly 80 sites now report through that arm and set no detail, so losing it would silently downgrade all of them to the `uncategorized` catch-all.

## The rule, written down

A new section in `docs/dev/gc-safety-and-error-handling.md` states both rules, names the rejected alternatives with the reason each is wrong, and flags one seam honestly rather than papering over it: the `raise*` helpers ending in `return PrimitiveError.ExceptionRaised` split across both rules. `ExceptionRaised` is the one tag a guard cannot borrow — it promises `vm.current_exception` was set, and the guard fired precisely because there is no VM to set it on.

Four places taught the now-retired pattern by example and were updated with it: `docs/dev/adding-features.md` (including the copy-paste sample new primitives inherit), the `add-builtin` skill, `.claude/rules/gc-safety.md` (auto-loaded when editing `src/primitives_*.zig`, which is where these guards live), and the CI gate's own help text, which cited "a `vm_instance orelse` with no VM" as the canonical legitimate `bare-ok`.

## Verification

No behavior change is expected or observed — the threadlocals are set during VM init, before `registerAll`, so none of these guards fires in a working build. As the issue asked, no tests were invented for the unreachable paths.

- `zig build` + `zig fmt --check src/` clean
- `zig build test` — all unit tests pass
- `bash tests/scheme/run-all.sh` — **2017 pass, 0 fail** (622 Scheme files, 1395 R7RS)
- CI bare-`TypeError` gate passes; ~42 legitimate `bare-ok` annotations remain, so the gate stays meaningful
- `markdownlint-cli2` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)