### PR TITLE
Re-derive the bytecode and IR docs from source, and gate the counts at comptime

### DIFF
--- a/.claude/skills/bytecode-isa/SKILL.md
+++ b/.claude/skills/bytecode-isa/SKILL.md
@@ -5,7 +5,7 @@ description: Reference for the Kaappi bytecode instruction set
 # Bytecode ISA
 
 The instruction set reference lives in `docs/dev/bytecode.md` — read that
-file for the full 32-opcode table, operand encodings, closure capture
+file for the full 31-opcode table, operand encodings, closure capture
 encoding, and disassembler output format. Do not duplicate the table here;
 that doc is the single source of truth.
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -73,9 +73,15 @@ reviews:
 
     - path: "src/ir.zig"
       instructions: |
-        Intermediate representation: 33 node types, 3 analysis passes,
-        5 optimization passes. New node types need: NodeTag variant, Data union
-        field, freeNode arm, markTailPositions arm, and llvm_node_table entry.
+        Intermediate representation: 18 node types, 1 analysis pass
+        (markTailPositions), 5 optimization passes. Most special forms are NOT
+        their own node type — they share the single `sexpr_form` tag and are
+        discriminated by one of 18 `FormKind`s, so a new form normally needs
+        only the FormKind + sexpr_form_map path described for src/compiler*.zig
+        above, with no NodeTag, Data union, freeNode or analysis-pass change.
+        Only a genuinely structured node (one with IR-level children) needs:
+        NodeTag variant, Data union field, lowering, freeNode arm,
+        markTailPositions arm, and llvm_node_table entry.
         Optimization passes use `else => return node` — only add arms if the
         new form should participate in constant folding or simplification.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,9 +240,9 @@ cannot resolve. `zig cc` includes these automatically.
 
 ```text
 Source → Reader → Expander → IR → Analysis → Optimization → Bytecode Emission → VM
-         (UTF-8    (syntax-    (33 node  (tail pos,    (const fold,     (register-   (generational
-          lexer)    rules)      types)    primitives,   dead branch,      based)       GC)
-                                          constants)    boolean, etc.)
+         (UTF-8    (syntax-    (18 node  (tail pos)    (const fold,     (register-   (generational
+          lexer)    rules)      types)                  dead branch,      based)       GC)
+                                                        boolean, etc.)
 ```
 
 ### Pipeline stages
@@ -251,7 +251,7 @@ Source → Reader → Expander → IR → Analysis → Optimization → Bytecode
 |-------|------|------|
 | Reader | `reader.zig` (+ `reader_tokens.zig`, `reader_datum.zig`) | Tokenizer + recursive descent parser. Handles R7RS lexical syntax including Unicode identifiers and `#\λ` character literals. |
 | Expander | `expander.zig` | `syntax-rules` pattern matching and template instantiation. Called by the compiler when a macro keyword is encountered. |
-| IR | `ir.zig` | Lowers S-expressions to tree-structured IR (33 node types). Runs 3 analysis passes (tail positions, primitive identification, constant detection) and 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification). See `docs/dev/ir.md`. |
+| IR | `ir.zig` | Lowers S-expressions to tree-structured IR (18 node types; `sexpr_form` carries 18 `FormKind`s). Runs 1 analysis pass (tail positions) and 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification). See `docs/dev/ir.md`. |
 | Compiler | `compiler.zig` | IR nodes → register-based bytecode via `compileFromNode()`. Retains `compileExpr()` for forms delegated via `passthrough`. Dispatches derived forms to sub-modules. |
 | VM | `vm.zig` | Executes bytecode. Growable register file + call frame stack (heap-allocated, double-on-overflow). Handles continuations (stack-copying), exception handler stack, dynamic-wind stack, stepping debugger. |
 | GC | `memory.zig` | Generational collector (young/old) with minor and full collections, write barrier for old→young references. Roots tracked via `gc.pushRoot`/`gc.popRoot`. Triggered after N allocations. |
@@ -328,8 +328,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 
 | File | Responsibility |
 |------|---------------|
-| `ir.zig` | IR node types (33), AST→IR lowering, 3 analysis passes, 5 optimization passes |
-| `ir_emitter.zig` | Standalone IR → bytecode emitter (used by Stage 1 parity tests) |
+| `ir.zig` | IR node types (18), AST→IR lowering, 1 analysis pass, 5 optimization passes |
 | `compiler.zig` | Core: IR pipeline orchestration (`compile()` lowers to IR, runs passes), retains `compileExpr()` for passthrough forms, scope/register management, macro forms |
 | `compiler_ir.zig` | IR-to-bytecode: `compileFromNode()` dispatch, if, begin, call, lambda, define, set!, and, or, when, unless |
 | `compiler_lambda.zig` | lambda, define, set!, begin, delay, delay-force, body compilation |

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Source → Reader → Expander → IR → Bytecode emission → VM
 |-----------|------|
 | **Reader** | Tokenizer + recursive descent parser for the full R7RS lexical syntax, including Unicode identifiers and `#\λ` character literals. |
 | **Expander** | `syntax-rules` pattern matching and hygienic template instantiation. |
-| **IR** | Tree-structured intermediate representation (33 node types) with analysis passes (tail positions, primitives, constants) and optimization passes (constant folding, dead-branch elimination, and more). |
+| **IR** | Tree-structured intermediate representation (18 node types) with a tail-position analysis pass and 5 optimization passes (constant folding, dead-branch elimination, and more). |
 | **Compiler** | IR → register-based bytecode. |
 | **VM** | Bytecode interpreter with growable register file and frame stack, exception handler and dynamic-wind stacks, stack-copying continuations, and a stepping debugger. |
 | **GC** | Generational collector (young/old) with write barrier for old→young references. |

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -72,7 +72,7 @@ investigations.
 
 | Document | Contents |
 |----------|----------|
-| [bytecode.md](bytecode.md) | Bytecode instruction set (32 opcodes), encoding, disassembler |
+| [bytecode.md](bytecode.md) | Bytecode instruction set (31 opcodes), encoding, disassembler |
 | [repl.md](repl.md) | REPL reference: line editing, comma commands, completion |
 | [unicode-case-mapping.md](unicode-case-mapping.md) | Case-conversion coverage by script |
 | [fuzzing-feasibility.md](fuzzing-feasibility.md) | Why neither Fuzzilli nor AFL++ is the tool, the existing `std.testing.fuzz` targets, and where fuzzing can improve |

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -20,7 +20,7 @@ investigation produced analysis worth keeping.
 |----------|----------|
 | [vision.md](vision.md) | Why Kaappi exists, what it values, how those values guide decisions |
 | [architecture.md](architecture.md) | Major subsystems: pipeline, value representation, VM, GC, file organization |
