### PR TITLE
Drop the per-PR CHANGELOG gate; derive release notes from git log

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -40,9 +40,21 @@ Present the analysis and recommendation, then ask for confirmation before contin
 
 ## Step 2: Generate release notes
 
-Combine the `[Unreleased]` section from `CHANGELOG.md` (primary source) with any
-commits not already reflected in it. Present draft notes to the user for review.
-Wait for confirmation.
+**Derive the notes from `git log` since the previous tag** — that is the primary
+source. There is no CI gate requiring a `CHANGELOG.md` entry per PR (it was
+removed: it conflicted constantly across concurrent branches, since every PR
+edited the same few lines at the top of one file), so `[Unreleased]` is
+normally sparse or empty and cannot be relied on.
+
+```bash
+git log --no-merges --pretty='%h %s' "$(git describe --tags --abbrev=0)"..HEAD
+```
+
+Read the commit bodies, not just the subjects — this project's convention is
+that the body explains *why*, which is what a release note needs. Fold in
+anything `[Unreleased]` does happen to carry. Group by user-visible effect
+rather than by commit, and drop pure test/CI/refactor commits. Present draft
+notes to the user for review. Wait for confirmation.
 
 ## Step 3: Update CHANGELOG.md
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,50 +55,6 @@ jobs:
   # than written as the work lands -- v0.22.0 shipped with 14 of 100 commits
   # reflected in it, v0.22.1 with 5 of 16. Ask for the entry here, while the
   # change is fresh and its author is present to write it.
-  changelog:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Require a CHANGELOG entry for user-visible changes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # Labels are read live rather than from github.event, because
-          # re-running a job replays the ORIGINAL event payload -- a
-          # `no-changelog` label added in response to this job failing would
-          # be invisible to it, making the documented escape hatch a dead end.
-          if gh pr view "$PR" --repo "$REPO" --json labels \
-               --jq '.labels[].name' | grep -qx 'no-changelog'; then
-            echo "Labelled 'no-changelog' -- skipping."
-            exit 0
-          fi
-
-          files=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
-
-          if ! grep -qE '^(src/|lib/srfi/)' <<<"$files"; then
-            echo "No src/ or lib/srfi/ changes -- CHANGELOG entry not required."
-            exit 0
-          fi
-          if grep -qx 'CHANGELOG.md' <<<"$files"; then
-            echo "CHANGELOG.md updated."
-            exit 0
-          fi
-
-          echo "::error::This PR changes src/ or lib/srfi/ but does not touch CHANGELOG.md."
-          echo "::error::Add an entry under [Unreleased] describing the user-visible effect."
-          echo "::error::If the change is not user-visible (refactor, tests, CI), apply the"
-          echo "::error::'no-changelog' label and re-run this job -- labels are read live, so"
-          echo "::error::a re-run picks it up without pushing a commit."
-          exit 1
-
   test:
     needs: format
     # Explicit name, deliberately NOT including matrix.timeout: this job's


### PR DESCRIPTION
The `changelog` CI job required every PR touching `src/` or `lib/srfi/` to edit `CHANGELOG.md`. With concurrent branches that is a guaranteed conflict: every PR appends to the same few lines under `[Unreleased]`, so each one that merges leaves the others needing a rebase for a reason unrelated to their content. It has cost several rebases in the current audit campaign alone.

**Nothing depends on the job.** `release.yml:385` still reads `CHANGELOG.md` when it builds the release body, and the release skill still writes that section at release time (its Step 3). Only the *per-PR* requirement is removed.

**The release skill's Step 2 is flipped to match.** It already combined `[Unreleased]` with "any commits not already reflected in it" — but called `CHANGELOG.md` the primary source, which will now usually be empty. It now derives from `git log` since the previous tag as the primary source:

```bash
git log --no-merges --pretty='%h %s' "$(git describe --tags --abbrev=0)"..HEAD
```

with a note to read commit **bodies**, not just subjects — this project's commit convention puts the *why* in the body, which is exactly what a release note needs.

**One correction worth recording:** the request was to remove this rule from `CLAUDE.md`, but `CLAUDE.md` never carried it. Its only changelog mention is the `/github-release` skill description, which remains accurate. The rule lived solely in `.github/workflows/ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
