### PR TITLE
Make a fuzz overrun reportable, and stop it destroying its own evidence

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -429,8 +429,8 @@ jobs:
   # job-level timeouts — a possible hang — and runners reclaimed mid-job) are
   # collected under a single "Fuzz CI: infrastructure or build failure" issue
   # instead of wearing a divergence title, each carrying a verdict read from
-  # its own job log so the three are told apart without opening the run
-  # (#2040).
+  # its own job log and check-run annotations so the three are told apart
+  # without opening the run (#2040).
   #
   # This is a SEPARATE job so the write-capable token never coexists with
   # execution of fuzzer-generated programs — the four jobs above keep
@@ -440,10 +440,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [fuzz, native-diff, oracle-diff, cross-diff]
-    if: failure()
+    # `cancelled()` as well as `failure()`, because a job killed by its own
+    # `timeout-minutes` is CANCELLED, not failed — and it cancels the whole
+    # run with it. Under a bare `failure()` this job was therefore skipped
+    # for exactly the outcome the workflow most wants to hear about: a fuzz
+    # leg overrunning its budget, i.e. the possible hang. That is not
+    # hypothetical — it silently dropped #2040's re-run. A plain manual or
+    # concurrency cancellation is also `cancelled()`, so the step itself
+    # files nothing unless a job carries the job-timeout annotation.
+    if: failure() || cancelled()
     permissions:
       issues: write
-      actions: read # this run's failure artifacts, and its job logs for the verdict
+      actions: read # this run's failure artifacts, plus its job logs and annotations
     steps:
       # No checkout: the job needs nothing from the repo, and gh targets it
       # via -R. Artifacts usually land in per-name subdirectories of
@@ -559,8 +567,12 @@ jobs:
           }
 
           # run_log_diagnosis OUT — append a per-failed-job verdict read from
-          # this run's OWN logs, via the `actions: read` token this job
-          # already holds. Artifact-less failures are exactly the ones whose
+          # this run's OWN logs and check-run annotations, via the
+          # `actions: read` token this job already holds. Both sources are
+          # needed: the runner-shutdown line appears only in the log, the
+          # job-timeout message only in the annotations, and a cancelled job
+          # often has no archived log at all.
+          # Artifact-less failures are exactly the ones whose
           # cause exists nowhere else: a runner reclaimed mid-job CANCELS the
           # job, so even the `if: failure()` upload step is skipped and
           # nothing is uploaded — leaving the issue able to say no more than
@@ -579,18 +591,26 @@ jobs:
                                 .name]
                              | @tsv' 2>/dev/null || true)
             [ -n "$failed" ] || return 0
-            printf '**Why the job(s) failed** (read from the run logs):\n\n' >> "$rout"
+            printf '**Why the job(s) failed** (read from the run logs and job annotations):\n\n' >> "$rout"
             while IFS=$'\t' read -r jid jconc jdur jname; do
               [ -n "$jid" ] || continue
               case "$jdur" in '' | *[!0-9]*) jdur=0 ;; esac
               jlog="job-$jid.log"
               gh api "repos/$GITHUB_REPOSITORY/actions/jobs/$jid/logs" > "$jlog" 2>/dev/null || true
-              # Most- to least-specific: a reclaimed runner can also print the
-              # generic cancellation line, so its own line must be tested first.
-              if grep -qF 'The runner has received a shutdown signal' "$jlog" 2>/dev/null; then
-                verdict='the **GitHub-hosted runner was shut down mid-job** and the step was SIGTERMed (exit 143). That is runner infrastructure, not a build failure and not a hang; a shutdown cancels rather than fails the job, which is why the `if: failure()` upload step never ran and no artifact reached this issue. Re-run the job.'
+              # A cancelled job's log blob is often never archived, but its
+              # annotations survive — and the job-timeout message lives ONLY
+              # there. Read both, so a timed-out job still gets a verdict and
+              # quotable evidence.
+              anns=$(gh api "repos/$GITHUB_REPOSITORY/check-runs/$jid/annotations" --jq '.[].message' 2>/dev/null || true)
+              # Most- to least-specific. The timeout is first because it is the
+              # only one of these that indicts the code; a reclaimed runner can
+              # also print the generic cancellation line, so it precedes that.
+              if printf '%s' "$anns" | grep -qF 'exceeded the maximum execution time'; then
+                verdict='the job **exceeded its `timeout-minutes` budget** and was killed. This is the one verdict here that points at the code rather than the infrastructure: every generated program is individually time-bounded, so a whole job overrunning should not be possible — but that bound guards only the bytecode loop, and read/expand/lower/emit are unchecked (see the deadline comment in `src/tests_fuzz.zig`). Compare this leg'"'"'s duration against its recent history, and check whether sibling legs on the same commit were normal.'
+              elif grep -qF 'The runner has received a shutdown signal' "$jlog" 2>/dev/null; then
+                verdict='the **GitHub-hosted runner was shut down mid-job** and the step was SIGTERMed (exit 143). The shutdown is runner infrastructure, and it cancels rather than fails the job, which is why no artifact reached this issue. It does **not** prove the job was otherwise healthy: a reclaimed runner kills whatever happened to be running, so check this leg'"'"'s elapsed time against its recent history before writing it off — #2040 read as pure infrastructure until its re-run hit the 55-minute timeout on the very same leg.'
               elif grep -qF 'The operation was canceled' "$jlog" 2>/dev/null; then
