### PR TITLE
Phase 6E: thottam audit — 301 assertions, and a nightly tag installs as a release

### DIFF
--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -314,7 +314,7 @@ test "parseConstraints accepts a four-part range (issue #2132)" {
     // try std.testing.expect(semver.parseConstraints(">= 1.0.0") != null);
 }
 
-test "isConstraintSpec routes exactly the four operator-led forms" {
+test "isConstraintSpec routes the six operator-led forms and nothing else" {
     try std.testing.expect(semver.isConstraintSpec(">=1.0.0"));
     try std.testing.expect(semver.isConstraintSpec(">1.0.0"));
     try std.testing.expect(semver.isConstraintSpec("<=1.0.0"));
@@ -571,11 +571,16 @@ test "updateLockfile records and replaces the provenance URL in place" {
     defer if (eb.source) |s| allocator.free(s);
     try std.testing.expectEqualStrings("sha-b", eb.sha);
 
-    // And must not duplicate the rewritten one.
+    // And must not duplicate the rewritten one, nor leave the superseded
+    // line behind. The old line is `a sha-a https://h/a` — matching on
+    // `sha-a` alone would also match `sha-a2`, so the whole line is the
+    // only spelling that can actually fail here.
     const content = try thottam.readFile(allocator, lock);
     defer allocator.free(content);
-    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, content, "sha-a2"));
-    try std.testing.expect(std.mem.indexOf(u8, content, "sha-a\n") == null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, content, "a sha-a2 https://h/a2\n"));
+    try std.testing.expect(std.mem.indexOf(u8, content, "a sha-a https://h/a\n") == null);
+    // Two entries in, two lines out — an in-place rewrite, not an append.
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, content, "\n"));
 }
 
 test "lockfile lookup does not match a package whose name is a prefix (issue #403)" {

--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -1,0 +1,710 @@
+//! Audit-campaign v2 Phase 6E: `thottam`, the package manager.
+//!
+//! The three pre-existing tests here covered the caret operator only. This
+//! file covers the rest of the surface that needs no network: version
+//! parsing, the seven constraint operators and their boundaries, the
+//! `name[@ver][::url]` spec grammar, `kaappi.pkg` manifest parsing, the
+//! package-name guard that keeps an install inside `$KAAPPI_HOME/lib`, and
+//! the lockfile reader/writer round trip.
+//!
+//! **Oracle.** For the constraint operators the oracle is SemVer 2.0.0
+//! (semver.org) for what a *version* is, and node-semver's range grammar
+//! (github.com/npm/node-semver, "Ranges") for what `^` and `~` *mean* —
+//! `^` and `~` are not in the SemVer spec at all, they are npm's, and every
+//! ecosystem that spells them this way inherited them from npm. Where the
+//! two could disagree the assertion says which one it is pinning.
+//!
+//! Assertions that document a *filed* defect are commented out with a
+//! `FAIL: #N` marker directly above, per the campaign protocol: the fix PR
+//! re-enables them. They state the property that *should* hold, never the
+//! symptom that currently does.
+
+const std = @import("std");
+const platform = @import("platform.zig");
+const thottam = @import("thottam.zig");
+const semver = @import("thottam_semver.zig");
+const state = @import("thottam_state.zig");
+
+const Semver = semver.Semver;
+
+fn sv(major: u32, minor: u32, patch: u32) Semver {
+    return .{ .major = major, .minor = minor, .patch = patch };
+}
+
+/// `<op><ver>` parsed through the same entry point `resolveVersion` uses,
+/// then asked about `v`. Fails the test if the constraint does not parse —
+/// a constraint that silently fails to parse is reported by thottam as
+/// "no version matching", which is why every table below goes through here
+/// rather than constructing a `Constraint` by hand.
+fn allows(spec: []const u8, v: Semver) !bool {
+    const c = semver.parseSingleConstraint(spec) orelse return error.ConstraintDidNotParse;
+    return c.matches(v);
+}
+
+// ---------------------------------------------------------------------------
+// Semver.parse — what counts as a version at all
+// ---------------------------------------------------------------------------
+
+test "Semver.parse accepts X.Y.Z with and without the conventional v prefix" {
+    try std.testing.expectEqual(sv(1, 2, 3), Semver.parse("1.2.3").?);
+    try std.testing.expectEqual(sv(1, 2, 3), Semver.parse("v1.2.3").?);
+    try std.testing.expectEqual(sv(0, 0, 0), Semver.parse("0.0.0").?);
+    try std.testing.expectEqual(sv(0, 0, 0), Semver.parse("v0.0.0").?);
+}
+
+test "Semver.parse defaults omitted trailing components to zero" {
+    // Deliberate leniency: git tags in this ecosystem are sometimes `v1.2`.
+    try std.testing.expectEqual(sv(1, 2, 0), Semver.parse("1.2").?);
+    try std.testing.expectEqual(sv(1, 0, 0), Semver.parse("1").?);
+    try std.testing.expectEqual(sv(1, 2, 0), Semver.parse("v1.2").?);
+}
+
+test "Semver.parse rejects non-numeric, signed and empty components" {
+    try std.testing.expect(Semver.parse("") == null);
+    try std.testing.expect(Semver.parse("v") == null);
+    try std.testing.expect(Semver.parse("vv1.2.3") == null);
+    try std.testing.expect(Semver.parse("a.b.c") == null);
+    try std.testing.expect(Semver.parse("1.2.x") == null);
+    try std.testing.expect(Semver.parse("1.two.3") == null);
+    try std.testing.expect(Semver.parse("-1.2.3") == null);
+    try std.testing.expect(Semver.parse("1.-2.3") == null);
+    try std.testing.expect(Semver.parse("1..3") == null);
+    try std.testing.expect(Semver.parse("3junk") == null);
+    try std.testing.expect(Semver.parse("1.2.3junk") == null);
+    try std.testing.expect(Semver.parse("0x10.0.0") == null);
+}
+
+test "Semver.parse rejects surrounding whitespace" {
+    try std.testing.expect(Semver.parse(" 1.2.3") == null);
+    try std.testing.expect(Semver.parse("1.2.3 ") == null);
+    try std.testing.expect(Semver.parse("\t1.2.3") == null);
+}
+
+test "Semver.parse rejects SemVer pre-release and build metadata (2.0.0 s9, s10)" {
+    // SemVer 2.0.0 s11: "a pre-release version has lower precedence than
+    // the associated normal version". thottam has no precedence rule for
+    // them, so excluding them from range matching (node-semver's default
+    // for a range with no pre-release tag of its own) is the right answer.
+    try std.testing.expect(Semver.parse("1.0.0-rc1") == null);
+    try std.testing.expect(Semver.parse("1.0.0-alpha.1") == null);
+    try std.testing.expect(Semver.parse("1.0.0+build.5") == null);
+    try std.testing.expect(Semver.parse("1.0.0-rc1+build") == null);
+}
+
+test "Semver.parse does not overflow or wrap on out-of-range components" {
+    try std.testing.expectEqual(sv(4294967295, 0, 0), Semver.parse("4294967295.0.0").?);
+    try std.testing.expect(Semver.parse("4294967296.0.0") == null);
+    try std.testing.expect(Semver.parse("99999999999999999999.0.0") == null);
+    try std.testing.expect(Semver.parse("0.99999999999999999999.0") == null);
+    try std.testing.expect(Semver.parse("0.0.99999999999999999999") == null);
+}
+
+test "Semver.parse rejects a tag that is not a version (issue #2130)" {
+    // SemVer 2.0.0 s2: "A normal version number MUST take the form X.Y.Z
+    // where X, Y, and Z are non-negative integers" — three components, not
+    // "at least three". A `git ls-remote --tags` sweep sees whatever the
+    // repo tagged, so a tag that is not a version must not become a
+    // candidate release.
+    //
+    // FAIL: #2130 (Semver.parse reads three components and discards the rest,
+    // so v2.0.0.nightly-UNRELEASED parses as 2.0.0 and >=1.0.0 installs it)
+    // try std.testing.expect(Semver.parse("2.0.0.nightly-UNRELEASED") == null);
+    // try std.testing.expect(Semver.parse("1.2.3.4") == null);
+    // try std.testing.expect(Semver.parse("1.2.3.") == null);
+
+    // SemVer 2.0.0 s2: "and MUST NOT contain leading zeroes".
+    // FAIL: #2130
+    // try std.testing.expect(Semver.parse("01.02.03") == null);
+
+    // Each component goes to std.fmt.parseInt, which implements *Zig's*
+    // integer-literal grammar — an explicit '+' sign and '_' digit
+    // separators are both legal there and neither is a SemVer digit.
+    // `v1_0.0.0` therefore parses as version 10.0.0.
+    // FAIL: #2130
+    // try std.testing.expect(Semver.parse("+1.2.3") == null);
+    // try std.testing.expect(Semver.parse("1.+2.3") == null);
+    // try std.testing.expect(Semver.parse("1_0.0.0") == null);
+
+    // Discriminating control — the adjacent malformed spellings ARE
+    // rejected, so the leniency is specific to extra dot-separated
+    // components, leading zeros, and Zig's own numeric-literal syntax.
+    try std.testing.expect(Semver.parse("2.0.0-nightly") == null);
+    try std.testing.expect(Semver.parse("2.0.0nightly") == null);
+    try std.testing.expect(Semver.parse("2.0.0/4") == null);
+    try std.testing.expect(Semver.parse("1-0.0.0") == null);
+}
+
+test "Semver.order is a total order over the three components" {
+    try std.testing.expectEqual(std.math.Order.eq, Semver.order(sv(1, 2, 3), sv(1, 2, 3)));
+    try std.testing.expectEqual(std.math.Order.lt, Semver.order(sv(1, 2, 3), sv(1, 2, 4)));
+    try std.testing.expectEqual(std.math.Order.lt, Semver.order(sv(1, 2, 3), sv(1, 3, 0)));
+    try std.testing.expectEqual(std.math.Order.lt, Semver.order(sv(1, 9, 9), sv(2, 0, 0)));
+    try std.testing.expectEqual(std.math.Order.gt, Semver.order(sv(2, 0, 0), sv(1, 9, 9)));
+    // Major dominates minor dominates patch, not a lexicographic string compare.
+    try std.testing.expectEqual(std.math.Order.gt, Semver.order(sv(10, 0, 0), sv(9, 0, 0)));
+    try std.testing.expectEqual(std.math.Order.gt, Semver.order(sv(1, 10, 0), sv(1, 9, 0)));
+    try std.testing.expectEqual(std.math.Order.gt, Semver.order(sv(1, 0, 10), sv(1, 0, 9)));
+}
+
+// ---------------------------------------------------------------------------
+// The seven constraint operators, at their boundaries
+// ---------------------------------------------------------------------------
+
+test "constraint >= includes its own version and everything above" {
+    try std.testing.expect(try allows(">=1.2.3", sv(1, 2, 3)));
+    try std.testing.expect(try allows(">=1.2.3", sv(1, 2, 4)));
+    try std.testing.expect(try allows(">=1.2.3", sv(99, 0, 0)));
+    try std.testing.expect(!try allows(">=1.2.3", sv(1, 2, 2)));
+    try std.testing.expect(!try allows(">=1.2.3", sv(0, 9, 9)));
+}
+
+test "constraint > excludes its own version" {
+    try std.testing.expect(!try allows(">1.2.3", sv(1, 2, 3)));
+    try std.testing.expect(try allows(">1.2.3", sv(1, 2, 4)));
+    try std.testing.expect(!try allows(">1.2.3", sv(1, 2, 2)));
+}
+
+test "constraint <= includes its own version and everything below" {
+    try std.testing.expect(try allows("<=1.2.3", sv(1, 2, 3)));
+    try std.testing.expect(try allows("<=1.2.3", sv(1, 2, 2)));
+    try std.testing.expect(try allows("<=1.2.3", sv(0, 0, 0)));
+    try std.testing.expect(!try allows("<=1.2.3", sv(1, 2, 4)));
+}
+
+test "constraint < excludes its own version" {
+    try std.testing.expect(!try allows("<1.2.3", sv(1, 2, 3)));
+    try std.testing.expect(try allows("<1.2.3", sv(1, 2, 2)));
+    try std.testing.expect(!try allows("<1.2.3", sv(1, 3, 0)));
+}
+
+test "a bare version inside a comma list is an equality constraint" {
+    // Reachable only from a comma list: isConstraintSpec routes a bare
+    // `pkg@1.2.3` to `git checkout` as a literal ref, never to the matcher.
+    try std.testing.expect(try allows("1.2.3", sv(1, 2, 3)));
+    try std.testing.expect(!try allows("1.2.3", sv(1, 2, 4)));
+    try std.testing.expect(!try allows("1.2.3", sv(1, 2, 2)));
+}
+
+test "caret ^X.Y.Z with X>0 is >=X.Y.Z <(X+1).0.0 (node-semver Ranges)" {
+    try std.testing.expect(try allows("^1.2.3", sv(1, 2, 3)));
+    try std.testing.expect(try allows("^1.2.3", sv(1, 2, 4)));
+    try std.testing.expect(try allows("^1.2.3", sv(1, 99, 99)));
+    try std.testing.expect(!try allows("^1.2.3", sv(1, 2, 2)));
+    try std.testing.expect(!try allows("^1.2.3", sv(1, 1, 99)));
+    try std.testing.expect(!try allows("^1.2.3", sv(2, 0, 0)));
+    try std.testing.expect(!try allows("^1.2.3", sv(0, 99, 99)));
+}
+
+test "caret ^0.Y.Z with Y>0 is >=0.Y.Z <0.(Y+1).0 (node-semver Ranges)" {
+    try std.testing.expect(try allows("^0.2.3", sv(0, 2, 3)));
+    try std.testing.expect(try allows("^0.2.3", sv(0, 2, 99)));
+    try std.testing.expect(!try allows("^0.2.3", sv(0, 2, 2)));
+    try std.testing.expect(!try allows("^0.2.3", sv(0, 3, 0)));
+    try std.testing.expect(!try allows("^0.2.3", sv(1, 0, 0)));
+}
+
+test "caret ^0.0.Z is exactly Z — >=0.0.Z <0.0.(Z+1) (node-semver Ranges)" {
+    try std.testing.expect(try allows("^0.0.3", sv(0, 0, 3)));
+    try std.testing.expect(!try allows("^0.0.3", sv(0, 0, 4)));
+    try std.testing.expect(!try allows("^0.0.3", sv(0, 0, 2)));
+    try std.testing.expect(!try allows("^0.0.3", sv(0, 1, 0)));
+}
+
+test "caret on an abbreviated range (issue #2131)" {
+    // node-semver: `^1` is `>=1.0.0 <2.0.0`. This one is right, because
+    // filling the omitted components with 0 happens to give the same answer.
+    try std.testing.expect(try allows("^1", sv(1, 0, 0)));
+    try std.testing.expect(try allows("^1", sv(1, 9, 9)));
+    try std.testing.expect(!try allows("^1", sv(2, 0, 0)));
+
+    // node-semver: `^0.2` is `>=0.2.0 <0.3.0`. Also right.
+    try std.testing.expect(try allows("^0.2", sv(0, 2, 9)));
+    try std.testing.expect(!try allows("^0.2", sv(0, 3, 0)));
+
+    // node-semver: `^0.0` is `>=0.0.0 <0.1.0` — the whole 0.0.x line.
+    // FAIL: #2131 (an omitted component is filled with 0 and then treated as
+    // if it had been written, so ^0.0 collapses to ^0.0.0 = exactly 0.0.0)
+    // try std.testing.expect(try allows("^0.0", sv(0, 0, 5)));
+    try std.testing.expect(try allows("^0.0", sv(0, 0, 0)));
+    try std.testing.expect(!try allows("^0.0", sv(0, 1, 0)));
+}
+
+test "tilde ~X.Y.Z is >=X.Y.Z <X.(Y+1).0 (node-semver Ranges)" {
+    try std.testing.expect(try allows("~1.2.3", sv(1, 2, 3)));
+    try std.testing.expect(try allows("~1.2.3", sv(1, 2, 99)));
+    try std.testing.expect(!try allows("~1.2.3", sv(1, 2, 2)));
+    try std.testing.expect(!try allows("~1.2.3", sv(1, 3, 0)));
+    try std.testing.expect(!try allows("~1.2.3", sv(2, 2, 3)));
+    try std.testing.expect(!try allows("~1.2.3", sv(0, 2, 3)));
+}
+
+test "tilde on an abbreviated range (issue #2131)" {
+    // node-semver: `~1.2` is `>=1.2.0 <1.3.0`. Right.
+    try std.testing.expect(try allows("~1.2", sv(1, 2, 0)));
+    try std.testing.expect(try allows("~1.2", sv(1, 2, 9)));
+    try std.testing.expect(!try allows("~1.2", sv(1, 3, 0)));
+
+    // node-semver: `~1` is `>=1.0.0 <2.0.0` — "allows minor-level changes
+    // when only the major version is specified".
+    // FAIL: #2131 (`~1` is filled to 1.0.0 and then pinned to minor 0, so it
+    // means `~1.0.0` = `>=1.0.0 <1.1.0` instead)
+    // try std.testing.expect(try allows("~1", sv(1, 9, 0)));
+    try std.testing.expect(try allows("~1", sv(1, 0, 0)));
+    try std.testing.expect(!try allows("~1", sv(2, 0, 0)));
+
+    // Discriminating control: `~1.0.0` and `~1` are DIFFERENT ranges in
+    // node-semver but identical here — the fully-spelled form is correct.
+    try std.testing.expect(try allows("~1.0.0", sv(1, 0, 9)));
+    try std.testing.expect(!try allows("~1.0.0", sv(1, 1, 0)));
+}
+
+// ---------------------------------------------------------------------------
+// parseConstraints — the comma-separated range
+// ---------------------------------------------------------------------------
+
+fn rangeAllows(spec: []const u8, v: Semver) !bool {
+    const cs = semver.parseConstraints(spec) orelse return error.RangeDidNotParse;
+    return semver.matchesAllConstraints(v, cs);
+}
+
+test "parseConstraints conjoins every comma-separated part" {
+    try std.testing.expect(try rangeAllows(">=1.0.0,<2.0.0", sv(1, 9, 9)));
+    try std.testing.expect(!try rangeAllows(">=1.0.0,<2.0.0", sv(2, 0, 0)));
+    try std.testing.expect(!try rangeAllows(">=1.0.0,<2.0.0", sv(0, 9, 9)));
+    // An unsatisfiable range parses and simply matches nothing.
+    try std.testing.expect(!try rangeAllows(">=2.0.0,<1.0.0", sv(1, 5, 0)));
+    try std.testing.expect(!try rangeAllows(">=2.0.0,<1.0.0", sv(2, 5, 0)));
+}
+
+test "parseConstraints tolerates surrounding quotes and spaces after commas" {
+    // `depends: kaappi-net@">=0.2.0"` keeps its quotes through the manifest.
+    try std.testing.expect(try rangeAllows("\">=1.0.0\"", sv(1, 0, 0)));
+    try std.testing.expect(try rangeAllows("\">=1.0.0,<2.0.0\"", sv(1, 5, 0)));
+    try std.testing.expect(try rangeAllows(">=1.0.0, <2.0.0", sv(1, 5, 0)));
+}
+
+test "parseConstraints rejects malformed ranges rather than matching loosely" {
+    try std.testing.expect(semver.parseConstraints("") == null);
+    try std.testing.expect(semver.parseConstraints(">=") == null);
+    try std.testing.expect(semver.parseConstraints("^") == null);
+    try std.testing.expect(semver.parseConstraints("~") == null);
+    try std.testing.expect(semver.parseConstraints(">") == null);
+    try std.testing.expect(semver.parseConstraints("<") == null);
+    try std.testing.expect(semver.parseConstraints(">=>1.0.0") == null);
+    try std.testing.expect(semver.parseConstraints(">>1.0.0") == null);
+    try std.testing.expect(semver.parseConstraints("^~1.0.0") == null);
+    try std.testing.expect(semver.parseConstraints(">=1.0.0,") == null);
+    try std.testing.expect(semver.parseConstraints(",>=1.0.0") == null);
+    try std.testing.expect(semver.parseConstraints(">=1.0.0,,<2.0.0") == null);
+    try std.testing.expect(semver.parseConstraints(">=1.0.0-rc1") == null);
+    try std.testing.expect(semver.parseConstraints("\"\"") == null);
+}
+
+test "parseConstraints accepts a four-part range (issue #2132)" {
+    try std.testing.expect(semver.parseConstraints(">=1.0.0,<2.0.0,>0.5.0,<=1.9.0") != null);
+    // Four is the ceiling (`[4]?Constraint`): a fifth part makes the whole
+    // range `null`, which reaches the user as "no version matching ...",
+    // indistinguishable from "no such tag". Not asserted either way — the
+    // limit is undocumented, and a fix may raise it or diagnose it.
+
+    // node-semver allows whitespace between an operator and its version
+    // (`>= 1.0.0` is the same range as `>=1.0.0`).
+    // FAIL: #2132 (the space is handed to Semver.parse, which rejects it, and
+    // the whole range is then reported as "no version matching")
+    // try std.testing.expect(semver.parseConstraints(">= 1.0.0") != null);
+}
+
+test "isConstraintSpec routes exactly the four operator-led forms" {
+    try std.testing.expect(semver.isConstraintSpec(">=1.0.0"));
+    try std.testing.expect(semver.isConstraintSpec(">1.0.0"));
+    try std.testing.expect(semver.isConstraintSpec("<=1.0.0"));
+    try std.testing.expect(semver.isConstraintSpec("<1.0.0"));
+    try std.testing.expect(semver.isConstraintSpec("^1.0.0"));
+    try std.testing.expect(semver.isConstraintSpec("~1.0.0"));
+    try std.testing.expect(semver.isConstraintSpec("\">=1.0.0\""));
+    // Everything else is a literal git ref for `git checkout`.
+    try std.testing.expect(!semver.isConstraintSpec("1.0.0"));
+    try std.testing.expect(!semver.isConstraintSpec("v1.0.0"));
+    try std.testing.expect(!semver.isConstraintSpec("=1.0.0"));
+    try std.testing.expect(!semver.isConstraintSpec("main"));
+    try std.testing.expect(!semver.isConstraintSpec("abc123"));
+    // Regression for #613: empty after quote trimming must not index [0].
+    try std.testing.expect(!semver.isConstraintSpec(""));
+    try std.testing.expect(!semver.isConstraintSpec("\"\""));
+    try std.testing.expect(!semver.isConstraintSpec("\"\"\"\""));
+}
+
+// ---------------------------------------------------------------------------
+// parsePkgSpec — name[@ver][::url]
+// ---------------------------------------------------------------------------
+
+test "parsePkgSpec splits at the first :: and the first @ before it" {
+    const a = state.parsePkgSpec("pkg@v1.0.0::https://example.com/a/b");
+    try std.testing.expectEqualStrings("pkg", a.name);
+    try std.testing.expectEqualStrings("v1.0.0", a.ver.?);
+    try std.testing.expectEqualStrings("https://example.com/a/b", a.source.?);
+}
+
+test "parsePkgSpec leaves @ and :: inside the URL alone" {
+    // A userinfo@host URL must not be re-split: the @ search is confined to
+    // the part before ::.
+    const a = state.parsePkgSpec("pkg::https://user@host.example/repo.git");
+    try std.testing.expectEqualStrings("pkg", a.name);
+    try std.testing.expect(a.ver == null);
+    try std.testing.expectEqualStrings("https://user@host.example/repo.git", a.source.?);
+
+    // Only the FIRST :: separates; later ones belong to the URL.
+    const b = state.parsePkgSpec("pkg::https://h/a::b");
+    try std.testing.expectEqualStrings("pkg", b.name);
+    try std.testing.expectEqualStrings("https://h/a::b", b.source.?);
+
+    const c = state.parsePkgSpec("pkg@v1::https://u@h/r::x");
+    try std.testing.expectEqualStrings("pkg", c.name);
+    try std.testing.expectEqualStrings("v1", c.ver.?);
+    try std.testing.expectEqualStrings("https://u@h/r::x", c.source.?);
+}
+
+test "parsePkgSpec drops an option-shaped source URL (issue #614 guard)" {
+    // A URL starting with '-' would be parsed as an option by git even
+    // behind `--`; it is discarded so the org default is used instead.
+    try std.testing.expect(state.parsePkgSpec("pkg::-upload-pack=evil").source == null);
+    try std.testing.expect(state.parsePkgSpec("pkg::--upload-pack=evil").source == null);
+    // An empty URL likewise falls back to the org default.
+    try std.testing.expect(state.parsePkgSpec("pkg::").source == null);
+    // Discriminating control: an ordinary URL survives.
+    try std.testing.expect(state.parsePkgSpec("pkg::https://h/r").source != null);
+}
+
+test "parsePkgSpec on degenerate specs (issue #2132)" {
+    // An empty name is produced, not rejected here — isValidPkgName is the
+    // gate, and it runs on every path that builds a filesystem path.
+    try std.testing.expectEqualStrings("", state.parsePkgSpec("::https://h/r").name);
+    try std.testing.expectEqualStrings("", state.parsePkgSpec("@v1").name);
+    try std.testing.expectEqualStrings("", state.parsePkgSpec("").name);
+
+    // A trailing @ with nothing after it should mean "no version pinned",
+    // the same as omitting the @ entirely.
+    // FAIL: #2132 (`pkg@` yields ver == "", which prints as `Installing pkg@`
+    // and then fails at checkout instead of installing the default branch)
+    // try std.testing.expect(state.parsePkgSpec("pkg@").ver == null);
+
+    // Discriminating control: omitting the @ does give null.
+    try std.testing.expect(state.parsePkgSpec("pkg").ver == null);
+}
+
+// ---------------------------------------------------------------------------
+// isValidPkgName — the guard that keeps an install inside $KAAPPI_HOME/lib
+// ---------------------------------------------------------------------------
+
+test "isValidPkgName rejects every byte that could leave the install tree" {
+    // Exhaustive over the byte range: a package name reaches
+    // joinPath(src_dir, name) and joinPath(lib_dir, name), so the accepted
+    // set must contain no separator, no '.', and nothing a shell or a
+    // Windows path parser treats specially. Property, not a spot check —
+    // a future "allow dots in names" change has to come here first.
+    var b: u16 = 0;
+    while (b <= 255) : (b += 1) {
+        const c: u8 = @intCast(b);
+        const one = [_]u8{c};
+        const want = std.ascii.isAlphanumeric(c) or c == '-' or c == '_';
+        try std.testing.expectEqual(want, state.isValidPkgName(&one));
+    }
+}
+
+test "isValidPkgName rejects traversal, absolute and empty names" {
+    try std.testing.expect(!state.isValidPkgName(""));
+    try std.testing.expect(!state.isValidPkgName("."));
+    try std.testing.expect(!state.isValidPkgName(".."));
+    try std.testing.expect(!state.isValidPkgName("../evil"));
+    try std.testing.expect(!state.isValidPkgName("../../etc/passwd"));
+    try std.testing.expect(!state.isValidPkgName("a/../../b"));
+    try std.testing.expect(!state.isValidPkgName("/tmp/evil"));
+    try std.testing.expect(!state.isValidPkgName("C:\\evil"));
+    try std.testing.expect(!state.isValidPkgName("a\\b"));
+    try std.testing.expect(!state.isValidPkgName("foo.bar"));
+    try std.testing.expect(!state.isValidPkgName("foo bar"));
+    try std.testing.expect(!state.isValidPkgName("foo\x00bar"));
+    try std.testing.expect(!state.isValidPkgName("foo\nbar"));
+    try std.testing.expect(!state.isValidPkgName("~root"));
+    try std.testing.expect(!state.isValidPkgName("$HOME"));
+    try std.testing.expect(!state.isValidPkgName("kaappi—json")); // U+2014, not '-'
+}
+
+test "isValidPkgName accepts the shapes the ecosystem actually uses" {
+    try std.testing.expect(state.isValidPkgName("kaappi-json"));
+    try std.testing.expect(state.isValidPkgName("kaappi_json"));
+    try std.testing.expect(state.isValidPkgName("kaappi-160"));
+    try std.testing.expect(state.isValidPkgName("a"));
+    try std.testing.expect(state.isValidPkgName("A"));
+    try std.testing.expect(state.isValidPkgName("0"));
+}
+
+// ---------------------------------------------------------------------------
+// kaappi.pkg manifest parsing
+// ---------------------------------------------------------------------------
+
+test "parsePkgManifest reads the four documented fields" {
+    const m = state.parsePkgManifest(
+        \\name: kaappi-web
+        \\depends: kaappi-http kaappi-json
+        \\build: make
+        \\source: https://github.com/alice/kaappi-web
+        \\
+    );
+    try std.testing.expectEqualStrings("kaappi-web", m.name.?);
+    try std.testing.expectEqualStrings("kaappi-http kaappi-json", m.depends.?);
+    try std.testing.expectEqualStrings("make", m.build_cmd.?);
+    try std.testing.expectEqualStrings("https://github.com/alice/kaappi-web", m.source.?);
+}
+
+test "parsePkgManifest tolerates CRLF line endings" {
+    // thottam runs on Windows under Git Bash; a manifest checked out with
+    // core.autocrlf=true has \r before every \n.
+    const m = state.parsePkgManifest("name: kaappi-web\r\ndepends: kaappi-http\r\nbuild: make\r\n");
+    try std.testing.expectEqualStrings("kaappi-web", m.name.?);
+    try std.testing.expectEqualStrings("kaappi-http", m.depends.?);
+    try std.testing.expectEqualStrings("make", m.build_cmd.?);
+}
+
+test "parsePkgManifest ignores unknown keys and near-miss key names" {
+    const m = state.parsePkgManifest(
+        \\# a comment line
+        \\names: not-the-name
+        \\builds: not-the-build
+        \\sources: not-the-source
+        \\dependency: not-the-depends
+        \\version: 1.0.0
+        \\name: real
+        \\
+    );
+    try std.testing.expectEqualStrings("real", m.name.?);
+    try std.testing.expect(m.depends == null);
+    try std.testing.expect(m.build_cmd == null);
+    try std.testing.expect(m.source == null);
+}
+
+test "parsePkgManifest takes the last of duplicate keys" {
+    const m = state.parsePkgManifest("name: first\nname: second\nbuild: a\nbuild: b\n");
+    try std.testing.expectEqualStrings("second", m.name.?);
+    try std.testing.expectEqualStrings("b", m.build_cmd.?);
+}
+
+test "parsePkgManifest requires the key at column 0" {
+    // Strictness worth pinning: an indented key is silently dropped, so a
+    // future whitespace-tolerant rewrite has to notice this test.
+    const m = state.parsePkgManifest("  name: indented\n\tbuild: tabbed\n");
+    try std.testing.expect(m.name == null);
+    try std.testing.expect(m.build_cmd == null);
+}
+
+test "parsePkgManifest on missing and empty values" {
+    const none = state.parsePkgManifest("");
+    try std.testing.expect(none.name == null);
+    try std.testing.expect(none.depends == null);
+    try std.testing.expect(none.build_cmd == null);
+    try std.testing.expect(none.source == null);
+
+    // An option-shaped source is dropped, like the spec-level guard.
+    try std.testing.expect(state.parsePkgManifest("source: -evil\n").source == null);
+
+    // An empty `build:` should mean "no build command", not "run the empty
+    // command" — thottam prints "Building <pkg>..." and runs `/bin/sh -c ""`.
+    // FAIL: #2132
+    // try std.testing.expect(state.parsePkgManifest("build:\n").build_cmd == null);
+
+    // Discriminating control: a genuinely absent build: key is null.
+    try std.testing.expect(state.parsePkgManifest("name: x\n").build_cmd == null);
+}
+
+test "parseField trims the value but not the key" {
+    try std.testing.expectEqualStrings("value", state.parseField("key: value", "key:").?);
+    try std.testing.expectEqualStrings("value", state.parseField("key:value", "key:").?);
+    try std.testing.expectEqualStrings("value", state.parseField("key:  value  ", "key:").?);
+    try std.testing.expectEqualStrings("value", state.parseField("key:\tvalue\r", "key:").?);
+    try std.testing.expectEqualStrings("a  b", state.parseField("key: a  b ", "key:").?);
+    try std.testing.expect(state.parseField("other: value", "key:") == null);
+    try std.testing.expect(state.parseField(" key: value", "key:") == null);
+    try std.testing.expect(state.parseField("", "key:") == null);
+}
+
+// ---------------------------------------------------------------------------
+// Lockfile and installed-list round trips
+// ---------------------------------------------------------------------------
+
+fn tempPath(buf: []u8, name: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}/kaappi-thottam-6e-{d}-{s}", .{ platform.tempDir(), platform.getPid(), name });
+}
+
+test "updateLockfile round-trips through getLockedEntry" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const lock = try tempPath(&buf, "lock1");
+    defer thottam.removeDir(allocator, lock) catch {};
+
+    try state.updateLockfile(allocator, lock, "kaappi-json", "abc123", null);
+    const e = state.getLockedEntry(allocator, lock, "kaappi-json").?;
+    defer allocator.free(e.sha);
+    defer if (e.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("abc123", e.sha);
+    try std.testing.expect(e.source == null);
+}
+
+test "updateLockfile records and replaces the provenance URL in place" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const lock = try tempPath(&buf, "lock2");
+    defer thottam.removeDir(allocator, lock) catch {};
+
+    try state.updateLockfile(allocator, lock, "a", "sha-a", "https://h/a");
+    try state.updateLockfile(allocator, lock, "b", "sha-b", null);
+    try state.updateLockfile(allocator, lock, "a", "sha-a2", "https://h/a2");
+
+    const ea = state.getLockedEntry(allocator, lock, "a").?;
+    defer allocator.free(ea.sha);
+    defer if (ea.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("sha-a2", ea.sha);
+    try std.testing.expectEqualStrings("https://h/a2", ea.source.?);
+
+    // Rewriting one entry must not disturb its neighbour.
+    const eb = state.getLockedEntry(allocator, lock, "b").?;
+    defer allocator.free(eb.sha);
+    defer if (eb.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("sha-b", eb.sha);
+
+    // And must not duplicate the rewritten one.
+    const content = try thottam.readFile(allocator, lock);
+    defer allocator.free(content);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, content, "sha-a2"));
+    try std.testing.expect(std.mem.indexOf(u8, content, "sha-a\n") == null);
+}
+
+test "lockfile lookup does not match a package whose name is a prefix (issue #403)" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const lock = try tempPath(&buf, "lock3");
+    defer thottam.removeDir(allocator, lock) catch {};
+
+    try state.updateLockfile(allocator, lock, "kaappi-net-extra", "sha-extra", null);
+    // "kaappi-net" is a strict prefix of "kaappi-net-extra": the delimiter
+    // check is what keeps this from returning the wrong entry.
+    try std.testing.expect(state.getLockedEntry(allocator, lock, "kaappi-net") == null);
+
+    try state.updateLockfile(allocator, lock, "kaappi-net", "sha-net", null);
+    const e = state.getLockedEntry(allocator, lock, "kaappi-net").?;
+    defer allocator.free(e.sha);
+    defer if (e.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("sha-net", e.sha);
+
+    const e2 = state.getLockedEntry(allocator, lock, "kaappi-net-extra").?;
+    defer allocator.free(e2.sha);
+    defer if (e2.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("sha-extra", e2.sha);
+}
+
+test "removeFromLockfile removes only the named entry" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const lock = try tempPath(&buf, "lock4");
+    defer thottam.removeDir(allocator, lock) catch {};
+
+    try state.updateLockfile(allocator, lock, "kaappi-net", "sha-net", null);
+    try state.updateLockfile(allocator, lock, "kaappi-net-extra", "sha-extra", "https://h/x");
+    try state.removeFromLockfile(allocator, lock, "kaappi-net");
+
+    try std.testing.expect(state.getLockedEntry(allocator, lock, "kaappi-net") == null);
+    const e = state.getLockedEntry(allocator, lock, "kaappi-net-extra").?;
+    defer allocator.free(e.sha);
+    defer if (e.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("sha-extra", e.sha);
+    try std.testing.expectEqualStrings("https://h/x", e.source.?);
+
+    // Removing an absent package is a no-op, not an error.
+    try state.removeFromLockfile(allocator, lock, "not-there");
+    const still = state.getLockedEntry(allocator, lock, "kaappi-net-extra").?;
+    defer allocator.free(still.sha);
+    defer if (still.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("sha-extra", still.sha);
+}
+
+test "lockfile reader on a truncated or malformed file" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const lock = try tempPath(&buf, "lock5");
+    defer thottam.removeDir(allocator, lock) catch {};
+
+    // A name with no SHA and no delimiter: no entry, no crash.
+    try thottam.writeFile(allocator, lock, "kaappi-json");
+    try std.testing.expect(state.getLockedEntry(allocator, lock, "kaappi-json") == null);
+
+    // Binary garbage: no entry, no crash.
+    try thottam.writeFile(allocator, lock, "\x00\x01\xff\xfe\n\x7f");
+    try std.testing.expect(state.getLockedEntry(allocator, lock, "kaappi-json") == null);
+
+    // A name followed by a bare space: an empty SHA, reported as such.
+    try thottam.writeFile(allocator, lock, "kaappi-json \n");
+    const e = state.getLockedEntry(allocator, lock, "kaappi-json").?;
+    defer allocator.free(e.sha);
+    defer if (e.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("", e.sha);
+
+    // A missing file is null, not an error.
+    var buf2: [512]u8 = undefined;
+    const gone = try tempPath(&buf2, "lock5-absent");
+    try std.testing.expect(state.getLockedEntry(allocator, gone, "kaappi-json") == null);
+}
+
+test "lockfile reader tolerates CRLF line endings (issue #2133)" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const lock = try tempPath(&buf, "lock6");
+    defer thottam.removeDir(allocator, lock) catch {};
+
+    const sha = "75f253e118c0976ac2caabec574af39394e7bc4e";
+    try thottam.writeFile(allocator, lock, "kaappi-alpha " ++ "75f253e118c0976ac2caabec574af39394e7bc4e" ++ "\r\n");
+    const e = state.getLockedEntry(allocator, lock, "kaappi-alpha").?;
+    defer allocator.free(e.sha);
+    defer if (e.source) |s| allocator.free(s);
+
+    // The lockfile is meant to be committed and shared between machines, so
+    // a checkout that normalised it to CRLF must still compare equal.
+    // FAIL: #2133 (the \r stays in the SHA, and `thottam verify` then prints
+    // "MISMATCH (locked: 75f253e118c0, actual: 75f253e118c0)" — the trailing
+    // \r is outside the 12-character display prefix, so the two reported
+    // values are identical and the message is unusable)
+    // try std.testing.expectEqualStrings(sha, e.sha);
+
+    // Discriminating control: with LF, the same line reads back exactly.
+    try thottam.writeFile(allocator, lock, "kaappi-alpha " ++ "75f253e118c0976ac2caabec574af39394e7bc4e" ++ "\n");
+    const e2 = state.getLockedEntry(allocator, lock, "kaappi-alpha").?;
+    defer allocator.free(e2.sha);
+    defer if (e2.source) |s| allocator.free(s);
+    try std.testing.expectEqualStrings(sha, e2.sha);
+}
+
+test "installed-list membership is exact, never a prefix match" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const inst = try tempPath(&buf, "inst1");
+    defer thottam.removeDir(allocator, inst) catch {};
+
+    try thottam.writeFile(allocator, inst, "kaappi-net-extra\nkaappi-json\n");
+    try std.testing.expect(state.isInstalled(allocator, inst, "kaappi-json"));
+    try std.testing.expect(state.isInstalled(allocator, inst, "kaappi-net-extra"));
+    try std.testing.expect(!state.isInstalled(allocator, inst, "kaappi-net"));
+    try std.testing.expect(!state.isInstalled(allocator, inst, "kaappi"));
+    try std.testing.expect(!state.isInstalled(allocator, inst, "json"));
+
+    try state.removeFromInstalled(allocator, inst, "kaappi-json");
+    try std.testing.expect(!state.isInstalled(allocator, inst, "kaappi-json"));
+    try std.testing.expect(state.isInstalled(allocator, inst, "kaappi-net-extra"));
+}
+
+test "appendLockEntry emits the documented two- and three-column shapes" {
+    const allocator = std.testing.allocator;
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+
+    try state.appendLockEntry(&out, allocator, "a", "sha-a", null);
+    try state.appendLockEntry(&out, allocator, "b", "sha-b", "https://h/b");
+    try std.testing.expectEqualStrings("a sha-a\nb sha-b https://h/b\n", out.items);
+}

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -914,6 +914,7 @@ test {
     _ = proc;
     _ = state;
     _ = tfs;
+    _ = @import("tests_thottam.zig");
 }
 
 test "markVisited copies keys so freed dependency names stay valid (issue #784)" {

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -509,6 +509,7 @@ run_shell_suite "Cache" tests/scheme/cache
 run_shell_suite "Timings" tests/scheme/timings
 run_shell_suite "Shell completions" tests/scheme/completions
 run_shell_suite "Language server" tests/scheme/lsp
+run_shell_suite "Package manager" tests/scheme/thottam
 # Execution-tier differential: every corpus file must give the same answer with
 # the IR optimiser off and from a warm bytecode cache as it does from a cold
 # one. Defaults to the smoke+compliance+audit corpus plus its own probes

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -39,28 +39,26 @@ if ! command -v git > /dev/null 2>&1; then
     exit 77
 fi
 
-# This suite's whole method is "point KAAPPI_ORG at local bare repositories",
-# which needs git to clone a plain filesystem path.  That holds on macOS and
-# Linux and does NOT hold on the three BSD CI legs, where thottam reports
-# `Failed to clone repository` for a fixture the setup created successfully
-# (kaappi#2150).  The cause is not yet known, so rather than assert a
-# precondition we cannot explain, probe it directly and skip when it does not
-# hold -- the same shape as skip_without_zig in shell-common.sh.
+# thottam invokes git as the absolute path /usr/bin/git (thottam_proc.zig:148),
+# not through PATH. That path exists on macOS and on CI's Linux images, and on
+# none of the three BSDs -- FreeBSD and OpenBSD put git in /usr/local/bin,
+# NetBSD in /usr/pkg/bin -- so every git-backed thottam operation fails there
+# (kaappi#2152). This suite is entirely git-backed, so it cannot run.
 #
-# Probing beats hardcoding a platform list: if the underlying issue is fixed,
-# or if it turns out to be a git-version rather than an OS boundary, this
-# starts running again on its own with no allowlist to maintain.
-_probe="$(mktemp -d)"
-if ! ( cd "$_probe" && git init -q bare-src > /dev/null 2>&1 \
-        && cd bare-src && git -c user.email=t@example.com -c user.name=Test \
-             commit -q --allow-empty -m probe > /dev/null 2>&1 \
-        && cd .. && git clone -q --bare bare-src probe.git > /dev/null 2>&1 \
-        && git clone -q -- "$_probe/probe.git" clone-out > /dev/null 2>&1 ); then
-    rm -rf "$_probe"
-    echo "SKIP: git cannot clone a local bare repository here (see kaappi#2150)"
+# Probe for the exact precondition rather than listing platforms: when #2152 is
+# fixed to search PATH, this check should be replaced by `command -v git`,
+# which is already asserted above. Until then, testing for the very path
+# thottam will execute is the honest gate -- it skips exactly where thottam is
+# broken and nowhere else.
+#
+# An earlier version of this probe created a bare repo and cloned it, on the
+# hypothesis that local-bare-clone was unsupported there. It PASSED on OpenBSD
+# while the suite still failed, because the probe used PATH and thottam does
+# not. That falsified hypothesis is what located #2152.
+if [[ ! -x /usr/bin/git ]]; then
+    echo "SKIP: thottam hardcodes /usr/bin/git, which does not exist here (kaappi#2152)"
     exit 77
 fi
-rm -rf "$_probe"
 
 PASS=0
 FAIL=0

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -282,11 +282,18 @@ mkdir -p "$WORK/kaappi-evildep/lib/kaappi"
 )
 git clone -q --bare "$WORK/kaappi-evildep" "$ORG/kaappi-evildep.git"
 fresh_home
