### PR TITLE
Put the reason a fuzz job died into the issue it files

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -426,9 +426,11 @@ jobs:
   # phase failing is filed as "Fuzz CI: unit-test failure (<platform>
   # <variant>)" with the failing test names extracted from the log (#1688).
   # Remaining marker-less failures (toolchain/apt flakes, build failures,
-  # job-level timeouts — a possible hang) are collected under a single
-  # "Fuzz CI: infrastructure or build failure" issue instead of wearing a
-  # divergence title.
+  # job-level timeouts — a possible hang — and runners reclaimed mid-job) are
+  # collected under a single "Fuzz CI: infrastructure or build failure" issue
+  # instead of wearing a divergence title, each carrying a verdict read from
+  # its own job log so the three are told apart without opening the run
+  # (#2040).
   #
   # This is a SEPARATE job so the write-capable token never coexists with
   # execution of fuzzer-generated programs — the four jobs above keep
@@ -441,7 +443,7 @@ jobs:
     if: failure()
     permissions:
       issues: write
-      actions: read # download this run's failure artifacts for the excerpt
+      actions: read # this run's failure artifacts, and its job logs for the verdict
     steps:
       # No checkout: the job needs nothing from the repo, and gh targets it
       # via -R. Artifacts usually land in per-name subdirectories of
@@ -554,6 +556,58 @@ jobs:
               printf '\n```\n' >> "$out"
             fi
             printf '</details>\n' >> "$out"
+          }
+
+          # run_log_diagnosis OUT — append a per-failed-job verdict read from
+          # this run's OWN logs, via the `actions: read` token this job
+          # already holds. Artifact-less failures are exactly the ones whose
+          # cause exists nowhere else: a runner reclaimed mid-job CANCELS the
+          # job, so even the `if: failure()` upload step is skipped and
+          # nothing is uploaded — leaving the issue able to say no more than
+          # "see the run log". #2040 was such a case (a GitHub-hosted arm64
+          # runner shut down 46 min into a 55-min-timeout leg) and took a
+          # manual `gh api .../logs` to explain. Every failed job in the run
+          # is listed, including any whose finding was filed separately
+          # above, so the verdicts are never a partial view of the run.
+          run_log_diagnosis() {
+            rout="$1"
+            failed=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" --paginate \
+                       --jq '.jobs[]
+                             | select(.conclusion == "failure" or .conclusion == "cancelled")
+                             | [.id, .conclusion,
+                                (try ((.completed_at|fromdateiso8601) - (.started_at|fromdateiso8601)) catch 0),
+                                .name]
+                             | @tsv' 2>/dev/null || true)
+            [ -n "$failed" ] || return 0
+            printf '**Why the job(s) failed** (read from the run logs):\n\n' >> "$rout"
+            while IFS=$'\t' read -r jid jconc jdur jname; do
+              [ -n "$jid" ] || continue
+              case "$jdur" in '' | *[!0-9]*) jdur=0 ;; esac
+              jlog="job-$jid.log"
+              gh api "repos/$GITHUB_REPOSITORY/actions/jobs/$jid/logs" > "$jlog" 2>/dev/null || true
+              # Most- to least-specific: a reclaimed runner can also print the
+              # generic cancellation line, so its own line must be tested first.
+              if grep -qF 'The runner has received a shutdown signal' "$jlog" 2>/dev/null; then
+                verdict='the **GitHub-hosted runner was shut down mid-job** and the step was SIGTERMed (exit 143). That is runner infrastructure, not a build failure and not a hang; a shutdown cancels rather than fails the job, which is why the `if: failure()` upload step never ran and no artifact reached this issue. Re-run the job.'
+              elif grep -qF 'The operation was canceled' "$jlog" 2>/dev/null; then
+                verdict='the job was **cancelled** — it hit its `timeout-minutes`, or the run was cancelled. A fuzz leg reaching its own timeout deserves a second look: every generated program is individually time-bounded, so a whole job overrunning is itself suspicious.'
+              elif [ -s "$jlog" ]; then
+                verdict='a step failed; the runner diagnostics are below.'
+              else
+                verdict='its log could not be fetched from the API — open the run in the web UI.'
+              fi
+              printf -- '- `%s` — %s after %dm%02ds: %s\n' \
+                "$jname" "$jconc" "$((jdur / 60))" "$((jdur % 60))" "$verdict" >> "$rout"
+              errs=$(grep -oE '##\[error\].*' "$jlog" 2>/dev/null | sed 's/^##\[error\]//' | tail -5 || true)
+              if [ -n "$errs" ]; then
+                # No trailing newline on the body: command substitution already
+                # stripped it, and the closing fence supplies its own.
+                { printf '\n  ```\n'
+                  printf '%s' "$errs" | sed 's/^/  /' | head -c 1500
+                  printf '\n  ```\n'; } >> "$rout"
+              fi
+            done <<< "$failed"
+            printf '\n' >> "$rout"
           }
 
           # body_start LABEL HINT OUT — the report header shared by every issue kind.
