### PR TITLE
Phase 6A: fmt line-ending policy — normalize to LF, and the two places fmt emitted a CR of its own

### DIFF
--- a/docs/dev/fmt.md
+++ b/docs/dev/fmt.md
@@ -36,6 +36,72 @@ kaappi fmt [--check]              # format stdin to stdout
   rewritten — `1.5e10`, `#xFF`, `#\newline`, `'x` vs `(quote x)` all pass
   through untouched. The formatter rearranges whitespace *between* lexemes; it
   never edits a lexeme.
+* **LF line endings.** Every line break `fmt` emits is a bare `\n`, whatever the
+  input used. See *Line endings* below.
+
+## Line endings
+
+`kaappi fmt` **normalises line endings to LF** — the same policy `zig fmt`
+applies to this compiler's own Zig, verified against it. CRLF and lone CR
+between lexemes are line-ending whitespace, and normalise like any other
+whitespace run; the file ends in exactly one `\n`.
+
+**Bytes inside a datum are never touched.** A CR there is program data, not
+layout, so all of these survive byte-for-byte under this policy and would under
+any other:
+
+| Datum | Example |
+|---|---|
+| String literal | `"a<CR>b"`, `"a<CR><LF>b"` |
+| SRFI 267 raw string | `#"X"a<CR>b"X"` |
+| Piped symbol | `\|a<CR>b\|` |
+| Character literal | `#\<CR>` (and its `#\return` spelling) |
+
+Comments are not datums, so both kinds normalise. A line comment's trailing
+`\r` is the carriage return of the CRLF that ended it, and is dropped alongside
+the trailing spaces beside it; a block comment ends at `|#`, so its *interior*
+line endings normalise outright.
+
+`--check` reports a file that differs only in line endings, because `fmt` would
+rewrite it. The two share one comparison in `formatFile`, so they can never
+disagree about any file.
+
+### Why this is not left to the round-trip guard
+
+The [safety net](#the-round-trip-safety-net) below is structurally blind to
+this. `\r` is whitespace to the reader, so a whole-file CRLF→LF rewrite is
+`equal?`-**invariant**: the guard passes while every line in the file changes.
+It proves the *program* did not change; it cannot prove the *bytes* did not.
+Line endings are the one dimension it cannot see, which is why the policy is
+stated here and enforced by dedicated tests rather than inferred from the
+guard (kaappi#1897).
+
+### On Windows
+
+`fmt` writes LF on every platform — file descriptors are opened `O_BINARY`, and
+stdin/stdout/stderr are `_setmode(O_BINARY)` (`src/platform.zig`), so no CRT
+translation applies. On a checkout with `core.autocrlf=true` the working tree
+holds CRLF, so `fmt` rewrites those files and `fmt --check` reports them. The
+fix is the same one Go and Zig projects use — normalise the checkout:
+
+```gitattributes
+*.scm text eol=lf
+*.sld text eol=lf
+```
+
+or `git config core.autocrlf input`. This repo needs neither: no tracked
+`.scm`/`.sld` contains a CR.
+
+### Known deviation: a lone CR does not end a `;` comment
+
+R7RS 7.1.1 defines `⟨line ending⟩ → ⟨newline⟩ | ⟨return⟩ ⟨newline⟩ | ⟨return⟩`
+and ends a `;` comment at one, but this **reader** ends it only at `\n`
+(kaappi#2079) — so in a classic-Mac-line-ending file everything after the first
+`;` is one comment. `fmt`'s lexer mirrors the real reader by design, so it
+inherits that: the comment's interior CR is preserved rather than normalised,
+since rewriting it to `\n` would split the comment and promote its tail to real
+code. Every other lone CR in such a file does become LF. `fmt` is faithful to
+what the program means today; fixing the reader is what changes it.
 
 ## Why it needs its own reader
 
@@ -123,9 +189,14 @@ program source.
   preservation, the idempotence property and semantics-preserving round-trip
   over programs from the grammar fuzzer (`fuzz_gen`), and parser diagnostics.
 * **`tests/scheme/fmt/fmt.sh`** — CLI behaviour (write in place, `--check` exit
-  codes, stdin) plus two corpus-wide properties: formatting every `.scm`/`.sld`
-  under `tests/scheme/` and `lib/` has **zero semantic drift**, and the result
-  is **idempotent**.
+  codes, stdin), the line-ending policy, plus two corpus-wide properties:
+  formatting every `.scm`/`.sld` under `tests/scheme/` and `lib/` has **zero
+  semantic drift**, and the result is **idempotent**.
+
+  Its line-ending fixtures are built with `printf`, never checked in: a
+  committed CRLF file would be rewritten by git's own eol filters on a
+  `core.autocrlf=true` checkout — exactly the Windows configuration those cases
+  exist to cover — leaving the test asserting nothing.
 
 ## CI adoption
 

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -25,6 +25,20 @@
 //! datum sequences with `equal?`. On any mismatch — or if either side fails to
 //! read — `fmt` refuses to write and reports it, so a bug here can never corrupt
 //! a source file.
+//!
+//! **Line endings are LF** (kaappi#1897), the same policy `zig fmt` applies to
+//! this compiler's own Zig. Every line break `fmt` emits is a bare `\n`; a CRLF
+//! or a lone CR between lexemes is line-ending whitespace and normalises like
+//! any other whitespace run. Bytes *inside a datum* are never touched — a
+//! `"a\r\nb"` string, a SRFI 267 raw string, a `|piped symbol|` and a `#\return`
+//! all survive byte-for-byte, because there the CR is program data.
+//!
+//! That split is why the policy has to be stated here rather than left to the
+//! round-trip guard: `\r` is whitespace to the reader, so a whole-file CRLF→LF
+//! rewrite is *invariant* under `equal?`. The guard proves the program did not
+//! change; it cannot prove the bytes did not. Line endings are the one dimension
+//! it is blind to, so `normalizeEol` and the comment trim below are what keep
+//! `fmt`'s own output free of stray CRs.
 
 const std = @import("std");
 const platform = @import("platform.zig");
@@ -133,12 +147,22 @@ const Lexer = struct {
         return isSpace(c) or c == '(' or c == ')' or c == '"' or c == ';' or c == '|';
     }
 
-    /// Consume whitespace, returning the newline count. Whitespace-only runs and
-    /// blank lines are recovered from this count, not stored verbatim.
+    /// Consume whitespace, returning the count of *line endings* crossed.
+    /// Whitespace-only runs and blank lines are recovered from this count, not
+    /// stored verbatim.
+    ///
+    /// R7RS 7.1.1: `⟨line ending⟩ → ⟨newline⟩ | ⟨return⟩ ⟨newline⟩ | ⟨return⟩`.
+    /// All three count as one, so blank-line grouping and trailing-vs-leading
+    /// comment placement come out the same whichever convention the file uses —
+    /// counting only `\n` would silently flatten a CR-only file to a single line.
     fn skipSpace(self: *Lexer) u32 {
         var newlines: u32 = 0;
         while (self.pos < self.src.len and isSpace(self.src[self.pos])) : (self.pos += 1) {
-            if (self.src[self.pos] == '\n') newlines += 1;
+            const c = self.src[self.pos];
+            // In CRLF the `\n` is the one counted, so skip the `\r`.
+            if (c == '\n' or (c == '\r' and !(self.pos + 1 < self.src.len and self.src[self.pos + 1] == '\n'))) {
+                newlines += 1;
+            }
         }
         return newlines;
     }
@@ -401,13 +425,21 @@ const Parser = struct {
                     .block_comment => .block_comment,
                     else => .atom,
                 },
-                // Trailing whitespace inside a line comment is invisible and
-                // never part of a datum; strip it so the output has no trailing
-                // spaces. Block comment and atom text stays byte-for-byte.
-                .text = if (tok.kind == .line_comment)
-                    std.mem.trimEnd(u8, tok.text, " \t")
-                else
-                    tok.text,
+                // Neither comment kind is a datum, so both get the LF policy
+                // (see the module header). A line comment runs to the `\n` that
+                // ends it, so a trailing `\r` is that CRLF's carriage return —
+                // dropping it is what keeps commented lines from being the one
+                // place `fmt` emits a CR. Interior bytes are *not* rewritten:
+                // this reader ends a `;` comment only at `\n` (kaappi#2079), so
+                // turning an interior CR into `\n` would split the comment and
+                // promote its tail to code. Block comments have no such hazard —
+                // they end at `|#` — so their line endings normalise outright.
+                // Atom text stays byte-for-byte: a CR in a string is program data.
+                .text = switch (tok.kind) {
+                    .line_comment => std.mem.trimEnd(u8, tok.text, " \t\r"),
+                    .block_comment => try normalizeEol(self.arena, tok.text),
+                    else => tok.text,
+                },
                 .newlines_before = tok.newlines_before,
             },
             .prefix, .datum_comment => {
@@ -436,6 +468,31 @@ const Parser = struct {
         };
     }
 };
