### PR TITLE
Stop reporting a platform and a range rule as type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -936,6 +936,9 @@ jobs:
       - name: Parallel pool test (fiber-degraded, KEP-0002 Phase 5)
         run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/parallel.scm
 
+      - name: Platform gate diagnostics (kaappi#1972)
+        run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/platform-gates.scm
+
   coverage:
     needs: test
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **On the WebAssembly build, `open-input-file`, `open-output-file` and
+  `delete-file` now signal a file error** (#1972). R7RS 6.13 says these signal
+  a condition satisfying `file-error?`, which is what they do on every native
+  target, but the WASM build — which has no filesystem to reach — raised a
+  *type* error instead: `expected non-WASM platform, got #<string>`, blaming a
+  valid filename for the platform. So a portable
+  `(guard (e ((file-error? e) …)) (open-input-file …))`, correct everywhere
+  else, fell straight through to its caller on the playground. They now report
+  `cannot open input file: this WebAssembly build has no filesystem access`
+  (and the output/delete equivalents), keeping the path as the irritant. A
+  non-string argument is still a type error, on every target.
+- **`fd->port` reports its range rules as `KP3007 invalid argument`, not
+  `KP3002 type error`** (#1972). `0` is a fixnum — exactly the type the
+  procedure wants — so `expected socket/pipe file descriptor (> 2)` put a rule
+  about the *value* where the expected type belongs. The two bounds are also
+  now reported separately: `fd->port: descriptor 0 is a standard stream; 0, 1
+  and 2 stay blocking`, and `fd->port: -1 is outside the file-descriptor
+  range`. Its WebAssembly gate says `raw file descriptors are unavailable in
+  this WebAssembly build` rather than naming a type. A genuinely wrong
+  argument type is unchanged.
 - **A `guard` clause now runs in its own `guard`'s dynamic environment**
   (#1988). R7RS 4.2.7 evaluates the implicit `cond` "with the continuation and
   dynamic environment of the guard expression", but a handler runs at the raise

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -300,6 +300,57 @@ from its own bad input, or lets it swallow a genuine VM limit.
    - Debug info (source line tracking, line tables)
    - Error-path recovery where the primary error takes precedence
 
+### Nothing but a type belongs in the "expected type" slot (#1972)
+
+`typeError`'s third argument is printed as `expected <that>, got <value>`, so
+whatever goes there is read as a type. Two things kept ending up there that are
+not:
+
+- **A range rule.** `fd->port` rejected `0` with `expected socket/pipe file
+  descriptor (> 2)` — but `0` *is* a fixnum, the type it wants; the fault is the
+  value. That is `argError` (KP3007), not `indexError`: the reserved-stdio bound
+  is a semantic rule, and `indexError`'s wording (`index N out of range for
+  length L`) needs a length that does not exist here.
+- **A platform.** Four `comptime is_wasm` gates read `expected non-WASM
+  platform, got #<string>`, blaming a valid filename for the build it was
+  compiled into.
+
+The platform gates split two ways, and the seam is worth knowing because it
+looks like drift:
+
+| Procedure | Reports | Why |
+|---|---|---|
+| `open-input-file`, `open-output-file`, `delete-file` | a **file error** (`file-error?` → `#t`) | R7RS 6.13 already says what these signal when the file cannot be opened or deleted, and the WASM build cannot |
+| `fd->port` | `argError` (KP3007) | a Kaappi extension over `(kaappi ffi)`; no file, so nothing satisfies `file-error?` |
+
+That split is the same one SRFI 170 already makes: its POSIX-only procedures
+report `not supported on Windows` through `raiseUnsupportedOnWindows`, a file
+error, because the SRFI's own text says its procedures signal file errors — not
+because "unsupported platform" is generically a file error. Where no spec asks
+for one, don't borrow it.
+
+The first row is not a cosmetic choice. A type error is not a file error, so
+until #1972 a portable `(guard (e ((file-error? e) …)) (open-input-file …))` —
+correct on every native target — fell through to its caller on the WASM tier,
+which is the playground at kaappi-lang.org. The gate now raises through
+`raiseFileError`, the same helper the procedure's *own* native failure path two
+lines down already used; the platform is named in the message and the path stays
+the irritant. That neighbour is the general tell: **before inventing a phrasing
+for a failure, check what the same procedure raises for the same failure on a
+target where it can actually run.**
+
+Two ordering consequences. The type check now runs *before* the platform gate,
+so a non-string argument is a type error on every target rather than whatever
+the gate said. And the gate has to stay above the first POSIX call, since a
+comptime-true early return is what keeps `openat`/`unlink` out of the WASM
+build's analysis at all.
+
+A `comptime` gate cannot be tested from a native build — an assertion for one
+would compile away and silently never run, passing forever. They are covered by
+`tests/wasm/platform-gates.scm`, which the `wasm` CI job runs under wasmtime;
+the native half (`fd->port`'s range rules) lives in
+`tests/scheme/audit/primitives_io-audit.scm` next to #1944's.
+
 ### Tagging the `vm_instance` / `gc_instance` guards (#1874)
 
 Roughly 450 sites open with one of:

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -707,10 +707,29 @@ fn raiseFileError(gc: *@import("memory.zig").GC, msg_text: []const u8, irritant:
     return PrimitiveError.ExceptionRaised;
 }
 
+/// Appended to the ordinary failure message of the three `(scheme file)`
+/// procedures the WASM build compiles out (there is no POSIX `openat`/`unlink`
+/// to call), so the platform limit is reported as the *same condition* their
+/// native failure paths raise a few lines further down: a file error,
+/// satisfying `file-error?`. `primitives_filesystem.raiseUnsupportedOnWindows`
+/// is the same mechanism for SRFI 170's POSIX-only half; this one keeps the
+/// path as the irritant rather than `#f`, matching what the native failure
+/// paths here already report.
+///
+/// Until kaappi#1972 all three reported `type error in 'open-input-file':
+/// expected non-WASM platform, got #<string>` — a valid filename blamed for the
+/// platform, with a non-type in the "expected type" slot, and (the part that is
+/// not merely cosmetic) a condition no `(file-error? e)` guard clause ever
+/// caught, so portable R7RS code that handles a missing file correctly on every
+/// native target fell through to its caller on the playground.
+const wasm_no_fs = ": this WebAssembly build has no filesystem access";
+
 fn openInputFile(args: []const Value) PrimitiveError!Value {
-    if (comptime is_wasm) return primitives.typeError("open-input-file", "non-WASM platform", args[0]);
+    // The type check runs first even on WASM: a non-string argument is a type
+    // error on every target, and only a well-formed call reaches the gate.
     if (!types.isString(args[0])) return primitives.typeError("open-input-file", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (comptime is_wasm) return raiseFileError(gc, "cannot open input file" ++ wasm_no_fs, args[0]);
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 
@@ -730,9 +749,9 @@ fn openInputFile(args: []const Value) PrimitiveError!Value {
 }
 
 fn openOutputFile(args: []const Value) PrimitiveError!Value {
-    if (comptime is_wasm) return primitives.typeError("open-output-file", "non-WASM platform", args[0]);
     if (!types.isString(args[0])) return primitives.typeError("open-output-file", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (comptime is_wasm) return raiseFileError(gc, "cannot open output file" ++ wasm_no_fs, args[0]);
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 
@@ -777,12 +796,22 @@ fn openBinaryOutputFile(args: []const Value) PrimitiveError!Value {
 /// must not also close the fd through its own path, or the number could be
 /// recycled onto an unrelated port.
 fn fdToPort(args: []const Value) PrimitiveError!Value {
-    if (comptime is_wasm) return primitives.typeError("fd->port", "non-WASM platform", args[0]);
     if (!types.isFixnum(args[0])) return primitives.typeError("fd->port", "file descriptor", args[0]);
+    // Unlike the three `(scheme file)` procedures above, this one is a Kaappi
+    // extension over `(kaappi ffi)` with no R7RS condition to raise: there is
+    // no file, and nothing here satisfies `file-error?`. So the platform limit
+    // is an argument fault (KP3007) rather than a type error over a fixnum
+    // that is a perfectly good descriptor number (kaappi#1972).
+    if (comptime is_wasm) return primitives.argError("fd->port", "raw file descriptors are unavailable in this WebAssembly build", .{});
     const fd_i = types.toFixnum(args[0]);
     // Reject the standard streams (whose blocking semantics other code
-    // relies on) and anything outside fd_t's range.
-    if (fd_i < 3 or fd_i > std.math.maxInt(i32)) return primitives.typeError("fd->port", "socket/pipe file descriptor (> 2)", args[0]);
+    // relies on) and anything outside fd_t's range. Both are range rules over
+    // an argument of the right type, not type errors — and neither is an
+    // index into anything with a length, which is what rules out `indexError`.
+    if (fd_i >= 0 and fd_i <= 2)
+        return primitives.argError("fd->port", "descriptor {d} is a standard stream; 0, 1 and 2 stay blocking", .{fd_i});
+    if (fd_i < 0 or fd_i > std.math.maxInt(i32))
+        return primitives.argError("fd->port", "{d} is outside the file-descriptor range", .{fd_i});
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port_val = gc.allocPort(@intCast(fd_i), true, true, "fd", false) catch return PrimitiveError.OutOfMemory;
     types.toObject(port_val).as(types.Port).is_binary = true;
@@ -1832,9 +1861,9 @@ fn flushOutputPort(args: []const Value) PrimitiveError!Value {
 }
 
 fn deleteFile(args: []const Value) PrimitiveError!Value {
-    if (comptime is_wasm) return primitives.typeError("delete-file", "non-WASM platform", args[0]);
     if (!types.isString(args[0])) return primitives.typeError("delete-file", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (comptime is_wasm) return raiseFileError(gc, "cannot delete file" ++ wasm_no_fs, args[0]);
     const str = types.toObject(args[0]).as(types.SchemeString);
     const path = str.data[0..str.len];
 

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -590,7 +590,12 @@ test "#1478: fd->port rejects the standard streams and non-fixnums" {
 
     _ = try vm.eval("(import (kaappi ffi))");
     // fd 0/1/2 keep their blocking semantics -- fd->port must refuse them.
-    try std.testing.expectError(error.TypeError, vm.eval("(fd->port 1)"));
+    // The refusal is InvalidArgument (KP3007), not TypeError: 1 is a fixnum,
+    // which is exactly the type fd->port wants, so the fault is the value
+    // (kaappi#1972). Same for a number outside fd_t's range.
+    try std.testing.expectError(error.InvalidArgument, vm.eval("(fd->port 1)"));
+    try std.testing.expectError(error.InvalidArgument, vm.eval("(fd->port -1)"));
+    // A genuinely wrong type still is one -- the two are not the same check.
     try std.testing.expectError(error.TypeError, vm.eval("(fd->port \"nope\")"));
 }
 

--- a/tests/scheme/audit/primitives_io-audit.scm
+++ b/tests/scheme/audit/primitives_io-audit.scm
@@ -11,6 +11,7 @@
 
 (import (scheme base) (scheme write) (scheme read) (scheme file) (scheme char))
 (import (scheme process-context) (srfi 64) (srfi 181) (srfi 192))
+(import (only (kaappi ffi) fd->port))
 (import (only (srfi 18) thread-sleep! thread-start! thread-join! make-thread))
 
 (test-begin "primitives_io audit")
@@ -744,6 +745,45 @@
 ;; CONTROL: a valid sub-range still writes exactly that slice.
 (test-equal "bc"
   (let ((o (open-output-string))) (write-string "abcde" o 1 3) (get-output-string o)))
+
+;;; --- #1972: fd->port range constraints are not type errors -----------------
+;; 0/1/2 and an out-of-range number are all fixnums — the type fd->port wants —
+;; so "expected socket/pipe file descriptor (> 2)" put a range rule where the
+;; expected *type* belongs. They are argError (KP3007), not indexError: neither
+;; bound is an index into anything with a length.
+;;
+;; The four sibling sites this issue covers are `comptime is_wasm` gates, so
+;; they cannot be reached from a native build at all — tests/wasm/platform-gates.scm
+;; covers those under wasmtime.
+(test-equal "fd->port: descriptor 0 is a standard stream; 0, 1 and 2 stay blocking"
+  (err-message (lambda () (fd->port 0))))
+(test-equal "fd->port: descriptor 2 is a standard stream; 0, 1 and 2 stay blocking"
+  (err-message (lambda () (fd->port 2))))
+(test-equal "fd->port: -1 is outside the file-descriptor range"
+  (err-message (lambda () (fd->port -1))))
+(test-equal "fd->port: 999999999999 is outside the file-descriptor range"
+  (err-message (lambda () (fd->port 999999999999))))
+;; CONTROL: a genuinely wrong type is still a type error, so the fix drew the
+;; distinction rather than flattening every rejection into one kind.
+(test-equal "type error in 'fd->port': expected file descriptor, got #<symbol>"
+  (err-message (lambda () (fd->port 'nope))))
+(test-equal "type error in 'fd->port': expected file descriptor, got 3.0"
+  (err-message (lambda () (fd->port 3.0))))
+;; CONTROL: a number past the reserved range is accepted — the lower bound is
+;; the rule being enforced, not a blanket rejection. fd->port never probes the
+;; descriptor, so the number need not be open, and it deliberately is *not*:
+;; the port takes ownership and gc_sweep closes any fd > 2 it collects, which
+;; over a live descriptor would silently close something this run still needs.
+;;
+;; POSIX-only, because the eventual close is what makes the number matter.
+;; close(2) on an unopened descriptor is a plain EBADF, but the Windows CRT's
+;; _close invokes the invalid-parameter handler, whose default terminates the
+;; process — so this control would turn a passing suite into a crash there.
+(cond-expand
+  (windows)
+  (else
+   (test-equal #t (let ((p (fd->port 4096)))
+                    (and (port? p) (binary-port? p))))))
 
 ;; with-output-to-file restores current-output-port even when the thunk raises.
 (let ((path "/tmp/kaappi-audit-io-wo.txt"))

--- a/tests/wasm/platform-gates.scm
+++ b/tests/wasm/platform-gates.scm
@@ -1,0 +1,102 @@
+;;; Kaappi WASM platform-gate test (kaappi#1972).
+;;;
+;;; The WASM build compiles out every filesystem entry point, so a handful of
+;;; procedures stay registered but cannot do their job. What they report when
+;;; called is only checkable here: the gates are `comptime is_wasm` branches,
+;;; so a native-suite assertion for them would silently never run.
+;;;
+;;; All five reported a *type error* until #1972, putting "non-WASM platform"
+;;; — not a type — in the "expected type" slot and blaming a valid argument for
+;;; the platform. For the three `(scheme file)` procedures that was more than
+;;; cosmetic: R7RS says they signal a condition satisfying `file-error?`, which
+;;; is what they do on every native target and what portable code guards on, so
+;;; the type error fell straight through such a guard on the playground.
+;;;
+;;; Any FAIL line fails CI.
+
+(import (scheme base) (scheme write) (scheme file))
+
+(define failures 0)
+(define (check label ok)
+  (display (if ok "PASS " "FAIL "))
+  (display label)
+  (newline)
+  (if (not ok) (set! failures (+ failures 1))))
+
+(define (classify thunk)
+  (guard (e (#t (list (cond ((file-error? e) 'file-error)
+                            ((error-object? e) 'error)
+                            (else 'other))
+                      (if (error-object? e) (error-object-message e) #f)
+                      (if (error-object? e) (error-object-irritants e) #f))))
+    (list 'returned (thunk))))
+
+;; --- the three (scheme file) procedures ------------------------------------
+;; Same condition their native failure paths raise, so `(file-error? e)` is the
+;; one clause a caller needs on every target. The reason rides along in the
+;; message and the offending path stays the irritant.
+
+(check "open-input-file signals a file error naming the platform"
+       (equal? (classify (lambda () (open-input-file "gate.txt")))
+               '(file-error
+                 "cannot open input file: this WebAssembly build has no filesystem access"
+                 ("gate.txt"))))
+
+(check "open-output-file signals a file error naming the platform"
+       (equal? (classify (lambda () (open-output-file "gate.txt")))
+               '(file-error
+                 "cannot open output file: this WebAssembly build has no filesystem access"
+                 ("gate.txt"))))
+
+(check "delete-file signals a file error naming the platform"
+       (equal? (classify (lambda () (delete-file "gate.txt")))
+               '(file-error
+                 "cannot delete file: this WebAssembly build has no filesystem access"
+                 ("gate.txt"))))
+
+;; The binary constructors delegate to the textual ones, so they inherit it.
+(check "open-binary-input-file inherits the gate"
+       (equal? (car (classify (lambda () (open-binary-input-file "gate.txt"))))
+               'file-error))
+(check "open-binary-output-file inherits the gate"
+       (equal? (car (classify (lambda () (open-binary-output-file "gate.txt"))))
+               'file-error))
+
+;; The point of the R7RS condition: a portable fallback clause runs here.
+(check "a portable (file-error? e) guard catches it"
+       (eq? 'fallback
+            (guard (e ((file-error? e) 'fallback))
+              (open-input-file "gate.txt"))))
+
+;; --- fd->port ---------------------------------------------------------------
+;; A Kaappi extension over (kaappi ffi) — which is itself unavailable on WASM,
+;; though the primitive stays registered as a global, so the gate is reachable.
+;; No file is involved and nothing here satisfies file-error?, so this one is an
+;; argument fault (KP3007) rather than a borrowed file error.
+
+(check "fd->port reports the platform, not the descriptor"
+       (equal? (classify (lambda () (fd->port 5)))
+               '(error "fd->port: raw file descriptors are unavailable in this WebAssembly build" ())))
+
+;; --- controls ---------------------------------------------------------------
+;; Without these the fix could have flattened every failure into a file error
+;; instead of drawing the distinction.
+
+(check "CONTROL: a non-string argument is still a type error"
+       (equal? (classify (lambda () (open-input-file 42)))
+               '(error "type error in 'open-input-file': expected string, got 42" ())))
+
+(check "CONTROL: fd->port still type-checks its argument first"
+       (equal? (classify (lambda () (fd->port 'not-a-fixnum)))
+               '(error "type error in 'fd->port': expected file descriptor, got #<symbol>" ())))
+
+;; file-exists? is the one filesystem procedure with a value to degrade to, so
+;; it answers #f rather than raising anything at all — deliberately unlike the
+;; three above, and unchanged by #1972.
+(check "CONTROL: file-exists? degrades to #f instead of raising"
+       (equal? (classify (lambda () (file-exists? "gate.txt")))
+               '(returned #f)))
+
+(if (> failures 0)
+    (begin (display "PLATFORM GATE TESTS FAILED") (newline) (exit 1))
+    (begin (display "all platform gate tests passed") (newline)))


### PR DESCRIPTION
Closes #1972.

`typeError`'s third argument renders as `expected <that>`, so whatever goes there reads as a type. Five sites in `primitives_io.zig` put something else there.

## What they said, and what they say now

| Call | Before | After |
|---|---|---|
| `(open-input-file "x")` on WASM | `KP3002 type error in 'open-input-file': expected non-WASM platform, got #<string>` | `cannot open input file: this WebAssembly build has no filesystem access` — a **file error**, irritant `"x"` |
| `(open-output-file "x")` on WASM | same shape | `cannot open output file: …` (file error) |
| `(delete-file "x")` on WASM | same shape | `cannot delete file: …` (file error) |
| `(fd->port 5)` on WASM | same shape, `got 5` | `KP3007 fd->port: raw file descriptors are unavailable in this WebAssembly build` |
| `(fd->port 0)` | `KP3002 … expected socket/pipe file descriptor (> 2), got 0` | `KP3007 fd->port: descriptor 0 is a standard stream; 0, 1 and 2 stay blocking` |
| `(fd->port -1)` | same | `KP3007 fd->port: -1 is outside the file-descriptor range` |

## Why the three file procedures get a file error, not `argError`

The issue offered `argError` or "its own unsupported-platform phrasing". A third option turned out to be the right one, and it fixes more than wording: R7RS 6.13 says `open-input-file`/`open-output-file`/`delete-file` signal a condition satisfying `file-error?`. They do on every native target. On WASM they raised a *type* error, so this — correct everywhere else — fell through to the caller on the playground:

```scheme
(guard (e ((file-error? e) 'fallback)) (open-input-file "x"))
```

They now raise through `raiseFileError`, the helper their own native failure path two lines down already used. Same mechanism as `primitives_filesystem.raiseUnsupportedOnWindows` for SRFI 170's POSIX-only half, and for the same reason — the spec asks for a file error. `fd->port` has no spec and no file, so nothing there satisfies `file-error?`; its gate and both range rules are `argError`. Not `indexError`: neither bound indexes anything with a length.

## Ordering

The type check now runs *before* the platform gate, so a non-string argument is a type error on every target instead of whatever the gate said. The gate still sits above the first POSIX call — a comptime-true early return is what keeps `openat`/`unlink` out of the WASM build's analysis.

## Tests

A `comptime` gate cannot be tested from a native build: the assertion compiles away and passes forever. So the four gates are covered by a new `tests/wasm/platform-gates.scm`, run under wasmtime by the existing `wasm` CI job; `fd->port`'s native range rules join #1944's text assertions in `tests/scheme/audit/primitives_io-audit.scm`.

Both sets were mutation-tested by reverting `primitives_io.zig`, rebuilding, and re-running: **9 of 10** wasm assertions and **4 of 7** audit assertions fail without the fix. The rest are controls that must pass either way — a wrong-typed argument still being a type error, `file-exists?` still degrading to `#f` rather than raising.

One pre-existing unit test pinned the old taxonomy (`tests_port_io.zig`, `#1478: fd->port rejects the standard streams`) and is updated, with the two checks now split so the type error and the range fault are asserted separately.

The audit's acceptance control (`(fd->port 4096)` is accepted, so the bound is a boundary and not a blanket ban) is `cond-expand`'d off Windows: the port takes ownership and the collector closes any fd > 2, which is a plain `EBADF` under POSIX but hits the Windows CRT's invalid-parameter handler, whose default terminates the process.

## Verification

- `zig build test` — 1525 pass, 3 skip, 0 fail
- `zig build test -Dgc-stress=true -Dtest-filter="fd->port"` — 6 matched, 6 pass
- `bash tests/scheme/run-all.sh` — 2033 pass, 0 fail
- `wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/platform-gates.scm` — 10/10
- `markdownlint-cli2` and the `format` job's bare-`TypeError` grep, both clean

## Follow-up not taken here

`fd->port` is the only `.kaappi_ffi` spec without `.wasm = false` — its seven siblings in `primitives_ffi.zig` all have it — so on WASM the library is unimportable while the primitive stays reachable as a bare global. That inconsistency is what makes this gate reachable at all; whether to close it by deregistering instead is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)