### PR TITLE
Tick 5D; 2.12 still blocked on a second FreeBSD divergence

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -1,6 +1,6 @@
 # Systematic Correctness Audit Strategy (v2)
 
-**Status:** in progress (18 of 53 units — 2.12 and 5D complete but held by BSD failures, see [#1985](https://github.com/kaappi/kaappi/pull/1985)/[#1986](https://github.com/kaappi/kaappi/pull/1986)) · **Last updated:** 2026-08-01 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
+**Status:** in progress (19 of 53 units — 2.12 still held by a FreeBSD divergence, see [#1985](https://github.com/kaappi/kaappi/pull/1985)) · **Last updated:** 2026-08-01 · **Tracking issue:** [#1890](https://github.com/kaappi/kaappi/issues/1890)
 · **Supersedes:** the v1 campaign (issue [#1137](https://github.com/kaappi/kaappi/issues/1137), closed 2026-07-05, 87 findings, all fixed)
 
 ## Why a second campaign
@@ -301,7 +301,7 @@ Tick when the PR is open and issues are filed; add date and issue numbers.
 - [ ] 5A: **Validate-or-retire** the SRFI 120 corruption claim; deliver either a live repro or a PR rewriting the header plus tests pinning both rejections
 - [x] 5B: `waitForFd` park-vs-drive protocol — zero tests reference `waitForFd`, `driving_waits`, or `anyAncestorWaitResolved` (2026-08-01, [#1960](https://github.com/kaappi/kaappi/pull/1960); 26 tests, **no bugs in `waitForFd`**. Pinned the 2×2 selector and the unwind asymmetry, whose nine `false` rows had zero coverage. Filed [#1959](https://github.com/kaappi/kaappi/issues/1959) — the user-visible error names `dynamic-wind` as unparkable when it is not)
 - [x] 5C: `gc_deep_copy` promoted-stub ownership skip — an already-promoted channel stub bypasses the owner check (2026-07-31, [#1938](https://github.com/kaappi/kaappi/pull/1938); 49 assertions, 24 disabled — CLAUDE.md's sharing model confirmed verbatim, 11 sound behaviours pinned; filed [#1933](https://github.com/kaappi/kaappi/issues/1933) **parent GC reclaims objects a live child references** (gc-stress: hard UAF panic), [#1932](https://github.com/kaappi/kaappi/issues/1932) a record loses its type across `thread-join!`, [#1934](https://github.com/kaappi/kaappi/issues/1934)–[#1937](https://github.com/kaappi/kaappi/issues/1937))
-- [ ] 5D: SRFI-18 re-audit (994 → 1435 lines since v1)
+- [x] 5D: SRFI-18 re-audit (994 → 1435 lines since v1) (2026-08-01, [#1986](https://github.com/kaappi/kaappi/pull/1986); 77 → 274 assertions — filed [#1982](https://github.com/kaappi/kaappi/issues/1982) `thread-terminate!` **cannot interrupt a native wait**, a residual of closed #880 whose own verification used a `(thread-yield!)` loop — exactly the case its fix handles; [#1983](https://github.com/kaappi/kaappi/issues/1983) unguarded float→int aborts that reach `(kaappi fibers)` too; [#1984](https://github.com/kaappi/kaappi/issues/1984) four state-machine defects. **Portability lesson:** an assertion pinning `(seconds->time +nan.0)` ⟹ `0.0` failed only on CI's NetBSD — `@intFromFloat` on NaN is undefined, so never assert its *value*; assert that it does not abort, which is the real contrast with #1983's aborting cases.)
 - [ ] 5E: De-flake and arm the timing tests (76 wall-clock lines; `smoke/thread-sleep-876.scm` has no exit path at all)
 - [ ] 5F: gc-stress × concurrency — needs `/do-stress-test` (Linux, hours)
 - [ ] 5G: Reactor backend parity — needs `/do-linux-test` (epoll) and `/vm-test` (kqueue)


### PR DESCRIPTION
**18 → 19 of 53 units.** 5D merged (#1986) with all three BSD legs green.

## 2.12 is still blocked, and honestly so

The `rdev` fix was real: FreeBSD reports `st_rdev = -1` (`NODEV`) for a non-device file where macOS and Linux report `0`. Verified on the reference VM — **409 pass / 3 fail → 412 pass / 0 fail**.

CI still fails, on a **second and distinct** divergence I cannot reproduce:

| | assertions | result |
|---|---:|---|
| FreeBSD reference VM (15.1) | 412 | **0 fail** |
| CI freebsd-test (14.3) | 423 | 2 fail |

The totals differ by 11, so these are not the same run. On the VM a `set-file-mode` raises inside the error-taxonomy block — with a *fresh* scratch directory, so not leftover state — which plausibly ends that block early and skips the assertions CI reaches. Different FreeBSD versions, different behaviour.

I stopped there rather than iterating further: the next step needs a FreeBSD 14.3 box, or CI logs that name the failing assertions. The current CI log prints bare `#f`/`FAIL` markers with no test names for these two — which is itself worth fixing, since the NetBSD failure was diagnosed in one step precisely *because* its assertion had a name.

## The 5D entry records a lesson, not just issue numbers

An assertion pinned `(seconds->time +nan.0)` ⟹ `0.0`. That is the result of `@intFromFloat` on a NaN — **undefined**. macOS and the NetBSD VM both happen to yield `0.0`, so it passed everywhere I could reach and failed only on CI.

Six sequential and twelve four-way-concurrent runs on the VM were all clean. An idle box cannot distinguish "fixed" from "did not fire", so the diagnosis came from reading the CI log for the assertion's *name*, not from re-creating the failure.

It now asserts that NaN does **not** abort — the real contrast with #1983's aborting `+inf.0` — which is true wherever the conversion lands.

Docs only; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)