-                verdict='the job was **cancelled** — it hit its `timeout-minutes`, or the run was cancelled. A fuzz leg reaching its own timeout deserves a second look: every generated program is individually time-bounded, so a whole job overrunning is itself suspicious.'
+                verdict='the job was **cancelled** without a timeout annotation — most likely the run was cancelled manually or by a concurrency rule.'
               elif [ -s "$jlog" ]; then
                 verdict='a step failed; the runner diagnostics are below.'
               else
@@ -598,7 +618,8 @@ jobs:
               fi
               printf -- '- `%s` — %s after %dm%02ds: %s\n' \
                 "$jname" "$jconc" "$((jdur / 60))" "$((jdur % 60))" "$verdict" >> "$rout"
-              errs=$(grep -oE '##\[error\].*' "$jlog" 2>/dev/null | sed 's/^##\[error\]//' | tail -5 || true)
+              errs=$( { grep -oE '##\[error\].*' "$jlog" 2>/dev/null | sed 's/^##\[error\]//'
+                        printf '%s\n' "$anns"; } | awk 'NF && !seen[$0]++' | tail -5 || true)
               if [ -n "$errs" ]; then
                 # No trailing newline on the body: command substitution already
                 # stripped it, and the closing fence supplies its own.
@@ -718,6 +739,41 @@ jobs:
             file_or_append "Fuzz CI: unit-test failure ($ut_label)" unit-test-preamble.md "$utbody"
           }
 
+          # Names of jobs killed by their own `timeout-minutes`. The check-run
+          # ANNOTATION is the only durable evidence: a cancelled job's log blob
+          # is frequently never archived at all (verified on #2040's re-run —
+          # the logs endpoint answered BlobNotFound while the annotation was
+          # intact), and the timeout message appears nowhere else. This list is
+          # also what keeps `cancelled()` above from turning every manual or
+          # concurrency cancellation into an issue: no annotation, no report.
+          timed_out_names=$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" --paginate \
+              --jq '.jobs[] | select(.conclusion == "cancelled" or .conclusion == "failure") | [.id, .name] | @tsv' \
+              2>/dev/null \
+            | while IFS=$'\t' read -r tid tname; do
+                [ -n "$tid" ] || continue
+                if gh api "repos/$GITHUB_REPOSITORY/check-runs/$tid/annotations" --jq '.[].message' 2>/dev/null \
+                     | grep -qF 'exceeded the maximum execution time'; then
+                  printf '%s\n' "$tname"
+                fi
+              done || true
+          )
+
+          # group_timed_out GROUP — did a job of this matrix group time out?
+          # Anchored so a group name can only match a whole leading job name.
+          group_timed_out() {
+            [ -n "$timed_out_names" ] || return 1
+            printf '%s\n' "$timed_out_names" | grep -qE "^$1( |\(|\$)"
+          }
+
+          # reportable RESULT GROUP — a failed group always reports; a cancelled
+          # one reports only when the cancellation was its own timeout.
+          reportable() {
+            [ "$1" = failure ] && return 0
+            { [ "$1" = cancelled ] && group_timed_out "$2"; } && return 0
+            return 1
+          }
+
           infra_jobs=""
           fuzz_dir="artifacts/fuzz-absent"
 
@@ -731,7 +787,7 @@ jobs:
           # confuses one job's files for another's.
 
           # ---- fuzz (native x86_64 + arm64 matrix) — three routes per leg ----
-          if [ "$RESULT_FUZZ" = failure ]; then
+          if reportable "$RESULT_FUZZ" fuzz; then
             crashes=$(find artifacts -type f -path '*/.zig-cache/f/crash' 2>/dev/null | sort || true)
             crash_dirs=""
             if [ -n "$crashes" ]; then
@@ -767,7 +823,7 @@ jobs:
           fi
 
           # ---- native-diff (one finding per arch that diverged) ----
-          if [ "$RESULT_NATIVE" = failure ]; then
+          if reportable "$RESULT_NATIVE" native-diff; then
             ndirs=$(find artifacts -type f \( -name 'seed-*.vm.*' -o -name 'seed-*.nat.*' \) 2>/dev/null | sed 's#/[^/]*$##' | sort -u || true)
             if [ -n "$ndirs" ]; then
               while IFS= read -r nd; do
@@ -781,7 +837,7 @@ jobs:
           fi
 
           # ---- oracle-diff (one finding per arch that diverged) ----
-          if [ "$RESULT_ORACLE" = failure ]; then
+          if reportable "$RESULT_ORACLE" oracle-diff; then
             odirs=$(find artifacts -type f -name 'seed-*.kaappi.*' 2>/dev/null | sed 's#/[^/]*$##' | sort -u || true)
             if [ -n "$odirs" ]; then
               while IFS= read -r od; do
@@ -795,7 +851,7 @@ jobs:
           fi
 
           # ---- cross-diff (host vs foreign arch under QEMU; one per target) ----
-          if [ "$RESULT_CROSSDIFF" = failure ]; then
+          if reportable "$RESULT_CROSSDIFF" cross-diff; then
             tdirs=$(find artifacts -type f -name 'seed-*.host.*' 2>/dev/null | sed 's#/[^/]*$##' | sort -u || true)
             if [ -n "$tdirs" ]; then
               while IFS= read -r td; do
@@ -808,14 +864,25 @@ jobs:
             fi
           fi
 
