### PR TITLE
Phase 7C: the big-endian canary — it ran the unit suite and r7rs-tests.scm, and SRFI 74's one endian assertion compared a function to its own definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,13 @@ jobs:
       - name: R7RS test suite (riscv64 via QEMU)
         run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
 
+      # The little-endian control for the same step on s390x below: every
+      # assertion in these suites is either host-independent or derived from
+      # `%host-big-endian?`, so a failure here means the suite itself is wrong,
+      # not that the host's byte order is.
+      - name: Endian-sensitive Scheme suites (riscv64 via QEMU)
+        run: bash tools/run-endian-suite.sh zig-out/bin/kaappi
+
   # s390x: interpreter tier like riscv64 (#1654), and the only big-endian
   # target in the matrix — a permanent canary for byte-order bugs in the
   # `.sbc` codec and any future serialization. Also validated on a
@@ -235,6 +242,17 @@ jobs:
       - name: R7RS test suite (s390x via QEMU)
         run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
 
+      # THE POINT OF THE CANARY (audit v2, Phase 7C). Until this step, the
+      # three things that ran here were the build, the unit suite and
+      # `r7rs-tests.scm` -- and `r7rs-tests.scm` imports no SRFI with a
+      # byte-order-sensitive surface, so SRFI 74 (blobs), 160 (host-native
+      # numeric-vector storage) and 135 (UTF-16) had never executed on a
+      # big-endian machine at all. `run-all.sh` is too heavy for an emulated
+      # leg; this runs just the files that carry endian assertions, in about
+      # a second natively. See tools/run-endian-suite.sh.
+      - name: Endian-sensitive Scheme suites (s390x via QEMU)
+        run: bash tools/run-endian-suite.sh zig-out/bin/kaappi
+
   # ppc64le: interpreter tier like riscv64 (#1654). Also validated on a
   # real-kernel Alpine ppc64le VM (unit + thottam + R7RS + full Scheme
   # suites; 128 TB = 2^47 default map window fits the NaN-box payload).
@@ -266,6 +284,13 @@ jobs:
 
       - name: R7RS test suite (ppc64le via QEMU)
         run: zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm
+
+      # POWER is little-endian in this configuration despite the architecture
+      # family's big-endian history, so this is a control leg, not a second
+      # canary -- worth stating, because "ppc64le covers big-endian too" is an
+      # easy and wrong assumption to make from the job list.
+      - name: Endian-sensitive Scheme suites (ppc64le via QEMU)
+        run: bash tools/run-endian-suite.sh zig-out/bin/kaappi
 
   # FreeBSD: cross-compile the binaries and test executables from Linux
   # (guarding the cross-compilation path release.yml ships with), then

--- a/docs/dev/porting.md
+++ b/docs/dev/porting.md
@@ -309,6 +309,38 @@ all, only build/CI work — *provided* the preconditions hold.
       precondition now expresses: new serialization or byte-punning code
       must use the same explicit-conversion helpers — the s390x job is
       the canary that catches it if it doesn't.
+
+      **Exactly what that job runs, and what it therefore cannot see.**
+      Four steps: the cross-compile, `zig build test
+      -Dtarget=s390x-linux`, `tests/scheme/r7rs/r7rs-tests.scm`, and (as
+      of audit v2 Phase 7C) `bash tools/run-endian-suite.sh`. It does
+      **not** run `tests/scheme/run-all.sh`, which is why the endian
+      suite is a separate, deliberately small entry point rather than
+      the whole tree. Two blind spots remain, both structural:
+
+      * **A paired byte-swap cancels out.** Every `.sbc` test writes and
+        reads on the same host, so a bug that swapped *both* directions
+        stays green everywhere. `src/tests_endian.zig` breaks the pairing
+        one direction at a time — the writer against literal expected
+        bytes, the reader against a hand-assembled literal-little-endian
+        header — but no test yet writes a file on one endianness and
+        reads it on the other. The nightly `cross-diff` fuzz job does not
+        close this either: both sides run against their own arch's cache.
+      * **A local `zig build test -Dtarget=s390x-linux` proves nothing
+        about behaviour.** `build.zig` sets `skip_foreign_checks = true`,
+        so on a host with no emulator registered the run step is
+        *skipped* and the command still exits 0 (`--summary all` shows
+        `run test unit-tests skipped`). On the CI leg it does execute,
+        because `docker/setup-qemu-action` registers binfmt_misc and the
+        direct spawn succeeds. Locally that command is a compile gate,
+        which is exactly what it was added for.
+      * **`%host-big-endian?` is the only Scheme-visible witness of host
+        byte order.** SRFI 74's `(endianness native)` is defined as
+        `(if (%host-big-endian?) 'big 'little)`, so no Scheme test can
+        check that primitive non-circularly — a test can only ask it
+        again. It is pinned against an actual memory probe in
+        `src/tests_endian.zig`, which is why that pin is Zig and not
+        Scheme.
 - [ ] **f64 hardware or soft-float** with IEEE-754 semantics (flonums
       are NaN-boxed doubles; NaN canonicalization assumes IEEE bit
       patterns).

--- a/src/tests_endian.zig
+++ b/src/tests_endian.zig
@@ -52,7 +52,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
-const platform = @import("platform.zig");
 const file_utils = @import("file_utils.zig");
 const bf = @import("bytecode_file.zig");
 const bfw = @import("bytecode_file_write.zig");

