### PR TITLE
Phase 4A: derive isRejectedFormHead — the one missing name was define-property, and it was live on cond/case/do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`define-property` inside a top-level `cond`, `case` or `do` is no longer
+  miscompiled by the native backend** (#1896). `isRejectedFormHead` was a
+  hand-maintained list parallel to the comptime-derived
+  `ir.eval_fallback_form_names`, and was missing that one name — so the form
+  was emitted natively instead of deferring to the interpreter. The effect was
+  observable with `display`: the property expression ran *after* the clause
+  body under `kaappi compile` and *before* it under the interpreter, and a
+  `do` loop containing one failed to compile at all (`KP9001`), since `emitDo`
+  installs loop-variable locals before the eval fallback can run. The gate is
+  now derived from the same comptime set, with six deliberate exclusions each
+  carrying its reason in code, and a comptime block asserts
+  `derived ⊆ rejected ∪ exclusions` so it cannot drift again.
+
 - **On the WebAssembly build, `open-input-file`, `open-output-file` and
   `delete-file` now signal a file error** (#1972). R7RS 6.13 says these signal
   a condition satisfying `file-error?`, which is what they do on every native

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,12 +206,30 @@ maintenance: it walks `llvm_node_table`, then every `FormKind` field (skipping
 it automatically, and a comptime block enforces one `llvm_node_table` entry per
 `NodeTag`.
 
-The silent-miscompilation hazard is real but lives one file over, in
-`isRejectedFormHead` (`llvm_emit_forms.zig`) — a **hand-maintained** 32-name
-array gating `cond`/`case`/`do` through `exprNativeEmittable`, structurally
-independent of the derived set and already missing `define-property`
-(kaappi#1896). Add a keyword there when you add a form, until that list is
-derived too.
+The second gate — `isRejectedFormHead` (`llvm_emit_forms.zig`), which routes
+`cond`/`case`/`do` through `exprNativeEmittable` — **is derived too** as of
+kaappi#1896, and needs no maintenance either. Until then it was a
+hand-maintained 32-name array structurally independent of the derived set, and
+it had drifted by exactly one name: `define-property`. That was not theoretical.
+`define-property` is a *compile-time* form (`compileDefineProperty` evaluates
+its expression while the enclosing form is compiled), so a top-level
+`(cond (#t (display "B") (define-property x k (begin (display "P") 1)) (display "C")))`
+printed `PBC` interpreted and `BPC` compiled — the cond was emitted natively and
+the registration left behind as a run-time `kaappi_eval`. `case` diverged the
+same way; `do` did not compile at all (`KP9001`), because `emitDo` installs
+loop-variable locals before reaching the deferred form and `emitFormEval`
+refuses to eval inside a lexical scope. The lexical-scope path was never at
+risk — `sexprNeedsEvalFallback` consults the *derived* set, so any enclosing
+`let`/`lambda` already declined.
+
+`rejected_form_heads` is now `(eval_fallback_form_names \ derived_exclusions) ∪
+extra_rejected_heads`, with `derived_exclusions` empty and
+`extra_rejected_heads` holding the six names the gate rejects for its own
+reasons (`lambda`, `define`, `unquote`, `unquote-splicing`, `else`, `=>`). A
+comptime block rejects a stale exclusion, a duplicate extra, and any derived
+name that escapes the gate; a deliberately stricter runtime test in
+`tests_native.zig` fails if `derived_exclusions` gains an entry at all, so
+weakening the gate takes two edits, not one quiet line.
 
 **Always use `zig cc` (not `clang`) for linking native binaries against
 `libkaappi_rt.a`.** The Zig-compiled static library references

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -397,24 +397,117 @@ fn isKeyword(v: Value, name: []const u8) bool {
 // scope (they route through eval / passthrough) or deliberately declines to
 // handle here (lambda, => markers). A form containing any of these is sent to
 // the interpreter as a whole.
-fn isRejectedFormHead(name: []const u8) bool {
-    const rejected = [_][]const u8{
-        "lambda",                         "letrec",         "letrec*",
-        "guard",                          "quasiquote",     "delay",
-        "delay-force",                    "parameterize",   "define-values",
-        "let-values",                     "let*-values",    "define-syntax",
-        "let-syntax",                     "letrec-syntax",  "cond-expand",
-        "case-lambda",                    "define",         "define-record-type",
-        "call-with-current-continuation", "call/cc",        "call-with-values",
-        "eval",                           "import",         "include",
-        "include-ci",                     "define-library", "syntax-rules",
-        "syntax-error",                   "unquote",        "unquote-splicing",
-        "else",                           "=>",
-    };
-    for (rejected) |r| {
-        if (std.mem.eql(u8, name, r)) return true;
+//
+// DERIVED from `ir.eval_fallback_form_names`, not hand-maintained (kaappi#1896).
+// Until that issue this was a literal 32-name array structurally independent of
+// the comptime set, and it had drifted: `define-property` was missing, so a
+// top-level `(cond (#t (display "B") (define-property x k (begin (display "P") 1))))`
+// emitted the cond natively and left only the property registration as a
+// run-time `kaappi_eval` — moving a COMPILE-time effect after the rest of the
+// clause body (interpreter `PBC`, native `BPC`), and in a `do` failing emission
+// outright with KP9001 because `emitDo` installs loop-variable locals before the
+// deferred form is reached and `emitFormEval` refuses to eval inside a lexical
+// scope. Deriving makes a future `FormKind` join this gate automatically.
+//
+// Two explicit lists carry what the derivation cannot know; the comptime block
+// below keeps both honest.
+//
+// Heads rejected for this gate's OWN reasons, and therefore absent from the
+// derived set by design:
+const extra_rejected_heads = [_][]const u8{
+    // Lowered natively elsewhere, but not in an arbitrary sub-expression
+    // position inside a cond/case/do. Rejecting `lambda` also sidesteps `do`'s
+    // fresh-binding-per-iteration semantics (see this file's header): with no
+    // closure able to capture a loop variable, the mutable allocas `emitDo`
+    // updates in place are observably equivalent. Rejecting `define` keeps
+    // `emitDo`'s cleared `scope_define_names` from being load-bearing (#1854).
+    "lambda",
+    "define",
+    // Syntax-position markers, not expression heads: they are only meaningful
+    // inside an enclosing form (`unquote`/`unquote-splicing` inside
+    // `quasiquote`, which is itself derived-and-rejected; `else`/`=>` as
+    // cond/case clause markers, which the clause walkers handle before ever
+    // consulting this gate). All four must stay OUT of the derived set —
+    // `sexprNeedsEvalFallback` recurses blindly into clause bodies, so listing
+    // `else`/`=>` there would reject every natively-lowered cond/case that has
+    // an else clause (#1496; asserted in tests_native.zig).
+    "unquote",
+    "unquote-splicing",
+    "else",
+    "=>",
+};
+
+// Derived names this gate deliberately does NOT reject. Empty today: every
+// eval-fallback form is also un-emittable here. An entry needs a written
+// reason, and the comptime block rejects one that has gone stale.
+const derived_exclusions = [_][]const u8{};
+
+fn nameListHas(list: []const []const u8, name: []const u8) bool {
+    for (list) |n| {
+        if (std.mem.eql(u8, n, name)) return true;
     }
     return false;
+}
+
+// Counted rather than `derived.len - exclusions.len + extras.len` so that a
+// derived_exclusions entry naming a form that does not exist produces only the
+// comptime block's own diagnostic below, not a confusing bounds error first.
+fn rejectedHeadCount() usize {
+    @setEvalBranchQuota(20_000);
+    var n: usize = extra_rejected_heads.len;
+    for (ir.eval_fallback_form_names) |name| {
+        if (!nameListHas(&derived_exclusions, name)) n += 1;
+    }
+    return n;
+}
+
+pub const rejected_form_heads: [rejectedHeadCount()][]const u8 = blk: {
+    @setEvalBranchQuota(20_000);
+    var out: [rejectedHeadCount()][]const u8 = undefined;
+    var i: usize = 0;
+    for (ir.eval_fallback_form_names) |name| {
+        if (nameListHas(&derived_exclusions, name)) continue;
+        out[i] = name;
+        i += 1;
+    }
+    for (extra_rejected_heads) |name| {
+        out[i] = name;
+        i += 1;
+    }
+    break :blk out;
+};
+
+comptime {
+    // Three nested scans, each ~33 names against ~33 names, every comparison a
+    // comptime `std.mem.eql` byte loop — well past the 1000 default.
+    @setEvalBranchQuota(20_000);
+    // A stale exclusion would silently widen this gate back open, which is
+    // exactly the failure kaappi#1896 was.
+    for (derived_exclusions) |name| {
+        if (!nameListHas(&ir.eval_fallback_form_names, name))
+            @compileError("derived_exclusions names '" ++ name ++
+                "', which is not an ir.eval_fallback_form_names entry — drop it");
+    }
+    // An extra head that the derivation already supplies is a duplicate; the
+    // real question in that case is whether it wants a derived_exclusions entry.
+    for (extra_rejected_heads) |name| {
+        if (nameListHas(&ir.eval_fallback_form_names, name))
+            @compileError("extra_rejected_heads names '" ++ name ++
+                "', which ir.eval_fallback_form_names already contributes");
+    }
+    // The invariant, re-checked independently of how `rejected_form_heads` was
+    // built: derived ⊆ rejected ∪ documented-exclusions.
+    for (ir.eval_fallback_form_names) |name| {
+        if (nameListHas(&rejected_form_heads, name)) continue;
+        if (nameListHas(&derived_exclusions, name)) continue;
+        @compileError("'" ++ name ++ "' routes through kaappi_eval but is not " ++
+            "rejected by the cond/case/do gate and is not in derived_exclusions " ++
+            "(kaappi#1896)");
+    }
+}
+
+fn isRejectedFormHead(name: []const u8) bool {
+    return nameListHas(&rejected_form_heads, name);
 }
 
 // True if `expr` is an expression the emitter can lower natively while

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -1464,6 +1464,66 @@ test "LLVM emit: a cond containing letrec falls back to the interpreter (#1496)"
     try std.testing.expect(countEvalFallbacks(ll) >= 1);
 }
 
+// -- the cond/case/do gate is DERIVED from the eval-fallback set (#1896) --
+//
+// `isRejectedFormHead` was a hand-maintained 32-name array parallel to
+// `ir.eval_fallback_form_names`, and had drifted: `define-property` was absent,
+// so a natively-lowered cond/case/do left the property registration behind as a
+// run-time eval — a compile-time effect moved past the rest of the clause body.
+// `llvm_emit_forms.rejected_form_heads` now derives from the comptime set, and
+// a comptime block there asserts derived ⊆ rejected ∪ derived_exclusions, so a
+// future FormKind cannot reopen the gap. These two tests cover what a comptime
+// assertion cannot: that the derived list is still the one the gate consults,
+// and that consulting it produces the fallback.
+
+test "cond/case/do gate rejects every eval-fallback form (#1896)" {
+    // Deliberately STRICTER than llvm_emit_forms.zig's comptime invariant,
+    // which permits `derived_exclusions` entries. That list is empty and this
+    // test is what keeps it that way: adding an entry compiles fine but fails
+    // here, so weakening the gate takes a second, deliberate edit — with the
+    // reason written down in both places — rather than one quiet line.
+    const forms = @import("llvm_emit_forms.zig");
+    for (ir_mod.eval_fallback_form_names) |name| {
+        var found = false;
+        for (forms.rejected_form_heads) |r| {
+            if (std.mem.eql(u8, r, name)) found = true;
+        }
+        if (!found) {
+            std.debug.print("\n--- eval-fallback form '{s}' is not rejected by the cond/case/do gate ---\n", .{name});
+            return error.TestExpectedEqual;
+        }
+    }
+    // The name the drift actually dropped, called out so a regression names
+    // itself rather than reporting a generic set-inclusion failure.
+    var has_define_property = false;
+    for (forms.rejected_form_heads) |r| {
+        if (std.mem.eql(u8, r, "define-property")) has_define_property = true;
+    }
+    try std.testing.expect(has_define_property);
+}
+
+test "LLVM emit: define-property makes cond/case/do fall back whole (#1896)" {
+    // Before the derivation each of these emitted the enclosing form natively
+    // and deferred only the `define-property` to run time. `do` was worse than
+    // wrong-order: emitDo installs loop-variable locals before reaching the
+    // body, and emitFormEval refuses to eval inside a lexical scope, so the
+    // whole emission failed with KP9001 on a program the interpreter runs.
+    var c = try emitMultiResult("(cond (#t (define-property x k 1) 2))");
+    defer c.deinit();
+    try expectNotContains(c.toSlice(), "cond_merge_");
+    try expectContains(c.toSlice(), "(cond (#t (define-property x k 1) 2))");
+
+    var s = try emitMultiResult("(case 1 ((1) (define-property x k 1) 2))");
+    defer s.deinit();
+    try expectNotContains(s.toSlice(), "case_merge_");
+    try expectContains(s.toSlice(), "(case 1 ((1) (define-property x k 1) 2))");
+
+    var d = try emitMultiResult("(do ((i 0 (+ i 1))) ((= i 1)) (define-property x k 1))");
+    defer d.deinit();
+    try expectNotContains(d.toSlice(), "do_header_");
+    try expectContains(d.toSlice(), "(do ((i 0 (+ i 1))) ((= i 1)) (define-property x k 1))");
+}
+
 // -- macro-use gate in natively-lowered let/lambda scopes (#1807) --
 //
 // emitLet and the lambda closure tiers (tryCompileNativeClosure,

--- a/tests/scheme/compile/native-rejected-form-head-1896.sh
+++ b/tests/scheme/compile/native-rejected-form-head-1896.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Regression test for #1896 (LLVM native backend): the cond/case/do
+# emittability gate was a hand-maintained keyword array parallel to the
+# comptime-derived `ir.eval_fallback_form_names`, and it had drifted —
+# `define-property` was in the derived set and absent from the array.
+#
+# `define-property` (SRFI 213) is a COMPILE-time form: compileDefineProperty
+# evaluates its expression and stores the property while the enclosing form is
+# being compiled, before any of that form runs. The interpreter compiles a
+# top-level `cond` whole, so a `define-property` in a clause body takes effect
+# before the clause body executes.
+#
+# With the keyword missing from the gate, the native backend emitted the cond
+# natively and left only the `define-property` behind as a run-time
+# `kaappi_eval` — so the compile-time effect happened in sequence with the rest
+# of the clause body instead of ahead of it. `case` diverged identically.
+# `do` failed harder: emitDo installs loop-variable locals before reaching the
+# body, and emitFormEval refuses to eval inside a lexical scope, so a program
+# the interpreter runs fine could not be compiled at all (KP9001).
+#
+# The gate is now derived from the comptime set (llvm_emit_forms.rejected_form_heads),
+# so these three forms fall back whole and agree with the interpreter again.
+#
+# The `-nowrap` cases are the discriminating control: the same three top-level
+# forms NOT wrapped in cond/case/do agreed between the tiers before the fix and
+# still do. That is what pins the divergence to this gate rather than to
+# `define-property`'s phase behaviour in general.
+#
+# Usage: bash tests/scheme/compile/native-rejected-form-head-1896.sh [path-to-kaappi]
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+FAILED=0
+
+# Run one program both ways and require identical output. The interpreter is
+# the oracle; `expected` documents intent without being what the comparison
+# rests on.
+check_both() {
+    local label="$1" expected="$2"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$src" 2>&1)" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        FAILED=1
+        return
+    fi
+
+    # A nonzero exit means the compiler rejected the program (this is the `do`
+    # case's pre-fix failure mode, so keep its diagnostics); a zero exit with no
+    # executable means it claimed success and produced nothing.
+    local compile_out compile_status=0
+    compile_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" 2>&1)" || compile_status=$?
+    if [[ $compile_status -ne 0 ]]; then
+        echo "FAIL: $label — kaappi compile exited $compile_status: $compile_out" >&2
+        FAILED=1
+        return
+    fi
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — kaappi compile succeeded but produced no binary" >&2
+        FAILED=1
+        return
+    fi
+
+    local native_out native_status=0
+    native_out="$("$bin" 2>&1)" || native_status=$?
+    if [[ $native_status -ne 0 ]]; then
+        echo "FAIL: $label — compiled binary exited $native_status (output: '$native_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$native_out" != "$interp_out" ]]; then
+        echo "FAIL: $label — native '$native_out' != interpreted '$interp_out'" >&2
+        FAILED=1
+    fi
+}
+
+# The probe prints "P" when the property expression is evaluated and "B"/"C"
+# around it when the clause body runs. Compiling the whole form first means P
+# comes out ahead of both: "PBC". Deferring only the define-property to run
+# time gives the sequential "BPC" — the pre-fix native answer.
+
+# 1. cond — the shape the issue was filed on.
+cat > "$DIR/cond.scm" << 'SCHEME'
+(define x 'ident)
+(define k 'key)
+(cond (#t (display "B")
+          (define-property x k (begin (display "P") 1))
+          (display "C")))
+(newline)
+SCHEME
+check_both "cond" "PBC"
+
+# 2. case — the same gate, reached through caseArgsEmittable.
+cat > "$DIR/case.scm" << 'SCHEME'
+(define x 'ident)
+(define k 'key)
+(case 1
+  ((1) (display "B")
+       (define-property x k (begin (display "P") 1))
+       (display "C")))
+(newline)
+SCHEME
+check_both "case" "PBC"
+
+# 3. do — pre-fix this did not merely diverge, it failed to compile at all
+#    with "error[KP9001]: LLVM emit failed: internal error".
+cat > "$DIR/do.scm" << 'SCHEME'
+(define x 'ident)
+(define k 'key)
+(do ((i 0 (+ i 1)))
+    ((= i 1))
+  (display "B")
+  (define-property x k (begin (display "P") 1))
+  (display "C"))
+(newline)
+SCHEME
+check_both "do" "PBC"
+
+# 4. Discriminating control: the identical forms with no cond/case/do wrapper.
+#    Each top-level form is compiled and run before the next is compiled, so
+#    the property expression fires between B and C in BOTH tiers — "BPC". This
+#    agreed before the fix too; it is what localises the bug to the gate.
+cat > "$DIR/nowrap.scm" << 'SCHEME'
+(define x 'ident)
+(define k 'key)
+(display "B")
+(define-property x k (begin (display "P") 1))
+(display "C")
+(newline)
+SCHEME
+check_both "nowrap" "BPC"
+
+# 5. Second control: a form ALREADY in the rejected list (`delay`) in the same
+#    clause position. This always fell back correctly, and must keep doing so —
+#    a derivation that dropped names would show up here.
+cat > "$DIR/rejected-sibling.scm" << 'SCHEME'
+(cond (#t (display "B") (delay (display "P")) (display "C")))
+(newline)
+SCHEME
+check_both "rejected-sibling" "BC"
+
+# 6. Third control: a cond with none of this in it still lowers natively and
+#    still agrees. Guards against "fix by rejecting everything".
+cat > "$DIR/plain-cond.scm" << 'SCHEME'
+(define (f n) (cond ((> n 0) (* n 2)) (else 0)))
+(display (f 21))
+(newline)
+(display (f -1))
+(newline)
+SCHEME
+check_both "plain-cond" "$(printf '42\n0')"
+
+if [[ $FAILED -ne 0 ]]; then
+    exit 1
+fi
+
+echo "PASS"


### PR DESCRIPTION
Closes #1896. Phase 4A of the systematic correctness audit (#1890).

## The gap was **LIVE**, not latent

`isRejectedFormHead` (`src/llvm_emit_forms.zig`) was a hand-maintained 32-name
array running parallel to the comptime-derived `ir.eval_fallback_form_names`,
gating `cond`/`case`/`do` through `exprNativeEmittable`. It had drifted by
exactly one name — and that one name produces a **wrong answer** under
`kaappi compile`, plus a **hard compile failure** on a program the interpreter
runs fine.

### The mechanical diff

Computed by a throwaway test over the real comptime data, not by eye.

**In the derived set (27), absent from the gate (32) — 1 name:**

| name | status |
|---|---|
| **`define-property`** | the finding — undocumented, no comment excluded it |

**In the gate, absent from the derived set — 6 names, all deliberate:**

| name | why |
|---|---|
| `lambda`, `define` | lowered natively elsewhere, but not in an arbitrary sub-expression position inside a cond/case/do |
| `unquote`, `unquote-splicing`, `else`, `=>` | syntax-position markers, not expression heads. `else`/`=>` must stay **out** of the derived set: `sexprNeedsEvalFallback` recurses blindly into clause bodies, so listing them there would reject every natively-lowered cond/case with an else clause (#1496, asserted in `tests_native.zig`) |

Both lists are now explicit in code (`extra_rejected_heads`,
`derived_exclusions`) with the reasons written down.

### Evidence that it was live

`define-property` (SRFI 213) is a **compile-time** form: `compileDefineProperty`
evaluates its expression and stores the property while the enclosing form is
being *compiled*, before any of that form runs. The interpreter compiles a
top-level `cond` whole, so the effect lands ahead of the clause body.

```scheme
(define x 'ident)
(define k 'key)
(cond (#t (display "B")
          (define-property x k (begin (display "P") 1))
          (display "C")))
```

| tier | output |
|---|---|
| interpreter (oracle) | `PBC` |
| `kaappi compile` — **before** | `BPC` |
| `kaappi compile` — after | `PBC` |

`--emit-llvm` before the fix: three `cond_merge_` labels (cond emitted
natively) and the property registration left behind as
`@kaappi_eval_cached(vm, "(define-property x k (begin (display \"P\") 1))")`,
sequenced *after* the `display "B"`. After the fix: zero `cond_merge_` labels,
one `kaappi_eval_cached` carrying the whole cond.

`case` diverges identically (`PBC` vs `BPC`).

`do` fails **harder than diverging** — it does not compile at all:

```
$ kaappi compile do.scm -o do
error[KP9001]: LLVM emit failed: internal error
```

`emitDo` runs the gate, then installs loop-variable locals; `emitFormEval`
refuses to eval inside a lexical scope, so the deferred `define-property`
returns `error.UnsupportedNodeType` and the whole emission dies. With the name
in the gate, `doArgsEmittable` declines up front and the top-level fallback
takes the correct whole-form path.

### Discriminating control

The identical three forms **without** the cond/case/do wrapper agree between
the tiers (`BPC` both) — before *and* after this change. Each top-level form is
compiled and run before the next is compiled, so the property expression fires
between `B` and `C` in either tier. That is what pins the divergence to this
gate rather than to `define-property`'s phase behaviour in general. A form
already in the list (`delay`) in the same clause position also agreed
throughout.

### What was *not* reachable

The lexical-scope path is closed twice over, so nothing there was at risk:
`sexprNeedsEvalFallback` (which consults the *derived* set, and therefore did
know about `define-property`) already declines native compilation of any
enclosing `let`/`lambda` whose body mentions it, and the interpreter itself
rejects `define-property` in body scope with `KP2001`. The live surface was
exactly top-level `cond`/`case`/`do`.

One residual, unchanged by this PR and not a regression: in a natively compiled
binary the property registration still happens at *run* time, so a
macro-expansion-time `lookup` would see nothing. That is currently unobservable
— `lookup` is only reachable from a procedural transformer, which needs
`(srfi 211 explicit-renaming)`, and `kaappi compile` refuses any program
importing a `.sld`. The observable consequence was the effect *ordering*, which
is what the repro above measures and what this fixes.

## The derivation

`rejected_form_heads` is now built at comptime:

```
rejected_form_heads = (ir.eval_fallback_form_names \ derived_exclusions)
                       ∪ extra_rejected_heads
```

so a new `FormKind` joins this gate automatically, exactly as it already joins
`eval_fallback_form_names`. `derived_exclusions` is empty; an entry there needs
a written reason.

## The invariant

A `comptime` block in `llvm_emit_forms.zig` — a compile error, not a test
failure — asserts three things:

1. every `derived_exclusions` entry actually names a derived form (a stale
   exclusion would silently widen the gate back open, which is what #1896 was);
2. every `extra_rejected_heads` entry is **not** in the derived set (a
   duplicate means the real question is whether it wants an exclusion);
3. `derived ⊆ rejected ∪ derived_exclusions`, re-checked independently of how
   `rejected_form_heads` was constructed.

Two runtime tests cover what comptime cannot:

- `cond/case/do gate rejects every eval-fallback form (#1896)` is deliberately
  **stricter** than (3): it permits no exclusions at all. Adding one compiles
  but fails here, so weakening the gate takes two deliberate edits rather than
  one quiet line.
- `LLVM emit: define-property makes cond/case/do fall back whole (#1896)`
  asserts the emitter *behaviour* — that the derived list is still the one
  `exprNativeEmittable` consults. A correct list that nothing reads would pass
  every list-level check.

Both were mutation-tested: with `define-property` moved into
`derived_exclusions`, each fails with a message naming the form.

## Tests

`tests/scheme/compile/native-rejected-form-head-1896.sh` — six end-to-end
interpreter-vs-native parity cases (cond, case, do, plus the three controls
above). Mutation-tested against a build with the gap reopened:

```
FAIL: cond — native 'BPC' != interpreted 'PBC'
FAIL: case — native 'BPC' != interpreted 'PBC'
FAIL: do — kaappi compile exited 1: error[KP9001]: LLVM emit failed: internal error
```

The three controls passed in both configurations.

## Filed, not fixed

While diffing the keyword lists this turned up a **third** hand-maintained one
with the same drift and the same missing name, in a different subsystem:
`expander.well_known_forms` is missing `define-property`, so any `syntax-rules`
template using it expands to `__hyg_N_define-property` and dies as an undefined
variable. Filed as
[#2089](https://github.com/kaappi/kaappi/issues/2089) with a repro, a
discriminating control, and a sweep confirming it is one name and not a class —
not fixed here, per the campaign's separate-discovery-from-fixing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