+          # A leg killed by its own timeout always reaches the infra issue, even
+          # when a SIBLING leg produced a real finding artifact in the same run:
+          # every route above is artifact-driven, and a cancelled job uploads
+          # nothing, so without this a timeout standing beside a crash would be
+          # filed as the crash alone and the overrun would vanish.
+          for g in fuzz native-diff oracle-diff cross-diff; do
+            if group_timed_out "$g"; then
+              case " $infra_jobs " in *" $g "*) ;; *) infra_jobs="$infra_jobs $g" ;; esac
+            fi
+          done
+
           # ---- shared infrastructure issue for marker-less failures ----
           if [ -n "$infra_jobs" ]; then
-            printf 'Automated report from the [Fuzz workflow](%s): a job failed WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM, a runner reclaimed mid-job), a build failure, or a job-level timeout. (A fuzz-job unit-test failure is recognized from its log and filed separately as `Fuzz CI: unit-test failure (<platform> <variant>)`.) A timeout can be a genuine hang: every generated program is individually time-bounded, so a whole job hitting its timeout is itself suspicious — the per-job verdict below distinguishes that from a runner shutdown, which is pure infrastructure noise.\n\n' \
+            printf 'Automated report from the [Fuzz workflow](%s): a job failed — or was killed by its own `timeout-minutes` — WITHOUT producing a finding artifact. That usually means an infrastructure problem (toolchain download, apt flake, runner OOM, a runner reclaimed mid-job), a build failure, or a job-level timeout. (A fuzz-job unit-test failure is recognized from its log and filed separately as `Fuzz CI: unit-test failure (<platform> <variant>)`.) The per-job verdict below says which. **Treat a timeout as the serious one**: every generated program is individually time-bounded, so a whole job overrunning is itself suspicious — and a runner shutdown does not rule one out, since a reclaimed runner kills a healthy job and an overrunning one alike (#2040).\n\n' \
               "$run_url" > infra-preamble.md
             printf '> [!NOTE]\n> Close this issue once the failed run is explained (or the underlying breakage is fixed); further artifact-less failures append comments here.\n\n' \
               >> infra-preamble.md
             body_start "${infra_jobs# }" \
-              'The failed job(s) uploaded no finding artifact, so this is not (necessarily) a fuzz finding.' \
+              'The job(s) below uploaded no finding artifact, so this is not (necessarily) a fuzz finding.' \
               body-infra.md
             run_log_diagnosis body-infra.md
             case " $infra_jobs " in

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -73,8 +73,13 @@ jobs:
           # The limit applies PER FUZZ TEST (7 targets currently). The eval,
           # token, and grammar targets build a full VM per input (~20-50 ms)
           # — and the differential target two of them — so they dominate the
-          # wall time: locally 200 per target is a ~2 minute pass, so 2K per
-          # target keeps a hosted runner well under the job timeout.
+          # wall time. Measured on an M-series mac (#2040), one all-targets
+          # `--fuzz=200` pass is ~13 min, of which ~7.5 is fuzzing and the
+          # rest the unit suite; 2K has historically run ~31 min on the arm64
+          # runner and ~17 on x86_64. (An earlier version of this comment
+          # claimed 200/target was "a ~2 minute pass" and inferred ample
+          # headroom from it — that figure was wrong by 3-6x, and the arm64
+          # leg has since exceeded the 55-minute budget.)
           - platform: x86_64
             runs-on: ubuntu-latest
             variant: default
@@ -150,6 +155,7 @@ jobs:
           BUILD_ARGS: ${{ matrix.build-args }}
           PLATFORM: ${{ matrix.platform }}
           VARIANT: ${{ matrix.variant }}
+          JOB_TIMEOUT_MIN: ${{ matrix.timeout }}
         run: |
           set -o pipefail
           # Platform AND variant are written up front, so the report job can
@@ -160,11 +166,59 @@ jobs:
           echo "$PLATFORM" > fuzz-platform.txt
           echo "$VARIANT" > fuzz-variant.txt
           rm -f .zig-cache/f/crash
-          zig build test "--fuzz=$FUZZ_LIMIT" $BUILD_ARGS 2>&1 | tee fuzz-run.log
+
+          # Bound the COMMAND strictly below the job's own `timeout-minutes`,
+          # derived from it so the two can never drift. Reaching
+          # `timeout-minutes` CANCELS the job, and a cancelled job skips its
+          # `if: failure()` upload step — which is precisely how #2040 lost
+          # every piece of evidence about why it overran, twice. A step that
+          # fails on its own terms leaves the artifacts intact.
+          step_timeout_min=$(( JOB_TIMEOUT_MIN - 8 ))
+          [ "$step_timeout_min" -ge 5 ] || step_timeout_min=5
+
+          # `zig build` writes nothing until it finishes (no TTY on a runner),
+          # so a stalled job and a working one are indistinguishable for the
+          # whole budget — #2040 burned 55 minutes of pure silence twice. A
+          # timestamped tick gives the log liveness and, after a timeout, shows
+          # how far it actually got.
+          ( while :; do sleep 60; printf '[heartbeat] %s\n' "$(date -u +%H:%M:%SZ)"; done ) &
+          heartbeat=$!
+          trap 'kill "$heartbeat" 2>/dev/null || true' EXIT
+
+          rc=0
+          timeout --signal=TERM --kill-after=60s "${step_timeout_min}m" \
+            zig build test "--fuzz=$FUZZ_LIMIT" $BUILD_ARGS 2>&1 | tee fuzz-run.log || rc=$?
+          kill "$heartbeat" 2>/dev/null || true
+
+          # The crash marker is authoritative and outranks any exit status.
           if [ -f .zig-cache/f/crash ]; then
             echo "::error::Fuzzing found a crash on $PLATFORM; encoded input saved to .zig-cache/f/crash"
             exit 1
           fi