-| [ir.md](ir.md) | Compiler IR: 33 node types, analysis passes, optimization passes |
+| [ir.md](ir.md) | Compiler IR: 18 node types, the tail-position analysis pass, optimization passes |
 | [observing-the-pipeline.md](observing-the-pipeline.md) | `kaappi ast` / `expand` / `ir` / `--disassemble`: read-only dumps of every stage between source and bytecode |
 | [llvm-backend.md](llvm-backend.md) | LLVM native backend: what LLVM provides vs what the runtime provides |
 | [windows.md](windows.md) | Windows aarch64 port: the platform.zig shim, the two deliberate degradations, the `windows` feature identifier, how to test on a Windows machine |

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -216,46 +216,60 @@ without the fix.
 When you need a new special form that the compiler must handle directly
 (not a procedure and not a macro).
 
-### 1. Add an IR node type
+`.claude/rules/compiler-forms.md` is the maintained checklist (it loads
+automatically when you edit `src/compiler*.zig` or `src/ir.zig`) and covers
+both paths — a *delegating* form, which passes its raw s-expression to a form
+compiler, and a *structured* form, which lowers into IR children. Almost every
+new form is delegating; that is the path shown here.
+
+### 1. Add a FormKind
+
+A delegating form does **not** get its own `NodeTag`. All of them share the
+single `sexpr_form` tag and are discriminated by `FormKind`, so there is no
+`Data` union variant to add and nothing to teach `freeNode`, the analysis pass
+or the optimization passes — they handle `.sexpr_form` through catch-all arms
+already.
 
 In `src/ir.zig`:
 
-a. Add a variant to `NodeTag`:
+a. Add a variant to `FormKind` and return its keyword from `keyword()`:
 
 ```zig
-pub const NodeTag = enum {
-    // ... existing tags ...
+pub const FormKind = enum {
+    // ... existing kinds ...
     my_form,
+
+    pub fn keyword(self: FormKind) []const u8 {
+        return switch (self) {
+            // ...
+            .my_form => "my-form",
+        };
+    }
 };
 ```
 
-b. Add the corresponding `Data` union variant. For simple forms with
-sub-expressions that should be analyzed/optimized, define a custom data
-struct and lower recursively. For complex forms, use `SexprArgs` to defer
-to the existing compiler path:
+b. Add the keyword → `FormKind` entry to `sexpr_form_map`:
 
 ```zig
-// In Node.Data union:
-my_form: SexprArgs,   // delegates body to existing compiler
+.{ "my-form", .my_form },
 ```
 
-c. Add lowering in `lowerFormWithMacros()` and `lowerForm()`:
+That is the whole lowering change — `lowerWithMacros` consults the map and
+calls `makeSexprNode(form, types.cdr(expr))` for any hit. (A form with no
+keyword of its own, like named `let`, is instead detected structurally in its
+`lower*` helper.)
 
-```zig
-if (std.mem.eql(u8, effective_name, "my-form"))
-    return ir.makeSexprNode(.my_form, types.cdr(expr));
-```
-
-d. Handle the new tag in `freeNode`, `markTailPositions`, `identifyPrimitives`,
-and `markConstants` (add to the appropriate switch arms -- usually the
-no-op catch-all arm for `SexprArgs`-based forms).
+Adding a `FormKind` also enrolls the keyword in `eval_fallback_form_names`
+automatically, which is what keeps the LLVM backend's native/eval-fallback
+decision correct — see the note in the root `CLAUDE.md`.
 
 ### 2. Add compilation dispatch
 
-In `src/compiler.zig`, add a case in `compileFromNode()`:
+In `src/compiler_ir.zig`, add a case to the inner `switch (sf.form)` inside the
+`.sexpr_form` arm of `compileFromNode()`:
 
 ```zig
-.my_form => try forms.compileMyForm(self, node.data.my_form.args, dst, tail),
+.my_form => try forms.compileMyForm(self, sf.args, dst, tail),
 ```
 
 ### 3. Implement the compilation
@@ -272,7 +286,7 @@ Write the compilation function:
 pub fn compileMyForm(
     self: *Compiler,
     args: Value,
-    dst: u8,
+    dst: u16,
     is_tail: bool,
 ) CompileError!void {
     // Parse the form's subexpressions from `args`
@@ -296,7 +310,8 @@ pub const compileMyForm = @import("compiler_advanced.zig").compileMyForm;
 
 Test both at the Zig level (compile and check emitted bytecode) and at the
 Scheme level (run expressions using the new form). Add IR-specific tests
-in `src/tests_ir.zig` -- at minimum a behavioral parity test.
+in `src/tests_ir.zig` -- at minimum a behavioral test (`test "IR behavioral:
+my-form ..."`) that evaluates the form and checks its result.
 
 ---
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -28,7 +28,7 @@ Source code
 |-------|---------|------|
 | **Reader** | `reader.zig` | Tokenizer + recursive descent parser. Handles full R7RS lexical syntax including Unicode identifiers, `#\lambda` character literals, `#(...)` vectors, `#u8(...)` bytevectors, datum labels. |
 | **Expander** | `expander.zig` | `syntax-rules` pattern matching with ellipsis, literal identifiers, and underscore wildcards. Template instantiation with hygienic renaming (gensym-based). |
-| **IR** | `ir.zig` | Lowers S-expressions to a tree-structured IR (33 node types). Runs 3 analysis passes (tail positions, primitive identification, constant detection) and 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification). See [ir.md](ir.md) for details. |
+| **IR** | `ir.zig` | Lowers S-expressions to a tree-structured IR (18 node types, one of which — `sexpr_form` — carries 18 `FormKind`s). Runs 1 analysis pass (tail positions) and 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification). See [ir.md](ir.md) for details. |
 | **Compiler** | `compiler.zig` + 5 sub-modules | Emits register-based bytecode from IR nodes via `compileFromNode()`. Retains `compileExpr()` for forms delegated via `passthrough`. Dispatches 32 syntax forms across 6 files. |
 | **VM** | `vm.zig` + 7 sub-modules | Executes bytecode with a growable register file, call frame stack, exception handler stack, and dynamic-wind stack (all heap-allocated, double-on-overflow; exceeding a hard cap is an uncatchable KP3008). First-class continuations via stack copying, plus a stepping debugger. |
 | **GC** | `memory.zig` | Mark-and-sweep collector with intrusive linked list. Root tracking via `pushRoot`/`popRoot`. Triggered after N allocations. |
@@ -58,7 +58,7 @@ Source code
 
 | File | Responsibility |
 |------|---------------|
-| `ir.zig` | IR node types (33), AST→IR lowering, 3 analysis passes, 5 optimization passes, standalone Emitter for parity testing |
+| `ir.zig` | IR node types (18), AST→IR lowering, 1 analysis pass, 5 optimization passes |
 | `compiler.zig` | Core: IR pipeline orchestration (`compile()` lowers to IR, runs passes, emits via `compileFromNode()`), also retains `compileExpr()` for passthrough forms, scope/register management |
 | `compiler_lambda.zig` | lambda, define, set!, begin, delay, delay-force, body compilation |
 | `compiler_conditionals.zig` | and, or, when, unless, cond, cond-expand |
