### PR TITLE
Let a record's constructor be named `fields` or `parent` (#1882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `parent`, or another R6RS clause keyword** (#1882). SRFI 237's R6RS clause
   grammar is ambient — `(scheme base)`'s `define-record-type` accepts it with no
   `(import (srfi 237))` — so the two syntaxes are told apart structurally, and
-  the test read only the head of the form's 2nd element, which in R7RS syntax is
-  the *constructor's* name. `(define-record-type point (fields x y) point? (x
-  point-x) (y point-y))` was therefore parsed as R6RS and rejected with a bare
+  the syntax detector inspected only the head of the form's 2nd element, which
+  in R7RS syntax is the *constructor's* name. `(define-record-type point (fields
+  x y) point? (x point-x) (y point-y))` was therefore parsed as R6RS and
+  rejected with a bare
   `KP2001: invalid syntax`, in a program with nothing to suggest the R6RS
   grammar was in play; the follow-on `undefined variable 'fields'` and its `Did
   you mean 'yield'?` pointed away from the cause. The 3rd element now decides:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A valid R7RS record was rejected when its constructor was named `fields`,
+  `parent`, or another R6RS clause keyword** (#1882). SRFI 237's R6RS clause
+  grammar is ambient — `(scheme base)`'s `define-record-type` accepts it with no
+  `(import (srfi 237))` — so the two syntaxes are told apart structurally, and
+  the test read only the head of the form's 2nd element, which in R7RS syntax is
+  the *constructor's* name. `(define-record-type point (fields x y) point? (x
+  point-x) (y point-y))` was therefore parsed as R6RS and rejected with a bare
+  `KP2001: invalid syntax`, in a program with nothing to suggest the R6RS
+  grammar was in play; the follow-on `undefined variable 'fields'` and its `Did
+  you mean 'yield'?` pointed away from the cause. The 3rd element now decides:
+  R7RS always has one and it is always the bare-symbol `<predicate>`, while an
+  R6RS `<record clause>` is always a list — or absent, when there is at most one
+  clause. That is a pure narrowing, so no R6RS form and no malformed form
+  changes path, and no diagnostic changes. In a body the same misdetection also
+  aborted the internal-define scan, so sibling `define`s written after the
+  record lost their mutual visibility; in a library body, where the R6RS grammar
+  is rejected outright, the whole library failed to load.
 - **Native backend: a nested `let` that fell back to the interpreter lost the
   enclosing `let`'s bindings** (#1862). When a `let` inside another `let` gave up
   on native compilation mid-emission — more than 32 bindings, more head

--- a/src/tests_records.zig
+++ b/src/tests_records.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const vm_mod = @import("vm.zig");
 
 test "define-record-type basic" {
     var gc = memory.GC.init(std.testing.allocator);
@@ -121,19 +122,18 @@ test "record type distinction" {
 // a clause keyword; the 3rd element (R7RS's bare-symbol predicate, vs. an
 // R6RS clause list or nothing) is what actually separates them.
 test "R7RS record whose constructor is named after an R6RS clause keyword" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    _ = try vm.eval(
+    _ = try ctx.vm.eval(
         \\(define-record-type point
         \\  (fields x y)
         \\  point?
         \\  (x point-x)
         \\  (y point-y))
     );
-    _ = try vm.eval(
+    _ = try ctx.vm.eval(
         \\(define-record-type node
         \\  (parent l r)
         \\  node?
@@ -141,35 +141,64 @@ test "R7RS record whose constructor is named after an R6RS clause keyword" {
         \\  (r node-r))
     );
 
-    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(try vm.eval("(point-x (fields 1 2))")));
-    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(try vm.eval("(point-y (fields 1 2))")));
-    try std.testing.expectEqual(types.TRUE, try vm.eval("(point? (fields 1 2))"));
-    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(try vm.eval("(node-l (parent 3 4))")));
-    try std.testing.expectEqual(types.FALSE, try vm.eval("(point? (parent 3 4))"));
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(try ctx.vm.eval("(point-x (fields 1 2))")));
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(try ctx.vm.eval("(point-y (fields 1 2))")));
+    try std.testing.expectEqual(types.TRUE, try ctx.vm.eval("(point? (fields 1 2))"));
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(try ctx.vm.eval("(node-l (parent 3 4))")));
+    try std.testing.expectEqual(types.FALSE, try ctx.vm.eval("(point? (parent 3 4))"));
 }
 
 // The other half of #1882's narrowing: every genuine R6RS form must keep
 // its path, whether it has one clause (no 3rd element at all) or several
 // (a clause list there).
 test "R6RS clause syntax still detected after the #1882 narrowing" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
-    _ = try vm.eval("(define-record-type box (fields (mutable contents)))");
-    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try vm.eval("(box-contents (make-box 42))")));
+    _ = try ctx.vm.eval("(define-record-type box (fields (mutable contents)))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try ctx.vm.eval("(box-contents (make-box 42))")));
 
-    _ = try vm.eval("(define-record-type animal (fields (immutable id animal-id)))");
-    _ = try vm.eval(
+    _ = try ctx.vm.eval("(define-record-type animal (fields (immutable id animal-id)))");
+    _ = try ctx.vm.eval(
         \\(define-record-type (dog make-dog dog?)
         \\  (parent animal)
         \\  (fields (immutable breed dog-breed)))
     );
-    _ = try vm.eval("(define rex (make-dog 7 9))");
-    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(try vm.eval("(animal-id rex)")));
-    try std.testing.expectEqual(@as(i64, 9), types.toFixnum(try vm.eval("(dog-breed rex)")));
-    try std.testing.expectEqual(types.TRUE, try vm.eval("(animal? rex)"));
+    _ = try ctx.vm.eval("(define rex (make-dog 7 9))");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(try ctx.vm.eval("(animal-id rex)")));
+    try std.testing.expectEqual(@as(i64, 9), types.toFixnum(try ctx.vm.eval("(dog-breed rex)")));
+    try std.testing.expectEqual(types.TRUE, try ctx.vm.eval("(animal? rex)"));
+}
+
+// The risk in narrowing a discriminator is that a form which used to be
+// rejected by the parser it reached now reaches the *other* parser and
+// slips through. These are the shapes near #1882's new boundary — a
+// non-symbol atom, a list, and a well-formed-looking R7RS form — and each
+// must still be an error whichever parser ends up seeing it.
+test "malformed record forms still fail after the #1882 narrowing" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const malformed = [_][]const u8{
+        // A non-symbol atom where a predicate or a clause would go: not a
+        // predicate for R7RS, not a clause for R6RS.
+        "(define-record-type point (fields x y) 42 (x point-x))",
+        "(define-record-type point (fields x y) \"pred\" (x point-x))",
+        // A list there, so still R6RS — and these are clauses it rejects
+        // (unknown, and the documented `parent-rtd` gap).
+        "(define-record-type point (fields x) (bogus 1))",
+        "(define-record-type point (fields x) (parent-rtd r))",
+        // Now reaches the R7RS parser, which must still catch a constructor
+        // field with no matching field spec.
+        "(define-record-type point (fields x) point?)",
+        // Not a clause keyword at all, so untouched by this fix.
+        "(define-record-type point (make-point x y))",
+    };
+    for (malformed) |src| {
+        try std.testing.expectError(vm_mod.VMError.CompileError, ctx.vm.eval(src));
+    }
 }
 
 test "record with mixed field types" {

--- a/src/tests_records.zig
+++ b/src/tests_records.zig
@@ -115,6 +115,63 @@ test "record type distinction" {
     try std.testing.expectEqual(@as(i64, 0), types.toFixnum(try vm.eval("(color-b c)")));
 }
 
+// #1882: SRFI 237's R6RS clause grammar is ambient, so `define-record-type`
+// tells the two syntaxes apart structurally. Reading only the head of the
+// 2nd element captured any R7RS record whose *constructor* was named after
+// a clause keyword; the 3rd element (R7RS's bare-symbol predicate, vs. an
+// R6RS clause list or nothing) is what actually separates them.
+test "R7RS record whose constructor is named after an R6RS clause keyword" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-record-type point
+        \\  (fields x y)
+        \\  point?
+        \\  (x point-x)
+        \\  (y point-y))
+    );
+    _ = try vm.eval(
+        \\(define-record-type node
+        \\  (parent l r)
+        \\  node?
+        \\  (l node-l)
+        \\  (r node-r))
+    );
+
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(try vm.eval("(point-x (fields 1 2))")));
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(try vm.eval("(point-y (fields 1 2))")));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(point? (fields 1 2))"));
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(try vm.eval("(node-l (parent 3 4))")));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(point? (parent 3 4))"));
+}
+
+// The other half of #1882's narrowing: every genuine R6RS form must keep
+// its path, whether it has one clause (no 3rd element at all) or several
+// (a clause list there).
+test "R6RS clause syntax still detected after the #1882 narrowing" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define-record-type box (fields (mutable contents)))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try vm.eval("(box-contents (make-box 42))")));
+
+    _ = try vm.eval("(define-record-type animal (fields (immutable id animal-id)))");
+    _ = try vm.eval(
+        \\(define-record-type (dog make-dog dog?)
+        \\  (parent animal)
+        \\  (fields (immutable breed dog-breed)))
+    );
+    _ = try vm.eval("(define rex (make-dog 7 9))");
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(try vm.eval("(animal-id rex)")));
+    try std.testing.expectEqual(@as(i64, 9), types.toFixnum(try vm.eval("(dog-breed rex)")));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(animal? rex)"));
+}
+
 test "record with mixed field types" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -280,11 +280,22 @@ fn isR6RSClauseKeyword(name: []const u8) bool {
     return false;
 }
 
-/// R7RS syntax's 2nd element is always (ctor-name field...) where ctor-name
-/// is a plain symbol naming the constructor -- never one of the R6RS clause
-/// keywords above, so checking the head of the 2nd element disambiguates
-/// the two syntaxes (a constructor literally named e.g. "parent" would
-/// misdetect, but that's an extreme, self-inflicted edge case).
+/// Both syntaxes put a list at the 2nd element -- R7RS's
+/// `(<constructor> <field name>*)` and R6RS's first `<record clause>` -- so
+/// that element's head is only half a discriminator: it is a clause keyword
+/// for every R6RS form, but also for a perfectly valid R7RS record whose
+/// constructor happens to be named `fields`, `parent`, `sealed`, ... The
+/// R6RS grammar is ambient (no `(import (srfi 237))` required), so such a
+/// program was misparsed with nothing to hint why (#1882).
+///
+/// The 3rd element settles it, unambiguously: R7RS always has one and it is
+/// always the `<predicate>`, a bare symbol; R6RS either has none (at most
+/// one clause) or has another `<record clause>`, which is always a list.
+/// So a symbol there means R7RS and nothing else -- and only that case is
+/// taken away from the keyword test, which is what makes this a pure
+/// narrowing. Every R6RS form keeps its path, and so does every malformed
+/// one (a missing 3rd element, an improper tail, a non-symbol atom), so no
+/// diagnostic changes either.
 fn looksLikeR6RSClauseSyntax(args: Value) bool {
     if (!types.isPair(args)) return false;
     const rest = types.cdr(args);
@@ -293,7 +304,11 @@ fn looksLikeR6RSClauseSyntax(args: Value) bool {
     if (!types.isPair(second)) return false;
     const head = types.car(second);
     if (!types.isSymbol(head)) return false;
-    return isR6RSClauseKeyword(types.symbolName(head));
+    if (!isR6RSClauseKeyword(types.symbolName(head))) return false;
+
+    const third_cell = types.cdr(rest);
+    if (types.isPair(third_cell) and types.isSymbol(types.car(third_cell))) return false;
+    return true;
 }
 
 fn lookupInternalGlobal(vm: *VM, name: []const u8) ?Value {

--- a/tests/scheme/compliance/lib1882/rec.sld
+++ b/tests/scheme/compliance/lib1882/rec.sld
@@ -1,0 +1,24 @@
+;; Fixture for #1882: a library body whose R7RS `define-record-type` has a
+;; constructor named `fields`.
+;;
+;; Library bodies reach the record desugarer through a different door than
+;; the top level -- compiler_lambda's body scan, via
+;; vm_records.collectRecordTypeDefNames/expandRecordTypeDefines -- and those
+;; two reject R6RS clause syntax outright (it is a documented top-level-only
+;; feature). So a misdetection here didn't just mangle one form: the whole
+;; library failed to load, and every importer saw `undefined variable` for
+;; every name it exports.
+(define-library (lib1882 rec)
+  (export make-lib-point lib-point? lib-point-x lib-point-y)
+  (import (scheme base))
+  (begin
+
+    (define-record-type lib-point
+      (fields x y)
+      lib-point?
+      (x lib-point-x)
+      (y lib-point-y))
+
+    ;; `fields` itself stays library-internal -- an importer shouldn't have
+    ;; to take a binding with that name to exercise the fix.
+    (define (make-lib-point x y) (fields x y))))

--- a/tests/scheme/compliance/record-ctor-clause-keyword-1882.scm
+++ b/tests/scheme/compliance/record-ctor-clause-keyword-1882.scm
@@ -1,0 +1,102 @@
+;; #1882: R6RS clause-syntax detection must not capture a valid R7RS-small
+;; record whose constructor happens to be named after a clause keyword.
+;;
+;; SRFI 237's R6RS `define-record-type` grammar is ambient -- `(scheme base)`
+;; accepts it with no `(import (srfi 237))` -- so the two syntaxes have to be
+;; told apart structurally. The discriminator used to read only the head of
+;; the form's 2nd element, which in R7RS syntax is the *constructor's* name;
+;; a record whose constructor was called `fields` or `parent` was therefore
+;; parsed as R6RS and rejected with a bare KP2001, in a program that never
+;; mentions SRFI 237 at all.
+;;
+;; The 3rd element is what actually separates the two grammars: R7RS always
+;; has one and it is always the bare-symbol `<predicate>`, while an R6RS
+;; `<record clause>` is always a list -- or absent, when there is at most one
+;; clause. So the tests below come in two halves: R7RS forms that must no
+;; longer be captured, and R6RS forms that must still be detected.
+
+(import (scheme base) (scheme process-context) (srfi 64) (lib1882 rec))
+
+(test-begin "record-ctor-clause-keyword-1882")
+
+;; --- R7RS: a clause keyword is an ordinary constructor name ---
+
+(define-record-type point (fields x y) point? (x point-x) (y point-y))
+(test-equal "ctor named `fields` constructs" 1 (point-x (fields 1 2)))
+(test-equal "ctor named `fields`, second field" 2 (point-y (fields 1 2)))
+(test-equal "ctor named `fields` satisfies its predicate" #t (point? (fields 1 2)))
+
+(define-record-type node (parent l r) node? (l node-l) (r node-r))
+(test-equal "ctor named `parent` constructs" 'a (node-l (parent 'a 'b)))
+(test-equal "ctor named `parent` satisfies its predicate" #t (node? (parent 'a 'b)))
+(test-equal "the two remain distinct record types" #f (point? (parent 'a 'b)))
+
+;; A mutable field, so the misdetection can't hide behind the read-only path.
+(define-record-type cell (sealed v) cell? (v cell-v set-cell-v!))
+(test-equal "ctor named `sealed` constructs" 7 (cell-v (sealed 7)))
+(let ((c (sealed 7)))
+  (set-cell-v! c 8)
+  (test-equal "mutator on a `sealed`-constructed record" 8 (cell-v c)))
+
+;; The remaining keywords are unlikely constructor names, but they are here
+;; so that a future edit to the keyword list can't quietly re-capture one.
+(define-record-type r-protocol (protocol v) r-protocol? (v r-protocol-v))
+(define-record-type r-opaque (opaque v) r-opaque? (v r-opaque-v))
+(define-record-type r-nongen (nongenerative v) r-nongen? (v r-nongen-v))
+(define-record-type r-gen (generative v) r-gen? (v r-gen-v))
+(define-record-type r-prtd (parent-rtd v) r-prtd? (v r-prtd-v))
+(test-equal "remaining clause keywords work as constructor names"
+  '(1 2 3 4 5)
+  (list (r-protocol-v (protocol 1))
+        (r-opaque-v (opaque 2))
+        (r-nongen-v (nongenerative 3))
+        (r-gen-v (generative 4))
+        (r-prtd-v (parent-rtd 5))))
+
+;; --- R7RS: the same name in a body, and in a library body ---
+
+;; A body's record form is scanned by the compiler's internal-define pass,
+;; not the top-level handler. A misdetection there aborted the whole scan,
+;; so the *siblings* defined after the record lost their forward
+;; declarations too -- `ev?` below could not see `od?`.
+(define (body-scan-check n)
+  (define-record-type bp (fields a) bp? (a bp-a))
+  (define (ev? k) (if (= k 0) #t (od? (- k 1))))
+  (define (od? k) (if (= k 0) #f (ev? (- k 1))))
+  (list (bp-a (fields 9)) (ev? n)))
+(test-equal "a body keeps its sibling defines visible" '(9 #t) (body-scan-check 4))
+
+;; A library body rejects R6RS clause syntax outright (top-level-only
+;; feature), so a misdetection failed the entire library load -- see
+;; lib1882/rec.sld.
+(let ((p (make-lib-point 3 4)))
+  (test-equal "library-body record with a `fields` constructor" 3 (lib-point-x p))
+  (test-equal "library-body record, second field" 4 (lib-point-y p))
+  (test-equal "library-body record predicate" #t (lib-point? p)))
+
+;; --- R6RS: clause syntax is still detected, still without importing it ---
+
+;; One clause, so there is no 3rd element at all.
+(define-record-type box (fields (mutable contents)))
+(test-equal "R6RS single-clause form" 42 (box-contents (make-box 42)))
+
+;; Two clauses: the 3rd element is `(fields ...)`, a list, so still R6RS.
+(define-record-type animal (fields (immutable name animal-name)))
+(define-record-type (dog make-dog dog?)
+  (parent animal)
+  (fields (immutable breed dog-breed)))
+(define rex (make-dog "rex" "lab"))
+(test-equal "R6RS inheritance: parent field" "rex" (animal-name rex))
+(test-equal "R6RS inheritance: own field" "lab" (dog-breed rex))
+(test-equal "R6RS inheritance: parent predicate" #t (animal? rex))
+
+;; Three clauses, none of them `fields` in 3rd position.
+(define-record-type sealed-thing
+  (fields (immutable v sealed-thing-v))
+  (sealed #t)
+  (opaque #t))
+(test-equal "R6RS multi-clause form" 5 (sealed-thing-v (make-sealed-thing 5)))
+
+(let ((runner (test-runner-current)))
+  (test-end "record-ctor-clause-keyword-1882")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #1882.

## The bug

SRFI 237's R6RS clause grammar is ambient — `(scheme base)`'s
`define-record-type` accepts it with no `(import (srfi 237))` — so the two
syntaxes have to be told apart structurally. `looksLikeR6RSClauseSyntax` read
only the head of the form's 2nd element, which in R7RS syntax is the
*constructor's* name:

```scheme
(import (scheme base) (scheme write))
(define-record-type point (fields x y) point? (x point-x) (y point-y))
(display (point-x (fields 1 2)))
```

```
error[KP2001]: invalid syntax
error[KP3001]: undefined variable 'fields'. Did you mean 'yield'?
```

Nothing in that program signals that the R6RS grammar is in play, and the
follow-on `undefined variable` with its `Did you mean 'yield'?` points away
from the cause. All 8 keywords were affected (`fields`, `parent`, `protocol`,
`sealed`, `opaque`, `nongenerative`, `generative`, `parent-rtd`); `fields` and
`parent` are the ones anyone would realistically write.

## The fix

The 3rd element separates the grammars unambiguously:

| | 3rd element |
|---|---|
| R7RS-small | always the `<predicate>` — a bare **symbol**, always present |
| R6RS / SRFI 237 | a `<record clause>`, always a **list** — or absent, with ≤1 clause |

So the keyword test gets a second condition rather than a replacement: a
**symbol** there means R7RS and nothing else. That is a pure narrowing — only
the symbol case is taken away — which is what makes it safe.

Verified by A/B against a binary built from the parent commit:

- The repro above, all 8 keywords as constructor names, and a zero-field
  record whose *predicate* is `sealed`: rejected before, correct after.
- Every genuine R6RS form in `srfi237.scm`/`srfi240.scm` still routes to the
  R6RS path (single-clause, multi-clause, and `parent` inheritance are all
  covered by the new tests).
- 10 malformed forms — missing predicate, non-symbol predicate, improper
  tail, undeclared constructor field, `parent-rtd`, duplicate fields — produce
  byte-identical diagnostics before and after.

## Two paths the issue didn't mention

The same predicate guards two other call sites, and both were also affected:

- **In a body**, a misdetection made the internal-define scan `break`, so
  sibling `define`s written *after* the record lost their forward
  declarations — mutual recursion among them failed with `undefined variable`
  even though the record itself still worked.
- **In a library body**, where the R6RS grammar is rejected outright as a
  documented top-level-only feature, the whole library failed to load and
  every importer saw `undefined variable` for every name it exports.

Both are covered by the new tests.

## Tests

- `tests/scheme/compliance/record-ctor-clause-keyword-1882.scm` (18
  assertions) with the library fixture `lib1882/rec.sld` — all 8 keywords as
  constructor names, a mutable field, the body-scan case, the library-body
  case, and R6RS single-clause/multi-clause/inheritance forms to pin that
  detection did not regress. Fails 8 assertions on the parent commit.
- Two unit tests in `src/tests_records.zig`; the R7RS one fails without the
  fix, the R6RS one passes either way by design (it is the "still detected"
  pin).
- `zig build test` and `bash tests/scheme/run-all.sh` green: 623 Scheme files,
  1395 R7RS, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)