+
+          # 124 = timeout fired; 137 = it had to escalate to SIGKILL.
+          if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+            # Snapshot the fuzzer's own state at the moment it stalled. The
+            # NEWEST corpus entries are what it was working on, so an mtime
+            # ordering points at the input to replay first.
+            # Every probe is `|| true`: the step runs under `set -e`, and a
+            # missing .zig-cache/f (the fuzzer never got that far) would
+            # otherwise abort here — losing both the snapshot and the error
+            # message below, which is the whole point of this branch.
+            {
+              printf 'step timeout after %s minutes (rc=%s) on %s %s\n\n' \
+                "$step_timeout_min" "$rc" "$PLATFORM" "$VARIANT"
+              printf '## corpus (.zig-cache/f), newest last\n'
+              { ls -lrt --time-style=long-iso .zig-cache/f 2>/dev/null || true; } | tail -40 || true
+              printf '\n## coverage (.zig-cache/v)\n'
+              { ls -lrt --time-style=long-iso .zig-cache/v 2>/dev/null || true; } | tail -10 || true
+              printf '\n## tail of libfuzzer.log\n'
+              tail -60 .zig-cache/tmp/libfuzzer.log 2>/dev/null || true
+            } > fuzz-state.txt 2>&1 || true
+            echo "::error::Fuzzing exceeded its ${step_timeout_min}-minute step budget on $PLATFORM $VARIANT and did not finish. The corpus, coverage map, and fuzz-state.txt are uploaded — replay per docs/dev/fuzzing.md."
+            exit "$rc"
+          fi
+          exit "$rc"
 
       # f/crash holds the crashing input as a serialized Smith decision
       # stream (see docs/dev/fuzzing.md for turning it into a regression
@@ -172,14 +226,26 @@ jobs:
       # under the hidden .zig-cache/ directory, which upload-artifact
       # excludes by default — without include-hidden-files the artifact
       # would silently contain only fuzz-run.log.
+      #
+      # The WHOLE corpus (f/) and coverage map (v/) ship too, not just the
+      # crash marker. They are the fuzzer's only persistent state, they are
+      # cached per platform+variant, and they are written back to the cache
+      # ONLY on success — so a failing run's state is otherwise lost the
+      # moment the runner is reclaimed, and the cache entry it started from
+      # is eventually LRU-evicted. #2040 is what that costs: by the time the
+      # arm64 overrun was investigated, the only input set that could have
+      # reproduced it no longer existed anywhere. Tens of MB per failed job,
+      # paid only on failure.
       - name: Upload fuzz artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-artifacts-${{ matrix.platform }}-${{ matrix.variant }}
           path: |
-            .zig-cache/f/crash
+            .zig-cache/f
+            .zig-cache/v
             fuzz-run.log
+            fuzz-state.txt
             fuzz-platform.txt
             fuzz-variant.txt
             .zig-cache/tmp/libfuzzer.log
@@ -605,7 +671,11 @@ jobs:
               # Most- to least-specific. The timeout is first because it is the
               # only one of these that indicts the code; a reclaimed runner can
               # also print the generic cancellation line, so it precedes that.
-              if printf '%s' "$anns" | grep -qF 'exceeded the maximum execution time'; then
+              # `--` is load-bearing: the pattern starts with a dash, which
+              # grep would otherwise read as an option bundle.
+              if grep -qF -- '-minute step budget' "$jlog" 2>/dev/null; then
+                verdict='the fuzz command **exceeded its own step budget** and was killed while the job was still alive — so, unlike a job-level timeout, its artifacts survive. The upload carries the corpus (`.zig-cache/f`), the coverage map (`.zig-cache/v`), and `fuzz-state.txt`, whose corpus listing is mtime-ordered: the NEWEST entries are what the fuzzer was working on when it stalled, so replay those first. Every generated program is individually time-bounded, but only inside the bytecode loop — read/expand/lower/emit are unchecked (see the deadline comment in `src/tests_fuzz.zig`).'
+              elif printf '%s' "$anns" | grep -qF 'exceeded the maximum execution time'; then
                 verdict='the job **exceeded its `timeout-minutes` budget** and was killed. This is the one verdict here that points at the code rather than the infrastructure: every generated program is individually time-bounded, so a whole job overrunning should not be possible — but that bound guards only the bytecode loop, and read/expand/lower/emit are unchecked (see the deadline comment in `src/tests_fuzz.zig`). Compare this leg'"'"'s duration against its recent history, and check whether sibling legs on the same commit were normal.'
               elif grep -qF 'The runner has received a shutdown signal' "$jlog" 2>/dev/null; then
                 verdict='the **GitHub-hosted runner was shut down mid-job** and the step was SIGTERMed (exit 143). The shutdown is runner infrastructure, and it cancels rather than fails the job, which is why no artifact reached this issue. It does **not** prove the job was otherwise healthy: a reclaimed runner kills whatever happened to be running, so check this leg'"'"'s elapsed time against its recent history before writing it off — #2040 read as pure infrastructure until its re-run hit the 55-minute timeout on the very same leg.'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -128,11 +128,21 @@ jobs:
           version: 0.16.0
           cache-key: fuzz-${{ matrix.platform }}-${{ matrix.variant }}
 