+
+/// Rewrite the line endings inside a lexeme to LF, returning `text` unchanged
+/// (and allocating nothing) when it holds no CR — the overwhelmingly common
+/// case. Only ever applied to lexemes that contribute no bytes to any datum, so
+/// it cannot change the program a reader sees.
+///
+/// Normalising here rather than in the printer keeps `measure` honest: a CR-only
+/// block comment holds no `\n` and would otherwise be measured as inline-able,
+/// putting a raw carriage return in the middle of an output line.
+fn normalizeEol(arena: std.mem.Allocator, text: []const u8) ParseError![]const u8 {
+    if (std.mem.indexOfScalar(u8, text, '\r') == null) return text;
+    const buf = try arena.alloc(u8, text.len); // never grows: CRLF loses a byte
+    var n: usize = 0;
+    for (text, 0..) |c, i| {
+        if (c == '\r') {
+            // CRLF: drop the CR and let the LF through on the next iteration.
+            if (i + 1 < text.len and text[i + 1] == '\n') continue;
+            buf[n] = '\n'; // lone CR is a line ending in its own right
+        } else {
+            buf[n] = c;
+        }
+        n += 1;
+    }
+    return buf[0..n];
+}
 
 /// Parse `source` into a top-level CST node sequence. Caller owns nothing —
 /// everything is arena-allocated.

