### PR TITLE
Parallelise run-all.sh's shell suites, and stop rebuilding the interpreter twice

### DIFF
--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -243,12 +243,40 @@ runs `kaappi test`'s own acceptance shell tests
 `kaappi test`; nothing forces the switch.
 
 It runs its own `.scm` suites concurrently too, via `KAAPPI_TEST_JOBS`
-(default: one per CPU, `KAAPPI_TEST_JOBS=1` to serialise). Its **shell** suites
-stay sequential: several of them call `ensure_runtime_lib`, which runs
-`zig build lib` and installs into the shared `zig-out/lib`, so concurrent
-scripts would race over one output archive. Parallelising those means giving
-`tests/scheme/shell-common.sh` a build-once guard first — worth doing, since
-they are now the larger half of that script's wall time.
+(default: one per CPU, `KAAPPI_TEST_JOBS=1` to serialise), and its **shell**
+suites at `KAAPPI_SHELL_TEST_JOBS` (default: the same). They get separate knobs
+because a shell script can fork a whole compiler, so a box that wants the
+`.scm` files N-wide does not necessarily want N concurrent `zig build`s.
+
+Three things make that safe and worthwhile (kaappi#1926):
+
+- **One archive, built once.** 18 scripts in `compile/` need
+  `zig-out/lib/libkaappi_rt.a` and each ran `zig build lib` itself, racing
+  over one install. `run-all.sh` now builds it up front and exports
+  `KAAPPI_RT_LIB_READY`, which `ensure_runtime_lib` treats as "already
+  fresh". The marker is advisory: a script run standalone — the Windows CI
+  legs invoke each one directly — sees none and builds its own, as before.
+- **A lock for the builds that remain.** `build_lock`/`build_unlock` in
+  `shell-common.sh` serialise anything that installs into `zig-out/`, using a
+  `mkdir` lock (atomic on POSIX and Git Bash alike; `flock` is Linux-only and
+  macOS has none). A lock whose holder died — `run-all.sh` kills a script that
+  overruns `SHELL_TIMEOUT` — is stolen by the next waiter via the recorded pid.
+- **One interpreter rebuild, not two.** `zig build -Dbundle=…` recompiles the
+  whole interpreter, because the embedded bytecode is part of the compiled
+  module graph; at ~180s on a 4-core runner, the two scripts that needed one
+  were 85% of the shell suites' entire wall time. They now share the fixture
+  in `tests/scheme/compile/fixtures/bundle-replay/`, so the second build is a
+  ~0.2s hit in Zig's own content-addressed cache. `bundle_fixture_binary`
+  regenerates the `.sbc` on every call rather than caching one: identical
+  sources give identical bytes and the hit, while an edit under `src/` changes
+  them and forces exactly the rebuild it must — a cached `.sbc` of our own
+  would go stale against the new binary's build id and fail with
+  `invalid embedded bytecode` (see [cache.md](cache.md)).
+
+Dispatch inside a suite is longest-first — scripts that shell out to a full
+`zig build -D…` go first, found by grep rather than a hand-kept list of names.
+Reporting still walks the glob-sorted order, so a transcript diff between two
+runs stays meaningful at any job count.
 
 ## Tests
 

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -82,12 +82,18 @@ KAAPPI_TEST_SKIP="callcc-bench.scm" bash tests/scheme/run-all.sh
 
 # Run .scm files N at a time (default: one per CPU; 1 = strictly sequential)
 KAAPPI_TEST_JOBS=1 bash tests/scheme/run-all.sh
+
+# Same for the *.sh suites (default: whatever KAAPPI_TEST_JOBS resolved to)
+KAAPPI_SHELL_TEST_JOBS=2 bash tests/scheme/run-all.sh
 ```
 
 The `.scm` suites run concurrently because each file is a fresh interpreter with
-no shared state (see Quirks below). Shell suites (`*.sh`) always run one at a
-time: several call `ensure_runtime_lib`, which builds into the shared
-`zig-out/lib`.
+no shared state (see Quirks below). Shell suites (`*.sh`) run concurrently too
+(kaappi#1926), with their own job count: a shell script can fork a whole
+compiler, so a box that wants the `.scm` files N-wide does not necessarily want
+N concurrent `zig build`s. Their shared state is `zig-out/`, which
+`shell-common.sh` serialises with `build_lock` — a new script that installs
+anything there must take that lock too. See `docs/dev/test-runner.md`.
 
 Results are reported in sorted file order regardless of the job count, so a
 transcript diff between two runs stays meaningful.
@@ -115,9 +121,13 @@ Conventions:
   assertions), `rt_lib_name` (`libkaappi_rt.a` / `kaappi_rt.lib`),
   `skip_without_zig` (skip when the script itself must rebuild with a
   Zig toolchain — boxes running cross-compiled binaries have none, see
-  `docs/dev/freebsd.md`), and `ensure_runtime_lib` (freshen
+  `docs/dev/freebsd.md`), `ensure_runtime_lib` (freshen
   `libkaappi_rt.a` with zig when present, else accept a prebuilt
-  archive so `kaappi compile` tests still run).
+  archive so `kaappi compile` tests still run), `build_lock`/`build_unlock`
+  (serialise anything that installs into `zig-out/`), and
+  `bundle_fixture_binary` (the standalone binary embedding
+  `compile/fixtures/bundle-replay/`, shared so one `zig build -Dbundle`
+  serves every test that needs one).
 - Don't bake POSIX-only spellings into assertions: kaappi prints native
   paths, the runtime archive name is per-platform, and a Windows abort
   exits 3 rather than dying by signal (see `errors/crash-handler.sh`).

--- a/tests/scheme/compile/compile-import-error-703.sh
+++ b/tests/scheme/compile/compile-import-error-703.sh
@@ -6,6 +6,11 @@
 # Without the fix, handleDefineLibrary returns immediately on CompileError,
 # skipping the begin block (so module state is UNDEFINED) and library registration.
 #
+# The project lives in fixtures/bundle-replay/ and is shared with
+# compile-preamble-gc-700.sh, which needs a bundled binary for its own reason:
+# building one recompiles the whole interpreter, so one fixture means one
+# rebuild rather than two (kaappi#1926). Each script asserts only its own line.
+#
 # Usage: bash tests/scheme/compile/compile-import-error-703.sh [path-to-kaappi]
 
 set -euo pipefail
@@ -19,73 +24,32 @@ skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaa
 skip_without_zig "rebuilds the interpreter with -Dbundle on this machine"
 
 KAAPPI="${1:-zig-out/bin/kaappi}"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+FIXTURE="$REPO_DIR/tests/scheme/compile/fixtures/bundle-replay"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 
-mkdir -p "$DIR/lib/myapp"
-
-# Library A: simple leaf
-cat > "$DIR/lib/myapp/util.sld" << 'SCHEME'
-(define-library (myapp util)
-  (import (scheme base))
-  (export greet)
-  (begin
-    (define (greet name) (string-append "Hello, " name "!"))))
-SCHEME
-
-# Library B: depends on A, defines module-level state in begin block
-cat > "$DIR/lib/myapp/app.sld" << 'SCHEME'
-(define-library (myapp app)
-  (import (scheme base) (srfi 69) (myapp util))
-  (export app-greet lookup register!)
-  (begin
-    (define registry (make-hash-table string=? string-hash))
-    (define (register! key val) (hash-table-set! registry key val))
-    (define (lookup key) (hash-table-ref/default registry key #f))
-    (define (app-greet name)
-      (register! name #t)
-      (greet name))))
-SCHEME
-
-# Main program
-cat > "$DIR/main.scm" << 'SCHEME'
-(import (scheme base) (scheme write) (myapp app))
-(display (app-greet "world"))
-(newline)
-(display (lookup "world"))
-(newline)
-SCHEME
+EXPECTED="703: Hello, world! #t"
 
 # Run in interpreter mode — must succeed
-OUTPUT=$("$KAAPPI" --lib-path "$DIR/lib" "$DIR/main.scm" 2>/dev/null)
-if [[ "$OUTPUT" != "Hello, world!"$'\n'"#t" ]]; then
-    echo "FAIL: interpreter mode — expected 'Hello, world!' + '#t', got '$OUTPUT'" >&2
+OUTPUT=$("$KAAPPI" --lib-path "$FIXTURE/lib" "$FIXTURE/main.scm" 2>/dev/null)
+LINE=$(printf '%s\n' "$OUTPUT" | grep '^703: ' || true)
+if [[ "$LINE" != "$EXPECTED" ]]; then
+    echo "FAIL: interpreter mode — expected '$EXPECTED', got '$LINE'" >&2
+    echo "full output: $OUTPUT" >&2
     exit 1
 fi
 
-# Compile to .sbc
-KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
-(cd "$DIR" && "$KAAPPI_ABS" --lib-path lib --compile -o main.sbc main.scm > /dev/null 2>&1)
-
-if [[ ! -f "$DIR/main.sbc" ]]; then
-    echo "FAIL: .sbc file not created" >&2
-    exit 1
-fi
-
-# Build bundled binary into an isolated --prefix so the shared zig-out/bin/kaappi
-# binary -- which run-all.sh and every other test read from a fixed path -- is
-# never touched. Rebuilding it in place here raced the next sequential test's
-# exec of that same path (kaappi#1748).
+# Same program as a bundled binary, where the define-library forms are reached
+# through the preamble replay rather than a plain top-level load.
 BUNDLE_BIN="$DIR/main-standalone"
-REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
-BUNDLE_PREFIX="$DIR/bundle-out"
-(cd "$REPO_DIR" && zig build -Dbundle="$DIR/main.sbc" -Doptimize=ReleaseSafe --prefix "$BUNDLE_PREFIX" 2>/dev/null)
-cp "$BUNDLE_PREFIX/bin/kaappi" "$BUNDLE_BIN"
+bundle_fixture_binary "$REPO_DIR" "$KAAPPI" "$BUNDLE_BIN"
 
-# Run bundled binary — the begin block must have executed (hash table initialized)
 OUTPUT=$("$BUNDLE_BIN" 2>/dev/null)
-if [[ "$OUTPUT" != "Hello, world!"$'\n'"#t" ]]; then
-    echo "FAIL: standalone mode — expected 'Hello, world!' + '#t', got '$OUTPUT'" >&2
+LINE=$(printf '%s\n' "$OUTPUT" | grep '^703: ' || true)
+if [[ "$LINE" != "$EXPECTED" ]]; then
+    echo "FAIL: standalone mode — expected '$EXPECTED', got '$LINE'" >&2
+    echo "full output: $OUTPUT" >&2
     exit 1
 fi

--- a/tests/scheme/compile/compile-preamble-gc-700.sh
+++ b/tests/scheme/compile/compile-preamble-gc-700.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 # Regression test for #700: preamble replay GC root and resilient imports.
-# Creates a multi-library project where a bundled binary must replay preamble
-# imports that trigger nested library loading (stressing GC). Without the
-# expr root in the preamble replay loop, GC corrupts the import-set list.
+# A bundled binary must replay preamble imports that trigger nested library
+# loading (stressing GC). Without the expr root in the preamble replay loop,
+# GC corrupts the import-set list.
+#
+# The multi-library project lives in fixtures/bundle-replay/ and is shared with
+# compile-import-error-703.sh, which needs a bundled binary for its own reason:
+# building one recompiles the whole interpreter, so one fixture means one
+# rebuild rather than two (kaappi#1926). Each script asserts only its own line.
 #
 # Usage: bash tests/scheme/compile/compile-preamble-gc-700.sh [path-to-kaappi]
 
@@ -17,69 +22,13 @@ skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaa
 skip_without_zig "rebuilds the interpreter with -Dbundle on this machine"
 
 KAAPPI="${1:-zig-out/bin/kaappi}"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 
-mkdir -p "$DIR/lib/myapp"
-
-# Leaf library with no dependencies. `sq` (not `square`) -- `square` is
-# itself a (scheme base) export, and main.scm below imports both.
-cat > "$DIR/lib/myapp/util.sld" << 'SCHEME'
-(define-library (myapp util)
-  (import (scheme base))
-  (export double sq)
-  (begin
-    (define (double x) (* x 2))
-    (define (sq x) (* x x))))
-SCHEME
-
-# Middle library depending on util
-cat > "$DIR/lib/myapp/math.sld" << 'SCHEME'
-(define-library (myapp math)
-  (import (scheme base) (myapp util))
-  (export quad)
-  (begin
-    (define (quad x) (double (double x)))))
-SCHEME
-
-# Top library depending on both
-cat > "$DIR/lib/myapp/app.sld" << 'SCHEME'
-(define-library (myapp app)
-  (import (scheme base) (myapp util) (myapp math))
-  (export run-app)
-  (begin
-    (define (run-app n) (+ (quad n) (sq n)))))
-SCHEME
-
-# Main program importing all libraries in one form
-cat > "$DIR/main.scm" << 'SCHEME'
-(import (scheme base) (scheme write) (myapp app) (myapp util))
-(display (run-app 3))
-(display " ")
-(display (double 5))
-(newline)
-SCHEME
-
-# Compile to .sbc (from within temp dir so lib paths are relative)
-KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
-(cd "$DIR" && "$KAAPPI_ABS" --lib-path lib --compile -o main.sbc main.scm > /dev/null 2>&1)
-
-# Verify .sbc was created
-if [[ ! -f "$DIR/main.sbc" ]]; then
-    echo "FAIL: .sbc file not created" >&2
-    exit 1
-fi
-
-# Build bundled binary into an isolated --prefix so the shared zig-out/bin/kaappi
-# binary -- which run-all.sh and every other test read from a fixed path -- is
-# never touched. Rebuilding it in place here raced the next sequential test's
-# exec of that same path (kaappi#1748).
 BUNDLE_BIN="$DIR/main-standalone"
-REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
-BUNDLE_PREFIX="$DIR/bundle-out"
-(cd "$REPO_DIR" && zig build -Dbundle="$DIR/main.sbc" -Doptimize=ReleaseSafe --prefix "$BUNDLE_PREFIX" 2>/dev/null)
-cp "$BUNDLE_PREFIX/bin/kaappi" "$BUNDLE_BIN"
+bundle_fixture_binary "$REPO_DIR" "$KAAPPI" "$BUNDLE_BIN"
 
 # Run the bundled binary — must not crash or show preamble errors
 OUTPUT=$("$BUNDLE_BIN" 2>&1)
@@ -87,7 +36,9 @@ if echo "$OUTPUT" | grep -q "preamble error"; then
     echo "FAIL: preamble error in bundled binary: $OUTPUT" >&2
     exit 1
 fi
-if [[ "$OUTPUT" != "21 10" ]]; then
-    echo "FAIL: expected '21 10', got '$OUTPUT'" >&2
+LINE=$(printf '%s\n' "$OUTPUT" | grep '^700: ' || true)
+if [[ "$LINE" != "700: 21 10" ]]; then
+    echo "FAIL: expected '700: 21 10', got '$LINE'" >&2
+    echo "full output: $OUTPUT" >&2
     exit 1
 fi

--- a/tests/scheme/compile/fixtures/bundle-replay/lib/bundle700/app.sld
+++ b/tests/scheme/compile/fixtures/bundle-replay/lib/bundle700/app.sld
@@ -1,0 +1,6 @@
+;; Top library depending on both — the nested load the preamble replay must
+;; survive (kaappi#700).
+(define-library (bundle700 app)
+  (import (scheme base) (bundle700 util) (bundle700 math))
+  (export run-app)
+  (begin (define (run-app n) (+ (quad n) (sq n)))))

--- a/tests/scheme/compile/fixtures/bundle-replay/lib/bundle700/math.sld
+++ b/tests/scheme/compile/fixtures/bundle-replay/lib/bundle700/math.sld
@@ -1,0 +1,5 @@
+;; Middle library depending on util (kaappi#700).
+(define-library (bundle700 math)
+  (import (scheme base) (bundle700 util))
+  (export quad)
+  (begin (define (quad x) (double (double x)))))

--- a/tests/scheme/compile/fixtures/bundle-replay/lib/bundle700/util.sld
+++ b/tests/scheme/compile/fixtures/bundle-replay/lib/bundle700/util.sld
@@ -1,0 +1,5 @@
+;; Leaf library with no dependencies (kaappi#700).
+(define-library (bundle700 util)
+  (import (scheme base))
+  (export double sq)
+  (begin (define (double x) (* x 2)) (define (sq x) (* x x))))

--- a/tests/scheme/compile/fixtures/bundle-replay/lib/bundle703/app.sld
+++ b/tests/scheme/compile/fixtures/bundle-replay/lib/bundle703/app.sld
@@ -1,0 +1,12 @@
+;; Depends on util and defines module-level state in its begin block. The
+;; multi-import is the point (kaappi#703): when one of its import sets raises a
+;; CompileError, handleDefineLibrary must still run this begin block and
+;; register the exports, or `registry` stays UNDEFINED and `lookup` dies.
+(define-library (bundle703 app)
+  (import (scheme base) (srfi 69) (bundle703 util))
+  (export app-greet lookup register!)
+  (begin
+    (define registry (make-hash-table string=? string-hash))
+    (define (register! key val) (hash-table-set! registry key val))
+    (define (lookup key) (hash-table-ref/default registry key #f))
+    (define (app-greet name) (register! name #t) (greet name))))

--- a/tests/scheme/compile/fixtures/bundle-replay/lib/bundle703/util.sld
+++ b/tests/scheme/compile/fixtures/bundle-replay/lib/bundle703/util.sld
@@ -1,0 +1,5 @@
+;; Leaf library (kaappi#703).
+(define-library (bundle703 util)
+  (import (scheme base))
+  (export greet)
+  (begin (define (greet name) (string-append "Hello, " name "!"))))

--- a/tests/scheme/compile/fixtures/bundle-replay/main.scm
+++ b/tests/scheme/compile/fixtures/bundle-replay/main.scm
@@ -1,0 +1,31 @@
+;; Shared fixture for the two bundled-binary regression tests, kaappi#700 and
+;; kaappi#703. Both need a standalone binary whose preamble replays library
+;; imports, and `zig build -Dbundle=...` recompiles the whole interpreter to
+;; make one. Sharing a single fixture makes the second build a content-cache
+;; hit instead of a second full rebuild (kaappi#1926) — see
+;; bundle_fixture_binary in tests/scheme/shell-common.sh.
+;;
+;; Every library is imported in one form, as kaappi#700 requires. `sq` is not
+;; spelled `square` on purpose: `square` is itself a (scheme base) export, and
+;; this program imports both.
+(import (scheme base)
+        (scheme write)
+        (bundle700 app)
+        (bundle700 util)
+        (bundle703 app))
+
+;; kaappi#700: nested library loading during preamble replay must not corrupt
+;; the import-set list under GC. (run-app 3) = (+ (quad 3) (sq 3)) = 12 + 9.
+(display "700: ")
+(display (run-app 3))
+(display " ")
+(display (double 5))
+(newline)
+
+;; kaappi#703: (bundle703 app)'s begin block must have run, so `registry` is a
+;; live hash table rather than UNDEFINED.
+(display "703: ")
+(display (app-greet "world"))
+(display " ")
+(display (lookup "world"))
+(newline)

--- a/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
+++ b/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
@@ -26,9 +26,7 @@ REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 
-if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
-    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
-fi
+ensure_runtime_lib "$REPO_DIR"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT

--- a/tests/scheme/compile/native-let-partial-emit-dup-1586.sh
+++ b/tests/scheme/compile/native-let-partial-emit-dup-1586.sh
@@ -40,9 +40,7 @@ KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
-    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
-fi
+ensure_runtime_lib "$REPO_DIR"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT

--- a/tests/scheme/compile/native-let-tail-root-leak-1585.sh
+++ b/tests/scheme/compile/native-let-tail-root-leak-1585.sh
@@ -35,9 +35,7 @@ KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
-    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
-fi
+ensure_runtime_lib "$REPO_DIR"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT

--- a/tests/scheme/compile/native-rebind-stale-call-822.sh
+++ b/tests/scheme/compile/native-rebind-stale-call-822.sh
@@ -25,9 +25,7 @@ KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
-    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
-fi
+ensure_runtime_lib "$REPO_DIR"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT

--- a/tests/scheme/compile/native-set-capture-divergence-1422.sh
+++ b/tests/scheme/compile/native-set-capture-divergence-1422.sh
@@ -27,9 +27,7 @@ KAAPPI="${1:-zig-out/bin/kaappi}"
 KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
-    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
-fi
+ensure_runtime_lib "$REPO_DIR"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT

--- a/tests/scheme/compile/set-define-lexical-scope-819.sh
+++ b/tests/scheme/compile/set-define-lexical-scope-819.sh
@@ -24,9 +24,7 @@ KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 
 # `kaappi compile` needs libkaappi_rt.a (searched in <exe_dir>/../lib).
-if [[ ! -f "$REPO_DIR/zig-out/lib/libkaappi_rt.a" ]]; then
-    (cd "$REPO_DIR" && zig build lib > /dev/null 2>&1)
-fi
+ensure_runtime_lib "$REPO_DIR"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -24,10 +24,9 @@ KAAPPI=zig-out/bin/kaappi
 KAAPPI_HOME_TMP=$(mktemp -d /tmp/kaappi-test-home-XXXXXX)
 export KAAPPI_HOME="$KAAPPI_HOME_TMP"
 
-TMPOUT=$(mktemp /tmp/kaappi-test-XXXXXX)
 TMPSTDOUT=$(mktemp /tmp/kaappi-r7rs-stdout-XXXXXX)
 TMPSTDERR=$(mktemp /tmp/kaappi-r7rs-stderr-XXXXXX)
-trap 'rm -f "$TMPOUT" "$TMPSTDOUT" "$TMPSTDERR"; rm -rf "$KAAPPI_HOME_TMP"' EXIT
+trap 'rm -f "$TMPSTDOUT" "$TMPSTDERR"; rm -rf "$KAAPPI_HOME_TMP"' EXIT
 
 TIMEOUT="${KAAPPI_TEST_TIMEOUT:-60}"
 # Shell-suite tests do real work (native compiles, sometimes a `zig build`) so
@@ -41,9 +40,12 @@ SHELL_TIMEOUT="${KAAPPI_SHELL_TEST_TIMEOUT:-300}"
 # How many .scm files to run at once. Each file is a fresh interpreter with no
 # shared state (see tests/scheme/CLAUDE.md), so they parallelise cleanly — the
 # suite's own audit found no cross-file collisions on fixed paths or ports.
-# Shell suites stay sequential: they do native compiles and `zig build` into a
-# shared .zig-cache, which is a different (unaudited) contention story.
-# KAAPPI_TEST_JOBS=1 restores the old strictly-sequential behaviour.
+# The shell suites run concurrently too (kaappi#1926), at KAAPPI_SHELL_TEST_JOBS
+# — their contention is over the one zig-out/ that `zig build` installs into,
+# which tests/scheme/shell-common.sh now serialises with a lock. They get their
+# own knob because each script can fork a whole compiler: a box that wants the
+# .scm files N-wide does not necessarily want N concurrent `zig build`s.
+# KAAPPI_TEST_JOBS=1 restores the old strictly-sequential behaviour for both.
 detect_jobs() {
     local n=""
     n=$(getconf _NPROCESSORS_ONLN 2>/dev/null) \
@@ -56,8 +58,9 @@ detect_jobs() {
     esac
 }
 JOBS="${KAAPPI_TEST_JOBS:-$(detect_jobs)}"
+SHELL_JOBS="${KAAPPI_SHELL_TEST_JOBS:-$JOBS}"
 
-# Reject a bad KAAPPI_TEST_JOBS loudly. `[[ $running -ge $JOBS ]]` evaluates its
+# Reject a bad job count loudly. `[[ $running -ge $JOBS ]]` evaluates its
 # operands arithmetically, where a non-numeric value is silently 0 — so
 # KAAPPI_TEST_JOBS=abc would not fail, it would just quietly serialise the run
 # with a spurious `wait` per file. A typo in a CI env var should not cost a
@@ -65,6 +68,12 @@ JOBS="${KAAPPI_TEST_JOBS:-$(detect_jobs)}"
 case "$JOBS" in
     ''|*[!0-9]*|0)
         echo "run-all.sh: KAAPPI_TEST_JOBS must be a positive integer (got '${KAAPPI_TEST_JOBS:-}')" >&2
+        exit 2
+        ;;
+esac
+case "$SHELL_JOBS" in
+    ''|*[!0-9]*|0)
+        echo "run-all.sh: KAAPPI_SHELL_TEST_JOBS must be a positive integer (got '${KAAPPI_SHELL_TEST_JOBS:-}')" >&2
         exit 2
         ;;
 esac
@@ -257,52 +266,164 @@ run_suite() {
     echo ""
 }
 
+# Same shape as run_file_worker: record the verdict, never touch the counters.
+run_shell_worker() {
+    local script="$1" slot="$2"
+    local pid status
+    KAAPPI="$KAAPPI" bash "$script" "$KAAPPI" > "$slot.out" 2>&1 &
+    pid=$!
+    if wait_with_timeout "$pid" "$SHELL_TIMEOUT"; then
+        status=0
+        wait "$pid" || status=$?
+    else
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        echo "TIMEOUT" > "$slot.rec"
+        return 0
+    fi
+    case $status in
+        0) echo "PASS" > "$slot.rec" ;;
+        # Exit 77 = SKIP (shell-common.sh skip_on_windows/skip_without_zig/
+        # skip_on_debug_build): the script's premise cannot hold here.
+        77) echo "SKIP" > "$slot.rec" ;;
+        *) echo "FAIL" > "$slot.rec" ;;
+    esac
+    return 0
+}
+
+report_shell_result() {
+    local script="$1" slot="$2"
+    local kind=""
+    [[ -f "$slot.rec" ]] && kind=$(cat "$slot.rec")
+    case "$kind" in
+        PASS)
+            echo "  PASS  $script"
+            PASS=$((PASS + 1))
+            ;;
+        SKIP)
+            echo "  SKIP  $script"
+            SKIPPED=$((SKIPPED + 1))
+            ;;
+        TIMEOUT)
+            echo "  TIMEOUT  $script  (killed after ${SHELL_TIMEOUT}s)"
+            [[ -f "$slot.out" ]] && cat "$slot.out"
+            TIMEDOUT=$((TIMEDOUT + 1))
+            ;;
+        NOTEXEC)
+            echo "  FAIL  $script  (not executable)"
+            FAIL=$((FAIL + 1))
+            ;;
+        *)
+            echo "  FAIL  $script"
+            [[ -f "$slot.out" ]] && cat "$slot.out"
+            FAIL=$((FAIL + 1))
+            ;;
+    esac
+}
+
+# A script that rebuilds the whole interpreter takes minutes, where every other
+# script takes seconds. With a pool of N, when those start matters far more than
+# N does, so they go first. Derived by grep rather than a hand-kept list of
+# names, so a future rebuild-shaped script sorts itself; a wrong answer here
+# costs makespan, never a verdict. Both spellings count: a script that runs the
+# build itself, and one that goes through shell-common.sh's shared fixture
+# (where only the first caller pays, but which one that is isn't known here).
+is_slow_shell_test() {
+    # `^[^#]*`: skip comment lines, several of which mention the build they
+    # deliberately do not run.
+    grep -Eq '^[^#]*(zig build -D|bundle_fixture_binary)' "$1" 2>/dev/null
+}
+
 run_shell_suite() {
     local title="$1" dir="$2"
-    local matched=0 pid status
     echo "=== $title ==="
+
+    # Collect first, so the run can be dispatched $SHELL_JOBS-at-a-time and
+    # still be reported in a stable, glob-sorted order.
+    local scripts=()
+    local test_script
     for test_script in "$dir"/*.sh; do
         [[ -e "$test_script" ]] || continue
-        if [[ ! -x "$test_script" ]]; then
-            echo "  FAIL  $test_script  (not executable)"
-            FAIL=$((FAIL + 1))
-            continue
-        fi
-        matched=1
-        KAAPPI="$KAAPPI" bash "$test_script" "$KAAPPI" > "$TMPOUT" 2>&1 &
-        pid=$!
-        if wait_with_timeout "$pid" "$SHELL_TIMEOUT"; then
-            status=0
-            wait "$pid" || status=$?
-        else
-            kill "$pid" 2>/dev/null || true
-            wait "$pid" 2>/dev/null || true
-            echo "  TIMEOUT  $test_script  (killed after ${SHELL_TIMEOUT}s)"
-            cat "$TMPOUT"
-            TIMEDOUT=$((TIMEDOUT + 1))
-            continue
-        fi
-        if [[ $status -eq 0 ]]; then
-            echo "  PASS  $test_script"
-            PASS=$((PASS + 1))
-        elif [[ $status -eq 77 ]]; then
-            # Exit 77 = SKIP (shell-common.sh skip_on_windows/skip_without_zig/
-            # skip_on_debug_build): the script's premise cannot hold here.
-            echo "  SKIP  $test_script"
-            SKIPPED=$((SKIPPED + 1))
-        else
-            echo "  FAIL  $test_script"
-            cat "$TMPOUT"
-            FAIL=$((FAIL + 1))
-        fi
+        scripts[${#scripts[@]}]="$test_script"
     done
-    if [[ $matched -eq 0 ]]; then
+
+    if [[ ${#scripts[@]} -eq 0 ]]; then
         echo "  (no tests matched)"
+        echo ""
+        return
     fi
+
+    local slotdir
+    slotdir=$(mktemp -d "${TMPDIR:-/tmp}/kaappi-shell-XXXXXX")
+
+    # Dispatch order is a list of indices into $scripts, slow ones first; the
+    # report below still walks 0..n-1, so the printed order never moves.
+    local order=() i=0
+    while [[ $i -lt ${#scripts[@]} ]]; do
+        if [[ ! -x "${scripts[$i]}" ]]; then
+            echo "NOTEXEC" > "$slotdir/$i.rec"
+        elif is_slow_shell_test "${scripts[$i]}"; then
+            order[${#order[@]}]=$i
+        fi
+        i=$((i + 1))
+    done
+    i=0
+    while [[ $i -lt ${#scripts[@]} ]]; do
+        if [[ -x "${scripts[$i]}" ]] && ! is_slow_shell_test "${scripts[$i]}"; then
+            order[${#order[@]}]=$i
+        fi
+        i=$((i + 1))
+    done
+
+    local running=0 idx
+    i=0
+    while [[ $i -lt ${#order[@]} ]]; do
+        if [[ $running -ge $SHELL_JOBS ]]; then
+            if [[ $HAVE_WAIT_N -eq 1 ]]; then
+                wait -n 2>/dev/null || true
+                running=$((running - 1))
+            else
+                wait || true
+                running=0
+            fi
+        fi
+        idx=${order[$i]}
+        run_shell_worker "${scripts[$idx]}" "$slotdir/$idx" &
+        running=$((running + 1))
+        i=$((i + 1))
+    done
+    wait || true
+
+    i=0
+    while [[ $i -lt ${#scripts[@]} ]]; do
+        report_shell_result "${scripts[$i]}" "$slotdir/$i"
+        i=$((i + 1))
+    done
+
+    rm -rf "$slotdir"
     echo ""
 }
 
 echo "Running .scm suites with $JOBS parallel job(s) (override: KAAPPI_TEST_JOBS)."
+echo "Running shell suites with $SHELL_JOBS parallel job(s) (override: KAAPPI_SHELL_TEST_JOBS)."
+
+# Build the native runtime archive once, up front. 18 scripts in the compile
+# suite need it and each used to run `zig build lib` itself — 18 redundant
+# builds installing into one zig-out/lib, which is exactly the race that kept
+# the shell suites sequential (kaappi#1926). Doing it here and exporting the
+# marker turns every one of those into a no-op. The marker is advisory: a
+# script that does not see it builds its own archive as before, which is what
+# the Windows CI legs (they invoke each script directly) rely on.
+if command -v zig > /dev/null 2>&1; then
+    # Says so out loud: cold, this is a minute of silence before the first
+    # suite prints anything.
+    echo "Building the native runtime archive (zig build lib) once, up front."
+    if zig build lib > /dev/null 2>&1; then
+        export KAAPPI_RT_LIB_READY=1
+    else
+        echo "  WARN  zig build lib failed; compile scripts will each retry it"
+    fi
+fi
 echo ""
 
 run_suite "Smoke tests" tests/scheme/smoke/*.scm

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -72,16 +72,140 @@ skip_on_debug_build() {
     fi
 }
 
+# --- build serialisation -------------------------------------------------
+#
+# Several scripts shell out to `zig build …`, which installs into the repo's
+# single zig-out/. run-all.sh runs the shell suites concurrently (kaappi#1926),
+# so two of them can reach that install at the same time and one can observe a
+# half-written artefact. `zig build` locks its own cache, but the install copy
+# happens outside that lock, so the suites take a lock of their own.
+#
+# mkdir is the portable atomic test-and-set — it fails when the directory
+# already exists, on POSIX and under Git Bash alike. flock is Linux-only and
+# absent from macOS entirely.
+#
+# The lock lives under .zig-cache/, which is gitignored: a lock file inside the
+# tracked tree would make the worktree dirty, and a dirty tree changes the
+# build id baked into every .sbc (docs/dev/cache.md).
+
+build_lock_dir() {
+    printf '%s/.zig-cache/kaappi-test-%s.lock\n' "$1" "$2"
+}
+
+# build_lock <repo-dir> <name>: block until the named lock is ours.
+build_lock() {
+    local lock waited holder
+    lock=$(build_lock_dir "$1" "$2")
+    mkdir -p "$1/.zig-cache" 2> /dev/null || true
+    waited=0
+    while ! mkdir "$lock" 2> /dev/null; do
+        # Steal a lock whose holder is gone. run-all.sh kills a script that
+        # overruns SHELL_TIMEOUT, and a dead holder's lock would otherwise
+        # stall every later script for the rest of the run.
+        holder=$(cat "$lock/pid" 2> /dev/null || true)
+        if [ -n "$holder" ] && ! kill -0 "$holder" 2> /dev/null; then
+            rm -rf "$lock"
+            continue
+        fi
+        sleep 1
+        waited=$((waited + 1))
+        # Last resort, for a holder that is alive but wedged: 15 minutes is
+        # well past the slowest thing anyone holds this for (a full
+        # interpreter rebuild, ~3 minutes on a 4-core runner).
+        if [ "$waited" -ge 900 ]; then
+            echo "warning: stealing $lock after ${waited}s" >&2
+            rm -rf "$lock"
+        fi
+    done
+    echo $$ > "$lock/pid"
+}
+
+# build_unlock <repo-dir> <name>: release it.
+build_unlock() {
+    rm -rf "$(build_lock_dir "$1" "$2")"
+}
+
 # ensure_runtime_lib <repo-dir>: freshen the native runtime archive via
 # `zig build lib` when a toolchain is present. Without one, accept an
 # already-built archive (cross-compiled and copied to the box) so the
 # `kaappi compile` + C-compiler part of the test still runs; skip-77
 # only when neither exists.
 ensure_runtime_lib() {
+    local lib rt_status
+    lib="$1/zig-out/lib/$(rt_lib_name)"
+
+    # run-all.sh builds the archive once, up front, and exports the marker:
+    # every call here is then a no-op instead of 18 redundant builds racing
+    # each other's install. The marker is an optimisation, never a
+    # requirement — a script run standalone (the Windows CI legs invoke each
+    # one directly) sees no marker and takes the path below, as before.
+    if [ -n "${KAAPPI_RT_LIB_READY:-}" ] && [ -f "$lib" ]; then
+        return 0
+    fi
+
     if command -v zig > /dev/null 2>&1; then
-        (cd "$1" && zig build lib > /dev/null 2>&1)
-    elif [ ! -f "$1/zig-out/lib/$(rt_lib_name)" ]; then
+        build_lock "$1" rt-lib
+        rt_status=0
+        (cd "$1" && zig build lib > /dev/null 2>&1) || rt_status=$?
+        build_unlock "$1" rt-lib
+        return "$rt_status"
+    elif [ ! -f "$lib" ]; then
         echo "SKIP: no zig toolchain and no prebuilt zig-out/lib/$(rt_lib_name)"
         exit 77
     fi
+}
+
+# bundle_fixture_binary <repo-dir> <kaappi> <dest>: build the standalone binary
+# that embeds tests/scheme/compile/fixtures/bundle-replay, and copy it to
+# <dest>. Callers must have passed skip_without_zig first.
+#
+# `zig build -Dbundle=…` recompiles the whole interpreter — the embedded
+# bytecode is part of the compiled module graph — which is ~180s on a 4-core
+# runner. Two regression tests need such a binary (kaappi#700 and kaappi#703),
+# and paying for it twice was 85% of the shell suites' entire wall time
+# (kaappi#1926). They share one fixture program instead, so the second caller's
+# build is a ~0.2s hit in Zig's own content-addressed cache.
+#
+# Regenerating the .sbc on every call is what keeps that honest: it is
+# deterministic, so unchanged sources give byte-identical bytes and a cache
+# hit, while an edit under src/ changes them and forces exactly the rebuild it
+# must. A cached .sbc of our own would instead go stale against the rebuilt
+# binary's build id and fail with `invalid embedded bytecode` (docs/dev/cache.md).
+#
+# The binary is copied to the caller's own <dest> before it is ever run: the
+# shared install path is written by whichever script holds the lock, and
+# exec'ing a path another script may be reinstalling is exactly the race that
+# kaappi#1748 fixed.
+bundle_fixture_binary() {
+    # `rc`, not `status`: this file is sourced, and `status` is read-only in
+    # some shells.
+    local repo="$1" kaappi="$2" dest="$3" fixture out sbc kaappi_abs log rc
+    fixture="$repo/tests/scheme/compile/fixtures/bundle-replay"
+    out="$repo/.zig-cache/kaappi-test-fixtures"
+    sbc="$out/bundle-replay.sbc"
+    kaappi_abs="$(cd "$(dirname "$kaappi")" && pwd)/$(basename "$kaappi")"
+    log=$(mktemp)
+
+    build_lock "$repo" bundle-fixture
+    rc=0
+    (
+        mkdir -p "$out"
+        # Compile from inside the fixture directory so the paths recorded in
+        # the .sbc are relative, and its bytes therefore identical run to run.
+        cd "$fixture" &&
+            "$kaappi_abs" --lib-path lib --compile -o "$sbc" main.scm &&
+            [ -f "$sbc" ] &&
+            cd "$repo" &&
+            zig build -Dbundle="$sbc" -Doptimize=ReleaseSafe \
+                --prefix "$out/prefix" &&
+            cp "$out/prefix/bin/kaappi" "$dest"
+    ) > "$log" 2>&1 || rc=$?
+    build_unlock "$repo" bundle-fixture
+
+    if [ "$rc" -ne 0 ]; then
+        echo "FAIL: could not build the bundled fixture binary" >&2
+        cat "$log" >&2
+    fi
+    rm -f "$log"
+    return "$rc"
 }


### PR DESCRIPTION
Closes #1926.

The issue was right that the blocker and the cost are different things, so this fixes both.

## The cost: two full interpreter rebuilds → one

`zig build -Dbundle=…` recompiles the whole interpreter — the embedded bytecode is part of the compiled module graph — and the two scripts that need a standalone binary (#700, #703) each paid for one. That was 85% of the shell suites' entire wall time, for two tests.

They needed *different* embedded bytecode only because each carried its own heredoc fixture. They now share one, in `tests/scheme/compile/fixtures/bundle-replay/`, and each still asserts only its own line. Measured directly on this box, back to back:

| | before | after |
|---|--:|--:|
| `compile-preamble-gc-700.sh` | 42s | 42s |
| `compile-import-error-703.sh` | 35s | **0.56s** |

The second is a hit in Zig's own content-addressed cache — confirmed that `--prefix` does not affect it, so each script still installs into its own temp dir and never execs a path another script may be rewriting (#1748).

`bundle_fixture_binary` regenerates the `.sbc` on every call rather than caching one. That is what keeps it honest: the compile is deterministic, so unchanged sources give byte-identical bytes and the cache hit, while an edit under `src/` changes them and forces exactly the rebuild it must. A cached `.sbc` of our own would instead go stale against the rebuilt binary's build id and fail with `invalid embedded bytecode` — the trap the issue's own measurement notes hit.

## The blocker: one archive, built once, behind a lock

- `run-all.sh` builds the runtime archive up front and exports `KAAPPI_RT_LIB_READY`; `ensure_runtime_lib` treats it as "already fresh". It is advisory — a script run standalone sees no marker and builds its own, which is what the Windows CI legs rely on.
- What builds remain take a `mkdir`-based lock (atomic on POSIX and Git Bash alike; `flock` is Linux-only and macOS has none). A lock whose holder was killed — `run-all.sh` kills a script that overruns `SHELL_TIMEOUT` — is stolen by the next waiter via the recorded pid, so one timeout cannot stall the rest of the run.
- **Six scripts the issue did not count** had their own inline copy of the archive build, gated only on the file's *existence* — the more dangerous half of the same race. They go through `ensure_runtime_lib` now, so one guard covers all 18.

## Dispatch

Shell suites run at `KAAPPI_SHELL_TEST_JOBS` (default: whatever `KAAPPI_TEST_JOBS` resolved to). Separate knob because a shell script can fork a whole compiler. Longest-first inside a suite, derived by grep rather than a hand-kept list of names, so a future rebuild-shaped script sorts itself; reporting still walks glob order.

## Verification

Against the three criteria in the issue:

- **Same verdicts, same order.** Full run vs `KAAPPI_TEST_JOBS=1`: the transcripts differ in exactly two lines, both reporting the job count. Every verdict and every per-file line is identical. 2026 pass / 0 fail either way.
- **No torn archive under concurrency.** Four `ensure_runtime_lib` callers started together against a *deleted* archive, no marker: all pass, archive intact. An 8-way mutual-exclusion probe on the lock never overlaps, and a dead holder's lock is stolen immediately.
- **Standalone still works.** All 59 shell scripts run one at a time with no marker set, the way the Windows legs invoke them: 59 pass, 0 fail.

Both bundle tests were also mutation-tested — breaking #700's nested-library result fails only `compile-preamble-gc-700.sh`, breaking #703's begin-block state fails only `compile-import-error-703.sh` — so sharing a fixture did not couple their verdicts.

Full suite on this 12-core box, both cold for the bundle build: **475s → 245s**, same 2026 pass / 0 fail. The ~2x ceiling the issue predicted holds; most of it is the rebuild that no longer happens, not the concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)