### PR TITLE
Phase 0B: correct six documentation claims that no longer describe the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,9 +184,19 @@ quasiquote, `call/cc`, `call-with-values`, `eval`, …) run through
 environment, any lexical scope containing one (the enclosing `define`/`lambda`
 frame or `let`) declines native compilation as a whole rather than splitting
 itself across the boundary. The keyword set driving that decision is
-`ir.eval_fallback_form_names`; a keyword missing from it is a silent
-miscompilation, not a missed optimization (kaappi#827/#1496/#1799 — see
-`docs/dev/llvm-backend.md`).
+`ir.eval_fallback_form_names` (kaappi#827/#1496/#1799 — see
+`docs/dev/llvm-backend.md`). That set is **comptime-derived** and needs no
+maintenance: it walks `llvm_node_table`, then every `FormKind` field (skipping
+`isNativeLoweredForm`), then `other_special_forms`, so a new `FormKind` joins
+it automatically, and a comptime block enforces one `llvm_node_table` entry per
+`NodeTag`.
+
+The silent-miscompilation hazard is real but lives one file over, in
+`isRejectedFormHead` (`llvm_emit_forms.zig`) — a **hand-maintained** 32-name
+array gating `cond`/`case`/`do` through `exprNativeEmittable`, structurally
+independent of the derived set and already missing `define-property`
+(kaappi#1896). Add a keyword there when you add a form, until that list is
+derived too.
 
 **Always use `zig cc` (not `clang`) for linking native binaries against
 `libkaappi_rt.a`.** The Zig-compiled static library references
@@ -387,17 +397,19 @@ reply channel per call) so the timer thread stays the one place a task-id
 counter needs to live; `timer-cancel!` `thread-join!`s the timer's thread
 before returning, both for correct resource cleanup and because not doing
 so raced process/thread teardown into a nondeterministic crash during
