### PR TITLE
Phase 7B: per-tag GC reachability — 62 mutation-verified tests, and the remembered set turns out not to be load-bearing

### DIFF
--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -1,0 +1,1425 @@
+//! Per-`ObjectTag` reachability under a forced collection — the coverage the
+//! five exhaustive per-tag switches cannot provide (audit v2, Phase 7B).
+//!
+//! Zig's exhaustiveness check guarantees that `markObjectContents`,
+//! `markValueInner` and `referencesYoung` (gc_collect.zig) plus `objectSize`
+//! and `freeObject` (gc_sweep.zig) each have an *arm* for all 41 tags. Nothing
+//! guarantees what is *inside* an arm: a tag whose arm forgets one of its
+//! Value fields compiles cleanly and traces nothing, and the referent is
+//! silently freed while still live. `Port`'s satellites alone are hand-written
+//! at five sites, and `markValueInner` deliberately duplicates
+//! `markPortValues` rather than calling it.
+//!
+//! Two runtime shapes, because the three mark-graph switches are reached by
+//! two different paths:
+//!
+//!   * `expectTraced` (Test A) roots the container, so `markRoots` →
+//!     `markValue` → **`markValueInner`** is the only thing that can keep the
+//!     referent alive.
+//!   * `expectRememberedTrace` (Test B) promotes the container to the old
+//!     generation, repoints a field at a fresh young object through
+//!     `writeBarrier`, and then drops the root before a *minor* collection.
+//!     Old objects are never swept by a minor collection, so the container
+//!     survives while being unreachable from every root — which makes the
+//!     remembered-set walk (**`markObjectContents`**, its only caller) the
+//!     only thing that can mark the referent, and `pruneRememberedSet`'s
+//!     retention decision (**`referencesYoung`**) directly observable.
+//!
+//! Every Test A case ends with a discriminating control: with the container
+//! unrooted the same referents MUST be reclaimed. Without it "still alive"
+//! proves nothing — an assertion that cannot fail is not a test.
+//!
+//! Liveness is decided by walking the GC's own `objects`/`old_objects` lists
+//! for the referent's address, never by dereferencing it: a swept referent is
+//! freed (and, in Debug/gc-stress builds, poisoned), so reading it back would
+//! be the very use-after-free this file exists to detect.
+//!
+//! `objectSize` and `freeObject` are *not* reachability switches — a wrong
+//! arm there leaks or double-frees rather than losing a referent, which
+//! `std.testing.allocator`'s own leak check already catches on every test in
+//! this file (each one allocates through the GC and tears it down).
+//!
+//! The comptime inventory at the bottom is the compiler-enforced half: it
+//! pins the exact field list of every heap struct these switches dispatch on,
+//! so adding a field is a build error until someone has looked at the arms.
+
+const std = @import("std");
+const memory = @import("memory.zig");
+const types = @import("types.zig");
+const fiber_mod = @import("fiber.zig");
+
+const Value = types.Value;
+const Object = types.Object;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// A referent the container under test must keep alive. `id` is the `car` a
+/// pair referent must still hold afterwards; it is null for the handful of
+/// referents that have to be some other type (a `*RecordType` for
+/// `RecordType.parent`, a `*Function` for `Closure.func`, ...), where pointer
+/// identity plus the tag is the whole check.
+const Ref = struct {
+    val: Value,
+    id: ?i64 = null,
+};
+
+/// A fresh young heap object nothing else references, tagged with `id` so a
+/// surviving referent can be told apart from a recycled slot.
+fn young(gc: *memory.GC, id: i64) !Value {
+    return gc.allocPair(types.makeFixnum(id), types.NIL);
+}
+
+fn ref(val: Value, id: i64) Ref {
+    return .{ .val = val, .id = id };
+}
+
+/// True iff `obj` is still on one of this GC's object lists. Deliberately
+/// never dereferences `obj` itself.
+fn isLive(gc: *memory.GC, obj: *Object) bool {
+    var cur = gc.objects;
+    while (cur) |o| : (cur = o.next) if (o == obj) return true;
+    cur = gc.old_objects;
+    while (cur) |o| : (cur = o.next) if (o == obj) return true;
+    return false;
+}
+
+fn inRemembered(gc: *memory.GC, obj: *Object) bool {
+    for (gc.remembered_set.items) |o| if (o == obj) return true;
+    return false;
+}
+
+fn expectAlive(gc: *memory.GC, r: Ref) !void {
+    const obj = types.toObject(r.val);
+    if (!isLive(gc, obj)) {
+        std.debug.print("\nreferent was reclaimed while its container was reachable\n", .{});
+        return error.ReferentCollected;
+    }
+    if (r.id) |id| try std.testing.expectEqual(types.makeFixnum(id), obj.as(types.Pair).car);
+}
+
+fn expectDead(gc: *memory.GC, r: Ref) !void {
+    if (isLive(gc, types.toObject(r.val))) {
+        std.debug.print("\nreferent survived with nothing referencing it — " ++
+            "this case's positive assertions prove nothing\n", .{});
+        return error.ControlNotDiscriminating;
+    }
+}
+
+/// `collect()` runs a full collection every 8th cycle; drive the choice
+/// explicitly instead of depending on the cycle counter's history.
+fn forceMinor(gc: *memory.GC) void {
+    gc.minor_cycle_count = 0;
+    gc.collect();
+}
+
+fn forceFull(gc: *memory.GC) void {
+    gc.minor_cycle_count = 7;
+    gc.collect();
+}
+
+/// Two surviving minor collections promote a young object to the old
+/// generation (`sweepYoung`: `survive_count >= 2`).
+fn promoteToOld(gc: *memory.GC, v: Value) !void {
+    var root = v;
+    gc.pushRoot(&root);
+    forceMinor(gc);
+    forceMinor(gc);
+    gc.popRoot();
+    try std.testing.expectEqual(@as(u1, 1), types.toObject(v).flags.generation);
+}
+
+/// Test A — `markValueInner`, via the root set.
+fn expectTraced(gc: *memory.GC, container: Value, refs: []const Ref) !void {
+    var root = container;
+    gc.pushRoot(&root);
+    forceMinor(gc);
+    for (refs) |r| try expectAlive(gc, r);
+    forceFull(gc);
+    for (refs) |r| try expectAlive(gc, r);
+    gc.popRoot();
+
+    // Discriminating control.
+    forceFull(gc);
+    for (refs) |r| try expectDead(gc, r);
+}
+
+/// Test B — `markObjectContents` and `referencesYoung`, via the remembered
+/// set. `container` must already be old and carry a `writeBarrier`-recorded
+/// young reference to every entry in `refs`.
+fn expectRememberedTrace(gc: *memory.GC, container: Value, refs: []const Ref) !void {
+    const cobj = types.toObject(container);
+    try std.testing.expectEqual(@as(u1, 1), cobj.flags.generation);
+    // Without this the case would be vacuous: nothing would walk the object.
+    try std.testing.expect(inRemembered(gc, cobj));
+
+    forceMinor(gc);
+    for (refs) |r| try expectAlive(gc, r);
+
+    // The referents survived exactly one minor collection, so they are still
+    // young — `referencesYoung` must therefore still say yes and the entry
+    // must still be there. A missing field in that arm drops the entry, and
+    // with it every later collection's only route to these referents.
+    try std.testing.expect(inRemembered(gc, cobj));
+}
+
+/// Every test here drives collection by hand: `enabled = false` stops
+/// allocation from collecting underneath the setup (so intermediates need no
+/// rooting), and makes the suite behave identically under `-Dgc-stress=true`,
+/// where an implicit collection at every allocation would otherwise reclaim
+/// a container before its fields were even filled in.
+fn newGc() memory.GC {
+    var gc = memory.GC.init(std.testing.allocator);
+    gc.enabled = false;
+    return gc;
+}
+
+fn dummyNative(_: []const Value) anyerror!Value {
+    return types.NIL;
+}
+
+fn dummyNativeClosure(_: ?*@import("vm.zig").VM, _: [*]const Value, _: u64, _: [*]const Value) callconv(.c) u64 {
+    return types.NIL;
+}
+
+/// A throwaway non-null address for the `*anyopaque` handles a few
+/// constructors demand (an FFI symbol, a `DIR*`). Never dereferenced: the
+/// FFI arms only trace `library`/`closure`, and the directory arm's handle is
+/// cleared before any sweep can reach `dirIterDestroy`.
+var opaque_handle: u64 = 0;
+
+// ---------------------------------------------------------------------------
+// Tags with Value-bearing fields — Test A (markValueInner)
+// ---------------------------------------------------------------------------
+
+test "gc tracing: pair traces car and cdr" {
+    var gc = newGc();
+    defer gc.deinit();
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const c = try gc.allocPair(a, b);
+    try expectTraced(&gc, c, &.{ ref(a, 1), ref(b, 2) });
+}
+
+test "gc tracing: vector traces every element" {
+    var gc = newGc();
+    defer gc.deinit();
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const c = try young(&gc, 3);
+    const v = try gc.allocVector(&.{ a, types.makeFixnum(0), b, c });
+    try expectTraced(&gc, v, &.{ ref(a, 1), ref(b, 2), ref(c, 3) });
+}
+
+test "gc tracing: closure traces func and upvalues" {
+    var gc = newGc();
+    defer gc.deinit();
+    const func = try gc.allocFunction();
+    func.upvalue_count = 2;
+    const cls = try gc.allocClosure(func);
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const c = types.toObject(cls).as(types.Closure);
+    c.upvalues[0] = a;
+    c.upvalues[1] = b;
+    try expectTraced(&gc, cls, &.{
+        .{ .val = types.makePointer(&func.header) },
+        ref(a, 1),
+        ref(b, 2),
+    });
+}
+
+test "gc tracing: function traces constants, global cache and env_val" {
+    var gc = newGc();
+    defer gc.deinit();
+    const func = try gc.allocFunction();
+    const konst = try young(&gc, 1);
+    const cached = try young(&gc, 2);
+    const env = try young(&gc, 3);
+    try func.constants.append(gc.allocator, konst);
+    const cache = try gc.allocator.alloc(Value, 1);
+    cache[0] = cached;
+    func.global_cache = cache;
+    func.env_val = env;
+    try expectTraced(&gc, types.makePointer(&func.header), &.{
+        ref(konst, 1), ref(cached, 2), ref(env, 3),
+    });
+}
+
+test "gc tracing: native_closure traces upvalues" {
+    var gc = newGc();
+    defer gc.deinit();
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const nc = try gc.allocNativeClosure(&dummyNativeClosure, &.{ a, b }, 0, "probe");
+    try expectTraced(&gc, nc, &.{ ref(a, 1), ref(b, 2) });
+}
+
+test "gc tracing: record_type traces parent" {
+    var gc = newGc();
+    defer gc.deinit();
+    const parent = try gc.allocRecordType("parent", 0);
+    const child = try gc.allocRecordTypeExtended(
+        "child",
+        types.toObject(parent).as(types.RecordType),
+        &.{},
+        &.{},
+        null,
+        false,
+        false,
+    );
+    try expectTraced(&gc, child, &.{.{ .val = parent }});
+}
+
+test "gc tracing: record_instance traces record_type and fields" {
+    var gc = newGc();
+    defer gc.deinit();
+    const rt = try gc.allocRecordType("probe", 2);
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const ri = try gc.allocRecordInstance(types.toObject(rt).as(types.RecordType), &.{ a, b });
+    try expectTraced(&gc, ri, &.{ .{ .val = rt }, ref(a, 1), ref(b, 2) });
+}
+
+test "gc tracing: hash_table traces equiv/hash procs and every occupied entry" {
+    var gc = newGc();
+    defer gc.deinit();
+    const eq = try young(&gc, 1);
+    const hash = try young(&gc, 2);
+    const key = try young(&gc, 3);
+    const val = try young(&gc, 4);
+    const ht_val = try gc.allocHashTable(8);
+    const ht = types.toObject(ht_val).as(types.HashTable);
+    ht.equiv_fn = eq;
+    ht.hash_fn = hash;
+    ht.compare_mode = .custom;
+    ht.entries[0] = .{ .key = key, .value = val, .state = .occupied };
+    ht.count = 1;
+    try expectTraced(&gc, ht_val, &.{ ref(eq, 1), ref(hash, 2), ref(key, 3), ref(val, 4) });
+}
+
+test "gc tracing: promise traces value" {
+    var gc = newGc();
+    defer gc.deinit();
+    const a = try young(&gc, 1);
+    const p = try gc.allocPromise(true, a);
+    try expectTraced(&gc, p, &.{ref(a, 1)});
+}
+
+test "gc tracing: parameter traces value and converter" {
+    var gc = newGc();
+    defer gc.deinit();
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const p = try gc.allocParameter(a, b);
+    try expectTraced(&gc, p, &.{ ref(a, 1), ref(b, 2) });
+}
+
+test "gc tracing: port traces all six custom-backend callbacks" {
+    var gc = newGc();
+    defer gc.deinit();
+    const rd = try young(&gc, 1);
+    const wr = try young(&gc, 2);
+    const gp = try young(&gc, 3);
+    const sp = try young(&gc, 4);
+    const cl = try young(&gc, 5);
+    const fl = try young(&gc, 6);
+    const port = try gc.allocCustomPort(true, true, false, rd, wr, gp, sp, cl, fl);
+    try expectTraced(&gc, port, &.{
+        ref(rd, 1), ref(wr, 2), ref(gp, 3), ref(sp, 4), ref(cl, 5), ref(fl, 6),
+    });
+}
+
+test "gc tracing: port traces transcode wrapped_port" {
+    var gc = newGc();
+    defer gc.deinit();
+    const wrapped = try young(&gc, 1);
+    const port = try gc.allocTranscodedPort(wrapped, true, false, .utf8, .lf, .replace);
+    try expectTraced(&gc, port, &.{ref(wrapped, 1)});
+}
+
+test "gc tracing: transformer traces rules, proc, def_env_val and peer vals" {
+    var gc = newGc();
+    defer gc.deinit();
+    const lit = try young(&gc, 1);
+    const pat = try young(&gc, 2);
+    const tmpl = try young(&gc, 3);
+    const proc = try young(&gc, 4);
+    const env = try young(&gc, 5);
+    const peer = try young(&gc, 6);
+    const tx_val = try gc.allocTransformer(&.{lit}, &.{pat}, &.{tmpl});
+    const tx = types.toObject(tx_val).as(types.Transformer);
+    tx.kind = .er_macro;
+    tx.proc = proc;
+    tx.def_env_val = env;
+    const peers = try gc.allocator.alloc(Value, 1);
+    peers[0] = peer;
+    tx.let_syntax_peer_vals = peers;
+    try expectTraced(&gc, tx_val, &.{
+        ref(lit, 1), ref(pat, 2), ref(tmpl, 3), ref(proc, 4), ref(env, 5), ref(peer, 6),
+    });
+}
+
+test "gc tracing: error_object traces message, irritants and uncaught_reason" {
+    var gc = newGc();
+    defer gc.deinit();
+    const msg = try young(&gc, 1);
+    const irr = try young(&gc, 2);
+    const reason = try young(&gc, 3);
+    const err = try gc.allocErrorObject(msg, irr);
+    types.toObject(err).as(types.ErrorObject).uncaught_reason = reason;
+    try expectTraced(&gc, err, &.{ ref(msg, 1), ref(irr, 2), ref(reason, 3) });
+}
+
+test "gc tracing: continuation traces registers, frames, handlers and winds" {
+    var gc = newGc();
+    defer gc.deinit();
+    const reg = try young(&gc, 1);
+    const handler = try young(&gc, 2);
+    const before = try young(&gc, 3);
+    const after = try young(&gc, 4);
+    const func = try gc.allocFunction();
+    const cls = try gc.allocClosure(func);
+    const nf = try gc.allocNativeFn("probe", &dummyNative, .{ .exact = 0 });
+
+    const registers = [_]Value{ reg, types.makeFixnum(0) };
+    const frames = [_]types.SavedFrame{.{
+        .closure = types.toObject(cls).as(types.Closure),
+        .native = types.toObject(nf).as(types.NativeFn),
+        .code = &.{},
+        .ip = 0,
+        .base = 0,
+        .dst = 0,
+        .saved_wind_count = 0,
+        .returns_to_native = false,
+        .seq = 0,
+    }};
+    const handlers = [_]types.SavedHandler{.{ .handler = handler, .frame_count = 0 }};
+    const winds = [_]types.WindRecord{.{ .before = before, .after = after }};
+
+    const cont = try gc.allocContinuation(&registers, &frames, 1, &handlers, 1, &winds, 1, 0, 0);
+    try expectTraced(&gc, cont, &.{
+        ref(reg, 1),
+        ref(handler, 2),
+        ref(before, 3),
+        ref(after, 4),
+        .{ .val = cls },
+        .{ .val = nf },
+    });
+}
+
+test "gc tracing: multiple_values traces every value" {
+    var gc = newGc();
+    defer gc.deinit();
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const mv = try gc.allocMultipleValues(&.{ a, types.TRUE, b });
+    try expectTraced(&gc, mv, &.{ ref(a, 1), ref(b, 2) });
+}
+
+test "gc tracing: rational traces numerator and denominator" {
+    var gc = newGc();
+    defer gc.deinit();
+    const n = try young(&gc, 1);
+    const d = try young(&gc, 2);
+    const rat = try gc.allocRational(n, d);
+    try expectTraced(&gc, rat, &.{ ref(n, 1), ref(d, 2) });
+}
+
+test "gc tracing: ffi_function traces library" {
+    var gc = newGc();
+    defer gc.deinit();
+    const lib = try young(&gc, 1);
+    const fn_val = try gc.allocFfiFunction(@ptrCast(&opaque_handle), lib, "probe", &.{}, .void_type);
+    try expectTraced(&gc, fn_val, &.{ref(lib, 1)});
+}
+
+test "gc tracing: ffi_callback traces closure" {
+    var gc = newGc();
+    defer gc.deinit();
+    const cls = try young(&gc, 1);
+    // Slot 255 is past NUM_SLOTS, so freeObject's releaseSlot is a no-op and
+    // this never disturbs a real callback registration.
+    const cb = try gc.allocFfiCallback(cls, 255, @ptrCast(&opaque_handle));
+    try expectTraced(&gc, cb, &.{ref(cls, 1)});
+}
+
+test "gc tracing: channel traces head and tail" {
+    var gc = newGc();
+    defer gc.deinit();
+    const head = try young(&gc, 1);
+    const tail = try young(&gc, 2);
+    const ch_val = try gc.allocChannel();
+    const ch = types.toObject(ch_val).as(types.Channel);
+    ch.head = head;
+    ch.tail = tail;
+    try expectTraced(&gc, ch_val, &.{ ref(head, 1), ref(tail, 2) });
+}
+
+test "gc tracing: mutex traces name, owner and specific" {
+    var gc = newGc();
+    defer gc.deinit();
+    const name = try young(&gc, 1);
+    const owner = try young(&gc, 2);
+    const specific = try young(&gc, 3);
+    const m_val = try gc.allocMutex(name);
+    const m = types.toObject(m_val).as(types.Mutex);
+    m.owner = owner;
+    m.specific = specific;
+    try expectTraced(&gc, m_val, &.{ ref(name, 1), ref(owner, 2), ref(specific, 3) });
+}
+
+test "gc tracing: condition_variable traces name and specific" {
+    var gc = newGc();
+    defer gc.deinit();
+    const name = try young(&gc, 1);
+    const specific = try young(&gc, 2);
+    const cv_val = try gc.allocConditionVariable(name);
+    types.toObject(cv_val).as(types.ConditionVariable).specific = specific;
+    try expectTraced(&gc, cv_val, &.{ ref(name, 1), ref(specific, 2) });
+}
+
+test "gc tracing: scheme_environment traces every binding" {
+    var gc = newGc();
+    defer gc.deinit();
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const map = try gc.allocator.create(std.StringHashMap(Value));
+    map.* = std.StringHashMap(Value).init(gc.allocator);
+    try map.put("a", a);
+    try map.put("b", b);
+    const env = try gc.allocEnvironment(map, true, false);
+    try expectTraced(&gc, env, &.{ ref(a, 1), ref(b, 2) });
+}
+
+test "gc tracing: transport_cell traces key and value" {
+    var gc = newGc();
+    defer gc.deinit();
+    const k = try young(&gc, 1);
+    const v = try young(&gc, 2);
+    const tc = try gc.allocTransportCell(k, v);
+    try expectTraced(&gc, tc, &.{ ref(k, 1), ref(v, 2) });
+}
+
+test "gc tracing: fiber traces every Value-bearing field" {
+    var gc = newGc();
+    defer gc.deinit();
+    const thunk = try young(&gc, 1);
+    const fiber = try gc.allocFiber(thunk, 1);
+    const fiber_val = types.makePointer(&fiber.header);
+
+    const result = try young(&gc, 2);
+    const waiting_on = try young(&gc, 3);
+    const rv_demand_on = try young(&gc, 4);
+    const name = try young(&gc, 5);
+    const specific = try young(&gc, 6);
+    const reg = try young(&gc, 7);
+    const handler = try young(&gc, 8);
+    const before = try young(&gc, 9);
+    const after = try young(&gc, 10);
+    const param = try young(&gc, 11);
+    const exc = try young(&gc, 12);
+    const cont_val = try young(&gc, 13);
+    const io_buffer = try young(&gc, 14);
+    const owned_mutex = try young(&gc, 15);
+
+    const func = try gc.allocFunction();
+    func.locals_count = 8;
+    const cls = try gc.allocClosure(func);
+    const nf = try gc.allocNativeFn("probe", &dummyNative, .{ .exact = 0 });
+
+    fiber.result = result;
+    fiber.waiting_on = waiting_on;
+    fiber.rv_demand_on = rv_demand_on;
+    fiber.name = name;
+    fiber.specific = specific;
+    fiber.current_exception = exc;
+    fiber.continuation_value = cont_val;
+    fiber.io_buffer = io_buffer;
+    fiber.frames[0] = .{
+        .closure = types.toObject(cls).as(types.Closure),
+        .native = types.toObject(nf).as(types.NativeFn),
+        .code = &.{},
+        .ip = 0,
+        .base = 0,
+        .dst = 0,
+    };
+    fiber.frame_count = 1;
+    fiber.registers[3] = reg;
+    fiber.handler_stack[0] = .{ .handler = handler, .frame_count = 0 };
+    fiber.handler_count = 1;
+    fiber.wind_stack[0] = .{ .before = before, .after = after };
+    fiber.wind_count = 1;
+    try fiber.param_overrides.put(1, param);
+    try fiber.owned_mutexes.append(gc.allocator, owned_mutex);
+
+    try expectTraced(&gc, fiber_val, &.{
+        ref(thunk, 1),        ref(result, 2),     ref(waiting_on, 3),
+        ref(rv_demand_on, 4), ref(name, 5),       ref(specific, 6),
+        ref(reg, 7),          ref(handler, 8),    ref(before, 9),
+        ref(after, 10),       ref(param, 11),     ref(exc, 12),
+        ref(cont_val, 13),    ref(io_buffer, 14), ref(owned_mutex, 15),
+        .{ .val = cls },      .{ .val = nf },
+    });
+}
+
+// --- SRFI 254 weak structures: traced, but conditionally ------------------
+
+test "gc tracing: ephemeron retains its value while the key is reachable" {
+    var gc = newGc();
+    defer gc.deinit();
+    const key = try young(&gc, 1);
+    const val = try young(&gc, 2);
+    const eph = try gc.allocEphemeron(key, val);
+
+    // The key must be independently reachable: an ephemeron does not hold
+    // its own key (that is the whole point of the type).
+    var key_root = key;
+    gc.pushRoot(&key_root);
+    var eph_root = eph;
+    gc.pushRoot(&eph_root);
+    forceMinor(&gc);
+    try expectAlive(&gc, ref(val, 2));
+    forceFull(&gc);
+    try expectAlive(&gc, ref(val, 2));
+    gc.popRoot(); // eph_root
+    gc.popRoot(); // key_root
+
+    forceFull(&gc);
+    try expectDead(&gc, ref(val, 2));
+}
+
+test "gc tracing: ephemeron with an unreachable key breaks rather than retaining" {
+    var gc = newGc();
+    defer gc.deinit();
+    const key = try young(&gc, 1);
+    const val = try young(&gc, 2);
+    const eph = try gc.allocEphemeron(key, val);
+
+    var eph_root = eph;
+    gc.pushRoot(&eph_root);
+    defer gc.popRoot();
+    forceFull(&gc);
+
+    // The ephemeron itself survives (it is rooted); its key and value do not.
+    try std.testing.expect(isLive(&gc, types.toObject(eph)));
+    try expectDead(&gc, ref(key, 1));
+    try expectDead(&gc, ref(val, 2));
+    const e = types.toObject(eph).as(types.Ephemeron);
+    try std.testing.expect(e.broken);
+    try std.testing.expectEqual(types.FALSE, e.key);
+    try std.testing.expectEqual(types.FALSE, e.value);
+}
+
+test "gc tracing: object guardian holds ready elements strongly" {
+    var gc = newGc();
+    defer gc.deinit();
+    const watched = try young(&gc, 1);
+    const payload = try young(&gc, 2);
+    const g_val = try gc.allocGuardian(false);
+    const g = types.toObject(g_val).as(types.Guardian);
+    try g.ready.append(gc.allocator, .{ .watched = watched, .payload = payload });
+    try expectTraced(&gc, g_val, &.{ ref(watched, 1), ref(payload, 2) });
+}
+
+test "gc tracing: transport guardian holds registered cells strongly" {
+    var gc = newGc();
+    defer gc.deinit();
+    const k = try young(&gc, 1);
+    const v = try young(&gc, 2);
+    const cell = try gc.allocTransportCell(k, v);
+    const g_val = try gc.allocGuardian(true);
+    const g = types.toObject(g_val).as(types.Guardian);
+    try g.registered.append(gc.allocator, .{ .watched = cell, .payload = cell });
+    // The cell is strong, and marking it reaches its own key/value through
+    // the `.transport_cell` arm.
+    try expectTraced(&gc, g_val, &.{ .{ .val = cell }, ref(k, 1), ref(v, 2) });
+}
+
+test "gc tracing: object guardian resurrects a registered element" {
+    var gc = newGc();
+    defer gc.deinit();
+    const watched = try young(&gc, 1);
+    const payload = try young(&gc, 2);
+    const g_val = try gc.allocGuardian(false);
+    const g = types.toObject(g_val).as(types.Guardian);
+    try g.registered.append(gc.allocator, .{ .watched = watched, .payload = payload });
+
+    var root = g_val;
+    gc.pushRoot(&root);
+    defer gc.popRoot();
+    forceFull(&gc);
+
+    // `watched` is unreachable, so the element is resurrected: both fields
+    // are marked and it moves to the ready queue.
+    try expectAlive(&gc, ref(watched, 1));
+    try expectAlive(&gc, ref(payload, 2));
+    try std.testing.expectEqual(@as(usize, 0), g.registered.items.len);
+    try std.testing.expectEqual(@as(usize, 1), g.ready.items.len);
+}
+
+// ---------------------------------------------------------------------------
+// Tags with no Value-bearing field
+// ---------------------------------------------------------------------------
+//
+// Nothing to trace, so reachability is vacuous — but the tag must still be
+// *swept* correctly, and its `freeObject` arm must release exactly what it
+// owns (checked by std.testing.allocator's leak detector on GC.deinit).
+// The comptime inventory below is what actually guards these against
+// silently gaining a Value field.
+
+test "gc tracing: leaf tags survive while rooted and are reclaimed when not" {
+    var gc = newGc();
+    defer gc.deinit();
+
+    const dir = try gc.allocDirectoryObject(@ptrCast(&opaque_handle), false);
+    // Not a real DIR*; clear it before any sweep can hand it to
+    // platform.dirIterDestroy.
+    types.toObject(dir).as(types.DirectoryObject).dir = null;
+
+    // Interned symbols are permanent roots (`gc.symbols` is walked by
+    // markRoots and never swept), so the symbol is the one leaf that
+    // legitimately survives the control below — kept out of `leaves`.
+    const sym = try gc.allocSymbol("gc-tracing-probe");
+
+    const leaves = [_]Value{
+        try gc.allocString("probe"),
+        try gc.allocNativeFn("probe", &dummyNative, .{ .exact = 0 }),
+        try gc.allocBytevector(&.{ 1, 2, 3 }),
+        try gc.allocNumericVector(.f64, &.{ 0, 0, 0, 0, 0, 0, 0, 0 }),
+        try gc.allocComplex(1.0, 2.0),
+        try gc.allocBignumFromI64(1 << 62),
+        try gc.allocFfiLibrary(null, "probe"),
+        try gc.allocUserInfo("u", 0, 0, "/", "/bin/sh", "U"),
+        try gc.allocGroupInfo("g", 0),
+        try gc.allocRandomSource(1),
+        try gc.allocSrfi18Time(1, 2, .utc),
+        dir,
+        try gc.allocFileInfo(.{
+            .size = 0,
+            .mtime = 0,
+            .atime = 0,
+            .ctime = 0,
+            .dev = 0,
+            .ino = 0,
+            .nlinks = 0,
+            .rdev = 0,
+            .blksize = 0,
+            .blocks = 0,
+            .mode = 0,
+            .uid = 0,
+            .gid = 0,
+            .file_type = .regular,
+        }),
+    };
+
+    // Record each tag now: after the control collection the objects are
+    // freed (and poisoned in Debug/gc-stress builds), so `obj.tag` may not
+    // be read then.
+    var tags: [leaves.len]types.ObjectTag = undefined;
+    for (leaves, 0..) |l, i| tags[i] = types.toObject(l).tag;
+
+    // Root them all through one vector, then collect.
+    const holder = try gc.allocVector(&leaves);
+    var root = holder;
+    gc.pushRoot(&root);
+    forceMinor(&gc);
+    forceFull(&gc);
+    for (leaves, tags) |l, tag| {
+        if (!isLive(&gc, types.toObject(l))) {
+            std.debug.print("\nleaf tag {t} was reclaimed while rooted\n", .{tag});
+            return error.ReferentCollected;
+        }
+    }
+    try std.testing.expect(isLive(&gc, types.toObject(sym)));
+    gc.popRoot();
+
+    forceFull(&gc);
+    for (leaves, tags) |l, tag| {
+        if (isLive(&gc, types.toObject(l))) {
+            std.debug.print("\nleaf tag {t} survived unrooted\n", .{tag});
+            return error.ControlNotDiscriminating;
+        }
+    }
+    try std.testing.expect(isLive(&gc, types.toObject(sym)));
+}
+
+// ---------------------------------------------------------------------------
+// Test B — markObjectContents + referencesYoung, via the remembered set
+// ---------------------------------------------------------------------------
+
+test "gc tracing (remembered set): pair" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocPair(types.NIL, types.NIL);
+    try promoteToOld(&gc, c);
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const p = types.toObject(c).as(types.Pair);
+    p.car = a;
+    p.cdr = b;
+    gc.writeBarrier(&p.header, a);
+    try expectRememberedTrace(&gc, c, &.{ ref(a, 1), ref(b, 2) });
+}
+
+test "gc tracing (remembered set): vector" {
+    var gc = newGc();
+    defer gc.deinit();
+    const v = try gc.allocVectorFill(2, types.NIL);
+    try promoteToOld(&gc, v);
+    const a = try young(&gc, 1);
+    const vec = types.toObject(v).as(types.Vector);
+    vec.data[1] = a;
+    gc.writeBarrier(&vec.header, a);
+    try expectRememberedTrace(&gc, v, &.{ref(a, 1)});
+}
+
+test "gc tracing (remembered set): closure" {
+    var gc = newGc();
+    defer gc.deinit();
+    const func = try gc.allocFunction();
+    func.upvalue_count = 1;
+    const cls = try gc.allocClosure(func);
+    try promoteToOld(&gc, cls);
+    const a = try young(&gc, 1);
+    const c = types.toObject(cls).as(types.Closure);
+    c.upvalues[0] = a;
+    gc.writeBarrier(&c.header, a);
+    try expectRememberedTrace(&gc, cls, &.{ref(a, 1)});
+}
+
+test "gc tracing (remembered set): function" {
+    var gc = newGc();
+    defer gc.deinit();
+    const func = try gc.allocFunction();
+    const fv = types.makePointer(&func.header);
+    try promoteToOld(&gc, fv);
+    const konst = try young(&gc, 1);
+    const env = try young(&gc, 2);
+    try func.constants.append(gc.allocator, konst);
+    func.env_val = env;
+    gc.writeBarrier(&func.header, konst);
+    try expectRememberedTrace(&gc, fv, &.{ ref(konst, 1), ref(env, 2) });
+}
+
+test "gc tracing (remembered set): native_closure" {
+    var gc = newGc();
+    defer gc.deinit();
+    const nc = try gc.allocNativeClosure(&dummyNativeClosure, &.{types.NIL}, 0, "probe");
+    try promoteToOld(&gc, nc);
+    const a = try young(&gc, 1);
+    const n = types.toObject(nc).as(types.NativeClosure);
+    n.upvalues[0] = a;
+    gc.writeBarrier(&n.header, a);
+    try expectRememberedTrace(&gc, nc, &.{ref(a, 1)});
+}
+
+test "gc tracing (remembered set): record_type parent" {
+    var gc = newGc();
+    defer gc.deinit();
+    const child = try gc.allocRecordType("child", 0);
+    try promoteToOld(&gc, child);
+    const parent = try gc.allocRecordType("parent", 0);
+    const rt = types.toObject(child).as(types.RecordType);
+    rt.parent = types.toObject(parent).as(types.RecordType);
+    gc.writeBarrier(&rt.header, parent);
+    try expectRememberedTrace(&gc, child, &.{.{ .val = parent }});
+}
+
+test "gc tracing (remembered set): record_instance" {
+    var gc = newGc();
+    defer gc.deinit();
+    const rt = try gc.allocRecordType("probe", 1);
+    const ri = try gc.allocRecordInstance(types.toObject(rt).as(types.RecordType), &.{types.NIL});
+    try promoteToOld(&gc, ri);
+    const a = try young(&gc, 1);
+    const inst = types.toObject(ri).as(types.RecordInstance);
+    inst.fields[0] = a;
+    gc.writeBarrier(&inst.header, a);
+    try expectRememberedTrace(&gc, ri, &.{ref(a, 1)});
+}
+
+test "gc tracing (remembered set): hash_table" {
+    var gc = newGc();
+    defer gc.deinit();
+    const ht_val = try gc.allocHashTable(8);
+    try promoteToOld(&gc, ht_val);
+    const eq = try young(&gc, 1);
+    const key = try young(&gc, 2);
+    const val = try young(&gc, 3);
+    const ht = types.toObject(ht_val).as(types.HashTable);
+    ht.equiv_fn = eq;
+    ht.compare_mode = .custom;
+    ht.entries[2] = .{ .key = key, .value = val, .state = .occupied };
+    ht.count = 1;
+    gc.writeBarrier(&ht.header, key);
+    try expectRememberedTrace(&gc, ht_val, &.{ ref(eq, 1), ref(key, 2), ref(val, 3) });
+}
+
+test "gc tracing (remembered set): promise" {
+    var gc = newGc();
+    defer gc.deinit();
+    const p = try gc.allocPromise(false, types.NIL);
+    try promoteToOld(&gc, p);
+    const a = try young(&gc, 1);
+    const pr = types.toObject(p).as(types.Promise);
+    pr.value = a;
+    pr.forced = true;
+    gc.writeBarrier(&pr.header, a);
+    try expectRememberedTrace(&gc, p, &.{ref(a, 1)});
+}
+
+test "gc tracing (remembered set): parameter" {
+    var gc = newGc();
+    defer gc.deinit();
+    const p = try gc.allocParameter(types.NIL, types.NIL);
+    try promoteToOld(&gc, p);
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const param = types.toObject(p).as(types.ParameterObject);
+    param.value = a;
+    param.converter = b;
+    gc.writeBarrier(&param.header, a);
+    try expectRememberedTrace(&gc, p, &.{ ref(a, 1), ref(b, 2) });
+}
+
+test "gc tracing (remembered set): port custom backend" {
+    var gc = newGc();
+    defer gc.deinit();
+    const port = try gc.allocCustomPort(
+        true,
+        true,
+        false,
+        types.FALSE,
+        types.FALSE,
+        types.FALSE,
+        types.FALSE,
+        types.FALSE,
+        types.FALSE,
+    );
+    try promoteToOld(&gc, port);
+    const rd = try young(&gc, 1);
+    const fl = try young(&gc, 2);
+    const p = types.toObject(port).as(types.Port);
+    p.custom_backend.?.read_proc = rd;
+    p.custom_backend.?.flush_proc = fl;
+    gc.writeBarrier(&p.header, rd);
+    try expectRememberedTrace(&gc, port, &.{ ref(rd, 1), ref(fl, 2) });
+}
+
+test "gc tracing (remembered set): port transcode" {
+    var gc = newGc();
+    defer gc.deinit();
+    const port = try gc.allocTranscodedPort(types.FALSE, true, false, .utf8, .lf, .replace);
+    try promoteToOld(&gc, port);
+    const wrapped = try young(&gc, 1);
+    const p = types.toObject(port).as(types.Port);
+    p.transcode.?.wrapped_port = wrapped;
+    gc.writeBarrier(&p.header, wrapped);
+    try expectRememberedTrace(&gc, port, &.{ref(wrapped, 1)});
+}
+
+test "gc tracing (remembered set): transformer" {
+    var gc = newGc();
+    defer gc.deinit();
+    const tx_val = try gc.allocTransformer(&.{types.NIL}, &.{types.NIL}, &.{types.NIL});
+    try promoteToOld(&gc, tx_val);
+    const lit = try young(&gc, 1);
+    const pat = try young(&gc, 2);
+    const tmpl = try young(&gc, 3);
+    const proc = try young(&gc, 4);
+    const env = try young(&gc, 5);
+    const tx = types.toObject(tx_val).as(types.Transformer);
+    tx.literals[0] = lit;
+    tx.patterns[0] = pat;
+    tx.templates[0] = tmpl;
+    tx.proc = proc;
+    tx.def_env_val = env;
+    gc.writeBarrier(&tx.header, proc);
+    try expectRememberedTrace(&gc, tx_val, &.{
+        ref(lit, 1), ref(pat, 2), ref(tmpl, 3), ref(proc, 4), ref(env, 5),
+    });
+}
+
+test "gc tracing (remembered set): error_object" {
+    var gc = newGc();
+    defer gc.deinit();
+    const e = try gc.allocErrorObject(types.NIL, types.NIL);
+    try promoteToOld(&gc, e);
+    const msg = try young(&gc, 1);
+    const irr = try young(&gc, 2);
+    const reason = try young(&gc, 3);
+    const err = types.toObject(e).as(types.ErrorObject);
+    err.message = msg;
+    err.irritants = irr;
+    err.uncaught_reason = reason;
+    gc.writeBarrier(&err.header, msg);
+    try expectRememberedTrace(&gc, e, &.{ ref(msg, 1), ref(irr, 2), ref(reason, 3) });
+}
+
+test "gc tracing (remembered set): continuation" {
+    var gc = newGc();
+    defer gc.deinit();
+    const registers = [_]Value{types.NIL};
+    const frames = [_]types.SavedFrame{.{
+        .closure = null,
+        .native = null,
+        .code = &.{},
+        .ip = 0,
+        .base = 0,
+        .dst = 0,
+        .saved_wind_count = 0,
+        .returns_to_native = false,
+        .seq = 0,
+    }};
+    const handlers = [_]types.SavedHandler{.{ .handler = types.NIL, .frame_count = 0 }};
+    const winds = [_]types.WindRecord{.{ .before = types.NIL, .after = types.NIL }};
+    const cont = try gc.allocContinuation(&registers, &frames, 1, &handlers, 1, &winds, 1, 0, 0);
+    try promoteToOld(&gc, cont);
+
+    const reg = try young(&gc, 1);
+    const handler = try young(&gc, 2);
+    const before = try young(&gc, 3);
+    const after = try young(&gc, 4);
+    const func = try gc.allocFunction();
+    const cls = try gc.allocClosure(func);
+    const nf = try gc.allocNativeFn("probe", &dummyNative, .{ .exact = 0 });
+
+    const k = types.toObject(cont).as(types.Continuation);
+    k.registers[0] = reg;
+    k.handlers[0].handler = handler;
+    k.wind_records[0] = .{ .before = before, .after = after };
+    k.frames[0].closure = types.toObject(cls).as(types.Closure);
+    k.frames[0].native = types.toObject(nf).as(types.NativeFn);
+    gc.writeBarrier(&k.header, reg);
+
+    try expectRememberedTrace(&gc, cont, &.{
+        ref(reg, 1),     ref(handler, 2), ref(before, 3), ref(after, 4),
+        .{ .val = cls }, .{ .val = nf },
+    });
+}
+
+test "gc tracing (remembered set): multiple_values" {
+    var gc = newGc();
+    defer gc.deinit();
+    const mv = try gc.allocMultipleValues(&.{ types.NIL, types.NIL });
+    try promoteToOld(&gc, mv);
+    const a = try young(&gc, 1);
+    const m = types.toObject(mv).as(types.MultipleValues);
+    m.values[1] = a;
+    gc.writeBarrier(&m.header, a);
+    try expectRememberedTrace(&gc, mv, &.{ref(a, 1)});
+}
+
+test "gc tracing (remembered set): rational" {
+    var gc = newGc();
+    defer gc.deinit();
+    const rat = try gc.allocRational(types.makeFixnum(1), types.makeFixnum(2));
+    try promoteToOld(&gc, rat);
+    const n = try young(&gc, 1);
+    const d = try young(&gc, 2);
+    const r = types.toObject(rat).as(types.Rational);
+    r.numerator = n;
+    r.denominator = d;
+    gc.writeBarrier(&r.header, n);
+    try expectRememberedTrace(&gc, rat, &.{ ref(n, 1), ref(d, 2) });
+}
+
+test "gc tracing (remembered set): ffi_function" {
+    var gc = newGc();
+    defer gc.deinit();
+    const fn_val = try gc.allocFfiFunction(@ptrCast(&opaque_handle), types.NIL, "probe", &.{}, .void_type);
+    try promoteToOld(&gc, fn_val);
+    const lib = try young(&gc, 1);
+    const f = types.toObject(fn_val).as(types.FfiFunction);
+    f.library = lib;
+    gc.writeBarrier(&f.header, lib);
+    try expectRememberedTrace(&gc, fn_val, &.{ref(lib, 1)});
+}
+
+test "gc tracing (remembered set): ffi_callback" {
+    var gc = newGc();
+    defer gc.deinit();
+    const cb = try gc.allocFfiCallback(types.NIL, 255, @ptrCast(&opaque_handle));
+    try promoteToOld(&gc, cb);
+    const cls = try young(&gc, 1);
+    const c = types.toObject(cb).as(types.FfiCallback);
+    c.closure = cls;
+    gc.writeBarrier(&c.header, cls);
+    try expectRememberedTrace(&gc, cb, &.{ref(cls, 1)});
+}
+
+test "gc tracing (remembered set): channel" {
+    var gc = newGc();
+    defer gc.deinit();
+    const ch_val = try gc.allocChannel();
+    try promoteToOld(&gc, ch_val);
+    const head = try young(&gc, 1);
+    const tail = try young(&gc, 2);
+    const ch = types.toObject(ch_val).as(types.Channel);
+    ch.head = head;
+    ch.tail = tail;
+    gc.writeBarrier(&ch.header, head);
+    try expectRememberedTrace(&gc, ch_val, &.{ ref(head, 1), ref(tail, 2) });
+}
+
+test "gc tracing (remembered set): mutex" {
+    var gc = newGc();
+    defer gc.deinit();
+    const m_val = try gc.allocMutex(types.NIL);
+    try promoteToOld(&gc, m_val);
+    const name = try young(&gc, 1);
+    const owner = try young(&gc, 2);
+    const specific = try young(&gc, 3);
+    const m = types.toObject(m_val).as(types.Mutex);
+    m.name = name;
+    m.owner = owner;
+    m.specific = specific;
+    gc.writeBarrier(&m.header, owner);
+    try expectRememberedTrace(&gc, m_val, &.{ ref(name, 1), ref(owner, 2), ref(specific, 3) });
+}
+
+test "gc tracing (remembered set): condition_variable" {
+    var gc = newGc();
+    defer gc.deinit();
+    const cv_val = try gc.allocConditionVariable(types.NIL);
+    try promoteToOld(&gc, cv_val);
+    const name = try young(&gc, 1);
+    const specific = try young(&gc, 2);
+    const cv = types.toObject(cv_val).as(types.ConditionVariable);
+    cv.name = name;
+    cv.specific = specific;
+    gc.writeBarrier(&cv.header, name);
+    try expectRememberedTrace(&gc, cv_val, &.{ ref(name, 1), ref(specific, 2) });
+}
+
+test "gc tracing (remembered set): scheme_environment" {
+    var gc = newGc();
+    defer gc.deinit();
+    const map = try gc.allocator.create(std.StringHashMap(Value));
+    map.* = std.StringHashMap(Value).init(gc.allocator);
+    const env = try gc.allocEnvironment(map, true, false);
+    try promoteToOld(&gc, env);
+    const a = try young(&gc, 1);
+    try map.put("a", a);
+    gc.writeBarrier(types.toObject(env), a);
+    try expectRememberedTrace(&gc, env, &.{ref(a, 1)});
+}
+
+test "gc tracing (remembered set): transport_cell" {
+    var gc = newGc();
+    defer gc.deinit();
+    const tc = try gc.allocTransportCell(types.NIL, types.NIL);
+    try promoteToOld(&gc, tc);
+    const k = try young(&gc, 1);
+    const v = try young(&gc, 2);
+    const cell = types.toObject(tc).as(types.TransportCell);
+    cell.key = k;
+    cell.value = v;
+    gc.writeBarrier(&cell.header, k);
+    try expectRememberedTrace(&gc, tc, &.{ ref(k, 1), ref(v, 2) });
+}
+
+test "gc tracing (remembered set): fiber" {
+    var gc = newGc();
+    defer gc.deinit();
+    const fiber = try gc.allocFiber(types.NIL, 1);
+    const fiber_val = types.makePointer(&fiber.header);
+    try promoteToOld(&gc, fiber_val);
+
+    const thunk = try young(&gc, 1);
+    const reg = try young(&gc, 2);
+    const handler = try young(&gc, 3);
+    const before = try young(&gc, 4);
+    const after = try young(&gc, 5);
+    const param = try young(&gc, 6);
+    const owned_mutex = try young(&gc, 7);
+    const io_buffer = try young(&gc, 8);
+
+    fiber.thunk = thunk;
+    fiber.io_buffer = io_buffer;
+    fiber.frames[0] = .{ .closure = null, .code = &.{}, .ip = 0, .base = 0, .dst = 0 };
+    fiber.frame_count = 1;
+    fiber.registers[3] = reg;
+    fiber.handler_stack[0] = .{ .handler = handler, .frame_count = 0 };
+    fiber.handler_count = 1;
+    fiber.wind_stack[0] = .{ .before = before, .after = after };
+    fiber.wind_count = 1;
+    try fiber.param_overrides.put(1, param);
+    try fiber.owned_mutexes.append(gc.allocator, owned_mutex);
+    gc.writeBarrier(&fiber.header, thunk);
+
+    // `.fiber` is the one arm that is shared rather than duplicated:
+    // markObjectContents and markValueInner both delegate to
+    // fiber.markFiberState, so this case and the Test A one above cover the
+    // same code. referencesYoung's `.fiber` arm is still hand-written, and
+    // its own comment says the remembered-set path is belt-and-braces there
+    // because a scheduler-resident fiber is an unconditional root — this
+    // fiber belongs to no scheduler, so the path is exercised for real.
+    try expectRememberedTrace(&gc, fiber_val, &.{
+        ref(thunk, 1),       ref(reg, 2),       ref(handler, 3),
+        ref(before, 4),      ref(after, 5),     ref(param, 6),
+        ref(owned_mutex, 7), ref(io_buffer, 8),
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Write barrier
+// ---------------------------------------------------------------------------
+
+test "gc write barrier: records an old container pointing at a young value" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocPair(types.NIL, types.NIL);
+    try promoteToOld(&gc, c);
+    const cobj = types.toObject(c);
+    try std.testing.expect(!inRemembered(&gc, cobj));
+
+    const a = try young(&gc, 1);
+    cobj.as(types.Pair).car = a;
+    gc.writeBarrier(cobj, a);
+    try std.testing.expect(inRemembered(&gc, cobj));
+}
+
+test "gc write barrier: no entry for a young container or a non-pointer value" {
+    var gc = newGc();
+    defer gc.deinit();
+
+    // Young container: minor collections mark it from the roots anyway.
+    const y = try gc.allocPair(types.NIL, types.NIL);
+    const a = try young(&gc, 1);
+    gc.writeBarrier(types.toObject(y), a);
+    try std.testing.expect(!inRemembered(&gc, types.toObject(y)));
+
+    // Old container, immediate value: nothing to remember.
+    const o = try gc.allocPair(types.NIL, types.NIL);
+    try promoteToOld(&gc, o);
+    gc.writeBarrier(types.toObject(o), types.makeFixnum(7));
+    try std.testing.expect(!inRemembered(&gc, types.toObject(o)));
+}
+
+test "gc write barrier: an entry whose young referent is gone is pruned" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocPair(types.NIL, types.NIL);
+    try promoteToOld(&gc, c);
+    const cobj = types.toObject(c);
+
+    const a = try young(&gc, 1);
+    cobj.as(types.Pair).car = a;
+    gc.writeBarrier(cobj, a);
+    try std.testing.expect(inRemembered(&gc, cobj));
+
+    // Repoint at an immediate: `referencesYoung` must now say no, and
+    // pruneRememberedSet must drop the stale entry.
+    cobj.as(types.Pair).car = types.makeFixnum(7);
+    forceMinor(&gc);
+    try std.testing.expect(!inRemembered(&gc, cobj));
+    try expectDead(&gc, ref(a, 1));
+}
+
+// Pins a property that is easy to assume the other way round, and that
+// decides how dangerous a *missing* `gc.writeBarrier` call is anywhere in
+// the tree: a minor collection here is a **full transitive mark** from the
+// roots. `minorCollect` calls `clearOldMarks` and then `markRoots`, and
+// `markValueInner` never stops at the young/old boundary — only the *sweep*
+// is generational (`sweepYoung` vs `sweep` + `sweepOld`).
+//
+// So an old object that is reachable from any root has its young children
+// traced whether or not it is in the remembered set, and the remembered set
+// only ever adds young children of old objects that are *not* root-reachable
+// — floating garbage a minor collection cannot free anyway. A forgotten
+// barrier is therefore a conservative-retention miss, not a lost live object.
+//
+// If `minorCollect` ever becomes a true generational mark that stops at old
+// objects, this test flips to failing — which is exactly the moment every
+// heap-mutation site in the tree needs auditing for a missing barrier.
+test "gc write barrier: a minor collection marks through an old object with no remembered-set entry" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocPair(types.NIL, types.NIL);
+    try promoteToOld(&gc, c);
+
+    var root = c;
+    gc.pushRoot(&root);
+    defer gc.popRoot();
+
+    const a = try young(&gc, 1);
+    types.toObject(c).as(types.Pair).car = a; // deliberately no writeBarrier
+    try std.testing.expect(!inRemembered(&gc, types.toObject(c)));
+
+    forceMinor(&gc);
+    try expectAlive(&gc, ref(a, 1));
+}
+
+// ---------------------------------------------------------------------------
+// Comptime inventory
+// ---------------------------------------------------------------------------
+
+/// Pins the exact field list of a heap struct (or a satellite one of the GC
+/// switches reaches through). A field added, removed or renamed here is a
+/// build error until someone has decided whether it holds a `Value` and, if
+/// so, updated all five per-tag switches. This is the only compiler-enforced
+/// check on the *inside* of those arms: exhaustiveness only proves an arm
+/// exists. `Value` is `u64`, so no comptime type test can tell a real Value
+/// apart from `profile_calls: u64` — pinning the whole field list is what
+/// makes the guard sound.
+fn expectFields(comptime T: type, comptime pinned: []const []const u8) void {
+    comptime {
+        var actual: []const u8 = "";
+        for (@typeInfo(T).@"struct".fields, 0..) |f, i| {
+            actual = actual ++ (if (i == 0) "" else ", ") ++ f.name;
+        }
+        var want: []const u8 = "";
+        for (pinned, 0..) |p, i| {
+            want = want ++ (if (i == 0) "" else ", ") ++ p;
+        }
+        if (!std.mem.eql(u8, actual, want)) @compileError(
+            "GC tracing inventory out of date for " ++ @typeName(T) ++ "\n" ++
+                "  pinned: " ++ want ++ "\n" ++
+                "  actual: " ++ actual ++ "\n" ++
+                "If the change adds or removes a Value-bearing field, update ALL of\n" ++
+                "  gc_collect.zig: markObjectContents, markValueInner, referencesYoung\n" ++
+                "  gc_sweep.zig:   objectSize, freeObject\n" ++
+                "and add a case to src/tests_gc_tracing.zig. Then re-pin here.",
+        );
+    }
+}
+
+test "gc tracing: heap-struct field inventory is unchanged" {
+    // The 41 ObjectTag members, in enum order.
+    expectFields(types.Pair, &.{ "header", "car", "cdr" });
+    expectFields(types.Symbol, &.{ "header", "name", "interned" });
+    expectFields(types.SchemeString, &.{ "header", "data", "len" });
+    expectFields(types.Closure, &.{ "header", "func", "upvalues" });
+    expectFields(types.NativeFn, &.{
+        "header",        "func",            "name",                "arity",
+        "profile_calls", "profile_time_ns", "profile_alloc_bytes",
+    });
+    expectFields(types.Vector, &.{ "header", "data" });
+    expectFields(types.Bytevector, &.{ "header", "data", "shared" });
+    expectFields(types.Port, &.{
+        "header",         "fd",             "is_input",       "is_output",
+        "is_open",        "name",           "owns_name",      "peek_byte",
+        "peek_extra",     "peek_extra_len", "is_string_port", "string_data",
+        "string_pos",     "string_out_buf", "string_out_len", "string_out_cap",
+        "string_out_pos", "is_binary",      "read_buf",       "read_buf_len",
+        "random_gen",     "nonblocking",    "write_buf",      "write_buf_start",
+        "write_buf_len",  "fd_state",       "custom_backend", "transcode",
+    });
+    expectFields(types.RecordType, &.{
+        "header", "name",            "num_fields",        "own_field_count",
+        "parent", "own_field_names", "own_field_mutable", "uid",
+        "sealed", "is_opaque",
+    });
+    expectFields(types.Function, &.{
+        "header",          "code",                 "constants",           "arity",
+        "locals_count",    "upvalue_count",        "is_variadic",         "name",
+        "owns_name",       "source_line",          "source_name",         "debug_locals",
+        "line_table",      "global_cache",         "cache_version",       "env",
+        "env_val",         "restricted_globals",   "profile_instrs",      "profile_calls",
+        "profile_time_ns", "profile_inclusive_ns", "profile_alloc_bytes",
+    });
+    expectFields(types.Flonum, &.{ "header", "value" });
+    expectFields(types.Transformer, &.{
+        "header",               "literals",        "patterns",            "templates",
+        "num_rules",            "kind",            "proc",                "finalized",
+        "peers_computed",       "captured_locals", "def_env",             "def_env_val",
+        "def_lib_name",         "custom_ellipsis", "literal_bound",       "let_syntax_peer_names",
+        "let_syntax_peer_vals", "bound_free_refs", "def_site_local_refs",
+    });
+    expectFields(types.ErrorObject, &.{
+        "header", "message", "irritants", "error_type", "uncaught_reason", "code",
+    });
+    expectFields(types.RecordInstance, &.{ "header", "record_type", "fields" });
+    expectFields(types.Continuation, &.{
+        "header",   "registers",          "frames",            "frame_count",
+        "handlers", "handler_count",      "wind_records",      "wind_count",
+        "dst_reg",  "dst_base",           "backing",           "is_escape",
+        "valid",    "target_frame_count", "target_wind_count", "target_handler_count",
+    });
+    expectFields(types.MultipleValues, &.{ "header", "values" });
+    expectFields(types.Complex, &.{ "header", "real", "imag", "exact_real", "exact_imag" });
+    expectFields(types.Promise, &.{ "header", "forced", "forcing", "value" });
+    expectFields(types.ParameterObject, &.{ "header", "value", "converter" });
+    expectFields(types.FfiLibrary, &.{ "header", "handle", "name" });
+    expectFields(types.FfiFunction, &.{
+        "header", "symbol", "library", "name", "param_types", "return_type", "param_count",
+    });
+    expectFields(types.FfiCallback, &.{ "header", "closure", "slot_index", "fn_ptr", "active" });
+    expectFields(types.HashTable, &.{
+        "header", "entries", "count", "capacity", "compare_mode", "equiv_fn", "hash_fn",
+    });
+    expectFields(types.Bignum, &.{ "header", "limbs", "len", "positive" });
+    expectFields(types.Rational, &.{ "header", "numerator", "denominator" });
+    expectFields(types.FileInfo, &.{
+        "header", "size",   "mtime",     "atime",   "ctime",  "dev",
+        "ino",    "nlinks", "rdev",      "blksize", "blocks", "mode",
+        "uid",    "gid",    "file_type",
+    });
+    expectFields(types.UserInfo, &.{
+        "header", "name", "uid", "gid", "home_dir", "shell", "full_name",
+    });
+    expectFields(types.GroupInfo, &.{ "header", "name", "gid" });
+    expectFields(types.DirectoryObject, &.{ "header", "dir", "include_dotfiles" });
+    expectFields(types.RandomSource, &.{ "header", "prng" });
+    expectFields(fiber_mod.Fiber, &.{
+        "header",            "registers",            "frames",             "frame_count",
+        "handler_stack",     "handler_count",        "wind_stack",         "wind_count",
+        "current_exception", "continuation_invoked", "continuation_value", "status",
+        "thunk",             "result",               "waiting_on",         "id",
+        "name",              "specific",             "param_overrides",    "deadline_ns",
+        "timed_out",         "driving",              "terminated",         "os_thread",
+        "io_fd",             "io_interest",          "io_buffer",          "sched_idx",
+        "queued",            "rv_demand_on",         "owned_mutexes",
+    });
+    expectFields(types.Channel, &.{
+        "header", "head", "tail", "queue_len", "capacity", "rv_demand", "closed", "shared",
+    });
+    expectFields(types.Mutex, &.{
+        "header", "name", "owner", "locked", "abandoned", "specific",
+    });
+    expectFields(types.ConditionVariable, &.{
+        "header", "name", "specific", "signal_generation",
+    });
+    expectFields(types.Srfi18Time, &.{ "header", "seconds", "nanoseconds", "time_type" });
+    expectFields(types.NativeClosure, &.{ "header", "fn_ptr", "upvalues", "arity", "name" });
+    expectFields(types.SchemeEnvironment, &.{ "header", "env", "owned", "immutable" });
+    expectFields(types.Ephemeron, &.{ "header", "key", "value", "broken" });
+    expectFields(types.Guardian, &.{ "header", "is_transport", "registered", "ready" });
+    expectFields(types.TransportCell, &.{ "header", "key", "value", "broken" });
+    expectFields(types.NumericVector, &.{ "header", "kind", "data" });
+
+    // Satellites the switches reach *through* — the highest-risk group,
+    // because a new field here is invisible at the ObjectTag level entirely.
+    expectFields(types.CustomBacking, &.{
+        "read_proc",         "write_proc", "get_position_proc",
+        "set_position_proc", "close_proc", "flush_proc",
+    });
+    expectFields(types.TranscodeState, &.{
+        "wrapped_port", "codec", "eol_style", "error_mode",
+    });
+    expectFields(types.HashEntry, &.{ "key", "value", "state" });
+    expectFields(types.GuardEntry, &.{ "watched", "payload" });
+    expectFields(types.WindRecord, &.{ "before", "after" });
+    expectFields(types.ExceptionHandler, &.{ "handler", "frame_count", "sticky" });
+    expectFields(types.SavedFrame, &.{
+        "closure", "native",           "code",              "ip",  "base",
+        "dst",     "saved_wind_count", "returns_to_native", "seq",
+    });
+    expectFields(types.CallFrame, &.{
+        "closure", "native",           "code",              "ip",  "base",
+        "dst",     "saved_wind_count", "returns_to_native", "seq",
+    });
+}
+
+test "gc tracing: every ObjectTag has a case in this file" {
+    // The runtime cases above cover every tag that carries a Value; the
+    // remaining ones are covered by "leaf tags survive while rooted".
+    // `.flonum` is the one tag with no allocator at all — `allocFlonum`
+    // returns a NaN-boxed immediate, so no heap Flonum is ever created (the
+    // tag, its struct and its five arms are vestigial). Keep this count in
+    // step with ObjectTag so a new tag cannot be added without landing here.
+    try std.testing.expectEqual(@as(usize, 41), @typeInfo(types.ObjectTag).@"enum".fields.len);
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -17,6 +17,7 @@ test {
     _ = @import("tests_filesystem.zig");
     _ = @import("tests_robustness.zig");
     _ = @import("tests_gc_root_boundary.zig");
+    _ = @import("tests_gc_tracing.zig");
     _ = @import("tests_fuzz.zig");
     _ = @import("tests_deepcopy.zig");
     _ = @import("tests_shared_channel.zig");


### PR DESCRIPTION
Phase 7B of the v2 audit campaign (#1890). Adds `src/tests_gc_tracing.zig` (1,425 lines, 62 tests).

**1496/1496 under `-Dgc-stress=true`**, exit 0. Default `zig build test` green. Full `run-all.sh` on the rebased tree: **632 pass, 0 fail; R7RS 1395/1395**.

## The gap this closes

Zig's exhaustiveness check guarantees an *arm exists* for each of 41 tags in all five per-tag switches. **Nothing guaranteed what is inside each arm.** A tag whose arm forgets a Value field compiles cleanly and traces nothing.

## No arm is missing a field

All three mark-graph switches are complete against a 41-tag × Value-field inventory (26 tags with Value fields, 15 without).

And the best news is a compile error: **mutation 8 added a 7th `Value` field to `CustomBacking` and got a build failure naming all five switches.** The hazard this phase was built around is compiler-caught after all — for that struct.

## Mutation-verified, which is the whole point

Eight mutations, each with its exact kill set. Two worth calling out:

- **Mutation 2** dropped `transcode.wrapped_port` from `markPortValues` and killed only the remembered-set case — Test A's transcode case still **passed**, proving the two duplicated port implementations are independently covered.
- **Mutation 3** dropped the same check from `referencesYoung` and killed the same case at the *retention* assertion, isolating it from `markObjectContents`.

I independently re-ran one (dropping `tx.proc` from `markValueInner`): **65 pass, 1 fail**, tree restored clean.

## The finding: a minor collection performs a full transitive mark — #1961

```text
minorCollect:       clearOldMarks → markRoots → remembered walk → sweepYoung
markValueInner:     0 generation checks
markObjectContents: exactly 1 production caller
```

Only the *sweep* is generational. Three consequences: minor and full collections cost the same to mark; a forgotten `writeBarrier` is currently a **retention miss, not a use-after-free**; and `markObjectContents`' 41 arms are retention-only.

**All three invert if the minor mark is ever made truly generational** — the obvious optimisation. A dedicated test **flips to failing the moment that happens**, telling whoever makes that change that every mutation site now needs auditing. That is the intended signal, not a spurious failure.

## Also filed: #1962

`Function.env` and `Transformer.def_env` are raw `*StringHashMap(Value)` traced by **nothing**, safe only via an unwritten invariant — and five call sites already pass `env_val = NIL` with a live map, relying entirely on the map being separately VM-rooted. A future caller passing a private map would silently lose its bindings and look identical to the five that are fine.

Alongside it: `markFiberState` and `referencesYoung` disagree on the fiber register range despite a comment claiming lockstep. Conservative-only today, and only because of #1961.

## Honest gaps

- **`.flonum` has no allocator at all** — `allocFlonum` returns a NaN-boxed immediate, so the tag, its struct and its five arms are vestigial. Pinned as a comment, not a test.
- The 15 no-Value tags get liveness-and-reclamation only; the comptime inventory is their real guard.
- `Channel.shared` is not a Value and is not traced by these switches — KEP-0002 machinery, covered by Phase 5C.
- Ephemerons/guardians are excluded from the remembered-set shape because `processWeakRefs` resurrects an unrooted guardian's elements anyway, making that case non-discriminating. Their weak semantics get 4 dedicated cases instead.

`Fiber`, `Continuation`, the FFI types and `DirectoryObject` turned out **not** to be hard — `gc_alloc.zig` exports public constructors, so they are built directly rather than through the VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)