### PR TITLE
Report an uninstalled bootstrap as KP9001, not a caller type error

### DIFF
--- a/.claude/skills/add-builtin/SKILL.md
+++ b/.claude/skills/add-builtin/SKILL.md
@@ -113,7 +113,10 @@ Use `primitives.typeError(proc, expected, got)` for type checks — it produces
 rejects **any** bare `return PrimitiveError.TypeError` that lacks a
 `// bare-ok: <reason>` comment, so adding one fails the build; the annotation is
 only for infrastructure guards with no procedure context to report *and* whose
-function returns `TypeError` anyway (`typeError` itself, `bootstrapStub`).
+function returns `TypeError` anyway (`typeError` itself is the canonical one).
+Check that second half before reaching for the annotation: `bootstrapStub`
+carried it until #1876 on the strength of the first half alone, while its
+function was reporting a mis-initialized VM as a caller type error.
 
 A bare return is not silent — `vm_calls.mapNativeError` fills in
 `type error in '<primitive>': got <args[0]>` — so it looks deliberate while

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -290,7 +290,6 @@ losing the VM costs the message, not the diagnosis:
 | the `overApplied`-style arity helpers (SRFI 181/254/258/260) | `ArityMismatch` |
 | `primitives_fiber.reraiseFiberError` | `ExceptionRaised` |
 | `primitives_io`'s `waitPortFd` / `raisePortClosedDuringIo` | `InvalidArgument` |
-| `primitives.bootstrapStub` (its own tag is `TypeError`) | `TypeError` |
 
 A `gc_instance` guard in an allocating function is the same rule at scale: no
 GC means the allocation the function exists to perform cannot happen, so
