### PR TITLE
Phase 3.9: eight large-and-thin SRFIs — 1579 assertions, and bitvector-logical-shift shifts the wrong way in both directions

### DIFF
--- a/tests/scheme/srfi/srfi113-audit.scm
+++ b/tests/scheme/srfi/srfi113-audit.scm
@@ -1,0 +1,514 @@
+;;; Audit: lib/srfi/113.sld (SRFI 113 — Sets and Bags)
+;;; Systematic audit v2, Phase 3.9 (docs/audit-strategy.md, tracking #1890).
+;;;
+;;; Oracle: SRFI 113, https://srfi.schemers.org/srfi-113/srfi-113.html, plus its
+;;; own reference implementation (scheme-requests-for-implementation/srfi-113,
+;;; sets/sets-impl.scm) where the prose is silent. Every result below was also
+;;; run under chibi-scheme 0.12.0, an independent SRFI 113 implementation.
+;;;
+;;; Two divergences from chibi are chibi's defects, not Kaappi's, and are
+;;; asserted here in Kaappi's favour because the spec text settles them:
+;;;
+;;;   * bag-sum "the count of each unique element in the result is equal to
+;;;     the sum of the counts of that element in the arguments" — chibi
+;;;     doubles the count of an element present only in the second bag.
+;;;   * bag-unfold — chibi collapses duplicate elements, producing a set.
+;;;   * bag-replace / bag-search!'s update continuation — the reference's
+;;;     sob-replace! writes the OLD count back (hash-table-set! ht element
+;;;     value), and sob-search!'s update decrements then increments, so both
+;;;     preserve multiplicity. chibi collapses to 1; Kaappi preserves.
+;;;
+;;; What this file deliberately does NOT assert: the two chibi divergences
+;;; where the spec says only "it is an error" (an element failing the
+;;; comparator's type test; two sets with different comparators combined),
+;;; and bag-product with n=0, where retaining or dropping a zero-count entry
+;;; is a representation choice no procedure in the SRFI can observe portably.
+;;;
+;;; Portability: sets and bags are unordered, so nothing asserts iteration
+;;; order — every list result is sorted, and every bag result is compared as
+;;; a sorted element/count alist.
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi113-audit.scm
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 64) (srfi 113) (srfi 128))
+
+(test-begin "srfi113 audit")
+
+(define cmp (make-default-comparator))
+(define (S . e) (apply set cmp e))
+(define (B . e) (apply bag cmp e))
+
+(define (isort less l)
+  (let loop ((in l) (out '()))
+    (if (null? in) out
+        (loop (cdr in)
+              (let ins ((o out))
+                (cond ((null? o) (list (car in)))
+                      ((less (car in) (car o)) (cons (car in) o))
+                      (else (cons (car o) (ins (cdr o))))))))))
+(define (sl s) (isort < (set->list s)))
+(define (bl b) (isort < (bag->list b)))
+;; canonical bag shape: a sorted ((element . count) ...) alist
+(define (ba b) (isort (lambda (x y) (< (car x) (car y))) (bag->alist b)))
+
+(define (raises? thunk)
+  (call-with-current-continuation
+   (lambda (k) (with-exception-handler (lambda (e) (k #t)) (lambda () (thunk) #f)))))
+
+;;; ------------------------------------------------------------------
+;;; Basic construction and predicates
+;;; ------------------------------------------------------------------
+
+(test-assert "set? on a set" (set? (S 1)))
+(test-assert "set? on a bag is #f" (not (set? (B 1))))
+(test-assert "set? on a non-collection is #f" (not (set? 1)))
+(test-assert "bag? on a bag" (bag? (B 1)))
+(test-assert "bag? on a set is #f" (not (bag? (S 1))))
+(test-equal "a set collapses duplicates" '(1 2) (sl (S 1 2 1 2 1)))
+(test-equal "a bag keeps duplicates" '(1 1 1 2 2) (bl (B 1 2 1 2 1)))
+(test-equal "set-size counts unique elements" 3 (set-size (S 1 2 3)))
+(test-equal "bag-size counts multiplicities" 3 (bag-size (B 1 1 2)))
+(test-equal "bag-unique-size counts unique elements" 2 (bag-unique-size (B 1 1 2)))
+(test-assert "set-empty? on the empty set" (set-empty? (S)))
+(test-assert "set-empty? on a non-empty set" (not (set-empty? (S 1))))
+(test-assert "bag-empty? on the empty bag" (bag-empty? (B)))
+(test-assert "bag-empty? on a non-empty bag" (not (bag-empty? (B 1))))
+(test-assert "set-contains? present" (set-contains? (S 1) 1))
+(test-assert "set-contains? absent" (not (set-contains? (S 1) 2)))
+(test-assert "bag-contains? present" (bag-contains? (B 1) 1))
+(test-assert "bag-contains? absent" (not (bag-contains? (B 1) 2)))
+(test-equal "set-member present" 1 (set-member (S 1) 1 'dflt))
+(test-equal "set-member absent returns the default" 'dflt (set-member (S 1) 2 'dflt))
+(test-equal "bag-member present" 1 (bag-member (B 1) 1 'dflt))
+(test-equal "bag-member absent returns the default" 'dflt (bag-member (B 1) 2 'dflt))
+(test-assert "set-element-comparator is the one it was built with"
+             (eq? cmp (set-element-comparator (S 1))))
+(test-assert "bag-element-comparator is the one it was built with"
+             (eq? cmp (bag-element-comparator (B 1))))
+(test-assert "set-comparator is a comparator" (comparator? set-comparator))
+(test-assert "bag-comparator is a comparator" (comparator? bag-comparator))
+(test-assert "set-comparator's equality ignores insertion order"
+             ((comparator-equality-predicate set-comparator) (S 1 2) (S 2 1)))
+(test-assert "bag-comparator's equality compares multiplicities"
+             ((comparator-equality-predicate bag-comparator) (B 1 1) (B 1 1)))
+(test-assert "bag-comparator's equality separates differing multiplicities"
+             (not ((comparator-equality-predicate bag-comparator) (B 1 1) (B 1))))
+(test-assert "set-comparator hashes to an exact integer"
+             (exact-integer? ((comparator-hash-function set-comparator) (S 1 2))))
+(test-assert "bag-comparator hashes to an exact integer"
+             (exact-integer? ((comparator-hash-function bag-comparator) (B 1 1))))
+
+;;; ------------------------------------------------------------------
+;;; bag-element-count. "Returns the number of occurrences of element in bag."
+;;; ------------------------------------------------------------------
+
+(test-equal "bag-element-count of a present element" 2 (bag-element-count (B 1 1 2) 1))
+(test-equal "bag-element-count of a singleton" 1 (bag-element-count (B 1 1 2) 2))
+(test-equal "bag-element-count of an absent element is 0" 0 (bag-element-count (B 1 1 2) 9))
+(test-equal "bag-element-count on the empty bag is 0" 0 (bag-element-count (B) 1))
+
+;;; ------------------------------------------------------------------
+;;; The pure set-theory operations must not touch either argument, must
+;;; return a fresh object, and must compute the documented multiplicity.
+;;; ------------------------------------------------------------------
+
+(define (check-set-purity name op a b expected)
+  (let* ((s1 (apply S a)) (s2 (apply S b))
+         (before1 (sl s1)) (before2 (sl s2))
+         (r (op s1 s2)))
+    (test-equal (string-append name ": result") expected (sl r))
+    (test-equal (string-append name ": first argument unchanged") before1 (sl s1))
+    (test-equal (string-append name ": second argument unchanged") before2 (sl s2))
+    (test-assert (string-append name ": result is not the first argument") (not (eq? r s1)))
+    (test-assert (string-append name ": mutating the result does not reach the argument")
+                 (begin (set-adjoin! r 99) (equal? before1 (sl s1))))))
+
+(check-set-purity "set-union" set-union '(1 2 3) '(3 4 5) '(1 2 3 4 5))
+(check-set-purity "set-intersection" set-intersection '(1 2 3) '(3 4 5) '(3))
+(check-set-purity "set-difference" set-difference '(1 2 3) '(3 4 5) '(1 2))
+(check-set-purity "set-xor" set-xor '(1 2 3) '(3 4 5) '(1 2 4 5))
+
+(define (check-bag-purity name op a b expected)
+  (let* ((b1 (apply B a)) (b2 (apply B b))
+         (before1 (ba b1)) (before2 (ba b2))
+         (r (op b1 b2)))
+    (test-equal (string-append name ": result") expected (ba r))
+    (test-equal (string-append name ": first argument unchanged") before1 (ba b1))
+    (test-equal (string-append name ": second argument unchanged") before2 (ba b2))
+    (test-assert (string-append name ": result is not the first argument") (not (eq? r b1)))
+    (test-assert (string-append name ": mutating the result does not reach the argument")
+                 (begin (bag-adjoin! r 99) (equal? before1 (ba b1))))))
+
+;; "For bag-union, the number of equal elements in the result is the largest
+;;  number of equal elements in any of the original bags."
+(check-bag-purity "bag-union" bag-union '(1 1 1 2) '(1 2 2 3) '((1 . 3) (2 . 2) (3 . 1)))
+;; "For bag-intersection, ... the smallest number ..."
+(check-bag-purity "bag-intersection" bag-intersection '(1 1 1 2) '(1 2 2 3) '((1 . 1) (2 . 1)))
+;; "For bag-difference, ... the number in the first bag, minus the number in
+;;  the other bags (but not less than zero)."
+(check-bag-purity "bag-difference" bag-difference '(1 1 1 2) '(1 2 2 3) '((1 . 2)))
+(check-bag-purity "bag-xor" bag-xor '(1 1 1 2) '(1 2 2 3) '((1 . 2) (2 . 1) (3 . 1)))
+;; "the count of each unique element in the result is equal to the sum of the
+;;  counts of that element in the arguments"
+(check-bag-purity "bag-sum" bag-sum '(1 1 1 2) '(1 2 2 3) '((1 . 4) (2 . 3) (3 . 1)))
+
+(test-equal "bag-difference floors at zero, it does not go negative"
+            '() (ba (bag-difference (B 1) (B 1 1 1))))
+(test-equal "bag-difference subtracts every later bag"
+            '((1 . 2)) (ba (bag-difference (B 1 1 1 1 1) (B 1) (B 1 1))))
+(test-equal "bag-union takes the maximum across three bags"
+            '((1 . 3)) (ba (bag-union (B 1) (B 1 1) (B 1 1 1))))
+(test-equal "bag-intersection takes the minimum across three bags"
+            '((1 . 1)) (ba (bag-intersection (B 1 1 1) (B 1 1) (B 1))))
+(test-equal "bag-sum adds across three bags" '((1 . 3)) (ba (bag-sum (B 1) (B 1) (B 1))))
+(test-equal "bag-xor of disjoint bags keeps both counts"
+            '((1 . 2) (2 . 3)) (ba (bag-xor (B 1 1) (B 2 2 2))))
+(test-equal "bag-xor of equal bags is empty" '() (ba (bag-xor (B 1 1) (B 1 1))))
+(test-equal "set-union with no other sets copies" '(1 2) (sl (set-union (S 1 2))))
+(test-equal "bag-union with no other bags copies" '((1 . 2)) (ba (bag-union (B 1 1))))
+
+;; The `!` twins are linear-update: the spec permits, but does not require,
+;; mutation, so only the RETURNED value is asserted.
+(test-equal "set-union! returns the union" '(1 2 3) (sl (set-union! (S 1 2) (S 2 3))))
+(test-equal "set-intersection! returns the intersection" '(2) (sl (set-intersection! (S 1 2) (S 2 3))))
+(test-equal "set-difference! returns the difference" '(1) (sl (set-difference! (S 1 2) (S 2 3))))
+(test-equal "set-xor! returns the symmetric difference" '(1 3) (sl (set-xor! (S 1 2) (S 2 3))))
+(test-equal "bag-union! returns the maximum counts"
+            '((1 . 3) (2 . 2) (3 . 1)) (ba (bag-union! (B 1 1 1 2) (B 1 2 2 3))))
+(test-equal "bag-intersection! returns the minimum counts"
+            '((1 . 1) (2 . 1)) (ba (bag-intersection! (B 1 1 1 2) (B 1 2 2 3))))
+(test-equal "bag-difference! returns the floored difference"
+            '((1 . 2)) (ba (bag-difference! (B 1 1 1 2) (B 1 2 2 3))))
+(test-equal "bag-xor! returns the absolute differences"
+            '((1 . 2) (2 . 1) (3 . 1)) (ba (bag-xor! (B 1 1 1 2) (B 1 2 2 3))))
+(test-equal "bag-sum! returns the summed counts"
+            '((1 . 4) (2 . 3) (3 . 1)) (ba (bag-sum! (B 1 1 1 2) (B 1 2 2 3))))
+
+;;; ------------------------------------------------------------------
+;;; bag-product. "the count of each unique element in the bag is equal to
+;;; the count of that element in bag multiplied by n."
+;;; ------------------------------------------------------------------
+
+(test-equal "bag-product multiplies every count" '((1 . 6) (2 . 3)) (ba (bag-product 3 (B 1 1 2))))
+(test-equal "bag-product 1 is the identity" '((1 . 2)) (ba (bag-product 1 (B 1 1))))
+(test-equal "bag-product does not mutate its argument"
+            '((1 . 2)) (let ((b (B 1 1))) (bag-product 3 b) (ba b)))
+(test-equal "bag-product! returns the multiplied bag"
+            '((1 . 6)) (ba (bag-product! 3 (B 1 1))))
+(test-equal "bag-product on the empty bag is empty" '() (ba (bag-product 5 (B))))
+(test-equal "bag-product then bag-size" 6 (bag-size (bag-product 3 (B 1 1))))
+(test-equal "bag-product then bag->list length" 6 (length (bag->list (bag-product 3 (B 1 1)))))
+
+;;; ------------------------------------------------------------------
+;;; bag-increment! / bag-decrement!
+;;; "Linear update procedures that return a bag with the same elements as
+;;;  bag, but with the element count of element in bag increased or
+;;;  decreased by the exact integer count (but not less than zero)."
+;;; ------------------------------------------------------------------
+
+(test-equal "bag-increment! on a present element"
+            '((1 . 4)) (ba (bag-increment! (B 1) 1 3)))
+(test-equal "bag-increment! on an absent element inserts it"
+            '((1 . 1) (9 . 2)) (ba (bag-increment! (B 1) 9 2)))
+(test-equal "bag-increment! by 0 is the identity" '((1 . 1)) (ba (bag-increment! (B 1) 1 0)))
+(test-equal "bag-decrement! reduces the count" '((1 . 1)) (ba (bag-decrement! (B 1 1 1) 1 2)))
+(test-equal "bag-decrement! to exactly zero removes the element"
+            '() (ba (bag-decrement! (B 1 1) 1 2)))
+(test-equal "bag-decrement! below zero removes the element rather than going negative"
+            '() (ba (bag-decrement! (B 1) 1 5)))
+(test-equal "bag-decrement! of an absent element changes nothing"
+            '((1 . 1)) (ba (bag-decrement! (B 1) 9 1)))
+
+;; FAIL: #2085 (bag-increment! with a negative count is not clamped at zero, and
+;;              the resulting negative multiplicity makes bag->list, bag-fold and
+;;              bag-for-each loop forever)
+;; (test-equal "bag-increment! with a negative count is clamped at zero"
+;;             0 (bag-element-count (bag-increment! (B 1 1) 1 -5) 1))
+;; FAIL: #2085
+;; (test-equal "a bag built by bag-increment! with a negative count still lists"
+;;             0 (length (bag->list (bag-increment! (B 1 1) 1 -5))))
+;; FAIL: #2085
+;; (test-assert "bag-product with a negative n does not produce a negative count"
+;;              (>= (bag-size (bag-product -1 (B 1 1))) 0))
+
+;; Discriminating controls: the same loops terminate for zero and positive
+;; multiplicities, so the non-termination is specific to a negative count.
+(test-equal "bag->list terminates for a zero-count bag" 0 (length (bag->list (bag-product 0 (B 1)))))
+(test-equal "bag->list terminates for a positive-count bag"
+            3 (length (bag->list (bag-product 3 (B 1)))))
+(test-equal "bag-fold terminates for a positive-count bag"
+            3 (bag-fold (lambda (e a) (+ a 1)) 0 (bag-product 3 (B 1))))
+
+;;; ------------------------------------------------------------------
+;;; Set/bag conversions
+;;; ------------------------------------------------------------------
+
+(test-equal "bag->set drops multiplicities" '(1 2 3) (sl (bag->set (B 1 1 2 3 3 3))))
+(test-equal "set->bag gives every element count 1"
+            '((1 . 1) (2 . 1) (3 . 1)) (ba (set->bag (S 1 2 3))))
+(test-equal "set->bag does not mutate the set" '(1 2) (let ((s (S 1 2))) (set->bag s) (sl s)))
+(test-equal "set->bag! into an empty bag" '((1 . 1) (2 . 1)) (ba (set->bag! (B) (S 1 2))))
+
+;; "The set->bag! procedure returns a bag containing the elements of both bag
+;;  and set." The reference implementation is
+;;      (hash-table-for-each (lambda (key value) (sob-increment! bag key value))
+;;                           (sob-hash-table set))
+;;  — every element of the set is ADDED to whatever count the bag already has.
+;;  chibi-scheme 0.12.0 agrees with the reference here.
+;; FAIL: #2086 (set->bag! leaves an element already in the bag at its old count)
+;; (test-equal "set->bag! adds to the count of an element already in the bag"
+;;             '((1 . 3) (2 . 1)) (ba (set->bag! (B 1 1) (S 1 2))))
+
+;; Discriminating control: the element the bag does NOT already hold is added
+;; correctly, so only the already-present branch is wrong.
+(test-equal "set->bag! does add an element the bag did not have"
+            1 (bag-element-count (set->bag! (B 1 1) (S 1 2)) 2))
+
+(test-equal "bag->alist pairs each element with its count"
+            '((1 . 2) (2 . 1)) (isort (lambda (x y) (< (car x) (car y))) (bag->alist (B 1 1 2))))
+(test-equal "alist->bag reads element/count pairs"
+            '((1 . 2) (2 . 1)) (ba (alist->bag cmp '((1 . 2) (2 . 1)))))
+(test-equal "bag->list expands multiplicities" '(1 1 2) (bl (B 1 1 2)))
+(test-equal "list->bag counts duplicates" '((1 . 2) (2 . 1)) (ba (list->bag cmp '(1 1 2))))
+(test-equal "list->bag! adds to an existing bag"
+            '((1 . 2) (2 . 1) (5 . 1)) (ba (list->bag! (B 5) '(1 1 2))))
+(test-equal "set->list" '(1 2) (sl (S 1 2)))
+(test-equal "list->set collapses duplicates" '(1 2) (sl (list->set cmp '(1 1 2))))
+(test-equal "list->set! adds to an existing set" '(1 2 5) (sl (list->set! (S 5) '(1 1 2))))
+(test-equal "set->bag! returns a bag" #t (bag? (set->bag! (B) (S 1))))
+
+;;; ------------------------------------------------------------------
+;;; adjoin / delete / replace
+;;; ------------------------------------------------------------------
+
+(test-equal "set-adjoin adds several elements" '(1 2 3) (sl (set-adjoin (S 1) 2 3)))
+(test-equal "set-adjoin of a present element is a no-op" '(1) (sl (set-adjoin (S 1) 1)))
+(test-equal "set-adjoin does not mutate its argument" '(1) (let ((s (S 1))) (set-adjoin s 2) (sl s)))
+(test-equal "set-adjoin! adds in place" '(1 2 3) (sl (set-adjoin! (S 1) 2 3)))
+(test-equal "bag-adjoin increments multiplicity" '((1 . 2) (2 . 1)) (ba (bag-adjoin (B 1) 1 2)))
+(test-equal "bag-adjoin does not mutate its argument"
+            '((1 . 1)) (let ((b (B 1))) (bag-adjoin b 1) (ba b)))
+(test-equal "bag-adjoin! increments in place" '((1 . 2) (2 . 1)) (ba (bag-adjoin! (B 1) 1 2)))
+(test-equal "set-delete removes an element" '(1 3) (sl (set-delete (S 1 2 3) 2)))
+(test-equal "set-delete does not mutate its argument"
+            '(1 2 3) (let ((s (S 1 2 3))) (set-delete s 2) (sl s)))
+(test-equal "set-delete! removes in place" '(1 3) (sl (set-delete! (S 1 2 3) 2)))
+(test-equal "set-delete of an absent element changes nothing" '(1) (sl (set-delete (S 1) 9)))
+(test-equal "set-delete-all takes a list" '(2) (sl (set-delete-all (S 1 2 3) '(1 3))))
+(test-equal "set-delete-all does not mutate its argument"
+            '(1 2 3) (let ((s (S 1 2 3))) (set-delete-all s '(1 3)) (sl s)))
+(test-equal "set-delete-all! removes in place" '(2) (sl (set-delete-all! (S 1 2 3) '(1 3))))
+(test-equal "bag-delete removes one occurrence" '((1 . 1) (2 . 1)) (ba (bag-delete (B 1 1 2) 1)))
+(test-equal "bag-delete does not mutate its argument"
+            '((1 . 2) (2 . 1)) (let ((b (B 1 1 2))) (bag-delete b 1) (ba b)))
+(test-equal "bag-delete! removes one occurrence in place"
+            '((1 . 1) (2 . 1)) (ba (bag-delete! (B 1 1 2) 1)))
+;; The reference's sob-delete-all! decrements each listed element by one, so a
+;; bag loses ONE occurrence per list entry, not all of them. chibi agrees.
+(test-equal "bag-delete-all removes one occurrence per list entry"
+            '((1 . 1) (2 . 2)) (ba (bag-delete-all (B 1 1 2 2) '(1))))
+(test-equal "bag-delete-all does not mutate its argument"
+            '((1 . 2) (2 . 1)) (let ((b (B 1 1 2))) (bag-delete-all b '(1)) (ba b)))
+(test-equal "bag-delete-all! removes one occurrence per list entry, in place"
+            '((1 . 1) (2 . 2)) (ba (bag-delete-all! (B 1 1 2 2) '(1))))
+(test-equal "bag-delete-all with a repeated element removes that many occurrences"
+            '((2 . 2)) (ba (bag-delete-all (B 1 1 2 2) '(1 1))))
+
+;; "If element is equal to an existing member of set, then that member is
+;;  omitted and replaced by element." For a bag the reference writes the OLD
+;;  count back, so multiplicity survives.
+(test-equal "set-replace keeps the set the same size" '(1 2) (sl (set-replace (S 1 2) 2)))
+(test-equal "set-replace does not mutate its argument"
+            '(1 2) (let ((s (S 1 2))) (set-replace s 2) (sl s)))
+(test-equal "set-replace! replaces in place" '(1 2) (sl (set-replace! (S 1 2) 2)))
+(test-equal "set-replace of an absent element changes nothing" '(1) (sl (set-replace (S 1) 9)))
+(test-equal "bag-replace preserves multiplicity"
+            '((1 . 1) (2 . 2)) (ba (bag-replace (B 1 2 2) 2)))
+(test-equal "bag-replace does not mutate its argument"
+            '((1 . 1) (2 . 2)) (let ((b (B 1 2 2))) (bag-replace b 2) (ba b)))
+(test-equal "bag-replace! preserves multiplicity in place"
+            '((1 . 1) (2 . 2)) (ba (bag-replace! (B 1 2 2) 2)))
+
+;;; ------------------------------------------------------------------
+;;; set-search! / bag-search!
+;;; ------------------------------------------------------------------
+
+(test-equal "set-search! insert on an absent element"
+            '((1 2 9) inserted)
+            (call-with-values
+             (lambda () (set-search! (S 1 2) 9
+                                     (lambda (insert ignore) (insert 'inserted))
+                                     (lambda (elt update remove) (update elt 'updated))))
+             (lambda (s obj) (list (sl s) obj))))
+(test-equal "set-search! ignore on an absent element"
+            '((1 2) ignored)
+            (call-with-values
+             (lambda () (set-search! (S 1 2) 9
+                                     (lambda (insert ignore) (ignore 'ignored))
+                                     (lambda (elt update remove) (update elt 'updated))))
+             (lambda (s obj) (list (sl s) obj))))
+(test-equal "set-search! update on a present element"
+            '((1 2) updated)
+            (call-with-values
+             (lambda () (set-search! (S 1 2) 2
+                                     (lambda (insert ignore) (insert 'inserted))
+                                     (lambda (elt update remove) (update elt 'updated))))
+             (lambda (s obj) (list (sl s) obj))))
+(test-equal "set-search! remove on a present element"
+            '((1) removed)
+            (call-with-values
+             (lambda () (set-search! (S 1 2) 2
+                                     (lambda (insert ignore) (insert 'inserted))
+                                     (lambda (elt update remove) (remove 'removed))))
+             (lambda (s obj) (list (sl s) obj))))
+(test-equal "bag-search! insert on an absent element"
+            '(((1 . 1) (9 . 1)) inserted)
+            (call-with-values
+             (lambda () (bag-search! (B 1) 9
+                                     (lambda (insert ignore) (insert 'inserted))
+                                     (lambda (elt update remove) (update elt 'updated))))
+             (lambda (b obj) (list (ba b) obj))))
+(test-equal "bag-search! update preserves multiplicity"
+            '(((1 . 1) (2 . 2)) updated)
+            (call-with-values
+             (lambda () (bag-search! (B 1 2 2) 2
+                                     (lambda (insert ignore) (insert 'inserted))
+                                     (lambda (elt update remove) (update elt 'updated))))
+             (lambda (b obj) (list (ba b) obj))))
+;; The SRFI says only that remove "removes" the element; for a bag that is
+;; ambiguous between one occurrence and all of them. Kaappi drops the element
+;; entirely, and chibi-scheme 0.12.0 does the same -- the reference
+;; implementation's sob-search! decrements by one instead. Pinned as observed,
+;; with both readings recorded, rather than filed.
+(test-equal "bag-search! remove drops the element entirely"
+            '(((1 . 1)) removed)
+            (call-with-values
+             (lambda () (bag-search! (B 1 2 2) 2
+                                     (lambda (insert ignore) (insert 'inserted))
+                                     (lambda (elt update remove) (remove 'removed))))
+             (lambda (b obj) (list (ba b) obj))))
+
+;;; ------------------------------------------------------------------
+;;; filter / remove / partition / map / fold / find
+;;; ------------------------------------------------------------------
+
+(test-equal "set-filter keeps matching elements" '(2 4) (sl (set-filter even? (S 1 2 3 4))))
+(test-equal "set-filter does not mutate its argument"
+            '(1 2 3 4) (let ((s (S 1 2 3 4))) (set-filter even? s) (sl s)))
+(test-equal "set-filter! returns the filtered set" '(2 4) (sl (set-filter! even? (S 1 2 3 4))))
+(test-equal "set-remove drops matching elements" '(1 3) (sl (set-remove even? (S 1 2 3 4))))
+(test-equal "set-remove does not mutate its argument"
+            '(1 2 3 4) (let ((s (S 1 2 3 4))) (set-remove even? s) (sl s)))
+(test-equal "set-remove! returns the reduced set" '(1 3) (sl (set-remove! even? (S 1 2 3 4))))
+(test-equal "bag-filter keeps multiplicities" '((2 . 2) (4 . 1)) (ba (bag-filter even? (B 1 2 2 3 4))))
+(test-equal "bag-filter does not mutate its argument"
+            '((1 . 1) (2 . 2) (3 . 1) (4 . 1)) (let ((b (B 1 2 2 3 4))) (bag-filter even? b) (ba b)))
+(test-equal "bag-filter! returns the filtered bag"
+            '((2 . 2) (4 . 1)) (ba (bag-filter! even? (B 1 2 2 3 4))))
+(test-equal "bag-remove keeps multiplicities" '((1 . 1) (3 . 1)) (ba (bag-remove even? (B 1 2 2 3 4))))
+(test-equal "bag-remove does not mutate its argument"
+            '((1 . 1) (2 . 2) (3 . 1) (4 . 1)) (let ((b (B 1 2 2 3 4))) (bag-remove even? b) (ba b)))
+(test-equal "bag-remove! returns the reduced bag"
+            '((1 . 1) (3 . 1)) (ba (bag-remove! even? (B 1 2 2 3 4))))
+
+(test-equal "set-partition splits into in and out"
+            '((2 4) (1 3))
+            (call-with-values (lambda () (set-partition even? (S 1 2 3 4)))
+                              (lambda (a b) (list (sl a) (sl b)))))
+(test-equal "set-partition does not mutate its argument"
+            '(1 2 3 4) (let ((s (S 1 2 3 4))) (set-partition even? s) (sl s)))
+(test-equal "set-partition! returns both halves"
+            '((2 4) (1 3))
+            (call-with-values (lambda () (set-partition! even? (S 1 2 3 4)))
+                              (lambda (a b) (list (sl a) (sl b)))))
+(test-equal "bag-partition keeps multiplicities in both halves"
+            '(((2 . 2)) ((1 . 1) (3 . 1)))
+            (call-with-values (lambda () (bag-partition even? (B 1 2 2 3)))
+                              (lambda (a b) (list (ba a) (ba b)))))
+(test-equal "bag-partition does not mutate its argument"
+            '((1 . 1) (2 . 2) (3 . 1)) (let ((b (B 1 2 2 3))) (bag-partition even? b) (ba b)))
+(test-equal "bag-partition! returns both halves"
+            '(((2 . 2)) ((1 . 1) (3 . 1)))
+            (call-with-values (lambda () (bag-partition! even? (B 1 2 2 3)))
+                              (lambda (x y) (list (ba x) (ba y)))))
+
+(test-equal "set-map" '(2 4 6) (sl (set-map cmp (lambda (x) (* 2 x)) (S 1 2 3))))
+(test-equal "set-map collapses collisions" '(1) (sl (set-map cmp (lambda (x) 1) (S 1 2 3))))
+(test-equal "bag-map keeps multiplicities" '((2 . 2) (4 . 1)) (ba (bag-map cmp (lambda (x) (* 2 x)) (B 1 1 2))))
+(test-equal "bag-map accumulates collisions" '((1 . 3)) (ba (bag-map cmp (lambda (x) 1) (B 1 2 3))))
+(test-equal "set-fold visits every element once" 6 (set-fold + 0 (S 1 2 3)))
+(test-equal "bag-fold visits every occurrence" 4 (bag-fold + 0 (B 1 1 2)))
+(test-equal "set-for-each visits every element once"
+            6 (let ((n 0)) (set-for-each (lambda (x) (set! n (+ n x))) (S 1 2 3)) n))
+(test-equal "bag-for-each visits every occurrence"
+            4 (let ((n 0)) (bag-for-each (lambda (x) (set! n (+ n x))) (B 1 1 2)) n))
+(test-equal "bag-for-each-unique visits each element once, with its count"
+            4 (let ((n 0)) (bag-for-each-unique (lambda (e c) (set! n (+ n (* e c)))) (B 1 1 2)) n))
+(test-equal "bag-fold-unique folds over element/count pairs"
+            4 (bag-fold-unique (lambda (e c a) (+ a (* e c))) 0 (B 1 1 2)))
+(test-equal "set-count counts matching elements" 2 (set-count even? (S 1 2 3 4)))
+(test-equal "bag-count counts matching occurrences" 3 (bag-count even? (B 1 1 2 2 2 3)))
+(test-equal "set-find returns a matching element" 2 (set-find even? (S 2) (lambda () 'none)))
+(test-equal "set-find calls failure when nothing matches"
+            'none (set-find even? (S 1 3) (lambda () 'none)))
+(test-equal "bag-find returns a matching element" 2 (bag-find even? (B 2 2) (lambda () 'none)))
+(test-equal "bag-find calls failure when nothing matches"
+            'none (bag-find even? (B 1) (lambda () 'none)))
+(test-assert "set-any? true" (set-any? even? (S 1 2)))
+(test-assert "set-any? false" (not (set-any? even? (S 1 3))))
+(test-assert "set-every? true" (set-every? even? (S 2 4)))
+(test-assert "set-every? false" (not (set-every? even? (S 1 2))))
+(test-assert "set-every? on the empty set is true" (set-every? even? (S)))
+(test-assert "bag-any? true" (bag-any? even? (B 1 2)))
+(test-assert "bag-any? false" (not (bag-any? even? (B 1 3))))
+(test-assert "bag-every? true" (bag-every? even? (B 2 4)))
+(test-assert "bag-every? false" (not (bag-every? even? (B 1 2))))
+
+(test-equal "set-unfold builds a set from a seed"
+            '(0 1 2 3 4)
+            (sl (set-unfold cmp (lambda (s) (= s 5)) (lambda (s) s) (lambda (s) (+ s 1)) 0)))
+(test-equal "set-unfold with an immediately-true stop predicate is empty"
+            '() (sl (set-unfold cmp (lambda (s) #t) (lambda (s) s) (lambda (s) (+ s 1)) 0)))
+(test-equal "bag-unfold accumulates duplicate mapped values"
+            '((0 . 3) (1 . 2))
+            (ba (bag-unfold cmp (lambda (s) (= s 5)) (lambda (s) (modulo s 2)) (lambda (s) (+ s 1)) 0)))
+
+;;; ------------------------------------------------------------------
+;;; Copies and comparisons
+;;; ------------------------------------------------------------------
+
+(test-assert "set-copy is a real copy"
+             (let* ((s (S 1)) (c (set-copy s))) (set-adjoin! c 2) (equal? '(1) (sl s))))
+(test-assert "bag-copy is a real copy"
+             (let* ((b (B 1)) (c (bag-copy b))) (bag-adjoin! c 1) (equal? '((1 . 1)) (ba b))))
+(test-assert "set=? ignores order" (set=? (S 1 2) (S 2 1)))
+(test-assert "set=? on different sets" (not (set=? (S 1) (S 2))))
+(test-assert "set=? of three equal sets" (set=? (S 1) (S 1) (S 1)))
+(test-assert "set<? on a proper subset" (set<? (S 1) (S 1 2)))
+(test-assert "set<? on an equal set is #f" (not (set<? (S 1) (S 1))))
+(test-assert "set<? chained" (set<? (S 1) (S 1 2) (S 1 2 3)))
+(test-assert "set<=? on an equal set" (set<=? (S 1) (S 1)))
+(test-assert "set<=? on a superset is #f" (not (set<=? (S 1 2) (S 1))))
+(test-assert "set>? on a proper superset" (set>? (S 1 2) (S 1)))
+(test-assert "set>? on an equal set is #f" (not (set>? (S 1) (S 1))))
+(test-assert "set>=? on an equal set" (set>=? (S 1) (S 1)))
+(test-assert "set>=? on a subset is #f" (not (set>=? (S 1) (S 1 2))))
+(test-assert "set-disjoint? on disjoint sets" (set-disjoint? (S 1) (S 2)))
+(test-assert "set-disjoint? on overlapping sets" (not (set-disjoint? (S 1) (S 1))))
+(test-assert "bag=? compares multiplicities" (bag=? (B 1 1) (B 1 1)))
+(test-assert "bag=? separates differing multiplicities" (not (bag=? (B 1 1) (B 1))))
+(test-assert "bag<? on a proper sub-bag" (bag<? (B 1) (B 1 1)))
+(test-assert "bag<? on an equal bag is #f" (not (bag<? (B 1 1) (B 1 1))))
+(test-assert "bag<=? on a sub-bag" (bag<=? (B 1) (B 1 1)))
+(test-assert "bag<=? on a super-bag is #f" (not (bag<=? (B 1 1) (B 1))))
+(test-assert "bag>? on a proper super-bag" (bag>? (B 1 1) (B 1)))
+(test-assert "bag>? on an equal bag is #f" (not (bag>? (B 1) (B 1))))
+(test-assert "bag>=? on an equal bag" (bag>=? (B 1 1) (B 1)))
+(test-assert "bag>=? on a super-bag is #f" (not (bag>=? (B 1) (B 1 1))))
+(test-assert "bag-disjoint? on disjoint bags" (bag-disjoint? (B 1) (B 2)))
+(test-assert "bag-disjoint? on overlapping bags" (not (bag-disjoint? (B 1) (B 1))))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi113 audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi152-audit.scm
+++ b/tests/scheme/srfi/srfi152-audit.scm
@@ -1,0 +1,181 @@
+;;; Audit: lib/srfi/152.sld (SRFI 152 — String Library, reduced) — the SRFI 13
+;;; seam and the (scheme base) re-exports.
+;;; Systematic audit v2, Phase 3.9 (docs/audit-strategy.md, tracking #1890).
+;;;
+;;; Oracle: SRFI 152, https://srfi.schemers.org/srfi-152/srfi-152.html
+;;;
+;;; DELIBERATELY SHALLOW, for two reasons stated up front:
+;;;
+;;;   1. SRFI 152's own behaviour was already audited in the v1 campaign
+;;;      (kaappi#1234 — string-every's return value, string-split's grammar
+;;;      and limit, ~24 missing exports; all fixed), and the existing
+;;;      tests/scheme/srfi/srfi152.scm carries 134 assertions.
+;;;   2. All 20 of its "untested" exports are R7RS `(scheme base)` names it
+;;;      re-exports unchanged, and `(scheme base)` has its own audit
+;;;      (tests/scheme/audit/primitives_string-audit.scm).
+;;;
+;;; What was left unmeasured is the SEAM the unit was scoped around: does
+;;; SRFI 152 agree with SRFI 13 (src/primitives_string_ext.zig, audited)
+;;; where the two overlap? The answer is stronger than "agree" — the .sld
+;;; imports those 22 names straight from `(srfi 13)`, so they are the SAME
+;;; BINDING and cannot diverge. That is asserted by identity below, which is
+;;; both the tightest possible statement and a regression gate: if a future
+;;; change reimplements any of them inside 152, one of these fails and the
+;;; behavioural comparison stops being free.
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi152-audit.scm
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64)
+        (prefix (srfi 13) s13:)
+        (prefix (srfi 152) s152:))
+
+(test-begin "srfi152 audit")
+
+;;; ------------------------------------------------------------------
+;;; The SRFI 13 seam: same binding, not merely same behaviour.
+;;; ------------------------------------------------------------------
+
+(for-each
+ (lambda (pair)
+   (test-assert (string-append "SRFI 152's " (car pair) " is SRFI 13's own binding")
+                (eq? (cadr pair) (caddr pair))))
+ (list (list "string-contains" s13:string-contains s152:string-contains)
+       (list "string-prefix?" s13:string-prefix? s152:string-prefix?)
+       (list "string-suffix?" s13:string-suffix? s152:string-suffix?)
+       (list "string-index" s13:string-index s152:string-index)
+       (list "string-index-right" s13:string-index-right s152:string-index-right)
+       (list "string-skip" s13:string-skip s152:string-skip)
+       (list "string-skip-right" s13:string-skip-right s152:string-skip-right)
+       (list "string-count" s13:string-count s152:string-count)
+       (list "string-take" s13:string-take s152:string-take)
+       (list "string-drop" s13:string-drop s152:string-drop)
+       (list "string-take-right" s13:string-take-right s152:string-take-right)
+       (list "string-drop-right" s13:string-drop-right s152:string-drop-right)
+       (list "string-pad" s13:string-pad s152:string-pad)
+       (list "string-pad-right" s13:string-pad-right s152:string-pad-right)
+       (list "string-trim" s13:string-trim s152:string-trim)
+       (list "string-trim-right" s13:string-trim-right s152:string-trim-right)
+       (list "string-trim-both" s13:string-trim-both s152:string-trim-both)
+       (list "string-replace" s13:string-replace s152:string-replace)
+       (list "string-join" s13:string-join s152:string-join)
+       (list "string-concatenate" s13:string-concatenate s152:string-concatenate)
+       (list "string-tabulate" s13:string-tabulate s152:string-tabulate)
+       (list "string-every" s13:string-every s152:string-every)
+       (list "string-any" s13:string-any s152:string-any)
+       (list "string-unfold" s13:string-unfold s152:string-unfold)
+       (list "string-unfold-right" s13:string-unfold-right s152:string-unfold-right)
+       (list "string-filter" s13:string-filter s152:string-filter)))
+
+;; SRFI 152's string-remove is SRFI 13's string-delete under a new name --
+;; the one renamed import, and the only place the two specs disagree on
+;; spelling for the same operation.
+(test-assert "SRFI 152's string-remove is SRFI 13's string-delete"
+             (eq? s13:string-delete s152:string-remove))
+(test-equal "string-remove and string-delete therefore agree on a value"
+            "bcd" (s152:string-remove (lambda (c) (char=? c #\a)) "abacad"))
+
+;;; ------------------------------------------------------------------
+;;; The (scheme base) re-exports: 20 names that had never appeared in the
+;;; SRFI 152 test file. Same-binding again, so nothing can drift.
+;;; ------------------------------------------------------------------
+
+(for-each
+ (lambda (pair)
+   (test-assert (string-append "SRFI 152's " (car pair) " is (scheme base)'s own binding")
+                (eq? (cadr pair) (caddr pair))))
+ (list (list "string?" string? s152:string?)
+       (list "string" string s152:string)
+       (list "make-string" make-string s152:make-string)
+       (list "string-length" string-length s152:string-length)
+       (list "string-ref" string-ref s152:string-ref)
+       (list "string-set!" string-set! s152:string-set!)
+       (list "substring" substring s152:substring)
+       (list "string-copy" string-copy s152:string-copy)
+       (list "string-copy!" string-copy! s152:string-copy!)
+       (list "string-fill!" string-fill! s152:string-fill!)
+       (list "string-append" string-append s152:string-append)
+       (list "string->list" string->list s152:string->list)
+       (list "list->string" list->string s152:list->string)
+       (list "string->vector" string->vector s152:string->vector)
+       (list "vector->string" vector->string s152:vector->string)
+       (list "string-for-each" string-for-each s152:string-for-each)
+       (list "string-map" string-map s152:string-map)
+       (list "string=?" string=? s152:string=?)
+       (list "string<?" string<? s152:string<?)
+       (list "string<=?" string<=? s152:string<=?)
+       (list "string>?" string>? s152:string>?)
+       (list "string>=?" string>=? s152:string>=?)
+       (list "string-ci=?" string-ci=? s152:string-ci=?)
+       (list "read-string" read-string s152:read-string)
+       (list "write-string" write-string s152:write-string)))
+
+;;; ------------------------------------------------------------------
+;;; A few values through the SRFI 152 spelling, so the identity assertions
+;;; above are backed by at least one live call each on the shared surface.
+;;; ------------------------------------------------------------------
+
+(test-equal "string-null? on the empty string" #t (s152:string-null? ""))
+(test-equal "string-null? on a non-empty string" #f (s152:string-null? "a"))
+(test-equal "string-take" "ab" (s152:string-take "abcd" 2))
+(test-equal "string-drop" "cd" (s152:string-drop "abcd" 2))
+(test-equal "string-take-right" "cd" (s152:string-take-right "abcd" 2))
+(test-equal "string-drop-right" "ab" (s152:string-drop-right "abcd" 2))
+(test-equal "string-pad pads on the left" "..ab" (s152:string-pad "ab" 4 #\.))
+(test-equal "string-pad-right pads on the right" "ab.." (s152:string-pad-right "ab" 4 #\.))
+(test-equal "string-trim" "ab  " (s152:string-trim "  ab  "))
+(test-equal "string-trim-right" "  ab" (s152:string-trim-right "  ab  "))
+(test-equal "string-trim-both" "ab" (s152:string-trim-both "  ab  "))
+(test-equal "string-index finds the first match" 1 (s152:string-index "abc" (lambda (c) (char=? c #\b))))
+(test-equal "string-index returns #f when nothing matches"
+            #f (s152:string-index "abc" (lambda (c) (char=? c #\z))))
+(test-equal "string-index-right finds the last match"
+            3 (s152:string-index-right "abab" (lambda (c) (char=? c #\b))))
+(test-equal "string-count" 2 (s152:string-count "abab" (lambda (c) (char=? c #\a))))
+(test-equal "string-contains finds a substring" 1 (s152:string-contains "abcd" "bc"))
+(test-equal "string-contains returns #f when absent" #f (s152:string-contains "abcd" "zz"))
+(test-equal "string-contains-right finds the last occurrence"
+            2 (s152:string-contains-right "abab" "ab"))
+(test-assert "string-prefix? on a real prefix" (s152:string-prefix? "ab" "abcd"))
+(test-assert "string-suffix? on a real suffix" (s152:string-suffix? "cd" "abcd"))
+(test-equal "string-prefix-length" 2 (s152:string-prefix-length "abcd" "abzz"))
+(test-equal "string-suffix-length" 2 (s152:string-suffix-length "zzcd" "abcd"))
+(test-equal "string-join with the default delimiter" "a b" (s152:string-join '("a" "b")))
+(test-equal "string-join with an explicit delimiter" "a-b" (s152:string-join '("a" "b") "-"))
+(test-equal "string-concatenate" "abc" (s152:string-concatenate '("a" "b" "c")))
+(test-equal "string-tabulate" "abc" (s152:string-tabulate (lambda (i) (integer->char (+ 97 i))) 3))
+(test-equal "string-filter" "aa" (s152:string-filter (lambda (c) (char=? c #\a)) "abab"))
+(test-equal "string-replace" "aXXd" (s152:string-replace "abcd" "XX" 1 3))
+(test-equal "string-reverse via reverse-list->string"
+            "cba" (s152:reverse-list->string '(#\a #\b #\c)))
+(test-equal "string-fold accumulates left to right"
+            '(#\c #\b #\a) (s152:string-fold cons '() "abc"))
+(test-equal "string-fold-right accumulates right to left"
+            '(#\a #\b #\c) (s152:string-fold-right cons '() "abc"))
+(test-equal "string-split on a delimiter" '("a" "b") (s152:string-split "a,b" ","))
+(test-equal "string-segment chops into fixed-size pieces" '("ab" "cd" "e")
+            (s152:string-segment "abcde" 2))
+(test-equal "string-take-while" "ab" (s152:string-take-while "abZd" (lambda (c) (char-lower-case? c))))
+(test-equal "string-drop-while" "Zd" (s152:string-drop-while "abZd" (lambda (c) (char-lower-case? c))))
+(test-equal "string-span returns the matching prefix"
+            "ab" (call-with-values (lambda () (s152:string-span "abZ" char-lower-case?))
+                                   (lambda (a b) a)))
+(test-equal "string-break returns the non-matching prefix"
+            "ab" (call-with-values (lambda () (s152:string-break "abZ" char-upper-case?))
+                                   (lambda (a b) a)))
+(test-equal "string-unfold" "abc"
+            (s152:string-unfold (lambda (i) (= i 3)) (lambda (i) (integer->char (+ 97 i)))
+                                (lambda (i) (+ i 1)) 0))
+(test-equal "string-unfold-right" "cba"
+            (s152:string-unfold-right (lambda (i) (= i 3)) (lambda (i) (integer->char (+ 97 i)))
+                                      (lambda (i) (+ i 1)) 0))
+;; kaappi#1234's own finding: string-every returns the LAST true value.
+(test-equal "string-every returns the last value the predicate produced"
+            #\c (s152:string-every (lambda (c) c) "abc"))
+(test-equal "string-every on the empty string is #t" #t (s152:string-every (lambda (c) #f) ""))
+(test-equal "string-any returns the first true value"
+            #\a (s152:string-any (lambda (c) c) "abc"))
+(test-equal "string-any on the empty string is #f" #f (s152:string-any (lambda (c) c) ""))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi152 audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi178-audit.scm
+++ b/tests/scheme/srfi/srfi178-audit.scm
@@ -1,0 +1,582 @@
+;;; Audit: lib/srfi/178.sld (SRFI 178 — Bitvector Library)
+;;; Systematic audit v2, Phase 3.9 (docs/audit-strategy.md, tracking #1890).
+;;;
+;;; Oracle: SRFI 178, https://srfi.schemers.org/srfi-178/srfi-178.html, and its
+;;; own reference implementation + test suite at
+;;; scheme-requests-for-implementation/srfi-178 (srfi/178/*.scm, test/*.scm).
+;;; The reference implementation was loaded into this build as an alternate
+;;; library and every one of the 107 exports was diffed against it over a
+;;; 523,361-check corpus (14 bit patterns from empty to 65 bits, every
+;;; start/end pair, every shift/rotate count, 300 integers, all copy!/swap!
+;;; index triples). Exactly THREE procedures diverged:
+;;;
+;;;   * bitvector-logical-shift — shifts the wrong way for both signs (#2083)
+;;;   * bitvector-pad / bitvector-pad-right when the requested length is
+;;;     SHORTER than the vector. Kaappi truncates (SRFI 13 string-pad
+;;;     semantics, and what "so that the length of the result is length" says);
+;;;     the reference returns the argument untouched. The spec's own test suite
+;;;     never exercises the shrinking case and the prose supports both
+;;;     readings, so the assertions below pin only the two lengths the spec
+;;;     settles (grow, and exact-fit) and deliberately assert nothing about
+;;;     shrink. Not filed.
+;;;
+;;; Everything else — every field operation, every logical operation and its
+;;; `!` twin, fold/map/for-each in both /int and /bool flavours, unfold and
+;;; unfold-right with and without seeds, the generators and the accumulator,
+;;; both integer directions, the string syntax, prefix/suffix over mismatched
+;;; lengths, and overlapping bitvector-copy! in both directions — agreed with
+;;; the reference on every one of the remaining ~523k checks.
+;;;
+;;; Portability: nothing here asserts an internal representation. A bitvector
+;;; is one byte per bit in this implementation and one bit per bit elsewhere;
+;;; every assertion goes through bitvector-ref/int, ->list/int or ->integer,
+;;; so the big-endian s390x CI leg sees identical values.
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi178-audit.scm
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 178))
+
+(test-begin "srfi178 audit")
+
+(define (L bv) (bitvector->list/int bv))
+(define (raises? thunk)
+  (call-with-current-continuation
+   (lambda (k) (with-exception-handler (lambda (e) (k #t))
+                                       (lambda () (thunk) #f)))))
+
+;;; ------------------------------------------------------------------
+;;; bit->integer / bit->boolean
+;;; "A bit is either an exact integer 0 or 1, or a boolean."
+;;; ------------------------------------------------------------------
+
+(test-equal "bit->integer #t" 1 (bit->integer #t))
+(test-equal "bit->integer #f" 0 (bit->integer #f))
+(test-equal "bit->integer 0" 0 (bit->integer 0))
+(test-equal "bit->integer 1" 1 (bit->integer 1))
+(test-equal "bit->boolean #t" #t (bit->boolean #t))
+(test-equal "bit->boolean #f" #f (bit->boolean #f))
+(test-equal "bit->boolean 0" #f (bit->boolean 0))
+(test-equal "bit->boolean 1" #t (bit->boolean 1))
+
+;;; ------------------------------------------------------------------
+;;; Disjointness. The header of lib/srfi/178.sld promises a bitvector is
+;;; "kept disjoint from bytevectors and from SRFI 160 u8vectors".
+;;; ------------------------------------------------------------------
+
+(test-assert "bitvector? on a bytevector is #f" (not (bitvector? (bytevector 1 0))))
+(test-assert "bytevector? on a bitvector is #f" (not (bytevector? (bitvector 1 0))))
+(test-assert "bitvector? on a bitvector" (bitvector? (bitvector 1 0)))
+(test-assert "bitvector? on a list" (not (bitvector? '(1 0))))
+
+;;; ------------------------------------------------------------------
+;;; make-bitvector: "Returns a bitvector whose length is size. If bit is
+;;; provided, all the elements of the bitvector are initialized to it."
+;;; ------------------------------------------------------------------
+
+(test-equal "make-bitvector 0 is empty" '() (L (make-bitvector 0)))
+(test-equal "make-bitvector 3 defaults to 0" '(0 0 0) (L (make-bitvector 3)))
+(test-equal "make-bitvector 3 1" '(1 1 1) (L (make-bitvector 3 1)))
+(test-equal "make-bitvector 3 #t" '(1 1 1) (L (make-bitvector 3 #t)))
+(test-equal "make-bitvector 3 #f" '(0 0 0) (L (make-bitvector 3 #f)))
+(test-equal "make-bitvector 65 crosses a 64-bit word" 65 (bitvector-length (make-bitvector 65 1)))
+(test-equal "make-bitvector 65 is all ones" 65 (bitvector-count 1 (make-bitvector 65 1)))
+(test-assert "make-bitvector with a negative size is rejected"
+             (raises? (lambda () (make-bitvector -1))))
+
+;;; ------------------------------------------------------------------
+;;; Word-boundary lengths. Nothing in the spec knows about words, so these
+;;; assert only that 63/64/65 behave like every other length.
+;;; ------------------------------------------------------------------
+
+(for-each
+ (lambda (n)
+   (let* ((label (number->string n))
+          (bv (bitvector-unfold (lambda (i) (if (even? i) 1 0)) n)))
+     (test-equal (string-append "boundary " label ": length") n (bitvector-length bv))
+     (test-equal (string-append "boundary " label ": count of 1s")
+                 (quotient (+ n 1) 2) (bitvector-count 1 bv))
+     (test-equal (string-append "boundary " label ": count of 0s")
+                 (quotient n 2) (bitvector-count 0 bv))
+     (test-equal (string-append "boundary " label ": ref at the last index")
+                 (if (even? (- n 1)) 1 0)
+                 (if (= n 0) 0 (bitvector-ref/int bv (- n 1))))
+     (test-assert (string-append "boundary " label ": copy is =?")
+                  (bitvector=? bv (bitvector-copy bv)))
+     (test-assert (string-append "boundary " label ": double reverse is identity")
+                  (bitvector=? bv (bitvector-reverse-copy (bitvector-reverse-copy bv))))
+     (test-equal (string-append "boundary " label ": integer round trip")
+                 (bitvector->integer bv)
+                 (bitvector->integer (integer->bitvector (bitvector->integer bv) n)))
+     (test-equal (string-append "boundary " label ": string round trip")
+                 (L bv) (L (string->bitvector (bitvector->string bv))))
+     (test-assert (string-append "boundary " label ": flipping every bit twice restores it")
+                  (bitvector=? bv (bitvector-field-flip (bitvector-field-flip bv 0 n) 0 n)))))
+ '(0 1 7 8 31 32 63 64 65 127 128 129))
+
+;;; ------------------------------------------------------------------
+;;; bitvector->integer / integer->bitvector.
+;;; "Returns a non-negative exact integer whose bits, starting with the
+;;;  least significant bit as bit 0, correspond to the values in bitvector."
+;;; Index 0 is therefore the LEAST significant bit. This is the one place a
+;;; big-endian port could plausibly differ, so it is pinned by value.
+;;; ------------------------------------------------------------------
+
+(test-equal "bitvector->integer: index 0 is the least significant bit"
+            13 (bitvector->integer (bitvector 1 0 1 1)))
+(test-equal "bitvector->integer of the empty bitvector" 0 (bitvector->integer (bitvector)))
+(test-equal "bitvector->integer (1)" 1 (bitvector->integer (bitvector 1)))
+(test-equal "bitvector->integer (0 1)" 2 (bitvector->integer (bitvector 0 1)))
+(test-equal "integer->bitvector 13 puts the low bit first"
+            '(1 0 1 1) (L (integer->bitvector 13)))
+(test-equal "integer->bitvector 0 has length 0" 0 (bitvector-length (integer->bitvector 0)))
+(test-equal "integer->bitvector with an explicit longer length pads with 0"
+            '(1 0 1 1 0 0) (L (integer->bitvector 13 6)))
+(test-equal "integer->bitvector with an explicit shorter length truncates"
+            '(1 0) (L (integer->bitvector 13 2)))
+(test-equal "integer->bitvector of 2^64-1 is 64 ones"
+            64 (bitvector-count 1 (integer->bitvector (- (expt 2 64) 1) 64)))
+(test-equal "bitvector->integer of a 100-bit bignum round trips"
+            (- (expt 2 100) 1)
+            (bitvector->integer (integer->bitvector (- (expt 2 100) 1) 100)))
+(test-equal "bitvector->integer of 2^64 round trips"
+            (expt 2 64) (bitvector->integer (integer->bitvector (expt 2 64))))
+
+(let loop ((i 0))
+  (when (< i 40)
+    (test-equal (string-append "integer round trip " (number->string i))
+                i (bitvector->integer (integer->bitvector i)))
+    (loop (+ i 1))))
+
+;;; ------------------------------------------------------------------
+;;; bitvector->string / string->bitvector
+;;; ------------------------------------------------------------------
+
+(test-equal "bitvector->string of empty" "#*" (bitvector->string (bitvector)))
+(test-equal "bitvector->string keeps index order" "#*1011" (bitvector->string (bitvector 1 0 1 1)))
+(test-equal "string->bitvector #*1011" '(1 0 1 1) (L (string->bitvector "#*1011")))
+(test-equal "string->bitvector #*" '() (L (string->bitvector "#*")))
+(test-assert "string->bitvector rejects a non-bit character"
+             (not (string->bitvector "#*2")))
+(test-assert "string->bitvector rejects a missing prefix"
+             (not (string->bitvector "1011")))
+(test-assert "string->bitvector rejects the empty string"
+             (not (string->bitvector "")))
+
+;;; ------------------------------------------------------------------
+;;; bitvector-logical-shift
+;;; "Returns a bitvector equal in length to bvec containing the logical
+;;;  left shift (toward lower indices) when count>=0 or the right shift
+;;;  (toward upper indices) when count<0. Newly vacated elements are filled
+;;;  with bit."
+;;; The two assertions below are the SRFI's own test suite verbatim
+;;; (test/quasi-ints.scm lines 8-13).
+;;; ------------------------------------------------------------------
+
+;; FAIL: #2083 (bitvector-logical-shift moves bits the wrong way for both signs)
+;; (test-equal "logical-shift +2 moves toward lower indices"
+;;             '(1 1 0 0) (L (bitvector-logical-shift (bitvector 1 0 1 1) 2 0)))
+;; FAIL: #2083
+;; (test-equal "logical-shift -2 moves toward upper indices, filling with the bit"
+;;             '(1 1 1 0) (L (bitvector-logical-shift (bitvector 1 0 1 1) -2 #t)))
+;; FAIL: #2083
+;; (test-equal "logical-shift +1 of (0 0 0 1)"
+;;             '(0 0 1 0) (L (bitvector-logical-shift (bitvector 0 0 0 1) 1 0)))
+;; FAIL: #2083
+;; (test-equal "logical-shift -1 of (1 0 0 0)"
+;;             '(0 1 0 0) (L (bitvector-logical-shift (bitvector 1 0 0 0) -1 0)))
+
+;; Discriminating control: count 0 is the identity, and it is correct today.
+(test-equal "logical-shift 0 is the identity"
+            '(1 0 1 1) (L (bitvector-logical-shift (bitvector 1 0 1 1) 0 0)))
+(test-equal "logical-shift by the full length leaves only the fill bit"
+            '(1 1 1 1) (L (bitvector-logical-shift (bitvector 1 0 1 1) 4 1)))
+(test-equal "logical-shift of the empty bitvector is empty"
+            '() (L (bitvector-logical-shift (bitvector) 3 1)))
+
+;;; ------------------------------------------------------------------
+;;; Field operations. Verified identical to the reference implementation on
+;;; every (start, end) pair of every corpus vector.
+;;; ------------------------------------------------------------------
+
+(test-assert "field-any? on an all-zero field" (not (bitvector-field-any? (bitvector 0 0 0) 0 3)))
+(test-assert "field-any? sees a 1 inside the field" (bitvector-field-any? (bitvector 0 1 0) 0 3))
+(test-assert "field-any? ignores a 1 outside the field"
+             (not (bitvector-field-any? (bitvector 1 0 0 1) 1 3)))
+(test-assert "field-any? on an empty field is #f" (not (bitvector-field-any? (bitvector 1 1) 1 1)))
+(test-assert "field-every? on an all-one field" (bitvector-field-every? (bitvector 1 1 1) 0 3))
+(test-assert "field-every? on an empty field is #t" (bitvector-field-every? (bitvector 0 0) 1 1))
+(test-assert "field-every? sees a 0 inside the field"
+             (not (bitvector-field-every? (bitvector 1 0 1) 0 3)))
+
+(test-equal "field-clear" '(1 0 0 1) (L (bitvector-field-clear (bitvector 1 1 1 1) 1 3)))
+(test-equal "field-set" '(0 1 1 0) (L (bitvector-field-set (bitvector 0 0 0 0) 1 3)))
+(test-equal "field-flip" '(1 0 0 1) (L (bitvector-field-flip (bitvector 1 1 1 1) 1 3)))
+(test-equal "field-replace takes the FIRST end-start bits of source"
+            '(0 1 1 0) (L (bitvector-field-replace (bitvector 0 0 0 0) (bitvector 1 1) 1 3)))
+(test-equal "field-replace-same takes the CORRESPONDING bits of source"
+            '(0 1 1 0) (L (bitvector-field-replace-same (bitvector 0 0 0 0) (bitvector 1 1 1 1) 1 3)))
+(test-equal "field-replace-same really does index source at i, not i-start"
+            '(0 1 0 0)
+            (L (bitvector-field-replace-same (bitvector 0 0 0 0) (bitvector 1 1 0 1) 1 3)))
+
+;; "Returns bvec with the field cyclically permuted by count bits towards
+;;  higher indices when count is negative, and toward lower indices otherwise."
+(test-equal "field-rotate +1 moves toward lower indices"
+            '(0 0 0 1) (L (bitvector-field-rotate (bitvector 1 0 0 0) 1 0 4)))
+(test-equal "field-rotate -1 moves toward higher indices"
+            '(0 1 0 0) (L (bitvector-field-rotate (bitvector 1 0 0 0) -1 0 4)))
+(test-equal "field-rotate 0 is the identity"
+            '(1 0 0 0) (L (bitvector-field-rotate (bitvector 1 0 0 0) 0 0 4)))
+(test-equal "field-rotate by the field length is the identity"
+            '(1 0 0 0) (L (bitvector-field-rotate (bitvector 1 0 0 0) 4 0 4)))
+(test-equal "field-rotate leaves bits outside the field alone"
+            '(1 0 0 1 1) (L (bitvector-field-rotate (bitvector 1 1 0 0 1) 1 1 4)))
+(test-equal "field-rotate on an empty field is the identity"
+            '(1 0) (L (bitvector-field-rotate (bitvector 1 0) 3 1 1)))
+
+;; The pure field operations must not touch their argument.
+(let ((bv (bitvector 1 1 1 1)))
+  (bitvector-field-clear bv 1 3)
+  (test-equal "field-clear does not mutate its argument" '(1 1 1 1) (L bv)))
+(let ((bv (bitvector 0 0 0 0)))
+  (bitvector-field-set bv 1 3)
+  (test-equal "field-set does not mutate its argument" '(0 0 0 0) (L bv)))
+(let ((bv (bitvector 1 0 1 0)))
+  (bitvector-field-flip bv 0 4)
+  (test-equal "field-flip does not mutate its argument" '(1 0 1 0) (L bv)))
+(let ((bv (bitvector 0 0 0 0)))
+  (bitvector-field-replace bv (bitvector 1 1) 1 3)
+  (test-equal "field-replace does not mutate its argument" '(0 0 0 0) (L bv)))
+(let ((bv (bitvector 1 0 0 0)))
+  (bitvector-field-rotate bv 1 0 4)
+  (test-equal "field-rotate does not mutate its argument" '(1 0 0 0) (L bv)))
+
+;; ... and the `!` twins must produce the same value in place.
+(let ((bv (bitvector 1 1 1 1))) (bitvector-field-clear! bv 1 3)
+     (test-equal "field-clear! matches field-clear" '(1 0 0 1) (L bv)))
+(let ((bv (bitvector 0 0 0 0))) (bitvector-field-set! bv 1 3)
+     (test-equal "field-set! matches field-set" '(0 1 1 0) (L bv)))
+(let ((bv (bitvector 1 1 1 1))) (bitvector-field-flip! bv 1 3)
+     (test-equal "field-flip! matches field-flip" '(1 0 0 1) (L bv)))
+(let ((bv (bitvector 0 0 0 0))) (bitvector-field-replace! bv (bitvector 1 1) 1 3)
+     (test-equal "field-replace! matches field-replace" '(0 1 1 0) (L bv)))
+(let ((bv (bitvector 0 0 0 0))) (bitvector-field-replace-same! bv (bitvector 1 1 1 1) 1 3)
+     (test-equal "field-replace-same! matches field-replace-same" '(0 1 1 0) (L bv)))
+
+;;; ------------------------------------------------------------------
+;;; bitvector-copy! — "Copies the portion of from from start to end onto
+;;; to, starting at index at." R7RS requires the underlying copy to work
+;;; even when source and destination overlap, so both directions are pinned.
+;;; ------------------------------------------------------------------
+
+(let ((bv (bitvector 1 1 0 0 0 0)))
+  (bitvector-copy! bv 2 bv 0 4)
+  (test-equal "copy! forward-overlapping (dest after source)" '(1 1 1 1 0 0) (L bv)))
+(let ((bv (bitvector 0 0 1 1 0 0)))
+  (bitvector-copy! bv 0 bv 2 6)
+  (test-equal "copy! backward-overlapping (dest before source)" '(1 1 0 0 0 0) (L bv)))
+(let ((bv (bitvector 1 0 1 0)))
+  (bitvector-copy! bv 0 bv 0 4)
+  (test-equal "copy! onto itself in place is the identity" '(1 0 1 0) (L bv)))
+(let ((bv (bitvector 0 0 0 0)))
+  (bitvector-copy! bv 1 (bitvector 1 1))
+  (test-equal "copy! with the 3-argument form copies all of from" '(0 1 1 0) (L bv)))
+(let ((bv (bitvector 0 0 0 0)))
+  (bitvector-copy! bv 0 (bitvector 1 1 1) 1)
+  (test-equal "copy! with the 4-argument form copies from start to the end" '(1 1 0 0) (L bv)))
+(let ((bv (bitvector 1 0 1 0)))
+  (bitvector-copy! bv 0 (bitvector) 0 0)
+  (test-equal "copy! of an empty range changes nothing" '(1 0 1 0) (L bv)))
+
+(let ((bv (bitvector 1 0 0 0)))
+  (bitvector-reverse-copy! bv 0 (bitvector 1 1 0 0) 0 4)
+  (test-equal "reverse-copy! reverses as it copies" '(0 0 1 1) (L bv)))
+(let ((bv (bitvector 1 0 1 0)))
+  (bitvector-swap! bv 0 3)
+  (test-equal "swap! exchanges two elements" '(0 0 1 1) (L bv)))
+(let ((bv (bitvector 1 0 1 0)))
+  (bitvector-swap! bv 2 2)
+  (test-equal "swap! of an index with itself is the identity" '(1 0 1 0) (L bv)))
+(let ((bv (bitvector 1 1 0 0 1)))
+  (bitvector-reverse! bv)
+  (test-equal "reverse! of the whole vector" '(1 0 0 1 1) (L bv)))
+(let ((bv (bitvector 1 1 0 0 1)))
+  (bitvector-reverse! bv 1 4)
+  (test-equal "reverse! of a sub-range leaves the ends alone" '(1 0 0 1 1) (L bv)))
+
+;;; ------------------------------------------------------------------
+;;; Logical operations. Every one was diffed against the reference over the
+;;; whole corpus; these pin the truth tables by value.
+;;; ------------------------------------------------------------------
+
+(define A (bitvector 0 0 1 1))
+(define Bv (bitvector 0 1 0 1))
+
+(test-equal "bitvector-not" '(1 1 0 0) (L (bitvector-not A)))
+(test-equal "bitvector-and" '(0 0 0 1) (L (bitvector-and A Bv)))
+(test-equal "bitvector-ior" '(0 1 1 1) (L (bitvector-ior A Bv)))
+(test-equal "bitvector-xor" '(0 1 1 0) (L (bitvector-xor A Bv)))
+(test-equal "bitvector-eqv" '(1 0 0 1) (L (bitvector-eqv A Bv)))
+(test-equal "bitvector-nand" '(1 1 1 0) (L (bitvector-nand A Bv)))
+(test-equal "bitvector-nor" '(1 0 0 0) (L (bitvector-nor A Bv)))
+(test-equal "bitvector-andc1" '(0 1 0 0) (L (bitvector-andc1 A Bv)))
+(test-equal "bitvector-andc2" '(0 0 1 0) (L (bitvector-andc2 A Bv)))
+(test-equal "bitvector-orc1" '(1 1 0 1) (L (bitvector-orc1 A Bv)))
+(test-equal "bitvector-orc2" '(1 0 1 1) (L (bitvector-orc2 A Bv)))
+(test-equal "bitvector-if selects then/else per bit"
+            '(0 1 0 1) (L (bitvector-if A (bitvector 1 1 0 1) (bitvector 0 1 1 0))))
+
+(test-assert "the pure logical operations leave both arguments alone"
+             (let ((a (bitvector 0 0 1 1)) (b (bitvector 0 1 0 1)))
+               (bitvector-and a b) (bitvector-ior a b) (bitvector-xor a b)
+               (bitvector-not a)
+               (and (equal? '(0 0 1 1) (L a)) (equal? '(0 1 0 1) (L b)))))
+
+(for-each
+ (lambda (entry)
+   (let* ((name (car entry)) (pure (cadr entry)) (bang (caddr entry))
+          (expected (L (pure (bitvector 0 0 1 1) (bitvector 0 1 0 1))))
+          (dest (bitvector 0 0 1 1))
+          (src (bitvector 0 1 0 1)))
+     (bang dest src)
+     (test-equal (string-append name "! writes the same value into its first argument")
+                 expected (L dest))
+     (test-equal (string-append name "! leaves its second argument alone")
+                 '(0 1 0 1) (L src))))
+ (list (list "bitvector-and" bitvector-and bitvector-and!)
+       (list "bitvector-ior" bitvector-ior bitvector-ior!)
+       (list "bitvector-xor" bitvector-xor bitvector-xor!)
+       (list "bitvector-eqv" bitvector-eqv bitvector-eqv!)
+       (list "bitvector-nand" bitvector-nand bitvector-nand!)
+       (list "bitvector-nor" bitvector-nor bitvector-nor!)
+       (list "bitvector-andc1" bitvector-andc1 bitvector-andc1!)
+       (list "bitvector-andc2" bitvector-andc2 bitvector-andc2!)
+       (list "bitvector-orc1" bitvector-orc1 bitvector-orc1!)
+       (list "bitvector-orc2" bitvector-orc2 bitvector-orc2!)))
+
+(let ((bv (bitvector 1 0 1 0))) (bitvector-not! bv)
+     (test-equal "bitvector-not! inverts in place" '(0 1 0 1) (L bv)))
+(test-assert "logical operations reject mismatched lengths"
+             (raises? (lambda () (bitvector-and (bitvector 1 0 1) (bitvector 1 1)))))
+
+;;; ------------------------------------------------------------------
+;;; Selectors, prefixes and suffixes
+;;; ------------------------------------------------------------------
+
+(test-equal "bitvector-take" '(1 0) (L (bitvector-take (bitvector 1 0 1 1) 2)))
+(test-equal "bitvector-take-right" '(1 1) (L (bitvector-take-right (bitvector 1 0 1 1) 2)))
+(test-equal "bitvector-drop" '(1 1) (L (bitvector-drop (bitvector 1 0 1 1) 2)))
+(test-equal "bitvector-drop-right" '(1 0) (L (bitvector-drop-right (bitvector 1 0 1 1) 2)))
+(test-equal "bitvector-take 0 is empty" '() (L (bitvector-take (bitvector 1 0) 0)))
+(test-equal "bitvector-drop everything is empty" '() (L (bitvector-drop (bitvector 1 0) 2)))
+
+(test-equal "prefix-length of two equal vectors is the length"
+            4 (bitvector-prefix-length (bitvector 1 0 1 1) (bitvector 1 0 1 1)))
+(test-equal "prefix-length stops at the first difference"
+            2 (bitvector-prefix-length (bitvector 1 0 1 1) (bitvector 1 0 0 1)))
+(test-equal "prefix-length of a shorter first argument"
+            2 (bitvector-prefix-length (bitvector 1 0) (bitvector 1 0 1 1)))
+(test-equal "prefix-length with no common prefix" 0
+            (bitvector-prefix-length (bitvector 0) (bitvector 1)))
+(test-equal "suffix-length counts backwards from the end"
+            2 (bitvector-suffix-length (bitvector 0 0 1 1) (bitvector 1 1 1 1)))
+(test-equal "suffix-length of equal vectors is the length"
+            3 (bitvector-suffix-length (bitvector 1 0 1) (bitvector 1 0 1)))
+(test-assert "prefix? on a real prefix" (bitvector-prefix? (bitvector 1 0) (bitvector 1 0 1)))
+(test-assert "prefix? on a non-prefix" (not (bitvector-prefix? (bitvector 0 0) (bitvector 1 0 1))))
+(test-assert "prefix? of the empty bitvector" (bitvector-prefix? (bitvector) (bitvector 1)))
+(test-assert "prefix? rejects a longer first argument"
+             (not (bitvector-prefix? (bitvector 1 0 1) (bitvector 1 0))))
+(test-assert "suffix? on a real suffix" (bitvector-suffix? (bitvector 0 1) (bitvector 1 0 1)))
+(test-assert "suffix? on a non-suffix" (not (bitvector-suffix? (bitvector 1 1) (bitvector 1 0 1))))
+
+;;; pad: the spec settles the growing and exact-fit cases; the shrinking
+;;; case is left ambiguous by "added (if necessary) so that the length of
+;;; the result is length" and its own test suite never probes it.
+(test-equal "pad adds leading bits" '(0 0 0 1) (L (bitvector-pad 0 (bitvector 1) 4)))
+(test-equal "pad-right adds trailing bits" '(1 0 0 0) (L (bitvector-pad-right 0 (bitvector 1) 4)))
+(test-equal "pad to the current length is the identity"
+            '(1 0 1 0) (L (bitvector-pad 0 (bitvector 1 0 1 0) 4)))
+(test-equal "pad-right to the current length is the identity"
+            '(1 0 1 0) (L (bitvector-pad-right 0 (bitvector 1 0 1 0) 4)))
+(test-equal "pad with bit 1" '(1 1 1 0) (L (bitvector-pad 1 (bitvector 0) 4)))
+
+(test-equal "trim removes leading bits equal to bit"
+            '(1 0) (L (bitvector-trim 0 (bitvector 0 0 1 0))))
+(test-equal "trim-right removes trailing bits equal to bit"
+            '(0 0 1) (L (bitvector-trim-right 0 (bitvector 0 0 1 0))))
+(test-equal "trim-both removes from both ends"
+            '(1) (L (bitvector-trim-both 0 (bitvector 0 0 1 0))))
+(test-equal "trim of an all-matching vector is empty"
+            '() (L (bitvector-trim 0 (bitvector 0 0 0))))
+(test-equal "trim-right of an all-matching vector is empty"
+            '() (L (bitvector-trim-right 0 (bitvector 0 0 0))))
+
+;;; ------------------------------------------------------------------
+;;; Counting and searching
+;;; ------------------------------------------------------------------
+
+(test-equal "bitvector-count 1" 3 (bitvector-count 1 (bitvector 1 1 0 1)))
+(test-equal "bitvector-count 0" 1 (bitvector-count 0 (bitvector 1 1 0 1)))
+(test-equal "bitvector-count on empty" 0 (bitvector-count 1 (bitvector)))
+(test-equal "count-run from index 0" 2 (bitvector-count-run 1 (bitvector 1 1 0 1) 0))
+(test-equal "count-run when the first element does not match"
+            0 (bitvector-count-run 0 (bitvector 1 1 0 1) 0))
+(test-equal "count-run from a middle index" 1 (bitvector-count-run 0 (bitvector 1 1 0 1) 2))
+(test-equal "count-run at the end of the vector" 0 (bitvector-count-run 1 (bitvector 1 0) 2))
+(test-equal "first-bit finds the smallest matching index"
+            2 (bitvector-first-bit 1 (bitvector 0 0 1 1)))
+(test-equal "first-bit returns -1 when there is no match"
+            -1 (bitvector-first-bit 1 (bitvector 0 0 0)))
+(test-equal "first-bit on the empty bitvector is -1" -1 (bitvector-first-bit 0 (bitvector)))
+
+;;; ------------------------------------------------------------------
+;;; bitvector-segment. "It is an error if n is not an exact positive
+;;; integer." A 200,000-bit vector with n=1 is NOT an error, and it is the
+;;; case that matters.
+;;; ------------------------------------------------------------------
+
+(test-equal "segment into 2s" '((1 0) (1 1)) (map L (bitvector-segment (bitvector 1 0 1 1) 2)))
+(test-equal "segment when the last piece is short"
+            '((1 0) (1)) (map L (bitvector-segment (bitvector 1 0 1) 2)))
+(test-equal "segment with n larger than the vector"
+            '((1 0)) (map L (bitvector-segment (bitvector 1 0) 9)))
+(test-equal "segment of the empty bitvector" '() (bitvector-segment (bitvector) 2))
+
+;; FAIL: #2084 (bitvector-segment recurses once per segment; a legal call on a
+;;              200,000-bit vector overflows the stack, and n=0 recurses without
+;;              bound into an uncatchable KP3008)
+;; (test-equal "segment of a 200,000-bit vector with n=1"
+;;             200000 (length (bitvector-segment (make-bitvector 200000 1) 1)))
+;; FAIL: #2084
+;; (test-assert "segment with n=0 raises a catchable error"
+;;              (raises? (lambda () (bitvector-segment (bitvector 1 0 1) 0))))
+
+;; Discriminating control: the same shape at a size the recursion survives.
+(test-equal "segment of a 1,000-bit vector with n=1 does terminate"
+            1000 (length (bitvector-segment (make-bitvector 1000 1) 1)))
+
+;;; ------------------------------------------------------------------
+;;; Iteration: fold, map, for-each in both /int and /bool flavours
+;;; ------------------------------------------------------------------
+
+(test-equal "fold/int visits in increasing index order"
+            '(1 1 0 1) (reverse (bitvector-fold/int (lambda (acc b) (cons b acc)) '() (bitvector 1 1 0 1))))
+(test-equal "fold-right/int visits in decreasing index order"
+            '(1 0 1 1) (reverse (bitvector-fold-right/int (lambda (acc b) (cons b acc)) '() (bitvector 1 1 0 1))))
+(test-equal "fold/bool yields booleans"
+            '(#t #f) (reverse (bitvector-fold/bool (lambda (acc b) (cons b acc)) '() (bitvector 1 0))))
+(test-equal "fold-right/bool yields booleans"
+            '(#f #t) (reverse (bitvector-fold-right/bool (lambda (acc b) (cons b acc)) '() (bitvector 1 0))))
+(test-equal "fold/int over two bitvectors"
+            '(2 0) (reverse (bitvector-fold/int (lambda (acc a b) (cons (+ a b) acc)) '()
+                                                (bitvector 1 0) (bitvector 1 0))))
+(test-equal "fold/int knil on an empty bitvector" 'seed
+            (bitvector-fold/int (lambda (acc b) 'other) 'seed (bitvector)))
+
+(test-equal "map/int" '(0 1 0) (L (bitvector-map/int (lambda (b) (- 1 b)) (bitvector 1 0 1))))
+(test-equal "map/bool" '(0 1 0) (L (bitvector-map/bool (lambda (b) (not b)) (bitvector 1 0 1))))
+(test-equal "map/int over two bitvectors"
+            '(1 0) (L (bitvector-map/int (lambda (a b) (if (= a b) 1 0)) (bitvector 1 0) (bitvector 1 1))))
+(let ((bv (bitvector 1 0 1)))
+  (bitvector-map/int (lambda (b) (- 1 b)) bv)
+  (test-equal "map/int does not mutate its argument" '(1 0 1) (L bv)))
+(let ((bv (bitvector 1 0 1)))
+  (bitvector-map!/int (lambda (b) (- 1 b)) bv)
+  (test-equal "map!/int mutates in place" '(0 1 0) (L bv)))
+(let ((bv (bitvector 1 0 1)))
+  (bitvector-map!/bool (lambda (b) (not b)) bv)
+  (test-equal "map!/bool mutates in place" '(0 1 0) (L bv)))
+(test-equal "map->list/int" '(2 0 2) (bitvector-map->list/int (lambda (b) (* 2 b)) (bitvector 1 0 1)))
+(test-equal "map->list/bool" '(y n) (bitvector-map->list/bool (lambda (b) (if b 'y 'n)) (bitvector 1 0)))
+(test-equal "for-each/int visits every element in order"
+            '(1 0 1) (reverse (let ((a '())) (bitvector-for-each/int (lambda (b) (set! a (cons b a)))
+                                                                    (bitvector 1 0 1)) a)))
+(test-equal "for-each/bool visits every element in order"
+            '(#t #f) (reverse (let ((a '())) (bitvector-for-each/bool (lambda (b) (set! a (cons b a)))
+                                                                      (bitvector 1 0)) a)))
+
+;;; ------------------------------------------------------------------
+;;; Unfolds
+;;; ------------------------------------------------------------------
+
+(test-equal "unfold with no seed" '(1 0 1 0) (L (bitvector-unfold (lambda (i) (if (even? i) 1 0)) 4)))
+(test-equal "unfold of length 0 is empty" '() (L (bitvector-unfold (lambda (i) 1) 0)))
+(test-equal "unfold with a seed threads the seed forward"
+            '(0 1 0 1) (L (bitvector-unfold (lambda (i s) (values (if (odd? s) 1 0) (+ s 1))) 4 0)))
+(test-equal "unfold-right with no seed"
+            '(1 0 1 0) (L (bitvector-unfold-right (lambda (i) (if (even? i) 1 0)) 4)))
+(test-equal "unfold-right with a seed runs from the last index down"
+            '(1 0 1 0) (L (bitvector-unfold-right (lambda (i s) (values (if (odd? s) 1 0) (+ s 1))) 4 0)))
+
+;;; ------------------------------------------------------------------
+;;; Conversions
+;;; ------------------------------------------------------------------
+
+(test-equal "bitvector->list/int" '(1 0 1) (bitvector->list/int (bitvector 1 0 1)))
+(test-equal "bitvector->list/bool" '(#t #f #t) (bitvector->list/bool (bitvector 1 0 1)))
+(test-equal "reverse-bitvector->list/int" '(1 0 1) (reverse-bitvector->list/int (bitvector 1 0 1)))
+(test-equal "reverse-bitvector->list/bool" '(#f #t #t)
+            (reverse-bitvector->list/bool (bitvector 1 1 0)))
+(test-equal "list->bitvector" '(1 0 1) (L (list->bitvector '(1 0 1))))
+(test-equal "list->bitvector accepts booleans" '(1 0) (L (list->bitvector '(#t #f))))
+(test-equal "reverse-list->bitvector" '(1 0 1) (L (reverse-list->bitvector '(1 0 1))))
+(test-equal "bitvector->vector/int" '#(1 0 1) (bitvector->vector/int (bitvector 1 0 1)))
+(test-equal "bitvector->vector/bool" '#(#t #f #t) (bitvector->vector/bool (bitvector 1 0 1)))
+(test-equal "reverse-bitvector->vector/int" '#(0 1 1)
+            (reverse-bitvector->vector/int (bitvector 1 1 0)))
+(test-equal "reverse-bitvector->vector/bool" '#(#f #t #t)
+            (reverse-bitvector->vector/bool (bitvector 1 1 0)))
+(test-equal "vector->bitvector" '(1 0 1) (L (vector->bitvector '#(1 0 1))))
+(test-equal "reverse-vector->bitvector" '(0 1 1) (L (reverse-vector->bitvector '#(1 1 0))))
+(test-equal "bitvector-append" '(1 0 1 1) (L (bitvector-append (bitvector 1 0) (bitvector 1 1))))
+(test-equal "bitvector-append with no arguments is empty" '() (L (bitvector-append)))
+(test-equal "bitvector-concatenate" '(1 0 1 1)
+            (L (bitvector-concatenate (list (bitvector 1 0) (bitvector 1 1)))))
+(test-equal "bitvector-concatenate of the empty list is empty" '() (L (bitvector-concatenate '())))
+(test-equal "bitvector-append-subbitvectors"
+            '(1 0 1) (L (bitvector-append-subbitvectors (bitvector 1 1) 0 1 (bitvector 0 0 1) 1 3)))
+(test-assert "bitvector-empty? on empty" (bitvector-empty? (bitvector)))
+(test-assert "bitvector-empty? on non-empty" (not (bitvector-empty? (bitvector 0))))
+(test-assert "bitvector=? on equal vectors" (bitvector=? (bitvector 1 0) (bitvector 1 0)))
+(test-assert "bitvector=? on differing vectors" (not (bitvector=? (bitvector 1 0) (bitvector 0 1))))
+(test-assert "bitvector=? on different lengths" (not (bitvector=? (bitvector 1) (bitvector 1 0))))
+(test-assert "bitvector=? of three equal vectors"
+             (bitvector=? (bitvector 1 0) (bitvector 1 0) (bitvector 1 0)))
+(test-assert "bitvector=? of one argument is #t" (bitvector=? (bitvector 1)))
+
+;;; ------------------------------------------------------------------
+;;; Generators and accumulator
+;;; ------------------------------------------------------------------
+
+(let ((g (make-bitvector/int-generator (bitvector 1 0))))
+  (test-equal "int-generator first" 1 (g))
+  (test-equal "int-generator second" 0 (g))
+  (test-assert "int-generator ends with eof" (eof-object? (g)))
+  (test-assert "int-generator stays exhausted" (eof-object? (g))))
+(let ((g (make-bitvector/bool-generator (bitvector 1 0))))
+  (test-equal "bool-generator first" #t (g))
+  (test-equal "bool-generator second" #f (g))
+  (test-assert "bool-generator ends with eof" (eof-object? (g))))
+(let ((g (make-bitvector/int-generator (bitvector))))
+  (test-assert "generator over an empty bitvector is immediately exhausted" (eof-object? (g))))
+(let ((a (make-bitvector-accumulator)))
+  (a 1) (a 0) (a #t)
+  (test-equal "accumulator collects in order" '(1 0 1) (L (a (eof-object)))))
+(let ((a (make-bitvector-accumulator)))
+  (test-equal "accumulator with no elements yields the empty bitvector"
+              '() (L (a (eof-object)))))
+
+;;; ------------------------------------------------------------------
+;;; Index checking
+;;; ------------------------------------------------------------------
+
+(test-assert "ref past the end is rejected" (raises? (lambda () (bitvector-ref/int (bitvector 1) 5))))
+(test-assert "ref at a negative index is rejected" (raises? (lambda () (bitvector-ref/int (bitvector 1) -1))))
+(test-assert "set! past the end is rejected" (raises? (lambda () (bitvector-set! (bitvector 1) 5 1))))
+(test-assert "copy with start > end is rejected"
+             (raises? (lambda () (bitvector-copy (bitvector 1 0) 2 1))))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi178 audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi189-audit.scm
+++ b/tests/scheme/srfi/srfi189-audit.scm
@@ -1,0 +1,278 @@
+;;; Audit: lib/srfi/189.sld (SRFI 189 — Maybe and Either)
+;;; Systematic audit v2, Phase 3.9 (docs/audit-strategy.md, tracking #1890).
+;;;
+;;; Oracle: SRFI 189, https://srfi.schemers.org/srfi-189/srfi-189.html
+;;;
+;;; SRFI 189 specifies 82 identifiers. lib/srfi/189.sld exports 24, of which
+;;; 23 are spec names — 59 are missing, and several of the 23 present ones
+;;; have a narrower signature than the spec requires. `(cond-expand (srfi-189
+;;; ...))` and `(cond-expand ((library (srfi 189)) ...))` both answer yes, so
+;;; portable code has no way to detect the gap. Filed as #2087; the assertions
+;;; that pin it are disabled below.
+;;;
+;;; What IS implemented is asserted here against the spec, including the three
+;;; monad laws as properties (left identity, right identity, associativity)
+;;; rather than case by case.
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi189-audit.scm
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 189))
+
+(test-begin "srfi189 audit")
+
+(define (raises? thunk)
+  (call-with-current-continuation
+   (lambda (k) (with-exception-handler (lambda (e) (k #t)) (lambda () (thunk) #f)))))
+
+;;; ------------------------------------------------------------------
+;;; Constructors and predicates
+;;; ------------------------------------------------------------------
+
+(test-assert "just? on a Just" (just? (just 1)))
+(test-assert "just? on Nothing" (not (just? (nothing))))
+(test-assert "nothing? on Nothing" (nothing? (nothing)))
+(test-assert "nothing? on a Just" (not (nothing? (just 1))))
+(test-assert "maybe? on a Just" (maybe? (just 1)))
+(test-assert "maybe? on Nothing" (maybe? (nothing)))
+(test-assert "maybe? on a plain value" (not (maybe? 1)))
+(test-assert "maybe? on an Either" (not (maybe? (right 1))))
+;; "There is only one Nothing object."
+(test-assert "the Nothing object is unique" (eq? (nothing) (nothing)))
+(test-assert "a Just is not eq? to another Just of the same payload"
+             (not (eq? (just 1) (just 1))))
+(test-assert "right? on a Right" (right? (right 1)))
+(test-assert "right? on a Left" (not (right? (left 1))))
+(test-assert "left? on a Left" (left? (left 1)))
+(test-assert "left? on a Right" (not (left? (right 1))))
+(test-assert "either? on a Right" (either? (right 1)))
+(test-assert "either? on a Left" (either? (left 1)))
+(test-assert "either? on a plain value" (not (either? 1)))
+(test-assert "either? on a Maybe" (not (either? (just 1))))
+(test-assert "a Just can hold #f" (just? (just #f)))
+(test-assert "a Just holding #f is not Nothing" (not (nothing? (just #f))))
+(test-assert "a Left can hold #f" (left? (left #f)))
+
+;;; ------------------------------------------------------------------
+;;; Accessors
+;;; ------------------------------------------------------------------
+
+(test-equal "maybe-ref on a Just yields the payload" 5 (maybe-ref (just 5)))
+(test-assert "maybe-ref on Nothing raises" (raises? (lambda () (maybe-ref (nothing)))))
+(test-equal "maybe-ref/default on a Just" 5 (maybe-ref/default (just 5) 0))
+(test-equal "maybe-ref/default on Nothing" 0 (maybe-ref/default (nothing) 0))
+(test-equal "maybe-ref/default on a Just holding #f" #f (maybe-ref/default (just #f) 0))
+(test-equal "either-ref on a Right yields the payload" 5 (either-ref (right 5)))
+(test-assert "either-ref on a Left raises" (raises? (lambda () (either-ref (left 'e)))))
+(test-equal "either-ref/default on a Right" 5 (either-ref/default (right 5) 0))
+(test-equal "either-ref/default on a Left" 0 (either-ref/default (left 'e) 0))
+
+;; The spec's signatures are (maybe-ref maybe failure [success]) and
+;; (either-ref either failure [success]) — the failure argument is REQUIRED
+;; and the success argument transforms the payload.
+;; FAIL: #2087 (maybe-ref/either-ref take only the container)
+;; (test-equal "maybe-ref calls failure on Nothing"
+;;             'gone (maybe-ref (nothing) (lambda () 'gone)))
+;; FAIL: #2087
+;; (test-equal "maybe-ref applies success to the payload of a Just"
+;;             10 (maybe-ref (just 5) (lambda () 'gone) (lambda (x) (* x 2))))
+;; FAIL: #2087
+;; (test-equal "either-ref passes the Left payload to failure"
+;;             'e (either-ref (left 'e) (lambda (x) x)))
+;; FAIL: #2087
+;; (test-equal "either-ref applies success to the payload of a Right"
+;;             10 (either-ref (right 5) (lambda (x) x) (lambda (x) (* x 2))))
+
+;;; ------------------------------------------------------------------
+;;; Monad laws, asserted as properties rather than case by case.
+;;;   left identity   (bind (unit a) f)   == (f a)
+;;;   right identity  (bind m unit)       == m
+;;;   associativity   (bind (bind m f) g) == (bind m (lambda (x) (bind (f x) g)))
+;;; ------------------------------------------------------------------
+
+(define (mdouble x) (just (* 2 x)))
+(define (minc x) (just (+ 1 x)))
+(define (mfail x) (nothing))
+(define (edouble x) (right (* 2 x)))
+(define (einc x) (right (+ 1 x)))
+(define (efail x) (left 'boom))
+
+(define (maybe-same? a b)
+  (or (and (nothing? a) (nothing? b))
+      (and (just? a) (just? b) (equal? (maybe-ref a) (maybe-ref b)))))
+(define (either-same? a b)
+  (or (and (left? a) (left? b) (equal? (either-ref/default a 'L) (either-ref/default b 'L)))
+      (and (right? a) (right? b) (equal? (either-ref b) (either-ref a)))))
+
+(for-each
+ (lambda (v)
+   (let ((label (number->string v)))
+     (test-assert (string-append "Maybe left identity at " label)
+                  (maybe-same? (maybe-bind (just v) mdouble) (mdouble v)))
+     (test-assert (string-append "Maybe left identity with a failing mproc at " label)
+                  (maybe-same? (maybe-bind (just v) mfail) (mfail v)))
+     (test-assert (string-append "Maybe right identity at " label)
+                  (maybe-same? (maybe-bind (just v) just) (just v)))
+     (test-assert (string-append "Maybe associativity at " label)
+                  (maybe-same? (maybe-bind (maybe-bind (just v) mdouble) minc)
+                               (maybe-bind (just v) (lambda (x) (maybe-bind (mdouble x) minc)))))
+     (test-assert (string-append "Maybe associativity with a failing first step at " label)
+                  (maybe-same? (maybe-bind (maybe-bind (just v) mfail) minc)
+                               (maybe-bind (just v) (lambda (x) (maybe-bind (mfail x) minc)))))
+     (test-assert (string-append "Maybe associativity with a failing second step at " label)
+                  (maybe-same? (maybe-bind (maybe-bind (just v) mdouble) mfail)
+                               (maybe-bind (just v) (lambda (x) (maybe-bind (mdouble x) mfail)))))
+     (test-assert (string-append "Either left identity at " label)
+                  (either-same? (either-bind (right v) edouble) (edouble v)))
+     (test-assert (string-append "Either left identity with a failing mproc at " label)
+                  (either-same? (either-bind (right v) efail) (efail v)))
+     (test-assert (string-append "Either right identity at " label)
+                  (either-same? (either-bind (right v) right) (right v)))
+     (test-assert (string-append "Either associativity at " label)
+                  (either-same? (either-bind (either-bind (right v) edouble) einc)
+                                (either-bind (right v) (lambda (x) (either-bind (edouble x) einc)))))
+     (test-assert (string-append "Either associativity with a failing first step at " label)
+                  (either-same? (either-bind (either-bind (right v) efail) einc)
+                                (either-bind (right v) (lambda (x) (either-bind (efail x) einc)))))))
+ '(0 1 2 7 100))
+
+;; Functor laws, likewise as properties.
+(for-each
+ (lambda (v)
+   (let ((label (number->string v)))
+     (test-assert (string-append "maybe-map preserves identity at " label)
+                  (maybe-same? (maybe-map (lambda (x) x) (just v)) (just v)))
+     (test-assert (string-append "maybe-map composes at " label)
+                  (maybe-same? (maybe-map (lambda (x) (+ 1 (* 2 x))) (just v))
+                               (maybe-map (lambda (x) (+ 1 x)) (maybe-map (lambda (x) (* 2 x)) (just v)))))
+     (test-assert (string-append "either-map preserves identity at " label)
+                  (either-same? (either-map (lambda (x) x) (right v)) (right v)))
+     (test-assert (string-append "either-map composes at " label)
+                  (either-same? (either-map (lambda (x) (+ 1 (* 2 x))) (right v))
+                                (either-map (lambda (x) (+ 1 x))
+                                            (either-map (lambda (x) (* 2 x)) (right v)))))))
+ '(0 1 2 7 100))
+
+;;; ------------------------------------------------------------------
+;;; bind / map short-circuiting
+;;; ------------------------------------------------------------------
+
+(test-assert "maybe-bind on Nothing does not call the mproc"
+             (nothing? (maybe-bind (nothing) (lambda (x) (error "should not run")))))
+(test-assert "either-bind on a Left does not call the mproc"
+             (left? (either-bind (left 'e) (lambda (x) (error "should not run")))))
+;; The Left payload cannot be read back at all through the exported surface:
+;; either-ref/default returns its own default for a Left, and the two spec
+;; procedures that WOULD expose it (either-ref with a failure procedure, and
+;; either-swap) are among the 59 missing names -- see #2087.
+(test-equal "either-ref/default on a Left returns the default, not the payload"
+            'other (either-ref/default (either-bind (left 'e) right) 'other))
+(test-assert "maybe-map on Nothing does not call the proc"
+             (nothing? (maybe-map (lambda (x) (error "should not run")) (nothing))))
+(test-assert "either-map on a Left does not call the proc"
+             (left? (either-map (lambda (x) (error "should not run")) (left 'e))))
+(test-assert "either-map returns a Left unchanged, by identity"
+             (let ((l (left 'e))) (eq? l (either-map (lambda (x) x) l))))
+(test-assert "either-bind returns a Left unchanged, by identity"
+             (let ((l (left 'e))) (eq? l (either-bind l right))))
+(test-equal "maybe-map applies the proc to a Just" 6 (maybe-ref (maybe-map (lambda (x) (* 2 x)) (just 3))))
+(test-equal "either-map applies the proc to a Right" 6 (either-ref (either-map (lambda (x) (* 2 x)) (right 3))))
+
+;; FAIL: #2087 (maybe-bind/either-bind accept only one mproc)
+;; (test-equal "maybe-bind chains several mprocs"
+;;             7 (maybe-ref (maybe-bind (just 3) mdouble minc)))
+;; FAIL: #2087
+;; (test-equal "either-bind chains several mprocs"
+;;             7 (either-ref (either-bind (right 3) edouble einc)))
+
+;; Discriminating control: chaining by hand through nested single-mproc binds
+;; gives the value the variadic form would.
+(test-equal "chaining two binds by hand yields the same value"
+            7 (maybe-ref (maybe-bind (maybe-bind (just 3) mdouble) minc)))
+
+;;; ------------------------------------------------------------------
+;;; filter
+;;; ------------------------------------------------------------------
+
+(test-assert "maybe-filter keeps a Just whose payload passes"
+             (just? (maybe-filter even? (just 2))))
+(test-equal "maybe-filter keeps the payload" 2 (maybe-ref (maybe-filter even? (just 2))))
+(test-assert "maybe-filter drops a Just whose payload fails"
+             (nothing? (maybe-filter even? (just 3))))
+(test-assert "maybe-filter on Nothing is Nothing" (nothing? (maybe-filter even? (nothing))))
+(test-assert "either-filter keeps a Right whose payload passes"
+             (right? (either-filter even? (right 2))))
+(test-assert "either-filter turns a failing Right into a Left"
+             (left? (either-filter even? (right 3))))
+(test-assert "either-filter on a Left is a Left" (left? (either-filter even? (left 'e))))
+
+;; The spec's signature is (either-filter pred either obj) — obj is the payload
+;; of the Left produced when the predicate fails.
+;; FAIL: #2087 (either-filter takes no Left payload; it synthesises its own)
+;; (test-equal "either-filter uses the supplied object as the Left payload"
+;;             'nope (either-ref/default (either-filter even? (right 3) 'nope) 'other))
+
+;;; ------------------------------------------------------------------
+;;; Values conversion
+;;; ------------------------------------------------------------------
+
+(test-equal "maybe->values on a Just yields one value"
+            '(5) (call-with-values (lambda () (maybe->values (just 5))) list))
+(test-equal "maybe->values on Nothing yields no values"
+            '() (call-with-values (lambda () (maybe->values (nothing))) list))
+(test-equal "values->maybe of one value is a Just" 5 (maybe-ref (values->maybe 5)))
+(test-assert "values->maybe of no values is Nothing" (nothing? (values->maybe)))
+(test-assert "values->maybe round trips a Just"
+             (maybe-same? (just 5) (call-with-values (lambda () (maybe->values (just 5))) values->maybe)))
+(test-assert "values->maybe round trips Nothing"
+             (maybe-same? (nothing)
+                          (call-with-values (lambda () (maybe->values (nothing))) values->maybe)))
+(test-equal "either->values on a Right yields one value"
+            '(5) (call-with-values (lambda () (either->values (right 5))) list))
+(test-equal "either->values on a Left yields no values"
+            '() (call-with-values (lambda () (either->values (left 5))) list))
+
+;;; ------------------------------------------------------------------
+;;; Export completeness. SRFI 189 specifies 82 identifiers; 59 are absent.
+;;; Each disabled assertion below names one representative from a distinct
+;;; group of the spec's own table of contents.
+;;; ------------------------------------------------------------------
+
+;; FAIL: #2087 (maybe= / either= — the "Predicates" group)
+;; (test-assert "maybe= compares two Maybes" (maybe= eqv? (just 1) (just 1)))
+;; FAIL: #2087 (maybe-join / either-join — the "Join and bind" group)
+;; (test-equal "maybe-join flattens a nested Just" 1 (maybe-ref (maybe-join (just (just 1)))))
+;; FAIL: #2087 (either-swap — the "Constructors" group)
+;; (test-assert "either-swap turns a Right into a Left" (left? (either-swap (right 1))))
+;; FAIL: #2087 (maybe->either / either->maybe — protocol conversion between the two types)
+;; (test-assert "maybe->either converts a Just to a Right" (right? (maybe->either (just 1) 'e)))
+;; FAIL: #2087 (list->maybe / maybe->list — the list protocol)
+;; (test-equal "list->maybe of a one-element list is a Just" 1 (maybe-ref (list->maybe '(1))))
+;; FAIL: #2087 (maybe-length / either-length — the "Sequence operations" group)
+;; (test-equal "maybe-length of a Just is 1" 1 (maybe-length (just 1)))
+;; FAIL: #2087 (maybe-fold / maybe-unfold / maybe-for-each — the "Map, fold, unfold" group)
+;; (test-equal "maybe-fold folds over the payload" 6 (maybe-fold + 5 (just 1)))
+;; FAIL: #2087 (maybe-if / maybe-and / maybe-or / maybe-let* — the "Syntax" group)
+;; (test-equal "maybe-if branches on a Just" 'yes (maybe-if (just 1) 'yes 'no))
+;; FAIL: #2087 (tri-not / tri=? / tri-and / tri-or / tri-merge — the "Trivalent logic" group)
+;; (test-assert "tri-not negates a Just #t" (not (maybe-ref (tri-not (just #t)))))
+;; FAIL: #2087 (exception->either — the "Protocol conversion" group)
+;; (test-assert "exception->either catches a raise into a Left"
+;;              (left? (exception->either error? (lambda () (error "boom")))))
+
+;; Discriminating control: the SRFI answers "available" to both feature tests,
+;; so a portable program cannot detect the missing 59 names.
+(test-assert "cond-expand reports the srfi-189 feature identifier"
+             (cond-expand (srfi-189 #t) (else #f)))
+(test-assert "cond-expand reports (library (srfi 189)) as available"
+             (cond-expand ((library (srfi 189)) #t) (else #f)))
+
+;;; `either` appears in the library's export clause but is never defined in its
+;;; body, so it is a phantom export: Kaappi silently skips an export naming an
+;;; identifier that is not in lib_env, and a program that imports it gets an
+;;; undefined-variable error at the point of USE, not of import. Part of #2087.
+;; FAIL: #2087 (`either` is exported but never defined)
+;; (test-assert "the exported `either` is bound" (procedure? either))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi189 audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi225-audit.scm
+++ b/tests/scheme/srfi/srfi225-audit.scm
@@ -1,0 +1,428 @@
+;;; Audit: lib/srfi/225.sld (SRFI 225 — Dictionaries)
+;;; Systematic audit v2, Phase 3.9 (docs/audit-strategy.md, tracking #1890).
+;;;
+;;; Oracle: SRFI 225, https://srfi.schemers.org/srfi-225/srfi-225.html
+;;;
+;;; SRFI 225 is a generic protocol over several concrete dictionary types, so
+;;; the instrument that matters is the DIFFERENTIAL: the same operation on
+;;; every DTO the library ships must produce the same answer. Every generic
+;;; procedure below is therefore run against all three
+;;; (eqv-alist-dto, equal-alist-dto, hash-table-dto) and asserted equal
+;;; across them, then asserted against the spec's own stated value.
+;;;
+;;; The cross-DTO sweep found 49 of 51 operation groups in exact agreement.
+;;; The two that differ, both correctly:
+;;;   * dict-ref with no failure procedure raises on all three (the spec's
+;;;     default failure signals an error), so "agreement" there is agreement
+;;;     on raising;
+;;;   * dict-pure? is #t for the two alist DTOs and #f for the hash-table
+;;;     DTO, which is exactly what the predicate exists to report.
+;;;
+;;; Portability: dictionaries are unordered, so every list result is sorted
+;;; and every dictionary result is compared as a sorted key/value alist.
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi225-audit.scm
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 64) (srfi 225)
+        (except (srfi 69) string-hash string-ci-hash)
+        (srfi 128) (srfi 158))
+
+(test-begin "srfi225 audit")
+
+(define (isort less l)
+  (let loop ((in l) (out '()))
+    (if (null? in) out
+        (loop (cdr in)
+              (let ins ((o out))
+                (cond ((null? o) (list (car in)))
+                      ((less (car in) (car o)) (cons (car in) o))
+                      (else (cons (car o) (ins (cdr o))))))))))
+(define (srt l) (isort < l))
+(define (srtp l) (isort (lambda (x y) (< (car x) (car y))) l))
+(define (raises? thunk)
+  (call-with-current-continuation
+   (lambda (k) (with-exception-handler (lambda (e) (k #t)) (lambda () (thunk) #f)))))
+
+(define (mk-alist) (list (cons 1 'a) (cons 2 'b) (cons 3 'c)))
+(define (mk-ht)
+  (let ((h (make-hash-table equal?)))
+    (hash-table-set! h 1 'a) (hash-table-set! h 2 'b) (hash-table-set! h 3 'c) h))
+
+;; (label dto fresh-dict-maker)
+(define dtos
+  (list (list "eqv-alist" eqv-alist-dto mk-alist)
+        (list "equal-alist" equal-alist-dto mk-alist)
+        (list "hash-table" hash-table-dto mk-ht)))
+
+(define (canon dto d) (srtp (dict->alist dto d)))
+
+;; A fresh dict of the same concrete type as `dto` expects.
+(define (fresh-for dto)
+  (let loop ((es dtos))
+    (cond ((null? es) (error "fresh-for: unknown dto"))
+          ((eq? dto (cadr (car es))) ((caddr (car es))))
+          (else (loop (cdr es))))))
+
+;; Run `proc` under every DTO. Assert (a) all three agree with each other and
+;; (b) they all equal `expected`.
+(define (differential name expected proc)
+  (let* ((vals (map (lambda (e) (proc (cadr e) ((caddr e)))) dtos))
+         (first (car vals)))
+    (for-each
+     (lambda (e v)
+       (test-equal (string-append name " [" (car e) "] agrees with the spec") expected v)
+       (test-equal (string-append name " [" (car e) "] agrees with eqv-alist") first v))
+     dtos vals)))
+
+;;; ------------------------------------------------------------------
+;;; Type predicate and inspection
+;;; ------------------------------------------------------------------
+
+(differential "dictionary? on a matching dict" #t (lambda (dto d) (dictionary? dto d)))
+(differential "dictionary? on a number" #f (lambda (dto d) (dictionary? dto 42)))
+(differential "dict->alist" '((1 . a) (2 . b) (3 . c)) (lambda (dto d) (canon dto d)))
+(differential "dict-size" 3 (lambda (dto d) (dict-size dto d)))
+(differential "dict-empty? on a populated dict" #f (lambda (dto d) (dict-empty? dto d)))
+(differential "dict-empty? after deleting everything" #t
+              (lambda (dto d) (dict-empty? dto (dict-delete-all! dto d '(1 2 3)))))
+(differential "dict-contains? present" #t (lambda (dto d) (dict-contains? dto d 1)))
+(differential "dict-contains? absent" #f (lambda (dto d) (dict-contains? dto d 9)))
+(differential "dict-comparator returns a comparator" #t
+              (lambda (dto d) (comparator? (dict-comparator dto d))))
+
+;;; ------------------------------------------------------------------
+;;; Lookup
+;;; ------------------------------------------------------------------
+
+(differential "dict-ref finds a present key" 'a (lambda (dto d) (dict-ref dto d 1)))
+(differential "dict-ref calls failure for an absent key" 'none
+              (lambda (dto d) (dict-ref dto d 9 (lambda () 'none))))
+(differential "dict-ref passes the value to success" '(got a)
+              (lambda (dto d) (dict-ref dto d 1 (lambda () 'none) (lambda (v) (list 'got v)))))
+;; "If failure is not supplied, ... an error satisfying dictionary-error? is signalled."
+(differential "dict-ref with no failure raises on an absent key" #t
+              (lambda (dto d) (raises? (lambda () (dict-ref dto d 9)))))
+(differential "dict-ref/default present" 'a (lambda (dto d) (dict-ref/default dto d 1 'dflt)))
+(differential "dict-ref/default absent" 'dflt (lambda (dto d) (dict-ref/default dto d 9 'dflt)))
+
+;;; ------------------------------------------------------------------
+;;; Mutation. "New values override existing ones" for dict-set!;
+;;; "Existing values prevail over new ones" for dict-adjoin!.
+;;; ------------------------------------------------------------------
+
+(differential "dict-set! adds a new key" '((1 . a) (2 . b) (3 . c) (4 . d))
+              (lambda (dto d) (canon dto (dict-set! dto d 4 'd))))
+(differential "dict-set! overrides an existing value" '((1 . z) (2 . b) (3 . c))
+              (lambda (dto d) (canon dto (dict-set! dto d 1 'z))))
+(differential "dict-set! takes several key/value pairs"
+              '((1 . a) (2 . b) (3 . c) (4 . d) (5 . e))
+              (lambda (dto d) (canon dto (dict-set! dto d 4 'd 5 'e))))
+(differential "dict-adjoin! adds a new key" '((1 . a) (2 . b) (3 . c) (4 . d))
+              (lambda (dto d) (canon dto (dict-adjoin! dto d 4 'd))))
+(differential "dict-adjoin! leaves an existing value alone" '((1 . a) (2 . b) (3 . c))
+              (lambda (dto d) (canon dto (dict-adjoin! dto d 1 'z))))
+(differential "dict-delete! removes a key" '((2 . b) (3 . c))
+              (lambda (dto d) (canon dto (dict-delete! dto d 1))))
+(differential "dict-delete! of an absent key changes nothing" '((1 . a) (2 . b) (3 . c))
+              (lambda (dto d) (canon dto (dict-delete! dto d 9))))
+(differential "dict-delete-all! takes a list" '((2 . b))
+              (lambda (dto d) (canon dto (dict-delete-all! dto d '(1 3)))))
+;; "Returns a dictionary with all associations of dict except that if key
+;;  exists, its value is replaced. If key absent, dict returns unchanged."
+(differential "dict-replace! replaces a present key" '((1 . z) (2 . b) (3 . c))
+              (lambda (dto d) (canon dto (dict-replace! dto d 1 'z))))
+(differential "dict-replace! does not insert an absent key" '((1 . a) (2 . b) (3 . c))
+              (lambda (dto d) (canon dto (dict-replace! dto d 9 'z))))
+;; "Returns two values: if key exists, dict and its associated value;
+;;  otherwise, an updated dictionary with new association and the failure result."
+(differential "dict-intern! on a present key returns the existing value"
+              '(((1 . a) (2 . b) (3 . c)) a)
+              (lambda (dto d)
+                (call-with-values (lambda () (dict-intern! dto d 1 (lambda () 'new)))
+                                  (lambda (d2 v) (list (canon dto d2) v)))))
+(differential "dict-intern! on an absent key inserts the failure result"
+              '(((1 . a) (2 . b) (3 . c) (9 . new)) new)
+              (lambda (dto d)
+                (call-with-values (lambda () (dict-intern! dto d 9 (lambda () 'new)))
+                                  (lambda (d2 v) (list (canon dto d2) v)))))
+(differential "dict-update! applies the updater to a present value"
+              '((1 . (a a)) (2 . b) (3 . c))
+              (lambda (dto d)
+                (canon dto (dict-update! dto d 1 (lambda (v) (list v v)) (lambda () 'fail)))))
+(differential "dict-update! uses failure for an absent key"
+              '((1 . a) (2 . b) (3 . c) (9 . (fail fail)))
+              (lambda (dto d)
+                (canon dto (dict-update! dto d 9 (lambda (v) (list v v)) (lambda () 'fail)))))
+(differential "dict-update! with no failure raises on an absent key" #t
+              (lambda (dto d) (raises? (lambda () (dict-update! dto d 9 (lambda (v) v))))))
+(differential "dict-update/default! uses the default for an absent key"
+              '((1 . a) (2 . b) (3 . c) (9 . (dflt dflt)))
+              (lambda (dto d)
+                (canon dto (dict-update/default! dto d 9 (lambda (v) (list v v)) 'dflt))))
+(differential "dict-update/default! ignores the default for a present key"
+              '((1 . (a a)) (2 . b) (3 . c))
+              (lambda (dto d)
+                (canon dto (dict-update/default! dto d 1 (lambda (v) (list v v)) 'dflt))))
+;; "Chooses an association from dict and returns three values: a dictionary
+;;  containing all associations except the chosen one, the key, and the value."
+(differential "dict-pop! shrinks by one and drops the key it returned" '(2 #f)
+              (lambda (dto d)
+                (call-with-values (lambda () (dict-pop! dto d))
+                                  (lambda (d2 k v) (list (dict-size dto d2)
+                                                         (dict-contains? dto d2 k))))))
+(differential "dict-pop! returns a key/value pair that was in the dict" #t
+              (lambda (dto d)
+                (call-with-values (lambda () (dict-pop! dto d))
+                                  (lambda (d2 k v) (memv k '(1 2 3)) (and (memv k '(1 2 3)) #t)))))
+
+;;; ------------------------------------------------------------------
+;;; dict-find-update! — the primitive every other updater is built on.
+;;; ------------------------------------------------------------------
+
+(differential "dict-find-update! success/update"
+              '(((1 . (a a)) (2 . b) (3 . c)) upd)
+              (lambda (dto d)
+                (call-with-values
+                 (lambda () (dict-find-update!
+                             dto d 1
+                             (lambda (insert ignore) (ignore 'absent))
+                             (lambda (key value update delete) (update key (list value value) 'upd))))
+                 (lambda (d2 obj) (list (canon dto d2) obj)))))
+(differential "dict-find-update! failure/insert"
+              '(((1 . a) (2 . b) (3 . c) (9 . new)) ins)
+              (lambda (dto d)
+                (call-with-values
+                 (lambda () (dict-find-update!
+                             dto d 9
+                             (lambda (insert ignore) (insert 'new 'ins))
+                             (lambda (key value update delete) (update key value 'upd))))
+                 (lambda (d2 obj) (list (canon dto d2) obj)))))
+(differential "dict-find-update! failure/ignore leaves the dict alone"
+              '(((1 . a) (2 . b) (3 . c)) skipped)
+              (lambda (dto d)
+                (call-with-values
+                 (lambda () (dict-find-update!
+                             dto d 9
+                             (lambda (insert ignore) (ignore 'skipped))
+                             (lambda (key value update delete) (update key value 'upd))))
+                 (lambda (d2 obj) (list (canon dto d2) obj)))))
+(differential "dict-find-update! success/delete"
+              '(((2 . b) (3 . c)) del)
+              (lambda (dto d)
+                (call-with-values
+                 (lambda () (dict-find-update!
+                             dto d 1
+                             (lambda (insert ignore) (ignore 'absent))
+                             (lambda (key value update delete) (delete 'del))))
+                 (lambda (d2 obj) (list (canon dto d2) obj)))))
+
+;;; ------------------------------------------------------------------
+;;; Whole-dictionary traversal
+;;; ------------------------------------------------------------------
+
+(differential "dict-count counts matching associations" 2
+              (lambda (dto d) (dict-count dto (lambda (k v) (odd? k)) d)))
+(differential "dict-any returns the first true result" 'found
+              (lambda (dto d) (dict-any dto (lambda (k v) (and (= k 2) 'found)) d)))
+(differential "dict-any returns #f when nothing matches" #f
+              (lambda (dto d) (dict-any dto (lambda (k v) (and (= k 99) 'found)) d)))
+(differential "dict-every is true when every association matches" #t
+              (lambda (dto d) (and (dict-every dto (lambda (k v) (< k 10)) d) #t)))
+(differential "dict-every is #f as soon as one fails" #f
+              (lambda (dto d) (dict-every dto (lambda (k v) (= k 1)) d)))
+(differential "dict-keys" '(1 2 3) (lambda (dto d) (srt (dict-keys dto d))))
+(differential "dict-values has one entry per association" 3
+              (lambda (dto d) (length (dict-values dto d))))
+(differential "dict-entries returns keys and values as two values" '((1 2 3) 3)
+              (lambda (dto d)
+                (call-with-values (lambda () (dict-entries dto d))
+                                  (lambda (ks vs) (list (srt ks) (length vs))))))
+(differential "dict-fold threads the accumulator" 6
+              (lambda (dto d) (dict-fold dto (lambda (k v acc) (+ acc k)) 0 d)))
+(differential "dict-fold on an emptied dict returns knil" 'seed
+              (lambda (dto d) (dict-fold dto (lambda (k v acc) 'other) 'seed
+                                         (dict-delete-all! dto d '(1 2 3)))))
+(differential "dict-map rewrites every value" '((1 . (a)) (2 . (b)) (3 . (c)))
+              (lambda (dto d) (canon dto (dict-map dto (lambda (k v) (list v)) d))))
+(differential "dict-filter keeps matching associations" '((1 . a) (3 . c))
+              (lambda (dto d) (canon dto (dict-filter dto (lambda (k v) (odd? k)) d))))
+(differential "dict-remove drops matching associations" '((2 . b))
+              (lambda (dto d) (canon dto (dict-remove dto (lambda (k v) (odd? k)) d))))
+(differential "dict-map->list" '(1 2 3)
+              (lambda (dto d) (srt (dict-map->list dto (lambda (k v) k) d))))
+(differential "dict-for-each visits every association" 6
+              (lambda (dto d) (let ((n 0)) (dict-for-each dto (lambda (k v) (set! n (+ n k))) d) n)))
+(differential "dict->generator yields every key then eof" '(1 2 3)
+              (lambda (dto d)
+                (let ((g (dict->generator dto d)))
+                  (srt (let loop ((acc '()))
+                         (let ((x (g)))
+                           (if (eof-object? x) acc (loop (cons (car x) acc)))))))))
+(differential "dict->generator is exhausted after the last association" #t
+              (lambda (dto d)
+                (let ((g (dict->generator dto d)))
+                  (g) (g) (g) (eof-object? (g)))))
+(differential "dict=? on a dict and itself" #t
+              (lambda (dto d) (dict=? dto eqv? d d)))
+;; Build the second dict with the SAME DTO, so the hash-table leg is compared
+;; against a hash table rather than an alist.
+(differential "dict=? on two independently built equal dicts" #t
+              (lambda (dto d) (dict=? dto eqv? d (fresh-for dto))))
+(differential "dict=? on dicts with different values" #f
+              (lambda (dto d) (dict=? dto eqv? d (dict-set! dto (fresh-for dto) 1 'z))))
+(differential "dict=? on dicts of different sizes" #f
+              (lambda (dto d) (dict=? dto eqv? d (dict-delete! dto (fresh-for dto) 1))))
+
+;;; The pure traversal procedures must not touch their argument.
+(differential "dict-map does not mutate its argument" #t
+              (lambda (dto d) (let ((before (canon dto d)))
+                                (dict-map dto (lambda (k v) 'x) d)
+                                (equal? before (canon dto d)))))
+(differential "dict-filter does not mutate its argument" #t
+              (lambda (dto d) (let ((before (canon dto d)))
+                                (dict-filter dto (lambda (k v) #f) d)
+                                (equal? before (canon dto d)))))
+(differential "dict-remove does not mutate its argument" #t
+              (lambda (dto d) (let ((before (canon dto d)))
+                                (dict-remove dto (lambda (k v) #t) d)
+                                (equal? before (canon dto d)))))
+
+;;; ------------------------------------------------------------------
+;;; Accumulators
+;;; ------------------------------------------------------------------
+
+(differential "dict-set!-accumulator collects pairs until eof"
+              '((1 . a) (2 . b) (3 . c) (7 . g))
+              (lambda (dto d) (let ((a (dict-set!-accumulator dto d)))
+                                (a (cons 7 'g)) (canon dto (a (eof-object))))))
+(differential "dict-set!-accumulator overrides an existing key"
+              '((1 . z) (2 . b) (3 . c))
+              (lambda (dto d) (let ((a (dict-set!-accumulator dto d)))
+                                (a (cons 1 'z)) (canon dto (a (eof-object))))))
+(differential "dict-adjoin!-accumulator collects pairs until eof"
+              '((1 . a) (2 . b) (3 . c) (7 . g))
+              (lambda (dto d) (let ((a (dict-adjoin!-accumulator dto d)))
+                                (a (cons 7 'g)) (canon dto (a (eof-object))))))
+(differential "dict-adjoin!-accumulator leaves an existing key alone"
+              '((1 . a) (2 . b) (3 . c))
+              (lambda (dto d) (let ((a (dict-adjoin!-accumulator dto d)))
+                                (a (cons 1 'z)) (canon dto (a (eof-object))))))
+
+;;; ------------------------------------------------------------------
+;;; DTO construction and the proc-id tags. The `-id` names are the whole
+;;; extension mechanism and none of them had ever been referenced by a test.
+;;; ------------------------------------------------------------------
+
+(test-assert "dto? on a shipped DTO" (dto? eqv-alist-dto))
+(test-assert "dto? on a number" (not (dto? 42)))
+(test-assert "dto? on a freshly made empty DTO" (dto? (make-dto)))
+(test-assert "make-alist-dto builds a DTO" (dto? (make-alist-dto equal?)))
+(test-assert "srfi-69-dto and hash-table-dto are the same object"
+             (eq? srfi-69-dto hash-table-dto))
+(test-assert "eqv-alist-dto and equal-alist-dto are different objects"
+             (not (eq? eqv-alist-dto equal-alist-dto)))
+
+;; Every proc-id is a distinct tag, and dto-ref answers with a procedure or #f.
+(for-each
+ (lambda (entry)
+   (let ((name (car entry)) (id (cadr entry)))
+     (test-assert (string-append "dto-ref " name " on the alist DTO answers a procedure or #f")
+                  (let ((v (dto-ref eqv-alist-dto id)))
+                    (or (procedure? v) (eq? v #f))))
+     (test-assert (string-append "dto-ref " name " on the hash-table DTO answers a procedure or #f")
+                  (let ((v (dto-ref hash-table-dto id)))
+                    (or (procedure? v) (eq? v #f))))
+     (test-assert (string-append "dto-ref " name " on an empty DTO is #f")
+                  (not (dto-ref (make-dto) id)))))
+ (list (list "dictionary?-id" dictionary?-id)
+       (list "dict-find-update!-id" dict-find-update!-id)
+       (list "dict-comparator-id" dict-comparator-id)
+       (list "dict-map-id" dict-map-id)
+       (list "dict-pure?-id" dict-pure?-id)
+       (list "dict-remove-id" dict-remove-id)
+       (list "dict-size-id" dict-size-id)
+       (list "dict-ref-id" dict-ref-id)
+       (list "dict-ref/default-id" dict-ref/default-id)
+       (list "dict-set!-id" dict-set!-id)
+       (list "dict-adjoin!-id" dict-adjoin!-id)
+       (list "dict-delete!-id" dict-delete!-id)
+       (list "dict-delete-all!-id" dict-delete-all!-id)
+       (list "dict-replace!-id" dict-replace!-id)
+       (list "dict-intern!-id" dict-intern!-id)
+       (list "dict-update!-id" dict-update!-id)
+       (list "dict-update/default!-id" dict-update/default!-id)
+       (list "dict-pop!-id" dict-pop!-id)
+       (list "dict-contains?-id" dict-contains?-id)
+       (list "dict-empty?-id" dict-empty?-id)
+       (list "dict-count-id" dict-count-id)
+       (list "dict-any-id" dict-any-id)
+       (list "dict-every-id" dict-every-id)
+       (list "dict-keys-id" dict-keys-id)
+       (list "dict-values-id" dict-values-id)
+       (list "dict-entries-id" dict-entries-id)
+       (list "dict-fold-id" dict-fold-id)
+       (list "dict-for-each-id" dict-for-each-id)
+       (list "dict-map->list-id" dict-map->list-id)
+       (list "dict-filter-id" dict-filter-id)
+       (list "dict->alist-id" dict->alist-id)
+       (list "dict->generator-id" dict->generator-id)
+       (list "dict=?-id" dict=?-id)
+       (list "dict-set!-accumulator-id" dict-set!-accumulator-id)
+       (list "dict-adjoin!-accumulator-id" dict-adjoin!-accumulator-id)))
+
+;; A DTO built by hand from make-dto really is dispatched through.
+(let ((custom (make-dto dictionary?-id (lambda (obj) (eq? obj 'my-dict))
+                        dict-size-id (lambda (d) 42))))
+  (test-assert "make-dto: the supplied type predicate is used"
+               (dictionary? custom 'my-dict))
+  (test-assert "make-dto: the supplied type predicate rejects other objects"
+               (not (dictionary? custom 'something-else)))
+  (test-equal "make-dto: the supplied dict-size is used" 42 (dict-size custom 'my-dict)))
+(test-assert "make-dto with an odd number of arguments is rejected"
+             (raises? (lambda () (make-dto dictionary?-id))))
+
+;;; dict-pure? is the one operation that legitimately differs by DTO.
+(test-assert "dict-pure? is true for the eqv alist DTO" (dict-pure? eqv-alist-dto (mk-alist)))
+(test-assert "dict-pure? is true for the equal alist DTO" (dict-pure? equal-alist-dto (mk-alist)))
+(test-assert "dict-pure? is false for the hash-table DTO"
+             (not (dict-pure? hash-table-dto (mk-ht))))
+
+;;; The alist DTOs really do use their own equality predicate.
+(test-equal "the equal alist DTO matches a string key by equal?"
+            'v (dict-ref equal-alist-dto (list (cons "k" 'v)) (string-copy "k") (lambda () 'none)))
+(test-equal "the eqv alist DTO does not match a fresh string key"
+            'none (dict-ref eqv-alist-dto (list (cons "k" 'v)) (string-copy "k") (lambda () 'none)))
+
+;;; ------------------------------------------------------------------
+;;; dictionary-error
+;;; ------------------------------------------------------------------
+
+(test-assert "dictionary-error? on a non-condition" (not (dictionary-error? 42)))
+(test-equal "dictionary-error raises an object carrying its message and irritants"
+            '(#t "boom" (1 2))
+            (call-with-current-continuation
+             (lambda (k)
+               (with-exception-handler
+                (lambda (e) (k (list (dictionary-error? e)
+                                     (dictionary-message e)
+                                     (dictionary-irritants e))))
+                (lambda () (dictionary-error "boom" 1 2))))))
+(test-equal "dictionary-error with no irritants"
+            '()
+            (call-with-current-continuation
+             (lambda (k)
+               (with-exception-handler (lambda (e) (k (dictionary-irritants e)))
+                                       (lambda () (dictionary-error "boom"))))))
+
+;;; The library's own documented scope decision: start/end bounds only make
+;;; sense for an ordered dict, and none of the three DTOs is ordered, so both
+;;; range-taking procedures reject them rather than ignoring them.
+(test-assert "dict-for-each rejects a start bound on an unordered dict"
+             (raises? (lambda () (dict-for-each eqv-alist-dto (lambda (k v) #f) (mk-alist) 0))))
+(test-assert "dict->generator rejects a start bound on an unordered dict"
+             (raises? (lambda () (dict->generator eqv-alist-dto (mk-alist) 0))))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi225 audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi240-audit.scm
+++ b/tests/scheme/srfi/srfi240-audit.scm
@@ -1,0 +1,227 @@
+;;; Audit: lib/srfi/240.sld (SRFI 240 — Reconciled Records) over (srfi 237)
+;;; Systematic audit v2, Phase 3.9 (docs/audit-strategy.md, tracking #1890).
+;;;
+;;; Oracle: SRFI 240, https://srfi.schemers.org/srfi-240/srfi-240.html, whose
+;;; whole content is "a `define-record-type` that accepts EITHER R6RS clause
+;;; syntax or the R7RS/SRFI-9 positional syntax, both producing interoperable
+;;; record types", with everything else inherited from SRFI 237.
+;;;
+;;; That interoperability claim is what this file tests, and it is where the
+;;; finding is: a record type created by R7RS positional `define-record-type`
+;;; reports ZERO field names to the SRFI 237/240 inspection layer, so
+;;; record-type-field-names lies (#() rather than the fields the type has) and
+;;; record-accessor / record-mutator / record-field-mutable? are unusable on
+;;; it. The R6RS-clause and procedural paths are both correct, which is the
+;;; discriminating control. Filed as #2088.
+;;;
+;;; The pre-existing tests/scheme/srfi/srfi240.scm has 12 assertions and never
+;;; touches 17 of the 23 exports.
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi240-audit.scm
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 240))
+
+(test-begin "srfi240 audit")
+
+(define (raises? thunk)
+  (call-with-current-continuation
+   (lambda (k) (with-exception-handler (lambda (e) (k #t)) (lambda () (thunk) #f)))))
+
+;;; ------------------------------------------------------------------
+;;; The procedural layer, which SRFI 240 re-exports verbatim from SRFI 237.
+;;; ------------------------------------------------------------------
+
+(define rtd-pt (make-record-type-descriptor 'pt #f #f #f #f '#((mutable x) (immutable y))))
+
+(test-assert "record-type-descriptor? on a procedurally built rtd"
+             (record-type-descriptor? rtd-pt))
+(test-assert "record-type-descriptor? on a non-rtd" (not (record-type-descriptor? 42)))
+(test-equal "record-type-name" 'pt (record-type-name rtd-pt))
+(test-equal "record-type-field-names is a vector of the own field names"
+            '#(x y) (record-type-field-names rtd-pt))
+(test-assert "record-field-mutable? on a mutable field" (record-field-mutable? rtd-pt 0))
+(test-assert "record-field-mutable? on an immutable field"
+             (not (record-field-mutable? rtd-pt 1)))
+(test-assert "record-type-parent of a parentless rtd is #f" (not (record-type-parent rtd-pt)))
+(test-assert "record-type-uid of a generative rtd is #f" (not (record-type-uid rtd-pt)))
+(test-assert "record-type-generative? of a uid-less rtd" (record-type-generative? rtd-pt))
+(test-assert "record-type-sealed? defaults to false" (not (record-type-sealed? rtd-pt)))
+(test-assert "record-type-opaque? defaults to false" (not (record-type-opaque? rtd-pt)))
+
+(define rcd-pt (make-record-constructor-descriptor rtd-pt #f #f))
+(test-assert "record-constructor-descriptor? on a fresh rcd"
+             (record-constructor-descriptor? rcd-pt))
+(test-assert "record-constructor-descriptor? on an rtd" (not (record-constructor-descriptor? rtd-pt)))
+(define make-pt (record-constructor rcd-pt))
+(define pt? (record-predicate rtd-pt))
+(define pt-x (record-accessor rtd-pt 0))
+(define pt-y (record-accessor rtd-pt 1))
+(define set-pt-x! (record-mutator rtd-pt 0))
+(define p1 (make-pt 1 2))
+
+(test-assert "record? on a procedurally built instance" (record? p1))
+(test-assert "record? on a non-record" (not (record? 42)))
+(test-assert "the predicate accepts its own instances" (pt? p1))
+(test-assert "the predicate rejects other values" (not (pt? 42)))
+(test-equal "accessor 0" 1 (pt-x p1))
+(test-equal "accessor 1" 2 (pt-y p1))
+(test-assert "record-rtd returns the type it was built from" (eq? rtd-pt (record-rtd p1)))
+(test-equal "the mutator writes the field" 9 (begin (set-pt-x! p1 9) (pt-x p1)))
+(test-assert "record-mutator on an immutable field is rejected"
+             (raises? (lambda () (record-mutator rtd-pt 1))))
+(test-assert "record-accessor with an out-of-range index is rejected"
+             (raises? (lambda () (record-accessor rtd-pt 5))))
+
+;;; Sealed, opaque and nongenerative rtds
+(define rtd-sealed (make-record-type-descriptor 'sealed-pt #f #f #t #f '#((immutable a))))
+(test-assert "record-type-sealed? on a sealed rtd" (record-type-sealed? rtd-sealed))
+(test-assert "a sealed rtd cannot be a parent"
+             (raises? (lambda () (make-record-type-descriptor 'kid rtd-sealed #f #f #f '#()))))
+(define rtd-opaque (make-record-type-descriptor 'opaque-pt #f #f #f #t '#((immutable a))))
+(test-assert "record-type-opaque? on an opaque rtd" (record-type-opaque? rtd-opaque))
+(define rtd-uid (make-record-type-descriptor 'uid-pt #f 'srfi240-audit-uid #f #f '#((immutable a))))
+(test-equal "record-type-uid of a nongenerative rtd" 'srfi240-audit-uid (record-type-uid rtd-uid))
+(test-assert "record-type-generative? of a nongenerative rtd is false"
+             (not (record-type-generative? rtd-uid)))
+(test-assert "record-uid->rtd finds a nongenerative rtd by its uid"
+             (eq? rtd-uid (record-uid->rtd 'srfi240-audit-uid)))
+(test-assert "record-uid->rtd of an unknown uid is #f"
+             (not (record-uid->rtd 'srfi240-audit-no-such-uid)))
+(test-assert "re-declaring the same uid with the same shape yields the same rtd"
+             (eq? rtd-uid (make-record-type-descriptor 'uid-pt #f 'srfi240-audit-uid #f #f
+                                                       '#((immutable a)))))
+
+;;; Inheritance through the procedural layer
+(define rtd-base (make-record-type-descriptor 'base #f #f #f #f '#((immutable a))))
+(define rtd-kid (make-record-type-descriptor 'kid rtd-base #f #f #f '#((immutable b))))
+(test-assert "record-type-parent of a child rtd" (eq? rtd-base (record-type-parent rtd-kid)))
+(test-equal "a child rtd's field names exclude the parent's" '#(b)
+            (record-type-field-names rtd-kid))
+(define make-kid (record-constructor (make-record-constructor-descriptor rtd-kid #f #f)))
+(define k1 (make-kid 1 2))
+(test-equal "a child instance's inherited field" 1 ((record-accessor rtd-base 0) k1))
+(test-equal "a child instance's own field" 2 ((record-accessor rtd-kid 0) k1))
+(test-assert "the parent's predicate accepts a child instance" ((record-predicate rtd-base) k1))
+(test-assert "the child's predicate rejects a parent instance"
+             (not ((record-predicate rtd-kid)
+                   ((record-constructor (make-record-constructor-descriptor rtd-base #f #f)) 1))))
+
+;;; record-descriptor: the pairing of an rtd with an rcd
+;; Two arities: the 3-argument (rtd parent-rd protocol) form and the
+;; 7-argument (name parent uid sealed? opaque? fields protocol) shorthand.
+(define rd (make-record-descriptor rtd-pt #f #f))
+(test-assert "record-descriptor? on a fresh record descriptor" (record-descriptor? rd))
+(test-assert "record-descriptor? on an rtd" (not (record-descriptor? rtd-pt)))
+(test-assert "record-descriptor-rtd returns the rtd" (eq? rtd-pt (record-descriptor-rtd rd)))
+(test-assert "record-descriptor-parent of a parentless descriptor is #f"
+             (not (record-descriptor-parent rd)))
+(define rd7 (make-record-descriptor 'rd7 #f #f #f #f '#((immutable a)) #f))
+(test-assert "the 7-argument make-record-descriptor shorthand builds a descriptor"
+             (record-descriptor? rd7))
+(test-equal "the 7-argument shorthand names the type it built"
+            'rd7 (record-type-name (record-descriptor-rtd rd7)))
+(test-assert "a constructor from a 7-argument descriptor works"
+             (record? ((record-constructor rd7) 1)))
+(test-assert "record-descriptor-rtd also accepts a bare rtd"
+             (eq? rtd-pt (record-descriptor-rtd rtd-pt)))
+
+;;; ------------------------------------------------------------------
+;;; R6RS clause syntax. SRFI 240's own reason for existing is that this and
+;;; the R7RS positional syntax produce interoperable types.
+;;; ------------------------------------------------------------------
+
+(define-record-type <r6> (fields (immutable a) (mutable b)))
+(define r6 (make-<r6> 1 2))
+
+(test-assert "an R6RS-clause record is a record" (record? r6))
+(test-assert "an R6RS-clause record has an rtd" (record-type-descriptor? (record-rtd r6)))
+(test-equal "an R6RS-clause record reports its field names"
+            '#(a b) (record-type-field-names (record-rtd r6)))
+(test-equal "record-accessor works on an R6RS-clause record"
+            1 ((record-accessor (record-rtd r6) 0) r6))
+(test-equal "record-accessor reaches the second field of an R6RS-clause record"
+            2 ((record-accessor (record-rtd r6) 1) r6))
+(test-assert "record-field-mutable? works on an R6RS-clause record"
+             (not (record-field-mutable? (record-rtd r6) 0)))
+(test-assert "record-field-mutable? sees the mutable field of an R6RS-clause record"
+             (record-field-mutable? (record-rtd r6) 1))
+(test-equal "record-mutator works on an R6RS-clause record"
+            9 (let ((m (record-mutator (record-rtd r6) 1))) (m r6 9) (<r6>-b r6)))
+(test-assert "a constructor derived from an R6RS-clause record's own rtd works"
+             (<r6>? ((record-constructor
+                      (make-record-constructor-descriptor (record-rtd r6) #f #f)) 1 2)))
+
+;;; ------------------------------------------------------------------
+;;; R7RS positional syntax. `record?`, `record-rtd`, `record-type-name` and a
+;;; derived `record-constructor` all work, so the type IS visible to the
+;;; inspection layer — but its field metadata is empty.
+;;; ------------------------------------------------------------------
+
+(define-record-type <r7> (make-r7 x y) r7? (x r7-x) (y r7-y set-r7-y!))
+(define r7 (make-r7 1 2))
+
+(test-assert "an R7RS record is a record" (record? r7))
+(test-assert "an R7RS record has an rtd" (record-type-descriptor? (record-rtd r7)))
+(test-equal "an R7RS record's rtd carries its name" '<r7> (record-type-name (record-rtd r7)))
+(test-assert "record-type-parent of an R7RS record's rtd is #f"
+             (not (record-type-parent (record-rtd r7))))
+(test-assert "record-type-sealed? of an R7RS record's rtd is #f"
+             (not (record-type-sealed? (record-rtd r7))))
+(test-assert "record-type-opaque? of an R7RS record's rtd is #f"
+             (not (record-type-opaque? (record-rtd r7))))
+(test-assert "the R7RS record's own predicate works" (r7? r7))
+(test-assert "record-predicate derived from the rtd works" ((record-predicate (record-rtd r7)) r7))
+;; The arity IS known somewhere: a procedurally derived constructor takes two
+;; arguments and builds a valid instance, even though field-names says zero.
+(test-assert "a constructor derived from an R7RS record's own rtd builds an instance"
+             (r7? ((record-constructor
+                    (make-record-constructor-descriptor (record-rtd r7) #f #f)) 1 2)))
+
+;; FAIL: #2088 (an R7RS define-record-type produces an rtd with zero own field
+;;              names, so the SRFI 237/240 inspection layer cannot see its fields)
+;; (test-equal "an R7RS record reports its field names"
+;;             '#(x y) (record-type-field-names (record-rtd r7)))
+;; FAIL: #2088
+;; (test-equal "record-accessor works on an R7RS record"
+;;             1 ((record-accessor (record-rtd r7) 0) r7))
+;; FAIL: #2088
+;; (test-assert "record-field-mutable? works on an R7RS record"
+;;              (not (record-field-mutable? (record-rtd r7) 0)))
+;; FAIL: #2088
+;; (test-assert "record-mutator works on an R7RS record's mutable field"
+;;              (procedure? (record-mutator (record-rtd r7) 1)))
+
+;; The observed behaviour, pinned so the fix flips these too.
+(test-equal "an R7RS record's rtd currently reports zero field names"
+            '#() (record-type-field-names (record-rtd r7)))
+(test-assert "record-accessor on an R7RS record's rtd currently raises"
+             (raises? (lambda () (record-accessor (record-rtd r7) 0))))
+(test-assert "record-field-mutable? on an R7RS record's rtd currently raises"
+             (raises? (lambda () (record-field-mutable? (record-rtd r7) 0))))
+(test-assert "record-mutator on an R7RS record's rtd currently raises"
+             (raises? (lambda () (record-mutator (record-rtd r7) 1))))
+
+;; Discriminating control: the same two-field, one-mutable shape built the two
+;; other ways is fully introspectable, so the defect is specific to the R7RS
+;; positional desugarer, not to the inspection layer.
+(test-equal "control: the same shape as an R6RS-clause type reports 2 field names"
+            2 (vector-length (record-type-field-names (record-rtd r6))))
+(test-equal "control: the same shape built procedurally reports 2 field names"
+            2 (vector-length (record-type-field-names rtd-pt)))
+
+;;; ------------------------------------------------------------------
+;;; SRFI 240 adds no semantics of its own: the reconciliation it describes is
+;;; the engine's unconditional top-level behaviour, with or without the
+;;; import. Pinned so the .sld's own header claim is checkable.
+;;; ------------------------------------------------------------------
+
+(test-assert "the R6RS and R7RS syntaxes produce distinct types"
+             (not (eq? (record-rtd r6) (record-rtd r7))))
+(test-assert "an R6RS-clause instance is not an R7RS instance" (not (r7? r6)))
+(test-assert "an R7RS instance is not an R6RS-clause instance" (not (<r6>? r7)))
+(test-assert "cond-expand reports the srfi-240 feature identifier"
+             (cond-expand (srfi-240 #t) (else #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi240 audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi27-audit.scm
+++ b/tests/scheme/srfi/srfi27-audit.scm
@@ -1,0 +1,292 @@
+;;; Audit: lib/srfi/27.sld + src/primitives_random.zig (SRFI 27 — Sources of
+;;; Random Bits)
+;;; Systematic audit v2, Phase 3.9 (docs/audit-strategy.md, tracking #1890).
+;;;
+;;; Oracle: SRFI 27, https://srfi.schemers.org/srfi-27/srfi-27.html
+;;;
+;;; There is no tests/scheme/srfi/srfi27.scm — the two existing files
+;;; (srfi-27-unit.scm, srfi27-state.scm) never mention random-integer,
+;;; random-real, random-source? or random-source-randomize!.
+;;;
+;;; A random source cannot be asserted by value, so this file asserts the two
+;;; things the spec DOES fix:
+;;;   * shape — exactness, range, and the exclusivity of each bound;
+;;;   * reproducibility — the same pseudo-randomization or the same restored
+;;;     state must replay the same sequence, and different seeds must not.
+;;; Distributional sanity is asserted only as "every bucket of a small range
+;;; is hit at least once over many draws", which is a property, not a value.
+;;;
+;;; Known and NOT re-filed: #1913 (the all-zero-seed random port's own state
+;;; fails random-port-state?) is a SRFI 271 issue over the same primitives.
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi27-audit.scm
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 27))
+
+(test-begin "srfi27 audit")
+
+(define (raises? thunk)
+  (call-with-current-continuation
+   (lambda (k) (with-exception-handler (lambda (e) (k #t)) (lambda () (thunk) #f)))))
+
+(define (repeat n proc)
+  (let loop ((i 0) (acc '())) (if (= i n) (reverse acc) (loop (+ i 1) (cons (proc) acc)))))
+
+;;; ------------------------------------------------------------------
+;;; random-integer. "(random-integer n) -> Returns the next number of the
+;;; sequence ... an exact integer in {0, ..., n-1}."
+;;; ------------------------------------------------------------------
+
+(test-assert "random-integer 10 always lands in [0,10)"
+             (let loop ((i 0))
+               (or (= i 2000)
+                   (let ((r (random-integer 10)))
+                     (and (exact-integer? r) (>= r 0) (< r 10) (loop (+ i 1)))))))
+(test-assert "random-integer 1 is always 0"
+             (let loop ((i 0)) (or (= i 200) (and (= 0 (random-integer 1)) (loop (+ i 1))))))
+(test-assert "random-integer's upper bound is exclusive: 2 never yields 2"
+             (let loop ((i 0)) (or (= i 2000) (and (< (random-integer 2) 2) (loop (+ i 1))))))
+(test-assert "random-integer 2 does yield both 0 and 1 over many draws"
+             (let loop ((i 0) (saw0 #f) (saw1 #f))
+               (cond ((and saw0 saw1) #t)
+                     ((= i 2000) #f)
+                     (else (let ((r (random-integer 2)))
+                             (loop (+ i 1) (or saw0 (= r 0)) (or saw1 (= r 1))))))))
+(test-assert "random-integer 8 hits every bucket over many draws"
+             (let ((seen (make-vector 8 #f)))
+               (let loop ((i 0))
+                 (when (< i 4000) (vector-set! seen (random-integer 8) #t) (loop (+ i 1))))
+               (let check ((j 0)) (or (= j 8) (and (vector-ref seen j) (check (+ j 1)))))))
+(test-assert "random-integer accepts a bignum bound and stays inside it"
+             (let ((n (expt 2 100)))
+               (let loop ((i 0))
+                 (or (= i 200)
+                     (let ((r (random-integer n)))
+                       (and (exact-integer? r) (>= r 0) (< r n) (loop (+ i 1))))))))
+(test-assert "random-integer of a bignum bound is not always small"
+             (let ((n (expt 2 100)))
+               (let loop ((i 0))
+                 (cond ((= i 200) #f)
+                       ((> (random-integer n) (expt 2 90)) #t)
+                       (else (loop (+ i 1)))))))
+;; "It is an error if n is not a positive integer."
+(test-assert "random-integer 0 is rejected" (raises? (lambda () (random-integer 0))))
+(test-assert "random-integer with a negative bound is rejected"
+             (raises? (lambda () (random-integer -5))))
+
+;;; ------------------------------------------------------------------
+;;; random-real. "Returns the next number of the sequence ... an inexact
+;;; number strictly between 0 and 1."
+;;; ------------------------------------------------------------------
+
+(test-assert "random-real is inexact and strictly inside (0,1)"
+             (let loop ((i 0))
+               (or (= i 2000)
+                   (let ((r (random-real)))
+                     (and (real? r) (inexact? r) (> r 0) (< r 1) (loop (+ i 1)))))))
+(test-assert "random-real is not constant"
+             (let ((a (random-real)))
+               (let loop ((i 0)) (cond ((= i 200) #f)
+                                       ((not (= a (random-real))) #t)
+                                       (else (loop (+ i 1)))))))
+(test-assert "random-real covers both halves of (0,1) over many draws"
+             (let loop ((i 0) (lo #f) (hi #f))
+               (cond ((and lo hi) #t)
+                     ((= i 2000) #f)
+                     (else (let ((r (random-real)))
+                             (loop (+ i 1) (or lo (< r 0.5)) (or hi (> r 0.5))))))))
+
+;;; ------------------------------------------------------------------
+;;; Random sources
+;;; ------------------------------------------------------------------
+
+(test-assert "random-source? on the default source" (random-source? default-random-source))
+(test-assert "random-source? on a fresh source" (random-source? (make-random-source)))
+(test-assert "random-source? on a number" (not (random-source? 42)))
+(test-assert "random-source? on a procedure" (not (random-source? car)))
+(test-assert "make-random-source returns a new object each time"
+             (not (eq? (make-random-source) (make-random-source))))
+(test-assert "make-random-source is not the default source"
+             (not (eq? (make-random-source) default-random-source)))
+(test-assert "random-source-make-integers returns a procedure"
+             (procedure? (random-source-make-integers (make-random-source))))
+(test-assert "random-source-make-reals returns a procedure"
+             (procedure? (random-source-make-reals (make-random-source))))
+(test-assert "an integers generator from the default source obeys its bound"
+             (let ((g (random-source-make-integers default-random-source)))
+               (let loop ((i 0))
+                 (or (= i 500)
+                     (let ((r (g 100))) (and (exact-integer? r) (>= r 0) (< r 100)
+                                             (loop (+ i 1))))))))
+(test-assert "an integers generator rejects a bound of 0"
+             (raises? (lambda () ((random-source-make-integers (make-random-source)) 0))))
+(test-assert "a reals generator with no unit stays strictly inside (0,1)"
+             (let ((g (random-source-make-reals (make-random-source))))
+               (let loop ((i 0))
+                 (or (= i 500) (let ((r (g))) (and (> r 0) (< r 1) (loop (+ i 1))))))))
+;; "unit must satisfy 0 < unit < 1"
+(test-assert "a reals generator with unit 1/10 stays strictly inside (0,1)"
+             (let ((g (random-source-make-reals (make-random-source) 1/10)))
+               (let loop ((i 0))
+                 (or (= i 500) (let ((r (g))) (and (> r 0) (< r 1) (loop (+ i 1))))))))
+(test-assert "a reals generator with an exact unit yields multiples of it"
+             (let ((g (random-source-make-reals (make-random-source) 1/8)))
+               (let loop ((i 0))
+                 (or (= i 200) (and (exact-integer? (* 8 (g))) (loop (+ i 1)))))))
+(test-assert "random-source-make-reals rejects a unit of 1"
+             (raises? (lambda () (random-source-make-reals (make-random-source) 1))))
+(test-assert "random-source-make-reals rejects a unit above 1"
+             (raises? (lambda () (random-source-make-reals (make-random-source) 2))))
+(test-assert "random-source-make-reals rejects a unit of 0"
+             (raises? (lambda () (random-source-make-reals (make-random-source) 0))))
+(test-assert "random-source-make-reals rejects a negative unit"
+             (raises? (lambda () (random-source-make-reals (make-random-source) -1/2))))
+
+;;; ------------------------------------------------------------------
+;;; Reproducibility. "random-source-pseudo-randomize! changes the state of
+;;; the random source s into the initial state of the (i, j)-th independent
+;;; random source" — the SAME (i, j) must therefore replay the SAME sequence.
+;;; ------------------------------------------------------------------
+
+(define (draws-after-pseudo i j n)
+  (let ((s (make-random-source)))
+    (random-source-pseudo-randomize! s i j)
+    (let ((g (random-source-make-integers s)))
+      (repeat n (lambda () (g 1000000))))))
+
+(test-equal "the same (i,j) replays the same sequence"
+            (draws-after-pseudo 1 2 10) (draws-after-pseudo 1 2 10))
+(test-equal "the same (i,j) replays the same sequence at (0,0)"
+            (draws-after-pseudo 0 0 10) (draws-after-pseudo 0 0 10))
+(test-equal "the same (i,j) replays the same sequence for large indices"
+            (draws-after-pseudo 12345 67890 10) (draws-after-pseudo 12345 67890 10))
+(test-assert "a different i gives a different sequence"
+             (not (equal? (draws-after-pseudo 1 2 10) (draws-after-pseudo 3 2 10))))
+(test-assert "a different j gives a different sequence"
+             (not (equal? (draws-after-pseudo 1 2 10) (draws-after-pseudo 1 4 10))))
+(test-assert "(0,0) and (1,1) are different sources"
+             (not (equal? (draws-after-pseudo 0 0 10) (draws-after-pseudo 1 1 10))))
+(test-assert "pseudo-randomize! on the SAME source object resets it"
+             (let ((s (make-random-source)))
+               (random-source-pseudo-randomize! s 7 8)
+               (let* ((g1 (random-source-make-integers s))
+                      (a (repeat 10 (lambda () (g1 1000000)))))
+                 (random-source-pseudo-randomize! s 7 8)
+                 (let ((g2 (random-source-make-integers s)))
+                   (equal? a (repeat 10 (lambda () (g2 1000000))))))))
+(test-assert "a pseudo-randomized sequence is not constant"
+             (let ((d (draws-after-pseudo 5 5 20)))
+               (let loop ((l (cdr d))) (cond ((null? l) #f)
+                                             ((not (= (car l) (car d))) #t)
+                                             (else (loop (cdr l)))))))
+(test-assert "every draw of a pseudo-randomized sequence obeys its bound"
+             (let loop ((l (draws-after-pseudo 9 9 50)))
+               (or (null? l) (and (exact-integer? (car l)) (>= (car l) 0) (< (car l) 1000000)
+                                  (loop (cdr l))))))
+
+;;; ------------------------------------------------------------------
+;;; State capture and restore. "random-source-state-ref returns an external
+;;; representation of the internal state of s" and state-set! restores it.
+;;; ------------------------------------------------------------------
+
+(test-assert "restoring a captured state replays the same sequence"
+             (let* ((s (make-random-source))
+                    (st (random-source-state-ref s))
+                    (g (random-source-make-integers s))
+                    (a (repeat 10 (lambda () (g 1000000)))))
+               (random-source-state-set! s st)
+               (let ((g2 (random-source-make-integers s)))
+                 (equal? a (repeat 10 (lambda () (g2 1000000)))))))
+(test-assert "a state captured mid-sequence resumes from that point"
+             (let* ((s (make-random-source))
+                    (g (random-source-make-integers s)))
+               (repeat 5 (lambda () (g 1000000)))
+               (let* ((st (random-source-state-ref s))
+                      (a (repeat 10 (lambda () (g 1000000)))))
+                 (random-source-state-set! s st)
+                 (equal? a (repeat 10 (lambda () (g 1000000)))))))
+(test-assert "a state copied into a DIFFERENT source replays the same sequence"
+             (let* ((s (make-random-source)) (t (make-random-source)))
+               (random-source-state-set! t (random-source-state-ref s))
+               (let ((g (random-source-make-integers s)) (h (random-source-make-integers t)))
+                 (equal? (repeat 10 (lambda () (g 100000)))
+                         (repeat 10 (lambda () (h 100000)))))))
+(test-assert "a captured state survives being captured again unchanged"
+             (let* ((s (make-random-source))
+                    (st1 (random-source-state-ref s))
+                    (st2 (random-source-state-ref s)))
+               (random-source-state-set! s st1)
+               (let ((a (repeat 5 (lambda () ((random-source-make-integers s) 100000)))))
+                 (random-source-state-set! s st2)
+                 (equal? a (repeat 5 (lambda () ((random-source-make-integers s) 100000)))))))
+(test-assert "a state captured after pseudo-randomization restores that source"
+             (let ((s (make-random-source)))
+               (random-source-pseudo-randomize! s 11 22)
+               (let* ((st (random-source-state-ref s))
+                      (g (random-source-make-integers s))
+                      (a (repeat 10 (lambda () (g 1000)))))
+                 (random-source-state-set! s st)
+                 (let ((g2 (random-source-make-integers s)))
+                   (equal? a (repeat 10 (lambda () (g2 1000))))))))
+(test-assert "two sources pseudo-randomized differently have different states"
+             (let ((s (make-random-source)) (t (make-random-source)))
+               (random-source-pseudo-randomize! s 1 1)
+               (random-source-pseudo-randomize! t 2 2)
+               (not (equal? (random-source-state-ref s) (random-source-state-ref t)))))
+(test-assert "a source's own state round-trips through state-set! unchanged"
+             (let* ((s (make-random-source)) (st (random-source-state-ref s)))
+               (random-source-state-set! s st)
+               (equal? st (random-source-state-ref s))))
+
+;;; ------------------------------------------------------------------
+;;; randomize!. Nothing about its result is specified beyond "changes the
+;;; state ... to a truly random one", so only the call and its effect on
+;;; subsequent draws are asserted.
+;;; ------------------------------------------------------------------
+
+(test-assert "random-source-randomize! runs without error"
+             (begin (random-source-randomize! (make-random-source)) #t))
+(test-assert "a randomized source still produces in-range integers"
+             (let ((s (make-random-source)))
+               (random-source-randomize! s)
+               (let ((g (random-source-make-integers s)))
+                 (let loop ((i 0))
+                   (or (= i 500) (let ((r (g 100))) (and (>= r 0) (< r 100) (loop (+ i 1)))))))))
+(test-assert "randomize! changes the state away from a pseudo-randomized one"
+             (let ((s (make-random-source)))
+               (random-source-pseudo-randomize! s 1 1)
+               (let ((before (random-source-state-ref s)))
+                 (random-source-randomize! s)
+                 (not (equal? before (random-source-state-ref s))))))
+(test-assert "randomize! on the default source runs without error"
+             (begin (random-source-randomize! default-random-source) #t))
+
+;;; ------------------------------------------------------------------
+;;; Independence of sources
+;;; ------------------------------------------------------------------
+
+(test-assert "drawing from one source does not advance another"
+             (let ((s (make-random-source)) (t (make-random-source)))
+               (random-source-pseudo-randomize! s 3 3)
+               (random-source-pseudo-randomize! t 3 3)
+               (let ((g (random-source-make-integers s)) (h (random-source-make-integers t)))
+                 (g 1000) (g 1000) (g 1000)
+                 ;; t has not been drawn from; its next value must equal s's first.
+                 (random-source-pseudo-randomize! s 3 3)
+                 (let ((g2 (random-source-make-integers s)))
+                   (= (g2 1000) (h 1000))))))
+(test-assert "two generators made from the same source share its state"
+             (let ((s (make-random-source)))
+               (random-source-pseudo-randomize! s 4 4)
+               (let* ((g (random-source-make-integers s))
+                      (h (random-source-make-integers s))
+                      (a (g 1000000)) (b (h 1000000)))
+                 ;; a and b come from consecutive draws of one stream, so
+                 ;; replaying the source must reproduce both, in order.
+                 (random-source-pseudo-randomize! s 4 4)
+                 (let ((k (random-source-make-integers s)))
+                   (and (= a (k 1000000)) (= b (k 1000000)))))))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi27 audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi35-audit.scm
+++ b/tests/scheme/srfi/srfi35-audit.scm
@@ -1,0 +1,246 @@
+;;; Audit: lib/srfi/35.sld (SRFI 35 — Conditions)
+;;; Systematic audit v2, Phase 3.9 (docs/audit-strategy.md, tracking #1890).
+;;;
+;;; Oracle: SRFI 35, https://srfi.schemers.org/srfi-35/srfi-35.html
+;;;
+;;; The pre-existing tests/scheme/srfi/srfi35.scm uses an ad-hoc `check`
+;;; framework and never touches 8 of the 23 exports. This file covers all 23
+;;; under SRFI 64, and adds the question the unit was scoped around: how
+;;; SRFI 35's condition world relates to R7RS's error-object world.
+;;;
+;;; Answer, asserted below: they are DISJOINT and self-consistent. A SRFI 35
+;;; &error condition is not an R7RS error object and vice versa, in both
+;;; directions and for both predicates. That is not a defect — SRFI 35
+;;; predates R7RS and specifies its own hierarchy rooted at &condition — but
+;;; nothing had ever pinned it, so a change in either direction was invisible.
+;;; chibi-scheme could not serve as an oracle here: its (srfi 35) fails to
+;;; load at all (it imports a missing `(srfi 35 internal)`).
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/srfi/srfi35-audit.scm
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 35))
+
+(test-begin "srfi35 audit")
+
+(define (raises? thunk)
+  (call-with-current-continuation
+   (lambda (k) (with-exception-handler (lambda (e) (k #t)) (lambda () (thunk) #f)))))
+(define (catch thunk)
+  (call-with-current-continuation
+   (lambda (k) (with-exception-handler (lambda (e) (k e)) thunk))))
+
+;;; ------------------------------------------------------------------
+;;; Condition types and the standard hierarchy
+;;; ------------------------------------------------------------------
+
+(test-assert "condition-type? on &condition" (condition-type? &condition))
+(test-assert "condition-type? on &message" (condition-type? &message))
+(test-assert "condition-type? on &serious" (condition-type? &serious))
+(test-assert "condition-type? on &error" (condition-type? &error))
+(test-assert "condition-type? on a non-type" (not (condition-type? 42)))
+(test-assert "condition-type? on a condition instance"
+             (not (condition-type? (make-condition &serious))))
+(test-equal "condition-type-name of &condition" '&condition (condition-type-name &condition))
+(test-equal "condition-type-name of &message" '&message (condition-type-name &message))
+(test-equal "condition-type-name of &serious" '&serious (condition-type-name &serious))
+(test-equal "condition-type-name of &error" '&error (condition-type-name &error))
+
+;; "&message, &serious ... are subtypes of &condition; &error is a subtype of
+;;  &serious."
+(test-assert "&message is a subtype of &condition" (condition-subtype? &message &condition))
+(test-assert "&serious is a subtype of &condition" (condition-subtype? &serious &condition))
+(test-assert "&error is a subtype of &serious" (condition-subtype? &error &serious))
+(test-assert "&error is transitively a subtype of &condition"
+             (condition-subtype? &error &condition))
+(test-assert "&message is not a subtype of &serious"
+             (not (condition-subtype? &message &serious)))
+(test-assert "&serious is not a subtype of &error" (not (condition-subtype? &serious &error)))
+(test-assert "a type is a subtype of itself" (condition-subtype? &error &error))
+(test-assert "&condition is not a subtype of &error" (not (condition-subtype? &condition &error)))
+
+(test-assert "condition-type-supertype of &error is &serious"
+             (eq? &serious (condition-type-supertype &error)))
+(test-assert "condition-type-supertype of &serious is &condition"
+             (eq? &condition (condition-type-supertype &serious)))
+(test-assert "condition-type-supertype of &message is &condition"
+             (eq? &condition (condition-type-supertype &message)))
+(test-equal "condition-type-fields of &message" '(message) (condition-type-fields &message))
+(test-equal "condition-type-fields of &error is empty" '() (condition-type-fields &error))
+(test-equal "condition-type-fields of &condition is empty" '() (condition-type-fields &condition))
+(test-equal "condition-type-all-fields of &message" '(message)
+            (condition-type-all-fields &message))
+(test-equal "condition-type-all-fields of &error is empty" '()
+            (condition-type-all-fields &error))
+
+;;; ------------------------------------------------------------------
+;;; make-condition-type. "(make-condition-type name supertype field-names)"
+;;; ------------------------------------------------------------------
+
+(define &mine (make-condition-type '&mine &error '(x y)))
+(test-assert "make-condition-type builds a condition type" (condition-type? &mine))
+(test-equal "the new type keeps its name" '&mine (condition-type-name &mine))
+(test-assert "the new type is a subtype of its supertype" (condition-subtype? &mine &error))
+(test-assert "the new type is transitively a subtype of &condition"
+             (condition-subtype? &mine &condition))
+(test-assert "the new type's supertype is the one it was given"
+             (eq? &error (condition-type-supertype &mine)))
+(test-equal "the new type's own fields" '(x y) (condition-type-fields &mine))
+(test-equal "the new type's all-fields includes only its own here" '(x y)
+            (condition-type-all-fields &mine))
+(test-assert "&error is not a subtype of the new type" (not (condition-subtype? &error &mine)))
+
+(define &deeper (make-condition-type '&deeper &mine '(z)))
+(test-equal "a grandchild type's own fields exclude inherited ones" '(z)
+            (condition-type-fields &deeper))
+(test-assert "a grandchild type's all-fields includes inherited ones"
+             (let ((all (condition-type-all-fields &deeper)))
+               (and (memq 'x all) (memq 'y all) (memq 'z all) #t)))
+(test-assert "a grandchild is a subtype of its grandparent"
+             (condition-subtype? &deeper &error))
+
+;;; ------------------------------------------------------------------
+;;; make-condition / condition-ref / condition-has-type?
+;;; ------------------------------------------------------------------
+
+(define c-msg (make-condition &message 'message "hello"))
+(test-assert "make-condition builds a condition" (condition? c-msg))
+(test-assert "a condition is not a condition type" (not (condition-type? c-msg)))
+(test-assert "condition? on a plain value" (not (condition? 42)))
+(test-equal "condition-message reads the message field" "hello" (condition-message c-msg))
+(test-equal "condition-ref reads a named field" "hello" (condition-ref c-msg 'message))
+(test-assert "condition-has-type? for its own type" (condition-has-type? c-msg &message))
+(test-assert "condition-has-type? for its supertype" (condition-has-type? c-msg &condition))
+(test-assert "condition-has-type? for an unrelated type"
+             (not (condition-has-type? c-msg &error)))
+(test-assert "condition-ref of a field the condition does not have raises"
+             (raises? (lambda () (condition-ref c-msg 'nope))))
+(test-assert "make-condition with a field left unsupplied raises"
+             (raises? (lambda () (make-condition &message))))
+
+(define c-mine (make-condition &mine 'x 1 'y 2))
+(test-equal "a user type's fields are readable: x" 1 (condition-ref c-mine 'x))
+(test-equal "a user type's fields are readable: y" 2 (condition-ref c-mine 'y))
+(test-assert "a user condition has its own type" (condition-has-type? c-mine &mine))
+(test-assert "a user condition has its supertype" (condition-has-type? c-mine &error))
+(test-assert "a user condition has &serious transitively" (condition-has-type? c-mine &serious))
+(test-assert "a user condition of a subtype of &error satisfies error?" (error? c-mine))
+(test-assert "a user condition of a subtype of &error satisfies serious-condition?"
+             (serious-condition? c-mine))
+
+;;; ------------------------------------------------------------------
+;;; The three standard predicates
+;;; ------------------------------------------------------------------
+
+(test-assert "message-condition? on a &message condition" (message-condition? c-msg))
+(test-assert "message-condition? on a non-condition" (not (message-condition? 42)))
+(test-assert "message-condition? on a plain &error condition"
+             (not (message-condition? (make-condition &error))))
+(test-assert "serious-condition? on a &serious condition"
+             (serious-condition? (make-condition &serious)))
+(test-assert "serious-condition? on a &message condition" (not (serious-condition? c-msg)))
+(test-assert "serious-condition? on a non-condition" (not (serious-condition? 42)))
+(test-assert "error? on an &error condition" (error? (make-condition &error)))
+(test-assert "error? on a &serious condition" (not (error? (make-condition &serious))))
+(test-assert "error? on a &message condition" (not (error? c-msg)))
+(test-assert "error? on a non-condition" (not (error? 42)))
+
+;;; ------------------------------------------------------------------
+;;; Compound conditions
+;;; ------------------------------------------------------------------
+
+(define compound (make-compound-condition c-msg (make-condition &error)))
+(test-assert "a compound condition is a condition" (condition? compound))
+(test-assert "a compound condition has the first component's type"
+             (condition-has-type? compound &message))
+(test-assert "a compound condition has the second component's type"
+             (condition-has-type? compound &error))
+(test-assert "a compound condition has the supertypes of its components"
+             (condition-has-type? compound &serious))
+(test-equal "condition-message reaches into a compound condition"
+            "hello" (condition-message compound))
+(test-assert "error? sees the &error component of a compound condition" (error? compound))
+(test-assert "message-condition? sees the &message component of a compound condition"
+             (message-condition? compound))
+(test-equal "condition-ref reaches a component's field" "hello" (condition-ref compound 'message))
+
+(define extracted (extract-condition compound &message))
+(test-assert "extract-condition returns a condition" (condition? extracted))
+(test-assert "the extracted condition has the requested type"
+             (condition-has-type? extracted &message))
+(test-equal "the extracted condition keeps its field" "hello" (condition-message extracted))
+(test-assert "extracting a type the compound does not have raises"
+             (raises? (lambda () (extract-condition compound &mine))))
+(test-assert "extract-condition on a simple condition of that type works"
+             (condition? (extract-condition c-msg &message)))
+(test-assert "make-compound-condition with one component is still a condition"
+             (condition? (make-compound-condition c-msg)))
+
+;;; ------------------------------------------------------------------
+;;; The `condition` syntax
+;;; ------------------------------------------------------------------
+
+(define c-syntax (condition (&error) (&message (message "boom"))))
+(test-assert "the condition syntax builds a condition" (condition? c-syntax))
+(test-assert "the condition syntax includes a type with no fields"
+             (condition-has-type? c-syntax &error))
+(test-assert "the condition syntax includes a type with fields"
+             (condition-has-type? c-syntax &message))
+(test-equal "the condition syntax fills the field" "boom" (condition-message c-syntax))
+(test-assert "the condition syntax result satisfies error?" (error? c-syntax))
+
+(define-condition-type &my-io &error my-io? (port my-io-port))
+(test-assert "define-condition-type defines a condition type" (condition-type? &my-io))
+(test-assert "define-condition-type defines a working predicate"
+             (my-io? (make-condition &my-io 'port 'p)))
+(test-assert "the generated predicate rejects other conditions" (not (my-io? c-msg)))
+(test-assert "the generated predicate rejects non-conditions" (not (my-io? 42)))
+(test-equal "define-condition-type defines a working accessor"
+            'p (my-io-port (make-condition &my-io 'port 'p)))
+(test-assert "the generated type is a subtype of the declared supertype"
+             (condition-subtype? &my-io &error))
+(test-assert "a condition of the generated type satisfies error?"
+             (error? (make-condition &my-io 'port 'p)))
+
+;;; ------------------------------------------------------------------
+;;; Raising and catching SRFI 35 conditions
+;;; ------------------------------------------------------------------
+
+(test-equal "a raised condition reaches the handler as itself"
+            '(#t #t "hi")
+            (let ((e (catch (lambda () (raise (condition (&error) (&message (message "hi"))))))))
+              (list (condition? e) (error? e) (condition-message e))))
+(test-assert "a raised condition can be caught by guard"
+             (guard (e ((error? e) #t)) (raise (make-condition &error))))
+(test-assert "guard can discriminate on a user condition type"
+             (guard (e ((my-io? e) 'io) (#t 'other))
+               (raise (make-condition &my-io 'port 'p))))
+(test-equal "a condition raised through guard keeps its field"
+            'p (guard (e ((my-io? e) (my-io-port e))) (raise (make-condition &my-io 'port 'p))))
+
+;;; ------------------------------------------------------------------
+;;; The seam with R7RS error objects. Nothing in SRFI 35 requires these two
+;;; worlds to overlap, and in this implementation they do not — pinned in
+;;; both directions so a future change is visible.
+;;; ------------------------------------------------------------------
+
+(test-equal "an R7RS error object is an error-object? but not a SRFI 35 error?"
+            '(#f #t)
+            (let ((e (catch (lambda () (error "boom")))))
+              (list (error? e) (error-object? e))))
+(test-assert "an R7RS error object is not a SRFI 35 condition"
+             (not (condition? (catch (lambda () (error "boom"))))))
+(test-equal "a SRFI 35 &error condition is a SRFI 35 error? but not an error-object?"
+            '(#t #f)
+            (let ((c (make-condition &error))) (list (error? c) (error-object? c))))
+(test-assert "condition-message on an R7RS error object raises"
+             (raises? (lambda () (condition-message (catch (lambda () (error "boom")))))))
+(test-assert "error-object-message on a SRFI 35 condition raises"
+             (raises? (lambda () (error-object-message (make-condition &message 'message "m")))))
+(test-assert "a guard clause using error-object? does not catch a SRFI 35 condition"
+             (guard (e ((error-object? e) #f) (#t #t)) (raise (make-condition &error))))
+(test-assert "a guard clause using SRFI 35 error? does not catch an R7RS error object"
+             (guard (e ((error? e) #f) (#t #t)) (error "boom")))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi35 audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Phase 3.9 of the systematic correctness audit (docs/audit-strategy.md, tracking #1890) — the large-and-thin batch: eight SRFIs with substantial export surfaces and thin tests.

Eight new files under `tests/scheme/srfi/`, **1,579 assertions**, 32 of them disabled behind a filed issue. Exported-name coverage across the eight goes from **290/456 to 456/456**; assertions from 493 to 2,072.

| SRFI | exports | covered before | covered after | assertions (was → now) | findings |
|---|---:|---:|---:|---|---|
| 113 sets and bags | 113 | 72 | 113 | 133 → 371 | #2085, #2086 |
| 225 dictionaries | 82 | 54 | 82 | 101 → 622 | clean |
| 178 bitvectors | 107 | 72 | 107 | 85 → 452 | #2083, #2084 |
| 152 string library | 73 | 53 | 73 | 134 → 230 | clean (shallow — see below) |
| 240 records | 23 | 6 | 23 | 12 → 85 | #2088 |
| 189 maybe/either | 24 | 11 | 24 | 17 → 149 | #2087 |
| 35 conditions | 23 | 15 | 23 | 26 → 127 | clean |
| 27 random | 11 | 7 | 11 | 235 → 286 | clean |

## Where the leverage came from

The unit was scoped as a measurement gap, and the strategy doc is explicit that a high untested-export count is not itself evidence of bugs. Six turned up anyway, because two of these SRFIs had a **real oracle**:

* **SRFI 178's own reference implementation loads into this build** as an alternate library (`(ref 178)` over `(srfi 151)` + `(srfi 160 u8)` + `(srfi 133)`). All 107 exports were diffed against it over a **523,361-check corpus** — 14 bit patterns from empty to 65 bits, every `(start, end)` pair, every shift and rotate count, 300 integers, every `copy!`/`swap!` index triple. Exactly **three** procedures diverged: one real bug (#2083), and `bitvector-pad`/`bitvector-pad-right` in the shrinking case, which the spec's prose leaves genuinely ambiguous and its own test suite never probes — **not filed**, and the suite deliberately asserts nothing there.
* **SRFI 113 has both a reference implementation and chibi-scheme 0.12.0.** Where the three disagree the suite says which is right and why: three chibi defects (`bag-sum` double-counting, `bag-unfold` collapsing duplicates, `bag-replace`/`bag-search!` losing multiplicity) are asserted **in Kaappi's favour** with the spec sentence quoted, and the two Kaappi defects are disabled with the reference's own code quoted.

## Findings

Each reproduced on a fresh ReleaseSafe build at `1718a2e1` with an isolated `KAAPPI_HOME`, and each with a discriminating control.

* **#2083 — `bitvector-logical-shift` shifts the wrong way for both signs.** `count>=0` moves toward *higher* indices and `count<0` toward *lower*, exactly inverted. It fails both assertions in SRFI 178's own `test/quasi-ints.scm`. Control: `count=0` is correct, so the defect is precisely the two sign branches; the neighbouring `bitvector-count-run` and `bitvector-first-bit` are equivalent to the reference.
* **#2084 — `bitvector-segment` conses outside its recursive call.** A legal 200,000-bit vector with `n=1` dies of an **uncatchable** `KP3008`, and `n=0` recurses without bound instead of raising the error the spec calls for. Control: 1,000 segments succeeds. The reference validates `n` and delegates to a `map`. Same *class* as #1949, different library and different code, and this one additionally fails on legal input.
* **#2085 — `bag-increment!` ignores the spec's "but not less than zero".** The resulting negative multiplicity makes `bag->list`, `bag-fold` and `bag-for-each` loop forever, because each expands a count with `(do ((i 0 (+ i 1))) ((= i count)) ...)`. `bag-product` with a negative `n` is a second route. Controls: zero and positive counts terminate. The missing `bag-product` validation is shared with the reference (which calls `valid-n` and discards the result) and with chibi; the **hang** and the missing clamp are not.
* **#2086 — `set->bag!` leaves an element already in the bag at its old count.** The reference's unconditional `sob-increment!` and chibi both increment. Control: an element the bag did *not* hold is added correctly.
* **#2087 — SRFI 189 exports 24 of the spec's 82 names.** Whole groups are absent (trivalent logic, the syntax forms, sequence operations, most protocol conversion, join/compose). Four present names have narrower signatures than the spec — `maybe-ref`/`either-ref` lack failure and success, `maybe-bind`/`either-bind` are not variadic, `either-filter` takes no Left payload — and `either` is in the export clause but never defined. Consequence: a Left's payload cannot be read back at all. Control: `cond-expand` answers yes to both `srfi-189` and `(library (srfi 189))`, so the gap is undetectable. The 23 names that *are* present are correct — all three monad laws and both functor laws are asserted as properties over five payloads for both types, and every one holds.
* **#2088 — an R7RS `define-record-type` produces an rtd with zero own field names.** `record-type-field-names` returns `#()` for a record that has fields — it lies rather than erroring — and `record-accessor`/`record-mutator`/`record-field-mutable?` all fail with `index 0 out of range for length 0`. This is the exact interoperability SRFI 240 exists to provide, and `lib/srfi/240.sld`'s own header claims. Controls: the same shape via R6RS clause syntax and via `make-record-type-descriptor` both report `#(a b)`, and a constructor derived from the R7RS rtd takes two arguments and builds a valid instance — so the field count is known, just not the metadata. `src/types_record.zig` documents the cause in a comment. Distinct from closed #1974.

## Clean results, which is what the measurement was for

* **SRFI 225** — the generic layer agrees across all three DTOs on **49 of 51** operation groups, and the two that differ do so correctly (`dict-ref` with no failure raises on all three; `dict-pure?` is the predicate that exists to tell them apart). All 35 `-id` proc tags are exercised through `dto-ref` for the first time, plus a hand-built `make-dto` proving dispatch reaches the supplied procedures.
* **SRFI 152** — deliberately shallow, stated in the file header. #1234 already audited it in v1, and its 20 remaining untested exports are `(scheme base)` re-exports. The seam the unit was scoped around turns out to be tighter than "agrees": the `.sld` imports those 22 names **straight from `(srfi 13)`**, so they are the same binding and cannot diverge. Asserted by `eq?` identity, which doubles as a gate if anyone reimplements one.
* **SRFI 27** — correct on every axis a random source can be pinned on: range and exclusivity of both bounds, exactness, bignum bounds, `pseudo-randomize!` reproducibility and source independence, and state capture/restore including mid-sequence and copied into a different source. Stable across three consecutive runs. #1913 is over the same primitives and is not re-filed.
* **SRFI 35** — its condition world and R7RS's error-object world are **disjoint and self-consistent in both directions**, for both predicates and through `guard`. Not a defect, but nothing had pinned it. chibi could not serve as an oracle here: its `(srfi 35)` fails to load at all.

## Verification

* All eight suites green; `kaappi test tests/scheme/srfi` goes from 30,654 to 32,233 passing with **0 failed**, the delta matching the 1,579 exactly.
* **All 32 disabled assertions were mutation-tested** by enabling each one alone in its own copy of its file: 30 fail, one errors, one hangs. None pins nothing.
* Portability: no assertion depends on an internal representation (bitvectors go through `->list/int`/`->integer`, so the big-endian s390x leg sees identical values), and no assertion depends on iteration order for the unordered collections — sets, bags and dictionaries are compared as sorted alists throughout.

One note on `run-all.sh`: `tests/scheme/compile/*.sh` failed intermittently during verification, with a **different failing file on each of four runs** (including one on a clean stashed tree, where a file that passes on this branch failed instead). All three implicated files pass 3/3 in isolation. This branch adds only `.scm` files under `tests/scheme/srfi/` and cannot reach that suite; three other audit units were building concurrently on the same machine. Reported rather than filed, since it does not reproduce in isolation and the failing set moves.

Closes nothing; files #2083–#2088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