@@ -244,41 +244,20 @@ be balanced and follow LIFO order.
 The compiler produces register-based bytecode. Each instruction is an `OpCode`
 enum value followed by operands.
 
-### Opcodes (31)
+### Opcodes
 
-| Opcode | Operands | Description |
-|--------|----------|-------------|
-| `load_const` | dst:u8, idx:u16 | Load constant from pool |
-| `load_nil` | dst:u8 | Load nil |
-| `load_true` | dst:u8 | Load #t |
-| `load_false` | dst:u8 | Load #f |
-| `load_void` | dst:u8 | Load void |
-| `move` | dst:u8, src:u8 | Copy register |
-| `get_global` | dst:u8, sym_idx:u16 | Read global variable |
-| `set_global` | sym_idx:u16, src:u8 | Write global variable |
-| `define_global` | sym_idx:u16, src:u8 | Define global variable |
-| `tail_apply` | base:u8, nargs:u8 | Tail `apply` (spreads final list arg) |
-| `get_local` | dst:u8, slot:u8 | Read local variable |
-| `set_local` | slot:u8, src:u8 | Write local variable |
-| `get_upvalue` | dst:u8, idx:u8 | Read captured variable |
-| `set_upvalue` | idx:u8, src:u8 | Write captured variable |
-| `call` | base:u8, nargs:u8 | Call function |
-| `tail_call` | base:u8, nargs:u8 | Tail call (reuses frame) |
-| `return` | src:u8 | Return value |
-| `jump` | offset:i16 | Unconditional jump |
-| `jump_false` | test:u8, offset:i16 | Jump if register is `#f` |
-| `jump_true` | test:u8, offset:i16 | Jump if register is not `#f` |
-| `closure` | dst:u8, idx:u16 | Create closure from function |
-| `close_upvalue` | slot:u8 | Close over a local variable |
-| `cons` | dst:u8, car:u8, cdr:u8 | Allocate a pair |
-| `push_handler` | handler_reg:u8 | Push exception handler |
-| `pop_handler` | -- | Pop exception handler |
-| `halt` | -- | Stop execution |
-| `call_global` | base:u8, sym_idx:u16, nargs:u8 | Call a global directly (fused get_global + call) |
-| `tail_call_global` | base:u8, sym_idx:u16, nargs:u8 | Tail-call a global directly |
-| `box_local` | reg:u8 | Wrap a register value in a box (pair) for shared mutation |
-| `get_box_local` | dst:u8, reg:u8 | Read the boxed value (car of box) |
-| `set_box_local` | reg:u8, src:u8 | Set the boxed value (car of box) |
+31 opcodes, defined by the `OpCode` enum in `src/types.zig`. Register, slot,
+constant-index and symbol-index operands are u16 (big-endian); only `nargs` and
+a closure capture descriptor's `is_local` flag are u8.
+
+**[bytecode.md](bytecode.md) has the full table** — opcode numbers, operands,
+byte widths, the closure capture encoding, and the disassembler's output
+format. It is the single source of truth for the ISA and is deliberately not
+duplicated here: this file carried its own copy until kaappi#2102, and it had
+drifted to describe three opcodes that do not exist (`get_local`, `set_local`,
+`close_upvalue`) while omitting three that do (`self_tail_call`,
+`tail_call_cc`, `tail_eval`) — a wrong table whose row count happened to stay
+right.
 
 ### Function objects
 

--- a/docs/dev/bytecode.md
+++ b/docs/dev/bytecode.md
@@ -5,43 +5,50 @@ the ISA — the `/bytecode-isa` skill points here.
 
 ## Instruction set
 
-29 opcodes, register-based, variable-length encoding. Operands are u8
-(register/slot) or u16 (constant index, big-endian). Jump offsets are i16
-(signed, relative to the instruction after the jump). Defined in the
-`OpCode` enum in `src/types.zig`; executed by the dispatch loop in
-`src/vm_dispatch.zig`.
+31 opcodes, register-based, variable-length encoding. Register/slot,
+constant-index and symbol-index operands are all u16 (big-endian); jump
+offsets are i16 (signed, relative to the instruction after the jump). The
+only u8 operands are `nargs` and the `is_local` flag in a closure capture
+descriptor. Defined in the `OpCode` enum in `src/types.zig`; executed by the
+dispatch loop in `src/vm_dispatch.zig`.
+
+The `fixed_operand_bytes` switch in `src/vm_dispatch.zig` is the authoritative
+operand-width table — it is what `ensureOperands` validates against, so the
+**Bytes** column below is always `1 + fixed_operand_bytes` for that opcode.
 
 | # | Opcode | Operands | Bytes | Description |
 |---|--------|----------|-------|-------------|
-| 0 | `load_const` | dst:u8, idx:u16 | 4 | Load constant pool[idx] → dst |
-| 1 | `load_nil` | dst:u8 | 2 | Load () → dst |
-| 2 | `load_true` | dst:u8 | 2 | Load #t → dst |
-| 3 | `load_false` | dst:u8 | 2 | Load #f → dst |
-| 4 | `load_void` | dst:u8 | 2 | Load void → dst |
-| 5 | `move` | dst:u8, src:u8 | 3 | Copy src → dst |
-| 6 | `get_global` | dst:u8, sym_idx:u16 | 4 | Lookup global symbol → dst |
-| 7 | `set_global` | sym_idx:u16, src:u8 | 4 | Set global from src |
-| 8 | `define_global` | sym_idx:u16, src:u8 | 4 | Define global from src |
-| 9 | `tail_apply` | base:u8, nargs:u8 | 3 | Tail apply with list unpacking |
-| 10 | `get_upvalue` | dst:u8, idx:u8 | 3 | Load captured var → dst |
-| 11 | `set_upvalue` | idx:u8, src:u8 | 3 | Set captured var from src |
-| 12 | `call` | base:u8, nargs:u8 | 3 | Call fn at base with nargs args |
-| 13 | `tail_call` | base:u8, nargs:u8 | 3 | Tail call (reuses frame) |
-| 14 | `return` | src:u8 | 2 | Return value from src |
+| 0 | `load_const` | dst:u16, idx:u16 | 5 | Load constant pool[idx] → dst |
+| 1 | `load_nil` | dst:u16 | 3 | Load () → dst |
+| 2 | `load_true` | dst:u16 | 3 | Load #t → dst |
+| 3 | `load_false` | dst:u16 | 3 | Load #f → dst |
+| 4 | `load_void` | dst:u16 | 3 | Load void → dst |
+| 5 | `move` | dst:u16, src:u16 | 5 | Copy src → dst |
+| 6 | `get_global` | dst:u16, sym_idx:u16 | 5 | Lookup global symbol → dst |
+| 7 | `set_global` | sym_idx:u16, src:u16 | 5 | Set global from src |
+| 8 | `define_global` | sym_idx:u16, src:u16 | 5 | Define global from src |
+| 9 | `tail_apply` | base:u16, nargs:u8 | 4 | Tail apply with list unpacking |
+| 10 | `get_upvalue` | dst:u16, idx:u16 | 5 | Load captured var → dst |
+| 11 | `set_upvalue` | idx:u16, src:u16 | 5 | Set captured var from src |
+| 12 | `call` | base:u16, nargs:u8 | 4 | Call fn at base with nargs args |
+| 13 | `tail_call` | base:u16, nargs:u8 | 4 | Tail call (reuses frame) |
+| 14 | `return` | src:u16 | 3 | Return value from src |
 | 15 | `jump` | offset:i16 | 3 | Unconditional relative jump |
