### PR TITLE
Stop piping into grep -q under pipefail (fixes freebsd-test after #1957)

### DIFF
--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -140,6 +140,16 @@ Conventions:
   a literal match has to escape. A suite whose *assertions* all fail
   uniformly while its output comparisons stay clean is the signature of
   this, not of a real regression.
+- **Never pipe into `grep -q` under `set -o pipefail`.** Write
+  `grep -q PATTERN <<< "$output"`, not `echo "$output" | grep -q PATTERN`.
+  `grep -q` exits the moment it matches, so when the match is on an early
+  line the writer can still be mid-write and dies of SIGPIPE — and
+  `pipefail` then reports the *pipeline* as failed even though the match
+  succeeded. The assertion fails while printing the very text it was
+  looking for. It is a race, so it passes locally and fails on a loaded CI
+  runner (kaappi#1926 hit three of these at once on `freebsd-test`);
+  matching the last line of the output hides it, matching the first line
+  exposes it. The here-string has no pipeline for `pipefail` to judge.
 
 ## Quirks
 

--- a/tests/scheme/compile/compile-preamble-gc-700.sh
+++ b/tests/scheme/compile/compile-preamble-gc-700.sh
@@ -32,7 +32,7 @@ bundle_fixture_binary "$REPO_DIR" "$KAAPPI" "$BUNDLE_BIN"
 
 # Run the bundled binary — must not crash or show preamble errors
 OUTPUT=$("$BUNDLE_BIN" 2>&1)
-if echo "$OUTPUT" | grep -q "preamble error"; then
+if grep -q "preamble error" <<< "$OUTPUT"; then
     echo "FAIL: preamble error in bundled binary: $OUTPUT" >&2
     exit 1
 fi

--- a/tests/scheme/errors/check.sh
+++ b/tests/scheme/errors/check.sh
@@ -39,7 +39,7 @@ assert_out() {
     printf '%s\n' "$src" > "$TMP/prog.scm"
     local out
     out="$("$KAAPPI" check "$@" "$TMP/prog.scm" 2>&1 || true)"
-    if echo "$out" | grep -qE "$pattern"; then
+    if grep -qE "$pattern" <<< "$out"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else
@@ -92,7 +92,7 @@ assert_out "3-state message echoes the token"    "invalid number literal '3-stat
 echo "== --diagnostics=json parity =="
 printf '(car 5)\n' > "$TMP/j.scm"
 JSON="$("$KAAPPI" check --diagnostics=json "$TMP/j.scm" 2>&1 || true)"
-if echo "$JSON" | grep -q '"code":"KP4003"' && echo "$JSON" | grep -q '"severity":1'; then
+if grep -q '"code":"KP4003"' <<< "$JSON" && grep -q '"severity":1' <<< "$JSON"; then
     echo "PASS: json emits an LSP Diagnostic with the KP code and severity"
     PASS=$((PASS + 1))
 else

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -14,7 +14,7 @@ assert_output_contains() {
     local expected="$3"
     local output
     output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
-    if echo "$output" | grep -qF "$expected"; then
+    if grep -qF "$expected" <<< "$output"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else
@@ -29,7 +29,7 @@ assert_output_lacks() {
     local forbidden="$3"
     local output
     output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
-    if echo "$output" | grep -qF "$forbidden"; then
+    if grep -qF "$forbidden" <<< "$output"; then
         echo "FAIL: $label — output still contains '$forbidden'"
         FAIL=$((FAIL + 1))
     else
@@ -44,7 +44,7 @@ assert_file_output_contains() {
     local expected="$3"
     local output
     output=$("$KAAPPI" "$file" 2>&1 || true)
-    if echo "$output" | grep -qF "$expected"; then
+    if grep -qF "$expected" <<< "$output"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else
@@ -62,7 +62,7 @@ assert_no_zig_leak() {
     local input="$2"
     local output
     output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
-    if echo "$output" | grep -qE 'error\.[A-Z][A-Za-z]+'; then
+    if grep -qE 'error\.[A-Z][A-Za-z]+' <<< "$output"; then
         echo "FAIL: $label — leaked a Zig error name: $(echo "$output" | grep -oE 'error\.[A-Z][A-Za-z]+' | head -1)"
         FAIL=$((FAIL + 1))
     else
@@ -295,7 +295,7 @@ assert_output_contains "library not found includes library name" \
 # Missing dependency reports the actual missing library, not the top-level one
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 dep_output=$("$KAAPPI" --lib-path "$SCRIPT_DIR/fixtures" "$SCRIPT_DIR/fixtures/missing-dep.scm" 2>&1 || true)
-if echo "$dep_output" | grep -qF "srfi.999"; then
+if grep -qF "srfi.999" <<< "$dep_output"; then
     echo "PASS: missing dependency names the dependency"
     PASS=$((PASS + 1))
 else

--- a/tests/scheme/errors/exit-code.sh
+++ b/tests/scheme/errors/exit-code.sh
@@ -185,7 +185,7 @@ SRFI78
 assert_exit_code "SRFI-78 check-report with failure exits 1" 1 "$KAAPPI" "$TMPDIR_TESTS/srfi78-fail.scm"
 # Also verify it prints "First failure:" (not crash on unbound caddr)
 output=$("$KAAPPI" "$TMPDIR_TESTS/srfi78-fail.scm" 2>&1 || true)
-if echo "$output" | grep -q "First failure:"; then
+if grep -q "First failure:" <<< "$output"; then
     echo "PASS: SRFI-78 check-report prints first failure"
     PASS=$((PASS + 1))
 else

--- a/tests/scheme/errors/import-filter.sh
+++ b/tests/scheme/errors/import-filter.sh
@@ -31,7 +31,7 @@ assert_stderr_contains() {
     shift 2
     local output
     output=$("$@" 2>&1 >/dev/null) || true
-    if echo "$output" | grep -q "$pattern"; then
+    if grep -q "$pattern" <<< "$output"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else

--- a/tests/scheme/errors/test-source-snippet.sh
+++ b/tests/scheme/errors/test-source-snippet.sh
@@ -13,7 +13,7 @@ assert_contains() {
     local expected="$3"
     local output
     output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
-    if echo "$output" | grep -qF "$expected"; then
+    if grep -qF "$expected" <<< "$output"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else
@@ -29,7 +29,7 @@ TMPFILE="$TMPDIR/test.scm"
 echo '(define (foo x) (+ x 1))
 (foo "hello")' > "$TMPFILE"
 output=$("$KAAPPI" "$TMPFILE" 2>&1 || true)
-if echo "$output" | grep -qF '(define (foo x) (+ x 1))'; then
+if grep -qF '(define (foo x) (+ x 1))' <<< "$output"; then
     echo "PASS: runtime error includes source snippet"
     PASS=$((PASS + 1))
 else

--- a/tests/scheme/pipeline/pipeline.sh
+++ b/tests/scheme/pipeline/pipeline.sh
@@ -42,7 +42,7 @@ assert_out() {
     local pattern="$1"; shift
     local out
     out="$("$@" 2>&1)"
-    if echo "$out" | grep -qF "$pattern"; then
+    if grep -qF "$pattern" <<< "$out"; then
         pass "$label"
     else
         fail "$label" "expected to find: $pattern"$'\n'"  got: $out"

--- a/tests/scheme/robustness/robustness.sh
+++ b/tests/scheme/robustness/robustness.sh
@@ -19,7 +19,7 @@ assert_error() {
     output=$(echo "$expr" | "$KAAPPI" 2>&1 || true)
     # Match both the coded form ("error[KP3002]:", KEP-0005) and any legacy
     # "error:" prefix.
-    if echo "$output" | grep -qE 'error(\[|:)'; then
+    if grep -qE 'error(\[|:)' <<< "$output"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else

--- a/tests/scheme/sandbox/parallel-degrades.sh
+++ b/tests/scheme/sandbox/parallel-degrades.sh
@@ -41,7 +41,7 @@ assert_blocked() {
     local expr="$2"
     local output
     output=$(echo "$expr" | "$KAAPPI" --sandbox 2>&1 || true)
-    if echo "$output" | grep -qi "error"; then
+    if grep -qi "error" <<< "$output"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else

--- a/tests/scheme/sandbox/sandbox-escape.sh
+++ b/tests/scheme/sandbox/sandbox-escape.sh
@@ -15,7 +15,7 @@ assert_blocked() {
     local expr="$2"
     local output
     output=$(echo "$expr" 2>&1 | "$KAAPPI" --sandbox 2>&1 || true)
-    if echo "$output" | grep -qi "error"; then
+    if grep -qi "error" <<< "$output"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else
@@ -32,7 +32,7 @@ assert_works() {
     # Filter out DebugAllocator messages (not Scheme errors)
     local filtered
     filtered=$(echo "$output" | grep -v "DebugAllocator" | grep -v "empty stack trace" | grep -v "^$")
-    if echo "$filtered" | grep -q "^error:"; then
+    if grep -q "^error:" <<< "$filtered"; then
         echo "FAIL: $label — should work but got error: $filtered"
         FAIL=$((FAIL + 1))
     else
@@ -128,7 +128,7 @@ echo "=== Resource limits ==="
 
 # Timeout test
 output=$(echo '(let loop () (loop))' | "$KAAPPI" --timeout 200 2>&1 || true)
-if echo "$output" | grep -qF "timed out"; then
+if grep -qF "timed out" <<< "$output"; then
     echo "PASS: --timeout stops infinite loop"
     PASS=$((PASS + 1))
 else
@@ -139,7 +139,7 @@ fi
 # Memory limit test. The out-of-memory diagnostic is KP9002 (KEP-0005); match
 # the stable code, not the old leaked Zig error name ("OutOfMemory").
 output=$(echo '(define (eat n a) (if (= n 0) a (eat (- n 1) (cons n a)))) (eat 1000000 (list))' | "$KAAPPI" --max-memory 100000 2>&1 || true)
-if echo "$output" | grep -qF "KP9002"; then
+if grep -qF "KP9002" <<< "$output"; then
     echo "PASS: --max-memory stops excessive allocation"
     PASS=$((PASS + 1))
 else
@@ -149,7 +149,7 @@ fi
 
 # Normal program works with generous limits
 output=$(echo '(display (+ 1 2))' | "$KAAPPI" --timeout 5000 --max-memory 10000000 2>&1 || true)
-if echo "$output" | grep -qF "3"; then
+if grep -qF "3" <<< "$output"; then
     echo "PASS: normal program works with generous limits"
     PASS=$((PASS + 1))
 else

--- a/tests/scheme/sandbox/srfi181-sandbox.sh
+++ b/tests/scheme/sandbox/srfi181-sandbox.sh
@@ -46,7 +46,7 @@ assert_blocked() {
     local expr="$2"
     local output
     output=$(echo "$expr" | "$KAAPPI" --sandbox 2>&1 || true)
-    if echo "$output" | grep -qi "error"; then
+    if grep -qi "error" <<< "$output"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else

--- a/tests/scheme/smoke/chibi-test-guard-1196.sh
+++ b/tests/scheme/smoke/chibi-test-guard-1196.sh
@@ -20,7 +20,7 @@ EOF
 output=$("$KAAPPI" "$tmpfile") || true
 
 # Should report exactly 2 pass and 1 fail
-if echo "$output" | grep -q "2 pass, 1 fail"; then
+if grep -q "2 pass, 1 fail" <<< "$output"; then
   echo "PASS: exception in test expression counted as failure"
 else
   echo "FAIL: unexpected output:"

--- a/tests/scheme/smoke/repl-history-newline-821.sh
+++ b/tests/scheme/smoke/repl-history-newline-821.sh
@@ -16,7 +16,7 @@ KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
 # If newlines become spaces, ";; comment" eats "(+ 1 2)" on the same line.
 output=$(printf '(begin\n  ;; a comment\n  (+ 1 2))\n,quit\n' | $KAAPPI 2>&1 || true)
 
-if echo "$output" | grep -q "3"; then
+if grep -q "3" <<< "$output"; then
     echo "PASS: multi-line entry with comment evaluates correctly"
 else
     echo "FAIL: multi-line entry with comment did not evaluate correctly"

--- a/tests/scheme/smoke/sandbox-script-arg-783.sh
+++ b/tests/scheme/smoke/sandbox-script-arg-783.sh
@@ -21,7 +21,7 @@ SCM
 
 # 1) --sandbox AFTER the filename is a script argument — must NOT sandbox
 output=$("$KAAPPI" "$tmpdir/writer.scm" --sandbox 2>&1)
-if echo "$output" | grep -qF -- "--sandbox"; then
+if grep -qF -- "--sandbox" <<< "$output"; then
     echo "PASS: --sandbox after filename passed through as script arg"
     PASS=$((PASS + 1))
 else
@@ -31,7 +31,7 @@ fi
 
 # 2) --sandbox BEFORE the filename is an interpreter flag — must sandbox
 output=$("$KAAPPI" --sandbox "$tmpdir/writer.scm" 2>&1 || true)
-if echo "$output" | grep -qi "error"; then
+if grep -qi "error" <<< "$output"; then
     echo "PASS: --sandbox before filename activates sandboxing"
     PASS=$((PASS + 1))
 else

--- a/tests/scheme/smoke/step-debug-mode-823.sh
+++ b/tests/scheme/smoke/step-debug-mode-823.sh
@@ -15,7 +15,7 @@ KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
 output=$(printf ',break test-fn\n,step (+ 1 2)\n,breakpoints\n,quit\n' | $KAAPPI 2>&1 || true)
 
 # After ,step, breakpoints should still be listed (debug_mode preserved)
-if echo "$output" | grep -q "test-fn"; then
+if grep -q "test-fn" <<< "$output"; then
     echo "PASS: breakpoint preserved after ,step"
 else
     echo "FAIL: breakpoint lost after ,step"

--- a/tests/scheme/smoke/version-flag.sh
+++ b/tests/scheme/smoke/version-flag.sh
@@ -7,7 +7,7 @@ KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
 expected=$(grep '\.version' build.zig.zon | sed 's/.*"\(.*\)".*/\1/')
 output=$("$KAAPPI" --version 2>&1)
 
-if echo "$output" | grep -qF "$expected"; then
+if grep -qF "$expected" <<< "$output"; then
     echo "PASS: --version contains $expected"
 else
     echo "FAIL: expected '$expected' in output: $output"

--- a/tests/scheme/test-runner/changed.sh
+++ b/tests/scheme/test-runner/changed.sh
@@ -39,7 +39,7 @@ check() { # check <condition-exit-code> <label> [detail]
         echo "FAIL: $2  ${3:-}"; failed=$((failed + 1))
     fi
 }
-has()  { printf '%s\n' "$1" | grep -qxF "$2"; }  # exact-line match in a list
+has()  { grep -qxF "$2" <<< "$1"; }  # exact-line match in a list
 
 # ── Build the fixture repo ─────────────────────────────────────────────
 mkdir -p "$FIX/lib/mylib" "$FIX/tests"
@@ -128,7 +128,7 @@ AFF="$(run --list-affected --lib-path ./lib 2>/dev/null)"      # nothing changed
 NOTE="$(run --list-affected --lib-path ./lib 2>&1 1>/dev/null)"
 has "$AFF" "tests/test-load.scm"; check $? "load-using suite runs even with no change (incomplete graph)" "$AFF"
 ! has "$AFF" "tests/test-a.scm"; check $? "graph-complete suites skipped when nothing changed" "$AFF"
-printf '%s' "$NOTE" | grep -q "incomplete"; check $? "stderr names the forced suite as incomplete" "$NOTE"
+grep -q "incomplete" <<< "$NOTE"; check $? "stderr names the forced suite as incomplete" "$NOTE"
 
 # ── 4. Clean exit status when the affected set is empty of failures ─────
 set +e; run --changed --lib-path ./lib >/dev/null 2>&1; rc=$?; set -e
@@ -170,14 +170,14 @@ mkdir -p "$FIX/csrc"; echo 'int x;' > "$FIX/csrc/helper.c"      # untracked
 AFF="$(run --list-affected --lib-path ./lib 2>/dev/null)"
 NOTE="$(run --list-affected --lib-path ./lib 2>&1 1>/dev/null)"
 has "$AFF" "tests/test-b.scm"; check $? "csrc change forces a full run (independent test-b included)" "$AFF"
-printf '%s' "$NOTE" | grep -q "native/FFI artifact changed"; check $? "stderr explains the native-artifact full run" "$NOTE"
+grep -q "native/FFI artifact changed" <<< "$NOTE"; check $? "stderr explains the native-artifact full run" "$NOTE"
 rm -rf "$FIX/csrc"
 
 # ── 8. Unknown revision → loud full run ────────────────────────────────
 AFF="$(run --list-affected --since no-such-rev --lib-path ./lib 2>/dev/null)"
 NOTE="$(run --list-affected --since no-such-rev --lib-path ./lib 2>&1 1>/dev/null)"
 has "$AFF" "tests/test-b.scm"; check $? "unknown --since revision forces a full run" "$AFF"
-printf '%s' "$NOTE" | grep -q "running all"; check $? "stderr explains the unknown-revision full run" "$NOTE"
+grep -q "running all" <<< "$NOTE"; check $? "stderr explains the unknown-revision full run" "$NOTE"
 
 # ── 9. A brand-new untracked suite counts as changed ───────────────────
 cat > "$FIX/tests/test-new.scm" <<'EOF'


### PR DESCRIPTION
Fixes the `freebsd-test` failure on main introduced by #1957. **main is red on that leg right now**, so this is a fix-forward.

Closes #1967, which tracks the same failure from the observation side.

## What broke

Three assertions in `tests/scheme/errors/` failed on `freebsd-test` — `check.sh`, `error-format.sh`, `test-source-snippet.sh` — each printing the very text it claimed not to find:

```
FAIL: runtime error should include source snippet
  got: /tmp/tmp.7RMMyb5rIc/test.scm:1:17: error[KP3002]: type error in 'arithmetic': ...
    (define (foo x) (+ x 1))          <-- the string it was grepping for
  called from /tmp/tmp.7RMMyb5rIc/test.scm:2
```

## Why

`grep -q` exits the moment it matches. When the match is on an **early** line, the `echo` on the left of the pipe can still be mid-write and dies of SIGPIPE — and `set -o pipefail`, which all of these scripts set, then reports the *pipeline* as failed even though the match succeeded.

The tell is in the results themselves: in each script the assertion matching the **last** line of the output passed, while the one matching the **first or second** line failed. Matching the last line makes grep read to EOF, so the writer never sees a closed pipe.

Reproduced directly, early match with a large output:

| form | false negatives |
|---|--:|
| `echo "$x" \| grep -q PAT` (pipefail) | **20 / 20** |
| `grep -q PAT <<< "$x"` | 0 / 20 |

At the real ~3-line output size it is roughly 1 in 16,000 on an idle machine — rare enough to sit latent for a long time, common enough to hit three assertions in one run on an emulated 4-core VM. The bug predates #1957; making the shell suites concurrent raised the load enough to fire it, and `freebsd-test` was the only leg that lost the race (openbsd and netbsd, also QEMU VMs, passed).

## Fix

A here-string has no pipeline for `pipefail` to judge — same grep, same pattern, same exit status, no second process whose death can be mistaken for a failed match.

All 29 sites converted, not just the three that failed: they are one latent bug and the rest would surface next. Two piped `grep -q` uses remain in `errors/reader-*-errors.sh`; those have a command rather than a variable on the left, and neither script sets `pipefail`, so neither can hit this.

The rule is now written down in `tests/scheme/CLAUDE.md`, beside the existing note about GNU regex extensions — same shape of trap, where a green local run tells you nothing about the strictest or slowest CI leg.

## Verification

- The three previously-failing scripts pass.
- Every suite the rewrite touches — `errors/`, `smoke/`, `pipeline/`, `test-runner/`, `sandbox/`, `robustness/` — passes standalone.
- The change is mechanical and status-preserving; `bash -n` clean on all 17 scripts.

Real confirmation is `freebsd-test` on this PR, since the failure is probabilistic and I cannot reproduce the VM's exact load locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