@@ -316,6 +315,17 @@ drifted sites had:
   as deliberate. That synthesized-detail trap is the whole reason the CI
   `format` job rejects an unannotated bare `return PrimitiveError.TypeError`
   (kaappi#1868/#1871); `// bare-ok: <reason>` is for Rule 1 sites only.
+
+**Rule 1 vets the guard against its function — it does not vet the function.**
+`primitives.bootstrapStub` sat in the Rule 1 table until #1876, with a
+`bare-ok` on each of its two lines. The guard did mirror the function, so the
+rule passed it; what nobody re-read was the function, which was reporting
+"`vm_bootstrap.install()` never ran" — a Rule 2 condition if there ever was
+one — as a caller type error. Both lines are `InvalidBytecode` now, and both
+annotations are gone with them. So when a Rule 1 site keeps surfacing in the
+kaappi#1874 grep, check what the function itself returns before recording the
+site as settled: a correct guard on a wrongly-tagged function looks exactly
+like a site the rule has already cleared.
 
 Guards in functions that do not return an error union (`orelse return 0`,
 `null`, `false`, or a bare `return`) have no tag to settle and are outside

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -405,13 +405,19 @@ pub fn registerSandboxed(vm: *vm_mod.VM) !void {
 /// version became the single implementation (#1375): a stub that errors
 /// makes a missing vm_bootstrap.install() fail loudly instead of silently
 /// falling back to a native implementation that has since diverged.
+///
+/// The tag is `InvalidBytecode` (-> KP9001 "internal error") because that is
+/// what an uninstalled bootstrap is: an implementation-invariant violation no
+/// program can cause or fix. It read `TypeError` (-> KP3002) until #1876,
+/// which told every tool reading the code -- `--diagnostics=json`, the LSP,
+/// `error-object-code` -- that the caller had passed a bad argument type.
 pub fn bootstrapStub(comptime name: []const u8) types.NativeFnType {
     const S = struct {
         fn call(args: []const Value) PrimitiveError!Value {
             _ = args;
-            const vm = vm_mod.vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+            const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode;
             vm.setErrorDetail("'{s}' is implemented in Scheme (src/vm_bootstrap.zig) but vm_bootstrap.install() has not run for this VM", .{name});
-            return PrimitiveError.TypeError; // bare-ok: detail set on the line above
+            return PrimitiveError.InvalidBytecode;
         }
     };
     return &S.call;

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -619,10 +619,22 @@ test "bootstrap stubs fail loudly without vm_bootstrap.install (#1375)" {
     try primitives_mod.registerAll(&vm);
 
     const result = vm.eval("(map (lambda (x) x) (list 1 2 3))");
-    try std.testing.expectError(vm_mod.VMError.TypeError, result);
+    try std.testing.expectError(vm_mod.VMError.InvalidBytecode, result);
     const detail = vm.last_error_detail[0..vm.last_error_detail_len];
     try std.testing.expect(std.mem.indexOf(u8, detail, "vm_bootstrap.install") != null);
     try std.testing.expect(std.mem.indexOf(u8, detail, "'map'") != null);
+
+    // The tag is only half of it (#1876) -- what a tool reads is the code. Run
+    // the error this eval actually returned through the same mapping
+    // `toplevel_driver` reports with: an uninstalled bootstrap must surface as
+    // KP9001 "internal error" ("please report it"), not the KP3002 type error
+    // ("you passed a bad argument") it claimed until #1876. Deriving the code
+    // from `result` rather than from a literal tag is what keeps this coupled
+    // to bootstrapStub -- `runtimeErrorCode`'s own table is pinned separately
+    // in tests_diagnostics.zig.
+    const diagnostics = @import("diagnostics.zig");
+    const err = if (result) |_| unreachable else |e| e;
+    try std.testing.expectEqual(diagnostics.Code.internal_error, diagnostics.runtimeErrorCode(err));
 }
 
 // Regression test: `call_global`/`tail_call_global` populated the per-Function


### PR DESCRIPTION
Closes #1876. Spun out of #1874 (PR #1875), which deliberately left this alone.

## What

`primitives.bootstrapStub` is the registration placeholder for the 9 procedures whose
real bodies are Scheme installed by `vm_bootstrap.install()` (`map`, `for-each`,
`vector-map`, `vector-for-each`, `string-map`, `string-for-each`, `force`,
`dynamic-wind`). It returned `TypeError`, which `diagnostics.runtimeErrorCode` maps to
**KP3002** — telling `--diagnostics=json`, the LSP and `error-object-code` that the
caller passed a bad argument type. The truth is the opposite: Kaappi is mis-initialized,
and nothing the user does to their program will help. Both lines are `InvalidBytecode`
(→ **KP9001** "internal error") now, whose registry text — "please report it with the
program that triggered it" — is the correct instruction.

The two lines were not equally wrong:

- The **second** sets a detail first, so only the code misled; the message was fine.
- The **first**, the no-VM guard, set no detail, so `vm_calls.mapNativeError` synthesized
  `type error in 'map': got <args[0]>` — naming a real list element as the culprit. Wrong
  code *and* wrong message, the exact trap #1868/#1871 closed everywhere else.

Both `bare-ok` annotations go away with the tag (the CI `format` gate only polices
`TypeError`).

## Why #1874 left it, and why this is still right

#1874's rule is *a guard returns the tag its function was going to return anyway*, and
this guard did mirror its function — so the rule passed it, and `primitives.zig:412` still
turned up in #1874's own grep. What was never re-read was the **function's** tag, which is
a different question. This answers it.

Both prose sites that recorded `bootstrapStub` as a settled Rule 1 keeper are updated —
`docs/dev/gc-safety-and-error-handling.md` and `.claude/skills/add-builtin/SKILL.md` —
with the distinction written down, since neither surfaces as a git conflict and a branch
that misses them ships silent doc drift. `.claude/rules/gc-safety.md` and
`docs/dev/adding-features.md` name only `typeError`/`indexError`/`argError` and needed no
change.

## Reachability

Unreachable from every shipped entry point — `main.zig`, `kaappi_lsp.zig`, the bench
harnesses, `testing_helpers.makeTestVM` and `tests_fuzz` all call `install()`, and
`runtime_exports.zig` bails out cleanly if it fails. So this is a tripwire for a *new*
embedding that forgets the call, which is precisely when a code pointing at Kaappi rather
than at the user's arguments is worth the most.

## Testing

`tests_core_eval.zig`'s existing #1375 test is kept and retargeted — it is the one test
pinning the tag, and a good one. It now *also* derives the diagnostic code from the error
the eval actually returned, rather than from a literal tag, so a silent re-tagging fails
it; `runtimeErrorCode`'s own table stays pinned separately in `tests_diagnostics.zig`.

Mutation-tested: reverting just the tag fails the test with
`expected error.InvalidBytecode, found error.TypeError`.

- `zig build test` — green
- `bash tests/scheme/run-all.sh` — **2017 pass, 0 fail** (622 Scheme files + 1395 R7RS)
- `zig fmt --check src/`, the CI bare-`TypeError` gate, and `markdownlint-cli2` — all clean


## Follow-up found while doing this — #1878

Verifying a claim in this PR's own SKILL.md wording turned up four more
`vm_instance orelse return …TypeError; // bare-ok: no VM` guards that survived #1874:
`primitives.zig:979` (`applyFn`) and `vm.zig:53`/`79`/`100` (the SRFI 211/213 hooks, all
returning `anyerror`, so with no natural tag at all).

Deliberately **not** fixed here — retagging them is #1874's kind of decision, not this
one's, and `applyFn` is arguable in a way the others are not, since `apply` does call
`typeError(...)` elsewhere. Tracked as #1878 with the full analysis.

Relevant to reviewing *this* PR: the `format` job's bare-`TypeError` gate has two
independent blind spots, so a green gate here is not evidence those four are fine. It runs
`grep -rn 'return PrimitiveError\.TypeError' src/primitives*.zig` — the path excludes
`vm.zig`, *and* the pattern matches only the `PrimitiveError.` spelling while those sites
write `VMError.TypeError`. Widening it is scoped out of #1878 as well, since matching every
spelling across `src/` also picks up ~35 real type checks in `ffi.zig` and the VM layer.

This is why the SKILL.md hunk here says `typeError` is "the canonical one" rather than the
only one — an earlier draft claimed the latter and was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