-| 16 | `jump_false` | test:u8, offset:i16 | 4 | Jump if test is #f |
-| 17 | `jump_true` | test:u8, offset:i16 | 4 | Jump if test is not #f |
-| 18 | `closure` | dst:u8, func_idx:u16 | 4+ | Create closure, followed by upvalue capture pairs |
-| 19 | `cons` | dst:u8, car:u8, cdr:u8 | 4 | Allocate pair → dst |
-| 20 | `push_handler` | handler:u8 | 2 | Push exception handler |
+| 16 | `jump_false` | test:u16, offset:i16 | 5 | Jump if test is #f |
+| 17 | `jump_true` | test:u16, offset:i16 | 5 | Jump if test is not #f |
+| 18 | `closure` | dst:u16, func_idx:u16 | 5 + 3n | Create closure, followed by n=`upvalue_count` capture descriptors |
+| 19 | `cons` | dst:u16, car:u16, cdr:u16 | 7 | Allocate pair → dst |
+| 20 | `push_handler` | handler:u16 | 3 | Push exception handler |
 | 21 | `pop_handler` | (none) | 1 | Pop exception handler |
 | 22 | `halt` | (none) | 1 | Stop execution |
-| 23 | `call_global` | base:u8, sym:u16, nargs:u8 | 5 | Fused get_global + call |
-| 24 | `tail_call_global` | base:u8, sym:u16, nargs:u8 | 5 | Fused get_global + tail_call |
-| 25 | `box_local` | reg:u8 | 2 | Wrap register in pair for mutation |
-| 26 | `get_box_local` | dst:u8, reg:u8 | 3 | Read car of boxed register |
-| 27 | `set_box_local` | reg:u8, src:u8 | 3 | Write car of boxed register |
-| 28 | `self_tail_call` | base:u8, nargs:u8 | 3 | Self-recursive tail call: copy args to frame base, reset IP |
+| 23 | `call_global` | base:u16, sym:u16, nargs:u8 | 6 | Fused get_global + call |
+| 24 | `tail_call_global` | base:u16, sym:u16, nargs:u8 | 6 | Fused get_global + tail_call |
+| 25 | `box_local` | reg:u16 | 3 | Wrap register in pair for mutation |
+| 26 | `get_box_local` | dst:u16, reg:u16 | 5 | Read car of boxed register |
+| 27 | `set_box_local` | reg:u16, src:u16 | 5 | Write car of boxed register |
+| 28 | `self_tail_call` | base:u16, nargs:u8 | 4 | Self-recursive tail call: copy args to frame base, reset IP |
+| 29 | `tail_call_cc` | base:u16, dst:u16 | 5 | `call/cc` in tail position: captures the continuation into dst, then tail-calls the receiver at base+0 |
+| 30 | `tail_eval` | base:u16, nargs:u8 | 4 | `eval` in tail position: compiles the expression at base+0 (optional environment at base+1) and tail-calls it |
 
 `self_tail_call` skips the global lookup, type check, and arity check for
 direct self-recursion and named `let` loops — see
@@ -52,8 +59,12 @@ direct self-recursion and named `let` loops — see
 - Opcodes: 1 byte (`@intFromEnum(op)`)
 - u16 operands: big-endian (high byte first)
 - i16 jump offsets: bitcast of u16, relative to instruction AFTER the jump
-- `closure` instruction: followed by `upvalue_count * 2` bytes of capture
-  descriptors (is_local:u8, index:u8 pairs)
+- `closure` instruction: followed by `upvalue_count * 3` bytes of capture
+  descriptors — each is `is_local:u8` then `index:u16`. `is_local == 1`
+  captures the parent frame's register `index` (boxing it first if it is not
+  already a box); otherwise it copies the parent closure's upvalue `index`.
+  The same `* 3` stride is what `bytecode_file_read.zig` skips when walking
+  a `.sbc` code stream.
 
 ## Available metadata per function
 
@@ -66,8 +77,8 @@ The `Function` struct (`src/types.zig`) provides:
 | `source_line` | `u32` | Source location |
 | `arity` | `u8` | Parameter count display |
 | `is_variadic` | `bool` | Show rest parameter |
-| `locals_count` | `u8` | Register window size |
-| `upvalue_count` | `u8` | Captured variable count |
+| `locals_count` | `u16` | Register window size |
+| `upvalue_count` | `u16` | Captured variable count |
 | `constants` | `ArrayList(Value)` | Constant pool for symbolic display |
 | `debug_locals` | `[]DebugLocal` | Map register slots to variable names |
 | `code` | `ArrayList(u8)` | Bytecode to disassemble |
@@ -83,29 +94,44 @@ Implemented in `src/disassembler.zig`. Three entry points:
 
 ### Output format
 
+For `(define (fib n) (if (<= n 1) n (+ (fib (- n 1)) (fib (- n 2)))))`,
+`(disassemble fib)` prints:
+
 ```text
 ; Function: fib
 ; Source: fib.scm:1
-; Arity: 1, Locals: 6, Upvalues: 0
-; Constants: [<=, n, 1, -, fib, +, 2]
+; Arity: 1, Locals: 7, Upvalues: 0
+; Constants: <=, 1, +, fib, -, 2
 ;
-; Bytecode (28 bytes):
-  0000  call_global     r0, <=, 2         ; (<=  n 1)
-  0005  jump_false      r0, +8            ; if false, goto 0017
-  0009  move            r0, r1            ; return n
-  000c  return          r0
-  000e  call_global     r2, -, 2          ; (- n 1)
-  0013  call_global     r2, fib, 1        ; (fib ...)
-  0018  call_global     r4, -, 2          ; (- n 2)
-  001d  tail_call_global r4, fib, 1       ; (fib ...) [tail]
+  0000  move            r2, r0
+  0005  load_const      r3, 1
+  0010  call_global     r1, <=, 2
+  0016  jump_false      r1, -> 0029
+  0021  move            r1, r0
+  0026  jump            -> 0082
+  0029  get_global      r1, +
+  0034  move            r4, r0
+  0039  load_const      r5, 1
+  0044  call_global     r3, -, 2
+  0050  call_global     r2, fib, 1
+  0056  move            r5, r0
+  0061  load_const      r6, 2
+  0066  call_global     r4, -, 2
+  0072  call_global     r3, fib, 1
+  0078  tail_call       r1, 2
+  0082  return          r1
 ```
