### PR TITLE
Say what R6RS rejected, instead of raising a bare type error (#1880)

### DIFF
--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -368,13 +368,60 @@ sites fell through both at once:
 There are in fact three spellings of the same error in `src/`, since
 `PrimitiveError` and `VMError` are both aliases of `errors.KaappiError` and
 `ffi.zig` declares inline `error{TypeError}` sets instead of using either. A
-grep covering all three outside `primitives*.zig` returns 35 sites: 27 in
-`ffi.zig` (all the bare `return error.TypeError` spelling), 4 in
-`vm_dispatch.zig`, 2 each in `vm_records.zig` and `vm_calls.zig`. Those are
-real error conditions — an unsupported FFI signature, a sealed parent rtd —
-not threadlocal guards, so widening the gate means triaging them first rather
-than turning it on. Until someone does, read the gate as covering the
-primitives layer it was written for, not the rules as a whole.
+grep covering all three outside `primitives*.zig` returned 35 sites, triaged
+by #1880. They were not 35 problems, and the four groups wanted four different
+treatments:
+
+| Group | Sites | What it was | What #1880 did |
+|---|---|---|---|
+| A | 2, `vm_records.zig` | Live defects: a sealed parent rtd and a `nongenerative` uid collision reported `error[KP3002]: type error` and nothing else | Both now report through `primitives_srfi237.zig`'s shared helpers as KP3007 with a message (plus a third condition the census could not see — below) |
+| B | 4, `vm_dispatch.zig` + `vm_calls.zig` | Latent: two of `callFfi`'s four call sites supplied a fallback message and two did not | All four route through one `vm_calls.mapFfiError` |
+| C | 2, `vm_dispatch.zig` | Already correct — `setErrorDetail` on the line above | Annotated `// bare-ok: detail set above` |
+| D | 27, `ffi.zig` | Internal pass/fail signalling behind `validateArgsDetailed`, which supplies every message | Left alone |
+
+Group A is the one worth knowing about beyond its own fix. R6RS's sealed-parent
+and uid-collision rules are enforced twice — syntactically in
+`vm_records.handleDefineRecordTypeR6RS`, procedurally in
+`%make-record-type-descriptor` — and the procedural half had been getting this
+right since #1868 while the syntactic half raised a message-less KP3002 the
+whole time. Both the rule and its wording now live once, in
+`primitives_srfi237.zig` (`RtdShape`, `sealedParentError`,
+`reuseNongenerativeRtd`), so the two routes cannot disagree about what R6RS
+requires or about how to say so. Only the procedure name differs, because a
+caller who wrote `define-record-type` should not be told about the internal
+primitive it desugars to.
+
+Reading those two functions turned up a **third** condition of the same shape
+that no grep in this section can see, and it is the more useful lesson: both
+routes signalled "more than 255 fields once the parent's are counted" as a
+`return switch` arm yielding a bare `TypeError`. Neither the path nor the
+spelling blind spot explains that one — `return switch (err) { .X => VMError
+.TypeError, … }` simply is not `return VMError.TypeError`, so a gate widened
+to all three spellings and all of `src/` would still have walked past it. It
+also showed why "bare" is the wrong mental model for these: out of a primitive,
+`mapNativeError` fills a missing detail in from `args[0]`, so the procedural
+half did not report *nothing* — it reported `type error in
+'%make-record-type-descriptor': got "chi"`, confidently blaming the type's name
+for a limit the field list broke. A message that names the wrong argument is
+harder to spot in review than no message at all, and impossible to find by
+counting grep hits.
+
+Group B leaves one fact worth recording, because the obvious way to check it is
+wrong. `callFfi`'s four sites are *not* reached by direct call / `apply` / `map`
+— all three of those go through `vm_calls.zig`, and the two hot
+`vm_dispatch.zig` sites are the **tail-call** and **tail-apply** opcodes, which
+a non-tail call never reaches. A three-form check built from
+`(f x)` / `(apply f …)` / `(map f …)` tests two sites twice and the other two
+not at all; `tests/scheme/ffi/error-messages.scm` uses tail-position forms for
+exactly this reason.
+
+That leaves 27 sites, all of them Group D and all in `ffi.zig`, so widening the
+gate is now a single question rather than a mixed bag: whether the validator's
+internal pass/fail signal should carry a distinct tag (`error.FfiArgReject`)
+that the grep would never count, or simply be annotated. Retagging them as
+user-facing errors would change nothing a user sees and would break
+`validateArgsDetailed`'s own switch. Until that is settled, read the gate as
+covering the primitives layer it was written for, not the rules as a whole.
 
 ### Sandbox enforcement
 

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -117,12 +117,94 @@ fn isOrDescendsFrom(start: *RecordType, target: *RecordType) bool {
 
 /// Same field names, in the same order, with the same mutability -- used
 /// to check R6RS's nongenerative-uid equivalence requirement.
-pub fn fieldsEquivalent(existing: *RecordType, names: []const []const u8, mutable: []const bool) bool {
+fn fieldsEquivalent(existing: *RecordType, names: []const []const u8, mutable: []const bool) bool {
     if (existing.own_field_names.len != names.len) return false;
     for (existing.own_field_names, existing.own_field_mutable, names, mutable) |en, em, n, m| {
         if (em != m or !std.mem.eql(u8, en, n)) return false;
     }
     return true;
+}
+
+// ---------------------------------------------------------------------------
+// Shared with the syntactic path (vm_records.handleDefineRecordTypeR6RS)
+//
+// R6RS rejects a sealed parent and a mismatched `nongenerative` uid, and both
+// `define-record-type` and `make-record-type-descriptor` have to enforce it.
+// Keeping the rule and its wording here means the two paths cannot drift into
+// disagreeing about what R6RS requires or into reporting it differently --
+// which they did until kaappi#1880: the procedural path said exactly what was
+// wrong while the syntactic one raised a bare, message-less KP3002.
+//
+// Neither condition is a *type* error. Both arguments are of a perfectly good
+// type and the procedure rejects them anyway, which is what KP3007
+// (invalid-argument) is for -- so both report through `argError`.
+// ---------------------------------------------------------------------------
+
+/// The parts of a record-type definition R6RS compares for `nongenerative`
+/// equivalence: "equal fields, equally sealed and opaque, and their parents
+/// ... are equivalent".
+pub const RtdShape = struct {
+    parent: ?*RecordType,
+    sealed: bool,
+    is_opaque: bool,
+    field_names: []const []const u8,
+    field_mutable: []const bool,
+};
+
+/// R6RS: "An exception ... is raised if `parent` is sealed" -- a sealed type
+/// must never become an ancestor of another record type.
+pub fn sealedParentError(proc: []const u8, parent: *RecordType) PrimitiveError {
+    return argError(proc, "record type '{s}' is sealed and cannot be a parent", .{parent.name});
+}
+
+/// `GC.allocRecordTypeExtended` caps a record type at 255 fields *including*
+/// inherited ones, since `RecordType.num_fields` is a u8. Only the inherited
+/// total can trip it here -- both parsers already cap a type's own fields --
+/// so the message has to name the parent's contribution or it reads as a lie
+/// about a definition with 100 fields in front of the caller.
+///
+/// This one is not in kaappi#1880's census of 35: the grep matches a bare
+/// `VMError.TypeError` return statement, and both sites spell it as a
+/// `return switch` arm instead (a fourth blind spot, on top of the path and
+/// spelling ones). It is the same defect as the two that are -- a condition
+/// that is not a type error reporting as a message-less KP3002 -- found by reading
+/// the functions the census pointed at. The procedural half was arguably worse
+/// than the syntactic one: a bare `TypeError` out of a primitive is not
+/// anonymous, `mapNativeError` fills in `type error in '<proc>': got <args[0]>`
+/// from the *first argument*, so it blamed the type's name for a limit the
+/// field list broke.
+pub fn tooManyFieldsError(proc: []const u8, own: usize, parent: ?*RecordType) PrimitiveError {
+    const inherited: usize = if (parent) |p| p.num_fields else 0;
+    return argError(
+        proc,
+        "record type would have {d} fields ({d} of its own plus {d} inherited), but the limit is 255",
+        .{ own + inherited, own, inherited },
+    );
+}
+
+/// Resolve a `nongenerative` uid that is already claimed: R6RS reuses the
+/// registered rtd when this definition is equivalent to it, and raises
+/// otherwise. `existing` is the registry's rtd for `uid`.
+///
+/// A parent is compared by identity: a parent that is itself nongenerative
+/// always resolves to the same RTD object for a given uid, so pointer
+/// equality already captures parent equivalence.
+pub fn reuseNongenerativeRtd(proc: []const u8, uid: []const u8, existing: Value, want: RtdShape) PrimitiveError!Value {
+    const existing_rt = asRecordType(existing);
+    // Checked in R6RS's own order, and reported as the single axis that
+    // actually differs -- a list of every axis it might have been tells the
+    // caller nothing they didn't already know.
+    const differs: []const u8 = if (existing_rt.parent != want.parent)
+        "parent"
+    else if (existing_rt.sealed != want.sealed)
+        "sealed flag"
+    else if (existing_rt.is_opaque != want.is_opaque)
+        "opaque flag"
+    else if (!fieldsEquivalent(existing_rt, want.field_names, want.field_mutable))
+        "field set"
+    else
+        return existing;
+    return argError(proc, "uid \"{s}\" is already bound to a record type with a different {s}", .{ uid, differs });
 }
 
 fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
@@ -137,11 +219,7 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
         if (!types.isRecordType(args[1])) return typeError(MAKE_RTD, "record-type", args[1]);
         break :blk asRecordType(args[1]);
     };
-    // R6RS: "An exception ... is raised if parent is sealed". Not a type error:
-    // a sealed rtd is a perfectly good record type, it just refuses to be
-    // extended -- so this reports as `invalid-argument` (KP3007).
-    if (parent) |p| if (p.sealed)
-        return argError(MAKE_RTD, "record type '{s}' is sealed and cannot be a parent", .{p.name});
+    if (parent) |p| if (p.sealed) return sealedParentError(MAKE_RTD, p);
 
     const uid: ?[]const u8 = if (args[2] == types.FALSE)
         null
@@ -168,27 +246,17 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
 
     // nongenerative: reuse an existing RTD registered under this uid rather
     // than allocating a new, non-interoperable one -- but only when it's
-    // actually equivalent (R6RS: "the record-type definitions should be
-    // equivalent, in the sense that they specify ... equal fields, equally
-    // sealed and opaque, and their parents ... are equivalent"). A parent
-    // is compared by identity: a parent that is itself nongenerative always
-    // resolves to the same RTD object for a given uid, so pointer equality
-    // already captures parent equivalence.
+    // actually equivalent.
     if (uid) |u| {
         const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
         if (vm.record_uid_registry.get(u)) |existing| {
-            const existing_rt = asRecordType(existing);
-            if (existing_rt.parent == parent and
-                existing_rt.sealed == sealed and
-                existing_rt.is_opaque == is_opaque and
-                fieldsEquivalent(existing_rt, field_names_buf[0..field_count], field_mutable_buf[0..field_count]))
-            {
-                return existing;
-            }
-            // Also not a type error: the uid is a fine string, it is just
-            // already claimed by a type this call does not match.
-            return argError(MAKE_RTD, "uid \"{s}\" is already bound to a record type with a " ++
-                "different parent, sealed/opaque flag, or field set", .{u});
+            return reuseNongenerativeRtd(MAKE_RTD, u, existing, .{
+                .parent = parent,
+                .sealed = sealed,
+                .is_opaque = is_opaque,
+                .field_names = field_names_buf[0..field_count],
+                .field_mutable = field_mutable_buf[0..field_count],
+            });
         }
     }
 
@@ -201,7 +269,7 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
         sealed,
         is_opaque,
     ) catch |err| return switch (err) {
-        error.TooManyFields => PrimitiveError.TypeError,
+        error.TooManyFields => tooManyFieldsError(MAKE_RTD, field_count, parent),
         else => PrimitiveError.OutOfMemory,
     };
 

--- a/src/tests_ffi.zig
+++ b/src/tests_ffi.zig
@@ -4,6 +4,8 @@ const types = @import("types.zig");
 const ffi = @import("ffi.zig");
 const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
+const vm_mod = @import("vm.zig");
+const vm_calls = @import("vm_calls.zig");
 
 // A C-ABI function with a real `_Bool` parameter. In safe builds (the default)
 // the Zig compiler inserts a check that traps if the incoming byte is not 0 or
@@ -273,4 +275,76 @@ test "ffi-open: a path with separators is not re-searched under home lib" {
     // "<home>/lib/<path>" mashup may appear anywhere in the message.
     try std.testing.expect(std.mem.indexOf(u8, msg, "/lib/)") == null);
     try std.testing.expect(std.mem.indexOf(u8, msg, "lib//") == null);
+}
+
+// kaappi#1880: `callFfi`'s four call sites now route failures through one
+// mapper. Until #1880 only the two in vm_calls.zig supplied a fallback message
+// when callFfi returned TypeError without setting a detail; the two hot ones
+// in vm_dispatch.zig (the tail-call and tail-apply opcodes) returned a bare
+// TypeError, so such a failure would report usefully or not at all depending
+// on which opcode dispatched the call.
+//
+// `callFfi` sets a detail on every path it can currently fail through, so
+// nothing reaches the fallback from Scheme -- the Scheme-level check in
+// tests/scheme/ffi/error-messages.scm can only pin that the four sites agree,
+// not that the fallback works. Forcing the empty-detail state here is the only
+// way to exercise what those sites now share.
+test "mapFfiError supplies a fallback message when callFfi left none (#1880)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    var ptypes = [_]types.FfiType{.bool_type};
+    var ffi_fn = makeBoolFn(ptypes[0..], .int);
+
+    ctx.vm.last_error_detail_len = 0;
+    try std.testing.expectEqual(
+        vm_mod.VMError.TypeError,
+        vm_calls.mapFfiError(ctx.vm, error.TypeError, &ffi_fn),
+    );
+    // Naming the function is the whole point: "type error" alone is what the
+    // two dispatch sites used to produce.
+    const detail = ctx.vm.last_error_detail[0..ctx.vm.last_error_detail_len];
+    try std.testing.expect(std.mem.indexOf(u8, detail, "recv_bool") != null);
+}
+
+test "mapFfiError never overwrites a detail callFfi already set (#1880)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    var ptypes = [_]types.FfiType{.bool_type};
+    var ffi_fn = makeBoolFn(ptypes[0..], .int);
+
+    // The fallback is a floor, not an overwrite. Clobbering the specific
+    // message `validateArgsDetailed` produces with the generic one would be
+    // strictly worse than the bug being fixed -- this is what the two sites
+    // that already had the guard got right, and what is being copied.
+    ctx.vm.setErrorDetail("'{s}': argument 1 must be string, got integer", .{ffi_fn.name});
+    try std.testing.expectEqual(
+        vm_mod.VMError.TypeError,
+        vm_calls.mapFfiError(ctx.vm, error.TypeError, &ffi_fn),
+    );
+    try std.testing.expectEqualStrings(
+        "'recv_bool': argument 1 must be string, got integer",
+        ctx.vm.last_error_detail[0..ctx.vm.last_error_detail_len],
+    );
+}
+
+test "mapFfiError passes a raised Scheme exception through untouched (#1880)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    var ptypes = [_]types.FfiType{.bool_type};
+    var ffi_fn = makeBoolFn(ptypes[0..], .int);
+
+    // An ffi-callback that raised must stay an exception, not become a type
+    // error, and must not pick up an FFI-signature detail on the way out.
+    ctx.vm.last_error_detail_len = 0;
+    try std.testing.expectEqual(
+        vm_mod.VMError.ExceptionRaised,
+        vm_calls.mapFfiError(ctx.vm, error.ExceptionRaised, &ffi_fn),
+    );
+    try std.testing.expectEqual(@as(usize, 0), ctx.vm.last_error_detail_len);
 }

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -350,6 +350,30 @@ fn mainFiberResult(sched: *fiber_mod.FiberScheduler) Value {
     return types.VOID;
 }
 
