### PR TITLE
Report a missing VM as an internal error in the last four guards

### DIFF
--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -342,6 +342,40 @@ all five the same way — but `ExceptionRaised` is the one tag a guard cannot
 honestly borrow, since it promises `vm.current_exception` was set and the guard
 fired precisely because there is no VM to set it on.
 
+A second seam, settled by #1878, is the one place a guard sits in a function
+that genuinely raises `TypeError` elsewhere. `primitives.applyFn` does — for a
+non-procedure first argument, and for an improper final list — so at a glance
+its `vm_instance` guard reads as Rule 1. It is not: Rule 1 covers a helper that
+fetches the VM only to *attach a message* to an error it was already committed
+to raising, and `apply` fetches the VM in order to *call the procedure*. A null
+threadlocal means `apply` cannot run at all, so it is `InvalidBytecode`, while
+the `gc_instance` line directly under it keeps `OutOfMemory`. Two adjacent
+guards, two different tags, one per rule — that shape is the rules working, not
+drift.
+
+The same fix covered `vm.zig`'s three macro-expansion hooks —
+`evalDatumForMacro`, `callProcForMacro`, `syntaxPropertySet`. Those are the
+easy half (they return `anyerror`, so there was never a tag to borrow), but
+they are worth knowing about for scope: **these rules are not confined to
+`primitives*.zig`.** Nothing mechanical would have found them. The `format`
+job's bare-`TypeError` grep has two independent blind spots, and the `vm.zig`
+sites fell through both at once:
+
+- **Path** — it scans only `src/primitives*.zig`, so `vm.zig` is never read.
+- **Spelling** — it matches only `return PrimitiveError.TypeError`, and those
+  sites write `VMError.TypeError`. Fixing the path alone would still miss them.
+
+There are in fact three spellings of the same error in `src/`, since
+`PrimitiveError` and `VMError` are both aliases of `errors.KaappiError` and
+`ffi.zig` declares inline `error{TypeError}` sets instead of using either. A
+grep covering all three outside `primitives*.zig` returns 35 sites: 27 in
+`ffi.zig` (all the bare `return error.TypeError` spelling), 4 in
+`vm_dispatch.zig`, 2 each in `vm_records.zig` and `vm_calls.zig`. Those are
+real error conditions — an unsupported FFI signature, a sealed parent rtd —
+not threadlocal guards, so widening the gate means triaging them first rather
+than turning it on. Until someone does, read the gate as covering the
+primitives layer it was written for, not the rules as a whole.
+
 ### Sandbox enforcement
 
 Sandbox restrictions operate at two levels:

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -975,8 +975,17 @@ fn symbolToString(args: []const Value) PrimitiveError!Value {
 // Misc
 // ---------------------------------------------------------------------------
 
+/// The `vm_instance` guard is `InvalidBytecode` (-> KP9001 "internal error")
+/// even though `apply` raises real `typeError`s a few lines down, for a
+/// non-procedure and for an improper final list (#1878). Those report what the
+/// caller passed; the guard reports that `apply` cannot run at all, because it
+/// fetches the VM in order to *call* the procedure rather than to attach a
+/// message to an error it was already raising. The `gc_instance` line below is
+/// the other case and keeps `OutOfMemory`: the allocations it protects return
+/// exactly that. See "Tagging the vm_instance / gc_instance guards" in
+/// `docs/dev/gc-safety-and-error-handling.md`.
 fn applyFn(args: []const Value) PrimitiveError!Value {
-    const vm = @import("vm.zig").vm_instance orelse return PrimitiveError.TypeError; // bare-ok: no VM
+    const vm = @import("vm.zig").vm_instance orelse return PrimitiveError.InvalidBytecode;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const proc = args[0];
     if (!types.isProcedure(proc) and !types.isNativeFn(proc)) return typeError("apply", "procedure", proc);

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -853,3 +853,79 @@ test "profile: JSON report includes functions promoted to the old generation" {
     defer std.testing.allocator.free(contents);
     try std.testing.expect(std.mem.indexOf(u8, contents, "profile-oldgen-json-fn") != null);
 }
+
+// ---------------------------------------------------------------------------
+// The `vm_instance orelse` guards report a missing VM as an internal error
+// (kaappi#1874 Rule 2, applied to the four sites #1878 found still on
+// `TypeError`). None of these fire in a working build -- `setVMInstance` runs
+// before `registerAll` -- so they are tripwires for a new embedding or entry
+// point, and the tag is the whole diagnosis such an embedder gets. Nulling the
+// threadlocal is how a test reaches them at all; each guard is the first line
+// of its function, so nothing allocates while it is null.
+// ---------------------------------------------------------------------------
+
+const vm_mod = @import("vm.zig");
+const globals_mod = @import("globals.zig");
+const diagnostics = @import("diagnostics.zig");
+const primitives_mod = @import("primitives.zig");
+
+test "apply's no-VM guard is an internal error, not a caller type error (#1878)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const apply_fn = for (&primitives_mod.all_specs) |spec| {
+        if (std.mem.eql(u8, spec.name, "apply")) break spec.func;
+    } else return error.TestSetupApplySpecMissing;
+
+    // `(apply + '())` -- a call that succeeds with 0 when the VM is there, so
+    // the arguments are not what the failure below is about. `apply` does
+    // raise real type errors (non-procedure, improper final list), which is
+    // exactly why this site read `TypeError` until #1878.
+    const call_args = [_]types.Value{ ctx.vm.globals.get("+").?, types.NIL };
+    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(try apply_fn(&call_args)));
+
+    const saved = vm_mod.vm_instance;
+    vm_mod.vm_instance = null;
+    const result = apply_fn(&call_args);
+    vm_mod.vm_instance = saved;
+
+    try std.testing.expectError(vm_mod.VMError.InvalidBytecode, result);
+
+    // The tag is only half of it: what a tool reads is the code. `apply` is a
+    // primitive, so this error really does reach `--diagnostics=json`, the LSP
+    // and `error-object-code` -- as KP3002 "you passed a bad argument type"
+    // until #1878, now as KP9001 "internal error ... please report it".
+    const err = if (result) |_| unreachable else |e| e;
+    try std.testing.expectEqual(diagnostics.Code.internal_error, diagnostics.runtimeErrorCode(err));
+}
+
+test "the macro-expansion VM hooks report a missing VM as an internal error (#1878)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // Registered by setVMInstance, which th.makeTestVM has already run.
+    const eval_fn = globals_mod.eval_datum_for_macro.?;
+    const call_fn = globals_mod.call_proc_for_macro.?;
+    const set_fn = globals_mod.syntax_property_set.?;
+
+    const saved = vm_mod.vm_instance;
+    vm_mod.vm_instance = null;
+    const eval_res = eval_fn(types.NIL);
+    const call_res = call_fn(types.NIL, &.{});
+    const set_res = set_fn("id", "key", types.NIL);
+    vm_mod.vm_instance = saved;
+
+    // These three return `anyerror`, so unlike `apply` above there is no tag
+    // they were going to return anyway -- squarely Rule 2. No code assertion
+    // to match: their callers in compiler_define_syntax.zig and expander.zig
+    // collapse everything but `OutOfMemory` into `InvalidSyntax` /
+    // `TransformerFailed`, so the tag is read by the next maintainer rather
+    // than by a diagnostic. That is what makes it worth pinning here -- an
+    // unpinned readability-only tag is precisely what drifted in the first
+    // place.
+    try std.testing.expectError(vm_mod.VMError.InvalidBytecode, eval_res);
+    try std.testing.expectError(vm_mod.VMError.InvalidBytecode, call_res);
+    try std.testing.expectError(vm_mod.VMError.InvalidBytecode, set_res);
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -50,7 +50,7 @@ pub fn setVMInstance(vm: *VM) void {
 /// lisp-transformer, or a define-property value expression). Same
 /// compile-and-run discipline as primitives_r7rs.evalFn's plain path.
 fn evalDatumForMacro(expr: Value) anyerror!Value {
-    const vm = vm_instance orelse return VMError.TypeError; // bare-ok: no VM
+    const vm = vm_instance orelse return VMError.InvalidBytecode;
     const gc = vm.gc;
     var expr_root = expr;
     gc.pushRoot(&expr_root);
@@ -76,7 +76,7 @@ fn evalDatumForMacro(expr: Value) anyerror!Value {
 /// (e.g. `(car 7)`) already sets last_error_detail itself and is unaffected
 /// (noteUncaughtException no-ops for anything other than ExceptionRaised).
 fn callProcForMacro(proc: Value, args: []const Value) anyerror!Value {
-    const vm = vm_instance orelse return VMError.TypeError; // bare-ok: no VM
+    const vm = vm_instance orelse return VMError.InvalidBytecode;
     return vm.callWithArgs(proc, args) catch |err| {
         vm.noteUncaughtException(err);
         return err;
@@ -97,7 +97,7 @@ fn errorDetailForMacro() []const u8 {
 /// "<id>\x1f<key>". Overwriting an existing property replaces its value
 /// (the SRFI's post-finalization note on repeated definition).
 fn syntaxPropertySet(id: []const u8, key: []const u8, val: Value) anyerror!void {
-    const vm = vm_instance orelse return VMError.TypeError; // bare-ok: no VM
+    const vm = vm_instance orelse return VMError.InvalidBytecode;
     const gpa = vm.gc.allocator;
     const composite = try std.fmt.allocPrint(gpa, "{s}\x1f{s}", .{ id, key });
     const gop = try vm.syntax_properties.getOrPut(composite);


### PR DESCRIPTION
Closes #1878.

The four `vm_instance orelse return …TypeError; // bare-ok: no VM` guards that
survived kaappi#1874's sweep now return `InvalidBytecode` (→ KP9001 "internal
error"), and the annotations go with the tag.

| Site | Function |
|---|---|
| `src/primitives.zig` | `applyFn` |
| `src/vm.zig` | `evalDatumForMacro` |
| `src/vm.zig` | `callProcForMacro` |
| `src/vm.zig` | `syntaxPropertySet` |

The three `vm.zig` hooks return `anyerror`, so there was never a tag they were
going to return anyway — squarely #1874's Rule 2. Their nearest same-shaped
neighbour, `expander.zig`'s `erRenameFn`, already wrote
`error.InvalidBytecode` for exactly this.

## `applyFn` is the arguable one, and it changes

`apply` raises real `typeError`s — for a non-procedure and for an improper
final list — so its guard reads as Rule 1 at a glance. It isn't. Rule 1 covers
a helper that fetches the VM *only to attach a message* to an error it was
already committed to raising; `apply` fetches it in order to **call the
procedure**, and a null threadlocal means it cannot run at all. The
`gc_instance` line directly under it keeps `OutOfMemory`, so the two adjacent
tags are one per rule rather than drift. A doc comment on the function records
the decision.

`runtime_exports.kaappi_apply` — the native twin whose comment says it must
stay in lockstep — takes `vm` as a parameter and hard-exits on null, so there
is no parallel guard to keep in sync.

## Only `apply`'s tag was user-visible

`apply` is a primitive, so a bare `TypeError` really did reach
`--diagnostics=json`, the LSP and `error-object-code` as KP3002 "you passed a
bad argument type", via `mapNativeError`'s synthesized
`type error in 'apply': got <args[0]>`.

The issue's rationale does **not** carry to the other three: their callers
(`compiler_define_syntax.zig`, `expander.zig`'s `mapProcCallError`) collapse
everything but `OutOfMemory` into `InvalidSyntax`/`TransformerFailed`, so the
tag never reaches a diagnostic. It is maintainer-facing only — which is why it
needed pinning by a test, an unpinned readability-only tag being exactly what
drifted here in the first place. No `runtimeErrorCode` assertion is possible
for those three.

## One correction to the issue's own analysis

There are **three** spellings of this error in `src/`, not two. `ffi.zig`
declares inline `error{TypeError}!T` sets and writes bare
`return error.TypeError`, using neither the `PrimitiveError` nor the `VMError`
alias — and it holds 27 of the 35 out-of-scope sites. A grep widened from the
two-alias description misses all of them, which is the same blind-spot class
the warning exists for. Verified census outside `primitives*.zig`: 27
`ffi.zig`, 4 `vm_dispatch.zig`, 2 each `vm_records.zig` / `vm_calls.zig` — all
real error conditions (an unsupported FFI signature, a sealed parent rtd), not
threadlocal guards.

**The CI gate is deliberately not widened**, per the issue's scoping; the doc
now names both of its blind spots and all three spellings so the next person
sizes the job correctly.

## Tests

Two in `tests_robustness.zig`, reaching the guards by nulling the threadlocal
(each guard is its function's first line, so nothing allocates while it is
null). The `apply` test derives the diagnostic code from the returned error, so
it pins KP9001 rather than just the tag, and uses `(apply + '())` — a call that
returns 0 with the VM present — so nothing about the arguments is what fails.

Both **mutation-verified**: flipping all four tags back to `TypeError` fails
both with `expected error.InvalidBytecode, found error.TypeError`.

## Verification

- `zig build test` — 1441/1444 pass (3 skipped)
- `zig build test -Dgc-stress=true` on the new tests — green
- `bash tests/scheme/run-all.sh` — 2017 pass, 0 fail
- `zig fmt --check src/`, `markdownlint-cli2`, and the `format` job's
  bare-`TypeError` gate — clean

## Base note

#1877 is still open, so its doc paragraph is not in this base. This paragraph
sits at the end of the same section, clear of #1877's insertion point, and
leaves the Rule 1 table row #1877 deletes untouched — the two should merge
cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)