-development. **Single calling thread only** is a hard requirement of this
-implementation, not just a style guideline: calling any of these
-procedures on one timer from a *second*, different thread reproduced
-nondeterministic memory corruption this session (varying panic
-signatures — integer overflow, bad alignment, bus error — across runs),
-even though a bare hand-written two-thread channel round trip with none
-of this library's other moving parts did not reproduce it in isolation.
-This points at a real bug in the interaction between multi-hop channel
-messages and cross-thread deep-copy that was not root-caused and is
-out of scope for a portable-library change — worth its own investigation
-later. SRFI 21 and 230 are excluded — see `docs/dev/srfi-exclusions.md`.
+development. **Single calling thread only** is a requirement of this
+implementation: its request/reply design assumes it. This header used to
+report that a second thread calling into a timer produced nondeterministic
+memory corruption, blamed on an un-root-caused interaction between
+multi-hop channel messages and cross-thread deep-copy. **That no longer
+reproduces** — re-checked 2026-07-31 at v0.22.1, both documented entry
+paths fail cleanly and deterministically (10/10 runs) with a catchable
+error, because a `<timer>` holds a Fiber and `gc_deep_copy` rejects that
+tag as `error.UncopyableType`, making the constraint engine-enforced. The
+multi-hop mechanism itself survived ~4,000 nested reply-channel round
+trips. Treat single-thread-only as the supported usage, not as a live
+corruption hazard; see `lib/srfi/120.sld`'s header for the caveats on
+that re-check. SRFI 21 and 230 are excluded — see `docs/dev/srfi-exclusions.md`.
 SRFI 237 (R6RS Records, refined) is the one record-system SRFI needing real
 engine changes: `RecordType` (`types.zig`) gained `parent`/`own_field_names`/
 `own_field_mutable`/`uid`/`sealed`/`is_opaque` fields (`parent` is the only
@@ -425,10 +437,15 @@ before dispatching to the built-in handler (mirroring `compiler.zig`'s
 every *non*-top-level use — see its own comment citing SRFI 219 redefining
 `define`) — without this, no portable library could ever give that name new
 meaning via `define-syntax`, since the top-level dispatch checked for the
-literal name unconditionally. This only closes the gap for top-level use;
-library-body use of a shadowing `define-record-type` (`compiler_lambda.zig`/
-`vm_library.zig`'s separate scanning path) is a documented, un-closed gap —
-same limitation on the R6RS-clause syntax itself. SRFI 137 (Minimal Unique
+literal name unconditionally. Library-body use of a shadowing
+`define-record-type` (`compiler_lambda.zig`/`vm_library.zig`'s separate
+scanning path) was documented here as an un-closed gap; **it works as of
+v0.22.1** — a `.sld` body that shadows the name via `define-syntax` binds
+the shadowed definition, same as at top level. When testing this, bind a
+name that comes from the macro's **pattern**, not one introduced by its
+template: a template-introduced name is hygienically renamed, so the
+binding is invisible from outside and the test looks like a failure for
+an unrelated reason. SRFI 137 (Minimal Unique
 Types) is pure portable Scheme built directly on `(srfi 237)`: a "subtype"
 is exactly SRFI 237's `parent` relation, with every level correctly
 sharing the ROOT type's single payload field (a subtype's own rtd adds
@@ -476,13 +493,15 @@ mergeable at once via left-to-right append + delete-duplicates) is portable
 (`lib/srfi/57.sld`) but deliberately does NOT port its own reference
 implementation's technique: that reference compares field-label identifiers
 at macro-expansion time via the standard `let-syntax`-plus-literals-list
-"if-free=?" trick. A third, previously-undiscovered expander bug surfaced
-while attempting this port: a `let-syntax` anywhere in an expansion chain
-that eventually produces a `define-syntax` form (even many macro layers
-removed) fails to compile outright — reproduced in isolation down to a
-two-line `(let-syntax (...) (define-syntax ...))`, unrelated to the two
-already-documented quirks above. Rather than root-cause that (a separate
-expander investigation), SRFI 57 sidesteps it: field labels become ordinary
+"if-free=?" trick. A third expander bug surfaced while attempting this
+port: a `let-syntax` anywhere in an expansion chain that eventually
+produced a `define-syntax` form failed to compile outright, reproduced
+down to a two-line `(let-syntax (...) (define-syntax ...))`. **That is
+fixed as of v0.22.1** — the two-line repro compiles and runs. SRFI 57's
+design below was chosen while it was live and has not been revisited;
+it remains the better design on its own merits (see the end of this
+paragraph), so this note is history, not a TODO. SRFI 57 sidesteps it:
+field labels become ordinary
 quoted symbols and every list merge/dedup/lookup happens at plain run time
 (`assq`/`memq` over symbol lists) instead of macro-expansion time — a
 scheme or type name is bound with plain `define` (not `define-syntax`) to a
@@ -901,12 +920,13 @@ em-set-intersection/em-set-difference dropping `'compare` in their 3+-list
 recursions, and em-set= being vacuously `#t` for 3+ arguments) — all
 documented with evidence in the `.sld` header. The test suite
 (`tests/scheme/srfi/srfi148.scm`) is the reference's own `test.sld`
-ported verbatim: 134 pass, 8 `test-expect-fail` (one call per name —
-SRFI 64 combines multiple specifiers with AND, so batching matches
-nothing) citing the two remaining general engine bugs #1800
-(macro-expanded bare `(define x v)` in body position invisible to later
-siblings) and #1801 (two expansions of a template-introduced literal
-symbol wrongly `bound-identifier=?`).
+ported verbatim, and **all 142 assertions pass with zero
+`test-expect-fail`**. The two general engine bugs the port surfaced
+— #1800 (macro-expanded bare `(define x v)` in body position invisible
+to later siblings) and #1801 (two expansions of a template-introduced
+literal symbol wrongly `bound-identifier=?`) — are both fixed; the test
+file's own header explains each fix and is accurate, so read it rather
+than assuming the citations are stale.
 
 SRFI 211 (Scheme Macro Libraries) and SRFI 213 (Identifier Properties)
 closed issue #1699, and are the codebase's first *procedural* macro

--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -1,6 +1,6 @@
 # Systematic Correctness Audit Strategy (v2)
 