+
+The offsets double as a check on the table above: `move` at 0000 to
+`load_const` at 0005 is 5 bytes, `call_global` at 0010 to `jump_false` at
+0016 is 6, and `jump` at 0026 to 0029 is 3.
 
 Formatting choices:
 
-- Hex offsets for jump target calculation
+- Decimal offsets, zero-padded to 4 digits (`{d:0>4}`)
 - Register names (`r0`, `r1`, ...) with `debug_locals` annotations where available
 - Symbol names resolved from constant pool (not raw indices)
-- Jump targets shown as absolute offsets
+- Jump targets shown as absolute offsets, written `-> NNNN`
 
 ## Key files
 

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -227,7 +227,7 @@ missing type dispatch).
 ### `/bytecode-isa`
 
 Reference for the bytecode instruction set. Points at
-[bytecode.md](bytecode.md) (the single source of truth for the 32-opcode
+[bytecode.md](bytecode.md) (the single source of truth for the 31-opcode
 table and encodings) and carries the adding-a-new-opcode checklist. Used
 when working on the compiler or VM.
 

--- a/docs/dev/ir.md
+++ b/docs/dev/ir.md
@@ -5,8 +5,8 @@ between the macro expander and bytecode emission. It enables shared analysis
 and optimization passes that benefit both the bytecode VM and LLVM backend, and
 provides a clean lowering target for a future native backend.
 
-**Source:** `src/ir.zig` (~1,500 lines)
-**Tests:** `src/tests_ir.zig` (~540 lines)
+**Source:** `src/ir.zig` (~1,400 lines)
+**Tests:** `src/tests_ir.zig` (~850 lines)
 
 ---
 
@@ -20,9 +20,7 @@ S-expression (post-expansion)
     v  lowerWithMacros()
 IR Node tree
     |
-    v  markTailPositions()     \
-    v  identifyPrimitives()     } analysis passes
-    v  markConstants()         /
+    v  markTailPositions()      } the one analysis pass
     |
     v  foldConstants()         \
     v  eliminateDeadBranches()  \
@@ -39,7 +37,14 @@ Bytecode
 ## Node Types
 
 Each IR node has a `NodeTag`, a `Data` union, and an `Annotations` struct.
-The 33 node types are grouped by how they carry data:
+There are **18** node tags, grouped by how they carry data.
+
+The IR is much less lowered than the tag count alone suggests. Only the first
+group below has its sub-expressions recursively lowered into IR nodes; the four
+binding tags keep their bindings as raw S-expressions, and every remaining
+special form collapses into the single `sexpr_form` tag, discriminated by one
+of 18 `FormKind`s. So a `cond` is not its own node type — it is
+`sexpr_form` carrying `.cond`.
 
 ### Fully lowered (sub-expressions are IR nodes)
 
@@ -58,12 +63,10 @@ The 33 node types are grouped by how they carry data:
 | `set_form` | `SetData` | Variable mutation: name symbol + value S-expr |
 | `lambda` | `LambdaData` | Lambda: args S-expr + optional name |
 
-### S-expression delegation (body stored as raw S-expression)
+### Binding forms (bindings stored as a raw S-expression)
 
-These forms are recognized and tagged during lowering but their
-sub-expressions are not recursively lowered. The compiler's
-`compileFromNode()` delegates them to the existing form compilers via
-their `SexprArgs` data.
+These four have their own tags but share `LetData`, which holds the whole form
+tail unlowered. `compileFromNode()` delegates them to `compiler_bindings.zig`.
 
 | Tag | Scheme form |
 |-----|-------------|
@@ -71,23 +74,34 @@ their `SexprArgs` data.
 | `let_star` | `let*` |
 | `letrec` | `letrec` |
 | `letrec_star` | `letrec*` |
-| `named_let` | named `let` |
-| `do_form` | `do` |
-| `delay` | `delay` |
-| `delay_force` | `delay-force` |
-| `cond` | `cond` |
-| `case_form` | `case` |
-| `case_lambda` | `case-lambda` |
-| `guard` | `guard` |
-| `quasiquote` | quasiquote |
-| `parameterize` | `parameterize` |
-| `define_values` | `define-values` |
-| `let_values` | `let-values` |
-| `let_star_values` | `let*-values` |
-| `define_syntax` | `define-syntax` |
-| `let_syntax` | `let-syntax` |
-| `letrec_syntax` | `letrec-syntax` |
-| `cond_expand` | `cond-expand` |
+
+### S-expression delegation (one tag, 18 form kinds)
+
+| Tag | Data type | Description |
+|-----|-----------|-------------|
+| `sexpr_form` | `SexprFormData` | A `FormKind` discriminant plus the unlowered form tail |
+
+Recognized during lowering but not recursively lowered; `compileFromNode()`
+dispatches on the `FormKind` to the existing form compilers. The 18 kinds and
+their keywords:
+
+| FormKind | Keyword | FormKind | Keyword |
+|----------|---------|----------|---------|
+| `do_form` | `do` | `let_values` | `let-values` |
+| `delay` | `delay` | `let_star_values` | `let*-values` |
+| `delay_force` | `delay-force` | `define_syntax` | `define-syntax` |
+| `cond` | `cond` | `define_property` | `define-property` |
+| `case_form` | `case` | `named_let` | `let` (named) |
+| `case_lambda` | `case-lambda` | `let_syntax` | `let-syntax` |
+| `guard` | `guard` | `letrec_syntax` | `letrec-syntax` |
+| `quasiquote` | `quasiquote` | `cond_expand` | `cond-expand` |
+| `parameterize` | `parameterize` | | |
+| `define_values` | `define-values` | | |
+
+`sexpr_form_map` maps keyword → `FormKind` for 17 of them. `named_let` is the
+exception: it has no keyword of its own, so `lowerLet` detects it structurally
+(a `let` whose second element is a symbol). `FormKind.keyword()` is the inverse
+and covers all 18.
 
 ### Fallback
 
@@ -100,28 +114,26 @@ their `SexprArgs` data.
 ## Data Structures
 
 ```zig
-CallData    { operator: *Node, args: []const *Node }
-IfData      { test_expr: *Node, consequent: *Node, alternate: ?*Node }
-CondBodyData { test_expr: *Node, body: []const *Node }
-DefineData  { name: Value, value: Value }
-SetData     { name: Value, value: Value }
-LambdaData  { args: Value, name: ?[]const u8 }
-LetData     { args: Value }
-SexprArgs   { args: Value }
+CallData      { operator: *Node, args: []const *Node }
+IfData        { test_expr: *Node, consequent: *Node, alternate: ?*Node }
+CondBodyData  { test_expr: *Node, body: []const *Node }
+DefineData    { name: Value, value: Value }
+SetData       { name: Value, value: Value }
+LambdaData    { args: Value, name: ?[]const u8 }
+LetData       { args: Value }
+SexprFormData { form: FormKind, args: Value }
 ```
 
 ---
 
 ## Annotations
 
