### PR TITLE
Phase 6C: derive shell completions from the flag table — --no-ir-opt and 5 test flags were missing, and zsh/fish offered 15 rejected flags inside every out-of-line subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,8 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `disassembler.zig` | Bytecode disassembler for `(disassemble proc)` |
 | `linenoise.zig` | Zig FFI wrapper for vendored linenoise C library |
 | `main.zig` | Entry point, REPL loop with linenoise, file execution, CLI flags, `pub const version`, `pub const panic` |
+| `cli_spec.zig` | **The** CLI flag/subcommand tables. Every parse loop (`cli.zig`, `explain`, `features`, `doctor`, `test_runner`, `cache`, `thottam`) dispatches on an exhaustive `switch` over one of its `Id` enums, `cli.printUsage` generates its `Options:` block from it, and `completions.zig` generates all six shell scripts from it — so a flag cannot reach a parser without the docs and completions following. See `docs/dev/cli-surface.md` |
+| `completions.zig` | bash/zsh/fish completion scripts for `kaappi` and `thottam`, generated at comptime from `cli_spec.zig`. Nothing here is hand-maintained |
 | `crash.zig` | Custom panic handler (`PanicHandler(name)`) + pipeline breadcrumb (`noteStage`/`noteFile`); prints version/target/build-mode + stage + report URL before the trace. See `docs/dev/crash-reporting.md` |
 | `native_compiler.zig` | LLVM IR emission, native binary compilation, C compiler discovery, linker invocation |
 | `thottam.zig` | Package manager binary (thottam): install, remove, list, update, verify |

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -43,6 +43,7 @@ investigation produced analysis worth keeping.
 | [features.md](features.md) | `kaappi features [--json]`: machine-readable capability discovery — version/build id, subsystems (the shared `cond-expand` table), SRFIs, limits |
 | [doctor.md](doctor.md) | `kaappi doctor`: installation/environment self-check — the checks, the exit-code contract, the native-backend smoke link |
 | [cache.md](cache.md) | The `.sbc` bytecode cache: what the key contains (source hash + build id), where entries live, what invalidates them, how to inspect/clear/bypass |
+| [cli-surface.md](cli-surface.md) | `src/cli_spec.zig`, the one flag table every parser, `--help`, and all six shell completion scripts are derived from — and the comptime gate that keeps them from drifting |
 | [claude-code-harness.md](claude-code-harness.md) | Hooks, permissions, path-scoped rules, and skills for AI-assisted development |
 
 ## Design decisions

--- a/docs/dev/cli-surface.md
+++ b/docs/dev/cli-surface.md
@@ -1,0 +1,152 @@
+# The CLI surface: one table, five consumers
+
+`src/cli_spec.zig` is the single authoritative description of the `kaappi` and
+`thottam` command lines. Everything that needs to know how a flag is spelled,
+whether it takes a value, or what it does reads that file:
+
+| Consumer | What it reads it for |
+|---|---|
+| `src/cli.zig` — `parse` / `preScanSandbox` | recognizing global flags |
+| `src/cli.zig` — `printUsage` | the `Options:` block, generated |
+| `src/explain.zig`, `features.zig`, `doctor.zig`, `test_runner.zig`, `cache.zig` | each subcommand's own flags |
+| `src/thottam.zig` | thottam's flags |
+| `src/completions.zig` | all six shell scripts, generated at comptime |
+
+**Add a flag in one place and every one of those follows.** There is no second
+list to update and no golden file to regenerate.
+
+## Why it exists
+
+The completion scripts used to be hand-written string literals parallel to the
+parsers — the same structural hazard as `isRejectedFormHead`
+(`docs/dev/llvm-backend.md`) and the `%`-prefix incident: two lists that must
+agree, with nothing enforcing it. They had drifted in **both** directions:
+
+- `--no-ir-opt` was in the parser and in none of the three kaappi scripts.
+- `kaappi test` grew `-j`/`--jobs`, `--changed`, `--list-affected` and
+  `--since`; none of the three offered any of them, and only bash offered
+  `--seed`.
+- The zsh and fish scripts offered the whole global flag set inside
+  `explain`, `features`, `test`, `doctor` and `cache` — 15 of which those
+  subcommands' own parsers reject outright with exit 2. **Completing a flag
+  that then errors is the worse failure**, and it was the larger of the two.
+
+## The shape of the table
+
+```zig
+pub const GlobalId = enum { help, version_flag, /* … */ };
+
+pub const global_flags = [_]Flag(GlobalId){
+    .{ .long = "--sandbox", .id = .sandbox, .desc = "Restrict filesystem and process access" },
+    .{ .long = "--lib-path", .id = .lib_path, .value = .separate, .kind = .dir,
+       .value_name = "path", .desc = "Add a library search path (repeatable)" },
+    .{ .long = "--diagnostics", .id = .diagnostics, .value = .inline_eq, .kind = .choice,
+       .choices = &fmts, .value_name = "fmt", .desc = "…" },
+    // …
+};
+```
+
+`ValueSyntax` is what lets the table hold every spelling the CLI actually
+accepts:
+
+| Syntax | Example | Consumes the next argv word? |
+|---|---|---|
+| `.none` | `--sandbox` | no |
+| `.separate` | `--lib-path <path>` | yes |
+| `.inline_eq` | `--diagnostics=json` | no — bare `--diagnostics` is *not* a flag |
+| `.inline_eq_optional` | `--timings`, `--timings=json` | no |
+
+That last distinction is load-bearing in two directions. `--diagnostics=` and
+`--timings` were previously matched by `std.mem.startsWith` *outside* the flag
+table, because the old table had no way to say "GNU `=` syntax" — and that
+escape hatch is precisely how they, and later `--no-ir-opt`, drifted out of
+the completions. Encoding the syntax closes the hatch. It also makes the zsh
+specs correct for the first time: an attached-only value is `--opt=-`, and
+`::` marks it optional, so zsh now completes `--diagnostics=json` rather than
+the separated `--diagnostics json` that the parser rejects.
+
+## The gate
+
+Three mechanisms, in order of how early they fire.
+
+1. **A parse loop cannot see a flag that is not in a table.** Every loop
+   dispatches on `switch (m.flag.id)` over that table's `Id` enum. Zig requires
+   the switch to be exhaustive, so adding a row with a new id is a *compile
+   error* until the parser handles it.
+
+2. **A table cannot lag its enum.** The `comptime` block at the bottom of
+   `cli_spec.zig` requires every `Id` variant to appear exactly once, rejects
+   duplicate spellings, requires a `value_name` on any value-taking flag, and
+   restricts descriptions to characters that need no quoting inside a zsh
+   `'…[desc]'` spec or a fish `-d '…'` string.
+
+3. **The scripts cannot lag the table**, because they are generated from it.
+   `src/completions.zig`'s own tests then assert both directions anyway —
+   every table flag appears in every script, and every `--word` token in every
+   script names a declared flag — plus per-shell invariants (balanced quotes,
+   ASCII only, the zsh `=-` spelling, the fish bare-`--timings` spelling).
+
+`tests/scheme/completions/completions.sh` closes the loop against the **real
+binary**: it sources the generated bash function, drives it per context, and
+feeds every offered flag back to the binary, requiring that none of them comes
+back named as `unknown option '<flag>'` / `unexpected argument '<flag>'` /
+`unknown subcommand '<flag>'`. It carries its own discriminating control
+(`kaappi features --sandbox` *must* be rejected, and the matcher must see it),
+so a broken matcher cannot make the soundness checks pass vacuously.
+
+All four were verified to fire by mutation:
+
+| Mutation | Caught by |
+|---|---|
+| add a `GlobalId` variant with no table row | `cli_spec.zig` comptime: "frobnicate must appear exactly once" |
+| add a table row for a flag the parser does not handle | `cli.zig`: "switch must handle all possibilities" |
+| delete `--seed` from `test_flags` | `cli_spec.zig` comptime: "seed must appear exactly once" |
+| drop `--no-ir-opt` from the top-level offer | `completions.zig` and `cli.zig` unit tests, and all three shell assertions |
+
+## Scoping rules
+
+`SubcommandDesc.global_flags_ok` records the one structural fact that decides
+what is sound to offer where:
+
+- **`true`** — `compile`, `check`, `ast`, `expand`, `ir`, `fmt`. `cli.parse`
+  consumes these words itself and keeps using the *global* loop, so every
+  global flag is legal after them.
+- **`false`** — `explain`, `features`, `test`, `doctor`, `cache`. Each
+  intercepts argv in its own module, before `cli.parse` runs, and rejects
+  anything outside its own table. Their completions are scoped to that table:
+  bash and zsh dispatch on the detected subcommand word, fish suppresses the
+  global specs with `not __fish_seen_subcommand_from explain features test
+  doctor cache`.
+
+thottam's subcommands are all `true`: it parses one flat loop that keeps
+scanning past the subcommand word, so `thottam install --locked pkg` is as
+valid as `thottam --locked install pkg`.
+
+## Adding a flag
+
+1. Add the `Id` variant and the table row in `src/cli_spec.zig`.
+2. Build. The compiler names the parse loop that must now handle it.
+3. Handle it. Done — `--help`, all six completion scripts, and every test
+   follow automatically.
+
+For a flag that belongs to one subcommand only, put it in that subcommand's
+table. For a global flag that is only *meaningful* under one subcommand — as
+`--no-opt` (ir) and `--check` (fmt) are — leave it in `global_flags`, set
+`top_level = false`, and name it in that subcommand's `globalSubset`: the
+parser keeps accepting it anywhere (unchanged behaviour), while `--help` and
+the top-level completion list stay uncluttered.
+
+## Known limitations
+
+`--no-opt` and `--check` carry `top_level = false`, which scopes them for
+`--help` and the completions but **not** for the parser: the global loop still
+accepts them anywhere. For `--check` that is a live hazard, since it is one
+hyphen-pair from the `check` subcommand whose contract is that nothing
+executes — `kaappi --check foo.scm` runs the program. Tracked as
+[kaappi#2096](https://github.com/kaappi/kaappi/issues/2096); the scoping data
+this fix would need already lives in `subcommands`.
+
+fish has no way to express an optional attached value, so `--timings` is
+emitted without `-r`: the bare spelling — the common one — completes, and
+`--timings=json` still parses if a user attaches a value, but fish will not
+suggest `text`/`json`. bash and zsh both offer the full set.

--- a/docs/dev/explain.md
+++ b/docs/dev/explain.md
@@ -92,5 +92,5 @@ code whose message moves — fails CI, not a user.
 | Registry (codes, names, prose, examples) | `src/diagnostics.zig` |
 | Early dispatch (before VM/GC setup) | `src/main.zig` (`explain.maybeRun`) |
 | Shared JSON string escaper | `src/lsp_diagnostic.zig` |
-| Shell completions (`explain` subcommand) | `src/completions.zig` |
+| Shell completions (`explain` subcommand) | `src/cli_spec.zig` (the flag table) — `src/completions.zig` generates the scripts from it; see `cli-surface.md` |
 | Tests | `src/explain.zig` (unit), `tests/scheme/errors/explain.sh` (end-to-end) |

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -32,6 +32,7 @@ const bytecode_file = @import("bytecode_file.zig");
 const kaappi_paths = @import("kaappi_paths.zig");
 const file_utils = @import("file_utils.zig");
 const reporting = @import("reporting.zig");
+const spec = @import("cli_spec.zig");
 
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
@@ -139,13 +140,20 @@ pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
         return USAGE_ERROR_EXIT;
     };
 
