### PR TITLE
Require a priority label on every issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1258,6 +1258,44 @@ every release, across `ubuntu-latest`, `ubuntu-24.04-arm`, and `macos-latest`.
 Adding a platform means teaching its `detect_platform` the `uname` spelling
 and its `rt_artifact` case — `docs/dev/porting.md` Stage 6.
 
+## Issue tracker
+
+**Every issue you file or triage gets exactly one `priority:` label** —
+`critical`, `high`, `medium`, or `low`. Set it when filing; an issue that
+arrives without one is not triaged. `docs/dev/github-issues.md` is the full
+rubric (the four label axes, worked boundary cases, the triage commands);
+this is the part you need at filing time:
+
+| Level | The question it answers |
+|-------|------------------------|
+| critical | Does this compromise the process — memory unsafety, or an abort reachable from an ordinary program? |
+| high | Does a legal program get a silently wrong answer, hang, or lose data in a path users actually reach? |
+| medium | Is behaviour wrong against a spec or a documented guarantee, but loud, narrow, or recoverable? |
+| low | Is the behaviour right and only its *description* or *diagnostic* wrong? |
+
+Four rules decide the hard cases:
+
+- **`critical` is process-level unsafety only.** A correctness bug tops out
+  at `high` however broad or silent. All 13 issues ever marked critical are
+  memory unsafety or a process abort.
+- **Reachability separates critical from high.** An abort needing a stress
+  harness is `high`; one reachable from a five-line program is `critical`.
+- **An audit header's `Severity:` is an input, not the answer.**
+  `wrong-result` spans `high` to `medium` purely on blast radius.
+- **Silence is an aggravator, not a level.** A loud failure is safer than a
+  quiet one, so silence moves an issue up *within* its level.
+
+Auto-filed `fuzz-finding` CI reports are the one exemption — they are
+triage-and-close, and carry no priority. To find what still needs a label:
+
+```bash
+gh issue list --repo kaappi/kaappi --state open --limit 400 \
+  --json number,title,labels \
+  --jq '.[] | select([.labels[].name] | any(startswith("priority:")) | not)
+            | select([.labels[].name] | index("fuzz-finding") | not)
+        | "\(.number)\t\(.title)"'
+```
+
 ## Package manager (thottam)
 
 `src/thottam.zig` is a Zig binary that installs Kaappi ecosystem libraries.
@@ -1489,6 +1527,7 @@ workspace-level `.claude/settings.json` when working from the multi-repo workspa
 | Compiler form checklist | Path-scoped rule (auto-loaded) | `.claude/rules/compiler-forms.md` |
 | Bug fixes need tests | Advisory only | This file (Tests section) |
 | Files ≤ 1500 lines | Advisory only | This file (File size policy) |
+| One `priority:` label per issue | Advisory only | This file (Issue tracker), `docs/dev/github-issues.md` |
 | Commit message format | Advisory only | Parent CLAUDE.md (Conventions) |
 
 ## Known limitations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1286,12 +1286,15 @@ Four rules decide the hard cases:
   quiet one, so silence moves an issue up *within* its level.
 
 Auto-filed `fuzz-finding` CI reports are the one exemption — they are
-triage-and-close, and carry no priority. To find what still needs a label:
+triage-and-close, and carry no priority. To find every issue that violates
+the rule — none *or* more than one, since "exactly one" has two failure
+modes:
 
 ```bash
 gh issue list --repo kaappi/kaappi --state open --limit 400 \
   --json number,title,labels \
-  --jq '.[] | select([.labels[].name] | any(startswith("priority:")) | not)
+  --jq '.[] | ([.labels[].name | select(startswith("priority:"))] | length) as $n
+            | select($n != 1)
             | select([.labels[].name] | index("fuzz-finding") | not)
         | "\(.number)\t\(.title)"'
 ```

--- a/docs/dev/github-issues.md
+++ b/docs/dev/github-issues.md
@@ -194,12 +194,16 @@ It needs re-checking after any filing burst. An `audit` phase lands its
 findings all at once, so the gap opens between one triage pass and the next
 rather than drifting gradually.
 
-Find open issues missing a priority:
+Find every issue that violates the rule. "Exactly one" has two failure modes,
+so this counts the priority labels and reports anything that is not 1 — a
+missing label and a double label are equally worth knowing about, and only the
+first is the common case:
 
 ```bash
 gh issue list --repo kaappi/kaappi --state open --limit 400 \
   --json number,title,labels \
-  --jq '.[] | select([.labels[].name] | any(startswith("priority:")) | not)
+  --jq '.[] | ([.labels[].name | select(startswith("priority:"))] | length) as $n
+            | select($n != 1)
             | select([.labels[].name] | index("fuzz-finding") | not)
         | "\(.number)\t\(.title)"'
 ```


### PR DESCRIPTION
## Summary

Adds an **Issue tracker** section to `CLAUDE.md` and a row to its enforcement map. Follow-up to #2032 and #2041, which documented the priority rubric in `docs/dev/github-issues.md` but left nothing telling a filer to apply it.

The evidence that a document alone is not enough: **41 issues were filed without a priority label while those two PRs were open**, arriving in bursts of 6–27 as each audit phase completed. Triaging after the fact means re-reading every issue body to recover a judgement the filer had already made and discarded.

All of them are now labeled. Every open issue carries exactly one priority label, modulo the `fuzz-finding` exemption.

## What the rule says

The decision table, at filing time rather than a link away:

| Level | The question it answers |
|-------|------------------------|
| critical | Does this compromise the process — memory unsafety, or an abort reachable from an ordinary program? |
| high | Does a legal program get a silently wrong answer, hang, or lose data in a path users actually reach? |
| medium | Is behaviour wrong against a spec or a documented guarantee, but loud, narrow, or recoverable? |
| low | Is the behaviour right and only its *description* or *diagnostic* wrong? |

Plus the four rules that settle the hard cases — `critical` is process-level unsafety only; reachability separates critical from high; an audit header's `Severity:` is an input, not the answer; and silence is an aggravator that moves an issue up *within* a level rather than between levels.

The full rubric, the four label axes, and the worked boundary cases stay in `docs/dev/github-issues.md`. This is the filing-time subset, and it points there.

## Advisory, not gated

Listed as **Advisory only** in the enforcement map, alongside the existing test and file-size rules. A CI gate would have to run against the tracker rather than the diff, and the failure mode is a missing label rather than broken code — not worth a workflow that can only ever fail after the fact.

`AGENTS.md` is a symlink to `CLAUDE.md`, so the rule reaches both without a second copy.

## Checklist

- [x] `zig build test` passes — n/a, no `src/` changes
- [x] `zig fmt --check src/` passes — n/a, no `.zig` files touched
- [x] Scheme test suites pass — n/a, no engine or library changes
- [ ] New tests added for new behavior — n/a, documentation only
- [x] Documentation updated (if applicable) — this PR is the documentation

`npx markdownlint-cli2` is clean, and the `gh` snippet embedded in the section was run verbatim before committing. The CHANGELOG gate does not apply (fires only on `src/` or `lib/srfi/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)