+# The traversal target is a fixed absolute path baked into the fixture's
+# manifest (it has to be — the escape is expressed relative to
+# $KAAPPI_HOME/src), so clear it on both sides: a leftover from a previous
+# run, or from a concurrent leg on a shared builder, would otherwise decide
+# this assertion instead of the install under test.
+rm -rf /tmp/kaappi-ESCAPED
 out="$("$THOTTAM" install kaappi-evildep 2>&1)" && ec=0 || ec=$?
 check_exit "a traversal name in a manifest depends: fails the install" 1 "$ec"
 check "the rejected transitive name is reported" "invalid package name" "$out"
 check_not "the traversal target was never created" "yes" \
     "$([[ -e /tmp/kaappi-ESCAPED ]] && echo yes || echo no)"
+rm -rf /tmp/kaappi-ESCAPED
 
 # ---------------------------------------------------------------------------
 # 5. Re-installing at a different version
@@ -426,12 +433,23 @@ out="$("$THOTTAM" --locked install kaappi-nosuch 2>&1)" && ec=0 || ec=$?
 check_exit "--locked refuses a package absent from the lockfile" 1 "$ec"
 check "--locked says the package is not in the lockfile" "not in the lockfile" "$out"
 
-# Restore-from-lockfile: wipe the installation, keep the lockfile.
+# Restore-from-lockfile: wipe the installation, keep the lockfile. This is
+# the whole point of the flag — reproduce an installation from a committed
+# lockfile — so it must be a fixed point: same SHA, same recorded source.
 rm -rf "$KAAPPI_HOME/src" "$KAAPPI_HOME/lib"
 : > "$KAAPPI_HOME/installed.txt"
 out="$("$THOTTAM" --locked install kaappi-alpha 2>&1)" && ec=0 || ec=$?
 check_exit "--locked restores a locked package" 0 "$ec"
 check "--locked checks out the locked SHA" "Checking out" "$out"
