### PR TITLE
Stop pinning #2027's presence — whether a freed alias still works is luck

### DIFF
--- a/tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
+++ b/tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
@@ -652,8 +652,25 @@
   (let ((r (join-thunk (lambda () (ffi-fn (ffi-open ffi-name) "abs" '(int) 'int)))))
     (test-assert "OUT ffi_function: the join itself does not refuse the handle"
                  (not (and (pair? r) (eq? (car r) 'RAISED))))
-    (test-assert "OUT ffi_function: child-created handle does NOT arrive callable (bug pinned, #2027)"
-                 (not (procedure? r))))
+    ;; FAIL: #2027 — DO NOT re-enable as a bug-presence pin.
+    ;;
+    ;;   (test-assert "OUT ffi_function: child-created handle does NOT arrive
+    ;;                 callable (bug pinned, #2027)"
+    ;;                (not (procedure? r)))
+    ;;
+    ;; This asserted that the bug is still THERE, and whether an aliased
+    ;; handle is still usable after the far heap frees it is an accident of
+    ;; the allocator, not a property of the code.  It held on macOS and
+    ;; failed on freebsd-test, where the handle arrives callable.  Same class
+    ;; as the #2023 pin that held on ReleaseSafe and failed on the Debug leg.
+    ;;
+    ;; The assertion above it is the stable half and is the one the matrix
+    ;; actually needs: `ffi_function` is in the ALIASED class, not the
+    ;; REFUSED class, and "the join does not refuse it" is exactly that
+    ;; classification.  When #2027 is fixed, that assertion flips — a fixed
+    ;; implementation must refuse or copy, not alias — so the row still has
+    ;; a tripwire without depending on how a freed pointer happens to behave.
+    (if #f #f))
 
   ;; ffi_callback is the one refused FFI tag, and docs/dev/thread-value-sharing.md
   ;; records it as "not probed". Only some signatures are supported, so this


### PR DESCRIPTION
**`main` is red on five platform legs** (`freebsd-test`, `netbsd-test`, `windows-arm-test`, `windows-x64-test`, `test (ubuntu-24.04-arm, ReleaseSafe)`) from #2030. This fixes it.

The failing assertion pinned the **presence** of #2027:

```scheme
(test-assert "OUT ffi_function: child-created handle does NOT arrive callable (bug pinned, #2027)"
             (not (procedure? r)))
```

Whether a freed pointer still behaves like a live one is an accident of the allocator, not a property of the code. It held on macOS and fails on FreeBSD, where the handle arrives callable.

**This is the third bug-presence pin in this campaign to fail on a platform other than its author's** — #2023 held on ReleaseSafe and failed on Debug (94/200 deep keys found under Debug, 6/200 under ReleaseSafe); this one held on macOS and failed on FreeBSD. Both were written because a real bug had been found and pinning it seemed responsible. The pattern is clear enough to state as a rule: **assert the specified property, never the current symptom of a bug.**

The assertion immediately above is the stable half and is the one the matrix actually needs — `ffi_function` is in the **aliased** class, not the **refused** class, and *"the join does not refuse it"* is exactly that classification. When #2027 is fixed, that assertion flips, because a correct implementation must refuse or copy rather than alias. So the row keeps its tripwire without depending on freed-pointer behaviour.

122 → 121 assertions; verified locally, no stray output.

**How this reached main:** #2030 merged at 14:41 on checks green for an *earlier* push; the rebase-triggered run completed 15:03–15:45 and failed. A rebase followed quickly by a merge can land on stale green — worth knowing for the remaining units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