--- a/src/tests_endian.zig
+++ b/src/tests_endian.zig
@@ -1,0 +1,285 @@
+//! Byte-order pins for the surfaces where a big-endian host can disagree
+//! with a little-endian one.
+//!
+//! WHY THIS FILE EXISTS, AND WHY IT IS ZIG RATHER THAN SCHEME.
+//!
+//! s390x is the project's only big-endian target and exists precisely to
+//! catch byte-order bugs (#1654). What actually executes there in `ci.yml`
+//! is three steps: the cross-compile, `zig build test -Dtarget=s390x-linux`,
+//! and `r7rs-tests.scm`. **The unit suite is one of them** — so an assertion
+//! placed here runs on the canary today, with no CI change required. That is
+//! not true of any `tests/scheme/**` file: none of them run on that leg.
+//!
+//! DO NOT "VERIFY BIG-ENDIAN BEHAVIOUR" BY RUNNING THIS LOCALLY ON A MAC.
+//! `build.zig` sets `skip_foreign_checks = true`, so `zig build test
+//! -Dtarget=s390x-linux` compiles the test binary and then **silently skips
+//! running it**, exiting 0 with no output — `--summary all` shows `run test
+//! unit-tests skipped`. That is deliberate (it makes the same command a
+//! compile gate for targets with no emulator, e.g. Windows), and it works on
+//! the CI leg because `docker/setup-qemu-action` registers binfmt_misc, so
+//! the direct spawn succeeds and Zig never consults its foreign-executor
+//! logic at all. The consequence to remember: a clean local exit code from
+//! that command is evidence the code *compiles* big-endian, and evidence of
+//! nothing whatsoever about how it *behaves*.
+//!
+//! Two properties in this codebase cannot be pinned from Scheme at all, and
+//! both live here:
+//!
+//!   1. **`%host-big-endian?` telling the truth.** SRFI 74's `(endianness
+//!      native)` is `(if (%host-big-endian?) 'big 'little)`, so every
+//!      "native accessors agree" assertion written in Scheme is circular:
+//!      it can only re-derive the answer from the same primitive. The one
+//!      non-circular check is against the machine, which needs a memory
+//!      probe, which needs Zig.
+//!
+//!   2. **The `.sbc` codec's canonical little-endian scalars.** Every
+//!      scalar goes through `nativeToLittle`/`littleToNative`, but the
+//!      existing round-trip tests write and read on the *same* host, so a
+//!      paired byte-swap bug cancels out and they stay green. The two tests
+//!      below break the pairing in each direction independently: the writer
+//!      is checked against literal expected bytes, and the reader is fed a
+//!      hand-assembled literal-little-endian header. Neither expected value
+//!      depends on the host, so both mean the same thing on every target.
+//!
+//! Endian-*insensitive* by construction, deliberately not pinned here:
+//! bytecode operands inside `Function.code` are assembled and consumed a
+//! byte at a time (`v >> 8`, `v & 0xFF` in `compiler.zig`; `readU16` in
+//! `vm_dispatch.zig`), never byte-punned; bignum limbs are `[]u64` in
+//! little-endian *limb* order, with each limb serialized through
+//! `writeU64`; and SRFI 178 bit order is spec-defined, not host-defined.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const platform = @import("platform.zig");
+const file_utils = @import("file_utils.zig");
+const bf = @import("bytecode_file.zig");
+const bfw = @import("bytecode_file_write.zig");
+const th = @import("testing_helpers.zig");
+
+const GC = memory.GC;
+const Function = types.Function;
+
+/// The host's byte order observed as a *memory layout* rather than read off
+/// `builtin.cpu.arch.endian()`. On a big-endian host the most significant
+/// byte of the word occupies the lowest address.
+fn probeHostIsBigEndian() bool {
+    var word: u32 = 0x01020304;
+    const bytes: *const [4]u8 = @ptrCast(&word);
+    return bytes[0] == 0x01;
+}
+
+// ---------------------------------------------------------------------------
+// 1. The host's byte order, and the one primitive that reports it
+// ---------------------------------------------------------------------------
+
+test "endian: the memory probe agrees with builtin.cpu.arch.endian()" {
+    const declared_big = builtin.cpu.arch.endian() == .big;
+    try std.testing.expectEqual(declared_big, probeHostIsBigEndian());
+}
+
+test "endian: %host-big-endian? reports the host's real byte order" {
+    // The load-bearing one. SRFI 74's `(endianness native)`, and therefore
+    // every `blob-*-native-*` accessor, is exactly this primitive's answer.
+    // Nothing reachable from Scheme can check it -- a Scheme test can only
+    // ask the same primitive again.
+    try th.expectEvalBool("(%host-big-endian?)", probeHostIsBigEndian());
+}
+
+test "endian: %host-big-endian? is false on a little-endian host and true on a big-endian one" {
+    // Spelled out as two mutually exclusive arms so the failure message on
+    // the s390x leg names the direction that broke rather than printing a
+    // bare boolean mismatch.
+    if (probeHostIsBigEndian()) {
+        try th.expectEvalBool("(%host-big-endian?)", true);
+        try th.expectEvalBool("(not (%host-big-endian?))", false);
+    } else {
+        try th.expectEvalBool("(%host-big-endian?)", false);
+        try th.expectEvalBool("(not (%host-big-endian?))", true);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. `.sbc` writer: scalars are little-endian on every host
+//
+// Each expected byte string below is a constant, not a function of the host.
+// On a little-endian host `nativeToLittle` is the identity and these pass
+// trivially; on s390x they are the byte-swap assertion.
+// ---------------------------------------------------------------------------
+
+fn expectWriterBytes(
+    comptime writeFn: []const u8,
+    value: anytype,
+    expected: []const u8,
+) !void {
+    const allocator = std.testing.allocator;
+    var w = bfw.Writer{ .buf = .empty };
+    defer w.buf.deinit(allocator);
+    try @field(bfw.Writer, writeFn)(&w, allocator, value);
+    try std.testing.expectEqualSlices(u8, expected, w.buf.items);
+}
+
+test "endian: .sbc writeU16 emits little-endian bytes" {
+    try expectWriterBytes("writeU16", @as(u16, 0x0102), &.{ 0x02, 0x01 });
+}
+
+test "endian: .sbc writeU32 emits little-endian bytes" {
+    try expectWriterBytes("writeU32", @as(u32, 0x01020304), &.{ 0x04, 0x03, 0x02, 0x01 });
+}
+
+test "endian: .sbc writeU64 emits little-endian bytes" {
+    try expectWriterBytes(
+        "writeU64",
+        @as(u64, 0x0102030405060708),
+        &.{ 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 },
+    );
+}
+
+test "endian: .sbc writeI64 emits little-endian bytes for a negative value" {
+    // -2 is 0xFFFF_FFFF_FFFF_FFFE; the discriminating byte is the 0xFE, which
+    // sits at the lowest address on a little-endian encoding and would move to
+    // the highest if the conversion were dropped.
+    try expectWriterBytes(
+        "writeI64",
+        @as(i64, -2),
+        &.{ 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+    );
+}
+
+test "endian: .sbc writeF64 emits the IEEE-754 bits little-endian" {
+    // 1.5 is 0x3FF8_0000_0000_0000.
+    try expectWriterBytes(
+        "writeF64",
+        @as(f64, 1.5),
+        &.{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x3F },
+    );
+}
+
+test "endian: .sbc writeStr's u16 length prefix is little-endian" {
+    const allocator = std.testing.allocator;
+    var w = bfw.Writer{ .buf = .empty };
+    defer w.buf.deinit(allocator);
+    // 258 bytes: the length's high byte is nonzero, so a dropped conversion
+    // is visible in the prefix rather than hidden by a zero byte.
+    const payload = "x" ** 258;
+    try w.writeStr(allocator, payload);
+    try std.testing.expectEqual(@as(usize, 2 + 258), w.buf.items.len);
+    try std.testing.expectEqual(@as(u8, 0x02), w.buf.items[0]);
+    try std.testing.expectEqual(@as(u8, 0x01), w.buf.items[1]);
+}
+
+// ---------------------------------------------------------------------------
+// 3. `.sbc` reader: a hand-assembled little-endian header decodes correctly
+//
+// This is the direction the existing round-trip tests cannot cover, because
+// they read back what this same host just wrote. Here the bytes are literals.
+// ---------------------------------------------------------------------------
+
+fn appendLeU16(list: *std.ArrayList(u8), allocator: std.mem.Allocator, v: u16) !void {
+    try list.append(allocator, @truncate(v));
+    try list.append(allocator, @truncate(v >> 8));
+}
+
+test "endian: readHeaderInfo decodes a hand-assembled little-endian header" {
+    const allocator = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+
+    try buf.appendSlice(allocator, &bf.MAGIC);
+    try appendLeU16(&buf, allocator, bf.VERSION);
+    // source_hash = 0x0102030405060708, spelled little-endian by hand.
+    try buf.appendSlice(allocator, &.{ 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 });
+    // compiler_hash = 0x1122334455667788, likewise.
+    try buf.appendSlice(allocator, &.{ 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11 });
+    try appendLeU16(&buf, allocator, 2);
+    try buf.appendSlice(allocator, "id");
+    try appendLeU16(&buf, allocator, 6);
+    try buf.appendSlice(allocator, "a.scm\x00"[0..6]);
+
+    const info = bf.readHeaderInfo(buf.items) orelse
+        return error.HeaderRejected;
+    try std.testing.expectEqual(@as(u64, 0x0102030405060708), info.source_hash);
+    try std.testing.expectEqual(@as(u64, 0x1122334455667788), info.compiler_hash);
+    try std.testing.expectEqualStrings("id", info.build_id);
+}
+
+test "endian: readHeaderInfo rejects a big-endian-spelled version field" {
+    // The discriminating control for the test above: the same header with
+    // only the two VERSION bytes swapped must be rejected. If it were
+    // accepted, `readHeaderInfo` would be ignoring byte order rather than
+    // honouring it -- and on a big-endian host that is precisely the bug
+    // this file exists to catch.
+    comptime {
+        // The control is only discriminating while VERSION's two bytes
+        // differ. At VERSION 10 (0x000A) they do. A future bump to a value
+        // like 0x0101 would make the swap invisible and this test vacuous,
+        // so fail the build then rather than keep a green no-op.
+        const lo: u8 = @truncate(bf.VERSION);
+        const hi: u8 = @truncate(bf.VERSION >> 8);
+        if (lo == hi) @compileError(
+            "bytecode_file.VERSION's two bytes are equal, so byte-swapping it " ++
+                "is undetectable and this endianness control asserts nothing. " ++
+                "Pick a different discriminating field, or a VERSION whose bytes differ.",
+        );
+    }
+    const allocator = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+
+    try buf.appendSlice(allocator, &bf.MAGIC);
+    try buf.append(allocator, @truncate(bf.VERSION >> 8));
+    try buf.append(allocator, @truncate(bf.VERSION));
+    try buf.appendSlice(allocator, &[_]u8{0} ** 16);
+    try appendLeU16(&buf, allocator, 0);
+    try appendLeU16(&buf, allocator, 0);
+
+    try std.testing.expect(bf.readHeaderInfo(buf.items) == null);
+}
+
+// ---------------------------------------------------------------------------
+// 4. A real `.sbc` file, checked at the byte level
+//
+// The two tests above use the codec's own primitives; this one goes through
+// the whole serializer and reads the bytes back off disk, so a byte-order
+// mistake made in the header assembly rather than in a `writeXxx` helper
+// still shows up.
+// ---------------------------------------------------------------------------
+
+test "endian: a written .sbc file carries VERSION and source_hash little-endian" {
+    const allocator = std.testing.allocator;
+    var gc = GC.init(allocator);
+    defer gc.deinit();
+
+    const func = try gc.allocFunction();
+    func.code.append(allocator, @intFromEnum(types.OpCode.load_void)) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.code.append(allocator, @intFromEnum(types.OpCode.@"return")) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+    func.code.append(allocator, 0) catch unreachable;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try th.tmpDirRealPathAlloc(&tmp, allocator);
+    defer allocator.free(dir);
+    const path = try std.fs.path.joinZ(allocator, &.{ dir, "endian.sbc" });
+    defer allocator.free(path);
+
+    var funcs_arr = [_]*Function{func};
+    const hash: u64 = 0x0102030405060708;
+    try bf.writeFileWithTopLevel(allocator, &funcs_arr, hash, "endian.scm", path);
+
+    const bytes = try file_utils.readWholeFile(allocator, path, 1 << 20);
+    defer allocator.free(bytes);
+
+    try std.testing.expect(bytes.len >= 14);
+    try std.testing.expectEqualSlices(u8, &bf.MAGIC, bytes[0..4]);
+    try std.testing.expectEqual(@as(u8, @truncate(bf.VERSION)), bytes[4]);
+    try std.testing.expectEqual(@as(u8, @truncate(bf.VERSION >> 8)), bytes[5]);
+    try std.testing.expectEqualSlices(
+        u8,
+        &.{ 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 },
+        bytes[6..14],
+    );
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -48,4 +48,8 @@ test {
     _ = @import("tests_diagnostics.zig");
     _ = @import("tests_spans.zig");
     _ = @import("tests_platform.zig");
+    // Byte-order pins. The unit suite is one of only three things that runs
+    // on the big-endian s390x leg, so this is where an endian assertion
+    // actually reaches the canary (src/tests_endian.zig explains the rest).
+    _ = @import("tests_endian.zig");
 }

--- a/tests/scheme/audit/endianness-audit.scm
+++ b/tests/scheme/audit/endianness-audit.scm
@@ -1,0 +1,451 @@
+;;; Byte-order audit -- every Scheme-visible surface whose answer could differ
+;;; on a big-endian host (audit v2, Phase 7C).
+;;;
+;;; WHY THIS FILE EXISTS
+;;;
+;;; s390x is the project's only big-endian target and exists precisely to catch
+;;; byte-order bugs (kaappi#1654). What `ci.yml`'s `s390x-test` job actually
+;;; runs is three steps -- the cross-compile, `zig build test
+;;; -Dtarget=s390x-linux`, and `tests/scheme/r7rs/r7rs-tests.scm`. It does NOT
+;;; run `run-all.sh`, so no `tests/scheme/**` file except `r7rs-tests.scm` has
+;;; ever executed on a big-endian machine, and `r7rs-tests.scm` imports no SRFI
+;;; with a byte-order-sensitive surface. This file gathers those surfaces into
+;;; one command:
+;;;
+;;;     zig-out/bin/kaappi tests/scheme/audit/endianness-audit.scm
+;;;
+;;; and `tools/run-endian-suite.sh` runs it alongside the other files that
+;;; carry endian assertions.
+;;;
+;;; THE TAUTOLOGY THIS FILE REPLACES
+;;;
+;;; `tests/scheme/srfi/srfi74.scm` asserted, under the heading "native
+;;; accessors agree with explicit-endianness accessors", that
+;;;
+;;;     (blob-u32-native-set! b1 0 42)
+;;;     (blob-u32-set! (endianness native) b2 0 42)
+;;;
+;;; produce the same bytes. But `lib/srfi/74.sld` defines
+;;;
+;;;     (define (blob-u32-native-set! b k n) (blob-u32-set! (endianness native) b k n))
+;;;
+;;; so the two sides are the same call. The assertion cannot fail on any host.
+;;;
+;;; What CAN fail, and is pinned here, is a three-link chain:
+;;;
+;;;   1. `(endianness big)` and `(endianness little)` produce the documented
+;;;      byte layouts. Host-independent -- the expected bytes below are
+;;;      constants, not functions of the platform -- so these run and mean the
+;;;      same thing everywhere, and they are the assertions a swapped Horner
+;;;      loop in `lib/srfi/74.sld` would break.
+;;;   2. `(endianness native)` selects between those two by `%host-big-endian?`.
+;;;      Pinned here relative to that primitive, never to a hardcoded order:
+;;;      the byte layout of a native access is a value the platform decides.
+;;;   3. `%host-big-endian?` tells the truth about the machine. NOT pinnable
+;;;      from Scheme -- every Scheme route to the host's byte order goes
+;;;      through this same primitive. It is pinned against an actual memory
+;;;      probe in `src/tests_endian.zig`, which the s390x leg already runs.
+;;;
+;;; Nothing below asserts a value the platform decides. Where a native-order
+;;; layout is checked, the expectation is computed from `%host-big-endian?`.
+
+(import (scheme base) (scheme write) (scheme char) (scheme process-context)
+        (srfi 64) (srfi 74) (srfi 135)
+        (srfi 160 u8) (srfi 160 u16) (srfi 160 s16) (srfi 160 u32) (srfi 160 s32)
+        (srfi 160 u64) (srfi 160 s64) (srfi 160 f32) (srfi 160 f64)
+        (srfi 160 c64) (srfi 160 c128)
+        (kaappi primitives))
+
+(test-begin "endianness audit")
+
+(define (bl b) (blob->u8-list b))
+
+(define (bytevector->list bv)
+  (let loop ((i (- (bytevector-length bv) 1)) (acc '()))
+    (if (< i 0) acc (loop (- i 1) (cons (bytevector-u8-ref bv i) acc)))))
+
+(define (write-to-string x)
+  (let ((p (open-output-string))) (write x p) (get-output-string p)))
+
+;;; ------------------------------------------------------------------
+;;; 1. The two Scheme-visible facts about host byte order, pinned to
+;;;    each other.
+;;;
+;;;    `%host-big-endian?` itself is ground truth as far as Scheme is
+;;;    concerned; `src/tests_endian.zig` is where it meets the machine.
+;;; ------------------------------------------------------------------
+
+(test-assert "%host-big-endian? answers with a boolean"
+             (boolean? (%host-big-endian?)))
+
+(test-assert "(endianness native) is one of the two named orders"
+             (memq (endianness native) '(big little)))
+
+(test-equal "(endianness native) is 'big exactly when %host-big-endian? is true"
+            (if (%host-big-endian?) 'big 'little)
+            (endianness native))
+
+(test-equal "(endianness big) is the symbol big" 'big (endianness big))
+(test-equal "(endianness little) is the symbol little" 'little (endianness little))
+
+;;; ------------------------------------------------------------------
+;;; 2. SRFI 74 explicit endianness, checked at the byte level.
+;;;
+;;;    "The procedure blob-uint-ref ... interpreting the octets as the
+;;;     representation of a number in the endianness specified by endianness"
+;;;     -- SRFI 74, Operations on blobs.
+;;;
+;;;    Every expected byte list below is a constant. Each test value is chosen
+;;;    so its byte-reverse is a *different* number, which is what makes the
+;;;    assertion discriminating rather than symmetric: 0x0102030405060708
+;;;    reversed is 0x0807060504030201, and a palindromic value like
+;;;    0x01010101 would pass under either order.
+;;; ------------------------------------------------------------------
+
+(let ((b (make-blob 2)))
+  (blob-u16-set! (endianness big) b 0 #x0102)
+  (test-equal "blob-u16-set! big puts the most significant byte first"
+              '(1 2) (bl b)))
+
+(let ((b (make-blob 2)))
+  (blob-u16-set! (endianness little) b 0 #x0102)
+  (test-equal "blob-u16-set! little puts the least significant byte first"
+              '(2 1) (bl b)))
+
+(let ((b (make-blob 4)))
+  (blob-u32-set! (endianness big) b 0 #x01020304)
+  (test-equal "blob-u32-set! big byte layout" '(1 2 3 4) (bl b))
+  (test-equal "blob-u32-ref big reads back what big wrote"
+              #x01020304 (blob-u32-ref (endianness big) b 0))
+  (test-equal "blob-u32-ref little over big-written bytes reads the reverse"
+              #x04030201 (blob-u32-ref (endianness little) b 0)))
+
+(let ((b (make-blob 4)))
+  (blob-u32-set! (endianness little) b 0 #x01020304)
+  (test-equal "blob-u32-set! little byte layout" '(4 3 2 1) (bl b)))
+
+(let ((b (make-blob 8)))
+  (blob-u64-set! (endianness big) b 0 #x0102030405060708)
+  (test-equal "blob-u64-set! big byte layout" '(1 2 3 4 5 6 7 8) (bl b))
+  (test-equal "blob-u64-ref big round-trips"
+              #x0102030405060708 (blob-u64-ref (endianness big) b 0)))
+
+(let ((b (make-blob 8)))
+  (blob-u64-set! (endianness little) b 0 #x0102030405060708)
+  (test-equal "blob-u64-set! little byte layout" '(8 7 6 5 4 3 2 1) (bl b))
+  (test-equal "blob-u64-ref little round-trips"
+              #x0102030405060708 (blob-u64-ref (endianness little) b 0)))
+
+;; Signed accessors: sign extension must not depend on which end the sign byte
+;; landed on. -2 is 0xFFFE / 0xFFFFFFFE, whose discriminating byte is the 0xFE.
+(let ((b (make-blob 2)))
+  (blob-s16-set! (endianness big) b 0 -2)
+  (test-equal "blob-s16-set! big puts the sign byte first" '(255 254) (bl b))
+  (test-equal "blob-s16-ref big round-trips a negative"
+              -2 (blob-s16-ref (endianness big) b 0)))
+
+(let ((b (make-blob 2)))
+  (blob-s16-set! (endianness little) b 0 -2)
+  (test-equal "blob-s16-set! little puts the sign byte last" '(254 255) (bl b))
+  (test-equal "blob-s16-ref little round-trips a negative"
+              -2 (blob-s16-ref (endianness little) b 0)))
+
+(let ((b (make-blob 4)))
+  (blob-s32-set! (endianness big) b 0 -2)
+  (test-equal "blob-s32-set! big byte layout" '(255 255 255 254) (bl b)))
+
+(let ((b (make-blob 4)))
+  (blob-s32-set! (endianness little) b 0 -2)
+  (test-equal "blob-s32-set! little byte layout" '(254 255 255 255) (bl b)))
+
+(let ((b (make-blob 8)))
+  (blob-s64-set! (endianness big) b 0 -2)
+  (test-equal "blob-s64-set! big byte layout"
+              '(255 255 255 255 255 255 255 254) (bl b))
+  (test-equal "blob-s64-ref big round-trips a negative"
+              -2 (blob-s64-ref (endianness big) b 0)))
+
+(let ((b (make-blob 8)))
+  (blob-s64-set! (endianness little) b 0 -2)
+  (test-equal "blob-s64-set! little byte layout"
+              '(254 255 255 255 255 255 255 255) (bl b))
+  (test-equal "blob-s64-ref little round-trips a negative"
+              -2 (blob-s64-ref (endianness little) b 0)))
+
+;; A 64-bit magnitude past the fixnum range (2^47) exercises the bignum path
+;; through the same Horner loops. 2^63 - 1 is 0x7FFFFFFFFFFFFFFF.
+(let ((b (make-blob 8)))
+  (blob-u64-set! (endianness big) b 0 #x7F0102030405060E)
+  (test-equal "blob-u64-set! big byte layout beyond the fixnum range"
+              '(127 1 2 3 4 5 6 14) (bl b))
+  (test-equal "blob-u64-ref big round-trips beyond the fixnum range"
+              #x7F0102030405060E (blob-u64-ref (endianness big) b 0)))
+
+;;; Generic width accessors at sizes with no fixed-width alias.
+
+(let ((b (make-blob 3)))
+  (blob-uint-set! 3 (endianness big) b 0 #x010203)
+  (test-equal "blob-uint-set! size 3 big byte layout" '(1 2 3) (bl b)))
+
+(let ((b (make-blob 3)))
+  (blob-uint-set! 3 (endianness little) b 0 #x010203)
+  (test-equal "blob-uint-set! size 3 little byte layout" '(3 2 1) (bl b)))
+
+(let ((b (make-blob 5)))
+  (blob-uint-set! 5 (endianness big) b 0 #x0102030405)
+  (test-equal "blob-uint-set! size 5 big byte layout" '(1 2 3 4 5) (bl b))
+  (test-equal "blob-uint-ref size 5 big round-trips"
+              #x0102030405 (blob-uint-ref 5 (endianness big) b 0)))
+
+(let ((b (make-blob 3)))
+  (blob-sint-set! 3 (endianness little) b 0 -2)
+  (test-equal "blob-sint-set! size 3 little byte layout" '(254 255 255) (bl b))
+  (test-equal "blob-sint-ref size 3 little round-trips a negative"
+              -2 (blob-sint-ref 3 (endianness little) b 0)))
+
+(let ((b (make-blob 3)))
+  (blob-sint-set! 3 (endianness big) b 0 -2)
+  (test-equal "blob-sint-set! size 3 big byte layout" '(255 255 254) (bl b)))
+
+;;; List conversions carry the same order through, element by element.
+
+(test-equal "uint-list->blob size 2 big byte layout"
+            '(1 2 2 1) (bl (uint-list->blob 2 (endianness big) '(#x0102 #x0201))))
+(test-equal "uint-list->blob size 2 little byte layout"
+            '(2 1 1 2) (bl (uint-list->blob 2 (endianness little) '(#x0102 #x0201))))
+(test-equal "blob->uint-list size 2 big reads elements in order"
+            '(#x0102 #x0304) (blob->uint-list 2 (endianness big) (u8-list->blob '(1 2 3 4))))
+(test-equal "blob->uint-list size 2 little reads elements in order"
+            '(#x0201 #x0403) (blob->uint-list 2 (endianness little) (u8-list->blob '(1 2 3 4))))
+(test-equal "blob->sint-list size 2 big sign-extends per element"
+            '(-2 1) (blob->sint-list 2 (endianness big) (u8-list->blob '(255 254 0 1))))
+(test-equal "sint-list->blob size 4 little byte layout"
+            '(254 255 255 255) (bl (sint-list->blob 4 (endianness little) '(-2))))
+
+;;; ------------------------------------------------------------------
+;;; 3. SRFI 74 native accessors -- the replacement for the tautology.
+;;;
+;;;    The expectation is derived from `%host-big-endian?`, never hardcoded:
+;;;    a native access's byte layout is a value the platform decides. What is
+;;;    asserted is that native SELECTS the right one of the two layouts
+;;;    section 2 has already pinned independently.
+;;; ------------------------------------------------------------------
+
+(define (native-layout big-bytes little-bytes)
+  (if (%host-big-endian?) big-bytes little-bytes))
+
+(let ((b (make-blob 2)))
+  (blob-u16-native-set! b 0 #x0102)
+  (test-equal "blob-u16-native-set! lays out bytes in the host's order"
+              (native-layout '(1 2) '(2 1)) (bl b)))
+
+(let ((b (make-blob 4)))
+  (blob-u32-native-set! b 0 #x01020304)
+  (test-equal "blob-u32-native-set! lays out bytes in the host's order"
+              (native-layout '(1 2 3 4) '(4 3 2 1)) (bl b))
+  (test-equal "blob-u32-native-ref round-trips"
+              #x01020304 (blob-u32-native-ref b 0)))
+
+(let ((b (make-blob 8)))
+  (blob-u64-native-set! b 0 #x0102030405060708)
+  (test-equal "blob-u64-native-set! lays out bytes in the host's order"
+              (native-layout '(1 2 3 4 5 6 7 8) '(8 7 6 5 4 3 2 1)) (bl b))
+  (test-equal "blob-u64-native-ref round-trips"
+              #x0102030405060708 (blob-u64-native-ref b 0)))
+
+(let ((b (make-blob 4)))
+  (blob-s32-native-set! b 0 -2)
+  (test-equal "blob-s32-native-set! lays out bytes in the host's order"
+              (native-layout '(255 255 255 254) '(254 255 255 255)) (bl b))
+  (test-equal "blob-s32-native-ref round-trips a negative"
+              -2 (blob-s32-native-ref b 0)))
+
+(let ((b (make-blob 2)))
+  (blob-s16-native-set! b 0 -2)
+  (test-equal "blob-s16-native-set! lays out bytes in the host's order"
+              (native-layout '(255 254) '(254 255)) (bl b))
+  (test-equal "blob-s16-native-ref round-trips a negative"
+              -2 (blob-s16-native-ref b 0)))
+
+(let ((b (make-blob 8)))
+  (blob-s64-native-set! b 0 -2)
+  (test-equal "blob-s64-native-ref round-trips a negative"
+              -2 (blob-s64-native-ref b 0)))
+
+;; The other half of "native selects the right one": on a little-endian host a
+;; native write must NOT match the big-endian layout, and vice versa. Without
+;; this, a `native` arm that always answered 'big would still pass everything
+;; above on a big-endian machine.
+(let ((native (make-blob 4)) (other (make-blob 4)))
+  (blob-u32-native-set! native 0 #x01020304)
+  (blob-u32-set! (if (%host-big-endian?) (endianness little) (endianness big))
+                 other 0 #x01020304)
+  (test-assert "a native write differs from the opposite explicit order"
+               (not (equal? (bl native) (bl other)))))
+
+;;; ------------------------------------------------------------------
+;;; 4. SRFI 160 numeric vectors.
+;;;
+;;;    Multi-byte elements are stored in HOST-NATIVE byte order in a raw byte
+;;;    buffer (`primitives_srfi160.zig`, `native_endian`). That order is not
+;;;    observable from Scheme -- there is no byte view of a NumericVector, and
+;;;    the six `%numeric-vector-*` primitives are the entire native surface --
+;;;    so nothing here asserts a layout. What IS observable is that the two
+;;;    independent hand-written decoders agree with the encoder: element
+;;;    access (`primitives_srfi160.zig`) and the printer's own numeric-vector
+;;;    arm (`printer.zig`). On a little-endian host they cannot disagree even
+;;;    if both were wrong; on s390x a one-sided byte-order mistake shows up
+;;;    here. Values are chosen so each byte-reverse is a different number.
+;;; ------------------------------------------------------------------
+
+(test-equal "u16vector: ref agrees with the encoder" 258 (u16vector-ref (u16vector 258) 0))
+(test-equal "u16vector: printer agrees with the encoder"
+            "#<u16vector 258>" (write-to-string (u16vector 258)))
+(test-equal "s16vector: ref agrees with the encoder on a negative"
+            -2 (s16vector-ref (s16vector -2) 0))
+(test-equal "s16vector: printer agrees with the encoder on a negative"
+            "#<s16vector -2>" (write-to-string (s16vector -2)))
+(test-equal "u32vector: ref agrees with the encoder"
+            16909060 (u32vector-ref (u32vector 16909060) 0))
+(test-equal "u32vector: printer agrees with the encoder"
+            "#<u32vector 16909060>" (write-to-string (u32vector 16909060)))
+(test-equal "s32vector: ref agrees with the encoder on a negative"
+            -2 (s32vector-ref (s32vector -2) 0))
+(test-equal "u64vector: ref agrees with the encoder"
+            72623859790382856 (u64vector-ref (u64vector 72623859790382856) 0))
+(test-equal "u64vector: printer agrees with the encoder"
+            "#<u64vector 72623859790382856>"
+            (write-to-string (u64vector 72623859790382856)))
+(test-equal "s64vector: ref agrees with the encoder on a negative"
+            -2 (s64vector-ref (s64vector -2) 0))
+(test-equal "f32vector: ref agrees with the encoder" 1.5 (f32vector-ref (f32vector 1.5) 0))
+(test-equal "f64vector: ref agrees with the encoder" 1.5 (f64vector-ref (f64vector 1.5) 0))
+(test-equal "f64vector: printer agrees with the encoder"
+            "#<f64vector 1.5>" (write-to-string (f64vector 1.5)))
+(test-equal "f64vector: an asymmetric double survives encode/decode"
+            1.0000000000000002 (f64vector-ref (f64vector 1.0000000000000002) 0))
+
+;; Complex elements are two consecutive reals in the same buffer, so a
+;; byte-order mistake can also swap real and imaginary halves. -2.5 vs 1.5
+;; makes that swap observable.
+(test-equal "c64vector: ref keeps real and imaginary in order"
+            (make-rectangular 1.5 -2.5)
+            (c64vector-ref (c64vector (make-rectangular 1.5 -2.5)) 0))
+(test-equal "c128vector: ref keeps real and imaginary in order"
+            (make-rectangular 1.5 -2.5)
+            (c128vector-ref (c128vector (make-rectangular 1.5 -2.5)) 0))
+(test-equal "c64vector: printer agrees with the encoder"
+            "#<c64vector 1.5-2.5i>"
+            (write-to-string (c64vector (make-rectangular 1.5 -2.5))))
+
+;; Adjacent elements must not bleed into one another -- the failure mode a
+;; width/offset mistake produces, which byte-order bugs often accompany.
+(test-equal "u16vector: adjacent elements stay separate"
+            '(258 513 1027) (u16vector->list (u16vector 258 513 1027)))
+(test-equal "u32vector: adjacent elements stay separate"
+            '(16909060 33752069) (u32vector->list (u32vector 16909060 33752069)))
+(test-equal "s64vector: adjacent elements stay separate"
+            '(-2 1 -9007199254740993)
+            (s64vector->list (s64vector -2 1 -9007199254740993)))
+(test-equal "f64vector: adjacent elements stay separate"
+            '(1.5 -2.5) (f64vector->list (f64vector 1.5 -2.5)))
+
+;; u8 is a plain bytevector, so its "byte order" is the identity on every host
+;; -- the discriminating control for the block above.
+(test-equal "u8vector is a bytevector and has no byte order to get wrong"
+            '(1 2 3) (bytevector->list (u8vector 1 2 3)))
+
+;;; ------------------------------------------------------------------
+;;; 5. SRFI 135 UTF-16 conversions.
+;;;
+;;;    "textual->utf16be ... returns a bytevector containing the UTF-16BE
+;;;     encoding" -- SRFI 135. These orders are named by the procedure, not by
+;;;    the host, so every expectation here is a constant on every platform.
+;;;    `tests/scheme/srfi/srfi135.scm` has no utf16 coverage at all.
+;;; ------------------------------------------------------------------
+
+(test-equal "textual->utf16be puts the high byte first"
+            '(0 65 0 66) (bytevector->list (textual->utf16be (text #\A #\B))))
+(test-equal "textual->utf16le puts the low byte first"
+            '(65 0 66 0) (bytevector->list (textual->utf16le (text #\A #\B))))
+(test-equal "textual->utf16 emits a big-endian BOM followed by big-endian data"
+            '(#xFE #xFF 0 65) (bytevector->list (textual->utf16 (text #\A))))
+
+;; A codepoint whose two bytes differ makes the order discriminating; U+00E9
+;; is 0x00E9 and U+03BB (lambda) is 0x03BB.
+(test-equal "textual->utf16be of a non-ASCII BMP codepoint"
+            '(#x03 #xBB) (bytevector->list (textual->utf16be (text #\x3BB))))
+(test-equal "textual->utf16le of a non-ASCII BMP codepoint"
+            '(#xBB #x03) (bytevector->list (textual->utf16le (text #\x3BB))))
+
+;; A surrogate pair is where a UTF-16 byte-order mistake hides best: each of
+;; the two units must be byte-swapped independently, and a whole-pair swap
+;; still decodes to *a* character. U+1F600 is D83D DE00.
+(test-equal "textual->utf16be of an astral codepoint (surrogate pair)"
+            '(#xD8 #x3D #xDE #x00) (bytevector->list (textual->utf16be (text #\x1F600))))
+(test-equal "textual->utf16le of an astral codepoint (surrogate pair)"
+            '(#x3D #xD8 #x00 #xDE) (bytevector->list (textual->utf16le (text #\x1F600))))
+(test-equal "utf16be->text round-trips an astral codepoint"
+            "\x1F600;" (textual->string (utf16be->text (textual->utf16be (text #\x1F600)))))
+(test-equal "utf16le->text round-trips an astral codepoint"
+            "\x1F600;" (textual->string (utf16le->text (textual->utf16le (text #\x1F600)))))
+
+;; BOM dispatch: the reader must follow the BOM it is given, not the host.
+(test-equal "utf16->text follows a little-endian BOM"
+            "A" (textual->string (utf16->text (bytevector #xFF #xFE #x41 #x00))))
+(test-equal "utf16->text follows a big-endian BOM"
+            "A" (textual->string (utf16->text (bytevector #xFE #xFF #x00 #x41))))
+(test-equal "utf16->text with no BOM defaults to big-endian"
+            "A" (textual->string (utf16->text (bytevector #x00 #x41))))
+
+(test-equal "utf16be->text decodes big-endian bytes"
+            "AB" (textual->string (utf16be->text (textual->utf16be (text #\A #\B)))))
+(test-equal "utf16le->text decodes little-endian bytes"
+            "AB" (textual->string (utf16le->text (textual->utf16le (text #\A #\B)))))
+(test-equal "utf16->text honours a big-endian BOM"
+            "\x3BB;" (textual->string (utf16->text (textual->utf16 (text #\x3BB)))))
+
+;;; ------------------------------------------------------------------
+;;; 6. Byte-oriented surfaces that must NOT vary with host order.
+;;;
+;;;    These are the discriminating controls for the whole file: UTF-8 and
+;;;    bytevectors are defined over octets, so a big-endian host must produce
+;;;    byte-for-byte identical answers. If one of these ever differs on s390x,
+;;;    something is byte-punning a multi-byte scalar that should not be.
+;;; ------------------------------------------------------------------
+
+(test-equal "string->utf8 of a 2-byte codepoint is order-independent"
+            '(#xCE #xBB) (bytevector->list (string->utf8 "\x3BB;")))
+(test-equal "string->utf8 of a 3-byte codepoint is order-independent"
+            '(#xE2 #x82 #xAC) (bytevector->list (string->utf8 "\x20AC;")))
+(test-equal "string->utf8 of a 4-byte codepoint is order-independent"
+            '(#xF0 #x9F #x98 #x80) (bytevector->list (string->utf8 "\x1F600;")))
+(test-equal "utf8->string round-trips a 4-byte codepoint"
+            "\x1F600;" (utf8->string (string->utf8 "\x1F600;")))
+(test-equal "bytevector literals keep their index order"
+            '(1 2 3 4) (bytevector->list #u8(1 2 3 4)))
+(test-equal "char->integer is a codepoint, not a byte layout"
+            955 (char->integer #\x3BB))
+
+;;; ------------------------------------------------------------------
+;;; 7. Exact integers wider than a machine word.
+;;;
+;;;    Bignum limbs are u64 in little-endian LIMB order (not byte order),
+;;;    each limb serialized whole. Arithmetic across the limb boundary is
+;;;    where a limb-order confusion would surface as a wrong value.
+;;; ------------------------------------------------------------------
+
+(test-equal "a bignum straddling the 64-bit limb boundary is exact"
+            18446744073709551617 (+ (expt 2 64) 1))
+(test-equal "a bignum's low bits survive the limb boundary"
+            1 (modulo (+ (expt 2 64) 1) (expt 2 32)))
+(test-equal "a bignum's high limb survives division"
+            (expt 2 32) (quotient (expt 2 64) (expt 2 32)))
+(test-equal "number->string of a two-limb bignum"
+            "18446744073709551617" (number->string (+ (expt 2 64) 1)))
+(test-equal "a negative two-limb bignum round-trips through string->number"
+            (- (+ (expt 2 64) 1)) (string->number "-18446744073709551617"))
+
+(let ((runner (test-runner-current)))
+  (test-end "endianness audit")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi74.scm
+++ b/tests/scheme/srfi/srfi74.scm
@@ -1,76 +1,112 @@
 ;; SRFI 74 (octet-addressed binary blocks) tests.
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi74.scm
+;;
+;; The byte-order surface this SRFI exposes is audited in depth in
+;; tests/scheme/audit/endianness-audit.scm (audit v2, Phase 7C), which also
+;; explains why the native accessors cannot be pinned non-circularly from
+;; Scheme alone. This file keeps the SRFI's own functional coverage.
+;;
+;; Every assertion carries a name: a failure here can surface on the big-endian
+;; s390x leg, where SRFI-64 prints the failed assertion's *value* and not its
+;; source, so an unnamed failure is literally a bare `#f` among 30 candidates.
 
-(import (scheme base) (scheme process-context) (srfi 64) (srfi 74))
+(import (scheme base) (scheme process-context) (srfi 64) (srfi 74)
+        (kaappi primitives))
 
 (test-begin "srfi-74")
 
-(test-equal #t (eq? (endianness big) (endianness big)))
-(test-equal #f (eq? (endianness big) (endianness little)))
-(test-assert (or (eq? (endianness native) (endianness big))
-                  (eq? (endianness native) (endianness little))))
+(test-equal "(endianness big) is eq? to itself"
+            #t (eq? (endianness big) (endianness big)))
+(test-equal "(endianness big) is not (endianness little)"
+            #f (eq? (endianness big) (endianness little)))
+(test-assert "(endianness native) is one of the two named orders"
+             (or (eq? (endianness native) (endianness big))
+                 (eq? (endianness native) (endianness little))))
 
-(test-equal #t (blob? (make-blob 4)))
-(test-equal #t (bytevector? (make-blob 4)))
-(test-equal 4 (blob-length (make-blob 4)))
-(test-equal '(0 0 0 0) (blob->u8-list (make-blob 4)))
-(test-equal '(9 8 7) (blob->u8-list (u8-list->blob '(9 8 7))))
-(test-equal #t (blob=? (make-blob 2) (u8-list->blob '(0 0))))
-(test-equal #f (blob=? (u8-list->blob '(1 2)) (u8-list->blob '(1 3))))
-(test-equal '(1 2 3) (blob->u8-list (blob-copy (u8-list->blob '(1 2 3)))))
+(test-equal "blob? accepts a fresh blob" #t (blob? (make-blob 4)))
+(test-equal "a blob is a bytevector" #t (bytevector? (make-blob 4)))
+(test-equal "blob-length of a fresh blob" 4 (blob-length (make-blob 4)))
+(test-equal "make-blob zero-fills" '(0 0 0 0) (blob->u8-list (make-blob 4)))
+(test-equal "u8-list->blob preserves order" '(9 8 7) (blob->u8-list (u8-list->blob '(9 8 7))))
+(test-equal "blob=? on equal blobs" #t (blob=? (make-blob 2) (u8-list->blob '(0 0))))
+(test-equal "blob=? on differing blobs" #f (blob=? (u8-list->blob '(1 2)) (u8-list->blob '(1 3))))
+(test-equal "blob-copy duplicates contents"
+            '(1 2 3) (blob->u8-list (blob-copy (u8-list->blob '(1 2 3)))))
 
 (let ((a (u8-list->blob '(1 2 3))) (b (make-blob 3)))
   (blob-copy! a 1 b 0 2)
-  (test-equal '(2 3 0) (blob->u8-list b)))
+  (test-equal "blob-copy! copies n octets from source-start" '(2 3 0) (blob->u8-list b)))
 
 ;; single-byte accessors
 (let ((b (make-blob 2)))
   (blob-u8-set! b 0 200)
-  (test-equal 200 (blob-u8-ref b 0))
+  (test-equal "blob-u8-ref reads what blob-u8-set! wrote" 200 (blob-u8-ref b 0))
   (blob-s8-set! b 1 -1)
-  (test-equal -1 (blob-s8-ref b 1))
-  (test-equal 255 (blob-u8-ref b 1)))
+  (test-equal "blob-s8-ref sign-extends" -1 (blob-s8-ref b 1))
+  (test-equal "blob-u8-ref sees the same octet unsigned" 255 (blob-u8-ref b 1)))
 
 ;; fixed-width big/little round trips
 (let ((b (make-blob 8)))
   (blob-u16-set! (endianness big) b 0 #x0102)
-  (test-equal '(1 2) (list (blob-u8-ref b 0) (blob-u8-ref b 1)))
-  (test-equal 258 (blob-u16-ref (endianness big) b 0))
+  (test-equal "blob-u16-set! big byte layout"
+              '(1 2) (list (blob-u8-ref b 0) (blob-u8-ref b 1)))
+  (test-equal "blob-u16-ref big round-trips" 258 (blob-u16-ref (endianness big) b 0))
   (blob-u16-set! (endianness little) b 2 #x0102)
-  (test-equal '(2 1) (list (blob-u8-ref b 2) (blob-u8-ref b 3)))
-  (test-equal 258 (blob-u16-ref (endianness little) b 2))
+  (test-equal "blob-u16-set! little byte layout"
+              '(2 1) (list (blob-u8-ref b 2) (blob-u8-ref b 3)))
+  (test-equal "blob-u16-ref little round-trips" 258 (blob-u16-ref (endianness little) b 2))
   (blob-s16-set! (endianness big) b 4 -1)
-  (test-equal -1 (blob-s16-ref (endianness big) b 4))
-  (test-equal 65535 (blob-u16-ref (endianness big) b 4)))
+  (test-equal "blob-s16-ref big round-trips -1" -1 (blob-s16-ref (endianness big) b 4))
+  (test-equal "the same octets read unsigned are 65535"
+              65535 (blob-u16-ref (endianness big) b 4)))
 
 (let ((b (make-blob 4)))
   (blob-u32-set! (endianness big) b 0 #xDEADBEEF)
-  (test-equal #xDEADBEEF (blob-u32-ref (endianness big) b 0))
-  (test-equal (list #xDE #xAD #xBE #xEF)
-    (list (blob-u8-ref b 0) (blob-u8-ref b 1) (blob-u8-ref b 2) (blob-u8-ref b 3))))
+  (test-equal "blob-u32-ref big round-trips" #xDEADBEEF (blob-u32-ref (endianness big) b 0))
+  (test-equal "blob-u32-set! big byte layout"
+              (list #xDE #xAD #xBE #xEF)
+              (list (blob-u8-ref b 0) (blob-u8-ref b 1) (blob-u8-ref b 2) (blob-u8-ref b 3))))
 
 (let ((b (make-blob 8)))
   (blob-s64-set! (endianness little) b 0 -123456789012345)
-  (test-equal -123456789012345 (blob-s64-ref (endianness little) b 0)))
+  (test-equal "blob-s64-ref little round-trips a large negative"
+              -123456789012345 (blob-s64-ref (endianness little) b 0))
+  ;; -123456789012345 is 0xFFFF_8FB7_79F2_2087, so the low byte is 0x87 and
+  ;; the high byte 0xFF: a byte-level check, where the round trip above would
+  ;; pass under either order.
+  (test-equal "blob-s64-set! little byte layout"
+              '(#x87 #x20 #xF2 #x79 #xB7 #x8F #xFF #xFF) (blob->u8-list b)))
 
-;; native accessors agree with explicit-endianness accessors
-(let ((b1 (make-blob 4)) (b2 (make-blob 4)))
-  (blob-u32-native-set! b1 0 42)
-  (blob-u32-set! (endianness native) b2 0 42)
-  (test-equal (blob->u8-list b1) (blob->u8-list b2))
-  (test-equal 42 (blob-u32-native-ref b1 0)))
+;; Native accessors. NOT "native agrees with (endianness native)" -- that was
+;; the assertion here until Phase 7C, and it could not fail on any host:
+;; lib/srfi/74.sld *defines* blob-u32-native-set! as
+;; (blob-u32-set! (endianness native) ...), so both sides were the same call.
+;; What is pinned instead is that native selects the layout the host's own
+;; byte order calls for, against the two explicit layouts checked above.
+;; The remaining link -- %host-big-endian? telling the truth about the
+;; machine -- is unreachable from Scheme and lives in src/tests_endian.zig.
+(let ((b (make-blob 4)))
+  (blob-u32-native-set! b 0 #x01020304)
+  (test-equal "blob-u32-native-set! lays out bytes in the host's order"
+              (if (%host-big-endian?) '(1 2 3 4) '(4 3 2 1))
+              (blob->u8-list b))
+  (test-equal "blob-u32-native-ref round-trips" #x01020304 (blob-u32-native-ref b 0)))
 
 ;; generic uint/sint at arbitrary sizes
 (let ((b (make-blob 5)))
   (blob-uint-set! 5 (endianness big) b 0 1099511627775) ; 2^40 - 1
-  (test-equal 1099511627775 (blob-uint-ref 5 (endianness big) b 0)))
+  (test-equal "blob-uint-ref size 5 big round-trips 2^40-1"
+              1099511627775 (blob-uint-ref 5 (endianness big) b 0)))
 (let ((b (make-blob 3)))
   (blob-sint-set! 3 (endianness little) b 0 -8388608) ; -(2^23)
-  (test-equal -8388608 (blob-sint-ref 3 (endianness little) b 0)))
+  (test-equal "blob-sint-ref size 3 little round-trips -(2^23)"
+              -8388608 (blob-sint-ref 3 (endianness little) b 0)))
 
 ;; list conversions
-(test-equal '(1 2 3) (blob->uint-list 2 (endianness big) (uint-list->blob 2 (endianness big) '(1 2 3))))
-(test-equal '(-1 -2 3) (blob->sint-list 2 (endianness little) (sint-list->blob 2 (endianness little) '(-1 -2 3))))
+(test-equal "blob->uint-list inverts uint-list->blob (big)"
+            '(1 2 3) (blob->uint-list 2 (endianness big) (uint-list->blob 2 (endianness big) '(1 2 3))))
+(test-equal "blob->sint-list inverts sint-list->blob (little)"
+            '(-1 -2 3) (blob->sint-list 2 (endianness little) (sint-list->blob 2 (endianness little) '(-1 -2 3))))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-74")

--- a/tools/run-endian-suite.sh
+++ b/tools/run-endian-suite.sh
@@ -62,6 +62,13 @@ fi
 #   srfi66/srfi63     u8vector and prototype-typed arrays over SRFI 160
 #   srfi135           UTF-16BE/LE conversions
 #   srfi178           bit order (spec-defined, asserted not to drift)
+#   srfi271           determinized random ports: `primitives_random_port.zig`
+#                     and `types_port.zig` move u64s in and out of a bytevector
+#                     with an explicit `.little`, so a seeded stream is meant
+#                     to be identical on every host. Its own assertions compare
+#                     two ports *on the same host*, which is the same
+#                     cancelling pairing the `.sbc` tests have -- running it
+#                     big-endian at least catches a write/read side disagreeing
 #   internal-primitives-audit
 #                     %host-big-endian? reachability and arity
 FILES=(
@@ -73,6 +80,7 @@ FILES=(
     tests/scheme/srfi/srfi63.scm
     tests/scheme/srfi/srfi135.scm
     tests/scheme/srfi/srfi178-audit.scm
+    tests/scheme/srfi/srfi271.scm
     tests/scheme/audit/primitives_srfi160-audit.scm
     tests/scheme/audit/internal-primitives-audit.scm
 )

--- a/tools/run-endian-suite.sh
+++ b/tools/run-endian-suite.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Run every Scheme suite that carries a byte-order assertion, in one command.
+#
+#     bash tools/run-endian-suite.sh [path/to/kaappi]
+#
+# WHY THIS EXISTS. s390x is the project's only big-endian target and exists
+# precisely to catch byte-order bugs (kaappi#1654), but `ci.yml`'s `s390x-test`
+# job runs exactly three steps -- the cross-compile, `zig build test
+# -Dtarget=s390x-linux`, and `tests/scheme/r7rs/r7rs-tests.scm`. It does not
+# run `tests/scheme/run-all.sh`, so until this script every file below had
+# executed only on little-endian hosts, where a byte-order assertion cannot
+# fail. `r7rs-tests.scm` imports no SRFI with a byte-order-sensitive surface.
+#
+# The Zig unit suite DOES run on that leg, which is why `src/tests_endian.zig`
+# holds the two pins Scheme cannot express: `%host-big-endian?` against an
+# actual memory probe, and the `.sbc` codec's canonical little-endian scalars.
+# This script is the Scheme half.
+#
+# Deliberately NOT wired into run-all.sh: every file listed here is already
+# reached by run-all.sh's own suite globs, so doing both would run them twice.
+# This is the entry point for hosts where run-all.sh is too heavy to run --
+# which today means the three QEMU legs.
+#
+# Exit status is 0 only if every file exits 0. Each file is an (srfi 64) suite
+# with the exit-on-fail epilogue, so a failed assertion is a nonzero exit.
+
+set -u
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+
+if [[ ! -x "$KAAPPI" ]]; then
+    echo "run-endian-suite: no executable kaappi at '$KAAPPI'" >&2
+    echo "Usage: bash tools/run-endian-suite.sh [path/to/kaappi]" >&2
+    exit 2
+fi
+
+# Keep the cache out of the invoking user's real KAAPPI_HOME: this script is
+# also run by hand during audits, and `run-all.sh` isolates for the same reason.
+if [[ -z "${KAAPPI_HOME:-}" ]]; then
+    KAAPPI_HOME="$(mktemp -d)"
+    export KAAPPI_HOME
+    trap 'rm -rf "$KAAPPI_HOME"' EXIT
+fi
+
+# The hub written for this purpose comes first; the rest are pre-existing
+# suites that carry endian-relevant assertions and had never run big-endian.
+#   srfi74            blobs: explicit big/little layouts, native selection
+#   srfi160/srfi4     numeric vectors: host-native element storage
+#   primitives_srfi160-audit
+#                     the encoder-vs-ref-vs-printer cross-decoder probe
+#   srfi66/srfi63     u8vector and prototype-typed arrays over SRFI 160
+#   srfi135           UTF-16BE/LE conversions
+#   srfi178           bit order (spec-defined, asserted not to drift)
+#   internal-primitives-audit
+#                     %host-big-endian? reachability and arity
+FILES=(
+    tests/scheme/audit/endianness-audit.scm
+    tests/scheme/srfi/srfi74.scm
+    tests/scheme/srfi/srfi160.scm
+    tests/scheme/srfi/srfi4.scm
+    tests/scheme/srfi/srfi66.scm
+    tests/scheme/srfi/srfi63.scm
+    tests/scheme/srfi/srfi135.scm
+    tests/scheme/srfi/srfi178-audit.scm
+    tests/scheme/audit/primitives_srfi160-audit.scm
+    tests/scheme/audit/internal-primitives-audit.scm
+)
+
+PASS=0
+FAIL=0
+MISSING=0
+
+echo "=== Endian-sensitive Scheme suites ==="
+echo "kaappi: $KAAPPI"
+echo ""
+
+for f in "${FILES[@]}"; do
+    if [[ ! -f "$f" ]]; then
+        # A renamed or deleted file must be loud: silently running nine of ten
+        # files is exactly how tests/scheme/srfi/slow/ went unnoticed for
+        # eleven days (kaappi#1900).
+        echo "  MISSING  $f"
+        MISSING=$((MISSING + 1))
+        continue
+    fi
+    out="$("$KAAPPI" "$f" 2>&1)"
+    status=$?
+    if [[ $status -eq 0 ]]; then
+        echo "  PASS  $f"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  $f (exit $status)"
+        echo "$out" | sed 's/^/        /'
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo ""
+echo "=== Summary: $PASS passed, $FAIL failed, $MISSING missing ==="
+
+if [[ $FAIL -gt 0 || $MISSING -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/run-endian-suite.sh
+++ b/tools/run-endian-suite.sh
@@ -26,7 +26,18 @@
 
 set -u
 
+# Resolve the binary against the CALLER's cwd first -- a relative argument
+# means what the caller meant, not what it happens to mean after the cd below.
 KAAPPI="${1:-zig-out/bin/kaappi}"
+case "$KAAPPI" in
+    /*) ;;
+    *) KAAPPI="$PWD/$KAAPPI" ;;
+esac
+
+# Then run from the repo root regardless of where we were invoked: every path
+# below is repo-relative, and so is the --lib-path passed to each run.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 2
 
 if [[ ! -x "$KAAPPI" ]]; then
     echo "run-endian-suite: no executable kaappi at '$KAAPPI'" >&2
@@ -83,7 +94,12 @@ for f in "${FILES[@]}"; do
         MISSING=$((MISSING + 1))
         continue
     fi
-    out="$("$KAAPPI" "$f" 2>&1)"
+    # --lib-path is explicit rather than relying on the exe-relative default
+    # (<exe_dir>/../lib): that default reads /proc/self/exe on Linux, and the
+    # QEMU legs this script exists for run the binary through binfmt_misc,
+    # where that path's meaning is the emulator's business rather than ours.
+    # Naming ./lib costs nothing and removes the question.
+    out="$("$KAAPPI" --lib-path lib "$f" 2>&1)"
     status=$?
     if [[ $status -eq 0 ]]; then
         echo "  PASS  $f"


### PR DESCRIPTION
Audit v2, Phase 7C. Closes #2139.

## What `s390x-test` actually ran (verified from `ci.yml`)

Three steps: `zig build -Dtarget=s390x-linux`, `zig build test
-Dtarget=s390x-linux`, `zig-out/bin/kaappi tests/scheme/r7rs/r7rs-tests.scm`.
No `run-all.sh`. `r7rs-tests.scm` imports no SRFI with a byte-order-sensitive
surface, so **no `tests/scheme/**` file carrying a byte-order assertion had
ever executed on a big-endian machine** — including
`tests/scheme/audit/primitives_srfi160-audit.scm`, whose own section header
cites this gap by name.

`ppc64le-test` is **not** a second canary: POWER is little-endian in this
configuration. s390x is the only big-endian leg.

## The assertion that could not fail

`tests/scheme/srfi/srfi74.scm`, under *"native accessors agree with
explicit-endianness accessors"*:

```scheme
(blob-u32-native-set! b1 0 42)
(blob-u32-set! (endianness native) b2 0 42)
(test-equal (blob->u8-list b1) (blob->u8-list b2))
```

`lib/srfi/74.sld:109` defines the left as the right. **Measured:** hardcode
the `endianness` macro's native arm to `'big` and `srfi74.scm` still reports
**30 of 30 pass, exit 0**; the replacement suite reports **7 failures**.
Reverting the mutation makes both green — the 30/30 was not a stale binary.

## Why the fix is split between Zig and Scheme

`(endianness native)` is `(if (%host-big-endian?) 'big 'little)`, and that
primitive is the only Scheme-visible witness of host byte order — nothing else
in `lib/` calls it, and SRFI 160 exposes no byte view of a `NumericVector`
(its six primitives are create/predicate/kind/length/ref/set!). A Scheme
assertion can only re-derive its expectation from the same primitive. So:

**`src/tests_endian.zig`** (11 tests) holds what Scheme cannot express, and
needs **no CI change** — the unit suite is already one of the three things the
s390x leg runs.

* `%host-big-endian?` against an actual in-memory byte probe.
* The `.sbc` codec's canonical little-endian scalars. Every existing `.sbc`
  test writes and reads on the *same* host, so a paired byte-swap cancels out
  and stays green everywhere. These break the pairing one direction at a time:
  the writer (`writeU16/U32/U64/I64/F64/writeStr`) against **literal** expected
  bytes, and `readHeaderInfo` against a **hand-assembled literal-little-endian
  header** — with a discriminating control (the same header with only the two
  VERSION bytes swapped must be rejected) and a `comptime` guard that fails the
  build if a future VERSION makes that control vacuous.
  #438 (`writeF64` omitted the endianness conversion) was exactly this class of
  bug and was found by inspection, not by a test.
* A whole written `.sbc` file, checked at byte offsets 0–14.

**`tests/scheme/audit/endianness-audit.scm`** (99 assertions) covers the
Scheme surfaces:

* SRFI 74 explicit big/little at every width, signed and unsigned, plus
  `blob-uint/sint` at sizes 3 and 5 and the list conversions — byte-level, with
  every expected value a constant and every test value chosen so its
  byte-reverse is a *different* number.
* SRFI 74 native: the layout expectation is **derived from
  `%host-big-endian?`**, never hardcoded, plus the other half ("a native write
  differs from the opposite explicit order") so an arm that always answered
  `'big` cannot pass on a big-endian host either.
* SRFI 160: encoder ↔ `ref` ↔ printer agreement across all 10 multi-byte
  kinds. Those are two independent hand-written decoders; on little-endian they
  cannot disagree even if both were wrong.
* SRFI 135 UTF-16BE/LE including **surrogate pairs** and BOM dispatch.
  `tests/scheme/srfi/srfi135.scm` had **zero** utf16 coverage.
* Controls: UTF-8, bytevectors, `char->integer`, and two-limb bignums — all
  byte-oriented and required to be identical on every host.

**`tools/run-endian-suite.sh`** is the one command: the hub plus the nine
pre-existing suites that carry endian assertions. ~1s natively. Loud on a
missing file, since silently running nine of ten is how
`tests/scheme/srfi/slow/` went unnoticed for eleven days (#1900).

## CI change

One step added to `s390x-test` (the point) and to `riscv64-test` /
`ppc64le-test` as little-endian controls — a failure there means the suite is
wrong, not the host.

## Also fixed

`srfi74.scm`'s tautology is replaced, and **all 31 of its assertions are
named**: SRFI-64 prints a failed assertion's *value*, not its source, so an
unnamed failure on an emulated leg is a bare `#f` among 30 candidates. One
byte-level expectation I hand-computed there was wrong (`0x07` for `0x87`) and
the test caught it — which is the argument for byte-level assertions in
miniature.

`docs/dev/porting.md` claimed the s390x job "guards the invariant on every
PR". It now says what the job runs and what remains blind, including two
things worth stating outright:

* **A paired byte-swap still cancels**, and the nightly `cross-diff` fuzz job
  does not close it either — each side runs against its own arch's cache. Left
  for Phase 7D.
* **A local `zig build test -Dtarget=s390x-linux` proves nothing about
  behaviour.** `build.zig` sets `skip_foreign_checks = true`, so on macOS the
  run step is *skipped* and the command exits 0 with no output (`--summary all`
  shows `run test unit-tests skipped`). It executes on the CI leg only because
  `setup-qemu-action` registers binfmt_misc, so the direct spawn succeeds and
  Zig never consults its foreign-executor logic.

## Verification status

**Verified, little-endian macOS aarch64 ReleaseSafe at `94ebd5a0`:**
`zig build test` green; `run-all.sh` **2060 pass / 0 fail** on a clean tree
(an earlier run showed 2 compile-suite failures caused by cross-compiling
concurrently into the same `zig-out/`, which cleared on a native rebuild —
not attributable to the diff); the endian suite 10/10; the mutation results
above; `zig fmt --check` and markdownlint clean.

**Verified about building, not behaviour:** `zig build -Dtarget=s390x-linux`
produces an `ELF 64-bit MSB executable, IBM S/390`, and the test binary
cross-compiles for s390x.

**Not verified locally, by construction:** every claim about how this code
*behaves* big-endian. No s390x execution was performed on the authoring
machine, and none is possible there. **The `s390x-test` leg on this PR is the
first real big-endian run of any of it** — read that check before merging, and
treat a failure there as a finding rather than as a flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