--- a/src/tests_fmt.zig
+++ b/src/tests_fmt.zig
@@ -317,3 +317,129 @@ test "unterminated raw string is a format error" {
     defer arena.deinit();
     try testing.expectError(fmt.ParseError.UnterminatedString, fmt.formatSource(arena.allocator(), "(a #\"X\"never closed"));
 }
+
+// ── Line endings (kaappi#1897) ───────────────────────────────────────────────
+// Policy: LF, like `zig fmt`. Every line break `fmt` emits is a bare `\n`;
+// bytes inside a datum are never touched. The round-trip guard is blind to this
+// entirely — `\r` is whitespace to the reader, so a whole-file CRLF→LF rewrite
+// is `equal?`-invariant — which is exactly why it needs its own tests.
+
+/// Assert `src` holds no CR outside a datum after formatting. Datum-bearing
+/// lexemes (strings, raw strings, `|symbols|`, `#\return`) are exempt, so this
+/// is only applied to sources that contain none.
+fn expectNoCr(src: []const u8) !void {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const got = try fmtInto(arena.allocator(), src);
+    if (std.mem.indexOfScalar(u8, got, '\r')) |at| {
+        std.debug.print("stray CR at byte {d} of:\n{s}\n", .{ at, got });
+        return error.StrayCarriageReturn;
+    }
+}
+
+test "CRLF and lone CR both format to LF" {
+    try expectFormat("(define x 1)\r\n(define y 2)\r\n", "(define x 1)\n(define y 2)\n");
+    try expectFormat("(define x 1)\r(define y 2)\r", "(define x 1)\n(define y 2)\n");
+    // Mixed within one file: no dominant-ending heuristic, every ending is LF.
+    try expectFormat("(a)\r\n(b)\n(c)\r", "(a)\n(b)\n(c)\n");
+}
+
+test "line endings never affect the output" {
+    // The policy in one property: a file and its CRLF twin format identically.
+    // This is what a preserve policy would have made false.
+    const programs = [_][]const u8{
+        "(define (f x)\n  (+ x 1))\n",
+        ";; header\n(define x 1) ; trailing\n\n(define y 2)\n",
+        "(begin\n  (a)\n\n  (b))\n",
+        "#| block\n   comment |#\n(define x 1)\n",
+        "(let loop ((i 0))\n  (when (< i 10) (loop (+ i 1))))\n",
+    };
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    for (programs) |lf| {
+        _ = arena.reset(.retain_capacity);
+        const a = arena.allocator();
+
+        const crlf = try std.mem.replaceOwned(u8, a, lf, "\n", "\r\n");
+        try testing.expectEqualStrings(try fmt.formatSource(a, lf), try fmt.formatSource(a, crlf));
+
+        // The CR-only twin is only a twin for a program with no `;` comment:
+        // this reader does not end one at a lone CR, so converting a commented
+        // program to CR endings genuinely changes what it means. See the
+        // "a lone CR does not end a line comment" test.
+        if (std.mem.indexOfScalar(u8, lf, ';') != null) continue;
+        const cr = try std.mem.replaceOwned(u8, a, lf, "\n", "\r");
+        try testing.expectEqualStrings(try fmt.formatSource(a, lf), try fmt.formatSource(a, cr));
+    }
+}
+
+test "a CR in a datum is program data and survives byte-for-byte" {
+    // Changing any of these would change the program, so they are exempt from
+    // the LF policy under *any* policy — string, raw string, piped symbol, and
+    // the raw spelling of the return character.
+    try expectFormat("(define s \"a\rb\")\n", "(define s \"a\rb\")\n");
+    try expectFormat("(define c #\\\r)\n", "(define c #\\\r)\n");
+    try expectFormat("(define s #\"X\"a\rb\"X\")\n", "(define s #\"X\"a\rb\"X\")\n");
+    try expectFormat("(define |a\rb| 1)\n", "(define |a\rb| 1)\n");
+    // A CRLF inside a string keeps *both* bytes; the embedded newline is what
+    // stops the enclosing form from inlining, so the layout breaks around it.
+    try expectFormat("(define s \"a\r\nb\")\n", "(define s\n  \"a\r\nb\")\n");
+    try expectRoundTrips("(define s \"a\r\nb\")\n");
+    try expectIdempotent("(define s \"a\r\nb\")\n");
+}
+
+test "comment line endings normalise; comment interiors are handled per kind" {
+    // A line comment runs to the `\n`, so its trailing `\r` is that CRLF's
+    // carriage return — dropped, like the trailing spaces beside it. Before
+    // kaappi#1897 this was the one place fmt emitted a CR of its own.
+    try expectFormat("(define x 1) ; note\r\n(define y 2)\r\n", "(define x 1) ; note\n(define y 2)\n");
+    try expectFormat(";; header\r\n(define x 1)\r\n", ";; header\n(define x 1)\n");
+    try expectNoCr("(define x 1) ; note\r\n;; own line\r\n(define y 2)\r\n");
+
+    // A block comment ends at `|#`, so its interior line endings normalise too:
+    // its bytes reach no datum, and leaving them would make the output mixed.
+    try expectFormat("#| a\r\nb |#\n(define x 1)\n", "#| a\nb |#\n(define x 1)\n");
+    try expectFormat("#| a\rb |#\n(define x 1)\n", "#| a\nb |#\n(define x 1)\n");
+    try expectNoCr("#| a\r\nb |#\r\n(define x 1)\r\n");
+}
+
+test "a lone CR does not end a line comment — fmt mirrors the reader" {
+    // R7RS 7.1.1 makes a lone ⟨return⟩ a line ending, but this reader ends a
+    // `;` comment only at `\n` (kaappi#2079). fmt's lexer must carve the same
+    // lexemes the real reader does, so it inherits that: everything after the
+    // `;` is one comment to both, and its interior CR is preserved rather than
+    // normalised — rewriting it to `\n` would promote the tail to real code.
+    // Pinned so the day the reader is fixed, this test says so.
+    try expectFormat("(define x 1) ; note\r(define y 2)\r", "(define x 1) ; note\r(define y 2)\n");
+    try expectRoundTrips("(define x 1) ; note\r(define y 2)\r");
+    try expectIdempotent("(define x 1) ; note\r(define y 2)\r");
+}
+
+test "blank-line grouping survives every line-ending convention" {
+    try expectFormat("(a)\r\n\r\n(b)\r\n", "(a)\n\n(b)\n");
+    // Lone CR counts as a line ending too, so `\r\r` is a blank line. Counting
+    // only `\n` would flatten a CR-only file to one line and drop the grouping.
+    try expectFormat("(a)\r\r(b)\r", "(a)\n\n(b)\n");
+}
+
+test "the trailing newline is added as LF, whatever the file used" {
+    try expectFormat("(define x 1)", "(define x 1)\n");
+    try expectFormat("(define x 1)\r\n(define y 2)", "(define x 1)\n(define y 2)\n");
+    try expectFormat("\r\n", "");
+}
+
+test "idempotent and round-tripping across line-ending conventions" {
+    const cases = [_][]const u8{
+        "(define x 1)\r\n(define y 2)\r\n",
+        "(define x 1)\r(define y 2)\r",
+        "(a)\r\n(b)\n(c)\r",
+        "#| a\r\nb |#\r\n(define x 1)\r\n",
+        "(define s \"a\rb\")\r\n",
+        "(define s #\"X\"a\r\nb\"X\")\r\n",
+        ";; head\r\n(define x 1) ; tail\r\n\r\n(define y 2)\r\n",
+    };
+    for (cases) |c| {
+        try expectIdempotent(c);
+        try expectRoundTrips(c);
+    }
+}