+# FAIL: #2137 (doInstall rewrites the lockfile from `parsed.source`, which is
+# null when no ::url was given, so restoring from the lockfile ERASES the
+# provenance column the lockfile exists to carry — the SHA survives, the URL
+# does not)
+# check "--locked restore leaves the lockfile byte-for-byte unchanged" \
+#     "$saved_lock" "$(cat "$KAAPPI_HOME/thottam.lock")"
+# Discriminating control: the SHA half of the line does survive the restore.
+check "--locked restore preserves the locked SHA" \
+    "$(printf '%s' "$saved_lock" | cut -d' ' -f2)" "$(cat "$KAAPPI_HOME/thottam.lock")"
 
 # Control: --locked does enforce the SHA.
 fresh_home

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -39,6 +39,29 @@ if ! command -v git > /dev/null 2>&1; then
     exit 77
 fi
 
+# This suite's whole method is "point KAAPPI_ORG at local bare repositories",
+# which needs git to clone a plain filesystem path.  That holds on macOS and
+# Linux and does NOT hold on the three BSD CI legs, where thottam reports
+# `Failed to clone repository` for a fixture the setup created successfully
+# (kaappi#2150).  The cause is not yet known, so rather than assert a
+# precondition we cannot explain, probe it directly and skip when it does not
+# hold -- the same shape as skip_without_zig in shell-common.sh.
+#
+# Probing beats hardcoding a platform list: if the underlying issue is fixed,
+# or if it turns out to be a git-version rather than an OS boundary, this
+# starts running again on its own with no allowlist to maintain.
+_probe="$(mktemp -d)"
+if ! ( cd "$_probe" && git init -q bare-src > /dev/null 2>&1 \
+        && cd bare-src && git -c user.email=t@example.com -c user.name=Test \
+             commit -q --allow-empty -m probe > /dev/null 2>&1 \
+        && cd .. && git clone -q --bare bare-src probe.git > /dev/null 2>&1 \
+        && git clone -q -- "$_probe/probe.git" clone-out > /dev/null 2>&1 ); then
+    rm -rf "$_probe"
+    echo "SKIP: git cannot clone a local bare repository here (see kaappi#2150)"
+    exit 77
+fi
+rm -rf "$_probe"
+
 PASS=0
 FAIL=0
 

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -1,0 +1,464 @@
+#!/bin/bash
+# Audit-campaign v2 Phase 6E: `thottam` install/list/verify/remove/update
+# end to end, with **no network**.
+#
+# The whole fixture is a directory of local bare git repositories pointed at
+# by KAAPPI_ORG, which thottam joins as "<org>/<pkg>.git" — git clones a
+# plain path as happily as a URL, so every code path that a real install
+# takes (clone, `ls-remote --tags` constraint resolution, checkout, lib
+# copy, lockfile write) runs unchanged against on-disk repos.
+#
+# Hermetic: KAAPPI_HOME and KAAPPI_ORG both point at throwaway directories,
+# so the real ~/.kaappi is never read, written, or removed. `thottam remove`
+# deletes trees, so this isolation is load-bearing, not tidiness.
+#
+# Usage: bash tests/scheme/thottam/thottam-lifecycle.sh [path-to-kaappi]
+#
+# run-all.sh passes the *kaappi* binary to every shell suite; thottam is
+# built into the same directory, so it is derived from that rather than
+# taking a second argument nothing would pass.
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+
+# The fixture builds git repositories at POSIX paths and hands them to
+# thottam, which on Windows resolves "git" through PATH while this script
+# would be handing it MSYS spellings. The Zig unit suite
+# (src/tests_thottam.zig) covers the pure parsing surface on every leg.
+skip_on_windows "thottam lifecycle fixture builds local git repos at POSIX paths"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+THOTTAM="$(dirname "$KAAPPI")/thottam"
+if [[ ! -x "$THOTTAM" ]]; then
+    echo "SKIP: no thottam binary at $THOTTAM"
+    exit 77
+fi
+if ! command -v git > /dev/null 2>&1; then
+    echo "SKIP: git is not on PATH"
+    exit 77
+fi
+
+PASS=0
+FAIL=0
+
+ORG="$(mktemp -d)"
+WORK="$(mktemp -d)"
+HOMEROOT="$(mktemp -d)"
+trap 'rm -rf "$ORG" "$WORK" "$HOMEROOT"' EXIT
+export KAAPPI_ORG="$ORG"
+
+check() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" == *"$expected"* ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  expected to contain: $expected"
+        echo "  actual: $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_not() {
+    local label="$1" unexpected="$2" actual="$3"
+    if [[ "$actual" != *"$unexpected"* ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  expected NOT to contain: $unexpected"
+        echo "  actual: $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_exit() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" -eq "$expected" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected exit $expected, got $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_file() {
+    local label="$1" path="$2"
+    if [[ -f "$path" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — no such file: $path"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+git_q() { git -c user.email=t@example.com -c user.name=Test -c commit.gpgsign=false "$@"; }
+
+# mkpkg <name> <extra-sld-basename-or-empty> <tag>...
+# One commit per tag so every tag names a distinct SHA.
+mkpkg() {
+    local name="$1" extra="$2"
+    shift 2
+    local d="$WORK/$name"
+    mkdir -p "$d/lib/kaappi"
+    (
+        cd "$d"
+        git init -q .
+        printf 'name: %s\n' "$name" > kaappi.pkg
+        printf '(define-library (kaappi %s) (export tag) (import (scheme base)) (begin (define tag "base")))\n' \
+            "${name#kaappi-}" > "lib/kaappi/${name#kaappi-}.sld"
+        if [[ -n "$extra" ]]; then
+            printf '(define-library (kaappi %s) (export owner) (import (scheme base)) (begin (define owner "%s")))\n' \
+                "$extra" "$name" > "lib/kaappi/$extra.sld"
+        fi
+        git add -A
+        git_q commit -q -m base
+        local t
+        for t in "$@"; do
+            printf '(define-library (kaappi %s) (export tag) (import (scheme base)) (begin (define tag "%s")))\n' \
+                "${name#kaappi-}" "$t" > "lib/kaappi/${name#kaappi-}.sld"
+            git add -A
+            git_q commit -q -m "$t"
+            git tag "$t"
+        done
+    )
+    git clone -q --bare "$d" "$ORG/$name.git"
+}
+
+# fresh_home: a brand-new KAAPPI_HOME for the next scenario.
+fresh_home() {
+    KAAPPI_HOME="$(mktemp -d "$HOMEROOT/home-XXXXXX")"
+    export KAAPPI_HOME
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+mkpkg kaappi-alpha "" v0.1.0 v0.2.0 v0.2.5 v1.0.0 v1.2.3 v1.9.0 v2.0.0
+mkpkg kaappi-one shared
+mkpkg kaappi-two shared
+# Two single-variable fixtures, so the pre-release case and the
+# four-component case cannot mask one another: each carries exactly one
+# release tag (v1.0.0) plus one odd tag on a later commit.
+mkpkg kaappi-odd "" v1.0.0
+(
+    cd "$WORK/kaappi-odd"
+    printf 'rc\n' > rc.txt
+    git add -A
+    git_q commit -q -m rc
+    git tag 'v2.0.0-rc1'
+)
+rm -rf "$ORG/kaappi-odd.git"
+git clone -q --bare "$WORK/kaappi-odd" "$ORG/kaappi-odd.git"
+
+mkpkg kaappi-nightly "" v1.0.0
+(
+    cd "$WORK/kaappi-nightly"
+    printf 'nightly\n' > nightly.txt
+    git add -A
+    git_q commit -q -m nightly
+    git tag 'v2.0.0.nightly-UNRELEASED'
+)
+rm -rf "$ORG/kaappi-nightly.git"
+git clone -q --bare "$WORK/kaappi-nightly" "$ORG/kaappi-nightly.git"
+
+# ---------------------------------------------------------------------------
+# 1. A plain install, and what it records
+# ---------------------------------------------------------------------------
+
+fresh_home
+out="$("$THOTTAM" install kaappi-alpha 2>&1)" && ec=0 || ec=$?
+check_exit "plain install succeeds" 0 "$ec"
+check "install reports the resolved SHA" "installed (locked at" "$out"
+check_file "the package's .sld lands in KAAPPI_HOME/lib" "$KAAPPI_HOME/lib/kaappi/alpha.sld"
+check "installed.txt lists the package" "kaappi-alpha" "$(cat "$KAAPPI_HOME/installed.txt")"
+check "lockfile records the package and a SHA" "kaappi-alpha " "$(cat "$KAAPPI_HOME/thottam.lock")"
+check "list shows the package" "kaappi-alpha" "$("$THOTTAM" list)"
+out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+check_exit "verify passes on a clean install" 0 "$ec"
+check "verify reports OK for the package" "OK: kaappi-alpha" "$out"
+
+# ---------------------------------------------------------------------------
+# 2. Provenance: an explicit ::url is recorded and shown
+# ---------------------------------------------------------------------------
+
+fresh_home
+"$THOTTAM" install "kaappi-alpha::$ORG/kaappi-alpha.git" > /dev/null 2>&1
+check "lockfile records the source URL it cloned from" \
+    "$ORG/kaappi-alpha.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
+check "list shows the recorded provenance" \
+    "(from: $ORG/kaappi-alpha.git)" "$("$THOTTAM" list)"
+
+# ---------------------------------------------------------------------------
+# 3. Constraint resolution against real tags
+#    Oracle: node-semver's range grammar (github.com/npm/node-semver).
+#    Tags present: v0.1.0 v0.2.0 v0.2.5 v1.0.0 v1.2.3 v1.9.0 v2.0.0
+# ---------------------------------------------------------------------------
+
+resolve() { # resolve <pkg> <constraint> -> the tag chosen, or "" on failure
+    fresh_home
+    "$THOTTAM" install "$1@$2" 2>&1 | sed -n 's/.*Resolved .* -> \(.*\)/\1/p' | head -1
+}
+
+check "constraint >=1.0.0 picks the highest tag"        "v2.0.0" "$(resolve kaappi-alpha '>=1.0.0')"
+check "constraint <1.0.0 picks the highest below 1.0.0" "v0.2.5" "$(resolve kaappi-alpha '<1.0.0')"
+check "constraint <=1.0.0 includes its own version"     "v1.0.0" "$(resolve kaappi-alpha '<=1.0.0')"
+check "constraint ^1.2.3 stays inside major 1"          "v1.9.0" "$(resolve kaappi-alpha '^1.2.3')"
+check "constraint ^0.2.0 stays inside minor 0.2"        "v0.2.5" "$(resolve kaappi-alpha '^0.2.0')"
+check "constraint ~1.2.3 stays inside minor 1.2"        "v1.2.3" "$(resolve kaappi-alpha '~1.2.3')"
+check "range >=1.0.0,<2.0.0 excludes the upper bound"   "v1.9.0" "$(resolve kaappi-alpha '>=1.0.0,<2.0.0')"
+
+fresh_home
+out="$("$THOTTAM" install 'kaappi-alpha@>=9.0.0' 2>&1)" && ec=0 || ec=$?
+check_exit "an unsatisfiable constraint fails" 1 "$ec"
+check "an unsatisfiable constraint says so" "no version matching" "$out"
+
+# A tag that is a SemVer pre-release must not satisfy a plain range
+# (node-semver: a range with no pre-release of its own excludes them).
+check "a -rc1 pre-release tag does not satisfy >=1.0.0" \
+    "v1.0.0" "$(resolve kaappi-odd '>=1.0.0')"
+
+# ...but SemVer 2.0.0 s2 says a version is exactly three numeric components,
+# so a tag with a fourth is not a version at all and must not be a candidate.
+# FAIL: #2130 (Semver.parse reads three components and discards the rest, so
+# v2.0.0.nightly-UNRELEASED parses as 2.0.0 and wins this range; the fixture
+# is identical to kaappi-odd above except for that one tag, which is what
+# makes the pair discriminating)
+# check "a four-component tag is not treated as a release" \
+#     "v1.0.0" "$(resolve kaappi-nightly '>=1.0.0')"
+
+# ---------------------------------------------------------------------------
+# 4. The package-name guard: nothing escapes KAAPPI_HOME
+# ---------------------------------------------------------------------------
+
+fresh_home
+for bad in '../../evil' 'foo/bar' '..' '.' 'a/../../b' '/tmp/evil' 'a\b' ''; do
+    out="$("$THOTTAM" install "$bad" 2>&1)" && ec=0 || ec=$?
+    check_exit "install rejects the name [$bad]" 1 "$ec"
+    check "install names the rejected package [$bad]" "invalid package name" "$out"
+done
+out="$("$THOTTAM" remove '../../evil' 2>&1)" && ec=0 || ec=$?
+check_exit "remove rejects a traversal name" 1 "$ec"
+check "remove names the rejected package" "invalid package name" "$out"
+
+# The same guarantee must hold for a name that arrives from a state file
+# rather than from the command line: nothing should build a path out of an
+# unvalidated package name.
+fresh_home
+printf '../../../../../../tmp/kaappi-escape-probe\n' > "$KAAPPI_HOME/installed.txt"
+printf '../../../../../../tmp/kaappi-escape-probe deadbeef\n' > "$KAAPPI_HOME/thottam.lock"
+out="$("$THOTTAM" update '../../../../../../tmp/kaappi-escape-probe' 2>&1)" && ec=0 || ec=$?
+# FAIL: #2144 (isValidPkgName guards install and remove only; list, verify and
+# update take the name straight from installed.txt / thottam.lock, so `git -C
+# <escaped path>` runs outside KAAPPI_HOME)
+# check "update rejects a traversal name read back from installed.txt" \
+#     "invalid package name" "$out"
+# out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+# check "verify rejects a traversal name read back from the lockfile" \
+#     "invalid package name" "$out"
+
+# Discriminating control: the destructive command does validate, so the
+# escaped path is never a removeTree target.
+out="$("$THOTTAM" remove '../../../../../../tmp/kaappi-escape-probe' 2>&1)" && ec=0 || ec=$?
+check_exit "remove still rejects that name when it is in installed.txt" 1 "$ec"
+check "remove names it as invalid rather than deleting it" "invalid package name" "$out"
+
+# The guard also covers a name arriving from an untrusted manifest, which is
+# the case a user never types and so never reviews.
+mkdir -p "$WORK/kaappi-evildep/lib/kaappi"
+(
+    cd "$WORK/kaappi-evildep"
+    git init -q .
+    printf 'name: kaappi-evildep\ndepends: ../../../../../../tmp/kaappi-ESCAPED\n' > kaappi.pkg
+    printf '(define-library (kaappi evildep) (export x) (import (scheme base)) (begin (define x 1)))\n' \
+        > lib/kaappi/evildep.sld
+    git add -A
+    git_q commit -q -m base
+)
+git clone -q --bare "$WORK/kaappi-evildep" "$ORG/kaappi-evildep.git"
+fresh_home
+out="$("$THOTTAM" install kaappi-evildep 2>&1)" && ec=0 || ec=$?
+check_exit "a traversal name in a manifest depends: fails the install" 1 "$ec"
+check "the rejected transitive name is reported" "invalid package name" "$out"
+check_not "the traversal target was never created" "yes" \
+    "$([[ -e /tmp/kaappi-ESCAPED ]] && echo yes || echo no)"
+
+# ---------------------------------------------------------------------------
+# 5. Re-installing at a different version
+# ---------------------------------------------------------------------------
+
+sha_v010="$(git -C "$WORK/kaappi-alpha" rev-parse 'v0.1.0^{commit}')"
+
+# Control: pinning on a FRESH home works. The pin machinery is fine, and this
+# assertion holds both before and after the fix below — it is what makes the
+# disabled one next to it about the *re*-install path specifically.
+fresh_home
+"$THOTTAM" install kaappi-alpha@v0.1.0 > /dev/null 2>&1
+check "a first install at a pin records that pin's SHA" \
+    "$sha_v010" "$(cat "$KAAPPI_HOME/thottam.lock")"
+
+# The same command against an already-installed package must either move the
+# install to the requested version or fail. Reporting success while leaving a
+# different version in place makes it unusable in a provisioning script.
+fresh_home
+"$THOTTAM" install kaappi-alpha > /dev/null 2>&1
+"$THOTTAM" install kaappi-alpha@v0.1.0 > /dev/null 2>&1 || true
+# FAIL: #2134 (the "already installed" short-circuit runs before the requested
+# version is looked at, so this exits 0 having done nothing)
+# check "re-installing at a pin records that pin's SHA" \
+#     "$sha_v010" "$(cat "$KAAPPI_HOME/thottam.lock")"
+
+# ---------------------------------------------------------------------------
+# 6. verify's coverage
+# ---------------------------------------------------------------------------
+
+fresh_home
+"$THOTTAM" install kaappi-alpha > /dev/null 2>&1
+"$THOTTAM" install kaappi-one > /dev/null 2>&1
+
+out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+check_exit "verify passes with both packages locked" 0 "$ec"
+check "verify checks the first package" "OK: kaappi-alpha" "$out"
+check "verify checks the second package" "OK: kaappi-one" "$out"
+
+# Control: a lockfile entry whose SHA does not match IS caught.
+sed 's/^kaappi-one .*/kaappi-one 0000000000000000000000000000000000000000/' \
+    "$KAAPPI_HOME/thottam.lock" > "$KAAPPI_HOME/thottam.lock.new"
+mv "$KAAPPI_HOME/thottam.lock.new" "$KAAPPI_HOME/thottam.lock"
+out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+check_exit "verify fails on a SHA mismatch" 1 "$ec"
+check "verify names the mismatched package" "MISMATCH: kaappi-one" "$out"
+
+# An installed package must be verified whether or not the lockfile happens
+# to mention it — otherwise "All packages verified" is a claim about the
+# lockfile, not about the installation.
+grep -v '^kaappi-one ' "$KAAPPI_HOME/thottam.lock" > "$KAAPPI_HOME/thottam.lock.new"
+mv "$KAAPPI_HOME/thottam.lock.new" "$KAAPPI_HOME/thottam.lock"
+out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+# FAIL: #2135 (verify iterates the lockfile, so dropping a line silently
+# removes that package from verification and the run reports success)
+# check_exit "verify fails when an installed package has no lockfile entry" 1 "$ec"
+
+# An empty lockfile is the degenerate case of the same thing: nothing is
+# checked, and the command reports that everything is fine.
+: > "$KAAPPI_HOME/thottam.lock"
+out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+# FAIL: #2135
+# check_exit "verify fails on an empty lockfile with packages installed" 1 "$ec"
+# Discriminating control: an ABSENT lockfile *is* caught, so the blind spot
+# is specific to a lockfile that exists and says nothing.
+rm -f "$KAAPPI_HOME/thottam.lock"
+out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+check_exit "verify fails when the lockfile is missing entirely" 1 "$ec"
+check "verify says the lockfile is missing" "No lockfile found" "$out"
+
+# ---------------------------------------------------------------------------
+# 7. remove, and the shared library namespace
+# ---------------------------------------------------------------------------
+
+fresh_home
+"$THOTTAM" install kaappi-one > /dev/null 2>&1
+out="$("$THOTTAM" remove kaappi-one 2>&1)" && ec=0 || ec=$?
+check_exit "remove succeeds" 0 "$ec"
+check "remove reports the package" "kaappi-one" "$out"
+check_not "remove deletes the package's own .sld" "yes" \
+    "$([[ -f "$KAAPPI_HOME/lib/kaappi/one.sld" ]] && echo yes || echo no)"
+check_not "remove drops the package from installed.txt" \
+    "kaappi-one" "$(cat "$KAAPPI_HOME/installed.txt")"
+out="$("$THOTTAM" remove kaappi-one 2>&1)" && ec=0 || ec=$?
+check_exit "removing an absent package fails" 1 "$ec"
+check "removing an absent package says so" "is not installed" "$out"
+
+# kaappi-one and kaappi-two both ship lib/kaappi/shared.sld. Removing one
+# must not take a file the other is still relying on.
+fresh_home
+"$THOTTAM" install kaappi-one > /dev/null 2>&1
+"$THOTTAM" install kaappi-two > /dev/null 2>&1
+check_file "both packages installed, shared.sld present" "$KAAPPI_HOME/lib/kaappi/shared.sld"
+"$THOTTAM" remove kaappi-two > /dev/null 2>&1
+check "kaappi-one is still listed as installed" "kaappi-one" "$("$THOTTAM" list)"
+# FAIL: #2136 (removal unlinks every .sld name the removed package ships, with
+# no record of which package a given installed file came from, so kaappi-one
+# loses lib/kaappi/shared.sld while still being reported as installed)
+# check_file "a still-installed package keeps its library file" \
+#     "$KAAPPI_HOME/lib/kaappi/shared.sld"
+
+# ---------------------------------------------------------------------------
+# 8. update
+# ---------------------------------------------------------------------------
+
+fresh_home
+"$THOTTAM" install kaappi-alpha > /dev/null 2>&1
+out="$("$THOTTAM" update kaappi-alpha 2>&1)" && ec=0 || ec=$?
+check_exit "update of an unpinned package succeeds" 0 "$ec"
+check "update reports the resulting SHA" "updated (now at" "$out"
+
+out="$("$THOTTAM" update kaappi-nosuch 2>&1)" && ec=0 || ec=$?
+check_exit "update of an uninstalled package fails" 1 "$ec"
+check "update of an uninstalled package says so" "is not installed" "$out"
+
+# A package installed at a pin is on a detached HEAD, which `git pull`
+# cannot advance. `thottam update` should say what it can and cannot do
+# about a pinned package rather than surfacing git's own advice.
+fresh_home
+"$THOTTAM" install kaappi-alpha@v1.0.0 > /dev/null 2>&1
+out="$("$THOTTAM" update kaappi-alpha 2>&1)" && ec=0 || ec=$?
+# FAIL: #2134 (update runs `git pull` unconditionally; on the detached HEAD a
+# pinned install leaves behind, it fails with git's "You are not currently on
+# a branch" and no thottam-level explanation)
+# check_not "updating a pinned package does not leak raw git advice" \
+#     "You are not currently on a branch" "$out"
+
+# ---------------------------------------------------------------------------
+# 9. --locked
+# ---------------------------------------------------------------------------
+
+fresh_home
+"$THOTTAM" install "kaappi-alpha::$ORG/kaappi-alpha.git" > /dev/null 2>&1
+saved_lock="$(cat "$KAAPPI_HOME/thottam.lock")"
+
+out="$("$THOTTAM" --locked install kaappi-nosuch 2>&1)" && ec=0 || ec=$?
+check_exit "--locked refuses a package absent from the lockfile" 1 "$ec"
+check "--locked says the package is not in the lockfile" "not in the lockfile" "$out"
+
+# Restore-from-lockfile: wipe the installation, keep the lockfile.
+rm -rf "$KAAPPI_HOME/src" "$KAAPPI_HOME/lib"
+: > "$KAAPPI_HOME/installed.txt"
+out="$("$THOTTAM" --locked install kaappi-alpha 2>&1)" && ec=0 || ec=$?
+check_exit "--locked restores a locked package" 0 "$ec"
+check "--locked checks out the locked SHA" "Checking out" "$out"
+
+# Control: --locked does enforce the SHA.
+fresh_home
+printf 'kaappi-alpha 0000000000000000000000000000000000000000 %s/kaappi-alpha.git\n' "$ORG" \
+    > "$KAAPPI_HOME/thottam.lock"
+out="$("$THOTTAM" --locked install kaappi-alpha 2>&1)" && ec=0 || ec=$?
+check_exit "--locked fails when the locked SHA is unreachable" 1 "$ec"
+
+# ...but the source URL recorded next to that SHA is not enforced, and is
+# overwritten by whatever URL this invocation was handed. A fork that shares
+# history satisfies the SHA check, so the one field that records *where the
+# code came from* is both unchecked and destroyed by the check that passes.
+git clone -q --bare "$ORG/kaappi-alpha.git" "$ORG/FORK-kaappi-alpha.git"
+fresh_home
+"$THOTTAM" install "kaappi-alpha::$ORG/kaappi-alpha.git" > /dev/null 2>&1
+rm -rf "$KAAPPI_HOME/src" "$KAAPPI_HOME/lib"
+: > "$KAAPPI_HOME/installed.txt"
+out="$("$THOTTAM" --locked install "kaappi-alpha::$ORG/FORK-kaappi-alpha.git" 2>&1)" && ec=0 || ec=$?
+# FAIL: #2137 (--locked compares only the SHA; the clone comes from the URL
+# passed on this invocation and the lockfile's recorded source is then
+# overwritten with it)
+# check_exit "--locked refuses a source URL that differs from the lockfile" 1 "$ec"
+# check "--locked leaves the recorded provenance intact" \
+#     "$ORG/kaappi-alpha.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
+
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "thottam lifecycle: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Phase 6E of the [systematic correctness audit v2](https://github.com/kaappi/kaappi/issues/1890): `thottam`, the package manager.

`thottam` is 932 lines that ship in every release for every platform, clone from GitHub, run a `build:` command out of a downloaded manifest, and copy files into `~/.kaappi/lib`. It had **3 tests**, all of them on the caret operator.

## What this adds

**`src/tests_thottam.zig` — 233 assertions, 46 test blocks, no network.** Version parsing, all seven constraint operators at their boundaries, the `name[@ver][::url]` spec grammar, `kaappi.pkg` manifest parsing, the package-name guard, and the lockfile/installed-list round trip. Runs on all 18 CI legs via `zig build test`.

**`tests/scheme/thottam/thottam-lifecycle.sh` — 68 assertions, still no network.** The whole install/list/verify/remove/update lifecycle against a directory of local **bare git repositories** pointed at by `KAAPPI_ORG`: git clones a plain path as happily as a URL, so clone, `ls-remote --tags` constraint resolution, checkout, lib copy and lockfile write all run unchanged offline. Wired into `run-all.sh` as a new "Package manager" suite.

Both are hermetic — `KAAPPI_HOME` and `KAAPPI_ORG` point at throwaway directories. That is load-bearing rather than tidy: `thottam remove` calls `removeTree`.

**Oracle.** SemVer 2.0.0 for what a *version* is; node-semver's "Ranges" for what `^` and `~` *mean*, since neither operator appears in the SemVer spec at all. Every assertion says which one it is pinning where they could disagree.

## Issues filed

Assertions documenting a filed defect are commented out with a `FAIL: #N` marker stating the property that *should* hold; the fix PR re-enables them.

| # | Finding |
|---|---|
| [#2130](https://github.com/kaappi/kaappi/issues/2130) | `Semver.parse` reads three dot-separated components and discards the rest, and hands each to `std.fmt.parseInt` — so Zig's integer-literal grammar becomes the version grammar. `v2.0.0.nightly-UNRELEASED` parses as 2.0.0 and `>=1.0.0` installs it; `v1_0.0.0` parses as **10.0.0** and outranks `v2.0.0`. |
| [#2131](https://github.com/kaappi/kaappi/issues/2131) | An omitted version component is filled with `0` and then treated as written, so `~1` means `1.0.x` instead of node-semver's `1.x`. |
| [#2132](https://github.com/kaappi/kaappi/issues/2132) | Six distinct constraint parse failures all surface as `no version matching X`. |
| [#2133](https://github.com/kaappi/kaappi/issues/2133) | A CRLF lockfile makes `verify` print `MISMATCH (locked: 75f253e118c0, actual: 75f253e118c0)`. |
| [#2134](https://github.com/kaappi/kaappi/issues/2134) | `install pkg@ver` on an installed package is a silent no-op, exit 0; `update` can never move a package off a pin. |
| [#2135](https://github.com/kaappi/kaappi/issues/2135) | `verify` iterates the lockfile, not `installed.txt` — an empty lockfile reports `All packages verified.` and exits 0. |
| [#2136](https://github.com/kaappi/kaappi/issues/2136) | `remove` unlinks `.sld` files by name with no ownership record, breaking a still-installed package. |
| [#2137](https://github.com/kaappi/kaappi/issues/2137) | `--locked` enforces the SHA but not the source URL, then overwrites the recorded provenance. |
| [#2138](https://github.com/kaappi/kaappi/issues/2138) | Doc-truth: `kaappi.pkg` `source:` and `name:` are parsed and never read. |
| [#2144](https://github.com/kaappi/kaappi/issues/2144) | `isValidPkgName` guards `install` and `remove` only; `list`/`verify`/`update` build paths from state-file names. |

### The most striking one

Two fixtures identical except for a single tag:

```console
$ git -C repo tag ; thottam install 'kaappi-odd@>=1.0.0'
v1.0.0
v2.0.0-rc1
  Resolved >=1.0.0 -> v1.0.0                      # correct: pre-releases excluded

$ git -C repo tag ; thottam install 'kaappi-nightly@>=1.0.0'
v1.0.0
v2.0.0.nightly-UNRELEASED
  Resolved >=1.0.0 -> v2.0.0.nightly-UNRELEASED   # a nightly marker, installed as a release
```

## Negative results, recorded so they are not re-tested

- **A package name cannot escape `$KAAPPI_HOME/lib`** through `install` or `remove`. The unit suite pins this as a property over the whole byte range rather than a spot check, so a future "allow dots in names" change has to come through that test first. The transitive `depends:` path is guarded too — a manifest naming `../../../../../../tmp/kaappi-ESCAPED` as a dependency fails the install.
- git refuses the `ext::` transport outright (`fatal: transport 'ext' not allowed`), so a `pkg::ext::sh -c …` spec is not a way in.
- The #614 option-injection guard on source URLs holds (`pkg::-upload-pack=…` falls back to the org default).
- The #403 lockfile prefix-collision fix holds (`kaappi-net` does not match `kaappi-net-extra`), as does #613's empty-after-quote-trim guard.

## What could not be tested offline

Nothing that mattered. The `KAAPPI_ORG` fixture reaches `install`, `update`, `remove`, `verify`, `list` and the full constraint resolver. Not covered: real HTTPS/SSH transport error handling, GitHub-specific behaviour, and `runBuildCommand` beyond an empty `build:` (running a real `make` would need a native fixture; the Windows refusal path is `comptime`-gated and unreachable natively). The shell suite skips on Windows — it builds POSIX-path git repositories — but the unit suite covers the parsing surface on all 18 legs, which is where the CRLF finding lives.

**Verified:** fresh ReleaseSafe build at `94ebd5a0`; `zig build test` 1638/1641 (3 skipped), `bash tests/scheme/run-all.sh` green including the new suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