-Every node carries an `Annotations` struct set by the analysis passes:
+Every node carries an `Annotations` struct. It has exactly two fields:
 
 | Field | Type | Set by | Meaning |
 |-------|------|--------|---------|
 | `is_tail` | `bool` | `markTailPositions` | Node is in tail position (enables TCO) |
-| `is_primitive_call` | `bool` | `identifyPrimitives` | Call targets a known built-in |
-| `primitive_name` | `?[]const u8` | `identifyPrimitives` | Name of the primitive (e.g. `"+"`) |
-| `is_constant` | `bool` | `markConstants` | Expression evaluates to a compile-time constant |
+| `span` | `types.Span` | the lowerer | Source span of the form this node came from, when the reader could key it (a pair or vector). `span.line == 0` means unknown; the compiler emits it into the bytecode line table so runtime errors can report `file:line:col` (kaappi#1506). |
 
 ---
 
@@ -154,7 +166,15 @@ on constant fixnum arguments, it is folded to a `constant` node immediately
 
 ---
 
-## Analysis Passes
+## Analysis Pass
+
+`markTailPositions` is the only analysis pass. Two others —
+`identifyPrimitives` and `markConstants`, along with the
+`is_primitive_call` / `primitive_name` / `is_constant` annotations they set —
+were removed as dead code in v0.13.0 (#1039, #1041). The
+primitive-name list they used survives in `ir.zig` as `isKnownGlobal`, but its
+only caller is now the LLVM backend's `isKnownOrReservedGlobal` — it annotates
+nothing and is not part of any IR pass.
 
 ### markTailPositions(node, is_tail)
 
@@ -168,25 +188,6 @@ Propagation rules:
 - `begin`, `and`, `or`: last expression inherits; all others are non-tail
 - `when`, `unless`: test is non-tail; last body expression inherits
 - `call`: operator and arguments are always non-tail
-
-### identifyPrimitives(node)
-
-Marks calls to known built-in procedures. If a `call` node's operator is a
-`global_ref` matching one of 72 known primitive names, the node gets
-`ann.is_primitive_call = true` and `ann.primitive_name` set.
-
-Recognized primitives include: `+`, `-`, `*`, `/`, `=`, `<`, `>`, `cons`,
-`car`, `cdr`, `list`, `map`, `apply`, `display`, `write`, `eq?`, `equal?`,
-`string-append`, `vector-ref`, and ~50 others.
-
-### markConstants(node)
-
-Identifies compile-time constant expressions:
-
-- `constant` nodes are always constant
-- `call` nodes are constant if the operator is a primitive and all arguments
-  are constant
-- `begin` nodes inherit the constancy of their last expression
 
 ---
 
@@ -247,42 +248,40 @@ Structural cleanup:
   `and_form`, `or_form`, `when_form`, `unless_form`, `define`, `set_form`,
   `lambda`) are compiled directly from their IR data structures.
 
-- **S-expression forms** (`let_form`, `cond`, `do_form`, etc.) delegate to
-  the existing compiler sub-modules (`compiler_bindings.zig`,
-  `compiler_advanced.zig`, etc.) via their `SexprArgs`.
+- **Binding forms** (`let_form`, `let_star`, `letrec`, `letrec_star`) delegate
+  to `compiler_bindings.zig` via their `LetData`.
+
+- **`sexpr_form`** dispatches on its `FormKind` to the existing compiler
+  sub-modules (`compiler_bindings.zig`, `compiler_advanced.zig`, etc.) via its
+  `SexprFormData`.
 
 - **`passthrough`** delegates to `compileExpr()`, the original
   syntax-directed compiler path.
 
 Tail position: `compileFromNode()` uses `node.ann.is_tail` (set by
-`markTailPositions`) instead of recomputing tail status. Primitive
-identification: `node.ann.is_primitive_call` is passed through to call
-emission for optimized dispatch.
-
----
-
-## Standalone Emitter
-
-`ir.zig` contains an `Emitter` struct that compiles IR nodes directly to
-bytecode without going through the full compiler. This is used exclusively
-by the test suite to verify bytecode parity between the IR path and the
-direct compiler.
+`markTailPositions`) instead of recomputing tail status.
 
 ---
 
 ## Testing
 
-`tests_ir.zig` covers four categories:
+`tests_ir.zig` holds ~94 tests in four groups:
 
-- **Parity tests** — verify that IR compilation produces identical bytecode
-  to the direct compiler path for the same expression
-- **Behavioral tests** — verify that IR-compiled code evaluates to the
-  correct result at runtime
-- **Analysis tests** — verify that each analysis pass annotates nodes
-  correctly (tail positions, primitive identification, constant detection)
-- **Optimization tests** — verify that each optimization pass transforms
-  nodes as expected (constant folding, dead branches, boolean simplification,
-  identity elimination, begin simplification)
+- **Behavioral** (`test "IR behavioral: …"`) — verify that IR-compiled code
+  evaluates to the correct result at runtime. The bulk of the file.
+- **Lowering** (`test "IR lowering: …"`) — verify the shape of the lowered
+  tree for a given form
+- **Analysis** (`test "IR analysis: …"`) — verify that `markTailPositions`
+  annotates nodes correctly
+- **Optimization** (`test "IR optimization: …"`, `test "IR fold: …"`,
+  `test "IR opt: …"`) — verify that each optimization pass transforms nodes as
+  expected (constant folding, dead branches, boolean simplification, identity
+  elimination, begin simplification)
+
+There is no longer a bytecode-parity group. It tested `ir.zig`'s standalone
+`Emitter` against the direct compiler path; that emitter (and its own file,
+`ir_emitter.zig`) was removed as a duplicate in v0.13.0, leaving
+`compileFromNode()` as the only IR-to-bytecode path.
 
 ---
 