+/// `mapNativeError`'s counterpart for `ffi.callFfi`, which reports through an
+/// inline `error{TypeError}` set of its own rather than the VM's.
+///
+/// `callFfi` guarantees a detail on every path it can currently fail through
+/// (`validateArgsDetailed` covers every user-reachable argument problem, and
+/// `callFfi` has this same fallback at its own exit), so the fallback here is
+/// unreachable today. It exists because the four call sites did not used to
+/// agree: the two in this file had it and the two hot ones in
+/// `vm_dispatch.zig` did not, so a future `callFfi` failure that forgot a
+/// detail would have reported usefully or not at all depending on which opcode
+/// dispatched the call (kaappi#1880). One shared mapper is cheaper than
+/// separate copies of the same guard staying in sync.
+///
+/// The four sites are callValue and callWithArgs here, and the tail-call and
+/// tail-apply opcodes in `vm_dispatch.zig`. Note that a *non*-tail call
+/// reaches neither of the latter two, which is why
+/// `tests/scheme/ffi/error-messages.scm` covers them with tail-position forms.
+pub fn mapFfiError(vm: *VM, err: anyerror, ffi_fn: *types.FfiFunction) VMError {
+    if (err == error.ExceptionRaised) return VMError.ExceptionRaised;
+    if (vm.last_error_detail_len == 0)
+        vm.setErrorDetail("'{s}': unsupported FFI signature", .{ffi_fn.name});
+    return VMError.TypeError; // bare-ok: this is mapFfiError itself
+}
+
 pub fn mapNativeError(vm: *VM, err: anyerror, name: []const u8, args: []const Value) VMError {
     return switch (err) {
         error.TypeError => blk: {
@@ -431,12 +455,8 @@ pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
             return VMError.ArityMismatch;
         }
         const ffi_mod = @import("ffi.zig");
-        const result = ffi_mod.callFfi(ffi_fn, vm.registers[base + 1 .. base + 1 + nargs], vm.gc, vm) catch |err| {
-            if (err == error.ExceptionRaised) return VMError.ExceptionRaised;
-            if (vm.last_error_detail_len == 0)
-                vm.setErrorDetail("'{s}': unsupported FFI signature", .{ffi_fn.name});
-            return VMError.TypeError;
-        };
+        const result = ffi_mod.callFfi(ffi_fn, vm.registers[base + 1 .. base + 1 + nargs], vm.gc, vm) catch |err|
+            return mapFfiError(vm, err, ffi_fn);
         vm.registers[base] = result;
         return;
     }
@@ -790,12 +810,8 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
             return VMError.ArityMismatch;
         }
         const ffi_mod = @import("ffi.zig");