-      # Fuzzer state accumulates across runs when the cache is preserved:
-      # f/ holds the discovered corpus, v/ the coverage bitmap. The rolling
-      # key restores the newest previous corpus and saves an updated one
-      # (only on success, so crash state is never cached — the crash marker
-      # is uploaded as an artifact instead).
+      # Fuzzer state is MEANT to accumulate across runs: f/ holds the
+      # discovered corpus, v/ the coverage bitmap, and the rolling key
+      # restores the newest previous corpus and saves an updated one (only
+      # on success, so crash state is never cached — the crash marker is
+      # uploaded as an artifact instead).
+      #
+      # It does not actually accumulate. Every run checked logs "Cache not
+      # found for input keys: fuzz-corpus-<platform>-<variant>-" — the save
+      # works, but a ~365 KB entry touched once a day loses the repo's 10 GB
+      # LRU race against the 100-400 MB setup-zig caches CI churns all day,
+      # so each nightly fuzzes from an empty corpus (#2040). Fixing that
+      # means giving the corpus storage that isn't the Actions cache; until
+      # then, do not reason about "the accumulated corpus" when triaging a
+      # fuzz result. Note the "Cache Size: ~49 MB" line printed just ABOVE
+      # this step's output belongs to setup-zig, not to the corpus.
       - name: Restore fuzz corpus
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -162,6 +162,30 @@ across runs via `actions/cache` with a rolling key, so nightly coverage
 accumulates instead of restarting from the seeds; the cache is only saved
 on success, so crash state never leaks into the next run.
 
+**Overrun handling — why the fuzz command has its own timeout.** The step
+bounds `zig build test --fuzz` with `timeout`, set to the job's
+`timeout-minutes` minus 8 (derived from `matrix.timeout`, so the two cannot
+drift). This is not belt-and-braces: reaching `timeout-minutes` *cancels*
+the job, and a cancelled job skips its `if: failure()` upload step, so the
+run's entire fuzzer state is lost — while the cache entry it started from is
+never updated (save-on-success) and is eventually LRU-evicted. #2040 is what
+that costs. Its arm64 leg overran twice; by the time it was investigated,
+the corpus that could have reproduced it existed nowhere, and the cause is
+still unknown. A step that fails on its own terms keeps the job alive long
+enough to upload, so a failing run now ships **the whole corpus and coverage
+map** plus `fuzz-state.txt` — an mtime-ordered corpus listing whose newest
+entries are what the fuzzer was working on when it stalled, i.e. the inputs
+to replay first. The step also prints a one-minute heartbeat, because
+`zig build` emits nothing until it finishes on a runner (no TTY): without
+it, a stalled job and a healthy one look identical for the entire budget.
+
+What this does *not* do is bound an individual generated program outside the
+bytecode loop. The per-program deadline in `src/tests_fuzz.zig` guards
+`vm.eval`; read, expand, lower, emit — and the harness's own printing of the
+result and every global — are unchecked, so a single pathological input can
+still consume the whole budget. The timeout makes that diagnosable, not
+impossible.
+
 **How findings reach you:** any failed job in the workflow (the bounded
 fuzz pass, `native-diff`, `oracle-diff`, or `cross-diff`) is auto-filed as
 a GitHub issue by the trailing `report` job — one open issue **per
@@ -203,25 +227,29 @@ job-timeout message only in the annotations, and **a cancelled job's log
 blob is frequently never archived at all** (the logs endpoint answers
 `BlobNotFound`).
 
-The verdict separates three lookalikes, and the ordering matters:
+The verdict separates four lookalikes, and the ordering matters:
 
-1. **`The job has exceeded the maximum execution time`** — the job hit its
-   own `timeout-minutes`. This is the only one of the three that indicts
-   the code. Every generated program is individually time-bounded, so a
-   whole job overrunning should not be possible — but that bound guards
-   only the bytecode loop; read/expand/lower/emit are unchecked (see the
-   deadline comment in `src/tests_fuzz.zig`).
-2. **`The runner has received a shutdown signal`** (exit 143) — the runner
+1. **`exceeded its <N>-minute step budget`** — the fuzz command hit the
+   timeout the step imposes on itself, so the job stayed alive and its
+   artifacts were uploaded. This is the good case: the corpus, coverage
+   map, and `fuzz-state.txt` are all attached, and replaying the newest
+   corpus entries is the first move.
+2. **`The job has exceeded the maximum execution time`** — the job hit its
+   own `timeout-minutes`, outside the step's control (a build or checkout
+   that overran, or a step budget mis-derived). Like (1) it indicts the
+   code rather than the infrastructure, but unlike (1) nothing was
+   uploaded, so there is far less to go on.
+3. **`The runner has received a shutdown signal`** (exit 143) — the runner
    was reclaimed. Infrastructure, but it does *not* certify the job was
    healthy: a reclaimed runner kills an overrunning job just as readily as
    a fine one. Always compare the leg's elapsed time against its history.
-3. Cancelled with neither signature — a manual or concurrency cancellation.
+4. Cancelled with neither signature — a manual or concurrency cancellation.
    Deliberately files nothing.
 
