### PR TITLE
Phase 4D: WASM cross-tier — an 848-deep write aborts the module, and no .sld loads there at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -865,7 +865,9 @@ jobs:
   wasm:
     needs: format
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 20, not 10: this job now also builds the native binary and runs the
+    # cross-tier differential over the shared corpus (~60s locally).
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -897,6 +899,18 @@ jobs:
 
       - name: Platform gate diagnostics (kaappi#1972)
         run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/platform-gates.scm
+
+      # The four steps above are hand-written WASM-only programs that assert
+      # their own results. The differential below instead runs the SHARED
+      # corpus on both tiers and requires the WASM output to match the
+      # interpreter's byte-for-byte, which is what catches a WASM build that
+      # runs but answers differently (audit v2, Phase 4D). Needs the native
+      # binary as the oracle, hence the extra build.
+      - name: Build native oracle
+        run: zig build
+
+      - name: WASM cross-tier differential (audit v2, Phase 4D)
+        run: bash tests/scheme/differential/run-wasm-differential.sh
 
   coverage:
     needs: test

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -23,7 +23,7 @@
 | `timings/` | `--timings` stage reporting | yes |
 | `completions/` | `--completions` scripts vs. the flag table (`docs/dev/cli-surface.md`) | yes |
 | `lsp/` | `kaappi-lsp` end-to-end JSON-RPC session over stdio | yes |
-| `differential/` | Execution-tier differential harness (`--no-ir-opt`, cold-vs-warm cache) + its `probes/` | yes |
+| `differential/` | Execution-tier differential harnesses (`--no-ir-opt`, cold-vs-warm cache; WASM-vs-interpreter) + its `probes/` | yes |
 | `coverage/` | Coverage gap-fillers (`zig build coverage-scheme`) | no |
 | `robustness/` | Stress tests | no (CI runs it separately) |
 | `sandbox/` | Sandbox isolation tests | no (CI runs it separately) |

--- a/tests/scheme/differential/run-wasm-differential.sh
+++ b/tests/scheme/differential/run-wasm-differential.sh
@@ -1,0 +1,460 @@
+#!/bin/bash
+# run-wasm-differential.sh — WASM cross-tier differential (audit v2, Phase 4D)
+#
+# Sibling of run-differential.sh, which covers tier (b) --no-ir-opt and tier
+# (d) cold-vs-warm cache.  This one covers the WASM tier:
+#
+#   base   kaappi F                              <- the oracle (interpreter)
+#   wasm   wasmtime run --dir=. kaappi.wasm F    <- tier (e)
+#
+# Pass criterion: byte-identical stdout, identical exit status, and identical
+# stderr after the same normalisation the sibling uses.
+#
+#   Usage:  bash tests/scheme/differential/run-wasm-differential.sh [path-to-kaappi]
+#
+#   KAAPPI_WASM=<path>         the .wasm module (default zig-out/bin/kaappi.wasm)
+#   KAAPPI_WASM_DIFF_FULL=1    add continuations/, hygiene/ and srfi/
+#   KAAPPI_WASM_DIFF_TIMEOUT=N per-run timeout in seconds (default 60)
+#   KAAPPI_WASM_DIFF_VERBOSE=1 print a line per file instead of only diffs
+#   KAAPPI_WASM_DIFF_KEEP=1    keep the temp tree of captured outputs
+#
+# Exits 77 (SKIP) when there is no WASM runtime or no module to run — most
+# dev boxes have neither, and CI's `wasm` job has both.
+#
+# ---------------------------------------------------------------------------
+# READ THIS BEFORE TRUSTING A GREEN RUN
+# ---------------------------------------------------------------------------
+# Most of the corpus cannot run on this tier at all, and the reason is a bug,
+# not a property of WASM.
+#
+# MEASURED 2026-08-01 over 591 corpus files (smoke, compliance, audit,
+# continuations, hygiene, srfi, probes): **401 of them fail on WASM with
+# nothing but `KP2001 library not found`**, because no file-backed `.sld` is
+# importable there even when the host mounts the directory (kaappi#2108 —
+# `platform.openRead` has no WASI branch, so `resolveLibraryPath`'s existence
+# probe fails for every candidate path).  Only registry built-ins and the two
+# `embedded_libraries` entries resolve.
+#
+# So the comparison is structurally narrow: ~184 of 591 files actually execute
+# on both tiers.  This script REPORTS that number rather than leaving it to be
+# assumed — the summary prints "excluded (no .sld on WASM)" — for the same
+# reason the sibling reports its optimiser-vacuity meter.  When kaappi#2108 is
+# fixed, that count should collapse and the compared count should jump; if it
+# does not, something else has broken.
+#
+# The honest reading of a green run today: the ~184 files that CAN run agree
+# byte-for-byte, and the other ~400 are untested on this tier.
+#
+# ---------------------------------------------------------------------------
+# Exclusions
+# ---------------------------------------------------------------------------
+# Three buckets, all measured rather than guessed, all reported:
+#
+# (a) LIBDIFF — the wasm run's only complaint is `library not found` and the
+#     native run has none.  kaappi#2108.  Counted, not a failure.
+#
+# (b) PLATFORM — the wasm run hit a degradation the engine reports
+#     deliberately and CLAUDE.md documents: no filesystem access (the
+#     `(scheme file)` gates from kaappi#1972/#2016) or no FFI.  These are
+#     matched on the engine's OWN message text, not on a file list, so a
+#     degradation that stops being reported cleanly shows up as a DIFF
+#     instead of being silently swallowed.
+#
+# (c) KNOWN_DIFFS — real, filed, unfixed divergences, one `basename` per line
+#     with its issue number.  As in the sibling, an entry that stops
+#     diverging is reported as STALE (a note, not a failure).
+#
+# Nondeterminism is handled the same way the sibling handles it: a candidate
+# divergence is replayed against a second native baseline, and dropped unless
+# it reproduces.  Paid only when something already looks wrong.
+#
+# ---------------------------------------------------------------------------
+# Normalisation
+# ---------------------------------------------------------------------------
+# stdout and the exit status are compared BYTE-EXACTLY.  Only stderr is
+# normalised, for absolute paths and line/column numbers.
+#
+# Regex portability: `sed -E` / `grep -E` only, plain POSIX ERE — GNU BRE
+# extensions match nothing on OpenBSD (kaappi#1862).  No `grep -q` on the
+# right of a pipe under `pipefail` (kaappi#1926).
+#
+# ---------------------------------------------------------------------------
+# Runtime
+# ---------------------------------------------------------------------------
+# wasmtime only, deliberately.  It is what CI installs and what this harness
+# was validated against (46.0.0).  Adding another runtime means adding a
+# `wasm_run` implementation below and verifying its `--dir`-equivalent
+# actually pre-opens the repo root; an unverified invocation would report
+# every file as broken, which is worse than skipping.
+
+set -uo pipefail
+
+# shellcheck source=tests/scheme/shell-common.sh
+. "$(dirname "$0")/../shell-common.sh"
+
+KAAPPI="${1:-${KAAPPI:-zig-out/bin/kaappi}}"
+case "$KAAPPI" in
+    /* | ?:[/\\]*) ;;
+    *) KAAPPI="$PWD/$KAAPPI" ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+WASM="${KAAPPI_WASM:-zig-out/bin/kaappi.wasm}"
+
+if [ ! -x "$KAAPPI" ]; then
+    echo "FAIL: no kaappi binary at $KAAPPI (run 'zig build' first)"
+    exit 1
+fi
+if ! command -v wasmtime > /dev/null 2>&1; then
+    echo "SKIP: no wasmtime on PATH (see the Runtime note in this script)"
+    exit 77
+fi
+if [ ! -f "$WASM" ]; then
+    echo "SKIP: no wasm module at $WASM (run 'zig build wasm' first)"
+    exit 77
+fi
+
+TIMEOUT="${KAAPPI_WASM_DIFF_TIMEOUT:-60}"
+VERBOSE="${KAAPPI_WASM_DIFF_VERBOSE:-0}"
+
+# Portable timeout: stock macOS has no GNU `timeout`; the perl fallback is the
+# only thing guaranteed on the BSD reference boxes.  Same ladder as
+# tests/scheme/audit-baseline.sh and the sibling script.
+if command -v timeout > /dev/null 2>&1; then
+    run_timeout() { timeout "$@"; }
+elif command -v gtimeout > /dev/null 2>&1; then
+    run_timeout() { gtimeout "$@"; }
+else
+    run_timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
+fi
+timed_out() { [ "$1" -eq 124 ] || [ "$1" -eq 142 ] || [ "$1" -eq 143 ]; }
+
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/kaappi-wasmdiff-XXXXXX")"
+if [ "${KAAPPI_WASM_DIFF_KEEP:-0}" = "1" ]; then
+    trap 'echo "kept: $TMPROOT"' EXIT
+else
+    trap 'rm -rf "$TMPROOT"' EXIT
+fi
+
+# ---------------------------------------------------------------------------
+# Corpus
+# ---------------------------------------------------------------------------
+
+CORPUS_DIRS="tests/scheme/differential/probes
+tests/scheme/smoke
+tests/scheme/compliance
+tests/scheme/audit"
+
+if [ "${KAAPPI_WASM_DIFF_FULL:-0}" = "1" ]; then
+    CORPUS_DIRS="$CORPUS_DIRS
+tests/scheme/continuations
+tests/scheme/hygiene
+tests/scheme/srfi"
+fi
+
+# Real, filed, unfixed divergences.  `basename` per line; the comment carries
+# the issue.  A listed file that stops diverging is reported as STALE.
+#
+# deep-nesting-print.scm      kaappi#2107 — write/display of a car-nested
+#   structure deeper than 847 aborts the module (shadow-stack underflow);
+#   MAX_PRINT_DEPTH's 1024 guard is unreachable on wasm32.  This file nests
+#   200000 deep, so it aborts where native truncates and passes.
+# command-line-o-flag.scm     kaappi#2109 — (command-line) is '() on WASM
+#   because main.zig's WASM entry returns before vm.command_line_args is set.
+# condexpand-include-lib-868-879.scm  kaappi#2108 — cond-expand (library …)
+#   over a file-backed .sld, the same resolver failure as the LIBDIFF bucket,
+#   but reported through cond-expand rather than a KP2001, so it does not
+#   match that bucket's signature.
+# large-index-bounds-1912.scm kaappi#1912 — index arguments are truncated to
+#   u32 inside the bounds check on wasm32, so 2^32+1 aliases element 1: a
+#   silent wrong read, and a silent wrong WRITE. Written as a probe for this
+#   harness; see its header for the control that pins it to truncation.
+KNOWN_DIFFS="
+deep-nesting-print.scm
+command-line-o-flag.scm
+condexpand-include-lib-868-879.scm
+large-index-bounds-1912.scm
+"
+
+is_known_diff() {
+    local line base
+    base="$(basename "$1")"
+    # shellcheck disable=SC2086  # deliberate word splitting over the entry list
+    for line in $KNOWN_DIFFS; do
+        [ "$line" = "$base" ] && return 0
+    done
+    return 1
+}
+
+# note_stale <file>: record that a KNOWN_DIFFS file did NOT produce the
+# divergence it is listed for.
+#
+# Called from every terminal bucket except KNOWN itself and NONDET — not just
+# from the agreeing path.  A listed file that starts agreeing is the obvious
+# case, but one that shifts into LIBDIFF or PLATFORM is equally stale: the
+# recorded divergence is no longer what happens, and leaving the entry in
+# place would keep suppressing a bucket nobody reviewed.  NONDET is excluded
+# deliberately, since a flaky run would otherwise report a perfectly good
+# entry as stale.
+note_stale() {
+    if is_known_diff "$1"; then
+        STALE="$STALE
+  $(basename "$1")"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Run helpers
+# ---------------------------------------------------------------------------
+
+# run_native <home> <out> <err> <file>
+run_native() {
+    local home="$1" out="$2" err="$3" f="$4"
+    export KAAPPI_HOME="$home"
+    run_timeout "$TIMEOUT" "$KAAPPI" "$f" > "$out" 2> "$err"
+}
+
+# run_wasm <out> <err> <file>
+# Paths stay RELATIVE to the repo root: wasmtime pre-opens "." there, and a
+# host absolute path is not resolvable inside the guest.
+run_wasm() {
+    local out="$1" err="$2" f="$3"
+    run_timeout "$TIMEOUT" wasmtime run --dir=. "$WASM" "$f" > "$out" 2> "$err"
+}
+
+normalise() {
+    sed -E \
+        -e "s|${TMPROOT}[A-Za-z0-9._/-]*|<tmp>|g" \
+        -e "s|${REPO_ROOT}|<repo>|g" \
+        -e 's|/private/var/folders/[A-Za-z0-9._/+-]*|<tmp>|g' \
+        -e 's|/var/folders/[A-Za-z0-9._/+-]*|<tmp>|g' \
+        -e 's|/tmp/[A-Za-z0-9._/+-]*|<tmp>|g' \
+        -e 's|:[0-9]+:[0-9]+|:<line>:<col>|g' \
+        -e 's|\(eval\):[0-9]+|(eval):<line>|g' \
+        -e 's|\.scm:[0-9]+|.scm:<line>|g' \
+        -e 's|line [0-9]+|line <n>|g' \
+        "$1"
+}
+
+# wasm_only_match <pattern> <native-err> <wasm-err>: the wasm run reports it
+# and the native run does not.  Both greps read files directly — never the
+# right-hand side of a pipe, so `pipefail` has no pipeline to misjudge.
+wasm_only_match() {
+    grep -Eq "$1" "$3" 2> /dev/null && ! grep -Eq "$1" "$2" 2> /dev/null
+}
+
+LIB_SIGNATURE='KP2001|library not found'
+# The engine's own platform-gate wording (kaappi#1972/#2016) plus the FFI
+# names that are simply not registered on this target.  Matching the message
+# rather than a file list is what keeps a *degraded* gate from being confused
+# with a *working* one: if these stop being reported cleanly, the file lands
+# in DIFF instead of here.
+PLATFORM_SIGNATURE='this WebAssembly build has no filesystem access|undefined variable .(ffi-open|ffi-fn|ffi-close|ffi-callback|fd->port).'
+
+# ---------------------------------------------------------------------------
+# Counters
+# ---------------------------------------------------------------------------
+
+TOTAL=0
+COMPARED=0
+AGREE=0
+LIBDIFF=0
+PLATFORM=0
+KNOWN=0
+DIFF=0
+NONDET=0
+BASE_TIMEOUT=0
+WASM_TIMEOUT=0
+COSMETIC=0
+FAILED_FILES=""
+STALE=""
+
+report_diff() {   # report_diff <file> <what> <expected> <actual>
+    echo "  DIFF  $1 — $2"
+    diff -u "$3" "$4" 2> /dev/null | sed -e '1,2d' -e 's/^/        /' | head -30
+}
+
+# ---------------------------------------------------------------------------
+# Per-file differential
+# ---------------------------------------------------------------------------
+
+check_file() {
+    local f="$1"
+    local d="$TMPROOT/work"
+    rm -rf "$d"
+    mkdir -p "$d/home1" "$d/home2"
+
+    local rc_base rc_wasm
+
+    run_native "$d/home1" "$d/base.out" "$d/base.err" "$f"
+    rc_base=$?
+    if timed_out $rc_base; then
+        echo "  TIMEOUT  $f  (native baseline, ${TIMEOUT}s) — not a tier finding; see run-all.sh"
+        BASE_TIMEOUT=$((BASE_TIMEOUT + 1))
+        return 0
+    fi
+
+    run_wasm "$d/wasm.out" "$d/wasm.err" "$f"
+    rc_wasm=$?
+    # A hang is a finding (audit v2 protocol): the WASM reactor degrades to
+    # CLOCK-only poll_oneoff waits, so a fd wait that can never be ready is
+    # exactly the shape that hangs here and not natively.
+    if timed_out $rc_wasm; then
+        echo "  HANG  $f  (wasm, ${TIMEOUT}s) — native completed in time"
+        WASM_TIMEOUT=$((WASM_TIMEOUT + 1))
+        FAILED_FILES="$FAILED_FILES
+  [wasm hang] $f"
+        return 0
+    fi
+
+    COMPARED=$((COMPARED + 1))
+
+    normalise "$d/base.err" > "$d/base.nerr"
+    normalise "$d/wasm.err" > "$d/wasm.nerr"
+
+    local bad=0 cosmetic=0
+    [ "$rc_wasm" != "$rc_base" ] && bad=1
+    cmp -s "$d/base.out" "$d/wasm.out" || bad=1
+    if ! cmp -s "$d/base.nerr" "$d/wasm.nerr"; then
+        bad=1
+    elif ! cmp -s "$d/base.err" "$d/wasm.err"; then
+        cosmetic=1
+    fi
+
+    if [ $bad -eq 0 ]; then
+        AGREE=$((AGREE + 1))
+        [ $cosmetic -eq 1 ] && {
+            COSMETIC=$((COSMETIC + 1))
+            echo "  NOTE  $f — stderr differs only in paths/line numbers"
+        }
+        note_stale "$f"
+        [ "$VERBOSE" = "1" ] && echo "  ok    $f"
+        return 0
+    fi
+
+    # --- bucket the mismatch ---------------------------------------------
+    # Order matters: the library failure is checked first because a file that
+    # cannot import its library never reaches whatever else it would have hit.
+    if wasm_only_match "$LIB_SIGNATURE" "$d/base.err" "$d/wasm.err"; then
+        LIBDIFF=$((LIBDIFF + 1))
+        note_stale "$f"
+        [ "$VERBOSE" = "1" ] && echo "  LIBDIFF  $f  (no .sld on WASM — kaappi#2108)"
+        return 0
+    fi
+    if wasm_only_match "$PLATFORM_SIGNATURE" "$d/base.err" "$d/wasm.err"; then
+        PLATFORM=$((PLATFORM + 1))
+        note_stale "$f"
+        [ "$VERBOSE" = "1" ] && echo "  PLATFORM  $f  (documented WASM degradation, reported cleanly)"
+        return 0
+    fi
+
+    # --- discriminating control ------------------------------------------
+    # Does the native side agree with ITSELF?  A second baseline in a fresh
+    # home; if the two disagree, the file is nondeterministic and no tier is
+    # implicated.  Paid only once something already looks wrong.
+    local rc_ctl
+    run_native "$d/home2" "$d/ctl.out" "$d/ctl.err" "$f"
+    rc_ctl=$?
+    normalise "$d/ctl.err" > "$d/ctl.nerr"
+    if [ "$rc_ctl" != "$rc_base" ] ||
+        ! cmp -s "$d/base.out" "$d/ctl.out" ||
+        ! cmp -s "$d/base.nerr" "$d/ctl.nerr"; then
+        echo "  NONDET  $f  (two native baseline runs disagree — excluded, not a tier finding)"
+        NONDET=$((NONDET + 1))
+        return 0
+    fi
+
+    # Require the divergence to REPRODUCE — the control above can pass by
+    # luck on an intermittently flaky file.
+    local rc_w2
+    run_wasm "$d/w2.out" "$d/w2.err" "$f"
+    rc_w2=$?
+    normalise "$d/w2.err" > "$d/w2.nerr"
+    if [ "$rc_w2" = "$rc_base" ] && cmp -s "$d/base.out" "$d/w2.out" &&
+        cmp -s "$d/base.nerr" "$d/w2.nerr"; then
+        echo "  NONDET  $f  (divergence did not reproduce — flaky, not a finding)"
+        NONDET=$((NONDET + 1))
+        return 0
+    fi
+
+    if is_known_diff "$f"; then
+        KNOWN=$((KNOWN + 1))
+        echo "  KNOWN  $f  (see KNOWN_DIFFS)"
+        return 0
+    fi
+
+    DIFF=$((DIFF + 1))
+    FAILED_FILES="$FAILED_FILES
+  [wasm] $f"
+    echo "  DIFF  $f  (exit $rc_base native vs $rc_wasm wasm)"
+    cmp -s "$d/base.out" "$d/wasm.out" || report_diff "$f" stdout "$d/base.out" "$d/wasm.out"
+    cmp -s "$d/base.nerr" "$d/wasm.nerr" || report_diff "$f" stderr "$d/base.nerr" "$d/wasm.nerr"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+echo "=== differential: WASM tier vs interpreter oracle ==="
+echo "native:  $KAAPPI ($("$KAAPPI" --version 2> /dev/null | head -1))"
+echo "wasm:    $WASM"
+echo "runtime: $(wasmtime --version 2> /dev/null | head -1)"
+printf 'corpus: '
+# shellcheck disable=SC2086  # deliberate word splitting over the dir list
+printf '%s ' $CORPUS_DIRS
+echo ""
+echo ""
+
+START=$(date +%s)
+# shellcheck disable=SC2086  # deliberate word splitting over the dir list
+for dir in $CORPUS_DIRS; do
+    [ -d "$dir" ] || continue
+    for f in "$dir"/*.scm; do
+        [ -e "$f" ] || continue
+        TOTAL=$((TOTAL + 1))
+        check_file "$f"
+    done
+done
+ELAPSED=$(($(date +%s) - START))
+
+echo ""
+echo "=== summary ==="
+echo "  corpus files:                    $TOTAL"
+echo "  skipped (native timeout):        $BASE_TIMEOUT"
+echo "  compared:                        $COMPARED"
+echo ""
+echo "  agree (stdout+exit+stderr):      $AGREE"
+echo "  excluded, no .sld on WASM:       $LIBDIFF  (kaappi#2108)"
+echo "  excluded, documented degradation:$PLATFORM"
+echo "  nondeterministic (excluded):     $NONDET"
+echo "  known divergences hit:           $KNOWN (suppressed; see KNOWN_DIFFS)"
+echo "  stderr cosmetic-only notes:      $COSMETIC"
+echo ""
+echo "  DIVERGENCES:                     $DIFF"
+echo "  wasm hangs:                      $WASM_TIMEOUT"
+
+if [ "$COMPARED" -gt 0 ] && [ "$LIBDIFF" -gt $((COMPARED / 2)) ]; then
+    echo ""
+    echo "  NOTE: over half the corpus could not run on this tier at all"
+    echo "        (kaappi#2108).  A green result here covers $AGREE files, not $COMPARED."
+fi
+if [ -n "$STALE" ]; then
+    echo ""
+    echo "  STALE: these KNOWN_DIFFS entries no longer diverge — delete them"
+    echo "         from run-wasm-differential.sh (not a failure):$STALE"
+fi
+echo ""
+echo "  elapsed: ${ELAPSED}s"
+
+if [ $((DIFF + WASM_TIMEOUT)) -gt 0 ]; then
+    echo ""
+    echo "FAIL: $((DIFF + WASM_TIMEOUT)) WASM tier divergence(s):$FAILED_FILES"
+    exit 1
+fi
+echo ""
+echo "PASS: no unknown WASM tier divergence across $COMPARED files"
+exit 0

--- a/tests/scheme/smoke/deep-nesting-print-tier-margin.scm
+++ b/tests/scheme/smoke/deep-nesting-print-tier-margin.scm
@@ -1,0 +1,56 @@
+;;; Cross-tier canary for the printer's car-recursion depth (audit v2, Phase 4D).
+;;;
+;;; `printer.zig` bounds its car-recursion at MAX_PRINT_DEPTH = 1024 and walks
+;;; the cdr spine iteratively, so a deep proper list costs no stack while a
+;;; deep CAR nest costs one frame per level. That bound is only safe if the
+;;; target's stack can hold 1024 such frames.
+;;;
+;;; On wasm32 it cannot: `write` of an 848-deep car nest exhausts the shadow
+;;; stack and aborts the module with an out-of-bounds memory access, before the
+;;; 1024 guard can fire and with no Kaappi diagnostic (kaappi#2107 — the guard
+;;; is calibrated to the 64 MB stack build.zig gives every NATIVE executable;
+;;; wasm_exe is the one with no stack_size set). Its sibling
+;;; deep-nesting-print.scm nests 200000 deep and so aborts there outright; it
+;;; is listed in run-wasm-differential.sh's KNOWN_DIFFS until #2107 is fixed.
+;;;
+;;; This file is the positive control that stays green on BOTH tiers, so the
+;;; differential keeps watching the margin instead of only the known failure.
+;;; Depth 500 is deliberate: comfortably under the measured 847 cliff (a ~40%
+;;; margin, so it cannot flake on a runtime whose frame layout differs
+;;; slightly), and comfortably under MAX_PRINT_DEPTH, so it exercises real
+;;; recursion rather than the truncation path. A change that materially grows
+;;; the per-frame cost, shrinks the WASM stack, or raises MAX_PRINT_DEPTH shows
+;;; up here as a tier divergence rather than silently eating the headroom.
+;;;
+;;; Deliberately import-free so it costs nothing on the other tiers.
+
+(define (nest n acc) (if (= n 0) acc (nest (- n 1) (list acc))))
+
+(define depth 500)
+
+;; Depth 500 renders as 500 open parens + "()" + 500 close parens.
+(define expected (+ 500 2 500))
+
+(define port (open-output-string))
+(write (nest depth '()) port)
+(define actual (string-length (get-output-string port)))
+
+(if (= actual expected)
+    (begin (display "PASS: car-nested write at depth 500, length=")
+           (display actual)
+           (newline))
+    (begin (display "FAIL: car-nested write at depth 500 — expected length ")
+           (display expected)
+           (display ", got ")
+           (display actual)
+           (newline)))
+
+;; The cdr spine is walked iteratively, so this is 400x more pairs at O(1)
+;; stack. It is the control that keeps the assertion above attributable to
+;; recursion DEPTH rather than to structure size.
+(define (mk n acc) (if (= n 0) acc (mk (- n 1) (cons 1 acc))))
+(define flat-port (open-output-string))
+(write (mk 200000 '()) flat-port)
+(if (= (string-length (get-output-string flat-port)) 400001)
+    (begin (display "PASS: cdr-nested write of 200000 pairs") (newline))
+    (begin (display "FAIL: cdr-nested write of 200000 pairs") (newline)))

--- a/tests/scheme/smoke/large-index-bounds-1912.scm
+++ b/tests/scheme/smoke/large-index-bounds-1912.scm
@@ -1,0 +1,44 @@
+;;; Large-index bounds checking, and the cross-tier probe for kaappi#1912.
+;;;
+;;; Natively this is an ordinary regression test: an index far beyond any
+;;; vector's length must raise, whether or not its low 32 bits happen to be in
+;;; range.
+;;;
+;;; On wasm32 it is the probe for kaappi#1912. Index arguments are @intCast to
+;;; usize INSIDE the bounds comparison, and usize is u32 there, so 2^32+1 wraps
+;;; to 1 before the check, passes it, and aliases element 1 — a silent wrong
+;;; read, and for vector-set! a silent wrong WRITE to a valid-but-unintended
+;;; element. Measured (wasmtime 46.0.0, v0.22.1):
+;;;
+;;;     (vector-ref v 4294967297)   native: raised   wasm32: 11
+;;;     (vector-set! v 4294967297 99) then (vector-ref v 1)
+;;;                                 native: 11       wasm32: 99
+;;;
+;;; The 2^32+9 line is the discriminating control that makes this attributable
+;;; to low-32-bit truncation rather than to a missing bounds check: its low 32
+;;; bits are 9, which still exceeds the length 4, so it raises on BOTH tiers.
+;;;
+;;; run-wasm-differential.sh lists this file in KNOWN_DIFFS against #1912, so
+;;; the divergence does not fail the run while the bug is open — and its STALE
+;;; check reports the entry once the tiers agree again, which is the signal to
+;;; delete both the entry and this note.
+;;;
+;;; Deliberately import-free so it runs on every tier.
+
+(define v (vector 10 11 12 13))
+
+(define (try thunk) (guard (e (#t 'raised)) (thunk)))
+
+;; 2^32+1 — low 32 bits are 1, which IS in range for a 4-element vector.
+(display (list 'ref-2^32+1 (try (lambda () (vector-ref v 4294967297)))))
+(newline)
+
+;; Control: 2^32+9 — low 32 bits are 9, still out of range. Raises everywhere.
+(display (list 'ref-2^32+9 (try (lambda () (vector-ref v 4294967305)))))
+(newline)
+
+;; The write side, which is the more serious half: element 1 must be untouched.
+(display (list 'set-2^32+1
+               (try (lambda () (vector-set! v 4294967297 99)))
+               'elt1 (vector-ref v 1)))
+(newline)


### PR DESCRIPTION
Audit v2 Phase 4D (#1890). The WASM tier ships in every release and backs the playground; it was checked by four hand-written programs plus an exit code, so a build that ran but answered differently would pass.

`tests/scheme/differential/run-wasm-differential.sh` is the sibling of Phase 4B's harness (#1923). The interpreter is the oracle; every corpus file must produce byte-identical stdout, an identical exit status, and identical normalised stderr under `wasmtime run --dir=.`. It exits 77 where there is no runtime or module, so `run-all.sh` picks it up everywhere and only runs it where it can. Also wired into CI's `wasm` job, which now builds the native oracle too (timeout 10 -> 20 min).

## What the sweep found

591 files. **184 agree byte-for-byte**, 3 are documented degradations, **4 diverge** — three of them new:

| | Finding |
|---|---|
| **#2107** | `write`/`display` of an **848**-deep car nest aborts the module with an out-of-bounds memory access — the shadow stack runs off the bottom and wraps past address 0. `MAX_PRINT_DEPTH`'s 1024 guard is *unreachable* on wasm32: `build.zig` gives every native executable a 64 MB stack and `wasm_exe` is the one with no `stack_size` at all. **Uncatchable** — a `guard` with a `#t` clause never runs. The regression test for closed #49 is itself one of the files that aborts. |
| **#2108** | **No file-backed `.sld` is importable, even when the host mounts it.** `platform.openRead` has no WASI branch (`AT.FDCWD` is not a WASI concept), so `resolveLibraryPath`'s existence probe fails for every candidate path. This is why **401 of 591** files cannot run on this tier. Contradicts `vm_library.zig:329`'s own comment, *"a host that does mount lib/ still serves those fine"* — CI is exactly such a host. |
| **#2109** | `(command-line)` is `'()` (R7RS 6.14: *"The first string corresponds to the command name"*) and `vm.lib_paths` is empty — `main.zig`'s WASM entry returns before both are set, leaving a now-dead `if (!is_wasm)` inside the block it skips. |
| **#1912** | Pre-existing, now pinned: index arguments truncate to u32 inside the bounds check, so `2^32+1` aliases element 1 — a silent wrong read and a silent wrong **write**. |

Each was reproduced on a fresh build with a discriminating control. For #2107 two: building the same structure without printing it survives at every depth, and a **cdr**-nested list of 200,000 pairs (236x more pairs) prints fine on both tiers — the printer walks the cdr spine iteratively and recurses only into cars. For #2108: `lib/srfi/2.sld` runs fine *as a script* but cannot be resolved *as a library*, same path, same process, same mount — so it is the resolver, not the mount.

One hypothesis was **dropped** after checking rather than filed: `libraryFileExists` does not consult `findEmbeddedLibrary`, which predicts a #2019-shaped `cond-expand`/import disagreement for the two embedded libraries. Both actually agree, on both tiers.

## Honesty about coverage

The summary reports the 401 unrunnable files as their own line, and prints a note when they exceed half the corpus, so a green run cannot be mistaken for broad coverage: **it covers 184 files, not 591**. That is the same discipline as the sibling's optimiser-vacuity meter. When #2108 is fixed the count collapses and the compared count jumps; if it does not, something else broke.

## Tests

Two probes join the shared corpus, both import-free so they cost nothing on other tiers:

- `large-index-bounds-1912.scm` — pins #1912, with the `2^32+9` control that attributes it to low-32-bit truncation rather than to a missing bounds check.
- `deep-nesting-print-tier-margin.scm` — the *positive* control for #2107, at depth 500: a 40% margin under the measured 847 cliff, so it cannot flake, and the harness watches the headroom instead of only the known failure.

`KNOWN_DIFFS` suppresses the four while they are open. `note_stale` reports an entry that stops diverging — from the agreeing, library **and** platform buckets, since an entry that merely shifts bucket is equally stale and would otherwise keep suppressing a bucket nobody reviewed. Verified by planting entries that land in two different buckets; both were reported, and the four real ones were not.

## Verification

`bash tests/scheme/run-all.sh` on macOS aarch64, ReleaseSafe, at this branch's HEAD:

```
Scheme files: 666 pass, 0 fail, 0 timeout, 0 skipped
R7RS suite:   1395 pass, 0 fail
Total:        2061 pass, 0 fail
```

Runtime: wasmtime 46.0.0. Harness cost 55s (default corpus) / 106s (`KAAPPI_WASM_DIFF_FULL=1`).

Neither `docs/audit-strategy.md` nor `CHANGELOG.md` is touched, per the concurrent-unit protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
