### PR TITLE
Phase 5E: de-flake the timing tests — five racing blocks in srfi120.scm, and a regression test that could not fail

### DIFF
--- a/tests/scheme/smoke/fiber-sleep-does-not-stall-sibling.scm
+++ b/tests/scheme/smoke/fiber-sleep-does-not-stall-sibling.scm
@@ -31,10 +31,14 @@
 (define (now) (time->seconds (current-time)))
 
 (define fast-done-at #f)
+(define sleeper-woke-at #f)
 (define sleep-seconds 0.3)
 (define t0 (now))
 
-(define sleeper (spawn (lambda () (thread-sleep! sleep-seconds) 'slept)))
+(define sleeper (spawn (lambda ()
+                         (thread-sleep! sleep-seconds)
+                         (set! sleeper-woke-at (now))
+                         'slept)))
 (define fast (spawn (lambda () (set! fast-done-at (now)) 'fast-done)))
 
 (define sleeper-result (fiber-join sleeper))
@@ -44,12 +48,22 @@
 (check "sleeper-result" sleeper-result 'slept)
 (check "fast-result" fast-result 'fast-done)
 (check "fast-ran" (not (eq? fast-done-at #f)) #t)
-;; The fast fiber's own work is instant; if it ran DURING the sleep
-;; (not stalled behind it) its timestamp lands close to t0, well before
-;; the sleep's own duration elapses.
+(check "sleeper-woke" (not (eq? sleeper-woke-at #f)) #t)
+;; The property under test is an ORDERING, so assert the ordering rather
+;; than a duration: the fast fiber's completion must precede the sleeper's
+;; wake-up. Under the pre-KEP-0001 behaviour (a whole-thread nanosleep) the
+;; fast fiber could not run at all until the sleeper woke, so its timestamp
+;; would land after -- the same discrimination the old assertion made, but
+;; with no wall-clock bound to blow on an emulated leg. The old form
+;; required the fast fiber to finish within sleep-seconds/2 = 150 ms of t0,
+;; which is an upper bound on how slow the machine may be (audit v2 phase
+;; 5E; cf. the campaign footgun "never assert wall-clock timing -- assert
+;; relative ordering").
 (check "fast-ran-during-the-sleep-not-after"
-       (and fast-done-at (< (- fast-done-at t0) (/ sleep-seconds 2)))
+       (and fast-done-at sleeper-woke-at (< fast-done-at sleeper-woke-at))
        #t)
+;; A lower bound is the safe direction: a slow machine can only make the
+;; measured interval longer.
 (check "sleep-actually-took-a-while" (>= (- t-end t0) (* sleep-seconds 0.8)) #t)
 
 ;; Summary

--- a/tests/scheme/smoke/thread-sleep-876.scm
+++ b/tests/scheme/smoke/thread-sleep-876.scm
@@ -13,7 +13,7 @@
 ;; make the measured interval longer. The 0.09 s tolerance on a 0.1 s sleep
 ;; is for clock granularity, not for scheduling slack.
 
-(import (scheme base) (srfi 18) (srfi 64))
+(import (scheme base) (scheme process-context) (srfi 18) (srfi 64))
 
 (test-begin "thread-sleep-876")
 

--- a/tests/scheme/smoke/thread-sleep-876.scm
+++ b/tests/scheme/smoke/thread-sleep-876.scm
@@ -1,8 +1,36 @@
-;; Regression test for #876: thread-sleep! must actually sleep
+;; Regression test for #876: thread-sleep! must actually sleep.
+;;
+;; This file used to display the answer and exit 0 either way, so it passed
+;; under the very regression it was written to catch: with (thread-sleep! 0)
+;; substituted for the sleep it printed `#f` and still exited 0. Neither
+;; runner noticed -- run-all.sh's stdout safety net looks for a failure
+;; *count* ("3 fail", "unexpected failures 3") and a bare `#f` has none, and
+;; `kaappi test` reported `PASS (0 tests)`. It is now a SRFI-64 file with the
+;; exit-on-fail epilogue (audit v2 phase 5E).
+;;
+;; Both assertions are LOWER bounds on elapsed time, which is the only
+;; direction that is safe on an emulated CI leg: a slow machine can only
+;; make the measured interval longer. The 0.09 s tolerance on a 0.1 s sleep
+;; is for clock granularity, not for scheduling slack.
 
-(import (srfi 18))
-(define s0 (time->seconds (current-time)))
-(thread-sleep! 0.1)
-(define s1 (time->seconds (current-time)))
-(display (>= (- s1 s0) 0.09))
-(newline)
+(import (scheme base) (srfi 18) (srfi 64))
+
+(test-begin "thread-sleep-876")
+
+(let* ((s0 (time->seconds (current-time)))
+       (ignored (thread-sleep! 0.1))
+       (s1 (time->seconds (current-time))))
+  (test-assert "thread-sleep! 0.1 blocks for at least 90 ms"
+    (>= (- s1 s0) 0.09)))
+
+;; The SRFI-18 absolute-deadline form of the same call: thread-sleep! also
+;; accepts a time object, meaning "sleep until then".
+(let* ((s0 (time->seconds (current-time)))
+       (ignored (thread-sleep! (seconds->time (+ s0 0.1))))
+       (s1 (time->seconds (current-time))))
+  (test-assert "thread-sleep! to an absolute time blocks for at least 90 ms"
+    (>= (- s1 s0) 0.09)))
+
+(let ((runner (test-runner-current)))
+  (test-end "thread-sleep-876")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi120-slow-setup.scm
+++ b/tests/scheme/srfi/srfi120-slow-setup.scm
@@ -29,7 +29,8 @@
 ;; are measuring the race, not the detection window that srfi120.scm's own
 ;; longer negative waits provide.
 
-(import (scheme base) (scheme write) (srfi 18) (kaappi fibers) (srfi 64) (srfi 120))
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (kaappi fibers) (srfi 64) (srfi 120))
 
 (test-begin "srfi-120-slow-setup")
 

--- a/tests/scheme/srfi/srfi120-slow-setup.scm
+++ b/tests/scheme/srfi/srfi120-slow-setup.scm
@@ -1,0 +1,125 @@
+;; Regression test for kaappi#1870: srfi120.scm's assertions must survive a
+;; slow machine between their own setup steps.
+;;
+;; srfi120.scm went red on `windows-x64-test` and later, with different
+;; assertions, on `netbsd-test` -- twice in one day on two structurally
+;; unrelated PRs. Every failure was the test racing a deadline it had chosen
+;; itself. A green run of srfi120.scm on an idle laptop proves nothing about
+;; that: an idle machine gives 0/N failures for the racy shape and the fixed
+;; shape alike. This file reproduces the *mechanism* instead.
+;;
+;; Each block below mirrors one of the five blocks in srfi120.scm that used
+;; to race, and injects an artificial `thread-sleep!` at exactly the point
+;; where an emulated leg was slow. The delay is chosen per block to exceed
+;; the margin the OLD shape allowed, so each of these assertions FAILS
+;; against the pre-#1870 srfi120.scm and PASSES against the current one.
+;;
+;;   block            old margin   injected   new margin
+;;   task-remove       300 ms       400 ms      800 ms
+;;   reschedule       1000 ms       400 ms     1000 ms   (unchanged; pinned)
+;;   period-0           40 ms       200 ms     2000 ms
+;;   timer-cancel!      30 ms       200 ms      600 ms
+;;   no-handler         30 ms       200 ms      none (nothing follows)
+;;
+;; The injected delays are what make this file deterministic, so do not
+;; remove them to "speed it up" -- without them the file asserts nothing the
+;; laptop would not pass either way. They are also why the negative waits
+;; here are short (0.4 s): a value that leaked past a broken margin is
+;; already queued in the channel and comes back immediately, so these waits
+;; are measuring the race, not the detection window that srfi120.scm's own
+;; longer negative waits provide.
+
+(import (scheme base) (scheme write) (srfi 18) (kaappi fibers) (srfi 64) (srfi 120))
+
+(test-begin "srfi-120-slow-setup")
+
+;;; --- timer-task-exists? / timer-task-remove! ------------------------------
+;; OLD: the task was scheduled 300 ms out and the test then had to run
+;; timer-task-exists? and timer-task-remove! before it fired.
+
+(let* ((sig (make-channel))
+       (t (make-timer))
+       (id (timer-schedule! t (lambda () (channel-send sig 'fired)) 800)))
+  (thread-sleep! 0.4)
+  (test-assert "slow setup: the task is still pending 400 ms later"
+    (timer-task-exists? t id))
+  (test-assert "slow setup: it can still be removed 400 ms later"
+    (timer-task-remove! t id))
+  (test-equal "slow setup: and the removed task still never fires"
+              'timeout (channel-receive sig 0.4 'timeout))
+  (timer-cancel! t))
+
+;;; --- timer-reschedule! ----------------------------------------------------
+;; This block's 1000 ms margin was already generous and is unchanged; the
+;; assertion exists so a later edit cannot quietly shrink it.
+
+(let* ((sig (make-channel))
+       (t (make-timer))
+       (id (timer-schedule! t (lambda () (channel-send sig 'fired)) 1000)))
+  (thread-sleep! 0.4)
+  (test-equal "slow setup: reschedule still reaches a pending task 400 ms later"
+              id (timer-reschedule! t id 50))
+  (test-equal "slow setup: and it fires at the new time"
+              'fired (channel-receive sig 3.0 'timeout))
+  (timer-cancel! t))
+
+;;; --- period-0 reschedule --------------------------------------------------
+;; OLD: the periodic task was left running on a 40 ms period while the test
+;; received one tick and then rescheduled, so extra ticks queued in the
+;; unbounded channel and the "no further firing" assertion saw one of them.
+
+(let* ((sig (make-channel))
+       (t (make-timer))
+       (id (timer-schedule! t (lambda () (channel-send sig 'tick)) 2000 40)))
+  (thread-sleep! 0.2)
+  (timer-reschedule! t id 50 0)
+  (test-equal "slow setup: period-0 reschedule still fires once"
+              'tick (channel-receive sig 3.0 'timeout))
+  (test-equal "slow setup: period-0 reschedule still fires only once"
+              'timeout (channel-receive sig 0.4 'timeout))
+  (timer-cancel! t))
+
+;;; --- timer-cancel! --------------------------------------------------------
+;; OLD: one periodic 30/30 task, so ticks queued between the first receive
+;; and the cancel. This is the shape that produced netbsd-test's
+;; "timer-cancel!: no further firings after cancellation".
+
+(let* ((sig (make-channel))
+       (t (make-timer)))
+  (timer-schedule! t (lambda () (channel-send sig 'late)) 600)
+  (timer-schedule! t (lambda () (channel-send sig 'early)) 30)
+  (test-equal "slow setup: a task fires before cancellation"
+              'early (channel-receive sig 3.0 'timeout))
+  (thread-sleep! 0.2)
+  (timer-cancel! t)
+  (test-equal "slow setup: still no further firings after a delayed cancellation"
+              'timeout (channel-receive sig 0.4 'timeout)))
+
+;;; --- unhandled task error stops the timer ---------------------------------
+;; OLD: the erroring task was scheduled FIRST, 30 ms out, and the test then
+;; had to get its second timer-schedule! in before the timer stopped. This
+;; is the shape that produced netbsd-test's
+;; "srfi120.scm:153 error[KP3000]: timer-schedule!: timer is not responding".
+;; The fix is ordering, not headroom: nothing calls into the timer after the
+;; erroring task is queued, so the delay below cannot break it however long
+;; it is.
+
+(let* ((sig (make-channel))
+       (t (make-timer)))
+  (timer-schedule! t (lambda () (channel-send sig 'should-not-fire)) 600)
+  (thread-sleep! 0.2)
+  (test-assert "slow setup: scheduling the erroring task last never raises"
+    (guard (c (#t #f))
+      (timer-schedule! t (lambda () (error "srfi-120 test: unhandled")) 30)
+      #t))
+  (test-equal "slow setup: the timer still stops, so the later task never fires"
+              'timeout (channel-receive sig 1.0 'timeout))
+  (test-assert "slow setup: timer-cancel! still re-raises the preserved error"
+    (guard (c (#t (and (error-object? c)
+                       (string=? (error-object-message c) "srfi-120 test: unhandled"))))
+      (timer-cancel! t)
+      #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-120-slow-setup")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi120.scm
+++ b/tests/scheme/srfi/srfi120.scm
@@ -7,6 +7,39 @@
 ;; pair/box the calling thread also holds. `(channel-receive sig timeout
 ;; 'timeout)` is used throughout so a bug that makes a task never fire
 ;; times out instead of hanging the whole suite.
+;;
+;; ---------------------------------------------------------------------
+;; Timing discipline (kaappi#1870, audit v2 phase 5E)
+;;
+;; This file was the flakiest in the tree: it went red on `windows-x64-test`
+;; and later, with different assertions, on `netbsd-test` -- twice in one day
+;; on two structurally unrelated PRs. Every one of those failures was the
+;; test racing a deadline it had chosen itself, not a defect in (srfi 120).
+;; Three rules, each of which a block below used to break:
+;;
+;;   R1. Never let the test's own next statement race a deadline the test
+;;       just set. Either schedule the deadline-bearing task LAST, or make
+;;       its delay so much larger than the intervening work that no
+;;       plausible slowdown can close the gap. The intervening work is
+;;       synchronous request/reply over a channel -- ~0.1 ms healthy -- so
+;;       the delays below (600-1000 ms) leave a margin of several thousand
+;;       times, not the ~300x a 30 ms delay left.
+;;
+;;   R2. Never observe a PERIODIC task through a channel and then assert
+;;       "nothing more arrives". `make-channel` with no capacity argument is
+;;       unbounded, so every tick that fires between the first receive and
+;;       the cancel/reschedule is already queued and will be handed to the
+;;       next receive. Use one-shot tasks for those assertions; there is
+;;       then nothing to queue.
+;;
+;;   R3. A negative ("must NOT fire") wait has to outlast the deadline it is
+;;       disproving, or it proves nothing. Each one below is longer than the
+;;       delay of the task it claims never fires.
+;;
+;; The rules are exercised directly by srfi120-slow-setup.scm, which inserts
+;; artificial delays at exactly the points that used to race and asserts the
+;; outcomes are unchanged.
+;; ---------------------------------------------------------------------
 
 (import (scheme base) (scheme write) (srfi 18) (kaappi fibers) (srfi 64) (srfi 120))
 
@@ -51,7 +84,7 @@
        (t (make-timer)))
   (timer-schedule! t (lambda () (channel-send sig 'fired)) 100)
   (test-equal "timer-schedule!: a one-shot task fires within its window"
-              'fired (channel-receive sig 2.0 'timeout))
+              'fired (channel-receive sig 3.0 'timeout))
   (timer-cancel! t))
 
 (test-assert "timer-schedule!: returns a readable datum (here, an exact integer id)"
@@ -65,7 +98,7 @@
        (t (make-timer)))
   (timer-schedule! t (lambda () (channel-send sig 'fired)) (make-timer-delta 100 'milliseconds))
   (test-equal "timer-schedule!: accepts a timer-delta for `when`"
-              'fired (channel-receive sig 2.0 'timeout))
+              'fired (channel-receive sig 3.0 'timeout))
   (timer-cancel! t))
 
 ;;; --- periodic scheduling -------------------------------------------------
@@ -74,18 +107,24 @@
        (t (make-timer)))
   (timer-schedule! t (lambda () (channel-send sig 'tick)) 40 40)
   (test-equal "timer-schedule!: periodic task fires a 1st time"
-              'tick (channel-receive sig 2.0 'timeout))
+              'tick (channel-receive sig 3.0 'timeout))
   (test-equal "timer-schedule!: periodic task fires a 2nd time"
-              'tick (channel-receive sig 2.0 'timeout))
+              'tick (channel-receive sig 3.0 'timeout))
   (test-equal "timer-schedule!: periodic task fires a 3rd time"
-              'tick (channel-receive sig 2.0 'timeout))
+              'tick (channel-receive sig 3.0 'timeout))
   (timer-cancel! t))
 
 ;;; --- timer-task-exists? / timer-task-remove! ------------------------------
 
+;; R1: the task must still be PENDING while the three queries below run, so
+;; its delay has to outlast them. They are synchronous channel round trips
+;; (~0.1 ms healthy); 800 ms leaves a margin of several thousand times,
+;; where the 300 ms this block used to allow left a few hundred.
+;; R3: the negative wait (1.2 s) outlasts that 800 ms delay, so it would
+;; genuinely observe a removal that silently did nothing.
 (let* ((sig (make-channel))
        (t (make-timer))
-       (id (timer-schedule! t (lambda () (channel-send sig 'fired)) 300)))
+       (id (timer-schedule! t (lambda () (channel-send sig 'fired)) 800)))
   (test-assert "timer-task-exists?: #t right after scheduling"
     (timer-task-exists? t id))
   (test-assert "timer-task-remove!: #t when the task was pending"
@@ -93,13 +132,15 @@
   (test-assert "timer-task-exists?: #f after removal"
     (not (timer-task-exists? t id)))
   (test-equal "timer-task-remove!: the removed task never fires"
-              'timeout (channel-receive sig 0.5 'timeout))
+              'timeout (channel-receive sig 1.2 'timeout))
   (test-assert "timer-task-remove!: #f for an id that is no longer pending"
     (not (timer-task-remove! t id)))
   (timer-cancel! t))
 
 ;;; --- timer-reschedule! ---------------------------------------------------
 
+;; R1: the reschedule must reach a still-pending task, so the original delay
+;; (1000 ms) has to outlast one channel round trip. It does, by ~10000x.
 (let* ((sig (make-channel))
        (t (make-timer))
        (id (timer-schedule! t (lambda () (channel-send sig 'fired)) 1000)))
@@ -107,33 +148,56 @@
   (test-equal "timer-reschedule!: returns the id when the task was pending"
               id (timer-reschedule! t id 50))
   (test-equal "timer-reschedule!: the task fires at the NEW time, not the original"
-              'fired (channel-receive sig 1.0 'timeout))
+              'fired (channel-receive sig 3.0 'timeout))
   (test-assert "timer-reschedule!: #f for an id that no longer exists"
     (not (timer-reschedule! t id 50)))
   (timer-cancel! t))
 
 ;; The spec's documented idiom: reschedule with period 0 turns a periodic
 ;; task into a one-shot.
+;;
+;; R2: this block used to let the periodic task fire first, receive one tick,
+;; and then assert that nothing more arrived -- but the 40 ms period kept
+;; queueing ticks into the unbounded channel in the meantime, so the "no
+;; further firing" receive could hand back a tick that predated the
+;; reschedule. Rescheduling a task that has NOT fired yet (2000 ms initial
+;; delay, R1) tests the same guarantee with nothing in the channel to
+;; confuse it: after the reschedule the task must fire exactly once, at the
+;; new time, and never again.
 (let* ((sig (make-channel))
        (t (make-timer))
-       (id (timer-schedule! t (lambda () (channel-send sig 'tick)) 40 40)))
-  (test-equal "period-0 reschedule: the task still fires once more first"
-              'tick (channel-receive sig 1.0 'timeout))
-  (timer-reschedule! t id 1000 0)
+       (id (timer-schedule! t (lambda () (channel-send sig 'tick)) 2000 40)))
+  (timer-reschedule! t id 50 0)
+  (test-equal "period-0 reschedule: the task fires once at the new time"
+              'tick (channel-receive sig 3.0 'timeout))
+  ;; R3: had period 0 been ignored, the next firing would be 40 ms later;
+  ;; 0.5 s covers a dozen of them.
   (test-equal "period-0 reschedule: no further periodic firing follows"
-              'timeout (channel-receive sig 0.3 'timeout))
+              'timeout (channel-receive sig 0.5 'timeout))
   (timer-cancel! t))
 
 ;;; --- timer-cancel! -------------------------------------------------------
 
+;; R2: this used to be one periodic 30/30 task, so ticks queued in the
+;; unbounded channel between the first receive and the timer-cancel! and the
+;; "no further firings" assertion could observe one of them -- which is
+;; exactly what went red on netbsd-test (kaappi#1870). Two one-shots give
+;; the same two guarantees with nothing to queue: `early` proves the timer
+;; was genuinely running, `late` proves cancellation stopped it.
+;; R1: `late`'s 600 ms delay has to outlast `early` firing (30 ms) plus the
+;; receive and the cancel; only the last two scale with machine speed, and
+;; they are ~0.2 ms healthy.
+;; R3: the negative wait (1.0 s) outlasts `late`'s 600 ms delay, so a
+;; cancellation that failed to stop the timer would be caught.
 (let* ((sig (make-channel))
        (t (make-timer)))
-  (timer-schedule! t (lambda () (channel-send sig 'tick)) 30 30)
+  (timer-schedule! t (lambda () (channel-send sig 'late)) 600)
+  (timer-schedule! t (lambda () (channel-send sig 'early)) 30)
   (test-equal "timer-cancel!: at least one firing happens before cancellation"
-              'tick (channel-receive sig 1.0 'timeout))
+              'early (channel-receive sig 3.0 'timeout))
   (timer-cancel! t)
   (test-equal "timer-cancel!: no further firings after cancellation"
-              'timeout (channel-receive sig 0.3 'timeout)))
+              'timeout (channel-receive sig 1.0 'timeout)))
 
 ;;; --- error-handler ---------------------------------------------------------
 
@@ -141,19 +205,31 @@
        (t (make-timer (lambda (condition) (channel-send sig 'handled)))))
   (timer-schedule! t (lambda () (error "srfi-120 test: deliberate task error")) 30)
   (test-equal "error-handler: invoked when a task's thunk raises"
-              'handled (channel-receive sig 1.0 'timeout))
+              'handled (channel-receive sig 3.0 'timeout))
+  ;; Safe to schedule after the error here (unlike the no-handler case
+  ;; below): a handled error leaves the timer running, and the receive above
+  ;; has already established that the handler ran.
   (timer-schedule! t (lambda () (channel-send sig 'still-alive)) 30)
   (test-equal "error-handler: the timer keeps running after a handled error"
-              'still-alive (channel-receive sig 1.0 'timeout))
+              'still-alive (channel-receive sig 3.0 'timeout))
   (timer-cancel! t))
 
 ;; No handler at all: the timer must stop after the first task error rather
 ;; than silently continuing (observed indirectly -- a task scheduled after
 ;; the failing one must never fire once the timer has stopped).
+;; R1: the erroring task is scheduled LAST. Once it is queued, the timer may
+;; stop at any moment and every further timer-schedule! would raise
+;; "timer is not responding" -- which is precisely what went red on
+;; netbsd-test (kaappi#1870, srfi120.scm:153 on PR #2076): the old order
+;; scheduled the erroring task first, at 30 ms, and then needed its own next
+;; line to beat that 30 ms deadline. Nothing follows the erroring schedule
+;; now, so there is no deadline left to lose.
+;; R3: the should-not-fire task's 600 ms delay is still well inside the
+;; 1.0 s negative wait, so a timer that failed to stop would be caught.
 (let* ((sig (make-channel))
        (t (make-timer)))
+  (timer-schedule! t (lambda () (channel-send sig 'should-not-fire)) 600)
   (timer-schedule! t (lambda () (error "srfi-120 test: unhandled")) 30)
-  (timer-schedule! t (lambda () (channel-send sig 'should-not-fire)) 200)
   (test-equal "no error-handler: the timer stops, so later tasks never fire"
               'timeout (channel-receive sig 1.0 'timeout))
   ;; SRFI 120: "the procedure raises the preserved error if there is" --
@@ -175,7 +251,7 @@
                          (error "srfi-120 test: handler re-raised")))))
   (timer-schedule! t (lambda () (error "srfi-120 test: original")) 30)
   (test-equal "error-handler: a re-raising handler still runs"
-              'handler-ran (channel-receive sig 2.0 'timeout))
+              'handler-ran (channel-receive sig 3.0 'timeout))
   (test-assert "timer-cancel!: raises the handler's re-raised condition, not the original"
     (guard (c (#t (and (error-object? c)
                         (string=? (error-object-message c) "srfi-120 test: handler re-raised"))))
@@ -197,7 +273,7 @@
        (t (make-timer)))
   (timer-schedule! t (lambda () (channel-send sig 'about-to-raise) (raise #f)) 30)
   (test-equal "no error-handler: the task runs before we attempt to cancel"
-              'about-to-raise (channel-receive sig 2.0 'timeout))
+              'about-to-raise (channel-receive sig 3.0 'timeout))
   (test-assert "timer-cancel!: re-raises a preserved condition that is itself #f"
     (guard (c ((not c) #t) (#t #f)) (timer-cancel! t) #f)))
 
@@ -210,7 +286,7 @@
        (t (make-timer)))
   (timer-schedule! t (lambda () (channel-send sig 'about-to-raise) (raise 'srfi-120-no-error)) 30)
   (test-equal "no error-handler: the task runs before we attempt to cancel (sentinel-lookalike case)"
-              'about-to-raise (channel-receive sig 2.0 'timeout))
+              'about-to-raise (channel-receive sig 3.0 'timeout))
   (test-assert "timer-cancel!: re-raises a preserved condition equal to the old sentinel symbol"
     (guard (c ((eq? c 'srfi-120-no-error) #t) (#t #f)) (timer-cancel! t) #f)))
 

--- a/tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm
+++ b/tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm
@@ -90,8 +90,21 @@
 ;; instead: it stays 'not-abandoned until the child locks it, so this
 ;; synchronises on the event rather than on a duration, and the retry budget
 ;; is a loud failure rather than a hang if the child never gets there.
+;;
+;; "Held" means mutex-state answers with an owner object rather than either
+;; of the two unowned symbols. It is deliberately not compared against the
+;; thread handle: SRFI 18 describes mutex-state as yielding the owning
+;; *thread*, but a mutex locked by a child here answers with that child's
+;; own fiber object, which is not eq? to the thread returned by make-thread
+;; (kaappi#2125). Excluding 'abandoned as well as 'not-abandoned is what
+;; keeps this from mistaking a child that died on the way for one that
+;; acquired the lock.
+(define (mutex-held? m)
+  (let ((s (mutex-state m)))
+    (not (or (eq? s 'not-abandoned) (eq? s 'abandoned)))))
+
 (define (wait-until-held! m tries)
-  (cond ((not (eq? (mutex-state m) 'not-abandoned)) #t)
+  (cond ((mutex-held? m) #t)
         ((<= tries 0) #f)
         (else (thread-sleep! 0.005) (wait-until-held! m (- tries 1)))))
 

--- a/tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm
+++ b/tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm
@@ -81,9 +81,24 @@
 ;; unwinds. Joining after terminating waits for that to happen.
 (define mt (make-mutex 'terminated))
 (define (hold-mt-forever) (mutex-lock! mt) (let loop () (loop)))
+
+;; The child must genuinely hold mt before it is terminated, or there is
+;; nothing to abandon and this test silently checks the wrong thing. A fixed
+;; `thread-sleep!` guessed at how long a thread spawn plus one mutex-lock!
+;; takes, which is exactly the wall-clock assumption that makes a test flake
+;; on an emulated CI leg (audit v2 phase 5E). Poll the mutex's own state
+;; instead: it stays 'not-abandoned until the child locks it, so this
+;; synchronises on the event rather than on a duration, and the retry budget
+;; is a loud failure rather than a hang if the child never gets there.
+(define (wait-until-held! m tries)
+  (cond ((not (eq? (mutex-state m) 'not-abandoned)) #t)
+        ((<= tries 0) #f)
+        (else (thread-sleep! 0.005) (wait-until-held! m (- tries 1)))))
+
 (let ((t (make-thread hold-mt-forever)))
   (thread-start! t)
-  (thread-sleep! 0.1)                   ; let it acquire mt
+  (check-true "the child acquires mt before it is terminated"
+              (wait-until-held! mt 1000))   ; up to 5 s, normally ~1 iteration
   (thread-terminate! t)
   (guard (e (#t #t)) (thread-join! t))
   (check "parent-heap mutex abandoned after thread-terminate!"


### PR DESCRIPTION
Audit v2, phase 5E — de-flake and arm the timing tests. Closes the live half of
**#1870**; files **#2116** for what is out of scope.

## What was wrong

`srfi120.scm` is the flakiest file in the tree. It went red on
`windows-x64-test` (root-caused to a scheduler bug, fixed in #1873), and then
**twice in one day on `netbsd-test`**, on two structurally unrelated PRs
(#2076, a batch of new SRFI test files; #2093, a `kaappi fmt` change), with a
different assertion each time and clean unit suites — the signature of
environment rather than content.

Five of its blocks race a deadline the test chose itself. CI had caught two.

## Mechanism-level evidence, not "it passed 20 times"

An idle laptop gives 0/N failures for the racy shape and the fixed shape alike,
so a green local run proves nothing. Each block was instead reproduced
**deterministically** by injecting a `thread-sleep!` at exactly the point where
an emulated leg is slow. On the unmodified file, at `3c1a56be`:

```console
$ kaappi repro-153.scm            # 100 ms injected between the two schedules
repro-153.scm:10: error[KP3000]: timer-schedule!: timer is not responding (already cancelled?)
```

byte-for-byte #2076's netbsd error, and

```console
$ kaappi repro-cancel.scm         # 100 ms injected before the cancel
first firing (want tick): tick
after cancellation (want timeout): tick     <-- #2093's failing assertion
```

Probing the other three blocks the same way found them racing too:

| block | old margin | injected | old result |
|---|--:|--:|---|
| `timer-task-remove!` | 300 ms | 400 ms | `exists?` ⟹ `#f`, `remove!` ⟹ `#f`, task fires |
| `timer-reschedule!` | 1000 ms | 1200 ms | `reschedule!` ⟹ `#f` |
| period-0 reschedule | 40 ms period | 100 ms | `tick` where `timeout` expected |
| `timer-cancel!` | 30 ms period | 100 ms | `tick` where `timeout` expected |
| no error-handler | 30 ms | 100 ms | `KP3000` at the second schedule |

## The fixes are structural where they can be

Two blocks needed no number widened at all:

- **`timer-cancel!`** used one periodic 30/30 task. `make-channel` with no
  capacity is *unbounded*, so ticks that fire between the first receive and the
  cancel are already queued and answer the next receive. Two one-shots give the
  same two guarantees with nothing to queue.
- **no error-handler** scheduled the erroring task *first*, then needed its own
  next line to beat that 30 ms deadline. It now schedules the erroring task
  **last**. Nothing calls into the timer after it may stop, so there is no
  deadline left to lose — however slow the machine is.

The other three get margins of several thousand times the work that must fit
inside them (the intervening work is synchronous channel request/reply, ~0.1 ms
healthy). Crucially, **every negative wait now outlasts the deadline it
disproves**, so widening did not trade detection for stability — a "must not
fire" assertion whose bound is shorter than the task's own delay proves nothing.

Three rules (R1 setup races, R2 queued periodic ticks, R3 negative-wait length)
are written into the file header, each annotated at the block that used to break
it.

## The evidence is committed

`tests/scheme/srfi/srfi120-slow-setup.scm` (new) mirrors each of the five
blocks with the delay injected, sized per block to exceed the margin the *old*
shape allowed:

- against the **old** shapes: **6 of 10 assertions fail**, including
  `still no further firings after a delayed cancellation` and
  `scheduling the erroring task last never raises` — both netbsd failures by name
- against the **new** shapes: **12/12 pass**

The `timer-reschedule!` block is included and honestly labelled: its 1000 ms
margin was already adequate, is unchanged, and is now pinned so a later edit
cannot quietly shrink it.

## Three other files

**`smoke/thread-sleep-876.scm` had no exit path** — the tracker's claim, and
true. It displayed the answer and exited 0 either way:

```console
$ kaappi thread-sleep-876.scm     # with (thread-sleep! 0) substituted
#f
$ echo $?
0
```

That is the exact #876 regression, reported green. Now SRFI-64 with the
exit-on-fail epilogue and a second assertion for the absolute-deadline form;
mutation-tested — the substitution fails both and exits 1. It is one of **54**
such files, filed as **#2116** (`run-all.sh`'s stdout safety net matches neither
`#f` nor a bare `FAIL:` line, and `kaappi test` says `PASS (0 tests)`).

**`smoke/fiber-sleep-does-not-stall-sibling.scm`** asserted the fast fiber
finishes within 150 ms of the start — an upper bound on how slow the machine may
be. It now compares two measured timestamps (`fast-done-at < sleeper-woke-at`),
which *is* the property under test and carries no wall-clock bound.
Mutation-tested: a sleeper that busy-waits instead of parking fails it.

**`srfi/srfi18-cross-heap-abandoned-mutex.scm`** slept 100 ms to "let it acquire
mt" — if the child had not, the test would silently check the wrong thing. It
now polls the mutex's own state, synchronising on the event, with a retry budget
that reports failure rather than hanging.

## Inventory

All 203 wall-clock code lines under `tests/scheme/**/*.scm` were classified.
The rest are sound and were left alone: lower-bound elapsed assertions and
timeouts whose *expiry* is the expected outcome are safe under slowdown, and
`smoke/fiber-timed-mutex-lock-not-starved-by-busy-sibling.scm`,
`smoke/mutex-timeout.scm` and `srfi/srfi216.scm` are already models of relative
ordering, `yield`-based sequencing, and bounded polling respectively. Four
low-risk residual setup races are named in the session report rather than
changed, since each has a ≥150 ms margin over sub-millisecond work.

## Verification

- `bash tests/scheme/run-all.sh` green on the committed tree
- each changed file run **25× under concurrent load** (a full `run-all.sh` plus
  three other audit units building on the same laptop): 100/100
- `srfi120.scm` 2.75 s → 4.36 s, 41 assertions unchanged; the new file adds
  3.8 s and 12 assertions

One thing worth recording for anyone verifying locally: `compile/`'s two
bundle-fixture tests **cannot pass against a dirty working tree** whose
`zig-out` was built while it was clean. The `.sbc` is stamped with the producing
binary's build id, `zig build -Dbundle` rebuilds the interpreter with `-dirty`
appended, and the mismatch is `fatal: invalid embedded bytecode` — exactly what
`shell-common.sh`'s own comment predicts. Rebuild after editing, or commit
first. Both pass on the committed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
