### PR TITLE
Say which kind of failure a port error is (#1944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   message landed on the wrong procedure. Both now name themselves, via the
   shared-constant convention `primitives_srfi237.zig` already used for
   exactly this reason.
+- **Port errors now say which kind of failure they are** (#1944).
+  `primitives_io.zig` reported every failure as a type error, so three
+  distinct faults all arrived mislabelled. Seeking a string port past its end
+  raised a detail-less `invalid argument in 'set-port-position!'` — no index,
+  no length — and now reports both, as `KP3006`. `(write-string "abc" port 5)`
+  said `expected valid range, got #<string>`, blaming the one argument that
+  was valid; the offending *index* is named now, with an inverted-but-in-range
+  pair (`… port 2 1`) reported as `start 2 is greater than end 1` rather than
+  as a range fault. And using a closed port was `KP3002 type error: expected
+  open input port, got #<port>` — a closed port is a port, so it is `KP3007
+  invalid argument` ("input port is closed"). Passing a genuine non-port, or
+  an input port where an output port is wanted, is still a type error.
+- Three internal guards in `primitives_io.zig` no longer blame the program for
+  a broken interpreter (#1944). A missing VM or GC in the fiber-park I/O path
+  reported `KP3007 invalid argument`; per the rules settled in #1874/#1876/#1878
+  these are `KP9001 internal error` and out-of-memory respectively — the same
+  tags the byte-for-byte twin helper 950 lines down the same file already used.
+  Unreachable in a working build; the tag is what the next maintainer reads.
 
 ## [0.22.1] - 2026-07-31
 

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -328,7 +328,6 @@ losing the VM costs the message, not the diagnosis:
 | `primitives_arithmetic.raiseDivByZero` | `DivisionByZero` |
 | the `overApplied`-style arity helpers (SRFI 181/254/258/260) | `ArityMismatch` |
 | `primitives_fiber.reraiseFiberError` | `ExceptionRaised` |
-| `primitives_io`'s `waitPortFd` / `raisePortClosedDuringIo` | `InvalidArgument` |
 
 A `gc_instance` guard in an allocating function is the same rule at scale: no
 GC means the allocation the function exists to perform cannot happen, so
@@ -372,14 +371,24 @@ both rules.
 
 One seam the two rules leave visible, so it does not read as fresh drift: the
 `raise*` helpers that build a condition object and end in `return
-PrimitiveError.ExceptionRaised` split across both. `reraiseFiberError` and
-`raisePortClosedDuringIo` already carried a tag of their own and keep it under
-Rule 1; `raiseFiberError`, `raiseWrappedPortClosed` and
-`raiseEntropyUnavailable` carried `OutOfMemory`, which is not what they return,
-so Rule 2 moved them to `InvalidBytecode`. Reading Rule 1 strictly would send
-all five the same way — but `ExceptionRaised` is the one tag a guard cannot
-honestly borrow, since it promises `vm.current_exception` was set and the guard
-fired precisely because there is no VM to set it on.
+PrimitiveError.ExceptionRaised`. `reraiseFiberError` already carried a tag of
+its own and keeps it under Rule 1; `raiseFiberError`, `raiseWrappedPortClosed`
+and `raiseEntropyUnavailable` carried `OutOfMemory`, which is not what they
+return, so Rule 2 moved them to `InvalidBytecode`. Reading Rule 1 strictly
+would send all of them the same way — but `ExceptionRaised` is the one tag a
+guard cannot honestly borrow, since it promises `vm.current_exception` was set
+and the guard fired precisely because there is no VM to set it on.
+
+`primitives_io`'s `waitPortFd` and `raisePortClosedDuringIo` sat on this seam's
+Rule 1 side until #1944, on the same "it already carried a tag of its own"
+reasoning — but the tag was `InvalidArgument`, which neither function returns
+for any other reason, and `raisePortClosedDuringIo` is a byte-for-byte twin of
+`raiseWrappedPortClosed` 950 lines further down the same file, which Rule 2 had
+already moved. Both are settled the same way now: `InvalidBytecode` for the
+`vm_instance` guards, `OutOfMemory` for the `gc_instance` one. That makes the
+seam narrower than it reads above — a guard is only on Rule 1's side if the tag
+it borrows is one the function genuinely returns, not merely one it was written
+with. `primitives_io.zig`'s own test block pins all three.
 
 A second seam, settled by #1878, is the one place a guard sits in a function
 that genuinely raises `TypeError` elsewhere. `primitives.applyFn` does — for a

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -78,12 +78,17 @@ pub const writeStdout = reporting.writeStdout;
 pub const writeStderr = reporting.writeStderr;
 
 /// Get the output port: use args[arg_idx] if provided, else current-output-port.
+///
+/// A *closed* port is `argError`, not `typeError`: it is a port, and an
+/// output one, so nothing about its type is wrong — the procedure rejects it
+/// for its state. Same reasoning at every other closed-port check in this
+/// file (`getInputPort`, `portPosition`, `setPortPositionBang`).
 fn getOutputPort(args: []const Value, arg_idx: usize, proc: []const u8) PrimitiveError!*types.Port {
     if (args.len > arg_idx) {
         if (!types.isPort(args[arg_idx])) return primitives.typeError(proc, "output port", args[arg_idx]);
         const port = types.toObject(args[arg_idx]).as(types.Port);
         if (!port.is_output) return primitives.typeError(proc, "output port", args[arg_idx]);
-        if (!port.is_open) return primitives.typeError(proc, "open output port", args[arg_idx]);
+        if (!port.is_open) return primitives.argError(proc, "output port is closed", .{});
         return port;
     }
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
@@ -98,7 +103,7 @@ fn getInputPort(args: []const Value, arg_idx: usize, proc: []const u8) Primitive
         if (!types.isPort(args[arg_idx])) return primitives.typeError(proc, "input port", args[arg_idx]);
         const port = types.toObject(args[arg_idx]).as(types.Port);
         if (!port.is_input) return primitives.typeError(proc, "input port", args[arg_idx]);
-        if (!port.is_open) return primitives.typeError(proc, "open input port", args[arg_idx]);
+        if (!port.is_open) return primitives.argError(proc, "input port is closed", .{});
         return port;
     }
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
@@ -266,14 +271,14 @@ fn portFdWrite(port: *types.Port, buf: [*]const u8, len: usize) isize {
 /// resumes here, so the is_open re-check — a sibling may have closed the
 /// port while we waited — must raise the clean "port closed" error itself.
 fn waitPortFd(port: *types.Port, interest: reactor_mod.Interest) PrimitiveError!void {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidArgument;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     try fiber_mod.waitForFd(vm, port.fd, interest);
     if (!port.is_open) return raisePortClosedDuringIo();
 }
 
 fn raisePortClosedDuringIo() PrimitiveError {
-    const gc = memory.gc_instance orelse return PrimitiveError.InvalidArgument;
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidArgument;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     var msg = gc.allocString("port closed while I/O was blocked on it") catch return PrimitiveError.OutOfMemory;
     gc.pushRoot(&msg);
     defer gc.popRoot();
@@ -876,7 +881,7 @@ fn portPosition(args: []const Value) PrimitiveError!Value {
     // A closed fd-backed port's fd number may already have been reused by
     // the OS for an unrelated, newly opened file; seeking on it would
     // silently reposition that unrelated file instead of erroring.
-    if (!port.is_open) return primitives.typeError("port-position", "open port", args[0]);
+    if (!port.is_open) return primitives.argError("port-position", "port is closed", .{});
     if (port.is_string_port) {
         const pos: i64 = if (port.is_input) @intCast(port.string_pos) else @intCast(port.string_out_pos);
         return types.makeFixnum(pos);
@@ -885,10 +890,7 @@ fn portPosition(args: []const Value) PrimitiveError!Value {
         return portPositionFromCustomPort(cb);
     }
     const os_pos = platform.seek(port.fd, 0, platform.SEEK_CUR);
-    if (os_pos < 0) {
-        if (vm_mod.vm_instance) |vm| vm.setErrorDetail("port-position: port does not support positioning", .{});
-        return PrimitiveError.InvalidArgument;
-    }
+    if (os_pos < 0) return primitives.argError("port-position", "port does not support positioning", .{});
     const ahead: i64 = @as(i64, @intCast(port.read_buf_len)) +
         @as(i64, if (port.peek_byte != null) 1 else 0) +
         @as(i64, port.peek_extra_len);
@@ -927,7 +929,7 @@ fn setPortPositionBang(args: []const Value) PrimitiveError!Value {
     // See portPosition: a closed fd's number may have been reused by the
     // OS for an unrelated file, so seeking on it must not be allowed to
     // silently reposition that unrelated file instead of erroring.
-    if (!port.is_open) return primitives.typeError("set-port-position!", "open port", args[0]);
+    if (!port.is_open) return primitives.argError("set-port-position!", "port is closed", .{});
 
     if (port.is_output and !port.is_string_port and port.write_buf_len > port.write_buf_start) {
         try drainWriteBuffer(port);
@@ -936,14 +938,14 @@ fn setPortPositionBang(args: []const Value) PrimitiveError!Value {
     if (port.is_string_port) {
         if (port.is_input) {
             const len = if (port.string_data) |d| d.len else 0;
-            if (pos > len) return PrimitiveError.InvalidArgument;
+            if (pos > len) return primitives.indexError("set-port-position!", pos, len);
             port.string_pos = @intCast(pos);
         } else {
             // Move the write cursor only -- string_out_len (the buffer's
             // total extent, what get-output-string reads up to) is
             // untouched, so a subsequent write overwrites in place
             // rather than truncating whatever came after the seek point.
-            if (pos > port.string_out_len) return PrimitiveError.InvalidArgument;
+            if (pos > port.string_out_len) return primitives.indexError("set-port-position!", pos, port.string_out_len);
             port.string_out_pos = @intCast(pos);
         }
         return types.VOID;
@@ -960,10 +962,7 @@ fn setPortPositionBang(args: []const Value) PrimitiveError!Value {
     // discarding them first would silently lose already-read data for no
     // reason once the (failed) seek leaves the position unchanged.
     const rc = platform.seek(port.fd, pos, platform.SEEK_SET);
-    if (rc < 0) {
-        if (vm_mod.vm_instance) |vm| vm.setErrorDetail("set-port-position!: invalid position or port does not support positioning", .{});
-        return PrimitiveError.InvalidArgument;
-    }
+    if (rc < 0) return primitives.argError("set-port-position!", "invalid position or port does not support positioning", .{});
     // Discard read-ahead lookahead: it describes bytes at the *old*
     // position and is meaningless once we've jumped elsewhere.
     port.peek_byte = null;
@@ -986,10 +985,8 @@ fn setPortPositionBang(args: []const Value) PrimitiveError!Value {
 /// calls it itself; it just isn't threaded through port-position.
 fn portPositionFromCustomPort(cb: *types.CustomBacking) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
-    if (cb.get_position_proc == types.FALSE) {
-        vm.setErrorDetail("port-position: port does not support positioning", .{});
-        return PrimitiveError.InvalidArgument;
-    }
+    if (cb.get_position_proc == types.FALSE)
+        return primitives.argError("port-position", "port does not support positioning", .{});
     const result = try callCustomPortProc(vm, cb.get_position_proc, &[_]Value{});
     if (!types.isFixnum(result)) return raiseCustomPortBadReturn(vm, "get-position");
     return result;
@@ -1003,10 +1000,8 @@ fn portPositionFromCustomPort(cb: *types.CustomBacking) PrimitiveError!Value {
 /// jumps elsewhere.
 fn setPortPositionOnCustomPort(port: *types.Port, cb: *types.CustomBacking, pos: i64) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
-    if (cb.set_position_proc == types.FALSE) {
-        vm.setErrorDetail("set-port-position!: port does not support positioning", .{});
-        return PrimitiveError.InvalidArgument;
-    }
+    if (cb.set_position_proc == types.FALSE)
+        return primitives.argError("set-port-position!", "port does not support positioning", .{});
     if (port.is_output) try flushCustomPortIfNeeded(vm, cb);
     _ = try callCustomPortProc(vm, cb.set_position_proc, &[_]Value{types.makeFixnum(pos)});
     port.peek_byte = null;
@@ -1544,9 +1539,16 @@ fn writeStringFn(args: []const Value) PrimitiveError!Value {
         if (e < 0) return primitives.typeError("write-string", "non-negative integer", args[3]);
         end_cp = @intCast(e);
     }
-    if (start_cp > end_cp or end_cp > cp_count) return primitives.typeError("write-string", "valid range", args[0]);
-    const byte_start = string_mod.utf8IndexToByteOffset(data, start_cp) orelse return primitives.typeError("write-string", "valid start index", args[0]);
-    const byte_end = string_mod.utf8IndexToByteOffset(data, end_cp) orelse return primitives.typeError("write-string", "valid end index", args[0]);
+    // Report the *index* that is out of range, not the string: `args[0]` is
+    // the one argument here that is never at fault, and `substring` (the
+    // house precedent for a start/end pair) already names the index. An
+    // inverted-but-in-range pair is neither a type nor a range fault, so it
+    // is argError rather than indexError.
+    if (end_cp > cp_count) return primitives.indexError("write-string", @intCast(end_cp), cp_count);
+    if (start_cp > cp_count) return primitives.indexError("write-string", @intCast(start_cp), cp_count);
+    if (start_cp > end_cp) return primitives.argError("write-string", "start {d} is greater than end {d}", .{ start_cp, end_cp });
+    const byte_start = string_mod.utf8IndexToByteOffset(data, start_cp) orelse return primitives.indexError("write-string", @intCast(start_cp), cp_count);
+    const byte_end = string_mod.utf8IndexToByteOffset(data, end_cp) orelse return primitives.indexError("write-string", @intCast(end_cp), cp_count);
     try portWriteBytes(port, data[byte_start..byte_end]);
     return types.VOID;
 }
@@ -1938,4 +1940,69 @@ fn setCurrentPort(vm: *vm_mod.VM, param_val: Value, port_val: Value) void {
     if (param_val != types.VOID) {
         vm.setParameterValue(types.toParameter(param_val), port_val) catch {};
     }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// This file's own test block, rather than `tests_io.zig`: `waitPortFd` and
+// `raisePortClosedDuringIo` are private, and the point of the test is the tag
+// they pick when the threadlocal is gone -- a readability-only choice that no
+// program can reach, and so exactly the kind that drifts unless something
+// pins it (kaappi#1878's lesson, kaappi#1944's instance).
+test "the fiber-park I/O guards report a missing VM/GC as internal error and OOM (#1944)" {
+    const th = @import("testing_helpers.zig");
+    const diagnostics = @import("diagnostics.zig");
+
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // Rooted because the CONTROL below allocates twice: under -Dgc-stress the
+    // collection that follows would otherwise free the port this test still
+    // holds a raw `*Port` into.
+    var port_val = try ctx.vm.eval("(open-input-string \"x\")");
+    ctx.gc.pushRoot(&port_val);
+    const port = types.toObject(port_val).as(types.Port);
+
+    // CONTROL: with the VM present, `raisePortClosedDuringIo` returns
+    // `ExceptionRaised` -- so neither tag below is merely what the function
+    // always returns. `ExceptionRaised` is also the one tag a guard can never
+    // borrow: it promises `vm.current_exception` was set, and the guard fires
+    // precisely because there is no VM to set it on (#1874).
+    try std.testing.expectEqual(PrimitiveError.ExceptionRaised, raisePortClosedDuringIo());
+
+    // Both guards sit on the first lines of their functions, so nothing
+    // allocates or touches the port while a threadlocal is null; restore
+    // explicitly rather than by `defer`, which would outlive the call.
+    const saved_vm = vm_mod.vm_instance;
+    vm_mod.vm_instance = null;
+    const wait_res = waitPortFd(port, .read);
+    const raise_vm_res = raisePortClosedDuringIo();
+    vm_mod.vm_instance = saved_vm;
+
+    const saved_gc = memory.gc_instance;
+    memory.gc_instance = null;
+    const raise_gc_res = raisePortClosedDuringIo();
+    memory.gc_instance = saved_gc;
+
+    ctx.gc.popRoot(); // last use of `port`; popped explicitly, not by defer
+
+    // No VM means the wait cannot happen at all, so there is no tag to borrow
+    // from the function -- Rule 2. Both sites read `InvalidArgument` until
+    // #1944, which blamed the caller's port for a broken interpreter.
+    try std.testing.expectError(vm_mod.VMError.InvalidBytecode, wait_res);
+    try std.testing.expectEqual(PrimitiveError.InvalidBytecode, raise_vm_res);
+    // The tag is only half of it: what a reader sees is the code. KP9001 is
+    // "internal error ... please report it"; KP3007, which these carried
+    // before, tells the reader to go fix their own arguments.
+    const wait_err = if (wait_res) |_| unreachable else |e| e;
+    try std.testing.expectEqual(diagnostics.Code.internal_error, diagnostics.runtimeErrorCode(wait_err));
+    try std.testing.expectEqual(diagnostics.Code.internal_error, diagnostics.runtimeErrorCode(raise_vm_res));
+
+    // The GC guard is Rule 1 at scale: the allocation this helper exists to
+    // perform cannot happen, and `OutOfMemory` is what its own two
+    // `allocXxx catch` lines already return.
+    try std.testing.expectEqual(PrimitiveError.OutOfMemory, raise_gc_res);
 }

--- a/tests/scheme/audit/primitives_io-audit.scm
+++ b/tests/scheme/audit/primitives_io-audit.scm
@@ -699,6 +699,52 @@
   (test-equal #f (input-port-open? p)))
 (test-equal #t (raises? (lambda () (call-with-port 42 values))))
 
+;;; --- #1944: error taxonomy -------------------------------------------------
+;; Every assertion above only ever asked whether a bad call *raises*, which is
+;; why this file's messages could all be the wrong kind and still pass. These
+;; pin the message text, so a regression to the pre-#1944 wording fails here.
+
+;; A closed port is a port: rejecting it is argError, not typeError. The
+;; direction is still reported, since the direction check runs first.
+(test-equal "write-string: output port is closed"
+  (err-message (lambda () (let ((p (open-output-string))) (close-port p) (write-string "x" p)))))
+(test-equal "read-char: input port is closed"
+  (err-message (lambda () (let ((p (open-input-string "x"))) (close-port p) (read-char p)))))
+(test-equal "port-position: port is closed"
+  (err-message (lambda () (let ((p (open-input-string "x"))) (close-port p) (port-position p)))))
+(test-equal "set-port-position!: port is closed"
+  (err-message (lambda () (let ((p (open-input-string "x"))) (close-port p) (set-port-position! p 0)))))
+;; CONTROL: a genuinely wrong type — and a right-type/wrong-direction port —
+;; must still be a type error, or the fix above would have flattened the
+;; distinction instead of drawing it.
+(test-equal "type error in 'write-string': expected output port, got #<symbol>"
+  (err-message (lambda () (write-string "x" 'not-a-port))))
+(test-equal "type error in 'write-string': expected output port, got #<port>"
+  (err-message (lambda () (write-string "x" (open-input-string "y")))))
+
+;; set-port-position! past the end of a string port reports index and length
+;; (it was a detail-less "invalid argument in 'set-port-position!'").
+(test-equal "set-port-position!: index 99 out of range for length 3"
+  (err-message (lambda () (set-port-position! (open-input-string "abc") 99))))
+(test-equal "set-port-position!: index 99 out of range for length 0"
+  (err-message (lambda () (set-port-position! (open-output-string) 99))))
+;; CONTROL: position == length is the legal end-of-input seek, not an error.
+(test-equal #t
+  (let ((p (open-input-string "abc"))) (set-port-position! p 3) (eof-object? (read-char p))))
+
+;; write-string range errors name the offending index, not args[0] — the
+;; string is the one argument that is never at fault here.
+(test-equal "write-string: index 5 out of range for length 3"
+  (err-message (lambda () (write-string "abc" (open-output-string) 5))))
+(test-equal "write-string: index 9 out of range for length 3"
+  (err-message (lambda () (write-string "abc" (open-output-string) 1 9))))
+;; An in-range but inverted pair is neither a type nor a range fault.
+(test-equal "write-string: start 2 is greater than end 1"
+  (err-message (lambda () (write-string "abc" (open-output-string) 2 1))))
+;; CONTROL: a valid sub-range still writes exactly that slice.
+(test-equal "bc"
+  (let ((o (open-output-string))) (write-string "abcde" o 1 3) (get-output-string o)))
+
 ;; with-output-to-file restores current-output-port even when the thunk raises.
 (let ((path "/tmp/kaappi-audit-io-wo.txt"))
   (test-equal #t (raises? (lambda () (with-output-to-file path (lambda () (error "x"))))))


### PR DESCRIPTION
Fixes #1944.

`primitives_io.zig` had 44 `typeError` sites and zero `indexError`/`argError` sites, so every non-type failure in the file arrived mislabelled. All four items in the issue reproduced exactly on a fresh ReleaseSafe build.

## What changed

| Case | Before | After |
|---|---|---|
| `(set-port-position! (open-input-string "abc") 99)` | `KP3007 invalid argument in 'set-port-position!'` | `KP3006 set-port-position!: index 99 out of range for length 3` |
| `(write-string "abc" p 5)` | `KP3002 expected valid range, got #<string>` | `KP3006 write-string: index 5 out of range for length 3` |
| `(write-string "abc" p 2 1)` | `KP3002 expected valid range, got #<string>` | `KP3007 write-string: start 2 is greater than end 1` |
| `(read-char closed-port)` | `KP3002 expected open input port, got #<port>` | `KP3007 read-char: input port is closed` |
| no VM/GC in the fiber-park I/O path | `KP3007 invalid argument` | `KP9001 internal error` / out-of-memory |

Genuine type errors are untouched: `(write-string "x" 'sym)` and `(write-string "x" (open-input-string "y"))` still report `KP3002 expected output port`, and both are pinned as controls.

Four `set-port-position!`/`port-position` sites that already hand-rolled `setErrorDetail` + `return InvalidArgument` now go through `argError` instead — identical output, one idiom.

## On the three guards

#1874 blessed `waitPortFd` and `raisePortClosedDuringIo` as Rule 1 keepers because they "already carried a tag of their own". But `InvalidArgument` is not a tag either function returns for any other reason, and `raisePortClosedDuringIo` is a byte-for-byte twin of `raiseWrappedPortClosed` 950 lines down the same file, which Rule 2 had already moved. Both are settled the same way now (`InvalidBytecode` for the two `vm_instance` guards, `OutOfMemory` for the `gc_instance` one), and `docs/dev/gc-safety-and-error-handling.md`'s seam paragraph is updated to say why Rule 1's side is narrower than it read — this is the same "a Rule 1 site that keeps surfacing deserves a second look" shape as `bootstrapStub`/#1876.

## Tests

The audit file's existing assertions only ever asked whether a bad call *raises*, which is how all of this drifted. 13 new assertions pin the message text (`tests/scheme/audit/primitives_io-audit.scm`, 197 → 210); mutation-tested against the unfixed source: **9 fail, 4 are controls that pass either way**.

The guard tags are unreachable from Scheme, so they get a Zig test where the private helpers live, following #1878's pattern (null the threadlocal, call, restore explicitly). It asserts the tag *and* the resulting diagnostic code, plus a control showing the function returns `ExceptionRaised` when the VM is there — so neither guard tag is merely what the function always returns. Mutation-tested: restoring the old tags fails it.

## Verification

- `zig build test`: 1432 pass, 3 skip, 0 fail (+ thottam 25 pass)
- `zig build test -Dgc-stress=true` on the new test: pass
- `bash tests/scheme/run-all.sh`: 2029 pass, 0 fail
- `zig fmt --check src/`, the bare-`TypeError` CI gate, and markdownlint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)