### PR TITLE
Gate publishing on CI, and ask for a changelog entry while it is cheap

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -166,7 +166,8 @@ Note: `src/main.zig` and `src/thottam.zig` read the version from
 **STOP.** Ask the user for explicit confirmation before pushing. Explain:
 
 - Pushing the tag triggers the release workflow in CI
-- CI builds kaappi and thottam binaries for aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, aarch64-windows and x86_64-windows (kaappi-{aarch64,x86_64}-windows.exe, cross-compiled), x86_64-freebsd, aarch64-freebsd, x86_64-openbsd, aarch64-openbsd, x86_64-netbsd, aarch64-netbsd, plus kaappi.wasm (wasm32-wasi)
+- CI builds kaappi and thottam binaries for all 14 targets — aarch64-macos, x86_64-linux, aarch64-linux, riscv64-linux, s390x-linux, powerpc64le-linux, aarch64-windows and x86_64-windows (kaappi-{aarch64,x86_64}-windows.exe, cross-compiled), x86_64-freebsd, aarch64-freebsd, x86_64-openbsd, aarch64-openbsd, x86_64-netbsd, aarch64-netbsd — plus kaappi.wasm (wasm32-wasi) and the kaappi-lib.tar.gz portable-library bundle
+- Publishing now waits on the `ci-gate` job, which requires ci.yml to have passed for the tagged commit. A tag whose CI fails builds every artifact and then refuses to publish
 - macOS binaries are Developer ID signed and Apple notarized
 - It generates SHA256SUMS and creates a GitHub Release
 - This is irreversible
@@ -278,14 +279,24 @@ ssh netbsd "ftp -o /tmp/kaappi-$TAG https://github.com/kaappi/kaappi/releases/do
 ssh netbsd "/tmp/kaappi-$TAG --version"
 ssh netbsd "echo '(display (+ 1 2)) (newline)' | /tmp/kaappi-$TAG /dev/stdin"
 ssh netbsd "/tmp/kaappi-$TAG features"
-ssh netbsd "echo '(import (scheme base)(scheme write)(srfi 144)) (write (> fl-least 0.0))' | /tmp/kaappi-$TAG /dev/stdin"
+ssh netbsd "echo '(display (> 5e-324 0.0)) (newline)' | /tmp/kaappi-$TAG /dev/stdin"
 ```
 
 Verify: version matches, the script prints `3`, `features` shows `posix`
 
-+ `kaappi-threads` with target `aarch64-netbsd-none`, and the SRFI-144
-probe prints `#t` (denormal arithmetic — guards the startup FPCR
-flush-to-zero fix on NetBSD/aarch64). See `docs/dev/netbsd.md`.
++ `kaappi-threads` with target `aarch64-netbsd-none`, and the denormal
+probe prints `#t` — that last one guards the startup FPCR flush-to-zero
+fix on NetBSD/aarch64. See `docs/dev/netbsd.md`.
+
+**The denormal probe is deliberately library-free.** The obvious spelling
+imports `(srfi 144)` and tests `(> fl-least 0.0)`, but a freshly imaged VM
+has no `~/.kaappi/lib`, so the import fails and the check dies with
+`undefined variable 'fl-least'` — which reads as a denormal regression on
+the very platform whose FPCR fix it exists to guard. Worse, a failed import
+does not stop execution, so the error surfaces downstream rather than at the
+import. `5e-324` is the same denormal with no library at all. Only reach for
+the SRFI-144 form on a VM you have already populated with
+`kaappi-lib.tar.gz`.
 
 ## Step 11: Update docs site (playground WASM + version)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,54 @@ jobs:
       - name: Markdown lint
         uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
 
+  # `[Unreleased]` has been reconstructed from `git log` at release time rather
+  # than written as the work lands -- v0.22.0 shipped with 14 of 100 commits
+  # reflected in it, v0.22.1 with 5 of 16. Ask for the entry here, while the
+  # change is fresh and its author is present to write it.
+  changelog:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Require a CHANGELOG entry for user-visible changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Labels are read live rather than from github.event, because
+          # re-running a job replays the ORIGINAL event payload -- a
+          # `no-changelog` label added in response to this job failing would
+          # be invisible to it, making the documented escape hatch a dead end.
+          if gh pr view "$PR" --repo "$REPO" --json labels \
+               --jq '.labels[].name' | grep -qx 'no-changelog'; then
+            echo "Labelled 'no-changelog' -- skipping."
+            exit 0
+          fi
+
+          files=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
+
+          if ! grep -qE '^(src/|lib/srfi/)' <<<"$files"; then
+            echo "No src/ or lib/srfi/ changes -- CHANGELOG entry not required."
+            exit 0
+          fi
+          if grep -qx 'CHANGELOG.md' <<<"$files"; then
+            echo "CHANGELOG.md updated."
+            exit 0
+          fi
+
+          echo "::error::This PR changes src/ or lib/srfi/ but does not touch CHANGELOG.md."
+          echo "::error::Add an entry under [Unreleased] describing the user-visible effect."
+          echo "::error::If the change is not user-visible (refactor, tests, CI), apply the"
+          echo "::error::'no-changelog' label and re-run this job -- labels are read live, so"
+          echo "::error::a re-run picks it up without pushing a commit."
+          exit 1
+
   test:
     needs: format
     # Explicit name, deliberately NOT including matrix.timeout: this job's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
 
 permissions:
   contents: write
