### PR TITLE
Phase 4C: give the compile suite an interpreter oracle — 23 scripts, not 22; 8 already compared tiers, not 2; 11 converted and 4 live divergences found

### DIFF
--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -170,6 +170,37 @@ Conventions:
   matching the last line of the output hides it, matching the first line
   exposes it. The here-string has no pipeline for `pipefail` to judge.
 
+### The interpreter is the oracle (`compile/`)
+
+A test for a non-interpreter execution tier — a natively compiled binary, a
+`-Dbundle` standalone — asserts `native output == interpreter output`, not
+`native output == a string someone typed`. `shell-common.sh` provides
+`interp_stdout` and `assert_tiers_agree`; its "interpreter as the native tier's
+oracle" block is the full rationale and lists the three tier differences that
+are **by design** (documented in `docs/dev/fuzzing.md`) and must not be
+compared: the VM echoes a bare top-level expression's value and a native binary
+does not, the VM continues past a top-level error while a native binary exits
+at the first, and a procedure prints as `#<procedure name>` vs `#<procedure>`.
+
+Keep the golden string too, as a second assertion against the *interpreter* —
+it documents intent and still catches a bug both tiers share. What it must not
+be is the only thing between a miscompilation and a green run: kaappi#2092 was
+a form evaluated at the wrong *time* natively, printing `BPC` where the
+interpreter printed `PBC`, and a golden only catches that if someone thought to
+write `PBC` down. Converting the suite (kaappi#2110) found four live tier
+divergences the golden strings had been silent about: kaappi#2115, kaappi#2117,
+kaappi#2118, and kaappi#2119.
+
+Three things genuinely have no interpreter counterpart, and stay golden:
+assertions that **compilation fails** (`native-external-library-import-1743.sh`),
+assertions about **emitted LLVM IR** — which tier ran, root-stack balance
+(`native-let-internal-define-root-1854.sh`, `-1861`, `-1862`) — and the **text
+of a native diagnostic**, since the VM frames one with file:line and a source
+excerpt and the native runtime does not. A named `.sbc` is a fourth: nothing
+can execute one (`kaappi out.sbc` reads it as source), so
+`compile-preamble-699.sh` has no runnable second tier short of a ~180s
+`-Dbundle` rebuild.
+
 ## Quirks
 
 - `run-all.sh` parses R7RS suite output with awk — don't change its output format.

--- a/tests/scheme/compile/compile-import-error-703.sh
+++ b/tests/scheme/compile/compile-import-error-703.sh
@@ -32,11 +32,13 @@ trap 'rm -rf "$DIR"' EXIT
 
 EXPECTED="703: Hello, world! #t"
 
-# Run in interpreter mode — must succeed
+# The interpreter is the oracle; the golden string documents intent and still
+# catches a value both tiers get wrong. See the "interpreter as the native
+# tier's oracle" block in ../shell-common.sh.
 OUTPUT=$("$KAAPPI" --lib-path "$FIXTURE/lib" "$FIXTURE/main.scm" 2>/dev/null)
-LINE=$(printf '%s\n' "$OUTPUT" | grep '^703: ' || true)
-if [[ "$LINE" != "$EXPECTED" ]]; then
-    echo "FAIL: interpreter mode — expected '$EXPECTED', got '$LINE'" >&2
+INTERP_LINE=$(printf '%s\n' "$OUTPUT" | grep '^703: ' || true)
+if [[ "$INTERP_LINE" != "$EXPECTED" ]]; then
+    echo "FAIL: interpreter mode — expected '$EXPECTED', got '$INTERP_LINE'" >&2
     echo "full output: $OUTPUT" >&2
     exit 1
 fi
@@ -48,8 +50,8 @@ bundle_fixture_binary "$REPO_DIR" "$KAAPPI" "$BUNDLE_BIN"
 
 OUTPUT=$("$BUNDLE_BIN" 2>/dev/null)
 LINE=$(printf '%s\n' "$OUTPUT" | grep '^703: ' || true)
-if [[ "$LINE" != "$EXPECTED" ]]; then
-    echo "FAIL: standalone mode — expected '$EXPECTED', got '$LINE'" >&2
+if [[ "$LINE" != "$INTERP_LINE" ]]; then
+    echo "FAIL: standalone '$LINE' != interpreter '$INTERP_LINE'" >&2
     echo "full output: $OUTPUT" >&2
     exit 1
 fi

--- a/tests/scheme/compile/compile-preamble-699.sh
+++ b/tests/scheme/compile/compile-preamble-699.sh
@@ -10,6 +10,16 @@
 # the bundle tests (compile-preamble-gc-700.sh, compile-import-error-703.sh),
 # which embed the .sbc and replay its preamble via readFromBuffer.
 #
+# This is one of the compile suite's genuine exceptions to the
+# interpreter-oracle rule (kaappi#2110): the tier under test is a NAMED .sbc,
+# and nothing can execute one. `kaappi out.sbc` reads it as source and dies at
+# the `KPBC` magic; the only executor is `zig build -Dbundle`, a ~180s whole-
+# interpreter rebuild that 700/703 already pay for once, via a shared fixture
+# with a different program. So the assertion below is a golden value, and the
+# comparison it is standing in for is made by those two scripts instead. What
+# this script can still check, and now does, is that `--compile` produced a
+# non-empty artifact rather than claiming success and writing nothing.
+#
 # Usage: bash tests/scheme/compile/compile-preamble-699.sh [path-to-kaappi]
 
 set -euo pipefail
@@ -35,6 +45,11 @@ cat > "$COMPILE_DIR/test.scm" << 'SCHEME'
 SCHEME
 
 "$KAAPPI" --compile -o "$COMPILE_DIR/test.sbc" "$COMPILE_DIR/test.scm" > /dev/null 2>&1
+
+if [[ ! -s "$COMPILE_DIR/test.sbc" ]]; then
+    echo "FAIL: --compile exited 0 but wrote no (or an empty) .sbc" >&2
+    exit 1
+fi
 
 REPLAY_OUTPUT=$("$KAAPPI" "$COMPILE_DIR/test.scm" 2>/dev/null)
 if [[ "$REPLAY_OUTPUT" != "HELLO 42" ]]; then

--- a/tests/scheme/compile/compile-preamble-gc-700.sh
+++ b/tests/scheme/compile/compile-preamble-gc-700.sh
@@ -23,9 +23,25 @@ skip_without_zig "rebuilds the interpreter with -Dbundle on this machine"
 
 KAAPPI="${1:-zig-out/bin/kaappi}"
 REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+FIXTURE="$REPO_DIR/tests/scheme/compile/fixtures/bundle-replay"
 
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
+
+EXPECTED="700: 21 10"
+
+# The interpreter is the oracle: the bundled tier replays the preamble from an
+# embedded .sbc, the interpreter loads the same libraries directly, and the two
+# must agree. The golden string documents intent and still catches a value both
+# tiers get wrong. See the "interpreter as the native tier's oracle" block in
+# ../shell-common.sh.
+INTERP_OUTPUT=$("$KAAPPI" --lib-path "$FIXTURE/lib" "$FIXTURE/main.scm" 2>/dev/null)
+INTERP_LINE=$(printf '%s\n' "$INTERP_OUTPUT" | grep '^700: ' || true)
+if [[ "$INTERP_LINE" != "$EXPECTED" ]]; then
+    echo "FAIL: interpreter mode — expected '$EXPECTED', got '$INTERP_LINE'" >&2
+    echo "full output: $INTERP_OUTPUT" >&2
+    exit 1
+fi
 
 BUNDLE_BIN="$DIR/main-standalone"
 bundle_fixture_binary "$REPO_DIR" "$KAAPPI" "$BUNDLE_BIN"
@@ -37,8 +53,8 @@ if grep -q "preamble error" <<< "$OUTPUT"; then
     exit 1
 fi
 LINE=$(printf '%s\n' "$OUTPUT" | grep '^700: ' || true)
-if [[ "$LINE" != "700: 21 10" ]]; then
-    echo "FAIL: expected '700: 21 10', got '$LINE'" >&2
+if [[ "$LINE" != "$INTERP_LINE" ]]; then
+    echo "FAIL: standalone '$LINE' != interpreter '$INTERP_LINE'" >&2
     echo "full output: $OUTPUT" >&2
     exit 1
 fi

--- a/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
+++ b/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
@@ -33,20 +33,34 @@ ensure_runtime_lib "$REPO_DIR"
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 
-check_native() {
+# The interpreter is the oracle: every one of these is a bootstrapped
+# higher-order primitive whose bytecode path was already correct, and the bug
+# was the native callback bridge. `expected` documents intent and still catches
+# a value both tiers get wrong. See the "interpreter as the native tier's
+# oracle" block in ../shell-common.sh.
+check_both() {
     local src="$1" expected="$2" label="$3"
     local bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        exit 1
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        exit 1
+    fi
+
     (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
     if [[ ! -x "$bin" ]]; then
         echo "FAIL: $label — native compile did not produce a binary" >&2
         exit 1
     fi
-    local out
-    out="$("$bin")"
-    if [[ "$out" != "$expected" ]]; then
-        echo "FAIL: $label — expected '$expected', got '$out'" >&2
-        exit 1
-    fi
+    local out status=0
+    out="$("$bin" 2> /dev/null)" || status=$?
+    assert_tiers_agree "$label" "$interp_out" "$interp_status" "$out" "$status" || exit 1
 }
 
 # --- Case 1: map with a native callback (the #1376 repro) ---
@@ -55,7 +69,7 @@ cat > "$DIR/map-single.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/map-single.scm" "(1 2)" "map-single"
+check_both "$DIR/map-single.scm" "(1 2)" "map-single"
 
 # --- Case 2: multi-list map (callback reaches the closure via apply) ---
 cat > "$DIR/map-multi.scm" << 'SCHEME'
@@ -63,7 +77,7 @@ cat > "$DIR/map-multi.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/map-multi.scm" "(11 22 33)" "map-multi"
+check_both "$DIR/map-multi.scm" "(11 22 33)" "map-multi"
 
 # --- Case 3: for-each with a side-effecting native callback ---
 cat > "$DIR/for-each.scm" << 'SCHEME'
@@ -71,7 +85,7 @@ cat > "$DIR/for-each.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/for-each.scm" "7 8 9 " "for-each"
+check_both "$DIR/for-each.scm" "7 8 9 " "for-each"
 
 # --- Case 4: dynamic-wind with three native thunks ---
 cat > "$DIR/dynamic-wind.scm" << 'SCHEME'
@@ -82,7 +96,7 @@ cat > "$DIR/dynamic-wind.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/dynamic-wind.scm" "before during after" "dynamic-wind"
+check_both "$DIR/dynamic-wind.scm" "before during after" "dynamic-wind"
 
 # --- Case 5: map inside a dynamic-wind thunk ---
 cat > "$DIR/wind-map.scm" << 'SCHEME'
@@ -93,7 +107,7 @@ cat > "$DIR/wind-map.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/wind-map.scm" "[(1 4 9)]" "wind-map"
+check_both "$DIR/wind-map.scm" "[(1 4 9)]" "wind-map"
 
 # --- Case 6: rest of the trampolined family + force still works ---
 cat > "$DIR/family.scm" << 'SCHEME'
@@ -105,7 +119,7 @@ cat > "$DIR/family.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/family.scm" "#(2 3 4)45Abcxy42" "family"
+check_both "$DIR/family.scm" "#(2 3 4)45Abcxy42" "family"
 
 # --- Case 7: callback capturing a local (native closure with upvalues) ---
 cat > "$DIR/upvalue.scm" << 'SCHEME'
@@ -115,7 +129,7 @@ cat > "$DIR/upvalue.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/upvalue.scm" "(11 12 13)" "upvalue"
+check_both "$DIR/upvalue.scm" "(11 12 13)" "upvalue"
 
 # --- Case 8: bytecode tail positions calling a native callback ---
 # Each body is wrapped in a semantically transparent (letrec () ...) — an
@@ -150,7 +164,7 @@ cat > "$DIR/tail-calls.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/tail-calls.scm" "300
+check_both "$DIR/tail-calls.scm" "300
 15
 42" "tail-calls"
 
@@ -161,12 +175,27 @@ cat > "$DIR/callcc.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/callcc.scm" "9955" "callcc"
+check_both "$DIR/callcc.scm" "9955" "callcc"
 
 # --- Case 10: errors escaping to native code report the detail ---
+#
+# The only case here that stays a golden assertion, and deliberately: the
+# *text* of the native diagnostic is what it is about. Full-output equality
+# with the interpreter is impossible — the VM frames a diagnostic with
+# file:line and a source excerpt, the native runtime prints the bare message —
+# so the tier check is the weaker but still real "both tiers reject it".
 cat > "$DIR/arity-err.scm" << 'SCHEME'
 (display (map (lambda (x y) x) (list 1 2)))
 SCHEME
+
+set +e
+interp_err="$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$DIR/arity-err.scm" 2>&1)"
+interp_status=$?
+set -e
+if [[ $interp_status -eq 0 ]]; then
+    echo "FAIL: arity-err — interpreter unexpectedly succeeded: '$interp_err'" >&2
+    exit 1
+fi
 
 bin="$DIR/arity-err.bin"
 (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/arity-err.scm" -o "$bin" > /dev/null 2>&1)

--- a/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
+++ b/tests/scheme/compile/native-boxed-shadow-divergence-1584.sh
@@ -62,13 +62,36 @@ run_bounded() {
 
 fail=0
 
-# Compile natively and check output.  When expect_native is "yes", also
-# verify that at least one user-defined native function was emitted; when
-# "no", verify that none were (the whole program fell back to eval).
+# Compile natively and require the output to match the interpreter's — the
+# oracle, since name resolution checking the innermost lexical binding first is
+# exactly what the VM always did and the native emitter did not. `expect_out`
+# documents intent and still catches an answer both tiers get wrong. See the
+# "interpreter as the native tier's oracle" block in ../shell-common.sh.
+#
+# The interpreter run is bounded too: case 5's pre-fix native failure was an
+# infinite loop, and a hang on either tier must fail rather than stall the run.
+#
+# When expect_native is "yes", also verify that at least one user-defined
+# native function was emitted; when "no", verify that none were (the whole
+# program fell back to eval). That pin has no interpreter counterpart by
+# construction — it is about which tier ran, not what it answered.
 check() {
     local name="$1" src="$2" expect_out="$3" expect_native="${4:-}"
 
     printf '%s' "$src" > "$DIR/$name.scm"
+
+    local interp_out interp_status=0
+    interp_out=$(cd "$REPO_DIR" && run_bounded "$KAAPPI_ABS" "$DIR/$name.scm" 2>/dev/null) || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $name — interpreter exited $interp_status or timed out (output: '$interp_out')" >&2
+        fail=1
+        return
+    fi
+    if [[ "$interp_out" != "$expect_out" ]]; then
+        echo "FAIL: $name — interpreter expected '$expect_out', got '$interp_out'" >&2
+        fail=1
+        return
+    fi
 
     if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
         echo "FAIL: $name — native compilation failed" >&2
@@ -76,17 +99,9 @@ check() {
         return
     fi
 
-    local out
-    if ! out=$(run_bounded "$DIR/$name" 2>/dev/null); then
-        echo "FAIL: $name — binary exited nonzero or timed out" >&2
-        fail=1
-        return
-    fi
-
-    if [[ "$out" != "$expect_out" ]]; then
-        echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
-        fail=1
-    fi
+    local out status=0
+    out=$(run_bounded "$DIR/$name" 2>/dev/null) || status=$?
+    assert_tiers_agree "$name" "$interp_out" "$interp_status" "$out" "$status" || fail=1
 
     if [[ -n "$expect_native" ]]; then
         (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1) || true

--- a/tests/scheme/compile/native-external-library-import-1743.sh
+++ b/tests/scheme/compile/native-external-library-import-1743.sh
@@ -66,26 +66,39 @@ expect_refused() {
 }
 
 # A program using only built-in libraries, or a self-contained
-# define-library, must keep compiling and running exactly as before.
+# define-library, must keep compiling and running exactly as before — and must
+# agree with the interpreter, which is the oracle. `expect_out` documents
+# intent and still catches an answer both tiers get wrong. See the "interpreter
+# as the native tier's oracle" block in ../shell-common.sh.
+#
+# The refusal cases above have no interpreter counterpart at all: the assertion
+# there is that COMPILATION fails, while the interpreter runs the very same
+# program successfully. That is the point of the guard, not a divergence.
 expect_compiles_and_runs() {
     local name="$1" src="$2" expect_out="$3"; shift 3
     printf '%s' "$src" > "$DIR/$name.scm"
+
+    local interp_out interp_status=0
+    interp_out=$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$@" "$DIR/$name.scm" 2>/dev/null) || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $name — interpreter exited $interp_status (output: '$interp_out')" >&2
+        fail=1
+        return
+    fi
+    if [[ "$interp_out" != "$expect_out" ]]; then
+        echo "FAIL: $name — interpreter expected '$expect_out', got '$interp_out'" >&2
+        fail=1
+        return
+    fi
 
     if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" "$@" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
         echo "FAIL: $name — native compilation failed" >&2
         fail=1
         return
     fi
-    local out
-    if ! out=$("$DIR/$name" 2>/dev/null); then
-        echo "FAIL: $name — binary exited nonzero" >&2
-        fail=1
-        return
-    fi
-    if [[ "$out" != "$expect_out" ]]; then
-        echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
-        fail=1
-    fi
+    local out status=0
+    out=$("$DIR/$name" 2>/dev/null) || status=$?
+    assert_tiers_agree "$name" "$interp_out" "$interp_status" "$out" "$status" || fail=1
 }
 
 # --- Case 1: third-party-style library, resolved via --lib-path, mirrors

--- a/tests/scheme/compile/native-gc-roots-1034.sh
+++ b/tests/scheme/compile/native-gc-roots-1034.sh
@@ -30,20 +30,37 @@ ensure_runtime_lib "$REPO_DIR"
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 
-check_native() {
+# The interpreter is the oracle — it roots these intermediates correctly and
+# never had the bug. `expected` documents intent and still catches a value both
+# tiers get wrong. See the "interpreter as the native tier's oracle" block in
+# ../shell-common.sh.
+#
+# KAAPPI_GC_THRESHOLD is read only by the native runtime (runtime_exports.zig),
+# so it is set on the compiled binary alone; the interpreter's own equivalent
+# is the -Dgc-stress build option, which does not apply to native codegen.
+check_both() {
     local src="$1" expected="$2" label="$3"
     local bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        exit 1
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        exit 1
+    fi
+
     (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
     if [[ ! -x "$bin" ]]; then
         echo "FAIL: $label — native compile did not produce a binary" >&2
         exit 1
     fi
-    local out
-    out="$(KAAPPI_GC_THRESHOLD=1 "$bin")"
-    if [[ "$out" != "$expected" ]]; then
-        echo "FAIL: $label — expected '$expected', got '$out'" >&2
-        exit 1
-    fi
+    local out status=0
+    out="$(KAAPPI_GC_THRESHOLD=1 "$bin" 2> /dev/null)" || status=$?
+    assert_tiers_agree "$label" "$interp_out" "$interp_status" "$out" "$status" || exit 1
 }
 
 # --- Case 1: nested cons with allocating arguments ---
@@ -58,7 +75,7 @@ cat > "$DIR/nested-cons.scm" << 'SCHEME'
   (newline))
 SCHEME
 
-check_native "$DIR/nested-cons.scm" "1234" "nested-cons"
+check_both "$DIR/nested-cons.scm" "1234" "nested-cons"
 
 # --- Case 2: let bindings with allocating inits ---
 cat > "$DIR/let-alloc.scm" << 'SCHEME'
@@ -73,7 +90,7 @@ cat > "$DIR/let-alloc.scm" << 'SCHEME'
 (f)
 SCHEME
 
-check_native "$DIR/let-alloc.scm" "10203040" "let-alloc"
+check_both "$DIR/let-alloc.scm" "10203040" "let-alloc"
 
 # --- Case 3: let* bindings with allocating inits ---
 cat > "$DIR/let-star-alloc.scm" << 'SCHEME'
@@ -86,7 +103,7 @@ cat > "$DIR/let-star-alloc.scm" << 'SCHEME'
 (g)
 SCHEME
 
-check_native "$DIR/let-star-alloc.scm" "57" "let-star-alloc"
+check_both "$DIR/let-star-alloc.scm" "57" "let-star-alloc"
 
 # --- Case 4: deeply nested calls building a list ---
 cat > "$DIR/deep-nest.scm" << 'SCHEME'
@@ -99,7 +116,7 @@ cat > "$DIR/deep-nest.scm" << 'SCHEME'
   (newline))
 SCHEME
 
-check_native "$DIR/deep-nest.scm" "135" "deep-nest"
+check_both "$DIR/deep-nest.scm" "135" "deep-nest"
 
 # --- Case 5: inline binary (cons) with call arguments ---
 cat > "$DIR/inline-cons.scm" << 'SCHEME'
@@ -110,7 +127,7 @@ cat > "$DIR/inline-cons.scm" << 'SCHEME'
   (newline))
 SCHEME
 
-check_native "$DIR/inline-cons.scm" "13" "inline-cons"
+check_both "$DIR/inline-cons.scm" "13" "inline-cons"
 
 # --- Case 6: allocation-heavy recursive function ---
 cat > "$DIR/recursive-alloc.scm" << 'SCHEME'
@@ -128,6 +145,6 @@ cat > "$DIR/recursive-alloc.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native "$DIR/recursive-alloc.scm" "1275" "recursive-alloc"
+check_both "$DIR/recursive-alloc.scm" "1275" "recursive-alloc"
 
 echo "PASS"

--- a/tests/scheme/compile/native-let-partial-emit-dup-1586.sh
+++ b/tests/scheme/compile/native-let-partial-emit-dup-1586.sh
@@ -86,8 +86,14 @@ check() {
         fail=1
         return
     fi
-    if [[ "$out" != "$expect" ]]; then
-        echo "FAIL: $name — native gave '$out', expected '$expect' (side effect duplicated?)" >&2
+    # The tier comparison, on the one line the tiers can be compared on: the
+    # native binary's whole output must equal the interpreter's final line.
+    # Full-output equality is impossible here by construction — these must be
+    # bare top-level lets to reach the incremental-emit path, and the VM echoes
+    # a bare top-level form's value while a native binary does not (documented
+    # in docs/dev/fuzzing.md, and repeated in ../shell-common.sh).
+    if [[ "$out" != "$interp_last" ]]; then
+        echo "FAIL: $name — native '$out' != interpreter's final line '$interp_last' (side effect duplicated?)" >&2
         fail=1
     fi
 }

--- a/tests/scheme/compile/native-let-tail-root-leak-1585.sh
+++ b/tests/scheme/compile/native-let-tail-root-leak-1585.sh
@@ -42,13 +42,32 @@ trap 'rm -rf "$DIR"' EXIT
 
 fail=0
 
-# Compile natively, run, and compare output. Also assert a native user function
-# was actually emitted, so a silent fallback to the interpreter (which never had
-# the bug) can never make this test pass vacuously.
+# Compile natively, run, and require the output to match the interpreter's —
+# the oracle: it never leaked a root here, and printed the right answer while
+# the native binary panicked with "GC root stack overflow". `expect_out`
+# documents intent and still catches an answer both tiers get wrong. See the
+# "interpreter as the native tier's oracle" block in ../shell-common.sh.
+#
+# Also assert a native user function was actually emitted, so a silent fallback
+# to the interpreter can never make this test pass vacuously — that pin has no
+# interpreter counterpart, being about which tier ran rather than the answer.
 check() {
     local name="$1" src="$2" expect_out="$3"
 
     printf '%s' "$src" > "$DIR/$name.scm"
+
+    local interp_out interp_status=0
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$DIR/$name.scm") || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $name — interpreter exited $interp_status (output: '$interp_out')" >&2
+        fail=1
+        return
+    fi
+    if [[ "$interp_out" != "$expect_out" ]]; then
+        echo "FAIL: $name — interpreter expected '$expect_out', got '$interp_out'" >&2
+        fail=1
+        return
+    fi
 
     if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
         echo "FAIL: $name — native compilation failed" >&2
@@ -58,19 +77,13 @@ check() {
 
     local out status
     set +e
-    out=$("$DIR/$name" 2>&1)
+    out=$("$DIR/$name" 2>/dev/null)
     status=$?
     set -e
-    if [[ $status -ne 0 ]]; then
-        echo "FAIL: $name — binary aborted (exit $status): $out" >&2
+    assert_tiers_agree "$name" "$interp_out" "$interp_status" "$out" "$status" || {
         fail=1
         return
-    fi
-    if [[ "$out" != "$expect_out" ]]; then
-        echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
-        fail=1
-        return
-    fi
+    }
 
     # Confirm this exercised native codegen rather than a fallback.
     (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$DIR/$name.ll" "$DIR/$name.scm" > /dev/null 2>&1) || true

--- a/tests/scheme/compile/native-nested-closure-1410.sh
+++ b/tests/scheme/compile/native-nested-closure-1410.sh
@@ -34,23 +34,33 @@ ensure_runtime_lib "$REPO_DIR"
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 
-check_native() {
+# The interpreter is the oracle — closure capture was always right there, and
+# the bug was the native emitter losing the upvalue. `expected` documents
+# intent and still catches a value both tiers get wrong. See the "interpreter
+# as the native tier's oracle" block in ../shell-common.sh.
+check_both() {
     local label="$1" expected="$2"
     local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        exit 1
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        exit 1
+    fi
+
     (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
     if [[ ! -x "$bin" ]]; then
         echo "FAIL: $label — native compile did not produce a binary" >&2
         exit 1
     fi
-    local out
-    if ! out="$("$bin")"; then
-        echo "FAIL: $label — binary exited nonzero (output: '$out')" >&2
-        exit 1
-    fi
-    if [[ "$out" != "$expected" ]]; then
-        echo "FAIL: $label — expected '$expected', got '$out'" >&2
-        exit 1
-    fi
+    local out status=0
+    out="$("$bin" 2> /dev/null)" || status=$?
+    assert_tiers_agree "$label" "$interp_out" "$interp_status" "$out" "$status" || exit 1
 }
 
 # 1. The issue's reproducer: capture reaches u only through an inner lambda.
@@ -59,7 +69,7 @@ cat > "$DIR/nested.scm" << 'SCHEME'
 (write ((g0 5) 0))
 (newline)
 SCHEME
-check_native "nested" "5"
+check_both "nested" "5"
 
 # 2. The let-wrapped variant from the issue.
 cat > "$DIR/nested-let.scm" << 'SCHEME'
@@ -67,7 +77,7 @@ cat > "$DIR/nested-let.scm" << 'SCHEME'
 (write ((g0 5) 0))
 (newline)
 SCHEME
-check_native "nested-let" "5"
+check_both "nested-let" "5"
 
 # 3. Chained captures are per-instance copies: closures made by separate
 #    calls must not alias (this is what distinguishes real upvalue chaining
@@ -84,7 +94,7 @@ cat > "$DIR/retention.scm" << 'SCHEME'
 (write (h3 0)) (newline)
 (write (h9 0)) (newline)
 SCHEME
-check_native "retention" "$(printf '5\n7\n3\n9')"
+check_both "retention" "$(printf '5\n7\n3\n9')"
 
 # 4. A variadic inner lambda can never be a native closure; its eval
 #    fallback must republish the captured upvalue u.
@@ -93,7 +103,7 @@ cat > "$DIR/variadic-inner.scm" << 'SCHEME'
 (write ((g0 5) 0))
 (newline)
 SCHEME
-check_native "variadic-inner" "5"
+check_both "variadic-inner" "5"
 
 # 5. Capture of both a let-local and the outer param: the let's eval
 #    fallback (#827) must republish the upvalue u alongside the params.
@@ -102,7 +112,7 @@ cat > "$DIR/let-mixed.scm" << 'SCHEME'
 (write ((g0 5) 0))
 (newline)
 SCHEME
-check_native "let-mixed" "(5 . 2)"
+check_both "let-mixed" "(5 . 2)"
 
 # 6. The rest parameter must be republished at eval boundaries too.
 cat > "$DIR/rest-capture.scm" << 'SCHEME'
@@ -110,7 +120,7 @@ cat > "$DIR/rest-capture.scm" << 'SCHEME'
 (write ((f 5 1 2) 0))
 (newline)
 SCHEME
-check_native "rest-capture" "(1 2)"
+check_both "rest-capture" "(1 2)"
 
 # 7. emitLetFallback must republish the enclosing function's params before
 #    evaluating the let form (here u is referenced by a binding init).
@@ -119,7 +129,7 @@ cat > "$DIR/let-fallback-param.scm" << 'SCHEME'
 (write ((f 5) 0))
 (newline)
 SCHEME
-check_native "let-fallback-param" "5"
+check_both "let-fallback-param" "5"
 
 # 8. A closed lambda inside a capturing closure: its own eval fallback must
 #    NOT inherit the enclosing closure's upvalue map (a closed function
@@ -130,7 +140,7 @@ cat > "$DIR/closed-inside-closure.scm" << 'SCHEME'
 (write (car pair)) (newline)
 (write ((cdr pair) 0)) (newline)
 SCHEME
-check_native "closed-inside-closure" "$(printf '5\n2')"
+check_both "closed-inside-closure" "$(printf '5\n2')"
 
 # 9. An abandoned native let (body lambda exceeds the 16-param tier cap)
 #    must pop the GC roots pushed for its bindings: 2000 calls would
@@ -146,7 +156,7 @@ cat > "$DIR/root-balance.scm" << 'SCHEME'
 (write (loop 2000))
 (newline)
 SCHEME
-check_native "root-balance" "done"
+check_both "root-balance" "done"
 
 # 10. A lambda in a let *binding init* previously aborted native compilation
 #     outright (the emission error escaped emitLet); it must fall back.
@@ -154,6 +164,6 @@ cat > "$DIR/init-lambda.scm" << 'SCHEME'
 (define glob 9)
 (let ((b (lambda (c) glob))) (write (b 0)) (newline))
 SCHEME
-check_native "init-lambda" "9"
+check_both "init-lambda" "9"
 
 echo "PASS"

--- a/tests/scheme/compile/native-param-shadow-fold-790.sh
+++ b/tests/scheme/compile/native-param-shadow-fold-790.sh
@@ -41,23 +41,35 @@ cat > "$DIR/define.scm" << 'SCHEME'
 (newline)
 SCHEME
 
-check_native() {
+# The interpreter is the oracle (it never folded a shadowed name); `expected`
+# documents intent and still catches a fold both tiers get wrong. See the
+# "interpreter as the native tier's oracle" block in ../shell-common.sh.
+check_both() {
     local src="$1" expected="$2" label="$3"
     local bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        exit 1
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        exit 1
+    fi
+
     (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
     if [[ ! -x "$bin" ]]; then
         echo "FAIL: $label — native compile did not produce a binary" >&2
         exit 1
     fi
-    local out
-    out="$("$bin")"
-    if [[ "$out" != "$expected" ]]; then
-        echo "FAIL: $label — expected '$expected', got '$out'" >&2
-        exit 1
-    fi
+    local out status=0
+    out="$("$bin" 2> /dev/null)" || status=$?
+    assert_tiers_agree "$label" "$interp_out" "$interp_status" "$out" "$status" || exit 1
 }
 
-check_native "$DIR/lambda.scm" "-1" "lambda-param-shadow"
-check_native "$DIR/define.scm" "-1" "define-param-shadow"
+check_both "$DIR/lambda.scm" "-1" "lambda-param-shadow"
+check_both "$DIR/define.scm" "-1" "define-param-shadow"
 
 echo "PASS"

--- a/tests/scheme/compile/native-rebind-stale-call-822.sh
+++ b/tests/scheme/compile/native-rebind-stale-call-822.sh
@@ -32,10 +32,29 @@ trap 'rm -rf "$DIR"' EXIT
 
 fail=0
 
+# Compile a program natively and require its stdout + exit status to match the
+# interpreter's — the oracle: a rebound global is looked up afresh on every
+# call in the VM, and the bug was the native emitter inlining the binding it
+# saw at compile time. `expect_out`/`expect_status` document intent and still
+# catch an answer both tiers get wrong. See the "interpreter as the native
+# tier's oracle" block in ../shell-common.sh.
 check() {
     local name="$1" src="$2" expect_out="$3" expect_status="$4"
 
     printf '%s' "$src" > "$DIR/$name.scm"
+
+    local interp_out interp_status=0
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm") || interp_status=$?
+    if [[ "$interp_out" != "$expect_out" ]]; then
+        echo "FAIL: $name — interpreter stdout '$interp_out' != expected '$expect_out'" >&2
+        fail=1
+        return
+    fi
+    if [[ "$interp_status" -ne "$expect_status" ]]; then
+        echo "FAIL: $name — interpreter exit $interp_status != expected $expect_status" >&2
+        fail=1
+        return
+    fi
 
     if ! (cd "$DIR" && "$KAAPPI_ABS" compile "$name.scm" -o "$name" > /dev/null 2>&1); then
         echo "FAIL: $name — native compilation failed" >&2
@@ -49,14 +68,7 @@ check() {
     status=$?
     set -e
 
-    if [[ "$out" != "$expect_out" ]]; then
-        echo "FAIL: $name — native stdout '$out' != expected '$expect_out'" >&2
-        fail=1
-    fi
-    if [[ "$status" -ne "$expect_status" ]]; then
-        echo "FAIL: $name — native exit $status != expected $expect_status" >&2
-        fail=1
-    fi
+    assert_tiers_agree "$name" "$interp_out" "$interp_status" "$out" "$status" || fail=1
 }
 
 # 1. set! replacing a natively compiled function.

--- a/tests/scheme/compile/native-set-capture-divergence-1422.sh
+++ b/tests/scheme/compile/native-set-capture-divergence-1422.sh
@@ -34,13 +34,34 @@ trap 'rm -rf "$DIR"' EXIT
 
 fail=0
 
-# Compile natively and check output.  When expect_native is "yes", also
-# verify that at least one user-defined native function was emitted; when
-# "no", verify that none were (the whole program fell back to eval).
+# Compile natively and require the output to match the interpreter's — the
+# oracle, since a boxed capture is exactly what the VM always got right and the
+# native emitter did not. `expect_out` documents intent and still catches an
+# answer both tiers get wrong. See the "interpreter as the native tier's
+# oracle" block in ../shell-common.sh.
+#
+# When expect_native is "yes", also verify that at least one user-defined
+# native function was emitted; when "no", verify that none were (the whole
+# program fell back to eval). That pin has no interpreter counterpart by
+# construction — it is about which tier ran, not what it answered — and is what
+# keeps a silent fallback from making a "native" case pass vacuously.
 check() {
     local name="$1" src="$2" expect_out="$3" expect_native="${4:-}"
 
     printf '%s' "$src" > "$DIR/$name.scm"
+
+    local interp_out interp_status=0
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$DIR/$name.scm") || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $name — interpreter exited $interp_status (output: '$interp_out')" >&2
+        fail=1
+        return
+    fi
+    if [[ "$interp_out" != "$expect_out" ]]; then
+        echo "FAIL: $name — interpreter expected '$expect_out', got '$interp_out'" >&2
+        fail=1
+        return
+    fi
 
     if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/$name.scm" -o "$DIR/$name" > /dev/null 2>&1); then
         echo "FAIL: $name — native compilation failed" >&2
@@ -48,17 +69,9 @@ check() {
         return
     fi
 
-    local out
-    if ! out=$("$DIR/$name" 2>/dev/null); then
-        echo "FAIL: $name — binary exited nonzero" >&2
-        fail=1
-        return
-    fi
-
-    if [[ "$out" != "$expect_out" ]]; then
-        echo "FAIL: $name — expected '$expect_out', got '$out'" >&2
-        fail=1
-    fi
+    local out status=0
+    out=$("$DIR/$name" 2>/dev/null) || status=$?
+    assert_tiers_agree "$name" "$interp_out" "$interp_status" "$out" "$status" || fail=1
 
     # Pin the compilation tier when requested. A native user-function definition
     # is `@lambda_N` (uniform) or, since #1499, a reserved `@rN` / `@rN.fast` /

--- a/tests/scheme/compile/set-define-lexical-scope-819.sh
+++ b/tests/scheme/compile/set-define-lexical-scope-819.sh
@@ -31,13 +31,34 @@ trap 'rm -rf "$DIR"' EXIT
 
 fail=0
 
-# Compile a program natively and check its stdout + exit status match the
-# interpreter. For the error case we match the interpreter's exit status and a
-# substring (native diagnostics are terser than the interpreter's).
+# Compile a program natively and require its stdout + exit status to match the
+# interpreter's — which is the oracle here; every one of these is plain lexical
+# scoping the VM always got right. `expect_out`/`expect_status` document intent
+# and still catch an answer both tiers get wrong, but the comparison no longer
+# rests on them. See the "interpreter as the native tier's oracle" block in
+# ../shell-common.sh.
+#
+# stdout and exit status, never stderr: case 4 errors, and after a top-level
+# error the VM reports it and moves to the next form while the native binary
+# exits at the first — so the two tiers' diagnostics legitimately differ in
+# both count and framing.
 check() {
     local name="$1" src="$2" expect_out="$3" expect_status="$4"
 
     printf '%s' "$src" > "$DIR/$name.scm"
+
+    local interp_out interp_status=0
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm") || interp_status=$?
+    if [[ "$interp_out" != "$expect_out" ]]; then
+        echo "FAIL: $name — interpreter stdout '$interp_out' != expected '$expect_out'" >&2
+        fail=1
+        return
+    fi
+    if [[ "$interp_status" -ne "$expect_status" ]]; then
+        echo "FAIL: $name — interpreter exit $interp_status != expected $expect_status" >&2
+        fail=1
+        return
+    fi
 
     if ! (cd "$DIR" && "$KAAPPI_ABS" compile "$name.scm" -o "$name" > /dev/null 2>&1); then
         echo "FAIL: $name — native compilation failed" >&2
@@ -51,14 +72,7 @@ check() {
     status=$?
     set -e
 
-    if [[ "$out" != "$expect_out" ]]; then
-        echo "FAIL: $name — native stdout '$out' != expected '$expect_out'" >&2
-        fail=1
-    fi
-    if [[ "$status" -ne "$expect_status" ]]; then
-        echo "FAIL: $name — native exit $status != expected $expect_status" >&2
-        fail=1
-    fi
+    assert_tiers_agree "$name" "$interp_out" "$interp_status" "$out" "$status" || fail=1
 }
 
 # 1. set! on a parameter must mutate the parameter slot, not define a global.

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -72,6 +72,63 @@ skip_on_debug_build() {
     fi
 }
 
+# --- the interpreter as the native tier's oracle -------------------------
+#
+# A native-backend regression test whose expected value is a hand-typed string
+# checks the compiled tier against *a human's belief about what the program
+# should print* — not against the reference implementation. It also rots: when
+# the golden value is wrong, the test pins the wrong answer forever.
+#
+# The interpreter is the oracle. Run the same source both ways and require them
+# to agree; keep the golden string too, as documentation of intent and as the
+# one thing that still catches a bug BOTH tiers share. kaappi#2092 is the
+# worked example: `define-property` inside a top-level cond/case/do evaluated
+# at the wrong *time* natively, so the native binary printed `BPC` where the
+# interpreter printed `PBC` — a plausible permutation of the right characters
+# that only a tier comparison catches by construction.
+#
+# THREE differences between the two tiers are by design, documented in
+# docs/dev/fuzzing.md ("The VM-vs-native differential batch"). A comparison
+# must not trip over them:
+#
+#   1. The VM echoes the value of a non-void bare top-level expression; a
+#      native binary does not. Test programs must print every observable
+#      explicitly (`display`/`write`) rather than leaning on the echo.
+#   2. After a top-level error the VM reports it and continues with the next
+#      form, while the native binary exits at the first one — so for an
+#      erroring program compare stdout and exit status, never stderr.
+#   3. A procedure value prints as `#<procedure name>` in the VM and
+#      `#<procedure>` natively.
+#
+# interp_stdout <kaappi> <workdir> <src>: run <src> through the interpreter
+# from <workdir>, print its stdout, and return its own exit status. stderr is
+# dropped deliberately: the two tiers' diagnostics differ in framing by design
+# (the VM prefixes file:line and a source excerpt, the native runtime does
+# not), so a script asserting on a diagnostic's text does that separately,
+# against whichever tier it means.
+interp_stdout() {
+    (cd "$2" && "$1" "$3" 2> /dev/null)
+}
+
+# assert_tiers_agree <label> <interp-out> <interp-status> <native-out> <native-status>
+# Return 0 when the two tiers agree on both stdout and exit status; otherwise
+# print a FAIL: line naming both and return 1.
+assert_tiers_agree() {
+    local label="$1" interp_out="$2" interp_status="$3" native_out="$4" native_status="$5"
+    local ok=0
+    if [ "$native_out" != "$interp_out" ]; then
+        printf "FAIL: %s — native stdout '%s' != interpreter '%s'\n" \
+            "$label" "$native_out" "$interp_out" >&2
+        ok=1
+    fi
+    if [ "$native_status" -ne "$interp_status" ]; then
+        printf 'FAIL: %s — native exit %s != interpreter exit %s\n' \
+            "$label" "$native_status" "$interp_status" >&2
+        ok=1
+    fi
+    return "$ok"
+}
+
 # --- build serialisation -------------------------------------------------
 #
 # Several scripts shell out to `zig build …`, which installs into the repo's


### PR DESCRIPTION
Audit v2 Phase 4C (tracking: #1890). Tracker item: *"Convert `tests/scheme/compile/*.sh` from golden strings to an interpreter oracle (only 2 of 22 compare tiers today)."*

A golden string checks the native tier against **a human's belief about what the program should print**, not against the reference implementation — and it rots: when the expected value is wrong, the test pins the wrong answer forever. #2092 is the worked example: `define-property` inside a top-level `cond`/`case`/`do` evaluated at the wrong *time* natively, so the binary printed `BPC` where the interpreter printed `PBC`. A tier comparison catches that by construction; a golden only if someone thought to write `PBC` down.

## Survey — 23 scripts, not 22, and 8 already compared tiers, not 2

`native-rejected-form-head-1896.sh` landed with Phase 4A earlier today, and the "2 of 22" count predates the five tier-comparing scripts written since #1799.

| # | Script | Asserted before | Now |
|--:|---|---|---|
| 1 | `compile-import-error-703.sh` | golden, one grepped line, on interpreter **and** bundle | **tier**: bundle line vs interpreter line |
| 2 | `compile-preamble-699.sh` | golden, interpreter only | **exception** + `.sbc` non-empty check |
| 3 | `compile-preamble-gc-700.sh` | golden, bundle only | **tier**: bundle line vs interpreter line |
| 4 | `define-library-many-exports-862.sh` | self-checking Scheme, exit code | **exception** (unchanged) |
| 5 | `native-apply-lexical-scope-1799.sh` | **tier** + golden | unchanged |
| 6 | `native-apply-lowering-1803.sh` | **tier** + golden; error-shape pair | unchanged |
| 7 | `native-bootstrap-callbacks-1376.sh` | golden ×9 + native diagnostic substring | **tier** ×9; diagnostic case gains "both tiers reject it" |
| 8 | `native-boxed-shadow-divergence-1584.sh` | golden ×8 + LLVM-IR tier pin | **tier** ×8, pin kept |
| 9 | `native-external-library-import-1743.sh` | compile-refusal ×4 + golden ×2 | **tier** ×2; refusals are exceptions |
| 10 | `native-gc-roots-1034.sh` | golden ×6 under `KAAPPI_GC_THRESHOLD=1` | **tier** ×6 |
| 11 | `native-let-internal-define-root-1854.sh` | **tier** + IR routing pin | unchanged |
| 12 | `native-let-partial-emit-dup-1586.sh` | interpreter *last line* vs golden; native *whole* vs golden | **tier**: native whole vs interpreter's last line |
| 13 | `native-let-tail-root-leak-1585.sh` | golden ×5 + IR native pin | **tier** ×5, pin kept |
| 14 | `native-loop-alloca-stack-growth-1808.sh` | **tier** + golden | unchanged |
| 15 | `native-macro-use-in-scope-1807.sh` | **tier** + golden | unchanged |
| 16 | `native-nested-closure-1410.sh` | golden ×10 | **tier** ×10 |
| 17 | `native-nested-let-fallback-scope-1862.sh` | **tier** + IR routing pin + IR root-balance | unchanged |
| 18 | `native-param-shadow-fold-790.sh` | golden ×2 | **tier** ×2 |
| 19 | `native-rebind-stale-call-822.sh` | golden + exit code ×7 | **tier** (stdout + exit) ×7 |
| 20 | `native-rejected-form-head-1896.sh` | **tier** + golden | unchanged |
| 21 | `native-set-capture-divergence-1422.sh` | golden ×8 + IR tier pin | **tier** ×8, pin kept |
| 22 | `native-shorthand-internal-define-scope-1861.sh` | **tier** + IR routing pin + IR root-balance | unchanged |
| 23 | `set-define-lexical-scope-819.sh` | golden + exit code ×9 — its **comment claimed** it matched the interpreter, and it never ran it | **tier** (stdout + exit) ×9 |

**11 converted, 1 upgraded** (row 12), 8 already correct, **4 genuine exceptions**. Every converted script keeps its golden string as a second assertion — now checked against the *interpreter*, where it documents intent and still catches a bug both tiers share.

## The exceptions, and why

- **Compilation must fail** (`native-external-library-import-1743.sh`, 4 cases incl. `--emit-llvm`). No counterpart: the interpreter runs the very same program successfully. That is the guard working.
- **Emitted LLVM IR** — which tier ran (`expect_native`, `whole-scope:`/`whole-define:`/`native` routing) and root-stack balance, in `-1854`/`-1861`/`-1862`/`-1584`/`-1585`/`-1422`. About *which tier ran*, not what it answered; this is what stops a silent fallback making a "native" case pass vacuously.
- **A native diagnostic's text** (`-1376` case 10, `-1803`'s `check_both_fail`). Full equality is impossible: the VM frames a diagnostic with file:line and a source excerpt, the native runtime prints the bare message. Both now at least assert *both* tiers reject the program.
- **A named `.sbc`** (`compile-preamble-699.sh`). Nothing can execute one — `kaappi out.sbc` reads it as source and dies at the `KPBC` magic — and the only executor is `zig build -Dbundle`, a ~180s whole-interpreter rebuild that 700/703 already pay for once via a shared fixture with a different program. It now at least asserts `--compile` wrote a non-empty file instead of discarding its output. `define-library-many-exports-862.sh` is adjacent: it imports an external `.sld`, which `kaappi compile` refuses by design (#1743).

## Four live divergences — filed, not fixed

Found by a throwaway tier-(c) sweep of `tests/scheme/{smoke,compliance,audit}`: of 338 files, **178 compile** (160 refused for external imports), and **25 differ**. Most of the 25 are the documented bare-top-level-value echo. Four are real, each with a discriminating control:

| Issue | Divergence | Control that discriminates |
|---|---|---|
| #2115 | A `guard` does not catch an error raised inside a natively compiled callee; the program dies. 4 smoke files. `llvm-backend.md:746` lists `guard` under "stress-tested", and `continuation-strategy.md` puts it under "Must pass natively". | The same `guard` with the raise *inline* rather than behind a call catches on both tiers |
| #2117 | Constant folding accepts a primitive the program took away, by two routes: a `set!` rebinding, and a shadowing parameter reached through an *enclosing* frame. **#600 and #790 are live again in the LLVM emitter.** | Non-constant operands are correct natively (nothing to fold); a parameter shadowing in *its own* frame is correct (#790's fix) |
| #2118 | A parameter named `if`/`quote`/`when`/… is lowered as the special form natively. **#788 likewise.** 9 assertions in its own regression test fail. | The same programs without the shadowing parameter agree on both tiers |
| #2119 | Re-invoking a top-level continuation from a native callback silently keeps the stale value — no error, exit 0. Against `continuation-strategy.md`'s stated behavioural-equivalence commitment. | An escape used *within* its dynamic extent returns 42 on both tiers |

The sweep script is deliberately **not** shipped: at 178 native compiles + links it is far too slow for `run-all.sh`, and it is tier (c) of `run-differential.sh`, which that harness's own header says "lives in its own unit".

## Mutation-test evidence

**A — the comparison is live, and catches what a golden cannot.** Appended a bare top-level expression to `native-gc-roots-1034.sh`'s first program (the VM echoes its value, a native binary does not — a genuine divergence):

```text
converted:       FAIL: nested-cons — native stdout '1234' != interpreter '1234
                 1'                                                    exit 1
pre-conversion:  PASS                                                  exit 0
```

The pre-conversion script — same program, golden `"1234"`, which is exactly what the native binary prints — is **blind to it**. That is the golden-rot failure mode, reproduced.

**B — the golden is now judged against the oracle, not against native.** Changed one golden to `10203041`:

```text
FAIL: let-alloc — interpreter expected '10203041', got '10203040'
```

It fires at the *interpreter* check. Before, a golden that happened to match a miscompiling native tier passed.

## Verification

All **VERIFIED** on macOS aarch64, ReleaseSafe, isolated `KAAPPI_HOME`, `zig cc`:

- `zig build test` — 0 failures
- `bash tests/scheme/run-all.sh` — **663 Scheme files pass, 0 fail; R7RS 1395 pass, 0 fail; total 2058 pass, 0 fail**
- `tests/scheme/compile/` alone — 23/23 PASS on a clean tree after rebuilding post-commit
- `markdownlint-cli2` — 0 issues; `bash -n` clean on every touched script

Both build-id footguns bit and were handled: the bundle tests (700/703) failed with `invalid embedded bytecode` while the tree was dirty, and again needed a rebuild after committing.

Closes nothing; #2115/#2117/#2118/#2119 stay open. Tracker tick for 4C is the orchestrator's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