-        return ffi_mod.callFfi(ffi_fn, args, vm.gc, vm) catch |err| {
-            if (err == error.ExceptionRaised) return VMError.ExceptionRaised;
-            if (vm.last_error_detail_len == 0)
-                vm.setErrorDetail("'{s}': unsupported FFI signature", .{ffi_fn.name});
-            return VMError.TypeError;
-        };
+        return ffi_mod.callFfi(ffi_fn, args, vm.gc, vm) catch |err|
+            return mapFfiError(vm, err, ffi_fn);
     }
     if (types.isParameter(proc)) {
         const param = types.toObject(proc).as(types.ParameterObject);

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -566,10 +566,8 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const ffi_mod = @import("ffi.zig");
                     const return_dst = frame.dst;
                     const from_native_call = frame.returns_to_native;
-                    const result = ffi_mod.callFfi(ffi_fn, self.registers[abs_base + 1 .. abs_base + 1 + nargs], self.gc, self) catch |err| {
-                        if (err == error.ExceptionRaised) return VMError.ExceptionRaised;
-                        return VMError.TypeError;
-                    };
+                    const result = ffi_mod.callFfi(ffi_fn, self.registers[abs_base + 1 .. abs_base + 1 + nargs], self.gc, self) catch |err|
+                        return vm_calls.mapFfiError(self, err, ffi_fn);
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     if (from_native_call) return raiseDeadNativeReturn(self);
@@ -638,7 +636,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 while (rest != types.NIL) {
                     if (!types.isPair(rest)) {
                         self.setErrorDetail("apply: last argument must be a list", .{});
-                        return VMError.TypeError;
+                        return VMError.TypeError; // bare-ok: detail set above
                     }
                     if (count >= 255) return VMError.StackOverflow;
                     flat_args[count] = types.car(rest);
@@ -747,10 +745,8 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;
                     const from_native_call = frame.returns_to_native;
-                    const result = ffi_mod.callFfi(ffi_fn, flat_args[0..count], self.gc, self) catch |err| {
-                        if (err == error.ExceptionRaised) return VMError.ExceptionRaised;
-                        return VMError.TypeError;
-                    };
+                    const result = ffi_mod.callFfi(ffi_fn, flat_args[0..count], self.gc, self) catch |err|
+                        return vm_calls.mapFfiError(self, err, ffi_fn);
                     self.frame_count -= 1;
                     if (self.frame_count <= target_frame_count) return result;
                     if (from_native_call) return raiseDeadNativeReturn(self);
@@ -1319,7 +1315,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             const s = p.valueToString(self.gc.allocator, self.registers[abs_base + 1], .write) catch "";
                             defer if (s.len > 0) self.gc.allocator.free(s);
                             self.setErrorDetail("type error in 'eval': expected environment, got {s}", .{if (s.len > 0) s else "?"});
-                            return VMError.TypeError;
+                            return VMError.TypeError; // bare-ok: detail set above
                         }
                         const se = types.toEnvironment(self.registers[abs_base + 1]);
                         const macro_target: *std.StringHashMap(Value) = if (se.env == self.globals) &self.macros else mt: {

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -265,6 +265,13 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
 // define-record-type inside its own .sld body -- a real but narrower gap
 // than the top-level case this session's test suite exercises.
 
+/// The name this path's errors report. The syntactic and procedural routes to
+/// R6RS's sealed-parent and nongenerative-uid rejections share their wording
+/// (primitives_srfi237.zig) but not their name: a caller who wrote
+/// `define-record-type` should never be told about the internal primitive it
+/// happens to desugar to.
+const DEFINE_RTD = "define-record-type";
+
 fn isR6RSClauseKeyword(name: []const u8) bool {
     const keywords = [_][]const u8{ "fields", "parent", "protocol", "sealed", "opaque", "nongenerative", "generative", "parent-rtd" };
     for (keywords) |kw| {
@@ -532,9 +539,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
         if (!types.isRecordType(parent_val)) return VMError.CompileError;
         break :blk types.toObject(parent_val).as(types.RecordType);
     } else null;
-    // R6RS: "An exception ... is raised if parent is sealed" -- a sealed
-    // type must never become an ancestor of another record type.
-    if (parent_rt) |p| if (p.sealed) return VMError.TypeError;
+    if (parent_rt) |p| if (p.sealed) return srfi237_prims.sealedParentError(DEFINE_RTD, p);
     const parent_total_fields: usize = if (parent_rt) |p| p.num_fields else 0;
 
     var field_names_buf: [256][]const u8 = undefined;
@@ -545,21 +550,19 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
     }
 
     // nongenerative: reuse an existing RTD registered under this uid, but
-    // only when it's actually equivalent (same check as
-    // %make-record-type-descriptor in primitives_srfi237.zig -- R6RS:
-    // "the record-type definitions should be equivalent").
+    // only when it's actually equivalent -- R6RS's rule and its rejection
+    // message are shared with %make-record-type-descriptor, the procedural
+    // route to the same condition.
     var rt_val: Value = undefined;
     if (spec.uid) |u| {
         if (vm.record_uid_registry.get(u)) |existing| {
-            const existing_rt = types.toObject(existing).as(types.RecordType);
-            if (existing_rt.parent != parent_rt or
-                existing_rt.sealed != spec.sealed or
-                existing_rt.is_opaque != spec.is_opaque or
-                !srfi237_prims.fieldsEquivalent(existing_rt, field_names_buf[0..spec.field_count], field_mutable_buf[0..spec.field_count]))
-            {
-                return VMError.TypeError;
-            }
-            rt_val = existing;
+            rt_val = try srfi237_prims.reuseNongenerativeRtd(DEFINE_RTD, u, existing, .{
+                .parent = parent_rt,
+                .sealed = spec.sealed,
+                .is_opaque = spec.is_opaque,
+                .field_names = field_names_buf[0..spec.field_count],
+                .field_mutable = field_mutable_buf[0..spec.field_count],
+            });
         } else {
             rt_val = vm.gc.allocRecordTypeExtended(
                 spec.type_name,
@@ -570,7 +573,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
                 spec.sealed,
                 spec.is_opaque,
             ) catch |err| return switch (err) {
-                error.TooManyFields => VMError.TypeError,
+                error.TooManyFields => srfi237_prims.tooManyFieldsError(DEFINE_RTD, spec.field_count, parent_rt),
                 else => VMError.OutOfMemory,
             };
             vm.gc.pushRoot(&rt_val);
@@ -587,7 +590,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
             spec.sealed,
             spec.is_opaque,
         ) catch |err| return switch (err) {
-            error.TooManyFields => VMError.TypeError,
+            error.TooManyFields => srfi237_prims.tooManyFieldsError(DEFINE_RTD, spec.field_count, parent_rt),
             else => VMError.OutOfMemory,
         };
     }

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -588,6 +588,77 @@ assert_output_contains "non-equivalent uid collision is KP3007 and echoes the ui
     "(import (scheme base) (srfi 237)) (make-record-type-descriptor 'a #f 'dup #f #f '#((mutable x))) (make-record-type-descriptor 'a #f 'dup #f #f '#((mutable y)))" \
     'error[KP3007]: %make-record-type-descriptor: uid "dup" is already bound to a record type'
 
+# The same two conditions reached SYNTACTICALLY. Until kaappi#1880 these were
+# the only two `define-record-type` errors that reported nothing at all: a bare
+# "error[KP3002]: type error" naming no procedure, no expected type and no
+# value -- the three things KP3007's own registry entry promises. Both now go
+# through the same helpers as the procedural twins above, so the pair also pins
+# that the two routes cannot drift apart again.
+assert_output_contains "syntactic sealed parent is KP3007, and names the parent" \
+    "(import (scheme base) (srfi 237)) (define-record-type (p mk-p p?) (fields (immutable x)) (sealed #t)) (define-record-type (c mk-c c?) (parent p) (fields (immutable y)))" \
+    "error[KP3007]: define-record-type: record type 'p' is sealed and cannot be a parent"
+
+assert_output_contains "syntactic uid collision is KP3007, and names the axis that differs" \
+    "(import (scheme base) (srfi 237)) (define-record-type (a mk-a a?) (fields (immutable x)) (nongenerative dup)) (define-record-type (b mk-b b?) (fields (immutable y)) (nongenerative dup))" \
+    'error[KP3007]: define-record-type: uid "dup" is already bound to a record type with a different field set'
+
+# The negative half: the old answer was KP3002, so a regression that reverted
+# either site would still satisfy a "contains KP3007" check on the other one.
+assert_output_lacks "syntactic sealed parent is not reported as a type error" \
+    "(import (scheme base) (srfi 237)) (define-record-type (p mk-p p?) (fields (immutable x)) (sealed #t)) (define-record-type (c mk-c c?) (parent p) (fields (immutable y)))" \
+    'error[KP3002]'
+
+# A uid collision names the ONE axis that actually differs, not a list of every
+# axis it might have been. Checked on an axis other than the field set so a
+# hardcoded tail cannot pass.
+assert_output_contains "a uid differing only in sealedness says so" \
+    "(import (scheme base) (srfi 237)) (define-record-type (a mk-a a?) (fields (immutable x)) (nongenerative dup)) (define-record-type (b mk-b b?) (fields (immutable x)) (sealed #t) (nongenerative dup))" \
+    'is already bound to a record type with a different sealed flag'
+
+# The other half of the uid rule: an EQUIVALENT redefinition is not an error at
+# all, it reuses the registered rtd. Without this, "reject everything" passes
+# every assertion above.
+assert_output_contains "an equivalent nongenerative redefinition still reuses the rtd" \
+    "(import (scheme base) (scheme write) (srfi 237)) (define-record-type (a mk-a a?) (fields (immutable x)) (nongenerative dup)) (define-record-type (b mk-b b?) (fields (immutable x)) (nongenerative dup)) (display (a? (mk-b 1)))" \
+    '#t'
+
+# A third condition of the same shape, in the same two functions, that
+# kaappi#1880's census could not see: RecordType.num_fields is a u8, so 255 is
+# the cap on a type's fields INCLUDING inherited ones. Both parsers already cap
+# a type's own fields, so only the inherited total can trip it -- and both
+# routes signalled it as a `return switch` arm yielding a bare TypeError, a
+# spelling the gate's grep does not match either.
+gen_fields() {
+    prefix="$1"; count="$2"; i=0; out=""
+    while [ "$i" -lt "$count" ]; do
+        out="$out (immutable $prefix$i)"
+        i=$((i + 1))
+    done
+    printf '%s' "$out"
+}
+OVERSIZE_SYNTACTIC="(import (scheme base) (srfi 237))
+(define-record-type (par mk-par par?) (fields $(gen_fields p 200)))
+(define-record-type (chi mk-chi chi?) (parent par) (fields $(gen_fields c 100)))"
+OVERSIZE_PROCEDURAL="(import (scheme base) (srfi 237))
+(define P (make-record-type-descriptor 'par #f #f #f #f '#($(gen_fields p 200))))
+(make-record-type-descriptor 'chi P #f #f #f '#($(gen_fields c 100)))"
+
+assert_output_contains "an oversized inherited field count names both contributions" \
+    "$OVERSIZE_SYNTACTIC" \
+    'error[KP3007]: define-record-type: record type would have 300 fields (100 of its own plus 200 inherited), but the limit is 255'
+
+assert_output_contains "the procedural route reports the same limit the same way" \
+    "$OVERSIZE_PROCEDURAL" \
+    'record type would have 300 fields (100 of its own plus 200 inherited), but the limit is 255'
+
+# The procedural route was the worse of the two before the fix: a bare
+# TypeError out of a primitive is not anonymous, so mapNativeError synthesized
+# "type error in '%make-record-type-descriptor': got \"chi\"" -- blaming the
+# type's NAME, the first argument, for a limit the field list broke.
+assert_output_lacks "the oversized-field error does not blame the type's name" \
+    "$OVERSIZE_PROCEDURAL" \
+    'got "chi"'
+
 # %elision-lever-set! is a KEP-0002 gate-harness hook compiled in only with
 # -Dchannel-instrument=true, so it is absent from ordinary builds (including
 # the one CI runs this suite against). Probe for it rather than assuming.
@@ -626,6 +697,8 @@ assert_no_zig_leak "string-keyed table, non-string key (kaappi#1868)" \
     '(import (scheme base) (srfi 69)) (hash-table-set! (make-hash-table string=?) 1 2)'
 assert_no_zig_leak "sealed parent rtd (kaappi#1868)" \
     "(import (scheme base) (srfi 237)) (define l (make-record-type-descriptor 'l #f #f #t #f '#())) (make-record-type-descriptor 'c l #f #f #f '#())"
+assert_no_zig_leak "syntactic sealed parent rtd (kaappi#1880)" \
+    "(import (scheme base) (srfi 237)) (define-record-type (p mk-p p?) (fields (immutable x)) (sealed #t)) (define-record-type (c mk-c c?) (parent p) (fields (immutable y)))"
 
 echo
 echo "=== Results ==="

--- a/tests/scheme/ffi/error-messages.scm
+++ b/tests/scheme/ffi/error-messages.scm
@@ -59,6 +59,35 @@
     (c-abs (expt 2 40))
     #f))
 
+;; kaappi#1880: one FFI failure, four dispatch sites. `callFfi` is reached from
+;; four places -- callValue and callWithArgs in vm_calls.zig, and the tail-call
+;; and tail-apply opcodes in vm_dispatch.zig -- and until #1880 only the first
+;; two supplied a fallback message when callFfi returned without setting one.
+;; The four forms below are chosen because each reaches a DIFFERENT one of
+;; those sites: the tail-position pair is what a non-tail call never reaches,
+;; so a check built from direct/apply/map alone leaves both hot sites untested.
+(define (ffi-error-message thunk)
+  (guard (e (#t (error-object-message e)))
+    (thunk)
+    "no error raised"))
+
+(define (tail-call x) (c-abs x))                       ; vm_dispatch: tail call
+(define (tail-apply x) (apply c-abs (list x)))         ; vm_dispatch: tail apply
+(define (nontail-call x) (+ 0 (c-abs x)))              ; vm_calls: callValue
+(define (nontail-apply x) (+ 0 (apply c-abs (list x)))) ; vm_calls: callWithArgs
+
+(define site-messages
+  (map (lambda (f) (ffi-error-message (lambda () (f -3.0))))
+       (list tail-call tail-apply nontail-call nontail-apply)))
+
+(test-assert "the same FFI error reports identically through all four dispatch sites"
+  (let ((first (car site-messages)))
+    (and (string-contains first "abs")
+         (let loop ((rest (cdr site-messages)))
+           (cond ((null? rest) #t)
+                 ((string=? (car rest) first) (loop (cdr rest)))
+                 (else #f))))))
+
 (let ((runner (test-runner-current)))
   (test-end "ffi-error-messages")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #1880.

## Group A — the two live defects (plus a third the census could not see)

`define-record-type`'s R6RS clause syntax had two conditions that reported
`error[KP3002]: type error` and nothing else:

```scheme
(import (scheme base) (srfi 237))
(define-record-type (parent make-parent parent?) (fields (immutable x)) (sealed #t))
(define-record-type (child make-child child?) (parent parent) (fields (immutable y)))
```

| | before | after |
|---|---|---|
| sealed parent | `error[KP3002]: type error` | `error[KP3007]: define-record-type: record type 'parent' is sealed and cannot be a parent` |
| uid collision | `error[KP3002]: type error` | `error[KP3007]: define-record-type: uid "my-uid" is already bound to a record type with a different field set` |

The procedural half of the same two R6RS rules
(`%make-record-type-descriptor`) has been getting this right since #1868, so
rather than writing the messages a second time, the rule and its wording now
live once — `RtdShape`, `sealedParentError` and `reuseNongenerativeRtd` in
`primitives_srfi237.zig` — and both routes share them. Only the procedure name
differs: a caller who wrote `define-record-type` should not be told about the
internal primitive it desugars to.

A uid collision now names **the one axis that actually differs** (`parent` /
`sealed flag` / `opaque flag` / `field set`) instead of listing every axis it
might have been. That improves the procedural message too, which is the point
of sharing.

### The third condition

Reading those two functions turned up the same defect a third time, in a
spelling no grep in the issue can match — a `return switch` arm, not a bare
return. `RecordType.num_fields` is a `u8`, so 255 is the cap **including
inherited** fields, and exceeding it was signalled as a bare `TypeError`:

| | before | after |
|---|---|---|
| syntactic | `error[KP3002]: type error` | `error[KP3007]: define-record-type: record type would have 300 fields (100 of its own plus 200 inherited), but the limit is 255` |
| procedural | `type error in '%make-record-type-descriptor': got "chi"` | same message as above, under `%make-record-type-descriptor` |

The procedural half is the more interesting one, and the reason "bare" is a
misleading mental model for these: a bare `TypeError` out of a primitive is
**not** anonymous — `mapNativeError` fills the missing detail in from
`args[0]`, so it confidently blamed the type's *name* for a limit the field
list broke. A message naming the wrong argument is harder to catch in review
than no message at all, and impossible to find by counting grep hits.

This is beyond the issue's census of 35; it is the identical defect in the
identical functions, found by reading them.

## Group B — one FFI error mapper instead of four call sites

`callFfi`'s four call sites disagreed about a detail-less failure: the two in
`vm_calls.zig` supplied a fallback message, the two hot ones in
`vm_dispatch.zig` did not. All four now go through `vm_calls.mapFfiError`.

Latent, not live — `callFfi` guarantees a detail on every path it can
currently fail through, verified — so no user-visible behavior changes.

**One correction to the issue.** Its empirical check used `(f x)`,
`(apply f …)` and `(map f …)` and concluded the three paths agree. All three of
those land in `vm_calls.zig`; neither `vm_dispatch.zig` site is reached by a
non-tail call. The two hot sites are the **tail-call** and **tail-apply**
opcodes — confirmed by instrumenting all four. The conclusion still holds, but
the check never touched the sites it was about, so the new test uses
tail-position forms.

## Group C — annotated

The two already-correct sites (`setErrorDetail` on the line above) now carry
`// bare-ok: detail set above`. Every bare `TypeError` in `src/` outside
`ffi.zig` is now either fixed or carrying a stated reason.

## Group D — deliberately not touched

`ffi.zig`'s 27 sites are internal pass/fail signalling behind
`validateArgsDetailed`, which supplies every message. Retagging them changes
nothing a user sees and breaks the caller's switch. The `format` job's grep is
**unchanged** — widening it is now a single question about those 27 rather
than a mixed bag, which is what the issue asked for before deciding.

## Tests

- `tests/scheme/errors/error-format.sh` — 9 new assertions beside their
  procedural twins: each condition's code and message, a negative pinning that
  KP3002 is gone, an axis other than `field set` so a hardcoded tail cannot
  pass, and the happy path (an *equivalent* nongenerative redefinition still
  reuses the rtd — without it, "reject everything" passes every other
  assertion).
- `tests/scheme/ffi/error-messages.scm` — one FFI failure through all four
  dispatch sites, using the tail-position forms that actually reach them.
- `src/tests_ffi.zig` — three tests on `mapFfiError` itself. The Scheme-level
  check can only pin that the four sites agree; forcing the empty-detail state
  is the only way to exercise a fallback that is unreachable today.

Mutation-tested: inverting the field-equivalence test, collapsing every uid
axis to one label, suppressing the FFI fallback, making it overwrite instead of
fill, and breaking the `ExceptionRaised` pass-through each kill their intended
test and no others.

Full unit suite and `bash tests/scheme/run-all.sh` (2017 pass, 0 fail) green;
`zig fmt --check` and markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)