### PR TITLE
Phase 4E: .sbc cache coverage — every constant tag round-trips clean; a HIT unfreezes literals, unshares datum labels, and empties the macro table

### DIFF
--- a/tests/scheme/differential/probes/sbc-closures.scm
+++ b/tests/scheme/differential/probes/sbc-closures.scm
@@ -1,0 +1,94 @@
+;; Probe: the *code* half of a `.sbc` round trip — nested functions, upvalues,
+;; and the control forms whose bytecode the deserialiser has to validate.
+;;
+;; Audit v2, Phase 4E.  The constant probes cover `writeConstant`'s data tags;
+;; this one covers `TAG_FUNCTION` (a by-index reference into the flattened
+;; function table), `collectFunctions`'s depth-first flattening, the `closure`
+;; opcode's upvalue-capture bytes, and `validateFunctionBytecode`'s per-opcode
+;; length and operand checks.
+;;
+;; Nothing here may `import` — see sbc-population.scm for why.
+
+(define (chk name a b)
+  (display name)
+  (display " ")
+  (display (if (equal? a b) "ok" (list "MISMATCH" a b)))
+  (newline))
+
+;; --- closures and upvalues (TAG_FUNCTION + the closure opcode) -----------
+(define (mk n) (lambda (x) (+ n x)))
+(define add5 (mk 5))
+(chk "closure-capture" (list (add5 1) (add5 2)) (list 6 7))
+
+(define (counter)
+  (let ((c 0))
+    (lambda () (set! c (+ c 1)) c)))
+(define c1 (counter))
+(define c2 (counter))
+(chk "boxed-upvalue" (list (c1) (c1) (c2) (c1)) (list 1 2 1 3))
+
+;; --- nested function graph, three deep ------------------------------------
+(define (outer a)
+  (lambda (b)
+    (lambda (c)
+      (list a b c))))
+(chk "nested-3" (((outer 1) 2) 3) (list 1 2 3))
+
+;; --- case-lambda (several arities behind one value) ----------------------
+(define pick
+  (case-lambda
+    ((a) (list 'one a))
+    ((a b) (list 'two a b))
+    ((a . r) (list 'many a r))))
+(chk "case-lambda" (list (pick 1) (pick 1 2) (pick 1 2 3))
+     (list '(one 1) '(two 1 2) '(many 1 (2 3))))
+
+;; --- case over datum lists (constants reached from a jump table) ---------
+(define (classify x)
+  (case x
+    ((1 2 3) 'low)
+    ((a b) 'sym)
+    (("s") 'str)
+    (else 'other)))
+(chk "case-datums" (list (classify 2) (classify 'b) (classify 99))
+     (list 'low 'sym 'other))
+
+;; --- named let and self-tail-call (the self_tail_call opcode) ------------
+(chk "named-let"
+     (let loop ((n 1000) (acc 0)) (if (= n 0) acc (loop (- n 1) (+ acc n))))
+     500500)
+
+;; --- deep tail recursion through a global (tail_call_global) -------------
+(define (sum n acc) (if (= n 0) acc (sum (- n 1) (+ acc n))))
+(chk "tail-recursion" (sum 100000 0) 5000050000)
+
+;; --- continuations, handlers and winds (push_handler/pop_handler,
+;;     tail_call_cc) -------------------------------------------------------
+(chk "call/cc-escape"
+     (call-with-current-continuation (lambda (k) (+ 1 (k 42))))
+     42)
+(chk "call/cc-normal"
+     (call-with-current-continuation (lambda (k) 7))
+     7)
+(chk "guard"
+     (guard (e (#t (list 'caught (error-object-message e))))
+       (error "boom" 1 2))
+     (list 'caught "boom"))
+(define wind-log '())
+(dynamic-wind
+  (lambda () (set! wind-log (cons 'in wind-log)))
+  (lambda () (set! wind-log (cons 'body wind-log)))
+  (lambda () (set! wind-log (cons 'out wind-log))))
+(chk "dynamic-wind" (reverse wind-log) (list 'in 'body 'out))
+
+;; --- parameters and promises ---------------------------------------------
+(define p (make-parameter 1))
+(chk "parameterize" (list (p) (parameterize ((p 2)) (p)) (p)) (list 1 2 1))
+(define lazy (delay (begin (display "") 41)))
+(chk "delay-force" (list (force lazy) (force lazy)) (list 41 41))
+
+;; --- apply / values / variadic -------------------------------------------
+(define (var a . rest) (cons a rest))
+(chk "variadic" (list (var 1) (var 1 2 3)) (list '(1) '(1 2 3)))
+(chk "apply" (apply + '(1 2 3 4)) 10)
+(chk "values" (call-with-values (lambda () (values 1 2 3)) list) (list 1 2 3))

--- a/tests/scheme/differential/probes/sbc-constant-depth.scm
+++ b/tests/scheme/differential/probes/sbc-constant-depth.scm
@@ -1,0 +1,47 @@
+;; Probe / KNOWN PERMANENT MISS: a constant nested deeper than 256 is written
+;; to the cache and can never be read back, so this file recompiles AND
+;; rewrites its `.sbc` on every single run — and `kaappi cache status` calls
+;; the entry "current".
+;;
+;; Audit v2, Phase 4E.  Tracked as kaappi#2113.  Not a KNOWN_DIFFS entry: cold
+;; and warm agree byte for byte, because the warm run is simply a second cold
+;; run.  That is precisely the hazard — tier (d) is vacuous for this file while
+;; the harness's "cache exercised" count says it is covered, which is why
+;; run-differential.sh now checks that a written entry actually HITs.
+;;
+;; Mechanism.  The two halves of the codec disagree about who enforces the
+;; limits:
+;;
+;;   - `writeConstant` (src/bytecode_file_write.zig) TRUNCATES to TAG_NIL at
+;;     `depth > 256` and enforces no other size limit at all.
+;;   - `readConstant` (src/bytecode_file_read.zig) REJECTS at
+;;     `depth > MAX_CONSTANT_DEPTH` (256) and additionally rejects
+;;     MAX_STRING_BYTES, MAX_VECTOR_LEN, MAX_BYTEVECTOR_LEN, MAX_BIGNUM_LIMBS
+;;     and MAX_CONSTANTS_PER_FUNCTION overruns.
+;;
+;; The reader being the stricter half is what keeps this from being a silent
+;; wrong answer: the truncated tail is never observed, because the whole file
+;; is rejected first.  The cost is paid instead as an invisible permanent miss.
+;;
+;; The cliff is exact.  A quoted proper list of N elements reaches depth N in
+;; `writeConstant` (each cdr step is one level), so:
+;;
+;;     N = 256   ->  warm run HITs
+;;     N = 257   ->  warm run MISSes, forever
+;;
+;; A vector literal longer than MAX_VECTOR_LEN (262144) behaves identically,
+;; as does a cyclic literal such as `'#0=(1 . #0#)`, which recurses to the
+;; guard on its own.
+;;
+;; The list below is 300 elements: past the cliff, and small enough that the
+;; wasted recompile is cheap.  The discriminating control is
+;; sbc-constants-aggregate.scm's 250-element list, which does HIT.
+
+(define past-cliff '(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256 257 258 259 260 261 262 263 264 265 266 267 268 269 270 271 272 273 274 275 276 277 278 279 280 281 282 283 284 285 286 287 288 289 290 291 292 293 294 295 296 297 298 299))
+(display (list (length past-cliff) (car past-cliff) (list-ref past-cliff 299)))
+(newline)
+
+;; A cyclic literal reaches the same guard by a different route.
+(define cyc '#0=(1 2 . #0#))
+(display (list (car cyc) (cadr cyc) (caddr cyc) (eq? cyc (cddr cyc))))
+(newline)

--- a/tests/scheme/differential/probes/sbc-constants-aggregate.scm
+++ b/tests/scheme/differential/probes/sbc-constants-aggregate.scm
@@ -1,0 +1,82 @@
+;; Probe: text and aggregate constant tags survive a `.sbc` round trip.
+;;
+;; Audit v2, Phase 4E.  Companion to sbc-constants-numeric.scm; see that file's
+;; header for the oracle and for why nothing here may `import`.
+;;
+;; Two tags in `writeConstant` are deliberately NOT probed here:
+;;
+;;   - an *uninterned* symbol (SRFI 258).  `TAG_SYMBOL` writes only the name
+;;     and `readConstant` calls `gc.allocSymbol`, which interns — so a round
+;;     trip would silently intern it.  It is unreachable in practice: the only
+;;     constructors are `string->uninterned-symbol` /
+;;     `generate-uninterned-symbol`, which run at run time and produce values
+;;     that never enter a constant pool, and reaching them at all needs
+;;     `(import (srfi 258))`, which makes the file uncacheable anyway.
+;;   - `TAG_FUNCTION`, exercised by sbc-closures.scm rather than here.
+
+(define (chk name a b)
+  (display name)
+  (display " ")
+  (display (if (equal? a b) "ok" (list "MISMATCH" a b)))
+  (newline))
+
+;; --- strings: UTF-8 bytes are copied verbatim, so non-ASCII matters -------
+(write (list "" "ascii" "λ αβγ 日本語" "tab\there" "q\"q" "b\\b"))
+(newline)
+(chk "string-length-codepoints" (list (string-length "λαβ")) (list 3))
+(chk "string-value" '"λx" (string (integer->char #x3bb) #\x))
+
+;; --- characters, including the top of the code-point range ---------------
+(write (list #\a #\space #\newline #\tab #\x41 #\x03bb #\x10FFFF #\null #\delete))
+(newline)
+(chk "char-high" '#\x10FFFF (integer->char #x10FFFF))
+(chk "char-codepoints" (list (char->integer #\x03bb) (char->integer #\null)) (list #x3bb 0))
+
+;; --- symbols, including the ones needing |...| on the way back out -------
+(write (list 'plain '|weird sym| '|| 'UPPER 'a.b 'λμ))
+(newline)
+(chk "symbol-value" 'abc (string->symbol "abc"))
+(chk "symbol-eq" (list (eq? '|weird sym| (string->symbol "weird sym"))) (list #t))
+
+;; --- bytevectors ----------------------------------------------------------
+(write (list #u8() #u8(0 1 255) #u8(128 64 32)))
+(newline)
+(chk "bytevector-value" '#u8(0 255) (bytevector 0 255))
+
+;; --- vectors and pairs, nested and improper ------------------------------
+(write '#(1 "two" #\3 (4) #(5) 6.5 sym))
+(newline)
+(write '#(1 #(2 #(3 #(4)))))
+(newline)
+(write '(1 . 2))
+(newline)
+(write '(1 2 . 3))
+(newline)
+(write '(1 (2 (3 (4 (5 . 6)))) #(7 (8)) "s" #\c 9/2 1.5 1+2i))
+(newline)
+(chk "vector-value" '#(1 2 3) (vector 1 2 3))
+(chk "improper-tail" (list (cdr (cdr '(1 2 . 3)))) (list 3))
+
+;; --- the immediates ------------------------------------------------------
+(write (list #t #f '()))
+(newline)
+(chk "nil-is-null" (list (null? '())) (list #t))
+
+;; --- nesting just inside MAX_CONSTANT_DEPTH (256) ------------------------
+;; A cdr chain of 250 pairs reaches depth 250 in `writeConstant`; 257 or more
+;; does not survive at all (see sbc-constant-depth.scm).
+(define long250
+  '(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27
+    28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52
+    53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77
+    78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101
+    102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119
+    120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137
+    138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155
+    156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173
+    174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191
+    192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209
+    210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227
+    228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245
+    246 247 248 249))
+(chk "deep-list-250" (list (length long250) (list-ref long250 249)) (list 250 249))

--- a/tests/scheme/differential/probes/sbc-constants-numeric.scm
+++ b/tests/scheme/differential/probes/sbc-constants-numeric.scm
@@ -1,0 +1,64 @@
+;; Probe: every numeric constant tag survives a `.sbc` round trip.
+;;
+;; Audit v2, Phase 4E.  `writeConstant`/`readConstant`
+;; (src/bytecode_file_write.zig, src/bytecode_file_read.zig) have one arm per
+;; constant kind; a kind the corpus never happens to embed is untested.  The
+;; oracle is the harness's own: a cold run compiles from source, a warm run
+;; deserialises this file's constant pool, and the two must print the same
+;; bytes.
+;;
+;; The stronger half of each line is the second column: it compares the
+;; *constant* (which only the cache round-trips) against a value the bytecode
+;; *computes* at run time, so a lossy round trip shows up as a mismatch even
+;; if both runs would otherwise print the same literal back.
+;;
+;; Nothing here may `import`, may use `define-record-type`, `define-values`,
+;; `include`, a top-level `begin` or a top-level `cond-expand`: any of those
+;; makes the whole file uncacheable (see the header of sbc-population.scm),
+;; which would silently make this probe vacuous.
+
+(define (chk name a b)
+  (display name)
+  (display " ")
+  (display (if (equal? a b) "ok" (list "MISMATCH" a b)))
+  (newline))
+
+;; --- fixnum, including both ends of the 48-bit payload --------------------
+(write (list -140737488355328 -1 0 1 140737488355327))
+(newline)
+(chk "fixnum-arith" '140737488355327 (- (* 140737488355328 1) 1))
+
+;; --- flonum, including the values a naive f64 codec loses -----------------
+(write (list 1.5 0.0 -0.0 1e308 5e-324 0.1))
+(newline)
+(write (list (/ 1.0 0.0) (/ -1.0 0.0)))
+(newline)
+;; -0.0 must keep its sign bit: 1/-0.0 is -inf, 1/0.0 is +inf.
+(chk "negative-zero" (list (/ 1.0 -0.0)) (list (/ 1.0 (- 0.0))))
+(chk "flonum-value" '0.1 (/ 1.0 10.0))
+(chk "denormal" (list (> 5e-324 0.0)) (list #t))
+(chk "nan-is-nan" (list (nan? (/ 0.0 0.0))) (list #t))
+(chk "inexact" (list (exact? 1.0) (exact? 0.5)) (list #f #f))
+
+;; --- bignum (sign + limb vector) ------------------------------------------
+(write (list 123456789012345678901234567890
+             -98765432109876543210987654321098765432109876543210
+             340282366920938463463374607431768211456))
+(newline)
+(chk "bignum-value" '123456789012345678900000000000 (* 12345678901234567890 10000000000))
+(chk "bignum-exact" (list (exact? '123456789012345678901234567890)) (list #t))
+(chk "bignum-sign" (list (negative? '-98765432109876543210987654321098765432109876543210)) (list #t))
+
+;; --- rational (a nested numerator/denominator constant) -------------------
+(write (list 1/3 -22/7 123456789012345678901234567890/98765432109876543210987654321))
+(newline)
+(chk "rational-value" '22/7 (/ 22 7))
+(chk "rational-exact" (list (exact? 1/3)) (list #t))
+(chk "rational-parts" (list (numerator '-22/7) (denominator '-22/7)) (list -22 7))
+
+;; --- complex (two f64s plus two exactness bits) ---------------------------
+(write (list 1+2i -3.5-4.25i 0+1i))
+(newline)
+(chk "complex-value" '1+2i (make-rectangular 1 2))
+(chk "complex-parts" (list (real-part '-3.5-4.25i) (imag-part '-3.5-4.25i)) (list -3.5 -4.25))
+(chk "complex-exactness" (list (exact? '1+2i) (exact? '1.5+2.5i)) (list #t #f))

--- a/tests/scheme/differential/probes/sbc-literal-immutability.scm
+++ b/tests/scheme/differential/probes/sbc-literal-immutability.scm
@@ -1,0 +1,73 @@
+;; Probe / KNOWN DIVERGENCE: a cache HIT makes every literal constant mutable.
+;;
+;; Audit v2, Phase 4E.  Listed in run-differential.sh's KNOWN_DIFFS, so the
+;; suite stays green until the fix lands; delete the entry there (and this
+;; note) once it does.  Tracked as kaappi#2110.
+;;
+;; R7RS 4.1.2: "It is an error to alter a constant (i.e. the value of a literal
+;; expression) using a mutation procedure like set-car! or string-set!."
+;; Kaappi *enforces* that: `reader_datum.zig` stamps `Object.flags.immutable`
+;; on every datum it reads under `mark_immutable`, and the four mutators reject
+;; it with KP3002 "expected mutable <type>".
+;;
+;; `writeConstant`/`readConstant` carry no immutability bit, so a cache HIT
+;; rebuilds every constant through the ordinary `gc.allocPair` / `allocString`
+;; / `allocVectorFill` / `allocBytevector` constructors, whose `immutable`
+;; defaults to false:
+;;
+;;   $ kaappi t.scm            # cold — cache MISS
+;;   t.scm:2:1: error[KP3002]: type error in 'set-car!': expected mutable pair
+;;   ...exit 1
+;;
+;;   $ kaappi t.scm            # warm — cache HIT
+;;   (99 2)
+;;   ...exit 0
+;;
+;; So this is not a diagnostic degradation like kaappi#1922: the program takes
+;; a different branch, prints different bytes, and exits 0 instead of 1.
+;;
+;; Discriminating control: the last group builds the same shapes with `list` /
+;; `string-copy` / `vector` / `bytevector` at run time.  Those are mutable in
+;; BOTH runs, so the divergence is specific to the *literal* path and is not
+;; "the cache loses all object flags".
+;;
+;; Every case is wrapped in `guard` so the file runs to the end and the
+;; divergence shows up as differing stdout rather than as an early exit.
+
+(define (try name thunk)
+  (display name)
+  (display " ")
+  (display (guard (e (#t 'raised)) (thunk) 'mutated))
+  (newline))
+
+;; --- literals: must raise ------------------------------------------------
+(define lit-pair '(1 2))
+(define lit-string "abc")
+(define lit-vector '#(1 2 3))
+(define lit-bytevector '#u8(1 2 3))
+
+(try "literal-pair" (lambda () (set-car! lit-pair 99)))
+(try "literal-pair-cdr" (lambda () (set-cdr! lit-pair 99)))
+(try "literal-string" (lambda () (string-set! lit-string 0 #\z)))
+(try "literal-vector" (lambda () (vector-set! lit-vector 0 99)))
+(try "literal-vector-fill" (lambda () (vector-fill! lit-vector 0)))
+(try "literal-bytevector" (lambda () (bytevector-u8-set! lit-bytevector 0 99)))
+(try "nested-literal-pair" (lambda () (set-car! (car '((1) 2)) 99)))
+(try "literal-in-vector" (lambda () (set-car! (vector-ref '#((1 2)) 0) 99)))
+
+;; What the values are afterwards — a second channel on the same defect.
+(write (list lit-pair lit-string lit-vector lit-bytevector))
+(newline)
+
+;; --- control: run-time-built values are mutable in BOTH runs -------------
+(define run-pair (list 1 2))
+(define run-string (string-copy "abc"))
+(define run-vector (vector 1 2 3))
+(define run-bytevector (bytevector 1 2 3))
+
+(try "runtime-pair" (lambda () (set-car! run-pair 99)))
+(try "runtime-string" (lambda () (string-set! run-string 0 #\z)))
+(try "runtime-vector" (lambda () (vector-set! run-vector 0 99)))
+(try "runtime-bytevector" (lambda () (bytevector-u8-set! run-bytevector 0 99)))
+(write (list run-pair run-string run-vector run-bytevector))
+(newline)

--- a/tests/scheme/differential/probes/sbc-macro-table.scm
+++ b/tests/scheme/differential/probes/sbc-macro-table.scm
@@ -1,0 +1,58 @@
+;; Probe / KNOWN DIVERGENCE: a cache HIT leaves the macro table empty, so a
+;; top-level `define-syntax` is invisible to a run-time `eval`.
+;;
+;; Audit v2, Phase 4E.  Listed in run-differential.sh's KNOWN_DIFFS, so the
+;; suite stays green until the fix lands; delete the entry there (and this
+;; note) once it does.  Tracked as kaappi#2112.
+;;
+;; `define-syntax` is a *compiler* form: `compileDefineSyntax`
+;; (src/compiler_define_syntax.zig) registers the transformer in the live macro
+;; table as a side effect of compiling the file, and emits no bytecode that
+;; would re-register it.  A cache HIT skips compilation entirely, so on the
+;; warm run `vm.macros` never learns the name, and `eval` — which compiles its
+;; argument at run time against that table — reports it as an undefined
+;; variable:
+;;
+;;   $ kaappi t.scm       # cold — cache MISS
+;;   42
+;;   10
+;;   ...exit 0
+;;
+;;   $ kaappi t.scm       # warm — cache HIT
+;;   42
+;;   t.scm:3: error[KP3001]: undefined variable 'dbl'
+;;   ...exit 1
+;;
+;; Discriminating control: the first line of output is the macro used at
+;; *compile* time.  It agrees in both runs, because that use was already
+;; compiled into the cached bytecode.  So the defect is precisely "compile-time
+;; side effects of the source are not replayed on a HIT", not "macros are
+;; broken after a HIT".
+;;
+;; `define-property` (SRFI 213) is the same shape and is included below: it
+;; writes into the VM-owned `syntax_properties` table at compile time.
+
+(define-syntax dbl (syntax-rules () ((_ x) (* 2 x))))
+(define-syntax outer (syntax-rules () ((_ x) (inner x))))
+(define-syntax inner (syntax-rules () ((_ x) (+ x 100))))
+(define-property dbl kind 'doubler)
+
+;; --- control: compile-time uses.  These agree cold and warm. -------------
+(display (dbl 21))
+(newline)
+(display (outer 1))
+(newline)
+
+;; --- the divergence: run-time uses through `eval`. -----------------------
+(display (guard (e (#t 'undefined)) (eval '(dbl 5) (interaction-environment))))
+(newline)
+(display (guard (e (#t 'undefined)) (eval '(outer 2) (interaction-environment))))
+(newline)
+(display (guard (e (#t 'undefined)) (eval '(let () (dbl 3)) (interaction-environment))))
+(newline)
+
+;; A plain global defined the ordinary way IS visible to eval in both runs —
+;; globals are runtime state, macros are not.
+(define (trip x) (* 3 x))
+(display (guard (e (#t 'undefined)) (eval '(trip 4) (interaction-environment))))
+(newline)

--- a/tests/scheme/differential/probes/sbc-population.scm
+++ b/tests/scheme/differential/probes/sbc-population.scm
@@ -1,0 +1,74 @@
+;; Probe: the rule governing which files populate the `.sbc` cache at all —
+;; and the control showing it is a TOP-LEVEL HEAD-POSITION rule, not a
+;; whole-file scan.
+;;
+;; Audit v2, Phase 4E.  This is the file every other sbc-*.scm probe's header
+;; points at, because a probe that stops populating the cache stops testing
+;; anything and looks green.
+;;
+;; MEASURED RULE (src/main.zig `runFile`).  A run writes a cache entry iff all
+;; three hold:
+;;
+;;   1. caching is enabled at all — not `--sandbox`, not `--no-ir-opt`, and a
+;;      home directory resolves (`cache.pathForSource`);
+;;   2. at least one top-level form compiled to a Function; and
+;;   3. `has_imports` stayed false — i.e. NO top-level form was claimed by
+;;      `vm_eval.handleTopLevelForm`.
+;;
+;; Condition 3 is the one that matters, and it is much broader than its name
+;; and than docs/dev/cache.md ("a program that does not `import`").
+;; `handleTopLevelForm` claims EIGHT head symbols:
+;;
+;;     import   define-library   define-record-type   define-values
+;;     include  include-ci       begin                cond-expand
+;;
+;; Any one of them, once, anywhere at top level, makes the WHOLE file
+;; uncacheable — including the forms that have nothing to do with library
+;; loading, which is the rationale the source comment gives.  `--timings` then
+;; reports `cache: MISS (not cached: imports)` even for a file containing no
+;; `import` at all.  Measured over the harness's own default corpus: 40 of 345
+;; files populate the cache; of the 305 that do not, 303 have a top-level
+;; `import` and the other two are disabled by a top-level `begin` and a
+;; top-level `define-values` respectively.  Tracked as kaappi#2114; the import
+;; half is kaappi#1888.
+;;
+;; This file therefore contains NONE of the eight at top level — and, as the
+;; control, uses four of them in NESTED position, where they are ordinary
+;; compiler forms and leave caching alive.  If a future change makes the rule a
+;; whole-file scan, this file stops populating the cache and the harness's
+;; "cache exercised" count drops.
+
+(define (chk name a b)
+  (display name)
+  (display " ")
+  (display (if (equal? a b) "ok" (list "MISMATCH" a b)))
+  (newline))
+
+;; `begin` in a body, not at top level.
+(define (nested-begin)
+  (begin 1 2 3))
+(chk "nested-begin" (nested-begin) 3)
+
+;; `cond-expand` in a body.
+(define (nested-cond-expand)
+  (cond-expand (else 'chosen)))
+(chk "nested-cond-expand" (nested-cond-expand) 'chosen)
+
+;; `define-values` in a body.
+(define (nested-define-values)
+  (define-values (a b) (values 10 20))
+  (+ a b))
+(chk "nested-define-values" (nested-define-values) 30)
+
+;; `define-record-type` in a body.
+(define (nested-define-record-type)
+  (define-record-type <pt> (mk x) pt? (x pt-x))
+  (pt-x (mk 7)))
+(chk "nested-define-record-type" (nested-define-record-type) 7)
+
+;; A top-level `define` of a procedure whose body does all of the above at
+;; once — the shape a real program takes when it avoids top-level declarations.
+(chk "all-nested"
+     (list (nested-begin) (nested-cond-expand)
+           (nested-define-values) (nested-define-record-type))
+     (list 3 'chosen 30 7))

--- a/tests/scheme/differential/probes/sbc-shared-structure.scm
+++ b/tests/scheme/differential/probes/sbc-shared-structure.scm
@@ -1,0 +1,60 @@
+;; Probe / KNOWN DIVERGENCE: a cache HIT unshares datum-label structure.
+;;
+;; Audit v2, Phase 4E.  Listed in run-differential.sh's KNOWN_DIFFS, so the
+;; suite stays green until the fix lands; delete the entry there (and this
+;; note) once it does.  Tracked as kaappi#2111.
+;;
+;; R7RS 2.4 (Datum labels): "#<n>= <datum> reads as <datum>, but also results
+;; in <datum> being labelled by <n>.  #<n># serves as a reference to some
+;; object labelled by #<n>=; the result is the same object as the #<n>= label."
+;; The reader honours that — `reader_datum.zig` patches every reference to the
+;; one labelled object — so cold, `(eq? (car v) (cadr v))` on `'(#1=(1 2) #1#)`
+;; is #t.
+;;
+;; `writeConstant` is a plain recursive walk with no visited-set, so it emits
+;; the labelled datum once per *reference*, and `readConstant` allocates a
+;; fresh object for each.  A cache HIT therefore answers #f:
+;;
+;;   $ kaappi t.scm      # cold  -> #t
+;;   $ kaappi t.scm      # warm  -> #f
+;;
+;; Discriminating control: the last group writes the same shape WITHOUT a
+;; label.  Cold already answers #f there, and warm agrees — so this is sharing
+;; being lost, not `eq?` behaving differently after a HIT.
+;;
+;; Same root cause, two more symptoms, neither probed here because neither can
+;; be a deterministic corpus file:
+;;
+;;   - a CYCLIC literal (`'#0=(1 . #0#)`) recurses until `writeConstant`'s
+;;     depth-256 guard truncates it, and `readConstant`'s matching guard then
+;;     rejects the file — a permanent MISS.  See sbc-constant-depth.scm.
+;;   - a shared DAG makes the .sbc exponential in the source: labels nested
+;;     `#k=(#k-1# #k-1#)` 20 deep are 241 source bytes and 4.7 MB of .sbc,
+;;     doubling per level.
+
+(define shared-pair '(#1=(1 2) #1#))
+(define shared-vector '#(#2=(a) #2# #2#))
+(define shared-string '(#3="abc" #3#))
+(define shared-deep '(#4=(1 2) (x #4#) #(#4#)))
+
+(display (list 'pair (eq? (car shared-pair) (cadr shared-pair))))
+(newline)
+(display (list 'vector
+               (eq? (vector-ref shared-vector 0) (vector-ref shared-vector 1))
+               (eq? (vector-ref shared-vector 1) (vector-ref shared-vector 2))))
+(newline)
+(display (list 'string (eq? (car shared-string) (cadr shared-string))))
+(newline)
+(display (list 'deep
+               (eq? (car shared-deep) (cadr (cadr shared-deep)))
+               (eq? (car shared-deep) (vector-ref (caddr shared-deep) 0))))
+(newline)
+
+;; `write-shared` is the printer's own view of the same question.
+(write-shared shared-pair)
+(newline)
+
+;; --- control: the same shape with no label -------------------------------
+(define unshared-pair '((1 2) (1 2)))
+(display (list 'control (eq? (car unshared-pair) (cadr unshared-pair))))
+(newline)

--- a/tests/scheme/differential/run-differential.sh
+++ b/tests/scheme/differential/run-differential.sh
@@ -51,10 +51,14 @@
 # Two things follow:
 #
 #   1. `probes/` exists for this reason.  Those files put the optimisable
-#      shapes at top level on purpose, and 6 of the 7 are verified non-vacuous
-#      (`kaappi ir` differs from `kaappi ir --no-opt`); the seventh,
-#      cache-error-location.scm, is a tier-(d) probe.  They roughly TRIPLE the
-#      number of files in the corpus that exercise the optimiser at all.
+#      shapes at top level on purpose, and 6 of the original 7 are verified
+#      non-vacuous (`kaappi ir` differs from `kaappi ir --no-opt`); the
+#      seventh, cache-error-location.scm, is a tier-(d) probe.  They roughly
+#      TRIPLE the number of files in the corpus that exercise the optimiser at
+#      all.  The eight `sbc-*.scm` probes added by audit v2 Phase 4E are
+#      tier-(d) probes in the same sense: they exist because the cache is the
+#      thing under test, so every one of them is written to stay cacheable
+#      (see probes/sbc-population.scm).
 #   2. This script MEASURES the vacuity rather than leaving it to be assumed.
 #      The summary reports "IR differs under --no-opt: N / M files".  If that
 #      number is small, the tier-(b) result is correspondingly weak, and it
@@ -67,12 +71,41 @@
 # adding more corpus directories — KAAPPI_DIFF_FULL=1 adds 227 files and
 # exactly zero additional optimiser coverage.
 #
-# The same discipline applies to tier (d): only a program that does NOT
-# `import` populates the bytecode cache at all (docs/dev/cache.md) — measured
-# 40 of 330 files on the default corpus, 47 of 557 on the full one.  The
-# summary reports how many files actually created an `.sbc` entry, so a
-# regression that silently disables caching shows up as that count collapsing
-# rather than as a vacuously green run.
+# The same discipline applies to tier (d), and audit v2 Phase 4E measured it
+# rather than leaving it at "programs that import are skipped".
+#
+# WHICH FILES POPULATE THE CACHE.  `src/main.zig`'s `runFile` writes an entry
+# iff caching is enabled (no `--sandbox`, no `--no-ir-opt`, a home directory
+# resolves), at least one top-level form compiled to a Function, and
+# `has_imports` stayed false.  That last flag is set by ANY top-level form
+# `vm_eval.handleTopLevelForm` claims, which is eight head symbols, not one:
+#
+#     import   define-library   define-record-type   define-values
+#     include  include-ci       begin                cond-expand
+#
+# One occurrence of any of them, anywhere at top level, makes the whole file
+# uncacheable — and `--timings` still reports `not cached: imports`.
+# docs/dev/cache.md documents only the `import` case (kaappi#2114; the import
+# half alone is kaappi#1888).  MEASURED over the default corpus: 40 of 345
+# files populate the cache; of the 305 that do not, 303 have a top-level
+# `import`, one is disabled by a top-level `begin` and one by a top-level
+# `define-values`.  probes/sbc-population.scm pins the rule, including the
+# control that a NESTED `begin`/`cond-expand`/`define-values`/
+# `define-record-type` leaves caching alive.
+#
+# The summary reports how many files created an `.sbc` entry, so a regression
+# that silently disables caching shows up as that count collapsing rather than
+# as a vacuously green run.
+#
+# WRITING AN ENTRY IS NOT THE SAME AS USING ONE.  The write half of the codec
+# enforces almost no size limits and the read half enforces several, so a file
+# can write an entry that can never be loaded: it recompiles and rewrites the
+# same `.sbc` on every run, forever, while `kaappi cache status` reports the
+# entry as "current".  Counting entries alone reads that as covered.  So for
+# every file that wrote one, this script now runs `--timings` once more and
+# requires the entry to actually HIT; an unexpected permanent miss FAILS the
+# run.  probes/sbc-constant-depth.scm is the one deliberate exception (a
+# quoted list past `MAX_CONSTANT_DEPTH`), listed in KNOWN_NEVER_HIT below.
 #
 # ---------------------------------------------------------------------------
 # Exclusions
@@ -289,9 +322,57 @@ is_skipped() {
 #   see the header of probes/cache-error-location.scm for the full repro and
 #   its discriminating control.  Tracked as kaappi#1922 -- delete this entry
 #   when that is fixed, and the STALE check below will confirm it.
+#
+# d:sbc-literal-immutability.scm
+#   A cache HIT makes every literal constant mutable: `writeConstant` /
+#   `readConstant` carry no `Object.flags.immutable` bit, so a HIT rebuilds
+#   constants through the ordinary allocators, whose default is mutable.  A
+#   `set-car!` on a literal that must raise KP3002 (R7RS 4.1.2) instead
+#   succeeds, and the process exits 0 where the cold run exits 1.  Found by
+#   audit v2 Phase 4E; tracked as kaappi#2110.
+#
+# d:sbc-shared-structure.scm
+#   A cache HIT unshares datum-label structure: `writeConstant` is a recursive
+#   walk with no visited-set, so `'(#1=(1 2) #1#)` is emitted twice and read
+#   back as two objects.  `(eq? (car v) (cadr v))` flips #t -> #f, contradicting
+#   R7RS 2.4.  Found by audit v2 Phase 4E; tracked as kaappi#2111.
+#
+# d:sbc-macro-table.scm
+#   A cache HIT leaves the macro table empty, so a top-level `define-syntax`
+#   is invisible to a run-time `eval`: `define-syntax` registers its
+#   transformer as a compile-time side effect and emits no bytecode, and a HIT
+#   skips compilation.  Found by audit v2 Phase 4E; tracked as kaappi#2112.
 KNOWN_DIFFS="
 d:cache-error-location.scm
+d:sbc-literal-immutability.scm
+d:sbc-shared-structure.scm
+d:sbc-macro-table.scm
 "
+
+# Files that DO write an `.sbc` entry but can never load it back, so every run
+# is a cold run.  Same convention as KNOWN_DIFFS: a listed basename is reported
+# and does not fail the run, and the summary prints a STALE line when a listed
+# file starts hitting.  An UNLISTED permanent miss fails the run.
+#
+# sbc-constant-depth.scm
+#   A quoted list of 300 elements reaches depth 300 in `writeConstant`, which
+#   truncates past 256, and `readConstant` rejects the file at the same depth.
+#   The reader being the stricter half is what keeps this from being a silent
+#   wrong answer; the cost is an invisible permanent miss instead.  Found by
+#   audit v2 Phase 4E; tracked as kaappi#2113.
+KNOWN_NEVER_HIT="
+sbc-constant-depth.scm
+"
+
+is_known_never_hit() {   # is_known_never_hit <file>
+    local base line
+    base="$(basename "$1")"
+    # shellcheck disable=SC2086  # deliberate word splitting over the entry list
+    for line in $KNOWN_NEVER_HIT; do
+        [ "$line" = "$base" ] && return 0
+    done
+    return 1
+}
 
 is_known_diff() {   # is_known_diff <tier> <file>
     local key line
@@ -355,6 +436,8 @@ DIFF_D=0
 COSMETIC_B=0
 COSMETIC_D=0
 CACHE_USED=0
+CACHE_NEVER_HIT=0
+CACHE_NEVER_HIT_KNOWN=0
 IR_DIFFERS=0
 IR_SAME=0
 IR_UNKNOWN=0
@@ -548,6 +631,32 @@ check_file() {
         echo "  NOTE  [b] $f — stderr differs only in paths/line numbers"
     }
 
+    # --- usability meter for tier (d) ------------------------------------
+    # An entry on disk is not the same as an entry in use.  Ask the binary
+    # itself, in the home the two runs above already warmed: `--timings` prints
+    # HIT/MISS and is the only channel that distinguishes "the warm run reused
+    # the entry" from "the warm run recompiled and rewrote it".  Paid only for
+    # the files that wrote something, so most of the corpus costs nothing.
+    if [ "$entries" -gt 0 ]; then
+        run_kaappi "$d/home1" "$d/tm.out" "$d/tm.err" --timings "$f"
+        local cache_state
+        cache_state=$(sed -n 's/^cache: \([A-Za-z]*\).*/\1/p' "$d/tm.err" | head -1)
+        if [ "$cache_state" != "HIT" ]; then
+            if is_known_never_hit "$f"; then
+                CACHE_NEVER_HIT_KNOWN=$((CACHE_NEVER_HIT_KNOWN + 1))
+                echo "  KNOWN [d permanent miss] $f  (wrote an .sbc it can never load; see KNOWN_NEVER_HIT)"
+            else
+                CACHE_NEVER_HIT=$((CACHE_NEVER_HIT + 1))
+                FAILED_FILES="$FAILED_FILES
+  [d permanent miss] $f"
+                echo "  DIFF  [d permanent miss] $f  (wrote an .sbc entry, then reported cache: ${cache_state:-?})"
+            fi
+        elif is_known_never_hit "$f"; then
+            STALE="$STALE
+  never-hit:$(basename "$f")"
+        fi
+    fi
+
     # --- vacuity meter for tier (b) --------------------------------------
     # Does the optimiser change this file's IR at all?  `kaappi ir` executes
     # nothing, so this is cheap; it is what turns "no diff" into "no diff, and
@@ -617,6 +726,7 @@ echo "  known divergences hit:        $KNOWN (suppressed; see KNOWN_DIFFS)"
 echo "  stderr cosmetic-only notes:   b=$COSMETIC_B d=$COSMETIC_D"
 echo ""
 echo "  cache exercised:              $CACHE_USED / $COMPARED files wrote an .sbc entry"
+echo "  cache entries never loaded:   $CACHE_NEVER_HIT unexpected, $CACHE_NEVER_HIT_KNOWN known (see KNOWN_NEVER_HIT)"
 echo "  IR differs under --no-ir-opt: $IR_DIFFERS / $IR_TOTAL files ($IR_UNKNOWN undetermined)"
 if [ "$IR_DIFFERS" -eq 0 ] && [ "$IR_TOTAL" -gt 0 ]; then
     echo "  WARNING: the optimiser changed NO file's IR — tier (b) is fully vacuous here."
@@ -626,15 +736,15 @@ if [ "$CACHE_USED" -eq 0 ] && [ "$COMPARED" -gt 0 ]; then
 fi
 if [ -n "$STALE" ]; then
     echo ""
-    echo "  STALE: these KNOWN_DIFFS entries no longer diverge — delete them"
-    echo "         from run-differential.sh (not a failure):$STALE"
+    echo "  STALE: these KNOWN_DIFFS / KNOWN_NEVER_HIT entries no longer apply —"
+    echo "         delete them from run-differential.sh (not a failure):$STALE"
 fi
 echo ""
 echo "  elapsed: ${ELAPSED}s"
 
-if [ $((DIFF_B + DIFF_D)) -gt 0 ]; then
+if [ $((DIFF_B + DIFF_D + CACHE_NEVER_HIT)) -gt 0 ]; then
     echo ""
-    echo "FAIL: $((DIFF_B + DIFF_D)) tier divergence(s):$FAILED_FILES"
+    echo "FAIL: $((DIFF_B + DIFF_D + CACHE_NEVER_HIT)) tier divergence(s):$FAILED_FILES"
     exit 1
 fi
 echo ""


### PR DESCRIPTION
Audit v2 **Phase 4E** — `.sbc` bytecode-cache coverage. Tracking: #1890.

Phase 4B (#1923) shipped the cold-vs-warm cache differential and found **zero
divergence across 333 files**. That was a *coverage* result, not a correctness
one: only 40 of those files populate the cache at all. This unit establishes
why, round-trips every constant tag through a real cold/warm run, and turns the
"entries written" count into a check that the entries are actually *usable*.

## The population rule (measured, not guessed)

`src/main.zig:829` gates the write on `has_imports`, which `:785` sets whenever
**any** top-level form is claimed by `vm_eval.handleTopLevelForm` — eight head
symbols, not one:

```text
import   define-library   define-record-type   define-values
include  include-ci       begin               cond-expand
```

One occurrence, anywhere at top level, makes the whole file uncacheable. Over
the default corpus, one isolated `KAAPPI_HOME` per file:

| | files |
|---|---:|
| populate the cache | **40** |
| do not | 305 |
| …with a top-level `import` | 303 |
| …disabled by a top-level `begin` only | 1 |
| …disabled by a top-level `define-values` only | 1 |
| cached files containing any of the eight | **0** |

`docs/dev/cache.md` documents only `import`, and `--timings` reports
`not cached: imports` for all eight — **#2114**. The rule is head-position-at-top-level
only: the same four constructs *nested* in a body leave caching alive, which
`probes/sbc-population.scm` pins as the control.

## Round-trip results

Every constant tag, cold vs warm, with a runtime-computed oracle beside each
literal so a lossy round trip shows up even when both runs print the same text:

| tag | probed with | result |
|---|---|---|
| fixnum | both ends of the 48-bit payload | clean |
| flonum | `-0.0`, `±inf.0`, NaN, `1e308`, `5e-324`, `0.1` | clean (sign of zero preserved) |
| bignum | both signs, multi-limb | clean |
| rational | incl. bignum numerator/denominator | clean |
| complex | both exactness bits | clean |
| string | non-ASCII UTF-8, escapes, empty | clean |
| char | `#\x10FFFF`, `#\null`, `#\x03bb` | clean |
| symbol | `\|weird sym\|`, `\|\|`, unicode | clean |
| bytevector | empty, 0/255 | clean |
| vector / pair | nested, improper, mixed | clean *except sharing* |
| function | closures, upvalues, case-lambda, 3-deep nesting | clean |
| booleans / `'()` | | clean |

Uninterned symbols (SRFI 258) would be silently interned by `TAG_SYMBOL`, but
are unreachable as constants — documented in the probe header rather than
tested.

Control forms are clean too: `call/cc`, `guard`, `dynamic-wind`,
`parameterize`, `delay`/`force`, named let, self-tail-call, `apply`, `values`.

**That is the headline: the codec is correct for every value it can represent.**

## Three things a HIT changes anyway

| | issue |
|---|---|
| `readConstant` rebuilds constants through the ordinary allocators, dropping `Object.flags.immutable` — `set-car!` on a literal **raises cold and succeeds warm**, exit 1 → exit 0 (R7RS §3.4, §4.1.2) | **#2110** |
| `writeConstant` has no visited-set — datum-label sharing is emitted once per reference, so `eq?` flips `#t` → `#f` (R7RS §2.4); a shared DAG is exponential (241 source bytes → 4.7 MB `.sbc`); a cyclic literal never loads | **#2111** |
| `define-syntax` registers its transformer as a compile-time side effect a HIT never replays — a top-level macro is **invisible to run-time `eval`** | **#2112** |

And the one that hid the third symptom above:

| | issue |
|---|---|
| The writer enforces almost none of the reader's limits, so a constant past `MAX_CONSTANT_DEPTH` (cliff measured at exactly 257 list elements) or a vector past `MAX_VECTOR_LEN` writes an entry that can **never** be loaded. The file recompiles and rewrites the same `.sbc` forever, and `kaappi cache status` calls the entry **`current`** — which `docs/dev/cache.md` defines as "would hit" | **#2113** |

#1922 (a HIT losing error source lines) still reproduces and is already listed
in `KNOWN_DIFFS`; not re-filed.

## Harness changes

- **New gate:** for every file that wrote an entry, run `--timings` once more
  and require a `HIT`. An unexpected permanent miss now **fails** the run.
  Across the full 599-file corpus there are **zero** — `KNOWN_NEVER_HIT` holds
  only `sbc-constant-depth.scm`, the deliberate probe for #2113.
- Three new `KNOWN_DIFFS` entries for #2110/#2111/#2112, each with the
  mechanism written out; the existing STALE check flags them when fixed.
- Header now carries the measured population rule and the
  writing-an-entry-is-not-using-one distinction.

## Numbers

| | before | after |
|---|---:|---:|
| default corpus | 345 | **353** |
| files exercising the cache | 40 | **48** |
| default runtime | 113s | 126s (budget 300s) |

Full sweep (`KAAPPI_DIFF_FULL=1`): 599 files, 0 divergence, 0 unexpected
permanent misses. `bash tests/scheme/run-all.sh`: **663 Scheme files pass,
1395 R7RS assertions pass, 2058 total, 0 fail.**

## Also verified (documented behaviour, no issue)

- **The `-dirty` build-id aliasing in `docs/dev/cache.md` is real and still
  bites.** Built two binaries from *different* uncommitted edits at the same
  commit — one with a deliberately wrong `+` constant-folder. Both get build id
  `3c1a56be-dirty`, and the *correct* binary printed `1003` off the broken
  binary's cache entry. Discriminating control: the same binary on a fresh cold
  home prints `3`.
- A single **untracked file** flips the build id to `-dirty` (#2097's
  mechanism), confirmed by rebuild.
- `cache clear` removes only top-level `*.sbc`, leaves other files and
  subdirectories alone, and is idempotent. A corrupt entry reports `unknown`
  and recovers as a clean miss.

No source changes. Does not touch `docs/audit-strategy.md` or `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