@@ -756,13 +810,14 @@ jobs:
 
           # ---- shared infrastructure issue for marker-less failures ----
           if [ -n "$infra_jobs" ]; then
-            printf 'Automated report from the [Fuzz workflow](%s): a job failed WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM), a build failure, or a job-level timeout. (A fuzz-job unit-test failure is recognized from its log and filed separately as `Fuzz CI: unit-test failure (<platform> <variant>)`.) A timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious.\n\n' \
+            printf 'Automated report from the [Fuzz workflow](%s): a job failed WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM, a runner reclaimed mid-job), a build failure, or a job-level timeout. (A fuzz-job unit-test failure is recognized from its log and filed separately as `Fuzz CI: unit-test failure (<platform> <variant>)`.) A timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious — the per-job verdict below distinguishes that from a runner shutdown, which is pure infrastructure noise.\n\n' \
               "$run_url" > infra-preamble.md
             printf '> [!NOTE]\n> Close this issue once the failed run is explained (or the underlying breakage is fixed); further artifact-less failures append comments here.\n\n' \
               >> infra-preamble.md
             body_start "${infra_jobs# }" \
-              'The failed job(s) uploaded no finding artifact, so this is not (necessarily) a fuzz finding. Check the run log for a setup or build step failure, a test failure the classifier did not recognize, or a job cancelled at its timeout.' \
+              'The failed job(s) uploaded no finding artifact, so this is not (necessarily) a fuzz finding.' \
               body-infra.md
