### PR TITLE
Phase 5A: retire the SRFI 120 corruption claim — it was two guards, not one, and the real crash is one level up (#2129)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,15 +435,25 @@ development. **Single calling thread only** is a requirement of this
 implementation: its request/reply design assumes it. This header used to
 report that a second thread calling into a timer produced nondeterministic
 memory corruption, blamed on an un-root-caused interaction between
-multi-hop channel messages and cross-thread deep-copy. **That no longer
-reproduces** — re-checked 2026-07-31 at v0.22.1, both documented entry
-paths fail cleanly and deterministically (10/10 runs) with a catchable
-error, because a `<timer>` holds a Fiber and `gc_deep_copy` rejects that
-tag as `error.UncopyableType`, making the constraint engine-enforced. The
-multi-hop mechanism itself survived ~4,000 nested reply-channel round
-trips. Treat single-thread-only as the supported usage, not as a live
-corruption hazard; see `lib/srfi/120.sld`'s header for the caveats on
-that re-check. SRFI 21 and 230 are excluded — see `docs/dev/srfi-exclusions.md`.
+multi-hop channel messages and cross-thread deep-copy. **That claim is
+retired** — re-checked 2026-07-31 at v0.22.1 and again 2026-08-02 (audit
+v2 phase 5A) under both ReleaseSafe and `-Dgc-stress=true`; nothing
+corrupts, and the multi-hop mechanism itself survived ~4,000 nested
+reply-channel round trips. A `<timer>` simply cannot reach another thread,
+and it is refused by **two independent guards, not one** — the earlier
+re-check credited `gc_deep_copy`'s `.fiber` rejection with closing both
+entry paths, but a value reached through a top-level binding is never
+deep-copied at all, so that list has no bearing on it; what refuses there
+is the control channel's `Object.owner` check. Five entry paths (both
+copy-route and globals-route, plus a channel payload, a task thunk closing
+over a second timer, and a top-level *container*) are pinned by
+`tests/scheme/srfi/srfi120-thread-boundary.scm`. What *is* a live hazard
+is **kaappi#2129**: do not call `make-timer` from inside a SRFI-18 thread
+— `thread-join!` frees the joined thread's GC/VM while a thread it spawned
+is still in its startup prologue, and the process dies (24/30 runs) when
+the creating thread is joined. That is an engine bug reproducible with no
+timers at all, and `(srfi 120)` cannot work around it. See
+`lib/srfi/120.sld`'s header. SRFI 21 and 230 are excluded — see `docs/dev/srfi-exclusions.md`.
 SRFI 237 (R6RS Records, refined) is the one record-system SRFI needing real
 engine changes: `RecordType` (`types.zig`) gained `parent`/`own_field_names`/
 `own_field_mutable`/`uid`/`sealed`/`is_opaque`/`has_protocol` fields (`parent`

--- a/lib/srfi/120.sld
+++ b/lib/srfi/120.sld
@@ -6,15 +6,26 @@
 ;;; IMPORTANT: every scheduled thunk runs on the timer's own dedicated
 ;;; thread, which has its own independent GC heap (see kaappi/CLAUDE.md's
 ;;; "OS threads" section) -- the same as any SRFI-18 `thread-start!`'d
-;;; thread. A thunk therefore CANNOT safely mutate state visible to the
-;;; thread that called `timer-schedule!` (e.g. `set-car!` on a pair the
-;;; caller also holds): Kaappi's primitives don't stop you from writing
-;;; through a pointer into another thread's heap, but doing so from a
-;;; concurrently-running thread with its own independent collector is a
-;;; data race, not a supported way to observe that a task ran. Use a
-;;; `(kaappi fibers)` channel instead -- have the thunk `channel-send` a
-;;; result and have the caller `channel-receive` it -- exactly how this
-;;; library's own request/reply plumbing works internally.
+;;; thread. A thunk therefore CANNOT be observed by mutating state the
+;;; thread that called `timer-schedule!` also holds (e.g. `set-car!` on a
+;;; pair) -- and it fails two different ways depending on how the thunk
+;;; reached the pair, which is why "just use set-car!" looks like it works
+;;; until it doesn't:
+;;;
+;;;   - a LEXICALLY captured pair was deep-copied into the timer's heap
+;;;     along with the thunk, so the thunk mutates its own private copy and
+;;;     the caller's pair is simply never written. Silently invisible, not
+;;;     racy.
+;;;   - a pair reached through a TOP-LEVEL binding was not copied (globals
+;;;     are shared by pointer), so the write really does land in the
+;;;     caller's heap -- from a concurrently-running thread with its own
+;;;     independent collector. That is a live data race and a
+;;;     use-after-free hazard (kaappi#1924), not a supported idiom.
+;;;
+;;; Use a `(kaappi fibers)` channel instead -- have the thunk `channel-send`
+;;; a result and have the caller `channel-receive` it -- exactly how this
+;;; library's own request/reply plumbing works internally. Both halves above
+;;; are pinned by `tests/scheme/srfi/srfi120-thread-boundary.scm`.
 ;;;
 ;;; IMPORTANT: every value a scheduled thunk closes over (channels
 ;;; included) must be a genuine lexical binding, never a top-level
@@ -22,58 +33,115 @@
 ;;; (`initForThread` shares `globals`), not deep-copied-and-re-owned the
 ;;; way a closure's lexical captures are, so a thunk that references a
 ;;; top-level channel/pair reaches the ORIGINAL object from the wrong
-;;; heap and either corrupts memory silently or (for a channel
-;;; specifically, whose primitives do check) fails with "channel belongs
-;;; to another thread". Note this rule is a channel rule, NOT a general
-;;; one: a mutex or condition variable is the exact opposite -- a
-;;; top-level binding is the only supported way to share one, since
+;;; heap and either writes through it unchecked (a pair: kaappi#1924) or
+;;; -- for a channel specifically, whose primitives do check -- fails with
+;;; "channel belongs to another thread". Note this rule is a channel rule,
+;;; NOT a general one: a mutex or condition variable is the exact opposite
+;;; -- a top-level binding is the only supported way to share one, since
 ;;; capturing it is what gets deep-copy-rejected. See
-;;; docs/dev/thread-value-sharing.md for the per-type matrix.
+;;; docs/dev/thread-value-sharing.md for the per-type matrix; both halves
+;;; of the channel rule and both halves of the mutex inversion are pinned
+;;; by `tests/scheme/srfi/srfi120-thread-boundary.scm`.
 ;;;
 ;;; IMPORTANT: call `make-timer` and every subsequent
 ;;; `timer-schedule!`/`timer-reschedule!`/`timer-task-remove!`/
 ;;; `timer-task-exists?`/`timer-cancel!` on a given timer from the SAME
-;;; thread throughout. This is thoroughly verified reliable (this
-;;; library's own test suite, `tests/scheme/srfi/srfi120.scm`, does
-;;; nothing else).
+;;; thread throughout. This is not merely a convention: a `<timer>` cannot
+;;; reach another thread at all, and the two routes by which any value
+;;; crosses a thread boundary each refuse it, by a *different* mechanism.
+;;; Knowing which is which matters, because a change to one leaves the
+;;; other untouched:
+;;;
+;;;   - COPY ROUTE (a `thread-start!` thunk closure, a `thread-join!`
+;;;     result, a channel message payload). `gc_deep_copy.zig`'s fourteen
+;;;     uncopyable tags govern this route. A `<timer>` holds the timer
+;;;     thread's handle, which is a `.fiber`, which is on that list -- so
+;;;     the copy fails as a whole and nothing is delivered.
+;;;   - GLOBALS ROUTE (a top-level binding, or any mutable container
+;;;     reachable from one). Nothing is copied here, so the uncopyable list
+;;;     never runs and is irrelevant. What refuses instead is the
+;;;     per-primitive `Object.owner` check -- and only two types have one:
+;;;     channels (`primitives_fiber.zig`) and thread handles
+;;;     (`primitives_srfi18.checkThreadOwner`). A `<timer>`'s two fields are
+;;;     exactly those two types, which is the entire reason this route is
+;;;     covered. Every public procedure sends on the control channel before
+;;;     touching the thread handle, so the message the caller actually sees
+;;;     is the channel one: "channel belongs to another thread".
+;;;
+;;; See `docs/dev/thread-value-sharing.md` for the general matrix. Both
+;;; refusals, and the three further entry paths listed under HISTORY, are
+;;; pinned by `tests/scheme/srfi/srfi120-thread-boundary.scm` -- so this
+;;; cannot regress silently.
 ;;;
 ;;; HISTORY: this header previously reported that a *different* thread
-;;; calling into a timer it didn't create produced nondeterministic
-;;; memory corruption (varying crash signatures -- integer overflow, bad
+;;; calling into a timer it didn't create produced nondeterministic memory
+;;; corruption (varying crash signatures -- integer overflow, bad
 ;;; alignment, bus error), and attributed it to an un-root-caused bug in
 ;;; the interaction between multi-hop channel messages and cross-thread
-;;; deep-copy. That no longer reproduces. Re-checked 2026-07-31 at
-;;; v0.22.1: both documented entry paths fail cleanly and
-;;; deterministically (10/10 runs) with a catchable error rather than
-;;; corrupting anything, because a `<timer>` holds a Fiber and
-;;; `gc_deep_copy` rejects that tag as `error.UncopyableType` -- so the
-;;; single-thread constraint is now *engine-enforced*, not merely
-;;; documented here. The separate multi-hop channel mechanism the old
-;;; note blamed was also exercised directly (~4,000 nested reply-channel
-;;; round trips, 20 soak processes) with zero failures.
+;;; deep-copy. **That claim is retired.** It was re-checked twice: on
+;;; 2026-07-31 at v0.22.1, and again on 2026-08-02 (audit v2 phase 5A,
+;;; kaappi#1890) under both ReleaseSafe and `-Dgc-stress=true`, which
+;;; stamps freed headers and quarantines freed slots so a dangling value
+;;; panics deterministically instead of corrupting by luck (kaappi#1687).
+;;; Nothing corrupted anything on either build. The multi-hop channel
+;;; mechanism the old note blamed was also exercised directly (~4,000
+;;; nested reply-channel round trips, 20 soak processes) with zero
+;;; failures.
 ;;;
-;;; Single-thread-only is still the supported usage -- this library's
-;;; request/reply design assumes it, and the checks above are a guard
-;;; rail, not a concurrency model. But do not treat the old corruption
-;;; claim as a live hazard to design around. Caveat on the re-check: it
-;;; was macOS/kqueue, ReleaseSafe, without `-Dgc-stress=true`, so it is
-;;; strong evidence the claim is stale rather than proof the bug never
-;;; existed.
+;;; The 2026-07-31 re-check gave the right verdict for a partly wrong
+;;; reason, corrected above: it credited `gc_deep_copy`'s Fiber rejection
+;;; with closing *both* entry paths, but a value reached through a
+;;; top-level binding is never deep-copied, so that list has no bearing on
+;;; it whatsoever. Two independent guards, not one.
+;;;
+;;; The 5A pass also found three entry paths neither earlier check had
+;;; enumerated -- all refused, all now pinned: a timer sent to another
+;;; thread as a channel message payload; a task thunk that closes over a
+;;; *second* timer (`timer-schedule!` ships the thunk over the control
+;;; channel, so that is a copy boundary with no `thread-start!` in sight);
+;;; and a timer reached through a top-level *container* rather than a
+;;; top-level binding of its own.
+;;;
+;;; HAZARD, and it is a real one: do not call `make-timer` from inside a
+;;; SRFI-18 thread. kaappi#2129 -- `thread-join!` frees the joined thread's
+;;; GC and VM while a thread that thread started is still in its startup
+;;; prologue, and `make-timer` returns at exactly that moment. The process
+;;; dies with a SIGSEGV or a Zig panic when the creating thread is joined
+;;; (24/30 runs on ReleaseSafe, 13/15 under `-Dgc-stress=true`). This is
+;;; not a `(srfi 120)` defect -- a bare `thread-start!` of any thread that
+;;; itself spawns one reproduces it with no timers involved -- and this
+;;; library cannot work around it, since the timer thread is meant to
+;;; outlive `make-timer`. Create timers on the thread that will use them.
+;;;
+;;; So: single-thread-only remains the supported usage, the guard rails are
+;;; real and named, and the old corruption claim is not a live hazard to
+;;; design around. #2129 is.
 ;;;
 ;;; LIMITATION: the spec requires a task to "be able to cancel or
 ;;; reschedule other tasks" on the same timer -- e.g. a health-check task
 ;;; cancelling a retry task once it succeeds. This implementation does not
-;;; support that: `%run-due-tasks` invokes thunks synchronously from
-;;; inside `%timer-loop`, so the loop is not servicing `control` while a
-;;; thunk runs, and a thunk that calls `timer-schedule!`/`timer-cancel!`/
-;;; etc. on its own timer deadlocks (it sends a request and waits on a
-;;; reply that can only ever arrive once the loop resumes -- which needs
-;;; the thunk to return first). Fixing this properly needs either
-;;; reentrant reply-channel semantics or running thunks on their own
-;;; thread, and the latter would only route through the same multi-hop
-;;; channel machinery already flagged above as unreliable across threads
-;;; -- so, like the single-thread requirement, this is documented as a
-;;; known gap rather than worked around.
+;;; support that. The gap is real, but the *symptom* is not what this
+;;; header used to say: it claimed such a thunk "deadlocks", waiting on a
+;;; reply that can only arrive once the loop resumes. Measured 2026-08-02,
+;;; it does not -- it cannot get far enough to deadlock, because a thunk
+;;; has no way to name its own timer in the first place. Capturing the
+;;; `<timer>` lexically makes the thunk itself uncopyable, so
+;;; `timer-schedule!` refuses it up front; reaching it through a top-level
+;;; binding hands the timer thread the *caller's* control channel, which
+;;; the owner check refuses with "channel belongs to another thread". Both
+;;; are immediate, catchable errors. The deadlock the old text described is
+;;; unreachable.
+;;;
+;;; (The mechanism behind the gap is still as described: `%run-due-tasks`
+;;; invokes thunks synchronously from inside `%timer-loop`, so the loop is
+;;; not servicing `control` while a thunk runs.) Fixing this properly needs
+;;; either reentrant reply-channel semantics or running thunks on their own
+;;; thread. The old text rejected the latter on the grounds that it would
+;;; route through "the same multi-hop channel machinery already flagged
+;;; above as unreliable across threads" -- that flag is retired (see
+;;; HISTORY), so that objection no longer applies and the option is open
+;;; again. This stays a documented gap because nothing needs it yet, not
+;;; because it is blocked.
 ;;;
 ;;; Design notes:
 ;;;

--- a/tests/scheme/srfi/srfi120-thread-boundary.scm
+++ b/tests/scheme/srfi/srfi120-thread-boundary.scm
@@ -1,0 +1,260 @@
+;; SRFI-120 thread-boundary characterisation (audit v2 Phase 5A, kaappi#1890).
+;;
+;; Why this file exists
+;; -------------------
+;; lib/srfi/120.sld's header carried, in some form, a claim that a *second*
+;; thread calling into a timer produced nondeterministic memory corruption,
+;; "not root-caused". That claim is retired: every way a `<timer>` can reach
+;; another thread is refused, and refused by a *named* mechanism. This file
+;; pins those refusals, so the retirement cannot silently regress into being
+;; true again.
+;;
+;; The two mechanisms are unrelated, and conflating them is the mistake this
+;; file is designed to prevent (see docs/dev/thread-value-sharing.md, and
+;; tests/scheme/srfi/srfi18-sharing-model.scm for the general matrix):
+;;
+;;   COPY ROUTE -- a thread-start! thunk closure, a thread-join! result, a
+;;   channel message payload. Governed by gc_deep_copy.zig's fourteen-tag
+;;   uncopyable list. A <timer> holds a thread handle, which is a `.fiber`,
+;;   which is on that list -- so a timer is structurally uncopyable and the
+;;   copy fails as a whole.
+;;
+;;   GLOBALS ROUTE -- a top-level binding, shared by pointer, never copied.
+;;   The uncopyable list does not apply at all here. What refuses instead is
+;;   the per-primitive `Object.owner` check, and only two types have one:
+;;   channels (primitives_fiber.zig) and thread handles
+;;   (primitives_srfi18.checkThreadOwner). A <timer>'s two fields are exactly
+;;   those two types, which is the whole reason this route is covered.
+;;
+;; So the constraint is engine-enforced twice over, by two different guards,
+;; and a change to either one on its own would leave a hole. Hence: both,
+;; here, named.
+;;
+;; Every channel-receive below is bounded, and every thread started is
+;; joined -- a wedged probe would otherwise take the whole runner down.
+
+(import (scheme base) (scheme write) (srfi 18) (srfi 120) (srfi 64)
+        (kaappi fibers))
+
+(test-begin "srfi-120-thread-boundary")
+
+(define (msg-of e) (if (error-object? e) (error-object-message e) e))
+
+;; Runs THUNK on a child thread; answers its value, or (raised . message)
+;; for whichever raises first -- the child itself (globals route: the
+;; primitive refuses on the child) or the join (copy route: thread-start!
+;; never spawns anything and the refusal surfaces at the join). Both shapes
+;; reduce to one answer. Mirrors srfi18-sharing-model.scm's `on-child`.
+(define (on-child thunk)
+  (let ((t (make-thread
+            (lambda ()
+              (guard (e (#t (cons 'raised (msg-of e))))
+                (thunk))))))
+    (guard (e (#t (cons 'raised (msg-of e))))
+      (thread-start! t)
+      (thread-join! t))))
+
+(define (raised? x) (and (pair? x) (eq? (car x) 'raised)))
+
+(define (contains? haystack needle)
+  (let ((hl (string-length haystack)) (nl (string-length needle)))
+    (let loop ((i 0))
+      (cond ((> (+ i nl) hl) #f)
+            ((string=? (substring haystack i (+ i nl)) needle) #t)
+            (else (loop (+ i 1)))))))
+
+;; ---------------------------------------------------------------------
+;; COPY ROUTE: a <timer> is structurally uncopyable, in every direction.
+;; ---------------------------------------------------------------------
+
+;; Captured by a child thread's thunk. thread-start! runs the copy on the
+;; parent, hits the `.fiber` inside the record, and leaves the fiber
+;; .errored without ever spawning an OS thread.
+(let ((tmr (make-timer)))
+  (let ((answer (on-child (lambda () (timer? tmr)))))
+    (test-assert "copy route: a timer captured by a child thunk is refused, not delivered"
+                 (raised? answer)))
+  (timer-cancel! tmr))
+
+;; As a channel message payload. Same list, different boundary, and here the
+;; message names the reason outright.
+;;
+;; The channel must actually be shared with another thread first: a channel
+;; nobody else holds is unpromoted, and a send on one enqueues the value as
+;; is with no copy at all -- so the uncopyable list never runs and a timer
+;; goes through. That is correct (nothing crossed a heap), and it is why the
+;; local case is asserted separately below rather than left to look like a
+;; missing check.
+(let* ((tmr (make-timer))
+       (ch (make-channel))
+       (peer (make-thread (lambda () (channel-receive ch 3.0 'timeout)))))
+  (thread-start! peer)          ; promotes ch; the timer now has a heap to cross
+  (test-assert "copy route: sending a timer to another thread over a channel raises"
+    (guard (e (#t (contains? (msg-of e) "uncopyable")))
+      (channel-send ch tmr)
+      #f))
+  (thread-join! peer)
+  (timer-cancel! tmr))
+
+;; The control for the case above: same call, same value, no second thread.
+(let ((tmr (make-timer))
+      (ch (make-channel)))
+  (test-assert "copy route: a send on an unshared channel does not copy, so a timer passes"
+    (guard (e (#t #f))
+      (channel-send ch tmr)
+      (timer? (channel-receive ch 1.0 'timeout))))
+  (timer-cancel! tmr))
+
+;; Inside a task thunk. timer-schedule! ships the thunk over the control
+;; channel, so a thunk closing over a *second* timer crosses the same
+;; boundary -- an entry path that is easy to miss because it looks purely
+;; local, with no thread-start! in sight.
+(let ((a (make-timer))
+      (b (make-timer)))
+  (test-assert "copy route: timer-schedule! refuses a thunk that closes over another timer"
+    (guard (e (#t (contains? (msg-of e) "uncopyable")))
+      (timer-schedule! a (lambda () (timer? b)) 10)
+      #f))
+  (timer-cancel! a)
+  (timer-cancel! b))
+
+;; ---------------------------------------------------------------------
+;; GLOBALS ROUTE: nothing is copied, so the uncopyable list never runs.
+;; The control channel's own owner check is what refuses.
+;; ---------------------------------------------------------------------
+
+(define top-level-timer (make-timer))
+
+(let ((answer (on-child (lambda () (timer-task-exists? top-level-timer 0)))))
+  (test-assert "globals route: a query on a foreign timer raises"
+               (raised? answer))
+  (test-assert "globals route: and it is the CHANNEL owner check that refuses, not the copy route"
+               (and (raised? answer) (contains? (cdr answer) "another thread"))))
+
+;; timer-cancel! would also thread-join! a foreign handle -- but it sends
+;; first, so the channel check is what the caller actually sees. Pinned
+;; because a future refactor that reorders those two would change which
+;; guard is load-bearing.
+(let ((answer (on-child (lambda () (timer-cancel! top-level-timer)))))
+  (test-assert "globals route: timer-cancel! on a foreign timer raises"
+               (raised? answer))
+  (test-assert "globals route: timer-cancel! is refused by the control channel, before the join"
+               (and (raised? answer) (contains? (cdr answer) "another thread"))))
+
+;; A timer reached through a mutable top-level *container* is the same
+;; route: only the cell needs to be top-level for the record to be shared
+;; by pointer. Worth its own case -- the header's rule is phrased about
+;; bindings, and this shape has no timer-valued binding at all.
+(define timer-cell (list #f))
+(set-car! timer-cell top-level-timer)
+
+(let ((answer (on-child (lambda () (timer-task-exists? (car timer-cell) 0)))))
+  (test-assert "globals route: a timer reached through a top-level cell is refused too"
+               (and (raised? answer) (contains? (cdr answer) "another thread"))))
+
+(timer-cancel! top-level-timer)
+
+;; ---------------------------------------------------------------------
+;; What a task thunk may and may not close over. The header states this as
+;; a rule; these are the two halves of it.
+;; ---------------------------------------------------------------------
+
+;; A LEXICALLY captured channel is the supported way to observe a task.
+(let ((tmr (make-timer))
+      (sig (make-channel)))
+  (timer-schedule! tmr (lambda () (channel-send sig 'fired)) 10)
+  (test-equal "task thunk: a lexically captured channel delivers"
+              'fired (channel-receive sig 5.0 'timeout))
+  (timer-cancel! tmr))
+
+;; A TOP-LEVEL channel does not: the thunk is copied into the timer's heap
+;; but the channel is not, so the send hits a channel this thread does not
+;; own. With no error-handler the timer stops and preserves the condition,
+;; and SRFI 120 has timer-cancel! re-raise it -- which is how the refusal
+;; becomes visible to the caller.
+(define top-level-channel (make-channel))
+
+(let ((tmr (make-timer)))
+  (timer-schedule! tmr (lambda () (channel-send top-level-channel 'fired)) 10)
+  (test-equal "task thunk: a top-level channel delivers nothing"
+              'timeout (channel-receive top-level-channel 2.0 'timeout))
+  (test-assert "task thunk: and timer-cancel! re-raises the channel-ownership refusal"
+    (guard (e (#t (contains? (msg-of e) "another thread")))
+      (timer-cancel! tmr)
+      #f)))
+
+;; The inversion, which is the part of the rule people get backwards: for a
+;; mutex, capture is what fails and a top-level binding is what works --
+;; exactly the opposite of a channel. Both halves, so the pair is visible.
+(let ((m (make-mutex))
+      (tmr (make-timer)))
+  (test-assert "task thunk: a lexically captured mutex is refused (copy route rejects .mutex)"
+    (guard (e (#t (contains? (msg-of e) "uncopyable")))
+      (timer-schedule! tmr (lambda () (mutex-lock! m)) 10)
+      #f))
+  (timer-cancel! tmr))
+
+(define top-level-mutex (make-mutex))
+
+(let ((tmr (make-timer))
+      (sig (make-channel)))
+  (timer-schedule! tmr
+                   (lambda ()
+                     (mutex-lock! top-level-mutex)
+                     (mutex-unlock! top-level-mutex)
+                     (channel-send sig 'locked))
+                   10)
+  (test-equal "task thunk: a top-level mutex IS usable from the timer thread"
+              'locked (channel-receive sig 5.0 'timeout))
+  (timer-cancel! tmr))
+
+;; ---------------------------------------------------------------------
+;; A task's writes are not a way to observe it -- for two different
+;; reasons, depending on how the datum was reached. Both are pinned
+;; because a reader who only knows one of them will draw the wrong
+;; conclusion from the other.
+;; ---------------------------------------------------------------------
+
+;; Lexically captured: the thunk got its own COPY, so the caller's pair is
+;; untouched. The mutation is invisible, not racy.
+(let ((tmr (make-timer))
+      (p (list 'untouched))
+      (sig (make-channel)))
+  (timer-schedule! tmr (lambda () (set-car! p 'touched) (channel-send sig (car p))) 10)
+  (test-equal "task writes: the thunk sees its own copy mutated"
+              'touched (channel-receive sig 5.0 'timeout))
+  (test-equal "task writes: the caller's lexically captured pair is untouched (it was copied)"
+              'untouched (car p))
+  (timer-cancel! tmr))
+
+;; Top-level: shared by pointer, so the write really does land in the
+;; caller's heap, from a thread with its own independent collector. This is
+;; the unchecked case -- asserted as it behaves so that a fix for #1924
+;; fails here and this file gets updated with it, not so that anyone treats
+;; it as supported.
+(define shared-pair (list 'untouched))
+
+(let ((tmr (make-timer))
+      (sig (make-channel)))
+  (timer-schedule! tmr (lambda () (set-car! shared-pair 'touched) (channel-send sig 'done)) 10)
+  (test-equal "task writes: the task completes"
+              'done (channel-receive sig 5.0 'timeout))
+  (test-equal "task writes: a top-level pair IS written through (globals route, unchecked -- #1924)"
+              'touched (car shared-pair))
+  (timer-cancel! tmr))
+
+;; ---------------------------------------------------------------------
+;; FAIL: #2129 -- make-timer inside a SRFI-18 thread crashes the process at
+;; that thread's join (thread-join! frees the joined thread's GC/VM while
+;; the timer thread is still in its startup prologue). 24/30 on ReleaseSafe,
+;; 13/15 under -Dgc-stress=true. Commented out rather than test-expect-fail:
+;; it aborts the process, which would take the whole runner down.
+;;
+;; (let ((t (make-thread (lambda () (make-timer)))))
+;;   (thread-start! t)
+;;   (test-assert "a timer created inside a thread does not survive its join"
+;;     (guard (e (#t #t)) (thread-join! t) #f)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-120-thread-boundary")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Audit v2 Phase 5A (#1890). Scope: settle the SRFI 120 corruption claim — the
most alarming statement in the tree — with either a live reproduction or a
header rewrite plus tests pinning why it cannot happen.

**Verdict: retired.** It is not true, and here are the tests that keep it
untrue. Separately, a *different* live crash turned up on an entry path
nobody had written down; filed as **#2129**, not fixed here.

## Every claim the header made, and its verdict

| # | Claim | Verdict |
|---|---|---|
| A | A task thunk cannot be observed by mutating state the caller holds | **True, for two different reasons** the header collapsed into one. Lexical capture → the thunk got a *copy*, so the write is invisible. Top-level → shared by pointer, so the write really lands cross-heap (#1924). Both now stated and pinned. |
| B | A thunk's captures must be lexical, never top-level; a channel refuses, a mutex is inverted | **True.** Verified all four halves. |
| C | Use one thread throughout — "thoroughly verified reliable" | **True, and understated.** It is engine-enforced, by two named guards. Rewritten to say which. |
| D | The corruption claim no longer reproduces | **Confirmed** — but the stated *reason* is wrong. It credited `gc_deep_copy`'s `.fiber` rejection with closing *both* entry paths. A value reached through a top-level binding is never deep-copied, so that list has no bearing on it; the control channel's `Object.owner` check is what refuses. Two independent guards, not one. |
| E | Caveat: re-check was ReleaseSafe, not `-Dgc-stress=true` | **Closed.** Re-run under gc-stress. |
| F | A thunk calling into its own timer "deadlocks" | **False.** It cannot reach the timer at all — capture makes the thunk uncopyable, a top-level binding hands the timer thread the caller's channel and the owner check refuses. Immediate catchable error, no deadlock. The paragraph's reason for not fixing the gap also cited the now-retired corruption flag, so that objection is gone too. |
| G | A task outlasting `%reply-timeout-seconds` makes the timer look cancelled | **True.** `timer-schedule!` raises "not responding"; `timer-task-remove!`/`-exists?` answer `#f`. |
| H | The control channel is unbounded, so a caller's send never blocks | Inferred from `(make-channel)` with no capacity; not separately measured. |

## Run counts behind "does not reproduce"

`-Dgc-stress=true` (freed headers stamped, freed slots quarantined — #1687),
at load average ~18 from three concurrent audit units:

| entry path | corruption/panic | clean refusal |
|---|---|---|
| copy route (timer captured by a child thunk) | 0 | 25 |
| globals route (query on a foreign timer) | 0 | 25 |
| globals route (`timer-cancel!` on a foreign timer) | 0 | 25 |
| globals route via a top-level *container* | 0 | 25 |
| task thunk closing over a second timer | 0 | 25 |

The harness is demonstrably sensitive: on the same machine, same builds, it
catches #2129 at 13/15 (gc-stress) and 24/30 (ReleaseSafe). A 0/125 here is a
measurement, not an idle machine.

## The third entry path

Three, and all are refused — a timer as a channel message payload, a task
thunk closing over a *second* timer (`timer-schedule!` ships the thunk over
the control channel, so it is a copy boundary with no `thread-start!` in
sight), and a timer reached through a top-level *container* rather than a
binding of its own. All three are now pinned.

A fourth is not refused, and it crashes: **creating a timer inside a SRFI-18
thread**. `thread-join!` frees the joined thread's GC/VM while a thread that
thread started is still in its startup prologue, and `make-timer` returns at
exactly that moment. 24/30 crash on ReleaseSafe, 13/15 under gc-stress. It is
not a `(srfi 120)` defect — a bare `thread-start!` of any thread that itself
spawns one reproduces it with no timers involved, and `(srfi 120)` cannot work
around it since the timer thread must outlive `make-timer`. Filed as **#2129**
with a discriminating control table; the header now names it in place of the
unlocated corruption claim it replaces.

## Changes

- `lib/srfi/120.sld` — header rewritten: both guards named and separated,
  claim F corrected, #2129 documented as the live hazard, claim A split.
- `tests/scheme/srfi/srfi120-thread-boundary.scm` — new, 18 assertions
  pinning both refusal mechanisms, the three extra entry paths, both halves
  of the channel rule and of the mutex inversion, and both halves of claim A.
  Contains one commented-out case marked `FAIL: #2129` — commented rather
  than `test-expect-fail` because it aborts the process and would take the
  runner down.
- `CLAUDE.md` — the same partly-wrong attribution was repeated there.

## Verification

- `kaappi test tests/scheme/srfi/srfi120.scm tests/scheme/srfi/srfi120-thread-boundary.scm tests/scheme/srfi/srfi18-sharing-model.scm` → 81 passed, 0 failed
- New suite flake-checked 10/10 green (it is a concurrency test)
- `bash tests/scheme/run-all.sh` green
- `markdownlint-cli2` clean