--- a/tests/scheme/fmt/fmt.sh
+++ b/tests/scheme/fmt/fmt.sh
@@ -109,6 +109,80 @@ else
     fail "check: file #70 of 70 still checked (#1652)" "exit $status, output: $(cat "$TMP/argcliff.out")"
 fi
 
+# ── Line endings: LF, like `zig fmt` (kaappi#1897) ───────────────────────────
+#
+# Every fixture here is built with an explicit printf, never checked in: a
+# committed CRLF file would be rewritten by git's own eol filters on a checkout
+# with core.autocrlf=true — which is precisely the Windows configuration these
+# cases exist to cover — and the test would then assert nothing. printf writes
+# the bytes it is given on every platform, Git Bash included, and the fd is
+# opened O_BINARY throughout (src/platform.zig), so no CRT translation touches
+# it either.
+#
+# assert_bytes <label> <expected-file> <actual-file>: byte-exact comparison.
+# `cmp`, not `$(cat …)`: command substitution would strip the trailing newline
+# whose presence is half of what several of these check.
+assert_bytes() {
+    if cmp -s "$2" "$3"; then
+        pass "$1"
+    else
+        fail "$1" "expected [$(od -c < "$2" | tr '\n' ' ')], got [$(od -c < "$3" | tr '\n' ' ')]"
+    fi
+}
+
+# eol_case <label> <input-printf-format> <expected-printf-format>
+eol_case() {
+    local label="$1"
+    printf "$2" > "$TMP/eol-in.scm"
+    printf "$3" > "$TMP/eol-want.scm"
+    "$KAAPPI" fmt "$TMP/eol-in.scm" > /dev/null 2>&1
+    assert_bytes "eol: $label" "$TMP/eol-want.scm" "$TMP/eol-in.scm"
+    # Whatever the policy produces must be a fixed point, or a formatted tree
+    # goes dirty again on the next run.
+    assert_exit "eol: $label (fixed point)" 0 "$KAAPPI" fmt --check "$TMP/eol-in.scm"
+}
+
+eol_case "CRLF throughout becomes LF" \
+    '(define x 1)\r\n(define y 2)\r\n' '(define x 1)\n(define y 2)\n'
+eol_case "lone CR becomes LF" \
+    '(define x 1)\r(define y 2)\r' '(define x 1)\n(define y 2)\n'
+eol_case "mixed endings all become LF" \
+    '(a)\r\n(b)\n(c)\r' '(a)\n(b)\n(c)\n'
+eol_case "CRLF file gains no second newline" \
+    '(define x 1)\r\n(define y 2)' '(define x 1)\n(define y 2)\n'
+eol_case "trailing CR of a line comment is dropped" \
+    '(define x 1) ; note\r\n(define y 2)\r\n' '(define x 1) ; note\n(define y 2)\n'
+eol_case "block comment interior normalises" \
+    '#| a\r\nb |#\r\n(define x 1)\r\n' '#| a\nb |#\n(define x 1)\n'
+eol_case "CRLF blank line stays one blank line" \
+    '(a)\r\n\r\n(b)\r\n' '(a)\n\n(b)\n'
+
+# A CR *inside a datum* is program data — changing it changes the program — so
+# it survives under any policy. These files are already canonical: --check must
+# say so, and fmt must not touch a byte.
+eol_case "CR inside a string literal is untouched" \
+    '(define s "a\rb")\n' '(define s "a\rb")\n'
+eol_case "CR inside a raw string is untouched" \
+    '(define s #"X"a\rb"X")\n' '(define s #"X"a\rb"X")\n'
+eol_case "CR inside a piped symbol is untouched" \
+    '(define |a\rb| 1)\n' '(define |a\rb| 1)\n'
+eol_case "raw return character literal is untouched" \
+    '(define c #\\\r)\n' '(define c #\\\r)\n'
+
+# --check reports a CRLF file, because fmt would rewrite it. The two share one
+# comparison in formatFile, so they cannot disagree — this pins the direction.
+printf '(define x 1)\r\n' > "$TMP/eol-crlf.scm"
+assert_exit "eol: --check flags a CRLF-only difference" 1 "$KAAPPI" fmt --check "$TMP/eol-crlf.scm"
+before="$(od -c < "$TMP/eol-crlf.scm")"
+"$KAAPPI" fmt --check "$TMP/eol-crlf.scm" > /dev/null 2>&1 || true
+assert_eq "eol: --check leaves the CRLF file untouched" "$before" "$(od -c < "$TMP/eol-crlf.scm")"
+
+# stdin takes the same policy. fd 0/1 are _setmode(O_BINARY) on Windows
+# (src/platform.zig), so this is the same comparison there.
+printf '(define x 1)\n' > "$TMP/eol-stdin-want.scm"
+printf '(define x 1)\r\n' | "$KAAPPI" fmt > "$TMP/eol-stdin-got.scm" 2>/dev/null
+assert_bytes "eol: stdin CRLF formats to LF" "$TMP/eol-stdin-want.scm" "$TMP/eol-stdin-got.scm"
+
 # ── Corpus: zero semantic drift + idempotence over the repo tree ─────────────
 
 corpus_files() {


### PR DESCRIPTION
Closes #1897. Phase 6A of the systematic audit v2 (#1890) — a **fix** unit, not a survey.

## The decision: normalize to LF

`kaappi fmt` normalizes every line ending it controls to LF, and never touches a
byte inside a datum. `docs/dev/fmt.md` now has a *Line endings* section saying
so; it previously said nothing at all, which is half of what #1897 reported.

**The argument I rejected** — so you can disagree with the reasoning, not just
the code. rustfmt's default `newline_style = "Auto"` *preserves* a file's
dominant ending, precisely so a Windows checkout is never rewritten wholesale,
and #1897's own framing ("an unrequested, undocumented, whole-file change") is
the strongest version of that case. It is a real cost and I am accepting it, not
dismissing it. Three things tip it:

1. **`fmt.md` already promised the opposite.** "Layout depends only on the
   program's content and its comments, **not** on the input's own line breaks,
   so two files that differ only in whitespace format identically." A preserve
   policy makes that sentence false. Normalize makes it true in one more
   dimension, and there is now a test that *is* that sentence
   ("line endings never affect the output").
2. **`fmt` already canonicalizes every other whitespace dimension
   unconditionally** — tabs, runs of spaces, all indentation, a missing trailing
   newline, every line break's *position*. Preserving exactly one of them is the
   arbitrary position. "Large diff on first run" is this tool's normal behaviour
   on any unformatted file; line endings are not a special case of it.
3. **Preserve has undefined cases; normalize has none.** What is the dominant
   ending of a 50/50 mixed file, or of a one-line file with no line break at
   all? Normalize never has to answer.

Plus the in-house precedent: `zig fmt` — which this module's own header names as
its model, and which gates this repo's Zig in CI — normalizes both CRLF and lone
CR to LF. Verified directly rather than assumed.

**I also rejected #1897's own option-2b**, "make `--check` exit 0 on a file that
differs only by line endings." That would be the same incoherence mirrored:
`--check` is documented as reporting each path that is not already formatted,
and under a normalize policy a CRLF file is not. In fact `--check` and the
rewrite **cannot** disagree about any file — `formatFile` computes the formatted
text once and both paths compare it to the source with the same `mem.eql`. So
the "incoherent" half of #1897 is narrower than filed: the policy was undeclared,
not self-contradictory. Windows CI gets the standard answer instead —
`.gitattributes` `*.scm text eol=lf` or `core.autocrlf=input`, documented in
`fmt.md`. This repo needs neither; no tracked `.scm`/`.sld` contains a CR.

## What actually changed

Characterizing first turned up that #1897's headline (inter-lexeme CRLF→LF) was
never a bug in isolation — `\r` is whitespace to the lexer and the printer only
ever emits `\n`, so that half was already the policy, just undeclared. The real
defects are the two places `fmt` emitted a CR **of its own**:

* **A line comment's trailing `\r` survived.** The comment scan runs to `\n`, so
  that CR is the terminating CRLF's — but `trimEnd` stripped only `" \t"`. Every
  commented line in a CRLF file came out ending in a stray CR while every other
  line got LF, contradicting the code's own stated intent one line above it. The
  result was a fixed point, so this was stable-and-wrong rather than noisy.
* **Block-comment interiors kept their CRs**, so a CRLF file with a block comment
  formatted to a *mixed*-ending file. A block comment ends at `|#` and its bytes
  reach no datum, so normalizing them cannot change the program. Done at parse
  time rather than in the printer, which also keeps `measure` honest: a CR-only
  block comment holds no `\n` and would otherwise be judged inline-able, putting
  a raw CR mid-line.

Plus `skipSpace` now counts a lone CR as a line ending (R7RS 7.1.1 lists it as
one), so blank-line grouping and trailing-vs-leading comment placement no longer
collapse on a CR-only file.

## Before / after, all six cases

| # | Case | Before | After |
|--:|---|---|---|
| 1 | CRLF throughout | CRLF→LF, 28→26 B; `--check` exit 1 | unchanged — now the **declared** policy, documented and tested |
| 2 | Lone CR throughout | CR→LF, but `\r\r` counted as **zero** line endings, so blank-line grouping was silently dropped | CR→LF **and** grouping preserved |
| 3 | Mixed CRLF + LF | all→LF | unchanged; pinned in both directions (CRLF-dominant and LF-dominant) |
| 4 | CRLF inside a string literal | **already correct** — byte-for-byte, `--check` exit 0 for the CR-only form | unchanged, now asserted (+ raw string, `\|piped symbol\|`, `#\<CR>`) |
| 5 | CRLF inside a block comment | interior CRs kept ⇒ **mixed-ending output** | normalized ⇒ uniform LF |
| 6 | No trailing newline | **already correct** — exactly one LF added | unchanged, now asserted for the CRLF case too |
| + | CRLF file with a line comment | trailing `\r` kept ⇒ **stray CR on every commented line** | trimmed |
| + | Lone CR + a `;` comment | comment swallows the rest of the file | unchanged — matches the real reader; filed as #2079 and pinned |

So two of the six named cases were already right, one was right but undeclared,
and the two genuinely broken ones are the two the issue did not name.

## The deviation I did not fix

R7RS 7.1.1 makes a lone `⟨return⟩` a line ending, so it should end a `;`
comment. This **reader** ends one only at `\n`, so in a CR-only file everything
after the first `;` is swallowed — filed as **#2079** with five discriminating
controls isolating it to `;`-comment × lone-CR (CRLF, block comments, datum
comments and CR-as-whitespace are all fine). Chibi (our pinned fuzz oracle) and
Guile behave identically, which is in the issue.

`fmt`'s lexer must carve the same lexemes the real reader does, so it inherits
this, and a `;` comment's *interior* CR is deliberately left alone: rewriting it
to `\n` would split the comment and promote its tail to real code. Pinned by a
test named for it and documented in `fmt.md` § *Known deviation*, both citing
#2079 — closing that issue means updating both.

Also filed: **#2080**, `fmt` reports an ordinary user syntax error as
`internal error: formatting would change the program`, discarding the reader's
own `KP1xxx` message and line:column. Four reader error classes reproduce it.

## Verification

* `zig build test` — **1533 pass, 3 skip**; `src/tests_fmt.zig` goes 33 → 41 test blocks.
* `tests/scheme/fmt/fmt.sh` — **37 pass, 0 fail**, up from 12; the
  876-file corpus is still zero-drift and idempotent.
* `bash tests/scheme/run-all.sh` — **639 pass, 3 fail; R7RS 1395/1395.** All
  three failures are in `tests/scheme/compile/`, and none is attributable to
  this diff: `compile-import-error-703.sh` and `compile-preamble-gc-700.sh`
  fail **identically on the unmodified pre-change binary** under the same
  conditions, and `native-boxed-shadow-divergence-1584.sh` passes standalone
  (its failure line is "binary exited nonzero or timed out"). All three shell
  out to `zig build` and take the shared `zig-out/` build lock, and this laptop
  was running seven other audit worktrees at the time — one of them a
  `zig build test -Dgc-stress=true`. `tests/scheme/fmt/fmt.sh` passes in the
  full run. A separate earlier run also flagged
  `primitives_filesystem-audit.scm`; that one passes here, and under deliberate
  concurrent load it flakes at the same rate on both binaries (5-9 of 12 on
  pre-change, 6-10 of 12 on post-change), so it is load-sensitive and
  pre-existing. Not filed — I could not separate it from my own load, and
  saying so is more useful than a speculative issue.
* **Strict no-op on the existing tree:** formatting all 942 tracked `.scm`/`.sld`
  files with the pre-change and post-change binaries gives **byte-identical
  output**, and `fmt --check` flags the same **833** files before and after
  (pre-existing — the repo has no `kaappi fmt` gate, only `zig fmt --check src/`).
* Windows: file descriptors are `O_BINARY` and fd 0/1/2 are
  `_setmode(O_BINARY)` (`src/platform.zig`), so LF output is uniform there too.
  Read from source, not executed.

## Note on the test fixtures

Every line-ending fixture is built with `printf`, never checked in. A committed
CRLF file would be rewritten by git's own eol filters on a `core.autocrlf=true`
checkout — exactly the Windows configuration these cases exist to cover — and
the test would then assert nothing. Comparisons use `cmp` against a
printf-built expectation, not `$(cat …)`, whose trailing-newline stripping is
half of what several cases check. No `grep -q` pipes and no GNU regex
extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
