### PR TITLE
Stop the "port I/O abandoned" error naming dynamic-wind as unparkable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The "port I/O abandoned" error no longer blames `dynamic-wind`** (#1959).
+  It named "guard, dynamic-wind, callbacks" as the frames a fiber cannot
+  suspend under, but `dynamic-wind` is bootstrapped Scheme: its body runs in
+  the bytecode dispatch loop and a fiber parks inside it exactly like a bare
+  read. Anyone debugging this error was being sent to move blocking I/O out
+  of a `dynamic-wind` for no reason, leaving it inside the `guard` that
+  actually caused the drive. The message now names what genuinely opens a
+  nested native frame: `guard`, and the native higher-order drivers (SRFI-1
+  `fold`/`filter`/`find`, `hash-table-walk`, `assoc`/`member` with a custom
+  predicate, `string-index`, `eval`). README's matching list also dropped
+  `sort`, which is portable Scheme (SRFI 95) and parks too.
 - **Nested `guard` past 64 levels no longer returns a wrong answer** (#1886).
   The exception-handler and dynamic-wind stacks were fixed 64-entry arrays.
   Past that, `with-exception-handler` relabelled the overflow as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   nested native frame: `guard`, and the native higher-order drivers (SRFI-1
   `fold`/`filter`/`find`, `hash-table-walk`, `assoc`/`member` with a custom
   predicate, `string-index`, `eval`). README's matching list also dropped
-  `sort`, which is portable Scheme (SRFI 95) and parks too.
+  `sort`, which is portable Scheme (SRFI 95) and parks too — a fiber
+  blocking inside a `sort` comparator is now covered by the same test.
 - **Nested `guard` past 64 levels no longer returns a wrong answer** (#1886).
   The exception-handler and dynamic-wind stacks were fixed 64-entry arrays.
   Past that, `with-exception-handler` relabelled the overflow as

--- a/README.md
+++ b/README.md
@@ -420,8 +420,8 @@ Callbacks driven by `map`, `for-each`, `vector-map`, `vector-for-each`,
 bytecode dispatch loop, so a fiber can park inside them (e.g. block on an
 empty channel) and resume later. Other higher-order procedures are still
 native drivers — SRFI-1 (`fold`, `filter`, `find`, `any`, `every`, ...),
-`sort`, `hash-table-walk`/`hash-table-update!`, `assoc`/`member` with a
-custom predicate, `string-index`, `eval`, ... — and a fiber that blocks on
+`hash-table-walk`/`hash-table-update!`, `assoc`/`member` with a custom
+predicate, `string-index`, `eval`, ... — and a fiber that blocks on
 an empty channel inside one of those callbacks cannot be parked: the native
 call's state lives on the Zig stack and cannot be suspended. If other fibers
 are runnable the scheduler still makes progress, but if the blocked receive

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -1232,8 +1232,10 @@ pub fn waitForFd(vm: *VM, fd: platform.fd_t, interest: reactor_mod.Interest) VME
     // retry the syscall, EAGAIN again, and re-enter the same drive: an
     // unbreakable spin. Raise a catchable error instead; the defer above
     // has already pulled `me` off the reactor, and the re-entrant frames
-    // that made parking impossible (guard, dynamic-wind) are exception
-    // plumbing — an ordinary raise is exactly the unwind they handle.
+    // that made parking impossible (guard's exception plumbing, a native
+    // higher-order driver's callback) all sit under a Zig caller that
+    // propagates an error — an ordinary raise is exactly the unwind they
+    // already handle.
     if (!done) return raiseIoWaitAbandoned(vm);
 }
 
@@ -1241,10 +1243,24 @@ pub fn waitForFd(vm: *VM, fd: platform.fd_t, interest: reactor_mod.Interest) VME
 /// A plain ErrorObject like blockOrDeadlock's deadlock errors — this is the
 /// I/O drive's analogue of those: "this wait can no longer be serviced
 /// without wedging the scheduler."
+///
+/// The frames named here must be *native* ones (#1959). `dynamic-wind`,
+/// `map`/`for-each`, the vector/string mapping procedures and `force` are
+/// bootstrapped Scheme (vm_bootstrap.zig): their bodies and callbacks run
+/// in the bytecode dispatch loop, so a fiber parks inside them normally.
+/// Naming `dynamic-wind` here sent readers of this error hunting in
+/// exactly the wrong place. (Its before/after thunks *are* native frames
+/// when a continuation transition or an unwind runs them via callThunk —
+/// but that is the wind machinery re-entering them, not the ordinary
+/// `(dynamic-wind before thunk after)` call this message was read as
+/// indicting.) The drive/park split is pinned by the "#1959:" and
+/// "#1625:" tests in tests_port_io.zig.
 fn raiseIoWaitAbandoned(vm: *VM) VMError {
     var msg = vm.gc.allocString(
         "port I/O abandoned: fiber cannot suspend under re-entrant native frames " ++
-            "(guard, dynamic-wind, callbacks) while an enclosing completed wait needs this thread",
+            "(guard, and native higher-order drivers such as SRFI-1 fold/filter/find, " ++
+            "hash-table-walk, assoc/member with a custom predicate, string-index, eval) " ++
+            "while an enclosing completed wait needs this thread",
     ) catch return VMError.OutOfMemory;
     vm.gc.pushRoot(&msg);
     defer vm.gc.popRoot();

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -1273,9 +1273,11 @@ fn localChannelDeadlockMsg(buf: []u8, base: []const u8) []const u8 {
 /// scheduler loop parks itself: status .waiting on the channel/fiber, and
 /// yield_retry makes the dispatch loop rewind ip so the blocking primitive
 /// re-executes when a channel-send (or fiber completion) wakes it. The main
-/// fiber — or a fiber blocked under re-entrant native frames (map/for-each
-/// callbacks, eval), which cannot be safely rewound — raises a deadlock
-/// error instead of returning an unspecified value.
+/// fiber — or a fiber blocked under re-entrant native frames (a native
+/// higher-order driver's callback, eval), which cannot be safely rewound —
+/// raises a deadlock error instead of returning an unspecified value.
+/// `map`/`for-each` are not such frames: they are bootstrapped Scheme and
+/// a fiber parks inside them (#1959).
 fn blockOrDeadlock(vm: *vm_mod.VM, me: *fiber_mod.Fiber, my_idx: usize, wait_on: Value, deadlock_msg: []const u8) PrimitiveError!Value {
     if (my_idx != 0 and vm.dispatched_from_scheduler) {
         me.status = .waiting;

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -169,7 +169,7 @@ test "closing a port with a parked reader raises a clean error in that fiber" {
     try std.testing.expectEqual(types.TRUE, r);
 }
 
-test "#1959: a reader inside dynamic-wind or map parks; only native frames drive" {
+test "#1959: a reader inside dynamic-wind, map or sort parks; only native frames drive" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -177,19 +177,24 @@ test "#1959: a reader inside dynamic-wind or map parks; only native frames drive
 
     const pipe1 = makePipe();
     const pipe2 = makePipe();
+    const pipe3 = makePipe();
     _ = try definePortGlobal(vm, "rp1", pipe1[0], true, false);
     _ = try definePortGlobal(vm, "wp1", pipe1[1], false, true);
     _ = try definePortGlobal(vm, "rp2", pipe2[0], true, false);
     _ = try definePortGlobal(vm, "wp2", pipe2[1], false, true);
+    _ = try definePortGlobal(vm, "rp3", pipe3[0], true, false);
+    _ = try definePortGlobal(vm, "wp3", pipe3[1], false, true);
 
-    _ = try vm.eval("(import (kaappi fibers))");
-    // dynamic-wind and map are bootstrapped Scheme (vm_bootstrap.zig), not
-    // natives: their callbacks run in the bytecode dispatch loop, so a fiber
-    // blocking on an fd inside one parks and retries like a bare read. Only
-    // *native* re-entrant frames — guard's exception plumbing (the test
-    // below), native higher-order drivers, eval — force the drive-in-place
-    // path. This pins the split that raiseIoWaitAbandoned's message names,
-    // which listed dynamic-wind as unparkable until #1959.
+    _ = try vm.eval("(import (kaappi fibers) (srfi 95))");
+    // dynamic-wind and map are bootstrapped Scheme (vm_bootstrap.zig) and
+    // sort is portable Scheme (lib/srfi/95.sld) — none is a native: their
+    // callbacks run in the bytecode dispatch loop, so a fiber blocking on
+    // an fd inside one parks and retries like a bare read. Only *native*
+    // re-entrant frames — guard's exception plumbing (the test below),
+    // native higher-order drivers, eval — force the drive-in-place path.
+    // This pins the split that raiseIoWaitAbandoned's message names, which
+    // listed dynamic-wind as unparkable until #1959 (and which README and
+    // the docs site's conformance page both listed `sort` under).
     _ = try vm.eval(
         \\(define fw (spawn (lambda ()
         \\  (dynamic-wind (lambda () #f)
@@ -200,11 +205,23 @@ test "#1959: a reader inside dynamic-wind or map parks; only native frames drive
         \\(define fm (spawn (lambda ()
         \\  (car (map (lambda (p) (read-char p)) (list rp2))))))
     );
-    // Dispatch both before any writer exists, so the assertion cannot be
-    // satisfied by a lucky write-first schedule: a fiber that drove in place
-    // instead of parking never reaches .io_waiting here.
+    // The comparator reads once and caches: sort calls less? an unspecified
+    // number of times, but only the first must find the pipe empty. (A park
+    // re-executes the read-char primitive, not the enclosing comparator, so
+    // the cache survives the retry.)
+    _ = try vm.eval(
+        \\(define fs (spawn (lambda ()
+        \\  (let ((c #f))
+        \\    (sort (list 2 1)
+        \\          (lambda (a b)
+        \\            (if (not c) (set! c (read-char rp3)))
+        \\            (< a b)))))))
+    );
+    // Dispatch all three before any writer exists, so the assertion cannot
+    // be satisfied by a lucky write-first schedule: a fiber that drove in
+    // place instead of parking never reaches .io_waiting here.
     _ = try vm.eval("(fiber-join (spawn (lambda () 1)))");
-    for ([_][]const u8{ "fw", "fm" }) |name| {
+    for ([_][]const u8{ "fw", "fm", "fs" }) |name| {
         const f_val = try vm.eval(name);
         try std.testing.expectEqual(fiber_mod.FiberStatus.io_waiting, types.toObject(f_val).as(fiber_mod.Fiber).status);
     }
@@ -212,10 +229,12 @@ test "#1959: a reader inside dynamic-wind or map parks; only native frames drive
     _ = try vm.eval(
         \\(define w (spawn (lambda ()
         \\  (write-char #\a wp1) (flush-output-port wp1)
-        \\  (write-char #\b wp2) (flush-output-port wp2))))
+        \\  (write-char #\b wp2) (flush-output-port wp2)
+        \\  (write-char #\c wp3) (flush-output-port wp3))))
     );
     try std.testing.expectEqual(types.makeChar('a'), try vm.eval("(fiber-join fw)"));
     try std.testing.expectEqual(types.makeChar('b'), try vm.eval("(fiber-join fm)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? (fiber-join fs) '(1 2))"));
 }
 
 test "#1625: guard reader's idle drive unwinds instead of wedging a resolved join" {

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -169,6 +169,55 @@ test "closing a port with a parked reader raises a clean error in that fiber" {
     try std.testing.expectEqual(types.TRUE, r);
 }
 
+test "#1959: a reader inside dynamic-wind or map parks; only native frames drive" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe1 = makePipe();
+    const pipe2 = makePipe();
+    _ = try definePortGlobal(vm, "rp1", pipe1[0], true, false);
+    _ = try definePortGlobal(vm, "wp1", pipe1[1], false, true);
+    _ = try definePortGlobal(vm, "rp2", pipe2[0], true, false);
+    _ = try definePortGlobal(vm, "wp2", pipe2[1], false, true);
+
+    _ = try vm.eval("(import (kaappi fibers))");
+    // dynamic-wind and map are bootstrapped Scheme (vm_bootstrap.zig), not
+    // natives: their callbacks run in the bytecode dispatch loop, so a fiber
+    // blocking on an fd inside one parks and retries like a bare read. Only
+    // *native* re-entrant frames — guard's exception plumbing (the test
+    // below), native higher-order drivers, eval — force the drive-in-place
+    // path. This pins the split that raiseIoWaitAbandoned's message names,
+    // which listed dynamic-wind as unparkable until #1959.
+    _ = try vm.eval(
+        \\(define fw (spawn (lambda ()
+        \\  (dynamic-wind (lambda () #f)
+        \\                (lambda () (read-char rp1))
+        \\                (lambda () #f)))))
+    );
+    _ = try vm.eval(
+        \\(define fm (spawn (lambda ()
+        \\  (car (map (lambda (p) (read-char p)) (list rp2))))))
+    );
+    // Dispatch both before any writer exists, so the assertion cannot be
+    // satisfied by a lucky write-first schedule: a fiber that drove in place
+    // instead of parking never reaches .io_waiting here.
+    _ = try vm.eval("(fiber-join (spawn (lambda () 1)))");
+    for ([_][]const u8{ "fw", "fm" }) |name| {
+        const f_val = try vm.eval(name);
+        try std.testing.expectEqual(fiber_mod.FiberStatus.io_waiting, types.toObject(f_val).as(fiber_mod.Fiber).status);
+    }
+    // ...and the parked reads resume losslessly once the peer writes.
+    _ = try vm.eval(
+        \\(define w (spawn (lambda ()
+        \\  (write-char #\a wp1) (flush-output-port wp1)
+        \\  (write-char #\b wp2) (flush-output-port wp2))))
+    );
+    try std.testing.expectEqual(types.makeChar('a'), try vm.eval("(fiber-join fw)"));
+    try std.testing.expectEqual(types.makeChar('b'), try vm.eval("(fiber-join fm)"));
+}
+
 test "#1625: guard reader's idle drive unwinds instead of wedging a resolved join" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -504,8 +504,13 @@ pub const VM = struct {
     /// True while the innermost active runUntil was invoked directly by a
     /// fiber scheduler loop. Blocking primitives may only park the current
     /// fiber with yield_retry when this is set — otherwise Zig-native frames
-    /// (map/for-each callbacks, eval) sit between the fiber's bytecode and
-    /// the scheduler, and a retry would corrupt them.
+    /// (a native higher-order driver's callback, with-exception-handler's
+    /// thunk, eval) sit between the fiber's bytecode and the scheduler, and
+    /// a retry would corrupt them. `map`/`for-each` and `dynamic-wind` are
+    /// *not* examples: they are bootstrapped Scheme (vm_bootstrap.zig), so
+    /// their bodies and callbacks stay in this loop and a fiber parks
+    /// inside them (#1959). Only the wind before/after thunks a
+    /// continuation transition re-enters via callThunk are native frames.
     dispatched_from_scheduler: bool = false,
     /// SRFI 181: incremented/decremented (via defer) only around the
     /// callWithArgs calls into a custom port's read!/write!/get-position/
@@ -516,10 +521,11 @@ pub const VM = struct {
     /// (fiber.waitForFd's park-vs-drive branch) with a confirmed native-
     /// stack-overflow risk under concurrent fibers. This narrow counter
     /// (not the broader native_reentry_depth, which is incremented for
-    /// every reentrant call — with-exception-handler thunks, map/for-each
-    /// callbacks, apply — and would wrongly reject those already-working
-    /// patterns too) lets those two sites raise a specific, catchable
-    /// error instead, only for the case this SRFI introduces.
+    /// every reentrant call — with-exception-handler thunks, native
+    /// higher-order drivers' callbacks, apply — and would wrongly reject
+    /// those already-working patterns too) lets those two sites raise a
+    /// specific, catchable error instead, only for the case this SRFI
+    /// introduces.
     in_custom_port_callback: u16 = 0,
     /// For child OS threads (SRFI-18): points at the parent-heap fiber's
     /// `terminated` flag. Checked at the periodic dispatch-loop safepoint so

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -509,8 +509,11 @@ pub const VM = struct {
     /// a retry would corrupt them. `map`/`for-each` and `dynamic-wind` are
     /// *not* examples: they are bootstrapped Scheme (vm_bootstrap.zig), so
     /// their bodies and callbacks stay in this loop and a fiber parks
-    /// inside them (#1959). Only the wind before/after thunks a
-    /// continuation transition re-enters via callThunk are native frames.
+    /// inside them (#1959). Only the wind before/after thunks re-entered
+    /// via callThunk are native frames — by a continuation transition
+    /// (vm_continuations.zig) or by an unwind, either a frame return
+    /// leaving its own extent (vm_dispatch.zig) or an error unwinding
+    /// execute (vm_calls.zig).
     dispatched_from_scheduler: bool = false,
     /// SRFI 181: incremented/decremented (via defer) only around the
     /// callWithArgs calls into a custom port's read!/write!/get-position/

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -43,8 +43,10 @@ fn maybeRewindRetry(self: *VM, instr_len: usize) void {
 /// A frame with returns_to_native set (pushed by vm.callWithArgs) delivers its
 /// result via its own runUntil session's return value; its dst is a
 /// placeholder. When such a frame returns while frame_count is still above
-/// the dispatching loop's target, that session — the native Zig caller (map,
-/// for-each, sort, apply, ...) that owned the result — has already returned:
+/// the dispatching loop's target, that session — the native Zig caller
+/// (apply, a native higher-order driver like SRFI-1 fold or
+/// hash-table-update!, eval, a wind thunk, ...) that owned the result — has
+/// already returned:
 /// a continuation captured under the native call was resumed after the call
 /// ended. There is no register to deliver into and the native's iteration
 /// state is gone, so raise a catchable Scheme error instead of silently

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -66,9 +66,10 @@ noinline fn raiseDeadNativeReturn(self: *VM) VMError {
 /// execution must resume in the innermost dispatch loop whose scope-root
 /// frame is still live (checked by frame birth id, see resumesHere). Loops
 /// whose scope frames were discarded propagate ContinuationInvoked instead,
-/// so the re-entrant Zig callers (callThunk/callHandler in natives like
-/// with-exception-handler or dynamic-wind) between that loop and the resume
-/// point unwind and keep their pending result-register writes consistent.
+/// so the re-entrant Zig callers (callThunk/callHandler — with-exception-
+/// handler's thunk and handler, and the wind-stack before/after thunks a
+/// continuation transition runs) between that loop and the resume point
+/// unwind and keep their pending result-register writes consistent.
 pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) VMError!Value {
     // Birth id of this loop's scope-root frame (the frame whose return ends
     // the loop). Tail calls reuse the frame and keep the id, so it is stable
@@ -79,7 +80,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
         0;
     // Blocking primitives may park the current fiber (yield_retry) only when
     // this loop was entered directly from a scheduler loop; nested runUntil
-    // calls (map/for-each callbacks, eval) clear the marker for their extent.
+    // calls (a native higher-order driver's callback, with-exception-handler's
+    // thunk, eval) clear the marker for their extent. Bootstrapped-Scheme
+    // drivers like map/for-each and dynamic-wind open no nested loop for
+    // their own bodies and callbacks, so a fiber still parks inside them
+    // (#1959).
     const from_scheduler = self.sched_dispatch_pending;
     self.sched_dispatch_pending = false;
     const saved_from_scheduler = self.dispatched_from_scheduler;


### PR DESCRIPTION
Fixes #1959.

## The bug

`fiber.zig`'s `raiseIoWaitAbandoned` told users a fiber cannot suspend under
*"guard, dynamic-wind, callbacks"*. `dynamic-wind` is bootstrapped Scheme
(`vm_bootstrap.zig:272`) — its body runs in the bytecode dispatch loop and a
fiber parks inside it exactly like a bare read.

This is the worst way for a diagnostic to be wrong: the text is what a user
reads *while standing in this situation*, so it sends them to move blocking
I/O out of a `dynamic-wind` for no reason, leaving it inside the `guard` that
actually caused the drive.

## What changed

**The message** now names what genuinely opens a nested `runUntil`:

> port I/O abandoned: fiber cannot suspend under re-entrant native frames (guard, and native higher-order drivers such as SRFI-1 fold/filter/find, hash-table-walk, assoc/member with a custom predicate, string-index, eval) while an enclosing completed wait needs this thread

**Four code comments** carried the same stale claim, each naming `map`/`for-each`
callbacks as native frames — `vm.zig`'s `dispatched_from_scheduler` (the one the
issue flagged) and `in_custom_port_callback`, `vm_dispatch.zig`'s `runUntil`, and
`primitives_fiber.zig`'s `blockOrDeadlock`. Corrected alongside, since that is
how the error text acquired the claim in the first place.

One nuance kept rather than flattened: `dynamic-wind`'s before/after thunks **are**
native frames when a continuation transition re-enters them via `callThunk`
(`vm_continuations.zig:111/151/158`). That is the wind machinery, not the ordinary
`(dynamic-wind before thunk after)` call the message was read as indicting — so
`vm_dispatch.zig`'s `runUntil` doc, which was talking about exactly that path,
keeps its `dynamic-wind` reference, spelled out.

**One README correction beyond the issue's ask.** The issue holds up README §Fibers
as the correct copy, and it is — except it lists `sort` among the native drivers.
There is no native `sort`: it is portable Scheme in `lib/srfi/95.sld`, so it parks
too. Dropped, so README and the corrected message agree.

## Verification

New test `#1959: a reader inside dynamic-wind or map parks; only native frames
drive` in `tests_port_io.zig`, placed directly above the `#1625` test where `guard`
drives and unwinds, so the contrast is readable in one screen. Both readers are
dispatched *before any writer exists*, so a lucky write-first schedule cannot
satisfy it — a fiber that drove in place never reaches `.io_waiting`.

Mutation-checked: flipping the expectation to `.completed` fails with
`expected .completed, found .io_waiting`, confirming the test both runs and
discriminates.

- `zig build test` — 1457 pass, 3 skip
- `bash tests/scheme/run-all.sh` — 2029 pass, 0 fail
- `zig fmt --check`, `markdownlint-cli2` — clean

## Note for a follow-up (different repo)

`kaappi.github.io/docs/conformance.md:37` repeats the same two errors — it lists
`dynamic-wind` correctly as parkable but `sort` incorrectly as a native driver.
Not touched here since it is a separate repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)