### PR TITLE
Triage the 16 unlabelled issues, and record #2107 as the 14th critical

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1295,8 +1295,9 @@ this is the part you need at filing time:
 Four rules decide the hard cases:
 
 - **`critical` is process-level unsafety only.** A correctness bug tops out
-  at `high` however broad or silent. All 13 issues ever marked critical are
-  memory unsafety or a process abort.
+  at `high` however broad or silent. All 14 issues ever marked critical are
+  memory unsafety or a process abort — including one, kaappi#2107, whose
+  abort is reachable on wasm32 only. Tier does not discount an entry.
 - **Reachability separates critical from high.** An abort needing a stress
   harness is `high`; one reachable from a five-line program is `critical`.
 - **An audit header's `Severity:` is an input, not the answer.**

--- a/docs/dev/github-issues.md
+++ b/docs/dev/github-issues.md
@@ -79,11 +79,12 @@ level has a load-bearing question behind it.
 Adopted 2026-08-01. A correctness bug does not earn `critical` no matter how
 broad or how silent — it tops out at `high`.
 
-This is not an invented rule; it describes the existing corpus. All 13 issues
+This is not an invented rule; it describes the existing corpus. All 14 issues
 ever labeled `priority: critical` are memory unsafety or a process abort:
 
 | Issue | Why critical |
 |------:|--------------|
+| [2107](https://github.com/kaappi/kaappi/issues/2107) | Printing an 848-deep list exhausts the wasm32 stack — module trap, exit 134, uncatchable |
 | [2027](https://github.com/kaappi/kaappi/issues/2027) | Deep copy aliases FFI handles across heaps; the freed slot reads back as a pair of flonums |
 | [2024](https://github.com/kaappi/kaappi/issues/2024) | A custom hash inserting into its own table double-frees the entry array |
 | [2008](https://github.com/kaappi/kaappi/issues/2008) | Cross-heap mutation of a raw `ArrayList`; silent abort or type-confused object |
@@ -121,6 +122,22 @@ in the same subsystem — a missing `in_custom_port_callback` guard at three
 `(kaappi fibers)` call sites — but the SIGBUS needs ~2500 concurrent fibers
 (2400 is clean 3/3; 2500 aborts 5/5). Below that depth the bug is real but
 non-crashing. High.
+
+[2107](https://github.com/kaappi/kaappi/issues/2107) and
+[2084](https://github.com/kaappi/kaappi/issues/2084) split the same way, and
+are the sharper pair: both are uncatchable stack exhaustion rather than a heap
+defect, so reachability is the *only* thing separating them. 2107 aborts the
+wasm32 module from a three-line program that prints an 848-deep list — below
+`printer.zig`'s own `MAX_PRINT_DEPTH` of 1024, so the program sits inside the
+envelope the implementation intends to support, and the guard that makes deep
+printing safe on every other target is simply out of reach. Critical. 2084
+needs a 200,000-bit bitvector to recurse deep enough to overflow. High.
+
+2107 is also the first critical confined to a single tier — every other row in
+the table is core-tier, reachable on the primary platform. Tier is not part of
+the rule and does not discount an entry: wasm32 backs the public playground,
+and an abort a `guard` cannot intercept is process-level whichever target it
+happens on.
 
 Every existing critical aborts from an ordinary program. That is the line.
 


### PR DESCRIPTION
Every open issue is meant to carry exactly one `priority:` label. Sixteen did
not — the gap an audit filing burst opens between triage passes, which
`docs/dev/github-issues.md` warns about directly. This labels all sixteen and
brings the rubric doc back in step with the corpus it describes.

## Labels applied

No code changes; the labels are already live on the tracker. Recorded here so
the reasoning is reviewable alongside the doc change it produced.

| Level | Issues |
|---|---|
| critical | #2107 |
| high | #2119, #2118, #2117, #2116, #2115, #2110, #2108 |
| medium | #2113, #2112, #2111, #2109, #2101, #2100, #2097 |
| low | #2114 |

The invariant now holds tracker-wide: no open issue has zero or two priority
labels, excluding the exempt auto-filed `fuzz-finding` reports.

Three calls worth surfacing, since each went against a first reading:

- **#2107 is critical, not high.** Its nearest neighbours in the corpus
  (#2084, #2035, #1976, #1983) are all aborts labelled `high`, which is what
  I matched it to first. But the written rule is "memory unsafety, **or** an
  abort reachable from an ordinary program", and the corpus already contains
  pure-abort criticals (#1907, a reader panic on `#e`; #1191, a GC root-stack
  panic). #2107's repro is three lines. The rule's text wins over the nearest
  precedent.
- **The four `.sbc` cache issues split across two levels** (#2110 high,
  #2111/#2112/#2113 medium) even though they would likely be fixed together.
  #2110 silently drops R7RS §3.4 immutability for *every* literal in any
  cached program; the other three need datum labels, a runtime `eval` of a
  macro, or oversized constants respectively. Narrow triggers, per the medium
  question's "loud, narrow, or recoverable".
- **#2116 is high despite being tooling.** A CI gate blind spot usually lands
  low (#2026). This one is not a blind spot in a lint — 54 regression tests
  report green unconditionally, and one was demonstrably green under the very
  regression it was written to catch. Silent, broad, and not recoverable: a
  green run tells you nothing.

## The doc change

`docs/dev/github-issues.md` keeps a table of every issue ever labelled
critical, so that triage has something to calibrate against rather than a bare
rule. #2107 has to be in it, and the count it opens with is stated twice — in
the doc and again in `CLAUDE.md`'s summary — so both would have contradicted
the tracker.

The entry earns more than a row:

- It is the first critical that is **stack exhaustion rather than a heap
  defect**, which makes #2107/#2084 a sharper reachability pair than the
  existing #1939/#2000 one. Both are uncatchable stack exhaustion, so
  reachability is the *only* variable between them. The deciding fact is that
  848 sits **below** `printer.zig`'s own `MAX_PRINT_DEPTH` of 1024 — the
  program is inside the envelope the implementation intends to support, and
  the guard that makes deep printing safe on every other target is out of
  reach there. #2084 needs a 200,000-bit bitvector.
- It is the first critical **confined to a single tier**. The doc now says
  outright that tier is not part of the rule, because a reader who sees twelve
  core-tier heap defects plus one WASM row will otherwise infer a discount that
  the rule does not contain.

The rule itself is unchanged. The section heading ("critical is reserved for
process-level unsafety") and the closing line ("Every existing critical aborts
from an ordinary program") are both still true of #2107 — only the corpus
description needed updating.

## Verification

- `npx markdownlint-cli2` — 0 issues across 85 files.
- The invariant query from `docs/dev/github-issues.md` returns empty.
- Open distribution after this pass: 9 critical, 43 high, 83 medium, 20 low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
