### PR TITLE
Drop the resolved blocker from the 5B entry

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -1,6 +1,6 @@
 # Systematic Correctness Audit Strategy (v2)
 
-**Status:** in progress (14 of 53 units — three parallel batches; 5B awaits [#1967](https://github.com/kaappi/kaappi/issues/1967)) · **Last updated:** 2026-08-01 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
+**Status:** in progress (14 of 53 units — three parallel batches, all merged) · **Last updated:** 2026-08-01 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
 · **Supersedes:** the v1 campaign (issue [#1137](https://github.com/kaappi/kaappi/issues/1137), closed 2026-07-05, 87 findings, all fixed)
 
 ## Why a second campaign
@@ -299,7 +299,7 @@ Tick when the PR is open and issues are filed; add date and issue numbers.
 **Phase 5 — Concurrency**
 
 - [ ] 5A: **Validate-or-retire** the SRFI 120 corruption claim; deliver either a live repro or a PR rewriting the header plus tests pinning both rejections
-- [x] 5B: `waitForFd` park-vs-drive protocol — zero tests reference `waitForFd`, `driving_waits`, or `anyAncestorWaitResolved` (2026-08-01, [#1960](https://github.com/kaappi/kaappi/pull/1960) — **open**, blocked by [#1967](https://github.com/kaappi/kaappi/issues/1967); 26 tests, **no bugs in `waitForFd`**. Pinned the 2×2 selector and the unwind asymmetry, whose nine `false` rows had zero coverage. Filed [#1959](https://github.com/kaappi/kaappi/issues/1959) — the user-visible error names `dynamic-wind` as unparkable when it is not)
+- [x] 5B: `waitForFd` park-vs-drive protocol — zero tests reference `waitForFd`, `driving_waits`, or `anyAncestorWaitResolved` (2026-08-01, [#1960](https://github.com/kaappi/kaappi/pull/1960); 26 tests, **no bugs in `waitForFd`**. Pinned the 2×2 selector and the unwind asymmetry, whose nine `false` rows had zero coverage. Filed [#1959](https://github.com/kaappi/kaappi/issues/1959) — the user-visible error names `dynamic-wind` as unparkable when it is not)
 - [x] 5C: `gc_deep_copy` promoted-stub ownership skip — an already-promoted channel stub bypasses the owner check (2026-07-31, [#1938](https://github.com/kaappi/kaappi/pull/1938); 49 assertions, 24 disabled — CLAUDE.md's sharing model confirmed verbatim, 11 sound behaviours pinned; filed [#1933](https://github.com/kaappi/kaappi/issues/1933) **parent GC reclaims objects a live child references** (gc-stress: hard UAF panic), [#1932](https://github.com/kaappi/kaappi/issues/1932) a record loses its type across `thread-join!`, [#1934](https://github.com/kaappi/kaappi/issues/1934)–[#1937](https://github.com/kaappi/kaappi/issues/1937))
 - [ ] 5D: SRFI-18 re-audit (994 → 1435 lines since v1)
 - [ ] 5E: De-flake and arm the timing tests (76 wall-clock lines; `smoke/thread-sleep-876.scm` has no exit path at all)


### PR DESCRIPTION
#1960 merged, so the tracker's two references to it being blocked are stale.

- Status line: `14 of 53 units — three parallel batches; 5B awaits #1967` → `…three parallel batches, all merged`
- 5B entry: `#1960 — **open**, blocked by #1967;` → `#1960;`

#1967 was the `pipefail`/`grep -q` race in the parallel shell suites, fixed by #1966. 5B's FreeBSD leg then passed with **nothing changed but its base** — the same commit content that had failed three times.

Everything else in the 5B entry stays, including that it found **no bugs in `waitForFd`** and what it closed instead: the nine `false` rows of the unwind asymmetry, which had zero coverage. A unit that finds nothing is the one most likely to be read as wasted, so the entry says what it actually bought.

Docs only; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)