### PR TITLE
Tick 2.5 and 6D; close 3.2/3.3 as subsumed by 2.4

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -1,6 +1,6 @@
 # Systematic Correctness Audit Strategy (v2)
 
-**Status:** in progress (14 of 53 units — three parallel batches, all merged) · **Last updated:** 2026-08-01 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
+**Status:** in progress (16 of 53 units — 3.2/3.3 closed as subsumed by 2.4) · **Last updated:** 2026-08-01 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
 · **Supersedes:** the v1 campaign (issue [#1137](https://github.com/kaappi/kaappi/issues/1137), closed 2026-07-05, 87 findings, all fixed)
 
 ## Why a second campaign
@@ -278,8 +278,8 @@ Tick when the PR is open and issues are filed; add date and issue numbers.
 **Phase 3 — SRFI breadth** (independent)
 
 - [x] 3.1: **SRFI 14 rewrite** (F6) — range/inversion-list rep over the existing Unicode tables, plus the ~37 missing names (2026-07-31, [#1928](https://github.com/kaappi/kaappi/pull/1928), closed #1895; inversion lists, all 64 spec names, 172-assertion suite — 17/147 against the old library; filed [#1924](https://github.com/kaappi/kaappi/issues/1924) **cross-thread use-after-free**, [#1925](https://github.com/kaappi/kaappi/issues/1925) `char-numeric?` BMP-only, [#1927](https://github.com/kaappi/kaappi/issues/1927) `--lib-path` cannot shadow a bundled SRFI)
-- [ ] 3.2: SRFI 160 sweep A — the generic surface across all 12 element kinds (the test is 87% `s8`)
-- [ ] 3.3: SRFI 160 sweep B — per-type wrappers, c64/c128 packing, the u8-as-bytevector seam
+- [x] ~~3.2: SRFI 160 sweep A~~ — **subsumed by 2.4**, which swept all 12 element kinds (8 integer kinds × {min, min±1, max, max±1} plus 9 rejection classes, every cell correct) and cross-checked the two independent range rules across 276 cells. The "87% `s8`" gap it was written against is closed.
+- [x] ~~3.3: SRFI 160 sweep B~~ — **subsumed by 2.4**, which covered both seams (u8-as-bytevector in both directions; c64/c128 packing incl. per-component precision, ±inf/NaN, and a rejected `set!` leaving the slot untouched) and verified the per-type wrappers three ways — each `.sld` mentions only its own tag, tag-normalised the 12 files are byte-identical, and a 12×12 predicate matrix is true only on the diagonal.
 - [ ] 3.4: SRFI 146 (108 of 161 exports untested)
 - [ ] 3.5: SRFI 166 + `columnar`/`unicode`/`color`/`pretty` sub-libraries (52 of 89 untested)
 - [ ] 3.6: SRFI 158 generators (43 of 55 untested)

--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -1,6 +1,6 @@
 # Systematic Correctness Audit Strategy (v2)
 
-**Status:** in progress (16 of 53 units — 3.2/3.3 closed as subsumed by 2.4) · **Last updated:** 2026-08-01 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
+**Status:** in progress (18 of 53 units — 2.12 and 5D complete but held by BSD failures, see [#1985](https://github.com/kaappi/kaappi/pull/1985)/[#1986](https://github.com/kaappi/kaappi/pull/1986)) · **Last updated:** 2026-08-01 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
 · **Supersedes:** the v1 campaign (issue [#1137](https://github.com/kaappi/kaappi/issues/1137), closed 2026-07-05, 87 findings, all fixed)
 
 ## Why a second campaign
@@ -265,7 +265,7 @@ Tick when the PR is open and issues are filed; add date and issue numbers.
 - [x] 2.2: `primitives_io.zig` (+1108 lines against a 112-line audit test; custom-port and transcode branches are new) (2026-07-31, [#1947](https://github.com/kaappi/kaappi/pull/1947); 49 → 197 assertions, all 45 specs covered; filed [#1939](https://github.com/kaappi/kaappi/issues/1939) re-entrant custom-port read **aborts the process**, [#1941](https://github.com/kaappi/kaappi/issues/1941)–[#1944](https://github.com/kaappi/kaappi/issues/1944))
 - [ ] 2.3: `primitives_srfi181.zig` (new, no test) — custom-port callback re-entrancy and the blocking rejection
 - [x] 2.4: `primitives_srfi160.zig` (new, no test) — 11-way element-kind dispatch over raw bytes, c64/c128 packing (2026-07-31, [#1952](https://github.com/kaappi/kaappi/pull/1952); 1066 assertions — filed [#1949](https://github.com/kaappi/kaappi/issues/1949) `Uvector-segment` with `n=0` **hangs**, [#1950](https://github.com/kaappi/kaappi/issues/1950)/[#1951](https://github.com/kaappi/kaappi/issues/1951) c64/c128 elements are always Complex. The 12-kind × boundary matrix and both seams are **correct**; the two range rules agree across 276 cells)
-- [ ] 2.5: `primitives_srfi237.zig` (new, no test) — sealed/opaque/uid, multi-level inheritance
+- [x] 2.5: `primitives_srfi237.zig` (new, no test) — sealed/opaque/uid, multi-level inheritance (2026-08-01, [#1975](https://github.com/kaappi/kaappi/pull/1975); 186 assertions, 26 disabled — filed [#1973](https://github.com/kaappi/kaappi/issues/1973) a **27-field record aborts the process** via u8 size arithmetic, reachable from plain R7RS `define-record-type`, and [#1974](https://github.com/kaappi/kaappi/issues/1974) four R6RS defects. Protocol composition is exact at 16/16 masks; the **nongenerative** cross-thread path is pinned enabled so #1932's fix flips a test)
 - [ ] 2.6: `primitives_fiber.zig` (+1241 lines against a 135-line audit test)
 - [ ] 2.7: `primitives_srfi18.zig` (+793/−352) — deep-copy round-trip for every new heap type
 - [ ] 2.8: `primitives_hashtable.zig` (+403, 8 callback sites)
@@ -311,7 +311,7 @@ Tick when the PR is open and issues are filed; add date and issue numbers.
 - [ ] 6A: `fmt` line-ending policy (F8) — decide preserve-vs-normalise, implement, document, test CRLF/lone-CR/mixed
 - [ ] 6B: Reconcile `kaappi test` with `run-all.sh` (F13)
 - [ ] 6C: Completions ↔ flag-table drift gate (`--no-ir-opt` is missing from all three scripts; `completions.zig` has zero tests)
-- [ ] 6D: LSP end-to-end — 942 lines, 6 inline tests, no integration test at all
+- [x] 6D: LSP end-to-end — 942 lines, 6 inline tests, no integration test at all (2026-08-01, [#1987](https://github.com/kaappi/kaappi/pull/1987); 152 assertions, 5.2s — filed [#1979](https://github.com/kaappi/kaappi/issues/1979) a `define-syntax` **leaks across documents** and survives `didClose`, [#1981](https://github.com/kaappi/kaappi/issues/1981) four divergences from `kaappi check` incl. whole files going undiagnosed and `KP4xxx` never appearing, [#1980](https://github.com/kaappi/kaappi/issues/1980) six protocol defects incl. **no response at all** on bad `params`)
 - [ ] 6E: `thottam` — 932 lines, 3 tests; version-constraint parsing, `--locked`, lockfile provenance
 - [ ] 6F: `fmt` adversarial comment placement and a byte-level mutation fuzzer over the corpus
 


### PR DESCRIPTION
Tracker sync for the fourth batch, plus a scope correction. **14 → 18 of 53 units.**

## Ticked

| unit | PR | headline |
|---|---|---|
| 2.5 SRFI 237 | #1975 | #1973 — a **27-field record aborts the process**, reachable from plain R7RS |
| 6D LSP | #1987 | #1979 — a `define-syntax` **leaks across documents**; #1980, #1981 |

## Not ticked, deliberately: 2.12 and 5D

Both are complete and green on macOS, and both were **held back by real BSD failures**:

- **#1985** (filesystem) — 2 failures on FreeBSD *and* OpenBSD, out of 421 passes
- **#1986** (SRFI-18) — 1 failure on NetBSD, out of 273 passes

They stay unticked because the work is not landed and the tests are not running anywhere. The status line names both PRs, so the next reader finds them rather than two silently absent entries.

**This is not the #1967 harness flake.** That one was diagnosable by its signature — different assertions each run, clean unit suite, and a docs-only PR failing too. These are in the units' own audit files, on exactly the platforms whose filesystem and thread semantics those units probe, and the same files pass everywhere else. That points at genuine platform divergence in my assertions, which needs a real BSD box to chase — `/vm-test` has FreeBSD, OpenBSD and NetBSD.

## 3.2 and 3.3 closed as subsumed by 2.4

Struck through rather than deleted, with what 2.4 actually covered recorded inline: all 12 element kinds at every boundary (8 integer kinds × min/max ± 1, plus 9 rejection classes), the two independent range rules cross-checked across 276 cells, both seams, and per-type wrappers verified three ways.

A tracker that **overstates** remaining work wastes a session as surely as one that understates finished work — left open, these would have told the next reader SRFI 160 coverage was missing when 1,066 assertions already cover it.

Docs only; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)