-**Status:** in progress (1 of 53 units) · **Last updated:** 2026-07-31 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
+**Status:** in progress (2 of 53 units — Phase 0 complete) · **Last updated:** 2026-07-31 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
 · **Supersedes:** the v1 campaign (issue [#1137](https://github.com/kaappi/kaappi/issues/1137), closed 2026-07-05, 87 findings, all fixed)
 
 ## Why a second campaign
@@ -250,7 +250,7 @@ Tick when the PR is open and issues are filed; add date and issue numbers.
 **Phase 0 — Baseline and documentation truth**
 
 - [x] 0A: Baseline run, tracking issue, labels, file F1–F13 (2026-07-31, [#1890](https://github.com/kaappi/kaappi/issues/1890) tracking; baseline fully green at `261fde5f` — 624/624 Scheme files, 1395/1395 R7RS assertions, 0 fail; all 13 reconnaissance findings filed as 12 issues [#1891](https://github.com/kaappi/kaappi/issues/1891)–[#1903](https://github.com/kaappi/kaappi/issues/1903) — `#e1e19`/`#e1e400` merged as one root cause; labels `tier-divergence`, `tooling`, `doc-truth` created)
-- [ ] 0B: Documentation-truth pass (CLAUDE.md expander section, SRFI 148 counts, SRFI 120 header, `srfi-exclusions.md` 58/163, `tests/scheme/CLAUDE.md` table, the `eval_fallback_form_names` note)
+- [x] 0B: Documentation-truth pass (2026-07-31, [#1901](https://github.com/kaappi/kaappi/issues/1901); all 6 items corrected — every claim re-verified against v0.22.1 first, which corrected two of the reconnaissance findings in turn: `srfi148.scm`'s header is accurate rather than stale, and there are 6 `test-expect-fail` calls repo-wide (4 in `srfi150.scm`), not 7/6)
 
 **Phase 1 — Reader, printer, numeric tower** (independent)
 

--- a/docs/dev/srfi-exclusions.md
+++ b/docs/dev/srfi-exclusions.md
@@ -364,16 +364,21 @@ Specifies `#nA(...)` reader syntax for n-dimensional arrays, e.g. `#2A((1
 of the same idea (no non-zero lower bounds, no explicit bounds, no
 element-type tag).
 
-**Why excluded:** Same two blockers as SRFI 163, since this is the
-earlier, smaller version of the same feature. First, there is no typed
-or general n-dimensional array heap type to construct — SRFI 4 in this
-codebase is a purely portable wrapper over ordinary bytevectors/vectors
-(`lib/srfi/4.sld`), and SRFI 160 has no implementation at all, so `#nA(...)`
-would have nothing to build. Second, the syntax itself is a bare digit
+**Why excluded:** One blocker, down from two. The syntax is a bare digit
 immediately after `#` (`#2A(...)`), which the reader already uses for
 datum labels (`#N=`/`#N#`, `reader_tokens.zig`'s digit arm in `readHash`)
 — disambiguating the two would need lookahead past the digits for `A`
 specifically, not just a new dispatch arm.
+
+**The second blocker no longer holds** (corrected 2026-07-31). This entry
+used to say there was "no typed or general n-dimensional array heap type
+to construct", that SRFI 4 was "a purely portable wrapper over ordinary
+bytevectors/vectors", and that "SRFI 160 has no implementation at all".
+All three are now false: SRFI 160 ships a native `types.NumericVector`
+heap type, SRFI 4 is a thin re-export over `(srfi 160 <tag>)`, and SRFI
+25, 164, 63 and 231 all ship real array systems. There is now plenty for
+`#nA(...)` to build. **SRFI 58 is therefore genuinely re-considerable** —
+the only remaining question is the reader ambiguity above.
 
 **Scope of change:** New heap type(s) for n-dimensional arrays (or
 building on typed vectors from SRFI 4/160, if those get genuine engine
@@ -389,14 +394,20 @@ literals, extending Common Lisp's `#NA(...)` syntax to support non-zero
 lower bounds, explicit bounds, and uniform element types compatible with
 SRFI 4. Originally implemented in Guile and Kawa.
 
-**Why excluded:** Two blockers. First, the reader syntax (`#2a(...)`,
-`#f64(...)`, etc.) adds a family of new dispatch sequences to the `#`
-reader, each parameterized by dimension count and element type — a
-combinatorial addition to `reader_tokens.zig`. Second, the syntax is
-meaningless without the underlying typed array infrastructure (SRFI 4,
-SRFI 25, SRFI 160, SRFI 164), which is itself a large engine-change
-project tracked separately. If the array SRFIs are implemented in the
-future, this reader syntax can be reconsidered as a follow-up.
+**Why excluded:** One blocker, down from two. The reader syntax
+(`#2a(...)`, `#f64(...)`, etc.) adds a family of new dispatch sequences to
+the `#` reader, each parameterized by dimension count and element type — a
+combinatorial addition to `reader_tokens.zig`.
+
+**The second blocker no longer holds** (corrected 2026-07-31). This entry
+used to say the syntax was "meaningless without the underlying typed array
+infrastructure (SRFI 4, SRFI 25, SRFI 160, SRFI 164), which is itself a
+large engine-change project tracked separately", and that the syntax could
+be reconsidered "if the array SRFIs are implemented in the future". They
+have been: 4, 25, 63, 160, 164 and 231 all ship, on a native
+`types.NumericVector` heap type. That follow-up condition is met, so
+**SRFI 163 is genuinely re-considerable** on the reader-cost question
+alone.
 
 **Scope of change:** Parameterized `#` dispatch in `reader_tokens.zig`,
 array construction in `reader.zig`, depends on typed array heap types

--- a/lib/srfi/120.sld
+++ b/lib/srfi/120.sld
@@ -31,18 +31,30 @@
 ;;; `timer-task-exists?`/`timer-cancel!` on a given timer from the SAME
 ;;; thread throughout. This is thoroughly verified reliable (this
 ;;; library's own test suite, `tests/scheme/srfi/srfi120.scm`, does
-;;; nothing else). A *different* thread calling into a timer it didn't
-;;; create was tried this session and produced nondeterministic memory
-;;; corruption (different crash signatures across runs -- integer
-;;; overflow, bad alignment, bus error) via this library's request/reply
-;;; protocol specifically, even though a bare hand-written two-thread
-;;; channel round trip with no other moving parts did not reproduce it in
-;;; isolation. This points at a real bug somewhere in the interaction
-;;; between multi-hop channel messages and cross-thread deep-copy, not a
-;;; mistake in this library's own logic, but it has not been root-caused
-;;; and is out of scope for a portable-library change -- treat
-;;; single-thread-only as a hard requirement of this implementation until
-;;; that is investigated separately.
+;;; nothing else).
+;;;
+;;; HISTORY: this header previously reported that a *different* thread
+;;; calling into a timer it didn't create produced nondeterministic
+;;; memory corruption (varying crash signatures -- integer overflow, bad
+;;; alignment, bus error), and attributed it to an un-root-caused bug in
+;;; the interaction between multi-hop channel messages and cross-thread
+;;; deep-copy. That no longer reproduces. Re-checked 2026-07-31 at
+;;; v0.22.1: both documented entry paths fail cleanly and
+;;; deterministically (10/10 runs) with a catchable error rather than
+;;; corrupting anything, because a `<timer>` holds a Fiber and
+;;; `gc_deep_copy` rejects that tag as `error.UncopyableType` -- so the
+;;; single-thread constraint is now *engine-enforced*, not merely
+;;; documented here. The separate multi-hop channel mechanism the old
+;;; note blamed was also exercised directly (~4,000 nested reply-channel
+;;; round trips, 20 soak processes) with zero failures.
+;;;
+;;; Single-thread-only is still the supported usage -- this library's
+;;; request/reply design assumes it, and the checks above are a guard
+;;; rail, not a concurrency model. But do not treat the old corruption
+;;; claim as a live hazard to design around. Caveat on the re-check: it
+;;; was macOS/kqueue, ReleaseSafe, without `-Dgc-stress=true`, so it is
+;;; strong evidence the claim is stale rather than proof the bug never
+;;; existed.
 ;;;
 ;;; LIMITATION: the spec requires a task to "be able to cancel or
 ;;; reschedule other tasks" on the same timer -- e.g. a health-check task

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -11,13 +11,24 @@
 | `srfi/` | SRFI library conformance | yes |
 | `ffi/` | C FFI integration | yes |
 | `audit/` | Auto-generated primitives audit tests | yes |
-| `r7rs/` | Full R7RS suite (1,391 tests, `chibi test`) | yes (special) |
+| `r7rs/` | Full R7RS suite (1,395 tests, `chibi test`) | yes (special) |
 | `errors/` | Error message format, exit code, and reader error regression tests | yes |
 | `bench/` | Micro-benchmarks (no assertions, timing only) | no |
 | `compile/` | Native compiler regression tests | yes |
+| `test-runner/` | `kaappi test` runner (`--json`, `--seed`, `--changed`, `--lib-path`) | yes |
+| `pipeline/` | `kaappi ast`/`expand`/`ir` stage dumps | yes |
+| `doctor/` | `kaappi doctor` self-check | yes |
+| `fmt/` | `kaappi fmt` formatter | yes |
+| `cache/` | `.sbc` bytecode cache transparency | yes |
+| `timings/` | `--timings` stage reporting | yes |
 | `coverage/` | Coverage gap-fillers (`zig build coverage-scheme`) | no |
-| `robustness/` | Stress tests | no |
-| `sandbox/` | Sandbox isolation tests | no |
+| `robustness/` | Stress tests | no (CI runs it separately) |
+| `sandbox/` | Sandbox isolation tests | no (CI runs it separately) |
+
+**The globs in `run-all.sh` are non-recursive** (`tests/scheme/srfi/*.scm`,
+not `**`). A test placed in a subdirectory of a suite is silently never run —
+`tests/scheme/srfi/slow/` is exactly that today (kaappi#1900). Put new files
+directly in a suite directory, or wire the subdirectory up explicitly.
 
 ## Adding a test
 


### PR DESCRIPTION
Closes #1901. Phase 0B of the v2 audit campaign (#1890).

Every claim was re-verified against v0.22.1 before being edited. That discipline is the point of the pass — taking the reconnaissance report on faith would have reproduced exactly the failure mode it exists to fix — and it changed two of the findings.

## The six corrections

**1. The native-backend warning pointed at the wrong list.** CLAUDE.md said a keyword missing from `ir.eval_fallback_form_names` is a silent miscompilation. That set is comptime-derived and self-maintaining. The hand-maintained array that *can* cause one is `isRejectedFormHead`, already missing `define-property` (#1896). Anyone adding a form was being sent to the safe list.

**2. SRFI 148 counts.** Recorded as "134 pass, 8 `test-expect-fail`". Actual: **142 pass, zero**.

**3. Three "open" limitations are fixed** — the `let-syntax` chain producing `define-syntax`, library-body shadowing of `define-record-type`, and the ellipsis leniency (#1791). The shadowing note now records the trap that makes it *look* broken: bind a name from the macro's **pattern**, not one introduced by its template, or hygiene renames it and the test fails for an unrelated reason. I hit that trap myself before getting the real answer.

**4. The SRFI 120 corruption claim does not reproduce.** Both documented entry paths fail cleanly and deterministically, 10/10 runs, because `<timer>` holds a Fiber that `gc_deep_copy` rejects — the single-thread constraint is now engine-enforced, not a live hazard. The re-check's limits (macOS/kqueue, ReleaseSafe, no gc-stress) are recorded alongside it: stale claim, not proof the bug never existed. Single-thread-only remains the supported usage.

**5. SRFI 58 and 163 exclusions** rested on "SRFI 160 has no implementation at all" and "SRFI 4 is a purely portable wrapper". Both false since 4/25/63/160/164/231 shipped. Each entry drops to a single reader-ambiguity blocker, and both SRFIs become re-considerable.

**6. `tests/scheme/CLAUDE.md`'s directory table** omitted six suites that exist and run, and said nothing about the non-recursive globs — the reason `tests/scheme/srfi/slow/` has never run (#1900).

## Two reconnaissance findings corrected by the re-check

- **`srfi148.scm`'s header is accurate, not stale.** #1901 called its #1800/#1801 citations "dead comments"; reading it shows the opposite — it documents both fixes in detail. The note now says to read it rather than distrust it.
- **6 `test-expect-fail` calls repo-wide, 4 in `srfi150.scm`** — not 7/6. Four matches that file's reported "4 expected-fail" exactly, which disproves the claim that two never execute.

## Verification

- Every expander claim reproduced directly; snippets in the commit body's reasoning
- `kaappi test tests/scheme/srfi/srfi120.scm` → **41 passed, 0 failed** after the `.sld` edit
- markdownlint clean

## Notes for review

- `lib/srfi/120.sld` is a **comment-only** change with no user-visible effect, so this needs the `no-changelog` label — I've applied it.
- Stacks on #1904, which ticks Phase 0A. Both touch the tracker's Phase 0 block on adjacent lines; whichever merges second may want a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)