+            run_log_diagnosis body-infra.md
             case " $infra_jobs " in
               *' fuzz '*) excerpt "$fuzz_dir" body-infra.md ;;
             esac

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -190,9 +190,22 @@ rooting bug (`.claude/rules/gc-safety.md`, #1401, #1682).
 Both matrix variants are classified independently: a crash in one
 variant does not swallow the other variant's failure.
 Remaining marker-less failures — toolchain flakes, build failures,
-job-level timeouts (a possible hang) — are collected under a single
-shared issue titled `Fuzz CI: infrastructure or build
-failure` instead. Marker detection must not assume where inside
+job-level timeouts (a possible hang), and runners reclaimed mid-job — are
+collected under a single shared issue titled `Fuzz CI: infrastructure or
+build failure` instead. That issue carries a **per-job verdict read from
+the run's own logs** (the report job holds `actions: read`, so it fetches
+each failed job's log over the API and quotes its `##[error]` lines),
+because an artifact-less failure is exactly the case whose cause exists
+nowhere else: a reclaimed runner *cancels* the job, so even the
+`if: failure()` upload step is skipped and nothing is uploaded. The verdict
+is what separates the three lookalikes — a runner shutdown (`The runner has
+received a shutdown signal`, exit 143) is pure infrastructure and wants a
+re-run, whereas a job cancelled at its own `timeout-minutes` is worth
+investigating as a hang, since every generated program is individually
+time-bounded. #2040 was the first kind, mistakable for the second: an arm64
+leg killed 46 min into its 55-min budget, which took a manual
+`gh api repos/kaappi/kaappi/actions/jobs/<id>/logs` to tell apart.
+Marker detection must not assume where inside
 `artifacts/` a file lands: `download-artifact` normally extracts each
 artifact into its own named subdirectory, but a run with exactly one
 artifact (one failed job — the common case) is extracted into `artifacts/`


### PR DESCRIPTION
Closes #2040.

## What happened in #2040

`fuzz (arm64, ubuntu-24.04-arm, default, 2K, 55)` in [run #25](https://github.com/kaappi/kaappi/actions/runs/30686329736) was killed 46m08s into its `Fuzz (bounded)` step:

```
##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
##[error]Process completed with exit code 143.
```

A GitHub-hosted runner reclaimed mid-job — infrastructure, not a build failure, not a fuzz finding, and **not** the job timeout (55 min budget; the job died at 46m18s). Corroborating evidence: on the same commit the x86_64 `default` leg finished normally (988s vs. its 1009–1102s history) and the arm64 `gc-stress` leg likewise (813s vs. 713–977s). Because a shutdown *cancels* rather than fails the job, the `if: failure()` upload step and every post-step were skipped — hence no artifact, hence the generic infra issue.

Finding that took a manual `gh api repos/kaappi/kaappi/actions/jobs/91332793085/logs`. The issue itself could only say "see the run log", and its stock text pointed the wrong way: *"A timeout can be a genuine hang… itself suspicious."*

## The change

The `report` job already holds `actions: read`. A new `run_log_diagnosis` helper fetches each failed job's log over the API and leads the infra issue with a per-job verdict — conclusion, duration, and the last few `##[error]` lines — recognizing the runner-shutdown line specifically, ahead of the generic cancellation line (a reclaimed runner can print both).

This is the distinction the old text could not draw:

- **runner shutdown** (exit 143) — infrastructure; re-run the job.
- **cancelled at `timeout-minutes`** — worth chasing as a hang, since every generated program is individually time-bounded.
- anything else — the `##[error]` lines, verbatim.

What #2040 would have said instead:

> - `fuzz (arm64, ubuntu-24.04-arm, default, 2K, 55)` — failure after 46m18s: the **GitHub-hosted runner was shut down mid-job** and the step was SIGTERMed (exit 143). That is runner infrastructure, not a build failure and not a hang; a shutdown cancels rather than fails the job, which is why the `if: failure()` upload step never ran and no artifact reached this issue. Re-run the job.

Degradation is total: the jobs API failing drops the section entirely, an unfetchable log yields a "log unavailable" verdict, and neither aborts the step. The three existing routes (crash finding, unit-test failure, artifact excerpt) are untouched.

## Testing

The report script cannot run in CI, so it was driven offline with the protocol from #1689: extract the `run:` block from the YAML with pyyaml (so the tested bytes are the shipped bytes), stub `gh` on `PATH` recording every issue create/comment, synthesize the job-list and log fixtures, assert on titles and bodies. **9 scenarios / 40 assertions, all passing:**

| Scenario | Asserts |
|---|---|
| #2040's exact failure | verdict, duration `46m18s`, quoted log, still reports the missing artifact |
| genuine `timeout-minutes` cancellation | distinct verdict, keeps the hang hint |
| log carrying *both* lines | shutdown verdict wins (ordering) |
| ordinary build failure | falls through, `##[error]` lines still shown |
| log API unavailable | degrades, step still exits 0 |
| jobs API unavailable | section omitted, issue still filed |
| crash finding / unit-test failure | regression guards — no infra issue, no verdict leakage |
| two failed jobs | one shared issue, one verdict line each |
| existing open infra issue | comments instead of duplicating, verdict included |

`shellcheck -S warning` clean on the extracted script; `markdownlint-cli2` clean on the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