--- a/docs/dev/understanding-map.md
+++ b/docs/dev/understanding-map.md
@@ -91,8 +91,8 @@ the leakiness measurement.
 
 - **Where:** `src/ir.zig`, `src/compiler_ir.zig`, `src/compiler.zig`
 - **Theory:** the lowering shape (structured nodes vs. `sexpr_form`
-  passthrough), what the 3 analysis passes establish (tail positions above
-  all), what the 5 optimization passes are allowed to assume, and the
+  passthrough), what the tail-position analysis pass establishes, what the
+  5 optimization passes are allowed to assume, and the
   contract emitted bytecode relies on from the VM: register file, frames,
   gap registers.
 - **Why core:** every new form passes through it, and tail-position

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -209,16 +209,25 @@ comptime {
 //
 // Several docs quote these two counts to describe how lowered the IR is, and
 // they went stale at 33 — the pre-`sexpr_form` tag count — for long enough to
-// give readers entirely the wrong picture (kaappi#2102). Change a number here
-// only together with `docs/dev/ir.md`, `docs/dev/architecture.md`,
-// `docs/dev/README.md`, the root `CLAUDE.md` and `README.md`.
+// give readers entirely the wrong picture (kaappi#2102).
+//
+// `.coderabbit.yaml` is in the list because it is *configuration for the
+// automated reviewer*: a stale count there does not merely misinform a human
+// who might check, it feeds the wrong model into every future PR review.
+//
+// As with the OpCode gate in `types.zig`, treat the list as the known set
+// rather than a guarantee, and re-run the search — grep the noun, not the
+// number, since the count appears as "18 node types", "**18** node tags" and
+// "node types (18)" alike, and a bare "18" collides with every SRFI number.
 comptime {
     if (@typeInfo(NodeTag).@"enum".fields.len != 18)
-        @compileError("NodeTag count changed: update docs/dev/ir.md, docs/dev/architecture.md, " ++
-            "docs/dev/README.md, CLAUDE.md and README.md, then update this number");
+        @compileError("NodeTag count changed. Update docs/dev/ir.md, docs/dev/architecture.md, " ++
+            "docs/dev/README.md, CLAUDE.md, README.md and .coderabbit.yaml. Find any others with: " ++
+            "grep -rniE 'node (type|tag)' --include='*.md' --include='*.yaml' . Then update this number.");
     if (@typeInfo(FormKind).@"enum".fields.len != 18)
-        @compileError("FormKind count changed: update the FormKind table in docs/dev/ir.md, " ++
-            "then update this number");
+        @compileError("FormKind count changed. Update the FormKind table in docs/dev/ir.md, and the " ++
+            "count in CLAUDE.md, docs/dev/architecture.md and .coderabbit.yaml. Find any others with: " ++
+            "grep -rniE 'form ?kind' --include='*.md' --include='*.yaml' . Then update this number.");
 }
 
 pub const Annotations = struct {

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -205,6 +205,22 @@ comptime {
     }
 }
 
+// -- Doc sync gate ----------------------------------------------------------
+//
+// Several docs quote these two counts to describe how lowered the IR is, and
+// they went stale at 33 — the pre-`sexpr_form` tag count — for long enough to
+// give readers entirely the wrong picture (kaappi#2102). Change a number here
+// only together with `docs/dev/ir.md`, `docs/dev/architecture.md`,
+// `docs/dev/README.md`, the root `CLAUDE.md` and `README.md`.
+comptime {
+    if (@typeInfo(NodeTag).@"enum".fields.len != 18)
+        @compileError("NodeTag count changed: update docs/dev/ir.md, docs/dev/architecture.md, " ++
+            "docs/dev/README.md, CLAUDE.md and README.md, then update this number");
+    if (@typeInfo(FormKind).@"enum".fields.len != 18)
+        @compileError("FormKind count changed: update the FormKind table in docs/dev/ir.md, " ++
+            "then update this number");
+}
+
 pub const Annotations = struct {
     is_tail: bool = false,
     /// Source span of the form this node was lowered from, if it was a datum the
@@ -1070,7 +1086,13 @@ pub fn markTailPositions(node: *Node, is_tail: bool) void {
 }
 
 // ---------------------------------------------------------------------------
-// Semantic analysis: primitive identification
+// Known-global vocabulary
+//
+// This list outlived the `identifyPrimitives` IR analysis pass it was written
+// for (removed in v0.13.0). Its one remaining caller is the LLVM backend's
+// `isKnownOrReservedGlobal` (`llvm_emit.zig`), deciding global-vs-lexical for
+// free-variable analysis. It is not an IR annotation source — nothing here
+// marks nodes — so do not describe it as an analysis pass.
 // ---------------------------------------------------------------------------
 
 pub fn isKnownGlobal(name: []const u8) bool {

--- a/src/types.zig
+++ b/src/types.zig
@@ -1120,15 +1120,22 @@ pub const OpCode = enum(u8) {
 // -- Doc sync gate ----------------------------------------------------------
 //
 // `docs/dev/bytecode.md` documents this table by count and per-opcode operand
-// width, and `.claude/skills/bytecode-isa/SKILL.md` quotes the count. All three
-// drifted apart — doc 29, skill 32, enum 31 — because nothing tied them
-// together (kaappi#2102). Change the number here only together with those two
-// files. The widths themselves stay pinned by `fixed_operand_bytes` in
-// `vm_dispatch.zig`, which `ensureOperands` enforces at run time.
+// width, and four other files quote the count. They drifted apart — doc 29,
+// skill 32, enum 31 — because nothing tied them together (kaappi#2102). The
+// widths themselves stay pinned by `fixed_operand_bytes` in `vm_dispatch.zig`,
+// which `ensureOperands` enforces at run time.
+//
+// The file list below is the known set at the time of writing, not a guarantee:
+// a list of filenames in a string is its own drift surface, which is exactly
+// the bug class this gate exists for. Re-run the search in the message rather
+// than trusting the list — grep the *noun*, since the count is written at least
+// four ways ("31 opcodes", "31-opcode", "(31 opcodes)", and number-after-noun).
 comptime {
     if (@typeInfo(OpCode).@"enum".fields.len != 31)
-        @compileError("OpCode count changed: update the table in docs/dev/bytecode.md " ++
-            "and the count in .claude/skills/bytecode-isa/SKILL.md, then update this number");
+        @compileError("OpCode count changed. Update the table in docs/dev/bytecode.md, then every " ++
+            "file quoting the count — known: docs/dev/architecture.md, docs/dev/README.md, " ++
+            "docs/dev/claude-code-harness.md, .claude/skills/bytecode-isa/SKILL.md. Find any others " ++
+            "with: grep -rni opcode --include='*.md' --include='*.yaml' . Then update this number.");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types.zig
+++ b/src/types.zig
@@ -1084,38 +1084,52 @@ pub fn boxSet(v: Value, val: Value) void {
 // ---------------------------------------------------------------------------
 
 pub const OpCode = enum(u8) {
-    load_const, // dst:u8, idx:u16
-    load_nil, // dst:u8
-    load_true, // dst:u8
-    load_false, // dst:u8
-    load_void, // dst:u8
-    move, // dst:u8, src:u8
-    get_global, // dst:u8, sym_idx:u16
-    set_global, // sym_idx:u16, src:u8
-    define_global, // sym_idx:u16, src:u8
-    tail_apply, // base:u8, nargs:u8
-    get_upvalue, // dst:u8, idx:u8
-    set_upvalue, // idx:u8, src:u8
-    call, // base:u8, nargs:u8
-    tail_call, // base:u8, nargs:u8
-    @"return", // src:u8
+    load_const, // dst:u16, idx:u16
+    load_nil, // dst:u16
+    load_true, // dst:u16
+    load_false, // dst:u16
+    load_void, // dst:u16
+    move, // dst:u16, src:u16
+    get_global, // dst:u16, sym_idx:u16
+    set_global, // sym_idx:u16, src:u16
+    define_global, // sym_idx:u16, src:u16
+    tail_apply, // base:u16, nargs:u8
+    get_upvalue, // dst:u16, idx:u16
+    set_upvalue, // idx:u16, src:u16
+    call, // base:u16, nargs:u8
+    tail_call, // base:u16, nargs:u8
+    @"return", // src:u16
     jump, // offset:i16
-    jump_false, // test:u8, offset:i16
-    jump_true, // test:u8, offset:i16
-    closure, // dst:u8, idx:u16
-    cons, // dst:u8, car:u8, cdr:u8
-    push_handler, // handler_reg:u8
+    jump_false, // test:u16, offset:i16
+    jump_true, // test:u16, offset:i16
+    closure, // dst:u16, idx:u16, then upvalue_count * (is_local:u8, index:u16)
+    cons, // dst:u16, car:u16, cdr:u16
+    push_handler, // handler_reg:u16
     pop_handler, // (no operands)
     halt,
-    call_global, // base:u8, sym_idx:u16, nargs:u8
-    tail_call_global, // base:u8, sym_idx:u16, nargs:u8
-    box_local, // reg:u8 — wrap register value in a pair (box) for shared mutation
-    get_box_local, // dst:u8, reg:u8 — read car of boxed register
-    set_box_local, // reg:u8, src:u8 — set car of boxed register
-    self_tail_call, // base:u8, nargs:u8
+    call_global, // base:u16, sym_idx:u16, nargs:u8
+    tail_call_global, // base:u16, sym_idx:u16, nargs:u8
+    box_local, // reg:u16 — wrap register value in a pair (box) for shared mutation
+    get_box_local, // dst:u16, reg:u16 — read car of boxed register
+    set_box_local, // reg:u16, src:u16 — set car of boxed register
+    self_tail_call, // base:u16, nargs:u8
     tail_call_cc, // base:u16, dst:u16 (receiver at base+0; captures continuation at dst, tail-calls receiver)
-    tail_eval, // base:u8, nargs:u8 (expr at base+0, optional env at base+1; compiles and tail-calls)
+    tail_eval, // base:u16, nargs:u8 (expr at base+0, optional env at base+1; compiles and tail-calls)
 };
+
+// -- Doc sync gate ----------------------------------------------------------
+//
+// `docs/dev/bytecode.md` documents this table by count and per-opcode operand
+// width, and `.claude/skills/bytecode-isa/SKILL.md` quotes the count. All three
+// drifted apart — doc 29, skill 32, enum 31 — because nothing tied them
+// together (kaappi#2102). Change the number here only together with those two
+// files. The widths themselves stay pinned by `fixed_operand_bytes` in
+// `vm_dispatch.zig`, which `ensureOperands` enforces at run time.
+comptime {
+    if (@typeInfo(OpCode).@"enum".fields.len != 31)
+        @compileError("OpCode count changed: update the table in docs/dev/bytecode.md " ++
+            "and the count in .claude/skills/bytecode-isa/SKILL.md, then update this number");
+}
 
 // ---------------------------------------------------------------------------
 // List helpers


### PR DESCRIPTION
Fixes #2102.

Every claim in the issue was verified against `src/` before changing anything, and all of them held. The fix re-derives both documents from the source and adds the comptime guard the issue suggested.

## What was wrong

**`docs/dev/bytecode.md`** — 29 opcodes documented, 31 in the enum. Register operands documented as u8, but `vm_dispatch.zig` reads `readU16` for every one of them, so **every byte count in the table was wrong** — the part that actually matters, since a reader computing instruction widths gets a stream `validateCode` rejects. Closure capture descriptors are 3 bytes (`is_local:u8` + `index:u16`), not 2.

The table is now re-derived from the `OpCode` enum and the `fixed_operand_bytes` switch, with `tail_call_cc` and `tail_eval` added. I verified the finished table programmatically against both — 31 rows, correct numbering, `Bytes == 1 + fixed_operand_bytes` throughout.

The disassembly example was hand-computed with the old widths, so I replaced it with real `(disassemble fib)` output. It also showed a `; Bytecode (N bytes):` header the disassembler never emits, and described offsets as hex when the format is `{d:0>4}` — decimal.

**`docs/dev/ir.md`** — 33 node tags documented, `NodeTag` has 18. The doc predates the collapse of `cond`/`case`/`guard`/… into the single `sexpr_form` tag with its 18 `FormKind`s, which gives entirely the wrong picture of how lowered the IR is. Three documented `Annotations` fields don't exist, and the two passes that set them (`identifyPrimitives`, `markConstants`) were removed in v0.13.0 — `markTailPositions` is the only pass left. The standalone `Emitter` and its bytecode-parity tests went with them.

## Three findings the issue didn't list

- **`architecture.md` carried a second, undeclared opcode table** describing three opcodes that do not exist (`get_local`, `set_local`, `close_upvalue`) while omitting three that do (`self_tail_call`, `tail_call_cc`, `tail_eval`) — a wrong table whose row count happened to stay right at **31**, so a count check would have passed it. Removed rather than corrected: `bytecode.md` is the declared single source of truth, and duplicating it is how this drifted in the first place.
- **`adding-features.md` instructed the reader** to add a `NodeTag` variant, a `Data` union variant, and switch arms in `identifyPrimitives`/`markConstants` — the pre-`sexpr_form` procedure, contradicting `.claude/rules/compiler-forms.md`. Following it would not have compiled. Rewritten to the current `FormKind` + `sexpr_form_map` path (also `dst: u8` → `u16`, and dispatch is in `compiler_ir.zig`, not `compiler.zig`).
- **The `OpCode` enum's own inline comments** claimed `dst:u8` too, so the source read as wrong as the doc. Fixed.

## The guard

`OpCode`, `NodeTag` and `FormKind` counts are now pinned at comptime in the `diagnostics.zig` style — changing one fails the build with a message naming the files to update. **Each gate was mutation-tested** (count off by one → build fails with the intended message; restored → builds clean), since a guard that never fires is worthless.

This would have caught everything here except `architecture.md`'s table, whose count was coincidentally right — which is exactly why that table is now gone instead of corrected.

## Also swept

`README.md`, `CLAUDE.md`, `docs/dev/README.md`, `understanding-map.md`, `claude-code-harness.md`, and the `/bytecode-isa` skill all repeated the same counts. The skill said **32** — so the count existed as 29 (doc), 32 (skill), and 31 (enum) simultaneously. `CHANGELOG.md` entries are left alone as historical record.

## Verification

- `zig build` clean; `zig fmt --check` clean
- `zig build test` passes
- `npx markdownlint-cli2` — 0 issues in 84 files (the CI `format` job)
- Opcode table checked programmatically against the enum and `fixed_operand_bytes`
- Disassembly example is verbatim real output
- `markTailPositions` propagation rules re-checked against the code

No behavior change — docs, comments, and comptime assertions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)