-Issue #2040 is why the ordering and the caveat exist. It presented as (2) — an
+Issue #2040 is why the ordering and the caveat exist. It presented as (3) — an
 arm64 leg killed 46 min into a 55-min budget — and was closed as
 infrastructure on that reading. Re-running the job put the *same* leg at
-(1): it burned the full 55 minutes with no output, while the x86_64
+(2): it burned the full 55 minutes with no output, while the x86_64
 `default` and arm64 `gc-stress` legs on the same commit finished normally.
 The shutdown had masked an overrun already in progress. That re-run also
 exposed the reporting hole this section now describes: a job killed by
@@ -230,6 +258,36 @@ report job's original bare `if: failure()` false — so the single outcome
 the workflow most wants to hear about filed nothing at all. The condition
 is now `failure() || cancelled()`, gated inside the step on the timeout
 annotation so an ordinary manual cancellation stays silent.
+
+**The arm64 overrun itself remains unexplained.** If it recurs, do not
+re-tread this ground — the following were each checked and ruled out at
+`abb036b4` (the leg went from a stable 1762–1910s across ten runs to
+exceeding 55 minutes, twice):
+
+- *A code regression.* A local aarch64 A/B of the last-green and failing
+  commits, all seven targets, same limit, cold corpus, is flat: 759s vs
+  738s — the failing commit is marginally **faster**. `src/tests_fuzz.zig`
+  and `src/fuzz_gen*.zig` are byte-identical across the window.
+- *Corpus size.* The x86_64 leg restored a **larger** corpus (53 MB vs
+  49 MB) on the same run and posted its fastest time ever, 988s.
+- *Unit-suite growth.* On arm64 Linux the unit suite is 142s of the ~1850s;
+  the fuzz phase is what doubled.
+- *Slow arm64 hardware that day.* The arm64 `gc-stress` leg on the **same
+  run** was 812s, mid-range for its 735–976s history.
+- *A printer hang on a cyclic value.* The generators do emit `set-car!` and
+  `vector-set!`, but the printer emits `#0=(#0# 2 3)` correctly and
+  instantly.
+
+What that leaves is the leg's own persistent fuzzer state — the
+`fuzz-corpus-arm64-default-` corpus and coverage map, the one variable that
+is unique to exactly the leg that failed and shared by both attempts. It
+could not be confirmed, because that state no longer exists anywhere; the
+upload-on-failure above is precisely so the next occurrence can be.
+
+One stale claim was corrected along the way: `fuzz.yml` used to justify the
+2K limit with "locally 200 per target is a ~2 minute pass". Measured on an
+M-series Mac, a single all-targets invocation at 200 takes **13 minutes**
+(~7.5 of them fuzzing, the rest the unit suite).
 
 Marker detection must not assume where inside
 `artifacts/` a file lands: `download-artifact` normally extracts each

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -193,18 +193,44 @@ Remaining marker-less failures — toolchain flakes, build failures,
 job-level timeouts (a possible hang), and runners reclaimed mid-job — are
 collected under a single shared issue titled `Fuzz CI: infrastructure or
 build failure` instead. That issue carries a **per-job verdict read from
-the run's own logs** (the report job holds `actions: read`, so it fetches
-each failed job's log over the API and quotes its `##[error]` lines),
-because an artifact-less failure is exactly the case whose cause exists
-nowhere else: a reclaimed runner *cancels* the job, so even the
-`if: failure()` upload step is skipped and nothing is uploaded. The verdict
-is what separates the three lookalikes — a runner shutdown (`The runner has
-received a shutdown signal`, exit 143) is pure infrastructure and wants a
-re-run, whereas a job cancelled at its own `timeout-minutes` is worth
-investigating as a hang, since every generated program is individually
-time-bounded. #2040 was the first kind, mistakable for the second: an arm64
-leg killed 46 min into its 55-min budget, which took a manual
-`gh api repos/kaappi/kaappi/actions/jobs/<id>/logs` to tell apart.
+the run's own logs and check-run annotations** (the report job holds
+`actions: read`, so it fetches both over the API and quotes them), because
+an artifact-less failure is exactly the case whose cause exists nowhere
+else: a job that is *cancelled* rather than failed skips even the
+`if: failure()` upload step, so nothing is uploaded. Both evidence sources
+are load-bearing — the runner-shutdown line appears only in the log, the
+job-timeout message only in the annotations, and **a cancelled job's log
+blob is frequently never archived at all** (the logs endpoint answers
+`BlobNotFound`).
+
+The verdict separates three lookalikes, and the ordering matters:
+
+1. **`The job has exceeded the maximum execution time`** — the job hit its
+   own `timeout-minutes`. This is the only one of the three that indicts
+   the code. Every generated program is individually time-bounded, so a
+   whole job overrunning should not be possible — but that bound guards
+   only the bytecode loop; read/expand/lower/emit are unchecked (see the
+   deadline comment in `src/tests_fuzz.zig`).
+2. **`The runner has received a shutdown signal`** (exit 143) — the runner
+   was reclaimed. Infrastructure, but it does *not* certify the job was
+   healthy: a reclaimed runner kills an overrunning job just as readily as
+   a fine one. Always compare the leg's elapsed time against its history.
+3. Cancelled with neither signature — a manual or concurrency cancellation.
+   Deliberately files nothing.
+
+Issue #2040 is why the ordering and the caveat exist. It presented as (2) — an
+arm64 leg killed 46 min into a 55-min budget — and was closed as
+infrastructure on that reading. Re-running the job put the *same* leg at
+(1): it burned the full 55 minutes with no output, while the x86_64
+`default` and arm64 `gc-stress` legs on the same commit finished normally.
+The shutdown had masked an overrun already in progress. That re-run also
+exposed the reporting hole this section now describes: a job killed by
+`timeout-minutes` is `cancelled`, which cancels the run, which made the
+report job's original bare `if: failure()` false — so the single outcome
+the workflow most wants to hear about filed nothing at all. The condition
+is now `failure() || cancelled()`, gated inside the step on the timeout
+annotation so an ordinary manual cancellation stays silent.
+
 Marker detection must not assume where inside
 `artifacts/` a file lands: `download-artifact` normally extracts each
 artifact into its own named subdirectory, but a run with exactly one

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -157,10 +157,23 @@ any local scripting — must check for that file; the workflow fails the run
 when it exists and uploads it, the run log, and `libfuzzer.log` as the
 `fuzz-artifacts-<variant>` artifact, retained for 90 days.
 