+  # ci-gate reads this repo's CI runs via `gh run list`. Declaring any
+  # `permissions:` block zeroes every scope not listed, so without this the
+  # gate 403s instead of gating.
+  actions: read
 
 jobs:
   build:
@@ -290,8 +294,58 @@ jobs:
             | ./${{ matrix.artifact }} /dev/stdin | grep -qx '2.0'
           echo "dynamic loading OK"
 
+  # The tag push and the `main` push start ci.yml and release.yml as two
+  # independent runs, so without this they race -- and publishing wins. v0.22.1
+  # went public at 06:35:24 with CI on the same commit still running, and would
+  # have published just the same had CI failed. Builds below run in parallel
+  # with CI regardless; only the publish waits, so gating costs no wall clock
+  # unless CI is genuinely the long pole.
+  ci-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Require CI to have passed for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          echo "Waiting for CI on $SHA"
+
+          # A tag pushed at the same moment as the branch can beat its own CI
+          # run into existence, so absence is retried rather than fatal.
+          for attempt in $(seq 1 80); do
+            read -r status conclusion url <<<"$(
+              gh run list --repo "$REPO" --workflow=ci.yml --commit="$SHA" \
+                --limit 1 --json status,conclusion,url \
+                --jq '.[0] // empty | "\(.status) \(.conclusion // "-") \(.url)"' 2>/dev/null || echo "")"
+
+            case "${status:-}" in
+              completed)
+                if [ "$conclusion" = "success" ]; then
+                  echo "CI passed: $url"
+                  exit 0
+                fi
+                echo "::error::CI concluded '$conclusion' for $SHA -- refusing to publish. $url"
+                exit 1
+                ;;
+              "")
+                echo "attempt $attempt: no CI run found yet for $SHA"
+                ;;
+              *)
+                echo "attempt $attempt: CI $status -- $url"
+                ;;
+            esac
+            sleep 60
+          done
+
+          echo "::error::Timed out waiting for CI to conclude on $SHA."
+          echo "::error::Re-run this job once CI finishes, or delete the tag if CI failed."
+          exit 1
+
   release:
-    needs: [build, build-wasm, linux-ffi-smoke]
+    needs: [build, build-wasm, linux-ffi-smoke, ci-gate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 .zig-cache/
 zig-out/
+
+# Interpreter copies kept in the repo root for A/B runs (build one, stash it
+# under a distinct name, rebuild, compare). Root-anchored so they cannot mask
+# anything under src/ or tests/.
+/kaappi
+/pkaappi
+
 .kaappi_history
 *.sbc
 !src/testdata/*.sbc


### PR DESCRIPTION
## Why

v0.22.1 published at 06:35:24 with `ci.yml` **still running** on the same commit — and would have published identically had CI failed:

```
06:30:21  CI starts on 40f04a6d (push to main)
06:30:30  Release workflow starts on tag v0.22.1
06:35:24  ★ Release PUBLISHED
06:58:32  CI on 40f04a6d still in progress
```

The tag push and the branch push start `release.yml` and `ci.yml` as two independent runs with nothing between them. They race; publishing wins. The only real gate on that release was a local test run.

## What changed

**`ci-gate` (release.yml)** — polls for the `ci.yml` run on the tagged SHA. Only the `release` job depends on it, so the 14 platform builds still run in parallel with CI; gating costs no wall clock unless CI is the long pole.

- A missing run is *retried*, not failed — a tag pushed alongside its branch can beat its own CI run into existence.
- A concluded-but-unsuccessful run refuses to publish, `cancelled` included.
- Adds `actions: read`. Without it the poll 403s, since declaring any `permissions:` block zeroes every scope not listed.

**`changelog` (ci.yml)** — a PR touching `src/` or `lib/srfi/` without touching `CHANGELOG.md` fails, with a `no-changelog` label escape hatch. `[Unreleased]` had 14 of 100 commits at v0.22.0 and 5 of 16 at v0.22.1, because it gets reconstructed from `git log` at release time instead of written as the work lands.

Labels are read **live via the API**, not from `github.event`: re-running a job replays the original event payload, so a label added in response to the failure would be invisible to the re-run — making the documented escape hatch a dead end.

**Release skill** — the build-target list said 12 where the matrix ships 14 (`s390x`, `ppc64le` missing, both in the released assets). The NetBSD denormal probe imported `(srfi 144)`, which needs `~/.kaappi/lib` and so dies on a fresh VM as `undefined variable 'fl-least'` — reading as a denormal regression on the one platform whose FPCR fix it guards. Replaced with the library-free `5e-324` spelling, verified locally (`#t`, `1.0e-320`).

**`.gitignore`** — root-anchored `/kaappi`, `/pkaappi` for A/B interpreter copies.

## Verification

- Both workflows parse (`yaml.safe_load`); `release.needs` includes `ci-gate`.
- Gate logic exercised offline against all six states: no-run → retry, queued → retry, in_progress → retry, success → publish, failure → refuse, cancelled → refuse.
- Caught and fixed a bug in the gate while testing: `.[0] | ...` on an empty array yields the string `null`, so the "no run found yet" branch never fired. Needs `.[0] // empty`.
- `markdownlint-cli2`: 0 issues / 1410 files.

## Note for after merge

`changelog` is a new job — it is **not** automatically a required status check. Add it in branch protection if you want it enforced rather than merely visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)