### PR TITLE
Phase 6B: reconcile kaappi test with run-all.sh — a suppressed (exit 0) still meant exit 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`kaappi test` and `run-all.sh` now agree on every file** (#1903). A file
+  that raised an uncaught top-level error and then called `(exit 0)` was
+  reported `PASS` by `run-all.sh`, which reads the process status, and `ERROR`
+  with exit 1 by `kaappi test`, whose worker suppresses the exit and never
+  consulted what the suppressed call had asked for. `run-all.sh` was right:
+  `tests/scheme/errors/exit-code.sh` already pins "explicit `(exit 0)` wins
+  over an earlier uncaught error", and `emitResult`'s own doc comment claimed
+  `errored` covered a nonzero exit, which the code never implemented.
+  A single `resolveVerdict` now weighs the counters, the recorded exit and the
+  top-level error together. An `(exit 0)` waives only the file's *own*
+  top-level error and can never bury a failing assertion, since the counters
+  stay authoritative; the waived error is still reported, as a **note** printed
+  under the verdict and tallied separately. This also closes the opposite
+  divergence, which nobody had noticed: a file exiting nonzero with counters
+  that do not explain it was `FAIL` under `run-all.sh` and silently `PASS`
+  here. Across all 352 SRFI-64 files, disagreements went from 1 to 0. The
+  summary's first line is now labelled `Tests:`, because `0 failed` (tests) sat
+  directly above `1 failed` (files) with nothing naming the difference.
+
 - **The handler and dynamic-wind stacks now grow on demand**, like the frame
   and register stacks, from an initial 64 entries up to 32768 (#1886). The
   initial capacities are configurable with `-Dmax-handlers` and

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -92,10 +92,11 @@ Inside the worker (`src/main.zig` `runWorkerFile` → `src/test_runner.zig`):
    factory. Multiple `test-begin`/`test-end` groups in one file each get a fresh
    runner via the factory, and all funnel into the same accumulators.
 2. **Suppress `(exit)`.** The worker sets `vm.suppress_exit`, so a file's
-   `(exit 1)` failure epilogue becomes a *recorded* no-op (`vm.exit_requested`)
-   instead of terminating the worker before it can emit its result. A test
-   file's `(exit 1)` is redundant with the fail counts we already collected, so
-   it is **not** treated as a file error.
+   `(exit 1)` failure epilogue becomes a *recorded* no-op (`vm.exit_requested`
+   / `vm.exit_code`) instead of terminating the worker before it can emit its
+   result. Because the call never happens, its *semantics* are reapplied when
+   the verdict is resolved — see [Verdicts](#verdicts-and-what-errored-means)
+   below.
 3. **Run the file** via the normal `runFile` path (so the `.sbc` cache, imports,
    and error diagnostics all behave exactly as a plain run).
 4. **Emit one JSON object** for the file to `KAAPPI_TEST_EMIT`, built by walking
@@ -109,9 +110,47 @@ worker's stdout/stderr (which the worker itself never sees, since that went to
 the pipe the orchestrator owns). A worker that writes no result (a crash) is
 reported as an errored file synthesised from the captured output.
 
-A **file-level error** (`"error": true`) means an *uncaught* read/compile/runtime
-error at top level. SRFI-64 catches ordinary test failures internally via
+## Verdicts, and what "errored" means
+
+A **file-level error** (`"error": true`) is a failure of the *file*, as opposed
+to a failure of a test. SRFI-64 catches ordinary test failures internally via
 `guard`, so those never set it — they show up in the counts and `failures`.
+
+Three inputs decide it (`resolveVerdict` in `src/test_runner.zig`): whether an
+uncaught read/compile/runtime error was reported at top level, what the file's
+suppressed `(exit)` asked for, and whether the SRFI-64 counters already show a
+failure.
+
+| The file… | `error` | Why |
+|---|---|---|
+| ran clean | `false` | — |
+| hit an uncaught top-level error, never called `(exit)` | **`true`** | a plain run would exit 1 |
+| hit an uncaught top-level error, then `(exit 0)` | `false` + a **note** | the file waived it; a plain run exits 0 |
+| called `(exit N≠0)` with a failing count | `false` | redundant — the counts carry it, and `files_failed` already counts the file |
+| called `(exit N≠0)` with nothing failing | **`true`** + a **note** | otherwise the file's own verdict is lost |
+
+An `(exit 0)` waives only the file's *own* top-level error. It can never bury a
+failing assertion: the counters stay authoritative, so a file that both errors
+and fails is still reported as a failure.
+
+**Why the exit status matters at all**, given the whole point of this runner is
+to stop scraping: `tests/scheme/run-all.sh` runs the same file as a plain
+`kaappi <file>` and reads exactly that status, and
+`tests/scheme/errors/exit-code.sh` pins the rule it follows — *an explicit
+`(exit N)` always wins over an already-reported top-level error*. A runner that
+suppressed the call and then ignored what it asked for would reach a different
+verdict than the legacy runner on the same file, which is what
+[kaappi#1903](https://github.com/kaappi/kaappi/issues/1903) was: `srfi150.scm`
+green under `run-all.sh` and `1 errored`, exit 1, under `kaappi test`.
+`tests/scheme/test-runner/runner-agreement.sh` runs a fixture matrix through
+*both* verdict rules and requires them to match.
+
+A **note** is the channel for something a verdict deliberately tolerates. It
+travels in `error_message` (with `"error": false`), prints under the file's
+`PASS`/`FAIL` line in text mode along with whatever the worker wrote to
+stdout/stderr, and is tallied as `noted` in the summary. So a waived top-level
+error is visible without being fatal, rather than either failing the run or
+disappearing from it.
 
 ## JSON schema
 
@@ -145,6 +184,9 @@ Per-file object:
 ```
 
 - `suite` — the outermost `test-begin` name, or `null`.
+- `error_message` — the diagnostic for an errored file, **or** the note for a
+  file whose verdict tolerated something (`"error": false` with a non-null
+  message). Never assume `error_message != null` implies `error`.
 - `tests` — `pass + fail + xpass + xfail + skip`.
 - `kind` — `"fail"` (an expected pass that failed) or `"xpass"` (an
   expected-fail that unexpectedly passed). `xfail` (expected fail) and `skip`
@@ -161,12 +203,15 @@ Summary object (always last):
 ```json
 {
   "type": "summary",
-  "files": 108, "files_failed": 1, "errors": 0,
+  "files": 108, "files_failed": 1, "errors": 0, "noted": 0,
   "tests": 1611, "pass": 1610, "fail": 1, "xpass": 0, "xfail": 0, "skip": 0,
   "seed": 543286,
   "duration_ms": 15825.0
 }
 ```
+
+- `noted` — files carrying a note (see [Verdicts](#verdicts-and-what-errored-means)).
+  A note never fails the run, so `noted` is independent of `files_failed`.
 
 ## `--changed`: affected-test selection over the import graph
 
@@ -292,6 +337,12 @@ runs stays meaningful at any job count.
 - `tests/scheme/test-runner/seed.sh` — `--seed` reproducibility (same seed →
   same draw, different seed → different draw, seed echoed on every run),
   observed through the JSON.
+- `tests/scheme/test-runner/runner-agreement.sh` — the guarantee that this
+  runner and `tests/scheme/run-all.sh` cannot reach different verdicts
+  (kaappi#1903). Seven fixtures — top-level errors acknowledged and not,
+  `(exit 0)` over a failing assertion, redundant and unexplained nonzero exits,
+  a plain `test-expect-fail`, and a clean control — are each run through *both*
+  verdict rules, which must agree *and* land on the expected verdict.
 - `tests/scheme/test-runner/changed.sh` — `--changed`/`--list-affected` over a
   throwaway git repo with a known dependency shape: diamond import, `include`,
   a `(load …)` escape hatch, native-artifact and unknown-revision full-run

--- a/src/main.zig
+++ b/src/main.zig
@@ -860,12 +860,12 @@ fn runWorkerFile(vm: *vm_mod.VM, fp: []const u8, emit_path: []const u8) !void {
     };
     const duration_ms = @as(f64, @floatFromInt(@import("vm_calls.zig").clockNs() -| start_ns)) / 1_000_000.0;
 
-    // A file-level error is an *uncaught* read/compile/runtime error at top
-    // level — SRFI-64 catches test failures internally, so those never set
-    // this. A test file's `(exit 1)` failure epilogue is deliberately NOT an
-    // error: it is redundant with the fail counts we already collected.
-    const errored = script_had_error;
-    test_runner.emitResult(vm, emit_path, fp, errored, null, duration_ms);
+    // `script_had_error` means an *uncaught* read/compile/runtime error at top
+    // level — SRFI-64 catches test failures internally, so those never set it.
+    // Whether that makes the file errored is `test_runner.resolveVerdict`'s
+    // call, not ours: `suppress_exit` above swallowed any `(exit)` the file
+    // made, and that call's semantics still have to be applied (kaappi#1903).
+    test_runner.emitResult(vm, emit_path, fp, script_had_error, null, duration_ms);
     // The result is emitted; don't let the file's error propagate to a nonzero
     // worker exit — the orchestrator uses the JSON.
     script_had_error = false;

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -149,15 +149,57 @@ pub fn installCollector(vm: *VM) !void {
     }
 }
 
+/// The file-level verdict, resolved from everything the worker observed about
+/// how the file terminated.
+///
+/// The worker suppresses `(exit)` so it can still reach its result-emission
+/// step, which means the *semantics* of that call have to be reapplied here.
+/// Left unapplied, a file whose exit status a plain run would honour gets a
+/// different verdict under `kaappi test` than under `tests/scheme/run-all.sh`,
+/// which reads exactly that status (kaappi#1903). The rule a plain run follows
+/// is pinned by `tests/scheme/errors/exit-code.sh`: an explicit `(exit N)`
+/// always wins over an already-reported top-level error.
+///
+/// The one place this runner deliberately does *not* follow the exit status is
+/// a nonzero exit the SRFI-64 counters already explain — an ordinary failure
+/// epilogue. Reporting that as a file error would replace the failure detail
+/// with a bare ERROR line and double-count it in the summary.
+const Verdict = struct {
+    errored: bool,
+    /// Set when something happened that the counts alone do not show, so it
+    /// still reaches the report instead of vanishing with the verdict.
+    note: ?[]const u8 = null,
+};
+
+/// Resolve the verdict. `counters_failed` is the same predicate the
+/// orchestrator uses to fail a file (`fail > 0 or xpass > 0`), so the two can
+/// never disagree about what "the counters already explain this" means.
+fn resolveVerdict(toplevel_error: bool, exit_requested: bool, exit_code: u8, counters_failed: bool) Verdict {
+    if (!exit_requested) return .{ .errored = toplevel_error };
+    if (exit_code == 0) return .{
+        .errored = false,
+        .note = if (toplevel_error)
+            "uncaught top-level error, acknowledged by an explicit (exit 0)"
+        else
+            null,
+    };
+    if (counters_failed) return .{ .errored = false };
+    return .{
+        .errored = true,
+        .note = "file requested a nonzero exit with no failing test to explain it",
+    };
+}
+
 /// Write the file's one JSON result object to `emit_path`. Called after the
-/// test file has run (whether it completed, errored, or asked to exit). `errored`
-/// records a file-level failure — an uncaught top-level error or a nonzero
-/// `(exit)` — distinct from ordinary test failures, which live in the counts.
-pub fn emitResult(vm: *VM, emit_path: []const u8, file_path: []const u8, errored: bool, err_msg: ?[]const u8, duration_ms: f64) void {
+/// test file has run (whether it completed, errored, or asked to exit).
+/// `toplevel_error` says an uncaught read/compile/runtime error was reported at
+/// top level; the emitted `error` flag is `resolveVerdict`'s answer, which also
+/// weighs the file's own suppressed `(exit)` request and its SRFI-64 counts.
+pub fn emitResult(vm: *VM, emit_path: []const u8, file_path: []const u8, toplevel_error: bool, err_msg: ?[]const u8, duration_ms: f64) void {
     const allocator = vm.gc.allocator;
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
-    buildFileJson(&aw.writer, vm, file_path, errored, err_msg, duration_ms) catch {
+    buildFileJson(&aw.writer, vm, file_path, toplevel_error, err_msg, duration_ms) catch {
         // Fall back to a minimal, always-valid error object so the orchestrator
         // never has to treat a write we attempted as a missing result.
         writeFile(emit_path, "{\"type\":\"file\",\"error\":true,\"error_message\":\"result serialization failed\"}\n");
@@ -167,7 +209,7 @@ pub fn emitResult(vm: *VM, emit_path: []const u8, file_path: []const u8, errored
 }
 
 /// Serialize one `{"type":"file", ...}` object from the `%kt-collect` vector.
-fn buildFileJson(w: *std.Io.Writer, vm: *VM, file_path: []const u8, errored: bool, err_msg: ?[]const u8, duration_ms: f64) !void {
+fn buildFileJson(w: *std.Io.Writer, vm: *VM, file_path: []const u8, toplevel_error: bool, err_msg: ?[]const u8, duration_ms: f64) !void {
     var collected: Value = vm.eval("(%kt-collect)") catch types.FALSE;
     vm.gc.pushRoot(&collected);
     defer vm.gc.popRoot();
@@ -194,6 +236,13 @@ fn buildFileJson(w: *std.Io.Writer, vm: *VM, file_path: []const u8, errored: boo
     }
     const tests = pass + fail + xpass + xfail + skip;
 
+    const verdict = resolveVerdict(
+        toplevel_error,
+        vm.exit_requested,
+        vm.exit_code,
+        fail > 0 or xpass > 0,
+    );
+
     try w.writeAll("{\"type\":\"file\",\"file\":");
     try lsp_diagnostic.writeJsonString(w, file_path);
     try w.writeAll(",\"suite\":");
@@ -203,9 +252,12 @@ fn buildFileJson(w: *std.Io.Writer, vm: *VM, file_path: []const u8, errored: boo
         .{ tests, pass, fail, xpass, xfail, skip },
     );
     try w.writeAll(",\"error\":");
-    try w.writeAll(if (errored) "true" else "false");
+    try w.writeAll(if (verdict.errored) "true" else "false");
+    // A caller-supplied message (only the collector-setup failure has one) wins;
+    // otherwise the verdict's note travels here, so an acknowledged top-level
+    // error is still visible on a file this runner now reports as passing.
     try w.writeAll(",\"error_message\":");
-    if (err_msg) |m| try lsp_diagnostic.writeJsonString(w, m) else try w.writeAll("null");
+    if (err_msg orelse verdict.note) |m| try lsp_diagnostic.writeJsonString(w, m) else try w.writeAll("null");
     try w.print(",\"duration_ms\":{d:.3},\"failures\":[", .{duration_ms});
 
     var first = true;
@@ -305,6 +357,9 @@ const Totals = struct {
     files: u64 = 0,
     files_failed: u64 = 0,
     errors: u64 = 0,
+    /// Files that carried a `Verdict.note` — something worth seeing that the
+    /// counts alone do not show, and that does not by itself fail the run.
+    noted: u64 = 0,
     pass: u64 = 0,
     fail: u64 = 0,
     xpass: u64 = 0,
@@ -840,6 +895,7 @@ fn accumulateAndReport(allocator: std.mem.Allocator, file: []const u8, result_js
     totals.skip += r.skip;
     const errored = r.@"error" or spawn.signaled;
     if (errored) totals.errors += 1;
+    if (!errored and r.error_message != null) totals.noted += 1;
     const failed = errored or r.fail > 0 or r.xpass > 0;
     if (failed) totals.files_failed += 1;
 
@@ -876,6 +932,15 @@ fn reportFileText(file: []const u8, r: FileResultJson, errored: bool, spawn: Spa
     } else {
         const line = std.fmt.bufPrint(&buf, "  PASS  {s}  ({d} tests, {d} skipped, {d:.0}ms)\n", .{ file, r.tests, r.skip, r.duration_ms }) catch "  PASS\n";
         writeStdout(line);
+    }
+    // A note rides along with a non-errored verdict (an acknowledged top-level
+    // error, say). Print it plus whatever the worker wrote, so the fact the
+    // verdict deliberately tolerates is still on the transcript.
+    if (r.error_message) |m| {
+        writeStdout("        note: ");
+        writeStdout(m);
+        writeStdout("\n");
+        printCapturedOutput(spawn.output);
     }
 }
 
@@ -993,8 +1058,8 @@ fn emitSummary(allocator: std.mem.Allocator, json: bool, t: *Totals, seed: u64, 
         const w = &aw.writer;
         (blk: {
             w.print(
-                "{{\"type\":\"summary\",\"files\":{d},\"files_failed\":{d},\"errors\":{d},\"tests\":{d},\"pass\":{d},\"fail\":{d},\"xpass\":{d},\"xfail\":{d},\"skip\":{d},\"seed\":{d},\"duration_ms\":{d:.3}}}\n",
-                .{ t.files, t.files_failed, t.errors, t.pass + t.fail + t.xpass + t.xfail + t.skip, t.pass, t.fail, t.xpass, t.xfail, t.skip, seed, total_ms },
+                "{{\"type\":\"summary\",\"files\":{d},\"files_failed\":{d},\"errors\":{d},\"noted\":{d},\"tests\":{d},\"pass\":{d},\"fail\":{d},\"xpass\":{d},\"xfail\":{d},\"skip\":{d},\"seed\":{d},\"duration_ms\":{d:.3}}}\n",
+                .{ t.files, t.files_failed, t.errors, t.noted, t.pass + t.fail + t.xpass + t.xfail + t.skip, t.pass, t.fail, t.xpass, t.xfail, t.skip, seed, total_ms },
             ) catch break :blk error.W;
             break :blk {};
         }) catch return;
@@ -1002,11 +1067,14 @@ fn emitSummary(allocator: std.mem.Allocator, json: bool, t: *Totals, seed: u64, 
         return;
     }
 
+    // Both lines are labelled by what they count. They used to read "Summary:"
+    // and "Files:", so `0 failed` (tests) sat directly above `1 failed` (files)
+    // with nothing saying the two words had different subjects (kaappi#1903).
     var buf: [512]u8 = undefined;
     writeStdout("\n");
-    const s1 = std.fmt.bufPrint(&buf, "Summary: {d} passed, {d} failed, {d} unexpected-pass, {d} expected-fail, {d} skipped\n", .{ t.pass, t.fail, t.xpass, t.xfail, t.skip }) catch "";
+    const s1 = std.fmt.bufPrint(&buf, "Tests:   {d} passed, {d} failed, {d} unexpected-pass, {d} expected-fail, {d} skipped\n", .{ t.pass, t.fail, t.xpass, t.xfail, t.skip }) catch "";
     writeStdout(s1);
-    const s2 = std.fmt.bufPrint(&buf, "Files:   {d} run, {d} failed, {d} errored ({d:.0}ms)\n", .{ t.files, t.files_failed, t.errors, total_ms }) catch "";
+    const s2 = std.fmt.bufPrint(&buf, "Files:   {d} run, {d} failed, {d} errored, {d} noted ({d:.0}ms)\n", .{ t.files, t.files_failed, t.errors, t.noted, total_ms }) catch "";
     writeStdout(s2);
     const s3 = std.fmt.bufPrint(&buf, "Seed:    {d}  (reproduce with: kaappi test --seed {d})\n", .{ seed, seed }) catch "";
     writeStdout(s3);
@@ -1262,6 +1330,51 @@ test "writeFileObject round-trips through the JSON parser" {
     try testing.expectEqualStrings("t.scm", parsed.value.file);
     try testing.expectEqual(@as(u64, 1), parsed.value.fail);
     try testing.expectEqualStrings("2", parsed.value.failures[0].actual.?);
+}
+
+// kaappi#1903. The worker suppresses `(exit)`, so this is where that call's
+// semantics get reapplied — and where `kaappi test` either agrees with the exit
+// status `tests/scheme/run-all.sh` reads, or does not. Every row below is a
+// verdict `run-all.sh` would reach from the process status alone.
+test "resolveVerdict: no explicit exit — a top-level error is the whole story" {
+    // run-all.sh: kaappi exits `script_had_error ? 1 : 0`, so PASS / FAIL.
+    try testing.expect(!resolveVerdict(false, false, 0, false).errored);
+    try testing.expect(resolveVerdict(true, false, 0, false).errored);
+    // Failing counts alone are a FAIL, not an ERROR — the counts carry it.
+    try testing.expect(!resolveVerdict(false, false, 0, true).errored);
+}
+
+test "resolveVerdict: an explicit (exit 0) acknowledges a top-level error" {
+    // The rule tests/scheme/errors/exit-code.sh pins for a plain run:
+    // "explicit (exit 0) after error exits 0". run-all.sh therefore says PASS,
+    // and so must this — but the fact does not get to vanish, hence the note.
+    const v = resolveVerdict(true, true, 0, false);
+    try testing.expect(!v.errored);
+    try testing.expect(v.note != null);
+    // Nothing to acknowledge, nothing to say.
+    try testing.expect(resolveVerdict(false, true, 0, false).note == null);
+}
+
+test "resolveVerdict: (exit 0) cannot bury a failing test" {
+    // A file may waive its own top-level error; it may not waive an assertion.
+    // The counts stay authoritative, so the orchestrator still fails the file.
+    const v = resolveVerdict(true, true, 0, true);
+    try testing.expect(!v.errored);
+}
+
+test "resolveVerdict: a nonzero exit the counts explain is redundant" {
+    // The ordinary SRFI-64 failure epilogue. Calling this an error would trade
+    // the per-assertion detail for a bare ERROR line and double-count the file.
+    try testing.expect(!resolveVerdict(false, true, 1, true).errored);
+    try testing.expect(!resolveVerdict(true, true, 1, true).errored);
+}
+
+test "resolveVerdict: a nonzero exit the counts do not explain is an error" {
+    // run-all.sh sees exit 1 and says FAIL. With no failing count to carry it,
+    // this is the only place the file's own verdict can survive.
+    const v = resolveVerdict(false, true, 1, false);
+    try testing.expect(v.errored);
+    try testing.expect(v.note != null);
 }
 
 test "writeFileObject uses the error-message override only when none is present" {

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -55,6 +55,15 @@ directly in a suite directory, or wire the subdirectory up explicitly.
    resets the current runner, so `(test-runner-current)` afterwards no
    longer returns the runner and `test-runner-fail-count` raises a type
    error.
+
+   A file that deliberately provokes an **uncaught top-level error** — one
+   no `guard` can reach, e.g. a known engine limitation at a macro-definition
+   site — must also `(exit 0)` on the clean path, or the process's own exit
+   status makes the suite look failed. Both runners honour that waiver and
+   `kaappi test` prints it as a `note` rather than swallowing it, so the
+   error stays on the transcript (kaappi#1903,
+   `tests/scheme/test-runner/runner-agreement.sh`). The waiver covers only
+   the file's own top-level error: a failing assertion still fails the file.
 4. No registration needed — `run-all.sh` picks up `*.scm` files automatically.
 5. For bug regressions, name the file after the bug and add a comment:
 

--- a/tests/scheme/test-runner/runner-agreement.sh
+++ b/tests/scheme/test-runner/runner-agreement.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# kaappi#1903 — `kaappi test` and tests/scheme/run-all.sh must reach the SAME
+# verdict for a file.
+#
+# They read different signals. run-all.sh runs `kaappi <file>` and reads the
+# process exit status (plus a grep over the printed counts, for a suite that
+# forgets its epilogue). `kaappi test` runs the same file in a worker with
+# `vm.suppress_exit` set, so the file's `(exit)` never happens, and derives its
+# verdict from the SRFI-64 counters plus whether an uncaught top-level error was
+# reported. Anywhere those two disagree, a suite is green in one runner and red
+# in the other and nobody can say which is right.
+#
+# The shape that first exposed it was `tests/scheme/srfi/srfi150.scm`: a
+# deliberate top-level error, four `test-expect-fail` annotations, and an
+# `(exit 0)` epilogue. run-all.sh reported it green; `kaappi test` reported
+# exit 1 with `1 errored`. This file reconstructs that shape directly — plus
+# every neighbouring case — so the guarantee outlives SRFI 150's own defects
+# (kaappi#2051), which will one day stop producing the top-level error at all.
+#
+# Each fixture is run BOTH ways and the two verdicts are required to match.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+KAAPPI="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+PASS=0
+FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export KAAPPI_HOME="$WORK/home"
+mkdir -p "$KAAPPI_HOME"
+# Run from the temp dir: the `kaappi test` worker installs test-runner-null and
+# writes no log, but `verdict_run_all` runs a *plain* `kaappi <file>`, whose
+# SRFI-64 runner drops a `<suite>.log` in the cwd. Keep those out of the repo.
+cd "$WORK"
+
+# --- the two runners' verdict rules -----------------------------------------
+
+# run-all.sh's rule, copied from run_file_worker(): exit status first, then a
+# grep over the output for a suite that reported failures but exited 0 anyway.
+verdict_run_all() {
+    local file="$1" status=0
+    "$KAAPPI" "$file" > "$WORK/out.txt" 2>&1 || status=$?
+    if [[ $status -ne 0 ]]; then
+        echo "FAIL"
+    elif grep -Eq '(^|[^0-9])[1-9][0-9]* fail|unexpected (failures|errors) +[1-9]' "$WORK/out.txt"; then
+        echo "FAIL"
+    else
+        echo "PASS"
+    fi
+}
+
+# `kaappi test`'s rule, read off its own exit status — nonzero iff a test
+# failed, unexpectedly passed, or a file errored.
+verdict_kaappi_test() {
+    local file="$1" status=0
+    "$KAAPPI" test "$file" > "$WORK/kt.txt" 2>&1 || status=$?
+    if [[ $status -ne 0 ]]; then echo "FAIL"; else echo "PASS"; fi
+}
+
+# --- the assertion ----------------------------------------------------------
+
+# Both runners must agree, and both must reach `expected`. Requiring only
+# agreement would be satisfied by two runners that are wrong together.
+assert_agree() {
+    local label="$1" file="$2" expected="$3"
+    local a b
+    a=$(verdict_run_all "$file")
+    b=$(verdict_kaappi_test "$file")
+    if [[ "$a" == "$b" && "$a" == "$expected" ]]; then
+        echo "PASS: $label ($expected in both runners)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — run-all.sh=$a kaappi-test=$b, expected $expected in both"
+        sed 's/^/      | /' "$WORK/kt.txt"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Assert a substring is present in the last `kaappi test` transcript. Uses a
+# here-string, never a pipe into grep -q (see tests/scheme/CLAUDE.md).
+assert_kt_mentions() {
+    local label="$1" needle="$2"
+    local body
+    body=$(cat "$WORK/kt.txt")
+    if grep -qF "$needle" <<< "$body"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — transcript does not mention '$needle'"
+        sed 's/^/      | /' "$WORK/kt.txt"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+# The srfi150.scm shape, reduced to its essentials: a top-level raise that no
+# `guard` can reach, an expected-fail assertion that depends on it, and an
+# epilogue that exits 0 because the SRFI-64 counters are clean.
+cat > ack.scm <<'EOF'
+(import (scheme base) (scheme process-context) (srfi 64))
+(test-begin "ack")
+(test-equal "an ordinary passing assertion" 1 1)
+(error "deliberate uncaught top-level error")
+(test-expect-fail "depends on the form that errored")
+(test-assert "depends on the form that errored" never-defined-by-the-errored-form)
+(let ((runner (test-runner-current)))
+  (test-end "ack")
+  (if (> (test-runner-fail-count runner) 0) (exit 1) (exit 0)))
+EOF
+
+# The same top-level error with no epilogue at all: nothing acknowledges it, so
+# `kaappi <file>` exits 1 and both runners must call it a failure.
+cat > unack.scm <<'EOF'
+(import (scheme base) (srfi 64))
+(test-begin "unack")
+(test-equal "an ordinary passing assertion" 1 1)
+(error "deliberate uncaught top-level error")
+(test-end "unack")
+EOF
+
+# A top-level error acknowledged by (exit 0) *and* a genuinely failing
+# assertion. The waiver covers the file's own error; it must not cover the
+# assertion, or a suite could declare itself green by fiat.
+cat > ack-but-failing.scm <<'EOF'
+(import (scheme base) (scheme process-context) (srfi 64))
+(test-begin "ack-but-failing")
+(error "deliberate uncaught top-level error")
+(test-equal "a genuinely failing assertion" 1 2)
+(test-end "ack-but-failing")
+(exit 0)
+EOF
+
+# The ordinary SRFI-64 failure epilogue: a failing assertion plus (exit 1).
+# The nonzero exit is redundant with the counts, so `kaappi test` must report
+# it as a FAIL carrying the assertion detail, not as an opaque file error.
+cat > failing-epilogue.scm <<'EOF'
+(import (scheme base) (scheme process-context) (srfi 64))
+(test-begin "failing-epilogue")
+(test-equal "a genuinely failing assertion" 1 2)
+(let ((runner (test-runner-current)))
+  (test-end "failing-epilogue")
+  (if (> (test-runner-fail-count runner) 0) (exit 1) (exit 0)))
+EOF
+
+# A nonzero exit with nothing in the counts to explain it. run-all.sh sees
+# exit 1; `kaappi test` has no failing assertion to report, so the file's own
+# verdict is the only signal there is and it must not be discarded.
+cat > bare-nonzero-exit.scm <<'EOF'
+(import (scheme base) (scheme process-context) (srfi 64))
+(test-begin "bare-nonzero-exit")
+(test-equal "an ordinary passing assertion" 1 1)
+(test-end "bare-nonzero-exit")
+(exit 1)
+EOF
+
+# `test-expect-fail` on its own — a wrong *value*, not a raise. This is the
+# case the annotation is actually for, and it must stay green in both runners.
+cat > expect-fail-only.scm <<'EOF'
+(import (scheme base) (srfi 64))
+(test-begin "expect-fail-only")
+(test-expect-fail "a known wrong answer")
+(test-equal "a known wrong answer" 1 2)
+(test-equal "an ordinary passing assertion" 1 1)
+(test-end "expect-fail-only")
+EOF
+
+# A wholly ordinary green suite — the control that keeps the matrix honest.
+cat > clean.scm <<'EOF'
+(import (scheme base) (srfi 64))
+(test-begin "clean")
+(test-equal "an ordinary passing assertion" 1 1)
+(test-end "clean")
+EOF
+
+# --- the matrix -------------------------------------------------------------
+
+assert_agree "top-level error acknowledged by (exit 0)" ack.scm PASS
+assert_kt_mentions "the acknowledged error is still on the transcript" \
+    "acknowledged by an explicit (exit 0)"
+assert_kt_mentions "the acknowledged error keeps its own diagnostic" \
+    "deliberate uncaught top-level error"
+
+assert_agree "top-level error with no epilogue to acknowledge it" unack.scm FAIL
+assert_agree "(exit 0) does not bury a failing assertion" ack-but-failing.scm FAIL
+assert_agree "ordinary failing suite with an (exit 1) epilogue" failing-epilogue.scm FAIL
+assert_kt_mentions "a redundant (exit 1) keeps the assertion detail" \
+    "a genuinely failing assertion"
+
+assert_agree "nonzero exit with nothing in the counts to explain it" bare-nonzero-exit.scm FAIL
+assert_agree "test-expect-fail on a wrong value, not a raise" expect-fail-only.scm PASS
+assert_agree "an ordinary green suite" clean.scm PASS
+
+echo ""
+echo "runner-agreement: $PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #1903.

`kaappi test` and `tests/scheme/run-all.sh` reported different verdicts for the
same file. On `tests/scheme/srfi/srfi150.scm`, `run-all.sh` said green and
`kaappi test` said exit 1 with a summary that read as self-contradictory:

```text
Summary: 21 passed, 0 failed, 0 unexpected-pass, 4 expected-fail, 0 skipped
Files:   1 run, 1 failed, 1 errored (98ms)
```

Every unit of the audit campaign has been reporting this as noise, and it is
what blocks `kaappi test` from replacing the legacy runner.

## The mechanism (verified)

Not `test-expect-fail`, despite where the finding pointed. The annotations are
incidental — they only decide whether the orphaned assertions land in `xfail`
rather than `fail`. The divergence is entirely about **the file's own exit
status**:

1. `srfi150.scm:164` raises an uncaught top-level error (`KP3000`). `runFile`
   reports it, sets `script_had_error`, and continues to the next form.
2. A plain `kaappi <file>` would then exit 1 — except the file's epilogue calls
   `(exit 0)` on the SRFI-64-clean path, deliberately, with a comment saying so.
   `run-all.sh` reads the process status, sees 0, and reports **PASS**.
3. The `kaappi test` worker sets `vm.suppress_exit`, so the `(exit 0)` never
   happens — it is only *recorded* in `vm.exit_requested`/`vm.exit_code`.
   `runWorkerFile` then reported `script_had_error` directly as `error: true`,
   never consulting what the suppressed call asked for. **ERROR**, exit 1.

## Which runner was right: `run-all.sh`

`tests/scheme/errors/exit-code.sh` already pins the rule a plain run follows,
with its own regression test and an explicit comment:

```bash
# Explicit (exit 0) wins over earlier uncaught error (R7RS: exit sets the code)
assert_exit_code "explicit (exit 0) after error exits 0" 0 "$KAAPPI" ".../exit0.scm"
```

`run-all.sh` matches that contract. `kaappi test` did not — and not by design:
`emitResult`'s own doc comment already claimed `errored` covered "an uncaught
top-level error **or a nonzero `(exit)`**", which the implementation never did.
Suppressing the *termination* was never meant to also discard the *status*.

## What changed — in the runner, not the file

`src/test_runner.zig` grows `resolveVerdict`, one place that weighs all three
facts. `srfi150.scm` is untouched.

| The file… | `error` | Why |
|---|---|---|
| ran clean | `false` | — |
| top-level error, no `(exit)` | **`true`** | a plain run exits 1 |
| top-level error, then `(exit 0)` | `false` + **note** | the file waived it; a plain run exits 0 |
| `(exit N≠0)` with a failing count | `false` | redundant — the counts carry it |
| `(exit N≠0)` with nothing failing | **`true`** + **note** | otherwise the file's own verdict is lost |

An `(exit 0)` waives only the file's *own* top-level error. It can never bury a
failing assertion — the counters stay authoritative.

The last row is the **opposite-direction divergence**, which nobody had noticed:
before this change, a suite that exited nonzero with clean SRFI-64 counters was
`FAIL` under `run-all.sh` and silently `PASS` under `kaappi test`. The mutation
test below kills it.

**Nothing goes quiet.** A waived error becomes a *note* — it travels in
`error_message` with `"error": false`, prints under the file's `PASS`/`FAIL`
line together with whatever the worker wrote, and is tallied as `noted` in the
summary and in the summary JSON:

```text
  PASS  tests/scheme/srfi/srfi150.scm  (25 tests, 0 skipped, 19ms)
        note: uncaught top-level error, acknowledged by an explicit (exit 0)
        | tests/scheme/srfi/srfi150.scm:164: error[KP3000]: record-accessor: unknown field name a
        |     (def a make-record get-a get-b)

Tests:   21 passed, 0 failed, 0 unexpected-pass, 4 expected-fail, 0 skipped
Files:   1 run, 0 failed, 0 errored, 1 noted (53ms)
```

The summary's first line is relabelled `Tests:` — it counts tests, while `Files:`
counts files, and `0 failed` sitting directly above `1 failed` with nothing
naming the difference in subject is the incoherence the issue called out.

## Evidence: per-file agreement over the whole corpus

Both runners' verdict rules, applied to all 352 SRFI-64 files, sequentially so
the comparison is not perturbed by scheduling:

| | disagreements | `kaappi test` |
|---|---:|---|
| before | **1** — `tests/scheme/srfi/srfi150.scm` (`ERROR` vs `PASS`) | 352 files, 1 failed, 1 errored |
| after | **0** | 352 files, 0 failed, 0 errored, 1 noted |

`srfi150.scm` is the only file repo-wide in this state — the `noted` count is
the sweep, and it is 1.

## Tests

- **`tests/scheme/test-runner/runner-agreement.sh`** (new, 10 assertions). Seven
  fixtures, each run through *both* verdict rules, which must agree **and** land
  on the expected verdict — agreement alone would be satisfied by two runners
  that are wrong together. The first fixture reconstructs srfi150's shape
  directly (top-level raise + `test-expect-fail` + `(exit 0)`), so the guarantee
  survives #2051 fixing SRFI 150 and the file ceasing to exercise it.
- **5 unit tests** over `resolveVerdict`, one per row of the table above.
- **Mutation-tested.** Reverting `resolveVerdict` to the old
  `errored = script_had_error` kills 3 of the 10 shell assertions, and does so in
  *both* directions:

  ```text
  FAIL: top-level error acknowledged by (exit 0) — run-all.sh=PASS kaappi-test=FAIL
  FAIL: nonzero exit with nothing in the counts to explain it — run-all.sh=FAIL kaappi-test=PASS
  ```

`json.sh`, `seed.sh`, `changed.sh` and `jobs.sh` all still pass unchanged.

## Also

`docs/dev/test-runner.md` gains a *Verdicts* section (the table, why the exit
status matters at all given this runner exists to stop scraping, and what a note
is), documents `noted` and the `error_message`-with-`error:false` case, and
corrects the `suppress_exit` description.

Filed separately while diffing per-file verdicts: #2077 —
`primitives_filesystem-audit.scm` pins an exact `atime`, which any reader of the
file can change, and flakes ~2 in 9 parallel corpus runs. Ruled out as a
`--jobs` bug and as a `set-file-times` bug by three controls; unrelated to this
change.

**Found by:** Systematic audit v2, Phase 6B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