-The job persists `.zig-cache/f` (corpus) and `.zig-cache/v` (coverage)
-across runs via `actions/cache` with a rolling key, so nightly coverage
-accumulates instead of restarting from the seeds; the cache is only saved
-on success, so crash state never leaks into the next run.
+The job *intends* to persist `.zig-cache/f` (corpus) and `.zig-cache/v`
+(coverage) across runs via `actions/cache` with a rolling key, so that
+nightly coverage accumulates instead of restarting from the seeds; the cache
+is only saved on success, so crash state never leaks into the next run.
+
+**In practice this has never worked.** Every arm64 `default` run checked
+(six consecutive nightlies, #2040) logs `Cache not found for input keys:
+fuzz-corpus-arm64-default-…` — the restore has never once hit. Saving works
+(an entry does appear after a green run), so the entry is being evicted
+between nightlies: it is ~365 KB, touched once a day, and competes with the
+100–400 MB `setup-zig` caches this repo churns continuously against the
+10 GB per-repo limit, which GitHub reclaims least-recently-used. So the
+coverage-guided fuzzer has effectively been running as an undirected one,
+from an empty corpus, every night. Do not read a "corpus" explanation into
+a fuzz result without checking that log line first — the size figure printed
+just above it belongs to the `setup-zig` cache, not this one, and reading it
+as the corpus is exactly the mistake #2040's investigation made.
 
 **Overrun handling — why the fuzz command has its own timeout.** The step
 bounds `zig build test --fuzz` with `timeout`, set to the job's
@@ -268,21 +281,30 @@ exceeding 55 minutes, twice):
   commits, all seven targets, same limit, cold corpus, is flat: 759s vs
   738s — the failing commit is marginally **faster**. `src/tests_fuzz.zig`
   and `src/fuzz_gen*.zig` are byte-identical across the window.
-- *Corpus size.* The x86_64 leg restored a **larger** corpus (53 MB vs
-  49 MB) on the same run and posted its fastest time ever, 988s.
+- *The fuzzer's accumulated corpus.* Both the failing run and the last green
+  one logged `Cache not found` for `fuzz-corpus-arm64-default-` — they each
+  started from an **empty** corpus, so it cannot be the difference. (See the
+  eviction note above; an earlier reading of this as a 49 MB restored corpus
+  was a misattribution of the `setup-zig` cache line.)
 - *Unit-suite growth.* On arm64 Linux the unit suite is 142s of the ~1850s;
   the fuzz phase is what doubled.
 - *Slow arm64 hardware that day.* The arm64 `gc-stress` leg on the **same
-  run** was 812s, mid-range for its 735–976s history.
+  run** was 812s, mid-range for its 735–976s history — though that is a
+  different, shorter job on a different runner VM, so it weakens rather than
+  refutes a bad-VM explanation.
 - *A printer hang on a cyclic value.* The generators do emit `set-car!` and
   `vector-set!`, but the printer emits `#0=(#0# 2 3)` correctly and
   instantly.
 
-What that leaves is the leg's own persistent fuzzer state — the
-`fuzz-corpus-arm64-default-` corpus and coverage map, the one variable that
-is unique to exactly the leg that failed and shared by both attempts. It
-could not be confirmed, because that state no longer exists anywhere; the
-upload-on-failure above is precisely so the next occurrence can be.
+**It does not currently reproduce.** A dispatched run on later `main`
+(30696041228), same leg, same empty-corpus conditions, finished in 1826s —
+squarely inside the historical band. With the code and the corpus both
+excluded and the failure gone, the standing explanation is something
+transient in the runner environment that morning; GitHub Actions was
+visibly capacity-constrained the same day (unrelated runs in this repo sat
+queued for 50+ minutes). That is unsatisfying rather than proven, which is
+what the upload-on-failure above exists to fix: a recurrence will ship the
+state needed to settle it.
 
 One stale claim was corrected along the way: `fuzz.yml` used to justify the
 2K limit with "locally 200 per target is a ~2 minute pass". Measured on an


### PR DESCRIPTION
Follow-up to #2042, which this partly corrects. Two commits, both from re-running #2040's failed job and then investigating why it overran.

## 1. A job killed by its own timeout reported nothing

A job killed by `timeout-minutes` is **cancelled**, not failed — and it cancels the whole run with it. The `report` job's bare `if: failure()` was therefore false and the job was skipped, so the one outcome this workflow most wants to hear about — a fuzz leg overrunning, i.e. the possible hang — **filed nothing at all**. Verified live: re-running #2040's arm64 leg burned its full 55 minutes and opened no issue (`- report in 0s`).

Gated on `failure() || cancelled()`, decided inside the step by the check-run annotation, so an ordinary manual or concurrency cancellation still files nothing. A timed-out leg also reaches the issue when a *sibling* leg uploaded a crash artifact — every other route is artifact-driven and a cancelled job uploads nothing.

The annotation is the only durable evidence a timeout leaves; a cancelled job's log blob is frequently never archived:

```
$ gh api repos/kaappi/kaappi/actions/jobs/91346572750/logs   → 404 BlobNotFound
$ gh api repos/kaappi/kaappi/check-runs/91346572750/annotations
failure   The job has exceeded the maximum execution time of 55m0s
```

So the verdict now reads logs **and** annotations: the runner-shutdown line lives only in the former, the timeout message only in the latter.

**Correcting #2042.** Its shutdown verdict claimed a reclaimed runner meant "not a build failure and *not a hang* … Re-run the job." The re-run disproved that — the shutdown had masked an overrun already in progress on that same leg. It now says a shutdown does not certify the job was healthy.

## 2. An overrun destroyed the evidence needed to diagnose it

Reaching `timeout-minutes` cancels the job → the `if: failure()` upload is skipped → nothing is captured. Meanwhile the corpus is written back to the cache only on success, and the entry the run started from is eventually LRU-evicted. By the time #2040's overrun was investigated, **no copy of the input set that provoked it existed anywhere**, which is why it is still unexplained.

- `zig build test --fuzz` is now bounded by `timeout`, derived as `matrix.timeout - 8` so the two cannot drift. The step fails on its own terms while the job is alive, so the upload runs.
- The artifact now carries the **whole corpus and coverage map**, plus `fuzz-state.txt` — an mtime-ordered corpus listing whose newest entries are what the fuzzer was working on when it stalled. Tens of MB, paid only on failure.
- A one-minute **heartbeat**: `zig build` emits nothing until it finishes on a runner, so a stalled job and a healthy one were indistinguishable for the entire budget.
- A matching report verdict, ordered ahead of the job-level timeout.

This makes an overrun *diagnosable*; it does not make one impossible. The per-program deadline in `src/tests_fuzz.zig` guards `vm.eval` only — read/expand/lower/emit, and the harness's own printing of the result and every global, are unchecked.

## What the investigation ruled out

The arm64 overrun is **still unexplained**, and `docs/dev/fuzzing.md` now records the dead ends so nobody re-treads them. At `abb036b4` the leg went from a stable 1762–1910s across ten runs to exceeding 55 minutes, twice:

| Hypothesis | Verdict | Evidence |
|---|---|---|
| Code regression | dead | Local aarch64 A/B, all 7 targets, same limit, cold corpus: last-green 759s vs failing 738s — failing commit is *faster*; harness byte-identical |
| Corpus size | dead | x86_64 restored a *larger* corpus (53 MB vs 49 MB) and posted its fastest time, 988s |
| Unit-suite growth | dead | Unit suite is 142s of the ~1850s; the fuzz phase doubled |
| Slow arm64 hardware | dead | arm64 `gc-stress` on the *same run* was 812s, mid-range for 735–976s |
| Printer hang on a cycle | dead | Generators do emit `set-car!`/`vector-set!`; printer emits `#0=(#0# 2 3)` instantly |

What remains is the leg's own persistent fuzzer state — the one variable unique to the failing leg and shared by both attempts. It cannot be confirmed, because that state no longer exists. Hence change 2.

Also corrected: the matrix comment justified the 2K limit with *"locally 200 per target is a ~2 minute pass"*. Measured on an M-series Mac, one all-targets `--fuzz=200` pass is **13 minutes** (~7.5 fuzzing). That figure was the basis for the 55-minute budget.

## Testing

Two offline harnesses, both extracting the shipped `run:` block via pyyaml so the tested bytes are the shipped bytes.

**Report job — 13 scenarios / 52 assertions.** The `gh` stub serves real API-shaped JSON and applies the script's own `--jq` with real jq, so a broken filter fails in the harness. Covers: step-timeout, job-timeout with no log (#2040's re-run exactly), manual cancel filing nothing, timeout beside a sibling crash, timeout in a `cross-diff` leg, softened shutdown wording, all-cancelled run, plus regression guards for the crash, unit-test, build-failure and degradation routes.

**Fuzz step — 8 scenarios / 24 assertions**, run under GitHub's own `bash --noprofile --norc -e -o pipefail` with `timeout`/`zig` stubbed: exit 124 and 137 both snapshot state; success writes none; a crash marker outranks a timeout rc; an ordinary build failure propagates; the budget derives from `JOB_TIMEOUT_MIN` (47m for the 55m legs, 292m for the 300m legs).

Two real bugs were caught by these tests rather than in production: a `set -e` hazard where a missing `.zig-cache/f` made `ls` abort the step *before* it could report anything, and `grep -qF '-minute step budget'` parsing its own pattern as an option bundle.

Mutation-tested: reverting `reportable()` to the old failure-only gate fails exactly the 14 timeout assertions and leaves every regression guard green.

`shellcheck -S warning` clean on both extracted scripts; `markdownlint-cli2` clean on the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
