### PR TITLE
Phase 3.10: un-quarantine slow/ — the two reference suites run in 0.4s, and SRFI 150's 4 failures are neither #1832 nor stale

### DIFF
--- a/lib/srfi/150.sld
+++ b/lib/srfi/150.sld
@@ -80,20 +80,29 @@
 ;;;     a plain, hygiene-renamed symbol (see lib/srfi/211/explicit-
 ;;;     renaming.sld's own header), and SRFI 213's property storage keeps
 ;;;     a stored value exactly as given (it is not itself macro-expanded
-;;;     or re-processed), a stored field-name/accessor-name symbol
-;;;     retains its full hygienic spelling (rename prefix included) across
-;;;     the definition/lookup boundary. Plain `equal?` on that raw symbol
-;;;     therefore already implements both bound-identifier=? (within one
-;;;     form: two same-spelled-but-differently-renamed identifiers are
-;;;     literally different symbols) and free-identifier=? (across forms:
-;;;     a name written directly by the user resolves to the same bare
-;;;     symbol wherever it's written, and a macro-introduced fresh name
-;;;     never collides with it) -- verified against the exact scenario
-;;;     each SRFI 150 hygiene test group requires (a template-introduced
-;;;     field name vs. the same-spelled caller-supplied one; a fresh
-;;;     per-expansion rename never matching an unrelated same-spelled
-;;;     binding) during this investigation, so no em-bound-identifier=?-
-;;;     style machinery is needed at all. This is specific to this
+;;;     or re-processed), a stored field-name/accessor-name symbol was
+;;;     believed to retain its full hygienic spelling (rename prefix
+;;;     included) across the definition/lookup boundary, so that plain
+;;;     `equal?` on that raw symbol would already implement both
+;;;     bound-identifier=? and free-identifier=? with no
+;;;     em-bound-identifier=?-style machinery at all.
+;;;
+;;;     *** THAT IS FALSE -- see kaappi#2051. *** The rename does NOT
+;;;     survive the boundary, because this library carries field names
+;;;     across it inside `quote`, and quoting strips the hygiene prefix:
+;;;     (eq? '__hyg_2_a 'a) is #t. Expansion is correct (`kaappi expand`
+;;;     shows the two names properly distinguished), and both then strip
+;;;     to the same bare symbol before the runtime by-name lookup below
+;;;     ever sees them, so two hygienically-distinct fields collapse into
+;;;     one. This is what all four KNOWN FAILURES in
+;;;     tests/scheme/srfi/srfi150.scm are; the claim above was previously
+;;;     recorded as "verified against the exact scenario each SRFI 150
+;;;     hygiene test group requires", which is precisely the scenario
+;;;     that fails. A fix has to stop round-tripping hygienic identity
+;;;     through `quote` -- resolve field names entirely at expansion
+;;;     time, or key the property table on something that is not a quoted
+;;;     symbol. The rename-by-spelling representation described here is
+;;;     otherwise accurate, and is specific to this
 ;;;     engine's rename-by-spelling hygiene representation, noted as a
 ;;;     `(srfi 213)` conformance property already ("nominal... matching
 ;;;     this symbol-based expander's identity model") -- a portable

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -28,9 +28,17 @@
 | `sandbox/` | Sandbox isolation tests | no (CI runs it separately) |
 
 **The globs in `run-all.sh` are non-recursive** (`tests/scheme/srfi/*.scm`,
-not `**`). A test placed in a subdirectory of a suite is silently never run —
-`tests/scheme/srfi/slow/` is exactly that today (kaappi#1900). Put new files
-directly in a suite directory, or wire the subdirectory up explicitly.
+not `**`). A test placed in a subdirectory of a suite would be silently never
+run — `tests/scheme/srfi/slow/` was exactly that for eleven days, holding the
+two full SRFI 257 reference suites (kaappi#1900). Put new files directly in a
+suite directory, or wire the subdirectory up explicitly.
+
+This is no longer silent: `run-all.sh` opens with a **reachability check** that
+fails the run if any `.scm` file under a suite subdirectory contains
+`test-begin`. Fixtures are exempt by construction — a fixture is a library or
+an included fragment and never opens a SRFI-64 suite — so the check needs no
+allowlist to maintain. If you add a genuine fixture that must call
+`test-begin`, wire its directory into a glob rather than weakening the check.
 
 ## Adding a test
 

--- a/tests/scheme/differential/run-differential.sh
+++ b/tests/scheme/differential/run-differential.sh
@@ -152,10 +152,11 @@
 #
 # So: gate on the default set, sweep the full one on demand.
 #
-# `tests/scheme/srfi/slow/` is not in either corpus — it is the pair of
-# reference suites that `run-all.sh`'s non-recursive globs already miss
-# (audit v2 finding F11); pulling it in here would hide that gap behind a
-# passing differential rather than fix it.
+# `tests/scheme/srfi/slow/` no longer exists: audit v2 Phase 3.10 found its
+# quarantine obsolete (the two full SRFI 257 reference suites now run in ~0.4s
+# each, not the minutes that put them there) and moved both files up into
+# `tests/scheme/srfi/`, so they are now in the opt-in KAAPPI_DIFF_FULL corpus
+# along with the rest of srfi/.
 
 set -uo pipefail
 

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -404,6 +404,51 @@ run_shell_suite() {
     echo ""
 }
 
+# The .scm suite globs below are non-recursive (srfi/*.scm, not **), so a test
+# file dropped into a subdirectory of a suite is silently never run by anything.
+# tests/scheme/srfi/slow/ was exactly that for eleven days, holding the two full
+# SRFI 257 reference suites (kaappi#1900) — the quarantine that put them there
+# was obsoleted by #1804 a week later and nobody re-measured, because nothing
+# ever reported them as missing.
+#
+# Fixtures legitimately live in subdirectories (tests/scheme/CLAUDE.md requires
+# it), so the discriminator is `test-begin`: a fixture is a library or an
+# included fragment and never opens a SRFI-64 suite, while every real suite
+# file does. Verified against the whole tree — 11 fixture .scm files under
+# suite subdirectories, none containing `test-begin`, and no false positives.
+SCM_SUITE_DIRS="smoke compliance continuations hygiene srfi ffi audit"
+
+check_unreachable_tests() {
+    echo "=== Reachability check ==="
+    local found=0 dir f listing
+    listing=$(mktemp "${TMPDIR:-/tmp}/kaappi-reach-XXXXXX")
+    for dir in $SCM_SUITE_DIRS; do
+        [[ -d "tests/scheme/$dir" ]] || continue
+        find "tests/scheme/$dir" -type f -name '*.scm' > "$listing" 2>/dev/null || true
+        while IFS= read -r f; do
+            [[ -n "$f" ]] || continue
+            # Top-level files are covered by the globs below; only look deeper.
+            [[ "$(dirname "$f")" = "tests/scheme/$dir" ]] && continue
+            if grep -Fq 'test-begin' "$f"; then
+                echo "  UNREACHABLE  $f"
+                found=$((found + 1))
+            fi
+        done < "$listing"
+    done
+    rm -f "$listing"
+    if [[ $found -gt 0 ]]; then
+        echo ""
+        echo "  $found test file(s) sit in a suite subdirectory, where this script's"
+        echo "  non-recursive globs cannot see them. Move each into its suite directory,"
+        echo "  or wire the subdirectory into a run_suite glob below."
+        echo "  See tests/scheme/CLAUDE.md (Directory layout)."
+        FAIL=$((FAIL + found))
+    else
+        echo "  PASS  no test files hidden in suite subdirectories"
+    fi
+    echo ""
+}
+
 echo "Running .scm suites with $JOBS parallel job(s) (override: KAAPPI_TEST_JOBS)."
 echo "Running shell suites with $SHELL_JOBS parallel job(s) (override: KAAPPI_SHELL_TEST_JOBS)."
 
@@ -425,6 +470,8 @@ if command -v zig > /dev/null 2>&1; then
     fi
 fi
 echo ""
+
+check_unreachable_tests
 
 run_suite "Smoke tests" tests/scheme/smoke/*.scm
 run_shell_suite "Smoke shell tests" tests/scheme/smoke

--- a/tests/scheme/srfi/srfi150.scm
+++ b/tests/scheme/srfi/srfi150.scm
@@ -20,11 +20,28 @@
 ;;     reference gained a descriptive string label, matching every other
 ;;     test file in this directory (srfi131.scm included).
 ;;
-;; Three assertions below are wrapped or annotated as KNOWN FAILURES --
-;; see lib/srfi/150.sld's header for the underlying engine limitation
-;; (a pre-existing top-level binding same-spelled as a macro template's
-;; own field-name literal can leak through unrenamed on one of a macro's
-;; two internal expansion passes). Two of the three additionally hard-
+;; Four assertions below are annotated as KNOWN FAILURES, all four of
+;; them one defect: kaappi#2051. They were originally attributed to
+;; kaappi#1832 ("a pre-existing top-level binding same-spelled as a
+;; macro template's own field-name literal leaks through unrenamed on
+;; one of a macro's two internal expansion passes"). Audit v2 Phase 3.10
+;; established that attribution is wrong on both halves. #1832 is fixed
+;; and its own regression test passes; its exact shape works correctly
+;; under plain (scheme base) define-record-type. And a pre-existing
+;; top-level binding is not required here at all -- removing it leaves
+;; every one of these cases failing identically.
+;;
+;; The real mechanism is that lib/srfi/150.sld carries field names from
+;; expansion time to run time inside `quote`, and a hygiene rename does
+;; not survive quoting ((eq? '__hyg_2_a 'a) is #t). The expansion is
+;; correct -- `kaappi expand` shows the two field names properly
+;; distinguished as __hyg_2_a and a -- and both then strip to `a` before
+;; the runtime by-name lookup sees them, so the two fields collapse into
+;; one. The trigger is purely a spelling collision between the template's
+;; own field-name literal and the identifier the use site supplies;
+;; giving the use site a different spelling makes each case pass.
+;;
+;; Two of the four additionally hard-
 ;; error at the record-type-definition site itself, not merely at the
 ;; assertion that reads a field back -- SRFI-64's `test-expect-fail`
 ;; only covers a wrong-value assertion, not a top-level form throwing
@@ -145,9 +162,13 @@
        (a get-a)
        (b get-b)))))
 
-;; KNOWN FAILURE (see lib/srfi/150.sld header and the file header above):
-;; `def`'s own field-name literal `a` collides in spelling with the
-;; pre-existing top-level `(define a #f)` above, so this hard-errors at
+;; KNOWN FAILURE: kaappi#2051 (see the file header above). `def`'s own
+;; field-name literal `a` and the `a` this use site passes as `b` are
+;; distinct after expansion (__hyg_2_a vs a) but collapse to one name
+;; when SRFI 150 carries them through `quote` into its runtime lookup.
+;; The `(define a #f)` above is NOT the trigger -- deleting it leaves
+;; this failing identically; passing a different spelling at the use
+;; site is what makes it pass. This hard-errors at
 ;; definition time on kaappi (reported directly to stderr below) rather
 ;; than merely returning a wrong value -- `get-a`/`get-b` are therefore
 ;; never defined, and both dependent assertions below fail by reference
@@ -189,9 +210,12 @@
 
 (define-child make-child child-get x)
 
-;; KNOWN FAILURE (see lib/srfi/150.sld header): same root cause as
-;; hygiene 1 above, but this one returns a wrong value instead of
-;; hard-erroring, so plain test-expect-fail covers it.
+;; KNOWN FAILURE: kaappi#2051, same root cause as hygiene 1 above --
+;; the template's own field `x` and the inherited parent field the use
+;; site names `x` collapse to one name through `quote`. This one returns
+;; a wrong value instead of hard-erroring, so plain test-expect-fail
+;; covers it. Control: renaming the template's own field to `y` (no
+;; spelling collision) makes it return the correct (1 2).
 (test-expect-fail "hygiene 2: inherited field set via macro-introduced reference")
 (test-eqv "hygiene 2: inherited field set via macro-introduced reference"
   1 (parent-get (make-child 1 2)))
@@ -227,12 +251,14 @@
 
 (test-equal "Alex Shinn's example: default-filled tuple"
   '(0 0) (let ((pt (make-point))) (list (point-ref pt 0) (point-ref pt 1))))
-;; KNOWN FAILURE (see lib/srfi/150.sld header): same limitation family as
-;; the hygiene tests above -- both explicitly-supplied fields read back
-;; as the second argument (confirmed (2 2), not (1 2)), consistent with
-;; deftuple's per-step `tmp` template literal collapsing to one shared
-;; name across its recursive expansion, though the exact mechanism
-;; wasn't traced as precisely as the hygiene 1/2 cases above.
+;; KNOWN FAILURE: kaappi#2051, same root cause as the hygiene tests
+;; above -- both explicitly-supplied fields read back as the second
+;; argument ((2 2), not (1 2)). The earlier guess here, that deftuple's
+;; per-step `tmp` template literal collapses to one shared name across
+;; its recursive expansion, is now confirmed and its mechanism traced:
+;; `kaappi expand` shows the fields correctly distinguished as
+;; __hyg_1_tmp and __hyg_2_tmp, and both strip to `tmp` when SRFI 150
+;; carries them through `quote` into its runtime by-name lookup.
 (test-expect-fail "Alex Shinn's example: explicitly-constructed tuple")
 (test-equal "Alex Shinn's example: explicitly-constructed tuple"
   '(1 2) (let ((pt (make-point 1 2))) (list (point-ref pt 0) (point-ref pt 1))))

--- a/tests/scheme/srfi/srfi257-full.scm
+++ b/tests/scheme/srfi/srfi257-full.scm
@@ -10,19 +10,31 @@
 ;;     boxes is implementation-specific; Kaappi boxes compare by identity)
 ;;
 ;; The rx sublibrary has its own reference suite, ported alongside this one as
-;; tests/scheme/srfi/slow/srfi257-rx-full.scm.
+;; tests/scheme/srfi/srfi257-rx-full.scm.
 ;;
-;; This is the FULL port (about 4½ minutes of macro expansion on an M-class
-;; laptop), kept out of run-all.sh's non-recursive srfi/*.scm glob; CI runs
-;; the lean tests/scheme/srfi/srfi257.scm smoke instead.
+;; This is the FULL port. It lived in a `slow/` subdirectory until audit v2
+;; Phase 3.10, quarantined because it cost about 4½ minutes of macro expansion
+;; and run-all.sh allows 60s per file. That is no longer true: it runs in
+;; ~0.4s, which #1802/#1804 (ReleaseSafe was memsetting the expander's 1MB
+;; buffers on every expansion) made obsolete eight days after the quarantine
+;; went in, with nobody re-measuring. Five files already in this directory are
+;; slower. Being in a subdirectory made it unreachable from run-all.sh's
+;; non-recursive globs (kaappi#1900), so it now sits here directly.
 ;;
-;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/slow/srfi257-full.scm
+;; It does NOT supersede the lean tests/scheme/srfi/srfi257.scm: 18 of that
+;; file's 34 assertions have no counterpart here, so both are kept. That is
+;; also why this file's suite name is "srfi-257-full" and not "srfi-257" —
+;; SRFI-64 derives its log filename from the suite name, and two files
+;; writing one log under run-all.sh's parallel dispatch was the only such
+;; collision in the tree.
+;;
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi257-full.scm
 
 (import (scheme base) (srfi 64)
         (srfi 257) (srfi 257 misc)
         (srfi 111) (srfi 257 box))
 
-(test-begin "srfi-257")
+(test-begin "srfi-257-full")
 
 (define-syntax test-matcher
   (syntax-rules ()

--- a/tests/scheme/srfi/srfi257-rx-full.scm
+++ b/tests/scheme/srfi/srfi257-rx-full.scm
@@ -3,12 +3,23 @@
 ;; reference test suite by Sergei Egorov, whose second half is in turn
 ;; adapted from Alex Shinn's chibi regexp tests.
 ;;
-;; This is the FULL port (about 1½ minutes of macro expansion on an M-class
-;; laptop, over run-all.sh's 60s per-file budget), kept out of run-all.sh's
-;; non-recursive srfi/*.scm glob; CI runs the lean
-;; tests/scheme/srfi/srfi257-rx.scm smoke instead.
+;; This is the FULL port. It lived in a `slow/` subdirectory until audit v2
+;; Phase 3.10, quarantined because it cost about 1½ minutes of macro expansion
+;; against run-all.sh's 60s per-file budget. That is no longer true: it runs in
+;; ~0.4s, which #1802/#1804 (ReleaseSafe was memsetting the expander's 1MB
+;; buffers on every expansion) made obsolete eight days after the quarantine
+;; went in, with nobody re-measuring. Being in a subdirectory made it
+;; unreachable from run-all.sh's non-recursive globs (kaappi#1900), so it now
+;; sits here directly.
 ;;
-;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/slow/srfi257-rx-full.scm
+;; It does NOT supersede the lean tests/scheme/srfi/srfi257-rx.scm: 8 of that
+;; file's 25 assertions have no counterpart here, so both are kept. That is
+;; also why this file's suite name is "srfi-257-rx-full" and not
+;; "srfi-257-rx" — SRFI-64 derives its log filename from the suite name, and
+;; two files writing one log under run-all.sh's parallel dispatch was the only
+;; such collision in the tree.
+;;
+;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi257-rx-full.scm
 
 ;;;; SPDX-FileCopyrightText: Sergei Egorov
 ;;;; SPDX-License-Identifier: BSD-3-Clause
@@ -18,7 +29,7 @@
 
 ; SRFI 257 RX Tests (some of them borrowed)
 
-(test-begin "srfi-257-rx")
+(test-begin "srfi-257-rx-full")
 
 (test-equal #f
   (match 42 ((~/ "[0-9]+" a) a) (_ #f)))


### PR DESCRIPTION
Audit v2 unit **3.10** (tracking: #1890). Two jobs, both closing on the same theme: a thing that was true once, stopped being true, and nothing re-checked it.

## Job A — `tests/scheme/srfi/slow/` (F11, #1900)

`run-all.sh`'s globs are non-recursive, so the subdirectory holding the two full SRFI 257 reference suites was reachable from **nothing**. Confirmed by exhaustive search: the only mentions in the tree were two doc comments describing the gap.

**What the files actually do:** both pass, in **0.39s** and **0.44s** (VERIFIED, cold cache, isolated `KAAPPI_HOME`). Their headers claimed 4½ and 1½ minutes against run-all.sh's 60s budget — that was true when they were quarantined on 2026-07-20, and stopped being true on 2026-07-28 when #1802/#1804 stopped ReleaseSafe memsetting the expander's 1MB buffers on every expansion. Nobody re-measured, because nothing ever reported the files as missing.

They are not slow by any current measure. Timed all 202 srfi files: they rank **6th and 7th**, behind `srfi120.scm` (2.74s) and `srfi264.scm` (1.86s), which are already enabled. Since those pass on the emulated QEMU legs today, the 60s budget is settled by a wide margin.

**What changed, and why this shape:** both files moved up into `tests/scheme/srfi/` rather than run-all.sh gaining another glob. That preserves the documented invariant (subdirectories hold fixtures; suite files sit at the top level), and touches none of the 18 CI legs that run this script.

Two things checked before committing to it:

- **They do not supersede the lean smokes.** Diffed the assertion multisets: 18 of `srfi257.scm`'s 34 and 8 of `srfi257-rx.scm`'s 25 have no counterpart in the full ports. Deleting the lean files would have lost coverage. Both are kept.
- **Keeping both created a collision.** The lean and full files shared `test-begin` names, and SRFI-64 derives its log filename from the suite name — the tree's *only* two duplicate suite names, which under parallel dispatch meant two files writing one log. The full ports are renamed `srfi-257-full` / `srfi-257-rx-full`.

Net: **+131 assertions for ~0.8s.**

**The generalisable half.** `run-all.sh` opens with a reachability check that fails the run if any `.scm` under a suite subdirectory contains `test-begin`. Fixtures are exempt by construction — a fixture is a library or an included fragment and never opens a SRFI-64 suite — so it needs no allowlist to maintain. Verified zero false positives against the whole tree (11 fixture files under suite subdirectories, none matching), and mutation-tested in both directions: clean tree → PASS, planted test file → `UNREACHABLE` + nonzero, planted fixture → PASS.

**Other unreachable tests:** audited every glob against `find tests -name '*.scm' -o -name '*.sh'`. 114 files are outside run-all.sh; **every one is accounted for** — fixtures/probes (19), documented-`no` suites `bench`/`coverage`/`robustness`/`sandbox` (39), and CI-driven corpora each with a real driver (`e2e/programs` + `run-e2e.sh` in ci.yml, `tests/wasm` in ci.yml/release.yml, `tests/fuzz` in fuzz.yml, `tests/acceptance` in post-release.yml), plus run-all.sh's own infrastructure scripts. `srfi/slow/` was the **only** genuinely orphaned directory.

## Job B — SRFI 150's 4 expected failures → **#2051**

All four still fail. The verdict is **neither** stale annotations **nor** an incomplete #1832 fix: they are a **third, distinct defect**, and the #1832 citation is wrong on both halves.

- **#1832 is fixed.** Its own regression test passes 6/6, and its exact shape works correctly under plain `(scheme base)` `define-record-type` — matching chibi 0.12.
- **#1832's defining condition is not present.** It requires a pre-existing top-level binding of the colliding spelling. Removing that binding leaves every case failing **identically** (the decisive control). Passing a different spelling at the use site is what makes them pass — so the trigger is purely the spelling collision.
- **Not #2003 either**, which needs the captured global to hold a *procedure*; here nothing is bound at all.

**Actual root cause:** `lib/srfi/150.sld` carries field names from expansion time to run time inside `quote`, and a hygiene rename does not survive quoting — `(eq? '__hyg_2_a 'a)` is `#t`. The expansion is *correct* (`kaappi expand` shows the fields properly distinguished as `__hyg_2_a` and `a`); both then strip to `a` before the runtime by-name lookup, so two hygienically-distinct fields collapse into one. The strip is not at read time (`kaappi ast` shows it intact) and is correct in general — a template's `'foo` must yield `foo`. The defect is that SRFI 150's strategy is unsound on top of it. Same mechanism explains all four, including Alex Shinn's tuple case (`__hyg_1_tmp` and `__hyg_2_tmp` both strip to `tmp`).

**Doc-truth:** `lib/srfi/150.sld`'s header asserted the opposite — that the rename prefix survives that boundary, "verified against the exact scenario each SRFI 150 hygiene test group requires", which is precisely the scenario that fails. Corrected in place, along with the four per-case annotations.

**On #1903 / F13:** entangled but deliberately untouched. The divergence on this file is caused by the hygiene-1 case's uncaught top-level error, so fixing #2051 would remove this instance — but #1903's own text names "restructure `srfi150.scm`" as one candidate resolution, and that is 6B's call. Its reproducer is left intact.

## Verification

Full suite from a **clean rebuild at the committed tree**: `644 pass, 0 fail, 0 timeout`, R7RS `1395 pass, 0 fail`, exit 0 — up from 642 files, the two newly-reachable ones both green.

One process note worth recording: an intermediate run showed 2 failures in the compile suite. They were an artefact of my own stash/pop A/B thrashing leaving inconsistent `.zig-cache`/`zig-out` state against the git build id's bare `-dirty` flag — the documented footgun. Both pass from a clean build with this diff applied; nothing in this change touches them.

Also checked: `markdownlint-cli2` clean; `shellcheck -S warning` clean on the new code (the one warning at `run-all.sh:273` is pre-existing); `kaappi fmt --check` reports **zero semantic drift** on all four edited Scheme files, which is what `fmt.sh`'s corpus assertion actually gates on.

Portability of the `run-all.sh` change (18 CI legs): no GNU regex extensions — the check uses `grep -Fq` with a fixed string; no pipe into `grep -q` under `pipefail` — the file is read directly with no pipeline; `find` follows the existing precedent at `fmt.sh:115`, which already runs on OpenBSD and Windows Git Bash.

Tracker tick left to the orchestrator per the batch protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
