### PR TITLE
Stop three diagnostics from misdescribing what they are about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Import cost is unchanged and every char set is immutable once built.
   `tools/gen_srfi115_charsets.py` is now `tools/gen_srfi_charsets.py`, with a
   `--target {115,14}` selector.
+- **Three diagnostics that misdescribed the value or the procedure they were
+  about** (#1916). An integral flonum rendered in a type error without its
+  `.0`, so `(vector-ref v 1.0)` reported "expected exact integer, got 1" —
+  and 1 *is* an exact integer, leaving the message arguing against itself.
+  Error messages now render flonums through the printer, so `1.0`, `+inf.0`
+  and `1.0e+30` read as they do everywhere else; this affects every type
+  error, not just the numeric-vector ones. Separately, a multi-limb bignum
+  handed to a `(srfi 160)` constructor was reported as "expected exact
+  integer, got #<bignum>" — it is an exact integer, and its only fault was
+  not fitting the element kind, so it now says "in-range" (or "non-negative"
+  when the value is negative), matching what an out-of-range fixnum has
+  always said. Finally, `%record?` and `%transcoded-port` reported their
+  errors under the names `record?` and `transcoded-port` — each a real and
+  *different* procedure, exported by `(srfi 237)` and `(srfi 181)`
+  respectively, with a different argument list — so a reader who followed the
+  message landed on the wrong procedure. Both now name themselves, via the
+  shared-constant convention `primitives_srfi237.zig` already used for
+  exactly this reason.
 
 ## [0.22.1] - 2026-07-31
 

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
+const printer = @import("printer.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 
@@ -250,6 +251,14 @@ const BR = LS.initMany(&.{ .scheme_base, .scheme_r5rs });
 const BRS1 = LS.initMany(&.{ .scheme_base, .scheme_r5rs, .srfi_1 });
 const BCRS1 = LS.initMany(&.{ .scheme_base, .scheme_cxr, .scheme_r5rs, .srfi_1 });
 
+/// Shared by the spec entry and every error this primitive reports, so the name
+/// a caller sees can never drift from the name it called -- the same convention
+/// `primitives_srfi237.zig`'s `MAKE_RTD` follows. It matters more here than for
+/// most: drop the `%` and the message names `record?`, a real and *different*
+/// procedure `lib/srfi/237.sld` exports, which takes one argument rather than
+/// two (kaappi#1916).
+const RECORD_CHECK = "%record?";
+
 const core_specs = [_]PrimSpec{
     .{ .name = "cons", .func = &cons, .arity = .{ .exact = 2 }, .libs = BRS1 },
     .{ .name = "car", .func = &car, .arity = .{ .exact = 1 }, .libs = BRS1 },
@@ -298,7 +307,7 @@ const core_specs = [_]PrimSpec{
     // not `(scheme base)` exports (kaappi#1856).
     .{ .name = "%make-record-type", .func = &makeRecordTypeFn, .arity = .{ .exact = 2 }, .libs = INTERNAL_PUBLIC },
     .{ .name = "%make-record", .func = &makeRecordFn, .arity = .{ .variadic = 1 }, .libs = INTERNAL_PUBLIC },
-    .{ .name = "%record?", .func = &recordCheckFn, .arity = .{ .exact = 2 }, .libs = INTERNAL_PUBLIC },
+    .{ .name = RECORD_CHECK, .func = &recordCheckFn, .arity = .{ .exact = 2 }, .libs = INTERNAL_PUBLIC },
     .{ .name = "%record-ref", .func = &recordRefFn, .arity = .{ .exact = 3 }, .libs = INTERNAL_PUBLIC },
     .{ .name = "%record-set!", .func = &recordSetFn, .arity = .{ .exact = 4 }, .libs = INTERNAL_PUBLIC },
     .{ .name = "apply", .func = &applyFn, .arity = .{ .variadic = 2 }, .libs = BR },
@@ -561,7 +570,13 @@ fn safeValueDescription(buf: *[128]u8, value: Value) []const u8 {
     if (value == types.EOF) return "#<eof>";
     if (types.isChar(value)) return "#<char>";
     if (types.isFlonum(value)) {
-        return std.fmt.bufPrint(buf, "{d}", .{types.toFlonum(value)}) catch "?";
+        // Via the printer, not a bare `{d}`, so an integral flonum keeps its
+        // `.0`. Without it `(… 1.0)` reported "expected exact integer, got 1",
+        // and 1 *is* an exact integer -- the message argued against itself
+        // (kaappi#1916). Safe in this deliberately-defensive helper: a flonum
+        // is inline under NaN-boxing, so `formatFlonum` reads no heap and
+        // handles NaN/Inf itself.
+        return printer.formatFlonum(buf, types.toFlonum(value));
     }
     if (types.isPointer(value)) {
         const addr = @as(usize, @truncate(value));
@@ -1043,7 +1058,7 @@ fn makeRecordFn(args: []const Value) PrimitiveError!Value {
 
 fn recordCheckFn(args: []const Value) PrimitiveError!Value {
     // args[0] = value to check, args[1] = record_type
-    if (!types.isRecordType(args[1])) return typeError("record?", "record-type", args[1]);
+    if (!types.isRecordType(args[1])) return typeError(RECORD_CHECK, "record-type", args[1]);
     const rt = types.toObject(args[1]).as(types.RecordType);
     if (!types.isRecordInstance(args[0])) return types.FALSE;
     const ri = types.toObject(args[0]).as(types.RecordInstance);

--- a/src/primitives_srfi160.zig
+++ b/src/primitives_srfi160.zig
@@ -74,22 +74,39 @@ fn parseKind(name: []const u8) ?NumericElementKind {
 
 const MagSign = struct { mag: u64, positive: bool };
 
-fn magnitudeAndSign(val: Value) ?MagSign {
+/// Keeping `.too_wide` distinct from `.not_exact` is what stops a multi-limb
+/// bignum from being reported as the wrong *type*: it genuinely is an exact
+/// integer, so collapsing the two (as a plain `?MagSign` did) answered
+/// "expected exact integer, got #<bignum>" and pointed the reader at a problem
+/// that isn't there -- the value's only fault is not fitting s8..u64
+/// (kaappi#1916). `.too_wide` carries the sign because the unsigned case
+/// distinguishes "negative" from "too large", exactly as it does for a fixnum.
+const ExactMag = union(enum) {
+    fits: MagSign,
+    too_wide: struct { positive: bool },
+    not_exact,
+};
+
+fn magnitudeAndSign(val: Value) ExactMag {
     if (types.isFixnum(val)) {
         const n = types.toFixnum(val);
-        return .{ .mag = if (n < 0) @intCast(-n) else @intCast(n), .positive = n >= 0 };
+        return .{ .fits = .{ .mag = if (n < 0) @intCast(-n) else @intCast(n), .positive = n >= 0 } };
     }
     if (types.isBignum(val)) {
         const bn = types.toBignum(val);
-        if (bn.len == 0) return .{ .mag = 0, .positive = true };
-        if (bn.len > 1) return null;
-        return .{ .mag = bn.limbs[0], .positive = bn.positive };
+        if (bn.len == 0) return .{ .fits = .{ .mag = 0, .positive = true } };
+        if (bn.len > 1) return .{ .too_wide = .{ .positive = bn.positive } };
+        return .{ .fits = .{ .mag = bn.limbs[0], .positive = bn.positive } };
     }
-    return null;
+    return .not_exact;
 }
 
 fn expectSignedInRange(proc: []const u8, val: Value, comptime bits: u7) PrimitiveError!i64 {
-    const ms = magnitudeAndSign(val) orelse return typeError(proc, "exact integer", val);
+    const ms = switch (magnitudeAndSign(val)) {
+        .fits => |m| m,
+        .too_wide => return typeError(proc, "in-range signed integer", val),
+        .not_exact => return typeError(proc, "exact integer", val),
+    };
     const shift: u6 = bits - 1;
     const max_mag_pos: u64 = (@as(u64, 1) << shift) - 1;
     const max_mag_neg: u64 = @as(u64, 1) << shift;
@@ -109,7 +126,13 @@ fn expectSignedInRange(proc: []const u8, val: Value, comptime bits: u7) Primitiv
 }
 
 fn expectUnsignedInRange(proc: []const u8, val: Value, comptime bits: u7) PrimitiveError!u64 {
-    const ms = magnitudeAndSign(val) orelse return typeError(proc, "exact integer", val);
+    const ms = switch (magnitudeAndSign(val)) {
+        .fits => |m| m,
+        // A negative one is rejected for being negative, not for being wide --
+        // the same reason, and the same message, a negative fixnum gets below.
+        .too_wide => |w| return typeError(proc, if (w.positive) "in-range unsigned integer" else "non-negative integer", val),
+        .not_exact => return typeError(proc, "exact integer", val),
+    };
     if (!ms.positive and ms.mag != 0) return typeError(proc, "non-negative integer", val);
     const max_mag: u64 = if (bits == 64) std.math.maxInt(u64) else blk: {
         const shift: u6 = bits;

--- a/src/primitives_srfi181.zig
+++ b/src/primitives_srfi181.zig
@@ -65,6 +65,15 @@ const LS = primitives.LibSet;
 
 const SRFI181 = LS.initOne(.srfi_181_primitives);
 
+/// Shared by the spec entry and every error this primitive reports, so the name
+/// a caller sees can never drift from the name it called -- the same convention
+/// `primitives_srfi237.zig`'s `MAKE_RTD` follows. It matters more here than for
+/// most: drop the `%` and the message names `transcoded-port`, a real and
+/// *different* procedure `lib/srfi/181.sld` exports, whose second argument is a
+/// transcoder record rather than this one's three unpacked symbols
+/// (kaappi#1916).
+const TRANSCODED_PORT = "%transcoded-port";
+
 pub const specs = [_]primitives.PrimSpec{
     .{ .name = "make-custom-binary-input-port", .func = &makeCustomBinaryInputPort, .arity = .{ .exact = 5 }, .libs = SRFI181 },
     .{ .name = "make-custom-binary-output-port", .func = &makeCustomBinaryOutputPort, .arity = .{ .variadic = 5 }, .libs = SRFI181 },
@@ -72,7 +81,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "make-custom-textual-output-port", .func = &makeCustomTextualOutputPort, .arity = .{ .variadic = 5 }, .libs = SRFI181 },
     .{ .name = "make-custom-binary-input/output-port", .func = &makeCustomBinaryInputOutputPort, .arity = .{ .variadic = 6 }, .libs = SRFI181 },
     .{ .name = "make-file-error", .func = &makeFileError, .arity = .{ .variadic = 0 }, .libs = SRFI181 },
-    .{ .name = "%transcoded-port", .func = &transcodedPortPrim, .arity = .{ .exact = 4 }, .libs = SRFI181 },
+    .{ .name = TRANSCODED_PORT, .func = &transcodedPortPrim, .arity = .{ .exact = 4 }, .libs = SRFI181 },
     .{ .name = "i/o-decoding-error?", .func = &ioDecodingErrorP, .arity = .{ .exact = 1 }, .libs = SRFI181 },
     .{ .name = "i/o-encoding-error?", .func = &ioEncodingErrorP, .arity = .{ .exact = 1 }, .libs = SRFI181 },
     .{ .name = "i/o-encoding-error-char", .func = &ioEncodingErrorCharFn, .arity = .{ .exact = 1 }, .libs = SRFI181 },
@@ -204,13 +213,13 @@ fn symbolToErrorMode(v: Value) ?types.ErrorMode {
 /// binary-port's own directions, per the spec ("a new textual port ...
 /// from binary-port"), not passed separately.
 fn transcodedPortPrim(args: []const Value) PrimitiveError!Value {
-    if (!types.isPort(args[0])) return primitives.typeError("transcoded-port", "port", args[0]);
+    if (!types.isPort(args[0])) return primitives.typeError(TRANSCODED_PORT, "port", args[0]);
     const binary_port = types.toObject(args[0]).as(types.Port);
-    if (!binary_port.is_binary) return primitives.typeError("transcoded-port", "binary port", args[0]);
+    if (!binary_port.is_binary) return primitives.typeError(TRANSCODED_PORT, "binary port", args[0]);
 
-    const codec = symbolToCodec(args[1]) orelse return primitives.typeError("transcoded-port", "recognized codec", args[1]);
-    const eol_style = symbolToEolStyle(args[2]) orelse return primitives.typeError("transcoded-port", "recognized eol-style", args[2]);
-    const error_mode = symbolToErrorMode(args[3]) orelse return primitives.typeError("transcoded-port", "recognized error-handling-mode", args[3]);
+    const codec = symbolToCodec(args[1]) orelse return primitives.typeError(TRANSCODED_PORT, "recognized codec", args[1]);
+    const eol_style = symbolToEolStyle(args[2]) orelse return primitives.typeError(TRANSCODED_PORT, "recognized eol-style", args[2]);
+    const error_mode = symbolToErrorMode(args[3]) orelse return primitives.typeError(TRANSCODED_PORT, "recognized error-handling-mode", args[3]);
 
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocTranscodedPort(args[0], binary_port.is_input, binary_port.is_output, codec, eol_style, error_mode) catch PrimitiveError.OutOfMemory;

--- a/tests/scheme/audit/internal-primitives-audit.scm
+++ b/tests/scheme/audit/internal-primitives-audit.scm
@@ -682,37 +682,66 @@
 ;;; ==================================================================
 ;;; #1899 (heap values render opaquely as `#<symbol>` etc.) is already
 ;;; filed and is NOT re-asserted here. These two are distinct from it.
+;;;
+;;; All three defects below were found by this audit and fixed in #1916; the
+;;; assertions are kept alongside their original controls, which is what makes
+;;; each one discriminating (every control passed before the fix too).
 
-;; An integral flonum renders without its `.0`, so "expected exact integer,
-;; got 1" is self-contradictory. Control: 1.5 renders correctly as "1.5".
+;; An integral flonum must keep its `.0`, or "expected exact integer, got 1"
+;; argues against itself -- 1 *is* an exact integer. Control: 1.5 always
+;; rendered correctly as "1.5", so a `{d}`-vs-printer regression shows up here
+;; and not in the control.
 (test-assert "diagnostic control: 1.5 renders as 1.5"
              (has-substring? (raised-message (%make-record-type "T" 1.5)) "1.5"))
-;; FAIL: #1916 (integral flonum 1.0 renders as "1" in error messages)
-;; (test-assert "diagnostic: 1.0 does not render as an exact 1"
-;;              (not (has-substring? (raised-message (%make-record-type "T" 1.0))
-;;                                   "got 1")))
+;; Stated positively, not as `(not (has-substring? ... "got 1"))`: "got 1" is a
+;; PREFIX of the correct "got 1.0", so the negative form cannot pass whatever
+;; the code does. The positive form is fully discriminating anyway -- the buggy
+;; message was exactly "got 1", which does not contain "got 1.0".
+(test-assert "diagnostic: 1.0 renders as 1.0, not as an exact 1"
+             (has-substring? (raised-message (%make-record-type "T" 1.0)) "got 1.0"))
 
-;; A multi-limb bignum that is out of an element kind's range is reported as
-;; "expected exact integer" -- but it IS an exact integer. Control: a
-;; single-limb out-of-range value gets the correct "in-range" wording.
+;; A multi-limb bignum out of an element kind's range must be reported as out
+;; of RANGE, not as the wrong TYPE -- it is an exact integer. Control: a
+;; single-limb out-of-range value already got the "in-range" wording.
 (test-assert "diagnostic control: 65536 for u16 says in-range"
              (has-substring? (raised-message (%make-numeric-vector 'u16 1 65536))
                              "in-range"))
-;; FAIL: #1916 (out-of-range multi-limb bignum reported as "expected exact integer")
-;; (test-assert "diagnostic: 2^64 for u16 also says in-range"
-;;              (has-substring? (raised-message (%make-numeric-vector 'u16 1 (expt 2 64)))
-;;                              "in-range"))
+(test-assert "diagnostic: 2^64 for u16 also says in-range"
+             (has-substring? (raised-message (%make-numeric-vector 'u16 1 (expt 2 64)))
+                             "in-range"))
+(test-assert "diagnostic: 2^64 for s8 says in-range"
+             (has-substring? (raised-message (%make-numeric-vector 's8 1 (expt 2 64)))
+                             "in-range"))
+;; A NEGATIVE multi-limb bignum into an unsigned kind is rejected for its sign,
+;; not its width -- the same wording a negative fixnum gets, which is the
+;; control here.
+(test-assert "diagnostic control: -1 for u16 says non-negative"
+             (has-substring? (raised-message (%make-numeric-vector 'u16 1 -1))
+                             "non-negative"))
+(test-assert "diagnostic: -2^64 for u16 also says non-negative"
+             (has-substring? (raised-message (%make-numeric-vector 'u16 1 (- (expt 2 64))))
+                             "non-negative"))
+;; The distinction only means something if a genuine non-integer still reports
+;; as one -- otherwise "in-range" everywhere would pass the assertions above.
+(test-assert "diagnostic: a string still says exact integer"
+             (has-substring? (raised-message (%make-numeric-vector 'u16 1 "x"))
+                             "exact integer"))
 
 ;;; The procedure name a `%` primitive reports must match the name that was
 ;;; called -- otherwise the message points at a DIFFERENT, real procedure
 ;;; (`record?` is exported by (srfi 237); `transcoded-port` by (srfi 181)).
-;; FAIL: #1916 (%record? reports its errors as `record?`, dropping the % prefix)
-;; (test-assert "name drift: %record? reports as %record?"
-;;              (has-substring? (raised-message (%record? 5 5)) "%record?"))
-;; FAIL: #1916 (%transcoded-port reports its errors as `transcoded-port`)
-;; (test-assert "name drift: %transcoded-port reports as %transcoded-port"
-;;              (has-substring? (raised-message (%transcoded-port 5 'utf-8 'none 'replace))
-;;                              "%transcoded-port"))
+;;; Asserting the bare name is absent is what discriminates: "%record?"
+;;; contains "record?", so the presence check alone would pass either way.
+(test-assert "name drift: %record? reports as %record?"
+             (has-substring? (raised-message (%record? 5 5)) "%record?"))
+(test-assert "name drift: %record? does not report as bare record?"
+             (not (has-substring? (raised-message (%record? 5 5)) "'record?")))
+(test-assert "name drift: %transcoded-port reports as %transcoded-port"
+             (has-substring? (raised-message (%transcoded-port 5 'utf-8 'none 'replace))
+                             "%transcoded-port"))
+(test-assert "name drift: %transcoded-port does not report as bare transcoded-port"
+             (not (has-substring? (raised-message (%transcoded-port 5 'utf-8 'none 'replace))
+                                  "'transcoded-port")))
 
 ;;; ==================================================================
 ;;; D4 -- registration-table invariant


### PR DESCRIPTION
Fixes #1916.

Three independent diagnostic defects found by the audit v2 Phase 2.1 sweep of the `%`-prefixed surface (#1890). Each one sent a reader looking at the wrong thing.

## 1. Integral flonums rendered without their `.0`

```
(%make-numeric-vector 's8 1 1.0)
  before: type error in '%make-numeric-vector': expected exact integer, got 1
  after:  type error in '%make-numeric-vector': expected exact integer, got 1.0
```

`1` *is* an exact integer, so the message argued against itself.

`safeValueDescription` formatted flonums with a bare `{d}` rather than the printer, so **this affected every type error in the codebase**, not just the numeric-vector ones it was found in — `(car 2.0)` said "got 2", `(vector-ref v 0.0)` said "got 0". It now goes through `printer.formatFlonum`, which also fixes `+inf.0`, `+nan.0` and scientific notation (`1.0e+30`). That call is safe in this deliberately-defensive helper: a flonum is inline under NaN-boxing, so nothing heap-shaped is read, and `formatFlonum` handles NaN/Inf itself.

Distinct from #1899, which is about *heap* values rendering as opaque tags; that is untouched here.

## 2. Out-of-range multi-limb bignum reported as the wrong *type*

```
(%make-numeric-vector 'u16 1 (expt 2 64))
  before: expected exact integer, got #<bignum>
  after:  expected in-range unsigned integer, got #<bignum>
```

A bignum **is** an exact integer; its only fault is not fitting `s8..u64`. `magnitudeAndSign` returned a plain `?MagSign`, which gave "too wide" and "not an integer at all" the same answer. Splitting them into `ExactMag.too_wide` / `.not_exact` lets the message match what an out-of-range *fixnum* has always said. A negative multi-limb bignum now says `non-negative integer` instead, since there the sign is the real complaint — again matching the fixnum wording.

Boundary values that must still succeed (s64 min/max, u64 max) are unaffected and covered by pre-existing assertions.

## 3. Name drift onto real, different procedures

```
(%record? 5 5)                              -> type error in '%record?': ...
(%transcoded-port 5 'utf-8 'none 'replace)  -> type error in '%transcoded-port': ...
```

These were not cosmetic truncations. `record?` (`lib/srfi/237.sld`) and `transcoded-port` (`lib/srfi/181.sld`) are both real, exported procedures with different argument lists — `(record? 5 5)` is an *arity* error, not a type error — so a reader who followed the message landed on the wrong procedure. Both now use the shared-constant convention `primitives_srfi237.zig`'s `MAKE_RTD` already documented for exactly this reason, so the name cannot drift again.

A sweep of every `%`-prefixed spec against the names its body reports found these two and no others. The same sweep over *all* primitives turned up `port-has-set-port-position!?`, which is already filed as #1942 (a larger problem — wrong function entirely), and four legitimate synonym pairs (`call/cc`, `call/ec`, `close-port`, `inexact`).

## Tests

The Phase 2.1 audit had already written these assertions and commented them out as known failures; they are enabled in `tests/scheme/audit/internal-primitives-audit.scm`, alongside their original controls and three cases the audit did not cover: a negative multi-limb bignum, a signed-kind overflow, and a genuine non-integer — the last is what stops "in-range everywhere" from passing the other two.

One of the four could not be enabled as written. `(not (has-substring? msg "got 1"))` cannot pass whatever the code does, because `"got 1"` is a prefix of the correct `"got 1.0"`. It is stated positively instead, which is fully discriminating: the buggy message was exactly `"got 1"`, which does not contain `"got 1.0"`. The two name-drift assertions likewise needed a negative half (`"'record?"` absent), since `"%record?"` contains `"record?"` and the presence check alone would pass either way.

**Mutation-tested.** Reverting each of the three fixes in turn fails exactly the assertions belonging to it and no others:

| reverted | failing assertions |
|---|---|
| `%record?` name | 2 (both name-drift `%record?`) |
| `%transcoded-port` name | 2 (both name-drift `%transcoded-port`) |
| bignum classification | 3 (u16/s8 in-range, u16 non-negative) |
| flonum rendering | 1 (renders as 1.0) |

## Verification

- `zig build test` — pass
- `bash tests/scheme/run-all.sh` — 632 Scheme files pass, R7RS 1395 pass, **2027 pass / 0 fail**
- audit suite 249 assertions pass (was 239 + 4 disabled)
- `zig fmt --check` clean; markdownlint clean; the CI bare-`TypeError` gate still reports zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)