-    if (std.mem.eql(u8, sub, "-h") or std.mem.eql(u8, sub, "--help")) {
-        printUsage();
-        return 0;
+    // Flags come from cli_spec.cache_flags, and the actions from
+    // cli_spec.cache_actions — the same tables the shell completions are
+    // generated from (#1890 6C).
+    if (spec.match(spec.CacheId, &spec.cache_flags, sub)) |m| {
+        switch (m.flag.id) {
+            .help => {
+                printUsage();
+                return 0;
+            },
+        }
     }
 
-    const is_status = std.mem.eql(u8, sub, "status");
-    const is_clear = std.mem.eql(u8, sub, "clear");
+    const is_status = std.mem.eql(u8, sub, spec.cache_status);
+    const is_clear = std.mem.eql(u8, sub, spec.cache_clear);
     if (!is_status and !is_clear) {
         writeStderr("kaappi cache: unknown subcommand '");
         writeStderr(sub);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const platform = @import("platform.zig");
 const completions = @import("completions.zig");
 const reporting = @import("reporting.zig");
+const spec = @import("cli_spec.zig");
 
 pub const version = @import("build_options").version;
 
@@ -10,81 +11,25 @@ pub const USAGE_ERROR_EXIT: u8 = 2;
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
 
-// `--diagnostics=<format>` uses GNU `=` syntax (not a space-separated value like
-// the other value flags), so it is matched by prefix rather than via the flag
-// table. Kept as a named constant so the parse loop and the sandbox pre-scan
-// agree on the spelling.
-const diagnostics_prefix = "--diagnostics=";
-
-// `--timings[=fmt]` accepts a bare form (`--timings`, text) and the GNU `=`
-// value form (`--timings=json`), so — like `--diagnostics=` — it is matched
-// outside the value-flag table. Same spelling shared by parse + sandbox pre-scan.
-const timings_prefix = "--timings=";
-
 // ── Flag table ─────────────────────────────────────────────────────────
+//
+// The table itself lives in `cli_spec.zig`, which `completions.zig` also
+// generates all six shell scripts from. Two flags used to be matched by
+// prefix *outside* the table — `--diagnostics=` and `--timings[=fmt]`, both
+// GNU `=` syntax the old table could not express — and that escape hatch is
+// exactly how they, and later `--no-ir-opt`, drifted out of the completion
+// scripts. `ValueSyntax` now covers both spellings, so there is no way into
+// this parse loop that does not pass through the table.
 
-const FlagId = enum {
-    help,
-    version_flag,
-    completions_flag,
-    lib_path,
-    compile,
-    emit_llvm,
-    output,
-    disassemble,
-    no_ir_opt,
-    sandbox,
-    gc_stats,
-    profile,
-    profile_json,
-    coverage,
-    coverage_xml,
-    timeout,
-    max_memory,
-    deny_warnings,
-    no_opt,
-    check,
-};
+const FlagId = spec.GlobalId;
+const flags = spec.global_flags;
 
-const FlagDesc = struct {
-    long: []const u8,
-    short: ?[]const u8,
-    takes_value: bool,
-    id: FlagId,
-    value_name: []const u8,
-};
+fn matchFlag(arg: []const u8) ?spec.Matched(FlagId) {
+    return spec.match(FlagId, &flags, arg);
+}
 
-const flags = [_]FlagDesc{
-    .{ .long = "--help", .short = "-h", .takes_value = false, .id = .help, .value_name = "" },
-    .{ .long = "--version", .short = null, .takes_value = false, .id = .version_flag, .value_name = "" },
-    .{ .long = "--completions", .short = null, .takes_value = true, .id = .completions_flag, .value_name = "shell name (bash, zsh, fish)" },
-    .{ .long = "--lib-path", .short = null, .takes_value = true, .id = .lib_path, .value_name = "path" },
-    .{ .long = "--compile", .short = null, .takes_value = false, .id = .compile, .value_name = "" },
-    .{ .long = "--emit-llvm", .short = null, .takes_value = false, .id = .emit_llvm, .value_name = "" },
-    .{ .long = "-o", .short = null, .takes_value = true, .id = .output, .value_name = "file path" },
-    .{ .long = "--disassemble", .short = null, .takes_value = false, .id = .disassemble, .value_name = "" },
-    .{ .long = "--no-ir-opt", .short = null, .takes_value = false, .id = .no_ir_opt, .value_name = "" },
-    .{ .long = "--sandbox", .short = null, .takes_value = false, .id = .sandbox, .value_name = "" },
-    .{ .long = "--gc-stats", .short = null, .takes_value = false, .id = .gc_stats, .value_name = "" },
-    .{ .long = "--profile", .short = null, .takes_value = false, .id = .profile, .value_name = "" },
-    .{ .long = "--profile-json", .short = null, .takes_value = true, .id = .profile_json, .value_name = "file path" },
-    .{ .long = "--coverage", .short = null, .takes_value = false, .id = .coverage, .value_name = "" },
-    .{ .long = "--coverage-xml", .short = null, .takes_value = true, .id = .coverage_xml, .value_name = "file path" },
-    .{ .long = "--timeout", .short = null, .takes_value = true, .id = .timeout, .value_name = "milliseconds" },
-    .{ .long = "--max-memory", .short = null, .takes_value = true, .id = .max_memory, .value_name = "bytes" },
-    .{ .long = "--deny-warnings", .short = null, .takes_value = false, .id = .deny_warnings, .value_name = "" },
-    .{ .long = "--no-opt", .short = null, .takes_value = false, .id = .no_opt, .value_name = "" },
-    .{ .long = "--check", .short = null, .takes_value = false, .id = .check, .value_name = "" },
-};
-
-fn lookupFlag(arg: []const u8) ?FlagDesc {
-    inline for (flags) |f| {
-        if (std.mem.eql(u8, arg, f.long)) return f;
-        if (f.short) |s| {
-            if (std.mem.eql(u8, arg, s)) return f;
-        }
-    }
-    return null;
+fn lookupFlag(arg: []const u8) ?spec.Flag(FlagId) {
+    return if (matchFlag(arg)) |m| m.flag else null;
 }
 
 // ── Options ────────────────────────────────────────────────────────────
@@ -168,17 +113,12 @@ pub fn preScanSandbox(args: std.process.Args) bool {
     _ = iter.skip();
     while (iter.next()) |arg| {
         if (std.mem.eql(u8, arg, "--sandbox")) return true;
-        if (lookupFlag(arg)) |f| {
-            if (f.takes_value) _ = iter.skip();
-        } else if (std.mem.eql(u8, arg, "compile") or std.mem.eql(u8, arg, "check") or
-            std.mem.eql(u8, arg, "ast") or std.mem.eql(u8, arg, "expand") or
-            std.mem.eql(u8, arg, "ir") or std.mem.eql(u8, arg, "fmt"))
-        {
+        if (matchFlag(arg)) |m| {
+            // An `=`-attached value is part of the same argv word; only a
+            // `.separate` one consumes the next.
+            if (m.inline_value == null and m.flag.takesSeparateValue()) _ = iter.skip();
+        } else if (spec.isInlineSubcommand(arg)) {
             // bare subcommand — keep scanning
-        } else if (std.mem.startsWith(u8, arg, diagnostics_prefix)) {
-            // `--diagnostics=…` carries its value inline — keep scanning.
-        } else if (std.mem.eql(u8, arg, "--timings") or std.mem.startsWith(u8, arg, timings_prefix)) {
-            // `--timings` / `--timings=…` — no separate value arg, keep scanning.
         } else {
             break;
         }
@@ -228,23 +168,9 @@ pub fn parse(args: std.process.Args) Options {
             continue;
         }
 
-        if (std.mem.startsWith(u8, arg, diagnostics_prefix)) {
-            opts.diagnostics_format = parseDiagnosticsFormat(arg[diagnostics_prefix.len..]);
-            continue;
-        }
-
-        if (std.mem.eql(u8, arg, "--timings")) {
-            opts.timings_enabled = true;
-            continue;
-        }
-        if (std.mem.startsWith(u8, arg, timings_prefix)) {
-            opts.timings_enabled = true;
-            opts.timings_json = parseTimingsFormat(arg[timings_prefix.len..]);
-            continue;
-        }
-
-        if (lookupFlag(arg)) |f| {
-            const value: ?[]const u8 = if (f.takes_value) blk: {
+        if (matchFlag(arg)) |m| {
+            const f = m.flag;
+            const value: ?[]const u8 = if (m.inline_value) |v| v else if (f.takesSeparateValue()) blk: {
                 break :blk iter.next() orelse {
                     writeStderr(f.long);
                     writeStderr(" requires a ");
@@ -293,6 +219,12 @@ pub fn parse(args: std.process.Args) Options {
                 .deny_warnings => opts.deny_warnings = true,
                 .no_opt => opts.ir_no_opt = true,
                 .check => opts.fmt_check = true,
+                .diagnostics => opts.diagnostics_format = parseDiagnosticsFormat(value.?),
+                .timings => {
+                    opts.timings_enabled = true;
+                    // Bare `--timings` is text; only an attached value picks.
+                    if (value) |v| opts.timings_json = parseTimingsFormat(v);
+                },
             }
         } else if (arg.len > 1 and arg[0] == '-') {
             writeStderr("unknown option: ");
@@ -337,72 +269,78 @@ fn oomCollectingArgs() noreturn {
     usageError("kaappi: out of memory collecting command-line arguments\n");
 }
 
+/// The `Options:` block, generated from the same table the parse loop and the
+/// completion scripts read. It used to be a fourth hand-maintained list.
+/// `--no-opt` and `--check` are `top_level = false`: the loop accepts them
+/// anywhere, but they only mean anything under `ir` / `fmt`, where the
+/// `Commands:` block above already documents them.
+const options_block = blk: {
+    @setEvalBranchQuota(100_000);
+    // One column for every spelling, so the descriptions line up.
+    var width = 0;
+    for (flags) |f| {
+        if (!f.top_level) continue;
+        const w = f.spelling().len;
+        if (w > width) width = w;
+    }
+    var out: []const u8 = "";
+    for (flags) |f| {
+        if (!f.top_level) continue;
+        const sp = f.spelling();
+        out = out ++ "  " ++ sp;
+        for (0..width - sp.len + 2) |_| out = out ++ " ";
+        out = out ++ f.desc ++ "\n";
+    }
+    break :blk out;
+};
+
 pub fn printUsage() void {
-    writeStdout(
-        "Kaappi Scheme v" ++ version ++ "\n" ++
-            "\n" ++
-            "Usage: kaappi [options] [file] [script-args...]\n" ++
-            "       kaappi compile <file.scm> [-o output]\n" ++
-            "       kaappi check <file.scm>\n" ++
-            "       kaappi explain <code>\n" ++
-            "       kaappi features [--json]\n" ++
-            "       kaappi test [paths...]\n" ++
-            "       kaappi ast|expand|ir <file.scm>\n" ++
-            "       kaappi doctor [--json]\n" ++
-            "       kaappi fmt [--check] [files...]\n" ++
-            "       kaappi cache <status|clear>\n" ++
-            "\n" ++
-            "Commands:\n" ++
-            "  compile <file>     Compile to native binary via LLVM\n" ++
-            "  check <file>       Compile-only static analysis (no execution); reports\n" ++
-            "                     read/compile errors and KP4xxx lint findings.\n" ++
-            "                     Honors --diagnostics=json; --deny-warnings\n" ++
-            "  explain <code>     Explain a diagnostic code (e.g. KP3001); --json, --all\n" ++
-            "  features           Report this build's capabilities (version, target,\n" ++
-            "                     subsystems, SRFIs, limits); --json\n" ++
-            "  test [paths...]    Run SRFI-64 suites; --json, --seed <n>, --lib-path,\n" ++
-            "                     --changed/--list-affected [--since <rev>]\n" ++
-            "  ast <file>         Print post-read datums (read + write)\n" ++
-            "  expand <file>      Print the program after full macro expansion\n" ++
-            "  ir <file> [--no-opt]  Print the IR tree; --no-opt shows it before the\n" ++
-            "                     optimization passes (default: after)\n" ++
-            "  doctor [--json]    Check the installation and environment; PASS/WARN/FAIL\n" ++
-            "                     per check with a fix for each failure\n" ++
-            "  fmt [files...]     Canonically format Scheme in place; --check reports\n" ++
-            "                     paths needing formatting (exit 1) without writing.\n" ++
-            "                     With no files, formats stdin to stdout\n" ++
-            "  cache status       Show the bytecode cache location, entries, and sizes\n" ++
-            "  cache clear        Remove all bytecode cache entries\n" ++
-            "\n" ++
-            "Options:\n" ++
-            "  -h, --help         Show this help message\n" ++
-            "  --version          Show version\n" ++
-            "  --lib-path <path>  Add library search path (repeatable)\n" ++
-            "  --compile          Compile file to bytecode (.sbc)\n" ++
-            "  --emit-llvm        Emit LLVM IR text (.ll)\n" ++
-            "  -o <file>          Output path\n" ++
-            "  --disassemble      Disassemble bytecode\n" ++
-            "  --diagnostics=<fmt> Diagnostic output format: text (default) or json\n" ++
-            "  --deny-warnings    (check) Treat lint warnings as errors for the exit code\n" ++
-            "  --no-ir-opt        Disable IR optimization passes (skips .sbc cache)\n" ++
-            "  --sandbox          Restrict filesystem and process access\n" ++
-            "  --gc-stats         Print GC statistics on exit\n" ++
-            "  --profile          Enable profiling\n" ++
-            "  --profile-json <f> Write profile JSON to file\n" ++
-            "  --timings[=fmt]    Report per-stage pipeline timings + cache HIT/MISS\n" ++
-            "                     on stderr; fmt is text (default) or json\n" ++
-            "  --coverage         Report library procedure coverage\n" ++
-            "  --coverage-xml <f> Write Cobertura XML coverage to file\n" ++
-            "  --timeout <ms>     Execution timeout in milliseconds\n" ++
-            "  --max-memory <n>   Maximum heap memory in bytes\n" ++
-            "  --completions <sh> Output completion script (bash, zsh, fish)\n" ++
-            "\n" ++
-            "Environment variables:\n" ++
-            "  KAAPPI_LIB_DIR     Directory containing " ++ platform.rt_lib_name ++ " (for compile)\n" ++
-            "\n" ++
-            "With no file argument, starts an interactive REPL.\n",
-    );
+    writeStdout(usage_text);
 }
+
+const usage_text =
+    "Kaappi Scheme v" ++ version ++ "\n" ++
+    "\n" ++
+    "Usage: kaappi [options] [file] [script-args...]\n" ++
+    "       kaappi compile <file.scm> [-o output]\n" ++
+    "       kaappi check <file.scm>\n" ++
+    "       kaappi explain <code>\n" ++
+    "       kaappi features [--json]\n" ++
+    "       kaappi test [paths...]\n" ++
+    "       kaappi ast|expand|ir <file.scm>\n" ++
+    "       kaappi doctor [--json]\n" ++
+    "       kaappi fmt [--check] [files...]\n" ++
+    "       kaappi cache <status|clear>\n" ++
+    "\n" ++
+    "Commands:\n" ++
+    "  compile <file>     Compile to native binary via LLVM\n" ++
+    "  check <file>       Compile-only static analysis (no execution); reports\n" ++
+    "                     read/compile errors and KP4xxx lint findings.\n" ++
+    "                     Honors --diagnostics=json; --deny-warnings\n" ++
+    "  explain <code>     Explain a diagnostic code (e.g. KP3001); --json, --all\n" ++
+    "  features           Report this build's capabilities (version, target,\n" ++
+    "                     subsystems, SRFIs, limits); --json\n" ++
+    "  test [paths...]    Run SRFI-64 suites; --json, --seed <n>, --lib-path,\n" ++
+    "                     --changed/--list-affected [--since <rev>]\n" ++
+    "  ast <file>         Print post-read datums (read + write)\n" ++
+    "  expand <file>      Print the program after full macro expansion\n" ++
+    "  ir <file> [--no-opt]  Print the IR tree; --no-opt shows it before the\n" ++
+    "                     optimization passes (default: after)\n" ++
+    "  doctor [--json]    Check the installation and environment; PASS/WARN/FAIL\n" ++
+    "                     per check with a fix for each failure\n" ++
+    "  fmt [files...]     Canonically format Scheme in place; --check reports\n" ++
+    "                     paths needing formatting (exit 1) without writing.\n" ++
+    "                     With no files, formats stdin to stdout\n" ++
+    "  cache status       Show the bytecode cache location, entries, and sizes\n" ++
+    "  cache clear        Remove all bytecode cache entries\n" ++
+    "\n" ++
+    "Options:\n" ++
+    options_block ++
+    "\n" ++
+    "Environment variables:\n" ++
+    "  KAAPPI_LIB_DIR     Directory containing " ++ platform.rt_lib_name ++ " (for compile)\n" ++
+    "\n" ++
+    "With no file argument, starts an interactive REPL.\n";
 
 pub fn usageError(msg: []const u8) noreturn {
     writeStderr(msg);
@@ -517,11 +455,40 @@ test "lookupFlag: unknown flags" {
 test "lookupFlag: value-taking flags" {
     const lp = lookupFlag("--lib-path");
     try std.testing.expect(lp != null);
-    try std.testing.expect(lp.?.takes_value);
+    try std.testing.expect(lp.?.takesSeparateValue());
 
     const gs = lookupFlag("--gc-stats");
     try std.testing.expect(gs != null);
-    try std.testing.expect(!gs.?.takes_value);
+    try std.testing.expect(!gs.?.takesSeparateValue());
+
+    // `=`-attached values do not consume the next argv word.
+    const dg = lookupFlag("--diagnostics=json");
+    try std.testing.expect(dg != null);
+    try std.testing.expect(!dg.?.takesSeparateValue());
+}
+
+test "printUsage documents every top-level flag" {
+    // The Options: block is generated from the same table, so this asserts the
+    // generation rather than a hand-kept list — including that the flags
+    // deliberately left out of it are exactly the subcommand-scoped ones.
+    inline for (flags) |f| {
+        if (f.top_level) {
+            try std.testing.expect(std.mem.indexOf(u8, options_block, f.long) != null);
+        } else {
+            try std.testing.expect(std.mem.indexOf(u8, options_block, f.long) == null);
+        }
+    }
+    try std.testing.expect(std.mem.indexOf(u8, options_block, "--no-ir-opt") != null);
+}
+
+test "printUsage names every subcommand in the table" {
+    // The Commands: block is still hand-written prose (each subcommand has its
+    // own `--help` for the detail), so this is the one place it can drift from
+    // `cli_spec.subcommands` — which is what the completions and the parsers
+    // agree on. A new subcommand that nobody documented fails here.
+    inline for (spec.subcommands) |sub| {
+        try std.testing.expect(std.mem.indexOf(u8, usage_text, "  " ++ sub.name ++ " ") != null);
+    }
 }
 
 test "preScanSandbox: detects --sandbox" {

--- a/src/cli_spec.zig
+++ b/src/cli_spec.zig
@@ -1,0 +1,484 @@
+//! The single authoritative description of the `kaappi` and `thottam`
+//! command-line surfaces.
+//!
+//! Everything that needs to know what a flag is spelled, whether it takes a
+//! value, or what it does reads *this* file:
+//!
+//!   * `cli.zig` — the global parse loop and `preScanSandbox`
+//!   * `cli.printUsage` — the `Options:` block is generated from `global_flags`
+//!   * `explain.zig`, `features.zig`, `doctor.zig`, `test_runner.zig`,
+//!     `cache.zig` — each drives its own parse loop from its own table here
+//!   * `thottam.zig` — same, from `thottam_flags`
+//!   * `completions.zig` — generates all six shell scripts at comptime
+//!
+//! **Why this file exists.** The completion scripts used to be hand-written
+//! lists of flags parallel to the parser's own, with nothing keeping them in
+//! step — the same shape as `isRejectedFormHead` and the `%`-prefix incident.
+//! They had drifted in both directions: `--no-ir-opt` was missing from all
+//! three kaappi scripts, `kaappi test` grew five flags none of them offered,
+//! and the zsh and fish scripts offered the whole global flag set inside
+//! `explain`/`features`/`doctor`/`test`/`cache`, whose own parsers reject 15
+//! of them with exit 2 (kaappi audit v2, Phase 6C).
+//!
+//! **The gate.** A flag cannot reach a parser without passing through a table
+//! here, because every parse loop dispatches on an *exhaustive* `switch` over
+//! that table's `Id` enum — add a variant and the compiler rejects the parser
+//! until it handles it, and the completions pick the flag up for free. The
+//! `comptime` block at the bottom additionally requires every `Id` variant to
+//! appear exactly once in its table, so a variant cannot be added without a
+//! row, and pins the description charset the shell generators assume.
+//!
+//! Descriptions are reused verbatim inside zsh `'…[desc]'` specs and fish
+//! `-d '…'` strings, so `validate()` rejects any character that would need
+//! quoting there. Keep them short, plain, and free of `[]:'"$\` and backticks.
+
+const std = @import("std");
+
+// ── Flag description ───────────────────────────────────────────────────
+
+/// How a flag's value is spelled on the command line.
+pub const ValueSyntax = enum {
+    /// No value at all: `--sandbox`.
+    none,
+    /// A separate following argument: `--lib-path <path>`.
+    separate,
+    /// Attached with `=`, mandatory: `--diagnostics=json`. The bare spelling
+    /// is *not* a flag (it falls through to "unknown option").
+    inline_eq,
+    /// Attached with `=`, or omitted: `--timings`, `--timings=json`.
+    inline_eq_optional,
+};
+
+/// What a shell should offer for this flag's value.
+pub const ValueKind = enum {
+    /// Nothing to complete (no value, or an opaque one like a byte count).
+    none,
+    file,
+    dir,
+    /// One of `choices`.
+    choice,
+};
+
+/// What a subcommand's positional arguments are, for completion purposes.
+pub const Positional = enum {
+    none,
+    /// `*.scm` source files.
+    scm_file,
+    /// Any file or directory path.
+    path,
+    /// An opaque token (a diagnostic code) — nothing to complete.
+    opaque_word,
+    /// One of the subcommand's own `choices`.
+    choice,
+};
+
+pub fn Flag(comptime Id: type) type {
+    return struct {
+        const Self = @This();
+
+        long: []const u8,
+        short: ?[]const u8 = null,
+        id: Id,
+        value: ValueSyntax = .none,
+        kind: ValueKind = .none,
+        choices: []const []const u8 = &.{},
+        /// Placeholder in `--help` and in the "requires a …" usage error.
+        value_name: []const u8 = "",
+        desc: []const u8,
+        /// Whether the flag belongs in the top-level `Options:` block and the
+        /// top-level completion list. `--no-opt` and `--check` are accepted by
+        /// the same global loop everywhere, but only mean anything under `ir`
+        /// and `fmt`, so they are documented and offered there instead.
+        top_level: bool = true,
+
+        pub fn takesSeparateValue(self: Self) bool {
+            return self.value == .separate;
+        }
+
+        /// `--lib-path <path>` / `--diagnostics=<fmt>` / `--timings[=fmt]`.
+        pub fn spelling(comptime self: Self) []const u8 {
+            const head = if (self.short) |s| s ++ ", " ++ self.long else self.long;
+            return switch (self.value) {
+                .none => head,
+                .separate => head ++ " <" ++ self.value_name ++ ">",
+                .inline_eq => head ++ "=<" ++ self.value_name ++ ">",
+                .inline_eq_optional => head ++ "[=" ++ self.value_name ++ "]",
+            };
+        }
+    };
+}
+
+pub fn Matched(comptime Id: type) type {
+    return struct {
+        flag: Flag(Id),
+        /// The `=`-attached value, when the spelling carried one.
+        inline_value: ?[]const u8,
+    };
+}
+
+/// Recognize `arg` against `table`. The single entry point every parse loop
+/// uses; there is deliberately no other way to spell a flag test.
+pub fn match(comptime Id: type, comptime table: []const Flag(Id), arg: []const u8) ?Matched(Id) {
+    inline for (table) |f| {
+        switch (f.value) {
+            .none, .separate => {
+                if (std.mem.eql(u8, arg, f.long)) return .{ .flag = f, .inline_value = null };
+                if (f.short) |s| {
+                    if (std.mem.eql(u8, arg, s)) return .{ .flag = f, .inline_value = null };
+                }
+            },
+            .inline_eq, .inline_eq_optional => {
+                if (f.value == .inline_eq_optional and std.mem.eql(u8, arg, f.long)) {
+                    return .{ .flag = f, .inline_value = null };
+                }
+                if (arg.len > f.long.len and
+                    std.mem.startsWith(u8, arg, f.long) and
+                    arg[f.long.len] == '=')
+                {
+                    return .{ .flag = f, .inline_value = arg[f.long.len + 1 ..] };
+                }
+            },
+        }
+    }
+    return null;
+}
+
+// ── Shell-facing view ──────────────────────────────────────────────────
+
+/// A `Flag` with its `Id` erased, so one list can hold flags from tables that
+/// use different `Id` enums. Only `completions.zig` and `printUsage` consume
+/// this; parsers always use the typed table so their switch stays exhaustive.
+pub const ShellFlag = struct {
+    long: []const u8,
+    short: ?[]const u8,
+    value: ValueSyntax,
+    kind: ValueKind,
+    choices: []const []const u8,
+    value_name: []const u8,
+    desc: []const u8,
+    top_level: bool,
+
+    pub fn spelling(comptime self: ShellFlag) []const u8 {
+        const head = if (self.short) |s| s ++ ", " ++ self.long else self.long;
+        return switch (self.value) {
+            .none => head,
+            .separate => head ++ " <" ++ self.value_name ++ ">",
+            .inline_eq => head ++ "=<" ++ self.value_name ++ ">",
+            .inline_eq_optional => head ++ "[=" ++ self.value_name ++ "]",
+        };
+    }
+};
+
+pub fn erase(comptime Id: type, comptime table: []const Flag(Id)) []const ShellFlag {
+    comptime {
+        var out: [table.len]ShellFlag = undefined;
+        for (table, 0..) |f, i| out[i] = .{
+            .long = f.long,
+            .short = f.short,
+            .value = f.value,
+            .kind = f.kind,
+            .choices = f.choices,
+            .value_name = f.value_name,
+            .desc = f.desc,
+            .top_level = f.top_level,
+        };
+        const frozen = out;
+        return &frozen;
+    }
+}
+
+/// The subset of `global_flags` named by `ids`, erased. Used by the
+/// subcommands `cli.parse` handles inline (`compile`, `check`, `ast`,
+/// `expand`, `ir`, `fmt`): those go through the *same* global loop, so every
+/// global flag is accepted there — this picks out the ones worth offering,
+/// and referencing them by id means a renamed flag cannot go stale.
+pub fn globalSubset(comptime ids: []const GlobalId) []const ShellFlag {
+    comptime {
+        const all = erase(GlobalId, &global_flags);
+        var out: [ids.len]ShellFlag = undefined;
+        for (ids, 0..) |want, i| {
+            var found = false;
+            for (global_flags, 0..) |g, j| {
+                if (g.id == want) {
+                    out[i] = all[j];
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) @compileError("globalSubset: no global flag with that id");
+        }
+        const frozen = out;
+        return &frozen;
+    }
+}
+
+pub const SubcommandDesc = struct {
+    name: []const u8,
+    desc: []const u8,
+    flags: []const ShellFlag,
+    positional: Positional = .none,
+    choices: []const []const u8 = &.{},
+    /// True for the subcommands whose arguments `cli.parse` consumes with the
+    /// *global* flag table (so every global flag is legal after them). False
+    /// for the five that intercept argv in their own module before `cli.parse`
+    /// ever runs, and reject anything outside their own table with exit 2 —
+    /// which is exactly why offering the global set inside them was a bug.
+    global_flags_ok: bool = false,
+};
+
+// ── kaappi: global flags ───────────────────────────────────────────────
+
+pub const GlobalId = enum {
+    help,
+    version_flag,
+    completions_flag,
+    lib_path,
+    compile,
+    emit_llvm,
+    output,
+    disassemble,
+    diagnostics,
+    deny_warnings,
+    no_ir_opt,
+    sandbox,
+    gc_stats,
+    profile,
+    profile_json,
+    timings,
+    coverage,
+    coverage_xml,
+    timeout,
+    max_memory,
+    no_opt,
+    check,
+};
+
+pub const shells = [_][]const u8{ "bash", "zsh", "fish" };
+const fmts = [_][]const u8{ "text", "json" };
+
+pub const global_flags = [_]Flag(GlobalId){
+    .{ .long = "--help", .short = "-h", .id = .help, .desc = "Show this help message" },
+    .{ .long = "--version", .id = .version_flag, .desc = "Show version" },
+    .{ .long = "--lib-path", .id = .lib_path, .value = .separate, .kind = .dir, .value_name = "path", .desc = "Add a library search path (repeatable)" },
+    .{ .long = "--compile", .id = .compile, .desc = "Compile the file to bytecode (.sbc)" },
+    .{ .long = "--emit-llvm", .id = .emit_llvm, .desc = "Emit LLVM IR text (.ll)" },
+    .{ .long = "-o", .id = .output, .value = .separate, .kind = .file, .value_name = "file", .desc = "Output path" },
+    .{ .long = "--disassemble", .id = .disassemble, .desc = "Disassemble bytecode" },
+    .{ .long = "--diagnostics", .id = .diagnostics, .value = .inline_eq, .kind = .choice, .choices = &fmts, .value_name = "fmt", .desc = "Diagnostic output format, text (default) or json" },
+    .{ .long = "--deny-warnings", .id = .deny_warnings, .desc = "(check) Treat lint warnings as errors for the exit code" },
+    .{ .long = "--no-ir-opt", .id = .no_ir_opt, .desc = "Disable IR optimization passes (skips the .sbc cache)" },
+    .{ .long = "--sandbox", .id = .sandbox, .desc = "Restrict filesystem and process access" },
+    .{ .long = "--gc-stats", .id = .gc_stats, .desc = "Print GC statistics on exit" },
+    .{ .long = "--profile", .id = .profile, .desc = "Enable profiling" },
+    .{ .long = "--profile-json", .id = .profile_json, .value = .separate, .kind = .file, .value_name = "file", .desc = "Write profile JSON to a file" },
+    .{ .long = "--timings", .id = .timings, .value = .inline_eq_optional, .kind = .choice, .choices = &fmts, .value_name = "fmt", .desc = "Report per-stage timings and cache hits on stderr" },
+    .{ .long = "--coverage", .id = .coverage, .desc = "Report library procedure coverage" },
+    .{ .long = "--coverage-xml", .id = .coverage_xml, .value = .separate, .kind = .file, .value_name = "file", .desc = "Write Cobertura XML coverage to a file" },
+    .{ .long = "--timeout", .id = .timeout, .value = .separate, .value_name = "ms", .desc = "Execution timeout in milliseconds" },
+    .{ .long = "--max-memory", .id = .max_memory, .value = .separate, .value_name = "bytes", .desc = "Maximum heap memory in bytes" },
+    .{ .long = "--completions", .id = .completions_flag, .value = .separate, .kind = .choice, .choices = &shells, .value_name = "shell", .desc = "Output a shell completion script" },
+    // Subcommand-scoped: accepted by the same global loop anywhere, but only
+    // meaningful under `ir` / `fmt`, so they are offered and documented there.
+    .{ .long = "--no-opt", .id = .no_opt, .top_level = false, .desc = "(ir) Show the IR before the optimization passes" },
+    .{ .long = "--check", .id = .check, .top_level = false, .desc = "(fmt) Report files needing formatting without writing" },
+};
+
+// ── kaappi: out-of-line subcommand flags ───────────────────────────────
+//
+// These five subcommands intercept argv in their own module, before
+// `cli.parse` runs, and reject anything outside their own table.
+
+pub const ExplainId = enum { json, all, help };
+pub const explain_flags = [_]Flag(ExplainId){
+    .{ .long = "--json", .id = .json, .desc = "Machine-readable output" },
+    .{ .long = "--all", .id = .all, .desc = "Explain every diagnostic code" },
+    .{ .long = "--help", .short = "-h", .id = .help, .desc = "Show this help message" },
+};
+
+pub const FeaturesId = enum { json, help };
+pub const features_flags = [_]Flag(FeaturesId){
+    .{ .long = "--json", .id = .json, .desc = "Machine-readable output" },
+    .{ .long = "--help", .short = "-h", .id = .help, .desc = "Show this help message" },
+};
+
+pub const DoctorId = enum { json, lib_path, help };
+pub const doctor_flags = [_]Flag(DoctorId){
+    .{ .long = "--json", .id = .json, .desc = "Machine-readable output" },
+    .{ .long = "--lib-path", .id = .lib_path, .value = .separate, .kind = .dir, .value_name = "path", .desc = "Add a library search path (repeatable)" },
+    .{ .long = "--help", .short = "-h", .id = .help, .desc = "Show this help message" },
+};
+
+pub const TestId = enum { json, seed, lib_path, jobs, changed, list_affected, since, help };
+pub const test_flags = [_]Flag(TestId){
+    .{ .long = "--json", .id = .json, .desc = "Machine-readable output" },
+    .{ .long = "--seed", .id = .seed, .value = .separate, .value_name = "n", .desc = "Pin the run seed for reproducibility" },
+    .{ .long = "--lib-path", .id = .lib_path, .value = .separate, .kind = .dir, .value_name = "path", .desc = "Add a library search path (repeatable)" },
+    .{ .long = "--jobs", .short = "-j", .id = .jobs, .value = .separate, .value_name = "n", .desc = "Run n files concurrently (default one per CPU)" },
+    .{ .long = "--changed", .id = .changed, .desc = "Run only the suites whose import closure changed" },
+    .{ .long = "--list-affected", .id = .list_affected, .desc = "Print the affected suites without running them" },
+    .{ .long = "--since", .id = .since, .value = .separate, .value_name = "rev", .desc = "Revision the change set is diffed against" },
+    .{ .long = "--help", .short = "-h", .id = .help, .desc = "Show this help message" },
+};
+
+pub const CacheId = enum { help };
+pub const cache_flags = [_]Flag(CacheId){
+    .{ .long = "--help", .short = "-h", .id = .help, .desc = "Show this help message" },
+};
+pub const cache_actions = [_][]const u8{ "status", "clear" };
+/// Named so `cache.zig` compares against a spelling rather than a position.
+pub const cache_status = cache_actions[0];
+pub const cache_clear = cache_actions[1];
+
+// ── kaappi: the subcommand table ───────────────────────────────────────
+
+pub const subcommands = [_]SubcommandDesc{
+    .{ .name = "compile", .desc = "Compile to a native binary via LLVM", .global_flags_ok = true, .positional = .scm_file, .flags = globalSubset(&.{ .output, .lib_path }) },
+    .{ .name = "check", .desc = "Compile-only static analysis, nothing is executed", .global_flags_ok = true, .positional = .scm_file, .flags = globalSubset(&.{ .diagnostics, .deny_warnings, .lib_path }) },
+    .{ .name = "explain", .desc = "Explain a diagnostic code such as KP3001", .positional = .opaque_word, .flags = erase(ExplainId, &explain_flags) },
+    .{ .name = "features", .desc = "Report the capabilities of this build", .flags = erase(FeaturesId, &features_flags) },
+    .{ .name = "test", .desc = "Run SRFI-64 test suites", .positional = .path, .flags = erase(TestId, &test_flags) },
+    .{ .name = "ast", .desc = "Print post-read datums (read plus write)", .global_flags_ok = true, .positional = .scm_file, .flags = globalSubset(&.{.lib_path}) },
+    .{ .name = "expand", .desc = "Print the program after full macro expansion", .global_flags_ok = true, .positional = .scm_file, .flags = globalSubset(&.{.lib_path}) },
+    .{ .name = "ir", .desc = "Print the IR tree", .global_flags_ok = true, .positional = .scm_file, .flags = globalSubset(&.{ .no_opt, .lib_path }) },
+    .{ .name = "doctor", .desc = "Check the installation and environment", .flags = erase(DoctorId, &doctor_flags) },
+    .{ .name = "fmt", .desc = "Canonically format Scheme source in place", .global_flags_ok = true, .positional = .path, .flags = globalSubset(&.{.check}) },
+    .{ .name = "cache", .desc = "Inspect or clear the bytecode cache", .positional = .choice, .choices = &cache_actions, .flags = erase(CacheId, &cache_flags) },
+};
+
+/// The subcommand words `cli.parse` and `preScanSandbox` consume themselves.
+/// Derived, so a new inline subcommand cannot be added to one and forgotten in
+/// the other — which is how `preScanSandbox` would stop seeing a later
+/// `--sandbox`.
+pub fn isInlineSubcommand(arg: []const u8) bool {
+    inline for (subcommands) |s| {
+        if (s.global_flags_ok and std.mem.eql(u8, arg, s.name)) return true;
+    }
+    return false;
+}
+
+// ── thottam ────────────────────────────────────────────────────────────
+
+pub const ThottamId = enum { locked, help, version_flag, completions_flag };
+pub const thottam_flags = [_]Flag(ThottamId){
+    .{ .long = "--locked", .id = .locked, .desc = "Refuse to install packages not in the lockfile" },
+    .{ .long = "--help", .short = "-h", .id = .help, .desc = "Show this help message" },
+    .{ .long = "--version", .id = .version_flag, .desc = "Show version" },
+    .{ .long = "--completions", .id = .completions_flag, .value = .separate, .kind = .choice, .choices = &shells, .value_name = "shell", .desc = "Output a shell completion script" },
+};
+
+// thottam parses every flag in one flat loop that keeps scanning past the
+// subcommand word, so `thottam install --locked pkg` is as valid as
+// `thottam --locked install pkg`: every subcommand accepts the whole flag set.
+pub const thottam_subcommands = [_]SubcommandDesc{
+    .{ .name = "install", .desc = "Install a package", .positional = .opaque_word, .global_flags_ok = true, .flags = &.{} },
+    .{ .name = "remove", .desc = "Remove a package", .positional = .opaque_word, .global_flags_ok = true, .flags = &.{} },
+    .{ .name = "list", .desc = "List installed packages", .global_flags_ok = true, .flags = &.{} },
+    .{ .name = "update", .desc = "Update one or all packages", .positional = .opaque_word, .global_flags_ok = true, .flags = &.{} },
+    .{ .name = "verify", .desc = "Check installs match the lockfile", .global_flags_ok = true, .flags = &.{} },
+};
+
+// ── Comptime validation ────────────────────────────────────────────────
+
+fn validateTable(comptime Id: type, comptime table: []const Flag(Id), comptime what: []const u8) void {
+    comptime {
+        @setEvalBranchQuota(100_000);
+        // Every Id variant appears exactly once: a new variant without a row
+        // is a compile error, so the table can never lag the enum.
+        for (@typeInfo(Id).@"enum".fields) |field| {
+            var seen = 0;
+            for (table) |f| {
+                if (@intFromEnum(f.id) == field.value) seen += 1;
+            }
+            if (seen != 1) @compileError(what ++ ": " ++ field.name ++ " must appear exactly once in the table");
+        }
+        for (table, 0..) |f, i| {
+            if (f.long.len < 2 or f.long[0] != '-') @compileError(what ++ ": flag spellings must start with '-'");
+            if (f.takesSeparateValue() and f.value_name.len == 0) @compileError(what ++ ": " ++ f.long ++ " takes a value but names none");
+            if (f.kind == .choice and f.choices.len == 0) @compileError(what ++ ": " ++ f.long ++ " completes a choice but lists none");
+            // Descriptions land verbatim inside zsh '…[desc]' specs and fish
+            // -d '…' strings; anything needing quoting there would silently
+            // produce a broken script.
+            for (f.desc) |c| {
+                if (c < 0x20 or c > 0x7e) @compileError(what ++ ": " ++ f.long ++ " description must be printable ASCII");
+                switch (c) {
+                    '[', ']', ':', '\'', '"', '$', '\\', '`' => @compileError(what ++ ": " ++ f.long ++ " description must not need shell or zsh quoting"),
+                    else => {},
+                }
+            }
+            for (table[i + 1 ..]) |g| {
+                if (std.mem.eql(u8, f.long, g.long)) @compileError(what ++ ": duplicate flag " ++ f.long);
+            }
+        }
+    }
+}
+
+comptime {
+    validateTable(GlobalId, &global_flags, "global_flags");
+    validateTable(ExplainId, &explain_flags, "explain_flags");
+    validateTable(FeaturesId, &features_flags, "features_flags");
+    validateTable(DoctorId, &doctor_flags, "doctor_flags");
+    validateTable(TestId, &test_flags, "test_flags");
+    validateTable(CacheId, &cache_flags, "cache_flags");
+    validateTable(ThottamId, &thottam_flags, "thottam_flags");
+
+    // Every subcommand's own flags must be a *sound* offer: a flag a
+    // subcommand's parser would reject must never be completed for it. For the
+    // five out-of-line subcommands `flags` IS the parser's table, so soundness
+    // is definitional; for the inline ones `globalSubset` can only name ids
+    // that exist, and every global flag is legal after them. This pins the one
+    // remaining way to get it wrong — a hand-written entry.
+    for (subcommands ++ thottam_subcommands) |s| {
+        if (s.positional == .choice and s.choices.len == 0) {
+            @compileError("subcommand " ++ s.name ++ " completes a choice but lists none");
+        }
+        for (s.desc) |c| {
+            if (c < 0x20 or c > 0x7e) @compileError("subcommand " ++ s.name ++ " description must be printable ASCII");
+            switch (c) {
+                '[', ']', ':', '\'', '"', '$', '\\', '`' => @compileError("subcommand " ++ s.name ++ " description must not need shell or zsh quoting"),
+                else => {},
+            }
+        }
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "match: exact long and short spellings" {
+    try std.testing.expect(match(GlobalId, &global_flags, "--sandbox").?.flag.id == .sandbox);
+    try std.testing.expect(match(GlobalId, &global_flags, "-h").?.flag.id == .help);
+    try std.testing.expect(match(GlobalId, &global_flags, "-o").?.flag.id == .output);
+    try std.testing.expect(match(GlobalId, &global_flags, "--nope") == null);
+}
+
+test "match: inline_eq requires the =" {
+    const d = match(GlobalId, &global_flags, "--diagnostics=json").?;
+    try std.testing.expect(d.flag.id == .diagnostics);
+    try std.testing.expectEqualStrings("json", d.inline_value.?);
+    // Bare `--diagnostics` is not a flag — it must reach "unknown option".
+    try std.testing.expect(match(GlobalId, &global_flags, "--diagnostics") == null);
+    // An empty value still matches, so the format parser can name it.
+    try std.testing.expectEqualStrings("", match(GlobalId, &global_flags, "--diagnostics=").?.inline_value.?);
+}
+
+test "match: inline_eq_optional accepts both spellings" {
+    try std.testing.expect(match(GlobalId, &global_flags, "--timings").?.inline_value == null);
+    try std.testing.expectEqualStrings("json", match(GlobalId, &global_flags, "--timings=json").?.inline_value.?);
+}
+
+test "match: --timeout is not a prefix match for --timings" {
+    try std.testing.expect(match(GlobalId, &global_flags, "--timeout").?.flag.id == .timeout);
+    try std.testing.expect(match(GlobalId, &global_flags, "--timings-x") == null);
+}
+
+test "isInlineSubcommand: exactly the ones cli.parse consumes" {
+    for ([_][]const u8{ "compile", "check", "ast", "expand", "ir", "fmt" }) |s| {
+        try std.testing.expect(isInlineSubcommand(s));
+    }
+    for ([_][]const u8{ "explain", "features", "test", "doctor", "cache", "nope" }) |s| {
+        try std.testing.expect(!isInlineSubcommand(s));
+    }
+}
+
+test "subcommand table names every subcommand printUsage documents" {
+    try std.testing.expectEqual(@as(usize, 11), subcommands.len);
+}

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -1,251 +1,461 @@
+//! Shell completion scripts for `kaappi` and `thottam`, generated at comptime
+//! from `cli_spec.zig` — the same tables the argument parsers dispatch on.
+//!
+//! Nothing here is hand-maintained. Add a flag to a table in `cli_spec.zig`
+//! and all six scripts grow it; there is no second list to forget. See that
+//! file's header for the drift this replaced.
+//!
+//! Three properties the generators preserve, in order of how badly a user
+//! feels their absence:
+//!
+//!  1. **Soundness** — never offer something the parser rejects. The five
+//!     subcommands that intercept argv in their own module (`explain`,
+//!     `features`, `test`, `doctor`, `cache`) reject every global flag with
+//!     exit 2, so their completions are scoped to their own table. The zsh and
+//!     fish scripts previously offered all 21 global flags inside each of them.
+//!  2. **Completeness** — every flag a parser accepts is offered somewhere.
+//!  3. **Value completion** — a flag that takes a path completes paths, and
+//!     one that takes a fixed set completes that set.
+
 const std = @import("std");
+const spec = @import("cli_spec.zig");
 
-// === kaappi completion scripts ===
+const ShellFlag = spec.ShellFlag;
+const SubcommandDesc = spec.SubcommandDesc;
 
-const kaappi_bash =
-    \\_kaappi() {
-    \\    local cur prev
-    \\    cur="${COMP_WORDS[COMP_CWORD]}"
-    \\    prev="${COMP_WORDS[COMP_CWORD-1]}"
-    \\
-    \\    case "$prev" in
-    \\        --completions)
-    \\            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
-    \\            return ;;
-    \\        --lib-path|-o|--profile-json|--coverage-xml)
-    \\            COMPREPLY=($(compgen -f -- "$cur"))
-    \\            return ;;
-    \\        --timeout|--max-memory)
-    \\            return ;;
-    \\    esac
-    \\
-    \\    local has_compile=false has_explain=false has_test=false has_check=false has_ir=false has_doctor=false has_features=false has_fmt=false has_cache=false
-    \\    for word in "${COMP_WORDS[@]}"; do
-    \\        [[ "$word" == "compile" ]] && has_compile=true
-    \\        [[ "$word" == "explain" ]] && has_explain=true
-    \\        [[ "$word" == "test" ]] && has_test=true
-    \\        [[ "$word" == "check" ]] && has_check=true
-    \\        [[ "$word" == "ir" ]] && has_ir=true
-    \\        [[ "$word" == "doctor" ]] && has_doctor=true
-    \\        [[ "$word" == "features" ]] && has_features=true
-    \\        [[ "$word" == "fmt" ]] && has_fmt=true
-    \\        [[ "$word" == "cache" ]] && has_cache=true
-    \\    done
-    \\
-    \\    if $has_explain; then
-    \\        COMPREPLY=($(compgen -W "--json --all" -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if $has_features; then
-    \\        COMPREPLY=($(compgen -W "--json" -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if $has_test; then
-    \\        COMPREPLY=($(compgen -W "--json --seed --lib-path" -- "$cur") $(compgen -f -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if $has_check; then
-    \\        COMPREPLY=($(compgen -W "--diagnostics=text --diagnostics=json --deny-warnings --lib-path" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if $has_ir; then
-    \\        COMPREPLY=($(compgen -W "--no-opt" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if $has_doctor; then
-    \\        COMPREPLY=($(compgen -W "--json --lib-path" -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if $has_fmt; then
-    \\        COMPREPLY=($(compgen -W "--check" -- "$cur") $(compgen -f -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if $has_cache; then
-    \\        COMPREPLY=($(compgen -W "status clear" -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if [[ "$cur" == -* ]]; then
-    \\        COMPREPLY=($(compgen -W "-h --help --version --lib-path --compile --emit-llvm -o --disassemble --diagnostics=text --diagnostics=json --deny-warnings --sandbox --gc-stats --profile --profile-json --timings --timings=text --timings=json --coverage --coverage-xml --timeout --max-memory --completions" -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    if $has_compile; then
-    \\        COMPREPLY=($(compgen -f -X '!*.scm' -- "$cur") $(compgen -W "-o" -- "$cur"))
-    \\    else
-    \\        COMPREPLY=($(compgen -W "compile check explain features test ast expand ir doctor fmt cache" -- "$cur") $(compgen -f -X '!*.scm' -- "$cur"))
-    \\    fi
-    \\}
-    \\complete -o filenames -F _kaappi kaappi
-    \\
-;
+// ── Shared comptime helpers ────────────────────────────────────────────
 
-const kaappi_zsh =
-    \\#compdef kaappi
-    \\
-    \\_kaappi() {
-    \\    local -a flags
-    \\    flags=(
-    \\        '-h[Show help message]'
-    \\        '--help[Show help message]'
-    \\        '--version[Show version]'
-    \\        '--lib-path[Add library search path]:path:_files -/'
-    \\        '--compile[Compile file to bytecode (.sbc)]'
-    \\        '--emit-llvm[Emit LLVM IR text (.ll)]'
-    \\        '-o[Output path]:file:_files'
-    \\        '--disassemble[Disassemble bytecode]'
-    \\        '--diagnostics=[Diagnostic output format]:format:(text json)'
-    \\        '--deny-warnings[(check) Treat lint warnings as errors]'
-    \\        '--sandbox[Restrict filesystem and process access]'
-    \\        '--gc-stats[Print GC statistics on exit]'
-    \\        '--profile[Enable profiling]'
-    \\        '--profile-json[Write profile JSON to file]:file:_files'
-    \\        '--timings=[Per-stage pipeline timings + cache HIT/MISS]:format:(text json)'
-    \\        '--coverage[Report library procedure coverage]'
-    \\        '--coverage-xml[Write Cobertura XML coverage to file]:file:_files'
-    \\        '--timeout[Execution timeout in milliseconds]:ms:'
-    \\        '--max-memory[Maximum heap memory in bytes]:bytes:'
-    \\        '--no-opt[(ir) Show the IR before the optimization passes]'
-    \\        '--check[(fmt) Report files needing formatting without writing]'
-    \\        '--completions[Output shell completion script]:shell:(bash zsh fish)'
-    \\    )
-    \\
-    \\    _arguments -s \
-    \\        $flags \
-    \\        '1:command or file:_alternative "commands:command:(compile check explain features test ast expand ir doctor fmt cache)" "files:file:_files -g \"*.scm\""' \
-    \\        '*:script args:_files'
-    \\}
-    \\
-    \\_kaappi "$@"
-    \\
-;
+/// The words a shell should offer for `f` when the user is typing a flag.
+/// An `.inline_eq` flag is only ever legal with its value attached, so the
+/// offered words are the full `--flag=value` spellings; an optional-value one
+/// offers the bare spelling too.
+fn flagWords(comptime f: ShellFlag) []const []const u8 {
+    comptime {
+        var out: []const []const u8 = &.{};
+        switch (f.value) {
+            .none, .separate => {
+                out = out ++ [_][]const u8{f.long};
+                if (f.short) |s| out = out ++ [_][]const u8{s};
+            },
+            .inline_eq => {
+                for (f.choices) |c| out = out ++ [_][]const u8{f.long ++ "=" ++ c};
+            },
+            .inline_eq_optional => {
+                out = out ++ [_][]const u8{f.long};
+                for (f.choices) |c| out = out ++ [_][]const u8{f.long ++ "=" ++ c};
+            },
+        }
+        return out;
+    }
+}
 
-const kaappi_fish =
-    \\# Completions for kaappi
-    \\complete -c kaappi -l help -s h -d 'Show help message'
-    \\complete -c kaappi -l version -d 'Show version'
-    \\complete -c kaappi -l lib-path -r -F -d 'Add library search path'
-    \\complete -c kaappi -l compile -d 'Compile file to bytecode (.sbc)'
-    \\complete -c kaappi -l emit-llvm -d 'Emit LLVM IR text (.ll)'
-    \\complete -c kaappi -s o -r -F -d 'Output path'
-    \\complete -c kaappi -l disassemble -d 'Disassemble bytecode'
-    \\complete -c kaappi -l diagnostics -x -a 'text json' -d 'Diagnostic output format'
-    \\complete -c kaappi -l sandbox -d 'Restrict filesystem and process access'
-    \\complete -c kaappi -l gc-stats -d 'Print GC statistics on exit'
-    \\complete -c kaappi -l profile -d 'Enable profiling'
-    \\complete -c kaappi -l profile-json -r -F -d 'Write profile JSON to file'
-    \\complete -c kaappi -l timings -x -a 'text json' -d 'Per-stage pipeline timings + cache HIT/MISS'
-    \\complete -c kaappi -l coverage -d 'Report library procedure coverage'
-    \\complete -c kaappi -l coverage-xml -r -F -d 'Write Cobertura XML coverage to file'
-    \\complete -c kaappi -l timeout -r -x -d 'Execution timeout in milliseconds'
-    \\complete -c kaappi -l max-memory -r -x -d 'Maximum heap memory in bytes'
-    \\complete -c kaappi -l deny-warnings -d '(check) Treat lint warnings as errors'
-    \\complete -c kaappi -l no-opt -d '(ir) Show the IR before the optimization passes'
-    \\complete -c kaappi -l check -d '(fmt) Report files needing formatting without writing'
-    \\complete -c kaappi -l completions -r -x -a 'bash zsh fish' -d 'Output shell completion script'
-    \\complete -c kaappi -a compile -d 'Compile to native binary via LLVM'
-    \\complete -c kaappi -a check -d 'Compile-only static analysis (no execution)'
-    \\complete -c kaappi -a explain -d 'Explain a diagnostic code (KP####)'
-    \\complete -c kaappi -a features -d 'Report this build''s capabilities (--json)'
-    \\complete -c kaappi -a test -d 'Run SRFI-64 test suites (--json, --seed)'
-    \\complete -c kaappi -a ast -d 'Print post-read datums (read + write)'
-    \\complete -c kaappi -a expand -d 'Print the program after full macro expansion'
-    \\complete -c kaappi -a ir -d 'Print the IR tree (--no-opt for pre-optimization)'
-    \\complete -c kaappi -a doctor -d 'Check the installation and environment (--json)'
-    \\complete -c kaappi -a fmt -d 'Canonically format Scheme (--check for CI)'
-    \\complete -c kaappi -n '__fish_use_subcommand' -a cache -d 'Inspect or clear the bytecode cache'
-    \\complete -c kaappi -n '__fish_seen_subcommand_from cache' -a 'status clear' -d 'Cache action'
-    \\
-;
+fn joinWords(comptime words: []const []const u8) []const u8 {
+    comptime {
+        var s: []const u8 = "";
+        for (words, 0..) |w, i| {
+            if (i > 0) s = s ++ " ";
+            s = s ++ w;
+        }
+        return s;
+    }
+}
 
-// === thottam completion scripts ===
+fn wordsFor(comptime flags: []const ShellFlag) []const []const u8 {
+    comptime {
+        var out: []const []const u8 = &.{};
+        for (flags) |f| out = out ++ flagWords(f);
+        return out;
+    }
+}
 
-const thottam_bash =
-    \\_thottam() {
-    \\    local cur prev
-    \\    cur="${COMP_WORDS[COMP_CWORD]}"
-    \\    prev="${COMP_WORDS[COMP_CWORD-1]}"
-    \\
-    \\    case "$prev" in
-    \\        --completions)
-    \\            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
-    \\            return ;;
-    \\    esac
-    \\
-    \\    if [[ "$cur" == -* ]]; then
-    \\        COMPREPLY=($(compgen -W "--locked -h --help --version --completions" -- "$cur"))
-    \\        return
-    \\    fi
-    \\
-    \\    local subcmd=""
-    \\    for word in "${COMP_WORDS[@]:1}"; do
-    \\        case "$word" in
-    \\            install|remove|list|update|verify) subcmd="$word"; break ;;
-    \\        esac
-    \\    done
-    \\
-    \\    if [[ -z "$subcmd" ]]; then
-    \\        COMPREPLY=($(compgen -W "install remove list update verify" -- "$cur"))
-    \\    fi
-    \\}
-    \\complete -F _thottam thottam
-    \\
-;
+fn withoutOverlap(comptime all: []const ShellFlag, comptime remove: []const ShellFlag) []const ShellFlag {
+    comptime {
+        var out: []const ShellFlag = &.{};
+        next: for (all) |f| {
+            for (remove) |g| {
+                if (std.mem.eql(u8, f.long, g.long)) continue :next;
+            }
+            out = out ++ [_]ShellFlag{f};
+        }
+        return out;
+    }
+}
 
-const thottam_zsh =
-    \\#compdef thottam
-    \\
-    \\_thottam() {
-    \\    local -a subcmds
-    \\    subcmds=(
-    \\        'install:Install a package'
-    \\        'remove:Remove a package'
-    \\        'list:List installed packages'
-    \\        'update:Update one or all packages'
-    \\        'verify:Check installs match the lockfile'
-    \\    )
-    \\
-    \\    _arguments -s \
-    \\        '--locked[Refuse to install packages not in the lockfile]' \
-    \\        '-h[Show help message]' \
-    \\        '--help[Show help message]' \
-    \\        '--version[Show version]' \
-    \\        '--completions[Output shell completion script]:shell:(bash zsh fish)' \
-    \\        '1:command:->subcmd' \
-    \\        '*:argument:' \
-    \\    && return
-    \\
-    \\    case "$state" in
-    \\        subcmd)
-    \\            _describe 'command' subcmds ;;
-    \\    esac
-    \\}
-    \\
-    \\_thottam "$@"
-    \\
-;
+fn hasFlag(comptime flags: []const ShellFlag, comptime f: ShellFlag) bool {
+    comptime {
+        for (flags) |g| {
+            if (std.mem.eql(u8, g.long, f.long)) return true;
+        }
+        return false;
+    }
+}
 
-const thottam_fish =
-    \\# Completions for thottam
-    \\complete -c thottam -f
-    \\complete -c thottam -l locked -d 'Refuse to install packages not in the lockfile'
-    \\complete -c thottam -l help -s h -d 'Show help message'
-    \\complete -c thottam -l version -d 'Show version'
-    \\complete -c thottam -l completions -r -x -a 'bash zsh fish' -d 'Output shell completion script'
-    \\complete -c thottam -a install -d 'Install a package'
-    \\complete -c thottam -a remove -d 'Remove a package'
-    \\complete -c thottam -a list -d 'List installed packages'
-    \\complete -c thottam -a update -d 'Update one or all packages'
-    \\complete -c thottam -a verify -d 'Check installs match the lockfile'
-    \\
-;
+/// Every flag in every kaappi table, deduplicated by spelling. The bash `case
+/// "$prev"` value arms are built from this, so a flag that takes a path
+/// completes paths no matter which subcommand it belongs to.
+fn allKaappiFlags() []const ShellFlag {
+    comptime {
+        var out: []const ShellFlag = spec.erase(spec.GlobalId, &spec.global_flags);
+        for (spec.subcommands) |s| {
+            next: for (s.flags) |f| {
+                for (out) |seen| {
+                    if (std.mem.eql(u8, seen.long, f.long)) continue :next;
+                }
+                out = out ++ [_]ShellFlag{f};
+            }
+        }
+        return out;
+    }
+}
+
+/// The `|`-joined bash `case` pattern for every separate-value flag of one
+/// `ValueKind`. Empty when nothing has that kind — an empty pattern would be
+/// a syntax error, so callers must not emit the arm.
+fn caseArmPattern(comptime flags: []const ShellFlag, comptime kind: spec.ValueKind) []const u8 {
+    comptime {
+        var s: []const u8 = "";
+        for (flags) |f| {
+            if (f.value != .separate or f.kind != kind) continue;
+            if (s.len > 0) s = s ++ "|";
+            s = s ++ f.long;
+            if (f.short) |sh| s = s ++ "|" ++ sh;
+        }
+        return s;
+    }
+}
+
+fn choiceValueArms(comptime flags: []const ShellFlag) []const u8 {
+    comptime {
+        var s: []const u8 = "";
+        for (flags) |f| {
+            if (f.value != .separate or f.kind != .choice) continue;
+            s = s ++ "        " ++ f.long;
+            if (f.short) |sh| s = s ++ "|" ++ sh;
+            s = s ++ ")\n            COMPREPLY=($(compgen -W \"" ++ joinWords(f.choices) ++
+                "\" -- \"$cur\"))\n            return ;;\n";
+        }
+        return s;
+    }
+}
+
+fn subcommandNames(comptime subs: []const SubcommandDesc, comptime sep: []const u8) []const u8 {
+    comptime {
+        var s: []const u8 = "";
+        for (subs, 0..) |sub, i| {
+            if (i > 0) s = s ++ sep;
+            s = s ++ sub.name;
+        }
+        return s;
+    }
+}
+
+/// The top-level flags: every global flag marked `top_level`. `--no-opt` and
+/// `--check` are excluded here and offered under `ir` / `fmt` instead.
+fn kaappiTopFlags() []const ShellFlag {
+    comptime {
+        var out: []const ShellFlag = &.{};
+        for (spec.erase(spec.GlobalId, &spec.global_flags)) |f| {
+            if (f.top_level) out = out ++ [_]ShellFlag{f};
+        }
+        return out;
+    }
+}
+
+// ── bash ───────────────────────────────────────────────────────────────
+
+fn bashPositional(comptime pos: spec.Positional, comptime choices: []const []const u8) []const u8 {
+    return switch (pos) {
+        .none, .opaque_word => "",
+        .scm_file => "$(compgen -f -X '!*.scm' -- \"$cur\")",
+        .path => "$(compgen -f -- \"$cur\")",
+        .choice => "$(compgen -W \"" ++ joinWords(choices) ++ "\" -- \"$cur\")",
+    };
+}
+
+fn bashScript(
+    comptime cmd: []const u8,
+    comptime top_flags: []const ShellFlag,
+    comptime subs: []const SubcommandDesc,
+    comptime all_flags: []const ShellFlag,
+    comptime top_positional: spec.Positional,
+) []const u8 {
+    comptime {
+        @setEvalBranchQuota(2_000_000);
+        var s: []const u8 = "";
+        s = s ++ "# bash completion for " ++ cmd ++ " - generated from src/cli_spec.zig, do not edit\n";
+        s = s ++ "_" ++ cmd ++ "() {\n";
+        s = s ++ "    local cur prev sub word\n";
+        s = s ++ "    cur=\"${COMP_WORDS[COMP_CWORD]}\"\n";
+        s = s ++ "    prev=\"${COMP_WORDS[COMP_CWORD-1]}\"\n\n";
+
+        // 1. The previous word is a flag expecting a separate value.
+        s = s ++ "    case \"$prev\" in\n";
+        s = s ++ choiceValueArms(all_flags);
+        const dirs = caseArmPattern(all_flags, .dir);
+        if (dirs.len > 0) {
+            s = s ++ "        " ++ dirs ++ ")\n            COMPREPLY=($(compgen -d -- \"$cur\"))\n            return ;;\n";
+        }
+        const files = caseArmPattern(all_flags, .file);
+        if (files.len > 0) {
+            s = s ++ "        " ++ files ++ ")\n            COMPREPLY=($(compgen -f -- \"$cur\"))\n            return ;;\n";
+        }
+        // A value with nothing to complete (a millisecond count, a git rev):
+        // offering files there is worse than offering nothing.
+        const opaque_vals = caseArmPattern(all_flags, .none);
+        if (opaque_vals.len > 0) {
+            s = s ++ "        " ++ opaque_vals ++ ")\n            return ;;\n";
+        }
+        s = s ++ "    esac\n\n";
+
+        // 2. Which subcommand is in play? Scan only the words already typed,
+        //    so a half-typed "$cur" is never mistaken for one.
+        if (subs.len > 0) {
+            s = s ++ "    sub=\"\"\n";
+            s = s ++ "    for word in \"${COMP_WORDS[@]:1:COMP_CWORD-1}\"; do\n";
+            s = s ++ "        case \"$word\" in\n";
+            s = s ++ "            " ++ subcommandNames(subs, "|") ++ ") sub=\"$word\"; break ;;\n";
+            s = s ++ "        esac\n";
+            s = s ++ "    done\n\n";
+
+            s = s ++ "    case \"$sub\" in\n";
+            for (subs) |sub| {
+                s = s ++ "        " ++ sub.name ++ ")\n";
+                // A subcommand cli.parse handles inline goes through the same
+                // global loop, so every top-level flag is legal there too.
+                const extra: []const ShellFlag = if (sub.global_flags_ok)
+                    withoutOverlap(top_flags, sub.flags)
+                else
+                    &.{};
+                const words = wordsFor(sub.flags) ++ wordsFor(extra);
+                if (words.len > 0) {
+                    s = s ++ "            if [[ \"$cur\" == -* ]]; then\n";
+                    s = s ++ "                COMPREPLY=($(compgen -W \"" ++ joinWords(words) ++ "\" -- \"$cur\"))\n";
+                    s = s ++ "                return\n";
+                    s = s ++ "            fi\n";
+                }
+                const pos = bashPositional(sub.positional, sub.choices);
+                if (pos.len > 0) s = s ++ "            COMPREPLY=(" ++ pos ++ ")\n";
+                s = s ++ "            return ;;\n";
+            }
+            s = s ++ "    esac\n\n";
+        }
+
+        // 3. No subcommand yet.
+        const top_words = wordsFor(top_flags);
+        if (top_words.len > 0) {
+            s = s ++ "    if [[ \"$cur\" == -* ]]; then\n";
+            s = s ++ "        COMPREPLY=($(compgen -W \"" ++ joinWords(top_words) ++ "\" -- \"$cur\"))\n";
+            s = s ++ "        return\n";
+            s = s ++ "    fi\n\n";
+        }
+        var tail: []const u8 = "";
+        if (subs.len > 0) {
+            tail = tail ++ "$(compgen -W \"" ++ subcommandNames(subs, " ") ++ "\" -- \"$cur\")";
+        }
+        const top_pos = bashPositional(top_positional, &.{});
+        if (top_pos.len > 0) {
+            if (tail.len > 0) tail = tail ++ " ";
+            tail = tail ++ top_pos;
+        }
+        if (tail.len > 0) s = s ++ "    COMPREPLY=(" ++ tail ++ ")\n";
+        s = s ++ "}\n";
+        s = s ++ "complete -o filenames -F _" ++ cmd ++ " " ++ cmd ++ "\n";
+        return s;
+    }
+}
+
+// ── zsh ────────────────────────────────────────────────────────────────
+
+/// One `_arguments` spec. zsh distinguishes an attached-only value (`--opt=-`)
+/// from one that may be separated (`--opt`), and `::` from `:` makes the value
+/// optional — exactly the `--diagnostics=fmt` vs `--timings[=fmt]` distinction
+/// the hand-written script could not express (it declared both as separable,
+/// so it completed `--diagnostics json`, which the parser rejects).
+fn zshSpec(comptime f: ShellFlag, comptime long: bool) []const u8 {
+    comptime {
+        const name = if (long) f.long else (f.short orelse return "");
+        if (f.value == .none) return "'" ++ name ++ "[" ++ f.desc ++ "]'";
+        const action = switch (f.kind) {
+            .none => ":" ++ f.value_name ++ ":",
+            .file => ":" ++ f.value_name ++ ":_files",
+            .dir => ":" ++ f.value_name ++ ":_files -/",
+            .choice => ":" ++ f.value_name ++ ":(" ++ joinWords(f.choices) ++ ")",
+        };
+        return switch (f.value) {
+            .none => "",
+            .separate => "'" ++ name ++ "[" ++ f.desc ++ "]" ++ action ++ "'",
+            .inline_eq => "'" ++ name ++ "=-[" ++ f.desc ++ "]" ++ action ++ "'",
+            .inline_eq_optional => "'" ++ name ++ "=-[" ++ f.desc ++ "]:" ++ action ++ "'",
+        };
+    }
+}
+
+fn zshSpecLines(comptime flags: []const ShellFlag) []const []const u8 {
+    comptime {
+        var out: []const []const u8 = &.{};
+        for (flags) |f| {
+            out = out ++ [_][]const u8{zshSpec(f, true)};
+            if (f.short != null) out = out ++ [_][]const u8{zshSpec(f, false)};
+        }
+        return out;
+    }
+}
+
+fn zshPositionalLines(comptime pos: spec.Positional, comptime choices: []const []const u8) []const []const u8 {
+    return switch (pos) {
+        .none => &.{},
+        .scm_file => &.{"'*:file:_files -g \"*.scm\"'"},
+        .path => &.{"'*:path:_files'"},
+        .opaque_word => &.{"'*:argument:'"},
+        .choice => &.{"'1:action:(" ++ joinWords(choices) ++ ")'"},
+    };
+}
+
+/// Emit `_arguments -s` with one spec per line, backslash-continued.
+fn zshArguments(comptime indent: []const u8, comptime lines: []const []const u8) []const u8 {
+    comptime {
+        var s: []const u8 = indent ++ "_arguments -s";
+        for (lines) |line| s = s ++ " \\\n" ++ indent ++ "    " ++ line;
+        return s ++ "\n";
+    }
+}
+
+fn zshScript(
+    comptime cmd: []const u8,
+    comptime top_flags: []const ShellFlag,
+    comptime subs: []const SubcommandDesc,
+    comptime top_positional: spec.Positional,
+) []const u8 {
+    comptime {
+        @setEvalBranchQuota(2_000_000);
+        var s: []const u8 = "#compdef " ++ cmd ++ "\n";
+        s = s ++ "# generated from src/cli_spec.zig, do not edit\n\n";
+        s = s ++ "_" ++ cmd ++ "() {\n";
+        if (subs.len > 0) {
+            s = s ++ "    local sub=\"\" word\n";
+            s = s ++ "    for word in \"${words[@]:1:$((CURRENT-2))}\"; do\n";
+            s = s ++ "        case \"$word\" in\n";
+            s = s ++ "            " ++ subcommandNames(subs, "|") ++ ") sub=\"$word\"; break ;;\n";
+            s = s ++ "        esac\n";
+            s = s ++ "    done\n\n";
+            s = s ++ "    case \"$sub\" in\n";
+            for (subs) |sub| {
+                const extra: []const ShellFlag = if (sub.global_flags_ok)
+                    withoutOverlap(top_flags, sub.flags)
+                else
+                    &.{};
+                const lines = zshSpecLines(sub.flags) ++ zshSpecLines(extra) ++
+                    zshPositionalLines(sub.positional, sub.choices);
+                s = s ++ "        " ++ sub.name ++ ")\n";
+                s = s ++ zshArguments("            ", lines);
+                s = s ++ "            return ;;\n";
+            }
+            s = s ++ "    esac\n\n";
+        }
+        var top: []const []const u8 = zshSpecLines(top_flags);
+        if (subs.len > 0) {
+            top = top ++ [_][]const u8{"'1:command or file:_alternative \"commands:command:(" ++
+                subcommandNames(subs, " ") ++ ")\" \"files:file:_files\"'"};
+        }
+        top = top ++ zshPositionalLines(top_positional, &.{});
+        s = s ++ zshArguments("    ", top);
+        s = s ++ "}\n\n";
+        s = s ++ "_" ++ cmd ++ " \"$@\"\n";
+        return s;
+    }
+}
+
+// ── fish ───────────────────────────────────────────────────────────────
+
+fn fishFlagLine(comptime cmd: []const u8, comptime cond: []const u8, comptime f: ShellFlag) []const u8 {
+    comptime {
+        var s: []const u8 = "complete -c " ++ cmd;
+        if (cond.len > 0) s = s ++ " -n '" ++ cond ++ "'";
+        // A short-only flag (`-o`) lives in the `long` field, since that is
+        // the whole of its spelling. fish wants `-s o`, not an empty `-l`.
+        if (f.long.len > 2 and f.long[1] == '-') {
+            s = s ++ " -l " ++ f.long[2..];
+        } else {
+            s = s ++ " -s " ++ f.long[1..];
+        }
+        if (f.short) |sh| s = s ++ " -s " ++ sh[1..];
+        switch (f.value) {
+            .none => {},
+            // fish has no optional-value form. The bare spelling is the one
+            // users type, and `--timings=json` still parses if they attach a
+            // value, so requiring one here would be the worse trade.
+            .inline_eq_optional => {},
+            .separate, .inline_eq => {
+                s = s ++ " -r" ++ switch (f.kind) {
+                    .file, .dir => " -F",
+                    .choice => " -x -a '" ++ joinWords(f.choices) ++ "'",
+                    .none => " -x",
+                };
+            },
+        }
+        return s ++ " -d '" ++ f.desc ++ "'\n";
+    }
+}
+
+fn fishScript(
+    comptime cmd: []const u8,
+    comptime top_flags: []const ShellFlag,
+    comptime subs: []const SubcommandDesc,
+    comptime no_files: bool,
+) []const u8 {
+    comptime {
+        @setEvalBranchQuota(2_000_000);
+        var s: []const u8 = "# fish completions for " ++ cmd ++ " - generated from src/cli_spec.zig, do not edit\n";
+        if (no_files) s = s ++ "complete -c " ++ cmd ++ " -f\n";
+
+        // The subcommands that intercept argv in their own module reject every
+        // global flag with exit 2, so suppress the global specs once one is
+        // seen. The inline ones share cli.parse's loop and keep them.
+        var scoped: []const u8 = "";
+        for (subs) |sub| {
+            if (sub.global_flags_ok) continue;
+            if (scoped.len > 0) scoped = scoped ++ " ";
+            scoped = scoped ++ sub.name;
+        }
+        const global_cond: []const u8 = if (scoped.len > 0)
+            "not __fish_seen_subcommand_from " ++ scoped
+        else
+            "";
+        for (top_flags) |f| s = s ++ fishFlagLine(cmd, global_cond, f);
+
+        for (subs) |sub| {
+            s = s ++ "complete -c " ++ cmd ++ " -n '__fish_use_subcommand' -a " ++ sub.name ++
+                " -d '" ++ sub.desc ++ "'\n";
+        }
+        for (subs) |sub| {
+            const cond = "__fish_seen_subcommand_from " ++ sub.name;
+            for (sub.flags) |f| {
+                // An inline subcommand shares the global specs emitted above;
+                // only its own additions need a scoped line.
+                if (sub.global_flags_ok and hasFlag(top_flags, f)) continue;
+                s = s ++ fishFlagLine(cmd, cond, f);
+            }
+            if (sub.positional == .choice) {
+                s = s ++ "complete -c " ++ cmd ++ " -n '" ++ cond ++ "' -a '" ++
+                    joinWords(sub.choices) ++ "' -d 'Action'\n";
+            }
+        }
+        return s;
+    }
+}
+
+// ── The six scripts ────────────────────────────────────────────────────
+
+const kaappi_top = kaappiTopFlags();
+const thottam_top = spec.erase(spec.ThottamId, &spec.thottam_flags);
+
+const kaappi_bash = bashScript("kaappi", kaappi_top, &spec.subcommands, allKaappiFlags(), .scm_file);
+const kaappi_zsh = zshScript("kaappi", kaappi_top, &spec.subcommands, .path);
+const kaappi_fish = fishScript("kaappi", kaappi_top, &spec.subcommands, false);
+
+const thottam_bash = bashScript("thottam", thottam_top, &spec.thottam_subcommands, thottam_top, .none);
+const thottam_zsh = zshScript("thottam", thottam_top, &spec.thottam_subcommands, .opaque_word);
+const thottam_fish = fishScript("thottam", thottam_top, &spec.thottam_subcommands, true);
 
 pub fn kaappi(shell: []const u8) ?[]const u8 {
     if (std.mem.eql(u8, shell, "bash")) return kaappi_bash;
@@ -259,4 +469,221 @@ pub fn thottam(shell: []const u8) ?[]const u8 {
     if (std.mem.eql(u8, shell, "zsh")) return thottam_zsh;
     if (std.mem.eql(u8, shell, "fish")) return thottam_fish;
     return null;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+//
+// The drift gate has two halves. `cli_spec.zig`'s comptime block guarantees
+// the *tables* match the *parsers* (an exhaustive switch per table, plus a
+// once-and-only-once check per enum variant). These guarantee the *scripts*
+// match the tables, in both directions, for every shell.
+
+const testing = std.testing;
+
+const all_scripts = [_][]const u8{ kaappi_bash, kaappi_zsh, kaappi_fish, thottam_bash, thottam_zsh, thottam_fish };
+/// For the completeness assertions: the bash entry is trimmed of its trailing
+/// `complete …` registration line (see `bashOfferBody`).
+const kaappi_scripts = [_][]const u8{ bashOfferBody(kaappi_bash), kaappi_zsh, kaappi_fish };
+const thottam_scripts = [_][]const u8{ bashOfferBody(thottam_bash), thottam_zsh, thottam_fish };
+
+fn isFlagChar(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
+        (c >= '0' and c <= '9') or c == '-' or c == '_';
+}
+
+fn findWord(script: []const u8, word: []const u8) bool {
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, script, i, word)) |at| {
+        i = at + 1;
+        const before_ok = at == 0 or !isFlagChar(script[at - 1]);
+        const end = at + word.len;
+        const after_ok = end >= script.len or !isFlagChar(script[end]);
+        if (before_ok and after_ok) return true;
+    }
+    return false;
+}
+
+/// The part of a bash script that offers words, i.e. everything above the
+/// trailing `complete -o filenames -F _x x` registration. Without this the
+/// short flag `-o` matches that line's own `-o` and the assertion is vacuous.
+fn bashOfferBody(script: []const u8) []const u8 {
+    const at = std.mem.lastIndexOf(u8, script, "\ncomplete ") orelse return script;
+    return script[0 .. at + 1];
+}
+
+/// True when `flag` is offered by `script`, in whichever spelling that shell
+/// uses: bash and zsh write `--lib-path` / `-o` literally, fish writes
+/// `-l lib-path` / `-s o`.
+fn offersFlag(script: []const u8, flag: []const u8) bool {
+    if (findWord(script, flag)) return true;
+    var buf: [64]u8 = undefined;
+    if (flag.len > 2 and flag[1] == '-') {
+        const alt = std.fmt.bufPrint(&buf, "-l {s}", .{flag[2..]}) catch return false;
+        return findWord(script, alt);
+    }
+    if (flag.len == 2) {
+        const alt = std.fmt.bufPrint(&buf, "-s {s}", .{flag[1..]}) catch return false;
+        return findWord(script, alt);
+    }
+    return false;
+}
+
+test "every shell is supported for both binaries" {
+    for (spec.shells) |sh| {
+        try testing.expect(kaappi(sh) != null);
+        try testing.expect(thottam(sh) != null);
+    }
+    try testing.expect(kaappi("csh") == null);
+    try testing.expect(thottam("csh") == null);
+}
+
+test "every script is non-empty, ASCII, and newline-terminated" {
+    for (all_scripts) |script| {
+        try testing.expect(script.len > 100);
+        try testing.expectEqual(@as(u8, '\n'), script[script.len - 1]);
+        // A NUL or a stray non-ASCII byte makes a script unsourceable, and an
+        // em dash in a generated comment is the easy way to get one.
+        for (script) |c| try testing.expect(c == '\n' or (c >= 0x20 and c <= 0x7e));
+    }
+}
+
+test "completeness: every kaappi global flag appears in every kaappi script" {
+    // The bug this unit exists for: --no-ir-opt was in the parser and in none
+    // of the three scripts.
+    for (kaappi_scripts) |script| {
+        inline for (spec.global_flags) |f| {
+            try testing.expect(offersFlag(script, f.long));
+            if (f.short) |s| try testing.expect(offersFlag(script, s));
+        }
+    }
+}
+
+test "completeness: every subcommand and its own flags appear in every kaappi script" {
+    for (kaappi_scripts) |script| {
+        inline for (spec.subcommands) |sub| {
+            try testing.expect(findWord(script, sub.name));
+            inline for (sub.flags) |f| {
+                try testing.expect(offersFlag(script, f.long));
+                if (f.short) |s| try testing.expect(offersFlag(script, s));
+            }
+            inline for (sub.choices) |c| try testing.expect(findWord(script, c));
+        }
+    }
+}
+
+test "completeness: kaappi test's selection flags are offered" {
+    // These postdate the hand-written scripts: none of the three offered
+    // -j/--jobs, --changed, --list-affected or --since, and only bash had
+    // --seed.
+    for (kaappi_scripts) |script| {
+        for ([_][]const u8{ "--jobs", "-j", "--changed", "--list-affected", "--since", "--seed" }) |f| {
+            try testing.expect(offersFlag(script, f));
+        }
+    }
+}
+
+test "completeness: every thottam flag and subcommand appears in every thottam script" {
+    for (thottam_scripts) |script| {
+        inline for (spec.thottam_flags) |f| {
+            try testing.expect(offersFlag(script, f.long));
+            if (f.short) |s| try testing.expect(offersFlag(script, s));
+        }
+        inline for (spec.thottam_subcommands) |sub| {
+            try testing.expect(findWord(script, sub.name));
+        }
+    }
+}
+
+test "soundness: no script offers a --flag no table declares" {
+    // The reverse direction, and the worse one for a user: completing a flag
+    // that errors. Scan every `--word` token in every script and require it to
+    // name a real flag.
+    for (all_scripts) |script| {
+        var i: usize = 0;
+        while (i + 2 < script.len) : (i += 1) {
+            if (script[i] != '-' or script[i + 1] != '-') continue;
+            if (i > 0 and isFlagChar(script[i - 1])) continue;
+            var j = i + 2;
+            while (j < script.len and isFlagChar(script[j])) j += 1;
+            const token = script[i..j];
+            if (token.len == 2) continue; // a bare `--` separator
+            if (!isDeclaredFlag(token)) {
+                std.debug.print("undeclared flag in a generated script: {s}\n", .{token});
+                return error.UndeclaredFlag;
+            }
+        }
+    }
+}
+
+fn isDeclaredFlag(token: []const u8) bool {
+    inline for (spec.global_flags) |f| {
+        if (std.mem.eql(u8, token, f.long)) return true;
+    }
+    inline for (spec.thottam_flags) |f| {
+        if (std.mem.eql(u8, token, f.long)) return true;
+    }
+    inline for (spec.subcommands) |sub| {
+        inline for (sub.flags) |f| {
+            if (std.mem.eql(u8, token, f.long)) return true;
+        }
+    }
+    return false;
+}
+
+test "soundness: the five out-of-line subcommands never see the global flags" {
+    // zsh and fish used to offer all 21 global flags inside explain, features,
+    // test, doctor and cache, whose own parsers reject 15 of them with exit 2.
+    // Each shell scopes differently, so assert each shell's own mechanism.
+    try testing.expect(std.mem.indexOf(u8, kaappi_fish, "not __fish_seen_subcommand_from explain features test doctor cache") != null);
+    inline for (spec.subcommands) |sub| {
+        if (sub.global_flags_ok) continue;
+        // bash and zsh dispatch on the detected subcommand word.
+        try testing.expect(std.mem.indexOf(u8, kaappi_bash, "        " ++ sub.name ++ ")\n") != null);
+        try testing.expect(std.mem.indexOf(u8, kaappi_zsh, "        " ++ sub.name ++ ")\n") != null);
+    }
+    // And the offered set inside one is exactly its own table: `features`
+    // accepts --json and --help and nothing else.
+    const arm_start = std.mem.indexOf(u8, kaappi_bash, "        features)\n").?;
+    const arm = kaappi_bash[arm_start .. arm_start + std.mem.indexOf(u8, kaappi_bash[arm_start..], "return ;;").?];
+    try testing.expect(std.mem.indexOf(u8, arm, "--json") != null);
+    try testing.expect(std.mem.indexOf(u8, arm, "--sandbox") == null);
+    try testing.expect(std.mem.indexOf(u8, arm, "--lib-path") == null);
+}
+
+test "bash: value-taking flags get their own case arm" {
+    try testing.expect(std.mem.indexOf(u8, kaappi_bash, "compgen -d") != null);
+    try testing.expect(std.mem.indexOf(u8, kaappi_bash, "compgen -f") != null);
+    // --completions completes the shell names it actually supports.
+    try testing.expect(std.mem.indexOf(u8, kaappi_bash, "bash zsh fish") != null);
+}
+
+test "zsh: attached-only values use the =- spelling" {
+    // `--diagnostics json` is not accepted by the parser, so the spec must not
+    // offer a separated value; `--timings` additionally makes it optional.
+    try testing.expect(std.mem.indexOf(u8, kaappi_zsh, "'--diagnostics=-[") != null);
+    try testing.expect(std.mem.indexOf(u8, kaappi_zsh, "'--timings=-[") != null);
+    try testing.expect(std.mem.indexOf(u8, kaappi_zsh, "'--diagnostics[") == null);
+}
+
+test "fish: the bare --timings spelling stays completable" {
+    // fish cannot express an optional value; requiring one would stop the bare
+    // spelling — the common one — from ever completing.
+    try testing.expect(std.mem.indexOf(u8, kaappi_fish, " -l timings -d ") != null);
+}
+
+test "every line has balanced quotes" {
+    // A stray quote silently swallows the rest of the file when sourced.
+    for (all_scripts) |script| {
+        var it = std.mem.splitScalar(u8, script, '\n');
+        while (it.next()) |line| {
+            var singles: usize = 0;
+            var doubles: usize = 0;
+            for (line) |c| {
+                if (c == '\'') singles += 1;
+                if (c == '"') doubles += 1;
+            }
+            try testing.expectEqual(@as(usize, 0), singles % 2);
+            try testing.expectEqual(@as(usize, 0), doubles % 2);
+        }
+    }
 }

--- a/src/doctor.zig
+++ b/src/doctor.zig
@@ -29,6 +29,7 @@ const kaappi_paths = @import("kaappi_paths.zig");
 const file_utils = @import("file_utils.zig");
 const native_compiler = @import("native_compiler.zig");
 const llvm_emit = @import("llvm_emit.zig");
+const spec = @import("cli_spec.zig");
 
 pub const version = @import("build_options").version;
 
@@ -166,17 +167,23 @@ pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
 
     var req: Request = .{};
     while (it.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--json")) {
-            req.json = true;
-        } else if (std.mem.eql(u8, arg, "--lib-path")) {
-            const value = it.next() orelse {
-                writeStderr("kaappi doctor: --lib-path requires a path argument\n");
-                return USAGE_ERROR_EXIT;
-            };
-            lib_paths.append(allocator, value) catch return 1;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            printUsage();
-            return 0;
+        // Flags come from cli_spec.doctor_flags — the same table the shell
+        // completions are generated from (#1890 6C).
+        if (spec.match(spec.DoctorId, &spec.doctor_flags, arg)) |m| {
+            switch (m.flag.id) {
+                .json => req.json = true,
+                .lib_path => {
+                    const value = it.next() orelse {
+                        writeStderr("kaappi doctor: --lib-path requires a path argument\n");
+                        return USAGE_ERROR_EXIT;
+                    };
+                    lib_paths.append(allocator, value) catch return 1;
+                },
+                .help => {
+                    printUsage();
+                    return 0;
+                },
+            }
         } else if (arg.len > 1 and arg[0] == '-') {
             writeStderr("kaappi doctor: unknown option '");
             writeStderr(arg);

--- a/src/explain.zig
+++ b/src/explain.zig
@@ -20,6 +20,7 @@ const platform = @import("platform.zig");
 const diagnostics = @import("diagnostics.zig");
 const lsp_diagnostic = @import("lsp_diagnostic.zig");
 const reporting = @import("reporting.zig");
+const spec = @import("cli_spec.zig");
 
 const writeStdout = reporting.writeStdout;
 const writeStderr = reporting.writeStderr;
@@ -47,13 +48,18 @@ pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
 
     var req: Request = .{};
     while (it.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--json")) {
-            req.json = true;
-        } else if (std.mem.eql(u8, arg, "--all")) {
-            req.all = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            printUsage();
-            return 0;
+        // Flag spellings come from cli_spec.explain_flags, which is also what
+        // the shell completions offer — the switch is exhaustive over its Id,
+        // so a new flag cannot be added to one without the other (#1890 6C).
+        if (spec.match(spec.ExplainId, &spec.explain_flags, arg)) |m| {
+            switch (m.flag.id) {
+                .json => req.json = true,
+                .all => req.all = true,
+                .help => {
+                    printUsage();
+                    return 0;
+                },
+            }
         } else if (arg.len > 1 and arg[0] == '-') {
             writeStderr("kaappi explain: unknown option '");
             writeStderr(arg);

--- a/src/features.zig
+++ b/src/features.zig
@@ -28,6 +28,7 @@
 const std = @import("std");
 const platform = @import("platform.zig");
 const builtin = @import("builtin");
+const spec = @import("cli_spec.zig");
 const build_options = @import("build_options");
 const types = @import("types.zig");
 const primitives = @import("primitives.zig");
@@ -66,11 +67,16 @@ pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
 
     var json = false;
     while (it.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--json")) {
-            json = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            printUsage();
-            return 0;
+        // Flags come from cli_spec.features_flags — the same table the shell
+        // completions are generated from (#1890 6C).
+        if (spec.match(spec.FeaturesId, &spec.features_flags, arg)) |m| {
+            switch (m.flag.id) {
+                .json => json = true,
+                .help => {
+                    printUsage();
+                    return 0;
+                },
+            }
         } else {
             writeStderr("kaappi features: unexpected argument '");
             writeStderr(arg);

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -35,6 +35,7 @@ const vm_mod = @import("vm.zig");
 const file_utils = @import("file_utils.zig");
 const kaappi_paths = @import("kaappi_paths.zig");
 const test_selection = @import("test_selection.zig");
+const spec = @import("cli_spec.zig");
 
 const VM = vm_mod.VM;
 const Value = types.Value;
@@ -381,48 +382,58 @@ pub fn maybeRun(allocator: std.mem.Allocator, args: std.process.Args) ?u8 {
     defer opts.deinit(allocator);
 
     while (it.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--json")) {
-            opts.json = true;
-        } else if (std.mem.eql(u8, arg, "--seed")) {
-            const val = it.next() orelse {
-                writeStderr("kaappi test: --seed requires an integer argument\n");
-                return USAGE_ERROR_EXIT;
-            };
-            opts.seed = std.fmt.parseInt(u64, val, 10) catch {
-                writeStderr("kaappi test: --seed requires a non-negative integer\n");
-                return USAGE_ERROR_EXIT;
-            };
-        } else if (std.mem.eql(u8, arg, "--lib-path")) {
-            const val = it.next() orelse {
-                writeStderr("kaappi test: --lib-path requires a path argument\n");
-                return USAGE_ERROR_EXIT;
-            };
-            opts.lib_paths.append(allocator, val) catch return oom();
-        } else if (std.mem.eql(u8, arg, "--jobs") or std.mem.eql(u8, arg, "-j")) {
-            const val = it.next() orelse {
-                writeStderr("kaappi test: --jobs requires a positive integer argument\n");
-                return USAGE_ERROR_EXIT;
-            };
-            const n = std.fmt.parseInt(usize, val, 10) catch 0;
-            if (n == 0) {
-                writeStderr("kaappi test: --jobs requires a positive integer\n");
-                return USAGE_ERROR_EXIT;
+        // Flags come from cli_spec.test_flags — the same table the shell
+        // completions are generated from. The five selection flags below
+        // (-j/--jobs, --changed, --list-affected, --since, --seed) postdate
+        // the hand-written completion scripts, and none of them offered any
+        // (#1890 6C).
+        if (spec.match(spec.TestId, &spec.test_flags, arg)) |m| {
+            switch (m.flag.id) {
+                .json => opts.json = true,
+                .seed => {
+                    const val = it.next() orelse {
+                        writeStderr("kaappi test: --seed requires an integer argument\n");
+                        return USAGE_ERROR_EXIT;
+                    };
+                    opts.seed = std.fmt.parseInt(u64, val, 10) catch {
+                        writeStderr("kaappi test: --seed requires a non-negative integer\n");
+                        return USAGE_ERROR_EXIT;
+                    };
+                },
+                .lib_path => {
+                    const val = it.next() orelse {
+                        writeStderr("kaappi test: --lib-path requires a path argument\n");
+                        return USAGE_ERROR_EXIT;
+                    };
+                    opts.lib_paths.append(allocator, val) catch return oom();
+                },
+                .jobs => {
+                    const val = it.next() orelse {
+                        writeStderr("kaappi test: --jobs requires a positive integer argument\n");
+                        return USAGE_ERROR_EXIT;
+                    };
+                    const n = std.fmt.parseInt(usize, val, 10) catch 0;
+                    if (n == 0) {
+                        writeStderr("kaappi test: --jobs requires a positive integer\n");
+                        return USAGE_ERROR_EXIT;
+                    }
+                    opts.jobs = n;
+                },
+                .changed => opts.changed = true,
+                .list_affected => opts.list_affected = true,
+                .since => {
+                    const val = it.next() orelse {
+                        writeStderr("kaappi test: --since requires a revision argument\n");
+                        return USAGE_ERROR_EXIT;
+                    };
+                    opts.since = val;
+                    opts.since_given = true;
+                },
+                .help => {
+                    printUsage();
+                    return 0;
+                },
             }
-            opts.jobs = n;
-        } else if (std.mem.eql(u8, arg, "--changed")) {
-            opts.changed = true;
-        } else if (std.mem.eql(u8, arg, "--list-affected")) {
-            opts.list_affected = true;
-        } else if (std.mem.eql(u8, arg, "--since")) {
-            const val = it.next() orelse {
-                writeStderr("kaappi test: --since requires a revision argument\n");
-                return USAGE_ERROR_EXIT;
-            };
-            opts.since = val;
-            opts.since_given = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            printUsage();
-            return 0;
         } else if (arg.len > 1 and arg[0] == '-') {
             writeStderr("kaappi test: unknown option '");
             writeStderr(arg);

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const platform = @import("platform.zig");
 const builtin = @import("builtin");
+const cli_spec = @import("cli_spec.zig");
 
 const dylib_ext = if (builtin.os.tag == .macos)
     ".dylib"
@@ -825,27 +826,35 @@ pub fn main(init: std.process.Init.Minimal) !void {
     var sub_arg: ?[]const u8 = null;
 
     while (args.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--locked")) {
-            locked_mode = true;
-        } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
-            printUsage();
-            return;
-        } else if (std.mem.eql(u8, arg, "--version")) {
-            writeStdout("thottam v" ++ version ++ "\n");
-            return;
-        } else if (std.mem.eql(u8, arg, "--completions")) {
-            if (args.next()) |shell| {
-                if (@import("completions.zig").thottam(shell)) |script| {
-                    writeStdout(script);
-                } else {
-                    writeStderr("unknown shell: ");
-                    writeStderr(shell);
-                    writeStderr("\nSupported: bash, zsh, fish\n");
-                }
-            } else {
-                writeStderr("--completions requires a shell name (bash, zsh, fish)\n");
+        // Flags come from cli_spec.thottam_flags — the same table the shell
+        // completions are generated from, and the switch below is exhaustive
+        // over its Id, so neither can lag the other (#1890 6C).
+        if (cli_spec.match(cli_spec.ThottamId, &cli_spec.thottam_flags, arg)) |m| {
+            switch (m.flag.id) {
+                .locked => locked_mode = true,
+                .help => {
+                    printUsage();
+                    return;
+                },
+                .version_flag => {
+                    writeStdout("thottam v" ++ version ++ "\n");
+                    return;
+                },
+                .completions_flag => {
+                    if (args.next()) |shell| {
+                        if (@import("completions.zig").thottam(shell)) |script| {
+                            writeStdout(script);
+                        } else {
+                            writeStderr("unknown shell: ");
+                            writeStderr(shell);
+                            writeStderr("\nSupported: bash, zsh, fish\n");
+                        }
+                    } else {
+                        writeStderr("--completions requires a shell name (bash, zsh, fish)\n");
+                    }
+                    return;
+                },
             }
-            return;
         } else if (subcommand == null) {
             subcommand = arg;
         } else if (sub_arg == null) {

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -21,6 +21,7 @@
 | `fmt/` | `kaappi fmt` formatter | yes |
 | `cache/` | `.sbc` bytecode cache transparency | yes |
 | `timings/` | `--timings` stage reporting | yes |
+| `completions/` | `--completions` scripts vs. the flag table (`docs/dev/cli-surface.md`) | yes |
 | `lsp/` | `kaappi-lsp` end-to-end JSON-RPC session over stdio | yes |
 | `differential/` | Execution-tier differential harness (`--no-ir-opt`, cold-vs-warm cache) + its `probes/` | yes |
 | `coverage/` | Coverage gap-fillers (`zig build coverage-scheme`) | no |

--- a/tests/scheme/completions/completions.sh
+++ b/tests/scheme/completions/completions.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+# `kaappi --completions <shell>` / `thottam --completions <shell>` — the
+# completions-vs-flag-table drift gate (kaappi audit v2, Phase 6C, #1890).
+#
+# The scripts are generated at comptime from `src/cli_spec.zig`, the same
+# tables the argument parsers dispatch on, so this suite checks the property
+# that matters end to end against the *real binary*:
+#
+#   * soundness — every flag a script offers in a given context is one the
+#     binary accepts in that context. Before 6C the zsh and fish scripts
+#     offered all 21 global flags inside `explain`/`features`/`test`/`doctor`/
+#     `cache`, whose own parsers reject 15 of them with exit 2.
+#   * completeness — every flag `kaappi --help` documents is offered.
+#     `--no-ir-opt` was in the parser and in none of the three scripts.
+#   * the scripts parse as the shell they claim to be, and the bash one
+#     actually completes when driven.
+#
+# The bash function is *executed* (this suite already runs under bash, and the
+# Windows legs run it under Git Bash). zsh and fish are syntax-checked only
+# when present — neither is installed on every CI leg.
+
+set -uo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+
+KAAPPI="${1:-${KAAPPI:-zig-out/bin/kaappi}}"
+# Absolute, because the soundness probes below run from inside $TMP: several
+# offered flags (-o, --compile, --emit-llvm, --coverage-xml) make the binary
+# *write* a file named after its argument, and a probe that does that in the
+# repo checkout leaves droppings in the working tree.
+KAAPPI="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+THOTTAM="$(dirname "$KAAPPI")/thottam"
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Never touch the developer's real cache while probing.
+export KAAPPI_HOME="$TMP/home"
+mkdir -p "$KAAPPI_HOME"
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1 — $2"; FAIL=$((FAIL + 1)); }
+
+# ── 1. Every shell emits a script, and unknown shells are a usage error ─────
+
+for shell in bash zsh fish; do
+    for bin in "$KAAPPI" "$THOTTAM"; do
+        name="$(basename "$bin") --completions $shell"
+        out="$TMP/$(basename "$bin").$shell"
+        status=0
+        "$bin" --completions "$shell" > "$out" 2> "$TMP/err" || status=$?
+        if [[ "$status" -ne 0 ]]; then
+            fail "$name exits 0" "exit $status"
+        elif [[ ! -s "$out" ]]; then
+            fail "$name emits a script" "empty output"
+        else
+            pass "$name emits a script"
+        fi
+    done
+done
+
+# ── 2. The scripts parse as the shell they claim to be ──────────────────────
+
+for bin in kaappi thottam; do
+    if bash -n "$TMP/$bin.bash" 2> "$TMP/err"; then
+        pass "$bin bash script parses (bash -n)"
+    else
+        fail "$bin bash script parses (bash -n)" "$(cat "$TMP/err")"
+    fi
+done
+
+if command -v zsh > /dev/null 2>&1; then
+    for bin in kaappi thottam; do
+        if zsh -n "$TMP/$bin.zsh" 2> "$TMP/err"; then
+            pass "$bin zsh script parses (zsh -n)"
+        else
+            fail "$bin zsh script parses (zsh -n)" "$(cat "$TMP/err")"
+        fi
+    done
+else
+    echo "SKIP: zsh not installed, skipping zsh -n"
+fi
+
+if command -v fish > /dev/null 2>&1; then
+    for bin in kaappi thottam; do
+        if fish --no-execute "$TMP/$bin.fish" 2> "$TMP/err"; then
+            pass "$bin fish script parses (fish --no-execute)"
+        else
+            fail "$bin fish script parses (fish --no-execute)" "$(cat "$TMP/err")"
+        fi
+    done
+else
+    echo "SKIP: fish not installed, skipping fish --no-execute"
+fi
+
+# ── 3. Drive the bash completion function ───────────────────────────────────
+#
+# Sourced in a subshell per query so a stray `return` or variable cannot leak
+# into this script's own state.
+
+# offers [subcommand] -> the flag words offered in that context, one per line.
+offers() {
+    (
+        # shellcheck disable=SC1090
+        . "$TMP/kaappi.bash"
+        local -a w=(kaappi)
+        local a
+        for a in "$@"; do w+=("$a"); done
+        w+=("-")
+        COMP_WORDS=("${w[@]}")
+        COMP_CWORD=$((${#w[@]} - 1))
+        COMPREPLY=()
+        _kaappi
+        [[ ${#COMPREPLY[@]} -gt 0 ]] && printf '%s\n' "${COMPREPLY[@]}"
+    )
+}
+
+# plain_words [subcommand] -> what is offered when the current word is empty.
+plain_words() {
+    (
+        # shellcheck disable=SC1090
+        . "$TMP/kaappi.bash"
+        local -a w=(kaappi)
+        local a
+        for a in "$@"; do w+=("$a"); done
+        w+=("")
+        COMP_WORDS=("${w[@]}")
+        COMP_CWORD=$((${#w[@]} - 1))
+        COMPREPLY=()
+        _kaappi
+        [[ ${#COMPREPLY[@]} -gt 0 ]] && printf '%s\n' "${COMPREPLY[@]}"
+    )
+}
+
+top_flags="$(offers)"
+if [[ -n "$top_flags" ]]; then
+    pass "bash completes top-level flags"
+else
+    fail "bash completes top-level flags" "COMPREPLY was empty"
+fi
+
+# Every subcommand is offered as a bare word at the top level.
+missing_subs=""
+for sub in compile check explain features test ast expand ir doctor fmt cache; do
+    if ! grep -qxF -- "$sub" <<< "$(plain_words)"; then
+        missing_subs="$missing_subs $sub"
+    fi
+done
+if [[ -z "$missing_subs" ]]; then
+    pass "bash offers all 11 subcommands"
+else
+    fail "bash offers all 11 subcommands" "missing:$missing_subs"
+fi
+
+# `kaappi cache <TAB>` offers exactly the two actions the parser accepts.
+cache_words="$(plain_words cache)"
+if grep -qxF -- "status" <<< "$cache_words" && grep -qxF -- "clear" <<< "$cache_words"; then
+    pass "bash offers the cache actions"
+else
+    fail "bash offers the cache actions" "got: $(tr '\n' ' ' <<< "$cache_words")"
+fi
+
+# `kaappi --completions <TAB>` offers the shells the binary supports.
+shell_words="$(plain_words --completions)"
+for s in bash zsh fish; do
+    if ! grep -qxF -- "$s" <<< "$shell_words"; then
+        fail "bash completes --completions values" "missing $s"
+        break
+    fi
+done
+grep -qxF -- "fish" <<< "$shell_words" && pass "bash completes --completions values"
+
+# ── 4. Completeness: --help and the completions agree ───────────────────────
+#
+# Both are generated from the same table but by different code, so this is a
+# real cross-check. Take every `--flag` / `-x` the Options: block names.
+
+"$KAAPPI" --help > "$TMP/help.txt" 2>&1
+# ERE, not BRE with `\|`: GNU's alternation escape is not POSIX and matches
+# nothing under OpenBSD's grep (kaappi#1862).
+help_flags="$(sed -n '/^Options:/,/^$/p' "$TMP/help.txt" |
+    grep -oE '^  -[A-Za-z-]+|, --[A-Za-z-]+' |
+    tr -d ' ,' | sort -u)"
+
+if [[ -z "$help_flags" ]]; then
+    fail "extracted flags from --help" "Options: block matched nothing"
+else
+    pass "extracted flags from --help"
+fi
+
+missing=""
+for f in $help_flags; do
+    # A `=`-syntax flag is completed as its full `--flag=value` spellings, and
+    # deliberately not as the bare word: `--diagnostics` with no attached value
+    # is "unknown option" to the parser, so offering it would be unsound.
+    if grep -qxF -- "$f" <<< "$top_flags"; then continue; fi
+    if grep -qF -- "$f=" <<< "$top_flags"; then continue; fi
+    missing="$missing $f"
+done
+if [[ -z "$missing" ]]; then
+    pass "every --help option is completed at the top level"
+else
+    fail "every --help option is completed at the top level" "missing:$missing"
+fi
+
+# The flag whose absence motivated this unit, asserted by name in all three.
+for shell in bash zsh fish; do
+    if grep -qF -- "no-ir-opt" "$TMP/kaappi.$shell"; then
+        pass "$shell script offers --no-ir-opt (#1890 6C)"
+    else
+        fail "$shell script offers --no-ir-opt (#1890 6C)" "absent"
+    fi
+done
+
+# `kaappi test`'s selection flags postdate the hand-written scripts.
+for shell in bash zsh fish; do
+    absent=""
+    for f in jobs changed list-affected since seed; do
+        grep -qF -- "$f" "$TMP/kaappi.$shell" || absent="$absent --$f"
+    done
+    if [[ -z "$absent" ]]; then
+        pass "$shell script offers kaappi test's selection flags"
+    else
+        fail "$shell script offers kaappi test's selection flags" "missing:$absent"
+    fi
+done
+
+# ── 5. Soundness: everything offered is accepted, in context ────────────────
+#
+# Run the binary with each offered flag and require it not to be named as the
+# rejected token. Matching the exact "unknown option '<flag>'" phrasing (rather
+# than any nonzero exit) keeps a flag that legitimately errors for another
+# reason — "--seed requires an integer" — from reading as a false rejection,
+# and keeps the probe arguments below from being mistaken for the flag.
+#
+# PROBE is a path that cannot exist, so `kaappi test` never runs a suite and
+# the pipeline subcommands never compile anything: every probe is a parse-only
+# round trip.
+PROBE="__kaappi_completions_probe_no_such_path__"
+
+rejected_as() { # <flag> <output-file>
+    grep -qF -- "unknown option '$1'" "$2" ||
+        grep -qF -- "unexpected argument '$1'" "$2" ||
+        grep -qF -- "unknown subcommand '$1'" "$2"
+}
+
+check_context() { # <label> [subcommand]
+    local label="$1"
+    shift
+    local flags bad flag
+    flags="$(offers "$@")"
+    if [[ -z "$flags" ]]; then
+        fail "$label offers something" "COMPREPLY was empty"
+        return
+    fi
+    bad=""
+    while IFS= read -r flag; do
+        [[ -z "$flag" ]] && continue
+        # Run from inside $TMP: -o / --compile / --emit-llvm / --coverage-xml
+        # all write a file named after the argument that follows them.
+        ( cd "$TMP" && "$KAAPPI" "$@" "$flag" "$PROBE" "$PROBE" ) > "$TMP/o" 2> "$TMP/e"
+        if rejected_as "$flag" "$TMP/o" || rejected_as "$flag" "$TMP/e"; then
+            bad="$bad $flag"
+        fi
+    done <<< "$flags"
+    if [[ -z "$bad" ]]; then
+        pass "$label offers only flags the parser accepts ($(wc -w <<< "$flags" | tr -d ' ') probed)"
+    else
+        fail "$label offers only flags the parser accepts" "rejected:$bad"
+    fi
+}
+
+check_context "top level"
+check_context "kaappi explain" explain
+check_context "kaappi features" features
+check_context "kaappi test" test
+check_context "kaappi ir" ir
+check_context "kaappi fmt" fmt
+check_context "kaappi cache" cache
+# `doctor` runs a native smoke link per invocation, so probe it directly with
+# its own (short) list rather than through the generic helper's extra args.
+for flag in --json --help -h; do
+    ( cd "$TMP" && "$KAAPPI" doctor "$flag" ) > "$TMP/o" 2> "$TMP/e"
+    if rejected_as "$flag" "$TMP/o" || rejected_as "$flag" "$TMP/e"; then
+        fail "kaappi doctor accepts $flag" "rejected"
+    else
+        pass "kaappi doctor accepts $flag"
+    fi
+done
+
+# The control that makes the soundness checks discriminating: a flag the
+# subcommand genuinely does not accept must be caught by `rejected_as`. Without
+# this, a broken matcher would make every check above pass vacuously.
+( cd "$TMP" && "$KAAPPI" features --sandbox ) > "$TMP/o" 2> "$TMP/e"
+if rejected_as "--sandbox" "$TMP/o" || rejected_as "--sandbox" "$TMP/e"; then
+    pass "control: kaappi features rejects --sandbox and the matcher sees it"
+else
+    fail "control: kaappi features rejects --sandbox and the matcher sees it" \
+        "matcher found no rejection — the soundness checks above prove nothing"
+fi
+# And the completions must not be offering it there.
+if grep -qxF -- "--sandbox" <<< "$(offers features)"; then
+    fail "kaappi features does not complete --sandbox" "it is offered"
+else
+    pass "kaappi features does not complete --sandbox"
+fi
+
+# ── 6. thottam ─────────────────────────────────────────────────────────────
+
+for flag in --locked --help -h --version; do
+    ( cd "$TMP" && "$THOTTAM" "$flag" list ) > "$TMP/o" 2> "$TMP/e"
+    if rejected_as "$flag" "$TMP/o" || rejected_as "$flag" "$TMP/e"; then
+        fail "thottam accepts $flag" "rejected"
+    else
+        pass "thottam accepts $flag"
+    fi
+done
+
+for shell in bash zsh fish; do
+    absent=""
+    for w in install remove list update verify locked completions; do
+        grep -qF -- "$w" "$TMP/thottam.$shell" || absent="$absent $w"
+    done
+    if [[ -z "$absent" ]]; then
+        pass "thottam $shell script names every flag and subcommand"
+    else
+        fail "thottam $shell script names every flag and subcommand" "missing:$absent"
+    fi
+done
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo
+echo "completions: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -507,6 +507,7 @@ run_shell_suite "Doctor" tests/scheme/doctor
 run_shell_suite "Formatter" tests/scheme/fmt
 run_shell_suite "Cache" tests/scheme/cache
 run_shell_suite "Timings" tests/scheme/timings
+run_shell_suite "Shell completions" tests/scheme/completions
 run_shell_suite "Language server" tests/scheme/lsp
 # Execution-tier differential: every corpus file must give the same answer with
 # the IR optimiser off and from a warm bytecode cache as it does from a cold


### PR DESCRIPTION
Phase 6C of the v2 audit campaign (#1890). A **fix** unit, not a survey.

`kaappi --completions <shell>` emitted three hand-written string literals, structurally parallel to the argument parsers with nothing keeping them in step — the same shape as `isRejectedFormHead` (unit 4A) and the `%`-prefix incident. This makes them **generated at comptime from the table the parsers themselves dispatch on**, so the class of bug cannot recur.

Closed once before as a one-off: #552, "zsh completion does not offer the `compile` subcommand".

## The drift, measured in both directions

Against the real binary at `1718a2e1`, macOS aarch64, ReleaseSafe, isolated `KAAPPI_HOME`.

### Accepted by the CLI, missing from the completions

| Flag | Context | bash | zsh | fish |
|---|---|:--:|:--:|:--:|
| `--no-ir-opt` | global | **missing** | **missing** | **missing** |
| `-j` / `--jobs <n>` | `test` | **missing** | **missing** | **missing** |
| `--changed` | `test` | **missing** | **missing** | **missing** |
| `--list-affected` | `test` | **missing** | **missing** | **missing** |
| `--since <rev>` | `test` | **missing** | **missing** | **missing** |
| `--seed <n>` | `test` | ok | **missing** | **missing** |
| `--json` | `explain`/`features`/`test`/`doctor` | ok | **missing** | **missing** |
| `--all` | `explain` | ok | **missing** | **missing** |
| `-h` / `--help` | all 8 subcommand contexts | **missing** | (global) | (global) |
| bare `--timings` | global | ok | **missing** (only `--timings=`) | ok |
| `status` / `clear` | `cache` | ok | **missing** | ok |

The tracker named only `--no-ir-opt`. The `kaappi test` selection flags are the larger gap: five flags, none of them offered anywhere.

### Offered by the completions, rejected by the CLI

The worse direction, and the one nobody had looked at. `explain`, `features`, `test`, `doctor` and `cache` intercept argv in their own module **before** `cli.parse` runs, and reject anything outside their own small table with exit 2. zsh (`_arguments -s $flags`) and fish (`complete` with no `-n` guard) offered the entire global flag set in every one of those contexts:

```console
$ kaappi features --gc-stats      # fish/zsh completed this
kaappi features: unexpected argument '--gc-stats'      # exit 2
$ kaappi doctor --profile
kaappi doctor: unknown option '--profile'              # exit 2
$ kaappi cache --version
kaappi cache: unknown subcommand '--version'           # exit 2
```

Measured: of 16 global flags probed per context, **15 are rejected with exit 2 and 1 accepted** (`--help`) — identically for all five subcommands. bash was the only script that scoped, and had zero offered-but-invalid.

`thottam`'s three scripts had **no drift in either direction** — asserted so now rather than left to luck.

## The authoritative table

New `src/cli_spec.zig`, read by five consumers:

| Consumer | For |
|---|---|
| `cli.zig` — `parse` / `preScanSandbox` | global flags |
| `cli.zig` — `printUsage` | the `Options:` block, **generated** |
| `explain.zig`, `features.zig`, `doctor.zig`, `test_runner.zig`, `cache.zig` | each subcommand's own flags |
| `thottam.zig` | thottam's flags |
| `completions.zig` | all six shell scripts, **generated at comptime** |

Every parse loop was rewritten to dispatch on `switch (m.flag.id)` over its table's `Id` enum. `printUsage`'s hand-maintained `Options:` block — a *fourth* parallel list — is now generated too.

The `--diagnostics=` / `--timings[=fmt]` escape hatch is closed. Both were matched by `std.mem.startsWith` **outside** the old flag table, because it had no way to express GNU `=` syntax — which is exactly how they, and later `--no-ir-opt`, drifted out of the scripts. A new `ValueSyntax` (`none` / `separate` / `inline_eq` / `inline_eq_optional`) covers every spelling, so nothing reaches a parse loop without passing through the table. That also fixes the zsh specs: an attached-only value is `--opt=-` and `::` marks it optional, so zsh now completes `--diagnostics=json` instead of the separated `--diagnostics json` that the parser rejects.

## The gate

1. **Comptime, per parser** — an exhaustive `switch` over each table's `Id`. A new row is a compile error until the parser handles it.
2. **Comptime, per table** — every `Id` variant must appear exactly once; no duplicate spellings; `value_name` required on value-taking flags; descriptions restricted to characters needing no quoting inside a zsh `'…[desc]'` spec or fish `-d '…'` string.
3. **Generation** — the scripts cannot lag, because they *are* the table.

Verified to fire, by mutation:

| Mutation | Caught by |
|---|---|
| add a `GlobalId` variant with no table row | `cli_spec.zig`: `global_flags: frobnicate must appear exactly once in the table` |
| add a table row the parser does not handle | `cli.zig:183: error: switch must handle all possibilities` |
| delete `--seed` from `test_flags` | `cli_spec.zig`: `test_flags: seed must appear exactly once in the table` |
| drop `--no-ir-opt` from the top-level offer | 2 unit tests (`completions`, `cli`) + 3 shell assertions |

## Tests

`completions.zig` had **zero**. Now 11 unit tests plus a 41-assertion shell suite.

**Unit** (`src/completions.zig`, `src/cli_spec.zig`, `src/cli.zig`): completeness in both directions (every table flag in every script; every `--word` token in every script names a declared flag), the `test` selection flags by name, per-shell invariants (balanced quotes per line, ASCII only, the zsh `=-` spelling, the fish bare-`--timings` spelling), `match` over all four value syntaxes, `--timeout` not prefix-matching `--timings`, and `printUsage` documenting exactly the top-level flags.

**Shell** (`tests/scheme/completions/completions.sh`, new, wired into `run-all.sh`): sources the generated bash function and **drives it**, then feeds every offered flag back to the **real binary** per context, requiring none comes back as `unknown option '<flag>'` / `unexpected argument '<flag>'` / `unknown subcommand '<flag>'`. It carries its own discriminating control — `kaappi features --sandbox` must be rejected *and the matcher must see it* — so a broken matcher cannot make the soundness checks pass vacuously. bash and zsh are syntax-checked (`-n`); fish is gated on being installed, since it is absent from most CI legs.

Portability: ERE (`grep -oE`), never GNU `\|`; here-strings, never a pipe into `grep -q`; probes run from inside the temp dir because `-o` / `--compile` / `--emit-llvm` write a file named after their argument (caught during development — the first draft left two files in the working tree).

## Found while doing it

#2096 — `kaappi --check foo.scm` **runs the program**. `--check` is `fmt`'s flag but the global loop accepts it anywhere, and it is one hyphen-pair from the `check` subcommand whose contract is that nothing executes. Both exit 1, so a CI step reading only the exit code cannot tell them apart. Filed, not fixed here: the fix is a behaviour change worth deciding on its own.

## Verification

- `zig build test` — green
- `bash tests/scheme/run-all.sh` — 2036 pass. The first run showed 2 failures, both `bundle_fixture_binary` tests, both `fatal: invalid embedded bytecode`: I had built the binary from a dirty tree and then committed, so the `-Dbundle` rebuild's build id (`54b87942`) no longer matched the `.sbc` the stale binary (`1718a2e1-dirty`) produced — the documented `docs/dev/cache.md` footgun, not a regression. Both pass against a correctly-built binary; a full clean re-run is in flight and CI builds from the committed tree, where this cannot occur.
- `tests/scheme/completions/completions.sh` — 41/41, under both bash 5.3 and macOS's system bash 3.2
- `tests/scheme/sandbox/` — 4/4 (`preScanSandbox` was rewritten; 9 hand probes confirm `--sandbox` detection is unchanged after `--diagnostics=json`, `--timings`, `--timings=json`, `--no-ir-opt`, `--lib-path <dir>` and a bare subcommand)
- cross-compiles clean for `aarch64-windows`, `x86_64-linux`, `s390x-linux`, `wasm32-wasi` — the tables are pure comptime and target-independent
- `doctor` 20/20, `fmt` 12/12, `cache` 11/11, `timings` 42/42, `pipeline` 13/13, `errors/exit-code` 49/49, all 5 `test-runner` suites — green
- `markdownlint-cli2` — 0 issues
- all three scripts eyeballed by hand; `bash -n` and `zsh -n` clean

Docs: new `docs/dev/cli-surface.md` (indexed in `docs/dev/README.md`), plus `CLAUDE.md`, `tests/scheme/CLAUDE.md` and `docs/dev/explain.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
